### PR TITLE
fix: serve web images under /ui

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -574,7 +574,7 @@ func (s *serveServer) Start() error {
 		mux.HandleFunc("/v2/runs/", s.auth(s.cors(s.handleRunV2ByID)))
 	}
 
-	mux.HandleFunc("/images/", s.auth(s.cors(s.handleImage)))
+	mux.HandleFunc("/ui/images/", s.auth(s.cors(s.handleImage)))
 	mux.HandleFunc("/v1/sessions/", s.auth(s.cors(s.handleSessionByID)))
 
 	if s.store != nil {

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -78,7 +78,7 @@ func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filename := strings.TrimPrefix(r.URL.Path, "/images/")
+	filename := strings.TrimPrefix(r.URL.Path, "/ui/images/")
 	if filename == "" || strings.Contains(filename, "/") || strings.Contains(filename, "..") {
 		http.NotFound(w, r)
 		return
@@ -113,7 +113,7 @@ func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {
 // ensureImageServeable ensures the given image path is under the serveable
 // image output directory. If the file is already there, the path is returned
 // as-is. Otherwise the file is copied into the output dir so that the
-// /images/ handler can serve it. Returns the serveable path and true on
+// /ui/images/ handler can serve it. Returns the serveable path and true on
 // success, or ("", false) if the image could not be made serveable.
 func (s *serveServer) ensureImageServeable(imgPath string) (string, bool) {
 	outputDir := image.ExpandPath(s.cfgRef.Image.OutputDir)

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -807,7 +807,7 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 			imageURLs := make([]string, 0, len(ev.ToolImages))
 			for _, imgPath := range ev.ToolImages {
 				if served, ok := s.ensureImageServeable(imgPath); ok {
-					imageURLs = append(imageURLs, "/images/"+filepath.Base(served))
+					imageURLs = append(imageURLs, "/ui/images/"+filepath.Base(served))
 				}
 			}
 			if len(imageURLs) > 0 {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -897,7 +897,7 @@ func TestServeAuthMiddleware_CookieFallback(t *testing.T) {
 	})
 
 	// No credentials → 401
-	req := httptest.NewRequest(http.MethodGet, "/images/test.png", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/images/test.png", nil)
 	rr := httptest.NewRecorder()
 	h(rr, req)
 	if rr.Code != http.StatusUnauthorized {
@@ -905,7 +905,7 @@ func TestServeAuthMiddleware_CookieFallback(t *testing.T) {
 	}
 
 	// Valid cookie → allowed
-	req = httptest.NewRequest(http.MethodGet, "/images/test.png", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/test.png", nil)
 	req.AddCookie(&http.Cookie{Name: "term_llm_token", Value: "secret"})
 	rr = httptest.NewRecorder()
 	h(rr, req)
@@ -914,7 +914,7 @@ func TestServeAuthMiddleware_CookieFallback(t *testing.T) {
 	}
 
 	// Wrong cookie → 401
-	req = httptest.NewRequest(http.MethodGet, "/images/test.png", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/test.png", nil)
 	req.AddCookie(&http.Cookie{Name: "term_llm_token", Value: "wrong"})
 	rr = httptest.NewRecorder()
 	h(rr, req)
@@ -923,7 +923,7 @@ func TestServeAuthMiddleware_CookieFallback(t *testing.T) {
 	}
 
 	// Bearer still works
-	req = httptest.NewRequest(http.MethodGet, "/images/test.png", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/test.png", nil)
 	req.Header.Set("Authorization", "Bearer secret")
 	rr = httptest.NewRecorder()
 	h(rr, req)
@@ -945,7 +945,7 @@ func TestServeAuthMiddleware_CookieFallback(t *testing.T) {
 	h2 := srv2.auth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
-	req = httptest.NewRequest(http.MethodGet, "/images/test.png", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/test.png", nil)
 	req.AddCookie(&http.Cookie{Name: "term_llm_token", Value: "se%2Bcret%2Fval%3D"})
 	rr = httptest.NewRecorder()
 	h2(rr, req)
@@ -964,7 +964,7 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	srv.cfgRef.Image.OutputDir = dir
 
 	// Valid file
-	req := httptest.NewRequest(http.MethodGet, "/images/cat.png", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/images/cat.png", nil)
 	rr := httptest.NewRecorder()
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusOK {
@@ -981,7 +981,7 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	}
 
 	// Path traversal with ..
-	req = httptest.NewRequest(http.MethodGet, "/images/..%2Fetc%2Fpasswd", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/..%2Fetc%2Fpasswd", nil)
 	rr = httptest.NewRecorder()
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusNotFound {
@@ -989,7 +989,7 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	}
 
 	// Empty filename
-	req = httptest.NewRequest(http.MethodGet, "/images/", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/", nil)
 	rr = httptest.NewRecorder()
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusNotFound {
@@ -997,7 +997,7 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	}
 
 	// Nonexistent file
-	req = httptest.NewRequest(http.MethodGet, "/images/nope.png", nil)
+	req = httptest.NewRequest(http.MethodGet, "/ui/images/nope.png", nil)
 	rr = httptest.NewRecorder()
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusNotFound {
@@ -1061,7 +1061,7 @@ func TestEnsureImageServeable_CopiesExternalFile(t *testing.T) {
 		t.Fatal("ensureImageServeable should succeed for second external copy")
 	}
 	copiedName := filepath.Base(copied)
-	req := httptest.NewRequest(http.MethodGet, "/images/"+copiedName, nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/images/"+copiedName, nil)
 	rr := httptest.NewRecorder()
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusOK {

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -35,9 +35,9 @@ const state = {
   approval: null,
   serviceWorkerRegistration: null
 };
-// Ensure cookie is set on load so <img> requests to /images/ can authenticate
+// Ensure cookie is set on load so <img> requests to /ui/images/ can authenticate
 if (state.token) {
-  document.cookie = `term_llm_token=${encodeURIComponent(state.token)}; path=/images; SameSite=Strict; max-age=31536000`;
+  document.cookie = `term_llm_token=${encodeURIComponent(state.token)}; path=/ui/images; SameSite=Strict; max-age=31536000`;
 }
 
 const elements = {
@@ -128,9 +128,9 @@ const sanitizeInterruptState = (value) => {
 
 const syncTokenCookie = (token) => {
   if (token) {
-    document.cookie = `term_llm_token=${encodeURIComponent(token)}; path=/images; SameSite=Strict; max-age=31536000`;
+    document.cookie = `term_llm_token=${encodeURIComponent(token)}; path=/ui/images; SameSite=Strict; max-age=31536000`;
   } else {
-    document.cookie = 'term_llm_token=; path=/images; SameSite=Strict; max-age=0';
+    document.cookie = 'term_llm_token=; path=/ui/images; SameSite=Strict; max-age=0';
   }
 };
 


### PR DESCRIPTION
## What

Move web-served images from `/images/...` to `/ui/images/...`.

This updates:

- the HTTP route registration
- the image handler path parsing
- generated image URLs emitted by response runs
- the auth cookie path used by the web UI for image requests
- the serve tests to match the new route

## Why

When the app is mounted behind a proxy or subpath, having the UI under `/ui/...` but images under root `/images/...` makes proxying and rewrite rules unnecessarily awkward.

Keeping both UI assets and image requests under `/ui/` means the proxy only needs to forward a single subtree.

## Validation

- `go test ./...`
