### PR TITLE
docs: simplify docs homepage navigation

### DIFF
--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -1,19 +1,29 @@
 ---
 title: "term-llm"
 description: "Terminal-first AI runtime for commands, chat, agents, editing, tools, jobs, and local workflows."
-belongs: |
-  - Quickstart flows that take you from installation to a working setup
-  - Task-focused guides for common workflows and integrations
-  - Architecture notes that explain how the major pieces fit together
-  - Reference pages for configuration, commands, and persistent state
-avoids: |
-  - Mixing tutorials, conceptual notes, and reference material on the same page
-  - Navigation that depends on browsing repository directories
-  - Landing pages that look polished but do not help readers find the right page
-  - Burying important configuration and command details inside long prose
+new_here: |
+  - [Quickstart](/getting-started/quickstart/) for the shortest path from install to a working first run
+  - [Installation](/getting-started/installation/) if you just want the install command and platform notes
+  - [Providers and setup](/getting-started/providers-and-setup/) to wire up OpenAI, Anthropic, Gemini, Ollama, OpenRouter, and the rest
+  - [Usage guide](/guides/usage/) when you want the mental model for `exec`, `ask`, and `chat`
+common_workflows: |
+  - [Agents](/guides/agents/) for built-in agents and when to use them
+  - [File editing](/guides/file-editing/) for safe edit workflows from the terminal
+  - [MCP servers](/guides/mcp-servers/) to connect external tools and services
+  - [Job runner](/guides/job-runner/) for scheduled and background automation
+reference_shortcuts: |
+  - [Configuration reference](/reference/configuration/) for config keys, file locations, and examples
+  - [Providers and models](/reference/providers-and-models/) for provider-specific settings and model naming
+  - [Built-in tools](/reference/built-in-tools/) for tool behavior and availability
+  - [Sessions](/reference/sessions/) for persistence, resume behavior, and storage details
+understand_it: |
+  - [Architecture overview](/architecture/overview/) for how runtimes, tools, routing, skills, and memory fit together
+  - [Memory guide](/guides/memory/) for persistent memory behavior and fragment management
+  - [Web UI and API](/guides/web-ui-and-api/) for browser access and HTTP endpoints
+  - [Debugging](/guides/debugging/) when something feels off and you need the shortest path to evidence
 ---
 term-llm is a terminal-first AI runtime.
 
 It turns natural language into command suggestions, supports persistent chat, runs agents, edits files, calls tools, schedules jobs, and works with local or hosted models.
 
-Use `exec` for fast one-shot terminal help, `ask` when you want an answer or an agent, and `chat` when you need an ongoing working session.
+If you are new, install it, configure one provider, run the quickstart, and then come back for the workflow or reference page that matches the job.

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -29,7 +29,7 @@ $ term-llm chat @codebase</code></pre>
       <pre class="install-command"><code id="install-command">curl -fsSL https://raw.githubusercontent.com/samsaffron/term-llm/main/install.sh | sh</code></pre>
       <button class="button primary copy-button" type="button" data-copy-text="curl -fsSL https://raw.githubusercontent.com/samsaffron/term-llm/main/install.sh | sh" data-copy-default="Copy install command" data-copy-success="Copied install command">Copy install command</button>
     </div>
-    <p class="install-note">The full command is shown inline, so people do not have to horizontally scroll just to see what they are about to paste.</p>
+    <p class="install-note">The full command is shown inline, so you can see exactly what you are about to paste.</p>
   </section>
 
   <section class="section-block">
@@ -46,12 +46,12 @@ $ term-llm chat @codebase</code></pre>
       <a class="card detail-card" href="/guides/agents/">
         <p class="card-kicker">Ask + agents</p>
         <h3><code>term-llm ask @reviewer</code></h3>
-        <p>Use a built-in agent when the job has a mode. `@reviewer` is read-only and git-aware, so it reviews code without wandering off into edits.</p>
+        <p>Use a built-in agent when the job has a mode. <code>@reviewer</code> is read-only and git-aware, so it reviews code without wandering off into edits.</p>
       </a>
       <a class="card detail-card" href="/guides/agents/">
         <p class="card-kicker">Chat + agents</p>
         <h3><code>term-llm chat @codebase</code></h3>
-        <p>Start a persistent session when you need back-and-forth. `@codebase` is the right tool for tracing behavior and understanding a repository.</p>
+        <p>Start a persistent session when you need back-and-forth. <code>@codebase</code> is the right tool for tracing behavior and understanding a repository.</p>
       </a>
     </div>
   </section>
@@ -59,28 +59,24 @@ $ term-llm chat @codebase</code></pre>
   <section class="section-block split-layout">
     <div>
       <div class="section-heading">
-        <p class="eyebrow">Built-in agents</p>
-        <h2>Use the ones that already exist</h2>
+        <p class="eyebrow">Read the right page</p>
+        <h2>New here</h2>
       </div>
-      <div class="list-panel">
-        <p><code>@reviewer</code>, <code>@codebase</code>, <code>@developer</code>, <code>@researcher</code>, <code>@commit-message</code></p>
-        <p><code>@active-review</code>, <code>@agent-builder</code>, <code>@artist</code>, <code>@changelog</code>, <code>@editor</code>, <code>@file-organizer</code>, <code>@shell</code></p>
-        <p><a href="/guides/agents/">See the built-in agents guide</a></p>
-      </div>
+      <div class="list-panel markdown">{{ .Params.new_here | markdownify }}</div>
     </div>
     <div>
       <div class="section-heading">
-        <p class="eyebrow">What belongs here</p>
-        <h2>Documentation structure</h2>
+        <p class="eyebrow">Common workflows</p>
+        <h2>Already using it</h2>
       </div>
-      <div class="list-panel markdown">{{ .Params.belongs | markdownify }}</div>
+      <div class="list-panel markdown">{{ .Params.common_workflows | markdownify }}</div>
     </div>
   </section>
 
   <section class="section-block">
     <div class="section-heading">
       <p class="eyebrow">Choose your path</p>
-      <h2>Start with the task at hand</h2>
+      <h2>Browse by section</h2>
     </div>
     <div class="card-grid card-grid-4">
       {{ range site.Sections.ByWeight }}
@@ -96,25 +92,17 @@ $ term-llm chat @codebase</code></pre>
   <section class="section-block split-layout">
     <div>
       <div class="section-heading">
-        <p class="eyebrow">What to avoid</p>
-        <h2>Documentation failure modes</h2>
+        <p class="eyebrow">Reference shortcuts</p>
+        <h2>When you need exact details</h2>
       </div>
-      <div class="list-panel markdown">{{ .Params.avoids | markdownify }}</div>
+      <div class="list-panel markdown">{{ .Params.reference_shortcuts | markdownify }}</div>
     </div>
     <div>
       <div class="section-heading">
-        <p class="eyebrow">Featured pages</p>
-        <h2>Recommended starting points</h2>
+        <p class="eyebrow">Understand the internals</p>
+        <h2>When the model matters</h2>
       </div>
-      <div class="card-grid card-grid-3">
-        {{ range first 3 (where site.RegularPages "Params.featured" true) }}
-          <a class="card detail-card" href="{{ .RelPermalink }}">
-            <p class="card-kicker">{{ .CurrentSection.Title }}</p>
-            <h3>{{ .Title }}</h3>
-            <p>{{ with .Description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}</p>
-          </a>
-        {{ end }}
-      </div>
+      <div class="list-panel markdown">{{ .Params.understand_it | markdownify }}</div>
     </div>
   </section>
 

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -56,77 +56,32 @@ $ term-llm chat @codebase</code></pre>
     </div>
   </section>
 
-  <section class="section-block split-layout">
-    <div>
-      <div class="section-heading">
-        <p class="eyebrow">Read the right page</p>
-        <h2>New here</h2>
-      </div>
-      <div class="list-panel markdown">{{ .Params.new_here | markdownify }}</div>
-    </div>
-    <div>
-      <div class="section-heading">
-        <p class="eyebrow">Common workflows</p>
-        <h2>Already using it</h2>
-      </div>
-      <div class="list-panel markdown">{{ .Params.common_workflows | markdownify }}</div>
-    </div>
-  </section>
-
   <section class="section-block">
     <div class="section-heading">
-      <p class="eyebrow">Choose your path</p>
-      <h2>Browse by section</h2>
+      <p class="eyebrow">Read the right page</p>
+      <h2>Pick the lane that matches the job</h2>
     </div>
     <div class="card-grid card-grid-4">
-      {{ range site.Sections.ByWeight }}
-        <a class="card path-card" href="{{ .RelPermalink }}">
-          <p class="card-kicker">{{ with .Params.kicker }}{{ . }}{{ else }}Section{{ end }}</p>
-          <h3>{{ .Title }}</h3>
-          <p>{{ with .Description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}</p>
-        </a>
-      {{ end }}
-    </div>
-  </section>
-
-  <section class="section-block split-layout">
-    <div>
-      <div class="section-heading">
-        <p class="eyebrow">Reference shortcuts</p>
-        <h2>When you need exact details</h2>
+      <div class="card docs-card markdown">
+        <p class="card-kicker">Start here</p>
+        <h3>New here</h3>
+        {{ .Params.new_here | markdownify }}
       </div>
-      <div class="list-panel markdown">{{ .Params.reference_shortcuts | markdownify }}</div>
-    </div>
-    <div>
-      <div class="section-heading">
-        <p class="eyebrow">Understand the internals</p>
-        <h2>When the model matters</h2>
+      <div class="card docs-card markdown">
+        <p class="card-kicker">Do a thing</p>
+        <h3>Common workflows</h3>
+        {{ .Params.common_workflows | markdownify }}
       </div>
-      <div class="list-panel markdown">{{ .Params.understand_it | markdownify }}</div>
-    </div>
-  </section>
-
-  <section class="section-block">
-    <div class="section-heading">
-      <p class="eyebrow">More topics</p>
-      <h2>Other important capabilities</h2>
-    </div>
-    <div class="card-grid card-grid-3">
-      <a class="card detail-card" href="/guides/text-embeddings/">
-        <p class="card-kicker">Guides</p>
-        <h3>Text embeddings</h3>
-        <p>Generate vectors for retrieval, semantic similarity, clustering, and RAG workflows.</p>
-      </a>
-      <a class="card detail-card" href="/reference/usage-tracking/">
-        <p class="card-kicker">Reference</p>
-        <h3>Usage tracking</h3>
-        <p>Inspect local token usage and cost data across term-llm, Claude Code, and Gemini CLI.</p>
-      </a>
-      <a class="card detail-card" href="/guides/image-generation/">
-        <p class="card-kicker">Guides</p>
-        <h3>Image generation</h3>
-        <p>Generate and edit images with Gemini, OpenAI, xAI, Venice, and Flux providers.</p>
-      </a>
+      <div class="card docs-card markdown">
+        <p class="card-kicker">Exact details</p>
+        <h3>Reference shortcuts</h3>
+        {{ .Params.reference_shortcuts | markdownify }}
+      </div>
+      <div class="card docs-card markdown">
+        <p class="card-kicker">Model underneath</p>
+        <h3>Architecture and internals</h3>
+        {{ .Params.understand_it | markdownify }}
+      </div>
     </div>
   </section>
 {{ end }}

--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -116,9 +116,13 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
 .card-grid { display: grid; gap: 1rem; }
 .card-grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 .card-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.path-card, .detail-card { padding: 1.2rem; text-decoration: none; color: var(--soft); }
+.path-card, .detail-card, .docs-card { padding: 1.2rem; text-decoration: none; color: var(--soft); }
 .card-kicker { margin: 0 0 0.6rem; color: var(--accent); font-size: 0.8rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
 .path-card p, .detail-card p { margin: 0.75rem 0 0; line-height: 1.65; }
+.docs-card { height: 100%; }
+.docs-card h3 { margin-bottom: 0.85rem; }
+.docs-card ul { margin: 0; padding-left: 1.2rem; }
+.docs-card li + li { margin-top: 0.55rem; }
 .split-layout, .doc-grid { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .doc-grid-wide { grid-template-columns: minmax(0, 1.7fr) minmax(260px, 0.7fr); align-items: start; }
 .list-panel, .doc-surface { padding: 1.2rem 1.25rem; }


### PR DESCRIPTION
## What

Simplifies the docs site homepage so it helps people find the right page instead of explaining documentation theory.

### Changes
- removes the `What to avoid / Documentation failure modes` block
- removes the empty `Featured pages` logic that depended on `featured: true` pages
- replaces those sections with explicit, useful link groups:
  - New here
  - Common workflows
  - Reference shortcuts
  - Understand the internals
- rewrites the homepage intro copy to push readers toward quickstart, setup, workflow, and reference pages
- keeps the install command and command-entry examples intact

## Why

The current front page is too self-conscious about documentation structure. It spends homepage real estate on what docs should not do, while doing a worse job of getting readers to the page they actually need.

This makes the landing page more practical:
- new users get an obvious first path
- returning users get direct links to common workflows and reference pages
- architecture/debugging pages are still discoverable without turning the homepage into a manifesto about docs

## Validation

```bash
hugo --source docs-site --destination /tmp/term-llm-docs-website-frontpage
```
