### PR TITLE
docs: add copyable install command section

### DIFF
--- a/docs-site/layouts/_default/baseof.html
+++ b/docs-site/layouts/_default/baseof.html
@@ -23,5 +23,29 @@
       </main>
       {{ partial "footer.html" . }}
     </div>
+    <script>
+      document.addEventListener("click", async (event) => {
+        const button = event.target.closest("[data-copy-text]");
+        if (!button) {
+          return;
+        }
+
+        const text = button.getAttribute("data-copy-text") || "";
+        const defaultLabel = button.getAttribute("data-copy-default") || button.textContent;
+        const successLabel = button.getAttribute("data-copy-success") || "Copied";
+        const failureLabel = "Copy failed";
+
+        try {
+          await navigator.clipboard.writeText(text);
+          button.textContent = successLabel;
+        } catch (_error) {
+          button.textContent = failureLabel;
+        }
+
+        window.setTimeout(() => {
+          button.textContent = defaultLabel;
+        }, 1800);
+      });
+    </script>
   </body>
 </html>

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -20,6 +20,18 @@ $ term-llm chat @codebase</code></pre>
     </aside>
   </section>
 
+  <section class="section-block install-section">
+    <div class="section-heading">
+      <p class="eyebrow">Install</p>
+      <h2>Copy the command and run it</h2>
+    </div>
+    <div class="install-panel">
+      <pre class="install-command"><code id="install-command">curl -fsSL https://raw.githubusercontent.com/samsaffron/term-llm/main/install.sh | sh</code></pre>
+      <button class="button primary copy-button" type="button" data-copy-text="curl -fsSL https://raw.githubusercontent.com/samsaffron/term-llm/main/install.sh | sh" data-copy-default="Copy install command" data-copy-success="Copied install command">Copy install command</button>
+    </div>
+    <p class="install-note">The full command is shown inline, so people do not have to horizontally scroll just to see what they are about to paste.</p>
+  </section>
+
   <section class="section-block">
     <div class="section-heading">
       <p class="eyebrow">Start with intent</p>

--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -77,9 +77,42 @@ h3 { font-size: 1.26rem; }
 .terminal-bar { display: flex; gap: 0.45rem; padding: 0.9rem 1rem; border-bottom: 1px solid rgba(125,211,252,0.12); background: rgba(4,8,16,0.6); }
 .terminal-bar span { width: 0.72rem; height: 0.72rem; border-radius: 999px; background: rgba(155,169,189,0.28); }
 .terminal-panel pre { margin: 0; padding: 1.3rem 1.25rem 1.4rem; color: var(--soft); font-size: 0.94rem; line-height: 1.75; white-space: pre-wrap; }
-pre, code, .terminal-panel code { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; }
+pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; }
 .section-block, .doc-section { padding: 1.55rem; }
 .section-heading { margin-bottom: 1rem; }
+.install-section { display: grid; gap: 1rem; }
+.install-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.2rem 1.25rem;
+  border-radius: 22px;
+  background: var(--panel-strong);
+  border: 1px solid rgba(125,211,252,0.14);
+}
+.install-command {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(4,8,16,0.8);
+  border: 1px solid rgba(125,211,252,0.12);
+  overflow-x: auto;
+}
+.install-command code {
+  display: block;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.7;
+  color: var(--soft);
+}
+.copy-button { white-space: nowrap; }
+.install-note {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
 .card-grid { display: grid; gap: 1rem; }
 .card-grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 .card-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -112,6 +145,7 @@ pre, code, .terminal-panel code { font-family: "JetBrains Mono", "SFMono-Regular
 .site-footer { margin-top: 0.5rem; padding: 0 1rem; color: var(--muted); font-size: 0.95rem; text-align: center; }
 @media (max-width: 980px) {
   .hero, .card-grid-4, .card-grid-3, .split-layout, .doc-grid, .doc-grid-wide { grid-template-columns: 1fr; }
+  .install-panel { grid-template-columns: 1fr; }
 }
 @media (max-width: 700px) {
   .page-shell { width: min(100% - 1rem, 1160px); }


### PR DESCRIPTION
## What

Add a dedicated install section to the docs homepage that makes the install command easy to copy and easy to read.

- add a homepage install block with the full install command visible
- add a copy button that writes the command to the clipboard
- add responsive styling so the command wraps instead of getting awkwardly clipped on smaller screens

## Why

The install path should be stupidly easy to use. If people have to drag-select a partially visible command, the page is already doing a bad job.

## Validation

- `hugo --source docs-site`
