### PR TITLE
fix: let header title use full available width on mobile

### DIFF
--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -380,6 +380,7 @@
       display: inline-flex;
       align-items: center;
       gap: 0.6rem;
+      flex: 1;
       min-width: 0;
     }
 
@@ -395,7 +396,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: min(48vw, 520px);
+      min-width: 0;
     }
 
     .connection-state {
@@ -1755,9 +1756,6 @@
         display: inline-flex;
       }
 
-      .header-title {
-        max-width: 38vw;
-      }
 
       .header-right {
         margin-left: auto;


### PR DESCRIPTION
## What

Remove the hard `max-width` constraints on `.header-title` and replace with proper flex layout.

- `.header-left` gets `flex: 1` so it expands to fill all space not consumed by `.header-right`
- `.header-title` drops `max-width: min(48vw, 520px)` (desktop) and `max-width: 38vw` (mobile override), replaced with `min-width: 0`
- Title still truncates with `…` via the existing `overflow: hidden; text-overflow: ellipsis` — it just does so at the actual available boundary rather than an arbitrary fraction of the viewport

## Why

On mobile, `38vw` was truncating titles far too early — e.g. "Anything new on nzbgeek" rendered as "Anything new on …". The right-side action buttons take up maybe 25–30% of the width, leaving plenty of room the title wasn't allowed to use.
