### PR TITLE
fix: inject chat developer message in TUI on platform boundary

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -384,7 +384,11 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	useAltScreen := term.IsTerminal(int(os.Stdout.Fd())) && !autoSendMode
 
 	// Create chat model
-	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, chatNoWebFetch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, false, initialText, store, sess, useAltScreen, chatAutoSend, autoSendMode, chatTextMode, agentName, chatYolo)
+	chatPlatformMessage := ""
+	if agent != nil {
+		chatPlatformMessage = agent.PlatformMessages.For("chat")
+	}
+	model := chat.NewWithFastProvider(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, chatNoWebFetch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, false, initialText, store, sess, useAltScreen, chatAutoSend, autoSendMode, chatTextMode, agentName, chatPlatformMessage, chatYolo)
 	model.SetRootContext(ctx)
 
 	// Wire handover auto-send if pending from previous iteration

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -94,6 +94,9 @@ type Model struct {
 	modelName    string
 	agentName    string
 
+	platformDeveloperMessage string
+	currentOrigin            session.SessionOrigin
+
 	// Agent handover
 	agentResolver       func(name string, cfg *config.Config) (*agents.Agent, error)
 	agentLister         func(cfg *config.Config) ([]string, error) // Lists available agent names
@@ -321,13 +324,13 @@ type AskUserRequestMsg struct {
 
 // New creates a new chat model.
 // fast-provider aware callers should use NewWithFastProvider.
-func New(cfg *config.Config, provider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, yolo bool) *Model {
-	return NewWithFastProvider(cfg, provider, nil, engine, providerKey, modelName, mcpManager, maxTurns, forceExternalSearch, disableExternalWebFetch, searchEnabled, localTools, toolsStr, mcpStr, showStats, initialText, store, sess, altScreen, autoSendQueue, autoSendExitOnDone, textMode, agentName, yolo)
+func New(cfg *config.Config, provider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, platformDeveloperMessage string, yolo bool) *Model {
+	return NewWithFastProvider(cfg, provider, nil, engine, providerKey, modelName, mcpManager, maxTurns, forceExternalSearch, disableExternalWebFetch, searchEnabled, localTools, toolsStr, mcpStr, showStats, initialText, store, sess, altScreen, autoSendQueue, autoSendExitOnDone, textMode, agentName, platformDeveloperMessage, yolo)
 }
 
 // NewWithFastProvider creates a new chat model with an optional fast provider
 // for control-plane classification tasks.
-func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, yolo bool) *Model {
+func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider llm.Provider, engine *llm.Engine, providerKey string, modelName string, mcpManager *mcp.Manager, maxTurns int, forceExternalSearch bool, disableExternalWebFetch bool, searchEnabled bool, localTools []string, toolsStr string, mcpStr string, showStats bool, initialText string, store session.Store, sess *session.Session, altScreen bool, autoSendQueue []string, autoSendExitOnDone bool, textMode bool, agentName string, platformDeveloperMessage string, yolo bool) *Model {
 	// Get terminal size
 	width := 80
 	height := 24
@@ -373,6 +376,7 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 			ProviderKey: providerKey,
 			Model:       modelName,
 			Mode:        session.ModeChat,
+			Origin:      session.OriginTUI,
 			Agent:       agentName,
 			CreatedAt:   time.Now(),
 			UpdatedAt:   time.Now(),
@@ -452,52 +456,54 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 	}
 
 	return &Model{
-		width:                   width,
-		height:                  height,
-		textarea:                ta,
-		spinner:                 s,
-		styles:                  styles,
-		keyMap:                  DefaultKeyMap(),
-		store:                   store,
-		sess:                    sess,
-		messages:                messages,
-		rootCtx:                 context.Background(),
-		provider:                provider,
-		fastProvider:            fastProvider,
-		engine:                  engine,
-		config:                  cfg,
-		providerName:            provider.Name(),
-		providerKey:             providerKey,
-		modelName:               modelName,
-		agentName:               agentName,
-		yolo:                    yolo,
-		phase:                   "Thinking",
-		viewportRows:            height - 8, // Reserve space for input and status
-		tracker:                 tracker,
-		subagentTracker:         subagentTracker,
-		smoothBuffer:            ui.NewSmoothBuffer(),
-		completions:             completions,
-		dialog:                  dialog,
-		approvedDirs:            approvedDirs,
-		mcpManager:              mcpManager,
-		maxTurns:                maxTurns,
-		forceExternalSearch:     forceExternalSearch,
-		disableExternalWebFetch: disableExternalWebFetch,
-		searchEnabled:           searchEnabled,
-		localTools:              localTools,
-		toolsStr:                toolsStr,
-		mcpStr:                  mcpStr,
-		showStats:               showStats,
-		stats:                   stats,
-		streamPerf:              newStreamPerfTelemetryFromEnv(),
-		altScreen:               altScreen,
-		viewport:                vp,
-		streamRenderMinInterval: chatRenderMinIntervalFromEnv(),
-		chatRenderer:            chatRenderer,
-		autoSendQueue:           autoSendQueue,
-		autoSendExitOnDone:      autoSendExitOnDone,
-		textMode:                textMode,
-		selectedImage:           -1,
+		width:                    width,
+		height:                   height,
+		textarea:                 ta,
+		spinner:                  s,
+		styles:                   styles,
+		keyMap:                   DefaultKeyMap(),
+		store:                    store,
+		sess:                     sess,
+		messages:                 messages,
+		rootCtx:                  context.Background(),
+		provider:                 provider,
+		fastProvider:             fastProvider,
+		engine:                   engine,
+		config:                   cfg,
+		providerName:             provider.Name(),
+		providerKey:              providerKey,
+		modelName:                modelName,
+		agentName:                agentName,
+		platformDeveloperMessage: strings.TrimSpace(platformDeveloperMessage),
+		currentOrigin:            session.OriginTUI,
+		yolo:                     yolo,
+		phase:                    "Thinking",
+		viewportRows:             height - 8, // Reserve space for input and status
+		tracker:                  tracker,
+		subagentTracker:          subagentTracker,
+		smoothBuffer:             ui.NewSmoothBuffer(),
+		completions:              completions,
+		dialog:                   dialog,
+		approvedDirs:             approvedDirs,
+		mcpManager:               mcpManager,
+		maxTurns:                 maxTurns,
+		forceExternalSearch:      forceExternalSearch,
+		disableExternalWebFetch:  disableExternalWebFetch,
+		searchEnabled:            searchEnabled,
+		localTools:               localTools,
+		toolsStr:                 toolsStr,
+		mcpStr:                   mcpStr,
+		showStats:                showStats,
+		stats:                    stats,
+		streamPerf:               newStreamPerfTelemetryFromEnv(),
+		altScreen:                altScreen,
+		viewport:                 vp,
+		streamRenderMinInterval:  chatRenderMinIntervalFromEnv(),
+		chatRenderer:             chatRenderer,
+		autoSendQueue:            autoSendQueue,
+		autoSendExitOnDone:       autoSendExitOnDone,
+		textMode:                 textMode,
+		selectedImage:            -1,
 	}
 }
 

--- a/internal/tui/chat/image_attachments_test.go
+++ b/internal/tui/chat/image_attachments_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 func TestIsImagePasteAttempt(t *testing.T) {
@@ -109,5 +110,52 @@ func TestSendMessage_IncludesImageParts(t *testing.T) {
 	}
 	if len(m.images) != 0 {
 		t.Fatalf("expected images to be cleared after send, got %d", len(m.images))
+	}
+}
+
+func TestSendMessage_InjectsPlatformDeveloperMessageOnlyOnFirstTurn(t *testing.T) {
+	m := newTestChatModel(false)
+	m.platformDeveloperMessage = "You are running on the CLI chat platform."
+
+	_, _ = m.sendMessage("hello")
+	if len(m.messages) != 2 {
+		t.Fatalf("expected developer + user messages after first send, got %d", len(m.messages))
+	}
+	if m.messages[0].Role != llm.RoleDeveloper {
+		t.Fatalf("expected first message role developer, got %q", m.messages[0].Role)
+	}
+
+	_, _ = m.sendMessage("again")
+	devCount := 0
+	for _, msg := range m.messages {
+		if msg.Role == llm.RoleDeveloper {
+			devCount++
+		}
+	}
+	if devCount != 1 {
+		t.Fatalf("developer message count = %d, want 1", devCount)
+	}
+}
+
+func TestSendMessage_InjectsPlatformDeveloperMessageWhenOriginChanges(t *testing.T) {
+	m := newTestChatModel(false)
+	m.platformDeveloperMessage = "You are running on the CLI chat platform."
+	m.sess.Origin = session.OriginWeb
+	m.messages = []session.Message{{
+		SessionID:   m.sess.ID,
+		Role:        llm.RoleUser,
+		Parts:       []llm.Part{{Type: llm.PartText, Text: "from web"}},
+		TextContent: "from web",
+	}}
+
+	_, _ = m.sendMessage("now from tui")
+	if len(m.messages) < 3 {
+		t.Fatalf("expected at least 3 messages after origin change, got %d", len(m.messages))
+	}
+	if m.messages[0].Role != llm.RoleDeveloper {
+		t.Fatalf("expected prepended developer message, got %q", m.messages[0].Role)
+	}
+	if m.sess.Origin != session.OriginTUI {
+		t.Fatalf("session origin = %q, want %q", m.sess.Origin, session.OriginTUI)
 	}
 }

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -219,6 +219,7 @@ func newTestChatModel(altScreen bool) *Model {
 		false,
 		false,
 		"",
+		"",
 		false, // yolo
 	)
 }

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -67,6 +67,7 @@ func TestUpdate_StreamError_BumpsContentVersion(t *testing.T) {
 		false, // autoSendExitOnDone
 		false, // textMode
 		"",    // agentName
+		"",    // platformDeveloperMessage
 		false, // yolo
 	)
 	m.streaming = true
@@ -106,6 +107,7 @@ func TestViewAltScreen_FirstRenderAnchorsToBottom(t *testing.T) {
 		false, // autoSendExitOnDone
 		false, // textMode
 		"",    // agentName
+		"",    // platformDeveloperMessage
 		false, // yolo
 	)
 
@@ -314,6 +316,7 @@ func TestStreamEventDiffFlushUsesOrderedCommandComposition(t *testing.T) {
 		false,
 		false,
 		"",
+		"",
 		false, // yolo
 	)
 	m.streaming = true
@@ -424,6 +427,7 @@ func TestRenderStatusLine_ShowsSeededCachedUsageFromSession(t *testing.T) {
 		nil,
 		false,
 		false,
+		"",
 		"",
 		false, // yolo
 	)

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -15,6 +15,74 @@ import (
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
+func (m *Model) shouldInjectPlatformDeveloperMessage() bool {
+	if strings.TrimSpace(m.platformDeveloperMessage) == "" {
+		return false
+	}
+	if len(m.messages) == 0 {
+		return true
+	}
+	if m.sess == nil {
+		return false
+	}
+	return m.sess.Origin != m.currentOrigin
+}
+
+func (m *Model) prependMessage(msg session.Message) {
+	m.messages = append([]session.Message{msg}, m.messages...)
+	m.invalidateHistoryCache()
+}
+
+func (m *Model) ensureContextMessages() {
+	hasSystemMsg := false
+	for _, msg := range m.messages {
+		if msg.Role == llm.RoleSystem {
+			hasSystemMsg = true
+			break
+		}
+	}
+
+	if m.config.Chat.Instructions != "" && !hasSystemMsg {
+		sysMsg := &session.Message{
+			SessionID:   m.sess.ID,
+			Role:        llm.RoleSystem,
+			Parts:       []llm.Part{{Type: llm.PartText, Text: m.config.Chat.Instructions}},
+			TextContent: m.config.Chat.Instructions,
+			CreatedAt:   time.Now(),
+			Sequence:    -1,
+		}
+		if m.store != nil {
+			_ = m.store.AddMessage(context.Background(), m.sess.ID, sysMsg)
+		}
+		m.prependMessage(*sysMsg)
+	}
+
+	if !m.shouldInjectPlatformDeveloperMessage() {
+		return
+	}
+
+	devText := strings.TrimSpace(m.platformDeveloperMessage)
+	devMsg := &session.Message{
+		SessionID:   m.sess.ID,
+		Role:        llm.RoleDeveloper,
+		Parts:       []llm.Part{{Type: llm.PartText, Text: devText}},
+		TextContent: devText,
+		CreatedAt:   time.Now(),
+		Sequence:    -1,
+	}
+	if m.store != nil {
+		_ = m.store.AddMessage(context.Background(), m.sess.ID, devMsg)
+	}
+	m.prependMessage(*devMsg)
+
+	if m.sess != nil {
+		m.sess.Origin = m.currentOrigin
+		if m.store != nil {
+			_ = m.store.Update(context.Background(), m.sess)
+		}
+	}
+}
+
 func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	m.selection = Selection{}
 	m.interruptNotice = ""
@@ -46,6 +114,9 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 		displayText = "[" + strings.Join(imageLabels, ", ") + "]"
 	}
 
+	// Ensure system/platform context messages exist before the user turn.
+	m.ensureContextMessages()
+
 	// Create user message and store it
 	userMsg := &session.Message{
 		SessionID:   m.sess.ID,
@@ -58,30 +129,6 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	m.messages = append(m.messages, *userMsg)
 	m.invalidateHistoryCache()
 	if m.store != nil {
-		// Save system message first if this is a new session with instructions
-		// Check if there's no existing system message in history
-		hasSystemMsg := false
-		for _, msg := range m.messages {
-			if msg.Role == llm.RoleSystem {
-				hasSystemMsg = true
-				break
-			}
-		}
-		if m.config.Chat.Instructions != "" && !hasSystemMsg {
-			sysMsg := &session.Message{
-				SessionID:   m.sess.ID,
-				Role:        llm.RoleSystem,
-				Parts:       []llm.Part{{Type: llm.PartText, Text: m.config.Chat.Instructions}},
-				TextContent: m.config.Chat.Instructions,
-				CreatedAt:   time.Now(),
-				Sequence:    -1, // Auto-allocate sequence
-			}
-			_ = m.store.AddMessage(context.Background(), m.sess.ID, sysMsg)
-			// Prepend to m.messages so we don't save it again on subsequent sends
-			m.messages = append([]session.Message{*sysMsg}, m.messages...)
-			m.invalidateHistoryCache()
-		}
-
 		_ = m.store.AddMessage(context.Background(), m.sess.ID, userMsg)
 		// Sync the assigned ID back to the copy in m.messages to avoid cache collisions
 		// (AddMessage sets userMsg.ID, but the copy was made before that)


### PR DESCRIPTION
## What

Fix `term-llm chat` so agent `chat_developer_message` instructions are injected in the TUI path.

The TUI already resolved `Platform: "chat"` for system prompt template expansion, but it never consulted `agent.PlatformMessages.For("chat")`, so `chat_developer_message` was silently skipped while web and Telegram got platform-specific developer injection.

This change:

- passes the resolved chat platform message from `cmd/chat.go` into the TUI model
- injects it as a `developer` role message before the next user turn
- injects it only on the platform boundary, not every turn
- sets new TUI chat sessions to `OriginTUI`
- updates a resumed session's origin back to `tui` after injecting on a cross-platform transition

## Why

Sam reported that a `term-llm chat` session was not getting the chat platform developer message at all.

The important behavioral requirement was: inject for chat sessions, but **do not inject every turn** — only when entering the TUI/chat platform context.

This keeps TUI behavior aligned with the existing web/telegram platform-message design while avoiding repeated developer-role spam on normal multi-turn chat.

## Tests

- added TUI tests covering:
  - first-turn chat developer injection
  - no reinjection on subsequent TUI turns
  - reinjection when resuming a session whose origin differs from `tui`
- updated existing constructor call sites in chat tests
- verified with:
  - `go test ./internal/tui/chat ./cmd/...`
  - `go build ./...`
