### PR TITLE
fix: add missing Venice credential resolution in provider config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -629,6 +629,12 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 			cfg.ResolvedAPIKey = os.Getenv("XAI_API_KEY")
 		}
 
+	case ProviderTypeVenice:
+		cfg.ResolvedAPIKey = expandEnv(cfg.APIKey)
+		if cfg.ResolvedAPIKey == "" {
+			cfg.ResolvedAPIKey = os.Getenv("VENICE_API_KEY")
+		}
+
 	case ProviderTypeOpenAICompat:
 		cfg.ResolvedAPIKey = expandEnv(cfg.APIKey)
 		if cfg.ResolvedAPIKey == "" {
@@ -733,6 +739,8 @@ func DescribeCredentialSource(name string, cfg *ProviderConfig) (string, bool) {
 		return source, found
 	case ProviderTypeXAI:
 		return describeEnvKeyCredential(cfg, "XAI_API_KEY")
+	case ProviderTypeVenice:
+		return describeEnvKeyCredential(cfg, "VENICE_API_KEY")
 	case ProviderTypeClaudeBin:
 		return "claude-bin CLI (no key needed)", true
 	case ProviderTypeChatGPT:


### PR DESCRIPTION
## What

Add missing `ProviderTypeVenice` case to the credential resolution switch in `resolveProviderCredentials`, and to `describeCredentialSource`.

## Why

Every other built-in provider (Anthropic, OpenAI, Gemini, OpenRouter, XAI, Zen, etc.) has a case in the credential resolution switch that wires `providers.<name>.api_key` → `cfg.ResolvedAPIKey`. Venice was missing, so config-file API keys were silently ignored — the only working path was the `VENICE_API_KEY` environment variable.

This meant `providers.venice.api_key: <key>` in config.yaml had no effect, and `--provider venice:grok-4-20-beta` would fail with a 401 unless the env var was set.

## Changes

- `internal/config/config.go`: Add `case ProviderTypeVenice` to both `resolveProviderCredentials` (reads `api_key`, falls back to `VENICE_API_KEY` env) and `describeCredentialSource` (for `term-llm providers` status display).
