### PR TITLE
fix: smooth interjection UX — clear on cancel, Esc to stop, empty-Enter hint

### DIFF
--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -453,6 +453,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if key.Matches(msg, m.keyMap.Send) {
 			content := strings.TrimSpace(m.textarea.Value())
 			if content == "" {
+				m.phase = "Type to interject, or press Esc to cancel"
 				return m, nil
 			}
 
@@ -469,7 +470,8 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case llm.InterruptCancel:
 				m.pendingInterjection = ""
 				m.queuedInterjection = ""
-				// Keep typed content so user can resend or edit after cancellation.
+				m.setTextareaValue("")
+				m.phase = "Stopping..."
 				if m.streamCancelFunc != nil {
 					m.streamCancelFunc()
 				}

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -32,3 +32,75 @@ func TestHandleKeyMsg_SessionListEnterResumesSession(t *testing.T) {
 		t.Fatalf("expected pending resume session ID %q, got %q", sessionID, rm.RequestedResumeSessionID())
 	}
 }
+
+func TestHandleKeyMsg_StreamingCancelInterjectionClearsComposerAndShowsStopping(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.phase = "Running shell sleep"
+	m.pendingInterjection = "old"
+	m.queuedInterjection = "old"
+	m.setTextareaValue("stop sleeping")
+
+	cancelCalls := 0
+	m.streamCancelFunc = func() {
+		cancelCalls++
+	}
+
+	_, _ = m.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cancelCalls != 1 {
+		t.Fatalf("expected stream cancel to be called once, got %d", cancelCalls)
+	}
+	if got := m.textarea.Value(); got != "" {
+		t.Fatalf("expected textarea to be cleared after cancel interjection, got %q", got)
+	}
+	if m.pendingInterjection != "" {
+		t.Fatalf("expected pendingInterjection to be cleared, got %q", m.pendingInterjection)
+	}
+	if m.queuedInterjection != "" {
+		t.Fatalf("expected queuedInterjection to be cleared, got %q", m.queuedInterjection)
+	}
+	if m.phase != "Stopping..." {
+		t.Fatalf("expected stopping phase after cancel interjection, got %q", m.phase)
+	}
+}
+
+func TestHandleKeyMsg_StreamingEnterOnEmptyComposerShowsHint(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.phase = "Thinking"
+	m.setTextareaValue("   ")
+
+	cancelCalls := 0
+	m.streamCancelFunc = func() {
+		cancelCalls++
+	}
+
+	_, _ = m.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cancelCalls != 0 {
+		t.Fatalf("expected empty enter to avoid cancellation, got %d cancel calls", cancelCalls)
+	}
+	if m.phase != "Type to interject, or press Esc to cancel" {
+		t.Fatalf("expected empty enter hint phase, got %q", m.phase)
+	}
+}
+
+func TestHandleKeyMsg_StreamingEscCancelsActiveStream(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+
+	cancelCalls := 0
+	m.streamCancelFunc = func() {
+		cancelCalls++
+	}
+
+	_, _ = m.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if cancelCalls != 1 {
+		t.Fatalf("expected esc to call stream cancel once, got %d", cancelCalls)
+	}
+	if m.streaming {
+		t.Fatal("expected esc to end streaming mode immediately")
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes interjection UX during active `term-llm chat` streams so users can cancel or interject with a single Enter and clear feedback.

### Root causes

1. **Cancel interjections left composer text in place**
   - In the streaming Enter handler, `InterruptCancel` intentionally kept the typed text.
   - This made users think the cancel didn’t register and press Enter again.

2. **No feedback for empty Enter during streaming**
   - Pressing Enter on an empty composer during a stream was a silent no-op.

3. **No immediate visual feedback when cancel interjection is accepted**
   - Cancel request was sent, but UI phase stayed unchanged until stream shutdown propagated.

(For `Esc` during streaming: behavior is already wired via the existing global cancel path; this PR adds a regression test to lock that behavior in.)

## Changes

### `internal/tui/chat/handlers.go`

- In streaming Enter handling:
  - **Empty composer** now sets a short status hint in phase:
    - `Type to interject, or press Esc to cancel`
  - In `InterruptCancel` branch:
    - clears pending/queued interjection state,
    - **clears textarea** (`setTextareaValue("")`),
    - sets immediate phase feedback to **`Stopping...`**,
    - then calls `streamCancelFunc()`.

### `internal/tui/chat/handlers_test.go`

Added coverage for the UX behavior:

- `TestHandleKeyMsg_StreamingCancelInterjectionClearsComposerAndShowsStopping`
- `TestHandleKeyMsg_StreamingEnterOnEmptyComposerShowsHint`
- `TestHandleKeyMsg_StreamingEscCancelsActiveStream` (regression coverage for Esc cancel wiring)

## Verification

- `go build ./...`
- `go test ./...`

Both pass.
