### PR TITLE
fix: Stateful session creation ignores request cancellation and can leak expensive runtimes

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -959,8 +959,9 @@ func (s *serveServer) runtimeForRequest(ctx context.Context, sessionID string) (
 		}
 		return rt, false, nil
 	}
-	// Stateful sessions should outlive a single HTTP request context.
-	rt, err := s.sessionMgr.GetOrCreate(context.Background(), sessionID)
+	// Stateful sessions should persist beyond a single HTTP request, but
+	// creation must still respect request cancellation/timeouts.
+	rt, err := s.sessionMgr.GetOrCreate(ctx, sessionID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -994,7 +995,7 @@ func (s *serveServer) runtimeForProviderRequest(ctx context.Context, sessionID s
 		}
 	}
 	// Use GetOrCreateWith to get proper in-flight deduplication.
-	rt, err := s.sessionMgr.GetOrCreateWith(context.Background(), sessionID, func(ctx context.Context) (*serveRuntime, error) {
+	rt, err := s.sessionMgr.GetOrCreateWith(ctx, sessionID, func(ctx context.Context) (*serveRuntime, error) {
 		return s.runtimeFactory(ctx, providerName, "")
 	})
 	if err != nil {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4709,6 +4709,84 @@ func TestServeSessionManager_GetOrCreate_RespectsContextCancel(t *testing.T) {
 	close(proceed)
 }
 
+func TestServeServer_RuntimeForRequest_StatefulRespectsRequestCancel(t *testing.T) {
+	started := make(chan struct{})
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	mgr := newServeSessionManager(time.Minute, 10, factory)
+	defer mgr.Close()
+
+	srv := &serveServer{sessionMgr: mgr}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := srv.runtimeForRequest(ctx, "slow-sess")
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("runtimeForRequest did not return after request cancellation")
+	}
+
+	if _, ok := mgr.Get("slow-sess"); ok {
+		t.Fatal("cancelled runtime creation should not store a session runtime")
+	}
+}
+
+func TestServeServer_RuntimeForProviderRequest_StatefulRespectsRequestCancel(t *testing.T) {
+	started := make(chan struct{})
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return nil, fmt.Errorf("default session manager factory should not be used")
+	})
+	defer mgr.Close()
+
+	srv := &serveServer{
+		sessionMgr: mgr,
+		runtimeFactory: func(ctx context.Context, providerName string, model string) (*serveRuntime, error) {
+			if providerName != "test-provider" {
+				return nil, fmt.Errorf("expected provider test-provider, got %q", providerName)
+			}
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := srv.runtimeForProviderRequest(ctx, "slow-sess", "test-provider")
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("runtimeForProviderRequest did not return after request cancellation")
+	}
+
+	if _, ok := mgr.Get("slow-sess"); ok {
+		t.Fatal("cancelled runtime creation should not store a session runtime")
+	}
+}
+
 func TestServeSessionManager_EvictionCallbackCleansResponseIDs(t *testing.T) {
 	factory := func(ctx context.Context) (*serveRuntime, error) {
 		rt := &serveRuntime{}


### PR DESCRIPTION
## What

Use the request context when creating stateful serve runtimes so cancelled/timed-out requests stop session initialization instead of continuing in the background.

Also add regression tests covering both the default stateful session path and the provider-specific stateful session path.

## Why

These code paths were using context.Background() for stateful session creation. If a client disconnected while provider/session initialization was still in progress, creation could keep running and still install an expensive runtime into the session manager. Respecting the request context prevents leaked session slots and wasted initialization work after aborted requests.
