### PR TITLE
docs: explain what term-llm actually is on home page

### DIFF
--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Documentation"
-description: "Documentation for term-llm, organized into getting started, guides, architecture, and reference."
+title: "term-llm"
+description: "Terminal-first AI runtime for commands, chat, agents, editing, tools, jobs, and local workflows."
 belongs: |
   - Quickstart flows that take you from installation to a working setup
   - Task-focused guides for common workflows and integrations
@@ -12,6 +12,8 @@ avoids: |
   - Landing pages that look polished but do not help readers find the right page
   - Burying important configuration and command details inside long prose
 ---
-term-llm has a documentation hub with clear entry points for setup, day-to-day use, architecture, and reference.
+term-llm is a terminal-first AI runtime.
 
-It is not just one generic chat box in a trench coat. The built-in agents are a real part of the product: use `@reviewer` for code review, `@codebase` for repo exploration, `@developer` for implementation, `@researcher` for web-backed investigation, and the rest when the job fits.
+It turns natural language into command suggestions, supports persistent chat, runs agents, edits files, calls tools, schedules jobs, and works with local or hosted models.
+
+Use `exec` for fast one-shot terminal help, `ask` when you want an answer or an agent, and `chat` when you need an ongoing working session.

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <section class="hero">
     <div>
-      <p class="eyebrow">Documentation hub</p>
+      <p class="eyebrow">What it is</p>
       <h1>{{ .Title }}</h1>
       <div class="lede markdown">{{ .Content }}</div>
       <div class="actions">


### PR DESCRIPTION
## What

Rewrite the docs homepage hero copy so it explains what term-llm is instead of announcing that the site is documentation.

- change the homepage title from `Documentation` to `term-llm`
- replace the generic "documentation hub" copy with a short product description
- change the eyebrow from `Documentation hub` to `What it is`

## Why

Someone landing on `term-llm.com` does not care that they have found documentation. They care what the thing actually is and what it does.

## Validation

- `hugo --source docs-site`
