### PR TITLE
docs: document Perplexity search provider

### DIFF
--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -52,6 +52,9 @@ export OPENROUTER_API_KEY=your-key
 
 # For Gemini
 export GEMINI_API_KEY=your-key
+
+# For Perplexity search (used by search.provider: perplexity)
+export PERPLEXITY_API_KEY=your-key
 ```
 
 ### Option 3: Use Anthropic with OAuth (Claude Pro/Max subscription)

--- a/docs-site/content/guides/search.md
+++ b/docs-site/content/guides/search.md
@@ -35,7 +35,10 @@ Use this when you want consistency, debugging clarity, or to work around a provi
 
 ```yaml
 search:
-  provider: exa
+  provider: perplexity
+
+  perplexity:
+    api_key: ${PERPLEXITY_API_KEY}
 
   exa:
     api_key: ${EXA_API_KEY}
@@ -54,6 +57,7 @@ Available external providers:
 |---|---|---|
 | DuckDuckGo | none | default, free |
 | Exa | `EXA_API_KEY` | semantic search |
+| Perplexity | `PERPLEXITY_API_KEY` | search API with concise answer-oriented results |
 | Tavily | `TAVILY_API_KEY` | agent-oriented search |
 | Brave | `BRAVE_API_KEY` | independent index |
 | Google | `GOOGLE_SEARCH_API_KEY` + `GOOGLE_SEARCH_CX` | Custom Search |

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -125,8 +125,11 @@ Use this to control whether sessions are persisted, how long they are kept, and 
 
 ```yaml
 search:
-  provider: exa
+  provider: perplexity
   force_external: false
+
+  perplexity:
+    api_key: ${PERPLEXITY_API_KEY}
 
   exa:
     api_key: ${EXA_API_KEY}


### PR DESCRIPTION
## What

Document the Perplexity external search provider now that the code path has already landed.

- add `PERPLEXITY_API_KEY` to the setup docs
- show `search.provider: perplexity` and `search.perplexity.api_key` in config examples
- add Perplexity to the external search provider table

## Why

PR #125 added the provider, but the docs still only listed DuckDuckGo, Exa, Tavily, Brave, and Google. That leaves the implementation discoverable only by reading code or config completions, which is a bit stupid.

## Validation

- `hugo --source docs-site`
