### PR TITLE
feat: allow claude-bin provider env overrides

### DIFF
--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -251,12 +251,15 @@ default_provider: claude-bin
 providers:
   claude-bin:
     model: sonnet  # opus, sonnet, or haiku
+    env:
+      IS_SANDBOX: "1"  # useful when running term-llm as root in a trusted container
 ```
 
 **Features:**
 - No API key required - uses Claude Code's OAuth authentication
 - Full tool support via MCP (exec, search, edit all work)
 - Model selection: `opus`, `sonnet` (default), `haiku`
+- Optional `providers.claude-bin.env` passthrough for Claude subprocess settings (for example `IS_SANDBOX=1` in trusted root-run containers)
 - Works immediately if Claude Code is installed and logged in
 
 ### Option 10: Use existing CLI credentials (gemini-cli)

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -50,6 +50,11 @@ providers:
   xai:
     model: grok-4-1-fast
 
+  claude-bin:
+    model: opus
+    env:
+      IS_SANDBOX: "1"
+
   openrouter:
     model: x-ai/grok-code-fast-1
     app_url: https://github.com/samsaffron/term-llm
@@ -152,6 +157,22 @@ embed:
 ```
 
 Each feature block can hold provider-specific credentials and defaults. The image and embedding providers are independent of the main text provider.
+
+## Provider-specific environment overrides
+
+Providers that shell out to local CLIs can accept extra subprocess environment variables via `providers.<name>.env`.
+
+Example for Claude Code when term-llm itself runs as root inside a trusted container:
+
+```yaml
+providers:
+  claude-bin:
+    model: opus
+    env:
+      IS_SANDBOX: "1"
+```
+
+This is passed only to the Claude subprocess. It does not mutate your parent shell environment.
 
 ## Dynamic secrets and endpoints
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,12 +62,13 @@ type ProviderConfig struct {
 	Type ProviderType `mapstructure:"type"`
 
 	// Common fields
-	APIKey       string   `mapstructure:"api_key"`
-	Model        string   `mapstructure:"model"`
-	FastModel    string   `mapstructure:"fast_model"`    // Lightweight model for control-plane tasks
-	FastProvider string   `mapstructure:"fast_provider"` // Optional provider key override for FastModel
-	Models       []string `mapstructure:"models"`        // Available models for autocomplete
-	Credentials  string   `mapstructure:"credentials"`   // "api_key", "codex", "gemini-cli"
+	APIKey       string            `mapstructure:"api_key"`
+	Model        string            `mapstructure:"model"`
+	FastModel    string            `mapstructure:"fast_model"`    // Lightweight model for control-plane tasks
+	FastProvider string            `mapstructure:"fast_provider"` // Optional provider key override for FastModel
+	Models       []string          `mapstructure:"models"`        // Available models for autocomplete
+	Credentials  string            `mapstructure:"credentials"`   // "api_key", "codex", "gemini-cli"
+	Env          map[string]string `mapstructure:"env"`           // Extra subprocess env vars for providers that shell out (e.g. claude-bin)
 
 	// Search behavior - nil means auto (use native if available)
 	UseNativeSearch *bool `mapstructure:"use_native_search"`
@@ -1079,6 +1080,7 @@ var KnownProviderKeys = map[string]bool{
 	"fast_provider":     true,
 	"models":            true,
 	"credentials":       true,
+	"env":               true,
 	"use_native_search": true,
 	"base_url":          true,
 	"url":               true,
@@ -1188,7 +1190,7 @@ func IsKnownKey(keyPath string) bool {
 
 	// Check for providers.* pattern
 	if strings.HasPrefix(keyPath, "providers.") {
-		parts := strings.SplitN(keyPath, ".", 3)
+		parts := strings.Split(keyPath, ".")
 		if len(parts) == 2 {
 			// providers.<name> is always valid
 			return true
@@ -1196,6 +1198,10 @@ func IsKnownKey(keyPath string) bool {
 		if len(parts) == 3 {
 			// providers.<name>.<key> - check if <key> is valid
 			return KnownProviderKeys[parts[2]]
+		}
+		if len(parts) >= 4 && parts[2] == "env" {
+			// providers.<name>.env.<VAR> - arbitrary subprocess env vars
+			return true
 		}
 	}
 

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -33,7 +33,8 @@ type ClaudeBinProvider struct {
 	sessionID    string // For session continuity with --resume
 	messagesSent int    // Track messages already in session to avoid re-sending
 	toolExecutor mcphttp.ToolExecutor
-	preferOAuth  bool // If true, clear ANTHROPIC_API_KEY to force OAuth auth
+	preferOAuth  bool              // If true, clear ANTHROPIC_API_KEY to force OAuth auth
+	extraEnv     map[string]string // Extra subprocess env vars from provider config
 
 	// Persistent MCP server for multi-turn conversations.
 	// The server is kept alive across turns so Claude CLI can maintain
@@ -106,13 +107,20 @@ func parseClaudeEffort(model string) (string, string) {
 }
 
 // NewClaudeBinProvider creates a new provider that uses the claude binary.
-func NewClaudeBinProvider(model string) *ClaudeBinProvider {
+func NewClaudeBinProvider(model string, env map[string]string) *ClaudeBinProvider {
 	actualModel, effort := parseClaudeEffort(model)
-	return &ClaudeBinProvider{
+	provider := &ClaudeBinProvider{
 		model:       actualModel,
 		effort:      effort,
 		preferOAuth: true, // Default to OAuth to avoid API key limits
 	}
+	if len(env) > 0 {
+		provider.extraEnv = make(map[string]string, len(env))
+		for k, v := range env {
+			provider.extraEnv[k] = v
+		}
+	}
+	return provider
 }
 
 // SetPreferOAuth controls whether to prefer OAuth auth over API key.
@@ -120,6 +128,18 @@ func NewClaudeBinProvider(model string) *ClaudeBinProvider {
 // so Claude CLI uses OAuth subscription auth instead.
 func (p *ClaudeBinProvider) SetPreferOAuth(prefer bool) {
 	p.preferOAuth = prefer
+}
+
+// SetEnv configures extra environment variables for the Claude CLI subprocess.
+func (p *ClaudeBinProvider) SetEnv(env map[string]string) {
+	if len(env) == 0 {
+		p.extraEnv = nil
+		return
+	}
+	p.extraEnv = make(map[string]string, len(env))
+	for k, v := range env {
+		p.extraEnv[k] = v
+	}
 }
 
 // SetToolExecutor sets the function used to execute tools.
@@ -219,6 +239,42 @@ func (p *ClaudeBinProvider) Stream(ctx context.Context, req Request) (Stream, er
 	}), nil
 }
 
+func (p *ClaudeBinProvider) buildCommandEnv(effort string) []string {
+	env := os.Environ()
+	filtered := env[:0]
+	for _, e := range env {
+		if p.preferOAuth && strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
+			continue
+		}
+		if effort != "" && strings.HasPrefix(e, "CLAUDE_CODE_EFFORT_LEVEL=") {
+			continue
+		}
+		if len(p.extraEnv) > 0 {
+			key := e
+			if idx := strings.IndexByte(e, '='); idx >= 0 {
+				key = e[:idx]
+			}
+			if _, ok := p.extraEnv[key]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, e)
+	}
+	if effort != "" {
+		filtered = append(filtered, "CLAUDE_CODE_EFFORT_LEVEL="+effort)
+	}
+	for k, v := range p.extraEnv {
+		if p.preferOAuth && k == "ANTHROPIC_API_KEY" {
+			continue
+		}
+		if effort != "" && k == "CLAUDE_CODE_EFFORT_LEVEL" {
+			continue
+		}
+		filtered = append(filtered, k+"="+v)
+	}
+	return filtered
+}
+
 // runClaudeCommand executes the claude CLI binary with the given arguments and prompt,
 // parsing its streaming JSON output into events. Returns nil on success.
 func (p *ClaudeBinProvider) runClaudeCommand(
@@ -243,26 +299,7 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 	}
 
 	cmd := exec.CommandContext(ctx, "claude", args...)
-
-	// Set up environment - optionally clear ANTHROPIC_API_KEY to prefer OAuth,
-	// and set CLAUDE_CODE_EFFORT_LEVEL for reasoning effort control.
-	if p.preferOAuth || effort != "" {
-		env := os.Environ()
-		filtered := env[:0]
-		for _, e := range env {
-			if p.preferOAuth && strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
-				continue
-			}
-			if effort != "" && strings.HasPrefix(e, "CLAUDE_CODE_EFFORT_LEVEL=") {
-				continue
-			}
-			filtered = append(filtered, e)
-		}
-		if effort != "" {
-			filtered = append(filtered, "CLAUDE_CODE_EFFORT_LEVEL="+effort)
-		}
-		cmd.Env = filtered
-	}
+	cmd.Env = p.buildCommandEnv(effort)
 
 	// Set up stdin pipe for the prompt
 	stdin, err := cmd.StdinPipe()

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 )
 
 func TestClaudeBinProvider_ImplementsToolExecutorSetter(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 
 	// This type assertion must succeed for tools to work.
 	// The bug was that ClaudeBinProvider.SetToolExecutor used mcphttp.ToolExecutor
@@ -24,7 +25,7 @@ func TestClaudeBinProvider_ImplementsToolExecutorSetter(t *testing.T) {
 func TestRetryProvider_ForwardsToolExecutorSetter(t *testing.T) {
 	// ClaudeBinProvider is wrapped with WrapWithRetry in the factory.
 	// The RetryProvider must forward SetToolExecutor to the inner provider.
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	wrapped := WrapWithRetry(provider, DefaultRetryConfig())
 
 	// The wrapped provider must also implement ToolExecutorSetter
@@ -34,7 +35,7 @@ func TestRetryProvider_ForwardsToolExecutorSetter(t *testing.T) {
 }
 
 func TestClaudeBinProvider_ImplementsProviderCleaner(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 
 	// ClaudeBinProvider must implement ProviderCleaner for MCP server cleanup
 	if _, ok := interface{}(provider).(ProviderCleaner); !ok {
@@ -45,7 +46,7 @@ func TestClaudeBinProvider_ImplementsProviderCleaner(t *testing.T) {
 func TestRetryProvider_ForwardsProviderCleaner(t *testing.T) {
 	// ClaudeBinProvider is wrapped with WrapWithRetry in the factory.
 	// The RetryProvider must forward CleanupMCP to the inner provider.
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	wrapped := WrapWithRetry(provider, DefaultRetryConfig())
 
 	// The wrapped provider must also implement ProviderCleaner
@@ -56,7 +57,7 @@ func TestRetryProvider_ForwardsProviderCleaner(t *testing.T) {
 
 func TestClaudeBinProvider_CleanupMCP_Safe(t *testing.T) {
 	// CleanupMCP should be safe to call even without an active MCP server
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 
 	// Should not panic when called without active MCP server
 	provider.CleanupMCP()
@@ -116,7 +117,7 @@ func TestSafeSendEvent_Success(t *testing.T) {
 }
 
 func TestDispatchClaudeEvents_PrioritizesTextOverToolRequest(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event, 8)
 	lines := make(chan string, 4)
 	toolReqs := make(chan claudeToolRequest, 2)
@@ -154,7 +155,7 @@ func TestDispatchClaudeEvents_PrioritizesTextOverToolRequest(t *testing.T) {
 }
 
 func TestDispatchClaudeEvents_PrioritizesSlightlyDelayedTextOverToolRequest(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event, 8)
 	lines := make(chan string, 4)
 	toolReqs := make(chan claudeToolRequest, 2)
@@ -196,7 +197,7 @@ func TestDispatchClaudeEvents_PrioritizesSlightlyDelayedTextOverToolRequest(t *t
 }
 
 func TestDispatchClaudeEvents_FallsBackToAssistantTextWhenNoDeltas(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event, 8)
 	lines := make(chan string, 4)
 	toolReqs := make(chan claudeToolRequest, 1)
@@ -224,7 +225,7 @@ func TestDispatchClaudeEvents_FallsBackToAssistantTextWhenNoDeltas(t *testing.T)
 }
 
 func TestDispatchClaudeEvents_DoesNotDuplicateAssistantFallbackWhenDeltasPresent(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event, 8)
 	lines := make(chan string, 4)
 	toolReqs := make(chan claudeToolRequest, 1)
@@ -258,7 +259,7 @@ drained:
 }
 
 func TestHandleClaudeToolRequest_ClosedStreamReturnsError(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event)
 	close(events)
 
@@ -278,7 +279,7 @@ func TestHandleClaudeToolRequest_ClosedStreamReturnsError(t *testing.T) {
 }
 
 func TestHandleClaudeLine_ContextCancelledDoesNotBlock(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event) // unbuffered/no receiver to simulate blocked sink
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -304,7 +305,7 @@ func TestHandleClaudeLine_ContextCancelledDoesNotBlock(t *testing.T) {
 }
 
 func TestClaudeBinProvider_ToolExecutorIsWired(t *testing.T) {
-	provider := NewClaudeBinProvider("sonnet")
+	provider := NewClaudeBinProvider("sonnet", nil)
 	registry := NewToolRegistry()
 
 	// Register a test tool
@@ -374,11 +375,46 @@ func TestClaudeBinProvider_NameWithEffort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			p := NewClaudeBinProvider(tt.model)
+			p := NewClaudeBinProvider(tt.model, nil)
 			if got := p.Name(); got != tt.wantName {
 				t.Errorf("Name() = %q, want %q", got, tt.wantName)
 			}
 		})
+	}
+}
+
+func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "should-be-cleared")
+	t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "medium")
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	p := NewClaudeBinProvider("opus-max", map[string]string{
+		"IS_SANDBOX":                 "1",
+		"CLAUDE_CODE_EFFORT_LEVEL":   "max-from-config-should-be-overridden",
+		"ANTHROPIC_API_KEY":          "config-value-should-not-survive",
+		"CUSTOM_TERM_LLM_TEST_VALUE": "ok",
+	})
+
+	env := p.buildCommandEnv("max")
+	joined := strings.Join(env, "\n")
+
+	if strings.Contains(joined, "ANTHROPIC_API_KEY=should-be-cleared") {
+		t.Fatal("expected inherited ANTHROPIC_API_KEY to be removed when preferOAuth is enabled")
+	}
+	if !strings.Contains(joined, "IS_SANDBOX=1") {
+		t.Fatal("expected extra env IS_SANDBOX=1 to be present")
+	}
+	if !strings.Contains(joined, "CUSTOM_TERM_LLM_TEST_VALUE=ok") {
+		t.Fatal("expected custom extra env var to be present")
+	}
+	if strings.Contains(joined, "CLAUDE_CODE_EFFORT_LEVEL=medium") {
+		t.Fatal("expected inherited effort level to be removed")
+	}
+	if strings.Contains(joined, "CLAUDE_CODE_EFFORT_LEVEL=max-from-config-should-be-overridden") {
+		t.Fatal("expected config effort level to be overridden by model effort")
+	}
+	if !strings.Contains(joined, "CLAUDE_CODE_EFFORT_LEVEL=max") {
+		t.Fatal("expected model-derived effort level to be present")
 	}
 }
 

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -81,7 +81,7 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		case config.ProviderTypeClaudeBin:
 			// claude-bin doesn't need API key, can create directly
-			provider := NewClaudeBinProvider(model)
+			provider := NewClaudeBinProvider(model, nil)
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		case config.ProviderTypeZen:
 			// zen can work without API key (free tier)
@@ -199,7 +199,7 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 			return NewAnthropicProvider("", "", "")
 		case config.ProviderTypeClaudeBin:
 			// claude-bin doesn't need API key, can create directly
-			return NewClaudeBinProvider(""), nil
+			return NewClaudeBinProvider("", nil), nil
 		case config.ProviderTypeZen:
 			// zen can work without API key (free tier)
 			return NewZenProvider("", ""), nil
@@ -303,7 +303,7 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		return NewVeniceProvider(apiKey, cfg.Model), nil
 
 	case config.ProviderTypeClaudeBin:
-		return NewClaudeBinProvider(cfg.Model), nil
+		return NewClaudeBinProvider(cfg.Model, cfg.Env), nil
 
 	case config.ProviderTypeOpenAICompat:
 		// Use ResolvedURL if available (from srv:// or $() resolution), otherwise use config values


### PR DESCRIPTION
## What

- add `providers.<name>.env` support to provider config
- wire `providers.claude-bin.env` into the Claude CLI subprocess environment
- document the Claude Code/root container case, including `IS_SANDBOX=1`

## Why

`claude-bin` currently shells out to the Claude CLI with `--dangerously-skip-permissions`.
Claude rejects that when running as root unless it believes it is inside a sandboxed environment.

For Jarvis, the practical need is to set:

```yaml
providers:
  claude-bin:
    env:
      IS_SANDBOX: "1"
```

without patching runtime shells or carrying an unmerged local fork.

## How

- extend `ProviderConfig` with an `env` map for subprocess-backed providers
- pass `cfg.Env` into `claude-bin` provider creation
- merge extra env vars into the Claude subprocess environment
- preserve existing behavior:
  - still clears inherited `ANTHROPIC_API_KEY` when `preferOAuth` is on
  - still sets `CLAUDE_CODE_EFFORT_LEVEL` from the selected `opus-*` model
  - provider-config env does not override model-derived effort
- treat `providers.<name>.env.<VAR>` as a valid config path so it does not show up as an unknown key
- add docs for the new config option in:
  - `getting-started/providers-and-setup.md`
  - `reference/configuration.md`

## Verification

- `gofmt -w internal/config/config.go internal/llm/factory.go internal/llm/claude_bin.go internal/llm/claude_bin_test.go`
- `go test ./...`
- `go build ./...`
