### PR TITLE
fix(web): allow new chats during active runs

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -18,6 +18,7 @@ const switchToSession = async (sessionId, options = {}) => {
   const nextId = String(sessionId || '').trim();
   if (!nextId) return null;
 
+  const previousActiveSessionId = String(state.activeSessionId || '').trim();
   const session = state.sessions.find((item) => item.id === nextId);
   if (!session) return null;
 
@@ -30,6 +31,9 @@ const switchToSession = async (sessionId, options = {}) => {
   }
   if (state.currentStreamSessionId && state.currentStreamSessionId !== nextId) {
     detachResponseStream();
+  }
+  if (previousActiveSessionId && previousActiveSessionId !== nextId && state.currentStreamSessionId !== nextId) {
+    setStreaming(false);
   }
 
   state.activeSessionId = nextId;
@@ -439,8 +443,6 @@ const initialize = async () => {
 
 // ===== Event listeners =====
 elements.newChatBtn.addEventListener('click', async () => {
-  if (state.streaming) return;
-
   const session = createSession();
   state.sessions.unshift(session);
   await switchToSession(session.id, { sync: false, focusPrompt: true });


### PR DESCRIPTION
## What
- allow the web UI "New chat" button to work even while another session has a turn in progress
- clear the active-session streaming state when switching to a different session so a fresh chat is immediately usable

## Why
Right now if a turn is in progress, clicking "New chat" does nothing because the button bails out on `state.streaming`.

That prevents the multi-session workflow you want in the web UI. A run can keep going server-side in the old session while the UI moves to a new one.

## Testing
- `go test ./...`
