### PR TITLE
feat: expose local file path for Telegram-uploaded images

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -611,6 +611,9 @@ func buildAnthropicBlocks(parts []Part, allowToolUse bool) []anthropic.ContentBl
 						},
 					},
 				})
+				if part.ImagePath != "" {
+					blocks = append(blocks, anthropic.NewTextBlock("[image saved at: "+part.ImagePath+"]"))
+				}
 			}
 		case PartToolCall:
 			if allowToolUse && part.ToolCall != nil {
@@ -648,6 +651,9 @@ func buildAnthropicBetaBlocks(parts []Part, allowToolUse bool) []anthropic.BetaC
 						},
 					},
 				})
+				if part.ImagePath != "" {
+					blocks = append(blocks, anthropic.NewBetaTextBlock("[image saved at: "+part.ImagePath+"]"))
+				}
 			}
 		case PartToolCall:
 			if allowToolUse && part.ToolCall != nil {

--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -413,6 +413,12 @@ func buildChatGPTInput(messages []Message) (string, []interface{}) {
 						"type":      "input_image",
 						"image_url": dataURL,
 					})
+					if part.ImagePath != "" {
+						imageParts = append(imageParts, map[string]interface{}{
+							"type": "input_text",
+							"text": "[image saved at: " + part.ImagePath + "]",
+						})
+					}
 				}
 			}
 			if text == "" && len(imageParts) == 0 {

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -328,6 +328,9 @@ func buildGeminiContent(role string, parts []Part) *genai.Content {
 							Data:     imageData,
 						},
 					})
+					if part.ImagePath != "" {
+						content.Parts = append(content.Parts, &genai.Part{Text: "[image saved at: " + part.ImagePath + "]"})
+					}
 				}
 			}
 		case PartToolCall:

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -474,6 +474,9 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 					if part.Type == PartImage && part.ImageData != nil {
 						dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
 						imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: "auto"}})
+						if part.ImagePath != "" {
+							imageParts = append(imageParts, oaiContentPart{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
+						}
 					}
 				}
 				if len(imageParts) > 0 {

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -234,12 +234,14 @@ func buildResponsesMessageItems(role string, parts []Part) []ResponsesInputItem 
 			if part.ImageData != nil {
 				flushText()
 				dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
+				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL}}
+				if part.ImagePath != "" {
+					imageParts = append(imageParts, ResponsesContentPart{Type: "input_text", Text: "[image saved at: " + part.ImagePath + "]"})
+				}
 				items = append(items, ResponsesInputItem{
-					Type: "message",
-					Role: role,
-					Content: []ResponsesContentPart{
-						{Type: "input_image", ImageURL: dataURL},
-					},
+					Type:    "message",
+					Role:    role,
+					Content: imageParts,
 				})
 			}
 		case PartToolCall:

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -105,6 +105,7 @@ type Part struct {
 	ReasoningItemID           string         // Responses API reasoning item ID for replay
 	ReasoningEncryptedContent string         // Responses API encrypted reasoning content for replay
 	ImageData                 *ToolImageData // User-supplied image (base64-encoded)
+	ImagePath                 string         // Local filesystem path to the image (when available, e.g. Telegram uploads)
 	ToolCall                  *ToolCall
 	ToolResult                *ToolResult
 }
@@ -300,9 +301,16 @@ func UserText(text string) Message {
 
 // UserImageMessage creates a user message with an image and an optional text caption.
 func UserImageMessage(mediaType, base64Data, caption string) Message {
+	return UserImageMessageWithPath(mediaType, base64Data, "", caption)
+}
+
+// UserImageMessageWithPath creates a user message with an image, an optional local
+// file path (so tools like image_generate can reference it), and an optional caption.
+func UserImageMessageWithPath(mediaType, base64Data, filePath, caption string) Message {
 	parts := []Part{{
 		Type:      PartImage,
 		ImageData: &ToolImageData{MediaType: mediaType, Base64: base64Data},
+		ImagePath: filePath,
 	}}
 	if caption != "" {
 		parts = append(parts, Part{Type: PartText, Text: caption})

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -773,21 +773,27 @@ func TestDownloadTelegramPhoto_PicksLargest(t *testing.T) {
 		{FileID: "large", Width: 800, Height: 600},
 	}
 
-	mediaType, b64, err := downloadTelegramPhoto(fg, photos)
+	mediaType, b64, filePath, err := downloadTelegramPhoto(fg, photos)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mediaType != "image/jpeg" {
-		t.Fatalf("mediaType = %q, want %q", mediaType, "image/jpeg")
+	if filePath != "" {
+		defer os.Remove(filePath)
+	}
+	if mediaType == "" {
+		t.Fatal("expected non-empty media type")
 	}
 	if b64 == "" {
 		t.Fatal("expected non-empty base64 data")
+	}
+	if filePath == "" {
+		t.Fatal("expected non-empty file path")
 	}
 }
 
 func TestDownloadTelegramPhoto_EmptyPhotos(t *testing.T) {
 	fg := &fakeFileGetter{}
-	_, _, err := downloadTelegramPhoto(fg, nil)
+	_, _, _, err := downloadTelegramPhoto(fg, nil)
 	if err == nil {
 		t.Fatal("expected error for empty photos")
 	}


### PR DESCRIPTION
## What

When Telegram delivers a photo, term-llm was correctly forwarding it to the LLM as base64 in the message — but there was no filesystem path associated with it. Tools like `image_generate` that take an `input_image` file path had nothing to reference.

This PR implements the D+A approach:

**A — write to temp file at ingest:** `downloadTelegramPhoto` now writes the downloaded bytes to an `os.CreateTemp` file (e.g. `/tmp/tg-img-XXXXX.jpg`), detects the real MIME type via `http.DetectContentType`, and returns the path alongside the base64 data. The temp file is deferred-removed after `streamReply` completes, covering all exit paths.

**D — `Part.ImagePath` field:** A new `ImagePath string` field is added to `llm.Part`. When set, each provider appends a short text annotation immediately after the image block: `[image saved at: /path/to/file.jpg]`. This is structurally in the message, survives history replay, and gives the LLM something concrete to put in `input_image` when calling tools.

## Changes

- `internal/llm/types.go` — add `ImagePath` to `Part`; add `UserImageMessageWithPath` constructor; `UserImageMessage` delegates to it with an empty path (no callers broken)
- `internal/llm/anthropic.go` — emit path annotation after image block in both regular and beta builders
- `internal/llm/openai_compat.go` — emit path annotation after image part
- `internal/llm/gemini.go` — emit path annotation after inline data part
- `internal/llm/chatgpt.go` — emit path annotation after input_image part
- `internal/llm/responses_api.go` — emit path annotation in Responses API image item
- `internal/serve/telegram.go` — `downloadTelegramPhoto` writes temp file and returns path; `handleMessage` uses `UserImageMessageWithPath` and defers cleanup
- `internal/serve/telegram_test.go` — update tests for new 4-value return signature

## Why

With this change, when you send an image to the Telegram bot and then ask it to edit or use that image as a base for generation, the LLM can pass the path directly to `image_generate` as `input_image`. No ambient magic, no session-level state — the path lives in the message where it belongs.