### PR TITLE
fix: restore web chat continuity and clear transcribe state

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1402,31 +1402,21 @@ const handleRecordedVoiceBlob = async (blob, mimeType) => {
   state.voice.transcribing = true;
   updateVoiceUI();
 
-  let draftUpdated = false;
   try {
     const transcript = await transcribeVoiceBlob(blob, mimeType);
     const existingPrompt = String(elements.promptInput.value || '').trim();
 
     if (!existingPrompt && state.attachments.length === 0) {
-      await sendMessage({ prompt: transcript, attachments: [] });
+      void sendMessage({ prompt: transcript, attachments: [] });
       return;
     }
 
     elements.promptInput.value = existingPrompt ? `${existingPrompt}\n${transcript}` : transcript;
     autoGrowPrompt();
     elements.promptInput.focus();
-    draftUpdated = true;
   } finally {
     state.voice.transcribing = false;
     updateVoiceUI();
-    if (draftUpdated) {
-      setVoiceStatus('<span class="voice-status-copy">Transcript added to your draft.</span>');
-      window.setTimeout(() => {
-        if (!state.voice.recording && !state.voice.transcribing) {
-          setVoiceStatus('');
-        }
-      }, 2200);
-    }
   }
 };
 
@@ -1906,6 +1896,8 @@ const sendMessage = async (options = {}) => {
 
   if (session.lastResponseId) {
     body.previous_response_id = session.lastResponseId;
+  } else if (session.messages.length > 1) {
+    body.input = rebuildInputFromSession(session, inputContent);
   }
 
   if (state.selectedModel) {


### PR DESCRIPTION
## What
- rebuild web UI request input from stored session messages when a restored session has history but no `previous_response_id`
- stop holding the voice/transcribe UI in the busy state while waiting for the assistant response stream
- remove the lingering post-transcription draft status so the transcribe UI clears immediately after transcription finishes

## Why
Two separate bits of web UI behavior were off:

1. Chat continuity looked non-persistent after reload for sessions that had local message history but no stored `lastResponseId`. In that case the UI sent only the new prompt, so the server started a fresh conversation instead of continuing the visible one.
2. Voice transcription stayed stuck in the transcribing state because the UI awaited the full `sendMessage()` lifecycle, which includes the assistant response, not just the transcript request.

## Validation
- `go test ./...`
- `go build ./...`
