### PR TITLE
fix: materialise image data in MCP tool responses for claude-bin

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -157,10 +157,18 @@ func (p *ClaudeBinProvider) SetEnv(env map[string]string) {
 // to satisfy the ToolExecutorSetter interface in engine.go.
 func (p *ClaudeBinProvider) SetToolExecutor(executor func(ctx context.Context, name string, args json.RawMessage) (ToolOutput, error)) {
 	// Wrap the ToolOutput executor to satisfy the mcphttp.ToolExecutor (string, error) interface.
-	// MCP tools only use the text content — diffs/images are forwarded via events.
+	// For tool outputs with image data, materialise images to temp files and include their
+	// paths in the response text so Claude CLI can read them natively as vision inputs.
 	p.toolExecutor = func(ctx context.Context, name string, args json.RawMessage) (string, error) {
 		output, err := executor(ctx, name, args)
-		return output.Content, err
+		if err != nil {
+			return output.Content, err
+		}
+		result := &ToolResult{
+			Content:      output.Content,
+			ContentParts: output.ContentParts,
+		}
+		return p.processToolResultContent(result), nil
 	}
 }
 


### PR DESCRIPTION
## What

Route `view_image` (and any other tool with image output) through `processToolResultContent` in the `SetToolExecutor` MCP wrapper, so image data is materialised to temp files and their paths are included in the MCP response text that Claude CLI receives.

## Why

PR #174 fixed `processToolResultContent` for the prompt-rebuild path (re-sending full history). But the claude-bin provider calls tools via MCP *during* streaming — and the `SetToolExecutor` wrapper only returned `output.Content`, silently dropping `ContentParts` (including image data).

The flow:
1. Claude CLI calls `view_image` via MCP during streaming
2. `SetToolExecutor` wrapper executes the tool → gets `ToolOutput` with `ContentParts` containing image base64
3. **Before this fix**: returns only `output.Content` (text metadata) — image dropped
4. Claude CLI stores the text-only result in its session; session continuity means the full `req.Messages` tool result (with `ContentParts`) is never re-sent on subsequent turns

Claude CLI can load image file paths embedded in tool result text as native vision inputs (verified by direct test). By running the output through `processToolResultContent`, the image is written to a temp file and its path appended — Claude CLI then sees and processes the image.

## Test

Confirmed manually: `claude -p "Tool result (view_image): ...\n/tmp/term-llm-img-XXX.jpg"` correctly describes the image. Without this fix the model only saw metadata text and couldn't describe the photo.
