### PR TITLE
fix: self-heal stale web UI session state

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -233,10 +233,10 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
 };
 
 const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
-  if (!session || !state.token) return;
+  if (!session || !state.token) return null;
 
   const runtimeState = await loadServerSessionState(session.id);
-  if (!runtimeState) return;
+  if (!runtimeState) return null;
 
   const prompts = Array.isArray(runtimeState.pending_ask_users)
     ? runtimeState.pending_ask_users
@@ -279,12 +279,12 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
     if (session.id === state.activeSessionId && !state.abortController) {
       setStreaming(true);
       void resumeActiveResponse(session, { responseId: activeResponseId });
-      return;
+      return runtimeState;
     }
     if (pollOnActive) {
       scheduleSessionStatePoll(session.id);
     }
-    return;
+    return runtimeState;
   }
 
   if (activeRun && !state.abortController) {
@@ -292,7 +292,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
     if (pollOnActive) {
       scheduleSessionStatePoll(session.id);
     }
-    return;
+    return runtimeState;
   }
 
   if (!activeRun && !state.abortController) {
@@ -319,6 +319,8 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
     setConnectionState('', '');
     setStreaming(false);
   }
+
+  return runtimeState;
 };
 
 const mergeServerSessions = async () => {

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -655,6 +655,9 @@ const cancelActiveResponse = async (session) => {
     if (state.abortController) {
       state.abortController.abort();
     }
+    if (session?.id) {
+      await refreshSessionFromServerTruth(session, true);
+    }
     return;
   }
 
@@ -663,7 +666,13 @@ const cancelActiveResponse = async (session) => {
     method: 'POST',
     headers: requestHeaders(session?.id || '')
   });
-  if (!response.ok && response.status !== 404 && response.status !== 409) {
+  if (!response.ok) {
+    if (response.status === 404 || response.status === 409) {
+      if (session?.id) {
+        await refreshSessionFromServerTruth(session, true);
+      }
+      return;
+    }
     throw await normalizeError(response);
   }
 
@@ -1057,6 +1066,15 @@ const submitAskUserModal = async (cancelled = false) => {
       app.scheduleSessionStatePoll(prompt.sessionId, 400);
     }
   } catch (err) {
+    if (err?.status === 409) {
+      const session = state.sessions.find((item) => item.id === prompt.sessionId) || null;
+      const runtimeState = session ? await refreshSessionFromServerTruth(session, true) : null;
+      if (!runtimeHasPendingAskUser(runtimeState, prompt.callId)) {
+        closeAskUserModal();
+        return;
+      }
+    }
+
     elements.askUserError.textContent = err?.message || 'Failed to submit your answer.';
     if (err?.status === 401) {
       handleAuthFailure();
@@ -1164,6 +1182,15 @@ const submitApprovalModal = async (denied = false) => {
       app.scheduleSessionStatePoll(prompt.sessionId, 400);
     }
   } catch (err) {
+    if (err?.status === 409) {
+      const session = state.sessions.find((item) => item.id === prompt.sessionId) || null;
+      const runtimeState = session ? await refreshSessionFromServerTruth(session, true) : null;
+      if (!runtimeHasPendingApproval(runtimeState, prompt.approvalId)) {
+        closeApprovalModal();
+        return;
+      }
+    }
+
     elements.approvalError.textContent = err?.message || 'Failed to submit approval.';
     if (err?.status === 401) {
       handleAuthFailure();
@@ -1644,6 +1671,10 @@ const setStreaming = (streaming) => {
 };
 
 const queueInterruptFollowUp = (prompt, messageId) => {
+  const normalizedMessageId = String(messageId || '').trim();
+  if (normalizedMessageId && state.queuedInterrupts.some(entry => entry.messageId === normalizedMessageId)) {
+    return;
+  }
   state.queuedInterrupts.push({ prompt, messageId });
 };
 
@@ -1739,6 +1770,57 @@ const interruptActiveRun = async (session, prompt, messageId) => {
   return action;
 };
 
+const runtimeHasActiveRun = (runtimeState) => {
+  if (!runtimeState || typeof runtimeState !== 'object') return false;
+  return Boolean(runtimeState.active_run || String(runtimeState.active_response_id || '').trim());
+};
+
+const runtimeHasPendingAskUser = (runtimeState, callId) => {
+  const normalizedCallId = String(callId || '').trim();
+  if (!normalizedCallId || !runtimeState || typeof runtimeState !== 'object') return false;
+  const prompts = Array.isArray(runtimeState.pending_ask_users)
+    ? runtimeState.pending_ask_users
+    : (runtimeState.pending_ask_user ? [runtimeState.pending_ask_user] : []);
+  return prompts.some((item) => String(item?.call_id || '').trim() === normalizedCallId);
+};
+
+const runtimeHasPendingApproval = (runtimeState, approvalId) => {
+  const normalizedApprovalId = String(approvalId || '').trim();
+  if (!normalizedApprovalId || !runtimeState || typeof runtimeState !== 'object') return false;
+  const approvals = Array.isArray(runtimeState.pending_approvals)
+    ? runtimeState.pending_approvals
+    : (runtimeState.pending_approval ? [runtimeState.pending_approval] : []);
+  return approvals.some((item) => String(item?.approval_id || '').trim() === normalizedApprovalId);
+};
+
+const refreshSessionFromServerTruth = async (session, pollOnActive = false) => {
+  if (!session?.id) return null;
+  return app.syncActiveSessionFromServer(session, pollOnActive);
+};
+
+const recoverInterruptConflict = async (session, prompt, messageId) => {
+  const runtimeState = await refreshSessionFromServerTruth(session, true);
+  if (!runtimeState) {
+    return false;
+  }
+  if (runtimeHasActiveRun(runtimeState)) {
+    discardPendingInterruptCommit(messageId);
+    setInterruptMessageState(session, messageId, 'queue');
+    queueInterruptFollowUp(prompt, messageId);
+    persistAndRefreshShell();
+    scrollToBottom(true);
+    return true;
+  }
+
+  discardPendingInterruptCommit(messageId);
+  await sendMessage({
+    prompt,
+    attachments: [],
+    reuseMessageId: messageId
+  });
+  return true;
+};
+
 const addErrorMessage = (text, session) => {
   const message = {
     id: generateId('msg'),
@@ -1830,6 +1912,17 @@ const sendMessage = async (options = {}) => {
     try {
       await interruptActiveRun(session, prompt, pendingMessage.id);
     } catch (err) {
+      if (err?.status === 409) {
+        try {
+          const recovered = await recoverInterruptConflict(session, prompt, pendingMessage.id);
+          if (recovered) {
+            return;
+          }
+        } catch (recoveryErr) {
+          err = recoveryErr;
+        }
+      }
+
       discardPendingInterruptCommit(pendingMessage.id);
       setInterruptMessageState(session, pendingMessage.id, 'error');
       const message = err?.message || 'Failed to interrupt active run.';


### PR DESCRIPTION
## What

Make the web UI reconcile against server truth when optimistic client state goes stale.

### Included fixes

- recover from stale interrupt state by refreshing session runtime on `409` and then:
  - re-send as a normal message when the run is already over
  - queue the message when the server still reports an active run
- refresh session state immediately when cancel hits `404`/`409` instead of leaving the UI in a stale streaming state
- close stale `ask_user` and approval modals when submit returns `409` and the server no longer reports the pending prompt
- dedupe queued follow-up interrupts by `messageId`
- return runtime state from `syncActiveSessionFromServer()` so reconciliation paths can make decisions from the authoritative server snapshot

## Why

The browser should not behave like a fragile state machine that dies on races around stream completion.

If the server is reachable, the UI should treat it as source of truth, reconcile, and keep going. This makes the web UI much more robust around:

- end-of-stream interrupt races (`session has no active stream`)
- stale stop/cancel state
- stale prompt/approval submission state after the run already moved on

## Validation

- `node --check internal/serveui/static/app-stream.js`
- `node --check internal/serveui/static/app-sessions.js`
- `go test ./cmd -run 'TestHandleSessionState_ConsumesDeferredUIRunError|TestHandleSessionInterrupt|TestResponses|TestServe'`
