### PR TITLE
fix: keep provider session IDs when --no-session disables DB writes

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -265,9 +265,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	if sess != nil {
 		sessionID = sess.ID
 	}
-	if sessionID == "" && store != nil && !resuming {
-		sessionID = session.NewID()
-	}
+	sessionID = ensureRequestSessionID(sessionID, resuming)
 	settings.SessionID = sessionID
 
 	// Initialize local tools if we have any
@@ -297,10 +295,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		// PromptFunc is set in streamWithGlamour to use bubbletea UI
 
 		// Wire spawn_agent runner if enabled (with session tracking)
-		var parentSessionID string
-		if sess != nil {
-			parentSessionID = sess.ID
-		}
+		parentSessionID := sessionID
 		if err := WireSpawnAgentRunnerWithStore(cfg, toolMgr, askYolo, store, parentSessionID); err != nil {
 			return err
 		}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -437,6 +437,16 @@ func sessionStoreConfig(cfg *config.Config) session.Config {
 	}
 }
 
+// ensureRequestSessionID returns a stable request/session key for provider-side
+// continuity and prompt caching. This is intentionally independent of the local
+// session store so --no-session only disables DB persistence, not upstream cache hints.
+func ensureRequestSessionID(sessionID string, resuming bool) string {
+	if sessionID != "" || resuming {
+		return sessionID
+	}
+	return session.NewID()
+}
+
 // InitSessionStore creates a session store if enabled in config.
 // Returns the store (may be nil if disabled) and a cleanup function.
 // The cleanup function is always safe to call (handles nil store).

--- a/cmd/session_store_test.go
+++ b/cmd/session_store_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestEnsureRequestSessionID_GeneratesWithoutPersistence(t *testing.T) {
+	got := ensureRequestSessionID("", false)
+	if got == "" {
+		t.Fatal("expected non-empty request session ID")
+	}
+}
+
+func TestEnsureRequestSessionID_PreservesExistingID(t *testing.T) {
+	const existing = "sess-existing"
+	if got := ensureRequestSessionID(existing, false); got != existing {
+		t.Fatalf("ensureRequestSessionID() = %q, want %q", got, existing)
+	}
+}
+
+func TestEnsureRequestSessionID_DoesNotInventResumeID(t *testing.T) {
+	if got := ensureRequestSessionID("", true); got != "" {
+		t.Fatalf("ensureRequestSessionID() = %q, want empty string for resume without session", got)
+	}
+}
+
 func TestInitSessionStore_NoSessionFlagBypassesStore(t *testing.T) {
 	oldNoSession := noSession
 	oldSessionDB := sessionDBPath

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -163,11 +163,13 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 		}
 	}
 
-	// Create child session if store is available (before engine setup so nested agents can reference it)
-	var childSessionID string
+	// Create child session ID up front so provider-side continuity/cache hints are
+	// available even when local session persistence is disabled.
+	childSessionID := session.NewID()
+	persistChildSession := false
 	if r.store != nil {
 		childSession := &session.Session{
-			ID:         session.NewID(),
+			ID:         childSessionID,
 			ParentID:   r.parentSessionID,
 			IsSubagent: true,
 			Provider:   providerName,
@@ -184,7 +186,7 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 		if err := safeStoreOp(func() error { return r.store.Create(ctx, childSession) }); err != nil {
 			r.warn("session Create failed: %v", err)
 		} else {
-			childSessionID = childSession.ID
+			persistChildSession = true
 
 			// Save initial user prompt as first message
 			userMsg := session.NewMessage(childSessionID, llm.UserText(prompt), -1)
@@ -206,7 +208,7 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 	// Set up callbacks to save messages incrementally (after tools setup)
 	// Track when streaming starts for duration calculation
 	streamStartTime := time.Now()
-	if r.store != nil && childSessionID != "" {
+	if persistChildSession {
 		// Response callback saves assistant message immediately (before tool execution)
 		// This ensures the message is persisted even if tool execution fails/crashes
 		engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
@@ -292,7 +294,7 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 	output, err := r.runAndCollectWithCallback(ctx, engine, req, callID, cb, providerName, modelName)
 	if err != nil {
 		// Update session status on error
-		if r.store != nil && childSessionID != "" {
+		if persistChildSession {
 			if statusErr := r.store.UpdateStatus(ctx, childSessionID, session.StatusError); statusErr != nil {
 				r.warn("session UpdateStatus failed: %v", statusErr)
 			}
@@ -301,7 +303,7 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 	}
 
 	// Update session status on completion
-	if r.store != nil && childSessionID != "" {
+	if persistChildSession {
 		if statusErr := r.store.UpdateStatus(ctx, childSessionID, session.StatusComplete); statusErr != nil {
 			r.warn("session UpdateStatus failed: %v", statusErr)
 		}


### PR DESCRIPTION
## What

Decouple provider-side request session IDs from the local session store so `--no-session` only disables SQLite session persistence.

Specifically:

- add `ensureRequestSessionID()` to generate a request/session key even when the session DB is disabled
- use that request session ID in `ask` before wiring tools/subagents
- pass the same parent request session ID into `spawn_agent` wiring
- generate subagent request session IDs even when there is no backing session store
- keep DB writes/status updates gated behind successful session-store creation
- add focused tests for the new request-session-ID helper

## Why

Today `--no-session` does more than it says on the tin.

Because request `SessionID` generation was coupled to `store != nil`, disabling the session DB also stripped provider-side continuity/cache hints (`prompt_cache_key` / `session_id` in the ChatGPT path). That made long `--no-session` runs far less cache-efficient, especially for tool-heavy agent sessions.

`--no-session` should mean “don't read/write the sessions database”, not “make upstream prompt caching worse”.

## How

- move request-session-ID generation behind a helper that is independent of DB persistence
- preserve existing resume behavior by not inventing IDs for invalid resume cases
- in subagents, allocate a request session ID up front, but only persist messages/metrics/status if the store-backed session was actually created successfully

## Validation

- `gofmt -w cmd/session.go cmd/ask.go cmd/spawn_runner.go cmd/session_store_test.go`
- `go build ./...`
- `go test ./...`
