### PR TITLE
fix: show tool count in footer when 4+ tools, remove MCP tip

### DIFF
--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -672,11 +672,13 @@ func (m *Model) renderStatusLine() string {
 	// Calculate available width for tools and mcp
 	availableWidth := m.width - fixedWidth
 
-	// Build tools string - use full names if they fit, otherwise abbreviate
+	// Build tools string - show count when 4+ tools, full names only for small sets
 	var toolsPart string
 	if len(m.localTools) > 0 {
 		if len(m.localTools) == len(tools.AllToolNames()) {
 			toolsPart = successStyle.Render("tools:all")
+		} else if len(m.localTools) >= 4 {
+			toolsPart = successStyle.Render(fmt.Sprintf("tools:%d", len(m.localTools)))
 		} else {
 			fullTools := "tools:" + strings.Join(m.localTools, ",")
 			shortTools := fmt.Sprintf("tools:%d", len(m.localTools))
@@ -713,9 +715,6 @@ func (m *Model) renderStatusLine() string {
 			} else {
 				mcpPart = mutedStyle.Render("mcp:off")
 			}
-		} else if len(m.messages) == 0 {
-			// Show hint for new users on empty conversation
-			mcpPart = mutedStyle.Render("Ctrl+T:mcp")
 		}
 	}
 


### PR DESCRIPTION
## What

- When 4 or more tools are active, the chat footer now shows `tools:N` (a count) instead of trying to list all tool names
- Removed the `Ctrl+T:mcp` hint that appeared on empty conversations

## Why

Listing 8+ tool names in the footer is noise — the names are long and the line becomes unreadable. A count is sufficient. The MCP tip was similarly low-signal; users who want MCP know how to enable it.
