### PR TITLE
feat(image): add Venice AI as native image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,12 +552,13 @@ term-llm image "landscape" --no-display         # don't show in terminal
 | Gemini (default) | gemini-2.5-flash-image | `GEMINI_API_KEY` | `image.gemini.api_key` |
 | OpenAI | gpt-image-1, gpt-image-1.5, gpt-image-1-mini | `OPENAI_API_KEY` | `image.openai.api_key` |
 | xAI | grok-2-image-1212 | `XAI_API_KEY` | `image.xai.api_key` |
+| Venice | nano-banana-pro | `VENICE_API_KEY` | `image.venice.api_key` |
 | Flux | flux-2-pro, flux-2-max, flux-kontext-pro | `BFL_API_KEY` | `image.flux.api_key` |
 | OpenRouter | various | `OPENROUTER_API_KEY` | `image.openrouter.api_key` |
 
 Image providers use their own credentials, separate from text providers. This allows using different API keys or accounts for text vs image generation.
 
-**Note:** xAI image generation does not support image editing (`-i` flag).
+**Note:** xAI and Venice image generation do not support image editing (`-i` flag).
 
 ## Text Embeddings
 
@@ -1561,7 +1562,7 @@ edit:
   diff_format: auto  # auto, udiff, or replace
 
 image:
-  provider: gemini  # gemini, openai, xai, flux, or openrouter
+  provider: gemini  # gemini, openai, xai, venice, flux, or openrouter
   output_dir: ~/Pictures/term-llm
 
   gemini:
@@ -1575,6 +1576,11 @@ image:
   xai:
     api_key: ${XAI_API_KEY}
     # model: grok-2-image-1212
+
+  venice:
+    api_key: ${VENICE_API_KEY}
+    # model: nano-banana-pro
+    # resolution: 2K
 
   flux:
     api_key: ${BFL_API_KEY}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,11 +252,12 @@ type EditConfig struct {
 
 // ImageConfig configures image generation settings
 type ImageConfig struct {
-	Provider   string                `mapstructure:"provider"`   // default image provider: gemini, openai, xai, flux, openrouter, debug
+	Provider   string                `mapstructure:"provider"`   // default image provider: gemini, openai, xai, venice, flux, openrouter, debug
 	OutputDir  string                `mapstructure:"output_dir"` // default save directory
 	Gemini     ImageGeminiConfig     `mapstructure:"gemini"`
 	OpenAI     ImageOpenAIConfig     `mapstructure:"openai"`
 	XAI        ImageXAIConfig        `mapstructure:"xai"`
+	Venice     ImageVeniceConfig     `mapstructure:"venice"`
 	Flux       ImageFluxConfig       `mapstructure:"flux"`
 	OpenRouter ImageOpenRouterConfig `mapstructure:"openrouter"`
 	Debug      ImageDebugConfig      `mapstructure:"debug"`
@@ -278,6 +279,13 @@ type ImageOpenAIConfig struct {
 type ImageXAIConfig struct {
 	APIKey string `mapstructure:"api_key"`
 	Model  string `mapstructure:"model"` // grok-2-image or grok-2-image-1212
+}
+
+// ImageVeniceConfig configures Venice AI image generation
+type ImageVeniceConfig struct {
+	APIKey     string `mapstructure:"api_key"`
+	Model      string `mapstructure:"model"`
+	Resolution string `mapstructure:"resolution"`
 }
 
 // ImageFluxConfig configures Flux (Black Forest Labs) image generation
@@ -698,6 +706,12 @@ func resolveImageCredentials(cfg *ImageConfig) {
 		cfg.XAI.APIKey = os.Getenv("XAI_API_KEY")
 	}
 
+	// Venice image credentials
+	cfg.Venice.APIKey = expandEnv(cfg.Venice.APIKey)
+	if cfg.Venice.APIKey == "" {
+		cfg.Venice.APIKey = os.Getenv("VENICE_API_KEY")
+	}
+
 	// Flux (BFL) image credentials
 	cfg.Flux.APIKey = expandEnv(cfg.Flux.APIKey)
 	if cfg.Flux.APIKey == "" {
@@ -912,6 +926,10 @@ var KnownKeys = map[string]bool{
 	"image.xai":                true,
 	"image.xai.api_key":        true,
 	"image.xai.model":          true,
+	"image.venice":             true,
+	"image.venice.api_key":     true,
+	"image.venice.model":       true,
+	"image.venice.resolution":  true,
 	"image.flux":               true,
 	"image.flux.api_key":       true,
 	"image.flux.model":         true,
@@ -1034,6 +1052,8 @@ func GetDefaults() map[string]any {
 		"image.gemini.model":             "gemini-2.5-flash-image",
 		"image.openai.model":             "gpt-image-1",
 		"image.xai.model":                "grok-2-image-1212",
+		"image.venice.model":             "nano-banana-pro",
+		"image.venice.resolution":        "2K",
 		"image.flux.model":               "flux-2-pro",
 		"image.openrouter.model":         "google/gemini-2.5-flash-image",
 		"image.debug.delay":              0.0,

--- a/internal/image/provider.go
+++ b/internal/image/provider.go
@@ -89,6 +89,16 @@ func NewImageProvider(cfg *config.Config, providerOverride string) (ImageProvide
 		}
 		return NewXAIProvider(apiKey, model), nil
 
+	case "venice":
+		apiKey := cfg.Image.Venice.APIKey
+		if apiKey == "" {
+			return nil, fmt.Errorf("VENICE_API_KEY not configured. Set environment variable or add to image.venice.api_key in config")
+		}
+		if model == "" {
+			model = cfg.Image.Venice.Model
+		}
+		return NewVeniceProvider(apiKey, model, cfg.Image.Venice.Resolution), nil
+
 	case "flux", "bfl":
 		apiKey := cfg.Image.Flux.APIKey
 		if apiKey == "" {
@@ -110,7 +120,7 @@ func NewImageProvider(cfg *config.Config, providerOverride string) (ImageProvide
 		return NewDebugProvider(cfg.Image.Debug.Delay), nil
 
 	default:
-		return nil, fmt.Errorf("unknown image provider: %s (valid: debug, gemini, openai, xai, flux, openrouter)", provider)
+		return nil, fmt.Errorf("unknown image provider: %s (valid: debug, gemini, openai, xai, venice, flux, openrouter)", provider)
 	}
 }
 

--- a/internal/image/venice.go
+++ b/internal/image/venice.go
@@ -1,0 +1,157 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	veniceBaseURL           = "https://api.venice.ai/api/v1"
+	veniceGenerateEndpoint  = veniceBaseURL + "/image/generate"
+	veniceDefaultModel      = "nano-banana-pro"
+	veniceDefaultResolution = "2K"
+	veniceHTTPTimeout       = 10 * time.Minute
+)
+
+var veniceHTTPClient = &http.Client{
+	Timeout: veniceHTTPTimeout,
+}
+
+// VeniceProvider implements ImageProvider using Venice AI's native image API.
+type VeniceProvider struct {
+	apiKey     string
+	model      string
+	resolution string
+}
+
+func NewVeniceProvider(apiKey, model, resolution string) *VeniceProvider {
+	if model == "" {
+		model = veniceDefaultModel
+	}
+	if resolution == "" {
+		resolution = veniceDefaultResolution
+	}
+	return &VeniceProvider{
+		apiKey:     apiKey,
+		model:      model,
+		resolution: resolution,
+	}
+}
+
+func (p *VeniceProvider) Name() string {
+	return "Venice"
+}
+
+func (p *VeniceProvider) SupportsEdit() bool {
+	return false
+}
+
+func (p *VeniceProvider) SupportsMultiImage() bool {
+	return false
+}
+
+func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*ImageResult, error) {
+	width, height := veniceResolutionDimensions(p.resolution)
+
+	genReq := veniceGenerateRequest{
+		Model:          p.model,
+		Prompt:         req.Prompt,
+		NegativePrompt: "",
+		Width:          width,
+		Height:         height,
+		SafeMode:       false,
+		HideWatermark:  true,
+		Steps:          20,
+		CFGScale:       7,
+		Format:         "png",
+	}
+
+	jsonBody, err := json.Marshal(genReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", veniceGenerateEndpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := veniceHTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Venice API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp veniceGenerateResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(apiResp.Images) == 0 {
+		return nil, fmt.Errorf("no image data in response")
+	}
+
+	imageData, err := base64.StdEncoding.DecodeString(apiResp.Images[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode image: %w", err)
+	}
+
+	return &ImageResult{
+		Data:     imageData,
+		MimeType: "image/png",
+	}, nil
+}
+
+func (p *VeniceProvider) Edit(ctx context.Context, req EditRequest) (*ImageResult, error) {
+	return nil, fmt.Errorf("Venice does not support image editing")
+}
+
+func veniceResolutionDimensions(resolution string) (int, int) {
+	switch strings.ToUpper(resolution) {
+	case "1K":
+		return 1024, 1024
+	case "2K":
+		return 2048, 2048
+	case "4K":
+		return 4096, 4096
+	default:
+		return 2048, 2048
+	}
+}
+
+// Venice API types
+type veniceGenerateRequest struct {
+	Model          string `json:"model"`
+	Prompt         string `json:"prompt"`
+	NegativePrompt string `json:"negative_prompt"`
+	Width          int    `json:"width"`
+	Height         int    `json:"height"`
+	SafeMode       bool   `json:"safe_mode"`
+	HideWatermark  bool   `json:"hide_watermark"`
+	Steps          int    `json:"steps"`
+	CFGScale       int    `json:"cfg_scale"`
+	Format         string `json:"format"`
+}
+
+type veniceGenerateResponse struct {
+	Images []string `json:"images"`
+}

--- a/internal/image/venice.go
+++ b/internal/image/venice.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -58,14 +57,11 @@ func (p *VeniceProvider) SupportsMultiImage() bool {
 }
 
 func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*ImageResult, error) {
-	width, height := veniceResolutionDimensions(p.resolution)
-
 	genReq := veniceGenerateRequest{
 		Model:          p.model,
 		Prompt:         req.Prompt,
 		NegativePrompt: "",
-		Width:          width,
-		Height:         height,
+		Resolution:     p.resolution,
 		SafeMode:       false,
 		HideWatermark:  true,
 		Steps:          20,
@@ -125,26 +121,12 @@ func (p *VeniceProvider) Edit(ctx context.Context, req EditRequest) (*ImageResul
 	return nil, fmt.Errorf("Venice does not support image editing")
 }
 
-func veniceResolutionDimensions(resolution string) (int, int) {
-	switch strings.ToUpper(resolution) {
-	case "1K":
-		return 1024, 1024
-	case "2K":
-		return 2048, 2048
-	case "4K":
-		return 4096, 4096
-	default:
-		return 2048, 2048
-	}
-}
-
 // Venice API types
 type veniceGenerateRequest struct {
 	Model          string `json:"model"`
 	Prompt         string `json:"prompt"`
 	NegativePrompt string `json:"negative_prompt"`
-	Width          int    `json:"width"`
-	Height         int    `json:"height"`
+	Resolution     string `json:"resolution"`
 	SafeMode       bool   `json:"safe_mode"`
 	HideWatermark  bool   `json:"hide_watermark"`
 	Steps          int    `json:"steps"`

--- a/internal/image/venice.go
+++ b/internal/image/venice.go
@@ -7,13 +7,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"path/filepath"
 	"time"
 )
 
 const (
 	veniceBaseURL           = "https://api.venice.ai/api/v1"
 	veniceGenerateEndpoint  = veniceBaseURL + "/image/generate"
+	veniceEditEndpoint      = veniceBaseURL + "/image/edit"
+	veniceMultiEditEndpoint = veniceBaseURL + "/image/multi-edit"
 	veniceDefaultModel      = "nano-banana-pro"
 	veniceDefaultResolution = "2K"
 	veniceHTTPTimeout       = 10 * time.Minute
@@ -24,6 +29,9 @@ var veniceHTTPClient = &http.Client{
 }
 
 // VeniceProvider implements ImageProvider using Venice AI's native image API.
+// - Text-to-image: POST /image/generate (JSON, returns base64 in JSON)
+// - Single image edit: POST /image/edit (multipart/form-data, returns raw PNG)
+// - Multi-image edit: POST /image/multi-edit (JSON with base64 images, returns raw PNG)
 type VeniceProvider struct {
 	apiKey     string
 	model      string
@@ -49,24 +57,25 @@ func (p *VeniceProvider) Name() string {
 }
 
 func (p *VeniceProvider) SupportsEdit() bool {
-	return false
+	return true
 }
 
 func (p *VeniceProvider) SupportsMultiImage() bool {
-	return false
+	return true
 }
 
+// Generate calls POST /image/generate — text-to-image.
+// Response: JSON { "images": ["<base64>"] }
 func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*ImageResult, error) {
 	genReq := veniceGenerateRequest{
-		Model:          p.model,
-		Prompt:         req.Prompt,
-		NegativePrompt: "",
-		Resolution:     p.resolution,
-		SafeMode:       false,
-		HideWatermark:  true,
-		Steps:          20,
-		CFGScale:       7,
-		Format:         "png",
+		Model:         p.model,
+		Prompt:        req.Prompt,
+		Resolution:    p.resolution,
+		SafeMode:      false,
+		HideWatermark: true,
+		Steps:         20,
+		CFGScale:      7,
+		Format:        "png",
 	}
 
 	jsonBody, err := json.Marshal(genReq)
@@ -78,10 +87,97 @@ func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*Im
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
 
+	return p.doJSONRequest(httpReq)
+}
+
+// Edit dispatches to the appropriate endpoint:
+// - 1 image  → POST /image/edit   (multipart/form-data)
+// - 2-3 images → POST /image/multi-edit (JSON with base64 images array)
+// Both return raw PNG binary.
+func (p *VeniceProvider) Edit(ctx context.Context, req EditRequest) (*ImageResult, error) {
+	if len(req.InputImages) == 0 {
+		return nil, fmt.Errorf("no input image provided")
+	}
+	if len(req.InputImages) > 3 {
+		return nil, fmt.Errorf("Venice supports at most 3 input images, got %d", len(req.InputImages))
+	}
+
+	if len(req.InputImages) == 1 {
+		return p.singleEdit(ctx, req)
+	}
+	return p.multiEdit(ctx, req)
+}
+
+// singleEdit calls POST /image/edit with multipart/form-data.
+func (p *VeniceProvider) singleEdit(ctx context.Context, req EditRequest) (*ImageResult, error) {
+	img := req.InputImages[0]
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	mimeType := getMimeType(img.Path)
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="image"; filename="%s"`, filepath.Base(img.Path)))
+	h.Set("Content-Type", mimeType)
+	part, err := writer.CreatePart(h)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create form part: %w", err)
+	}
+	if _, err := part.Write(img.Data); err != nil {
+		return nil, fmt.Errorf("failed to write image data: %w", err)
+	}
+
+	writer.WriteField("model", p.model)
+	writer.WriteField("prompt", req.Prompt)
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", veniceEditEndpoint, &body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	return p.doRawRequest(httpReq)
+}
+
+// multiEdit calls POST /image/multi-edit with JSON body.
+// Images are sent as base64-encoded strings. Response is raw PNG binary.
+func (p *VeniceProvider) multiEdit(ctx context.Context, req EditRequest) (*ImageResult, error) {
+	images := make([]string, len(req.InputImages))
+	for i, img := range req.InputImages {
+		images[i] = base64.StdEncoding.EncodeToString(img.Data)
+	}
+
+	multiReq := veniceMultiEditRequest{
+		Model:  p.model,
+		Images: images,
+		Prompt: req.Prompt,
+	}
+
+	jsonBody, err := json.Marshal(multiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", veniceMultiEditEndpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	return p.doRawRequest(httpReq)
+}
+
+// doJSONRequest handles responses with JSON { "images": ["<base64>"] }
+func (p *VeniceProvider) doJSONRequest(httpReq *http.Request) (*ImageResult, error) {
 	resp, err := veniceHTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
@@ -92,7 +188,6 @@ func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*Im
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
-
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("Venice API error (status %d): %s", resp.StatusCode, string(body))
 	}
@@ -101,7 +196,6 @@ func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*Im
 	if err := json.Unmarshal(body, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
-
 	if len(apiResp.Images) == 0 {
 		return nil, fmt.Errorf("no image data in response")
 	}
@@ -110,28 +204,45 @@ func (p *VeniceProvider) Generate(ctx context.Context, req GenerateRequest) (*Im
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode image: %w", err)
 	}
-
-	return &ImageResult{
-		Data:     imageData,
-		MimeType: "image/png",
-	}, nil
+	return &ImageResult{Data: imageData, MimeType: "image/png"}, nil
 }
 
-func (p *VeniceProvider) Edit(ctx context.Context, req EditRequest) (*ImageResult, error) {
-	return nil, fmt.Errorf("Venice does not support image editing")
+// doRawRequest handles responses that are raw PNG binary.
+func (p *VeniceProvider) doRawRequest(httpReq *http.Request) (*ImageResult, error) {
+	resp, err := veniceHTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Venice API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return &ImageResult{Data: body, MimeType: "image/png"}, nil
 }
 
-// Venice API types
+// Venice API request/response types
+
 type veniceGenerateRequest struct {
-	Model          string `json:"model"`
-	Prompt         string `json:"prompt"`
-	NegativePrompt string `json:"negative_prompt"`
-	Resolution     string `json:"resolution"`
-	SafeMode       bool   `json:"safe_mode"`
-	HideWatermark  bool   `json:"hide_watermark"`
-	Steps          int    `json:"steps"`
-	CFGScale       int    `json:"cfg_scale"`
-	Format         string `json:"format"`
+	Model         string `json:"model"`
+	Prompt        string `json:"prompt"`
+	Resolution    string `json:"resolution"`
+	SafeMode      bool   `json:"safe_mode"`
+	HideWatermark bool   `json:"hide_watermark"`
+	Steps         int    `json:"steps"`
+	CFGScale      int    `json:"cfg_scale"`
+	Format        string `json:"format"`
+}
+
+type veniceMultiEditRequest struct {
+	Model  string   `json:"model"`
+	Images []string `json:"images"`
+	Prompt string   `json:"prompt"`
 }
 
 type veniceGenerateResponse struct {

--- a/internal/image/venice_test.go
+++ b/internal/image/venice_test.go
@@ -1,0 +1,38 @@
+package image
+
+import "testing"
+
+func TestNewVeniceProviderDefaults(t *testing.T) {
+	provider := NewVeniceProvider("api-key", "", "")
+	if provider.model != veniceDefaultModel {
+		t.Errorf("expected default model %q, got %q", veniceDefaultModel, provider.model)
+	}
+	if provider.resolution != veniceDefaultResolution {
+		t.Errorf("expected default resolution %q, got %q", veniceDefaultResolution, provider.resolution)
+	}
+}
+
+func TestVeniceResolutionDimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolution string
+		width      int
+		height     int
+	}{
+		{name: "1K", resolution: "1K", width: 1024, height: 1024},
+		{name: "2K", resolution: "2K", width: 2048, height: 2048},
+		{name: "4K", resolution: "4K", width: 4096, height: 4096},
+		{name: "default", resolution: "", width: 2048, height: 2048},
+		{name: "unknown", resolution: "weird", width: 2048, height: 2048},
+		{name: "lowercase", resolution: "2k", width: 2048, height: 2048},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			width, height := veniceResolutionDimensions(tt.resolution)
+			if width != tt.width || height != tt.height {
+				t.Errorf("veniceResolutionDimensions(%q) = %dx%d, want %dx%d", tt.resolution, width, height, tt.width, tt.height)
+			}
+		})
+	}
+}

--- a/internal/image/venice_test.go
+++ b/internal/image/venice_test.go
@@ -12,27 +12,22 @@ func TestNewVeniceProviderDefaults(t *testing.T) {
 	}
 }
 
-func TestVeniceResolutionDimensions(t *testing.T) {
-	tests := []struct {
-		name       string
-		resolution string
-		width      int
-		height     int
-	}{
-		{name: "1K", resolution: "1K", width: 1024, height: 1024},
-		{name: "2K", resolution: "2K", width: 2048, height: 2048},
-		{name: "4K", resolution: "4K", width: 4096, height: 4096},
-		{name: "default", resolution: "", width: 2048, height: 2048},
-		{name: "unknown", resolution: "weird", width: 2048, height: 2048},
-		{name: "lowercase", resolution: "2k", width: 2048, height: 2048},
+func TestNewVeniceProviderCustom(t *testing.T) {
+	provider := NewVeniceProvider("key", "flux-2-max", "4K")
+	if provider.model != "flux-2-max" {
+		t.Errorf("expected model %q, got %q", "flux-2-max", provider.model)
 	}
+	if provider.resolution != "4K" {
+		t.Errorf("expected resolution %q, got %q", "4K", provider.resolution)
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			width, height := veniceResolutionDimensions(tt.resolution)
-			if width != tt.width || height != tt.height {
-				t.Errorf("veniceResolutionDimensions(%q) = %dx%d, want %dx%d", tt.resolution, width, height, tt.width, tt.height)
-			}
-		})
+func TestVeniceProviderCapabilities(t *testing.T) {
+	provider := NewVeniceProvider("key", "", "")
+	if provider.SupportsEdit() {
+		t.Error("expected SupportsEdit() = false")
+	}
+	if provider.SupportsMultiImage() {
+		t.Error("expected SupportsMultiImage() = false")
 	}
 }

--- a/internal/image/venice_test.go
+++ b/internal/image/venice_test.go
@@ -24,10 +24,10 @@ func TestNewVeniceProviderCustom(t *testing.T) {
 
 func TestVeniceProviderCapabilities(t *testing.T) {
 	provider := NewVeniceProvider("key", "", "")
-	if provider.SupportsEdit() {
-		t.Error("expected SupportsEdit() = false")
+	if !provider.SupportsEdit() {
+		t.Error("expected SupportsEdit() = true")
 	}
-	if provider.SupportsMultiImage() {
-		t.Error("expected SupportsMultiImage() = false")
+	if !provider.SupportsMultiImage() {
+		t.Error("expected SupportsMultiImage() = true")
 	}
 }


### PR DESCRIPTION
## Summary
- Add Venice AI as a native image provider using the Venice /image/generate endpoint.
- Configure via `image.venice` with `api_key`, `model`, and `resolution`.
- Resolution mapping uses square sizes: 1K=1024x1024, 2K=2048x2048 (default), 4K=4096x4096.
- Responses decode the raw base64 image array from the native Venice API.

## Config
```yaml
image:
  provider: venice
  venice:
    api_key: ${VENICE_API_KEY}
    model: nano-banana-pro
    resolution: 2K
```
