### PR TITLE
fix: Telegram message splitting counts bytes, not characters, and can cut UTF-8 mid-rune

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/samsaffron/term-llm/internal/config"
@@ -1302,14 +1303,16 @@ loop:
 				rendered = buildHeartbeatSegment(prose, toolDisplay, phase, spin, elapsed)
 			}
 
-			if len(prose) >= telegramMaxMessageLen || len(rendered) >= telegramMaxMessageLen {
+			if utf8.RuneCountInString(prose) >= telegramMaxMessageLen || utf8.RuneCountInString(rendered) >= telegramMaxMessageLen {
 				// Keep chunk splitting based on prose, not status line rendering.
-				splitAt := telegramMaxMessageLen
-				if splitAt > len(prose) {
-					splitAt = len(prose)
+				splitAtRunes := telegramMaxMessageLen
+				proseRunes := utf8.RuneCountInString(prose)
+				if splitAtRunes > proseRunes {
+					splitAtRunes = proseRunes
 				}
-				sendEdit(currentMsgID, prose[:splitAt], false)
-				msgStart += splitAt
+				chunk, splitAtBytes := prefixRunes(prose, splitAtRunes)
+				sendEdit(currentMsgID, chunk, false)
+				msgStart += splitAtBytes
 				needNewMsg = true
 				continue
 			}
@@ -1618,6 +1621,22 @@ func tailRunes(s string, maxRunes int) string {
 		return s
 	}
 	return string(runes[len(runes)-maxRunes:])
+}
+
+func prefixRunes(s string, maxRunes int) (string, int) {
+	if maxRunes <= 0 || s == "" {
+		return "", 0
+	}
+
+	runeCount := 0
+	for idx := range s {
+		if runeCount == maxRunes {
+			return s[:idx], idx
+		}
+		runeCount++
+	}
+
+	return s, len(s)
 }
 
 // activeToolDisplay returns a short human-readable string describing which tools

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -486,6 +486,34 @@ func TestStreamReply_ExactChunkBoundary(t *testing.T) {
 	}
 }
 
+func TestStreamReply_UnicodeChunkBoundaryPreservesUTF8(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	response := strings.Repeat("世", telegramMaxMessageLen)
+	h.Provider.AddTextResponse(response)
+
+	mgr, sess := newTestMgrAndSession(h)
+	mgr.tickerInterval = 1 * time.Millisecond
+	bot := &fakeBotSender{}
+
+	if err := mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hi")); err != nil {
+		t.Fatalf("streamReply returned error: %v", err)
+	}
+
+	texts := bot.allTexts()
+	foundContent := false
+	for _, text := range texts {
+		if !utf8.ValidString(text) {
+			t.Fatalf("sent invalid UTF-8 text: %q", text)
+		}
+		if text == response || strings.HasPrefix(text, response) {
+			foundContent = true
+		}
+	}
+	if !foundContent {
+		t.Fatalf("expected full unicode response in sent texts; got %d messages", len(texts))
+	}
+}
+
 func TestStreamReply_PlaceholderSendFails(t *testing.T) {
 	h := testutil.NewEngineHarness()
 	h.Provider.AddTextResponse("Hello")


### PR DESCRIPTION
## What

- count Telegram message chunk sizes using Unicode characters instead of bytes
- split prose at rune boundaries so streamed chunks stay valid UTF-8
- add a regression test covering a full-length non-ASCII response at the chunk boundary

## Why

Telegram's limit is character-based, but the stream renderer was checking byte length and slicing strings by byte index. That could split multi-byte runes in half, produce invalid UTF-8, and mis-handle long non-ASCII or emoji-heavy responses.
