### PR TITLE
feat(telegram): full context continuity across restarts + notify command

### DIFF
--- a/cmd/serve_telegram_notify.go
+++ b/cmd/serve_telegram_notify.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/spf13/cobra"
+)
+
+var (
+	serveTelegramChatID    int64
+	serveTelegramParseMode string
+)
+
+var serveTelegramCmd = &cobra.Command{
+	Use:   "telegram",
+	Short: "Telegram utilities",
+}
+
+var serveTelegramNotifyCmd = &cobra.Command{
+	Use:   "notify --chat-id <id> <message>",
+	Short: "Send a Telegram message and log it to the session store",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runServeTelegramNotify,
+}
+
+func init() {
+	serveTelegramNotifyCmd.Flags().Int64Var(&serveTelegramChatID, "chat-id", 0, "Telegram chat ID to send to")
+	serveTelegramNotifyCmd.Flags().StringVar(&serveTelegramParseMode, "parse-mode", "Markdown", "Telegram parse mode: Markdown or HTML")
+	if err := serveTelegramNotifyCmd.MarkFlagRequired("chat-id"); err != nil {
+		panic(fmt.Sprintf("failed to mark chat-id required: %v", err))
+	}
+
+	serveTelegramCmd.AddCommand(serveTelegramNotifyCmd)
+	serveCmd.AddCommand(serveTelegramCmd)
+}
+
+type telegramSendRequest struct {
+	ChatID    int64  `json:"chat_id"`
+	Text      string `json:"text"`
+	ParseMode string `json:"parse_mode"`
+}
+
+type telegramSendResponse struct {
+	OK          bool   `json:"ok"`
+	Description string `json:"description"`
+}
+
+func runServeTelegramNotify(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	message := args[0]
+	parseMode, err := normalizeTelegramParseMode(serveTelegramParseMode)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := loadConfigWithSetup()
+	if err != nil {
+		return err
+	}
+
+	token := strings.TrimSpace(cfg.Serve.Telegram.Token)
+	if token == "" {
+		return fmt.Errorf("telegram token is not configured (serve.telegram.token)")
+	}
+
+	if err := sendTelegramMessage(ctx, token, serveTelegramChatID, message, parseMode); err != nil {
+		return err
+	}
+
+	logTelegramNotifySession(ctx, cfg, serveTelegramChatID, message, cmd.ErrOrStderr())
+	return nil
+}
+
+func normalizeTelegramParseMode(parseMode string) (string, error) {
+	mode := strings.TrimSpace(parseMode)
+	if mode == "" {
+		return "Markdown", nil
+	}
+	switch strings.ToLower(mode) {
+	case "markdown":
+		return "Markdown", nil
+	case "html":
+		return "HTML", nil
+	default:
+		return "", fmt.Errorf("invalid --parse-mode %q (must be Markdown or HTML)", parseMode)
+	}
+}
+
+func sendTelegramMessage(ctx context.Context, token string, chatID int64, message, parseMode string) error {
+	payload := telegramSendRequest{
+		ChatID:    chatID,
+		Text:      message,
+		ParseMode: parseMode,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal telegram request: %w", err)
+	}
+
+	url := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create telegram request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send telegram message: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read telegram response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("telegram send failed: status %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	var apiResp telegramSendResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return fmt.Errorf("decode telegram response: %w", err)
+	}
+	if !apiResp.OK {
+		detail := strings.TrimSpace(apiResp.Description)
+		if detail == "" {
+			detail = "unknown error"
+		}
+		return fmt.Errorf("telegram send failed: %s", detail)
+	}
+
+	return nil
+}
+
+func logTelegramNotifySession(ctx context.Context, cfg *config.Config, chatID int64, message string, errWriter io.Writer) {
+	store, cleanup := InitSessionStore(cfg, errWriter)
+	defer cleanup()
+	if store == nil {
+		return
+	}
+
+	sessionName := fmt.Sprintf("telegram:%d", chatID)
+	var sess *session.Session
+
+	summaries, err := store.List(ctx, session.ListOptions{Name: sessionName, Limit: 1})
+	if err != nil {
+		log.Printf("warning: list telegram sessions: %v", err)
+	} else if len(summaries) > 0 && summaries[0].Status == session.StatusActive {
+		sess, err = store.Get(ctx, summaries[0].ID)
+		if err != nil {
+			log.Printf("warning: load telegram session %s: %v", summaries[0].ID, err)
+			sess = nil
+		}
+	}
+
+	if sess == nil {
+		sess = &session.Session{
+			Name:     sessionName,
+			Provider: "telegram-notify",
+			Model:    "push",
+			Mode:     session.ModeChat,
+			Status:   session.StatusActive,
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			log.Printf("warning: create telegram session: %v", err)
+			return
+		}
+	}
+
+	msg := session.NewMessage(sess.ID, llm.Message{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{{
+			Type: llm.PartText,
+			Text: message,
+		}},
+	}, -1)
+
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		log.Printf("warning: add telegram message to session: %v", err)
+		return
+	}
+
+	if err := store.Update(ctx, sess); err != nil {
+		log.Printf("warning: update telegram session timestamp: %v", err)
+	}
+	if err := store.SetCurrent(ctx, sess.ID); err != nil {
+		log.Printf("warning: set current telegram session: %v", err)
+	}
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,4 +84,7 @@ RUN chmod +x /entrypoint.sh
 # Drop your service dirs under docker/sv/ and they'll be available at /etc/sv/
 COPY docker/sv/ /etc/sv/
 
+# Remove retired service definitions
+RUN rm -rf /etc/sv/job-scheduler
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -829,6 +829,10 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		WHERE 1=1`
 	args := []any{}
 
+	if opts.Name != "" {
+		query += " AND s.name = ?"
+		args = append(args, opts.Name)
+	}
 	if opts.Provider != "" {
 		query += " AND s.provider = ?"
 		args = append(args, opts.Provider)

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -99,6 +99,7 @@ type SessionSummary struct {
 
 // ListOptions configures session listing.
 type ListOptions struct {
+	Name     string        // Filter by name
 	Provider string        // Filter by provider
 	Model    string        // Filter by model
 	Mode     SessionMode   // Filter by mode (chat, ask, plan, exec)


### PR DESCRIPTION
## What

Three changes to fix Telegram context continuity:

### 1. Restore context from previous session on reconnect
When the bot restarts or an idle timeout fires, `newSession()` now queries the store for the most recent prior `telegram:<chatID>` session, fetches its last messages, and injects them as carryover context. Previously the bot started every reconnection completely cold.

### 2. Walk back multiple sessions to fill context budget
The initial implementation only looked at one prior session. If that session was short (1-2 messages), you'd get almost no context. Now it walks back through up to 20 prior sessions, prepending older ones chronologically, until `TelegramCarryoverChars` is satisfied.

### 3. `serve telegram notify` command
A new CLI command that sends a Telegram message **and** logs it to the session store:

```bash
term-llm serve telegram notify --chat-id 505849291 "🌅 Good morning! Here is your digest..."
```

Previously all outbound pushes (daily digest, bug-hunter notifications, etc.) were raw HTTP calls that never touched the session store, so the continuity context was blind to everything Jarvis proactively sent. Now `notify` writes an assistant-role message into the `telegram:<chatID>` session, so the next reconnection will see it.

## Why

Telegram sessions were fully stateless across restarts. Users had to repeatedly say "look at prev session and resume". These three changes together mean the bot arrives with real context of what's been happening.

## How

- Added `Name` filter to `ListOptions` → wired into `SQLiteStore.List`
- `newSession()` calls `loadPreviousSessionContext()` which iterates prior sessions newest-first until char budget is hit
- New `cmd/serve_telegram_notify.go` — sends via Bot API + logs to store; non-fatal store errors
- All existing tests pass
