### PR TITLE
fix: Session-capacity eviction can kill an actively running session

### DIFF
--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -73,6 +73,32 @@ func (m *serveSessionManager) evictExpired() {
 	}
 }
 
+func (m *serveSessionManager) evictOldestIdleLocked() *serveRuntime {
+	if len(m.sessions) < m.max {
+		return nil
+	}
+
+	oldestID := ""
+	var oldestTime time.Time
+	for sid, srt := range m.sessions {
+		if srt.hasActiveRun() {
+			continue
+		}
+		t := srt.LastUsed()
+		if oldestID == "" || t.Before(oldestTime) {
+			oldestID = sid
+			oldestTime = t
+		}
+	}
+	if oldestID == "" {
+		return nil
+	}
+
+	evicted := m.sessions[oldestID]
+	delete(m.sessions, oldestID)
+	return evicted
+}
+
 // Get returns an existing session runtime without creating one.
 // Returns (nil, false) if the session does not exist.
 func (m *serveSessionManager) Get(id string) (*serveRuntime, bool) {
@@ -134,21 +160,7 @@ func (m *serveSessionManager) GetOrCreate(ctx context.Context, id string) (*serv
 			duplicate = rt
 		} else {
 			rt.Touch()
-			if len(m.sessions) >= m.max {
-				oldestID := ""
-				var oldestTime time.Time
-				for sid, srt := range m.sessions {
-					t := srt.LastUsed()
-					if oldestID == "" || t.Before(oldestTime) {
-						oldestID = sid
-						oldestTime = t
-					}
-				}
-				if oldestID != "" {
-					evicted = m.sessions[oldestID]
-					delete(m.sessions, oldestID)
-				}
-			}
+			evicted = m.evictOldestIdleLocked()
 			m.sessions[id] = rt
 			inflight.rt = rt
 		}
@@ -230,21 +242,7 @@ func (m *serveSessionManager) GetOrCreateWith(ctx context.Context, id string, cr
 			duplicate = rt
 		} else {
 			rt.Touch()
-			if len(m.sessions) >= m.max {
-				oldestID := ""
-				var oldestTime time.Time
-				for sid, srt := range m.sessions {
-					t := srt.LastUsed()
-					if oldestID == "" || t.Before(oldestTime) {
-						oldestID = sid
-						oldestTime = t
-					}
-				}
-				if oldestID != "" {
-					evicted = m.sessions[oldestID]
-					delete(m.sessions, oldestID)
-				}
-			}
+			evicted = m.evictOldestIdleLocked()
 			m.sessions[id] = rt
 			inflight.rt = rt
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1092,6 +1092,130 @@ func TestServeSessionManager_EvictExpiredSkipsActiveRun(t *testing.T) {
 	}
 }
 
+func TestServeSessionManager_GetOrCreateSkipsEvictingActiveRunAtCapacity(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 2, func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	var evicted *serveRuntime
+	manager.onEvict = func(rt *serveRuntime) {
+		evicted = rt
+	}
+
+	busyCtx, busyCancel := context.WithCancel(context.Background())
+	defer busyCancel()
+
+	busy := &serveRuntime{}
+	busy.lastUsedUnixNano.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+	busyState := &runtimeInterruptState{cancel: busyCancel, done: make(chan struct{})}
+	busy.setActiveInterrupt(busyState)
+
+	idle := &serveRuntime{}
+	idle.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	manager.mu.Lock()
+	manager.sessions["busy"] = busy
+	manager.sessions["idle"] = idle
+	manager.mu.Unlock()
+
+	created, err := manager.GetOrCreate(context.Background(), "new")
+	if err != nil {
+		t.Fatalf("GetOrCreate error: %v", err)
+	}
+	if created == nil {
+		t.Fatal("expected created runtime")
+	}
+
+	manager.mu.Lock()
+	_, busyOK := manager.sessions["busy"]
+	_, idleOK := manager.sessions["idle"]
+	_, newOK := manager.sessions["new"]
+	sessionCount := len(manager.sessions)
+	manager.mu.Unlock()
+
+	if !busyOK {
+		t.Fatal("expected active session to remain in manager")
+	}
+	if idleOK {
+		t.Fatal("expected idle session to be evicted instead of active session")
+	}
+	if !newOK {
+		t.Fatal("expected new session to be stored in manager")
+	}
+	if sessionCount != 2 {
+		t.Fatalf("session count = %d, want 2", sessionCount)
+	}
+	if evicted != idle {
+		t.Fatal("expected idle session to be evicted")
+	}
+	select {
+	case <-busyCtx.Done():
+		t.Fatal("expected active session not to be cancelled during capacity eviction")
+	default:
+	}
+}
+
+func TestServeSessionManager_GetOrCreateWithDoesNotEvictActiveRunWhenAllSessionsAreBusy(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 1, nil)
+	defer manager.Close()
+
+	var evictions atomic.Int32
+	manager.onEvict = func(rt *serveRuntime) {
+		evictions.Add(1)
+	}
+
+	busyCtx, busyCancel := context.WithCancel(context.Background())
+	defer busyCancel()
+
+	busy := &serveRuntime{}
+	busy.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+	busyState := &runtimeInterruptState{cancel: busyCancel, done: make(chan struct{})}
+	busy.setActiveInterrupt(busyState)
+
+	manager.mu.Lock()
+	manager.sessions["busy"] = busy
+	manager.mu.Unlock()
+
+	created, err := manager.GetOrCreateWith(context.Background(), "new", func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{}
+		rt.Touch()
+		return rt, nil
+	})
+	if err != nil {
+		t.Fatalf("GetOrCreateWith error: %v", err)
+	}
+	if created == nil {
+		t.Fatal("expected created runtime")
+	}
+
+	manager.mu.Lock()
+	_, busyOK := manager.sessions["busy"]
+	_, newOK := manager.sessions["new"]
+	sessionCount := len(manager.sessions)
+	manager.mu.Unlock()
+
+	if !busyOK {
+		t.Fatal("expected active session to remain in manager")
+	}
+	if !newOK {
+		t.Fatal("expected new session to be stored in manager")
+	}
+	if sessionCount != 2 {
+		t.Fatalf("session count = %d, want 2", sessionCount)
+	}
+	if got := evictions.Load(); got != 0 {
+		t.Fatalf("evictions = %d, want 0", got)
+	}
+	select {
+	case <-busyCtx.Done():
+		t.Fatal("expected active session not to be cancelled during capacity eviction")
+	default:
+	}
+}
+
 func TestRequireJSONContentType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	if err := requireJSONContentType(req); err == nil {


### PR DESCRIPTION
## What

- avoid evicting runtimes with an active run when session creation hits the in-memory capacity limit
- share that capacity-eviction logic between `GetOrCreate` and `GetOrCreateWith`
- add regression coverage for both capacity paths, including the all-sessions-busy case

## Why

The TTL janitor already skips active runs, but the max-capacity eviction path did not. That let creating a new session cancel and close the least-recently-used runtime even if it was actively streaming a response. Skipping active runs keeps in-flight sessions alive and only evicts idle sessions when available.
