### PR TITLE
feat: group grep results by file with match count summary

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -588,17 +588,73 @@ func formatFilesWithMatches(matches []GrepMatch) string {
 	return strings.TrimSuffix(sb.String(), "\n")
 }
 
-// formatGrepResults formats grep results for the LLM.
-func formatGrepResults(matches []GrepMatch, truncated bool) string {
-	var sb strings.Builder
+// fileGroup holds the ordered matches for a single file.
+type fileGroup struct {
+	path    string
+	matches []GrepMatch
+}
 
-	for i, m := range matches {
-		if i > 0 {
-			sb.WriteString("\n---\n")
+// groupMatchesByFile groups matches by file path, preserving encounter order.
+func groupMatchesByFile(matches []GrepMatch) []fileGroup {
+	var groups []fileGroup
+	idx := make(map[string]int, len(matches))
+	for _, m := range matches {
+		if i, ok := idx[m.FilePath]; ok {
+			groups[i].matches = append(groups[i].matches, m)
+		} else {
+			idx[m.FilePath] = len(groups)
+			groups = append(groups, fileGroup{path: m.FilePath, matches: []GrepMatch{m}})
 		}
-		sb.WriteString(fmt.Sprintf("%s:%d\n", m.FilePath, m.LineNumber))
-		sb.WriteString(m.Context)
-		sb.WriteString("\n")
+	}
+	return groups
+}
+
+// formatGrepResults formats grep results grouped by file for the LLM.
+//
+// Output shape:
+//
+//	N matches in M files
+//
+//	path/to/file.go (K matches):
+//	  3: context line
+//	> 4: matching line
+//	  5: context line
+//
+//	path/to/other.go (1 match):
+//	...
+func formatGrepResults(matches []GrepMatch, truncated bool) string {
+	if len(matches) == 0 {
+		return ""
+	}
+
+	groups := groupMatchesByFile(matches)
+
+	pluralOf := map[string]string{
+		"match": "matches",
+		"file":  "files",
+	}
+	plural := func(n int, word string) string {
+		if n == 1 {
+			return fmt.Sprintf("%d %s", n, word)
+		}
+		if p, ok := pluralOf[word]; ok {
+			return fmt.Sprintf("%d %s", n, p)
+		}
+		return fmt.Sprintf("%d %ss", n, word)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s in %s\n", plural(len(matches), "match"), plural(len(groups), "file")))
+
+	for _, g := range groups {
+		sb.WriteString(fmt.Sprintf("\n%s (%s):\n", g.path, plural(len(g.matches), "match")))
+		for i, m := range g.matches {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(m.Context)
+			sb.WriteString("\n")
+		}
 	}
 
 	if truncated {

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -37,3 +37,142 @@ func TestGrepTool_UsesFilePath(t *testing.T) {
 		t.Fatalf("expected output to contain %q, got: %s", filePath, output.Content)
 	}
 }
+
+func TestFormatGrepResults_SingleFile(t *testing.T) {
+	matches := []GrepMatch{
+		{FilePath: "pkg/foo.go", LineNumber: 10, Match: "func Foo()", Context: "  9: // Foo does things\n> 10: func Foo()\n  11: {"},
+		{FilePath: "pkg/foo.go", LineNumber: 20, Match: "func Bar()", Context: "> 20: func Bar()"},
+	}
+
+	result := formatGrepResults(matches, false)
+
+	// Summary line
+	if !strings.Contains(result, "2 matches in 1 file") {
+		t.Errorf("expected summary '2 matches in 1 file', got:\n%s", result)
+	}
+
+	// File header appears once
+	count := strings.Count(result, "pkg/foo.go")
+	if count != 1 {
+		t.Errorf("expected file path to appear once, got %d times", count)
+	}
+
+	// File header shows match count
+	if !strings.Contains(result, "pkg/foo.go (2 matches):") {
+		t.Errorf("expected file header with count, got:\n%s", result)
+	}
+
+	// Context present
+	if !strings.Contains(result, "func Foo()") || !strings.Contains(result, "func Bar()") {
+		t.Errorf("expected both match lines in output, got:\n%s", result)
+	}
+}
+
+func TestFormatGrepResults_MultipleFiles(t *testing.T) {
+	matches := []GrepMatch{
+		{FilePath: "a/one.go", LineNumber: 1, Match: "match1", Context: "> 1: match1"},
+		{FilePath: "b/two.go", LineNumber: 5, Match: "match2", Context: "> 5: match2"},
+		{FilePath: "b/two.go", LineNumber: 9, Match: "match3", Context: "> 9: match3"},
+	}
+
+	result := formatGrepResults(matches, false)
+
+	if !strings.Contains(result, "3 matches in 2 files") {
+		t.Errorf("expected summary '3 matches in 2 files', got:\n%s", result)
+	}
+
+	if !strings.Contains(result, "a/one.go (1 match):") {
+		t.Errorf("expected singular 'match' for single result, got:\n%s", result)
+	}
+
+	if !strings.Contains(result, "b/two.go (2 matches):") {
+		t.Errorf("expected '2 matches' for two.go, got:\n%s", result)
+	}
+
+	// File path for b/two.go appears exactly once (as header, not per-match)
+	count := strings.Count(result, "b/two.go")
+	if count != 1 {
+		t.Errorf("expected b/two.go to appear once, got %d times", count)
+	}
+}
+
+func TestFormatGrepResults_Truncated(t *testing.T) {
+	matches := []GrepMatch{
+		{FilePath: "x.go", LineNumber: 1, Match: "foo", Context: "> 1: foo"},
+	}
+
+	result := formatGrepResults(matches, true)
+
+	if !strings.Contains(result, "[Results truncated at limit]") {
+		t.Errorf("expected truncation notice, got:\n%s", result)
+	}
+}
+
+func TestFormatGrepResults_Empty(t *testing.T) {
+	result := formatGrepResults(nil, false)
+	if result != "" {
+		t.Errorf("expected empty string for nil matches, got %q", result)
+	}
+}
+
+func TestGroupMatchesByFile_PreservesOrder(t *testing.T) {
+	matches := []GrepMatch{
+		{FilePath: "c.go", LineNumber: 1},
+		{FilePath: "a.go", LineNumber: 1},
+		{FilePath: "c.go", LineNumber: 2},
+		{FilePath: "b.go", LineNumber: 1},
+		{FilePath: "a.go", LineNumber: 2},
+	}
+
+	groups := groupMatchesByFile(matches)
+
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+	// Encounter order: c.go first, then a.go, then b.go
+	if groups[0].path != "c.go" || groups[1].path != "a.go" || groups[2].path != "b.go" {
+		t.Errorf("unexpected group order: %v, %v, %v", groups[0].path, groups[1].path, groups[2].path)
+	}
+	if len(groups[0].matches) != 2 || len(groups[1].matches) != 2 || len(groups[2].matches) != 1 {
+		t.Errorf("unexpected match counts: %d, %d, %d", len(groups[0].matches), len(groups[1].matches), len(groups[2].matches))
+	}
+}
+
+func TestGrepTool_GroupedOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write two files, both containing the token
+	if err := os.WriteFile(filepath.Join(dir, "alpha.go"), []byte("line1\nmatch_here\nline3"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "beta.go"), []byte("other\nmatch_here\nend"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewGrepTool(nil, DefaultOutputLimits())
+	args, _ := json.Marshal(GrepArgs{
+		Pattern:      "match_here",
+		Path:         dir,
+		ContextLines: 0,
+	})
+
+	output, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have summary
+	if !strings.Contains(output.Content, "2 matches in 2 files") {
+		t.Errorf("expected grouped summary, got:\n%s", output.Content)
+	}
+
+	// Each file path should appear exactly once
+	alphaPath := filepath.Join(dir, "alpha.go")
+	betaPath := filepath.Join(dir, "beta.go")
+	if strings.Count(output.Content, alphaPath) != 1 {
+		t.Errorf("alpha.go should appear once, got:\n%s", output.Content)
+	}
+	if strings.Count(output.Content, betaPath) != 1 {
+		t.Errorf("beta.go should appear once, got:\n%s", output.Content)
+	}
+}


### PR DESCRIPTION
## What

Groups `grep` tool results by file instead of repeating the full file path for every match. Adds a summary line showing total matches and file count.

**Before** (5 matches across 2 files = 5 file path lines + 5 `---` dividers):
```
/path/to/foo.go:42
  41: before
> 42: the match
  43: after
---
/path/to/foo.go:99
  98: before
> 99: another match
 100: after
---
/path/to/bar.go:7
  ...
```

**After** (1 file path per file, summary up front):
```
5 matches in 2 files

/path/to/foo.go (2 matches):
  41: before
> 42: the match
  43: after

  98: before
> 99: another match
 100: after

/path/to/bar.go (3 matches):
  ...
```

## Why

Inspired by reading the [rtk source](https://github.com/rtk-ai/rtk) — the flat per-match format wastes tokens on repeated file paths and `---` dividers. For a search returning 30 matches across 3 files, the old format repeated each path 30 times and added 30 separator lines. The grouped format conveys the same information in less space and is easier for a model to parse structurally.

The summary line (`N matches in M files`) also gives the model an immediate count without having to scan the full output.

## Changes

- `formatGrepResults`: rewritten to group matches under per-file headers
- `groupMatchesByFile`: new helper, preserves encounter order (not alphabetical)
- `grep_test.go`: 5 new test cases covering single-file, multi-file, truncation, empty input, and group ordering
