### PR TITLE
fix: OpenAI Responses provider also drops valid zero temperature/top_p settings

### DIFF
--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -125,9 +125,11 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 	}
 	if req.Temperature != nil {
 		llmReq.Temperature = *req.Temperature
+		llmReq.TemperatureSet = true
 	}
 	if req.TopP != nil {
 		llmReq.TopP = *req.TopP
+		llmReq.TopPSet = true
 	}
 
 	if req.Stream {

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -87,9 +87,11 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 	}
 	if req.Temperature != nil {
 		llmReq.Temperature = *req.Temperature
+		llmReq.TemperatureSet = true
 	}
 	if req.TopP != nil {
 		llmReq.TopP = *req.TopP
+		llmReq.TopPSet = true
 	}
 
 	if req.Stream {

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -136,9 +136,11 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Temperature != nil {
 		llmReq.Temperature = *req.Temperature
+		llmReq.TemperatureSet = true
 	}
 	if req.TopP != nil {
 		llmReq.TopP = *req.TopP
+		llmReq.TopPSet = true
 	}
 
 	if req.Stream {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -126,11 +126,11 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req Request) (Stream, error
 	if len(tools) > 0 {
 		responsesReq.ParallelToolCalls = boolPtr(req.ParallelToolCalls)
 	}
-	if req.Temperature > 0 {
+	if req.TemperatureSet || req.Temperature != 0 {
 		v := float64(req.Temperature)
 		responsesReq.Temperature = &v
 	}
-	if req.TopP > 0 {
+	if req.TopPSet || req.TopP != 0 {
 		v := float64(req.TopP)
 		responsesReq.TopP = &v
 	}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -76,3 +76,64 @@ func TestOpenAIProviderStreamSendsExplicitParallelToolCallsFalse(t *testing.T) {
 		t.Fatal("expected stream=true")
 	}
 }
+
+func TestOpenAIProviderStreamSendsExplicitZeroTemperatureAndTopP(t *testing.T) {
+	var got struct {
+		Temperature *float64 `json:"temperature,omitempty"`
+		TopP        *float64 `json:"top_p,omitempty"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	provider := &OpenAIProvider{
+		apiKey: "test-key",
+		model:  "gpt-4.1",
+		responsesClient: &ResponsesClient{
+			BaseURL:       ts.URL,
+			GetAuthHeader: func() string { return "Bearer test-key" },
+			HTTPClient:    ts.Client(),
+		},
+	}
+
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages:       []Message{UserText("hello")},
+		Temperature:    0,
+		TemperatureSet: true,
+		TopP:           0,
+		TopPSet:        true,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.Temperature == nil {
+		t.Fatal("expected temperature=0 to be sent explicitly")
+	}
+	if *got.Temperature != 0 {
+		t.Fatalf("expected temperature=0, got %v", *got.Temperature)
+	}
+	if got.TopP == nil {
+		t.Fatal("expected top_p=0 to be sent explicitly")
+	}
+	if *got.TopP != 0 {
+		t.Fatalf("expected top_p=0, got %v", *got.TopP)
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -66,7 +66,9 @@ type Request struct {
 	ReasoningEffort         string
 	MaxOutputTokens         int
 	Temperature             float32
+	TemperatureSet          bool // If true, Temperature was explicitly provided, including zero
 	TopP                    float32
+	TopPSet                 bool              // If true, TopP was explicitly provided, including zero
 	MaxTurns                int               // Max agentic turns for tool execution (0 = use default)
 	ToolMap                 map[string]string // Maps client tool names to server tool names (e.g. "WebSearch" → "search")
 	Debug                   bool


### PR DESCRIPTION
## What

Preserve explicitly provided `temperature: 0` and `top_p: 0` values on the OpenAI Responses provider path instead of dropping them.

## Why

Zero is a valid sampling setting for deterministic or tightly controlled inference. The previous `> 0` checks rewrote explicit zero values into provider defaults, which changed model behavior from what the caller requested.
