### PR TITLE
fix: Response-run SSE/recovery emits empty call_id for tool calls that only set Event.ToolCallID

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -794,10 +794,14 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 			return nil
 		}
 		state.toolsSeen = true
+		toolCallID := strings.TrimSpace(ev.ToolCallID)
+		if toolCallID == "" {
+			toolCallID = strings.TrimSpace(ev.Tool.ID)
+		}
 		item := map[string]any{
-			"id":        "fc_" + ev.Tool.ID,
+			"id":        "fc_" + toolCallID,
 			"type":      "function_call",
-			"call_id":   ev.Tool.ID,
+			"call_id":   toolCallID,
 			"name":      ev.Tool.Name,
 			"arguments": string(ev.Tool.Arguments),
 		}

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -1,10 +1,67 @@
 package cmd
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
 )
+
+func TestAppendResponseRunEventUsesToolCallIDForFunctionCallItems(t *testing.T) {
+	run := newResponseRun("resp_toolcall", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	state := &responseRunStreamState{}
+
+	err := (&serveServer{}).appendResponseRunEvent(&serveRuntime{}, run, state, llm.Event{
+		Type:       llm.EventToolCall,
+		ToolCallID: "call_123",
+		Tool: &llm.ToolCall{
+			Name:      "fetch_url",
+			Arguments: json.RawMessage(`{"url":"https://example.com"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("appendResponseRunEvent failed: %v", err)
+	}
+
+	if len(run.events) < 1 {
+		t.Fatal("expected stored events")
+	}
+	if run.events[0].Event != "response.output_item.added" {
+		t.Fatalf("expected first event to be response.output_item.added, got %s", run.events[0].Event)
+	}
+
+	var payload struct {
+		Item struct {
+			ID        string `json:"id"`
+			CallID    string `json:"call_id"`
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(run.events[0].Data, &payload); err != nil {
+		t.Fatalf("unmarshal stored event payload: %v", err)
+	}
+	if payload.Item.ID != "fc_call_123" {
+		t.Fatalf("expected item id fc_call_123, got %q", payload.Item.ID)
+	}
+	if payload.Item.CallID != "call_123" {
+		t.Fatalf("expected call_id call_123, got %q", payload.Item.CallID)
+	}
+
+	run.mu.Lock()
+	defer run.mu.Unlock()
+	if len(run.recoveryMessages) != 1 {
+		t.Fatalf("expected 1 recovery message, got %d", len(run.recoveryMessages))
+	}
+	if len(run.recoveryMessages[0].Tools) != 1 {
+		t.Fatalf("expected 1 recovery tool, got %d", len(run.recoveryMessages[0].Tools))
+	}
+	if run.recoveryMessages[0].Tools[0].ID != "call_123" {
+		t.Fatalf("expected recovery tool ID call_123, got %q", run.recoveryMessages[0].Tools[0].ID)
+	}
+}
 
 func TestResponseRunSubscriberSurvivesUpToBufferLimit(t *testing.T) {
 	run := newResponseRun("resp_test1", "sess_test", "", "mock", time.Now().Unix(), func() {})


### PR DESCRIPTION
## What

Fix response-run tool-call SSE/recovery events to prefer `Event.ToolCallID` before falling back to `Event.Tool.ID` when building `response.output_item.added` and `response.output_item.done` payloads.

Add a regression test covering tool-call events where providers only populate `ToolCallID`.

## Why

Some providers leave `Tool.ID` empty while still setting `Event.ToolCallID`. The response-run bridge was using `Tool.ID` for both `id` and `call_id`, which could emit blank tool call identifiers in replay/recovery events even though later `response.tool_exec.*` events had the real call ID. That broke client-side matching after reconnects.
