### PR TITLE
improve docs search overlay

### DIFF
--- a/docs-site/layouts/_default/baseof.html
+++ b/docs-site/layouts/_default/baseof.html
@@ -14,9 +14,7 @@
     <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/styles.css" />
-    {{ if eq .Layout "search" }}
-      <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
-    {{ end }}
+    <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
   </head>
   <body class="{{ if not .IsHome }}docs-page{{ end }}">
     <div class="page-shell">
@@ -26,6 +24,22 @@
       </main>
       {{ partial "footer.html" . }}
     </div>
+
+    <div id="search-modal" class="search-modal" hidden data-pagefind-ignore>
+      <div class="search-modal-backdrop" data-close-search></div>
+      <div class="search-modal-panel" role="dialog" aria-modal="true" aria-labelledby="search-modal-title">
+        <div class="search-modal-header">
+          <div>
+            <p class="eyebrow">Find the thing</p>
+            <h2 id="search-modal-title">Search term-llm docs</h2>
+          </div>
+          <button class="search-modal-close" type="button" data-close-search aria-label="Close search">Close</button>
+        </div>
+        <p class="search-modal-copy">Jump to commands, flags, pages, and section headings without leaving the page.</p>
+        <div id="search-modal-ui" class="search-interface"></div>
+      </div>
+    </div>
+
     <script>
       document.addEventListener("click", async (event) => {
         const button = event.target.closest("[data-copy-text]");
@@ -50,27 +64,136 @@
         }, 1800);
       });
     </script>
-    {{ if eq .Layout "search" }}
-      <script src="/pagefind/pagefind-ui.js"></script>
-      <script>
-        window.addEventListener("DOMContentLoaded", () => {
-          const mount = document.getElementById("search-ui");
-          if (!mount || typeof PagefindUI === "undefined") {
+    <script>
+      (() => {
+        const modal = document.getElementById("search-modal");
+        const modalUI = document.getElementById("search-modal-ui");
+        let pagefindUILoad;
+        let pagefindUIReady;
+        let lastFocused = null;
+
+        function getSearchInput() {
+          return modal.querySelector(".pagefind-ui__search-input");
+        }
+
+        function loadPagefindUI() {
+          if (typeof PagefindUI !== "undefined") {
+            return Promise.resolve();
+          }
+          if (pagefindUILoad) {
+            return pagefindUILoad;
+          }
+
+          pagefindUILoad = new Promise((resolve, reject) => {
+            const script = document.createElement("script");
+            script.src = "/pagefind/pagefind-ui.js";
+            script.onload = resolve;
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
+
+          return pagefindUILoad;
+        }
+
+        async function ensureSearchUI() {
+          if (pagefindUIReady) {
+            return pagefindUIReady;
+          }
+
+          pagefindUIReady = loadPagefindUI().then(() => {
+            if (modalUI.dataset.initialized === "true") {
+              return;
+            }
+
+            new PagefindUI({
+              element: "#search-modal-ui",
+              showSubResults: true,
+              resetStyles: false,
+              autofocus: true,
+              excerptLength: 18,
+              translations: {
+                placeholder: "Search commands, flags, guides, concepts…"
+              }
+            });
+
+            modalUI.dataset.initialized = "true";
+          });
+
+          return pagefindUIReady;
+        }
+
+        async function openSearch(prefill) {
+          lastFocused = document.activeElement;
+          modal.hidden = false;
+          document.body.classList.add("search-open");
+
+          try {
+            await ensureSearchUI();
+            window.setTimeout(() => {
+              const input = getSearchInput();
+              if (!input) {
+                return;
+              }
+              input.focus();
+              if (typeof prefill === "string") {
+                input.value = prefill;
+                input.dispatchEvent(new Event("input", { bubbles: true }));
+              }
+            }, 20);
+          } catch (_error) {
+            modalUI.innerHTML = '<p class="search-error">Search assets failed to load. Try reloading the page.</p>';
+          }
+        }
+
+        function closeSearch() {
+          if (modal.hidden) {
+            return;
+          }
+          modal.hidden = true;
+          document.body.classList.remove("search-open");
+          if (lastFocused && typeof lastFocused.focus === "function") {
+            lastFocused.focus();
+          }
+        }
+
+        document.addEventListener("click", (event) => {
+          const open = event.target.closest("[data-open-search]");
+          if (open) {
+            event.preventDefault();
+            openSearch(open.getAttribute("data-search-query") || undefined);
             return;
           }
 
-          new PagefindUI({
-            element: "#search-ui",
-            showSubResults: true,
-            resetStyles: false,
-            autofocus: true,
-            excerptLength: 18,
-            translations: {
-              placeholder: "Search commands, flags, guides, concepts…"
-            }
-          });
+          if (event.target.closest("[data-close-search]")) {
+            event.preventDefault();
+            closeSearch();
+          }
         });
-      </script>
-    {{ end }}
+
+        document.addEventListener("keydown", (event) => {
+          const tag = document.activeElement && document.activeElement.tagName;
+          const typing = tag === "INPUT" || tag === "TEXTAREA" || document.activeElement?.isContentEditable;
+
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+            event.preventDefault();
+            openSearch();
+            return;
+          }
+
+          if (event.key === "Escape") {
+            closeSearch();
+            return;
+          }
+
+          if (event.key === "/" && !typing && !modal.hidden) {
+            event.preventDefault();
+            const input = getSearchInput();
+            if (input) {
+              input.focus();
+            }
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs-site/layouts/_default/search.html
+++ b/docs-site/layouts/_default/search.html
@@ -11,9 +11,12 @@
   </section>
 
   <section class="doc-section search-section" data-pagefind-ignore="all">
-    <div class="search-shell">
+    <div class="search-shell search-shell-static">
       <div class="search-lede markdown">{{ .Content }}</div>
-      <div id="search-ui"></div>
+      <div class="search-actions">
+        <button class="button primary" type="button" data-open-search>Open search</button>
+        <p class="search-hint">Or hit <kbd>⌘K</kbd> on Mac or <kbd>Ctrl+K</kbd> elsewhere.</p>
+      </div>
     </div>
   </section>
 {{ end }}

--- a/docs-site/layouts/partials/header.html
+++ b/docs-site/layouts/partials/header.html
@@ -5,7 +5,10 @@
     <a href="/guides/" class="{{ if eq .Section "guides" }}active{{ end }}">Guides</a>
     <a href="/architecture/" class="{{ if eq .Section "architecture" }}active{{ end }}">Architecture</a>
     <a href="/reference/" class="{{ if eq .Section "reference" }}active{{ end }}">Reference</a>
-    <a href="/search/" class="{{ if eq .Layout "search" }}active{{ end }}">Search</a>
+    <button class="search-trigger{{ if eq .Layout "search" }} active{{ end }}" type="button" data-open-search aria-haspopup="dialog" aria-controls="search-modal">
+      <span>Search</span>
+      <span class="search-shortcut" aria-hidden="true">⌘K</span>
+    </button>
     <a href="https://github.com/samsaffron/term-llm">GitHub</a>
   </nav>
 </header>

--- a/docs-site/static/styles.css
+++ b/docs-site/static/styles.css
@@ -48,9 +48,34 @@ body::before {
 }
 .brand { color: var(--text); text-decoration: none; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
 .topnav { display: flex; flex-wrap: wrap; gap: 1rem; }
-.topnav a, .markdown a, .doc-meta a { color: var(--accent-2); text-decoration: none; }
-.topnav a { color: var(--muted); font-size: 0.96rem; }
-.topnav a:hover, .topnav a.active, .brand:hover, .card:hover h3 { color: var(--text); }
+.topnav a, .topnav button, .markdown a, .doc-meta a { color: var(--accent-2); text-decoration: none; }
+.topnav a, .topnav button {
+  color: var(--muted);
+  font-size: 0.96rem;
+  font-family: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+.search-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+.search-shortcut {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2rem;
+  padding: 0.1rem 0.38rem;
+  border-radius: 999px;
+  border: 1px solid rgba(125,211,252,0.12);
+  background: rgba(13,23,40,0.72);
+  font-size: 0.74rem;
+  color: var(--soft);
+}
+.topnav a:hover, .topnav a.active, .topnav button:hover, .topnav button.active, .brand:hover, .card:hover h3 { color: var(--text); }
 main { display: grid; gap: 1.5rem; }
 .hero, .section-block, .doc-hero, .doc-section {
   position: relative; background: var(--panel); border: 1px solid var(--panel-border); border-radius: 28px; box-shadow: 0 20px 60px var(--shadow);
@@ -157,68 +182,168 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
   background: var(--panel-strong);
   border: 1px solid rgba(125,211,252,0.14);
 }
-.search-lede { color: var(--soft); }
-#search-ui .pagefind-ui__search-input {
-  width: 100%;
-  padding: 1rem 1.1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(125,211,252,0.18);
-  background: rgba(4,8,16,0.82);
-  color: var(--text);
-  font: inherit;
-  box-shadow: none;
+.search-shell-static { gap: 1.25rem; }
+.search-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
 }
-#search-ui .pagefind-ui__search-input::placeholder {
+.search-hint {
+  margin: 0;
   color: var(--muted);
-  opacity: 0.75;
 }
-#search-ui .pagefind-ui__search-input:focus {
+.search-hint kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2rem;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(125,211,252,0.12);
+  background: rgba(13,23,40,0.72);
+  color: var(--soft);
+  font: inherit;
+  font-size: 0.82rem;
+}
+.search-lede { color: var(--soft); }
+body.search-open { overflow: hidden; }
+.search-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: start center;
+  padding: 5rem 1rem 1rem;
+}
+.search-modal[hidden] { display: none; }
+.search-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 8, 16, 0.72);
+  backdrop-filter: blur(10px);
+}
+.search-modal-panel {
+  position: relative;
+  width: min(900px, 100%);
+  max-height: min(80vh, 960px);
+  overflow: auto;
+  padding: 1.25rem;
+  border-radius: 28px;
+  border: 1px solid rgba(125,211,252,0.18);
+  background: rgba(8,14,25,0.94);
+  box-shadow: 0 30px 80px rgba(0,0,0,0.45);
+}
+.search-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.search-modal-header h2 {
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+}
+.search-modal-header .eyebrow { margin-bottom: 0.4rem; }
+.search-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(125,211,252,0.16);
+  background: rgba(13,23,40,0.74);
+  color: var(--soft);
+  font: inherit;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+}
+.search-modal-close:hover {
+  color: var(--text);
+  border-color: rgba(114,241,184,0.36);
+  background: rgba(13,23,40,0.96);
+}
+.search-modal-copy {
+  margin: 0.6rem 0 1rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
+.search-interface .pagefind-ui__form {
+  margin: 0;
+}
+.search-interface .pagefind-ui__search-clear,
+.search-interface .pagefind-ui__button {
+  appearance: none;
+  border-radius: 12px !important;
+  border: 1px solid rgba(125,211,252,0.18) !important;
+  background: rgba(13,23,40,0.96) !important;
+  color: var(--text) !important;
+  box-shadow: none !important;
+}
+.search-interface .pagefind-ui__search-clear:hover,
+.search-interface .pagefind-ui__button:hover {
+  border-color: rgba(114,241,184,0.36) !important;
+  background: rgba(16,28,48,1) !important;
+}
+.search-interface .pagefind-ui__search-clear {
+  min-width: 2.9rem;
+  padding: 0 0.8rem !important;
+}
+.search-interface .pagefind-ui__search-input {
+  width: 100%;
+  padding: 1rem 1.1rem !important;
+  border-radius: 16px !important;
+  border: 1px solid rgba(125,211,252,0.18) !important;
+  background: rgba(4,8,16,0.82) !important;
+  color: var(--text) !important;
+  font: inherit !important;
+  box-shadow: inset 0 0 0 1px rgba(114,241,184,0.18) !important;
+}
+.search-interface .pagefind-ui__search-input::placeholder {
+  color: rgba(199,211,228,0.72) !important;
+  opacity: 1 !important;
+}
+.search-interface .pagefind-ui__search-input:focus {
   outline: 2px solid rgba(114,241,184,0.35);
   outline-offset: 2px;
 }
-#search-ui .pagefind-ui__search-clear,
-#search-ui .pagefind-ui__button {
-  border-radius: 12px;
-  border: 1px solid rgba(125,211,252,0.18);
-  background: rgba(10,18,32,0.96);
-  color: var(--text);
-}
-#search-ui .pagefind-ui__search-clear:hover,
-#search-ui .pagefind-ui__button:hover {
-  background: rgba(13,23,40,1);
-  border-color: rgba(114,241,184,0.36);
-}
-#search-ui .pagefind-ui__drawer {
+.search-interface .pagefind-ui__drawer {
   margin-top: 1rem;
 }
-#search-ui .pagefind-ui__message {
+.search-interface .pagefind-ui__message {
   color: var(--muted);
 }
-#search-ui .pagefind-ui__results {
+.search-interface .pagefind-ui__results {
   margin-top: 0.5rem;
 }
-#search-ui .pagefind-ui__result {
+.search-interface .pagefind-ui__result {
   padding: 1rem 0;
   border-top: 1px solid rgba(125,211,252,0.12);
 }
-#search-ui .pagefind-ui__result:first-of-type {
+.search-interface .pagefind-ui__result:first-of-type {
   border-top: 0;
 }
-#search-ui .pagefind-ui__result-title,
-#search-ui .pagefind-ui__result-link,
-#search-ui .pagefind-ui__result-link:hover,
-#search-ui .pagefind-ui__button {
+.search-interface .pagefind-ui__result-title,
+.search-interface .pagefind-ui__result-link,
+.search-interface .pagefind-ui__result-link:hover,
+.search-interface .pagefind-ui__button {
   color: var(--text);
 }
-#search-ui .pagefind-ui__result-excerpt,
-#search-ui .pagefind-ui__result-nested {
+.search-interface .pagefind-ui__result-excerpt,
+.search-interface .pagefind-ui__result-nested {
   color: var(--soft);
 }
-#search-ui mark {
+.search-interface mark {
   background: rgba(114,241,184,0.2);
   color: var(--text);
   padding: 0.05rem 0.18rem;
   border-radius: 4px;
+}
+.search-error {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255,180,162,0.24);
+  background: rgba(43, 20, 24, 0.7);
+  color: var(--danger);
 }
 .site-footer { margin-top: 0.5rem; padding: 0 1rem; color: var(--muted); font-size: 0.95rem; text-align: center; }
 @media (max-width: 980px) {
@@ -231,11 +356,15 @@ pre, code, .terminal-panel code, .install-command code { font-family: "JetBrains
   h1 { font-size: clamp(2.2rem, 12vw, 3.6rem); }
   .topbar { flex-direction: column; align-items: flex-start; gap: 0.65rem; }
   .topnav { gap: 0.75rem; }
-  .topnav a { font-size: 0.88rem; }
+  .topnav a, .topnav button { font-size: 0.88rem; }
+  .search-shortcut { display: none; }
   .list-panel, .doc-surface { padding: 1rem; }
   .markdown pre, .install-command { padding: 0.85rem 0.9rem; border-radius: 14px; }
   .markdown pre, .markdown table { font-size: 0.88rem; }
   .markdown th, .markdown td { padding: 0.6rem; }
   .search-shell { padding: 1rem; }
-  #search-ui .pagefind-ui__search-input { padding: 0.9rem 1rem; }
+  .search-modal { padding: 1rem 0.5rem 0.5rem; }
+  .search-modal-panel { padding: 1rem; max-height: calc(100vh - 1rem); }
+  .search-modal-header { flex-direction: column; }
+  .search-interface .pagefind-ui__search-input { padding: 0.9rem 1rem !important; }
 }


### PR DESCRIPTION
## What
- replace the docs site's search-page-first flow with a floating Pagefind search overlay that opens from any docs page
- make the top nav `Search` action open the overlay directly, with a visible `⌘K` hint on desktop
- keep `/search/` as a lightweight fallback page, but turn it into an "open search" launch point instead of a second full search UI
- restyle the Pagefind input, placeholder, clear button, modal, and results so they match the docs theme and read properly on mobile and desktop
- add keyboard open/close behavior (`Cmd/Ctrl+K`, `Esc`)

## Why
The initial search implementation worked, but it made search feel heavier than it should:
- you had to leave the page just to search
- the clear button looked bolted on
- the placeholder/input contrast was off

Docs search should feel like a lightweight command palette, not a detour.

## Verification
- built docs locally with `hugo --source docs-site --destination /tmp/term-llm-docs-overlay`
- generated the Pagefind index with `npx --yes pagefind --site /tmp/term-llm-docs-overlay`
- smoke tested overlay search from `/reference/sessions/` on desktop and mobile
- verified keyboard open with `Ctrl+K`
- queried `session` and `insight` and confirmed relevant results returned in the overlay
- verified computed styles after the fix:
  - placeholder color: `rgba(199, 211, 228, 0.72)`
  - clear button background: `rgba(13, 23, 40, 0.96)`
