### PR TITLE
fix: activate_skill tool missing from chat TUI and serve command

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -359,6 +359,11 @@ func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provi
 		}
 	}
 
+	// Wire skills system (activate_skill tool + system prompt injection).
+	skillsSetup := SetupSkills(&cfg.Skills, "", io.Discard)
+	RegisterSkillToolWithEngine(engine, toolMgr, skillsSetup)
+	settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
+
 	return engine, toolMgr, nil
 }
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -191,6 +191,22 @@ func (m *Model) startStream(content string) tea.Cmd {
 			}
 		}
 
+		// Add any engine-registered tools not covered by localTools.
+		// activate_skill is registered directly on the engine by RegisterSkillToolWithEngine
+		// but is not part of the agent's tools.enabled list, so it would be silently dropped.
+		for _, spec := range m.engine.Tools().AllSpecs() {
+			found := false
+			for _, existing := range reqTools {
+				if existing.Name == spec.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				reqTools = append(reqTools, spec)
+			}
+		}
+
 		req := llm.Request{
 			SessionID:           m.sess.ID,
 			Messages:            messages,


### PR DESCRIPTION
Two separate bugs prevented the activate_skill tool from reaching the LLM:

1. chat TUI (streaming.go): req.Tools was built only from m.localTools
   (the agent's tools.enabled list). activate_skill is registered directly
   on the engine by RegisterSkillToolWithEngine but is not in that list,
   so it was silently dropped from every request. Fix: after the localTools
   loop, add any engine-registered tools not already in reqTools. This
   mirrors how ask.go uses ToolSpecsForRequest(engine.Tools(), ...) which
   calls AllSpecs() and picks up everything.

2. serve command (serve.go): newServeEngineWithTools never called
   SetupSkills or RegisterSkillToolWithEngine at all. The skills system
   was fully wired in chat.go and ask.go but completely absent from the
   serve path (used by the Telegram bot and web server). Fix: call both
   after tool manager setup, consistent with the other commands.
