### PR TITLE
Fix skills max_active default (8→50) and warn on truncation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1062,7 +1062,7 @@ func GetDefaults() map[string]any {
 		"skills.enabled":                 false,
 		"skills.auto_invoke":             true,
 		"skills.metadata_budget_tokens":  8000,
-		"skills.max_active":              8,
+		"skills.max_active":              50,
 		"skills.include_project_skills":  true,
 		"skills.include_ecosystem_paths": true,
 		"skills.always_enabled":          []string{},

--- a/internal/skills/prompt.go
+++ b/internal/skills/prompt.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -121,6 +122,13 @@ func TruncateSkillsToTokenBudget(skills []*Skill, alwaysEnabled []string, budget
 
 		result = append(result, skill)
 		currentTokens += tokens
+	}
+
+	// Warn if any skills were dropped due to limits
+	if len(result) < len(skills) {
+		dropped := len(skills) - len(result)
+		fmt.Fprintf(os.Stderr, "warning: %d skill(s) not shown (max_active=%d, token_budget=%d); increase skills.max_active or skills.metadata_budget_tokens in config\n",
+			dropped, maxSkills, budgetTokens)
 	}
 
 	return result


### PR DESCRIPTION
## Problem

The default `max_active` for skills was 8. With 10 skills installed, the last two alphabetically (`pr-to-term-llm`, `weather`) were silently dropped from `<available_skills>` every session — no error, no warning, just gone. This was only noticed when a user asked why a skill they'd created wasn't appearing despite multiple session restarts.

## Changes

**`internal/config/config.go`** — bump `skills.max_active` default from `8` → `50`. A limit of 8 is far too low for typical use; 50 gives plenty of headroom while still acting as a sanity cap.

**`internal/skills/prompt.go`** — emit a `warning:` to stderr when `TruncateSkillsToTokenBudget` drops skills due to hitting `max_active` or the token budget. The message tells the user exactly how many were dropped and which config knobs to turn.

Example warning:
```
warning: 2 skill(s) not shown (max_active=8, token_budget=8000); increase skills.max_active or skills.metadata_budget_tokens in config
```

## Why not just remove the cap?

The cap still serves a purpose — prompt injection has a real cost at very high skill counts. But it should fail loudly, not silently.
