### PR TITLE
fix(memory): search finds BM25-only fragments + add fragments sync command

### DIFF
--- a/cmd/memory_fragments.go
+++ b/cmd/memory_fragments.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,6 +16,7 @@ var (
 	memoryFragmentsSince    time.Duration
 	memoryFragmentsLimit    int
 	memoryFragmentsHalfLife float64
+	memoryFragmentsSyncDir  string
 )
 
 var memoryFragmentsCmd = &cobra.Command{
@@ -40,14 +43,33 @@ var memoryFragmentsGCCmd = &cobra.Command{
 	RunE:  runMemoryFragmentsGC,
 }
 
+var memoryFragmentsSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync on-disk fragment .md files into the memory database",
+	Long: `Walks a directory of .md files and upserts each into the memory database.
+
+Fragments are stored under <dir>/<category>/<topic>/<fact>.md (any depth).
+The path stored in the DB is relative to <dir>, prefixed with "fragments/".
+
+Use --agent to set the owning agent (required).
+Use --dir to specify the fragments root directory (required).
+
+New files are created; files whose content has changed are updated (embeddings
+are cleared and will be regenerated on the next 'memory mine --embed' run).
+Files already in the DB with identical content are skipped.`,
+	RunE: runMemoryFragmentsSync,
+}
+
 func init() {
 	memoryFragmentsCmd.AddCommand(memoryFragmentsListCmd)
 	memoryFragmentsCmd.AddCommand(memoryFragmentsShowCmd)
 	memoryFragmentsCmd.AddCommand(memoryFragmentsGCCmd)
+	memoryFragmentsCmd.AddCommand(memoryFragmentsSyncCmd)
 
 	memoryFragmentsListCmd.Flags().DurationVar(&memoryFragmentsSince, "since", 0, "Only show fragments updated within this duration (e.g. 24h)")
 	memoryFragmentsListCmd.Flags().IntVar(&memoryFragmentsLimit, "limit", 0, "Maximum number of fragments to return (0 = all)")
 	memoryFragmentsGCCmd.Flags().Float64Var(&memoryFragmentsHalfLife, "half-life", 30.0, "Decay half-life in days for GC recalculation")
+	memoryFragmentsSyncCmd.Flags().StringVar(&memoryFragmentsSyncDir, "dir", "", "Root directory containing .md fragment files (required)")
 	// --dry-run is inherited from the root memory command's persistent flags.
 }
 
@@ -168,5 +190,127 @@ func runMemoryFragmentsGC(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Printf("gc: removed %d fragments\n", removed)
+	return nil
+}
+
+func runMemoryFragmentsSync(cmd *cobra.Command, args []string) error {
+	agent := strings.TrimSpace(memoryAgent)
+	if agent == "" {
+		return fmt.Errorf("--agent is required")
+	}
+	dir := strings.TrimSpace(memoryFragmentsSyncDir)
+	if dir == "" {
+		return fmt.Errorf("--dir is required")
+	}
+
+	// Resolve to absolute path
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolve dir: %w", err)
+	}
+	if _, err := os.Stat(absDir); err != nil {
+		return fmt.Errorf("dir not found: %w", err)
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	var created, updated, skipped, errors int
+
+	err = filepath.Walk(absDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		// Compute DB path: "fragments/<relative-from-dir>"
+		rel, err := filepath.Rel(absDir, path)
+		if err != nil {
+			return err
+		}
+		dbPath := "fragments/" + filepath.ToSlash(rel)
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  error reading %s: %v\n", rel, err)
+			errors++
+			return nil
+		}
+		contentStr := string(content)
+		if strings.TrimSpace(contentStr) == "" {
+			skipped++
+			return nil
+		}
+
+		existing, err := store.GetFragment(ctx, agent, dbPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  error checking %s: %v\n", dbPath, err)
+			errors++
+			return nil
+		}
+
+		if existing != nil {
+			if existing.Content == contentStr {
+				// Identical — nothing to do
+				skipped++
+				return nil
+			}
+			// Content changed — update
+			if memoryDryRun {
+				fmt.Printf("  would update: %s\n", dbPath)
+				updated++
+				return nil
+			}
+			_, err = store.UpdateFragment(ctx, agent, dbPath, contentStr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  error updating %s: %v\n", dbPath, err)
+				errors++
+				return nil
+			}
+			fmt.Printf("  updated: %s\n", dbPath)
+			updated++
+			return nil
+		}
+
+		// New fragment — create it, using file mtime for timestamps
+		mtime := info.ModTime()
+		frag := &memorydb.Fragment{
+			Agent:     agent,
+			Path:      dbPath,
+			Content:   contentStr,
+			Source:    "sync",
+			CreatedAt: mtime,
+			UpdatedAt: mtime,
+		}
+		if memoryDryRun {
+			fmt.Printf("  would create: %s\n", dbPath)
+			created++
+			return nil
+		}
+		if err := store.CreateFragment(ctx, frag); err != nil {
+			fmt.Fprintf(os.Stderr, "  error creating %s: %v\n", dbPath, err)
+			errors++
+			return nil
+		}
+		fmt.Printf("  created: %s\n", dbPath)
+		created++
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk error: %w", err)
+	}
+
+	action := "sync"
+	if memoryDryRun {
+		action = "dry-run"
+	}
+	fmt.Printf("\n%s complete: %d created, %d updated, %d skipped, %d errors\n",
+		action, created, updated, skipped, errors)
 	return nil
 }


### PR DESCRIPTION
## Problem

`memory search` was returning the same ~6 results regardless of query. Two root causes:

### Bug 1: BM25-only fragments silently filtered out

Fragments without embeddings could never pass the min-score threshold:

```
max score = 0.7 * vectorScore(0) + 0.3 * bm25Score(1.0) = 0.30
min threshold = 0.35
```

So any fragment that hadn't been embedded yet was **always dropped**, even if it was the best BM25 match. With only 5-6 of 150+ fragments having embeddings, effectively nothing useful was being returned.

### Bug 2: on-disk fragments not in the DB

Fragments written to disk by `write_file` tool calls or `mine-sessions.sh` were never indexed into `memory.db`, so the FTS and vector search couldn't see them at all.

## Fixes

### 1. BM25-only scoring path (`cmd/memory_search.go`)

When a fragment has no vector embedding, use its BM25 score directly instead of the weighted hybrid formula. Apply a lower min-score threshold (0.10 vs 0.35) since there's no vector signal to confirm relevance.

Embedded fragments still rank above equally-good BM25-only ones because their scores are boosted by the 0.7 vector weight.

### 2. `memory fragments sync` subcommand (`cmd/memory_fragments.go`)

New command that walks a directory of `.md` files and upserts each into `memory.db`:

```
term-llm memory fragments sync --agent jarvis --dir /path/to/fragments
```

- Idempotent: skips unchanged files, updates changed ones (clears stale embeddings)
- Uses file mtime for timestamps, `source='sync'`
- Supports `--dry-run`

This bridges the gap between fragments written to disk and the search index.

## Result

Before: every query returned the same 6 term-llm project fragments.

After, with 150 fragments synced and embedded:
- `"telegram bot setup runit"` → telegram-bot-setup.md, restart-telegram-service.md
- `"paste file share URL curl"` → snippets/pastebin.md  
- `"Sam preferences ripgrep"` → preferences/use-ripgrep-not-grep.md
- `"nzbgeek sabnzbd"` → skills/nzbgeek.md
- `"homelab docker infra"` → homelab/network/network-map.md, runit-as-pid1.md
