### PR TITLE
fix: Server-side tool execution ignores ParallelToolCalls=false and always runs tools concurrently

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1090,7 +1090,7 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			}
 		}
 
-		toolResults, err := e.executeToolCalls(ctx, registered, events, req.Debug, req.DebugRaw)
+		toolResults, err := e.executeToolCalls(ctx, registered, req.ParallelToolCalls, events, req.Debug, req.DebugRaw)
 		if err != nil {
 			return err
 		}
@@ -1190,15 +1190,31 @@ func buildAssistantMessageWithReasoningMetadata(text string, toolCalls []ToolCal
 	return Message{Role: RoleAssistant, Parts: parts}
 }
 
-// executeToolCalls executes multiple tool calls, potentially in parallel.
+// executeToolCalls executes multiple tool calls.
 // Note: When executing in parallel, EventToolExecStart/EventToolExecEnd events
 // are emitted from concurrent goroutines. While the channel is thread-safe, events
 // may arrive in non-deterministic order. Consumers should use ToolCallID to correlate
 // start/end events rather than relying on ordering.
-func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, events chan<- Event, debug bool, debugRaw bool) ([]Message, error) {
+func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, parallel bool, events chan<- Event, debug bool, debugRaw bool) ([]Message, error) {
 	// Fast path: single call, no concurrency overhead
 	if len(calls) == 1 {
 		return e.executeSingleToolCallSafe(ctx, calls[0], events, debug, debugRaw)
+	}
+
+	if !parallel {
+		results := make([]Message, 0, len(calls))
+		for _, call := range calls {
+			msgs, err := e.executeSingleToolCallSafe(ctx, call, events, debug, debugRaw)
+			if err != nil {
+				return nil, err
+			}
+			msg := ToolErrorMessage(call.ID, call.Name, "tool returned no result", call.ThoughtSig)
+			if len(msgs) > 0 {
+				msg = msgs[0]
+			}
+			results = append(results, msg)
+		}
+		return results, nil
 	}
 
 	// Parallel execution for multiple calls (events may arrive out of order)

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -827,6 +827,76 @@ func TestEngineParallelToolExecution(t *testing.T) {
 	t.Logf("Parallel execution: peak concurrent=%d, elapsed=%v", tool.concurrentAt, elapsed)
 }
 
+func TestEngineSequentialToolExecutionWhenParallelToolCallsDisabled(t *testing.T) {
+	tool := &delayingTool{delay: 100 * time.Millisecond}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				return []Event{
+					{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "delay_tool", Arguments: json.RawMessage(`{}`)}},
+					{Type: EventToolCall, Tool: &ToolCall{ID: "call-2", Name: "delay_tool", Arguments: json.RawMessage(`{}`)}},
+					{Type: EventToolCall, Tool: &ToolCall{ID: "call-3", Name: "delay_tool", Arguments: json.RawMessage(`{}`)}},
+					{Type: EventDone},
+				}
+			default:
+				return []Event{
+					{Type: EventTextDelta, Text: "done"},
+					{Type: EventDone},
+				}
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages:          []Message{UserText("run tools")},
+		Tools:             []ToolSpec{tool.Spec()},
+		ParallelToolCalls: false,
+		ToolChoice:        ToolChoice{Mode: ToolChoiceAuto},
+	}
+
+	start := time.Now()
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+		if event.Type == EventError && event.Err != nil {
+			t.Fatalf("event error: %v", event.Err)
+		}
+	}
+	elapsed := time.Since(start)
+
+	if tool.calls != 3 {
+		t.Fatalf("expected 3 tool calls, got %d", tool.calls)
+	}
+	if tool.concurrentAt != 1 {
+		t.Fatalf("expected sequential execution, peak concurrent=%d", tool.concurrentAt)
+	}
+	for i := 1; i < len(tool.startTimes); i++ {
+		if tool.startTimes[i].Before(tool.endTimes[i-1]) {
+			t.Fatalf("tool call %d started before previous call ended", i+1)
+		}
+	}
+	minExpected := 250 * time.Millisecond
+	if elapsed < minExpected {
+		t.Fatalf("sequential execution completed too quickly: %v (min expected: %v)", elapsed, minExpected)
+	}
+}
+
 // namedTool is a simple tool with a configurable name for testing
 type namedTool struct {
 	name string


### PR DESCRIPTION
## What

- respect `Request.ParallelToolCalls` when executing multiple server-side tool calls
- run tool calls sequentially when `parallel_tool_calls=false` instead of always spawning goroutines
- add an engine test that verifies tool calls stay serialized when parallel execution is disabled

## Why

Clients can explicitly disable parallel tool execution when tool calls have ordering or on-disk side effects. The engine was ignoring that setting and always running multiple server-side tools concurrently, which could reorder dependent operations and race destructive actions.
