### PR TITLE
fix: mobile viewport rendering on iOS

### DIFF
--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -139,6 +139,7 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
 .markdown pre { overflow-x: auto; padding: 1rem; border-radius: 16px; background: rgba(4,8,16,0.8); border: 1px solid rgba(125,211,252,0.12); }
 .markdown code { background: rgba(7, 13, 24, 0.8); padding: 0.15rem 0.35rem; border-radius: 6px; }
 .markdown pre code { background: transparent; padding: 0; }
+.markdown img { max-width: 100%; height: auto; }
 .markdown table { display: block; width: max-content; max-width: 100%; overflow-x: auto; border-collapse: collapse; font-size: 0.95rem; }
 .markdown th, .markdown td { padding: 0.75rem; border-bottom: 1px solid rgba(125,211,252,0.12); text-align: left; vertical-align: top; }
 .markdown th { color: var(--text); }
@@ -153,7 +154,10 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
   .install-panel { grid-template-columns: 1fr; }
 }
 @media (max-width: 700px) {
-  .page-shell { width: min(100% - 1rem, 1160px); }
+  .page-shell { width: min(calc(100% - 1rem), 1160px); }
   .topbar, .hero, .doc-hero, .section-block, .doc-section { padding: 1rem; }
   h1 { font-size: clamp(2.2rem, 12vw, 3.6rem); }
+  .topbar { flex-direction: column; align-items: flex-start; gap: 0.65rem; }
+  .topnav { gap: 0.75rem; }
+  .topnav a { font-size: 0.88rem; }
 }


### PR DESCRIPTION
## What

Three small CSS fixes for the docs site on mobile (iOS/iPhone):

1. **Topbar stacking** — on narrow screens the `flex` topbar with `justify-content: space-between` caused the nav links to awkwardly split across two rows while fighting for space with the brand. Now the topbar switches to `flex-direction: column` at ≤700px so the brand sits on top and nav links flow naturally below it with a slightly tighter font size.

2. **`min()` calc fix** — `min(100% - 1rem, 1160px)` in the mobile breakpoint was missing the `calc()` wrapper. Changed to `min(calc(100% - 1rem), 1160px)` for consistent WebKit/Safari behaviour.

3. **Markdown images** — added `max-width: 100%; height: auto` so any inline images in docs pages can't blow out the viewport width.

## Why

The docs site was rendering incorrectly on iPhone — nav overflow and potential horizontal scroll. Upstream already landed `overflow-x: clip` and the table scroll fix; this PR covers the remaining issues visible in the screenshot.
