### PR TITLE
fix: set no-cache headers on UI handler to prevent stale JS

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -627,6 +627,7 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	html := serveui.IndexHTML()
 	if prefix := s.cfg.uiPrefix; prefix != "" && prefix != "/ui" {
 		snippet := `<script>window.TERM_LLM_UI_PREFIX=` + "`" + prefix + "`" + `;</script></head>`


### PR DESCRIPTION
## What

Sets `Cache-Control: no-cache, no-store, must-revalidate` on the `/ui` HTML response.

## Why

The UI is a single self-contained HTML file with all JS inline. Without cache headers, browsers cache it aggressively. Any change to the served HTML (e.g. injected scripts via `--ui-prefix`) won't be picked up until the user does a manual hard reload — there's no filename-based cache busting to fall back on.
