### PR TITLE
fix: persist TUI developer messages in session history

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS sessions (
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-    role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+    role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool', 'developer')),
     parts TEXT NOT NULL,
     text_content TEXT,
     duration_ms INTEGER,
@@ -108,6 +108,18 @@ CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
 END;
 `
+
+const messagesTableSchema = `
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool', 'developer')),
+    parts TEXT NOT NULL,
+    text_content TEXT,
+    duration_ms INTEGER,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sequence INTEGER NOT NULL
+)`
 
 // NewSQLiteStore creates a new SQLite-based session store.
 func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
@@ -179,7 +191,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 16
+const schemaVersion = 17
 
 // migration represents a schema migration.
 type migration struct {
@@ -571,6 +583,57 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		// Migration 17: Allow developer-role messages in persisted chat history.
+		// Platform developer messages were added above the session layer, but the
+		// messages table still rejected role='developer', causing silent drops.
+		version:     17,
+		description: "allow developer messages in messages table",
+		up: func(db *sql.DB) error {
+			return rebuildMessagesTableForDeveloperRole(db)
+		},
+	},
+}
+
+func rebuildMessagesTableForDeveloperRole(db *sql.DB) error {
+	stmts := []string{
+		`DROP TRIGGER IF EXISTS messages_ai`,
+		`DROP TRIGGER IF EXISTS messages_ad`,
+		`DROP TRIGGER IF EXISTS messages_au`,
+		`DROP INDEX IF EXISTS idx_messages_session_id`,
+		`DROP INDEX IF EXISTS idx_messages_session_sequence`,
+		`DROP TABLE IF EXISTS messages_fts`,
+		`ALTER TABLE messages RENAME TO messages_old`,
+		messagesTableSchema,
+		`INSERT INTO messages (id, session_id, role, parts, text_content, duration_ms, created_at, sequence)
+		 SELECT id, session_id, role, parts, text_content, duration_ms, created_at, sequence
+		 FROM messages_old`,
+		`DROP TABLE messages_old`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, sequence)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_sequence ON messages(session_id, sequence)`,
+		`CREATE VIRTUAL TABLE messages_fts USING fts5(
+			text_content,
+			content='messages',
+			content_rowid='id'
+		)`,
+		`INSERT INTO messages_fts(rowid, text_content) SELECT id, text_content FROM messages`,
+		`CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+			INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+		END`,
+		`CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+		END`,
+		`CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+			INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+		END`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // initSchema initializes the database schema and runs any pending migrations.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 func TestSessionPreferredTitlePrecedence(t *testing.T) {
@@ -23,6 +25,145 @@ func TestSessionPreferredTitlePrecedence(t *testing.T) {
 	}
 	if got := sess.PreferredLongTitle(); got != "Custom name" {
 		t.Fatalf("PreferredLongTitle() with name = %q", got)
+	}
+}
+
+func TestSQLiteStorePersistsDeveloperMessages(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	msg := NewMessage(sess.ID, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "Be concise"}}}, -1)
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		t.Fatalf("AddMessage developer: %v", err)
+	}
+
+	msgs, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleDeveloper {
+		t.Fatalf("message role = %q, want %q", msgs[0].Role, llm.RoleDeveloper)
+	}
+}
+
+func TestSQLiteStoreMigratesMessagesTableToAllowDeveloperRole(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed database: %v", err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			number INTEGER,
+			name TEXT,
+			summary TEXT,
+			generated_short_title TEXT,
+			generated_long_title TEXT,
+			title_source TEXT,
+			title_generated_at TIMESTAMP,
+			title_basis_msg_seq INTEGER DEFAULT 0,
+			title_skipped_at TIMESTAMP,
+			provider TEXT NOT NULL,
+			provider_key TEXT,
+			model TEXT NOT NULL,
+			mode TEXT DEFAULT 'chat',
+			origin TEXT DEFAULT 'tui',
+			agent TEXT,
+			cwd TEXT,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			archived BOOLEAN DEFAULT FALSE,
+			pinned BOOLEAN DEFAULT FALSE,
+			parent_id TEXT REFERENCES sessions(id),
+			search BOOLEAN DEFAULT FALSE,
+			tools TEXT,
+			mcp TEXT,
+			user_turns INTEGER DEFAULT 0,
+			llm_turns INTEGER DEFAULT 0,
+			tool_calls INTEGER DEFAULT 0,
+			input_tokens INTEGER DEFAULT 0,
+			cached_input_tokens INTEGER DEFAULT 0,
+			cache_write_tokens INTEGER DEFAULT 0,
+			output_tokens INTEGER DEFAULT 0,
+			status TEXT DEFAULT 'active',
+			tags TEXT,
+			compaction_seq INTEGER DEFAULT -1,
+			last_user_message_at TIMESTAMP
+		);
+		CREATE UNIQUE INDEX idx_sessions_number ON sessions(number);
+		CREATE INDEX idx_sessions_updated_at ON sessions(updated_at DESC);
+		CREATE INDEX idx_sessions_mode ON sessions(mode);
+		CREATE INDEX idx_sessions_origin ON sessions(origin);
+		CREATE INDEX idx_sessions_pinned ON sessions(pinned);
+		CREATE INDEX idx_sessions_last_user_msg ON sessions(last_user_message_at DESC);
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+			role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+			parts TEXT NOT NULL,
+			text_content TEXT,
+			duration_ms INTEGER,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			sequence INTEGER NOT NULL
+		);
+		CREATE INDEX idx_messages_session_id ON messages(session_id, sequence);
+		CREATE UNIQUE INDEX idx_messages_session_sequence ON messages(session_id, sequence);
+		CREATE VIRTUAL TABLE messages_fts USING fts5(
+			text_content,
+			content='messages',
+			content_rowid='id'
+		);
+		CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+			INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+		END;
+		CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+		END;
+		CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+			INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+		END;
+		CREATE TABLE schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version(version) VALUES (16);
+	`)
+	if err != nil {
+		t.Fatalf("seed schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seed database: %v", err)
+	}
+
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("failed to open migrated sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	msg := NewMessage(sess.ID, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "Be concise"}}}, -1)
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		t.Fatalf("AddMessage developer after migration: %v", err)
 	}
 }
 

--- a/internal/tui/chat/image_attachments_test.go
+++ b/internal/tui/chat/image_attachments_test.go
@@ -113,6 +113,23 @@ func TestSendMessage_IncludesImageParts(t *testing.T) {
 	}
 }
 
+func TestSendMessage_InjectsPlatformDeveloperMessageOnFirstTurnEvenWithSystemInstructions(t *testing.T) {
+	m := newTestChatModel(false)
+	m.platformDeveloperMessage = "You are running on the CLI chat platform."
+	m.config.Chat.Instructions = "Base system instructions"
+
+	_, _ = m.sendMessage("hello")
+	if len(m.messages) != 3 {
+		t.Fatalf("expected system + developer + user messages after first send, got %d", len(m.messages))
+	}
+	if m.messages[0].Role != llm.RoleSystem {
+		t.Fatalf("expected first message role system, got %q", m.messages[0].Role)
+	}
+	if m.messages[1].Role != llm.RoleDeveloper {
+		t.Fatalf("expected second message role developer, got %q", m.messages[1].Role)
+	}
+}
+
 func TestSendMessage_InjectsPlatformDeveloperMessageOnlyOnFirstTurn(t *testing.T) {
 	m := newTestChatModel(false)
 	m.platformDeveloperMessage = "You are running on the CLI chat platform."

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -19,9 +19,18 @@ func (m *Model) shouldInjectPlatformDeveloperMessage() bool {
 	if strings.TrimSpace(m.platformDeveloperMessage) == "" {
 		return false
 	}
-	if len(m.messages) == 0 {
+
+	hasUserMsg := false
+	for _, msg := range m.messages {
+		if msg.Role == llm.RoleUser {
+			hasUserMsg = true
+			break
+		}
+	}
+	if !hasUserMsg {
 		return true
 	}
+
 	if m.sess == nil {
 		return false
 	}
@@ -30,6 +39,15 @@ func (m *Model) shouldInjectPlatformDeveloperMessage() bool {
 
 func (m *Model) prependMessage(msg session.Message) {
 	m.messages = append([]session.Message{msg}, m.messages...)
+	m.invalidateHistoryCache()
+}
+
+func (m *Model) insertDeveloperMessage(msg session.Message) {
+	insertAt := 0
+	for insertAt < len(m.messages) && m.messages[insertAt].Role == llm.RoleSystem {
+		insertAt++
+	}
+	m.messages = append(m.messages[:insertAt], append([]session.Message{msg}, m.messages[insertAt:]...)...)
 	m.invalidateHistoryCache()
 }
 
@@ -73,7 +91,7 @@ func (m *Model) ensureContextMessages() {
 	if m.store != nil {
 		_ = m.store.AddMessage(context.Background(), m.sess.ID, devMsg)
 	}
-	m.prependMessage(*devMsg)
+	m.insertDeveloperMessage(*devMsg)
 
 	if m.sess != nil {
 		m.sess.Origin = m.currentOrigin


### PR DESCRIPTION
## What

Fix the follow-up bug from #239: TUI chat now both injects and **persists** `developer` role messages correctly.

Root cause turned out to be two separate issues:

1. **First-turn injection guard was wrong**
   - it checked `len(m.messages) == 0`
   - but the system message is prepended first, so first-turn developer injection was skipped whenever chat had system instructions

2. **The session DB schema still rejected `role='developer'`**
   - the `messages` table CHECK constraint only allowed `user`, `assistant`, `system`, and `tool`
   - so even when the TUI tried to persist a developer message, SQLite rejected it and the insert error was silently ignored at the call site

This PR fixes both:

- first-turn TUI developer injection now keys off whether a user turn exists yet, not raw message count
- developer messages are inserted after leading system messages (matching the intended order)
- the sessions schema now allows `developer` in `messages.role`
- migration 17 rebuilds the `messages` table for existing DBs and restores FTS + triggers

## Why

Sam manually tested this after updating and searched for a fresh post-update message (`12345`) in a new TUI session. The raw session messages still had:

- `system`
- `user`
- `assistant`

with **no `developer` row at all**.

So #239 was not actually fixed in real usage. This PR closes the gap the real-world test exposed.

## Red tests / verification

I first reproduced it by hand:

```bash
term-llm chat --session-db /tmp/tui-platform-test.db --agent jarvis --auto-send hello
sqlite3 /tmp/tui-platform-test.db 'select sequence, role, text_content from messages order by sequence;'
```

Before this fix, that produced only `system`, `user`, `assistant`.

Then I added regression coverage for the two real failure modes:

- `TestSendMessage_InjectsPlatformDeveloperMessageOnFirstTurnEvenWithSystemInstructions`
- `TestSQLiteStorePersistsDeveloperMessages`
- `TestSQLiteStoreMigratesMessagesTableToAllowDeveloperRole`

Manual repro after the fix now shows:

- `system`
- `developer`
- `user`
- `assistant`

## Validation

- `go test ./internal/session ./internal/tui/chat ./cmd/...`
- `go build ./...`
