### PR TITLE
fix: Serve runtimes never configure context tracking or auto-compaction

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -329,7 +329,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
-		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, serveYolo, WireSpawnAgentRunner, skillsSetup)
+		engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, provKey, rtModelName, serveYolo, WireSpawnAgentRunner, skillsSetup)
 		if err != nil {
 			return nil, err
 		}
@@ -547,12 +547,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 }
 
 // newServeEngineWithTools creates a new engine with tools wired up for serving.
+// It also enables context-window tracking and optional auto-compaction using the
+// effective provider/model for the runtime.
 // skillsSetup must be pre-initialized by the caller (e.g. via SetupSkills); this
 // function registers the activate_skill tool on the engine but does NOT inject
 // <available_skills> metadata into the system prompt — the caller must do that
 // before constructing serveRuntime/serveSettings so the mutation is not lost.
-func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provider llm.Provider, yoloMode bool, wireSpawn func(*config.Config, *tools.ToolManager, bool) error, skillsSetup *skills.Setup) (*llm.Engine, *tools.ToolManager, error) {
+func newServeEngineWithTools(cfg *config.Config, settings SessionSettings, provider llm.Provider, providerName, modelName string, yoloMode bool, wireSpawn func(*config.Config, *tools.ToolManager, bool) error, skillsSetup *skills.Setup) (*llm.Engine, *tools.ToolManager, error) {
 	engine := newEngine(provider, cfg)
+	engine.ConfigureContextManagement(provider, providerName, modelName, cfg.AutoCompact)
 
 	toolMgr, err := settings.SetupToolManager(cfg, engine)
 	if err != nil {

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -2115,7 +2115,7 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 			return serveJobsExecResult{}, err
 		}
 
-		engine, toolMgr, err := newServeEngineWithTools(jobCfg, settings, provider, serveYolo, WireSpawnAgentRunner, jobSkillsSetup)
+		engine, toolMgr, err := newServeEngineWithTools(jobCfg, settings, provider, jobCfg.DefaultProvider, modelName, serveYolo, WireSpawnAgentRunner, jobSkillsSetup)
 		if err != nil {
 			return serveJobsExecResult{}, err
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -17,6 +17,7 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1376,7 +1377,7 @@ func TestNewServeEngineWithTools_ConfiguresToolManagerAndSpawnWiring(t *testing.
 		return nil
 	}
 
-	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, true, wireSpawn, nil)
+	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, cfg.DefaultProvider, activeModel(cfg), true, wireSpawn, nil)
 	if err != nil {
 		t.Fatalf("newServeEngineWithTools failed: %v", err)
 	}
@@ -1411,7 +1412,7 @@ func TestNewServeEngineWithTools_SkipsToolManagerWhenToolsDisabled(t *testing.T)
 		return nil
 	}
 
-	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, false, wireSpawn, nil)
+	engine, toolMgr, err := newServeEngineWithTools(cfg, settings, provider, cfg.DefaultProvider, activeModel(cfg), false, wireSpawn, nil)
 	if err != nil {
 		t.Fatalf("newServeEngineWithTools failed: %v", err)
 	}
@@ -1423,6 +1424,31 @@ func TestNewServeEngineWithTools_SkipsToolManagerWhenToolsDisabled(t *testing.T)
 	}
 	if wireCalls != 0 {
 		t.Fatalf("wireCalls = %d, want 0", wireCalls)
+	}
+}
+
+func TestNewServeEngineWithTools_ConfiguresContextManagement(t *testing.T) {
+	cfg := &config.Config{
+		DefaultProvider: "openai",
+		Providers: map[string]config.ProviderConfig{
+			"openai": {Model: "gpt-4o-mini"},
+		},
+		AutoCompact: true,
+	}
+	provider := llm.NewMockProvider("mock")
+
+	engine, toolMgr, err := newServeEngineWithTools(cfg, SessionSettings{}, provider, cfg.DefaultProvider, activeModel(cfg), false, nil, nil)
+	if err != nil {
+		t.Fatalf("newServeEngineWithTools failed: %v", err)
+	}
+	if toolMgr != nil {
+		t.Fatalf("toolMgr != nil, want nil")
+	}
+	if got := engine.InputLimit(); got <= 0 {
+		t.Fatalf("engine.InputLimit() = %d, want > 0", got)
+	}
+	if compaction := reflect.ValueOf(engine).Elem().FieldByName("compactionConfig"); !compaction.IsValid() || compaction.IsNil() {
+		t.Fatalf("expected auto-compaction to be configured")
 	}
 }
 


### PR DESCRIPTION
## What

Configure serve-mode engines with context-window tracking and auto-compaction using the runtime's effective provider/model, matching the existing ask/TUI paths. This also adds a regression test that verifies serve engines pick up an input limit and enable compaction when auto_compact is on.

## Why

Without calling ConfigureContextManagement, long-lived served sessions never tracked context usage and never auto-compacted before hitting provider limits. That caused avoidable context-overflow failures in persistent serve runtimes like web, API, Telegram, and jobs.
