### PR TITLE
fix: remove session number prefix from sidebar titles

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -175,8 +175,7 @@ const renderSidebar = () => {
 
       const title = document.createElement('div');
       title.className = 'session-title';
-      const titlePrefix = session.number > 0 ? `#${session.number} ` : '';
-      title.textContent = titlePrefix + (session.title || 'New chat');
+      title.textContent = session.title || 'New chat';
       if (session.longTitle) {
         title.title = session.longTitle;
       }


### PR DESCRIPTION
## What

Remove the `#1293`-style number prefix from session titles in the web UI sidebar.

## Why

The numbers are visually noisy and unwanted. The sequential number is still used for clean URLs (`/chat/1293`) — this change only affects what's displayed as text in the sidebar list.
