### PR TITLE
fix: preserve web UI image uploads across session reloads

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -232,6 +232,8 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		ToolName   string `json:"tool_name,omitempty"`
 		ToolArgs   string `json:"tool_arguments,omitempty"`
 		ToolCallID string `json:"tool_call_id,omitempty"`
+		ImageURL   string `json:"image_url,omitempty"`
+		MimeType   string `json:"mime_type,omitempty"`
 	}
 
 	type messageEntry struct {
@@ -253,6 +255,14 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 					entry.Parts = append(entry.Parts, partEntry{
 						Type: "text",
 						Text: p.Text,
+					})
+				}
+			case llm.PartImage:
+				if p.ImageData != nil && p.ImageData.Base64 != "" {
+					entry.Parts = append(entry.Parts, partEntry{
+						Type:     "image",
+						ImageURL: "data:" + p.ImageData.MediaType + ";base64," + p.ImageData.Base64,
+						MimeType: p.ImageData.MediaType,
 					})
 				}
 			case llm.PartToolCall:

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -478,8 +478,11 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					if filename == "" {
 						filename = "image"
 					}
-					if _, err := saveUploadedFile(filename, b64); err != nil {
+					savedPath := ""
+					if path, err := saveUploadedFile(filename, b64); err != nil {
 						log.Printf("[web] warning: could not save uploaded image %q: %v", filename, err)
+					} else {
+						savedPath = path
 					}
 
 					// Decode raw bytes for possible resize.
@@ -490,6 +493,7 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 						llmParts = append(llmParts, llm.Part{
 							Type:      llm.PartImage,
 							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
+							ImagePath: savedPath,
 						})
 						continue
 					}
@@ -503,6 +507,7 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					llmParts = append(llmParts, llm.Part{
 						Type:      llm.PartImage,
 						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64},
+						ImagePath: savedPath,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -235,6 +235,9 @@ func TestParseResponsesInput_String(t *testing.T) {
 }
 
 func TestParseResponsesInput_ImageContent(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
 	payload := json.RawMessage(`[
 		{"type":"message","role":"user","content":[
 			{"type":"input_image","image_url":"data:image/png;base64,aGVsbG8="},
@@ -266,6 +269,12 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	}
 	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
 		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
+	}
+	if msg.Parts[0].ImagePath == "" {
+		t.Fatal("parts[0].ImagePath = empty, want saved upload path")
+	}
+	if _, err := os.Stat(msg.Parts[0].ImagePath); err != nil {
+		t.Fatalf("saved upload missing at %q: %v", msg.Parts[0].ImagePath, err)
 	}
 	if msg.Parts[1].Type != llm.PartText {
 		t.Fatalf("parts[1].type = %s, want text", msg.Parts[1].Type)
@@ -1102,6 +1111,8 @@ func TestHandleSessionMessages_ReturnsStructuredParts(t *testing.T) {
 				ToolName   string `json:"tool_name"`
 				ToolArgs   string `json:"tool_arguments"`
 				ToolCallID string `json:"tool_call_id"`
+				ImageURL   string `json:"image_url"`
+				MimeType   string `json:"mime_type"`
 			} `json:"parts"`
 		} `json:"messages"`
 	}
@@ -1134,6 +1145,82 @@ func TestHandleSessionMessages_ReturnsStructuredParts(t *testing.T) {
 	// Second tool call (was lost before due to break)
 	if m.Parts[2].Type != "tool_call" || m.Parts[2].ToolName != "read_url" || m.Parts[2].ToolCallID != "call-2" {
 		t.Fatalf("part[2] = %+v, want read_url tool_call", m.Parts[2])
+	}
+}
+
+func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &session.Session{
+		ID: "sess-image", Provider: "mock", Model: "mock-model",
+		Mode: session.ModeChat, CreatedAt: time.Now(), UpdatedAt: time.Now(), Status: session.StatusActive,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	msg := session.NewMessage("sess-image", llm.Message{
+		Role: llm.RoleUser,
+		Parts: []llm.Part{
+			{Type: llm.PartImage, ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="}},
+			{Type: llm.PartText, Text: "describe this"},
+		},
+	}, -1)
+	if err := store.AddMessage(ctx, "sess-image", msg); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	srv := &serveServer{store: store}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-image/messages", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var body struct {
+		Messages []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				Type     string `json:"type"`
+				Text     string `json:"text"`
+				ImageURL string `json:"image_url"`
+				MimeType string `json:"mime_type"`
+			} `json:"parts"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(body.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(body.Messages))
+	}
+	m := body.Messages[0]
+	if m.Role != "user" {
+		t.Fatalf("role = %q, want user", m.Role)
+	}
+	if len(m.Parts) != 2 {
+		t.Fatalf("parts count = %d, want 2", len(m.Parts))
+	}
+	if m.Parts[0].Type != "image" {
+		t.Fatalf("part[0].type = %q, want image", m.Parts[0].Type)
+	}
+	if m.Parts[0].ImageURL != "data:image/png;base64,aGVsbG8=" {
+		t.Fatalf("part[0].image_url = %q, want data URL", m.Parts[0].ImageURL)
+	}
+	if m.Parts[0].MimeType != "image/png" {
+		t.Fatalf("part[0].mime_type = %q, want image/png", m.Parts[0].MimeType)
+	}
+	if m.Parts[1].Type != "text" || m.Parts[1].Text != "describe this" {
+		t.Fatalf("part[1] = %+v, want trailing text part", m.Parts[1])
 	}
 }
 

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -28,13 +28,40 @@ const convertServerMessages = (serverMessages) => {
     const parts = Array.isArray(msg.parts) ? msg.parts : [];
     const created = msg.created_at || Date.now();
 
-    // Walk through parts in order to preserve interleaving
+    if (msg.role === 'user') {
+      flushGroup();
+
+      const attachments = [];
+      const textParts = [];
+      for (const part of parts) {
+        if (part.type === 'image' && part.image_url) {
+          attachments.push({
+            name: 'image',
+            type: part.mime_type || 'image/*',
+            dataURL: part.image_url
+          });
+        } else if (part.type === 'text' && part.text) {
+          textParts.push(part.text);
+        }
+      }
+
+      result.push({
+        id: generateId('msg'),
+        role: 'user',
+        content: textParts.join('\n'),
+        created,
+        ...(attachments.length > 0 ? { attachments } : {})
+      });
+      continue;
+    }
+
+    // Walk through assistant parts in order to preserve interleaving with tool calls.
     for (const part of parts) {
       if (part.type === 'text' && part.text) {
         flushGroup();
         result.push({
           id: generateId('msg'),
-          role: msg.role === 'user' ? 'user' : 'assistant',
+          role: 'assistant',
           content: part.text,
           created
         });
@@ -63,11 +90,11 @@ const convertServerMessages = (serverMessages) => {
     }
 
     // If message had no recognized parts, emit text content if present
-    if (parts.length === 0 && (msg.role === 'user' || msg.role === 'assistant')) {
+    if (parts.length === 0 && msg.role === 'assistant') {
       flushGroup();
       result.push({
         id: generateId('msg'),
-        role: msg.role,
+        role: 'assistant',
         content: '',
         created
       });


### PR DESCRIPTION
## What

Fix web UI image upload round-tripping so uploaded images remain visible after session sync/reload.

- include persisted `image` parts in `/v1/sessions/:id/messages`
- rebuild user message attachments from server-side image parts in the web UI
- retain saved upload paths on parsed web image messages
- add tests covering image persistence and session message serialization

## Why

Web uploads were accepted and sent to the model correctly, but the session messages API dropped image parts when reloading history. The web UI then rebuilt the session from server messages with only text/tool-call parts, so uploaded images disappeared after sync/reload even though Telegram uploads worked.

This preserves the actual user-visible behavior instead of relying on the temporary in-memory preview.

## Validation

- `go test ./cmd/...`
- `go test ./...`
