### PR TITLE
fix: stop restoring mobile composer focus

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -50,7 +50,8 @@ const state = {
     cancelOnStop: false,
     mimeType: '',
     status: ''
-  }
+  },
+  restorePromptFocus: false
 };
 // Ensure cookie is set on load so <img> requests to basePath/images/ can authenticate
 if (state.token) {
@@ -296,6 +297,9 @@ const updateDocumentTitle = () => {
 };
 
 const isStandalone = () => window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+
+// Mobile browsers treat programmatic focus as an instruction to pop the keyboard.
+const shouldSuppressPromptAutoFocus = () => window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 
 const syncNotificationPermissionState = () => {
   if (typeof Notification === 'undefined') return;
@@ -704,6 +708,7 @@ Object.assign(app, {
   updateDocumentTitle,
   UI_PREFIX,
   isStandalone,
+  shouldSuppressPromptAutoFocus,
   refreshNotificationUI,
   registerServiceWorker,
   subscribeToPush,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -7,7 +7,7 @@ const {
   getActiveSession, ensureActiveSession, createSession, findMessageElement, scrollToBottom, setConnectionState,
   persistAndRefreshShell, updateSessionUsageDisplay, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection
+  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus
 } = app;
 
 // ===== Network helpers =====
@@ -1599,6 +1599,12 @@ const handleFiles = (fileList) => {
 };
 
 const setStreaming = (streaming) => {
+  const wasStreaming = state.streaming;
+  if (streaming && !wasStreaming) {
+    // Only restore focus after a reply if the user was already typing and the device
+    // will not pop an on-screen keyboard just because we touched focus().
+    state.restorePromptFocus = document.activeElement === elements.promptInput && !shouldSuppressPromptAutoFocus();
+  }
   state.streaming = streaming;
   elements.promptInput.disabled = false;
   elements.sendBtn.disabled = false;
@@ -1606,7 +1612,11 @@ const setStreaming = (streaming) => {
   elements.stopBtn.classList.toggle('visible', streaming && (Boolean(state.abortController) || Boolean(state.currentStreamResponseId)));
   updateVoiceUI();
   if (!streaming) {
-    elements.promptInput.focus();
+    const shouldRestoreFocus = state.restorePromptFocus;
+    state.restorePromptFocus = false;
+    if (shouldRestoreFocus) {
+      elements.promptInput.focus();
+    }
   }
 };
 


### PR DESCRIPTION
## What

- stop `setStreaming(false)` from blindly focusing the composer
- track whether the prompt was focused when streaming started
- only restore focus on non-coarse-pointer devices, so mobile load/refresh/reply completion does not pop the keyboard

## Why

On mobile, the composer was being auto-focused during normal lifecycle work, not just explicit user actions. The main culprit was startup sync:

- `initialize()` calls `syncActiveSessionFromServer()`
- the no-active-run path calls `setStreaming(false)`
- `setStreaming(false)` always called `promptInput.focus()`

That means simply opening the chat on a phone could trigger focus and open the keyboard. The same thing could happen again when a reply finished.

This keeps desktop's convenient focus restoration after sending a message, but removes the mobile keyboard-jump behavior.

## Validation

- `go build ./...`
- `go test ./...`
