### PR TITLE
clarify docs memory insights

### DIFF
--- a/docs-site/content/guides/memory.md
+++ b/docs-site/content/guides/memory.md
@@ -137,6 +137,24 @@ term-llm memory promote --agent assistant --dry-run
 
 Fragments store facts. Insights store reusable behavioral rules.
 
+Why care? Because facts tell the agent **what is true**, while insights tell it **how to behave next time**.
+
+A fragment is something like:
+- "Use the staging Redis instance at `redis://staging.internal:6379/2`."
+
+An insight is something like:
+- "When debugging staging issues, check Redis connectivity before blaming Sidekiq."
+
+Or:
+- fragment: "The docs site is built with Hugo and deployed from GitHub Actions."
+- insight: "For docs changes, preview locally first and verify mobile layout before opening the PR."
+
+Another invented example:
+- fragment: "This repo keeps generated files under `internal/embed/`."
+- insight: "When changing frontend assets, search for the generated embed step before assuming the file is served directly."
+
+That is the point of insights: they capture **reusable judgment**, not just stored facts.
+
 ```bash
 term-llm memory insights list --agent assistant
 term-llm memory insights search "code review"
@@ -153,6 +171,14 @@ term-llm memory insights add --agent assistant \
 
 term-llm memory insights reinforce 42 --agent assistant
 ```
+
+Good insight candidates usually sound like:
+- a rule of thumb
+- a repeated correction
+- a workflow preference
+- a pattern that prevents future mistakes
+
+Bad insight candidates are usually just facts wearing a fake mustache.
 
 High-confidence insights are meant to shape future behavior, not just sit in storage looking profound.
 


### PR DESCRIPTION
## What
- clarify the `Behavioral insights` section in the memory docs
- add concrete invented examples showing the difference between a fragment and an insight
- explain why a user should care: facts store truth, insights store reusable judgment
- add a quick rule of thumb for good vs bad insight candidates

## Why
The existing section was technically correct but too abstract. "Insights" can sound hand-wavey unless the docs show what one actually looks like and why it is different from a normal memory fragment.

The new examples make the distinction concrete:
- fragment = a stored fact
- insight = a reusable behavior rule derived from facts or repeated corrections

## Verification
- reviewed the rendered Markdown source for clarity and flow
- kept the change docs-only and confined to `docs-site/content/guides/memory.md`
