### PR TITLE
fix: sanitize dangling tool calls for responses input

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -391,6 +391,10 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 // buildChatGPTInput converts Messages to the ChatGPT Responses API input format.
 // Returns the system instructions string and the input array.
 func buildChatGPTInput(messages []Message) (string, []interface{}) {
+	// ChatGPT Responses API requires every function_call to have a matching
+	// function_call_output in replayed history.
+	messages = sanitizeToolHistory(messages)
+
 	var systemParts []string
 	var input []interface{}
 

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -147,6 +147,11 @@ type responsesSSEEvent struct {
 
 // BuildResponsesInput converts []Message to Open Responses input format
 func BuildResponsesInput(messages []Message) []ResponsesInputItem {
+	// Responses-style APIs reject assistant function calls that do not have
+	// a matching function_call_output. This can happen when a tool call is
+	// interrupted (for example, user interjects before a long-running tool returns).
+	messages = sanitizeToolHistory(messages)
+
 	var inputItems []ResponsesInputItem
 
 	for _, msg := range messages {


### PR DESCRIPTION
## What

- Sanitized tool history before building ChatGPT Responses API input (`buildChatGPTInput`) so dangling assistant tool calls are removed if they have no matching tool output.
- Sanitized tool history before building generic Responses API input (`BuildResponsesInput`) used by OpenAI/Copilot responses flows.
- Added regression tests:
  - `TestBuildChatGPTInput_DropsDanglingToolCalls`
  - `TestBuildResponsesInput_DropsDanglingToolCalls`

## Why

A live session hit:

`API error (400): No tool output found for function call ...`

This happens when history contains an assistant `function_call` without a corresponding `function_call_output` (e.g. user interjects while a long-running tool call is still pending). Responses-style APIs reject this history.

## How

- Reused existing `sanitizeToolHistory(...)` helper (already used by other providers) in both input builders.
- Kept non-tool text intact while removing unmatched tool call/result items.
- Verified with full build and test run.
