### PR TITLE
fix: ChatGPT streaming is forcibly aborted after 10 minutes by http.Client.Timeout

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -19,13 +19,11 @@ const chatGPTDefaultModel = "gpt-5.3-codex"
 // chatGPTResponsesURL is the ChatGPT backend API endpoint for responses
 const chatGPTResponsesURL = "https://chatgpt.com/backend-api/codex/responses"
 
-// chatGPTHTTPTimeout is the timeout for ChatGPT HTTP requests
-const chatGPTHTTPTimeout = 10 * time.Minute
-
-// chatGPTHTTPClient is a shared HTTP client with reasonable timeouts
-var chatGPTHTTPClient = &http.Client{
-	Timeout: chatGPTHTTPTimeout,
-}
+// chatGPTHTTPClient intentionally uses transport-level timeouts only.
+//
+// ChatGPT streams can legitimately run for longer than 10 minutes, and
+// http.Client.Timeout would abort an otherwise healthy stream mid-response.
+var chatGPTHTTPClient = defaultHTTPClient
 
 // ChatGPTProvider implements Provider using the ChatGPT backend API with native OAuth.
 type ChatGPTProvider struct {

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -33,6 +33,12 @@ func TestBuildResponsesInputWithInstructions_ExtractsSystem(t *testing.T) {
 	}
 }
 
+func TestChatGPTHTTPClient_DoesNotUseClientTimeout(t *testing.T) {
+	if chatGPTHTTPClient.Timeout != 0 {
+		t.Fatalf("expected no http.Client.Timeout for ChatGPT streaming client, got %s", chatGPTHTTPClient.Timeout)
+	}
+}
+
 func TestChatGPTStream_ReasoningSummaryByOutputIndex(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() {


### PR DESCRIPTION
## What

Remove the ChatGPT provider's `http.Client.Timeout` and use the shared transport-timeout client instead. This preserves connect/header protection without killing valid long-lived streaming responses. Added a small regression test asserting the ChatGPT streaming client does not use `http.Client.Timeout`.

## Why

In Go, `http.Client.Timeout` applies to the full request lifetime, including reading the response body. The ChatGPT provider uses streaming responses that can legitimately run longer than 10 minutes, so the previous client-level timeout would truncate healthy streams and fail long reasoning/tool runs.
