### PR TITLE
fix(claude-bin): allow root sandbox MCP tool runs

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -571,6 +571,23 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 			}
 		}
 
+	case "streamlined_text":
+		var streamlinedMsg claudeStreamlinedTextMessage
+		if err := json.Unmarshal([]byte(line), &streamlinedMsg); err != nil {
+			return nil
+		}
+		if streamlinedMsg.Text != "" {
+			if !safeSendEvent(ctx, events, Event{Type: EventTextDelta, Text: streamlinedMsg.Text}) {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				return fmt.Errorf("failed to emit claude streamlined text: stream closed")
+			}
+			if sawTextDelta != nil {
+				*sawTextDelta = true
+			}
+		}
+
 	case "assistant":
 		// Buffer assistant text as a fallback for providers/versions that
 		// don't emit stream_event text deltas.
@@ -588,12 +605,20 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 			if resultMsg.IsError && resultMsg.Result != "" {
 				return fmt.Errorf("claude API error: %s", resultMsg.Result)
 			}
-			if sawTextDelta != nil && assistantFallbackText != nil && !*sawTextDelta && strings.TrimSpace(*assistantFallbackText) != "" {
-				if !safeSendEvent(ctx, events, Event{Type: EventTextDelta, Text: *assistantFallbackText}) {
+
+			fallbackText := ""
+			if assistantFallbackText != nil {
+				fallbackText = strings.TrimSpace(*assistantFallbackText)
+			}
+			if fallbackText == "" {
+				fallbackText = strings.TrimSpace(resultMsg.Result)
+			}
+			if sawTextDelta != nil && !*sawTextDelta && fallbackText != "" {
+				if !safeSendEvent(ctx, events, Event{Type: EventTextDelta, Text: fallbackText}) {
 					if ctx.Err() != nil {
 						return ctx.Err()
 					}
-					return fmt.Errorf("failed to emit claude assistant fallback text: stream closed")
+					return fmt.Errorf("failed to emit claude result fallback text: stream closed")
 				}
 				*sawTextDelta = true
 			}
@@ -683,6 +708,16 @@ wait:
 // The events channel is passed to the MCP server for routing tool execution events.
 // The MCP server is kept alive across turns - call CleanupMCP() when the conversation ends.
 // Returns the args and the effective reasoning effort (if any).
+func (p *ClaudeBinProvider) claudeSandboxEnabled() bool {
+	if v, ok := p.extraEnv["IS_SANDBOX"]; ok {
+		return strings.TrimSpace(v) == "1"
+	}
+	if v, ok := p.extraEnv["CLAUDE_CODE_BUBBLEWRAP"]; ok {
+		return strings.TrimSpace(v) == "1"
+	}
+	return strings.TrimSpace(os.Getenv("IS_SANDBOX")) == "1" || strings.TrimSpace(os.Getenv("CLAUDE_CODE_BUBBLEWRAP")) == "1"
+}
+
 func (p *ClaudeBinProvider) buildArgs(ctx context.Context, req Request, events chan<- Event) ([]string, string) {
 	args := []string{
 		"--print",
@@ -693,7 +728,9 @@ func (p *ClaudeBinProvider) buildArgs(ctx context.Context, req Request, events c
 		"--setting-sources", "user", // Skip project CLAUDE.md files (term-llm provides its own context)
 	}
 	if getEuid() != 0 {
-		args = append(args, "--dangerously-skip-permissions") // Claude rejects this flag when running as root
+		args = append(args, "--dangerously-skip-permissions")
+	} else if p.claudeSandboxEnabled() {
+		args = append(args, "--permission-mode", "bypassPermissions")
 	}
 	if !p.enableHooks {
 		args = append(args, "--settings", `{"disableAllHooks":true}`)
@@ -1386,6 +1423,12 @@ type claudeContentBlock struct {
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
+}
+
+type claudeStreamlinedTextMessage struct {
+	Type      string `json:"type"`
+	Text      string `json:"text"`
+	SessionID string `json:"session_id"`
 }
 
 type claudeResultMessage struct {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -224,6 +224,61 @@ func TestDispatchClaudeEvents_FallsBackToAssistantTextWhenNoDeltas(t *testing.T)
 	}
 }
 
+func TestDispatchClaudeEvents_FallsBackToResultTextWhenNoAssistantOrDeltas(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"result","subtype":"success","is_error":false,"result":"result fallback text","usage":{"input_tokens":1,"output_tokens":3,"cache_read_input_tokens":0}}`
+	close(lines)
+
+	_, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, events)
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Type != EventTextDelta {
+			t.Fatalf("expected EventTextDelta, got %+v", ev)
+		}
+		if ev.Text != "result fallback text" {
+			t.Fatalf("unexpected result fallback text: %q", ev.Text)
+		}
+	default:
+		t.Fatal("expected result fallback text event when no assistant or deltas are present")
+	}
+}
+
+func TestDispatchClaudeEvents_EmitsStreamlinedText(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"streamlined_text","text":"streamlined assistant text"}`
+	lines <- `{"type":"result","subtype":"success","is_error":false,"result":"ignored final result","usage":{"input_tokens":1,"output_tokens":3,"cache_read_input_tokens":0}}`
+	close(lines)
+
+	_, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, events)
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Type != EventTextDelta {
+			t.Fatalf("expected EventTextDelta, got %+v", ev)
+		}
+		if ev.Text != "streamlined assistant text" {
+			t.Fatalf("unexpected streamlined text: %q", ev.Text)
+		}
+	default:
+		t.Fatal("expected streamlined text event")
+	}
+}
+
 func TestDispatchClaudeEvents_DoesNotDuplicateAssistantFallbackWhenDeltasPresent(t *testing.T) {
 	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event, 8)
@@ -404,7 +459,7 @@ func TestClaudeBinProvider_BuildArgsDangerousPermissionsRespectsEuid(t *testing.
 	origGetEuid := getEuid
 	defer func() { getEuid = origGetEuid }()
 
-	t.Run("non-root includes flag", func(t *testing.T) {
+	t.Run("non-root includes dangerous skip flag", func(t *testing.T) {
 		getEuid = func() int { return 1000 }
 		p := NewClaudeBinProvider("sonnet", nil)
 		args, _ := p.buildArgs(context.Background(), Request{}, nil)
@@ -412,15 +467,34 @@ func TestClaudeBinProvider_BuildArgsDangerousPermissionsRespectsEuid(t *testing.
 		if !strings.Contains(joined, "--dangerously-skip-permissions") {
 			t.Fatal("expected --dangerously-skip-permissions for non-root")
 		}
+		if strings.Contains(joined, "--permission-mode\nbypassPermissions") {
+			t.Fatal("did not expect bypassPermissions permission mode for non-root")
+		}
 	})
 
-	t.Run("root omits flag", func(t *testing.T) {
+	t.Run("root sandbox uses bypass permission mode", func(t *testing.T) {
+		getEuid = func() int { return 0 }
+		p := NewClaudeBinProvider("sonnet", map[string]string{"IS_SANDBOX": "1"})
+		args, _ := p.buildArgs(context.Background(), Request{}, nil)
+		joined := strings.Join(args, "\n")
+		if strings.Contains(joined, "--dangerously-skip-permissions") {
+			t.Fatal("expected claude-bin args to omit --dangerously-skip-permissions when running as root")
+		}
+		if !strings.Contains(joined, "--permission-mode\nbypassPermissions") {
+			t.Fatal("expected root sandbox runs to request bypassPermissions mode")
+		}
+	})
+
+	t.Run("root outside sandbox omits bypass flags", func(t *testing.T) {
 		getEuid = func() int { return 0 }
 		p := NewClaudeBinProvider("sonnet", nil)
 		args, _ := p.buildArgs(context.Background(), Request{}, nil)
 		joined := strings.Join(args, "\n")
 		if strings.Contains(joined, "--dangerously-skip-permissions") {
 			t.Fatal("expected claude-bin args to omit --dangerously-skip-permissions when running as root")
+		}
+		if strings.Contains(joined, "--permission-mode\nbypassPermissions") {
+			t.Fatal("did not expect bypassPermissions mode outside sandbox")
 		}
 	})
 }


### PR DESCRIPTION
## What

Fix `claude-bin` ask/agent runs in root sandboxed environments by switching Claude CLI to `--permission-mode bypassPermissions` instead of omitting permission bypass entirely.

Also make the parser more defensive by:

- handling `streamlined_text` output frames
- falling back to `result.result` when Claude returns final text without streamed deltas or assistant text blocks

## Why

The repro was:

```bash
term-llm ask --agent jarvis 'is seedancev2ai.com legit'
```

Under root with `IS_SANDBOX=1`, Claude CLI was started without any permission bypass flag. That caused MCP tool calls like `web_search` to be denied before term-llm could execute them, and the run terminated after a single tool-use turn with no assistant answer persisted.

With this change, root sandbox runs use Claude's supported bypass mode and the repro now completes with a normal answer.

## Verification

Built and tested in the worktree:

```bash
go test ./...
go build ./...
go build -o /tmp/term-llm-fix .
```

Confirmed the repro against the built binary:

```bash
/tmp/term-llm-fix --debug-raw ask --agent jarvis 'is seedancev2ai.com legit'
```

Before:
- tool permission denied
- `result` came back with `error_max_turns`
- no assistant text persisted

After:
- first turn executes `web_search`
- second turn resumes cleanly
- assistant text deltas stream and final answer is printed
