### PR TITLE
fix: persist insights in resolved system prompt

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -19,7 +19,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/input"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
-	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/prompt"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
@@ -402,19 +401,6 @@ func runAsk(cmd *cobra.Command, args []string) error {
 
 	// Add new user message
 	messages = append(messages, llm.UserText(userPrompt))
-
-	// Insights expansion: on the first turn of a new (non-resumed) session,
-	// inject relevant behavioral guidelines. Gated by agent.yaml
-	// memory.insights_expansion (default: false).
-	if len(sessionMessages) == 0 && settings.InsightsExpansion {
-		if ms, msErr := openMemoryStore(); msErr == nil {
-			defer ms.Close() // defers to enclosing function — store stays open until ask returns
-			expander := memorydb.NewInsightsExpander(ms, settings.AgentName, settings.InsightsMaxTokens)
-			if expanded := expander.Expand(ctx, userPrompt); expanded != "" {
-				messages = append(messages, llm.UserText(expanded))
-			}
-		}
-	}
 
 	debugMode := askDebug
 	if sess != nil {

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -10,7 +10,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
-	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -357,16 +356,6 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 
 	// Create chat model
 	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, showStats, initialText, store, sess, useAltScreen, chatAutoSend, true, chatTextMode, agentName, chatYolo)
-
-	// Wire insight expansion (no-op when disabled or store unavailable).
-	if settings.InsightsExpansion {
-		if ms, msErr := openMemoryStore(); msErr == nil {
-			expander := memorydb.NewInsightsExpander(ms, agentName, settings.InsightsMaxTokens)
-			model.SetInsightsExpander(expander)
-			// Store is kept open for the session lifetime; closed when program exits.
-			defer ms.Close()
-		}
-	}
 
 	// Build program options
 	var opts []tea.ProgramOption

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,7 +17,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
-	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/serve"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
@@ -234,17 +233,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	forceExternalSearch := resolveForceExternalSearch(cfg, serveNativeSearch, serveNoNativeSearch)
 
-	// Build the insight expander (nil when disabled or store unavailable).
-	// Captured by the factory closure and shared across all runtimes.
-	var insightsExpander *memorydb.InsightsExpander
-	var insightsMemStore *memorydb.Store // kept for deferred Close
-	if settings.InsightsExpansion {
-		if ms, msErr := openMemoryStore(); msErr == nil {
-			insightsMemStore = ms
-			insightsExpander = memorydb.NewInsightsExpander(ms, agentName, settings.InsightsMaxTokens)
-		}
-	}
-
 	modelName := activeModel(cfg)
 	factory := func(ctx context.Context) (*serveRuntime, error) {
 		provider, err := llm.NewProvider(cfg)
@@ -280,7 +268,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 			debugRaw:            debugRaw,
 			defaultModel:        modelName,
 			store:               store,
-			insightsExpander:    insightsExpander,
 			toolsSetting:        settings.Tools,
 			mcpSetting:          settings.MCP,
 			agentName:           agentName,
@@ -310,7 +297,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		MCP:                    settings.MCP,
 		Agent:                  agentName,
 		Store:                  store,
-		InsightsExpander:       insightsExpander,
 		NewSession: func(ctx context.Context) (*serve.SessionRuntime, error) {
 			rt, err := factory(ctx)
 			if err != nil {
@@ -412,10 +398,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	<-ctx.Done()
-
-	if insightsMemStore != nil {
-		_ = insightsMemStore.Close()
-	}
 
 	if s != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
-	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
@@ -29,7 +28,6 @@ type serveRuntime struct {
 	toolMgr             *tools.ToolManager
 	mcpManager          *mcp.Manager
 	store               session.Store
-	insightsExpander    *memorydb.InsightsExpander
 	systemPrompt        string
 	history             []llm.Message
 	search              bool
@@ -380,15 +378,6 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	}
 	messages = append(messages, baseHistory...)
 	messages = append(messages, inputMessages...)
-
-	// Insights expansion: on the first turn of a stateful session, inject
-	// relevant behavioral guidelines. Requires memory.insights_expansion: true
-	// in agent.yaml (default: false).
-	if len(baseHistory) == 0 && stateful {
-		if expanded := rt.insightsExpander.Expand(ctx, lastUserText(inputMessages)); expanded != "" {
-			messages = append(messages, llm.UserText(expanded))
-		}
-	}
 
 	req.Messages = messages
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -268,8 +270,48 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 		s.InsightsExpansion = agent.Memory.InsightsExpansion
 		s.InsightsMaxTokens = agent.Memory.InsightsMaxTokens
 	}
+	s.SystemPrompt = injectInsightsMetadata(s.SystemPrompt, s.AgentName, s.InsightsExpansion, s.InsightsMaxTokens)
 
 	return s, nil
+}
+
+func injectInsightsMetadata(instructions, agentName string, enabled bool, maxTokens int) string {
+	if !enabled || strings.TrimSpace(agentName) == "" {
+		return instructions
+	}
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return instructions
+	}
+	defer store.Close()
+
+	expander := memorydb.NewInsightsExpander(store, agentName, maxTokens)
+	insights := strings.TrimSpace(expander.Expand(context.Background(), ""))
+	if insights == "" {
+		return instructions
+	}
+	if strings.TrimSpace(instructions) == "" {
+		return insights
+	}
+	return strings.TrimRight(instructions, "\n") + "\n\n" + insights
+}
+
+func splitTrailingInsightsBlock(instructions string) (head, insights string) {
+	idx := strings.LastIndex(instructions, "<insights>\n")
+	if idx == -1 {
+		return instructions, ""
+	}
+	candidate := instructions[idx:]
+	end := strings.LastIndex(candidate, "</insights>")
+	if end == -1 {
+		return instructions, ""
+	}
+	end += len("</insights>")
+	if strings.TrimSpace(candidate[end:]) != "" {
+		return instructions, ""
+	}
+	return strings.TrimRight(instructions[:idx], "\n"), candidate[:end]
 }
 
 func expandSystemPromptWithIncludes(prompt string, templateCtx agents.TemplateContext, baseDir string) (string, error) {
@@ -581,8 +623,15 @@ func InjectSkillsMetadata(instructions string, skillsSetup *skills.Setup) string
 	if skillsSetup == nil || !skillsSetup.HasSkillsXML() || skills.CheckAgentsMdForSkills() {
 		return instructions
 	}
-	if instructions != "" {
-		return instructions + "\n\n" + skillsSetup.XML
+
+	head, insights := splitTrailingInsightsBlock(instructions)
+	if strings.TrimSpace(head) != "" {
+		head += "\n\n" + skillsSetup.XML
+	} else {
+		head = skillsSetup.XML
 	}
-	return skillsSetup.XML
+	if insights != "" {
+		return head + "\n\n" + insights
+	}
+	return head
 }

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
 
@@ -80,6 +83,64 @@ func TestResolveSettings_AgentSystemPromptIncludeUsesAgentDir(t *testing.T) {
 
 	if settings.SystemPrompt != "X from agent dir Y" {
 		t.Fatalf("SystemPrompt = %q, want %q", settings.SystemPrompt, "X from agent dir Y")
+	}
+}
+
+func TestResolveSettings_AppendsInsightsToSystemPrompt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	t.Setenv("TERM_LLM_MEMORY_DB", dbPath)
+	oldMemoryDBPath := memoryDBPath
+	memoryDBPath = defaultMemoryDBPath
+	t.Cleanup(func() { memoryDBPath = oldMemoryDBPath })
+
+	store, err := memorydb.NewStore(memorydb.Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateInsight(context.Background(), &memorydb.Insight{
+		Agent:          "jarvis",
+		Content:        "Avoid filler.",
+		CompactContent: "Avoid filler.",
+		Category:       "communication-style",
+		Confidence:     0.9,
+	}); err != nil {
+		t.Fatalf("CreateInsight() error = %v", err)
+	}
+
+	agent := &agents.Agent{
+		Name:         "jarvis",
+		SystemPrompt: "Base prompt",
+		Memory: agents.MemoryConfig{
+			InsightsExpansion: true,
+			InsightsMaxTokens: 500,
+		},
+	}
+
+	settings, err := ResolveSettings(&config.Config{}, agent, CLIFlags{}, "", "", "", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+	if !strings.Contains(settings.SystemPrompt, "Base prompt") {
+		t.Fatalf("SystemPrompt missing base prompt: %q", settings.SystemPrompt)
+	}
+	if !strings.Contains(settings.SystemPrompt, "<insights>") {
+		t.Fatalf("SystemPrompt missing insights block: %q", settings.SystemPrompt)
+	}
+	if !strings.Contains(settings.SystemPrompt, "Avoid filler.") {
+		t.Fatalf("SystemPrompt missing insight content: %q", settings.SystemPrompt)
+	}
+}
+
+func TestInjectSkillsMetadata_KeepsInsightsAtTail(t *testing.T) {
+	instructions := "Base prompt\n\n<insights>\nBehavioral guidelines from past sessions:\n1. Avoid filler.\n</insights>"
+	skillsSetup := &skills.Setup{XML: "<available_skills>demo</available_skills>"}
+
+	got := InjectSkillsMetadata(instructions, skillsSetup)
+	want := "Base prompt\n\n<available_skills>demo</available_skills>\n\n<insights>\nBehavioral guidelines from past sessions:\n1. Avoid filler.\n</insights>"
+	if got != want {
+		t.Fatalf("InjectSkillsMetadata() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -172,8 +172,8 @@ type MCPConfig struct {
 
 // MemoryConfig holds memory-related settings for an agent.
 type MemoryConfig struct {
-	// InsightsExpansion enables injecting relevant behavioral insights at the
-	// start of each new session (first user turn). Default false.
+	// InsightsExpansion appends behavioral insights to the resolved system
+	// prompt for sessions started with this agent. Default false.
 	InsightsExpansion bool `yaml:"insights_expansion,omitempty"`
 	// InsightsMaxTokens caps the insight block token budget. Default: 500.
 	InsightsMaxTokens int `yaml:"insights_max_tokens,omitempty"`

--- a/internal/memory/expander.go
+++ b/internal/memory/expander.go
@@ -3,8 +3,9 @@ package memory
 import "context"
 
 // InsightsExpander wraps a Store and exposes a single Expand method for
-// injecting behavioral insights at conversation start. A nil *InsightsExpander
-// is always a safe no-op — callers never need to nil-check before calling.
+// appending behavioral insights to the resolved system prompt. A nil
+// *InsightsExpander is always a safe no-op — callers never need to nil-check
+// before calling.
 type InsightsExpander struct {
 	store     *Store
 	agent     string
@@ -24,14 +25,13 @@ func NewInsightsExpander(store *Store, agent string, maxTokens int) *InsightsExp
 	return &InsightsExpander{store: store, agent: agent, maxTokens: maxTokens}
 }
 
-// Expand searches the insight bank using userText as the query and returns
-// the formatted block ready to inject as a user message.
-// Returns "" when disabled, no matches, or on any error.
-func (e *InsightsExpander) Expand(ctx context.Context, userText string) string {
+// Expand returns the formatted insight block for the configured agent.
+// Returns "" when disabled, no insights exist, or on any error.
+func (e *InsightsExpander) Expand(ctx context.Context, _ string) string {
 	if e == nil || e.store == nil {
 		return ""
 	}
-	expanded, err := e.store.ExpandInsights(ctx, e.agent, userText, e.maxTokens)
+	expanded, err := e.store.ExpandInsights(ctx, e.agent, "", e.maxTokens)
 	if err != nil {
 		return ""
 	}

--- a/internal/serve/platform.go
+++ b/internal/serve/platform.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
-	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
@@ -37,11 +36,6 @@ type Settings struct {
 	MCP                 string
 	Agent               string
 	Store               session.Store
-	// InsightsExpander, when non-nil, injects relevant behavioral insights at
-	// the first user turn of each new session. Nil means disabled (default).
-	// Build with memory.NewInsightsExpander — enabled only when agent.yaml
-	// sets memory.insights_expansion: true.
-	InsightsExpander *memorydb.InsightsExpander
 	// NewSession creates a fresh runtime instance for a new conversation.
 	// Called once per platform session (for example, per Telegram chat session).
 	NewSession func(context.Context) (*SessionRuntime, error)

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -920,14 +920,6 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	messages = append(messages, sess.history...)
 	messages = append(messages, userMsg)
 
-	// Insights expansion: on the first turn of a new session, inject relevant
-	// behavioral guidelines. Requires memory.insights_expansion: true in agent.yaml.
-	if len(sess.history) == 0 {
-		if expanded := m.settings.InsightsExpander.Expand(ctx, userText); expanded != "" {
-			messages = append(messages, llm.UserText(expanded))
-		}
-	}
-
 	sessionID := ""
 	if sess.meta != nil {
 		sessionID = sess.meta.ID

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -19,7 +19,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/clipboard"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
-	memorydb "github.com/samsaffron/term-llm/internal/memory"
 
 	"github.com/samsaffron/term-llm/internal/mcp"
 	render "github.com/samsaffron/term-llm/internal/render/chat"
@@ -193,10 +192,6 @@ type Model struct {
 	textMode bool
 	// Expanded tool display (full commands/env)
 	toolsExpanded bool
-
-	// InsightsExpander, when non-nil, injects behavioral insights on the
-	// first user turn of a new session. Nil means disabled.
-	insightsExpander *memorydb.InsightsExpander
 
 	// Mouse layout tracking for textarea click-to-cursor support
 	textareaBoundsValid    bool
@@ -443,12 +438,6 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 
 // WantsReload reports whether the user requested a binary reload via /reload.
 func (m *Model) WantsReload() bool { return m.reloadRequested }
-
-// SetInsightsExpander wires up insight injection for the first user turn.
-// Call this after construction when agent.yaml has memory.insights_expansion: true.
-func (m *Model) SetInsightsExpander(expander *memorydb.InsightsExpander) {
-	m.insightsExpander = expander
-}
 
 // ReloadSessionID returns the session ID to resume after a reload, if any.
 func (m *Model) ReloadSessionID() string { return m.reloadSessionID }

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -332,7 +332,7 @@ func (m *Model) listenForStreamEventsSync() tea.Msg {
 	return streamEventMsg{event: event}
 }
 
-func (m *Model) buildMessages(includeInsights bool) []llm.Message {
+func (m *Model) buildMessages() []llm.Message {
 	m.messagesMu.Lock()
 	snapshot := make([]session.Message, len(m.messages))
 	copy(snapshot, m.messages)
@@ -349,41 +349,19 @@ func (m *Model) buildMessages(includeInsights bool) []llm.Message {
 	}
 
 	// Add conversation history - convert session messages to llm messages
-	userMsgCount := 0
 	for _, msg := range snapshot {
 		messages = append(messages, msg.ToLLMMessage())
-		if msg.Role == llm.RoleUser {
-			userMsgCount++
-		}
-	}
-
-	if includeInsights {
-		// Insights expansion: inject on the very first user turn of a new session.
-		// buildMessages is called once per stream start, so this fires exactly once.
-		// On subsequent turns userMsgCount > 1 and the block is skipped.
-		if userMsgCount == 1 {
-			userText := ""
-			for _, msg := range snapshot {
-				if msg.Role == llm.RoleUser {
-					userText = msg.TextContent
-					break
-				}
-			}
-			if expanded := m.insightsExpander.Expand(context.Background(), userText); expanded != "" {
-				messages = append(messages, llm.UserText(expanded))
-			}
-		}
 	}
 
 	return messages
 }
 
 func (m *Model) buildMessagesForStream() []llm.Message {
-	return m.buildMessages(true)
+	return m.buildMessages()
 }
 
 func (m *Model) buildMessagesForContextEstimate() []llm.Message {
-	return m.buildMessages(false)
+	return m.buildMessages()
 }
 
 func (m *Model) tickEvery() tea.Cmd {


### PR DESCRIPTION
## What

Moves insight memory from a synthetic first-turn user augmentation into the resolved system prompt.

- append the `<insights>` block during `ResolveSettings`
- persist the resolved system prompt so inspector/session history show the actual augmentation
- remove the separate runtime/user-message insight injection paths from ask/chat/serve/telegram
- keep insights at the tail of the system prompt even when `<available_skills>` metadata is injected
- add tests covering insight appending and skills ordering

## Why

The previous design sent insights over the wire but did not persist them in session history, so `ctrl-o` showed an incomplete transcript.

This makes the stored session match the actual prompt seen by the model and keeps the implementation simple now that the insight bank is small and always-on.

## Validation

- `go test ./...`
- `go build ./...`
