### PR TITLE
docs: add robots.txt for term-llm.com

### DIFF
--- a/docs-site/static/robots.txt
+++ b/docs-site/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## What

Add a `robots.txt` file for `term-llm.com` via the docs site static assets.

- add `docs-site/static/robots.txt`
- allow all crawlers by default

## Why

There was no `robots.txt` file in the repo, and Hugo has `robotsTXT` disabled in `docs-site/hugo.toml`, so nothing was being generated automatically.

## Validation

- `hugo --source docs-site`
- verified `docs-site/public/robots.txt` contains:
  - `User-agent: *`
  - `Allow: /`
