### PR TITLE
feat: suppress iOS keyboard navigation bar and autocorrect toolbar

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1281,6 +1281,8 @@ const openAuthModal = (errorText = '', required = !state.token) => {
   elements.modelSelect.value = state.selectedModel;
   app.refreshNotificationUI();
   elements.authModal.classList.remove('hidden');
+  elements.modelSelect.removeAttribute('tabindex');
+  elements.authTokenInput.removeAttribute('tabindex');
 
   setTimeout(() => {
     if (required) {
@@ -1294,6 +1296,8 @@ const closeAuthModal = () => {
   if (state.authRequired && !state.token) return;
   elements.authModal.classList.add('hidden');
   elements.authError.textContent = '';
+  elements.modelSelect.setAttribute('tabindex', '-1');
+  elements.authTokenInput.setAttribute('tabindex', '-1');
 };
 
 const handleAuthFailure = () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -184,7 +184,7 @@
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
             </button>
             <input type="file" id="fileInput" multiple hidden>
-            <textarea id="promptInput" class="prompt" rows="1" placeholder="Message…" aria-label="Message"></textarea>
+            <textarea id="promptInput" class="prompt" rows="1" placeholder="Message…" aria-label="Message" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
             <div class="composer-actions">
               <button class="stop-btn" id="stopBtn" type="button">Stop</button>
               <button class="composer-icon-btn voice-btn" id="voiceBtn" type="button" title="Record voice message" aria-label="Record voice message">
@@ -206,13 +206,13 @@
       <h2 id="authModalTitle">Settings</h2>
       <div class="settings-field">
         <label class="settings-label" for="modelSelect">Model</label>
-        <select class="settings-select" id="modelSelect" title="Model selection">
+        <select class="settings-select" id="modelSelect" title="Model selection" tabindex="-1">
           <option value="">Auto (server default)</option>
         </select>
       </div>
       <div class="settings-field">
         <label class="settings-label" for="authTokenInput">Bearer token</label>
-        <input id="authTokenInput" type="password" placeholder="sk-..." autocomplete="off">
+        <input id="authTokenInput" type="password" placeholder="sk-..." autocomplete="off" tabindex="-1">
       </div>
       <div class="settings-field">
         <div class="settings-row">


### PR DESCRIPTION
## What

Suppress the iOS keyboard navigation bar (↑↓✓) and reduce the AutoFill/Format accessory bar in the web UI.

## Changes

**`index.html` — textarea attributes:**
Add `autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"` to `#promptInput`. This reduces the iOS AutoFill/Format accessory bar above the keyboard.

**`index.html` — modal input tabindex:**
Set `tabindex="-1"` on `#modelSelect` and `#authTokenInput` by default. iOS counts all focusable inputs on the page (even hidden ones) when deciding whether to show the ↑↓✓ navigation toolbar. With those two hidden-modal inputs excluded, the toolbar disappears while the main chat view is active.

**`app-stream.js` — tabindex lifecycle:**
`openAuthModal` restores tabindex to normal so the settings modal is fully usable. `closeAuthModal` resets them to `-1`.

## Why

The ↑↓✓ bar and AutoFill toolbar consume vertical space and are not useful in a single-input chat UI. The keyboard can still be dismissed by tapping outside the textarea.
