### PR TITLE
feat: track generated images in memory DB + mine into fragments

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -234,6 +234,10 @@ func runChat(cmd *cobra.Command, args []string) error {
 		engine.SetDebugLogger(debugLogger)
 	}
 
+	if sess != nil {
+		settings.SessionID = sess.ID
+	}
+
 	// Initialize tools if enabled (using possibly-updated settings from resume)
 	enabledLocalTools := tools.ParseToolsFlag(settings.Tools)
 	toolMgr, err := settings.SetupToolManager(cfg, engine)

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -27,6 +27,9 @@ type SessionSettings struct {
 	// Agent name (if any)
 	AgentName string
 
+	// Session ID (if any)
+	SessionID string
+
 	// Tool settings
 	Tools        string
 	ReadDirs     []string
@@ -323,7 +326,7 @@ func (s *SessionSettings) SetupToolManager(cfg *config.Config, engine *llm.Engin
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize tools: %w", err)
 	}
-	wireImageRecorder(toolMgr.Registry, s.AgentName, "")
+	wireImageRecorder(toolMgr.Registry, s.AgentName, s.SessionID)
 
 	// Register any custom script-backed tools declared in agent.yaml
 	if len(s.CustomTools) > 0 {


### PR DESCRIPTION
## Summary

Tracks generated images in `memory.db` so they can be recalled later — both for direct browsing and as part of unified memory search.

### What this adds

**Storage:**
- `generated_images` table with FTS5 on prompt — records every `image_generate` tool call (agent, session, prompt, path, provider, dimensions, size)
- Default save path: `~/Pictures/term-llm` (persistent, not `/tmp`)

**Commands:**
- `memory images list` — browse recent generated images (newest first)
- `memory images search <query>` — FTS search by prompt

**Mining integration:**
- `memory mine` now also mines the `generated_images` table into fragments at `images/<date>/<slug>.md`
- Tracks `last_image_mine_at_<agent>` in `memory_meta` so each mine run only processes new images
- This means `memory search "astronaut"` finds both text facts and generated images in unified search

**Wiring:**
- `wireImageRecorder` called from `ask`, `chat`, `session` (interactive), `edit`, `exec`, `plan`, `spawn_runner` — captures agent name + session ID
- Non-fatal everywhere: image generation continues normally if memory store fails to open

### Storage design

```
Image files   → ~/Pictures/term-llm/<slug>.png  (persistent disk)
Image metadata → memory.db `generated_images` table  (searchable by prompt)
Image facts   → memory_fragments `images/<date>/<slug>.md`  (unified search)
```

Three ways to find a past image:
1. `memory images list` — chronological browse
2. `memory images search <query>` — direct FTS on prompts  
3. `memory search <query>` — unified search across all fragments including images

### Tests

- `TestRecordImage` — insert + list round-trip, validates all fields
- `TestSearchImages` — FTS search with agent filter
- `TestListImagesSince` — incremental mining state (via `ListImagesSince`)
