### PR TITLE
fix(docker): use compose gpu support for jarvis

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,6 @@ RUN pacman -Syu --noconfirm && \
       openbsd-netcat \
       strace \
       gnupg \
-      nvidia-utils \
       uv \
       nspr \
       nss \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,13 +11,10 @@ services:
       lan:
         ipv4_address: 10.0.0.52
     restart: unless-stopped
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+    gpus: all
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
 volumes:
   jarvis-state:


### PR DESCRIPTION
## What

Fix Docker Compose GPU configuration for the `jarvis` service by switching from Swarm-style device reservations to standard Compose GPU support.

Also remove `nvidia-utils` from the container image so the container relies on the host-injected NVIDIA userspace instead of bundling its own potentially mismatched driver utilities.

## Why

The current container sees `/dev/nvidia*` device nodes but cannot use the GPU correctly. The compose file currently uses:

```yaml
deploy:
  resources:
    reservations:
      devices:
        - driver: nvidia
          count: all
          capabilities: [gpu]
```

That syntax is for Swarm deployments and is not the right way to request GPUs in normal `docker compose` usage.

At the same time, bundling `nvidia-utils` in the image can introduce host/container driver version skew, which is exactly the kind of nonsense that wastes an afternoon.

This change makes the deployment match regular Compose expectations:

```yaml
gpus: all
environment:
  NVIDIA_VISIBLE_DEVICES: all
  NVIDIA_DRIVER_CAPABILITIES: compute,utility
```

## Expected result

After rebuilding the `jarvis` container, GPU access should be wired correctly for standard Compose deployments, and the container should stop carrying its own conflicting NVIDIA userspace stack.
