### PR TITLE
fix(mobile): hide sidebar with visibility+pointer-events to fix iOS Safari overlay bug

### DIFF
--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1940,9 +1940,11 @@
         display: flex;
         flex-direction: column;
         transform: translateX(-100%);
-        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.22s;
         box-shadow: none;
         padding-bottom: var(--safe-bottom);
+        visibility: hidden;
+        pointer-events: none;
       }
 
       .sidebar-rail {
@@ -1964,6 +1966,9 @@
       .sidebar.open {
         transform: translateX(0);
         box-shadow: 4px 0 20px rgba(0, 0, 0, 0.28);
+        visibility: visible;
+        pointer-events: auto;
+        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0s;
       }
 
       .sidebar-close {


### PR DESCRIPTION
## Problem

On iOS Safari, `position: fixed` elements inside a `position: fixed; overflow: hidden` container can have their `transform` ignored, causing the sidebar to render on top of the main content even when translated off-screen with `translateX(-100%)`.

## Fix

Add `visibility: hidden` + `pointer-events: none` to the closed sidebar state in the mobile media query, with a delayed visibility transition so the element hides only *after* the slide-out animation completes. On open, both are reset immediately (zero delay) so the sidebar is interactive as soon as it starts sliding in.

```css
/* closed — element hidden after 0.22s animation finishes */
.sidebar {
  transform: translateX(-100%);
  transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.22s;
  visibility: hidden;
  pointer-events: none;
}

/* open — visible and interactive immediately */
.sidebar.open {
  transform: translateX(0);
  transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0s;
  visibility: visible;
  pointer-events: auto;
}
```

CSS-only change, no JS changes needed. 6 lines added, 1 changed.