### PR TITLE
feat(tui): show agent name first in chat footer

### DIFF
--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -386,8 +386,16 @@ func (m *Model) viewAutoSend() string {
 	if m.streaming {
 		// Minimal status line during streaming
 		elapsed := time.Since(m.streamStartTime)
-		return fmt.Sprintf("%s:%s · mcp:off · %s  Responding %s",
-			m.providerName, m.modelName, m.spinner.View(), formatChatElapsed(elapsed))
+		return fmt.Sprintf("%s%s:%s · mcp:off · %s  Responding %s",
+			m.agentPrefix(), m.providerName, m.modelName, m.spinner.View(), formatChatElapsed(elapsed))
+	}
+	return ""
+}
+
+// agentPrefix returns "agentname · " when an agent is set, or "" otherwise.
+func (m *Model) agentPrefix() string {
+	if m.agentName != "" {
+		return m.agentName + " · "
 	}
 	return ""
 }
@@ -586,7 +594,12 @@ func (m *Model) renderStatusLine() string {
 	// Build fixed parts first (these are always shown as-is)
 	var fixedParts []string
 
-	// Model-first label to reduce footer noise.
+	// Agent name first if set.
+	if m.agentName != "" {
+		fixedParts = append(fixedParts, m.agentName)
+	}
+
+	// Model label (after agent, to keep agent identity prominent).
 	model := shortenModelName(m.modelName)
 	if model != "" {
 		fixedParts = append(fixedParts, model)

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -536,3 +536,70 @@ func TestRenderInputInline_TruncatesLongInterjection(t *testing.T) {
 		t.Fatalf("expected long interjection to be truncated, got %q", stripped)
 	}
 }
+
+func TestRenderStatusLine_ShowsAgentNameBeforeModel(t *testing.T) {
+	m := newTestChatModel(false)
+	m.agentName = "jarvis"
+	m.modelName = "mock-model"
+
+	line := ui.StripANSI(m.renderStatusLine())
+
+	if !strings.Contains(line, "jarvis") {
+		t.Fatalf("expected agent name in status line, got %q", line)
+	}
+	agentIdx := strings.Index(line, "jarvis")
+	modelIdx := strings.Index(line, "mock-model")
+	if modelIdx == -1 {
+		t.Fatalf("expected model name in status line, got %q", line)
+	}
+	if agentIdx > modelIdx {
+		t.Fatalf("expected agent name before model name in status line, got %q", line)
+	}
+}
+
+func TestRenderStatusLine_OmitsAgentNameWhenUnset(t *testing.T) {
+	m := newTestChatModel(false)
+	m.agentName = ""
+	m.modelName = "mock-model"
+
+	line := ui.StripANSI(m.renderStatusLine())
+
+	// Status line should begin with the model segment, not a blank " · " prefix.
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, " · ") {
+		t.Fatalf("expected no leading separator when agentName is empty, got %q", line)
+	}
+}
+
+func TestViewAutoSend_ShowsAgentNameFirstWhenStreaming(t *testing.T) {
+	m := newTestChatModel(false)
+	m.agentName = "jarvis"
+	m.providerName = "anthropic"
+	m.modelName = "claude-sonnet"
+	m.streaming = true
+	m.streamStartTime = time.Now()
+
+	out := m.viewAutoSend()
+
+	if !strings.HasPrefix(out, "jarvis · ") {
+		t.Fatalf("expected viewAutoSend to start with 'jarvis · ', got %q", out)
+	}
+}
+
+func TestViewAutoSend_OmitsAgentPrefixWhenUnset(t *testing.T) {
+	m := newTestChatModel(false)
+	m.agentName = ""
+	m.providerName = "anthropic"
+	m.modelName = "claude-sonnet"
+	m.streaming = true
+	m.streamStartTime = time.Now()
+
+	out := m.viewAutoSend()
+
+	if strings.HasPrefix(out, " · ") {
+		t.Fatalf("expected no leading ' · ' when agentName is empty, got %q", out)
+	}
+	if !strings.Contains(out, "anthropic") {
+		t.Fatalf("expected provider name in auto-send output, got %q", out)
+	}
+}


### PR DESCRIPTION
## What

When a chat session is started with `--agent`, the agent name now appears first in the footer status line, before the model name.

Before: `sonnet-4-6 · yolo`
After: `jarvis · sonnet-4-6 · yolo`

Also applied to the minimal streaming status line shown during `--auto-send` sessions.

## Why

With multiple agents available, it's not obvious which agent is running just from the model name. Agent name first gives immediate context.
