### PR TITLE
fix: align view_image MIME with actual image bytes

### DIFF
--- a/internal/tools/view_image.go
+++ b/internal/tools/view_image.go
@@ -180,6 +180,11 @@ func processImage(data []byte, originalMime string) ([]byte, string, bool, error
 		return nil, "", false, fmt.Errorf("failed to decode image: %w", err)
 	}
 
+	detectedMime := mimeTypeFromDecodedFormat(format)
+	if detectedMime == "" {
+		detectedMime = originalMime
+	}
+
 	bounds := img.Bounds()
 	width := bounds.Dx()
 	height := bounds.Dy()
@@ -188,7 +193,7 @@ func processImage(data []byte, originalMime string) ([]byte, string, bool, error
 	needsResize := width > maxDimension || height > maxDimension || len(data) > maxImageSize
 
 	if !needsResize {
-		return data, originalMime, false, nil
+		return data, detectedMime, false, nil
 	}
 
 	// Calculate new dimensions maintaining aspect ratio
@@ -256,6 +261,21 @@ func processImage(data []byte, originalMime string) ([]byte, string, bool, error
 	}
 
 	return result, outputMime, true, nil
+}
+
+func mimeTypeFromDecodedFormat(format string) string {
+	switch strings.ToLower(format) {
+	case "jpeg", "jpg":
+		return "image/jpeg"
+	case "png":
+		return "image/png"
+	case "gif":
+		return "image/gif"
+	case "webp":
+		return "image/webp"
+	default:
+		return ""
+	}
 }
 
 // resizeImage resizes an image to the specified dimensions using high-quality interpolation.


### PR DESCRIPTION
## What
- Fix `view_image` so it reports image media type from decoded bytes (actual format), not only from file extension.
- Add a regression test for mismatched extension/content (`sample.jpg` containing PNG bytes).

## Why
A live Anthropic request failed with:

`Image does not match the provided media type image/jpeg`

In this failure mode, `view_image` accepted a `.jpg` path but the file bytes were another format (e.g. PNG/WebP). When no resize was needed, the tool returned original bytes with MIME derived from extension (`image/jpeg`), causing provider-side validation failure.

## How
- In `internal/tools/view_image.go`:
  - After decoding, map the decoder-reported format (`jpeg/png/gif/webp`) to MIME.
  - Use that detected MIME when returning unmodified image bytes.
  - Keep existing fallback to extension-derived MIME if format mapping is unavailable.
- In `internal/tools/view_image_test.go`:
  - Added `TestViewImageToolExecute_DetectsMimeWhenExtensionMismatched` to verify MIME and bytes stay consistent when extension is wrong.

## Verification
- `gofmt -w .`
- `go build ./...`
- `go test ./...`
