### PR TITLE
fix: Anthropic proxy ignores client tool restrictions and injects all server tools

### DIFF
--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -71,16 +71,19 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 
 	search := runtime.search
 	toolChoice := parseAnthropicToolChoice(req.ToolChoice)
+	requestedTools := parseAnthropicRequestedToolNames(req.Tools)
 
-	// Merge server tools (engine can execute) with client tools (passthrough).
-	// Server tools win on name collision so the engine executes its own version.
+	// Merge requested server tools (engine can execute) with client tools
+	// (passthrough). Server tools win on name collision so the engine executes
+	// its own version.
+	//
 	// Client tools the engine doesn't recognise are forwarded to the LLM and
 	// returned as tool_use blocks for the client to handle.
 	//
 	// ToolMap targets (e.g. "search" when mapping "WebSearch" → "search") are
 	// excluded from the server list — the LLM will see the client's tool name
 	// and the engine redirects execution via ToolMap.
-	serverTools := runtime.selectTools(nil) // all registered server tools
+	serverTools := runtime.selectTools(requestedTools)
 	mappedTargets := make(map[string]bool)
 	if runtime.toolMap != nil {
 		for _, target := range runtime.toolMap {

--- a/cmd/serve_protocol_anthropic.go
+++ b/cmd/serve_protocol_anthropic.go
@@ -230,6 +230,17 @@ func anthropicToolsToSpecs(tools []anthropicToolDef) []llm.ToolSpec {
 	return specs
 }
 
+func parseAnthropicRequestedToolNames(tools []anthropicToolDef) map[string]bool {
+	selected := map[string]bool{}
+	for _, t := range tools {
+		name := strings.TrimSpace(t.Name)
+		if name != "" {
+			selected[name] = true
+		}
+	}
+	return selected
+}
+
 // parseAnthropicToolChoice parses Anthropic-format tool_choice into llm.ToolChoice.
 func parseAnthropicToolChoice(raw json.RawMessage) llm.ToolChoice {
 	if len(raw) == 0 {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4564,6 +4564,50 @@ func TestHandleAnthropicMessages_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestHandleAnthropicMessages_RespectsClientToolRestrictions(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	registry := llm.NewToolRegistry()
+	registry.Register(&echoTool{})
+	registry.Register(&testServeDelayTool{})
+	engine := llm.NewEngine(provider, registry)
+
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	})
+	defer mgr.Close()
+
+	srv := &serveServer{sessionMgr: mgr}
+	body := `{
+		"model":"test",
+		"max_tokens":1024,
+		"messages":[{"role":"user","content":"Hi"}],
+		"tools":[{"name":"echo","input_schema":{"type":"object"}}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleAnthropicMessages(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(provider.Requests))
+	}
+	if len(provider.Requests[0].Tools) != 1 {
+		t.Fatalf("provider saw %d tools, want 1: %+v", len(provider.Requests[0].Tools), provider.Requests[0].Tools)
+	}
+	if provider.Requests[0].Tools[0].Name != "echo" {
+		t.Fatalf("provider saw tool %q, want echo", provider.Requests[0].Tools[0].Name)
+	}
+}
+
 func TestHandleAnthropicMessages_StreamText(t *testing.T) {
 	srv := newTestServeServer("streamed text")
 	body := `{"model":"test","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hi"}]}`


### PR DESCRIPTION
## What

- limit Anthropic server-side tool injection to the tools explicitly named by the client
- keep passthrough client tools and existing ToolMap behavior unchanged
- add a regression test proving unrequested server tools are not exposed to the provider

## Why

The Anthropic messages proxy was calling `runtime.selectTools(nil)`, which injected every registered server tool into requests even when the client sent a tightly scoped tool list. That could expose backend-only tools the client never intended to make available.
