### PR TITLE
fix: Failed first run permanently suppresses the platform developer message

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -395,10 +395,11 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		rt.lastInjectedPlatform = ""
 	}
 
+	var injectedPlatform string
 	if devText := rt.platformMessages.For(rt.platform); devText != "" && rt.lastInjectedPlatform != rt.platform {
 		devMsg := llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: devText}}}
 		inputMessages = append([]llm.Message{devMsg}, inputMessages...)
-		rt.lastInjectedPlatform = rt.platform
+		injectedPlatform = rt.platform
 	}
 
 	runCtx, runCancel := context.WithCancel(ctx)
@@ -426,6 +427,12 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	req.Messages = messages
 
 	var produced []llm.Message
+	persistPlatformInjection := func() {
+		if injectedPlatform != "" && (stateful || persisted) {
+			rt.lastInjectedPlatform = injectedPlatform
+		}
+	}
+
 	persistProducedSnapshot := func(persistCtx context.Context) {
 		snapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+len(produced))
 		snapshot = append(snapshot, baseHistory...)
@@ -437,6 +444,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		if persisted {
 			rt.persistSnapshot(persistCtx, req.SessionID, snapshot)
 		}
+		persistPlatformInjection()
 	}
 	// ResponseCompletedCallback receives the assistant message (with tool call parts)
 	// immediately after streaming, BEFORE tool execution. Without this, tool calls
@@ -533,6 +541,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	if persisted {
 		rt.persistSnapshot(ctx, req.SessionID, newHistory)
 	}
+	persistPlatformInjection()
 
 	return result, nil
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
+	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/serveui"
@@ -1263,6 +1265,66 @@ func TestServeRuntimeRun_PersistsSessionAndMessages(t *testing.T) {
 	}
 	if msgs[len(msgs)-1].Role != llm.RoleAssistant {
 		t.Fatalf("last role = %s, want assistant", msgs[len(msgs)-1].Role)
+	}
+}
+
+func TestServeRuntimeRun_ReinjectsPlatformDeveloperMessageAfterFailedFirstRun(t *testing.T) {
+	provider := llm.NewMockProvider("mock").
+		AddError(errors.New("boom")).
+		AddTextResponse("hello from serve")
+	engine := llm.NewEngine(provider, nil)
+	devText := "telegram developer instructions"
+	input := []llm.Message{llm.UserText("hello")}
+
+	rt := &serveRuntime{
+		provider:         provider,
+		engine:           engine,
+		platform:         "telegram",
+		platformMessages: agents.PlatformMessagesConfig{Telegram: devText},
+	}
+	rt.Touch()
+
+	_, err := rt.Run(context.Background(), true, false, input, llm.Request{})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("first Run error = %v, want boom", err)
+	}
+	if rt.lastInjectedPlatform != "" {
+		t.Fatalf("lastInjectedPlatform = %q, want empty after failed first run", rt.lastInjectedPlatform)
+	}
+	if len(rt.history) != 0 {
+		t.Fatalf("history len = %d, want 0 after failed first run", len(rt.history))
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("request count after first run = %d, want 1", len(provider.Requests))
+	}
+	if len(provider.Requests[0].Messages) != 2 {
+		t.Fatalf("first request message count = %d, want 2", len(provider.Requests[0].Messages))
+	}
+	if provider.Requests[0].Messages[0].Role != llm.RoleDeveloper || provider.Requests[0].Messages[0].Parts[0].Text != devText {
+		t.Fatalf("first request did not include injected developer message: %+v", provider.Requests[0].Messages)
+	}
+
+	_, err = rt.Run(context.Background(), true, false, input, llm.Request{})
+	if err != nil {
+		t.Fatalf("second Run failed: %v", err)
+	}
+	if rt.lastInjectedPlatform != "telegram" {
+		t.Fatalf("lastInjectedPlatform = %q, want telegram after successful run", rt.lastInjectedPlatform)
+	}
+	if len(provider.Requests) != 2 {
+		t.Fatalf("request count after second run = %d, want 2", len(provider.Requests))
+	}
+	if len(provider.Requests[1].Messages) != 2 {
+		t.Fatalf("second request message count = %d, want 2", len(provider.Requests[1].Messages))
+	}
+	if provider.Requests[1].Messages[0].Role != llm.RoleDeveloper || provider.Requests[1].Messages[0].Parts[0].Text != devText {
+		t.Fatalf("second request did not re-include injected developer message: %+v", provider.Requests[1].Messages)
+	}
+	if len(rt.history) < 3 {
+		t.Fatalf("history len = %d, want at least 3 after successful run", len(rt.history))
+	}
+	if rt.history[0].Role != llm.RoleDeveloper || rt.history[0].Parts[0].Text != devText {
+		t.Fatalf("history missing injected developer message: %+v", rt.history)
 	}
 }
 


### PR DESCRIPTION
## What

Delay updating `lastInjectedPlatform` until the platform developer message has actually been recorded in runtime history or persisted session snapshots.

Also add a regression test covering a failed first run followed by a successful retry, ensuring the developer message is reinjected after the failure.

## Why

Previously, the runtime marked the platform as already injected before the run had succeeded or been persisted. If the first request failed early, the developer message never made it into `rt.history`, but later turns still skipped reinjection, so the session could continue without its platform-specific instructions.
