### PR TITLE
fix: Event-stream error delivery can block forever and leak goroutines/resources

### DIFF
--- a/internal/llm/stream.go
+++ b/internal/llm/stream.go
@@ -17,7 +17,13 @@ func newEventStream(ctx context.Context, run func(context.Context, chan<- Event)
 	go func() {
 		defer close(ch)
 		if err := run(streamCtx, ch); err != nil {
-			ch <- Event{Type: EventError, Err: err}
+			// If the consumer has stopped draining and the buffer is full, drop the
+			// terminal error rather than block forever and leak the producer goroutine.
+			select {
+			case ch <- Event{Type: EventError, Err: err}:
+			case <-streamCtx.Done():
+			default:
+			}
 		}
 	}()
 	return &channelStream{ctx: streamCtx, cancel: cancel, events: ch}

--- a/internal/llm/stream_test.go
+++ b/internal/llm/stream_test.go
@@ -1,0 +1,44 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestNewEventStreamDoesNotQueueRunErrorAfterCloseWhenBufferIsFull(t *testing.T) {
+	filled := make(chan struct{})
+	wantErr := errors.New("boom")
+	bufSize := 0
+
+	stream := newEventStream(context.Background(), func(ctx context.Context, ch chan<- Event) error {
+		bufSize = cap(ch)
+		for range bufSize {
+			ch <- Event{Type: EventTextDelta, Text: "x"}
+		}
+		close(filled)
+		return wantErr
+	})
+
+	<-filled
+
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	for i := range bufSize {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() %d error = %v", i, err)
+		}
+		if event.Type == EventError {
+			t.Fatalf("Recv() %d unexpectedly returned error event: %v", i, event.Err)
+		}
+	}
+
+	event, err := stream.Recv()
+	if err != io.EOF {
+		t.Fatalf("final Recv() error = %v, want %v (event=%+v)", err, io.EOF, event)
+	}
+}


### PR DESCRIPTION
## What

- make `newEventStream` deliver a terminal `EventError` with a non-blocking send
- drop that error event if the stream context is already canceled or the fixed-size buffer is full
- add a regression test covering the full-buffer + `Close()` case so the stream ends with EOF instead of queueing a late error event

## Why

`newEventStream` previously always sent `EventError` into a 16-slot channel after `run` returned an error. If the consumer had already stopped draining and the buffer was full, that send blocked forever, which kept the producer goroutine alive and could leak underlying resources on cancellation/error paths. A non-blocking terminal error send preserves normal delivery when there is room, while avoiding permanent blockage when the stream is no longer being consumed.
