### PR TITLE
feat: add gpt-5.4 model (1.05M context)

### DIFF
--- a/internal/llm/context_window.go
+++ b/internal/llm/context_window.go
@@ -112,6 +112,7 @@ var inputLimitTable = []inputLimitEntry{
 	{"claude-3-haiku", 196_000},    // 200K - 4K
 
 	// OpenAI GPT-5 family (from models.dev openai section: explicit input=272000)
+	{"gpt-5.4", 922_000},             // 1,050,000 ctx - 128,000 out
 	{"gpt-5.3-codex-spark", 100_000}, // input=100000
 	{"gpt-5.1-chat", 112_000},        // 128K ctx - 16K out (no explicit input)
 	{"gpt-5.2-chat", 112_000},        // 128K ctx - 16K out

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -23,6 +23,7 @@ var ProviderModels = map[string][]string{
 		"claude-haiku-4-5-thinking",
 	},
 	"openai": {
+		"gpt-5.4",
 		"gpt-5.3-codex",
 		"gpt-5.2-codex",
 		"gpt-5.2",
@@ -34,6 +35,7 @@ var ProviderModels = map[string][]string{
 	},
 	"chatgpt": {
 		// Uses ChatGPT backend API with native OAuth
+		"gpt-5.4",
 		"gpt-5.3-codex",
 		"gpt-5.3-codex-spark",
 		"gpt-5.2-codex",


### PR DESCRIPTION
## What

Adds GPT-5.4 to the model lists for `openai` and `chatgpt` providers, and registers its context window.

## Details

- **Context window**: 1,050,000 tokens (1.05M)
- **Max output**: 128,000 tokens
- **Effective input**: 922,000 tokens (context − output)
- **Reasoning effort**: none / low / medium / high / xhigh (same as rest of GPT-5 family)
- **Released**: 2026-03-05

`gpt-5.4` is added before the generic `gpt-5` catch-all in `context_window.go` so the prefix matcher picks it up correctly. It appears first in the `openai` and `chatgpt` model lists as the current flagship.
