### PR TITLE
feat: use sequential session numbers in web UI URLs and sidebar

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -259,6 +259,7 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 
 	type sessionEntry struct {
 		ID         string                `json:"id"`
+		Number     int64                 `json:"number,omitempty"`
 		Name       string                `json:"name,omitempty"`
 		ShortTitle string                `json:"short_title"`
 		LongTitle  string                `json:"long_title"`
@@ -275,6 +276,7 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 		result = append(result, sessionEntry{
 			Name:       sess.Name,
 			ID:         sess.ID,
+			Number:     sess.Number,
 			ShortTitle: sess.PreferredShortTitle(),
 			LongTitle:  sess.PreferredLongTitle(),
 			Mode:       sess.Mode,
@@ -299,6 +301,15 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 	}
 
 	sessionID := parts[0]
+	// If the path segment is purely numeric, resolve via session number.
+	if num, err := strconv.ParseInt(sessionID, 10, 64); err == nil && num > 0 && s.store != nil {
+		sess, err := s.store.GetByNumber(r.Context(), num)
+		if err != nil || sess == nil {
+			http.NotFound(w, r)
+			return
+		}
+		sessionID = sess.ID
+	}
 	suffix := ""
 	if len(parts) > 1 {
 		suffix = parts[1]
@@ -636,7 +647,7 @@ func (s *serveServer) cors(next http.HandlerFunc) http.HandlerFunc {
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, X-Term-LLM-UI, X-API-Key, anthropic-version")
-			w.Header().Set("Access-Control-Expose-Headers", "x-session-id")
+			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number")
 		}
 
 		if r.Method == http.MethodOptions {

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -175,6 +175,8 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		model = runtime.defaultModel
 	}
 
+	setSessionNumberHeader(w, runtime)
+
 	respID := "resp_" + randomSuffix()
 	s.registerResponseID(runtime, respID, sessionID)
 

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -337,6 +338,12 @@ func ensureSessionID(w http.ResponseWriter) string {
 	sessionID := session.NewID()
 	w.Header().Set("x-session-id", sessionID)
 	return sessionID
+}
+
+func setSessionNumberHeader(w http.ResponseWriter, rt *serveRuntime) {
+	if rt != nil && rt.sessionMeta != nil && rt.sessionMeta.Number > 0 {
+		w.Header().Set("x-session-number", strconv.FormatInt(rt.sessionMeta.Number, 10))
+	}
 }
 
 func requireJSONContentType(r *http.Request) error {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -81,6 +81,13 @@ func (rt *serveRuntime) LastUsed() time.Time {
 	return time.Unix(0, unixNano)
 }
 
+func (rt *serveRuntime) SessionNumber() int64 {
+	if rt.sessionMeta != nil {
+		return rt.sessionMeta.Number
+	}
+	return 0
+}
+
 func (rt *serveRuntime) Close() {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -762,6 +762,7 @@ const visibleSessions = () => state.sessions.filter(sessionMatchesSidebarFilters
 
 const createSession = () => ({
   id: `sess_${generateUUID()}`,
+  number: 0,
   name: '',
   title: 'New chat',
   longTitle: '',
@@ -779,6 +780,20 @@ const createSession = () => ({
   activeModel: ''
 });
 
+const sessionSlug = (session) => {
+  if (session && session.number > 0) return String(session.number);
+  return session ? session.id : '';
+};
+
+const findSessionBySlug = (slug) => {
+  if (!slug) return null;
+  const num = /^\d+$/.test(slug) ? Number(slug) : 0;
+  if (num > 0) {
+    return state.sessions.find(s => s.number === num) || null;
+  }
+  return state.sessions.find(s => s.id === slug) || null;
+};
+
 const ensureActiveSession = () => {
   if (state.draftSessionActive) {
     return null;
@@ -786,7 +801,7 @@ const ensureActiveSession = () => {
   let active = getActiveSession();
   if (active) {
     state.draftSessionActive = false;
-    updateURL(active.id);
+    updateURL(sessionSlug(active));
     return active;
   }
 
@@ -807,7 +822,7 @@ const ensureActiveSession = () => {
   active = sorted[0];
   state.activeSessionId = active.id;
   state.draftSessionActive = false;
-  updateURL(active.id);
+  updateURL(sessionSlug(active));
   saveSessions();
   return active;
 };
@@ -883,6 +898,8 @@ Object.assign(app, {
   requestNotificationPermission,
   maybeNotifyResponseComplete,
   sessionIdFromURL,
+  sessionSlug,
+  findSessionBySlug,
   updateURL,
   sanitizeMessage,
   sanitizeSession,

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -175,7 +175,8 @@ const renderSidebar = () => {
 
       const title = document.createElement('div');
       title.className = 'session-title';
-      title.textContent = session.title || 'New chat';
+      const titlePrefix = session.number > 0 ? `#${session.number} ` : '';
+      title.textContent = titlePrefix + (session.title || 'New chat');
       if (session.longTitle) {
         title.title = session.longTitle;
       }

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, updateURL, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
+  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
   autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
@@ -138,7 +138,7 @@ const switchToSession = async (sessionId, options = {}) => {
 
   state.activeSessionId = nextId;
   state.draftSessionActive = false;
-  updateURL(nextId);
+  updateURL(sessionSlug(session));
 
   if (session._serverOnly) {
     const msgs = await loadServerSessionMessages(session.id);
@@ -437,6 +437,7 @@ const applyServerSessionSummary = (target, serverSession) => {
   target.pinned = Boolean(serverSession.pinned);
   target.created = asTimestamp(serverSession.created_at || target.created);
   target.messageCount = Number(serverSession.message_count || target.messageCount || 0);
+  target.number = Number(serverSession.number || target.number || 0);
   return target;
 };
 
@@ -470,6 +471,7 @@ const mergeServerSessions = async (options = {}) => {
 
       local = applyServerSessionSummary({
         id: serverSession.id,
+        number: 0,
         name: '',
         title: 'New chat',
         longTitle: '',
@@ -664,17 +666,19 @@ const initialize = async () => {
   setStartupStatus('Loading your chat shell…');
   state.sessions = loadSessions();
 
-  // Check URL for a specific session ID
-  const urlSessionId = sessionIdFromURL();
-  if (urlSessionId) {
-    const found = state.sessions.find(s => s.id === urlSessionId);
+  // Check URL for a specific session (number or ID)
+  const urlSlug = sessionIdFromURL();
+  if (urlSlug) {
+    const found = findSessionBySlug(urlSlug);
     if (found) {
       state.activeSessionId = found.id;
       state.draftSessionActive = false;
     } else {
       // Create a server-only stub that will be lazy-loaded
+      const num = /^\d+$/.test(urlSlug) ? Number(urlSlug) : 0;
       const stub = {
-        id: urlSessionId,
+        id: num > 0 ? `pending_${urlSlug}` : urlSlug,
+        number: num,
         name: '',
         title: 'Loading…',
         longTitle: '',
@@ -690,7 +694,7 @@ const initialize = async () => {
         _serverOnly: true
       };
       state.sessions.unshift(stub);
-      state.activeSessionId = urlSessionId;
+      state.activeSessionId = stub.id;
       state.draftSessionActive = false;
     }
   } else if (!state.activeSessionId && state.sessions.length === 0) {
@@ -941,20 +945,21 @@ if (typeof sidebarViewportMedia.addEventListener === 'function') {
 }
 
 window.addEventListener('popstate', async () => {
-  const urlId = sessionIdFromURL();
-  if (!urlId) {
+  const urlSlug = sessionIdFromURL();
+  if (!urlSlug) {
     await switchToDraftSession({ closeSidebar: false });
     return;
   }
-  if (urlId === state.activeSessionId) return;
-
-  const found = state.sessions.find(s => s.id === urlId);
+  const found = findSessionBySlug(urlSlug);
   if (found) {
+    if (found.id === state.activeSessionId) return;
     await switchToSession(found.id, { closeSidebar: false });
     return;
   }
+  const num = /^\d+$/.test(urlSlug) ? Number(urlSlug) : 0;
   const stub = {
-    id: urlId,
+    id: num > 0 ? `pending_${urlSlug}` : urlSlug,
+    number: num,
     name: '',
     title: 'Loading…',
     longTitle: '',

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, findMessageElement, scrollToBottom, setConnectionState, updateURL,
+  getActiveSession, createSession, findMessageElement, scrollToBottom, setConnectionState, sessionSlug, updateURL,
   persistAndRefreshShell, updateSessionUsageDisplay, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
   enqueueAssistantStreamUpdate, finalizeAssistantStreamRender,
@@ -2314,6 +2314,11 @@ const sendMessage = async (options = {}) => {
     }
 
     const headerResponseId = String(response.headers.get('x-response-id') || '').trim();
+    const headerSessionNumber = Number(response.headers.get('x-session-number') || 0);
+    if (headerSessionNumber > 0 && session.number !== headerSessionNumber) {
+      session.number = headerSessionNumber;
+      updateURL(sessionSlug(session));
+    }
     if (!response.ok) {
       throw await normalizeError(response);
     }

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2182,7 +2182,7 @@ const sendMessage = async (options = {}) => {
     state.sessions.unshift(session);
     state.activeSessionId = session.id;
     state.draftSessionActive = false;
-    updateURL(session.id);
+    updateURL(sessionSlug(session));
   }
 
   const reuseMessageId = typeof options.reuseMessageId === 'string' ? options.reuseMessageId : '';

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -178,11 +178,13 @@ function createHarness(options = {}) {
         lastResponseId: null,
         activeResponseId: null,
         lastSequenceNumber: 0,
+        number: 0,
       };
     },
     findMessageElement() { return null; },
     scrollToBottom() {},
     setConnectionState() {},
+    sessionSlug(s) { return s ? s.id : ''; },
     updateURL() {},
     persistAndRefreshShell() {},
     updateSessionUsageDisplay() {},


### PR DESCRIPTION
## What

Replace timestamp-based session IDs (`20260328-173034-c847c7`) with simple sequential numbers (`#1277`) in the web UI, matching how the CLI identifies sessions. Makes it easier to reason about sessions across platforms.

## Changes

**Server (Go):**
- `sessionEntry` includes `Number` field in `/v1/sessions` response
- `handleSessionByID` resolves numeric path segments via `store.GetByNumber`
- `x-session-number` response header set after persist (non-streaming path)
- CORS exposes `x-session-number` header
- `serveRuntime.SessionNumber()` getter

**Client (JS):**
- URLs use `/chat/1277` instead of `/chat/20260328-173034-c847c7`
- Sidebar shows `#1277` prefix on session titles
- `sessionSlug()` returns number when available, falls back to ID
- `findSessionBySlug()` resolves numeric slugs by `.number` field
- New sessions get number from `x-session-number` header or `mergeServerSessions`
- Pending stubs (`id: pending_1277`) for direct URL navigation before session list loads

## Timing gap

Session numbers are assigned server-side on DB persist. For new streaming sessions, HTTP headers are already sent before persist completes. The client gets the number either from `x-session-number` (non-streaming) or from `mergeServerSessions` (session list poll). Draft sessions before first message keep URL at `/chat/` with no number.