### PR TITLE
DEV: add {{platform}} template variable to system prompts

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -198,6 +198,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        askSearch,
 		Files:         askFiles,
+		Platform:      "console",
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
 	if err != nil {
 		return err

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -151,6 +151,7 @@ func runChat(cmd *cobra.Command, args []string) error {
 		MaxTurns:      chatMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        chatSearch,
+		Platform:      "chat",
 	}, cfg.Chat.Provider, cfg.Chat.Model, cfg.Chat.Instructions, cfg.Chat.MaxTurns, 200)
 	if err != nil {
 		return err

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -208,7 +208,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MaxTurns:      serveMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        serveSearch,
-		Platform:      strings.Join(platformNames, "+"),
+		Platform:      singlePlatformName(platformNames),
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
 	if err != nil {
 		return err
@@ -444,6 +444,23 @@ func platformContains(platforms []string, name string) bool {
 		}
 	}
 	return false
+}
+
+// singlePlatformName returns the platform name when exactly one non-jobs platform
+// is being served, so the system prompt knows which surface it's on.
+// Returns empty string for multi-platform serves — the system prompt is shared
+// across all surfaces and can't reflect a single one.
+func singlePlatformName(platforms []string) string {
+	var nonJobs []string
+	for _, p := range platforms {
+		if p != "jobs" {
+			nonJobs = append(nonJobs, p)
+		}
+	}
+	if len(nonJobs) == 1 {
+		return nonJobs[0]
+	}
+	return ""
 }
 
 func authSummary(required bool) string {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -208,7 +208,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MaxTurns:      serveMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        serveSearch,
-		Platform:      singlePlatformName(platformNames),
+		// Platform intentionally omitted — {{platform}} is expanded per-session
+		// by platformFactory so each surface (telegram, web) gets the right value.
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
 	if err != nil {
 		return err
@@ -230,20 +231,26 @@ func runServe(cmd *cobra.Command, args []string) error {
 	forceExternalSearch := resolveForceExternalSearch(cfg, serveNativeSearch, serveNoNativeSearch)
 
 	modelName := activeModel(cfg)
-	factory := func(ctx context.Context) (*serveRuntime, error) {
+	// platformFactory creates a runtime for a specific platform surface.
+	// It substitutes {{platform}} in the system prompt at session-creation time
+	// so each conversation knows which surface it's on (telegram, web, etc.).
+	platformFactory := func(ctx context.Context, platform string) (*serveRuntime, error) {
 		provider, err := llm.NewProvider(cfg)
 		if err != nil {
 			return nil, err
 		}
-		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, serveYolo, WireSpawnAgentRunner)
+		// Substitute {{platform}} now that we know the surface.
+		ps := settings
+		ps.SystemPrompt = strings.ReplaceAll(settings.SystemPrompt, "{{platform}}", platform)
+		engine, toolMgr, err := newServeEngineWithTools(cfg, ps, provider, serveYolo, WireSpawnAgentRunner)
 		if err != nil {
 			return nil, err
 		}
 
 		var mcpManager *mcp.Manager
-		if settings.MCP != "" {
+		if ps.MCP != "" {
 			mcpOpts := &MCPOptions{Provider: provider, Model: modelName, YoloMode: serveYolo}
-			mgr, err := enableMCPServersWithFeedback(ctx, settings.MCP, engine, io.Discard, mcpOpts)
+			mgr, err := enableMCPServersWithFeedback(ctx, ps.MCP, engine, io.Discard, mcpOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -255,20 +262,24 @@ func runServe(cmd *cobra.Command, args []string) error {
 			engine:              engine,
 			toolMgr:             toolMgr,
 			mcpManager:          mcpManager,
-			systemPrompt:        settings.SystemPrompt,
-			search:              settings.Search,
+			systemPrompt:        ps.SystemPrompt,
+			search:              ps.Search,
 			forceExternalSearch: forceExternalSearch,
-			maxTurns:            settings.MaxTurns,
+			maxTurns:            ps.MaxTurns,
 			debug:               serveDebug,
 			debugRaw:            debugRaw,
 			defaultModel:        modelName,
 			store:               store,
-			toolsSetting:        settings.Tools,
-			mcpSetting:          settings.MCP,
+			toolsSetting:        ps.Tools,
+			mcpSetting:          ps.MCP,
 			agentName:           agentName,
 		}
 		runtime.Touch()
 		return runtime, nil
+	}
+	// factory is the web-platform session factory (platform = "web").
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		return platformFactory(ctx, "web")
 	}
 
 	sessionMgr := newServeSessionManager(serveSessionTTL, serveSessionMax, factory)
@@ -293,7 +304,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Agent:                  agentName,
 		Store:                  store,
 		NewSession: func(ctx context.Context) (*serve.SessionRuntime, error) {
-			rt, err := factory(ctx)
+			rt, err := platformFactory(ctx, "telegram")
 			if err != nil {
 				return nil, err
 			}
@@ -446,22 +457,7 @@ func platformContains(platforms []string, name string) bool {
 	return false
 }
 
-// singlePlatformName returns the platform name when exactly one non-jobs platform
-// is being served, so the system prompt knows which surface it's on.
-// Returns empty string for multi-platform serves — the system prompt is shared
-// across all surfaces and can't reflect a single one.
-func singlePlatformName(platforms []string) string {
-	var nonJobs []string
-	for _, p := range platforms {
-		if p != "jobs" {
-			nonJobs = append(nonJobs, p)
-		}
-	}
-	if len(nonJobs) == 1 {
-		return nonJobs[0]
-	}
-	return ""
-}
+
 
 func authSummary(required bool) string {
 	if required {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -208,6 +208,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MaxTurns:      serveMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        serveSearch,
+		Platform:      strings.Join(platformNames, "+"),
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
 	if err != nil {
 		return err

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -68,6 +68,7 @@ type CLIFlags struct {
 	MaxTurnsSet   bool // true if --max-turns was explicitly set
 	Search        bool
 	Files         []string // files passed via -f flag, used for agent template expansion (e.g., {{.Files}})
+	Platform      string   // runtime surface: "telegram", "web", "chat", "console", or empty
 }
 
 // LoadAgent loads and validates an agent by name or path.
@@ -198,7 +199,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 
 	// System prompt: CLI > agent > config
 	if cli.SystemMessage != "" {
-		templateCtx := agents.NewTemplateContextForTemplate(cli.SystemMessage).WithFiles(cli.Files)
+		templateCtx := agents.NewTemplateContextForTemplate(cli.SystemMessage).WithFiles(cli.Files).WithPlatform(cli.Platform)
 		cwd, err := systemPromptCWDBaseDir()
 		if err != nil {
 			return s, err
@@ -213,6 +214,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 		if err != nil {
 			return s, fmt.Errorf("prepare agent system prompt context: %w", err)
 		}
+		templateCtx = templateCtx.WithPlatform(cli.Platform)
 		expanded, err := expandSystemPromptWithIncludes(agent.SystemPrompt, templateCtx, includeBaseDir)
 		if err != nil {
 			return s, fmt.Errorf("expand agent system prompt: %w", err)
@@ -226,7 +228,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 			}
 		}
 	} else {
-		templateCtx := agents.NewTemplateContextForTemplate(configInstructions).WithFiles(cli.Files)
+		templateCtx := agents.NewTemplateContextForTemplate(configInstructions).WithFiles(cli.Files).WithPlatform(cli.Platform)
 		cwd, err := systemPromptCWDBaseDir()
 		if err != nil {
 			return s, err

--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -40,6 +40,11 @@ type TemplateContext struct {
 	// Agent context
 	ResourceDir string // Directory containing agent resources (for builtin agents)
 
+	// Platform context
+	// Identifies the runtime surface: "telegram", "web", "chat", "console", or empty.
+	// Set at startup by serve/ask/chat commands; empty when not applicable.
+	Platform string
+
 	// Project agent instructions (dynamically discovered)
 	// Searches in priority order: AGENTS.md, CLAUDE.md, .github/copilot-instructions.md,
 	// .cursor/rules, CONTRIBUTING.md - returns first found
@@ -129,6 +134,12 @@ func (c TemplateContext) WithResourceDir(resourceDir string) TemplateContext {
 	return c
 }
 
+// WithPlatform sets the platform identifier (e.g. "telegram", "web", "chat", "console").
+func (c TemplateContext) WithPlatform(platform string) TemplateContext {
+	c.Platform = platform
+	return c
+}
+
 // ExpandTemplate replaces {{variable}} placeholders with values from context.
 func ExpandTemplate(text string, ctx TemplateContext) string {
 	// Match {{variable}} patterns
@@ -169,6 +180,8 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 			return ctx.OS
 		case "resource_dir":
 			return ctx.ResourceDir
+		case "platform":
+			return ctx.Platform
 		case "agents":
 			return ctx.Agents
 		default:

--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -181,6 +181,10 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 		case "resource_dir":
 			return ctx.ResourceDir
 		case "platform":
+			// Leave unexpanded when platform is unknown — caller will substitute later.
+			if ctx.Platform == "" {
+				return match
+			}
 			return ctx.Platform
 		case "agents":
 			return ctx.Agents

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -136,10 +136,10 @@ func TestTemplateContext_WithPlatform(t *testing.T) {
 		t.Errorf("Original Platform should be empty, got %q", ctx.Platform)
 	}
 
-	// Empty platform — variable expands to empty string
+	// Empty platform — variable is left unexpanded (deferred for per-session substitution)
 	result := ExpandTemplate("platform: {{platform}}", TemplateContext{})
-	if result != "platform: " {
-		t.Errorf("ExpandTemplate with empty platform = %q, want %q", result, "platform: ")
+	if result != "platform: {{platform}}" {
+		t.Errorf("ExpandTemplate with empty platform = %q, want %q", result, "platform: {{platform}}")
 	}
 }
 

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -22,6 +22,7 @@ func TestExpandTemplate(t *testing.T) {
 		FileCount:   "2",
 		OS:          "linux",
 		ResourceDir: "/home/user/.cache/term-llm/agents/artist",
+		Platform:    "telegram",
 	}
 
 	tests := []struct {
@@ -51,9 +52,15 @@ func TestExpandTemplate(t *testing.T) {
 		},
 		{
 			name:     "all variables",
-			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{resource_dir}}",
-			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux /home/user/.cache/term-llm/agents/artist",
+			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{resource_dir}} {{platform}}",
+			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux /home/user/.cache/term-llm/agents/artist telegram",
 		},
+		{
+			name:     "platform variable",
+			template: "Running on {{platform}}",
+			expected: "Running on telegram",
+		},
+
 		{
 			name:     "resource_dir variable",
 			template: "Read styles at {{resource_dir}}/styles.md",
@@ -112,6 +119,27 @@ func TestNewTemplateContext(t *testing.T) {
 	// Check that cwd is populated (should be valid in test)
 	if ctx.Cwd == "" {
 		t.Error("Cwd should not be empty")
+	}
+}
+
+func TestTemplateContext_WithPlatform(t *testing.T) {
+	ctx := TemplateContext{}
+
+	// Set platform
+	ctx2 := ctx.WithPlatform("telegram")
+	if ctx2.Platform != "telegram" {
+		t.Errorf("Platform = %q, want %q", ctx2.Platform, "telegram")
+	}
+
+	// Original unchanged
+	if ctx.Platform != "" {
+		t.Errorf("Original Platform should be empty, got %q", ctx.Platform)
+	}
+
+	// Empty platform — variable expands to empty string
+	result := ExpandTemplate("platform: {{platform}}", TemplateContext{})
+	if result != "platform: " {
+		t.Errorf("ExpandTemplate with empty platform = %q, want %q", result, "platform: ")
 	}
 }
 


### PR DESCRIPTION
Adds `{{platform}}` as a template variable available in any system prompt (`system.md`, `--system`, or `ask.instructions`).

## What

Populates from the active command surface at startup:

| Surface | Value |
|---|---|
| `term-llm serve --platform telegram` | `telegram` |
| `term-llm serve --platform web` | `web` |
| `term-llm serve --platform telegram,web` | `telegram+web` |
| `term-llm chat` | `chat` |
| `term-llm ask` | `console` |

Expands to empty string when not set (e.g. spawn_runner).

## Why

Agents that serve multiple surfaces (Telegram, web UI, console) can't currently tailor their system prompt per platform without separate agent configs. `{{platform}}` lets a single `system.md` branch on surface without touching built-in agents or adding new flags.

Usage in `system.md`:

```
Current platform: {{platform}}
```

## Changes

- `internal/agents/template.go` — `Platform` field on `TemplateContext`; `WithPlatform()` builder; `{{platform}}` case in `ExpandTemplate`
- `cmd/session.go` — `Platform` field on `CLIFlags`; `.WithPlatform(cli.Platform)` at all three template construction sites
- `cmd/serve.go` — passes `strings.Join(platformNames, "+")` (handles multi-platform e.g. `telegram+web`)
- `cmd/ask.go` — passes `"console"`
- `cmd/chat.go` — passes `"chat"`
- `internal/agents/template_test.go` — tests for expansion and `WithPlatform`
