### PR TITLE
fix: autotitle — increase timeout to 30s, limit message fetch to 50 rows

### DIFF
--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -160,7 +160,9 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 	for _, c := range candidates {
 		sess := c.sess
 
-		messages, err := store.GetMessages(ctx, sess.ID, 0, 0)
+		// Only the first few user+assistant messages are used for titling.
+		// Fetch at most 50 rows to avoid loading entire large sessions.
+		messages, err := store.GetMessages(ctx, sess.ID, 50, 0)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "#%d messages failed: %v\n", sess.Number, err)
 			continue

--- a/internal/sessiontitle/generator.go
+++ b/internal/sessiontitle/generator.go
@@ -53,7 +53,7 @@ JSON schema:
 Conversation slice:
 %s`, slice)
 
-	text, err := completeText(ctx, provider, prompt, 10*time.Second)
+	text, err := completeText(ctx, provider, prompt, 30*time.Second)
 	if err != nil {
 		return Candidate{}, err
 	}


### PR DESCRIPTION
## What

Two performance fixes for `sessions autotitle` that were causing persistent `context deadline exceeded` on large sessions.

## Fix 1: Timeout 10s → 30s

The `completeText` timeout was 10 seconds. With `fast_provider: claude-bin`, every call spawns a subprocess (~2-4s startup) before the API call even begins. Combined with normal API latency, 10s was regularly exceeded on cold runs.

The input to the model is always small (≤700 words via `BuildConversationSlice`), so the model itself responds quickly — it's the subprocess overhead that eats the budget. 30s is conservative but correct.

## Fix 2: Limit GetMessages to 50 rows

`GetMessages(ctx, id, 0, 0)` fetches all messages. Sessions with 120+ messages — many containing large tool outputs with file contents — were loading everything into memory before `BuildConversationSlice` threw away all but the first ~5 messages.

Changed to `GetMessages(ctx, id, 50, 0)`. 50 rows covers even the heaviest tool-use first exchange, and avoids the DB/memory overhead of loading the full session.
