### PR TITLE
feat: track generated images in memory DB

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -162,6 +162,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize tools: %w", err)
 		}
+		wireImageRecorder(toolMgr.Registry, "", "")
 		// Enable yolo mode if flag is set
 		if editYolo {
 			toolMgr.ApprovalMgr.SetYoloMode(true)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -143,6 +143,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize tools: %w", err)
 		}
+		wireImageRecorder(toolMgr.Registry, "", "")
 		// Enable yolo mode if flag is set
 		if execYolo {
 			toolMgr.ApprovalMgr.SetYoloMode(true)

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,7 @@ func init() {
 	memoryCmd.AddCommand(memoryPromoteCmd)
 	memoryCmd.AddCommand(memoryStatusCmd)
 	memoryCmd.AddCommand(memoryFragmentsCmd)
+	memoryCmd.AddCommand(memoryImagesCmd)
 }
 
 func openMemoryStore() (*memorydb.Store, error) {
@@ -59,4 +61,17 @@ func openMemoryStore() (*memorydb.Store, error) {
 		return nil, fmt.Errorf("open memory store: %w", err)
 	}
 	return store, nil
+}
+
+// wireImageRecorder opens the memory store and attaches it to the registry as an image recorder.
+// Non-fatal: if the store cannot be opened, image generation still works normally.
+func wireImageRecorder(registry *tools.LocalToolRegistry, agent, sessionID string) {
+	if registry == nil {
+		return
+	}
+	store, err := openMemoryStore()
+	if err != nil {
+		return
+	}
+	registry.SetImageRecorder(store, agent, sessionID)
 }

--- a/cmd/memory_images.go
+++ b/cmd/memory_images.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	memoryImagesLimit  int
+	memoryImagesOffset int
+	memoryImagesJSON   bool
+)
+
+var memoryImagesCmd = &cobra.Command{
+	Use:   "images",
+	Short: "Browse and search generated images",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var memoryImagesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List generated images (newest first)",
+	RunE:  runMemoryImagesList,
+}
+
+var memoryImagesSearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search generated images by prompt",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runMemoryImagesSearch,
+}
+
+func init() {
+	memoryImagesListCmd.Flags().IntVar(&memoryImagesLimit, "limit", 20, "Maximum number of results")
+	memoryImagesListCmd.Flags().IntVar(&memoryImagesOffset, "offset", 0, "Offset for pagination")
+	memoryImagesListCmd.Flags().BoolVar(&memoryImagesJSON, "json", false, "Output as JSON")
+
+	memoryImagesSearchCmd.Flags().IntVar(&memoryImagesLimit, "limit", 10, "Maximum number of results")
+	memoryImagesSearchCmd.Flags().BoolVar(&memoryImagesJSON, "json", false, "Output as JSON")
+
+	memoryImagesCmd.AddCommand(memoryImagesListCmd)
+	memoryImagesCmd.AddCommand(memoryImagesSearchCmd)
+}
+
+func runMemoryImagesList(cmd *cobra.Command, args []string) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	images, err := store.ListImages(ctx, memorydb.ImageListOptions{
+		Agent:  memoryAgent,
+		Limit:  memoryImagesLimit,
+		Offset: memoryImagesOffset,
+	})
+	if err != nil {
+		return err
+	}
+
+	return printImages(images, memoryImagesJSON)
+}
+
+func runMemoryImagesSearch(cmd *cobra.Command, args []string) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	query := strings.TrimSpace(strings.Join(args, " "))
+	ctx := context.Background()
+	images, err := store.SearchImages(ctx, query, memoryAgent, memoryImagesLimit)
+	if err != nil {
+		return err
+	}
+
+	return printImages(images, memoryImagesJSON)
+}
+
+func printImages(images []memorydb.ImageRecord, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(images)
+	}
+
+	if len(images) == 0 {
+		fmt.Println("No images found.")
+		return nil
+	}
+
+	for _, img := range images {
+		age := formatRelativeTime(img.CreatedAt)
+		prompt := img.Prompt
+		if len(prompt) > 60 {
+			prompt = prompt[:57] + "..."
+		}
+		sizeStr := ""
+		if img.FileSize > 0 {
+			sizeStr = fmt.Sprintf(" (%s)", formatBytes(int64(img.FileSize)))
+		}
+		dims := ""
+		if img.Width > 0 && img.Height > 0 {
+			dims = fmt.Sprintf(" %dx%d", img.Width, img.Height)
+		}
+		fmt.Printf("[%s] %s\n  %s%s%s  %s\n\n",
+			age,
+			prompt,
+			img.OutputPath,
+			sizeStr,
+			dims,
+			img.Provider,
+		)
+	}
+	return nil
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -147,6 +147,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	wireImageRecorder(registry, "", "")
 
 	engine := newEngine(provider, cfg)
 	registry.RegisterWithEngine(engine)

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -24,6 +24,9 @@ type SessionSettings struct {
 	Provider string
 	Model    string
 
+	// Agent name (if any)
+	AgentName string
+
 	// Tool settings
 	Tools        string
 	ReadDirs     []string
@@ -116,6 +119,9 @@ func LoadAgent(agentName string, cfg *config.Config) (*agents.Agent, error) {
 // Priority: CLI > agent > config
 func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, configProvider, configModel, configInstructions string, configMaxTurns, defaultMaxTurns int) (SessionSettings, error) {
 	s := SessionSettings{}
+	if agent != nil {
+		s.AgentName = agent.Name
+	}
 
 	// Provider/model: CLI > agent > config
 	s.Provider = configProvider
@@ -317,6 +323,7 @@ func (s *SessionSettings) SetupToolManager(cfg *config.Config, engine *llm.Engin
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize tools: %w", err)
 	}
+	wireImageRecorder(toolMgr.Registry, s.AgentName, "")
 
 	// Register any custom script-backed tools declared in agent.yaml
 	if len(s.CustomTools) > 0 {

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -359,6 +359,7 @@ func (r *SpawnAgentRunner) setupAgentTools(cfg *config.Config, engine *llm.Engin
 	if err != nil {
 		return nil, err
 	}
+	wireImageRecorder(toolMgr.Registry, agent.Name, childSessionID)
 
 	// Register any custom script-backed tools declared in agent.yaml
 	if len(agent.Tools.Custom) > 0 {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -18,6 +18,10 @@ type LocalToolRegistry struct {
 	limits      OutputLimits
 	appConfig   *config.Config
 
+	memoryStore ImageRecorder
+	agent       string
+	sessionID   string
+
 	// Registered tools
 	tools map[string]llm.Tool
 }
@@ -51,6 +55,13 @@ func NewLocalToolRegistry(toolConfig *ToolConfig, appConfig *config.Config, appr
 	}
 
 	return r, nil
+}
+
+// SetImageRecorder wires an image recorder for image generation tracking.
+func (r *LocalToolRegistry) SetImageRecorder(recorder ImageRecorder, agent, sessionID string) {
+	r.memoryStore = recorder
+	r.agent = agent
+	r.sessionID = sessionID
 }
 
 // registerEnabledTools registers all tools that are enabled in config.
@@ -91,7 +102,7 @@ func (r *LocalToolRegistry) registerTool(specName string) error {
 	case ShowImageToolName:
 		tool = NewShowImageTool(r.approval)
 	case ImageGenerateToolName:
-		tool = NewImageGenerateTool(r.approval, r.appConfig, r.config.ImageProvider)
+		tool = NewImageGenerateTool(r.approval, r.appConfig, r.config.ImageProvider, r.memoryStore, r.agent, r.sessionID)
 	case AskUserToolName:
 		tool = NewAskUserTool()
 	case SpawnAgentToolName:


### PR DESCRIPTION
## What

Adds automatic tracking of every generated image to the memory database, plus `memory images` subcommands to browse and search the history.

### New commands

```
term-llm memory images list                      # newest first, default 20
term-llm memory images list --limit 50 --agent jarvis
term-llm memory images list --json               # machine-readable

term-llm memory images search "cartoon cat"      # FTS5 over prompt + path
term-llm memory images search "dragon" --limit 5
```

### Changes

- **`internal/memory/store.go`**: New `generated_images` table (id, agent, session_id, prompt, output_path, mime_type, provider, width, height, file_size, created_at) with FTS5 index on prompt/path. `RecordImage`, `ListImages`, `SearchImages` methods.
- **`internal/tools/image_gen.go`**: `ImageRecorder` interface; records every successful generation non-fatally (failures are silently ignored — image gen is never blocked).
- **`internal/tools/registry.go`**: `SetImageRecorder` wires the recorder into the tool at registry construction time; `memoryStore`, `agent`, `sessionID` fields on `LocalToolRegistry`.
- **`cmd/memory.go`**: `wireImageRecorder` helper + `memoryImagesCmd` registered.
- **`cmd/memory_images.go`**: New `memory images list` and `memory images search <query>` subcommands.
- **`cmd/edit.go`, `cmd/exec.go`, `cmd/plan.go`, `cmd/session.go`, `cmd/spawn_runner.go`**: All call `wireImageRecorder` after tool registry setup, passing agent name and session ID where available.

## Why

Previously there was no way to find a generated image after the session ended without grepping `~/Pictures/term-llm`. Now every image is automatically indexed — prompt, path, provider, dimensions, and file size — and fully searchable.

## Notes

- Recording is **non-fatal** everywhere. If the memory DB is unavailable, image generation continues normally.
- The `generated_images_fts` FTS5 table uses `content='generated_images'` (external content table) for storage efficiency.
- The store is opened fresh per CLI invocation (same pattern as other memory subcommands) so there's no connection leak concern.
- Session ID is available in spawned-agent context (`spawn_runner.go`) but empty string for top-level sessions (acceptable — agent name is the useful grouping key anyway).
