### PR TITLE
fix: Active sessions can be evicted and cancelled while still streaming

### DIFF
--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -58,7 +58,7 @@ func (m *serveSessionManager) evictExpired() {
 
 	m.mu.Lock()
 	for id, rt := range m.sessions {
-		if now.Sub(rt.LastUsed()) > m.ttl {
+		if now.Sub(rt.LastUsed()) > m.ttl && !rt.hasActiveRun() {
 			delete(m.sessions, id)
 			stale = append(stale, rt)
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1038,6 +1038,58 @@ func TestServeSessionManager_GetOrCreateSingleFactoryCall(t *testing.T) {
 	}
 }
 
+func TestServeSessionManager_EvictExpiredSkipsActiveRun(t *testing.T) {
+	manager := newServeSessionManager(10*time.Millisecond, 10, nil)
+	defer manager.Close()
+
+	var evictions atomic.Int32
+	manager.onEvict = func(rt *serveRuntime) {
+		evictions.Add(1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rt := &serveRuntime{}
+	rt.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+	state := &runtimeInterruptState{cancel: cancel, done: make(chan struct{})}
+	rt.setActiveInterrupt(state)
+
+	manager.mu.Lock()
+	manager.sessions["busy"] = rt
+	manager.mu.Unlock()
+
+	manager.evictExpired()
+
+	manager.mu.Lock()
+	_, ok := manager.sessions["busy"]
+	manager.mu.Unlock()
+	if !ok {
+		t.Fatal("expected active expired session to remain in manager")
+	}
+	if got := evictions.Load(); got != 0 {
+		t.Fatalf("evictions after active session sweep = %d, want 0", got)
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("expected active session not to be cancelled during eviction sweep")
+	default:
+	}
+
+	rt.clearActiveInterrupt(state)
+	manager.evictExpired()
+
+	manager.mu.Lock()
+	_, ok = manager.sessions["busy"]
+	manager.mu.Unlock()
+	if ok {
+		t.Fatal("expected inactive expired session to be evicted")
+	}
+	if got := evictions.Load(); got != 1 {
+		t.Fatalf("evictions after inactive session sweep = %d, want 1", got)
+	}
+}
+
 func TestRequireJSONContentType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	if err := requireJSONContentType(req); err == nil {


### PR DESCRIPTION
## What

- prevent the session janitor from evicting runtimes whose TTL has expired while they still have an active run
- add a regression test covering an expired session that is still streaming and verifying it is only evicted after the active run clears

## Why

A long-running streamed response can exceed `--session-ttl`. Before this change, the janitor would remove that runtime from the session map and call `Close()`, which cancels the active interrupt context mid-stream. This keeps busy sessions alive until they become idle so in-flight responses are not cancelled spuriously.
