### PR TITLE
feat: default stop_when to timeout when progressive + timeout are both set

### DIFF
--- a/cmd/progressive.go
+++ b/cmd/progressive.go
@@ -200,7 +200,13 @@ func validateAskProgressiveOptions(opts askProgressiveOptions) error {
 
 	stopWhen := opts.StopWhen
 	if stopWhen == "" {
-		stopWhen = progressiveStopWhenDone
+		// When a timeout is configured, default to "timeout" so the agent
+		// actually uses its budget instead of exiting after the first pass.
+		if opts.Timeout > 0 {
+			stopWhen = progressiveStopWhenTimeout
+		} else {
+			stopWhen = progressiveStopWhenDone
+		}
 	}
 	switch stopWhen {
 	case progressiveStopWhenDone, progressiveStopWhenTimeout:


### PR DESCRIPTION
## What

When `--progressive` is used with `--timeout` (or `timeout_seconds` in a job config), default `stop_when` to `"timeout"` instead of `"done"`.

## Why

Previously, setting `progressive: true` + `timeout_seconds: 600` in a job would exit after the first clean pass (~90 seconds), completely ignoring the remaining 8+ minutes. The model did one round of research, called `update_progress`, finished naturally, and returned. The 10-minute budget was wasted.

The root cause: `stop_when` defaulted to `"done"` regardless of whether a timeout was configured. `"done"` means "stop when the model finishes a pass cleanly". `"timeout"` means "keep looping with continuation prompts until the budget runs out".

If you set a timeout, you want the agent to use it. The new default makes that happen automatically.

## Behaviour

- `progressive=true`, no timeout → `stop_when=done` (unchanged)
- `progressive=true`, timeout set, no explicit `stop_when` → `stop_when=timeout` (new default)
- `progressive=true`, timeout set, explicit `stop_when=done` → `stop_when=done` (explicit override still works)
