### PR TITLE
feat: live sidebar session status with adaptive polling

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -824,6 +824,7 @@ func (s *serveServer) httpHandler() http.Handler {
 	}
 
 	inner.HandleFunc("/images/", s.auth(s.cors(s.handleImage)))
+	inner.HandleFunc("/v1/sessions/status", s.auth(s.cors(s.handleSessionsStatus)))
 	inner.HandleFunc("/v1/sessions/", s.auth(s.cors(s.handleSessionByID)))
 	inner.HandleFunc("/v1/push/subscribe", s.auth(s.cors(s.handlePushSubscribe)))
 

--- a/cmd/serve_handlers_status.go
+++ b/cmd/serve_handlers_status.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func (s *serveServer) handleSessionsStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+		return
+	}
+	if s.store == nil {
+		writeOpenAIError(w, http.StatusServiceUnavailable, "server_error", "session store not available")
+		return
+	}
+
+	categories, err := parseSidebarSessionCategories(r.URL.Query().Get("categories"), false)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	includeArchived := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_archived")), "1") ||
+		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_archived")), "true")
+
+	sessions, err := s.store.List(r.Context(), session.ListOptions{
+		Limit:      100,
+		Archived:   includeArchived,
+		Categories: categories,
+	})
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to list sessions")
+		return
+	}
+
+	// Collect active session IDs from in-memory state without touching runtimes.
+	activeIDs := s.activeSessionIDs()
+
+	type statusEntry struct {
+		ID         string `json:"id"`
+		ShortTitle string `json:"short_title"`
+		LongTitle  string `json:"long_title"`
+		ActiveRun  bool   `json:"active_run,omitempty"`
+		MsgCount   int    `json:"message_count"`
+	}
+
+	result := make([]statusEntry, 0, len(sessions))
+	for _, sess := range sessions {
+		result = append(result, statusEntry{
+			ID:         sess.ID,
+			ShortTitle: sess.PreferredShortTitle(),
+			LongTitle:  sess.PreferredLongTitle(),
+			ActiveRun:  activeIDs[sess.ID],
+			MsgCount:   sess.MessageCount,
+		})
+	}
+
+	body, _ := json.Marshal(map[string]any{"sessions": result})
+
+	// ETag for conditional requests — avoids re-transmitting unchanged data.
+	hash := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(hash[:8]) + `"`
+
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", "no-cache")
+	if match := r.Header.Get("If-None-Match"); match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// activeSessionIDs returns the set of session IDs that have an active run,
+// either via the session manager (in-memory runtimes) or via detached
+// response runs. It does NOT touch runtimes (no TTL refresh).
+func (s *serveServer) activeSessionIDs() map[string]bool {
+	result := make(map[string]bool)
+	if s.sessionMgr != nil {
+		for id, active := range s.sessionMgr.ActiveSessionIDs() {
+			if active {
+				result[id] = true
+			}
+		}
+	}
+	if s.responseRuns != nil {
+		for id := range s.responseRuns.ActiveSessionIDs() {
+			result[id] = true
+		}
+	}
+	return result
+}

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -641,6 +641,18 @@ func (m *responseRunManager) activeRunID(sessionID string) string {
 	return m.activeBySession[sessionID]
 }
 
+// ActiveSessionIDs returns session IDs that currently have an active
+// response run. Does not touch any runtime TTLs.
+func (m *responseRunManager) ActiveSessionIDs() map[string]bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]bool, len(m.activeBySession))
+	for sid := range m.activeBySession {
+		result[sid] = true
+	}
+	return result
+}
+
 func (m *responseRunManager) Close() {
 	m.mu.Lock()
 	if m.closed {

--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -274,6 +274,21 @@ func (m *serveSessionManager) GetOrCreateWith(ctx context.Context, id string, cr
 	return inflight.rt, nil
 }
 
+// ActiveSessionIDs returns the set of session IDs that currently have an
+// active run (activeInterrupt != nil). Unlike Get, this does NOT touch
+// runtimes, so it won't extend their TTL.
+func (m *serveSessionManager) ActiveSessionIDs() map[string]bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]bool, len(m.sessions))
+	for id, rt := range m.sessions {
+		if rt.hasActiveRun() {
+			result[id] = true
+		}
+	}
+	return result
+}
+
 func (m *serveSessionManager) Close() {
 	m.mu.Lock()
 	if m.closed {

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -999,6 +999,41 @@ const renderMessages = (forceScroll = false) => {
   updateHeader();
 };
 
+const updateSidebarStatus = (statusSessions) => {
+  if (!Array.isArray(statusSessions)) return false;
+  let changed = false;
+  for (const entry of statusSessions) {
+    const row = elements.sessionGroups.querySelector(`.session-row[data-session-id="${CSS.escape(entry.id)}"]`);
+    if (!row) continue;
+    const wasActive = row.classList.contains('is-active');
+    row.classList.toggle('is-active', Boolean(entry.active_run));
+    if (wasActive !== Boolean(entry.active_run)) changed = true;
+
+    const titleEl = row.querySelector('.session-title');
+    if (titleEl && entry.short_title && titleEl.textContent !== entry.short_title) {
+      titleEl.textContent = entry.short_title;
+      if (entry.long_title) titleEl.title = entry.long_title;
+      changed = true;
+    }
+
+    const metaEl = row.querySelector('.session-meta');
+    if (metaEl && entry.message_count != null) {
+      const count = entry.message_count;
+      const local = state.sessions.find(s => s.id === entry.id);
+      if (local) {
+        if (entry.short_title) local.title = entry.short_title;
+        if (entry.long_title) local.longTitle = entry.long_title;
+        local.messageCount = count;
+      }
+      const parts = [`${count} message${count === 1 ? '' : 's'}`];
+      if (local?.archived) parts.push('hidden');
+      parts.push(relativeTime(local?.created || Date.now()));
+      metaEl.textContent = parts.join(' · ');
+    }
+  }
+  return changed;
+};
+
 Object.assign(app, {
   openSidebar,
   closeSidebar,
@@ -1008,6 +1043,7 @@ Object.assign(app, {
   toggleSidebarCollapsed,
   updateHeader,
   renderSidebar,
+  updateSidebarStatus,
   directionForText,
   applyTextDirection,
   createInterruptBadgeNode,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -11,9 +11,67 @@ const {
   connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, isNearBottom,
   openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
   requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD, HEARTBEAT_ABORT_REASON,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, renderAttachments
+  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, renderAttachments,
+  updateSidebarStatus
 } = app;
 let sessionStatePollTimer = null;
+
+// ===== Sidebar status polling =====
+const SIDEBAR_POLL_ACTIVE = 2000;
+const SIDEBAR_POLL_IDLE = 30000;
+let sidebarStatusTimer = null;
+let sidebarStatusEtag = null;
+let sidebarHasActive = false;
+
+const stopSidebarStatusPoll = () => {
+  if (sidebarStatusTimer !== null) {
+    clearTimeout(sidebarStatusTimer);
+    sidebarStatusTimer = null;
+  }
+};
+
+const pollSidebarStatus = async () => {
+  stopSidebarStatusPoll();
+  if (document.visibilityState === 'hidden') return;
+
+  try {
+    const params = new URLSearchParams();
+    const categories = state.sidebarSessionCategories;
+    if (Array.isArray(categories) && categories.length > 0 && !categories.includes('all')) {
+      params.set('categories', categories.join(','));
+    }
+    if (state.showHiddenSessions) params.set('include_archived', '1');
+    const query = params.toString();
+
+    const headers = requestHeaders('');
+    if (sidebarStatusEtag) headers['If-None-Match'] = sidebarStatusEtag;
+
+    const resp = await fetch(`${UI_PREFIX}/v1/sessions/status${query ? `?${query}` : ''}`, { headers });
+
+    if (resp.status === 304) {
+      // No change — keep current active state, schedule next poll
+    } else if (resp.ok) {
+      const etag = resp.headers.get('ETag');
+      if (etag) sidebarStatusEtag = etag;
+      const data = await resp.json();
+      if (Array.isArray(data.sessions)) {
+        sidebarHasActive = data.sessions.some(s => s.active_run);
+        updateSidebarStatus(data.sessions);
+      }
+    }
+  } catch (_e) {
+    // Network error — just retry on next interval
+  }
+
+  const delay = sidebarHasActive ? SIDEBAR_POLL_ACTIVE : SIDEBAR_POLL_IDLE;
+  sidebarStatusTimer = setTimeout(pollSidebarStatus, delay);
+};
+
+const startSidebarStatusPoll = () => {
+  stopSidebarStatusPoll();
+  sidebarStatusEtag = null;
+  pollSidebarStatus();
+};
 
 const createAndSwitchToFreshSession = async () => {
   await switchToDraftSession({ clearComposer: true, focusPrompt: true });
@@ -667,6 +725,7 @@ const initialize = async () => {
 
     // Merge server-side sessions after successful auth
     await mergeServerSessions();
+    startSidebarStatusPoll();
     if (!state.draftSessionActive && !getActiveSession()) {
       ensureActiveSession();
       renderMessages(true);
@@ -917,8 +976,10 @@ window.addEventListener('popstate', async () => {
 document.addEventListener('visibilitychange', async () => {
   if (document.visibilityState !== 'visible') {
     flushStreamPersistence();
+    stopSidebarStatusPoll();
     return;
   }
+  startSidebarStatusPoll();
   const session = getActiveSession();
   if (!session) return;
 
@@ -990,6 +1051,8 @@ Object.assign(app, {
   syncActiveSessionFromServer,
   applyServerSessionSummary,
   mergeServerSessions,
+  startSidebarStatusPoll,
+  stopSidebarStatusPoll,
   promptRenameSession,
   setSessionArchived,
   setSessionPinned,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -428,6 +428,24 @@
       white-space: nowrap;
     }
 
+    .session-row.is-active .session-title::before {
+      content: '';
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: #22c55e;
+      margin-right: 0.4em;
+      flex-shrink: 0;
+      animation: pulse-dot 1.8s ease-in-out infinite;
+      vertical-align: middle;
+    }
+
+    @keyframes pulse-dot {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.35; }
+    }
+
     .session-row-menu {
       position: absolute;
       top: 0.4rem;


### PR DESCRIPTION
## What

Adds a bulk status endpoint and client-side polling so the sidebar shows which sessions have an active run (pulsing green dot) and picks up title/message-count changes without a full page reload.

## Backend: `GET /v1/sessions/status`

- Returns all sessions with `active_run` flag, titles, and `message_count`
- Respects `categories` and `include_archived` query params (same as sidebar list)
- **ETag/304**: SHA256 of response body → `ETag` header; honours `If-None-Match` so idle polls cost almost nothing
- `activeSessionIDs()` helper merges live session manager state with detached response-run state, without calling `Touch()` (no TTL extension)

## Frontend: adaptive polling

- **2 s** when any session has an active run
- **30 s** when all sessions are idle
- **Stops entirely** when the tab is hidden (Visibility API); resumes immediately on return
- ETag passed on every request; 304s are no-ops
- `updateSidebarStatus()` patches existing DOM rows in-place — no full sidebar rebuild

## Visual

Active sessions get `.is-active` class → pulsing green dot via `::before` pseudo-element on `.session-title`.

## Files changed

| File | Change |
|---|---|
| `cmd/serve_handlers_status.go` | New bulk status handler |
| `cmd/serve.go` | Route registration (before trailing-slash pattern) |
| `cmd/serve_session.go` | `ActiveSessionIDs()` on session manager (no Touch) |
| `cmd/serve_response_runs.go` | `ActiveSessionIDs()` on response run manager |
| `internal/serveui/static/app-render.js` | `updateSidebarStatus()` DOM patcher |
| `internal/serveui/static/app-sessions.js` | Polling lifecycle + visibility hooks |
| `internal/serveui/static/app.css` | Pulsing dot styles |