### PR TITLE
fix: Reusing a session ID with a different provider silently keeps the old provider

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -881,6 +881,13 @@ func (s *serveServer) runtimeForProviderRequest(ctx context.Context, sessionID s
 	if err != nil {
 		return nil, false, err
 	}
+	existingProvider := strings.TrimSpace(rt.providerKey)
+	if existingProvider == "" && rt.provider != nil {
+		existingProvider = strings.TrimSpace(rt.provider.Name())
+	}
+	if existingProvider != "" && existingProvider != providerName {
+		return nil, false, fmt.Errorf("session %q already uses provider %q (requested %q)", sessionID, existingProvider, providerName)
+	}
 	return rt, true, nil
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4109,6 +4109,60 @@ func TestHandleResponses_WithProviderField(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_WithProviderFieldRejectsDifferentProviderForExistingSession(t *testing.T) {
+	newRuntime := func(providerKey string) *serveRuntime {
+		provider := llm.NewMockProvider(providerKey).AddTextResponse("ok")
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  providerKey,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt
+	}
+
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return newRuntime("mock"), nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfgRef:     &config.Config{DefaultProvider: "mock"},
+		sessionMgr: manager,
+		runtimeFactory: func(ctx context.Context, providerName string, model string) (*serveRuntime, error) {
+			if providerName == "" {
+				providerName = "mock"
+			}
+			return newRuntime(providerName), nil
+		},
+	}
+
+	const sessionID = "sess-provider-mismatch"
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"hello"}`))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstReq.Header.Set("session_id", sessionID)
+	firstRR := httptest.NewRecorder()
+	srv.handleResponses(firstRR, firstReq)
+	if firstRR.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want 200; body: %s", firstRR.Code, firstRR.Body.String())
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"hello again","provider":"other"}`))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondReq.Header.Set("session_id", sessionID)
+	secondRR := httptest.NewRecorder()
+	srv.handleResponses(secondRR, secondReq)
+	if secondRR.Code != http.StatusBadRequest {
+		t.Fatalf("second status = %d, want 400; body: %s", secondRR.Code, secondRR.Body.String())
+	}
+	if !strings.Contains(secondRR.Body.String(), `already uses provider`) {
+		t.Fatalf("expected provider mismatch error, got body: %s", secondRR.Body.String())
+	}
+}
+
 func TestSessionManager_GetOrCreateWithDeduplication(t *testing.T) {
 	var calls int32
 	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {


### PR DESCRIPTION
## What

- detect when a stateful serve session is reused with a different requested provider
- return an explicit error instead of silently reusing the existing runtime
- add a regression test covering a reused session ID with a provider override

## Why

Session runtimes are keyed by session ID, so reusing a session ID with a different non-default provider could previously return the existing runtime and ignore the requested provider. That could send requests to the wrong backend and mix conversation state across providers with no error.
