### PR TITLE
feat: Whisper transcription — term-llm transcribe command + Telegram voice support

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/signal"
+	"github.com/spf13/cobra"
+)
+
+var (
+	transcribeLanguage  string
+	transcribePorcelain bool
+	transcribeProvider  string
+)
+
+var transcribeCmd = &cobra.Command{
+	Use:   "transcribe <file>",
+	Short: "Transcribe an audio file to text using Whisper",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTranscribe,
+}
+
+func init() {
+	transcribeCmd.Flags().StringVar(&transcribeLanguage, "language", "", "Language hint for transcription (e.g. \"en\", \"ja\")")
+	transcribeCmd.Flags().BoolVar(&transcribePorcelain, "porcelain", false, "Output only the transcript text")
+	transcribeCmd.Flags().StringVar(&transcribeProvider, "provider", "openai", "Transcription provider (default: openai)")
+
+	rootCmd.AddCommand(transcribeCmd)
+}
+
+func runTranscribe(cmd *cobra.Command, args []string) error {
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+
+	cfg, err := loadConfigWithSetup()
+	if err != nil {
+		return err
+	}
+
+	filePath := args[0]
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open audio file: %w", err)
+	}
+	defer f.Close()
+
+	mimeType, err := detectAudioMimeType(filePath)
+	if err != nil {
+		return err
+	}
+
+	if !transcribePorcelain {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Transcribing %s (%s)...\n", filepath.Base(filePath), mimeType)
+	}
+
+	transcript, err := transcribeAudio(ctx, cfg, filePath, strings.TrimSpace(transcribeLanguage))
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), transcript)
+	return nil
+}
+
+func detectAudioMimeType(filePath string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".ogg":
+		return "audio/ogg", nil
+	case ".mp3":
+		return "audio/mpeg", nil
+	case ".wav":
+		return "audio/wav", nil
+	case ".m4a":
+		return "audio/mp4", nil
+	case ".flac":
+		return "audio/flac", nil
+	case ".mp4":
+		return "audio/mp4", nil
+	case ".webm":
+		return "audio/webm", nil
+	default:
+		return "", fmt.Errorf("unsupported audio extension %q", ext)
+	}
+}
+
+func transcribeAudio(ctx context.Context, cfg *config.Config, filePath, language string) (string, error) {
+	provider := strings.TrimSpace(transcribeProvider)
+	baseProvider := strings.SplitN(provider, ":", 2)[0]
+	if baseProvider == "" {
+		baseProvider = string(config.ProviderTypeOpenAI)
+	}
+	if baseProvider != string(config.ProviderTypeOpenAI) {
+		return "", fmt.Errorf("unsupported provider %q (only openai is supported)", provider)
+	}
+
+	openaiCfg := cfg.Providers[string(config.ProviderTypeOpenAI)]
+	apiKey := openaiCfg.ResolvedAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return "", fmt.Errorf("no OpenAI API key configured (providers.openai.api_key or OPENAI_API_KEY)")
+	}
+
+	return llm.TranscribeFile(ctx, filePath, llm.TranscribeOptions{
+		APIKey:   apiKey,
+		Language: language,
+	})
+}

--- a/internal/llm/whisper.go
+++ b/internal/llm/whisper.go
@@ -1,0 +1,76 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type TranscribeOptions struct {
+	APIKey   string
+	Language string // optional, e.g. "en"
+}
+
+type whisperResponse struct {
+	Text string `json:"text"`
+}
+
+// TranscribeFile sends an audio file to the OpenAI Whisper API and returns the transcript.
+// Supported formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.
+func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open audio file: %w", err)
+	}
+	defer f.Close()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+
+	fw, err := mw.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(fw, f); err != nil {
+		return "", fmt.Errorf("write form file: %w", err)
+	}
+
+	_ = mw.WriteField("model", "whisper-1")
+	_ = mw.WriteField("response_format", "json")
+	if opts.Language != "" {
+		_ = mw.WriteField("language", opts.Language)
+	}
+	mw.Close()
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		"https://api.openai.com/v1/audio/transcriptions", &body)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := defaultHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("whisper request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("whisper API error %d: %s", resp.StatusCode, string(b))
+	}
+
+	var result whisperResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode whisper response: %w", err)
+	}
+
+	return result.Text, nil
+}


### PR DESCRIPTION
## Summary
- add Whisper transcription helper and `term-llm transcribe` command with OpenAI key resolution
- add Telegram voice download/transcription handling and voice download tests

## Testing
- go build ./...
- go vet ./... *(fails: internal/llm/* tests report existing context-cancel vet warnings in debug_provider_test.go and engine_test.go)*
- go test ./internal/llm/... ./cmd/... ./internal/serve/...
