### PR TITLE
fix: mobile UX — remove sidebar shadow bleed + SSE keepalive ping

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -569,6 +570,42 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, responsesFinalResponse(result, model, respID))
 }
 
+// sseKeepalive starts a background goroutine that writes an SSE comment ping
+// to w every interval while streaming is active. This prevents intermediate
+// proxies (e.g. nginx with a short send_timeout) from closing the connection
+// during silent periods — e.g. when the LLM is in extended thinking mode or
+// the API is slow to emit tokens.
+//
+// The returned mu must wrap all writes to w inside the RunWithEvents callback.
+// Call stop() immediately after RunWithEvents returns; it blocks until the
+// goroutine has exited so subsequent final writes to w are safe without a lock.
+func sseKeepalive(w http.ResponseWriter, flusher http.Flusher, interval time.Duration) (mu *sync.Mutex, stop func()) {
+	mu = &sync.Mutex{}
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				mu.Lock()
+				_, _ = io.WriteString(w, ": ping\n\n")
+				flusher.Flush()
+				mu.Unlock()
+			case <-done:
+				return
+			}
+		}
+	}()
+	return mu, func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
 func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -595,9 +632,13 @@ func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter
 	})
 	flusher.Flush()
 
+	pingMu, stopPing := sseKeepalive(w, flusher, 20*time.Second)
+
 	outputIndex := 0
 	toolsSeen := false
 	result, err := runtime.RunWithEvents(ctx, stateful, replaceHistory, inputMessages, llmReq, func(ev llm.Event) error {
+		pingMu.Lock()
+		defer pingMu.Unlock()
 		switch ev.Type {
 		case llm.EventTextDelta:
 			if toolsSeen {
@@ -663,6 +704,8 @@ func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter
 		flusher.Flush()
 		return nil
 	})
+	stopPing() // wait for keepalive goroutine before any final writes
+
 	if err != nil {
 		errType := "invalid_request_error"
 		if errors.Is(err, errServeSessionBusy) {
@@ -816,9 +859,13 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 	}
 	created := time.Now().Unix()
 
+	pingMu, stopPing := sseKeepalive(w, flusher, 20*time.Second)
+
 	first := true
 	toolCallSeen := false
 	result, err := runtime.RunWithEvents(ctx, stateful, replaceHistory, inputMessages, llmReq, func(ev llm.Event) error {
+		pingMu.Lock()
+		defer pingMu.Unlock()
 		var writeErr error
 		switch ev.Type {
 		case llm.EventTextDelta:
@@ -891,6 +938,8 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 		flusher.Flush()
 		return nil
 	})
+	stopPing() // wait for keepalive goroutine before any final writes
+
 	if err != nil {
 		if errors.Is(err, errServeSessionBusy) {
 			_ = writeChatStreamChunk(w, map[string]any{

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -1064,12 +1064,13 @@
 
     @media (max-width: 767px) {
       body {
-        overflow: auto;
+        overflow: hidden;
       }
 
       .app {
         grid-template-columns: 1fr;
         height: 100dvh;
+        overflow: hidden;
       }
 
       .sidebar {
@@ -1077,14 +1078,16 @@
         top: 0;
         bottom: 0;
         left: 0;
-        width: 260px;
-        transform: translateX(-102%);
-        transition: transform 0.2s ease;
-        box-shadow: 18px 0 42px rgba(0, 0, 0, 0.42);
+        width: min(280px, 85vw);
+        transform: translateX(-100%);
+        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+        /* No shadow when closed — prevents bleed onto the main content */
+        box-shadow: none;
       }
 
       .sidebar.open {
         transform: translateX(0);
+        box-shadow: 4px 0 20px rgba(0, 0, 0, 0.28);
       }
 
       .sidebar-close {
@@ -1092,11 +1095,13 @@
       }
 
       .main {
-        min-height: 100dvh;
+        height: 100dvh;
+        min-height: 0;
       }
 
       .main-header {
-        padding: 0.65rem 0.75rem;
+        padding: 0.6rem 0.75rem;
+        flex-wrap: nowrap;
       }
 
       .mobile-menu {
@@ -1104,17 +1109,21 @@
       }
 
       .header-title {
-        max-width: 52vw;
+        max-width: 38vw;
       }
 
       .header-right {
-        width: 100%;
-        margin-left: 0;
+        margin-left: auto;
+        flex-shrink: 0;
       }
 
       .model-select {
-        flex: 1;
+        max-width: 42vw;
         min-width: 0;
+      }
+
+      .session-usage {
+        display: none;
       }
 
       .chat-scroll {
@@ -1122,7 +1131,11 @@
       }
 
       .composer {
-        padding: 0.6rem 0.7rem 0.75rem;
+        padding: 0.6rem 0.7rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
+      }
+
+      .composer-hint {
+        display: none;
       }
 
       .message.user {


### PR DESCRIPTION
## What

Two fixes in one:

### 1. Mobile CSS — eliminate the shadow artifact

The sidebar had `box-shadow: 18px 0 42px rgba(0,0,0,0.42)` applied unconditionally in the mobile block — meaning the shadow was rendered even when the sidebar was off-screen at `translateX(-102%)`. The shadow offset-x pushes it rightward, so it bleeds into the visible viewport even though the sidebar itself is hidden. Ugly.

**Changes:**
- `box-shadow: none` on the base (closed) sidebar; shadow only applied to `.sidebar.open`
- `translateX(-102%)` → `translateX(-100%)` — cleaner, exactly off-screen
- `overflow: hidden` on both `body` and `.app` — nothing escapes the container
- Responsive sidebar: `min(280px, 85vw)` instead of a fixed 260px
- Smoother open animation: `cubic-bezier(0.4, 0, 0.2, 1)` easing
- Header stays single-row on mobile — no more 2-row wrap. Model select gets `max-width: 42vw`, session usage token count hidden (not useful on mobile), composer hint hidden (redundant on touch)
- Composer bottom padding uses `env(safe-area-inset-bottom)` for iPhone home indicator

### 2. SSE keepalive — prevent response cut-off on slow LLMs

During pure text generation (no tool calls), no SSE data flows between token chunks when the LLM is "thinking" or the API is slow. With nginx's default `send_timeout: 60s`, this silently kills the SSE connection after a 60-second lull — response appears cut off mid-sentence.

**Also applied separately:** `proxy_send_timeout 300s; send_timeout 300s;` added to the nginx jarvis locations on wasnotwas.com.

**Changes:**
- New `sseKeepalive(w, flusher, interval)` helper — launches a goroutine that writes an SSE comment (`: ping\n\n`) every 20 seconds. SSE comments are ignored by browsers but keep the TCP connection and all proxies alive.
- Goroutine uses `sync.Mutex` to safely share `ResponseWriter` with the event callback. `stop()` blocks with `wg.Wait()` so final writes after `RunWithEvents` are safe without a lock.
- Wired into both `streamResponses` (`/v1/responses`) and `streamChatCompletions` (`/v1/chat/completions`).

## Why

- Users on mobile (especially iOS Safari, which aggressively manages background tabs) were seeing responses cut off mid-sentence
- The sidebar shadow was visible as an ugly artifact on the right edge of the chat view on mobile
