### PR TITLE
fix(transcribe): reject implausibly long transcripts for short audio

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,11 +20,12 @@ import (
 )
 
 var (
-	transcribeLanguage  string
-	transcribePorcelain bool
-	transcribeProvider  string
+	transcribeLanguage       string
+	transcribePorcelain      bool
+	transcribeProvider       string
 	transcribeCLIOutputLimit int64         = 1 << 20
 	transcribeCLIWaitDelay   time.Duration = time.Second
+	transcribeValidator                    = llm.ValidateTranscriptPlausibility
 )
 
 var transcribeCmd = &cobra.Command{
@@ -64,12 +66,19 @@ func transcribeWhisperCLI(ctx context.Context, cfg *config.Config, filePath, lan
 		return "", fmt.Errorf("no whisper model found; set WHISPER_MODEL or providers.local_whisper.model in config")
 	}
 
-	args := []string{"-m", modelPath, "-f", filePath, "--print-special", "false", "-np"}
+	workDir, inputPath, cleanupInput, err := prepareWhisperCLIInput(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer cleanupInput()
+
+	args := []string{"-m", modelPath, "-f", inputPath, "--print-special", "false", "-np", "-otxt"}
 	if language != "" {
 		args = append(args, "--language", language)
 	}
 
 	cmd := exec.CommandContext(ctx, whisperBin, args...)
+	cmd.Dir = workDir
 	cmd.WaitDelay = transcribeCLIWaitDelay
 	cleanup, prepErr := procutil.PrepareCommand(cmd)
 	if prepErr != nil {
@@ -99,15 +108,74 @@ func transcribeWhisperCLI(ctx context.Context, cfg *config.Config, filePath, lan
 		return "", fmt.Errorf("whisper-cli: %w", err)
 	}
 
+	transcriptPath := inputPath + ".txt"
+	transcriptBytes, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		return "", fmt.Errorf("whisper-cli: read transcript %s: %w", filepath.Base(transcriptPath), err)
+	}
+
 	re := regexp.MustCompile(`^\[[\d:.,\s>-]+\]\s*`)
 	var lines []string
-	for _, line := range strings.Split(stdout.String(), "\n") {
+	for _, line := range strings.Split(string(transcriptBytes), "\n") {
 		line = re.ReplaceAllString(strings.TrimSpace(line), "")
 		if line != "" {
 			lines = append(lines, line)
 		}
 	}
-	return strings.Join(lines, " "), nil
+	transcript := strings.Join(lines, " ")
+	if err := transcribeValidator(ctx, filePath, transcript); err != nil {
+		return "", err
+	}
+	return transcript, nil
+}
+
+func prepareWhisperCLIInput(filePath string) (workDir string, inputPath string, cleanup func(), err error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("resolve audio file path: %w", err)
+	}
+
+	workDir, err = os.MkdirTemp("", "term-llm-whisper-cli-*")
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create whisper temp dir: %w", err)
+	}
+	cleanup = func() {
+		_ = os.RemoveAll(workDir)
+	}
+
+	inputPath = filepath.Join(workDir, filepath.Base(absPath))
+	if err := os.Symlink(absPath, inputPath); err == nil {
+		return workDir, inputPath, cleanup, nil
+	}
+	if err := copyFile(absPath, inputPath); err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("prepare whisper input: %w", err)
+	}
+	return workDir, inputPath, cleanup, nil
+}
+
+func copyFile(srcPath, dstPath string) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", srcPath, err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dstPath, err)
+	}
+	defer func() {
+		_ = dst.Close()
+	}()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("copy %s to %s: %w", srcPath, dstPath, err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", dstPath, err)
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/transcribe_test.go
+++ b/cmd/transcribe_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 func writeWhisperScript(t *testing.T, body string) string {
@@ -16,15 +17,80 @@ func writeWhisperScript(t *testing.T, body string) string {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "whisper")
-	script := "#!/bin/sh\n" + body + "\n"
+	script := "#!/bin/sh\nset -eu\n" + body + "\n"
 	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	return dir
 }
 
-func TestTranscribeWhisperCLI_RejectsOversizedOutput(t *testing.T) {
-	scriptDir := writeWhisperScript(t, `head -c 1100000 /dev/zero | tr '\000' x`)
+func TestTranscribeWhisperCLI_RejectsImplausiblyLongTranscript(t *testing.T) {
+	scriptDir := writeWhisperScript(t, `
+file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f)
+      file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "$file" ]; then
+  echo "missing -f" >&2
+  exit 1
+fi
+head -c 1100000 /dev/zero | tr '\000' x > "$file.txt"
+`)
+
+	origValidator := transcribeValidator
+	defer func() {
+		transcribeValidator = origValidator
+	}()
+	transcribeValidator = func(context.Context, string, string) error {
+		return llm.ValidateTranscriptPlausibilityForDuration(time.Minute, strings.TrimSpace(strings.Repeat("word ", 351)))
+	}
+
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("WHISPER_MODEL", "/tmp/fake-model.bin")
+
+	audioPath := filepath.Join(t.TempDir(), "sample.wav")
+	if err := os.WriteFile(audioPath, []byte("fake-audio"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	_, err := transcribeWhisperCLI(context.Background(), &config.Config{}, audioPath, "")
+	if err == nil {
+		t.Fatal("expected transcribeWhisperCLI to fail")
+	}
+	if !strings.Contains(err.Error(), "implausibly long") {
+		t.Fatalf("error = %q, want contains %q", err.Error(), "implausibly long")
+	}
+}
+
+func TestTranscribeWhisperCLI_RejectsOversizedLogs(t *testing.T) {
+	scriptDir := writeWhisperScript(t, `
+file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f)
+      file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "$file" ]; then
+  echo "missing -f" >&2
+  exit 1
+fi
+printf 'ok' > "$file.txt"
+head -c 1100000 /dev/zero | tr '\000' x
+`)
 
 	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("WHISPER_MODEL", "/tmp/fake-model.bin")

--- a/internal/llm/transcribe.go
+++ b/internal/llm/transcribe.go
@@ -27,6 +27,9 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 
 	modelOverride := cfg.Transcription.Model
 
+	var transcript string
+	var err error
+
 	switch providerName {
 	case "local":
 		// whisper.cpp HTTP server — OpenAI-compatible endpoint, typically no auth required
@@ -40,7 +43,7 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 				endpoint = strings.TrimRight(baseURL, "/") + "/inference"
 			}
 		}
-		return TranscribeFile(ctx, filePath, TranscribeOptions{
+		transcript, err = TranscribeFile(ctx, filePath, TranscribeOptions{
 			Endpoint: endpoint,
 			Model:    modelOverride,
 			Language: language,
@@ -67,7 +70,7 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 		if model == "" {
 			model = "voxtral-mini-latest"
 		}
-		return TranscribeFile(ctx, filePath, TranscribeOptions{
+		transcript, err = TranscribeFile(ctx, filePath, TranscribeOptions{
 			APIKey:   apiKey,
 			Endpoint: endpoint,
 			Model:    model,
@@ -85,19 +88,20 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 			if baseURL != "" {
 				endpoint = strings.TrimRight(baseURL, "/") + "/audio/transcriptions"
 			}
-			return TranscribeFile(ctx, filePath, TranscribeOptions{
+			transcript, err = TranscribeFile(ctx, filePath, TranscribeOptions{
 				APIKey:   p.ResolvedAPIKey,
 				Endpoint: endpoint,
 				Model:    modelOverride,
 				Language: language,
 			})
+			break
 		}
 		// Fall back to environment variable
 		apiKey := os.Getenv("OPENAI_API_KEY")
 		if apiKey == "" {
 			return "", fmt.Errorf("transcription is not configured — set providers.openai.api_key or configure a transcription provider in config")
 		}
-		return TranscribeFile(ctx, filePath, TranscribeOptions{
+		transcript, err = TranscribeFile(ctx, filePath, TranscribeOptions{
 			APIKey:   apiKey,
 			Model:    modelOverride,
 			Language: language,
@@ -117,13 +121,21 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 			} else if p.BaseURL != "" {
 				endpoint = strings.TrimRight(p.BaseURL, "/") + "/audio/transcriptions"
 			}
-			return TranscribeFile(ctx, filePath, TranscribeOptions{
+			transcript, err = TranscribeFile(ctx, filePath, TranscribeOptions{
 				APIKey:   apiKey,
 				Endpoint: endpoint,
 				Model:    modelOverride,
 				Language: language,
 			})
+			break
 		}
 		return "", fmt.Errorf("transcription provider %q not found in providers config (supported builtins: openai, mistral, local, whisper-cli)", providerName)
 	}
+	if err != nil {
+		return "", err
+	}
+	if err := ValidateTranscriptPlausibility(ctx, filePath, transcript); err != nil {
+		return "", err
+	}
+	return transcript, nil
 }

--- a/internal/llm/transcribe_test.go
+++ b/internal/llm/transcribe_test.go
@@ -7,15 +7,21 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
 func TestTranscribeWithConfig_UsesResolvedURLForBuiltins(t *testing.T) {
 	origClient := defaultHTTPClient
+	origProbe := probeAudioDuration
 	defer func() {
 		defaultHTTPClient = origClient
+		probeAudioDuration = origProbe
 	}()
+	probeAudioDuration = func(context.Context, string) (time.Duration, error) {
+		return time.Minute, nil
+	}
 
 	audioFile, err := os.CreateTemp(t.TempDir(), "audio-*.wav")
 	if err != nil {
@@ -102,5 +108,51 @@ func TestTranscribeWithConfig_UsesResolvedURLForBuiltins(t *testing.T) {
 				t.Fatalf("request URL = %q, want %q", capturedURL, tt.wantURL)
 			}
 		})
+	}
+}
+
+func TestTranscribeWithConfig_RejectsImplausiblyLongTranscript(t *testing.T) {
+	origClient := defaultHTTPClient
+	origProbe := probeAudioDuration
+	defer func() {
+		defaultHTTPClient = origClient
+		probeAudioDuration = origProbe
+	}()
+	probeAudioDuration = func(context.Context, string) (time.Duration, error) {
+		return time.Minute, nil
+	}
+
+	audioFile, err := os.CreateTemp(t.TempDir(), "audio-*.wav")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	if _, err := audioFile.WriteString("not really audio"); err != nil {
+		t.Fatalf("write temp audio: %v", err)
+	}
+	if err := audioFile.Close(); err != nil {
+		t.Fatalf("close temp audio: %v", err)
+	}
+
+	transcript := strings.TrimSpace(strings.Repeat("word ", 351))
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"text":"` + transcript + `"}`)),
+			}, nil
+		}),
+	}
+
+	_, err = TranscribeWithConfig(context.Background(), &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"openai": {ResolvedAPIKey: "test-key"},
+		},
+	}, audioFile.Name(), "", "openai")
+	if err == nil {
+		t.Fatal("expected TranscribeWithConfig to fail")
+	}
+	if !strings.Contains(err.Error(), "implausibly long") {
+		t.Fatalf("error = %q, want contains %q", err.Error(), "implausibly long")
 	}
 }

--- a/internal/llm/transcript_sanity.go
+++ b/internal/llm/transcript_sanity.go
@@ -1,0 +1,60 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var probeAudioDuration = ffprobeAudioDuration
+
+const transcriptMaxWordsPerMinute = 350
+
+func ValidateTranscriptPlausibility(ctx context.Context, filePath, transcript string) error {
+	duration, err := probeAudioDuration(ctx, filePath)
+	if err != nil || duration <= 0 {
+		return nil
+	}
+	return ValidateTranscriptPlausibilityForDuration(duration, transcript)
+}
+
+func ValidateTranscriptPlausibilityForDuration(duration time.Duration, transcript string) error {
+	wordCount := len(strings.Fields(transcript))
+	maxWords := int(math.Ceil(duration.Minutes() * transcriptMaxWordsPerMinute))
+	if maxWords < 1 {
+		maxWords = 1
+	}
+	if wordCount <= maxWords {
+		return nil
+	}
+	seconds := int(math.Round(duration.Seconds()))
+	return fmt.Errorf("transcript implausibly long for %ds audio: got %d words, expected <= %d", seconds, wordCount, maxWords)
+}
+
+func ffprobeAudioDuration(ctx context.Context, filePath string) (time.Duration, error) {
+	ffprobeBin, err := exec.LookPath("ffprobe")
+	if err != nil {
+		return 0, err
+	}
+
+	cmd := exec.CommandContext(ctx, ffprobeBin,
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=nokey=1:noprint_wrappers=1",
+		filePath,
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, err
+	}
+
+	seconds, err := strconv.ParseFloat(strings.TrimSpace(string(output)), 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse ffprobe duration: %w", err)
+	}
+	return time.Duration(seconds * float64(time.Second)), nil
+}


### PR DESCRIPTION
## What

Fixes a transcription failure mode where short audio can produce transcripts that are far longer than a person could plausibly say.

This change adds a duration-based sanity check after transcription:

- probe the audio duration with `ffprobe`
- derive a generous hard cap of **350 words per minute**
- reject transcripts that exceed that bound with a clear error
- apply the check across provider-based transcription paths and the `whisper-cli` path

The `whisper-cli` path still keeps its existing log-size guard so runaway stdout/stderr output is treated separately from transcript length.

## Why

The bug was framed as generic output truncation, but that was the wrong invariant.

The real problem is that transcription can occasionally go off the rails and return hallucinated or repeated text that is physically impossible for the source audio duration. A 60-second recording should not come back with a transcript hundreds or thousands of words long.

Audio duration gives us a much better safety check than a raw byte limit.

## Tests

Added coverage for:

- built-in providers still using resolved URLs correctly under the new validation path
- provider transcripts being rejected when a 60-second clip returns more than 350 words
- `whisper-cli` transcripts being rejected when they exceed the same plausibility bound
- `whisper-cli` still failing on oversized logs independently of transcript validation

## Verification

```bash
gofmt -w cmd/transcribe.go cmd/transcribe_test.go internal/llm/transcribe.go internal/llm/transcribe_test.go internal/llm/transcript_sanity.go
go test ./cmd ./internal/llm
go build ./...
go test ./...
```