### PR TITLE
fix: normalize web push VAPID subject

### DIFF
--- a/cmd/notify_web.go
+++ b/cmd/notify_web.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/samsaffron/term-llm/internal/config"
@@ -53,6 +54,18 @@ func runNotifyWeb(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func normalizeWebPushSubject(raw string) string {
+	subject := strings.TrimSpace(raw)
+	if subject == "" {
+		return "https://github.com/samsaffron/term-llm"
+	}
+	lower := strings.ToLower(subject)
+	if strings.HasPrefix(lower, "mailto:") {
+		return strings.TrimSpace(subject[len("mailto:"):])
+	}
+	return subject
+}
+
 // sendWebPushAll sends a push notification to all stored subscriptions.
 // Returns the number of successful sends and a list of error strings.
 func sendWebPushAll(ctx context.Context, cfg *config.Config, message string, errWriter io.Writer) (int, []string) {
@@ -75,10 +88,7 @@ func sendWebPushAll(ctx context.Context, cfg *config.Config, message string, err
 		"body":  message,
 	})
 
-	subject := cfg.Serve.WebPush.Subject
-	if subject == "" {
-		subject = "mailto:webpush@term-llm.local"
-	}
+	subject := normalizeWebPushSubject(cfg.Serve.WebPush.Subject)
 
 	opts := &webpush.Options{
 		VAPIDPublicKey:  cfg.Serve.WebPush.VAPIDPublicKey,

--- a/cmd/notify_web_test.go
+++ b/cmd/notify_web_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestNormalizeWebPushSubject(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty uses https default", input: "", want: "https://github.com/samsaffron/term-llm"},
+		{name: "whitespace empty uses https default", input: "   ", want: "https://github.com/samsaffron/term-llm"},
+		{name: "bare email kept", input: "test@example.com", want: "test@example.com"},
+		{name: "mailto stripped once", input: "mailto:test@example.com", want: "test@example.com"},
+		{name: "mailto stripped case insensitive", input: "MAILTO:test@example.com", want: "test@example.com"},
+		{name: "https URL kept", input: "https://example.com", want: "https://example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeWebPushSubject(tt.input); got != tt.want {
+				t.Fatalf("normalizeWebPushSubject(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fix web push VAPID subject handling so Safari/iPhone subscriptions do not fail with `403 {"reason":"BadJwtToken"}`.

- normalize configured web push subjects before passing them to `webpush-go`
- strip an explicit `mailto:` prefix so the library does not prepend `mailto:` a second time
- switch the empty default subject to a valid HTTPS URL instead of the old `mailto:webpush@term-llm.local`
- add unit coverage for empty, bare-email, explicit-`mailto:`, and HTTPS subjects

## Why

`webpush-go` already prepends `mailto:` for any non-HTTPS subscriber value.

That means a configured subject like:

- `mailto:jarvis@wasnotwas.com`

turns into:

- `mailto:mailto:jarvis@wasnotwas.com`

inside the JWT.

Safari/APNs rejects that with:

- `403 {"reason":"BadJwtToken"}`

The old empty fallback was also poor for Safari because it used:

- `mailto:webpush@term-llm.local`

which both double-prefixed and used a `.local` address.

## Testing

- `go test ./cmd/...`
- `go test ./...`
