### PR TITLE
fix: use MarkTitleSkipped to avoid updated_at race in autotitle skip

### DIFF
--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -171,9 +171,10 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 					fmt.Fprintf(cmd.ErrOrStderr(), "#%d rejected: %v\n", sess.Number, err)
 				}
 				// Mark session as trivial so we don't retry until it changes.
+				// Uses MarkTitleSkipped (not Update) to avoid bumping updated_at,
+				// which would cause the skip check to immediately re-qualify the session.
 				if !sessionsAutotitleDryRun {
-					sess.TitleSkippedAt = time.Now().UTC()
-					if uerr := store.Update(ctx, sess); uerr != nil {
+					if uerr := store.MarkTitleSkipped(ctx, sess.ID, time.Now().UTC()); uerr != nil {
 						fmt.Fprintf(cmd.ErrOrStderr(), "#%d skip-mark failed: %v\n", sess.Number, uerr)
 					}
 				}

--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -1,6 +1,9 @@
 package session
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // NoopStore is a no-op implementation of Store used when sessions are disabled.
 // It silently discards all writes and returns empty results for reads.
@@ -26,6 +29,10 @@ func (s *NoopStore) GetByPrefix(ctx context.Context, prefix string) (*Session, e
 }
 
 func (s *NoopStore) Update(ctx context.Context, sess *Session) error {
+	return nil
+}
+
+func (s *NoopStore) MarkTitleSkipped(ctx context.Context, id string, t time.Time) error {
 	return nil
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -842,6 +842,20 @@ func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	return nil
 }
 
+// MarkTitleSkipped sets title_skipped_at on a session without bumping updated_at.
+// This lets the autotitle job skip trivial sessions until real new messages arrive.
+func (s *SQLiteStore) MarkTitleSkipped(ctx context.Context, id string, t time.Time) error {
+	if !s.hasTitleSkippedAt {
+		return nil // column absent on old schema; skip silently
+	}
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE sessions SET title_skipped_at = ? WHERE id = ?", t, id)
+	if err != nil {
+		return fmt.Errorf("mark title skipped: %w", err)
+	}
+	return nil
+}
+
 // UpdateMetrics atomically increments the metrics fields for a session.
 // All token counters use += to avoid clobbering concurrent accumulation.
 func (s *SQLiteStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Store is the interface for session persistence.
@@ -16,6 +17,7 @@ type Store interface {
 	GetByNumber(ctx context.Context, number int64) (*Session, error)
 	GetByPrefix(ctx context.Context, prefix string) (*Session, error)
 	Update(ctx context.Context, s *Session) error
+	MarkTitleSkipped(ctx context.Context, id string, t time.Time) error
 	Delete(ctx context.Context, id string) error
 
 	// Listing and search


### PR DESCRIPTION
## What

Fixes a race in the autotitle skip logic introduced in #212.

## The bug

`Update()` sets `sess.UpdatedAt = time.Now()` internally — this fires *after* the caller sets `sess.TitleSkippedAt = time.Now()`. So `UpdatedAt` ends up a few microseconds ahead of `TitleSkippedAt`, and the skip check `!UpdatedAt.After(TitleSkippedAt)` evaluates to false immediately. Result: the session never gets skipped.

## Fix

Add `MarkTitleSkipped(ctx, id, t)` — a targeted `UPDATE sessions SET title_skipped_at = ? WHERE id = ?` that does **not** touch `updated_at`. The autotitle rejection path calls this instead of `Update`.

- `session.Store`: `MarkTitleSkipped` added to interface
- `SQLiteStore`: implementation (no-op on old schema without the column)
- `NoopStore`: no-op stub
- `sessions autotitle`: use `MarkTitleSkipped` on rejection instead of `Update`
