### PR TITLE
fix: ToolRegistry is an unprotected map and can panic on concurrent skill tool activation

### DIFF
--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/samsaffron/term-llm/internal/prompt"
 )
@@ -39,6 +40,7 @@ type FinishingTool interface {
 
 // ToolRegistry stores tools by name for execution.
 type ToolRegistry struct {
+	mu    sync.RWMutex
 	tools map[string]Tool
 }
 
@@ -47,16 +49,22 @@ func NewToolRegistry() *ToolRegistry {
 }
 
 func (r *ToolRegistry) Register(tool Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.tools[tool.Spec().Name] = tool
 }
 
 func (r *ToolRegistry) Get(name string) (Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	tool, ok := r.tools[name]
 	return tool, ok
 }
 
 // IsFinishingTool returns true if the named tool is a finishing tool.
 func (r *ToolRegistry) IsFinishingTool(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	tool, ok := r.tools[name]
 	if !ok {
 		return false
@@ -68,11 +76,16 @@ func (r *ToolRegistry) IsFinishingTool(name string) bool {
 }
 
 func (r *ToolRegistry) Unregister(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	delete(r.tools, name)
 }
 
 // AllSpecs returns the specs for all registered tools in deterministic name order.
 func (r *ToolRegistry) AllSpecs() []ToolSpec {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	names := make([]string, 0, len(r.tools))
 	for name := range r.tools {
 		names = append(names, name)

--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -3,10 +3,14 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 )
 
 type namedTestTool struct{ name string }
+
+type finishingNamedTestTool struct{ namedTestTool }
 
 func (t *namedTestTool) Spec() ToolSpec {
 	return ToolSpec{Name: t.name, Description: t.name, Schema: map[string]any{"type": "object"}}
@@ -17,6 +21,8 @@ func (t *namedTestTool) Execute(ctx context.Context, args json.RawMessage) (Tool
 }
 
 func (t *namedTestTool) Preview(args json.RawMessage) string { return t.name }
+
+func (t *finishingNamedTestTool) IsFinishingTool() bool { return true }
 
 func TestToolRegistryAllSpecsSortedByName(t *testing.T) {
 	registry := NewToolRegistry()
@@ -55,4 +61,53 @@ func TestToolSpecsForRequestPreservesSortedOrderAfterFiltering(t *testing.T) {
 			t.Fatalf("ToolSpecsForRequest() order = %v, want %v", got, want)
 		}
 	}
+}
+
+func TestToolRegistryConcurrentAccess(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&finishingNamedTestTool{namedTestTool{name: "base"}})
+
+	const (
+		writers    = 2
+		readers    = 6
+		iterations = 2000
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for writerID := 0; writerID < writers; writerID++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				name := fmt.Sprintf("writer-%d-tool-%d", writerID, i)
+				registry.Register(&finishingNamedTestTool{namedTestTool{name: name}})
+				if i%2 == 0 {
+					registry.Unregister(name)
+				}
+			}
+		}(writerID)
+	}
+
+	for readerID := 0; readerID < readers; readerID++ {
+		wg.Add(1)
+		go func(readerID int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				if _, ok := registry.Get("base"); !ok {
+					t.Fatalf("Get(base) = missing")
+				}
+				if !registry.IsFinishingTool("base") {
+					t.Fatalf("IsFinishingTool(base) = false, want true")
+				}
+				_ = registry.AllSpecs()
+			}
+		}(readerID)
+	}
+
+	close(start)
+	wg.Wait()
 }


### PR DESCRIPTION
## What

Add a `sync.RWMutex` to `internal/llm.ToolRegistry` and guard all map reads/writes in `Register`, `Get`, `IsFinishingTool`, `Unregister`, and `AllSpecs`.
Also add a concurrent access test that exercises readers and writers against the registry.

## Why

`activate_skill` can register tools during a running conversation while other goroutines are reading the registry for tool lookup/spec selection. Without synchronization this can trigger Go's fatal `concurrent map read and map write` panic during live parallel tool execution.
