### PR TITLE
fix: Serve runtimes never enable context tracking or auto-compaction

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -329,7 +329,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
-		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, serveYolo, WireSpawnAgentRunner, skillsSetup)
+		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, provKey, rtModelName, serveYolo, WireSpawnAgentRunner, skillsSetup)
 		if err != nil {
 			return nil, err
 		}
@@ -551,7 +551,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 // function registers the activate_skill tool on the engine but does NOT inject
 // <available_skills> metadata into the system prompt — the caller must do that
 // before constructing serveRuntime/serveSettings so the mutation is not lost.
-func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provider llm.Provider, yoloMode bool, wireSpawn func(*config.Config, *tools.ToolManager, bool) error, skillsSetup *skills.Setup) (*llm.Engine, *tools.ToolManager, error) {
+func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provider llm.Provider, providerName, modelName string, yoloMode bool, wireSpawn func(*config.Config, *tools.ToolManager, bool) error, skillsSetup *skills.Setup) (*llm.Engine, *tools.ToolManager, error) {
 	engine := newEngine(provider, cfg)
 
 	toolMgr, err := settings.SetupToolManager(cfg, engine)
@@ -568,6 +568,10 @@ func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provi
 			}
 		}
 	}
+
+	// Serve runtimes need the same context tracking/auto-compaction setup as ask/TUI
+	// so long-lived sessions can warn or compact before hitting provider limits.
+	engine.ConfigureContextManagement(provider, providerName, modelName, cfg.AutoCompact)
 
 	// Register the activate_skill tool on the engine. Metadata injection into the
 	// system prompt is handled by the caller to avoid the by-value settings copy trap.

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -2115,7 +2115,7 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 			return serveJobsExecResult{}, err
 		}
 
-		engine, toolMgr, err := newServeEngineWithTools(jobCfg, settings, provider, serveYolo, WireSpawnAgentRunner, jobSkillsSetup)
+		engine, toolMgr, err := newServeEngineWithTools(jobCfg, settings, provider, jobCfg.DefaultProvider, modelName, serveYolo, WireSpawnAgentRunner, jobSkillsSetup)
 		if err != nil {
 			return serveJobsExecResult{}, err
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -17,6 +17,7 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1376,7 +1377,7 @@ func TestNewServeEngineWithTools_ConfiguresToolManagerAndSpawnWiring(t *testing.
 		return nil
 	}
 
-	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, true, wireSpawn, nil)
+	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, "mock", "mock-model", true, wireSpawn, nil)
 	if err != nil {
 		t.Fatalf("newServeEngineWithTools failed: %v", err)
 	}
@@ -1411,7 +1412,7 @@ func TestNewServeEngineWithTools_SkipsToolManagerWhenToolsDisabled(t *testing.T)
 		return nil
 	}
 
-	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, false, wireSpawn, nil)
+	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, "mock", "mock-model", false, wireSpawn, nil)
 	if err != nil {
 		t.Fatalf("newServeEngineWithTools failed: %v", err)
 	}
@@ -1423,6 +1424,54 @@ func TestNewServeEngineWithTools_SkipsToolManagerWhenToolsDisabled(t *testing.T)
 	}
 	if wireCalls != 0 {
 		t.Fatalf("wireCalls = %d, want 0", wireCalls)
+	}
+}
+
+func TestNewServeEngineWithTools_ConfiguresContextManagement(t *testing.T) {
+	llm.RegisterConfigLimits([]llm.ConfigModelLimit{{Provider: "mock", Model: "serve-test-model", InputLimit: 1234}})
+	defer llm.RegisterConfigLimits(nil)
+
+	cfg := &config.Config{AutoCompact: true}
+	provider := llm.NewMockProvider("mock")
+
+	engine, _, err := newServeEngineWithTools(cfg, SessionSettings{}, provider, "mock", "serve-test-model", false, nil, nil)
+	if err != nil {
+		t.Fatalf("newServeEngineWithTools failed: %v", err)
+	}
+	if got := engine.InputLimit(); got != 1234 {
+		t.Fatalf("engine.InputLimit() = %d, want 1234", got)
+	}
+
+	compactionConfig := reflect.ValueOf(engine).Elem().FieldByName("compactionConfig")
+	if !compactionConfig.IsValid() {
+		t.Fatalf("compactionConfig field not found")
+	}
+	if compactionConfig.IsNil() {
+		t.Fatalf("compactionConfig = nil, want enabled when auto_compact is true")
+	}
+}
+
+func TestNewServeEngineWithTools_TracksContextWhenAutoCompactDisabled(t *testing.T) {
+	llm.RegisterConfigLimits([]llm.ConfigModelLimit{{Provider: "mock", Model: "serve-test-model", InputLimit: 1234}})
+	defer llm.RegisterConfigLimits(nil)
+
+	cfg := &config.Config{AutoCompact: false}
+	provider := llm.NewMockProvider("mock")
+
+	engine, _, err := newServeEngineWithTools(cfg, SessionSettings{}, provider, "mock", "serve-test-model", false, nil, nil)
+	if err != nil {
+		t.Fatalf("newServeEngineWithTools failed: %v", err)
+	}
+	if got := engine.InputLimit(); got != 1234 {
+		t.Fatalf("engine.InputLimit() = %d, want 1234", got)
+	}
+
+	compactionConfig := reflect.ValueOf(engine).Elem().FieldByName("compactionConfig")
+	if !compactionConfig.IsValid() {
+		t.Fatalf("compactionConfig field not found")
+	}
+	if !compactionConfig.IsNil() {
+		t.Fatalf("compactionConfig != nil, want tracking-only when auto_compact is false")
 	}
 }
 


### PR DESCRIPTION
## What

Configure serve runtimes with the effective provider/model context window settings when building engines in `newServeEngineWithTools`, so served sessions enable token tracking and `auto_compact` like ask/TUI do.

Also add focused tests covering both auto-compaction enabled and tracking-only behavior.

## Why

Without calling `engine.ConfigureContextManagement(...)`, web/API/Telegram/jobs sessions never tracked context usage and never auto-compacted. Long-running served conversations could grow until the upstream provider rejected a request for context overflow instead of warning or compacting first.
