### PR TITLE
fix: Telegram media downloads use the default HTTP client with no timeout, allowing handler exhaustion

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -31,6 +31,9 @@ const streamEventTimeout = 10 * time.Minute
 const telegramMaxConcurrentHandlers = 8
 const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
+const telegramDownloadTimeout = 30 * time.Second
+
+var telegramDownloadHTTPClient = &http.Client{Timeout: telegramDownloadTimeout}
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -61,7 +64,7 @@ func downloadTelegramPhoto(fileGetter botFileGetter, photos []tgbotapi.PhotoSize
 		return "", "", "", fmt.Errorf("get file URL: %w", err)
 	}
 
-	resp, err := http.Get(directURL)
+	resp, err := telegramDownloadHTTPClient.Get(directURL)
 	if err != nil {
 		return "", "", "", fmt.Errorf("download photo: %w", err)
 	}
@@ -123,7 +126,7 @@ func downloadTelegramVoice(fileGetter botFileGetter, voice *tgbotapi.Voice) (fil
 		return "", fmt.Errorf("get voice file URL: %w", err)
 	}
 
-	resp, err := http.Get(directURL)
+	resp, err := telegramDownloadHTTPClient.Get(directURL)
 	if err != nil {
 		return "", fmt.Errorf("download voice: %w", err)
 	}

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1387,6 +1387,30 @@ func TestDownloadTelegramPhoto_TooLarge(t *testing.T) {
 	}
 }
 
+func TestDownloadTelegramPhoto_Timeout(t *testing.T) {
+	oldClient := telegramDownloadHTTPClient
+	telegramDownloadHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	t.Cleanup(func() {
+		telegramDownloadHTTPClient = oldClient
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	photos := []tgbotapi.PhotoSize{{FileID: "photo-1"}}
+
+	_, _, _, err := downloadTelegramPhoto(fg, photos)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "Client.Timeout") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
 func TestDownloadTelegramVoice(t *testing.T) {
 	ts := newTestAudioServer(t, []byte("fake-ogg-data"))
 	defer ts.Close()
@@ -1467,6 +1491,30 @@ func TestDownloadTelegramVoice_TooLarge(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "voice file too large") {
 		t.Fatalf("expected too large error, got %v", err)
+	}
+}
+
+func TestDownloadTelegramVoice_Timeout(t *testing.T) {
+	oldClient := telegramDownloadHTTPClient
+	telegramDownloadHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	t.Cleanup(func() {
+		telegramDownloadHTTPClient = oldClient
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	fg := &fakeFileGetter{fileURL: ts.URL}
+	voice := &tgbotapi.Voice{FileID: "voice-1"}
+
+	_, err := downloadTelegramVoice(fg, voice)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "Client.Timeout") {
+		t.Fatalf("expected timeout error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Use a dedicated HTTP client with an overall timeout for Telegram photo and voice downloads instead of the default client with no timeout.

Also add regression tests covering timed-out photo and voice downloads.

## Why

The default HTTP client can hang indefinitely if Telegram's file endpoint or the network stalls. These stuck downloads hold limited Telegram handler slots, so a small number of stalled requests can exhaust the semaphore and stop the bot from handling new messages.
