### PR TITLE
feat: auto-enrich grep context for small result sets

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -29,7 +29,32 @@ const (
 	// in the grouped output.  When a file has more matches than this, a note
 	// is appended so the model knows to narrow its search.
 	maxMatchesPerFileDisplay = 10
+
+	// autoEnrichThreshold is the maximum number of match blocks for which
+	// auto-enrichment is applied.  Above this, the result set is large enough
+	// that adding more context would bloat the response unhelpfully.
+	autoEnrichThreshold = 3
 )
+
+// autoEnrichContextLines returns the number of context lines to use when
+// auto-enriching a small result set.  The goal is to give the model enough
+// surrounding code to understand each match without a follow-up read_file
+// call.
+//
+//   - 1 block  → 30 lines: wide window to capture the full function/method body
+//   - 2–3 blocks → 10 lines: moderate window; adjacent blocks will merge via
+//     the normal block-merge pipeline, producing a clean single view
+//   - >3 blocks → 0 (no enrichment)
+func autoEnrichContextLines(blockCount int) int {
+	switch {
+	case blockCount == 1:
+		return 30
+	case blockCount >= 2 && blockCount <= autoEnrichThreshold:
+		return 10
+	default:
+		return 0
+	}
+}
 
 // GrepTool implements the grep tool.
 type GrepTool struct {
@@ -542,6 +567,16 @@ func (t *GrepTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 			}
 			if a.FilesWithMatches {
 				return textOutput(formatFilesWithMatches(matches)), nil
+			}
+			// Auto-enrich: when the result set is small and the caller didn't
+			// request explicit context, bump the context window so the model can
+			// understand the match without an extra read_file round-trip.
+			if a.ContextLines <= 0 {
+				if enriched := autoEnrichContextLines(len(matches)); enriched > contextLines {
+					if richer, err2 := t.executeRipgrep(ctx, a.Pattern, searchPath, a.Include, a.Exclude, enriched, maxResults, false); err2 == nil && len(richer) > 0 {
+						matches = richer
+					}
+				}
 			}
 			return textOutput(formatGrepResults(matches, len(matches) >= maxResults)), nil
 		}

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -122,18 +122,18 @@ func TestFormatGrepResults_Empty(t *testing.T) {
 func TestPendingsToBlocks_MergeAdjacent(t *testing.T) {
 	pending := []pendingMatch{
 		{
-			filePath:  "f.go",
+			filePath:   "f.go",
 			lineNumber: 41,
-			matchLine: "matchA",
-			before:    []contextEntry{{39, "ctx39"}, {40, "ctx40"}},
-			after:     []contextEntry{},
+			matchLine:  "matchA",
+			before:     []contextEntry{{39, "ctx39"}, {40, "ctx40"}},
+			after:      []contextEntry{},
 		},
 		{
-			filePath:  "f.go",
+			filePath:   "f.go",
 			lineNumber: 42,
-			matchLine: "matchB",
-			before:    []contextEntry{},
-			after:     []contextEntry{{43, "ctx43"}, {44, "ctx44"}},
+			matchLine:  "matchB",
+			before:     []contextEntry{},
+			after:      []contextEntry{{43, "ctx43"}, {44, "ctx44"}},
 		},
 	}
 
@@ -174,18 +174,18 @@ func TestPendingsToBlocks_MergeAdjacent(t *testing.T) {
 func TestPendingsToBlocks_NoMergeFarApart(t *testing.T) {
 	pending := []pendingMatch{
 		{
-			filePath:  "f.go",
+			filePath:   "f.go",
 			lineNumber: 41,
-			matchLine: "matchA",
-			before:    []contextEntry{{39, "ctx39"}, {40, "ctx40"}},
-			after:     []contextEntry{{43, "ctx43"}, {44, "ctx44"}},
+			matchLine:  "matchA",
+			before:     []contextEntry{{39, "ctx39"}, {40, "ctx40"}},
+			after:      []contextEntry{{43, "ctx43"}, {44, "ctx44"}},
 		},
 		{
-			filePath:  "f.go",
+			filePath:   "f.go",
 			lineNumber: 339,
-			matchLine: "matchB",
-			before:    []contextEntry{{337, "ctx337"}, {338, "ctx338"}},
-			after:     []contextEntry{{340, "ctx340"}, {341, "ctx341"}},
+			matchLine:  "matchB",
+			before:     []contextEntry{{337, "ctx337"}, {338, "ctx338"}},
+			after:      []contextEntry{{340, "ctx340"}, {341, "ctx341"}},
 		},
 	}
 
@@ -550,5 +550,96 @@ func TestGrepTool_GroupedOutput(t *testing.T) {
 	}
 	if strings.Count(output.Content, betaPath) != 1 {
 		t.Errorf("beta.go should appear once, got:\n%s", output.Content)
+	}
+}
+
+// TestAutoEnrichContextLines checks the block-count → context-lines mapping.
+func TestAutoEnrichContextLines(t *testing.T) {
+	cases := []struct {
+		blocks int
+		want   int
+	}{
+		{0, 0},
+		{1, 30},
+		{2, 10},
+		{3, 10},
+		{4, 0},
+		{100, 0},
+	}
+	for _, c := range cases {
+		got := autoEnrichContextLines(c.blocks)
+		if got != c.want {
+			t.Errorf("autoEnrichContextLines(%d) = %d, want %d", c.blocks, got, c.want)
+		}
+	}
+}
+
+// TestAutoEnrich_SingleMatch verifies that a single-match result is enriched
+// with additional context when the caller does not request explicit context.
+func TestAutoEnrich_SingleMatch(t *testing.T) {
+	if !ripgrepAvailable() {
+		t.Skip("ripgrep not available")
+	}
+
+	dir := t.TempDir()
+
+	// Write a file with padding lines so we can verify context expansion.
+	var content strings.Builder
+	for i := 1; i <= 40; i++ {
+		if i == 20 {
+			content.WriteString("UNIQUE_AUTOENRICH_TOKEN\n")
+		} else {
+			content.WriteString(fmt.Sprintf("padding line %d\n", i))
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "target.go"), []byte(content.String()), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewGrepTool(nil, DefaultOutputLimits())
+
+	// With explicit ContextLines=0 (default), auto-enrich should kick in.
+	args, _ := json.Marshal(GrepArgs{
+		Pattern:      "UNIQUE_AUTOENRICH_TOKEN",
+		Path:         dir,
+		ContextLines: 0,
+	})
+	output, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Auto-enrich bumps to 30 lines for a single block.
+	// The file has 39 padding lines + 1 match.  With 30 lines of context
+	// the result should contain significantly more than the default 2 lines.
+	// We verify by counting context lines (prefixed with "  ") in the output.
+	contextLineCount := 0
+	for _, line := range strings.Split(output.Content, "\n") {
+		if strings.HasPrefix(line, "  ") && strings.Contains(line, "padding line") {
+			contextLineCount++
+		}
+	}
+	if contextLineCount < 20 {
+		t.Errorf("expected ≥20 context lines with auto-enrich, got %d\noutput:\n%s", contextLineCount, output.Content)
+	}
+
+	// Explicit context override must suppress auto-enrichment.
+	args2, _ := json.Marshal(GrepArgs{
+		Pattern:      "UNIQUE_AUTOENRICH_TOKEN",
+		Path:         dir,
+		ContextLines: 1,
+	})
+	output2, err := tool.Execute(context.Background(), args2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextLineCount2 := 0
+	for _, line := range strings.Split(output2.Content, "\n") {
+		if strings.HasPrefix(line, "  ") && strings.Contains(line, "padding line") {
+			contextLineCount2++
+		}
+	}
+	if contextLineCount2 > 2 {
+		t.Errorf("explicit ContextLines=1 should not auto-enrich; got %d context lines\noutput:\n%s", contextLineCount2, output2.Content)
 	}
 }


### PR DESCRIPTION
## What

When a grep returns a small number of match blocks (1–3), automatically re-run with more context lines — without requiring the model to ask for it.

| Block count | Auto-enriched context |
|---|---|
| 1 | 30 lines (wide window — captures a full function/method body) |
| 2–3 | 10 lines (moderate; adjacent blocks merge via existing pipeline) |
| >3 | no change (result set is large enough already) |

Auto-enrichment is suppressed when the caller explicitly sets `context_lines`.

## Why

Stolen from Gemini CLI, which runs a similar heuristic and reports ~10% reduction in SWEBench turn count. The logic: if there are only 1–3 matches, the model almost always needs to read surrounding code to understand them — so we preempt the follow-up `read_file` call by expanding context on the second rg pass.

The two-rg-pass overhead only applies to small result sets (fast searches), so it's negligible in practice.

Our numbers (30/10) are slightly tighter than Gemini's (50/15). Fifty lines for a single match risks showing too much noise; 30 comfortably captures any function body. Ten lines per block at 2–3 results is enough context while keeping token cost reasonable — and the adjacent-block merge pipeline combines any overlapping windows into a single clean view.

## Tests

- `TestAutoEnrichContextLines` — unit test for the block-count → context mapping
- `TestAutoEnrich_SingleMatch` — integration test verifying context expansion fires at default settings and is suppressed by explicit `context_lines`
