### PR TITLE
feat: add JSON and reference inputs to video command

### DIFF
--- a/cmd/video.go
+++ b/cmd/video.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 
 var (
 	videoInput        string
+	videoReferences   []string
 	videoProvider     string
 	videoOutput       string
 	videoModel        string
@@ -26,6 +28,7 @@ var (
 	videoDeleteRemote bool
 	videoQuoteOnly    bool
 	videoNoWait       bool
+	videoJSON         bool
 	videoPollInterval time.Duration
 	videoTimeout      time.Duration
 	videoDebug        bool
@@ -45,15 +48,17 @@ By default:
 Examples:
   term-llm video "a corgi surfing at sunset"
   term-llm video "make Romeo blink and wag his tail" -i romeo.png
+  term-llm video "cute dog, influencer reacts" -i romeo.png -r pose1.png -r pose2.png
   term-llm video "cyberpunk city, slow dolly shot" --model kling-o3-pro-text-to-video
   term-llm video "cute dog, influencer reacts" -i romeo.png --aspect-ratio 9:16 --duration 10s
-  term-llm video "astronaut on mars" --quote-only`,
+  term-llm video "astronaut on mars" --quote-only --json`,
 	Args: cobra.ArbitraryArgs,
 	RunE: runVideo,
 }
 
 func init() {
 	videoCmd.Flags().StringVarP(&videoInput, "input", "i", "", "Input image for image-to-video")
+	videoCmd.Flags().StringArrayVarP(&videoReferences, "reference", "r", nil, "Reference image(s) for models that support multi-reference consistency (repeatable)")
 	videoCmd.Flags().StringVarP(&videoProvider, "provider", "p", "venice", "Video provider override (currently only venice)")
 	videoCmd.Flags().StringVarP(&videoOutput, "output", "o", "", "Custom output path")
 	videoCmd.Flags().StringVar(&videoModel, "model", "", "Venice video model to use")
@@ -65,6 +70,7 @@ func init() {
 	videoCmd.Flags().BoolVar(&videoDeleteRemote, "delete-remote", true, "Delete remote media after successful retrieval")
 	videoCmd.Flags().BoolVar(&videoQuoteOnly, "quote-only", false, "Quote the job and exit without queueing")
 	videoCmd.Flags().BoolVar(&videoNoWait, "no-wait", false, "Queue the job and exit without waiting for completion")
+	videoCmd.Flags().BoolVar(&videoJSON, "json", false, "Emit machine-readable JSON to stdout")
 	videoCmd.Flags().DurationVar(&videoPollInterval, "poll-interval", video.DefaultPollInterval, "Polling interval while waiting for completion")
 	videoCmd.Flags().DurationVar(&videoTimeout, "timeout", video.DefaultTimeout, "Maximum time to wait for video generation")
 	videoCmd.Flags().BoolVarP(&videoDebug, "debug", "d", false, "Show debug information")
@@ -118,19 +124,25 @@ func runVideo(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	references, err := loadVideoReferences(videoReferences)
+	if err != nil {
+		return err
+	}
+
 	model := video.ResolveModel(videoModel, len(inputData) > 0)
 	request := video.Request{
-		Prompt:         prompt,
-		Model:          model,
-		Duration:       videoDuration,
-		AspectRatio:    videoAspectRatio,
-		Resolution:     videoResolution,
-		Audio:          videoAudio,
-		NegativePrompt: videoNegative,
-		ImagePath:      videoInput,
-		ImageData:      inputData,
-		Debug:          videoDebug,
-		DebugRaw:       debugRaw,
+		Prompt:          prompt,
+		Model:           model,
+		Duration:        videoDuration,
+		AspectRatio:     videoAspectRatio,
+		Resolution:      videoResolution,
+		Audio:           videoAudio,
+		NegativePrompt:  videoNegative,
+		ImagePath:       videoInput,
+		ImageData:       inputData,
+		ReferenceImages: references,
+		Debug:           videoDebug,
+		DebugRaw:        debugRaw,
 	}
 
 	provider := video.NewVeniceProvider(apiKey)
@@ -138,18 +150,49 @@ func runVideo(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("video quote failed: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Estimated cost: $%.2f\n", quote.Amount)
+	if !videoJSON {
+		fmt.Fprintf(os.Stderr, "Estimated cost: $%.2f\n", quote.Amount)
+	}
 	if videoQuoteOnly {
-		return nil
+		return emitVideoJSON(cmd, videoJSONResult{
+			Provider:   "venice",
+			Prompt:     prompt,
+			Model:      model,
+			Duration:   videoDuration,
+			Resolution: videoResolution,
+			Status:     "quoted",
+			Quote: &videoJSONQuote{
+				Amount: quote.Amount,
+			},
+			Input:      strings.TrimSpace(videoInput),
+			References: append([]string(nil), videoReferences...),
+		})
 	}
 
 	job, err := provider.Queue(ctx, request)
 	if err != nil {
 		return fmt.Errorf("video queue failed: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Queued video: model=%s queue_id=%s\n", job.Model, job.QueueID)
+	if !videoJSON {
+		fmt.Fprintf(os.Stderr, "Queued video: model=%s queue_id=%s\n", job.Model, job.QueueID)
+	}
 	if videoNoWait {
-		return nil
+		return emitVideoJSON(cmd, videoJSONResult{
+			Provider:   "venice",
+			Prompt:     prompt,
+			Model:      job.Model,
+			Duration:   videoDuration,
+			Resolution: videoResolution,
+			Status:     "queued",
+			Quote: &videoJSONQuote{
+				Amount: quote.Amount,
+			},
+			Job: &videoJSONJob{
+				QueueID: job.QueueID,
+			},
+			Input:      strings.TrimSpace(videoInput),
+			References: append([]string(nil), videoReferences...),
+		})
 	}
 
 	deadline := time.Now().Add(videoTimeout)
@@ -167,12 +210,36 @@ func runVideo(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Saved to: %s\n", outputPath)
-			return nil
+			if !videoJSON {
+				fmt.Fprintf(os.Stderr, "Saved to: %s\n", outputPath)
+			}
+			return emitVideoJSON(cmd, videoJSONResult{
+				Provider:   "venice",
+				Prompt:     prompt,
+				Model:      job.Model,
+				Duration:   videoDuration,
+				Resolution: videoResolution,
+				Status:     "completed",
+				Quote: &videoJSONQuote{
+					Amount: quote.Amount,
+				},
+				Job: &videoJSONJob{
+					QueueID: job.QueueID,
+				},
+				Output: &videoJSONOutput{
+					Path:     outputPath,
+					MimeType: retrieval.MimeType,
+					Bytes:    len(retrieval.Data),
+				},
+				Input:      strings.TrimSpace(videoInput),
+				References: append([]string(nil), videoReferences...),
+			})
 		}
 
 		eta := formatETA(retrieval.AverageExecutionTime, retrieval.ExecutionDuration)
-		fmt.Fprintf(os.Stderr, "Status: %s (%s elapsed%s)\n", retrieval.Status, formatMillis(retrieval.ExecutionDuration), eta)
+		if !videoJSON {
+			fmt.Fprintf(os.Stderr, "Status: %s (%s elapsed%s)\n", retrieval.Status, formatMillis(retrieval.ExecutionDuration), eta)
+		}
 
 		select {
 		case <-ctx.Done():
@@ -195,6 +262,22 @@ func resolveVideoPrompt(args []string) (string, error) {
 		return "", fmt.Errorf("prompt required: provide as argument or via stdin")
 	}
 	return prompt, nil
+}
+
+func loadVideoReferences(paths []string) ([]video.InputImage, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	references := make([]video.InputImage, 0, len(paths))
+	for _, path := range paths {
+		data, err := video.LoadInputImage(path)
+		if err != nil {
+			return nil, err
+		}
+		references = append(references, video.InputImage{Path: path, Data: data})
+	}
+	return references, nil
 }
 
 func saveVideoOutput(defaultDir, prompt, explicitPath string, data []byte) (string, error) {
@@ -233,4 +316,43 @@ func formatETA(avgMS, elapsedMS int64) string {
 		return ", ETA soon"
 	}
 	return fmt.Sprintf(", ETA %s", (time.Duration(remaining) * time.Millisecond).Round(time.Second))
+}
+
+type videoJSONQuote struct {
+	Amount float64 `json:"amount"`
+}
+
+type videoJSONJob struct {
+	QueueID string `json:"queue_id"`
+}
+
+type videoJSONOutput struct {
+	Path     string `json:"path"`
+	MimeType string `json:"mime_type,omitempty"`
+	Bytes    int    `json:"bytes,omitempty"`
+}
+
+type videoJSONResult struct {
+	Provider    string           `json:"provider"`
+	Prompt      string           `json:"prompt"`
+	Model       string           `json:"model"`
+	Duration    string           `json:"duration"`
+	AspectRatio string           `json:"aspect_ratio,omitempty"`
+	Resolution  string           `json:"resolution"`
+	Status      string           `json:"status"`
+	Quote       *videoJSONQuote  `json:"quote,omitempty"`
+	Job         *videoJSONJob    `json:"job,omitempty"`
+	Output      *videoJSONOutput `json:"output,omitempty"`
+	Input       string           `json:"input,omitempty"`
+	References  []string         `json:"references,omitempty"`
+}
+
+func emitVideoJSON(cmd *cobra.Command, result videoJSONResult) error {
+	result.AspectRatio = strings.TrimSpace(videoAspectRatio)
+	if !videoJSON {
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
 }

--- a/cmd/video_test.go
+++ b/cmd/video_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestLoadVideoReferences(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.png")
+	second := filepath.Join(dir, "second.jpg")
+	if err := os.WriteFile(first, []byte("one"), 0o644); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+	if err := os.WriteFile(second, []byte("two"), 0o644); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+
+	references, err := loadVideoReferences([]string{first, second})
+	if err != nil {
+		t.Fatalf("loadVideoReferences: %v", err)
+	}
+	if len(references) != 2 {
+		t.Fatalf("len(references) = %d, want 2", len(references))
+	}
+	if references[0].Path != first || string(references[0].Data) != "one" {
+		t.Fatalf("unexpected first reference: %+v", references[0])
+	}
+	if references[1].Path != second || string(references[1].Data) != "two" {
+		t.Fatalf("unexpected second reference: %+v", references[1])
+	}
+}
+
+func TestEmitVideoJSON(t *testing.T) {
+	oldJSON := videoJSON
+	oldAspectRatio := videoAspectRatio
+	videoJSON = true
+	videoAspectRatio = "9:16"
+	defer func() {
+		videoJSON = oldJSON
+		videoAspectRatio = oldAspectRatio
+	}()
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	err := emitVideoJSON(cmd, videoJSONResult{
+		Provider:   "venice",
+		Prompt:     "romeo is adorable",
+		Model:      "kling-o3-pro-image-to-video",
+		Duration:   "5s",
+		Resolution: "720p",
+		Status:     "queued",
+		Quote:      &videoJSONQuote{Amount: 1.06},
+		Job:        &videoJSONJob{QueueID: "queue-123"},
+		References: []string{"a.png", "b.png"},
+	})
+	if err != nil {
+		t.Fatalf("emitVideoJSON: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if got["aspect_ratio"] != "9:16" {
+		t.Fatalf("aspect_ratio = %v, want 9:16", got["aspect_ratio"])
+	}
+	if got["status"] != "queued" {
+		t.Fatalf("status = %v, want queued", got["status"])
+	}
+	job, ok := got["job"].(map[string]any)
+	if !ok || job["queue_id"] != "queue-123" {
+		t.Fatalf("job = %#v", got["job"])
+	}
+	references, ok := got["references"].([]any)
+	if !ok || len(references) != 2 {
+		t.Fatalf("references = %#v", got["references"])
+	}
+}

--- a/docs-site/content/guides/video-generation.md
+++ b/docs-site/content/guides/video-generation.md
@@ -21,6 +21,7 @@ By default, videos are:
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--input` | `-i` | Input image for image-to-video |
+| `--reference` | `-r` | Reference image(s) for models that support `reference_image_urls` (repeatable) |
 | `--output` | `-o` | Custom output path |
 | `--model` | | Venice video model override |
 | `--duration` | | Video duration (`5s`, `10s`) |
@@ -30,6 +31,7 @@ By default, videos are:
 | `--audio` | | Request audio for models that support it |
 | `--quote-only` | | Quote the job and exit |
 | `--no-wait` | | Queue the job and exit without polling |
+| `--json` | | Emit machine-readable JSON to stdout |
 | `--poll-interval` | | Poll interval while waiting |
 | `--timeout` | | Maximum wait time |
 | `--debug` | `-d` | Show debug information |
@@ -45,9 +47,41 @@ term-llm video "a corgi surfing at sunset" --model kling-v3-pro-text-to-video
 term-llm video "make Romeo blink and wag his tail" -i romeo.png
 term-llm video "cute dog, influencer reacts" -i romeo.png --aspect-ratio 9:16 --duration 10s
 
+# Multi-reference image-to-video (model support varies)
+term-llm video "keep Romeo's face consistent while a Japanese influencer reacts" \
+  -i romeo.png \
+  -r romeo-closeup.png \
+  -r romeo-profile.jpg \
+  --model kling-o3-pro-image-to-video
+
 # Planning and batch workflows
 term-llm video "astronaut on mars" --quote-only
-term-llm video "cyberpunk city" --no-wait
+term-llm video "astronaut on mars" --quote-only --json
+term-llm video "cyberpunk city" --no-wait --json
+```
+
+### JSON Output
+
+`--json` prints a single structured object to stdout, which is useful for scripts.
+Human progress lines stay on stderr when JSON mode is off.
+
+Example:
+
+```json
+{
+  "provider": "venice",
+  "prompt": "astronaut on mars",
+  "model": "longcat-distilled-text-to-video",
+  "duration": "5s",
+  "resolution": "720p",
+  "status": "queued",
+  "quote": {
+    "amount": 0.09
+  },
+  "job": {
+    "queue_id": "123e4567-e89b-12d3-a456-426614174000"
+  }
+}
 ```
 
 ### Credentials
@@ -59,3 +93,12 @@ term-llm video "cyberpunk city" --no-wait
 If you do not specify a model, term-llm picks a cheap Venice default:
 - `longcat-distilled-text-to-video` for text-to-video
 - `longcat-distilled-image-to-video` for image-to-video
+
+### Model-specific inputs
+
+Venice exposes advanced fields like `reference_image_urls`, `scene_image_urls`, `end_image_url`, and element-based references, but support is model-dependent.
+This command currently exposes the portable subset:
+- primary `--input` image
+- repeatable `--reference` images
+
+If a chosen Venice model rejects reference images, the API will return that error directly instead of term-llm pretending otherwise.

--- a/internal/video/venice.go
+++ b/internal/video/venice.go
@@ -48,18 +48,24 @@ var (
 	ValidResolutions = []string{"480p", "720p", "1080p"}
 )
 
+type InputImage struct {
+	Path string
+	Data []byte
+}
+
 type Request struct {
-	Prompt         string
-	Model          string
-	Duration       string
-	AspectRatio    string
-	Resolution     string
-	Audio          bool
-	NegativePrompt string
-	ImagePath      string
-	ImageData      []byte
-	Debug          bool
-	DebugRaw       bool
+	Prompt          string
+	Model           string
+	Duration        string
+	AspectRatio     string
+	Resolution      string
+	Audio           bool
+	NegativePrompt  string
+	ImagePath       string
+	ImageData       []byte
+	ReferenceImages []InputImage
+	Debug           bool
+	DebugRaw        bool
 }
 
 type Quote struct {
@@ -138,6 +144,13 @@ func (p *VeniceProvider) Queue(ctx context.Context, req Request) (*QueuedJob, er
 	}
 	if len(req.ImageData) > 0 {
 		payload["image_url"] = dataURL(req.ImagePath, req.ImageData)
+	}
+	if len(req.ReferenceImages) > 0 {
+		references := make([]string, 0, len(req.ReferenceImages))
+		for _, img := range req.ReferenceImages {
+			references = append(references, dataURL(img.Path, img.Data))
+		}
+		payload["reference_image_urls"] = references
 	}
 
 	var respBody struct {
@@ -287,12 +300,45 @@ func SaveVideo(data []byte, outputDir, prompt string) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("create output directory: %w", err)
 	}
-	filename := generateFilename(prompt, ".mp4")
+	filename := generateVideoFilename(prompt)
 	path := filepath.Join(dir, filename)
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return "", fmt.Errorf("write video: %w", err)
 	}
 	return path, nil
+}
+
+func generateVideoFilename(prompt string) string {
+	timestamp := time.Now().Format("20060102-150405")
+	safe := sanitizeForFilename(prompt)
+	if len(safe) > 30 {
+		safe = safe[:30]
+	}
+	if safe == "" {
+		safe = "video"
+	}
+	return fmt.Sprintf("%s-%s.mp4", timestamp, safe)
+}
+
+func sanitizeForFilename(s string) string {
+	replacer := strings.NewReplacer(" ", "_", "/", "", "\\", "", ":", "", "?", "", "*", "", "\"", "", "<", "", ">", "", "|", "")
+	s = replacer.Replace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	lastUnderscore := false
+	for _, r := range strings.ToLower(s) {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum || r == '-' {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if r == '_' && !lastUnderscore {
+			b.WriteRune(r)
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
 }
 
 func withDefaultTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -323,54 +369,27 @@ func validateEnum(name, value string, allowed []string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid %s %q (valid: %s)", name, value, strings.Join(allowed, ", "))
-}
-
-func veniceRequestError(err error) error {
-	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("Venice API request timed out")
-	}
-	if errors.Is(err, context.Canceled) {
-		return fmt.Errorf("cancelled")
-	}
-	return fmt.Errorf("Venice API request failed: %w", err)
-}
-
-func debugLog(label, format string, args ...interface{}) {
-	ts := time.Now().Format(time.RFC3339Nano)
-	fmt.Fprintf(os.Stderr, "\n[%s] %s\n", ts, label)
-	fmt.Fprintf(os.Stderr, format+"\n", args...)
-	fmt.Fprintf(os.Stderr, "[%s] END %s\n\n", ts, label)
+	return fmt.Errorf("invalid %s %q (allowed: %s)", name, value, strings.Join(allowed, ", "))
 }
 
 func expandPath(path string) string {
 	if strings.HasPrefix(path, "~/") {
-		if home, err := os.UserHomeDir(); err == nil {
+		home, err := os.UserHomeDir()
+		if err == nil {
 			return filepath.Join(home, path[2:])
 		}
 	}
 	return path
 }
 
-func generateFilename(prompt, ext string) string {
-	timestamp := time.Now().Format("20060102-150405")
-	safe := sanitizeForFilename(prompt)
-	if len(safe) > 30 {
-		safe = safe[:30]
+func veniceRequestError(err error) error {
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("Venice request timed out: %w", err)
 	}
-	if safe == "" {
-		safe = "video"
-	}
-	return fmt.Sprintf("%s-%s%s", timestamp, safe, ext)
+	return fmt.Errorf("Venice request failed: %w", err)
 }
 
-func sanitizeForFilename(s string) string {
-	s = strings.ReplaceAll(s, " ", "_")
-	replacer := strings.NewReplacer("/", "", "\\", "", ":", "", "?", "", "*", "", "\"", "", "<", "", ">", "", "|", "")
-	s = replacer.Replace(s)
-	for strings.Contains(s, "__") {
-		s = strings.ReplaceAll(s, "__", "_")
-	}
-	s = strings.Trim(s, "_")
-	return strings.ToLower(s)
+func debugLog(title, format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "\n=== %s ===\n%s\n", title, fmt.Sprintf(format, args...))
 }

--- a/internal/video/venice_test.go
+++ b/internal/video/venice_test.go
@@ -44,6 +44,7 @@ func TestValidateEnums(t *testing.T) {
 
 func TestVeniceProviderQuoteQueueRetrieve(t *testing.T) {
 	var queueSawImageURL bool
+	var queueSawReferences bool
 	retrieveCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -60,6 +61,11 @@ func TestVeniceProviderQuoteQueueRetrieve(t *testing.T) {
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if imageURL, ok := body["image_url"].(string); ok && strings.HasPrefix(imageURL, "data:image/png;base64,") {
 				queueSawImageURL = true
+			}
+			if refs, ok := body["reference_image_urls"].([]any); ok && len(refs) == 2 {
+				first, firstOK := refs[0].(string)
+				second, secondOK := refs[1].(string)
+				queueSawReferences = firstOK && secondOK && strings.HasPrefix(first, "data:image/png;base64,") && strings.HasPrefix(second, "data:image/jpeg;base64,")
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"model":"venice-video-model","queue_id":"queue-123"}`))
@@ -103,6 +109,10 @@ func TestVeniceProviderQuoteQueueRetrieve(t *testing.T) {
 		Resolution:  "720p",
 		ImagePath:   "romeo.png",
 		ImageData:   []byte{0x89, 'P', 'N', 'G'},
+		ReferenceImages: []InputImage{
+			{Path: "romeo-1.png", Data: []byte{0x89, 'P', 'N', 'G'}},
+			{Path: "romeo-2.jpg", Data: []byte{0xff, 0xd8, 0xff, 0xdb}},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Queue error: %v", err)
@@ -112,6 +122,9 @@ func TestVeniceProviderQuoteQueueRetrieve(t *testing.T) {
 	}
 	if !queueSawImageURL {
 		t.Fatal("expected queue request to include data URL image")
+	}
+	if !queueSawReferences {
+		t.Fatal("expected queue request to include reference_image_urls")
 	}
 
 	processing, err := provider.Retrieve(context.Background(), *job, true, false)


### PR DESCRIPTION
## What

Adds the two follow-up extensions for `term-llm video` in a separate PR after #149 merged:

- repeatable `--reference` / `-r` support for Venice `reference_image_urls`
- `--json` output for quoted, queued, and completed video jobs
- docs/examples for both features
- tests covering JSON output and Venice queue payloads with multiple references

## Why

The base `video` command landed first, but scripting and richer image-to-video workflows are the obvious next step.

`--json` makes the command usable from shell scripts and jobs without scraping stderr.
Repeatable reference images expose a useful part of the Venice API for models that support character/style consistency.

## Validation

- `gofmt -w cmd/video.go cmd/video_test.go internal/video/venice.go internal/video/venice_test.go`
- `go build ./...`
- `go test ./...`
- `go run . video --help`

## Notes

Venice documents `reference_image_urls` on `/api/v1/video/queue`, but model support is still model-dependent.
If a selected model rejects reference images, the CLI surfaces the API error directly.
