### PR TITLE
move docs site into term-llm repo

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -1,0 +1,78 @@
+name: Deploy docs site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+      - 'ops/nginx/term-llm*.conf'
+      - '.github/workflows/deploy-docs-site.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare release directories
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: wasnotwas.com
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            rm -rf /root/term-llm-release
+            mkdir -p /root/term-llm-release/site /root/term-llm-release/ops/nginx
+
+      - name: Upload static site assets
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: wasnotwas.com
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "docs-site/*"
+          target: "/root/term-llm-release/site"
+          strip_components: 1
+
+      - name: Upload nginx configuration
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: wasnotwas.com
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "ops/nginx/term-llm*.conf"
+          target: "/root/term-llm-release/ops/nginx"
+          strip_components: 2
+
+      - name: Install nginx config, issue cert, and swap webroot
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: wasnotwas.com
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+
+            mkdir -p /var/www/term-llm /etc/nginx/sites-available /etc/nginx/sites-enabled
+            rsync -a --delete /root/term-llm-release/site/ /var/www/term-llm/
+
+            cp /root/term-llm-release/ops/nginx/term-llm-http.conf /etc/nginx/sites-available/term-llm.conf
+            ln -sfn /etc/nginx/sites-available/term-llm.conf /etc/nginx/sites-enabled/term-llm.conf
+            nginx -t
+            systemctl reload nginx
+
+            if [ ! -f /etc/letsencrypt/live/term-llm.com/fullchain.pem ]; then
+              certbot certonly \
+                --webroot \
+                -w /var/www/term-llm \
+                -d term-llm.com \
+                -d www.term-llm.com \
+                --non-interactive \
+                --agree-tos
+            fi
+
+            cp /root/term-llm-release/ops/nginx/term-llm.conf /etc/nginx/sites-available/term-llm.conf
+            nginx -t
+            systemctl reload nginx

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Swiss Army knife for your terminal—AI-powered commands, answers, and images 
 
 [![Release](https://img.shields.io/github/v/release/samsaffron/term-llm?style=flat-square)](https://github.com/samsaffron/term-llm/releases)
 
+Docs hub: **https://term-llm.com**
+
 ## Features
 
 - **Command suggestions**: Natural language → executable shell commands

--- a/docs-site/architecture/index.html
+++ b/docs-site/architecture/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Architecture · term-llm docs</title>
+    <meta
+      name="description"
+      content="Architecture overview for term-llm: runtimes, sessions, tools, skills, memory, and routing."
+    />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="docs-page">
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="/">term-llm</a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="/getting-started/">Start</a>
+          <a href="/guides/">Guides</a>
+          <a class="active" href="/architecture/">Architecture</a>
+          <a href="/reference/">Reference</a>
+          <a href="https://github.com/samsaffron/term-llm">GitHub</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="doc-hero">
+          <div class="breadcrumbs"><a href="/">Docs</a><span>→</span><span>Architecture</span></div>
+          <p class="eyebrow">Understand the system</p>
+          <h1>How the moving pieces actually fit together.</h1>
+          <p class="doc-intro">
+            term-llm has enough subsystems now that “just read the README” is no longer a serious answer.
+            Architecture docs should explain the model without forcing people to reverse-engineer the runtime.
+          </p>
+        </section>
+
+        <section class="doc-section">
+          <div class="card-grid card-grid-2">
+            <article class="card detail-card">
+              <h3>Core architecture pages</h3>
+              <ul>
+                <li>Runtimes: chat, web, jobs, Telegram</li>
+                <li>Sessions, persistence, and stateless turns</li>
+                <li>Agents vs tools vs skills</li>
+                <li>Memory model and fragment store</li>
+                <li>Search and model routing</li>
+              </ul>
+            </article>
+            <article class="card detail-card">
+              <h3>Design questions worth answering directly</h3>
+              <ul>
+                <li>Why externalized memory instead of giant prompts</li>
+                <li>What state lives where</li>
+                <li>How jobs and sub-agents differ</li>
+                <li>Where provider-specific complexity leaks through</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="doc-section">
+          <div class="doc-grid">
+            <div class="doc-surface">
+              <h3>Architecture page rules</h3>
+              <ul class="simple-list">
+                <li>Explain, do not meander</li>
+                <li>Use diagrams and examples where they pay rent</li>
+                <li>Link out to guides for procedures</li>
+                <li>Link out to reference for exact flags, schemas, and endpoints</li>
+              </ul>
+            </div>
+            <aside class="doc-meta">
+              <div class="doc-surface">
+                <h3>Why this section matters</h3>
+                <p>The system now has enough shape that users and contributors need a mental model, not just commands.</p>
+              </div>
+              <div class="doc-surface">
+                <h3>Failure mode</h3>
+                <p>Pages that are really just code comments with better typography. That is not architecture documentation.</p>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <p>Architecture shelf under construction.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs-site/favicon.svg
+++ b/docs-site/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="term-llm icon">
+  <rect width="128" height="128" rx="24" fill="#0b1020" />
+  <path d="M28 34h72v12H28zm0 24h48v12H28zm0 24h72v12H28z" fill="#8bffb0" />
+  <path d="M82 58l18 18-18 18" fill="none" stroke="#8bffb0" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" />
+</svg>

--- a/docs-site/getting-started/index.html
+++ b/docs-site/getting-started/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Getting started · term-llm docs</title>
+    <meta
+      name="description"
+      content="Getting started path for term-llm: install, configure, and reach a first successful run."
+    />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="docs-page">
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="/">term-llm</a>
+        <nav class="topnav" aria-label="Primary">
+          <a class="active" href="/getting-started/">Start</a>
+          <a href="/guides/">Guides</a>
+          <a href="/architecture/">Architecture</a>
+          <a href="/reference/">Reference</a>
+          <a href="https://github.com/samsaffron/term-llm">GitHub</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="doc-hero">
+          <div class="breadcrumbs"><a href="/">Docs</a><span>→</span><span>Getting started</span></div>
+          <p class="eyebrow">Start here</p>
+          <h1>From zero to a first useful run.</h1>
+          <p class="doc-intro">
+            This path should get someone from “what the hell is this” to “it is installed,
+            configured, and doing something real” without drowning them in architecture too early.
+          </p>
+        </section>
+
+        <section class="doc-section">
+          <div class="doc-grid">
+            <div class="doc-surface">
+              <h3>Planned pages</h3>
+              <ul class="simple-list">
+                <li>What term-llm is and who it is for</li>
+                <li>Installation on Linux and macOS</li>
+                <li>Minimum config for a first chat</li>
+                <li>Running chat, web, and jobs modes</li>
+                <li>First successful agent/tool workflow</li>
+              </ul>
+            </div>
+            <aside class="doc-meta">
+              <div class="doc-surface">
+                <h3>Primary outcome</h3>
+                <p>A user can install term-llm, configure one provider, and run the thing successfully.</p>
+              </div>
+              <div class="doc-surface">
+                <h3>Not for this page set</h3>
+                <p>Deep routing theory, edge-case operators notes, or giant config matrices. That belongs elsewhere.</p>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section class="doc-section">
+          <div class="card-grid card-grid-3">
+            <article class="card detail-card">
+              <p class="card-kicker">Step 1</p>
+              <h3>Install</h3>
+              <p>How to get the binary or build it locally without the docs wandering off into contributor mode.</p>
+            </article>
+            <article class="card detail-card">
+              <p class="card-kicker">Step 2</p>
+              <h3>Configure</h3>
+              <p>Provider credentials, essential settings, and just enough explanation to avoid common footguns.</p>
+            </article>
+            <article class="card detail-card">
+              <p class="card-kicker">Step 3</p>
+              <h3>Run</h3>
+              <p>First chat, first web run, first job. The docs should prove the system works before philosophizing.</p>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <p>Skeleton page. The structure is here; the real docs still need writing.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs-site/guides/index.html
+++ b/docs-site/guides/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Guides · term-llm docs</title>
+    <meta
+      name="description"
+      content="Task-focused guides for term-llm: providers, agents, memory, jobs, web, and Telegram."
+    />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="docs-page">
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="/">term-llm</a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="/getting-started/">Start</a>
+          <a class="active" href="/guides/">Guides</a>
+          <a href="/architecture/">Architecture</a>
+          <a href="/reference/">Reference</a>
+          <a href="https://github.com/samsaffron/term-llm">GitHub</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="doc-hero">
+          <div class="breadcrumbs"><a href="/">Docs</a><span>→</span><span>Guides</span></div>
+          <p class="eyebrow">Do a thing</p>
+          <h1>Task-focused docs, not essay-shaped wandering.</h1>
+          <p class="doc-intro">
+            Guides should solve one concrete problem each. If a page starts trying to teach the whole system,
+            it belongs in architecture or getting started instead.
+          </p>
+        </section>
+
+        <section class="doc-section">
+          <div class="card-grid card-grid-3">
+            <article class="card detail-card">
+              <h3>Providers and models</h3>
+              <ul>
+                <li>Configure OpenAI-compatible endpoints</li>
+                <li>Switch provider routing</li>
+                <li>Handle auth and model naming footguns</li>
+              </ul>
+            </article>
+            <article class="card detail-card">
+              <h3>Agents, memory, and skills</h3>
+              <ul>
+                <li>Create an agent</li>
+                <li>Persist the right memory</li>
+                <li>Use skills without turning prompts into soup</li>
+              </ul>
+            </article>
+            <article class="card detail-card">
+              <h3>Runtimes and automation</h3>
+              <ul>
+                <li>Run web mode</li>
+                <li>Set up Telegram</li>
+                <li>Create scheduled jobs</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="doc-section">
+          <div class="doc-grid">
+            <div class="doc-surface">
+              <h3>Guide rules</h3>
+              <ul class="simple-list">
+                <li>One job per guide</li>
+                <li>Use step-by-step instructions where they help</li>
+                <li>Link to reference for exact flags and config keys</li>
+                <li>Link to architecture when understanding is required</li>
+              </ul>
+            </div>
+            <aside class="doc-meta">
+              <div class="doc-surface">
+                <h3>Examples to add</h3>
+                <p>Set up web UI, add a provider, configure memory, write a job, and debug a failing tool call.</p>
+              </div>
+              <div class="doc-surface">
+                <h3>Anti-pattern</h3>
+                <p>A guide that becomes half tutorial, half internal architecture note, and half reference page. Three halves again.</p>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <p>Guide shelf under construction.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>term-llm docs</title>
+    <meta
+      name="description"
+      content="term-llm documentation hub: getting started, guides, architecture, and reference."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="term-llm docs" />
+    <meta
+      property="og:description"
+      content="A terminal-first AI runtime for chat, web, jobs, agents, tools, skills, and memory."
+    />
+    <meta property="og:url" content="https://term-llm.com/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="term-llm docs" />
+    <meta
+      name="twitter:description"
+      content="Documentation hub for the terminal-first AI runtime."
+    />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="/">term-llm</a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="/getting-started/">Start</a>
+          <a href="/guides/">Guides</a>
+          <a href="/architecture/">Architecture</a>
+          <a href="/reference/">Reference</a>
+          <a href="https://github.com/samsaffron/term-llm">GitHub</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="hero">
+          <div>
+            <p class="eyebrow">Documentation hub</p>
+            <h1>A front door, not another markdown landfill.</h1>
+            <p class="lede">
+              term-llm has outgrown the giant README. This is the hub: clear paths,
+              fewer dead ends, and room for the docs to become an actual product.
+            </p>
+            <div class="actions">
+              <a class="button primary" href="/getting-started/">Open quickstart path</a>
+              <a class="button" href="/reference/">Browse reference skeleton</a>
+            </div>
+          </div>
+
+          <aside class="hero-panel terminal-panel">
+            <div class="terminal-bar">
+              <span></span><span></span><span></span>
+            </div>
+            <pre><code>$ term-llm chat --agent jarvis
+
+&gt; what is term-llm?
+
+A terminal-first AI runtime with:
+- chat, web, and jobs runtimes
+- agents, tools, skills, and memory
+- enough structure to run real workflows
+  instead of demo theatre</code></pre>
+          </aside>
+        </section>
+
+        <section class="section-block">
+          <div class="section-heading">
+            <p class="eyebrow">Choose your path</p>
+            <h2>Start with intent, not file names</h2>
+          </div>
+
+          <div class="card-grid card-grid-4">
+            <a class="card path-card" href="/getting-started/">
+              <p class="card-kicker">New here</p>
+              <h3>Getting started</h3>
+              <p>Install, configure, and get to a first successful run without archaeology.</p>
+            </a>
+            <a class="card path-card" href="/guides/">
+              <p class="card-kicker">Do a thing</p>
+              <h3>Guides</h3>
+              <p>Task-focused docs for providers, agents, memory, jobs, web, and Telegram.</p>
+            </a>
+            <a class="card path-card" href="/architecture/">
+              <p class="card-kicker">Understand it</p>
+              <h3>Architecture</h3>
+              <p>How sessions, runtimes, tools, skills, memory, and routing actually fit together.</p>
+            </a>
+            <a class="card path-card" href="/reference/">
+              <p class="card-kicker">Need exact truth</p>
+              <h3>Reference</h3>
+              <p>CLI, config, env vars, API surface, and the sharp edges where hand-waving dies.</p>
+            </a>
+          </div>
+        </section>
+
+        <section class="section-block split-layout">
+          <div>
+            <div class="section-heading">
+              <p class="eyebrow">What belongs here</p>
+              <h2>Documentation shape</h2>
+            </div>
+            <div class="list-panel">
+              <ul class="check-list">
+                <li>Quickstart flows that get from zero to useful</li>
+                <li>How-to guides for concrete tasks</li>
+                <li>Architecture pages that explain the model</li>
+                <li>Reference pages that stop arguing and state facts</li>
+              </ul>
+            </div>
+          </div>
+
+          <div>
+            <div class="section-heading">
+              <p class="eyebrow">What does not</p>
+              <h2>Things we are trying not to repeat</h2>
+            </div>
+            <div class="list-panel">
+              <ul class="warning-list">
+                <li>One README containing tutorial, manifesto, and config dump in a trench coat</li>
+                <li>GitHub directory spelunking mistaken for information architecture</li>
+                <li>Pretty docs chrome hiding content that still has no classification</li>
+                <li>Reference facts trapped inside prose paragraphs nobody can scan</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="section-block">
+          <div class="section-heading">
+            <p class="eyebrow">First skeleton</p>
+            <h2>Planned doc clusters</h2>
+          </div>
+          <div class="card-grid card-grid-2">
+            <article class="card detail-card">
+              <h3>Core user paths</h3>
+              <ul>
+                <li>First chat</li>
+                <li>Running the web UI and API</li>
+                <li>Scheduling jobs</li>
+                <li>Configuring agents, tools, skills, and memory</li>
+              </ul>
+            </article>
+            <article class="card detail-card">
+              <h3>Operator and contributor paths</h3>
+              <ul>
+                <li>Deploying runtimes</li>
+                <li>Understanding session/state behavior</li>
+                <li>Adding providers and tools</li>
+                <li>Troubleshooting weird runtime failure modes</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <p>Initial docs hub skeleton for term-llm.com. Better than a README trying to swallow the planet.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs-site/reference/index.html
+++ b/docs-site/reference/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reference · term-llm docs</title>
+    <meta
+      name="description"
+      content="Reference docs for term-llm: CLI, config, env vars, HTTP API, and runtime file layout."
+    />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body class="docs-page">
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="/">term-llm</a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="/getting-started/">Start</a>
+          <a href="/guides/">Guides</a>
+          <a href="/architecture/">Architecture</a>
+          <a class="active" href="/reference/">Reference</a>
+          <a href="https://github.com/samsaffron/term-llm">GitHub</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="doc-hero">
+          <div class="breadcrumbs"><a href="/">Docs</a><span>→</span><span>Reference</span></div>
+          <p class="eyebrow">Exact truth</p>
+          <h1>Facts, flags, schemas, and nothing pretending to be a tutorial.</h1>
+          <p class="doc-intro">
+            Reference docs should be boring in the good way: scan-friendly, exact, and not hiding key facts in narrative detours.
+          </p>
+        </section>
+
+        <section class="doc-section">
+          <div class="card-grid card-grid-2">
+            <article class="card detail-card">
+              <h3>Reference buckets</h3>
+              <ul>
+                <li>CLI commands and flags</li>
+                <li>Configuration schema and examples</li>
+                <li>Environment variables</li>
+                <li>HTTP API endpoints</li>
+                <li>Runtime file layout</li>
+              </ul>
+            </article>
+            <article class="card detail-card">
+              <h3>Good reference behavior</h3>
+              <ul>
+                <li>Tables when tables help</li>
+                <li>Copy-paste examples</li>
+                <li>Cross-links to guides, not repeated walkthroughs</li>
+                <li>One canonical place for exact values</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="doc-section">
+          <div class="doc-grid">
+            <div class="doc-surface">
+              <h3>Likely first pages</h3>
+              <ul class="simple-list">
+                <li>CLI command map</li>
+                <li><code>config.yaml</code> schema and common settings</li>
+                <li>Provider configuration keys</li>
+                <li>HTTP API surface</li>
+                <li>Jobs and scheduling config</li>
+              </ul>
+            </div>
+            <aside class="doc-meta">
+              <div class="doc-surface">
+                <h3>Warning</h3>
+                <p>If reference pages start telling a story, they are slipping into guides again.</p>
+              </div>
+              <div class="doc-surface">
+                <h3>What this unlocks</h3>
+                <p>Shorter guides, cleaner README, and fewer repeated config snippets rotting in different corners.</p>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <p>Reference shelf under construction.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs-site/styles.css
+++ b/docs-site/styles.css
@@ -1,0 +1,438 @@
+:root {
+  color-scheme: dark;
+  --bg: #08111f;
+  --bg-2: #0d1728;
+  --panel: rgba(10, 18, 32, 0.86);
+  --panel-strong: rgba(14, 24, 42, 0.95);
+  --panel-border: rgba(90, 153, 255, 0.18);
+  --text: #e7edf7;
+  --muted: #9ba9bd;
+  --soft: #c7d3e4;
+  --accent: #72f1b8;
+  --accent-2: #7dd3fc;
+  --danger: #ffb4a2;
+  --shadow: rgba(0, 0, 0, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(125, 211, 252, 0.14), transparent 34%),
+    radial-gradient(circle at 18% 16%, rgba(114, 241, 184, 0.1), transparent 28%),
+    linear-gradient(180deg, #0b1220 0%, #050a13 100%);
+}
+
+body.docs-page {
+  background:
+    radial-gradient(circle at top right, rgba(125, 211, 252, 0.12), transparent 28%),
+    linear-gradient(180deg, var(--bg-2) 0%, #060b14 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+  background-size: 40px 40px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent 85%);
+}
+
+.page-shell {
+  width: min(1160px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.25rem 0 3rem;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  margin-bottom: 2rem;
+  background: rgba(8, 14, 25, 0.6);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+  border-radius: 18px;
+  backdrop-filter: blur(10px);
+}
+
+.brand {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.topnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.topnav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.96rem;
+}
+
+.topnav a:hover,
+.topnav a.active,
+.brand:hover,
+.card:hover h3,
+.card:hover .card-link {
+  color: var(--text);
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero,
+.section-block,
+.doc-hero,
+.doc-section {
+  position: relative;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 28px;
+  box-shadow: 0 20px 60px var(--shadow);
+}
+
+.hero,
+.doc-hero {
+  padding: 2rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.95fr);
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.doc-hero {
+  display: grid;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.7rem;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.84rem;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  line-height: 1.03;
+}
+
+h1 {
+  max-width: 11ch;
+  font-size: clamp(2.9rem, 7vw, 5.8rem);
+}
+
+.doc-hero h1 {
+  max-width: 16ch;
+  font-size: clamp(2.2rem, 5vw, 4.2rem);
+}
+
+h2 {
+  font-size: clamp(1.55rem, 3vw, 2.2rem);
+}
+
+h3 {
+  font-size: 1.26rem;
+}
+
+.lede,
+.doc-intro {
+  max-width: 60rem;
+  margin: 1.1rem 0 0;
+  color: var(--soft);
+  font-size: clamp(1.05rem, 2vw, 1.22rem);
+  line-height: 1.75;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.92rem 1.24rem;
+  border-radius: 999px;
+  border: 1px solid rgba(155, 169, 189, 0.24);
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 650;
+  background: rgba(13, 23, 40, 0.74);
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.button:hover,
+.card:hover {
+  transform: translateY(-1px);
+}
+
+.button:hover {
+  background: rgba(13, 23, 40, 0.96);
+  border-color: rgba(114, 241, 184, 0.44);
+}
+
+.button.primary {
+  background: linear-gradient(135deg, rgba(114, 241, 184, 0.2), rgba(125, 211, 252, 0.12));
+  border-color: rgba(114, 241, 184, 0.36);
+}
+
+.terminal-panel,
+.list-panel,
+.card,
+.doc-surface {
+  background: var(--panel-strong);
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  border-radius: 22px;
+}
+
+.terminal-panel {
+  overflow: hidden;
+}
+
+.terminal-bar {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(125, 211, 252, 0.12);
+  background: rgba(4, 8, 16, 0.6);
+}
+
+.terminal-bar span {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 999px;
+  background: rgba(155, 169, 189, 0.28);
+}
+
+.terminal-panel pre {
+  margin: 0;
+  padding: 1.3rem 1.25rem 1.4rem;
+  color: var(--soft);
+  font-size: 0.94rem;
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
+.terminal-panel code,
+.doc-surface code {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+}
+
+.section-block,
+.doc-section {
+  padding: 1.55rem;
+}
+
+.section-heading {
+  margin-bottom: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.card-grid-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.card-grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card {
+  padding: 1.25rem;
+  color: inherit;
+  text-decoration: none;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.card:hover {
+  border-color: rgba(114, 241, 184, 0.3);
+  background: rgba(16, 27, 46, 0.98);
+  text-decoration: none;
+}
+
+.card-kicker {
+  margin: 0 0 0.55rem;
+  color: var(--accent-2);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card p,
+.card li,
+.doc-section p,
+.doc-section li,
+.doc-hero li {
+  color: var(--muted);
+  line-height: 1.72;
+}
+
+.card ul,
+.doc-section ul,
+.doc-hero ul {
+  margin: 0.9rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.path-card h3,
+.detail-card h3,
+.doc-surface h3 {
+  margin-bottom: 0.65rem;
+}
+
+.split-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.check-list,
+.warning-list,
+.simple-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.warning-list li::marker {
+  color: var(--danger);
+}
+
+.list-panel {
+  padding: 1.2rem;
+  min-height: 100%;
+}
+
+.breadcrumbs {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.breadcrumbs a {
+  color: var(--accent-2);
+  text-decoration: none;
+}
+
+.doc-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.9fr);
+  gap: 1rem;
+}
+
+.doc-surface {
+  padding: 1.25rem;
+}
+
+.doc-surface h3 {
+  margin-bottom: 0.7rem;
+}
+
+.doc-meta {
+  display: grid;
+  gap: 1rem;
+}
+
+.card-link {
+  color: var(--accent-2);
+  font-weight: 600;
+}
+
+.site-footer {
+  margin-top: 1.5rem;
+  padding: 1.2rem 0 0;
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 1024px) {
+  .hero,
+  .doc-grid,
+  .card-grid-4,
+  .card-grid-3,
+  .split-layout {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .page-shell {
+    width: min(100%, calc(100% - 1rem));
+    padding-top: 0.5rem;
+  }
+
+  .topbar,
+  .hero,
+  .doc-hero,
+  .section-block,
+  .doc-section {
+    padding: 1.2rem;
+  }
+
+  .topbar,
+  .topnav,
+  .actions,
+  .card-grid-4,
+  .card-grid-3,
+  .card-grid-2,
+  .split-layout,
+  .doc-grid {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  h1 {
+    max-width: 100%;
+    font-size: clamp(2.3rem, 11vw, 3.4rem);
+  }
+
+  .doc-hero h1 {
+    font-size: clamp(1.9rem, 9vw, 2.8rem);
+  }
+}

--- a/ops/nginx/term-llm-http.conf
+++ b/ops/nginx/term-llm-http.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name term-llm.com www.term-llm.com;
+
+    root /var/www/term-llm;
+    index index.html;
+
+    location /.well-known/acme-challenge/ {
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/ops/nginx/term-llm.conf
+++ b/ops/nginx/term-llm.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name www.term-llm.com term-llm.com;
+    return 301 https://term-llm.com$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name www.term-llm.com;
+
+    ssl_certificate /etc/letsencrypt/live/term-llm.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/term-llm.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://term-llm.com$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name term-llm.com;
+
+    root /var/www/term-llm;
+    index index.html;
+
+    ssl_certificate /etc/letsencrypt/live/term-llm.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/term-llm.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location /.well-known/acme-challenge/ {
+        try_files $uri =404;
+    }
+
+    location = /robots.txt {
+        add_header Content-Type text/plain;
+        return 200 "User-agent: *\nAllow: /\n";
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## What

- move the `term-llm.com` docs hub into the `term-llm` repo under `docs-site/`
- rebuild the docs site as a Hugo site so docs content lives in Markdown under `docs-site/content/`
- migrate the big README sections into sectioned docs pages for getting started, guides, architecture, and reference
- slim the root `README.md` down to a GitHub-friendly front page with install, quickstart, and docs links
- add the current nginx config under `ops/nginx/`
- add a GitHub Actions workflow that builds the Hugo site and deploys it to the existing `wasnotwas.com` host on pushes to `main`

## Why

The docs site should live with the project it documents, not in the separate `wasnotwas.com` repo. At the same time, the root README had become an overgrown warehouse. This PR puts the docs hub, its deployment path, and a first serious README decomposition in the `term-llm` repo, while keeping the actual docs authored in Markdown and rendered into a proper site by Hugo.

## Notes

- the workflow expects a `DEPLOY_SSH_KEY` repository secret in `samsaffron/term-llm`
- the workflow keeps the current deployment target (`wasnotwas.com`) and webroot (`/var/www/term-llm`)
- docs content now lives under `docs-site/content/`; layouts and styling live under `docs-site/layouts/` and `docs-site/static/`

## Verification

- `hugo --source docs-site --destination /tmp/term-llm-docs-build`
- `go build ./...`
- `go test ./...`
