### PR TITLE
fix: Telegram bot spawns an unbounded goroutine for every incoming update

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -27,6 +27,7 @@ import (
 const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
+const telegramMaxConcurrentHandlers = 8
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -319,6 +320,7 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 		fastProvider:     fastProvider,
 		allowedUserIDs:   buildAllowedSet(p.cfg.AllowedUserIDs),
 		allowedUsernames: buildAllowedUsernameSet(p.cfg.AllowedUsernames),
+		messageSlots:     make(chan struct{}, telegramMaxConcurrentHandlers),
 	}
 
 	u := tgbotapi.NewUpdate(0)
@@ -338,7 +340,15 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 			if update.Message == nil {
 				continue
 			}
-			go mgr.handleMessage(ctx, bot, update.Message)
+			if !mgr.acquireMessageSlot(ctx) {
+				mgr.closeAllSessions()
+				bot.StopReceivingUpdates()
+				return nil
+			}
+			go func(msg *tgbotapi.Message) {
+				defer mgr.releaseMessageSlot()
+				mgr.handleMessage(ctx, bot, msg)
+			}(update.Message)
 		}
 	}
 }
@@ -357,6 +367,24 @@ func buildAllowedUsernameSet(names []string) map[string]struct{} {
 		m[strings.ToLower(name)] = struct{}{}
 	}
 	return m
+}
+
+func (m *telegramSessionMgr) acquireMessageSlot(ctx context.Context) bool {
+	slots := m.messageSlots
+	if slots == nil {
+		slots = make(chan struct{}, telegramMaxConcurrentHandlers)
+		m.messageSlots = slots
+	}
+	select {
+	case slots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (m *telegramSessionMgr) releaseMessageSlot() {
+	<-m.messageSlots
 }
 
 // telegramSession holds per-chat conversation state.
@@ -393,6 +421,7 @@ type telegramSessionMgr struct {
 	fastProvider     llm.Provider
 	allowedUserIDs   map[int64]struct{}
 	allowedUsernames map[string]struct{}
+	messageSlots     chan struct{}
 	tickerInterval   time.Duration // 0 means use default (500ms); overridden in tests
 }
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -99,6 +99,52 @@ func TestHandleMessage_IgnoresMessagesWithNilFrom(t *testing.T) {
 	mgr.handleMessage(context.Background(), nil, &tgbotapi.Message{Text: "hi"})
 }
 
+func TestTelegramSessionMgrAcquireMessageSlot_BlocksUntilReleased(t *testing.T) {
+	mgr := &telegramSessionMgr{messageSlots: make(chan struct{}, 1)}
+	if !mgr.acquireMessageSlot(context.Background()) {
+		t.Fatal("first acquireMessageSlot returned false")
+	}
+
+	acquired := make(chan bool, 1)
+	go func() {
+		acquired <- mgr.acquireMessageSlot(context.Background())
+	}()
+
+	select {
+	case ok := <-acquired:
+		t.Fatalf("acquireMessageSlot succeeded while full: %v", ok)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	mgr.releaseMessageSlot()
+
+	select {
+	case ok := <-acquired:
+		if !ok {
+			t.Fatal("acquireMessageSlot returned false after release")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("acquireMessageSlot did not succeed after release")
+	}
+
+	mgr.releaseMessageSlot()
+}
+
+func TestTelegramSessionMgrAcquireMessageSlot_RespectsContextCancel(t *testing.T) {
+	mgr := &telegramSessionMgr{messageSlots: make(chan struct{}, 1)}
+	if !mgr.acquireMessageSlot(context.Background()) {
+		t.Fatal("first acquireMessageSlot returned false")
+	}
+	defer mgr.releaseMessageSlot()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if mgr.acquireMessageSlot(ctx) {
+		t.Fatal("acquireMessageSlot returned true after context cancellation")
+	}
+}
+
 // --- TestBuildSegment ---
 
 func TestBuildSegment(t *testing.T) {


### PR DESCRIPTION
## What

Add bounded concurrency to Telegram update handling by limiting the number of in-flight message handlers before spawning a goroutine, instead of starting an unbounded goroutine for every incoming update.

Also add focused tests covering the message-slot backpressure and cancellation behavior.

## Why

`handleMessage` can block for a long time while a model streams or waits on session state. Spawning a goroutine for every update lets a user flood the bot and accumulate unbounded goroutines and pending work, which can exhaust server memory and resources.

A small semaphore keeps concurrency bounded while preserving asynchronous handling for active chats and interrupt messages.
