### PR TITLE
feat: make memory extraction tool-driven

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -39,6 +39,7 @@ var (
 	memoryMineToolMaxTurns      int
 	memoryMineMaxOutputTokens   int
 	memoryMineShowStats         bool
+	memoryMineUseFastModel      bool
 )
 
 var memoryMineCmd = &cobra.Command{
@@ -49,28 +50,18 @@ var memoryMineCmd = &cobra.Command{
 
 const memoryExtractionSystemPrompt = `You are a strict memory extraction engine.
 
-Output must be valid JSON only (no markdown fences, no prose).
-Return exactly one object with key "operations".
-
 Goal: extract durable long-term memory from the provided transcript.
 Focus on stable facts, decisions, preferences, and technical details worth remembering.
-Ignore ephemeral details such as transient errors, one-off debugging steps, and conversational filler.`
+Ignore ephemeral details such as transient errors, one-off debugging steps, and conversational filler.
+
+Use the provided memory tools to inspect existing fragments and to create or update memory directly.
+Prefer updating existing fragments over creating duplicates.
+When finished, reply briefly with plain text like "done".`
 
 type memoryMineCandidate struct {
 	Summary session.SessionSummary
 	Session *session.Session
 	Agent   string
-}
-
-type extractionResponse struct {
-	Operations []extractionOperation `json:"operations"`
-}
-
-type extractionOperation struct {
-	Op      string `json:"op"`
-	Path    string `json:"path,omitempty"`
-	Content string `json:"content,omitempty"`
-	Reason  string `json:"reason,omitempty"`
 }
 
 type transcriptMessage struct {
@@ -98,6 +89,7 @@ func init() {
 	memoryMineCmd.Flags().IntVar(&memoryMineToolMaxTurns, "tool-max-turns", defaultMemoryMineToolMaxTurns, "Maximum tool-assisted turns allowed for one extraction request")
 	memoryMineCmd.Flags().IntVar(&memoryMineMaxOutputTokens, "max-output-tokens", defaultMemoryMineMaxOutputTokens, "Maximum output tokens for one extraction request")
 	memoryMineCmd.Flags().BoolVar(&memoryMineShowStats, "stats", false, "Print prompt, tool, token, and timing stats for each mined batch")
+	memoryMineCmd.Flags().BoolVar(&memoryMineUseFastModel, "fast-model", false, "Use the configured fast provider/model for memory extraction")
 	memoryMineCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)
 }
 
@@ -149,7 +141,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		cfg.ApplyOverrides("", strings.TrimSpace(memoryMineModel))
 	}
 
-	provider, err := llm.NewProvider(cfg)
+	provider, modelName, err := newMemoryMineProvider(cfg)
 	if err != nil {
 		return err
 	}
@@ -191,7 +183,10 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		fmt.Println("No sessions eligible for memory mining.")
 	}
 
-	modelName := activeModel(cfg)
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		modelName = activeModel(cfg)
+	}
 	if modelName == "" {
 		modelName = "(default model)"
 	}
@@ -240,28 +235,14 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		promptParts := buildExtractionPromptParts(candidate, startOffset, loadResult.NextOffset, loadResult.Messages, taxonomyMap)
 		batchStats := newMemoryExtractionStats(candidate, startOffset, loadResult.NextOffset, len(existing), loadResult, promptParts)
 		batchStart := time.Now()
-		raw, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, promptParts.Prompt, &batchStats)
+		extractionResult, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, promptParts.Prompt, &batchStats)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping session %s batch at offset %d: %v\n", candidate.Session.ID, startOffset, err)
 			continue
 		}
-
-		ops, err := parseExtractionOperations(raw)
 		batchStats.Duration = time.Since(batchStart)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: bad extraction output for session %s at offset %d: %v\nraw: %s\n", candidate.Session.ID, startOffset, err, raw)
-			if memoryMineShowStats {
-				fmt.Printf("[%d/%d] #%d %s\n", i+1, len(candidates), candidate.Summary.Number, batchStats.oneLine())
-				summaryStats.add(batchStats)
-			}
-			continue
-		}
 
-		created, updated, skipped, affectedPaths, err := applyExtractionOperations(ctx, memStore, candidate.Agent, ops)
-		if err != nil {
-			return fmt.Errorf("apply operations for session %s: %w", candidate.Session.ID, err)
-		}
-		batchStats.Duration = time.Since(batchStart)
+		created, updated, skipped, affectedPaths := extractionResult.Created, extractionResult.Updated, extractionResult.Skipped, extractionResult.AffectedPaths
 
 		if !memoryDryRun {
 			for _, p := range affectedPaths {
@@ -377,6 +358,47 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func newMemoryMineProvider(cfg *config.Config) (llm.Provider, string, error) {
+	if memoryMineUseFastModel && strings.TrimSpace(memoryMineModel) != "" {
+		return nil, "", fmt.Errorf("--fast-model and --model are mutually exclusive")
+	}
+	if memoryMineUseFastModel {
+		provider, err := llm.NewFastProvider(cfg, cfg.DefaultProvider)
+		if err != nil {
+			return nil, "", fmt.Errorf("fast provider: %w", err)
+		}
+		if provider == nil {
+			return nil, "", fmt.Errorf("no fast model configured for %q", cfg.DefaultProvider)
+		}
+		return provider, resolveMemoryMineFastModelName(cfg), nil
+	}
+	provider, err := llm.NewProvider(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	return provider, strings.TrimSpace(memoryMineModel), nil
+}
+
+func resolveMemoryMineFastModelName(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	providerKey := strings.TrimSpace(cfg.DefaultProvider)
+	targetKey := providerKey
+	model := ""
+	if pc, ok := cfg.Providers[providerKey]; ok {
+		if strings.TrimSpace(pc.FastProvider) != "" {
+			targetKey = strings.TrimSpace(pc.FastProvider)
+		}
+		model = strings.TrimSpace(pc.FastModel)
+	}
+	if model != "" {
+		return model
+	}
+	providerType := string(config.InferProviderType(targetKey, ""))
+	return llm.ProviderFastModels[providerType]
 }
 
 func minePromoteAgents(globalAgent string, candidates []memoryMineCandidate) []string {
@@ -561,10 +583,15 @@ func collectToolCallNames(msg session.Message) []string {
 	return out
 }
 
-func runExtractionRequest(ctx context.Context, engine *llm.Engine, store *memorydb.Store, agent, prompt string, stats *memoryExtractionStats) (string, error) {
-	toolSpecs, cleanup := registerMemoryExtractionTools(engine, store, agent)
+func runExtractionRequest(ctx context.Context, engine *llm.Engine, store *memorydb.Store, agent, prompt string, stats *memoryExtractionStats) (memoryExtractionResult, error) {
+	collector := newMemoryExtractionCollector()
+	toolSpecs, cleanup := registerMemoryExtractionTools(engine, store, agent, collector)
 	defer cleanup()
-	return runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt, stats, toolSpecs...)
+	finalText, err := runExtractionRequestWithSystem(ctx, engine, memoryExtractionSystemPrompt, prompt, stats, toolSpecs...)
+	if err != nil {
+		return memoryExtractionResult{}, err
+	}
+	return collector.result(finalText), nil
 }
 
 func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string, stats *memoryExtractionStats, tools ...llm.ToolSpec) (string, error) {
@@ -640,56 +667,6 @@ func stripMarkdownFences(s string) string {
 	return strings.TrimSpace(s)
 }
 
-func parseExtractionOperations(raw string) ([]extractionOperation, error) {
-	raw = stripMarkdownFences(raw)
-	dec := json.NewDecoder(strings.NewReader(raw))
-
-	var response extractionResponse
-	if err := dec.Decode(&response); err != nil {
-		return nil, fmt.Errorf("decode json: %w", err)
-	}
-	var trailing any
-	if err := dec.Decode(&trailing); err != io.EOF {
-		return nil, fmt.Errorf("unexpected trailing content after JSON object")
-	}
-
-	if len(response.Operations) > 20 {
-		return nil, fmt.Errorf("too many operations: got %d, max 20", len(response.Operations))
-	}
-
-	normalized := make([]extractionOperation, 0, len(response.Operations))
-	for i, op := range response.Operations {
-		op.Op = strings.ToLower(strings.TrimSpace(op.Op))
-		switch op.Op {
-		case "create", "update":
-			p, err := validateFragmentPath(op.Path)
-			if err != nil {
-				return nil, fmt.Errorf("op[%d] path invalid: %w", i, err)
-			}
-			content := strings.TrimSpace(op.Content)
-			if content == "" {
-				return nil, fmt.Errorf("op[%d] content cannot be empty", i)
-			}
-			if len([]byte(content)) > 8192 {
-				return nil, fmt.Errorf("op[%d] content exceeds 8192 bytes", i)
-			}
-			op.Path = p
-			op.Content = content
-		case "skip":
-			op.Path = ""
-			op.Content = ""
-			if strings.TrimSpace(op.Reason) == "" {
-				op.Reason = "no durable memory extracted"
-			}
-		default:
-			return nil, fmt.Errorf("op[%d] has invalid op %q", i, op.Op)
-		}
-		normalized = append(normalized, op)
-	}
-
-	return normalized, nil
-}
-
 func validateFragmentPath(p string) (string, error) {
 	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
 	if p == "" {
@@ -719,68 +696,6 @@ func isWindowsAbsPath(p string) bool {
 		return p[1] == ':'
 	}
 	return false
-}
-
-func applyExtractionOperations(ctx context.Context, store *memorydb.Store, agent string, ops []extractionOperation) (created, updated, skipped int, affectedPaths []string, err error) {
-	seenPaths := map[string]struct{}{}
-	addAffectedPath := func(p string) {
-		if _, exists := seenPaths[p]; exists {
-			return
-		}
-		seenPaths[p] = struct{}{}
-		affectedPaths = append(affectedPaths, p)
-	}
-
-	for _, op := range ops {
-		switch op.Op {
-		case "create":
-			created++
-			if memoryDryRun {
-				continue
-			}
-			createErr := store.CreateFragment(ctx, &memorydb.Fragment{
-				Agent:   agent,
-				Path:    op.Path,
-				Content: op.Content,
-				Source:  memorydb.DefaultSourceMine,
-			})
-			if createErr != nil {
-				if isUniqueConstraintError(createErr) {
-					ok, upErr := store.UpdateFragment(ctx, agent, op.Path, op.Content)
-					if upErr != nil {
-						return created, updated, skipped, affectedPaths, upErr
-					}
-					if ok {
-						created--
-						updated++
-						addAffectedPath(op.Path)
-						continue
-					}
-				}
-				return created, updated, skipped, affectedPaths, createErr
-			}
-			addAffectedPath(op.Path)
-		case "update":
-			updated++
-			if memoryDryRun {
-				continue
-			}
-			ok, updateErr := store.UpdateFragment(ctx, agent, op.Path, op.Content)
-			if updateErr != nil {
-				return created, updated, skipped, affectedPaths, updateErr
-			}
-			if !ok {
-				// Keep this as a skipped op if target fragment does not exist.
-				updated--
-				skipped++
-				continue
-			}
-			addAffectedPath(op.Path)
-		case "skip":
-			skipped++
-		}
-	}
-	return created, updated, skipped, affectedPaths, nil
 }
 
 func mineGeneratedImages(ctx context.Context, store *memorydb.Store) int {

--- a/cmd/memory_mine_budget.go
+++ b/cmd/memory_mine_budget.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultMemoryMinePromptMaxTokens   = 12000
 	defaultMemoryMineTaxonomyMaxTokens = 1000
-	defaultMemoryMineToolMaxTurns      = 6
+	defaultMemoryMineToolMaxTurns      = 10
 	defaultMemoryMineMaxOutputTokens   = 2048
 	memoryMineFragmentSearchLimit      = 8
 	memoryMineFragmentListLimit        = 20

--- a/cmd/memory_mine_budget.go
+++ b/cmd/memory_mine_budget.go
@@ -317,25 +317,6 @@ func assistantMessagePriority(text string) int {
 	return 0
 }
 
-func registerMemoryExtractionTools(engine *llm.Engine, store *memorydb.Store, agent string) ([]llm.ToolSpec, func()) {
-	tools := []llm.Tool{
-		&memorySearchFragmentsTool{store: store, agent: agent},
-		&memoryListFragmentsTool{store: store, agent: agent},
-		&memoryGetFragmentTool{store: store, agent: agent},
-	}
-	specs := make([]llm.ToolSpec, 0, len(tools))
-	for _, tool := range tools {
-		engine.RegisterTool(tool)
-		specs = append(specs, tool.Spec())
-	}
-	cleanup := func() {
-		for _, tool := range tools {
-			engine.UnregisterTool(tool.Spec().Name)
-		}
-	}
-	return specs, cleanup
-}
-
 type memorySearchFragmentsTool struct {
 	store *memorydb.Store
 	agent string

--- a/cmd/memory_mine_stats.go
+++ b/cmd/memory_mine_stats.go
@@ -92,19 +92,13 @@ func buildExtractionPromptParts(candidate memoryMineCandidate, startOffset, endO
 - Skip ephemeral content like specific transient errors, one-off debugging output, and conversational filler.
 - The fragment map is intentionally compact and may omit exact duplicates or existing content details.
 - Use lookup tools when you need to confirm whether related memory already exists, inspect exact fragment content, or browse likely paths.
-- Prefer update when an existing fragment already captures the fact; use create for genuinely new memory.
-- Return at most 20 operations.
+- Use memory_create_fragment for genuinely new memory.
+- Use memory_update_fragment when an existing fragment should be revised.
+- Avoid duplicate fragments.
 - Fragment content must stay <= 8192 bytes.
-- Path must be relative and must not contain ../ or be absolute.
-
-Return strict JSON only, exactly in this format:
-{
-  "operations": [
-    {"op": "create", "path": "...", "content": "..."},
-    {"op": "update", "path": "...", "content": "...", "reason": "..."},
-    {"op": "skip", "reason": "..."}
-  ]
-}`
+- Paths must be relative and must not contain ../ or be absolute.
+- You may apply multiple create/update tool calls in one extraction batch.
+- When finished, reply with plain text such as "done". Do not return JSON.`
 	prompt := fmt.Sprintf(`%s
 
 Existing fragment map (compact, partial by design):

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,40 +14,34 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
-func TestParseExtractionOperations_PlainJSON(t *testing.T) {
-	raw := `{"operations": [{"op": "skip", "reason": "nothing to extract"}]}`
-	ops, err := parseExtractionOperations(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(ops) != 1 || ops[0].Op != "skip" {
-		t.Fatalf("unexpected ops: %+v", ops)
-	}
-}
-
-func TestParseExtractionOperations_MarkdownFence(t *testing.T) {
-	raw := "```json\n{\"operations\": [{\"op\": \"skip\", \"reason\": \"nothing to extract\"}]}\n```"
-	ops, err := parseExtractionOperations(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(ops) != 1 || ops[0].Op != "skip" {
-		t.Fatalf("unexpected ops: %+v", ops)
-	}
-}
-
-func TestParseExtractionOperations_MarkdownFenceNoLang(t *testing.T) {
-	raw := "```\n{\"operations\": [{\"op\": \"skip\", \"reason\": \"nothing\"}]}\n```"
-	ops, err := parseExtractionOperations(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(ops) != 1 {
-		t.Fatalf("unexpected ops: %+v", ops)
+func TestValidateFragmentPath(t *testing.T) {
+	for _, tc := range []struct {
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{"fragments/foo.md", "fragments/foo.md", false},
+		{"fragments\\foo.md", "fragments/foo.md", false},
+		{"../evil.md", "", true},
+		{"/abs/path.md", "", true},
+	} {
+		got, err := validateFragmentPath(tc.path)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("validateFragmentPath(%q) expected error", tc.path)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("validateFragmentPath(%q) error = %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Fatalf("validateFragmentPath(%q) = %q, want %q", tc.path, got, tc.want)
+		}
 	}
 }
 
-func TestApplyExtractionOperations_AffectedPaths(t *testing.T) {
+func TestMemoryExtractionCollectorAndTools(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "memory.db")
 	store, err := memorydb.NewStore(memorydb.Config{Path: dbPath})
@@ -55,68 +50,27 @@ func TestApplyExtractionOperations_AffectedPaths(t *testing.T) {
 	}
 	defer store.Close()
 
-	agent := "jarvis"
-	if err := store.CreateFragment(ctx, &memorydb.Fragment{
-		Agent:   agent,
-		Path:    "fragments/existing.md",
-		Content: "old",
-		Source:  memorydb.DefaultSourceMine,
-	}); err != nil {
-		t.Fatalf("CreateFragment(existing) error = %v", err)
-	}
-
-	ops := []extractionOperation{
-		{Op: "create", Path: "fragments/new.md", Content: "new"},
-		{Op: "update", Path: "fragments/existing.md", Content: "existing updated"},
-		{Op: "update", Path: "fragments/missing.md", Content: "missing"},
-		{Op: "skip", Reason: "no durable memory"},
-		{Op: "create", Path: "fragments/dup.md", Content: "dup initial"},
-		{Op: "update", Path: "fragments/dup.md", Content: "dup updated"},
-	}
+	collector := newMemoryExtractionCollector()
+	createTool := &memoryCreateFragmentTool{store: store, agent: "jarvis", collector: collector}
+	updateTool := &memoryUpdateFragmentTool{store: store, agent: "jarvis", collector: collector}
 
 	oldDryRun := memoryDryRun
 	memoryDryRun = false
 	t.Cleanup(func() { memoryDryRun = oldDryRun })
 
-	created, updated, skipped, affectedPaths, err := applyExtractionOperations(ctx, store, agent, ops)
-	if err != nil {
-		t.Fatalf("applyExtractionOperations() error = %v", err)
+	if _, err := createTool.Execute(ctx, json.RawMessage(`{"path":"fragments/new.md","content":"new content"}`)); err != nil {
+		t.Fatalf("create tool error = %v", err)
 	}
-	if created != 2 || updated != 2 || skipped != 2 {
-		t.Fatalf("counts = create=%d update=%d skip=%d, want 2/2/2", created, updated, skipped)
-	}
-
-	want := map[string]bool{
-		"fragments/new.md":      true,
-		"fragments/existing.md": true,
-		"fragments/dup.md":      true,
-	}
-	if len(affectedPaths) != len(want) {
-		t.Fatalf("affectedPaths len = %d, want %d (%v)", len(affectedPaths), len(want), affectedPaths)
-	}
-	seen := map[string]int{}
-	for _, p := range affectedPaths {
-		seen[p]++
-		if !want[p] {
-			t.Fatalf("affectedPaths contains unexpected path %q (%v)", p, affectedPaths)
-		}
-	}
-	for p := range want {
-		if seen[p] != 1 {
-			t.Fatalf("affected path %q count = %d, want 1 (%v)", p, seen[p], affectedPaths)
-		}
+	if _, err := updateTool.Execute(ctx, json.RawMessage(`{"path":"fragments/new.md","content":"updated content"}`)); err != nil {
+		t.Fatalf("update tool error = %v", err)
 	}
 
-	memoryDryRun = true
-	_, _, _, dryRunPaths, err := applyExtractionOperations(ctx, store, agent, []extractionOperation{
-		{Op: "create", Path: "fragments/dry-run-create.md", Content: "x"},
-		{Op: "update", Path: "fragments/existing.md", Content: "y"},
-	})
-	if err != nil {
-		t.Fatalf("applyExtractionOperations(dry-run) error = %v", err)
+	res := collector.result("done")
+	if res.Created != 1 || res.Updated != 1 || res.Skipped != 0 {
+		t.Fatalf("result counts = %+v, want create=1 update=1 skip=0", res)
 	}
-	if len(dryRunPaths) != 0 {
-		t.Fatalf("affectedPaths in dry-run = %v, want empty", dryRunPaths)
+	if len(res.AffectedPaths) != 1 || res.AffectedPaths[0] != "fragments/new.md" {
+		t.Fatalf("affected paths = %+v", res.AffectedPaths)
 	}
 }
 

--- a/cmd/memory_mine_tools_runtime.go
+++ b/cmd/memory_mine_tools_runtime.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+)
+
+type memoryExtractionResult struct {
+	Created       int
+	Updated       int
+	Skipped       int
+	AffectedPaths []string
+	FinalText     string
+}
+
+type memoryExtractionCollector struct {
+	mu       sync.Mutex
+	created  int
+	updated  int
+	skipped  int
+	affected []string
+	seen     map[string]struct{}
+}
+
+func newMemoryExtractionCollector() *memoryExtractionCollector {
+	return &memoryExtractionCollector{seen: map[string]struct{}{}}
+}
+
+func (c *memoryExtractionCollector) noteCreated(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.created++
+	c.addPath(path)
+}
+
+func (c *memoryExtractionCollector) noteUpdated(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.updated++
+	c.addPath(path)
+}
+
+func (c *memoryExtractionCollector) noteSkipped() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.skipped++
+}
+
+func (c *memoryExtractionCollector) addPath(path string) {
+	if _, ok := c.seen[path]; ok {
+		return
+	}
+	c.seen[path] = struct{}{}
+	c.affected = append(c.affected, path)
+}
+
+func (c *memoryExtractionCollector) result(finalText string) memoryExtractionResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	affected := make([]string, len(c.affected))
+	copy(affected, c.affected)
+	sort.Strings(affected)
+	res := memoryExtractionResult{
+		Created:       c.created,
+		Updated:       c.updated,
+		Skipped:       c.skipped,
+		AffectedPaths: affected,
+		FinalText:     strings.TrimSpace(finalText),
+	}
+	if res.Created == 0 && res.Updated == 0 && res.Skipped == 0 {
+		res.Skipped = 1
+	}
+	return res
+}
+
+type memoryCreateFragmentTool struct {
+	store     *memorydb.Store
+	agent     string
+	collector *memoryExtractionCollector
+}
+
+func (t *memoryCreateFragmentTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        "memory_create_fragment",
+		Description: "Create a new durable memory fragment. Use this only when memory does not already exist under a suitable path.",
+		Schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path":    map[string]interface{}{"type": "string", "description": "Relative fragment path"},
+				"content": map[string]interface{}{"type": "string", "description": "Full fragment markdown/text content"},
+				"reason":  map[string]interface{}{"type": "string", "description": "Why this new fragment is warranted"},
+			},
+			"required":             []string{"path", "content"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *memoryCreateFragmentTool) Preview(args json.RawMessage) string {
+	var payload struct {
+		Path string `json:"path"`
+	}
+	_ = json.Unmarshal(args, &payload)
+	return strings.TrimSpace(payload.Path)
+}
+
+func (t *memoryCreateFragmentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var payload struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return llm.ToolOutput{}, fmt.Errorf("parse memory_create_fragment args: %w", err)
+	}
+	fragPath, err := validateFragmentPath(payload.Path)
+	if err != nil {
+		return llm.ToolOutput{}, err
+	}
+	content := strings.TrimSpace(payload.Content)
+	if content == "" {
+		return llm.ToolOutput{}, fmt.Errorf("content cannot be empty")
+	}
+	if len([]byte(content)) > 8192 {
+		return llm.ToolOutput{}, fmt.Errorf("content exceeds 8192 bytes")
+	}
+	if !memoryDryRun {
+		if err := t.store.CreateFragment(ctx, &memorydb.Fragment{Agent: t.agent, Path: fragPath, Content: content, Source: memorydb.DefaultSourceMine}); err != nil {
+			return llm.ToolOutput{}, err
+		}
+	}
+	t.collector.noteCreated(fragPath)
+	return llm.TextOutput(fmt.Sprintf("created %s", fragPath)), nil
+}
+
+type memoryUpdateFragmentTool struct {
+	store     *memorydb.Store
+	agent     string
+	collector *memoryExtractionCollector
+}
+
+func (t *memoryUpdateFragmentTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        "memory_update_fragment",
+		Description: "Update an existing durable memory fragment after inspecting it. Use this when the memory already exists and should be revised or expanded.",
+		Schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path":    map[string]interface{}{"type": "string", "description": "Relative fragment path"},
+				"content": map[string]interface{}{"type": "string", "description": "Replacement fragment content"},
+				"reason":  map[string]interface{}{"type": "string", "description": "Why this fragment should be updated"},
+			},
+			"required":             []string{"path", "content"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *memoryUpdateFragmentTool) Preview(args json.RawMessage) string {
+	var payload struct {
+		Path string `json:"path"`
+	}
+	_ = json.Unmarshal(args, &payload)
+	return strings.TrimSpace(payload.Path)
+}
+
+func (t *memoryUpdateFragmentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var payload struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return llm.ToolOutput{}, fmt.Errorf("parse memory_update_fragment args: %w", err)
+	}
+	fragPath, err := validateFragmentPath(payload.Path)
+	if err != nil {
+		return llm.ToolOutput{}, err
+	}
+	content := strings.TrimSpace(payload.Content)
+	if content == "" {
+		return llm.ToolOutput{}, fmt.Errorf("content cannot be empty")
+	}
+	if len([]byte(content)) > 8192 {
+		return llm.ToolOutput{}, fmt.Errorf("content exceeds 8192 bytes")
+	}
+	if !memoryDryRun {
+		ok, err := t.store.UpdateFragment(ctx, t.agent, fragPath, content)
+		if err != nil {
+			return llm.ToolOutput{}, err
+		}
+		if !ok {
+			return llm.ToolOutput{}, fmt.Errorf("fragment %s does not exist", fragPath)
+		}
+	}
+	t.collector.noteUpdated(fragPath)
+	return llm.TextOutput(fmt.Sprintf("updated %s", fragPath)), nil
+}
+
+func registerMemoryExtractionTools(engine *llm.Engine, store *memorydb.Store, agent string, collector *memoryExtractionCollector) ([]llm.ToolSpec, func()) {
+	tools := []llm.Tool{
+		&memorySearchFragmentsTool{store: store, agent: agent},
+		&memoryListFragmentsTool{store: store, agent: agent},
+		&memoryGetFragmentTool{store: store, agent: agent},
+		&memoryCreateFragmentTool{store: store, agent: agent, collector: collector},
+		&memoryUpdateFragmentTool{store: store, agent: agent, collector: collector},
+	}
+	specs := make([]llm.ToolSpec, 0, len(tools))
+	for _, tool := range tools {
+		engine.RegisterTool(tool)
+		specs = append(specs, tool.Spec())
+	}
+	cleanup := func() {
+		for _, tool := range tools {
+			engine.UnregisterTool(tool.Spec().Name)
+		}
+	}
+	return specs, cleanup
+}


### PR DESCRIPTION
## What

Reworks `memory mine` extraction to be tool-driven instead of JSON-operation driven.

This PR:

- removes the fragile "return strict JSON operations" extraction contract
- gives the extractor direct memory mutation tools:
  - `memory_create_fragment`
  - `memory_update_fragment`
- keeps the existing lookup tools:
  - `memory_search_fragments`
  - `memory_list_fragments`
  - `memory_get_fragment`
- changes the extraction prompt so the model reads existing fragments, applies create/update tools, then finishes with a plain-text `done`
- adds `--fast-model` to `memory mine` so extraction can explicitly use the configured fast provider/model
- keeps `--stats` working for the tool-driven path
- cleans up dead JSON-op extraction code/tests and replaces them with tool-runtime tests

## Why

The old extraction loop still had two problems:

1. it depended on the model emitting strict JSON, which is brittle and regularly failed with prose preambles
2. it forced the model to plan all fragment mutations up front instead of reading/updating memory interactively

The tool-driven version is a better fit for the architecture we now have:

- compact taxonomy in the prompt
- on-demand lookup via tools
- direct create/update mutations via tools
- no need to parse LLM JSON output just to turn around and write to the DB

## Fast vs default benchmark

I benchmarked the same dry-run extraction batch on the branch using `--stats`.

### Default model

```bash
go run . memory mine --limit 3 --dry-run --embed=false --promote never --stats
```

Output:

```text
[2/3] #1072 stats: wall=30.352s prompt≈1818t/12000t system=131t meta=39t taxonomy=998t transcript=401t(user=0t assistant=385t) instr=222t existing=610 msgs=1 turns=3 tool_calls=3 tools=memory_get_fragment,memory_update_fragment usage[in=12884 cached=0 out=1168 write=0] truncated_msgs=0 assistant_cut=0 user_cut=0 budget_hit=false single_clip=false
```

### Fast model

```bash
go run . memory mine --limit 3 --dry-run --embed=false --promote never --stats --fast-model
```

Output:

```text
[2/3] #1072 stats: wall=55.046s prompt≈1818t/12000t system=131t meta=39t taxonomy=998t transcript=401t(user=0t assistant=385t) instr=222t existing=610 msgs=1 turns=5 tool_calls=6 tools=memory_get_fragment,memory_search_fragments,memory_update_fragment usage[in=22118 cached=0 out=2373 write=0] truncated_msgs=0 assistant_cut=0 user_cut=0 budget_hit=false single_clip=false
```

For this batch, the fast model was actually worse: more tool churn, more turns, slower wall time.

## Validation

- `go test ./...`
- dry-run smoke tests above for default and `--fast-model`
