### PR TITLE
fix: Server-state Responses follow-up turns resend full history after tool execution

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -417,7 +417,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 	// Use server state: send previous_response_id if we have one (unless disabled)
 	if !c.DisableServerState && c.LastResponseID != "" {
 		req.PreviousResponseID = c.LastResponseID
-		// When continuing a conversation, only send the new user message
+		// When continuing a conversation, only send the new input items for this turn.
 		req.Input = filterToNewInput(req.Input)
 	}
 
@@ -742,10 +742,31 @@ func (c *ResponsesClient) ResetConversation() {
 	c.LastResponseID = ""
 }
 
-// filterToNewInput returns only the latest user input when continuing a conversation
+// filterToNewInput returns only the new input items for a server-state continuation.
 func filterToNewInput(input []ResponsesInputItem) []ResponsesInputItem {
-	// Find the last user message and any following items (including any tool results/calls)
-	// This is needed because when we have server state, we only send new messages
+	// Tool follow-up turns append function_call_output items (and sometimes
+	// synthetic/user messages such as image parts) with no new user message.
+	// When present at the end of the input, send only that trailing suffix.
+	start := len(input)
+	sawToolOutput := false
+	for start > 0 {
+		item := input[start-1]
+		if item.Type == "function_call_output" {
+			sawToolOutput = true
+			start--
+			continue
+		}
+		if item.Type == "message" && item.Role == "user" {
+			start--
+			continue
+		}
+		break
+	}
+	if sawToolOutput {
+		return input[start:]
+	}
+
+	// Otherwise fall back to the latest user message and any following items.
 	for i := len(input) - 1; i >= 0; i-- {
 		if input[i].Role == "user" {
 			return input[i:]

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -763,6 +763,47 @@ func TestBuildResponsesInput_ConvertsDanglingToolCalls(t *testing.T) {
 	}
 }
 
+func TestFilterToNewInput_ToolFollowUpReturnsOnlyNewToolOutputs(t *testing.T) {
+	input := []ResponsesInputItem{
+		{Type: "message", Role: "developer", Content: "Be concise"},
+		{Type: "message", Role: "user", Content: "old question"},
+		{Type: "message", Role: "assistant", Content: "I'll check"},
+		{Type: "function_call", CallID: "call_1", Name: "shell", Arguments: `{"command":"pwd"}`},
+		{Type: "function_call_output", CallID: "call_1", Output: "/root/source/term-llm"},
+	}
+
+	got := filterToNewInput(input)
+
+	if len(got) != 1 {
+		t.Fatalf("expected only trailing tool output, got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "function_call_output" || got[0].CallID != "call_1" {
+		t.Fatalf("expected trailing function_call_output for call_1, got %+v", got[0])
+	}
+}
+
+func TestFilterToNewInput_ToolFollowUpPreservesTrailingOutputsAndUserMessages(t *testing.T) {
+	input := []ResponsesInputItem{
+		{Type: "message", Role: "developer", Content: "Be concise"},
+		{Type: "message", Role: "user", Content: "describe this image"},
+		{Type: "function_call", CallID: "call_img", Name: "view_image", Arguments: `{"path":"img.png"}`},
+		{Type: "function_call_output", CallID: "call_img", Output: "loaded"},
+		{Type: "message", Role: "user", Content: []ResponsesContentPart{{Type: "input_image", ImageURL: "data:image/png;base64,abc"}}},
+	}
+
+	got := filterToNewInput(input)
+
+	if len(got) != 2 {
+		t.Fatalf("expected trailing tool output and synthetic user message, got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "function_call_output" || got[0].CallID != "call_img" {
+		t.Fatalf("expected first item function_call_output for call_img, got %+v", got[0])
+	}
+	if got[1].Type != "message" || got[1].Role != "user" {
+		t.Fatalf("expected second item trailing user message, got %+v", got[1])
+	}
+}
+
 func TestResponsesClientStream_Retries404WithFullHistory(t *testing.T) {
 	type capturedRequest struct {
 		PreviousResponseID string               `json:"previous_response_id"`


### PR DESCRIPTION
## What

Fix `filterToNewInput` so server-state Responses continuations send only the new trailing tool follow-up items instead of falling back to the full prior history when there is no new user message.

Add tests covering tool-only follow-up turns and tool follow-ups that include a trailing user message (for example synthetic image input after a tool result).

## Why

In the agentic loop, the turn after tool execution often contains only assistant `function_call` history plus new `function_call_output` items. The old logic only looked for the last user message, so it resent full history together with `previous_response_id`. That duplicated context on server-state providers and could lead to incorrect continuations after tool calls.
