### PR TITLE
fix: Telegram photo download reads arbitrary response bodies fully into memory without any size or status checks

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -29,6 +29,7 @@ const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
+const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
@@ -63,9 +64,20 @@ func downloadTelegramPhoto(fileGetter botFileGetter, photos []tgbotapi.PhotoSize
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return "", "", "", fmt.Errorf("download photo: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if resp.ContentLength > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("photo file too large: %d bytes (max %d)", resp.ContentLength, telegramMaxPhotoDownloadBytes)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, telegramMaxPhotoDownloadBytes+1))
 	if err != nil {
 		return "", "", "", fmt.Errorf("read photo data: %w", err)
+	}
+	if int64(len(data)) > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("photo file too large: exceeds %d bytes", telegramMaxPhotoDownloadBytes)
 	}
 
 	// Detect MIME type from content (Telegram can serve PNG, WebP, etc.)

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1320,6 +1320,54 @@ func TestDownloadTelegramPhoto_EmptyPhotos(t *testing.T) {
 	}
 }
 
+func TestDownloadTelegramPhoto_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "photo-1"}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 502") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramPhoto_TooLarge(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		chunk := []byte(strings.Repeat("a", 32*1024))
+		remaining := telegramMaxPhotoDownloadBytes + 1
+		for remaining > 0 {
+			n := len(chunk)
+			if int64(n) > remaining {
+				n = int(remaining)
+			}
+			if _, err := w.Write(chunk[:n]); err != nil {
+				return
+			}
+			remaining -= int64(n)
+		}
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "photo-1"}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for oversized photo download")
+	}
+	if !strings.Contains(err.Error(), "photo file too large") {
+		t.Fatalf("expected too large error, got %v", err)
+	}
+}
+
 func TestDownloadTelegramVoice(t *testing.T) {
 	ts := newTestAudioServer(t, []byte("fake-ogg-data"))
 	defer ts.Close()


### PR DESCRIPTION
## What

Add status and size checks to Telegram photo downloads before reading the body into memory. The photo downloader now rejects non-200 responses, enforces a 25 MiB limit using both Content-Length and a bounded reader, and includes targeted tests for HTTP errors and oversized downloads.

## Why

Previously the Telegram photo path used http.Get followed by io.ReadAll(resp.Body) with no validation. That allowed arbitrary response bodies, including error pages or oversized payloads, to be read fully into RAM and then base64-encoded, which could cause avoidable memory spikes and bad downstream image handling.
