### PR TITLE
fix: Responses developer messages are promoted to system messages and suppress the server prompt

### DIFF
--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -54,7 +54,10 @@ func parseResponsesInput(input json.RawMessage) ([]llm.Message, bool, error) {
 		case "message":
 			role := strings.ToLower(strings.TrimSpace(jsonString(item["role"])))
 			switch role {
-			case "developer", "system":
+			case "developer":
+				messages = append(messages, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: extractItemContent(item["content"])}}})
+				replaceHistory = true
+			case "system":
 				messages = append(messages, llm.SystemText(extractItemContent(item["content"])))
 				replaceHistory = true
 			case "assistant":

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -678,6 +678,52 @@ func TestParseResponsesInput_String(t *testing.T) {
 	}
 }
 
+func TestParseResponsesInput_DeveloperDoesNotSuppressServerSystemPrompt(t *testing.T) {
+	payload := json.RawMessage(`[
+		{"type":"message","role":"developer","content":"Be concise"},
+		{"type":"message","role":"user","content":"hello"}
+	]`)
+	msgs, replaceHistory, err := parseResponsesInput(payload)
+	if err != nil {
+		t.Fatalf("parseResponsesInput failed: %v", err)
+	}
+	if !replaceHistory {
+		t.Fatalf("replaceHistory = false, want true")
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("len(msgs) = %d, want 2", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleDeveloper {
+		t.Fatalf("first role = %s, want developer", msgs[0].Role)
+	}
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	rt := &serveRuntime{
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		systemPrompt: "server system prompt",
+	}
+	_, err = rt.Run(context.Background(), true, replaceHistory, msgs, llm.Request{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(provider.Requests))
+	}
+	if len(provider.Requests[0].Messages) != 3 {
+		t.Fatalf("request message count = %d, want 3", len(provider.Requests[0].Messages))
+	}
+	if provider.Requests[0].Messages[0].Role != llm.RoleSystem || provider.Requests[0].Messages[0].Parts[0].Text != "server system prompt" {
+		t.Fatalf("first request message = %+v, want server system prompt", provider.Requests[0].Messages[0])
+	}
+	if provider.Requests[0].Messages[1].Role != llm.RoleDeveloper || provider.Requests[0].Messages[1].Parts[0].Text != "Be concise" {
+		t.Fatalf("second request message = %+v, want developer prompt", provider.Requests[0].Messages[1])
+	}
+	if provider.Requests[0].Messages[2].Role != llm.RoleUser || provider.Requests[0].Messages[2].Parts[0].Text != "hello" {
+		t.Fatalf("third request message = %+v, want user prompt", provider.Requests[0].Messages[2])
+	}
+}
+
 func TestParseResponsesInput_ImageContent(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)


### PR DESCRIPTION
## What

Preserve Responses API `developer` input items as `llm.RoleDeveloper` instead of converting them into `llm.SystemText`.
Add a regression test covering a developer message plus user input to verify the server system prompt is still injected.

## Why

Converting client-supplied developer messages into system messages incorrectly elevated their priority and made `serveRuntime` think a system prompt was already present.
That let a client developer message suppress the server-configured system prompt entirely, breaking prompt hierarchy and instruction integrity.
