### PR TITLE
Expand {{platform}} template token

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -198,6 +198,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        askSearch,
 		Files:         askFiles,
+		Platform:      "console",
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
 	if err != nil {
 		return err

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -193,6 +193,7 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 		MaxTurns:      chatMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        chatSearch,
+		Platform:      "chat",
 	}, cfg.Chat.Provider, cfg.Chat.Model, cfg.Chat.Instructions, cfg.Chat.MaxTurns, 200)
 	if err != nil {
 		return "", err

--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -247,6 +247,7 @@ func runLoop(cmd *cobra.Command, args []string) error {
 		MaxTurns:      loopMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        loopSearch,
+		Platform:      "console",
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 100)
 	if err != nil {
 		return err

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -300,8 +300,9 @@ func runChatFromPlan(cfg *config.Config, planContent string, agentName string, m
 
 	// Resolve settings using agent configuration
 	cliFlags := CLIFlags{
-		Tools:  "all",
-		Search: searchEnabled,
+		Tools:    "all",
+		Search:   searchEnabled,
+		Platform: "chat",
 	}
 	settings, err := ResolveSettings(cfg, agent, cliFlags, cfg.Chat.Provider, cfg.Chat.Model, cfg.Chat.Instructions, cfg.Chat.MaxTurns, 200)
 	if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -211,6 +211,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MaxTurns:      serveMaxTurns,
 		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
 		Search:        serveSearch,
+		Platform:      singleServeTemplatePlatform(platformNames),
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
 	if err != nil {
 		return err
@@ -447,6 +448,26 @@ func platformContains(platforms []string, name string) bool {
 		}
 	}
 	return false
+}
+
+// singleServeTemplatePlatform returns a stable platform token for serve prompts.
+// If multiple runtime surfaces are selected (for example web+telegram), returns
+// empty so {{platform}} stays unexpanded and is not misleading.
+func singleServeTemplatePlatform(platforms []string) string {
+	unique := make(map[string]struct{})
+	for _, p := range platforms {
+		switch p {
+		case "web", "telegram", "jobs":
+			unique[p] = struct{}{}
+		}
+	}
+	if len(unique) != 1 {
+		return ""
+	}
+	for p := range unique {
+		return p
+	}
+	return ""
 }
 
 func authSummary(required bool) string {

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1791,6 +1791,7 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 			SystemMessage: serveSystemMessage,
 			MaxTurns:      serveMaxTurns,
 			Search:        serveSearch,
+			Platform:      "jobs",
 		}, jobCfg.Ask.Provider, jobCfg.Ask.Model, jobCfg.Ask.Instructions, jobCfg.Ask.MaxTurns, 20)
 		if err != nil {
 			return err

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -19,6 +19,29 @@ import (
 	"github.com/samsaffron/term-llm/internal/tools"
 )
 
+func TestSingleServeTemplatePlatform(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms []string
+		want      string
+	}{
+		{name: "web only", platforms: []string{"web"}, want: "web"},
+		{name: "telegram only", platforms: []string{"telegram"}, want: "telegram"},
+		{name: "jobs only", platforms: []string{"jobs"}, want: "jobs"},
+		{name: "web and telegram", platforms: []string{"web", "telegram"}, want: ""},
+		{name: "web and jobs", platforms: []string{"web", "jobs"}, want: ""},
+		{name: "unknown ignored", platforms: []string{"web", "foo"}, want: "web"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := singleServeTemplatePlatform(tt.platforms); got != tt.want {
+				t.Fatalf("singleServeTemplatePlatform(%v) = %q, want %q", tt.platforms, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseResponsesInput_String(t *testing.T) {
 	msgs, replaceHistory, err := parseResponsesInput(json.RawMessage(`"hello"`))
 	if err != nil {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -68,6 +68,7 @@ type CLIFlags struct {
 	MaxTurnsSet   bool // true if --max-turns was explicitly set
 	Search        bool
 	Files         []string // files passed via -f flag, used for agent template expansion (e.g., {{.Files}})
+	Platform      string   // runtime surface for template expansion (e.g., chat, console, web, telegram, jobs)
 }
 
 // LoadAgent loads and validates an agent by name or path.
@@ -198,7 +199,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 
 	// System prompt: CLI > agent > config
 	if cli.SystemMessage != "" {
-		templateCtx := agents.NewTemplateContextForTemplate(cli.SystemMessage).WithFiles(cli.Files)
+		templateCtx := agents.NewTemplateContextForTemplate(cli.SystemMessage).WithFiles(cli.Files).WithPlatform(cli.Platform)
 		cwd, err := systemPromptCWDBaseDir()
 		if err != nil {
 			return s, err
@@ -213,6 +214,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 		if err != nil {
 			return s, fmt.Errorf("prepare agent system prompt context: %w", err)
 		}
+		templateCtx = templateCtx.WithPlatform(cli.Platform)
 		expanded, err := expandSystemPromptWithIncludes(agent.SystemPrompt, templateCtx, includeBaseDir)
 		if err != nil {
 			return s, fmt.Errorf("expand agent system prompt: %w", err)
@@ -226,7 +228,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 			}
 		}
 	} else {
-		templateCtx := agents.NewTemplateContextForTemplate(configInstructions).WithFiles(cli.Files)
+		templateCtx := agents.NewTemplateContextForTemplate(configInstructions).WithFiles(cli.Files).WithPlatform(cli.Platform)
 		cwd, err := systemPromptCWDBaseDir()
 		if err != nil {
 			return s, err

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -105,6 +105,28 @@ func TestResolveSettings_MissingIncludeIsLeftUnchanged(t *testing.T) {
 	}
 }
 
+func TestResolveSettings_ExpandsPlatformTokenWhenProvided(t *testing.T) {
+	cfg := &config.Config{}
+	settings, err := ResolveSettings(cfg, nil, CLIFlags{Platform: "chat"}, "", "", "surface={{platform}}", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+	if settings.SystemPrompt != "surface=chat" {
+		t.Fatalf("SystemPrompt = %q, want %q", settings.SystemPrompt, "surface=chat")
+	}
+}
+
+func TestResolveSettings_LeavesPlatformTokenWhenPlatformUnavailable(t *testing.T) {
+	cfg := &config.Config{}
+	settings, err := ResolveSettings(cfg, nil, CLIFlags{}, "", "", "surface={{platform}}", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+	if settings.SystemPrompt != "surface={{platform}}" {
+		t.Fatalf("SystemPrompt = %q, want %q", settings.SystemPrompt, "surface={{platform}}")
+	}
+}
+
 func TestResolveSettings_AgentToolsAppliedWhenCLIToolsUnset(t *testing.T) {
 	cfg := &config.Config{}
 	agent := &agents.Agent{

--- a/internal/agents/builtin/agent-builder/system.md
+++ b/internal/agents/builtin/agent-builder/system.md
@@ -65,7 +65,7 @@ mcp:
 - `{{cwd}}`, `{{cwd_name}}`, `{{home}}`, `{{user}}`
 - `{{git_branch}}`, `{{git_repo}}`, `{{git_diff_stat}}`
 - `{{files}}`, `{{file_count}}` (from -f flags)
-- `{{os}}`, `{{resource_dir}}`
+- `{{os}}`, `{{platform}}`, `{{resource_dir}}`
 - `{{agents}}` - Auto-discovers project instructions (AGENTS.md, CLAUDE.md, etc.)
 
 **The `{{agents}}` variable** searches in priority order and returns the first found:

--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -37,6 +37,9 @@ type TemplateContext struct {
 	// System
 	OS string // Operating system
 
+	// Runtime surface (chat, console, web, telegram, jobs)
+	Platform string
+
 	// Agent context
 	ResourceDir string // Directory containing agent resources (for builtin agents)
 
@@ -129,6 +132,12 @@ func (c TemplateContext) WithResourceDir(resourceDir string) TemplateContext {
 	return c
 }
 
+// WithPlatform sets the runtime surface for {{platform}} token expansion.
+func (c TemplateContext) WithPlatform(platform string) TemplateContext {
+	c.Platform = strings.TrimSpace(platform)
+	return c
+}
+
 // ExpandTemplate replaces {{variable}} placeholders with values from context.
 func ExpandTemplate(text string, ctx TemplateContext) string {
 	// Match {{variable}} patterns
@@ -167,6 +176,12 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 			return ctx.FileCount
 		case "os":
 			return ctx.OS
+		case "platform":
+			if ctx.Platform == "" {
+				// Leave token untouched when platform context is unavailable.
+				return match
+			}
+			return ctx.Platform
 		case "resource_dir":
 			return ctx.ResourceDir
 		case "agents":

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -21,6 +21,7 @@ func TestExpandTemplate(t *testing.T) {
 		Files:       "main.go, utils.go",
 		FileCount:   "2",
 		OS:          "linux",
+		Platform:    "chat",
 		ResourceDir: "/home/user/.cache/term-llm/agents/artist",
 	}
 
@@ -40,6 +41,11 @@ func TestExpandTemplate(t *testing.T) {
 			expected: "testuser is working on term-llm (branch: main)",
 		},
 		{
+			name:     "platform variable",
+			template: "Platform: {{platform}}",
+			expected: "Platform: chat",
+		},
+		{
 			name:     "no variables",
 			template: "Just plain text",
 			expected: "Just plain text",
@@ -51,8 +57,8 @@ func TestExpandTemplate(t *testing.T) {
 		},
 		{
 			name:     "all variables",
-			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{resource_dir}}",
-			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux /home/user/.cache/term-llm/agents/artist",
+			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{platform}} {{resource_dir}}",
+			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux chat /home/user/.cache/term-llm/agents/artist",
 		},
 		{
 			name:     "resource_dir variable",
@@ -139,6 +145,25 @@ func TestTemplateContext_WithFiles(t *testing.T) {
 	}
 	if ctx3.Files != "" {
 		t.Errorf("Files = %q, want empty string", ctx3.Files)
+	}
+}
+
+func TestTemplateContext_WithPlatform(t *testing.T) {
+	ctx := TemplateContext{}
+
+	ctx2 := ctx.WithPlatform("chat")
+	if ctx2.Platform != "chat" {
+		t.Errorf("Platform = %q, want %q", ctx2.Platform, "chat")
+	}
+	if ctx.Platform != "" {
+		t.Errorf("Original Platform = %q, want empty", ctx.Platform)
+	}
+}
+
+func TestExpandTemplate_PlatformTokenUnchangedWhenUnavailable(t *testing.T) {
+	result := ExpandTemplate("Platform={{platform}}", TemplateContext{})
+	if result != "Platform={{platform}}" {
+		t.Fatalf("ExpandTemplate() = %q, want %q", result, "Platform={{platform}}")
 	}
 }
 


### PR DESCRIPTION
## Problem

`{{platform}}` in system prompts (e.g. Jarvis's `system.md`) is left unexpanded because:
- `TemplateContext` had no `Platform` field
- `ExpandTemplate` had no `"platform"` case in its switch

Result: the token hits `default:` and is returned as-is. Jarvis sees the literal string `{{platform}}` and guesses — incorrectly.

## Fix

- Add `Platform string` field to `TemplateContext`
- Add `WithPlatform()` method for chaining
- Add `"platform"` case to `ExpandTemplate` (leaves token untouched if `Platform` is empty — unknown context → no expansion, not a misleading value)
- Wire `Platform` through all execution paths: `chat`, `ask`, `loop`, `plan`, `serve` (web, telegram, jobs)
- Tests for template expansion and `ResolveSettings` platform propagation