### PR TITLE
fix: invalidate chat history caches on message updates

### DIFF
--- a/internal/render/chat/renderer.go
+++ b/internal/render/chat/renderer.go
@@ -1,6 +1,8 @@
 package chat
 
 import (
+	"hash"
+	"hash/fnv"
 	"strconv"
 	"strings"
 	"sync"
@@ -346,6 +348,21 @@ func (r *Renderer) renderHistory(state RenderState) string {
 	return strings.Clone(b.String())
 }
 
+// MessageHistorySignature fingerprints rendered message history so cache validity
+// does not rely on message count alone.
+func MessageHistorySignature(messages []session.Message) uint64 {
+	h := fnv.New64a()
+	for i := range messages {
+		msg := &messages[i]
+		writeStringHash(h, strconv.FormatInt(msg.ID, 10))
+		writeStringHash(h, strconv.Itoa(msg.Sequence))
+		writeStringHash(h, string(msg.Role))
+		writeStringHash(h, msg.TextContent)
+		writeStringHash(h, messagePartsSignature(msg))
+	}
+	return h.Sum64()
+}
+
 // getOrRenderBlock gets a rendered block from cache or renders it.
 func (r *Renderer) getOrRenderBlock(msg *session.Message, index int, messages []session.Message) *MessageBlock {
 	// Check cache first
@@ -364,14 +381,68 @@ func (r *Renderer) getOrRenderBlock(msg *session.Message, index int, messages []
 }
 
 // blockCacheKey generates a cache key for a message.
-// Key is based on message ID and width only - NOT index.
-// This ensures cache hits even when new messages are added.
+// Key includes a content fingerprint, not just message ID, so stale blocks
+// cannot survive same-ID content changes.
 func (r *Renderer) blockCacheKey(msg *session.Message, index int) string {
 	expanded := "0"
 	if r.toolsExpanded {
 		expanded = "1"
 	}
-	return strconv.FormatInt(msg.ID, 10) + ":" + strconv.Itoa(r.width) + ":" + expanded
+	return strconv.FormatInt(msg.ID, 10) + ":" + strconv.Itoa(r.width) + ":" + expanded + ":" + messagePartsSignature(msg)
+}
+
+func messagePartsSignature(msg *session.Message) string {
+	h := fnv.New64a()
+	writeStringHash(h, msg.TextContent)
+	writeStringHash(h, strconv.Itoa(len(msg.Parts)))
+	for i := range msg.Parts {
+		part := &msg.Parts[i]
+		writeStringHash(h, string(part.Type))
+		writeStringHash(h, part.Text)
+		writeStringHash(h, part.ReasoningContent)
+		writeStringHash(h, part.ReasoningItemID)
+		writeStringHash(h, part.ReasoningEncryptedContent)
+		writeStringHash(h, part.ImagePath)
+		if part.ImageData != nil {
+			writeStringHash(h, part.ImageData.MediaType)
+			writeStringHash(h, part.ImageData.Base64)
+		}
+		if part.ToolCall != nil {
+			writeStringHash(h, part.ToolCall.ID)
+			writeStringHash(h, part.ToolCall.Name)
+			writeStringHash(h, string(part.ToolCall.Arguments))
+		}
+		if part.ToolResult != nil {
+			writeStringHash(h, part.ToolResult.ID)
+			writeStringHash(h, part.ToolResult.Name)
+			writeStringHash(h, part.ToolResult.Content)
+			writeStringHash(h, part.ToolResult.Display)
+			writeStringHash(h, strconv.FormatBool(part.ToolResult.IsError))
+			for _, diff := range part.ToolResult.Diffs {
+				writeStringHash(h, diff.File)
+				writeStringHash(h, diff.Old)
+				writeStringHash(h, diff.New)
+				writeStringHash(h, strconv.Itoa(diff.Line))
+			}
+			for _, image := range part.ToolResult.Images {
+				writeStringHash(h, image)
+			}
+			for _, contentPart := range part.ToolResult.ContentParts {
+				writeStringHash(h, string(contentPart.Type))
+				writeStringHash(h, contentPart.Text)
+				if contentPart.ImageData != nil {
+					writeStringHash(h, contentPart.ImageData.MediaType)
+					writeStringHash(h, contentPart.ImageData.Base64)
+				}
+			}
+		}
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+func writeStringHash(h hash.Hash64, s string) {
+	_, _ = h.Write([]byte(s))
+	_, _ = h.Write([]byte{0})
 }
 
 // renderMessageBlock renders a single message to a block.

--- a/internal/render/chat/renderer_test.go
+++ b/internal/render/chat/renderer_test.go
@@ -87,6 +87,42 @@ func TestRenderer_Render(t *testing.T) {
 	}
 }
 
+func TestRenderer_BlockCacheKeyChangesWhenMessageContentChanges(t *testing.T) {
+	renderer := NewRenderer(80, 24)
+
+	msg := &session.Message{
+		ID:          42,
+		Role:        llm.RoleAssistant,
+		TextContent: "old reply",
+		Parts:       []llm.Part{{Type: llm.PartText, Text: "old reply"}},
+	}
+	first := renderer.blockCacheKey(msg, 0)
+
+	msg.TextContent = "new reply"
+	msg.Parts = []llm.Part{{Type: llm.PartText, Text: "new reply"}}
+	second := renderer.blockCacheKey(msg, 0)
+
+	if first == second {
+		t.Fatalf("expected block cache key to change when message content changes")
+	}
+}
+
+func TestHistorySignatureChangesWhenSameCountMessagesChange(t *testing.T) {
+	messages := []session.Message{
+		{ID: 1, Role: llm.RoleUser, TextContent: "prompt", Parts: []llm.Part{{Type: llm.PartText, Text: "prompt"}}, Sequence: 0},
+		{ID: 2, Role: llm.RoleAssistant, TextContent: "old reply", Parts: []llm.Part{{Type: llm.PartText, Text: "old reply"}}, Sequence: 1},
+	}
+	first := MessageHistorySignature(messages)
+
+	messages[1].TextContent = "new reply"
+	messages[1].Parts = []llm.Part{{Type: llm.PartText, Text: "new reply"}}
+	second := MessageHistorySignature(messages)
+
+	if first == second {
+		t.Fatalf("expected history signature to change when same-count messages change")
+	}
+}
+
 func TestRenderer_CacheHit(t *testing.T) {
 	renderer := NewRenderer(80, 24)
 	renderer.SetMarkdownRenderer(simpleMarkdownRenderer)

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -162,6 +162,7 @@ type Model struct {
 		lastVPWidth         int    // Viewport width when view was cached
 		lastVPHeight        int    // Viewport height when view was cached
 		lastSetContentAt    time.Time
+		historySignature    uint64 // Content fingerprint for cached history
 		// completedStream holds rendered streaming content (diffs, tools) that should
 		// persist after streaming ends. Cleared when a new prompt is sent.
 		completedStream string
@@ -657,6 +658,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.messagesMu.Lock()
 		m.messages = newSessionMsgs
 		m.messagesMu.Unlock()
+		m.invalidateHistoryCache()
 
 		if m.store != nil {
 			if err := m.store.ReplaceMessages(context.Background(), m.sess.ID, newSessionMsgs); err != nil {
@@ -1038,6 +1040,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Reload from store to ensure consistency (callback saved messages incrementally)
 				if loadedMsgs, err := m.store.GetMessages(context.Background(), m.sess.ID, 0, 0); err == nil {
 					m.messages = loadedMsgs
+					m.invalidateHistoryCache()
 				}
 				_ = m.store.UpdateStatus(context.Background(), m.sess.ID, session.StatusComplete)
 			} else {
@@ -1053,6 +1056,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Sequence:    len(m.messages),
 					}
 					m.messages = append(m.messages, assistantMsg)
+					m.invalidateHistoryCache()
 				}
 			}
 
@@ -1150,6 +1154,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.sess != nil {
 			m.sess = msg.sess
 			m.messages = msg.messages
+			m.invalidateHistoryCache()
 			m.scrollOffset = 0
 			if m.store != nil {
 				_ = m.store.SetCurrent(context.Background(), m.sess.ID)

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -115,13 +115,15 @@ func (m *Model) viewAltScreen() string {
 	// Build scrollable content with caching to avoid re-rendering unchanged content
 
 	// Check if history cache is valid
+	historySig := render.MessageHistorySignature(m.messages)
 	historyValid := m.viewCache.historyValid &&
-		m.viewCache.historyMsgCount == len(m.messages) &&
+		m.viewCache.historySignature == historySig &&
 		m.viewCache.historyWidth == m.width &&
 		m.viewCache.historyScrollOffset == m.scrollOffset
 	if !historyValid {
 		m.viewCache.historyContent = m.renderHistory()
 		m.viewCache.historyMsgCount = len(m.messages)
+		m.viewCache.historySignature = historySig
 		m.viewCache.historyWidth = m.width
 		m.viewCache.historyScrollOffset = m.scrollOffset
 		m.viewCache.historyValid = true

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -130,6 +130,71 @@ func TestViewAltScreen_FirstRenderAnchorsToBottom(t *testing.T) {
 	}
 }
 
+func TestViewAltScreen_RefreshesWhenMessagesReplacedWithSameCount(t *testing.T) {
+	m := newTestChatModel(true)
+	sessionID := m.sess.ID
+
+	m.messages = []session.Message{
+		{
+			ID:          1,
+			SessionID:   sessionID,
+			Role:        llm.RoleUser,
+			TextContent: "first prompt",
+			Parts:       []llm.Part{{Type: llm.PartText, Text: "first prompt"}},
+			CreatedAt:   time.Now(),
+			Sequence:    0,
+		},
+		{
+			ID:          2,
+			SessionID:   sessionID,
+			Role:        llm.RoleAssistant,
+			TextContent: "old reply",
+			Parts:       []llm.Part{{Type: llm.PartText, Text: "old reply"}},
+			CreatedAt:   time.Now(),
+			Sequence:    1,
+		},
+	}
+
+	first := ui.StripANSI(m.View())
+	if !strings.Contains(first, "old reply") {
+		t.Fatalf("expected initial render to include old reply, got %q", first)
+	}
+
+	replacement := []session.Message{
+		{
+			ID:          1,
+			SessionID:   sessionID,
+			Role:        llm.RoleUser,
+			TextContent: "first prompt",
+			Parts:       []llm.Part{{Type: llm.PartText, Text: "first prompt"}},
+			CreatedAt:   time.Now(),
+			Sequence:    0,
+		},
+		{
+			ID:          2,
+			SessionID:   sessionID,
+			Role:        llm.RoleAssistant,
+			TextContent: "new final reply",
+			Parts:       []llm.Part{{Type: llm.PartText, Text: "new final reply"}},
+			CreatedAt:   time.Now(),
+			Sequence:    1,
+		},
+	}
+
+	_, _ = m.Update(sessionLoadedMsg{
+		sess:     &session.Session{ID: sessionID},
+		messages: replacement,
+	})
+
+	second := ui.StripANSI(m.View())
+	if strings.Contains(second, "old reply") {
+		t.Fatalf("expected stale history cache to be invalidated, got %q", second)
+	}
+	if !strings.Contains(second, "new final reply") {
+		t.Fatalf("expected refreshed render to include replacement message, got %q", second)
+	}
+}
+
 func TestStreamEventDiffFlushUsesOrderedCommandComposition(t *testing.T) {
 	provider := llm.NewMockProvider("mock")
 	engine := llm.NewEngine(provider, nil)

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -53,6 +53,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 		Sequence:    -1, // Auto-allocate sequence
 	}
 	m.messages = append(m.messages, *userMsg)
+	m.invalidateHistoryCache()
 	if m.store != nil {
 		// Save system message first if this is a new session with instructions
 		// Check if there's no existing system message in history
@@ -75,6 +76,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 			_ = m.store.AddMessage(context.Background(), m.sess.ID, sysMsg)
 			// Prepend to m.messages so we don't save it again on subsequent sends
 			m.messages = append([]session.Message{*sysMsg}, m.messages...)
+			m.invalidateHistoryCache()
 		}
 
 		_ = m.store.AddMessage(context.Background(), m.sess.ID, userMsg)
@@ -289,6 +291,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 			m.messagesMu.Lock()
 			m.messages = newSessionMsgs
 			m.messagesMu.Unlock()
+			m.invalidateHistoryCache()
 			if m.store != nil {
 				return m.store.ReplaceMessages(ctx, m.sess.ID, newSessionMsgs)
 			}
@@ -386,6 +389,14 @@ func (m *Model) invalidateViewCache() {
 	m.viewCache.lastTrackerVersion = 0
 	m.viewCache.lastWavePos = 0
 	m.viewCache.lastSetContentAt = time.Time{}
+	if m.chatRenderer != nil {
+		m.chatRenderer.InvalidateCache()
+	}
+	m.bumpContentVersion()
+}
+
+func (m *Model) invalidateHistoryCache() {
+	m.viewCache.historyValid = false
 	if m.chatRenderer != nil {
 		m.chatRenderer.InvalidateCache()
 	}


### PR DESCRIPTION
## What

Invalidate the alt-screen chat history caches whenever `m.messages` is appended, replaced, or reloaded.

Also harden the cache layer so this class of bug is less likely to come back:

- history cache validity now uses a message-content signature instead of message count alone
- rendered message block cache keys now include a message-content fingerprint instead of just message ID + width

Adds regression tests for:

- same-count message replacement in the chat TUI
- history signature changes on same-count content changes
- block cache keys changing when same-ID message content changes

## Why

The chat TUI cached rendered history using `historyValid`, message count, width, and scroll offset. That meant a same-count message replacement could slip through as a false cache hit.

When that happened, Bubble Tea kept reusing stale `historyContent` and cached message blocks until a resize invalidated width-dependent caches. That's why the "last message appears only after resizing" bug was possible.

This fixes the immediate mutation paths and also makes the cache keys themselves depend on message content, which is the more robust guardrail.

## Testing

- `go test ./internal/tui/chat/...`
- `go test ./internal/render/chat`
- `go test ./...`
- `go build ./...`
