### PR TITLE
feat: merge adjacent match blocks, gap separator, Go fallback truncation

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -127,12 +127,14 @@ func (t *GrepTool) executeRipgrep(ctx context.Context, pattern, searchPath, incl
 }
 
 // pendingMatch tracks context for building ripgrep results.
+// before and after carry line numbers so adjacent matches can be merged
+// without re-parsing formatted strings.
 type pendingMatch struct {
 	filePath   string
 	lineNumber int
 	matchLine  string
-	before     []string
-	after      []string
+	before     []contextEntry
+	after      []contextEntry
 }
 
 // contextEntry is one line from a ripgrep "context" event.
@@ -141,7 +143,108 @@ type contextEntry struct {
 	text       string
 }
 
-// parseRipgrepOutput parses ripgrep JSON output into GrepMatches.
+// matchBlock is the merged display unit for one contiguous context window.
+// A single block may highlight multiple match lines when adjacent matches
+// are merged.
+type matchBlock struct {
+	filePath string
+	lines    []blockLine
+}
+
+type blockLine struct {
+	number  int
+	text    string
+	isMatch bool
+}
+
+// pendingToBlock converts a pendingMatch to a matchBlock.
+func pendingToBlock(p *pendingMatch) matchBlock {
+	lines := make([]blockLine, 0, len(p.before)+1+len(p.after))
+	for _, e := range p.before {
+		lines = append(lines, blockLine{e.lineNumber, e.text, false})
+	}
+	lines = append(lines, blockLine{p.lineNumber, p.matchLine, true})
+	for _, e := range p.after {
+		lines = append(lines, blockLine{e.lineNumber, e.text, false})
+	}
+	return matchBlock{p.filePath, lines}
+}
+
+// mergeBlocks combines two matchBlocks into one, deduplicating shared lines.
+// Lines present in both blocks are shown once; a line that is a match in
+// either block is marked as a match in the result.
+func mergeBlocks(a, b matchBlock) matchBlock {
+	byNum := make(map[int]int, len(a.lines)+len(b.lines)) // lineNum → slice index
+	merged := make([]blockLine, 0, len(a.lines)+len(b.lines))
+	for _, l := range a.lines {
+		byNum[l.number] = len(merged)
+		merged = append(merged, l)
+	}
+	for _, l := range b.lines {
+		if idx, ok := byNum[l.number]; ok {
+			if l.isMatch {
+				merged[idx].isMatch = true
+			}
+		} else {
+			byNum[l.number] = len(merged)
+			merged = append(merged, l)
+		}
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].number < merged[j].number
+	})
+	return matchBlock{a.filePath, merged}
+}
+
+// pendingsToBlocks converts raw parsed matches to display blocks, merging
+// adjacent matches whose context windows overlap or are contiguous.
+func pendingsToBlocks(pending []pendingMatch) []matchBlock {
+	var blocks []matchBlock
+	for i := range pending {
+		b := pendingToBlock(&pending[i])
+		if len(blocks) > 0 && blocks[len(blocks)-1].filePath == b.filePath {
+			last := blocks[len(blocks)-1]
+			lastLine := last.lines[len(last.lines)-1].number
+			firstLine := b.lines[0].number
+			if firstLine <= lastLine+1 {
+				blocks[len(blocks)-1] = mergeBlocks(last, b)
+				continue
+			}
+		}
+		blocks = append(blocks, b)
+	}
+	return blocks
+}
+
+// blockToGrepMatch converts a matchBlock to a GrepMatch for external use.
+func blockToGrepMatch(b matchBlock) GrepMatch {
+	var sb strings.Builder
+	for _, l := range b.lines {
+		prefix := "  "
+		if l.isMatch {
+			prefix = "> "
+		}
+		sb.WriteString(fmt.Sprintf("%s%d: %s\n", prefix, l.number, truncateLine(l.text)))
+	}
+	// LineNumber and Match refer to the first highlighted line.
+	var firstNum int
+	var firstText string
+	for _, l := range b.lines {
+		if l.isMatch {
+			firstNum = l.number
+			firstText = l.text
+			break
+		}
+	}
+	return GrepMatch{
+		FilePath:   b.filePath,
+		LineNumber: firstNum,
+		Match:      firstText,
+		Context:    strings.TrimSuffix(sb.String(), "\n"),
+	}
+}
+
+// parseToPending parses ripgrep JSON output into raw pendingMatches.
 //
 // # Stream ordering
 //
@@ -166,9 +269,9 @@ type contextEntry struct {
 // After-context lines go directly into pending.after, capped at maxAfterContext.
 // Lines beyond the cap are buffered (not discarded) so they are available as
 // before-context for the next match.
-func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepMatch, error) {
-	var matches []GrepMatch
+func parseToPending(output []byte, maxResults, maxAfterContext int) ([]pendingMatch, error) {
 	var pending *pendingMatch
+	var result []pendingMatch
 	var contextBuf []contextEntry // look-back buffer for before-context
 
 	bufAppend := func(e contextEntry) {
@@ -182,9 +285,9 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 		if pending == nil {
 			return false
 		}
-		matches = append(matches, buildMatchFromPending(pending))
+		result = append(result, *pending)
 		pending = nil
-		return len(matches) >= maxResults
+		return len(result) >= maxResults
 	}
 
 	lines := strings.Split(string(output), "\n")
@@ -201,7 +304,7 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 		switch msg.Type {
 		case "match":
 			if flush() {
-				return matches, nil
+				return result, nil
 			}
 
 			var data rgMatchData
@@ -210,10 +313,10 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 			}
 
 			// Collect before-context from the look-back buffer.
-			var before []string
+			var before []contextEntry
 			for _, e := range contextBuf {
 				if e.lineNumber < data.LineNumber {
-					before = append(before, e.text)
+					before = append(before, e)
 				}
 			}
 
@@ -234,7 +337,7 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 			text := strings.TrimSuffix(data.Lines.Text, "\n")
 			if pending != nil && data.LineNumber > pending.lineNumber && len(pending.after) < maxAfterContext {
 				// Normal after-context for the current match.
-				pending.after = append(pending.after, text)
+				pending.after = append(pending.after, contextEntry{data.LineNumber, text})
 			} else {
 				// Everything else goes into the look-back buffer:
 				//  - lines before the first match in a group (pending == nil)
@@ -248,7 +351,7 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 			// last match in a group gets its after-context before the next
 			// group's before-context starts arriving.
 			if flush() {
-				return matches, nil
+				return result, nil
 			}
 			contextBuf = nil // each group starts with a clean buffer
 		}
@@ -257,6 +360,21 @@ func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepM
 	// Flush any remaining match not terminated by an "end" event.
 	flush()
 
+	return result, nil
+}
+
+// parseRipgrepOutput parses ripgrep JSON output into GrepMatches.
+// It runs the full pipeline: raw parse → merge adjacent blocks → format.
+func parseRipgrepOutput(output []byte, maxResults, maxAfterContext int) ([]GrepMatch, error) {
+	pending, err := parseToPending(output, maxResults, maxAfterContext)
+	if err != nil {
+		return nil, err
+	}
+	blocks := pendingsToBlocks(pending)
+	matches := make([]GrepMatch, len(blocks))
+	for i, b := range blocks {
+		matches[i] = blockToGrepMatch(b)
+	}
 	return matches, nil
 }
 
@@ -270,26 +388,6 @@ func truncateLine(s string) string {
 		return s
 	}
 	return string(r[:maxLineDisplayLen-1]) + "…"
-}
-
-func buildMatchFromPending(p *pendingMatch) GrepMatch {
-	var sb strings.Builder
-	startLine := p.lineNumber - len(p.before)
-
-	for i, line := range p.before {
-		sb.WriteString(fmt.Sprintf("  %d: %s\n", startLine+i, truncateLine(line)))
-	}
-	sb.WriteString(fmt.Sprintf("> %d: %s\n", p.lineNumber, truncateLine(p.matchLine)))
-	for i, line := range p.after {
-		sb.WriteString(fmt.Sprintf("  %d: %s\n", p.lineNumber+1+i, truncateLine(line)))
-	}
-
-	return GrepMatch{
-		FilePath:   p.filePath,
-		LineNumber: p.lineNumber,
-		Match:      p.matchLine,
-		Context:    strings.TrimSuffix(sb.String(), "\n"),
-	}
 }
 
 // GrepArgs are the arguments for grep.
@@ -654,7 +752,7 @@ func buildContext(lines []string, matchIdx, contextLines int) string {
 		if i == matchIdx {
 			prefix = "> "
 		}
-		sb.WriteString(fmt.Sprintf("%s%d: %s\n", prefix, i+1, lines[i]))
+		sb.WriteString(fmt.Sprintf("%s%d: %s\n", prefix, i+1, truncateLine(lines[i])))
 	}
 
 	return strings.TrimSuffix(sb.String(), "\n")
@@ -743,7 +841,7 @@ func formatGrepResults(matches []GrepMatch, truncated bool) string {
 
 		for i, m := range display {
 			if i > 0 {
-				sb.WriteString("\n")
+				sb.WriteString("  …\n")
 			}
 			sb.WriteString(m.Context)
 			sb.WriteString("\n")

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -116,6 +116,171 @@ func TestFormatGrepResults_Empty(t *testing.T) {
 	}
 }
 
+// TestPendingsToBlocks_MergeAdjacent verifies that two matches on consecutive
+// lines (e.g. lines 41 and 42) are merged into a single block with two ">"
+// markers rather than displayed as two separate overlapping context windows.
+func TestPendingsToBlocks_MergeAdjacent(t *testing.T) {
+	pending := []pendingMatch{
+		{
+			filePath:  "f.go",
+			lineNumber: 41,
+			matchLine: "matchA",
+			before:    []contextEntry{{39, "ctx39"}, {40, "ctx40"}},
+			after:     []contextEntry{},
+		},
+		{
+			filePath:  "f.go",
+			lineNumber: 42,
+			matchLine: "matchB",
+			before:    []contextEntry{},
+			after:     []contextEntry{{43, "ctx43"}, {44, "ctx44"}},
+		},
+	}
+
+	blocks := pendingsToBlocks(pending)
+
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 merged block, got %d", len(blocks))
+	}
+
+	b := blocks[0]
+	// Should have: 39(ctx), 40(ctx), 41(match), 42(match), 43(ctx), 44(ctx)
+	if len(b.lines) != 6 {
+		t.Errorf("expected 6 lines in merged block, got %d: %+v", len(b.lines), b.lines)
+	}
+
+	matchCount := 0
+	for _, l := range b.lines {
+		if l.isMatch {
+			matchCount++
+		}
+	}
+	if matchCount != 2 {
+		t.Errorf("expected 2 match lines in merged block, got %d", matchCount)
+	}
+
+	m := blockToGrepMatch(b)
+	if !strings.Contains(m.Context, "> 41:") || !strings.Contains(m.Context, "> 42:") {
+		t.Errorf("merged context missing match markers:\n%s", m.Context)
+	}
+	// No duplicate context lines (39,40 should appear once each)
+	if strings.Count(m.Context, "ctx39") != 1 || strings.Count(m.Context, "ctx40") != 1 {
+		t.Errorf("context lines duplicated in merged block:\n%s", m.Context)
+	}
+}
+
+// TestPendingsToBlocks_NoMergeFarApart verifies that matches with a large gap
+// between them are kept as separate blocks.
+func TestPendingsToBlocks_NoMergeFarApart(t *testing.T) {
+	pending := []pendingMatch{
+		{
+			filePath:  "f.go",
+			lineNumber: 41,
+			matchLine: "matchA",
+			before:    []contextEntry{{39, "ctx39"}, {40, "ctx40"}},
+			after:     []contextEntry{{43, "ctx43"}, {44, "ctx44"}},
+		},
+		{
+			filePath:  "f.go",
+			lineNumber: 339,
+			matchLine: "matchB",
+			before:    []contextEntry{{337, "ctx337"}, {338, "ctx338"}},
+			after:     []contextEntry{{340, "ctx340"}, {341, "ctx341"}},
+		},
+	}
+
+	blocks := pendingsToBlocks(pending)
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 separate blocks, got %d", len(blocks))
+	}
+	if blocks[0].lines[0].number != 39 {
+		t.Errorf("block 0 should start at line 39, got %d", blocks[0].lines[0].number)
+	}
+	if blocks[1].lines[0].number != 337 {
+		t.Errorf("block 1 should start at line 337, got %d", blocks[1].lines[0].number)
+	}
+}
+
+// TestPendingsToBlocks_DifferentFiles verifies that matches in different files
+// are never merged even if line numbers overlap.
+func TestPendingsToBlocks_DifferentFiles(t *testing.T) {
+	pending := []pendingMatch{
+		{filePath: "a.go", lineNumber: 10, matchLine: "matchA"},
+		{filePath: "b.go", lineNumber: 10, matchLine: "matchB"},
+	}
+
+	blocks := pendingsToBlocks(pending)
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks for different files, got %d", len(blocks))
+	}
+	if blocks[0].filePath != "a.go" || blocks[1].filePath != "b.go" {
+		t.Errorf("unexpected file order: %s, %s", blocks[0].filePath, blocks[1].filePath)
+	}
+}
+
+// TestFormatGrepResults_EllipsisSeparator verifies that non-adjacent blocks
+// within the same file are separated by "  …" rather than a blank line.
+func TestFormatGrepResults_EllipsisSeparator(t *testing.T) {
+	matches := []GrepMatch{
+		{FilePath: "f.go", LineNumber: 10, Match: "matchA", Context: "> 10: matchA"},
+		{FilePath: "f.go", LineNumber: 300, Match: "matchB", Context: "> 300: matchB"},
+	}
+
+	result := formatGrepResults(matches, false)
+
+	if !strings.Contains(result, "  …") {
+		t.Errorf("expected ellipsis separator between non-adjacent blocks:\n%s", result)
+	}
+}
+
+// TestParseRipgrepOutput_MergesAdjacent is an end-to-end test verifying that
+// adjacent matches produce a single merged GrepMatch with both ">" lines.
+func TestParseRipgrepOutput_MergesAdjacent(t *testing.T) {
+	makeMatch := func(lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"match","data":{"path":{"text":"f.go"},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			text+"\n", lineNum)
+	}
+	makeContext := func(lineNum int, text string) string {
+		return fmt.Sprintf(`{"type":"context","data":{"path":{"text":"f.go"},"lines":{"text":%q},"line_number":%d,"absolute_offset":0,"submatches":[]}}`,
+			text+"\n", lineNum)
+	}
+	makeEnd := func() string {
+		return `{"type":"end","data":{"path":{"text":"f.go"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":0},"searches":1,"searches_with_match":1,"bytes_searched":0,"bytes_printed":0,"matched_lines":2,"matches":2}}}`
+	}
+
+	// Two adjacent matches at lines 41 and 42, context=2.
+	// rg emits before-context for 41, then match@41, then match@42 (no context
+	// between), then after-context for 42, then end.
+	lines := []string{
+		makeContext(39, "ctx39"),
+		makeContext(40, "ctx40"),
+		makeMatch(41, "matchA"),
+		makeMatch(42, "matchB"),
+		makeContext(43, "ctx43"),
+		makeContext(44, "ctx44"),
+		makeEnd(),
+	}
+	input := []byte(strings.Join(lines, "\n"))
+
+	matches, err := parseRipgrepOutput(input, 100, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 merged match, got %d", len(matches))
+	}
+
+	ctx := matches[0].Context
+	if !strings.Contains(ctx, "> 41:") || !strings.Contains(ctx, "> 42:") {
+		t.Errorf("merged context missing match markers:\n%s", ctx)
+	}
+	if strings.Count(ctx, "ctx39") != 1 || strings.Count(ctx, "ctx44") != 1 {
+		t.Errorf("context lines should appear exactly once:\n%s", ctx)
+	}
+}
+
 func TestGroupMatchesByFile_PreservesOrder(t *testing.T) {
 	matches := []GrepMatch{
 		{FilePath: "c.go", LineNumber: 1},


### PR DESCRIPTION
Follow-up to #91.

## Changes

### 1. Merge adjacent match blocks

When two matches in the same file have overlapping or contiguous context windows, they are now merged into a single display block with both lines marked `>`.

**Before** (two separate blocks, shared context lines shown twice):
```
  39: match cmd {
  40:     GitCommand::Diff => run_diff(...)
> 41:     GitCommand::Log => run_log(...)
  43:     GitCommand::Show => ...
  44:     GitCommand::Add => ...

  40:     GitCommand::Diff => run_diff(...)
  41:     GitCommand::Log => run_log(...)
> 42:     GitCommand::Status => run_status(...)
  43:     GitCommand::Show => ...
  44:     GitCommand::Add => ...
```

**After** (one block, no duplication):
```
  39: match cmd {
  40:     GitCommand::Diff => run_diff(...)
> 41:     GitCommand::Log => run_log(...)
> 42:     GitCommand::Status => run_status(...)
  43:     GitCommand::Show => ...
  44:     GitCommand::Add => ...
```

Merge rule: if block B's first context line ≤ block A's last context line + 1, merge. Lines present in both blocks are deduplicated; a line that is a match in either block is marked `>` in the result.

**Implementation:** `pendingMatch.before/after` changed from `[]string` to `[]contextEntry` to carry line numbers for accurate dedup. Internal pipeline is now `parseToPending` → `pendingsToBlocks` (merge) → `blockToGrepMatch` (format). Public `parseRipgrepOutput` signature unchanged.

### 2. `…` separator between non-adjacent blocks

Blank line between context windows replaced with `  …` to make gaps explicit. Adjacent matches that were merged don't produce a separator.

### 3. Go fallback truncation

`buildContext` (used when `rg` is unavailable) now calls `truncateLine` on each line, matching the rg path behaviour.

## Tests added

- `TestPendingsToBlocks_MergeAdjacent` — adjacent matches merge into one block with two `>` markers
- `TestPendingsToBlocks_NoMergeFarApart` — far-apart matches stay separate
- `TestPendingsToBlocks_DifferentFiles` — different-file matches never merge
- `TestFormatGrepResults_EllipsisSeparator` — `…` appears between non-adjacent blocks
- `TestParseRipgrepOutput_MergesAdjacent` — end-to-end test with real rg JSON stream