### PR TITLE
feat: compress recent.md to 3000-word target

### DIFF
--- a/cmd/memory_promote.go
+++ b/cmd/memory_promote.go
@@ -18,9 +18,18 @@ import (
 )
 
 const (
-	defaultRecentMaxBytes          = 200000
+	defaultRecentMaxBytes          = 20000
 	defaultInitialPromoteLookback  = 7 * 24 * time.Hour
-	memoryPromoteSystemInstruction = "You are a memory curator. Given recently changed memory fragments and the current recent.md, produce an updated recent.md that incorporates the new/changed information. Be concise. Preserve existing entries that are still relevant. Output ONLY the raw markdown content for recent.md — no commentary, no code fences."
+	memoryPromoteSystemInstruction = `You are a memory curator. Given recently changed memory fragments and the current recent.md, produce an updated recent.md.
+
+Rules:
+- Target **3000 words maximum** — treat this as a hard limit, not a guideline.
+- Compress aggressively: merge related facts, drop low-value or stale details, prefer dense summaries over verbose prose.
+- Prioritise: active projects, recent events, infrastructure facts, preferences, API/config details that would be painful to re-derive.
+- Drop: transient observations, resolved issues, one-off tasks, anything already obvious from context.
+- Incorporate new/changed fragments; if they conflict with existing content, prefer the newer version.
+- Preserve structure (dates, headers) but trim ruthlessly within each section.
+- Output ONLY the raw markdown — no commentary, no code fences.`
 )
 
 var (


### PR DESCRIPTION
## What

- `defaultRecentMaxBytes`: 200,000 → 20,000 (hard cap matching ~3,000 words)
- `memoryPromoteSystemInstruction`: replaced one-liner with explicit compression rules

## Why

`recent.md` was allowed to grow to 200KB with no guidance to compress. The curator prompt said "be concise" but didn't define what that meant, so the LLM just preserved everything. The result was a bloated file that defeated the point of having a compact rolling summary.

## Changes

The new prompt gives the LLM a concrete target (3,000 words), a priority ordering (active projects > recent events > infra/config > transient observations), and an explicit drop list (resolved issues, one-off tasks, things obvious from context). The byte cap now enforces the limit as a backstop rather than a theoretical ceiling.
