### PR TITLE
feat: record telegram photo uploads and term-llm image command in image memory

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -193,6 +193,7 @@ func runImage(cmd *cobra.Command, args []string) error {
 
 	if outputPath != "" {
 		fmt.Fprintf(os.Stderr, "Saved to: %s\n", outputPath)
+		recordImageDirect(cfg, prompt, outputPath, result, provider.Name())
 	}
 
 	// Display via icat

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/image"
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/tools"
 	"github.com/spf13/cobra"
@@ -75,4 +78,24 @@ func wireImageRecorder(registry *tools.LocalToolRegistry, agent, sessionID strin
 		return
 	}
 	registry.SetImageRecorder(store, agent, sessionID)
+}
+
+func recordImageDirect(cfg *config.Config, prompt, outputPath string, result *image.ImageResult, providerName string) {
+	if cfg == nil || outputPath == "" || result == nil {
+		return
+	}
+	store, err := openMemoryStore()
+	if err != nil {
+		return
+	}
+	defer store.Close()
+
+	rec := &memorydb.ImageRecord{
+		Prompt:     prompt,
+		OutputPath: outputPath,
+		MimeType:   result.MimeType,
+		Provider:   providerName,
+		FileSize:   len(result.Data),
+	}
+	_ = store.RecordImage(context.Background(), rec)
 }


### PR DESCRIPTION
## What

Extends image memory tracking (introduced in #26) to cover the two remaining sources that were not recorded:

1. **Telegram photo uploads** — when a user sends a photo to the bot, it is now copied to a permanent location (`~/Pictures/term-llm/uploads/`) and recorded in the `generated_images` memory table.
2. **`term-llm image` command** — the standalone CLI image generation command now records to the memory DB after saving the output file.

## Why

PR #26 wired image recording through the `image_generate` tool / `ImageRecorder` interface, which covers all agent-driven generation. But two paths bypass that system entirely:

- **Telegram uploads**: the bot downloads the photo to a temp file and deletes it via `defer os.Remove` once the reply is sent. The image was never persisted or recorded.
- **`term-llm image`**: calls the image provider directly without going through the tool engine, so `wireImageRecorder` is never invoked.

Now all three image sources feed into `memory images list` / `memory images search`.

## How

### Telegram (`internal/serve/telegram.go`)

- Captures `mediaType`, `caption`, and temp file path from the photo download
- After `streamReply` completes (but before deferred `os.Remove` fires), calls `recordTelegramUpload`
- `recordTelegramUpload`: reads the temp file bytes → calls `image.SaveImage` to write a permanent copy → opens the memory store → calls `RecordImage` with `provider = "telegram-upload"`
- Non-fatal: any error is logged but does not affect bot behaviour

### `term-llm image` (`cmd/image.go` + `cmd/memory.go`)

- After `outputPath` is determined, calls `recordImageDirect(cfg, prompt, outputPath, result, provider.Name())`
- `recordImageDirect`: new helper in `cmd/memory.go` that opens the memory store and records the image; no agent/session ID since this is a CLI command
- Non-fatal: silently returns on any error

## Testing

- `go build ./...` ✅
- `go test ./...` ✅ (all existing tests pass)
