### PR TITLE
feat: add --timeout flag to mcp run

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -108,6 +108,8 @@ type mcpToolCall struct {
 	args map[string]any
 }
 
+var mcpRunTimeout time.Duration
+
 var mcpRunCmd = &cobra.Command{
 	Use:   "run <server> <tool> [key=val|json] ...",
 	Short: "Run MCP tool(s) directly",
@@ -136,6 +138,7 @@ Examples:
 
 func init() {
 	mcpBrowseCmd.Flags().BoolVar(&mcpBrowseTUI, "no-tui", false, "Use simple CLI output instead of interactive browser")
+	mcpRunCmd.Flags().DurationVar(&mcpRunTimeout, "timeout", 30*time.Second, "Timeout for MCP server startup and tool execution")
 	rootCmd.AddCommand(mcpCmd)
 	mcpCmd.AddCommand(mcpListCmd)
 	mcpCmd.AddCommand(mcpBrowseCmd)
@@ -763,7 +766,7 @@ func mcpRun(cmd *cobra.Command, args []string) error {
 
 	client := mcp.NewClient(serverName, serverCfg)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), mcpRunTimeout)
 	defer cancel()
 
 	if err := client.Start(ctx); err != nil {


### PR DESCRIPTION
## Summary

- Adds a `--timeout` flag to `term-llm mcp run` (default: `30s`, matching current behaviour)
- The flag controls the `context.WithTimeout` deadline applied to MCP server startup and tool execution

## Motivation

Some MCP tools invoke long-running operations (e.g. LLM API calls that can take 15–20 s). The hardcoded 30 s deadline makes it impossible to reliably call these tools via `mcp run` since startup overhead eats into the budget. A configurable timeout unblocks these use cases without changing the default behaviour.

## Usage

```
term-llm mcp run --timeout 120s my-server my-slow-tool key=val
```