### PR TITLE
fix: restore --version flag support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ import (
 
 func init() {
 	update.SetupUpdateChecks(rootCmd, Version)
+	rootCmd.Version = versionString()
+	rootCmd.SetVersionTemplate("{{printf \"%s version %s\\n\" .Name .Version}}")
 	rootCmd.PersistentFlags().BoolVar(&debugRaw, "debug-raw", false, "Emit raw debug logs with timestamps")
 	rootCmd.PersistentFlags().BoolVar(&showStats, "stats", false, "Show session statistics (time, tokens, tool calls)")
 	rootCmd.PersistentFlags().BoolVar(&noSession, "no-session", false, "Disable session persistence (no reads/writes to sessions database)")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,11 +11,15 @@ var Version = "dev"
 var Commit = "unknown"
 var Date = "unknown"
 
+func versionString() string {
+	return fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, Date)
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("term-llm version %s (commit: %s, built: %s)\n", Version, Commit, Date)
+		fmt.Fprintf(cmd.OutOrStdout(), "term-llm version %s\n", versionString())
 	},
 }
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestVersionCommandAndFlagMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "subcommand", args: []string{"version"}},
+		{name: "flag", args: []string{"--version"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			rootCmd.SetOut(&stdout)
+			rootCmd.SetErr(&stderr)
+			rootCmd.SetArgs(tc.args)
+
+			if _, err := rootCmd.ExecuteC(); err != nil {
+				t.Fatalf("ExecuteC() error = %v", err)
+			}
+
+			got := stdout.String()
+			want := "term-llm version " + versionString() + "\n"
+			if got != want {
+				t.Fatalf("stdout = %q, want %q", got, want)
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Restore `term-llm --version` while keeping `term-llm version` working with identical output.

## Why

The CLI already has a `version` subcommand, so dropping the standard root `--version` flag is needless breakage. This wires Cobra's built-in version flag on the root command and reuses the same formatted version string for both paths.

## Testing

- `go test ./cmd -run TestVersionCommandAndFlagMatch`
- `go build ./...`
- `go run . --version`
- `go run . version`
