### PR TITLE
fix: autotitle — use message count guard, generate over name-only sessions

### DIFF
--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -107,19 +107,26 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 		skips      autotitleSkipStats
 	)
 	for _, summary := range summaries {
+		// Skip sessions with no messages at all (no point loading full session).
+		if summary.MessageCount == 0 {
+			continue
+		}
 		sess, err := store.Get(ctx, summary.ID)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "#%d load failed: %v\n", summary.Number, err)
 			continue
 		}
-		if sess == nil || sess.UserTurns == 0 {
+		if sess == nil {
 			continue
 		}
 		if sessionsAutotitleMinAge > 0 && time.Since(sess.UpdatedAt) < sessionsAutotitleMinAge {
 			skips.recent++
 			continue
 		}
-		if sess.Name != "" && !sessionsAutotitleForce {
+		// Only skip custom-named sessions if they already have a generated title too.
+		// If Name is set but GeneratedShortTitle is empty, still generate — the generated
+		// title serves as a backup and the Name will still win in the UI.
+		if sess.Name != "" && sess.GeneratedShortTitle != "" && !sessionsAutotitleForce {
 			skips.customName++
 			continue
 		}

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -193,6 +193,9 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 			if err := safeStoreOp(func() error { return r.store.AddMessage(ctx, childSessionID, userMsg) }); err != nil {
 				r.warn("session AddMessage failed: %v", err)
 			}
+			if err := safeStoreOp(func() error { return r.store.IncrementUserTurns(ctx, childSessionID) }); err != nil {
+				r.warn("session IncrementUserTurns failed: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

Two fixes to `sessions autotitle` to ensure sessions with real content get titles.

## Fix 1: MessageCount guard replaces UserTurns guard

The `UserTurns == 0` check was silently dropping sessions where `user_turns` is never incremented — Claude Code sessions, tool-only sessions, and any session where the turn counter wasn't tracked. Several sessions with 10–100+ messages were being skipped entirely with no trace in the skip stats.

Replaced with `summary.MessageCount == 0`, which is a direct row count of the messages table and reliably reflects whether a session has content. As a bonus, this avoids loading the full session for truly empty sessions.

## Fix 2: Generate over name-only sessions

Previously any `Name != ""` caused a `customName` skip, even if no generated title existed. This meant sessions whose Name was auto-populated from the first user message (e.g. "what is gastown? clone it...") would never get a generated title.

Changed to: only skip on `customName` if *both* `Name` and `GeneratedShortTitle` are already set. If Name is set but GeneratedShortTitle is empty, we generate — the Name still wins in the UI via `PreferredShortTitle()`, so this is purely additive.
