### PR TITLE
fix: Telegram handler panics on messages with nil From

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -649,6 +649,10 @@ func (m *telegramSessionMgr) runStoreOpWithTimeout(sessionID, op string, fn func
 }
 
 func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.BotAPI, msg *tgbotapi.Message) {
+	if msg.From == nil {
+		log.Printf("[telegram] ignoring message with no sender")
+		return
+	}
 	if !m.isAllowed(msg.From.ID, msg.From.UserName) {
 		log.Printf("[telegram] ignoring message from unauthorised user %d (@%s)", msg.From.ID, msg.From.UserName)
 		return

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -87,6 +87,18 @@ func newTestMgrAndSession(h *testutil.EngineHarness) (*telegramSessionMgr, *tele
 	return mgr, sess
 }
 
+func TestHandleMessage_IgnoresMessagesWithNilFrom(t *testing.T) {
+	mgr := &telegramSessionMgr{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleMessage panicked: %v", r)
+		}
+	}()
+
+	mgr.handleMessage(context.Background(), nil, &tgbotapi.Message{Text: "hi"})
+}
+
 // --- TestBuildSegment ---
 
 func TestBuildSegment(t *testing.T) {


### PR DESCRIPTION
## What

Add a nil check for `msg.From` at the start of the Telegram message handler so updates without a sender are ignored instead of panicking.
Also add a regression test covering a message with a nil `From` field.

## Why

Telegram can deliver updates such as channel posts or anonymous admin messages without `From`. The handler previously dereferenced `msg.From.ID` and `msg.From.UserName` unconditionally, which crashed the bot before it could finish authorization checks or logging.
