### PR TITLE
FIX: route transcription through configured provider, fix Telegram error message

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	Chat            ChatConfig                `mapstructure:"chat"`
 	Edit            EditConfig                `mapstructure:"edit"`
 	Image           ImageConfig               `mapstructure:"image"`
+	Transcription   TranscriptionConfig       `mapstructure:"transcription"`
 	Embed           EmbedConfig               `mapstructure:"embed"`
 	Search          SearchConfig              `mapstructure:"search"`
 	Theme           ThemeConfig               `mapstructure:"theme"`
@@ -295,6 +296,12 @@ type ImageOpenRouterConfig struct {
 // ImageDebugConfig configures the debug image provider (local random images)
 type ImageDebugConfig struct {
 	Delay float64 `mapstructure:"delay"` // delay in seconds before returning (e.g., 1.5)
+}
+
+// TranscriptionConfig configures audio transcription settings.
+type TranscriptionConfig struct {
+	Provider string `mapstructure:"provider"` // named provider from providers map; default "openai"
+	Model    string `mapstructure:"model"`    // optional model override
 }
 
 // EmbedConfig configures text embedding generation
@@ -851,6 +858,7 @@ var KnownKeys = map[string]bool{
 	"chat":             true,
 	"edit":             true,
 	"image":            true,
+	"transcription":    true,
 	"search":           true,
 	"theme":            true,
 	"tools":            true,
@@ -920,6 +928,10 @@ var KnownKeys = map[string]bool{
 	"image.openrouter.model":   true,
 	"image.debug":              true,
 	"image.debug.delay":        true,
+
+	// Transcription
+	"transcription.provider": true,
+	"transcription.model":    true,
 
 	// Embed
 	"embed.provider":        true,

--- a/internal/llm/transcribe.go
+++ b/internal/llm/transcribe.go
@@ -1,0 +1,115 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+// TranscribeWithConfig transcribes an audio file using the provider configured in cfg.
+// providerOverride, if non-empty, overrides cfg.Transcription.Provider.
+//
+// Supported provider names: "openai" (default), "mistral" (Voxtral), "local" (whisper.cpp server),
+// "whisper-cli" (whisper.cpp CLI binary). The whisper-cli case is delegated back to cmd via
+// the transcribeWhisperCLI function — callers that don't support it (e.g. Telegram) will get
+// an unsupported-provider error, which is intentional.
+func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, language, providerOverride string) (string, error) {
+	providerName := providerOverride
+	if providerName == "" {
+		providerName = cfg.Transcription.Provider
+	}
+	if providerName == "" {
+		providerName = "openai"
+	}
+
+	modelOverride := cfg.Transcription.Model
+
+	switch providerName {
+	case "local":
+		// whisper.cpp HTTP server — OpenAI-compatible endpoint, typically no auth required
+		endpoint := "http://localhost:8080/inference"
+		if providerCfg, ok := cfg.Providers["local_whisper"]; ok && providerCfg.BaseURL != "" {
+			endpoint = strings.TrimRight(providerCfg.BaseURL, "/") + "/inference"
+		}
+		return TranscribeFile(ctx, filePath, TranscribeOptions{
+			Endpoint: endpoint,
+			Model:    modelOverride,
+			Language: language,
+		})
+
+	case "mistral":
+		mistralCfg := cfg.Providers["mistral"]
+		apiKey := mistralCfg.ResolvedAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("MISTRAL_API_KEY")
+		}
+		if apiKey == "" {
+			return "", fmt.Errorf("transcription provider %q has no API key configured (providers.mistral.api_key or MISTRAL_API_KEY)", providerName)
+		}
+		endpoint := "https://api.mistral.ai/v1/audio/transcriptions"
+		if mistralCfg.BaseURL != "" {
+			endpoint = strings.TrimRight(mistralCfg.BaseURL, "/") + "/audio/transcriptions"
+		}
+		model := modelOverride
+		if model == "" {
+			model = "voxtral-mini-latest"
+		}
+		return TranscribeFile(ctx, filePath, TranscribeOptions{
+			APIKey:   apiKey,
+			Endpoint: endpoint,
+			Model:    model,
+			Language: language,
+		})
+
+	case "openai":
+		// Named provider entry takes precedence over env var
+		if p, ok := cfg.Providers[string(config.ProviderTypeOpenAI)]; ok && p.ResolvedAPIKey != "" {
+			endpoint := ""
+			if p.BaseURL != "" {
+				endpoint = strings.TrimRight(p.BaseURL, "/") + "/audio/transcriptions"
+			}
+			return TranscribeFile(ctx, filePath, TranscribeOptions{
+				APIKey:   p.ResolvedAPIKey,
+				Endpoint: endpoint,
+				Model:    modelOverride,
+				Language: language,
+			})
+		}
+		// Fall back to environment variable
+		apiKey := os.Getenv("OPENAI_API_KEY")
+		if apiKey == "" {
+			return "", fmt.Errorf("transcription is not configured — set providers.openai.api_key or configure a transcription provider in config")
+		}
+		return TranscribeFile(ctx, filePath, TranscribeOptions{
+			APIKey:   apiKey,
+			Model:    modelOverride,
+			Language: language,
+		})
+
+	default:
+		// Try looking up by name in providers map (allows any openai_compatible provider)
+		if p, ok := cfg.Providers[providerName]; ok {
+			apiKey := p.ResolvedAPIKey
+			if apiKey == "" {
+				return "", fmt.Errorf("transcription provider %q has no API key configured", providerName)
+			}
+			endpoint := ""
+			resolvedURL := p.ResolvedURL
+			if resolvedURL != "" {
+				endpoint = strings.TrimRight(resolvedURL, "/") + "/audio/transcriptions"
+			} else if p.BaseURL != "" {
+				endpoint = strings.TrimRight(p.BaseURL, "/") + "/audio/transcriptions"
+			}
+			return TranscribeFile(ctx, filePath, TranscribeOptions{
+				APIKey:   apiKey,
+				Endpoint: endpoint,
+				Model:    modelOverride,
+				Language: language,
+			})
+		}
+		return "", fmt.Errorf("transcription provider %q not found in providers config (supported builtins: openai, mistral, local, whisper-cli)", providerName)
+	}
+}

--- a/internal/llm/whisper.go
+++ b/internal/llm/whisper.go
@@ -14,16 +14,16 @@ import (
 
 type TranscribeOptions struct {
 	APIKey   string
-	Language string // optional, e.g. "en"
-	Endpoint string // full URL, e.g. "http://localhost:8080/inference" or "https://api.openai.com/v1/audio/transcriptions"
+	Endpoint string // full URL, e.g. "http://localhost:8080/inference" or "https://api.mistral.ai/v1/audio/transcriptions"
 	Model    string // optional, overrides default model name sent to API
+	Language string // optional, e.g. "en"
 }
 
 type whisperResponse struct {
 	Text string `json:"text"`
 }
 
-// TranscribeFile sends an audio file to the OpenAI Whisper API and returns the transcript.
+// TranscribeFile sends an audio file to a Whisper-compatible API and returns the transcript.
 // Supported formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.
 func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions) (string, error) {
 	f, err := os.Open(filePath)
@@ -43,13 +43,11 @@ func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions
 		return "", fmt.Errorf("write form file: %w", err)
 	}
 
-	if opts.APIKey != "" {
-		model := opts.Model
-		if model == "" {
-			model = "whisper-1"
-		}
-		_ = mw.WriteField("model", model)
+	model := opts.Model
+	if model == "" {
+		model = "whisper-1"
 	}
+	_ = mw.WriteField("model", model)
 	_ = mw.WriteField("response_format", "json")
 	if opts.Language != "" {
 		_ = mw.WriteField("language", opts.Language)
@@ -61,8 +59,7 @@ func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions
 		endpoint = "https://api.openai.com/v1/audio/transcriptions"
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST",
-		endpoint, &body)
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, &body)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
 	}


### PR DESCRIPTION
## Problem

`term-llm transcribe` and Telegram voice transcription both hardcode OpenAI as the only
transcription provider. If you have a different `openai_compatible` provider configured
(e.g. Mistral/Voxtral), they fail with a misleading "requires an OpenAI API key" error.

## Changes

- `internal/llm/whisper.go`: add `BaseURL` and `Model` to `TranscribeOptions`; use them in `TranscribeFile`
- `internal/config/config.go`: add `TranscriptionConfig` struct + `Transcription` field on `Config`
- `internal/llm/transcribe.go` (new): shared `TranscribeWithConfig` helper that resolves provider from config
- `cmd/transcribe.go`: call `llm.TranscribeWithConfig`; `--provider` flag overrides config
- `internal/serve/telegram.go`: use `llm.TranscribeWithConfig`; fix error message to not mention OpenAI

## Config

```yaml
transcription:
  provider: mistral        # any key from providers map, or "openai" (default)
  model: voxtral-mini-latest  # optional model override
```

## Worktree setup
```bash
bash ~/source/term-llm/scripts/term-llm-checkout.sh fix/transcription-provider
```
Work in the resulting worktree (check output of the script for the path).
