### PR TITLE
fix: use practical 20K output reserve for Claude 4.x context window

### DIFF
--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -345,12 +345,13 @@ func TestInputLimitForModel(t *testing.T) {
 		model    string
 		expected int
 	}{
-		// Values are effective input limits (not total context)
-		{"claude-sonnet-4-6", 136_000},          // 200K - 64K
-		{"claude-opus-4-6", 136_000},            // 200K - 64K
-		{"claude-sonnet-4-5-20250929", 136_000}, // 200K - 64K
-		{"claude-sonnet-4-20250514", 136_000},   // 200K - 64K
-		{"claude-opus-4-20250514", 168_000},     // 200K - 32K
+		// Claude 4.x: 200K - 20K practical output reserve = 180K
+		{"claude-sonnet-4-6", 180_000},
+		{"claude-opus-4-6", 180_000},
+		{"claude-sonnet-4-5-20250929", 180_000},
+		{"claude-sonnet-4-20250514", 180_000},
+		{"claude-opus-4-20250514", 180_000},
+		// Claude 3.x: small max output, full deduction
 		{"claude-3.5-sonnet-20241022", 192_000}, // 200K - 8K
 		{"gpt-4o-2024-05-13", 112_000},          // 128K - 16K
 		{"gpt-4.1-2025-04-14", 1_014_808},       // 1047K - 32K
@@ -379,7 +380,7 @@ func TestInputLimitForModel(t *testing.T) {
 		{"", 0},
 		// Case insensitivity
 		{"GPT-5", 272_000},
-		{"Claude-Sonnet-4-5-20250929", 136_000},
+		{"Claude-Sonnet-4-5-20250929", 180_000},
 	}
 
 	for _, tt := range tests {

--- a/internal/llm/context_window.go
+++ b/internal/llm/context_window.go
@@ -74,34 +74,34 @@ func lookupPrefix(model string, table []inputLimitEntry) int {
 	return best
 }
 
-// inputLimitTable contains effective input token limits from models.dev/api.json.
-// These represent the maximum INPUT tokens (not total context = input + output).
-// Compaction must trigger before hitting this limit. Values are computed as:
-//   - limit.input if explicitly set (GPT-5 family)
-//   - limit.context - limit.output if both are set
-//   - limit.context as fallback (conservative upper bound)
+// inputLimitTable contains effective input token limits.
+// These represent the practical INPUT token budget for compaction purposes.
+//
+// For Anthropic Claude 4.x: we follow Claude CLI's approach — cap the output
+// reservation at 20K rather than the full theoretical max (64K–128K). In practice,
+// compaction never fires while the model is also generating 64K of output, so
+// reserving that much is needlessly conservative. 200K - 20K = 180K working window.
+// Claude 3.x models have small max outputs (4K–8K) so the full deduction applies.
+//
+// For other providers: context - max_output (or explicit input limit if known).
 //
 // Entries are matched by longest prefix. Unknown models return 0 (compaction disabled).
 var inputLimitTable = []inputLimitEntry{
-	// Anthropic Claude (from models.dev anthropic section: context - output)
-	// Claude 4.6: 200K ctx - 64K out = 136K input
-	{"claude-sonnet-4-6", 136_000},
-	// technically supports 128 out but in practice will not happen
-	{"claude-opus-4-6", 136_000},
-	// Claude 4.5: 200K ctx - 64K out = 136K input
-	{"claude-sonnet-4-5", 136_000},
-	{"claude-opus-4-5", 136_000},
-	{"claude-haiku-4-5", 136_000},
-	// Claude 4.0: 200K ctx - 64K out = 136K input
-	{"claude-sonnet-4", 136_000},
-	{"claude-opus-4", 168_000}, // 200K - 32K
-	{"claude-haiku-4", 136_000},
-	// Claude 3.x: 200K ctx - 8K out = 192K input
-	{"claude-3.5-sonnet", 192_000},
-	{"claude-3.5-haiku", 192_000},
-	{"claude-3-opus", 196_000}, // 200K - 4K
-	{"claude-3-sonnet", 196_000},
-	{"claude-3-haiku", 196_000},
+	// Anthropic Claude 4.x: 200K ctx - 20K practical output reserve = 180K
+	{"claude-sonnet-4-6", 180_000},
+	{"claude-opus-4-6", 180_000},
+	{"claude-sonnet-4-5", 180_000},
+	{"claude-opus-4-5", 180_000},
+	{"claude-haiku-4-5", 180_000},
+	{"claude-sonnet-4", 180_000},
+	{"claude-opus-4", 180_000},
+	{"claude-haiku-4", 180_000},
+	// Claude 3.x: max output is 4K–8K, well under 20K — full deduction
+	{"claude-3.5-sonnet", 192_000}, // 200K - 8K
+	{"claude-3.5-haiku", 192_000},  // 200K - 8K
+	{"claude-3-opus", 196_000},     // 200K - 4K
+	{"claude-3-sonnet", 196_000},   // 200K - 4K
+	{"claude-3-haiku", 196_000},    // 200K - 4K
 
 	// OpenAI GPT-5 family (from models.dev openai section: explicit input=272000)
 	{"gpt-5.3-codex-spark", 100_000}, // input=100000


### PR DESCRIPTION
## What

Changes Claude 4.x effective input limits from `context - max_output` to `context - 20K` (a capped practical reserve), matching Claude CLI's approach.

**Before:** `claude-sonnet-4-6` → 136K (200K - 64K max output)
**After:** all Claude 4.x → 180K (200K - 20K practical reserve)

## Why

The original values were derived mechanically: subtract the model's theoretical max output from the context window. For Claude 4.x models with 64K–128K max outputs, this produced overly conservative input limits (136K or even less for Opus 4.6 which has 128K max output).

In practice, compaction never fires while the model is also generating tens of thousands of output tokens. Claude CLI confirms this intuition: it caps the output reservation at `min(max_output, 20K)`, giving a working window of **180K** for all 200K-context models.

This also fixes a correctness bug: `claude-opus-4-6` was set to 136K (same as Sonnet) despite having 128K max output — it should have been 72K by the old logic, which would have been even more wrong in the opposite direction.

Claude 3.x models are unchanged — their max outputs (4K–8K) already fall below the 20K cap.

## Result

- Displayed context bar: `~12K/180K` instead of `~12K/136K` for Sonnet 4.6 with thinking
- Auto-compact triggers at ~162K (90% of 180K) vs Claude CLI's ~167K — roughly equivalent
- Opus 4.6 no longer has a silently wrong value
