### PR TITLE
feat(webrtc): TERM_LLM_WEBRTC_DIAGNOSTICS env var enables browser debug logging

### DIFF
--- a/cmd/serve_webrtc.go
+++ b/cmd/serve_webrtc.go
@@ -42,7 +42,7 @@ func webrtcHTMLSnippet() string {
 	urlJSON, _ := json.Marshal(serveWebRTCSignalingURL)
 	snippet := `<script>window.__WEBRTC_ENABLED__=true;window.__WEBRTC_SIGNALING_URL__=` +
 		string(urlJSON) + `;`
-	if serveWebRTCDiagnostics {
+	if serveWebRTCDiagnostics || envEnabled("TERM_LLM_WEBRTC_DIAGNOSTICS") {
 		snippet += `window.__WEBRTC_DIAGNOSTICS__=true;`
 	}
 	snippet += `</script>`


### PR DESCRIPTION
## What

Add `TERM_LLM_WEBRTC_DIAGNOSTICS` environment variable as an alternative to the existing `--webrtc-diagnostics` flag.

When set to `1`, `true`, `yes`, or `y`, the browser will receive `window.__WEBRTC_DIAGNOSTICS__=true` in the injected script snippet, enabling the `[webrtc]` console log timeline (connection lifecycle events + per-request latency).

## Why

The `--webrtc-diagnostics` flag requires editing the runit service run script to toggle. An ENV var lets you enable it without touching the service definition — useful when actively debugging WebRTC over an extended period.

## Change

One line in `webrtcHTMLSnippet()`: ORs the existing flag with `envEnabled("TERM_LLM_WEBRTC_DIAGNOSTICS")`, reusing the existing helper from `exec.go`.
