### PR TITLE
fix: remove additionalProperties constraints from progress tool schema to fix Responses API rejection

### DIFF
--- a/internal/tools/progressive.go
+++ b/internal/tools/progressive.go
@@ -51,26 +51,24 @@ func (t *progressTool) Spec() llm.ToolSpec {
 			"type": "object",
 			"properties": map[string]any{
 				"state": map[string]any{
-					"type":                 "object",
-					"description":          "Best-so-far structured state for the task.",
-					"additionalProperties": true,
+					"type":        "object",
+					"description": "Best-so-far structured state for the task.",
 				},
 				"reason": map[string]any{
-					"type":        []string{"string", "null"},
+					"type":        "string",
 					"description": "Why this checkpoint is being saved: voluntary, milestone, or finalize.",
-					"enum":        []any{"voluntary", "milestone", "finalize", nil},
+					"enum":        []string{"voluntary", "milestone", "finalize"},
 				},
 				"message": map[string]any{
-					"type":        []string{"string", "null"},
+					"type":        "string",
 					"description": "Optional short summary of what changed.",
 				},
 				"final": map[string]any{
-					"type":        []string{"boolean", "null"},
+					"type":        "boolean",
 					"description": "Whether this checkpoint is the final saved state for the run.",
 				},
 			},
-			"required":             []string{"state", "reason", "message", "final"},
-			"additionalProperties": false,
+			"required": []string{"state"},
 		},
 	}
 }


### PR DESCRIPTION
## What

Remove `additionalProperties` constraints from the `update_progress` / `finalize_progress` tool JSON schema, and restore `required` to only `["state"]`.

## Why

The OpenAI Responses API (gpt-5.x) enforces strict schema mode whenever it encounters `"additionalProperties": false` at the root of a function's parameters schema. Strict mode requires that **every** nested object also carry `"additionalProperties": false`. The `state` property was defined as `"type": "object"` with `"additionalProperties": true` — a free-form object — which violates that requirement.

OpenAI's validation then drops `state` from the accepted properties list, finds it still present in `required`, and returns:

```
Invalid schema for function 'update_progress': In context=(), 'required' is required to
be supplied and to be an array including every key in properties.
Extra required key 'state' supplied.
```

PR #179 attempted to fix this by adding all four fields to `required` and making their types nullable, but left `additionalProperties: true` on `state` untouched — so the same error persisted.

## How

- Removed `"additionalProperties": true` from the `state` property schema (no constraint = API accepts it freely).
- Removed `"additionalProperties": false` from the root schema (avoids triggering strict mode entirely).
- Reverted `required` back to `["state"]` — the only genuinely mandatory field.
- Reverted `reason`/`message`/`final` back to simple (non-nullable) types, which is sufficient since they are not in `required`.

All existing tests pass.
