### PR TITLE
fix: cap after-context bleed, truncate long lines, per-file match limit

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -19,6 +19,18 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 )
 
+const (
+	// maxLineDisplayLen is the maximum rune length of any line written into
+	// grep context output.  Lines beyond this are truncated with "…" to keep
+	// token counts predictable on minified / generated files.
+	maxLineDisplayLen = 120
+
+	// maxMatchesPerFileDisplay is the maximum number of matches shown per file
+	// in the grouped output.  When a file has more matches than this, a note
+	// is appended so the model knows to narrow its search.
+	maxMatchesPerFileDisplay = 10
+)
+
 // GrepTool implements the grep tool.
 type GrepTool struct {
 	approval *ApprovalManager
@@ -111,7 +123,7 @@ func (t *GrepTool) executeRipgrep(ctx context.Context, pattern, searchPath, incl
 		return nil, err
 	}
 
-	return parseRipgrepOutput(output, maxResults)
+	return parseRipgrepOutput(output, maxResults, contextLines)
 }
 
 // pendingMatch tracks context for building ripgrep results.
@@ -124,9 +136,24 @@ type pendingMatch struct {
 }
 
 // parseRipgrepOutput parses ripgrep JSON output into GrepMatches.
-func parseRipgrepOutput(output []byte, maxResults int) ([]GrepMatch, error) {
+//
+// maxAfterContext caps the number of after-context lines stored per match.
+// This prevents bleed: when two matches are close together rg emits the
+// lines between them as "context" events only once.  Without a cap they all
+// accumulate in the first match's after-slice, producing more context lines
+// than requested and stealing before-context from the next match.
+func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepMatch, error) {
 	var matches []GrepMatch
 	var pending *pendingMatch
+
+	flush := func() bool {
+		if pending == nil {
+			return false
+		}
+		matches = append(matches, buildMatchFromPending(pending))
+		pending = nil
+		return len(matches) >= maxResults
+	}
 
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {
@@ -141,12 +168,8 @@ func parseRipgrepOutput(output []byte, maxResults int) ([]GrepMatch, error) {
 
 		switch msg.Type {
 		case "match":
-			// Flush any pending match
-			if pending != nil {
-				matches = append(matches, buildMatchFromPending(pending))
-				if len(matches) >= maxResults {
-					return matches, nil
-				}
+			if flush() {
+				return matches, nil
 			}
 
 			var data rgMatchData
@@ -172,18 +195,40 @@ func parseRipgrepOutput(output []byte, maxResults int) ([]GrepMatch, error) {
 			contextLine := strings.TrimSuffix(data.Lines.Text, "\n")
 			if data.LineNumber < pending.lineNumber {
 				pending.before = append(pending.before, contextLine)
-			} else {
+			} else if len(pending.after) < maxAfterContext {
+				// Cap after-context to prevent inter-match bleed.
+				// Lines beyond maxAfterContext belong to the next match's
+				// before-context; rg won't re-emit them for that match.
 				pending.after = append(pending.after, contextLine)
+			}
+
+		case "end":
+			// rg emits "end" at the close of each match group (separated by
+			// gaps wider than the context window).  Flush here so the final
+			// match in a group gets its after-context correctly assigned before
+			// the next group's before-context starts arriving.
+			if flush() {
+				return matches, nil
 			}
 		}
 	}
 
-	// Flush final pending match
-	if pending != nil {
-		matches = append(matches, buildMatchFromPending(pending))
-	}
+	// Flush any remaining match not terminated by an "end" event.
+	flush()
 
 	return matches, nil
+}
+
+// truncateLine trims leading/trailing whitespace and caps the line at
+// maxLineDisplayLen runes, appending "…" when truncated.  Leading whitespace
+// is preserved up to the cap so indentation remains meaningful.
+func truncateLine(s string) string {
+	s = strings.TrimRight(s, " \t")
+	r := []rune(s)
+	if len(r) <= maxLineDisplayLen {
+		return s
+	}
+	return string(r[:maxLineDisplayLen-1]) + "…"
 }
 
 func buildMatchFromPending(p *pendingMatch) GrepMatch {
@@ -191,11 +236,11 @@ func buildMatchFromPending(p *pendingMatch) GrepMatch {
 	startLine := p.lineNumber - len(p.before)
 
 	for i, line := range p.before {
-		sb.WriteString(fmt.Sprintf("  %d: %s\n", startLine+i, line))
+		sb.WriteString(fmt.Sprintf("  %d: %s\n", startLine+i, truncateLine(line)))
 	}
-	sb.WriteString(fmt.Sprintf("> %d: %s\n", p.lineNumber, p.matchLine))
+	sb.WriteString(fmt.Sprintf("> %d: %s\n", p.lineNumber, truncateLine(p.matchLine)))
 	for i, line := range p.after {
-		sb.WriteString(fmt.Sprintf("  %d: %s\n", p.lineNumber+1+i, line))
+		sb.WriteString(fmt.Sprintf("  %d: %s\n", p.lineNumber+1+i, truncateLine(line)))
 	}
 
 	return GrepMatch{
@@ -648,12 +693,24 @@ func formatGrepResults(matches []GrepMatch, truncated bool) string {
 
 	for _, g := range groups {
 		sb.WriteString(fmt.Sprintf("\n%s (%s):\n", g.path, plural(len(g.matches), "match")))
-		for i, m := range g.matches {
+
+		display := g.matches
+		overflow := 0
+		if len(g.matches) > maxMatchesPerFileDisplay {
+			display = g.matches[:maxMatchesPerFileDisplay]
+			overflow = len(g.matches) - maxMatchesPerFileDisplay
+		}
+
+		for i, m := range display {
 			if i > 0 {
 				sb.WriteString("\n")
 			}
 			sb.WriteString(m.Context)
 			sb.WriteString("\n")
+		}
+
+		if overflow > 0 {
+			sb.WriteString(fmt.Sprintf("\n  [+%d more in this file — use a more specific pattern or narrow the path]\n", overflow))
 		}
 	}
 

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,6 +136,166 @@ func TestGroupMatchesByFile_PreservesOrder(t *testing.T) {
 	}
 	if len(groups[0].matches) != 2 || len(groups[1].matches) != 2 || len(groups[2].matches) != 1 {
 		t.Errorf("unexpected match counts: %d, %d, %d", len(groups[0].matches), len(groups[1].matches), len(groups[2].matches))
+	}
+}
+
+// TestParseRipgrepOutput_NoContextBleed verifies that after-context is capped
+// at maxAfterContext lines.
+//
+// The bleed bug: rg emits before-context lines for match B as "context"
+// events while match A is still pending (because those lines have higher line
+// numbers than A, they went into A's after-slice without bound).  Example:
+//
+//	match@41  → pending
+//	context@43,44      → correct after for 41
+//	context@337,338    → before-context for match@339, but lineNumber>41
+//	                     so without a cap they bleed into 41's after-slice
+//	match@339 → flush 41 (would show 4 after-lines instead of 2)
+//
+// With maxAfterContext=2, context@337,338 are dropped and 41 flushes cleanly.
+func TestParseRipgrepOutput_NoContextBleed(t *testing.T) {
+	makeContext := func(path string, lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"context","data":{"path":{"text":%q},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			path, text+"\n", lineNum)
+	}
+	makeMatch := func(path string, lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"match","data":{"path":{"text":%q},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			path, text+"\n", lineNum)
+	}
+	makeEnd := func() string {
+		return `{"type":"end","data":{"path":{"text":"f.go"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":0},"searches":1,"searches_with_match":1,"bytes_searched":0,"bytes_printed":0,"matched_lines":2,"matches":2}}}`
+	}
+
+	// Matches at lines 41 and 339, context=2.
+	// rg stream order (observed from real rg --json --context 2 output):
+	//   match@41
+	//   context@43,44          (after-context for 41)
+	//   context@337,338        (before-context for 339, arrives while 41 is pending)
+	//   match@339
+	//   context@340,341        (after-context for 339)
+	//   end
+	lines := []string{
+		makeMatch("f.go", 41, "matchA"),
+		makeContext("f.go", 43, "after43"),
+		makeContext("f.go", 44, "after44"),
+		// These are before-context for matchB but arrive while matchA is pending.
+		// Without the cap they bleed into matchA's after-slice.
+		makeContext("f.go", 337, "before337"),
+		makeContext("f.go", 338, "before338"),
+		makeMatch("f.go", 339, "matchB"),
+		makeContext("f.go", 340, "after340"),
+		makeContext("f.go", 341, "after341"),
+		makeEnd(),
+	}
+	input := []byte(strings.Join(lines, "\n"))
+
+	matches, err := parseRipgrepOutput(input, 100, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+
+	// matchA: after should be exactly [43,44] — no bleed from 337,338.
+	ctxA := matches[0].Context
+	if strings.Contains(ctxA, "before337") || strings.Contains(ctxA, "before338") {
+		t.Errorf("context bleed: matchA context contains matchB's before-context:\n%s", ctxA)
+	}
+	if !strings.Contains(ctxA, "after43") || !strings.Contains(ctxA, "after44") {
+		t.Errorf("matchA missing correct after-context:\n%s", ctxA)
+	}
+
+	// matchB: after should be [340,341].
+	ctxB := matches[1].Context
+	if !strings.Contains(ctxB, "after340") || !strings.Contains(ctxB, "after341") {
+		t.Errorf("matchB missing after-context:\n%s", ctxB)
+	}
+}
+
+// TestParseRipgrepOutput_EndEventFlush verifies that an "end" event flushes
+// the pending match, so the last match in each group is correctly emitted.
+func TestParseRipgrepOutput_EndEventFlush(t *testing.T) {
+	makeMatch := func(lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"match","data":{"path":{"text":"f.go"},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			text+"\n", lineNum)
+	}
+	makeEnd := func() string {
+		return `{"type":"end","data":{"path":{"text":"f.go"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":0},"searches":1,"searches_with_match":1,"bytes_searched":0,"bytes_printed":0,"matched_lines":1,"matches":1}}}`
+	}
+
+	lines := []string{
+		makeMatch(10, "matchA"),
+		makeEnd(),
+		makeMatch(200, "matchB"),
+		makeEnd(),
+	}
+	input := []byte(strings.Join(lines, "\n"))
+
+	matches, err := parseRipgrepOutput(input, 100, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+	if matches[0].Match != "matchA" || matches[1].Match != "matchB" {
+		t.Errorf("unexpected match content: %v %v", matches[0].Match, matches[1].Match)
+	}
+}
+
+func TestTruncateLine(t *testing.T) {
+	short := "hello world"
+	if truncateLine(short) != short {
+		t.Errorf("short line should be unchanged, got %q", truncateLine(short))
+	}
+
+	long := strings.Repeat("x", maxLineDisplayLen+10)
+	result := truncateLine(long)
+	r := []rune(result)
+	if len(r) > maxLineDisplayLen {
+		t.Errorf("truncated line too long: %d runes (max %d)", len(r), maxLineDisplayLen)
+	}
+	if !strings.HasSuffix(result, "…") {
+		t.Errorf("truncated line should end with ellipsis, got %q", result[len(result)-4:])
+	}
+
+	// Trailing whitespace stripped even if short
+	withTrail := "foo   "
+	if truncateLine(withTrail) != "foo" {
+		t.Errorf("trailing whitespace not stripped, got %q", truncateLine(withTrail))
+	}
+}
+
+func TestFormatGrepResults_PerFileOverflow(t *testing.T) {
+	// Build more than maxMatchesPerFileDisplay matches for one file.
+	var matches []GrepMatch
+	for i := 1; i <= maxMatchesPerFileDisplay+3; i++ {
+		matches = append(matches, GrepMatch{
+			FilePath:   "big.go",
+			LineNumber: i,
+			Match:      "match",
+			Context:    fmt.Sprintf("> %d: match", i),
+		})
+	}
+
+	result := formatGrepResults(matches, false)
+
+	// File header should show true total.
+	expected := fmt.Sprintf("big.go (%d matches):", maxMatchesPerFileDisplay+3)
+	if !strings.Contains(result, expected) {
+		t.Errorf("expected header %q in:\n%s", expected, result)
+	}
+
+	// Overflow note should be present.
+	if !strings.Contains(result, "[+3 more") {
+		t.Errorf("expected overflow note '[+3 more' in:\n%s", result)
+	}
+
+	// Only maxMatchesPerFileDisplay match lines should appear.
+	displayed := strings.Count(result, "> ")
+	if displayed != maxMatchesPerFileDisplay {
+		t.Errorf("expected %d displayed matches, got %d", maxMatchesPerFileDisplay, displayed)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #88 (grouped grep output).

## Problems fixed

### 1. Context bleed between matches

rg emits before-context for match B as `context` events while match A is still pending. Because those lines have a higher line number than A, they accumulated in A's `after` slice without any cap — producing more context lines than requested and obscuring match B's surroundings.

Real example from the previous conversation: a match at line 41 was showing context lines 43, 44 (correct) **plus** lines 337–338 (before-context for the match at line 339). That's 4 after-lines when `context_lines=2` was requested.

**Fix:** `parseRipgrepOutput` now takes `maxAfterContext` (= the `contextLines` argument from the call site) and drops any after-context beyond that cap. Also added an `"end"` event handler so the final match in each rg group flushes at the right boundary rather than relying on the next match event or EOF.

### 2. Long line blowout

Minified JS, generated code, and long log lines could dominate context blocks with hundreds of characters per line.

**Fix:** `truncateLine()` caps any line at 120 runes and appends `…`. Trailing whitespace is stripped. Applied to both match lines and context lines in `buildMatchFromPending`.

### 3. Per-file match wall

When a file has many hits the grouped output became a wall of text that still cost as many tokens as the old flat format.

**Fix:** `formatGrepResults` shows at most `maxMatchesPerFileDisplay` (10) matches per file and appends `[+N more — use a more specific pattern or narrow the path]` for overflow. The file header retains the true hit count.

## Tests added

- `TestParseRipgrepOutput_NoContextBleed` — verifies the cap prevents bleed from far-apart matches
- `TestParseRipgrepOutput_EndEventFlush` — verifies `end` events flush pending matches
- `TestTruncateLine` — short/long/trailing-whitespace cases
- `TestFormatGrepResults_PerFileOverflow` — overflow count and display cap