### PR TITLE
fix: normalize legacy minimax-{N} model names to minimax-m{N} for Venice

### DIFF
--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -165,8 +165,28 @@ func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error
 	}), nil
 }
 
+// normalizeVeniceModel rewrites legacy Venice model names to their current API IDs.
+// Venice renamed minimax models from minimax-{N} to minimax-m{N} (e.g. minimax-27 → minimax-m27).
+func normalizeVeniceModel(model string) string {
+	const prefix = "minimax-"
+	if !strings.HasPrefix(model, prefix) {
+		return model
+	}
+	rest := model[len(prefix):]
+	if len(rest) == 0 || rest[0] == 'm' {
+		return model
+	}
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return model
+		}
+	}
+	return prefix + "m" + rest
+}
+
 func buildVeniceModelAndParams(model string, search bool) (string, map[string]interface{}) {
 	baseModel, suffixParams := parseVeniceModelSuffix(model)
+	baseModel = normalizeVeniceModel(baseModel)
 	params := make(map[string]interface{}, len(suffixParams)+1)
 	for k, v := range suffixParams {
 		params[k] = v

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -74,6 +74,26 @@ func TestVeniceProviderCapabilities(t *testing.T) {
 	}
 }
 
+func TestNormalizeVeniceModel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"minimax-27", "minimax-m27"},
+		{"minimax-21", "minimax-m21"},
+		{"minimax-25", "minimax-m25"},
+		{"minimax-m27", "minimax-m27"},             // already correct
+		{"minimax-m2.1-free", "minimax-m2.1-free"}, // non-digit suffix, untouched
+		{"venice-uncensored", "venice-uncensored"},
+		{"grok-4-20-beta", "grok-4-20-beta"},
+	}
+	for _, c := range cases {
+		got := normalizeVeniceModel(c.in)
+		if got != c.want {
+			t.Errorf("normalizeVeniceModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestParseVeniceModelSuffix(t *testing.T) {
 	base, params := parseVeniceModelSuffix("grok-4-20-beta:enable_x_search=true&enable_web_citations=true")
 	if base != "grok-4-20-beta" {


### PR DESCRIPTION
## What

Add `normalizeVeniceModel` in the Venice provider that rewrites legacy `minimax-{N}` model names to their current `minimax-m{N}` API IDs (e.g. `minimax-27` → `minimax-m27`).

## Why

Venice renamed their minimax models from `minimax-27` / `minimax-21` / `minimax-25` to `minimax-m27` / `minimax-m21` / `minimax-m25`. Users with the old name in their config received a 404 from the API:

```
Venice API error (status 404): {"error":"Specified model not found: minimax-27. Did you mean: minimax-m27, minimax-m21, minimax-m25?"}
```

## How

- `normalizeVeniceModel` is called inside `buildVeniceModelAndParams` after suffix parsing, so it applies transparently to all Venice requests.
- Only rewrites `minimax-` followed by all-digit suffixes (e.g. `27`, `21`, `25`); names already containing `m` or non-digit characters (like `minimax-m2.1-free`) are left untouched.
- Test added covering the old names, already-correct names, and unrelated models.
