### PR TITLE
feat: record L1->L2 source backpointers when mining fragments

### DIFF
--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 )
 
 func TestParseExtractionOperations_PlainJSON(t *testing.T) {
@@ -34,5 +38,79 @@ func TestParseExtractionOperations_MarkdownFenceNoLang(t *testing.T) {
 	}
 	if len(ops) != 1 {
 		t.Fatalf("unexpected ops: %+v", ops)
+	}
+}
+
+func TestApplyExtractionOperations_AffectedPaths(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	store, err := memorydb.NewStore(memorydb.Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	defer store.Close()
+
+	agent := "jarvis"
+	if err := store.CreateFragment(ctx, &memorydb.Fragment{
+		Agent:   agent,
+		Path:    "fragments/existing.md",
+		Content: "old",
+		Source:  memorydb.DefaultSourceMine,
+	}); err != nil {
+		t.Fatalf("CreateFragment(existing) error = %v", err)
+	}
+
+	ops := []extractionOperation{
+		{Op: "create", Path: "fragments/new.md", Content: "new"},
+		{Op: "update", Path: "fragments/existing.md", Content: "existing updated"},
+		{Op: "update", Path: "fragments/missing.md", Content: "missing"},
+		{Op: "skip", Reason: "no durable memory"},
+		{Op: "create", Path: "fragments/dup.md", Content: "dup initial"},
+		{Op: "update", Path: "fragments/dup.md", Content: "dup updated"},
+	}
+
+	oldDryRun := memoryDryRun
+	memoryDryRun = false
+	t.Cleanup(func() { memoryDryRun = oldDryRun })
+
+	created, updated, skipped, affectedPaths, err := applyExtractionOperations(ctx, store, agent, ops)
+	if err != nil {
+		t.Fatalf("applyExtractionOperations() error = %v", err)
+	}
+	if created != 2 || updated != 2 || skipped != 2 {
+		t.Fatalf("counts = create=%d update=%d skip=%d, want 2/2/2", created, updated, skipped)
+	}
+
+	want := map[string]bool{
+		"fragments/new.md":      true,
+		"fragments/existing.md": true,
+		"fragments/dup.md":      true,
+	}
+	if len(affectedPaths) != len(want) {
+		t.Fatalf("affectedPaths len = %d, want %d (%v)", len(affectedPaths), len(want), affectedPaths)
+	}
+	seen := map[string]int{}
+	for _, p := range affectedPaths {
+		seen[p]++
+		if !want[p] {
+			t.Fatalf("affectedPaths contains unexpected path %q (%v)", p, affectedPaths)
+		}
+	}
+	for p := range want {
+		if seen[p] != 1 {
+			t.Fatalf("affected path %q count = %d, want 1 (%v)", p, seen[p], affectedPaths)
+		}
+	}
+
+	memoryDryRun = true
+	_, _, _, dryRunPaths, err := applyExtractionOperations(ctx, store, agent, []extractionOperation{
+		{Op: "create", Path: "fragments/dry-run-create.md", Content: "x"},
+		{Op: "update", Path: "fragments/existing.md", Content: "y"},
+	})
+	if err != nil {
+		t.Fatalf("applyExtractionOperations(dry-run) error = %v", err)
+	}
+	if len(dryRunPaths) != 0 {
+		t.Fatalf("affectedPaths in dry-run = %v, want empty", dryRunPaths)
 	}
 }


### PR DESCRIPTION
## What

Adds `memory_fragment_sources` — a many-to-many table linking each memory fragment (L1) back to the raw session turn range(s) it was mined from (L2).

Every time the session miner creates or updates a fragment it now writes a source record. One fragment can accumulate sources from multiple sessions over time.

## Why

Inspired by the HyMem architecture (arXiv 2602.13933). When retrieval surfaces a fragment, there is currently no way to backtrack to the original conversation for more context. These backpointers make that possible.

## Changes

- `internal/memory/store.go`: new `memory_fragment_sources` table + `FragmentSource` type + `AddFragmentSource`, `GetFragmentSources`, `GetSourcesForSession` methods. `DeleteFragment` and `DeleteFragmentByRowID` clean up sources in-transaction.
- `cmd/memory_mine.go`: `applyExtractionOperations` now returns `affectedPaths`; caller records a source row for each affected fragment after each mining batch.
- `cmd/memory_fragments.go`: new `sources` subcommand — `term-llm memory fragments sources <path-or-rowid>` shows the session backpointers for any fragment.
