### PR TITLE
fix: increase progressive finalization budget for slow providers (30s→5m)

### DIFF
--- a/cmd/progressive.go
+++ b/cmd/progressive.go
@@ -19,8 +19,8 @@ const (
 	progressiveStopWhenDone    progressiveStopWhen = "done"
 	progressiveStopWhenTimeout progressiveStopWhen = "timeout"
 
-	progressiveDefaultFinalizeGrace = 15 * time.Second
-	progressiveMaxFinalizeBudget    = 30 * time.Second
+	progressiveDefaultFinalizeGrace = 5 * time.Minute
+	progressiveMaxFinalizeBudget    = 5 * time.Minute
 	progressiveMinFinalizeBudget    = 5 * time.Second
 )
 


### PR DESCRIPTION
## What

Increase the progressive finalization budget constants:

- `progressiveMaxFinalizeBudget`: 30s → 5m
- `progressiveDefaultFinalizeGrace`: 15s → 5m

## Why

With slow providers (e.g. claude-bin/Opus), a single LLM round-trip takes 60–70s. The old 30s cap meant the finalization pass — where the agent calls `finalize_progress` to commit a final answer — could never complete. The model response would arrive after the context was already cancelled, leaving every progressive run with `finalized: false` regardless of how long the main timeout was.

Observed in a comparison run:
- vanilla (~4min): succeeded, good prose output
- progressive-5m: `timed_out`, `finalized: false` — fell back to last raw text stream
- progressive-10m: `timed_out`, `finalized: false` — fell back to raw `update_progress` JSON state

The finalization context already uses `context.WithoutCancel`, so it correctly runs outside the main job deadline. This change simply raises the cap. If you've invested 20 minutes of work budget, dying with a 30s finalization grace is a bad trade. 5 minutes gives the model enough time to synthesize the accumulated state into a clean final answer even on a slow provider.

`progressiveMinFinalizeBudget` (5s) is unchanged.
