### PR TITLE
feat: /reload command — re-exec under new binary, resume session

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -490,6 +490,17 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 		nextResumeID = m.RequestedResumeSessionID()
 	}
 
+	// Handle /reload: close the store, then re-exec under the (potentially new) binary.
+	if m, ok := finalModel.(*chat.Model); ok && m.WantsReload() {
+		storeCleanup() // flush & close DB before replacing the process
+		sessionID := m.ReloadSessionID()
+		if execErr := execReload(sessionID); execErr != nil {
+			// exec failed (shouldn't happen on Unix) — fall through and exit normally
+			fmt.Fprintf(cmd.ErrOrStderr(), "reload: %v\n", execErr)
+		}
+		return "", nil
+	}
+
 	// Print resume hint after alt-screen has been dismissed.
 	// Re-fetch the session so we get the latest LLMTurns written during streaming.
 	if nextResumeID == "" && store != nil && sess != nil && sess.ID != "" {

--- a/cmd/reload_exec.go
+++ b/cmd/reload_exec.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"strings"
+	"syscall"
+)
+
+// execReload replaces the current process with a fresh instance of the same
+// binary, resuming sessionID if non-empty.  It strips any pre-existing
+// --resume / -r flags from os.Args and appends the new one so the flags don't
+// stack across repeated reloads.
+//
+// On success this function never returns.  On failure it returns an error.
+func execReload(sessionID string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	// Rebuild argv, stripping any existing --resume / -r flags.
+	newArgs := []string{os.Args[0]}
+	skipNext := false
+	for _, arg := range os.Args[1:] {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if arg == "--resume" || arg == "-r" {
+			skipNext = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--resume=") || strings.HasPrefix(arg, "-r=") {
+			continue
+		}
+		newArgs = append(newArgs, arg)
+	}
+
+	if sessionID != "" {
+		newArgs = append(newArgs, "--resume", sessionID)
+	}
+
+	return syscall.Exec(exe, newArgs, os.Environ())
+}

--- a/cmd/reload_exec_windows.go
+++ b/cmd/reload_exec_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cmd
+
+import "fmt"
+
+// execReload is not supported on Windows; it returns an error.
+func execReload(sessionID string) error {
+	return fmt.Errorf("reload is not supported on Windows")
+}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -117,6 +117,11 @@ type Model struct {
 	err      error
 	yolo     bool
 
+	// reloadRequested signals the caller to re-exec the binary (e.g. after an upgrade).
+	// The session ID to resume is stored in reloadSessionID.
+	reloadRequested bool
+	reloadSessionID string
+
 	// Dialog components
 	completions *CompletionsModel
 	dialog      *DialogModel
@@ -429,6 +434,12 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 		selectedImage:           -1,
 	}
 }
+
+// WantsReload reports whether the user requested a binary reload via /reload.
+func (m *Model) WantsReload() bool { return m.reloadRequested }
+
+// ReloadSessionID returns the session ID to resume after a reload, if any.
+func (m *Model) ReloadSessionID() string { return m.reloadSessionID }
 
 // Init initializes the model
 func (m *Model) Init() tea.Cmd {

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -140,6 +140,11 @@ func AllCommands() []Command {
 			Description: "Browse and resume a previous session",
 			Usage:       "/resume [number|id]",
 		},
+		{
+			Name:        "reload",
+			Description: "Re-exec under the current binary, resuming this session (useful after upgrades)",
+			Usage:       "/reload",
+		},
 	}
 }
 
@@ -324,6 +329,8 @@ func (m *Model) ExecuteCommand(input string) (tea.Model, tea.Cmd) {
 		return m.cmdCompress()
 	case "resume":
 		return m.cmdResume(args)
+	case "reload":
+		return m.cmdReload()
 	default:
 		return m.showSystemMessage(fmt.Sprintf("Command /%s is not yet implemented.", cmd.Name))
 	}
@@ -444,6 +451,22 @@ func (m *Model) cmdClear() (tea.Model, tea.Cmd) {
 func (m *Model) cmdQuit() (tea.Model, tea.Cmd) {
 	m.quitting = true
 	return m, tea.Quit
+}
+
+func (m *Model) cmdReload() (tea.Model, tea.Cmd) {
+	if m.streaming {
+		return m.showSystemMessage("Cannot reload while streaming. Cancel first (Esc).")
+	}
+	m.setTextareaValue("")
+	m.quitting = true
+	m.reloadRequested = true
+	if m.sess != nil {
+		m.reloadSessionID = m.sess.ID
+	}
+	return m, tea.Batch(
+		tea.Println("Reloading..."),
+		tea.Quit,
+	)
 }
 
 func (m *Model) cmdModel(args []string) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## What

Adds a `/reload` slash command to the chat TUI that re-execs the process under the current on-disk binary, resuming the active session.

## Why

After running `term-llm upgrade` inside a chat session you're stuck on the old binary until you exit and restart. `/reload` handles this cleanly — no copy-paste of session IDs, no interrupted flow.

## How it works

1. `/reload` blocks during streaming (prompts user to cancel first)
2. The TUI quits normally via `tea.Quit`
3. Back in `runChat`, after MCP servers are stopped and the debug logger is closed, `storeCleanup()` is called explicitly to flush and close the SQLite session DB before replacing the process
4. `syscall.Exec(os.Executable(), newArgs, os.Environ())` replaces the current process with the new binary
5. `os.Args` are forwarded, but any existing `--resume`/`-r` flag is stripped and `--resume <session-id>` is appended — so the session picks up exactly where it left off

## Files

- `internal/tui/chat/chat.go` — `reloadRequested bool`, `reloadSessionID string` fields + `WantsReload()` / `ReloadSessionID()` accessors
- `internal/tui/chat/commands.go` — `/reload` added to `AllCommands()`, `ExecuteCommand`, and `cmdReload()` implementation
- `cmd/reload_exec.go` (`!windows`) — `execReload()` via `syscall.Exec`
- `cmd/reload_exec_windows.go` — stub returning an error
- `cmd/chat.go` — capture final model from `p.Run()`, detect `WantsReload()`, call `execReload()`
