### PR TITLE
add static docs search

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -21,13 +21,20 @@ jobs:
           hugo-version: '0.145.0'
           extended: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Build docs site
         run: |
           rm -rf docs-site-public
           cd docs-site
           hugo --destination ../docs-site-public
           cd ..
+          npx --yes pagefind --site docs-site-public
           test -f docs-site-public/index.html
+          test -f docs-site-public/pagefind/pagefind.js
 
       - name: Prepare release directories
         uses: appleboy/ssh-action@v1.2.0

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -12,6 +12,9 @@ hugo server --source docs-site
 
 ```bash
 hugo --source docs-site --destination /tmp/term-llm-docs
+npx --yes pagefind --site /tmp/term-llm-docs
 ```
+
+The Pagefind step generates the static search index and UI assets under `/pagefind/`.
 
 All documentation content should live in Markdown under `docs-site/content/`.

--- a/docs-site/content/search.md
+++ b/docs-site/content/search.md
@@ -1,0 +1,8 @@
+---
+title: "Search"
+description: "Search the term-llm documentation by command, flag, page title, or topic."
+kicker: "Find the thing"
+layout: "search"
+---
+
+Use this when you remember the command, the flag, or half the concept but not where it lives.

--- a/docs-site/layouts/_default/baseof.html
+++ b/docs-site/layouts/_default/baseof.html
@@ -14,11 +14,14 @@
     <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/styles.css" />
+    {{ if eq .Layout "search" }}
+      <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+    {{ end }}
   </head>
   <body class="{{ if not .IsHome }}docs-page{{ end }}">
     <div class="page-shell">
       {{ partial "header.html" . }}
-      <main>
+      <main data-pagefind-body>
         {{ block "main" . }}{{ end }}
       </main>
       {{ partial "footer.html" . }}
@@ -47,5 +50,27 @@
         }, 1800);
       });
     </script>
+    {{ if eq .Layout "search" }}
+      <script src="/pagefind/pagefind-ui.js"></script>
+      <script>
+        window.addEventListener("DOMContentLoaded", () => {
+          const mount = document.getElementById("search-ui");
+          if (!mount || typeof PagefindUI === "undefined") {
+            return;
+          }
+
+          new PagefindUI({
+            element: "#search-ui",
+            showSubResults: true,
+            resetStyles: false,
+            autofocus: true,
+            excerptLength: 18,
+            translations: {
+              placeholder: "Search commands, flags, guides, concepts…"
+            }
+          });
+        });
+      </script>
+    {{ end }}
   </body>
 </html>

--- a/docs-site/layouts/_default/search.html
+++ b/docs-site/layouts/_default/search.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+  <section class="doc-hero" data-pagefind-ignore="all">
+    <div class="breadcrumbs">
+      <a href="/">Docs</a>
+      <span>→</span>
+      <span>{{ .Title }}</span>
+    </div>
+    <p class="eyebrow">{{ with .Params.kicker }}{{ . }}{{ else }}Search{{ end }}</p>
+    <h1>{{ .Title }}</h1>
+    <p class="doc-intro">{{ with .Description }}{{ . }}{{ else }}Search the term-llm docs.{{ end }}</p>
+  </section>
+
+  <section class="doc-section search-section" data-pagefind-ignore="all">
+    <div class="search-shell">
+      <div class="search-lede markdown">{{ .Content }}</div>
+      <div id="search-ui"></div>
+    </div>
+  </section>
+{{ end }}

--- a/docs-site/layouts/partials/footer.html
+++ b/docs-site/layouts/partials/footer.html
@@ -1,3 +1,3 @@
-<footer class="site-footer">
-  <p>Documentation for term-llm, maintained in the repository as Markdown and published with Hugo.</p>
+<footer class="site-footer" data-pagefind-ignore>
+  Documentation for term-llm, maintained in the repository as Markdown and published with Hugo.
 </footer>

--- a/docs-site/layouts/partials/header.html
+++ b/docs-site/layouts/partials/header.html
@@ -1,10 +1,11 @@
-<header class="topbar">
+<header class="topbar" data-pagefind-ignore>
   <a class="brand" href="/">term-llm</a>
   <nav class="topnav" aria-label="Primary">
     <a href="/getting-started/" class="{{ if eq .Section "getting-started" }}active{{ end }}">Start</a>
     <a href="/guides/" class="{{ if eq .Section "guides" }}active{{ end }}">Guides</a>
     <a href="/architecture/" class="{{ if eq .Section "architecture" }}active{{ end }}">Architecture</a>
     <a href="/reference/" class="{{ if eq .Section "reference" }}active{{ end }}">Reference</a>
+    <a href="/search/" class="{{ if eq .Layout "search" }}active{{ end }}">Search</a>
     <a href="https://github.com/samsaffron/term-llm">GitHub</a>
   </nav>
 </header>

--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -149,6 +149,77 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
 .doc-meta p { margin: 0.5rem 0 0; color: var(--soft); line-height: 1.6; }
 .toc-box { margin-bottom: 1.5rem; padding: 1rem 1rem 0.2rem; border-radius: 16px; background: rgba(8,14,25,0.5); border: 1px solid rgba(125,211,252,0.12); }
 .toc-box ul { padding-left: 1rem; }
+.search-shell {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 22px;
+  background: var(--panel-strong);
+  border: 1px solid rgba(125,211,252,0.14);
+}
+.search-lede { color: var(--soft); }
+#search-ui .pagefind-ui__search-input {
+  width: 100%;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(125,211,252,0.18);
+  background: rgba(4,8,16,0.82);
+  color: var(--text);
+  font: inherit;
+  box-shadow: none;
+}
+#search-ui .pagefind-ui__search-input::placeholder {
+  color: var(--muted);
+  opacity: 0.75;
+}
+#search-ui .pagefind-ui__search-input:focus {
+  outline: 2px solid rgba(114,241,184,0.35);
+  outline-offset: 2px;
+}
+#search-ui .pagefind-ui__search-clear,
+#search-ui .pagefind-ui__button {
+  border-radius: 12px;
+  border: 1px solid rgba(125,211,252,0.18);
+  background: rgba(10,18,32,0.96);
+  color: var(--text);
+}
+#search-ui .pagefind-ui__search-clear:hover,
+#search-ui .pagefind-ui__button:hover {
+  background: rgba(13,23,40,1);
+  border-color: rgba(114,241,184,0.36);
+}
+#search-ui .pagefind-ui__drawer {
+  margin-top: 1rem;
+}
+#search-ui .pagefind-ui__message {
+  color: var(--muted);
+}
+#search-ui .pagefind-ui__results {
+  margin-top: 0.5rem;
+}
+#search-ui .pagefind-ui__result {
+  padding: 1rem 0;
+  border-top: 1px solid rgba(125,211,252,0.12);
+}
+#search-ui .pagefind-ui__result:first-of-type {
+  border-top: 0;
+}
+#search-ui .pagefind-ui__result-title,
+#search-ui .pagefind-ui__result-link,
+#search-ui .pagefind-ui__result-link:hover,
+#search-ui .pagefind-ui__button {
+  color: var(--text);
+}
+#search-ui .pagefind-ui__result-excerpt,
+#search-ui .pagefind-ui__result-nested {
+  color: var(--soft);
+}
+#search-ui mark {
+  background: rgba(114,241,184,0.2);
+  color: var(--text);
+  padding: 0.05rem 0.18rem;
+  border-radius: 4px;
+}
 .site-footer { margin-top: 0.5rem; padding: 0 1rem; color: var(--muted); font-size: 0.95rem; text-align: center; }
 @media (max-width: 980px) {
   .hero, .card-grid-4, .card-grid-3, .split-layout, .doc-grid, .doc-grid-wide { grid-template-columns: 1fr; }
@@ -165,4 +236,6 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
   .markdown pre, .install-command { padding: 0.85rem 0.9rem; border-radius: 14px; }
   .markdown pre, .markdown table { font-size: 0.88rem; }
   .markdown th, .markdown td { padding: 0.6rem; }
+  .search-shell { padding: 1rem; }
+  #search-ui .pagefind-ui__search-input { padding: 0.9rem 1rem; }
 }


### PR DESCRIPTION
## What
- add a static docs search page at `/search/` using Pagefind
- add a `Search` link in the top navigation
- wire the docs deploy workflow to build the Pagefind index after Hugo
- limit indexing to page content (`data-pagefind-body`) while excluding header/footer chrome from the index
- style the Pagefind UI so it matches the current docs look on desktop and mobile

## Why
The docs site had no search, which is annoying once you vaguely remember a command or flag but not the page it lives on.

Pagefind keeps this lightweight:
- no backend
- no hosted search service
- no extra runtime infrastructure
- just static assets generated during the docs build

## Verification
- built docs locally with `hugo --source docs-site --destination /tmp/term-llm-docs-search`
- generated the search index with `npx --yes pagefind --site /tmp/term-llm-docs-search`
- smoke tested `/search/` locally and queried `session`
- confirmed results returned relevant pages/sections including `Session management`, `Session commands`, `Storage`, `Session titles`, and `Memory`
