### PR TITLE
feat: drop sessions from localStorage, fix cross-tab discovery

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -26,7 +26,6 @@ const parseSidebarSessionCategories = (raw) => {
 };
 
 const STORAGE_KEYS = {
-  sessions: 'term_llm_sessions',
   token: 'term_llm_token',
   activeSession: 'term_llm_active_session',
   draftSessionActive: 'term_llm_draft_session_active',
@@ -787,44 +786,29 @@ const isEphemeralEmptySession = (session) => {
 };
 
 const loadSessions = () => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEYS.sessions);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.map(sanitizeSession).filter((session) => session && !isEphemeralEmptySession(session));
-  } catch {
-    return [];
-  }
+  // Sessions are no longer persisted to localStorage — always start empty
+  // and let mergeServerSessions() populate from the server.
+  // Clean up legacy key from older versions.
+  try { localStorage.removeItem('term_llm_sessions'); } catch { /* ignore */ }
+  return [];
 };
 
-// Prepare sessions for localStorage.  Only the 20 most-recent sessions
-// keep their full message arrays; older ones are stored as metadata-only
-// stubs that will be lazy-loaded from the server on next switch.
-const MAX_CACHED_MESSAGE_SESSIONS = 20;
+// Evict messages from in-memory sessions beyond the 10 most-recently-created
+// to cap RAM usage.  Evicted sessions become lazy-load stubs.
+const MAX_CACHED_MESSAGE_SESSIONS = 10;
 
-const sessionsForStorage = () => {
+const evictStaleSessionMessages = () => {
   const sorted = [...state.sessions]
     .filter(s => s.messages && s.messages.length > 0 && !s._serverOnly)
     .sort((a, b) => b.created - a.created);
   const keep = new Set(sorted.slice(0, MAX_CACHED_MESSAGE_SESSIONS).map(s => s.id));
 
-  return state.sessions.map(s => {
+  for (const s of state.sessions) {
     if (!keep.has(s.id) && s.messages && s.messages.length > 0) {
-      return { ...s, messages: [], _serverOnly: true };
+      s.messages = [];
+      s._serverOnly = true;
     }
-    if (!s.messages || !s.messages.some(m => m.attachments)) return s;
-    return {
-      ...s,
-      messages: s.messages.map(m => {
-        if (!m.attachments) return m;
-        return {
-          ...m,
-          attachments: m.attachments.map(a => ({ name: a.name, type: a.type }))
-        };
-      })
-    };
-  });
+  }
 };
 
 const saveSessions = () => {
@@ -840,12 +824,12 @@ const saveSessions = () => {
       state.activeSessionId = '';
     }
   }
+  evictStaleSessionMessages();
   try {
-    localStorage.setItem(STORAGE_KEYS.sessions, JSON.stringify(sessionsForStorage()));
     localStorage.setItem(STORAGE_KEYS.activeSession, state.activeSessionId || '');
     localStorage.setItem(STORAGE_KEYS.draftSessionActive, state.draftSessionActive ? '1' : '0');
   } catch {
-    // QuotaExceededError or other storage failure — continue without persistence
+    // storage failure — continue without persistence
   }
 };
 
@@ -1030,7 +1014,7 @@ Object.assign(app, {
   sanitizeSession,
   isEphemeralEmptySession,
   loadSessions,
-  sessionsForStorage,
+  evictStaleSessionMessages,
   saveSessions,
   getActiveSession,
   sessionMatchesSidebarFilters,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -62,6 +62,11 @@ const pollSidebarStatus = async () => {
       const data = await resp.json();
       if (Array.isArray(data.sessions)) {
         updateSidebarStatus(data.sessions);
+        // Discover sessions created in other tabs/devices
+        const hasUnknown = data.sessions.some(
+          (entry) => !state.sessions.find((s) => s.id === entry.id)
+        );
+        if (hasUnknown) mergeServerSessions();
       }
     }
   } catch (_e) {
@@ -570,7 +575,7 @@ const mergeServerSessions = async (options = {}) => {
 
     persistAndRefreshShell();
   } catch {
-    // Gracefully fall back to localStorage-only
+    // Gracefully fall back to in-memory-only
   }
 };
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -405,7 +405,6 @@ async function testSwitchToSessionSyncsWithoutTokenAndResumes() {
 
   const { app } = await createSessionsHarness({
     initialStorage: {
-      term_llm_sessions: JSON.stringify(initialSessions),
       term_llm_active_session: 'sess_other',
     },
     fetchImpl: async (url) => {
@@ -511,7 +510,6 @@ async function testSwitchToSessionClearsStaleActiveResponseWithoutToken() {
 
   const { app } = await createSessionsHarness({
     initialStorage: {
-      term_llm_sessions: JSON.stringify(initialSessions),
       term_llm_active_session: 'sess_other',
     },
     fetchImpl: async (url) => {


### PR DESCRIPTION
## What

Remove `term_llm_sessions` from localStorage entirely. Sessions now live only in memory with a cap of 10 message-cached sessions. Also fix cross-tab session discovery so new sessions created in other tabs/devices appear without a full page reload.

## Why

**localStorage removal:** The `term_llm_sessions` blob was the root cause of the session-1434 bug class — stale `activeResponseId` persisted in localStorage caused infinite polling loops. Storing full session state (including messages for top 20 sessions) in localStorage felt wrong: the server is the source of truth, and `mergeServerSessions()` always fetches the canonical list on load. The localStorage copy was a stale cache that caused more problems than it solved.

**Cross-tab discovery:** `pollSidebarStatus()` polls `/v1/sessions/status` every 2-30s but only updated busy/idle indicators for *known* sessions. Sessions created in other tabs were silently ignored (`if (!row) continue` in `updateSidebarStatus`). Now when the status response contains session IDs not in `state.sessions`, we trigger `mergeServerSessions()` to pick them up.

## Changes

**app-core.js:**
- Remove `sessions` from `STORAGE_KEYS`
- `loadSessions()` returns `[]` and cleans up the legacy `term_llm_sessions` key
- `saveSessions()` only persists `activeSession` and `draftSessionActive`
- Add `evictStaleSessionMessages()` — caps in-memory message caches at 10 most recent sessions (replaces `sessionsForStorage`)

**app-sessions.js:**
- `pollSidebarStatus()` detects unknown session IDs in status response and calls `mergeServerSessions()` to discover them
- Comment fix: "localStorage-only" → "in-memory-only"

**app_sessions_test.js:**
- Remove `term_llm_sessions` from `initialStorage` in two test cases (sessions come from server mock via `mergeServerSessions()`)
