### PR TITLE
fix: progressive tools compatibility with OpenAI Responses API strict mode

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -295,6 +295,30 @@ func deepCopySlice(s []interface{}) []interface{} {
 
 // normalizeSchemaRecursive applies OpenAI normalization recursively
 func normalizeSchemaRecursive(schema map[string]interface{}) map[string]interface{} {
+	// Handle union types expressed as []string (e.g. []string{"string", "null"}).
+	// OpenAI strict mode requires anyOf instead of array type values.
+	if typeSlice, ok := schema["type"].([]string); ok {
+		anyOf := make([]interface{}, 0, len(typeSlice))
+		enum, hasEnum := schema["enum"]
+		delete(schema, "enum")
+		delete(schema, "type")
+		for _, t := range typeSlice {
+			branch := map[string]interface{}{"type": t}
+			if hasEnum && t != "null" {
+				branch["enum"] = enum
+			}
+			anyOf = append(anyOf, branch)
+		}
+		schema["anyOf"] = anyOf
+		// Recurse into the newly created anyOf branches.
+		for i, item := range anyOf {
+			if m, ok := item.(map[string]interface{}); ok {
+				anyOf[i] = normalizeSchemaRecursive(m)
+			}
+		}
+		return schema
+	}
+
 	// Remove unsupported format values (OpenAI only supports a limited set)
 	if format, ok := schema["format"].(string); ok {
 		// OpenAI supported formats: date-time, date, time, email

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -364,12 +364,20 @@ func BuildResponsesTools(specs []ToolSpec) []any {
 	}
 	tools := make([]any, 0, len(specs))
 	for _, spec := range specs {
+		var params map[string]interface{}
+		strict := true
+		if spec.NoStrict {
+			params = normalizeSchemaForOpenAI(spec.Schema)
+			strict = false
+		} else {
+			params = normalizeSchemaForOpenAIStrict(spec.Schema)
+		}
 		tools = append(tools, ResponsesTool{
 			Type:        "function",
 			Name:        spec.Name,
 			Description: spec.Description,
-			Parameters:  normalizeSchemaForOpenAIStrict(spec.Schema),
-			Strict:      true,
+			Parameters:  params,
+			Strict:      strict,
 		})
 	}
 	return tools

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -117,6 +117,10 @@ type ToolSpec struct {
 	Name        string
 	Description string
 	Schema      map[string]interface{}
+	// NoStrict disables OpenAI strict mode for this tool. Use when the schema
+	// contains free-form objects (additionalProperties: true) or union types
+	// that are incompatible with OpenAI's strict structured-output requirements.
+	NoStrict bool
 }
 
 // ToolChoiceMode controls tool selection behavior.

--- a/internal/tools/progressive.go
+++ b/internal/tools/progressive.go
@@ -47,6 +47,9 @@ func (t *progressTool) Spec() llm.ToolSpec {
 	return llm.ToolSpec{
 		Name:        t.name,
 		Description: t.description,
+		// NoStrict: state is a free-form object and optional fields use union
+		// types — both are incompatible with OpenAI strict mode.
+		NoStrict: true,
 		Schema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
## What

Fixes `update_progress` and `finalize_progress` tools crashing with OpenAI's Responses API (`400: Extra required key 'state' supplied`).

Two root causes:

### 1. `state` property: `additionalProperties: true` stomped to `false`

`normalizeSchemaRecursive` checks `schema["additionalProperties"].(map[string]interface{})` to decide whether to preserve it. `true` (bool) fails that assertion, so it gets overwritten with `false`. The result is an object schema with `additionalProperties: false` and no `properties` — an object that accepts nothing. OpenAI's strict-mode validator then rejects the tool entirely.

### 2. `reason`/`message`/`final`: `[]string{"string","null"}` union types

OpenAI strict mode doesn't support array type values. `"type": ["string", "null"]` must be expressed as `anyOf: [{type:"string"},{type:"null"}]`. The normalization pipeline passed these through unchanged.

## Fixes

- **`ToolSpec.NoStrict bool`** — new opt-out field. When set, the tool uses `normalizeSchemaForOpenAI` (no strict transforms) and `strict: false` in the Responses API payload.
- **Progressive tools set `NoStrict: true`** — `state` is inherently free-form; strict mode can't represent it without degrading the interface.
- **`normalizeSchemaRecursive` now handles `[]string` types** — converts `"type": []string{"T1","T2"}` to `anyOf: [{type:T1},{type:T2}]`, with enum moved to the non-null branch. Applies to any strict-mode tool going forward.
