### PR TITLE
feat(chat): remote TUI mode via WebSocket

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -333,7 +333,7 @@ func runChatFromPlan(cfg *config.Config, planContent string, agentName string, m
 	defer storeCleanup()
 
 	// Create chat model
-	model := chat.New(cfg, provider, engine, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, settings.Search, enabledLocalTools, settings.Tools, "", false, "", store, nil, useAltScreen, autoSendQueue, false, false, agentName, false)
+	model := chat.New(cfg, provider, engine, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, settings.Search, enabledLocalTools, settings.Tools, "", false, "", store, nil, useAltScreen, autoSendQueue, false, false, agentName, false, nil)
 
 	// Build program options
 	var opts []tea.ProgramOption

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	Exec            ExecConfig                `mapstructure:"exec"`
 	Ask             AskConfig                 `mapstructure:"ask"`
 	Chat            ChatConfig                `mapstructure:"chat"`
+	Remote          RemoteConfig              `mapstructure:"remote"`
 	Edit            EditConfig                `mapstructure:"edit"`
 	Image           ImageConfig               `mapstructure:"image"`
 	Embed           EmbedConfig               `mapstructure:"embed"`
@@ -110,6 +111,13 @@ type Config struct {
 // ServeConfig holds configuration for the serve command platforms.
 type ServeConfig struct {
 	Telegram TelegramServeConfig `mapstructure:"telegram" yaml:"telegram,omitempty"`
+	Chat     ChatServeConfig     `mapstructure:"chat" yaml:"chat,omitempty"`
+}
+
+// ChatServeConfig holds configuration for the remote chat server.
+type ChatServeConfig struct {
+	Listen string `mapstructure:"listen" yaml:"listen,omitempty"`
+	Token  string `mapstructure:"token" yaml:"token,omitempty"`
 }
 
 // TelegramServeConfig holds configuration for the Telegram bot platform.
@@ -238,6 +246,12 @@ type ChatConfig struct {
 	Model        string `mapstructure:"model"`        // Override model for chat only
 	Instructions string `mapstructure:"instructions"` // Custom system prompt for chat
 	MaxTurns     int    `mapstructure:"max_turns"`    // Max agentic turns (default 200)
+}
+
+type RemoteConfig struct {
+	URL   string `mapstructure:"url" yaml:"url,omitempty"`
+	Token string `mapstructure:"token" yaml:"token,omitempty"`
+	Agent string `mapstructure:"agent" yaml:"agent,omitempty"`
 }
 
 type EditConfig struct {

--- a/internal/serve/chat/server.go
+++ b/internal/serve/chat/server.go
@@ -1,0 +1,695 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/mcp"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+// Runtime bundles the state needed to run an LLM session.
+type Runtime struct {
+	Engine       *llm.Engine
+	ProviderName string
+	ModelName    string
+	ToolMgr      *tools.ToolManager
+	MCPManager   *mcp.Manager
+	Cleanup      func()
+}
+
+// RuntimeFactory creates a new runtime for a chat session.
+type RuntimeFactory func(ctx context.Context) (*Runtime, error)
+
+// RemoteSession tracks a remote WebSocket chat session.
+type RemoteSession struct {
+	ID           string
+	Agent        string
+	History      []session.Message
+	EventBuf     []WireEvent
+	NextSeq      int64
+	LastActiveAt time.Time
+	mu           sync.Mutex
+	conn         *websocket.Conn
+	cancelStream context.CancelFunc
+	runtime      *Runtime
+
+	pendingApprovals map[string]chan tools.ApprovalResult
+	pendingAskUser   map[string]chan []tools.AskUserAnswer
+}
+
+// SessionManager manages active remote chat sessions.
+type SessionManager struct {
+	sessions       map[string]*RemoteSession
+	mu             sync.RWMutex
+	cfg            config.ChatServeConfig
+	runtimeFactory RuntimeFactory
+	systemPrompt   string
+	search         bool
+	forceSearch    bool
+	maxTurns       int
+	agentName      string
+}
+
+// NewSessionManager creates a session manager using the supplied configuration.
+func NewSessionManager(cfg config.ChatServeConfig) *SessionManager {
+	return &SessionManager{
+		sessions: make(map[string]*RemoteSession),
+		cfg:      cfg,
+	}
+}
+
+// SetRuntimeFactory supplies the runtime factory used for new sessions.
+func (m *SessionManager) SetRuntimeFactory(factory RuntimeFactory) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runtimeFactory = factory
+}
+
+// SetDefaults configures defaults used when creating new sessions.
+func (m *SessionManager) SetDefaults(systemPrompt string, search bool, forceSearch bool, maxTurns int, agentName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.systemPrompt = systemPrompt
+	m.search = search
+	m.forceSearch = forceSearch
+	m.maxTurns = maxTurns
+	m.agentName = agentName
+}
+
+// HTTPHandler returns an http.Handler for the chat endpoints.
+func (m *SessionManager) HTTPHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat/sessions", m.auth(m.handleListSessions))
+	mux.HandleFunc("/chat/sessions/new", m.auth(m.handleNewSession))
+	mux.HandleFunc("/chat/sessions/", m.auth(m.handleResumeSession))
+	return mux
+}
+
+// StartGC starts background GC for inactive sessions.
+func (m *SessionManager) StartGC(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.gcSessions()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *SessionManager) gcSessions() {
+	cutoff := time.Now().Add(-30 * time.Minute)
+	var stale []*RemoteSession
+
+	m.mu.Lock()
+	for id, sess := range m.sessions {
+		sess.mu.Lock()
+		inactive := sess.LastActiveAt.Before(cutoff)
+		streaming := sess.cancelStream != nil
+		connected := sess.conn != nil
+		sess.mu.Unlock()
+		if inactive && !streaming && !connected {
+			delete(m.sessions, id)
+			stale = append(stale, sess)
+		}
+	}
+	m.mu.Unlock()
+
+	for _, sess := range stale {
+		sess.mu.Lock()
+		rt := sess.runtime
+		sess.runtime = nil
+		sess.mu.Unlock()
+		if rt != nil && rt.Cleanup != nil {
+			rt.Cleanup()
+		}
+	}
+}
+
+func (m *SessionManager) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	items := make([]map[string]any, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		sess.mu.Lock()
+		item := map[string]any{
+			"id":          sess.ID,
+			"agent":       sess.Agent,
+			"last_active": sess.LastActiveAt.Format(time.RFC3339Nano),
+		}
+		sess.mu.Unlock()
+		items = append(items, item)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sessions": items})
+}
+
+func (m *SessionManager) handleNewSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	conn, err := m.upgrade(w, r)
+	if err != nil {
+		return
+	}
+
+	sess, err := m.newSession(r.Context())
+	if err != nil {
+		_ = conn.Close()
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+
+	m.attachConn(sess, conn)
+	m.sendSessionReady(sess, nil)
+	m.runSessionLoop(sess)
+}
+
+func (m *SessionManager) handleResumeSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/chat/sessions/")
+	id = strings.Trim(id, "/")
+	if id == "" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	m.mu.RLock()
+	sess := m.sessions[id]
+	m.mu.RUnlock()
+	if sess == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	conn, err := m.upgrade(w, r)
+	if err != nil {
+		return
+	}
+
+	m.attachConn(sess, conn)
+
+	since := int64(0)
+	if sinceStr := r.URL.Query().Get("since"); sinceStr != "" {
+		if parsed, err := strconv.ParseInt(sinceStr, 10, 64); err == nil {
+			since = parsed
+		}
+	}
+
+	m.sendSessionReady(sess, func() *WireEvent {
+		if since <= 0 {
+			return nil
+		}
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		var events []WireEvent
+		for _, evt := range sess.EventBuf {
+			if evt.Seq > since {
+				events = append(events, evt)
+			}
+		}
+		if len(events) == 0 {
+			return nil
+		}
+		return &WireEvent{Seq: 0, Type: "catchup", Events: events}
+	})
+
+	m.runSessionLoop(sess)
+}
+
+func (m *SessionManager) runSessionLoop(sess *RemoteSession) {
+	readCh := make(chan ClientEvent)
+	go func() {
+		defer close(readCh)
+		for {
+			var ev ClientEvent
+			if err := sess.conn.ReadJSON(&ev); err != nil {
+				return
+			}
+			readCh <- ev
+		}
+	}()
+
+	for ev := range readCh {
+		sess.mu.Lock()
+		sess.LastActiveAt = time.Now()
+		sess.mu.Unlock()
+
+		switch ev.Type {
+		case "message":
+			if strings.TrimSpace(ev.Text) == "" {
+				continue
+			}
+			go m.startStream(sess, ev.Text)
+		case "interrupt":
+			m.interruptStream(sess)
+		case "reset":
+			m.resetSession(sess)
+		case "approval_response":
+			m.handleApprovalResponse(sess, ev.RequestID, ev.Approved)
+		case "ask_user_response":
+			m.handleAskUserResponse(sess, ev.RequestID, ev.Responses)
+		}
+	}
+
+	m.detachConn(sess)
+}
+
+func (m *SessionManager) interruptStream(sess *RemoteSession) {
+	sess.mu.Lock()
+	cancel := sess.cancelStream
+	sess.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (m *SessionManager) resetSession(sess *RemoteSession) {
+	m.interruptStream(sess)
+	sess.mu.Lock()
+	sess.History = nil
+	sess.EventBuf = nil
+	sess.NextSeq = 1
+	sess.mu.Unlock()
+}
+
+func (m *SessionManager) startStream(sess *RemoteSession, text string) {
+	sess.mu.Lock()
+	if sess.cancelStream != nil {
+		sess.mu.Unlock()
+		m.writeError(sess, "stream already in progress")
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	sess.cancelStream = cancel
+	sess.mu.Unlock()
+
+	defer func() {
+		sess.mu.Lock()
+		sess.cancelStream = nil
+		sess.mu.Unlock()
+	}()
+
+	runtime := m.ensureRuntime(ctx, sess)
+	if runtime == nil || runtime.Engine == nil {
+		m.writeError(sess, "failed to initialize runtime")
+		return
+	}
+
+	userMsg := session.NewMessage(sess.ID, llm.UserText(text), -1)
+	sess.mu.Lock()
+	sess.History = append(sess.History, *userMsg)
+	sess.mu.Unlock()
+
+	runtime.Engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
+		sessMsg := session.NewMessage(sess.ID, assistantMsg, -1)
+		sess.mu.Lock()
+		sess.History = append(sess.History, *sessMsg)
+		sess.mu.Unlock()
+		return nil
+	})
+
+	runtime.Engine.SetTurnCompletedCallback(func(ctx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
+		if len(turnMessages) == 0 {
+			return nil
+		}
+		sess.mu.Lock()
+		for _, msg := range turnMessages {
+			sess.History = append(sess.History, *session.NewMessage(sess.ID, msg, -1))
+		}
+		sess.mu.Unlock()
+		return nil
+	})
+
+	messages := m.buildMessages(sess)
+	req := llm.Request{
+		SessionID:           sess.ID,
+		Messages:            messages,
+		Tools:               runtime.Engine.Tools().AllSpecs(),
+		Search:              m.search,
+		ForceExternalSearch: m.forceSearch,
+		ParallelToolCalls:   true,
+		MaxTurns:            m.maxTurns,
+	}
+
+	if runtime.ToolMgr != nil && runtime.ToolMgr.ApprovalMgr != nil {
+		runtime.ToolMgr.ApprovalMgr.PromptUIFunc = func(path string, isWrite bool, isShell bool) (tools.ApprovalResult, error) {
+			return m.requestApproval(ctx, sess, path, isWrite, isShell)
+		}
+	}
+
+	tools.SetAskUserUIFunc(func(questions []tools.AskUserQuestion) ([]tools.AskUserAnswer, error) {
+		return m.requestAskUser(ctx, sess, questions)
+	})
+	defer tools.ClearAskUserUIFunc()
+
+	adapter := ui.NewStreamAdapter(ui.DefaultStreamBufferSize)
+	stream, err := runtime.Engine.Stream(ctx, req)
+	if err != nil {
+		adapter.EmitErrorAndClose(err)
+	} else {
+		go func() {
+			defer stream.Close()
+			adapter.ProcessStream(ctx, stream)
+		}()
+	}
+
+	doneSent := false
+	for ev := range adapter.Events() {
+		wire := ToWireEvent(0, ev)
+		if wire.Type == "message_done" {
+			if doneSent {
+				continue
+			}
+			doneSent = true
+		}
+		if wire.Type == "" {
+			continue
+		}
+		m.writeStreamEvent(sess, wire)
+	}
+
+	if !doneSent {
+		m.writeStreamEvent(sess, WireEvent{Type: "message_done"})
+	}
+}
+
+func (m *SessionManager) buildMessages(sess *RemoteSession) []llm.Message {
+	var messages []llm.Message
+	if strings.TrimSpace(m.systemPrompt) != "" {
+		messages = append(messages, llm.SystemText(m.systemPrompt))
+	}
+
+	sess.mu.Lock()
+	history := make([]session.Message, len(sess.History))
+	copy(history, sess.History)
+	sess.mu.Unlock()
+
+	for _, msg := range history {
+		messages = append(messages, msg.ToLLMMessage())
+	}
+	return messages
+}
+
+func (m *SessionManager) ensureRuntime(ctx context.Context, sess *RemoteSession) *Runtime {
+	sess.mu.Lock()
+	if sess.runtime != nil {
+		rt := sess.runtime
+		sess.mu.Unlock()
+		return rt
+	}
+	factory := m.runtimeFactory
+	sess.mu.Unlock()
+
+	if factory == nil {
+		return nil
+	}
+
+	runtime, err := factory(ctx)
+	if err != nil {
+		return nil
+	}
+
+	sess.mu.Lock()
+	sess.runtime = runtime
+	sess.mu.Unlock()
+	return runtime
+}
+
+func (m *SessionManager) newSession(ctx context.Context) (*RemoteSession, error) {
+	id := uuid.NewString()
+	if id == "" {
+		id = fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+
+	sess := &RemoteSession{
+		ID:               id,
+		Agent:            m.agentName,
+		NextSeq:          1,
+		LastActiveAt:     time.Now(),
+		pendingApprovals: make(map[string]chan tools.ApprovalResult),
+		pendingAskUser:   make(map[string]chan []tools.AskUserAnswer),
+	}
+
+	runtime := m.ensureRuntime(ctx, sess)
+	if runtime == nil {
+		return nil, fmt.Errorf("runtime factory unavailable")
+	}
+	sess.runtime = runtime
+
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+	return sess, nil
+}
+
+func (m *SessionManager) attachConn(sess *RemoteSession, conn *websocket.Conn) {
+	sess.mu.Lock()
+	sess.conn = conn
+	sess.LastActiveAt = time.Now()
+	sess.mu.Unlock()
+}
+
+func (m *SessionManager) detachConn(sess *RemoteSession) {
+	sess.mu.Lock()
+	if sess.conn != nil {
+		_ = sess.conn.Close()
+	}
+	sess.conn = nil
+	sess.mu.Unlock()
+}
+
+func (m *SessionManager) sendSessionReady(sess *RemoteSession, catchup func() *WireEvent) {
+	sess.mu.Lock()
+	history := make([]HistoryItem, 0, len(sess.History))
+	for _, msg := range sess.History {
+		history = append(history, HistoryItem{Role: string(msg.Role), Text: msg.TextContent})
+	}
+	agent := sess.Agent
+	sess.mu.Unlock()
+
+	_ = writeEvent(sess.conn, WireEvent{Seq: 0, Type: "session_ready", SessionID: sess.ID, Agent: agent, History: history})
+	if catchup != nil {
+		if ev := catchup(); ev != nil {
+			_ = writeEvent(sess.conn, *ev)
+		}
+	}
+}
+
+func (m *SessionManager) writeStreamEvent(sess *RemoteSession, ev WireEvent) {
+	sess.mu.Lock()
+	seq := sess.NextSeq
+	sess.NextSeq++
+	ev.Seq = seq
+	sess.EventBuf = append(sess.EventBuf, ev)
+	conn := sess.conn
+	sess.mu.Unlock()
+
+	if conn != nil {
+		_ = writeEvent(conn, ev)
+	}
+}
+
+func (m *SessionManager) writeError(sess *RemoteSession, message string) {
+	m.writeStreamEvent(sess, WireEvent{Type: "error", Message: message})
+}
+
+func (m *SessionManager) requestApproval(ctx context.Context, sess *RemoteSession, path string, isWrite bool, isShell bool) (tools.ApprovalResult, error) {
+	requestID := uuid.NewString()
+	if requestID == "" {
+		requestID = fmt.Sprintf("req-%d", time.Now().UnixNano())
+	}
+
+	respCh := make(chan tools.ApprovalResult, 1)
+	sess.mu.Lock()
+	sess.pendingApprovals[requestID] = respCh
+	sess.mu.Unlock()
+	defer func() {
+		sess.mu.Lock()
+		delete(sess.pendingApprovals, requestID)
+		sess.mu.Unlock()
+	}()
+
+	m.writeStreamEvent(sess, WireEvent{
+		Type:        "approval_request",
+		RequestID:   requestID,
+		Description: path,
+		IsWrite:     isWrite,
+		IsShell:     isShell,
+	})
+
+	select {
+	case result := <-respCh:
+		return result, nil
+	case <-ctx.Done():
+		return tools.ApprovalResult{Choice: tools.ApprovalChoiceCancelled, Cancelled: true}, ctx.Err()
+	}
+}
+
+func (m *SessionManager) requestAskUser(ctx context.Context, sess *RemoteSession, questions []tools.AskUserQuestion) ([]tools.AskUserAnswer, error) {
+	requestID := uuid.NewString()
+	if requestID == "" {
+		requestID = fmt.Sprintf("req-%d", time.Now().UnixNano())
+	}
+
+	respCh := make(chan []tools.AskUserAnswer, 1)
+	sess.mu.Lock()
+	sess.pendingAskUser[requestID] = respCh
+	sess.mu.Unlock()
+	defer func() {
+		sess.mu.Lock()
+		delete(sess.pendingAskUser, requestID)
+		sess.mu.Unlock()
+	}()
+
+	wireQuestions := make([]AskUserQuestion, 0, len(questions))
+	for _, q := range questions {
+		opts := make([]AskUserOption, 0, len(q.Options))
+		for _, opt := range q.Options {
+			opts = append(opts, AskUserOption{Label: opt.Label, Description: opt.Description})
+		}
+		wireQuestions = append(wireQuestions, AskUserQuestion{
+			Header:      q.Header,
+			Question:    q.Question,
+			Options:     opts,
+			MultiSelect: q.MultiSelect,
+		})
+	}
+
+	m.writeStreamEvent(sess, WireEvent{
+		Type:      "ask_user_request",
+		RequestID: requestID,
+		Questions: wireQuestions,
+	})
+
+	select {
+	case result := <-respCh:
+		return result, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (m *SessionManager) handleApprovalResponse(sess *RemoteSession, requestID string, approved bool) {
+	if requestID == "" {
+		return
+	}
+
+	sess.mu.Lock()
+	ch := sess.pendingApprovals[requestID]
+	delete(sess.pendingApprovals, requestID)
+	sess.mu.Unlock()
+	if ch == nil {
+		return
+	}
+
+	result := tools.ApprovalResult{Choice: tools.ApprovalChoiceDeny}
+	if approved {
+		result.Choice = tools.ApprovalChoiceOnce
+	}
+	ch <- result
+}
+
+func (m *SessionManager) handleAskUserResponse(sess *RemoteSession, requestID string, responses []AskUserAnswer) {
+	if requestID == "" {
+		return
+	}
+
+	sess.mu.Lock()
+	ch := sess.pendingAskUser[requestID]
+	delete(sess.pendingAskUser, requestID)
+	sess.mu.Unlock()
+	if ch == nil {
+		return
+	}
+
+	answers := make([]tools.AskUserAnswer, 0, len(responses))
+	for _, resp := range responses {
+		selected := ""
+		if len(resp.Selected) > 0 {
+			selected = resp.Selected[0]
+		}
+		answers = append(answers, tools.AskUserAnswer{
+			QuestionIndex: resp.QuestionIndex,
+			Selected:      selected,
+			SelectedList:  resp.Selected,
+			IsMultiSelect: len(resp.Selected) > 1,
+		})
+	}
+	ch <- answers
+}
+
+func (m *SessionManager) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !m.authorized(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (m *SessionManager) authorized(r *http.Request) bool {
+	token := strings.TrimSpace(m.cfg.Token)
+	if token == "" {
+		return true
+	}
+	value := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(value, prefix)) == token
+}
+
+func (m *SessionManager) upgrade(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	return upgrader.Upgrade(w, r, nil)
+}
+
+func writeEvent(conn *websocket.Conn, e WireEvent) error {
+	if conn == nil {
+		return nil
+	}
+	payload, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/serve/chat/wire.go
+++ b/internal/serve/chat/wire.go
@@ -1,0 +1,113 @@
+package chat
+
+import (
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+// WireEvent is the JSON envelope sent server->client.
+// Every event has a monotonic Seq for catchup replay.
+type WireEvent struct {
+	Seq  int64  `json:"seq"`
+	Type string `json:"type"`
+
+	// session_ready
+	SessionID string        `json:"session_id,omitempty"`
+	Agent     string        `json:"agent,omitempty"`
+	History   []HistoryItem `json:"history,omitempty"`
+
+	// catchup
+	Events []WireEvent `json:"events,omitempty"`
+
+	// phase_change
+	Phase string `json:"phase,omitempty"`
+
+	// text_delta / reasoning_delta / error
+	Text    string `json:"text,omitempty"`
+	Message string `json:"message,omitempty"`
+
+	// tool_start / tool_end
+	Tool        string `json:"tool,omitempty"`
+	Description string `json:"description,omitempty"`
+	Success     bool   `json:"success,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+
+	// message_done
+	Usage *UsageInfo `json:"usage,omitempty"`
+
+	// approval_request
+	RequestID string `json:"request_id,omitempty"`
+	IsWrite   bool   `json:"is_write,omitempty"`
+	IsShell   bool   `json:"is_shell,omitempty"`
+
+	// ask_user_request
+	Questions []AskUserQuestion `json:"questions,omitempty"`
+}
+
+type HistoryItem struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
+}
+
+type UsageInfo struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+	Cached int `json:"cached"`
+}
+
+type AskUserQuestion struct {
+	Header      string          `json:"header"`
+	Question    string          `json:"question"`
+	Options     []AskUserOption `json:"options"`
+	MultiSelect bool            `json:"multi_select"`
+}
+
+type AskUserOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// ClientEvent is the JSON envelope sent client->server.
+type ClientEvent struct {
+	Type string `json:"type"`
+
+	// message
+	Text string `json:"text,omitempty"`
+
+	// approval_response
+	RequestID string `json:"request_id,omitempty"`
+	Approved  bool   `json:"approved,omitempty"`
+
+	// ask_user_response
+	Responses []AskUserAnswer `json:"responses,omitempty"`
+}
+
+type AskUserAnswer struct {
+	QuestionIndex int      `json:"question_index"`
+	Selected      []string `json:"selected"`
+}
+
+// ToWireEvent converts a StreamEvent into a WireEvent with the supplied sequence.
+func ToWireEvent(seq int64, e ui.StreamEvent) WireEvent {
+	switch e.Type {
+	case ui.StreamEventText:
+		return WireEvent{Seq: seq, Type: "text_delta", Text: e.Text}
+	case ui.StreamEventPhase:
+		return WireEvent{Seq: seq, Type: "phase_change", Phase: e.Phase}
+	case ui.StreamEventToolStart:
+		return WireEvent{Seq: seq, Type: "tool_start", Tool: e.ToolName, Description: e.ToolInfo}
+	case ui.StreamEventToolEnd:
+		return WireEvent{Seq: seq, Type: "tool_end", Tool: e.ToolName, Success: e.ToolSuccess, Summary: e.ToolInfo}
+	case ui.StreamEventUsage:
+		return WireEvent{Seq: seq, Type: "message_done", Usage: &UsageInfo{Input: e.InputTokens, Output: e.OutputTokens, Cached: e.CachedTokens}}
+	case ui.StreamEventDone:
+		return WireEvent{Seq: seq, Type: "message_done", Usage: &UsageInfo{Input: e.InputTokens, Output: e.OutputTokens, Cached: e.CachedTokens}}
+	case ui.StreamEventError:
+		msg := ""
+		if e.Err != nil {
+			msg = e.Err.Error()
+		}
+		return WireEvent{Seq: seq, Type: "error", Message: msg}
+	default:
+		return WireEvent{Seq: seq}
+	}
+}

--- a/internal/tui/chat/backend.go
+++ b/internal/tui/chat/backend.go
@@ -1,0 +1,14 @@
+package chat
+
+import (
+	"context"
+
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+// StreamBackend abstracts local LLM vs remote WebSocket.
+type StreamBackend interface {
+	SendMessage(ctx context.Context, text string) (<-chan ui.StreamEvent, error)
+	Interrupt()
+	Reset()
+}

--- a/internal/tui/chat/local_backend.go
+++ b/internal/tui/chat/local_backend.go
@@ -1,0 +1,48 @@
+package chat
+
+import (
+	"context"
+	"errors"
+
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+// LocalBackend wraps the existing local streaming logic.
+type LocalBackend struct {
+	sendFunc      func(ctx context.Context, text string) (<-chan ui.StreamEvent, error)
+	interruptFunc func()
+	resetFunc     func()
+}
+
+// NewLocalBackend creates a LocalBackend using the provided callbacks.
+func NewLocalBackend(send func(ctx context.Context, text string) (<-chan ui.StreamEvent, error), interrupt func(), reset func()) *LocalBackend {
+	return &LocalBackend{
+		sendFunc:      send,
+		interruptFunc: interrupt,
+		resetFunc:     reset,
+	}
+}
+
+// SendMessage sends a message through the local engine and returns stream events.
+func (b *LocalBackend) SendMessage(ctx context.Context, text string) (<-chan ui.StreamEvent, error) {
+	if b == nil || b.sendFunc == nil {
+		return nil, errors.New("local backend not configured")
+	}
+	return b.sendFunc(ctx, text)
+}
+
+// Interrupt cancels the current stream.
+func (b *LocalBackend) Interrupt() {
+	if b == nil || b.interruptFunc == nil {
+		return
+	}
+	b.interruptFunc()
+}
+
+// Reset clears the conversation state.
+func (b *LocalBackend) Reset() {
+	if b == nil || b.resetFunc == nil {
+		return
+	}
+	b.resetFunc()
+}

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -193,5 +193,6 @@ func newTestChatModel(altScreen bool) *Model {
 		false,
 		"",
 		false, // yolo
+		nil,
 	)
 }

--- a/internal/tui/chat/remote_backend.go
+++ b/internal/tui/chat/remote_backend.go
@@ -1,0 +1,298 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	servechat "github.com/samsaffron/term-llm/internal/serve/chat"
+	"github.com/samsaffron/term-llm/internal/tools"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+// RemoteBackend connects to a term-llm chat server via WebSocket.
+// Implements StreamBackend.
+type RemoteBackend struct {
+	url   string
+	token string
+	agent string
+	conn  *websocket.Conn
+
+	sendCh   chan servechat.ClientEvent
+	requestCh chan any
+
+	mu       sync.Mutex
+	streamCh chan ui.StreamEvent
+}
+
+// NewRemoteBackend creates a RemoteBackend and opens the WebSocket connection.
+func NewRemoteBackend(urlStr, token, agent string) (*RemoteBackend, error) {
+	wsURL, err := normalizeWSURL(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := http.Header{}
+	if strings.TrimSpace(token) != "" {
+		headers.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	}
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	var ready servechat.WireEvent
+	if err := conn.ReadJSON(&ready); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("read session_ready: %w", err)
+	}
+	if ready.Type != "session_ready" {
+		_ = conn.Close()
+		return nil, fmt.Errorf("unexpected event: %s", ready.Type)
+	}
+
+	backend := &RemoteBackend{
+		url:       wsURL,
+		token:     token,
+		agent:     agent,
+		conn:      conn,
+		sendCh:    make(chan servechat.ClientEvent, 32),
+		requestCh: make(chan any, 16),
+	}
+
+	go backend.writeLoop()
+	go backend.readLoop()
+
+	return backend, nil
+}
+
+// Requests returns a channel of backend request messages for the TUI.
+func (r *RemoteBackend) Requests() <-chan any {
+	return r.requestCh
+}
+
+// SendMessage sends a user message and returns a stream event channel.
+func (r *RemoteBackend) SendMessage(ctx context.Context, text string) (<-chan ui.StreamEvent, error) {
+	if r == nil {
+		return nil, errors.New("remote backend is nil")
+	}
+	r.mu.Lock()
+	if r.streamCh != nil {
+		close(r.streamCh)
+	}
+	r.streamCh = make(chan ui.StreamEvent, ui.DefaultStreamBufferSize)
+	streamCh := r.streamCh
+	r.mu.Unlock()
+
+	r.sendCh <- servechat.ClientEvent{Type: "message", Text: text}
+	return streamCh, nil
+}
+
+// Interrupt cancels the current stream.
+func (r *RemoteBackend) Interrupt() {
+	if r == nil {
+		return
+	}
+	r.sendCh <- servechat.ClientEvent{Type: "interrupt"}
+}
+
+// Reset clears the conversation state.
+func (r *RemoteBackend) Reset() {
+	if r == nil {
+		return
+	}
+	r.sendCh <- servechat.ClientEvent{Type: "reset"}
+}
+
+func (r *RemoteBackend) writeLoop() {
+	for ev := range r.sendCh {
+		if r.conn == nil {
+			return
+		}
+		if err := r.conn.WriteJSON(ev); err != nil {
+			return
+		}
+	}
+}
+
+func (r *RemoteBackend) readLoop() {
+	for {
+		if r.conn == nil {
+			return
+		}
+		var ev servechat.WireEvent
+		if err := r.conn.ReadJSON(&ev); err != nil {
+			r.closeStream(err)
+			return
+		}
+		r.handleWireEvent(ev)
+	}
+}
+
+func (r *RemoteBackend) handleWireEvent(ev servechat.WireEvent) {
+	switch ev.Type {
+	case "session_ready":
+		return
+	case "catchup":
+		for _, item := range ev.Events {
+			r.handleWireEvent(item)
+		}
+		return
+	case "approval_request":
+		r.handleApprovalRequest(ev)
+		return
+	case "ask_user_request":
+		r.handleAskUserRequest(ev)
+		return
+	}
+
+	streamEv, ok := wireToStreamEvent(ev)
+	if !ok {
+		return
+	}
+	r.emitStreamEvent(streamEv, ev.Type == "message_done" || ev.Type == "error")
+}
+
+func (r *RemoteBackend) handleApprovalRequest(ev servechat.WireEvent) {
+	doneCh := make(chan tools.ApprovalResult, 1)
+	request := ApprovalRequestMsg{
+		Path:    ev.Description,
+		IsWrite: ev.IsWrite,
+		IsShell: ev.IsShell,
+		DoneCh:  doneCh,
+	}
+	r.requestCh <- request
+
+	go func() {
+		result := <-doneCh
+		approved := result.Choice != tools.ApprovalChoiceDeny && result.Choice != tools.ApprovalChoiceCancelled && !result.Cancelled
+		r.sendCh <- servechat.ClientEvent{Type: "approval_response", RequestID: ev.RequestID, Approved: approved}
+	}()
+}
+
+func (r *RemoteBackend) handleAskUserRequest(ev servechat.WireEvent) {
+	questions := make([]tools.AskUserQuestion, 0, len(ev.Questions))
+	for _, q := range ev.Questions {
+		opts := make([]tools.AskUserOption, 0, len(q.Options))
+		for _, opt := range q.Options {
+			opts = append(opts, tools.AskUserOption{Label: opt.Label, Description: opt.Description})
+		}
+		questions = append(questions, tools.AskUserQuestion{
+			Header:      q.Header,
+			Question:    q.Question,
+			Options:     opts,
+			MultiSelect: q.MultiSelect,
+		})
+	}
+
+	doneCh := make(chan []tools.AskUserAnswer, 1)
+	request := AskUserRequestMsg{Questions: questions, DoneCh: doneCh}
+	r.requestCh <- request
+
+	go func() {
+		answers := <-doneCh
+		responses := make([]servechat.AskUserAnswer, 0, len(answers))
+		for _, ans := range answers {
+			selected := ans.SelectedList
+			if len(selected) == 0 && ans.Selected != "" {
+				selected = []string{ans.Selected}
+			}
+			responses = append(responses, servechat.AskUserAnswer{
+				QuestionIndex: ans.QuestionIndex,
+				Selected:      selected,
+			})
+		}
+		r.sendCh <- servechat.ClientEvent{Type: "ask_user_response", RequestID: ev.RequestID, Responses: responses}
+	}()
+}
+
+func (r *RemoteBackend) emitStreamEvent(ev ui.StreamEvent, closeAfter bool) {
+	r.mu.Lock()
+	streamCh := r.streamCh
+	if streamCh == nil {
+		r.mu.Unlock()
+		return
+	}
+	r.mu.Unlock()
+
+	streamCh <- ev
+	if closeAfter {
+		r.mu.Lock()
+		if r.streamCh != nil {
+			close(r.streamCh)
+			r.streamCh = nil
+		}
+		r.mu.Unlock()
+	}
+}
+
+func (r *RemoteBackend) closeStream(err error) {
+	r.mu.Lock()
+	streamCh := r.streamCh
+	if streamCh != nil {
+		streamCh <- ui.ErrorEvent(err)
+		close(streamCh)
+		r.streamCh = nil
+	}
+	r.mu.Unlock()
+}
+
+func normalizeWSURL(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", errors.New("remote URL is required")
+	}
+	if !strings.HasPrefix(value, "ws://") && !strings.HasPrefix(value, "wss://") && !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		value = "ws://" + value
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	}
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/") + "/chat/sessions/new"
+	return parsed.String(), nil
+}
+
+func wireToStreamEvent(ev servechat.WireEvent) (ui.StreamEvent, bool) {
+	switch ev.Type {
+	case "text_delta":
+		return ui.StreamEvent{Type: ui.StreamEventText, Text: ev.Text}, true
+	case "reasoning_delta":
+		return ui.StreamEvent{Type: ui.StreamEventText, Text: ev.Text}, true
+	case "phase_change":
+		return ui.StreamEvent{Type: ui.StreamEventPhase, Phase: ev.Phase}, true
+	case "tool_start":
+		return ui.StreamEvent{Type: ui.StreamEventToolStart, ToolName: ev.Tool, ToolInfo: ev.Description}, true
+	case "tool_end":
+		summary := ev.Summary
+		if summary == "" {
+			summary = ev.Description
+		}
+		return ui.StreamEvent{Type: ui.StreamEventToolEnd, ToolName: ev.Tool, ToolInfo: summary, ToolSuccess: ev.Success}, true
+	case "message_done":
+		input, output, cached := 0, 0, 0
+		if ev.Usage != nil {
+			input = ev.Usage.Input
+			output = ev.Usage.Output
+			cached = ev.Usage.Cached
+		}
+		return ui.StreamEvent{Type: ui.StreamEventDone, Done: true, InputTokens: input, OutputTokens: output, CachedTokens: cached}, true
+	case "error":
+		return ui.StreamEvent{Type: ui.StreamEventError, Err: errors.New(ev.Message)}, true
+	default:
+		return ui.StreamEvent{}, false
+	}
+}

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -65,6 +65,7 @@ func TestUpdate_StreamError_BumpsContentVersion(t *testing.T) {
 		false, // textMode
 		"",    // agentName
 		false, // yolo
+		nil,
 	)
 	m.streaming = true
 	before := m.viewCache.contentVersion
@@ -102,6 +103,7 @@ func TestViewAltScreen_FirstRenderAnchorsToBottom(t *testing.T) {
 		false, // textMode
 		"",    // agentName
 		false, // yolo
+		nil,
 	)
 
 	for i := 0; i < 120; i++ {
@@ -154,6 +156,7 @@ func TestStreamEventDiffFlushUsesOrderedCommandComposition(t *testing.T) {
 		false,
 		"",
 		false, // yolo
+		nil,
 	)
 	m.streaming = true
 
@@ -239,6 +242,7 @@ func TestRenderStatusLine_ShowsSeededCachedUsageFromSession(t *testing.T) {
 		false,
 		"",
 		false, // yolo
+		nil,
 	)
 
 	line := ui.StripANSI(m.renderStatusLine())


### PR DESCRIPTION
# feat(chat): remote TUI mode via WebSocket

Adds a remote chat mode: run the term-llm TUI on your Mac/host while all LLM calls, tool execution, memory, and agent config stay in the container. Rendering and keyboard input move to the client — everything else stays server-side.

## Usage

**Server (in container):**
```bash
term-llm serve --platform chat --agent jarvis
# combinable with existing platforms:
term-llm serve --platform telegram --platform chat --agent jarvis
```

Config (`config.yaml`):
```yaml
serve:
  chat:
    listen: "0.0.0.0:7374"
    token: "your-shared-secret"
```

**Client (on Mac or any host):**
```bash
term-llm chat --remote http://jarvis.local:7374
```

Or configured so plain `term-llm chat` connects remotely:
```yaml
remote:
  url: "ws://jarvis.local:7374"
  token: "your-shared-secret"
  agent: jarvis
```

## Protocol

WebSocket (gorilla/websocket — already an indirect dep). Single persistent connection per session, JSON-framed events both ways.

Every server→client event carries a monotonic `seq` integer. Reconnect with `?since=<seq>` — server sends a `catchup` burst of missed events then resumes live. If the client drops mid-LLM-call the server finishes the call and buffers everything.

Key server→client events: `session_ready`, `phase_change`, `reasoning_delta`, `text_delta`, `tool_start`, `tool_end`, `message_done`, `error`, `catchup`, `approval_request`, `ask_user_request`

Key client→server events: `message`, `interrupt`, `reset`, `approval_response`, `ask_user_response`

Tool approval prompts and `ask_user` interactions work across the wire — client renders the prompt, sends the response back.

## Security

Bearer token on the WebSocket upgrade `Authorization` header. **Tailscale is the recommended transport** — it provides end-to-end encryption at the network layer, so no TLS is needed in-app. Token still required for auth against other nodes on the tailnet.

Generate a token: `openssl rand -hex 32`

## Architecture

Introduced a `StreamBackend` interface in the TUI:
- `LocalBackend` — wraps existing `llm.Engine` path, behaviour unchanged
- `RemoteBackend` — WebSocket connection to the chat server

`cmd/chat.go` selects the backend based on `--remote` flag or `remote.url` config key. The TUI model is otherwise unmodified.

## New files

- `internal/serve/chat/wire.go` — WireEvent/ClientEvent types + StreamEvent↔wire translation
- `internal/serve/chat/server.go` — SessionManager, RemoteSession, WebSocket handlers, GC
- `internal/tui/chat/backend.go` — StreamBackend interface
- `internal/tui/chat/local_backend.go` — LocalBackend wrapper
- `internal/tui/chat/remote_backend.go` — RemoteBackend WebSocket client

## Modified files

- `cmd/serve.go` — `chat` platform dispatch, HTTP route registration
- `cmd/chat.go` — `--remote` flag, backend selection, remote config reading
- `internal/config/config.go` — `ChatServeConfig` struct, `RemoteConfig` struct
- `internal/tui/chat/chat.go` — `StreamBackend` field on model
- `internal/tui/chat/streaming.go` — backend integration in `startStream`

## Deferred (follow-up PRs)

- TLS in-app (`--tls-cert/--tls-key` on serve, `wss://` on client)
- Attachment support (image/file upload over WebSocket)
- Session settings sync (model switch, `/compact`, tool toggles)
- Session persistence across server restarts
- Web browser client
