### PR TITLE
fix: remove Retry-After text leaking into user-visible rate limit error messages

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -301,11 +301,6 @@ func parseChatGPTRateLimitError(body []byte, headers http.Header) error {
 
 	retryAfter := time.Duration(resetsIn) * time.Second
 
-	// For short waits, include Retry-After hint for the retry logic
-	if resetsIn > 0 && resetsIn <= 120 {
-		msg.WriteString(fmt.Sprintf(". Retry-After: %d", resetsIn))
-	}
-
 	return &RateLimitError{
 		Message:       msg.String(),
 		RetryAfter:    retryAfter,


### PR DESCRIPTION
## What

Remove 4 lines in `parseChatGPTRateLimitError` that appended `. Retry-After: N` to the user-visible error message string for short-wait (≤120 s) rate limit responses.

## Why

The comment claimed the text was "a hint for the retry logic", but the retry logic in `calculateBackoff` (retry.go) type-asserts the error directly to `*RateLimitError` and reads the `RetryAfter` struct field — it never parses the message string for a `*RateLimitError`. The regex fallback (`retryAfterRegex`) is only reached when the error is *not* a `*RateLimitError`, so the embedded text was dead code for this path.

The practical effect: users hitting a short-duration ChatGPT rate limit would see garbled messages like:

```
ChatGPT usage limit reached (team plan). Resets in 45s. Retry-After: 45
```

The `Retry-After: 45` suffix is implementation noise that should never appear in a user-facing error.

## How

Deleted the conditional block that appended the text. The `RetryAfter` duration field on `RateLimitError` is already populated and is what the retry logic actually consumes. No behaviour change for retries; error messages are now clean.
