### PR TITLE
fix: validate Venice API key before requests

### DIFF
--- a/internal/image/venice.go
+++ b/internal/image/venice.go
@@ -43,7 +43,7 @@ type VeniceProvider struct {
 }
 
 func NewVeniceProvider(apiKey, model, editModel, resolution string) *VeniceProvider {
-	apiKey = strings.TrimSpace(apiKey)
+	apiKey = normalizeVeniceAPIKey(apiKey)
 	if model == "" {
 		model = veniceDefaultModel
 	}
@@ -56,6 +56,14 @@ func NewVeniceProvider(apiKey, model, editModel, resolution string) *VeniceProvi
 		editMdl:    editModel,
 		resolution: resolution,
 	}
+}
+
+func normalizeVeniceAPIKey(apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if strings.HasPrefix(strings.ToLower(apiKey), "bearer ") {
+		apiKey = strings.TrimSpace(apiKey[len("Bearer "):])
+	}
+	return apiKey
 }
 
 func (p *VeniceProvider) Name() string {

--- a/internal/image/venice.go
+++ b/internal/image/venice.go
@@ -43,6 +43,7 @@ type VeniceProvider struct {
 }
 
 func NewVeniceProvider(apiKey, model, editModel, resolution string) *VeniceProvider {
+	apiKey = strings.TrimSpace(apiKey)
 	if model == "" {
 		model = veniceDefaultModel
 	}

--- a/internal/image/venice_test.go
+++ b/internal/image/venice_test.go
@@ -2,6 +2,13 @@ package image
 
 import "testing"
 
+func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
+	provider := NewVeniceProvider("  api-key\n", "", "", "")
+	if provider.apiKey != "api-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "api-key")
+	}
+}
+
 func TestNewVeniceProviderDefaults(t *testing.T) {
 	provider := NewVeniceProvider("api-key", "", "", "")
 	if provider.model != veniceDefaultModel {

--- a/internal/image/venice_test.go
+++ b/internal/image/venice_test.go
@@ -9,6 +9,13 @@ func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewVeniceProviderStripsBearerPrefix(t *testing.T) {
+	provider := NewVeniceProvider("  Bearer api-key\n", "", "", "")
+	if provider.apiKey != "api-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "api-key")
+	}
+}
+
 func TestNewVeniceProviderDefaults(t *testing.T) {
 	provider := NewVeniceProvider("api-key", "", "", "")
 	if provider.model != veniceDefaultModel {

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -296,9 +296,12 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		return NewXAIProvider(apiKey, cfg.Model), nil
 
 	case config.ProviderTypeVenice:
-		apiKey := cfg.ResolvedAPIKey
+		apiKey := strings.TrimSpace(cfg.ResolvedAPIKey)
 		if apiKey == "" {
-			apiKey = os.Getenv("VENICE_API_KEY")
+			apiKey = strings.TrimSpace(os.Getenv("VENICE_API_KEY"))
+		}
+		if apiKey == "" {
+			return nil, fmt.Errorf("provider %q requires VENICE_API_KEY or explicit config", name)
 		}
 		return NewVeniceProvider(apiKey, cfg.Model), nil
 

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -96,7 +96,7 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 			provider := NewXAIProvider(apiKey, model)
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		case config.ProviderTypeVenice:
-			apiKey := os.Getenv("VENICE_API_KEY")
+			apiKey := strings.TrimSpace(os.Getenv("VENICE_API_KEY"))
 			if apiKey == "" {
 				return nil, fmt.Errorf("provider %q requires VENICE_API_KEY or explicit config", name)
 			}
@@ -211,7 +211,7 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 			}
 			return NewXAIProvider(apiKey, ""), nil
 		case config.ProviderTypeVenice:
-			apiKey := os.Getenv("VENICE_API_KEY")
+			apiKey := strings.TrimSpace(os.Getenv("VENICE_API_KEY"))
 			if apiKey == "" {
 				return nil, fmt.Errorf("provider %q requires VENICE_API_KEY environment variable or explicit config", cfg.DefaultProvider)
 			}

--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -18,11 +18,19 @@ type VeniceProvider struct {
 }
 
 func NewVeniceProvider(apiKey, model string) *VeniceProvider {
-	apiKey = strings.TrimSpace(apiKey)
+	apiKey = normalizeVeniceAPIKey(apiKey)
 	if model == "" {
 		model = "venice-uncensored"
 	}
 	return &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(veniceBaseURL, apiKey, model, "Venice")}
+}
+
+func normalizeVeniceAPIKey(apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if strings.HasPrefix(strings.ToLower(apiKey), "bearer ") {
+		apiKey = strings.TrimSpace(apiKey[len("Bearer "):])
+	}
+	return apiKey
 }
 
 func (p *VeniceProvider) Capabilities() Capabilities {

--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -18,6 +18,7 @@ type VeniceProvider struct {
 }
 
 func NewVeniceProvider(apiKey, model string) *VeniceProvider {
+	apiKey = strings.TrimSpace(apiKey)
 	if model == "" {
 		model = "venice-uncensored"
 	}

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -5,8 +5,43 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
 )
+
+func TestCreateProviderFromConfig_VeniceRequiresAPIKey(t *testing.T) {
+	t.Setenv("VENICE_API_KEY", "")
+
+	_, err := createProviderFromConfig("venice", &config.ProviderConfig{Model: "venice-uncensored"})
+	if err == nil {
+		t.Fatal("expected missing Venice API key to return an error")
+	}
+	if !strings.Contains(err.Error(), "VENICE_API_KEY") {
+		t.Fatalf("expected VENICE_API_KEY guidance, got %v", err)
+	}
+}
+
+func TestCreateProviderFromConfig_VeniceTrimsConfiguredAPIKey(t *testing.T) {
+	t.Setenv("VENICE_API_KEY", "")
+
+	provider, err := createProviderFromConfig("venice", &config.ProviderConfig{
+		ResolvedAPIKey: "  test-key\n",
+		Model:          "venice-uncensored",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	venice, ok := provider.(*VeniceProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *VeniceProvider", provider)
+	}
+	if venice.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", venice.apiKey, "test-key")
+	}
+}
 
 func TestVeniceProviderCapabilities(t *testing.T) {
 	provider := NewVeniceProvider("key", "")

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -43,6 +43,48 @@ func TestCreateProviderFromConfig_VeniceTrimsConfiguredAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewProviderByName_VeniceTrimsEnvAPIKey(t *testing.T) {
+	t.Setenv("VENICE_API_KEY", "  test-key\n")
+
+	provider, err := NewProviderByName(&config.Config{}, "venice", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	retryProvider, ok := provider.(*RetryProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *RetryProvider", provider)
+	}
+	venice, ok := retryProvider.inner.(*VeniceProvider)
+	if !ok {
+		t.Fatalf("inner provider type = %T, want *VeniceProvider", retryProvider.inner)
+	}
+	if venice.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", venice.apiKey, "test-key")
+	}
+}
+
+func TestNewProvider_VeniceTrimsEnvAPIKey(t *testing.T) {
+	t.Setenv("VENICE_API_KEY", "  test-key\n")
+
+	provider, err := NewProvider(&config.Config{DefaultProvider: "venice"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	retryProvider, ok := provider.(*RetryProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *RetryProvider", provider)
+	}
+	venice, ok := retryProvider.inner.(*VeniceProvider)
+	if !ok {
+		t.Fatalf("inner provider type = %T, want *VeniceProvider", retryProvider.inner)
+	}
+	if venice.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", venice.apiKey, "test-key")
+	}
+}
+
 func TestVeniceProviderCapabilities(t *testing.T) {
 	provider := NewVeniceProvider("key", "")
 	caps := provider.Capabilities()

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -85,6 +85,13 @@ func TestNewProvider_VeniceTrimsEnvAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
+	provider := NewVeniceProvider("  test-key\n", "")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
 func TestVeniceProviderCapabilities(t *testing.T) {
 	provider := NewVeniceProvider("key", "")
 	caps := provider.Capabilities()

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -92,6 +92,13 @@ func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewVeniceProviderStripsBearerPrefix(t *testing.T) {
+	provider := NewVeniceProvider("  Bearer test-key\n", "")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
 func TestVeniceProviderCapabilities(t *testing.T) {
 	provider := NewVeniceProvider("key", "")
 	caps := provider.Capabilities()

--- a/internal/video/venice.go
+++ b/internal/video/venice.go
@@ -94,7 +94,7 @@ type VeniceProvider struct {
 
 func NewVeniceProvider(apiKey string) *VeniceProvider {
 	return &VeniceProvider{
-		apiKey:  apiKey,
+		apiKey:  strings.TrimSpace(apiKey),
 		baseURL: veniceBaseURL,
 		client:  &http.Client{},
 	}

--- a/internal/video/venice.go
+++ b/internal/video/venice.go
@@ -94,10 +94,18 @@ type VeniceProvider struct {
 
 func NewVeniceProvider(apiKey string) *VeniceProvider {
 	return &VeniceProvider{
-		apiKey:  strings.TrimSpace(apiKey),
+		apiKey:  normalizeVeniceAPIKey(apiKey),
 		baseURL: veniceBaseURL,
 		client:  &http.Client{},
 	}
+}
+
+func normalizeVeniceAPIKey(apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if strings.HasPrefix(strings.ToLower(apiKey), "bearer ") {
+		apiKey = strings.TrimSpace(apiKey[len("Bearer "):])
+	}
+	return apiKey
 }
 
 func (p *VeniceProvider) Quote(ctx context.Context, req Request) (*Quote, error) {

--- a/internal/video/venice_test.go
+++ b/internal/video/venice_test.go
@@ -16,6 +16,13 @@ func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewVeniceProviderStripsBearerPrefix(t *testing.T) {
+	provider := NewVeniceProvider("  Bearer test-key\n")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
 func TestResolveModel(t *testing.T) {
 	if got := ResolveModel("", false); got != veniceDefaultTextModel {
 		t.Fatalf("ResolveModel text default = %q, want %q", got, veniceDefaultTextModel)

--- a/internal/video/venice_test.go
+++ b/internal/video/venice_test.go
@@ -9,6 +9,13 @@ import (
 	"testing"
 )
 
+func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
+	provider := NewVeniceProvider("  test-key\n")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
 func TestResolveModel(t *testing.T) {
 	if got := ResolveModel("", false); got != veniceDefaultTextModel {
 		t.Fatalf("ResolveModel text default = %q, want %q", got, veniceDefaultTextModel)


### PR DESCRIPTION
## What

- validate that configured Venice chat providers have an API key before building the provider
- trim surrounding whitespace from the resolved `VENICE_API_KEY` value before using it
- add regression tests covering missing and whitespace-padded Venice keys

## Why

A Venice provider configured without a usable API key currently gets instantiated anyway, which defers the failure until the remote API returns `401 Authentication failed`. This surfaced in a live debug session and makes a local config problem look like a mysterious provider outage.

## How

- updated `createProviderFromConfig` to reject Venice providers with no resolved key
- reused the existing `VENICE_API_KEY` fallback, but now trim whitespace before use
- added unit tests to lock in the expected behavior
