### PR TITLE
fix: retry Anthropic internal server errors

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -199,6 +199,9 @@ func isRetryable(err error) bool {
 		strings.Contains(errStr, "rate limit") ||
 		strings.Contains(errStr, "too many requests") ||
 		strings.Contains(errStr, "high concurrency") ||
+		strings.Contains(errStr, "status 500") ||
+		strings.Contains(errStr, "500 internal server error") ||
+		strings.Contains(errStr, "internal server error") ||
 		strings.Contains(errStr, "502") ||
 		strings.Contains(errStr, "bad gateway") ||
 		strings.Contains(errStr, "503") ||

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -29,6 +30,29 @@ func (p *retryStreamingProvider) Stream(ctx context.Context, req Request) (Strea
 	return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
 		ch <- Event{Type: EventTextDelta, Text: "hello"}
 		ch <- Event{Type: EventTextDelta, Text: " world"}
+		return nil
+	}), nil
+}
+
+type retryInternalServerErrorProvider struct {
+	attempt int
+}
+
+func (p *retryInternalServerErrorProvider) Name() string { return "retry-500" }
+
+func (p *retryInternalServerErrorProvider) Credential() string { return "mock" }
+
+func (p *retryInternalServerErrorProvider) Capabilities() Capabilities { return Capabilities{} }
+
+func (p *retryInternalServerErrorProvider) Stream(ctx context.Context, req Request) (Stream, error) {
+	p.attempt++
+	if p.attempt == 1 {
+		return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
+			return fmt.Errorf(`anthropic streaming error: POST "https://api.anthropic.com/v1/messages": 500 Internal Server Error (Request-ID: req_123) {"type":"error","error":{"type":"api_error","message":"Internal server error"}}`)
+		}), nil
+	}
+	return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
+		ch <- Event{Type: EventTextDelta, Text: "recovered"}
 		return nil
 	}), nil
 }


### PR DESCRIPTION
## What

- treat HTTP 500 / "internal server error" responses as retryable in the shared LLM retry wrapper
- add a regression test covering an Anthropic-style streaming 500 that succeeds on retry

## Why

The captured failure was an Anthropic streaming request that returned a transient 500 Internal Server Error. term-llm already retries rate limits and some transient upstream failures, but 500s were not classified as retryable, so the session failed immediately instead of retrying.

## How

- update `internal/llm/retry.go` to recognize 500/internal-server-error messages as transient
- add `TestRetryProvider_RetriesOnInternalServerError` in `internal/llm/retry_test.go`
- verify with `gofmt -w`, `go build ./...`, and `go test ./...`
