### PR TITLE
fix: Telegram stream timeouts can be misclassified as user interrupts, hiding real failures

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -27,7 +27,10 @@ import (
 
 const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
-const streamEventTimeout = 10 * time.Minute
+
+// var so tests can shorten the watchdog without waiting 10 minutes.
+var streamEventTimeout = 10 * time.Minute
+
 const telegramMaxConcurrentHandlers = 8
 const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
@@ -1128,26 +1131,27 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	}
 
 	var (
-		textMu          sync.Mutex
-		textBuf         strings.Builder
-		activeTools     = make(map[string]string) // toolCallID → toolName
-		activePhase     string                    // most-recent EventPhase text, "" when idle
-		toolsRan        bool                      // true once any EventToolExecStart seen
-		collectedImages []string                  // image paths from tool executions
-		textDeltas      int
-		reasoningDeltas int
-		toolStarts      int
-		toolEnds        int
-		toolCalls       int
-		phaseEvents     int
-		usageEvents     int
-		doneEvents      int
-		retryEvents     int
-		errorEvents     int
-		otherEvents     int
-		otherTypes      = make(map[llm.EventType]int)
-		streamDone      = make(chan error, 1)
-		lastEventPing   = make(chan struct{}, 1)
+		textMu           sync.Mutex
+		textBuf          strings.Builder
+		activeTools      = make(map[string]string) // toolCallID → toolName
+		activePhase      string                    // most-recent EventPhase text, "" when idle
+		toolsRan         bool                      // true once any EventToolExecStart seen
+		collectedImages  []string                  // image paths from tool executions
+		textDeltas       int
+		reasoningDeltas  int
+		toolStarts       int
+		toolEnds         int
+		toolCalls        int
+		phaseEvents      int
+		usageEvents      int
+		doneEvents       int
+		retryEvents      int
+		errorEvents      int
+		otherEvents      int
+		otherTypes       = make(map[llm.EventType]int)
+		streamDone       = make(chan error, 1)
+		lastEventPing    = make(chan struct{}, 1)
+		watchdogTimedOut atomic.Bool
 	)
 
 	// Watchdog: cancel stream if no events arrive for streamEventTimeout.
@@ -1165,11 +1169,12 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 				}
 				t.Reset(streamEventTimeout)
 			case <-t.C:
-				streamCancel()
+				watchdogTimedOut.Store(true)
 				select {
 				case streamDone <- fmt.Errorf("stream timed out: no events for %s", streamEventTimeout):
 				default:
 				}
+				streamCancel()
 				return
 			case <-streamCtx.Done():
 				return
@@ -1382,7 +1387,7 @@ loop:
 			}
 			sendEdit(currentMsgID, rendered, forceProgress)
 		case <-streamCtx.Done():
-			// Distinguish server shutdown (parent ctx cancelled) from user interrupt.
+			// Distinguish server shutdown (parent ctx cancelled) from watchdog timeouts and user interrupt.
 			if ctx.Err() != nil {
 				// Server shutdown — existing behavior.
 				if m.store != nil && sess.meta != nil {
@@ -1395,6 +1400,15 @@ loop:
 					})
 				}
 				return ctx.Err()
+			}
+
+			if watchdogTimedOut.Load() {
+				select {
+				case streamErr = <-streamDone:
+				default:
+					streamErr = fmt.Errorf("stream timed out: no events for %s", streamEventTimeout)
+				}
+				break loop
 			}
 
 			// User interrupt: cancel the stream and preserve partial state.

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1040,6 +1040,54 @@ func TestHandleMessage_InterruptPreservesHistory(t *testing.T) {
 	}
 }
 
+func TestStreamReply_WatchdogTimeoutIsNotTreatedAsUserInterrupt(t *testing.T) {
+	oldTimeout := streamEventTimeout
+	streamEventTimeout = 25 * time.Millisecond
+	defer func() {
+		streamEventTimeout = oldTimeout
+	}()
+
+	h := testutil.NewEngineHarness()
+	h.Provider.AddTurn(llm.MockTurn{Delay: 200 * time.Millisecond, Text: "late reply"})
+
+	mgr, sess := newTestMgrAndSession(h)
+	bot := &fakeBotSender{}
+
+	sess.history = []llm.Message{
+		llm.UserText("previous question"),
+		llm.AssistantText("previous answer"),
+	}
+
+	err := mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hello"))
+	if err == nil {
+		t.Fatal("expected streamReply to return timeout error")
+	}
+	if !strings.Contains(err.Error(), "stream timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+
+	texts := bot.allTexts()
+	foundTimeout := false
+	for _, text := range texts {
+		if strings.Contains(text, "Response timed out") {
+			foundTimeout = true
+		}
+		if strings.Contains(text, "(interrupted)") {
+			t.Fatalf("watchdog timeout should not be shown as interrupted; sent texts: %v", texts)
+		}
+	}
+	if !foundTimeout {
+		t.Fatalf("expected timeout notification in sent texts, got: %v", texts)
+	}
+
+	sess.mu.Lock()
+	historyLen := len(sess.history)
+	sess.mu.Unlock()
+	if historyLen != 2 {
+		t.Fatalf("watchdog timeout should not persist partial history; got %d messages", historyLen)
+	}
+}
+
 func TestStreamReply_InjectsCarryoverSystemNoteOnce(t *testing.T) {
 	h := testutil.NewEngineHarness()
 	h.Provider.AddTextResponse("first")


### PR DESCRIPTION
## What

- treat Telegram watchdog-triggered stream cancellations as timeouts instead of user interrupts
- preserve the timeout error path even if `streamCtx.Done()` wins the race over `streamDone`
- add a regression test covering watchdog timeouts so they do not show `(interrupted)` or persist partial history

## Why

The watchdog currently cancels the stream and separately queues a timeout error. If the main select loop sees `streamCtx.Done()` first, it can take the user-interrupt branch, save partial conversation state, and return `nil`. That hides real model stalls/failures and corrupts Telegram session history. This change keeps real watchdog timeouts classified as errors.
