### PR TITLE
feat: embed sessions browser for resume

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -25,6 +25,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 	"github.com/samsaffron/term-llm/internal/tui/inspector"
+	sessionsui "github.com/samsaffron/term-llm/internal/tui/sessions"
 	"github.com/samsaffron/term-llm/internal/ui"
 	"golang.org/x/term"
 )
@@ -145,6 +146,10 @@ type Model struct {
 	// Inspector mode
 	inspectorMode  bool
 	inspectorModel *inspector.Model
+
+	// Resume browser mode
+	resumeBrowserMode  bool
+	resumeBrowserModel *sessionsui.Model
 
 	// Alt screen mode (full-screen rendering)
 	altScreen               bool
@@ -471,6 +476,65 @@ func (m *Model) WantsReload() bool { return m.reloadRequested }
 // ReloadSessionID returns the session ID to resume after a reload, if any.
 func (m *Model) ReloadSessionID() string { return m.reloadSessionID }
 
+func (m *Model) applyWindowSize(msg tea.WindowSizeMsg) {
+	m.selection = Selection{}
+	m.width = msg.Width
+	m.height = msg.Height
+	m.viewportRows = m.height - 8
+	m.textarea.SetWidth(m.width)
+	if m.completions != nil {
+		m.completions.SetSize(m.width, m.height)
+	}
+	if m.dialog != nil {
+		m.dialog.SetSize(m.width, m.height)
+	}
+
+	// Invalidate cached markdown renderings since they are width-dependent.
+	if m.tracker != nil {
+		for i := range m.tracker.Segments {
+			m.tracker.Segments[i].Rendered = ""
+			m.tracker.Segments[i].SafeRendered = ""
+			m.tracker.Segments[i].SafePos = 0
+			// Also clear diff caches (Issue 2: diff render cache invalidation).
+			m.tracker.Segments[i].DiffRendered = ""
+			m.tracker.Segments[i].DiffWidth = 0
+			// Clear subagent diff caches.
+			for j := range m.tracker.Segments[i].SubagentDiffs {
+				m.tracker.Segments[i].SubagentDiffs[j].Rendered = ""
+				m.tracker.Segments[i].SubagentDiffs[j].Width = 0
+			}
+		}
+		// Resize active streaming renderers.
+		m.tracker.ResizeStreamRenderers(m.width)
+	}
+
+	// Invalidate completed stream cache since it's width-dependent (Issue 1).
+	m.viewCache.completedStream = ""
+	m.bumpContentVersion()
+
+	// Resize viewport for alt screen mode.
+	// Reserve space for input area (textarea + separators + status).
+	vpHeight := m.height - 4
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+	m.viewport.Width = m.width
+	m.viewport.Height = vpHeight
+
+	// Propagate size to embedded dialogs if active.
+	if m.approvalModel != nil {
+		m.approvalModel.SetWidth(m.width)
+	}
+	if m.askUserModel != nil {
+		m.askUserModel.SetWidth(m.width)
+	}
+
+	// Update chat renderer size (invalidates cache).
+	if m.chatRenderer != nil {
+		m.chatRenderer.SetSize(m.width, vpHeight)
+	}
+}
+
 // Init initializes the model
 func (m *Model) Init() tea.Cmd {
 	// Update textarea height for any initial text
@@ -537,6 +601,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	var flushCmds []tea.Cmd
 
+	// Handle resume browser mode
+	if m.resumeBrowserMode {
+		return m.updateResumeBrowserMode(msg)
+	}
+
 	// Handle inspector mode
 	if m.inspectorMode {
 		return m.updateInspectorMode(msg)
@@ -544,58 +613,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.selection = Selection{}
-		m.width = msg.Width
-		m.height = msg.Height
-		m.viewportRows = m.height - 8
-		m.textarea.SetWidth(m.width)
-		m.completions.SetSize(m.width, m.height)
-		m.dialog.SetSize(m.width, m.height)
-
-		// Invalidate cached markdown renderings since they are width-dependent
-		if m.tracker != nil {
-			for i := range m.tracker.Segments {
-				m.tracker.Segments[i].Rendered = ""
-				m.tracker.Segments[i].SafeRendered = ""
-				m.tracker.Segments[i].SafePos = 0
-				// Also clear diff caches (Issue 2: diff render cache invalidation)
-				m.tracker.Segments[i].DiffRendered = ""
-				m.tracker.Segments[i].DiffWidth = 0
-				// Clear subagent diff caches
-				for j := range m.tracker.Segments[i].SubagentDiffs {
-					m.tracker.Segments[i].SubagentDiffs[j].Rendered = ""
-					m.tracker.Segments[i].SubagentDiffs[j].Width = 0
-				}
-			}
-			// Resize active streaming renderers
-			m.tracker.ResizeStreamRenderers(m.width)
-		}
-
-		// Invalidate completed stream cache since it's width-dependent (Issue 1)
-		m.viewCache.completedStream = ""
-		m.bumpContentVersion()
-
-		// Resize viewport for alt screen mode
-		// Reserve space for input area (textarea + separators + status)
-		vpHeight := m.height - 4
-		if vpHeight < 1 {
-			vpHeight = 1
-		}
-		m.viewport.Width = m.width
-		m.viewport.Height = vpHeight
-
-		// Propagate size to embedded dialogs if active
-		if m.approvalModel != nil {
-			m.approvalModel.SetWidth(m.width)
-		}
-		if m.askUserModel != nil {
-			m.askUserModel.SetWidth(m.width)
-		}
-
-		// Update chat renderer size (invalidates cache)
-		if m.chatRenderer != nil {
-			m.chatRenderer.SetSize(m.width, vpHeight)
-		}
+		m.applyWindowSize(msg)
 
 		// In alt screen mode, just clear screen (View() renders history)
 		// In inline mode, reprint history to scrollback after clearing

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -735,7 +735,7 @@ func (m *Model) cmdResume(args []string) (tea.Model, tea.Cmd) {
 
 	ctx := context.Background()
 
-	// /resume <number|id> — direct resume without the picker
+	// /resume <number|id> — direct resume without the browser.
 	if len(args) > 0 {
 		sess, err := m.store.GetByPrefix(ctx, args[0])
 		if err != nil {
@@ -745,15 +745,12 @@ func (m *Model) cmdResume(args []string) (tea.Model, tea.Cmd) {
 			return m.showSystemMessage(fmt.Sprintf("Session '%s' not found.", args[0]))
 		}
 
-		_ = m.store.SetCurrent(ctx, sess.ID)
-		m.pendingResumeSessionID = sess.ID
-		m.quitting = true
 		m.setTextareaValue("")
-		return m, tea.Quit
+		return m.requestResumeSession(sess.ID)
 	}
 
-	// /resume with no args — show the session picker dialog with richer labels
-	summaries, err := m.store.List(ctx, session.ListOptions{Limit: 30})
+	// /resume with no args — open the dedicated embedded sessions browser.
+	summaries, err := m.store.List(ctx, session.ListOptions{Limit: 1})
 	if err != nil {
 		return m.showSystemMessage(fmt.Sprintf("Failed to list sessions: %v", err))
 	}
@@ -761,43 +758,7 @@ func (m *Model) cmdResume(args []string) (tea.Model, tea.Cmd) {
 		return m.showSystemMessage("No saved sessions found.")
 	}
 
-	var items []DialogItem
-	for _, s := range summaries {
-		name := s.Name
-		if name == "" {
-			name = fmt.Sprintf("#%d", s.Number)
-		}
-
-		// Age
-		age := resumeFormatAge(s.UpdatedAt)
-
-		// Summary snippet
-		snippet := s.Summary
-		if len(snippet) > 45 {
-			snippet = snippet[:42] + "..."
-		}
-
-		shortModel := resumeShortenModel(s.Model)
-		var label string
-		if snippet != "" {
-			label = fmt.Sprintf("%s  %s · %d msgs · [%s] %s", name, snippet, s.MessageCount, shortModel, age)
-		} else {
-			label = fmt.Sprintf("%s  %d msgs · [%s] %s", name, s.MessageCount, shortModel, age)
-		}
-
-		items = append(items, DialogItem{
-			ID:    s.ID,
-			Label: label,
-		})
-	}
-
-	currentID := ""
-	if m.sess != nil {
-		currentID = m.sess.ID
-	}
-	m.dialog.ShowSessionList(items, currentID)
-	m.setTextareaValue("")
-	return m, nil
+	return m.openResumeBrowser()
 }
 
 // resumeFormatAge returns a compact human-readable age string.

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -127,6 +127,7 @@ func newCmdTestModel(store session.Store) *Model {
 	ta := textarea.New()
 	return &Model{
 		width:    80,
+		height:   24,
 		textarea: ta,
 		dialog:   NewDialogModel(nil),
 		store:    store,
@@ -195,7 +196,7 @@ func TestCmdResume_DoesNotMutateViewStateInPlace(t *testing.T) {
 	}
 }
 
-func TestCmdResume_NoArgs_ShowsSessionPicker(t *testing.T) {
+func TestCmdResume_NoArgs_OpensEmbeddedSessionsBrowser(t *testing.T) {
 	sessionID := "sess-resume-picker-1"
 	store := &mockStore{
 		summaries: []session.SessionSummary{
@@ -211,22 +212,22 @@ func TestCmdResume_NoArgs_ShowsSessionPicker(t *testing.T) {
 		},
 	}
 	m := newCmdTestModel(store)
+	m.setTextareaValue("draft note")
 
 	result, _ := m.cmdResume([]string{})
 	rm := result.(*Model)
 
-	if !rm.dialog.IsOpen() {
-		t.Fatal("expected session picker dialog to be open")
+	if !rm.resumeBrowserMode {
+		t.Fatal("expected resume browser mode to be active")
 	}
-	if rm.dialog.Type() != DialogSessionList {
-		t.Fatalf("expected dialog type %v, got %v", DialogSessionList, rm.dialog.Type())
+	if rm.resumeBrowserModel == nil {
+		t.Fatal("expected embedded resume browser model to be initialized")
 	}
-	selected := rm.dialog.Selected()
-	if selected == nil {
-		t.Fatal("expected selected session item to be available")
+	if rm.dialog.IsOpen() {
+		t.Fatal("expected generic dialog to remain closed")
 	}
-	if selected.ID != sessionID {
-		t.Fatalf("expected selected session ID %q, got %q", sessionID, selected.ID)
+	if got := rm.textarea.Value(); got != "draft note" {
+		t.Fatalf("expected draft input to be preserved, got %q", got)
 	}
 }
 

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -10,14 +10,53 @@ import (
 	"github.com/samsaffron/term-llm/internal/mcp"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tui/inspector"
+	sessionsui "github.com/samsaffron/term-llm/internal/tui/sessions"
 )
+
+// updateResumeBrowserMode handles updates while the embedded resume browser is active.
+func (m *Model) updateResumeBrowserMode(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.applyWindowSize(msg)
+		if m.resumeBrowserModel != nil {
+			var cmd tea.Cmd
+			updated, next := m.resumeBrowserModel.Update(msg)
+			if browser, ok := updated.(*sessionsui.Model); ok {
+				m.resumeBrowserModel = browser
+			}
+			cmd = next
+			return m, cmd
+		}
+		return m, nil
+
+	case sessionsui.ChatMsg:
+		m.resumeBrowserMode = false
+		m.resumeBrowserModel = nil
+		return m.requestResumeSession(msg.SessionID)
+
+	case sessionsui.CloseMsg:
+		return m.closeResumeBrowser()
+
+	default:
+		if m.resumeBrowserModel != nil {
+			var cmd tea.Cmd
+			updated, next := m.resumeBrowserModel.Update(msg)
+			if browser, ok := updated.(*sessionsui.Model); ok {
+				m.resumeBrowserModel = browser
+			}
+			cmd = next
+			return m, cmd
+		}
+	}
+
+	return m, nil
+}
 
 // updateInspectorMode handles updates while in inspector mode
 func (m *Model) updateInspectorMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
+		m.applyWindowSize(msg)
 		// Pass to inspector
 		if m.inspectorModel != nil {
 			m.inspectorModel, _ = m.inspectorModel.Update(msg)

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -3,10 +3,12 @@ package chat
 import (
 	"context"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
+	sessionsui "github.com/samsaffron/term-llm/internal/tui/sessions"
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
@@ -33,6 +35,90 @@ func TestHandleKeyMsg_SessionListEnterResumesSession(t *testing.T) {
 	}
 	if rm.RequestedResumeSessionID() != sessionID {
 		t.Fatalf("expected pending resume session ID %q, got %q", sessionID, rm.RequestedResumeSessionID())
+	}
+}
+
+func TestResumeBrowserEnterRequestsRelaunch(t *testing.T) {
+	sessionID := "sess-handler-resume-browser-1"
+	store := &mockStore{
+		summaries: []session.SessionSummary{{
+			ID:        sessionID,
+			Number:    11,
+			Name:      "picked session",
+			Summary:   "Discussed rollout checks and release notes",
+			UpdatedAt: time.Now(),
+		}},
+	}
+
+	m := newCmdTestModel(store)
+	result, _ := m.cmdResume(nil)
+	rm := result.(*Model)
+
+	result, cmd := rm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	rm = result.(*Model)
+	if cmd == nil {
+		t.Fatal("expected enter to return a resume selection command")
+	}
+
+	msg := cmd()
+	chatMsg, ok := msg.(sessionsui.ChatMsg)
+	if !ok {
+		t.Fatalf("expected sessions ChatMsg, got %T", msg)
+	}
+	if chatMsg.SessionID != sessionID {
+		t.Fatalf("expected selected session ID %q, got %q", sessionID, chatMsg.SessionID)
+	}
+
+	result, quitCmd := rm.Update(chatMsg)
+	rm = result.(*Model)
+	if quitCmd == nil {
+		t.Fatal("expected resume selection to request program quit")
+	}
+	if !rm.quitting {
+		t.Fatal("expected selecting a browser session to quit for relaunch")
+	}
+	if rm.RequestedResumeSessionID() != sessionID {
+		t.Fatalf("expected pending resume session ID %q, got %q", sessionID, rm.RequestedResumeSessionID())
+	}
+}
+
+func TestResumeBrowserCloseReturnsToChatWithoutLosingDraft(t *testing.T) {
+	sessionID := "sess-handler-resume-browser-close-1"
+	store := &mockStore{
+		summaries: []session.SessionSummary{{
+			ID:        sessionID,
+			Number:    12,
+			Name:      "picked session",
+			UpdatedAt: time.Now(),
+		}},
+	}
+
+	m := newCmdTestModel(store)
+	m.setTextareaValue("draft follow-up")
+	result, _ := m.cmdResume(nil)
+	rm := result.(*Model)
+
+	result, cmd := rm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	rm = result.(*Model)
+	if cmd == nil {
+		t.Fatal("expected q to return a close command")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(sessionsui.CloseMsg); !ok {
+		t.Fatalf("expected sessions CloseMsg, got %T", msg)
+	}
+
+	result, _ = rm.Update(msg)
+	rm = result.(*Model)
+	if rm.resumeBrowserMode {
+		t.Fatal("expected resume browser mode to close")
+	}
+	if rm.quitting {
+		t.Fatal("expected close to return to chat instead of quitting")
+	}
+	if got := rm.textarea.Value(); got != "draft follow-up" {
+		t.Fatalf("expected draft input to be preserved, got %q", got)
 	}
 }
 

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -34,6 +34,11 @@ func (m *Model) View() string {
 		return m.inspectorModel.View()
 	}
 
+	// Resume browser mode uses the dedicated sessions browser view
+	if m.resumeBrowserMode && m.resumeBrowserModel != nil {
+		return m.resumeBrowserModel.View()
+	}
+
 	if m.streaming && m.streamPerf != nil {
 		m.streamPerf.RecordFrameAt(time.Now())
 	}

--- a/internal/tui/chat/resume_browser.go
+++ b/internal/tui/chat/resume_browser.go
@@ -1,0 +1,53 @@
+package chat
+
+import (
+	"context"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	sessionsui "github.com/samsaffron/term-llm/internal/tui/sessions"
+)
+
+func (m *Model) openResumeBrowser() (tea.Model, tea.Cmd) {
+	browser := sessionsui.New(m.store, m.width, m.height, m.styles)
+	browser.SetEmbedded(true)
+	if m.sess != nil {
+		browser.SetPreferredSessionID(m.sess.ID)
+	}
+	if updated, _ := browser.Update(sessionsui.RefreshMsg{}); updated != nil {
+		if embedded, ok := updated.(*sessionsui.Model); ok {
+			browser = embedded
+		}
+	}
+
+	m.resumeBrowserMode = true
+	m.resumeBrowserModel = browser
+
+	if !m.altScreen {
+		return m, tea.EnterAltScreen
+	}
+	return m, nil
+}
+
+func (m *Model) closeResumeBrowser() (tea.Model, tea.Cmd) {
+	m.resumeBrowserMode = false
+	m.resumeBrowserModel = nil
+	m.textarea.Focus()
+	if !m.altScreen {
+		return m, tea.ExitAltScreen
+	}
+	return m, nil
+}
+
+func (m *Model) requestResumeSession(sessionID string) (tea.Model, tea.Cmd) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return m, nil
+	}
+	if m.store != nil {
+		_ = m.store.SetCurrent(context.Background(), sessionID)
+	}
+	m.pendingResumeSessionID = sessionID
+	m.quitting = true
+	return m, tea.Quit
+}

--- a/internal/tui/sessions/browse.go
+++ b/internal/tui/sessions/browse.go
@@ -76,6 +76,9 @@ type ChatMsg struct {
 	SessionID string
 }
 
+// CloseMsg signals that the browser should close and return to its parent view.
+type CloseMsg struct{}
+
 // DeleteConfirmMsg signals a delete was confirmed
 type DeleteConfirmMsg struct {
 	SessionID string
@@ -119,6 +122,11 @@ type Model struct {
 	// Chat request (set when user wants to chat with a session)
 	chatSessionID string
 
+	// Embedded/browser integration state
+	embedded               bool
+	preferredSessionID     string
+	selectPreferredSession bool
+
 	// Components
 	styles *ui.Styles
 	keyMap KeyMap
@@ -154,6 +162,17 @@ func New(store session.Store, width, height int, styles *ui.Styles) *Model {
 // Check this after the TUI exits to determine if chat should be launched.
 func (m *Model) ChatSessionID() string {
 	return m.chatSessionID
+}
+
+// SetEmbedded enables parent-managed close behavior for embedded browsers.
+func (m *Model) SetEmbedded(embedded bool) {
+	m.embedded = embedded
+}
+
+// SetPreferredSessionID selects a session after the next refresh, if present.
+func (m *Model) SetPreferredSessionID(sessionID string) {
+	m.preferredSessionID = strings.TrimSpace(sessionID)
+	m.selectPreferredSession = m.preferredSessionID != ""
 }
 
 // Init initializes the model
@@ -252,6 +271,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Normal key handling
 	switch {
 	case key.Matches(msg, m.keyMap.Quit):
+		if m.embedded {
+			return m, func() tea.Msg { return CloseMsg{} }
+		}
 		return m, tea.Quit
 
 	case key.Matches(msg, m.keyMap.Up):
@@ -327,7 +349,7 @@ func (m *Model) moveCursor(delta int) {
 
 // viewportHeight returns the number of visible session rows
 func (m *Model) viewportHeight() int {
-	// Header (2) + footer (2) + filter bar (1) = 5 lines reserved
+	// Header (1) + filter bar (1) + column header (1) + separator (1) + footer (1) = 5 lines reserved
 	return max(1, m.height-5)
 }
 
@@ -417,6 +439,16 @@ func (m *Model) doRefresh() (tea.Model, tea.Cmd) {
 	// Apply sort order
 	m.sortSessions()
 
+	if m.selectPreferredSession && m.preferredSessionID != "" {
+		for i, s := range m.sessions {
+			if s.ID == m.preferredSessionID {
+				m.cursor = i
+				break
+			}
+		}
+		m.selectPreferredSession = false
+	}
+
 	// Clamp cursor
 	if m.cursor >= len(m.sessions) && len(m.sessions) > 0 {
 		m.cursor = len(m.sessions) - 1
@@ -487,6 +519,13 @@ func (m *Model) View() string {
 	}
 
 	theme := m.styles.Theme()
+	selectedStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(theme.Text).
+		Background(theme.Primary)
+	normalStyle := lipgloss.NewStyle().Foreground(theme.Text)
+	mutedStyle := lipgloss.NewStyle().Foreground(theme.Muted)
+
 	var b strings.Builder
 
 	// Header
@@ -499,6 +538,9 @@ func (m *Model) View() string {
 
 	countStr := fmt.Sprintf("[%d sessions]", len(m.sessions))
 	title := "Sessions Browser"
+	if m.embedded {
+		title = "Resume Session"
+	}
 	padding := renderWidth - lipgloss.Width(title) - lipgloss.Width(countStr) - 4 // 4 for padding spaces
 	if padding < 1 {
 		padding = 1
@@ -526,7 +568,11 @@ func (m *Model) View() string {
 		filterParts = append(filterParts, "[FTS: on]")
 	}
 
-	b.WriteString(filterStyle.Render(strings.Join(filterParts, " ")))
+	b.WriteString(filterStyle.Render(fitToDisplayWidth(strings.Join(filterParts, " "), renderWidth)))
+	b.WriteString("\n")
+
+	cols := sessionColumnWidths(renderWidth)
+	b.WriteString(mutedStyle.Render(fitToDisplayWidth(renderSessionColumnsHeader(cols), renderWidth)))
 	b.WriteString("\n")
 
 	// Session list
@@ -542,55 +588,8 @@ func (m *Model) View() string {
 		end = len(m.sessions)
 	}
 
-	selectedStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(theme.Text).
-		Background(theme.Primary)
-	normalStyle := lipgloss.NewStyle().Foreground(theme.Text)
-	mutedStyle := lipgloss.NewStyle().Foreground(theme.Muted)
-
 	for i := start; i < end; i++ {
-		s := m.sessions[i]
-
-		// Format row
-		summary := s.Summary
-		if s.Name != "" {
-			summary = s.Name
-		}
-		summary = truncateDisplay(summary, 25, "...")
-
-		// Status
-		status := string(s.Status)
-		if status == "" {
-			status = "active"
-		}
-
-		// Mode indicator (style: chat/ask)
-		style := string(s.Mode)
-		if style == "" {
-			style = "chat"
-		}
-
-		// Tokens — show total input (uncached + cache read + cache write)
-		totalInput := s.InputTokens + s.CachedInputTokens + s.CacheWriteTokens
-		tokens := formatTokens(totalInput, s.OutputTokens)
-
-		// Age
-		age := formatRelativeTime(s.UpdatedAt)
-
-		// Format: cursor # summary style model msgs tokens status age
-		cursor := "  "
-		if i == m.cursor {
-			cursor = "> "
-		}
-
-		// Build row
-		row := fmt.Sprintf("%s%4d %-25s %-4s %-10s %3d %-11s %-8s %s",
-			cursor, s.Number, summary, style, truncateModel(s.Model, 10), s.MessageCount, tokens, status, age)
-
-		// Truncate or pad to width
-		row = fitToDisplayWidth(row, renderWidth)
-
+		row := fitToDisplayWidth(renderSessionRow(m.sessions[i], i == m.cursor, cols), renderWidth)
 		if i == m.cursor {
 			b.WriteString(selectedStyle.Render(row))
 		} else {
@@ -612,17 +611,136 @@ func (m *Model) View() string {
 	// Delete confirmation
 	if m.deleteConfirm {
 		confirmStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Error)
-		b.WriteString(confirmStyle.Render(fmt.Sprintf("Delete session #%d? (y/n)", m.deleteNumber)))
+		b.WriteString(confirmStyle.Render(fitToDisplayWidth(fmt.Sprintf("Delete session #%d? (y/n)", m.deleteNumber), renderWidth)))
 	} else if m.err != nil {
 		errorStyle := lipgloss.NewStyle().Foreground(theme.Error)
-		b.WriteString(errorStyle.Render(fmt.Sprintf("Error: %v", m.err)))
+		b.WriteString(errorStyle.Render(fitToDisplayWidth(fmt.Sprintf("Error: %v", m.err), renderWidth)))
 	} else {
 		// Help
 		help := "[enter] chat  [i] inspect  [d] delete  [/] search  [s] sort  [f] filter  [q] quit"
-		b.WriteString(mutedStyle.Render(help))
+		if m.embedded {
+			help = "[enter] resume  [i] inspect  [d] delete  [/] search  [s] sort  [f] filter  [q] back"
+		}
+		b.WriteString(mutedStyle.Render(fitToDisplayWidth(help, renderWidth)))
 	}
 
 	return b.String()
+}
+
+type sessionColumns struct {
+	cursor  int
+	number  int
+	summary int
+	mode    int
+	model   int
+	msgs    int
+	tokens  int
+	status  int
+	age     int
+}
+
+func sessionColumnWidths(renderWidth int) sessionColumns {
+	cols := sessionColumns{
+		cursor: 2,
+		number: 7,
+		mode:   4,
+		model:  min(18, max(10, renderWidth/6)),
+		msgs:   5,
+		tokens: 11,
+		status: 8,
+		age:    7,
+	}
+
+	fixed := cols.cursor + cols.number + cols.mode + cols.model + cols.msgs + cols.tokens + cols.status + cols.age
+	cols.summary = renderWidth - fixed - 8 // 8 spaces between columns
+	if cols.summary < 12 {
+		shrink := min(12-cols.summary, max(0, cols.model-8))
+		cols.model -= shrink
+		cols.summary += shrink
+	}
+	if cols.summary < 8 {
+		cols.summary = 8
+	}
+
+	return cols
+}
+
+func renderSessionColumnsHeader(cols sessionColumns) string {
+	parts := []string{
+		fitToDisplayWidth("", cols.cursor),
+		fitToDisplayWidth("session", cols.number),
+		fitToDisplayWidth("name / summary", cols.summary),
+		fitToDisplayWidth("mode", cols.mode),
+		fitToDisplayWidth("model", cols.model),
+		fitToDisplayWidth("msgs", cols.msgs),
+		fitToDisplayWidth("tokens", cols.tokens),
+		fitToDisplayWidth("status", cols.status),
+		fitToDisplayWidth("updated", cols.age),
+	}
+	return strings.Join(parts, " ")
+}
+
+func renderSessionRow(s session.SessionSummary, selected bool, cols sessionColumns) string {
+	status := string(s.Status)
+	if status == "" {
+		status = "active"
+	}
+
+	mode := string(s.Mode)
+	if mode == "" {
+		mode = "chat"
+	}
+
+	totalInput := s.InputTokens + s.CachedInputTokens + s.CacheWriteTokens
+	tokens := formatTokens(totalInput, s.OutputTokens)
+	age := formatRelativeTime(s.UpdatedAt)
+
+	number := truncateDisplay(s.ID, cols.number, "...")
+	if s.Number > 0 {
+		number = fmt.Sprintf("#%d", s.Number)
+	}
+
+	model := s.Model
+	if model == "" {
+		model = s.Provider
+	}
+
+	cursor := "  "
+	if selected {
+		cursor = "> "
+	}
+
+	parts := []string{
+		fitToDisplayWidth(cursor, cols.cursor),
+		fitToDisplayWidth(number, cols.number),
+		fitToDisplayWidth(sessionPrimaryText(s), cols.summary),
+		fitToDisplayWidth(mode, cols.mode),
+		fitToDisplayWidth(model, cols.model),
+		fitToDisplayWidth(fmt.Sprintf("%d", s.MessageCount), cols.msgs),
+		fitToDisplayWidth(tokens, cols.tokens),
+		fitToDisplayWidth(status, cols.status),
+		fitToDisplayWidth(age, cols.age),
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func sessionPrimaryText(s session.SessionSummary) string {
+	name := strings.TrimSpace(s.Name)
+	summary := strings.TrimSpace(s.Summary)
+
+	switch {
+	case name != "" && summary != "" && !strings.EqualFold(name, summary):
+		return name + " — " + summary
+	case name != "":
+		return name
+	case summary != "":
+		return summary
+	case s.Number > 0:
+		return fmt.Sprintf("Session #%d", s.Number)
+	default:
+		return strings.TrimSpace(s.ID)
+	}
 }
 
 // formatRelativeTime returns a human-readable relative time string

--- a/internal/tui/sessions/embedded_test.go
+++ b/internal/tui/sessions/embedded_test.go
@@ -1,0 +1,71 @@
+package sessions
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type embeddedTestStore struct {
+	session.NoopStore
+	summaries []session.SessionSummary
+}
+
+func (s *embeddedTestStore) List(_ context.Context, _ session.ListOptions) ([]session.SessionSummary, error) {
+	return s.summaries, nil
+}
+
+func TestEmbeddedQuitEmitsCloseMsg(t *testing.T) {
+	m := New(nil, 80, 24, nil)
+	m.SetEmbedded(true)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Fatal("expected quit key to return a command")
+	}
+	msg := cmd()
+	if _, ok := msg.(CloseMsg); !ok {
+		t.Fatalf("expected CloseMsg from embedded quit, got %T", msg)
+	}
+}
+
+func TestSetPreferredSessionIDSelectsMatchingSessionOnRefresh(t *testing.T) {
+	store := &embeddedTestStore{
+		summaries: []session.SessionSummary{
+			{ID: "sess-1", Number: 1, UpdatedAt: time.Now().Add(-time.Hour)},
+			{ID: "sess-2", Number: 2, UpdatedAt: time.Now()},
+		},
+	}
+	m := New(store, 80, 24, nil)
+	m.SetPreferredSessionID("sess-1")
+
+	updated, _ := m.Update(RefreshMsg{})
+	browser := updated.(*Model)
+	if browser.cursor != 1 {
+		t.Fatalf("expected preferred session cursor to be 1 after sort, got %d", browser.cursor)
+	}
+}
+
+func TestView_EmbeddedModeUsesResumeCopy(t *testing.T) {
+	m := New(nil, 80, 24, nil)
+	m.SetEmbedded(true)
+	m.sessions = []session.SessionSummary{{
+		ID:        "sess-1",
+		Number:    1,
+		Name:      "draft ideas",
+		Summary:   "explored resume browser layout",
+		UpdatedAt: time.Now(),
+	}}
+
+	out := m.View()
+	if !strings.Contains(out, "Resume Session") {
+		t.Fatalf("expected embedded header in view, got %q", out)
+	}
+	if !strings.Contains(out, "[enter] resume") {
+		t.Fatalf("expected embedded help copy in view, got %q", out)
+	}
+}


### PR DESCRIPTION
## What

Replace chat TUI `/resume`'s generic session list dialog with a dedicated embedded sessions browser.

This changes the no-arg `/resume` flow from a fixed-width modal into a full-width browser mode inside chat that reuses the existing sessions browser model.

## Changes

- add chat-side resume browser state and helpers
- open embedded sessions browser for `/resume` with no args
- keep direct `/resume <number|id>` behavior unchanged
- wire browser selection back into the existing relaunch/resume path
- let `q` / close return to chat cleanly without dropping the current draft
- adapt the sessions browser for embedded use:
  - embedded close message instead of quitting the whole app
  - current-session preselection on refresh
  - embedded header/help copy (`Resume Session`, `[enter] resume`, `[q] back`)
  - wider, more contextual row rendering
- add tests for embedded browser open/select/close behavior

## Why

The old `/resume` UI was using the generic dialog renderer:

- hardcoded narrow width
- flattened one-line labels
- limited context
- did not feel like a dedicated flow

Reusing the sessions browser gives `/resume` a proper full-width UI with search, sort, filter, inspect, and enough context to make resuming sessions actually pleasant.

## Verification

- `go build ./...`
- `go test ./...`
