### PR TITLE
fix: /v1/chat/completions silently drops all client-defined passthrough tools

### DIFF
--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -60,7 +60,29 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 	search := runtime.search
 	requestedTools := parseChatRequestedToolNames(req.Tools)
 	toolChoice := parseToolChoice(req.ToolChoice)
-	tools := runtime.selectTools(requestedTools)
+
+	serverTools := runtime.selectTools(requestedTools)
+	mappedTargets := make(map[string]bool)
+	if runtime.toolMap != nil {
+		for name := range requestedTools {
+			if mapped, ok := runtime.toolMap[name]; ok {
+				mappedTargets[mapped] = true
+			}
+		}
+	}
+	serverNames := make(map[string]bool, len(serverTools))
+	tools := make([]llm.ToolSpec, 0, len(serverTools)+len(req.Tools))
+	for _, t := range serverTools {
+		serverNames[t.Name] = true
+		if !mappedTargets[t.Name] {
+			tools = append(tools, t)
+		}
+	}
+	for _, ct := range chatToolsToSpecs(req.Tools) {
+		if !serverNames[ct.Name] {
+			tools = append(tools, ct)
+		}
+	}
 	if len(tools) == 0 {
 		toolChoice = llm.ToolChoice{}
 	}

--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -33,7 +33,9 @@ type chatTool struct {
 }
 
 type chatToolFuncDef struct {
-	Name string `json:"name"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
 }
 
 type chatMessage struct {
@@ -126,6 +128,30 @@ func parseChatRequestedToolNames(tools []chatTool) map[string]bool {
 		}
 	}
 	return selected
+}
+
+func chatToolsToSpecs(tools []chatTool) []llm.ToolSpec {
+	specs := make([]llm.ToolSpec, 0, len(tools))
+	for _, t := range tools {
+		if strings.ToLower(strings.TrimSpace(t.Type)) != "function" {
+			continue
+		}
+		name := strings.TrimSpace(t.Name)
+		spec := llm.ToolSpec{}
+		if t.Function != nil {
+			if name == "" {
+				name = strings.TrimSpace(t.Function.Name)
+			}
+			spec.Description = t.Function.Description
+			spec.Schema = t.Function.Parameters
+		}
+		if name == "" {
+			continue
+		}
+		spec.Name = name
+		specs = append(specs, spec)
+	}
+	return specs
 }
 
 func parseToolChoice(raw json.RawMessage) llm.ToolChoice {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -5105,6 +5105,73 @@ func TestToolMap_ChatCompletions(t *testing.T) {
 	}
 }
 
+func TestChatCompletions_PreservesClientPassthroughTools(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	engine := llm.NewEngine(provider, nil)
+
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	srv := &serveServer{sessionMgr: mgr}
+
+	body := `{
+		"model": "test",
+		"messages": [{"role": "user", "content": "Hi"}],
+		"tools": [{
+			"type": "function",
+			"function": {
+				"name": "client_tool",
+				"description": "Client-defined passthrough tool",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"query": {"type": "string"}
+					},
+					"required": ["query"]
+				}
+			}
+		}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleChatCompletions(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("expected 1 provider request, got %d", len(provider.Requests))
+	}
+	tools := provider.Requests[0].Tools
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 passthrough tool, got %d", len(tools))
+	}
+	if tools[0].Name != "client_tool" {
+		t.Fatalf("expected tool name client_tool, got %q", tools[0].Name)
+	}
+	if tools[0].Description != "Client-defined passthrough tool" {
+		t.Fatalf("unexpected tool description: %q", tools[0].Description)
+	}
+	if got := tools[0].Schema["type"]; got != "object" {
+		t.Fatalf("expected tool schema type object, got %#v", got)
+	}
+	props, ok := tools[0].Schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected schema properties map, got %#v", tools[0].Schema["properties"])
+	}
+	if _, ok := props["query"]; !ok {
+		t.Fatalf("expected query property in schema, got %#v", props)
+	}
+}
+
 func TestToolMap_Responses(t *testing.T) {
 	srv := newTestServeServerWithToolMap(
 		map[string]string{"MyEcho": "echo"},


### PR DESCRIPTION
## What

Preserve client-defined passthrough function tools in `/v1/chat/completions` by merging the client tool definitions back into `llmReq.Tools` instead of only forwarding server-registered tools.

Also add a regression test that verifies a custom Chat Completions tool definition reaches the provider unchanged.

## Why

The handler previously reduced the request tools to a name set and called `runtime.selectTools`, which only returns server-registered tool specs. That meant custom function tools from OpenAI-compatible proxy clients disappeared before the model saw them, so passthrough tool calling could never work correctly on this endpoint.
