### PR TITLE
reliability: fix goroutine leaks, data races, resource leaks, and perf issues

### DIFF
--- a/internal/cache/models.go
+++ b/internal/cache/models.go
@@ -101,6 +101,10 @@ func WriteModelCache(provider string, models []string) error {
 		return err
 	}
 
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+
 	if err := os.Rename(tmpPath, path); err != nil {
 		return err
 	}

--- a/internal/cache/models.go
+++ b/internal/cache/models.go
@@ -81,7 +81,31 @@ func WriteModelCache(provider string, models []string) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0644)
+	f, err := os.CreateTemp(dir, provider+"-models-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
 }
 
 func IsCacheValid(cache *ModelCache) bool {

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -305,6 +305,7 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 	// Log stderr in background (claude CLI outputs progress/errors here)
 	go func() {
 		stderrScanner := bufio.NewScanner(stderr)
+		stderrScanner.Buffer(make([]byte, 64*1024), 1024*1024)
 		for stderrScanner.Scan() {
 			line := stderrScanner.Text()
 			if debug {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -920,7 +920,7 @@ func TestEngineResetConversation(t *testing.T) {
 	e.lastTotalTokens = 500
 	e.lastMessageCount = 10
 	e.systemPrompt = "You are a helpful assistant."
-	e.contextNoticeEmitted = true
+	e.contextNoticeEmitted.Store(true)
 	e.callbackMu.Unlock()
 
 	// Reset conversation
@@ -937,7 +937,7 @@ func TestEngineResetConversation(t *testing.T) {
 	if e.systemPrompt != "" {
 		t.Errorf("expected systemPrompt=\"\", got %q", e.systemPrompt)
 	}
-	if e.contextNoticeEmitted {
+	if e.contextNoticeEmitted.Load() {
 		t.Error("expected contextNoticeEmitted=false")
 	}
 	e.callbackMu.RUnlock()

--- a/internal/llm/gemini_cli.go
+++ b/internal/llm/gemini_cli.go
@@ -965,6 +965,15 @@ func buildGeminiCLIUserContent(parts []Part) map[string]interface{} {
 			if part.Text != "" {
 				apiParts = append(apiParts, map[string]interface{}{"text": part.Text})
 			}
+		case PartImage:
+			if part.ImageData != nil {
+				apiParts = append(apiParts, map[string]interface{}{
+					"inline_data": map[string]interface{}{
+						"mime_type": part.ImageData.MediaType,
+						"data":      part.ImageData.Base64,
+					},
+				})
+			}
 		}
 	}
 	if len(apiParts) == 0 {

--- a/internal/llm/gemini_cli.go
+++ b/internal/llm/gemini_cli.go
@@ -20,6 +20,10 @@ import (
 	"github.com/samsaffron/term-llm/internal/credentials"
 )
 
+// geminiCLIHTTPClient is a package-level HTTP client with a timeout to prevent
+// hung Gemini API calls from blocking the event stream goroutine forever.
+var geminiCLIHTTPClient = &http.Client{Timeout: 10 * time.Minute}
+
 const (
 	codeAssistEndpoint             = "https://cloudcode-pa.googleapis.com"
 	codeAssistAPIVersion           = "v1internal"
@@ -313,7 +317,7 @@ func (p *GeminiCLIProvider) Stream(ctx context.Context, req Request) (Stream, er
 			return err
 		}
 
-		token, err := p.getAccessToken(req.Debug)
+		token, err := p.getAccessToken(ctx, req.Debug)
 		if err != nil {
 			return err
 		}
@@ -398,7 +402,7 @@ func (p *GeminiCLIProvider) Stream(ctx context.Context, req Request) (Stream, er
 			httpReq.Header.Set("Content-Type", "application/json")
 			httpReq.Header.Set("Authorization", "Bearer "+token)
 
-			resp, err := http.DefaultClient.Do(httpReq)
+			resp, err := geminiCLIHTTPClient.Do(httpReq)
 			if err != nil {
 				return fmt.Errorf("generateContent request failed: %w", err)
 			}
@@ -477,7 +481,7 @@ func (p *GeminiCLIProvider) Stream(ctx context.Context, req Request) (Stream, er
 		httpReq.Header.Set("Authorization", "Bearer "+token)
 
 		streamStart := time.Now()
-		resp, err := http.DefaultClient.Do(httpReq)
+		resp, err := geminiCLIHTTPClient.Do(httpReq)
 		if err != nil {
 			return fmt.Errorf("streamGenerateContent request failed: %w", err)
 		}
@@ -582,7 +586,7 @@ func (p *GeminiCLIProvider) Stream(ctx context.Context, req Request) (Stream, er
 }
 
 // getAccessToken returns a valid access token, refreshing if needed
-func (p *GeminiCLIProvider) getAccessToken(debug bool) (string, error) {
+func (p *GeminiCLIProvider) getAccessToken(ctx context.Context, debug bool) (string, error) {
 	now := time.Now().UnixMilli()
 	bufferMs := int64(codeAssistTokenExpiryBuffer.Milliseconds())
 
@@ -605,7 +609,7 @@ func (p *GeminiCLIProvider) getAccessToken(debug bool) (string, error) {
 		p.clientCredsFromCache = fromCache
 	}
 
-	token, expiryDate, err := p.refreshAccessToken(debug, "")
+	token, expiryDate, err := p.refreshAccessToken(ctx, debug, "")
 	if err != nil && p.clientCredsFromCache {
 		if debug {
 			fmt.Fprintln(os.Stderr, "Cache: client creds refresh failed, reloading from gemini-cli")
@@ -614,7 +618,7 @@ func (p *GeminiCLIProvider) getAccessToken(debug bool) (string, error) {
 		if loadErr == nil {
 			p.clientCreds = creds
 			p.clientCredsFromCache = false
-			token, expiryDate, err = p.refreshAccessToken(debug, "retry")
+			token, expiryDate, err = p.refreshAccessToken(ctx, debug, "retry")
 		}
 	}
 	if err != nil {
@@ -628,7 +632,7 @@ func (p *GeminiCLIProvider) getAccessToken(debug bool) (string, error) {
 	return token, nil
 }
 
-func (p *GeminiCLIProvider) refreshAccessToken(debug bool, detail string) (string, int64, error) {
+func (p *GeminiCLIProvider) refreshAccessToken(ctx context.Context, debug bool, detail string) (string, int64, error) {
 	refreshStart := time.Now()
 	data := url.Values{}
 	data.Set("client_id", p.clientCreds.clientID)
@@ -636,7 +640,12 @@ func (p *GeminiCLIProvider) refreshAccessToken(debug bool, detail string) (strin
 	data.Set("refresh_token", p.creds.RefreshToken)
 	data.Set("grant_type", "refresh_token")
 
-	resp, err := http.Post(googleTokenEndpoint, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+	tokenReq, err := http.NewRequestWithContext(ctx, "POST", googleTokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to create token refresh request: %w", err)
+	}
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := geminiCLIHTTPClient.Do(tokenReq)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to refresh token: %w", err)
 	}
@@ -762,7 +771,7 @@ func (p *GeminiCLIProvider) ensureProjectID(ctx context.Context, debug bool) err
 		return nil
 	}
 
-	token, err := p.getAccessToken(debug)
+	token, err := p.getAccessToken(ctx, debug)
 	if err != nil {
 		return err
 	}
@@ -786,7 +795,7 @@ func (p *GeminiCLIProvider) ensureProjectID(ctx context.Context, debug bool) err
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	loadStart := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := geminiCLIHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("loadCodeAssist request failed: %w", err)
 	}
@@ -817,7 +826,7 @@ func (p *GeminiCLIProvider) performSearch(ctx context.Context, query string, deb
 		return "", err
 	}
 
-	token, err := p.getAccessToken(debug)
+	token, err := p.getAccessToken(ctx, debug)
 	if err != nil {
 		return "", err
 	}
@@ -862,7 +871,7 @@ func (p *GeminiCLIProvider) performSearch(ctx context.Context, query string, deb
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := geminiCLIHTTPClient.Do(httpReq)
 	if err != nil {
 		return "", fmt.Errorf("search request failed: %w", err)
 	}
@@ -955,15 +964,6 @@ func buildGeminiCLIUserContent(parts []Part) map[string]interface{} {
 		case PartText:
 			if part.Text != "" {
 				apiParts = append(apiParts, map[string]interface{}{"text": part.Text})
-			}
-		case PartImage:
-			if part.ImageData != nil {
-				apiParts = append(apiParts, map[string]interface{}{
-					"inline_data": map[string]interface{}{
-						"mime_type": part.ImageData.MediaType,
-						"data":      part.ImageData.Base64,
-					},
-				})
 			}
 		}
 	}

--- a/internal/llm/read_url_tool.go
+++ b/internal/llm/read_url_tool.go
@@ -23,7 +23,7 @@ type ReadURLTool struct {
 func NewReadURLTool() *ReadURLTool {
 	return &ReadURLTool{
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: 2 * time.Minute,
 		},
 	}
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -117,7 +119,7 @@ func (c *Client) createStdioTransport(ctx context.Context) mcp.Transport {
 // createHTTPTransport creates an HTTP transport for URL-based servers.
 func (c *Client) createHTTPTransport() mcp.Transport {
 	// Create HTTP client with custom headers if specified
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Timeout: 30 * time.Second}
 
 	// Use StreamableClientTransport (the modern MCP transport)
 	transport := &mcp.StreamableClientTransport{
@@ -243,17 +245,17 @@ func (c *Client) CallTool(ctx context.Context, name string, args json.RawMessage
 
 // formatContent converts MCP content to a string.
 func formatContent(content []mcp.Content) string {
-	var result string
+	var sb strings.Builder
 	for _, c := range content {
 		switch v := c.(type) {
 		case *mcp.TextContent:
-			result += v.Text
+			sb.WriteString(v.Text)
 		default:
 			// For other content types, try JSON encoding
 			if data, err := json.Marshal(c); err == nil {
-				result += string(data)
+				sb.WriteString(string(data))
 			}
 		}
 	}
-	return result
+	return sb.String()
 }

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -192,7 +192,12 @@ func (m *Manager) Enable(ctx context.Context, name string) error {
 		err := client.Start(ctx)
 
 		m.mu.Lock()
-		state := m.statuses[name]
+		state, ok := m.statuses[name]
+		if !ok {
+			m.mu.Unlock()
+			client.Stop()
+			return
+		}
 		if err != nil {
 			state.Status = StatusFailed
 			state.Error = err

--- a/internal/mcphttp/http_server.go
+++ b/internal/mcphttp/http_server.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -182,7 +183,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		authHeader := r.Header.Get("Authorization")
 		expectedAuth := "Bearer " + s.authToken
 
-		if authHeader != expectedAuth {
+		if subtle.ConstantTimeCompare([]byte(authHeader), []byte(expectedAuth)) != 1 {
 			if s.debug {
 				fmt.Fprintf(os.Stderr, "[mcp-http] %s Unauthorized request from %s (got auth: %q)\n",
 					time.Now().Format("15:04:05.000"), r.RemoteAddr, authHeader[:min(20, len(authHeader))])

--- a/internal/oauth/chatgpt.go
+++ b/internal/oauth/chatgpt.go
@@ -123,7 +123,7 @@ func exchangeCodeForTokens(code, codeVerifier string) (*ChatGPTTokenResponse, er
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange request failed: %w", err)
 	}
@@ -166,7 +166,7 @@ func RefreshToken(refreshToken string) (*ChatGPTTokenResponse, error) {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token refresh request failed: %w", err)
 	}

--- a/internal/oauth/copilot.go
+++ b/internal/oauth/copilot.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+var oauthHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 const (
 	// CopilotClientID is the VS Code GitHub Copilot extension's client ID.
 	// This is required for access to GitHub's internal Copilot APIs (usage, token exchange).
@@ -65,7 +67,7 @@ func RequestCopilotDeviceCode() (*CopilotDeviceCodeResponse, error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("device code request failed: %w", err)
 	}
@@ -111,7 +113,7 @@ func PollForCopilotToken(ctx context.Context, deviceCode string, interval int) (
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Accept", "application/json")
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := oauthHTTPClient.Do(req)
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("token request failed: %w", err)

--- a/internal/render/chat/renderer.go
+++ b/internal/render/chat/renderer.go
@@ -330,7 +330,9 @@ func (r *Renderer) renderHistory(state RenderState) string {
 		}
 	}
 
-	return b.String()
+	// Clone so the returned string doesn't share the builder's backing
+	// array, which will be overwritten when the pool reuses this builder.
+	return strings.Clone(b.String())
 }
 
 // getOrRenderBlock gets a rendered block from cache or renders it.

--- a/internal/render/chat/renderer.go
+++ b/internal/render/chat/renderer.go
@@ -3,10 +3,17 @@ package chat
 import (
 	"strconv"
 	"strings"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/samsaffron/term-llm/internal/session"
 )
+
+// historyBuilderPool reuses strings.Builder instances across renderHistory
+// calls to reduce per-frame allocations in the hot render path.
+var historyBuilderPool = sync.Pool{
+	New: func() any { return new(strings.Builder) },
+}
 
 // RenderMode determines how content is displayed
 type RenderMode int
@@ -308,7 +315,9 @@ func (r *Renderer) renderHistory(state RenderState) string {
 
 	// Render only visible messages using cache
 	// Skip system and tool messages (they render as empty anyway)
-	var b strings.Builder
+	b := historyBuilderPool.Get().(*strings.Builder)
+	b.Reset()
+	defer historyBuilderPool.Put(b)
 	for i := start; i < end; i++ {
 		msg := &state.Messages[i]
 		// Skip non-renderable roles

--- a/internal/render/chat/streaming.go
+++ b/internal/render/chat/streaming.go
@@ -222,7 +222,9 @@ func (s *StreamingBlock) Render(wavePos int, pausedForUI bool, includeImages boo
 		}
 	}
 
-	return b.String()
+	// Clone so the returned string doesn't share the builder's backing
+	// array, which will be overwritten when the pool reuses this builder.
+	return strings.Clone(b.String())
 }
 
 // Flush returns content to print to scrollback and marks it as flushed.

--- a/internal/search/brave.go
+++ b/internal/search/brave.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // BraveSearcher implements Searcher using the Brave Search API.
@@ -19,7 +20,7 @@ type BraveSearcher struct {
 
 func NewBraveSearcher(apiKey string, client *http.Client) *BraveSearcher {
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &BraveSearcher{
 		client: client,

--- a/internal/search/duckduckgo.go
+++ b/internal/search/duckduckgo.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"golang.org/x/net/html"
 )
@@ -31,7 +32,7 @@ type DuckDuckGoLite struct {
 
 func NewDuckDuckGoLite(client *http.Client) *DuckDuckGoLite {
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &DuckDuckGoLite{
 		client:  client,

--- a/internal/search/exa.go
+++ b/internal/search/exa.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // ExaSearcher implements Searcher using the Exa API.
@@ -18,7 +19,7 @@ type ExaSearcher struct {
 
 func NewExaSearcher(apiKey string, client *http.Client) *ExaSearcher {
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &ExaSearcher{
 		client: client,

--- a/internal/search/google.go
+++ b/internal/search/google.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // GoogleSearcher implements Searcher using Google Custom Search API.
@@ -20,7 +21,7 @@ type GoogleSearcher struct {
 
 func NewGoogleSearcher(apiKey, cx string, client *http.Client) *GoogleSearcher {
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &GoogleSearcher{
 		client: client,

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -76,6 +76,9 @@ func (t *GlobTool) Preview(args json.RawMessage) string {
 }
 
 func (t *GlobTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	var a GlobArgs
 	if err := json.Unmarshal(args, &a); err != nil {
 		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, err.Error()))), nil
@@ -120,6 +123,9 @@ func (t *GlobTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 	pattern := a.Pattern
 
 	err = filepath.WalkDir(absBasePath, func(path string, d os.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return nil // Skip errors
 		}

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -436,11 +436,14 @@ func searchFile(path string, re *regexp.Regexp, maxMatches int) ([]GrepMatch, er
 	}
 
 	// Reset to beginning
-	file.Seek(0, 0)
+	if _, err := file.Seek(0, 0); err != nil {
+		return nil, fmt.Errorf("seek: %w", err)
+	}
 
 	// Read all lines for context support
 	var lines []string
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -15,17 +15,19 @@ import (
 
 // ShellTool implements the shell tool.
 type ShellTool struct {
-	approval *ApprovalManager
-	config   *ToolConfig
-	limits   OutputLimits
+	approval  *ApprovalManager
+	config    *ToolConfig
+	limits    OutputLimits
+	shellPath string
 }
 
 // NewShellTool creates a new ShellTool.
 func NewShellTool(approval *ApprovalManager, config *ToolConfig, limits OutputLimits) *ShellTool {
 	return &ShellTool{
-		approval: approval,
-		config:   config,
-		limits:   limits,
+		approval:  approval,
+		config:    config,
+		limits:    limits,
+		shellPath: detectShell(),
 	}
 }
 
@@ -126,14 +128,11 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 		}
 	}
 
-	// Detect shell
-	shell := detectShell()
-
 	// Create command with context timeout
 	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(execCtx, shell, "-c", a.Command)
+	cmd := exec.CommandContext(execCtx, t.shellPath, "-c", a.Command)
 	cmd.Dir = workDir
 
 	var stdout, stderr bytes.Buffer

--- a/internal/tools/write.go
+++ b/internal/tools/write.go
@@ -90,12 +90,16 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrInvalidParams, "cannot resolve path: %v", err))), nil
 	}
 
-	// Check if file exists for diff info
+	// Check if file exists for diff info and preserve permissions
 	existingContent := ""
 	isNew := true
-	if data, err := os.ReadFile(absPath); err == nil {
-		existingContent = string(data)
-		isNew = false
+	var existingMode os.FileMode
+	if info, err := os.Stat(absPath); err == nil {
+		existingMode = info.Mode()
+		if data, err := os.ReadFile(absPath); err == nil {
+			existingContent = string(data)
+			isNew = false
+		}
 	}
 
 	// Create parent directories
@@ -126,6 +130,17 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 	if err := tf.Close(); err != nil {
 		os.Remove(tempPath)
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to close temp file: %v", err))), nil
+	}
+
+	// Preserve existing file permissions, or use 0644 for new files.
+	// CreateTemp creates files with 0600 which is too restrictive for source files.
+	mode := existingMode
+	if isNew {
+		mode = 0644
+	}
+	if err := os.Chmod(tempPath, mode); err != nil {
+		os.Remove(tempPath)
+		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to set file permissions: %v", err))), nil
 	}
 
 	if err := os.Rename(tempPath, absPath); err != nil {

--- a/internal/update/upgrade.go
+++ b/internal/update/upgrade.go
@@ -123,7 +123,8 @@ func downloadFile(ctx context.Context, url string, dest string) error {
 		return err
 	}
 	req.Header.Set("User-Agent", updateUserAgent)
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Three sessions of automated bug hunting across the codebase. 29 files, ~40 fixes.

## Categories

**Data races (go test -race)**
- `engine.go`: `lastTotalTokens`, `lastMessageCount`, `contextNoticeEmitted` written in `runLoop` goroutine without holding `callbackMu` — fixed to acquire lock
- `engine.go`: `systemPrompt` written outside `callbackMu` lock
- `engine.go`: parallel `executeToolCalls` could leave result slots as zero-value `Message`
- `edit_file`: lock path constructed from unresolved user path — two calls with different path representations for same file would get different lock inodes, defeating the lock
- `unified_diff`: only write-capable tool with no locking — concurrent invocations on same file silently lose edits
- `write_file`: fixed-name `.tmp` suffix causes parallel writes to same file to corrupt each other
- `mcp/manager`: nil dereference race on `Enable()`
- `mcphttp`: auth token compared with `==` instead of `subtle.ConstantTimeCompare`

**Goroutine leaks**
- `retry.go`: blocking send of `EventRetry` to full channel when caller has cancelled — goroutine stuck forever
- `stream.go`: `ctx.Done` could be starved by buffered events in `Recv()` priority select
- `session/sqlite.go`: `defer rows.Close()` inside a loop defers until function return, not iteration end
- `glob.go`: `WalkDir` with no timeout — unbounded on deep/slow filesystems

**HTTP clients with no timeout** (all used `http.DefaultClient`)
- `gemini_cli.go`, `search/{brave,duckduckgo,exa,google}.go`
- `oauth/{copilot,chatgpt}.go`, `mcp/client.go`, `update/upgrade.go`, `tools/read_url`

**Performance**
- `chatgpt.go`: O(n²) SSE pending-string concat → `bufio.Scanner` with 1MB buffer
- `compaction.go`: O(n²) slice prepend → reverse-collect; add nil checks
- `skills/registry.go`: linear `IsNeverAuto`/`IsAlwaysEnabled` scans → maps; `Reload()` growing `searchPaths` unboundedly
- `shell.go`: `detectShell()` called on every execution → cached on struct
- `render`: reuse byte slice in render pool
- `mcp/client.go`: `formatContent` string concat → `strings.Builder`

**SQLite / retry**
- `sqlite.go`: add `mmap_size` and `cache_size` pragmas; bind params in `GetMessages`/`ListSessions`
- `sqlite.go`: `retryOnBusy` made context-aware
- `retry.go`: `isRetryable` now checks `context.Canceled` and `DeadlineExceeded`; jitter on Retry-After backoff
- `claude_bin.go`: set buffer size on `stderrScanner`
