### PR TITLE
fix: keep mobile composer above keyboard

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -320,6 +320,40 @@ const isStandalone = () => window.matchMedia('(display-mode: standalone)').match
 // Mobile browsers treat programmatic focus as an instruction to pop the keyboard.
 const shouldSuppressPromptAutoFocus = () => window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 
+// Keep the shell pinned to the visual viewport so the composer stays above
+// the on-screen keyboard even after iOS/WebKit viewport scrolling quirks.
+const syncViewportShell = (() => {
+  let rafId = 0;
+
+  const apply = () => {
+    rafId = 0;
+    const vv = window.visualViewport;
+    const height = vv ? Math.round(vv.height) : window.innerHeight;
+    const offsetTop = vv ? Math.max(0, Math.round(vv.offsetTop)) : 0;
+
+    document.documentElement.style.setProperty('--app-height', `${height}px`);
+    document.documentElement.style.setProperty('--app-offset-top', `${offsetTop}px`);
+  };
+
+  return () => {
+    if (rafId) return;
+    rafId = window.requestAnimationFrame(apply);
+  };
+})();
+
+syncViewportShell();
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', syncViewportShell);
+  window.visualViewport.addEventListener('scroll', syncViewportShell);
+}
+window.addEventListener('resize', syncViewportShell);
+window.addEventListener('orientationchange', syncViewportShell);
+window.addEventListener('pageshow', syncViewportShell);
+document.addEventListener('focusin', syncViewportShell);
+document.addEventListener('focusout', () => {
+  window.setTimeout(syncViewportShell, 50);
+});
+
 const syncNotificationPermissionState = () => {
   if (typeof Notification === 'undefined') return;
   if (Notification.permission === 'granted') {
@@ -727,6 +761,7 @@ Object.assign(app, {
   setStartupStatus,
   hideStartupSplash,
   updateDocumentTitle,
+  syncViewportShell,
   UI_PREFIX,
   isStandalone,
   shouldSuppressPromptAutoFocus,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -30,6 +30,8 @@
       --safe-right: env(safe-area-inset-right, 0px);
       --safe-bottom: env(safe-area-inset-bottom, 0px);
       --safe-left: env(safe-area-inset-left, 0px);
+      --app-height: 100dvh;
+      --app-offset-top: 0px;
     }
 
     @media (prefers-color-scheme: light) {
@@ -191,14 +193,16 @@
     .app {
       display: grid;
       grid-template-columns: 280px minmax(0, 1fr);
-      min-height: 100vh;
-      min-height: 100dvh;
-      height: 100vh;
-      height: 100dvh;
+      min-height: var(--app-height);
+      height: var(--app-height);
       width: 100%;
       background: transparent;
-      position: relative;
+      position: fixed;
+      top: var(--app-offset-top);
+      left: 0;
+      right: 0;
       z-index: 1;
+      overflow: hidden;
     }
 
     .sidebar {
@@ -1711,8 +1715,8 @@
 
       .app {
         grid-template-columns: 1fr;
-        height: 100dvh;
-        min-height: 100dvh;
+        height: var(--app-height);
+        min-height: var(--app-height);
         overflow: hidden;
       }
 
@@ -1738,7 +1742,7 @@
       }
 
       .main {
-        height: 100dvh;
+        height: var(--app-height);
         min-height: 0;
       }
 

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
   <title>Chat</title>
   <meta name="application-name" content="term-llm">
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## What

- opt the web UI into `interactive-widget=resizes-content` so Chromium resizes content with the virtual keyboard
- pin the app shell to the visual viewport using CSS variables synced from `window.visualViewport`
- keep using the visible viewport height/top offset when the keyboard opens or WebKit scrolls the viewport

## Why

On mobile, the composer could slip below the on-screen keyboard after the keyboard opened and the viewport got scrolled. `100dvh` already helps, but WebKit still has a nasty visual-vs-layout viewport mismatch when the keyboard is open. The least ugly cross-browser approach is:

1. let modern Chromium do the right thing via `interactive-widget=resizes-content`
2. use a small `visualViewport` fallback for Safari/WebKit quirks

That keeps the chat shell anchored to the visible viewport instead of the drifting layout viewport.

## Validation

- `go test ./...`
- `node --check internal/serveui/static/app-core.js`
