### PR TITLE
fix: only bump updated_at when fragment content actually changes

### DIFF
--- a/cmd/memory_fragments.go
+++ b/cmd/memory_fragments.go
@@ -120,18 +120,18 @@ func runMemoryFragmentsList(cmd *cobra.Command, args []string) error {
 	pathCol++ // one extra space of breathing room
 
 	if strings.TrimSpace(memoryAgent) == "" {
-		fmt.Printf("%-6s %-14s %-*s %-10s\n", "ID", "AGENT", pathCol, "PATH", "UPDATED")
+		fmt.Printf("%-6s %-14s %-*s %-10s\n", "ID", "AGENT", pathCol, "PATH", "CREATED")
 		fmt.Println(strings.Repeat("-", 6+1+14+1+pathCol+1+10))
 		for _, f := range fragments {
-			fmt.Printf("%-6d %-14s %-*s %-10s\n", f.RowID, f.Agent, pathCol, truncateString(f.Path, pathCol), formatRelativeTime(f.UpdatedAt))
+			fmt.Printf("%-6d %-14s %-*s %-10s\n", f.RowID, f.Agent, pathCol, truncateString(f.Path, pathCol), formatRelativeTime(f.CreatedAt))
 		}
 		return nil
 	}
 
-	fmt.Printf("%-6s %-*s %-10s\n", "ID", pathCol, "PATH", "UPDATED")
+	fmt.Printf("%-6s %-*s %-10s\n", "ID", pathCol, "PATH", "CREATED")
 	fmt.Println(strings.Repeat("-", 6+1+pathCol+1+10))
 	for _, f := range fragments {
-		fmt.Printf("%-6d %-*s %-10s\n", f.RowID, pathCol, truncateString(f.Path, pathCol), formatRelativeTime(f.UpdatedAt))
+		fmt.Printf("%-6d %-*s %-10s\n", f.RowID, pathCol, truncateString(f.Path, pathCol), formatRelativeTime(f.CreatedAt))
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

`UpdateFragment` was unconditionally writing content and bumping `updated_at` even when the incoming content was identical to what was already stored. This caused two problems:

1. **`updated_at` was meaningless as a recency signal.** Any caller that passed the same content again (e.g. `upsertImageFragment` on a conflict, or the miner emitting a no-op "update" op) would silently advance the timestamp, making `ORDER BY updated_at DESC` on `fragments list` return arbitrary ordering within a batch.

2. **Stale embeddings were invalidated unnecessarily.** `UpdateFragment` deletes all embeddings for the fragment before re-inserting. A no-op update would kick off a needless re-embed cycle.

## Fix

### `internal/memory/store.go` — `UpdateFragment`

Add a content equality check before touching the DB. If `oldFrag.Content == content`, return `updated=false` immediately. No SQL writes, no embedding invalidation, no `updated_at` bump.

```go
// No-op: content unchanged — don't bump updated_at or invalidate embeddings.
if oldFrag.Content == content {
    return false, nil
}
```

### `internal/memory/store.go` — `ListFragments`

Switch `ORDER BY updated_at DESC` → `ORDER BY created_at DESC`. `created_at` is immutable once a fragment is mined and gives a stable "most recently learned" ordering. `updated_at` is only bumped on real content changes (after this fix), but it's still a noisier signal than creation time for the default list view.

The `--since` filter is also updated to filter on `created_at` to match.

### `cmd/memory_fragments.go`

Rename the `UPDATED` column to `CREATED` and display `f.CreatedAt` instead of `f.UpdatedAt`.

## Tests

Two new tests in `internal/memory/store_test.go`:

- `TestUpdateFragmentNoOpWhenContentUnchanged` — verifies `updated=false` is returned and `updated_at` is not modified when content is identical.
- `TestUpdateFragmentBumpsUpdatedAtOnRealChange` — verifies `updated=true`, content is written, and `updated_at` is strictly advanced when content genuinely changes.
