### PR TITLE
fix: Telegram photo downloads are read fully into memory with no size or status checks

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -28,6 +28,8 @@ const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
+const telegramPhotoDownloadTimeout = 15 * time.Second
+const telegramMaxPhotoDownloadBytes = 25 << 20 // 25 MB
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -55,15 +57,34 @@ func downloadTelegramPhoto(fileGetter botFileGetter, photos []tgbotapi.PhotoSize
 		return "", "", "", fmt.Errorf("get file URL: %w", err)
 	}
 
-	resp, err := http.Get(directURL)
+	ctx, cancel := context.WithTimeout(context.Background(), telegramPhotoDownloadTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, directURL, nil)
+	if err != nil {
+		return "", "", "", fmt.Errorf("create photo request: %w", err)
+	}
+
+	client := &http.Client{Timeout: telegramPhotoDownloadTimeout}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", "", "", fmt.Errorf("download photo: %w", err)
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", "", "", fmt.Errorf("download photo: unexpected status %s", resp.Status)
+	}
+	if resp.ContentLength > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("download photo: response too large (%d bytes)", resp.ContentLength)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, telegramMaxPhotoDownloadBytes+1))
 	if err != nil {
 		return "", "", "", fmt.Errorf("read photo data: %w", err)
+	}
+	if len(data) > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("download photo: response exceeded %d bytes", telegramMaxPhotoDownloadBytes)
 	}
 
 	// Detect MIME type from content (Telegram can serve PNG, WebP, etc.)

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1292,6 +1292,46 @@ func TestDownloadTelegramPhoto_EmptyPhotos(t *testing.T) {
 	}
 }
 
+func TestDownloadTelegramPhoto_RejectsUnexpectedStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "large", Width: 800, Height: 600}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for unexpected status")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 502 Bad Gateway") {
+		t.Fatalf("expected unexpected status error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramPhoto_RejectsOversizeResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		chunk := []byte(strings.Repeat("a", 1024))
+		for written := 0; written < telegramMaxPhotoDownloadBytes+1; written += len(chunk) {
+			_, _ = w.Write(chunk)
+		}
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "large", Width: 800, Height: 600}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for oversized response")
+	}
+	if !strings.Contains(err.Error(), "response exceeded") {
+		t.Fatalf("expected oversized response error, got %v", err)
+	}
+}
+
 func TestDownloadTelegramVoice(t *testing.T) {
 	ts := newTestAudioServer(t, []byte("fake-ogg-data"))
 	defer ts.Close()


### PR DESCRIPTION
## What

Add bounds and validation to Telegram photo downloads by using a timed request, rejecting non-2xx responses, and capping the amount of image data read into memory before base64 encoding it.

## Why

The previous code used `http.Get` followed by `io.ReadAll(resp.Body)` with no status check or size limit, so an oversized response or HTTP error page could be buffered fully in memory and then expanded again during base64 encoding. This change prevents unexpected responses from being treated as images and avoids unbounded memory growth from large downloads.
