### PR TITLE
fix: version PWA shell assets and keep splash visible

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
-	htmlpkg "html"
 	"io"
 	"log"
 	"mime"
@@ -49,6 +47,32 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 
 	// basePath is already stripped by http.StripPrefix; URL.Path is "/" or "/session-id" etc.
 	assetName := strings.TrimPrefix(r.URL.Path, "/")
+	if assetName == "index.html" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if strings.Contains(r.URL.RawQuery, "v=") {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+		_, _ = w.Write(s.renderIndexHTML())
+		return
+	}
+	if assetName == "manifest.webmanifest" {
+		w.Header().Set("Content-Type", "application/manifest+json")
+		if strings.Contains(r.URL.RawQuery, "v=") {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+		_, _ = w.Write(serveui.RenderManifest())
+		return
+	}
+	if assetName == "sw.js" {
+		w.Header().Set("Content-Type", "text/javascript")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write(serveui.RenderServiceWorker())
+		return
+	}
 	if assetName != "" && !strings.Contains(assetName, "..") {
 		if data, err := serveui.StaticAsset(assetName); err == nil {
 			contentType := mime.TypeByExtension(filepath.Ext(assetName))
@@ -75,14 +99,10 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 	// SPA catch-all: serve index.html for all other paths.
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	html := serveui.IndexHTML()
+	_, _ = w.Write(s.renderIndexHTML())
+}
 
-	// Inject <base> so all relative asset URLs (app.css, vendor/*, etc.)
-	// resolve against the base path regardless of the SPA route depth.
-	baseTag := `<base href="` + htmlpkg.EscapeString(s.cfg.basePath) + `/">`
-	html = bytes.Replace(html, []byte(`<meta charset="utf-8">`),
-		[]byte(`<meta charset="utf-8">`+"\n  "+baseTag), 1)
-
+func (s *serveServer) renderIndexHTML() []byte {
 	// Inject UI prefix so JS can prefix all API calls with it.
 	// Also inject VAPID public key for web push if configured.
 	var headSnippet string
@@ -94,8 +114,7 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 			headSnippet += `<script>window.TERM_LLM_VAPID_PUBLIC_KEY=` + string(vapidEscaped) + `;</script>`
 		}
 	}
-	html = bytes.Replace(html, []byte("</head>"), []byte(headSnippet+"</head>"), 1)
-	_, _ = w.Write(html)
+	return serveui.RenderIndexHTML(s.cfg.basePath, headSnippet)
 }
 
 func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -26,6 +26,7 @@ import (
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/serveui"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
@@ -556,6 +557,59 @@ func TestHandleUI_VersionedAssetCaching(t *testing.T) {
 	}
 	if got := rr.Header().Get("Cache-Control"); got != "no-cache" {
 		t.Errorf("unversioned asset cache-control = %q, want no-cache", got)
+	}
+}
+
+func TestHandleUI_IndexVersionsShellAssets(t *testing.T) {
+	srv := &serveServer{cfg: serveServerConfig{ui: true, basePath: "/ui"}}
+	version := serveui.AssetVersion()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	srv.handleUI(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, snippet := range []string{
+		`href="manifest.webmanifest?v=` + version + `"`,
+		`href="icon-512.png?v=` + version + `"`,
+		`href="app.css?v=` + version + `"`,
+		`src="app-core.js?v=` + version + `"`,
+		`src="app-render.js?v=` + version + `"`,
+		`src="app-stream.js?v=` + version + `"`,
+		`src="app-sessions.js?v=` + version + `"`,
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("expected %q in body", snippet)
+		}
+	}
+}
+
+func TestHandleUI_ServiceWorkerVersionsShellCache(t *testing.T) {
+	srv := &serveServer{cfg: serveServerConfig{ui: true, basePath: "/ui"}}
+	version := serveui.AssetVersion()
+
+	req := httptest.NewRequest(http.MethodGet, "/sw.js", nil)
+	rr := httptest.NewRecorder()
+	srv.handleUI(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, snippet := range []string{
+		`term-llm-shell-` + version,
+		`'./manifest.webmanifest?v=` + version + `'`,
+		`'./icon-512.png?v=` + version + `'`,
+		`'./app.css?v=` + version + `'`,
+		`'./app-core.js?v=` + version + `'`,
+		`'./app-render.js?v=` + version + `'`,
+		`'./app-stream.js?v=` + version + `'`,
+		`'./app-sessions.js?v=` + version + `'`,
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("expected %q in body", snippet)
+		}
 	}
 }
 

--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -1,20 +1,122 @@
 package serveui
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"fmt"
+	htmlpkg "html"
 	"io/fs"
+	"sort"
 	"strings"
+	"sync"
 )
 
 //go:embed static/*
 var staticFiles embed.FS
+
+var (
+	assetVersionOnce sync.Once
+	assetVersion     string
+)
+
+// AssetVersion returns a stable hash of the embedded UI assets.
+func AssetVersion() string {
+	assetVersionOnce.Do(func() {
+		entries := make([]string, 0, 32)
+		_ = fs.WalkDir(staticFiles, "static", func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			entries = append(entries, path)
+			return nil
+		})
+		sort.Strings(entries)
+		h := sha256.New()
+		for _, path := range entries {
+			data, err := fs.ReadFile(staticFiles, path)
+			if err != nil {
+				continue
+			}
+			_, _ = h.Write([]byte(path))
+			_, _ = h.Write([]byte{0})
+			_, _ = h.Write(data)
+			_, _ = h.Write([]byte{0})
+		}
+		assetVersion = hex.EncodeToString(h.Sum(nil))[:12]
+	})
+	return assetVersion
+}
+
+func versioned(path string) string {
+	return path + "?v=" + AssetVersion()
+}
 
 // IndexHTML returns the embedded UI page.
 func IndexHTML() []byte {
 	data, err := StaticAsset("index.html")
 	if err != nil {
 		return nil
+	}
+	return data
+}
+
+// RenderIndexHTML returns the index page with versioned first-party assets and caller-supplied head markup.
+func RenderIndexHTML(basePath, headSnippet string) []byte {
+	html := IndexHTML()
+	if len(html) == 0 {
+		return nil
+	}
+
+	replacements := []struct{ old, new string }{
+		{`href="icon-512.png"`, `href="` + versioned("icon-512.png") + `"`},
+		{`href="manifest.webmanifest"`, `href="` + versioned("manifest.webmanifest") + `"`},
+		{`href="app.css"`, `href="` + versioned("app.css") + `"`},
+		{`src="app-core.js"`, `src="` + versioned("app-core.js") + `"`},
+		{`src="app-render.js"`, `src="` + versioned("app-render.js") + `"`},
+		{`src="app-stream.js"`, `src="` + versioned("app-stream.js") + `"`},
+		{`src="app-sessions.js"`, `src="` + versioned("app-sessions.js") + `"`},
+	}
+	for _, replacement := range replacements {
+		html = bytes.ReplaceAll(html, []byte(replacement.old), []byte(replacement.new))
+	}
+
+	baseTag := `<base href="` + htmlpkg.EscapeString(basePath) + `/">`
+	html = bytes.Replace(html, []byte(`<meta charset="utf-8">`), []byte(`<meta charset="utf-8">`+"\n  "+baseTag), 1)
+	if headSnippet != "" {
+		html = bytes.Replace(html, []byte("</head>"), []byte(headSnippet+"</head>"), 1)
+	}
+	return html
+}
+
+// RenderManifest returns the manifest with versioned icon URLs.
+func RenderManifest() []byte {
+	data, err := StaticAsset("manifest.webmanifest")
+	if err != nil {
+		return nil
+	}
+	return bytes.ReplaceAll(data, []byte(`"./icon-512.png"`), []byte(`"./`+versioned("icon-512.png")+`"`))
+}
+
+// RenderServiceWorker returns the service worker with a versioned cache key and shell asset URLs.
+func RenderServiceWorker() []byte {
+	data, err := StaticAsset("sw.js")
+	if err != nil {
+		return nil
+	}
+	replacements := []struct{ old, new string }{
+		{"term-llm-shell-v2", "term-llm-shell-" + AssetVersion()},
+		{"'./manifest.webmanifest'", "'./" + versioned("manifest.webmanifest") + "'"},
+		{"'./icon-512.png'", "'./" + versioned("icon-512.png") + "'"},
+		{"'./app.css'", "'./" + versioned("app.css") + "'"},
+		{"'./app-core.js'", "'./" + versioned("app-core.js") + "'"},
+		{"'./app-render.js'", "'./" + versioned("app-render.js") + "'"},
+		{"'./app-stream.js'", "'./" + versioned("app-stream.js") + "'"},
+		{"'./app-sessions.js'", "'./" + versioned("app-sessions.js") + "'"},
+	}
+	for _, replacement := range replacements {
+		data = bytes.ReplaceAll(data, []byte(replacement.old), []byte(replacement.new))
 	}
 	return data
 }

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -347,7 +347,6 @@ const initialize = async () => {
   autoGrowPrompt();
   updateVoiceUI();
   refreshNotificationUI();
-  hideStartupSplash();
   void registerServiceWorker().then(() => refreshNotificationUI());
 
   try {


### PR DESCRIPTION
## What

Version the first-party PWA shell assets so app updates actually invalidate the cached shell, and keep the startup splash visible until initialization completes.

Specifically this:

- derives a stable 12-character UI asset hash from the embedded `internal/serveui/static/*` files
- appends `?v=<hash>` to first-party shell assets in the rendered HTML (`app.css`, `app-core.js`, `app-render.js`, `app-stream.js`, `app-sessions.js`, `manifest.webmanifest`, `icon-512.png`)
- serves rendered `index.html`, `manifest.webmanifest`, and `sw.js` dynamically so those versioned URLs are emitted consistently
- changes the service worker shell cache key from a fixed `term-llm-shell-v2` to `term-llm-shell-<hash>` and precaches the versioned shell asset URLs
- removes the early `hideStartupSplash()` call so the startup overlay stays up during the actual auth/model/session boot work instead of disappearing immediately
- adds tests covering versioned shell URLs in the HTML and service worker output

## Why

The new loading screen could fail to show in an installed PWA for two separate reasons:

1. first-party shell assets were still fetched at stable URLs, while the service worker used a cache-first shell strategy and a fixed cache name, so PWA installs could keep serving the old shell after an upgrade
2. even when the new code loaded, the splash was being hidden before the async initialization flow started, so it often only flashed or never appeared meaningfully

This makes shell updates self-busting and lets the loading screen remain visible for the part of startup that is actually loading.

## Testing

- `go test ./cmd`
- `go test ./...`
- `go build ./...`
