### PR TITLE
feat: add shell completions for memory subcommands

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -40,6 +40,7 @@ func init() {
 	memoryCmd.PersistentFlags().StringVar(&memoryAgent, "agent", "", "Filter by agent")
 	memoryCmd.PersistentFlags().StringVar(&memoryDBPath, "db", defaultDB, "Override memory database path")
 	memoryCmd.PersistentFlags().BoolVar(&memoryDryRun, "dry-run", false, "Preview actions without writing changes")
+	memoryCmd.RegisterFlagCompletionFunc("agent", memoryAgentCompletion)
 
 	memoryCmd.AddCommand(memoryMineCmd)
 	memoryCmd.AddCommand(memorySearchCmd)

--- a/cmd/memory_completions.go
+++ b/cmd/memory_completions.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+func memoryAgentCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	store, err := openMemoryStore()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	defer store.Close()
+
+	agents, err := store.ListAgents(context.Background())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var completions []string
+	for _, agent := range agents {
+		if strings.HasPrefix(agent, toComplete) {
+			completions = append(completions, agent)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+func memoryFragmentPathCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	defer store.Close()
+
+	agent := ""
+	if flag := cmd.Flags().Lookup("agent"); flag != nil {
+		agent = flag.Value.String()
+	} else if flag := cmd.InheritedFlags().Lookup("agent"); flag != nil {
+		agent = flag.Value.String()
+	}
+	agent = strings.TrimSpace(agent)
+
+	fragments, err := store.ListFragments(context.Background(), memorydb.ListOptions{Agent: agent})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	seen := make(map[string]struct{})
+	var completions []string
+	for _, fragment := range fragments {
+		if strings.HasPrefix(fragment.Path, toComplete) {
+			if _, ok := seen[fragment.Path]; ok {
+				continue
+			}
+			seen[fragment.Path] = struct{}{}
+			completions = append(completions, fragment.Path)
+		}
+	}
+
+	sort.Strings(completions)
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/memory_fragments.go
+++ b/cmd/memory_fragments.go
@@ -28,10 +28,11 @@ var memoryFragmentsListCmd = &cobra.Command{
 }
 
 var memoryFragmentsShowCmd = &cobra.Command{
-	Use:   "show <path>",
-	Short: "Show a memory fragment by path",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runMemoryFragmentsShow,
+	Use:               "show <path>",
+	Short:             "Show a memory fragment by path",
+	Args:              cobra.ExactArgs(1),
+	RunE:              runMemoryFragmentsShow,
+	ValidArgsFunction: memoryFragmentPathCompletion,
 }
 
 var memoryFragmentsGCCmd = &cobra.Command{

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -496,6 +496,25 @@ func (s *Store) ListFragments(ctx context.Context, opts ListOptions) ([]Fragment
 	return out, nil
 }
 
+// ListAgents returns distinct agent names that have stored fragments.
+func (s *Store) ListAgents(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT DISTINCT agent FROM memory_fragments ORDER BY agent`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var agents []string
+	for rows.Next() {
+		var agent string
+		if err := rows.Scan(&agent); err != nil {
+			return nil, err
+		}
+		agents = append(agents, agent)
+	}
+	return agents, rows.Err()
+}
+
 // SearchBM25 performs BM25 search over FTS5 and returns fragment details.
 func (s *Store) SearchBM25(ctx context.Context, query string, limit int, agent string) ([]ScoredFragment, error) {
 	if limit <= 0 {


### PR DESCRIPTION
## What

Adds shell tab-completion for the `memory` command family:

- `--agent` flag on all memory subcommands (persistent): completes with agent names from the DB
- `memory fragments show <path>`: completes fragment paths from the DB, filtered by `--agent` if set

## Why

The memory command family lacked any completions, making it tedious to type fragment paths or agent names. This brings it in line with other commands like `agents`, `skills`, etc.

## How

- New `cmd/memory_completions.go` with `memoryAgentCompletion` and `memoryFragmentPathCompletion` functions
- New `Store.ListAgents()` method in `internal/memory/store.go`
- Completions registered in `init()` in `memory.go` and `memory_fragments.go`
