### PR TITLE
fix: support thinking models in llm job runner

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1830,7 +1830,6 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 		}
 
 		llmReq := llm.Request{
-			Model:               modelName,
 			Tools:               runtime.selectTools(nil),
 			ToolChoice:          llm.ToolChoice{Mode: llm.ToolChoiceAuto},
 			ParallelToolCalls:   true,


### PR DESCRIPTION
## What

Fix the `llm` job runner to correctly handle thinking model names (e.g. `claude-sonnet-4-6-thinking`).

## Why

The job runner was passing the raw model name to the Anthropic API, which 404s on `-thinking` suffixed names. The ask/chat pipeline has special handling that strips the suffix and injects thinking budget parameters — the job runner was bypassing this entirely.

## How

Route the job runner through the same provider codepath that handles thinking models, so the existing logic applies consistently.
