### PR TITLE
fix: chunk webrtc response frames at 16KiB

### DIFF
--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -504,15 +504,15 @@
           markGotResponse();
           resolveOnce(new Response(nullBodyStatus(status) ? null : stream, { status, headers: new Headers(headers) }));
         },
-        onChunk(line) {
+        onChunk(fragment) {
           markGotResponse();
           if (!resolved) {
             resolveOnce(new Response(stream, { status: 200 })); // 200 is never null-body
           }
-          const chunk = typeof line === 'string' ? line : '';
-          responseBytes += chunk.length + 1; // +1 for the \n
+          const chunk = typeof fragment === 'string' ? fragment : '';
+          responseBytes += chunk.length;
           if (streamController) {
-            streamController.enqueue(encoder.encode(chunk + '\n'));
+            streamController.enqueue(encoder.encode(chunk));
           }
         },
         onDone(status) {

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pion/datachannel"
 	dtls "github.com/pion/dtls/v3"
@@ -54,9 +55,11 @@ type responseFrame struct {
 	ID      string            `json:"id"`
 	Type    string            `json:"type"`              // "headers", "chunk", or "done"
 	Headers map[string]string `json:"headers,omitempty"` // only for "headers"
-	Data    string            `json:"data"`              // SSE line; only for "chunk"; blank lines must survive JSON encoding
+	Data    string            `json:"data"`              // response body fragment; may be one of several frames for a single HTTP write
 	Status  int               `json:"status,omitempty"`  // HTTP status; for "headers" and "done"
 }
+
+const maxChunkDataBytes = 16 * 1024
 
 // peer is the home-side WebRTC peer.
 type peer struct {
@@ -684,6 +687,34 @@ func sendDoneFrame(send func(string) error, id string, status int) {
 	_ = send(string(data))
 }
 
+func sendChunkFrames(send func(string) error, id string, data string) {
+	if data == "" {
+		f := responseFrame{ID: id, Type: "chunk", Data: ""}
+		enc, _ := json.Marshal(f)
+		_ = send(string(enc))
+		return
+	}
+
+	for len(data) > 0 {
+		n := maxChunkDataBytes
+		if len(data) < n {
+			n = len(data)
+		} else {
+			for n > 0 && !utf8.ValidString(data[:n]) {
+				n--
+			}
+			if n == 0 {
+				// Defensive fallback: impossible for valid UTF-8 input, but avoid infinite loops.
+				n = len([]byte(string([]rune(data)[0])))
+			}
+		}
+		f := responseFrame{ID: id, Type: "chunk", Data: data[:n]}
+		enc, _ := json.Marshal(f)
+		_ = send(string(enc))
+		data = data[n:]
+	}
+}
+
 // dcResponseWriter implements http.ResponseWriter and http.Flusher.
 // It streams the response body as data-channel frames.
 type dcResponseWriter struct {
@@ -733,11 +764,9 @@ func (w *dcResponseWriter) Write(b []byte) (int, error) {
 		if idx < 0 {
 			break
 		}
-		line := string(data[:idx])
+		fragment := string(data[:idx+1])
 		w.buf.Next(idx + 1)
-		f := responseFrame{ID: w.id, Type: "chunk", Data: line}
-		enc, _ := json.Marshal(f)
-		_ = w.send(string(enc))
+		sendChunkFrames(w.send, w.id, fragment)
 	}
 	return len(b), nil
 }
@@ -755,10 +784,8 @@ func (w *dcResponseWriter) Flush() {
 // finish flushes any remaining buffered data and is called after ServeHTTP returns.
 func (w *dcResponseWriter) finish() {
 	if w.buf.Len() > 0 {
-		f := responseFrame{ID: w.id, Type: "chunk", Data: w.buf.String()}
+		sendChunkFrames(w.send, w.id, w.buf.String())
 		w.buf.Reset()
-		enc, _ := json.Marshal(f)
-		_ = w.send(string(enc))
 	}
 	status := w.status
 	if status == 0 {

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -32,6 +32,16 @@ func collectFrames(p *peer, rawFrame []byte) []responseFrame {
 	return frames
 }
 
+func collectChunkData(frames []responseFrame) string {
+	var b strings.Builder
+	for _, f := range frames {
+		if f.Type == "chunk" {
+			b.WriteString(f.Data)
+		}
+	}
+	return b.String()
+}
+
 func encodeRequest(id, method, path string, headers map[string]string, body string) []byte {
 	f := requestFrame{ID: id, Method: method, Path: path, Headers: headers}
 	if body != "" {
@@ -211,7 +221,7 @@ func TestChunkStreaming(t *testing.T) {
 	raw := encodeRequest("req6", "GET", "/ui/v1/responses", nil, "")
 	frames := collectFrames(p, raw)
 
-	// Expect: 1 headers frame, 6 chunk frames, 1 done frame.
+	// Expect: 1 headers frame, chunk frames, 1 done frame.
 	if len(frames) < 3 {
 		t.Fatalf("too few frames: %v", frames)
 	}
@@ -222,20 +232,43 @@ func TestChunkStreaming(t *testing.T) {
 		t.Errorf("headers frame missing x-response-id: %v", frames[0].Headers)
 	}
 
-	var chunks []responseFrame
-	for _, f := range frames {
-		if f.Type == "chunk" {
-			chunks = append(chunks, f)
-		}
-	}
-	// At minimum we expect 6 SSE lines as chunks.
-	if len(chunks) < 6 {
-		t.Errorf("expected at least 6 chunks, got %d", len(chunks))
+	got := collectChunkData(frames)
+	want := "event: ping\ndata: {}\n\nevent: ping\ndata: {}\n\n"
+	if got != want {
+		t.Fatalf("chunk data mismatch\ngot:  %q\nwant: %q", got, want)
 	}
 
 	last := frames[len(frames)-1]
 	if last.Type != "done" || last.Status != http.StatusOK {
 		t.Errorf("last frame should be done/200, got %v", last)
+	}
+}
+
+func TestChunkWriter_SplitsLargePayloadInto16KFrames(t *testing.T) {
+	large := strings.Repeat("🙂", maxChunkDataBytes) + "tail"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(large))
+	})
+	p := newTestPeer("/ui", handler)
+	raw := encodeRequest("req-large", "GET", "/ui/v1/models", nil, "")
+	frames := collectFrames(p, raw)
+
+	var chunkCount int
+	for _, f := range frames {
+		if f.Type != "chunk" {
+			continue
+		}
+		chunkCount++
+		if len([]byte(f.Data)) > maxChunkDataBytes {
+			t.Fatalf("chunk size = %d, want <= %d", len([]byte(f.Data)), maxChunkDataBytes)
+		}
+	}
+	if chunkCount < 2 {
+		t.Fatalf("expected payload to split across multiple chunk frames, got %d", chunkCount)
+	}
+	if got := collectChunkData(frames); got != large {
+		t.Fatalf("reconstructed payload mismatch: got %d bytes want %d", len(got), len(large))
 	}
 }
 


### PR DESCRIPTION
## What

Chunk WebRTC response body frames to 16 KiB and reassemble them exactly in the browser.

This changes the response path so large JSON payloads (like session loads) no longer depend on a single oversized RTCDataChannel message making it through intact.

## Why

The current WebRTC transport sends each response chunk as a single JSON frame. That is brittle for larger payloads, especially session/message loads that may be emitted as one big HTTP write.

This patch makes the transport deterministic:

- split response body data into fragments capped at 16 KiB (down from the previous implicit single-frame behavior, and smaller than the earlier 32 KiB draft)
- preserve exact payload bytes across fragmentation/reassembly
- keep SSE working by sending real newline-containing fragments instead of reconstructing by appending `\n` client-side

## Tests

- `go test ./internal/webrtc ./cmd/...`
- `go build ./...`

## Notes

- adds a regression test that forces a large response to span multiple WebRTC chunk frames and verifies exact reconstruction
- updates the existing streaming test to verify exact SSE payload reconstruction end-to-end
