### PR TITLE
feat: script-backed custom tools via tools.custom in agent.yaml

### DIFF
--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -360,6 +360,13 @@ func (r *SpawnAgentRunner) setupAgentTools(cfg *config.Config, engine *llm.Engin
 		return nil, err
 	}
 
+	// Register any custom script-backed tools declared in agent.yaml
+	if len(agent.Tools.Custom) > 0 {
+		if err := toolMgr.Registry.RegisterCustomTools(agent.Tools.Custom, agent.SourcePath); err != nil {
+			return nil, fmt.Errorf("custom tools: %w", err)
+		}
+	}
+
 	// Set yolo mode for sub-agents (they inherit from parent)
 	if r.yoloMode {
 		toolMgr.ApprovalMgr.SetYoloMode(true)

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -1,0 +1,222 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/agents"
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+// validCustomToolNameRE matches valid custom tool names.
+var validCustomToolNameRE = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// CustomScriptTool implements llm.Tool for a script-backed custom tool
+// declared in agent.yaml under tools.custom.
+type CustomScriptTool struct {
+	def      agents.CustomToolDef
+	agentDir string
+	limits   OutputLimits
+}
+
+// newCustomScriptTool creates a CustomScriptTool from a definition and agent directory.
+func newCustomScriptTool(def agents.CustomToolDef, agentDir string, limits OutputLimits) *CustomScriptTool {
+	return &CustomScriptTool{
+		def:      def,
+		agentDir: agentDir,
+		limits:   limits,
+	}
+}
+
+// Spec returns the tool spec for the LLM.
+func (t *CustomScriptTool) Spec() llm.ToolSpec {
+	schema := t.def.Input
+	if schema == nil {
+		schema = map[string]interface{}{
+			"type":                 "object",
+			"properties":           map[string]interface{}{},
+			"additionalProperties": false,
+		}
+	}
+	return llm.ToolSpec{
+		Name:        t.def.Name,
+		Description: t.def.Description,
+		Schema:      schema,
+	}
+}
+
+// Preview returns a short preview string for display in the UI.
+func (t *CustomScriptTool) Preview(args json.RawMessage) string {
+	s := string(args)
+	if s == "" || s == "{}" || s == "null" {
+		return t.def.Name
+	}
+	preview := t.def.Name + " " + s
+	if len(preview) > 50 {
+		preview = preview[:47] + "..."
+	}
+	return preview
+}
+
+// Execute runs the custom script with the LLM's args as JSON on stdin.
+func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	// Validate agentDir is set
+	if t.agentDir == "" {
+		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "no agent directory configured"))), nil
+	}
+
+	// Resolve and validate the script path
+	scriptPath, err := t.resolveScript()
+	if err != nil {
+		return llm.TextOutput(formatToolError(err.(*ToolError))), nil
+	}
+
+	// Determine timeout
+	timeout := 30
+	if t.def.TimeoutSeconds > 0 {
+		timeout = t.def.TimeoutSeconds
+	}
+	if timeout > 300 {
+		timeout = 300
+	}
+
+	// Working directory: same as the term-llm process cwd
+	workDir, err := os.Getwd()
+	if err != nil {
+		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "cannot get working directory: %v", err))), nil
+	}
+
+	// Normalise args: nil → empty object
+	if args == nil || string(args) == "null" {
+		args = json.RawMessage("{}")
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, detectShell(), "-c", scriptPath)
+	cmd.Dir = workDir
+	cmd.Stdin = bytes.NewReader(args)
+
+	// Build environment: inherit + agent-specific vars + per-tool env
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("TERM_LLM_AGENT_DIR=%s", t.agentDir))
+	env = append(env, fmt.Sprintf("TERM_LLM_TOOL_NAME=%s", t.def.Name))
+	for k, v := range t.def.Env {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	execErr := cmd.Run()
+
+	result := ShellResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	if execCtx.Err() == context.DeadlineExceeded {
+		result.TimedOut = true
+		return llm.TextOutput(formatShellResult(result, t.limits)), nil
+	}
+
+	if execErr != nil {
+		if exitErr, ok := execErr.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script error: %v", execErr))), nil
+		}
+	}
+
+	return llm.TextOutput(formatShellResult(result, t.limits)), nil
+}
+
+// resolveScript resolves and validates the script path within the agent directory.
+// Returns the absolute real path on success, or a *ToolError on failure.
+func (t *CustomScriptTool) resolveScript() (string, error) {
+	agentDir, err := filepath.Abs(t.agentDir)
+	if err != nil {
+		return "", NewToolErrorf(ErrExecutionFailed, "resolve agent dir: %v", err)
+	}
+
+	// Join script path (relative) onto agent dir
+	scriptPath := filepath.Join(agentDir, t.def.Script)
+	absScript, err := filepath.Abs(scriptPath)
+	if err != nil {
+		return "", NewToolErrorf(ErrExecutionFailed, "resolve script path: %v", err)
+	}
+
+	// Verify the joined path is still inside the agent dir (pre-symlink check)
+	if !strings.HasPrefix(absScript, agentDir+string(filepath.Separator)) {
+		return "", NewToolError(ErrSymlinkEscape, "script path escapes agent directory")
+	}
+
+	// Resolve symlinks for the final containment check
+	realScript, err := filepath.EvalSymlinks(absScript)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", NewToolErrorf(ErrFileNotFound, "script not found: %s", t.def.Script)
+		}
+		return "", NewToolErrorf(ErrExecutionFailed, "resolve symlinks: %v", err)
+	}
+
+	realAgentDir, err := filepath.EvalSymlinks(agentDir)
+	if err != nil {
+		return "", NewToolErrorf(ErrExecutionFailed, "resolve agent dir symlinks: %v", err)
+	}
+
+	if !strings.HasPrefix(realScript, realAgentDir+string(filepath.Separator)) {
+		return "", NewToolError(ErrSymlinkEscape, "script symlink escapes agent directory")
+	}
+
+	// Must be a regular file
+	info, err := os.Stat(realScript)
+	if err != nil {
+		return "", NewToolErrorf(ErrFileNotFound, "script not found: %s", t.def.Script)
+	}
+	if info.IsDir() {
+		return "", NewToolErrorf(ErrInvalidParams, "script target is a directory, not a file: %s", t.def.Script)
+	}
+
+	return realScript, nil
+}
+
+// RegisterCustomTools registers script-backed custom tools from agent.yaml into the registry.
+// It validates that custom tool names don't collide with built-in tool names.
+// A startup warning (not an error) is emitted if a script file doesn't exist yet.
+func (r *LocalToolRegistry) RegisterCustomTools(defs []agents.CustomToolDef, agentDir string) error {
+	for _, def := range defs {
+		// Validate name format (belt-and-suspenders; agent.Validate() also checks this)
+		if !validCustomToolNameRE.MatchString(def.Name) {
+			return fmt.Errorf("custom tool %q: name must match ^[a-z][a-z0-9_]*$", def.Name)
+		}
+
+		// Check for collision with built-in tool names
+		if ValidToolName(def.Name) {
+			return fmt.Errorf("custom tool %q collides with a built-in tool name", def.Name)
+		}
+
+		// Warn if the script doesn't exist yet (non-fatal — may be created later)
+		if agentDir != "" {
+			scriptPath := filepath.Join(agentDir, def.Script)
+			if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "warning: custom tool %q script not found: %s\n", def.Name, scriptPath)
+			}
+		}
+
+		tool := newCustomScriptTool(def, agentDir, r.limits)
+		r.tools[def.Name] = tool
+	}
+	return nil
+}

--- a/internal/tools/custom_tool_test.go
+++ b/internal/tools/custom_tool_test.go
@@ -1,0 +1,291 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/agents"
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+// makeCustomTool creates a test CustomScriptTool.
+func makeCustomTool(t *testing.T, agentDir string, def agents.CustomToolDef) *CustomScriptTool {
+	t.Helper()
+	return newCustomScriptTool(def, agentDir, DefaultOutputLimits())
+}
+
+// writeScript writes an executable shell script into dir and returns its path.
+func writeScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return p
+}
+
+func TestCustomScriptTool_Spec_NoInput(t *testing.T) {
+	tool := makeCustomTool(t, "/agent", agents.CustomToolDef{
+		Name:        "my_tool",
+		Description: "Does a thing",
+		Script:      "scripts/my.sh",
+	})
+	spec := tool.Spec()
+	if spec.Name != "my_tool" {
+		t.Errorf("expected name my_tool, got %q", spec.Name)
+	}
+	if spec.Description != "Does a thing" {
+		t.Errorf("unexpected description %q", spec.Description)
+	}
+	// When no input defined, schema should be an empty object schema
+	tp, _ := spec.Schema["type"].(string)
+	if tp != "object" {
+		t.Errorf("expected schema type object, got %q", tp)
+	}
+}
+
+func TestCustomScriptTool_Spec_WithInput(t *testing.T) {
+	input := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"name": map[string]interface{}{"type": "string"},
+		},
+		"required": []interface{}{"name"},
+	}
+	tool := makeCustomTool(t, "/agent", agents.CustomToolDef{
+		Name:        "job_run",
+		Description: "Run a job",
+		Script:      "scripts/job-run.sh",
+		Input:       input,
+	})
+	spec := tool.Spec()
+	if spec.Schema["type"] != "object" {
+		t.Errorf("expected schema type object")
+	}
+	props, ok := spec.Schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected properties in schema")
+	}
+	if _, ok := props["name"]; !ok {
+		t.Errorf("expected name in properties")
+	}
+}
+
+func TestCustomScriptTool_Preview(t *testing.T) {
+	tool := makeCustomTool(t, "/agent", agents.CustomToolDef{
+		Name:   "my_tool",
+		Script: "scripts/my.sh",
+	})
+	// Empty args → just tool name
+	preview := tool.Preview(json.RawMessage("{}"))
+	if preview != "my_tool" {
+		t.Errorf("expected 'my_tool', got %q", preview)
+	}
+	// Non-trivial args
+	preview2 := tool.Preview(json.RawMessage(`{"name":"foo"}`))
+	if preview2 == "" {
+		t.Error("expected non-empty preview for non-trivial args")
+	}
+}
+
+func TestCustomScriptTool_Execute_Success(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, dir, "hello.sh", "#!/bin/sh\necho hello")
+
+	tool := makeCustomTool(t, dir, agents.CustomToolDef{
+		Name:        "hello",
+		Description: "Say hello",
+		Script:      "hello.sh",
+	})
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := out.Content
+	if result == "" {
+		t.Error("expected non-empty output")
+	}
+	// Should contain "hello"
+	if !containsStr(result, "hello") {
+		t.Errorf("expected output to contain 'hello', got %q", result)
+	}
+}
+
+func TestCustomScriptTool_Execute_ArgsOnStdin(t *testing.T) {
+	dir := t.TempDir()
+	// Script reads JSON from stdin and echoes the 'name' field
+	writeScript(t, dir, "echo-name.sh", `#!/bin/sh
+INPUT=$(cat)
+echo "$INPUT" | grep -o '"name":"[^"]*"'
+`)
+
+	tool := makeCustomTool(t, dir, agents.CustomToolDef{
+		Name:        "echo_name",
+		Description: "Echo name",
+		Script:      "echo-name.sh",
+	})
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"name":"jarvis"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !containsStr(out.Content, "jarvis") {
+		t.Errorf("expected 'jarvis' in output, got %q", out.Content)
+	}
+}
+
+func TestCustomScriptTool_Execute_EnvVars(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, dir, "env.sh", "#!/bin/sh\necho $TERM_LLM_TOOL_NAME $TERM_LLM_AGENT_DIR $MY_CUSTOM_VAR")
+
+	tool := makeCustomTool(t, dir, agents.CustomToolDef{
+		Name:        "env_test",
+		Description: "Test env",
+		Script:      "env.sh",
+		Env:         map[string]string{"MY_CUSTOM_VAR": "custom_value"},
+	})
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := out.Content
+	if !containsStr(text, "env_test") {
+		t.Errorf("expected TERM_LLM_TOOL_NAME in output, got %q", text)
+	}
+	if !containsStr(text, "custom_value") {
+		t.Errorf("expected MY_CUSTOM_VAR in output, got %q", text)
+	}
+}
+
+func TestCustomScriptTool_Execute_NonZeroExitCode(t *testing.T) {
+	dir := t.TempDir()
+	writeScript(t, dir, "fail.sh", "#!/bin/sh\necho oops >&2\nexit 2")
+
+	tool := makeCustomTool(t, dir, agents.CustomToolDef{
+		Name:        "fail_tool",
+		Description: "Fails",
+		Script:      "fail.sh",
+	})
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Non-zero exit should be surfaced in the output, not an error return
+	text := out.Content
+	if !containsStr(text, "exit") && !containsStr(text, "2") {
+		t.Logf("output: %q", text)
+	}
+}
+
+func TestCustomScriptTool_Execute_ScriptNotFound(t *testing.T) {
+	dir := t.TempDir()
+	tool := makeCustomTool(t, dir, agents.CustomToolDef{
+		Name:        "missing",
+		Description: "Missing script",
+		Script:      "nonexistent.sh",
+	})
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !containsStr(out.Content, "FILE_NOT_FOUND") && !containsStr(out.Content, "not found") {
+		t.Errorf("expected file-not-found error in output, got %q", out.Content)
+	}
+}
+
+func TestCustomScriptTool_Execute_SymlinkEscape(t *testing.T) {
+	agentDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// Create a script outside the agent dir
+	outsideScript := filepath.Join(outsideDir, "evil.sh")
+	if err := os.WriteFile(outsideScript, []byte("#!/bin/sh\necho evil"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink inside agentDir pointing outside
+	symlink := filepath.Join(agentDir, "evil.sh")
+	if err := os.Symlink(outsideScript, symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := makeCustomTool(t, agentDir, agents.CustomToolDef{
+		Name:        "evil",
+		Description: "Evil symlink",
+		Script:      "evil.sh",
+	})
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !containsStr(out.Content, "SYMLINK_ESCAPE") && !containsStr(out.Content, "symlink") {
+		t.Errorf("expected symlink escape error in output, got %q", out.Content)
+	}
+}
+
+func TestRegisterCustomTools_BuiltinCollision(t *testing.T) {
+	r := &LocalToolRegistry{
+		tools: make(map[string]llm.Tool),
+	}
+
+	err := r.RegisterCustomTools([]agents.CustomToolDef{
+		{Name: "shell", Description: "bad", Script: "shell.sh"},
+	}, "/agent")
+	if err == nil {
+		t.Fatal("expected error for built-in name collision")
+	}
+}
+
+func TestRegisterCustomTools_InvalidName(t *testing.T) {
+	r := &LocalToolRegistry{
+		tools: make(map[string]llm.Tool),
+	}
+
+	err := r.RegisterCustomTools([]agents.CustomToolDef{
+		{Name: "Bad-Name", Description: "x", Script: "x.sh"},
+	}, "/agent")
+	if err == nil {
+		t.Fatal("expected error for invalid name")
+	}
+}
+
+func TestRegisterCustomTools_WarnsMissingScript(t *testing.T) {
+	dir := t.TempDir()
+	r := &LocalToolRegistry{
+		tools:  make(map[string]llm.Tool),
+		limits: DefaultOutputLimits(),
+	}
+
+	// Should succeed (missing script is a warning, not an error)
+	err := r.RegisterCustomTools([]agents.CustomToolDef{
+		{Name: "my_tool", Description: "x", Script: "nonexistent.sh"},
+	}, dir)
+	if err != nil {
+		t.Fatalf("unexpected error for missing script: %v", err)
+	}
+	if _, ok := r.tools["my_tool"]; !ok {
+		t.Error("expected my_tool to be registered")
+	}
+}
+
+// containsStr is a simple substring check helper.
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## What

Adds `tools.custom` to `agent.yaml` — a way to declare named, schema-bearing tools backed by shell scripts in the agent directory. These become proper first-class tools with their own descriptions and JSON schemas that the LLM understands natively.

## Why

Today agents can't declare custom named tools. The closest mechanisms (`run_agent_script`, `shell.scripts`) either expose a single generic tool or have no typed parameters. MCP requires external infrastructure. This fills the gap for shell-scriptable control-plane tools that belong to an agent.

Motivating use case: job management tools (`job_status`, `job_run`, `job_history`, `job_logs`) — instead of the LLM invoking `run_agent_script` with a filename string arg, these become proper tools the LLM can discover and call with typed arguments.

## Usage

```yaml
tools:
  enabled: [read_file, shell]
  custom:
    - name: job_status
      description: "List all registered jobs and their last run result."
      script: scripts/job-status.sh

    - name: job_run
      description: "Trigger a scheduled job to run immediately."
      script: scripts/job-run.sh
      input:
        type: object
        properties:
          name:
            type: string
            description: "Job name"
        required: [name]
        additionalProperties: false

    - name: job_history
      description: "Fetch recent run history for a job."
      script: scripts/job-history.sh
      input:
        type: object
        properties:
          name:
            type: string
          limit:
            type: integer
            description: "Runs to return (default 10)"
        required: [name]
        additionalProperties: false
      timeout_seconds: 10
      env:
        DB_PATH: /var/lib/myapp/jobs.db
```

Scripts receive the LLM's arguments as JSON on stdin:

```bash
#!/usr/bin/env bash
INPUT=$(cat)
NAME=$(echo "$INPUT" | jq -r '.name')
LIMIT=$(echo "$INPUT" | jq -r '.limit // 10')
sqlite3 ~/.local/share/jarvis/jobs.db \
  "SELECT * FROM runs WHERE job_name='$NAME' ORDER BY started DESC LIMIT $LIMIT;"
```

## Design

- **Args via stdin JSON** — unambiguous, typed, no shell escaping hazards
- **No approval prompt** — scripts in the agent directory are implicitly trusted (same model as `run_agent_script`)
- **Security** — symlink containment check, must be a regular file, relative paths only
- **Script environment** — inherits process env + `TERM_LLM_AGENT_DIR`, `TERM_LLM_TOOL_NAME`, and any `env:` vars from the definition
- **Startup warning** (not error) if a script file doesn't exist yet
- **Name validation** — must match `^[a-z][a-z0-9_]*$`, no collision with built-in tool names, unique within the custom list
- **Input schema** — passed to LLM for guidance; must be `type: object` at root if provided
- **Not a MCP replacement** — for shell-scriptable agent-local tools, not tools needing external APIs

## Changes

- `internal/agents/agent.go` — adds `CustomToolDef` struct and `Custom []CustomToolDef` field to `ToolsConfig`; startup validation in `Validate()`
- `internal/tools/custom_tool.go` — new file: `CustomScriptTool`, `RegisterCustomTools()` on `LocalToolRegistry`
- `cmd/session.go` — carries `CustomTools` through `SessionSettings`, registers them in `SetupToolManager`
- `cmd/spawn_runner.go` — registers custom tools when spawning sub-agents
- Tests for validation logic and execution behaviour