### PR TITLE
fix: stop retry wrapper buffering sync tool calls

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -82,19 +82,11 @@ func (r *RetryProvider) Stream(ctx context.Context, req Request) (Stream, error)
 				}
 				lastErr = err
 			} else {
-				// Stream created, collect events so retryable failures do not leak
-				// partial text/tool state into the final stream.
-				buffered, err := r.collectEvents(ctx, stream)
+				err = r.forwardAttempt(ctx, stream, events)
 				if err == nil {
-					if err := flushEvents(ctx, events, buffered); err != nil {
-						return err
-					}
 					return nil // Success!
 				}
 				if !isRetryable(err) {
-					if flushErr := flushEvents(ctx, events, buffered); flushErr != nil {
-						return flushErr
-					}
 					return err
 				}
 				lastErr = err
@@ -134,35 +126,73 @@ func (r *RetryProvider) Stream(ctx context.Context, req Request) (Stream, error)
 	}), nil
 }
 
-// collectEvents reads events from the inner stream.
-// Retryable failures return the partial events separately so the caller can
-// discard them before retrying.
-func (r *RetryProvider) collectEvents(ctx context.Context, stream Stream) ([]Event, error) {
+// forwardAttempt reads a single inner stream attempt.
+//
+// Before any externally-visible side effects, events are buffered so retryable
+// failures can be retried without leaking partial text into the outer stream.
+//
+// Once the provider emits a synchronous tool request (EventToolCall with
+// ToolResponse), buffering must stop immediately: the caller needs to see the
+// event in real time to execute the tool, and after that point the attempt has
+// already escaped so retrying would duplicate visible/side-effecting work.
+func (r *RetryProvider) forwardAttempt(ctx context.Context, stream Stream, events chan<- Event) error {
 	defer stream.Close()
-	var collected []Event
+
+	var buffered []Event
+	live := false
 
 	for {
 		select {
 		case <-ctx.Done():
-			return collected, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 
 		event, err := stream.Recv()
 		if err == io.EOF {
-			return collected, nil
+			if !live {
+				return flushEvents(ctx, events, buffered)
+			}
+			return nil
 		}
 		if err != nil {
-			return collected, err
+			if live {
+				return err
+			}
+			return err
 		}
 
 		// Check for error events from the stream (e.g., 429 during streaming)
 		if event.Type == EventError && event.Err != nil {
-			return collected, event.Err
+			if live {
+				return event.Err
+			}
+			return event.Err
 		}
 
-		collected = append(collected, event)
+		if !live && eventRequiresImmediateForwarding(event) {
+			if err := flushEvents(ctx, events, buffered); err != nil {
+				return err
+			}
+			buffered = nil
+			live = true
+		}
+
+		if live {
+			select {
+			case events <- event:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			continue
+		}
+
+		buffered = append(buffered, event)
 	}
+}
+
+func eventRequiresImmediateForwarding(event Event) bool {
+	return event.Type == EventToolCall && event.ToolResponse != nil
 }
 
 func flushEvents(ctx context.Context, events chan<- Event, buffered []Event) error {

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 	"time"
@@ -11,11 +12,19 @@ type retryStreamingProvider struct {
 	attempt int
 }
 
+type syncToolProvider struct{}
+
 func (p *retryStreamingProvider) Name() string { return "retry-streaming" }
+
+func (p *syncToolProvider) Name() string { return "sync-tool" }
 
 func (p *retryStreamingProvider) Credential() string { return "mock" }
 
+func (p *syncToolProvider) Credential() string { return "mock" }
+
 func (p *retryStreamingProvider) Capabilities() Capabilities { return Capabilities{} }
+
+func (p *syncToolProvider) Capabilities() Capabilities { return Capabilities{} }
 
 func (p *retryStreamingProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	p.attempt++
@@ -30,6 +39,30 @@ func (p *retryStreamingProvider) Stream(ctx context.Context, req Request) (Strea
 		ch <- Event{Type: EventTextDelta, Text: "hello"}
 		ch <- Event{Type: EventTextDelta, Text: " world"}
 		return nil
+	}), nil
+}
+
+func (p *syncToolProvider) Stream(ctx context.Context, req Request) (Stream, error) {
+	return newEventStream(ctx, func(ctx context.Context, ch chan<- Event) error {
+		responseCh := make(chan ToolExecutionResponse, 1)
+		ch <- Event{
+			Type:         EventToolCall,
+			ToolCallID:   "tool-1",
+			ToolName:     "read_file",
+			Tool:         &ToolCall{ID: "tool-1", Name: "read_file", Arguments: json.RawMessage(`{"path":"/tmp/test.txt"}`)},
+			ToolResponse: responseCh,
+		}
+
+		select {
+		case resp := <-responseCh:
+			if resp.Err != nil {
+				return resp.Err
+			}
+			ch <- Event{Type: EventTextDelta, Text: resp.Result.Content}
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}), nil
 }
 
@@ -71,5 +104,53 @@ func TestRetryProvider_DropsPartialTextFromRetriedAttempt(t *testing.T) {
 	}
 	if text != "hello world" {
 		t.Fatalf("text = %q, want %q", text, "hello world")
+	}
+}
+
+func TestRetryProvider_ForwardsSyncToolCallsImmediately(t *testing.T) {
+	provider := WrapWithRetry(&syncToolProvider{}, RetryConfig{
+		MaxAttempts: 2,
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  10 * time.Millisecond,
+	})
+
+	stream, err := provider.Stream(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	defer stream.Close()
+
+	gotTool := make(chan Event, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		event, err := stream.Recv()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		gotTool <- event
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Recv returned error before tool event: %v", err)
+	case event := <-gotTool:
+		if event.Type != EventToolCall {
+			t.Fatalf("first event type = %v, want %v", event.Type, EventToolCall)
+		}
+		if event.ToolResponse == nil {
+			t.Fatal("expected ToolResponse channel on sync tool event")
+		}
+		event.ToolResponse <- ToolExecutionResponse{Result: ToolOutput{Content: "alpha"}}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for sync tool event; retry wrapper buffered it")
+	}
+
+	event, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv after tool response returned error: %v", err)
+	}
+	if event.Type != EventTextDelta || event.Text != "alpha" {
+		t.Fatalf("got event %+v, want text_delta alpha", event)
 	}
 }


### PR DESCRIPTION
## What

Fix `RetryProvider` so it stops buffering provider events once an attempt emits a synchronous tool request (`EventToolCall` with `ToolResponse`).

Before this change, the retry wrapper collected the entire inner stream before forwarding anything outward. That works for plain text, but it breaks `claude-bin`'s MCP bridge because the provider needs the outer engine to see the tool event immediately and send the tool result back on `ToolResponse`.

The fix:

- keeps the old buffering behavior before any externally-visible side effects
- flushes buffered events and switches to live passthrough as soon as a sync tool call appears
- avoids retrying after that point, because the attempt has already escaped and may have executed visible / side-effecting work
- adds a regression test covering immediate forwarding of sync tool calls through the retry wrapper

## Repro

Easy repro used while debugging:

```bash
term-llm ask -p claude-bin:opus --no-session --text --yolo \
  --tools read_file --read-dir /tmp/claude-bin-repro \
  "Read /tmp/claude-bin-repro/sample.txt and reply with just the first line."
```

On the current installed binary this took about **67.7s** for a trivial `read_file` tool call.

With this branch's binary built locally, the same repro dropped to about **10.5s**.

## Root cause

This turned out **not** to be MCP server startup or MCP HTTP transport latency.

The actual stall was:

1. `claude-bin` emitted the synchronous tool request quickly
2. the MCP bridge queued it immediately
3. `RetryProvider` buffered that event instead of forwarding it
4. the outer engine never saw the tool call, so it could not respond on `ToolResponse`
5. the Claude tool request sat there until the request eventually unwound ~60s later

So the retry wrapper was accidentally turning a synchronous tool rendezvous into a deadlock-ish wait.

## Testing

- `go test ./internal/llm/...`
- `go test ./...`
- manual repro before/after timing check for `claude-bin` tool calls
