### PR TITLE
feat: add --max-output-tokens flag to ask and loop commands

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -37,7 +37,8 @@ var (
 	askProvider       string
 	askFiles          []string
 	askMCP            string
-	askMaxTurns       int
+	askMaxTurns        int
+	askMaxOutputTokens int
 	askNativeSearch   bool
 	askNoNativeSearch bool
 	// Tool flags
@@ -97,6 +98,7 @@ func init() {
 	AddNativeSearchFlags(askCmd, &askNativeSearch, &askNoNativeSearch)
 	AddMCPFlag(askCmd, &askMCP)
 	AddMaxTurnsFlag(askCmd, &askMaxTurns, 20)
+	AddMaxOutputTokensFlag(askCmd, &askMaxOutputTokens)
 	AddToolFlags(askCmd, &askTools, &askReadDirs, &askWriteDirs, &askShellAllow)
 	AddSystemMessageFlag(askCmd, &askSystemMessage)
 	AddFileFlag(askCmd, &askFiles, "File(s) to include as context (supports globs, line ranges like file.go:10-20, 'clipboard')")
@@ -194,8 +196,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		ShellAllow:    askShellAllow,
 		MCP:           askMCP,
 		SystemMessage: askSystemMessage,
-		MaxTurns:      askMaxTurns,
-		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
+		MaxTurns:        askMaxTurns,
+		MaxTurnsSet:     cmd.Flags().Changed("max-turns"),
+		MaxOutputTokens: askMaxOutputTokens,
 		Search:        askSearch,
 		Files:         askFiles,
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 20)
@@ -409,6 +412,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		ForceExternalSearch: resolveForceExternalSearch(cfg, askNativeSearch, askNoNativeSearch),
 		ParallelToolCalls:   true,
 		MaxTurns:            settings.MaxTurns,
+		MaxOutputTokens:     settings.MaxOutputTokens,
 		Debug:               debugMode,
 		DebugRaw:            debugRaw,
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -63,6 +63,11 @@ func AddMaxTurnsFlag(cmd *cobra.Command, dest *int, defaultValue int) {
 	cmd.Flags().IntVar(dest, "max-turns", defaultValue, "Max agentic turns for tool execution")
 }
 
+// AddMaxOutputTokensFlag adds the --max-output-tokens flag
+func AddMaxOutputTokensFlag(cmd *cobra.Command, dest *int) {
+	cmd.Flags().IntVar(dest, "max-output-tokens", 0, "Maximum output tokens (0 = provider default)")
+}
+
 // AddToolFlags adds tool-related flags (--tools, --read-dir, --write-dir, --shell-allow)
 func AddToolFlags(cmd *cobra.Command, tools *string, readDirs, writeDirs, shellAllow *[]string) {
 	cmd.Flags().StringVar(tools, "tools", "", "Enable local tools (comma-separated, or 'all'): read_file,write_file,edit_file,shell,grep,glob,view_image,show_image,image_generate,ask_user,spawn_agent")

--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -24,7 +24,8 @@ var (
 	loopSearch         bool
 	loopProvider       string
 	loopMCP            string
-	loopMaxTurns       int
+	loopMaxTurns        int
+	loopMaxOutputTokens int
 	loopNativeSearch   bool
 	loopNoNativeSearch bool
 	// Tool flags
@@ -92,6 +93,7 @@ func init() {
 	AddNativeSearchFlags(loopCmd, &loopNativeSearch, &loopNoNativeSearch)
 	AddMCPFlag(loopCmd, &loopMCP)
 	AddMaxTurnsFlag(loopCmd, &loopMaxTurns, 100) // Higher default for loop
+	AddMaxOutputTokensFlag(loopCmd, &loopMaxOutputTokens)
 	AddToolFlags(loopCmd, &loopTools, &loopReadDirs, &loopWriteDirs, &loopShellAllow)
 	AddSystemMessageFlag(loopCmd, &loopSystemMessage)
 	AddAgentFlag(loopCmd, &loopAgent)
@@ -244,8 +246,9 @@ func runLoop(cmd *cobra.Command, args []string) error {
 		ShellAllow:    loopShellAllow,
 		MCP:           loopMCP,
 		SystemMessage: loopSystemMessage,
-		MaxTurns:      loopMaxTurns,
-		MaxTurnsSet:   cmd.Flags().Changed("max-turns"),
+		MaxTurns:        loopMaxTurns,
+		MaxTurnsSet:     cmd.Flags().Changed("max-turns"),
+		MaxOutputTokens: loopMaxOutputTokens,
 		Search:        loopSearch,
 	}, cfg.Ask.Provider, cfg.Ask.Model, cfg.Ask.Instructions, cfg.Ask.MaxTurns, 100)
 	if err != nil {
@@ -383,6 +386,7 @@ func runLoop(cmd *cobra.Command, args []string) error {
 			Search:              settings.Search,
 			ForceExternalSearch: forceExternalSearch,
 			MaxTurns:            settings.MaxTurns,
+			MaxOutputTokens:     settings.MaxOutputTokens,
 			Debug:               loopDebug,
 			DebugRaw:            debugRaw,
 		}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -51,8 +51,9 @@ type SessionSettings struct {
 	SystemPrompt string
 
 	// Behavior
-	MaxTurns int
-	Search   bool
+	MaxTurns        int
+	MaxOutputTokens int // 0 = use provider default
+	Search          bool
 }
 
 // CLIFlags holds the CLI flag values that can override settings.
@@ -64,9 +65,10 @@ type CLIFlags struct {
 	ShellAllow    []string
 	MCP           string
 	SystemMessage string
-	MaxTurns      int
-	MaxTurnsSet   bool // true if --max-turns was explicitly set
-	Search        bool
+	MaxTurns        int
+	MaxTurnsSet     bool // true if --max-turns was explicitly set
+	MaxOutputTokens int  // 0 = use provider default
+	Search          bool
 	Files         []string // files passed via -f flag, used for agent template expansion (e.g., {{.Files}})
 }
 
@@ -248,6 +250,9 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 	} else {
 		s.MaxTurns = defaultMaxTurns
 	}
+
+	// MaxOutputTokens: CLI only (no agent/config fallback — provider defaults are fine)
+	s.MaxOutputTokens = cli.MaxOutputTokens
 
 	// Search: CLI or agent enables it
 	s.Search = cli.Search || (agent != nil && agent.Search)


### PR DESCRIPTION
## What

Adds `--max-output-tokens <n>` flag to `ask` and `loop` commands.

```
term-llm ask --max-output-tokens 32000 "write me a very long document"
term-llm loop --max-output-tokens 16000 "..."
```

Zero (default) means use the provider's built-in default — no behaviour change for existing callers.

## Why

The immediate trigger: the daily digest script uses `term-llm ask --agent jarvis --max-turns 1` with Claude Sonnet 4.6 adaptive thinking. The `max_tokens` ceiling is 16K (shared between thinking tokens + output). For a complex summarisation task with large input context, the model burns ~10K tokens on thinking, leaving only ~6K for output — the digest was truncating mid-sentence.

The workaround is `--provider anthropic:claude-sonnet-4-6` (non-thinking), but `--max-output-tokens` is the proper fix — it lets callers explicitly request more output capacity when needed, or override the default for any reason.

## Scope

- `ask` and `loop` commands wired end-to-end: flag → `CLIFlags` → `SessionSettings` → `llm.Request.MaxOutputTokens`
- `serve` left for follow-up (routes through `internal/serve` which needs separate plumbing)
- `CLIFlags` and `SessionSettings` updated so future commands can trivially adopt the field
- All existing tests pass
