### PR TITLE
fix: raise serve default max_turns from 20 to 200

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -124,7 +124,7 @@ func init() {
 	AddSearchFlag(serveCmd, &serveSearch)
 	AddNativeSearchFlags(serveCmd, &serveNativeSearch, &serveNoNativeSearch)
 	AddMCPFlag(serveCmd, &serveMCP)
-	AddMaxTurnsFlag(serveCmd, &serveMaxTurns, 20)
+	AddMaxTurnsFlag(serveCmd, &serveMaxTurns, 200)
 	AddToolFlags(serveCmd, &serveTools, &serveReadDirs, &serveWriteDirs, &serveShellAllow)
 	AddSystemMessageFlag(serveCmd, &serveSystemMessage)
 	AddAgentFlag(serveCmd, &serveAgent)


### PR DESCRIPTION
## Summary
- raise the serve command default max_turns from 20 to 200

## Problem
Jobs executed via `serve` were hitting the 20-turn limit and stopping prematurely, while `chat` already defaults to 200 turns.

## Solution
Align the `serve` default with `chat` by setting the max_turns default to 200.
