### PR TITLE
fix: detach web chat streams and defer video loads

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -14,6 +14,9 @@ func TestStaticAssetsSupportEmbeddedVideoPlayback(t *testing.T) {
 	for _, want := range []string{
 		"ADD_TAGS: ['video', 'source']",
 		"ADD_ATTR: ['controls', 'playsinline', 'muted', 'loop', 'autoplay', 'poster', 'preload']",
+		"const deferEmbeddedVideos = (target) => {",
+		"button.textContent = 'Load video'",
+		"replacement.setAttribute('preload', 'metadata')",
 	} {
 		if !strings.Contains(renderSrc, want) {
 			t.Fatalf("app-render.js missing %q", want)
@@ -27,10 +30,43 @@ func TestStaticAssetsSupportEmbeddedVideoPlayback(t *testing.T) {
 	cssSrc := string(css)
 	for _, want := range []string{
 		".markdown-body video",
-		"max-width: 100%;",
+		".deferred-video",
+		".deferred-video-btn",
 	} {
 		if !strings.Contains(cssSrc, want) {
 			t.Fatalf("app.css missing %q", want)
+		}
+	}
+}
+
+func TestStaticAssetsSupportSessionStreamDetachOnSwitch(t *testing.T) {
+	sessionsJS, err := StaticAsset("app-sessions.js")
+	if err != nil {
+		t.Fatalf("StaticAsset(app-sessions.js): %v", err)
+	}
+	sessionsSrc := string(sessionsJS)
+	for _, want := range []string{
+		"const switchToSession = async (sessionId, options = {}) => {",
+		"if (state.currentStreamSessionId && state.currentStreamSessionId !== nextId) {",
+		"detachResponseStream();",
+	} {
+		if !strings.Contains(sessionsSrc, want) {
+			t.Fatalf("app-sessions.js missing %q", want)
+		}
+	}
+
+	streamJS, err := StaticAsset("app-stream.js")
+	if err != nil {
+		t.Fatalf("StaticAsset(app-stream.js): %v", err)
+	}
+	streamSrc := string(streamJS)
+	for _, want := range []string{
+		"const attachResponseStream = (session, responseId = '', controller = null) => {",
+		"const detachResponseStream = () => {",
+		"state.currentStreamSessionId = String(session?.id || '').trim();",
+	} {
+		if !strings.Contains(streamSrc, want) {
+			t.Fatalf("app-stream.js missing %q", want)
 		}
 	}
 }

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -27,6 +27,7 @@ const state = {
   lastNotifiedResponseId: localStorage.getItem(STORAGE_KEYS.lastNotifiedResponseId) || '',
   streaming: false,
   currentStreamResponseId: '',
+  currentStreamSessionId: '',
   queuedInterrupts: [],
   pendingInterruptCommits: [],
   expectCanceledRun: false,

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -99,25 +99,7 @@ const renderSidebar = () => {
       btn.appendChild(title);
       btn.appendChild(meta);
       btn.addEventListener('click', async () => {
-        app.stopSessionStatePoll();
-        if (state.askUser?.sessionId && state.askUser.sessionId !== session.id) {
-          app.closeAskUserModal();
-        }
-        state.activeSessionId = session.id;
-        updateURL(session.id);
-
-        // Lazy-load messages for server-only sessions
-        if (session._serverOnly) {
-          const msgs = await app.loadServerSessionMessages(session.id);
-          if (msgs !== null) {
-            app.mergeServerMessagesWithLocalState(session, msgs);
-          }
-        }
-
-        app.persistAndRefreshShell();
-        renderMessages(true);
-        await app.syncActiveSessionFromServer(session, true);
-        closeSidebarIfMobile();
+        await app.switchToSession(session.id);
       });
 
       groupEl.appendChild(btn);
@@ -174,6 +156,74 @@ const createMetaNode = (created, message = null) => {
   return meta;
 };
 
+const buildDeferredVideoNode = (video) => {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'deferred-video';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'deferred-video-btn';
+  button.textContent = 'Load video';
+
+  const src = video.getAttribute('src') || '';
+  const poster = video.getAttribute('poster') || '';
+  const preload = video.getAttribute('preload') || '';
+  if (src) button.dataset.videoSrc = src;
+  if (poster) button.dataset.videoPoster = poster;
+  if (preload) button.dataset.videoPreload = preload;
+
+  const sources = Array.from(video.querySelectorAll('source'))
+    .map((source) => ({
+      src: source.getAttribute('src') || '',
+      type: source.getAttribute('type') || ''
+    }))
+    .filter((source) => source.src);
+  if (sources.length > 0) {
+    button.dataset.videoSources = JSON.stringify(sources);
+  }
+
+  button.addEventListener('click', () => {
+    const replacement = document.createElement('video');
+    ['controls', 'playsinline', 'muted', 'loop'].forEach((attr) => {
+      if (video.hasAttribute(attr)) replacement.setAttribute(attr, '');
+    });
+    if (poster) replacement.setAttribute('poster', poster);
+    replacement.setAttribute('preload', 'metadata');
+
+    if (src) {
+      replacement.src = src;
+    } else {
+      sources.forEach((source) => {
+        const sourceNode = document.createElement('source');
+        sourceNode.src = source.src;
+        if (source.type) sourceNode.type = source.type;
+        replacement.appendChild(sourceNode);
+      });
+    }
+
+    wrapper.replaceWith(replacement);
+  });
+
+  if (poster) {
+    const preview = document.createElement('img');
+    preview.src = poster;
+    preview.alt = 'Video preview';
+    preview.className = 'deferred-video-poster';
+    wrapper.appendChild(preview);
+  }
+
+  wrapper.appendChild(button);
+  return wrapper;
+};
+
+const deferEmbeddedVideos = (target) => {
+  target.querySelectorAll('video').forEach((video) => {
+    video.removeAttribute('autoplay');
+    video.setAttribute('preload', 'none');
+    video.replaceWith(buildDeferredVideoNode(video));
+  });
+};
+
 const renderAssistantMarkdown = (target, content) => {
   applyTextDirection(target, content || '');
   const html = marked.parse(content || '');
@@ -182,6 +232,7 @@ const renderAssistantMarkdown = (target, content) => {
     ADD_ATTR: ['controls', 'playsinline', 'muted', 'loop', 'autoplay', 'poster', 'preload']
   });
   target.innerHTML = clean;
+  deferEmbeddedVideos(target);
 
   renderMath(target);
 

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -10,9 +10,52 @@ const {
   autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
   connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, isNearBottom,
   openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush
+  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream
 } = app;
 let sessionStatePollTimer = null;
+
+const switchToSession = async (sessionId, options = {}) => {
+  const nextId = String(sessionId || '').trim();
+  if (!nextId) return null;
+
+  const session = state.sessions.find((item) => item.id === nextId);
+  if (!session) return null;
+
+  stopSessionStatePoll();
+  if (state.askUser?.sessionId && state.askUser.sessionId !== nextId) {
+    closeAskUserModal();
+  }
+  if (state.approval?.sessionId && state.approval.sessionId !== nextId) {
+    closeApprovalModal();
+  }
+  if (state.currentStreamSessionId && state.currentStreamSessionId !== nextId) {
+    detachResponseStream();
+  }
+
+  state.activeSessionId = nextId;
+  updateURL(nextId);
+
+  if (session._serverOnly) {
+    const msgs = await loadServerSessionMessages(session.id);
+    if (msgs !== null) {
+      mergeServerMessagesWithLocalState(session, msgs);
+    }
+  }
+
+  persistAndRefreshShell();
+  renderMessages(true);
+
+  if (options.sync !== false) {
+    await syncActiveSessionFromServer(session, true);
+  }
+  if (options.focusPrompt) {
+    elements.promptInput.focus();
+  }
+  if (options.closeSidebar !== false) {
+    closeSidebarIfMobile();
+  }
+  return session;
+};
 
 // ===== Server session helpers =====
 const convertServerMessages = (serverMessages) => {
@@ -395,22 +438,12 @@ const initialize = async () => {
 };
 
 // ===== Event listeners =====
-elements.newChatBtn.addEventListener('click', () => {
+elements.newChatBtn.addEventListener('click', async () => {
   if (state.streaming) return;
-
-  stopSessionStatePoll();
-  if (state.askUser) {
-    closeAskUserModal();
-  }
 
   const session = createSession();
   state.sessions.unshift(session);
-  state.activeSessionId = session.id;
-  updateURL(session.id);
-  persistAndRefreshShell();
-  renderMessages(true);
-  elements.promptInput.focus();
-  closeSidebarIfMobile();
+  await switchToSession(session.id, { sync: false, focusPrompt: true });
 });
 
 elements.settingsBtn.addEventListener('click', () => {
@@ -553,23 +586,9 @@ window.addEventListener('popstate', async () => {
   const urlId = sessionIdFromURL();
   if (!urlId || urlId === state.activeSessionId) return;
 
-  stopSessionStatePoll();
-  if (state.askUser?.sessionId && state.askUser.sessionId !== urlId) {
-    closeAskUserModal();
-  }
-
   const found = state.sessions.find(s => s.id === urlId);
   if (found) {
-    state.activeSessionId = found.id;
-    if (found._serverOnly) {
-      const msgs = await loadServerSessionMessages(found.id);
-      if (msgs !== null) {
-        mergeServerMessagesWithLocalState(found, msgs);
-      }
-    }
-    persistAndRefreshShell();
-    renderMessages(true);
-    await syncActiveSessionFromServer(found, true);
+    await switchToSession(found.id, { closeSidebar: false });
   }
 });
 
@@ -586,6 +605,7 @@ Object.assign(app, {
   scheduleSessionStatePoll,
   syncActiveSessionFromServer,
   mergeServerSessions,
+  switchToSession,
   initialize
 });
 })();

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -130,8 +130,24 @@ const setActiveResponseTracking = (session, responseId, sequenceNumber = null) =
       session.lastSequenceNumber = nextSeq;
     }
   }
+};
 
-  state.currentStreamResponseId = normalized;
+const attachResponseStream = (session, responseId = '', controller = null) => {
+  state.currentStreamSessionId = String(session?.id || '').trim();
+  state.currentStreamResponseId = String(responseId || '').trim();
+  state.abortController = controller;
+};
+
+const detachResponseStream = () => {
+  const controller = state.abortController;
+  state.abortController = null;
+  state.currentStreamSessionId = '';
+  state.currentStreamResponseId = '';
+  if (controller) {
+    controller.abort();
+  }
+  setConnectionState('', '');
+  setStreaming(false);
 };
 
 const clearActiveResponseTracking = (session, responseId = '') => {
@@ -143,8 +159,18 @@ const clearActiveResponseTracking = (session, responseId = '') => {
     session.activeResponseId = null;
     session.lastSequenceNumber = 0;
   }
-  if (!targetId || state.currentStreamResponseId === targetId) {
+  if (
+    !targetId
+    || (
+      state.currentStreamSessionId === String(session.id || '').trim()
+      && (!state.currentStreamResponseId || state.currentStreamResponseId === targetId)
+    )
+  ) {
+    state.currentStreamSessionId = '';
     state.currentStreamResponseId = '';
+    if (!state.abortController) {
+      setConnectionState('', '');
+    }
   }
 };
 
@@ -509,11 +535,15 @@ const resumeActiveResponse = async (session, options = {}) => {
   const responseId = String(options.responseId || session.activeResponseId || '').trim();
   if (!responseId) return false;
 
+  if (state.currentStreamSessionId && state.currentStreamSessionId !== session.id) {
+    detachResponseStream();
+  }
+
   if (session.activeResponseId !== responseId) {
     setActiveResponseTracking(session, responseId, 0);
     saveSessions();
-  } else {
-    state.currentStreamResponseId = responseId;
+  } else if (state.currentStreamSessionId !== session.id || state.currentStreamResponseId !== responseId) {
+    attachResponseStream(session, responseId, null);
   }
 
   let streamState = options.streamState || createResponseStreamState(session);
@@ -526,8 +556,7 @@ const resumeActiveResponse = async (session, options = {}) => {
     }
 
     const controller = new AbortController();
-    state.abortController = controller;
-    state.currentStreamResponseId = responseId;
+    attachResponseStream(session, responseId, controller);
     setStreaming(true);
 
     try {
@@ -544,7 +573,9 @@ const resumeActiveResponse = async (session, options = {}) => {
 
       setConnectionState('', '');
       const terminal = await consumeResponseStream(response.body, session, streamState);
-      state.abortController = null;
+      if (state.abortController === controller) {
+        state.abortController = null;
+      }
 
       if (session.activeResponseId !== responseId) {
         setStreaming(Boolean(state.currentStreamResponseId));
@@ -555,7 +586,9 @@ const resumeActiveResponse = async (session, options = {}) => {
         return true;
       }
     } catch (err) {
-      state.abortController = null;
+      if (state.abortController === controller) {
+        state.abortController = null;
+      }
 
       if (err?.name === 'AbortError') {
         setStreaming(Boolean(state.currentStreamResponseId));
@@ -608,7 +641,7 @@ const resumeActiveResponse = async (session, options = {}) => {
 
   if (session.activeResponseId === responseId) {
     state.abortController = null;
-    state.currentStreamResponseId = responseId;
+    attachResponseStream(session, responseId, null);
     setStreaming(true);
     app.scheduleSessionStatePoll(session.id, 2000);
     setConnectionState('Stream disconnected', 'bad');
@@ -1866,7 +1899,7 @@ const sendMessage = async (options = {}) => {
 
   state.expectCanceledRun = false;
   const controller = new AbortController();
-  state.abortController = controller;
+  attachResponseStream(session, '', controller);
   setStreaming(true);
   const streamState = createResponseStreamState(session);
 
@@ -2028,6 +2061,8 @@ Object.assign(app, {
   parseSSEStream,
   sleep,
   setActiveResponseTracking,
+  attachResponseStream,
+  detachResponseStream,
   clearActiveResponseTracking,
   updateResponseSequence,
   createResponseStreamState,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -931,6 +931,34 @@
       margin: 0.5rem 0;
     }
 
+    .deferred-video {
+      display: inline-flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin: 0.5rem 0;
+      max-width: 100%;
+    }
+
+    .deferred-video-poster {
+      max-width: 100%;
+      border-radius: 8px;
+    }
+
+    .deferred-video-btn {
+      align-self: flex-start;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--surface-elevated);
+      color: var(--text);
+      padding: 0.55rem 0.9rem;
+      cursor: pointer;
+      font: inherit;
+    }
+
+    .deferred-video-btn:hover {
+      background: color-mix(in srgb, var(--surface-elevated) 70%, var(--accent) 30%);
+    }
+
     .composer {
       background: var(--bg);
       padding: 0.75rem calc(1rem + var(--safe-right)) max(0.3rem, calc(var(--safe-bottom) * 0.35)) calc(1rem + var(--safe-left));


### PR DESCRIPTION
## What

- detach the currently attached web response stream before switching to a different chat session
- track the attached stream by both session id and response id instead of using one global response id slot
- route sidebar/history/new-chat navigation through one session-switch path so polling, approval prompts, and ask-user modals get torn down consistently
- defer embedded video loads in assistant markdown behind an explicit "Load video" click instead of letting the browser start pulling media immediately
- add static asset tests covering the deferred video UI and session stream detach lifecycle

## Why

Two separate regressions were colliding:

1. The web UI kept one global stream attachment alive while switching sessions. That left the old fetch/subscription in place, blocked the new session from attaching cleanly, and produced the cross-session bleed/busted switching behavior.
2. Embedded video playback allowed raw `<video>` tags with preload/autoplay-related attributes, so loading a chat containing a movie-sized asset could make the browser start downloading it immediately. That made the whole session feel wedged and looked a lot like a server concurrency problem.

This keeps session attachment deterministic on the client side and makes video downloads explicit user intent instead of an accidental page-load side effect.

## Validation

- `gofmt -w internal/serveui/embed_test.go`
- `go test ./internal/serveui ./cmd/...`
- `go build ./...`
- `go test ./...`
