### PR TITLE
feat(autotitle): add --verbose flag and include rejection details in error

### DIFF
--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -23,9 +23,10 @@ User-set names always win in the UI and are not overwritten unless --force is pr
 }
 
 var (
-	sessionsAutotitleDryRun bool
-	sessionsAutotitleForce  bool
-	sessionsAutotitleMinAge time.Duration
+	sessionsAutotitleDryRun  bool
+	sessionsAutotitleForce   bool
+	sessionsAutotitleMinAge  time.Duration
+	sessionsAutotitleVerbose bool
 )
 
 type autotitleSkipStats struct {
@@ -67,6 +68,7 @@ func init() {
 	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleDryRun, "dry-run", false, "Preview generated titles without saving")
 	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleForce, "force", false, "Regenerate even when a custom name already exists")
 	sessionsAutotitleCmd.Flags().DurationVar(&sessionsAutotitleMinAge, "min-age", 3*time.Minute, "Skip sessions updated more recently than this duration")
+	sessionsAutotitleCmd.Flags().BoolVarP(&sessionsAutotitleVerbose, "verbose", "v", false, "Print rejected candidates with rejection reason")
 	sessionsCmd.AddCommand(sessionsAutotitleCmd)
 }
 
@@ -156,6 +158,9 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			if strings.Contains(err.Error(), "generated titles rejected") {
 				skips.rejected++
+				if sessionsAutotitleVerbose {
+					fmt.Fprintf(cmd.ErrOrStderr(), "#%d rejected: %v\n", sess.Number, err)
+				}
 			} else {
 				skips.generationErrs++
 				fmt.Fprintf(cmd.ErrOrStderr(), "#%d generation failed: %v\n", sess.Number, err)

--- a/internal/sessiontitle/generator.go
+++ b/internal/sessiontitle/generator.go
@@ -62,7 +62,10 @@ Conversation slice:
 		return Candidate{}, err
 	}
 	if !Acceptable(cand) {
-		return Candidate{}, fmt.Errorf("generated titles rejected")
+		return cand, fmt.Errorf("generated titles rejected: short=%q (%d words) long=%q (%d words) conf=%.2f",
+			cand.ShortTitle, wordCount(cand.ShortTitle),
+			cand.LongTitle, wordCount(cand.LongTitle),
+			cand.Confidence)
 	}
 	return cand, nil
 }


### PR DESCRIPTION
## What

- Adds `--verbose` / `-v` flag to `sessions autotitle` that prints rejected candidates to stderr with the reason for rejection
- Includes candidate field values (short title, word count, long title, word count, confidence) in the rejection error message so `--verbose` output is actionable

Example output with `--verbose`:
```
#1113 rejected: generated titles rejected: short="Gas Town" (2 words) long="What is Gas Town" (4 words) conf=0.90
```

## Why

Previously, rejected titles were silently counted but never shown. Impossible to know whether the model returned null, a too-short title, a low-confidence result, or a generic phrase without adding instrumentation. This makes the rejection reason immediately visible for debugging.
