### PR TITLE
feat: add term-llm memory command (Phase 1 - mine + BM25 search)

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	memoryAgent         string
+	memoryDBPath        string
+	memoryDryRun        bool
+	defaultMemoryDBPath string
+)
+
+var memoryCmd = &cobra.Command{
+	Use:   "memory",
+	Short: "Mine and query long-term memory fragments",
+	Long: `Manage long-term memory fragments mined from completed sessions.
+
+Examples:
+  term-llm memory mine
+  term-llm memory search "retry policy"
+  term-llm memory status
+  term-llm memory fragments list`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+func init() {
+	defaultDB := "~/.local/share/term-llm/memory.db"
+	if dbPath, err := memorydb.GetDBPath(); err == nil {
+		defaultDB = dbPath
+	}
+	defaultMemoryDBPath = defaultDB
+
+	memoryCmd.PersistentFlags().StringVar(&memoryAgent, "agent", "", "Filter by agent")
+	memoryCmd.PersistentFlags().StringVar(&memoryDBPath, "db", defaultDB, "Override memory database path")
+	memoryCmd.PersistentFlags().BoolVar(&memoryDryRun, "dry-run", false, "Preview actions without writing changes")
+
+	memoryCmd.AddCommand(memoryMineCmd)
+	memoryCmd.AddCommand(memorySearchCmd)
+	memoryCmd.AddCommand(memoryStatusCmd)
+	memoryCmd.AddCommand(memoryFragmentsCmd)
+}
+
+func openMemoryStore() (*memorydb.Store, error) {
+	if dbEnv := os.Getenv("TERM_LLM_MEMORY_DB"); dbEnv != "" {
+		if memoryDBPath == defaultMemoryDBPath {
+			memoryDBPath = dbEnv
+		}
+	}
+	store, err := memorydb.NewStore(memorydb.Config{Path: memoryDBPath})
+	if err != nil {
+		return nil, fmt.Errorf("open memory store: %w", err)
+	}
+	return store, nil
+}

--- a/cmd/memory_fragments.go
+++ b/cmd/memory_fragments.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	memoryFragmentsSince time.Duration
+	memoryFragmentsLimit int
+)
+
+var memoryFragmentsCmd = &cobra.Command{
+	Use:   "fragments",
+	Short: "Inspect stored memory fragments",
+}
+
+var memoryFragmentsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List memory fragments",
+	RunE:  runMemoryFragmentsList,
+}
+
+var memoryFragmentsShowCmd = &cobra.Command{
+	Use:   "show <path>",
+	Short: "Show a memory fragment by path",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runMemoryFragmentsShow,
+}
+
+func init() {
+	memoryFragmentsCmd.AddCommand(memoryFragmentsListCmd)
+	memoryFragmentsCmd.AddCommand(memoryFragmentsShowCmd)
+
+	memoryFragmentsListCmd.Flags().DurationVar(&memoryFragmentsSince, "since", 0, "Only show fragments updated within this duration (e.g. 24h)")
+	memoryFragmentsListCmd.Flags().IntVar(&memoryFragmentsLimit, "limit", 0, "Maximum number of fragments to return (0 = all)")
+}
+
+func runMemoryFragmentsList(cmd *cobra.Command, args []string) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	opts := memorydb.ListOptions{
+		Agent: strings.TrimSpace(memoryAgent),
+		Limit: memoryFragmentsLimit,
+	}
+	if memoryFragmentsSince > 0 {
+		cutoff := time.Now().Add(-memoryFragmentsSince)
+		opts.Since = &cutoff
+	}
+
+	fragments, err := store.ListFragments(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+	if len(fragments) == 0 {
+		fmt.Println("No memory fragments found.")
+		return nil
+	}
+
+	if strings.TrimSpace(memoryAgent) == "" {
+		fmt.Printf("%-14s %-42s %-10s\n", "AGENT", "PATH", "UPDATED")
+		fmt.Println(strings.Repeat("-", 72))
+		for _, f := range fragments {
+			fmt.Printf("%-14s %-42s %-10s\n", f.Agent, truncateString(f.Path, 42), formatRelativeTime(f.UpdatedAt))
+		}
+		return nil
+	}
+
+	fmt.Printf("%-42s %-10s\n", "PATH", "UPDATED")
+	fmt.Println(strings.Repeat("-", 56))
+	for _, f := range fragments {
+		fmt.Printf("%-42s %-10s\n", truncateString(f.Path, 42), formatRelativeTime(f.UpdatedAt))
+	}
+
+	return nil
+}
+
+func runMemoryFragmentsShow(cmd *cobra.Command, args []string) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	fragPath := strings.TrimSpace(args[0])
+	if fragPath == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
+
+	if strings.TrimSpace(memoryAgent) != "" {
+		frag, err := store.GetFragment(ctx, strings.TrimSpace(memoryAgent), fragPath)
+		if err != nil {
+			return err
+		}
+		if frag == nil {
+			return fmt.Errorf("fragment not found: %s", fragPath)
+		}
+		fmt.Print(frag.Content)
+		if !strings.HasSuffix(frag.Content, "\n") {
+			fmt.Println()
+		}
+		return nil
+	}
+
+	frags, err := store.FindFragmentsByPath(ctx, fragPath)
+	if err != nil {
+		return err
+	}
+	if len(frags) == 0 {
+		return fmt.Errorf("fragment not found: %s", fragPath)
+	}
+	if len(frags) > 1 {
+		return fmt.Errorf("fragment path %q exists for multiple agents; rerun with --agent", fragPath)
+	}
+
+	fmt.Print(frags[0].Content)
+	if !strings.HasSuffix(frags[0].Content, "\n") {
+		fmt.Println()
+	}
+	return nil
+}

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -1,0 +1,602 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/spf13/cobra"
+)
+
+var (
+	memoryMineModel            string
+	memoryMineSince            time.Duration
+	memoryMineLimit            int
+	memoryMineBatchSize        int
+	memoryMineIncludeSubagents bool
+	memoryMineMaxMessages      int
+	memoryMineReadBytes        int
+)
+
+var memoryMineCmd = &cobra.Command{
+	Use:   "mine",
+	Short: "Mine completed sessions into memory fragments",
+	RunE:  runMemoryMine,
+}
+
+const memoryExtractionSystemPrompt = `You are a strict memory extraction engine.
+
+Output must be valid JSON only (no markdown fences, no prose).
+Return exactly one object with key "operations".
+
+Goal: extract durable long-term memory from the provided transcript.
+Focus on stable facts, decisions, preferences, and technical details worth remembering.
+Ignore ephemeral details such as transient errors, one-off debugging steps, and conversational filler.`
+
+type memoryMineCandidate struct {
+	Summary session.SessionSummary
+	Session *session.Session
+	Agent   string
+}
+
+type extractionResponse struct {
+	Operations []extractionOperation `json:"operations"`
+}
+
+type extractionOperation struct {
+	Op      string `json:"op"`
+	Path    string `json:"path,omitempty"`
+	Content string `json:"content,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type transcriptMessage struct {
+	Role      string   `json:"role"`
+	Text      string   `json:"text,omitempty"`
+	ToolCalls []string `json:"tool_calls,omitempty"`
+}
+
+type taxonomyEntry struct {
+	Path    string `json:"path"`
+	Preview string `json:"preview"`
+}
+
+func init() {
+	memoryMineCmd.Flags().StringVar(&memoryMineModel, "model", "", "Override model used for memory extraction")
+	memoryMineCmd.Flags().DurationVar(&memoryMineSince, "since", 0, "Only mine sessions updated within this duration (e.g. 24h)")
+	memoryMineCmd.Flags().IntVar(&memoryMineLimit, "limit", 0, "Maximum number of sessions to mine (0 = all)")
+	memoryMineCmd.Flags().IntVar(&memoryMineBatchSize, "batch-size", 10, "Number of messages to fetch per pagination request")
+	memoryMineCmd.Flags().BoolVar(&memoryMineIncludeSubagents, "include-subagents", false, "Include subagent sessions")
+	memoryMineCmd.Flags().IntVar(&memoryMineMaxMessages, "max-messages", 0, "Maximum newly mined messages per session (0 = all)")
+	memoryMineCmd.Flags().IntVar(&memoryMineReadBytes, "read-bytes", 2048, "Bytes of existing fragment content to include in taxonomy context")
+}
+
+func runMemoryMine(cmd *cobra.Command, args []string) error {
+	if memoryMineBatchSize <= 0 {
+		return fmt.Errorf("--batch-size must be > 0")
+	}
+	if memoryMineLimit < 0 {
+		return fmt.Errorf("--limit must be >= 0")
+	}
+	if memoryMineMaxMessages < 0 {
+		return fmt.Errorf("--max-messages must be >= 0")
+	}
+	if memoryMineReadBytes < 0 {
+		return fmt.Errorf("--read-bytes must be >= 0")
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if err := applyProviderOverridesWithAgent(cfg, cfg.Ask.Provider, cfg.Ask.Model, "", "", ""); err != nil {
+		return err
+	}
+	if strings.TrimSpace(memoryMineModel) != "" {
+		cfg.ApplyOverrides("", strings.TrimSpace(memoryMineModel))
+	}
+
+	provider, err := llm.NewProvider(cfg)
+	if err != nil {
+		return err
+	}
+	engine := newEngine(provider, cfg)
+
+	memStore, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer memStore.Close()
+
+	sessStore, err := openReadOnlySessionStore(cfg)
+	if err != nil {
+		return err
+	}
+	defer sessStore.Close()
+
+	ctx := context.Background()
+
+	currentSession, err := sessStore.GetCurrent(ctx)
+	if err != nil {
+		return fmt.Errorf("get current session: %w", err)
+	}
+	currentID := ""
+	if currentSession != nil {
+		currentID = currentSession.ID
+	}
+
+	complete, err := listCompleteSessions(ctx, sessStore)
+	if err != nil {
+		return fmt.Errorf("list complete sessions: %w", err)
+	}
+
+	candidates, err := collectMineCandidates(ctx, sessStore, complete, currentID)
+	if err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		fmt.Println("No sessions eligible for memory mining.")
+		return nil
+	}
+
+	modelName := activeModel(cfg)
+	if modelName == "" {
+		modelName = "(default model)"
+	}
+	fmt.Printf("Mining %d session(s) with %s / %s\n", len(candidates), provider.Name(), modelName)
+	if memoryDryRun {
+		fmt.Println("Dry run mode: no database writes will be performed.")
+	}
+
+	var totalCreated, totalUpdated, totalSkipped int
+
+	for i, candidate := range candidates {
+		state, err := memStore.GetState(ctx, candidate.Session.ID)
+		if err != nil {
+			return fmt.Errorf("get mining state for session %s: %w", candidate.Session.ID, err)
+		}
+
+		startOffset := 0
+		if state != nil {
+			startOffset = state.LastMinedOffset
+		}
+
+		if startOffset >= candidate.Summary.MessageCount {
+			fmt.Printf("[%d/%d] #%d already mined (offset %d >= %d)\n",
+				i+1, len(candidates), candidate.Summary.Number, startOffset, candidate.Summary.MessageCount)
+			continue
+		}
+
+		messages, nextOffset, err := loadMessagesForMining(ctx, sessStore, candidate.Session.ID, startOffset)
+		if err != nil {
+			return fmt.Errorf("load messages for session %s: %w", candidate.Session.ID, err)
+		}
+		if len(messages) == 0 {
+			fmt.Printf("[%d/%d] #%d no new messages to mine\n", i+1, len(candidates), candidate.Summary.Number)
+			continue
+		}
+
+		existing, err := memStore.ListFragments(ctx, memorydb.ListOptions{Agent: candidate.Agent})
+		if err != nil {
+			return fmt.Errorf("list existing fragments for agent %s: %w", candidate.Agent, err)
+		}
+
+		prompt := buildExtractionPrompt(candidate, startOffset, nextOffset, messages, existing)
+		raw, err := runExtractionRequest(ctx, engine, prompt)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping session %s batch at offset %d: %v\n", candidate.Session.ID, startOffset, err)
+			continue
+		}
+
+		ops, err := parseExtractionOperations(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: bad extraction output for session %s at offset %d: %v\nraw: %s\n", candidate.Session.ID, startOffset, err, raw)
+			continue
+		}
+
+		created, updated, skipped, err := applyExtractionOperations(ctx, memStore, candidate.Agent, ops)
+		if err != nil {
+			return fmt.Errorf("apply operations for session %s: %w", candidate.Session.ID, err)
+		}
+
+		if !memoryDryRun {
+			if err := memStore.UpsertState(ctx, &memorydb.MiningState{
+				SessionID:       candidate.Session.ID,
+				Agent:           candidate.Agent,
+				LastMinedOffset: nextOffset,
+				MinedAt:         time.Now(),
+			}); err != nil {
+				return fmt.Errorf("update mining state for session %s: %w", candidate.Session.ID, err)
+			}
+		}
+
+		totalCreated += created
+		totalUpdated += updated
+		totalSkipped += skipped
+
+		fmt.Printf("[%d/%d] #%d mined messages [%d,%d): create=%d update=%d skip=%d\n",
+			i+1, len(candidates), candidate.Summary.Number, startOffset, nextOffset, created, updated, skipped)
+	}
+
+	fmt.Printf("Done. create=%d update=%d skip=%d\n", totalCreated, totalUpdated, totalSkipped)
+	return nil
+}
+
+func collectMineCandidates(ctx context.Context, store session.Store, complete []session.SessionSummary, currentID string) ([]memoryMineCandidate, error) {
+	cutoff := time.Time{}
+	if memoryMineSince > 0 {
+		cutoff = time.Now().Add(-memoryMineSince)
+	}
+
+	out := make([]memoryMineCandidate, 0, len(complete))
+	agentFilter := strings.TrimSpace(memoryAgent)
+
+	for _, summary := range complete {
+		if !cutoff.IsZero() && summary.UpdatedAt.Before(cutoff) {
+			continue
+		}
+
+		sess, err := store.Get(ctx, summary.ID)
+		if err != nil {
+			return nil, fmt.Errorf("get session %s: %w", summary.ID, err)
+		}
+		if sess == nil {
+			continue
+		}
+
+		if currentID != "" && sess.ID == currentID {
+			continue
+		}
+		if !memoryMineIncludeSubagents && sess.IsSubagent {
+			continue
+		}
+		if hasMemoryMiningTag(sess.Tags) {
+			continue
+		}
+		if agentFilter != "" && strings.TrimSpace(sess.Agent) != agentFilter {
+			continue
+		}
+
+		out = append(out, memoryMineCandidate{
+			Summary: summary,
+			Session: sess,
+			Agent:   resolveMemoryAgent(sess.Agent),
+		})
+
+		if memoryMineLimit > 0 && len(out) >= memoryMineLimit {
+			break
+		}
+	}
+
+	return out, nil
+}
+
+func loadMessagesForMining(ctx context.Context, store session.Store, sessionID string, offset int) ([]session.Message, int, error) {
+	remaining := memoryMineMaxMessages
+	currentOffset := offset
+	all := make([]session.Message, 0, memoryMineBatchSize)
+
+	for {
+		limit := memoryMineBatchSize
+		if remaining > 0 && remaining < limit {
+			limit = remaining
+		}
+
+		msgs, err := store.GetMessages(ctx, sessionID, limit, currentOffset)
+		if err != nil {
+			return nil, currentOffset, err
+		}
+		if len(msgs) == 0 {
+			break
+		}
+
+		all = append(all, msgs...)
+		currentOffset += len(msgs)
+
+		if remaining > 0 {
+			remaining -= len(msgs)
+			if remaining <= 0 {
+				break
+			}
+		}
+
+		if len(msgs) < limit {
+			break
+		}
+	}
+
+	return all, currentOffset, nil
+}
+
+func buildExtractionPrompt(candidate memoryMineCandidate, startOffset, endOffset int, messages []session.Message, existing []memorydb.Fragment) string {
+	transcriptJSON, _ := json.MarshalIndent(buildTranscript(messages), "", "  ")
+	taxonomyJSON, _ := json.MarshalIndent(buildTaxonomy(existing), "", "  ")
+
+	return fmt.Sprintf(`Session metadata:
+- session_id: %s
+- session_number: %d
+- agent: %s
+- mined_message_range: [%d, %d)
+
+Existing fragment taxonomy (path + preview):
+%s
+
+Transcript (role + text + tool call names only):
+%s
+
+Instructions:
+- Extract only durable facts, decisions, preferences, and technical details worth remembering long-term.
+- Skip ephemeral content like specific transient errors, one-off debugging output, and conversational filler.
+- Avoid duplicates: prefer update when a path already exists in taxonomy.
+- Return at most 20 operations.
+- Fragment content must stay <= 8192 bytes.
+- Path must be relative and must not contain ../ or be absolute.
+
+Return strict JSON only, exactly in this format:
+{
+  "operations": [
+    {"op": "create", "path": "...", "content": "..."},
+    {"op": "update", "path": "...", "content": "...", "reason": "..."},
+    {"op": "skip", "reason": "..."}
+  ]
+}
+`,
+		candidate.Session.ID,
+		candidate.Summary.Number,
+		candidate.Agent,
+		startOffset,
+		endOffset,
+		string(taxonomyJSON),
+		string(transcriptJSON),
+	)
+}
+
+func buildTaxonomy(fragments []memorydb.Fragment) []taxonomyEntry {
+	entries := make([]taxonomyEntry, 0, len(fragments))
+	for _, frag := range fragments {
+		entries = append(entries, taxonomyEntry{
+			Path:    frag.Path,
+			Preview: readPrefixBytes(frag.Content, memoryMineReadBytes),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries
+}
+
+func buildTranscript(messages []session.Message) []transcriptMessage {
+	out := make([]transcriptMessage, 0, len(messages))
+
+	for _, msg := range messages {
+		entry := transcriptMessage{Role: string(msg.Role)}
+
+		if msg.Role != llm.RoleTool {
+			if text := strings.TrimSpace(msg.TextContent); text != "" {
+				entry.Text = text
+			}
+		}
+
+		calls := collectToolCallNames(msg)
+		if len(calls) > 0 {
+			entry.ToolCalls = calls
+		}
+
+		if entry.Text == "" && len(entry.ToolCalls) == 0 && msg.Role == llm.RoleTool {
+			// Explicitly suppress raw tool output.
+			continue
+		}
+
+		out = append(out, entry)
+	}
+
+	return out
+}
+
+func collectToolCallNames(msg session.Message) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, part := range msg.Parts {
+		if part.Type != llm.PartToolCall || part.ToolCall == nil {
+			continue
+		}
+		name := strings.TrimSpace(part.ToolCall.Name)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+func runExtractionRequest(ctx context.Context, engine *llm.Engine, prompt string) (string, error) {
+	req := llm.Request{
+		Model:    strings.TrimSpace(memoryMineModel),
+		Messages: []llm.Message{llm.SystemText(memoryExtractionSystemPrompt), llm.UserText(prompt)},
+		MaxTurns: 1,
+		Debug:    false,
+		DebugRaw: debugRaw,
+	}
+
+	stream, err := engine.Stream(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	var b strings.Builder
+	for {
+		ev, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		switch ev.Type {
+		case llm.EventTextDelta:
+			b.WriteString(ev.Text)
+		case llm.EventError:
+			if ev.Err != nil {
+				return "", ev.Err
+			}
+		}
+	}
+
+	return strings.TrimSpace(b.String()), nil
+}
+
+func parseExtractionOperations(raw string) ([]extractionOperation, error) {
+	dec := json.NewDecoder(strings.NewReader(raw))
+
+	var response extractionResponse
+	if err := dec.Decode(&response); err != nil {
+		return nil, fmt.Errorf("decode json: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		return nil, fmt.Errorf("unexpected trailing content after JSON object")
+	}
+
+	if len(response.Operations) > 20 {
+		return nil, fmt.Errorf("too many operations: got %d, max 20", len(response.Operations))
+	}
+
+	normalized := make([]extractionOperation, 0, len(response.Operations))
+	for i, op := range response.Operations {
+		op.Op = strings.ToLower(strings.TrimSpace(op.Op))
+		switch op.Op {
+		case "create", "update":
+			p, err := validateFragmentPath(op.Path)
+			if err != nil {
+				return nil, fmt.Errorf("op[%d] path invalid: %w", i, err)
+			}
+			content := strings.TrimSpace(op.Content)
+			if content == "" {
+				return nil, fmt.Errorf("op[%d] content cannot be empty", i)
+			}
+			if len([]byte(content)) > 8192 {
+				return nil, fmt.Errorf("op[%d] content exceeds 8192 bytes", i)
+			}
+			op.Path = p
+			op.Content = content
+		case "skip":
+			op.Path = ""
+			op.Content = ""
+			if strings.TrimSpace(op.Reason) == "" {
+				op.Reason = "no durable memory extracted"
+			}
+		default:
+			return nil, fmt.Errorf("op[%d] has invalid op %q", i, op.Op)
+		}
+		normalized = append(normalized, op)
+	}
+
+	return normalized, nil
+}
+
+func validateFragmentPath(p string) (string, error) {
+	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
+	if p == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") || isWindowsAbsPath(p) {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	if p == ".." || strings.HasPrefix(p, "../") || strings.Contains(p, "../") || strings.HasSuffix(p, "/..") {
+		return "", fmt.Errorf("path traversal is not allowed")
+	}
+
+	clean := path.Clean(p)
+	if clean == "." || clean == "" || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("invalid path")
+	}
+
+	return clean, nil
+}
+
+func isWindowsAbsPath(p string) bool {
+	if len(p) < 2 {
+		return false
+	}
+	c := p[0]
+	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+		return p[1] == ':'
+	}
+	return false
+}
+
+func applyExtractionOperations(ctx context.Context, store *memorydb.Store, agent string, ops []extractionOperation) (created, updated, skipped int, err error) {
+	for _, op := range ops {
+		switch op.Op {
+		case "create":
+			created++
+			if memoryDryRun {
+				continue
+			}
+			createErr := store.CreateFragment(ctx, &memorydb.Fragment{
+				Agent:   agent,
+				Path:    op.Path,
+				Content: op.Content,
+				Source:  memorydb.DefaultSourceMine,
+			})
+			if createErr != nil {
+				if isUniqueConstraintError(createErr) {
+					ok, upErr := store.UpdateFragment(ctx, agent, op.Path, op.Content)
+					if upErr != nil {
+						return created, updated, skipped, upErr
+					}
+					if ok {
+						created--
+						updated++
+						continue
+					}
+				}
+				return created, updated, skipped, createErr
+			}
+		case "update":
+			updated++
+			if memoryDryRun {
+				continue
+			}
+			ok, updateErr := store.UpdateFragment(ctx, agent, op.Path, op.Content)
+			if updateErr != nil {
+				return created, updated, skipped, updateErr
+			}
+			if !ok {
+				// Keep this as a skipped op if target fragment does not exist.
+				updated--
+				skipped++
+			}
+		case "skip":
+			skipped++
+		}
+	}
+	return created, updated, skipped, nil
+}
+
+func readPrefixBytes(content string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	b := []byte(content)
+	if len(b) <= maxBytes {
+		return content
+	}
+	return string(b[:maxBytes]) + "..."
+}

--- a/cmd/memory_search.go
+++ b/cmd/memory_search.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	memorySearchLimit int
+	memorySearchJSON  bool
+)
+
+var memorySearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search memory fragments (BM25)",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runMemorySearch,
+}
+
+func init() {
+	memorySearchCmd.Flags().IntVar(&memorySearchLimit, "limit", 6, "Maximum number of results")
+	memorySearchCmd.Flags().BoolVar(&memorySearchJSON, "json", false, "Output as JSON")
+}
+
+func runMemorySearch(cmd *cobra.Command, args []string) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	query := strings.TrimSpace(strings.Join(args, " "))
+	if query == "" {
+		return fmt.Errorf("query cannot be empty")
+	}
+
+	results, err := store.SearchFragments(context.Background(), query, memorySearchLimit, strings.TrimSpace(memoryAgent))
+	if err != nil {
+		return err
+	}
+
+	if memorySearchJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+
+	if len(results) == 0 {
+		fmt.Println("No memory fragments found.")
+		return nil
+	}
+
+	if strings.TrimSpace(memoryAgent) == "" {
+		fmt.Printf("%-14s %-36s %s\n", "AGENT", "PATH", "SNIPPET")
+		fmt.Println(strings.Repeat("-", 108))
+		for _, r := range results {
+			fmt.Printf("%-14s %-36s %s\n", r.Agent, truncateString(r.Path, 36), oneLine(truncateString(r.Snippet, 64)))
+		}
+		return nil
+	}
+
+	fmt.Printf("%-36s %s\n", "PATH", "SNIPPET")
+	fmt.Println(strings.Repeat("-", 96))
+	for _, r := range results {
+		fmt.Printf("%-36s %s\n", truncateString(r.Path, 36), oneLine(truncateString(r.Snippet, 64)))
+	}
+
+	return nil
+}
+
+func truncateString(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}
+
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\t", " ")
+	return strings.TrimSpace(s)
+}

--- a/cmd/memory_shared.go
+++ b/cmd/memory_shared.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func openReadOnlySessionStore(cfg *config.Config) (session.Store, error) {
+	storeCfg := sessionStoreConfig(cfg)
+	if !storeCfg.Enabled {
+		return nil, fmt.Errorf("session storage is disabled (check sessions.enabled and --no-session)")
+	}
+	storeCfg.ReadOnly = true
+	return session.NewStore(storeCfg)
+}
+
+func listCompleteSessions(ctx context.Context, store session.Store) ([]session.SessionSummary, error) {
+	const pageSize = 200
+	offset := 0
+	all := make([]session.SessionSummary, 0, pageSize)
+
+	for {
+		page, err := store.List(ctx, session.ListOptions{
+			Status: session.StatusComplete,
+			Limit:  pageSize,
+			Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(page) == 0 {
+			break
+		}
+		all = append(all, page...)
+		if len(page) < pageSize {
+			break
+		}
+		offset += len(page)
+	}
+
+	return all, nil
+}
+
+func resolveMemoryAgent(sessionAgent string) string {
+	if strings.TrimSpace(memoryAgent) != "" {
+		return strings.TrimSpace(memoryAgent)
+	}
+	sessionAgent = strings.TrimSpace(sessionAgent)
+	if sessionAgent != "" {
+		return sessionAgent
+	}
+	return "default"
+}
+
+func hasMemoryMiningTag(tags string) bool {
+	for _, tag := range parseTags(tags) {
+		if tag == "memory-mining" {
+			return true
+		}
+	}
+	return false
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "UNIQUE constraint failed: memory_fragments.agent, memory_fragments.path")
+}

--- a/cmd/memory_status.go
+++ b/cmd/memory_status.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var memoryStatusJSON bool
+
+var memoryStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show memory mining status",
+	RunE:  runMemoryStatus,
+}
+
+type memoryStatusRow struct {
+	Agent           string     `json:"agent"`
+	FragmentCount   int        `json:"fragment_count"`
+	LastMinedAt     *time.Time `json:"last_mined_at,omitempty"`
+	SessionsPending int        `json:"sessions_pending"`
+}
+
+func init() {
+	memoryStatusCmd.Flags().BoolVar(&memoryStatusJSON, "json", false, "Output as JSON")
+}
+
+func runMemoryStatus(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	memStore, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer memStore.Close()
+
+	counts, err := memStore.FragmentCountsByAgent(ctx)
+	if err != nil {
+		return err
+	}
+	lastMinedByAgent, err := memStore.LastMinedByAgent(ctx)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	sessStore, err := openReadOnlySessionStore(cfg)
+	if err != nil {
+		return err
+	}
+	defer sessStore.Close()
+
+	rowsByAgent := map[string]*memoryStatusRow{}
+	filterAgent := strings.TrimSpace(memoryAgent)
+
+	for agent, count := range counts {
+		if filterAgent != "" && agent != filterAgent {
+			continue
+		}
+		row := rowsByAgent[agent]
+		if row == nil {
+			row = &memoryStatusRow{Agent: agent}
+			rowsByAgent[agent] = row
+		}
+		row.FragmentCount = count
+	}
+
+	for agent, minedAt := range lastMinedByAgent {
+		if filterAgent != "" && agent != filterAgent {
+			continue
+		}
+		row := rowsByAgent[agent]
+		if row == nil {
+			row = &memoryStatusRow{Agent: agent}
+			rowsByAgent[agent] = row
+		}
+		minedAtCopy := minedAt
+		row.LastMinedAt = &minedAtCopy
+	}
+
+	complete, err := listCompleteSessions(ctx, sessStore)
+	if err != nil {
+		return fmt.Errorf("list complete sessions: %w", err)
+	}
+
+	for _, summary := range complete {
+		sess, err := sessStore.Get(ctx, summary.ID)
+		if err != nil {
+			return fmt.Errorf("get session %s: %w", summary.ID, err)
+		}
+		if sess == nil {
+			continue
+		}
+
+		agent := resolveMemoryAgent(sess.Agent)
+		if filterAgent != "" && agent != filterAgent {
+			continue
+		}
+
+		row := rowsByAgent[agent]
+		if row == nil {
+			row = &memoryStatusRow{Agent: agent}
+			rowsByAgent[agent] = row
+		}
+
+		state, err := memStore.GetState(ctx, sess.ID)
+		if err != nil {
+			return fmt.Errorf("get mining state for session %s: %w", sess.ID, err)
+		}
+		if state == nil || state.LastMinedOffset < summary.MessageCount {
+			row.SessionsPending++
+		}
+	}
+
+	rows := make([]memoryStatusRow, 0, len(rowsByAgent))
+	for _, row := range rowsByAgent {
+		rows = append(rows, *row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Agent < rows[j].Agent
+	})
+
+	if memoryStatusJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	}
+
+	if len(rows) == 0 {
+		fmt.Println("No memory status data available.")
+		return nil
+	}
+
+	fmt.Printf("%-14s %-10s %-12s %-8s\n", "AGENT", "FRAGMENTS", "LAST MINED", "PENDING")
+	fmt.Println(strings.Repeat("-", 52))
+	for _, row := range rows {
+		lastMined := "-"
+		if row.LastMinedAt != nil {
+			lastMined = formatRelativeTime(*row.LastMinedAt)
+		}
+		fmt.Printf("%-14s %-10d %-12s %-8d\n", row.Agent, row.FragmentCount, lastMined, row.SessionsPending)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&memProfile, "memprofile", "", "Write memory profile to file")
 	rootCmd.PersistentFlags().StringVar(&pprofFlag, "pprof", "", "Start pprof debug server (optionally specify port)")
 	rootCmd.PersistentFlags().Lookup("pprof").NoOptDefVal = "0"
+
+	rootCmd.AddCommand(memoryCmd)
 }
 
 var rootCmd = &cobra.Command{

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1,0 +1,686 @@
+package memory
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const (
+	DefaultSourceMine = "mine"
+)
+
+// Config controls memory store initialization.
+type Config struct {
+	Path string // Optional DB path override (supports :memory:)
+}
+
+// Fragment is a durable memory item extracted from sessions.
+type Fragment struct {
+	ID          string
+	Agent       string
+	Path        string
+	Content     string
+	Source      string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	AccessedAt  *time.Time
+	AccessCount int
+	DecayScore  float64
+	Pinned      bool
+}
+
+// ListOptions configures fragment listing.
+type ListOptions struct {
+	Agent string
+	Since *time.Time
+	Limit int
+}
+
+// SearchResult is a BM25 result from FTS.
+type SearchResult struct {
+	Agent   string  `json:"agent"`
+	Path    string  `json:"path"`
+	Snippet string  `json:"snippet"`
+	Score   float64 `json:"score"`
+}
+
+// MiningState tracks per-session mining progress.
+type MiningState struct {
+	SessionID       string
+	Agent           string
+	LastMinedOffset int
+	MinedAt         time.Time
+}
+
+// Store persists memory fragments and mining state.
+type Store struct {
+	db *sql.DB
+}
+
+const schema = `
+CREATE TABLE IF NOT EXISTS memory_fragments (
+    id           TEXT PRIMARY KEY,
+    agent        TEXT NOT NULL,
+    path         TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    source       TEXT NOT NULL DEFAULT 'mine',
+    created_at   DATETIME NOT NULL,
+    updated_at   DATETIME NOT NULL,
+    accessed_at  DATETIME,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    decay_score  REAL NOT NULL DEFAULT 1.0,
+    pinned       BOOLEAN NOT NULL DEFAULT 0
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fragments_agent_path ON memory_fragments(agent, path);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+    id UNINDEXED,
+    agent UNINDEXED,
+    path,
+    content,
+    content='memory_fragments',
+    content_rowid='rowid',
+    tokenize='unicode61'
+);
+
+CREATE TABLE IF NOT EXISTS memory_mining_state (
+    session_id         TEXT PRIMARY KEY,
+    agent              TEXT NOT NULL,
+    last_mined_offset  INTEGER NOT NULL DEFAULT 0,
+    mined_at           DATETIME NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memory_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+`
+
+// NewStore opens memory.db and initializes schema.
+func NewStore(cfg Config) (*Store, error) {
+	dbPath, err := ResolveDBPath(cfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve memory db path: %w", err)
+	}
+
+	if dbPath != ":memory:" {
+		if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+			return nil, fmt.Errorf("create memory data directory: %w", err)
+		}
+	}
+
+	dsn := dbPath
+	if strings.Contains(dsn, "?") {
+		dsn += "&"
+	} else {
+		dsn += "?"
+	}
+	dsn += "_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=mmap_size(134217728)&_pragma=cache_size(-64000)"
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open memory db: %w", err)
+	}
+
+	if err := initSchema(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return &Store{db: db}, nil
+}
+
+func initSchema(db *sql.DB) error {
+	if _, err := db.Exec(schema); err != nil {
+		return fmt.Errorf("initialize memory schema: %w", err)
+	}
+
+	if err := ensureFTSInitialized(db); err != nil {
+		return fmt.Errorf("initialize memory fts: %w", err)
+	}
+
+	return nil
+}
+
+func ensureFTSInitialized(db *sql.DB) error {
+	var marker string
+	err := db.QueryRow(`SELECT value FROM memory_meta WHERE key = 'fts_initialized'`).Scan(&marker)
+	if err == nil {
+		return nil
+	}
+	if err != sql.ErrNoRows {
+		return err
+	}
+
+	if _, err := db.Exec(`INSERT INTO memory_fts(memory_fts) VALUES('rebuild')`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`INSERT OR REPLACE INTO memory_meta(key, value) VALUES('fts_initialized', '1')`); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetDataDir returns the XDG data directory for term-llm.
+func GetDataDir() (string, error) {
+	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
+		return filepath.Join(xdgData, "term-llm"), nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".local", "share", "term-llm"), nil
+}
+
+// GetDBPath returns the default memory.db path.
+func GetDBPath() (string, error) {
+	dataDir, err := GetDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataDir, "memory.db"), nil
+}
+
+// ResolveDBPath resolves an optional DB path override.
+func ResolveDBPath(pathOverride string) (string, error) {
+	pathOverride = strings.TrimSpace(pathOverride)
+	if pathOverride == "" {
+		return GetDBPath()
+	}
+	if pathOverride == ":memory:" {
+		return pathOverride, nil
+	}
+
+	pathOverride = os.ExpandEnv(pathOverride)
+	if strings.HasPrefix(pathOverride, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		pathOverride = filepath.Join(homeDir, pathOverride[2:])
+	}
+
+	abs, err := filepath.Abs(pathOverride)
+	if err != nil {
+		return "", fmt.Errorf("resolve db path %q: %w", pathOverride, err)
+	}
+	return abs, nil
+}
+
+// CreateFragment inserts a new fragment and syncs FTS explicitly.
+func (s *Store) CreateFragment(ctx context.Context, f *Fragment) error {
+	if f == nil {
+		return fmt.Errorf("fragment is nil")
+	}
+	if strings.TrimSpace(f.Agent) == "" {
+		return fmt.Errorf("agent is required")
+	}
+	if strings.TrimSpace(f.Path) == "" {
+		return fmt.Errorf("path is required")
+	}
+	if strings.TrimSpace(f.Content) == "" {
+		return fmt.Errorf("content is required")
+	}
+	if f.ID == "" {
+		f.ID = newID()
+	}
+	if f.Source == "" {
+		f.Source = DefaultSourceMine
+	}
+	now := time.Now()
+	if f.CreatedAt.IsZero() {
+		f.CreatedAt = now
+	}
+	if f.UpdatedAt.IsZero() {
+		f.UpdatedAt = f.CreatedAt
+	}
+	if f.DecayScore == 0 {
+		f.DecayScore = 1.0
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO memory_fragments (
+			id, agent, path, content, source,
+			created_at, updated_at, accessed_at,
+			access_count, decay_score, pinned
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		f.ID, f.Agent, f.Path, f.Content, f.Source,
+		f.CreatedAt, f.UpdatedAt, f.AccessedAt,
+		f.AccessCount, f.DecayScore, f.Pinned)
+	if err != nil {
+		return fmt.Errorf("insert fragment: %w", err)
+	}
+
+	var rowID int64
+	if err := tx.QueryRowContext(ctx, `SELECT rowid FROM memory_fragments WHERE id = ?`, f.ID).Scan(&rowID); err != nil {
+		return fmt.Errorf("get fragment rowid: %w", err)
+	}
+
+	if err := syncFTSInsert(ctx, tx, rowID, f); err != nil {
+		return fmt.Errorf("sync fts insert: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit create fragment: %w", err)
+	}
+	return nil
+}
+
+// UpdateFragment updates content for an existing (agent,path) fragment and syncs FTS.
+// Returns updated=false when no matching fragment exists.
+func (s *Store) UpdateFragment(ctx context.Context, agent, path, content string) (updated bool, err error) {
+	agent = strings.TrimSpace(agent)
+	path = strings.TrimSpace(path)
+	if agent == "" || path == "" {
+		return false, fmt.Errorf("agent and path are required")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	oldFrag, rowID, err := getFragmentByAgentPathTx(ctx, tx, agent, path)
+	if err != nil {
+		return false, err
+	}
+	if oldFrag == nil {
+		return false, nil
+	}
+
+	now := time.Now()
+	_, err = tx.ExecContext(ctx,
+		`UPDATE memory_fragments SET content = ?, updated_at = ? WHERE rowid = ?`,
+		content, now, rowID)
+	if err != nil {
+		return false, fmt.Errorf("update fragment: %w", err)
+	}
+
+	if err := syncFTSDelete(ctx, tx, rowID, oldFrag); err != nil {
+		return false, fmt.Errorf("sync fts delete: %w", err)
+	}
+
+	newFrag := *oldFrag
+	newFrag.Content = content
+	newFrag.UpdatedAt = now
+	if err := syncFTSInsert(ctx, tx, rowID, &newFrag); err != nil {
+		return false, fmt.Errorf("sync fts insert: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit update fragment: %w", err)
+	}
+
+	return true, nil
+}
+
+// DeleteFragment removes a fragment and syncs FTS.
+// Returns deleted=false when no matching fragment exists.
+func (s *Store) DeleteFragment(ctx context.Context, agent, path string) (deleted bool, err error) {
+	agent = strings.TrimSpace(agent)
+	path = strings.TrimSpace(path)
+	if agent == "" || path == "" {
+		return false, fmt.Errorf("agent and path are required")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	f, rowID, err := getFragmentByAgentPathTx(ctx, tx, agent, path)
+	if err != nil {
+		return false, err
+	}
+	if f == nil {
+		return false, nil
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM memory_fragments WHERE rowid = ?`, rowID)
+	if err != nil {
+		return false, fmt.Errorf("delete fragment: %w", err)
+	}
+
+	if err := syncFTSDelete(ctx, tx, rowID, f); err != nil {
+		return false, fmt.Errorf("sync fts delete: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit delete fragment: %w", err)
+	}
+
+	return true, nil
+}
+
+// GetFragment fetches a fragment by (agent,path).
+func (s *Store) GetFragment(ctx context.Context, agent, path string) (*Fragment, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, agent, path, content, source, created_at, updated_at,
+		       accessed_at, access_count, decay_score, pinned
+		FROM memory_fragments
+		WHERE agent = ? AND path = ?`,
+		agent, path)
+
+	f, err := scanFragment(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get fragment: %w", err)
+	}
+	return f, nil
+}
+
+// FindFragmentsByPath fetches fragments for a path across all agents.
+func (s *Store) FindFragmentsByPath(ctx context.Context, path string) ([]Fragment, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, agent, path, content, source, created_at, updated_at,
+		       accessed_at, access_count, decay_score, pinned
+		FROM memory_fragments
+		WHERE path = ?
+		ORDER BY updated_at DESC`, path)
+	if err != nil {
+		return nil, fmt.Errorf("query fragments by path: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Fragment
+	for rows.Next() {
+		f, err := scanFragment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan fragment: %w", err)
+		}
+		out = append(out, *f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListFragments returns fragments sorted by updated_at descending.
+func (s *Store) ListFragments(ctx context.Context, opts ListOptions) ([]Fragment, error) {
+	query := `
+		SELECT id, agent, path, content, source, created_at, updated_at,
+		       accessed_at, access_count, decay_score, pinned
+		FROM memory_fragments
+		WHERE 1=1`
+	args := []any{}
+
+	if strings.TrimSpace(opts.Agent) != "" {
+		query += ` AND agent = ?`
+		args = append(args, strings.TrimSpace(opts.Agent))
+	}
+	if opts.Since != nil {
+		query += ` AND updated_at >= ?`
+		args = append(args, *opts.Since)
+	}
+	query += ` ORDER BY updated_at DESC`
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list fragments: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Fragment
+	for rows.Next() {
+		f, err := scanFragment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan fragment: %w", err)
+		}
+		out = append(out, *f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SearchFragments performs BM25 search over FTS5.
+func (s *Store) SearchFragments(ctx context.Context, query string, limit int, agent string) ([]SearchResult, error) {
+	if limit <= 0 {
+		limit = 6
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT mf.agent,
+		       mf.path,
+		       snippet(memory_fts, 3, '[', ']', '...', 24) AS snippet,
+		       bm25(memory_fts) AS score
+		FROM memory_fts
+		JOIN memory_fragments mf ON mf.rowid = memory_fts.rowid
+		WHERE memory_fts MATCH ?
+		  AND (? = '' OR mf.agent = ?)
+		ORDER BY bm25(memory_fts)
+		LIMIT ?`, query, agent, agent, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search fragments: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		if err := rows.Scan(&r.Agent, &r.Path, &r.Snippet, &r.Score); err != nil {
+			return nil, fmt.Errorf("scan search result: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetState returns mining state for a session.
+func (s *Store) GetState(ctx context.Context, sessionID string) (*MiningState, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT session_id, agent, last_mined_offset, mined_at
+		FROM memory_mining_state
+		WHERE session_id = ?`, sessionID)
+
+	var st MiningState
+	if err := row.Scan(&st.SessionID, &st.Agent, &st.LastMinedOffset, &st.MinedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get mining state: %w", err)
+	}
+	return &st, nil
+}
+
+// UpsertState inserts or updates mining state.
+func (s *Store) UpsertState(ctx context.Context, st *MiningState) error {
+	if st == nil {
+		return fmt.Errorf("mining state is nil")
+	}
+	if strings.TrimSpace(st.SessionID) == "" {
+		return fmt.Errorf("session_id is required")
+	}
+	if strings.TrimSpace(st.Agent) == "" {
+		return fmt.Errorf("agent is required")
+	}
+	if st.MinedAt.IsZero() {
+		st.MinedAt = time.Now()
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO memory_mining_state(session_id, agent, last_mined_offset, mined_at)
+		VALUES(?, ?, ?, ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+			agent = excluded.agent,
+			last_mined_offset = excluded.last_mined_offset,
+			mined_at = excluded.mined_at`,
+		st.SessionID, st.Agent, st.LastMinedOffset, st.MinedAt)
+	if err != nil {
+		return fmt.Errorf("upsert mining state: %w", err)
+	}
+	return nil
+}
+
+// FragmentCountsByAgent returns count(fragment) grouped by agent.
+func (s *Store) FragmentCountsByAgent(ctx context.Context) (map[string]int, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT agent, COUNT(*)
+		FROM memory_fragments
+		GROUP BY agent`)
+	if err != nil {
+		return nil, fmt.Errorf("query fragment counts: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int{}
+	for rows.Next() {
+		var agent string
+		var count int
+		if err := rows.Scan(&agent, &count); err != nil {
+			return nil, fmt.Errorf("scan fragment count: %w", err)
+		}
+		counts[agent] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return counts, nil
+}
+
+// LastMinedByAgent returns MAX(mined_at) grouped by agent.
+func (s *Store) LastMinedByAgent(ctx context.Context) (map[string]time.Time, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT agent, MAX(mined_at)
+		FROM memory_mining_state
+		GROUP BY agent`)
+	if err != nil {
+		return nil, fmt.Errorf("query last mined: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]time.Time{}
+	for rows.Next() {
+		var agent string
+		var minedAt time.Time
+		if err := rows.Scan(&agent, &minedAt); err != nil {
+			return nil, fmt.Errorf("scan last mined: %w", err)
+		}
+		out[agent] = minedAt
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Close closes the underlying DB.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func scanFragment(scanner interface{ Scan(dest ...any) error }) (*Fragment, error) {
+	var f Fragment
+	var accessedAt sql.NullTime
+	err := scanner.Scan(
+		&f.ID,
+		&f.Agent,
+		&f.Path,
+		&f.Content,
+		&f.Source,
+		&f.CreatedAt,
+		&f.UpdatedAt,
+		&accessedAt,
+		&f.AccessCount,
+		&f.DecayScore,
+		&f.Pinned,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if accessedAt.Valid {
+		f.AccessedAt = &accessedAt.Time
+	}
+	return &f, nil
+}
+
+func getFragmentByAgentPathTx(ctx context.Context, tx *sql.Tx, agent, path string) (*Fragment, int64, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT rowid, id, agent, path, content, source, created_at, updated_at,
+		       accessed_at, access_count, decay_score, pinned
+		FROM memory_fragments
+		WHERE agent = ? AND path = ?`,
+		agent, path)
+
+	var rowID int64
+	var f Fragment
+	var accessedAt sql.NullTime
+	err := row.Scan(
+		&rowID,
+		&f.ID,
+		&f.Agent,
+		&f.Path,
+		&f.Content,
+		&f.Source,
+		&f.CreatedAt,
+		&f.UpdatedAt,
+		&accessedAt,
+		&f.AccessCount,
+		&f.DecayScore,
+		&f.Pinned,
+	)
+	if err == sql.ErrNoRows {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("get fragment: %w", err)
+	}
+	if accessedAt.Valid {
+		f.AccessedAt = &accessedAt.Time
+	}
+	return &f, rowID, nil
+}
+
+func syncFTSInsert(ctx context.Context, tx *sql.Tx, rowID int64, f *Fragment) error {
+	_, err := tx.ExecContext(ctx,
+		`INSERT INTO memory_fts(rowid, id, agent, path, content) VALUES(?, ?, ?, ?, ?)`,
+		rowID, f.ID, f.Agent, f.Path, f.Content)
+	return err
+}
+
+func syncFTSDelete(ctx context.Context, tx *sql.Tx, rowID int64, f *Fragment) error {
+	_, err := tx.ExecContext(ctx,
+		`INSERT INTO memory_fts(memory_fts, rowid, id, agent, path, content) VALUES('delete', ?, ?, ?, ?, ?)`,
+		rowID, f.ID, f.Agent, f.Path, f.Content)
+	return err
+}
+
+func newID() string {
+	now := time.Now().Format("20060102-150405")
+	randBytes := make([]byte, 3)
+	_, _ = rand.Read(randBytes)
+	return fmt.Sprintf("mem-%s-%s", now, hex.EncodeToString(randBytes))
+}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1,0 +1,109 @@
+package memory
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreFragmentCRUDAndSearch(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+
+	store, err := NewStore(Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	defer store.Close()
+
+	frag := &Fragment{
+		Agent:   "reviewer",
+		Path:    "preferences/editor",
+		Content: "User prefers concise answers and durable summaries.",
+		Source:  DefaultSourceMine,
+	}
+	if err := store.CreateFragment(ctx, frag); err != nil {
+		t.Fatalf("CreateFragment() error = %v", err)
+	}
+
+	got, err := store.GetFragment(ctx, "reviewer", "preferences/editor")
+	if err != nil {
+		t.Fatalf("GetFragment() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetFragment() returned nil fragment")
+	}
+	if got.Content != frag.Content {
+		t.Fatalf("content = %q, want %q", got.Content, frag.Content)
+	}
+
+	results, err := store.SearchFragments(ctx, "durable", 10, "reviewer")
+	if err != nil {
+		t.Fatalf("SearchFragments() error = %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("SearchFragments() returned no rows")
+	}
+
+	updated, err := store.UpdateFragment(ctx, "reviewer", "preferences/editor", "User prefers terse answers.")
+	if err != nil {
+		t.Fatalf("UpdateFragment() error = %v", err)
+	}
+	if !updated {
+		t.Fatal("UpdateFragment() returned updated=false")
+	}
+
+	results, err = store.SearchFragments(ctx, "terse", 10, "reviewer")
+	if err != nil {
+		t.Fatalf("SearchFragments() after update error = %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("SearchFragments() after update returned no rows")
+	}
+}
+
+func TestStoreMiningState(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+
+	store, err := NewStore(Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	defer store.Close()
+
+	st := &MiningState{
+		SessionID:       "sess-1",
+		Agent:           "reviewer",
+		LastMinedOffset: 42,
+		MinedAt:         time.Now().UTC(),
+	}
+	if err := store.UpsertState(ctx, st); err != nil {
+		t.Fatalf("UpsertState() error = %v", err)
+	}
+
+	got, err := store.GetState(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("GetState() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetState() returned nil")
+	}
+	if got.LastMinedOffset != 42 {
+		t.Fatalf("offset = %d, want 42", got.LastMinedOffset)
+	}
+
+	st.LastMinedOffset = 100
+	if err := store.UpsertState(ctx, st); err != nil {
+		t.Fatalf("UpsertState(update) error = %v", err)
+	}
+
+	got, err = store.GetState(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("GetState(update) error = %v", err)
+	}
+	if got.LastMinedOffset != 100 {
+		t.Fatalf("offset after update = %d, want 100", got.LastMinedOffset)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -47,6 +47,7 @@ type Config struct {
 	MaxAgeDays int    `mapstructure:"max_age_days"` // Auto-delete after N days (0=never)
 	MaxCount   int    `mapstructure:"max_count"`    // Keep at most N sessions (0=unlimited)
 	Path       string `mapstructure:"path"`         // Optional DB path override (supports :memory:)
+	ReadOnly   bool   `mapstructure:"-"`            // Open DB in read-only mode (skip schema init/cleanup)
 }
 
 // DefaultConfig returns the default session configuration.


### PR DESCRIPTION
## Summary

Adds a native `term-llm memory` command to mine session transcripts into durable, searchable memory fragments stored in a dedicated `memory.db` (separate from `sessions.db`).

This is **Phase 1** — BM25 full-text search only. Vector/embedding search (Phase 2) and decay/auto-promotion (Phase 3) follow in subsequent PRs.

## New commands

```
term-llm memory mine        # extract fragments from session transcripts via LLM
term-llm memory search      # BM25 full-text search across fragments  
term-llm memory status      # DB stats, fragment count, sessions pending/mined
term-llm memory fragments   # list/filter fragments
```

## New package: `internal/memory`

- SQLite-backed store with FTS5 (`unicode61` tokenizer) for BM25 search
- Fragments keyed by `(agent, path)` for upsert semantics
- Mining state tracks per-session offset — incremental re-runs pick up where they left off
- Schema: `id`, `agent`, `path`, `content`, `source`, `decay_score`, `pinned`, `access_count`, `accessed_at`
- `TERM_LLM_MEMORY_DB` env var supported for DB path override (default: `~/.local/share/term-llm/memory.db`)

## Session store changes

- Adds `GetMessages(ctx, sessionID, limit, offset int)` for paginated message access

## Robustness

- LLM/parse errors in `mine` loop warn and continue — one bad session doesn't abort the run
- Lenient JSON parsing of LLM output — unknown top-level keys tolerated
- `isUniqueConstraintError` matches only the specific `(agent, path)` composite constraint
- Partially-mined sessions counted correctly in `status` pending count

## What's not in Phase 1

- Vector/embedding search (Phase 2)
- Decay score application (Phase 3)
- Auto-promotion to `.md` files (Phase 3)
- Agent filter on `ListOptions` (separate small PR opportunity)
