### PR TITLE
fix: don't use strict mode for Responses API tools with free-form object schemas

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -184,6 +184,44 @@ func normalizeSchemaForOpenAIStrict(schema map[string]interface{}) map[string]in
 	return normalizeFreeFormMapProperties(normalizeSchemaForOpenAI(schema))
 }
 
+// schemaContainsFreeFormObject reports whether any object in the schema tree uses
+// additionalProperties: true (boolean), which cannot be expressed in OpenAI strict
+// mode. Tools with such schemas must be sent with Strict: false.
+func schemaContainsFreeFormObject(schema map[string]interface{}) bool {
+	if schema == nil {
+		return false
+	}
+	if v, ok := schema["additionalProperties"].(bool); ok && v {
+		return true
+	}
+	if props, ok := schema["properties"].(map[string]interface{}); ok {
+		for _, val := range props {
+			if propSchema, ok := val.(map[string]interface{}); ok {
+				if schemaContainsFreeFormObject(propSchema) {
+					return true
+				}
+			}
+		}
+	}
+	if items, ok := schema["items"].(map[string]interface{}); ok {
+		if schemaContainsFreeFormObject(items) {
+			return true
+		}
+	}
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		if arr, ok := schema[key].([]interface{}); ok {
+			for _, item := range arr {
+				if itemSchema, ok := item.(map[string]interface{}); ok {
+					if schemaContainsFreeFormObject(itemSchema) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 // normalizeFreeFormMapProperties converts any free-form map schema (one whose
 // additionalProperties is a schema object, not a bool) into an array of
 // {key, value} pair objects. OpenAI strict mode requires additionalProperties:
@@ -341,10 +379,16 @@ func normalizeSchemaRecursive(schema map[string]interface{}) map[string]interfac
 	}
 
 	// OpenAI requires additionalProperties to be false for objects.
-	// Exception: if additionalProperties is already a schema map (e.g. {"type":"string"}),
-	// preserve it — that's a valid free-form map type (like the env parameter).
+	// Exceptions:
+	//   - additionalProperties is already a schema map (e.g. {"type":"string"}) — free-form
+	//     typed map; normalizeFreeFormMapProperties will convert it to {key,value} pairs.
+	//   - additionalProperties is the boolean true — completely free-form object; preserving
+	//     true lets callers detect this case and opt out of strict mode.
 	if schema["type"] == "object" || schema["properties"] != nil {
-		if _, isSchemaMap := schema["additionalProperties"].(map[string]interface{}); !isSchemaMap {
+		switch schema["additionalProperties"].(type) {
+		case map[string]interface{}, bool:
+			// preserve: either an explicit schema map or an explicit boolean
+		default:
 			schema["additionalProperties"] = false
 		}
 	}

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -357,19 +357,28 @@ func buildResponsesReasoningItem(part Part) ResponsesInputItem {
 	return item
 }
 
-// BuildResponsesTools converts []ToolSpec to Open Responses format with schema normalization
+// BuildResponsesTools converts []ToolSpec to Open Responses format with schema normalization.
+// Tools whose schema contains a free-form object (additionalProperties: true) cannot be
+// expressed in OpenAI strict mode and are sent with Strict: false.
 func BuildResponsesTools(specs []ToolSpec) []any {
 	if len(specs) == 0 {
 		return nil
 	}
 	tools := make([]any, 0, len(specs))
 	for _, spec := range specs {
+		var params map[string]interface{}
+		strict := !schemaContainsFreeFormObject(spec.Schema)
+		if strict {
+			params = normalizeSchemaForOpenAIStrict(spec.Schema)
+		} else {
+			params = normalizeSchemaForOpenAI(spec.Schema)
+		}
 		tools = append(tools, ResponsesTool{
 			Type:        "function",
 			Name:        spec.Name,
 			Description: spec.Description,
-			Parameters:  normalizeSchemaForOpenAIStrict(spec.Schema),
-			Strict:      true,
+			Parameters:  params,
+			Strict:      strict,
 		})
 	}
 	return tools

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -351,6 +351,83 @@ func TestBuildResponsesTools(t *testing.T) {
 	}
 }
 
+// TestBuildResponsesTools_FreeFormObjectUsesNonStrictMode reproduces the bug where a
+// tool schema that contains a free-form object property (additionalProperties: true)
+// was sent to the Responses API with Strict: true, causing OpenAI to reject the schema
+// with "Extra required key 'state' supplied".
+func TestBuildResponsesTools_FreeFormObjectUsesNonStrictMode(t *testing.T) {
+	// Mirrors the progress tool schema that triggered the bug.
+	specs := []ToolSpec{
+		{
+			Name:        "update_progress",
+			Description: "Save progress state",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"state": map[string]interface{}{
+						"type":                 "object",
+						"description":          "Free-form state object",
+						"additionalProperties": true,
+					},
+					"reason": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required":             []string{"state", "reason"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "regular_tool",
+			Description: "A tool with no free-form properties",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"additionalProperties": false,
+			},
+		},
+	}
+
+	tools := BuildResponsesTools(specs)
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+
+	progressTool, ok := tools[0].(ResponsesTool)
+	if !ok {
+		t.Fatal("expected ResponsesTool")
+	}
+	// Tool with free-form object must NOT use strict mode.
+	if progressTool.Strict {
+		t.Error("expected Strict=false for tool with additionalProperties:true property")
+	}
+	// The 'state' property must still be present with additionalProperties: true preserved.
+	props, ok := progressTool.Parameters["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected parameters.properties to be a map")
+	}
+	stateSchema, ok := props["state"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected state property schema to be a map")
+	}
+	if stateSchema["additionalProperties"] != true {
+		t.Errorf("expected state.additionalProperties=true, got %v", stateSchema["additionalProperties"])
+	}
+
+	regularTool, ok := tools[1].(ResponsesTool)
+	if !ok {
+		t.Fatal("expected ResponsesTool")
+	}
+	// Regular tool (no free-form object) must use strict mode.
+	if !regularTool.Strict {
+		t.Error("expected Strict=true for tool without free-form object properties")
+	}
+}
+
 func TestBuildResponsesToolChoice(t *testing.T) {
 	tests := []struct {
 		choice   ToolChoice


### PR DESCRIPTION
## What

Fix `update_progress` and `finalize_progress` tools crashing with a 400 error from the OpenAI Responses API when used with models like `gpt-5.4`:

```
Responses API error (status 400): Invalid schema for function 'finalize_progress':
In context=(), 'required' is required to be supplied and to be an array including
every key in properties. Extra required key 'state' supplied.
```

## Why

The `state` parameter of the progress tools is defined as a free-form JSON object (`additionalProperties: true`). The schema normalisation pipeline in `normalizeSchemaRecursive` was overwriting **any** non-schema-map value of `additionalProperties` with `false`, including the explicit boolean `true`. This produced:

```json
{ "type": "object", "additionalProperties": false }
```

…with **no `properties` key** — an empty-object schema. OpenAI's Responses API strict-mode validator rejected it: it saw `state` in the parent `required` array but found its schema was an invalid strict object (no `properties` defined), and reported the confusing "Extra required key 'state' supplied" error.

## How

Two targeted changes:

1. **`normalizeSchemaRecursive`** — now preserves any explicit boolean value for `additionalProperties` (not just schema-map values). `additionalProperties: true` is valid JSON Schema and must not be silently clobbered.

2. **`BuildResponsesTools`** — introduces `schemaContainsFreeFormObject`, which walks the schema tree looking for `additionalProperties: true`. Tools that contain such a property cannot be expressed in OpenAI strict mode; they are sent with `Strict: false` and plain (non-strict) schema normalisation. All other tools continue to use `Strict: true`.

A regression test (`TestBuildResponsesTools_FreeFormObjectUsesNonStrictMode`) verifies that a progress-tool-shaped schema produces `Strict: false` and preserves `additionalProperties: true` on the `state` property, while a regular tool still gets `Strict: true`.
