### PR TITLE
fix: make Venice native search match direct API behavior

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -45,6 +45,7 @@ var (
 	askContinueWith    string
 	askNativeSearch    bool
 	askNoNativeSearch  bool
+	askNoWebFetch      bool
 	// Tool flags
 	askTools         string
 	askReadDirs      []string
@@ -100,6 +101,7 @@ func init() {
 	AddDebugFlag(askCmd, &askDebug)
 	AddSearchFlag(askCmd, &askSearch)
 	AddNativeSearchFlags(askCmd, &askNativeSearch, &askNoNativeSearch)
+	AddNoWebFetchFlag(askCmd, &askNoWebFetch)
 	AddMCPFlag(askCmd, &askMCP)
 	AddMaxTurnsFlag(askCmd, &askMaxTurns, 20)
 	AddMaxOutputTokensFlag(askCmd, &askMaxOutputTokens)
@@ -424,15 +426,16 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		sessionID = sess.ID
 	}
 	req := llm.Request{
-		SessionID:           sessionID,
-		Messages:            messages,
-		Search:              settings.Search,
-		ForceExternalSearch: resolveForceExternalSearch(cfg, askNativeSearch, askNoNativeSearch),
-		ParallelToolCalls:   true,
-		MaxTurns:            settings.MaxTurns,
-		MaxOutputTokens:     settings.MaxOutputTokens,
-		Debug:               debugMode,
-		DebugRaw:            debugRaw,
+		SessionID:               sessionID,
+		Messages:                messages,
+		Search:                  settings.Search,
+		ForceExternalSearch:     resolveForceExternalSearch(cfg, askNativeSearch, askNoNativeSearch),
+		DisableExternalWebFetch: askNoWebFetch,
+		ParallelToolCalls:       true,
+		MaxTurns:                settings.MaxTurns,
+		MaxOutputTokens:         settings.MaxOutputTokens,
+		Debug:                   debugMode,
+		DebugRaw:                debugRaw,
 	}
 
 	// Add tools to request if any are registered (local or MCP)

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -26,6 +26,7 @@ var (
 	chatMaxTurns       int
 	chatNativeSearch   bool
 	chatNoNativeSearch bool
+	chatNoWebFetch     bool
 	// Tool flags
 	chatTools         string
 	chatReadDirs      []string
@@ -92,6 +93,7 @@ func init() {
 	AddDebugFlag(chatCmd, &chatDebug)
 	AddSearchFlag(chatCmd, &chatSearch)
 	AddNativeSearchFlags(chatCmd, &chatNativeSearch, &chatNoNativeSearch)
+	AddNoWebFetchFlag(chatCmd, &chatNoWebFetch)
 	AddMCPFlag(chatCmd, &chatMCP)
 	AddMaxTurnsFlag(chatCmd, &chatMaxTurns, 200) // chat has higher default
 	AddToolFlags(chatCmd, &chatTools, &chatReadDirs, &chatWriteDirs, &chatShellAllow)
@@ -355,8 +357,7 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	useAltScreen := term.IsTerminal(int(os.Stdout.Fd())) && !autoSendMode
 
 	// Create chat model
-	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, showStats, initialText, store, sess, useAltScreen, chatAutoSend, true, chatTextMode, agentName, chatYolo)
-
+	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, chatNoWebFetch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, false, initialText, store, sess, useAltScreen, chatAutoSend, autoSendMode, chatTextMode, agentName, chatYolo)
 	// Build program options
 	var opts []tea.ProgramOption
 	if useAltScreen {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -30,6 +30,7 @@ var (
 	execMaxTurns       int
 	execNativeSearch   bool
 	execNoNativeSearch bool
+	execNoWebFetch     bool
 	// Tool flags
 	execTools         string
 	execReadDirs      []string
@@ -77,6 +78,7 @@ func init() {
 	AddDebugFlag(execCmd, &execDebug)
 	AddSearchFlag(execCmd, &execSearch)
 	AddNativeSearchFlags(execCmd, &execNativeSearch, &execNoNativeSearch)
+	AddNoWebFetchFlag(execCmd, &execNoWebFetch)
 	AddMCPFlag(execCmd, &execMCP)
 	AddMaxTurnsFlag(execCmd, &execMaxTurns, 20)
 	AddToolFlags(execCmd, &execTools, &execReadDirs, &execWriteDirs, &execShellAllow)
@@ -243,15 +245,16 @@ func runExec(cmd *cobra.Command, args []string) error {
 				llm.SystemText(systemPrompt),
 				llm.UserText(userPrompt),
 			},
-			Tools:               reqTools,
-			ToolChoice:          toolChoice,
-			LastTurnToolChoice:  lastTurnToolChoice,
-			ParallelToolCalls:   true,
-			Search:              execSearch,
-			ForceExternalSearch: resolveForceExternalSearch(cfg, execNativeSearch, execNoNativeSearch),
-			MaxTurns:            execMaxTurns,
-			Debug:               debugMode,
-			DebugRaw:            debugRaw,
+			Tools:                   reqTools,
+			ToolChoice:              toolChoice,
+			LastTurnToolChoice:      lastTurnToolChoice,
+			ParallelToolCalls:       true,
+			Search:                  execSearch,
+			ForceExternalSearch:     resolveForceExternalSearch(cfg, execNativeSearch, execNoNativeSearch),
+			DisableExternalWebFetch: execNoWebFetch,
+			MaxTurns:                execMaxTurns,
+			Debug:                   debugMode,
+			DebugRaw:                debugRaw,
 		}
 
 		// Create progress channel for spinner updates

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -21,6 +21,7 @@ type CommonFlags struct {
 	Search         *bool
 	NativeSearch   *bool
 	NoNativeSearch *bool
+	NoWebFetch     *bool
 	MaxTurns       *int
 	Files          *[]string
 	Agent          *string
@@ -48,6 +49,11 @@ func AddSearchFlag(cmd *cobra.Command, dest *bool) {
 func AddNativeSearchFlags(cmd *cobra.Command, native, noNative *bool) {
 	cmd.Flags().BoolVar(native, "native-search", false, "Use provider's native search (override config)")
 	cmd.Flags().BoolVar(noNative, "no-native-search", false, "Use external search tools instead of provider's native search")
+}
+
+// AddNoWebFetchFlag adds --no-web-fetch to disable external read_url injection.
+func AddNoWebFetchFlag(cmd *cobra.Command, dest *bool) {
+	cmd.Flags().BoolVar(dest, "no-web-fetch", false, "Disable external URL fetching (read_url) when search is enabled")
 }
 
 // AddMCPFlag adds the --mcp flag with completion

--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -28,6 +28,7 @@ var (
 	loopMaxOutputTokens int
 	loopNativeSearch    bool
 	loopNoNativeSearch  bool
+	loopNoWebFetch      bool
 	// Tool flags
 	loopTools         string
 	loopReadDirs      []string
@@ -91,6 +92,7 @@ func init() {
 	AddDebugFlag(loopCmd, &loopDebug)
 	AddSearchFlag(loopCmd, &loopSearch)
 	AddNativeSearchFlags(loopCmd, &loopNativeSearch, &loopNoNativeSearch)
+	AddNoWebFetchFlag(loopCmd, &loopNoWebFetch)
 	AddMCPFlag(loopCmd, &loopMCP)
 	AddMaxTurnsFlag(loopCmd, &loopMaxTurns, 100) // Higher default for loop
 	AddMaxOutputTokensFlag(loopCmd, &loopMaxOutputTokens)
@@ -380,16 +382,17 @@ func runLoop(cmd *cobra.Command, args []string) error {
 
 		// Build request
 		req := llm.Request{
-			Messages:            messages,
-			Tools:               toolSpecs,
-			ToolChoice:          llm.ToolChoice{Mode: llm.ToolChoiceAuto},
-			ParallelToolCalls:   true,
-			Search:              settings.Search,
-			ForceExternalSearch: forceExternalSearch,
-			MaxTurns:            settings.MaxTurns,
-			MaxOutputTokens:     settings.MaxOutputTokens,
-			Debug:               loopDebug,
-			DebugRaw:            debugRaw,
+			Messages:                messages,
+			Tools:                   toolSpecs,
+			ToolChoice:              llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+			ParallelToolCalls:       true,
+			Search:                  settings.Search,
+			ForceExternalSearch:     forceExternalSearch,
+			DisableExternalWebFetch: loopNoWebFetch,
+			MaxTurns:                settings.MaxTurns,
+			MaxOutputTokens:         settings.MaxOutputTokens,
+			Debug:                   loopDebug,
+			DebugRaw:                debugRaw,
 		}
 
 		// Print iteration header

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -26,6 +26,7 @@ var (
 	planNoSearch       bool
 	planNativeSearch   bool
 	planNoNativeSearch bool
+	planNoWebFetch     bool
 )
 
 var planCmd = &cobra.Command{
@@ -64,6 +65,7 @@ func init() {
 	planCmd.Flags().BoolVarP(&planSearch, "search", "s", true, "Enable web search for current information")
 	planCmd.Flags().BoolVar(&planNoSearch, "no-search", false, "Disable web search for this plan session")
 	AddNativeSearchFlags(planCmd, &planNativeSearch, &planNoNativeSearch)
+	AddNoWebFetchFlag(planCmd, &planNoWebFetch)
 
 	planCmd.Flags().StringVarP(&planFile, "file", "f", "plan.md", "Plan file to edit")
 
@@ -247,7 +249,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	if fm, ok := finalModel.(*plan.Model); ok && fm.HandedOff() {
 		planContent := fm.GetContent()
 		agentName := fm.HandoffAgent()
-		return runChatFromPlan(cfg, planContent, agentName, modelName, useAltScreen, forceExternalSearch, planSearchEnabled)
+		return runChatFromPlan(cfg, planContent, agentName, modelName, useAltScreen, forceExternalSearch, planNoWebFetch, planSearchEnabled)
 	}
 
 	return nil
@@ -258,7 +260,7 @@ func resolvePlanSearch(searchFlag, noSearchFlag bool) bool {
 }
 
 // runChatFromPlan launches a chat session with the plan content as system instructions.
-func runChatFromPlan(cfg *config.Config, planContent string, agentName string, modelName string, useAltScreen bool, forceExternalSearch bool, searchEnabled bool) error {
+func runChatFromPlan(cfg *config.Config, planContent string, agentName string, modelName string, useAltScreen bool, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool) error {
 	ctx, stop := signal.NotifyContext()
 	defer stop()
 
@@ -338,7 +340,7 @@ func runChatFromPlan(cfg *config.Config, planContent string, agentName string, m
 	defer storeCleanup()
 
 	// Create chat model
-	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, cfg.DefaultProvider, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, settings.Search, enabledLocalTools, settings.Tools, "", false, "", store, nil, useAltScreen, autoSendQueue, false, false, agentName, false)
+	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, cfg.DefaultProvider, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, disableExternalWebFetch, settings.Search, enabledLocalTools, settings.Tools, "", false, "", store, nil, useAltScreen, autoSendQueue, false, false, agentName, false)
 
 	// Build program options
 	var opts []tea.ProgramOption

--- a/cmd/search_fetch_test.go
+++ b/cmd/search_fetch_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import "testing"
+
+func TestNoWebFetchFlagRegistration(t *testing.T) {
+	cmd := askCmd
+	flag := cmd.Flags().Lookup("no-web-fetch")
+	if flag == nil {
+		t.Fatal("expected --no-web-fetch flag to be registered on ask command")
+	}
+}

--- a/internal/debuglog/types.go
+++ b/internal/debuglog/types.go
@@ -30,6 +30,7 @@ type RequestData struct {
 	ToolChoice              *ToolChoice `json:"tool_choice,omitempty"`
 	Search                  bool        `json:"search,omitempty"`
 	ForceExternalSearch     bool        `json:"force_external_search,omitempty"`
+	DisableExternalWebFetch bool        `json:"disable_external_web_fetch,omitempty"`
 	ParallelToolCalls       bool        `json:"parallel_tool_calls,omitempty"`
 	MaxOutputTokens         int         `json:"max_output_tokens,omitempty"`
 	Temperature             float32     `json:"temperature,omitempty"`

--- a/internal/llm/debug_logger.go
+++ b/internal/llm/debug_logger.go
@@ -56,6 +56,7 @@ type debugRequestData struct {
 	ToolChoice              *debugToolChoice `json:"tool_choice,omitempty"`
 	Search                  bool             `json:"search,omitempty"`
 	ForceExternalSearch     bool             `json:"force_external_search,omitempty"`
+	DisableExternalWebFetch bool             `json:"disable_external_web_fetch,omitempty"`
 	ParallelToolCalls       bool             `json:"parallel_tool_calls,omitempty"`
 	MaxOutputTokens         int              `json:"max_output_tokens,omitempty"`
 	Temperature             float32          `json:"temperature,omitempty"`
@@ -200,6 +201,7 @@ func (l *DebugLogger) LogRequest(provider, model string, req Request) {
 			ToolChoice:              convertToolChoice(req.ToolChoice),
 			Search:                  req.Search,
 			ForceExternalSearch:     req.ForceExternalSearch,
+			DisableExternalWebFetch: req.DisableExternalWebFetch,
 			ParallelToolCalls:       req.ParallelToolCalls,
 			MaxOutputTokens:         req.MaxOutputTokens,
 			Temperature:             req.Temperature,
@@ -257,6 +259,7 @@ func (l *DebugLogger) LogTurnRequest(turn int, provider, model string, req Reque
 			ToolChoice:              convertToolChoice(req.ToolChoice),
 			Search:                  req.Search,
 			ForceExternalSearch:     req.ForceExternalSearch,
+			DisableExternalWebFetch: req.DisableExternalWebFetch,
 			ParallelToolCalls:       req.ParallelToolCalls,
 			MaxOutputTokens:         req.MaxOutputTokens,
 			Temperature:             req.Temperature,

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -476,7 +476,7 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	// The LLM will use them naturally during conversation like any other tool.
 	if req.Search {
 		needsExternalSearch := !caps.NativeWebSearch || req.ForceExternalSearch
-		needsExternalFetch := !caps.NativeWebFetch || req.ForceExternalSearch
+		needsExternalFetch := (!caps.NativeWebFetch || req.ForceExternalSearch) && !req.DisableExternalWebFetch
 
 		if needsExternalSearch {
 			if t, ok := e.tools.Get(WebSearchToolName); ok {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -526,6 +526,119 @@ func TestEngineForceExternalSearchDisablesNativeProviderSearch(t *testing.T) {
 	}
 }
 
+func TestEngineDisableExternalWebFetchWithNativeSearch(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&countingSearchTool{})
+	registry.Register(NewReadURLTool())
+
+	provider := &fakeProvider{
+		hasCapabilities: true,
+		capabilities: Capabilities{
+			NativeWebSearch: true,
+			NativeWebFetch:  false,
+			ToolCalls:       true,
+		},
+		script: func(call int, req Request) []Event {
+			return []Event{{Type: EventDone}}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages:                []Message{UserText("search this")},
+		Search:                  true,
+		DisableExternalWebFetch: true,
+	}
+
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+	}
+
+	if len(provider.calls) != 1 {
+		t.Fatalf("expected 1 provider call, got %d", len(provider.calls))
+	}
+
+	firstReq := provider.calls[0]
+	if !firstReq.Search {
+		t.Fatalf("expected provider request Search=true with native search")
+	}
+	if hasToolNamed(firstReq.Tools, ReadURLToolName) {
+		t.Fatalf("did not expect injected %s tool", ReadURLToolName)
+	}
+	if hasToolNamed(firstReq.Tools, WebSearchToolName) {
+		t.Fatalf("did not expect injected %s tool", WebSearchToolName)
+	}
+}
+
+func TestEngineDisableExternalWebFetchStillAllowsExternalSearch(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&countingSearchTool{})
+	registry.Register(NewReadURLTool())
+
+	provider := &fakeProvider{
+		hasCapabilities: true,
+		capabilities: Capabilities{
+			NativeWebSearch: true,
+			NativeWebFetch:  false,
+			ToolCalls:       true,
+		},
+		script: func(call int, req Request) []Event {
+			return []Event{{Type: EventDone}}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages:                []Message{UserText("search this")},
+		Search:                  true,
+		ForceExternalSearch:     true,
+		DisableExternalWebFetch: true,
+	}
+
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+	}
+
+	if len(provider.calls) != 1 {
+		t.Fatalf("expected 1 provider call, got %d", len(provider.calls))
+	}
+
+	firstReq := provider.calls[0]
+	if firstReq.Search {
+		t.Fatalf("expected provider request Search=false when force_external is true")
+	}
+	if !hasToolNamed(firstReq.Tools, WebSearchToolName) {
+		t.Fatalf("expected injected %s tool", WebSearchToolName)
+	}
+	if hasToolNamed(firstReq.Tools, ReadURLToolName) {
+		t.Fatalf("did not expect injected %s tool", ReadURLToolName)
+	}
+}
+
 func countToolResults(messages []Message) int {
 	count := 0
 	for _, msg := range messages {

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -91,16 +91,17 @@ func (p *OpenAICompatProvider) Capabilities() Capabilities {
 // OpenAI-compatible request/response structures
 // Tool choice can be string ("none"/"auto") or object.
 type oaiChatRequest struct {
-	Model             string            `json:"model"`
-	Messages          []oaiMessage      `json:"messages"`
-	Tools             []oaiTool         `json:"tools,omitempty"`
-	ToolChoice        interface{}       `json:"tool_choice,omitempty"`
-	ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty"`
-	Temperature       *float64          `json:"temperature,omitempty"`
-	TopP              *float64          `json:"top_p,omitempty"`
-	MaxTokens         *int              `json:"max_tokens,omitempty"`
-	Stream            bool              `json:"stream,omitempty"`
-	StreamOptions     *oaiStreamOptions `json:"stream_options,omitempty"`
+	Model             string                 `json:"model"`
+	Messages          []oaiMessage           `json:"messages"`
+	Tools             []oaiTool              `json:"tools,omitempty"`
+	ToolChoice        interface{}            `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool                  `json:"parallel_tool_calls,omitempty"`
+	Temperature       *float64               `json:"temperature,omitempty"`
+	TopP              *float64               `json:"top_p,omitempty"`
+	MaxTokens         *int                   `json:"max_tokens,omitempty"`
+	Stream            bool                   `json:"stream,omitempty"`
+	StreamOptions     *oaiStreamOptions      `json:"stream_options,omitempty"`
+	VeniceParameters  map[string]interface{} `json:"venice_parameters,omitempty"`
 }
 
 type oaiStreamOptions struct {

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -53,22 +53,23 @@ type Stream interface {
 
 // Request represents a single model turn.
 type Request struct {
-	Model               string
-	SessionID           string // Optional session ID for provider-side continuity/caching hints
-	Messages            []Message
-	Tools               []ToolSpec
-	ToolChoice          ToolChoice
-	LastTurnToolChoice  *ToolChoice // If set, force this tool choice on the last agentic turn
-	ParallelToolCalls   bool
-	Search              bool
-	ForceExternalSearch bool // If true, use external search even if provider supports native
-	ReasoningEffort     string
-	MaxOutputTokens     int
-	Temperature         float32
-	TopP                float32
-	MaxTurns            int // Max agentic turns for tool execution (0 = use default)
-	Debug               bool
-	DebugRaw            bool
+	Model                   string
+	SessionID               string // Optional session ID for provider-side continuity/caching hints
+	Messages                []Message
+	Tools                   []ToolSpec
+	ToolChoice              ToolChoice
+	LastTurnToolChoice      *ToolChoice // If set, force this tool choice on the last agentic turn
+	ParallelToolCalls       bool
+	Search                  bool
+	ForceExternalSearch     bool // If true, use external search even if provider supports native
+	DisableExternalWebFetch bool // If true, do not inject external read_url even when provider lacks native fetch
+	ReasoningEffort         string
+	MaxOutputTokens         int
+	Temperature             float32
+	TopP                    float32
+	MaxTurns                int // Max agentic turns for tool execution (0 = use default)
+	Debug                   bool
+	DebugRaw                bool
 }
 
 // Role identifies a message role.

--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -1,7 +1,13 @@
 package llm
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -28,19 +34,184 @@ func (p *VeniceProvider) Capabilities() Capabilities {
 }
 
 func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error) {
-	req.ParallelToolCalls = false
-	if req.Search {
-		req.Model = appendVeniceModelSuffix(chooseModel(req.Model, p.model), "enable_web_search=on")
+	req.MaxOutputTokens = ClampOutputTokens(req.MaxOutputTokens, chooseModel(req.Model, p.model))
+	messages := buildCompatMessages(req.Messages)
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("no messages provided")
 	}
-	return p.OpenAICompatProvider.Stream(ctx, req)
+
+	tools, err := buildCompatTools(req.Tools)
+	if err != nil {
+		return nil, err
+	}
+
+	model, veniceParams := buildVeniceModelAndParams(chooseModel(req.Model, p.model), req.Search)
+	chatReq := oaiChatRequest{
+		Model:            model,
+		Messages:         messages,
+		Tools:            tools,
+		Stream:           true,
+		VeniceParameters: veniceParams,
+	}
+
+	if req.ToolChoice.Mode != "" {
+		chatReq.ToolChoice = buildCompatToolChoice(req.ToolChoice)
+	}
+	if req.Temperature > 0 {
+		v := float64(req.Temperature)
+		chatReq.Temperature = &v
+	}
+	if req.TopP > 0 {
+		v := float64(req.TopP)
+		chatReq.TopP = &v
+	}
+	if req.MaxOutputTokens > 0 {
+		v := req.MaxOutputTokens
+		chatReq.MaxTokens = &v
+	}
+
+	if req.Debug {
+		fmt.Fprintf(os.Stderr, "=== DEBUG: %s Stream Request ===\n", p.name)
+		fmt.Fprintf(os.Stderr, "Provider: %s\n", p.Name())
+		fmt.Fprintf(os.Stderr, "URL: %s/chat/completions\n", p.baseURL)
+		fmt.Fprintf(os.Stderr, "Model: %s\n", model)
+		fmt.Fprintf(os.Stderr, "Messages: %d\n", len(messages))
+		fmt.Fprintf(os.Stderr, "Tools: %d\n", len(tools))
+		fmt.Fprintf(os.Stderr, "Venice params: %v\n", veniceParams)
+		fmt.Fprintln(os.Stderr, "===================================")
+	}
+
+	resp, err := p.makeChatRequest(ctx, chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("%s API request failed: %w", p.name, err)
+	}
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, string(body))
+	}
+
+	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, 1024*1024)
+
+		toolState := newCompatToolState()
+		var lastUsage *Usage
+		var lastEventType string
+		var reasoningBuilder strings.Builder
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event: ") {
+				lastEventType = strings.TrimPrefix(line, "event: ")
+				continue
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				break
+			}
+
+			var chatResp oaiChatResponse
+			if err := json.Unmarshal([]byte(data), &chatResp); err != nil {
+				continue
+			}
+			if lastEventType == "error" || chatResp.Error != nil {
+				errMsg := "unknown error"
+				if chatResp.Error != nil {
+					errMsg = chatResp.Error.Message
+				}
+				return fmt.Errorf("%s API error: %s", p.name, errMsg)
+			}
+			if chatResp.Usage != nil {
+				cached := chatResp.Usage.PromptTokensDetails.CachedTokens
+				lastUsage = &Usage{InputTokens: chatResp.Usage.PromptTokens - cached, OutputTokens: chatResp.Usage.CompletionTokens, CachedInputTokens: cached}
+			}
+			for _, choice := range chatResp.Choices {
+				if choice.Delta != nil {
+					if content, ok := choice.Delta.Content.(string); ok && content != "" {
+						events <- Event{Type: EventTextDelta, Text: content}
+					}
+					if choice.Delta.Reasoning != "" {
+						reasoningBuilder.WriteString(choice.Delta.Reasoning)
+						events <- Event{Type: EventReasoningDelta, Text: choice.Delta.Reasoning}
+					}
+					if len(choice.Delta.ToolCalls) > 0 {
+						toolState.Add(choice.Delta.ToolCalls)
+					}
+				}
+			}
+			lastEventType = ""
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("%s streaming error: %w", p.name, err)
+		}
+		for _, call := range toolState.Calls() {
+			events <- Event{Type: EventToolCall, Tool: &call}
+		}
+		if lastUsage != nil {
+			events <- Event{Type: EventUsage, Use: lastUsage}
+		}
+		events <- Event{Type: EventDone}
+		return nil
+	}), nil
 }
 
-func appendVeniceModelSuffix(model, suffix string) string {
-	if model == "" || suffix == "" {
-		return model
+func buildVeniceModelAndParams(model string, search bool) (string, map[string]interface{}) {
+	baseModel, suffixParams := parseVeniceModelSuffix(model)
+	params := make(map[string]interface{}, len(suffixParams)+1)
+	for k, v := range suffixParams {
+		params[k] = v
 	}
-	if strings.Contains(model, ":") {
-		return model + "&" + suffix
+	if search {
+		if _, hasX := params["enable_x_search"]; !hasX {
+			if _, hasWeb := params["enable_web_search"]; !hasWeb {
+				params["enable_web_search"] = "on"
+			}
+		}
 	}
-	return model + ":" + suffix
+	if len(params) == 0 {
+		return baseModel, nil
+	}
+	return baseModel, params
+}
+
+func parseVeniceModelSuffix(model string) (string, map[string]interface{}) {
+	parts := strings.SplitN(model, ":", 2)
+	if len(parts) < 2 {
+		return model, nil
+	}
+	params := map[string]interface{}{}
+	for _, raw := range strings.Split(parts[1], "&") {
+		if raw == "" {
+			continue
+		}
+		kv := strings.SplitN(raw, "=", 2)
+		if len(kv) != 2 || kv[0] == "" {
+			continue
+		}
+		params[kv[0]] = parseVeniceParamValue(kv[1])
+	}
+	if len(params) == 0 {
+		return model, nil
+	}
+	return parts[0], params
+}
+
+func parseVeniceParamValue(v string) interface{} {
+	switch strings.ToLower(v) {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+	if i, err := strconv.Atoi(v); err == nil {
+		return i
+	}
+	return v
 }

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -25,32 +25,48 @@ func TestVeniceProviderCapabilities(t *testing.T) {
 	}
 }
 
-func TestAppendVeniceModelSuffix(t *testing.T) {
-	tests := []struct {
-		name   string
-		model  string
-		suffix string
-		want   string
-	}{
-		{name: "plain model", model: "venice-uncensored", suffix: "enable_web_search=on", want: "venice-uncensored:enable_web_search=on"},
-		{name: "existing suffix", model: "grok-4-20-beta:enable_x_search=true", suffix: "enable_web_search=on", want: "grok-4-20-beta:enable_x_search=true&enable_web_search=on"},
-		{name: "empty suffix", model: "venice-uncensored", suffix: "", want: "venice-uncensored"},
+func TestParseVeniceModelSuffix(t *testing.T) {
+	base, params := parseVeniceModelSuffix("grok-4-20-beta:enable_x_search=true&enable_web_citations=true")
+	if base != "grok-4-20-beta" {
+		t.Fatalf("base model = %q, want grok-4-20-beta", base)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := appendVeniceModelSuffix(tt.model, tt.suffix); got != tt.want {
-				t.Fatalf("appendVeniceModelSuffix(%q, %q) = %q, want %q", tt.model, tt.suffix, got, tt.want)
-			}
-		})
+	if params["enable_x_search"] != true {
+		t.Fatalf("expected enable_x_search=true, got %#v", params["enable_x_search"])
+	}
+	if params["enable_web_citations"] != true {
+		t.Fatalf("expected enable_web_citations=true, got %#v", params["enable_web_citations"])
 	}
 }
 
-func TestVeniceProviderSearchUsesModelSuffixAndDisablesParallelToolCalls(t *testing.T) {
+func TestBuildVeniceModelAndParams_PreservesExplicitXSearch(t *testing.T) {
+	model, params := buildVeniceModelAndParams("grok-4-20-beta:enable_x_search=true", true)
+	if model != "grok-4-20-beta" {
+		t.Fatalf("model = %q, want grok-4-20-beta", model)
+	}
+	if params["enable_x_search"] != true {
+		t.Fatalf("expected enable_x_search=true, got %#v", params["enable_x_search"])
+	}
+	if _, ok := params["enable_web_search"]; ok {
+		t.Fatalf("did not expect enable_web_search when explicit x search is set: %#v", params)
+	}
+}
+
+func TestBuildVeniceModelAndParams_AddsWebSearchWhenNeeded(t *testing.T) {
+	model, params := buildVeniceModelAndParams("venice-uncensored", true)
+	if model != "venice-uncensored" {
+		t.Fatalf("model = %q, want venice-uncensored", model)
+	}
+	if params["enable_web_search"] != "on" {
+		t.Fatalf("expected enable_web_search=on, got %#v", params["enable_web_search"])
+	}
+}
+
+func TestVeniceProviderSearchUsesVeniceParametersAndBaseModel(t *testing.T) {
 	var got struct {
-		Model             string `json:"model"`
-		ParallelToolCalls *bool  `json:"parallel_tool_calls,omitempty"`
-		Stream            bool   `json:"stream"`
+		Model             string                 `json:"model"`
+		ParallelToolCalls *bool                  `json:"parallel_tool_calls,omitempty"`
+		Stream            bool                   `json:"stream"`
+		VeniceParameters  map[string]interface{} `json:"venice_parameters,omitempty"`
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -87,13 +103,63 @@ func TestVeniceProviderSearchUsesModelSuffixAndDisablesParallelToolCalls(t *test
 		}
 	}
 
-	if got.Model != "venice-uncensored:enable_web_search=on" {
-		t.Fatalf("expected search model suffix, got %q", got.Model)
+	if got.Model != "venice-uncensored" {
+		t.Fatalf("expected base model only, got %q", got.Model)
+	}
+	if got.VeniceParameters["enable_web_search"] != "on" {
+		t.Fatalf("expected venice_parameters.enable_web_search=on, got %#v", got.VeniceParameters)
 	}
 	if got.ParallelToolCalls != nil {
 		t.Fatalf("expected parallel_tool_calls to be omitted/false, got %+v", got.ParallelToolCalls)
 	}
 	if !got.Stream {
 		t.Fatal("expected stream=true")
+	}
+}
+
+func TestVeniceProviderExplicitXSearchUsesVeniceParameters(t *testing.T) {
+	var got struct {
+		Model            string                 `json:"model"`
+		VeniceParameters map[string]interface{} `json:"venice_parameters,omitempty"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	provider := &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(ts.URL, "test-key", "venice-uncensored", "Venice")}
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("find recent posts")},
+		Search:   true,
+		Model:    "grok-4-20-beta:enable_x_search=true",
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.Model != "grok-4-20-beta" {
+		t.Fatalf("expected stripped base model, got %q", got.Model)
+	}
+	if got.VeniceParameters["enable_x_search"] != true {
+		t.Fatalf("expected venice_parameters.enable_x_search=true, got %#v", got.VeniceParameters)
+	}
+	if _, ok := got.VeniceParameters["enable_web_search"]; ok {
+		t.Fatalf("did not expect enable_web_search alongside explicit x search: %#v", got.VeniceParameters)
 	}
 }

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -91,19 +91,20 @@ type Model struct {
 	agentName    string
 
 	// Pending message context
-	files               []FileAttachment // Attached files for next message
-	images              []ImageAttachment
-	selectedImage       int      // -1 means no image chip selected
-	searchEnabled       bool     // Web search toggle
-	forceExternalSearch bool     // Force external search tools even if provider supports native
-	localTools          []string // Names of enabled local tools (read, write, etc.)
-	toolsStr            string   // Original tools setting (for session persistence)
-	mcpStr              string   // Original MCP setting (for session persistence)
-	pendingInterjection string   // Interrupt text waiting to be injected or cancelled
-	interruptRequestSeq uint64   // Monotonic sequence for async interrupt classification
-	activeInterruptSeq  uint64   // Currently active async interrupt classification request
-	pendingInterruptUI  string   // UI state: "", "deciding", "interject"
-	interruptNotice     string   // One-line UI notice for recent interrupt actions
+	files                   []FileAttachment // Attached files for next message
+	images                  []ImageAttachment
+	selectedImage           int      // -1 means no image chip selected
+	searchEnabled           bool     // Web search toggle
+	forceExternalSearch     bool     // Force external search tools even if provider supports native
+	disableExternalWebFetch bool     // Disable external read_url injection even when provider lacks native fetch
+	localTools              []string // Names of enabled local tools (read, write, etc.)
+	toolsStr                string   // Original tools setting (for session persistence)
+	mcpStr                  string   // Original MCP setting (for session persistence)
+	pendingInterjection     string   // Interrupt text waiting to be injected or cancelled
+	interruptRequestSeq     uint64   // Monotonic sequence for async interrupt classification
+	activeInterruptSeq      uint64   // Currently active async interrupt classification request
+	pendingInterruptUI      string   // UI state: "", "deciding", "interject"
+	interruptNotice         string   // One-line UI notice for recent interrupt actions
 	// MCP (Model Context Protocol)
 	mcpManager *mcp.Manager
 	maxTurns   int
@@ -285,13 +286,13 @@ type AskUserRequestMsg struct {
 
 // New creates a new chat model.
 // fast-provider aware callers should use NewWithFastProvider.
-func New(cfg *config.Config, provider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, yolo bool) *Model {
-	return NewWithFastProvider(cfg, provider, nil, engine, providerKey, modelName, mcpManager, maxTurns, forceExternalSearch, searchEnabled, localTools, toolsStr, mcpStr, showStats, initialText, store, sess, altScreen, autoSendQueue, autoSendExitOnDone, textMode, agentName, yolo)
+func New(cfg *config.Config, provider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, yolo bool) *Model {
+	return NewWithFastProvider(cfg, provider, nil, engine, providerKey, modelName, mcpManager, maxTurns, forceExternalSearch, disableExternalWebFetch, searchEnabled, localTools, toolsStr, mcpStr, showStats, initialText, store, sess, altScreen, autoSendQueue, autoSendExitOnDone, textMode, agentName, yolo)
 }
 
 // NewWithFastProvider creates a new chat model with an optional fast provider
 // for control-plane classification tasks.
-func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, yolo bool) *Model {
+func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, yolo bool) *Model {
 	// Get terminal size
 	width := 80
 	height := 24
@@ -445,6 +446,7 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 		mcpManager:              mcpManager,
 		maxTurns:                maxTurns,
 		forceExternalSearch:     forceExternalSearch,
+		disableExternalWebFetch: disableExternalWebFetch,
 		searchEnabled:           searchEnabled,
 		localTools:              localTools,
 		toolsStr:                toolsStr,

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -181,6 +181,7 @@ func newTestChatModel(altScreen bool) *Model {
 		20,
 		false,
 		false,
+		false,
 		nil,
 		"",
 		"",

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -52,6 +52,7 @@ func TestUpdate_StreamError_BumpsContentVersion(t *testing.T) {
 		nil,   // mcpManager
 		20,    // maxTurns
 		false, // forceExternalSearch
+		false, // disableExternalWebFetch
 		false, // searchEnabled
 		nil,   // localTools
 		"",    // toolsStr
@@ -90,6 +91,7 @@ func TestViewAltScreen_FirstRenderAnchorsToBottom(t *testing.T) {
 		nil,   // mcpManager
 		20,    // maxTurns
 		false, // forceExternalSearch
+		false, // disableExternalWebFetch
 		false, // searchEnabled
 		nil,   // localTools
 		"",    // toolsStr
@@ -209,6 +211,7 @@ func TestStreamEventDiffFlushUsesOrderedCommandComposition(t *testing.T) {
 		20,
 		false,
 		false,
+		false,
 		nil,
 		"",
 		"",
@@ -317,6 +320,7 @@ func TestRenderStatusLine_ShowsSeededCachedUsageFromSession(t *testing.T) {
 		"mock-model",
 		nil,
 		20,
+		false,
 		false,
 		false,
 		nil,

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -232,13 +232,14 @@ func (m *Model) startStream(content string) tea.Cmd {
 		}
 
 		req := llm.Request{
-			SessionID:           m.sess.ID,
-			Messages:            messages,
-			Tools:               reqTools,
-			Search:              m.searchEnabled,
-			ForceExternalSearch: m.forceExternalSearch,
-			ParallelToolCalls:   true,
-			MaxTurns:            m.maxTurns,
+			SessionID:               m.sess.ID,
+			Messages:                messages,
+			Tools:                   reqTools,
+			Search:                  m.searchEnabled,
+			ForceExternalSearch:     m.forceExternalSearch,
+			DisableExternalWebFetch: m.disableExternalWebFetch,
+			ParallelToolCalls:       true,
+			MaxTurns:                m.maxTurns,
 		}
 
 		// Set up callbacks for incremental message saving (sequence auto-allocated)


### PR DESCRIPTION
## What

Make Venice native search behave like the direct Venice API path instead of degrading into the weaker suffix/fetch behavior.

This PR does two related things:

1. **Fix Venice search wiring**
   - Venice provider now translates model suffix feature flags into `venice_parameters` in the request body
   - strips those suffixes back off the outbound `model`
   - when `-s/--search` is enabled, it adds `enable_web_search=on` only if the request does not already explicitly set `enable_x_search` or `enable_web_search`

2. **Add a `--no-web-fetch` escape hatch**
   - new CLI flag for search-enabled flows to disable external `read_url` injection
   - keeps “search only, no fetch” possible when a provider has native search but no native URL fetch
   - wired through ask/chat/exec/loop/plan and request/debug structures

## Why

We were trying to get parity with a direct Venice API call like this:

- model `grok-4-20-beta`
- `venice_parameters.enable_x_search=true`

That direct call successfully returned recent status URLs from X.

But term-llm was doing worse for the equivalent user flow because:

- Venice search support was being expressed by mutating the model name with suffixes
- Venice’s actual API behavior is materially better when those controls are sent in `venice_parameters`
- search-enabled flows could also pick up `read_url`, which is sometimes useful, but for X/Twitter profile pages often just sends the model into login-wall sludge

So the issue was partly fetch injection, but the bigger bug was that Venice search parity was not actually matching the successful direct API request shape.

## Validation

Code-level:

- `go build ./...`
- `go test ./...`

Live smoke tests with real `VENICE_API_KEY` and config forcing external search globally (`search.force_external: true`), then overriding via `--native-search`:

Prompt used:

```text
Find the 3 latest non-pinned posts from @samsaffron on X. Return only direct status URLs you can verify, with a one-line summary.
```

### Before this patch (current behavior)

`term-llm ask --provider 'venice:grok-4-20-beta:enable_x_search=true' -s --native-search --porcelain ...`

Returned failure / no verifiable posts.

### After this patch

Same command returned direct status URLs, e.g.:

- `https://x.com/samsaffron/status/2032342776910922051` — Jarvis is not disappointing.
- `https://x.com/samsaffron/status/2032342212667998549` — Claude Code feature request for better multi-terminal support.
- `https://x.com/samsaffron/status/2032207345783374010` — 40-hour Discourse security scan + progressive execution work.

With the new explicit search-only mode:

`term-llm ask --provider 'venice:grok-4-20-beta:enable_x_search=true' -s --native-search --no-web-fetch --porcelain ...`

also returned the same class of direct status URLs in repeated runs.

## Notes

The important fix here is **Venice request-shape parity** (`venice_parameters`), not just disabling fetch. `--no-web-fetch` is still useful as a control-plane escape hatch, but it was not the whole story.
