### PR TITLE
fix: use --resume=ID in execReload to prevent session ID leaking into textarea

### DIFF
--- a/cmd/reload_exec.go
+++ b/cmd/reload_exec.go
@@ -39,7 +39,10 @@ func execReload(sessionID string) error {
 	}
 
 	if sessionID != "" {
-		newArgs = append(newArgs, "--resume", sessionID)
+		// Use --resume=ID (not --resume ID) because the flag has NoOptDefVal set,
+		// which means cobra treats the next positional arg as a separate argument
+		// rather than the flag value when the two-arg form is used.
+		newArgs = append(newArgs, "--resume="+sessionID)
 	}
 
 	return syscall.Exec(exe, newArgs, os.Environ())


### PR DESCRIPTION
## What

When `/reload` fires, `execReload` rebuilds argv and appends `--resume <sessionID>` as two separate arguments. Because the `--resume` flag has `NoOptDefVal` set (to support the bare `--resume` form that resumes the most recent session), cobra treats the flag as not consuming a following argument — so the session ID lands in positional args instead of the flag value.

`runChat` then passes those positional args through `ExtractAgentFromArgs` → `initialText`, which gets `ta.SetValue(initialText)` called on it. Result: the session ID appears pre-populated in the textarea after every `/reload`.

## Fix

Use `--resume=<sessionID>` (equals form) instead of `--resume <sessionID>`. The equals form bypasses `NoOptDefVal` parsing and correctly binds the value to the flag.
