### PR TITLE
Add continuous tick for UI responsiveness during idle

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -585,6 +585,10 @@ func (m *Model) Init() tea.Cmd {
 	return tea.Batch(
 		textarea.Blink,
 		m.spinner.Tick,
+		// Continuous tick to keep UI responsive even when not streaming
+		tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
+			return tickMsg{}
+		}),
 	)
 }
 


### PR DESCRIPTION
I have noticed that sometimes the UI becomes stale after asking a question, and I must send a new message for the screen to update.

Adds a 100ms tick to keep the UI responsive even when not actively streaming, so key events are processed promptly.