### PR TITLE
feat: persist transcription audio uploads to configurable directory

### DIFF
--- a/cmd/serve_transcribe.go
+++ b/cmd/serve_transcribe.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
@@ -103,6 +104,20 @@ func (s *serveServer) handleTranscribe(w http.ResponseWriter, r *http.Request) {
 	if written == 0 {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "audio file is empty")
 		return
+	}
+
+	if saveDir := s.cfgRef.Transcription.SaveDir; saveDir != "" {
+		if mkErr := os.MkdirAll(saveDir, 0755); mkErr == nil {
+			ts := time.Now().Format("20060102-150405")
+			savePath := filepath.Join(saveDir, ts+"-"+filename)
+			if src, openErr := os.Open(tempPath); openErr == nil {
+				if dst, createErr := os.Create(savePath); createErr == nil {
+					_, _ = io.Copy(dst, src)
+					dst.Close()
+				}
+				src.Close()
+			}
+		}
 	}
 
 	transcript, err := llm.TranscribeWithConfig(r.Context(), s.cfgRef, tempPath, strings.TrimSpace(r.FormValue("language")), "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,6 +344,7 @@ type ImageDebugConfig struct {
 type TranscriptionConfig struct {
 	Provider string `mapstructure:"provider"` // named provider from providers map; default "openai"
 	Model    string `mapstructure:"model"`    // optional model override
+	SaveDir  string `mapstructure:"save_dir"` // if set, persist each uploaded audio file here
 }
 
 // EmbedConfig configures text embedding generation
@@ -1139,6 +1140,7 @@ var KnownKeys = map[string]bool{
 	// Transcription
 	"transcription.provider": true,
 	"transcription.model":    true,
+	"transcription.save_dir": true,
 
 	// Embed
 	"embed.provider":        true,


### PR DESCRIPTION
## What

Adds `transcription.save_dir` config option. When set, every audio file uploaded to the `/transcribe` endpoint is copied to that directory with a timestamp prefix before transcription runs:

```
<save_dir>/20060102-150405-voice-note.webm
```

The temp file is still cleaned up as before — `save_dir` gets its own persistent copy.

## Why

Enables reuse of transcription audio as `ref_audio` for Voxtral TTS voice cloning without requiring a separate upload step. Configure once:

```yaml
transcription:
  save_dir: /root/voice-recordings
```

Then pass any saved file directly to the TTS API as reference audio.
