### PR TITLE
fix docs mobile layout overflow

### DIFF
--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -126,6 +126,7 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
 .docs-card li + li { margin-top: 0.55rem; }
 .split-layout, .doc-grid { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .doc-grid-wide { grid-template-columns: minmax(0, 1.7fr) minmax(260px, 0.7fr); align-items: start; }
+.hero > *, .split-layout > *, .doc-grid > *, .doc-grid-wide > *, .install-panel > * { min-width: 0; }
 .list-panel, .doc-surface { padding: 1.2rem 1.25rem; }
 .breadcrumbs { display: flex; flex-wrap: wrap; gap: 0.55rem; color: var(--muted); font-size: 0.9rem; }
 .breadcrumbs a { color: var(--muted); text-decoration: none; }
@@ -160,4 +161,8 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
   .topbar { flex-direction: column; align-items: flex-start; gap: 0.65rem; }
   .topnav { gap: 0.75rem; }
   .topnav a { font-size: 0.88rem; }
+  .list-panel, .doc-surface { padding: 1rem; }
+  .markdown pre, .install-command { padding: 0.85rem 0.9rem; border-radius: 14px; }
+  .markdown pre, .markdown table { font-size: 0.88rem; }
+  .markdown th, .markdown td { padding: 0.6rem; }
 }


### PR DESCRIPTION
## What
- fix the docs grid/mobile overflow by allowing grid children to shrink instead of forcing the whole content column wider than the viewport
- tighten docs card padding and code/table spacing under 700px so long CLI examples stay readable without feeling cramped

## Why
On `/reference/sessions/`, the main docs column was rendering at ~758px wide on a 390px viewport because the grid item kept its default `min-width: auto`. That made the page look truncated on mobile, with the content squeezed into a narrow visible strip.

After the CSS change:
- page/body scroll width returns to the viewport width (`390px` on the mobile check)
- code blocks still scroll horizontally when needed, but the overall page no longer overflows
- the page reads like a normal mobile doc page instead of a broken desktop layout

## Verification
- built docs locally with `hugo --source docs-site --destination /tmp/term-llm-docs-mobile-test`
- compared mobile rendering before/after on `/reference/sessions/`
- measured widths in Playwright before fix: `bodyScrollWidth: 800`, after fix: `bodyScrollWidth: 390`
