### PR TITLE
fix(serve): restore tool call visibility in web UI chat completions

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -54,6 +54,7 @@ var (
 	serveJobsWorkers            int
 	serveSetup                  bool
 	serveVerbose                bool
+	serveFilterServerTools      bool
 	serveSidebarSessions        string
 	serveToolMap                []string
 )
@@ -129,6 +130,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveSidebarSessions, "sidebar-sessions", "all", "Default web sidebar session categories: all or a comma-separated list like chat,web,ask,plan,exec")
 	serveCmd.Flags().BoolVar(&serveVerbose, "verbose", false, "Log API request/response summaries to stderr")
 	serveCmd.Flags().StringArrayVar(&serveToolMap, "tool-map", nil, "Map client tool name to server tool (repeatable, format ClientName:ServerName)")
+	serveCmd.Flags().BoolVar(&serveFilterServerTools, "suppress-server-tool-calls", false, "Hide server-executed tool calls from API responses (use when proxying to external clients)")
 
 	AddProviderFlag(serveCmd, &serveProvider)
 	AddDebugFlag(serveCmd, &serveDebug)
@@ -465,16 +467,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 		serveUI := hasWeb
 		s = &serveServer{
 			cfg: serveServerConfig{
-				host:            serveHost,
-				port:            servePort,
-				requireAuth:     requireAuth,
-				token:           token,
-				ui:              serveUI,
-				api:             hasAPI,
-				verbose:         serveVerbose,
-				basePath:        serveBasePath,
-				sidebarSessions: append([]string(nil), sidebarSessions...),
-				corsOrigins:     append([]string(nil), serveCORSOrigins...),
+				host:                serveHost,
+				port:                servePort,
+				requireAuth:         requireAuth,
+				token:               token,
+				ui:                  serveUI,
+				api:                 hasAPI,
+				suppressServerTools: serveFilterServerTools,
+				verbose:             serveVerbose,
+				basePath:            serveBasePath,
+				sidebarSessions:     append([]string(nil), sidebarSessions...),
+				corsOrigins:         append([]string(nil), serveCORSOrigins...),
 			},
 			sessionMgr:     sessionMgr,
 			jobsV2:         jobsV2,
@@ -720,16 +723,17 @@ func generateServeToken() (string, error) {
 }
 
 type serveServerConfig struct {
-	host            string
-	port            int
-	requireAuth     bool
-	token           string
-	ui              bool
-	api             bool
-	verbose         bool
-	basePath        string // e.g. "/ui" or "/chat", always without trailing slash
-	sidebarSessions []string
-	corsOrigins     []string
+	host                string
+	port                int
+	requireAuth         bool
+	token               string
+	ui                  bool
+	api                 bool
+	suppressServerTools bool
+	verbose             bool
+	basePath            string // e.g. "/ui" or "/chat", always without trailing slash
+	sidebarSessions     []string
+	corsOrigins         []string
 }
 
 // uiRoute returns the base-path with trailing slash, e.g. "/ui/" or "/chat/".

--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -146,14 +146,15 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Filter out server-executed tool calls from the result
-	filtered := make([]llm.ToolCall, 0, len(result.ToolCalls))
-	for _, call := range result.ToolCalls {
-		if !runtime.isServerExecutedTool(call.Name) {
-			filtered = append(filtered, call)
+	if s.cfg.suppressServerTools {
+		filtered := make([]llm.ToolCall, 0, len(result.ToolCalls))
+		for _, call := range result.ToolCalls {
+			if !runtime.isServerExecutedTool(call.Name) {
+				filtered = append(filtered, call)
+			}
 		}
+		result.ToolCalls = filtered
 	}
-	result.ToolCalls = filtered
 
 	model := llmReq.Model
 	if model == "" {
@@ -251,7 +252,7 @@ func (s *serveServer) streamAnthropicMessages(ctx context.Context, w http.Respon
 			// Suppress tool_use blocks for server-executed tools —
 			// the engine handles these internally and the client
 			// should only see the final text result.
-			if runtime.isServerExecutedTool(ev.Tool.Name) {
+			if s.cfg.suppressServerTools && runtime.isServerExecutedTool(ev.Tool.Name) {
 				return nil
 			}
 			toolSeen = true

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -107,14 +107,15 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Filter out server-executed tool calls from the result
-	filtered := make([]llm.ToolCall, 0, len(result.ToolCalls))
-	for _, call := range result.ToolCalls {
-		if !runtime.isServerExecutedTool(call.Name) {
-			filtered = append(filtered, call)
+	if s.cfg.suppressServerTools {
+		filtered := make([]llm.ToolCall, 0, len(result.ToolCalls))
+		for _, call := range result.ToolCalls {
+			if !runtime.isServerExecutedTool(call.Name) {
+				filtered = append(filtered, call)
+			}
 		}
+		result.ToolCalls = filtered
 	}
-	result.ToolCalls = filtered
 
 	model := llmReq.Model
 	if model == "" {
@@ -166,8 +167,7 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 			if ev.Tool == nil {
 				return nil
 			}
-			// Suppress tool calls for server-executed tools
-			if runtime.isServerExecutedTool(ev.Tool.Name) {
+			if s.cfg.suppressServerTools && runtime.isServerExecutedTool(ev.Tool.Name) {
 				return nil
 			}
 			toolCallSeen = true

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -160,14 +160,15 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Filter out server-executed tool calls from the result
-	filtered := make([]llm.ToolCall, 0, len(result.ToolCalls))
-	for _, call := range result.ToolCalls {
-		if !runtime.isServerExecutedTool(call.Name) {
-			filtered = append(filtered, call)
+	if s.cfg.suppressServerTools {
+		filtered := make([]llm.ToolCall, 0, len(result.ToolCalls))
+		for _, call := range result.ToolCalls {
+			if !runtime.isServerExecutedTool(call.Name) {
+				filtered = append(filtered, call)
+			}
 		}
+		result.ToolCalls = filtered
 	}
-	result.ToolCalls = filtered
 
 	model := llmReq.Model
 	if model == "" {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -765,8 +765,8 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 		if ev.Tool == nil {
 			return nil
 		}
-		// Suppress tool calls for server-executed tools
-		if runtime.isServerExecutedTool(ev.Tool.Name) {
+		// Suppress tool calls for server-executed tools in API mode
+		if s.cfg.suppressServerTools && runtime.isServerExecutedTool(ev.Tool.Name) {
 			return nil
 		}
 		state.toolsSeen = true

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4560,8 +4560,10 @@ func TestServeHTTPHandler_MountsAPIOnlyUnderBasePath(t *testing.T) {
 	}
 }
 
-func TestNonStreamingChat_FiltersServerExecutedToolCalls(t *testing.T) {
-	// Script: model calls the echo tool, then returns "done"
+func TestNonStreamingChat_ShowsServerExecutedToolCalls(t *testing.T) {
+	// Script: model calls the echo tool (server-executed), then returns "done".
+	// The chat completions endpoint is used by the web UI, which needs to see
+	// tool calls so it can display them. They must NOT be filtered here.
 	provider := llm.NewMockProvider("mock").
 		AddToolCall("call-1", "echo", map[string]any{"input": "hi"}).
 		AddTextResponse("done")
@@ -4598,9 +4600,10 @@ func TestNonStreamingChat_FiltersServerExecutedToolCalls(t *testing.T) {
 	}
 	choices := result["choices"].([]any)
 	msg := choices[0].(map[string]any)["message"].(map[string]any)
-	// "echo" is a server-executed tool — it should be filtered from the response
-	if msg["tool_calls"] != nil {
-		t.Fatalf("server-executed tool calls should be filtered; got tool_calls: %v", msg["tool_calls"])
+	// "echo" is server-executed but the chat completions handler must pass tool
+	// calls through so the web UI can display them.
+	if msg["tool_calls"] == nil {
+		t.Fatalf("expected tool_calls to be visible in chat completions response, got nil")
 	}
 	if msg["content"] != "done" {
 		t.Fatalf("expected final text 'done', got %v", msg["content"])
@@ -4626,7 +4629,7 @@ func TestNonStreamingResponses_FiltersServerExecutedToolCalls(t *testing.T) {
 		return rt, nil
 	}
 	mgr := newServeSessionManager(time.Minute, 100, factory)
-	srv := &serveServer{sessionMgr: mgr}
+	srv := &serveServer{sessionMgr: mgr, cfg: serveServerConfig{suppressServerTools: true}}
 
 	body := `{"model":"test","input":"call echo"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))


### PR DESCRIPTION
## What

Add `--suppress-server-tool-calls` flag to `serve` and gate all `isServerExecutedTool` suppression on it, uniformly across all handlers.

## Why

v0.0.135 introduced tool call suppression in the handlers to hide server-executed tools from external API clients (Claude Code). The suppression was hardcoded in `serve_handlers_anthropic.go` and `serve_handlers_responses.go`, and accidentally added to `serve_handlers_chat.go` which is also used by the web UI.

The right fix is not just removing the chat handler suppression — it is making the behaviour explicitly opt-in via a flag, so it is consistent and intentional regardless of which platform is running.

## Changes

- `serveServerConfig.suppressServerTools bool` — new field
- `--suppress-server-tool-calls` CLI flag (default: false)
- All four suppression sites (`chat`, `anthropic`, `responses`, `response_runs`) now gate on `s.cfg.suppressServerTools`
- The flag is OFF by default, so web UI always sees tool calls
- Pass `--suppress-server-tool-calls` when running as a proxy for external clients (e.g. Claude Code)

## Tests

- `TestNonStreamingChat_ShowsServerExecutedToolCalls` — passes without flag (web UI behaviour)
- `TestNonStreamingResponses_FiltersServerExecutedToolCalls` — now sets `suppressServerTools: true` explicitly

Fixes: tool calls not visible in web UI after v0.0.135.