### PR TITLE
fix: OpenAI-compat message conversion drops earlier developer messages

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -509,7 +509,10 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 			// wrapped in <developer> tags.
 			text, _, _ := splitParts(msg.Parts)
 			if text != "" {
-				pendingDev = text
+				if pendingDev != "" {
+					pendingDev += "\n\n"
+				}
+				pendingDev += text
 			}
 		case RoleSystem, RoleUser, RoleAssistant:
 			text, toolCalls, reasoning := splitParts(msg.Parts)

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -718,6 +718,42 @@ func TestBuildCompatMessages_DeveloperMessageNotDropped(t *testing.T) {
 	}
 }
 
+func TestBuildCompatMessages_ConsecutiveDeveloperMessagesPreserved(t *testing.T) {
+	messages := []Message{
+		{
+			Role:  RoleDeveloper,
+			Parts: []Part{{Type: PartText, Text: "Platform instruction."}},
+		},
+		{
+			Role:  RoleDeveloper,
+			Parts: []Part{{Type: PartText, Text: "Runtime instruction."}},
+		},
+		{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "Hello"}},
+		},
+	}
+
+	oaiMsgs := buildCompatMessages(messages)
+
+	if len(oaiMsgs) != 1 {
+		t.Fatalf("expected 1 message (merged dev+user), got %d", len(oaiMsgs))
+	}
+	content, ok := oaiMsgs[0].Content.(string)
+	if !ok {
+		t.Fatalf("expected content to be string, got %T", oaiMsgs[0].Content)
+	}
+	if !strings.Contains(content, "Platform instruction.") {
+		t.Errorf("first developer text was dropped — not found in %q", content)
+	}
+	if !strings.Contains(content, "Runtime instruction.") {
+		t.Errorf("second developer text was dropped — not found in %q", content)
+	}
+	if !strings.Contains(content, "Hello") {
+		t.Errorf("user text was dropped — not found in %q", content)
+	}
+}
+
 func TestOpenAICompatProviderStreamSendsExplicitParallelToolCallsFalse(t *testing.T) {
 	var got struct {
 		ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty"`


### PR DESCRIPTION
## What

Accumulate consecutive developer-role messages in `buildCompatMessages()` instead of overwriting the pending developer text with the most recent message.

Also adds a regression test covering multiple developer messages before a user turn.

## Why

OpenAI-compatible backends do not support a native developer role, so term-llm folds developer instructions into the next user message. When more than one developer message was injected in a row, earlier instructions were silently discarded, which could strip platform or runtime constraints from the prompt.
