### PR TITLE
feat: add perplexity search provider

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -227,9 +227,10 @@ func printAnnotatedConfig(defaults map[string]any, rawKeys, unknownKeys map[stri
 			name: "search",
 			keys: []string{"provider", "force_external"},
 			nested: map[string][]string{
-				"exa":    {"api_key"},
-				"brave":  {"api_key"},
-				"google": {"api_key", "cx"},
+				"exa":        {"api_key"},
+				"perplexity": {"api_key"},
+				"brave":      {"api_key"},
+				"google":     {"api_key", "cx"},
 			},
 		},
 		{
@@ -1233,6 +1234,7 @@ func configKeyCompletions(toComplete string) []string {
 		"image.openrouter.api_key",
 		// Search API keys
 		"search.exa.api_key",
+		"search.perplexity.api_key",
 		"search.brave.api_key",
 		"search.google.api_key",
 		"search.google.cx",
@@ -1296,7 +1298,7 @@ func configValueCompletions(key, toComplete string) []string {
 		return completions
 
 	case "search.provider":
-		providers := []string{"duckduckgo", "exa", "brave", "google"}
+		providers := []string{"duckduckgo", "exa", "perplexity", "brave", "google"}
 		var completions []string
 		for _, p := range providers {
 			if strings.HasPrefix(p, toComplete) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,16 +370,22 @@ type EmbedOllamaConfig struct {
 
 // SearchConfig configures web search providers
 type SearchConfig struct {
-	Provider      string             `mapstructure:"provider"`       // exa, tavily, brave, google, duckduckgo (default)
-	ForceExternal bool               `mapstructure:"force_external"` // force external search for all providers
-	Exa           SearchExaConfig    `mapstructure:"exa"`
-	Tavily        SearchTavilyConfig `mapstructure:"tavily"`
-	Brave         SearchBraveConfig  `mapstructure:"brave"`
-	Google        SearchGoogleConfig `mapstructure:"google"`
+	Provider      string                 `mapstructure:"provider"`       // exa, perplexity, tavily, brave, google, duckduckgo (default)
+	ForceExternal bool                   `mapstructure:"force_external"` // force external search for all providers
+	Exa           SearchExaConfig        `mapstructure:"exa"`
+	Perplexity    SearchPerplexityConfig `mapstructure:"perplexity"`
+	Tavily        SearchTavilyConfig     `mapstructure:"tavily"`
+	Brave         SearchBraveConfig      `mapstructure:"brave"`
+	Google        SearchGoogleConfig     `mapstructure:"google"`
 }
 
 // SearchExaConfig configures Exa search
 type SearchExaConfig struct {
+	APIKey string `mapstructure:"api_key"`
+}
+
+// SearchPerplexityConfig configures Perplexity search
+type SearchPerplexityConfig struct {
 	APIKey string `mapstructure:"api_key"`
 }
 
@@ -792,6 +798,12 @@ func resolveSearchCredentials(cfg *SearchConfig) {
 		cfg.Exa.APIKey = os.Getenv("EXA_API_KEY")
 	}
 
+	// Perplexity credentials
+	cfg.Perplexity.APIKey = expandEnv(cfg.Perplexity.APIKey)
+	if cfg.Perplexity.APIKey == "" {
+		cfg.Perplexity.APIKey = os.Getenv("PERPLEXITY_API_KEY")
+	}
+
 	// Tavily credentials
 	cfg.Tavily.APIKey = expandEnv(cfg.Tavily.APIKey)
 	if cfg.Tavily.APIKey == "" {
@@ -1000,17 +1012,19 @@ var KnownKeys = map[string]bool{
 	"embed.ollama.model":    true,
 
 	// Search
-	"search.provider":       true,
-	"search.force_external": true,
-	"search.exa":            true,
-	"search.exa.api_key":    true,
-	"search.tavily":         true,
-	"search.tavily.api_key": true,
-	"search.brave":          true,
-	"search.brave.api_key":  true,
-	"search.google":         true,
-	"search.google.api_key": true,
-	"search.google.cx":      true,
+	"search.provider":           true,
+	"search.force_external":     true,
+	"search.exa":                true,
+	"search.exa.api_key":        true,
+	"search.perplexity":         true,
+	"search.perplexity.api_key": true,
+	"search.tavily":             true,
+	"search.tavily.api_key":     true,
+	"search.brave":              true,
+	"search.brave.api_key":      true,
+	"search.google":             true,
+	"search.google.api_key":     true,
+	"search.google.cx":          true,
 
 	// Theme
 	"theme.primary":   true,

--- a/internal/search/factory.go
+++ b/internal/search/factory.go
@@ -21,6 +21,12 @@ func NewSearcher(cfg *config.Config) (Searcher, error) {
 		}
 		return NewExaSearcher(cfg.Search.Exa.APIKey, nil), nil
 
+	case "perplexity":
+		if cfg.Search.Perplexity.APIKey == "" {
+			return nil, fmt.Errorf("perplexity search requires PERPLEXITY_API_KEY")
+		}
+		return NewPerplexitySearcher(cfg.Search.Perplexity.APIKey, nil), nil
+
 	case "tavily":
 		if cfg.Search.Tavily.APIKey == "" {
 			return nil, fmt.Errorf("tavily search requires TAVILY_API_KEY")
@@ -46,6 +52,6 @@ func NewSearcher(cfg *config.Config) (Searcher, error) {
 		return NewDuckDuckGoLite(nil), nil
 
 	default:
-		return nil, fmt.Errorf("unknown search provider: %s (valid: exa, tavily, brave, google, duckduckgo)", provider)
+		return nil, fmt.Errorf("unknown search provider: %s (valid: exa, perplexity, tavily, brave, google, duckduckgo)", provider)
 	}
 }

--- a/internal/search/perplexity.go
+++ b/internal/search/perplexity.go
@@ -1,0 +1,103 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// PerplexitySearcher implements Searcher using the Perplexity Search API.
+type PerplexitySearcher struct {
+	client *http.Client
+	apiKey string
+}
+
+func NewPerplexitySearcher(apiKey string, client *http.Client) *PerplexitySearcher {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &PerplexitySearcher{
+		client: client,
+		apiKey: apiKey,
+	}
+}
+
+type perplexityRequest struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+type perplexityResponse struct {
+	Results []perplexityResult `json:"results"`
+}
+
+type perplexityResult struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Snippet string `json:"snippet"`
+}
+
+func (p *PerplexitySearcher) Search(ctx context.Context, query string, maxResults int) ([]Result, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("empty query")
+	}
+	if maxResults <= 0 {
+		maxResults = 10
+	}
+	if maxResults > 20 {
+		maxResults = 20
+	}
+
+	reqBody := perplexityRequest{
+		Query:      query,
+		MaxResults: maxResults,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.perplexity.ai/search", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("perplexity http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var pplxResp perplexityResponse
+	if err := json.Unmarshal(body, &pplxResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	results := make([]Result, 0, len(pplxResp.Results))
+	for _, r := range pplxResp.Results {
+		results = append(results, Result{
+			Title:   r.Title,
+			URL:     r.URL,
+			Snippet: r.Snippet,
+		})
+	}
+
+	return results, nil
+}

--- a/internal/search/perplexity_test.go
+++ b/internal/search/perplexity_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPerplexitySearcherSearch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		fmt.Fprint(w, `{"results":[{"title":"Result 1","url":"https://example.com/1","snippet":"Snippet 1"},{"title":"Result 2","url":"https://example.com/2","snippet":"Snippet 2"}]}`)
+	}))
+	defer ts.Close()
+
+	searcher := NewPerplexitySearcher("test-key", ts.Client())
+	searcher.client.Transport = rewriteTransport{base: ts.Client().Transport, target: ts.URL}
+
+	results, err := searcher.Search(context.Background(), "hello", 2)
+	if err != nil {
+		t.Fatalf("Search error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Title != "Result 1" || results[0].URL != "https://example.com/1" || results[0].Snippet != "Snippet 1" {
+		t.Fatalf("results[0] = %+v", results[0])
+	}
+}


### PR DESCRIPTION
## What

Add Perplexity as a first-class external search provider.

- add `search.perplexity.api_key` config support with `PERPLEXITY_API_KEY` env fallback
- wire `search.provider: perplexity` into the search factory
- add a Perplexity Search API client and test coverage
- expose Perplexity in config annotation/completion paths

## Why

term-llm already supports Exa, Tavily, Brave, Google, and DuckDuckGo for the external `web_search` tool.
Perplexity now has a real Search API in the same category, so it should be selectable directly without pretending it's some generic custom endpoint.

## Validation

- `gofmt -w internal/config/config.go internal/search/factory.go internal/search/perplexity.go internal/search/perplexity_test.go cmd/config.go`
- `go test ./internal/search ./internal/config ./cmd/...`
- `go build ./...`
