### PR TITLE
fix: no-store on index.html to prevent stale cache after deploy

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -52,7 +52,7 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.RawQuery, "v=") {
 			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		} else {
-			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		}
 		_, _ = w.Write(s.renderIndexHTML())
 		return


### PR DESCRIPTION
## What

Change `Cache-Control` on the explicit `index.html` route from `no-cache` to `no-cache, no-store, must-revalidate`, matching the existing SPA catch-all handler.

## Why

After deploying a new version (e.g. the multi-provider PR), browsers with a cached `index.html` would continue serving the old page. The JS/CSS assets are already versioned with `?v=<hash>` so they're safe to cache aggressively — but `index.html` itself must never be stored, since it's the entry point that loads those versioned assets.

`no-cache` (revalidate before use) was weaker than needed; `no-store` prevents the browser from writing `index.html` to its cache at all, eliminating the stale-UI-on-deploy problem.
