### PR TITLE
fix: Telegram voice downloads can write an unbounded response to disk

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -28,6 +28,7 @@ const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
+const telegramMaxVoiceDownloadBytes int64 = 25 << 20
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -94,6 +95,10 @@ func downloadTelegramVoice(fileGetter botFileGetter, voice *tgbotapi.Voice) (fil
 	if voice == nil {
 		return "", fmt.Errorf("no voice provided")
 	}
+	if voice.FileSize > 0 && int64(voice.FileSize) > telegramMaxVoiceDownloadBytes {
+		return "", fmt.Errorf("voice file too large: %d bytes (max %d)", voice.FileSize, telegramMaxVoiceDownloadBytes)
+	}
+
 	directURL, err := fileGetter.GetFileDirectURL(voice.FileID)
 	if err != nil {
 		return "", fmt.Errorf("get voice file URL: %w", err)
@@ -105,16 +110,36 @@ func downloadTelegramVoice(fileGetter botFileGetter, voice *tgbotapi.Voice) (fil
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return "", fmt.Errorf("download voice: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if resp.ContentLength > telegramMaxVoiceDownloadBytes {
+		return "", fmt.Errorf("voice file too large: %d bytes (max %d)", resp.ContentLength, telegramMaxVoiceDownloadBytes)
+	}
+
 	tmp, err := os.CreateTemp("", "tg-voice-*.ogg")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}
-	if _, err := io.Copy(tmp, resp.Body); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return "", fmt.Errorf("write voice temp file: %w", err)
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+
+	written, copyErr := io.Copy(tmp, io.LimitReader(resp.Body, telegramMaxVoiceDownloadBytes+1))
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		return "", fmt.Errorf("write voice temp file: %w", copyErr)
 	}
-	tmp.Close()
+	if closeErr != nil {
+		return "", fmt.Errorf("close voice temp file: %w", closeErr)
+	}
+	if written > telegramMaxVoiceDownloadBytes {
+		return "", fmt.Errorf("voice file too large: exceeds %d bytes", telegramMaxVoiceDownloadBytes)
+	}
+
 	return tmp.Name(), nil
 }
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1327,6 +1327,54 @@ func TestDownloadTelegramVoice_NilVoice(t *testing.T) {
 	}
 }
 
+func TestDownloadTelegramVoice_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	voice := &tgbotapi.Voice{FileID: "voice-1"}
+
+	_, err := downloadTelegramVoice(fg, voice)
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 502") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramVoice_TooLarge(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/ogg")
+		chunk := []byte(strings.Repeat("a", 32*1024))
+		remaining := telegramMaxVoiceDownloadBytes + 1
+		for remaining > 0 {
+			n := len(chunk)
+			if int64(n) > remaining {
+				n = int(remaining)
+			}
+			if _, err := w.Write(chunk[:n]); err != nil {
+				return
+			}
+			remaining -= int64(n)
+		}
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	voice := &tgbotapi.Voice{FileID: "voice-1"}
+
+	_, err := downloadTelegramVoice(fg, voice)
+	if err == nil {
+		t.Fatal("expected error for oversized voice download")
+	}
+	if !strings.Contains(err.Error(), "voice file too large") {
+		t.Fatalf("expected too large error, got %v", err)
+	}
+}
+
 func TestCollectUserText(t *testing.T) {
 	msg := llm.UserImageMessage("image/jpeg", "data", "caption text")
 	got := collectUserText(msg)


### PR DESCRIPTION
## What

Check Telegram voice download responses before writing them to disk, and cap downloads at 25 MB.

## Why

The previous implementation streamed whatever the remote URL returned straight into a temp file without validating the HTTP status or enforcing a size limit. That could write error pages or arbitrarily large responses to disk, causing incorrect behavior and potential disk exhaustion.
