### PR TITLE
fix: cap ICE gathering at 4s to avoid 40s stall on broken IPv6 STUN paths

### DIFF
--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -97,12 +97,18 @@
       await pc.setLocalDescription(offer);
       diag('ICE gathering started');
 
-      await new Promise((resolve) => {
-        if (pc.iceGatheringState === 'complete') { resolve(); return; }
-        pc.onicegatheringstatechange = () => {
-          if (pc.iceGatheringState === 'complete') resolve();
-        };
-      });
+      // Wait for ICE gathering to complete, but cap at 4 s so a slow/broken
+      // STUN or TURN server (e.g. IPv6 timeout) never stalls the handshake.
+      // Whatever candidates are ready at that point are included in the offer.
+      await Promise.race([
+        new Promise((resolve) => {
+          if (pc.iceGatheringState === 'complete') { resolve(); return; }
+          pc.onicegatheringstatechange = () => {
+            if (pc.iceGatheringState === 'complete') resolve();
+          };
+        }),
+        new Promise((resolve) => setTimeout(resolve, 4000)),
+      ]);
       diag('ICE gathering complete');
 
       // 5. Send the completed offer to the signaling server.


### PR DESCRIPTION
## What

Caps ICE gathering at 4 seconds using `Promise.race` instead of waiting indefinitely for `iceGatheringState === 'complete'`.

## Why

When a STUN or TURN server has both IPv4 and IPv6 DNS records, Chrome attempts candidate gathering over both. If the IPv6 path is broken (common on home networks), the browser silently waits ~40 seconds for the IPv6 attempt to time out before declaring gathering complete — even when perfectly good UDP candidates are already available.

`stun.l.google.com` (the default STUN server) has an AAAA record, which triggers this on any Mac/Linux with IPv6 enabled but no working IPv6 path to Google's STUN servers.

The 4-second cap means the offer is sent with whatever candidates are ready, which in practice includes all working host + reflexive + relay candidates. The vanilla ICE approach still works — we just don't wait for stragglers.
