### PR TITLE
fix: inject [image saved at: path] text block in claude_bin SDK path

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -1267,6 +1267,9 @@ func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID s
 							Data:      base64Data,
 						},
 					})
+					if part.ImagePath != "" {
+						blocks = append(blocks, sdkContentBlock{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What

In the `claude_bin` SDK path, after sending an uploaded image as base64, also append a `[image saved at: <path>]` text block when `ImagePath` is set.

## Why

Every other provider (anthropic, openai_compat, responses_api, gemini) already does this — it lets the agent know where the uploaded file lives on disk so it can pass the path to tools like `image_generate`, `view_image`, etc.

The `claude_bin` SDK path was the only one missing this annotation. The image was sent correctly (as base64) but the agent had no way to reference the file by path.

## Change

3 lines added to `internal/llm/claude_bin.go` — after appending the image block, inject a text block with the saved path, matching the pattern in all other providers.
