### PR TITLE
feat: add jobs platform to developer messages

### DIFF
--- a/docs-site/content/guides/agents.md
+++ b/docs-site/content/guides/agents.md
@@ -109,6 +109,33 @@ mcp:
 
 Built-in agents that currently default to `search: true`: `agent-builder`, `web-researcher`, `developer`, `editor`, `shell`.
 
+## Platform developer messages
+
+When term-llm serves an agent on different platforms (web UI, Telegram, CLI chat, background jobs), each platform may need different behavioral guidance. The `platform_messages` block in `agent.yaml` lets you inject a developer-role message at the start of every new session, keyed by platform.
+
+```yaml
+platform_messages:
+  web_developer_message: |
+    You are running in the web UI. Use markdown, tables, and links freely.
+  telegram_developer_message: |
+    You are running as a Telegram bot. Keep responses short.
+  chat_developer_message: |
+    You are running in CLI chat mode.
+  jobs_developer_message: |
+    You are running as a background job. Do not prompt for input.
+```
+
+Supported platform keys:
+
+| Key | Platform | When used |
+|---|---|---|
+| `web_developer_message` | Web UI / HTTP API | `term-llm serve --platform web` |
+| `telegram_developer_message` | Telegram bot | `term-llm serve --platform telegram` |
+| `chat_developer_message` | CLI chat | `term-llm chat` |
+| `jobs_developer_message` | Scheduled/background jobs | `term-llm serve --platform jobs` |
+
+Messages are injected as `developer` role messages before the first user turn. If no message is configured for the active platform, nothing is injected. Each key is optional — define only the platforms you need.
+
 ## System prompt file includes
 
 System prompts support inline file includes with `{{file:...}}`.

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -22,9 +22,10 @@ type PlatformMessagesConfig struct {
 	Web      string `yaml:"web_developer_message,omitempty"`
 	Telegram string `yaml:"telegram_developer_message,omitempty"`
 	Chat     string `yaml:"chat_developer_message,omitempty"`
+	Jobs     string `yaml:"jobs_developer_message,omitempty"`
 }
 
-// For returns the developer message for the given platform name ("web", "telegram", "chat").
+// For returns the developer message for the given platform name ("web", "telegram", "chat", "jobs").
 // Returns empty string when no message is configured for that platform.
 func (p PlatformMessagesConfig) For(platform string) string {
 	switch platform {
@@ -34,6 +35,8 @@ func (p PlatformMessagesConfig) For(platform string) string {
 		return p.Telegram
 	case "chat":
 		return p.Chat
+	case "jobs":
+		return p.Jobs
 	default:
 		return ""
 	}

--- a/internal/agents/agent_test.go
+++ b/internal/agents/agent_test.go
@@ -687,6 +687,7 @@ func TestPlatformMessagesConfig_For(t *testing.T) {
 		Web:      "You are a web assistant",
 		Telegram: "You are a telegram bot",
 		Chat:     "You are a CLI helper",
+		Jobs:     "You are a background job",
 	}
 
 	tests := []struct {
@@ -696,8 +697,8 @@ func TestPlatformMessagesConfig_For(t *testing.T) {
 		{"web", "You are a web assistant"},
 		{"telegram", "You are a telegram bot"},
 		{"chat", "You are a CLI helper"},
+		{"jobs", "You are a background job"},
 		{"unknown", ""},
-		{"jobs", ""},
 		{"", ""},
 	}
 
@@ -712,7 +713,7 @@ func TestPlatformMessagesConfig_For(t *testing.T) {
 
 	// Empty config returns "" for all platforms
 	empty := PlatformMessagesConfig{}
-	for _, p := range []string{"web", "telegram", "chat"} {
+	for _, p := range []string{"web", "telegram", "chat", "jobs"} {
 		if got := empty.For(p); got != "" {
 			t.Errorf("empty config For(%q) = %q, want empty", p, got)
 		}


### PR DESCRIPTION
## What

Adds `jobs` as a fourth supported platform for developer messages, alongside web, telegram, and chat. Also documents the `platform_messages` feature in the agents guide.

## Changes

- Add `Jobs` field (`jobs_developer_message`) to `PlatformMessagesConfig` struct
- Add `"jobs"` case to `For()` switch method
- Update tests to cover the new platform
- Add "Platform developer messages" section to `docs-site/content/guides/agents.md` documenting all 4 platform keys with a YAML example and reference table

## Why

The jobs platform (scheduled/background tasks) needs its own developer message to tell the agent not to prompt for input, execute fully, and keep output structured. This was the missing fourth platform — follows on from #237 which introduced the feature for web/telegram/chat.
