### PR TITLE
fix: OpenAI provider ignores explicit parallel_tool_calls=false

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -123,8 +123,8 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req Request) (Stream, error
 	if req.ToolChoice.Mode != "" {
 		responsesReq.ToolChoice = BuildResponsesToolChoice(req.ToolChoice)
 	}
-	if req.ParallelToolCalls {
-		responsesReq.ParallelToolCalls = boolPtr(true)
+	if len(tools) > 0 {
+		responsesReq.ParallelToolCalls = boolPtr(req.ParallelToolCalls)
 	}
 	if req.Temperature > 0 {
 		v := float64(req.Temperature)

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,78 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOpenAIProviderStreamSendsExplicitParallelToolCallsFalse(t *testing.T) {
+	var got struct {
+		ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty"`
+		Tools             []json.RawMessage `json:"tools,omitempty"`
+		Stream            bool              `json:"stream"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	provider := &OpenAIProvider{
+		apiKey: "test-key",
+		model:  "gpt-4.1",
+		responsesClient: &ResponsesClient{
+			BaseURL:       ts.URL,
+			GetAuthHeader: func() string { return "Bearer test-key" },
+			HTTPClient:    ts.Client(),
+		},
+	}
+
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+		Tools: []ToolSpec{{
+			Name:        "echo",
+			Description: "Echo input",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"text": map[string]interface{}{"type": "string"},
+				},
+			},
+		}},
+		ParallelToolCalls: false,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.ParallelToolCalls == nil {
+		t.Fatal("expected parallel_tool_calls to be sent explicitly")
+	}
+	if *got.ParallelToolCalls {
+		t.Fatalf("expected parallel_tool_calls=false, got %v", *got.ParallelToolCalls)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(got.Tools))
+	}
+	if !got.Stream {
+		t.Fatal("expected stream=true")
+	}
+}


### PR DESCRIPTION
## What

- send `parallel_tool_calls` whenever the OpenAI Responses request includes tools so explicit `false` is preserved
- add a regression test covering `ParallelToolCalls: false` for the OpenAI provider

## Why

OpenAI can default to parallel tool execution when the field is omitted. Callers that explicitly disable parallel tool calls were still getting parallel execution because the provider only sent the field when the value was `true`.
