### PR TITLE
feat: mtime sort + 50KB byte cap for grep output

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -34,6 +34,12 @@ const (
 	// auto-enrichment is applied.  Above this, the result set is large enough
 	// that adding more context would bloat the response unhelpfully.
 	autoEnrichThreshold = 3
+
+	// maxOutputBytes is the total byte budget for a formatted grep response.
+	// File groups that would push the output over this limit are omitted and
+	// replaced with a truncation note.  Keeps minified / generated files from
+	// producing enormous single-block responses even after per-line truncation.
+	maxOutputBytes = 50 * 1024 // 50 KB
 )
 
 // autoEnrichContextLines returns the number of context lines to use when
@@ -578,6 +584,8 @@ func (t *GrepTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 					}
 				}
 			}
+			// Sort so the most recently modified files appear first.
+			matches = sortGrepMatchesByMtime(matches)
 			return textOutput(formatGrepResults(matches, len(matches) >= maxResults)), nil
 		}
 	}
@@ -683,6 +691,37 @@ func collectFiles(searchPath, include, exclude string) ([]string, error) {
 	})
 
 	return files, err
+}
+
+// sortGrepMatchesByMtime reorders matches so that matches from the
+// most-recently-modified file appear first.  Within a file the original
+// line order is preserved.  Files that cannot be stat'd are sorted last.
+func sortGrepMatchesByMtime(matches []GrepMatch) []GrepMatch {
+	groups := groupMatchesByFile(matches)
+
+	type mtimeGroup struct {
+		fg    fileGroup
+		mtime int64
+	}
+	mg := make([]mtimeGroup, len(groups))
+	for i, g := range groups {
+		info, err := os.Stat(g.path)
+		if err != nil {
+			mg[i] = mtimeGroup{fg: g, mtime: 0}
+		} else {
+			mg[i] = mtimeGroup{fg: g, mtime: info.ModTime().Unix()}
+		}
+	}
+
+	sort.SliceStable(mg, func(i, j int) bool {
+		return mg[i].mtime > mg[j].mtime
+	})
+
+	out := make([]GrepMatch, 0, len(matches))
+	for _, m := range mg {
+		out = append(out, m.fg.matches...)
+	}
+	return out
 }
 
 // sortFilesByMtime sorts files by modification time (newest first).
@@ -864,8 +903,14 @@ func formatGrepResults(matches []GrepMatch, truncated bool) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s in %s\n", plural(len(matches), "match"), plural(len(groups), "file")))
 
-	for _, g := range groups {
-		sb.WriteString(fmt.Sprintf("\n%s (%s):\n", g.path, plural(len(g.matches), "match")))
+	bytesWritten := sb.Len()
+	bytesCapped := false
+
+	for gi, g := range groups {
+		// Build this file's block into a temporary buffer so we can measure
+		// it before committing to the main output.
+		var block strings.Builder
+		block.WriteString(fmt.Sprintf("\n%s (%s):\n", g.path, plural(len(g.matches), "match")))
 
 		display := g.matches
 		overflow := 0
@@ -876,18 +921,32 @@ func formatGrepResults(matches []GrepMatch, truncated bool) string {
 
 		for i, m := range display {
 			if i > 0 {
-				sb.WriteString("  …\n")
+				block.WriteString("  …\n")
 			}
-			sb.WriteString(m.Context)
-			sb.WriteString("\n")
+			block.WriteString(m.Context)
+			block.WriteString("\n")
 		}
 
 		if overflow > 0 {
-			sb.WriteString(fmt.Sprintf("\n  [+%d more — narrow your search]\n", overflow))
+			block.WriteString(fmt.Sprintf("\n  [+%d more — narrow your search]\n", overflow))
 		}
+
+		// Enforce the total byte budget.  Stop before writing this block if it
+		// would push us over; always write at least the first group so the
+		// caller gets something useful.
+		if gi > 0 && bytesWritten+block.Len() > maxOutputBytes {
+			remaining := len(groups) - gi
+			sb.WriteString(fmt.Sprintf("\n[output capped at 50KB — %s not shown; narrow your search]\n",
+				plural(remaining, "file")))
+			bytesCapped = true
+			break
+		}
+
+		sb.WriteString(block.String())
+		bytesWritten += block.Len()
 	}
 
-	if truncated {
+	if truncated && !bytesCapped {
 		sb.WriteString("\n[Results truncated at limit]")
 	}
 

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGrepTool_UsesFilePath(t *testing.T) {
@@ -641,5 +642,81 @@ func TestAutoEnrich_SingleMatch(t *testing.T) {
 	}
 	if contextLineCount2 > 2 {
 		t.Errorf("explicit ContextLines=1 should not auto-enrich; got %d context lines\noutput:\n%s", contextLineCount2, output2.Content)
+	}
+}
+
+// TestSortGrepMatchesByMtime verifies that matches from the most recently
+// modified file appear first in the output.
+func TestSortGrepMatchesByMtime(t *testing.T) {
+	if !ripgrepAvailable() {
+		t.Skip("ripgrep not available")
+	}
+
+	dir := t.TempDir()
+
+	// Write two files with a deliberate mtime gap so the ordering is stable.
+	older := filepath.Join(dir, "older.go")
+	newer := filepath.Join(dir, "newer.go")
+
+	token := "MTIME_SORT_TOKEN"
+	if err := os.WriteFile(older, []byte("package x\n// "+token+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Touch newer after a short sleep to guarantee a different mtime.
+	time.Sleep(20 * time.Millisecond)
+	if err := os.WriteFile(newer, []byte("package x\n// "+token+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewGrepTool(nil, DefaultOutputLimits())
+	args, _ := json.Marshal(GrepArgs{Pattern: token, Path: dir, ContextLines: 0})
+	output, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newerPos := strings.Index(output.Content, "newer.go")
+	olderPos := strings.Index(output.Content, "older.go")
+	if newerPos < 0 || olderPos < 0 {
+		t.Fatalf("expected both files in output:\n%s", output.Content)
+	}
+	if newerPos > olderPos {
+		t.Errorf("expected newer.go before older.go in output:\n%s", output.Content)
+	}
+}
+
+// TestFormatGrepResults_ByteCap verifies that output is capped at maxOutputBytes
+// and a descriptive note is appended.
+func TestFormatGrepResults_ByteCap(t *testing.T) {
+	// Each block needs to be large enough to push us over 50KB well within
+	// the 50-file set.  Use a ~1500-char context string (simulating many
+	// context lines) so the cap fires around file 35.
+	bigContext := strings.Repeat("> 1: "+strings.Repeat("x", 110)+"\n", 12) // ~1500 bytes/block
+
+	var matches []GrepMatch
+	for i := 0; i < 50; i++ {
+		matches = append(matches, GrepMatch{
+			FilePath:   fmt.Sprintf("/tmp/file%02d.go", i),
+			LineNumber: 1,
+			Match:      "x",
+			Context:    bigContext,
+		})
+	}
+
+	result := formatGrepResults(matches, false)
+
+	// Must contain the cap notice.
+	if !strings.Contains(result, "output capped at 50KB") {
+		t.Errorf("expected byte-cap notice in output (total output %d bytes):\n%.500s", len(result), result)
+	}
+
+	// Must not exceed two blocks past the limit.
+	if len(result) > maxOutputBytes+2*len(bigContext) {
+		t.Errorf("output far exceeds byte cap: got %d bytes", len(result))
+	}
+
+	// First file must always be present.
+	if !strings.Contains(result, "file00.go") {
+		t.Errorf("first file missing from capped output:\n%s", result)
 	}
 }


### PR DESCRIPTION
## What

Two improvements to the grep tool output, both observed while auditing codex/opencode/gemini/pi implementations:

### 1. mtime sort (from Codex + OpenCode)

Results are now ordered so the most recently modified file appears first. Both Codex (`--sortr=modified` on rg) and OpenCode (explicit post-sort) do this. For agentic coding it's the right default — the file you just edited is almost always the one that matters.

The Go fallback path already had `sortFilesByMtime`. This adds `sortGrepMatchesByMtime` for the ripgrep JSON path, which stats each unique file once and reorders the match groups by descending mtime.

### 2. 50KB byte cap (from Pi)

Pi caps total grep output at 50KB regardless of match count or per-line truncation. We already truncate individual lines to 120 chars and cap per-file display at 10 matches, but those protections don't help when there are many files each with moderate matches. Minified JS, generated protobufs, lock files — all can produce responses that are technically within per-file limits but enormous in aggregate.

`formatGrepResults` now builds each file block into a scratch buffer, measures it, and stops before writing any block that would push total output over 50KB. The first block is always written so the caller gets something useful. When the cap fires, a note is appended: `[output capped at 50KB — N files not shown; narrow your search]`.

## Tests

- `TestSortGrepMatchesByMtime` — creates two files with a deliberate mtime gap, verifies newer appears first
- `TestFormatGrepResults_ByteCap` — 50 files with large context blocks; verifies cap notice fires and output stays bounded
