### PR TITLE
fix: /v1/responses silently drops all client-defined passthrough tools

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -105,10 +105,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		defer runtime.Close()
 	}
 
-	searchFromTools, requestedTools := parseRequestedTools(req.Tools)
+	searchFromTools, requestedTools, passthroughTools := parseRequestedTools(req.Tools)
 	search := runtime.search || searchFromTools
 	toolChoice := parseToolChoice(req.ToolChoice)
-	tools := runtime.selectTools(requestedTools)
+	tools := appendResponsePassthroughTools(runtime.selectTools(requestedTools), passthroughTools, runtime.toolMap)
 	if len(tools) == 0 {
 		toolChoice = llm.ToolChoice{}
 	}
@@ -183,6 +183,30 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	s.registerResponseID(runtime, respID, sessionID)
 
 	writeJSON(w, http.StatusOK, responsesFinalResponse(result, model, respID))
+}
+
+func appendResponsePassthroughTools(serverTools []llm.ToolSpec, passthroughTools []llm.ToolSpec, toolMap map[string]string) []llm.ToolSpec {
+	if len(passthroughTools) == 0 {
+		return serverTools
+	}
+
+	selected := make(map[string]bool, len(serverTools))
+	for _, spec := range serverTools {
+		selected[spec.Name] = true
+	}
+
+	for _, spec := range passthroughTools {
+		if selected[spec.Name] {
+			continue
+		}
+		if mapped, ok := toolMap[spec.Name]; ok && selected[mapped] {
+			continue
+		}
+		serverTools = append(serverTools, spec)
+		selected[spec.Name] = true
+	}
+
+	return serverTools
 }
 
 func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string) {

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -98,9 +98,10 @@ func parseResponsesInput(input json.RawMessage) ([]llm.Message, bool, error) {
 	return messages, replaceHistory, nil
 }
 
-func parseRequestedTools(raw []json.RawMessage) (bool, map[string]bool) {
+func parseRequestedTools(raw []json.RawMessage) (bool, map[string]bool, []llm.ToolSpec) {
 	search := false
 	toolNames := map[string]bool{}
+	passthrough := make([]llm.ToolSpec, 0, len(raw))
 
 	for _, item := range raw {
 		var generic map[string]json.RawMessage
@@ -112,21 +113,66 @@ func parseRequestedTools(raw []json.RawMessage) (bool, map[string]bool) {
 		case "web_search_preview", "web_search":
 			search = true
 		case "function":
-			name := strings.TrimSpace(jsonString(generic["name"]))
-			if name == "" {
-				var fn chatToolFuncDef
-				if rawFunc := generic["function"]; len(rawFunc) > 0 {
-					_ = json.Unmarshal(rawFunc, &fn)
-					name = strings.TrimSpace(fn.Name)
-				}
+			spec, ok := parseRequestedFunctionTool(generic)
+			if !ok {
+				continue
 			}
-			if name != "" {
-				toolNames[name] = true
+			toolNames[spec.Name] = true
+			passthrough = append(passthrough, spec)
+		}
+	}
+
+	return search, toolNames, passthrough
+}
+
+func parseRequestedFunctionTool(generic map[string]json.RawMessage) (llm.ToolSpec, bool) {
+	spec := llm.ToolSpec{
+		Name:        strings.TrimSpace(jsonString(generic["name"])),
+		Description: strings.TrimSpace(jsonString(generic["description"])),
+	}
+	if rawParams := generic["parameters"]; len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &spec.Schema)
+	}
+	if rawStrict := generic["strict"]; len(rawStrict) > 0 {
+		var strict bool
+		if err := json.Unmarshal(rawStrict, &strict); err == nil && !strict {
+			spec.NoStrict = true
+		}
+	}
+
+	if rawFunc := generic["function"]; len(rawFunc) > 0 {
+		var fn struct {
+			Name        string                 `json:"name"`
+			Description string                 `json:"description"`
+			Parameters  map[string]interface{} `json:"parameters"`
+			Strict      *bool                  `json:"strict"`
+		}
+		if err := json.Unmarshal(rawFunc, &fn); err == nil {
+			if spec.Name == "" {
+				spec.Name = strings.TrimSpace(fn.Name)
+			}
+			if spec.Description == "" {
+				spec.Description = strings.TrimSpace(fn.Description)
+			}
+			if spec.Schema == nil {
+				spec.Schema = fn.Parameters
+			}
+			if fn.Strict != nil && !*fn.Strict {
+				spec.NoStrict = true
 			}
 		}
 	}
 
-	return search, toolNames
+	if spec.Name == "" {
+		return llm.ToolSpec{}, false
+	}
+	if spec.Schema == nil {
+		spec.Schema = map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{},
+		}
+	}
+	return spec, true
 }
 
 func responsesFinalResponse(result serveRunResult, model string, respID string) map[string]any {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4724,6 +4724,73 @@ func TestHandleResponses_WithProviderField(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_PreservesClientDefinedPassthroughTools(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	provider.AddToolCall("call_passthrough_1", "client_tool", map[string]any{"value": "ok"})
+
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  "mock",
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	manager := newServeSessionManager(time.Minute, 10, factory)
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfgRef:     &config.Config{DefaultProvider: "mock"},
+		sessionMgr: manager,
+	}
+
+	code, _ := doResponses(t, srv, `{
+		"input":"hello",
+		"tools":[{
+			"type":"function",
+			"name":"client_tool",
+			"description":"Client-defined passthrough tool",
+			"parameters":{
+				"type":"object",
+				"properties":{"value":{"type":"string"}},
+				"required":["value"]
+			}
+		}],
+		"tool_choice":{"type":"function","name":"client_tool"}
+	}`)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider request count = %d, want 1", len(provider.Requests))
+	}
+
+	req := provider.Requests[0]
+	if len(req.Tools) != 1 {
+		t.Fatalf("tool count = %d, want 1", len(req.Tools))
+	}
+	if req.Tools[0].Name != "client_tool" {
+		t.Fatalf("tool name = %q, want client_tool", req.Tools[0].Name)
+	}
+	if req.Tools[0].Description != "Client-defined passthrough tool" {
+		t.Fatalf("tool description = %q", req.Tools[0].Description)
+	}
+	if req.ToolChoice.Mode != llm.ToolChoiceName || req.ToolChoice.Name != "client_tool" {
+		t.Fatalf("tool choice = %#v, want name client_tool", req.ToolChoice)
+	}
+	props, ok := req.Tools[0].Schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tool schema properties missing: %#v", req.Tools[0].Schema)
+	}
+	valueProp, ok := props["value"].(map[string]interface{})
+	if !ok || valueProp["type"] != "string" {
+		t.Fatalf("tool schema value property = %#v, want string type", props["value"])
+	}
+}
+
 func TestSessionManager_GetOrCreateWithDeduplication(t *testing.T) {
 	var calls int32
 	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {


### PR DESCRIPTION
## What

Preserve client-defined function tools on `/v1/responses` by parsing their full definitions into passthrough `llm.ToolSpec`s and appending any that are not satisfied by server-registered tools.

Also added a regression test covering a Responses request with a client-only tool and named `tool_choice`.

## Why

The handler previously reduced `req.Tools` to a set of names and then called `runtime.selectTools(...)`, which only returns server-registered tools. Any client-defined tool that was not also registered on the server disappeared from the upstream LLM request, so the model could not call it and named `tool_choice` for that tool was effectively ignored.
