### PR TITLE
fix: Inline image attachments bypass the configured attachment limit

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -203,6 +203,10 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					continue
 				}
 				if isLLMImageType(mt) {
+					fileCount++
+					if fileCount > maxAttachments {
+						return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
+					}
 					// Always save the original to disk first.
 					if filename == "" {
 						filename = "image"

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const onePixelPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+KDvV3wAAAABJRU5ErkJggg=="
+
+func TestParseUserMessageContent_AllowsUpToMaxInlineImages(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	content := marshalInlineImageParts(t, maxAttachments)
+
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	if len(msg.Parts) != maxAttachments {
+		t.Fatalf("len(msg.Parts) = %d, want %d", len(msg.Parts), maxAttachments)
+	}
+}
+
+func TestParseUserMessageContent_RejectsTooManyInlineImages(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	content := marshalInlineImageParts(t, maxAttachments+1)
+
+	_, err := parseUserMessageContent(content)
+	if err == nil {
+		t.Fatal("parseUserMessageContent() error = nil, want attachment limit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("too many attachments (max %d)", maxAttachments)) {
+		t.Fatalf("parseUserMessageContent() error = %v, want attachment limit error", err)
+	}
+}
+
+func marshalInlineImageParts(t *testing.T, count int) json.RawMessage {
+	t.Helper()
+
+	parts := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		parts = append(parts, map[string]any{
+			"type":      "input_image",
+			"image_url": onePixelPNGDataURL,
+			"filename":  fmt.Sprintf("image-%d.png", i),
+		})
+	}
+
+	content, err := json.Marshal(parts)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return content
+}


### PR DESCRIPTION
## What

- count LLM-native inline image attachments toward the existing `maxAttachments` limit in `parseUserMessageContent`
- add regression coverage for the max-attachments boundary and overflow case for inline `data:` images

## Why

Inline `image/png`/`image/jpeg` attachments were not included in the attachment counter, so a request could send an unbounded number of native image uploads and force the server to decode, save, and optionally resize each one. Enforcing the same cap for these images closes that denial-of-service path.
