### PR TITLE
docs: add Telegram bot guide, fix job-runner serve syntax, document multi-platform and --setup

### DIFF
--- a/docs-site/content/guides/job-runner.md
+++ b/docs-site/content/guides/job-runner.md
@@ -12,7 +12,7 @@ next:
 Use the jobs runtime when you want scheduled, delayed, or manually triggered background work:
 
 ```bash
-term-llm serve --platform jobs --port 8080
+term-llm serve jobs --port 8080
 ```
 
 ### Jobs V2 API

--- a/docs-site/content/guides/telegram-bot.md
+++ b/docs-site/content/guides/telegram-bot.md
@@ -1,0 +1,128 @@
+---
+title: "Telegram Bot"
+weight: 8
+description: "Run term-llm as a Telegram bot: create a bot, configure access control, and chat with your agent from any device."
+kicker: "Messaging"
+featured: true
+next:
+  label: Search
+  url: /guides/search/
+---
+
+## What this gives you
+
+A Telegram bot that runs your agent. You send a message from your phone or desktop; the bot replies with a streamed response. Sessions persist per chat: history carries over between messages until you `/reset`. Every conversation is stored in the same sessions DB as web and CLI interactions.
+
+## Step 1: Create a bot with BotFather
+
+1. Open Telegram and start a chat with [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts (name + username)
+3. Copy the token BotFather gives you — it looks like `123456789:ABCdef...`
+
+## Step 2: Configure the token
+
+The fastest path is the setup wizard:
+
+```bash
+term-llm serve telegram --setup
+```
+
+This prompts for your token and saves it to `config.yaml` under `serve.telegram`. Re-run with `--setup` any time to update credentials.
+
+To configure manually, add to `~/.config/term-llm/config.yaml`:
+
+```yaml
+serve:
+  telegram:
+    token: "123456789:ABCdef..."
+```
+
+## Step 3: Restrict access
+
+Without an allowlist, anyone who knows your bot's username can chat with it. You almost certainly want to restrict this.
+
+You can allowlist by **numeric user ID** (more stable) or by **username**:
+
+```yaml
+serve:
+  telegram:
+    token: "123456789:ABCdef..."
+    allowed_user_ids:
+      - 987654321
+    allowed_usernames:
+      - yourusername
+```
+
+To find your numeric user ID, forward a message from yourself to [@userinfobot](https://t.me/userinfobot).
+
+Messages from non-allowlisted users are silently ignored and logged.
+
+## Step 4: Start the bot
+
+```bash
+term-llm serve telegram
+```
+
+With an agent and yolo mode (auto-approve tool calls):
+
+```bash
+term-llm serve telegram --agent jarvis --yolo
+```
+
+Combined with the web UI on the same process:
+
+```bash
+term-llm serve telegram web
+```
+
+## Bot commands
+
+| Command | What it does |
+|---------|-------------|
+| `/start` | Show welcome message and command list |
+| `/help`  | Same as `/start` |
+| `/reset` | Clear conversation history and start a fresh session |
+| `/status` | Show message count and last activity time for the current session |
+
+## Configuration reference
+
+All fields live under `serve.telegram` in `config.yaml`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `token` | string | — | Bot token from BotFather. Required. |
+| `allowed_user_ids` | list of int | — | Numeric Telegram user IDs allowed to use the bot. |
+| `allowed_usernames` | list of string | — | Telegram usernames allowed to use the bot (without `@`). |
+| `idle_timeout` | int (minutes) | — | Close idle sessions after this many minutes. |
+| `interrupt_timeout` | int (seconds) | 3 | How long to wait for an in-flight response to stop before interrupting. |
+
+## CLI flags
+
+```bash
+term-llm serve telegram \
+  --agent jarvis \
+  --provider anthropic \
+  --yolo \
+  --telegram-carryover-chars 4000
+```
+
+`--telegram-carryover-chars` (default `4000`): when a session is reset via `/reset`, this many characters of the previous conversation are carried into the new session as context. Set to `0` to start completely fresh on each reset.
+
+## Set default platforms in config
+
+If you always run the same combination, set it in `config.yaml` so you can just run `term-llm serve`:
+
+```yaml
+serve:
+  platforms:
+    - telegram
+    - web
+```
+
+`term-llm serve` with no arguments reads from `serve.platforms`.
+
+## Related pages
+
+- [Notifications](/guides/notifications/) — send one-off Telegram messages via `term-llm notify`
+- [Web UI and API](/guides/web-ui-and-api/) — run the browser UI alongside the bot
+- [Agents](/guides/agents/) — configure which agent handles bot conversations

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -21,7 +21,31 @@ term-llm serve web --no-ui
 term-llm serve web --base-path /chat
 term-llm serve web --host 127.0.0.1 --port 8080
 term-llm serve web jobs
+term-llm serve web jobs telegram   # all three platforms at once
 ```
+
+## First-time setup
+
+Use `--setup` to run the interactive credential wizard for the selected platforms:
+
+```bash
+term-llm serve web --setup
+```
+
+Re-run with `--setup` any time to update stored credentials.
+
+## Default platforms
+
+To avoid specifying platforms every time, set them in `config.yaml`:
+
+```yaml
+serve:
+  platforms:
+    - web
+    - jobs
+```
+
+`term-llm serve` with no positional arguments reads from `serve.platforms`.
 
 ## What it serves
 
@@ -104,5 +128,6 @@ Use the web runtime when you want:
 ## Related pages
 
 - [Jobs](/guides/job-runner/)
+- [Telegram Bot](/guides/telegram-bot/)
 - [Configuration](/reference/configuration/)
 - [Search](/guides/search/)


### PR DESCRIPTION
## What

- **New page**: `docs-site/content/guides/telegram-bot.md` — full guide for running the Telegram bot platform
- **Bug fix**: `job-runner.md` was using the old `--platform jobs` flag syntax; corrected to `term-llm serve jobs`
- **Web UI guide additions**: multi-platform serving (`serve web jobs telegram`), `--setup` wizard, and `serve.platforms` config key

## Telegram bot guide covers

- User journey: BotFather → token → config → allowlist → run
- `--setup` wizard
- Config reference: `token`, `allowed_user_ids`, `allowed_usernames`, `idle_timeout`, `interrupt_timeout`
- CLI flags: `--telegram-carryover-chars`
- Bot commands: `/start`, `/help`, `/reset`, `/status`
- Multi-platform combinations
- `serve.platforms` default config
- Cross-links to notifications, web UI, agents guides

## Why

Telegram bot mode had zero documentation. The job-runner page had a broken example command. Multi-platform serving and the `--setup` flag were undocumented across all serve guides.
