### PR TITLE
feat: add web voice notes and RTL support

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -74,6 +74,7 @@ Examples:
 All HTTP routes are mounted under --base-path (default /ui):
   POST {base}/v1/responses
   POST {base}/v1/chat/completions
+  POST {base}/v1/transcribe
   GET  {base}/v1/models
   GET  {base}/healthz
   GET  {base}/                       (web UI)
@@ -679,6 +680,7 @@ func (s *serveServer) httpHandler() http.Handler {
 	inner.HandleFunc("/v1/responses", s.auth(s.cors(s.handleResponses)))
 	inner.HandleFunc("/v1/responses/", s.auth(s.cors(s.handleResponseByID)))
 	inner.HandleFunc("/v1/chat/completions", s.auth(s.cors(s.handleChatCompletions)))
+	inner.HandleFunc("/v1/transcribe", s.auth(s.cors(s.handleTranscribe)))
 	if s.jobsV2 != nil {
 		inner.HandleFunc("/v2/jobs", s.auth(s.cors(s.handleJobsV2)))
 		inner.HandleFunc("/v2/jobs/", s.auth(s.cors(s.handleJobV2ByID)))

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/ecdh"
 	"crypto/rand"
@@ -9,8 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1429,6 +1432,113 @@ func TestHandleSessions_ListsFromStore(t *testing.T) {
 	}
 	if body.Sessions[0].Summary != "hello world" {
 		t.Fatalf("summary = %q, want %q", body.Sessions[0].Summary, "hello world")
+	}
+}
+
+func TestHandleTranscribe_Success(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/audio/transcriptions" {
+			t.Fatalf("path = %q, want /audio/transcriptions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("authorization = %q, want Bearer test-key", got)
+		}
+		if err := r.ParseMultipartForm(2 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		f, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("FormFile: %v", err)
+		}
+		defer f.Close()
+		if header.Filename == "" {
+			t.Fatal("expected filename")
+		}
+		data, err := io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if string(data) != "fake audio" {
+			t.Fatalf("audio payload = %q, want fake audio", string(data))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"text": "hello from audio"})
+	}))
+	defer upstream.Close()
+
+	srv := &serveServer{cfgRef: &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"openai": {
+				ResolvedAPIKey: "test-key",
+				BaseURL:        upstream.URL,
+			},
+		},
+	}}
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("file", "voice-note.webm")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write([]byte("fake audio")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rr := httptest.NewRecorder()
+
+	srv.handleTranscribe(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rr.Code, rr.Body.String())
+	}
+
+	var payload struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Text != "hello from audio" {
+		t.Fatalf("text = %q, want %q", payload.Text, "hello from audio")
+	}
+}
+
+func TestHandleTranscribe_RejectsUnsupportedType(t *testing.T) {
+	srv := &serveServer{cfgRef: &config.Config{}}
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": {`form-data; name="file"; filename="voice-note.bin"`},
+		"Content-Type":        {"application/octet-stream"},
+	})
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	if _, err := fw.Write([]byte("nope")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rr := httptest.NewRecorder()
+
+	srv.handleTranscribe(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "unsupported") {
+		t.Fatalf("body = %q, want unsupported error", rr.Body.String())
 	}
 }
 

--- a/cmd/serve_transcribe.go
+++ b/cmd/serve_transcribe.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+const maxVoiceUploadBytes = 25 << 20 // 25 MB
+
+func audioExtensionForContentType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.ToLower(contentType))
+	}
+	switch strings.ToLower(mediaType) {
+	case "audio/webm":
+		return ".webm"
+	case "audio/ogg", "application/ogg":
+		return ".ogg"
+	case "audio/wav", "audio/x-wav", "audio/wave":
+		return ".wav"
+	case "audio/mp4", "audio/m4a", "video/mp4":
+		return ".m4a"
+	case "audio/mpeg", "audio/mp3":
+		return ".mp3"
+	case "audio/flac", "audio/x-flac":
+		return ".flac"
+	default:
+		return ""
+	}
+}
+
+func normalizeAudioUploadName(filename, contentType string) (string, error) {
+	name := strings.TrimSpace(filepath.Base(filename))
+	if name == "" || name == "." || name == "/" {
+		name = "voice-note"
+	}
+
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == "" {
+		ext = audioExtensionForContentType(contentType)
+		if ext == "" {
+			return "", fmt.Errorf("unsupported audio content type %q", contentType)
+		}
+		name += ext
+	}
+
+	if _, err := detectAudioMimeType(name); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+func (s *serveServer) handleTranscribe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxVoiceUploadBytes)
+	if err := r.ParseMultipartForm(maxVoiceUploadBytes); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "request must be multipart/form-data with an audio file")
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "file is required")
+		return
+	}
+	defer file.Close()
+
+	filename, err := normalizeAudioUploadName(header.Filename, header.Header.Get("Content-Type"))
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	tempFile, err := os.CreateTemp("", "term-llm-transcribe-*"+filepath.Ext(filename))
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to create temporary upload")
+		return
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	written, err := io.Copy(tempFile, file)
+	if closeErr := tempFile.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to store uploaded audio")
+		return
+	}
+	if written == 0 {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "audio file is empty")
+		return
+	}
+
+	transcript, err := llm.TranscribeWithConfig(r.Context(), s.cfgRef, tempPath, strings.TrimSpace(r.FormValue("language")), "")
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"text": strings.TrimSpace(transcript)})
+}

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -37,7 +37,20 @@ const state = {
   attachments: [],
   askUser: null,
   approval: null,
-  serviceWorkerRegistration: null
+  serviceWorkerRegistration: null,
+  voice: {
+    supported: typeof window !== 'undefined' && typeof navigator !== 'undefined' && !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia) && typeof window.MediaRecorder !== 'undefined',
+    recording: false,
+    transcribing: false,
+    recorder: null,
+    stream: null,
+    chunks: [],
+    timerId: null,
+    startedAt: 0,
+    cancelOnStop: false,
+    mimeType: '',
+    status: ''
+  }
 };
 // Ensure cookie is set on load so <img> requests to basePath/images/ can authenticate
 if (state.token) {
@@ -77,6 +90,8 @@ const elements = {
   attachBtn: document.getElementById('attachBtn'),
   fileInput: document.getElementById('fileInput'),
   attachmentsStrip: document.getElementById('attachmentsStrip'),
+  voiceStatus: document.getElementById('voiceStatus'),
+  voiceBtn: document.getElementById('voiceBtn'),
   dropOverlay: document.getElementById('dropOverlay'),
   headerStats: document.getElementById('headerStats'),
   modelSelect: document.getElementById('modelSelect'),

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -8,6 +8,29 @@ const {
   updateSessionUsageDisplay, updateURL
 } = app;
 
+const directionForText = (value) => {
+  const text = String(value || '');
+  const strongChars = text.match(/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F\u0590-\u08FF]/g);
+  if (!strongChars || strongChars.length === 0) return 'auto';
+  for (const ch of strongChars) {
+    if (/[\u0590-\u08FF]/.test(ch)) return 'rtl';
+    if (/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F]/.test(ch)) return 'ltr';
+  }
+  return 'auto';
+};
+
+const applyTextDirection = (element, value) => {
+  if (!element) return;
+  const dir = directionForText(value);
+  if (dir === 'auto') {
+    element.setAttribute('dir', 'auto');
+    element.classList.remove('rtl');
+    return;
+  }
+  element.setAttribute('dir', dir);
+  element.classList.toggle('rtl', dir === 'rtl');
+};
+
 const openSidebar = () => {
   elements.sidebar.classList.add('open');
   elements.sidebarBackdrop.classList.add('open');
@@ -152,6 +175,7 @@ const createMetaNode = (created, message = null) => {
 };
 
 const renderAssistantMarkdown = (target, content) => {
+  applyTextDirection(target, content || '');
   const html = marked.parse(content || '');
   const clean = DOMPurify.sanitize(html);
   target.innerHTML = clean;
@@ -233,6 +257,7 @@ const createMessageNode = (message) => {
 
   const body = document.createElement('div');
   body.className = 'message-body';
+  applyTextDirection(body, message.content || '');
 
   if (message.role === 'assistant') {
     body.classList.add('markdown-body');
@@ -289,6 +314,7 @@ const updateAssistantNode = (message) => {
 
   const body = node.querySelector('.message-body');
   if (!body) return;
+  applyTextDirection(body, message.content || '');
   renderAssistantMarkdown(body, message.content || '');
 
   let usageNode = node.querySelector('.usage-line');
@@ -593,6 +619,8 @@ Object.assign(app, {
   closeSidebarIfMobile,
   updateHeader,
   renderSidebar,
+  directionForText,
+  applyTextDirection,
   createInterruptBadgeNode,
   createMetaNode,
   renderAssistantMarkdown,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -7,7 +7,7 @@ const {
   sessionIdFromURL, updateURL, scrollToBottom, setConnectionState, persistAndRefreshShell, refreshRelativeTimes,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderModelOptions,
-  autoGrowPrompt, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
+  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
   connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, isNearBottom,
   openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
   requestNotificationPermission, shouldAutoSubscribeToPush
@@ -344,6 +344,7 @@ const initialize = async () => {
   renderMessages(true);
   renderModelOptions();
   autoGrowPrompt();
+  updateVoiceUI();
   refreshNotificationUI();
   void registerServiceWorker().then(() => refreshNotificationUI());
 
@@ -427,6 +428,11 @@ elements.promptInput.addEventListener('keydown', (event) => {
 });
 
 elements.sendBtn.addEventListener('click', sendMessage);
+if (elements.voiceBtn) {
+  elements.voiceBtn.addEventListener('click', () => {
+    toggleVoiceRecording();
+  });
+}
 elements.stopBtn.addEventListener('click', async () => {
   const session = getActiveSession();
   try {

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -7,7 +7,7 @@ const {
   getActiveSession, ensureActiveSession, createSession, findMessageElement, scrollToBottom, setConnectionState,
   persistAndRefreshShell, updateSessionUsageDisplay, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  subscribeToPush, shouldAutoSubscribeToPush
+  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection
 } = app;
 
 // ===== Network helpers =====
@@ -1269,8 +1269,258 @@ const renderModelOptions = () => {
 };
 
 // ===== Composer logic =====
+const formatVoiceDuration = (ms) => {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+};
+
+const stopVoiceTracks = () => {
+  const stream = state.voice.stream;
+  if (!stream) return;
+  stream.getTracks().forEach((track) => track.stop());
+  state.voice.stream = null;
+};
+
+const clearVoiceTimer = () => {
+  if (state.voice.timerId !== null) {
+    clearInterval(state.voice.timerId);
+    state.voice.timerId = null;
+  }
+};
+
+const setVoiceStatus = (message = '') => {
+  state.voice.status = String(message || '');
+  const el = elements.voiceStatus;
+  if (!el) return;
+  if (!state.voice.status) {
+    el.className = 'voice-status hidden';
+    el.innerHTML = '';
+    return;
+  }
+  el.className = 'voice-status';
+  el.innerHTML = state.voice.status;
+};
+
+const updateVoiceUI = () => {
+  const btn = elements.voiceBtn;
+  if (!btn) return;
+
+  const unsupported = !state.voice.supported;
+  const busy = state.voice.transcribing;
+  const recording = state.voice.recording;
+
+  btn.disabled = unsupported || busy;
+  btn.classList.toggle('recording', recording);
+  btn.classList.toggle('busy', busy);
+
+  if (unsupported) {
+    btn.title = 'Voice recording is not supported in this browser';
+    btn.setAttribute('aria-label', 'Voice recording is not supported in this browser');
+    setVoiceStatus('');
+    return;
+  }
+
+  if (recording) {
+    const elapsed = Date.now() - state.voice.startedAt;
+    btn.title = 'Stop and send voice message';
+    btn.setAttribute('aria-label', 'Stop and send voice message');
+    setVoiceStatus(
+      `<span class="voice-status-dot" aria-hidden="true"></span>` +
+      `<span class="voice-status-copy">Recording <strong>${formatVoiceDuration(elapsed)}</strong></span>` +
+      `<button type="button" class="voice-status-cancel" id="voiceCancelBtn">Cancel</button>`
+    );
+    const cancelBtn = document.getElementById('voiceCancelBtn');
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', () => stopVoiceRecording(true), { once: true });
+    }
+    return;
+  }
+
+  if (busy) {
+    btn.title = 'Transcribing voice message';
+    btn.setAttribute('aria-label', 'Transcribing voice message');
+    setVoiceStatus('<span class="voice-status-spinner" aria-hidden="true"></span><span class="voice-status-copy">Transcribing voice message…</span>');
+    return;
+  }
+
+  btn.title = 'Record voice message';
+  btn.setAttribute('aria-label', 'Record voice message');
+  setVoiceStatus('');
+};
+
+const voiceRecordingMimeType = () => {
+  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+    return '';
+  }
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/mp4',
+    'audio/webm',
+    'audio/ogg;codecs=opus'
+  ];
+  return candidates.find((type) => MediaRecorder.isTypeSupported(type)) || '';
+};
+
+const audioFilenameForMimeType = (mimeType) => {
+  const normalized = String(mimeType || '').toLowerCase();
+  if (normalized.includes('mp4') || normalized.includes('m4a')) return 'voice-note.m4a';
+  if (normalized.includes('ogg')) return 'voice-note.ogg';
+  if (normalized.includes('wav')) return 'voice-note.wav';
+  return 'voice-note.webm';
+};
+
+const transcribeVoiceBlob = async (blob, mimeType) => {
+  const form = new FormData();
+  form.append('file', blob, audioFilenameForMimeType(mimeType));
+
+  const headers = {};
+  if (state.token) {
+    headers.Authorization = `Bearer ${state.token}`;
+  }
+
+  const response = await fetch(`${UI_PREFIX}/v1/transcribe`, {
+    method: 'POST',
+    headers,
+    body: form
+  });
+
+  if (!response.ok) {
+    throw await normalizeError(response);
+  }
+
+  const payload = await response.json().catch(() => null);
+  const text = String(payload?.text || '').trim();
+  if (!text) {
+    throw new Error('Transcription came back empty.');
+  }
+  return text;
+};
+
+const handleRecordedVoiceBlob = async (blob, mimeType) => {
+  state.voice.transcribing = true;
+  updateVoiceUI();
+
+  let draftUpdated = false;
+  try {
+    const transcript = await transcribeVoiceBlob(blob, mimeType);
+    const existingPrompt = String(elements.promptInput.value || '').trim();
+
+    if (!existingPrompt && state.attachments.length === 0) {
+      await sendMessage({ prompt: transcript, attachments: [] });
+      return;
+    }
+
+    elements.promptInput.value = existingPrompt ? `${existingPrompt}\n${transcript}` : transcript;
+    autoGrowPrompt();
+    elements.promptInput.focus();
+    draftUpdated = true;
+  } finally {
+    state.voice.transcribing = false;
+    updateVoiceUI();
+    if (draftUpdated) {
+      setVoiceStatus('<span class="voice-status-copy">Transcript added to your draft.</span>');
+      window.setTimeout(() => {
+        if (!state.voice.recording && !state.voice.transcribing) {
+          setVoiceStatus('');
+        }
+      }, 2200);
+    }
+  }
+};
+
+const startVoiceRecording = async () => {
+  if (!state.voice.supported || state.voice.recording || state.voice.transcribing) return;
+  if (!state.connected) {
+    openAuthModal('Connect before sending a voice message.', true);
+    return;
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mimeType = voiceRecordingMimeType();
+    const recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+
+    state.voice.recording = true;
+    state.voice.recorder = recorder;
+    state.voice.stream = stream;
+    state.voice.chunks = [];
+    state.voice.cancelOnStop = false;
+    state.voice.startedAt = Date.now();
+    state.voice.mimeType = mimeType || recorder.mimeType || 'audio/webm';
+
+    recorder.addEventListener('dataavailable', (event) => {
+      if (event.data && event.data.size > 0) {
+        state.voice.chunks.push(event.data);
+      }
+    });
+
+    recorder.addEventListener('stop', async () => {
+      const cancelled = state.voice.cancelOnStop;
+      const chunks = [...state.voice.chunks];
+      const blobType = state.voice.mimeType || recorder.mimeType || 'audio/webm';
+
+      state.voice.recording = false;
+      state.voice.recorder = null;
+      state.voice.chunks = [];
+      state.voice.cancelOnStop = false;
+      clearVoiceTimer();
+      stopVoiceTracks();
+      updateVoiceUI();
+
+      if (cancelled || chunks.length === 0) {
+        setVoiceStatus('');
+        return;
+      }
+
+      const blob = new Blob(chunks, { type: blobType });
+      try {
+        await handleRecordedVoiceBlob(blob, blobType);
+      } catch (err) {
+        setVoiceStatus('');
+        if (err?.status === 401) {
+          handleAuthFailure();
+          return;
+        }
+        alert(err?.message || 'Failed to transcribe voice message.');
+      }
+    }, { once: true });
+
+    recorder.start();
+    clearVoiceTimer();
+    state.voice.timerId = window.setInterval(() => updateVoiceUI(), 250);
+    updateVoiceUI();
+  } catch (err) {
+    stopVoiceTracks();
+    state.voice.recording = false;
+    state.voice.recorder = null;
+    clearVoiceTimer();
+    updateVoiceUI();
+    alert(err?.message || 'Microphone access failed.');
+  }
+};
+
+const stopVoiceRecording = (cancelled = false) => {
+  if (!state.voice.recording || !state.voice.recorder) return;
+  state.voice.cancelOnStop = cancelled;
+  const recorder = state.voice.recorder;
+  if (recorder.state !== 'inactive') {
+    recorder.stop();
+  }
+};
+
+const toggleVoiceRecording = async () => {
+  if (state.voice.recording) {
+    stopVoiceRecording(false);
+    return;
+  }
+  await startVoiceRecording();
+};
+
 const autoGrowPrompt = () => {
   const el = elements.promptInput;
+  applyTextDirection(el, el.value || '');
   el.style.height = 'auto';
   const next = Math.min(el.scrollHeight, 200);
   el.style.height = `${Math.max(48, next)}px`;
@@ -1354,6 +1604,7 @@ const setStreaming = (streaming) => {
   elements.sendBtn.disabled = false;
   elements.sendBtn.classList.toggle('loading', streaming);
   elements.stopBtn.classList.toggle('visible', streaming && (Boolean(state.abortController) || Boolean(state.currentStreamResponseId)));
+  updateVoiceUI();
   if (!streaming) {
     elements.promptInput.focus();
   }
@@ -1799,6 +2050,10 @@ Object.assign(app, {
   connectToken,
   renderModelOptions,
   autoGrowPrompt,
+  updateVoiceUI,
+  startVoiceRecording,
+  stopVoiceRecording,
+  toggleVoiceRecording,
   renderAttachments,
   MAX_ATTACHMENTS,
   MAX_FILE_BYTES,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -467,6 +467,12 @@
       white-space: pre-wrap;
       word-wrap: break-word;
       background: var(--surface);
+      unicode-bidi: plaintext;
+    }
+
+    .message-body.rtl,
+    .markdown-body.rtl {
+      text-align: right;
     }
 
     .message.user .message-body {
@@ -541,6 +547,15 @@
       padding: 0.11rem 0.35rem;
       border-radius: 4px;
       font-size: 0.88em;
+    }
+
+    .markdown-body pre,
+    .markdown-body code,
+    .tool-details pre,
+    .tool-entry-args .arg-value,
+    .approval-path {
+      direction: ltr;
+      text-align: left;
     }
 
     .markdown-body table {
@@ -834,7 +849,7 @@
 
     .composer {
       background: var(--bg);
-      padding: 0.75rem calc(1rem + var(--safe-right)) calc(0.85rem + var(--safe-bottom)) calc(1rem + var(--safe-left));
+      padding: 0.75rem calc(1rem + var(--safe-right)) max(0.3rem, calc(var(--safe-bottom) * 0.35)) calc(1rem + var(--safe-left));
       position: relative;
       z-index: 1;
     }
@@ -845,6 +860,79 @@
       display: flex;
       flex-direction: column;
       gap: 0;
+    }
+
+    .voice-status {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin: 0 0.3rem 0.45rem;
+      padding: 0.65rem 0.85rem;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      min-height: 44px;
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+
+    .voice-status.hidden {
+      display: none;
+    }
+
+    .voice-status-copy {
+      min-width: 0;
+      line-height: 1.35;
+      font-size: 0.92rem;
+    }
+
+    .voice-status strong {
+      font-variant-numeric: tabular-nums;
+    }
+
+    .voice-status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: var(--danger);
+      flex-shrink: 0;
+      box-shadow: 0 0 0 0 rgba(248,113,113,0.5);
+      animation: voice-pulse 1.35s infinite;
+    }
+
+    .voice-status-spinner {
+      width: 15px;
+      height: 15px;
+      border-radius: 999px;
+      border: 2px solid var(--border);
+      border-top-color: var(--text);
+      animation: spin 0.8s linear infinite;
+      flex-shrink: 0;
+    }
+
+    .voice-status-cancel {
+      border: 1px solid var(--border);
+      background: var(--surface-2);
+      color: var(--text);
+      border-radius: 999px;
+      padding: 0.42rem 0.7rem;
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .voice-status-cancel:hover {
+      background: var(--surface-3);
+    }
+
+    @keyframes voice-pulse {
+      0% { box-shadow: 0 0 0 0 rgba(248,113,113,0.55); }
+      70% { box-shadow: 0 0 0 10px rgba(248,113,113,0); }
+      100% { box-shadow: 0 0 0 0 rgba(248,113,113,0); }
     }
 
     .composer-box {
@@ -882,9 +970,32 @@
       color: var(--text);
     }
 
+    .composer-icon-btn:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
     .composer-icon-btn svg {
       width: 20px;
       height: 20px;
+    }
+
+    .voice-btn {
+      margin-bottom: 6px;
+    }
+
+    .voice-btn.recording {
+      background: rgba(248,113,113,0.14);
+      color: var(--danger);
+    }
+
+    .voice-btn.recording:hover {
+      background: rgba(248,113,113,0.2);
+      color: var(--danger);
+    }
+
+    .voice-btn.busy {
+      color: var(--text);
     }
 
     .prompt {
@@ -898,6 +1009,7 @@
       line-height: 1.5;
       font-size: 1rem;
       overflow-y: hidden;
+      unicode-bidi: plaintext;
     }
 
     .prompt:focus {
@@ -1545,7 +1657,44 @@
       }
 
       .composer {
-        padding: 0.5rem calc(0.5rem + var(--safe-right)) calc(0.6rem + var(--safe-bottom)) calc(0.5rem + var(--safe-left));
+        padding: 0.45rem calc(0.5rem + var(--safe-right)) max(0.1rem, calc(var(--safe-bottom) * 0.2)) calc(0.5rem + var(--safe-left));
+      }
+
+      .voice-status {
+        margin: 0 0.15rem 0.4rem;
+        padding: 0.65rem 0.75rem;
+        border-radius: 16px;
+        gap: 0.6rem;
+      }
+
+      .voice-status-copy {
+        font-size: 0.89rem;
+      }
+
+      .voice-status-cancel {
+        padding: 0.48rem 0.72rem;
+      }
+
+      .composer-box {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        border-radius: 22px;
+        padding: 5px;
+      }
+
+      .composer-icon-btn,
+      .send-btn,
+      .stop-btn {
+        min-height: 40px;
+      }
+
+      .composer-icon-btn,
+      .send-btn {
+        width: 40px;
+        height: 40px;
+      }
+
+      .prompt {
+        padding: 12px 6px;
       }
 
       .message.user {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -55,6 +55,7 @@
 
       <footer class="composer">
         <div class="composer-inner">
+          <div id="voiceStatus" class="voice-status hidden" aria-live="polite"></div>
           <div id="attachmentsStrip" class="attachments" style="display:none;"></div>
           <div class="composer-box">
             <button class="composer-icon-btn attach-btn" id="attachBtn" title="Attach file" aria-label="Attach file">
@@ -64,6 +65,9 @@
             <textarea id="promptInput" class="prompt" rows="1" placeholder="Message…" aria-label="Message"></textarea>
             <div class="composer-actions">
               <button class="stop-btn" id="stopBtn" type="button">Stop</button>
+              <button class="composer-icon-btn voice-btn" id="voiceBtn" type="button" title="Record voice message" aria-label="Record voice message">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><path d="M12 19v3"/></svg>
+              </button>
               <button class="send-btn" id="sendBtn" type="button" aria-label="Send message">
                 <span class="arrow">↑</span>
                 <span class="spinner" aria-hidden="true"></span>


### PR DESCRIPTION
## What

- add a `/v1/transcribe` web endpoint that accepts multipart audio uploads and routes them through the existing transcription provider config
- add a WhatsApp-style voice note button to the web composer so mobile users can record, transcribe, and send voice messages
- auto-send the transcript when the composer is empty, or append it into the draft when there is already text/attachments
- tighten the mobile composer layout so it sits lower on iPhone while still respecting the unsafe area
- render Hebrew and other RTL text correctly in the composer and message bubbles while keeping code, paths, and tool args LTR

## Why

The web UI worked fine for typed chat, but on mobile it was missing the obvious thing: hold up the phone, talk, send. The voice-note flow makes the web client much more natural on iPhone, and the RTL fixes stop Hebrew from looking broken while doing it.

## Testing

- `go test ./...`
- `go build ./...`
- `node --check internal/serveui/static/app-core.js`
- `node --check internal/serveui/static/app-render.js`
- `node --check internal/serveui/static/app-stream.js`
- manual smoke test:
  - started `term-llm serve web`
  - verified `/ui/healthz`
  - verified live UI served the new voice button/status markup
  - verified live JS/CSS included the new voice/mobile code
  - verified `/v1/transcribe` returned a sane validation error for unsupported upload content
- manual deploy test:
  - swapped the web service to the patched binary
  - restarted `webui`
  - verified `/chat/healthz`
