### PR TITLE
fix: Engine.Interject can block indefinitely despite claiming to be non-blocking

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -366,11 +366,12 @@ func (e *Engine) SetMaxToolOutputChars(n int) {
 // Safe to call from any goroutine (e.g., the TUI thread).
 func (e *Engine) Interject(text string) {
 	e.callbackMu.Lock()
+	defer e.callbackMu.Unlock()
+
 	if e.interjection == nil {
 		e.interjection = make(chan string, 1)
 	}
 	ch := e.interjection
-	e.callbackMu.Unlock()
 
 	// Drain-then-send: replace any pending interjection with the new one.
 	select {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1673,6 +1673,46 @@ func TestEngineInterjection_DrainOnNoPending(t *testing.T) {
 	}
 }
 
+// TestEngineInterject_ConcurrentCallsDoNotBlock verifies that concurrent
+// Interject calls remain non-blocking even when several goroutines race to
+// replace the single pending interjection.
+func TestEngineInterject_ConcurrentCallsDoNotBlock(t *testing.T) {
+	for attempt := 0; attempt < 50; attempt++ {
+		engine := NewEngine(NewMockProvider("test"), nil)
+
+		const goroutines = 32
+		start := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				engine.Interject(fmt.Sprintf("msg-%d", i))
+			}(i)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		close(start)
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("concurrent Interject calls blocked on attempt %d", attempt)
+		}
+
+		if text := engine.DrainInterjection(); text == "" {
+			t.Fatalf("expected an interjection to remain queued on attempt %d", attempt)
+		}
+	}
+}
+
 // TestEngineInterjection_TurnCallback verifies that the turn callback receives
 // the interjected user message for session persistence.
 func TestEngineInterjection_TurnCallback(t *testing.T) {


### PR DESCRIPTION
## What

- keep `Engine.Interject`'s drain-and-replace logic under `callbackMu` so concurrent callers cannot race between draining and sending
- add a regression test that exercises many concurrent `Interject` calls and asserts they do not block

## Why

`Interject` is documented as non-blocking, but the final send happened after releasing the lock. Two goroutines could both observe the channel as empty and then race to send, leaving one blocked forever on the size-1 channel. Serializing the drain+send sequence preserves the replace-latest behavior without letting concurrent interjections hang the caller.
