### PR TITLE
fix: preserve interjections instead of auto-sending

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1082,7 +1082,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Auto-save session
 			cmds = append(cmds, m.saveSessionCmd())
 
-			// Send any queued follow-up immediately after the current stream completes.
+			// Restore any queued follow-up to the composer when the current stream completes.
+			// Do not auto-send it: user-authored text should remain visible and editable.
 			if m.queuedInterjection != "" && m.autoSendQueue == nil {
 				next := m.queuedInterjection
 				m.activeInterruptSeq = 0
@@ -1090,7 +1091,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.pendingInterjection = ""
 				m.pendingInterruptUI = ""
 				m.setTextareaValue(next)
-				return m.sendMessage(next)
 			}
 
 			// In auto-send mode, check if there are more messages to send

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -728,7 +728,6 @@ func (m *Model) handleInterruptClassified(msg interruptClassifiedMsg) (tea.Model
 		m.pendingInterruptUI = ""
 		if strings.TrimSpace(m.textarea.Value()) == "" {
 			m.setTextareaValue(msg.Content)
-			return m.sendMessage(msg.Content)
 		}
 		return m, nil
 	}

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/ui"
 )
 
 func TestHandleKeyMsg_SessionListEnterResumesSession(t *testing.T) {
@@ -119,6 +120,68 @@ func TestHandleKeyMsg_StreamingAsyncClassificationFeelsImmediate(t *testing.T) {
 	}
 	if got := m.engine.DrainInterjection(); got != "also check the schema" {
 		t.Fatalf("expected engine interjection to be queued, got %q", got)
+	}
+}
+
+func TestHandleInterruptClassified_StreamAlreadyFinishedRestoresDraft(t *testing.T) {
+	m := newTestChatModel(false)
+	m.activeInterruptSeq = 7
+	m.pendingInterjection = "keep sleeping"
+	m.pendingInterruptUI = "deciding"
+
+	_, cmd := m.handleInterruptClassified(interruptClassifiedMsg{
+		RequestID: 7,
+		Content:   "keep sleeping",
+		Action:    llm.InterruptQueue,
+	})
+	if cmd != nil {
+		t.Fatal("expected no follow-up command when restoring draft")
+	}
+	if got := m.textarea.Value(); got != "keep sleeping" {
+		t.Fatalf("expected interjection text restored to composer, got %q", got)
+	}
+	if m.streaming {
+		t.Fatal("expected stream to remain finished")
+	}
+	if got := m.pendingInterjection; got != "" {
+		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
+	}
+	if got := m.pendingInterruptUI; got != "" {
+		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
+	}
+	if got := len(m.messages); got != 0 {
+		t.Fatalf("expected restored draft not to auto-send, got %d messages", got)
+	}
+}
+
+func TestStreamDone_QueuedInterjectionRestoresDraftWithoutSending(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.queuedInterjection = "queue this for later"
+	m.pendingInterjection = "queue this for later"
+	m.pendingInterruptUI = "queued"
+
+	_, cmd := m.Update(streamEventMsg{event: ui.DoneEvent(0)})
+	if cmd == nil {
+		t.Fatal("expected command batch from stream completion")
+	}
+	if m.streaming {
+		t.Fatal("expected streaming to stop after done event")
+	}
+	if got := m.textarea.Value(); got != "queue this for later" {
+		t.Fatalf("expected queued interjection restored to composer, got %q", got)
+	}
+	if got := m.queuedInterjection; got != "" {
+		t.Fatalf("expected queued interjection state cleared, got %q", got)
+	}
+	if got := m.pendingInterjection; got != "" {
+		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
+	}
+	if got := m.pendingInterruptUI; got != "" {
+		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
+	}
+	if got := len(m.messages); got != 0 {
+		t.Fatalf("expected queued interjection not to auto-send, got %d messages", got)
 	}
 }
 


### PR DESCRIPTION
## What

Preserve interjection text instead of auto-sending it when the current stream finishes or when async interrupt classification returns after the stream already ended.

Specifically:

- restore `queued` interjections back into the composer on `StreamEventDone`
- stop auto-sending queued follow-ups after the current run completes
- if interrupt classification resolves after streaming has already finished, restore the user text to the composer instead of sending it automatically
- add regression tests for both race paths

## Why

Typing during a long-running turn currently clears the composer immediately and moves the only visible copy of the text into the pending interjection UI. From there two bad paths existed:

1. `queue` would auto-send the text the instant the current stream finished
2. if classification returned after the stream had already ended, the text could vanish from the pending UI and get auto-sent or effectively feel eaten

That UX is terrible. User-authored text should remain visible and recoverable until it is either explicitly cancelled or deliberately sent by the user.

## Testing

- `go test ./internal/tui/chat/...`
- `go build ./...`
- `go test ./...`
