### PR TITLE
feat: add Playwright + Chromium to base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,8 +48,22 @@ RUN pacman -Syu --noconfirm && \
       openbsd-netcat \
       strace \
       gnupg \
-      nvidia-utils && \
+      nvidia-utils \
+      uv \
+      nspr \
+      nss \
+      at-spi2-core \
+      libxcomposite \
+      libxdamage \
+      libxrandr \
+      libxkbcommon && \
     pacman -Scc --noconfirm
+
+# Playwright (Python) + Chromium headless shell — used by agent scripts for JS-heavy scraping.
+# Arch Linux isn't officially supported by playwright install-deps (apt-only), so we install
+# the required system libs above manually. Chromium goes to /root/.cache/ms-playwright/.
+RUN uv pip install playwright --system && \
+    playwright install chromium
 
 # Unprivileged user for AUR builds (makepkg refuses root)
 RUN useradd -m -G wheel aur && \


### PR DESCRIPTION
## What

Adds Playwright (Python) and a bundled Chromium headless shell to the base Docker image.

- 7 system libraries added to the pacman block (`nspr`, `nss`, `at-spi2-core`, `libxcomposite`, `libxdamage`, `libxrandr`, `libxkbcommon`) — these are the shared libs Playwright's bundled Chromium requires on Arch Linux
- `pip install playwright --break-system-packages` installs the Python package
- `playwright install chromium` downloads the headless shell to `/root/.cache/ms-playwright/`

## Why

Agent scripts (e.g. daily digest) use Playwright to scrape JS-heavy news sites (ABC News AU, N12, Al Arabiya). Without it baked in, those scrapers silently produce no output after every container rebuild — the world news section of the daily briefing was completely empty.

Arch Linux isn't in Playwright's official supported OS list so `playwright install-deps` doesn't work (it tries `apt-get`). The manual pacman approach is equivalent and confirmed working.

## Notes

- Playwright on Arch uses `--break-system-packages` flag for pip — intentional, we're root in a container
- Chromium binary lands in `/root/.cache/ms-playwright/` which is on the volume, so it persists across rebuilds
