### PR TITLE
feat: improve pwa startup experience

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -104,7 +104,9 @@ const elements = {
   approvalDenyBtn: document.getElementById('approvalDenyBtn'),
   approvalApproveBtn: document.getElementById('approvalApproveBtn'),
   lightbox: document.getElementById('lightbox'),
-  lightboxImg: document.getElementById('lightboxImg')
+  lightboxImg: document.getElementById('lightboxImg'),
+  startupSplash: document.getElementById('startupSplash'),
+  startupStatus: document.getElementById('startupStatus')
 };
 
 // ===== Markdown setup =====
@@ -285,6 +287,22 @@ const setConnectionState = (text, mode = '') => {
   if (mode) {
     elements.connectionState.classList.add(mode);
   }
+};
+
+const setStartupStatus = (text) => {
+  if (!elements.startupStatus || !text) return;
+  elements.startupStatus.textContent = text;
+};
+
+const hideStartupSplash = () => {
+  if (!elements.startupSplash || elements.startupSplash.classList.contains('hidden')) return;
+  document.body.classList.remove('app-loading');
+  elements.startupSplash.classList.add('hidden');
+  window.setTimeout(() => {
+    if (elements.startupSplash) {
+      elements.startupSplash.setAttribute('hidden', 'hidden');
+    }
+  }, 220);
 };
 
 const updateDocumentTitle = () => {
@@ -705,6 +723,8 @@ Object.assign(app, {
   isNearBottom,
   scrollToBottom,
   setConnectionState,
+  setStartupStatus,
+  hideStartupSplash,
   updateDocumentTitle,
   UI_PREFIX,
   isStandalone,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, updateURL, scrollToBottom, setConnectionState, persistAndRefreshShell, refreshRelativeTimes,
+  sessionIdFromURL, updateURL, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderModelOptions,
   autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
@@ -313,6 +313,7 @@ const mergeServerSessions = async () => {
 
 // ===== Initialization =====
 const initialize = async () => {
+  setStartupStatus('Loading your chat shell…');
   state.sessions = loadSessions();
 
   // Check URL for a specific session ID
@@ -346,14 +347,17 @@ const initialize = async () => {
   autoGrowPrompt();
   updateVoiceUI();
   refreshNotificationUI();
+  hideStartupSplash();
   void registerServiceWorker().then(() => refreshNotificationUI());
 
   try {
+    setStartupStatus(state.token ? 'Checking your token…' : 'Connecting…');
     setConnectionState(state.token ? 'Validating token…' : 'Connecting…');
     state.models = await fetchModels();
     state.connected = true;
     renderModelOptions();
     setConnectionState('', '');
+    setStartupStatus('Syncing sessions…');
 
     // Merge server-side sessions after successful auth
     await mergeServerSessions();
@@ -381,10 +385,13 @@ const initialize = async () => {
     }
   } catch (err) {
     const message = err?.message || 'Unable to validate token.';
+    setStartupStatus(message);
     setConnectionState(message, 'bad');
     if (!state.token || err?.status === 401) {
       handleAuthFailure();
     }
+  } finally {
+    hideStartupSplash();
   }
 };
 

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -112,6 +112,74 @@
       content: none;
     }
 
+    .startup-splash {
+      position: fixed;
+      inset: 0;
+      z-index: 120;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: calc(1.5rem + var(--safe-top)) calc(1.5rem + var(--safe-right)) calc(1.5rem + var(--safe-bottom)) calc(1.5rem + var(--safe-left));
+      background:
+        radial-gradient(circle at top, var(--bg-accent), transparent 55%),
+        var(--bg);
+      transition: opacity 180ms ease, visibility 180ms ease;
+    }
+
+    .startup-splash.hidden {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .startup-card {
+      width: min(320px, 100%);
+      padding: 1.5rem 1.35rem;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: var(--surface);
+      box-shadow: var(--shadow-strong);
+      text-align: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+    }
+
+    .startup-mark {
+      width: 52px;
+      height: 52px;
+      margin: 0 auto 0.9rem;
+      border-radius: 14px;
+      display: grid;
+      place-items: center;
+      background: var(--surface-2);
+      border: 1px solid var(--border);
+      font-size: 1.45rem;
+      font-weight: 800;
+    }
+
+    .startup-title {
+      font-size: 1.05rem;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+    }
+
+    .startup-subtitle {
+      margin-top: 0.4rem;
+      color: var(--text-muted);
+      font-size: 0.92rem;
+      line-height: 1.45;
+    }
+
+    .startup-spinner {
+      width: 22px;
+      height: 22px;
+      margin: 1rem auto 0;
+      border-radius: 50%;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent-strong);
+      animation: spin 0.8s linear infinite;
+    }
+
     button,
     input,
     textarea,

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -4,10 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Chat</title>
-  <meta name="theme-color" content="#212121">
+  <meta name="application-name" content="term-llm">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="term-llm">
+  <meta name="theme-color" content="#212121" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+  <meta name="color-scheme" content="dark light">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230d1117'/%3E%3Cpath d='M17 14h30v6H24v26h16v-9H30v-6h17v21H17z' fill='%23ececec'/%3E%3C/svg%3E">
   <link rel="apple-touch-icon" href="icon-512.png">
   <link rel="manifest" href="manifest.webmanifest">
@@ -16,7 +20,16 @@
   <link rel="stylesheet" href="vendor/hljs/github.min.css?v=11.11.1" media="(prefers-color-scheme: light)">
   <link rel="stylesheet" href="app.css">
 </head>
-<body>
+<body class="app-loading">
+  <div class="startup-splash" id="startupSplash" role="status" aria-live="polite">
+    <div class="startup-card">
+      <div class="startup-mark" aria-hidden="true">⌘</div>
+      <div class="startup-title">term-llm</div>
+      <div class="startup-subtitle" id="startupStatus">Loading your chat shell…</div>
+      <div class="startup-spinner" aria-hidden="true"></div>
+    </div>
+  </div>
+
   <div class="app">
     <aside class="sidebar" id="sidebar" aria-label="Sessions">
       <div class="sidebar-header">

--- a/internal/serveui/static/manifest.webmanifest
+++ b/internal/serveui/static/manifest.webmanifest
@@ -1,10 +1,13 @@
 {
+  "id": "./",
   "name": "term-llm Chat",
   "short_name": "term-llm",
   "description": "Chat with term-llm from your phone home screen.",
   "display": "standalone",
+  "display_override": ["standalone", "minimal-ui", "browser"],
   "start_url": "./",
   "scope": "./",
+  "orientation": "any",
   "background_color": "#212121",
   "theme_color": "#212121",
   "icons": [

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -1,9 +1,93 @@
+const SHELL_CACHE = 'term-llm-shell-v2';
+const SHELL_ASSETS = [
+  './',
+  './index.html',
+  './manifest.webmanifest',
+  './icon-512.png',
+  './app.css',
+  './app-core.js',
+  './app-render.js',
+  './app-stream.js',
+  './app-sessions.js',
+  './vendor/katex/katex.min.css?v=0.16.38',
+  './vendor/katex/katex.min.js?v=0.16.38',
+  './vendor/katex/auto-render.min.js?v=0.16.38',
+  './vendor/marked/marked.umd.min.js?v=16.3.0',
+  './vendor/hljs/github-dark.min.css?v=11.11.1',
+  './vendor/hljs/github.min.css?v=11.11.1',
+  './vendor/hljs/highlight.min.js?v=11.11.1',
+  './vendor/dompurify/purify.min.js?v=3.2.7'
+];
+
+const putIfCacheable = async (cache, request, response) => {
+  if (!response || !response.ok) return response;
+  try {
+    await cache.put(request, response.clone());
+  } catch {
+    // Ignore cache write failures. Storage pressure happens.
+  }
+  return response;
+};
+
 self.addEventListener('install', (event) => {
-  event.waitUntil(self.skipWaiting());
+  event.waitUntil((async () => {
+    const cache = await caches.open(SHELL_CACHE);
+    await cache.addAll(SHELL_ASSETS);
+    await self.skipWaiting();
+  })());
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((key) => key.startsWith('term-llm-shell-') && key !== SHELL_CACHE).map((key) => caches.delete(key)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  const scopePath = new URL(self.registration.scope).pathname;
+  const isAppRequest = url.pathname.startsWith(scopePath);
+  if (!isAppRequest) return;
+
+  if (request.mode === 'navigate') {
+    event.respondWith((async () => {
+      const cache = await caches.open(SHELL_CACHE);
+      try {
+        const response = await fetch(request);
+        await putIfCacheable(cache, './index.html', response.clone());
+        return response;
+      } catch {
+        return (await cache.match('./index.html')) || (await cache.match('./'));
+      }
+    })());
+    return;
+  }
+
+  const isShellAsset = SHELL_ASSETS.some((asset) => url.href === new URL(asset, self.registration.scope).href);
+  if (!isShellAsset && request.destination !== 'script' && request.destination !== 'style' && request.destination !== 'image' && request.destination !== 'font') {
+    return;
+  }
+
+  event.respondWith((async () => {
+    const cache = await caches.open(SHELL_CACHE);
+    const cached = await cache.match(request, { ignoreSearch: false });
+    const networkFetch = fetch(request)
+      .then((response) => putIfCacheable(cache, request, response))
+      .catch(() => null);
+    if (cached) {
+      void networkFetch;
+      return cached;
+    }
+    const response = await networkFetch;
+    return response || Response.error();
+  })());
 });
 
 self.addEventListener('push', (event) => {


### PR DESCRIPTION
## What
- add a startup splash screen while the web UI initializes
- surface startup progress text for loading, token validation, and session sync
- hide the splash once the shell is ready, including auth failure paths
- expand the service worker to cache the UI shell so installed PWAs can reopen cleanly offline or on slow launches
- tighten the web manifest for standalone installs

## Why
When term-llm is installed as a PWA, cold starts can feel blank or janky while the shell boots and the token/session checks run. A native-feeling loading screen makes launch state obvious instead of looking broken.

The shell caching change also gives the PWA a better chance of reopening into a usable frame before the network catches up, which is the whole point of installing the thing.

## Validation
- go test ./...
- go build ./...
