### PR TITLE
fix: inject skills metadata into system prompt for web/telegram/jobs serve

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -31,6 +31,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/serveui"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
+	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/tools"
 	"github.com/spf13/cobra"
 )
@@ -220,6 +221,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Setup skills once for this serve process. The <available_skills> XML is
+	// injected here into settings.SystemPrompt so that both the web serveRuntime
+	// and the Telegram serveSettings pick it up correctly. Per-session engine
+	// registration (activate_skill tool) still happens inside the factory via
+	// newServeEngineWithTools.
+	skillsSetup := SetupSkills(&cfg.Skills, "", cmd.ErrOrStderr())
+	settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
+
 	agentName := ""
 	if agent != nil {
 		agentName = agent.Name
@@ -241,7 +250,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return nil, err
 		}
-		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, serveYolo, WireSpawnAgentRunner)
+		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, serveYolo, WireSpawnAgentRunner, skillsSetup)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +415,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provider llm.Provider, yoloMode bool, wireSpawn func(*config.Config, *tools.ToolManager, bool) error) (*llm.Engine, *tools.ToolManager, error) {
+// newServeEngineWithTools creates a new engine with tools wired up for serving.
+// skillsSetup must be pre-initialized by the caller (e.g. via SetupSkills); this
+// function registers the activate_skill tool on the engine but does NOT inject
+// <available_skills> metadata into the system prompt — the caller must do that
+// before constructing serveRuntime/serveSettings so the mutation is not lost.
+func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provider llm.Provider, yoloMode bool, wireSpawn func(*config.Config, *tools.ToolManager, bool) error, skillsSetup *skills.Setup) (*llm.Engine, *tools.ToolManager, error) {
 	engine := newEngine(provider, cfg)
 
 	toolMgr, err := settings.SetupToolManager(cfg, engine)
@@ -424,10 +438,9 @@ func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provi
 		}
 	}
 
-	// Wire skills system (activate_skill tool + system prompt injection).
-	skillsSetup := SetupSkills(&cfg.Skills, "", io.Discard)
+	// Register the activate_skill tool on the engine. Metadata injection into the
+	// system prompt is handled by the caller to avoid the by-value settings copy trap.
 	RegisterSkillToolWithEngine(engine, toolMgr, skillsSetup)
-	settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
 
 	return engine, toolMgr, nil
 }

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1967,13 +1967,19 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 			return err
 		}
 
+		// Setup skills and inject metadata into settings.SystemPrompt before
+		// constructing serveRuntime; skills.Setup is then passed to the engine
+		// factory for per-session activate_skill tool registration.
+		jobSkillsSetup := SetupSkills(&jobCfg.Skills, "", io.Discard)
+		settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, jobSkillsSetup)
+
 		modelName := activeModel(jobCfg)
 		provider, err := llm.NewProvider(jobCfg)
 		if err != nil {
 			return err
 		}
 
-		engine, toolMgr, err := newServeEngineWithTools(jobCfg, settings, provider, serveYolo, WireSpawnAgentRunner)
+		engine, toolMgr, err := newServeEngineWithTools(jobCfg, settings, provider, serveYolo, WireSpawnAgentRunner, jobSkillsSetup)
 		if err != nil {
 			return err
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -452,7 +452,7 @@ func TestNewServeEngineWithTools_ConfiguresToolManagerAndSpawnWiring(t *testing.
 		return nil
 	}
 
-	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, true, wireSpawn)
+	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, true, wireSpawn, nil)
 	if err != nil {
 		t.Fatalf("newServeEngineWithTools failed: %v", err)
 	}
@@ -487,7 +487,7 @@ func TestNewServeEngineWithTools_SkipsToolManagerWhenToolsDisabled(t *testing.T)
 		return nil
 	}
 
-	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, false, wireSpawn)
+	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, false, wireSpawn, nil)
 	if err != nil {
 		t.Fatalf("newServeEngineWithTools failed: %v", err)
 	}


### PR DESCRIPTION
## What

`newServeEngineWithTools` accepted `settings SessionSettings` **by value**, then did:

```go
settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
```

That mutation was silently discarded — Go passed a copy, not a reference. Back in the caller:

- `serveRuntime.systemPrompt` was set from the original `settings.SystemPrompt` (no skills XML)
- `serveSettings.SystemPrompt` (used by Telegram) was also set from the unmodified value

The `activate_skill` tool was correctly registered on the engine, so the LLM *could* call it in theory — but it never saw the `<available_skills>` XML in the system prompt, so it had no idea the skills existed. Skills were silently broken for both web and Telegram (and jobs).

## Fix

Move `SetupSkills` + `InjectSkillsMetadata` into the caller's scope, *before* `serveRuntime` and `serveSettings` are constructed:

- `runServe` (web/telegram): compute once after `ResolveSettings`, inject into `settings.SystemPrompt` directly — both the factory `serveRuntime` and `serveSettings` (Telegram) then see the correct prompt
- `newServeJobsExecutor` (jobs): same pattern, per-job `settings.SystemPrompt` injected before `serveRuntime` is built

`newServeEngineWithTools` now accepts a pre-initialized `*skills.Setup` and only handles per-session `activate_skill` tool registration on the engine (which correctly stays per-session).

## Why

The CLI (`chat`, `ask`) never had this bug because they modify `cfg.Chat.Instructions` directly (a pointer-accessible field) rather than a local `settings` copy.
