### PR TITLE
fix: keep context meter live while sending

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -326,6 +326,22 @@ func (e *Engine) LastTotalTokens() int {
 	return v
 }
 
+// EstimateTokens returns the estimated input token count for the next API call
+// based on the current message list. It uses the most recent API usage as a
+// baseline when possible, then adds heuristic estimates for newly appended
+// messages.
+func (e *Engine) EstimateTokens(messages []Message) int {
+	e.callbackMu.RLock()
+	lastTotalTokens := e.lastTotalTokens
+	lastMessageCount := e.lastMessageCount
+	e.callbackMu.RUnlock()
+
+	if lastTotalTokens > 0 && lastMessageCount > 0 && lastMessageCount < len(messages) {
+		return lastTotalTokens + EstimateMessageTokens(messages[lastMessageCount:])
+	}
+	return EstimateMessageTokens(messages)
+}
+
 // SetCompactionCallback sets the callback for context compaction events.
 // Thread-safe: can be called while streaming is in progress.
 func (e *Engine) SetCompactionCallback(cb CompactionCallback) {
@@ -420,11 +436,7 @@ func (e *Engine) getCompactionCallback() CompactionCallback {
 // baseline — because the model's output gets echoed back as input on the
 // next turn — then adds heuristic estimates for messages appended since.
 func (e *Engine) estimatedTokens(messages []Message) int {
-	if e.lastTotalTokens > 0 && e.lastMessageCount > 0 && e.lastMessageCount < len(messages) {
-		return e.lastTotalTokens + EstimateMessageTokens(messages[e.lastMessageCount:])
-	}
-	// Fallback: pure heuristic estimate of all messages
-	return EstimateMessageTokens(messages)
+	return e.EstimateTokens(messages)
 }
 
 // nonSystemMessages returns all messages that are not system messages.

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -533,11 +533,11 @@ func (m *Model) renderStatusLine() string {
 	// Token usage counter (e.g., ~45K/136K) with optional cached segment
 	usagePart := ""
 	if m.engine != nil && m.engine.InputLimit() > 0 {
-		last := m.engine.LastTotalTokens()
+		contextTokens := m.engine.EstimateTokens(m.buildMessagesForContextEstimate())
 		limit := m.engine.InputLimit()
-		if last > 0 && limit > 0 {
+		if contextTokens > 0 && limit > 0 {
 			usagePart = fmt.Sprintf("~%s/%s",
-				llm.FormatTokenCount(last), llm.FormatTokenCount(limit))
+				llm.FormatTokenCount(contextTokens), llm.FormatTokenCount(limit))
 		}
 	}
 

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -197,6 +197,30 @@ func TestRenderStatusLine_UsesWholeSecondElapsedWhileStreaming(t *testing.T) {
 	}
 }
 
+func TestRenderStatusLine_UsesEstimatedContextBeforeUsageArrives(t *testing.T) {
+	m := newTestChatModel(false)
+	m.engine.SetContextTracking(200_000)
+	userText := strings.Repeat("architecture tradeoffs and implementation details ", 80)
+	m.messages = append(m.messages,
+		session.Message{
+			SessionID:   m.sess.ID,
+			Role:        llm.RoleUser,
+			TextContent: userText,
+			Parts:       []llm.Part{{Type: llm.PartText, Text: userText}},
+			CreatedAt:   time.Now(),
+			Sequence:    0,
+		},
+	)
+
+	line := ui.StripANSI(m.renderStatusLine())
+	if !strings.Contains(line, "/200K") {
+		t.Fatalf("expected estimated context usage in status line before usage event, got %q", line)
+	}
+	if strings.Contains(line, "~0K/") {
+		t.Fatalf("expected estimated context usage to stay above zero, got %q", line)
+	}
+}
+
 func TestRenderStatusLine_ShowsCachedUsageWhenPresent(t *testing.T) {
 	m := newTestChatModel(false)
 	m.stats.CachedInputTokens = 500_000

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -183,7 +183,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 		m.streamChan = adapter.Events()
 
 		// Build messages from conversation history
-		messages := m.buildMessages()
+		messages := m.buildMessagesForStream()
 
 		// Collect MCP tools if available and register them with the engine
 		var reqTools []llm.ToolSpec
@@ -332,7 +332,7 @@ func (m *Model) listenForStreamEventsSync() tea.Msg {
 	return streamEventMsg{event: event}
 }
 
-func (m *Model) buildMessages() []llm.Message {
+func (m *Model) buildMessages(includeInsights bool) []llm.Message {
 	m.messagesMu.Lock()
 	snapshot := make([]session.Message, len(m.messages))
 	copy(snapshot, m.messages)
@@ -357,23 +357,33 @@ func (m *Model) buildMessages() []llm.Message {
 		}
 	}
 
-	// Insights expansion: inject on the very first user turn of a new session.
-	// buildMessages is called once per stream start, so this fires exactly once.
-	// On subsequent turns userMsgCount > 1 and the block is skipped.
-	if userMsgCount == 1 {
-		userText := ""
-		for _, msg := range snapshot {
-			if msg.Role == llm.RoleUser {
-				userText = msg.TextContent
-				break
+	if includeInsights {
+		// Insights expansion: inject on the very first user turn of a new session.
+		// buildMessages is called once per stream start, so this fires exactly once.
+		// On subsequent turns userMsgCount > 1 and the block is skipped.
+		if userMsgCount == 1 {
+			userText := ""
+			for _, msg := range snapshot {
+				if msg.Role == llm.RoleUser {
+					userText = msg.TextContent
+					break
+				}
 			}
-		}
-		if expanded := m.insightsExpander.Expand(context.Background(), userText); expanded != "" {
-			messages = append(messages, llm.UserText(expanded))
+			if expanded := m.insightsExpander.Expand(context.Background(), userText); expanded != "" {
+				messages = append(messages, llm.UserText(expanded))
+			}
 		}
 	}
 
 	return messages
+}
+
+func (m *Model) buildMessagesForStream() []llm.Message {
+	return m.buildMessages(true)
+}
+
+func (m *Model) buildMessagesForContextEstimate() []llm.Message {
+	return m.buildMessages(false)
 }
 
 func (m *Model) tickEvery() tea.Cmd {


### PR DESCRIPTION
## What

- switch the chat footer context meter from `LastTotalTokens()` to an estimate based on the current transcript
- export `Engine.EstimateTokens()` so UI code can reuse the same baseline+delta logic as compaction tracking
- split chat message building into stream vs context-estimate paths so the footer can estimate context without running insights expansion on every render
- add a regression test covering the pre-usage window where the meter used to fall back to zero while a message was being posted

## Why

The footer is meant to show context fullness, but it was reading the most recent completed API usage snapshot instead. During a new send, that snapshot could be stale or zeroed, so the meter visibly dropped to `~0/...` even though the transcript had only grown.

Using the current transcript fixes the UX and matches what the meter is supposed to represent.
