### PR TITLE
fix: Telegram interrupt classifier reuses one shared fast provider across all chats, leaking state and racing requests

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -349,10 +349,6 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 	if p.cfg.InterruptTimeout > 0 {
 		interruptTimeout = time.Duration(p.cfg.InterruptTimeout) * time.Second
 	}
-	fastProvider, fastErr := llm.NewFastProvider(cfg, cfg.DefaultProvider)
-	if fastErr != nil {
-		log.Printf("[telegram] fast provider unavailable: %v", fastErr)
-	}
 
 	mgr := &telegramSessionMgr{
 		sessions:         make(map[int64]*telegramSession),
@@ -361,7 +357,6 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 		store:            settings.Store,
 		idleTimeout:      idleTimeout,
 		interruptTimeout: interruptTimeout,
-		fastProvider:     fastProvider,
 		allowedUserIDs:   buildAllowedSet(p.cfg.AllowedUserIDs),
 		allowedUsernames: buildAllowedUsernameSet(p.cfg.AllowedUsernames),
 		messageSlots:     make(chan struct{}, telegramMaxConcurrentHandlers),
@@ -462,11 +457,22 @@ type telegramSessionMgr struct {
 	store            session.Store
 	idleTimeout      time.Duration
 	interruptTimeout time.Duration
-	fastProvider     llm.Provider
 	allowedUserIDs   map[int64]struct{}
 	allowedUsernames map[string]struct{}
 	messageSlots     chan struct{}
 	tickerInterval   time.Duration // 0 means use default (500ms); overridden in tests
+}
+
+func (m *telegramSessionMgr) newFastProvider() llm.Provider {
+	if m == nil || m.cfg == nil {
+		return nil
+	}
+	fastProvider, err := llm.NewFastProvider(m.cfg, m.cfg.DefaultProvider)
+	if err != nil {
+		log.Printf("[telegram] fast provider unavailable: %v", err)
+		return nil
+	}
+	return fastProvider
 }
 
 func (m *telegramSessionMgr) isAllowed(userID int64, username string) bool {
@@ -873,7 +879,8 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 			}
 			sess.cancelMu.Unlock()
 
-			action := llm.ClassifyInterrupt(ctx, m.fastProvider, newMsgText, activity)
+			fastProvider := m.newFastProvider()
+			action := llm.ClassifyInterrupt(ctx, fastProvider, newMsgText, activity)
 			switch action {
 			case llm.InterruptCancel:
 				_, _ = bot.Send(tgbotapi.NewMessage(chatID, "↩️ Stopping current work and switching to your new request."))

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/testutil"
@@ -85,6 +86,35 @@ func newTestMgrAndSession(h *testutil.EngineHarness) (*telegramSessionMgr, *tele
 		},
 	}
 	return mgr, sess
+}
+
+func TestTelegramSessionMgrNewFastProvider_ReturnsFreshProviderEachTime(t *testing.T) {
+	mgr := &telegramSessionMgr{
+		cfg: &config.Config{
+			DefaultProvider: "my-openai",
+			Providers: map[string]config.ProviderConfig{
+				"my-openai": {
+					Type:         config.ProviderTypeOpenAI,
+					APIKey:       "sk-test",
+					Model:        "gpt-5.2",
+					FastProvider: "debug",
+					FastModel:    "random",
+				},
+			},
+		},
+	}
+
+	first := mgr.newFastProvider()
+	if first == nil {
+		t.Fatal("expected first fast provider to be non-nil")
+	}
+	second := mgr.newFastProvider()
+	if second == nil {
+		t.Fatal("expected second fast provider to be non-nil")
+	}
+	if first == second {
+		t.Fatal("expected a fresh fast provider per interrupt classification")
+	}
 }
 
 func TestHandleMessage_IgnoresMessagesWithNilFrom(t *testing.T) {


### PR DESCRIPTION
## What

Create a fresh fast provider for each Telegram interrupt-classification request instead of reusing one shared provider across all chats.

Also add a regression test that verifies the Telegram session manager does not cache and reuse the same fast provider instance.

## Why

Some fast providers keep mutable conversation state internally. Sharing one instance across concurrent Telegram chats could leak state between chats, chain classifications onto earlier requests, and introduce race-prone interrupt decisions. Recreating the fast provider per classification keeps each request isolated and one-shot.
