### PR TITLE
fix: progressive job response returns prose instead of JSON envelope

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -2048,6 +2048,9 @@ func runOnComplete(command, input string) error {
 }
 
 func progressiveOutputText(result progressiveRunResult) string {
+	if strings.TrimSpace(result.FinalResponse) != "" {
+		return result.FinalResponse
+	}
 	if strings.TrimSpace(result.FallbackText) != "" {
 		return result.FallbackText
 	}

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -377,12 +377,8 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 		if strings.TrimSpace(execResult.Progressive.SessionID) == "" {
 			execResult.Progressive.SessionID = cfg.SessionID
 		}
-		data, marshalErr := json.Marshal(execResult.Progressive)
-		if marshalErr != nil {
-			return res, fmt.Errorf("marshal progressive job result: %w", marshalErr)
-		}
 		res.ExitReason = execResult.Progressive.ExitReason
-		res.Response = string(data)
+		res.Response = progressiveOutputText(*execResult.Progressive)
 	}
 	return res, err
 }

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -426,24 +426,20 @@ func TestJobsV2LLMProgressiveRunStoresEnvelopeAndProgressEvents(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	var envelope progressiveRunResult
-	if err := json.Unmarshal([]byte(run.Response), &envelope); err != nil {
-		t.Fatalf("response is not a progressive envelope: %v", err)
+	// Response should be the human-readable output from progressiveOutputText.
+	// With no FinalResponse or FallbackText, it falls back to JSON-marshaled progress state.
+	var progressState map[string]any
+	if err := json.Unmarshal([]byte(run.Response), &progressState); err != nil {
+		t.Fatalf("response is not progress JSON: %v", err)
 	}
-	if envelope.ExitReason != exitReasonNatural {
-		t.Fatalf("exit_reason = %q, want %q", envelope.ExitReason, exitReasonNatural)
+	if got := progressState["step"]; got != "draft" {
+		t.Fatalf("progress step = %#v, want %q", got, "draft")
 	}
-	if strings.TrimSpace(envelope.SessionID) == "" {
-		t.Fatal("expected progressive envelope session_id to be populated")
+	if run.ExitReason != exitReasonNatural {
+		t.Fatalf("exit_reason = %q, want %q", run.ExitReason, exitReasonNatural)
 	}
 	if strings.TrimSpace(run.SessionID) == "" {
 		t.Fatal("expected persisted run session_id to be populated")
-	}
-	if run.SessionID != envelope.SessionID {
-		t.Fatalf("run session_id = %q, want %q", run.SessionID, envelope.SessionID)
-	}
-	if got := envelope.Progress["step"]; got != "draft" {
-		t.Fatalf("progress step = %#v, want %q", got, "draft")
 	}
 
 	events, _, err := mgr.ListRunEvents(run.ID, 0, 100, 0)
@@ -460,5 +456,65 @@ func TestJobsV2LLMProgressiveRunStoresEnvelopeAndProgressEvents(t *testing.T) {
 	}
 	if !foundProgressUpdate {
 		t.Fatalf("expected progress_update event, got %+v", events)
+	}
+}
+
+func TestJobsV2_ProgressiveLLM_FinalResponseProse(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 1, func(ctx context.Context, cfg jobsV2LLMConfig, onEvent func(llm.Event)) (serveJobsExecResult, error) {
+		return serveJobsExecResult{
+			Progressive: &progressiveRunResult{
+				ExitReason:    exitReasonTimeout,
+				Finalized:     true,
+				FinalResponse: "Here are the top 10 sci-fi audiobooks released in the past year.",
+				Progress: map[string]any{
+					"entries": []string{"Book A", "Book B"},
+				},
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:       "progressive-prose",
+		Enabled:    true,
+		RunnerType: jobsV2RunnerLLM,
+		RunnerConfig: json.RawMessage(`{
+			"agent_name":"planner",
+			"instructions":"Find audiobooks",
+			"progressive":true
+		}`),
+		TriggerType:    jobsV2TriggerManual,
+		TriggerConfig:  json.RawMessage(`{}`),
+		TimeoutSeconds: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		current, err := mgr.GetRun(run.ID)
+		if err == nil && current.Status == jobsV2RunTimedOut {
+			run = current
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for progressive prose run")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// When FinalResponse is set, Response should be the prose, not JSON.
+	expected := "Here are the top 10 sci-fi audiobooks released in the past year."
+	if run.Response != expected {
+		t.Fatalf("Response = %q, want prose %q", run.Response, expected)
 	}
 }


### PR DESCRIPTION
## What

Progressive job runs now return human-readable prose as `response` instead of the raw JSON envelope.

## The problem

When a progressive run finalized successfully, the job's `response` field contained the full JSON envelope (`{"exit_reason":"timeout","finalized":true,"progress":{...},"final_response":"..."}`). Users reading job results got raw JSON instead of the prose the model carefully wrote during finalization.

## The fix

Two changes:

1. **`progressiveOutputText`** now checks `FinalResponse` first (prose from finalization), then `FallbackText`, then falls back to JSON-marshaled `Progress` state. Previously it skipped `FinalResponse` entirely.

2. **Jobs runner** uses `progressiveOutputText()` to set `res.Response` instead of marshaling the entire envelope. The progressive metadata (`exit_reason`, etc.) is already stored in dedicated columns.

Priority order: `FinalResponse` (finalized prose) > `FallbackText` (last text stream) > `Progress` (JSON state, last resort).

## Tests

- Updated existing progressive envelope test to match new response format
- Added `TestJobsV2_ProgressiveLLM_FinalResponseProse` — verifies prose takes priority over JSON when `FinalResponse` is populated
