### PR TITLE
fix: Anthropic message parsing reorders tool results ahead of user text

### DIFF
--- a/cmd/serve_protocol_anthropic.go
+++ b/cmd/serve_protocol_anthropic.go
@@ -161,22 +161,30 @@ func parseAnthropicMessages(msgs []anthropicMessage) ([]llm.Message, error) {
 		switch role {
 		case "user":
 			// Anthropic puts tool_result blocks in user messages.
-			// Split them out into RoleTool messages so the OpenAI-compat
-			// provider can emit proper {"role":"tool"} entries.
-			var userParts, toolParts []llm.Part
-			for _, p := range parts {
-				if p.Type == llm.PartToolResult {
-					toolParts = append(toolParts, p)
-				} else {
-					userParts = append(userParts, p)
+			// Split them into RoleTool messages so the OpenAI-compat provider
+			// can emit proper {"role":"tool"} entries, while preserving the
+			// original block ordering within the user message.
+			var currentRole llm.Role
+			var currentParts []llm.Part
+			flush := func() {
+				if len(currentParts) == 0 {
+					return
 				}
+				result = append(result, llm.Message{Role: currentRole, Parts: currentParts})
+				currentParts = nil
 			}
-			if len(toolParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleTool, Parts: toolParts})
+			for _, p := range parts {
+				targetRole := llm.RoleUser
+				if p.Type == llm.PartToolResult {
+					targetRole = llm.RoleTool
+				}
+				if len(currentParts) > 0 && currentRole != targetRole {
+					flush()
+				}
+				currentRole = targetRole
+				currentParts = append(currentParts, p)
 			}
-			if len(userParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleUser, Parts: userParts})
-			}
+			flush()
 		case "assistant":
 			result = append(result, llm.Message{Role: llm.RoleAssistant, Parts: parts})
 		default:

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4848,6 +4848,32 @@ func TestParseAnthropicMessages_ToolUseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAnthropicMessages_PreservesMixedUserToolResultOrdering(t *testing.T) {
+	msgs, err := parseAnthropicMessages([]anthropicMessage{{
+		Role: "user",
+		Content: json.RawMessage(`[
+			{"type":"text","text":"before"},
+			{"type":"tool_result","tool_use_id":"call_1","content":"tool output"},
+			{"type":"text","text":"after"}
+		]`),
+	}})
+	if err != nil {
+		t.Fatalf("parseAnthropicMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("len = %d, want 3", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || len(msgs[0].Parts) != 1 || msgs[0].Parts[0].Text != "before" {
+		t.Fatalf("first message = %+v, want leading user text", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleTool || len(msgs[1].Parts) != 1 || msgs[1].Parts[0].ToolResult == nil || msgs[1].Parts[0].ToolResult.ID != "call_1" {
+		t.Fatalf("second message = %+v, want tool result", msgs[1])
+	}
+	if msgs[2].Role != llm.RoleUser || len(msgs[2].Parts) != 1 || msgs[2].Parts[0].Text != "after" {
+		t.Fatalf("third message = %+v, want trailing user text", msgs[2])
+	}
+}
+
 func TestParseAnthropicSystem(t *testing.T) {
 	// String form
 	if got := parseAnthropicSystem(json.RawMessage(`"Be helpful"`)); got != "Be helpful" {


### PR DESCRIPTION
## What

Preserve the original block order when parsing Anthropic user messages that mix normal user content with `tool_result` blocks.

## Why

The previous parser collected all tool results into a single `tool` message and appended it before the remaining user content, which changed the prompt structure seen by the backend model. Keeping tool-result and user-content segments in their original order avoids incorrect follow-up reasoning.
