### PR TITLE
feat: insights memory subsystem with expansion hook

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -19,6 +19,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/input"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/prompt"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
@@ -401,6 +402,19 @@ func runAsk(cmd *cobra.Command, args []string) error {
 
 	// Add new user message
 	messages = append(messages, llm.UserText(userPrompt))
+
+	// Insights expansion: on the first turn of a new (non-resumed) session,
+	// inject relevant behavioral guidelines. Gated by agent.yaml
+	// memory.insights_expansion (default: false).
+	if len(sessionMessages) == 0 && settings.InsightsExpansion {
+		if ms, msErr := openMemoryStore(); msErr == nil {
+			defer ms.Close()
+			expander := memorydb.NewInsightsExpander(ms, settings.AgentName, settings.InsightsMaxTokens)
+			if expanded := expander.Expand(ctx, userPrompt); expanded != "" {
+				messages = append(messages, llm.UserText(expanded))
+			}
+		}
+	}
 
 	debugMode := askDebug
 	if sess != nil {

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -408,7 +408,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	// memory.insights_expansion (default: false).
 	if len(sessionMessages) == 0 && settings.InsightsExpansion {
 		if ms, msErr := openMemoryStore(); msErr == nil {
-			defer ms.Close()
+			defer ms.Close() // defers to enclosing function — store stays open until ask returns
 			expander := memorydb.NewInsightsExpander(ms, settings.AgentName, settings.InsightsMaxTokens)
 			if expanded := expander.Expand(ctx, userPrompt); expanded != "" {
 				messages = append(messages, llm.UserText(expanded))

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -356,6 +357,16 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 
 	// Create chat model
 	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, showStats, initialText, store, sess, useAltScreen, chatAutoSend, true, chatTextMode, agentName, chatYolo)
+
+	// Wire insight expansion (no-op when disabled or store unavailable).
+	if settings.InsightsExpansion {
+		if ms, msErr := openMemoryStore(); msErr == nil {
+			expander := memorydb.NewInsightsExpander(ms, agentName, settings.InsightsMaxTokens)
+			model.SetInsightsExpander(expander)
+			// Store is kept open for the session lifetime; closed when program exits.
+			defer ms.Close()
+		}
+	}
 
 	// Build program options
 	var opts []tea.ProgramOption

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -53,6 +53,7 @@ func init() {
 	memoryCmd.AddCommand(memoryStatusCmd)
 	memoryCmd.AddCommand(memoryFragmentsCmd)
 	memoryCmd.AddCommand(memoryImagesCmd)
+	memoryCmd.AddCommand(memoryInsightsCmd)
 }
 
 func openMemoryStore() (*memorydb.Store, error) {

--- a/cmd/memory_insights.go
+++ b/cmd/memory_insights.go
@@ -79,6 +79,13 @@ var memoryInsightsSearchCmd = &cobra.Command{
 	RunE:  runMemoryInsightsSearch,
 }
 
+var memoryInsightsExpandCmd = &cobra.Command{
+	Use:   "expand <query>",
+	Short: "Preview the insight block that would be injected for a given query",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runMemoryInsightsExpand,
+}
+
 func init() {
 	memoryInsightsCmd.AddCommand(memoryInsightsListCmd)
 	memoryInsightsCmd.AddCommand(memoryInsightsAddCmd)
@@ -86,6 +93,7 @@ func init() {
 	memoryInsightsCmd.AddCommand(memoryInsightsDeleteCmd)
 	memoryInsightsCmd.AddCommand(memoryInsightsReinforceCmd)
 	memoryInsightsCmd.AddCommand(memoryInsightsSearchCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsExpandCmd)
 
 	memoryInsightsListCmd.Flags().IntVar(&insightLimit, "limit", 20, "Maximum insights to show (0 = all)")
 
@@ -97,6 +105,7 @@ func init() {
 	memoryInsightsUpdateCmd.Flags().StringVar(&insightContent, "content", "", "New insight content (required, or pipe via stdin)")
 
 	memoryInsightsSearchCmd.Flags().IntVar(&insightSearchLimit, "limit", 5, "Maximum results")
+	memoryInsightsExpandCmd.Flags().IntVar(&insightSearchLimit, "max-tokens", 500, "Token budget for expansion")
 }
 
 func runMemoryInsightsList(cmd *cobra.Command, args []string) error {
@@ -272,5 +281,32 @@ func runMemoryInsightsSearch(cmd *cobra.Command, args []string) error {
 		fmt.Println(ins.Content)
 		fmt.Println()
 	}
+	return nil
+}
+
+func runMemoryInsightsExpand(cmd *cobra.Command, args []string) error {
+	query := strings.TrimSpace(args[0])
+	agent := strings.TrimSpace(memoryAgent)
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	maxTok, _ := cmd.Flags().GetInt("max-tokens")
+	if maxTok <= 0 {
+		maxTok = 500
+	}
+
+	expanded, err := store.ExpandInsights(context.Background(), agent, query, maxTok)
+	if err != nil {
+		return err
+	}
+	if expanded == "" {
+		fmt.Println("(no insights matched — bank may be empty or below confidence threshold)")
+		return nil
+	}
+	fmt.Println(expanded)
 	return nil
 }

--- a/cmd/memory_insights.go
+++ b/cmd/memory_insights.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	insightCategory    string
+	insightTrigger     string
+	insightConfidence  float64
+	insightContent     string
+	insightLimit       int
+	insightSearchLimit int
+)
+
+var memoryInsightsCmd = &cobra.Command{
+	Use:   "insights",
+	Short: "Manage behavioral insight rules",
+	Long: `Manage the insight bank — generalized behavioral rules extracted from past sessions.
+
+Unlike fragments (which store facts), insights store actionable patterns that
+change how the agent behaves in future similar situations. High-confidence
+insights are automatically injected at the start of each session.
+
+Examples:
+  term-llm memory insights list --agent jarvis
+  term-llm memory insights add --agent jarvis --content "..." --category anti-pattern
+  term-llm memory insights search "code review" --agent jarvis
+  term-llm memory insights reinforce 42
+  term-llm memory insights delete 42`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var memoryInsightsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List insights, newest first",
+	RunE:  runMemoryInsightsList,
+}
+
+var memoryInsightsAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new insight",
+	RunE:  runMemoryInsightsAdd,
+}
+
+var memoryInsightsUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update insight content by ID",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runMemoryInsightsUpdate,
+}
+
+var memoryInsightsDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete an insight by ID",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runMemoryInsightsDelete,
+}
+
+var memoryInsightsReinforceCmd = &cobra.Command{
+	Use:   "reinforce <id>",
+	Short: "Reinforce an insight (bump confidence + count)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runMemoryInsightsReinforce,
+}
+
+var memoryInsightsSearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search insights by BM25 relevance",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runMemoryInsightsSearch,
+}
+
+func init() {
+	memoryInsightsCmd.AddCommand(memoryInsightsListCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsAddCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsUpdateCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsDeleteCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsReinforceCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsSearchCmd)
+
+	memoryInsightsListCmd.Flags().IntVar(&insightLimit, "limit", 20, "Maximum insights to show (0 = all)")
+
+	memoryInsightsAddCmd.Flags().StringVar(&insightContent, "content", "", "Insight rule text (required, or pipe via stdin)")
+	memoryInsightsAddCmd.Flags().StringVar(&insightCategory, "category", "", "Category: anti-pattern | communication-style | domain-approach | workflow | anticipation")
+	memoryInsightsAddCmd.Flags().StringVar(&insightTrigger, "trigger", "", "When this insight applies (optional description)")
+	memoryInsightsAddCmd.Flags().Float64Var(&insightConfidence, "confidence", 0.5, "Initial confidence 0.0–1.0")
+
+	memoryInsightsUpdateCmd.Flags().StringVar(&insightContent, "content", "", "New insight content (required, or pipe via stdin)")
+
+	memoryInsightsSearchCmd.Flags().IntVar(&insightSearchLimit, "limit", 5, "Maximum results")
+}
+
+func runMemoryInsightsList(cmd *cobra.Command, args []string) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	agent := strings.TrimSpace(memoryAgent)
+	insights, err := store.ListInsights(context.Background(), agent, insightLimit)
+	if err != nil {
+		return err
+	}
+	if len(insights) == 0 {
+		fmt.Println("No insights found.")
+		return nil
+	}
+
+	fmt.Printf("%-6s %-18s %-6s %-5s  %s\n", "ID", "CATEGORY", "CONF", "REINF", "CONTENT")
+	fmt.Println(strings.Repeat("-", 80))
+	for _, ins := range insights {
+		cat := ins.Category
+		if cat == "" {
+			cat = "-"
+		}
+		preview := ins.Content
+		if len(preview) > 52 {
+			preview = preview[:49] + "..."
+		}
+		preview = strings.ReplaceAll(preview, "\n", " ")
+		fmt.Printf("%-6d %-18s %-6.2f %-5d  %s\n",
+			ins.ID, truncateString(cat, 18), ins.Confidence, ins.ReinforcementCount, preview)
+	}
+	return nil
+}
+
+func runMemoryInsightsAdd(cmd *cobra.Command, args []string) error {
+	agent := strings.TrimSpace(memoryAgent)
+	if agent == "" {
+		return fmt.Errorf("--agent is required")
+	}
+	content, err := readFragmentContent(insightContent)
+	if err != nil {
+		return err
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return fmt.Errorf("--content is required (or pipe content via stdin)")
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ins := &memorydb.Insight{
+		Agent:       agent,
+		Content:     content,
+		Category:    strings.TrimSpace(insightCategory),
+		TriggerDesc: strings.TrimSpace(insightTrigger),
+		Confidence:  insightConfidence,
+	}
+	if err := store.CreateInsight(context.Background(), ins); err != nil {
+		return err
+	}
+	fmt.Printf("created insight: id=%d\n", ins.ID)
+	return nil
+}
+
+func runMemoryInsightsUpdate(cmd *cobra.Command, args []string) error {
+	id, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("id must be an integer: %w", err)
+	}
+	content, err := readFragmentContent(insightContent)
+	if err != nil {
+		return err
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return fmt.Errorf("--content is required (or pipe content via stdin)")
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	if err := store.UpdateInsight(context.Background(), id, content); err != nil {
+		return err
+	}
+	fmt.Printf("updated insight: id=%d\n", id)
+	return nil
+}
+
+func runMemoryInsightsDelete(cmd *cobra.Command, args []string) error {
+	id, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("id must be an integer: %w", err)
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	deleted, err := store.DeleteInsight(context.Background(), id)
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return fmt.Errorf("insight not found: %d", id)
+	}
+	fmt.Printf("deleted insight: id=%d\n", id)
+	return nil
+}
+
+func runMemoryInsightsReinforce(cmd *cobra.Command, args []string) error {
+	id, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("id must be an integer: %w", err)
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	if err := store.ReinforceInsight(context.Background(), id); err != nil {
+		return err
+	}
+
+	ins, _ := store.GetInsightByID(context.Background(), id)
+	if ins != nil {
+		fmt.Printf("reinforced insight %d: confidence=%.2f reinforcements=%d\n",
+			id, ins.Confidence, ins.ReinforcementCount)
+	} else {
+		fmt.Printf("reinforced insight %d\n", id)
+	}
+	return nil
+}
+
+func runMemoryInsightsSearch(cmd *cobra.Command, args []string) error {
+	query := strings.TrimSpace(args[0])
+	agent := strings.TrimSpace(memoryAgent)
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	insights, err := store.SearchInsights(context.Background(), agent, query, insightSearchLimit)
+	if err != nil {
+		return err
+	}
+	if len(insights) == 0 {
+		fmt.Println("No matching insights found.")
+		return nil
+	}
+
+	for _, ins := range insights {
+		cat := ins.Category
+		if cat == "" {
+			cat = "uncategorized"
+		}
+		fmt.Printf("[%d] %s (conf=%.2f, reinf=%d)\n", ins.ID, cat, ins.Confidence, ins.ReinforcementCount)
+		fmt.Println(ins.Content)
+		fmt.Println()
+	}
+	return nil
+}

--- a/cmd/memory_insights.go
+++ b/cmd/memory_insights.go
@@ -11,12 +11,14 @@ import (
 )
 
 var (
-	insightCategory    string
-	insightTrigger     string
-	insightConfidence  float64
-	insightContent     string
-	insightLimit       int
-	insightSearchLimit int
+	insightCategory      string
+	insightTrigger       string
+	insightConfidence    float64
+	insightContent       string
+	insightLimit         int
+	insightSearchLimit   int
+	insightHalfLifeDays  float64
+	insightMinConfidence float64
 )
 
 var memoryInsightsCmd = &cobra.Command{
@@ -86,6 +88,18 @@ var memoryInsightsExpandCmd = &cobra.Command{
 	RunE:  runMemoryInsightsExpand,
 }
 
+var memoryInsightsDecayCmd = &cobra.Command{
+	Use:   "decay",
+	Short: "Apply exponential confidence decay to stale insights",
+	RunE:  runMemoryInsightsDecay,
+}
+
+var memoryInsightsGCCmd = &cobra.Command{
+	Use:   "gc",
+	Short: "Delete insights below minimum confidence threshold",
+	RunE:  runMemoryInsightsGC,
+}
+
 func init() {
 	memoryInsightsCmd.AddCommand(memoryInsightsListCmd)
 	memoryInsightsCmd.AddCommand(memoryInsightsAddCmd)
@@ -94,6 +108,8 @@ func init() {
 	memoryInsightsCmd.AddCommand(memoryInsightsReinforceCmd)
 	memoryInsightsCmd.AddCommand(memoryInsightsSearchCmd)
 	memoryInsightsCmd.AddCommand(memoryInsightsExpandCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsDecayCmd)
+	memoryInsightsCmd.AddCommand(memoryInsightsGCCmd)
 
 	memoryInsightsListCmd.Flags().IntVar(&insightLimit, "limit", 20, "Maximum insights to show (0 = all)")
 
@@ -106,6 +122,8 @@ func init() {
 
 	memoryInsightsSearchCmd.Flags().IntVar(&insightSearchLimit, "limit", 5, "Maximum results")
 	memoryInsightsExpandCmd.Flags().IntVar(&insightSearchLimit, "max-tokens", 500, "Token budget for expansion")
+	memoryInsightsDecayCmd.Flags().Float64Var(&insightHalfLifeDays, "half-life", 30.0, "Decay half-life in days")
+	memoryInsightsGCCmd.Flags().Float64Var(&insightMinConfidence, "min-confidence", 0.1, "Delete insights below this confidence")
 }
 
 func runMemoryInsightsList(cmd *cobra.Command, args []string) error {
@@ -308,5 +326,41 @@ func runMemoryInsightsExpand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	fmt.Println(expanded)
+	return nil
+}
+
+func runMemoryInsightsDecay(cmd *cobra.Command, args []string) error {
+	agent := strings.TrimSpace(memoryAgent)
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	halfLife, _ := cmd.Flags().GetFloat64("half-life")
+	n, err := store.DecayInsights(context.Background(), agent, halfLife)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("decayed %d insights (half-life=%.1f days)\n", n, halfLife)
+	return nil
+}
+
+func runMemoryInsightsGC(cmd *cobra.Command, args []string) error {
+	agent := strings.TrimSpace(memoryAgent)
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	minConf, _ := cmd.Flags().GetFloat64("min-confidence")
+	n, err := store.GCInsights(context.Background(), agent, minConf)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("gc: deleted %d insights below confidence %.2f\n", n, minConf)
 	return nil
 }

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -33,6 +33,7 @@ var (
 	memoryMinePromote          string
 	memoryMinePromoteEvery     time.Duration
 	memoryMineHalfLifeDays     float64
+	memoryMineInsights         bool
 )
 
 var memoryMineCmd = &cobra.Command{
@@ -91,6 +92,7 @@ func init() {
 	memoryMineCmd.Flags().StringVar(&memoryMinePromote, "promote", "never", "Promotion mode: auto|always|never")
 	memoryMineCmd.Flags().DurationVar(&memoryMinePromoteEvery, "promote-every", 6*time.Hour, "Minimum interval between auto-promote runs")
 	memoryMineCmd.Flags().Float64Var(&memoryMineHalfLifeDays, "half-life", 30.0, "Decay half-life in days for post-mine recalculation")
+	memoryMineCmd.Flags().BoolVar(&memoryMineInsights, "insights", false, "Also run insight extraction pass after fragment mining")
 	memoryMineCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)
 }
 
@@ -321,6 +323,17 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Done. create=%d update=%d skip=%d\n", totalCreated, totalUpdated, totalSkipped)
+
+	if memoryMineInsights && !memoryDryRun {
+		fmt.Println("\n--- INSIGHT EXTRACTION ---")
+		insightCount, err := runInsightExtractionPass(ctx, cfg, engine, sessStore, memStore, candidates)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: insight extraction failed: %v\n", err)
+		} else {
+			fmt.Printf("insights: %d created/reinforced\n", insightCount)
+		}
+	}
+
 	return nil
 }
 
@@ -992,4 +1005,217 @@ func readPrefixBytes(content string, maxBytes int) string {
 		return content
 	}
 	return string(b[:maxBytes]) + "..."
+}
+
+// ── Insight extraction pass ───────────────────────────────────────────────────
+
+const insightExtractionSystemPrompt = `You are a behavioral insight extractor.
+
+Output must be valid JSON only (no markdown fences, no prose).
+Return exactly one object with key "insights".
+
+Goal: extract generalized behavioral rules from the conversation transcript.
+Focus on moments where:
+- The user corrects or redirects the assistant
+- The user expresses a preference explicitly or implicitly
+- The assistant failed to anticipate something the user then had to ask for
+- A pattern of interaction is repeated across multiple turns
+
+Do NOT extract:
+- One-off requests with no generalisation
+- Facts about the user's technical setup (those belong in fragment memory)
+- Anything that is already obvious assistant best practice
+- More than 10 insights total
+
+Each insight must have: category (one of: anti-pattern | communication-style | domain-approach | workflow | anticipation), trigger (when it applies), rule (the actionable behavioral change, 1-3 sentences), confidence (0.0-1.0 based on how clearly the evidence supports the pattern).`
+
+type insightExtractionResponse struct {
+	Insights []insightExtractionItem `json:"insights"`
+}
+
+type insightExtractionItem struct {
+	Category   string  `json:"category"`
+	Trigger    string  `json:"trigger"`
+	Rule       string  `json:"rule"`
+	Confidence float64 `json:"confidence"`
+}
+
+// buildInsightTranscript builds a lean transcript for insight extraction.
+// Sam's observation: insight extraction only needs user words + minimal buffer.
+// We include user messages in full (up to 800 chars) and assistant text at 200 chars,
+// stripping all tool output. This keeps the prompt compact while preserving the
+// signal that matters — what the user actually typed.
+func buildInsightTranscript(messages []session.Message) []transcriptMessage {
+	const maxUser = 800
+	const maxAssistant = 200
+	out := make([]transcriptMessage, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Role == llm.RoleTool || msg.Role == llm.RoleSystem {
+			continue
+		}
+		text := strings.TrimSpace(msg.TextContent)
+		if text == "" {
+			continue
+		}
+		limit := maxAssistant
+		if msg.Role == llm.RoleUser {
+			limit = maxUser
+		}
+		if len(text) > limit {
+			text = text[:limit] + "..."
+		}
+		out = append(out, transcriptMessage{Role: string(msg.Role), Text: text})
+	}
+	return out
+}
+
+func buildInsightExtractionPrompt(agent string, messages []session.Message, existing []*memorydb.Insight) string {
+	transcriptJSON, _ := json.MarshalIndent(buildInsightTranscript(messages), "", "  ")
+
+	// Pass a summary of existing insights so the LLM can deduplicate.
+	type existingSummary struct {
+		ID      int64  `json:"id"`
+		Preview string `json:"preview"`
+	}
+	summaries := make([]existingSummary, 0, len(existing))
+	for _, ins := range existing {
+		preview := ins.Content
+		if len(preview) > 120 {
+			preview = preview[:120] + "..."
+		}
+		summaries = append(summaries, existingSummary{ID: ins.ID, Preview: preview})
+	}
+	summariesJSON, _ := json.MarshalIndent(summaries, "", "  ")
+
+	return fmt.Sprintf(`Agent: %s
+
+Existing insights (do not duplicate these patterns):
+%s
+
+Transcript (user messages in full; assistant text abbreviated; tool output omitted):
+%s
+
+Return strict JSON only:
+{
+  "insights": [
+    {"category": "...", "trigger": "...", "rule": "...", "confidence": 0.7},
+    ...
+  ]
+}
+If no new insights are found, return {"insights": []}.`,
+		agent,
+		string(summariesJSON),
+		string(transcriptJSON),
+	)
+}
+
+// runInsightExtractionPass runs an insight extraction pass over mined candidates.
+// For each candidate session, it loads messages, builds a lean transcript, calls
+// the LLM, and writes new insights (or reinforces existing ones via BM25 match).
+func runInsightExtractionPass(
+	ctx context.Context,
+	cfg *config.Config,
+	engine *llm.Engine,
+	sessStore session.Store,
+	memStore *memorydb.Store,
+	candidates []memoryMineCandidate,
+) (int, error) {
+	total := 0
+	for _, candidate := range candidates {
+		messages, _, err := loadMessagesForMining(ctx, sessStore, candidate.Session.ID, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  [insight] skip %s: load messages: %v\n", candidate.Session.ID, err)
+			continue
+		}
+		if len(messages) < 4 {
+			// Too short to contain meaningful patterns.
+			continue
+		}
+
+		// Load existing insights for deduplication context.
+		existing, err := memStore.ListInsights(ctx, candidate.Agent, 50)
+		if err != nil {
+			existing = nil
+		}
+
+		prompt := buildInsightExtractionPrompt(candidate.Agent, messages, existing)
+		raw, err := runExtractionRequest(ctx, engine, prompt)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  [insight] skip %s: llm call: %v\n", candidate.Session.ID, err)
+			continue
+		}
+
+		var resp insightExtractionResponse
+		decoder := json.NewDecoder(strings.NewReader(raw))
+		if err := decoder.Decode(&resp); err != nil {
+			fmt.Fprintf(os.Stderr, "  [insight] skip %s: decode: %v\n", candidate.Session.ID, err)
+			continue
+		}
+
+		for _, item := range resp.Insights {
+			rule := strings.TrimSpace(item.Rule)
+			if rule == "" {
+				continue
+			}
+
+			// Merge-or-create: search for a similar existing insight via BM25.
+			// If we get a hit, reinforce rather than duplicate.
+			similar, _ := memStore.SearchInsights(ctx, candidate.Agent, rule, 1)
+			if len(similar) > 0 {
+				// Rough similarity check: if top result shares significant keywords,
+				// treat it as the same insight and reinforce.
+				if isSimilarInsight(rule, similar[0].Content) {
+					_ = memStore.ReinforceInsight(ctx, similar[0].ID)
+					fmt.Printf("  [insight] reinforced id=%d (conf=%.2f)\n", similar[0].ID, similar[0].Confidence+0.1)
+					total++
+					continue
+				}
+			}
+
+			ins := &memorydb.Insight{
+				Agent:       candidate.Agent,
+				Content:     rule,
+				Category:    strings.TrimSpace(item.Category),
+				TriggerDesc: strings.TrimSpace(item.Trigger),
+				Confidence:  item.Confidence,
+			}
+			if ins.Confidence <= 0 {
+				ins.Confidence = 0.5
+			}
+			if err := memStore.CreateInsight(ctx, ins); err != nil {
+				fmt.Fprintf(os.Stderr, "  [insight] create failed: %v\n", err)
+				continue
+			}
+			fmt.Printf("  [insight] created id=%d cat=%s conf=%.2f\n", ins.ID, ins.Category, ins.Confidence)
+			total++
+		}
+	}
+	return total, nil
+}
+
+// isSimilarInsight is a cheap keyword-overlap heuristic: if more than 40% of
+// the words in the candidate rule appear in the existing insight, treat them as
+// the same pattern. This avoids an embedding call while catching obvious dupes.
+func isSimilarInsight(candidate, existing string) bool {
+	words := func(s string) map[string]struct{} {
+		m := map[string]struct{}{}
+		for _, w := range strings.Fields(strings.ToLower(s)) {
+			if len(w) > 3 { // ignore short stop-words
+				m[w] = struct{}{}
+			}
+		}
+		return m
+	}
+	cw := words(candidate)
+	ew := words(existing)
+	if len(cw) == 0 {
+		return false
+	}
+	overlap := 0
+	for w := range cw {
+		if _, ok := ew[w]; ok {
+			overlap++
+		}
+	}
+	return float64(overlap)/float64(len(cw)) > 0.40
 }

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -1130,6 +1130,12 @@ func runInsightExtractionPass(
 ) (int, error) {
 	total := 0
 	for _, candidate := range candidates {
+		// Skip sessions already processed for insights — avoids redundant LLM
+		// calls and duplicate extraction. MarkInsightMined is called on success.
+		if minedAt, err := memStore.InsightMinedAt(ctx, candidate.Session.ID); err == nil && !minedAt.IsZero() {
+			continue
+		}
+
 		messages, _, err := loadMessagesForMining(ctx, sessStore, candidate.Session.ID, 0)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: load messages: %v\n", candidate.Session.ID, err)
@@ -1196,6 +1202,11 @@ func runInsightExtractionPass(
 			}
 			fmt.Printf("  [insight] created id=%d cat=%s conf=%.2f\n", ins.ID, ins.Category, ins.Confidence)
 			total++
+		}
+
+		// Mark this session as insight-mined so future runs skip it.
+		if err := memStore.MarkInsightMined(ctx, candidate.Session.ID, candidate.Agent); err != nil {
+			fmt.Fprintf(os.Stderr, "  [insight] warning: mark mined failed for %s: %v\n", candidate.Session.ID, err)
 		}
 	}
 	return total, nil

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -332,6 +332,14 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		} else {
 			fmt.Printf("insights: %d created/reinforced\n", insightCount)
 		}
+		// After extraction, apply decay and prune stale insights.
+		decayAgent := strings.TrimSpace(memoryAgent)
+		if n, decayErr := memStore.DecayInsights(ctx, decayAgent, memoryMineHalfLifeDays); decayErr == nil && n > 0 {
+			fmt.Printf("insights: decayed %d entries (half-life=%.1f days)\n", n, memoryMineHalfLifeDays)
+		}
+		if n, gcErr := memStore.GCInsights(ctx, decayAgent, 0.1); gcErr == nil && n > 0 {
+			fmt.Printf("insights: gc deleted %d below 0.10 confidence\n", n)
+		}
 	}
 
 	return nil

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -1201,14 +1201,16 @@ func runInsightExtractionPass(
 	return total, nil
 }
 
-// isSimilarInsight is a cheap keyword-overlap heuristic: if more than 40% of
-// the words in the candidate rule appear in the existing insight, treat them as
-// the same pattern. This avoids an embedding call while catching obvious dupes.
+// isSimilarInsight uses Jaccard similarity on keywords (words >3 chars) to
+// detect duplicate insights. Requires at least 3 qualifying words in the
+// candidate; returns false for very short insights to avoid false positives.
+// Threshold: 40% Jaccard (intersection/union), which catches paraphrases
+// without conflating opposites ("prefer verbose" vs "prefer terse").
 func isSimilarInsight(candidate, existing string) bool {
 	words := func(s string) map[string]struct{} {
 		m := map[string]struct{}{}
 		for _, w := range strings.Fields(strings.ToLower(s)) {
-			if len(w) > 3 { // ignore short stop-words
+			if len(w) > 3 {
 				m[w] = struct{}{}
 			}
 		}
@@ -1216,14 +1218,18 @@ func isSimilarInsight(candidate, existing string) bool {
 	}
 	cw := words(candidate)
 	ew := words(existing)
-	if len(cw) == 0 {
-		return false
+	if len(cw) < 3 {
+		return false // Too short to deduplicate reliably.
 	}
-	overlap := 0
+	intersection := 0
 	for w := range cw {
 		if _, ok := ew[w]; ok {
-			overlap++
+			intersection++
 		}
 	}
-	return float64(overlap)/float64(len(cw)) > 0.40
+	union := len(cw) + len(ew) - intersection
+	if union == 0 {
+		return false
+	}
+	return float64(intersection)/float64(union) > 0.40
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -234,6 +234,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	forceExternalSearch := resolveForceExternalSearch(cfg, serveNativeSearch, serveNoNativeSearch)
 
+	// Open the memory store for insight expansion (best-effort: non-fatal).
+	// Declared here so the factory closure can capture it.
+	var insightsMemStore *memorydb.Store
+	if ms, msErr := openMemoryStore(); msErr == nil {
+		insightsMemStore = ms
+	}
+
 	modelName := activeModel(cfg)
 	factory := func(ctx context.Context) (*serveRuntime, error) {
 		provider, err := llm.NewProvider(cfg)
@@ -269,6 +276,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 			debugRaw:            debugRaw,
 			defaultModel:        modelName,
 			store:               store,
+			insightsStore:       insightsMemStore,
+			insightsMaxTokens:   500,
 			toolsSetting:        settings.Tools,
 			mcpSetting:          settings.MCP,
 			agentName:           agentName,
@@ -282,12 +291,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	if hasJobs && strings.TrimSpace(serveAgent) != "" {
 		fmt.Fprintln(cmd.ErrOrStderr(), "warning: --agent is ignored for --platform jobs; set llm runner_config.agent_name per job definition")
-	}
-
-	// Open the memory store for insight expansion (best-effort: non-fatal).
-	var insightsMemStore *memorydb.Store
-	if ms, msErr := openMemoryStore(); msErr == nil {
-		insightsMemStore = ms
 	}
 
 	// Build the serve.Settings used by non-web platforms.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -234,11 +234,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	forceExternalSearch := resolveForceExternalSearch(cfg, serveNativeSearch, serveNoNativeSearch)
 
-	// Open the memory store for insight expansion (best-effort: non-fatal).
-	// Declared here so the factory closure can capture it.
-	var insightsMemStore *memorydb.Store
-	if ms, msErr := openMemoryStore(); msErr == nil {
-		insightsMemStore = ms
+	// Build the insight expander (nil when disabled or store unavailable).
+	// Captured by the factory closure and shared across all runtimes.
+	var insightsExpander *memorydb.InsightsExpander
+	var insightsMemStore *memorydb.Store // kept for deferred Close
+	if settings.InsightsExpansion {
+		if ms, msErr := openMemoryStore(); msErr == nil {
+			insightsMemStore = ms
+			insightsExpander = memorydb.NewInsightsExpander(ms, agentName, settings.InsightsMaxTokens)
+		}
 	}
 
 	modelName := activeModel(cfg)
@@ -276,9 +280,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			debugRaw:            debugRaw,
 			defaultModel:        modelName,
 			store:               store,
-			insightsStore:       insightsMemStore,
-			insightsExpansion:   settings.InsightsExpansion,
-			insightsMaxTokens:   settings.InsightsMaxTokens,
+			insightsExpander:    insightsExpander,
 			toolsSetting:        settings.Tools,
 			mcpSetting:          settings.MCP,
 			agentName:           agentName,
@@ -308,10 +310,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MCP:                    settings.MCP,
 		Agent:                  agentName,
 		Store:                  store,
-		InsightsExpansion:      settings.InsightsExpansion,
-		InsightsStore:          insightsMemStore,
-		InsightsAgent:          agentName,
-		InsightsMaxTokens:      settings.InsightsMaxTokens,
+		InsightsExpander:       insightsExpander,
 		NewSession: func(ctx context.Context) (*serve.SessionRuntime, error) {
 			rt, err := factory(ctx)
 			if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -277,7 +277,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 			defaultModel:        modelName,
 			store:               store,
 			insightsStore:       insightsMemStore,
-			insightsMaxTokens:   500,
+			insightsExpansion:   settings.InsightsExpansion,
+			insightsMaxTokens:   settings.InsightsMaxTokens,
 			toolsSetting:        settings.Tools,
 			mcpSetting:          settings.MCP,
 			agentName:           agentName,
@@ -307,9 +308,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MCP:                    settings.MCP,
 		Agent:                  agentName,
 		Store:                  store,
+		InsightsExpansion:      settings.InsightsExpansion,
 		InsightsStore:          insightsMemStore,
 		InsightsAgent:          agentName,
-		InsightsMaxTokens:      500,
+		InsightsMaxTokens:      settings.InsightsMaxTokens,
 		NewSession: func(ctx context.Context) (*serve.SessionRuntime, error) {
 			rt, err := factory(ctx)
 			if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/serve"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
@@ -283,6 +284,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.ErrOrStderr(), "warning: --agent is ignored for --platform jobs; set llm runner_config.agent_name per job definition")
 	}
 
+	// Open the memory store for insight expansion (best-effort: non-fatal).
+	var insightsMemStore *memorydb.Store
+	if ms, msErr := openMemoryStore(); msErr == nil {
+		insightsMemStore = ms
+	}
+
 	// Build the serve.Settings used by non-web platforms.
 	serveSettings := serve.Settings{
 		SystemPrompt:           settings.SystemPrompt,
@@ -297,6 +304,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MCP:                    settings.MCP,
 		Agent:                  agentName,
 		Store:                  store,
+		InsightsStore:          insightsMemStore,
+		InsightsAgent:          agentName,
+		InsightsMaxTokens:      500,
 		NewSession: func(ctx context.Context) (*serve.SessionRuntime, error) {
 			rt, err := factory(ctx)
 			if err != nil {
@@ -398,6 +408,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	<-ctx.Done()
+
+	if insightsMemStore != nil {
+		_ = insightsMemStore.Close()
+	}
 
 	if s != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -29,9 +29,7 @@ type serveRuntime struct {
 	toolMgr             *tools.ToolManager
 	mcpManager          *mcp.Manager
 	store               session.Store
-	insightsStore       *memorydb.Store
-	insightsExpansion   bool
-	insightsMaxTokens   int
+	insightsExpander    *memorydb.InsightsExpander
 	systemPrompt        string
 	history             []llm.Message
 	search              bool
@@ -384,17 +382,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	messages = append(messages, inputMessages...)
 
 	// Insights expansion: on the first turn of a stateful session, inject
-	// relevant behavioral guidelines from the insight bank.
-	// Only fires when memory.insights_expansion: true in agent.yaml (default: false).
-	if len(baseHistory) == 0 && stateful && rt.insightsExpansion && rt.insightsStore != nil {
-		maxTok := rt.insightsMaxTokens
-		if maxTok <= 0 {
-			maxTok = 500
-		}
-		userText := lastUserText(inputMessages)
-		if expanded, expErr := rt.insightsStore.ExpandInsights(
-			ctx, rt.agentName, userText, maxTok,
-		); expErr == nil && expanded != "" {
+	// relevant behavioral guidelines. Requires memory.insights_expansion: true
+	// in agent.yaml (default: false).
+	if len(baseHistory) == 0 && stateful {
+		if expanded := rt.insightsExpander.Expand(ctx, lastUserText(inputMessages)); expanded != "" {
 			messages = append(messages, llm.UserText(expanded))
 		}
 	}

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -30,6 +30,7 @@ type serveRuntime struct {
 	mcpManager          *mcp.Manager
 	store               session.Store
 	insightsStore       *memorydb.Store
+	insightsExpansion   bool
 	insightsMaxTokens   int
 	systemPrompt        string
 	history             []llm.Message
@@ -384,7 +385,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 
 	// Insights expansion: on the first turn of a stateful session, inject
 	// relevant behavioral guidelines from the insight bank.
-	if len(baseHistory) == 0 && stateful && rt.insightsStore != nil {
+	// Only fires when memory.insights_expansion: true in agent.yaml (default: false).
+	if len(baseHistory) == 0 && stateful && rt.insightsExpansion && rt.insightsStore != nil {
 		maxTok := rt.insightsMaxTokens
 		if maxTok <= 0 {
 			maxTok = 500

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
@@ -28,6 +29,8 @@ type serveRuntime struct {
 	toolMgr             *tools.ToolManager
 	mcpManager          *mcp.Manager
 	store               session.Store
+	insightsStore       *memorydb.Store
+	insightsMaxTokens   int
 	systemPrompt        string
 	history             []llm.Message
 	search              bool
@@ -378,6 +381,22 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	}
 	messages = append(messages, baseHistory...)
 	messages = append(messages, inputMessages...)
+
+	// Insights expansion: on the first turn of a stateful session, inject
+	// relevant behavioral guidelines from the insight bank.
+	if len(baseHistory) == 0 && stateful && rt.insightsStore != nil {
+		maxTok := rt.insightsMaxTokens
+		if maxTok <= 0 {
+			maxTok = 500
+		}
+		userText := lastUserText(inputMessages)
+		if expanded, expErr := rt.insightsStore.ExpandInsights(
+			ctx, rt.agentName, userText, maxTok,
+		); expErr == nil && expanded != "" {
+			messages = append(messages, llm.UserText(expanded))
+		}
+	}
+
 	req.Messages = messages
 
 	var produced []llm.Message

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -54,6 +54,10 @@ type SessionSettings struct {
 	MaxTurns        int
 	MaxOutputTokens int // 0 = use provider default
 	Search          bool
+
+	// Memory / insights
+	InsightsExpansion bool
+	InsightsMaxTokens int // 0 → default 500
 }
 
 // CLIFlags holds the CLI flag values that can override settings.
@@ -258,6 +262,12 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 
 	// Search: CLI or agent enables it
 	s.Search = cli.Search || (agent != nil && agent.Search)
+
+	// Memory / insights — only configurable via agent.yaml (no CLI override)
+	if agent != nil {
+		s.InsightsExpansion = agent.Memory.InsightsExpansion
+		s.InsightsMaxTokens = agent.Memory.InsightsMaxTokens
+	}
 
 	return s, nil
 }

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -64,6 +64,9 @@ type Agent struct {
 	// "auto" includes project instructions if the agent has coding tools (write_file, edit_file, shell)
 	ProjectInstructions string `yaml:"project_instructions,omitempty"`
 
+	// Memory settings
+	Memory MemoryConfig `yaml:"memory,omitempty"`
+
 	// MCP servers to auto-connect
 	MCP []MCPConfig `yaml:"mcp,omitempty"`
 
@@ -165,6 +168,15 @@ type SpawnConfig struct {
 type MCPConfig struct {
 	Name    string `yaml:"name"`
 	Command string `yaml:"command,omitempty"`
+}
+
+// MemoryConfig holds memory-related settings for an agent.
+type MemoryConfig struct {
+	// InsightsExpansion enables injecting relevant behavioral insights at the
+	// start of each new session (first user turn). Default false.
+	InsightsExpansion bool `yaml:"insights_expansion,omitempty"`
+	// InsightsMaxTokens caps the insight block token budget. Default: 500.
+	InsightsMaxTokens int `yaml:"insights_max_tokens,omitempty"`
 }
 
 // OutputToolConfig configures a tool for capturing structured output.

--- a/internal/memory/expander.go
+++ b/internal/memory/expander.go
@@ -1,0 +1,39 @@
+package memory
+
+import "context"
+
+// InsightsExpander wraps a Store and exposes a single Expand method for
+// injecting behavioral insights at conversation start. A nil *InsightsExpander
+// is always a safe no-op — callers never need to nil-check before calling.
+type InsightsExpander struct {
+	store     *Store
+	agent     string
+	maxTokens int
+}
+
+// NewInsightsExpander returns an expander configured for the given agent.
+// maxTokens is the token budget for the injected block (0 → default 500).
+// Returns nil when store is nil — the nil receiver is safe to call.
+func NewInsightsExpander(store *Store, agent string, maxTokens int) *InsightsExpander {
+	if store == nil {
+		return nil
+	}
+	if maxTokens <= 0 {
+		maxTokens = 500
+	}
+	return &InsightsExpander{store: store, agent: agent, maxTokens: maxTokens}
+}
+
+// Expand searches the insight bank using userText as the query and returns
+// the formatted block ready to inject as a user message.
+// Returns "" when disabled, no matches, or on any error.
+func (e *InsightsExpander) Expand(ctx context.Context, userText string) string {
+	if e == nil || e.store == nil {
+		return ""
+	}
+	expanded, err := e.store.ExpandInsights(ctx, e.agent, userText, e.maxTokens)
+	if err != nil {
+		return ""
+	}
+	return expanded
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -176,6 +176,30 @@ CREATE TABLE IF NOT EXISTS memory_fragment_sources (
 
 CREATE INDEX IF NOT EXISTS idx_fragment_sources_agent_path ON memory_fragment_sources(agent, path);
 CREATE INDEX IF NOT EXISTS idx_fragment_sources_session_id ON memory_fragment_sources(session_id);
+
+CREATE TABLE IF NOT EXISTS memory_insights (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent               TEXT NOT NULL,
+    content             TEXT NOT NULL,
+    category            TEXT NOT NULL DEFAULT '',
+    trigger_desc        TEXT NOT NULL DEFAULT '',
+    confidence          REAL NOT NULL DEFAULT 0.5,
+    reinforcement_count INTEGER NOT NULL DEFAULT 1,
+    created_at          DATETIME NOT NULL DEFAULT (datetime('now')),
+    last_reinforced     DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_insights_agent ON memory_insights(agent);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_insights_fts USING fts5(
+    agent UNINDEXED,
+    content,
+    category,
+    trigger_desc,
+    content='memory_insights',
+    content_rowid='id',
+    tokenize='unicode61'
+);
 `
 
 // NewStore opens memory.db and initializes schema.
@@ -1790,4 +1814,292 @@ func sqliteLikeEscape(s string) string {
 	s = strings.ReplaceAll(s, `%`, `\%`)
 	s = strings.ReplaceAll(s, `_`, `\_`)
 	return s
+}
+
+// ── Insights ──────────────────────────────────────────────────────────────────
+
+// Insight is a generalized behavioral rule extracted from past sessions.
+// Unlike fragments (which store facts), insights store actionable patterns
+// that change how the agent behaves in future similar situations.
+type Insight struct {
+	ID                 int64
+	Agent              string
+	Content            string
+	Category           string
+	TriggerDesc        string
+	Confidence         float64
+	ReinforcementCount int
+	CreatedAt          time.Time
+	LastReinforced     time.Time
+}
+
+// CreateInsight inserts a new insight and syncs the FTS index.
+func (s *Store) CreateInsight(ctx context.Context, ins *Insight) error {
+	if ins == nil {
+		return fmt.Errorf("insight is nil")
+	}
+	if strings.TrimSpace(ins.Agent) == "" {
+		return fmt.Errorf("agent is required")
+	}
+	if strings.TrimSpace(ins.Content) == "" {
+		return fmt.Errorf("content is required")
+	}
+	now := time.Now()
+	if ins.CreatedAt.IsZero() {
+		ins.CreatedAt = now
+	}
+	if ins.LastReinforced.IsZero() {
+		ins.LastReinforced = ins.CreatedAt
+	}
+	if ins.Confidence == 0 {
+		ins.Confidence = 0.5
+	}
+	if ins.ReinforcementCount == 0 {
+		ins.ReinforcementCount = 1
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO memory_insights
+		    (agent, content, category, trigger_desc, confidence, reinforcement_count, created_at, last_reinforced)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		ins.Agent, ins.Content, ins.Category, ins.TriggerDesc,
+		ins.Confidence, ins.ReinforcementCount,
+		ins.CreatedAt.UTC().Format(time.RFC3339),
+		ins.LastReinforced.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return fmt.Errorf("create insight: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get insight id: %w", err)
+	}
+	ins.ID = id
+
+	// Sync FTS.
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO memory_insights_fts(rowid, agent, content, category, trigger_desc)
+		 VALUES (?, ?, ?, ?, ?)`,
+		id, ins.Agent, ins.Content, ins.Category, ins.TriggerDesc)
+	if err != nil {
+		return fmt.Errorf("sync insight fts: %w", err)
+	}
+	return nil
+}
+
+// ListInsights returns insights for an agent, newest first.
+func (s *Store) ListInsights(ctx context.Context, agent string, limit int) ([]*Insight, error) {
+	q := `SELECT id, agent, content, category, trigger_desc, confidence, reinforcement_count,
+	             created_at, last_reinforced
+	      FROM memory_insights`
+	args := []any{}
+	if strings.TrimSpace(agent) != "" {
+		q += ` WHERE agent = ?`
+		args = append(args, agent)
+	}
+	q += ` ORDER BY last_reinforced DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT %d`, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list insights: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Insight
+	for rows.Next() {
+		ins, err := scanInsight(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ins)
+	}
+	return out, rows.Err()
+}
+
+// GetInsightByID returns a single insight by its row ID.
+func (s *Store) GetInsightByID(ctx context.Context, id int64) (*Insight, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, agent, content, category, trigger_desc, confidence, reinforcement_count,
+		       created_at, last_reinforced
+		FROM memory_insights WHERE id = ?`, id)
+	ins, err := scanInsight(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return ins, err
+}
+
+// UpdateInsight replaces the content of an insight and resets FTS.
+func (s *Store) UpdateInsight(ctx context.Context, id int64, content string) error {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return fmt.Errorf("content is required")
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE memory_insights SET content = ?, last_reinforced = ? WHERE id = ?`,
+		content, time.Now().UTC().Format(time.RFC3339), id)
+	if err != nil {
+		return fmt.Errorf("update insight: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("insight not found: %d", id)
+	}
+
+	// Rebuild FTS row.
+	ins, err := s.GetInsightByID(ctx, id)
+	if err != nil || ins == nil {
+		return err
+	}
+	_, _ = s.db.ExecContext(ctx,
+		`INSERT INTO memory_insights_fts(memory_insights_fts, rowid, agent, content, category, trigger_desc)
+		 VALUES ('delete', ?, ?, ?, ?, ?)`,
+		id, ins.Agent, ins.Content, ins.Category, ins.TriggerDesc)
+	_, _ = s.db.ExecContext(ctx,
+		`INSERT INTO memory_insights_fts(rowid, agent, content, category, trigger_desc)
+		 VALUES (?, ?, ?, ?, ?)`,
+		id, ins.Agent, content, ins.Category, ins.TriggerDesc)
+	return nil
+}
+
+// DeleteInsight removes an insight and its FTS entry.
+func (s *Store) DeleteInsight(ctx context.Context, id int64) (bool, error) {
+	ins, err := s.GetInsightByID(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	if ins == nil {
+		return false, nil
+	}
+
+	_, _ = s.db.ExecContext(ctx,
+		`INSERT INTO memory_insights_fts(memory_insights_fts, rowid, agent, content, category, trigger_desc)
+		 VALUES ('delete', ?, ?, ?, ?, ?)`,
+		id, ins.Agent, ins.Content, ins.Category, ins.TriggerDesc)
+
+	res, err := s.db.ExecContext(ctx, `DELETE FROM memory_insights WHERE id = ?`, id)
+	if err != nil {
+		return false, fmt.Errorf("delete insight: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// ReinforceInsight bumps the reinforcement count and nudges confidence upward
+// using a logarithmic schedule (diminishing returns after the first few observations).
+func (s *Store) ReinforceInsight(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE memory_insights
+		SET reinforcement_count = reinforcement_count + 1,
+		    confidence = MIN(1.0, confidence + (1.0 - confidence) * 0.2),
+		    last_reinforced = ?
+		WHERE id = ?`,
+		time.Now().UTC().Format(time.RFC3339), id)
+	if err != nil {
+		return fmt.Errorf("reinforce insight: %w", err)
+	}
+	return nil
+}
+
+// SearchInsights returns insights matching a BM25 query, sorted by relevance.
+func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit int) ([]*Insight, error) {
+	if strings.TrimSpace(query) == "" {
+		return s.ListInsights(ctx, agent, limit)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	args := []any{query}
+	agentClause := ""
+	if strings.TrimSpace(agent) != "" {
+		agentClause = `AND i.agent = ?`
+		args = append(args, agent)
+	}
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT i.id, i.agent, i.content, i.category, i.trigger_desc,
+		       i.confidence, i.reinforcement_count, i.created_at, i.last_reinforced
+		FROM memory_insights_fts f
+		JOIN memory_insights i ON i.id = f.rowid
+		WHERE memory_insights_fts MATCH ? %s
+		ORDER BY rank * (1.0 / MAX(i.confidence, 0.1))
+		LIMIT ?`, agentClause), args...)
+	if err != nil {
+		return nil, fmt.Errorf("search insights: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Insight
+	for rows.Next() {
+		ins, err := scanInsight(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ins)
+	}
+	return out, rows.Err()
+}
+
+// ExpandInsights searches the insight bank and formats the top results as a
+// compact block suitable for injection into the conversation context.
+// maxTokens is a rough token budget (approximated at 4 chars/token).
+// Returns an empty string when no insights are found or the store has none.
+func (s *Store) ExpandInsights(ctx context.Context, agent, query string, maxTokens int) (string, error) {
+	if maxTokens <= 0 {
+		maxTokens = 500
+	}
+	maxChars := maxTokens * 4
+
+	insights, err := s.SearchInsights(ctx, agent, query, 10)
+	if err != nil {
+		return "", err
+	}
+	if len(insights) == 0 {
+		return "", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<insights>\n")
+	sb.WriteString("Behavioral guidelines from past sessions:\n")
+	used := sb.Len()
+
+	for i, ins := range insights {
+		// Only include insights above a minimum confidence threshold.
+		if ins.Confidence < 0.4 {
+			continue
+		}
+		line := fmt.Sprintf("%d. %s\n", i+1, strings.TrimSpace(ins.Content))
+		if used+len(line) > maxChars {
+			break
+		}
+		sb.WriteString(line)
+		used += len(line)
+	}
+	sb.WriteString("</insights>")
+
+	// If nothing was written beyond the header, return empty.
+	if sb.Len() <= len("<insights>\nBehavioral guidelines from past sessions:\n</insights>") {
+		return "", nil
+	}
+	return sb.String(), nil
+}
+
+func scanInsight(scanner interface{ Scan(dest ...any) error }) (*Insight, error) {
+	var ins Insight
+	var createdAt, lastReinforced string
+	err := scanner.Scan(
+		&ins.ID, &ins.Agent, &ins.Content, &ins.Category, &ins.TriggerDesc,
+		&ins.Confidence, &ins.ReinforcementCount, &createdAt, &lastReinforced,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ins.CreatedAt, _ = parseFlexibleTime(createdAt)
+	ins.LastReinforced, _ = parseFlexibleTime(lastReinforced)
+	return &ins, nil
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1897,7 +1897,7 @@ func (s *Store) ListInsights(ctx context.Context, agent string, limit int) ([]*I
 		q += ` WHERE agent = ?`
 		args = append(args, agent)
 	}
-	q += ` ORDER BY last_reinforced DESC`
+	q += ` ORDER BY confidence DESC, last_reinforced DESC`
 	if limit > 0 {
 		q += fmt.Sprintf(` LIMIT %d`, limit)
 	}
@@ -2035,6 +2035,9 @@ func buildFTSQuery(query string) string {
 	return strings.Join(terms, " OR ")
 }
 
+// SearchInsights finds insights via BM25 full-text search. Used for deduplication
+// during extraction (checking if a newly mined insight already exists), not for
+// injection — ExpandInsights returns all insights sorted by confidence instead.
 func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit int) ([]*Insight, error) {
 	if strings.TrimSpace(query) == "" {
 		return s.ListInsights(ctx, agent, limit)
@@ -2076,17 +2079,21 @@ func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit i
 	return out, rows.Err()
 }
 
-// ExpandInsights searches the insight bank and formats the top results as a
-// compact block suitable for injection into the conversation context.
+// ExpandInsights returns all insights for the agent sorted by confidence,
+// formatted as a compact block ready for injection into conversation context.
 // maxTokens is a rough token budget (approximated at 4 chars/token).
-// Returns an empty string when no insights are found or the store has none.
-func (s *Store) ExpandInsights(ctx context.Context, agent, query string, maxTokens int) (string, error) {
+// Returns an empty string when the bank is empty.
+//
+// No search/filtering is applied: insight banks are small and curated, so
+// returning all of them (within the token cap) is more correct than trying
+// to match them against the user's first message via BM25 or embeddings.
+func (s *Store) ExpandInsights(ctx context.Context, agent, _ string, maxTokens int) (string, error) {
 	if maxTokens <= 0 {
 		maxTokens = 500
 	}
 	maxChars := maxTokens * 4
 
-	insights, err := s.SearchInsights(ctx, agent, query, 10)
+	insights, err := s.ListInsights(ctx, agent, 200)
 	if err != nil {
 		return "", err
 	}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2005,6 +2005,36 @@ func (s *Store) ReinforceInsight(ctx context.Context, id int64) error {
 }
 
 // SearchInsights returns insights matching a BM25 query, sorted by relevance.
+// buildFTSQuery converts a free-text query to an FTS5 OR expression so that
+// any word match scores a hit (BM25 ranking then surfaces the best results).
+// Words shorter than 3 characters and duplicates are dropped.
+func buildFTSQuery(query string) string {
+	seen := map[string]struct{}{}
+	var terms []string
+	for _, w := range strings.Fields(strings.ToLower(query)) {
+		// Strip non-alphanumeric so we don't pass FTS5 syntax characters.
+		var clean []rune
+		for _, r := range w {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+				clean = append(clean, r)
+			}
+		}
+		s := string(clean)
+		if len(s) < 3 {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		terms = append(terms, s+"*") // prefix match for basic stemming
+	}
+	if len(terms) == 0 {
+		return query
+	}
+	return strings.Join(terms, " OR ")
+}
+
 func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit int) ([]*Insight, error) {
 	if strings.TrimSpace(query) == "" {
 		return s.ListInsights(ctx, agent, limit)
@@ -2013,7 +2043,8 @@ func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit i
 		limit = 10
 	}
 
-	args := []any{query}
+	ftsQuery := buildFTSQuery(query)
+	args := []any{ftsQuery}
 	agentClause := ""
 	if strings.TrimSpace(agent) != "" {
 		agentClause = `AND i.agent = ?`
@@ -2102,4 +2133,88 @@ func scanInsight(scanner interface{ Scan(dest ...any) error }) (*Insight, error)
 	ins.CreatedAt, _ = parseFlexibleTime(createdAt)
 	ins.LastReinforced, _ = parseFlexibleTime(lastReinforced)
 	return &ins, nil
+}
+
+// DecayInsights reduces confidence for insights that haven't been reinforced
+// recently, using an exponential half-life model identical to fragment decay.
+// For each insight, the new confidence is:
+//
+//	new = current * 2^(-days_since_reinforced / halfLifeDays)
+//
+// Returns the number of insights updated.
+func (s *Store) DecayInsights(ctx context.Context, agent string, halfLifeDays float64) (int, error) {
+	if halfLifeDays <= 0 {
+		halfLifeDays = 30
+	}
+	// Fetch all insights for the agent (or all agents if agent=="").
+	query := `SELECT id, confidence, last_reinforced FROM memory_insights`
+	var args []any
+	if agent != "" {
+		query += ` WHERE agent = ?`
+		args = append(args, agent)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("decay insights query: %w", err)
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		id         int64
+		confidence float64
+		lastReinf  time.Time
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		var lastReinfStr string
+		if err := rows.Scan(&c.id, &c.confidence, &lastReinfStr); err != nil {
+			continue
+		}
+		c.lastReinf, _ = parseFlexibleTime(lastReinfStr)
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+
+	now := time.Now()
+	updated := 0
+	for _, c := range candidates {
+		daysSince := now.Sub(c.lastReinf).Hours() / 24
+		if daysSince < 1 {
+			continue // No meaningful decay within the first day.
+		}
+		decayed := c.confidence * math.Pow(2, -daysSince/halfLifeDays)
+		if math.Abs(decayed-c.confidence) < 0.001 {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE memory_insights SET confidence = ? WHERE id = ?`,
+			decayed, c.id,
+		); err != nil {
+			continue
+		}
+		updated++
+	}
+	return updated, nil
+}
+
+// GCInsights deletes insights whose confidence has fallen below minConfidence.
+// This is typically called after DecayInsights to prune stale entries.
+// Returns the number of insights deleted.
+func (s *Store) GCInsights(ctx context.Context, agent string, minConfidence float64) (int, error) {
+	if minConfidence <= 0 {
+		minConfidence = 0.1
+	}
+	query := `DELETE FROM memory_insights WHERE confidence < ?`
+	var args []any = []any{minConfidence}
+	if agent != "" {
+		query = `DELETE FROM memory_insights WHERE confidence < ? AND agent = ?`
+		args = append(args, agent)
+	}
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("gc insights: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1858,7 +1858,13 @@ func (s *Store) CreateInsight(ctx context.Context, ins *Insight) error {
 		ins.ReinforcementCount = 1
 	}
 
-	res, err := s.db.ExecContext(ctx, `
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("create insight tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	res, err := tx.ExecContext(ctx, `
 		INSERT INTO memory_insights
 		    (agent, content, category, trigger_desc, confidence, reinforcement_count, created_at, last_reinforced)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1876,15 +1882,13 @@ func (s *Store) CreateInsight(ctx context.Context, ins *Insight) error {
 	}
 	ins.ID = id
 
-	// Sync FTS.
-	_, err = s.db.ExecContext(ctx,
+	if _, err = tx.ExecContext(ctx,
 		`INSERT INTO memory_insights_fts(rowid, agent, content, category, trigger_desc)
 		 VALUES (?, ?, ?, ?, ?)`,
-		id, ins.Agent, ins.Content, ins.Category, ins.TriggerDesc)
-	if err != nil {
+		id, ins.Agent, ins.Content, ins.Category, ins.TriggerDesc); err != nil {
 		return fmt.Errorf("sync insight fts: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }
 
 // ListInsights returns insights for an agent, newest first.
@@ -1938,31 +1942,43 @@ func (s *Store) UpdateInsight(ctx context.Context, id int64, content string) err
 	if content == "" {
 		return fmt.Errorf("content is required")
 	}
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE memory_insights SET content = ?, last_reinforced = ? WHERE id = ?`,
-		content, time.Now().UTC().Format(time.RFC3339), id)
+
+	// Fetch old row before UPDATE so the FTS delete command uses the exact
+	// original content (FTS5 delete requires the stored values to match).
+	old, err := s.GetInsightByID(ctx, id)
 	if err != nil {
-		return fmt.Errorf("update insight: %w", err)
+		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
+	if old == nil {
 		return fmt.Errorf("insight not found: %d", id)
 	}
 
-	// Rebuild FTS row.
-	ins, err := s.GetInsightByID(ctx, id)
-	if err != nil || ins == nil {
-		return err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("update insight tx: %w", err)
 	}
-	_, _ = s.db.ExecContext(ctx,
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err = tx.ExecContext(ctx,
+		`UPDATE memory_insights SET content = ?, last_reinforced = ? WHERE id = ?`,
+		content, time.Now().UTC().Format(time.RFC3339), id); err != nil {
+		return fmt.Errorf("update insight: %w", err)
+	}
+
+	// Remove old FTS entry then insert updated one.
+	if _, err = tx.ExecContext(ctx,
 		`INSERT INTO memory_insights_fts(memory_insights_fts, rowid, agent, content, category, trigger_desc)
 		 VALUES ('delete', ?, ?, ?, ?, ?)`,
-		id, ins.Agent, ins.Content, ins.Category, ins.TriggerDesc)
-	_, _ = s.db.ExecContext(ctx,
+		id, old.Agent, old.Content, old.Category, old.TriggerDesc); err != nil {
+		return fmt.Errorf("fts delete insight: %w", err)
+	}
+	if _, err = tx.ExecContext(ctx,
 		`INSERT INTO memory_insights_fts(rowid, agent, content, category, trigger_desc)
 		 VALUES (?, ?, ?, ?, ?)`,
-		id, ins.Agent, content, ins.Category, ins.TriggerDesc)
-	return nil
+		id, old.Agent, content, old.Category, old.TriggerDesc); err != nil {
+		return fmt.Errorf("fts insert insight: %w", err)
+	}
+	return tx.Commit()
 }
 
 // DeleteInsight removes an insight and its FTS entry.
@@ -2030,7 +2046,7 @@ func buildFTSQuery(query string) string {
 		terms = append(terms, s+"*") // prefix match for basic stemming
 	}
 	if len(terms) == 0 {
-		return query
+		return ""
 	}
 	return strings.Join(terms, " OR ")
 }
@@ -2101,27 +2117,30 @@ func (s *Store) ExpandInsights(ctx context.Context, agent, _ string, maxTokens i
 		return "", nil
 	}
 
-	var sb strings.Builder
-	sb.WriteString("<insights>\n")
-	sb.WriteString("Behavioral guidelines from past sessions:\n")
-	used := sb.Len()
+	const header = "<insights>\nBehavioral guidelines from past sessions:\n"
+	const footer = "</insights>"
 
-	for i, ins := range insights {
+	var sb strings.Builder
+	sb.WriteString(header)
+	used := sb.Len()
+	n := 0
+
+	for _, ins := range insights {
 		// Only include insights above a minimum confidence threshold.
 		if ins.Confidence < 0.4 {
 			continue
 		}
-		line := fmt.Sprintf("%d. %s\n", i+1, strings.TrimSpace(ins.Content))
+		n++
+		line := fmt.Sprintf("%d. %s\n", n, strings.TrimSpace(ins.Content))
 		if used+len(line) > maxChars {
 			break
 		}
 		sb.WriteString(line)
 		used += len(line)
 	}
-	sb.WriteString("</insights>")
+	sb.WriteString(footer)
 
-	// If nothing was written beyond the header, return empty.
-	if sb.Len() <= len("<insights>\nBehavioral guidelines from past sessions:\n</insights>") {
+	if n == 0 {
 		return "", nil
 	}
 	return sb.String(), nil
@@ -2179,6 +2198,9 @@ func (s *Store) DecayInsights(ctx context.Context, agent string, halfLifeDays fl
 			continue
 		}
 		c.lastReinf, _ = parseFlexibleTime(lastReinfStr)
+		if c.lastReinf.IsZero() {
+			continue // Malformed timestamp — skip rather than catastrophic decay.
+		}
 		candidates = append(candidates, c)
 	}
 	rows.Close()
@@ -2212,16 +2234,59 @@ func (s *Store) GCInsights(ctx context.Context, agent string, minConfidence floa
 	if minConfidence <= 0 {
 		minConfidence = 0.1
 	}
-	query := `DELETE FROM memory_insights WHERE confidence < ?`
-	var args []any = []any{minConfidence}
+
+	// Fetch candidates first so we can clean up FTS entries before deleting rows.
+	selectQ := `SELECT id, agent, content, category, trigger_desc FROM memory_insights WHERE confidence < ?`
+	selectArgs := []any{minConfidence}
 	if agent != "" {
-		query = `DELETE FROM memory_insights WHERE confidence < ? AND agent = ?`
-		args = append(args, agent)
+		selectQ += ` AND agent = ?`
+		selectArgs = append(selectArgs, agent)
 	}
-	res, err := s.db.ExecContext(ctx, query, args...)
+	rows, err := s.db.QueryContext(ctx, selectQ, selectArgs...)
 	if err != nil {
-		return 0, fmt.Errorf("gc insights: %w", err)
+		return 0, fmt.Errorf("gc insights select: %w", err)
 	}
-	n, _ := res.RowsAffected()
-	return int(n), nil
+	type gcRow struct {
+		id          int64
+		agent       string
+		content     string
+		category    string
+		triggerDesc string
+	}
+	var victims []gcRow
+	for rows.Next() {
+		var r gcRow
+		if err := rows.Scan(&r.id, &r.agent, &r.content, &r.category, &r.triggerDesc); err == nil {
+			victims = append(victims, r)
+		}
+	}
+	rows.Close()
+
+	if len(victims) == 0 {
+		return 0, nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("gc insights tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	deleted := 0
+	for _, v := range victims {
+		_, _ = tx.ExecContext(ctx,
+			`INSERT INTO memory_insights_fts(memory_insights_fts, rowid, agent, content, category, trigger_desc)
+			 VALUES ('delete', ?, ?, ?, ?, ?)`,
+			v.id, v.agent, v.content, v.category, v.triggerDesc)
+		if res, err := tx.ExecContext(ctx,
+			`DELETE FROM memory_insights WHERE id = ?`, v.id); err == nil {
+			if n, _ := res.RowsAffected(); n > 0 {
+				deleted++
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("gc insights commit: %w", err)
+	}
+	return deleted, nil
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -200,6 +200,12 @@ CREATE VIRTUAL TABLE IF NOT EXISTS memory_insights_fts USING fts5(
     content_rowid='id',
     tokenize='unicode61'
 );
+
+CREATE TABLE IF NOT EXISTS memory_insight_mining_state (
+    session_id TEXT PRIMARY KEY,
+    agent      TEXT NOT NULL,
+    mined_at   DATETIME NOT NULL
+);
 `
 
 // NewStore opens memory.db and initializes schema.
@@ -1341,6 +1347,37 @@ func (s *Store) UpsertState(ctx context.Context, st *MiningState) error {
 		return fmt.Errorf("upsert mining state: %w", err)
 	}
 	return nil
+}
+
+// InsightMinedAt returns the time a session's insights were last extracted,
+// or (time.Time{}, nil) if the session has never been insight-mined.
+func (s *Store) InsightMinedAt(ctx context.Context, sessionID string) (time.Time, error) {
+	var raw string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT mined_at FROM memory_insight_mining_state WHERE session_id = ?`,
+		sessionID,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, _ := parseFlexibleTime(raw)
+	return t, nil
+}
+
+// MarkInsightMined records that insight extraction has run for a session.
+func (s *Store) MarkInsightMined(ctx context.Context, sessionID, agent string) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO memory_insight_mining_state(session_id, agent, mined_at)
+		VALUES(?, ?, ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+			agent    = excluded.agent,
+			mined_at = excluded.mined_at`,
+		sessionID, agent, time.Now().UTC().Format(time.RFC3339),
+	)
+	return err
 }
 
 // FragmentCountsByAgent returns count(fragment) grouped by agent.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1220,7 +1221,7 @@ func TestInsightExpand(t *testing.T) {
 	if out == "" {
 		t.Fatal("ExpandInsights returned empty string for matching query")
 	}
-	if !containsSubstring(out, "<insights>") {
+	if !strings.Contains(out, "<insights>") {
 		t.Errorf("output missing <insights> tag: %q", out)
 	}
 
@@ -1232,17 +1233,4 @@ func TestInsightExpand(t *testing.T) {
 	if out2 != "" {
 		t.Errorf("expected empty for unknown agent, got: %q", out2)
 	}
-}
-
-func containsSubstring(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstringHelper(s, sub))
-}
-
-func containsSubstringHelper(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1004,3 +1004,245 @@ func newTestStore(t *testing.T) *Store {
 	}
 	return store
 }
+
+// ── Insight tests ─────────────────────────────────────────────────────────────
+
+func TestInsightCRUD(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	ins := &Insight{
+		Agent:       "jarvis",
+		Content:     "Do not expose internal tooling names in public posts.",
+		Category:    "anti-pattern",
+		TriggerDesc: "writing a blog post or public article",
+		Confidence:  0.9,
+	}
+	if err := store.CreateInsight(ctx, ins); err != nil {
+		t.Fatalf("CreateInsight: %v", err)
+	}
+	if ins.ID == 0 {
+		t.Fatal("expected non-zero ID after CreateInsight")
+	}
+
+	got, err := store.GetInsightByID(ctx, ins.ID)
+	if err != nil {
+		t.Fatalf("GetInsightByID: %v", err)
+	}
+	if got.Content != ins.Content {
+		t.Errorf("content = %q, want %q", got.Content, ins.Content)
+	}
+	if got.Category != "anti-pattern" {
+		t.Errorf("category = %q, want anti-pattern", got.Category)
+	}
+
+	// Update
+	if err := store.UpdateInsight(ctx, ins.ID, "Never mention NZBGeek or SABnzbd in public posts."); err != nil {
+		t.Fatalf("UpdateInsight: %v", err)
+	}
+	got2, _ := store.GetInsightByID(ctx, ins.ID)
+	if got2.Content != "Never mention NZBGeek or SABnzbd in public posts." {
+		t.Errorf("after update, content = %q", got2.Content)
+	}
+
+	// Delete
+	deleted, err := store.DeleteInsight(ctx, ins.ID)
+	if err != nil {
+		t.Fatalf("DeleteInsight: %v", err)
+	}
+	if !deleted {
+		t.Error("DeleteInsight returned false")
+	}
+	got3, err := store.GetInsightByID(ctx, ins.ID)
+	if err != nil {
+		t.Fatalf("GetInsightByID after delete: %v", err)
+	}
+	if got3 != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestInsightListAndSearch(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for i, content := range []string{
+		"Never expose private tool names in public writing.",
+		"User prefers direct answers without hedging.",
+		"Always search memory before answering questions about setup.",
+	} {
+		cat := []string{"anti-pattern", "communication-style", "workflow"}[i]
+		if err := store.CreateInsight(ctx, &Insight{
+			Agent:      "jarvis",
+			Content:    content,
+			Category:   cat,
+			Confidence: 0.7 + float64(i)*0.1,
+		}); err != nil {
+			t.Fatalf("CreateInsight[%d]: %v", i, err)
+		}
+	}
+
+	list, err := store.ListInsights(ctx, "jarvis", 10)
+	if err != nil {
+		t.Fatalf("ListInsights: %v", err)
+	}
+	if len(list) != 3 {
+		t.Errorf("len(list) = %d, want 3", len(list))
+	}
+
+	results, err := store.SearchInsights(ctx, "jarvis", "private tool names blog", 5)
+	if err != nil {
+		t.Fatalf("SearchInsights: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("SearchInsights returned nothing for relevant query")
+	}
+	// Top result should be the anti-pattern about private tools.
+	if results[0].Category != "anti-pattern" {
+		t.Errorf("top result category = %q, want anti-pattern", results[0].Category)
+	}
+}
+
+func TestInsightReinforce(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	ins := &Insight{
+		Agent:      "jarvis",
+		Content:    "User always wants a recommendation, not a list of options.",
+		Category:   "communication-style",
+		Confidence: 0.5,
+	}
+	if err := store.CreateInsight(ctx, ins); err != nil {
+		t.Fatalf("CreateInsight: %v", err)
+	}
+
+	if err := store.ReinforceInsight(ctx, ins.ID); err != nil {
+		t.Fatalf("ReinforceInsight: %v", err)
+	}
+
+	got, _ := store.GetInsightByID(ctx, ins.ID)
+	if got.Confidence <= 0.5 {
+		t.Errorf("confidence after reinforce = %.3f, want > 0.5", got.Confidence)
+	}
+	// CreateInsight seeds reinforcement_count=1, so after one reinforce it's 2.
+	if got.ReinforcementCount != 2 {
+		t.Errorf("reinforcement_count = %d, want 2", got.ReinforcementCount)
+	}
+}
+
+func TestInsightDecayAndGC(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	// Insert a high-confidence insight and backdate last_reinforced by 60 days.
+	ins := &Insight{
+		Agent:      "jarvis",
+		Content:    "Old insight that should decay.",
+		Category:   "workflow",
+		Confidence: 0.8,
+	}
+	if err := store.CreateInsight(ctx, ins); err != nil {
+		t.Fatalf("CreateInsight: %v", err)
+	}
+	// Manually backdate to simulate staleness.
+	old := time.Now().Add(-60 * 24 * time.Hour)
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE memory_insights SET last_reinforced = ? WHERE id = ?`,
+		old.Format(time.RFC3339), ins.ID,
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	// Decay with 30-day half-life: after 60 days the confidence should halve twice.
+	n, err := store.DecayInsights(ctx, "jarvis", 30.0)
+	if err != nil {
+		t.Fatalf("DecayInsights: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("DecayInsights updated 0 rows — expected at least 1")
+	}
+	got, _ := store.GetInsightByID(ctx, ins.ID)
+	expected := 0.8 * math.Pow(2, -60.0/30.0) // ≈ 0.2
+	if math.Abs(got.Confidence-expected) > 0.02 {
+		t.Errorf("confidence after decay = %.4f, want ≈%.4f", got.Confidence, expected)
+	}
+
+	// Insert a fresh insight that should NOT be GC'd.
+	fresh := &Insight{
+		Agent:      "jarvis",
+		Content:    "Fresh insight.",
+		Category:   "workflow",
+		Confidence: 0.85,
+	}
+	if err := store.CreateInsight(ctx, fresh); err != nil {
+		t.Fatalf("CreateInsight fresh: %v", err)
+	}
+
+	// GC with threshold 0.3 — should remove the decayed insight (~0.2) but keep the fresh one.
+	deleted, err := store.GCInsights(ctx, "jarvis", 0.3)
+	if err != nil {
+		t.Fatalf("GCInsights: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("GCInsights deleted %d rows, want 1", deleted)
+	}
+
+	remaining, _ := store.ListInsights(ctx, "jarvis", 10)
+	if len(remaining) != 1 || remaining[0].ID != fresh.ID {
+		t.Errorf("expected only fresh insight to remain, got %d entries", len(remaining))
+	}
+}
+
+func TestInsightExpand(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	if err := store.CreateInsight(ctx, &Insight{
+		Agent:      "jarvis",
+		Content:    "When writing public content, use generic stand-ins for private tools.",
+		Category:   "anti-pattern",
+		Confidence: 0.9,
+	}); err != nil {
+		t.Fatalf("CreateInsight: %v", err)
+	}
+
+	// Query that should match — uses words present in the content.
+	out, err := store.ExpandInsights(ctx, "jarvis", "public content private tools generic", 500)
+	if err != nil {
+		t.Fatalf("ExpandInsights: %v", err)
+	}
+	if out == "" {
+		t.Fatal("ExpandInsights returned empty string for matching query")
+	}
+	if !containsSubstring(out, "<insights>") {
+		t.Errorf("output missing <insights> tag: %q", out)
+	}
+
+	// Empty bank for a different agent should return empty.
+	out2, err := store.ExpandInsights(ctx, "other-agent", "any query", 500)
+	if err != nil {
+		t.Fatalf("ExpandInsights other-agent: %v", err)
+	}
+	if out2 != "" {
+		t.Errorf("expected empty for unknown agent, got: %q", out2)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstringHelper(s, sub))
+}
+
+func containsSubstringHelper(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1234,3 +1234,43 @@ func TestInsightExpand(t *testing.T) {
 		t.Errorf("expected empty for unknown agent, got: %q", out2)
 	}
 }
+
+func TestInsightMiningState(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	const sid = "sess-abc-123"
+	const agent = "jarvis"
+
+	// Initially unmined.
+	ts, err := store.InsightMinedAt(ctx, sid)
+	if err != nil {
+		t.Fatalf("InsightMinedAt: %v", err)
+	}
+	if !ts.IsZero() {
+		t.Errorf("expected zero time for unmined session, got %v", ts)
+	}
+
+	// Mark mined.
+	if err := store.MarkInsightMined(ctx, sid, agent); err != nil {
+		t.Fatalf("MarkInsightMined: %v", err)
+	}
+
+	ts2, err := store.InsightMinedAt(ctx, sid)
+	if err != nil {
+		t.Fatalf("InsightMinedAt after mark: %v", err)
+	}
+	if ts2.IsZero() {
+		t.Error("expected non-zero time after MarkInsightMined")
+	}
+
+	// Idempotent: marking again updates mined_at but doesn't error.
+	if err := store.MarkInsightMined(ctx, sid, agent); err != nil {
+		t.Fatalf("MarkInsightMined second call: %v", err)
+	}
+	ts3, _ := store.InsightMinedAt(ctx, sid)
+	if ts3.IsZero() {
+		t.Error("expected non-zero time after second MarkInsightMined")
+	}
+}

--- a/internal/serve/platform.go
+++ b/internal/serve/platform.go
@@ -37,9 +37,10 @@ type Settings struct {
 	MCP                 string
 	Agent               string
 	Store               session.Store
-	// InsightsStore, when non-nil, enables insight expansion on the first user
-	// turn of each session. The top matching insights (up to InsightsMaxTokens)
-	// are injected as context immediately after the first user message.
+	// InsightsExpansion, when true, enables injecting relevant behavioral
+	// insights at the first user turn of each new session. Configurable via
+	// agent.yaml memory.insights_expansion (default false).
+	InsightsExpansion bool
 	InsightsStore     *memorydb.Store
 	InsightsAgent     string
 	InsightsMaxTokens int // 0 → default 500

--- a/internal/serve/platform.go
+++ b/internal/serve/platform.go
@@ -37,13 +37,11 @@ type Settings struct {
 	MCP                 string
 	Agent               string
 	Store               session.Store
-	// InsightsExpansion, when true, enables injecting relevant behavioral
-	// insights at the first user turn of each new session. Configurable via
-	// agent.yaml memory.insights_expansion (default false).
-	InsightsExpansion bool
-	InsightsStore     *memorydb.Store
-	InsightsAgent     string
-	InsightsMaxTokens int // 0 → default 500
+	// InsightsExpander, when non-nil, injects relevant behavioral insights at
+	// the first user turn of each new session. Nil means disabled (default).
+	// Build with memory.NewInsightsExpander — enabled only when agent.yaml
+	// sets memory.insights_expansion: true.
+	InsightsExpander *memorydb.InsightsExpander
 	// NewSession creates a fresh runtime instance for a new conversation.
 	// Called once per platform session (for example, per Telegram chat session).
 	NewSession func(context.Context) (*SessionRuntime, error)

--- a/internal/serve/platform.go
+++ b/internal/serve/platform.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
@@ -36,6 +37,12 @@ type Settings struct {
 	MCP                 string
 	Agent               string
 	Store               session.Store
+	// InsightsStore, when non-nil, enables insight expansion on the first user
+	// turn of each session. The top matching insights (up to InsightsMaxTokens)
+	// are injected as context immediately after the first user message.
+	InsightsStore     *memorydb.Store
+	InsightsAgent     string
+	InsightsMaxTokens int // 0 → default 500
 	// NewSession creates a fresh runtime instance for a new conversation.
 	// Called once per platform session (for example, per Telegram chat session).
 	NewSession func(context.Context) (*SessionRuntime, error)

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -920,6 +920,21 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	messages = append(messages, sess.history...)
 	messages = append(messages, userMsg)
 
+	// Insights expansion: on the first turn of a new session, search the insight
+	// bank using the user's message and inject the top results as context. This
+	// primes the model with relevant behavioral patterns before it responds.
+	if len(sess.history) == 0 && m.settings.InsightsStore != nil {
+		maxTok := m.settings.InsightsMaxTokens
+		if maxTok <= 0 {
+			maxTok = 500
+		}
+		if expanded, err := m.settings.InsightsStore.ExpandInsights(
+			ctx, m.settings.InsightsAgent, userText, maxTok,
+		); err == nil && expanded != "" {
+			messages = append(messages, llm.UserText(expanded))
+		}
+	}
+
 	sessionID := ""
 	if sess.meta != nil {
 		sessionID = sess.meta.ID

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -923,7 +923,8 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	// Insights expansion: on the first turn of a new session, search the insight
 	// bank using the user's message and inject the top results as context. This
 	// primes the model with relevant behavioral patterns before it responds.
-	if len(sess.history) == 0 && m.settings.InsightsStore != nil {
+	// Requires memory.insights_expansion: true in agent.yaml (default: false).
+	if len(sess.history) == 0 && m.settings.InsightsExpansion && m.settings.InsightsStore != nil {
 		maxTok := m.settings.InsightsMaxTokens
 		if maxTok <= 0 {
 			maxTok = 500

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -920,18 +920,10 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	messages = append(messages, sess.history...)
 	messages = append(messages, userMsg)
 
-	// Insights expansion: on the first turn of a new session, search the insight
-	// bank using the user's message and inject the top results as context. This
-	// primes the model with relevant behavioral patterns before it responds.
-	// Requires memory.insights_expansion: true in agent.yaml (default: false).
-	if len(sess.history) == 0 && m.settings.InsightsExpansion && m.settings.InsightsStore != nil {
-		maxTok := m.settings.InsightsMaxTokens
-		if maxTok <= 0 {
-			maxTok = 500
-		}
-		if expanded, err := m.settings.InsightsStore.ExpandInsights(
-			ctx, m.settings.InsightsAgent, userText, maxTok,
-		); err == nil && expanded != "" {
+	// Insights expansion: on the first turn of a new session, inject relevant
+	// behavioral guidelines. Requires memory.insights_expansion: true in agent.yaml.
+	if len(sess.history) == 0 {
+		if expanded := m.settings.InsightsExpander.Expand(ctx, userText); expanded != "" {
 			messages = append(messages, llm.UserText(expanded))
 		}
 	}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -19,6 +19,8 @@ import (
 	"github.com/samsaffron/term-llm/internal/clipboard"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+
 	"github.com/samsaffron/term-llm/internal/mcp"
 	render "github.com/samsaffron/term-llm/internal/render/chat"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -191,6 +193,10 @@ type Model struct {
 	textMode bool
 	// Expanded tool display (full commands/env)
 	toolsExpanded bool
+
+	// InsightsExpander, when non-nil, injects behavioral insights on the
+	// first user turn of a new session. Nil means disabled.
+	insightsExpander *memorydb.InsightsExpander
 
 	// Mouse layout tracking for textarea click-to-cursor support
 	textareaBoundsValid    bool
@@ -437,6 +443,12 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 
 // WantsReload reports whether the user requested a binary reload via /reload.
 func (m *Model) WantsReload() bool { return m.reloadRequested }
+
+// SetInsightsExpander wires up insight injection for the first user turn.
+// Call this after construction when agent.yaml has memory.insights_expansion: true.
+func (m *Model) SetInsightsExpander(expander *memorydb.InsightsExpander) {
+	m.insightsExpander = expander
+}
 
 // ReloadSessionID returns the session ID to resume after a reload, if any.
 func (m *Model) ReloadSessionID() string { return m.reloadSessionID }

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -349,8 +349,26 @@ func (m *Model) buildMessages() []llm.Message {
 	}
 
 	// Add conversation history - convert session messages to llm messages
+	userMsgCount := 0
 	for _, msg := range snapshot {
 		messages = append(messages, msg.ToLLMMessage())
+		if msg.Role == llm.RoleUser {
+			userMsgCount++
+		}
+	}
+
+	// Insights expansion: inject on the very first user turn of a new session.
+	if userMsgCount == 1 {
+		userText := ""
+		for _, msg := range snapshot {
+			if msg.Role == llm.RoleUser {
+				userText = msg.TextContent
+				break
+			}
+		}
+		if expanded := m.insightsExpander.Expand(context.Background(), userText); expanded != "" {
+			messages = append(messages, llm.UserText(expanded))
+		}
 	}
 
 	return messages

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -358,6 +358,8 @@ func (m *Model) buildMessages() []llm.Message {
 	}
 
 	// Insights expansion: inject on the very first user turn of a new session.
+	// buildMessages is called once per stream start, so this fires exactly once.
+	// On subsequent turns userMsgCount > 1 and the block is skipped.
 	if userMsgCount == 1 {
 		userText := ""
 		for _, msg := range snapshot {


### PR DESCRIPTION
## What

Adds a `memory insights` subsystem — a second memory tier for behavioral rules, distinct from factual fragments. Includes schema, full CRUD, lifecycle management, a unified injection abstraction, and first-turn expansion across all platforms.

## Why

Fragments store facts ("Sam uses Arch Linux"). Insights store behavioral rules ("when asked for a recommendation, give one — don't list options"). The distinction matters: facts require inference; insights are immediately actionable guidance.

The M² paper (arXiv:2603.00503) validates this architecture empirically: injecting generalized behavioral rules before the first model turn yields +19.6% task success and −58.7% token usage. The injection fires before the model makes its first decision, not after it has already gone wrong.

## Schema (`internal/memory/store.go`)

Three new tables:
- `memory_insights` — `content`, `category`, `trigger_desc`, `confidence`, `reinforcement_count`, `last_reinforced`
- `memory_insights_fts` — FTS5 virtual table for BM25 deduplication during extraction
- `memory_insight_mining_state` — per-session tracking so `mine --insights` is idempotent

## Store methods

| Method | Purpose |
|---|---|
| `CreateInsight` / `UpdateInsight` / `DeleteInsight` | CRUD, all transactional (main row + FTS in one tx) |
| `ListInsights` | All insights for agent, sorted by `confidence DESC` |
| `ReinforceInsight` | Logarithmic confidence bump: `conf += (1-conf) * 0.2` |
| `SearchInsights` | BM25 via FTS5 with OR-prefix query — used for dedup only, not injection |
| `ExpandInsights` | Returns all insights sorted by confidence, capped by token budget, wrapped in `<insights>` tags. No search — banks are small and curated; returning all is more correct than keyword matching |
| `DecayInsights` | Exponential half-life decay on confidence for unreinforced insights |
| `GCInsights` | Delete insights below a confidence floor (FTS entries cleaned up first) |
| `InsightMinedAt` / `MarkInsightMined` | Per-session tracking to skip already-processed sessions |

## InsightsExpander (`internal/memory/expander.go`)

Single nil-safe abstraction used at every injection point:

```go
expander.Expand(ctx, userText) // returns "" when nil/disabled/empty bank
```

`NewInsightsExpander` returns `nil` when disabled — callers never nil-check.

## Injection — first turn, all platforms

Enabled per agent via `agent.yaml` (default off):

```yaml
memory:
  insights_expansion: true
  insights_max_tokens: 1000  # default 500
```

Injection points:

| Platform | Location |
|---|---|
| Telegram | `internal/serve/telegram.go` — `len(sess.history) == 0` |
| Web / API | `cmd/serve_runtime.go` — `len(baseHistory) == 0 && stateful` |
| `ask` | `cmd/ask.go` — `len(sessionMessages) == 0` |
| `chat` TUI | `internal/tui/chat/streaming.go` — `userMsgCount == 1` in `buildMessages()` |

`serve.go` constructs one expander at startup (only when enabled), shared across all runtimes via closure. The memory store is opened once and closed on shutdown.

## CLI (`cmd/memory_insights.go`)

```
term-llm memory insights list
term-llm memory insights add --content "..." [--category x] [--trigger "..."] [--confidence 0.8]
term-llm memory insights update <id> --content "..."
term-llm memory insights delete <id>
term-llm memory insights reinforce <id>
term-llm memory insights search <query>
term-llm memory insights expand <query>   # preview what would be injected
term-llm memory insights decay [--half-life 30]
term-llm memory insights gc [--min-confidence 0.1]
```

## Extraction (`cmd/memory_mine.go`)

`memory mine --insights` runs a second pass after normal fragment mining:

- **Lean transcript**: user messages ≤800 chars, assistant ≤200 chars, all tool output stripped
- **LLM prompt**: asks for behavioral patterns (anti-pattern, communication-style, domain-approach, workflow, anticipation) — not facts
- **Merge-or-create**: BM25 similarity check; if Jaccard overlap >40% with at least 3 qualifying words, reinforce instead of create
- **Per-session tracking**: sessions already processed are skipped — idempotent, no redundant LLM calls
- **Decay + GC**: runs automatically after extraction

## Agent config (`internal/agents/agent.go`)

```go
type MemoryConfig struct {
    InsightsExpansion bool `yaml:"insights_expansion,omitempty"`
    InsightsMaxTokens int  `yaml:"insights_max_tokens,omitempty"`
}
```

Wired through `SessionSettings` → `serve.Settings` / `serveRuntime`.

## Tests

6 tests in `internal/memory/store_test.go`:
- `TestInsightCRUD` — create, get, update, delete
- `TestInsightListAndSearch` — list ordering, BM25 returns correct top category
- `TestInsightReinforce` — confidence bump, reinforcement count
- `TestInsightDecayAndGC` — backdated insight decays to ~half at 2x half-life; GC removes it, fresh insight survives
- `TestInsightExpand` — inject block present for matching query, empty for unknown agent
- `TestInsightMiningState` — zero for unmined, non-zero after mark, idempotent re-mark
