### PR TITLE
fix: require explicit inline math delimiters in web UI

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -39,6 +39,28 @@ func TestStaticAssetsSupportEmbeddedVideoPlayback(t *testing.T) {
 	}
 }
 
+func TestStaticAssetsUseStrictMathDelimiters(t *testing.T) {
+	coreJS, err := StaticAsset("app-core.js")
+	if err != nil {
+		t.Fatalf("StaticAsset(app-core.js): %v", err)
+	}
+	coreSrc := string(coreJS)
+	for _, want := range []string{
+		"const MATH_DELIMITERS = [",
+		"{ left: '$$', right: '$$', display: true }",
+		"{ left: '\\\\[', right: '\\\\]', display: true }",
+		"{ left: '\\\\(', right: '\\\\)', display: false }",
+		"delimiters: MATH_DELIMITERS,",
+	} {
+		if !strings.Contains(coreSrc, want) {
+			t.Fatalf("app-core.js missing %q", want)
+		}
+	}
+	if strings.Contains(coreSrc, "{ left: '$', right: '$', display: false }") {
+		t.Fatal("app-core.js still enables single-dollar inline math")
+	}
+}
+
 func TestStaticAssetsSupportSessionStreamDetachOnSwitch(t *testing.T) {
 	sessionsJS, err := StaticAsset("app-sessions.js")
 	if err != nil {

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -117,15 +117,18 @@ marked.use({
   gfm: true
 });
 
+// Be strict about inline math delimiters. Single-dollar math collides with
+// ordinary currency amounts in LLM output, so require \(...\) for inline math.
+const MATH_DELIMITERS = [
+  { left: '$$', right: '$$', display: true },
+  { left: '\\[', right: '\\]', display: true },
+  { left: '\\(', right: '\\)', display: false }
+];
+
 const renderMath = (target) => {
   if (!target || typeof renderMathInElement !== 'function') return;
   renderMathInElement(target, {
-    delimiters: [
-      { left: '$$', right: '$$', display: true },
-      { left: '\\[', right: '\\]', display: true },
-      { left: '$', right: '$', display: false },
-      { left: '\\(', right: '\\)', display: false }
-    ],
+    delimiters: MATH_DELIMITERS,
     ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'option'],
     throwOnError: false
   });


### PR DESCRIPTION
## What

- remove single-dollar (`$...$`) inline math rendering from the web UI
- keep explicit math delimiters only: `$$...$$`, `\[...\]`, and `\(...\)`
- add an embedded-asset test that locks in the stricter delimiter set and fails if single-dollar inline math comes back

## Why

The current KaTeX auto-render config is too lax for LLM output. Currency like `$100` / `$806` gets misread as math and mangles normal prose. Modern markdown/math renderers tend to be stricter here for exactly that reason.

This change makes inline math opt-in via clear escapes instead of guessing from ordinary dollar signs.

## Verification

- `go build ./...`
- `go test ./...`
