### PR TITLE
fix: LIMIT -1 guard in GetMessages when offset set without limit

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1092,6 +1092,9 @@ func (s *SQLiteStore) GetMessages(ctx context.Context, sessionID string, limit, 
 	if limit > 0 {
 		query += " LIMIT ?"
 		args = append(args, limit)
+	} else if offset > 0 {
+		// SQLite requires LIMIT before OFFSET; use -1 to mean "all rows".
+		query += " LIMIT -1"
 	}
 	if offset > 0 {
 		query += " OFFSET ?"


### PR DESCRIPTION
## What

`GetMessages` with `limit=0, offset>0` generated invalid SQL (`... ORDER BY sequence ASC OFFSET ?` with no LIMIT clause), causing SQLite to error: `near "OFFSET": syntax error`.

## Fix

Add `LIMIT -1` when offset is requested but no limit is set. SQLite accepts `-1` as "all rows", making `OFFSET` valid.

## Root cause

Surfaced by `memory update-recent` (PR #74) which calls `GetMessages(ctx, id, 0, startOffset)` once it has processed some sessions and stored non-zero offsets.
