### PR TITLE
fix: normalize retired anthropic model alias

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -61,6 +61,29 @@ func isAdaptiveModel(model string) bool {
 	return strings.HasPrefix(model, "claude-sonnet-4-6") || strings.HasPrefix(model, "claude-opus-4-6")
 }
 
+var anthropicLegacyModelAliases = map[string]string{
+	// Anthropic removed this legacy alias, causing 404s for older configs.
+	"claude-3-5-sonnet-latest": "claude-sonnet-4-6",
+}
+
+// normalizeAnthropicModel rewrites retired Anthropic aliases to supported model IDs
+// while preserving term-llm suffixes like -1m and -thinking.
+func normalizeAnthropicModel(model string) string {
+	suffix := ""
+	if strings.HasSuffix(model, "-thinking") {
+		model = strings.TrimSuffix(model, "-thinking")
+		suffix = "-thinking"
+	}
+	if strings.HasSuffix(model, "-1m") {
+		model = strings.TrimSuffix(model, "-1m")
+		suffix = "-1m" + suffix
+	}
+	if replacement, ok := anthropicLegacyModelAliases[model]; ok {
+		model = replacement
+	}
+	return model + suffix
+}
+
 // parseModelThinking extracts -thinking suffix from model name.
 // For 4.6 models, -thinking uses adaptive thinking (budget_tokens is deprecated).
 // For older models, -thinking uses budget_tokens as before.
@@ -117,6 +140,8 @@ func newOAuthClient(token string) anthropic.Client {
 //   - "oauth_env":  use only the CLAUDE_CODE_OAUTH_TOKEN environment variable
 //   - "oauth":      use only saved OAuth token or interactive setup
 func NewAnthropicProvider(apiKey, model, credentialMode string) (*AnthropicProvider, error) {
+	model = normalizeAnthropicModel(model)
+
 	// Strip -thinking first (may leave -1m), then strip -1m.
 	// This means claude-sonnet-4-6-1m-thinking works correctly:
 	//   step 1: strip -thinking -> "claude-sonnet-4-6-1m", adaptive=true
@@ -324,7 +349,9 @@ func (p *AnthropicProvider) Capabilities() Capabilities {
 }
 
 func (p *AnthropicProvider) Stream(ctx context.Context, req Request) (Stream, error) {
-	req.MaxOutputTokens = ClampOutputTokens(req.MaxOutputTokens, chooseModel(req.Model, p.model))
+	model := normalizeAnthropicModel(chooseModel(req.Model, p.model))
+	req.Model = model
+	req.MaxOutputTokens = ClampOutputTokens(req.MaxOutputTokens, model)
 	if req.Search {
 		return p.streamWithSearch(ctx, req)
 	}

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -111,6 +111,42 @@ func TestParseModelCombined1mThinking(t *testing.T) {
 	}
 }
 
+func TestNormalizeAnthropicModel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"claude-3-5-sonnet-latest", "claude-sonnet-4-6"},
+		{"claude-3-5-sonnet-latest-thinking", "claude-sonnet-4-6-thinking"},
+		{"claude-3-5-sonnet-latest-1m-thinking", "claude-sonnet-4-6-1m-thinking"},
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizeAnthropicModel(tt.input); got != tt.want {
+				t.Fatalf("normalizeAnthropicModel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAnthropicProviderNormalizesLegacyModelAlias(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	provider, err := NewAnthropicProvider("sk-test-key-123", "claude-3-5-sonnet-latest-thinking", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider.model != "claude-sonnet-4-6" {
+		t.Fatalf("model=%q, want %q", provider.model, "claude-sonnet-4-6")
+	}
+	if !provider.useAdaptive {
+		t.Fatal("expected legacy alias with -thinking to normalize to adaptive Claude 4.6 thinking")
+	}
+}
+
 func TestNewAnthropicProviderWithExplicitAPIKey(t *testing.T) {
 	// Clear env to isolate test
 	t.Setenv("ANTHROPIC_API_KEY", "")


### PR DESCRIPTION
## What

Normalize the retired Anthropic model alias `claude-3-5-sonnet-latest` to the supported `claude-sonnet-4-6` model before requests are sent.

## Why

Older term-llm configs can still contain `claude-3-5-sonnet-latest`. Anthropic now returns a 404 for that alias, which breaks chat sessions immediately.

## How

- added Anthropic model alias normalization that preserves `-thinking` and `-1m` suffixes
- applied normalization when constructing the Anthropic provider and when handling per-request model overrides
- added unit tests covering alias normalization and provider creation behavior
