### PR TITLE
feat: render math in web UI

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -112,6 +112,20 @@ marked.use({
   gfm: true
 });
 
+const renderMath = (target) => {
+  if (!target || typeof renderMathInElement !== 'function') return;
+  renderMathInElement(target, {
+    delimiters: [
+      { left: '$$', right: '$$', display: true },
+      { left: '\\[', right: '\\]', display: true },
+      { left: '$', right: '$', display: false },
+      { left: '\\(', right: '\\)', display: false }
+    ],
+    ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'option'],
+    throwOnError: false
+  });
+};
+
 // ===== Helpers =====
 // crypto.randomUUID() requires a secure context (HTTPS); use getRandomValues fallback for HTTP
 const generateUUID = () => {
@@ -682,6 +696,7 @@ Object.assign(app, {
   sessionBucket,
   toolIcon,
   formatUsage,
+  renderMath,
   updateSessionUsageDisplay,
   isNearBottom,
   scrollToBottom,

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -5,7 +5,7 @@ const app = window.TermLLMApp;
 const {
   state, elements, INTERRUPT_BADGE_META, sanitizeInterruptState, relativeTime, fullDate, sessionBucket, toolIcon, formatUsage,
   saveSessions, findMessageElement, scrollToBottom, refreshRelativeTimes, ensureActiveSession, updateDocumentTitle,
-  updateSessionUsageDisplay, updateURL
+  updateSessionUsageDisplay, updateURL, renderMath
 } = app;
 
 const directionForText = (value) => {
@@ -179,6 +179,8 @@ const renderAssistantMarkdown = (target, content) => {
   const html = marked.parse(content || '');
   const clean = DOMPurify.sanitize(html);
   target.innerHTML = clean;
+
+  renderMath(target);
 
   target.querySelectorAll('a').forEach((a) => {
     a.target = '_blank';

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -582,6 +582,21 @@
       text-decoration: underline;
     }
 
+    .markdown-body .katex {
+      font-size: 1.02em;
+    }
+
+    .markdown-body .katex-display {
+      margin: 0.85em 0;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-bottom: 0.1rem;
+    }
+
+    .markdown-body .katex-display > .katex {
+      white-space: nowrap;
+    }
+
     .message-meta {
       display: inline-flex;
       align-items: center;

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -11,6 +11,7 @@
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230d1117'/%3E%3Cpath d='M17 14h30v6H24v26h16v-9H30v-6h17v21H17z' fill='%23ececec'/%3E%3C/svg%3E">
   <link rel="apple-touch-icon" href="icon-512.png">
   <link rel="manifest" href="manifest.webmanifest">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" media="(prefers-color-scheme: light)">
   <link rel="stylesheet" href="app.css">
@@ -140,6 +141,8 @@
     <img id="lightboxImg" alt="Full size preview">
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/16.3.0/lib/marked.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.7/purify.min.js"></script>


### PR DESCRIPTION
## What

Add KaTeX-based math rendering to the web UI so assistant markdown can display inline and block LaTeX expressions.

## Changes

- load KaTeX CSS and JS in the web UI page
- add a shared `renderMath()` helper using KaTeX auto-render
- run math rendering after markdown sanitization/rendering
- keep `pre` and `code` blocks excluded from math parsing
- add CSS so display math scrolls horizontally instead of blowing up message layout

## Why

We tried to fix math rendering, but the deployed web UI was still only doing markdown + syntax highlighting. This wires in the missing math render step so expressions like `$x^2$`, `$$x^2$$`, `\(...\)`, and `\[...\]` actually render.

## Verification

- `go build ./...`
- `go test ./...`
