### PR TITLE
Print resume hint on chat exit when session has turns

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -458,11 +458,7 @@ func runChat(cmd *cobra.Command, args []string) error {
 	// Re-fetch the session so we get the latest LLMTurns written during streaming.
 	if store != nil && sess != nil && sess.ID != "" {
 		if refreshed, fetchErr := store.Get(context.Background(), sess.ID); fetchErr == nil && refreshed != nil && refreshed.LLMTurns >= 1 {
-			resumeCmd := fmt.Sprintf("term-llm chat --resume %s", session.ShortID(refreshed.ID))
-			if refreshed.Agent != "" {
-				resumeCmd += fmt.Sprintf(" @%s", refreshed.Agent)
-			}
-			fmt.Fprintf(os.Stdout, "\n💬 Resume: %s\n", resumeCmd)
+			fmt.Fprintf(os.Stdout, "\n💬 Resume: term-llm chat --resume %s\n", session.ShortID(refreshed.ID))
 		}
 	}
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -454,6 +454,18 @@ func runChat(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to run chat: %w", err)
 	}
 
+	// Print resume hint after alt-screen has been dismissed.
+	// Re-fetch the session so we get the latest LLMTurns written during streaming.
+	if store != nil && sess != nil && sess.ID != "" {
+		if refreshed, fetchErr := store.Get(context.Background(), sess.ID); fetchErr == nil && refreshed != nil && refreshed.LLMTurns >= 1 {
+			resumeCmd := fmt.Sprintf("term-llm chat --resume %s", session.ShortID(refreshed.ID))
+			if refreshed.Agent != "" {
+				resumeCmd += fmt.Sprintf(" @%s", refreshed.Agent)
+			}
+			fmt.Fprintf(os.Stdout, "\n💬 Resume: %s\n", resumeCmd)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## What

After exiting a chat session (Ctrl+C), if the session had at least one LLM turn, print a `term-llm chat --resume <shortID>` hint to stdout on the normal (non-alt) screen.

Example output after quitting:
```
💬 Resume: term-llm chat --resume 260221-1430
```

If the session used an agent:
```
💬 Resume: term-llm chat --resume 260221-1430 @jarvis
```

## Why

It's easy to forget the session ID or not know how to resume. This surfaces the exact command trivially — zero-friction continuation of any conversation that went anywhere.

## How

After `p.Run()` returns (alt-screen already dismissed), re-fetch the session from the store to get the latest `LLMTurns` (written during streaming). If `LLMTurns >= 1`, print the hint using `session.ShortID()` which produces the compact `YYMMDD-HHMM` format that `--resume` already accepts via `GetByPrefix`.

No output if sessions are disabled, the session had zero turns (e.g. immediately quit), or fetching fails.