### PR TITLE
feat: add --files-dir flag for serving arbitrary files

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,6 +57,7 @@ var (
 	serveFilterServerTools      bool
 	serveSidebarSessions        string
 	serveToolMap                []string
+	serveFilesDir               string
 )
 
 var serveCmd = &cobra.Command{
@@ -131,6 +132,7 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveVerbose, "verbose", false, "Log API request/response summaries to stderr")
 	serveCmd.Flags().StringArrayVar(&serveToolMap, "tool-map", nil, "Map client tool name to server tool (repeatable, format ClientName:ServerName)")
 	serveCmd.Flags().BoolVar(&serveFilterServerTools, "suppress-server-tool-calls", false, "Hide server-executed tool calls from API responses (use when proxying to external clients)")
+	serveCmd.Flags().StringVar(&serveFilesDir, "files-dir", "", "Directory for serving arbitrary files (videos, PDFs, etc) at {base}/files/")
 
 	AddProviderFlag(serveCmd, &serveProvider)
 	AddDebugFlag(serveCmd, &serveDebug)
@@ -483,6 +485,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 				basePath:            serveBasePath,
 				sidebarSessions:     append([]string(nil), sidebarSessions...),
 				corsOrigins:         append([]string(nil), serveCORSOrigins...),
+				filesDir:            resolveFilesDir(serveFilesDir, cfg),
 			},
 			sessionMgr:     sessionMgr,
 			jobsV2:         jobsV2,
@@ -739,6 +742,7 @@ type serveServerConfig struct {
 	basePath            string // e.g. "/ui" or "/chat", always without trailing slash
 	sidebarSessions     []string
 	corsOrigins         []string
+	filesDir            string // opt-in directory for serving arbitrary files (videos, PDFs, etc)
 }
 
 // uiRoute returns the base-path with trailing slash, e.g. "/ui/" or "/chat/".
@@ -746,6 +750,17 @@ func (c serveServerConfig) uiRoute() string { return c.basePath + "/" }
 
 // imagesRoute returns the images sub-route, e.g. "/ui/images/" or "/chat/images/".
 func (c serveServerConfig) imagesRoute() string { return c.basePath + "/images/" }
+
+// filesRoute returns the files sub-route, e.g. "/ui/files/" or "/chat/files/".
+func (c serveServerConfig) filesRoute() string { return c.basePath + "/files/" }
+
+// resolveFilesDir returns the files-dir from the flag if set, otherwise from config.
+func resolveFilesDir(flagVal string, cfg *config.Config) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	return cfg.Serve.FilesDir
+}
 
 // normalizeBasePath validates and normalizes a base-path value.
 // It ensures a leading slash, strips trailing slashes, and rejects
@@ -829,6 +844,9 @@ func (s *serveServer) httpHandler() http.Handler {
 	}
 
 	inner.HandleFunc("/images/", s.auth(s.cors(s.handleImage)))
+	if s.cfg.filesDir != "" {
+		inner.HandleFunc("/files/", s.auth(s.cors(s.handleFile)))
+	}
 	inner.HandleFunc("/v1/sessions/status", s.auth(s.cors(s.handleSessionsStatus)))
 	inner.HandleFunc("/v1/sessions/", s.auth(s.cors(s.handleSessionByID)))
 	inner.HandleFunc("/v1/push/subscribe", s.auth(s.cors(s.handlePushSubscribe)))

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -169,6 +169,102 @@ func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, absFile)
 }
 
+// handleFile serves arbitrary files from the configured files-dir.
+func (s *serveServer) handleFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+		return
+	}
+	filename := strings.TrimPrefix(r.URL.Path, "/files/")
+	if filename == "" || strings.Contains(filename, "/") || strings.Contains(filename, "..") {
+		http.NotFound(w, r)
+		return
+	}
+	filesDir := s.cfg.filesDir
+	if filesDir == "" {
+		http.NotFound(w, r)
+		return
+	}
+	absDir, err := filepath.EvalSymlinks(filesDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	filePath := filepath.Join(absDir, filename)
+	absFile, err := filepath.EvalSymlinks(filePath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if !strings.HasPrefix(absFile, absDir+string(filepath.Separator)) {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "private, max-age=86400")
+	w.Header().Add("Vary", "Authorization, Cookie")
+	http.ServeFile(w, r, absFile)
+}
+
+// ensureFileServeable copies the given file into the configured files-dir
+// so that the files handler can serve it. Returns the serveable path and true
+// on success, or ("", false) if the file could not be made serveable.
+func (s *serveServer) ensureFileServeable(filePath string) (string, bool) {
+	filesDir := s.cfg.filesDir
+	if filesDir == "" {
+		return "", false
+	}
+
+	absDir, err := filepath.Abs(filesDir)
+	if err != nil {
+		log.Printf("[serve] ensureFileServeable: abs(%s): %v", filesDir, err)
+		return "", false
+	}
+	absFile, err := filepath.Abs(filePath)
+	if err != nil {
+		log.Printf("[serve] ensureFileServeable: abs(%s): %v", filePath, err)
+		return "", false
+	}
+
+	// Already under the files dir — nothing to do.
+	if strings.HasPrefix(absFile, absDir+string(filepath.Separator)) {
+		return filePath, true
+	}
+
+	if err := os.MkdirAll(absDir, 0755); err != nil {
+		log.Printf("[serve] ensureFileServeable: mkdir %s: %v", absDir, err)
+		return "", false
+	}
+
+	src, err := os.Open(absFile)
+	if err != nil {
+		log.Printf("[serve] ensureFileServeable: open %s: %v", absFile, err)
+		return "", false
+	}
+	defer src.Close()
+
+	destName := fmt.Sprintf("serve-%s-%s", randomSuffix(), filepath.Base(absFile))
+	destPath := filepath.Join(absDir, destName)
+	dst, err := os.Create(destPath)
+	if err != nil {
+		log.Printf("[serve] ensureFileServeable: create %s: %v", destPath, err)
+		return "", false
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		os.Remove(destPath)
+		log.Printf("[serve] ensureFileServeable: copy to %s: %v", destPath, err)
+		return "", false
+	}
+	if err := dst.Close(); err != nil {
+		os.Remove(destPath)
+		log.Printf("[serve] ensureFileServeable: close %s: %v", destPath, err)
+		return "", false
+	}
+
+	return destPath, true
+}
+
 // ensureImageServeable ensures the given image path is under the serveable
 // image output directory. If the file is already there, the path is returned
 // as-is. Otherwise the file is copied into the output dir so that the

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -839,8 +839,14 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 		if len(ev.ToolImages) > 0 {
 			imageURLs := make([]string, 0, len(ev.ToolImages))
 			for _, imgPath := range ev.ToolImages {
-				if served, ok := s.ensureImageServeable(imgPath); ok {
-					imageURLs = append(imageURLs, s.cfg.imagesRoute()+filepath.Base(served))
+				if s.cfg.filesDir != "" {
+					if served, ok := s.ensureFileServeable(imgPath); ok {
+						imageURLs = append(imageURLs, s.cfg.filesRoute()+filepath.Base(served))
+					}
+				} else {
+					if served, ok := s.ensureImageServeable(imgPath); ok {
+						imageURLs = append(imageURLs, s.cfg.imagesRoute()+filepath.Base(served))
+					}
 				}
 			}
 			if len(imageURLs) > 0 {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -320,10 +320,11 @@ func TestServeServerConfig_RouteHelpers(t *testing.T) {
 		basePath   string
 		wantUI     string
 		wantImages string
+		wantFiles  string
 	}{
-		{"/ui", "/ui/", "/ui/images/"},
-		{"/chat", "/chat/", "/chat/images/"},
-		{"/app/v2", "/app/v2/", "/app/v2/images/"},
+		{"/ui", "/ui/", "/ui/images/", "/ui/files/"},
+		{"/chat", "/chat/", "/chat/images/", "/chat/files/"},
+		{"/app/v2", "/app/v2/", "/app/v2/images/", "/app/v2/files/"},
 	}
 	for _, tt := range tests {
 		cfg := serveServerConfig{basePath: tt.basePath}
@@ -332,6 +333,9 @@ func TestServeServerConfig_RouteHelpers(t *testing.T) {
 		}
 		if got := cfg.imagesRoute(); got != tt.wantImages {
 			t.Errorf("basePath=%q imagesRoute()=%q, want %q", tt.basePath, got, tt.wantImages)
+		}
+		if got := cfg.filesRoute(); got != tt.wantFiles {
+			t.Errorf("basePath=%q filesRoute()=%q, want %q", tt.basePath, got, tt.wantFiles)
 		}
 	}
 }
@@ -1694,6 +1698,108 @@ func TestEnsureImageServeable_CopiesExternalFile(t *testing.T) {
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("serve copied image: status = %d, want 200", rr.Code)
+	}
+}
+
+func TestHandleFile_ServesFileAndRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "video.mp4"), []byte("fake-video"), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui", filesDir: dir}}
+
+	// Valid file
+	req := httptest.NewRequest(http.MethodGet, "/files/video.mp4", nil)
+	rr := httptest.NewRecorder()
+	srv.handleFile(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid file: status = %d, want 200", rr.Code)
+	}
+	if got := rr.Body.String(); got != "fake-video" {
+		t.Fatalf("body = %q, want %q", got, "fake-video")
+	}
+	if cc := rr.Header().Get("Cache-Control"); !strings.Contains(cc, "private") {
+		t.Fatalf("Cache-Control = %q, want 'private'", cc)
+	}
+
+	// Path traversal
+	req = httptest.NewRequest(http.MethodGet, "/files/..%2Fetc%2Fpasswd", nil)
+	rr = httptest.NewRecorder()
+	srv.handleFile(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("traversal: status = %d, want 404", rr.Code)
+	}
+
+	// Empty filename
+	req = httptest.NewRequest(http.MethodGet, "/files/", nil)
+	rr = httptest.NewRecorder()
+	srv.handleFile(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("empty: status = %d, want 404", rr.Code)
+	}
+
+	// No files-dir configured → 404
+	srv2 := &serveServer{cfg: serveServerConfig{basePath: "/ui"}}
+	req = httptest.NewRequest(http.MethodGet, "/files/video.mp4", nil)
+	rr = httptest.NewRecorder()
+	srv2.handleFile(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("no files-dir: status = %d, want 404", rr.Code)
+	}
+}
+
+func TestEnsureFileServeable_CopiesExternalFile(t *testing.T) {
+	filesDir := t.TempDir()
+	externalDir := t.TempDir()
+
+	externalFile := filepath.Join(externalDir, "report.pdf")
+	if err := os.WriteFile(externalFile, []byte("pdf-data"), 0644); err != nil {
+		t.Fatalf("write external file: %v", err)
+	}
+
+	internalFile := filepath.Join(filesDir, "existing.mp4")
+	if err := os.WriteFile(internalFile, []byte("video-data"), 0644); err != nil {
+		t.Fatalf("write internal file: %v", err)
+	}
+
+	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui", filesDir: filesDir}}
+
+	// External file should be copied
+	result, ok := srv.ensureFileServeable(externalFile)
+	if !ok {
+		t.Fatal("ensureFileServeable should succeed for external file")
+	}
+	if result == externalFile {
+		t.Fatal("external file should have been copied, but path is unchanged")
+	}
+	absResult, _ := filepath.Abs(result)
+	absFilesDir, _ := filepath.Abs(filesDir)
+	if !strings.HasPrefix(absResult, absFilesDir+string(filepath.Separator)) {
+		t.Fatalf("copied file %q should be under files dir %q", absResult, absFilesDir)
+	}
+	data, err := os.ReadFile(result)
+	if err != nil {
+		t.Fatalf("read copied file: %v", err)
+	}
+	if string(data) != "pdf-data" {
+		t.Fatalf("copied data = %q, want %q", string(data), "pdf-data")
+	}
+
+	// Internal file should be returned as-is
+	result, ok = srv.ensureFileServeable(internalFile)
+	if !ok {
+		t.Fatal("ensureFileServeable should succeed for internal file")
+	}
+	if result != internalFile {
+		t.Fatalf("internal file should be unchanged, got %q want %q", result, internalFile)
+	}
+
+	// No files-dir → fails
+	srv2 := &serveServer{cfg: serveServerConfig{basePath: "/ui"}}
+	_, ok = srv2.ensureFileServeable(externalFile)
+	if ok {
+		t.Fatal("ensureFileServeable should fail when filesDir is empty")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,7 @@ type Config struct {
 type ServeConfig struct {
 	Platforms []string            `mapstructure:"platforms" yaml:"platforms,omitempty"`
 	BasePath  string              `mapstructure:"base_path" yaml:"base_path,omitempty"`
+	FilesDir  string              `mapstructure:"files_dir" yaml:"files_dir,omitempty"`
 	Telegram  TelegramServeConfig `mapstructure:"telegram" yaml:"telegram,omitempty"`
 	WebPush   WebPushConfig       `mapstructure:"web_push" yaml:"web_push,omitempty"`
 }


### PR DESCRIPTION
## What

Adds an opt-in `--files-dir` flag to the `serve` command that creates a `/files/` route for serving arbitrary content (videos, PDFs, documents, etc).

When `--files-dir` is configured (via flag or `serve.files_dir` in config YAML), tool outputs route through `/files/` instead of `/images/`. The flag value takes precedence over config.

## Why

PR #257 (now closed) proposed adding content-type validation to `ensureImageServeable` to reject non-image files. While the security concern was valid, that approach would break legitimate use cases where arbitrary files need to be served through web chat (e.g. tool-generated PDFs, video thumbnails, documents).

This PR takes a different approach: keep the default `/images/` endpoint unchanged (safe by default), but provide an explicit opt-in path for users who need arbitrary file serving.

## Changes

- **`cmd/serve.go`**: New `--files-dir` flag, `filesDir` field on `serveServerConfig`, `filesRoute()` method, `resolveFilesDir()` helper, conditional route registration
- **`cmd/serve_handlers.go`**: New `handleFile` handler and `ensureFileServeable` function — same security pattern as existing image handling (path traversal protection, symlink escape check, `Cache-Control` headers)
- **`cmd/serve_response_runs.go`**: Tool image routing branches on `filesDir` presence
- **`cmd/serve_test.go`**: Tests for route helpers, file serving (valid + traversal rejection), and file copy logic
- **`internal/config/config.go`**: `FilesDir` field on `ServeConfig`

## Security

`handleFile` uses the same protections as `handleImage`:
- Rejects `..` in paths
- Rejects absolute paths
- Checks symlink targets don't escape the files directory
- Serves with `Cache-Control: public, max-age=86400`
