### PR TITLE
fix: Telegram voice downloads can fill disk because response size is unbounded

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -28,6 +28,7 @@ const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
+const telegramMaxVoiceDownloadBytes = 25 << 20 // 25 MB
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -94,6 +95,9 @@ func downloadTelegramVoice(fileGetter botFileGetter, voice *tgbotapi.Voice) (fil
 	if voice == nil {
 		return "", fmt.Errorf("no voice provided")
 	}
+	if voice.FileSize > telegramMaxVoiceDownloadBytes {
+		return "", fmt.Errorf("voice file too large: %d bytes exceeds %d", voice.FileSize, telegramMaxVoiceDownloadBytes)
+	}
 	directURL, err := fileGetter.GetFileDirectURL(voice.FileID)
 	if err != nil {
 		return "", fmt.Errorf("get voice file URL: %w", err)
@@ -104,17 +108,31 @@ func downloadTelegramVoice(fileGetter botFileGetter, voice *tgbotapi.Voice) (fil
 		return "", fmt.Errorf("download voice: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download voice: unexpected HTTP status %s", resp.Status)
+	}
+	if resp.ContentLength > telegramMaxVoiceDownloadBytes {
+		return "", fmt.Errorf("voice file too large: %d bytes exceeds %d", resp.ContentLength, telegramMaxVoiceDownloadBytes)
+	}
 
 	tmp, err := os.CreateTemp("", "tg-voice-*.ogg")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}
-	if _, err := io.Copy(tmp, resp.Body); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return "", fmt.Errorf("write voice temp file: %w", err)
+
+	limitedBody := &io.LimitedReader{R: resp.Body, N: telegramMaxVoiceDownloadBytes + 1}
+	written, copyErr := io.Copy(tmp, limitedBody)
+	if closeErr := tmp.Close(); copyErr == nil && closeErr != nil {
+		copyErr = closeErr
 	}
-	tmp.Close()
+	if copyErr != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("write voice temp file: %w", copyErr)
+	}
+	if written > telegramMaxVoiceDownloadBytes {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("voice file too large: exceeds %d bytes", telegramMaxVoiceDownloadBytes)
+	}
 	return tmp.Name(), nil
 }
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1327,6 +1327,61 @@ func TestDownloadTelegramVoice_NilVoice(t *testing.T) {
 	}
 }
 
+func TestDownloadTelegramVoice_HTTPStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream failure", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	voice := &tgbotapi.Voice{FileID: "voice-1"}
+
+	_, err := downloadTelegramVoice(fg, voice)
+	if err == nil {
+		t.Fatal("expected error for unexpected HTTP status")
+	}
+	if !strings.Contains(err.Error(), "unexpected HTTP status") {
+		t.Fatalf("expected HTTP status error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramVoice_TooLarge(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/ogg")
+		chunk := make([]byte, 8192)
+		remaining := telegramMaxVoiceDownloadBytes + 1
+		for remaining > 0 {
+			n := len(chunk)
+			if n > remaining {
+				n = remaining
+			}
+			if _, err := w.Write(chunk[:n]); err != nil {
+				return
+			}
+			remaining -= n
+		}
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	voice := &tgbotapi.Voice{FileID: "voice-1"}
+
+	filePath, err := downloadTelegramVoice(fg, voice)
+	if err == nil {
+		if filePath != "" {
+			_ = os.Remove(filePath)
+		}
+		t.Fatal("expected error for oversized voice download")
+	}
+	if filePath != "" {
+		_ = os.Remove(filePath)
+		t.Fatalf("expected empty file path on oversized voice download, got %q", filePath)
+	}
+	if !strings.Contains(err.Error(), "voice file too large") {
+		t.Fatalf("expected size limit error, got %v", err)
+	}
+}
+
 func TestCollectUserText(t *testing.T) {
 	msg := llm.UserImageMessage("image/jpeg", "data", "caption text")
 	got := collectUserText(msg)


### PR DESCRIPTION
## What

Add bounds checks to Telegram voice downloads by rejecting non-200 responses, refusing oversized files up front when size metadata is available, and capping streamed writes to 25 MB so voice downloads cannot grow without limit on disk.

## Why

`downloadTelegramVoice` previously copied the entire upstream response into a temp file without checking the HTTP status or enforcing a maximum size. A large or unexpected upstream response could exhaust disk space and feed invalid data into transcription.
