### PR TITLE
feat: disable claude-bin hooks by default

### DIFF
--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -254,12 +254,16 @@ providers:
     env:
       IS_SANDBOX: "1"  # useful when running term-llm as root in a trusted container
       CLAUDE_CODE_OAUTH_TOKEN: "file:///root/.config/term-llm/anthropic_oauth.json#access_token"
+    # Optional: Claude Code hooks are disabled by default; set to true to opt back in
+    # enable_hooks: true
 ```
 
 **Features:**
 - No API key required - uses Claude Code's OAuth authentication
 - Full tool support via MCP (exec, search, edit all work)
 - Model selection: `opus`, `sonnet` (default), `haiku`
+- Claude Code hooks are disabled by default to keep user hook automation out of term-llm inference sessions
+- Optional `providers.claude-bin.enable_hooks: true` to opt back into Claude Code hooks
 - Optional `providers.claude-bin.env` passthrough for Claude subprocess settings (for example `IS_SANDBOX=1` in trusted root-run containers)
 - `providers.<name>.env` values support the same deferred resolution as other config values, including `file://...#json.path`, `op://...`, and `$()`
 - Works immediately if Claude Code is installed and logged in

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -162,6 +162,8 @@ Each feature block can hold provider-specific credentials and defaults. The imag
 
 Providers that shell out to local CLIs can accept extra subprocess environment variables via `providers.<name>.env`.
 
+For `claude-bin`, term-llm also disables Claude Code hooks by default so user-level Claude automation does not leak into inference sessions. Set `providers.claude-bin.enable_hooks: true` if you explicitly want Claude Code hooks to run.
+
 Example for Claude Code when term-llm itself runs as root inside a trusted container:
 
 ```yaml
@@ -171,6 +173,8 @@ providers:
     env:
       IS_SANDBOX: "1"
       CLAUDE_CODE_OAUTH_TOKEN: "file:///root/.config/term-llm/anthropic_oauth.json#access_token"
+    # Optional: re-enable Claude Code hooks for this provider
+    # enable_hooks: true
 ```
 
 `providers.<name>.env` values support the same resolution rules as other deferred config values:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ type ProviderConfig struct {
 	Models       []string          `mapstructure:"models"`        // Available models for autocomplete
 	Credentials  string            `mapstructure:"credentials"`   // "api_key", "codex", "gemini-cli"
 	Env          map[string]string `mapstructure:"env"`           // Extra subprocess env vars for providers that shell out (e.g. claude-bin)
+	EnableHooks  bool              `mapstructure:"enable_hooks"`  // Opt in to Claude Code hooks for claude-bin (disabled by default)
 
 	// Search behavior - nil means auto (use native if available)
 	UseNativeSearch *bool `mapstructure:"use_native_search"`

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -35,6 +35,7 @@ type ClaudeBinProvider struct {
 	toolExecutor mcphttp.ToolExecutor
 	preferOAuth  bool              // If true, clear ANTHROPIC_API_KEY to force OAuth auth
 	extraEnv     map[string]string // Extra subprocess env vars from provider config
+	enableHooks  bool              // Opt in to Claude Code hooks (disabled by default)
 
 	// Persistent MCP server for multi-turn conversations.
 	// The server is kept alive across turns so Claude CLI can maintain
@@ -128,6 +129,13 @@ func NewClaudeBinProvider(model string, env map[string]string) *ClaudeBinProvide
 // so Claude CLI uses OAuth subscription auth instead.
 func (p *ClaudeBinProvider) SetPreferOAuth(prefer bool) {
 	p.preferOAuth = prefer
+}
+
+// SetEnableHooks controls whether Claude Code hooks are allowed to run.
+// Hooks are disabled by default so term-llm sessions don't inherit user-defined
+// Claude Code automation unexpectedly.
+func (p *ClaudeBinProvider) SetEnableHooks(enable bool) {
+	p.enableHooks = enable
 }
 
 // SetEnv configures extra environment variables for the Claude CLI subprocess.
@@ -655,6 +663,9 @@ func (p *ClaudeBinProvider) buildArgs(ctx context.Context, req Request, events c
 		"--strict-mcp-config",            // Ignore Claude's configured MCPs
 		"--dangerously-skip-permissions", // Allow MCP tool execution
 		"--setting-sources", "user",      // Skip project CLAUDE.md files (term-llm provides its own context)
+	}
+	if !p.enableHooks {
+		args = append(args, "--settings", `{"disableAllHooks":true}`)
 	}
 
 	// Always limit to 1 turn - term-llm handles tool execution loop

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -383,6 +383,32 @@ func TestClaudeBinProvider_NameWithEffort(t *testing.T) {
 	}
 }
 
+func TestClaudeBinProvider_BuildArgsDisablesHooksByDefault(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+
+	args, _ := p.buildArgs(context.Background(), Request{}, nil)
+	joined := strings.Join(args, "\n")
+
+	if !strings.Contains(joined, "--settings") {
+		t.Fatal("expected claude-bin args to include --settings when hooks are disabled by default")
+	}
+	if !strings.Contains(joined, `{"disableAllHooks":true}`) {
+		t.Fatal("expected claude-bin args to disable hooks by default")
+	}
+}
+
+func TestClaudeBinProvider_BuildArgsCanEnableHooks(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	p.SetEnableHooks(true)
+
+	args, _ := p.buildArgs(context.Background(), Request{}, nil)
+	joined := strings.Join(args, "\n")
+
+	if strings.Contains(joined, `{"disableAllHooks":true}`) {
+		t.Fatal("expected disableAllHooks setting to be omitted when hooks are enabled")
+	}
+}
+
 func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "should-be-cleared")
 	t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "medium")

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -303,7 +303,9 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		return NewVeniceProvider(apiKey, cfg.Model), nil
 
 	case config.ProviderTypeClaudeBin:
-		return NewClaudeBinProvider(cfg.Model, cfg.Env), nil
+		provider := NewClaudeBinProvider(cfg.Model, cfg.Env)
+		provider.SetEnableHooks(cfg.EnableHooks)
+		return provider, nil
 
 	case config.ProviderTypeOpenAICompat:
 		// Use ResolvedURL if available (from srv:// or $() resolution), otherwise use config values


### PR DESCRIPTION
## What

- disable Claude Code hooks by default for the `claude-bin` provider by passing `--settings {"disableAllHooks":true}`
- add a provider-level `enable_hooks: true` opt-in for users who explicitly want Claude Code hooks to run
- document the new default and opt-in config in the Claude provider docs
- add tests covering the default hook disable and the opt-in path

## Why

`term-llm` uses Claude Code as an inference backend. Inheriting user Claude Code hooks into `term-llm` sessions is surprising and can interfere with tool/inference behavior. Safe default is no hooks unless the provider config explicitly opts in.

## Validation

- `go test ./...`
- `go build ./...`
