### PR TITLE
feat: platform developer messages

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -271,8 +271,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
 
 	agentName := ""
+	var agentPlatformMsgs agents.PlatformMessagesConfig
 	if agent != nil {
 		agentName = agent.Name
+		agentPlatformMsgs = agent.PlatformMessages
 	}
 
 	store, storeCleanup := InitSessionStore(cfg, cmd.ErrOrStderr())
@@ -370,6 +372,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 			toolsSetting:        settings.Tools,
 			mcpSetting:          settings.MCP,
 			agentName:           agentName,
+			platform:            "web",
+			platformMessages:    agentPlatformMsgs,
 		}
 		if toolMgr != nil {
 			imageBaseURL := ""
@@ -412,6 +416,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Tools:                  settings.Tools,
 		MCP:                    settings.MCP,
 		Agent:                  agentName,
+		PlatformMessages:       agentPlatformMsgs,
 		Store:                  store,
 		NewSession: func(ctx context.Context) (*serve.SessionRuntime, error) {
 			rt, err := factory(ctx)

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -19,41 +20,44 @@ import (
 )
 
 type serveRuntime struct {
-	mu                  sync.Mutex
-	interruptMu         sync.Mutex
-	responseMu          sync.Mutex // guards lastResponseID and responseIDs
-	askUserMu           sync.Mutex
-	approvalMu          sync.Mutex
-	uiStateMu           sync.Mutex
-	provider            llm.Provider
-	providerKey         string
-	engine              *llm.Engine
-	toolMgr             *tools.ToolManager
-	mcpManager          *mcp.Manager
-	store               session.Store
-	systemPrompt        string
-	history             []llm.Message
-	search              bool
-	toolsSetting        string
-	mcpSetting          string
-	agentName           string
-	sessionMeta         *session.Session
-	forceExternalSearch bool
-	maxTurns            int
-	toolMap             map[string]string
-	debug               bool
-	debugRaw            bool
-	defaultModel        string
-	lastUsedUnixNano    atomic.Int64
-	activeInterrupt     *runtimeInterruptState
-	lastResponseID      string
-	responseIDs         []string
-	cumulativeUsage     llm.Usage
-	pendingAskUsers     map[string]*servePendingAskUser
-	pendingApprovals    map[string]*servePendingApproval
-	approvalEventFunc   func(event string, data map[string]any) error
-	approvalCtx         context.Context
-	lastUIRunError      string
+	mu                   sync.Mutex
+	interruptMu          sync.Mutex
+	responseMu           sync.Mutex // guards lastResponseID and responseIDs
+	askUserMu            sync.Mutex
+	approvalMu           sync.Mutex
+	uiStateMu            sync.Mutex
+	provider             llm.Provider
+	providerKey          string
+	engine               *llm.Engine
+	toolMgr              *tools.ToolManager
+	mcpManager           *mcp.Manager
+	store                session.Store
+	systemPrompt         string
+	history              []llm.Message
+	search               bool
+	toolsSetting         string
+	mcpSetting           string
+	agentName            string
+	sessionMeta          *session.Session
+	forceExternalSearch  bool
+	maxTurns             int
+	toolMap              map[string]string
+	debug                bool
+	debugRaw             bool
+	defaultModel         string
+	lastUsedUnixNano     atomic.Int64
+	activeInterrupt      *runtimeInterruptState
+	lastResponseID       string
+	responseIDs          []string
+	cumulativeUsage      llm.Usage
+	pendingAskUsers      map[string]*servePendingAskUser
+	pendingApprovals     map[string]*servePendingApproval
+	approvalEventFunc    func(event string, data map[string]any) error
+	approvalCtx          context.Context
+	lastUIRunError       string
+	platform             string
+	platformMessages     agents.PlatformMessagesConfig
+	lastInjectedPlatform string
 }
 
 type runtimeInterruptState struct {
@@ -381,6 +385,13 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		baseHistory = nil
 		rt.engine.ResetConversation()
 		rt.cumulativeUsage = llm.Usage{}
+		rt.lastInjectedPlatform = ""
+	}
+
+	if devText := rt.platformMessages.For(rt.platform); devText != "" && rt.lastInjectedPlatform != rt.platform {
+		devMsg := llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: devText}}}
+		inputMessages = append([]llm.Message{devMsg}, inputMessages...)
+		rt.lastInjectedPlatform = rt.platform
 	}
 
 	runCtx, runCancel := context.WithCancel(ctx)

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -16,6 +16,29 @@ import (
 // validCustomToolNameRE matches valid custom tool names: lowercase letter, then lowercase alphanumeric or underscore.
 var validCustomToolNameRE = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
+// PlatformMessagesConfig holds per-platform developer messages that are injected
+// at the start of each new conversation session.
+type PlatformMessagesConfig struct {
+	Web      string `yaml:"web_developer_message,omitempty"`
+	Telegram string `yaml:"telegram_developer_message,omitempty"`
+	Chat     string `yaml:"chat_developer_message,omitempty"`
+}
+
+// For returns the developer message for the given platform name ("web", "telegram", "chat").
+// Returns empty string when no message is configured for that platform.
+func (p PlatformMessagesConfig) For(platform string) string {
+	switch platform {
+	case "web":
+		return p.Web
+	case "telegram":
+		return p.Telegram
+	case "chat":
+		return p.Chat
+	default:
+		return ""
+	}
+}
+
 // Agent represents a named configuration bundle.
 type Agent struct {
 	// Metadata
@@ -91,6 +114,10 @@ type Agent struct {
 
 	// GistID for syncing with GitHub Gists (set on export/import)
 	GistID string `yaml:"gist_id,omitempty"`
+
+	// PlatformMessages holds developer messages injected at the start of each
+	// new conversation session, keyed by platform.
+	PlatformMessages PlatformMessagesConfig `yaml:"platform_messages,omitempty"`
 
 	// System prompt (loaded from system.md + included files)
 	SystemPrompt string `yaml:"-"`

--- a/internal/agents/agent_test.go
+++ b/internal/agents/agent_test.go
@@ -682,6 +682,43 @@ func TestValidateCustomTools(t *testing.T) {
 	}
 }
 
+func TestPlatformMessagesConfig_For(t *testing.T) {
+	cfg := PlatformMessagesConfig{
+		Web:      "You are a web assistant",
+		Telegram: "You are a telegram bot",
+		Chat:     "You are a CLI helper",
+	}
+
+	tests := []struct {
+		platform string
+		want     string
+	}{
+		{"web", "You are a web assistant"},
+		{"telegram", "You are a telegram bot"},
+		{"chat", "You are a CLI helper"},
+		{"unknown", ""},
+		{"jobs", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			got := cfg.For(tt.platform)
+			if got != tt.want {
+				t.Errorf("For(%q) = %q, want %q", tt.platform, got, tt.want)
+			}
+		})
+	}
+
+	// Empty config returns "" for all platforms
+	empty := PlatformMessagesConfig{}
+	for _, p := range []string{"web", "telegram", "chat"} {
+		if got := empty.For(p); got != "" {
+			t.Errorf("empty config For(%q) = %q, want empty", p, got)
+		}
+	}
+}
+
 func containsSubstr(s, sub string) bool {
 	if len(sub) == 0 {
 		return true

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -603,13 +603,23 @@ func buildAnthropicMessages(messages []Message) (string, []anthropic.MessagePara
 
 	var systemParts []string
 	var out []anthropic.MessageParam
+	var pendingDev string
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case RoleSystem:
 			systemParts = append(systemParts, collectTextParts(msg.Parts))
+		case RoleDeveloper:
+			// Anthropic has no native developer role. Buffer the text and prepend
+			// it into the next user turn wrapped in <developer> tags.
+			pendingDev = collectTextParts(msg.Parts)
 		case RoleUser:
-			blocks := buildAnthropicBlocks(msg.Parts, false)
+			parts := msg.Parts
+			if pendingDev != "" {
+				parts = prependTextToParts(fmt.Sprintf("<developer>\n%s\n</developer>\n\n", pendingDev), parts)
+				pendingDev = ""
+			}
+			blocks := buildAnthropicBlocks(parts, false)
 			if len(blocks) > 0 {
 				m := anthropic.NewUserMessage(blocks...)
 				if msg.CacheAnchor {
@@ -638,13 +648,21 @@ func buildAnthropicBetaMessages(messages []Message) (string, []anthropic.BetaMes
 
 	var systemParts []string
 	var out []anthropic.BetaMessageParam
+	var pendingDev string
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case RoleSystem:
 			systemParts = append(systemParts, collectTextParts(msg.Parts))
+		case RoleDeveloper:
+			pendingDev = collectTextParts(msg.Parts)
 		case RoleUser:
-			blocks := buildAnthropicBetaBlocks(msg.Parts, false)
+			parts := msg.Parts
+			if pendingDev != "" {
+				parts = prependTextToParts(fmt.Sprintf("<developer>\n%s\n</developer>\n\n", pendingDev), parts)
+				pendingDev = ""
+			}
+			blocks := buildAnthropicBetaBlocks(parts, false)
 			if len(blocks) > 0 {
 				m := anthropic.NewBetaUserMessage(blocks...)
 				if msg.CacheAnchor {
@@ -669,6 +687,20 @@ func buildAnthropicBetaMessages(messages []Message) (string, []anthropic.BetaMes
 	}
 
 	return strings.Join(systemParts, "\n\n"), out
+}
+
+// prependTextToParts prepends prefix to the first PartText part in parts,
+// or inserts a new text part at the front if none exists.
+func prependTextToParts(prefix string, parts []Part) []Part {
+	for i, p := range parts {
+		if p.Type == PartText {
+			out := make([]Part, len(parts))
+			copy(out, parts)
+			out[i].Text = prefix + out[i].Text
+			return out
+		}
+	}
+	return append([]Part{{Type: PartText, Text: prefix}}, parts...)
 }
 
 func prepareAnthropicMessages(messages []Message) []Message {

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -906,5 +907,79 @@ func TestBuildAnthropicTools_ToolHasSchema(t *testing.T) {
 	schema := tools[0].OfTool.InputSchema
 	if schema.Type != constant.Object("object") {
 		t.Fatalf("expected schema type=object")
+	}
+}
+
+func TestBuildAnthropicMessages_DeveloperRole(t *testing.T) {
+	messages := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "Be concise"}}},
+		UserText("Hello"),
+	}
+
+	_, out := buildAnthropicMessages(messages)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message (developer merged into user), got %d", len(out))
+	}
+	if out[0].Role != anthropic.MessageParamRoleUser {
+		t.Fatalf("expected user role, got %v", out[0].Role)
+	}
+	if len(out[0].Content) != 1 || out[0].Content[0].OfText == nil {
+		t.Fatalf("expected single text block, got %#v", out[0].Content)
+	}
+	got := out[0].Content[0].OfText.Text
+	want := "<developer>\nBe concise\n</developer>\n\nHello"
+	if got != want {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+}
+
+func TestBuildAnthropicMessages_DeveloperRoleNotMergedWithoutUser(t *testing.T) {
+	// Developer message at end with no following user message — should be dropped
+	messages := []Message{
+		UserText("Hello"),
+		AssistantText("Hi"),
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "Be concise"}}},
+	}
+
+	_, out := buildAnthropicMessages(messages)
+
+	// Should have user + assistant + synthetic user (trailing assistant normalization)
+	// but no developer content since there's no user turn to merge into
+	for _, msg := range out {
+		if msg.Role == anthropic.MessageParamRoleUser {
+			for _, block := range msg.Content {
+				if block.OfText != nil && strings.Contains(block.OfText.Text, "<developer>") {
+					t.Fatalf("developer tag should not appear without a following user message, got %q", block.OfText.Text)
+				}
+			}
+		}
+	}
+}
+
+func TestBuildAnthropicBetaMessages_DeveloperRole(t *testing.T) {
+	messages := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "Be concise"}}},
+		UserText("Hello"),
+	}
+
+	_, out := buildAnthropicBetaMessages(messages)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(out))
+	}
+	if out[0].Role != anthropic.BetaMessageParamRoleUser {
+		t.Fatalf("expected user role, got %v", out[0].Role)
+	}
+	if len(out[0].Content) != 1 {
+		t.Fatalf("expected single content block, got %d", len(out[0].Content))
+	}
+	got := out[0].Content[0].GetText()
+	if got == nil {
+		t.Fatalf("expected text block, got %#v", out[0].Content[0])
+	}
+	want := "<developer>\nBe concise\n</developer>\n\nHello"
+	if *got != want {
+		t.Errorf("content = %q, want %q", *got, want)
 	}
 }

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -181,7 +181,7 @@ func BuildResponsesInput(messages []Message) []ResponsesInputItem {
 	messages = sanitizeToolHistory(messages)
 	var inputItems []ResponsesInputItem
 	for _, msg := range messages {
-		if msg.Role == RoleSystem {
+		if msg.Role == RoleSystem || msg.Role == RoleDeveloper {
 			inputItems = append(inputItems, buildResponsesMessageItems("developer", msg.Parts)...)
 		} else {
 			inputItems = append(inputItems, buildResponsesInputForRole(msg)...)
@@ -195,6 +195,8 @@ func buildResponsesInputForRole(msg Message) []ResponsesInputItem {
 	switch msg.Role {
 	case RoleUser:
 		return buildResponsesMessageItems("user", msg.Parts)
+	case RoleDeveloper:
+		return buildResponsesMessageItems("developer", msg.Parts)
 	case RoleAssistant:
 		return buildResponsesAssistantItems(msg.Parts)
 	case RoleTool:

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -889,3 +889,58 @@ func TestResponsesClient_NoOnAuthRetry_Returns401Error(t *testing.T) {
 		t.Fatalf("expected authentication failed error, got: %v", err)
 	}
 }
+
+func TestBuildResponsesInput_DeveloperRole(t *testing.T) {
+	messages := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "Be concise"}}},
+		UserText("Hello"),
+		AssistantText("Hi"),
+	}
+
+	input := BuildResponsesInput(messages)
+
+	if len(input) != 3 {
+		t.Fatalf("expected 3 input items, got %d", len(input))
+	}
+	if input[0].Role != "developer" {
+		t.Errorf("expected developer role, got %q", input[0].Role)
+	}
+	if input[0].Content != "Be concise" {
+		t.Errorf("expected developer content 'Be concise', got %v", input[0].Content)
+	}
+	if input[1].Role != "user" {
+		t.Errorf("expected user role, got %q", input[1].Role)
+	}
+	if input[2].Role != "assistant" {
+		t.Errorf("expected assistant role, got %q", input[2].Role)
+	}
+}
+
+func TestBuildResponsesInputWithInstructions_DeveloperStaysInline(t *testing.T) {
+	messages := []Message{
+		{Role: RoleSystem, Parts: []Part{{Type: PartText, Text: "You are helpful."}}},
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "Be concise"}}},
+		UserText("Hello"),
+	}
+
+	instructions, input := BuildResponsesInputWithInstructions(messages)
+
+	// System messages should be extracted to instructions
+	if instructions != "You are helpful." {
+		t.Fatalf("expected system instructions, got %q", instructions)
+	}
+
+	// Developer message should stay inline, not be extracted
+	if len(input) != 2 {
+		t.Fatalf("expected 2 input items (developer + user), got %d", len(input))
+	}
+	if input[0].Role != "developer" {
+		t.Errorf("expected developer role inline, got %q", input[0].Role)
+	}
+	if input[0].Content != "Be concise" {
+		t.Errorf("expected developer content 'Be concise', got %v", input[0].Content)
+	}
+	if input[1].Role != "user" {
+		t.Errorf("expected user role, got %q", input[1].Role)
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -81,6 +81,11 @@ const (
 	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
 	RoleTool      Role = "tool"
+	// RoleDeveloper is a privileged instruction role injected by the platform layer.
+	// OpenAI/Responses API providers send it as a "developer" role message; Anthropic
+	// providers have no native equivalent, so the text is prepended into the next user turn
+	// wrapped in <developer>…</developer> tags.
+	RoleDeveloper Role = "developer"
 )
 
 // PartType identifies a message content part.

--- a/internal/serve/platform.go
+++ b/internal/serve/platform.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -35,6 +36,7 @@ type Settings struct {
 	Tools               string
 	MCP                 string
 	Agent               string
+	PlatformMessages    agents.PlatformMessagesConfig
 	Store               session.Store
 	// NewSession creates a fresh runtime instance for a new conversation.
 	// Called once per platform session (for example, per Telegram chat session).

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -911,6 +911,10 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		sess.carryoverContext = ""
 		sess.carryoverContextLabel = ""
 	}
+	// Inject platform developer message for telegram.
+	if devText := m.settings.PlatformMessages.For("telegram"); devText != "" {
+		messages = append(messages, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: devText}}})
+	}
 	messages = append(messages, sess.history...)
 	messages = append(messages, userMsg)
 

--- a/internal/tui/inspector/content.go
+++ b/internal/tui/inspector/content.go
@@ -300,6 +300,14 @@ func (r *ContentRenderer) renderMessageWithItems(msg session.Message, msgID stri
 			items = append(items, *item)
 			lineCount = item.EndLine - startLine
 		}
+	case llm.RoleDeveloper:
+		roleStyle = roleStyle.Foreground(theme.Spinner)
+		content, item := r.renderBoxWithItem("Developer", roleStyle, r.renderTextContent(msg), msgID, "message", startLine)
+		b.WriteString(content)
+		if item != nil {
+			items = append(items, *item)
+			lineCount = item.EndLine - startLine
+		}
 	case llm.RoleTool:
 		content, toolItems := r.renderToolResultsWithItems(msg, msgID, startLine)
 		b.WriteString(content)
@@ -863,6 +871,8 @@ func (r *ContentRenderer) renderSubagentSession(sessionID string, startLine int)
 			roleLabel = "System"
 		case llm.RoleTool:
 			roleLabel = "Tool"
+		case llm.RoleDeveloper:
+			roleLabel = "Developer"
 		default:
 			roleLabel = string(msg.Role)
 		}


### PR DESCRIPTION
Add per-platform developer messages that inform the model which platform (web, telegram, chat) the user is interacting from.

## Config

`agent.yaml` gains a `platform_messages` block with 3 named fields:

```yaml
platform_messages:
  web_developer_message: "You are on the web UI..."
  telegram_developer_message: "You are on Telegram..."
  chat_developer_message: "You are on the CLI chat..."
```

## Injection

- **Web/chat (serveRuntime):** Injected on first turn and when platform changes. Tracks `lastInjectedPlatform`, resets on `replaceHistory`.
- **Telegram:** Unconditionally injected each `streamReply` (stateless sessions).

## Provider translation

- **OpenAI Responses API:** Native `developer` role — maps directly.
- **Anthropic:** No developer role. Developer messages are buffered and prepended to the next user message wrapped in `<developer>` XML tags (avoids consecutive user messages).

## Inspector (CTRL-O)

`RoleDeveloper` messages render in purple with a "Developer" header, visually distinct from system/user/assistant.

## Files changed

- `internal/llm/types.go` — `RoleDeveloper` constant
- `internal/agents/agent.go` — `PlatformMessagesConfig` struct + `.For(platform)`
- `internal/llm/responses_api.go` — developer role → OpenAI developer items
- `internal/llm/anthropic.go` — developer → `<developer>` XML prepend to next user msg
- `cmd/serve_runtime.go` — injection logic with `lastInjectedPlatform` tracking
- `cmd/serve.go` — wiring
- `internal/serve/platform.go` — `PlatformMessages` on Settings
- `internal/serve/telegram.go` — telegram injection
- `internal/tui/inspector/content.go` — purple Developer box rendering