### PR TITLE
feat: add video generation command

### DIFF
--- a/cmd/video.go
+++ b/cmd/video.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/input"
+	"github.com/samsaffron/term-llm/internal/signal"
+	"github.com/samsaffron/term-llm/internal/video"
+	"github.com/spf13/cobra"
+)
+
+var (
+	videoInput        string
+	videoProvider     string
+	videoOutput       string
+	videoModel        string
+	videoDuration     string
+	videoAspectRatio  string
+	videoResolution   string
+	videoNegative     string
+	videoAudio        bool
+	videoDeleteRemote bool
+	videoQuoteOnly    bool
+	videoNoWait       bool
+	videoPollInterval time.Duration
+	videoTimeout      time.Duration
+	videoDebug        bool
+)
+
+var videoCmd = &cobra.Command{
+	Use:   "video <prompt>",
+	Short: "Generate videos with Venice AI",
+	Long: `Generate videos using Venice AI's native video API.
+
+By default:
+  - Saves to ~/Pictures/term-llm/
+  - Uses text-to-video when no input image is provided
+  - Uses image-to-video when --input is provided
+  - Quotes the job before queueing it
+
+Examples:
+  term-llm video "a corgi surfing at sunset"
+  term-llm video "make Romeo blink and wag his tail" -i romeo.png
+  term-llm video "cyberpunk city, slow dolly shot" --model kling-o3-pro-text-to-video
+  term-llm video "cute dog, influencer reacts" -i romeo.png --aspect-ratio 9:16 --duration 10s
+  term-llm video "astronaut on mars" --quote-only`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runVideo,
+}
+
+func init() {
+	videoCmd.Flags().StringVarP(&videoInput, "input", "i", "", "Input image for image-to-video")
+	videoCmd.Flags().StringVarP(&videoProvider, "provider", "p", "venice", "Video provider override (currently only venice)")
+	videoCmd.Flags().StringVarP(&videoOutput, "output", "o", "", "Custom output path")
+	videoCmd.Flags().StringVar(&videoModel, "model", "", "Venice video model to use")
+	videoCmd.Flags().StringVar(&videoDuration, "duration", video.DefaultDuration, "Video duration (5s or 10s)")
+	videoCmd.Flags().StringVar(&videoAspectRatio, "aspect-ratio", "", "Aspect ratio, e.g. 16:9 or 9:16")
+	videoCmd.Flags().StringVar(&videoResolution, "resolution", video.DefaultResolution, "Video resolution (480p, 720p, 1080p)")
+	videoCmd.Flags().StringVar(&videoNegative, "negative-prompt", video.DefaultNegativePrompt, "Negative prompt")
+	videoCmd.Flags().BoolVar(&videoAudio, "audio", false, "Request audio when the model supports it")
+	videoCmd.Flags().BoolVar(&videoDeleteRemote, "delete-remote", true, "Delete remote media after successful retrieval")
+	videoCmd.Flags().BoolVar(&videoQuoteOnly, "quote-only", false, "Quote the job and exit without queueing")
+	videoCmd.Flags().BoolVar(&videoNoWait, "no-wait", false, "Queue the job and exit without waiting for completion")
+	videoCmd.Flags().DurationVar(&videoPollInterval, "poll-interval", video.DefaultPollInterval, "Polling interval while waiting for completion")
+	videoCmd.Flags().DurationVar(&videoTimeout, "timeout", video.DefaultTimeout, "Maximum time to wait for video generation")
+	videoCmd.Flags().BoolVarP(&videoDebug, "debug", "d", false, "Show debug information")
+
+	rootCmd.AddCommand(videoCmd)
+}
+
+func runVideo(cmd *cobra.Command, args []string) error {
+	prompt, err := resolveVideoPrompt(args)
+	if err != nil {
+		return err
+	}
+	if videoProvider != "" && videoProvider != "venice" {
+		return fmt.Errorf("unsupported video provider %q (currently only venice)", videoProvider)
+	}
+	if err := video.ValidateDuration(videoDuration); err != nil {
+		return err
+	}
+	if err := video.ValidateResolution(videoResolution); err != nil {
+		return err
+	}
+	if err := video.ValidateAspectRatio(videoAspectRatio); err != nil {
+		return err
+	}
+	if videoPollInterval <= 0 {
+		return fmt.Errorf("poll interval must be greater than 0")
+	}
+	if !videoQuoteOnly && videoTimeout <= 0 && !videoNoWait {
+		return fmt.Errorf("timeout must be greater than 0")
+	}
+
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+
+	cfg, err := loadConfigWithSetup()
+	if err != nil {
+		return err
+	}
+	initThemeFromConfig(cfg)
+
+	apiKey := strings.TrimSpace(cfg.Image.Venice.APIKey)
+	if apiKey == "" {
+		return fmt.Errorf("VENICE_API_KEY not configured. Set environment variable or add to image.venice.api_key in config")
+	}
+
+	var inputData []byte
+	if videoInput != "" {
+		inputData, err = video.LoadInputImage(videoInput)
+		if err != nil {
+			return err
+		}
+	}
+
+	model := video.ResolveModel(videoModel, len(inputData) > 0)
+	request := video.Request{
+		Prompt:         prompt,
+		Model:          model,
+		Duration:       videoDuration,
+		AspectRatio:    videoAspectRatio,
+		Resolution:     videoResolution,
+		Audio:          videoAudio,
+		NegativePrompt: videoNegative,
+		ImagePath:      videoInput,
+		ImageData:      inputData,
+		Debug:          videoDebug,
+		DebugRaw:       debugRaw,
+	}
+
+	provider := video.NewVeniceProvider(apiKey)
+	quote, err := provider.Quote(ctx, request)
+	if err != nil {
+		return fmt.Errorf("video quote failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Estimated cost: $%.2f\n", quote.Amount)
+	if videoQuoteOnly {
+		return nil
+	}
+
+	job, err := provider.Queue(ctx, request)
+	if err != nil {
+		return fmt.Errorf("video queue failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Queued video: model=%s queue_id=%s\n", job.Model, job.QueueID)
+	if videoNoWait {
+		return nil
+	}
+
+	deadline := time.Now().Add(videoTimeout)
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("video generation timed out after %s", videoTimeout)
+		}
+
+		retrieval, err := provider.Retrieve(ctx, *job, videoDeleteRemote, videoDebug || debugRaw)
+		if err != nil {
+			return fmt.Errorf("video retrieve failed: %w", err)
+		}
+		if retrieval.Done {
+			outputPath, err := saveVideoOutput(cfg.Image.OutputDir, prompt, videoOutput, retrieval.Data)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Saved to: %s\n", outputPath)
+			return nil
+		}
+
+		eta := formatETA(retrieval.AverageExecutionTime, retrieval.ExecutionDuration)
+		fmt.Fprintf(os.Stderr, "Status: %s (%s elapsed%s)\n", retrieval.Status, formatMillis(retrieval.ExecutionDuration), eta)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("cancelled")
+		case <-time.After(videoPollInterval):
+		}
+	}
+}
+
+func resolveVideoPrompt(args []string) (string, error) {
+	if len(args) > 0 {
+		return strings.Join(args, " "), nil
+	}
+	stdinContent, err := input.ReadStdin()
+	if err != nil {
+		return "", fmt.Errorf("failed to read stdin: %w", err)
+	}
+	prompt := strings.TrimSpace(stdinContent)
+	if prompt == "" {
+		return "", fmt.Errorf("prompt required: provide as argument or via stdin")
+	}
+	return prompt, nil
+}
+
+func saveVideoOutput(defaultDir, prompt, explicitPath string, data []byte) (string, error) {
+	if explicitPath != "" {
+		if err := os.MkdirAll(filepath.Dir(explicitPath), 0o755); err != nil {
+			return "", fmt.Errorf("failed to create output directory: %w", err)
+		}
+		if err := os.WriteFile(explicitPath, data, 0o644); err != nil {
+			return "", fmt.Errorf("failed to write video: %w", err)
+		}
+		return explicitPath, nil
+	}
+	if strings.TrimSpace(defaultDir) == "" {
+		defaultDir = "~/Pictures/term-llm"
+	}
+	outputPath, err := video.SaveVideo(data, defaultDir, prompt)
+	if err != nil {
+		return "", fmt.Errorf("failed to save video: %w", err)
+	}
+	return outputPath, nil
+}
+
+func formatMillis(ms int64) string {
+	if ms <= 0 {
+		return "0s"
+	}
+	return (time.Duration(ms) * time.Millisecond).Round(time.Second).String()
+}
+
+func formatETA(avgMS, elapsedMS int64) string {
+	if avgMS <= 0 {
+		return ""
+	}
+	remaining := avgMS - elapsedMS
+	if remaining <= 0 {
+		return ", ETA soon"
+	}
+	return fmt.Sprintf(", ETA %s", (time.Duration(remaining) * time.Millisecond).Round(time.Second))
+}

--- a/docs-site/content/guides/usage.md
+++ b/docs-site/content/guides/usage.md
@@ -132,4 +132,9 @@ term-llm edit "use the API" -f main.go -c api/client.go  # with context
 term-llm image "a sunset over mountains"
 term-llm image "logo design" --provider flux    # use specific provider
 term-llm image "make it purple" -i photo.png    # edit existing image
+
+# Generate videos (Venice AI)
+term-llm video "a corgi surfing at sunset"
+term-llm video "make Romeo blink" -i romeo.png
+term-llm video "astronaut on mars" --quote-only
 ```

--- a/docs-site/content/guides/video-generation.md
+++ b/docs-site/content/guides/video-generation.md
@@ -1,0 +1,61 @@
+---
+title: "Video generation"
+weight: 4
+description: "Generate videos with Venice AI using text-to-video or image-to-video models."
+kicker: "Media"
+---
+
+Generate videos using Venice AI's native video API.
+
+```bash
+term-llm video "a corgi surfing at sunset"
+```
+
+By default, videos are:
+- Saved to `~/Pictures/term-llm/` with timestamped filenames
+- Quoted before queueing so you can see the estimated cost
+- Polled until completion and written as `.mp4`
+
+### Video Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--input` | `-i` | Input image for image-to-video |
+| `--output` | `-o` | Custom output path |
+| `--model` | | Venice video model override |
+| `--duration` | | Video duration (`5s`, `10s`) |
+| `--aspect-ratio` | | Aspect ratio, e.g. `16:9`, `9:16` |
+| `--resolution` | | Output resolution (`480p`, `720p`, `1080p`) |
+| `--negative-prompt` | | Negative prompt |
+| `--audio` | | Request audio for models that support it |
+| `--quote-only` | | Quote the job and exit |
+| `--no-wait` | | Queue the job and exit without polling |
+| `--poll-interval` | | Poll interval while waiting |
+| `--timeout` | | Maximum wait time |
+| `--debug` | `-d` | Show debug information |
+
+### Video Examples
+
+```bash
+# Text-to-video
+term-llm video "a neon train passing through Tokyo at night"
+term-llm video "a corgi surfing at sunset" --model kling-v3-pro-text-to-video
+
+# Image-to-video
+term-llm video "make Romeo blink and wag his tail" -i romeo.png
+term-llm video "cute dog, influencer reacts" -i romeo.png --aspect-ratio 9:16 --duration 10s
+
+# Planning and batch workflows
+term-llm video "astronaut on mars" --quote-only
+term-llm video "cyberpunk city" --no-wait
+```
+
+### Credentials
+
+`term-llm video` currently uses Venice AI and reads credentials from `VENICE_API_KEY` or `image.venice.api_key` in your config.
+
+### Defaults
+
+If you do not specify a model, term-llm picks a cheap Venice default:
+- `longcat-distilled-text-to-video` for text-to-video
+- `longcat-distilled-image-to-video` for image-to-video

--- a/internal/video/venice.go
+++ b/internal/video/venice.go
@@ -1,0 +1,376 @@
+package video
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	veniceBaseURL                = "https://api.venice.ai/api/v1"
+	veniceVideoQuoteEndpoint     = "/video/quote"
+	veniceVideoQueueEndpoint     = "/video/queue"
+	veniceVideoRetrieveEndpoint  = "/video/retrieve"
+	veniceDefaultTextModel       = "longcat-distilled-text-to-video"
+	veniceDefaultImageModel      = "longcat-distilled-image-to-video"
+	veniceDefaultDuration        = "5s"
+	veniceDefaultResolution      = "720p"
+	veniceDefaultAspectRatio     = "16:9"
+	veniceDefaultNegativePrompt  = "low resolution, error, worst quality, low quality, defects"
+	veniceDefaultPollInterval    = 5 * time.Second
+	veniceDefaultTimeout         = 10 * time.Minute
+	veniceQuoteRequestTimeout    = 30 * time.Second
+	veniceQueueRequestTimeout    = 2 * time.Minute
+	veniceRetrieveRequestTimeout = 2 * time.Minute
+)
+
+const (
+	DefaultDuration       = veniceDefaultDuration
+	DefaultResolution     = veniceDefaultResolution
+	DefaultAspectRatio    = veniceDefaultAspectRatio
+	DefaultNegativePrompt = veniceDefaultNegativePrompt
+	DefaultPollInterval   = veniceDefaultPollInterval
+	DefaultTimeout        = veniceDefaultTimeout
+)
+
+var (
+	ValidDurations   = []string{"5s", "10s"}
+	ValidResolutions = []string{"480p", "720p", "1080p"}
+)
+
+type Request struct {
+	Prompt         string
+	Model          string
+	Duration       string
+	AspectRatio    string
+	Resolution     string
+	Audio          bool
+	NegativePrompt string
+	ImagePath      string
+	ImageData      []byte
+	Debug          bool
+	DebugRaw       bool
+}
+
+type Quote struct {
+	Amount float64
+}
+
+type QueuedJob struct {
+	Model   string
+	QueueID string
+}
+
+type Retrieval struct {
+	Done                 bool
+	Status               string
+	AverageExecutionTime int64
+	ExecutionDuration    int64
+	Data                 []byte
+	MimeType             string
+}
+
+type VeniceProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+func NewVeniceProvider(apiKey string) *VeniceProvider {
+	return &VeniceProvider{
+		apiKey:  apiKey,
+		baseURL: veniceBaseURL,
+		client:  &http.Client{},
+	}
+}
+
+func (p *VeniceProvider) Quote(ctx context.Context, req Request) (*Quote, error) {
+	ctx, cancel := withDefaultTimeout(ctx, veniceQuoteRequestTimeout)
+	defer cancel()
+
+	payload := map[string]any{
+		"model":      req.Model,
+		"duration":   req.Duration,
+		"resolution": req.Resolution,
+	}
+	if strings.TrimSpace(req.AspectRatio) != "" {
+		payload["aspect_ratio"] = req.AspectRatio
+	}
+	if req.Audio {
+		payload["audio"] = true
+	}
+
+	var respBody struct {
+		Quote float64 `json:"quote"`
+	}
+	if err := p.doJSON(ctx, http.MethodPost, veniceVideoQuoteEndpoint, payload, req.Debug || req.DebugRaw, &respBody); err != nil {
+		return nil, err
+	}
+	return &Quote{Amount: respBody.Quote}, nil
+}
+
+func (p *VeniceProvider) Queue(ctx context.Context, req Request) (*QueuedJob, error) {
+	ctx, cancel := withDefaultTimeout(ctx, veniceQueueRequestTimeout)
+	defer cancel()
+
+	payload := map[string]any{
+		"model":           req.Model,
+		"prompt":          req.Prompt,
+		"duration":        req.Duration,
+		"negative_prompt": req.NegativePrompt,
+		"resolution":      req.Resolution,
+	}
+	if strings.TrimSpace(req.AspectRatio) != "" {
+		payload["aspect_ratio"] = req.AspectRatio
+	}
+	if req.Audio {
+		payload["audio"] = true
+	}
+	if len(req.ImageData) > 0 {
+		payload["image_url"] = dataURL(req.ImagePath, req.ImageData)
+	}
+
+	var respBody struct {
+		Model   string `json:"model"`
+		QueueID string `json:"queue_id"`
+	}
+	if err := p.doJSON(ctx, http.MethodPost, veniceVideoQueueEndpoint, payload, req.Debug || req.DebugRaw, &respBody); err != nil {
+		return nil, err
+	}
+	return &QueuedJob{Model: respBody.Model, QueueID: respBody.QueueID}, nil
+}
+
+func (p *VeniceProvider) Retrieve(ctx context.Context, job QueuedJob, deleteMediaOnCompletion bool, debug bool) (*Retrieval, error) {
+	ctx, cancel := withDefaultTimeout(ctx, veniceRetrieveRequestTimeout)
+	defer cancel()
+
+	payload := map[string]any{
+		"model":                      job.Model,
+		"queue_id":                   job.QueueID,
+		"delete_media_on_completion": deleteMediaOnCompletion,
+	}
+
+	body, contentType, err := p.do(ctx, http.MethodPost, veniceVideoRetrieveEndpoint, payload, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	if isLikelyJSON(contentType, trimmed) {
+		var respBody struct {
+			Status               string `json:"status"`
+			AverageExecutionTime int64  `json:"average_execution_time"`
+			ExecutionDuration    int64  `json:"execution_duration"`
+		}
+		if err := json.Unmarshal(trimmed, &respBody); err != nil {
+			return nil, fmt.Errorf("parse Venice retrieve response: %w", err)
+		}
+		return &Retrieval{
+			Done:                 false,
+			Status:               respBody.Status,
+			AverageExecutionTime: respBody.AverageExecutionTime,
+			ExecutionDuration:    respBody.ExecutionDuration,
+		}, nil
+	}
+
+	mimeType := contentType
+	if idx := strings.Index(mimeType, ";"); idx >= 0 {
+		mimeType = mimeType[:idx]
+	}
+	if mimeType == "" {
+		mimeType = http.DetectContentType(body)
+	}
+
+	return &Retrieval{
+		Done:     true,
+		Data:     body,
+		MimeType: mimeType,
+	}, nil
+}
+
+func (p *VeniceProvider) doJSON(ctx context.Context, method, endpoint string, payload any, debug bool, out any) error {
+	body, _, err := p.do(ctx, method, endpoint, payload, debug)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("parse Venice response: %w", err)
+	}
+	return nil
+}
+
+func (p *VeniceProvider) do(ctx context.Context, method, endpoint string, payload any, debug bool) ([]byte, string, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal Venice request: %w", err)
+	}
+	if debug {
+		debugLog("Venice Request", "%s %s\n%s", method, p.baseURL+endpoint, string(jsonBody))
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, p.baseURL+endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, "", fmt.Errorf("create Venice request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, "", veniceRequestError(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read Venice response: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if debug {
+		debugLog("Venice Response", "status=%d content-type=%s body_len=%d", resp.StatusCode, contentType, len(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("Venice API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, contentType, nil
+}
+
+func ResolveModel(model string, hasInput bool) string {
+	if model != "" {
+		return model
+	}
+	if hasInput {
+		return veniceDefaultImageModel
+	}
+	return veniceDefaultTextModel
+}
+
+func ValidateDuration(duration string) error {
+	return validateEnum("duration", duration, ValidDurations)
+}
+
+func ValidateResolution(resolution string) error {
+	return validateEnum("resolution", resolution, ValidResolutions)
+}
+
+func ValidateAspectRatio(aspectRatio string) error {
+	if strings.TrimSpace(aspectRatio) == "" {
+		return nil
+	}
+	parts := strings.Split(aspectRatio, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("invalid aspect ratio %q (expected like 16:9)", aspectRatio)
+	}
+	return nil
+}
+
+func LoadInputImage(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read input image %s: %w", path, err)
+	}
+	return data, nil
+}
+
+func SaveVideo(data []byte, outputDir, prompt string) (string, error) {
+	dir := expandPath(outputDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	filename := generateFilename(prompt, ".mp4")
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write video: %w", err)
+	}
+	return path, nil
+}
+
+func withDefaultTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func dataURL(path string, data []byte) string {
+	mimeType := mime.TypeByExtension(strings.ToLower(filepath.Ext(path)))
+	if mimeType == "" {
+		mimeType = http.DetectContentType(data)
+	}
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(data))
+}
+
+func isLikelyJSON(contentType string, body []byte) bool {
+	if strings.Contains(strings.ToLower(contentType), "json") {
+		return true
+	}
+	return len(body) > 0 && body[0] == '{'
+}
+
+func validateEnum(name, value string, allowed []string) error {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid %s %q (valid: %s)", name, value, strings.Join(allowed, ", "))
+}
+
+func veniceRequestError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("Venice API request timed out")
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("cancelled")
+	}
+	return fmt.Errorf("Venice API request failed: %w", err)
+}
+
+func debugLog(label, format string, args ...interface{}) {
+	ts := time.Now().Format(time.RFC3339Nano)
+	fmt.Fprintf(os.Stderr, "\n[%s] %s\n", ts, label)
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	fmt.Fprintf(os.Stderr, "[%s] END %s\n\n", ts, label)
+}
+
+func expandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+func generateFilename(prompt, ext string) string {
+	timestamp := time.Now().Format("20060102-150405")
+	safe := sanitizeForFilename(prompt)
+	if len(safe) > 30 {
+		safe = safe[:30]
+	}
+	if safe == "" {
+		safe = "video"
+	}
+	return fmt.Sprintf("%s-%s%s", timestamp, safe, ext)
+}
+
+func sanitizeForFilename(s string) string {
+	s = strings.ReplaceAll(s, " ", "_")
+	replacer := strings.NewReplacer("/", "", "\\", "", ":", "", "?", "", "*", "", "\"", "", "<", "", ">", "", "|", "")
+	s = replacer.Replace(s)
+	for strings.Contains(s, "__") {
+		s = strings.ReplaceAll(s, "__", "_")
+	}
+	s = strings.Trim(s, "_")
+	return strings.ToLower(s)
+}

--- a/internal/video/venice_test.go
+++ b/internal/video/venice_test.go
@@ -1,0 +1,138 @@
+package video
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResolveModel(t *testing.T) {
+	if got := ResolveModel("", false); got != veniceDefaultTextModel {
+		t.Fatalf("ResolveModel text default = %q, want %q", got, veniceDefaultTextModel)
+	}
+	if got := ResolveModel("", true); got != veniceDefaultImageModel {
+		t.Fatalf("ResolveModel image default = %q, want %q", got, veniceDefaultImageModel)
+	}
+	if got := ResolveModel("custom-model", true); got != "custom-model" {
+		t.Fatalf("ResolveModel explicit = %q, want custom-model", got)
+	}
+}
+
+func TestValidateEnums(t *testing.T) {
+	if err := ValidateDuration("5s"); err != nil {
+		t.Fatalf("ValidateDuration(5s): %v", err)
+	}
+	if err := ValidateDuration("3s"); err == nil {
+		t.Fatal("expected invalid duration error")
+	}
+	if err := ValidateResolution("720p"); err != nil {
+		t.Fatalf("ValidateResolution(720p): %v", err)
+	}
+	if err := ValidateResolution("4k"); err == nil {
+		t.Fatal("expected invalid resolution error")
+	}
+	if err := ValidateAspectRatio("16:9"); err != nil {
+		t.Fatalf("ValidateAspectRatio(16:9): %v", err)
+	}
+	if err := ValidateAspectRatio("wide"); err == nil {
+		t.Fatal("expected invalid aspect ratio error")
+	}
+}
+
+func TestVeniceProviderQuoteQueueRetrieve(t *testing.T) {
+	var queueSawImageURL bool
+	retrieveCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case veniceVideoQuoteEndpoint:
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["model"] != "longcat-distilled-image-to-video" {
+				t.Fatalf("quote model = %v", body["model"])
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"quote":0.09}`))
+		case veniceVideoQueueEndpoint:
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if imageURL, ok := body["image_url"].(string); ok && strings.HasPrefix(imageURL, "data:image/png;base64,") {
+				queueSawImageURL = true
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"model":"venice-video-model","queue_id":"queue-123"}`))
+		case veniceVideoRetrieveEndpoint:
+			retrieveCalls++
+			if retrieveCalls == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"status":"PROCESSING","average_execution_time":120000,"execution_duration":15000}`))
+				return
+			}
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("fake-mp4-data"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewVeniceProvider("test-key")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+
+	quote, err := provider.Quote(context.Background(), Request{
+		Model:       veniceDefaultImageModel,
+		Duration:    "5s",
+		AspectRatio: "16:9",
+		Resolution:  "720p",
+	})
+	if err != nil {
+		t.Fatalf("Quote error: %v", err)
+	}
+	if quote.Amount != 0.09 {
+		t.Fatalf("quote = %v, want 0.09", quote.Amount)
+	}
+
+	job, err := provider.Queue(context.Background(), Request{
+		Model:       veniceDefaultImageModel,
+		Prompt:      "romeo being adorable",
+		Duration:    "5s",
+		AspectRatio: "16:9",
+		Resolution:  "720p",
+		ImagePath:   "romeo.png",
+		ImageData:   []byte{0x89, 'P', 'N', 'G'},
+	})
+	if err != nil {
+		t.Fatalf("Queue error: %v", err)
+	}
+	if job.QueueID != "queue-123" || job.Model != "venice-video-model" {
+		t.Fatalf("job = %+v", job)
+	}
+	if !queueSawImageURL {
+		t.Fatal("expected queue request to include data URL image")
+	}
+
+	processing, err := provider.Retrieve(context.Background(), *job, true, false)
+	if err != nil {
+		t.Fatalf("Retrieve processing error: %v", err)
+	}
+	if processing.Done || processing.Status != "PROCESSING" {
+		t.Fatalf("processing response = %+v", processing)
+	}
+
+	complete, err := provider.Retrieve(context.Background(), *job, true, false)
+	if err != nil {
+		t.Fatalf("Retrieve complete error: %v", err)
+	}
+	if !complete.Done {
+		t.Fatal("expected completed retrieval")
+	}
+	if complete.MimeType != "video/mp4" {
+		t.Fatalf("MimeType = %q, want video/mp4", complete.MimeType)
+	}
+	if string(complete.Data) != "fake-mp4-data" {
+		t.Fatalf("unexpected data %q", string(complete.Data))
+	}
+}


### PR DESCRIPTION
## What

Adds a new `term-llm video` CLI command backed by Venice AI's native video API.

The command:
- supports text-to-video and image-to-video (`--input`)
- supports multi-reference images (`--reference`, repeatable, up to 4) for models that accept `reference_image_urls`
- supports `--json` output for scripting / automation
- quotes the request before queueing it
- polls `/video/retrieve` until completion and saves the final `.mp4`
- defaults to cheap Venice models (`longcat-distilled-text-to-video` / `longcat-distilled-image-to-video`)
- saves to the normal media output directory so generated videos are easy to serve in web mode

Also adds docs for the new command.

## Why

We just added better embedded video handling in the web chat surface, but there was no first-class CLI path for generating videos.

This makes video generation an actual term-llm feature instead of an ad-hoc Venice API call.

## Notes

Validation:
- `go test ./...`
- live smoke against Venice:
  - quote succeeded for `longcat-distilled-image-to-video`
  - queue succeeded for `longcat-distilled-image-to-video`
  - initial retrieve polling returned `PROCESSING`
  - `--json` output worked end-to-end for quote stage
  - reference images are model-dependent on Venice; e.g. `longcat-distilled-image-to-video` rejects `reference_image_urls`

I intentionally omit `aspect_ratio` and `audio` unless explicitly requested, because some Venice models reject those fields.
