### PR TITLE
FIX: use getRandomValues fallback for crypto.randomUUID on HTTP

### DIFF
--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -962,7 +962,24 @@
       });
 
       // ===== Helpers =====
-      const generateId = (prefix) => `${prefix}_${crypto.randomUUID()}`;
+      // crypto.randomUUID() requires a secure context (HTTPS); use getRandomValues fallback for HTTP
+      const generateUUID = () => {
+        if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+          return crypto.randomUUID();
+        }
+        // Works on HTTP — getRandomValues is not restricted to secure contexts
+        if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+          return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+          );
+        }
+        // Last resort
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+          const r = Math.random() * 16 | 0;
+          return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+        });
+      };
+      const generateId = (prefix) => `${prefix}_${generateUUID()}`;
 
       const truncate = (text, max = 60) => {
         const value = (text || '').trim().replace(/\s+/g, ' ');
@@ -1080,7 +1097,7 @@
           : [];
 
         return {
-          id: typeof session.id === 'string' ? session.id : `sess_${crypto.randomUUID()}`,
+          id: typeof session.id === 'string' ? session.id : `sess_${generateUUID()}`,
           title: typeof session.title === 'string' && session.title.trim() ? session.title.trim() : 'New chat',
           created: asTimestamp(session.created),
           messages
@@ -1114,7 +1131,7 @@
       const getActiveSession = () => state.sessions.find((s) => s.id === state.activeSessionId) || null;
 
       const createSession = () => ({
-        id: `sess_${crypto.randomUUID()}`,
+        id: `sess_${generateUUID()}`,
         title: 'New chat',
         created: Date.now(),
         messages: []


### PR DESCRIPTION
## What

Replace all `crypto.randomUUID()` calls with a `generateUUID()` helper that has two fallbacks:

1. `crypto.getRandomValues()` — available on HTTP (not restricted to secure contexts), produces a proper UUID v4
2. `Math.random()` — last resort, fine for session IDs

## Why

`crypto.randomUUID()` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or localhost). The web UI is served over plain HTTP on the local network, causing `crypto.randomUUID is not a function`.

`crypto.getRandomValues()` has no such restriction and is universally supported.
