### PR TITLE
feat: add memory update-recent command

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -47,6 +47,7 @@ func init() {
 	memoryCmd.RegisterFlagCompletionFunc("agent", memoryAgentCompletion)
 
 	memoryCmd.AddCommand(memoryMineCmd)
+	memoryCmd.AddCommand(memoryUpdateRecentCmd)
 	memoryCmd.AddCommand(memorySearchCmd)
 	memoryCmd.AddCommand(memoryPromoteCmd)
 	memoryCmd.AddCommand(memoryStatusCmd)

--- a/cmd/memory_freshen.go
+++ b/cmd/memory_freshen.go
@@ -1,0 +1,512 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultMemoryUpdateRecentMaxInputChars = 120000
+	defaultMemoryUpdateRecentTargetTokens  = 4000
+	memoryUpdateRecentHighWaterPct         = 120 // high water mark = target * 120 / 100
+	memoryUpdateRecentCharsPerToken        = 4   // chars-per-token estimate
+
+	memoryUpdateRecentUserCharCap      = 2000
+	memoryUpdateRecentAssistantCharCap = 300
+)
+
+var (
+	memoryUpdateRecentMaxInputChars int
+	memoryUpdateRecentTargetTokens  int
+	memoryUpdateRecentModel         string
+	memoryUpdateRecentFile          string
+)
+
+var memoryUpdateRecentCmd = &cobra.Command{
+	Use:   "update-recent",
+	Short: "Update recent.md with terse summaries of new session activity",
+	RunE:  runMemoryUpdateRecent,
+}
+
+type memoryUpdateRecentSession struct {
+	ID        string
+	Number    int64
+	Status    session.SessionStatus
+	UpdatedAt time.Time
+}
+
+func init() {
+	memoryUpdateRecentCmd.Flags().IntVar(&memoryUpdateRecentMaxInputChars, "max-input-chars", defaultMemoryUpdateRecentMaxInputChars, "Max chars of session text to include in the prompt")
+	memoryUpdateRecentCmd.Flags().IntVar(&memoryUpdateRecentTargetTokens, "target-recent-tokens", defaultMemoryUpdateRecentTargetTokens, "Target size of recent.md in tokens (~4 chars/token); high water mark is +20%")
+	memoryUpdateRecentCmd.Flags().StringVar(&memoryUpdateRecentModel, "model", "", "Override model used for update-recent")
+	memoryUpdateRecentCmd.Flags().StringVarP(&memoryUpdateRecentFile, "file", "f", "", "Path to recent.md file (overrides default agent path)")
+}
+
+func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
+	if memoryUpdateRecentMaxInputChars <= 0 {
+		return fmt.Errorf("--max-input-chars must be > 0")
+	}
+	if memoryUpdateRecentTargetTokens <= 0 {
+		return fmt.Errorf("--target-recent-tokens must be > 0")
+	}
+
+	targetChars := memoryUpdateRecentTargetTokens * memoryUpdateRecentCharsPerToken
+	highWaterChars := targetChars * memoryUpdateRecentHighWaterPct / 100
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if err := applyProviderOverridesWithAgent(cfg, cfg.Ask.Provider, cfg.Ask.Model, "", "", ""); err != nil {
+		return err
+	}
+
+	agentName := resolveMemoryAgent("")
+	ctx := context.Background()
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	sessStore, err := openReadOnlySessionStore(cfg)
+	if err != nil {
+		return err
+	}
+	defer sessStore.Close()
+
+	current, err := sessStore.GetCurrent(ctx)
+	if err != nil {
+		return fmt.Errorf("get current session: %w", err)
+	}
+
+	if _, err := readLastUpdatedRecentAt(ctx, store, agentName); err != nil {
+		return err
+	}
+
+	sessions, err := listUpdateRecentSessions(ctx, sessStore, agentName, current)
+	if err != nil {
+		return err
+	}
+
+	currentID := ""
+	if current != nil {
+		currentID = current.ID
+	}
+
+	trackedOffsets := map[string]int{}
+	var inputBuilder strings.Builder
+
+	for _, sess := range sessions {
+		if currentID != "" && sess.ID == currentID {
+			continue
+		}
+
+		startOffset, err := readUpdateRecentOffset(ctx, store, sess.ID)
+		if err != nil {
+			return err
+		}
+
+		messages, err := sessStore.GetMessages(ctx, sess.ID, 0, startOffset)
+		if err != nil {
+			return fmt.Errorf("get messages for session %s: %w", sess.ID, err)
+		}
+		if len(messages) == 0 {
+			continue
+		}
+
+		block := formatUpdateRecentSessionBlock(sess, messages)
+		if block == "" {
+			continue
+		}
+
+		if inputBuilder.Len() > 0 {
+			inputBuilder.WriteString("\n\n---\n\n")
+		}
+		inputBuilder.WriteString(block)
+
+		trackedOffsets[sess.ID] = startOffset + len(messages)
+		if inputBuilder.Len() >= memoryUpdateRecentMaxInputChars {
+			break
+		}
+	}
+
+	if inputBuilder.Len() == 0 {
+		if memoryDryRun {
+			return nil
+		}
+		if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("update last update-recent timestamp: %w", err)
+		}
+		return nil
+	}
+
+	recentPath, err := resolveUpdateRecentPath(cfg, agentName)
+	if err != nil {
+		return err
+	}
+	existingRecent, err := loadRecentContent(recentPath)
+	if err != nil {
+		return err
+	}
+
+	provider, reqModel, err := newMemoryUpdateRecentProvider(cfg, strings.TrimSpace(memoryUpdateRecentModel))
+	if err != nil {
+		return err
+	}
+	engine := newEngine(provider, cfg)
+
+	updatedRecent, err := runMemoryUpdateRecentRequest(ctx, engine, reqModel, inputBuilder.String(), existingRecent, memoryUpdateRecentTargetTokens, targetChars)
+	if err != nil {
+		return err
+	}
+
+	if memoryDryRun {
+		fmt.Print(updatedRecent)
+		if !strings.HasSuffix(updatedRecent, "\n") {
+			fmt.Println()
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(recentPath), 0755); err != nil {
+		return fmt.Errorf("create memory directory: %w", err)
+	}
+	if err := os.WriteFile(recentPath, []byte(updatedRecent), 0644); err != nil {
+		return fmt.Errorf("write recent.md: %w", err)
+	}
+
+	sessionIDs := make([]string, 0, len(trackedOffsets))
+	for sessionID := range trackedOffsets {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	sort.Strings(sessionIDs)
+	for _, sessionID := range sessionIDs {
+		if err := store.SetMeta(ctx, updateRecentOffsetMetaKey(sessionID), strconv.Itoa(trackedOffsets[sessionID])); err != nil {
+			return fmt.Errorf("persist update-recent offset for session %s: %w", sessionID, err)
+		}
+	}
+
+	now := time.Now().UTC()
+	if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), now.Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("update last update-recent timestamp: %w", err)
+	}
+
+	if len([]byte(updatedRecent)) <= highWaterChars {
+		return nil
+	}
+
+	// recent.md has grown past the high water mark (+20% of target); rebuild from fragments.
+	promoteProvider, err := llm.NewProvider(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: promote after update-recent failed: %v\n", err)
+		return nil
+	}
+	promoteEngine := newEngine(promoteProvider, cfg)
+	if _, err := runMemoryPromoteFlow(ctx, cfg, promoteEngine, store, memoryPromoteOptions{
+		Agent:          agentName,
+		RecentMaxBytes: targetChars,
+		QuietNothing:   true,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: promote after update-recent failed: %v\n", err)
+	}
+	return nil
+}
+
+// resolveUpdateRecentPath returns the path to recent.md, honouring the -f flag.
+func resolveUpdateRecentPath(cfg *config.Config, agentName string) (string, error) {
+	if f := strings.TrimSpace(memoryUpdateRecentFile); f != "" {
+		return f, nil
+	}
+	return resolveAgentRecentPath(cfg, agentName)
+}
+
+func newMemoryUpdateRecentProvider(cfg *config.Config, modelOverride string) (llm.Provider, string, error) {
+	modelOverride = strings.TrimSpace(modelOverride)
+	if modelOverride == "" {
+		provider, err := llm.NewFastProvider(cfg, cfg.DefaultProvider)
+		if err != nil {
+			return nil, "", err
+		}
+		if provider != nil {
+			return provider, "", nil
+		}
+		provider, err = llm.NewProvider(cfg)
+		if err != nil {
+			return nil, "", err
+		}
+		return provider, "", nil
+	}
+
+	if strings.Contains(modelOverride, ":") {
+		overrideProvider, overrideModel, err := llm.ParseProviderModel(modelOverride, cfg)
+		if err != nil {
+			return nil, "", err
+		}
+		cfg.ApplyOverrides(overrideProvider, overrideModel)
+		provider, err := llm.NewProviderByName(cfg, overrideProvider, overrideModel)
+		if err != nil {
+			return nil, "", err
+		}
+		return provider, strings.TrimSpace(overrideModel), nil
+	}
+
+	cfg.ApplyOverrides("", modelOverride)
+	provider, err := llm.NewProviderByName(cfg, cfg.DefaultProvider, modelOverride)
+	if err != nil {
+		return nil, "", err
+	}
+	return provider, modelOverride, nil
+}
+
+func runMemoryUpdateRecentRequest(ctx context.Context, engine *llm.Engine, model, sessionSnippets, existingRecent string, targetTokens, targetChars int) (string, error) {
+	req := llm.Request{
+		Model: strings.TrimSpace(model),
+		Messages: []llm.Message{
+			llm.SystemText(memoryUpdateRecentSystemPrompt(targetTokens, targetChars)),
+			llm.UserText(memoryUpdateRecentUserPrompt(sessionSnippets, existingRecent)),
+		},
+		MaxTurns: 1,
+		DebugRaw: debugRaw,
+	}
+
+	stream, err := engine.Stream(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	var b strings.Builder
+	for {
+		ev, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		switch ev.Type {
+		case llm.EventTextDelta:
+			b.WriteString(ev.Text)
+		case llm.EventError:
+			if ev.Err != nil {
+				return "", ev.Err
+			}
+		}
+	}
+
+	return strings.TrimSpace(b.String()), nil
+}
+
+func memoryUpdateRecentSystemPrompt(targetTokens, targetChars int) string {
+	return fmt.Sprintf(`You are a memory curator. You maintain a concise recent memory file for an AI assistant named Jarvis.
+
+Given RECENT SESSION SNIPPETS and the CURRENT RECENT MEMORY, output the complete updated memory file integrating the new activity.
+
+Rules:
+- Target total output: ~%d tokens (~%d characters). Treat this as a soft ceiling on the whole document.
+- If today's date section already exists, add bullet points to it; otherwise prepend a new ## YYYY-MM-DD section.
+- Be extremely terse: facts only, no prose, no filler.
+- If the existing content is already near the target size, compress or drop low-value older entries to make room for new ones.
+- Output only the content, no code fences, no commentary.`, targetTokens, targetChars)
+}
+
+func memoryUpdateRecentUserPrompt(sessionSnippets, existingRecent string) string {
+	return fmt.Sprintf("RECENT SESSION SNIPPETS:\n\n%s\n\n===\n\nCURRENT RECENT MEMORY:\n\n%s", sessionSnippets, existingRecent)
+}
+
+func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agentName string, current *session.Session) ([]memoryUpdateRecentSession, error) {
+	complete, err := listCompleteSessions(ctx, sessStore)
+	if err != nil {
+		return nil, fmt.Errorf("list complete sessions: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	sessions := make([]memoryUpdateRecentSession, 0, len(complete)+1)
+
+	for _, summary := range complete {
+		sess, err := sessStore.Get(ctx, summary.ID)
+		if err != nil {
+			return nil, fmt.Errorf("get session %s: %w", summary.ID, err)
+		}
+		if sess == nil {
+			continue
+		}
+		if resolveMemoryAgent(sess.Agent) != agentName {
+			continue
+		}
+
+		status := summary.Status
+		if status == "" {
+			status = sess.Status
+		}
+		number := summary.Number
+		if number == 0 {
+			number = sess.Number
+		}
+		updatedAt := summary.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = sess.UpdatedAt
+		}
+
+		sessions = append(sessions, memoryUpdateRecentSession{
+			ID:        summary.ID,
+			Number:    number,
+			Status:    status,
+			UpdatedAt: updatedAt,
+		})
+		seen[summary.ID] = struct{}{}
+	}
+
+	if current != nil {
+		if _, exists := seen[current.ID]; !exists && resolveMemoryAgent(current.Agent) == agentName {
+			sessions = append(sessions, memoryUpdateRecentSession{
+				ID:        current.ID,
+				Number:    current.Number,
+				Status:    current.Status,
+				UpdatedAt: current.UpdatedAt,
+			})
+		}
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		if sessions[i].UpdatedAt.Equal(sessions[j].UpdatedAt) {
+			if sessions[i].Number == sessions[j].Number {
+				return sessions[i].ID > sessions[j].ID
+			}
+			return sessions[i].Number > sessions[j].Number
+		}
+		return sessions[i].UpdatedAt.After(sessions[j].UpdatedAt)
+	})
+
+	return sessions, nil
+}
+
+func formatUpdateRecentSessionBlock(sess memoryUpdateRecentSession, messages []session.Message) string {
+	lines := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		switch msg.Role {
+		case llm.RoleUser:
+			text := truncateUpdateRecentText(msg.TextContent, memoryUpdateRecentUserCharCap, false)
+			if text != "" {
+				lines = append(lines, "User: "+text)
+			}
+		case llm.RoleAssistant:
+			text := truncateUpdateRecentText(msg.TextContent, memoryUpdateRecentAssistantCharCap, true)
+			if text != "" {
+				lines = append(lines, "Assistant: "+text)
+			}
+		}
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	if sess.Number > 0 {
+		b.WriteString(fmt.Sprintf("[Session #%d - %s]\n", sess.Number, updateRecentSessionState(sess.Status)))
+	} else {
+		b.WriteString(fmt.Sprintf("[Session %s - %s]\n", sess.ID, updateRecentSessionState(sess.Status)))
+	}
+	for _, line := range lines {
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func truncateUpdateRecentText(text string, maxChars int, ellipsis bool) string {
+	text = strings.TrimSpace(text)
+	if text == "" || maxChars <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= maxChars {
+		return text
+	}
+	trimmed := string(runes[:maxChars])
+	if ellipsis {
+		return trimmed + "..."
+	}
+	return trimmed
+}
+
+func updateRecentSessionState(status session.SessionStatus) string {
+	switch status {
+	case session.StatusComplete:
+		return "completed"
+	case session.StatusActive:
+		return "active"
+	case session.StatusError:
+		return "error"
+	case session.StatusInterrupted:
+		return "interrupted"
+	default:
+		state := strings.TrimSpace(string(status))
+		if state == "" {
+			return "unknown"
+		}
+		return state
+	}
+}
+
+func readLastUpdatedRecentAt(ctx context.Context, store *memorydb.Store, agentName string) (time.Time, error) {
+	value, err := store.GetMeta(ctx, memoryUpdateRecentMetaKey(agentName))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("get last update-recent timestamp: %w", err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: invalid last update-recent timestamp for %s (%q), defaulting to zero\n", agentName, value)
+		return time.Time{}, nil
+	}
+	return parsed, nil
+}
+
+func readUpdateRecentOffset(ctx context.Context, store *memorydb.Store, sessionID string) (int, error) {
+	value, err := store.GetMeta(ctx, updateRecentOffsetMetaKey(sessionID))
+	if err != nil {
+		return 0, fmt.Errorf("get update-recent offset for session %s: %w", sessionID, err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	offset, err := strconv.Atoi(value)
+	if err != nil || offset < 0 {
+		fmt.Fprintf(os.Stderr, "warning: invalid update-recent offset for session %s (%q), defaulting to 0\n", sessionID, value)
+		return 0, nil
+	}
+	return offset, nil
+}
+
+func memoryUpdateRecentMetaKey(agentName string) string {
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		agentName = resolveMemoryAgent("")
+	}
+	return "last_update_recent_at_" + agentName
+}
+
+func updateRecentOffsetMetaKey(sessionID string) string {
+	return "update_recent_offset_" + strings.TrimSpace(sessionID)
+}

--- a/cmd/memory_freshen_test.go
+++ b/cmd/memory_freshen_test.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// -- truncateUpdateRecentText --
+
+func TestTruncateUpdateRecentText_ShortText(t *testing.T) {
+	got := truncateUpdateRecentText("hello", 100, false)
+	if got != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}
+
+func TestTruncateUpdateRecentText_ExactLimit(t *testing.T) {
+	got := truncateUpdateRecentText("abcde", 5, false)
+	if got != "abcde" {
+		t.Fatalf("got %q, want %q", got, "abcde")
+	}
+}
+
+func TestTruncateUpdateRecentText_TruncatesNoEllipsis(t *testing.T) {
+	got := truncateUpdateRecentText("abcdef", 5, false)
+	if got != "abcde" {
+		t.Fatalf("got %q, want %q", got, "abcde")
+	}
+}
+
+func TestTruncateUpdateRecentText_TruncatesWithEllipsis(t *testing.T) {
+	got := truncateUpdateRecentText("abcdef", 5, true)
+	if got != "abcde..." {
+		t.Fatalf("got %q, want %q", got, "abcde...")
+	}
+}
+
+func TestTruncateUpdateRecentText_Empty(t *testing.T) {
+	got := truncateUpdateRecentText("", 100, true)
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestTruncateUpdateRecentText_Whitespace(t *testing.T) {
+	got := truncateUpdateRecentText("  hello  ", 100, false)
+	if got != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}
+
+// -- updateRecentSessionState --
+
+func TestUpdateRecentSessionState(t *testing.T) {
+	cases := []struct {
+		status session.SessionStatus
+		want   string
+	}{
+		{session.StatusComplete, "completed"},
+		{session.StatusActive, "active"},
+		{session.StatusError, "error"},
+		{session.StatusInterrupted, "interrupted"},
+		{"", "unknown"},
+		{"custom", "custom"},
+	}
+	for _, tc := range cases {
+		got := updateRecentSessionState(tc.status)
+		if got != tc.want {
+			t.Errorf("updateRecentSessionState(%q) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+// -- meta keys --
+
+func TestMemoryUpdateRecentMetaKey(t *testing.T) {
+	key := memoryUpdateRecentMetaKey("jarvis")
+	if key != "last_update_recent_at_jarvis" {
+		t.Fatalf("got %q", key)
+	}
+}
+
+func TestUpdateRecentOffsetMetaKey(t *testing.T) {
+	key := updateRecentOffsetMetaKey("sess-123")
+	if key != "update_recent_offset_sess-123" {
+		t.Fatalf("got %q", key)
+	}
+}
+
+// -- system prompt --
+
+func TestMemoryUpdateRecentSystemPrompt_ContainsTokenCount(t *testing.T) {
+	prompt := memoryUpdateRecentSystemPrompt(4000, 16000)
+	if !contains(prompt, "4000") {
+		t.Error("prompt should mention target token count 4000")
+	}
+	if !contains(prompt, "16000") {
+		t.Error("prompt should mention target char count 16000")
+	}
+	if contains(prompt, "markdown") {
+		t.Error("prompt should not mention markdown")
+	}
+}
+
+func TestMemoryUpdateRecentUserPrompt(t *testing.T) {
+	prompt := memoryUpdateRecentUserPrompt("snippets here", "existing content")
+	if !contains(prompt, "RECENT SESSION SNIPPETS") {
+		t.Error("missing RECENT SESSION SNIPPETS label")
+	}
+	if !contains(prompt, "CURRENT RECENT MEMORY") {
+		t.Error("missing CURRENT RECENT MEMORY label")
+	}
+	if !contains(prompt, "snippets here") {
+		t.Error("missing snippets content")
+	}
+	if !contains(prompt, "existing content") {
+		t.Error("missing existing content")
+	}
+}
+
+// -- high water mark calculation --
+
+func TestHighWaterMarkCalculation(t *testing.T) {
+	targetTokens := 4000
+	targetChars := targetTokens * memoryUpdateRecentCharsPerToken   // 16000
+	highWater := targetChars * memoryUpdateRecentHighWaterPct / 100 // 19200
+
+	if targetChars != 16000 {
+		t.Errorf("targetChars = %d, want 16000", targetChars)
+	}
+	if highWater != 19200 {
+		t.Errorf("highWaterChars = %d, want 19200", highWater)
+	}
+	if highWater <= targetChars {
+		t.Error("high water mark must be above target")
+	}
+}
+
+// -- formatUpdateRecentSessionBlock --
+
+func TestFormatUpdateRecentSessionBlock_FiltersToolCalls(t *testing.T) {
+	sess := memoryUpdateRecentSession{ID: "s1", Number: 42, Status: session.StatusComplete}
+	messages := []session.Message{
+		{Role: llm.RoleUser, TextContent: "hello"},
+		{Role: llm.RoleAssistant, TextContent: "world"},
+		{Role: "tool", TextContent: "should be skipped"},
+	}
+	block := formatUpdateRecentSessionBlock(sess, messages)
+	if !contains(block, "User: hello") {
+		t.Error("expected user message in block")
+	}
+	if !contains(block, "Assistant: world") {
+		t.Error("expected assistant message in block")
+	}
+	if contains(block, "should be skipped") {
+		t.Error("tool message should be filtered out")
+	}
+}
+
+func TestFormatUpdateRecentSessionBlock_AssistantTruncated(t *testing.T) {
+	sess := memoryUpdateRecentSession{ID: "s1", Number: 1, Status: session.StatusComplete}
+	longText := string(make([]byte, memoryUpdateRecentAssistantCharCap+50))
+	for i := range longText {
+		longText = longText[:i] + "x" + longText[i+1:]
+	}
+	messages := []session.Message{
+		{Role: llm.RoleAssistant, TextContent: longText},
+	}
+	block := formatUpdateRecentSessionBlock(sess, messages)
+	if !contains(block, "...") {
+		t.Error("long assistant text should be truncated with ellipsis")
+	}
+}
+
+func TestFormatUpdateRecentSessionBlock_EmptyWhenNoRelevantMessages(t *testing.T) {
+	sess := memoryUpdateRecentSession{ID: "s1", Number: 1, Status: session.StatusComplete}
+	messages := []session.Message{
+		{Role: "tool", TextContent: "tool only"},
+	}
+	block := formatUpdateRecentSessionBlock(sess, messages)
+	if block != "" {
+		t.Errorf("expected empty block, got %q", block)
+	}
+}
+
+func TestFormatUpdateRecentSessionBlock_SessionHeader(t *testing.T) {
+	sess := memoryUpdateRecentSession{ID: "s1", Number: 7, Status: session.StatusActive}
+	messages := []session.Message{
+		{Role: llm.RoleUser, TextContent: "hi"},
+	}
+	block := formatUpdateRecentSessionBlock(sess, messages)
+	if !contains(block, "Session #7") {
+		t.Error("expected session number in header")
+	}
+	if !contains(block, "active") {
+		t.Error("expected active status in header")
+	}
+}
+
+// -- meta key read/write via real DB --
+
+func TestReadWriteUpdateRecentOffset(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	store, err := memorydb.NewStore(memorydb.Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	// Missing key → 0
+	offset, err := readUpdateRecentOffset(ctx, store, "sess-abc")
+	if err != nil {
+		t.Fatalf("readUpdateRecentOffset: %v", err)
+	}
+	if offset != 0 {
+		t.Errorf("expected 0 for missing key, got %d", offset)
+	}
+
+	// Write and read back
+	if err := store.SetMeta(ctx, updateRecentOffsetMetaKey("sess-abc"), "42"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	offset, err = readUpdateRecentOffset(ctx, store, "sess-abc")
+	if err != nil {
+		t.Fatalf("readUpdateRecentOffset: %v", err)
+	}
+	if offset != 42 {
+		t.Errorf("expected 42, got %d", offset)
+	}
+}
+
+func TestReadLastUpdatedRecentAt_Missing(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	store, err := memorydb.NewStore(memorydb.Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	ts, err := readLastUpdatedRecentAt(ctx, store, "jarvis")
+	if err != nil {
+		t.Fatalf("readLastUpdatedRecentAt: %v", err)
+	}
+	if !ts.IsZero() {
+		t.Errorf("expected zero time for missing key, got %v", ts)
+	}
+}
+
+func TestReadLastUpdatedRecentAt_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	store, err := memorydb.NewStore(memorydb.Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey("jarvis"), now.Format(time.RFC3339)); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	ts, err := readLastUpdatedRecentAt(ctx, store, "jarvis")
+	if err != nil {
+		t.Fatalf("readLastUpdatedRecentAt: %v", err)
+	}
+	if !ts.Equal(now) {
+		t.Errorf("got %v, want %v", ts, now)
+	}
+}
+
+// -- helpers --
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -88,7 +88,7 @@ func init() {
 	memoryMineCmd.Flags().IntVar(&memoryMineReadBytes, "read-bytes", 2048, "Bytes of existing fragment content to include in taxonomy context")
 	memoryMineCmd.Flags().BoolVar(&memoryMineEmbed, "embed", true, "Embed new/updated fragments after mining")
 	memoryMineCmd.Flags().StringVar(&memoryMineEmbedProvider, "embed-provider", "", "Override embedding provider used in EMBED phase (optionally provider:model)")
-	memoryMineCmd.Flags().StringVar(&memoryMinePromote, "promote", "auto", "Promotion mode: auto|always|never")
+	memoryMineCmd.Flags().StringVar(&memoryMinePromote, "promote", "never", "Promotion mode: auto|always|never")
 	memoryMineCmd.Flags().DurationVar(&memoryMinePromoteEvery, "promote-every", 6*time.Hour, "Minimum interval between auto-promote runs")
 	memoryMineCmd.Flags().Float64Var(&memoryMineHalfLifeDays, "half-life", 30.0, "Decay half-life in days for post-mine recalculation")
 	memoryMineCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)


### PR DESCRIPTION
## What

Adds `term-llm memory update-recent` command and changes `memory mine` default from `--promote=auto` to `--promote=never`, decoupling fragment mining from recent memory updates.

### Changes

- **`cmd/memory_freshen.go`** — new `memory update-recent` subcommand:
  - Reads new session messages since last run (tracked per-session offsets in meta table)
  - User messages: full text (capped 2000 chars); assistant: first 300 chars; tool calls: skipped
  - Single fast-model LLM call (`NewFastProvider` — e.g. `claude-haiku-4-5` on Anthropic)
  - Integrates new activity into the recent memory file; LLM outputs the complete updated content
  - `--target-recent-tokens` (default 4000): single control knob; target size ~4 chars/token
  - High water mark = target +20%; when exceeded, triggers a full promote from fragments back down to target size
  - Promote uses `targetChars` as `RecentMaxBytes`, so you always land with headroom for several cycles before the next rebuild
  - `-f/--file` flag to specify a custom recent memory file path
  - `--dry-run` and `--model` override flags
- **`cmd/memory_mine.go`** — default `--promote` changed from `"auto"` to `"never"`; mining is now purely fragment extraction
- **`internal/llm/models.go`** — removed duplicate `ProviderFastModels` declaration

## Why

The previous auto-promote in `mine` ran at most every 6 hours, making recent memory stale. This enables a cheap 10-minute cron (`memory update-recent`) using a fast/cheap model, keeping recent memory fresh. Full rebuilds from fragments only happen when the high water mark is breached.

## Prompt design

- No markdown framing — system prompt asks for plain content output, not "raw markdown"
- LLM is given the target token count so it can compress older entries when near the ceiling, not just blindly append

## Jobs (post-merge)

**Create** `update-recent` cron:
```
command: term-llm
args: [memory, update-recent, --agent, jarvis]
cron: */10 * * * *
concurrency: forbid
timeout: 300s
```

**Delete** `memory-promote` daily cron — redundant; threshold-triggered promote inside `update-recent` covers it.

**`mine-sessions`** — no config change needed; `--promote=never` is now the default.
