### PR TITLE
feat: finish Venice provider support

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -219,6 +219,7 @@ func printAnnotatedConfig(defaults map[string]any, rawKeys, unknownKeys map[stri
 				"gemini":     {"model", "api_key"},
 				"openai":     {"model", "api_key"},
 				"xai":        {"model", "api_key"},
+				"venice":     {"model", "edit_model", "resolution", "api_key"},
 				"flux":       {"model", "api_key"},
 				"openrouter": {"model", "api_key"},
 			},
@@ -396,7 +397,7 @@ func printProvidersSection(defaults map[string]any, rawKeys map[string]bool, raw
 	providerNames := make(map[string]bool)
 
 	// Default providers
-	defaultProviders := []string{"anthropic", "openai", "xai", "openrouter", "gemini", "zen"}
+	defaultProviders := []string{"anthropic", "openai", "xai", "venice", "openrouter", "gemini", "zen"}
 	for _, p := range defaultProviders {
 		providerNames[p] = true
 	}
@@ -781,6 +782,12 @@ providers:
     app_url: https://github.com/samsaffron/term-llm
     app_title: term-llm
 
+  xai:
+    model: grok-4-1-fast
+
+  venice:
+    model: venice-uncensored
+
   zen:
     model: minimax-m2.1-free
     # api_key optional - free tier access via opencode.ai
@@ -845,7 +852,7 @@ edit:
 
 # Image generation settings
 image:
-  provider: gemini  # gemini, openai, or flux
+  provider: gemini  # gemini, openai, xai, venice, flux, or openrouter
   output_dir: ~/Pictures/term-llm
 
   gemini:
@@ -856,9 +863,23 @@ image:
     model: gpt-image-1
     # api_key: uses OPENAI_API_KEY env var
 
+  xai:
+    model: grok-2-image-1212
+    # api_key: uses XAI_API_KEY env var
+
+  venice:
+    model: nano-banana-pro
+    # edit_model: optional override for image edits
+    resolution: 2K
+    # api_key: uses VENICE_API_KEY env var
+
   flux:
     model: flux-2-pro
     # api_key: uses BFL_API_KEY env var
+
+  openrouter:
+    model: google/gemini-2.5-flash-image
+    # api_key: uses OPENROUTER_API_KEY env var
 `
 }
 

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -28,6 +28,7 @@ Examples:
   term-llm models                       # list models from current provider
   term-llm models --provider anthropic  # list models from Anthropic
   term-llm models --provider openrouter # list models from OpenRouter
+  term-llm models --provider venice     # list models from Venice
   term-llm models --provider ollama     # list models from Ollama
   term-llm models --provider lmstudio   # list models from LM Studio
   term-llm models --json                # output as JSON`,
@@ -36,7 +37,7 @@ Examples:
 
 func init() {
 	rootCmd.AddCommand(modelsCmd)
-	modelsCmd.Flags().StringVarP(&modelsProvider, "provider", "p", "", "Provider to list models from (anthropic, copilot, openrouter, xai, zen, ollama, lmstudio, openai-compat)")
+	modelsCmd.Flags().StringVarP(&modelsProvider, "provider", "p", "", "Provider to list models from (anthropic, copilot, openrouter, venice, xai, zen, ollama, lmstudio, openai-compat)")
 	modelsCmd.Flags().BoolVar(&modelsJSON, "json", false, "Output as JSON")
 	modelsCmd.RegisterFlagCompletionFunc("provider", ProviderFlagCompletion)
 }
@@ -81,15 +82,14 @@ func runModels(cmd *cobra.Command, args []string) error {
 		config.ProviderTypeVenice:       true,
 	}
 
-	// For built-in providers without explicit config, check if they support dynamic listing
-	// or fall back to static model list
+	// For built-in providers without explicit config, continue for providers that
+	// can authenticate via environment/default credentials. Otherwise fall back to
+	// static model lists when available.
 	if !ok {
-		// Copilot can work without config (uses OAuth)
-		if providerType == config.ProviderTypeCopilot {
-			// Continue to dynamic listing below
-		} else if staticModels, hasStatic := llm.ProviderModels[providerName]; hasStatic {
-			return printStaticModels(providerName, staticModels)
-		} else {
+		if !supportedTypes[providerType] {
+			if staticModels, hasStatic := llm.ProviderModels[providerName]; hasStatic {
+				return printStaticModels(providerName, staticModels)
+			}
 			return fmt.Errorf("provider '%s' is not configured", providerName)
 		}
 	}
@@ -100,7 +100,7 @@ func runModels(cmd *cobra.Command, args []string) error {
 			return printStaticModels(providerName, staticModels)
 		}
 		return fmt.Errorf("provider '%s' (type: %s) does not support model listing.\n"+
-			"Model listing is supported for: anthropic, openrouter, xai, zen, copilot, and openai_compatible providers", providerName, providerType)
+			"Model listing is supported for: anthropic, openai, openrouter, xai, venice, zen, copilot, and openai_compatible providers", providerName, providerType)
 	}
 
 	// Create provider to query models
@@ -113,10 +113,14 @@ func runModels(cmd *cobra.Command, args []string) error {
 		}
 		lister = provider
 	case config.ProviderTypeOpenAI:
-		if providerCfg.ResolvedAPIKey == "" {
+		apiKey := providerCfg.ResolvedAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("OPENAI_API_KEY")
+		}
+		if apiKey == "" {
 			return fmt.Errorf("openai API key not configured. Set OPENAI_API_KEY or configure api_key")
 		}
-		lister = llm.NewOpenAIProvider(providerCfg.ResolvedAPIKey, providerCfg.Model)
+		lister = llm.NewOpenAIProvider(apiKey, providerCfg.Model)
 	case config.ProviderTypeCopilot:
 		// Copilot uses OAuth - create provider which will prompt for auth if needed
 		model := ""
@@ -129,10 +133,14 @@ func runModels(cmd *cobra.Command, args []string) error {
 		}
 		lister = provider
 	case config.ProviderTypeOpenRouter:
-		if providerCfg.ResolvedAPIKey == "" {
+		apiKey := providerCfg.ResolvedAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("OPENROUTER_API_KEY")
+		}
+		if apiKey == "" {
 			return fmt.Errorf("openrouter API key not configured. Set OPENROUTER_API_KEY or configure api_key")
 		}
-		lister = llm.NewOpenRouterProvider(providerCfg.ResolvedAPIKey, "", providerCfg.AppURL, providerCfg.AppTitle)
+		lister = llm.NewOpenRouterProvider(apiKey, "", providerCfg.AppURL, providerCfg.AppTitle)
 	case config.ProviderTypeOpenAICompat:
 		if providerCfg.BaseURL == "" {
 			return fmt.Errorf("provider '%s' requires base_url to be configured", providerName)

--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -9,7 +9,7 @@ next:
   label: Usage guide
   url: /guides/usage/
 ---
-On first run, term-llm will prompt you to choose a provider (Anthropic, OpenAI, ChatGPT, GitHub Copilot, xAI, OpenRouter, Gemini, Gemini CLI, Zen, Claude Code (claude-bin), Ollama, or LM Studio).
+On first run, term-llm will prompt you to choose a provider (Anthropic, OpenAI, ChatGPT, GitHub Copilot, xAI, Venice, OpenRouter, Gemini, Gemini CLI, Zen, Claude Code (claude-bin), Ollama, or LM Studio).
 
 ### Option 1: Try it free with Zen
 
@@ -43,6 +43,9 @@ export OPENAI_API_KEY=your-key
 
 # For xAI (Grok)
 export XAI_API_KEY=your-key
+
+# For Venice
+export VENICE_API_KEY=your-key
 
 # For OpenRouter
 export OPENROUTER_API_KEY=your-key
@@ -120,7 +123,30 @@ term-llm ask --provider xai:grok-4-1-fast-reasoning "solve this step by step"
 term-llm ask --provider xai:grok-code-fast-1 "review this code"
 ```
 
-### Option 6: Use OpenRouter
+### Option 6: Use Venice
+
+[Venice](https://venice.ai) exposes a wide mix of hosted text models behind an OpenAI-compatible API, including Venice's own uncensored models plus Claude, Gemini, Grok, Qwen, GLM, Kimi, DeepSeek, and more. term-llm also enables Venice native web search when you use `-s` / `--search`.
+
+```yaml
+# In ~/.config/term-llm/config.yaml
+default_provider: venice
+
+providers:
+  venice:
+    model: venice-uncensored  # default model
+    fast_model: llama-3.2-3b  # lightweight control-plane model
+```
+
+Or use the `--provider` flag directly:
+
+```bash
+term-llm ask --provider venice "explain quantum computing"
+term-llm ask --provider venice:grok-4-20-beta -s "latest xAI news"
+term-llm ask --provider venice:qwen3-coder-480b-a35b-instruct "review this code"
+term-llm models --provider venice
+```
+
+### Option 7: Use OpenRouter
 
 [OpenRouter](https://openrouter.ai) provides a unified OpenAI-compatible API across many models. term-llm sends attribution headers by default.
 
@@ -159,7 +185,7 @@ term-llm providers anthropic       # Show details for specific provider
 term-llm providers --json          # JSON output
 ```
 
-### Option 7: Use local LLMs (Ollama, LM Studio)
+### Option 8: Use local LLMs (Ollama, LM Studio)
 
 Run models locally with [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai):
 
@@ -201,7 +227,7 @@ providers:
 
 The `models` list enables tab completion for `--provider my-server:<TAB>`. The configured `model` is always included in completions.
 
-### Option 8: Use Claude Code (claude-bin)
+### Option 9: Use Claude Code (claude-bin)
 
 If you have [Claude Code](https://claude.ai/code) installed and logged in, you can use the `claude-bin` provider to run completions via the [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk). This requires no API key - it uses Claude Code's existing authentication.
 
@@ -230,7 +256,7 @@ providers:
 - Model selection: `opus`, `sonnet` (default), `haiku`
 - Works immediately if Claude Code is installed and logged in
 
-### Option 9: Use existing CLI credentials (gemini-cli)
+### Option 10: Use existing CLI credentials (gemini-cli)
 
 If you have [gemini-cli](https://github.com/google-gemini/gemini-cli) installed and logged in, term-llm can use those credentials directly:
 
@@ -252,7 +278,7 @@ OpenAI-compatible providers support two URL options:
 
 Use `url` when your endpoint doesn't follow the standard `/chat/completions` path, or to paste URLs directly from API documentation.
 
-### Option 10: Use GitHub Copilot
+### Option 11: Use GitHub Copilot
 
 If you have [GitHub Copilot](https://github.com/features/copilot) (free, Individual, or Business), you can use the `copilot` provider with OAuth device flow authentication:
 

--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -1,6 +1,9 @@
 package llm
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 const veniceBaseURL = "https://api.venice.ai/api/v1"
 
@@ -15,7 +18,29 @@ func NewVeniceProvider(apiKey, model string) *VeniceProvider {
 	return &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(veniceBaseURL, apiKey, model, "Venice")}
 }
 
+func (p *VeniceProvider) Capabilities() Capabilities {
+	return Capabilities{
+		NativeWebSearch:    true,
+		NativeWebFetch:     false,
+		ToolCalls:          true,
+		SupportsToolChoice: true,
+	}
+}
+
 func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	req.ParallelToolCalls = false
+	if req.Search {
+		req.Model = appendVeniceModelSuffix(chooseModel(req.Model, p.model), "enable_web_search=on")
+	}
 	return p.OpenAICompatProvider.Stream(ctx, req)
+}
+
+func appendVeniceModelSuffix(model, suffix string) string {
+	if model == "" || suffix == "" {
+		return model
+	}
+	if strings.Contains(model, ":") {
+		return model + "&" + suffix
+	}
+	return model + ":" + suffix
 }

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -1,0 +1,99 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVeniceProviderCapabilities(t *testing.T) {
+	provider := NewVeniceProvider("key", "")
+	caps := provider.Capabilities()
+	if !caps.NativeWebSearch {
+		t.Fatal("expected NativeWebSearch=true")
+	}
+	if caps.NativeWebFetch {
+		t.Fatal("expected NativeWebFetch=false")
+	}
+	if !caps.ToolCalls {
+		t.Fatal("expected ToolCalls=true")
+	}
+	if !caps.SupportsToolChoice {
+		t.Fatal("expected SupportsToolChoice=true")
+	}
+}
+
+func TestAppendVeniceModelSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  string
+		suffix string
+		want   string
+	}{
+		{name: "plain model", model: "venice-uncensored", suffix: "enable_web_search=on", want: "venice-uncensored:enable_web_search=on"},
+		{name: "existing suffix", model: "grok-4-20-beta:enable_x_search=true", suffix: "enable_web_search=on", want: "grok-4-20-beta:enable_x_search=true&enable_web_search=on"},
+		{name: "empty suffix", model: "venice-uncensored", suffix: "", want: "venice-uncensored"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendVeniceModelSuffix(tt.model, tt.suffix); got != tt.want {
+				t.Fatalf("appendVeniceModelSuffix(%q, %q) = %q, want %q", tt.model, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVeniceProviderSearchUsesModelSuffixAndDisablesParallelToolCalls(t *testing.T) {
+	var got struct {
+		Model             string `json:"model"`
+		ParallelToolCalls *bool  `json:"parallel_tool_calls,omitempty"`
+		Stream            bool   `json:"stream"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	provider := &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(ts.URL, "test-key", "venice-uncensored", "Venice")}
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages:          []Message{UserText("latest Venice news")},
+		Search:            true,
+		ParallelToolCalls: true,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.Model != "venice-uncensored:enable_web_search=on" {
+		t.Fatalf("expected search model suffix, got %q", got.Model)
+	}
+	if got.ParallelToolCalls != nil {
+		t.Fatalf("expected parallel_tool_calls to be omitted/false, got %+v", got.ParallelToolCalls)
+	}
+	if !got.Stream {
+		t.Fatal("expected stream=true")
+	}
+}

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -53,6 +53,18 @@ func detectAvailableProviders() []providerOption {
 			hint:      "run 'gemini' to login",
 		},
 		{
+			name:      "xAI - XAI_API_KEY",
+			value:     "xai",
+			available: os.Getenv("XAI_API_KEY") != "",
+			hint:      "set XAI_API_KEY",
+		},
+		{
+			name:      "Venice - VENICE_API_KEY",
+			value:     "venice",
+			available: os.Getenv("VENICE_API_KEY") != "",
+			hint:      "set VENICE_API_KEY",
+		},
+		{
 			name:      "OpenRouter - OPENROUTER_API_KEY",
 			value:     "openrouter",
 			available: os.Getenv("OPENROUTER_API_KEY") != "",
@@ -122,6 +134,18 @@ func detectAvailableImageProviders() []imageProviderOption {
 			value:     "flux",
 			available: os.Getenv("BFL_API_KEY") != "",
 			hint:      "set BFL_API_KEY",
+		},
+		{
+			name:      "xAI - XAI_API_KEY",
+			value:     "xai",
+			available: os.Getenv("XAI_API_KEY") != "",
+			hint:      "set XAI_API_KEY",
+		},
+		{
+			name:      "Venice - VENICE_API_KEY",
+			value:     "venice",
+			available: os.Getenv("VENICE_API_KEY") != "",
+			hint:      "set VENICE_API_KEY",
 		},
 		{
 			name:      "OpenRouter - OPENROUTER_API_KEY",
@@ -289,6 +313,12 @@ func RunSetupWizard() (*config.Config, error) {
 			},
 			"codeassist": {
 				Model: "gemini-2.5-pro",
+			},
+			"xai": {
+				Model: "grok-4-1-fast",
+			},
+			"venice": {
+				Model: "venice-uncensored",
 			},
 			"zen": {
 				Model: "minimax-m2.1-free",


### PR DESCRIPTION
## What

Finish Venice text-provider support across the CLI/UI/docs.

This PR:

- enables Venice native search when `-s/--search` is used by appending Venice model feature suffixes (`enable_web_search=on`)
- marks Venice as native-search capable in provider capabilities
- adds Venice provider tests for capability reporting, model suffix handling, and streamed request wiring
- adds Venice to the setup wizard and gives it a default text model
- lets `term-llm models --provider venice` work from `VENICE_API_KEY` even without explicit config
- updates config output/default config/docs so Venice shows up as a first-class text provider

## Why

Venice already had the basic provider plumbing, but it was still half-hidden:

- setup wizard didn't offer it
- docs/default config didn't present it as a normal text provider
- `models --provider venice` wasn't usable via env-only auth
- `--search` did not actually activate Venice native search

That made the provider technically present but not properly usable.

## Validation

Code-level:

- `go build ./...`
- `go test ./...`

Live smoke tests with a built binary and real `VENICE_API_KEY`:

- `term-llm models --provider venice --json`
  - returned live Venice model list including `venice-uncensored`, `grok-4-20-beta`, `claude-sonnet-4-6`, `openai-gpt-54`, etc.
- `term-llm ask --provider venice:grok-4-20-beta -s --porcelain 'Find the title and URL of the most recent post on the Venice AI blog. Answer with title and URL only.'`
  - returned:
    - `The World's Best Video Model is Now on Venice: Kling 3.0`
    - `https://venice.ai/blog/kling-video-models-suite-live`
