### PR TITLE
fix(edit): correct end-offset calculation in stripped/blank-filtered/fuzzy matchers

### DIFF
--- a/internal/edit/match.go
+++ b/internal/edit/match.go
@@ -149,8 +149,8 @@ func findStrippedMatch(content, search string) (MatchResult, bool) {
 			end := start
 			for k := 0; k < len(searchLines); k++ {
 				end += len(contentLines[i+k])
-				if i+k < len(contentLines)-1 {
-					end++ // newline
+				if k < len(searchLines)-1 {
+					end++ // newline between matched lines
 				}
 			}
 			// Handle trailing newline in search
@@ -226,8 +226,8 @@ func findBlankFilteredMatch(content, search string) (MatchResult, bool) {
 			end := start
 			for k := firstLineIdx; k <= lastLineIdx; k++ {
 				end += len(contentLines[k])
-				if k < len(contentLines)-1 {
-					end++ // newline
+				if k < lastLineIdx {
+					end++ // newline between matched lines
 				}
 			}
 			// Include trailing newline if search had one
@@ -381,8 +381,8 @@ func findFuzzyMatch(content, search string) (MatchResult, bool) {
 				end := start
 				for k := 0; k < len(searchLines); k++ {
 					end += len(contentLines[i+k])
-					if i+k < len(contentLines)-1 {
-						end++
+					if k < len(searchLines)-1 {
+						end++ // newline between matched lines
 					}
 				}
 				if strings.HasSuffix(search, "\n") && end < len(content) {

--- a/internal/edit/match_test.go
+++ b/internal/edit/match_test.go
@@ -206,6 +206,53 @@ func TestLevenshteinDistance(t *testing.T) {
 	}
 }
 
+// Regression tests for the trailing-newline offset bug:
+// When a match is not at the end of the file, the end byte offset must NOT
+// include the newline after the last matched line. If it did, ApplyMatch would
+// concatenate the replacement's last line with the following line (no separator).
+
+func TestApplyMatch_Stripped_MidFile(t *testing.T) {
+	// The matched block is in the middle of the file (line C follows it).
+	content := "line A\n\tline B\nline C\n"
+	// Stripped match: different indentation on line B
+	search := "line A\nline B"
+
+	result, err := FindMatch(content, search)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Level != MatchStripped {
+		t.Errorf("expected MatchStripped, got %v", result.Level)
+	}
+
+	got := ApplyMatch(content, result, "new A\nnew B")
+	want := "new A\nnew B\nline C\n"
+	if got != want {
+		t.Errorf("ApplyMatch result:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestApplyMatch_Fuzzy_MidFile(t *testing.T) {
+	// The matched block is in the middle of the file (line C follows it).
+	content := "line A\n\tfmt.Println(\"hello world\")\nline C\n"
+	// Fuzzy match: small typo in the search
+	search := "line A\n\tfmt.Prinltn(\"hello world\")"
+
+	result, err := FindMatch(content, search)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Level != MatchFuzzy {
+		t.Errorf("expected MatchFuzzy, got %v", result.Level)
+	}
+
+	got := ApplyMatch(content, result, "new A\nnew B")
+	want := "new A\nnew B\nline C\n"
+	if got != want {
+		t.Errorf("ApplyMatch result:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
 func TestLineSimilarity(t *testing.T) {
 	tests := []struct {
 		a, b   string


### PR DESCRIPTION
## Problem

When the edit matcher (stripped, blank-filtered, or fuzzy) computes the byte range of a matched block, it was using:

```go
if i+k < len(contentLines)-1 {
    end++ // newline
}
```

This adds a newline after the last matched line unless it happens to be the very last line of the file. The result: `content[match.End:]` starts with the next line's content (no leading newline), and since the replacement text also lacks a trailing newline, the two fragments concatenate — merging adjacent lines into one.

## Fix

Change the condition to:

```go
if k < len(searchLines)-1 {
    end++ // newline between matched lines
}
```

Newlines are now only added *between* matched lines. The existing `strings.HasSuffix(search, "\n")` guard already handles the case where the search pattern ends with a newline.

## Affected functions

- `findStrippedMatch`
- `findBlankFilteredMatch`
- `findFuzzyMatch`

All three had the same buggy condition.