### PR TITLE
fix: HTTP client hangs indefinitely after removing 10-minute timeout (#271 regression)

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -7,17 +7,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
-// defaultHTTPClient is a shared HTTP client. Do not set http.Client.Timeout here:
-// it applies to the entire request lifetime, including reading streaming response
-// bodies, and would abort legitimate long-running streams.
-var defaultHTTPClient = &http.Client{}
+// defaultHTTPClient is a shared HTTP client with transport-level timeouts.
+//
+// http.Client.Timeout is intentionally NOT set: it applies to the entire
+// request lifetime including reading the streaming response body, and would
+// abort legitimate long-running streams.
+//
+// Instead we use Transport-level timeouts that only cover connection
+// establishment and the initial response headers, so hung connections fail
+// fast while active streams are never killed.
+var defaultHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   15 * time.Second,
+		ResponseHeaderTimeout: 2 * time.Minute,
+		IdleConnTimeout:       90 * time.Second,
+	},
+}
 
 // OpenAICompatProvider implements Provider for OpenAI-compatible APIs
 // Used by Ollama, LM Studio, and other compatible servers.


### PR DESCRIPTION
## What

Adds transport-level timeouts to `defaultHTTPClient` in `openai_compat.go`:

- `DialContext` timeout: 30s
- `TLSHandshakeTimeout`: 15s  
- `ResponseHeaderTimeout`: 2 minutes
- `IdleConnTimeout`: 90s

## Why

Commit ed67f12 (#271) correctly removed `http.Client.Timeout` because it terminates the entire request including streaming response bodies. However, this left the client with **no timeouts at all**.

If a server accepts the TCP connection but never sends response headers (hung API endpoint, flaky network, etc.), the request now blocks forever. This was observed in production: the daily digest job timed out at 30 minutes stuck at `==> Running Jarvis LLM to generate digest...`, and users reported LLM calls stalling intermittently across the system.

Transport-level timeouts only apply to connection establishment and the initial response headers — they fire *before* any streaming begins, so long-running active streams are unaffected.
