### PR TITLE
document transcription notifications plan and profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Common entry points:
 - [Jobs](https://term-llm.com/guides/job-runner/)
 - [Text embeddings](https://term-llm.com/guides/text-embeddings/)
 - [Usage tracking](https://term-llm.com/reference/usage-tracking/)
+- [Transcription](https://term-llm.com/guides/transcription/)
+- [Plan mode](https://term-llm.com/guides/plan-mode/)
+- [Notifications](https://term-llm.com/guides/notifications/)
 
 ## License
 

--- a/docs-site/content/guides/agents.md
+++ b/docs-site/content/guides/agents.md
@@ -34,6 +34,12 @@ term-llm agents show reviewer                # Show agent configuration
 term-llm agents edit reviewer                # Edit agent configuration
 term-llm agents copy builtin/coder my-coder  # Copy agent to customize
 term-llm agents path                         # Print agents directory
+term-llm agents export reviewer              # Export an agent bundle
+term-llm agents import ./agent-dir           # Import an agent bundle
+term-llm agents gist reviewer                # Publish agent as a gist
+term-llm agents set reviewer provider=openai model=gpt-5.2
+term-llm agents get reviewer
+term-llm agents clear reviewer model
 ```
 
 ### Agent Configuration

--- a/docs-site/content/guides/mcp-servers.md
+++ b/docs-site/content/guides/mcp-servers.md
@@ -130,3 +130,7 @@ MCP servers are stored in `~/.config/term-llm/mcp.json`:
 | http | `url` | Connects to remote HTTP endpoint |
 
 HTTP transport uses [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) (MCP spec 2025-03-26).
+
+### MCP server mode
+
+`term-llm mcp-server` also exists, but it is an internal and deprecated stdio server path. It remains available for external MCP clients that want stdio transport, but it is not the primary integration path for most users.

--- a/docs-site/content/guides/notifications.md
+++ b/docs-site/content/guides/notifications.md
@@ -1,0 +1,57 @@
+---
+title: "Notifications"
+weight: 11
+description: "Send notifications through Telegram or web push from the command line."
+kicker: "Notify"
+next:
+  label: Plan mode
+  url: /guides/plan-mode/
+---
+## Broadcast notifications
+
+```bash
+term-llm notify "build finished"
+```
+
+The `notify` command sends to all configured notification platforms.
+
+Examples:
+
+```bash
+term-llm notify --chat-id 12345 "deploy complete"
+term-llm notify telegram --chat-id 12345 "test"
+term-llm notify web "test"
+```
+
+## Telegram
+
+To send Telegram notifications you need:
+
+- `serve.telegram.token` configured
+- a target `--chat-id`
+
+```bash
+term-llm notify --chat-id 12345 "deploy complete"
+term-llm notify telegram --chat-id 12345 --parse-mode Markdown "*done*"
+```
+
+## Web push
+
+Web push notifications require configured VAPID keys under `serve.web_push`.
+
+```bash
+term-llm notify web "job failed"
+```
+
+## When to use it
+
+Notifications are useful for:
+
+- build and deploy completion
+- long-running jobs finishing or failing
+- lightweight alerts from scripts and cron jobs
+
+## Related pages
+
+- [Jobs](/guides/job-runner/)
+- [Web UI and API](/guides/web-ui-and-api/)

--- a/docs-site/content/guides/plan-mode.md
+++ b/docs-site/content/guides/plan-mode.md
@@ -1,0 +1,59 @@
+---
+title: "Plan mode"
+weight: 12
+description: "Use the planning TUI to co-edit a plan document with an AI agent in real time."
+kicker: "Planning"
+next:
+  label: Notifications
+  url: /guides/notifications/
+---
+## Start a planning session
+
+```bash
+term-llm plan
+term-llm plan project.md
+```
+
+Plan mode opens a collaborative planning TUI where you and the model edit a plan document together.
+
+## Useful flags
+
+```bash
+term-llm plan --provider chatgpt
+term-llm plan --no-search
+term-llm plan --max-turns 50
+term-llm plan --file roadmap.md
+```
+
+## Keyboard shortcuts
+
+- `Ctrl+P` invoke the planner agent
+- `Ctrl+S` save the document
+- `Ctrl+C` cancel the agent or quit
+- `Esc` leave insert mode
+
+## What the planner can do
+
+The planner agent can:
+
+- add structure such as headings and sections
+- reorganize material
+- ask clarifying questions
+- make incremental edits while preserving your changes
+
+Plan mode also wires read-only investigation tools and limited sub-agent delegation for deeper exploration.
+
+## When to use it
+
+Use plan mode when you want to turn rough notes into:
+
+- project plans
+- research outlines
+- implementation checklists
+- decision documents
+
+## Related pages
+
+- [Usage](/guides/usage/)
+- [Agents](/guides/agents/)
+- [Search](/guides/search/)

--- a/docs-site/content/guides/skills.md
+++ b/docs-site/content/guides/skills.md
@@ -34,6 +34,7 @@ term-llm skills browse                       # Browse available skills
 term-llm skills validate my-skill            # Validate skill syntax
 term-llm skills update                       # Update skills from sources
 term-llm skills path                         # Print skills directory
+term-llm skills add owner/repo               # Add skill source from GitHub
 ```
 
 ### Skill Configuration

--- a/docs-site/content/guides/transcription.md
+++ b/docs-site/content/guides/transcription.md
@@ -1,0 +1,79 @@
+---
+title: "Transcription"
+weight: 8
+description: "Transcribe audio files to text with OpenAI, Mistral Voxtral, a local Whisper server, or whisper.cpp CLI."
+kicker: "Audio"
+featured: true
+next:
+  label: Image generation
+  url: /guides/image-generation/
+---
+## Basic usage
+
+```bash
+term-llm transcribe meeting.m4a
+```
+
+Supported input extensions include:
+
+- `.ogg`
+- `.mp3`
+- `.wav`
+- `.m4a`
+- `.flac`
+- `.mp4`
+- `.webm`
+
+## Useful flags
+
+```bash
+term-llm transcribe interview.mp3 --language en
+term-llm transcribe note.m4a --provider openai
+term-llm transcribe memo.wav --provider mistral
+term-llm transcribe call.ogg --provider whisper-cli --porcelain
+```
+
+Key options:
+
+- `--language` for a language hint such as `en` or `ja`
+- `--provider` to select the transcription backend
+- `--porcelain` to output only transcript text
+
+## Provider options
+
+term-llm supports several transcription backends:
+
+- `openai`
+- `mistral` (Voxtral)
+- `local` for a local Whisper-compatible server
+- `whisper-cli` for `whisper.cpp`
+
+If you omit `--provider`, term-llm uses the configured transcription provider or falls back to OpenAI.
+
+## whisper.cpp CLI mode
+
+For `--provider whisper-cli`, term-llm looks for a `whisper` binary in `PATH` and a model file via:
+
+- `WHISPER_MODEL`
+- `providers.local_whisper.model` in config
+- common default model paths
+
+Example:
+
+```bash
+export WHISPER_MODEL=~/.local/share/whisper/models/ggml-base.bin
+term-llm transcribe note.m4a --provider whisper-cli
+```
+
+## When to use it
+
+Use transcription when you want to:
+
+- turn voice notes into text before summarizing or editing
+- capture meeting audio for later analysis
+- feed transcripts into `ask`, `edit`, or your own downstream tooling
+
+## Related pages
+
+- [Web UI and API](/guides/web-ui-and-api/)
+- [Usage](/guides/usage/)

--- a/docs-site/content/reference/profiling.md
+++ b/docs-site/content/reference/profiling.md
@@ -1,0 +1,60 @@
+---
+title: "Profiling and pprof"
+weight: 7
+description: "Connect to a running term-llm pprof server for CPU, heap, goroutine, block, and mutex profiling."
+kicker: "Profiling"
+next:
+  label: Usage tracking
+  url: /reference/usage-tracking/
+---
+## Start term-llm with profiling enabled
+
+```bash
+term-llm chat --pprof
+term-llm chat --pprof=6060
+TERM_LLM_PPROF=1 term-llm chat
+```
+
+Then, from another terminal:
+
+```bash
+term-llm pprof cpu
+term-llm pprof heap
+term-llm pprof goroutine
+term-llm pprof block
+term-llm pprof mutex
+term-llm pprof web
+```
+
+## Commands
+
+- `pprof cpu [PORT]` capture a CPU profile
+- `pprof heap [PORT]` capture a heap profile
+- `pprof goroutine [PORT]` dump goroutine stacks
+- `pprof block [PORT]` capture a blocking profile
+- `pprof mutex [PORT]` capture a mutex contention profile
+- `pprof web [PORT]` open the pprof index in a browser
+
+If you omit the port, term-llm tries to auto-discover it from the pprof registry.
+
+## CPU duration
+
+```bash
+term-llm pprof cpu --duration 10
+```
+
+Default CPU capture duration is 30 seconds.
+
+## When to use it
+
+Use pprof when you are debugging:
+
+- CPU hotspots
+- memory growth
+- goroutine leaks
+- contention and blocking behavior
+
+## Related pages
+
+- [Debugging](/guides/debugging/)
+- [Usage tracking](/reference/usage-tracking/)


### PR DESCRIPTION
## What

- add docs for transcription
- add docs for notifications
- add docs for plan mode
- add docs for profiling / pprof
- extend the MCP page with a note about the deprecated internal `mcp-server` command
- extend agents and skills docs with some higher-value management operations
- add README links for transcription, plan mode, and notifications

## Why

After the previous docs batches, there were still several real product surfaces with little or no documentation coverage. This PR covers another chunk of those missing capabilities so the docs reflect more of what term-llm actually does.

## Verification

- `hugo --source docs-site --destination /tmp/term-llm-docs-next-batch`
- `go build ./...`
- `go test ./...`
