### PR TITLE
feat: make interrupt handling binary

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -394,7 +394,7 @@ func (s *serveServer) handleSessionInterrupt(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	actionName := "queue"
+	actionName := "interject"
 	switch action {
 	case llm.InterruptCancel:
 		actionName = "cancel"

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -723,26 +723,36 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 		return
 	}
 
-	started := time.Now().UTC()
-	_, _ = m.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobsV2RunRunning, started, run.ID)
-	_ = m.addRunEvent(run.ID, "running", "run started", map[string]any{"worker_id": m.workerID})
-
 	timeout := time.Duration(job.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	m.mu.Lock()
-	if !m.closed {
-		m.cancels[run.ID] = cancel
-	}
+	closed := m.closed
+	m.cancels[run.ID] = cancel
 	m.mu.Unlock()
+	if closed {
+		cancel()
+	}
 	defer func() {
 		cancel()
 		m.mu.Lock()
 		delete(m.cancels, run.ID)
 		m.mu.Unlock()
 	}()
+
+	started := time.Now().UTC()
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunRunning, started, run.ID, jobsV2RunClaimed)
+	if err != nil {
+		_ = m.finishRun(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("mark run running: %w", err), run.Attempt)
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return
+	}
+	_ = m.addRunEvent(run.ID, "running", "run started", map[string]any{"worker_id": m.workerID})
 
 	// Build a progress writer that writes events and flushes partial response to DB.
 	pw := func(eventType, message string, data any) {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -133,7 +133,7 @@ func (rt *serveRuntime) Interrupt(ctx context.Context, msg string, fastProvider 
 	state := rt.activeInterrupt
 	if state == nil {
 		rt.interruptMu.Unlock()
-		return llm.InterruptQueue, fmt.Errorf("session has no active stream")
+		return llm.InterruptInterject, fmt.Errorf("session has no active stream")
 	}
 	cancel := state.cancel
 	activity := llm.InterruptActivity{

--- a/internal/llm/classify.go
+++ b/internal/llm/classify.go
@@ -58,7 +58,6 @@ type InterruptAction int
 const (
 	InterruptCancel InterruptAction = iota
 	InterruptInterject
-	InterruptQueue
 )
 
 // InterruptActivity summarizes active stream state for interrupt classification.
@@ -78,7 +77,7 @@ func ClassifyInterruptImmediate(msg string) (InterruptAction, bool) {
 func classifyInterruptHeuristic(msg string) (InterruptAction, bool) {
 	normalized := strings.ToLower(strings.TrimSpace(msg))
 	if normalized == "" {
-		return InterruptQueue, true
+		return InterruptInterject, true
 	}
 
 	overrides := []string{"/stop", "/cancel", "/takeover", "stop", "cancel", "abort", "never mind", "nevermind", "forget it"}
@@ -88,7 +87,7 @@ func classifyInterruptHeuristic(msg string) (InterruptAction, bool) {
 		}
 	}
 
-	return InterruptQueue, false
+	return InterruptInterject, false
 }
 
 // ClassifyInterrupt decides how to handle a new user message while a stream is active.
@@ -98,7 +97,7 @@ func ClassifyInterrupt(ctx context.Context, fastProvider Provider, msg string, a
 		return action
 	}
 	if fastProvider == nil {
-		return InterruptQueue
+		return InterruptInterject
 	}
 
 	toolsRun := "none"
@@ -122,11 +121,10 @@ Agent has produced: %d characters so far.
 User's new message: %q
 
 Classify as one word:
-- cancel: user wants to stop current work
-- interject: user wants to add info/correction, agent should continue and incorporate
-- queue: user is starting a new topic, finish current work first
+- cancel: user wants to stop current work and replace it with this new message
+- interject: user wants to steer or correct the current work; agent should continue and incorporate it at the next legal boundary
 
-Reply with exactly one word.`,
+Reply with exactly one word. If unsure, reply interject.`,
 		agentActivity,
 		strings.TrimSpace(activity.CurrentTask),
 		toolsRun,
@@ -136,17 +134,15 @@ Reply with exactly one word.`,
 
 	decision, err := Classify(ctx, fastProvider, prompt, 3*time.Second)
 	if err != nil {
-		return InterruptQueue
+		return InterruptInterject
 	}
 
 	switch strings.TrimSpace(decision) {
 	case "cancel", "abort", "stop":
 		return InterruptCancel
-	case "interject", "inject":
+	case "interject", "inject", "queue", "wait", "later":
 		return InterruptInterject
-	case "queue", "wait", "later":
-		return InterruptQueue
 	default:
-		return InterruptQueue
+		return InterruptInterject
 	}
 }

--- a/internal/llm/classify_test.go
+++ b/internal/llm/classify_test.go
@@ -34,8 +34,8 @@ func TestClassifyInterruptExplicitCancel(t *testing.T) {
 func TestClassifyInterruptLLM(t *testing.T) {
 	provider := NewMockProvider("mock").AddTextResponse("queue")
 	a := InterruptActivity{CurrentTask: "analyzing", ActiveTool: "shell", ProseLen: 120}
-	if got := ClassifyInterrupt(context.Background(), provider, "new topic", a); got != InterruptQueue {
-		t.Fatalf("ClassifyInterrupt(queue) = %v, want InterruptQueue", got)
+	if got := ClassifyInterrupt(context.Background(), provider, "new topic", a); got != InterruptInterject {
+		t.Fatalf("ClassifyInterrupt(queue) = %v, want InterruptInterject", got)
 	}
 
 	provider = NewMockProvider("mock").AddTextResponse("interject")
@@ -52,7 +52,7 @@ func TestClassifyInterruptLLM(t *testing.T) {
 func TestClassifyInterruptFallbackOnError(t *testing.T) {
 	provider := NewMockProvider("mock").AddError(context.DeadlineExceeded)
 	got := ClassifyInterrupt(context.Background(), provider, "what about y", InterruptActivity{CurrentTask: "task"})
-	if got != InterruptQueue {
-		t.Fatalf("ClassifyInterrupt fallback = %v, want InterruptQueue", got)
+	if got != InterruptInterject {
+		t.Fatalf("ClassifyInterrupt fallback = %v, want InterruptInterject", got)
 	}
 }

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -829,13 +829,6 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 					})
 				}
 				return
-			default:
-				_, _ = bot.Send(tgbotapi.NewMessage(chatID, "📬 Got it. I’ll finish this task first, then handle your new request."))
-				select {
-				case <-doneCh:
-				case <-ctx.Done():
-					return
-				}
 			}
 		case <-ctx.Done():
 			return

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -98,11 +98,11 @@ type Model struct {
 	localTools          []string // Names of enabled local tools (read, write, etc.)
 	toolsStr            string   // Original tools setting (for session persistence)
 	mcpStr              string   // Original MCP setting (for session persistence)
-	pendingInterjection string   // Queued interjection text waiting to be injected
-	queuedInterjection  string   // Deferred follow-up to send after the current stream completes
+	pendingInterjection string   // Interrupt text waiting to be injected or cancelled
 	interruptRequestSeq uint64   // Monotonic sequence for async interrupt classification
 	activeInterruptSeq  uint64   // Currently active async interrupt classification request
-	pendingInterruptUI  string   // UI state: "", "deciding", "queued", "interject"
+	pendingInterruptUI  string   // UI state: "", "deciding", "interject"
+	interruptNotice     string   // One-line UI notice for recent interrupt actions
 	// MCP (Model Context Protocol)
 	mcpManager *mcp.Manager
 	maxTurns   int
@@ -1081,17 +1081,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Auto-save session
 			cmds = append(cmds, m.saveSessionCmd())
-
-			// Restore any queued follow-up to the composer when the current stream completes.
-			// Do not auto-send it: user-authored text should remain visible and editable.
-			if m.queuedInterjection != "" && m.autoSendQueue == nil {
-				next := m.queuedInterjection
-				m.activeInterruptSeq = 0
-				m.queuedInterjection = ""
-				m.pendingInterjection = ""
-				m.pendingInterruptUI = ""
-				m.setTextareaValue(next)
-			}
 
 			// In auto-send mode, check if there are more messages to send
 			if m.autoSendQueue != nil {

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -466,7 +466,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if m.fastProvider == nil {
-				m.applyInterruptAction(content, llm.InterruptQueue)
+				m.applyInterruptAction(content, llm.InterruptInterject)
 				return m, nil
 			}
 
@@ -680,7 +680,7 @@ func (m *Model) queueInterruptClassification(content string) tea.Cmd {
 	m.activeInterruptSeq = requestID
 	m.pendingInterjection = content
 	m.pendingInterruptUI = "deciding"
-	m.queuedInterjection = ""
+	m.interruptNotice = ""
 	m.setTextareaValue("")
 
 	provider := m.fastProvider
@@ -703,18 +703,15 @@ func (m *Model) applyInterruptAction(content string, action llm.InterruptAction)
 	case llm.InterruptCancel:
 		m.pendingInterjection = ""
 		m.pendingInterruptUI = ""
-		m.queuedInterjection = ""
+		m.interruptNotice = "✕ cancelled current response — draft restored below"
 		m.phase = "Stopping..."
+		m.setTextareaValue(content)
 		if m.streamCancelFunc != nil {
 			m.streamCancelFunc()
 		}
 	case llm.InterruptInterject:
 		m.pendingInterruptUI = "interject"
-		m.queuedInterjection = ""
 		m.engine.Interject(content)
-	default:
-		m.pendingInterruptUI = "queued"
-		m.queuedInterjection = content
 	}
 }
 
@@ -742,10 +739,6 @@ func (m *Model) restorePendingInterjectionDraft() {
 	}
 	if residual := m.engine.DrainInterjection(); residual != "" {
 		m.setTextareaValue(residual)
-		return
-	}
-	if m.queuedInterjection != "" {
-		m.setTextareaValue(m.queuedInterjection)
 		return
 	}
 	if m.pendingInterjection != "" && (m.pendingInterruptUI == "interject" || m.pendingInterruptUI == "deciding") {

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -36,12 +36,11 @@ func TestHandleKeyMsg_SessionListEnterResumesSession(t *testing.T) {
 	}
 }
 
-func TestHandleKeyMsg_StreamingCancelInterjectionClearsComposerAndShowsStopping(t *testing.T) {
+func TestHandleKeyMsg_StreamingCancelInterjectionRestoresComposerAndShowsStopping(t *testing.T) {
 	m := newTestChatModel(false)
 	m.streaming = true
 	m.phase = "Running shell sleep"
 	m.pendingInterjection = "old"
-	m.queuedInterjection = "old"
 	m.setTextareaValue("stop sleeping")
 
 	cancelCalls := 0
@@ -54,17 +53,17 @@ func TestHandleKeyMsg_StreamingCancelInterjectionClearsComposerAndShowsStopping(
 	if cancelCalls != 1 {
 		t.Fatalf("expected stream cancel to be called once, got %d", cancelCalls)
 	}
-	if got := m.textarea.Value(); got != "" {
-		t.Fatalf("expected textarea to be cleared after cancel interjection, got %q", got)
+	if got := m.textarea.Value(); got != "stop sleeping" {
+		t.Fatalf("expected textarea draft restored after cancel interjection, got %q", got)
 	}
 	if m.pendingInterjection != "" {
 		t.Fatalf("expected pendingInterjection to be cleared, got %q", m.pendingInterjection)
 	}
-	if m.queuedInterjection != "" {
-		t.Fatalf("expected queuedInterjection to be cleared, got %q", m.queuedInterjection)
-	}
 	if m.phase != "Stopping..." {
 		t.Fatalf("expected stopping phase after cancel interjection, got %q", m.phase)
+	}
+	if got := m.interruptNotice; got == "" {
+		t.Fatal("expected interrupt notice after cancellation")
 	}
 }
 
@@ -133,7 +132,7 @@ func TestHandleInterruptClassified_StreamAlreadyFinishedRestoresDraft(t *testing
 	_, cmd := m.handleInterruptClassified(interruptClassifiedMsg{
 		RequestID: 7,
 		Content:   "keep sleeping",
-		Action:    llm.InterruptQueue,
+		Action:    llm.InterruptInterject,
 	})
 	if cmd != nil {
 		t.Fatal("expected no follow-up command when restoring draft")
@@ -152,37 +151,6 @@ func TestHandleInterruptClassified_StreamAlreadyFinishedRestoresDraft(t *testing
 	}
 	if got := len(m.messages); got != 0 {
 		t.Fatalf("expected restored draft not to auto-send, got %d messages", got)
-	}
-}
-
-func TestStreamDone_QueuedInterjectionRestoresDraftWithoutSending(t *testing.T) {
-	m := newTestChatModel(false)
-	m.streaming = true
-	m.queuedInterjection = "queue this for later"
-	m.pendingInterjection = "queue this for later"
-	m.pendingInterruptUI = "queued"
-
-	_, cmd := m.Update(streamEventMsg{event: ui.DoneEvent(0)})
-	if cmd == nil {
-		t.Fatal("expected command batch from stream completion")
-	}
-	if m.streaming {
-		t.Fatal("expected streaming to stop after done event")
-	}
-	if got := m.textarea.Value(); got != "queue this for later" {
-		t.Fatalf("expected queued interjection restored to composer, got %q", got)
-	}
-	if got := m.queuedInterjection; got != "" {
-		t.Fatalf("expected queued interjection state cleared, got %q", got)
-	}
-	if got := m.pendingInterjection; got != "" {
-		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
-	}
-	if got := m.pendingInterruptUI; got != "" {
-		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
-	}
-	if got := len(m.messages); got != 0 {
-		t.Fatalf("expected queued interjection not to auto-send, got %d messages", got)
 	}
 }
 

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -367,18 +367,23 @@ func (m *Model) renderInputInline() string {
 	separator := lipgloss.NewStyle().Foreground(theme.Muted).Render(strings.Repeat("─", m.width))
 	b.WriteString(separator)
 
-	// Show pending interjection indicator (queued message during streaming)
+	// Show recent interrupt notice above the composer.
+	if m.interruptNotice != "" {
+		noticeStyle := lipgloss.NewStyle().Foreground(theme.Muted).Italic(true)
+		b.WriteString("\n")
+		b.WriteString(noticeStyle.Render("  " + m.interruptNotice))
+	}
+
+	// Show pending interjection indicator while interrupt classification/injection is in flight.
 	if m.pendingInterjection != "" {
 		pendingStyle := lipgloss.NewStyle().Foreground(theme.Muted).Italic(true)
 		pendingText := m.pendingInterjection
-		label := "queued"
+		label := "will incorporate"
 		switch m.pendingInterruptUI {
 		case "deciding":
 			label = "deciding…"
 		case "interject":
 			label = "will incorporate"
-		case "queued":
-			label = "queued"
 		}
 		// Truncate long messages to fit the terminal width
 		maxLen := m.width - 20 // account for prefix/suffix

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -389,8 +389,21 @@ func TestRenderInputInline_ShowsPendingInterjection(t *testing.T) {
 	if !strings.Contains(stripped, "stop doing that") {
 		t.Fatalf("expected interjection text in output, got %q", stripped)
 	}
-	if !strings.Contains(stripped, "queued") {
-		t.Fatalf("expected (queued) label in output, got %q", stripped)
+	if !strings.Contains(stripped, "will incorporate") {
+		t.Fatalf("expected inject label in output, got %q", stripped)
+	}
+}
+
+func TestRenderInputInline_ShowsInterruptNotice(t *testing.T) {
+	m := newTestChatModel(false)
+	m.interruptNotice = "✕ cancelled current response — draft restored below"
+	m.width = 80
+
+	output := m.renderInputInline()
+	stripped := ui.StripANSI(output)
+
+	if !strings.Contains(stripped, "cancelled current response") {
+		t.Fatalf("expected interrupt notice in output, got %q", stripped)
 	}
 }
 
@@ -405,8 +418,8 @@ func TestRenderInputInline_HidesPendingWhenEmpty(t *testing.T) {
 	if strings.Contains(stripped, "⏳") {
 		t.Fatalf("expected no ⏳ when pendingInterjection is empty, got %q", stripped)
 	}
-	if strings.Contains(stripped, "queued") {
-		t.Fatalf("expected no (queued) when pendingInterjection is empty, got %q", stripped)
+	if strings.Contains(stripped, "will incorporate") {
+		t.Fatalf("expected no inject label when pendingInterjection is empty, got %q", stripped)
 	}
 }
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -16,6 +16,8 @@ import (
 )
 
 func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
+	m.interruptNotice = ""
+
 	// Build the full message content including file attachments
 	fullContent := content
 	var fileNames []string


### PR DESCRIPTION
## What

Switch interrupt handling to a binary model:

- remove the old queue interrupt classification
- treat non-cancel interrupts as interjections/injections at the next legal boundary
- make cancel restore the draft to the composer in the chat TUI with a visible cancellation notice
- align serve and Telegram interrupt handling with the new two-way classification

Also includes a small jobs race fix that surfaced while running the full test suite:

- avoid promoting a cancelled `claimed` run to `running`
- register the cancel func before execution starts
- skip execution if the `claimed -> running` transition no longer succeeds

## Why

The old `queue` path was too late and too vague:

- it did not inject at the next tool/result boundary
- it did not appear in the active stream
- cancel interrupts could drop the replacement text from the composer/session flow

The new model is simpler and matches the intended UX:

- `interject` means steer the active run as soon as it legally can
- `cancel` means stop the run and keep the replacement text in the composer

The jobs fix is included because the broader verification exposed a cancellation race in `TestJobsV2ManualTriggerAndCancel`, and this branch now passes `go build ./...` and `go test ./...` cleanly.

## Testing

- `go build ./...`
- `go test ./internal/tui/chat`
- `go test ./internal/llm`
- `go test ./internal/serve`
- `go test ./cmd/...`
- `go test ./cmd -run TestJobsV2ManualTriggerAndCancel -count=100`
- `go test ./...`
