### PR TITLE
fix: Client developer messages are upgraded to system messages and can suppress the server system prompt

### DIFF
--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -62,8 +62,11 @@ func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 	for _, msg := range msgs {
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
 		switch role {
-		case "system", "developer":
+		case "system":
 			result = append(result, llm.SystemText(extractMessageText(msg.Content)))
+			replaceHistory = true
+		case "developer":
+			result = append(result, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: extractMessageText(msg.Content)}}})
 			replaceHistory = true
 		case "user":
 			userMsg, err := parseUserMessageContent(msg.Content)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1006,6 +1006,51 @@ func TestParseChatMessages_ToolCallAndToolResult(t *testing.T) {
 	}
 }
 
+func TestParseChatMessages_DeveloperDoesNotSuppressServerSystemPrompt(t *testing.T) {
+	msgs, replaceHistory, err := parseChatMessages([]chatMessage{
+		{Role: "developer", Content: json.RawMessage(`"Be concise"`)},
+		{Role: "user", Content: json.RawMessage(`"hello"`)},
+	})
+	if err != nil {
+		t.Fatalf("parseChatMessages failed: %v", err)
+	}
+	if !replaceHistory {
+		t.Fatalf("replaceHistory = false, want true")
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("len(msgs) = %d, want 2", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleDeveloper {
+		t.Fatalf("first role = %s, want developer", msgs[0].Role)
+	}
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	rt := &serveRuntime{
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		systemPrompt: "server system prompt",
+	}
+	_, err = rt.Run(context.Background(), true, replaceHistory, msgs, llm.Request{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(provider.Requests))
+	}
+	if len(provider.Requests[0].Messages) != 3 {
+		t.Fatalf("request message count = %d, want 3", len(provider.Requests[0].Messages))
+	}
+	if provider.Requests[0].Messages[0].Role != llm.RoleSystem || provider.Requests[0].Messages[0].Parts[0].Text != "server system prompt" {
+		t.Fatalf("first request message = %+v, want server system prompt", provider.Requests[0].Messages[0])
+	}
+	if provider.Requests[0].Messages[1].Role != llm.RoleDeveloper || provider.Requests[0].Messages[1].Parts[0].Text != "Be concise" {
+		t.Fatalf("second request message = %+v, want developer prompt", provider.Requests[0].Messages[1])
+	}
+	if provider.Requests[0].Messages[2].Role != llm.RoleUser || provider.Requests[0].Messages[2].Parts[0].Text != "hello" {
+		t.Fatalf("third request message = %+v, want user prompt", provider.Requests[0].Messages[2])
+	}
+}
+
 func TestParseChatMessages_UserImageContent(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What

Treat chat-completions `developer` messages as `RoleDeveloper` instead of upgrading them to `RoleSystem`, and add a regression test that verifies a client developer message no longer suppresses the configured server system prompt.

## Why

Client-controlled `developer` input was being promoted to a system message. `serveRuntime.run` only injects the server/runtime system prompt when no system message is present, so a single client developer message could prevent the server prompt from being added and weaken server-side constraints.
