### PR TITLE
feat: improve context compaction (threshold 90%, structured prompt, full tail, cache anchor)

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -568,7 +568,11 @@ func buildAnthropicMessages(messages []Message) (string, []anthropic.MessagePara
 		case RoleUser:
 			blocks := buildAnthropicBlocks(msg.Parts, false)
 			if len(blocks) > 0 {
-				out = append(out, anthropic.NewUserMessage(blocks...))
+				m := anthropic.NewUserMessage(blocks...)
+				if msg.CacheAnchor {
+					applyCacheControlToLastBlock(m.Content)
+				}
+				out = append(out, m)
 			}
 		case RoleAssistant:
 			blocks := buildAnthropicBlocks(msg.Parts, true)
@@ -599,7 +603,11 @@ func buildAnthropicBetaMessages(messages []Message) (string, []anthropic.BetaMes
 		case RoleUser:
 			blocks := buildAnthropicBetaBlocks(msg.Parts, false)
 			if len(blocks) > 0 {
-				out = append(out, anthropic.NewBetaUserMessage(blocks...))
+				m := anthropic.NewBetaUserMessage(blocks...)
+				if msg.CacheAnchor {
+					applyBetaCacheControlToLastBlock(m.Content)
+				}
+				out = append(out, m)
 			}
 		case RoleAssistant:
 			blocks := buildAnthropicBetaBlocks(msg.Parts, true)
@@ -851,8 +859,18 @@ func applyLastMessageCacheControl(messages []anthropic.MessageParam) {
 	if len(last.Content) == 0 {
 		return
 	}
+	applyCacheControlToLastBlock(last.Content)
+}
+
+// applyCacheControlToLastBlock applies cache_control: ephemeral to the last block
+// in a slice of Anthropic content blocks. Used for both the rolling per-turn
+// breakpoint and the stable summary anchor.
+func applyCacheControlToLastBlock(blocks []anthropic.ContentBlockParamUnion) {
+	if len(blocks) == 0 {
+		return
+	}
 	cc := anthropic.NewCacheControlEphemeralParam()
-	block := &last.Content[len(last.Content)-1]
+	block := &blocks[len(blocks)-1]
 	switch {
 	case block.OfText != nil:
 		block.OfText.CacheControl = cc
@@ -875,8 +893,17 @@ func applyBetaLastMessageCacheControl(messages []anthropic.BetaMessageParam) {
 	if len(last.Content) == 0 {
 		return
 	}
+	applyBetaCacheControlToLastBlock(last.Content)
+}
+
+// applyBetaCacheControlToLastBlock applies cache_control: ephemeral to the last
+// block in a slice of Anthropic beta content blocks.
+func applyBetaCacheControlToLastBlock(blocks []anthropic.BetaContentBlockParamUnion) {
+	if len(blocks) == 0 {
+		return
+	}
 	cc := anthropic.NewBetaCacheControlEphemeralParam()
-	block := &last.Content[len(last.Content)-1]
+	block := &blocks[len(blocks)-1]
 	switch {
 	case block.OfText != nil:
 		block.OfText.CacheControl = cc

--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultThresholdRatio        = 0.80
+	defaultThresholdRatio        = 0.90
 	defaultRecentUserTokenBudget = 20_000
 	defaultMaxToolResultChars    = 80_000
 	approxBytesPerToken          = 4
@@ -73,15 +73,27 @@ func EstimateMessageTokens(msgs []Message) int {
 	return total
 }
 
-const summarizationPrompt = `You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another instance of yourself that will resume this conversation.
+const summarizationPrompt = `You are performing a CONTEXT CHECKPOINT COMPACTION. Create a detailed handoff summary for another instance of yourself that will resume this conversation.
 
-Include:
-- The overall goal/task being worked on
-- What has been accomplished so far (key decisions, actions taken)
-- Important context (file paths, variable names, error messages, constraints)
-- What remains to be done (clear next steps)
+Before your final summary, wrap your analysis in <analysis> tags. In your analysis:
+1. Chronologically review each message and section of the conversation. For each section identify:
+   - The user's explicit requests and intent
+   - Key decisions made and actions taken
+   - Specific details: file paths, variable names, error messages, API contracts, config values
+   - Errors encountered and how they were resolved
+   - Specific user feedback or corrections
 
-Be concise and structured. Focus on details that would be lost without this summary.`
+Your summary must include all of the following sections:
+1. Primary Request and Intent
+2. Key Context (file paths, APIs, config values, constraints, environment details)
+3. Actions Taken and Decisions Made
+4. Errors and Fixes
+5. All User Messages (verbatim — critical for understanding the user's exact intent and any changing instructions)
+6. Current Work (precisely what was in-flight immediately before this summary)
+7. Next Step (direct quote from the most recent conversation showing exactly what needs to happen next)
+
+Wrap your final summary in <summary> tags.
+Extract only the contents of the <summary> block as the result — the <analysis> is for your reasoning only.`
 
 const summaryPrefix = `[Context Compaction]
 A previous conversation was compacted to fit within the context window. Below is a summary of what happened before. Use this context to continue seamlessly.
@@ -192,11 +204,11 @@ func Compact(ctx context.Context, provider Provider, model, systemPrompt string,
 		return nil, fmt.Errorf("compaction produced empty summary")
 	}
 
-	// Extract recent user messages within budget
-	recentUserMsgs := extractRecentUserMessages(messages, config.RecentUserTokenBudget)
+	// Extract recent conversation tail within budget (user + assistant)
+	recentMsgs := extractRecentContext(messages, config.RecentUserTokenBudget)
 
 	// Reconstruct history
-	newMessages := reconstructHistory(systemPrompt, summary.String(), recentUserMsgs)
+	newMessages := reconstructHistory(systemPrompt, summary.String(), recentMsgs)
 	newMessages = sanitizeToolHistory(newMessages)
 
 	return &CompactionResult{
@@ -207,54 +219,77 @@ func Compact(ctx context.Context, provider Provider, model, systemPrompt string,
 	}, nil
 }
 
-// extractRecentUserMessages walks messages newest→oldest, collecting user-role
-// messages until the token budget is exhausted. Returns in chronological order.
-func extractRecentUserMessages(messages []Message, tokenBudget int) []Message {
+// extractRecentContext walks messages newest→oldest, collecting both user and
+// assistant messages until the token budget is exhausted. It cuts only at clean
+// message boundaries and never splits a tool call / tool result pair.
+// Returns the tail in chronological order.
+func extractRecentContext(messages []Message, tokenBudget int) []Message {
 	if len(messages) == 0 {
 		return nil
 	}
-	var result []Message
+
+	// Walk backward, accumulating whole messages until budget is gone.
+	// We stop before a message that would push us over, so the first message
+	// collected is always the newest one that fits.
 	remaining := tokenBudget
+	cutIdx := len(messages) // exclusive lower bound (we'll slice messages[cutIdx:])
 
 	for i := len(messages) - 1; i >= 0; i-- {
 		msg := messages[i]
-		if msg.Role != RoleUser {
+		// Skip system messages — they're re-injected separately.
+		if msg.Role == RoleSystem {
 			continue
 		}
 		tokens := EstimateMessageTokens([]Message{msg})
-		if tokens > remaining && len(result) > 0 {
+		if tokens > remaining && cutIdx < len(messages) {
+			// Budget exhausted; stop before this message.
 			break
 		}
 		remaining -= tokens
-		result = append(result, msg)
+		cutIdx = i
 		if remaining <= 0 {
 			break
 		}
 	}
 
-	// Messages were collected newest→oldest; reverse to restore chronological order.
-	for l, r := 0, len(result)-1; l < r; l, r = l+1, r-1 {
-		result[l], result[r] = result[r], result[l]
+	tail := messages[cutIdx:]
+
+	// Ensure the tail forms a valid conversation: must start with a user message
+	// (Anthropic and most providers reject histories that open with an assistant turn).
+	for len(tail) > 0 && tail[0].Role != RoleUser {
+		tail = tail[1:]
 	}
 
-	return result
+	return tail
 }
 
 // reconstructHistory builds the compacted message list:
-// [SystemText(systemPrompt)] + [UserText(summaryPrefix + summary)] + [recent user messages]
-func reconstructHistory(systemPrompt, summary string, recentUserMsgs []Message) []Message {
+// [SystemText(systemPrompt)] + [summary(user, CacheAnchor)] + [ack(assistant)] + [recent context]
+//
+// The summary message is marked CacheAnchor=true so Anthropic-compatible providers
+// apply cache_control: ephemeral to it, creating a stable cache breakpoint at the
+// summary. This means subsequent turns only pay cold-prefill cost on the delta after
+// the summary, not on the full compacted context.
+func reconstructHistory(systemPrompt, summary string, recentMsgs []Message) []Message {
 	var messages []Message
 
 	if systemPrompt != "" {
 		messages = append(messages, SystemText(systemPrompt))
 	}
 
-	messages = append(messages, UserText(summaryPrefix+summary))
+	// The summary message gets a cache anchor so the Anthropic provider applies
+	// cache_control: ephemeral to it. The summary is stable until the next
+	// compaction, so caching it here gives a cheap warm hit on every subsequent turn.
+	messages = append(messages, Message{
+		Role:        RoleUser,
+		Parts:       []Part{{Type: PartText, Text: summaryPrefix + summary}},
+		CacheAnchor: true,
+	})
 
 	// Add an assistant acknowledgement so the conversation flow is valid
 	messages = append(messages, AssistantText("I've reviewed the context summary. I'll continue from where we left off."))
 
-	messages = append(messages, recentUserMsgs...)
+	messages = append(messages, recentMsgs...)
 
 	return messages
 }

--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -76,53 +76,74 @@ func TestEstimateMessageTokensEmpty(t *testing.T) {
 	}
 }
 
-func TestExtractRecentUserMessages(t *testing.T) {
+func TestExtractRecentContext(t *testing.T) {
 	messages := []Message{
-		UserText("first user message"), // ~5 tokens
-		AssistantText("first response"),
-		UserText("second user message"), // ~5 tokens
-		AssistantText("second response"),
-		UserText("third user message"), // ~5 tokens
+		UserText("first user message"),   // ~5 tokens
+		AssistantText("first response"),  // ~4 tokens
+		UserText("second user message"),  // ~5 tokens
+		AssistantText("second response"), // ~4 tokens
+		UserText("third user message"),   // ~5 tokens
 	}
 
-	// Budget large enough for all user messages
-	result := extractRecentUserMessages(messages, 1000)
-	if len(result) != 3 {
-		t.Errorf("expected 3 user messages with large budget, got %d", len(result))
+	// Budget large enough for the full conversation
+	result := extractRecentContext(messages, 1000)
+	if len(result) != 5 {
+		t.Errorf("expected 5 messages with large budget, got %d", len(result))
 	}
 
-	// Budget for only the last user message
-	result = extractRecentUserMessages(messages, 5)
+	// Small budget: should fit only the last user message (~5 tokens)
+	result = extractRecentContext(messages, 5)
 	if len(result) != 1 {
-		t.Errorf("expected 1 user message with small budget, got %d", len(result))
+		t.Errorf("expected 1 message with budget=5, got %d", len(result))
 	}
 	if result[0].Parts[0].Text != "third user message" {
 		t.Errorf("expected last user message, got %q", result[0].Parts[0].Text)
 	}
 
-	// Messages should be in chronological order
-	result = extractRecentUserMessages(messages, 100)
-	if len(result) < 2 {
-		t.Fatalf("expected at least 2 messages, got %d", len(result))
+	// Medium budget: should include assistant messages too
+	result = extractRecentContext(messages, 100)
+	if len(result) < 3 {
+		t.Fatalf("expected at least 3 messages with medium budget, got %d", len(result))
 	}
-	if result[0].Parts[0].Text != "first user message" {
-		t.Errorf("first result should be 'first user message', got %q", result[0].Parts[0].Text)
+	// Result must start with a user message
+	if result[0].Role != RoleUser {
+		t.Errorf("first result must be user-role, got %s", result[0].Role)
+	}
+	// Must be in chronological order
+	if result[0].Parts[0].Text == "third user message" && len(result) > 1 {
+		t.Errorf("expected chronological order, but first message is already the last")
 	}
 }
 
-func TestExtractRecentUserMessagesEmpty(t *testing.T) {
-	result := extractRecentUserMessages(nil, 1000)
+func TestExtractRecentContextEmpty(t *testing.T) {
+	result := extractRecentContext(nil, 1000)
 	if len(result) != 0 {
 		t.Errorf("expected 0 messages from nil input, got %d", len(result))
 	}
 
-	// No user messages
+	// Only assistant messages — result must start with user, so should be empty
 	messages := []Message{
 		AssistantText("just an assistant message"),
 	}
-	result = extractRecentUserMessages(messages, 1000)
+	result = extractRecentContext(messages, 1000)
 	if len(result) != 0 {
-		t.Errorf("expected 0 user messages, got %d", len(result))
+		t.Errorf("expected 0 messages when only assistant messages present, got %d", len(result))
+	}
+}
+
+func TestExtractRecentContextStartsWithUser(t *testing.T) {
+	// If the budget only fits the last assistant message, we should get nothing
+	// (because we strip leading assistant messages)
+	messages := []Message{
+		UserText("user one"),
+		AssistantText(strings.Repeat("a", 1000)), // large assistant message
+	}
+	// Budget too small for the user message but big enough for the assistant
+	userTokens := EstimateMessageTokens([]Message{UserText("user one")})
+	result := extractRecentContext(messages, userTokens-1)
+	// The assistant message alone would be left, then stripped — result is empty
+	if len(result) != 0 {
+		t.Errorf("expected empty result when only a leading assistant message fits, got %d", len(result))
 	}
 }
 
@@ -151,6 +172,9 @@ func TestReconstructHistory(t *testing.T) {
 	}
 	if !strings.Contains(result[1].Parts[0].Text, summaryPrefix) {
 		t.Errorf("summary message should contain prefix")
+	}
+	if !result[1].CacheAnchor {
+		t.Errorf("summary message should have CacheAnchor=true for stable cache breakpoint")
 	}
 
 	if result[2].Role != RoleAssistant {
@@ -584,8 +608,8 @@ func TestCompactNoSystemPrompt(t *testing.T) {
 
 func TestDefaultCompactionConfig(t *testing.T) {
 	config := DefaultCompactionConfig()
-	if config.ThresholdRatio != 0.80 {
-		t.Errorf("ThresholdRatio = %f, want 0.80", config.ThresholdRatio)
+	if config.ThresholdRatio != 0.90 {
+		t.Errorf("ThresholdRatio = %f, want 0.90", config.ThresholdRatio)
 	}
 	if config.RecentUserTokenBudget != 20_000 {
 		t.Errorf("RecentUserTokenBudget = %d, want 20000", config.RecentUserTokenBudget)

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -93,8 +93,9 @@ const (
 
 // Message holds a role with structured parts.
 type Message struct {
-	Role  Role
-	Parts []Part
+	Role        Role
+	Parts       []Part
+	CacheAnchor bool // provider should apply cache_control to this message (Anthropic-specific)
 }
 
 // Part represents a single content part.


### PR DESCRIPTION
## What

Three compaction improvements in one PR:

**1. Threshold: 80% → 90%**

Sonnet currently reports ~136k tokens on a 200k context. With 20k reserved for thinking and 20k for output, the practical safe ceiling is ~160k. 80% (160k) was already tight; 90% (180k) gives more headroom before compaction fires while still leaving a safe margin. All the harnesses studied in our [context compaction article](https://wasnotwas.com/writing/context-compaction/) fire at 86–96% — 80% was on the conservative end.

**2. Structured summarization prompt**

Replaces the Codex-style 4-bullet minimal prompt with a structured 9-section format (same lineage as Claude Code and Roo Code). Key additions:
- `<analysis>` reasoning pass before the summary
- Verbatim user message preservation (prevents intent drift across compactions)
- Direct-quote next step (prevents paraphrase-induced task drift)

Lab experiment in the article showed +49% richer summaries with a structured prompt at ~$0.013 additional cost per compaction.

**3. Full conversation tail instead of user-only**

`extractRecentUserMessages` kept only user-role messages within the recent token budget. This silently dropped all assistant responses — including partial work, tool reasoning, and in-progress analysis. Replaced with `extractRecentContext` which keeps the last N tokens of the full alternating conversation, trimming the head to always start on a user message.

**4. Stable cache anchor on summary (Anthropic)**

Adds `CacheAnchor bool` to `Message`. The summary message from `reconstructHistory` is tagged `CacheAnchor=true`. `buildAnthropicMessages` (and the beta variant) apply `cache_control: ephemeral` to that message's last content block.

This creates a stable second cache breakpoint at the summary, alongside the existing rolling per-turn breakpoint on the last message. Currently Anthropic uses 3 of the 4 allowed breakpoints (system prompt, last tool, last message); the summary anchor uses the fourth.

**Effect:** after compaction, the system prompt is already a cache hit (unchanged). On the first post-compaction turn the summary is cold but gets written to cache. On all subsequent turns the summary is a warm hit — only the delta after the summary pays cold-prefill rates. Without the anchor, the summary is not guaranteed its own cache slot and may lose cache residency before the per-turn breakpoint does.

## Why

Context compaction is a cache-bust event. Every compaction throws away the warm KV state and forces a cold prefill of the new summary. The structured prompt and full tail reduce how often compaction is *needed* (better summaries → less re-work). The cache anchor reduces the cost of each compaction event itself. The threshold change better matches the actual model limits in production.

## Changes

- `internal/llm/types.go`: add `CacheAnchor bool` to `Message`
- `internal/llm/compaction.go`: threshold 80→90%, new prompt, `extractRecentContext`, `reconstructHistory` sets `CacheAnchor`
- `internal/llm/anthropic.go`: refactor `applyLastMessageCacheControl` to share `applyCacheControlToLastBlock`; same for beta path; honour `CacheAnchor` in `buildAnthropicMessages`/`buildAnthropicBetaMessages`
- `internal/llm/compaction_test.go`: updated tests for new function names, threshold, and `CacheAnchor` assertion
