### PR TITLE
fix: Anthropic mixed user/tool_result content is reordered incorrectly

### DIFF
--- a/cmd/serve_protocol_anthropic.go
+++ b/cmd/serve_protocol_anthropic.go
@@ -163,20 +163,31 @@ func parseAnthropicMessages(msgs []anthropicMessage) ([]llm.Message, error) {
 			// Anthropic puts tool_result blocks in user messages.
 			// Split them out into RoleTool messages so the OpenAI-compat
 			// provider can emit proper {"role":"tool"} entries.
-			var userParts, toolParts []llm.Part
-			for _, p := range parts {
-				if p.Type == llm.PartToolResult {
-					toolParts = append(toolParts, p)
-				} else {
-					userParts = append(userParts, p)
+			// Preserve the original block ordering when user content and
+			// tool_result blocks are mixed in the same message.
+			var currentRole llm.Role
+			var currentParts []llm.Part
+			flush := func() {
+				if len(currentParts) == 0 {
+					return
 				}
+				result = append(result, llm.Message{Role: currentRole, Parts: currentParts})
+				currentParts = nil
 			}
-			if len(toolParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleTool, Parts: toolParts})
+			for _, p := range parts {
+				partRole := llm.RoleUser
+				if p.Type == llm.PartToolResult {
+					partRole = llm.RoleTool
+				}
+				if len(currentParts) > 0 && currentRole != partRole {
+					flush()
+				}
+				if len(currentParts) == 0 {
+					currentRole = partRole
+				}
+				currentParts = append(currentParts, p)
 			}
-			if len(userParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleUser, Parts: userParts})
-			}
+			flush()
 		case "assistant":
 			result = append(result, llm.Message{Role: llm.RoleAssistant, Parts: parts})
 		default:

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4500,6 +4500,31 @@ func TestParseAnthropicMessages_ToolUseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAnthropicMessages_MixedUserAndToolResultPreservesOrder(t *testing.T) {
+	msgs, err := parseAnthropicMessages([]anthropicMessage{
+		{Role: "user", Content: json.RawMessage(`[
+			{"type":"text","text":"before"},
+			{"type":"tool_result","tool_use_id":"call_1","content":"tool output"},
+			{"type":"text","text":"after"}
+		]`)},
+	})
+	if err != nil {
+		t.Fatalf("parseAnthropicMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("len = %d, want 3", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || msgs[0].Parts[0].Text != "before" {
+		t.Fatalf("first message = %#v, want leading user text", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleTool || msgs[1].Parts[0].ToolResult == nil || msgs[1].Parts[0].ToolResult.Content != "tool output" {
+		t.Fatalf("second message = %#v, want tool result", msgs[1])
+	}
+	if msgs[2].Role != llm.RoleUser || msgs[2].Parts[0].Text != "after" {
+		t.Fatalf("third message = %#v, want trailing user text", msgs[2])
+	}
+}
+
 func TestParseAnthropicSystem(t *testing.T) {
 	// String form
 	if got := parseAnthropicSystem(json.RawMessage(`"Be helpful"`)); got != "Be helpful" {


### PR DESCRIPTION
## What

Fix Anthropic message parsing so mixed user content and `tool_result` blocks preserve their original order.

The parser still converts `tool_result` blocks into `RoleTool` messages, but now it emits alternating user/tool messages in content order instead of always appending all tool results before all user parts.

Also add a regression test covering a user message that contains text, then a tool result, then more text.

## Why

Anthropic allows `user` messages to mix normal user content with `tool_result` blocks. The previous parser split those into separate `RoleTool` and `RoleUser` messages and always emitted the tool message first, which reordered the conversation seen by downstream providers.

That could change tool-followup reasoning and produce incorrect results compared with what the client actually sent.
