### PR TITLE
fix: Responses API client reads unlimited error bodies into memory

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 )
 
+const maxResponsesAPIErrorBodyBytes = 64 * 1024
+
+var truncatedResponsesAPIErrorBodySuffix = []byte("\n... response body truncated")
+
 // ResponsesClient makes raw HTTP calls to Open Responses-compliant endpoints.
 // See https://www.openresponses.org/specification
 type ResponsesClient struct {
@@ -410,6 +414,20 @@ func BuildResponsesToolChoice(choice ToolChoice) interface{} {
 	}
 }
 
+func readResponsesAPIErrorBody(resp *http.Response) []byte {
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponsesAPIErrorBodyBytes+1))
+	if len(body) <= maxResponsesAPIErrorBodyBytes {
+		return body
+	}
+
+	truncated := make([]byte, 0, maxResponsesAPIErrorBodyBytes+len(truncatedResponsesAPIErrorBodySuffix))
+	truncated = append(truncated, body[:maxResponsesAPIErrorBodyBytes]...)
+	truncated = append(truncated, truncatedResponsesAPIErrorBodySuffix...)
+	return truncated
+}
+
 // Stream makes a streaming request to the Responses API and returns events via a Stream
 func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debugRaw bool) (Stream, error) {
 	fullInput := req.Input
@@ -462,8 +480,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 
 	// Check for error responses synchronously so retry logic can handle them
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		respBody := readResponsesAPIErrorBody(resp)
 
 		if debugRaw {
 			var debugInfo strings.Builder
@@ -522,8 +539,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 				return nil, fmt.Errorf("Responses API retry request failed: %w", err)
 			}
 			if resp.StatusCode != http.StatusOK {
-				retryBody, _ := io.ReadAll(resp.Body)
-				resp.Body.Close()
+				retryBody := readResponsesAPIErrorBody(resp)
 				return nil, fmt.Errorf("Responses API error (status %d): %s", resp.StatusCode, string(retryBody))
 			}
 		} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
@@ -552,8 +568,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					return nil, fmt.Errorf("Responses API auth retry request failed: %w", err)
 				}
 				if resp.StatusCode != http.StatusOK {
-					retryBody, _ := io.ReadAll(resp.Body)
-					resp.Body.Close()
+					retryBody := readResponsesAPIErrorBody(resp)
 					return nil, fmt.Errorf("Responses API error after re-auth (status %d): %s", resp.StatusCode, string(retryBody))
 				}
 			} else {

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -1026,6 +1026,142 @@ func TestResponsesClient_NoOnAuthRetry_Returns401Error(t *testing.T) {
 	}
 }
 
+func assertResponsesAPIErrorBodyTruncated(t *testing.T, err error, prefix string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), prefix) {
+		t.Fatalf("expected error %q to contain %q", err.Error(), prefix)
+	}
+	if !strings.Contains(err.Error(), string(truncatedResponsesAPIErrorBodySuffix)) {
+		t.Fatalf("expected error %q to contain truncation suffix", err.Error())
+	}
+	if strings.Contains(err.Error(), "TAIL_MARKER") {
+		t.Fatalf("expected error %q not to include truncated tail marker", err.Error())
+	}
+}
+
+func TestResponsesClient_Stream_LimitsErrorBody(t *testing.T) {
+	body := strings.Repeat("x", maxResponsesAPIErrorBodyBytes+1024) + "TAIL_MARKER"
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Status:     "500 Internal Server Error",
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	_, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "test-model",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+
+	assertResponsesAPIErrorBodyTruncated(t, err, "Responses API error (status 500):")
+}
+
+func TestResponsesClientStream_Retry404FailureLimitsErrorBody(t *testing.T) {
+	body := strings.Repeat("x", maxResponsesAPIErrorBodyBytes+1024) + "TAIL_MARKER"
+	callCount := 0
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Status:     "404 Not Found",
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"error":"previous_response_id not found"}`)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Status:     "500 Internal Server Error",
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:        "https://example.test/v1/responses",
+		GetAuthHeader:  func() string { return "Bearer test-token" },
+		HTTPClient:     httpClient,
+		LastResponseID: "resp_prev",
+	}
+
+	_, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "test-model",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+
+	if callCount != 2 {
+		t.Fatalf("expected 2 HTTP calls (initial + retry), got %d", callCount)
+	}
+	assertResponsesAPIErrorBodyTruncated(t, err, "Responses API error (status 500):")
+}
+
+func TestResponsesClient_OnAuthRetry_LimitsErrorBodyAfterReauth(t *testing.T) {
+	body := strings.Repeat("x", maxResponsesAPIErrorBodyBytes+1024) + "TAIL_MARKER"
+	callCount := 0
+	token := "expired-token"
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Status:     "401 Unauthorized",
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"error":"invalid token"}`)),
+				}, nil
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer refreshed-token" {
+				t.Fatalf("expected refreshed token on retry, got %q", auth)
+			}
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Status:     "403 Forbidden",
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer " + token },
+		HTTPClient:    httpClient,
+		OnAuthRetry: func(_ context.Context) error {
+			token = "refreshed-token"
+			return nil
+		},
+	}
+
+	_, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "test-model",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+
+	if callCount != 2 {
+		t.Fatalf("expected 2 HTTP calls (initial + retry), got %d", callCount)
+	}
+	assertResponsesAPIErrorBodyTruncated(t, err, "Responses API error after re-auth (status 403):")
+}
+
 func TestBuildResponsesInput_DeveloperRole(t *testing.T) {
 	messages := []Message{
 		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "Be concise"}}},


### PR DESCRIPTION
## What

- cap Responses API error-body reads at 64 KiB before formatting non-200 errors
- reuse the bounded reader for the initial error path plus the 404 retry and auth-retry error paths
- add regression coverage for all three oversized error-body cases

## Why

The Responses client previously used unbounded `io.ReadAll(resp.Body)` calls when formatting non-200 responses. A provider or proxy returning a very large error body could force term-llm to allocate the entire payload just to build an error message, which risks excessive memory use or process crashes.
