### PR TITLE
fix: track cache_write_tokens and prevent Update from clobbering metrics

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -431,7 +431,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	// Create stream adapter for unified event handling with proper buffering
 	adapter := ui.NewStreamAdapter(ui.DefaultStreamBufferSize)
 	if sess != nil {
-		adapter.Stats().SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.ToolCalls, sess.LLMTurns)
+		adapter.Stats().SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns)
 	}
 
 	// For glamour mode, create the tea.Program and set PromptUIFunc BEFORE starting the stream
@@ -563,7 +563,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 				_ = store.AddMessage(ctx, sess.ID, sessionMsg)
 			}
 			// Update metrics
-			_ = store.UpdateMetrics(ctx, sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens)
+			_ = store.UpdateMetrics(ctx, sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
 			return nil
 		})
 	}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1008,9 +1008,10 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 			"usage": map[string]any{
 				"prompt_tokens":     result.Usage.InputTokens,
 				"completion_tokens": result.Usage.OutputTokens,
-				"total_tokens":      result.Usage.InputTokens + result.Usage.OutputTokens,
+				"total_tokens":      result.Usage.InputTokens + result.Usage.CachedInputTokens + result.Usage.CacheWriteTokens + result.Usage.OutputTokens,
 				"prompt_tokens_details": map[string]any{
-					"cached_tokens": result.Usage.CachedInputTokens,
+					"cached_tokens":      result.Usage.CachedInputTokens,
+					"cache_write_tokens": result.Usage.CacheWriteTokens,
 				},
 			},
 		})

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -659,17 +659,19 @@ func responsesFinalResponse(result serveRunResult, model string, respID string) 
 		"usage": map[string]any{
 			"input_tokens":  result.Usage.InputTokens,
 			"output_tokens": result.Usage.OutputTokens,
-			"total_tokens":  result.Usage.InputTokens + result.Usage.OutputTokens,
+			"total_tokens":  result.Usage.InputTokens + result.Usage.CachedInputTokens + result.Usage.CacheWriteTokens + result.Usage.OutputTokens,
 			"input_tokens_details": map[string]any{
-				"cached_tokens": result.Usage.CachedInputTokens,
+				"cached_tokens":      result.Usage.CachedInputTokens,
+				"cache_write_tokens": result.Usage.CacheWriteTokens,
 			},
 		},
 		"session_usage": map[string]any{
 			"input_tokens":  result.SessionUsage.InputTokens,
 			"output_tokens": result.SessionUsage.OutputTokens,
-			"total_tokens":  result.SessionUsage.InputTokens + result.SessionUsage.OutputTokens,
+			"total_tokens":  result.SessionUsage.InputTokens + result.SessionUsage.CachedInputTokens + result.SessionUsage.CacheWriteTokens + result.SessionUsage.OutputTokens,
 			"input_tokens_details": map[string]any{
-				"cached_tokens": result.SessionUsage.CachedInputTokens,
+				"cached_tokens":      result.SessionUsage.CachedInputTokens,
+				"cache_write_tokens": result.SessionUsage.CacheWriteTokens,
 			},
 		},
 	}
@@ -710,9 +712,10 @@ func chatCompletionFinalResponse(result serveRunResult, model string) map[string
 		"usage": map[string]any{
 			"prompt_tokens":     result.Usage.InputTokens,
 			"completion_tokens": result.Usage.OutputTokens,
-			"total_tokens":      result.Usage.InputTokens + result.Usage.OutputTokens,
+			"total_tokens":      result.Usage.InputTokens + result.Usage.CachedInputTokens + result.Usage.CacheWriteTokens + result.Usage.OutputTokens,
 			"prompt_tokens_details": map[string]any{
-				"cached_tokens": result.Usage.CachedInputTokens,
+				"cached_tokens":      result.Usage.CachedInputTokens,
+				"cache_write_tokens": result.Usage.CacheWriteTokens,
 			},
 		},
 	}

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -651,9 +651,10 @@ func usagePayload(usage llm.Usage) map[string]any {
 	return map[string]any{
 		"input_tokens":  usage.InputTokens,
 		"output_tokens": usage.OutputTokens,
-		"total_tokens":  usage.InputTokens + usage.OutputTokens,
+		"total_tokens":  usage.InputTokens + usage.CachedInputTokens + usage.CacheWriteTokens + usage.OutputTokens,
 		"input_tokens_details": map[string]any{
-			"cached_tokens": usage.CachedInputTokens,
+			"cached_tokens":      usage.CachedInputTokens,
+			"cache_write_tokens": usage.CacheWriteTokens,
 		},
 	}
 }

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -468,6 +468,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				result.Usage.InputTokens += ev.Use.InputTokens
 				result.Usage.OutputTokens += ev.Use.OutputTokens
 				result.Usage.CachedInputTokens += ev.Use.CachedInputTokens
+				result.Usage.CacheWriteTokens += ev.Use.CacheWriteTokens
 			}
 		case llm.EventError:
 			if ev.Err != nil {

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -262,8 +262,10 @@ func runSessionsList(cmd *cobra.Command, args []string) error {
 			summary = summary[:22] + "..."
 		}
 
-		// Format tokens as "input/output" in k format
-		tokens := formatSessionTokens(s.InputTokens, s.OutputTokens)
+		// Format tokens as "total_input/output" in k format
+		// Total input = input (after cache breakpoint) + cache read + cache write
+		totalInput := s.InputTokens + s.CachedInputTokens + s.CacheWriteTokens
+		tokens := formatSessionTokens(totalInput, s.OutputTokens)
 
 		// Format status
 		status := string(s.Status)
@@ -402,9 +404,10 @@ func runSessionsShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("User Turns: %d\n", sess.UserTurns)
 	fmt.Printf("LLM Turns: %d\n", sess.LLMTurns)
 	fmt.Printf("Tool Calls: %d\n", sess.ToolCalls)
-	fmt.Printf("Tokens: %s (input: %d, output: %d)\n",
-		formatSessionTokens(sess.InputTokens, sess.OutputTokens),
-		sess.InputTokens, sess.OutputTokens)
+	totalInput := sess.InputTokens + sess.CachedInputTokens + sess.CacheWriteTokens
+	fmt.Printf("Tokens: %s (input: %d, cache_read: %d, cache_write: %d, output: %d)\n",
+		formatSessionTokens(totalInput, sess.OutputTokens),
+		sess.InputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.OutputTokens)
 	if sess.Tags != "" {
 		fmt.Printf("Tags: %s\n", sess.Tags)
 	}

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -232,7 +232,7 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 					r.warn("session AddMessage failed: %v", err)
 				}
 			}
-			if err := r.store.UpdateMetrics(ctx, childSessionID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens); err != nil {
+			if err := r.store.UpdateMetrics(ctx, childSessionID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens); err != nil {
 				r.warn("session UpdateMetrics failed: %v", err)
 			}
 			return nil

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -31,9 +31,10 @@ func getMaxTurns(req Request) int {
 
 // TurnMetrics contains metrics collected during a turn.
 type TurnMetrics struct {
-	InputTokens       int // Tokens consumed as input this turn
+	InputTokens       int // Non-cached, non-cache-write input tokens this turn
 	OutputTokens      int // Tokens generated as output this turn
-	CachedInputTokens int // Input tokens served from cache this turn
+	CachedInputTokens int // Input tokens served from cache (cache read) this turn
+	CacheWriteTokens  int // Input tokens written to cache (cache creation) this turn
 	ToolCalls         int // Number of tools executed this turn
 }
 
@@ -589,6 +590,7 @@ func (s *callbackStream) Recv() (Event, error) {
 		s.metrics.InputTokens += event.Use.InputTokens
 		s.metrics.OutputTokens += event.Use.OutputTokens
 		s.metrics.CachedInputTokens += event.Use.CachedInputTokens
+		s.metrics.CacheWriteTokens += event.Use.CacheWriteTokens
 	}
 	if event.Type == EventReasoningDelta {
 		if event.Text != "" {
@@ -804,6 +806,7 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 				turnMetrics.InputTokens += event.Use.InputTokens
 				turnMetrics.OutputTokens += event.Use.OutputTokens
 				turnMetrics.CachedInputTokens += event.Use.CachedInputTokens
+				turnMetrics.CacheWriteTokens += event.Use.CacheWriteTokens
 				// Update token tracking for compaction threshold and status line display.
 				// InputTokens is the non-cached portion; CachedInputTokens is the cached
 				// portion. Together they equal the total context size this turn. Adding

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -994,7 +994,7 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 				})
 			}
 			m.runStoreOp(cbCtx, sess.meta.ID, "UpdateMetrics", func(storeCtx context.Context) error {
-				return m.store.UpdateMetrics(storeCtx, sess.meta.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens)
+				return m.store.UpdateMetrics(storeCtx, sess.meta.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
 			})
 		}
 		return nil

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -66,8 +66,8 @@ func (s *LoggingStore) AddMessage(ctx context.Context, sessionID string, msg *Me
 }
 
 // UpdateMetrics wraps Store.UpdateMetrics with error logging.
-func (s *LoggingStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens int) error {
-	err := s.Store.UpdateMetrics(ctx, id, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens)
+func (s *LoggingStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
+	err := s.Store.UpdateMetrics(ctx, id, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens)
 	s.logOnce("UpdateMetrics", err)
 	return err
 }

--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -61,7 +61,7 @@ func (s *NoopStore) CompactMessages(ctx context.Context, sessionID string, messa
 	return nil
 }
 
-func (s *NoopStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens int) error {
+func (s *NoopStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
 	return nil
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -15,9 +15,10 @@ import (
 
 // SQLiteStore implements Store using SQLite.
 type SQLiteStore struct {
-	db               *sql.DB
-	cfg              Config
-	hasCompactionSeq bool // true if sessions table has compaction_seq column
+	db                  *sql.DB
+	cfg                 Config
+	hasCompactionSeq    bool // true if sessions table has compaction_seq column
+	hasCacheWriteTokens bool // true if sessions table has cache_write_tokens column
 }
 
 // Schema for the sessions database.
@@ -45,6 +46,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     tool_calls INTEGER DEFAULT 0,
     input_tokens INTEGER DEFAULT 0,
     cached_input_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
     output_tokens INTEGER DEFAULT 0,
     status TEXT DEFAULT 'active',
     tags TEXT,
@@ -139,9 +141,10 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 
 	store := &SQLiteStore{db: db, cfg: cfg}
 
-	// Probe for compaction_seq column. Read-write mode always has it after
+	// Probe for optional columns. Read-write mode always has them after
 	// migration, but read-only mode skips migrations and may open an older DB.
-	store.hasCompactionSeq = store.probeCompactionSeq()
+	store.hasCompactionSeq = store.probeColumn("compaction_seq")
+	store.hasCacheWriteTokens = store.probeColumn("cache_write_tokens")
 
 	// Run cleanup if configured (read-write mode only).
 	if !cfg.ReadOnly {
@@ -158,7 +161,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 10
+const schemaVersion = 11
 
 // migration represents a schema migration.
 type migration struct {
@@ -424,6 +427,21 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		// Migration 11: Add cache_write_tokens for accurate cost accounting
+		// Tracks cache-creation input tokens (Anthropic cache_creation_input_tokens,
+		// distinct from cache reads and non-cached input). Without this column,
+		// the largest cost bucket on cold-cache turns was silently dropped.
+		version:     11,
+		description: "add cache_write_tokens column",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec("ALTER TABLE sessions ADD COLUMN cache_write_tokens INTEGER DEFAULT 0")
+			if err != nil && !isDuplicateColumnError(err) {
+				return err
+			}
+			return nil
+		},
+	},
 }
 
 // initSchema initializes the database schema and runs any pending migrations.
@@ -577,12 +595,12 @@ func (s *SQLiteStore) Create(ctx context.Context, sess *Session) error {
 		// Creates could read the same MAX(number).
 		result, err := s.db.ExecContext(ctx, `
 			INSERT INTO sessions (id, number, name, summary, provider, provider_key, model, mode, agent, cwd, created_at, updated_at, archived, parent_id, search, tools, mcp,
-			                      user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens, output_tokens, status, tags)
-			VALUES (?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			                      user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens, cache_write_tokens, output_tokens, status, tags)
+			VALUES (?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			sess.ID, sess.Name, sess.Summary, sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(sess.Agent), sess.CWD,
 			sess.CreatedAt, sess.UpdatedAt, sess.Archived, nullString(sess.ParentID),
 			sess.Search, nullString(sess.Tools), nullString(sess.MCP),
-			sess.UserTurns, sess.LLMTurns, sess.ToolCalls, sess.InputTokens, sess.CachedInputTokens, sess.OutputTokens,
+			sess.UserTurns, sess.LLMTurns, sess.ToolCalls, sess.InputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.OutputTokens,
 			string(sess.Status), nullString(sess.Tags))
 		if err != nil {
 			return fmt.Errorf("insert session: %w", err)
@@ -611,14 +629,14 @@ func (s *SQLiteStore) Create(ctx context.Context, sess *Session) error {
 func (s *SQLiteStore) Get(ctx context.Context, id string) (*Session, error) {
 	row := s.db.QueryRowContext(ctx,
 		"SELECT "+s.sessionSelectCols()+" FROM sessions WHERE id = ?", id)
-	return scanSessionRow(row, s.hasCompactionSeq)
+	return scanSessionRow(row, s.hasCacheWriteTokens, s.hasCompactionSeq)
 }
 
 // GetByNumber retrieves a session by its sequential number.
 func (s *SQLiteStore) GetByNumber(ctx context.Context, number int64) (*Session, error) {
 	row := s.db.QueryRowContext(ctx,
 		"SELECT "+s.sessionSelectCols()+" FROM sessions WHERE number = ?", number)
-	return scanSessionRow(row, s.hasCompactionSeq)
+	return scanSessionRow(row, s.hasCacheWriteTokens, s.hasCompactionSeq)
 }
 
 // GetByPrefix retrieves a session by number (with # prefix), exact ID, or by short ID prefix match.
@@ -665,23 +683,25 @@ func (s *SQLiteStore) GetByPrefix(ctx context.Context, prefix string) (*Session,
 	pattern := ExpandShortID(prefix)
 	row := s.db.QueryRowContext(ctx,
 		"SELECT "+s.sessionSelectCols()+" FROM sessions WHERE id LIKE ? ORDER BY created_at DESC LIMIT 1", pattern)
-	return scanSessionRow(row, s.hasCompactionSeq)
+	return scanSessionRow(row, s.hasCacheWriteTokens, s.hasCompactionSeq)
 }
 
-// Update modifies an existing session.
+// Update modifies an existing session's metadata fields.
+// Token metrics (input_tokens, cached_input_tokens, cache_write_tokens, output_tokens)
+// and turn counters (llm_turns, tool_calls) are intentionally excluded — they are
+// managed exclusively by UpdateMetrics (which uses atomic increments) to prevent
+// stale in-memory values from clobbering accumulated totals.
 func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	sess.UpdatedAt = time.Now()
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE sessions SET name = ?, summary = ?, provider = ?, provider_key = ?, model = ?, mode = ?, agent = ?, cwd = ?,
 		       updated_at = ?, archived = ?, parent_id = ?, search = ?, tools = ?, mcp = ?,
-		       user_turns = ?, llm_turns = ?, tool_calls = ?, input_tokens = ?, cached_input_tokens = ?, output_tokens = ?,
-		       status = ?, tags = ?
+		       user_turns = ?, status = ?, tags = ?
 		WHERE id = ?`,
 		sess.Name, sess.Summary, sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(sess.Agent), sess.CWD,
 		sess.UpdatedAt, sess.Archived, nullString(sess.ParentID),
 		sess.Search, nullString(sess.Tools), nullString(sess.MCP),
-		sess.UserTurns, sess.LLMTurns, sess.ToolCalls, sess.InputTokens, sess.CachedInputTokens, sess.OutputTokens,
-		string(sess.Status), nullString(sess.Tags), sess.ID)
+		sess.UserTurns, string(sess.Status), nullString(sess.Tags), sess.ID)
 	if err != nil {
 		return fmt.Errorf("update session: %w", err)
 	}
@@ -692,8 +712,9 @@ func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	return nil
 }
 
-// UpdateMetrics updates just the metrics fields (used for incremental saves).
-func (s *SQLiteStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens int) error {
+// UpdateMetrics atomically increments the metrics fields for a session.
+// All token counters use += to avoid clobbering concurrent accumulation.
+func (s *SQLiteStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
 	return retryOnBusy(ctx, 5, func() error {
 		_, err := s.db.ExecContext(ctx, `
 			UPDATE sessions SET
@@ -701,10 +722,11 @@ func (s *SQLiteStore) UpdateMetrics(ctx context.Context, id string, llmTurns, to
 			       tool_calls = tool_calls + ?,
 			       input_tokens = input_tokens + ?,
 			       cached_input_tokens = cached_input_tokens + ?,
+			       cache_write_tokens = cache_write_tokens + ?,
 			       output_tokens = output_tokens + ?,
 			       updated_at = ?
 			WHERE id = ?`,
-			llmTurns, toolCalls, inputTokens, cachedInputTokens, outputTokens, time.Now(), id)
+			llmTurns, toolCalls, inputTokens, cachedInputTokens, cacheWriteTokens, outputTokens, time.Now(), id)
 		return err
 	})
 }
@@ -747,10 +769,14 @@ func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
 
 // List returns sessions matching the options.
 func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSummary, error) {
+	cacheWriteCol := "0"
+	if s.hasCacheWriteTokens {
+		cacheWriteCol = "s.cache_write_tokens"
+	}
 	query := `
 		SELECT s.id, s.number, s.name, s.summary, s.provider, s.model, s.mode, s.created_at, s.updated_at,
 		       (SELECT COUNT(*) FROM messages WHERE session_id = s.id) as message_count,
-		       s.user_turns, s.llm_turns, s.tool_calls, s.input_tokens, s.cached_input_tokens, s.output_tokens, s.status, s.tags
+		       s.user_turns, s.llm_turns, s.tool_calls, s.input_tokens, s.cached_input_tokens, ` + cacheWriteCol + `, s.output_tokens, s.status, s.tags
 		FROM sessions s
 		WHERE 1=1`
 	args := []any{}
@@ -810,7 +836,7 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		var mode, status, tags sql.NullString
 		err := rows.Scan(&sum.ID, &number, &sum.Name, &sum.Summary, &sum.Provider, &sum.Model, &mode,
 			&sum.CreatedAt, &sum.UpdatedAt, &sum.MessageCount,
-			&sum.UserTurns, &sum.LLMTurns, &sum.ToolCalls, &sum.InputTokens, &sum.CachedInputTokens, &sum.OutputTokens,
+			&sum.UserTurns, &sum.LLMTurns, &sum.ToolCalls, &sum.InputTokens, &sum.CachedInputTokens, &sum.CacheWriteTokens, &sum.OutputTokens,
 			&status, &tags)
 		if err != nil {
 			return nil, fmt.Errorf("scan session summary: %w", err)
@@ -1204,10 +1230,10 @@ func (s *SQLiteStore) Close() error {
 	return s.db.Close()
 }
 
-// probeCompactionSeq checks whether the sessions table has a compaction_seq
-// column. This is necessary for read-only mode, which skips migrations and
-// may open a database created before compaction_seq was added.
-func (s *SQLiteStore) probeCompactionSeq() bool {
+// probeColumn checks whether the sessions table has a given column.
+// This is necessary for read-only mode, which skips migrations and
+// may open a database created before the column was added.
+func (s *SQLiteStore) probeColumn(colName string) bool {
 	rows, err := s.db.Query("PRAGMA table_info(sessions)")
 	if err != nil {
 		return false
@@ -1222,7 +1248,7 @@ func (s *SQLiteStore) probeCompactionSeq() bool {
 		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
 			return false
 		}
-		if name == "compaction_seq" {
+		if name == colName {
 			return true
 		}
 	}
@@ -1233,16 +1259,20 @@ func (s *SQLiteStore) probeCompactionSeq() bool {
 // Excludes compaction_seq when the column doesn't exist (old DB in read-only mode).
 func (s *SQLiteStore) sessionSelectCols() string {
 	base := `id, number, name, summary, provider, provider_key, model, mode, agent, cwd, created_at, updated_at, archived, parent_id, search, tools, mcp,
-		       user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens, output_tokens, status, tags`
+		       user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens`
+	if s.hasCacheWriteTokens {
+		base += ", cache_write_tokens"
+	}
+	base += ", output_tokens, status, tags"
 	if s.hasCompactionSeq {
-		return base + ", compaction_seq"
+		base += ", compaction_seq"
 	}
 	return base
 }
 
-// scanSessionRow scans a session row into a Session struct. The hasCompactionSeq
-// flag determines whether the compaction_seq column is present in the result set.
-func scanSessionRow(row *sql.Row, hasCompactionSeq bool) (*Session, error) {
+// scanSessionRow scans a session row into a Session struct. The flags
+// determine which optional columns are present in the result set.
+func scanSessionRow(row *sql.Row, hasCacheWriteTokens, hasCompactionSeq bool) (*Session, error) {
 	var sess Session
 	var number sql.NullInt64
 	var name, summary, cwd sql.NullString
@@ -1253,9 +1283,12 @@ func scanSessionRow(row *sql.Row, hasCompactionSeq bool) (*Session, error) {
 		&sess.ID, &number, &name, &summary, &sess.Provider, &providerKey, &sess.Model, &mode,
 		&agent, &cwd, &sess.CreatedAt, &sess.UpdatedAt, &sess.Archived, &parentID,
 		&sess.Search, &tools, &mcp,
-		&sess.UserTurns, &sess.LLMTurns, &sess.ToolCalls, &sess.InputTokens, &sess.CachedInputTokens, &sess.OutputTokens,
-		&status, &tags,
+		&sess.UserTurns, &sess.LLMTurns, &sess.ToolCalls, &sess.InputTokens, &sess.CachedInputTokens,
 	)
+	if hasCacheWriteTokens {
+		scanArgs = append(scanArgs, &sess.CacheWriteTokens)
+	}
+	scanArgs = append(scanArgs, &sess.OutputTokens, &status, &tags)
 	if hasCompactionSeq {
 		scanArgs = append(scanArgs, &sess.CompactionSeq)
 	}

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -31,7 +31,8 @@ func TestSQLiteStoreUpdateMetricsIncludesCachedTokens(t *testing.T) {
 		t.Fatalf("failed to create session: %v", err)
 	}
 
-	if err := store.UpdateMetrics(ctx, sess.ID, 2, 3, 1000, 250, 700); err != nil {
+	// Turn 1: 1000 input, 250 output, 700 cache read, 500 cache write
+	if err := store.UpdateMetrics(ctx, sess.ID, 2, 3, 1000, 250, 700, 500); err != nil {
 		t.Fatalf("failed to update session metrics: %v", err)
 	}
 
@@ -58,6 +59,30 @@ func TestSQLiteStoreUpdateMetricsIncludesCachedTokens(t *testing.T) {
 	if loaded.CachedInputTokens != 700 {
 		t.Errorf("expected cached_input_tokens=700, got %d", loaded.CachedInputTokens)
 	}
+	if loaded.CacheWriteTokens != 500 {
+		t.Errorf("expected cache_write_tokens=500, got %d", loaded.CacheWriteTokens)
+	}
+
+	// Turn 2: verify accumulation
+	if err := store.UpdateMetrics(ctx, sess.ID, 1, 2, 50, 100, 1200, 50); err != nil {
+		t.Fatalf("failed to update session metrics (turn 2): %v", err)
+	}
+	loaded2, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("failed to load session after turn 2: %v", err)
+	}
+	if loaded2.InputTokens != 1050 {
+		t.Errorf("expected input_tokens=1050 after accumulation, got %d", loaded2.InputTokens)
+	}
+	if loaded2.CachedInputTokens != 1900 {
+		t.Errorf("expected cached_input_tokens=1900 after accumulation, got %d", loaded2.CachedInputTokens)
+	}
+	if loaded2.CacheWriteTokens != 550 {
+		t.Errorf("expected cache_write_tokens=550 after accumulation, got %d", loaded2.CacheWriteTokens)
+	}
+	if loaded2.OutputTokens != 350 {
+		t.Errorf("expected output_tokens=350 after accumulation, got %d", loaded2.OutputTokens)
+	}
 
 	summaries, err := store.List(ctx, ListOptions{Limit: 10})
 	if err != nil {
@@ -66,8 +91,70 @@ func TestSQLiteStoreUpdateMetricsIncludesCachedTokens(t *testing.T) {
 	if len(summaries) != 1 {
 		t.Fatalf("expected 1 session summary, got %d", len(summaries))
 	}
-	if summaries[0].CachedInputTokens != 700 {
-		t.Errorf("expected summary cached_input_tokens=700, got %d", summaries[0].CachedInputTokens)
+	if summaries[0].CachedInputTokens != 1900 {
+		t.Errorf("expected summary cached_input_tokens=1900, got %d", summaries[0].CachedInputTokens)
+	}
+	if summaries[0].CacheWriteTokens != 550 {
+		t.Errorf("expected summary cache_write_tokens=550, got %d", summaries[0].CacheWriteTokens)
+	}
+}
+
+func TestUpdateDoesNotClobberTokenMetrics(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{
+		ID:       NewID(),
+		Provider: "test",
+		Model:    "test-model",
+		Mode:     ModeChat,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Accumulate metrics via UpdateMetrics
+	if err := store.UpdateMetrics(ctx, sess.ID, 3, 5, 1000, 250, 700, 500); err != nil {
+		t.Fatalf("UpdateMetrics: %v", err)
+	}
+
+	// Now call Update to change metadata (e.g. summary).
+	// The in-memory sess still has zero token counts — this must NOT reset the DB.
+	sess.Summary = "updated summary"
+	if err := store.Update(ctx, sess); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	reloaded, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if reloaded.Summary != "updated summary" {
+		t.Errorf("expected summary=%q, got %q", "updated summary", reloaded.Summary)
+	}
+	if reloaded.InputTokens != 1000 {
+		t.Errorf("Update clobbered input_tokens: expected 1000, got %d", reloaded.InputTokens)
+	}
+	if reloaded.CachedInputTokens != 700 {
+		t.Errorf("Update clobbered cached_input_tokens: expected 700, got %d", reloaded.CachedInputTokens)
+	}
+	if reloaded.CacheWriteTokens != 500 {
+		t.Errorf("Update clobbered cache_write_tokens: expected 500, got %d", reloaded.CacheWriteTokens)
+	}
+	if reloaded.OutputTokens != 250 {
+		t.Errorf("Update clobbered output_tokens: expected 250, got %d", reloaded.OutputTokens)
+	}
+	if reloaded.LLMTurns != 3 {
+		t.Errorf("Update clobbered llm_turns: expected 3, got %d", reloaded.LLMTurns)
+	}
+	if reloaded.ToolCalls != 5 {
+		t.Errorf("Update clobbered tool_calls: expected 5, got %d", reloaded.ToolCalls)
 	}
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -30,7 +30,7 @@ type Store interface {
 	CompactMessages(ctx context.Context, sessionID string, messages []Message) error
 
 	// Metrics operations (for incremental session saving)
-	UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens int) error
+	UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error
 	UpdateStatus(ctx context.Context, id string, status SessionStatus) error
 	IncrementUserTurns(ctx context.Context, id string) error
 

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -55,8 +55,9 @@ type Session struct {
 	UserTurns         int           `json:"user_turns,omitempty"`          // Number of user messages
 	LLMTurns          int           `json:"llm_turns,omitempty"`           // Number of LLM API round-trips
 	ToolCalls         int           `json:"tool_calls,omitempty"`          // Total tool executions
-	InputTokens       int           `json:"input_tokens,omitempty"`        // Total input tokens used
-	CachedInputTokens int           `json:"cached_input_tokens,omitempty"` // Total cached input tokens read
+	InputTokens       int           `json:"input_tokens,omitempty"`        // Total non-cached, non-cache-write input tokens
+	CachedInputTokens int           `json:"cached_input_tokens,omitempty"` // Total cached input tokens read (cache hits)
+	CacheWriteTokens  int           `json:"cache_write_tokens,omitempty"`  // Total tokens written to cache (cache misses)
 	OutputTokens      int           `json:"output_tokens,omitempty"`       // Total output tokens used
 	Status            SessionStatus `json:"status,omitempty"`              // Session status
 	Tags              string        `json:"tags,omitempty"`                // Comma-separated tags
@@ -92,6 +93,7 @@ type SessionSummary struct {
 	ToolCalls         int           `json:"tool_calls,omitempty"`
 	InputTokens       int           `json:"input_tokens,omitempty"`
 	CachedInputTokens int           `json:"cached_input_tokens,omitempty"`
+	CacheWriteTokens  int           `json:"cache_write_tokens,omitempty"`
 	OutputTokens      int           `json:"output_tokens,omitempty"`
 	Status            SessionStatus `json:"status,omitempty"`
 	Tags              string        `json:"tags,omitempty"`

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -412,7 +412,7 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 
 	stats := ui.NewSessionStats()
 	if sess != nil {
-		stats.SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.ToolCalls, sess.LLMTurns)
+		stats.SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns)
 	}
 
 	return &Model{

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -268,7 +268,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 					}
 					_ = m.store.AddMessage(ctx, m.sess.ID, sessionMsg)
 				}
-				_ = m.store.UpdateMetrics(ctx, m.sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens)
+				_ = m.store.UpdateMetrics(ctx, m.sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
 				return nil
 			})
 		}

--- a/internal/tui/sessions/browse.go
+++ b/internal/tui/sessions/browse.go
@@ -571,8 +571,9 @@ func (m *Model) View() string {
 			style = "chat"
 		}
 
-		// Tokens
-		tokens := formatTokens(s.InputTokens, s.OutputTokens)
+		// Tokens — show total input (uncached + cache read + cache write)
+		totalInput := s.InputTokens + s.CachedInputTokens + s.CacheWriteTokens
+		tokens := formatTokens(totalInput, s.OutputTokens)
 
 		// Age
 		age := formatRelativeTime(s.UpdatedAt)

--- a/internal/ui/stats.go
+++ b/internal/ui/stats.go
@@ -39,10 +39,11 @@ func NewSessionStats() *SessionStats {
 
 // SeedTotals initializes cumulative counters from persisted session metrics.
 // Timing remains scoped to the current process run.
-func (s *SessionStats) SeedTotals(input, output, cached, toolCalls, llmCalls int) {
+func (s *SessionStats) SeedTotals(input, output, cached, cacheWrite, toolCalls, llmCalls int) {
 	s.InputTokens = input
 	s.OutputTokens = output
 	s.CachedInputTokens = cached
+	s.CacheWriteTokens = cacheWrite
 	s.ToolCallCount = toolCalls
 	s.LLMCallCount = llmCalls
 	// Reset per-call fields so stale data from prior usage doesn't leak through

--- a/internal/ui/stats_test.go
+++ b/internal/ui/stats_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSessionStatsSeedTotals(t *testing.T) {
 	stats := NewSessionStats()
-	stats.SeedTotals(1000, 250, 700, 3, 2)
+	stats.SeedTotals(1000, 250, 700, 0, 3, 2)
 	stats.AddUsage(10, 5, 4, 0)
 
 	if stats.InputTokens != 1010 {
@@ -71,7 +71,7 @@ func TestAddUsageSetsLastAndPeak(t *testing.T) {
 
 func TestRenderAfterSeedTotalsWithoutAddUsage(t *testing.T) {
 	stats := NewSessionStats()
-	stats.SeedTotals(100000, 5000, 80000, 10, 5)
+	stats.SeedTotals(100000, 5000, 80000, 0, 10, 5)
 
 	out := stats.Render()
 	if strings.Contains(out, "last:") {
@@ -94,7 +94,7 @@ func TestSeedTotalsClearsPerCallState(t *testing.T) {
 	}
 
 	// Reseed should clear per-call state
-	stats.SeedTotals(100000, 10000, 80000, 5, 3)
+	stats.SeedTotals(100000, 10000, 80000, 0, 5, 3)
 
 	if stats.lastInputTokens != 0 {
 		t.Errorf("expected lastInputTokens 0 after reseed, got %d", stats.lastInputTokens)


### PR DESCRIPTION
## What

Fix token accounting: track `cache_write_tokens` and prevent `Update()` from clobbering accumulated metrics.

## Why

Two bugs made token cost tracking unreliable:

### 1. Cache write tokens silently dropped

Anthropic reports three input token categories per turn:

| Field | Meaning | Cost |
|---|---|---|
| `input_tokens` | Tokens after last cache breakpoint (not cacheable) | 1x base |
| `cache_read_input_tokens` | Cache hits | 0.1x base |
| `cache_creation_input_tokens` | Cache misses written to cache | 1.25x base (5min) / 2x (1h) |

`total_input = input_tokens + cache_read + cache_creation`

The `Usage` struct already carried `CacheWriteTokens` from the provider, but `UpdateMetrics()` never accepted or persisted it. The DB had no column for it. On a cold-cache first turn (where the entire system prompt is written to cache), this is the _largest_ cost bucket — and it was invisible.

Example from a real session: reported 88 `input_tokens` and 2.7M `cached_input_tokens`, but 0 `cache_write_tokens` because they were dropped. Actual cost was dominated by the missing cache writes.

### 2. `Update()` clobbered accumulated metrics

`UpdateMetrics()` correctly uses `SET input_tokens = input_tokens + ?` (atomic increment). But `Update()` uses `SET input_tokens = ?` (overwrite from in-memory struct). The in-memory `Session` struct was never synced after `UpdateMetrics` calls, so any metadata update (summary set, model switch, search toggle, `/save`) would reset all token counters to their stale in-memory values (typically zero).

## Changes

- **Schema**: Add `cache_write_tokens INTEGER DEFAULT 0` column (migration 11)
- **Types**: Add `CacheWriteTokens` to `Session`, `SessionSummary`, `TurnMetrics`
- **UpdateMetrics**: Accept and persist `cacheWriteTokens` parameter
- **Update**: Exclude token metrics (`input_tokens`, `cached_input_tokens`, `cache_write_tokens`, `output_tokens`) and turn counters (`llm_turns`, `tool_calls`) — these are now managed exclusively by `UpdateMetrics`
- **All callers**: Thread `CacheWriteTokens` through chat TUI, ask, telegram, spawn_runner, serve_runtime, and `SeedTotals`
- **API responses**: Include `cache_write_tokens` in `input_tokens_details`; fix `total_tokens` to sum all three input categories + output
- **Display**: `sessions list` shows total input (sum of all three); `sessions show` shows full breakdown
- **Backward compat**: Probe for column existence on read-only DBs (same pattern as `compaction_seq`)
- **Tests**: New `TestUpdateDoesNotClobberTokenMetrics`; extended `TestSQLiteStoreUpdateMetricsIncludesCachedTokens` to verify multi-turn accumulation
