### PR TITLE
feat: add Tavily external search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1746,16 +1746,20 @@ When using external search (non-native), you can choose from multiple search pro
 |----------|---------------------|-------------|
 | DuckDuckGo (default) | — | Free, no API key required |
 | [Exa](https://exa.ai) | `EXA_API_KEY` | AI-native semantic search |
+| [Tavily](https://tavily.com/) | `TAVILY_API_KEY` | Agent-oriented web search with snippets |
 | [Brave](https://brave.com/search/api/) | `BRAVE_API_KEY` | Independent index, privacy-focused |
 | [Google](https://developers.google.com/custom-search) | `GOOGLE_SEARCH_API_KEY` + `GOOGLE_SEARCH_CX` | Google Custom Search |
 
 **Configure in `~/.config/term-llm/config.yaml`:**
 ```yaml
 search:
-  provider: exa  # exa, brave, google, or duckduckgo (default)
+  provider: exa  # exa, tavily, brave, google, or duckduckgo (default)
 
   exa:
     api_key: ${EXA_API_KEY}
+
+  tavily:
+    api_key: ${TAVILY_API_KEY}
 
   brave:
     api_key: ${BRAVE_API_KEY}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,15 +370,21 @@ type EmbedOllamaConfig struct {
 
 // SearchConfig configures web search providers
 type SearchConfig struct {
-	Provider      string             `mapstructure:"provider"`       // exa, brave, google, duckduckgo (default)
+	Provider      string             `mapstructure:"provider"`       // exa, tavily, brave, google, duckduckgo (default)
 	ForceExternal bool               `mapstructure:"force_external"` // force external search for all providers
 	Exa           SearchExaConfig    `mapstructure:"exa"`
+	Tavily        SearchTavilyConfig `mapstructure:"tavily"`
 	Brave         SearchBraveConfig  `mapstructure:"brave"`
 	Google        SearchGoogleConfig `mapstructure:"google"`
 }
 
 // SearchExaConfig configures Exa search
 type SearchExaConfig struct {
+	APIKey string `mapstructure:"api_key"`
+}
+
+// SearchTavilyConfig configures Tavily search
+type SearchTavilyConfig struct {
 	APIKey string `mapstructure:"api_key"`
 }
 
@@ -786,6 +792,12 @@ func resolveSearchCredentials(cfg *SearchConfig) {
 		cfg.Exa.APIKey = os.Getenv("EXA_API_KEY")
 	}
 
+	// Tavily credentials
+	cfg.Tavily.APIKey = expandEnv(cfg.Tavily.APIKey)
+	if cfg.Tavily.APIKey == "" {
+		cfg.Tavily.APIKey = os.Getenv("TAVILY_API_KEY")
+	}
+
 	// Brave credentials
 	cfg.Brave.APIKey = expandEnv(cfg.Brave.APIKey)
 	if cfg.Brave.APIKey == "" {
@@ -992,6 +1004,8 @@ var KnownKeys = map[string]bool{
 	"search.force_external": true,
 	"search.exa":            true,
 	"search.exa.api_key":    true,
+	"search.tavily":         true,
+	"search.tavily.api_key": true,
 	"search.brave":          true,
 	"search.brave.api_key":  true,
 	"search.google":         true,

--- a/internal/search/factory.go
+++ b/internal/search/factory.go
@@ -21,6 +21,12 @@ func NewSearcher(cfg *config.Config) (Searcher, error) {
 		}
 		return NewExaSearcher(cfg.Search.Exa.APIKey, nil), nil
 
+	case "tavily":
+		if cfg.Search.Tavily.APIKey == "" {
+			return nil, fmt.Errorf("tavily search requires TAVILY_API_KEY")
+		}
+		return NewTavilySearcher(cfg.Search.Tavily.APIKey, nil), nil
+
 	case "brave":
 		if cfg.Search.Brave.APIKey == "" {
 			return nil, fmt.Errorf("brave search requires BRAVE_API_KEY")

--- a/internal/search/tavily.go
+++ b/internal/search/tavily.go
@@ -1,0 +1,110 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TavilySearcher implements Searcher using the Tavily Search API.
+type TavilySearcher struct {
+	client *http.Client
+	apiKey string
+}
+
+func NewTavilySearcher(apiKey string, client *http.Client) *TavilySearcher {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &TavilySearcher{
+		client: client,
+		apiKey: apiKey,
+	}
+}
+
+type tavilyRequest struct {
+	Query         string `json:"query"`
+	SearchDepth   string `json:"search_depth"`
+	MaxResults    int    `json:"max_results"`
+	Topic         string `json:"topic"`
+	IncludeAnswer bool   `json:"include_answer"`
+}
+
+type tavilyResponse struct {
+	Results []tavilyResult `json:"results"`
+}
+
+type tavilyResult struct {
+	Title   string  `json:"title"`
+	URL     string  `json:"url"`
+	Content string  `json:"content"`
+	Score   float64 `json:"score"`
+}
+
+func (t *TavilySearcher) Search(ctx context.Context, query string, maxResults int) ([]Result, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("empty query")
+	}
+	if maxResults <= 0 {
+		maxResults = 10
+	}
+	if maxResults > 20 {
+		maxResults = 20
+	}
+
+	reqBody := tavilyRequest{
+		Query:         query,
+		SearchDepth:   "basic",
+		MaxResults:    maxResults,
+		Topic:         "general",
+		IncludeAnswer: false,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.tavily.com/search", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+t.apiKey)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tavily http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tavilyResp tavilyResponse
+	if err := json.Unmarshal(body, &tavilyResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	results := make([]Result, 0, len(tavilyResp.Results))
+	for _, r := range tavilyResp.Results {
+		results = append(results, Result{
+			Title:   r.Title,
+			URL:     r.URL,
+			Snippet: r.Content,
+		})
+	}
+
+	return results, nil
+}

--- a/internal/search/tavily_test.go
+++ b/internal/search/tavily_test.go
@@ -1,0 +1,54 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTavilySearcherSearch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		fmt.Fprint(w, `{"results":[{"title":"Result 1","url":"https://example.com/1","content":"Snippet 1"},{"title":"Result 2","url":"https://example.com/2","content":"Snippet 2"}]}`)
+	}))
+	defer ts.Close()
+
+	searcher := NewTavilySearcher("test-key", ts.Client())
+	searcher.client.Transport = rewriteTransport{base: ts.Client().Transport, target: ts.URL}
+
+	results, err := searcher.Search(context.Background(), "hello", 2)
+	if err != nil {
+		t.Fatalf("Search error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Title != "Result 1" || results[0].URL != "https://example.com/1" || results[0].Snippet != "Snippet 1" {
+		t.Fatalf("results[0] = %+v", results[0])
+	}
+}
+
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	targetReq, err := http.NewRequestWithContext(cloned.Context(), cloned.Method, t.target, cloned.Body)
+	if err != nil {
+		return nil, err
+	}
+	targetReq.Header = cloned.Header.Clone()
+	return t.base.RoundTrip(targetReq)
+}


### PR DESCRIPTION
## What

Add Tavily as an external web search provider for `term-llm`.

- adds `search.tavily.api_key` config support plus `TAVILY_API_KEY` env fallback
- adds `internal/search/tavily.go` implementing the existing `Searcher` interface
- wires `tavily` into the search factory
- documents Tavily in the README search provider section
- adds a focused unit test for Tavily search response mapping

## Why

Tavily is a useful fallback/alternative to Exa and Brave for external search. The API shape maps cleanly onto term-llm's existing `Title` / `URL` / `Snippet` search abstraction, so support is low-churn and gives another provider option without changing search orchestration.

## Validation

- `go test ./...`
- live smoke against Tavily API with query `jarvis wasnotwas` returned `https://wasnotwas.com/` as the top result
