### PR TITLE
feat: add --ui-prefix flag to make session URL base path configurable

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
@@ -41,6 +42,7 @@ var (
 	serveAllowNoAuth            bool
 	serveAuthMode               string
 	serveUI                     bool
+	serveUIPrefix               string
 	serveCORSOrigins            []string
 	serveSessionTTL             time.Duration
 	serveSessionMax             int
@@ -108,6 +110,7 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveAllowNoAuth, "allow-no-auth", false, "Disable auth (only allowed on loopback host)")
 	serveCmd.Flags().StringVar(&serveAuthMode, "auth", "bearer", "Auth mode: bearer or none")
 	serveCmd.Flags().BoolVar(&serveUI, "ui", false, "Serve minimal web UI")
+	serveCmd.Flags().StringVar(&serveUIPrefix, "ui-prefix", "/ui", "URL prefix the UI uses for session URLs (e.g. /chat)")
 	serveCmd.Flags().StringArrayVar(&serveCORSOrigins, "cors-origin", nil, "Allowed CORS origin (repeatable, or '*' for all)")
 	serveCmd.Flags().DurationVar(&serveSessionTTL, "session-ttl", 30*time.Minute, "Stateful session idle TTL")
 	serveCmd.Flags().IntVar(&serveSessionMax, "session-max", 1000, "Max stateful sessions in memory")
@@ -352,6 +355,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 				requireAuth: requireAuth,
 				token:       token,
 				ui:          serveUI,
+				uiPrefix:    strings.TrimRight(serveUIPrefix, "/"),
 				corsOrigins: append([]string(nil), serveCORSOrigins...),
 			},
 			sessionMgr: sessionMgr,
@@ -520,6 +524,7 @@ type serveServerConfig struct {
 	requireAuth bool
 	token       string
 	ui          bool
+	uiPrefix    string
 	corsOrigins []string
 }
 
@@ -622,7 +627,12 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write(serveui.IndexHTML())
+	html := serveui.IndexHTML()
+	if prefix := s.cfg.uiPrefix; prefix != "" && prefix != "/ui" {
+		snippet := `<script>window.TERM_LLM_UI_PREFIX=` + "`" + prefix + "`" + `;</script></head>`
+		html = bytes.Replace(html, []byte("</head>"), []byte(snippet), 1)
+	}
+	_, _ = w.Write(html)
 }
 
 func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -1389,15 +1389,18 @@
         }
       };
 
+      const UI_PREFIX = (window.TERM_LLM_UI_PREFIX || '/ui');
+
       const sessionIdFromURL = () => {
         const path = window.location.pathname;
-        const match = path.match(/^\/ui\/(.+)$/);
+        const escaped = UI_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const match = path.match(new RegExp('^' + escaped + '/(.+)$'));
         return match ? decodeURIComponent(match[1]) : '';
       };
 
       const updateURL = (sessionId) => {
         if (!sessionId) return;
-        const target = '/ui/' + encodeURIComponent(sessionId);
+        const target = UI_PREFIX + '/' + encodeURIComponent(sessionId);
         if (window.location.pathname !== target) {
           history.pushState(null, '', target);
         }


### PR DESCRIPTION
## What

Adds a `--ui-prefix` flag to `term-llm serve` (default: `/ui`) that controls the URL prefix the web UI uses for session routing.

When set, the server injects `window.TERM_LLM_UI_PREFIX` into the served HTML, and the UI JS uses it instead of the hardcoded `/ui` path for both `sessionIdFromURL` and `history.pushState`.

## Why

Makes it possible to serve the UI behind a reverse proxy at a custom path (e.g. `/chat`) without the JS redirecting the browser to `/ui/<sessionId>` on session start.

```
term-llm serve --ui --ui-prefix /chat
```

Session URLs become `wasnotwas.com/chat/<sessionId>` instead of `wasnotwas.com/ui/<sessionId>`.

## Notes

- No change to registered HTTP routes — the backend still handles `/ui` and `/ui/`; the proxy is responsible for path mapping
- Injection only fires when prefix differs from the default `/ui` — no change to existing behaviour
- Trailing slashes on the flag value are stripped
