### PR TITLE
feat: skill-declared tools — scripts bundled in skill dirs registered on activation

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -530,6 +530,20 @@ func RegisterSkillToolWithEngine(engine *llm.Engine, toolMgr *tools.ToolManager,
 	skillTool.SetOnActivated(func(allowedTools []string) {
 		engine.SetAllowedTools(allowedTools)
 	})
+	if toolMgr != nil {
+		skillTool.SetOnToolsActivated(func(defs []skills.SkillToolDef, skillDir string) {
+			if err := toolMgr.Registry.RegisterSkillTools(defs, skillDir); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: skill tools registration failed: %v\n", err)
+				return
+			}
+			// Register the newly added tools with the engine so the LLM can call them
+			for _, def := range defs {
+				if tool, ok := toolMgr.Registry.Get(def.Name); ok {
+					engine.Tools().Register(tool)
+				}
+			}
+		})
+	}
 	engine.Tools().Register(skillTool)
 }
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -536,10 +536,12 @@ func RegisterSkillToolWithEngine(engine *llm.Engine, toolMgr *tools.ToolManager,
 				fmt.Fprintf(os.Stderr, "warning: skill tools registration failed: %v\n", err)
 				return
 			}
-			// Register the newly added tools with the engine so the LLM can call them
+			// Register the newly added tools with the engine so the LLM can call them.
+			// AddDynamicTool queues the spec for injection into the active agentic loop
+			// so the LLM sees the tools immediately on the very next turn.
 			for _, def := range defs {
 				if tool, ok := toolMgr.Registry.Get(def.Name); ok {
-					engine.Tools().Register(tool)
+					engine.AddDynamicTool(tool)
 				}
 			}
 		})

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -112,8 +112,6 @@ type ToolsConfig struct {
 }
 
 // CustomToolDef defines a script-backed custom tool declared in agent.yaml.
-// The script is resolved relative to the agent directory and invoked with
-// the LLM's tool call arguments as JSON on stdin.
 type CustomToolDef struct {
 	// Name is the tool name shown to the LLM. Must match ^[a-z][a-z0-9_]*$
 	// and must not collide with any built-in tool name.
@@ -135,6 +133,12 @@ type CustomToolDef struct {
 
 	// Env is a map of additional environment variables to set when running the script.
 	Env map[string]string `yaml:"env,omitempty"`
+
+	// Call controls how arguments are passed to the script.
+	//   ""       / "args"       — named flags: --key value (default)
+	//   "positional"            — positional args in schema property order
+	//   "json"                  — JSON object on stdin
+	Call string `yaml:"call,omitempty"`
 }
 
 // ShellConfig provides shell tool settings.

--- a/internal/skills/parser.go
+++ b/internal/skills/parser.go
@@ -18,6 +18,7 @@ type frontmatterData struct {
 	Compatibility string            `yaml:"compatibility,omitempty"`
 	AllowedTools  any               `yaml:"allowed-tools,omitempty"` // Can be string, list, or nil
 	Metadata      map[string]string `yaml:"metadata,omitempty"`
+	Tools         []SkillToolDef    `yaml:"tools,omitempty"`
 }
 
 // ParseSkillMD parses a SKILL.md file and returns a Skill.
@@ -60,6 +61,7 @@ func ParseSkillMDContent(content string, loadBody bool) (*Skill, error) {
 		Metadata:      fm.Metadata,
 		Extras:        extractExtras(rawMap),
 		loaded:        loadBody,
+		Tools:         fm.Tools,
 	}
 
 	// Parse allowed-tools from various formats
@@ -164,6 +166,7 @@ func extractExtras(raw map[string]any) map[string]any {
 		"compatibility": true,
 		"allowed-tools": true,
 		"metadata":      true,
+		"tools":         true,
 	}
 
 	extras := make(map[string]any)

--- a/internal/skills/skill.go
+++ b/internal/skills/skill.go
@@ -66,6 +66,12 @@ type SkillToolDef struct {
 
 	// Env is a map of additional environment variables to set when running the script.
 	Env map[string]string `yaml:"env,omitempty"`
+
+	// Call controls how arguments are passed to the script.
+	//   ""       / "args"       — named flags: --key value (default)
+	//   "positional"            — positional args in schema property order
+	//   "json"                  — JSON object on stdin
+	Call string `yaml:"call,omitempty"`
 }
 
 // Skill represents a skill loaded from a SKILL.md file.

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -281,6 +281,7 @@ func (r *LocalToolRegistry) RegisterSkillTools(defs []skills.SkillToolDef, skill
 			Input:          d.Input,
 			TimeoutSeconds: d.TimeoutSeconds,
 			Env:            d.Env,
+			Call:           d.Call,
 		})
 	}
 


### PR DESCRIPTION
## What

Skills can now declare script-backed tools directly in their `SKILL.md` frontmatter. When `activate_skill` is called, those tools are dynamically registered with the engine and immediately available to the LLM.

## Why

Previously, skills that needed to run scripts (e.g. API wrappers with embedded keys) had to either:
- Hardcode absolute paths in SKILL.md instructions → breaks on other machines
- Ask the LLM to call `shell` with a full path → fragile, leaks secrets into context

With skill tools, the script lives in the skill directory, the API key lives in the script, and the LLM gets a clean named tool with typed parameters. Fully portable — no paths in SKILL.md, no secrets in context.

## Changes

### `internal/skills/skill.go`
- New `SkillToolDef` struct (mirrors `agents.CustomToolDef` but lives in the skills package)
- `Skill` gets a `Tools []SkillToolDef` field
- `HasTools()` helper

### `internal/skills/parser.go`
- Parses `tools:` frontmatter key into `[]SkillToolDef`
- `tools` added to standard keys (excluded from `Extras`)

### `internal/tools/skill.go`
- New `SkillToolsRegisteredCallback` type
- `ActivateSkillTool` gains `SetOnToolsActivated(cb)` — called when a skill with tools is activated, receives `(defs, skillDir)`

### `internal/tools/registry.go`
- New `RegisterSkillTools(defs, skillDir)` — converts `SkillToolDef` → `CustomToolDef` and delegates to existing `RegisterCustomTools`

### `cmd/session.go`
- `RegisterSkillToolWithEngine` wires up `SetOnToolsActivated`: registers tools with the registry then immediately registers each new tool with the engine

### `README.md`
- Updated Skill Configuration section (was describing old YAML format)
- New **Skill Tools** subsection with full example, field reference, and the portability rationale

### `internal/skills/parser_test.go`
- `TestParseSkillMDContent_Tools` — verifies full tool definition round-trips through the parser
- `TestParseSkillMDContent_NoTools` — verifies `HasTools()` is false when no tools declared

## Usage

```markdown
---
name: google-maps
description: "Google Maps queries"
tools:
  - name: maps_travel_time
    description: "Traffic-aware travel time"
    script: scripts/travel-time.sh
    timeout_seconds: 15
    input:
      type: object
      properties:
        origin: {type: string}
        destination: {type: string}
      required: [origin, destination]
---
```

Activate the skill → `maps_travel_time` appears as a first-class tool. Script resolves relative to the skill directory. Symlink containment check enforced (same as agent custom tools).