### PR TITLE
feat: add WebRTC diagnostics mode (console timeline + per-request latency)

### DIFF
--- a/cmd/serve_webrtc.go
+++ b/cmd/serve_webrtc.go
@@ -15,6 +15,7 @@ var (
 	serveWebRTCToken        string
 	serveWebRTCSTUN         []string
 	serveWebRTCMaxConns     int
+	serveWebRTCDiagnostics  bool
 )
 
 func init() {
@@ -28,6 +29,8 @@ func init() {
 		[]string{"stun:stun.l.google.com:19302"}, "STUN server URL(s)")
 	serveCmd.Flags().IntVar(&serveWebRTCMaxConns, "webrtc-max-conns", 10,
 		"Maximum concurrent WebRTC connections")
+	serveCmd.Flags().BoolVar(&serveWebRTCDiagnostics, "webrtc-diagnostics", false,
+		"Enable WebRTC diagnostics: log connection timeline and per-request latency to browser console")
 }
 
 // webrtcHTMLSnippet returns the <script> snippet to inject into index.html
@@ -37,8 +40,13 @@ func webrtcHTMLSnippet() string {
 		return ""
 	}
 	urlJSON, _ := json.Marshal(serveWebRTCSignalingURL)
-	return `<script>window.__WEBRTC_ENABLED__=true;window.__WEBRTC_SIGNALING_URL__=` +
-		string(urlJSON) + `;</script>`
+	snippet := `<script>window.__WEBRTC_ENABLED__=true;window.__WEBRTC_SIGNALING_URL__=` +
+		string(urlJSON) + `;`
+	if serveWebRTCDiagnostics {
+		snippet += `window.__WEBRTC_DIAGNOSTICS__=true;`
+	}
+	snippet += `</script>`
+	return snippet
 }
 
 // runWebRTCPeer starts the WebRTC home peer in the background.

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -8,6 +8,11 @@
 // falls back to the normal HTTPS path; no user-visible error is shown.
 // When the data channel later disconnects or errors the same silent fallback
 // applies to all subsequent requests.
+//
+// Diagnostics mode: set window.__WEBRTC_DIAGNOSTICS__ = true (or pass
+// ?webrtc_diag=1 in the URL) to enable console.log timeline output:
+//   [webrtc] connection lifecycle events with timestamps
+//   [webrtc] per-request: method, path, body size, status, latency
 
 (function () {
   'use strict';
@@ -27,18 +32,43 @@
   let dataChannel = null;
 
   // ---------------------------------------------------------------------------
+  // Diagnostics
+  // ---------------------------------------------------------------------------
+
+  const diagEnabled = !!(
+    window.__WEBRTC_DIAGNOSTICS__ ||
+    new URLSearchParams(window.location.search).has('webrtc_diag')
+  );
+
+  // t0 is the timestamp when initWebRTC() starts, used for relative timings.
+  let diagT0 = 0;
+
+  function diag(msg) {
+    if (!diagEnabled) return;
+    const elapsed = diagT0 ? ((performance.now() - diagT0) | 0) : 0;
+    console.log('[webrtc] +' + elapsed + 'ms ' + msg);
+  }
+
+  // ---------------------------------------------------------------------------
   // Initialisation
   // ---------------------------------------------------------------------------
 
   async function initWebRTC() {
+    diagT0 = performance.now();
+    diag('init signaling=' + SIGNALING_URL);
     try {
       // 1. Request a signaling session (no auth — session_id gates routing).
       const sessResp = await originalFetch(SIGNALING_URL + '/session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });
-      if (!sessResp.ok) return;
+      if (!sessResp.ok) {
+        diag('session request failed status=' + sessResp.status);
+        return;
+      }
       const sess = await sessResp.json();
+      diag('session created id=' + sess.session_id +
+        (sess.turn_url ? ' turn=' + sess.turn_url : ' no-turn'));
 
       // 2. Build ICE server list from session response.
       const iceServers = [
@@ -54,6 +84,10 @@
 
       const pc = new RTCPeerConnection({ iceServers });
 
+      pc.oniceconnectionstatechange = () => {
+        diag('ICE state=' + pc.iceConnectionState);
+      };
+
       // 3. Browser creates the data channel (ordered, reliable).
       const dc = pc.createDataChannel('api', { ordered: true });
 
@@ -61,6 +95,7 @@
       //    includes all candidates (vanilla ICE — no trickle).
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
+      diag('ICE gathering started');
 
       await new Promise((resolve) => {
         if (pc.iceGatheringState === 'complete') { resolve(); return; }
@@ -68,6 +103,7 @@
           if (pc.iceGatheringState === 'complete') resolve();
         };
       });
+      diag('ICE gathering complete');
 
       // 5. Send the completed offer to the signaling server.
       const sendResp = await originalFetch(SIGNALING_URL + '/signal', {
@@ -79,11 +115,19 @@
           sdp: pc.localDescription.sdp,
         }),
       });
-      if (!sendResp.ok) return;
+      if (!sendResp.ok) {
+        diag('offer post failed status=' + sendResp.status);
+        return;
+      }
+      diag('offer sent');
 
       // 6. Poll for the home peer's answer (8-second timeout).
       const answer = await pollForAnswer(sess.session_id, ICE_TIMEOUT_MS);
-      if (!answer) return; // timed out — fall back to HTTPS silently
+      if (!answer) {
+        diag('answer timeout — falling back to HTTPS');
+        return; // timed out — fall back to HTTPS silently
+      }
+      diag('answer received');
 
       await pc.setRemoteDescription({ type: 'answer', sdp: answer.sdp });
 
@@ -103,10 +147,13 @@
 
       window.fetch = patchedFetch;
 
+      diag('data channel open — fetch patched');
+
       if (typeof setConnectionState === 'function') {
         setConnectionState('\u26A1 direct', 'ok');
       }
     } catch (_e) {
+      diag('init error: ' + (_e && _e.message ? _e.message : String(_e)));
       // Silent fallback — HTTPS continues to work for all requests.
     }
   }
@@ -163,6 +210,7 @@
 
   function onChannelClose() {
     dataChannel = null;
+    diag('data channel closed — restoring original fetch');
     // Restore native fetch so subsequent requests use HTTPS.
     window.fetch = originalFetch;
     if (typeof setConnectionState === 'function') {
@@ -199,11 +247,21 @@
       const reqId = crypto.randomUUID();
       let streamController;
       let resolved = false;
+      const reqStart = performance.now();
+
+      const urlObj = new URL(urlStr, window.location.origin);
+      const method = options.method || 'GET';
+      const path = urlObj.pathname + (urlObj.search || '');
+      const bodySize = options.body ? new Blob([options.body]).size : 0;
+
+      diag('→ ' + method + ' ' + path + ' (' + bodySize + 'b)');
 
       const stream = new ReadableStream({
         start(ctrl) { streamController = ctrl; },
         cancel() { pendingRequests.delete(reqId); },
       });
+
+      let responseBytes = 0;
 
       function resolveOnce(response) {
         if (!resolved) { resolved = true; resolve(response); }
@@ -215,11 +273,15 @@
         },
         onChunk(line) {
           resolveOnce(new Response(stream, { status: 200 }));
+          responseBytes += (line ? line.length : 0) + 1; // +1 for the \n
           if (streamController) {
             streamController.enqueue(encoder.encode(line + '\n'));
           }
         },
         onDone(status) {
+          const latency = (performance.now() - reqStart) | 0;
+          diag('← ' + status + ' ' + method + ' ' + path +
+            ' (' + responseBytes + 'b, ' + latency + 'ms)');
           resolveOnce(new Response(stream, { status }));
           if (streamController) streamController.close();
           pendingRequests.delete(reqId);
@@ -227,7 +289,6 @@
       });
 
       // Build and send the request frame.
-      const urlObj = new URL(urlStr, window.location.origin);
       const headersObj = {};
 
       // Carry over all request headers (Authorization, session_id, Content-Type, …).
@@ -240,8 +301,8 @@
 
       const frame = {
         id: reqId,
-        method: options.method || 'GET',
-        path: urlObj.pathname + (urlObj.search || ''),
+        method,
+        path,
         headers: Object.keys(headersObj).length ? headersObj : undefined,
         body: options.body ? strToBase64(options.body) : undefined,
       };
@@ -249,6 +310,7 @@
       try {
         dataChannel.send(JSON.stringify(frame));
       } catch (_e) {
+        diag('send error: ' + (_e && _e.message ? _e.message : String(_e)));
         // Channel error — fall back to HTTPS for this request.
         pendingRequests.delete(reqId);
         if (streamController) streamController.close();


### PR DESCRIPTION
## What

Adds a `--webrtc-diagnostics` flag to `term-llm serve web` and URL param `?webrtc_diag=1` for diagnosing WebRTC connection issues without touching server config.

## Why

ICE failures are hard to debug silently. This makes the full connection timeline and per-request performance visible in the browser console.

## How to enable

**Server-side** (injected into every page load):
```
term-llm serve web --webrtc --webrtc-diagnostics ...
```

**Client-side without restarting** (append to URL):
```
https://example.com/chat?webrtc_diag=1
```

**Or set in devtools console at any time:**
```js
window.__WEBRTC_DIAGNOSTICS__ = true
```

## Sample output

```
[webrtc] +0ms init signaling=https://example.com/jarvis-api/webrtc
[webrtc] +45ms session created id=abc123 turn=turn:example.com:3478
[webrtc] +46ms ICE gathering started
[webrtc] +312ms ICE state=checking
[webrtc] +380ms ICE gathering complete
[webrtc] +381ms offer sent
[webrtc] +430ms answer received
[webrtc] +431ms ICE state=connected
[webrtc] +432ms data channel open — fetch patched
[webrtc] +500ms → POST /chat/v1/chat (1234b)
[webrtc] +892ms ← 200 POST /chat/v1/chat (8432b, 392ms)
```

## Changes

- `cmd/serve_webrtc.go`: `--webrtc-diagnostics` flag; injects `window.__WEBRTC_DIAGNOSTICS__=true` into the HTML snippet when set
- `internal/serveui/static/app-webrtc.js`: diagnostics logger with relative timestamps; logs lifecycle events and per-request method/path/size/latency; also activates via `?webrtc_diag=1` URL param
