### PR TITLE
feat: add TURN relay support to WebRTC home peer

### DIFF
--- a/cmd/serve_webrtc.go
+++ b/cmd/serve_webrtc.go
@@ -10,12 +10,15 @@ import (
 )
 
 var (
-	serveWebRTC             bool
-	serveWebRTCSignalingURL string
-	serveWebRTCToken        string
-	serveWebRTCSTUN         []string
-	serveWebRTCMaxConns     int
-	serveWebRTCDiagnostics  bool
+	serveWebRTC               bool
+	serveWebRTCSignalingURL   string
+	serveWebRTCToken          string
+	serveWebRTCSTUN           []string
+	serveWebRTCTURN           []string
+	serveWebRTCTURNUsername   string
+	serveWebRTCTURNCredential string
+	serveWebRTCMaxConns       int
+	serveWebRTCDiagnostics    bool
 )
 
 func init() {
@@ -27,6 +30,12 @@ func init() {
 		"Bearer token for authenticating with the signaling server")
 	serveCmd.Flags().StringArrayVar(&serveWebRTCSTUN, "webrtc-stun",
 		[]string{"stun:stun.l.google.com:19302"}, "STUN server URL(s)")
+	serveCmd.Flags().StringArrayVar(&serveWebRTCTURN, "webrtc-turn", nil,
+		"TURN server URL(s) (e.g. turn:host:3478?transport=udp); requires --webrtc-turn-username and --webrtc-turn-credential")
+	serveCmd.Flags().StringVar(&serveWebRTCTURNUsername, "webrtc-turn-username", "",
+		"Username for TURN authentication")
+	serveCmd.Flags().StringVar(&serveWebRTCTURNCredential, "webrtc-turn-credential", "",
+		"Credential (password) for TURN authentication")
 	serveCmd.Flags().IntVar(&serveWebRTCMaxConns, "webrtc-max-conns", 10,
 		"Maximum concurrent WebRTC connections")
 	serveCmd.Flags().BoolVar(&serveWebRTCDiagnostics, "webrtc-diagnostics", false,
@@ -56,13 +65,16 @@ func runWebRTCPeer(ctx context.Context, s *serveServer) {
 		return
 	}
 	cfg := webrtc.Config{
-		SignalingURL: serveWebRTCSignalingURL,
-		Token:        serveWebRTCToken,
-		BasePath:     s.cfg.basePath,
-		STUNURLs:     append([]string(nil), serveWebRTCSTUN...),
-		PollInterval: 2 * time.Second,
-		IdleTimeout:  30 * time.Minute,
-		MaxConns:     serveWebRTCMaxConns,
+		SignalingURL:   serveWebRTCSignalingURL,
+		Token:          serveWebRTCToken,
+		BasePath:       s.cfg.basePath,
+		STUNURLs:       append([]string(nil), serveWebRTCSTUN...),
+		TURNURLs:       append([]string(nil), serveWebRTCTURN...),
+		TURNUsername:   serveWebRTCTURNUsername,
+		TURNCredential: serveWebRTCTURNCredential,
+		PollInterval:   2 * time.Second,
+		IdleTimeout:    30 * time.Minute,
+		MaxConns:       serveWebRTCMaxConns,
 	}
 	peer, err := webrtc.New(ctx, cfg, s.httpHandler())
 	if err != nil {

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -324,22 +324,32 @@ func (p *peer) handleOffer(ctx context.Context, offer signalingMsg) {
 		return
 	}
 
-	// Parse STUN server URLs.
-	var stunURLs []*stun.URI
+	// Parse STUN and TURN server URLs.
+	var iceURLs []*stun.URI
 	for _, raw := range p.cfg.STUNURLs {
 		u, parseErr := stun.ParseURI(raw)
 		if parseErr != nil {
 			log.Printf("webrtc: parse STUN URL %q: %v", raw, parseErr)
 			continue
 		}
-		stunURLs = append(stunURLs, u)
+		iceURLs = append(iceURLs, u)
+	}
+	for _, raw := range p.cfg.TURNURLs {
+		u, parseErr := stun.ParseURI(raw)
+		if parseErr != nil {
+			log.Printf("webrtc: parse TURN URL %q: %v", raw, parseErr)
+			continue
+		}
+		u.Username = p.cfg.TURNUsername
+		u.Password = p.cfg.TURNCredential
+		iceURLs = append(iceURLs, u)
 	}
 
 	// Create the ICE agent and gather candidates.
 	gatherDone := make(chan struct{})
 	var gatherOnce sync.Once
 	agent, err := ice.NewAgentWithOptions(
-		ice.WithUrls(stunURLs),
+		ice.WithUrls(iceURLs),
 		ice.WithNetworkTypes([]ice.NetworkType{ice.NetworkTypeUDP4, ice.NetworkTypeUDP6}),
 	)
 	if err != nil {

--- a/internal/webrtc/types.go
+++ b/internal/webrtc/types.go
@@ -21,6 +21,16 @@ type Config struct {
 	// Defaults to Google's public STUN server if empty.
 	STUNURLs []string
 
+	// TURNURLs is a list of TURN server URLs (e.g. "turn:host:3478?transport=udp").
+	// When set, TURNUsername and TURNCredential must also be provided.
+	TURNURLs []string
+
+	// TURNUsername is the username for TURN authentication.
+	TURNUsername string
+
+	// TURNCredential is the credential (password) for TURN authentication.
+	TURNCredential string
+
 	// PollInterval is how often to poll the signaling server for new offers.
 	// Defaults to 2 seconds.
 	PollInterval time.Duration


### PR DESCRIPTION
## What

Adds TURN relay support to the WebRTC home peer via three new CLI flags:

```
--webrtc-turn <url>          TURN server URL (e.g. turn:host:3478?transport=udp)
--webrtc-turn-username <u>   Username for TURN authentication
--webrtc-turn-credential <c> Credential (password) for TURN authentication
```

Multiple `--webrtc-turn` URLs can be specified; all use the same credential pair.

## Why

Without TURN on the home peer, the peer's ICE candidates are Docker-internal host IPs and a STUN reflexive address. The reflexive path works briefly through the home router NAT but drops after a few seconds under symmetric NAT — which is the common case for residential connections.

With TURN, the peer also gathers a relay candidate on the coturn server. The browser connects to the relay address and coturn forwards traffic to the peer. This path is stable regardless of NAT type on either side.
