### PR TITLE
docs: focus docs on built-in agents

### DIFF
--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -79,7 +79,7 @@ Examples:
     "Fix the tests. Don't repeat failed approaches."
 
   # Using an agent
-  term-llm loop @coder --done "make build" --max 20 \
+  term-llm loop @developer --done "make build" --max 20 \
     "Implement the feature described in {{SPEC.md}}"`,
 	Args:              cobra.MinimumNArgs(1),
 	RunE:              runLoop,

--- a/docker/sv/README.md
+++ b/docker/sv/README.md
@@ -15,7 +15,7 @@ ln -sf /etc/sv/<name> /etc/runit/runsvdir/<name>
 Or manage it from outside the container:
 
 ```bash
-docker exec jarvis ln -sf /etc/sv/<name> /etc/runit/runsvdir/<name>
+docker exec <container> ln -sf /etc/sv/<name> /etc/runit/runsvdir/<name>
 ```
 
 ## Service structure

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -12,4 +12,6 @@ avoids: |
   - Landing pages that look polished but do not help readers find the right page
   - Burying important configuration and command details inside long prose
 ---
-term-llm now has a documentation hub with clear entry points for setup, day-to-day use, architecture, and reference.
+term-llm has a documentation hub with clear entry points for setup, day-to-day use, architecture, and reference.
+
+It is not just one generic chat box in a trench coat. The built-in agents are a real part of the product: use `@reviewer` for code review, `@codebase` for repo exploration, `@developer` for implementation, `@researcher` for web-backed investigation, and the rest when the job fits.

--- a/docs-site/content/guides/agents.md
+++ b/docs-site/content/guides/agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Agents"
 weight: 9
-description: "Create and manage named workflow bundles with their own provider, model, tools, and instructions."
+description: "Use built-in agents or create your own workflow bundles with their own provider, model, tools, and instructions."
 kicker: "Workflow bundles"
 source_readme_heading: "Agents"
 featured: true
@@ -9,19 +9,54 @@ next:
   label: Skills
   url: /guides/skills/
 ---
-Agents are named configuration bundles that define a persona with specific provider, model, system prompt, tools, and MCP servers. Use agents to switch between different workflows quickly.
+Agents are named workflow bundles. An agent can carry its own system prompt, provider and model preferences, tool permissions, MCP servers, shell allowlists, and turn limits.
 
-### Using Agents
+That means you can stop restating the same intent over and over. Use `@reviewer` when you want review behavior, `@codebase` when you want repository exploration, `@researcher` when you want web-backed investigation, and so on.
+
+## Using agents
 
 Use the `@agent` prefix syntax or `--agent` flag:
 
 ```bash
-term-llm ask @reviewer "review this code"     # use reviewer agent
-term-llm chat @coder                          # start chat with coder agent
-term-llm ask --agent reviewer "question"      # alternative syntax
+term-llm ask @reviewer "review this code" -f main.go
+term-llm chat @codebase
+term-llm ask --agent researcher "Find info about Go 1.24"
 ```
 
-### Managing Agents
+## Built-in agents
+
+List them anytime with:
+
+```bash
+term-llm agents list --builtin
+```
+
+term-llm ships with these built-in agents:
+
+| Agent | What it is for |
+|---|---|
+| `active-review` | Runs a review-and-fix loop by spawning `reviewer`, then `developer` if fixes are needed. |
+| `agent-builder` | Creates and edits custom agents interactively. |
+| `artist` | Image generation and editing workflows. |
+| `changelog` | Writes human-readable summaries of interesting git activity. |
+| `codebase` | Reads repositories, traces call paths, and answers source-code questions. |
+| `commit-message` | Writes commit messages from staged or unstaged changes. |
+| `developer` | Implements code changes, fixes, and features. |
+| `editor` | Focused file editing without shell access. |
+| `file-organizer` | Renames and organizes files into sensible names and folders. |
+| `researcher` | Information gathering with web search. |
+| `reviewer` | Read-only code review with git-aware inspection tools. |
+| `shell` | General shell command helper. |
+
+A few good starting points:
+
+- `@reviewer` for code review without letting the model edit files
+- `@codebase` for architecture questions and tracing behavior across a repo
+- `@developer` when you want implementation work done
+- `@researcher` when the answer depends on current web information
+- `@commit-message` when you want a clean commit message without fuss
+
+## Managing agents
 
 ```bash
 term-llm agents                              # List all agents
@@ -32,7 +67,7 @@ term-llm agents list --user                  # Only user agents
 term-llm agents new my-agent                 # Create new agent
 term-llm agents show reviewer                # Show agent configuration
 term-llm agents edit reviewer                # Edit agent configuration
-term-llm agents copy builtin/coder my-coder  # Copy agent to customize
+term-llm agents copy reviewer my-reviewer    # Copy an agent to customize
 term-llm agents path                         # Print agents directory
 term-llm agents export reviewer              # Export an agent bundle
 term-llm agents import ./agent-dir           # Import an agent bundle
@@ -42,13 +77,13 @@ term-llm agents get reviewer
 term-llm agents clear reviewer model
 ```
 
-### Agent Configuration
+## Agent configuration
 
 Agents are YAML files stored in `~/.config/term-llm/agents/`:
 
 ```yaml
 # ~/.config/term-llm/agents/reviewer/agent.yaml
-name: Code Reviewer
+name: reviewer
 description: Reviews code for best practices and potential issues
 
 provider: anthropic
@@ -61,8 +96,8 @@ tools:
 
 shell:
   allow: ["git *", "npm test"]  # glob patterns for allowed commands
-  auto_run: true                 # skip confirmation for matched commands
-  scripts:                       # named shortcuts (auto-approved)
+  auto_run: true                   # skip confirmation for matched commands
+  scripts:                         # named shortcuts (auto-approved)
     build: "npm run build"
 
 search: true   # enables web_search and read_url tools
@@ -74,7 +109,7 @@ mcp:
 
 Built-in agents that currently default to `search: true`: `agent-builder`, `researcher`, `developer`, `editor`, `shell`.
 
-### System Prompt File Includes
+## System prompt file includes
 
 System prompts support inline file includes with `{{file:...}}`.
 

--- a/docs-site/content/guides/autonomous-loops.md
+++ b/docs-site/content/guides/autonomous-loops.md
@@ -63,6 +63,6 @@ term-llm loop --done-file RESEARCH.md:"## Conclusion" --tools read,write --searc
   "Research WebGPU compute shaders. Current progress: {{RESEARCH.md}}. Write a Conclusion section when done."
 
 # With an agent and iteration cap
-term-llm loop @coder --done "make build" --max 20 --yolo \
+term-llm loop @developer --done "make build" --max 20 --yolo \
   "Implement the feature described in {{SPEC.md}}"
 ```

--- a/docs-site/content/guides/memory.md
+++ b/docs-site/content/guides/memory.md
@@ -23,14 +23,14 @@ The distinction matters. Most session content is ephemeral. Memory is meant for 
 term-llm memory status
 term-llm memory search "retry policy"
 term-llm memory fragments list
-term-llm memory insights list --agent jarvis
+term-llm memory insights list --agent assistant
 ```
 
 Use `--agent` when you want to scope memory to a particular agent:
 
 ```bash
-term-llm memory status --agent jarvis
-term-llm memory search "docs tone" --agent jarvis
+term-llm memory status --agent assistant
+term-llm memory search "docs tone" --agent assistant
 ```
 
 ## Mine completed sessions into fragments
@@ -92,15 +92,15 @@ term-llm memory search "embedding provider" --embed-provider gemini
 List fragments:
 
 ```bash
-term-llm memory fragments list --agent jarvis --limit 20
+term-llm memory fragments list --agent assistant --limit 20
 term-llm memory fragments list --filter-path preferences
 ```
 
 Show a fragment by numeric ID or path:
 
 ```bash
-term-llm memory fragments show 42 --agent jarvis
-term-llm memory fragments show fragments/preferences/editor.md --agent jarvis
+term-llm memory fragments show 42 --agent assistant
+term-llm memory fragments show fragments/preferences/editor.md --agent assistant
 ```
 
 Show where a fragment came from:
@@ -112,15 +112,15 @@ term-llm memory fragments sources 42 --json
 Manage fragments manually when you need precise control:
 
 ```bash
-term-llm memory fragments add fragments/preferences/search.md --agent jarvis --content "Prefer Exa with Brave fallback."
-term-llm memory fragments update fragments/preferences/search.md --agent jarvis --content "Prefer Exa with Brave as fallback only."
-term-llm memory fragments delete fragments/preferences/search.md --agent jarvis
+term-llm memory fragments add fragments/preferences/search.md --agent assistant --content "Prefer Exa with Brave fallback."
+term-llm memory fragments update fragments/preferences/search.md --agent assistant --content "Prefer Exa with Brave as fallback only."
+term-llm memory fragments delete fragments/preferences/search.md --agent assistant
 ```
 
 ## Promote recent fragments into an agent summary
 
 ```bash
-term-llm memory promote --agent jarvis
+term-llm memory promote --agent assistant
 ```
 
 Promotion condenses recently changed fragments into an agent-level `recent.md` summary. It is a compression step, not a raw dump.
@@ -128,9 +128,9 @@ Promotion condenses recently changed fragments into an agent-level `recent.md` s
 Useful flags:
 
 ```bash
-term-llm memory promote --agent jarvis --since 6h
-term-llm memory promote --agent jarvis --recent-max-bytes 20000
-term-llm memory promote --agent jarvis --dry-run
+term-llm memory promote --agent assistant --since 6h
+term-llm memory promote --agent assistant --recent-max-bytes 20000
+term-llm memory promote --agent assistant --dry-run
 ```
 
 ## Behavioral insights
@@ -138,20 +138,20 @@ term-llm memory promote --agent jarvis --dry-run
 Fragments store facts. Insights store reusable behavioral rules.
 
 ```bash
-term-llm memory insights list --agent jarvis
+term-llm memory insights list --agent assistant
 term-llm memory insights search "code review"
-term-llm memory insights expand "debugging deploy failures" --agent jarvis
+term-llm memory insights expand "debugging deploy failures" --agent assistant
 ```
 
 You can add or reinforce them manually:
 
 ```bash
-term-llm memory insights add --agent jarvis \
+term-llm memory insights add --agent assistant \
   --category workflow \
   --confidence 0.8 \
   --content "Write code first, then wait for approval before starting services."
 
-term-llm memory insights reinforce 42 --agent jarvis
+term-llm memory insights reinforce 42 --agent assistant
 ```
 
 High-confidence insights are meant to shape future behavior, not just sit in storage looking profound.

--- a/docs-site/content/guides/usage.md
+++ b/docs-site/content/guides/usage.md
@@ -27,9 +27,9 @@ Use the `@agent` prefix syntax to use a specific agent:
 
 ```bash
 term-llm ask @reviewer "review this code"     # use reviewer agent
-term-llm chat @coder                          # start chat with coder agent
+term-llm chat @codebase                        # explore a repository
 term-llm loop @researcher --done-file ...     # use researcher agent in loop
-term-llm exec @bash-expert "find large files" # use bash-expert agent
+term-llm ask @shell "find the 3 biggest files"
 ```
 
 See [Agents](/guides/agents/) for more details on creating and managing agents.

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -60,7 +60,7 @@ term-llm serve web --auth none --host 127.0.0.1
 ```bash
 term-llm serve web \
   --provider anthropic \
-  --agent jarvis \
+  --agent assistant \
   --search \
   --mcp playwright \
   --max-turns 200 \

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -12,15 +12,57 @@
 
     <aside class="hero-panel terminal-panel">
       <div class="terminal-bar"><span></span><span></span><span></span></div>
-      <pre><code>$ term-llm chat --agent jarvis
+      <pre><code>$ term-llm exec "find the 3 biggest files"
 
-> what is term-llm?
+$ term-llm ask @reviewer "review the staged changes"
 
-A terminal-first AI runtime with:
-- chat, web, and jobs runtimes
-- agents, tools, skills, and memory
-- enough structure for real workflows</code></pre>
+$ term-llm chat @codebase</code></pre>
     </aside>
+  </section>
+
+  <section class="section-block">
+    <div class="section-heading">
+      <p class="eyebrow">Start with intent</p>
+      <h2>Three common entry points</h2>
+    </div>
+    <div class="card-grid card-grid-3">
+      <a class="card detail-card" href="/guides/usage/">
+        <p class="card-kicker">Exec</p>
+        <h3><code>term-llm exec</code></h3>
+        <p>Use plain English to get a command suggestion fast. Good for one-shot terminal tasks like finding the 3 biggest files.</p>
+      </a>
+      <a class="card detail-card" href="/guides/agents/">
+        <p class="card-kicker">Ask + agents</p>
+        <h3><code>term-llm ask @reviewer</code></h3>
+        <p>Use a built-in agent when the job has a mode. `@reviewer` is read-only and git-aware, so it reviews code without wandering off into edits.</p>
+      </a>
+      <a class="card detail-card" href="/guides/agents/">
+        <p class="card-kicker">Chat + agents</p>
+        <h3><code>term-llm chat @codebase</code></h3>
+        <p>Start a persistent session when you need back-and-forth. `@codebase` is the right tool for tracing behavior and understanding a repository.</p>
+      </a>
+    </div>
+  </section>
+
+  <section class="section-block split-layout">
+    <div>
+      <div class="section-heading">
+        <p class="eyebrow">Built-in agents</p>
+        <h2>Use the ones that already exist</h2>
+      </div>
+      <div class="list-panel">
+        <p><code>@reviewer</code>, <code>@codebase</code>, <code>@developer</code>, <code>@researcher</code>, <code>@commit-message</code></p>
+        <p><code>@active-review</code>, <code>@agent-builder</code>, <code>@artist</code>, <code>@changelog</code>, <code>@editor</code>, <code>@file-organizer</code>, <code>@shell</code></p>
+        <p><a href="/guides/agents/">See the built-in agents guide</a></p>
+      </div>
+    </div>
+    <div>
+      <div class="section-heading">
+        <p class="eyebrow">What belongs here</p>
+        <h2>Documentation structure</h2>
+      </div>
+      <div class="list-panel markdown">{{ .Params.belongs | markdownify }}</div>
+    </div>
   </section>
 
   <section class="section-block">
@@ -42,33 +84,25 @@ A terminal-first AI runtime with:
   <section class="section-block split-layout">
     <div>
       <div class="section-heading">
-        <p class="eyebrow">What belongs here</p>
-        <h2>Documentation structure</h2>
-      </div>
-      <div class="list-panel markdown">{{ .Params.belongs | markdownify }}</div>
-    </div>
-    <div>
-      <div class="section-heading">
         <p class="eyebrow">What to avoid</p>
         <h2>Documentation failure modes</h2>
       </div>
       <div class="list-panel markdown">{{ .Params.avoids | markdownify }}</div>
     </div>
-  </section>
-
-  <section class="section-block">
-    <div class="section-heading">
-      <p class="eyebrow">Featured pages</p>
-      <h2>Recommended starting points</h2>
-    </div>
-    <div class="card-grid card-grid-3">
-      {{ range first 6 (where site.RegularPages "Params.featured" true) }}
-        <a class="card detail-card" href="{{ .RelPermalink }}">
-          <p class="card-kicker">{{ .CurrentSection.Title }}</p>
-          <h3>{{ .Title }}</h3>
-          <p>{{ with .Description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}</p>
-        </a>
-      {{ end }}
+    <div>
+      <div class="section-heading">
+        <p class="eyebrow">Featured pages</p>
+        <h2>Recommended starting points</h2>
+      </div>
+      <div class="card-grid card-grid-3">
+        {{ range first 3 (where site.RegularPages "Params.featured" true) }}
+          <a class="card detail-card" href="{{ .RelPermalink }}">
+            <p class="card-kicker">{{ .CurrentSection.Title }}</p>
+            <h3>{{ .Title }}</h3>
+            <p>{{ with .Description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}</p>
+          </a>
+        {{ end }}
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## What

- remove Jarvis-specific examples from the public docs
- make the docs homepage lead with concrete entry points:
  - `term-llm exec "find the 3 biggest files"`
  - `term-llm ask @reviewer "review the staged changes"`
  - `term-llm chat @codebase`
- add a proper built-in agents section that covers all shipped agents and what each one is for
- replace stale doc examples that referenced nonexistent agents like `@coder` and `@bash-expert`
- keep agent examples aligned with the actual built-in agent names

## Why

The docs were mixing product docs with Sam-specific/Jarvis-specific examples, which makes no sense for public term-llm documentation.

They also were underselling one of the more compelling parts of the product: the built-in agents. The homepage and agents guide should make it obvious that term-llm is not just a generic chat interface — it already ships with useful modes like `@reviewer`, `@codebase`, `@developer`, and `@researcher`.

## Validation

- `go test ./cmd/...`
- `hugo` in `docs-site/`
