### PR TITLE
feat: resolve provider env values from files

### DIFF
--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -253,6 +253,7 @@ providers:
     model: sonnet  # opus, sonnet, or haiku
     env:
       IS_SANDBOX: "1"  # useful when running term-llm as root in a trusted container
+      CLAUDE_CODE_OAUTH_TOKEN: "file:///root/.config/term-llm/anthropic_oauth.json#access_token"
 ```
 
 **Features:**
@@ -260,6 +261,7 @@ providers:
 - Full tool support via MCP (exec, search, edit all work)
 - Model selection: `opus`, `sonnet` (default), `haiku`
 - Optional `providers.claude-bin.env` passthrough for Claude subprocess settings (for example `IS_SANDBOX=1` in trusted root-run containers)
+- `providers.<name>.env` values support the same deferred resolution as other config values, including `file://...#json.path`, `op://...`, and `$()`
 - Works immediately if Claude Code is installed and logged in
 
 ### Option 10: Use existing CLI credentials (gemini-cli)

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -170,9 +170,18 @@ providers:
     model: opus
     env:
       IS_SANDBOX: "1"
+      CLAUDE_CODE_OAUTH_TOKEN: "file:///root/.config/term-llm/anthropic_oauth.json#access_token"
 ```
 
-This is passed only to the Claude subprocess. It does not mutate your parent shell environment.
+`providers.<name>.env` values support the same resolution rules as other deferred config values:
+
+- `file://path` → trimmed file contents
+- `file://path#json.path` → JSON field extracted from the file
+- `op://...` → 1Password secret lookup
+- `$()` → command output
+- `${VAR}` / `$VAR` → environment variable expansion
+
+This is passed only to the provider subprocess. It does not mutate your parent shell environment.
 
 ## Dynamic secrets and endpoints
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -502,15 +502,16 @@ func (c *Config) GetActiveProviderConfig() *ProviderConfig {
 	return c.GetProviderConfig(c.DefaultProvider)
 }
 
-// needsLazyResolve checks if a value requires expensive resolution (1Password, commands, SRV)
+// needsLazyResolve checks if a value requires expensive resolution (1Password, files, commands, SRV)
 func needsLazyResolve(value string) bool {
 	return strings.HasPrefix(value, "op://") ||
 		strings.HasPrefix(value, "srv://") ||
+		strings.HasPrefix(value, "file://") ||
 		(strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")"))
 }
 
 // resolveProviderCredentials resolves credentials for a provider based on its type.
-// Expensive operations (op://, srv://, $()) are deferred - call ResolveForInference() before use.
+// Expensive operations (op://, file://, srv://, $()) are deferred - call ResolveForInference() before use.
 func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 	providerType := InferProviderType(name, cfg.Type)
 
@@ -526,8 +527,9 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 	// Expand environment variables in other fields
 	cfg.AppURL = expandEnv(cfg.AppURL)
 	cfg.AppTitle = expandEnv(cfg.AppTitle)
+	resolveProviderEnv(cfg)
 
-	// Check if api_key uses magic syntax (op://, $(), etc.)
+	// Check if api_key uses magic syntax (op://, file://, $(), etc.)
 	// If so, defer resolution until inference time
 	if cfg.APIKey != "" && needsLazyResolve(cfg.APIKey) {
 		cfg.needsLazyResolution = true
@@ -592,7 +594,20 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 	return nil
 }
 
-// ResolveForInference performs lazy resolution of expensive config values (op://, srv://, $()).
+func resolveProviderEnv(cfg *ProviderConfig) {
+	if len(cfg.Env) == 0 {
+		return
+	}
+	for k, v := range cfg.Env {
+		if needsLazyResolve(v) {
+			cfg.needsLazyResolution = true
+			continue
+		}
+		cfg.Env[k] = expandEnv(v)
+	}
+}
+
+// ResolveForInference performs lazy resolution of expensive config values (op://, file://, srv://, $()).
 // Call this before creating a provider for inference.
 func (cfg *ProviderConfig) ResolveForInference() error {
 	if !cfg.needsLazyResolution {
@@ -623,6 +638,16 @@ func (cfg *ProviderConfig) ResolveForInference() error {
 		}
 	}
 
+	for k, v := range cfg.Env {
+		if needsLazyResolve(v) {
+			resolved, err := ResolveValue(v)
+			if err != nil {
+				return fmt.Errorf("env.%s: %w", k, err)
+			}
+			cfg.Env[k] = resolved
+		}
+	}
+
 	cfg.needsLazyResolution = false
 	return nil
 }
@@ -634,7 +659,7 @@ func (cfg *ProviderConfig) ResolveForInference() error {
 func DescribeCredentialSource(name string, cfg *ProviderConfig) (string, bool) {
 	providerType := InferProviderType(name, cfg.Type)
 
-	// If there's a lazy-resolved api_key (op://, $()), describe it
+	// If there's a lazy-resolved api_key (op://, file://, $()), describe it
 	if cfg.APIKey != "" && needsLazyResolve(cfg.APIKey) {
 		return fmt.Sprintf("api_key (deferred: %s)", truncateValue(cfg.APIKey, 30)), true
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -42,6 +43,46 @@ func TestApplyOverrides(t *testing.T) {
 	}
 	if cfg.Providers["openai"].Model != "gemini-2.5-flash" {
 		t.Fatalf("openai model=%q, want %q", cfg.Providers["openai"].Model, "gemini-2.5-flash")
+	}
+}
+
+func TestResolveProviderCredentials_ExpandsEnvMap(t *testing.T) {
+	t.Setenv("CLAUDE_TEST_FLAG", "1")
+	cfg := &ProviderConfig{
+		Env: map[string]string{
+			"IS_SANDBOX": "$CLAUDE_TEST_FLAG",
+		},
+	}
+	if err := resolveProviderCredentials("claude-bin", cfg); err != nil {
+		t.Fatalf("resolveProviderCredentials: %v", err)
+	}
+	if got := cfg.Env["IS_SANDBOX"]; got != "1" {
+		t.Fatalf("env expansion = %q, want %q", got, "1")
+	}
+}
+
+func TestResolveProviderCredentials_ResolvesLazyEnvMapForInference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oauth.json")
+	if err := os.WriteFile(path, []byte(`{"access_token":"secret-token"}`), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	cfg := &ProviderConfig{
+		Env: map[string]string{
+			"CLAUDE_CODE_OAUTH_TOKEN": "file://" + path + "#access_token",
+		},
+	}
+	if err := resolveProviderCredentials("claude-bin", cfg); err != nil {
+		t.Fatalf("resolveProviderCredentials: %v", err)
+	}
+	if !cfg.needsLazyResolution {
+		t.Fatal("expected lazy resolution to be enabled for file:// env value")
+	}
+	if err := cfg.ResolveForInference(); err != nil {
+		t.Fatalf("ResolveForInference: %v", err)
+	}
+	if got := cfg.Env["CLAUDE_CODE_OAUTH_TOKEN"]; got != "secret-token" {
+		t.Fatalf("resolved env value = %q, want %q", got, "secret-token")
 	}
 }
 

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -2,11 +2,14 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -22,6 +25,8 @@ var (
 // ResolveValue handles magic URL schemes in config values:
 // - op://vault/item/field -> 1Password secret (via `op read`)
 // - srv://record/path -> DNS SRV lookup + path (always HTTPS)
+// - file://path -> file contents (trimmed)
+// - file://path#key or file://path#nested.path -> JSON field from file contents
 // - $(...) -> shell command output
 // - ${VAR} or $VAR -> environment variable
 // - literal string -> returned as-is
@@ -36,6 +41,8 @@ func ResolveValue(value string) (string, error) {
 		return resolveOnePassword(value)
 	case strings.HasPrefix(value, "srv://"):
 		return resolveSRV(value)
+	case strings.HasPrefix(value, "file://"):
+		return resolveFile(value)
 	case strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")"):
 		return resolveCommand(value[2 : len(value)-1])
 	default:
@@ -100,6 +107,77 @@ func resolveSRV(srvURL string) (string, error) {
 	host := strings.TrimSuffix(addr.Target, ".")
 
 	return fmt.Sprintf("https://%s:%d%s", host, addr.Port, path), nil
+}
+
+func resolveFile(fileURL string) (string, error) {
+	u, err := url.Parse(fileURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid file:// URL: %w", err)
+	}
+
+	if u.Host != "" && u.Host != "localhost" {
+		return "", fmt.Errorf("file:// URL host must be empty or localhost: %s", fileURL)
+	}
+
+	path := expandEnv(u.Path)
+	if path == "" {
+		return "", fmt.Errorf("file:// URL missing path: %s", fileURL)
+	}
+	path = filepath.Clean(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("file: failed to read %s: %w", path, err)
+	}
+	content := strings.TrimSpace(string(data))
+
+	fragment := strings.TrimSpace(u.Fragment)
+	if fragment == "" {
+		return content, nil
+	}
+
+	var parsed any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", fmt.Errorf("file: failed to parse JSON in %s for fragment %q: %w", path, fragment, err)
+	}
+	value, err := lookupJSONFragment(parsed, fragment)
+	if err != nil {
+		return "", fmt.Errorf("file: %w", err)
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func lookupJSONFragment(v any, fragment string) (string, error) {
+	parts := strings.Split(fragment, ".")
+	cur := v
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", fmt.Errorf("invalid JSON fragment %q", fragment)
+		}
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("fragment %q does not resolve to an object before %q", fragment, part)
+		}
+		next, ok := obj[part]
+		if !ok {
+			return "", fmt.Errorf("fragment %q not found", fragment)
+		}
+		cur = next
+	}
+
+	switch x := cur.(type) {
+	case string:
+		return x, nil
+	case float64, bool, nil:
+		return fmt.Sprintf("%v", x), nil
+	default:
+		b, err := json.Marshal(x)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal fragment %q: %w", fragment, err)
+		}
+		return string(b), nil
+	}
 }
 
 // resolveCommand executes a shell command and returns its output

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -42,5 +44,46 @@ func TestResolveCommand_RejectsOversizedOutput(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "output exceeded 32 bytes") {
 		t.Fatalf("error = %q, want output limit message", err)
+	}
+}
+
+func TestResolveValue_FileContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token.txt")
+	if err := os.WriteFile(path, []byte("  secret-token\n"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got, err := ResolveValue("file://" + path)
+	if err != nil {
+		t.Fatalf("ResolveValue(file) error: %v", err)
+	}
+	if got != "secret-token" {
+		t.Fatalf("ResolveValue(file) = %q, want %q", got, "secret-token")
+	}
+}
+
+func TestResolveValue_FileJSONFragment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "creds.json")
+	content := `{"access_token":"abc123","nested":{"value":"xyz"}}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got, err := ResolveValue("file://" + path + "#access_token")
+	if err != nil {
+		t.Fatalf("ResolveValue(file#access_token) error: %v", err)
+	}
+	if got != "abc123" {
+		t.Fatalf("ResolveValue(file#access_token) = %q, want %q", got, "abc123")
+	}
+
+	got, err = ResolveValue("file://" + path + "#nested.value")
+	if err != nil {
+		t.Fatalf("ResolveValue(file#nested.value) error: %v", err)
+	}
+	if got != "xyz" {
+		t.Fatalf("ResolveValue(file#nested.value) = %q, want %q", got, "xyz")
 	}
 }


### PR DESCRIPTION
## What

- add file-based resolution support to provider env values
- support `file://path` and `file://path#json.path` in config resolution
- document using file-backed `CLAUDE_CODE_OAUTH_TOKEN` for `claude-bin`

## Why

`providers.claude-bin.env` is the right place to pass Claude subprocess settings like `IS_SANDBOX=1`, but it still leaves the OAuth token question.

Sam wanted a way to keep the token in one place instead of embedding it directly in `config.yaml`.

This change lets config do that cleanly, for example:

```yaml
providers:
  claude-bin:
    model: opus
    env:
      IS_SANDBOX: "1"
      CLAUDE_CODE_OAUTH_TOKEN: "file:///root/.config/term-llm/anthropic_oauth.json#access_token"
```

## How

- extend `ResolveValue` with:
  - `file://path` → trimmed file contents
  - `file://path#json.path` → JSON field extraction from the file
- treat `file://...` as a lazy/deferred config value alongside `op://`, `srv://`, and `$()`
- apply deferred resolution to `providers.<name>.env` values during provider setup
- add tests for:
  - raw file reads
  - JSON fragment extraction
  - provider env expansion + lazy resolution
- update docs in:
  - `getting-started/providers-and-setup.md`
  - `reference/configuration.md`

## Verification

- `gofmt -w internal/config/resolve.go internal/config/config.go internal/config/resolve_test.go internal/config/config_test.go`
- `go test ./...`
- `go build ./...`
