### PR TITLE
fix: rebuild recent memory as current state

### DIFF
--- a/cmd/memory_freshen.go
+++ b/cmd/memory_freshen.go
@@ -174,6 +174,10 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	updatedRecent, err = fitUpdatedRecentWithinBudget(ctx, engine, reqModel, updatedRecent, memoryUpdateRecentTargetTokens, targetChars, highWaterChars)
+	if err != nil {
+		return err
+	}
 
 	if memoryDryRun {
 		fmt.Print(updatedRecent)
@@ -206,24 +210,6 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("update last update-recent timestamp: %w", err)
 	}
 
-	if len([]byte(updatedRecent)) <= highWaterChars {
-		return nil
-	}
-
-	// recent.md has grown past the high water mark (+20% of target); rebuild from fragments.
-	promoteProvider, err := llm.NewProvider(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: promote after update-recent failed: %v\n", err)
-		return nil
-	}
-	promoteEngine := newEngine(promoteProvider, cfg)
-	if _, err := runMemoryPromoteFlow(ctx, cfg, promoteEngine, store, memoryPromoteOptions{
-		Agent:          agentName,
-		RecentMaxBytes: targetChars,
-		QuietNothing:   true,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: promote after update-recent failed: %v\n", err)
-	}
 	return nil
 }
 
@@ -312,21 +298,99 @@ func runMemoryUpdateRecentRequest(ctx context.Context, engine *llm.Engine, model
 	return strings.TrimSpace(b.String()), nil
 }
 
+func runMemoryCompactRecentRequest(ctx context.Context, engine *llm.Engine, model, candidateRecent string, targetTokens, targetChars int) (string, error) {
+	req := llm.Request{
+		Model: strings.TrimSpace(model),
+		Messages: []llm.Message{
+			llm.SystemText(memoryCompactRecentSystemPrompt(targetTokens, targetChars)),
+			llm.UserText(memoryCompactRecentUserPrompt(candidateRecent)),
+		},
+		MaxTurns: 1,
+		DebugRaw: debugRaw,
+	}
+
+	stream, err := engine.Stream(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	var b strings.Builder
+	for {
+		ev, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		switch ev.Type {
+		case llm.EventTextDelta:
+			b.WriteString(ev.Text)
+		case llm.EventError:
+			if ev.Err != nil {
+				return "", ev.Err
+			}
+		}
+	}
+
+	return strings.TrimSpace(b.String()), nil
+}
+
+func fitUpdatedRecentWithinBudget(ctx context.Context, engine *llm.Engine, model, updatedRecent string, targetTokens, targetChars, highWaterChars int) (string, error) {
+	if len([]byte(updatedRecent)) <= highWaterChars {
+		return updatedRecent, nil
+	}
+
+	compacted, err := runMemoryCompactRecentRequest(ctx, engine, model, updatedRecent, targetTokens, targetChars)
+	if err != nil {
+		return "", err
+	}
+	if len([]byte(compacted)) <= highWaterChars {
+		return compacted, nil
+	}
+	return truncatePromotedRecent(compacted, targetChars), nil
+}
+
 func memoryUpdateRecentSystemPrompt(targetTokens, targetChars int) string {
 	return fmt.Sprintf(`You are a memory curator. You maintain a concise recent memory file for an AI assistant named Jarvis.
 
 Given RECENT SESSION SNIPPETS and the CURRENT RECENT MEMORY, output the complete updated memory file integrating the new activity.
 
+The file is a compact current-state working memory, not a changelog.
+
 Rules:
 - Target total output: ~%d tokens (~%d characters). Treat this as a soft ceiling on the whole document.
-- If today's date section already exists, add bullet points to it; otherwise prepend a new ## YYYY-MM-DD section.
+- Use this structure when relevant: ## Current state, then compact ### sections such as Deployed / configured, Active work, Open issues / quirks, Recent completed work, Temporary notes.
+- Prefer latest truth over historical sequence.
+- Replace superseded facts instead of keeping old and new versions.
+- Drop resolved or stale items unless they still affect current behaviour over the next few days.
+- Keep durable long-term facts out unless they are actively relevant right now.
 - Be extremely terse: facts only, no prose, no filler.
-- If the existing content is already near the target size, compress or drop low-value older entries to make room for new ones.
+- Output only the content, no code fences, no commentary.`, targetTokens, targetChars)
+}
+
+func memoryCompactRecentSystemPrompt(targetTokens, targetChars int) string {
+	return fmt.Sprintf(`You are compacting a recent memory file for Jarvis.
+
+Given a candidate recent.md that is too large, rewrite it into a smaller current-state working memory file.
+
+Rules:
+- Target total output: ~%d tokens (~%d characters). Treat this as a hard target.
+- Preserve the newest and most actionable facts.
+- Prefer latest truth over history; replace superseded facts.
+- Drop resolved, duplicated, stale, or low-value detail aggressively.
+- Keep the file as compact current-state memory, not a dated log or archive.
+- Use short headings and bullets only when they earn their keep.
 - Output only the content, no code fences, no commentary.`, targetTokens, targetChars)
 }
 
 func memoryUpdateRecentUserPrompt(sessionSnippets, existingRecent string) string {
 	return fmt.Sprintf("RECENT SESSION SNIPPETS:\n\n%s\n\n===\n\nCURRENT RECENT MEMORY:\n\n%s", sessionSnippets, existingRecent)
+}
+
+func memoryCompactRecentUserPrompt(candidateRecent string) string {
+	return fmt.Sprintf("CANDIDATE RECENT MEMORY TO COMPACT:\n\n%s", candidateRecent)
 }
 
 func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agentName string, current *session.Session) ([]memoryUpdateRecentSession, error) {
@@ -395,7 +459,6 @@ func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agen
 
 	return sessions, nil
 }
-
 func formatUpdateRecentSessionBlock(sess memoryUpdateRecentSession, messages []session.Message) string {
 	lines := make([]string, 0, len(messages))
 	for _, msg := range messages {

--- a/cmd/memory_freshen_test.go
+++ b/cmd/memory_freshen_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,9 +94,9 @@ func TestUpdateRecentOffsetMetaKey(t *testing.T) {
 	}
 }
 
-// -- system prompt --
+// -- system prompts --
 
-func TestMemoryUpdateRecentSystemPrompt_ContainsTokenCount(t *testing.T) {
+func TestMemoryUpdateRecentSystemPrompt_ContainsCurrentStateGuidance(t *testing.T) {
 	prompt := memoryUpdateRecentSystemPrompt(4000, 16000)
 	if !contains(prompt, "4000") {
 		t.Error("prompt should mention target token count 4000")
@@ -103,8 +104,27 @@ func TestMemoryUpdateRecentSystemPrompt_ContainsTokenCount(t *testing.T) {
 	if !contains(prompt, "16000") {
 		t.Error("prompt should mention target char count 16000")
 	}
-	if contains(prompt, "markdown") {
-		t.Error("prompt should not mention markdown")
+	if !contains(prompt, "current-state working memory") {
+		t.Error("prompt should describe recent.md as current-state working memory")
+	}
+	if !contains(prompt, "Replace superseded facts") {
+		t.Error("prompt should instruct replacement of superseded facts")
+	}
+	if contains(prompt, "today's date section") {
+		t.Error("prompt should no longer instruct dated append behaviour")
+	}
+}
+
+func TestMemoryCompactRecentSystemPrompt_ContainsAggressiveCompactionGuidance(t *testing.T) {
+	prompt := memoryCompactRecentSystemPrompt(4000, 16000)
+	if !contains(prompt, "hard target") {
+		t.Error("compact prompt should use a hard target")
+	}
+	if !contains(prompt, "Drop resolved, duplicated, stale") {
+		t.Error("compact prompt should drop stale detail aggressively")
+	}
+	if !contains(prompt, "not a dated log or archive") {
+		t.Error("compact prompt should reject dated log behaviour")
 	}
 }
 
@@ -124,6 +144,16 @@ func TestMemoryUpdateRecentUserPrompt(t *testing.T) {
 	}
 }
 
+func TestMemoryCompactRecentUserPrompt(t *testing.T) {
+	prompt := memoryCompactRecentUserPrompt("oversized memory")
+	if !contains(prompt, "CANDIDATE RECENT MEMORY TO COMPACT") {
+		t.Error("missing compact label")
+	}
+	if !contains(prompt, "oversized memory") {
+		t.Error("missing candidate memory content")
+	}
+}
+
 // -- high water mark calculation --
 
 func TestHighWaterMarkCalculation(t *testing.T) {
@@ -139,6 +169,17 @@ func TestHighWaterMarkCalculation(t *testing.T) {
 	}
 	if highWater <= targetChars {
 		t.Error("high water mark must be above target")
+	}
+}
+
+func TestFitUpdatedRecentWithinBudget_ReturnsUnchangedWhenUnderHighWater(t *testing.T) {
+	current := strings.Repeat("x", 100)
+	got, err := fitUpdatedRecentWithinBudget(context.Background(), nil, "", current, 4000, 16000, 19200)
+	if err != nil {
+		t.Fatalf("fitUpdatedRecentWithinBudget: %v", err)
+	}
+	if got != current {
+		t.Fatalf("got %q, want unchanged content", got)
 	}
 }
 


### PR DESCRIPTION
## What

Reworks `memory update-recent` so `recent.md` is rewritten as compact current-state working memory instead of a dated changelog.

Also replaces the high-water fallback: when the first-pass update result is too large, it now runs a dedicated recent-memory compaction pass on the candidate `recent.md` itself rather than rebuilding from changed fragments.

## Why

The old prompt biased toward dated append behavior (`add bullet points to today's date section`) and only applied compression pressure once the file was already large. That made `recent.md` drift toward release notes instead of active working memory.

The old oversize fallback was also the wrong source of truth. `update-recent` runs every 10 minutes, while session mining/promote can lag behind it. Rebuilding oversized `recent.md` from changed fragments could therefore miss fresh session-derived facts that had not yet been mined into fragments.

This change keeps the fresh `update-recent` output as the source of truth, then compacts *that* result when needed.

## Changes

- change `update-recent` prompt to:
  - describe `recent.md` as current-state working memory
  - prefer latest truth over historical sequence
  - replace superseded facts
  - drop stale/resolved items
  - avoid keeping durable long-term facts unless actively relevant
- remove the dated append instruction
- add a dedicated `runMemoryCompactRecentRequest(...)` second pass for oversized recent-memory output
- stop auto-falling back to fragment-based `promote` on high-water overflow
- add tests covering the new prompt/compaction behavior

## Validation

- `gofmt -w cmd/memory_freshen.go cmd/memory_freshen_test.go`
- `go test ./cmd/... ./internal/...`
