### PR TITLE
fix: Chat Completions requests silently drop image content

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -172,6 +172,7 @@ func abbreviatePath(path string) string {
 
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
+// Chat Completions-style text/image_url parts are also accepted.
 // Supported image types are sent inline to the LLM; all other files are saved to disk
 // and referenced by path in a text part.
 //
@@ -184,15 +185,15 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 		var llmParts []llm.Part
 		fileCount := 0
 		for _, part := range parts {
-			partType := jsonString(part["type"])
+			partType := strings.ToLower(strings.TrimSpace(jsonString(part["type"])))
 			switch partType {
-			case "input_text":
+			case "input_text", "text", "output_text":
 				text := jsonString(part["text"])
 				if text != "" {
 					llmParts = append(llmParts, llm.Part{Type: llm.PartText, Text: text})
 				}
-			case "input_image":
-				imageURL := jsonString(part["image_url"])
+			case "input_image", "image_url":
+				imageURL := jsonImageURL(part["image_url"])
 				filename := jsonString(part["filename"])
 				if !strings.HasPrefix(imageURL, "data:") {
 					continue
@@ -286,6 +287,19 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 		}
 	}
 	return llm.UserText(extractItemContent(content)), nil
+}
+
+func jsonImageURL(raw json.RawMessage) string {
+	if s := jsonString(raw); s != "" {
+		return s
+	}
+	var value struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(raw, &value); err == nil {
+		return strings.TrimSpace(value.URL)
+	}
+	return ""
 }
 
 func jsonString(raw json.RawMessage) string {

--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -64,13 +64,17 @@ func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 			result = append(result, llm.SystemText(extractMessageText(msg.Content)))
 			replaceHistory = true
 		case "user":
-			result = append(result, llm.UserText(extractMessageText(msg.Content)))
-		case "assistant":
-			parts := []llm.Part{}
-			text := extractMessageText(msg.Content)
-			if text != "" {
-				parts = append(parts, llm.Part{Type: llm.PartText, Text: text})
+			userMsg, err := parseUserMessageContent(msg.Content)
+			if err != nil {
+				return nil, false, fmt.Errorf("user message: %w", err)
 			}
+			result = append(result, userMsg)
+		case "assistant":
+			assistantMsg, err := parseUserMessageContent(msg.Content)
+			if err != nil {
+				return nil, false, fmt.Errorf("assistant message: %w", err)
+			}
+			parts := append([]llm.Part{}, assistantMsg.Parts...)
 			for _, tc := range msg.ToolCalls {
 				args := tc.Function.Arguments
 				if strings.TrimSpace(args) == "" {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -955,6 +955,78 @@ func TestParseChatMessages_ToolCallAndToolResult(t *testing.T) {
 	}
 }
 
+func TestParseChatMessages_UserImageContent(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	msgs, replaceHistory, err := parseChatMessages([]chatMessage{{
+		Role: "user",
+		Content: json.RawMessage(`[
+			{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}},
+			{"type":"text","text":"describe this"}
+		]`),
+	}})
+	if err != nil {
+		t.Fatalf("parseChatMessages failed: %v", err)
+	}
+	if replaceHistory {
+		t.Fatalf("replaceHistory = true, want false")
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs) = %d, want 1", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser {
+		t.Fatalf("role = %s, want user", msgs[0].Role)
+	}
+	if len(msgs[0].Parts) != 2 {
+		t.Fatalf("len(parts) = %d, want 2", len(msgs[0].Parts))
+	}
+	if msgs[0].Parts[0].Type != llm.PartImage {
+		t.Fatalf("parts[0].type = %s, want image", msgs[0].Parts[0].Type)
+	}
+	if msgs[0].Parts[0].ImageData == nil || msgs[0].Parts[0].ImageData.MediaType != "image/png" || msgs[0].Parts[0].ImageData.Base64 != "aGVsbG8=" {
+		t.Fatalf("parts[0].image = %#v, want png data URL", msgs[0].Parts[0].ImageData)
+	}
+	if msgs[0].Parts[1].Type != llm.PartText || msgs[0].Parts[1].Text != "describe this" {
+		t.Fatalf("parts[1] = %+v, want trailing text", msgs[0].Parts[1])
+	}
+}
+
+func TestParseChatMessages_AssistantImageContent(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	msgs, replaceHistory, err := parseChatMessages([]chatMessage{{
+		Role: "assistant",
+		Content: json.RawMessage(`[
+			{"type":"text","text":"looking"},
+			{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}
+		]`),
+	}})
+	if err != nil {
+		t.Fatalf("parseChatMessages failed: %v", err)
+	}
+	if !replaceHistory {
+		t.Fatalf("replaceHistory = false, want true")
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs) = %d, want 1", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleAssistant {
+		t.Fatalf("role = %s, want assistant", msgs[0].Role)
+	}
+	if len(msgs[0].Parts) != 2 {
+		t.Fatalf("len(parts) = %d, want 2", len(msgs[0].Parts))
+	}
+	if msgs[0].Parts[0].Type != llm.PartText || msgs[0].Parts[0].Text != "looking" {
+		t.Fatalf("parts[0] = %+v, want leading text", msgs[0].Parts[0])
+	}
+	if msgs[0].Parts[1].Type != llm.PartImage {
+		t.Fatalf("parts[1].type = %s, want image", msgs[0].Parts[1].Type)
+	}
+	if msgs[0].Parts[1].ImageData == nil || msgs[0].Parts[1].ImageData.MediaType != "image/png" || msgs[0].Parts[1].ImageData.Base64 != "aGVsbG8=" {
+		t.Fatalf("parts[1].image = %#v, want png data URL", msgs[0].Parts[1].ImageData)
+	}
+}
+
 func TestParseToolChoice(t *testing.T) {
 	if got := parseToolChoice(json.RawMessage(`"none"`)); got.Mode != llm.ToolChoiceNone {
 		t.Fatalf("mode = %s, want none", got.Mode)


### PR DESCRIPTION
## What

- parse Chat Completions user messages with the existing structured content parser instead of flattening them to text
- accept Chat Completions-style `text` and `image_url` content parts, including object-form `image_url.url`
- preserve assistant multimodal content parts before appending tool calls
- add regression coverage for user and assistant multimodal chat messages

## Why

OpenAI-compatible chat requests that send multimodal content arrays were losing their image parts during parsing because `parseChatMessages` only kept extracted text. This made the backend answer as if no image had been provided, with no validation error. These changes preserve image parts so multimodal chat history reaches the model correctly.
