### PR TITLE
DEV: expose RTX 4090 GPU to jarvis container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,8 @@ RUN pacman -Syu --noconfirm && \
       nmap \
       openbsd-netcat \
       strace \
-      gnupg && \
+      gnupg \
+      nvidia-utils && \
     pacman -Scc --noconfirm
 
 # Unprivileged user for AUR builds (makepkg refuses root)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,13 @@ services:
       lan:
         ipv4_address: 10.0.0.52
     restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
 
 volumes:
   jarvis-state:


### PR DESCRIPTION
Exposes the host RTX 4090 to the jarvis container.

**`docker-compose.yml`** — adds `deploy.resources.reservations.devices` with `driver: nvidia, count: all, capabilities: [gpu]`. This is the standard Docker Compose syntax for NVIDIA GPU passthrough (requires `nvidia-container-toolkit` on the host).

**`Dockerfile`** — adds `nvidia-utils` to the pacman install so `nvidia-smi` and CUDA userspace libs are available inside the container.

Motivation: enables local GPU-accelerated inference (voxtral.c, whisper.cpp w/ CUDA, faster-whisper w/ CUDA) and removes the CPU-only constraint for local model work.

Requires `nvidia-container-toolkit` installed on the host and the container rebuilt.
