### PR TITLE
FIX: clarify spawn_agent description to prefer codebase over researcher for local code

### DIFF
--- a/internal/tools/spawn_agent.go
+++ b/internal/tools/spawn_agent.go
@@ -176,7 +176,7 @@ Guidelines:
 			"properties": map[string]any{
 				"agent_name": map[string]any{
 					"type":        "string",
-					"description": "Name of the agent to spawn (e.g., 'reviewer', 'researcher')",
+					"description": "Name of the agent to spawn (e.g., 'developer', 'codebase', 'researcher'). Use 'codebase' for local source code questions; 'researcher' for external web research only.",
 				},
 				"prompt": map[string]any{
 					"type":        "string",


### PR DESCRIPTION
## Problem

The `spawn_agent` tool description used `'reviewer', 'researcher'` as its agent name examples. This primed the model to reach for `researcher` even for local codebase exploration tasks, because it was the first general-purpose agent mentioned and its name (`researcher`) is broad enough to feel applicable.

The `codebase` agent was never referenced in the tool spec, so it was easy to overlook.

## Fix

Updated the `agent_name` field description to:
- Replace the example set with `'developer', 'codebase', 'researcher'` — a more representative spread
- Add an inline disambiguation: `codebase` for local source code questions; `researcher` for external web research only

This makes the distinction machine-readable at the point of decision — in the tool schema itself — rather than relying solely on the agent table in a system prompt.

## Change

Single line in `internal/tools/spawn_agent.go` (`Spec()` → schema → `agent_name.description`).
