### PR TITLE
fix(chat): route middle-click paste through collapse logic

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -659,12 +659,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.handleTextareaMouse(msg) {
 			return m, nil
 		}
-		// Handle middle-click paste
+		// Handle middle-click paste: read primary selection and route through
+		// the same KeyMsg path as bracketed paste so collapse logic applies.
 		if msg.Button == tea.MouseButtonMiddle && msg.Action == tea.MouseActionPress {
 			text, err := clipboard.ReadPrimarySelection()
 			if err == nil && text != "" {
-				m.textarea.InsertString(text)
-				m.updateTextareaHeight()
+				return m.handleKeyMsg(tea.KeyMsg{
+					Type:  tea.KeyRunes,
+					Runes: []rune(text),
+					Paste: true,
+				})
 			}
 			return m, nil
 		}


### PR DESCRIPTION
## What

Routes middle-click paste through the same `handleKeyMsg` path as bracketed paste, so the collapse logic from PR #220 applies.

## Why

Middle-click paste reads from the primary selection via `clipboard.ReadPrimarySelection()` but then called `m.textarea.InsertString(text)` directly — bypassing the paste collapse. Large middle-click pastes still flooded the composer.

## Fix

Synthesize a `tea.KeyMsg{Paste: true}` with the primary selection content and pass it to `handleKeyMsg`. This gives middle-click paste the same inline placeholder treatment as Ctrl+V / bracketed paste: pastes over 100 chars collapse into `[Pasted text #1 +N lines]`.

One file changed, 7 lines.
