### PR TITLE
surface embeddings and usage in docs hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Common entry points:
 - [MCP servers](https://term-llm.com/guides/mcp-servers/)
 - [Memory](https://term-llm.com/guides/memory/)
 - [Jobs](https://term-llm.com/guides/job-runner/)
+- [Text embeddings](https://term-llm.com/guides/text-embeddings/)
+- [Usage tracking](https://term-llm.com/reference/usage-tracking/)
 
 ## License
 

--- a/docs-site/content/guides/text-embeddings.md
+++ b/docs-site/content/guides/text-embeddings.md
@@ -1,14 +1,15 @@
 ---
 title: "Text embeddings"
 weight: 4
-description: "Generate vector embeddings for search, RAG, clustering, and similarity workflows."
+description: "Generate vector embeddings for search, RAG, clustering, semantic similarity, and retrieval workflows."
+featured: true
 kicker: "Embeddings"
 source_readme_heading: "Text Embeddings"
 next:
   label: MCP servers
   url: /guides/mcp-servers/
 ---
-Generate vector embeddings from text for semantic search, RAG, clustering, and similarity comparison.
+Use `term-llm embed` when you need vectors for retrieval, ranking, clustering, semantic similarity, or local pipeline glue.
 
 ```bash
 term-llm embed "What is the meaning of life?"
@@ -116,3 +117,12 @@ Embedding providers use their own credentials, separate from text and image prov
 **Jina AI** is a great choice for getting started — sign up at [jina.ai/embeddings](https://jina.ai/embeddings/) for a free API key with 10M tokens, no credit card required.
 
 **Voyage AI** is Anthropic's recommended embedding partner (acquired by MongoDB, Feb 2025). The API remains fully available.
+
+## When to use it
+
+Typical uses include:
+
+- embedding a query and a corpus for retrieval
+- comparing candidate text by cosine similarity
+- generating vectors for a local RAG index
+- piping embeddings into your own scripts or downstream tools

--- a/docs-site/content/reference/usage-tracking.md
+++ b/docs-site/content/reference/usage-tracking.md
@@ -1,14 +1,15 @@
 ---
 title: "Usage tracking"
 weight: 4
-description: "Inspect token usage and local cost data for term-llm and related CLI tools."
+description: "Inspect token usage and local cost data for term-llm, Claude Code, and Gemini CLI."
+featured: true
 kicker: "Accounting"
 source_readme_heading: "Usage Tracking"
 next:
   label: Session management
   url: /reference/sessions/
 ---
-View token usage and costs from local CLI tools:
+Use the `usage` command to inspect token consumption and local cost data across supported tools:
 
 ```bash
 term-llm usage                           # Show all usage
@@ -20,3 +21,19 @@ term-llm usage --json                    # JSON output
 ```
 
 Supported sources: Claude Code, Gemini CLI, and term-llm's own usage logs.
+
+## What it covers
+
+Supported sources:
+
+- term-llm
+- Claude Code
+- Gemini CLI
+
+Useful patterns:
+
+```bash
+term-llm usage --provider term-llm --breakdown
+term-llm usage --provider claude-code --since 20250101
+term-llm usage --json
+```

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -71,4 +71,28 @@ A terminal-first AI runtime with:
       {{ end }}
     </div>
   </section>
+
+  <section class="section-block">
+    <div class="section-heading">
+      <p class="eyebrow">More topics</p>
+      <h2>Other important capabilities</h2>
+    </div>
+    <div class="card-grid card-grid-3">
+      <a class="card detail-card" href="/guides/text-embeddings/">
+        <p class="card-kicker">Guides</p>
+        <h3>Text embeddings</h3>
+        <p>Generate vectors for retrieval, semantic similarity, clustering, and RAG workflows.</p>
+      </a>
+      <a class="card detail-card" href="/reference/usage-tracking/">
+        <p class="card-kicker">Reference</p>
+        <h3>Usage tracking</h3>
+        <p>Inspect local token usage and cost data across term-llm, Claude Code, and Gemini CLI.</p>
+      </a>
+      <a class="card detail-card" href="/guides/image-generation/">
+        <p class="card-kicker">Guides</p>
+        <h3>Image generation</h3>
+        <p>Generate and edit images with Gemini, OpenAI, xAI, Venice, and Flux providers.</p>
+      </a>
+    </div>
+  </section>
 {{ end }}


### PR DESCRIPTION
## What

- surface text embeddings and usage tracking more clearly in the docs hub
- improve the embeddings guide copy and mark it as a featured page
- improve the usage tracking reference page and mark it as a featured page
- add a homepage section that explicitly calls out embeddings, usage tracking, and image generation
- add README links for text embeddings and usage tracking

## Why

These capabilities existed in the docs, but they were too easy to miss. The hub was doing a decent job for setup, agents, memory, and jobs, while embeddings and usage tracking were still effectively hidden in the long tail. This PR makes them visible from both the homepage and the GitHub front page.

## Verification

- `hugo --source docs-site --destination /tmp/term-llm-docs-embeddings-usage`
- `go build ./...`
- `go test ./...`
