### PR TITLE
fix: propagate ForceExternalSearch to spawn_agent child requests

### DIFF
--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -268,11 +268,12 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 
 	// Build request
 	req := llm.Request{
-		SessionID:         childSessionID,
-		Messages:          messages,
-		Search:            agent.Search,
-		ParallelToolCalls: true,
-		MaxTurns:          maxTurns,
+		SessionID:           childSessionID,
+		Messages:            messages,
+		Search:              agent.Search,
+		ForceExternalSearch: resolveForceExternalSearch(cfg, false, false),
+		ParallelToolCalls:   true,
+		MaxTurns:            maxTurns,
 	}
 
 	// Add tools if any


### PR DESCRIPTION
## What

Adds `ForceExternalSearch: resolveForceExternalSearch(cfg, false, false)` to the `llm.Request` built in `runAgentInternal` in `cmd/spawn_runner.go`.

## Why

Sub-agents spawned via `spawn_agent` were failing with Anthropic 400 "Tool names must be unique" when the target agent had `search: true` (e.g. the builtin `researcher` agent).

**Root cause:** When `search.force_external: true` is set in config (which routes search through Brave/external instead of Anthropic native), all other entry points (`ask.go`, `chat.go`, `serve.go`, etc.) call `resolveForceExternalSearch(cfg, ...)` and set `req.ForceExternalSearch = true`. This causes `engine.go` to:
1. Use the external `web_search` tool (not Anthropic native)
2. Set `req.Search = false` before the provider sees it, preventing `streamWithSearch`

`spawn_runner.go` was missing this field. So child agents with `search: true` hit `streamWithSearch`, which prepends Anthropic's native `BetaWebSearchTool20250305` (named `"web_search"`) on top of the external `web_search` tool already present in `req.Tools` from `ToolSpecsForRequest` → duplicate tool name → Anthropic 400.

## Fix

One field addition to the `req` struct literal. `resolveForceExternalSearch` is already in the `cmd` package.
