### PR TITLE
feat: add session autotitle scaffolding

### DIFF
--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -254,9 +254,9 @@ func runSessionsList(cmd *cobra.Command, args []string) error {
 	fmt.Println(strings.Repeat("-", 100))
 
 	for _, s := range summaries {
-		summary := s.Summary
-		if s.Name != "" {
-			summary = s.Name
+		summary := s.PreferredShortTitle()
+		if summary == "" {
+			summary = "(untitled)"
 		}
 		if len(summary) > 25 {
 			summary = summary[:22] + "..."
@@ -378,8 +378,15 @@ func runSessionsShow(cmd *cobra.Command, args []string) error {
 
 	// Text output
 	fmt.Printf("Session: %s\n", sess.ID)
+	fmt.Printf("Title: %s\n", fallbackString(sess.PreferredShortTitle(), "(untitled)"))
 	if sess.Name != "" {
 		fmt.Printf("Name: %s\n", sess.Name)
+	}
+	if sess.GeneratedShortTitle != "" {
+		fmt.Printf("Generated Short Title: %s\n", sess.GeneratedShortTitle)
+	}
+	if sess.GeneratedLongTitle != "" {
+		fmt.Printf("Generated Long Title: %s\n", sess.GeneratedLongTitle)
 	}
 	fmt.Printf("Provider: %s\n", sess.Provider)
 	fmt.Printf("Model: %s\n", sess.Model)
@@ -481,7 +488,7 @@ func runSessionsExport(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		outputPath = args[1]
 	} else {
-		name := sess.Name
+		name := sess.PreferredShortTitle()
 		if name == "" {
 			name = fmt.Sprintf("session-%d", sess.Number)
 		}
@@ -492,6 +499,7 @@ func runSessionsExport(cmd *cobra.Command, args []string) error {
 	var b strings.Builder
 	b.WriteString("# Chat Export\n\n")
 	b.WriteString(fmt.Sprintf("**Session:** %s\n", sess.ID))
+	b.WriteString(fmt.Sprintf("**Title:** %s\n", fallbackString(sess.PreferredShortTitle(), "(untitled)")))
 	if sess.Name != "" {
 		b.WriteString(fmt.Sprintf("**Name:** %s\n", sess.Name))
 	}
@@ -533,6 +541,13 @@ func formatRelativeTime(t time.Time) string {
 	default:
 		return t.Format("Jan 2")
 	}
+}
+
+func fallbackString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func runSessionsReset(cmd *cobra.Command, args []string) error {
@@ -609,6 +624,7 @@ func runSessionsName(cmd *cobra.Command, args []string) error {
 	}
 
 	sess.Name = args[1]
+	sess.TitleSource = session.TitleSourceUser
 	if err := store.Update(ctx, sess); err != nil {
 		return fmt.Errorf("failed to update session: %w", err)
 	}

--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/sessiontitle"
+	"github.com/spf13/cobra"
+)
+
+var sessionsAutotitleCmd = &cobra.Command{
+	Use:   "autotitle",
+	Short: "Generate candidate titles for recent sessions",
+	Long: `Generate short and long candidate titles for recent sessions using the configured fast model.
+
+By default this previews candidates without saving them. Use --write to persist generated titles.
+User-set names always win in the UI and are not overwritten unless --force is provided.`,
+	RunE: runSessionsAutotitle,
+}
+
+var (
+	sessionsAutotitleWrite bool
+	sessionsAutotitleForce bool
+)
+
+func init() {
+	sessionsAutotitleCmd.Flags().IntVar(&sessionsLimit, "limit", 20, "Maximum number of recent sessions to inspect")
+	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleWrite, "write", false, "Persist generated titles to the session store")
+	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleForce, "force", false, "Regenerate even when a custom name already exists")
+	sessionsCmd.AddCommand(sessionsAutotitleCmd)
+}
+
+func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
+	store, err := getSessionStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	fastProvider, err := llm.NewFastProvider(cfg, cfg.DefaultProvider)
+	if err != nil {
+		return fmt.Errorf("fast provider: %w", err)
+	}
+	if fastProvider == nil {
+		return fmt.Errorf("no fast provider configured for %q", cfg.DefaultProvider)
+	}
+
+	ctx := context.Background()
+	summaries, err := store.List(ctx, session.ListOptions{Limit: sessionsLimit})
+	if err != nil {
+		return fmt.Errorf("list sessions: %w", err)
+	}
+	if len(summaries) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No sessions found.")
+		return nil
+	}
+
+	generated := 0
+	for _, summary := range summaries {
+		sess, err := store.Get(ctx, summary.ID)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "#%d load failed: %v\n", summary.Number, err)
+			continue
+		}
+		if sess == nil || sess.UserTurns == 0 {
+			continue
+		}
+		if sess.Name != "" && !sessionsAutotitleForce {
+			fmt.Fprintf(cmd.OutOrStdout(), "#%d\n  current: %s\n  skipped: custom name present\n\n", sess.Number, sess.Name)
+			continue
+		}
+
+		messages, err := store.GetMessages(ctx, sess.ID, 0, 0)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "#%d messages failed: %v\n", sess.Number, err)
+			continue
+		}
+
+		cand, err := sessiontitle.Generate(ctx, fastProvider, sess, messages)
+		current := sess.PreferredShortTitle()
+		if strings.TrimSpace(current) == "" {
+			current = "Untitled"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "#%d\n  current: %s\n", sess.Number, current)
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "  skipped: %v\n\n", err)
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  short:   %s\n  long:    %s\n", cand.ShortTitle, cand.LongTitle)
+
+		if sessionsAutotitleWrite {
+			sess.GeneratedShortTitle = cand.ShortTitle
+			sess.GeneratedLongTitle = cand.LongTitle
+			sess.TitleSource = session.TitleSourceGenerated
+			sess.TitleGeneratedAt = time.Now().UTC()
+			if len(messages) > 0 {
+				sess.TitleBasisMsgSeq = messages[len(messages)-1].Sequence
+			}
+			if err := store.Update(ctx, sess); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "  save:    failed (%v)\n\n", err)
+				continue
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "  save:    ok")
+			generated++
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+
+	if sessionsAutotitleWrite {
+		fmt.Fprintf(cmd.OutOrStdout(), "Saved titles for %d sessions.\n", generated)
+	}
+	return nil
+}

--- a/internal/session/export.go
+++ b/internal/session/export.go
@@ -26,7 +26,7 @@ func ExportToMarkdown(sess *Session, messages []Message, opts ExportOptions) str
 	var b strings.Builder
 
 	// Title
-	title := sess.Name
+	title := sess.PreferredShortTitle()
 	if title == "" {
 		title = ShortID(sess.ID)
 	}

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -17,6 +17,7 @@ import (
 type SQLiteStore struct {
 	db                  *sql.DB
 	cfg                 Config
+	hasGeneratedTitles  bool // true if sessions table has generated title columns
 	hasCompactionSeq    bool // true if sessions table has compaction_seq column
 	hasCacheWriteTokens bool // true if sessions table has cache_write_tokens column
 }
@@ -28,6 +29,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     number INTEGER,
     name TEXT,
     summary TEXT,
+    generated_short_title TEXT,
+    generated_long_title TEXT,
+    title_source TEXT,
+    title_generated_at TIMESTAMP,
+    title_basis_msg_seq INTEGER DEFAULT 0,
     provider TEXT NOT NULL,
     provider_key TEXT,
     model TEXT NOT NULL,
@@ -143,6 +149,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 
 	// Probe for optional columns. Read-write mode always has them after
 	// migration, but read-only mode skips migrations and may open an older DB.
+	store.hasGeneratedTitles = store.probeColumn("generated_short_title")
 	store.hasCompactionSeq = store.probeColumn("compaction_seq")
 	store.hasCacheWriteTokens = store.probeColumn("cache_write_tokens")
 
@@ -161,7 +168,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 11
+const schemaVersion = 12
 
 // migration represents a schema migration.
 type migration struct {
@@ -442,6 +449,28 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		// Migration 12: Add generated session title fields for autotitling experiments.
+		version:     12,
+		description: "add generated title columns",
+		up: func(db *sql.DB) error {
+			alterStatements := []string{
+				"ALTER TABLE sessions ADD COLUMN generated_short_title TEXT",
+				"ALTER TABLE sessions ADD COLUMN generated_long_title TEXT",
+				"ALTER TABLE sessions ADD COLUMN title_source TEXT",
+				"ALTER TABLE sessions ADD COLUMN title_generated_at TIMESTAMP",
+				"ALTER TABLE sessions ADD COLUMN title_basis_msg_seq INTEGER DEFAULT 0",
+			}
+			for _, stmt := range alterStatements {
+				if _, err := db.Exec(stmt); err != nil {
+					if !isDuplicateColumnError(err) {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	},
 }
 
 // initSchema initializes the database schema and runs any pending migrations.
@@ -594,10 +623,12 @@ func (s *SQLiteStore) Create(ctx context.Context, sess *Session) error {
 		// next session number. This avoids race conditions where two concurrent
 		// Creates could read the same MAX(number).
 		result, err := s.db.ExecContext(ctx, `
-			INSERT INTO sessions (id, number, name, summary, provider, provider_key, model, mode, agent, cwd, created_at, updated_at, archived, parent_id, search, tools, mcp,
+			INSERT INTO sessions (id, number, name, summary, generated_short_title, generated_long_title, title_source, title_generated_at, title_basis_msg_seq,
+			                      provider, provider_key, model, mode, agent, cwd, created_at, updated_at, archived, parent_id, search, tools, mcp,
 			                      user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens, cache_write_tokens, output_tokens, status, tags)
-			VALUES (?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			sess.ID, sess.Name, sess.Summary, sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(sess.Agent), sess.CWD,
+			VALUES (?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			sess.ID, sess.Name, sess.Summary, nullString(sess.GeneratedShortTitle), nullString(sess.GeneratedLongTitle), nullString(string(sess.TitleSource)), nullTime(sess.TitleGeneratedAt), sess.TitleBasisMsgSeq,
+			sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(sess.Agent), sess.CWD,
 			sess.CreatedAt, sess.UpdatedAt, sess.Archived, nullString(sess.ParentID),
 			sess.Search, nullString(sess.Tools), nullString(sess.MCP),
 			sess.UserTurns, sess.LLMTurns, sess.ToolCalls, sess.InputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.OutputTokens,
@@ -629,14 +660,14 @@ func (s *SQLiteStore) Create(ctx context.Context, sess *Session) error {
 func (s *SQLiteStore) Get(ctx context.Context, id string) (*Session, error) {
 	row := s.db.QueryRowContext(ctx,
 		"SELECT "+s.sessionSelectCols()+" FROM sessions WHERE id = ?", id)
-	return scanSessionRow(row, s.hasCacheWriteTokens, s.hasCompactionSeq)
+	return scanSessionRow(row, s.hasGeneratedTitles, s.hasCacheWriteTokens, s.hasCompactionSeq)
 }
 
 // GetByNumber retrieves a session by its sequential number.
 func (s *SQLiteStore) GetByNumber(ctx context.Context, number int64) (*Session, error) {
 	row := s.db.QueryRowContext(ctx,
 		"SELECT "+s.sessionSelectCols()+" FROM sessions WHERE number = ?", number)
-	return scanSessionRow(row, s.hasCacheWriteTokens, s.hasCompactionSeq)
+	return scanSessionRow(row, s.hasGeneratedTitles, s.hasCacheWriteTokens, s.hasCompactionSeq)
 }
 
 // GetByPrefix retrieves a session by number (with # prefix), exact ID, or by short ID prefix match.
@@ -683,7 +714,7 @@ func (s *SQLiteStore) GetByPrefix(ctx context.Context, prefix string) (*Session,
 	pattern := ExpandShortID(prefix)
 	row := s.db.QueryRowContext(ctx,
 		"SELECT "+s.sessionSelectCols()+" FROM sessions WHERE id LIKE ? ORDER BY created_at DESC LIMIT 1", pattern)
-	return scanSessionRow(row, s.hasCacheWriteTokens, s.hasCompactionSeq)
+	return scanSessionRow(row, s.hasGeneratedTitles, s.hasCacheWriteTokens, s.hasCompactionSeq)
 }
 
 // Update modifies an existing session's metadata fields.
@@ -694,11 +725,13 @@ func (s *SQLiteStore) GetByPrefix(ctx context.Context, prefix string) (*Session,
 func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	sess.UpdatedAt = time.Now()
 	result, err := s.db.ExecContext(ctx, `
-		UPDATE sessions SET name = ?, summary = ?, provider = ?, provider_key = ?, model = ?, mode = ?, agent = ?, cwd = ?,
+		UPDATE sessions SET name = ?, summary = ?, generated_short_title = ?, generated_long_title = ?, title_source = ?, title_generated_at = ?, title_basis_msg_seq = ?,
+		       provider = ?, provider_key = ?, model = ?, mode = ?, agent = ?, cwd = ?,
 		       updated_at = ?, archived = ?, parent_id = ?, search = ?, tools = ?, mcp = ?,
 		       user_turns = ?, status = ?, tags = ?
 		WHERE id = ?`,
-		sess.Name, sess.Summary, sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(sess.Agent), sess.CWD,
+		sess.Name, sess.Summary, nullString(sess.GeneratedShortTitle), nullString(sess.GeneratedLongTitle), nullString(string(sess.TitleSource)), nullTime(sess.TitleGeneratedAt), sess.TitleBasisMsgSeq,
+		sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(sess.Agent), sess.CWD,
 		sess.UpdatedAt, sess.Archived, nullString(sess.ParentID),
 		sess.Search, nullString(sess.Tools), nullString(sess.MCP),
 		sess.UserTurns, string(sess.Status), nullString(sess.Tags), sess.ID)
@@ -773,8 +806,17 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 	if s.hasCacheWriteTokens {
 		cacheWriteCol = "s.cache_write_tokens"
 	}
+	generatedShortCol := "''"
+	generatedLongCol := "''"
+	titleSourceCol := "''"
+	if s.hasGeneratedTitles {
+		generatedShortCol = "s.generated_short_title"
+		generatedLongCol = "s.generated_long_title"
+		titleSourceCol = "s.title_source"
+	}
 	query := `
-		SELECT s.id, s.number, s.name, s.summary, s.provider, s.model, s.mode, s.created_at, s.updated_at,
+		SELECT s.id, s.number, s.name, s.summary, ` + generatedShortCol + `, ` + generatedLongCol + `, ` + titleSourceCol + `,
+		       s.provider, s.model, s.mode, s.created_at, s.updated_at,
 		       (SELECT COUNT(*) FROM messages WHERE session_id = s.id) as message_count,
 		       s.user_turns, s.llm_turns, s.tool_calls, s.input_tokens, s.cached_input_tokens, ` + cacheWriteCol + `, s.output_tokens, s.status, s.tags
 		FROM sessions s
@@ -833,8 +875,8 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 	for rows.Next() {
 		var sum SessionSummary
 		var number sql.NullInt64
-		var mode, status, tags sql.NullString
-		err := rows.Scan(&sum.ID, &number, &sum.Name, &sum.Summary, &sum.Provider, &sum.Model, &mode,
+		var mode, status, tags, generatedShortTitle, generatedLongTitle, titleSource sql.NullString
+		err := rows.Scan(&sum.ID, &number, &sum.Name, &sum.Summary, &generatedShortTitle, &generatedLongTitle, &titleSource, &sum.Provider, &sum.Model, &mode,
 			&sum.CreatedAt, &sum.UpdatedAt, &sum.MessageCount,
 			&sum.UserTurns, &sum.LLMTurns, &sum.ToolCalls, &sum.InputTokens, &sum.CachedInputTokens, &sum.CacheWriteTokens, &sum.OutputTokens,
 			&status, &tags)
@@ -843,6 +885,15 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		}
 		if number.Valid {
 			sum.Number = number.Int64
+		}
+		if generatedShortTitle.Valid {
+			sum.GeneratedShortTitle = generatedShortTitle.String
+		}
+		if generatedLongTitle.Valid {
+			sum.GeneratedLongTitle = generatedLongTitle.String
+		}
+		if titleSource.Valid {
+			sum.TitleSource = SessionTitleSource(titleSource.String)
 		}
 		if mode.Valid {
 			sum.Mode = SessionMode(mode.String)
@@ -1258,8 +1309,13 @@ func (s *SQLiteStore) probeColumn(colName string) bool {
 // sessionSelectCols returns the SELECT column list for session queries.
 // Excludes compaction_seq when the column doesn't exist (old DB in read-only mode).
 func (s *SQLiteStore) sessionSelectCols() string {
-	base := `id, number, name, summary, provider, provider_key, model, mode, agent, cwd, created_at, updated_at, archived, parent_id, search, tools, mcp,
-		       user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens`
+	base := `id, number, name, summary`
+	if s.hasGeneratedTitles {
+		base += ", generated_short_title, generated_long_title, title_source, title_generated_at, title_basis_msg_seq"
+	}
+	base += `,
+	       provider, provider_key, model, mode, agent, cwd, created_at, updated_at, archived, parent_id, search, tools, mcp,
+	       user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens`
 	if s.hasCacheWriteTokens {
 		base += ", cache_write_tokens"
 	}
@@ -1272,15 +1328,21 @@ func (s *SQLiteStore) sessionSelectCols() string {
 
 // scanSessionRow scans a session row into a Session struct. The flags
 // determine which optional columns are present in the result set.
-func scanSessionRow(row *sql.Row, hasCacheWriteTokens, hasCompactionSeq bool) (*Session, error) {
+func scanSessionRow(row *sql.Row, hasGeneratedTitles, hasCacheWriteTokens, hasCompactionSeq bool) (*Session, error) {
 	var sess Session
 	var number sql.NullInt64
 	var name, summary, cwd sql.NullString
+	var generatedShortTitle, generatedLongTitle, titleSource sql.NullString
+	var titleGeneratedAt sql.NullTime
 	var mode, agent, parentID, tools, mcp, status, tags, providerKey sql.NullString
 
 	var scanArgs []any
+	scanArgs = append(scanArgs, &sess.ID, &number, &name, &summary)
+	if hasGeneratedTitles {
+		scanArgs = append(scanArgs, &generatedShortTitle, &generatedLongTitle, &titleSource, &titleGeneratedAt, &sess.TitleBasisMsgSeq)
+	}
 	scanArgs = append(scanArgs,
-		&sess.ID, &number, &name, &summary, &sess.Provider, &providerKey, &sess.Model, &mode,
+		&sess.Provider, &providerKey, &sess.Model, &mode,
 		&agent, &cwd, &sess.CreatedAt, &sess.UpdatedAt, &sess.Archived, &parentID,
 		&sess.Search, &tools, &mcp,
 		&sess.UserTurns, &sess.LLMTurns, &sess.ToolCalls, &sess.InputTokens, &sess.CachedInputTokens,
@@ -1313,6 +1375,20 @@ func scanSessionRow(row *sql.Row, hasCacheWriteTokens, hasCompactionSeq bool) (*
 	}
 	if summary.Valid {
 		sess.Summary = summary.String
+	}
+	if hasGeneratedTitles {
+		if generatedShortTitle.Valid {
+			sess.GeneratedShortTitle = generatedShortTitle.String
+		}
+		if generatedLongTitle.Valid {
+			sess.GeneratedLongTitle = generatedLongTitle.String
+		}
+		if titleSource.Valid {
+			sess.TitleSource = SessionTitleSource(titleSource.String)
+		}
+		if titleGeneratedAt.Valid {
+			sess.TitleGeneratedAt = titleGeneratedAt.Time
+		}
 	}
 	if cwd.Valid {
 		sess.CWD = cwd.String
@@ -1350,6 +1426,13 @@ func nullString(s string) sql.NullString {
 		return sql.NullString{}
 	}
 	return sql.NullString{String: s, Valid: true}
+}
+
+func nullTime(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
 }
 
 // isBusyError checks if an error is a SQLite BUSY error

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -9,6 +9,82 @@ import (
 	"time"
 )
 
+func TestSessionPreferredTitlePrecedence(t *testing.T) {
+	sess := Session{Summary: "first message summary", GeneratedShortTitle: "Generated short title", GeneratedLongTitle: "Generated long title"}
+	if got := sess.PreferredShortTitle(); got != "Generated short title" {
+		t.Fatalf("PreferredShortTitle() = %q", got)
+	}
+	if got := sess.PreferredLongTitle(); got != "Generated long title" {
+		t.Fatalf("PreferredLongTitle() = %q", got)
+	}
+	sess.Name = "Custom name"
+	if got := sess.PreferredShortTitle(); got != "Custom name" {
+		t.Fatalf("PreferredShortTitle() with name = %q", got)
+	}
+	if got := sess.PreferredLongTitle(); got != "Custom name" {
+		t.Fatalf("PreferredLongTitle() with name = %q", got)
+	}
+}
+
+func TestSQLiteStoreGeneratedTitleRoundTrip(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	sess := &Session{
+		ID:                  NewID(),
+		Provider:            "test",
+		Model:               "test-model",
+		Mode:                ModeChat,
+		Summary:             "very long first prompt",
+		GeneratedShortTitle: "Fixing weird docs homepage",
+		GeneratedLongTitle:  "Cleaning docs homepage and removing confusing front-page sections",
+		TitleSource:         TitleSourceGenerated,
+		TitleGeneratedAt:    now,
+		TitleBasisMsgSeq:    7,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	loaded, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if loaded.GeneratedShortTitle != sess.GeneratedShortTitle {
+		t.Fatalf("GeneratedShortTitle = %q", loaded.GeneratedShortTitle)
+	}
+	if loaded.GeneratedLongTitle != sess.GeneratedLongTitle {
+		t.Fatalf("GeneratedLongTitle = %q", loaded.GeneratedLongTitle)
+	}
+	if loaded.TitleSource != TitleSourceGenerated {
+		t.Fatalf("TitleSource = %q", loaded.TitleSource)
+	}
+	if loaded.TitleBasisMsgSeq != 7 {
+		t.Fatalf("TitleBasisMsgSeq = %d", loaded.TitleBasisMsgSeq)
+	}
+	if loaded.TitleGeneratedAt.IsZero() {
+		t.Fatal("TitleGeneratedAt should be set")
+	}
+
+	summaries, err := store.List(ctx, ListOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	if summaries[0].PreferredShortTitle() != sess.GeneratedShortTitle {
+		t.Fatalf("PreferredShortTitle() = %q", summaries[0].PreferredShortTitle())
+	}
+}
+
 func TestSQLiteStoreUpdateMetricsIncludesCachedTokens(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -28,12 +28,27 @@ const (
 	ModeExec SessionMode = "exec" // Command suggestion/execution
 )
 
+type SessionTitleSource string
+
+const (
+	TitleSourceNone      SessionTitleSource = ""
+	TitleSourceUser      SessionTitleSource = "user"
+	TitleSourceGenerated SessionTitleSource = "generated"
+)
+
 // Session represents a chat session stored in the database.
 type Session struct {
-	ID          string      `json:"id"`
-	Number      int64       `json:"number,omitempty"` // Sequential session number (1, 2, 3...)
-	Name        string      `json:"name,omitempty"`
-	Summary     string      `json:"summary,omitempty"`      // First user message or auto-generated
+	ID      string `json:"id"`
+	Number  int64  `json:"number,omitempty"` // Sequential session number (1, 2, 3...)
+	Name    string `json:"name,omitempty"`
+	Summary string `json:"summary,omitempty"` // First user message or auto-generated
+
+	GeneratedShortTitle string             `json:"generated_short_title,omitempty"`
+	GeneratedLongTitle  string             `json:"generated_long_title,omitempty"`
+	TitleSource         SessionTitleSource `json:"title_source,omitempty"`
+	TitleGeneratedAt    time.Time          `json:"title_generated_at,omitempty"`
+	TitleBasisMsgSeq    int                `json:"title_basis_msg_seq,omitempty"`
+
 	Provider    string      `json:"provider"`               // Provider display label
 	ProviderKey string      `json:"provider_key,omitempty"` // Canonical provider key (e.g. openai, chatgpt, custom alias)
 	Model       string      `json:"model"`
@@ -80,25 +95,28 @@ type Message struct {
 
 // SessionSummary is a lightweight view of a session for listing.
 type SessionSummary struct {
-	ID                string        `json:"id"`
-	Number            int64         `json:"number,omitempty"` // Sequential session number
-	Name              string        `json:"name,omitempty"`
-	Summary           string        `json:"summary,omitempty"`
-	Provider          string        `json:"provider"`
-	Model             string        `json:"model"`
-	Mode              SessionMode   `json:"mode,omitempty"`
-	MessageCount      int           `json:"message_count"`
-	UserTurns         int           `json:"user_turns,omitempty"`
-	LLMTurns          int           `json:"llm_turns,omitempty"`
-	ToolCalls         int           `json:"tool_calls,omitempty"`
-	InputTokens       int           `json:"input_tokens,omitempty"`
-	CachedInputTokens int           `json:"cached_input_tokens,omitempty"`
-	CacheWriteTokens  int           `json:"cache_write_tokens,omitempty"`
-	OutputTokens      int           `json:"output_tokens,omitempty"`
-	Status            SessionStatus `json:"status,omitempty"`
-	Tags              string        `json:"tags,omitempty"`
-	CreatedAt         time.Time     `json:"created_at"`
-	UpdatedAt         time.Time     `json:"updated_at"`
+	ID                  string             `json:"id"`
+	Number              int64              `json:"number,omitempty"` // Sequential session number
+	Name                string             `json:"name,omitempty"`
+	Summary             string             `json:"summary,omitempty"`
+	GeneratedShortTitle string             `json:"generated_short_title,omitempty"`
+	GeneratedLongTitle  string             `json:"generated_long_title,omitempty"`
+	TitleSource         SessionTitleSource `json:"title_source,omitempty"`
+	Provider            string             `json:"provider"`
+	Model               string             `json:"model"`
+	Mode                SessionMode        `json:"mode,omitempty"`
+	MessageCount        int                `json:"message_count"`
+	UserTurns           int                `json:"user_turns,omitempty"`
+	LLMTurns            int                `json:"llm_turns,omitempty"`
+	ToolCalls           int                `json:"tool_calls,omitempty"`
+	InputTokens         int                `json:"input_tokens,omitempty"`
+	CachedInputTokens   int                `json:"cached_input_tokens,omitempty"`
+	CacheWriteTokens    int                `json:"cache_write_tokens,omitempty"`
+	OutputTokens        int                `json:"output_tokens,omitempty"`
+	Status              SessionStatus      `json:"status,omitempty"`
+	Tags                string             `json:"tags,omitempty"`
+	CreatedAt           time.Time          `json:"created_at"`
+	UpdatedAt           time.Time          `json:"updated_at"`
 }
 
 // ListOptions configures session listing.
@@ -178,6 +196,56 @@ func (m *Message) SetPartsFromJSON(data string) error {
 		return nil
 	}
 	return json.Unmarshal([]byte(data), &m.Parts)
+}
+
+// PreferredShortTitle returns the best short title available for the session.
+func (s Session) PreferredShortTitle() string {
+	if strings.TrimSpace(s.Name) != "" {
+		return strings.TrimSpace(s.Name)
+	}
+	if strings.TrimSpace(s.GeneratedShortTitle) != "" {
+		return strings.TrimSpace(s.GeneratedShortTitle)
+	}
+	return strings.TrimSpace(s.Summary)
+}
+
+// PreferredLongTitle returns the best long descriptive title available for the session.
+func (s Session) PreferredLongTitle() string {
+	if strings.TrimSpace(s.Name) != "" {
+		return strings.TrimSpace(s.Name)
+	}
+	if strings.TrimSpace(s.GeneratedLongTitle) != "" {
+		return strings.TrimSpace(s.GeneratedLongTitle)
+	}
+	if strings.TrimSpace(s.GeneratedShortTitle) != "" {
+		return strings.TrimSpace(s.GeneratedShortTitle)
+	}
+	return strings.TrimSpace(s.Summary)
+}
+
+// PreferredShortTitle returns the best short title available for the summary.
+func (s SessionSummary) PreferredShortTitle() string {
+	if strings.TrimSpace(s.Name) != "" {
+		return strings.TrimSpace(s.Name)
+	}
+	if strings.TrimSpace(s.GeneratedShortTitle) != "" {
+		return strings.TrimSpace(s.GeneratedShortTitle)
+	}
+	return strings.TrimSpace(s.Summary)
+}
+
+// PreferredLongTitle returns the best long descriptive title available for the summary.
+func (s SessionSummary) PreferredLongTitle() string {
+	if strings.TrimSpace(s.Name) != "" {
+		return strings.TrimSpace(s.Name)
+	}
+	if strings.TrimSpace(s.GeneratedLongTitle) != "" {
+		return strings.TrimSpace(s.GeneratedLongTitle)
+	}
+	if strings.TrimSpace(s.GeneratedShortTitle) != "" {
+		return strings.TrimSpace(s.GeneratedShortTitle)
+	}
+	return strings.TrimSpace(s.Summary)
 }
 
 // TruncateSummary returns the first line of content, truncated to 100 chars.

--- a/internal/sessiontitle/generator.go
+++ b/internal/sessiontitle/generator.go
@@ -1,0 +1,279 @@
+package sessiontitle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type Candidate struct {
+	ShortTitle string  `json:"short_title"`
+	LongTitle  string  `json:"long_title"`
+	Confidence float64 `json:"confidence"`
+}
+
+func Generate(ctx context.Context, provider llm.Provider, sess *session.Session, messages []session.Message) (Candidate, error) {
+	if provider == nil {
+		return Candidate{}, fmt.Errorf("provider is nil")
+	}
+	if sess == nil {
+		return Candidate{}, fmt.Errorf("session is nil")
+	}
+
+	slice := BuildConversationSlice(messages)
+	if strings.TrimSpace(slice) == "" {
+		return Candidate{}, fmt.Errorf("no usable conversation text")
+	}
+
+	prompt := fmt.Sprintf(`Produce two session titles from this conversation slice.
+
+Rules:
+- short_title: 3 to 6 words
+- long_title: 8 to 14 words
+- be specific, concrete, and friendly
+- prefer the main task, decision, or topic
+- do not use filler like "Help with", "Discussion about", or "Question about"
+- do not mention "session", "chat", or "conversation"
+- if the content is too trivial or unclear, return null for both titles and 0 confidence
+- return JSON only
+
+JSON schema:
+{"short_title":"string|null","long_title":"string|null","confidence":0.0}
+
+Conversation slice:
+%s`, slice)
+
+	text, err := completeText(ctx, provider, prompt, 10*time.Second)
+	if err != nil {
+		return Candidate{}, err
+	}
+	cand, err := ParseCandidate(text)
+	if err != nil {
+		return Candidate{}, err
+	}
+	if !Acceptable(cand) {
+		return Candidate{}, fmt.Errorf("generated titles rejected")
+	}
+	return cand, nil
+}
+
+func BuildConversationSlice(messages []session.Message) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	var lines []string
+	userWords := 0
+	assistantWords := 0
+
+	appendMsg := func(m session.Message) bool {
+		text := cleanMessageText(m.TextContent)
+		if text == "" {
+			return false
+		}
+		words := len(strings.Fields(text))
+		switch m.Role {
+		case llm.RoleUser:
+			if userWords >= 500 {
+				return false
+			}
+			if userWords+words > 500 {
+				text = truncateWords(text, 500-userWords)
+				words = len(strings.Fields(text))
+			}
+			userWords += words
+			lines = append(lines, "User: "+text)
+			return true
+		case llm.RoleAssistant:
+			if assistantWords >= 200 {
+				return false
+			}
+			if assistantWords+words > 200 {
+				text = truncateWords(text, 200-assistantWords)
+				words = len(strings.Fields(text))
+			}
+			assistantWords += words
+			lines = append(lines, "Assistant: "+text)
+			return true
+		default:
+			return false
+		}
+	}
+
+	selected := 0
+	userCount := 0
+	assistantCount := 0
+	for _, m := range messages {
+		if m.Role == llm.RoleUser && userCount < 3 {
+			if appendMsg(m) {
+				selected++
+				userCount++
+			}
+			continue
+		}
+		if m.Role == llm.RoleAssistant && assistantCount < 2 && selected > 0 {
+			if appendMsg(m) {
+				assistantCount++
+			}
+		}
+		if userCount >= 3 && assistantCount >= 2 {
+			break
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func ParseCandidate(raw string) (Candidate, error) {
+	cleaned := strings.TrimSpace(raw)
+	cleaned = strings.TrimPrefix(cleaned, "```json")
+	cleaned = strings.TrimPrefix(cleaned, "```")
+	cleaned = strings.TrimSuffix(cleaned, "```")
+	cleaned = strings.TrimSpace(cleaned)
+	if idx := strings.Index(cleaned, "{"); idx >= 0 {
+		cleaned = cleaned[idx:]
+	}
+	if idx := strings.LastIndex(cleaned, "}"); idx >= 0 {
+		cleaned = cleaned[:idx+1]
+	}
+	var payload struct {
+		ShortTitle *string `json:"short_title"`
+		LongTitle  *string `json:"long_title"`
+		Confidence float64 `json:"confidence"`
+	}
+	if err := json.Unmarshal([]byte(cleaned), &payload); err != nil {
+		return Candidate{}, fmt.Errorf("parse title json: %w", err)
+	}
+	cand := Candidate{Confidence: payload.Confidence}
+	if payload.ShortTitle != nil {
+		cand.ShortTitle = normalizeTitle(*payload.ShortTitle)
+	}
+	if payload.LongTitle != nil {
+		cand.LongTitle = normalizeTitle(*payload.LongTitle)
+	}
+	return cand, nil
+}
+
+func Acceptable(c Candidate) bool {
+	if strings.TrimSpace(c.ShortTitle) == "" || strings.TrimSpace(c.LongTitle) == "" {
+		return false
+	}
+	if c.Confidence > 0 && c.Confidence < 0.45 {
+		return false
+	}
+	if n := wordCount(c.ShortTitle); n < 3 || n > 6 {
+		return false
+	}
+	if n := wordCount(c.LongTitle); n < 8 || n > 14 {
+		return false
+	}
+	if isGenericTitle(c.ShortTitle) || isGenericTitle(c.LongTitle) {
+		return false
+	}
+	return true
+}
+
+func completeText(ctx context.Context, provider llm.Provider, prompt string, timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	stream, err := provider.Stream(ctx, llm.Request{
+		Messages: []llm.Message{
+			llm.SystemText("You generate concise, specific titles and reply exactly as requested."),
+			llm.UserText(prompt),
+		},
+		MaxTurns: 1,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+	var b strings.Builder
+	for {
+		ev, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		switch ev.Type {
+		case llm.EventTextDelta:
+			b.WriteString(ev.Text)
+		case llm.EventError:
+			if ev.Err != nil {
+				return "", ev.Err
+			}
+			return "", fmt.Errorf("provider returned error event")
+		}
+	}
+	return b.String(), nil
+}
+
+func cleanMessageText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	fileWrapper := regexp.MustCompile(`<<<<< FILE:[^>]+>>>>>`)
+	s = fileWrapper.ReplaceAllString(s, "")
+	s = strings.Join(strings.Fields(s), " ")
+	return strings.TrimSpace(s)
+}
+
+func truncateWords(s string, maxWords int) string {
+	if maxWords <= 0 {
+		return ""
+	}
+	fields := strings.Fields(s)
+	if len(fields) <= maxWords {
+		return s
+	}
+	return strings.Join(fields[:maxWords], " ")
+}
+
+func normalizeTitle(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `"'`)
+	s = strings.TrimRightFunc(s, func(r rune) bool {
+		return unicode.IsPunct(r) && r != '&' && r != '/'
+	})
+	s = strings.Join(strings.Fields(s), " ")
+	return s
+}
+
+func wordCount(s string) int {
+	return len(strings.Fields(strings.TrimSpace(s)))
+}
+
+func isGenericTitle(s string) bool {
+	norm := strings.ToLower(strings.TrimSpace(s))
+	generic := []string{
+		"general discussion",
+		"brainstorming ideas",
+		"technical help",
+		"follow-up question",
+		"help with",
+		"discussion about",
+		"question about",
+		"work on term-llm task",
+		"fix web issue",
+		"making it better",
+		"fixing this issue",
+	}
+	for _, g := range generic {
+		if norm == g || strings.HasPrefix(norm, g+" ") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sessiontitle/generator_test.go
+++ b/internal/sessiontitle/generator_test.go
@@ -1,0 +1,54 @@
+package sessiontitle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestParseCandidate(t *testing.T) {
+	raw := "```json\n{\"short_title\":\"Fix cross-session bleed\",\"long_title\":\"Repairing web UI session switching and resume correctness\",\"confidence\":0.82}\n```"
+	cand, err := ParseCandidate(raw)
+	if err != nil {
+		t.Fatalf("ParseCandidate: %v", err)
+	}
+	if cand.ShortTitle != "Fix cross-session bleed" {
+		t.Fatalf("ShortTitle = %q", cand.ShortTitle)
+	}
+	if cand.LongTitle != "Repairing web UI session switching and resume correctness" {
+		t.Fatalf("LongTitle = %q", cand.LongTitle)
+	}
+	if !Acceptable(cand) {
+		t.Fatal("candidate should be acceptable")
+	}
+}
+
+func TestBuildConversationSlice(t *testing.T) {
+	messages := []session.Message{
+		{Role: llm.RoleUser, TextContent: "<<<<< FILE: /tmp/task.txt >>>>> Work in the term-llm worktree and redesign the resume browser to use full width and show more context."},
+		{Role: llm.RoleAssistant, TextContent: "I'll inspect the existing implementation and propose a cleaner browsing experience."},
+		{Role: llm.RoleUser, TextContent: "It should feel delightful and not like a cramped dialog."},
+	}
+	slice := BuildConversationSlice(messages)
+	if slice == "" {
+		t.Fatal("BuildConversationSlice returned empty string")
+	}
+	if want := "User: Work in the term-llm worktree"; slice[:len(want)] != want {
+		t.Fatalf("unexpected slice prefix: %q", slice)
+	}
+}
+
+func TestGenerateUsesProvider(t *testing.T) {
+	provider := llm.NewMockProvider("fast").AddTextResponse(`{"short_title":"Delightful resume browser redesign","long_title":"Redesigning chat TUI resume flow into a real session browser","confidence":0.91}`)
+	sess := &session.Session{Summary: "resume command in chat tui is ugly"}
+	messages := []session.Message{{Role: llm.RoleUser, TextContent: "resume command in chat tui is ugly and cramped"}}
+	cand, err := Generate(context.Background(), provider, sess, messages)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if cand.ShortTitle != "Delightful resume browser redesign" {
+		t.Fatalf("ShortTitle = %q", cand.ShortTitle)
+	}
+}


### PR DESCRIPTION
## What

Adds the first cut of session title generation scaffolding:

- persists generated session title metadata in `sessions.db`
- adds `PreferredShortTitle` / `PreferredLongTitle` helpers with precedence of user `name` first, then generated titles, then summary
- updates session list/show/export paths to surface the preferred title
- adds `term-llm sessions autotitle` to preview or persist generated titles for recent sessions using the configured fast model
- adds a small `internal/sessiontitle` package for prompt construction, response parsing, and basic title quality checks

The generator is explicitly shaped around two title lengths:

- short title: **3-6 words**
- long title: **8-14 words**

## Why

Right now session history is mostly blank names or raw first-message summaries. This PR gives us a cheap way to see what generated titles would look like before wiring a full automatic background job.

It also avoids painting us into a corner by separating:

- explicit user names
- generated short/long titles
- title source metadata

## Validation

- `go test ./...`
- `go run . sessions autotitle --limit 5`
