### PR TITLE
fix: avoid unsupported ChatGPT codex-spark model

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -17,6 +17,7 @@ import (
 )
 
 const chatGPTDefaultModel = "gpt-5.3-codex"
+const chatGPTUnsupportedModel = "gpt-5.3-codex-spark"
 
 // chatGPTResponsesURL is the ChatGPT backend API endpoint for responses
 const chatGPTResponsesURL = "https://chatgpt.com/backend-api/codex/responses"
@@ -43,6 +44,7 @@ func NewChatGPTProvider(model string) (*ChatGPTProvider, error) {
 		model = chatGPTDefaultModel
 	}
 	actualModel, effort := parseModelEffort(model)
+	actualModel = normalizeChatGPTModel(actualModel)
 
 	// Try to load existing credentials
 	creds, err := credentials.GetChatGPTCredentials()
@@ -80,11 +82,22 @@ func NewChatGPTProviderWithCreds(creds *credentials.ChatGPTCredentials, model st
 		model = chatGPTDefaultModel
 	}
 	actualModel, effort := parseModelEffort(model)
+	actualModel = normalizeChatGPTModel(actualModel)
 	return &ChatGPTProvider{
 		creds:  creds,
 		model:  actualModel,
 		effort: effort,
 	}
+}
+
+// normalizeChatGPTModel maps models that the ChatGPT Codex backend rejects for
+// ChatGPT OAuth accounts back to the default supported model.
+func normalizeChatGPTModel(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" || model == chatGPTUnsupportedModel {
+		return chatGPTDefaultModel
+	}
+	return model
 }
 
 // promptForChatGPTAuth prompts the user to authenticate with ChatGPT
@@ -170,7 +183,7 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 
 		// Strip effort suffix from req.Model if present
 		reqModel, reqEffort := parseModelEffort(req.Model)
-		model := chooseModel(reqModel, p.model)
+		model := normalizeChatGPTModel(chooseModel(reqModel, p.model))
 		effort := p.effort
 		if effort == "" && reqEffort != "" {
 			effort = reqEffort
@@ -359,19 +372,20 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 				reasoningAcc.ensure(event.ItemID, event.OutputIndex)
 			case "response.reasoning_summary_text.delta":
 				reasoningAcc.appendSummary(event.ItemID, event.OutputIndex, event.Delta)
-		case "response.completed":
-			if event.Response.Usage.InputTokens > 0 ||
-				event.Response.Usage.OutputTokens > 0 ||
-				event.Response.Usage.InputTokensDetails.CachedTokens > 0 {
-				cached := event.Response.Usage.InputTokensDetails.CachedTokens
-				lastUsage = &Usage{
-					// ChatGPT input_tokens includes cached; subtract to get non-cached portion.
-					// CachedInputTokens + InputTokens = total context size.
-					InputTokens:       event.Response.Usage.InputTokens - cached,
-					OutputTokens:      event.Response.Usage.OutputTokens,
-					CachedInputTokens: cached,
+			case "response.completed":
+				if event.Response.Usage.InputTokens > 0 ||
+					event.Response.Usage.OutputTokens > 0 ||
+					event.Response.Usage.InputTokensDetails.CachedTokens > 0 {
+					cached := event.Response.Usage.InputTokensDetails.CachedTokens
+					lastUsage = &Usage{
+						// ChatGPT input_tokens includes cached; subtract to get non-cached portion.
+						// CachedInputTokens + InputTokens = total context size.
+						InputTokens:       event.Response.Usage.InputTokens - cached,
+						OutputTokens:      event.Response.Usage.OutputTokens,
+						CachedInputTokens: cached,
+					}
 				}
-			}			}
+			}
 		}
 		if err := scanner.Err(); err != nil {
 			return fmt.Errorf("stream read error: %w", err)

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -184,6 +184,102 @@ func TestBuildChatGPTInput_SkipsUnresolvedToolCalls(t *testing.T) {
 	}
 }
 
+func TestChatGPTProviderModelListExcludesUnsupportedCodexSpark(t *testing.T) {
+	for _, model := range ProviderModels["chatgpt"] {
+		if model == chatGPTUnsupportedModel {
+			t.Fatalf("chatgpt model list should not include unsupported model %q", chatGPTUnsupportedModel)
+		}
+	}
+}
+
+func TestChatGPTProviderNormalizesUnsupportedCodexSpark(t *testing.T) {
+	origClient := chatGPTHTTPClient
+	defer func() {
+		chatGPTHTTPClient = origClient
+	}()
+
+	captured := make(chan map[string]interface{}, 1)
+	errs := make(chan error, 1)
+	sse := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`,
+		`data: [DONE]`,
+	}, "\n")
+
+	chatGPTHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			defer req.Body.Close()
+
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				errs <- err
+				return nil, err
+			}
+
+			var payload map[string]interface{}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				errs <- err
+				return nil, err
+			}
+			captured <- payload
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(sse)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	provider := NewChatGPTProviderWithCreds(&credentials.ChatGPTCredentials{
+		AccessToken: "test-token",
+		AccountID:   "test-account",
+		ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+	}, chatGPTUnsupportedModel)
+
+	if provider.model != chatGPTDefaultModel {
+		t.Fatalf("provider model = %q, want %q", provider.model, chatGPTDefaultModel)
+	}
+
+	stream, err := provider.Stream(context.Background(), Request{
+		Model:    chatGPTUnsupportedModel,
+		Messages: []Message{UserText("hello")},
+	})
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("stream recv failed: %v", recvErr)
+		}
+		if event.Type == EventDone {
+			break
+		}
+	}
+
+	select {
+	case err := <-errs:
+		t.Fatalf("failed to capture request: %v", err)
+	default:
+	}
+
+	var payload map[string]interface{}
+	select {
+	case payload = <-captured:
+	default:
+		t.Fatal("expected captured request payload")
+	}
+
+	if got, _ := payload["model"].(string); got != chatGPTDefaultModel {
+		t.Fatalf("request model = %q, want %q", got, chatGPTDefaultModel)
+	}
+}
+
 func TestChatGPTStream_ReasoningSummaryByOutputIndex(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() {

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -37,7 +37,6 @@ var ProviderModels = map[string][]string{
 		// Uses ChatGPT backend API with native OAuth
 		"gpt-5.4",
 		"gpt-5.3-codex",
-		"gpt-5.3-codex-spark",
 		"gpt-5.2-codex",
 		"gpt-5.2",
 		"gpt-5.1-codex-max",


### PR DESCRIPTION
## What

- remove `gpt-5.3-codex-spark` from the curated ChatGPT model list
- normalize ChatGPT `codex-spark` selections back to `gpt-5.3-codex` before sending requests
- add tests covering the curated model list and request normalization

## Why

A live debug session showed ChatGPT OAuth requests failing with:

`The 'codex-spark' model is not supported when using Codex with a ChatGPT account.`

`term-llm` was still advertising `gpt-5.3-codex-spark` for the ChatGPT provider and would pass it through to the ChatGPT Codex backend unchanged, which produced a 400.

## How

- removed the unsupported model from `internal/llm/models.go` so it no longer appears in provider/model pickers and static listings
- added a small ChatGPT model normalizer in `internal/llm/chatgpt.go` so existing configs or request overrides that still reference `gpt-5.3-codex-spark` transparently fall back to the supported default model
- verified with `go build ./...` and `go test ./...`
