### PR TITLE
fix: Job concurrency settings are accepted but effectively ignored

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -747,22 +747,38 @@ func (m *jobsV2Manager) scheduleDueRuns(now time.Time) error {
 	return nil
 }
 
+func jobsV2ConcurrencyLimit(job jobsV2Job) int {
+	if job.ConcurrencyPolicy == "forbid" {
+		return 1
+	}
+	if job.MaxConcurrentRuns > 0 {
+		return job.MaxConcurrentRuns
+	}
+	return 1
+}
+
+func (m *jobsV2Manager) countActiveRuns(jobID string) (int, error) {
+	var active int
+	err := m.db.QueryRow(`SELECT COUNT(1) FROM job_runs_v2 WHERE job_id = ? AND status IN (?, ?, ?)`, jobID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning).Scan(&active)
+	if err != nil {
+		return 0, err
+	}
+	return active, nil
+}
+
 func (m *jobsV2Manager) scheduleOne(job jobsV2Job, now time.Time) error {
 	next, err := computeNextRunAt(job, now)
 	if err != nil {
 		return err
 	}
 
-	if job.ConcurrencyPolicy == "forbid" {
-		var active int
-		err := m.db.QueryRow(`SELECT COUNT(1) FROM job_runs_v2 WHERE job_id = ? AND status IN (?, ?, ?)`, job.ID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning).Scan(&active)
-		if err != nil {
-			return err
-		}
-		if active > 0 {
-			_, err = m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
-			return err
-		}
+	active, err := m.countActiveRuns(job.ID)
+	if err != nil {
+		return err
+	}
+	if active >= jobsV2ConcurrencyLimit(job) {
+		_, err = m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
+		return err
 	}
 
 	runID := "run_" + randomSuffix()
@@ -1273,16 +1289,19 @@ func (m *jobsV2Manager) TriggerJob(id string) (jobsV2Run, error) {
 	if !job.Enabled {
 		return jobsV2Run{}, fmt.Errorf("job is disabled")
 	}
-	if job.ConcurrencyPolicy == "forbid" {
-		var active int
-		err := m.db.QueryRow(`SELECT COUNT(1) FROM job_runs_v2 WHERE job_id = ? AND status IN (?, ?, ?)`, id, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning).Scan(&active)
-		if err != nil {
-			return jobsV2Run{}, err
-		}
-		if active > 0 {
+
+	active, err := m.countActiveRuns(id)
+	if err != nil {
+		return jobsV2Run{}, err
+	}
+	limit := jobsV2ConcurrencyLimit(job)
+	if active >= limit {
+		if limit == 1 {
 			return jobsV2Run{}, fmt.Errorf("job already has an active run")
 		}
+		return jobsV2Run{}, fmt.Errorf("job already has %d active runs (max %d)", active, limit)
 	}
+
 	runID := "run_" + randomSuffix()
 	now := time.Now().UTC()
 	_, err = m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, runID, id, "manual", now, jobsV2RunQueued)

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -518,3 +518,91 @@ func TestJobsV2_ProgressiveLLM_FinalResponseProse(t *testing.T) {
 		t.Fatalf("Response = %q, want prose %q", run.Response, expected)
 	}
 }
+
+func TestJobsV2TriggerJobRespectsMaxConcurrentRuns(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 1, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:              "manual-bounded-concurrency",
+		Enabled:           true,
+		RunnerType:        jobsV2RunnerProgram,
+		RunnerConfig:      json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:       jobsV2TriggerManual,
+		TriggerConfig:     json.RawMessage(`{}`),
+		ConcurrencyPolicy: "allow",
+		MaxConcurrentRuns: 2,
+		TimeoutSeconds:    30,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for _, runID := range []string{"run_existing_1", "run_existing_2"} {
+		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?)`,
+			runID, job.ID, now, jobsV2RunRunning, now, now)
+		if err != nil {
+			t.Fatalf("insert active run %s: %v", runID, err)
+		}
+	}
+
+	if _, err := mgr.TriggerJob(job.ID); err == nil {
+		t.Fatal("TriggerJob should reject runs above max_concurrent_runs")
+	}
+
+	active, err := mgr.countActiveRuns(job.ID)
+	if err != nil {
+		t.Fatalf("countActiveRuns failed: %v", err)
+	}
+	if active != 2 {
+		t.Fatalf("active runs = %d, want 2", active)
+	}
+}
+
+func TestJobsV2ScheduleOneRespectsMaxConcurrentRuns(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 1, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:              "cron-bounded-concurrency",
+		Enabled:           true,
+		RunnerType:        jobsV2RunnerProgram,
+		RunnerConfig:      json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:       jobsV2TriggerCron,
+		TriggerConfig:     json.RawMessage(`{"expression":"* * * * *","timezone":"UTC"}`),
+		ConcurrencyPolicy: "allow",
+		MaxConcurrentRuns: 2,
+		TimeoutSeconds:    30,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for _, runID := range []string{"run_existing_1", "run_existing_2"} {
+		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'schedule', ?, ?, ?, ?)`,
+			runID, job.ID, now, jobsV2RunRunning, now, now)
+		if err != nil {
+			t.Fatalf("insert active run %s: %v", runID, err)
+		}
+	}
+
+	if err := mgr.scheduleOne(job, now); err != nil {
+		t.Fatalf("scheduleOne failed: %v", err)
+	}
+
+	active, err := mgr.countActiveRuns(job.ID)
+	if err != nil {
+		t.Fatalf("countActiveRuns failed: %v", err)
+	}
+	if active != 2 {
+		t.Fatalf("active runs = %d, want 2", active)
+	}
+}


### PR DESCRIPTION
## What

- enforce job concurrency limits using `max_concurrent_runs` for scheduled and manual runs
- treat `forbid` as a hard limit of 1 active run, while non-`forbid` jobs honor their configured bound
- add regression coverage for both `scheduleOne` and `TriggerJob`

## Why

Jobs were only concurrency-gated when `concurrency_policy == "forbid"`. Other policies ignored `max_concurrent_runs`, so bounded parallel jobs could queue or trigger unlimited active runs. This fixes the bug with a targeted change and prevents resource blowups and duplicate work.
