### PR TITLE
Fix stdin isolation for tool subprocesses

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -337,6 +337,7 @@ func runChat(cmd *cobra.Command, args []string) error {
 		opts = append(opts, tea.WithInput(nil))
 	} else {
 		opts = append(opts, tea.WithMouseCellMotion()) // Enable mouse support
+		opts = append(opts, tea.WithInputTTY())
 	}
 
 	// Run the TUI

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/agents"
@@ -165,6 +166,7 @@ func (t *CustomScriptTool) buildCommand(ctx context.Context, scriptPath string, 
 		// Pass raw JSON on stdin
 		cmd := exec.CommandContext(ctx, detectShell(), "-c", scriptPath)
 		cmd.Stdin = bytes.NewReader(args)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		return cmd, nil
 
 	case "positional":
@@ -177,6 +179,8 @@ func (t *CustomScriptTool) buildCommand(ctx context.Context, scriptPath string, 
 			}
 		}
 		cmd := exec.CommandContext(ctx, detectShell(), append([]string{"-c"}, shellJoin(cmdArgs)...)...)
+		cmd.Stdin = strings.NewReader("")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		return cmd, nil
 
 	default: // "" or "args" — named flags (--key value)
@@ -186,6 +190,8 @@ func (t *CustomScriptTool) buildCommand(ctx context.Context, scriptPath string, 
 			cmdArgs = append(cmdArgs, "--"+k, jsonValueToString(argMap[k]))
 		}
 		cmd := exec.CommandContext(ctx, detectShell(), append([]string{"-c"}, shellJoin(cmdArgs)...)...)
+		cmd.Stdin = strings.NewReader("")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		return cmd, nil
 	}
 }


### PR DESCRIPTION
## Problem

Tool subprocesses (`shell`, `run_agent_script`, custom tools) were inheriting the TUI's raw stdin file descriptor. This caused two classes of bugs:

1. **stdin contention** — child processes could read bytes meant for the TUI, corrupting terminal state and causing interactive prompts in tools to hang waiting for input.
2. **signal cross-contamination** — child processes shared the same process group as the TUI, so Ctrl-C and other signals propagated unpredictably.

## Fix

**stdin isolation** — all three tool execution paths now redirect stdin to `/dev/null` (or `strings.NewReader("")` for in-process callers). Tools are non-interactive; they should never touch the terminal's input stream.

**process group isolation** — `SysProcAttr{Setpgid: true}` puts each tool subprocess in its own process group, so signals stay contained and `exec.CommandContext` can kill the whole group on timeout.

**TUI hardening** — `tea.WithInputTTY()` added to `runChat` so Bubble Tea always reads input from the actual TTY even when stdin is a pipe or redirected, making the overall setup more robust.

## Files changed

| File | Change |
|---|---|
| `cmd/chat.go` | Add `tea.WithInputTTY()` |
| `internal/tools/shell.go` | stdin → `/dev/null`, `Setpgid: true` |
| `internal/tools/run_agent_script.go` | stdin → `/dev/null`, `Setpgid: true` |
| `internal/tools/custom_tool.go` | stdin → `/dev/null` or `strings.NewReader("")`, `Setpgid: true` for all three call modes |
