### PR TITLE
tools: standardize on 'path' param, warn on unknown params

### DIFF
--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGrepTool_UsesFilePath(t *testing.T) {
+	dir := t.TempDir()
+	token := "unique_grep_token_1234567890"
+	filePath := filepath.Join(dir, "sample.txt")
+
+	if err := os.WriteFile(filePath, []byte("before "+token+" after"), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	tool := NewGrepTool(nil, DefaultOutputLimits())
+	args, err := json.Marshal(GrepArgs{
+		Pattern:          token,
+		Path:             dir,
+		FilesWithMatches: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	output, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !strings.Contains(output.Content, filePath) {
+		t.Fatalf("expected output to contain %q, got: %s", filePath, output.Content)
+	}
+}

--- a/internal/tools/params.go
+++ b/internal/tools/params.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// WarnUnknownParams checks args JSON for keys not in knownKeys.
+// Returns a warning string (with trailing newline) to prepend to tool output,
+// or "" if no unknown keys found.
+func WarnUnknownParams(args json.RawMessage, knownKeys []string) string {
+	var m map[string]interface{}
+	if err := json.Unmarshal(args, &m); err != nil {
+		return ""
+	}
+	known := make(map[string]bool, len(knownKeys))
+	for _, k := range knownKeys {
+		known[k] = true
+	}
+	var unknown []string
+	for k := range m {
+		if !known[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return ""
+	}
+	sort.Strings(unknown)
+	var sb strings.Builder
+	for _, k := range unknown {
+		sb.WriteString(fmt.Sprintf("Unknown parameter '%s' was ignored\n", k))
+	}
+	return sb.String()
+}

--- a/internal/tools/params_test.go
+++ b/internal/tools/params_test.go
@@ -1,0 +1,49 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWarnUnknownParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      json.RawMessage
+		knownKeys []string
+		expected  string
+	}{
+		{
+			name:      "empty args",
+			args:      json.RawMessage(`{}`),
+			knownKeys: []string{"a", "b"},
+			expected:  "",
+		},
+		{
+			name:      "all known keys",
+			args:      json.RawMessage(`{"a": 1, "b": 2}`),
+			knownKeys: []string{"a", "b"},
+			expected:  "",
+		},
+		{
+			name:      "one unknown key",
+			args:      json.RawMessage(`{"a": 1, "xyz": true}`),
+			knownKeys: []string{"a"},
+			expected:  "Unknown parameter 'xyz' was ignored\n",
+		},
+		{
+			name:      "multiple unknown keys sorted",
+			args:      json.RawMessage(`{"z": 1, "a": 2, "b": 3}`),
+			knownKeys: []string{},
+			expected:  "Unknown parameter 'a' was ignored\nUnknown parameter 'b' was ignored\nUnknown parameter 'z' was ignored\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WarnUnknownParams(tt.args, tt.knownKeys)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Two related bugs:

**1. Silent 60-second timeout when model confuses parameter names**

`grep` expected `path` but `read_file`/`write_file`/`edit_file` all used `file_path`. The model would send `{"pattern": "...", "file_path": "/some/path"}` to grep. JSON unmarshalling silently dropped the unknown key, `a.Path` fell back to `""`, which defaulted to `os.Getwd()` = `/`, and `rg` spent 60 seconds searching the entire filesystem before timing out. The model got no useful feedback.

**2. Unknown parameters dropped silently**

No tool notified the model when it passed an unrecognised parameter. The model had no way to know it had made a mistake.

## Changes

### Standardize on `path` everywhere

`path` is short, clear, and already used by `grep` and `glob`. Renamed `file_path` → `path` in:
- `read_file` (args struct + schema)
- `write_file` (args struct + schema)
- `edit_file` (args struct + schema)

`grep` and `glob` stay as `path` (already correct).

### Unknown parameter warnings (`WarnUnknownParams`)

New utility in `internal/tools/params.go`. When a tool receives a JSON key it doesn't recognise, it prepends a warning to its output:

```
Unknown parameter 'file_path' was ignored
```

Applied to: `grep`, `glob`, `read_file`, `write_file`, `edit_file`, `shell`.

The warning appears as the first line(s) of the tool result so the model sees it immediately and can self-correct on the next call.

## Testing

- `go build ./...` ✅
- `go test ./internal/tools/...` ✅
- New `params_test.go`: unit tests for `WarnUnknownParams`
- New `grep_test.go`: regression test confirming grep uses the provided `path` rather than falling back to `/`
