### PR TITLE
fix: preserve provider env key casing on load

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -437,6 +437,10 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
+	if err := overlayProviderEnvFromRawConfig(&cfg); err != nil {
+		return nil, fmt.Errorf("failed to load raw provider env config: %w", err)
+	}
+
 	// Initialize providers map if nil
 	if cfg.Providers == nil {
 		cfg.Providers = make(map[string]ProviderConfig)
@@ -455,6 +459,48 @@ func Load() (*Config, error) {
 	resolveSearchCredentials(&cfg.Search)
 
 	return &cfg, nil
+}
+
+func overlayProviderEnvFromRawConfig(cfg *Config) error {
+	configFile := viper.ConfigFileUsed()
+	if configFile == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	var raw struct {
+		Providers map[string]struct {
+			Env map[string]string `yaml:"env"`
+		} `yaml:"providers"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if len(raw.Providers) == 0 {
+		return nil
+	}
+	if cfg.Providers == nil {
+		cfg.Providers = make(map[string]ProviderConfig)
+	}
+
+	for name, provider := range raw.Providers {
+		if provider.Env == nil {
+			continue
+		}
+		providerCfg := cfg.Providers[name]
+		providerCfg.Env = make(map[string]string, len(provider.Env))
+		for k, v := range provider.Env {
+			providerCfg.Env[k] = v
+		}
+		cfg.Providers[name] = providerCfg
+	}
+
+	return nil
 }
 
 // GetBuiltInProviderNames returns a list of all built-in provider type names.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/samsaffron/term-llm/internal/credentials"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -43,6 +44,53 @@ func TestApplyOverrides(t *testing.T) {
 	}
 	if cfg.Providers["openai"].Model != "gemini-2.5-flash" {
 		t.Fatalf("openai model=%q, want %q", cfg.Providers["openai"].Model, "gemini-2.5-flash")
+	}
+}
+
+func TestLoad_PreservesProviderEnvKeyCase(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	configDir := filepath.Join(configHome, "term-llm")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	configYAML := `default_provider: claude-bin
+providers:
+  claude-bin:
+    model: sonnet
+    env:
+      IS_SANDBOX: "1"
+      CLAUDE_CODE_OAUTH_TOKEN: file:///tmp/oauth.json#access_token
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configYAML), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	providerCfg, ok := cfg.Providers["claude-bin"]
+	if !ok {
+		t.Fatal("expected claude-bin provider to be loaded")
+	}
+	if got := providerCfg.Env["IS_SANDBOX"]; got != "1" {
+		t.Fatalf("IS_SANDBOX = %q, want %q", got, "1")
+	}
+	if got := providerCfg.Env["CLAUDE_CODE_OAUTH_TOKEN"]; got != "file:///tmp/oauth.json#access_token" {
+		t.Fatalf("CLAUDE_CODE_OAUTH_TOKEN = %q", got)
+	}
+	if _, ok := providerCfg.Env["is_sandbox"]; ok {
+		t.Fatal("did not expect lowercased is_sandbox key")
+	}
+	if _, ok := providerCfg.Env["claude_code_oauth_token"]; ok {
+		t.Fatal("did not expect lowercased claude_code_oauth_token key")
 	}
 }
 


### PR DESCRIPTION
## What

Fix config loading for `providers.<name>.env` so env var names keep their original casing from `config.yaml`.

This specifically fixes `claude-bin` config like:

```yaml
providers:
  claude-bin:
    model: sonnet
    env:
      IS_SANDBOX: "1"
      CLAUDE_CODE_OAUTH_TOKEN: file:///root/.config/term-llm/anthropic_oauth.json#access_token
```

## Why

Viper lowercases nested map keys when unmarshalling config, which breaks environment-variable names.

That meant `providers.claude-bin.env` was loading as keys like:

- `is_sandbox`
- `claude_code_oauth_token`

instead of:

- `IS_SANDBOX`
- `CLAUDE_CODE_OAUTH_TOKEN`

So the claude subprocess never received the intended env vars, and `claude-bin` failed under root with:

`--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`

## How

- keep the normal Viper unmarshal path
- then re-read the raw YAML config and overlay `providers.*.env` from the file
- add a regression test proving provider env keys retain uppercase names after `Load()`

## Validation

- `go build ./...`
- `go test ./...`
- live smoke test after building the patched binary:

```bash
term-llm ask -p claude-bin:opus-max --no-session --porcelain hi
```

Now succeeds using config-driven `IS_SANDBOX` and `CLAUDE_CODE_OAUTH_TOKEN`.
