### PR TITLE
fix: recover before-context via look-back buffer, tighten defaults

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -135,16 +135,48 @@ type pendingMatch struct {
 	after      []string
 }
 
+// contextEntry is one line from a ripgrep "context" event.
+type contextEntry struct {
+	lineNumber int
+	text       string
+}
+
 // parseRipgrepOutput parses ripgrep JSON output into GrepMatches.
 //
-// maxAfterContext caps the number of after-context lines stored per match.
-// This prevents bleed: when two matches are close together rg emits the
-// lines between them as "context" events only once.  Without a cap they all
-// accumulate in the first match's after-slice, producing more context lines
-// than requested and stealing before-context from the next match.
+// # Stream ordering
+//
+// rg --json emits events in this order per match group:
+//
+//	begin → context(before) → match → context(after) → end
+//
+// Before-context lines arrive *before* the match event, so a naive parser
+// that creates pendingMatch on "match" will always drop them.
+//
+// # Before-context: look-back buffer
+//
+// We maintain a rolling contextBuf of recent context entries.  When a "match"
+// event fires we pull any entries with lineNumber < matchLine as before-context
+// and reset the buffer.  This correctly handles:
+//   - First match in a group (before lines arrive while pending == nil)
+//   - Far-apart matches in separate groups (before lines arrive after "end" flush)
+//   - Close matches: after-cap overflow lines buffer for the next match's before
+//
+// # After-context: capped slice
+//
+// After-context lines go directly into pending.after, capped at maxAfterContext.
+// Lines beyond the cap are buffered (not discarded) so they are available as
+// before-context for the next match.
 func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepMatch, error) {
 	var matches []GrepMatch
 	var pending *pendingMatch
+	var contextBuf []contextEntry // look-back buffer for before-context
+
+	bufAppend := func(e contextEntry) {
+		contextBuf = append(contextBuf, e)
+		if len(contextBuf) > maxAfterContext {
+			contextBuf = contextBuf[len(contextBuf)-maxAfterContext:]
+		}
+	}
 
 	flush := func() bool {
 		if pending == nil {
@@ -177,39 +209,48 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 				continue
 			}
 
+			// Collect before-context from the look-back buffer.
+			var before []string
+			for _, e := range contextBuf {
+				if e.lineNumber < data.LineNumber {
+					before = append(before, e.text)
+				}
+			}
+
 			pending = &pendingMatch{
 				filePath:   data.Path.Text,
 				lineNumber: data.LineNumber,
 				matchLine:  strings.TrimSuffix(data.Lines.Text, "\n"),
+				before:     before,
 			}
+			contextBuf = nil // reset; subsequent context lines are after-context
 
 		case "context":
-			if pending == nil {
-				continue
-			}
 			var data rgMatchData
 			if err := json.Unmarshal(msg.Data, &data); err != nil {
 				continue
 			}
 
-			contextLine := strings.TrimSuffix(data.Lines.Text, "\n")
-			if data.LineNumber < pending.lineNumber {
-				pending.before = append(pending.before, contextLine)
-			} else if len(pending.after) < maxAfterContext {
-				// Cap after-context to prevent inter-match bleed.
-				// Lines beyond maxAfterContext belong to the next match's
-				// before-context; rg won't re-emit them for that match.
-				pending.after = append(pending.after, contextLine)
+			text := strings.TrimSuffix(data.Lines.Text, "\n")
+			if pending != nil && data.LineNumber > pending.lineNumber && len(pending.after) < maxAfterContext {
+				// Normal after-context for the current match.
+				pending.after = append(pending.after, text)
+			} else {
+				// Everything else goes into the look-back buffer:
+				//  - lines before the first match in a group (pending == nil)
+				//  - lines after "end" / before the next group's first match
+				//  - after-cap overflow that belongs to the next match's before
+				bufAppend(contextEntry{data.LineNumber, text})
 			}
 
 		case "end":
-			// rg emits "end" at the close of each match group (separated by
-			// gaps wider than the context window).  Flush here so the final
-			// match in a group gets its after-context correctly assigned before
-			// the next group's before-context starts arriving.
+			// rg emits "end" at the close of each match group.  Flush so the
+			// last match in a group gets its after-context before the next
+			// group's before-context starts arriving.
 			if flush() {
 				return matches, nil
 			}
+			contextBuf = nil // each group starts with a clean buffer
 		}
 	}
 
@@ -295,10 +336,9 @@ func (t *GrepTool) Spec() llm.ToolSpec {
 				},
 				"context_lines": map[string]interface{}{
 					"type":        "integer",
-					"description": "Lines of context around each match (default: 3)",
-					"default":     3,
-				},
-				"files_with_matches": map[string]interface{}{
+					"description": "Lines of context around each match (default: 2)",
+					"default":     2,
+				}, "files_with_matches": map[string]interface{}{
 					"type":        "boolean",
 					"description": "Return only filenames containing matches, not the match lines (default: false)",
 				},
@@ -373,7 +413,7 @@ func (t *GrepTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 
 	contextLines := a.ContextLines
 	if contextLines <= 0 {
-		contextLines = 3
+		contextLines = 2
 	}
 
 	// Check permissions via approval manager
@@ -710,7 +750,7 @@ func formatGrepResults(matches []GrepMatch, truncated bool) string {
 		}
 
 		if overflow > 0 {
-			sb.WriteString(fmt.Sprintf("\n  [+%d more in this file — use a more specific pattern or narrow the path]\n", overflow))
+			sb.WriteString(fmt.Sprintf("\n  [+%d more — narrow your search]\n", overflow))
 		}
 	}
 

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -139,20 +139,14 @@ func TestGroupMatchesByFile_PreservesOrder(t *testing.T) {
 	}
 }
 
-// TestParseRipgrepOutput_NoContextBleed verifies that after-context is capped
-// at maxAfterContext lines.
+// TestParseRipgrepOutput_NoContextBleed verifies that:
+//   - After-context is capped at maxAfterContext (no bleed into matchA)
+//   - Cap-overflow lines are buffered and recovered as matchB's before-context
 //
-// The bleed bug: rg emits before-context lines for match B as "context"
-// events while match A is still pending (because those lines have higher line
-// numbers than A, they went into A's after-slice without bound).  Example:
-//
-//	match@41  → pending
-//	context@43,44      → correct after for 41
-//	context@337,338    → before-context for match@339, but lineNumber>41
-//	                     so without a cap they bleed into 41's after-slice
-//	match@339 → flush 41 (would show 4 after-lines instead of 2)
-//
-// With maxAfterContext=2, context@337,338 are dropped and 41 flushes cleanly.
+// rg emits before-context for match B while match A is still pending (those
+// lines have higher line numbers than A).  Old behaviour: they bled into A's
+// after-slice.  New behaviour: cap at maxAfterContext, buffer overflow, hand
+// off to B's before on the next "match" event.
 func TestParseRipgrepOutput_NoContextBleed(t *testing.T) {
 	makeContext := func(path string, lineNum int, text string) string {
 		return fmt.Sprintf(`{"type":"context","data":{"path":{"text":%q},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
@@ -166,20 +160,17 @@ func TestParseRipgrepOutput_NoContextBleed(t *testing.T) {
 		return `{"type":"end","data":{"path":{"text":"f.go"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":0},"searches":1,"searches_with_match":1,"bytes_searched":0,"bytes_printed":0,"matched_lines":2,"matches":2}}}`
 	}
 
-	// Matches at lines 41 and 339, context=2.
-	// rg stream order (observed from real rg --json --context 2 output):
+	// Matches at lines 41 and 339, context=2.  Real rg stream order:
 	//   match@41
-	//   context@43,44          (after-context for 41)
-	//   context@337,338        (before-context for 339, arrives while 41 is pending)
+	//   context@43,44      (after for 41; fills cap)
+	//   context@337,338    (before for 339; cap exceeded → buffer)
 	//   match@339
-	//   context@340,341        (after-context for 339)
+	//   context@340,341    (after for 339)
 	//   end
 	lines := []string{
 		makeMatch("f.go", 41, "matchA"),
 		makeContext("f.go", 43, "after43"),
 		makeContext("f.go", 44, "after44"),
-		// These are before-context for matchB but arrive while matchA is pending.
-		// Without the cap they bleed into matchA's after-slice.
 		makeContext("f.go", 337, "before337"),
 		makeContext("f.go", 338, "before338"),
 		makeMatch("f.go", 339, "matchB"),
@@ -197,19 +188,78 @@ func TestParseRipgrepOutput_NoContextBleed(t *testing.T) {
 		t.Fatalf("expected 2 matches, got %d", len(matches))
 	}
 
-	// matchA: after should be exactly [43,44] — no bleed from 337,338.
+	// matchA: after-context must be exactly [43,44] — overflow lines must NOT appear.
 	ctxA := matches[0].Context
 	if strings.Contains(ctxA, "before337") || strings.Contains(ctxA, "before338") {
-		t.Errorf("context bleed: matchA context contains matchB's before-context:\n%s", ctxA)
+		t.Errorf("context bleed: matchA contains matchB's before-context:\n%s", ctxA)
 	}
 	if !strings.Contains(ctxA, "after43") || !strings.Contains(ctxA, "after44") {
-		t.Errorf("matchA missing correct after-context:\n%s", ctxA)
+		t.Errorf("matchA missing after-context:\n%s", ctxA)
 	}
 
-	// matchB: after should be [340,341].
+	// matchB: overflow lines must be recovered as before-context.
 	ctxB := matches[1].Context
+	if !strings.Contains(ctxB, "before337") || !strings.Contains(ctxB, "before338") {
+		t.Errorf("matchB missing before-context recovered from overflow:\n%s", ctxB)
+	}
 	if !strings.Contains(ctxB, "after340") || !strings.Contains(ctxB, "after341") {
 		t.Errorf("matchB missing after-context:\n%s", ctxB)
+	}
+}
+
+// TestParseRipgrepOutput_BeforeContext verifies that before-context lines are
+// correctly captured even though rg emits them before the "match" event.
+func TestParseRipgrepOutput_BeforeContext(t *testing.T) {
+	makeContext := func(lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"context","data":{"path":{"text":"f.go"},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			text+"\n", lineNum)
+	}
+	makeMatch := func(lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"match","data":{"path":{"text":"f.go"},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			text+"\n", lineNum)
+	}
+	makeEnd := func() string {
+		return `{"type":"end","data":{"path":{"text":"f.go"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":0},"searches":1,"searches_with_match":1,"bytes_searched":0,"bytes_printed":0,"matched_lines":1,"matches":1}}}`
+	}
+
+	// Single match at line 10, context=2.  rg emits:
+	//   context@8  (before, arrives before the match event — pending==nil)
+	//   context@9  (before)
+	//   match@10
+	//   context@11 (after)
+	//   context@12 (after)
+	//   end
+	lines := []string{
+		makeContext(8, "before8"),
+		makeContext(9, "before9"),
+		makeMatch(10, "theMatch"),
+		makeContext(11, "after11"),
+		makeContext(12, "after12"),
+		makeEnd(),
+	}
+	input := []byte(strings.Join(lines, "\n"))
+
+	matches, err := parseRipgrepOutput(input, 100, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+
+	ctx := matches[0].Context
+	if !strings.Contains(ctx, "before8") || !strings.Contains(ctx, "before9") {
+		t.Errorf("before-context not captured:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "after11") || !strings.Contains(ctx, "after12") {
+		t.Errorf("after-context missing:\n%s", ctx)
+	}
+	// Verify ordering: before8 appears before the match line, after11 after.
+	iB := strings.Index(ctx, "before8")
+	iM := strings.Index(ctx, "theMatch")
+	iA := strings.Index(ctx, "after11")
+	if !(iB < iM && iM < iA) {
+		t.Errorf("context lines out of order: before=%d match=%d after=%d\n%s", iB, iM, iA, ctx)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #89.

## Problems fixed

### 1. Before-context was always empty

rg emits before-context lines **before** the `match` event in the JSON stream. The parser created `pendingMatch` on the `match` event, so before-context lines always hit a `nil` pending and were silently dropped — every result showed zero before-context regardless of `context_lines`.

**Fix:** a `contextBuf` rolling window (bounded to `maxAfterContext` entries). Context lines that can't go into `pending.after` (pending is nil, cap is full, or line number ≤ pending's) go into the buffer instead. When a `match` event fires, entries with `lineNumber < matchLine` are pulled out as `before` and the buffer is reset.

This correctly handles all three scenarios:
- **First match in a group** — before lines arrive while `pending == nil`
- **Far-apart matches / separate groups** — before lines arrive after the `end` flush
- **Close matches** — after-cap overflow lines buffer and hand off to the next match's before

As a bonus, the bleed fix from #89 now also correctly recovers the overflowed lines as before-context rather than discarding them entirely.

### 2. Overflow note shortened

`[+N more in this file — use a more specific pattern or narrow the path]`  
→ `[+N more — narrow your search]`

### 3. Default context_lines 3 → 2

With before-context now working, 2 lines each side is enough surrounding code for most matches. Saves ~33% of context tokens at the default setting. Callers can still pass `context_lines: 3` explicitly.

## Tests

- `TestParseRipgrepOutput_BeforeContext` — new; verifies before lines arriving before the match event are correctly captured and appear in order
- `TestParseRipgrepOutput_NoContextBleed` — updated; now also asserts that overflow lines are recovered as matchB's before-context rather than discarded