### PR TITLE
fix: read_url tool allows SSRF and leaks private URLs to a third-party fetch service

### DIFF
--- a/internal/llm/read_url_tool.go
+++ b/internal/llm/read_url_tool.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -14,6 +16,10 @@ const (
 	ReadURLToolName = "read_url"
 	maxReadURLChars = 50000
 )
+
+var readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+	return net.DefaultResolver.LookupIP(ctx, "ip", host)
+}
 
 // ReadURLTool fetches web pages using Jina AI Reader.
 type ReadURLTool struct {
@@ -73,10 +79,9 @@ func (t *ReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOu
 		return ToolOutput{}, fmt.Errorf("url is required")
 	}
 
-	// Ensure URL has a scheme
-	url := payload.URL
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
-		url = "https://" + url
+	url, err := normalizeReadURLTarget(ctx, payload.URL)
+	if err != nil {
+		return ToolOutput{}, err
 	}
 
 	// Fetch via Jina AI Reader
@@ -115,4 +120,64 @@ func (t *ReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOu
 	}
 
 	return TextOutput(content), nil
+}
+
+func normalizeReadURLTarget(ctx context.Context, rawURL string) (string, error) {
+	targetURL := rawURL
+	if !strings.HasPrefix(strings.ToLower(targetURL), "http://") && !strings.HasPrefix(strings.ToLower(targetURL), "https://") {
+		targetURL = "https://" + targetURL
+	}
+
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return "", fmt.Errorf("url scheme must be http or https")
+	}
+
+	host := strings.TrimSuffix(strings.ToLower(parsedURL.Hostname()), ".")
+	if host == "" {
+		return "", fmt.Errorf("url host is required")
+	}
+	if isBlockedReadURLHost(host) {
+		return "", fmt.Errorf("url host is not allowed")
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if isBlockedReadURLIP(ip) {
+			return "", fmt.Errorf("url host is not allowed")
+		}
+		return targetURL, nil
+	}
+
+	ips, err := readURLLookupIP(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("resolve url host: %w", err)
+	}
+	for _, ip := range ips {
+		if isBlockedReadURLIP(ip) {
+			return "", fmt.Errorf("url host is not allowed")
+		}
+	}
+
+	return targetURL, nil
+}
+
+func isBlockedReadURLHost(host string) bool {
+	switch host {
+	case "localhost", "metadata.google.internal", "metadata.goog":
+		return true
+	}
+
+	return strings.HasSuffix(host, ".localhost")
+}
+
+func isBlockedReadURLIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
 }

--- a/internal/llm/read_url_tool_test.go
+++ b/internal/llm/read_url_tool_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -34,10 +35,18 @@ func (r *failAfterNReadCloser) Close() error {
 }
 
 func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
 	readErr := errors.New("read past limit")
+	capturedURL := ""
 	tool := NewReadURLTool()
 	tool.client = &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			capturedURL = req.URL.String()
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body: &failAfterNReadCloser{
@@ -58,6 +67,9 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
+	if got, want := capturedURL, "https://r.jina.ai/https://example.com/article"; got != want {
+		t.Fatalf("expected fetch URL %q, got %q", want, got)
+	}
 	if strings.Contains(out.Content, readErr.Error()) {
 		t.Fatalf("expected limited read to avoid body read error, got %q", out.Content)
 	}
@@ -75,6 +87,76 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 	}
 	if out.Content[:32] != strings.Repeat("a", 32) {
 		t.Fatalf("expected response body prefix to be preserved")
+	}
+}
+
+func TestReadURLToolExecuteRejectsPrivateHosts(t *testing.T) {
+	blockedURLs := []string{
+		"localhost",
+		"http://127.0.0.1/admin",
+		"https://10.0.0.1/status",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]/",
+		"https://metadata.google.internal/computeMetadata/v1/",
+	}
+
+	for _, rawURL := range blockedURLs {
+		t.Run(rawURL, func(t *testing.T) {
+			called := false
+			tool := NewReadURLTool()
+			tool.client = &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					called = true
+					return nil, errors.New("request should not be sent")
+				}),
+			}
+
+			args, err := json.Marshal(map[string]string{"url": rawURL})
+			if err != nil {
+				t.Fatalf("marshal args: %v", err)
+			}
+
+			_, err = tool.Execute(context.Background(), args)
+			if err == nil || !strings.Contains(err.Error(), "url host is not allowed") {
+				t.Fatalf("expected blocked host error, got %v", err)
+			}
+			if called {
+				t.Fatalf("expected blocked host to prevent outbound request")
+			}
+		})
+	}
+}
+
+func TestReadURLToolExecuteRejectsHostsResolvingToPrivateIPs(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		if host != "intranet.example.com" {
+			t.Fatalf("unexpected host lookup %q", host)
+		}
+		return []net.IP{net.ParseIP("10.0.0.25")}, nil
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
+	called := false
+	tool := NewReadURLTool()
+	tool.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			return nil, errors.New("request should not be sent")
+		}),
+	}
+
+	args, err := json.Marshal(map[string]string{"url": "https://intranet.example.com/status"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	_, err = tool.Execute(context.Background(), args)
+	if err == nil || !strings.Contains(err.Error(), "url host is not allowed") {
+		t.Fatalf("expected blocked host error, got %v", err)
+	}
+	if called {
+		t.Fatalf("expected blocked host to prevent outbound request")
 	}
 }
 


### PR DESCRIPTION
## What

- validate read_url targets before sending them to the Jina reader service
- reject localhost, metadata-service hostnames, and hosts that resolve to loopback, RFC1918/private, link-local, multicast, or unspecified IPs
- add focused tests covering allowed public targets and blocked private/internal targets

## Why

The read_url tool was forwarding arbitrary http/https URLs to https://r.jina.ai/ without checking whether they pointed at private or internal network locations. That allowed SSRF-style requests and disclosed sensitive internal URLs to a third-party fetch service. This change blocks unsafe targets before any outbound request is made.
