### PR TITLE
fix: make progressiveDefaultFinalizeGrace a floor, not a no-deadline fallback

### DIFF
--- a/cmd/progressive.go
+++ b/cmd/progressive.go
@@ -509,7 +509,7 @@ func progressiveFinalizeReserve(total time.Duration) time.Duration {
 
 func progressiveFinalizationContext(parent context.Context, reserve time.Duration, exitReason string) context.Context {
 	grace := reserve
-	if grace <= 0 {
+	if grace < progressiveDefaultFinalizeGrace {
 		grace = progressiveDefaultFinalizeGrace
 	}
 	if exitReason == exitReasonNatural {


### PR DESCRIPTION
## What

One-line fix: change `progressiveDefaultFinalizeGrace` from a no-deadline fallback to a minimum floor for the finalization budget.

```go
// Before
if grace <= 0 {
    grace = progressiveDefaultFinalizeGrace
}

// After
if grace < progressiveDefaultFinalizeGrace {
    grace = progressiveDefaultFinalizeGrace
}
```

## Why

The previous condition only triggered when `reserve <= 0` — i.e. when there was no deadline at all. For any real timed job, `grace = reserve = timeout/10`, which for a 5-minute job is **30 seconds**. A claude-bin round-trip takes 60–70s, so finalization never stood a chance on short jobs.

`progressiveDefaultFinalizeGrace` (set to 5 minutes in #194) was effectively dead code for all timed runs.

With this fix, every finalization pass gets at least 5 minutes — a floor, not just a fallback. A 5-minute progressive job now gets:

- Main work phase: `5min - 30s = 4m30s`
- Finalization grace: `max(30s, 5min) = 5min` (via `context.WithoutCancel`, runs outside the job deadline)

Discovered while testing #194 — the 5-minute test run remained `finalized: false` even after that fix.
