### PR TITLE
fix: hide developer role messages in web UI history

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -417,8 +417,8 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 
 	result := make([]messageEntry, 0, len(msgs))
 	for _, msg := range msgs {
-		// System messages contain the internal system prompt — never expose to UI clients.
-		if msg.Role == llm.RoleSystem {
+		// System and developer messages contain internal prompts — never expose to UI clients.
+		if msg.Role == llm.RoleSystem || msg.Role == llm.RoleDeveloper {
 			continue
 		}
 		entry := messageEntry{

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2066,7 +2066,7 @@ func TestHandleSessionMessages_OmitsToolResults(t *testing.T) {
 	}
 }
 
-func TestHandleSessionMessages_OmitsSystemMessages(t *testing.T) {
+func TestHandleSessionMessages_OmitsSystemAndDeveloperMessages(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -2087,6 +2087,14 @@ func TestHandleSessionMessages_OmitsSystemMessages(t *testing.T) {
 	sysMsg := session.NewMessage("sess-sys", llm.SystemText("You are a helpful assistant."), -1)
 	if err := store.AddMessage(ctx, "sess-sys", sysMsg); err != nil {
 		t.Fatalf("AddMessage(system): %v", err)
+	}
+	// Add a developer message (platform developer prompt, persisted with role=developer)
+	devMsg := session.NewMessage("sess-sys", llm.Message{
+		Role:  llm.RoleDeveloper,
+		Parts: []llm.Part{{Type: llm.PartText, Text: "You are Jarvis, a personal AI assistant."}},
+	}, -1)
+	if err := store.AddMessage(ctx, "sess-sys", devMsg); err != nil {
+		t.Fatalf("AddMessage(developer): %v", err)
 	}
 	// Add a user message
 	userMsg := session.NewMessage("sess-sys", llm.UserText("hello"), -1)
@@ -2120,11 +2128,14 @@ func TestHandleSessionMessages_OmitsSystemMessages(t *testing.T) {
 	}
 
 	if len(body.Messages) != 2 {
-		t.Fatalf("message count = %d, want 2 (system message should be filtered)", len(body.Messages))
+		t.Fatalf("message count = %d, want 2 (system+developer should be filtered)", len(body.Messages))
 	}
 	for _, m := range body.Messages {
 		if m.Role == "system" {
 			t.Fatal("system messages should be filtered from API response")
+		}
+		if m.Role == "developer" {
+			t.Fatal("developer messages should be filtered from API response")
 		}
 	}
 }

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -178,7 +178,7 @@ const convertServerMessages = (serverMessages) => {
     const parts = Array.isArray(msg.parts) ? msg.parts : [];
     const created = msg.created_at || Date.now();
 
-    if (msg.role === 'system') continue;
+    if (msg.role === 'system' || msg.role === 'developer') continue;
 
     if (msg.role === 'user') {
       flushGroup();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -257,8 +257,210 @@ async function testNumericDeepLinkResolvesRealSessionId() {
   pass(name);
 }
 
+async function testDeveloperMessagesAreHidden() {
+  const name = 'developer role messages are excluded from converted messages';
+  const storage = new Map();
+
+  const document = {
+    cookie: '',
+    visibilityState: 'visible',
+    body: { classList: makeClassList() },
+    documentElement: { style: { setProperty() {} } },
+    getElementById() { return makeNode(); },
+    createElement() { return makeNode(); },
+    querySelector() { return makeNode(); },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+  };
+
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
+
+  const windowObj = {
+    TERM_LLM_UI_PREFIX: '/ui',
+    TERM_LLM_SIDEBAR_SESSIONS: 'all',
+    location: { pathname: '/ui/42', search: '', origin: 'https://example.test' },
+    history: { pushState(_state, _title, url) { windowObj.location.pathname = url; } },
+    matchMedia() {
+      return {
+        matches: false,
+        addEventListener() {},
+        addListener() {},
+        removeEventListener() {},
+        removeListener() {},
+      };
+    },
+    navigator: { standalone: false, mediaDevices: null, serviceWorker: null },
+    visualViewport: null,
+    addEventListener() {},
+    removeEventListener() {},
+    requestAnimationFrame(callback) { return setTimeout(callback, 0); },
+    cancelAnimationFrame(handle) { clearTimeout(handle); },
+    setTimeout,
+    clearTimeout,
+    setInterval() { return 0; },
+    clearInterval() {},
+    focus() {},
+  };
+  windowObj.document = document;
+  windowObj.localStorage = localStorage;
+
+  const context = {
+    window: windowObj,
+    document,
+    localStorage,
+    history: windowObj.history,
+    location: windowObj.location,
+    navigator: windowObj.navigator,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval() { return 0; },
+    clearInterval() {},
+    URL,
+    URLSearchParams,
+    fetch: async (url) => {
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: 'sess_dev',
+            number: 42,
+            short_title: 'Dev msg test',
+            long_title: 'Dev msg test',
+            mode: 'chat',
+            origin: 'web',
+            archived: false,
+            pinned: false,
+            created_at: 1710000000000,
+            message_count: 2,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_dev/messages') {
+        return new Response(JSON.stringify({
+          messages: [
+            {
+              role: 'developer',
+              created_at: 1710000000000,
+              parts: [{ type: 'text', text: 'You are Jarvis, a personal assistant.' }],
+            },
+            {
+              role: 'user',
+              created_at: 1710000001000,
+              parts: [{ type: 'text', text: 'hello' }],
+            },
+            {
+              role: 'assistant',
+              created_at: 1710000002000,
+              parts: [{ type: 'text', text: 'hi there' }],
+            },
+          ]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_dev/state') {
+        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    Response,
+    Headers,
+    AbortController,
+    Notification: undefined,
+    renderMathInElement() {},
+    crypto: webcrypto,
+  };
+  context.globalThis = context;
+
+  vm.createContext(context);
+  vm.runInContext(coreSource, context, { filename: 'app-core.js' });
+
+  const app = windowObj.TermLLMApp;
+  Object.assign(app, {
+    persistAndRefreshShell() {},
+    refreshRelativeTimes() {},
+    openAuthModal() {},
+    closeAuthModal() {},
+    handleAuthFailure() {},
+    closeAskUserModal() {},
+    openAskUserModal() {},
+    setActiveResponseTracking() {},
+    clearActiveResponseTracking() {},
+    setStreaming() {},
+    resumeActiveResponse: async () => {},
+    renderSidebar() {},
+    renderMessages() {},
+    renderProviderOptions() {},
+    renderModelOptions() {},
+    normalizeSelectedProvider() {},
+    autoGrowPrompt() {},
+    updateVoiceUI() {},
+    toggleVoiceRecording() {},
+    fetchProviders: async () => [],
+    fetchModels: async () => [],
+    addErrorMessage() {},
+    sendMessage() {},
+    openSidebar() {},
+    closeSidebar() {},
+    closeSidebarIfMobile() {},
+    connectToken: async () => {},
+    submitAskUserModal: async () => {},
+    cancelActiveResponse: async () => {},
+    handleFiles() {},
+    openApprovalModal() {},
+    closeApprovalModal() {},
+    submitApprovalModal: async () => {},
+    registerServiceWorker: async () => null,
+    subscribeToPush() {},
+    refreshNotificationUI() {},
+    requestNotificationPermission: async () => 'default',
+    shouldAutoSubscribeToPush() { return false; },
+    detachResponseStream() {},
+    HEARTBEAT_STALE_THRESHOLD: 45000,
+    HEARTBEAT_ABORT_REASON: 'heartbeat stale',
+    applyDesktopSidebarState() {},
+    toggleSidebarCollapsed() {},
+    flushStreamPersistence() {},
+    requestHeaders() { return {}; },
+    normalizeError: async (resp) => ({ status: resp.status, message: `HTTP ${resp.status}` }),
+    renderAttachments() {},
+    updateSidebarStatus() {},
+  });
+
+  vm.runInContext(sessionsSource, context, { filename: 'app-sessions.js' });
+  await windowObj.__termllmInitializePromise;
+
+  const session = app.state.sessions.find(s => s.id === 'sess_dev');
+  if (!session) {
+    fail(name, 'session not found');
+    return;
+  }
+
+  const developerMsg = session.messages.find(m => m.role === 'developer');
+  if (developerMsg) {
+    fail(name, 'developer message should not appear in converted messages');
+    return;
+  }
+
+  const devContent = session.messages.find(m => m.content && m.content.includes('You are Jarvis'));
+  if (devContent) {
+    fail(name, 'developer message content leaked into another role', `role=${devContent.role}`);
+    return;
+  }
+
+  if (session.messages.length !== 2) {
+    fail(name, `expected 2 messages (user + assistant), got ${session.messages.length}`);
+    return;
+  }
+
+  pass(name);
+}
+
 (async () => {
   await testNumericDeepLinkResolvesRealSessionId();
+  await testDeveloperMessagesAreHidden();
   if (failures > 0) process.exit(1);
   process.exit(0);
 })();


### PR DESCRIPTION
## Problem

Developer role messages (containing the full platform system prompt) were rendering visibly in the web UI chat history as assistant messages. This made the UI confusing — users would see the internal developer prompt displayed alongside their conversation.

## Root cause

Two layers were missing the `developer` role filter:

1. **Server** (`cmd/serve_handlers.go`): The `/messages` endpoint already skipped `system` role messages but not `developer`. Developer messages were sent to the client with `role: "developer"`.

2. **Client** (`app-sessions.js`): `convertServerMessages()` skipped `system` but not `developer`, so developer messages fell through to the assistant parts loop and rendered as generic messages.

## Fix

- **Server**: Skip `developer` alongside `system` in the messages endpoint — defense in depth, the server shouldn't send internal prompts to UI clients at all.
- **Client**: Skip `developer` alongside `system` in `convertServerMessages()`.

## Provider re-wrapping note

Some providers (e.g. Anthropic) don't support `developer` role natively — the LLM call layer re-wraps developer text into `<developer>` tags prepended to the next user turn. This re-wrapping only happens at the wire protocol layer; the persistence layer (SQLite) always stores `role='developer'`. So the filter works correctly regardless of which provider was used for the session.

## Tests

- **Server**: Extended `TestHandleSessionMessages_OmitsSystemMessages` → `TestHandleSessionMessages_OmitsSystemAndDeveloperMessages` — adds a developer message to the fixture, verifies it's filtered from the API response.
- **Client**: Added `testDeveloperMessagesAreHidden()` regression test — mocks server returning developer/user/assistant messages, verifies developer messages don't appear in converted output.