### PR TITLE
fix: Restart recovery resurrects runs that were already cancelled

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -585,7 +585,22 @@ func execJobsV2Schema(db *sql.DB) error {
 }
 
 func (m *jobsV2Manager) recoverRuns() error {
-	_, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE status IN (?, ?, ?)`, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
+	_, err := m.db.Exec(`
+		UPDATE job_runs_v2
+		SET status = CASE
+				WHEN status = ? THEN ?
+				ELSE ?
+			END,
+			finished_at = CASE
+				WHEN status = ? THEN CURRENT_TIMESTAMP
+				ELSE finished_at
+			END,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE status IN (?, ?, ?, ?)`,
+		jobsV2RunCancelRequested, jobsV2RunCancelled,
+		jobsV2RunQueued,
+		jobsV2RunCancelRequested,
+		jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
 	if err != nil {
 		return fmt.Errorf("recover runs: %w", err)
 	}

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -170,6 +170,52 @@ func TestJobsV2ManualTriggerAndCancel(t *testing.T) {
 	}
 }
 
+func TestJobsV2RecoverRunsCancelsCancelRequestedRuns(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "recover-cancel-requested",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+
+	startedAt := time.Now().UTC().Add(-time.Second)
+	_, err = mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobsV2RunCancelRequested, startedAt, run.ID)
+	if err != nil {
+		t.Fatalf("mark cancel_requested failed: %v", err)
+	}
+
+	if err := mgr.recoverRuns(); err != nil {
+		t.Fatalf("recoverRuns failed: %v", err)
+	}
+
+	recovered, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if recovered.Status != jobsV2RunCancelled {
+		t.Fatalf("status = %s, want %s", recovered.Status, jobsV2RunCancelled)
+	}
+	if recovered.FinishedAt == nil {
+		t.Fatalf("finished_at was not set for recovered cancelled run")
+	}
+}
+
 func TestJobsV2CronValidation(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)
 	if err != nil {


### PR DESCRIPTION
## What

- keep restart recovery re-queuing interrupted queued/claimed/running runs
- treat `cancel_requested` runs as cancelled during recovery instead of reviving them
- add a regression test covering recovery of a `cancel_requested` run

## Why

A run that had already received a cancellation request could be rewritten back to `queued` on startup and executed again after a crash or shutdown. This preserves the user's cancellation intent and avoids re-running potentially destructive or expensive jobs.
