### PR TITLE
feat: prefer user and durable assistant text in memory mine

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -471,26 +471,24 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 		}
 
 		for _, msg := range msgs {
-			candidateMessages := append(append([]session.Message(nil), all...), msg)
+			candidateMessages := append(cloneMessages(all), msg)
 			nextOffset := currentOffset + 1
-			if estimateExtractionPromptTokens(candidate, offset, nextOffset, candidateMessages, taxonomyMap) > memoryMinePromptMaxTokens {
+			fit, ok := fitMessagesForPromptBudget(candidate, offset, nextOffset, candidateMessages, taxonomyMap)
+			if !ok {
 				result.PromptBudgetHit = true
-				if len(all) == 0 {
-					clipped, ok := truncateMessageForPromptBudget(candidate, offset, nextOffset, taxonomyMap, msg)
-					if !ok {
-						return result, fmt.Errorf("single message at offset %d cannot fit within --prompt-max-tokens=%d", currentOffset, memoryMinePromptMaxTokens)
-					}
-					all = append(all, clipped)
-					currentOffset = nextOffset
-					result.TruncatedMessages++
-					result.SingleMessageClipped = true
-				}
 				result.Messages = all
 				result.NextOffset = currentOffset
 				return result, nil
 			}
-			all = candidateMessages
+			all = fit.Messages
 			currentOffset = nextOffset
+			result.TruncatedMessages = fit.TruncatedMessages
+			result.AssistantMessagesCut = fit.AssistantMessagesCut
+			result.UserMessagesCut = fit.UserMessagesCut
+			result.SingleMessageClipped = fit.SingleMessageClipped
+			if fit.TruncatedMessages > 0 {
+				result.PromptBudgetHit = true
+			}
 			if remaining > 0 {
 				remaining--
 				if remaining <= 0 {

--- a/cmd/memory_mine_budget.go
+++ b/cmd/memory_mine_budget.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
@@ -22,11 +23,20 @@ const (
 	memoryMineFragmentListLimit        = 20
 	memoryMineFragmentReadChars        = 6000
 	memoryMineFragmentSnippetChars     = 320
+	memoryMineTruncateMarker           = "... [truncated for memory mining budget]"
 )
 
 type taxonomyDirSummary struct {
 	Path  string
 	Count int
+}
+
+type transcriptFitResult struct {
+	Messages             []session.Message
+	TruncatedMessages    int
+	AssistantMessagesCut int
+	UserMessagesCut      int
+	SingleMessageClipped bool
 }
 
 func buildTaxonomyMap(fragments []memorydb.Fragment, maxTokens int) string {
@@ -131,14 +141,13 @@ func truncateMessageForPromptBudget(candidate memoryMineCandidate, startOffset, 
 	}
 
 	runes := []rune(text)
-	suffix := "... [truncated for memory mining budget]"
 	best := -1
 	lo, hi := 0, len(runes)
 	for lo <= hi {
 		mid := (lo + hi) / 2
 		candidateText := string(runes[:mid])
 		if mid < len(runes) {
-			candidateText = strings.TrimSpace(candidateText) + suffix
+			candidateText = strings.TrimSpace(candidateText) + memoryMineTruncateMarker
 		}
 		clone := msg
 		clone.TextContent = candidateText
@@ -152,12 +161,160 @@ func truncateMessageForPromptBudget(candidate memoryMineCandidate, startOffset, 
 	if best < 0 {
 		return session.Message{}, false
 	}
-	clone := msg
-	clone.TextContent = string(runes[:best])
-	if best < len(runes) {
-		clone.TextContent = strings.TrimSpace(clone.TextContent) + suffix
+	return cloneMessageWithText(msg, string(runes[:best]), best < len(runes)), true
+}
+
+func fitMessagesForPromptBudget(candidate memoryMineCandidate, startOffset, nextOffset int, messages []session.Message, taxonomyMap string) (transcriptFitResult, bool) {
+	result := transcriptFitResult{Messages: cloneMessages(messages)}
+	if estimateExtractionPromptTokens(candidate, startOffset, nextOffset, result.Messages, taxonomyMap) <= memoryMinePromptMaxTokens {
+		return result, true
 	}
-	return clone, true
+
+	passes := []struct {
+		High int
+		Med  int
+		Low  int
+	}{
+		{High: 1200, Med: 600, Low: 160},
+		{High: 800, Med: 320, Low: 80},
+		{High: 500, Med: 180, Low: 0},
+	}
+
+	for _, pass := range passes {
+		for i := range result.Messages {
+			msg := &result.Messages[i]
+			if msg.Role != llm.RoleAssistant {
+				continue
+			}
+			if strings.TrimSpace(msg.TextContent) == "" {
+				continue
+			}
+			target := assistantTargetChars(msg.TextContent, pass.High, pass.Med, pass.Low)
+			trimmed, changed := truncateTextToChars(msg.TextContent, target)
+			if !changed {
+				continue
+			}
+			msg.TextContent = trimmed
+			result.TruncatedMessages++
+			result.AssistantMessagesCut++
+			if estimateExtractionPromptTokens(candidate, startOffset, nextOffset, result.Messages, taxonomyMap) <= memoryMinePromptMaxTokens {
+				return result, true
+			}
+		}
+	}
+
+	for i := range result.Messages {
+		msg := &result.Messages[i]
+		if msg.Role != llm.RoleUser {
+			continue
+		}
+		if strings.TrimSpace(msg.TextContent) == "" {
+			continue
+		}
+		trimmed, changed := truncateTextToChars(msg.TextContent, 4000)
+		if !changed {
+			continue
+		}
+		msg.TextContent = trimmed
+		result.TruncatedMessages++
+		result.UserMessagesCut++
+		result.SingleMessageClipped = true
+		if estimateExtractionPromptTokens(candidate, startOffset, nextOffset, result.Messages, taxonomyMap) <= memoryMinePromptMaxTokens {
+			return result, true
+		}
+	}
+
+	if len(result.Messages) == 1 {
+		clipped, ok := truncateMessageForPromptBudget(candidate, startOffset, nextOffset, taxonomyMap, result.Messages[0])
+		if ok {
+			result.Messages[0] = clipped
+			result.TruncatedMessages++
+			if result.Messages[0].Role == llm.RoleAssistant {
+				result.AssistantMessagesCut++
+			} else if result.Messages[0].Role == llm.RoleUser {
+				result.UserMessagesCut++
+			}
+			result.SingleMessageClipped = true
+			return result, true
+		}
+	}
+
+	return result, false
+}
+
+func cloneMessages(messages []session.Message) []session.Message {
+	out := make([]session.Message, len(messages))
+	copy(out, messages)
+	return out
+}
+
+func cloneMessageWithText(msg session.Message, text string, truncated bool) session.Message {
+	clone := msg
+	clone.TextContent = strings.TrimSpace(text)
+	if truncated {
+		clone.TextContent = strings.TrimSpace(clone.TextContent) + memoryMineTruncateMarker
+	}
+	return clone
+}
+
+func truncateTextToChars(text string, limit int) (string, bool) {
+	text = strings.TrimSpace(text)
+	if limit < 0 {
+		limit = 0
+	}
+	if utf8.RuneCountInString(text) <= limit {
+		return text, false
+	}
+	runes := []rune(text)
+	base := string(runes[:limit])
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return memoryMineTruncateMarker, true
+	}
+	return base + memoryMineTruncateMarker, true
+}
+
+func assistantTargetChars(text string, high, med, low int) int {
+	score := assistantMessagePriority(text)
+	switch score {
+	case 2:
+		return high
+	case 1:
+		return med
+	default:
+		return low
+	}
+}
+
+func assistantMessagePriority(text string) int {
+	text = strings.TrimSpace(strings.ToLower(text))
+	if text == "" {
+		return 0
+	}
+	score := 0
+	for _, needle := range []string{"changed", "updated", "configured", "deployed", "restart", "merged", "commit", "pr ", "issue", "path", "url", "http", "https", "provider", "model", "token", "budget", "cache", "fragment", "memory", "version", "tool", "agent", "prompt"} {
+		if strings.Contains(text, needle) {
+			score += 2
+		}
+	}
+	for _, needle := range []string{"- ", "* ", "1. ", "2. ", "##", "```", "/", ".md", ".go", ".rb", "postgres", "redis", "docker", "system", "config"} {
+		if strings.Contains(text, needle) {
+			score++
+		}
+	}
+	if strings.Count(text, "\n") >= 3 {
+		score += 2
+	}
+	if utf8.RuneCountInString(text) >= 1000 {
+		score++
+	}
+	if score >= 5 {
+		return 2
+	}
+	if score >= 2 {
+		return 1
+	}
+	return 0
 }
 
 func registerMemoryExtractionTools(engine *llm.Engine, store *memorydb.Store, agent string) ([]llm.ToolSpec, func()) {

--- a/cmd/memory_mine_stats.go
+++ b/cmd/memory_mine_stats.go
@@ -23,36 +23,42 @@ type memoryMineLoadResult struct {
 	Messages             []session.Message
 	NextOffset           int
 	TruncatedMessages    int
+	AssistantMessagesCut int
+	UserMessagesCut      int
 	PromptBudgetHit      bool
 	SingleMessageClipped bool
 }
 
 type memoryExtractionStats struct {
-	SessionID             string
-	SessionNumber         int64
-	Agent                 string
-	StartOffset           int
-	EndOffset             int
-	ExistingFragments     int
-	TranscriptMessages    int
-	PromptMaxTokens       int
-	PromptEstimatedTokens int
-	SystemTokens          int
-	MetadataTokens        int
-	TaxonomyTokens        int
-	TranscriptTokens      int
-	InstructionsTokens    int
-	ToolTurns             int
-	ToolCalls             int
-	ToolNames             []string
-	InputTokens           int
-	CachedInputTokens     int
-	CacheWriteTokens      int
-	OutputTokens          int
-	TruncatedMessages     int
-	PromptBudgetHit       bool
-	SingleMessageClipped  bool
-	Duration              time.Duration
+	SessionID                 string
+	SessionNumber             int64
+	Agent                     string
+	StartOffset               int
+	EndOffset                 int
+	ExistingFragments         int
+	TranscriptMessages        int
+	PromptMaxTokens           int
+	PromptEstimatedTokens     int
+	SystemTokens              int
+	MetadataTokens            int
+	TaxonomyTokens            int
+	TranscriptTokens          int
+	TranscriptUserTokens      int
+	TranscriptAssistantTokens int
+	InstructionsTokens        int
+	ToolTurns                 int
+	ToolCalls                 int
+	ToolNames                 []string
+	InputTokens               int
+	CachedInputTokens         int
+	CacheWriteTokens          int
+	OutputTokens              int
+	TruncatedMessages         int
+	AssistantMessagesCut      int
+	UserMessagesCut           int
+	PromptBudgetHit           bool
+	SingleMessageClipped      bool
+	Duration                  time.Duration
 }
 
 type memoryMineSummaryStats struct {
@@ -118,25 +124,47 @@ Transcript (role + text + tool call names only):
 }
 
 func newMemoryExtractionStats(candidate memoryMineCandidate, startOffset, endOffset int, existingFragments int, load memoryMineLoadResult, parts memoryPromptParts) memoryExtractionStats {
+	userTokens, assistantTokens := transcriptRoleTokenBreakdown(load.Messages)
 	return memoryExtractionStats{
-		SessionID:             candidate.Session.ID,
-		SessionNumber:         candidate.Summary.Number,
-		Agent:                 candidate.Agent,
-		StartOffset:           startOffset,
-		EndOffset:             endOffset,
-		ExistingFragments:     existingFragments,
-		TranscriptMessages:    len(load.Messages),
-		PromptMaxTokens:       memoryMinePromptMaxTokens,
-		PromptEstimatedTokens: llm.EstimateTokens(memoryExtractionSystemPrompt) + llm.EstimateTokens(parts.Prompt),
-		SystemTokens:          llm.EstimateTokens(memoryExtractionSystemPrompt),
-		MetadataTokens:        llm.EstimateTokens(parts.Metadata),
-		TaxonomyTokens:        llm.EstimateTokens(parts.TaxonomyMap),
-		TranscriptTokens:      llm.EstimateTokens(parts.Transcript),
-		InstructionsTokens:    llm.EstimateTokens(parts.Instructions),
-		TruncatedMessages:     load.TruncatedMessages,
-		PromptBudgetHit:       load.PromptBudgetHit,
-		SingleMessageClipped:  load.SingleMessageClipped,
+		SessionID:                 candidate.Session.ID,
+		SessionNumber:             candidate.Summary.Number,
+		Agent:                     candidate.Agent,
+		StartOffset:               startOffset,
+		EndOffset:                 endOffset,
+		ExistingFragments:         existingFragments,
+		TranscriptMessages:        len(load.Messages),
+		PromptMaxTokens:           memoryMinePromptMaxTokens,
+		PromptEstimatedTokens:     llm.EstimateTokens(memoryExtractionSystemPrompt) + llm.EstimateTokens(parts.Prompt),
+		SystemTokens:              llm.EstimateTokens(memoryExtractionSystemPrompt),
+		MetadataTokens:            llm.EstimateTokens(parts.Metadata),
+		TaxonomyTokens:            llm.EstimateTokens(parts.TaxonomyMap),
+		TranscriptTokens:          llm.EstimateTokens(parts.Transcript),
+		TranscriptUserTokens:      userTokens,
+		TranscriptAssistantTokens: assistantTokens,
+		InstructionsTokens:        llm.EstimateTokens(parts.Instructions),
+		TruncatedMessages:         load.TruncatedMessages,
+		AssistantMessagesCut:      load.AssistantMessagesCut,
+		UserMessagesCut:           load.UserMessagesCut,
+		PromptBudgetHit:           load.PromptBudgetHit,
+		SingleMessageClipped:      load.SingleMessageClipped,
 	}
+}
+
+func transcriptRoleTokenBreakdown(messages []session.Message) (userTokens, assistantTokens int) {
+	for _, msg := range messages {
+		text := strings.TrimSpace(msg.TextContent)
+		if text == "" {
+			continue
+		}
+		tokens := llm.EstimateTokens(text)
+		switch msg.Role {
+		case llm.RoleUser:
+			userTokens += tokens
+		case llm.RoleAssistant:
+			assistantTokens += tokens
+		}
+	}
+	return userTokens, assistantTokens
 }
 
 func (s *memoryExtractionStats) noteToolCall(name string) {
@@ -155,7 +183,7 @@ func (s memoryExtractionStats) oneLine() string {
 	if len(s.ToolNames) > 0 {
 		tools = strings.Join(s.ToolNames, ",")
 	}
-	return fmt.Sprintf("stats: wall=%s prompt≈%dt/%dt system=%dt meta=%dt taxonomy=%dt transcript=%dt instr=%dt existing=%d msgs=%d turns=%d tool_calls=%d tools=%s usage[in=%d cached=%d out=%d write=%d] truncated_msgs=%d budget_hit=%t single_clip=%t",
+	return fmt.Sprintf("stats: wall=%s prompt≈%dt/%dt system=%dt meta=%dt taxonomy=%dt transcript=%dt(user=%dt assistant=%dt) instr=%dt existing=%d msgs=%d turns=%d tool_calls=%d tools=%s usage[in=%d cached=%d out=%d write=%d] truncated_msgs=%d assistant_cut=%d user_cut=%d budget_hit=%t single_clip=%t",
 		s.Duration.Round(time.Millisecond),
 		s.PromptEstimatedTokens,
 		s.PromptMaxTokens,
@@ -163,6 +191,8 @@ func (s memoryExtractionStats) oneLine() string {
 		s.MetadataTokens,
 		s.TaxonomyTokens,
 		s.TranscriptTokens,
+		s.TranscriptUserTokens,
+		s.TranscriptAssistantTokens,
 		s.InstructionsTokens,
 		s.ExistingFragments,
 		s.TranscriptMessages,
@@ -174,6 +204,8 @@ func (s memoryExtractionStats) oneLine() string {
 		s.OutputTokens,
 		s.CacheWriteTokens,
 		s.TruncatedMessages,
+		s.AssistantMessagesCut,
+		s.UserMessagesCut,
 		s.PromptBudgetHit,
 		s.SingleMessageClipped,
 	)

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
@@ -191,5 +192,42 @@ func TestLoadMessagesForMining_RespectsPromptBudget(t *testing.T) {
 	}
 	if got := estimateExtractionPromptTokens(candidate, 0, loadResult.NextOffset, loadResult.Messages, "Memory fragment map:\n- total_fragments: 0"); got > memoryMinePromptMaxTokens {
 		t.Fatalf("estimated prompt tokens = %d, want <= %d", got, memoryMinePromptMaxTokens)
+	}
+}
+
+func TestFitMessagesForPromptBudget_PrefersUserAndDurableAssistantText(t *testing.T) {
+	oldPromptMax := memoryMinePromptMaxTokens
+	memoryMinePromptMaxTokens = 1000
+	t.Cleanup(func() { memoryMinePromptMaxTokens = oldPromptMax })
+
+	candidate := memoryMineCandidate{
+		Summary: session.SessionSummary{Number: 1},
+		Session: &session.Session{ID: "sess-1"},
+		Agent:   "jarvis",
+	}
+	messages := []session.Message{
+		{Role: llm.RoleUser, TextContent: strings.Repeat("user durable preference ", 18)},
+		{Role: llm.RoleAssistant, TextContent: strings.Repeat("ok sure maybe maybe ", 45)},
+		{Role: llm.RoleAssistant, TextContent: strings.Repeat("Changed config path /etc/service and updated model budget summary. ", 18)},
+	}
+
+	fit, ok := fitMessagesForPromptBudget(candidate, 0, len(messages), messages, "Memory fragment map:\n- total_fragments: 0")
+	if !ok {
+		t.Fatal("expected fitMessagesForPromptBudget to succeed")
+	}
+	if got := estimateExtractionPromptTokens(candidate, 0, len(messages), fit.Messages, "Memory fragment map:\n- total_fragments: 0"); got > memoryMinePromptMaxTokens {
+		t.Fatalf("estimated prompt tokens = %d, want <= %d", got, memoryMinePromptMaxTokens)
+	}
+	if fit.Messages[0].TextContent != messages[0].TextContent {
+		t.Fatalf("user message should be preserved, got %q", fit.Messages[0].TextContent)
+	}
+	if utf8.RuneCountInString(fit.Messages[2].TextContent) <= utf8.RuneCountInString(fit.Messages[1].TextContent) {
+		t.Fatalf("durable assistant text should retain more budget than filler: durable=%d filler=%d", utf8.RuneCountInString(fit.Messages[2].TextContent), utf8.RuneCountInString(fit.Messages[1].TextContent))
+	}
+	if fit.AssistantMessagesCut == 0 {
+		t.Fatal("expected assistant truncation to occur")
+	}
+	if fit.UserMessagesCut != 0 {
+		t.Fatalf("expected no user truncation, got %d", fit.UserMessagesCut)
 	}
 }


### PR DESCRIPTION
## What

Improves memory-mine transcript budgeting so it preserves user text and higher-value assistant conclusions instead of treating all assistant text equally when the prompt gets tight.

This PR changes transcript fitting to:

- preserve the full contiguous transcript prefix when it already fits
- when it does not fit, compress assistant text first rather than immediately cutting off the batch
- rank assistant text by rough memory value and keep more budget for durable/operational assistant content than for filler
- only truncate user text as a last resort after assistant compression is exhausted
- keep the mining state contiguous (we still mine a prefix, not a semantic skip-list)

It also extends `memory mine --stats` to report:

- transcript role breakdown (`user` vs `assistant` token estimates)
- assistant vs user truncation counts

## Why

The previous prompt-budget PR fixed the explosion problem, but the transcript fitter was still too blunt.

A 12k prompt budget is not the issue by itself. The issue is allocating that budget intelligently:

- a long user message can absolutely be the thing worth mining
- assistant text also matters when it contains decisions, config summaries, corrections, or durable conclusions
- low-value assistant filler should lose budget before user evidence or durable assistant outcomes do

So this PR tries to make quality go up, not down, under the same budget.

## Validation

- `go test ./...`
- `go run . memory mine --limit 3 --dry-run --embed=false --promote never --stats`

Example stats from the smoke run:

```text
[2/3] #1072 stats: wall=30.618s prompt≈1796t/12000t system=104t meta=39t taxonomy=987t transcript=401t(user=0t assistant=385t) instr=239t existing=603 msgs=1 turns=2 tool_calls=2 tools=memory_get_fragment usage[in=3189 cached=0 out=1370 write=0] truncated_msgs=0 assistant_cut=0 user_cut=0 budget_hit=false single_clip=false
```

That run also confirms we're still on the normal memory-mine model path (Claude CLI / sonnet), not a separate fast path.
