### PR TITLE
fix: Claude CLI usage accounting double-counts cached tokens as normal input

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -629,8 +629,9 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 				*sawTextDelta = true
 			}
 			*lastUsage = &Usage{
-				InputTokens:  resultMsg.Usage.InputTokens + resultMsg.Usage.CacheReadInputTokens,
-				OutputTokens: resultMsg.Usage.OutputTokens,
+				InputTokens:       resultMsg.Usage.InputTokens,
+				OutputTokens:      resultMsg.Usage.OutputTokens,
+				CachedInputTokens: resultMsg.Usage.CacheReadInputTokens,
 			}
 		}
 	}

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -313,6 +313,33 @@ drained:
 	}
 }
 
+func TestDispatchClaudeEvents_SeparatesCachedInputTokensInUsage(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":11,"output_tokens":7,"cache_read_input_tokens":5}}`
+	close(lines)
+
+	usage, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, events)
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if usage == nil {
+		t.Fatal("expected usage")
+	}
+	if usage.InputTokens != 11 {
+		t.Fatalf("expected non-cached input tokens 11, got %d", usage.InputTokens)
+	}
+	if usage.CachedInputTokens != 5 {
+		t.Fatalf("expected cached input tokens 5, got %d", usage.CachedInputTokens)
+	}
+	if usage.OutputTokens != 7 {
+		t.Fatalf("expected output tokens 7, got %d", usage.OutputTokens)
+	}
+}
+
 func TestHandleClaudeToolRequest_ClosedStreamReturnsError(t *testing.T) {
 	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event)


### PR DESCRIPTION
## What

Fix Claude CLI usage accounting so cached prompt reads are stored in `CachedInputTokens` instead of being added into `InputTokens`.
Add a regression test covering the cached/non-cached split returned from Claude CLI result messages.

## Why

The rest of term-llm expects `InputTokens` to contain only non-cached prompt tokens and `CachedInputTokens` to track cache reads separately.
Claude CLI was double-counting cached reads as normal input, which inflated prompt totals and could trigger incorrect usage reporting, warnings, and context compaction decisions.
