### PR TITLE
fix: pre-seed modelsProviders cache in TestHandleModels_WithProviderParam

### DIFF
--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4019,7 +4019,13 @@ func TestHandleModels_WithProviderParam(t *testing.T) {
 			"anthropic": {Model: "claude-sonnet-4-6"},
 		},
 	}
-	srv := &serveServer{cfgRef: cfg}
+	// Pre-seed the cache so getModelsProvider doesn't try to construct a real
+	// Anthropic provider (which requires auth not present in CI).
+	mock := llm.NewMockProvider("anthropic")
+	srv := &serveServer{
+		cfgRef:          cfg,
+		modelsProviders: map[string]llm.Provider{"anthropic": mock},
+	}
 
 	// Without provider param — uses default
 	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)


### PR DESCRIPTION
## What

Pre-seed `modelsProviders` cache with a `MockProvider` in `TestHandleModels_WithProviderParam`.

## Why

`getModelsProvider` constructs a real Anthropic provider when the cache is empty. That requires `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, neither of which is present in CI — causing a 400 response and a failing test.

The fix pre-populates `srv.modelsProviders["anthropic"]` with a `MockProvider` so the cache hit path is taken and no real provider construction occurs.
