### PR TITLE
feat(chat): collapse large pastes into inline placeholders instead of flooding composer

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -94,18 +94,20 @@ type Model struct {
 	// Pending message context
 	files                   []FileAttachment // Attached files for next message
 	images                  []ImageAttachment
-	selectedImage           int      // -1 means no image chip selected
-	searchEnabled           bool     // Web search toggle
-	forceExternalSearch     bool     // Force external search tools even if provider supports native
-	disableExternalWebFetch bool     // Disable external read_url injection even when provider lacks native fetch
-	localTools              []string // Names of enabled local tools (read, write, etc.)
-	toolsStr                string   // Original tools setting (for session persistence)
-	mcpStr                  string   // Original MCP setting (for session persistence)
-	pendingInterjection     string   // Interrupt text waiting to be injected or cancelled
-	interruptRequestSeq     uint64   // Monotonic sequence for async interrupt classification
-	activeInterruptSeq      uint64   // Currently active async interrupt classification request
-	pendingInterruptUI      string   // UI state: "", "deciding", "interject"
-	interruptNotice         string   // One-line UI notice for recent interrupt actions
+	selectedImage           int            // -1 means no image chip selected
+	pasteChunks             map[int]string // Collapsed paste placeholders → actual content
+	pasteSeq                int            // Incrementing ID for paste placeholders
+	searchEnabled           bool           // Web search toggle
+	forceExternalSearch     bool           // Force external search tools even if provider supports native
+	disableExternalWebFetch bool           // Disable external read_url injection even when provider lacks native fetch
+	localTools              []string       // Names of enabled local tools (read, write, etc.)
+	toolsStr                string         // Original tools setting (for session persistence)
+	mcpStr                  string         // Original MCP setting (for session persistence)
+	pendingInterjection     string         // Interrupt text waiting to be injected or cancelled
+	interruptRequestSeq     uint64         // Monotonic sequence for async interrupt classification
+	activeInterruptSeq      uint64         // Currently active async interrupt classification request
+	pendingInterruptUI      string         // UI state: "", "deciding", "interject"
+	interruptNotice         string         // One-line UI notice for recent interrupt actions
 	// MCP (Model Context Protocol)
 	mcpManager *mcp.Manager
 	maxTurns   int

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -405,6 +405,7 @@ func (m *Model) cmdClear() (tea.Model, tea.Cmd) {
 	m.scrollOffset = 0
 	m.setTextareaValue("")
 	m.clearFiles()
+	m.pasteChunks = nil
 
 	// Reset engine state (compaction tracking, provider conversation IDs)
 	if m.engine != nil {
@@ -605,6 +606,7 @@ func (m *Model) cmdNew() (tea.Model, tea.Cmd) {
 	m.scrollOffset = 0
 	m.setTextareaValue("")
 	m.clearFiles()
+	m.pasteChunks = nil
 
 	// Reset engine state (compaction tracking, provider conversation IDs)
 	if m.engine != nil {

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -12,6 +13,10 @@ import (
 	"github.com/samsaffron/term-llm/internal/tui/inspector"
 	sessionsui "github.com/samsaffron/term-llm/internal/tui/sessions"
 )
+
+// pasteCollapseThreshold is the minimum length (in characters) of a paste
+// before it collapses into a placeholder instead of inline text.
+const pasteCollapseThreshold = 100
 
 // updateResumeBrowserMode handles updates while the embedded resume browser is active.
 func (m *Model) updateResumeBrowserMode(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -418,6 +423,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Clear input if not empty
 		if m.textarea.Value() != "" {
 			m.setTextareaValue("")
+			m.pasteChunks = nil
 		}
 		return m, nil
 	}
@@ -661,6 +667,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.handleSlashCommand(content)
 		}
 
+		// Expand inline paste placeholders back to real content before sending.
+		content = m.expandPastePlaceholders(content)
+
 		// Send message if not empty, or if there are pasted image attachments.
 		if content != "" || len(m.images) > 0 {
 			return m.sendMessage(content)
@@ -707,6 +716,27 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Update textarea for other keys (skip during streaming - no text input needed)
 	if !m.streaming {
+		// Intercept large pastes: replace content with an inline placeholder
+		// so the textarea stays compact. The placeholder is inserted at the
+		// cursor position and expanded back on send.
+		if msg.Paste {
+			text := string(msg.Runes)
+			if len(text) > pasteCollapseThreshold {
+				m.pasteSeq++
+				id := m.pasteSeq
+				if m.pasteChunks == nil {
+					m.pasteChunks = make(map[int]string)
+				}
+				m.pasteChunks[id] = text
+				placeholder := pastePlaceholder(id, text)
+				msg = tea.KeyMsg{
+					Type:  tea.KeyRunes,
+					Runes: []rune(placeholder),
+					Paste: true,
+				}
+			}
+		}
+
 		old := m.textarea.Value()
 		var cmd tea.Cmd
 		m.textarea, cmd = m.textarea.Update(msg)
@@ -722,6 +752,29 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 	return m, nil
+}
+
+// pastePlaceholder returns the inline placeholder text for a collapsed paste.
+func pastePlaceholder(id int, text string) string {
+	lines := strings.Count(text, "\n") + 1
+	if lines > 1 {
+		return fmt.Sprintf("[Pasted text #%d +%d lines]", id, lines)
+	}
+	return fmt.Sprintf("[Pasted text #%d +%d chars]", id, len(text))
+}
+
+// expandPastePlaceholders replaces all inline paste placeholders with their
+// actual content. Clears the pasteChunks map after expansion.
+func (m *Model) expandPastePlaceholders(content string) string {
+	if len(m.pasteChunks) == 0 {
+		return content
+	}
+	for id, text := range m.pasteChunks {
+		placeholder := pastePlaceholder(id, text)
+		content = strings.ReplaceAll(content, placeholder, text)
+	}
+	m.pasteChunks = nil
+	return content
 }
 
 func (m *Model) currentInterruptActivity() llm.InterruptActivity {

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -2,6 +2,8 @@ package chat
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -304,5 +306,117 @@ func TestHandleKeyMsg_StreamingEscCancelsActiveStream(t *testing.T) {
 	}
 	if m.streaming {
 		t.Fatal("expected esc to end streaming mode immediately")
+	}
+}
+
+func TestPasteCollapse_LargePasteBecomesInlinePlaceholder(t *testing.T) {
+	m := newTestChatModel(false)
+
+	// 100+ chars to trigger collapse
+	pasteText := strings.Repeat("abcdefghij", 11) // 110 chars
+
+	_, _ = m.handleKeyMsg(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(pasteText),
+		Paste: true,
+	})
+
+	// Placeholder should be in the textarea, not the literal paste
+	got := m.textarea.Value()
+	if got == pasteText {
+		t.Fatal("expected paste to be collapsed, but literal text appeared in textarea")
+	}
+	if !strings.Contains(got, "[Pasted text #1") {
+		t.Fatalf("expected inline placeholder in textarea, got %q", got)
+	}
+
+	// Actual content stored in pasteChunks map
+	if len(m.pasteChunks) != 1 {
+		t.Fatalf("expected 1 paste chunk, got %d", len(m.pasteChunks))
+	}
+	if m.pasteChunks[1] != pasteText {
+		t.Fatal("paste chunk content mismatch")
+	}
+}
+
+func TestPasteCollapse_SmallPasteGoesToTextarea(t *testing.T) {
+	m := newTestChatModel(false)
+
+	// Under 100 chars — should pass through
+	pasteText := "short paste that is under the hundred char threshold"
+
+	_, _ = m.handleKeyMsg(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(pasteText),
+		Paste: true,
+	})
+
+	if len(m.pasteChunks) != 0 {
+		t.Fatalf("expected no collapsed paste for short text, got %d", len(m.pasteChunks))
+	}
+	if got := m.textarea.Value(); got != pasteText {
+		t.Fatalf("expected literal paste in textarea, got %q", got)
+	}
+}
+
+func TestPasteCollapse_MultiplePastesGetUniquePlaceholders(t *testing.T) {
+	m := newTestChatModel(false)
+
+	longPaste := strings.Repeat("x", 101)
+	for i := 0; i < 3; i++ {
+		_, _ = m.handleKeyMsg(tea.KeyMsg{
+			Type:  tea.KeyRunes,
+			Runes: []rune(longPaste),
+			Paste: true,
+		})
+	}
+
+	if len(m.pasteChunks) != 3 {
+		t.Fatalf("expected 3 paste chunks, got %d", len(m.pasteChunks))
+	}
+
+	got := m.textarea.Value()
+	for i := 1; i <= 3; i++ {
+		placeholder := fmt.Sprintf("[Pasted text #%d", i)
+		if !strings.Contains(got, placeholder) {
+			t.Fatalf("expected %q in textarea, got %q", placeholder, got)
+		}
+	}
+}
+
+func TestPasteCollapse_ExpandPlaceholdersOnSend(t *testing.T) {
+	m := newTestChatModel(false)
+	content := strings.Repeat("y", 110)
+	m.pasteChunks = map[int]string{
+		1: content,
+	}
+
+	input := fmt.Sprintf("fix this: [Pasted text #1 +%d chars]", len(content))
+	expanded := m.expandPastePlaceholders(input)
+
+	expected := "fix this: " + content
+	if expanded != expected {
+		t.Fatalf("expected %q, got %q", expected, expanded)
+	}
+	if len(m.pasteChunks) != 0 {
+		t.Fatal("expected pasteChunks cleared after expansion")
+	}
+}
+
+func TestPasteCollapse_MultilinePlaceholderShowsLines(t *testing.T) {
+	m := newTestChatModel(false)
+
+	// Multi-line paste over 100 chars
+	pasteText := "line one is here with some extra text to pad\nline two also has plenty of content in it\nline three as well with more words\nline four rounds it out nicely"
+
+	_, _ = m.handleKeyMsg(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(pasteText),
+		Paste: true,
+	})
+
+	got := m.textarea.Value()
+	if !strings.Contains(got, "+4 lines]") {
+		t.Fatalf("expected '+4 lines' in placeholder, got %q", got)
 	}
 }

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -603,7 +603,6 @@ func (m *Model) renderStatusLine() string {
 	if len(m.images) > 0 {
 		fixedParts = append(fixedParts, fmt.Sprintf("%d image(s)", len(m.images)))
 	}
-
 	// Token usage counter (e.g., ~45K/136K) with optional cached segment
 	usagePart := ""
 	if m.engine != nil && m.engine.InputLimit() > 0 {

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -134,6 +134,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	m.files = nil
 	m.images = nil
 	m.selectedImage = -1
+	m.pasteChunks = nil
 
 	// Start streaming
 	m.streaming = true


### PR DESCRIPTION
## What

Pastes over 100 characters in the chat TUI composer are collapsed into compact inline placeholders instead of flooding the textarea.

A paste of 200 chars becomes `[Pasted text #1 +200 chars]` inserted right at the cursor. Multi-line pastes show `[Pasted text #1 +12 lines]`. Multiple pastes get unique IDs (`#1`, `#2`, etc.).

On send, all placeholders expand back to the original content transparently.

## Why

Middle-click pasting (or any large paste) in the terminal drowns the composer, making it impossible to see what you're typing or add context around the paste. This keeps the composer usable while preserving the full content for the LLM.

## How it works

- Pastes ≤100 chars pass through to the textarea as before
- Pastes >100 chars: runes are swapped for a placeholder before the textarea processes them, so the placeholder lands at the cursor position naturally
- Original content stored in a `pasteChunks` map keyed by paste ID
- `expandPastePlaceholders()` runs on send, replacing all placeholders with real content
- Placeholders are regular text in the textarea — select, backspace, delete all work normally
- Ctrl+K and `/clear` clean up paste state
