### PR TITLE
fix: Stream failures can be silently dropped and reported as clean EOF

### DIFF
--- a/internal/llm/stream.go
+++ b/internal/llm/stream.go
@@ -6,27 +6,31 @@ import (
 )
 
 type channelStream struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	events <-chan Event
+	ctx         context.Context
+	cancel      context.CancelFunc
+	events      <-chan Event
+	terminalErr <-chan error
 }
 
 func newEventStream(ctx context.Context, run func(context.Context, chan<- Event) error) Stream {
 	streamCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan Event, 16)
+	terminalErr := make(chan error, 1)
 	go func() {
-		defer close(ch)
 		if err := run(streamCtx, ch); err != nil {
-			// If the consumer has stopped draining and the buffer is full, drop the
-			// terminal error rather than block forever and leak the producer goroutine.
+			// If the consumer has stopped draining and the buffer is full, preserve the
+			// terminal error for Recv() rather than dropping it and reporting clean EOF.
 			select {
 			case ch <- Event{Type: EventError, Err: err}:
 			case <-streamCtx.Done():
 			default:
+				terminalErr <- err
 			}
 		}
+		close(terminalErr)
+		close(ch)
 	}()
-	return &channelStream{ctx: streamCtx, cancel: cancel, events: ch}
+	return &channelStream{ctx: streamCtx, cancel: cancel, events: ch, terminalErr: terminalErr}
 }
 
 func (s *channelStream) Recv() (Event, error) {
@@ -35,6 +39,9 @@ func (s *channelStream) Recv() (Event, error) {
 	select {
 	case event, ok := <-s.events:
 		if !ok {
+			if err, ok := <-s.terminalErr; ok {
+				return Event{Type: EventError, Err: err}, nil
+			}
 			return Event{}, io.EOF
 		}
 		return event, nil
@@ -46,6 +53,9 @@ func (s *channelStream) Recv() (Event, error) {
 		return Event{}, s.ctx.Err()
 	case event, ok := <-s.events:
 		if !ok {
+			if err, ok := <-s.terminalErr; ok {
+				return Event{Type: EventError, Err: err}, nil
+			}
 			return Event{}, io.EOF
 		}
 		return event, nil

--- a/internal/llm/stream_test.go
+++ b/internal/llm/stream_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestNewEventStreamDoesNotQueueRunErrorAfterCloseWhenBufferIsFull(t *testing.T) {
+func TestNewEventStreamReturnsRunErrorAfterBufferedEventsWhenBufferIsFull(t *testing.T) {
 	filled := make(chan struct{})
 	wantErr := errors.New("boom")
 	bufSize := 0
@@ -23,10 +23,6 @@ func TestNewEventStreamDoesNotQueueRunErrorAfterCloseWhenBufferIsFull(t *testing
 
 	<-filled
 
-	if err := stream.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
-	}
-
 	for i := range bufSize {
 		event, err := stream.Recv()
 		if err != nil {
@@ -38,6 +34,17 @@ func TestNewEventStreamDoesNotQueueRunErrorAfterCloseWhenBufferIsFull(t *testing
 	}
 
 	event, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv() terminal error = %v, want nil", err)
+	}
+	if event.Type != EventError {
+		t.Fatalf("Recv() terminal event type = %v, want %v", event.Type, EventError)
+	}
+	if !errors.Is(event.Err, wantErr) {
+		t.Fatalf("Recv() terminal event error = %v, want %v", event.Err, wantErr)
+	}
+
+	event, err = stream.Recv()
 	if err != io.EOF {
 		t.Fatalf("final Recv() error = %v, want %v (event=%+v)", err, io.EOF, event)
 	}


### PR DESCRIPTION
## What

Preserve terminal stream failures when the event buffer is already full by storing the run error for later delivery from `Recv()` instead of dropping it and closing as clean EOF.

Also adds coverage for the backpressure case to ensure buffered events are delivered first, followed by the terminal `EventError`.

## Why

When a producer exited with an error while the stream buffer was full, `newEventStream` could silently drop the terminal failure. Consumers would then only observe `io.EOF` and treat a failed run as successful, which could persist or return incomplete output without surfacing the real provider/tool/callback error.
