### PR TITLE
fix: /v1/transcribe leaks multipart temporary files and can fill disk

### DIFF
--- a/cmd/serve_transcribe.go
+++ b/cmd/serve_transcribe.go
@@ -68,8 +68,14 @@ func (s *serveServer) handleTranscribe(w http.ResponseWriter, r *http.Request) {
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxVoiceUploadBytes)
 	if err := r.ParseMultipartForm(maxVoiceUploadBytes); err != nil {
+		if r.MultipartForm != nil {
+			_ = r.MultipartForm.RemoveAll()
+		}
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "request must be multipart/form-data with an audio file")
 		return
+	}
+	if r.MultipartForm != nil {
+		defer r.MultipartForm.RemoveAll()
 	}
 
 	file, header, err := r.FormFile("file")


### PR DESCRIPTION
## What

Add multipart form cleanup to `/v1/transcribe` so parser-created temporary files are removed after each request.

## Why

`ParseMultipartForm` can leave uploaded parts in temporary files under `/tmp`. The handler already removes its own secondary temp file, but it did not clean up the multipart parser temp files, so repeated transcription uploads could accumulate and eventually fill the disk.
