### PR TITLE
fix: make chat interjections render immediately

### DIFF
--- a/internal/llm/classify.go
+++ b/internal/llm/classify.go
@@ -69,6 +69,12 @@ type InterruptActivity struct {
 	ProseLen    int
 }
 
+// ClassifyInterruptImmediate applies zero-latency local heuristics for common
+// interrupt intents. It returns (action, true) when a heuristic matched.
+func ClassifyInterruptImmediate(msg string) (InterruptAction, bool) {
+	return classifyInterruptHeuristic(msg)
+}
+
 func classifyInterruptHeuristic(msg string) (InterruptAction, bool) {
 	normalized := strings.ToLower(strings.TrimSpace(msg))
 	if normalized == "" {

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -100,7 +100,9 @@ type Model struct {
 	mcpStr              string   // Original MCP setting (for session persistence)
 	pendingInterjection string   // Queued interjection text waiting to be injected
 	queuedInterjection  string   // Deferred follow-up to send after the current stream completes
-
+	interruptRequestSeq uint64   // Monotonic sequence for async interrupt classification
+	activeInterruptSeq  uint64   // Currently active async interrupt classification request
+	pendingInterruptUI  string   // UI state: "", "deciding", "queued", "interject"
 	// MCP (Model Context Protocol)
 	mcpManager *mcp.Manager
 	maxTurns   int
@@ -215,10 +217,15 @@ type (
 		sess     *session.Session
 		messages []session.Message
 	}
-	tickMsg             time.Time
-	streamRenderTickMsg struct{}
-	compactStartedMsg   struct{}
-	compactDoneMsg      struct {
+	tickMsg                time.Time
+	streamRenderTickMsg    struct{}
+	interruptClassifiedMsg struct {
+		RequestID uint64
+		Content   string
+		Action    llm.InterruptAction
+	}
+	compactStartedMsg struct{}
+	compactDoneMsg    struct {
 		result *llm.CompactionResult
 		err    error
 	}
@@ -620,6 +627,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// This tick exists to ensure View() runs again after the throttle window, so
 		// pending content can pass shouldThrottleSetContent().
 
+	case interruptClassifiedMsg:
+		return m.handleInterruptClassified(msg)
+
 	case compactDoneMsg:
 		m.streaming = false
 		m.phase = "Thinking"
@@ -770,7 +780,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if residual := m.engine.DrainInterjection(); residual != "" {
 					m.setTextareaValue(residual)
 				}
+				m.activeInterruptSeq = 0
 				m.pendingInterjection = "" // Clear pending indicator
+				m.pendingInterruptUI = ""
 
 				return m, nil
 			}
@@ -933,7 +945,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case ui.StreamEventInterjection:
 			// User interjected a message mid-stream (injected between tool turns).
+			m.activeInterruptSeq = 0
 			m.pendingInterjection = "" // Interjection was injected, clear pending indicator
+			m.pendingInterruptUI = ""
 			// Flush smooth buffer so any pending text appears before the interjection.
 			if m.smoothBuffer != nil {
 				remaining := m.smoothBuffer.FlushAll()
@@ -1067,8 +1081,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Send any queued follow-up immediately after the current stream completes.
 			if m.queuedInterjection != "" && m.autoSendQueue == nil {
 				next := m.queuedInterjection
+				m.activeInterruptSeq = 0
 				m.queuedInterjection = ""
 				m.pendingInterjection = ""
+				m.pendingInterruptUI = ""
 				m.setTextareaValue(next)
 				return m.sendMessage(next)
 			}
@@ -1113,7 +1129,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if residual := m.engine.DrainInterjection(); residual != "" {
 				m.setTextareaValue(residual)
 			}
-			m.pendingInterjection = "" // Clear pending indicator
+			if m.activeInterruptSeq == 0 {
+				m.pendingInterjection = "" // Clear pending indicator
+				m.pendingInterruptUI = ""
+			}
 		}
 
 		// Continue listening for more events unless we're done or got an error

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -317,7 +317,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 			// Drain any pending interjection (discard since we're quitting)
 			_ = m.engine.DrainInterjection()
+			m.activeInterruptSeq = 0
 			m.pendingInterjection = "" // Clear visual indicator
+			m.pendingInterruptUI = ""
 
 			return m, nil
 		}
@@ -352,7 +354,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if residual := m.engine.DrainInterjection(); residual != "" {
 				m.setTextareaValue(residual)
 			}
+			m.activeInterruptSeq = 0
 			m.pendingInterjection = "" // Clear visual indicator
+			m.pendingInterruptUI = ""
 
 			m.textarea.Focus()
 			return m, nil
@@ -457,37 +461,16 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			activity := llm.InterruptActivity{
-				CurrentTask: m.phase,
-				ProseLen:    m.currentResponse.Len(),
+			if action, ok := llm.ClassifyInterruptImmediate(content); ok {
+				m.applyInterruptAction(content, action)
+				return m, nil
 			}
-			if m.tracker != nil && m.tracker.HasPending() {
-				activity.ActiveTool = "tool"
+			if m.fastProvider == nil {
+				m.applyInterruptAction(content, llm.InterruptQueue)
+				return m, nil
 			}
 
-			action := llm.ClassifyInterrupt(context.Background(), m.fastProvider, content, activity)
-			switch action {
-			case llm.InterruptCancel:
-				m.pendingInterjection = ""
-				m.queuedInterjection = ""
-				m.setTextareaValue("")
-				m.phase = "Stopping..."
-				if m.streamCancelFunc != nil {
-					m.streamCancelFunc()
-				}
-			case llm.InterruptInterject:
-				// Queue interjection in the engine — it will be injected after the
-				// current turn's tool results, before the next LLM turn begins.
-				m.engine.Interject(content)
-				m.pendingInterjection = content
-				m.setTextareaValue("")
-			default:
-				// Defer as a queued follow-up to run immediately after current stream ends.
-				m.queuedInterjection = content
-				m.pendingInterjection = content
-				m.setTextareaValue("")
-			}
-			return m, nil
+			return m, m.queueInterruptClassification(content)
 		}
 		// Allow textarea to receive input
 		var cmd tea.Cmd
@@ -675,6 +658,82 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateTextareaHeight()
 		return m, cmd
 	}
+	return m, nil
+}
+
+func (m *Model) currentInterruptActivity() llm.InterruptActivity {
+	activity := llm.InterruptActivity{
+		CurrentTask: m.phase,
+		ProseLen:    m.currentResponse.Len(),
+	}
+	if m.tracker != nil && m.tracker.HasPending() {
+		activity.ActiveTool = "tool"
+	}
+	return activity
+}
+
+func (m *Model) queueInterruptClassification(content string) tea.Cmd {
+	m.interruptRequestSeq++
+	requestID := m.interruptRequestSeq
+	activity := m.currentInterruptActivity()
+
+	m.activeInterruptSeq = requestID
+	m.pendingInterjection = content
+	m.pendingInterruptUI = "deciding"
+	m.queuedInterjection = ""
+	m.setTextareaValue("")
+
+	provider := m.fastProvider
+	return func() tea.Msg {
+		action := llm.ClassifyInterrupt(context.Background(), provider, content, activity)
+		return interruptClassifiedMsg{
+			RequestID: requestID,
+			Content:   content,
+			Action:    action,
+		}
+	}
+}
+
+func (m *Model) applyInterruptAction(content string, action llm.InterruptAction) {
+	m.activeInterruptSeq = 0
+	m.pendingInterjection = content
+	m.setTextareaValue("")
+
+	switch action {
+	case llm.InterruptCancel:
+		m.pendingInterjection = ""
+		m.pendingInterruptUI = ""
+		m.queuedInterjection = ""
+		m.phase = "Stopping..."
+		if m.streamCancelFunc != nil {
+			m.streamCancelFunc()
+		}
+	case llm.InterruptInterject:
+		m.pendingInterruptUI = "interject"
+		m.queuedInterjection = ""
+		m.engine.Interject(content)
+	default:
+		m.pendingInterruptUI = "queued"
+		m.queuedInterjection = content
+	}
+}
+
+func (m *Model) handleInterruptClassified(msg interruptClassifiedMsg) (tea.Model, tea.Cmd) {
+	if msg.RequestID == 0 || msg.RequestID != m.activeInterruptSeq {
+		return m, nil
+	}
+	if !m.streaming {
+		m.activeInterruptSeq = 0
+		m.pendingInterjection = ""
+		m.pendingInterruptUI = ""
+		if strings.TrimSpace(m.textarea.Value()) == "" {
+			m.setTextareaValue(msg.Content)
+			return m.sendMessage(msg.Content)
+		}
+		return m, nil
+	}
+
+	m.applyInterruptAction(msg.Content, msg.Action)
 	return m, nil
 }
 

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
@@ -83,6 +84,41 @@ func TestHandleKeyMsg_StreamingEnterOnEmptyComposerShowsHint(t *testing.T) {
 	}
 	if m.phase != "Type to interject, or press Esc to cancel" {
 		t.Fatalf("expected empty enter hint phase, got %q", m.phase)
+	}
+}
+
+func TestHandleKeyMsg_StreamingAsyncClassificationFeelsImmediate(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.phase = "Thinking"
+	m.fastProvider = llm.NewMockProvider("fast").AddTextResponse("interject")
+	m.setTextareaValue("also check the schema")
+
+	_, cmd := m.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected async classification command")
+	}
+	if got := m.textarea.Value(); got != "" {
+		t.Fatalf("expected textarea to clear immediately, got %q", got)
+	}
+	if got := m.pendingInterjection; got != "also check the schema" {
+		t.Fatalf("expected pending interjection to render immediately, got %q", got)
+	}
+	if got := m.pendingInterruptUI; got != "deciding" {
+		t.Fatalf("expected deciding state immediately, got %q", got)
+	}
+
+	msg := cmd()
+	if _, ok := msg.(interruptClassifiedMsg); !ok {
+		t.Fatalf("expected interruptClassifiedMsg, got %T", msg)
+	}
+	_, _ = m.handleInterruptClassified(msg.(interruptClassifiedMsg))
+
+	if got := m.pendingInterruptUI; got != "interject" {
+		t.Fatalf("expected interject state after classification, got %q", got)
+	}
+	if got := m.engine.DrainInterjection(); got != "also check the schema" {
+		t.Fatalf("expected engine interjection to be queued, got %q", got)
 	}
 }
 

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -369,13 +369,22 @@ func (m *Model) renderInputInline() string {
 	if m.pendingInterjection != "" {
 		pendingStyle := lipgloss.NewStyle().Foreground(theme.Muted).Italic(true)
 		pendingText := m.pendingInterjection
+		label := "queued"
+		switch m.pendingInterruptUI {
+		case "deciding":
+			label = "deciding…"
+		case "interject":
+			label = "will incorporate"
+		case "queued":
+			label = "queued"
+		}
 		// Truncate long messages to fit the terminal width
 		maxLen := m.width - 20 // account for prefix/suffix
 		if maxLen > 0 && len(pendingText) > maxLen {
 			pendingText = pendingText[:maxLen] + "…"
 		}
 		b.WriteString("\n")
-		b.WriteString(pendingStyle.Render("  ⏳ " + pendingText + " (queued)"))
+		b.WriteString(pendingStyle.Render("  ⏳ " + pendingText + " (" + label + ")"))
 	}
 
 	// Show attached files if any


### PR DESCRIPTION
## What

Makes chat interjections feel immediate instead of waiting on the fast-model interrupt classifier before the UI updates.

- keeps zero-latency heuristic interrupts (`stop`, `cancel`, etc.) immediate
- moves non-heuristic interrupt classification onto an async Bubble Tea command
- clears the composer and shows the pending interjection instantly with a transient `deciding…` state
- updates the pending status to `will incorporate` or `queued` once classification returns
- preserves in-flight async interjections when the current stream finishes first, so they can roll straight into the next turn instead of disappearing
- adds a regression test covering the immediate UI update path

## Why

The current flow blocks `Enter` on a network-backed classification call. That means you type an interjection, hit enter, and then stare at stale UI for a beat before anything changes. Technically correct, ergonomically crap.

This keeps the model-based decision, but takes it off the critical path so the composer responds instantly and the chat feels smooth.

## Verification

- `go build ./...`
- `go test ./...`
