### PR TITLE
feat: cap memory mining prompts with lookup tools

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -21,19 +21,23 @@ import (
 )
 
 var (
-	memoryMineModel            string
-	memoryMineSince            time.Duration
-	memoryMineLimit            int
-	memoryMineBatchSize        int
-	memoryMineIncludeSubagents bool
-	memoryMineMaxMessages      int
-	memoryMineReadBytes        int
-	memoryMineEmbed            bool
-	memoryMineEmbedProvider    string
-	memoryMinePromote          string
-	memoryMinePromoteEvery     time.Duration
-	memoryMineHalfLifeDays     float64
-	memoryMineInsights         bool
+	memoryMineModel             string
+	memoryMineSince             time.Duration
+	memoryMineLimit             int
+	memoryMineBatchSize         int
+	memoryMineIncludeSubagents  bool
+	memoryMineMaxMessages       int
+	memoryMineReadBytes         int
+	memoryMineEmbed             bool
+	memoryMineEmbedProvider     string
+	memoryMinePromote           string
+	memoryMinePromoteEvery      time.Duration
+	memoryMineHalfLifeDays      float64
+	memoryMineInsights          bool
+	memoryMinePromptMaxTokens   int
+	memoryMineTaxonomyMaxTokens int
+	memoryMineToolMaxTurns      int
+	memoryMineMaxOutputTokens   int
 )
 
 var memoryMineCmd = &cobra.Command{
@@ -74,11 +78,6 @@ type transcriptMessage struct {
 	ToolCalls []string `json:"tool_calls,omitempty"`
 }
 
-type taxonomyEntry struct {
-	Path    string `json:"path"`
-	Preview string `json:"preview"`
-}
-
 func init() {
 	memoryMineCmd.Flags().StringVar(&memoryMineModel, "model", "", "Override model used for memory extraction")
 	memoryMineCmd.Flags().DurationVar(&memoryMineSince, "since", 0, "Only mine sessions updated within this duration (e.g. 24h)")
@@ -86,13 +85,17 @@ func init() {
 	memoryMineCmd.Flags().IntVar(&memoryMineBatchSize, "batch-size", 10, "Number of messages to fetch per pagination request")
 	memoryMineCmd.Flags().BoolVar(&memoryMineIncludeSubagents, "include-subagents", false, "Include subagent sessions")
 	memoryMineCmd.Flags().IntVar(&memoryMineMaxMessages, "max-messages", 0, "Maximum newly mined messages per session (0 = all)")
-	memoryMineCmd.Flags().IntVar(&memoryMineReadBytes, "read-bytes", 2048, "Bytes of existing fragment content to include in taxonomy context")
+	memoryMineCmd.Flags().IntVar(&memoryMineReadBytes, "read-bytes", 2048, "Maximum bytes returned by fragment lookup tools during mining")
 	memoryMineCmd.Flags().BoolVar(&memoryMineEmbed, "embed", true, "Embed new/updated fragments after mining")
 	memoryMineCmd.Flags().StringVar(&memoryMineEmbedProvider, "embed-provider", "", "Override embedding provider used in EMBED phase (optionally provider:model)")
 	memoryMineCmd.Flags().StringVar(&memoryMinePromote, "promote", "never", "Promotion mode: auto|always|never")
 	memoryMineCmd.Flags().DurationVar(&memoryMinePromoteEvery, "promote-every", 6*time.Hour, "Minimum interval between auto-promote runs")
 	memoryMineCmd.Flags().Float64Var(&memoryMineHalfLifeDays, "half-life", 30.0, "Decay half-life in days for post-mine recalculation")
 	memoryMineCmd.Flags().BoolVar(&memoryMineInsights, "insights", false, "Also run insight extraction pass after fragment mining")
+	memoryMineCmd.Flags().IntVar(&memoryMinePromptMaxTokens, "prompt-max-tokens", defaultMemoryMinePromptMaxTokens, "Approximate maximum prompt budget per extraction request")
+	memoryMineCmd.Flags().IntVar(&memoryMineTaxonomyMaxTokens, "taxonomy-max-tokens", defaultMemoryMineTaxonomyMaxTokens, "Approximate maximum tokens for the compact fragment taxonomy map")
+	memoryMineCmd.Flags().IntVar(&memoryMineToolMaxTurns, "tool-max-turns", defaultMemoryMineToolMaxTurns, "Maximum tool-assisted turns allowed for one extraction request")
+	memoryMineCmd.Flags().IntVar(&memoryMineMaxOutputTokens, "max-output-tokens", defaultMemoryMineMaxOutputTokens, "Maximum output tokens for one extraction request")
 	memoryMineCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)
 }
 
@@ -108,6 +111,18 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	}
 	if memoryMineReadBytes < 0 {
 		return fmt.Errorf("--read-bytes must be >= 0")
+	}
+	if memoryMinePromptMaxTokens <= 0 {
+		return fmt.Errorf("--prompt-max-tokens must be > 0")
+	}
+	if memoryMineTaxonomyMaxTokens <= 0 {
+		return fmt.Errorf("--taxonomy-max-tokens must be > 0")
+	}
+	if memoryMineToolMaxTurns <= 0 {
+		return fmt.Errorf("--tool-max-turns must be > 0")
+	}
+	if memoryMineMaxOutputTokens <= 0 {
+		return fmt.Errorf("--max-output-tokens must be > 0")
 	}
 
 	promoteMode := strings.ToLower(strings.TrimSpace(memoryMinePromote))
@@ -204,7 +219,13 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		messages, nextOffset, err := loadMessagesForMining(ctx, sessStore, candidate.Session.ID, startOffset)
+		existing, err := memStore.ListFragments(ctx, memorydb.ListOptions{Agent: candidate.Agent})
+		if err != nil {
+			return fmt.Errorf("list existing fragments for agent %s: %w", candidate.Agent, err)
+		}
+		taxonomyMap := buildTaxonomyMap(existing, memoryMineTaxonomyMaxTokens)
+
+		messages, nextOffset, err := loadMessagesForMining(ctx, sessStore, candidate, startOffset, taxonomyMap)
 		if err != nil {
 			return fmt.Errorf("load messages for session %s: %w", candidate.Session.ID, err)
 		}
@@ -213,13 +234,8 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		existing, err := memStore.ListFragments(ctx, memorydb.ListOptions{Agent: candidate.Agent})
-		if err != nil {
-			return fmt.Errorf("list existing fragments for agent %s: %w", candidate.Agent, err)
-		}
-
-		prompt := buildExtractionPrompt(candidate, startOffset, nextOffset, messages, existing)
-		raw, err := runExtractionRequest(ctx, engine, prompt)
+		prompt := buildExtractionPrompt(candidate, startOffset, nextOffset, messages, taxonomyMap)
+		raw, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, prompt)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping session %s batch at offset %d: %v\n", candidate.Session.ID, startOffset, err)
 			continue
@@ -416,7 +432,7 @@ func collectMineCandidates(ctx context.Context, store session.Store, complete []
 	return out, nil
 }
 
-func loadMessagesForMining(ctx context.Context, store session.Store, sessionID string, offset int) ([]session.Message, int, error) {
+func loadMessagesForMining(ctx context.Context, store session.Store, candidate memoryMineCandidate, offset int, taxonomyMap string) ([]session.Message, int, error) {
 	remaining := memoryMineMaxMessages
 	currentOffset := offset
 	all := make([]session.Message, 0, memoryMineBatchSize)
@@ -427,7 +443,7 @@ func loadMessagesForMining(ctx context.Context, store session.Store, sessionID s
 			limit = remaining
 		}
 
-		msgs, err := store.GetMessages(ctx, sessionID, limit, currentOffset)
+		msgs, err := store.GetMessages(ctx, candidate.Session.ID, limit, currentOffset)
 		if err != nil {
 			return nil, currentOffset, err
 		}
@@ -435,13 +451,27 @@ func loadMessagesForMining(ctx context.Context, store session.Store, sessionID s
 			break
 		}
 
-		all = append(all, msgs...)
-		currentOffset += len(msgs)
-
-		if remaining > 0 {
-			remaining -= len(msgs)
-			if remaining <= 0 {
-				break
+		for _, msg := range msgs {
+			candidateMessages := append(append([]session.Message(nil), all...), msg)
+			nextOffset := currentOffset + 1
+			if estimateExtractionPromptTokens(candidate, offset, nextOffset, candidateMessages, taxonomyMap) > memoryMinePromptMaxTokens {
+				if len(all) == 0 {
+					clipped, ok := truncateMessageForPromptBudget(candidate, offset, nextOffset, taxonomyMap, msg)
+					if !ok {
+						return nil, currentOffset, fmt.Errorf("single message at offset %d cannot fit within --prompt-max-tokens=%d", currentOffset, memoryMinePromptMaxTokens)
+					}
+					all = append(all, clipped)
+					currentOffset = nextOffset
+				}
+				return all, currentOffset, nil
+			}
+			all = candidateMessages
+			currentOffset = nextOffset
+			if remaining > 0 {
+				remaining--
+				if remaining <= 0 {
+					return all, currentOffset, nil
+				}
 			}
 		}
 
@@ -453,17 +483,17 @@ func loadMessagesForMining(ctx context.Context, store session.Store, sessionID s
 	return all, currentOffset, nil
 }
 
-func buildExtractionPrompt(candidate memoryMineCandidate, startOffset, endOffset int, messages []session.Message, existing []memorydb.Fragment) string {
+func buildExtractionPrompt(candidate memoryMineCandidate, startOffset, endOffset int, messages []session.Message, taxonomyMap string) string {
 	transcriptJSON, _ := json.MarshalIndent(buildTranscript(messages), "", "  ")
-	taxonomyJSON, _ := json.MarshalIndent(buildTaxonomy(existing), "", "  ")
 
 	return fmt.Sprintf(`Session metadata:
 - session_id: %s
 - session_number: %d
 - agent: %s
 - mined_message_range: [%d, %d)
+- transcript_message_count: %d
 
-Existing fragment taxonomy (path + preview):
+Existing fragment map (compact, partial by design):
 %s
 
 Transcript (role + text + tool call names only):
@@ -472,7 +502,9 @@ Transcript (role + text + tool call names only):
 Instructions:
 - Extract only durable facts, decisions, preferences, and technical details worth remembering long-term.
 - Skip ephemeral content like specific transient errors, one-off debugging output, and conversational filler.
-- Avoid duplicates: prefer update when a path already exists in taxonomy.
+- The fragment map is intentionally compact and may omit exact duplicates or existing content details.
+- Use lookup tools when you need to confirm whether related memory already exists, inspect exact fragment content, or browse likely paths.
+- Prefer update when an existing fragment already captures the fact; use create for genuinely new memory.
 - Return at most 20 operations.
 - Fragment content must stay <= 8192 bytes.
 - Path must be relative and must not contain ../ or be absolute.
@@ -491,23 +523,10 @@ Return strict JSON only, exactly in this format:
 		candidate.Agent,
 		startOffset,
 		endOffset,
-		string(taxonomyJSON),
+		len(messages),
+		taxonomyMap,
 		string(transcriptJSON),
 	)
-}
-
-func buildTaxonomy(fragments []memorydb.Fragment) []taxonomyEntry {
-	entries := make([]taxonomyEntry, 0, len(fragments))
-	for _, frag := range fragments {
-		entries = append(entries, taxonomyEntry{
-			Path:    frag.Path,
-			Preview: readPrefixBytes(frag.Content, memoryMineReadBytes),
-		})
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Path < entries[j].Path
-	})
-	return entries
 }
 
 func buildTranscript(messages []session.Message) []transcriptMessage {
@@ -558,17 +577,26 @@ func collectToolCallNames(msg session.Message) []string {
 	return out
 }
 
-func runExtractionRequest(ctx context.Context, engine *llm.Engine, prompt string) (string, error) {
-	return runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt)
+func runExtractionRequest(ctx context.Context, engine *llm.Engine, store *memorydb.Store, agent, prompt string) (string, error) {
+	toolSpecs, cleanup := registerMemoryExtractionTools(engine, store, agent)
+	defer cleanup()
+	return runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt, toolSpecs...)
 }
 
-func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string) (string, error) {
+func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string, tools ...llm.ToolSpec) (string, error) {
 	req := llm.Request{
-		Model:    strings.TrimSpace(memoryMineModel),
-		Messages: []llm.Message{llm.SystemText(systemPrompt), llm.UserText(prompt)},
-		MaxTurns: 1,
-		Debug:    false,
-		DebugRaw: debugRaw,
+		Model:           strings.TrimSpace(memoryMineModel),
+		Messages:        []llm.Message{llm.SystemText(systemPrompt), llm.UserText(prompt)},
+		MaxTurns:        1,
+		MaxOutputTokens: memoryMineMaxOutputTokens,
+		Debug:           false,
+		DebugRaw:        debugRaw,
+	}
+	if len(tools) > 0 {
+		req.Tools = tools
+		req.ToolChoice = llm.ToolChoice{Mode: llm.ToolChoiceAuto}
+		req.ParallelToolCalls = true
+		req.MaxTurns = memoryMineToolMaxTurns
 	}
 
 	stream, err := engine.Stream(ctx, req)
@@ -1008,17 +1036,6 @@ func runMemoryEmbedPhase(ctx context.Context, cfg *config.Config, store *memoryd
 	return embeddedCount, nil
 }
 
-func readPrefixBytes(content string, maxBytes int) string {
-	if maxBytes <= 0 {
-		return ""
-	}
-	b := []byte(content)
-	if len(b) <= maxBytes {
-		return content
-	}
-	return string(b[:maxBytes]) + "..."
-}
-
 // ── Insight extraction pass ───────────────────────────────────────────────────
 
 const insightExtractionSystemPrompt = `You are a behavioral insight extractor.
@@ -1146,7 +1163,7 @@ func runInsightExtractionPass(
 			continue
 		}
 
-		messages, _, err := loadMessagesForMining(ctx, sessStore, candidate.Session.ID, 0)
+		messages, _, err := loadMessagesForMining(ctx, sessStore, candidate, 0, "Memory fragment map:\n- total_fragments: 0")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: load messages: %v\n", candidate.Session.ID, err)
 			continue

--- a/cmd/memory_mine_budget.go
+++ b/cmd/memory_mine_budget.go
@@ -1,0 +1,382 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+const (
+	defaultMemoryMinePromptMaxTokens   = 12000
+	defaultMemoryMineTaxonomyMaxTokens = 1000
+	defaultMemoryMineToolMaxTurns      = 6
+	defaultMemoryMineMaxOutputTokens   = 2048
+	memoryMineFragmentSearchLimit      = 8
+	memoryMineFragmentListLimit        = 20
+	memoryMineFragmentReadChars        = 6000
+	memoryMineFragmentSnippetChars     = 320
+)
+
+type taxonomyDirSummary struct {
+	Path  string
+	Count int
+}
+
+func buildTaxonomyMap(fragments []memorydb.Fragment, maxTokens int) string {
+	if maxTokens <= 0 {
+		return "(omitted)"
+	}
+	if len(fragments) == 0 {
+		base := "Memory fragment map:\n- total_fragments: 0\n- no existing fragments"
+		if llm.EstimateTokens(base) <= maxTokens {
+			return base
+		}
+		return "fragment_count=0; use lookup tools"
+	}
+
+	byPath := make([]memorydb.Fragment, len(fragments))
+	copy(byPath, fragments)
+	sort.Slice(byPath, func(i, j int) bool {
+		if byPath[i].UpdatedAt.Equal(byPath[j].UpdatedAt) {
+			return byPath[i].Path < byPath[j].Path
+		}
+		return byPath[i].UpdatedAt.After(byPath[j].UpdatedAt)
+	})
+
+	dirCounts := map[string]int{}
+	for _, frag := range byPath {
+		dir := path.Dir(frag.Path)
+		if dir == "." {
+			dir = "(root)"
+		}
+		dirCounts[dir]++
+	}
+	dirs := make([]taxonomyDirSummary, 0, len(dirCounts))
+	for dir, count := range dirCounts {
+		dirs = append(dirs, taxonomyDirSummary{Path: dir, Count: count})
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		if dirs[i].Count == dirs[j].Count {
+			return dirs[i].Path < dirs[j].Path
+		}
+		return dirs[i].Count > dirs[j].Count
+	})
+
+	var b strings.Builder
+	b.WriteString("Memory fragment map:\n")
+	b.WriteString(fmt.Sprintf("- total_fragments: %d\n", len(byPath)))
+	b.WriteString("- note: compact map only; use lookup tools for exact duplicate checks or content inspection\n")
+	if llm.EstimateTokens(b.String()) > maxTokens {
+		return fmt.Sprintf("fragment_count=%d; use lookup tools", len(byPath))
+	}
+
+	dirBudget := maxTokens / 3
+	if dirBudget < 150 {
+		dirBudget = 150
+	}
+	b.WriteString("Directories:\n")
+	dirLines := 0
+	for _, dir := range dirs {
+		line := fmt.Sprintf("- %s (%d)\n", dir.Path, dir.Count)
+		if llm.EstimateTokens(b.String()+line) > dirBudget {
+			break
+		}
+		b.WriteString(line)
+		dirLines++
+	}
+	if dirLines == 0 {
+		b.WriteString("- (directory summary omitted for budget)\n")
+	}
+
+	b.WriteString("Known fragment paths (recent-first, partial if needed):\n")
+	addedPaths := 0
+	for _, frag := range byPath {
+		line := "- " + frag.Path + "\n"
+		if llm.EstimateTokens(b.String()+line) > maxTokens {
+			break
+		}
+		b.WriteString(line)
+		addedPaths++
+	}
+	if omitted := len(byPath) - addedPaths; omitted > 0 {
+		line := fmt.Sprintf("- ... %d more path(s) omitted from map; use lookup tools\n", omitted)
+		if llm.EstimateTokens(b.String()+line) <= maxTokens {
+			b.WriteString(line)
+		}
+	}
+
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "(omitted)"
+	}
+	return out
+}
+
+func estimateExtractionPromptTokens(candidate memoryMineCandidate, startOffset, endOffset int, messages []session.Message, taxonomyMap string) int {
+	prompt := buildExtractionPrompt(candidate, startOffset, endOffset, messages, taxonomyMap)
+	return llm.EstimateTokens(memoryExtractionSystemPrompt) + llm.EstimateTokens(prompt)
+}
+
+func truncateMessageForPromptBudget(candidate memoryMineCandidate, startOffset, nextOffset int, taxonomyMap string, msg session.Message) (session.Message, bool) {
+	text := strings.TrimSpace(msg.TextContent)
+	if text == "" {
+		return msg, estimateExtractionPromptTokens(candidate, startOffset, nextOffset, []session.Message{msg}, taxonomyMap) <= memoryMinePromptMaxTokens
+	}
+
+	runes := []rune(text)
+	suffix := "... [truncated for memory mining budget]"
+	best := -1
+	lo, hi := 0, len(runes)
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		candidateText := string(runes[:mid])
+		if mid < len(runes) {
+			candidateText = strings.TrimSpace(candidateText) + suffix
+		}
+		clone := msg
+		clone.TextContent = candidateText
+		if estimateExtractionPromptTokens(candidate, startOffset, nextOffset, []session.Message{clone}, taxonomyMap) <= memoryMinePromptMaxTokens {
+			best = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	if best < 0 {
+		return session.Message{}, false
+	}
+	clone := msg
+	clone.TextContent = string(runes[:best])
+	if best < len(runes) {
+		clone.TextContent = strings.TrimSpace(clone.TextContent) + suffix
+	}
+	return clone, true
+}
+
+func registerMemoryExtractionTools(engine *llm.Engine, store *memorydb.Store, agent string) ([]llm.ToolSpec, func()) {
+	tools := []llm.Tool{
+		&memorySearchFragmentsTool{store: store, agent: agent},
+		&memoryListFragmentsTool{store: store, agent: agent},
+		&memoryGetFragmentTool{store: store, agent: agent},
+	}
+	specs := make([]llm.ToolSpec, 0, len(tools))
+	for _, tool := range tools {
+		engine.RegisterTool(tool)
+		specs = append(specs, tool.Spec())
+	}
+	cleanup := func() {
+		for _, tool := range tools {
+			engine.UnregisterTool(tool.Spec().Name)
+		}
+	}
+	return specs, cleanup
+}
+
+type memorySearchFragmentsTool struct {
+	store *memorydb.Store
+	agent string
+}
+
+func (t *memorySearchFragmentsTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        "memory_search_fragments",
+		Description: "Search existing memory fragments by content and path. Use this before creating a new fragment when duplicate or overlapping memory might already exist.",
+		Schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query": map[string]interface{}{"type": "string", "description": "Search query describing the memory you want to inspect"},
+				"limit": map[string]interface{}{"type": "integer", "description": "Maximum number of hits to return (default 5, max 8)", "default": 5},
+			},
+			"required":             []string{"query"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *memorySearchFragmentsTool) Preview(args json.RawMessage) string {
+	var payload struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Query)
+}
+
+func (t *memorySearchFragmentsTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var payload struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return llm.ToolOutput{}, fmt.Errorf("parse memory_search_fragments args: %w", err)
+	}
+	payload.Query = strings.TrimSpace(payload.Query)
+	if payload.Query == "" {
+		return llm.ToolOutput{}, fmt.Errorf("query is required")
+	}
+	if payload.Limit <= 0 || payload.Limit > memoryMineFragmentSearchLimit {
+		payload.Limit = 5
+	}
+
+	results, err := t.store.SearchFragments(ctx, payload.Query, payload.Limit, t.agent)
+	if err != nil {
+		return llm.ToolOutput{}, err
+	}
+	for i := range results {
+		snippetLimit := memoryMineFragmentSnippetChars
+		if memoryMineReadBytes > 0 && memoryMineReadBytes < snippetLimit {
+			snippetLimit = memoryMineReadBytes
+		}
+		if len(results[i].Snippet) > snippetLimit {
+			results[i].Snippet = results[i].Snippet[:snippetLimit] + "..."
+		}
+	}
+	response := map[string]any{
+		"query":   payload.Query,
+		"agent":   t.agent,
+		"results": results,
+	}
+	data, _ := json.MarshalIndent(response, "", "  ")
+	return llm.TextOutput(string(data)), nil
+}
+
+type memoryListFragmentsTool struct {
+	store *memorydb.Store
+	agent string
+}
+
+func (t *memoryListFragmentsTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        "memory_list_fragments",
+		Description: "List existing memory fragment paths, optionally narrowed by prefix. Use this when you know the area of memory you want to inspect but not the exact path.",
+		Schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"prefix": map[string]interface{}{"type": "string", "description": "Optional path prefix such as fragments/preferences or images/2026-03"},
+				"limit":  map[string]interface{}{"type": "integer", "description": "Maximum number of paths to return (default 20)", "default": 20},
+			},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *memoryListFragmentsTool) Preview(args json.RawMessage) string {
+	var payload struct {
+		Prefix string `json:"prefix"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Prefix)
+}
+
+func (t *memoryListFragmentsTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var payload struct {
+		Prefix string `json:"prefix"`
+		Limit  int    `json:"limit"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return llm.ToolOutput{}, fmt.Errorf("parse memory_list_fragments args: %w", err)
+	}
+	prefix := strings.TrimSpace(payload.Prefix)
+	limit := payload.Limit
+	if limit <= 0 || limit > memoryMineFragmentListLimit {
+		limit = memoryMineFragmentListLimit
+	}
+
+	fragments, err := t.store.ListFragments(ctx, memorydb.ListOptions{Agent: t.agent})
+	if err != nil {
+		return llm.ToolOutput{}, err
+	}
+	paths := make([]string, 0, limit)
+	for _, frag := range fragments {
+		if prefix != "" && !strings.HasPrefix(frag.Path, prefix) {
+			continue
+		}
+		paths = append(paths, frag.Path)
+		if len(paths) >= limit {
+			break
+		}
+	}
+	response := map[string]any{
+		"agent":  t.agent,
+		"prefix": prefix,
+		"paths":  paths,
+	}
+	data, _ := json.MarshalIndent(response, "", "  ")
+	return llm.TextOutput(string(data)), nil
+}
+
+type memoryGetFragmentTool struct {
+	store *memorydb.Store
+	agent string
+}
+
+func (t *memoryGetFragmentTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        "memory_get_fragment",
+		Description: "Read one existing memory fragment by exact path. Use this before updating a fragment so you can merge instead of overwrite blindly.",
+		Schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{"type": "string", "description": "Exact fragment path"},
+			},
+			"required":             []string{"path"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *memoryGetFragmentTool) Preview(args json.RawMessage) string {
+	var payload struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Path)
+}
+
+func (t *memoryGetFragmentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var payload struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return llm.ToolOutput{}, fmt.Errorf("parse memory_get_fragment args: %w", err)
+	}
+	fragPath := strings.TrimSpace(payload.Path)
+	if fragPath == "" {
+		return llm.ToolOutput{}, fmt.Errorf("path is required")
+	}
+	frag, err := t.store.GetFragment(ctx, t.agent, fragPath)
+	if err != nil {
+		return llm.ToolOutput{}, err
+	}
+	if frag == nil {
+		return llm.TextOutput(fmt.Sprintf("{\n  \"agent\": %q,\n  \"path\": %q,\n  \"found\": false\n}", t.agent, fragPath)), nil
+	}
+	content := frag.Content
+	readLimit := memoryMineFragmentReadChars
+	if memoryMineReadBytes > 0 && memoryMineReadBytes < readLimit {
+		readLimit = memoryMineReadBytes
+	}
+	if len(content) > readLimit {
+		content = content[:readLimit] + "\n... [truncated]"
+	}
+	response := map[string]any{
+		"agent":   t.agent,
+		"path":    frag.Path,
+		"found":   true,
+		"content": content,
+	}
+	data, _ := json.MarshalIndent(response, "", "  ")
+	return llm.TextOutput(string(data)), nil
+}

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -3,9 +3,13 @@ package cmd
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/samsaffron/term-llm/internal/llm"
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 func TestParseExtractionOperations_PlainJSON(t *testing.T) {
@@ -112,5 +116,80 @@ func TestApplyExtractionOperations_AffectedPaths(t *testing.T) {
 	}
 	if len(dryRunPaths) != 0 {
 		t.Fatalf("affectedPaths in dry-run = %v, want empty", dryRunPaths)
+	}
+}
+
+func TestBuildTaxonomyMap_RespectsBudget(t *testing.T) {
+	fragments := make([]memorydb.Fragment, 0, 20)
+	for i := 0; i < 20; i++ {
+		fragments = append(fragments, memorydb.Fragment{
+			Path:      filepath.ToSlash(filepath.Join("fragments", "prefs", "topic", time.Now().Format("150405"), strings.Repeat("x", 20)+".md")),
+			UpdatedAt: time.Now().Add(-time.Duration(i) * time.Minute),
+		})
+	}
+	got := buildTaxonomyMap(fragments, 60)
+	if tokens := llm.EstimateTokens(got); tokens > 60 {
+		t.Fatalf("taxonomy tokens = %d, want <= 60\n%s", tokens, got)
+	}
+	if !strings.Contains(got, "total_fragments") {
+		t.Fatalf("taxonomy map missing summary: %s", got)
+	}
+}
+
+func TestLoadMessagesForMining_RespectsPromptBudget(t *testing.T) {
+	ctx := context.Background()
+	sessStore, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer sessStore.Close()
+
+	sess := &session.Session{
+		ID:        session.NewID(),
+		Provider:  "test",
+		Model:     "test-model",
+		Mode:      session.ModeChat,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := sessStore.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for i := 0; i < 6; i++ {
+		msg := session.NewMessage(sess.ID, llm.UserText(strings.Repeat("long durable text ", 80)), -1)
+		if err := sessStore.AddMessage(ctx, sess.ID, msg); err != nil {
+			t.Fatalf("AddMessage(%d): %v", i, err)
+		}
+	}
+
+	oldPromptMax := memoryMinePromptMaxTokens
+	oldBatchSize := memoryMineBatchSize
+	oldMaxMessages := memoryMineMaxMessages
+	memoryMinePromptMaxTokens = 500
+	memoryMineBatchSize = 10
+	memoryMineMaxMessages = 0
+	t.Cleanup(func() {
+		memoryMinePromptMaxTokens = oldPromptMax
+		memoryMineBatchSize = oldBatchSize
+		memoryMineMaxMessages = oldMaxMessages
+	})
+
+	candidate := memoryMineCandidate{
+		Summary: session.SessionSummary{Number: 1},
+		Session: sess,
+		Agent:   "jarvis",
+	}
+	messages, nextOffset, err := loadMessagesForMining(ctx, sessStore, candidate, 0, "Memory fragment map:\n- total_fragments: 0")
+	if err != nil {
+		t.Fatalf("loadMessagesForMining: %v", err)
+	}
+	if len(messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+	if nextOffset >= 6 {
+		t.Fatalf("nextOffset = %d, want partial batch due to prompt budget", nextOffset)
+	}
+	if got := estimateExtractionPromptTokens(candidate, 0, nextOffset, messages, "Memory fragment map:\n- total_fragments: 0"); got > memoryMinePromptMaxTokens {
+		t.Fatalf("estimated prompt tokens = %d, want <= %d", got, memoryMinePromptMaxTokens)
 	}
 }


### PR DESCRIPTION
## What

Reworks `memory mine` so one extraction request stays on a sane budget instead of dumping the full transcript plus every fragment preview into the prompt.

This PR:

- adds an approximate per-request prompt budget for memory extraction (`--prompt-max-tokens`, default `12000`)
- replaces the old preview-heavy taxonomy with a compact fragment map capped by its own budget (`--taxonomy-max-tokens`, default `1000`)
- batches session messages to fit inside the extraction prompt budget instead of sending all newly mined messages at once
- truncates a single oversized message if needed so one giant paste does not blow up the whole run
- adds dynamic memory lookup tools during extraction:
  - `memory_search_fragments`
  - `memory_list_fragments`
  - `memory_get_fragment`
- updates the extraction prompt to treat the taxonomy as a compact map and use tools for exact duplicate/content inspection
- sets extraction-specific turn/output limits (`--tool-max-turns`, default `6`; `--max-output-tokens`, default `2048`)
- adds tests for taxonomy budgeting and prompt-budgeted message loading

## Why

The old setup was wasteful and did not have a real upper bound:

- taxonomy included per-fragment previews (default `2048` bytes each)
- all newly mined messages could be appended into one request
- there was no explicit request-level token budget for memory extraction

That becomes untenable as memory grows.

The new shape is closer to the right architecture for mining:

- keep the base prompt around the 10k–15k range (default `12000`)
- make taxonomy cheap and structural, not a full content dump
- let the model fetch specific fragment context on demand before deciding between create vs update

## Validation

- `gofmt -w cmd/memory_mine.go cmd/memory_mine_budget.go cmd/memory_mine_test.go`
- `go test ./...`
