### PR TITLE
fix: OpenAI-compatible streaming hard-fails on SSE lines larger than 1 MB

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -323,6 +323,17 @@ func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]ModelInfo, err
 	return models, nil
 }
 
+func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		if err == io.EOF {
+			return strings.TrimRight(line, "\r\n"), true, nil
+		}
+		return "", false, err
+	}
+	return strings.TrimRight(line, "\r\n"), false, nil
+}
+
 func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	req.MaxOutputTokens = ClampOutputTokens(req.MaxOutputTokens, chooseModel(req.Model, p.model))
 	// Build messages and tools synchronously
@@ -391,22 +402,33 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
 		defer resp.Body.Close()
 
-		scanner := bufio.NewScanner(resp.Body)
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		reader := bufio.NewReader(resp.Body)
 
 		toolState := newCompatToolState()
 		var lastUsage *Usage
 		var lastEventType string
 		var reasoningBuilder strings.Builder
 
-		for scanner.Scan() {
-			line := scanner.Text()
+		for {
+			line, eof, err := readSSELine(reader)
+			if err != nil {
+				return fmt.Errorf("%s streaming error: %w", p.name, err)
+			}
+			if eof && line == "" {
+				break
+			}
+
 			if strings.HasPrefix(line, "event: ") {
 				lastEventType = strings.TrimPrefix(line, "event: ")
+				if eof {
+					break
+				}
 				continue
 			}
 			if !strings.HasPrefix(line, "data: ") {
+				if eof {
+					break
+				}
 				continue
 			}
 			data := strings.TrimPrefix(line, "data: ")
@@ -416,6 +438,9 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 
 			var chatResp oaiChatResponse
 			if err := json.Unmarshal([]byte(data), &chatResp); err != nil {
+				if eof {
+					break
+				}
 				continue
 			}
 
@@ -455,10 +480,9 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 			}
 
 			lastEventType = ""
-		}
-
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("%s streaming error: %w", p.name, err)
+			if eof {
+				break
+			}
 		}
 
 		for _, call := range toolState.Calls() {

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,72 @@ import (
 func TestDefaultHTTPClient_HasNoOverallTimeout(t *testing.T) {
 	if defaultHTTPClient.Timeout != 0 {
 		t.Fatalf("expected shared HTTP client timeout to be disabled for streaming requests, got %v", defaultHTTPClient.Timeout)
+	}
+}
+
+func TestOpenAICompatStream_AllowsLargeSSEDataLines(t *testing.T) {
+	largeText := strings.Repeat("a", 1024*1024+1024)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk, err := json.Marshal(oaiChatResponse{
+			Choices: []oaiChoice{{
+				Delta: &oaiMessage{Content: largeText},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("marshal chunk: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if _, err := w.Write([]byte("data: ")); err != nil {
+			t.Fatalf("write prefix: %v", err)
+		}
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write chunk: %v", err)
+		}
+		if _, err := w.Write([]byte("\n\ndata: [DONE]\n\n")); err != nil {
+			t.Fatalf("write done: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewOpenAICompatProvider(server.URL, "", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "hello"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	var got strings.Builder
+	var sawDone bool
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			got.WriteString(event.Text)
+		case EventDone:
+			sawDone = true
+		case EventError:
+			t.Fatalf("unexpected stream error: %v", event.Err)
+		}
+	}
+
+	if got.String() != largeText {
+		t.Fatalf("expected %d bytes of streamed text, got %d", len(largeText), got.Len())
+	}
+	if !sawDone {
+		t.Fatal("expected EventDone")
 	}
 }
 


### PR DESCRIPTION
## What

- replace the OpenAI-compatible SSE stream parser's `bufio.Scanner` with a `bufio.Reader` line reader so individual `data:` lines are no longer capped at 1 MB
- add a regression test that streams a single SSE `data:` line larger than 1 MB and verifies the response completes successfully

## Why

OpenAI-compatible backends can emit very large single-line SSE payloads for tool call arguments or verbose JSON/content chunks. The old scanner-based parser hard-failed with `token too long`, aborting the stream mid-response even when the backend response was otherwise valid.
