### PR TITLE
docker: remove retired job-scheduler service from image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,4 +84,7 @@ RUN chmod +x /entrypoint.sh
 # Drop your service dirs under docker/sv/ and they'll be available at /etc/sv/
 COPY docker/sv/ /etc/sv/
 
+# Remove retired service definitions
+RUN rm -rf /etc/sv/job-scheduler
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Remove the `job-scheduler` service definition from the Docker image.

The `job-scheduler` service was retired when all cron jobs were migrated to the native `term-llm jobs` system. The `/etc/sv/job-scheduler` directory has been baked into the image ever since but serves no purpose — it's never symlinked, never runs.

This adds a single `RUN rm -rf /etc/sv/job-scheduler` after the `COPY docker/sv/` line.
