### PR TITLE
fix: prevent iOS viewport zoom-out on docs site

### DIFF
--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -14,7 +14,8 @@
   --shadow: rgba(0, 0, 0, 0.34);
 }
 * { box-sizing: border-box; }
-html { font-size: 16px; scroll-behavior: smooth; }
+html { font-size: 16px; scroll-behavior: smooth; max-width: 100%; overflow-x: clip; }
+body { overflow-x: clip; }
 body {
   margin: 0;
   min-height: 100vh;
@@ -138,7 +139,7 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
 .markdown pre { overflow-x: auto; padding: 1rem; border-radius: 16px; background: rgba(4,8,16,0.8); border: 1px solid rgba(125,211,252,0.12); }
 .markdown code { background: rgba(7, 13, 24, 0.8); padding: 0.15rem 0.35rem; border-radius: 6px; }
 .markdown pre code { background: transparent; padding: 0; }
-.markdown table { width: 100%; border-collapse: collapse; font-size: 0.95rem; }
+.markdown table { display: block; width: max-content; max-width: 100%; overflow-x: auto; border-collapse: collapse; font-size: 0.95rem; }
 .markdown th, .markdown td { padding: 0.75rem; border-bottom: 1px solid rgba(125,211,252,0.12); text-align: left; vertical-align: top; }
 .markdown th { color: var(--text); }
 .markdown blockquote { margin-left: 0; padding-left: 1rem; border-left: 3px solid rgba(114,241,184,0.35); color: var(--muted); }


### PR DESCRIPTION
## What

Two CSS fixes for the docs site on iOS Safari:

1. **`overflow-x: clip` on `html` and `body`** — prevents iOS from widening the viewport to accommodate overflowing content, which caused the whole page to zoom out and render tiny.

2. **Markdown tables scroll horizontally** — changed `.markdown table` to `display: block` with `overflow-x: auto` so wide tables scroll within their container rather than blowing out the page width.

## Why

On iPhone, if any element is wider than the viewport, iOS Safari zooms out to fit everything in view. The page was rendering at roughly 60% zoom, making all text tiny. The two most common culprits in this layout are wide markdown tables and fixed-minimum-width grid columns — this addresses both.

## Screenshots

Before: full page zoomed out ~60% on iPhone, tiny text throughout.
After: renders at normal size, wide tables get a horizontal scrollbar.
