### PR TITLE
fix: OpenAI-compatible providers cannot send temperature=0 or top_p=0

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -339,11 +339,11 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	if req.ParallelToolCalls {
 		chatReq.ParallelToolCalls = boolPtr(true)
 	}
-	if req.Temperature > 0 {
+	if req.Temperature >= 0 {
 		v := float64(req.Temperature)
 		chatReq.Temperature = &v
 	}
-	if req.TopP > 0 {
+	if req.TopP >= 0 {
 		v := float64(req.TopP)
 		chatReq.TopP = &v
 	}

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -1,6 +1,10 @@
 package llm
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -150,6 +154,66 @@ func TestBuildCompatMessages_NoReasoningContent(t *testing.T) {
 	}
 	if oaiMsgs[1].ReasoningContent != "" {
 		t.Errorf("expected empty reasoning_content, got %q", oaiMsgs[1].ReasoningContent)
+	}
+}
+
+func TestOpenAICompatProviderStreamSendsZeroTemperatureAndTopP(t *testing.T) {
+	var got struct {
+		Temperature *float64 `json:"temperature,omitempty"`
+		TopP        *float64 `json:"top_p,omitempty"`
+		Stream      bool     `json:"stream"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	oldHTTPClient := defaultHTTPClient
+	defaultHTTPClient = ts.Client()
+	defer func() {
+		defaultHTTPClient = oldHTTPClient
+	}()
+
+	provider := NewOpenAICompatProvider(ts.URL, "", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages:    []Message{UserText("hello")},
+		Temperature: 0,
+		TopP:        0,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.Temperature == nil {
+		t.Fatal("expected temperature to be sent explicitly")
+	}
+	if *got.Temperature != 0 {
+		t.Fatalf("expected temperature=0, got %v", *got.Temperature)
+	}
+	if got.TopP == nil {
+		t.Fatal("expected top_p to be sent explicitly")
+	}
+	if *got.TopP != 0 {
+		t.Fatalf("expected top_p=0, got %v", *got.TopP)
+	}
+	if !got.Stream {
+		t.Fatal("expected stream=true")
 	}
 }
 


### PR DESCRIPTION
## What

Forward zero-valued `temperature` and `top_p` in the OpenAI-compatible chat request instead of dropping them, and add a regression test covering both fields.

## Why

`temperature: 0` and `top_p: 0` are valid, meaningful settings. The previous `> 0` checks treated zero the same as unset, so deterministic or explicitly configured sampling requests were silently changed before reaching OpenAI-compatible backends.
