### PR TITLE
fix: preserve interrupted follow-ups across chat UIs

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -700,6 +700,10 @@ func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter
 				"call_id":   ev.ToolCallID,
 				"tool_name": ev.ToolName,
 			})
+		case llm.EventInterjection:
+			_ = writeSSEEvent(w, "response.interjection", map[string]any{
+				"text": ev.Text,
+			})
 		}
 		flusher.Flush()
 		return nil
@@ -930,6 +934,17 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 					"call_id":   ev.ToolCallID,
 					"tool_name": ev.ToolName,
 				},
+			})
+		case llm.EventInterjection:
+			writeErr = writeChatStreamChunk(w, map[string]any{
+				"id":      respID,
+				"object":  "chat.completion.chunk",
+				"created": created,
+				"model":   model,
+				"choices": []map[string]any{{
+					"index": 0,
+					"delta": map[string]any{"interjection": ev.Text},
+				}},
 			})
 		}
 		if writeErr != nil {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1129,6 +1129,27 @@ func TestEnsurePersistedSession_SkipsRestoreWhenHistoryExists(t *testing.T) {
 	}
 }
 
+type testServeDelayTool struct {
+	delay time.Duration
+}
+
+func (d *testServeDelayTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{Name: "slow_tool", Description: "delay for interjection test"}
+}
+
+func (d *testServeDelayTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	select {
+	case <-ctx.Done():
+		return llm.ToolOutput{}, ctx.Err()
+	case <-time.After(d.delay):
+	}
+	return llm.ToolOutput{Content: "slept"}, nil
+}
+
+func (d *testServeDelayTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 // newTestServeServer creates a serveServer with a mock factory for testing.
 // Each runtime gets its own mock provider with the given responses.
 func newTestServeServer(responses ...string) *serveServer {
@@ -1532,6 +1553,52 @@ func TestResponseToSessionMap_CleanedOnEviction(t *testing.T) {
 	// Mapping should be cleaned up
 	if _, ok := srv.responseToSession.Load(respID); ok {
 		t.Fatalf("responseToSession should be cleaned up after eviction")
+	}
+}
+
+func TestStreamResponses_EmitsInterjectionEvent(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	provider.AddToolCall("call_1", "slow_tool", map[string]any{})
+	provider.AddTextResponse("done")
+
+	registry := llm.NewToolRegistry()
+	registry.Register(&testServeDelayTool{delay: 20 * time.Millisecond})
+
+	engine := llm.NewEngine(provider, registry)
+	engine.Interject("keep sleeping")
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  "mock",
+		engine:       engine,
+		defaultModel: "mock-model",
+	}
+	rt.Touch()
+
+	mgr := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		return rt, nil
+	})
+	defer mgr.Close()
+
+	srv := &serveServer{sessionMgr: mgr}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses",
+		strings.NewReader(`{"input":"hi","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", "sess_interject")
+	rr := httptest.NewRecorder()
+
+	srv.handleResponses(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "event: response.interjection") {
+		t.Fatalf("expected response.interjection event in stream, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"text":"keep sleeping"`) {
+		t.Fatalf("expected interjection payload in stream, got:\n%s", body)
 	}
 }
 

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -1242,6 +1242,7 @@
         selectedModel: localStorage.getItem(STORAGE_KEYS.selectedModel) || '',
         streaming: false,
         queuedInterrupts: [],
+        pendingInterruptCommits: [],
         expectCanceledRun: false,
         abortController: null,
         autoScroll: true,
@@ -2462,6 +2463,36 @@
         state.queuedInterrupts.push({ prompt, messageId });
       };
 
+      const trackPendingInterruptCommit = (sessionId, prompt, messageId) => {
+        state.pendingInterruptCommits = state.pendingInterruptCommits.filter(entry => entry.messageId !== messageId);
+        state.pendingInterruptCommits.push({ sessionId, prompt, messageId });
+      };
+
+      const resolvePendingInterruptCommit = (sessionId, prompt) => {
+        const idx = state.pendingInterruptCommits.findIndex(entry => entry.sessionId === sessionId && entry.prompt === prompt);
+        if (idx < 0) return null;
+        const [entry] = state.pendingInterruptCommits.splice(idx, 1);
+        return entry;
+      };
+
+      const discardPendingInterruptCommit = (messageId) => {
+        if (!messageId) return;
+        state.pendingInterruptCommits = state.pendingInterruptCommits.filter(entry => entry.messageId !== messageId);
+      };
+
+      const requeueUncommittedInterrupts = (session) => {
+        if (!session?.id) return;
+        const remaining = [];
+        for (const entry of state.pendingInterruptCommits) {
+          if (entry.sessionId !== session.id) {
+            remaining.push(entry);
+            continue;
+          }
+          queueInterruptFollowUp(entry.prompt, entry.messageId);
+        }
+        state.pendingInterruptCommits = remaining;
+      };
+
       const setInterruptMessageState = (session, messageId, interruptState) => {
         if (!messageId) return;
         const normalized = sanitizeInterruptState(interruptState);
@@ -2505,6 +2536,12 @@
           : 'queue';
 
         setInterruptMessageState(session, messageId, action);
+
+        if (action === 'interject') {
+          trackPendingInterruptCommit(session.id, prompt, messageId);
+        } else {
+          discardPendingInterruptCommit(messageId);
+        }
 
         if (action === 'cancel' || action === 'queue') {
           queueInterruptFollowUp(prompt, messageId);
@@ -2574,6 +2611,7 @@
           try {
             await interruptActiveRun(session, prompt, pendingMessage.id);
           } catch (err) {
+            discardPendingInterruptCommit(pendingMessage.id);
             setInterruptMessageState(session, pendingMessage.id, 'error');
             const message = err?.message || 'Failed to interrupt active run.';
             addErrorMessage(message, session);
@@ -2839,6 +2877,15 @@
               return true;
             }
 
+            if (event === 'response.interjection') {
+              const interjectionText = String(payload.text || '').trim();
+              if (interjectionText) {
+                resolvePendingInterruptCommit(session.id, interjectionText);
+                saveSessions();
+              }
+              return true;
+            }
+
             if (event === 'response.completed') {
               const usage = payload?.response?.usage;
               closeToolGroup();
@@ -2920,6 +2967,8 @@
           state.abortController = null;
           setStreaming(false);
           refreshRelativeTimes();
+
+          requeueUncommittedInterrupts(session);
 
           if (state.queuedInterrupts.length > 0) {
             const queued = state.queuedInterrupts.shift();

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -778,10 +778,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				m.textarea.Focus()
 
-				// Recover pending interjection text into textarea on error
-				if residual := m.engine.DrainInterjection(); residual != "" {
-					m.setTextareaValue(residual)
-				}
+				// Recover pending interjection text into textarea on error.
+				// If the engine queue is already empty but we never rendered the
+				// interjection inline, fall back to the visible pending draft.
+				m.restorePendingInterjectionDraft()
 				m.activeInterruptSeq = 0
 				m.pendingInterjection = "" // Clear pending indicator
 				m.pendingInterruptUI = ""
@@ -1126,13 +1126,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Re-enable textarea
 			m.textarea.Focus()
 
-			// Recover any pending interjection that wasn't consumed (e.g.,
-			// when the LLM returned no tool calls so the between-turns
-			// injection point was never reached). Place the text back
-			// in the textarea so the user can send it as a follow-up.
-			if residual := m.engine.DrainInterjection(); residual != "" {
-				m.setTextareaValue(residual)
-			}
+			// Recover any pending interjection that wasn't consumed. If the
+			// engine queue is already empty but the UI still shows a pending
+			// interjection, restore that draft rather than letting it vanish.
+			m.restorePendingInterjectionDraft()
 			if m.activeInterruptSeq == 0 {
 				m.pendingInterjection = "" // Clear pending indicator
 				m.pendingInterruptUI = ""

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -736,6 +736,23 @@ func (m *Model) handleInterruptClassified(msg interruptClassifiedMsg) (tea.Model
 	return m, nil
 }
 
+func (m *Model) restorePendingInterjectionDraft() {
+	if strings.TrimSpace(m.textarea.Value()) != "" {
+		return
+	}
+	if residual := m.engine.DrainInterjection(); residual != "" {
+		m.setTextareaValue(residual)
+		return
+	}
+	if m.queuedInterjection != "" {
+		m.setTextareaValue(m.queuedInterjection)
+		return
+	}
+	if m.pendingInterjection != "" && (m.pendingInterruptUI == "interject" || m.pendingInterruptUI == "deciding") {
+		m.setTextareaValue(m.pendingInterjection)
+	}
+}
+
 func (m *Model) handleSlashCommand(input string) (tea.Model, tea.Cmd) {
 	return m.ExecuteCommand(input)
 }

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -182,6 +183,54 @@ func TestStreamDone_QueuedInterjectionRestoresDraftWithoutSending(t *testing.T) 
 	}
 	if got := len(m.messages); got != 0 {
 		t.Fatalf("expected queued interjection not to auto-send, got %d messages", got)
+	}
+}
+
+func TestStreamDone_PendingInterjectRestoresDraftWithoutEngineResidual(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.pendingInterjection = "keep sleeping"
+	m.pendingInterruptUI = "interject"
+
+	_, cmd := m.Update(streamEventMsg{event: ui.DoneEvent(0)})
+	if cmd == nil {
+		t.Fatal("expected command batch from stream completion")
+	}
+	if m.streaming {
+		t.Fatal("expected streaming to stop after done event")
+	}
+	if got := m.textarea.Value(); got != "keep sleeping" {
+		t.Fatalf("expected pending interjection restored to composer, got %q", got)
+	}
+	if got := m.pendingInterjection; got != "" {
+		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
+	}
+	if got := m.pendingInterruptUI; got != "" {
+		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
+	}
+}
+
+func TestStreamError_PendingInterjectRestoresDraftWithoutEngineResidual(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.pendingInterjection = "keep sleeping"
+	m.pendingInterruptUI = "interject"
+
+	_, cmd := m.Update(streamEventMsg{event: ui.ErrorEvent(context.Canceled)})
+	if cmd != nil {
+		t.Fatal("expected no follow-up command on error")
+	}
+	if m.streaming {
+		t.Fatal("expected streaming to stop after error")
+	}
+	if got := m.textarea.Value(); got != "keep sleeping" {
+		t.Fatalf("expected pending interjection restored to composer, got %q", got)
+	}
+	if got := m.pendingInterjection; got != "" {
+		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
+	}
+	if got := m.pendingInterruptUI; got != "" {
+		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What

Fix follow-up message loss when a user interjects during an active run and the current run finishes before that interjection is durably committed.

This patches both chat surfaces:

- chat web UI
- chat TUI

For web:

- emit an explicit `response.interjection` SSE event when the engine actually injects the interjection
- keep `interject` messages in a pending/uncommitted state until that event arrives
- if the run ends without a commit event, automatically carry the same user message forward as the next turn instead of letting it disappear

For TUI:

- restore pending interjection text back into the composer on stream completion and stream error when no committed inline interjection was rendered
- prefer actual engine residuals first, then queued follow-ups, then the visible pending interjection draft

Also adds regression tests for:

- streamed responses emitting `response.interjection`
- TUI restoring pending interjection drafts on done/error when the engine queue is already empty

## Why

The bug was a race between:

1. interrupt classification deciding `interject`
2. the UI clearing the composer and showing a pending state
3. the active run finishing before the interjection was visibly committed

In that window, the message could vanish from the UI even though the user had already sent it.

The new invariant is simple:

- either the interjection is actually committed and shown inline
- or the exact text is restored/carried forward as the next user message

No silent loss.

## Validation

- `go test ./cmd/... ./internal/llm/... ./internal/tui/chat/...`
- `go build ./...`
