### PR TITLE
fix(web): rescue orphaned interrupt commits when session confirmed idle

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -13,7 +13,7 @@ const {
   requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD, HEARTBEAT_ABORT_REASON,
   applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, renderAttachments,
   updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState
+  moveSessionProgressState, requeueUncommittedInterrupts
 } = app;
 let sessionStatePollTimer = null;
 
@@ -458,6 +458,13 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
     }
     setConnectionState('', '');
     setStreaming(false);
+    requeueUncommittedInterrupts(session);
+    if (session.id === state.activeSessionId && state.queuedInterrupts.length > 0) {
+      const queued = state.queuedInterrupts.shift();
+      elements.promptInput.value = queued.prompt;
+      autoGrowPrompt();
+      void sendMessage({ prompt: queued.prompt, attachments: [], reuseMessageId: queued.messageId });
+    }
   }
 
   return runtimeState;


### PR DESCRIPTION
## What

In `syncActiveSessionFromServer`, after confirming the session is idle (`!activeRun && !state.abortController`), call `requeueUncommittedInterrupts` and drain any resulting `queuedInterrupts` by sending the first one.

## Why

When the browser was backgrounded, the SSE connection dropped, or the page was restored from BFCache with a stale `activeResponseId`, there was no active stream in flight. The only place `requeueUncommittedInterrupts` was called was in the stream `finally` block — unreachable in this case.

The result: a user sends a message while the session appears busy → interrupt path → `trackPendingInterruptCommit` stores the message → no stream ever exits → commit orphaned permanently → session stuck.

`syncActiveSessionFromServer` is called by `visibilitychange`, `online`, `pageshow`, and the 5-consecutive-HTTP-failure path in `resumeActiveResponseInner`. All of these already confirmed the server says the session is idle. Rescuing the pending commits here closes the only path where they could be permanently lost.
