### PR TITLE
fix: make progress tool schema compatible with OpenAI Responses API strict mode

### DIFF
--- a/internal/tools/progressive.go
+++ b/internal/tools/progressive.go
@@ -56,20 +56,20 @@ func (t *progressTool) Spec() llm.ToolSpec {
 					"additionalProperties": true,
 				},
 				"reason": map[string]any{
-					"type":        "string",
+					"type":        []string{"string", "null"},
 					"description": "Why this checkpoint is being saved: voluntary, milestone, or finalize.",
-					"enum":        []string{"voluntary", "milestone", "finalize"},
+					"enum":        []any{"voluntary", "milestone", "finalize", nil},
 				},
 				"message": map[string]any{
-					"type":        "string",
+					"type":        []string{"string", "null"},
 					"description": "Optional short summary of what changed.",
 				},
 				"final": map[string]any{
-					"type":        "boolean",
+					"type":        []string{"boolean", "null"},
 					"description": "Whether this checkpoint is the final saved state for the run.",
 				},
 			},
-			"required":             []string{"state"},
+			"required":             []string{"state", "reason", "message", "final"},
 			"additionalProperties": false,
 		},
 	}


### PR DESCRIPTION
## What

Fix the `update_progress` and `finalize_progress` tool schemas to be compatible with OpenAI's Responses API strict mode.

## Why

When running `term-llm ask --progressive` with the `chatgpt` provider (gpt-5.4), the request fails with:

```
Responses API error (status 400): Invalid schema for function 'update_progress':
In context=(), 'required' is required to be supplied and to be an array including
every key in properties. Extra required key 'state' supplied.
```

OpenAI's Responses API enforces strict JSON schema validation: when `additionalProperties: false` is set, **every** key in `properties` must also appear in `required`. The previous schema only had `state` in `required`, omitting `reason`, `message`, and `final`.

## Fix

- Add all four properties to `required`
- Mark the three optional fields (`reason`, `message`, `final`) as nullable (`["type", "null"]`) so the LLM can satisfy the required constraint by passing `null` rather than having to supply a value

The `enum` for `reason` is also updated to include `null` as a valid value to match.

## Testing

All existing tests pass — the nullable types are semantically equivalent for the Go-side parsing (`json.Unmarshal` treats a JSON `null` as a zero value for the field type).
