### PR TITLE
fix: break infinite reconnect loop after server restart

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -652,6 +652,14 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
     if (consecutiveHttpFailures >= 5) {
       consecutiveHttpFailures = 0;
       setConnectionState('Checking session state\u2026');
+      // Temporarily clear the abort controller so syncActiveSessionFromServer
+      // can act on the server state.  The !activeRun && !state.abortController
+      // branch inside sync refuses to clear tracking while a controller is set,
+      // but our own retry loop is the one that set it — creating a deadlock
+      // where the loop never exits even after the server confirms the run is done.
+      if (state.abortController) {
+        state.abortController = null;
+      }
       await app.syncActiveSessionFromServer(session, false);
       if (session.activeResponseId !== responseId) {
         // Run completed/changed while we were polling — exit.


### PR DESCRIPTION
## What

Fixes an infinite reconnect loop in the web UI after a server restart (or any scenario where in-memory `responseRuns` are lost while the browser has a stale `activeResponseId`).

## The bug

`resumeActiveResponseInner` retries forever when the event stream fails. After 5 consecutive HTTP failures, it calls `syncActiveSessionFromServer(session, false)` to check whether the run is still active.

But the retry loop itself sets `state.abortController` (via `attachResponseStream` at line 669). Inside `syncActiveSessionFromServer`, the cleanup branch that clears `session.activeResponseId` requires `!activeRun && !state.abortController` (line 307). Even when the server confirms `active_run: false` and no `active_response_id`, the condition never fires because the controller is set by the calling loop. So `session.activeResponseId` is never cleared, the check at line 656 fails, and the loop continues forever — showing "Reconnecting (attempt N)…" indefinitely.

## The fix

Clear `state.abortController` before calling `syncActiveSessionFromServer` in the failure recovery path. This lets sync properly act on the server state and clear the stale tracking, breaking the loop.

## Reproduction

1. Open a session in the web UI with an active response streaming
2. Restart the server (e.g. deploy, `sv restart`)
3. Browser shows "Reconnecting (attempt N)…" climbing indefinitely instead of recovering
