### PR TITLE
fix: OpenAI-compatible providers ignore explicit parallel_tool_calls=false

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -336,8 +336,8 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	if req.ToolChoice.Mode != "" {
 		chatReq.ToolChoice = buildCompatToolChoice(req.ToolChoice)
 	}
-	if req.ParallelToolCalls {
-		chatReq.ParallelToolCalls = boolPtr(true)
+	if len(tools) > 0 {
+		chatReq.ParallelToolCalls = boolPtr(req.ParallelToolCalls)
 	}
 	if req.Temperature > 0 {
 		v := float64(req.Temperature)

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -1,6 +1,10 @@
 package llm
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -638,5 +642,68 @@ func TestBuildCompatMessages_DeveloperMessageNotDropped(t *testing.T) {
 	}
 	if !strings.Contains(content, "hey whats up") {
 		t.Errorf("user text was dropped — not found in %q", content)
+	}
+}
+
+func TestOpenAICompatProviderStreamSendsExplicitParallelToolCallsFalse(t *testing.T) {
+	var got struct {
+		ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty"`
+		Tools             []json.RawMessage `json:"tools,omitempty"`
+		Stream            bool              `json:"stream"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	provider := NewOpenAICompatProvider(ts.URL, "test-key", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+		Tools: []ToolSpec{{
+			Name:        "echo",
+			Description: "Echo input",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"text": map[string]interface{}{"type": "string"},
+				},
+			},
+		}},
+		ParallelToolCalls: false,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.ParallelToolCalls == nil {
+		t.Fatal("expected parallel_tool_calls to be sent explicitly")
+	}
+	if *got.ParallelToolCalls {
+		t.Fatalf("expected parallel_tool_calls=false, got %v", *got.ParallelToolCalls)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(got.Tools))
+	}
+	if !got.Stream {
+		t.Fatal("expected stream=true")
 	}
 }


### PR DESCRIPTION
## What

Send `parallel_tool_calls` explicitly for OpenAI-compatible chat-completions requests whenever tools are present, including when the requested value is `false`.

Also adds a regression test covering `parallel_tool_calls=false` for `OpenAICompatProvider.Stream`.

## Why

OpenAI-compatible providers previously only sent `parallel_tool_calls` when it was `true`, so an explicit `false` was silently dropped and the upstream provider's default behavior was used instead. That can re-enable parallel tool execution when callers are trying to force serialized tool calls.
