### PR TITLE
fix: Telegram photo downloads can exhaust memory and accept error pages as images

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -29,6 +29,7 @@ const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
 const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
+const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
@@ -52,6 +53,9 @@ func downloadTelegramPhoto(fileGetter botFileGetter, photos []tgbotapi.PhotoSize
 	}
 	// Pick the largest photo (last in the array).
 	photo := photos[len(photos)-1]
+	if photo.FileSize > 0 && int64(photo.FileSize) > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("photo file too large: %d bytes (max %d)", photo.FileSize, telegramMaxPhotoDownloadBytes)
+	}
 	directURL, err := fileGetter.GetFileDirectURL(photo.FileID)
 	if err != nil {
 		return "", "", "", fmt.Errorf("get file URL: %w", err)
@@ -63,15 +67,29 @@ func downloadTelegramPhoto(fileGetter botFileGetter, photos []tgbotapi.PhotoSize
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return "", "", "", fmt.Errorf("download photo: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if resp.ContentLength > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("photo file too large: %d bytes (max %d)", resp.ContentLength, telegramMaxPhotoDownloadBytes)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, telegramMaxPhotoDownloadBytes+1))
 	if err != nil {
 		return "", "", "", fmt.Errorf("read photo data: %w", err)
+	}
+	if int64(len(data)) > telegramMaxPhotoDownloadBytes {
+		return "", "", "", fmt.Errorf("photo file too large: exceeds %d bytes", telegramMaxPhotoDownloadBytes)
 	}
 
 	// Detect MIME type from content (Telegram can serve PNG, WebP, etc.)
 	mimeType := http.DetectContentType(data)
 	if mimeType == "application/octet-stream" {
 		mimeType = "image/jpeg" // safe fallback
+	}
+	if !strings.HasPrefix(mimeType, "image/") {
+		return "", "", "", fmt.Errorf("download photo: unexpected content type %q", mimeType)
 	}
 
 	// Write to a temp file so tools (e.g. image_generate) can reference it by path.

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1285,7 +1285,7 @@ func (f *fakeFileGetter) GetFileDirectURL(fileID string) (string, error) {
 
 func TestDownloadTelegramPhoto_PicksLargest(t *testing.T) {
 	// Start a test HTTP server serving an image
-	ts := newTestImageServer(t, []byte("fake-jpeg-data"))
+	ts := newTestImageServer(t, []byte{0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08})
 	defer ts.Close()
 
 	fg := &fakeFileGetter{fileURL: ts.URL}
@@ -1317,6 +1317,73 @@ func TestDownloadTelegramPhoto_EmptyPhotos(t *testing.T) {
 	_, _, _, err := downloadTelegramPhoto(fg, nil)
 	if err == nil {
 		t.Fatal("expected error for empty photos")
+	}
+}
+
+func TestDownloadTelegramPhoto_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "photo-1"}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 502") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramPhoto_NonImageContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>proxy error</body></html>"))
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "photo-1"}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for non-image response")
+	}
+	if !strings.Contains(err.Error(), "unexpected content type") {
+		t.Fatalf("expected content type error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramPhoto_TooLarge(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		chunk := []byte(strings.Repeat("a", 32*1024))
+		remaining := telegramMaxPhotoDownloadBytes + 1
+		for remaining > 0 {
+			n := len(chunk)
+			if int64(n) > remaining {
+				n = int(remaining)
+			}
+			if _, err := w.Write(chunk[:n]); err != nil {
+				return
+			}
+			remaining -= int64(n)
+		}
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "photo-1"}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected error for oversized photo download")
+	}
+	if !strings.Contains(err.Error(), "photo file too large") {
+		t.Fatalf("expected too large error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

- add status and size checks to `downloadTelegramPhoto` before reading the full response body
- bound photo downloads with a 25 MiB limit and reject oversized responses
- reject non-image payloads so HTML/error pages are not passed downstream as images
- add regression tests for non-200 responses, non-image payloads, and oversized downloads

## Why

The previous implementation used an unbounded `io.ReadAll(resp.Body)` and never checked the HTTP status code. That allowed large responses to spike memory usage and let proxy/error pages be base64-encoded and treated as images.
