### PR TITLE
fix: Trailing developer messages are rewritten as user messages

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -591,9 +591,11 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 		}
 	}
 	// Trailing developer message with no following user turn.
+	// Preserve instruction semantics by emitting it as a system message
+	// rather than rewriting it as a user prompt.
 	if pendingDev != "" {
 		result = append(result, oaiMessage{
-			Role:    "user",
+			Role:    "system",
 			Content: fmt.Sprintf("<developer>\n%s\n</developer>", pendingDev),
 		})
 	}

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -673,18 +673,18 @@ func TestBuildCompatMessages_TrailingDeveloperMessage(t *testing.T) {
 	oaiMsgs := buildCompatMessages(messages)
 
 	if len(oaiMsgs) != 3 {
-		t.Fatalf("expected 3 messages (user, assistant, synthetic user), got %d", len(oaiMsgs))
+		t.Fatalf("expected 3 messages (user, assistant, trailing system), got %d", len(oaiMsgs))
 	}
 	trailing := oaiMsgs[2]
-	if trailing.Role != "user" {
-		t.Errorf("expected trailing message role 'user', got %q", trailing.Role)
+	if trailing.Role != "system" {
+		t.Errorf("expected trailing message role 'system', got %q", trailing.Role)
 	}
 	content, ok := trailing.Content.(string)
 	if !ok {
 		t.Fatalf("expected trailing content to be string, got %T", trailing.Content)
 	}
 	if !strings.Contains(content, "<developer>") || !strings.Contains(content, "Be concise from now on.") {
-		t.Errorf("expected developer text in trailing user message, got %q", content)
+		t.Errorf("expected developer text in trailing system message, got %q", content)
 	}
 }
 


### PR DESCRIPTION
## What

Preserve trailing developer messages as instruction-role messages in `buildCompatMessages()` by emitting them as synthetic `system` messages instead of synthetic `user` messages.

## Why

Rewriting a trailing developer message as `user` changes its semantics from privileged instruction to ordinary prompt text. That can cause models to answer or ignore the instruction instead of following it, especially when late developer constraints are injected after the last assistant turn.
