### PR TITLE
fix: auto-enroll web push after permission grant

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -268,9 +268,27 @@ const updateDocumentTitle = () => {
 
 const isStandalone = () => window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
 
+const syncNotificationPermissionState = () => {
+  if (typeof Notification === 'undefined') return;
+  if (Notification.permission === 'granted') {
+    state.notificationsEnabled = true;
+    localStorage.setItem(STORAGE_KEYS.notificationsEnabled, '1');
+  } else if (Notification.permission === 'denied') {
+    state.notificationsEnabled = false;
+    localStorage.setItem(STORAGE_KEYS.notificationsEnabled, '0');
+  }
+};
+
+const shouldAutoSubscribeToPush = () => (
+  typeof Notification !== 'undefined' &&
+  Notification.permission === 'granted' &&
+  !!state.token
+);
+
 const refreshNotificationUI = () => {
   if (!elements.notificationStatus || !elements.notificationBtn) return;
   const supported = typeof Notification !== 'undefined';
+  syncNotificationPermissionState();
   if (!supported) {
     elements.notificationStatus.textContent = 'This browser does not support notifications.';
     elements.notificationBtn.disabled = true;
@@ -366,15 +384,13 @@ const requestNotificationPermission = async () => {
     return 'unsupported';
   }
   if (Notification.permission === 'granted') {
-    state.notificationsEnabled = true;
-    localStorage.setItem(STORAGE_KEYS.notificationsEnabled, '1');
+    syncNotificationPermissionState();
     subscribeToPush();
     refreshNotificationUI();
     return 'granted';
   }
   const permission = await Notification.requestPermission();
-  state.notificationsEnabled = permission === 'granted';
-  localStorage.setItem(STORAGE_KEYS.notificationsEnabled, state.notificationsEnabled ? '1' : '0');
+  syncNotificationPermissionState();
   if (permission === 'granted') {
     subscribeToPush();
   }
@@ -661,6 +677,7 @@ Object.assign(app, {
   refreshNotificationUI,
   registerServiceWorker,
   subscribeToPush,
+  shouldAutoSubscribeToPush,
   requestNotificationPermission,
   maybeNotifyResponseComplete,
   sessionIdFromURL,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -9,7 +9,8 @@ const {
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderModelOptions,
   autoGrowPrompt, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
   connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, isNearBottom,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI, requestNotificationPermission
+  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
+  requestNotificationPermission, shouldAutoSubscribeToPush
 } = app;
 let sessionStatePollTimer = null;
 
@@ -356,8 +357,10 @@ const initialize = async () => {
     // Merge server-side sessions after successful auth
     await mergeServerSessions();
 
-    // Retry push enrollment now that auth is confirmed
-    if (state.notificationsEnabled && typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+    // Retry push enrollment now that auth is confirmed. Also recover automatically
+    // when the browser permission is already granted but the old localStorage flag
+    // was never set (for example after earlier installs or app updates).
+    if (shouldAutoSubscribeToPush()) {
       subscribeToPush();
     }
 

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -7,7 +7,7 @@ const {
   getActiveSession, ensureActiveSession, createSession, findMessageElement, scrollToBottom, setConnectionState,
   persistAndRefreshShell, updateSessionUsageDisplay, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  subscribeToPush
+  subscribeToPush, shouldAutoSubscribeToPush
 } = app;
 
 // ===== Network helpers =====
@@ -1216,8 +1216,9 @@ const connectToken = async () => {
     state.authRequired = false;
     closeAuthModal();
 
-    // Retry push enrollment now that we have a valid token
-    if (state.notificationsEnabled && typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+    // Retry push enrollment now that we have a valid token. Also recover if the
+    // browser permission was already granted but the old client-side flag was missing.
+    if (shouldAutoSubscribeToPush()) {
       subscribeToPush();
     }
 


### PR DESCRIPTION
## What

Fix the web chat PWA so it automatically re-enrolls for web push when the browser permission is already granted.

- add a small helper to sync the local notification flag from the real browser permission state
- auto-treat `Notification.permission === 'granted'` as notifications enabled
- retry push subscription automatically after startup/auth success whenever permission is already granted and a token exists
- keep the explicit Enable button flow unchanged for first-time permission requests

## Why

The current PWA can get stuck in an awkward state where:

- iOS/browser notification permission is already granted
- but the client-side `notificationsEnabled` localStorage flag was never set
- so reopening the app never calls `subscribeToPush()` again
- and no push subscription is ever written to the server DB

That makes the UX look broken: opening the installed PWA does nothing, even though permission may already be granted.

This change makes the app recover automatically from that state without requiring a reinstall or another permission prompt.

## Testing

- `go test ./...`
