### PR TITLE
add high-impact docs for config web search and providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ The detailed docs live at **https://term-llm.com** and are authored in Markdown 
 Common entry points:
 
 - [Configuration](https://term-llm.com/reference/configuration/)
+- [Providers and models](https://term-llm.com/reference/providers-and-models/)
+- [Web UI and API](https://term-llm.com/guides/web-ui-and-api/)
+- [Search](https://term-llm.com/guides/search/)
 - [Usage](https://term-llm.com/guides/usage/)
 - [Agents](https://term-llm.com/guides/agents/)
 - [Skills](https://term-llm.com/guides/skills/)

--- a/docs-site/content/guides/search.md
+++ b/docs-site/content/guides/search.md
@@ -1,0 +1,114 @@
+---
+title: "Search"
+weight: 6
+description: "Use web search in term-llm, choose external providers, and control native versus external search routing."
+kicker: "Web search"
+featured: true
+next:
+  label: Jobs
+  url: /guides/job-runner/
+---
+## Search modes
+
+When you use `-s` or `--search`, term-llm can answer with either:
+
+- **native provider search** when the model backend supports it
+- **external search tools** using the configured search provider plus page reading
+
+Examples:
+
+```bash
+term-llm ask "latest node.js version" -s
+term-llm exec "install latest docker" -s
+```
+
+## Force native or external behavior
+
+```bash
+term-llm ask "latest news" -s --native-search
+term-llm ask "latest news" -s --no-native-search
+```
+
+Use this when you want consistency, debugging clarity, or to work around a provider’s native search behavior.
+
+## Configure external search
+
+```yaml
+search:
+  provider: exa
+
+  exa:
+    api_key: ${EXA_API_KEY}
+
+  brave:
+    api_key: ${BRAVE_API_KEY}
+
+  google:
+    api_key: ${GOOGLE_SEARCH_API_KEY}
+    cx: ${GOOGLE_SEARCH_CX}
+```
+
+Available external providers:
+
+| Provider | Credentials | Notes |
+|---|---|---|
+| DuckDuckGo | none | default, free |
+| Exa | `EXA_API_KEY` | semantic search |
+| Tavily | `TAVILY_API_KEY` | agent-oriented search |
+| Brave | `BRAVE_API_KEY` | independent index |
+| Google | `GOOGLE_SEARCH_API_KEY` + `GOOGLE_SEARCH_CX` | Custom Search |
+
+## Native versus external priority
+
+Priority is:
+
+1. CLI override: `--native-search` or `--no-native-search`
+2. global config: `search.force_external: true`
+3. provider config: `use_native_search: false`
+4. default provider behavior
+
+Example:
+
+```yaml
+search:
+  force_external: true
+
+providers:
+  gemini:
+    use_native_search: false
+```
+
+## Search in chat and agents
+
+In chat mode:
+
+- `Ctrl+S` toggles web search
+- `/search` toggles web search
+
+Agents can also enable search in their configuration:
+
+```yaml
+search: true
+```
+
+That exposes web search and page-reading tools to the agent.
+
+## When to prefer each mode
+
+Use **native search** when:
+
+- you want the provider’s built-in grounding behavior
+- you trust the provider’s integrated search product
+- you want fewer moving pieces
+
+Use **external search** when:
+
+- you want one search stack across providers
+- you need provider-independent behavior
+- you want to debug the search pipeline more explicitly
+
+## Related pages
+
+- [Providers and models](/reference/providers-and-models/)
+- [Configuration](/reference/configuration/)
+- [Usage](/guides/usage/)

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -1,0 +1,106 @@
+---
+title: "Web UI and API"
+weight: 7
+description: "Run term-llm as a web server, use the browser UI, and call the HTTP API endpoints exposed by serve mode."
+kicker: "Web runtime"
+featured: true
+next:
+  label: Search
+  url: /guides/search/
+---
+## Start the web runtime
+
+```bash
+term-llm serve web
+```
+
+Useful variants:
+
+```bash
+term-llm serve web --no-ui
+term-llm serve web --base-path /chat
+term-llm serve web --host 127.0.0.1 --port 8080
+term-llm serve web jobs
+```
+
+## What it serves
+
+With the default base path of `/ui`, the web runtime exposes:
+
+- `POST /ui/v1/responses`
+- `POST /ui/v1/chat/completions`
+- `POST /ui/v1/transcribe`
+- `GET /ui/v1/models`
+- `GET /ui/healthz`
+- `GET /ui/` for the browser UI
+- `GET /ui/images/:file` for generated images
+
+If the jobs platform is also enabled, the jobs API is mounted under the same base path.
+
+## Authentication
+
+By default, serve mode uses bearer-token auth.
+
+```bash
+term-llm serve web --token "$TOKEN"
+```
+
+If you omit `--token`, term-llm can generate one automatically.
+
+You can disable auth only on loopback hosts:
+
+```bash
+term-llm serve web --auth none --host 127.0.0.1
+```
+
+`--allow-no-auth` and `--auth none` are only valid for loopback use. Exposing an unauthenticated server beyond localhost would be idiotic.
+
+## Useful flags
+
+```bash
+term-llm serve web \
+  --provider anthropic \
+  --agent jarvis \
+  --search \
+  --mcp playwright \
+  --max-turns 200 \
+  --yolo
+```
+
+Relevant options include:
+
+- `--provider`
+- `--agent`
+- `--search`
+- `--native-search` / `--no-native-search`
+- `--mcp`
+- `--tools`, `--read-dir`, `--write-dir`, `--shell-allow`
+- `--base-path`
+- `--no-ui`
+- `--cors-origin`
+
+## Health checks
+
+Typical checks:
+
+```bash
+curl http://127.0.0.1:8080/ui/healthz
+curl http://127.0.0.1:8080/ui/v1/models
+```
+
+If you change `--base-path`, those URLs change with it.
+
+## When to use web mode
+
+Use the web runtime when you want:
+
+- a browser UI instead of terminal chat
+- an HTTP API surface for integrations
+- a shared local service with authentication
+- combined web and jobs runtime on one port
+
+## Related pages
+
+- [Jobs](/guides/job-runner/)
+- [Configuration](/reference/configuration/)
+- [Search](/guides/search/)

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -1,16 +1,188 @@
 ---
 title: "Configuration"
 weight: 2
-description: "Inspect, edit, and understand the main config file plus provider/model override behavior."
+description: "Inspect, edit, and understand the main config file, provider settings, search configuration, and per-command overrides."
 kicker: "Config"
-source_readme_heading: "Configuration"
 featured: true
 next:
-  label: Session management
-  url: /reference/sessions/
+  label: Providers and models
+  url: /reference/providers-and-models/
 ---
+## Configuration commands
+
 ```bash
-term-llm config        # Show current config
-term-llm config edit   # Edit config file
-term-llm config path   # Print config file path
+term-llm config
+term-llm config edit
+term-llm config path
+term-llm config get default_provider
+term-llm config set default_provider zen
+term-llm config reset
 ```
+
+The main config file lives at:
+
+```text
+~/.config/term-llm/config.yaml
+```
+
+## Configuration shape
+
+A typical config has a few major parts:
+
+- `default_provider` for the global LLM default
+- `providers` for model-specific credentials and routing
+- per-command blocks such as `exec`, `ask`, and `edit`
+- feature-specific blocks such as `image`, `embed`, `search`, `sessions`, and `tools`
+
+## Example
+
+```yaml
+default_provider: anthropic
+
+providers:
+  anthropic:
+    model: claude-sonnet-4-6
+
+  openai:
+    model: gpt-5.2
+    credentials: codex
+
+  xai:
+    model: grok-4-1-fast
+
+  openrouter:
+    model: x-ai/grok-code-fast-1
+    app_url: https://github.com/samsaffron/term-llm
+    app_title: term-llm
+
+exec:
+  suggestions: 3
+  instructions: |
+    I use Arch Linux with zsh.
+    I prefer ripgrep over grep and fd over find.
+
+ask:
+  instructions: |
+    Be concise. I'm an experienced developer.
+
+edit:
+  model: gpt-5.2-codex
+  diff_format: auto
+
+search:
+  provider: duckduckgo
+
+tools:
+  max_tool_output_chars: 20000
+```
+
+## Per-command overrides
+
+Each command can override provider and model independently of the global default.
+
+```yaml
+default_provider: anthropic
+
+providers:
+  anthropic:
+    model: claude-sonnet-4-6
+  openai:
+    model: gpt-5.2
+  zen:
+    model: glm-4.7-free
+
+exec:
+  provider: zen
+  model: glm-4.7-free
+
+ask:
+  model: claude-opus-4
+
+edit:
+  provider: openai
+  model: gpt-5.2-codex
+```
+
+Precedence is:
+
+1. CLI flag such as `--provider openai:gpt-5.2`
+2. per-command config such as `exec.provider` or `ask.model`
+3. global provider selection via `default_provider` and `providers.<name>.model`
+
+## Sessions config
+
+```yaml
+sessions:
+  enabled: true
+  max_age_days: 0
+  max_count: 0
+  path: ""
+```
+
+Use this to control whether sessions are persisted, how long they are kept, and where the SQLite database lives.
+
+## Search config
+
+```yaml
+search:
+  provider: exa
+  force_external: false
+
+  exa:
+    api_key: ${EXA_API_KEY}
+
+  brave:
+    api_key: ${BRAVE_API_KEY}
+```
+
+Search is large enough to deserve its own page; see [Search](/guides/search/).
+
+## Image and embedding config
+
+```yaml
+image:
+  provider: gemini
+  output_dir: ~/Pictures/term-llm
+
+embed:
+  provider: gemini
+```
+
+Each feature block can hold provider-specific credentials and defaults. The image and embedding providers are independent of the main text provider.
+
+## Dynamic secrets and endpoints
+
+term-llm supports dynamic resolution for some config values:
+
+- `op://...` for 1Password secret references
+- `srv://...` for DNS SRV-based endpoint discovery
+- `$()` for command-based resolution
+
+Example:
+
+```yaml
+providers:
+  production-llm:
+    type: openai_compatible
+    model: Qwen/Qwen3-30B-A3B
+    url: "srv://_vllm._tcp.ml.company.com/v1/chat/completions"
+    api_key: "op://Infrastructure/vLLM Cluster/credential?account=company.1password.com"
+```
+
+These values are resolved lazily when term-llm actually needs them.
+
+## Diagnostics
+
+```yaml
+diagnostics:
+  enabled: true
+```
+
+When edit retries fail, diagnostics can capture prompts, partial responses, and failure context for inspection.
+
+## Related pages
+
+- [Providers and models](/reference/providers-and-models/)
+- [Search](/guides/search/)
+- [Sessions](/reference/sessions/)
+- [Text embeddings](/guides/text-embeddings/)

--- a/docs-site/content/reference/providers-and-models.md
+++ b/docs-site/content/reference/providers-and-models.md
@@ -1,0 +1,166 @@
+---
+title: "Providers and models"
+weight: 3
+description: "Choose providers, discover models, understand credentials, and use provider-specific model features such as reasoning and native search."
+kicker: "Providers"
+featured: true
+next:
+  label: Sessions
+  url: /reference/sessions/
+---
+## Discover providers and models
+
+```bash
+term-llm providers
+term-llm providers --configured
+term-llm providers anthropic
+
+term-llm models --provider anthropic
+term-llm models --provider openrouter
+term-llm models --provider ollama
+term-llm models --json
+```
+
+Use `providers` when you want to know what is available and how it is configured. Use `models` when you want the concrete model names a provider currently exposes.
+
+## Provider categories
+
+term-llm supports a mix of provider types:
+
+- hosted API providers such as Anthropic, OpenAI, xAI, Gemini, and OpenRouter
+- subscription-backed OAuth providers such as ChatGPT, Copilot, and Gemini CLI
+- local or self-hosted OpenAI-compatible providers such as Ollama, LM Studio, vLLM, or custom endpoints
+
+## Credentials
+
+Most providers use API keys via environment variables. Some use OAuth credentials from companion CLIs or locally stored auth files.
+
+| Provider | Credentials source | Notes |
+|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` | API key or OAuth token |
+| `openai` | `OPENAI_API_KEY` | Standard OpenAI API key |
+| `chatgpt` | `~/.config/term-llm/chatgpt_creds.json` | ChatGPT Plus/Pro OAuth |
+| `copilot` | `~/.config/term-llm/copilot_creds.json` | GitHub Copilot OAuth |
+| `gemini` | `GEMINI_API_KEY` | Google AI Studio key |
+| `gemini-cli` | `~/.gemini/oauth_creds.json` | gemini-cli OAuth |
+| `xai` | `XAI_API_KEY` | xAI API key |
+| `openrouter` | `OPENROUTER_API_KEY` | OpenRouter API key |
+| `zen` | `ZEN_API_KEY` optional | empty is valid for free tier |
+
+Examples:
+
+```bash
+term-llm ask --provider anthropic "question"
+term-llm ask --provider chatgpt "question"
+term-llm ask --provider copilot "question"
+term-llm ask --provider gemini-cli "question"
+```
+
+## OpenAI-compatible providers
+
+For local or custom backends, use `type: openai_compatible`.
+
+```yaml
+providers:
+  ollama:
+    type: openai_compatible
+    base_url: http://localhost:11434/v1
+    model: llama3.2:latest
+
+  lmstudio:
+    type: openai_compatible
+    base_url: http://localhost:1234/v1
+    model: deepseek-coder-v2
+
+  cerebras:
+    type: openai_compatible
+    base_url: https://api.cerebras.ai/v1
+    model: llama-4-scout-17b
+    api_key: ${CEREBRAS_API_KEY}
+```
+
+Use `base_url` when the standard `/chat/completions` path should be appended automatically. Use `url` when you need to specify the full chat completions endpoint directly.
+
+## Reasoning and model suffixes
+
+### OpenAI reasoning effort
+
+For OpenAI models, append `-low`, `-medium`, `-high`, or `-xhigh` to control reasoning effort.
+
+```bash
+term-llm ask --provider openai:gpt-5.2-xhigh "complex question"
+term-llm exec --provider openai:gpt-5.2-low "quick task"
+```
+
+```yaml
+providers:
+  openai:
+    model: gpt-5.2-high
+```
+
+| Effort | Meaning |
+|---|---|
+| `low` | faster, cheaper, less thorough |
+| `medium` | balanced default |
+| `high` | more thorough reasoning |
+| `xhigh` | maximum reasoning on supported models |
+
+### Anthropic extended thinking
+
+For Anthropic models, append `-thinking`:
+
+```bash
+term-llm ask --provider anthropic:claude-sonnet-4-6-thinking "complex question"
+```
+
+```yaml
+providers:
+  anthropic:
+    model: claude-sonnet-4-6-thinking
+```
+
+## Native search support
+
+Some providers support native web search. Others rely on external search tooling.
+
+Native support is most relevant for:
+
+- Anthropic
+- OpenAI
+- xAI
+- Gemini
+
+You can override behavior with:
+
+```bash
+term-llm ask "latest news" -s --native-search
+term-llm ask "latest news" -s --no-native-search
+```
+
+Or in config:
+
+```yaml
+search:
+  force_external: true
+
+providers:
+  gemini:
+    use_native_search: false
+```
+
+See [Search](/guides/search/) for the full routing model.
+
+## Recommendations by use case
+
+- **fast free experimentation:** `zen`
+- **OpenAI ecosystem / Codex editing:** `openai`
+- **Claude models with OAuth:** `anthropic`
+- **broad model access:** `openrouter`
+- **local inference:** `ollama` or another OpenAI-compatible endpoint
+- **subscription-backed consumer access:** `chatgpt`, `copilot`, or `gemini-cli`
+
+## Related pages
+
+- [Configuration](/reference/configuration/)
+- [Search](/guides/search/)
+- [Providers and setup](/getting-started/providers-and-setup/)

--- a/docs-site/content/reference/sessions.md
+++ b/docs-site/content/reference/sessions.md
@@ -1,467 +1,78 @@
 ---
 title: "Session management"
 weight: 5
-description: "List, search, resume, export, and prune local sessions stored in SQLite."
+description: "List, search, resume, tag, export, and prune local sessions stored in SQLite."
 kicker: "State"
-source_readme_heading: "Session Management"
 featured: true
 ---
-Chat sessions are automatically stored locally and can be managed with the `sessions` command. Each session is assigned a sequential number (#1, #2, #3...) for easy reference:
+## Session commands
 
 ```bash
-term-llm sessions                        # List recent sessions
-term-llm sessions list --provider anthropic  # Filter by provider
-term-llm sessions search "kubernetes"    # Search session content
-term-llm sessions show 42                # Show session details (by number)
-term-llm sessions show #42               # Same thing (explicit # prefix)
-term-llm sessions export 42 [path.md]    # Export as markdown
-term-llm sessions name 42 "my session"   # Set custom name
-term-llm sessions delete 42              # Delete a session
-term-llm sessions reset                  # Delete all sessions
-term-llm chat --resume=42                # Resume a session by number
+term-llm sessions
+term-llm sessions list --provider anthropic
+term-llm sessions search "kubernetes"
+term-llm sessions show 42
+term-llm sessions export 42
+term-llm sessions name 42 "investigate auth flow"
+term-llm sessions tag 42 bughunt auth
+term-llm sessions untag 42 auth
+term-llm sessions browse
+term-llm sessions gist 42
+term-llm sessions delete 42
+term-llm sessions reset
+term-llm chat --resume=42
 ```
 
-Sessions are stored in a SQLite database at `~/.local/share/term-llm/sessions.db`. Configure session storage in your config:
+Sessions are numbered sequentially for convenience, so `42` and `#42` both work.
+
+## Storage
+
+Sessions are stored in SQLite at:
+
+```text
+~/.local/share/term-llm/sessions.db
+```
+
+Session storage config:
 
 ```yaml
 sessions:
-  enabled: true       # Master switch (default: true)
-  max_age_days: 0     # Auto-delete sessions older than N days (0=never)
-  max_count: 0        # Keep at most N sessions (0=unlimited)
-  path: ""            # Optional DB path override (supports :memory:)
+  enabled: true
+  max_age_days: 0
+  max_count: 0
+  path: ""
 ```
 
-Use CLI overrides when needed:
+CLI overrides:
 
 ```bash
-term-llm chat --no-session                      # Do not read/write session DB
-term-llm ask --session-db /tmp/term-llm.db ... # Use an alternate DB path
+term-llm chat --no-session
+term-llm ask --session-db /tmp/term-llm.db ...
 ```
 
-### Conversation Inspector
+## Conversation inspector
 
-While in `chat` or `ask` mode, press `Ctrl+O` to open the conversation inspector. This shows the full conversation history including tool calls and results, with vim-style navigation:
+While in `chat` or `ask`, press `Ctrl+O` to open the conversation inspector.
 
 | Key | Action |
-|-----|--------|
+|---|---|
 | `j/k` | Scroll up/down |
 | `g/G` | Go to top/bottom |
 | `e` | Toggle expand/collapse |
 | `q` | Close inspector |
 
-The main config lives at `~/.config/term-llm/config.yaml`: 
+## What sessions are for
 
-```yaml
-default_provider: anthropic
+Use sessions when you want:
 
-providers:
-  # Built-in providers - type is inferred from the key name
-  anthropic:
-    model: claude-sonnet-4-6
+- resumable conversation state
+- transcript search
+- exported chat history
+- per-session naming and tagging
 
-  openai:
-    model: gpt-5.2
-    credentials: codex  # or "api_key" (default)
+Use [Memory](/guides/memory/) when you want durable facts and behavioral insights that survive beyond one specific chat.
 
-  xai:
-    model: grok-4-1-fast  # grok-4, grok-3, grok-code-fast-1
+## Related pages
 
-  openrouter:
-    model: x-ai/grok-code-fast-1
-    app_url: https://github.com/samsaffron/term-llm
-    app_title: term-llm
-
-  gemini:
-    model: gemini-3-flash-preview  # uses GEMINI_API_KEY
-
-  gemini-cli:
-    model: gemini-3-flash-preview  # uses ~/.gemini/oauth_creds.json
-
-  zen:
-    model: glm-4.7-free
-    # api_key is optional - leave empty for free tier
-
-  copilot:
-    model: gpt-4.1  # free tier, or gpt-5.2-codex for paid
-
-  # Local LLM providers (require explicit type)
-  # Run 'term-llm models --provider ollama' to list available models
-  # ollama:
-  #   type: openai_compatible
-  #   base_url: http://localhost:11434/v1
-  #   model: llama3.2:latest
-
-  # Custom OpenAI-compatible endpoints
-  # cerebras:
-  #   type: openai_compatible
-  #   base_url: https://api.cerebras.ai/v1  # /chat/completions appended automatically
-  #   # url: https://api.cerebras.ai/v1/chat/completions  # alternative: full URL, used as-is
-  #   model: llama-4-scout-17b
-  #   api_key: ${CEREBRAS_API_KEY}
-  #   models:  # optional: enable autocomplete for --provider cerebras:<TAB>
-  #     - llama-4-scout-17b-16e-instruct
-  #     - llama-4-maverick-17b-128e-instruct
-  #     - qwen-3-32b
-
-exec:
-  suggestions: 3  # number of command suggestions
-  # provider: openai    # override provider for exec only
-  # model: gpt-4o       # override model for exec only
-  instructions: |
-    I use Arch Linux with zsh.
-    I prefer ripgrep over grep, fd over find.
-
-ask:
-  # provider: anthropic
-  # model: claude-opus-4  # use a smarter model for questions
-  instructions: |
-    Be concise. I'm an experienced developer.
-
-edit:
-  # provider: openai
-  # model: gpt-5.2-codex  # Codex models are optimized for code edits
-  diff_format: auto  # auto, udiff, or replace
-
-image:
-  provider: gemini  # gemini, openai, xai, venice, flux, or openrouter
-  output_dir: ~/Pictures/term-llm
-
-  gemini:
-    api_key: ${GEMINI_API_KEY}
-    # model: gemini-2.5-flash-image
-
-  openai:
-    api_key: ${OPENAI_API_KEY}
-    # model: gpt-image-1
-
-  xai:
-    api_key: ${XAI_API_KEY}
-    # model: grok-2-image-1212
-
-  venice:
-    api_key: ${VENICE_API_KEY}
-    # model: nano-banana-pro
-    # resolution: 2K
-
-  flux:
-    api_key: ${BFL_API_KEY}
-    # model: flux-2-pro
-
-  openrouter:
-    api_key: ${OPENROUTER_API_KEY}
-    # model: google/gemini-2.5-flash-image
-
-embed:
-  # provider: gemini  # gemini, openai, jina, voyage, ollama (auto-detected from default_provider)
-
-  # gemini:
-  #   api_key: ${GEMINI_API_KEY}
-  #   model: gemini-embedding-001
-
-  # openai:
-  #   api_key: ${OPENAI_API_KEY}
-  #   model: text-embedding-3-small
-
-  # jina:
-  #   api_key: ${JINA_API_KEY}        # free tier: 10M tokens at jina.ai/embeddings
-  #   model: jina-embeddings-v3
-
-  # voyage:
-  #   api_key: ${VOYAGE_API_KEY}
-  #   model: voyage-3.5
-
-  # ollama:
-  #   base_url: http://localhost:11434
-  #   model: nomic-embed-text
-
-search:
-  provider: duckduckgo  # exa, brave, google, or duckduckgo (default)
-
-  # exa:
-  #   api_key: ${EXA_API_KEY}
-
-  # brave:
-  #   api_key: ${BRAVE_API_KEY}
-
-  # google:
-  #   api_key: ${GOOGLE_SEARCH_API_KEY}
-  #   cx: ${GOOGLE_SEARCH_CX}
-
-tools:
-  max_tool_output_chars: 20000  # truncate tool outputs before sending to LLM (default 20000, 0 to disable)
-```
-
-### Per-Command Provider/Model
-
-Each command (exec, ask, edit) can have its own provider and model, overriding the global default:
-
-```yaml
-default_provider: anthropic  # global default
-
-providers:
-  anthropic:
-    model: claude-sonnet-4-6
-  openai:
-    model: gpt-5.2
-  zen:
-    model: glm-4.7-free
-
-exec:
-  provider: zen       # exec uses Zen (free)
-  model: glm-4.7-free
-
-ask:
-  model: claude-opus-4  # ask uses global provider with a smarter model
-
-edit:
-  provider: openai
-  model: gpt-5.2       # edit uses OpenAI
-```
-
-**Precedence** (highest to lowest):
-1. CLI flag: `--provider openai:gpt-5.2`
-2. Per-command config: `exec.provider` / `exec.model`
-3. Global config: `default_provider` + `providers.<name>.model`
-
-### Reasoning Effort (OpenAI)
-
-For OpenAI models, you can control reasoning effort by appending `-low`, `-medium`, `-high`, or `-xhigh` to the model name:
-
-```bash
-term-llm ask --provider openai:gpt-5.2-xhigh "complex question"  # max reasoning
-term-llm exec --provider openai:gpt-5.2-low "quick task"         # faster/cheaper
-```
-
-Or in config:
-```yaml
-providers:
-  openai:
-    model: gpt-5.2-high  # effort parsed from suffix
-```
-
-| Effort | Description |
-|--------|-------------|
-| `low` | Faster, cheaper, less thorough |
-| `medium` | Balanced (default if not specified) |
-| `high` | More thorough reasoning |
-| `xhigh` | Maximum reasoning (only on gpt-5.2) |
-
-### Extended Thinking (Anthropic)
-
-For Anthropic models, you can enable extended thinking by appending `-thinking` to the model name:
-
-```bash
-term-llm ask --provider anthropic:claude-sonnet-4-6-thinking "complex question"
-```
-
-Or in config:
-```yaml
-providers:
-  anthropic:
-    model: claude-sonnet-4-6-thinking  # enables 10k token thinking budget
-```
-
-Extended thinking allows Claude to reason through complex problems before responding. The thinking process uses ~10,000 tokens and is not shown in the output.
-
-### Web Search
-
-When using `-s`/`--search`, some providers (Anthropic, OpenAI, xAI, Gemini) have native web search built-in. xAI also includes X (Twitter) search. Others use external tools (configurable search provider + [Jina Reader](https://jina.ai/reader/)).
-
-You can force external search even for providers with native support—useful for consistency, debugging, or when native search doesn't work well for your use case.
-
-**CLI flags:**
-```bash
-term-llm ask "latest news" -s --no-native-search  # Force external search tools
-term-llm ask "latest news" -s --native-search     # Force native (override config)
-```
-
-**Global config** (applies to all providers):
-```yaml
-search:
-  force_external: true  # Never use native search, always use external tools
-```
-
-**Per-provider config:**
-```yaml
-providers:
-  gemini:
-    model: gemini-2.5-flash
-    use_native_search: false  # Always use external search for this provider
-
-  anthropic:
-    model: claude-sonnet-4-6
-    # use_native_search: true  # Default: use native if available
-```
-
-**Priority** (highest to lowest):
-1. CLI flag: `--native-search` or `--no-native-search`
-2. Global config: `search.force_external: true`
-3. Provider config: `use_native_search: false`
-4. Default: use native search if provider supports it
-
-### Search Providers
-
-When using external search (non-native), you can choose from multiple search providers:
-
-| Provider | Environment Variable | Description |
-|----------|---------------------|-------------|
-| DuckDuckGo (default) | — | Free, no API key required |
-| [Exa](https://exa.ai) | `EXA_API_KEY` | AI-native semantic search |
-| [Tavily](https://tavily.com/) | `TAVILY_API_KEY` | Agent-oriented web search with snippets |
-| [Brave](https://brave.com/search/api/) | `BRAVE_API_KEY` | Independent index, privacy-focused |
-| [Google](https://developers.google.com/custom-search) | `GOOGLE_SEARCH_API_KEY` + `GOOGLE_SEARCH_CX` | Google Custom Search |
-
-**Configure in `~/.config/term-llm/config.yaml`:**
-```yaml
-search:
-  provider: exa  # exa, tavily, brave, google, or duckduckgo (default)
-
-  exa:
-    api_key: ${EXA_API_KEY}
-
-  tavily:
-    api_key: ${TAVILY_API_KEY}
-
-  brave:
-    api_key: ${BRAVE_API_KEY}
-
-  google:
-    api_key: ${GOOGLE_SEARCH_API_KEY}
-    cx: ${GOOGLE_SEARCH_CX}  # Custom Search Engine ID
-```
-
-Run `term-llm config` to see which search providers have credentials configured.
-
-### Credentials
-
-Most providers use API keys via environment variables. Some providers use OAuth credentials from companion CLIs:
-
-| Provider | Credentials Source | Description |
-|----------|-------------------|-------------|
-| `anthropic` | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or OAuth | Anthropic API key or OAuth token |
-| `openai` | `OPENAI_API_KEY` | OpenAI API key |
-| `chatgpt` | `~/.config/term-llm/chatgpt_creds.json` | ChatGPT Plus/Pro OAuth |
-| `copilot` | `~/.config/term-llm/copilot_creds.json` | GitHub Copilot OAuth |
-| `gemini` | `GEMINI_API_KEY` | Google AI Studio API key |
-| `gemini-cli` | `~/.gemini/oauth_creds.json` | gemini-cli OAuth (Google Code Assist) |
-| `xai` | `XAI_API_KEY` | xAI API key |
-| `openrouter` | `OPENROUTER_API_KEY` | OpenRouter API key |
-| `zen` | `ZEN_API_KEY` (optional) | Empty for free tier |
-
-**Anthropic**, **ChatGPT**, **Copilot**, and **Gemini CLI** work without any API key if you have a subscription or the CLI installed and logged in:
-
-```bash
-term-llm ask --provider anthropic "question"  # uses OAuth token (runs `claude setup-token` on first use)
-term-llm ask --provider chatgpt "question"    # uses ChatGPT Plus/Pro subscription
-term-llm ask --provider copilot "question"    # uses GitHub Copilot OAuth
-term-llm ask --provider gemini-cli "question" # uses ~/.gemini/oauth_creds.json
-```
-
-### Dynamic Configuration
-
-For advanced setups, term-llm supports dynamic resolution of API keys and URLs using special prefixes. These are resolved lazily—only when actually making an API call, not when loading config.
-
-#### 1Password Integration (`op://`)
-
-Retrieve API keys from 1Password using secret references:
-
-```yaml
-providers:
-  my-provider:
-    type: openai_compatible
-    base_url: https://api.example.com/v1
-    api_key: "op://Private/My API Key/credential"
-```
-
-For multiple 1Password accounts, use the `?account=` query parameter:
-
-```yaml
-providers:
-  work-llm:
-    type: openai_compatible
-    base_url: https://llm.company.com/v1
-    api_key: "op://Engineering/LLM Service/api_key?account=company.1password.com"
-```
-
-This requires the [1Password CLI](https://developer.1password.com/docs/cli/) (`op`) to be installed and signed in.
-
-#### DNS SRV Records (`srv://`)
-
-Discover server endpoints dynamically via DNS SRV records:
-
-```yaml
-providers:
-  internal-llm:
-    type: openai_compatible
-    url: "srv://_llm._tcp.internal.company.com/v1/chat/completions"
-    api_key: ${LLM_API_KEY}
-```
-
-The SRV record is resolved to `https://host:port/path`. This is useful for:
-- Load-balanced services with multiple backends
-- Internal services with dynamic IPs
-- Kubernetes services exposed via external-dns
-
-#### Shell Commands (`$()`)
-
-Execute arbitrary shell commands to get values:
-
-```yaml
-providers:
-  vault-backed:
-    type: openai_compatible
-    base_url: https://api.example.com/v1
-    api_key: "$(vault kv get -field=api_key secret/llm)"
-
-  aws-secrets:
-    type: openai_compatible
-    base_url: https://api.example.com/v1
-    api_key: "$(aws secretsmanager get-secret-value --secret-id llm-key --query SecretString --output text)"
-```
-
-#### Combined Example
-
-Using SRV discovery with 1Password credentials:
-
-```yaml
-providers:
-  production-llm:
-    type: openai_compatible
-    model: "Qwen/Qwen3-30B-A3B"
-    url: "srv://_vllm._tcp.ml.company.com/v1/chat/completions"
-    api_key: "op://Infrastructure/vLLM Cluster/credential?account=company.1password.com"
-```
-
-When you run `term-llm config`, these show as `[set via 1password]` or `[set via command]` without actually resolving the values (no 1Password prompt until you make an API call).
-
-### Diagnostics
-
-Enable diagnostic logging to capture detailed information when edits fail and retry. This is useful for debugging and tuning prompts:
-
-```yaml
-diagnostics:
-  enabled: true
-  # dir: /custom/path  # optional, defaults to ~/.local/share/term-llm/diagnostics/
-```
-
-When an edit fails and retries, two files are written:
-- `edit-retry-{timestamp}.json` - Structured data for programmatic analysis
-- `edit-retry-{timestamp}.md` - Human-readable with syntax-highlighted code blocks
-
-Each diagnostic captures:
-- Provider and model used
-- Full system and user prompts
-- LLM's partial response before failure
-- Failed search pattern or diff
-- Current file content
-- Error reason
-
-### Shell Completions
-
-Generate and install shell completions:
-
-```bash
-term-llm config completion zsh --install   # Install for zsh
-term-llm config completion bash --install  # Install for bash
-term-llm config completion fish --install  # Install for fish
-```
+- [Configuration](/reference/configuration/)
+- [Memory](/guides/memory/)


### PR DESCRIPTION
## What

- expand the configuration docs into a real reference page
- add a dedicated providers-and-models reference page
- add a dedicated search guide
- add a dedicated web UI and API guide for `serve web`
- clean up the sessions page so it focuses on sessions instead of carrying unrelated provider/search/config content
- add README links for providers/models, web UI/API, and search

## Why

The docs hub had improved coverage for memory, jobs, embeddings, and usage, but some of the highest-value product surfaces were still under-documented or misplaced. In particular:

- configuration was too thin to be useful
- provider/model/search docs were leaking into the sessions page
- web serve mode was a major surface with no dedicated guide

This PR fixes those high-impact gaps and makes the information architecture less sloppy.

## Verification

- `hugo --source docs-site --destination /tmp/term-llm-docs-high-impact`
- `go build ./...`
- `go test ./...`
