### PR TITLE
feat: compact_content field for token-efficient insight injection

### DIFF
--- a/cmd/memory_insights.go
+++ b/cmd/memory_insights.go
@@ -15,6 +15,7 @@ var (
 	insightTrigger       string
 	insightConfidence    float64
 	insightContent       string
+	insightCompact       string
 	insightLimit         int
 	insightSearchLimit   int
 	insightHalfLifeDays  float64
@@ -114,11 +115,13 @@ func init() {
 	memoryInsightsListCmd.Flags().IntVar(&insightLimit, "limit", 20, "Maximum insights to show (0 = all)")
 
 	memoryInsightsAddCmd.Flags().StringVar(&insightContent, "content", "", "Insight rule text (required, or pipe via stdin)")
+	memoryInsightsAddCmd.Flags().StringVar(&insightCompact, "compact", "", "Short ≤15-word version for token-efficient injection (optional)")
 	memoryInsightsAddCmd.Flags().StringVar(&insightCategory, "category", "", "Category: anti-pattern | communication-style | domain-approach | workflow | anticipation")
 	memoryInsightsAddCmd.Flags().StringVar(&insightTrigger, "trigger", "", "When this insight applies (optional description)")
 	memoryInsightsAddCmd.Flags().Float64Var(&insightConfidence, "confidence", 0.5, "Initial confidence 0.0–1.0")
 
 	memoryInsightsUpdateCmd.Flags().StringVar(&insightContent, "content", "", "New insight content (required, or pipe via stdin)")
+	memoryInsightsUpdateCmd.Flags().StringVar(&insightCompact, "compact", "", "New compact form (leave empty to keep existing)")
 
 	memoryInsightsSearchCmd.Flags().IntVar(&insightSearchLimit, "limit", 5, "Maximum results")
 	memoryInsightsExpandCmd.Flags().IntVar(&insightSearchLimit, "max-tokens", 500, "Token budget for expansion")
@@ -143,14 +146,18 @@ func runMemoryInsightsList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("%-6s %-18s %-6s %-5s  %s\n", "ID", "CATEGORY", "CONF", "REINF", "CONTENT")
+	fmt.Printf("%-6s %-18s %-6s %-5s  %s\n", "ID", "CATEGORY", "CONF", "REINF", "COMPACT / CONTENT")
 	fmt.Println(strings.Repeat("-", 80))
 	for _, ins := range insights {
 		cat := ins.Category
 		if cat == "" {
 			cat = "-"
 		}
-		preview := ins.Content
+		// Show compact form if present, otherwise fall back to full content.
+		preview := ins.CompactContent
+		if preview == "" {
+			preview = ins.Content
+		}
 		if len(preview) > 52 {
 			preview = preview[:49] + "..."
 		}
@@ -182,11 +189,12 @@ func runMemoryInsightsAdd(cmd *cobra.Command, args []string) error {
 	defer store.Close()
 
 	ins := &memorydb.Insight{
-		Agent:       agent,
-		Content:     content,
-		Category:    strings.TrimSpace(insightCategory),
-		TriggerDesc: strings.TrimSpace(insightTrigger),
-		Confidence:  insightConfidence,
+		Agent:          agent,
+		Content:        content,
+		CompactContent: strings.TrimSpace(insightCompact),
+		Category:       strings.TrimSpace(insightCategory),
+		TriggerDesc:    strings.TrimSpace(insightTrigger),
+		Confidence:     insightConfidence,
 	}
 	if err := store.CreateInsight(context.Background(), ins); err != nil {
 		return err
@@ -215,7 +223,7 @@ func runMemoryInsightsUpdate(cmd *cobra.Command, args []string) error {
 	}
 	defer store.Close()
 
-	if err := store.UpdateInsight(context.Background(), id, content); err != nil {
+	if err := store.UpdateInsight(context.Background(), id, content, strings.TrimSpace(insightCompact)); err != nil {
 		return err
 	}
 	fmt.Printf("updated insight: id=%d\n", id)

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -1039,7 +1039,12 @@ Do NOT extract:
 - Anything that is already obvious assistant best practice
 - More than 10 insights total
 
-Each insight must have: category (one of: anti-pattern | communication-style | domain-approach | workflow | anticipation), trigger (when it applies), rule (the actionable behavioral change, 1-3 sentences), confidence (0.0-1.0 based on how clearly the evidence supports the pattern).`
+Each insight must have:
+- category: one of anti-pattern | communication-style | domain-approach | workflow | anticipation
+- trigger: when it applies (1 sentence)
+- rule: the full actionable behavioral change (1-3 sentences, can include justification/evidence)
+- compact: a terse version of the rule in ≤15 words, imperative, no hedging (used for token-efficient injection)
+- confidence: 0.0-1.0 based on how clearly the evidence supports the pattern`
 
 type insightExtractionResponse struct {
 	Insights []insightExtractionItem `json:"insights"`
@@ -1049,6 +1054,7 @@ type insightExtractionItem struct {
 	Category   string  `json:"category"`
 	Trigger    string  `json:"trigger"`
 	Rule       string  `json:"rule"`
+	Compact    string  `json:"compact"`
 	Confidence float64 `json:"confidence"`
 }
 
@@ -1192,11 +1198,12 @@ func runInsightExtractionPass(
 			}
 
 			ins := &memorydb.Insight{
-				Agent:       candidate.Agent,
-				Content:     rule,
-				Category:    strings.TrimSpace(item.Category),
-				TriggerDesc: strings.TrimSpace(item.Trigger),
-				Confidence:  item.Confidence,
+				Agent:          candidate.Agent,
+				Content:        rule,
+				CompactContent: strings.TrimSpace(item.Compact),
+				Category:       strings.TrimSpace(item.Category),
+				TriggerDesc:    strings.TrimSpace(item.Trigger),
+				Confidence:     item.Confidence,
 			}
 			if ins.Confidence <= 0 {
 				ins.Confidence = 0.5

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -181,6 +181,7 @@ CREATE TABLE IF NOT EXISTS memory_insights (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     agent               TEXT NOT NULL,
     content             TEXT NOT NULL,
+    compact_content     TEXT NOT NULL DEFAULT '',
     category            TEXT NOT NULL DEFAULT '',
     trigger_desc        TEXT NOT NULL DEFAULT '',
     confidence          REAL NOT NULL DEFAULT 0.5,
@@ -245,6 +246,18 @@ func NewStore(cfg Config) (*Store, error) {
 func initSchema(db *sql.DB) error {
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("initialize memory schema: %w", err)
+	}
+
+	// Idempotent column migrations for existing databases.
+	// SQLite returns "duplicate column name" when the column already exists;
+	// we suppress that specific error so initSchema is safe to run on any DB.
+	migrations := []string{
+		`ALTER TABLE memory_insights ADD COLUMN compact_content TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, m := range migrations {
+		if _, err := db.Exec(m); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+			return fmt.Errorf("schema migration %q: %w", m, err)
+		}
 	}
 
 	if err := ensureFTSInitialized(db); err != nil {
@@ -1862,6 +1875,7 @@ type Insight struct {
 	ID                 int64
 	Agent              string
 	Content            string
+	CompactContent     string // short form for injection; falls back to Content if empty
 	Category           string
 	TriggerDesc        string
 	Confidence         float64
@@ -1903,9 +1917,9 @@ func (s *Store) CreateInsight(ctx context.Context, ins *Insight) error {
 
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO memory_insights
-		    (agent, content, category, trigger_desc, confidence, reinforcement_count, created_at, last_reinforced)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		ins.Agent, ins.Content, ins.Category, ins.TriggerDesc,
+		    (agent, content, compact_content, category, trigger_desc, confidence, reinforcement_count, created_at, last_reinforced)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ins.Agent, ins.Content, ins.CompactContent, ins.Category, ins.TriggerDesc,
 		ins.Confidence, ins.ReinforcementCount,
 		ins.CreatedAt.UTC().Format(time.RFC3339),
 		ins.LastReinforced.UTC().Format(time.RFC3339),
@@ -1930,7 +1944,7 @@ func (s *Store) CreateInsight(ctx context.Context, ins *Insight) error {
 
 // ListInsights returns insights for an agent, newest first.
 func (s *Store) ListInsights(ctx context.Context, agent string, limit int) ([]*Insight, error) {
-	q := `SELECT id, agent, content, category, trigger_desc, confidence, reinforcement_count,
+	q := `SELECT id, agent, content, compact_content, category, trigger_desc, confidence, reinforcement_count,
 	             created_at, last_reinforced
 	      FROM memory_insights`
 	args := []any{}
@@ -1963,7 +1977,7 @@ func (s *Store) ListInsights(ctx context.Context, agent string, limit int) ([]*I
 // GetInsightByID returns a single insight by its row ID.
 func (s *Store) GetInsightByID(ctx context.Context, id int64) (*Insight, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, agent, content, category, trigger_desc, confidence, reinforcement_count,
+		SELECT id, agent, content, compact_content, category, trigger_desc, confidence, reinforcement_count,
 		       created_at, last_reinforced
 		FROM memory_insights WHERE id = ?`, id)
 	ins, err := scanInsight(row)
@@ -1973,12 +1987,14 @@ func (s *Store) GetInsightByID(ctx context.Context, id int64) (*Insight, error) 
 	return ins, err
 }
 
-// UpdateInsight replaces the content of an insight and resets FTS.
-func (s *Store) UpdateInsight(ctx context.Context, id int64, content string) error {
+// UpdateInsight replaces the content (and optionally compact_content) of an insight and resets FTS.
+// Pass compact="" to leave the compact form unchanged.
+func (s *Store) UpdateInsight(ctx context.Context, id int64, content, compact string) error {
 	content = strings.TrimSpace(content)
 	if content == "" {
 		return fmt.Errorf("content is required")
 	}
+	compact = strings.TrimSpace(compact)
 
 	// Fetch old row before UPDATE so the FTS delete command uses the exact
 	// original content (FTS5 delete requires the stored values to match).
@@ -1990,6 +2006,11 @@ func (s *Store) UpdateInsight(ctx context.Context, id int64, content string) err
 		return fmt.Errorf("insight not found: %d", id)
 	}
 
+	// Preserve existing compact if caller passes "".
+	if compact == "" {
+		compact = old.CompactContent
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("update insight tx: %w", err)
@@ -1997,8 +2018,8 @@ func (s *Store) UpdateInsight(ctx context.Context, id int64, content string) err
 	defer tx.Rollback() //nolint:errcheck
 
 	if _, err = tx.ExecContext(ctx,
-		`UPDATE memory_insights SET content = ?, last_reinforced = ? WHERE id = ?`,
-		content, time.Now().UTC().Format(time.RFC3339), id); err != nil {
+		`UPDATE memory_insights SET content = ?, compact_content = ?, last_reinforced = ? WHERE id = ?`,
+		content, compact, time.Now().UTC().Format(time.RFC3339), id); err != nil {
 		return fmt.Errorf("update insight: %w", err)
 	}
 
@@ -2109,7 +2130,7 @@ func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit i
 	args = append(args, limit)
 
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
-		SELECT i.id, i.agent, i.content, i.category, i.trigger_desc,
+		SELECT i.id, i.agent, i.content, i.compact_content, i.category, i.trigger_desc,
 		       i.confidence, i.reinforcement_count, i.created_at, i.last_reinforced
 		FROM memory_insights_fts f
 		JOIN memory_insights i ON i.id = f.rowid
@@ -2168,7 +2189,11 @@ func (s *Store) ExpandInsights(ctx context.Context, agent, _ string, maxTokens i
 			continue
 		}
 		n++
-		line := fmt.Sprintf("%d. %s\n", n, strings.TrimSpace(ins.Content))
+		text := strings.TrimSpace(ins.CompactContent)
+		if text == "" {
+			text = strings.TrimSpace(ins.Content)
+		}
+		line := fmt.Sprintf("%d. %s\n", n, text)
 		if used+len(line) > maxChars {
 			break
 		}
@@ -2187,7 +2212,7 @@ func scanInsight(scanner interface{ Scan(dest ...any) error }) (*Insight, error)
 	var ins Insight
 	var createdAt, lastReinforced string
 	err := scanner.Scan(
-		&ins.ID, &ins.Agent, &ins.Content, &ins.Category, &ins.TriggerDesc,
+		&ins.ID, &ins.Agent, &ins.Content, &ins.CompactContent, &ins.Category, &ins.TriggerDesc,
 		&ins.Confidence, &ins.ReinforcementCount, &createdAt, &lastReinforced,
 	)
 	if err != nil {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1014,11 +1014,12 @@ func TestInsightCRUD(t *testing.T) {
 	defer store.Close()
 
 	ins := &Insight{
-		Agent:       "jarvis",
-		Content:     "Do not expose internal tooling names in public posts.",
-		Category:    "anti-pattern",
-		TriggerDesc: "writing a blog post or public article",
-		Confidence:  0.9,
+		Agent:          "jarvis",
+		Content:        "Do not expose internal tooling names in public posts.",
+		CompactContent: "Never name internal tools in public writing.",
+		Category:       "anti-pattern",
+		TriggerDesc:    "writing a blog post or public article",
+		Confidence:     0.9,
 	}
 	if err := store.CreateInsight(ctx, ins); err != nil {
 		t.Fatalf("CreateInsight: %v", err)
@@ -1034,17 +1035,32 @@ func TestInsightCRUD(t *testing.T) {
 	if got.Content != ins.Content {
 		t.Errorf("content = %q, want %q", got.Content, ins.Content)
 	}
+	if got.CompactContent != ins.CompactContent {
+		t.Errorf("compact_content = %q, want %q", got.CompactContent, ins.CompactContent)
+	}
 	if got.Category != "anti-pattern" {
 		t.Errorf("category = %q, want anti-pattern", got.Category)
 	}
 
-	// Update
-	if err := store.UpdateInsight(ctx, ins.ID, "Never mention NZBGeek or SABnzbd in public posts."); err != nil {
+	// Update content + compact together.
+	if err := store.UpdateInsight(ctx, ins.ID, "Never mention NZBGeek or SABnzbd in public posts.", "No internal tool names in public posts."); err != nil {
 		t.Fatalf("UpdateInsight: %v", err)
 	}
 	got2, _ := store.GetInsightByID(ctx, ins.ID)
 	if got2.Content != "Never mention NZBGeek or SABnzbd in public posts." {
 		t.Errorf("after update, content = %q", got2.Content)
+	}
+	if got2.CompactContent != "No internal tool names in public posts." {
+		t.Errorf("after update, compact_content = %q", got2.CompactContent)
+	}
+
+	// Update content only — compact should be preserved.
+	if err := store.UpdateInsight(ctx, ins.ID, "Keep internal tool names out of published writing.", ""); err != nil {
+		t.Fatalf("UpdateInsight preserve compact: %v", err)
+	}
+	got3u, _ := store.GetInsightByID(ctx, ins.ID)
+	if got3u.CompactContent != "No internal tool names in public posts." {
+		t.Errorf("compact should be preserved when empty passed: %q", got3u.CompactContent)
 	}
 
 	// Delete
@@ -1204,25 +1220,47 @@ func TestInsightExpand(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close()
 
+	// Insight with both full and compact forms.
 	if err := store.CreateInsight(ctx, &Insight{
-		Agent:      "jarvis",
-		Content:    "When writing public content, use generic stand-ins for private tools.",
-		Category:   "anti-pattern",
-		Confidence: 0.9,
+		Agent:          "jarvis",
+		Content:        "When writing public content, use generic stand-ins for private tools.",
+		CompactContent: "Use generic names in public writing.",
+		Category:       "anti-pattern",
+		Confidence:     0.9,
 	}); err != nil {
-		t.Fatalf("CreateInsight: %v", err)
+		t.Fatalf("CreateInsight with compact: %v", err)
 	}
 
-	// Query that should match — uses words present in the content.
-	out, err := store.ExpandInsights(ctx, "jarvis", "public content private tools generic", 500)
+	// Insight without compact — should fall back to full content.
+	if err := store.CreateInsight(ctx, &Insight{
+		Agent:      "jarvis",
+		Content:    "Always confirm before overwriting existing files.",
+		Category:   "workflow",
+		Confidence: 0.8,
+	}); err != nil {
+		t.Fatalf("CreateInsight no compact: %v", err)
+	}
+
+	out, err := store.ExpandInsights(ctx, "jarvis", "any", 500)
 	if err != nil {
 		t.Fatalf("ExpandInsights: %v", err)
 	}
 	if out == "" {
-		t.Fatal("ExpandInsights returned empty string for matching query")
+		t.Fatal("ExpandInsights returned empty string")
 	}
 	if !strings.Contains(out, "<insights>") {
 		t.Errorf("output missing <insights> tag: %q", out)
+	}
+	// Compact form should appear, not the verbose form.
+	if !strings.Contains(out, "Use generic names in public writing.") {
+		t.Errorf("compact form not used in expansion: %q", out)
+	}
+	if strings.Contains(out, "use generic stand-ins for private tools") {
+		t.Errorf("verbose form should not appear when compact is set: %q", out)
+	}
+	// Insight without compact should show full content.
+	if !strings.Contains(out, "Always confirm before overwriting existing files.") {
+		t.Errorf("full content fallback not working: %q", out)
 	}
 
 	// Empty bank for a different agent should return empty.


### PR DESCRIPTION
## What

Adds a `compact_content` field to `memory_insights` — a ≤15-word imperative form of each insight, generated at mine time and used by `ExpandInsights` for injection instead of the full verbose content.

## Why

Each insight as currently stored has two logical parts:

- **Rule** (~27 tok avg): the actionable instruction
- **Context** (~40 tok avg): justification prose ("The user had to say this twice before…")

The context is useful for understanding and review, but at injection time the model just needs the rule. With full content the default 500-token budget fits 7 insights. With compact forms it fits 20+.

`compact_content` is the normalized injection form. `content` is preserved for display, review, and the mining dedup logic. `ExpandInsights` uses `compact_content` when set, falls back to `content` when empty — so existing insights keep working unchanged.

## Changes

**Schema** (`internal/memory/store.go`):
- `compact_content TEXT NOT NULL DEFAULT ''` added to `memory_insights`
- Idempotent `ALTER TABLE ADD COLUMN` migration in `initSchema` (suppresses "duplicate column name" for existing DBs)

**Store**:
- `Insight.CompactContent` field
- `CreateInsight`, `UpdateInsight`, `scanInsight`, `ListInsights`, `GetInsightByID`, `SearchInsights`: all include `compact_content`
- `UpdateInsight(ctx, id, content, compact string)`: pass `compact=""` to preserve the existing compact form
- `ExpandInsights`: injects `CompactContent` when non-empty, falls back to `Content`

**Mining** (`cmd/memory_mine.go`):
- `insightExtractionItem.Compact` field
- `insightExtractionSystemPrompt` updated to ask for a `compact` field alongside `rule` (≤15 words, imperative, no hedging)
- `CreateInsight` call passes `CompactContent: item.Compact`

**CLI** (`cmd/memory_insights.go`):
- `insights add --compact "..."` flag
- `insights update --compact "..."` flag (empty = preserve existing)
- `insights list` column header renamed to `COMPACT / CONTENT`, shows compact form when set

**Tests**:
- `TestInsightCRUD`: compact round-trip, `UpdateInsight` with compact, preserve-on-empty-update
- `TestInsightExpand`: compact form used in output, verbose form absent, fallback for insights without compact
