### PR TITLE
fix: Client developer messages are promoted to system messages and can suppress the server system prompt

### DIFF
--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -62,8 +62,11 @@ func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 	for _, msg := range msgs {
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
 		switch role {
-		case "system", "developer":
+		case "system":
 			result = append(result, llm.SystemText(extractMessageText(msg.Content)))
+			replaceHistory = true
+		case "developer":
+			result = append(result, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: extractMessageText(msg.Content)}}})
 			replaceHistory = true
 		case "user":
 			userMsg, err := parseUserMessageContent(msg.Content)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -729,6 +729,51 @@ func TestParseResponsesInput_DeveloperDoesNotSuppressServerSystemPrompt(t *testi
 	}
 }
 
+func TestParseChatMessages_DeveloperDoesNotSuppressServerSystemPrompt(t *testing.T) {
+	msgs, replaceHistory, err := parseChatMessages([]chatMessage{
+		{Role: "developer", Content: json.RawMessage(`"Be concise"`)},
+		{Role: "user", Content: json.RawMessage(`"hello"`)},
+	})
+	if err != nil {
+		t.Fatalf("parseChatMessages failed: %v", err)
+	}
+	if !replaceHistory {
+		t.Fatalf("replaceHistory = false, want true")
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("len(msgs) = %d, want 2", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleDeveloper {
+		t.Fatalf("first role = %s, want developer", msgs[0].Role)
+	}
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	rt := &serveRuntime{
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		systemPrompt: "server system prompt",
+	}
+	_, err = rt.Run(context.Background(), true, replaceHistory, msgs, llm.Request{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(provider.Requests))
+	}
+	if len(provider.Requests[0].Messages) != 3 {
+		t.Fatalf("request message count = %d, want 3", len(provider.Requests[0].Messages))
+	}
+	if provider.Requests[0].Messages[0].Role != llm.RoleSystem || provider.Requests[0].Messages[0].Parts[0].Text != "server system prompt" {
+		t.Fatalf("first request message = %+v, want server system prompt", provider.Requests[0].Messages[0])
+	}
+	if provider.Requests[0].Messages[1].Role != llm.RoleDeveloper || provider.Requests[0].Messages[1].Parts[0].Text != "Be concise" {
+		t.Fatalf("second request message = %+v, want developer prompt", provider.Requests[0].Messages[1])
+	}
+	if provider.Requests[0].Messages[2].Role != llm.RoleUser || provider.Requests[0].Messages[2].Parts[0].Text != "hello" {
+		t.Fatalf("third request message = %+v, want user prompt", provider.Requests[0].Messages[2])
+	}
+}
+
 func TestParseResponsesInput_ImageContent(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)


### PR DESCRIPTION
## What

Stop the chat-completions parser from converting client `developer` messages into `system` messages. Chat `developer` messages are now preserved as `llm.RoleDeveloper`, and a regression test covers the case where the server system prompt must still be injected ahead of a client developer message.

## Why

Promoting a user-controlled `developer` message to `system` caused `containsSystemMessage(...)` to think a real system prompt was already present. That let clients suppress the configured server/agent system prompt entirely, which is a security/policy bug.
