### PR TITLE
fix: include activate_skill in chat TUI request tools

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -288,6 +288,11 @@ func runChat(cmd *cobra.Command, args []string) error {
 				engine.SetAllowedTools(allowedTools)
 			})
 			engine.Tools().Register(skillTool)
+			// Append activate_skill to the local tools list so the chat TUI
+			// includes it in req.Tools sent to the LLM. Without this, the tool
+			// is registered in the engine but never advertised to the model when
+			// an explicit tools.enabled list is configured (e.g. in agent.yaml).
+			enabledLocalTools = append(enabledLocalTools, tools.ActivateSkillToolName)
 		}
 	}
 


### PR DESCRIPTION
## What

Append `activate_skill` to `enabledLocalTools` after registering it on the engine in `runChat`.

## Why

When an agent has an explicit `tools.enabled` list in `agent.yaml`, the chat TUI builds `req.Tools` from `enabledLocalTools` — only the tools explicitly listed. `activate_skill` is registered directly on the engine *after* the tool manager is built, so it was never in `enabledLocalTools` and therefore never advertised to the model.

The `ask` command and Telegram/serve handler are unaffected — they use `ToolSpecsForRequest(engine.Tools(), ...)` which grabs all registered tools, so `activate_skill` was already included there.

This caused skills to silently fail to activate in the chat TUI when `tools.enabled` was set.