### PR TITLE
fix: Tool execution can deadlock forever when the stream consumer stops draining events

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1086,7 +1086,11 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			info := e.getToolPreview(call)
 
 			if events != nil {
-				events <- Event{Type: EventToolExecStart, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: info, ToolArgs: call.Arguments}
+				if !safeSendEvent(ctx, events, Event{Type: EventToolExecStart, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: info, ToolArgs: call.Arguments}) {
+					if err := ctx.Err(); err != nil {
+						return err
+					}
+				}
 			}
 		}
 
@@ -1218,7 +1222,7 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, events 
 				if r := recover(); r != nil {
 					errMsg := fmt.Sprintf("Error: tool panicked: %v", r)
 					if events != nil {
-						events <- Event{Type: EventToolExecEnd, ToolCallID: c.ID, ToolName: c.Name, ToolSuccess: false}
+						_ = safeSendEvent(ctx, events, Event{Type: EventToolExecEnd, ToolCallID: c.ID, ToolName: c.Name, ToolSuccess: false})
 					}
 					resultChan <- toolResult{index: idx, message: ToolErrorMessage(c.ID, c.Name, errMsg, c.ThoughtSig)}
 				}
@@ -1253,7 +1257,7 @@ func (e *Engine) executeSingleToolCallSafe(ctx context.Context, call ToolCall, e
 		if r := recover(); r != nil {
 			errMsg := fmt.Sprintf("Error: tool panicked: %v", r)
 			if events != nil {
-				events <- Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolSuccess: false}
+				_ = safeSendEvent(ctx, events, Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolSuccess: false})
 			}
 			msgs = []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}
 			err = nil
@@ -1269,7 +1273,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, event
 		errMsg := fmt.Sprintf("Error: tool not registered: %s", call.Name)
 		DebugToolResult(debug, call.ID, call.Name, errMsg)
 		if events != nil {
-			events <- Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false}
+			_ = safeSendEvent(ctx, events, Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false})
 		}
 		return []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}, nil
 	}
@@ -1279,7 +1283,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, event
 		errMsg := fmt.Sprintf("Error: tool '%s' is not in the active skill's allowed-tools list", call.Name)
 		DebugToolResult(debug, call.ID, call.Name, errMsg)
 		if events != nil {
-			events <- Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false}
+			_ = safeSendEvent(ctx, events, Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false})
 		}
 		return []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}, nil
 	}
@@ -1321,7 +1325,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, event
 		errMsg := fmt.Sprintf("Error: %v", err)
 		DebugToolResult(debug, call.ID, call.Name, errMsg)
 		if events != nil {
-			events <- Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: info, ToolSuccess: false}
+			_ = safeSendEvent(ctx, events, Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: info, ToolSuccess: false})
 		}
 		return []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}, nil
 	}
@@ -1329,7 +1333,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, event
 	DebugToolResult(debug, call.ID, call.Name, output.Content)
 	DebugRawToolResult(debugRaw, call.ID, call.Name, output.Content)
 	if events != nil {
-		events <- Event{
+		_ = safeSendEvent(ctx, events, Event{
 			Type:        EventToolExecEnd,
 			ToolCallID:  call.ID,
 			ToolName:    call.Name,
@@ -1338,7 +1342,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, event
 			ToolOutput:  output.Content,
 			ToolDiffs:   output.Diffs,
 			ToolImages:  output.Images,
-		}
+		})
 	}
 	return []Message{ToolResultMessageFromOutput(call.ID, call.Name, output, call.ThoughtSig)}, nil
 }

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -101,6 +101,31 @@ func (t *countingTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+type signalTool struct {
+	started chan struct{}
+}
+
+func (t *signalTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "signal_tool",
+		Description: "Signals when execution starts",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (t *signalTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	select {
+	case <-t.started:
+	default:
+		close(t.started)
+	}
+	return TextOutput("ok"), nil
+}
+
+func (t *signalTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 type timeoutTool struct {
 	calls int
 }
@@ -1120,6 +1145,106 @@ func TestEngineEmitsToolCallAndExecStartForEachTool(t *testing.T) {
 		if _, ok := toolExecStartEvents[id]; !ok {
 			t.Errorf("EventToolCall ID %q has no matching EventToolExecStart", id)
 		}
+	}
+}
+
+func TestRunLoopDoesNotDeadlockOnBlockedToolExecStartWhenCancelled(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			return []Event{
+				{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "count_tool", Arguments: json.RawMessage(`{}`)}},
+				{Type: EventDone},
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan Event, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- engine.runLoop(ctx, Request{
+			Messages: []Message{UserText("test")},
+			Tools:    []ToolSpec{tool.Spec()},
+		}, events)
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for len(events) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for tool call event")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runLoop remained blocked after cancellation")
+	}
+
+	if tool.calls != 0 {
+		t.Fatalf("expected tool not to execute once cancellation unblocked the start event, got %d calls", tool.calls)
+	}
+}
+
+func TestExecuteSingleToolCallDoesNotDeadlockOnBlockedToolExecEndWhenCancelled(t *testing.T) {
+	tool := &signalTool{started: make(chan struct{})}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	engine := NewEngine(&fakeProvider{}, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan Event, 1)
+	events <- Event{Type: EventToolCall, ToolCallID: "buffer-full"}
+
+	type result struct {
+		msgs []Message
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		msgs, err := engine.executeSingleToolCall(ctx, ToolCall{
+			ID:        "call-1",
+			Name:      "signal_tool",
+			Arguments: json.RawMessage(`{}`),
+		}, events, false, false)
+		resultCh <- result{msgs: msgs, err: err}
+	}()
+
+	select {
+	case <-tool.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool never started")
+	}
+
+	cancel()
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("expected nil error, got %v", res.err)
+		}
+		if len(res.msgs) != 1 {
+			t.Fatalf("expected 1 tool result message, got %d", len(res.msgs))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeSingleToolCall remained blocked after cancellation")
 	}
 }
 


### PR DESCRIPTION
## What

Use ctx-aware event sends for tool execution lifecycle events in `internal/llm/engine.go` so blocked `EventToolExecStart` / `EventToolExecEnd` sends stop waiting once the stream context is cancelled. Also add regression tests covering blocked start and end event delivery.

## Why

If a stream consumer stops draining events and the small event buffer fills, the previous plain blocking sends could hang forever during tool execution. That prevented cancellation/cleanup from completing and could leak goroutines, especially with multiple tools running in parallel.
