### PR TITLE
fix: mount jobs-only serve routes at root

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -643,9 +643,35 @@ type serveServer struct {
 }
 
 func (s *serveServer) Start() error {
+	s.server = &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", s.cfg.host, s.cfg.port),
+		Handler: s.httpHandler(),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := s.server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("start server: %w", err)
+		}
+		return nil
+	case <-time.After(50 * time.Millisecond):
+		return nil
+	}
+}
+
+func (s *serveServer) httpHandler() http.Handler {
 	// Inner mux: all routes registered at their natural paths.
-	// basePath is stripped by http.StripPrefix on the outer mux, so
-	// handlers see /v1/..., /images/..., / etc. without the prefix.
+	// basePath is stripped by http.StripPrefix on the outer mux when mounted,
+	// so handlers see /v1/..., /images/..., / etc. without the prefix.
 	inner := http.NewServeMux()
 
 	inner.HandleFunc("/healthz", s.handleHealth)
@@ -672,6 +698,13 @@ func (s *serveServer) Start() error {
 		inner.HandleFunc("/", s.cors(s.handleUI)) // catch-all SPA
 	}
 
+	// Jobs-only serve instances have no UI surface, so mount at root and keep
+	// the canonical /v2/* API paths. The shared base-path wrapper is still used
+	// for web/UI surfaces where the browser and API must live under one prefix.
+	if s.jobsV2 != nil && !s.cfg.ui {
+		return inner
+	}
+
 	// Outer mux: mount everything under basePath.
 	// Requests to basePath/ are handled by StripPrefix → inner.
 	// Go's ServeMux auto-redirects basePath (no slash) → basePath/.
@@ -685,29 +718,7 @@ func (s *serveServer) Start() error {
 		}))
 	}
 
-	s.server = &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", s.cfg.host, s.cfg.port),
-		Handler: mux,
-	}
-
-	errCh := make(chan error, 1)
-	go func() {
-		err := s.server.ListenAndServe()
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
-		}
-		close(errCh)
-	}()
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return fmt.Errorf("start server: %w", err)
-		}
-		return nil
-	case <-time.After(50 * time.Millisecond):
-		return nil
-	}
+	return mux
 }
 
 func (s *serveServer) Stop(ctx context.Context) error {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -348,6 +348,52 @@ func TestCustomBasePath_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestServeHTTPHandler_MountsJobsOnlyAtRoot(t *testing.T) {
+	srv := &serveServer{
+		cfg:    serveServerConfig{basePath: "/ui"},
+		jobsV2: &jobsV2Manager{},
+	}
+	h := srv.httpHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/healthz status = %d, want 200", rr.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/ui/healthz", nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("/ui/healthz status = %d, want 404", rr.Code)
+	}
+}
+
+func TestServeHTTPHandler_MountsWebUnderBasePath(t *testing.T) {
+	srv := &serveServer{
+		cfg: serveServerConfig{ui: true, basePath: "/chat"},
+	}
+	h := srv.httpHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/chat/healthz", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/chat/healthz status = %d, want 200", rr.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("/healthz status = %d, want 307", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "/chat/" {
+		t.Fatalf("/healthz redirect location = %q, want %q", loc, "/chat/")
+	}
+}
+
 func TestNormalizeBasePath_ProducesValidRoutes(t *testing.T) {
 	// Verify that normalizeBasePath output always produces valid route helpers
 	// and that handleUI/handleImage parse paths correctly.


### PR DESCRIPTION
## What

Fix `serve` so jobs-only instances mount their HTTP routes at the canonical root paths instead of being forced under `base_path`.

- refactor `serveServer.Start()` to build its mux via `httpHandler()`
- mount jobs-only servers directly at root when `jobsV2` is enabled and the UI is not
- keep the existing `base_path` mount behavior for web/UI surfaces
- add tests covering jobs-only root mounting and web base-path mounting

## Why

After the route mounting refactor, a jobs-only service inherited the shared `base_path` wrapper and ended up serving on `/ui/v2/*` by default.

That broke the expected jobs API shape and made things like:

- `term-llm serve jobs`
- helper scripts hitting `/v2/jobs`
- config assumptions about a jobs-only service

all more awkward than they need to be.

Jobs-only services have no browser/UI surface to keep under a shared prefix, so they should continue serving at:

- `/v2/jobs`
- `/v2/runs`
- `/healthz`

while web/UI instances still use `base_path` as before.

## Testing

- `go build ./...`
- `go test ./cmd/...`
- `go test ./...`
