### PR TITLE
fix: Stateless /v1/responses calls leak response_id mappings forever

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -950,6 +950,15 @@ func (s *serveServer) registerResponseID(rt *serveRuntime, respID, sessionID str
 	}
 }
 
+func (s *serveServer) unregisterResponseIDs(rt *serveRuntime) {
+	if rt == nil {
+		return
+	}
+	for _, rid := range rt.getResponseIDs() {
+		s.responseToSession.Delete(rid)
+	}
+}
+
 func (s *serveServer) runtimeForRequest(ctx context.Context, sessionID string) (*serveRuntime, bool, error) {
 	if sessionID == "" {
 		// Ephemeral stateless runtime (fresh per request for isolation)

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -112,13 +112,17 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 			writeOpenAIError(w, http.StatusConflict, "conflict_error",
 				fmt.Sprintf("previous_response_id %q is stale; latest is %q", req.PreviousResponseID, lastRespID))
 			if !stateful {
+				s.unregisterResponseIDs(runtime)
 				runtime.Close()
 			}
 			return
 		}
 	}
 	if !stateful {
-		defer runtime.Close()
+		defer func() {
+			runtime.Close()
+			s.unregisterResponseIDs(runtime)
+		}()
 	}
 
 	searchFromTools, requestedTools, passthroughTools := parseRequestedTools(req.Tools)

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1066,7 +1066,10 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 			mgr.scheduleCleanup(respID)
 		}()
 		if !stateful {
-			defer runtime.Close()
+			defer func() {
+				runtime.Close()
+				s.unregisterResponseIDs(runtime)
+			}()
 		}
 
 		// Wire approval event callback so PromptUIFunc can emit SSE events

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4633,6 +4633,39 @@ func TestRegisterResponseID_CapsAtMax(t *testing.T) {
 	}
 }
 
+func TestStartResponseRun_StatelessCleanupRemovesResponseIDMapping(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	provider.AddTextResponse("hello")
+
+	rt := &serveRuntime{
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		defaultModel: "mock-model",
+	}
+	rt.Touch()
+
+	srv := &serveServer{responseRuns: newServeResponseRunManager()}
+	defer srv.responseRuns.Close()
+
+	run, err := srv.startResponseRun(rt, false, true, []llm.Message{
+		llm.UserText("hi"),
+	}, llm.Request{Model: "mock-model"}, "", startResponseRunOptions{})
+	if err != nil {
+		t.Fatalf("startResponseRun: %v", err)
+	}
+
+	waitForServeCondition(t, time.Second, func() bool {
+		run.mu.Lock()
+		defer run.mu.Unlock()
+		return run.status == "completed"
+	}, "stateless response run completion")
+
+	waitForServeCondition(t, time.Second, func() bool {
+		_, ok := srv.responseToSession.Load(run.id)
+		return !ok
+	}, "stateless response ID cleanup")
+}
+
 func TestServeSessionManager_Get_ExistingSession(t *testing.T) {
 	factory := func(ctx context.Context) (*serveRuntime, error) {
 		rt := &serveRuntime{}


### PR DESCRIPTION
## What

- clean up `response_id -> session_id` mappings when a stateless `/v1/responses` runtime is closed
- apply the cleanup in both the non-streaming handler and streamed response-run path
- add a regression test covering stateless response-run cleanup

## Why

Stateless response runtimes are closed immediately after a request, so they never hit the session-manager eviction hook that normally deletes response ID mappings. That left stale entries in the server-wide `responseToSession` map forever, causing unbounded memory growth on long-running servers and leaving invalid `previous_response_id` mappings behind.
