### PR TITLE
fix: honor ChatGPT rate limit reset windows

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -768,6 +768,8 @@ type chatGPTRateLimitResponse struct {
 }
 
 // RateLimitError represents a rate limit error with retry information.
+const maxAutomaticRateLimitRetryAfter = 15 * time.Minute
+
 type RateLimitError struct {
 	Message       string
 	RetryAfter    time.Duration
@@ -780,14 +782,14 @@ func (e *RateLimitError) Error() string {
 	return e.Message
 }
 
-// IsLongWait returns true if the retry wait is too long for automatic retry.
+// IsLongWait returns true if the suggested retry wait is too long for automatic retry.
 func (e *RateLimitError) IsLongWait() bool {
-	return e.RetryAfter > 2*time.Minute
+	return e.RetryAfter > maxAutomaticRateLimitRetryAfter
 }
 
 // parseChatGPTRateLimitError parses a 429 response and returns a RateLimitError.
-// For short waits, the retry logic can use RetryAfter to wait and retry.
-// For long waits, it gives a clear message about when to try again.
+// For manageable waits, the retry logic can use RetryAfter to wait and retry.
+// For longer waits, it gives a clear message about when to try again.
 func parseChatGPTRateLimitError(body []byte, headers http.Header) error {
 	var resp chatGPTRateLimitResponse
 	if err := json.Unmarshal(body, &resp); err != nil {

--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -209,14 +209,9 @@ var retryAfterRegex = regexp.MustCompile(`(?i)retry[- ]?after[:\s]+(\d+)`)
 
 // calculateBackoff computes the wait duration for a retry attempt.
 func (r *RetryProvider) calculateBackoff(attempt int, err error) time.Duration {
-	// Check for RateLimitError with explicit RetryAfter
+	// Honor explicit provider-provided retry windows.
 	if rle, ok := err.(*RateLimitError); ok && rle.RetryAfter > 0 {
-		wait := rle.RetryAfter
-		// Cap at max backoff for automatic retries
-		if wait > r.config.MaxBackoff {
-			wait = r.config.MaxBackoff
-		}
-		return wait
+		return rle.RetryAfter
 	}
 
 	// Try to parse Retry-After from error message

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -1,0 +1,34 @@
+package llm
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimitErrorRetryWindow(t *testing.T) {
+	withinWindow := &RateLimitError{RetryAfter: maxAutomaticRateLimitRetryAfter - time.Second}
+	if withinWindow.IsLongWait() {
+		t.Fatalf("expected %s wait to be retryable", withinWindow.RetryAfter)
+	}
+	if !isRetryable(withinWindow) {
+		t.Fatalf("expected %s wait to be retryable", withinWindow.RetryAfter)
+	}
+
+	overWindow := &RateLimitError{RetryAfter: maxAutomaticRateLimitRetryAfter + time.Second}
+	if !overWindow.IsLongWait() {
+		t.Fatalf("expected %s wait to be treated as too long", overWindow.RetryAfter)
+	}
+	if isRetryable(overWindow) {
+		t.Fatalf("expected %s wait to skip automatic retry", overWindow.RetryAfter)
+	}
+}
+
+func TestRetryProviderCalculateBackoffHonorsRateLimitRetryAfter(t *testing.T) {
+	provider := &RetryProvider{config: DefaultRetryConfig()}
+	retryAfter := 10*time.Minute + 11*time.Second
+
+	got := provider.calculateBackoff(1, &RateLimitError{RetryAfter: retryAfter})
+	if got != retryAfter {
+		t.Fatalf("calculateBackoff() = %s, want %s", got, retryAfter)
+	}
+}


### PR DESCRIPTION
## What

- allow ChatGPT `RateLimitError` retries to wait for the provider's full reset window instead of capping them at the generic 30s backoff
- expand the automatic retry window for explicit ChatGPT rate limits to 15 minutes
- add retry tests covering the new retry window and backoff behavior

## Why

A live session failed with:

`ChatGPT usage limit reached (pro plan). Resets in 10m 11s ...`

The retry code treated waits over 2 minutes as non-retryable, and even retryable `RateLimitError` waits were capped to 30 seconds. That meant ChatGPT's explicit reset windows were not honored, so temporary usage caps surfaced as hard failures instead of waiting until the provider said it was safe to retry.

## How

- updated `internal/llm/chatgpt.go` so explicit ChatGPT rate-limit waits up to 15 minutes are considered safe for automatic retry
- updated `internal/llm/retry.go` so provider-supplied `RetryAfter` durations are used as-is for `RateLimitError`
- added focused unit coverage in `internal/llm/retry_test.go`
