### PR TITLE
fix: retry on 500 Internal Server Error from LLM providers

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -199,6 +199,8 @@ func isRetryable(err error) bool {
 		strings.Contains(errStr, "rate limit") ||
 		strings.Contains(errStr, "too many requests") ||
 		strings.Contains(errStr, "high concurrency") ||
+		strings.Contains(errStr, "500") ||
+		strings.Contains(errStr, "internal server error") ||
 		strings.Contains(errStr, "502") ||
 		strings.Contains(errStr, "bad gateway") ||
 		strings.Contains(errStr, "503") ||

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -31,6 +32,26 @@ func (p *retryStreamingProvider) Stream(ctx context.Context, req Request) (Strea
 		ch <- Event{Type: EventTextDelta, Text: " world"}
 		return nil
 	}), nil
+}
+
+func TestIsRetryable_500InternalServerError(t *testing.T) {
+	cases := []struct {
+		msg       string
+		retryable bool
+	}{
+		{"anthropic streaming error: POST \"https://api.anthropic.com/v1/messages\": 500 Internal Server Error", true},
+		{"500 internal server error", true},
+		{"got 500 from upstream", true},
+		{"internal server error occurred", true},
+		{"400 Bad Request", false},
+		{"401 Unauthorized", false},
+	}
+	for _, tc := range cases {
+		got := isRetryable(errors.New(tc.msg))
+		if got != tc.retryable {
+			t.Errorf("isRetryable(%q) = %v, want %v", tc.msg, got, tc.retryable)
+		}
+	}
 }
 
 func TestRetryProvider_DropsPartialTextFromRetriedAttempt(t *testing.T) {


### PR DESCRIPTION
## What

Adds `500 Internal Server Error` and `internal server error` to the list of retryable error strings in `isRetryable()` (`internal/llm/retry.go`).

## Why

A live session failed with:

```
anthropic streaming error: POST "https://api.anthropic.com/v1/messages": 500 Internal Server Error
{"type":"error","error":{"type":"api_error","message":"Internal server error"}}
```

The retry layer already handles 502 Bad Gateway and 503 Service Unavailable — both transient infrastructure errors. A 500 from Anthropic is equally transient (Anthropic's own docs recommend retrying on 500s), but `isRetryable` did not match it, so the request failed immediately with no retry attempts (session showed 0 input tokens, 0 output tokens).

## How

- Added `"500"` and `"internal server error"` string checks alongside the existing 502/503 checks in `isRetryable()`.
- Added `TestIsRetryable_500InternalServerError` covering the exact error string from the session plus variants, and confirming 400/401 remain non-retryable.
