### PR TITLE
feat: memory Phase 2 — vector embeddings + hybrid search

### DIFF
--- a/cmd/memory_search.go
+++ b/cmd/memory_search.go
@@ -4,20 +4,41 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
+	"github.com/samsaffron/term-llm/internal/embedding"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/spf13/cobra"
 )
 
-var (
-	memorySearchLimit int
-	memorySearchJSON  bool
+const (
+	memorySearchCandidateLimit = 24
+	memorySearchVectorWeight   = 0.7
+	memorySearchBM25Weight     = 0.3
+	memorySearchMMRLambda      = 0.5
+	memorySearchMinScore       = 0.35
 )
+
+var (
+	memorySearchLimit         int
+	memorySearchJSON          bool
+	memorySearchEmbedProvider string
+	memorySearchNoDecay       bool
+	memorySearchBM25Only      bool
+)
+
+type hybridSearchCandidate struct {
+	fragment    memorydb.ScoredFragment
+	vectorScore float64
+	bm25Score   float64
+	mergedScore float64
+}
 
 var memorySearchCmd = &cobra.Command{
 	Use:   "search <query>",
-	Short: "Search memory fragments (BM25)",
+	Short: "Search memory fragments (hybrid BM25 + vector)",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  runMemorySearch,
 }
@@ -25,6 +46,10 @@ var memorySearchCmd = &cobra.Command{
 func init() {
 	memorySearchCmd.Flags().IntVar(&memorySearchLimit, "limit", 6, "Maximum number of results")
 	memorySearchCmd.Flags().BoolVar(&memorySearchJSON, "json", false, "Output as JSON")
+	memorySearchCmd.Flags().StringVar(&memorySearchEmbedProvider, "embed-provider", "", "Override embedding provider for query embedding (optionally provider:model)")
+	memorySearchCmd.Flags().BoolVar(&memorySearchNoDecay, "no-decay", false, "Ignore decay score multiplier")
+	memorySearchCmd.Flags().BoolVar(&memorySearchBM25Only, "bm25-only", false, "Force BM25-only retrieval")
+	memorySearchCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)
 }
 
 func runMemorySearch(cmd *cobra.Command, args []string) error {
@@ -39,18 +64,35 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("query cannot be empty")
 	}
 
-	results, err := store.SearchFragments(context.Background(), query, memorySearchLimit, strings.TrimSpace(memoryAgent))
+	if memorySearchLimit <= 0 {
+		memorySearchLimit = 6
+	}
+
+	ctx := context.Background()
+	results, err := searchMemory(ctx, store, query)
 	if err != nil {
 		return err
 	}
 
+	if len(results) > 0 {
+		for _, r := range results {
+			if r.ID == "" {
+				continue
+			}
+			if err := store.BumpAccess(ctx, r.ID); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to bump access for fragment %s: %v\n", r.ID, err)
+			}
+		}
+	}
+
+	output := projectSearchResults(results)
 	if memorySearchJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(results)
+		return enc.Encode(output)
 	}
 
-	if len(results) == 0 {
+	if len(output) == 0 {
 		fmt.Println("No memory fragments found.")
 		return nil
 	}
@@ -58,7 +100,7 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 	if strings.TrimSpace(memoryAgent) == "" {
 		fmt.Printf("%-14s %-36s %s\n", "AGENT", "PATH", "SNIPPET")
 		fmt.Println(strings.Repeat("-", 108))
-		for _, r := range results {
+		for _, r := range output {
 			fmt.Printf("%-14s %-36s %s\n", r.Agent, truncateString(r.Path, 36), oneLine(truncateString(r.Snippet, 64)))
 		}
 		return nil
@@ -66,11 +108,270 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("%-36s %s\n", "PATH", "SNIPPET")
 	fmt.Println(strings.Repeat("-", 96))
-	for _, r := range results {
+	for _, r := range output {
 		fmt.Printf("%-36s %s\n", truncateString(r.Path, 36), oneLine(truncateString(r.Snippet, 64)))
 	}
 
 	return nil
+}
+
+func searchMemory(ctx context.Context, store *memorydb.Store, query string) ([]memorydb.ScoredFragment, error) {
+	agent := strings.TrimSpace(memoryAgent)
+
+	if memorySearchBM25Only {
+		return store.SearchBM25(ctx, query, memorySearchLimit, agent)
+	}
+
+	bm25Candidates, err := store.SearchBM25(ctx, query, memorySearchCandidateLimit, agent)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	providerName, modelName, providerSpec := resolveMemoryEmbeddingProvider(cfg, memorySearchEmbedProvider)
+	if providerName == "" || providerSpec == "" {
+		fmt.Fprintln(os.Stderr, "warning: embedding provider unavailable, falling back to BM25-only search")
+		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+	}
+
+	embedder, err := embedding.NewEmbeddingProvider(cfg, providerSpec)
+	if err != nil {
+		if strings.TrimSpace(memorySearchEmbedProvider) != "" {
+			return nil, err
+		}
+		fmt.Fprintf(os.Stderr, "warning: embedding provider initialization failed (%v), falling back to BM25-only search\n", err)
+		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+	}
+
+	embRes, err := embedder.Embed(embedding.EmbedRequest{
+		Texts:    []string{query},
+		Model:    modelName,
+		TaskType: "RETRIEVAL_QUERY",
+	})
+	if err != nil {
+		if strings.TrimSpace(memorySearchEmbedProvider) != "" {
+			return nil, err
+		}
+		fmt.Fprintf(os.Stderr, "warning: query embedding failed (%v), falling back to BM25-only search\n", err)
+		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+	}
+	if len(embRes.Embeddings) == 0 || len(embRes.Embeddings[0].Vector) == 0 {
+		fmt.Fprintln(os.Stderr, "warning: empty query embedding result, falling back to BM25-only search")
+		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+	}
+
+	queryVec := embRes.Embeddings[0].Vector
+	if modelName == "" {
+		modelName = strings.TrimSpace(embRes.Model)
+	}
+
+	vectorCandidates, err := store.VectorSearch(ctx, agent, queryVec, memorySearchCandidateLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeSearchCandidates(ctx, store, providerName, modelName, bm25Candidates, vectorCandidates)
+	if len(merged) == 0 {
+		return nil, nil
+	}
+
+	reranked := rerankMMR(merged)
+	out := make([]memorydb.ScoredFragment, 0, memorySearchLimit)
+	for _, c := range reranked {
+		if c.mergedScore < memorySearchMinScore {
+			continue
+		}
+		out = append(out, c.fragment)
+		if len(out) >= memorySearchLimit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func mergeSearchCandidates(ctx context.Context, store *memorydb.Store, provider, model string, bm25, vector []memorydb.ScoredFragment) []*hybridSearchCandidate {
+	bm25Norm := normalizeBM25Scores(bm25)
+	merged := map[string]*hybridSearchCandidate{}
+
+	for _, candidate := range vector {
+		entry := merged[candidate.ID]
+		if entry == nil {
+			c := candidate
+			entry = &hybridSearchCandidate{fragment: c}
+			merged[candidate.ID] = entry
+		}
+		entry.vectorScore = maxFloat(entry.vectorScore, normalizeCosineScore(candidate.Score))
+		if entry.fragment.Snippet == "" {
+			entry.fragment.Snippet = snippetFromContent(candidate.Content)
+		}
+	}
+
+	for _, candidate := range bm25 {
+		entry := merged[candidate.ID]
+		if entry == nil {
+			c := candidate
+			entry = &hybridSearchCandidate{fragment: c}
+			merged[candidate.ID] = entry
+		}
+		entry.bm25Score = maxFloat(entry.bm25Score, bm25Norm[candidate.ID])
+		if entry.fragment.Snippet == "" {
+			entry.fragment.Snippet = candidate.Snippet
+		}
+		if len(entry.fragment.Vector) == 0 && provider != "" && model != "" {
+			vec, err := store.GetEmbedding(ctx, candidate.ID, provider, model)
+			if err == nil {
+				entry.fragment.Vector = vec
+			}
+		}
+	}
+
+	out := make([]*hybridSearchCandidate, 0, len(merged))
+	for _, candidate := range merged {
+		score := memorySearchVectorWeight*candidate.vectorScore + memorySearchBM25Weight*candidate.bm25Score
+		if !memorySearchNoDecay {
+			score *= candidate.fragment.DecayScore
+		}
+		candidate.mergedScore = score
+		candidate.fragment.Score = score
+		if candidate.fragment.Snippet == "" {
+			candidate.fragment.Snippet = snippetFromContent(candidate.fragment.Content)
+		}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func rerankMMR(candidates []*hybridSearchCandidate) []*hybridSearchCandidate {
+	remaining := append([]*hybridSearchCandidate(nil), candidates...)
+	selected := make([]*hybridSearchCandidate, 0, len(candidates))
+
+	for len(remaining) > 0 {
+		bestIdx := 0
+		bestScore := math.Inf(-1)
+		for i, candidate := range remaining {
+			maxSimilarity := 0.0
+			for _, picked := range selected {
+				sim := candidateSimilarity(candidate.fragment, picked.fragment)
+				if sim > maxSimilarity {
+					maxSimilarity = sim
+				}
+			}
+			mmrScore := memorySearchMMRLambda*candidate.mergedScore - (1.0-memorySearchMMRLambda)*maxSimilarity
+			if mmrScore > bestScore {
+				bestScore = mmrScore
+				bestIdx = i
+			}
+		}
+
+		selected = append(selected, remaining[bestIdx])
+		remaining = append(remaining[:bestIdx], remaining[bestIdx+1:]...)
+	}
+
+	return selected
+}
+
+func candidateSimilarity(a, b memorydb.ScoredFragment) float64 {
+	if len(a.Vector) == 0 || len(b.Vector) == 0 {
+		return 0
+	}
+	sim := embedding.CosineSimilarity(a.Vector, b.Vector)
+	if sim < 0 {
+		return 0
+	}
+	if sim > 1 {
+		return 1
+	}
+	return sim
+}
+
+func normalizeBM25Scores(candidates []memorydb.ScoredFragment) map[string]float64 {
+	out := make(map[string]float64, len(candidates))
+	if len(candidates) == 0 {
+		return out
+	}
+
+	transformed := make([]float64, len(candidates))
+	minScore := math.Inf(1)
+	maxScore := math.Inf(-1)
+	for i, candidate := range candidates {
+		relevance := -candidate.Score // lower bm25() is better in SQLite FTS5
+		transformed[i] = relevance
+		if relevance < minScore {
+			minScore = relevance
+		}
+		if relevance > maxScore {
+			maxScore = relevance
+		}
+	}
+
+	if maxScore-minScore < 1e-9 {
+		for _, candidate := range candidates {
+			out[candidate.ID] = 1.0
+		}
+		return out
+	}
+
+	for i, candidate := range candidates {
+		norm := (transformed[i] - minScore) / (maxScore - minScore)
+		if norm < 0 {
+			norm = 0
+		} else if norm > 1 {
+			norm = 1
+		}
+		out[candidate.ID] = norm
+	}
+	return out
+}
+
+func normalizeCosineScore(raw float64) float64 {
+	norm := (raw + 1.0) / 2.0
+	if norm < 0 {
+		return 0
+	}
+	if norm > 1 {
+		return 1
+	}
+	return norm
+}
+
+func limitScoredFragments(in []memorydb.ScoredFragment, limit int) []memorydb.ScoredFragment {
+	if limit <= 0 || len(in) <= limit {
+		return in
+	}
+	return in[:limit]
+}
+
+func projectSearchResults(results []memorydb.ScoredFragment) []memorydb.SearchResult {
+	out := make([]memorydb.SearchResult, 0, len(results))
+	for _, result := range results {
+		snippet := result.Snippet
+		if snippet == "" {
+			snippet = snippetFromContent(result.Content)
+		}
+		out = append(out, memorydb.SearchResult{
+			Agent:   result.Agent,
+			Path:    result.Path,
+			Snippet: snippet,
+			Score:   result.Score,
+		})
+	}
+	return out
+}
+
+func snippetFromContent(content string) string {
+	content = oneLine(strings.TrimSpace(content))
+	return truncateString(content, 140)
+}
+
+func maxFloat(a, b float64) float64 {
+	if b > a {
+		return b
+	}
+	return a
 }
 
 func truncateString(s string, max int) string {

--- a/cmd/memory_search_test.go
+++ b/cmd/memory_search_test.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "testing"
+
+func TestNormalizeCosineScoreNegative(t *testing.T) {
+	if got := normalizeCosineScore(-0.25); got != 0 {
+		t.Fatalf("normalizeCosineScore(-0.25) = %f, want 0", got)
+	}
+}

--- a/cmd/memory_shared.go
+++ b/cmd/memory_shared.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/embedding"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
@@ -71,4 +72,77 @@ func isUniqueConstraintError(err error) bool {
 	}
 	errStr := err.Error()
 	return strings.Contains(errStr, "UNIQUE constraint failed: memory_fragments.agent, memory_fragments.path")
+}
+
+func resolveMemoryEmbeddingProvider(cfg *config.Config, override string) (provider, model, providerSpec string) {
+	raw := strings.TrimSpace(override)
+	if raw == "" {
+		raw = strings.TrimSpace(cfg.Embed.Provider)
+	}
+	if raw == "" {
+		raw = strings.TrimSpace(embedding.InferEmbeddingProvider(cfg))
+	}
+	if raw == "" {
+		return "", "", ""
+	}
+
+	provider, model = parseEmbeddingProviderModel(raw)
+	if provider == "" {
+		return "", "", ""
+	}
+	if model == "" {
+		model = defaultEmbeddingModel(cfg, provider)
+	}
+
+	providerSpec = provider
+	if model != "" {
+		providerSpec = provider + ":" + model
+	}
+	return provider, model, providerSpec
+}
+
+func parseEmbeddingProviderModel(spec string) (provider, model string) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(spec, ":", 2)
+	provider = strings.TrimSpace(parts[0])
+	if len(parts) == 2 {
+		model = strings.TrimSpace(parts[1])
+	}
+	return provider, model
+}
+
+func defaultEmbeddingModel(cfg *config.Config, provider string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	switch provider {
+	case "gemini":
+		if strings.TrimSpace(cfg.Embed.Gemini.Model) != "" {
+			return strings.TrimSpace(cfg.Embed.Gemini.Model)
+		}
+		return "gemini-embedding-001"
+	case "openai":
+		if strings.TrimSpace(cfg.Embed.OpenAI.Model) != "" {
+			return strings.TrimSpace(cfg.Embed.OpenAI.Model)
+		}
+		return "text-embedding-3-small"
+	case "jina":
+		if strings.TrimSpace(cfg.Embed.Jina.Model) != "" {
+			return strings.TrimSpace(cfg.Embed.Jina.Model)
+		}
+		return "jina-embeddings-v3"
+	case "voyage":
+		if strings.TrimSpace(cfg.Embed.Voyage.Model) != "" {
+			return strings.TrimSpace(cfg.Embed.Voyage.Model)
+		}
+		return "voyage-3.5"
+	case "ollama":
+		if strings.TrimSpace(cfg.Embed.Ollama.Model) != "" {
+			return strings.TrimSpace(cfg.Embed.Ollama.Model)
+		}
+		return "nomic-embed-text"
+	default:
+		return ""
+	}
 }

--- a/internal/embedding/provider_test.go
+++ b/internal/embedding/provider_test.go
@@ -96,32 +96,24 @@ func TestParseProviderModel(t *testing.T) {
 
 func TestInferEmbeddingProvider(t *testing.T) {
 	tests := []struct {
-		name            string
-		defaultProvider string
-		hasVoyageKey    bool
-		expected        string
+		name      string
+		geminiKey string
+		openaiKey string
+		expected  string
 	}{
-		{"openai provider", "openai", false, "openai"},
-		{"gemini provider", "gemini", false, "gemini"},
-		{"gemini-cli provider", "gemini-cli", false, "gemini"},
-		{"anthropic defaults to gemini", "anthropic", false, "gemini"},
-		{"anthropic with voyage key", "anthropic", true, "voyage"},
-		{"claude-bin defaults to gemini", "claude-bin", false, "gemini"},
-		{"claude-bin with voyage key", "claude-bin", true, "voyage"},
-		{"unknown defaults to gemini", "something", false, "gemini"},
+		{name: "gemini preferred when available", geminiKey: "g-key", openaiKey: "o-key", expected: "gemini"},
+		{name: "openai fallback", openaiKey: "o-key", expected: "openai"},
+		{name: "none available", expected: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{
-				DefaultProvider: tt.defaultProvider,
-			}
-			if tt.hasVoyageKey {
-				cfg.Embed.Voyage.APIKey = "test-key"
-			}
+			cfg := &config.Config{}
+			cfg.Embed.Gemini.APIKey = tt.geminiKey
+			cfg.Embed.OpenAI.APIKey = tt.openaiKey
 			result := inferEmbeddingProvider(cfg)
 			if result != tt.expected {
-				t.Errorf("inferEmbeddingProvider(%q) = %q, want %q", tt.defaultProvider, result, tt.expected)
+				t.Errorf("inferEmbeddingProvider() = %q, want %q", result, tt.expected)
 			}
 		})
 	}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -113,6 +113,54 @@ func TestStoreEmbeddingMethods(t *testing.T) {
 	}
 }
 
+func TestStoreGetEmbeddingsByIDs(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	f1 := &Fragment{Agent: "jarvis", Path: "alpha", Content: "Alpha"}
+	f2 := &Fragment{Agent: "jarvis", Path: "beta", Content: "Beta"}
+	f3 := &Fragment{Agent: "jarvis", Path: "gamma", Content: "Gamma"}
+	for _, f := range []*Fragment{f1, f2, f3} {
+		if err := store.CreateFragment(ctx, f); err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", f.Path, err)
+		}
+	}
+
+	vec1 := []float64{0.4, 0.5}
+	vec2 := []float64{0.6, 0.7}
+	if err := store.UpsertEmbedding(ctx, f1.ID, "gemini", "gemini-embedding-001", len(vec1), vec1); err != nil {
+		t.Fatalf("UpsertEmbedding(f1) error = %v", err)
+	}
+	if err := store.UpsertEmbedding(ctx, f2.ID, "gemini", "gemini-embedding-001", len(vec2), vec2); err != nil {
+		t.Fatalf("UpsertEmbedding(f2) error = %v", err)
+	}
+
+	got, err := store.GetEmbeddingsByIDs(ctx, []string{f1.ID, f2.ID, f3.ID, f2.ID}, "gemini", "gemini-embedding-001")
+	if err != nil {
+		t.Fatalf("GetEmbeddingsByIDs() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetEmbeddingsByIDs() len = %d, want 2", len(got))
+	}
+	if vec, ok := got[f1.ID]; !ok || len(vec) != len(vec1) {
+		t.Fatalf("GetEmbeddingsByIDs() missing f1 or wrong length: %#v", got)
+	}
+	if vec, ok := got[f2.ID]; !ok || len(vec) != len(vec2) {
+		t.Fatalf("GetEmbeddingsByIDs() missing f2 or wrong length: %#v", got)
+	}
+	for i := range vec1 {
+		if math.Abs(got[f1.ID][i]-vec1[i]) > 1e-9 {
+			t.Fatalf("f1 embedding[%d] = %f, want %f", i, got[f1.ID][i], vec1[i])
+		}
+	}
+	for i := range vec2 {
+		if math.Abs(got[f2.ID][i]-vec2[i]) > 1e-9 {
+			t.Fatalf("f2 embedding[%d] = %f, want %f", i, got[f2.ID][i], vec2[i])
+		}
+	}
+}
+
 func TestStoreGetFragmentsNeedingEmbedding(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
@@ -160,34 +208,46 @@ func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
 	f1 := &Fragment{Agent: "jarvis", Path: "top", Content: "Top hit"}
 	f2 := &Fragment{Agent: "jarvis", Path: "mid", Content: "Mid hit"}
 	f3 := &Fragment{Agent: "jarvis", Path: "low", Content: "Low hit"}
-	for _, f := range []*Fragment{f1, f2, f3} {
+	f4 := &Fragment{Agent: "jarvis", Path: "other-model", Content: "Other model"}
+	for _, f := range []*Fragment{f1, f2, f3, f4} {
 		if err := store.CreateFragment(ctx, f); err != nil {
 			t.Fatalf("CreateFragment(%s) error = %v", f.Path, err)
 		}
 	}
 
-	mustUpsertEmbedding := func(id string, vec []float64) {
+	mustUpsertEmbedding := func(id string, provider, model string, vec []float64) {
 		t.Helper()
-		if err := store.UpsertEmbedding(ctx, id, "gemini", "gemini-embedding-001", len(vec), vec); err != nil {
+		if err := store.UpsertEmbedding(ctx, id, provider, model, len(vec), vec); err != nil {
 			t.Fatalf("UpsertEmbedding(%s) error = %v", id, err)
 		}
 	}
-	mustUpsertEmbedding(f1.ID, []float64{1, 0})
-	mustUpsertEmbedding(f2.ID, []float64{0.8, 0.2})
-	mustUpsertEmbedding(f3.ID, []float64{-1, 0})
+	mustUpsertEmbedding(f1.ID, "gemini", "gemini-embedding-001", []float64{1, 0})
+	mustUpsertEmbedding(f2.ID, "gemini", "gemini-embedding-001", []float64{0.8, 0.2})
+	mustUpsertEmbedding(f3.ID, "gemini", "gemini-embedding-001", []float64{-1, 0})
+	mustUpsertEmbedding(f4.ID, "openai", "text-embedding-3-large", []float64{1, 0})
 
-	results, err := store.VectorSearch(ctx, "jarvis", []float64{1, 0}, 2)
+	results, err := store.VectorSearch(ctx, "jarvis", "gemini", "gemini-embedding-001", []float64{1, 0}, 3)
 	if err != nil {
 		t.Fatalf("VectorSearch() error = %v", err)
 	}
-	if len(results) != 2 {
-		t.Fatalf("VectorSearch() len = %d, want 2", len(results))
+	if len(results) != 3 {
+		t.Fatalf("VectorSearch() len = %d, want 3", len(results))
 	}
 	if results[0].ID != f1.ID {
 		t.Fatalf("VectorSearch() top ID = %s, want %s", results[0].ID, f1.ID)
 	}
 	if results[0].Score < results[1].Score {
 		t.Fatalf("scores out of order: %f < %f", results[0].Score, results[1].Score)
+	}
+	ids := map[string]bool{}
+	for _, result := range results {
+		ids[result.ID] = true
+	}
+	if !ids[f1.ID] || !ids[f2.ID] || !ids[f3.ID] {
+		t.Fatalf("VectorSearch() IDs = %#v, want %s %s %s", ids, f1.ID, f2.ID, f3.ID)
+	}
+	if ids[f4.ID] {
+		t.Fatalf("VectorSearch() unexpectedly included other provider/model id %s", f4.ID)
 	}
 
 	if err := store.BumpAccess(ctx, f1.ID); err != nil {
@@ -209,6 +269,10 @@ func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
 	}
 	if got.AccessedAt == nil {
 		t.Fatal("accessed_at was not updated")
+	}
+
+	if err := store.BumpAccess(ctx, "missing-id"); err == nil {
+		t.Fatal("BumpAccess(missing-id) expected error")
 	}
 }
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -9,12 +10,7 @@ import (
 
 func TestStoreFragmentCRUDAndSearch(t *testing.T) {
 	ctx := context.Background()
-	dbPath := filepath.Join(t.TempDir(), "memory.db")
-
-	store, err := NewStore(Config{Path: dbPath})
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
+	store := newTestStore(t)
 	defer store.Close()
 
 	frag := &Fragment{
@@ -63,14 +59,162 @@ func TestStoreFragmentCRUDAndSearch(t *testing.T) {
 	}
 }
 
+func TestStoreEmbeddingMethods(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	frag := &Fragment{Agent: "jarvis", Path: "projects/term-llm/search", Content: "Hybrid search details"}
+	if err := store.CreateFragment(ctx, frag); err != nil {
+		t.Fatalf("CreateFragment() error = %v", err)
+	}
+
+	vec := []float64{0.1, 0.2, 0.3}
+	if err := store.UpsertEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001", len(vec), vec); err != nil {
+		t.Fatalf("UpsertEmbedding() error = %v", err)
+	}
+
+	got, err := store.GetEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001")
+	if err != nil {
+		t.Fatalf("GetEmbedding() error = %v", err)
+	}
+	if len(got) != len(vec) {
+		t.Fatalf("embedding length = %d, want %d", len(got), len(vec))
+	}
+	for i := range vec {
+		if math.Abs(got[i]-vec[i]) > 1e-9 {
+			t.Fatalf("embedding[%d] = %f, want %f", i, got[i], vec[i])
+		}
+	}
+
+	vec2 := []float64{0.3, 0.2, 0.1}
+	if err := store.UpsertEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001", len(vec2), vec2); err != nil {
+		t.Fatalf("UpsertEmbedding(update) error = %v", err)
+	}
+	got, err = store.GetEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001")
+	if err != nil {
+		t.Fatalf("GetEmbedding(update) error = %v", err)
+	}
+	for i := range vec2 {
+		if math.Abs(got[i]-vec2[i]) > 1e-9 {
+			t.Fatalf("updated embedding[%d] = %f, want %f", i, got[i], vec2[i])
+		}
+	}
+
+	if _, err := store.UpdateFragment(ctx, frag.Agent, frag.Path, "Updated content"); err != nil {
+		t.Fatalf("UpdateFragment() error = %v", err)
+	}
+	got, err = store.GetEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001")
+	if err != nil {
+		t.Fatalf("GetEmbedding(after update) error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected stale embedding to be cleared on update, got %v", got)
+	}
+}
+
+func TestStoreGetFragmentsNeedingEmbedding(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	f1 := &Fragment{Agent: "jarvis", Path: "a", Content: "A"}
+	f2 := &Fragment{Agent: "jarvis", Path: "b", Content: "B"}
+	f3 := &Fragment{Agent: "reviewer", Path: "c", Content: "C"}
+	for _, f := range []*Fragment{f1, f2, f3} {
+		if err := store.CreateFragment(ctx, f); err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", f.Path, err)
+		}
+	}
+
+	if err := store.UpsertEmbedding(ctx, f1.ID, "gemini", "gemini-embedding-001", 2, []float64{1, 0}); err != nil {
+		t.Fatalf("UpsertEmbedding() error = %v", err)
+	}
+
+	needJarvis, err := store.GetFragmentsNeedingEmbedding(ctx, "jarvis", "gemini", "gemini-embedding-001")
+	if err != nil {
+		t.Fatalf("GetFragmentsNeedingEmbedding(jarvis) error = %v", err)
+	}
+	if len(needJarvis) != 1 || needJarvis[0].ID != f2.ID {
+		t.Fatalf("jarvis needing embedding = %#v, want only %s", needJarvis, f2.ID)
+	}
+
+	needAll, err := store.GetFragmentsNeedingEmbedding(ctx, "", "gemini", "gemini-embedding-001")
+	if err != nil {
+		t.Fatalf("GetFragmentsNeedingEmbedding(all) error = %v", err)
+	}
+	ids := map[string]bool{}
+	for _, f := range needAll {
+		ids[f.ID] = true
+	}
+	if !ids[f2.ID] || !ids[f3.ID] || len(ids) != 2 {
+		t.Fatalf("all needing embedding IDs = %#v, want [%s %s]", ids, f2.ID, f3.ID)
+	}
+}
+
+func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	f1 := &Fragment{Agent: "jarvis", Path: "top", Content: "Top hit"}
+	f2 := &Fragment{Agent: "jarvis", Path: "mid", Content: "Mid hit"}
+	f3 := &Fragment{Agent: "jarvis", Path: "low", Content: "Low hit"}
+	for _, f := range []*Fragment{f1, f2, f3} {
+		if err := store.CreateFragment(ctx, f); err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", f.Path, err)
+		}
+	}
+
+	mustUpsertEmbedding := func(id string, vec []float64) {
+		t.Helper()
+		if err := store.UpsertEmbedding(ctx, id, "gemini", "gemini-embedding-001", len(vec), vec); err != nil {
+			t.Fatalf("UpsertEmbedding(%s) error = %v", id, err)
+		}
+	}
+	mustUpsertEmbedding(f1.ID, []float64{1, 0})
+	mustUpsertEmbedding(f2.ID, []float64{0.8, 0.2})
+	mustUpsertEmbedding(f3.ID, []float64{-1, 0})
+
+	results, err := store.VectorSearch(ctx, "jarvis", []float64{1, 0}, 2)
+	if err != nil {
+		t.Fatalf("VectorSearch() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("VectorSearch() len = %d, want 2", len(results))
+	}
+	if results[0].ID != f1.ID {
+		t.Fatalf("VectorSearch() top ID = %s, want %s", results[0].ID, f1.ID)
+	}
+	if results[0].Score < results[1].Score {
+		t.Fatalf("scores out of order: %f < %f", results[0].Score, results[1].Score)
+	}
+
+	if err := store.BumpAccess(ctx, f1.ID); err != nil {
+		t.Fatalf("BumpAccess(first) error = %v", err)
+	}
+	if err := store.BumpAccess(ctx, f1.ID); err != nil {
+		t.Fatalf("BumpAccess(second) error = %v", err)
+	}
+
+	got, err := store.GetFragment(ctx, f1.Agent, f1.Path)
+	if err != nil {
+		t.Fatalf("GetFragment() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetFragment() returned nil")
+	}
+	if got.AccessCount != 2 {
+		t.Fatalf("access_count = %d, want 2", got.AccessCount)
+	}
+	if got.AccessedAt == nil {
+		t.Fatal("accessed_at was not updated")
+	}
+}
+
 func TestStoreMiningState(t *testing.T) {
 	ctx := context.Background()
-	dbPath := filepath.Join(t.TempDir(), "memory.db")
-
-	store, err := NewStore(Config{Path: dbPath})
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
-	}
+	store := newTestStore(t)
 	defer store.Close()
 
 	st := &MiningState{
@@ -106,4 +250,14 @@ func TestStoreMiningState(t *testing.T) {
 	if got.LastMinedOffset != 100 {
 		t.Fatalf("offset after update = %d, want 100", got.LastMinedOffset)
 	}
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	store, err := NewStore(Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	return store
 }


### PR DESCRIPTION
## Phase 2: Vector embeddings + hybrid BM25/vector search

Builds on the Phase 1 memory command (PR #13) to add vector embeddings and hybrid search.

### What's new

**`memory_embeddings` table** — new migration adds a table keyed by `(fragment_id, provider, model)` storing JSON-encoded `[]float64` vectors. `UpdateFragment` clears stale embeddings on content change (forces re-embed).

**New store methods:**
- `UpsertEmbedding` / `GetEmbedding` — store and retrieve vectors
- `GetFragmentsNeedingEmbedding` — finds fragments with no embedding row for the given provider+model
- `VectorSearch` — full cosine similarity scan (sqlite-vec not required; full scan is fine for <10k fragments)
- `BumpAccess` — increments `access_count` and sets `accessed_at`

**`memory mine` EMBED phase** — after GENERATE, calls `GetFragmentsNeedingEmbedding` and embeds each via `internal/embedding` (RETRIEVAL_DOCUMENT task type). Skipped if `--embed=false` or no provider is configured. New flags: `--embed`, `--embed-provider`.

**`memory search` hybrid pipeline:**
```
query → embed (RETRIEVAL_QUERY)
  → top 24 vector candidates (VectorSearch)
  + top 24 BM25 candidates (SearchBM25)
  → merge: 0.7×vector + 0.3×BM25 (BM25 scores normalised to [0,1])
  → decay: score *= fragment.decay_score
  → MMR re-ranking (λ=0.5)
  → filter minScore=0.35 → top N
```
Falls back gracefully to BM25-only if no embedding provider is configured. New flags: `--embed-provider`, `--no-decay`, `--bm25-only`. Calls `BumpAccess` for each returned fragment.

**Embedding provider inference** — `resolveMemoryEmbeddingProvider` in `memory_shared.go` prefers Gemini (`gemini-embedding-001`, 3072 dims), falls back to OpenAI. Provider spec supports `provider:model` override syntax.

### Tests
All new store methods covered in `store_test.go`: embedding CRUD, stale-embedding clearing on update, `GetFragmentsNeedingEmbedding` (scoped + unscoped), `VectorSearch` ranking, `BumpAccess` counter.
