### PR TITLE
fix: Telegram photo downloads read the entire response into memory with no limits

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -28,6 +28,8 @@ const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
+const telegramDownloadTimeout = 30 * time.Second
+const telegramMaxPhotoBytes = 20 << 20 // 20 MB
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -55,15 +57,33 @@ func downloadTelegramPhoto(fileGetter botFileGetter, photos []tgbotapi.PhotoSize
 		return "", "", "", fmt.Errorf("get file URL: %w", err)
 	}
 
-	resp, err := http.Get(directURL)
+	ctx, cancel := context.WithTimeout(context.Background(), telegramDownloadTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, directURL, nil)
+	if err != nil {
+		return "", "", "", fmt.Errorf("create photo request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", "", "", fmt.Errorf("download photo: %w", err)
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", "", "", fmt.Errorf("download photo: unexpected status %s", resp.Status)
+	}
+	if resp.ContentLength > telegramMaxPhotoBytes {
+		return "", "", "", fmt.Errorf("download photo: response too large: %d bytes", resp.ContentLength)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, telegramMaxPhotoBytes+1))
 	if err != nil {
 		return "", "", "", fmt.Errorf("read photo data: %w", err)
+	}
+	if int64(len(data)) > telegramMaxPhotoBytes {
+		return "", "", "", fmt.Errorf("read photo data: response exceeds %d bytes", telegramMaxPhotoBytes)
 	}
 
 	// Detect MIME type from content (Telegram can serve PNG, WebP, etc.)

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1289,6 +1290,44 @@ func TestDownloadTelegramPhoto_EmptyPhotos(t *testing.T) {
 	_, _, _, err := downloadTelegramPhoto(fg, nil)
 	if err == nil {
 		t.Fatal("expected error for empty photos")
+	}
+}
+
+func TestDownloadTelegramPhoto_UnexpectedStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream error", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "large", Width: 800, Height: 600}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for unexpected status")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 502 Bad Gateway") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDownloadTelegramPhoto_TooLarge(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Header().Set("Content-Length", strconv.FormatInt(telegramMaxPhotoBytes+1, 10))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "large", Width: 800, Height: 600}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for oversized response")
+	}
+	if !strings.Contains(err.Error(), "response too large") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

- stop using `http.Get` for Telegram photo downloads and create a context-bound request with a timeout
- reject non-200 Telegram file responses before reading the body
- cap photo downloads at 20 MB and fail if the response is larger than that limit
- add tests for unexpected status codes and oversized responses

## Why

The previous implementation read the entire response body into memory with `io.ReadAll` and no size limit, then base64-encoded it, which could sharply increase memory usage. Checking the response status, binding the request to a timeout, and enforcing a maximum body size prevents oversized or bad upstream responses from exhausting process memory.
