### PR TITLE
fix: Shared HTTP client hard-stops streaming requests after 10 minutes

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -12,16 +12,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 )
 
-// httpClientTimeout is the default timeout for HTTP requests
-const httpClientTimeout = 10 * time.Minute
-
-// defaultHTTPClient is a shared HTTP client with reasonable timeouts
-var defaultHTTPClient = &http.Client{
-	Timeout: httpClientTimeout,
-}
+// defaultHTTPClient is a shared HTTP client. Do not set http.Client.Timeout here:
+// it applies to the entire request lifetime, including reading streaming response
+// bodies, and would abort legitimate long-running streams.
+var defaultHTTPClient = &http.Client{}
 
 // OpenAICompatProvider implements Provider for OpenAI-compatible APIs
 // Used by Ollama, LM Studio, and other compatible servers.

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+func TestDefaultHTTPClient_HasNoOverallTimeout(t *testing.T) {
+	if defaultHTTPClient.Timeout != 0 {
+		t.Fatalf("expected shared HTTP client timeout to be disabled for streaming requests, got %v", defaultHTTPClient.Timeout)
+	}
+}
+
 func TestSplitParts_WithReasoningContent(t *testing.T) {
 	// Test that splitParts correctly extracts reasoning content from parts
 	parts := []Part{


### PR DESCRIPTION
## What

Remove the shared `defaultHTTPClient`'s overall `http.Client.Timeout` so OpenAI-compatible and related streaming requests are not forcibly aborted after 10 minutes.

Add a regression test that verifies the shared client timeout remains disabled for streaming use.

## Why

`http.Client.Timeout` applies to the full lifetime of a request, including reading the response body. Reusing a client with a 10 minute timeout for streaming providers causes healthy long-running streams to be cut off mid-response, producing truncated output and spurious stream failures.
