### PR TITLE
feat: add memory mine extraction stats

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -38,6 +38,7 @@ var (
 	memoryMineTaxonomyMaxTokens int
 	memoryMineToolMaxTurns      int
 	memoryMineMaxOutputTokens   int
+	memoryMineShowStats         bool
 )
 
 var memoryMineCmd = &cobra.Command{
@@ -96,6 +97,7 @@ func init() {
 	memoryMineCmd.Flags().IntVar(&memoryMineTaxonomyMaxTokens, "taxonomy-max-tokens", defaultMemoryMineTaxonomyMaxTokens, "Approximate maximum tokens for the compact fragment taxonomy map")
 	memoryMineCmd.Flags().IntVar(&memoryMineToolMaxTurns, "tool-max-turns", defaultMemoryMineToolMaxTurns, "Maximum tool-assisted turns allowed for one extraction request")
 	memoryMineCmd.Flags().IntVar(&memoryMineMaxOutputTokens, "max-output-tokens", defaultMemoryMineMaxOutputTokens, "Maximum output tokens for one extraction request")
+	memoryMineCmd.Flags().BoolVar(&memoryMineShowStats, "stats", false, "Print prompt, tool, token, and timing stats for each mined batch")
 	memoryMineCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)
 }
 
@@ -201,6 +203,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	}
 
 	var totalCreated, totalUpdated, totalSkipped int
+	var summaryStats memoryMineSummaryStats
 
 	for i, candidate := range candidates {
 		state, err := memStore.GetState(ctx, candidate.Session.ID)
@@ -225,25 +228,32 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		}
 		taxonomyMap := buildTaxonomyMap(existing, memoryMineTaxonomyMaxTokens)
 
-		messages, nextOffset, err := loadMessagesForMining(ctx, sessStore, candidate, startOffset, taxonomyMap)
+		loadResult, err := loadMessagesForMining(ctx, sessStore, candidate, startOffset, taxonomyMap)
 		if err != nil {
 			return fmt.Errorf("load messages for session %s: %w", candidate.Session.ID, err)
 		}
-		if len(messages) == 0 {
+		if len(loadResult.Messages) == 0 {
 			fmt.Printf("[%d/%d] #%d no new messages to mine\n", i+1, len(candidates), candidate.Summary.Number)
 			continue
 		}
 
-		prompt := buildExtractionPrompt(candidate, startOffset, nextOffset, messages, taxonomyMap)
-		raw, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, prompt)
+		promptParts := buildExtractionPromptParts(candidate, startOffset, loadResult.NextOffset, loadResult.Messages, taxonomyMap)
+		batchStats := newMemoryExtractionStats(candidate, startOffset, loadResult.NextOffset, len(existing), loadResult, promptParts)
+		batchStart := time.Now()
+		raw, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, promptParts.Prompt, &batchStats)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping session %s batch at offset %d: %v\n", candidate.Session.ID, startOffset, err)
 			continue
 		}
 
 		ops, err := parseExtractionOperations(raw)
+		batchStats.Duration = time.Since(batchStart)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: bad extraction output for session %s at offset %d: %v\nraw: %s\n", candidate.Session.ID, startOffset, err, raw)
+			if memoryMineShowStats {
+				fmt.Printf("[%d/%d] #%d %s\n", i+1, len(candidates), candidate.Summary.Number, batchStats.oneLine())
+				summaryStats.add(batchStats)
+			}
 			continue
 		}
 
@@ -251,17 +261,18 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("apply operations for session %s: %w", candidate.Session.ID, err)
 		}
+		batchStats.Duration = time.Since(batchStart)
 
 		if !memoryDryRun {
 			for _, p := range affectedPaths {
-				if srcErr := memStore.AddFragmentSource(ctx, candidate.Agent, p, candidate.Session.ID, startOffset, nextOffset); srcErr != nil {
+				if srcErr := memStore.AddFragmentSource(ctx, candidate.Agent, p, candidate.Session.ID, startOffset, loadResult.NextOffset); srcErr != nil {
 					fmt.Fprintf(os.Stderr, "warning: record fragment source %s: %v\n", p, srcErr)
 				}
 			}
 			if err := memStore.UpsertState(ctx, &memorydb.MiningState{
 				SessionID:       candidate.Session.ID,
 				Agent:           candidate.Agent,
-				LastMinedOffset: nextOffset,
+				LastMinedOffset: loadResult.NextOffset,
 				MinedAt:         time.Now(),
 			}); err != nil {
 				return fmt.Errorf("update mining state for session %s: %w", candidate.Session.ID, err)
@@ -273,7 +284,11 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		totalSkipped += skipped
 
 		fmt.Printf("[%d/%d] #%d mined messages [%d,%d): create=%d update=%d skip=%d\n",
-			i+1, len(candidates), candidate.Summary.Number, startOffset, nextOffset, created, updated, skipped)
+			i+1, len(candidates), candidate.Summary.Number, startOffset, loadResult.NextOffset, created, updated, skipped)
+		if memoryMineShowStats {
+			fmt.Printf("[%d/%d] #%d %s\n", i+1, len(candidates), candidate.Summary.Number, batchStats.oneLine())
+			summaryStats.add(batchStats)
+		}
 	}
 
 	if memoryDryRun {
@@ -339,6 +354,9 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Done. create=%d update=%d skip=%d\n", totalCreated, totalUpdated, totalSkipped)
+	if memoryMineShowStats {
+		summaryStats.print()
+	}
 
 	if memoryMineInsights && !memoryDryRun {
 		fmt.Println("\n--- INSIGHT EXTRACTION ---")
@@ -432,10 +450,11 @@ func collectMineCandidates(ctx context.Context, store session.Store, complete []
 	return out, nil
 }
 
-func loadMessagesForMining(ctx context.Context, store session.Store, candidate memoryMineCandidate, offset int, taxonomyMap string) ([]session.Message, int, error) {
+func loadMessagesForMining(ctx context.Context, store session.Store, candidate memoryMineCandidate, offset int, taxonomyMap string) (memoryMineLoadResult, error) {
 	remaining := memoryMineMaxMessages
 	currentOffset := offset
 	all := make([]session.Message, 0, memoryMineBatchSize)
+	result := memoryMineLoadResult{}
 
 	for {
 		limit := memoryMineBatchSize
@@ -445,7 +464,7 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 
 		msgs, err := store.GetMessages(ctx, candidate.Session.ID, limit, currentOffset)
 		if err != nil {
-			return nil, currentOffset, err
+			return result, err
 		}
 		if len(msgs) == 0 {
 			break
@@ -455,22 +474,29 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 			candidateMessages := append(append([]session.Message(nil), all...), msg)
 			nextOffset := currentOffset + 1
 			if estimateExtractionPromptTokens(candidate, offset, nextOffset, candidateMessages, taxonomyMap) > memoryMinePromptMaxTokens {
+				result.PromptBudgetHit = true
 				if len(all) == 0 {
 					clipped, ok := truncateMessageForPromptBudget(candidate, offset, nextOffset, taxonomyMap, msg)
 					if !ok {
-						return nil, currentOffset, fmt.Errorf("single message at offset %d cannot fit within --prompt-max-tokens=%d", currentOffset, memoryMinePromptMaxTokens)
+						return result, fmt.Errorf("single message at offset %d cannot fit within --prompt-max-tokens=%d", currentOffset, memoryMinePromptMaxTokens)
 					}
 					all = append(all, clipped)
 					currentOffset = nextOffset
+					result.TruncatedMessages++
+					result.SingleMessageClipped = true
 				}
-				return all, currentOffset, nil
+				result.Messages = all
+				result.NextOffset = currentOffset
+				return result, nil
 			}
 			all = candidateMessages
 			currentOffset = nextOffset
 			if remaining > 0 {
 				remaining--
 				if remaining <= 0 {
-					return all, currentOffset, nil
+					result.Messages = all
+					result.NextOffset = currentOffset
+					return result, nil
 				}
 			}
 		}
@@ -480,53 +506,13 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 		}
 	}
 
-	return all, currentOffset, nil
+	result.Messages = all
+	result.NextOffset = currentOffset
+	return result, nil
 }
 
 func buildExtractionPrompt(candidate memoryMineCandidate, startOffset, endOffset int, messages []session.Message, taxonomyMap string) string {
-	transcriptJSON, _ := json.MarshalIndent(buildTranscript(messages), "", "  ")
-
-	return fmt.Sprintf(`Session metadata:
-- session_id: %s
-- session_number: %d
-- agent: %s
-- mined_message_range: [%d, %d)
-- transcript_message_count: %d
-
-Existing fragment map (compact, partial by design):
-%s
-
-Transcript (role + text + tool call names only):
-%s
-
-Instructions:
-- Extract only durable facts, decisions, preferences, and technical details worth remembering long-term.
-- Skip ephemeral content like specific transient errors, one-off debugging output, and conversational filler.
-- The fragment map is intentionally compact and may omit exact duplicates or existing content details.
-- Use lookup tools when you need to confirm whether related memory already exists, inspect exact fragment content, or browse likely paths.
-- Prefer update when an existing fragment already captures the fact; use create for genuinely new memory.
-- Return at most 20 operations.
-- Fragment content must stay <= 8192 bytes.
-- Path must be relative and must not contain ../ or be absolute.
-
-Return strict JSON only, exactly in this format:
-{
-  "operations": [
-    {"op": "create", "path": "...", "content": "..."},
-    {"op": "update", "path": "...", "content": "...", "reason": "..."},
-    {"op": "skip", "reason": "..."}
-  ]
-}
-`,
-		candidate.Session.ID,
-		candidate.Summary.Number,
-		candidate.Agent,
-		startOffset,
-		endOffset,
-		len(messages),
-		taxonomyMap,
-		string(transcriptJSON),
-	)
+	return buildExtractionPromptParts(candidate, startOffset, endOffset, messages, taxonomyMap).Prompt
 }
 
 func buildTranscript(messages []session.Message) []transcriptMessage {
@@ -577,13 +563,13 @@ func collectToolCallNames(msg session.Message) []string {
 	return out
 }
 
-func runExtractionRequest(ctx context.Context, engine *llm.Engine, store *memorydb.Store, agent, prompt string) (string, error) {
+func runExtractionRequest(ctx context.Context, engine *llm.Engine, store *memorydb.Store, agent, prompt string, stats *memoryExtractionStats) (string, error) {
 	toolSpecs, cleanup := registerMemoryExtractionTools(engine, store, agent)
 	defer cleanup()
-	return runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt, toolSpecs...)
+	return runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt, stats, toolSpecs...)
 }
 
-func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string, tools ...llm.ToolSpec) (string, error) {
+func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string, stats *memoryExtractionStats, tools ...llm.ToolSpec) (string, error) {
 	req := llm.Request{
 		Model:           strings.TrimSpace(memoryMineModel),
 		Messages:        []llm.Message{llm.SystemText(systemPrompt), llm.UserText(prompt)},
@@ -617,6 +603,18 @@ func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, sys
 		switch ev.Type {
 		case llm.EventTextDelta:
 			b.WriteString(ev.Text)
+		case llm.EventToolCall:
+			if stats != nil && ev.Tool != nil {
+				stats.noteToolCall(strings.TrimSpace(ev.Tool.Name))
+			}
+		case llm.EventUsage:
+			if stats != nil && ev.Use != nil {
+				stats.ToolTurns++
+				stats.InputTokens += ev.Use.InputTokens
+				stats.CachedInputTokens += ev.Use.CachedInputTokens
+				stats.CacheWriteTokens += ev.Use.CacheWriteTokens
+				stats.OutputTokens += ev.Use.OutputTokens
+			}
 		case llm.EventError:
 			if ev.Err != nil {
 				return "", ev.Err
@@ -1163,11 +1161,12 @@ func runInsightExtractionPass(
 			continue
 		}
 
-		messages, _, err := loadMessagesForMining(ctx, sessStore, candidate, 0, "Memory fragment map:\n- total_fragments: 0")
+		loadResult, err := loadMessagesForMining(ctx, sessStore, candidate, 0, "Memory fragment map:\n- total_fragments: 0")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: load messages: %v\n", candidate.Session.ID, err)
 			continue
 		}
+		messages := loadResult.Messages
 		if len(messages) < 4 {
 			// Too short to contain meaningful patterns.
 			continue
@@ -1180,7 +1179,7 @@ func runInsightExtractionPass(
 		}
 
 		prompt := buildInsightExtractionPrompt(candidate.Agent, messages, existing)
-		raw, err := runExtractionRequestWithSystem(ctx, engine, insightExtractionSystemPrompt, prompt)
+		raw, err := runExtractionRequestWithSystem(ctx, engine, insightExtractionSystemPrompt, prompt, nil)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: llm call: %v\n", candidate.Session.ID, err)
 			continue

--- a/cmd/memory_mine_stats.go
+++ b/cmd/memory_mine_stats.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type memoryPromptParts struct {
+	Metadata     string
+	TaxonomyMap  string
+	Transcript   string
+	Instructions string
+	Prompt       string
+}
+
+type memoryMineLoadResult struct {
+	Messages             []session.Message
+	NextOffset           int
+	TruncatedMessages    int
+	PromptBudgetHit      bool
+	SingleMessageClipped bool
+}
+
+type memoryExtractionStats struct {
+	SessionID             string
+	SessionNumber         int64
+	Agent                 string
+	StartOffset           int
+	EndOffset             int
+	ExistingFragments     int
+	TranscriptMessages    int
+	PromptMaxTokens       int
+	PromptEstimatedTokens int
+	SystemTokens          int
+	MetadataTokens        int
+	TaxonomyTokens        int
+	TranscriptTokens      int
+	InstructionsTokens    int
+	ToolTurns             int
+	ToolCalls             int
+	ToolNames             []string
+	InputTokens           int
+	CachedInputTokens     int
+	CacheWriteTokens      int
+	OutputTokens          int
+	TruncatedMessages     int
+	PromptBudgetHit       bool
+	SingleMessageClipped  bool
+	Duration              time.Duration
+}
+
+type memoryMineSummaryStats struct {
+	Batches           int
+	TotalDuration     time.Duration
+	TotalPromptTokens int
+	TotalToolCalls    int
+	TotalToolTurns    int
+	TotalInputTokens  int
+	TotalOutputTokens int
+	Slowest           []memoryExtractionStats
+}
+
+func buildExtractionPromptParts(candidate memoryMineCandidate, startOffset, endOffset int, messages []session.Message, taxonomyMap string) memoryPromptParts {
+	transcriptJSON, _ := json.MarshalIndent(buildTranscript(messages), "", "  ")
+	metadata := fmt.Sprintf(`Session metadata:
+- session_id: %s
+- session_number: %d
+- agent: %s
+- mined_message_range: [%d, %d)
+- transcript_message_count: %d`,
+		candidate.Session.ID,
+		candidate.Summary.Number,
+		candidate.Agent,
+		startOffset,
+		endOffset,
+		len(messages),
+	)
+	instructions := `Instructions:
+- Extract only durable facts, decisions, preferences, and technical details worth remembering long-term.
+- Skip ephemeral content like specific transient errors, one-off debugging output, and conversational filler.
+- The fragment map is intentionally compact and may omit exact duplicates or existing content details.
+- Use lookup tools when you need to confirm whether related memory already exists, inspect exact fragment content, or browse likely paths.
+- Prefer update when an existing fragment already captures the fact; use create for genuinely new memory.
+- Return at most 20 operations.
+- Fragment content must stay <= 8192 bytes.
+- Path must be relative and must not contain ../ or be absolute.
+
+Return strict JSON only, exactly in this format:
+{
+  "operations": [
+    {"op": "create", "path": "...", "content": "..."},
+    {"op": "update", "path": "...", "content": "...", "reason": "..."},
+    {"op": "skip", "reason": "..."}
+  ]
+}`
+	prompt := fmt.Sprintf(`%s
+
+Existing fragment map (compact, partial by design):
+%s
+
+Transcript (role + text + tool call names only):
+%s
+
+%s`, metadata, taxonomyMap, string(transcriptJSON), instructions)
+	return memoryPromptParts{
+		Metadata:     metadata,
+		TaxonomyMap:  taxonomyMap,
+		Transcript:   string(transcriptJSON),
+		Instructions: instructions,
+		Prompt:       prompt,
+	}
+}
+
+func newMemoryExtractionStats(candidate memoryMineCandidate, startOffset, endOffset int, existingFragments int, load memoryMineLoadResult, parts memoryPromptParts) memoryExtractionStats {
+	return memoryExtractionStats{
+		SessionID:             candidate.Session.ID,
+		SessionNumber:         candidate.Summary.Number,
+		Agent:                 candidate.Agent,
+		StartOffset:           startOffset,
+		EndOffset:             endOffset,
+		ExistingFragments:     existingFragments,
+		TranscriptMessages:    len(load.Messages),
+		PromptMaxTokens:       memoryMinePromptMaxTokens,
+		PromptEstimatedTokens: llm.EstimateTokens(memoryExtractionSystemPrompt) + llm.EstimateTokens(parts.Prompt),
+		SystemTokens:          llm.EstimateTokens(memoryExtractionSystemPrompt),
+		MetadataTokens:        llm.EstimateTokens(parts.Metadata),
+		TaxonomyTokens:        llm.EstimateTokens(parts.TaxonomyMap),
+		TranscriptTokens:      llm.EstimateTokens(parts.Transcript),
+		InstructionsTokens:    llm.EstimateTokens(parts.Instructions),
+		TruncatedMessages:     load.TruncatedMessages,
+		PromptBudgetHit:       load.PromptBudgetHit,
+		SingleMessageClipped:  load.SingleMessageClipped,
+	}
+}
+
+func (s *memoryExtractionStats) noteToolCall(name string) {
+	s.ToolCalls++
+	for _, existing := range s.ToolNames {
+		if existing == name {
+			return
+		}
+	}
+	s.ToolNames = append(s.ToolNames, name)
+	sort.Strings(s.ToolNames)
+}
+
+func (s memoryExtractionStats) oneLine() string {
+	tools := "-"
+	if len(s.ToolNames) > 0 {
+		tools = strings.Join(s.ToolNames, ",")
+	}
+	return fmt.Sprintf("stats: wall=%s prompt≈%dt/%dt system=%dt meta=%dt taxonomy=%dt transcript=%dt instr=%dt existing=%d msgs=%d turns=%d tool_calls=%d tools=%s usage[in=%d cached=%d out=%d write=%d] truncated_msgs=%d budget_hit=%t single_clip=%t",
+		s.Duration.Round(time.Millisecond),
+		s.PromptEstimatedTokens,
+		s.PromptMaxTokens,
+		s.SystemTokens,
+		s.MetadataTokens,
+		s.TaxonomyTokens,
+		s.TranscriptTokens,
+		s.InstructionsTokens,
+		s.ExistingFragments,
+		s.TranscriptMessages,
+		s.ToolTurns,
+		s.ToolCalls,
+		tools,
+		s.InputTokens,
+		s.CachedInputTokens,
+		s.OutputTokens,
+		s.CacheWriteTokens,
+		s.TruncatedMessages,
+		s.PromptBudgetHit,
+		s.SingleMessageClipped,
+	)
+}
+
+func (m *memoryMineSummaryStats) add(s memoryExtractionStats) {
+	m.Batches++
+	m.TotalDuration += s.Duration
+	m.TotalPromptTokens += s.PromptEstimatedTokens
+	m.TotalToolCalls += s.ToolCalls
+	m.TotalToolTurns += s.ToolTurns
+	m.TotalInputTokens += s.InputTokens + s.CachedInputTokens
+	m.TotalOutputTokens += s.OutputTokens
+	m.Slowest = append(m.Slowest, s)
+	sort.Slice(m.Slowest, func(i, j int) bool { return m.Slowest[i].Duration > m.Slowest[j].Duration })
+	if len(m.Slowest) > 5 {
+		m.Slowest = m.Slowest[:5]
+	}
+}
+
+func (m memoryMineSummaryStats) print() {
+	if m.Batches == 0 {
+		return
+	}
+	avgPrompt := m.TotalPromptTokens / m.Batches
+	avgDuration := time.Duration(int64(m.TotalDuration) / int64(m.Batches))
+	fmt.Printf("\n--- MEMORY MINE STATS ---\n")
+	fmt.Printf("batches=%d total_wall=%s avg_wall=%s avg_prompt≈%dt total_tool_calls=%d total_tool_turns=%d total_input=%d total_output=%d\n",
+		m.Batches,
+		m.TotalDuration.Round(time.Millisecond),
+		avgDuration.Round(time.Millisecond),
+		avgPrompt,
+		m.TotalToolCalls,
+		m.TotalToolTurns,
+		m.TotalInputTokens,
+		m.TotalOutputTokens,
+	)
+	if len(m.Slowest) > 0 {
+		fmt.Println("slowest batches:")
+		for _, s := range m.Slowest {
+			fmt.Printf("- #%d [%d,%d) wall=%s prompt≈%dt tools=%d (%s) budget_hit=%t\n",
+				s.SessionNumber,
+				s.StartOffset,
+				s.EndOffset,
+				s.Duration.Round(time.Millisecond),
+				s.PromptEstimatedTokens,
+				s.ToolCalls,
+				strings.Join(s.ToolNames, ","),
+				s.PromptBudgetHit,
+			)
+		}
+	}
+}

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -179,17 +179,17 @@ func TestLoadMessagesForMining_RespectsPromptBudget(t *testing.T) {
 		Session: sess,
 		Agent:   "jarvis",
 	}
-	messages, nextOffset, err := loadMessagesForMining(ctx, sessStore, candidate, 0, "Memory fragment map:\n- total_fragments: 0")
+	loadResult, err := loadMessagesForMining(ctx, sessStore, candidate, 0, "Memory fragment map:\n- total_fragments: 0")
 	if err != nil {
 		t.Fatalf("loadMessagesForMining: %v", err)
 	}
-	if len(messages) == 0 {
+	if len(loadResult.Messages) == 0 {
 		t.Fatal("expected at least one message")
 	}
-	if nextOffset >= 6 {
-		t.Fatalf("nextOffset = %d, want partial batch due to prompt budget", nextOffset)
+	if loadResult.NextOffset >= 6 {
+		t.Fatalf("nextOffset = %d, want partial batch due to prompt budget", loadResult.NextOffset)
 	}
-	if got := estimateExtractionPromptTokens(candidate, 0, nextOffset, messages, "Memory fragment map:\n- total_fragments: 0"); got > memoryMinePromptMaxTokens {
+	if got := estimateExtractionPromptTokens(candidate, 0, loadResult.NextOffset, loadResult.Messages, "Memory fragment map:\n- total_fragments: 0"); got > memoryMinePromptMaxTokens {
 		t.Fatalf("estimated prompt tokens = %d, want <= %d", got, memoryMinePromptMaxTokens)
 	}
 }


### PR DESCRIPTION
## What

Adds a `--stats` mode to `term-llm memory mine` so we can see where memory extraction time and budget go, batch by batch.

This PR adds:

- `term-llm memory mine --stats`
- per-batch extraction stats including:
  - wall time
  - estimated prompt tokens vs configured prompt max
  - prompt breakdown (`system`, `meta`, `taxonomy`, `transcript`, `instructions`)
  - existing fragment count
  - transcript message count
  - tool turns / tool calls / tool names
  - provider usage totals (`input`, `cached`, `output`, `cache_write`)
  - whether prompt budget was hit
  - whether a single oversized message had to be clipped
- a summary footer with:
  - batch count
  - total / average wall time
  - average prompt size
  - total tool calls / tool turns
  - total input / output tokens
  - slowest batches

It also refactors extraction prompt construction into structured prompt parts so the same components can be used both for prompting and for reporting.

## Why

After the prompt-budget PR, we still needed observability.

Without stats, we can't tell whether a slow memory mine is caused by:

- transcript size
- taxonomy size
- lookup tool churn
- model latency
- a handful of pathological sessions

This makes outliers visible instead of forcing manual timing and guesswork.

## Sample

A dry-run batch now prints stats like:

```text
[1/1] #1071 stats: wall=24.254s prompt≈11243t/12000t system=104t meta=39t taxonomy=997t transcript=9838t instr=239t existing=592 msgs=59 turns=2 tool_calls=2 tools=memory_list_fragments,memory_search_fragments usage[in=29328 cached=0 out=874 write=0] truncated_msgs=0 budget_hit=false single_clip=false
```

And a summary block:

```text
--- MEMORY MINE STATS ---
batches=1 total_wall=24.254s avg_wall=24.254s avg_prompt≈11243t total_tool_calls=2 total_tool_turns=2 total_input=29328 total_output=874
slowest batches:
- #1071 [0,59) wall=24.254s prompt≈11243t tools=2 (memory_list_fragments,memory_search_fragments) budget_hit=false
```

## Validation

- `go test ./...`
- `go run . memory mine --agent jarvis --limit 1 --dry-run --embed=false --promote never --stats`
