### PR TITLE
fix: insight extraction uses correct system prompt and strips markdown fences

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -559,9 +559,13 @@ func collectToolCallNames(msg session.Message) []string {
 }
 
 func runExtractionRequest(ctx context.Context, engine *llm.Engine, prompt string) (string, error) {
+	return runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt)
+}
+
+func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string) (string, error) {
 	req := llm.Request{
 		Model:    strings.TrimSpace(memoryMineModel),
-		Messages: []llm.Message{llm.SystemText(memoryExtractionSystemPrompt), llm.UserText(prompt)},
+		Messages: []llm.Message{llm.SystemText(systemPrompt), llm.UserText(prompt)},
 		MaxTurns: 1,
 		Debug:    false,
 		DebugRaw: debugRaw,
@@ -1153,11 +1157,12 @@ func runInsightExtractionPass(
 		}
 
 		prompt := buildInsightExtractionPrompt(candidate.Agent, messages, existing)
-		raw, err := runExtractionRequest(ctx, engine, prompt)
+		raw, err := runExtractionRequestWithSystem(ctx, engine, insightExtractionSystemPrompt, prompt)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: llm call: %v\n", candidate.Session.ID, err)
 			continue
 		}
+		raw = stripMarkdownFences(raw)
 
 		var resp insightExtractionResponse
 		decoder := json.NewDecoder(strings.NewReader(raw))


### PR DESCRIPTION
## What

Fixes `memory mine --insights` producing JSON decode failures on every session.

## Why

`runExtractionRequest` hardcodes `memoryExtractionSystemPrompt` (the fragment mining system prompt) as the system message for all extraction calls. When `runInsightExtractionPass` calls it, the wrong system prompt is sent to the LLM — one that says nothing about JSON output format.

The insight-specific `insightExtractionSystemPrompt` has an explicit instruction: *"Output must be valid JSON only (no markdown fences, no prose)"*. Because it was never being sent, the model wrapped its response in markdown code fences (````json ... ````), causing `json.Decode` to fail with `invalid character '`' looking for beginning of value`.

## Changes

- Refactor `runExtractionRequest` to delegate to a new `runExtractionRequestWithSystem(ctx, engine, systemPrompt, prompt)`
- `runExtractionRequest` (fragment mining) continues to call with `memoryExtractionSystemPrompt` — no behaviour change
- `runInsightExtractionPass` calls `runExtractionRequestWithSystem` with `insightExtractionSystemPrompt`
- Added `stripMarkdownFences` call on the raw insight response as a defensive fallback

## Effect

Before: every `mine --insights` session skipped with `decode: invalid character '`' looking for beginning of value`  
After: insights extracted correctly (23 behavioral patterns extracted from 30 Jarvis sessions in a single run)
