### PR TITLE
polish docs hub copy and remove migration noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Common entry points:
 - [Agents](https://term-llm.com/guides/agents/)
 - [Skills](https://term-llm.com/guides/skills/)
 - [MCP servers](https://term-llm.com/guides/mcp-servers/)
+- [Memory](https://term-llm.com/guides/memory/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Common entry points:
 - [Skills](https://term-llm.com/guides/skills/)
 - [MCP servers](https://term-llm.com/guides/mcp-servers/)
 - [Memory](https://term-llm.com/guides/memory/)
+- [Jobs](https://term-llm.com/guides/job-runner/)
 
 ## License
 

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -1,15 +1,15 @@
 ---
-title: "A front door, not another markdown landfill."
-description: "term-llm has outgrown the giant README. This hub gives people clear paths through getting started, guides, architecture, and reference."
+title: "Documentation"
+description: "Documentation for term-llm, organized into getting started, guides, architecture, and reference."
 belongs: |
-  - Quickstart flows that get from zero to useful
-  - How-to guides for concrete tasks
-  - Architecture pages that explain the model
-  - Reference pages that stop arguing and state facts
+  - Quickstart flows that take you from installation to a working setup
+  - Task-focused guides for common workflows and integrations
+  - Architecture notes that explain how the major pieces fit together
+  - Reference pages for configuration, commands, and persistent state
 avoids: |
-  - One README containing tutorial, manifesto, and config dump in a trench coat
-  - GitHub directory spelunking mistaken for information architecture
-  - Pretty docs chrome hiding content that still has no classification
-  - Reference facts trapped inside prose paragraphs nobody can scan
+  - Mixing tutorials, conceptual notes, and reference material on the same page
+  - Navigation that depends on browsing repository directories
+  - Landing pages that look polished but do not help readers find the right page
+  - Burying important configuration and command details inside long prose
 ---
-term-llm has outgrown the giant README. This is the hub: clear paths, fewer dead ends, and room for the docs to become an actual product.
+term-llm now has a documentation hub with clear entry points for setup, day-to-day use, architecture, and reference.

--- a/docs-site/content/architecture/overview.md
+++ b/docs-site/content/architecture/overview.md
@@ -33,6 +33,16 @@ The CLI can override provider or model per command, while config sets the defaul
 
 That statefulness is local and explicit rather than magical. The runtime can be told not to use sessions, or to use a different session database path.
 
+## Memory is long-term context
+
+Memory sits beside sessions rather than replacing them.
+
+- **Sessions** preserve the transcript of a conversation.
+- **Memory fragments** preserve durable facts mined from many conversations.
+- **Insights** preserve behavioral rules that should influence future runs.
+
+That gives term-llm a way to accumulate reusable context without pretending every prior token is still in the prompt. The runtime can search memory when needed, while keeping the live session focused on the current task.
+
 ## Tools and MCP extend the model
 
 Built-in tools handle common filesystem and shell tasks. MCP servers extend that with external capabilities such as browser automation, GitHub, or custom APIs.

--- a/docs-site/content/architecture/overview.md
+++ b/docs-site/content/architecture/overview.md
@@ -49,6 +49,19 @@ Built-in tools handle common filesystem and shell tasks. MCP servers extend that
 
 In practice that means the model is not just generating text — it can interrogate files, run commands, call external tools, and then keep going.
 
+## Jobs turn it into a runtime, not just a CLI
+
+The jobs platform lets term-llm run work on a schedule, after a delay, or on manual trigger.
+
+That matters because it moves the system beyond interactive use:
+
+- recurring agent runs
+- background program execution
+- inspectable run history and events
+- controllable retention and cancellation
+
+Once jobs are in the picture, term-llm starts looking less like a terminal helper and more like an automation substrate.
+
 ## Agents and skills are different things
 
 - **Agents** are named configuration bundles. They can choose provider, model, tools, MCP, search, and instructions.

--- a/docs-site/content/getting-started/_index.md
+++ b/docs-site/content/getting-started/_index.md
@@ -2,6 +2,6 @@
 title: "Getting started"
 weight: 1
 kicker: "New here"
-description: "Install term-llm, configure a provider, and get to a first successful run without archaeology."
+description: "Install term-llm, configure a provider, and get to a successful first run quickly."
 ---
-Start here if you want the shortest path from fresh install to a working term-llm setup.
+Start here for the shortest path from a fresh install to a working term-llm setup.

--- a/docs-site/content/getting-started/quickstart.md
+++ b/docs-site/content/getting-started/quickstart.md
@@ -44,7 +44,7 @@ term-llm ask "What is the difference between TCP and UDP?"
 term-llm chat
 ```
 
-## Then stop reading the README and use the docs
+## Continue with the docs
 
 - [Installation](/getting-started/installation/)
 - [Providers and setup](/getting-started/providers-and-setup/)

--- a/docs-site/content/guides/_index.md
+++ b/docs-site/content/guides/_index.md
@@ -2,6 +2,6 @@
 title: "Guides"
 weight: 2
 kicker: "Do a thing"
-description: "Task-focused docs for usage, editing, jobs, MCP, agents, skills, and the rest of the moving parts."
+description: "Task-focused docs for usage, memory, editing, jobs, MCP, agents, skills, and the rest of the moving parts."
 ---
 Guides are for concrete tasks: use a feature, wire up an integration, or operate a workflow without turning the page into a theory seminar.

--- a/docs-site/content/guides/job-runner.md
+++ b/docs-site/content/guides/job-runner.md
@@ -1,14 +1,15 @@
 ---
 title: "Job runner"
 weight: 7
-description: "Run the jobs server, use the v2 API, and manage definitions and runs from the CLI."
+description: "Run the jobs server, define scheduled work, and manage job definitions and runs from the CLI or API."
+featured: true
 kicker: "Operations"
 source_readme_heading: "Job Runner (Serve)"
 next:
   label: MCP servers
   url: /guides/mcp-servers/
 ---
-Run term-llm as a jobs server:
+Use the jobs runtime when you want scheduled, delayed, or manually triggered background work:
 
 ```bash
 term-llm serve --platform jobs --port 8080

--- a/docs-site/content/guides/memory.md
+++ b/docs-site/content/guides/memory.md
@@ -1,0 +1,204 @@
+---
+title: "Memory"
+weight: 9
+featured: true
+description: "Mine durable facts from completed sessions, search fragments, manage insights, and understand how memory differs from sessions."
+kicker: "Long-term memory"
+next:
+  label: Agents
+  url: /guides/agents/
+---
+## What memory is for
+
+term-llm has a long-term memory system separate from normal chat sessions.
+
+- **Sessions** store conversation history so you can resume, inspect, export, or search a chat.
+- **Memory** stores durable fragments and behavioral insights mined from completed sessions.
+
+The distinction matters. Most session content is ephemeral. Memory is meant for facts, decisions, preferences, and patterns worth carrying forward.
+
+## The main commands
+
+```bash
+term-llm memory status
+term-llm memory search "retry policy"
+term-llm memory fragments list
+term-llm memory insights list --agent jarvis
+```
+
+Use `--agent` when you want to scope memory to a particular agent:
+
+```bash
+term-llm memory status --agent jarvis
+term-llm memory search "docs tone" --agent jarvis
+```
+
+## Mine completed sessions into fragments
+
+```bash
+term-llm memory mine
+```
+
+This scans completed sessions, extracts durable memory, and stores it as fragments in the memory database.
+
+Useful flags:
+
+```bash
+term-llm memory mine --since 24h
+term-llm memory mine --limit 20
+term-llm memory mine --include-subagents
+term-llm memory mine --dry-run
+term-llm memory mine --embed=false
+term-llm memory mine --insights
+```
+
+What the mining pass is trying to keep:
+
+- stable preferences
+- technical details that are painful to rediscover
+- decisions and conventions
+- important project and infrastructure facts
+
+What it should mostly ignore:
+
+- transient debugging noise
+- filler conversation
+- one-off dead ends
+- resolved junk that does not matter later
+
+## Search memory
+
+```bash
+term-llm memory search "oauth token handling"
+```
+
+Search uses hybrid retrieval when embeddings are available:
+
+- BM25 keyword search
+- vector similarity search
+- reranking and decay-aware scoring
+
+Useful flags:
+
+```bash
+term-llm memory search "provider routing" --limit 10
+term-llm memory search "deploy key" --bm25-only
+term-llm memory search "session persistence" --no-decay
+term-llm memory search "embedding provider" --embed-provider gemini
+```
+
+## Inspect fragments directly
+
+List fragments:
+
+```bash
+term-llm memory fragments list --agent jarvis --limit 20
+term-llm memory fragments list --filter-path preferences
+```
+
+Show a fragment by numeric ID or path:
+
+```bash
+term-llm memory fragments show 42 --agent jarvis
+term-llm memory fragments show fragments/preferences/editor.md --agent jarvis
+```
+
+Show where a fragment came from:
+
+```bash
+term-llm memory fragments sources 42 --json
+```
+
+Manage fragments manually when you need precise control:
+
+```bash
+term-llm memory fragments add fragments/preferences/search.md --agent jarvis --content "Prefer Exa with Brave fallback."
+term-llm memory fragments update fragments/preferences/search.md --agent jarvis --content "Prefer Exa with Brave as fallback only."
+term-llm memory fragments delete fragments/preferences/search.md --agent jarvis
+```
+
+## Promote recent fragments into an agent summary
+
+```bash
+term-llm memory promote --agent jarvis
+```
+
+Promotion condenses recently changed fragments into an agent-level `recent.md` summary. It is a compression step, not a raw dump.
+
+Useful flags:
+
+```bash
+term-llm memory promote --agent jarvis --since 6h
+term-llm memory promote --agent jarvis --recent-max-bytes 20000
+term-llm memory promote --agent jarvis --dry-run
+```
+
+## Behavioral insights
+
+Fragments store facts. Insights store reusable behavioral rules.
+
+```bash
+term-llm memory insights list --agent jarvis
+term-llm memory insights search "code review"
+term-llm memory insights expand "debugging deploy failures" --agent jarvis
+```
+
+You can add or reinforce them manually:
+
+```bash
+term-llm memory insights add --agent jarvis \
+  --category workflow \
+  --confidence 0.8 \
+  --content "Write code first, then wait for approval before starting services."
+
+term-llm memory insights reinforce 42 --agent jarvis
+```
+
+High-confidence insights are meant to shape future behavior, not just sit in storage looking profound.
+
+## Status and health checks
+
+```bash
+term-llm memory status
+```
+
+That gives you, per agent:
+
+- fragment count
+- last mined time
+- how many completed sessions are still pending mining
+
+## Storage model
+
+The memory database defaults to:
+
+```text
+~/.local/share/term-llm/memory.db
+```
+
+You can override it per command:
+
+```bash
+term-llm memory status --db /tmp/memory.db
+```
+
+Or via environment:
+
+```bash
+export TERM_LLM_MEMORY_DB=/path/to/memory.db
+```
+
+## When to use sessions vs memory
+
+Use **sessions** when you want:
+
+- resumable conversation state
+- transcript search
+- exports and inspection
+
+Use **memory** when you want:
+
+- durable facts across sessions
+- stable preferences and conventions
+- behavior-shaping insights
+- compressed summaries that survive beyond one chat

--- a/docs-site/content/reference/_index.md
+++ b/docs-site/content/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Reference"
 weight: 4
-kicker: "Need exact truth"
-description: "Configuration, built-in tools, sessions, updates, and command reference material where hand-waving dies."
+kicker: "Reference"
+description: "Configuration, built-in tools, sessions, updates, and command reference material."
 ---
-Reference pages are the exact stuff: flags, config, command behavior, and other details that should be stated once and stated clearly.
+Reference pages cover flags, configuration, command behavior, and other details that should be stated clearly and kept easy to scan.

--- a/docs-site/layouts/_default/single.html
+++ b/docs-site/layouts/_default/single.html
@@ -28,12 +28,6 @@
           <h3>Section</h3>
           <p><a href="/{{ .Section }}/">{{ .CurrentSection.Title }}</a></p>
         </div>
-        {{ with .Params.source_readme_heading }}
-        <div class="doc-surface">
-          <h3>Source</h3>
-          <p>Migrated from <code>README.md</code> → <strong>{{ . }}</strong>.</p>
-        </div>
-        {{ end }}
         {{ with .Params.next }}
         <div class="doc-surface">
           <h3>Next</h3>

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -5,8 +5,8 @@
       <h1>{{ .Title }}</h1>
       <div class="lede markdown">{{ .Content }}</div>
       <div class="actions">
-        <a class="button primary" href="/getting-started/quickstart/">Open quickstart path</a>
-        <a class="button" href="/reference/configuration/">Browse configuration reference</a>
+        <a class="button primary" href="/getting-started/quickstart/">Start with the quickstart</a>
+        <a class="button" href="/reference/configuration/">Open configuration reference</a>
       </div>
     </div>
 
@@ -19,15 +19,14 @@
 A terminal-first AI runtime with:
 - chat, web, and jobs runtimes
 - agents, tools, skills, and memory
-- enough structure to run real workflows
-  instead of demo theatre</code></pre>
+- enough structure for real workflows</code></pre>
     </aside>
   </section>
 
   <section class="section-block">
     <div class="section-heading">
       <p class="eyebrow">Choose your path</p>
-      <h2>Start with intent, not file names</h2>
+      <h2>Start with the task at hand</h2>
     </div>
     <div class="card-grid card-grid-4">
       {{ range site.Sections.ByWeight }}
@@ -44,14 +43,14 @@ A terminal-first AI runtime with:
     <div>
       <div class="section-heading">
         <p class="eyebrow">What belongs here</p>
-        <h2>Documentation shape</h2>
+        <h2>Documentation structure</h2>
       </div>
       <div class="list-panel markdown">{{ .Params.belongs | markdownify }}</div>
     </div>
     <div>
       <div class="section-heading">
-        <p class="eyebrow">What does not</p>
-        <h2>Things we are trying not to repeat</h2>
+        <p class="eyebrow">What to avoid</p>
+        <h2>Documentation failure modes</h2>
       </div>
       <div class="list-panel markdown">{{ .Params.avoids | markdownify }}</div>
     </div>
@@ -60,7 +59,7 @@ A terminal-first AI runtime with:
   <section class="section-block">
     <div class="section-heading">
       <p class="eyebrow">Featured pages</p>
-      <h2>Good starting points</h2>
+      <h2>Recommended starting points</h2>
     </div>
     <div class="card-grid card-grid-3">
       {{ range first 6 (where site.RegularPages "Params.featured" true) }}

--- a/docs-site/layouts/partials/footer.html
+++ b/docs-site/layouts/partials/footer.html
@@ -1,3 +1,3 @@
 <footer class="site-footer">
-  <p>Docs live in the term-llm repo, written in Markdown, built with Hugo. Much healthier than one README trying to do all jobs badly.</p>
+  <p>Documentation for term-llm, maintained in the repository as Markdown and published with Hugo.</p>
 </footer>


### PR DESCRIPTION
## What

- remove the "Source / Migrated from README.md" sidebar block from docs pages
- rewrite the docs hub homepage copy to sound more professional and more cohesive
- replace jokey footer and section descriptions with plain documentation language
- tighten a few rough labels and headings in getting started and reference

## Why

The Hugo conversion got the structure into the right shape, but some of the copy still read like temporary migration scaffolding. The docs hub should sound intentional and stable, not like it is apologizing for the old README or winking at the reader.

## Verification

- `hugo --source docs-site --destination /tmp/term-llm-docs-polish`
- `go build ./...`
- `go test ./...`
