### PR TITLE
fix: use external search when Gemini tools are enabled

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -463,6 +463,21 @@ func (e *Engine) IsToolAllowed(name string) bool {
 	return e.allowedTools[name]
 }
 
+// nativeSearchWithToolCallsProvider is an optional provider capability for
+// providers that support native web search but cannot combine it with function
+// calling in the same request.
+type nativeSearchWithToolCallsProvider interface {
+	supportsNativeSearchWithToolCalls() bool
+}
+
+func providerSupportsNativeSearchWithToolCalls(provider Provider) bool {
+	supporter, ok := provider.(nativeSearchWithToolCallsProvider)
+	if !ok {
+		return true
+	}
+	return supporter.supportsNativeSearchWithToolCalls()
+}
+
 // Stream returns a stream, applying external tools when needed.
 func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	if req.DebugRaw {
@@ -470,13 +485,18 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	}
 
 	caps := e.provider.Capabilities()
+	effectiveForceExternalSearch := req.ForceExternalSearch
+	if req.Search && len(req.Tools) > 0 && caps.NativeWebSearch && !providerSupportsNativeSearchWithToolCalls(e.provider) {
+		effectiveForceExternalSearch = true
+	}
+	req.ForceExternalSearch = effectiveForceExternalSearch
 
 	// 1. Handle external search/fetch tool injection
 	// If Search is enabled, add web_search and read_url tools to the tool list.
 	// The LLM will use them naturally during conversation like any other tool.
 	if req.Search {
-		needsExternalSearch := !caps.NativeWebSearch || req.ForceExternalSearch
-		needsExternalFetch := !caps.NativeWebFetch || req.ForceExternalSearch
+		needsExternalSearch := !caps.NativeWebSearch || effectiveForceExternalSearch
+		needsExternalFetch := !caps.NativeWebFetch || effectiveForceExternalSearch
 
 		if needsExternalSearch {
 			if t, ok := e.tools.Get(WebSearchToolName); ok {
@@ -496,7 +516,7 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 
 	// Force external search means "do not use provider-native search".
 	// Keep req.Search=true only for providers that must handle native search.
-	if req.ForceExternalSearch && caps.NativeWebSearch {
+	if effectiveForceExternalSearch && caps.NativeWebSearch {
 		req.Search = false
 	}
 

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -486,8 +486,14 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 
 	caps := e.provider.Capabilities()
 	effectiveForceExternalSearch := req.ForceExternalSearch
-	if req.Search && len(req.Tools) > 0 && caps.NativeWebSearch && !providerSupportsNativeSearchWithToolCalls(e.provider) {
-		effectiveForceExternalSearch = true
+	if req.Search && caps.NativeWebSearch && !providerSupportsNativeSearchWithToolCalls(e.provider) {
+		nativeSearchWouldUseToolCalls := len(req.Tools) > 0
+		if !nativeSearchWouldUseToolCalls && !caps.NativeWebFetch {
+			_, nativeSearchWouldUseToolCalls = e.tools.Get(ReadURLToolName)
+		}
+		if nativeSearchWouldUseToolCalls {
+			effectiveForceExternalSearch = true
+		}
 	}
 	req.ForceExternalSearch = effectiveForceExternalSearch
 

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -37,6 +37,15 @@ type fakeProvider struct {
 	hasCapabilities bool
 }
 
+type nativeSearchToolCallsFakeProvider struct {
+	*fakeProvider
+	supportsNativeSearchWithTools bool
+}
+
+func (p *nativeSearchToolCallsFakeProvider) supportsNativeSearchWithToolCalls() bool {
+	return p.supportsNativeSearchWithTools
+}
+
 func (p *fakeProvider) Name() string {
 	return "fake"
 }
@@ -512,6 +521,79 @@ func TestEngineForceExternalSearchDisablesNativeProviderSearch(t *testing.T) {
 	firstReq := provider.calls[0]
 	if firstReq.Search {
 		t.Fatalf("expected provider request Search=false when force_external is true")
+	}
+
+	hasExternalSearchTool := false
+	for _, spec := range firstReq.Tools {
+		if spec.Name == WebSearchToolName {
+			hasExternalSearchTool = true
+			break
+		}
+	}
+	if !hasExternalSearchTool {
+		t.Fatalf("expected injected external web_search tool")
+	}
+}
+
+func TestEngineAutoDisablesNativeSearchWhenProviderCannotCombineItWithTools(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&countingSearchTool{})
+
+	provider := &nativeSearchToolCallsFakeProvider{
+		fakeProvider: &fakeProvider{
+			hasCapabilities: true,
+			capabilities: Capabilities{
+				NativeWebSearch: true,
+				NativeWebFetch:  false,
+				ToolCalls:       true,
+			},
+			script: func(call int, req Request) []Event {
+				return []Event{
+					{Type: EventTextDelta, Text: "ok"},
+					{Type: EventDone},
+				}
+			},
+		},
+		supportsNativeSearchWithTools: false,
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages: []Message{UserText("search this")},
+		Search:   true,
+		Tools: []ToolSpec{{
+			Name:        "activate_skill",
+			Description: "Load a skill",
+			Schema:      map[string]any{"type": "object"},
+		}},
+	}
+
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+	}
+
+	if len(provider.calls) != 1 {
+		t.Fatalf("expected 1 provider call, got %d", len(provider.calls))
+	}
+
+	firstReq := provider.calls[0]
+	if firstReq.Search {
+		t.Fatalf("expected provider request Search=false when native search cannot be combined with tools")
+	}
+	if !firstReq.ForceExternalSearch {
+		t.Fatalf("expected provider request ForceExternalSearch=true for incompatible native search + tools")
 	}
 
 	hasExternalSearchTool := false

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -89,6 +89,23 @@ func (t *countingSearchTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+type countingReadURLTool struct {
+	calls int
+}
+
+func (t *countingReadURLTool) Spec() ToolSpec {
+	return ReadURLToolSpec()
+}
+
+func (t *countingReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	t.calls++
+	return TextOutput(fmt.Sprintf("page %d", t.calls)), nil
+}
+
+func (t *countingReadURLTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 type countingTool struct {
 	calls int
 }
@@ -605,6 +622,81 @@ func TestEngineAutoDisablesNativeSearchWhenProviderCannotCombineItWithTools(t *t
 	}
 	if !hasExternalSearchTool {
 		t.Fatalf("expected injected external web_search tool")
+	}
+}
+
+func TestEngineAutoDisablesNativeSearchWhenReadURLWouldBeInjected(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&countingSearchTool{})
+	registry.Register(&countingReadURLTool{})
+
+	provider := &nativeSearchToolCallsFakeProvider{
+		fakeProvider: &fakeProvider{
+			hasCapabilities: true,
+			capabilities: Capabilities{
+				NativeWebSearch: true,
+				NativeWebFetch:  false,
+				ToolCalls:       true,
+			},
+			script: func(call int, req Request) []Event {
+				return []Event{
+					{Type: EventTextDelta, Text: "ok"},
+					{Type: EventDone},
+				}
+			},
+		},
+		supportsNativeSearchWithTools: false,
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages: []Message{UserText("search this")},
+		Search:   true,
+	}
+
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+	}
+
+	if len(provider.calls) != 1 {
+		t.Fatalf("expected 1 provider call, got %d", len(provider.calls))
+	}
+
+	firstReq := provider.calls[0]
+	if firstReq.Search {
+		t.Fatalf("expected provider request Search=false when read_url would force tool calls")
+	}
+	if !firstReq.ForceExternalSearch {
+		t.Fatalf("expected provider request ForceExternalSearch=true when read_url would be injected")
+	}
+
+	hasExternalSearchTool := false
+	hasReadURLTool := false
+	for _, spec := range firstReq.Tools {
+		switch spec.Name {
+		case WebSearchToolName:
+			hasExternalSearchTool = true
+		case ReadURLToolName:
+			hasReadURLTool = true
+		}
+	}
+	if !hasExternalSearchTool {
+		t.Fatalf("expected injected external web_search tool")
+	}
+	if !hasReadURLTool {
+		t.Fatalf("expected injected read_url tool")
 	}
 }
 

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -94,6 +94,10 @@ func (p *GeminiProvider) Capabilities() Capabilities {
 	}
 }
 
+func (p *GeminiProvider) supportsNativeSearchWithToolCalls() bool {
+	return false
+}
+
 func (p *GeminiProvider) newClient(ctx context.Context) (*genai.Client, error) {
 	return genai.NewClient(ctx, &genai.ClientConfig{APIKey: p.apiKey})
 }

--- a/internal/llm/gemini_cli.go
+++ b/internal/llm/gemini_cli.go
@@ -311,6 +311,10 @@ func (p *GeminiCLIProvider) Capabilities() Capabilities {
 	}
 }
 
+func (p *GeminiCLIProvider) supportsNativeSearchWithToolCalls() bool {
+	return false
+}
+
 func (p *GeminiCLIProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
 		if err := p.ensureProjectID(ctx, req.Debug); err != nil {


### PR DESCRIPTION
## What

- automatically fall back to external `web_search` when a provider supports native search but cannot combine it with function tools
- mark both Gemini providers as unable to mix native search with tool calls
- add an engine test covering the native-search-plus-tools fallback path

## Why

Gemini rejects requests that include both its built-in `google_search` tool and function calling in the same request. In real sessions this happened when search was enabled and a function tool like `activate_skill` was also present, causing the request to fail before the model could answer.

## How

- add a small optional provider capability used by the engine to detect providers that cannot combine native search with tool calls
- when that case is hit, treat the request as effectively `force_external_search`, inject the external search tool, and disable provider-native search for the provider request
- keep the change targeted to Gemini by implementing the capability on the Gemini API and Gemini CLI providers
