### PR TITLE
fix: stabilize tool ordering for prompt caching

### DIFF
--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/samsaffron/term-llm/internal/prompt"
 )
@@ -70,11 +71,17 @@ func (r *ToolRegistry) Unregister(name string) {
 	delete(r.tools, name)
 }
 
-// AllSpecs returns the specs for all registered tools.
+// AllSpecs returns the specs for all registered tools in deterministic name order.
 func (r *ToolRegistry) AllSpecs() []ToolSpec {
-	specs := make([]ToolSpec, 0, len(r.tools))
-	for _, tool := range r.tools {
-		specs = append(specs, tool.Spec())
+	names := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	specs := make([]ToolSpec, 0, len(names))
+	for _, name := range names {
+		specs = append(specs, r.tools[name].Spec())
 	}
 	return specs
 }

--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -1,0 +1,58 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type namedTestTool struct{ name string }
+
+func (t *namedTestTool) Spec() ToolSpec {
+	return ToolSpec{Name: t.name, Description: t.name, Schema: map[string]any{"type": "object"}}
+}
+
+func (t *namedTestTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	return TextOutput(t.name), nil
+}
+
+func (t *namedTestTool) Preview(args json.RawMessage) string { return t.name }
+
+func TestToolRegistryAllSpecsSortedByName(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&namedTestTool{name: "zeta"})
+	registry.Register(&namedTestTool{name: "alpha"})
+	registry.Register(&namedTestTool{name: "middle"})
+
+	specs := registry.AllSpecs()
+	if len(specs) != 3 {
+		t.Fatalf("len(AllSpecs()) = %d, want 3", len(specs))
+	}
+	got := []string{specs[0].Name, specs[1].Name, specs[2].Name}
+	want := []string{"alpha", "middle", "zeta"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("AllSpecs() order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestToolSpecsForRequestPreservesSortedOrderAfterFiltering(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&namedTestTool{name: "zeta"})
+	registry.Register(&namedTestTool{name: WebSearchToolName})
+	registry.Register(&namedTestTool{name: "alpha"})
+	registry.Register(&namedTestTool{name: ReadURLToolName})
+
+	specs := ToolSpecsForRequest(registry, false)
+	if len(specs) != 2 {
+		t.Fatalf("len(ToolSpecsForRequest()) = %d, want 2", len(specs))
+	}
+	got := []string{specs[0].Name, specs[1].Name}
+	want := []string{"alpha", "zeta"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ToolSpecsForRequest() order = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Make tool ordering deterministic when building request tool specs.

Specifically:

- sort `ToolRegistry.AllSpecs()` by tool name instead of relying on Go map iteration order
- add tests covering both raw `AllSpecs()` ordering and filtered `ToolSpecsForRequest()` ordering

## Why

OpenAI prompt caching requires exact prefix matches, and the tool list is part of the cacheable prefix.

We observed the same `session_id` alternating between cache hits and misses across turns because the request tool order changed from turn to turn purely due to map iteration order. That is terrible for cache efficiency and entirely self-inflicted.

This change keeps the request prefix stable so prompt caching has a fighting chance.

## How

- collect tool names from the registry map
- sort them lexicographically
- emit tool specs in that deterministic order
- verify that filtering search tools still preserves sorted order

## Validation

- `gofmt -w internal/llm/tools.go internal/llm/tools_test.go`
- `go test ./internal/llm ./cmd`
- `go build ./...`
