### PR TITLE
fix: Responses API 404 retry drops conversation history instead of restoring it

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -412,6 +412,8 @@ func BuildResponsesToolChoice(choice ToolChoice) interface{} {
 
 // Stream makes a streaming request to the Responses API and returns events via a Stream
 func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debugRaw bool) (Stream, error) {
+	fullInput := req.Input
+
 	// Use server state: send previous_response_id if we have one (unless disabled)
 	if !c.DisableServerState && c.LastResponseID != "" {
 		req.PreviousResponseID = c.LastResponseID
@@ -494,6 +496,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 			// Clear state and retry with full history
 			c.LastResponseID = ""
 			req.PreviousResponseID = ""
+			req.Input = fullInput
 			// Re-marshal without previous_response_id
 			body, err = json.Marshal(req)
 			if err != nil {

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -763,6 +763,101 @@ func TestBuildResponsesInput_ConvertsDanglingToolCalls(t *testing.T) {
 	}
 }
 
+func TestResponsesClientStream_Retries404WithFullHistory(t *testing.T) {
+	type capturedRequest struct {
+		PreviousResponseID string               `json:"previous_response_id"`
+		Input              []ResponsesInputItem `json:"input"`
+	}
+
+	callCount := 0
+	requests := make([]capturedRequest, 0, 2)
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			callCount++
+			defer r.Body.Close()
+
+			var payload capturedRequest
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read request body: %w", err)
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return nil, fmt.Errorf("failed to decode request body: %w", err)
+			}
+			requests = append(requests, payload)
+
+			if callCount == 1 {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Status:     "404 Not Found",
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"error":"previous_response_id not found"}`)),
+				}, nil
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:        "https://example.test/v1/responses",
+		GetAuthHeader:  func() string { return "Bearer test-token" },
+		HTTPClient:     httpClient,
+		LastResponseID: "resp_prev",
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model: "gpt-5.2",
+		Input: []ResponsesInputItem{
+			{Type: "message", Role: "developer", Content: "Be concise"},
+			{Type: "message", Role: "user", Content: "old question"},
+			{Type: "message", Role: "assistant", Content: "old answer"},
+			{Type: "message", Role: "user", Content: "new question"},
+		},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("expected stream to succeed after 404 retry, got error: %v", err)
+	}
+	defer stream.Close()
+	drainStreamToDone(t, stream)
+
+	if callCount != 2 {
+		t.Fatalf("expected 2 HTTP calls (initial + retry), got %d", callCount)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 captured requests, got %d", len(requests))
+	}
+
+	if requests[0].PreviousResponseID != "resp_prev" {
+		t.Fatalf("expected initial previous_response_id resp_prev, got %q", requests[0].PreviousResponseID)
+	}
+	if len(requests[0].Input) != 1 {
+		t.Fatalf("expected initial request to send only new input, got %d items", len(requests[0].Input))
+	}
+	if requests[0].Input[0].Content != "new question" {
+		t.Fatalf("expected initial request to send latest user message, got %#v", requests[0].Input[0].Content)
+	}
+
+	if requests[1].PreviousResponseID != "" {
+		t.Fatalf("expected retry request to clear previous_response_id, got %q", requests[1].PreviousResponseID)
+	}
+	if len(requests[1].Input) != 4 {
+		t.Fatalf("expected retry request to restore full history, got %d items", len(requests[1].Input))
+	}
+	if requests[1].Input[0].Role != "developer" || requests[1].Input[1].Content != "old question" || requests[1].Input[2].Content != "old answer" || requests[1].Input[3].Content != "new question" {
+		t.Fatalf("expected retry request to preserve full history, got %+v", requests[1].Input)
+	}
+	if client.LastResponseID != "" {
+		t.Fatalf("expected client LastResponseID to be cleared after 404 retry, got %q", client.LastResponseID)
+	}
+}
+
 func TestResponsesClient_OnAuthRetry_RefreshesAndRetries(t *testing.T) {
 	callCount := 0
 	httpClient := &http.Client{


### PR DESCRIPTION
## What

Restore the original `input` payload when a Responses API request gets a 404 for `previous_response_id` and is retried without server state.

Also add a regression test covering the retry flow to verify the first request sends only the new user input and the retry restores the full conversation history.

## Why

The client filtered `req.Input` down to only new input before the first request. On a 404 retry it cleared `previous_response_id`, but reused that already-filtered request body, so prior conversation context was silently lost after server-side state expiry.
