### PR TITLE
fix: Inline image attachments bypass the attachment-count limit entirely

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -202,6 +202,10 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 				if mt == "" || b64 == "" {
 					continue
 				}
+				fileCount++
+				if fileCount > maxAttachments {
+					return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
+				}
 				if isLLMImageType(mt) {
 					// Always save the original to disk first.
 					if filename == "" {
@@ -239,10 +243,6 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 						ImagePath: savedPath,
 					})
 				} else {
-					fileCount++
-					if fileCount > maxAttachments {
-						return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
-					}
 					if filename == "" {
 						filename = "image"
 					}

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseUserMessageContentLimitsNativeInlineImages(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	const tinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII="
+
+	parts := make([]map[string]any, 0, maxAttachments+1)
+	for i := 0; i < maxAttachments+1; i++ {
+		parts = append(parts, map[string]any{
+			"type":      "input_image",
+			"image_url": fmt.Sprintf("data:image/png;base64,%s", tinyPNG),
+			"filename":  fmt.Sprintf("image-%d.png", i),
+		})
+	}
+
+	content, err := json.Marshal(parts)
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+
+	_, err = parseUserMessageContent(content)
+	if err == nil {
+		t.Fatalf("expected attachment limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "too many attachments") {
+		t.Fatalf("expected attachment limit error, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

- count inline LLM-native data URL images toward the shared attachment limit in `parseUserMessageContent`
- add a regression test covering more than 10 native inline image attachments

## Why

Previously only non-native images and `input_file` parts incremented the attachment counter. Native inline images could bypass the limit entirely, allowing an unbounded number of base64 image uploads to be decoded, saved, and potentially resized, which created a denial-of-service path via CPU, memory, and temp-file exhaustion.
