### PR TITLE
fix em-dash spacing in README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # term-llm
 
-A Swiss Army knife for your terminal—AI-powered commands, answers, and images at your fingertips.
+A Swiss Army knife for your terminal — AI-powered commands, answers, and images at your fingertips.
 
 [![Release](https://img.shields.io/github/v/release/samsaffron/term-llm?style=flat-square)](https://github.com/samsaffron/term-llm/releases)
 


### PR DESCRIPTION
## What

Add spaces around the em-dash in the README tagline (`—` → ` — `).

## Why

Spaced em-dashes are the standard typographic convention in English prose.