### PR TITLE
feat: add resumable ask_user flow to web UI

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -562,10 +562,10 @@ func (s *serveServer) Start() error {
 	}
 
 	mux.HandleFunc("/images/", s.auth(s.cors(s.handleImage)))
+	mux.HandleFunc("/v1/sessions/", s.auth(s.cors(s.handleSessionByID)))
 
 	if s.store != nil {
 		mux.HandleFunc("/v1/sessions", s.auth(s.cors(s.handleSessions)))
-		mux.HandleFunc("/v1/sessions/", s.auth(s.cors(s.handleSessionByID)))
 	}
 
 	if s.cfg.ui {

--- a/cmd/serve_ask_user.go
+++ b/cmd/serve_ask_user.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+var (
+	errServeAskUserNotPending = errors.New("no pending ask_user request")
+	errServeAskUserAnswered   = errors.New("ask_user request already answered")
+	errServeAskUserCancelled  = errors.New("cancelled by user")
+)
+
+type serveAskUserPrompt struct {
+	CallID    string                  `json:"call_id"`
+	Questions []tools.AskUserQuestion `json:"questions"`
+	CreatedAt int64                   `json:"created_at"`
+}
+
+type serveAskUserSubmission struct {
+	Answers []tools.AskUserAnswer
+	Err     error
+}
+
+type servePendingAskUser struct {
+	CallID    string
+	Questions []tools.AskUserQuestion
+	CreatedAt time.Time
+	responseC chan serveAskUserSubmission
+	responded bool
+}
+
+func cloneAskUserQuestions(questions []tools.AskUserQuestion) []tools.AskUserQuestion {
+	if len(questions) == 0 {
+		return nil
+	}
+	cloned := make([]tools.AskUserQuestion, len(questions))
+	for i, q := range questions {
+		cloned[i] = q
+		if len(q.Options) > 0 {
+			cloned[i].Options = append([]tools.AskUserOption(nil), q.Options...)
+		}
+	}
+	return cloned
+}
+
+func (p *servePendingAskUser) snapshot() serveAskUserPrompt {
+	return serveAskUserPrompt{
+		CallID:    p.CallID,
+		Questions: cloneAskUserQuestions(p.Questions),
+		CreatedAt: p.CreatedAt.UnixMilli(),
+	}
+}
+
+func (rt *serveRuntime) prepareAskUser(callID string, questions []tools.AskUserQuestion) *servePendingAskUser {
+	rt.askUserMu.Lock()
+	defer rt.askUserMu.Unlock()
+	if rt.pendingAskUsers == nil {
+		rt.pendingAskUsers = make(map[string]*servePendingAskUser)
+	}
+	pending := rt.pendingAskUsers[callID]
+	if pending == nil {
+		pending = &servePendingAskUser{
+			CallID:    callID,
+			CreatedAt: time.Now(),
+			responseC: make(chan serveAskUserSubmission, 1),
+		}
+		rt.pendingAskUsers[callID] = pending
+	}
+	pending.Questions = cloneAskUserQuestions(questions)
+	return pending
+}
+
+func (rt *serveRuntime) prepareAskUserFromToolArgs(callID string, raw json.RawMessage) (serveAskUserPrompt, error) {
+	if callID == "" {
+		return serveAskUserPrompt{}, fmt.Errorf("ask_user missing tool call id")
+	}
+	var args tools.AskUserArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return serveAskUserPrompt{}, fmt.Errorf("parse ask_user args: %w", err)
+	}
+	if len(args.Questions) == 0 {
+		return serveAskUserPrompt{}, fmt.Errorf("ask_user requires at least one question")
+	}
+	return rt.prepareAskUser(callID, args.Questions).snapshot(), nil
+}
+
+func (rt *serveRuntime) awaitAskUser(ctx context.Context, questions []tools.AskUserQuestion) ([]tools.AskUserAnswer, error) {
+	callID := llm.CallIDFromContext(ctx)
+	if callID == "" {
+		return nil, fmt.Errorf("ask_user missing tool call id")
+	}
+	pending := rt.prepareAskUser(callID, questions)
+	defer rt.removePendingAskUser(callID, pending)
+
+	select {
+	case submission := <-pending.responseC:
+		return submission.Answers, submission.Err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (rt *serveRuntime) removePendingAskUser(callID string, pending *servePendingAskUser) {
+	rt.askUserMu.Lock()
+	defer rt.askUserMu.Unlock()
+	if current := rt.pendingAskUsers[callID]; current == pending {
+		delete(rt.pendingAskUsers, callID)
+	}
+}
+
+func (rt *serveRuntime) clearPendingAskUser(callID string) {
+	rt.askUserMu.Lock()
+	defer rt.askUserMu.Unlock()
+	delete(rt.pendingAskUsers, callID)
+}
+
+func (rt *serveRuntime) submitAskUser(callID string, answers []tools.AskUserAnswer, cancelled bool) ([]tools.AskUserAnswer, error) {
+	rt.askUserMu.Lock()
+	pending := rt.pendingAskUsers[callID]
+	if pending == nil {
+		rt.askUserMu.Unlock()
+		return nil, errServeAskUserNotPending
+	}
+	questions := cloneAskUserQuestions(pending.Questions)
+	rt.askUserMu.Unlock()
+
+	submission := serveAskUserSubmission{}
+	var normalized []tools.AskUserAnswer
+	if cancelled {
+		submission.Err = errServeAskUserCancelled
+	} else {
+		var err error
+		normalized, err = tools.NormalizeAskUserAnswers(questions, answers)
+		if err != nil {
+			return nil, err
+		}
+		submission.Answers = normalized
+	}
+
+	rt.askUserMu.Lock()
+	defer rt.askUserMu.Unlock()
+	pending = rt.pendingAskUsers[callID]
+	if pending == nil {
+		return nil, errServeAskUserNotPending
+	}
+	if pending.responded {
+		return nil, errServeAskUserAnswered
+	}
+	pending.responded = true
+	select {
+	case pending.responseC <- submission:
+		return normalized, nil
+	default:
+		return nil, errServeAskUserAnswered
+	}
+}
+
+func (rt *serveRuntime) pendingAskUserPrompts() []serveAskUserPrompt {
+	rt.askUserMu.Lock()
+	defer rt.askUserMu.Unlock()
+	if len(rt.pendingAskUsers) == 0 {
+		return nil
+	}
+	prompts := make([]serveAskUserPrompt, 0, len(rt.pendingAskUsers))
+	for _, pending := range rt.pendingAskUsers {
+		if pending == nil {
+			continue
+		}
+		prompts = append(prompts, pending.snapshot())
+	}
+	slices.SortFunc(prompts, func(a, b serveAskUserPrompt) int {
+		switch {
+		case a.CreatedAt < b.CreatedAt:
+			return -1
+		case a.CreatedAt > b.CreatedAt:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return prompts
+}
+
+func (rt *serveRuntime) clearPendingAskUsers() {
+	rt.askUserMu.Lock()
+	defer rt.askUserMu.Unlock()
+	rt.pendingAskUsers = nil
+}

--- a/cmd/serve_ask_user_handler.go
+++ b/cmd/serve_ask_user_handler.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+type sessionAskUserRequest struct {
+	CallID    string                `json:"call_id"`
+	Answers   []tools.AskUserAnswer `json:"answers,omitempty"`
+	Cancelled bool                  `json:"cancelled,omitempty"`
+}
+
+func (s *serveServer) handleSessionAskUser(w http.ResponseWriter, r *http.Request, sessionID string) {
+	var req sessionAskUserRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	callID := strings.TrimSpace(req.CallID)
+	if callID == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "call_id is required")
+		return
+	}
+
+	rt, ok := s.sessionMgr.Get(sessionID)
+	if !ok {
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
+		return
+	}
+
+	normalized, err := rt.submitAskUser(callID, req.Answers, req.Cancelled)
+	if err != nil {
+		switch {
+		case errors.Is(err, errServeAskUserNotPending), errors.Is(err, errServeAskUserAnswered):
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
+		default:
+			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		}
+		return
+	}
+
+	resp := map[string]any{"status": "ok"}
+	if !req.Cancelled {
+		resp["answers"] = normalized
+		resp["summary"] = tools.AskUserAnswerSummary(normalized)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "net/http"
+
+func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request, sessionID string) {
+	resp := map[string]any{
+		"active_run": false,
+	}
+
+	if s.sessionMgr != nil {
+		if rt, ok := s.sessionMgr.Get(sessionID); ok && rt != nil {
+			activeRun := rt.hasActiveRun()
+			resp["active_run"] = activeRun
+			if prompts := rt.pendingAskUserPrompts(); len(prompts) > 0 {
+				resp["pending_ask_users"] = prompts
+				resp["pending_ask_user"] = prompts[0]
+			}
+			if !activeRun {
+				if lastErr := rt.consumeLastUIRunError(); lastErr != "" {
+					resp["last_error"] = lastErr
+				}
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/serveui"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
 )
 
 func (s *serveServer) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -161,6 +162,30 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if suffix == "ask_user" {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
+			return
+		}
+		s.handleSessionAskUser(w, r, sessionID)
+		return
+	}
+
+	if suffix == "state" {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		s.handleSessionState(w, r, sessionID)
+		return
+	}
+
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
 		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
@@ -169,6 +194,10 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 
 	if suffix != "messages" {
 		http.NotFound(w, r)
+		return
+	}
+	if s.store == nil {
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session history is unavailable")
 		return
 	}
 
@@ -334,7 +363,7 @@ func (s *serveServer) cors(next http.HandlerFunc) http.HandlerFunc {
 				w.Header().Add("Vary", "Origin")
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, X-Term-LLM-UI")
 			w.Header().Set("Access-Control-Expose-Headers", "x-session-id")
 		}
 
@@ -545,7 +574,11 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Stream {
-		s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID)
+		if isServeUIRequest(r) && stateful {
+			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID)
+		} else {
+			s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID)
+		}
 		return
 	}
 
@@ -676,12 +709,21 @@ func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter
 			}
 			outputIndex++
 		case llm.EventToolExecStart:
+			if ev.ToolName == tools.AskUserToolName {
+				if prompt, err := runtime.prepareAskUserFromToolArgs(ev.ToolCallID, ev.ToolArgs); err == nil {
+					_ = writeSSEEvent(w, "response.ask_user.prompt", prompt)
+				}
+			}
 			_ = writeSSEEvent(w, "response.tool_exec.start", map[string]any{
-				"call_id":   ev.ToolCallID,
-				"tool_name": ev.ToolName,
-				"tool_info": ev.ToolInfo,
+				"call_id":        ev.ToolCallID,
+				"tool_name":      ev.ToolName,
+				"tool_info":      ev.ToolInfo,
+				"tool_arguments": string(ev.ToolArgs),
 			})
 		case llm.EventToolExecEnd:
+			if ev.ToolName == tools.AskUserToolName {
+				runtime.clearPendingAskUser(ev.ToolCallID)
+			}
 			payload := map[string]any{
 				"call_id":   ev.ToolCallID,
 				"tool_name": ev.ToolName,

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -22,6 +22,8 @@ type serveRuntime struct {
 	mu                  sync.Mutex
 	interruptMu         sync.Mutex
 	responseMu          sync.Mutex // guards lastResponseID and responseIDs
+	askUserMu           sync.Mutex
+	uiStateMu           sync.Mutex
 	provider            llm.Provider
 	providerKey         string
 	engine              *llm.Engine
@@ -45,6 +47,8 @@ type serveRuntime struct {
 	lastResponseID      string
 	responseIDs         []string
 	cumulativeUsage     llm.Usage
+	pendingAskUsers     map[string]*servePendingAskUser
+	lastUIRunError      string
 }
 
 type runtimeInterruptState struct {
@@ -76,6 +80,7 @@ func (rt *serveRuntime) Close() {
 		rt.activeInterrupt.cancel()
 	}
 	rt.interruptMu.Unlock()
+	rt.clearPendingAskUsers()
 	if rt.mcpManager != nil {
 		rt.mcpManager.StopAll()
 		rt.mcpManager = nil
@@ -360,6 +365,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
+	runCtx = tools.ContextWithAskUserUIFunc(runCtx, rt.awaitAskUser)
 
 	intState := &runtimeInterruptState{
 		cancel:      runCancel,
@@ -382,19 +388,33 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	req.Messages = messages
 
 	var produced []llm.Message
+	persistProducedSnapshot := func(persistCtx context.Context) {
+		snapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+len(produced))
+		snapshot = append(snapshot, baseHistory...)
+		snapshot = append(snapshot, inputMessages...)
+		snapshot = append(snapshot, produced...)
+		if stateful {
+			rt.history = snapshot
+		}
+		if persisted {
+			rt.persistSnapshot(persistCtx, req.SessionID, snapshot)
+		}
+	}
 	// ResponseCompletedCallback receives the assistant message (with tool call parts)
 	// immediately after streaming, BEFORE tool execution. Without this, tool calls
 	// are missing from persisted sessions because TurnCompletedCallback only receives
 	// tool results.
-	rt.engine.SetResponseCompletedCallback(func(_ context.Context, _ int, assistantMsg llm.Message, _ llm.TurnMetrics) error {
+	rt.engine.SetResponseCompletedCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message, _ llm.TurnMetrics) error {
 		produced = append(produced, assistantMsg)
+		persistProducedSnapshot(cbCtx)
 		return nil
 	})
 	defer rt.engine.SetResponseCompletedCallback(nil)
 	// TurnCompletedCallback receives tool results after execution, or the final
 	// assistant message when no tools are used (ResponseCompletedCallback never fires).
-	rt.engine.SetTurnCompletedCallback(func(_ context.Context, _ int, msgs []llm.Message, _ llm.TurnMetrics) error {
+	rt.engine.SetTurnCompletedCallback(func(cbCtx context.Context, _ int, msgs []llm.Message, _ llm.TurnMetrics) error {
 		produced = append(produced, msgs...)
+		persistProducedSnapshot(cbCtx)
 		return nil
 	})
 	defer rt.engine.SetTurnCompletedCallback(nil)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1212,6 +1212,186 @@ func doResponsesWithHeader(t *testing.T, srv *serveServer, bodyJSON, sessionID s
 	return rr.Code, result
 }
 
+// waitForServeCondition polls until fn returns true or timeout elapses.
+func waitForServeCondition(t *testing.T, timeout time.Duration, fn func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}
+
+func TestHandleResponses_UIAskUserResumeSurvivesDisconnect(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	provider := llm.NewMockProvider("mock")
+	provider.AddToolCall("call_ask_1", tools.AskUserToolName, map[string]any{
+		"questions": []map[string]any{{
+			"header":   "Theme",
+			"question": "Pick a theme",
+			"options": []map[string]any{
+				{"label": "Dark", "description": "Use dark mode"},
+				{"label": "Light", "description": "Use light mode"},
+			},
+		}},
+	})
+	provider.AddTextResponse("All set.")
+
+	engine := llm.NewEngine(provider, nil)
+	engine.RegisterTool(tools.NewAskUserTool())
+
+	rt := &serveRuntime{
+		provider:     provider,
+		engine:       engine,
+		store:        store,
+		defaultModel: "mock-model",
+	}
+	rt.Touch()
+
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return rt, nil
+	})
+	defer mgr.Close()
+
+	srv := &serveServer{sessionMgr: mgr, store: store}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := `{"stream":true,"input":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", "resume-session")
+	req.Header.Set("X-Term-LLM-UI", "1")
+	rr := httptest.NewRecorder()
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		srv.handleResponses(rr, req)
+	}()
+
+	waitForServeCondition(t, time.Second, func() bool {
+		return len(rt.pendingAskUserPrompts()) == 1
+	}, "pending ask_user prompt")
+
+	stateReq := httptest.NewRequest(http.MethodGet, "/v1/sessions/resume-session/state", nil)
+	stateRR := httptest.NewRecorder()
+	srv.handleSessionByID(stateRR, stateReq)
+	if stateRR.Code != http.StatusOK {
+		t.Fatalf("state status = %d, want 200", stateRR.Code)
+	}
+	var stateBody struct {
+		ActiveRun      bool                `json:"active_run"`
+		PendingAskUser *serveAskUserPrompt `json:"pending_ask_user"`
+	}
+	if err := json.Unmarshal(stateRR.Body.Bytes(), &stateBody); err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	if !stateBody.ActiveRun {
+		t.Fatal("expected active_run=true while ask_user is pending")
+	}
+	if stateBody.PendingAskUser == nil || stateBody.PendingAskUser.CallID != "call_ask_1" {
+		t.Fatalf("unexpected pending ask_user state: %#v", stateBody.PendingAskUser)
+	}
+
+	waitForServeCondition(t, time.Second, func() bool {
+		msgs, err := store.GetMessages(context.Background(), "resume-session", 0, 0)
+		if err != nil || len(msgs) < 2 {
+			return false
+		}
+		for _, msg := range msgs {
+			if msg.Role != llm.RoleAssistant {
+				continue
+			}
+			for _, part := range msg.Parts {
+				if part.Type == llm.PartToolCall && part.ToolCall != nil && part.ToolCall.Name == tools.AskUserToolName {
+					return true
+				}
+			}
+		}
+		return false
+	}, "persisted ask_user tool call snapshot")
+
+	cancel()
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for streaming request to detach")
+	}
+
+	if !rt.hasActiveRun() {
+		t.Fatal("expected runtime to remain active after client disconnect")
+	}
+
+	submitBody := `{"call_id":"call_ask_1","answers":[{"question_index":0,"header":"Theme","selected":"Dark","is_custom":false}]}`
+	submitReq := httptest.NewRequest(http.MethodPost, "/v1/sessions/resume-session/ask_user", strings.NewReader(submitBody))
+	submitReq.Header.Set("Content-Type", "application/json")
+	submitRR := httptest.NewRecorder()
+	srv.handleSessionByID(submitRR, submitReq)
+	if submitRR.Code != http.StatusOK {
+		t.Fatalf("submit status = %d, body=%s", submitRR.Code, submitRR.Body.String())
+	}
+
+	waitForServeCondition(t, time.Second, func() bool {
+		if rt.hasActiveRun() {
+			return false
+		}
+		msgs, err := store.GetMessages(context.Background(), "resume-session", 0, 0)
+		if err != nil {
+			return false
+		}
+		for _, msg := range msgs {
+			if msg.Role == llm.RoleAssistant && strings.Contains(msg.TextContent, "All set.") {
+				return true
+			}
+		}
+		return false
+	}, "completed resumed ask_user run")
+}
+
+func TestHandleSessionState_ConsumesDeferredUIRunError(t *testing.T) {
+	rt := &serveRuntime{}
+	rt.setLastUIRunError("resume failed")
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return rt, nil
+	})
+	defer mgr.Close()
+	mgr.mu.Lock()
+	mgr.sessions["sess-state"] = rt
+	mgr.mu.Unlock()
+
+	srv := &serveServer{sessionMgr: mgr}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-state/state", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first state status = %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "resume failed") {
+		t.Fatalf("expected first state response to include deferred error, got %s", rr.Body.String())
+	}
+
+	rr2 := httptest.NewRecorder()
+	srv.handleSessionByID(rr2, req)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second state status = %d", rr2.Code)
+	}
+	if strings.Contains(rr2.Body.String(), "resume failed") {
+		t.Fatalf("expected deferred error to be consumed, got %s", rr2.Body.String())
+	}
+}
+
 func TestHandleResponses_ReturnsStableResponseID(t *testing.T) {
 	srv := newTestServeServer("hello")
 	defer srv.sessionMgr.Close()
@@ -1510,6 +1690,168 @@ func TestStreamResponses_IncludesResponseIDAndSessionUsage(t *testing.T) {
 	}
 	if _, ok := sessionUsage["input_tokens"]; !ok {
 		t.Fatalf("session_usage missing input_tokens")
+	}
+}
+
+func TestStreamResponses_AskUserRoundTrip(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	provider.AddToolCall("call-ask", tools.AskUserToolName, map[string]any{
+		"questions": []map[string]any{{
+			"header":   "Color",
+			"question": "Pick a color",
+			"options": []map[string]any{
+				{"label": "Red", "description": "Warm"},
+				{"label": "Blue", "description": "Cool"},
+			},
+		}},
+	})
+	provider.AddTextResponse("Thanks for answering")
+
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		engine.RegisterTool(tools.NewAskUserTool())
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+
+	mgr := newServeSessionManager(time.Minute, 10, factory)
+	defer mgr.Close()
+	srv := &serveServer{sessionMgr: mgr}
+	mgr.onEvict = func(rt *serveRuntime) {
+		for _, rid := range rt.getResponseIDs() {
+			srv.responseToSession.Delete(rid)
+		}
+	}
+
+	sessionID := "sess-ask-user"
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses",
+		strings.NewReader(`{"input":"hi","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", sessionID)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		srv.handleResponses(rr, req)
+		close(done)
+	}()
+
+	var runtime *serveRuntime
+	pendingReady := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rt, ok := mgr.Get(sessionID)
+		if ok {
+			runtime = rt
+			rt.askUserMu.Lock()
+			_, pendingReady = rt.pendingAskUsers["call-ask"]
+			rt.askUserMu.Unlock()
+			if pendingReady {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if runtime == nil || !pendingReady {
+		t.Fatal("timed out waiting for pending ask_user prompt")
+	}
+
+	submitReq := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sessionID+"/ask_user",
+		strings.NewReader(`{"call_id":"call-ask","answers":[{"selected":"Blue","is_custom":false}]}`))
+	submitReq.Header.Set("Content-Type", "application/json")
+	submitRR := httptest.NewRecorder()
+	srv.handleSessionByID(submitRR, submitReq)
+	if submitRR.Code != http.StatusOK {
+		t.Fatalf("ask_user submit status = %d, body = %s", submitRR.Code, submitRR.Body.String())
+	}
+
+	var submitBody struct {
+		Summary string                `json:"summary"`
+		Answers []tools.AskUserAnswer `json:"answers"`
+	}
+	if err := json.Unmarshal(submitRR.Body.Bytes(), &submitBody); err != nil {
+		t.Fatalf("decode ask_user submit response: %v", err)
+	}
+	if submitBody.Summary != "Color: Blue" {
+		t.Fatalf("summary = %q, want %q", submitBody.Summary, "Color: Blue")
+	}
+	if len(submitBody.Answers) != 1 || submitBody.Answers[0].Selected != "Blue" {
+		t.Fatalf("answers = %#v", submitBody.Answers)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for streaming response to finish")
+	}
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200", rr.Code)
+	}
+
+	var sawPrompt bool
+	var sawCompleted bool
+	scanner := bufio.NewScanner(rr.Body)
+	var currentEvent string
+	var promptData serveAskUserPrompt
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event: ") {
+			currentEvent = strings.TrimPrefix(line, "event: ")
+			continue
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		switch currentEvent {
+		case "response.ask_user.prompt":
+			sawPrompt = true
+			if err := json.Unmarshal([]byte(data), &promptData); err != nil {
+				t.Fatalf("decode ask_user prompt: %v", err)
+			}
+		case "response.completed":
+			if data != "[DONE]" {
+				sawCompleted = true
+			}
+		}
+	}
+	if !sawPrompt {
+		t.Fatal("response.ask_user.prompt event not found")
+	}
+	if promptData.CallID != "call-ask" || len(promptData.Questions) != 1 || promptData.Questions[0].Header != "Color" {
+		t.Fatalf("prompt data = %#v", promptData)
+	}
+	if !sawCompleted {
+		t.Fatal("response.completed event not found")
+	}
+	if len(provider.Requests) != 2 {
+		t.Fatalf("provider request count = %d, want 2", len(provider.Requests))
+	}
+
+	var toolResult *tools.AskUserResult
+	for _, msg := range provider.Requests[1].Messages {
+		for _, part := range msg.Parts {
+			if part.Type != llm.PartToolResult || part.ToolResult == nil || part.ToolResult.Name != tools.AskUserToolName {
+				continue
+			}
+			var parsed tools.AskUserResult
+			if err := json.Unmarshal([]byte(part.ToolResult.Content), &parsed); err != nil {
+				t.Fatalf("decode tool result content: %v", err)
+			}
+			toolResult = &parsed
+		}
+	}
+	if toolResult == nil {
+		t.Fatal("second provider request missing ask_user tool result")
+	}
+	if len(toolResult.Answers) != 1 || toolResult.Answers[0].Selected != "Blue" {
+		t.Fatalf("tool result answers = %#v", toolResult.Answers)
 	}
 }
 

--- a/cmd/serve_ui_state.go
+++ b/cmd/serve_ui_state.go
@@ -1,0 +1,27 @@
+package cmd
+
+func (rt *serveRuntime) hasActiveRun() bool {
+	rt.interruptMu.Lock()
+	defer rt.interruptMu.Unlock()
+	return rt.activeInterrupt != nil
+}
+
+func (rt *serveRuntime) clearLastUIRunError() {
+	rt.uiStateMu.Lock()
+	defer rt.uiStateMu.Unlock()
+	rt.lastUIRunError = ""
+}
+
+func (rt *serveRuntime) setLastUIRunError(message string) {
+	rt.uiStateMu.Lock()
+	defer rt.uiStateMu.Unlock()
+	rt.lastUIRunError = message
+}
+
+func (rt *serveRuntime) consumeLastUIRunError() string {
+	rt.uiStateMu.Lock()
+	defer rt.uiStateMu.Unlock()
+	message := rt.lastUIRunError
+	rt.lastUIRunError = ""
+	return message
+}

--- a/cmd/serve_ui_stream.go
+++ b/cmd/serve_ui_stream.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+type serveUIResponseEvent struct {
+	name    string
+	payload any
+	done    bool
+}
+
+func isServeUIRequest(r *http.Request) bool {
+	value := strings.TrimSpace(strings.ToLower(r.Header.Get("X-Term-LLM-UI")))
+	return value == "1" || value == "true" || value == "yes"
+}
+
+func publishServeUIResponseEvent(ch chan<- serveUIResponseEvent, liveDone <-chan struct{}, event serveUIResponseEvent) {
+	select {
+	case <-liveDone:
+		return
+	case ch <- event:
+	}
+}
+
+func serveUILiveDetached(liveDone <-chan struct{}) bool {
+	select {
+	case <-liveDone:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *serveServer) streamUIResponses(w http.ResponseWriter, r *http.Request, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "streaming not supported")
+		return
+	}
+
+	setSSEHeaders(w)
+	liveEvents := make(chan serveUIResponseEvent, 32)
+	liveDone := make(chan struct{})
+	var liveDoneOnce sync.Once
+
+	go s.runUIResponsesDetached(runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, liveEvents, liveDone)
+
+	pingMu, stopPing := sseKeepalive(w, flusher, 20*time.Second)
+	defer stopPing()
+	defer liveDoneOnce.Do(func() { close(liveDone) })
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case evt, ok := <-liveEvents:
+			if !ok {
+				return
+			}
+			pingMu.Lock()
+			if evt.done {
+				_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			} else {
+				_ = writeSSEEvent(w, evt.name, evt.payload)
+			}
+			flusher.Flush()
+			pingMu.Unlock()
+		}
+	}
+}
+
+func (s *serveServer) runUIResponsesDetached(runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, liveEvents chan<- serveUIResponseEvent, liveDone <-chan struct{}) {
+	defer close(liveEvents)
+
+	runtime.clearLastUIRunError()
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	respID := "resp_" + randomSuffix()
+	model := llmReq.Model
+	if model == "" {
+		model = runtime.defaultModel
+	}
+	created := time.Now().Unix()
+
+	publish := func(name string, payload any) {
+		publishServeUIResponseEvent(liveEvents, liveDone, serveUIResponseEvent{name: name, payload: payload})
+	}
+
+	publish("response.created", map[string]any{
+		"response": map[string]any{
+			"id":      respID,
+			"object":  "response",
+			"created": created,
+			"model":   model,
+			"status":  "in_progress",
+		},
+	})
+
+	outputIndex := 0
+	toolsSeen := false
+	result, err := runtime.RunWithEvents(runCtx, stateful, replaceHistory, inputMessages, llmReq, func(ev llm.Event) error {
+		switch ev.Type {
+		case llm.EventTextDelta:
+			if toolsSeen {
+				publish("response.output_text.new_segment", map[string]any{"output_index": outputIndex})
+				toolsSeen = false
+			}
+			publish("response.output_text.delta", map[string]any{
+				"output_index": outputIndex,
+				"delta":        ev.Text,
+			})
+		case llm.EventToolCall:
+			if ev.Tool == nil {
+				return nil
+			}
+			toolsSeen = true
+			item := map[string]any{
+				"id":        "fc_" + ev.Tool.ID,
+				"type":      "function_call",
+				"call_id":   ev.Tool.ID,
+				"name":      ev.Tool.Name,
+				"arguments": string(ev.Tool.Arguments),
+			}
+			publish("response.output_item.added", map[string]any{"output_index": outputIndex, "item": item})
+			publish("response.function_call_arguments.delta", map[string]any{"output_index": outputIndex, "delta": string(ev.Tool.Arguments)})
+			publish("response.output_item.done", map[string]any{"output_index": outputIndex, "item": item})
+			outputIndex++
+		case llm.EventToolExecStart:
+			if ev.ToolName == tools.AskUserToolName {
+				if prompt, promptErr := runtime.prepareAskUserFromToolArgs(ev.ToolCallID, ev.ToolArgs); promptErr == nil {
+					publish("response.ask_user.prompt", prompt)
+				}
+			}
+			publish("response.tool_exec.start", map[string]any{
+				"call_id":        ev.ToolCallID,
+				"tool_name":      ev.ToolName,
+				"tool_info":      ev.ToolInfo,
+				"tool_arguments": string(ev.ToolArgs),
+			})
+		case llm.EventToolExecEnd:
+			if ev.ToolName == tools.AskUserToolName {
+				runtime.clearPendingAskUser(ev.ToolCallID)
+			}
+			payload := map[string]any{
+				"call_id":   ev.ToolCallID,
+				"tool_name": ev.ToolName,
+				"success":   ev.ToolSuccess,
+			}
+			if len(ev.ToolImages) > 0 {
+				imageURLs := make([]string, 0, len(ev.ToolImages))
+				for _, imgPath := range ev.ToolImages {
+					imageURLs = append(imageURLs, "/images/"+filepath.Base(imgPath))
+				}
+				payload["images"] = imageURLs
+			}
+			publish("response.tool_exec.end", payload)
+		case llm.EventHeartbeat:
+			publish("response.heartbeat", map[string]any{
+				"call_id":   ev.ToolCallID,
+				"tool_name": ev.ToolName,
+			})
+		case llm.EventInterjection:
+			publish("response.interjection", map[string]any{"text": ev.Text})
+		}
+		return nil
+	})
+
+	if err != nil {
+		if serveUILiveDetached(liveDone) {
+			runtime.setLastUIRunError(err.Error())
+		} else {
+			runtime.clearLastUIRunError()
+		}
+		errType := "invalid_request_error"
+		if errors.Is(err, errServeSessionBusy) {
+			errType = "conflict_error"
+		}
+		publish("response.failed", map[string]any{
+			"error": map[string]any{"message": err.Error(), "type": errType},
+		})
+		publishServeUIResponseEvent(liveEvents, liveDone, serveUIResponseEvent{done: true})
+		return
+	}
+
+	runtime.clearLastUIRunError()
+	s.registerResponseID(runtime, respID, sessionID)
+	publish("response.completed", map[string]any{
+		"response": map[string]any{
+			"id":      respID,
+			"object":  "response",
+			"created": created,
+			"model":   model,
+			"status":  "completed",
+			"usage": map[string]any{
+				"input_tokens":  result.Usage.InputTokens,
+				"output_tokens": result.Usage.OutputTokens,
+				"total_tokens":  result.Usage.InputTokens + result.Usage.OutputTokens,
+				"input_tokens_details": map[string]any{
+					"cached_tokens": result.Usage.CachedInputTokens,
+				},
+			},
+			"session_usage": map[string]any{
+				"input_tokens":  result.SessionUsage.InputTokens,
+				"output_tokens": result.SessionUsage.OutputTokens,
+				"total_tokens":  result.SessionUsage.InputTokens + result.SessionUsage.OutputTokens,
+				"input_tokens_details": map[string]any{
+					"cached_tokens": result.SessionUsage.CachedInputTokens,
+				},
+			},
+		},
+	})
+	publishServeUIResponseEvent(liveEvents, liveDone, serveUIResponseEvent{done: true})
+}

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -960,6 +960,111 @@
       cursor: not-allowed;
     }
 
+    .ask-user-modal {
+      width: min(720px, 100%);
+      max-height: min(82vh, 900px);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .ask-user-body {
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+      max-height: min(60vh, 560px);
+      overflow-y: auto;
+      padding-right: 0.1rem;
+    }
+
+    .ask-user-question {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface-2);
+      padding: 0.85rem;
+    }
+
+    .ask-user-question-header {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 0.45rem;
+    }
+
+    .ask-user-question-text {
+      margin: 0 0 0.75rem;
+      font-size: 0.98rem;
+      font-weight: 600;
+      line-height: 1.45;
+    }
+
+    .ask-user-options {
+      display: flex;
+      flex-direction: column;
+      gap: 0.55rem;
+    }
+
+    .ask-user-option {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.65rem 0.7rem;
+      background: color-mix(in srgb, var(--surface) 45%, var(--surface-2) 55%);
+      cursor: pointer;
+    }
+
+    .ask-user-option input {
+      margin: 0.18rem 0 0;
+      flex-shrink: 0;
+    }
+
+    .ask-user-option-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 0.14rem;
+      min-width: 0;
+    }
+
+    .ask-user-option-title {
+      font-weight: 600;
+      line-height: 1.35;
+    }
+
+    .ask-user-option-desc {
+      color: var(--text-muted);
+      font-size: 0.84rem;
+      line-height: 1.4;
+    }
+
+    .ask-user-custom textarea {
+      width: 100%;
+      min-height: 84px;
+      resize: vertical;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      border-radius: 10px;
+      padding: 0.65rem 0.75rem;
+      margin-top: 0.55rem;
+      font: inherit;
+      line-height: 1.45;
+    }
+
+    .ask-user-custom textarea:focus {
+      outline: 2px solid color-mix(in srgb, var(--accent) 60%, transparent);
+      border-color: var(--accent);
+    }
+
+    .ask-user-note {
+      margin-top: 0.55rem;
+      color: var(--text-muted);
+      font-size: 0.78rem;
+      line-height: 1.4;
+    }
+
     .attachments {
       display: flex;
       gap: 0.5rem;
@@ -1219,6 +1324,19 @@
     </div>
   </div>
 
+  <div class="modal-overlay hidden" id="askUserModal" role="dialog" aria-modal="true" aria-labelledby="askUserModalTitle">
+    <div class="modal ask-user-modal">
+      <h2 id="askUserModalTitle">Answer question</h2>
+      <p id="askUserModalSubtitle">The agent needs your input to continue.</p>
+      <div class="ask-user-body" id="askUserModalBody"></div>
+      <div class="modal-error" id="askUserError"></div>
+      <div class="modal-actions">
+        <button class="btn" id="askUserCancelBtn" type="button">Dismiss</button>
+        <button class="btn primary" id="askUserSubmitBtn" type="button">Continue</button>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/16.3.0/lib/marked.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.7/purify.min.js"></script>
@@ -1247,8 +1365,10 @@
         abortController: null,
         autoScroll: true,
         authRequired: false,
-        attachments: []
+        attachments: [],
+        askUser: null
       };
+      let sessionStatePollTimer = null;
 
       // Ensure cookie is set on load so <img> requests to /images/ can authenticate
       if (state.token) {
@@ -1276,6 +1396,13 @@
         authError: document.getElementById('authError'),
         authConnectBtn: document.getElementById('authConnectBtn'),
         authCancelBtn: document.getElementById('authCancelBtn'),
+        askUserModal: document.getElementById('askUserModal'),
+        askUserModalTitle: document.getElementById('askUserModalTitle'),
+        askUserModalSubtitle: document.getElementById('askUserModalSubtitle'),
+        askUserModalBody: document.getElementById('askUserModalBody'),
+        askUserError: document.getElementById('askUserError'),
+        askUserCancelBtn: document.getElementById('askUserCancelBtn'),
+        askUserSubmitBtn: document.getElementById('askUserSubmitBtn'),
         attachBtn: document.getElementById('attachBtn'),
         fileInput: document.getElementById('fileInput'),
         attachmentsStrip: document.getElementById('attachmentsStrip'),
@@ -1462,6 +1589,9 @@
             const interruptState = sanitizeInterruptState(msg.interruptState);
             if (interruptState) {
               base.interruptState = interruptState;
+            }
+            if (msg.askUser) {
+              base.askUser = true;
             }
             if (Array.isArray(msg.attachments) && msg.attachments.length > 0) {
               base.attachments = msg.attachments.map(a => ({
@@ -1679,6 +1809,10 @@
             btn.appendChild(title);
             btn.appendChild(meta);
             btn.addEventListener('click', async () => {
+              stopSessionStatePoll();
+              if (state.askUser?.sessionId && state.askUser.sessionId !== session.id) {
+                closeAskUserModal();
+              }
               state.activeSessionId = session.id;
               updateURL(session.id);
 
@@ -1686,13 +1820,13 @@
               if (session._serverOnly) {
                 const msgs = await loadServerSessionMessages(session.id);
                 if (msgs !== null) {
-                  session.messages = msgs;
-                  delete session._serverOnly;
+                  mergeServerMessagesWithLocalState(session, msgs);
                 }
               }
 
               persistAndRefreshShell();
               renderMessages(true);
+              await syncActiveSessionFromServer(session, true);
               closeSidebarIfMobile();
             });
 
@@ -2025,6 +2159,14 @@
           return [['task', '@' + agentName + ': ' + prompt]];
         }
 
+        if (name === 'ask_user') {
+          const questions = Array.isArray(args.questions) ? args.questions : [];
+          return questions.slice(0, 4).map((question, index) => [
+            question.header || `question_${index + 1}`,
+            question.question || ''
+          ]);
+        }
+
         // Pick the most relevant key(s) per tool type
         const priorityKeys = {
           'shell': ['command'],
@@ -2276,6 +2418,285 @@
         }
       };
 
+      // ===== ask_user modal =====
+      const closeAskUserModal = () => {
+        state.askUser = null;
+        elements.askUserModal.classList.add('hidden');
+        elements.askUserModalBody.innerHTML = '';
+        elements.askUserError.textContent = '';
+        elements.askUserSubmitBtn.disabled = false;
+        elements.askUserCancelBtn.disabled = false;
+        elements.askUserSubmitBtn.textContent = 'Continue';
+        elements.askUserCancelBtn.textContent = 'Dismiss';
+      };
+
+      const askUserSummaryFromAnswers = (answers) => {
+        if (!Array.isArray(answers) || answers.length === 0) return '';
+        return answers
+          .map((answer) => {
+            const header = String(answer?.header || '').trim();
+            const selected = String(answer?.selected || '').trim();
+            if (!header) return selected;
+            return `${header}: ${selected}`;
+          })
+          .filter(Boolean)
+          .join(' | ');
+      };
+
+      const collectAskUserAnswers = () => {
+        const prompt = state.askUser;
+        if (!prompt) {
+          throw new Error('No pending question.');
+        }
+        const answers = [];
+        prompt.questions.forEach((question, index) => {
+          const name = `ask_user_${index}`;
+          if (question.multi_select) {
+            const selectedList = Array.from(elements.askUserModalBody.querySelectorAll(`input[name="${name}"]:checked`))
+              .map((input) => String(input.value || '').trim())
+              .filter(Boolean);
+            if (selectedList.length === 0) {
+              throw new Error(`${question.header || `Question ${index + 1}`}: choose at least one option.`);
+            }
+            answers.push({
+              question_index: index,
+              header: question.header,
+              selected: selectedList.join(', '),
+              selected_list: selectedList,
+              is_custom: false,
+              is_multi_select: true
+            });
+            return;
+          }
+
+          const selected = elements.askUserModalBody.querySelector(`input[name="${name}"]:checked`);
+          if (!selected) {
+            throw new Error(`${question.header || `Question ${index + 1}`}: choose an option.`);
+          }
+          if (selected.value === '__custom__') {
+            const textarea = elements.askUserModalBody.querySelector(`#askUserCustom_${index}`);
+            const custom = String(textarea?.value || '').trim();
+            if (!custom) {
+              throw new Error(`${question.header || `Question ${index + 1}`}: enter your answer.`);
+            }
+            answers.push({
+              question_index: index,
+              header: question.header,
+              selected: custom,
+              is_custom: true,
+              is_multi_select: false
+            });
+            return;
+          }
+          answers.push({
+            question_index: index,
+            header: question.header,
+            selected: String(selected.value || '').trim(),
+            is_custom: false,
+            is_multi_select: false
+          });
+        });
+        return answers;
+      };
+
+      const renderAskUserModal = () => {
+        const prompt = state.askUser;
+        if (!prompt) return;
+
+        elements.askUserModalTitle.textContent = prompt.questions.length === 1 ? 'Answer question' : 'Answer questions';
+        elements.askUserModalSubtitle.textContent = 'The agent needs your input to continue.';
+        elements.askUserModalBody.innerHTML = '';
+        elements.askUserError.textContent = '';
+
+        prompt.questions.forEach((question, index) => {
+          const section = document.createElement('section');
+          section.className = 'ask-user-question';
+
+          const header = document.createElement('div');
+          header.className = 'ask-user-question-header';
+          header.textContent = question.header || `Question ${index + 1}`;
+          section.appendChild(header);
+
+          const text = document.createElement('p');
+          text.className = 'ask-user-question-text';
+          text.textContent = question.question || '';
+          section.appendChild(text);
+
+          const options = document.createElement('div');
+          options.className = 'ask-user-options';
+          const inputType = question.multi_select ? 'checkbox' : 'radio';
+          const groupName = `ask_user_${index}`;
+
+          (Array.isArray(question.options) ? question.options : []).forEach((option) => {
+            const label = document.createElement('label');
+            label.className = 'ask-user-option';
+
+            const input = document.createElement('input');
+            input.type = inputType;
+            input.name = groupName;
+            input.value = option.label || '';
+
+            const copy = document.createElement('span');
+            copy.className = 'ask-user-option-copy';
+
+            const title = document.createElement('span');
+            title.className = 'ask-user-option-title';
+            title.textContent = option.label || 'Option';
+
+            copy.appendChild(title);
+            if (option.description) {
+              const desc = document.createElement('span');
+              desc.className = 'ask-user-option-desc';
+              desc.textContent = option.description;
+              copy.appendChild(desc);
+            }
+
+            label.appendChild(input);
+            label.appendChild(copy);
+            options.appendChild(label);
+          });
+
+          if (!question.multi_select) {
+            const customWrap = document.createElement('div');
+            customWrap.className = 'ask-user-custom';
+
+            const customLabel = document.createElement('label');
+            customLabel.className = 'ask-user-option';
+
+            const customRadio = document.createElement('input');
+            customRadio.type = 'radio';
+            customRadio.name = groupName;
+            customRadio.value = '__custom__';
+
+            const customCopy = document.createElement('span');
+            customCopy.className = 'ask-user-option-copy';
+
+            const customTitle = document.createElement('span');
+            customTitle.className = 'ask-user-option-title';
+            customTitle.textContent = 'Other';
+
+            const customDesc = document.createElement('span');
+            customDesc.className = 'ask-user-option-desc';
+            customDesc.textContent = 'Type your own answer.';
+
+            customCopy.appendChild(customTitle);
+            customCopy.appendChild(customDesc);
+            customLabel.appendChild(customRadio);
+            customLabel.appendChild(customCopy);
+            customWrap.appendChild(customLabel);
+
+            const textarea = document.createElement('textarea');
+            textarea.id = `askUserCustom_${index}`;
+            textarea.placeholder = 'Type your answer';
+            textarea.addEventListener('focus', () => {
+              customRadio.checked = true;
+            });
+            customWrap.appendChild(textarea);
+            options.appendChild(customWrap);
+          }
+
+          const note = document.createElement('div');
+          note.className = 'ask-user-note';
+          note.textContent = question.multi_select
+            ? 'Choose one or more options to continue.'
+            : 'Choose one option or provide a custom answer.';
+          section.appendChild(options);
+          section.appendChild(note);
+          elements.askUserModalBody.appendChild(section);
+        });
+      };
+
+      const openAskUserModal = (sessionId, callId, questions) => {
+        if (!sessionId || !callId || !Array.isArray(questions) || questions.length === 0) return;
+        state.askUser = {
+          sessionId,
+          callId,
+          questions: questions.map((question) => ({
+            ...question,
+            options: Array.isArray(question?.options) ? question.options.map((option) => ({ ...option })) : []
+          }))
+        };
+        renderAskUserModal();
+        elements.askUserModal.classList.remove('hidden');
+        setTimeout(() => {
+          const firstInput = elements.askUserModalBody.querySelector('input, textarea');
+          firstInput?.focus();
+        }, 0);
+      };
+
+      const submitAskUserModal = async (cancelled = false) => {
+        const prompt = state.askUser;
+        if (!prompt) return;
+
+        let answers = [];
+        if (!cancelled) {
+          try {
+            answers = collectAskUserAnswers();
+          } catch (err) {
+            elements.askUserError.textContent = err?.message || 'Please answer all questions.';
+            return;
+          }
+        }
+
+        elements.askUserError.textContent = '';
+        elements.askUserSubmitBtn.disabled = true;
+        elements.askUserCancelBtn.disabled = true;
+        elements.askUserSubmitBtn.textContent = cancelled ? 'Closing…' : 'Sending…';
+        elements.askUserCancelBtn.textContent = cancelled ? 'Dismissing…' : 'Dismiss';
+
+        try {
+          const response = await fetch(`/v1/sessions/${encodeURIComponent(prompt.sessionId)}/ask_user`, {
+            method: 'POST',
+            headers: requestHeaders(prompt.sessionId),
+            body: JSON.stringify(cancelled
+              ? { call_id: prompt.callId, cancelled: true }
+              : { call_id: prompt.callId, answers })
+          });
+          if (!response.ok) {
+            throw await normalizeError(response);
+          }
+          const payload = await response.json().catch(() => ({}));
+          if (!cancelled) {
+            const session = state.sessions.find((item) => item.id === prompt.sessionId);
+            if (session) {
+              const normalized = Array.isArray(payload.answers) ? payload.answers : answers;
+              const summary = String(payload.summary || askUserSummaryFromAnswers(normalized) || 'Answered prompt').trim();
+              if (summary) {
+                const message = {
+                  id: generateId('msg'),
+                  role: 'user',
+                  content: summary,
+                  created: Date.now(),
+                  askUser: true
+                };
+                session.messages.push(message);
+                if (session.id === state.activeSessionId) {
+                  const empty = elements.messages.querySelector('.empty-state');
+                  if (empty) empty.remove();
+                  elements.messages.appendChild(createMessageNode(message));
+                }
+                saveSessions();
+                scrollToBottom(true);
+              }
+            }
+          }
+          closeAskUserModal();
+          if (!state.abortController) {
+            setStreaming(true);
+            scheduleSessionStatePoll(prompt.sessionId, 400);
+          }
+        } catch (err) {
+          elements.askUserError.textContent = err?.message || 'Failed to submit your answer.';
+          if (err?.status === 401) {
+            handleAuthFailure();
+          }
+          elements.askUserSubmitBtn.disabled = false;
+          elements.askUserCancelBtn.disabled = false;
+          elements.askUserSubmitBtn.textContent = 'Continue';
+          elements.askUserCancelBtn.textContent = 'Dismiss';
+        }
+      };
+
       // ===== Auth modal =====
       const openAuthModal = (errorText = '', required = !state.token) => {
         state.authRequired = required;
@@ -2297,6 +2718,8 @@
       };
 
       const handleAuthFailure = () => {
+        stopSessionStatePoll();
+        closeAskUserModal();
         state.token = '';
         localStorage.removeItem(STORAGE_KEYS.token);
         syncTokenCookie('');
@@ -2326,6 +2749,10 @@
           setConnectionState('', '');
           state.authRequired = false;
           closeAuthModal();
+          const active = getActiveSession();
+          if (active) {
+            await syncActiveSessionFromServer(active, true);
+          }
         } catch (err) {
           const message = err?.message || 'Unable to validate token.';
           elements.authError.textContent = message;
@@ -2453,7 +2880,7 @@
         elements.promptInput.disabled = false;
         elements.sendBtn.disabled = false;
         elements.sendBtn.classList.toggle('loading', streaming);
-        elements.stopBtn.classList.toggle('visible', streaming);
+        elements.stopBtn.classList.toggle('visible', streaming && Boolean(state.abortController));
         if (!streaming) {
           elements.promptInput.focus();
         }
@@ -2705,9 +3132,9 @@
         scrollToBottom(true);
 
         state.expectCanceledRun = false;
-        setStreaming(true);
         const controller = new AbortController();
         state.abortController = controller;
+        setStreaming(true);
 
         // Build input content: plain string or array with file/image parts
         let inputContent;
@@ -2744,7 +3171,10 @@
         try {
           const response = await fetch('/v1/responses', {
             method: 'POST',
-            headers: requestHeaders(session.id),
+            headers: {
+              ...requestHeaders(session.id),
+              'X-Term-LLM-UI': '1'
+            },
             body: JSON.stringify(body),
             signal: controller.signal
           });
@@ -2846,6 +3276,15 @@
                 }
                 updateToolGroupNode(currentToolGroup);
                 saveSessions();
+              }
+              return true;
+            }
+
+            if (event === 'response.ask_user.prompt') {
+              const callId = String(payload.call_id || '').trim();
+              const questions = Array.isArray(payload.questions) ? payload.questions : [];
+              if (callId && questions.length > 0) {
+                openAskUserModal(session.id, callId, questions);
               }
               return true;
             }
@@ -2963,12 +3402,14 @@
 
           persistAndRefreshShell();
           scrollToBottom(true);
-        } finally {
-          state.abortController = null;
-          setStreaming(false);
-          refreshRelativeTimes();
-
-          requeueUncommittedInterrupts(session);
+          } finally {
+            if (state.askUser?.sessionId === session.id) {
+              closeAskUserModal();
+            }
+            state.abortController = null;
+            setStreaming(false);
+            refreshRelativeTimes();
+         requeueUncommittedInterrupts(session);
 
           if (state.queuedInterrupts.length > 0) {
             const queued = state.queuedInterrupts.shift();
@@ -3053,13 +3494,129 @@
         try {
           const headers = {};
           if (state.token) headers.Authorization = `Bearer ${state.token}`;
-          const resp = await fetch(`/v1/sessions/${sessionId}/messages`, { headers });
+          const resp = await fetch(`/v1/sessions/${encodeURIComponent(sessionId)}/messages`, { headers });
           if (!resp.ok) return null;
           const data = await resp.json();
           if (!Array.isArray(data.messages)) return null;
           return convertServerMessages(data.messages);
         } catch {
           return null;
+        }
+      };
+
+      const loadServerSessionState = async (sessionId) => {
+        try {
+          const headers = {};
+          if (state.token) headers.Authorization = `Bearer ${state.token}`;
+          const resp = await fetch(`/v1/sessions/${encodeURIComponent(sessionId)}/state`, { headers });
+          if (!resp.ok) return null;
+          const data = await resp.json().catch(() => null);
+          if (!data || typeof data !== 'object') return null;
+          return data;
+        } catch {
+          return null;
+        }
+      };
+
+      const mergeServerMessagesWithLocalState = (session, serverMessages) => {
+        if (!session || !Array.isArray(serverMessages)) return;
+
+        const syntheticAskUserMessages = session.messages
+          .filter((message) => message?.askUser && message.role === 'user' && message.content)
+          .map((message) => ({ ...message }));
+
+        const merged = serverMessages.map((message) => ({ ...message }));
+        if (syntheticAskUserMessages.length > 0) {
+          const insertAfter = (() => {
+            for (let i = merged.length - 1; i >= 0; i -= 1) {
+              if (merged[i].role === 'tool-group') return i + 1;
+            }
+            for (let i = merged.length - 1; i >= 0; i -= 1) {
+              if (merged[i].role === 'user') return i + 1;
+            }
+            return merged.length;
+          })();
+          merged.splice(insertAfter, 0, ...syntheticAskUserMessages.filter((message) => !merged.some((existing) => existing.askUser && existing.content === message.content)));
+        }
+
+        session.messages = merged;
+        delete session._serverOnly;
+        if (merged.length > 0) {
+          const firstUserMsg = merged.find((message) => message.role === 'user' && !message.askUser);
+          if (firstUserMsg?.content) {
+            session.title = truncate(firstUserMsg.content, 60);
+          }
+        }
+      };
+
+      const stopSessionStatePoll = () => {
+        if (sessionStatePollTimer !== null) {
+          clearTimeout(sessionStatePollTimer);
+          sessionStatePollTimer = null;
+        }
+      };
+
+      const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
+        stopSessionStatePoll();
+        sessionStatePollTimer = setTimeout(async () => {
+          const active = getActiveSession();
+          if (!active || active.id !== sessionId || state.abortController) {
+            stopSessionStatePoll();
+            return;
+          }
+          await syncActiveSessionFromServer(active, true);
+        }, delay);
+      };
+
+      const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
+        if (!session || !state.token) return;
+
+        const runtimeState = await loadServerSessionState(session.id);
+        if (!runtimeState) return;
+
+        const prompts = Array.isArray(runtimeState.pending_ask_users)
+          ? runtimeState.pending_ask_users
+          : (runtimeState.pending_ask_user ? [runtimeState.pending_ask_user] : []);
+        const prompt = prompts[0] || null;
+
+        if (prompt && prompt.call_id && Array.isArray(prompt.questions) && prompt.questions.length > 0) {
+          const samePrompt = state.askUser
+            && state.askUser.sessionId === session.id
+            && state.askUser.callId === prompt.call_id;
+          if (!samePrompt) {
+            openAskUserModal(session.id, prompt.call_id, prompt.questions);
+          }
+        } else if (state.askUser?.sessionId === session.id) {
+          closeAskUserModal();
+        }
+
+        const activeRun = Boolean(runtimeState.active_run);
+        if (activeRun && !state.abortController) {
+          setStreaming(true);
+          if (pollOnActive) {
+            scheduleSessionStatePoll(session.id);
+          }
+          return;
+        }
+
+        if (!activeRun && !state.abortController) {
+          stopSessionStatePoll();
+          const serverMessages = await loadServerSessionMessages(session.id);
+          if (serverMessages !== null) {
+            mergeServerMessagesWithLocalState(session, serverMessages);
+            persistAndRefreshShell();
+            if (session.id === state.activeSessionId) {
+              renderMessages(true);
+            }
+          }
+          if (runtimeState.last_error) {
+            addErrorMessage(String(runtimeState.last_error), session);
+            persistAndRefreshShell();
+            if (session.id === state.activeSessionId) {
+              scrollToBottom(true);
+            }
+          }
+          setStreaming(false);
         }
       };
 
@@ -3146,16 +3703,14 @@
             if (active && active._serverOnly) {
               const msgs = await loadServerSessionMessages(active.id);
               if (msgs !== null) {
-                active.messages = msgs;
-                if (msgs.length > 0) {
-                  const firstUserMsg = msgs.find(m => m.role === 'user');
-                  if (firstUserMsg) active.title = truncate(firstUserMsg.content, 60);
-                }
-                delete active._serverOnly;
+                mergeServerMessagesWithLocalState(active, msgs);
                 saveSessions();
                 renderSidebar();
                 renderMessages(true);
               }
+            }
+            if (active) {
+              await syncActiveSessionFromServer(active, true);
             }
           } catch (err) {
             const message = err?.message || 'Unable to validate token.';
@@ -3170,6 +3725,11 @@
       // ===== Event listeners =====
       elements.newChatBtn.addEventListener('click', () => {
         if (state.streaming) return;
+
+        stopSessionStatePoll();
+        if (state.askUser) {
+          closeAskUserModal();
+        }
 
         const session = createSession();
         state.sessions.unshift(session);
@@ -3274,6 +3834,18 @@
 
       elements.authConnectBtn.addEventListener('click', connectToken);
       elements.authCancelBtn.addEventListener('click', closeAuthModal);
+      elements.askUserSubmitBtn.addEventListener('click', () => {
+        submitAskUserModal(false);
+      });
+      elements.askUserCancelBtn.addEventListener('click', () => {
+        submitAskUserModal(true);
+      });
+      elements.askUserModal.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !event.defaultPrevented) {
+          event.preventDefault();
+          submitAskUserModal(true);
+        }
+      });
       elements.authTokenInput.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') {
           event.preventDefault();
@@ -3291,18 +3863,23 @@
         const urlId = sessionIdFromURL();
         if (!urlId || urlId === state.activeSessionId) return;
 
+        stopSessionStatePoll();
+        if (state.askUser?.sessionId && state.askUser.sessionId !== urlId) {
+          closeAskUserModal();
+        }
+
         const found = state.sessions.find(s => s.id === urlId);
         if (found) {
           state.activeSessionId = found.id;
           if (found._serverOnly) {
             const msgs = await loadServerSessionMessages(found.id);
             if (msgs !== null) {
-              found.messages = msgs;
-              delete found._serverOnly;
+              mergeServerMessagesWithLocalState(found, msgs);
             }
           }
           persistAndRefreshShell();
           renderMessages(true);
+          await syncActiveSessionFromServer(found, true);
         }
       });
 

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
@@ -42,6 +43,97 @@ type AskUserResult struct {
 // AskUserArgs are the arguments passed to the ask_user tool.
 type AskUserArgs struct {
 	Questions []AskUserQuestion `json:"questions"`
+}
+
+// NormalizeAskUserAnswers validates ask_user answers and rewrites them into the
+// canonical shape expected by the tool result.
+func NormalizeAskUserAnswers(questions []AskUserQuestion, answers []AskUserAnswer) ([]AskUserAnswer, error) {
+	if len(answers) != len(questions) {
+		return nil, fmt.Errorf("ask_user UI returned incomplete answers")
+	}
+
+	normalized := make([]AskUserAnswer, len(questions))
+	for i, q := range questions {
+		answer := answers[i]
+		if q.MultiSelect {
+			if answer.IsCustom {
+				return nil, fmt.Errorf("question %d does not support custom answers", i+1)
+			}
+			if len(answer.SelectedList) == 0 {
+				return nil, fmt.Errorf("question %d requires at least one selection", i+1)
+			}
+			allowed := make(map[string]struct{}, len(q.Options))
+			for _, opt := range q.Options {
+				allowed[opt.Label] = struct{}{}
+			}
+			selected := make([]string, 0, len(answer.SelectedList))
+			seen := make(map[string]struct{}, len(answer.SelectedList))
+			for _, raw := range answer.SelectedList {
+				label := strings.TrimSpace(raw)
+				if label == "" {
+					return nil, fmt.Errorf("question %d has an empty selection", i+1)
+				}
+				if _, ok := allowed[label]; !ok {
+					return nil, fmt.Errorf("question %d has invalid selection %q", i+1, label)
+				}
+				if _, ok := seen[label]; ok {
+					return nil, fmt.Errorf("question %d has duplicate selection %q", i+1, label)
+				}
+				seen[label] = struct{}{}
+				selected = append(selected, label)
+			}
+			normalized[i] = AskUserAnswer{
+				QuestionIndex: i,
+				Header:        q.Header,
+				Selected:      strings.Join(selected, ", "),
+				SelectedList:  selected,
+				IsCustom:      false,
+				IsMultiSelect: true,
+			}
+			continue
+		}
+
+		selected := strings.TrimSpace(answer.Selected)
+		if selected == "" {
+			return nil, fmt.Errorf("question %d requires an answer", i+1)
+		}
+		if !answer.IsCustom {
+			valid := false
+			for _, opt := range q.Options {
+				if opt.Label == selected {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return nil, fmt.Errorf("question %d has invalid selection %q", i+1, selected)
+			}
+		}
+		normalized[i] = AskUserAnswer{
+			QuestionIndex: i,
+			Header:        q.Header,
+			Selected:      selected,
+			IsCustom:      answer.IsCustom,
+			IsMultiSelect: false,
+		}
+	}
+
+	return normalized, nil
+}
+
+// AskUserAnswerSummary renders a compact summary of canonical ask_user answers.
+func AskUserAnswerSummary(answers []AskUserAnswer) string {
+	parts := make([]string, 0, len(answers))
+	for _, answer := range answers {
+		header := strings.TrimSpace(answer.Header)
+		selected := strings.TrimSpace(answer.Selected)
+		if header == "" {
+			parts = append(parts, selected)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", header, selected))
+	}
+	return strings.Join(parts, " | ")
 }
 
 // AskUserTool implements the ask_user tool.
@@ -160,6 +252,8 @@ func (t *AskUserTool) Execute(ctx context.Context, args json.RawMessage) (llm.To
 		}
 	}
 
+	ctxHandler := askUserUIFuncFromContext(ctx)
+
 	// Get hooks and UI func under mutex protection
 	askUserMu.Lock()
 	startHook := OnAskUserStart
@@ -170,10 +264,13 @@ func (t *AskUserTool) Execute(ctx context.Context, args json.RawMessage) (llm.To
 	var answers []AskUserAnswer
 	var err error
 
-	if uiFunc != nil {
+	switch {
+	case ctxHandler != nil:
+		answers, err = ctxHandler(ctx, a.Questions)
+	case uiFunc != nil:
 		// Use custom UI function (inline rendering in alt screen mode)
 		answers, err = uiFunc(a.Questions)
-	} else {
+	default:
 		// Use default RunAskUser with hooks
 		// Call the hooks to pause spinner/TUI before showing UI
 		if startHook != nil {
@@ -203,9 +300,9 @@ func (t *AskUserTool) Execute(ctx context.Context, args json.RawMessage) (llm.To
 		return llm.TextOutput(formatAskUserError(ErrExecutionFailed, err.Error())), nil
 	}
 
-	// Validate answers from custom UI
-	if len(answers) != len(a.Questions) {
-		return llm.TextOutput(formatAskUserError(ErrExecutionFailed, "ask_user UI returned incomplete answers")), nil
+	answers, err = NormalizeAskUserAnswers(a.Questions, answers)
+	if err != nil {
+		return llm.TextOutput(formatAskUserError(ErrExecutionFailed, err.Error())), nil
 	}
 
 	// Return successful result

--- a/internal/tools/ask_user_context.go
+++ b/internal/tools/ask_user_context.go
@@ -1,0 +1,25 @@
+package tools
+
+import "context"
+
+type askUserUIContextKey struct{}
+
+// AskUserContextUIFunc renders ask_user questions using a request-scoped UI
+// implementation, such as the web serve roundtrip.
+type AskUserContextUIFunc func(context.Context, []AskUserQuestion) ([]AskUserAnswer, error)
+
+// ContextWithAskUserUIFunc stores a request-scoped ask_user handler in ctx.
+func ContextWithAskUserUIFunc(ctx context.Context, fn AskUserContextUIFunc) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, askUserUIContextKey{}, fn)
+}
+
+func askUserUIFuncFromContext(ctx context.Context) AskUserContextUIFunc {
+	if ctx == nil {
+		return nil
+	}
+	fn, _ := ctx.Value(askUserUIContextKey{}).(AskUserContextUIFunc)
+	return fn
+}

--- a/internal/tools/ask_user_test.go
+++ b/internal/tools/ask_user_test.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAskUserAnswers(t *testing.T) {
+	questions := []AskUserQuestion{
+		{
+			Header:   "Color",
+			Question: "Pick a color",
+			Options: []AskUserOption{
+				{Label: "Red", Description: "Warm"},
+				{Label: "Blue", Description: "Cool"},
+			},
+		},
+		{
+			Header:      "Tools",
+			Question:    "Pick tools",
+			MultiSelect: true,
+			Options: []AskUserOption{
+				{Label: "Go", Description: "Compiler"},
+				{Label: "Docker", Description: "Container"},
+				{Label: "Git", Description: "Version control"},
+			},
+		},
+	}
+
+	t.Run("canonicalizes valid answers", func(t *testing.T) {
+		answers, err := NormalizeAskUserAnswers(questions, []AskUserAnswer{
+			{Selected: " Blue ", IsCustom: false, Header: "ignored", QuestionIndex: 99},
+			{SelectedList: []string{"Go", "Git"}, IsMultiSelect: true},
+		})
+		if err != nil {
+			t.Fatalf("NormalizeAskUserAnswers error = %v", err)
+		}
+		if answers[0].QuestionIndex != 0 || answers[0].Header != "Color" || answers[0].Selected != "Blue" {
+			t.Fatalf("single-select answer not canonicalized: %#v", answers[0])
+		}
+		if answers[1].QuestionIndex != 1 || answers[1].Header != "Tools" {
+			t.Fatalf("multi-select metadata not canonicalized: %#v", answers[1])
+		}
+		if got := strings.Join(answers[1].SelectedList, ","); got != "Go,Git" {
+			t.Fatalf("multi-select list = %q, want %q", got, "Go,Git")
+		}
+		if answers[1].Selected != "Go, Git" {
+			t.Fatalf("multi-select Selected = %q, want %q", answers[1].Selected, "Go, Git")
+		}
+	})
+
+	t.Run("allows custom single-select answers", func(t *testing.T) {
+		answers, err := NormalizeAskUserAnswers(questions[:1], []AskUserAnswer{{Selected: "Chartreuse", IsCustom: true}})
+		if err != nil {
+			t.Fatalf("NormalizeAskUserAnswers error = %v", err)
+		}
+		if !answers[0].IsCustom || answers[0].Selected != "Chartreuse" {
+			t.Fatalf("custom answer = %#v", answers[0])
+		}
+	})
+
+	t.Run("rejects invalid predefined single-select values", func(t *testing.T) {
+		_, err := NormalizeAskUserAnswers(questions[:1], []AskUserAnswer{{Selected: "Green"}})
+		if err == nil || !strings.Contains(err.Error(), "invalid selection") {
+			t.Fatalf("error = %v, want invalid selection", err)
+		}
+	})
+
+	t.Run("rejects empty multi-select answers", func(t *testing.T) {
+		_, err := NormalizeAskUserAnswers(questions[1:], []AskUserAnswer{{}})
+		if err == nil || !strings.Contains(err.Error(), "at least one selection") {
+			t.Fatalf("error = %v, want at least one selection", err)
+		}
+	})
+
+	t.Run("rejects duplicate multi-select values", func(t *testing.T) {
+		_, err := NormalizeAskUserAnswers(questions[1:], []AskUserAnswer{{SelectedList: []string{"Go", "Go"}}})
+		if err == nil || !strings.Contains(err.Error(), "duplicate selection") {
+			t.Fatalf("error = %v, want duplicate selection", err)
+		}
+	})
+}
+
+func TestAskUserAnswerSummary(t *testing.T) {
+	summary := AskUserAnswerSummary([]AskUserAnswer{
+		{Header: "Color", Selected: "Blue"},
+		{Header: "Tools", Selected: "Go, Git"},
+	})
+	if summary != "Color: Blue | Tools: Go, Git" {
+		t.Fatalf("summary = %q", summary)
+	}
+}


### PR DESCRIPTION
## What

Adds a real `ask_user` flow for `term-llm serve` web UI instead of falling back to `/dev/tty`.

- adds server-side pending `ask_user` state and answer submission endpoints
- wires the serve runtime to use request-scoped web `ask_user` handlers
- updates the web UI to render an `ask_user` modal, submit answers, and show local answer summaries
- adds a resumable `/ui/<session-id>` path so a page refresh/reopen can recover a pending `ask_user` prompt from server state
- keeps the server-side run alive for UI requests so refreshes do not immediately kill the in-flight prompt
- adds focused Go tests for answer normalization, streamed web roundtrip, and resume/state recovery

## Why

The current web flow is broken: `ask_user` in web falls back to `/dev/tty`, which is not a real UI interaction and collapses on refresh/reopen.

This makes `ask_user` actually usable in the browser and gives pending prompts a sane resume path while the server-side session runtime is still alive.

## Verification

- `go test ./internal/tools -run 'TestNormalizeAskUserAnswers|TestAskUserAnswerSummary|TestAskUserUI'`
- `go test ./cmd -run 'TestHandleResponses_UIAskUserResumeSurvivesDisconnect|TestHandleSessionState_ConsumesDeferredUIRunError|TestStreamResponses_AskUserRoundTrip|TestHandleSessionMessages_OmitsToolResults'`
- `go build ./...`
