### PR TITLE
fix: Retry wrapper drops ResetConversation, so “new” sessions can silently continue old provider state

### DIFF
--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1302,6 +1302,18 @@ func TestEngineResetConversationCallsProvider(t *testing.T) {
 	}
 }
 
+func TestEngineResetConversationCallsWrappedProvider(t *testing.T) {
+	inner := &mockResettableProvider{MockProvider: NewMockProvider("test")}
+	provider := WrapWithRetry(inner, DefaultRetryConfig())
+	e := NewEngine(provider, nil)
+
+	e.ResetConversation()
+
+	if inner.resetCalls != 1 {
+		t.Errorf("expected wrapped provider ResetConversation called once, got %d", inner.resetCalls)
+	}
+}
+
 func TestEngineResetConversationSkipsNonResettableProvider(t *testing.T) {
 	// Regular MockProvider doesn't implement ResetConversation
 	provider := NewMockProvider("test")

--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -51,6 +51,15 @@ func (r *RetryProvider) Capabilities() Capabilities {
 	return r.inner.Capabilities()
 }
 
+// ResetConversation forwards to the inner provider if it implements
+// ResetConversation. This preserves provider-side conversation reset behavior
+// when providers are wrapped with retry logic.
+func (r *RetryProvider) ResetConversation() {
+	if resetter, ok := r.inner.(interface{ ResetConversation() }); ok {
+		resetter.ResetConversation()
+	}
+}
+
 // SetToolExecutor forwards to the inner provider if it implements ToolExecutorSetter.
 // This ensures providers like ClaudeBinProvider can receive their tool executor
 // even when wrapped with retry logic.


### PR DESCRIPTION
## What

Forward `ResetConversation()` through the retry wrapper so wrapped providers still clear any provider-side conversation state. Also add a regression test covering `Engine.ResetConversation()` with a retry-wrapped provider.

## Why

`Engine.ResetConversation()` detects reset support via a type assertion on the configured provider. Once a provider is wrapped with `WrapWithRetry`, that assertion no longer reached the inner provider, so Responses-API-style providers could keep reusing an old server-side conversation ID after `/new`, `/clear`, or history replacement. Forwarding the method preserves fresh-session semantics and prevents stale cross-conversation context from leaking into later requests.
