### PR TITLE
feat: allow embedded video playback in web UI markdown

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -1,0 +1,36 @@
+package serveui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStaticAssetsSupportEmbeddedVideoPlayback(t *testing.T) {
+	renderJS, err := StaticAsset("app-render.js")
+	if err != nil {
+		t.Fatalf("StaticAsset(app-render.js): %v", err)
+	}
+	renderSrc := string(renderJS)
+	for _, want := range []string{
+		"ADD_TAGS: ['video', 'source']",
+		"ADD_ATTR: ['controls', 'playsinline', 'muted', 'loop', 'autoplay', 'poster', 'preload']",
+	} {
+		if !strings.Contains(renderSrc, want) {
+			t.Fatalf("app-render.js missing %q", want)
+		}
+	}
+
+	css, err := StaticAsset("app.css")
+	if err != nil {
+		t.Fatalf("StaticAsset(app.css): %v", err)
+	}
+	cssSrc := string(css)
+	for _, want := range []string{
+		".markdown-body video",
+		"max-width: 100%;",
+	} {
+		if !strings.Contains(cssSrc, want) {
+			t.Fatalf("app.css missing %q", want)
+		}
+	}
+}

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -177,7 +177,10 @@ const createMetaNode = (created, message = null) => {
 const renderAssistantMarkdown = (target, content) => {
   applyTextDirection(target, content || '');
   const html = marked.parse(content || '');
-  const clean = DOMPurify.sanitize(html);
+  const clean = DOMPurify.sanitize(html, {
+    ADD_TAGS: ['video', 'source'],
+    ADD_ATTR: ['controls', 'playsinline', 'muted', 'loop', 'autoplay', 'poster', 'preload']
+  });
   target.innerHTML = clean;
 
   renderMath(target);

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -924,7 +924,8 @@
       min-width: 0;
     }
 
-    .markdown-body img {
+    .markdown-body img,
+    .markdown-body video {
       max-width: 100%;
       border-radius: 8px;
       margin: 0.5rem 0;


### PR DESCRIPTION
## What
- allow embedded `<video>` and `<source>` tags in assistant markdown rendering
- style inline videos the same way inline images are styled in the web UI
- add a serveui asset test so the sanitizer and CSS hooks do not quietly regress

## Why
- generated Venice videos can already be served from the existing authenticated `/images/` route because it serves files by path, not by image MIME only
- the missing piece was client-side playback: the sanitizer could strip video markup and the UI had no matching styling
- this keeps the change small enough to use immediately for a real generated WAN 2.6 clip
