### PR TITLE
fix: progressive stop_when default not propagated to run loop

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -150,7 +150,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		StopWhen:     progressiveStopWhen(strings.TrimSpace(askStopWhen)),
 		ContinueWith: askContinueWith,
 	}
-	if err := validateAskProgressiveOptions(progressiveOpts); err != nil {
+	if err := validateAskProgressiveOptions(&progressiveOpts); err != nil {
 		return err
 	}
 	if askTimeout > 0 {

--- a/cmd/progressive.go
+++ b/cmd/progressive.go
@@ -184,7 +184,7 @@ func parseProgressCandidate(raw json.RawMessage) (progressCandidate, error) {
 	}, nil
 }
 
-func validateAskProgressiveOptions(opts askProgressiveOptions) error {
+func validateAskProgressiveOptions(opts *askProgressiveOptions) error {
 	stopWhenSet := opts.StopWhen != ""
 	continueWithSet := strings.TrimSpace(opts.ContinueWith) != ""
 
@@ -198,26 +198,25 @@ func validateAskProgressiveOptions(opts askProgressiveOptions) error {
 		return nil
 	}
 
-	stopWhen := opts.StopWhen
-	if stopWhen == "" {
+	if opts.StopWhen == "" {
 		// When a timeout is configured, default to "timeout" so the agent
 		// actually uses its budget instead of exiting after the first pass.
 		if opts.Timeout > 0 {
-			stopWhen = progressiveStopWhenTimeout
+			opts.StopWhen = progressiveStopWhenTimeout
 		} else {
-			stopWhen = progressiveStopWhenDone
+			opts.StopWhen = progressiveStopWhenDone
 		}
 	}
-	switch stopWhen {
+	switch opts.StopWhen {
 	case progressiveStopWhenDone, progressiveStopWhenTimeout:
 	default:
 		return fmt.Errorf("invalid --stop-when %q", opts.StopWhen)
 	}
 
-	if continueWithSet && stopWhen != progressiveStopWhenTimeout {
+	if continueWithSet && opts.StopWhen != progressiveStopWhenTimeout {
 		return fmt.Errorf("--continue-with requires --stop-when timeout")
 	}
-	if stopWhen == progressiveStopWhenTimeout && opts.Timeout <= 0 {
+	if opts.StopWhen == progressiveStopWhenTimeout && opts.Timeout <= 0 {
 		return fmt.Errorf("--stop-when timeout requires --timeout")
 	}
 	return nil

--- a/cmd/progressive_test.go
+++ b/cmd/progressive_test.go
@@ -44,11 +44,18 @@ func TestValidateAskProgressiveOptions(t *testing.T) {
 				ContinueWith: "verify more",
 			},
 		},
+		{
+			name: "progressive with timeout defaults stop_when to timeout",
+			opts: askProgressiveOptions{
+				Enabled: true,
+				Timeout: 5 * time.Minute,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAskProgressiveOptions(tt.opts)
+			err := validateAskProgressiveOptions(&tt.opts)
 			if tt.wantErr && err == nil {
 				t.Fatal("expected error")
 			}
@@ -56,6 +63,31 @@ func TestValidateAskProgressiveOptions(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestValidateProgressiveDefaultsStopWhenToTimeout(t *testing.T) {
+	opts := askProgressiveOptions{
+		Enabled: true,
+		Timeout: 5 * time.Minute,
+	}
+	if err := validateAskProgressiveOptions(&opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.StopWhen != progressiveStopWhenTimeout {
+		t.Fatalf("StopWhen = %q, want %q", opts.StopWhen, progressiveStopWhenTimeout)
+	}
+}
+
+func TestValidateProgressiveDefaultsStopWhenToDoneWithoutTimeout(t *testing.T) {
+	opts := askProgressiveOptions{
+		Enabled: true,
+	}
+	if err := validateAskProgressiveOptions(&opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.StopWhen != progressiveStopWhenDone {
+		t.Fatalf("StopWhen = %q, want %q", opts.StopWhen, progressiveStopWhenDone)
 	}
 }
 

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -288,9 +288,12 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 		StopWhen:     progressiveStopWhen(strings.TrimSpace(cfg.StopWhen)),
 		ContinueWith: cfg.ContinueWith,
 	}
-	if err := validateAskProgressiveOptions(progressiveOpts); err != nil {
+	if err := validateAskProgressiveOptions(&progressiveOpts); err != nil {
 		return jobsV2RunResult{}, err
 	}
+	// Write resolved defaults back so the exec closure can use cfg directly.
+	cfg.StopWhen = string(progressiveOpts.StopWhen)
+	cfg.ContinueWith = progressiveOpts.ContinueWith
 	res := jobsV2RunResult{SessionID: cfg.SessionID}
 	progressTracker := newProgressTracker()
 	execResult, err := r.exec(ctx, cfg, func(ev llm.Event) {
@@ -2230,7 +2233,7 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 			}
 
 			progressiveResult, err := runProgressiveSession(ctx, engine, llmReq, progressiveRunOptions{
-				StopWhen:               progressiveStopWhen(strings.TrimSpace(cfg.StopWhen)),
+				StopWhen:               progressiveStopWhen(cfg.StopWhen),
 				ContinueWith:           cfg.ContinueWith,
 				SessionID:              cfg.SessionID,
 				ForceNamedFinalization: provider.Capabilities().SupportsToolChoice,


### PR DESCRIPTION
## What

`validateAskProgressiveOptions` correctly resolved an empty `stop_when` to `"timeout"` when a timeout was configured, but only used the resolved value for validation — it never wrote it back. Both `ask.go` and the jobs runner then passed the original empty string through to `runProgressiveSession`, which defaulted `""` → `"done"`.

## Effect

Progressive jobs with a timeout budget (e.g. `progressive: true, timeout_seconds: 300`) completed after one pass (~90 seconds) instead of running for the full 5 minutes. The `stop_when: timeout` default from PR #198 was dead code in practice.

## Fix

- Change `validateAskProgressiveOptions` to take `*askProgressiveOptions` and mutate `StopWhen` in place
- Jobs runner writes the resolved value back to `cfg` so the exec closure picks it up
- Updates all call sites (`ask.go`, `serve_jobs_v2.go`, tests)
- Adds two focused tests verifying the defaulting: timeout configured → `"timeout"`, no timeout → `"done"`
