### PR TITLE
fix: handle RoleDeveloper in claude-bin provider

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -972,14 +972,23 @@ func (p *ClaudeBinProvider) extractSystemPrompt(messages []Message) string {
 // This can be called with a subset of messages when resuming a session.
 func (p *ClaudeBinProvider) buildConversationPrompt(messages []Message) string {
 	var conversationParts []string
+	var pendingDev string
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case RoleSystem:
 			// System messages handled separately by extractSystemPrompt
 			continue
+		case RoleDeveloper:
+			// Claude CLI has no native developer role. Buffer the text and prepend
+			// it into the next user turn wrapped in <developer> tags.
+			pendingDev = collectTextParts(msg.Parts)
 		case RoleUser:
 			var userParts []string
+			if pendingDev != "" {
+				userParts = append(userParts, fmt.Sprintf("<developer>\n%s\n</developer>", pendingDev))
+				pendingDev = ""
+			}
 			for _, part := range msg.Parts {
 				switch part.Type {
 				case PartText:
@@ -1282,10 +1291,22 @@ func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID s
 		lines = append(lines, string(data))
 	}
 
+	var pendingDev string
 	for _, msg := range messages {
 		switch msg.Role {
+		case RoleDeveloper:
+			pendingDev = collectTextParts(msg.Parts)
 		case RoleUser:
-			appendUserMessage(buildSDKUserContentBlocks(msg.Parts), nil)
+			blocks := buildSDKUserContentBlocks(msg.Parts)
+			if pendingDev != "" {
+				devBlock := sdkContentBlock{
+					Type: "text",
+					Text: fmt.Sprintf("<developer>\n%s\n</developer>\n\n", pendingDev),
+				}
+				blocks = append([]sdkContentBlock{devBlock}, blocks...)
+				pendingDev = ""
+			}
+			appendUserMessage(blocks, nil)
 		case RoleTool:
 			for _, part := range msg.Parts {
 				if part.Type != PartToolResult || part.ToolResult == nil {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -972,3 +972,69 @@ func (t *testTool) Preview(args json.RawMessage) string { return "" }
 func (t *testTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
 	return t.exec(ctx, args)
 }
+
+func TestBuildConversationPrompt_DeveloperRole(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "You have access to /root/Files/"}}},
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "list the files"}}},
+	}
+	out := p.buildConversationPrompt(msgs)
+
+	// Developer text must be wrapped in <developer> tags and prepended to the user turn.
+	expected := "User: <developer>\nYou have access to /root/Files/\n</developer>\nlist the files"
+	if out != expected {
+		t.Errorf("unexpected output:\ngot:  %q\nwant: %q", out, expected)
+	}
+}
+
+func TestBuildConversationPrompt_DeveloperRoleWithoutFollowingUser(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "hello"}}},
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "trailing dev message"}}},
+	}
+	out := p.buildConversationPrompt(msgs)
+
+	// The developer message has no following user turn, so it should be silently dropped
+	// (same as anthropic.go behavior — pendingDev is lost at end of loop).
+	if strings.Contains(out, "trailing dev message") {
+		t.Errorf("trailing developer message without following user turn should be dropped, got: %q", out)
+	}
+}
+
+func TestBuildStreamJsonInput_DeveloperRole(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "You have access to /root/Files/"}}},
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "list the files"}}},
+	}
+	out := p.buildStreamJsonInput(msgs, "sess-dev")
+	if out == "" {
+		t.Fatal("expected non-empty stream-json output")
+	}
+
+	var msg sdkUserMessage
+	if err := json.Unmarshal([]byte(out), &msg); err != nil {
+		t.Fatalf("failed to parse stream-json: %v", err)
+	}
+	if msg.Message.Role != "user" {
+		t.Errorf("expected role 'user', got %q", msg.Message.Role)
+	}
+
+	// First block should be the developer-wrapped text, second the user text.
+	if len(msg.Message.Content) < 2 {
+		t.Fatalf("expected at least 2 content blocks, got %d", len(msg.Message.Content))
+	}
+	devBlock := msg.Message.Content[0]
+	if devBlock.Type != "text" {
+		t.Errorf("expected first block type 'text', got %q", devBlock.Type)
+	}
+	if !strings.Contains(devBlock.Text, "<developer>") || !strings.Contains(devBlock.Text, "/root/Files/") {
+		t.Errorf("expected developer-wrapped text, got %q", devBlock.Text)
+	}
+	userBlock := msg.Message.Content[1]
+	if userBlock.Text != "list the files" {
+		t.Errorf("expected user text 'list the files', got %q", userBlock.Text)
+	}
+}


### PR DESCRIPTION
## Problem

The `claude-bin` provider silently dropped `RoleDeveloper` messages. Both `buildConversationPrompt()` (text mode) and `buildStreamJsonInput()` (stream-json mode) had no case for `RoleDeveloper`, so developer-injected instructions (e.g. file paths from the platform layer) never reached the Claude CLI process.

This broke session 1327 — a web UI test of the files feature where the model ignored the developer message containing `/root/Files/` paths.

## Fix

Buffer developer message text in a `pendingDev` variable and prepend it to the next user turn wrapped in `<developer>` tags. This matches the existing pattern in `anthropic.go` (lines 605–704).

**Three code paths checked:**
- `buildConversationPrompt()` — fixed (text mode)
- `buildStreamJsonInput()` — fixed (stream-json mode with images)
- `extractSystemPrompt()` — intentionally unchanged (developer messages go into user turns, not system prompt)

## Tests

Three regression tests added:
- `TestBuildConversationPrompt_DeveloperRole` — verifies `<developer>` wrapping in text mode
- `TestBuildConversationPrompt_DeveloperRoleWithoutFollowingUser` — trailing dev message edge case
- `TestBuildStreamJsonInput_DeveloperRole` — verifies prepended text block in stream-json mode

All tests pass (`go test ./...` clean).