### PR TITLE
FIX: validate jobs args and add active runs command

### DIFF
--- a/cmd/jobs_test.go
+++ b/cmd/jobs_test.go
@@ -3,11 +3,17 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNormalizeJSONPayload_YAML(t *testing.T) {
@@ -80,4 +86,185 @@ func TestJobsClientDo_ParsesOpenAIError(t *testing.T) {
 	if err.Error() != "bad request" {
 		t.Fatalf("err = %q, want bad request", err.Error())
 	}
+}
+
+func TestJobsCommandsRejectExtraArgs(t *testing.T) {
+	if err := jobsCmd.Args(jobsCmd, []string{"running"}); err == nil {
+		t.Fatalf("expected jobs command to reject extra args")
+	}
+	if err := jobsListCmd.Args(jobsListCmd, []string{"unexpected"}); err == nil {
+		t.Fatalf("expected jobs list command to reject extra args")
+	}
+}
+
+func TestRunJobsActive_JSONFiltersActiveRunsAndUsesPagedRequests(t *testing.T) {
+	requests := make([]string, 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/v2/jobs":
+			_, _ = w.Write([]byte(`{"data":[{"id":"job_alpha","name":"alpha"},{"id":"job_beta","name":"beta"}]}`))
+		case "/v2/runs":
+			jobID := r.URL.Query().Get("job_id")
+			offset := r.URL.Query().Get("offset")
+			limit := r.URL.Query().Get("limit")
+			if limit != "10" {
+				t.Fatalf("limit = %s, want 10", limit)
+			}
+			switch {
+			case jobID == "job_alpha" && offset == "0":
+				_, _ = w.Write([]byte(`{"data":[
+					{"id":"run_running","job_id":"job_alpha","status":"running","started_at":"2026-02-27T15:04:05Z","scheduled_for":"2026-02-27T15:00:00Z","worker_id":"worker-1"},
+					{"id":"run_done","job_id":"job_alpha","status":"succeeded","scheduled_for":"2026-02-27T14:00:00Z"}
+				]}`))
+			case jobID == "job_alpha" && offset == "10":
+				_, _ = w.Write([]byte(`{"data":[
+					{"id":"run_queued","job_id":"job_alpha","status":"queued","scheduled_for":"2026-02-27T13:00:00Z"}
+				]}`))
+			case jobID == "job_alpha" && offset == "20":
+				_, _ = w.Write([]byte(`{"data":[]}`))
+			case jobID == "job_beta" && offset == "0":
+				_, _ = w.Write([]byte(`{"data":[
+					{"id":"run_failed","job_id":"job_beta","status":"failed","scheduled_for":"2026-02-27T12:00:00Z"}
+				]}`))
+			default:
+				t.Fatalf("unexpected runs request: %s", r.URL.RequestURI())
+			}
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	oldServerURL := jobsServerURL
+	oldToken := jobsToken
+	oldTimeout := jobsTimeout
+	oldJSON := jobsJSON
+	jobsServerURL = srv.URL
+	jobsToken = ""
+	jobsTimeout = 2 * time.Second
+	jobsJSON = true
+	t.Cleanup(func() {
+		jobsServerURL = oldServerURL
+		jobsToken = oldToken
+		jobsTimeout = oldTimeout
+		jobsJSON = oldJSON
+	})
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runJobsActive(cmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runJobsActive failed: %v", runErr)
+	}
+
+	var runs []jobsActiveRun
+	if err := json.Unmarshal([]byte(output), &runs); err != nil {
+		t.Fatalf("decode output: %v\noutput=%s", err, output)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("len(runs) = %d, want 2", len(runs))
+	}
+	if runs[0].RunID != "run_running" || runs[0].Status != jobsV2RunRunning || runs[0].JobName != "alpha" {
+		t.Fatalf("unexpected first active run: %+v", runs[0])
+	}
+	if runs[1].RunID != "run_queued" || runs[1].Status != jobsV2RunQueued || runs[1].JobName != "alpha" {
+		t.Fatalf("unexpected second active run: %+v", runs[1])
+	}
+
+	expectedRequests := []string{
+		"/v2/jobs?limit=500",
+		"/v2/runs?limit=10&offset=0&job_id=job_alpha",
+		"/v2/runs?limit=10&offset=10&job_id=job_alpha",
+		"/v2/runs?limit=10&offset=20&job_id=job_alpha",
+		"/v2/runs?limit=10&offset=0&job_id=job_beta",
+	}
+	if !reflect.DeepEqual(requests, expectedRequests) {
+		t.Fatalf("requests = %#v, want %#v", requests, expectedRequests)
+	}
+}
+
+func TestRunJobsActive_TableOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/jobs":
+			_, _ = w.Write([]byte(`{"data":[{"id":"job_alpha","name":"alpha"}]}`))
+		case "/v2/runs":
+			offset := r.URL.Query().Get("offset")
+			if offset == "0" {
+				_, _ = w.Write([]byte(`{"data":[{"id":"run_queued","job_id":"job_alpha","status":"queued","scheduled_for":"2026-02-27T13:00:00Z"}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	oldServerURL := jobsServerURL
+	oldToken := jobsToken
+	oldTimeout := jobsTimeout
+	oldJSON := jobsJSON
+	jobsServerURL = srv.URL
+	jobsToken = ""
+	jobsTimeout = 2 * time.Second
+	jobsJSON = false
+	t.Cleanup(func() {
+		jobsServerURL = oldServerURL
+		jobsToken = oldToken
+		jobsTimeout = oldTimeout
+		jobsJSON = oldJSON
+	})
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runJobsActive(cmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runJobsActive failed: %v", runErr)
+	}
+	if !strings.Contains(output, "JOB_ID") || !strings.Contains(output, "RUN_ID") {
+		t.Fatalf("expected table header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "run_queued") || !strings.Contains(output, "job_alpha") {
+		t.Fatalf("expected row in output, got: %s", output)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+	return string(out)
 }


### PR DESCRIPTION
## Summary
- prevent misleading fallback where extra args to `term-llm jobs` or `term-llm jobs list` silently listed jobs
- add `term-llm jobs active` to show active runs (`queued`, `claimed`, `running`) across all jobs
- include default table output and `--json` output with fields: `job_id`, `job_name`, `run_id`, `status`, `started_at`, `scheduled_for`, `worker_id`

## Implementation details
- `jobs` and `jobs list` now use `cobra.NoArgs`
- `jobs active` uses existing `/v2/jobs` + `/v2/runs` endpoints (no server API changes)
- active runs are gathered by listing jobs once, then paging each job's runs in small pages (`limit=10`) and stopping for that job when a page has no active statuses
- output is sorted by `scheduled_for` descending for stable display

## Tests
- added arg-validation test for `jobs` and `jobs list`
- added `httptest`-backed tests for `jobs active` to assert:
  - request paths/query params and pagination behavior
  - filtering to active statuses only
  - JSON output fields
  - default table output

## Verification
- `gofmt -w .`
- `go test ./...`
- `go build ./...`
