### PR TITLE
fix: retry Anthropic 500 streaming failures

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -199,6 +199,8 @@ func isRetryable(err error) bool {
 		strings.Contains(errStr, "rate limit") ||
 		strings.Contains(errStr, "too many requests") ||
 		strings.Contains(errStr, "high concurrency") ||
+		strings.Contains(errStr, "500") ||
+		strings.Contains(errStr, "internal server error") ||
 		strings.Contains(errStr, "502") ||
 		strings.Contains(errStr, "bad gateway") ||
 		strings.Contains(errStr, "503") ||
@@ -257,6 +259,5 @@ func (r *RetryProvider) calculateBackoff(attempt int, err error) time.Duration {
 	if delay > r.config.MaxBackoff {
 		delay = r.config.MaxBackoff
 	}
-
 	return delay
 }

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -29,6 +30,29 @@ func (p *retryStreamingProvider) Stream(ctx context.Context, req Request) (Strea
 	return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
 		ch <- Event{Type: EventTextDelta, Text: "hello"}
 		ch <- Event{Type: EventTextDelta, Text: " world"}
+		return nil
+	}), nil
+}
+
+type retryHTTP500Provider struct {
+	attempt int
+}
+
+func (p *retryHTTP500Provider) Name() string { return "retry-http-500" }
+
+func (p *retryHTTP500Provider) Credential() string { return "mock" }
+
+func (p *retryHTTP500Provider) Capabilities() Capabilities { return Capabilities{} }
+
+func (p *retryHTTP500Provider) Stream(ctx context.Context, req Request) (Stream, error) {
+	p.attempt++
+	if p.attempt == 1 {
+		return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
+			return errors.New("anthropic streaming error: POST \"https://api.anthropic.com/v1/messages\": 500 Internal Server Error")
+		}), nil
+	}
+	return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
+		ch <- Event{Type: EventTextDelta, Text: "ok"}
 		return nil
 	}), nil
 }
@@ -71,5 +95,50 @@ func TestRetryProvider_DropsPartialTextFromRetriedAttempt(t *testing.T) {
 	}
 	if text != "hello world" {
 		t.Fatalf("text = %q, want %q", text, "hello world")
+	}
+}
+
+func TestRetryProvider_RetriesStreamingHTTP500(t *testing.T) {
+	inner := &retryHTTP500Provider{}
+	provider := WrapWithRetry(inner, RetryConfig{
+		MaxAttempts: 2,
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  10 * time.Millisecond,
+	})
+
+	stream, err := provider.Stream(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	defer stream.Close()
+
+	var text string
+	retryEvents := 0
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv returned error: %v", err)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			text += event.Text
+		case EventRetry:
+			retryEvents++
+		case EventError:
+			t.Fatalf("unexpected final error event: %v", event.Err)
+		}
+	}
+
+	if retryEvents != 1 {
+		t.Fatalf("retryEvents = %d, want 1", retryEvents)
+	}
+	if inner.attempt != 2 {
+		t.Fatalf("attempts = %d, want 2", inner.attempt)
+	}
+	if text != "ok" {
+		t.Fatalf("text = %q, want %q", text, "ok")
 	}
 }


### PR DESCRIPTION
## What

- treat HTTP 500 / "Internal Server Error" failures as retryable in the shared LLM retry wrapper
- add a regression test covering an Anthropic-style streaming 500 that succeeds on retry

## Why

A live Anthropic session failed on a simple prompt with:

`anthropic streaming error: POST "https://api.anthropic.com/v1/messages": 500 Internal Server Error`

This is a transient upstream failure, but term-llm only retried 429/502/503-style errors. Because 500s were not classified as retryable, the request failed immediately instead of transparently retrying.

## How

- updated `internal/llm/retry.go` so `isRetryable` includes HTTP 500 / internal server errors
- added `TestRetryProvider_RetriesStreamingHTTP500` in `internal/llm/retry_test.go`
- verified with `go build ./...` and `go test ./...`
