### PR TITLE
fix: call ForceCompletePendingTools before FlushAllRemaining at stream end

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1100,6 +1100,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.bumpContentVersion()
 				} else {
 					// In inline mode, print remaining content to scrollback
+					m.tracker.ForceCompletePendingTools()
 					result := m.tracker.FlushAllRemaining(m.width, 0, m.renderMd)
 					cmds = append(cmds, ui.ScrollbackPrintlnCommands(result.ToPrint, true)...)
 				}


### PR DESCRIPTION
## What

Call `ForceCompletePendingTools()` before `FlushAllRemaining()` in the `StreamEventDone` inline-mode path in `internal/tui/chat/chat.go`.

## Why

`FlushAllRemaining` explicitly skips any tool segment still in `ToolPending` state (see `tool_tracker.go:923-925`). When a stream ends with a tool that hasn't been marked complete yet, that segment — and any content buffered after it — is silently dropped. The symptom is the last assistant message being missing after the stream finishes; resizing the window triggers a re-render which makes it appear, masking the real issue.

`cmd/ask.go` already calls `ForceCompletePendingTools()` before `FlushAllRemaining` (lines 1371-1375). This PR applies the same pattern to the TUI chat inline path, which was missing it.

PR #226 ("add continuous tick for UI responsiveness during idle") attempted to address the symptom via a periodic re-render tick, but the tick handler only reschedules when `m.streaming == true` — so it fires once on `Init()` and dies, and wouldn't fix the data loss anyway.
