### PR TITLE
feat(llm): add Venice AI as native inference provider

### DIFF
--- a/cmd/models.go
+++ b/cmd/models.go
@@ -78,6 +78,7 @@ func runModels(cmd *cobra.Command, args []string) error {
 		config.ProviderTypeOpenAICompat: true,
 		config.ProviderTypeZen:          true,
 		config.ProviderTypeXAI:          true,
+		config.ProviderTypeVenice:       true,
 	}
 
 	// For built-in providers without explicit config, check if they support dynamic listing
@@ -148,6 +149,15 @@ func runModels(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("xAI API key not configured. Set XAI_API_KEY or configure api_key")
 		}
 		lister = llm.NewXAIProvider(apiKey, providerCfg.Model)
+	case config.ProviderTypeVenice:
+		apiKey := providerCfg.ResolvedAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("VENICE_API_KEY")
+		}
+		if apiKey == "" {
+			return fmt.Errorf("Venice API key not configured. Set VENICE_API_KEY or configure api_key")
+		}
+		lister = llm.NewVeniceProvider(apiKey, providerCfg.Model)
 	}
 
 	// Copilot may need interactive device auth (up to 5 minutes)

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -102,6 +102,13 @@ var builtinProviderMeta = map[string]struct {
 		supportsListModels: true,
 		description:        "xAI API (Grok models)",
 	},
+	"venice": {
+		credential:         "api_key",
+		envVar:             "VENICE_API_KEY",
+		requiresKey:        true,
+		supportsListModels: true,
+		description:        "Venice AI (private, uncensored inference — OpenAI-compatible)",
+	},
 }
 
 var providersCmd = &cobra.Command{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ const (
 	ProviderTypeClaudeBin    ProviderType = "claude-bin"
 	ProviderTypeOpenAICompat ProviderType = "openai_compatible"
 	ProviderTypeXAI          ProviderType = "xai"
+	ProviderTypeVenice       ProviderType = "venice"
 )
 
 // builtInProviderTypes maps known provider names to their types
@@ -39,6 +40,7 @@ var builtInProviderTypes = map[string]ProviderType{
 	"zen":        ProviderTypeZen,
 	"claude-bin": ProviderTypeClaudeBin,
 	"xai":        ProviderTypeXAI,
+	"venice":     ProviderTypeVenice,
 }
 
 // InferProviderType returns the provider type for a given provider name
@@ -1024,6 +1026,7 @@ func GetDefaults() map[string]any {
 		"providers.anthropic.model":      "claude-sonnet-4-6",
 		"providers.openai.model":         "gpt-5.2",
 		"providers.xai.model":            "grok-4-1-fast",
+		"providers.venice.model":         "venice-uncensored",
 		"providers.openrouter.model":     "x-ai/grok-code-fast-1",
 		"providers.openrouter.app_url":   "https://github.com/samsaffron/term-llm",
 		"providers.openrouter.app_title": "term-llm",

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -95,6 +95,13 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 			}
 			provider := NewXAIProvider(apiKey, model)
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
+		case config.ProviderTypeVenice:
+			apiKey := os.Getenv("VENICE_API_KEY")
+			if apiKey == "" {
+				return nil, fmt.Errorf("provider %q requires VENICE_API_KEY or explicit config", name)
+			}
+			provider := NewVeniceProvider(apiKey, model)
+			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		case config.ProviderTypeGemini:
 			// gemini can use GEMINI_API_KEY env var
 			apiKey := os.Getenv("GEMINI_API_KEY")
@@ -170,6 +177,12 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 				return nil, fmt.Errorf("provider %q requires XAI_API_KEY environment variable or explicit config", cfg.DefaultProvider)
 			}
 			return NewXAIProvider(apiKey, ""), nil
+		case config.ProviderTypeVenice:
+			apiKey := os.Getenv("VENICE_API_KEY")
+			if apiKey == "" {
+				return nil, fmt.Errorf("provider %q requires VENICE_API_KEY environment variable or explicit config", cfg.DefaultProvider)
+			}
+			return NewVeniceProvider(apiKey, ""), nil
 		case config.ProviderTypeChatGPT:
 			// chatgpt uses native OAuth with interactive authentication
 			return NewChatGPTProvider("")
@@ -248,6 +261,13 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 			apiKey = os.Getenv("XAI_API_KEY")
 		}
 		return NewXAIProvider(apiKey, cfg.Model), nil
+
+	case config.ProviderTypeVenice:
+		apiKey := cfg.ResolvedAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("VENICE_API_KEY")
+		}
+		return NewVeniceProvider(apiKey, cfg.Model), nil
 
 	case config.ProviderTypeClaudeBin:
 		return NewClaudeBinProvider(cfg.Model), nil

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -123,6 +123,42 @@ var ProviderModels = map[string][]string{
 		// Grok 2
 		"grok-2",
 	},
+	"venice": {
+		"venice-uncensored",
+		"olafangensan-glm-4.7-flash-heretic",
+		"zai-org-glm-4.7-flash",
+		"zai-org-glm-5",
+		"zai-org-glm-4.7",
+		"qwen3-4b",
+		"mistral-31-24b",
+		"qwen3-235b-a22b-thinking-2507",
+		"qwen3-235b-a22b-instruct-2507",
+		"qwen3-next-80b",
+		"qwen3-coder-480b-a35b-instruct",
+		"hermes-3-llama-3.1-405b",
+		"google-gemma-3-27b-it",
+		"grok-41-fast",
+		"gemini-3-pro-preview",
+		"gemini-3-1-pro-preview",
+		"gemini-3-flash-preview",
+		"claude-opus-4-6",
+		"claude-opus-45",
+		"claude-sonnet-4-6",
+		"claude-sonnet-45",
+		"openai-gpt-oss-120b",
+		"kimi-k2-thinking",
+		"kimi-k2-5",
+		"deepseek-v3.2",
+		"llama-3.2-3b",
+		"llama-3.3-70b",
+		"openai-gpt-52",
+		"openai-gpt-52-codex",
+		"openai-gpt-53-codex",
+		"minimax-m21",
+		"minimax-m25",
+		"grok-code-fast-1",
+		"qwen3-vl-235b-a22b",
+	},
 }
 
 var ImageProviderModels = map[string][]string{
@@ -162,7 +198,7 @@ func ExpandWithEffortVariants(models []string) []string {
 
 // GetBuiltInProviderNames returns the built-in provider type names
 func GetBuiltInProviderNames() []string {
-	return []string{"anthropic", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai"}
+	return []string{"anthropic", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice"}
 }
 
 // GetProviderNames returns valid provider names from config plus built-in types.

--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -1,0 +1,21 @@
+package llm
+
+import "context"
+
+const veniceBaseURL = "https://api.venice.ai/api/v1"
+
+type VeniceProvider struct {
+	*OpenAICompatProvider
+}
+
+func NewVeniceProvider(apiKey, model string) *VeniceProvider {
+	if model == "" {
+		model = "venice-uncensored"
+	}
+	return &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(veniceBaseURL, apiKey, model, "Venice")}
+}
+
+func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error) {
+	req.ParallelToolCalls = false
+	return p.OpenAICompatProvider.Stream(ctx, req)
+}


### PR DESCRIPTION
## Summary
- add Venice provider wiring and defaults
- expose Venice models/metadata in provider/model listings
- disable parallel tool calls for Venice's OpenAI-compatible API

## Testing
- `go build ./...`
- `go test ./...`
- `VENICE_API_KEY=VENICE-INFERENCE-KEY-1clyKi3DKi5_C0T9kkhFROowvMF6qhO9hHhrA2Qjxx ./term-llm ask --provider venice "say hello in one sentence"`

Output:
```
Hello! It's great to meet you.
```

- `VENICE_API_KEY=VENICE-INFERENCE-KEY-1clyKi3DKi5_C0T9kkhFROowvMF6qhO9hHhrA2Qjxx ./term-llm models --provider venice`

Output:
```
Available models from venice:

  venice-uncensored
  olafangensan-glm-4.7-flash-heretic
  zai-org-glm-4.7-flash
  zai-org-glm-5
  zai-org-glm-4.7
  qwen3-4b
  mistral-31-24b
  qwen3-235b-a22b-thinking-2507
  qwen3-235b-a22b-instruct-2507
  qwen3-next-80b
  qwen3-coder-480b-a35b-instruct
  hermes-3-llama-3.1-405b
  google-gemma-3-27b-it
  grok-41-fast [192K input]
  gemini-3-pro-preview [936K input]
  gemini-3-1-pro-preview
  gemini-3-flash-preview [983K input]
  claude-opus-4-6 [136K input]
  claude-opus-45 [168K input]
  claude-sonnet-4-6 [136K input]
  claude-sonnet-45 [136K input]
  openai-gpt-oss-120b
  kimi-k2-thinking
  kimi-k2-5
  deepseek-v3.2
  llama-3.2-3b
  llama-3.3-70b
  openai-gpt-52
  openai-gpt-52-codex
  openai-gpt-53-codex
  minimax-m21
  minimax-m25
  grok-code-fast-1 [246K input]
  qwen3-vl-235b-a22b

To use a model, add to your config:
  providers:
    venice:
    model: <model-name>
```
