### PR TITLE
fix: reconcile numeric deep-link session stubs

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -131,6 +131,28 @@ func TestAppStreamJS(t *testing.T) {
 	}
 }
 
+func TestAppSessionsJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping JS app-sessions tests")
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "app_sessions_test.js")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("app_sessions_test.js not found at %s: %v", script, err)
+	}
+
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("app_sessions_test.js failed: %v", err)
+	}
+}
+
 func TestStaticAssetsSupportSessionStreamDetachOnSwitch(t *testing.T) {
 	sessionsJS, err := StaticAsset("app-sessions.js")
 	if err != nil {

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -441,6 +441,36 @@ const applyServerSessionSummary = (target, serverSession) => {
   return target;
 };
 
+const findMatchingServerSessionStub = (serverSession) => {
+  if (!serverSession) return null;
+
+  const exact = state.sessions.find((item) => item.id === serverSession.id) || null;
+  if (exact) return exact;
+
+  const num = Number(serverSession.number || 0);
+  if (num <= 0) return null;
+
+  return state.sessions.find((item) => item._serverOnly
+    && Number(item.number || 0) === num
+    && String(item.id || '').startsWith('pending_')) || null;
+};
+
+const reconcileServerSessionIdentity = (session, serverSession) => {
+  if (!session || !serverSession) return session;
+
+  const nextId = String(serverSession.id || '').trim();
+  const previousId = String(session.id || '').trim();
+  if (!nextId || nextId === previousId) return session;
+
+  session.id = nextId;
+  if (state.activeSessionId === previousId) state.activeSessionId = nextId;
+  if (state.renameSessionId === previousId) state.renameSessionId = nextId;
+  if (state.currentStreamSessionId === previousId) state.currentStreamSessionId = nextId;
+  if (state.askUser?.sessionId === previousId) state.askUser.sessionId = nextId;
+  if (state.approval?.sessionId === previousId) state.approval.sessionId = nextId;
+  return session;
+};
+
 const mergeServerSessions = async (options = {}) => {
   try {
     const categories = Array.isArray(options.categories) ? options.categories : state.sidebarSessionCategories;
@@ -463,8 +493,9 @@ const mergeServerSessions = async (options = {}) => {
     if (!Array.isArray(data.sessions)) return;
 
     for (const serverSession of data.sessions) {
-      let local = state.sessions.find((item) => item.id === serverSession.id) || null;
+      let local = findMatchingServerSessionStub(serverSession);
       if (local) {
+        reconcileServerSessionIdentity(local, serverSession);
         applyServerSessionSummary(local, serverSession);
         continue;
       }

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { webcrypto } = require('crypto');
+
+const dir = __dirname;
+const coreSource = fs.readFileSync(path.join(dir, 'app-core.js'), 'utf8');
+const sessionsSource = fs.readFileSync(path.join(dir, 'app-sessions.js'), 'utf8')
+  .replace('initialize();', 'window.__termllmInitializePromise = initialize();');
+
+let failures = 0;
+
+function fail(name, message, details) {
+  console.error('FAIL:', name, '-', message);
+  if (details) console.error('      ', details);
+  failures += 1;
+}
+
+function pass(name) {
+  console.log('PASS:', name);
+}
+
+function makeClassList() {
+  const classes = new Set();
+  return {
+    add(...names) { names.forEach((name) => classes.add(name)); },
+    remove(...names) { names.forEach((name) => classes.delete(name)); },
+    toggle(name, force) {
+      if (force === true) classes.add(name);
+      else if (force === false) classes.delete(name);
+      else if (classes.has(name)) classes.delete(name);
+      else classes.add(name);
+    },
+    contains(name) { return classes.has(name); },
+  };
+}
+
+function makeNode() {
+  return {
+    classList: makeClassList(),
+    style: {},
+    dataset: {},
+    hidden: false,
+    disabled: false,
+    value: '',
+    textContent: '',
+    innerHTML: '',
+    scrollHeight: 0,
+    scrollTop: 0,
+    clientHeight: 0,
+    appendChild(node) { return node; },
+    removeChild() {},
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    setAttribute(name, value) { this[name] = value; },
+    removeAttribute(name) { delete this[name]; },
+    addEventListener() {},
+    focus() {},
+    select() {},
+    remove() {},
+    click() {},
+  };
+}
+
+async function testNumericDeepLinkResolvesRealSessionId() {
+  const name = 'numeric deep link resolves server session id';
+  const fetchCalls = [];
+  const storage = new Map();
+
+  const document = {
+    cookie: '',
+    visibilityState: 'visible',
+    body: { classList: makeClassList() },
+    documentElement: { style: { setProperty() {} } },
+    getElementById() { return makeNode(); },
+    createElement() { return makeNode(); },
+    querySelector() { return makeNode(); },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+  };
+
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
+
+  const windowObj = {
+    TERM_LLM_UI_PREFIX: '/ui',
+    TERM_LLM_SIDEBAR_SESSIONS: 'all',
+    location: { pathname: '/ui/1291', search: '', origin: 'https://example.test' },
+    history: { pushState(_state, _title, url) { windowObj.location.pathname = url; } },
+    matchMedia() {
+      return {
+        matches: false,
+        addEventListener() {},
+        addListener() {},
+        removeEventListener() {},
+        removeListener() {},
+      };
+    },
+    navigator: { standalone: false, mediaDevices: null, serviceWorker: null },
+    visualViewport: null,
+    addEventListener() {},
+    removeEventListener() {},
+    requestAnimationFrame(callback) { return setTimeout(callback, 0); },
+    cancelAnimationFrame(handle) { clearTimeout(handle); },
+    setTimeout,
+    clearTimeout,
+    setInterval() { return 0; },
+    clearInterval() {},
+    focus() {},
+  };
+  windowObj.document = document;
+  windowObj.localStorage = localStorage;
+
+  const context = {
+    window: windowObj,
+    document,
+    localStorage,
+    history: windowObj.history,
+    location: windowObj.location,
+    navigator: windowObj.navigator,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval() { return 0; },
+    clearInterval() {},
+    URL,
+    URLSearchParams,
+    fetch: async (url) => {
+      fetchCalls.push(url);
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: 'sess_real',
+            number: 1291,
+            short_title: 'Real session',
+            long_title: 'Real session',
+            mode: 'chat',
+            origin: 'tui',
+            archived: false,
+            pinned: false,
+            created_at: 1710000000000,
+            message_count: 1,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_real/messages') {
+        return new Response(JSON.stringify({
+          messages: [{
+            role: 'user',
+            created_at: 1710000000000,
+            parts: [{ type: 'text', text: 'hello from server' }],
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_real/state') {
+        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/pending_1291/messages' || url === '/ui/v1/sessions/pending_1291/state') {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    Response,
+    Headers,
+    AbortController,
+    Notification: undefined,
+    renderMathInElement() {},
+    crypto: webcrypto,
+  };
+  context.globalThis = context;
+
+  vm.createContext(context);
+  vm.runInContext(coreSource, context, { filename: 'app-core.js' });
+
+  const app = windowObj.TermLLMApp;
+  Object.assign(app, {
+    persistAndRefreshShell() {},
+    refreshRelativeTimes() {},
+    openAuthModal() {},
+    closeAuthModal() {},
+    handleAuthFailure() {},
+    closeAskUserModal() {},
+    openAskUserModal() {},
+    setActiveResponseTracking() {},
+    clearActiveResponseTracking() {},
+    setStreaming() {},
+    resumeActiveResponse: async () => {},
+    renderSidebar() {},
+    renderMessages() {},
+    renderProviderOptions() {},
+    renderModelOptions() {},
+    normalizeSelectedProvider() {},
+    autoGrowPrompt() {},
+    updateVoiceUI() {},
+    toggleVoiceRecording() {},
+    fetchProviders: async () => [],
+    fetchModels: async () => [],
+    addErrorMessage() {},
+    sendMessage() {},
+    openSidebar() {},
+    closeSidebar() {},
+    closeSidebarIfMobile() {},
+    connectToken: async () => {},
+    submitAskUserModal: async () => {},
+    cancelActiveResponse: async () => {},
+    handleFiles() {},
+    openApprovalModal() {},
+    closeApprovalModal() {},
+    submitApprovalModal: async () => {},
+    registerServiceWorker: async () => null,
+    subscribeToPush() {},
+    refreshNotificationUI() {},
+    requestNotificationPermission: async () => 'default',
+    shouldAutoSubscribeToPush() { return false; },
+    detachResponseStream() {},
+    HEARTBEAT_STALE_THRESHOLD: 45000,
+    HEARTBEAT_ABORT_REASON: 'heartbeat stale',
+    applyDesktopSidebarState() {},
+    toggleSidebarCollapsed() {},
+    flushStreamPersistence() {},
+    requestHeaders() { return {}; },
+    normalizeError: async (resp) => ({ status: resp.status, message: `HTTP ${resp.status}` }),
+    renderAttachments() {},
+    updateSidebarStatus() {},
+  });
+
+  vm.runInContext(sessionsSource, context, { filename: 'app-sessions.js' });
+  await windowObj.__termllmInitializePromise;
+
+  if (app.state.activeSessionId !== 'sess_real') {
+    fail(name, 'active session id should be reconciled to real server id', `got ${app.state.activeSessionId}`);
+    return;
+  }
+  if (!fetchCalls.includes('/ui/v1/sessions/sess_real/messages')) {
+    fail(name, 'should load messages via resolved server session id', JSON.stringify(fetchCalls));
+    return;
+  }
+  if (fetchCalls.includes('/ui/v1/sessions/pending_1291/messages')) {
+    fail(name, 'should not request messages for pending stub id', JSON.stringify(fetchCalls));
+    return;
+  }
+  pass(name);
+}
+
+(async () => {
+  await testNumericDeepLinkResolvesRealSessionId();
+  if (failures > 0) process.exit(1);
+  process.exit(0);
+})();


### PR DESCRIPTION
## What

Fix web UI numeric deep links like `/ui/1291` when the app starts before it knows the real session ID.

The frontend was creating a placeholder session with an ID like `pending_1291`, but when `/v1/sessions` returned the real session summary it only reconciled by exact `id`. That left the placeholder active, so follow-up fetches went to `/v1/sessions/pending_1291/...` and the page stayed blank.

This change makes server session merging:

- match pending server-only stubs by `number`
- rewrite the stub to the real server `id`
- update active UI references that still point at the placeholder

## Why

CLI already works because the backend resolves numeric session identifiers correctly. The blank page is a frontend reconciliation bug that only appears when the browser opens a numeric deep link before it has cached the real session ID.

## Tests

Red/green regression coverage included:

- Added `internal/serveui/static/app_sessions_test.js`
- Verified it fails on `upstream/main` with:

```text
FAIL: numeric deep link resolves server session id - active session id should be reconciled to real server id
       got pending_1291
```

- Verified it passes with this branch
- Ran:

```bash
node internal/serveui/static/app_sessions_test.js
go test ./internal/serveui ./cmd/...
go build ./...
```
