### PR TITLE
fix: Fresh /v1/responses requests can be wrongly rejected for provider mismatch

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -977,6 +977,17 @@ func (s *serveServer) runtimeForRequest(ctx context.Context, sessionID string) (
 	return rt, true, nil
 }
 
+func runtimeProviderKey(rt *serveRuntime) string {
+	if rt == nil {
+		return ""
+	}
+	provider := strings.TrimSpace(rt.providerKey)
+	if provider == "" && rt.provider != nil {
+		provider = strings.TrimSpace(rt.provider.Name())
+	}
+	return provider
+}
+
 // runtimeForProviderRequest creates a runtime using a specific (non-default) provider.
 func (s *serveServer) runtimeForProviderRequest(ctx context.Context, sessionID string, providerName string) (*serveRuntime, bool, error) {
 	if s.runtimeFactory == nil {
@@ -1012,14 +1023,91 @@ func (s *serveServer) runtimeForProviderRequest(ctx context.Context, sessionID s
 	}
 	// Belt-and-suspenders: also check the live runtime in case the store
 	// missed (new session not yet persisted, store error, etc.).
-	existingProvider := strings.TrimSpace(rt.providerKey)
-	if existingProvider == "" && rt.provider != nil {
-		existingProvider = strings.TrimSpace(rt.provider.Name())
-	}
+	existingProvider := runtimeProviderKey(rt)
 	if existingProvider != "" && providerName != "" && existingProvider != providerName {
 		return nil, false, fmt.Errorf("session %q already uses provider %q (requested %q)", sessionID, existingProvider, providerName)
 	}
 	return rt, true, nil
+}
+
+// runtimeForFreshProviderRequest starts a fresh conversation for a non-default
+// provider, even when the caller reuses an existing session ID.
+func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessionID string, providerName string) (*serveRuntime, bool, error) {
+	if s.runtimeFactory == nil {
+		return s.runtimeForRequest(ctx, sessionID)
+	}
+	if sessionID == "" {
+		rt, err := s.runtimeFactory(ctx, providerName, "")
+		if err != nil {
+			return nil, false, err
+		}
+		return rt, false, nil
+	}
+	if existing, ok := s.sessionMgr.Get(sessionID); ok {
+		existingProvider := runtimeProviderKey(existing)
+		if existingProvider != "" && providerName != "" && existingProvider != providerName {
+			evicted, err := s.sessionMgr.DeleteIfIdle(sessionID)
+			if err != nil {
+				return nil, false, err
+			}
+			if evicted != nil {
+				s.unregisterResponseIDs(evicted)
+				evicted.Close()
+			}
+		}
+	}
+	rt, err := s.sessionMgr.GetOrCreateWith(ctx, sessionID, func(ctx context.Context) (*serveRuntime, error) {
+		return s.runtimeFactory(ctx, providerName, "")
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	existingProvider := runtimeProviderKey(rt)
+	if existingProvider != "" && providerName != "" && existingProvider != providerName {
+		return nil, false, fmt.Errorf("session %q already uses provider %q (requested %q)", sessionID, existingProvider, providerName)
+	}
+	return rt, true, nil
+}
+
+func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID string, rt *serveRuntime) {
+	if s.store == nil || sessionID == "" || rt == nil {
+		return
+	}
+	sess, err := s.store.Get(ctx, sessionID)
+	if err != nil || sess == nil {
+		return
+	}
+	providerKey := strings.TrimSpace(rt.providerKey)
+	providerName := providerKey
+	if rt.provider != nil {
+		if name := strings.TrimSpace(rt.provider.Name()); name != "" {
+			providerName = name
+		}
+	}
+	modelName := strings.TrimSpace(rt.defaultModel)
+	changed := false
+	if providerName != "" && sess.Provider != providerName {
+		sess.Provider = providerName
+		changed = true
+	}
+	if providerKey != "" && sess.ProviderKey != providerKey {
+		sess.ProviderKey = providerKey
+		changed = true
+	}
+	if modelName != "" && sess.Model != modelName {
+		sess.Model = modelName
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	if err := s.store.Update(ctx, sess); err != nil {
+		log.Printf("[serve] session Update failed for %s: %v", sessionID, err)
+		return
+	}
+	rt.mu.Lock()
+	rt.sessionMeta = sess
+	rt.mu.Unlock()
 }
 
 func (s *serveServer) handlePushSubscribe(w http.ResponseWriter, r *http.Request) {

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -90,16 +90,20 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 	var runtime *serveRuntime
 	var stateful bool
+	freshProviderRequest := req.PreviousResponseID == "" && reqProvider != "" && reqProvider != defaultProvider
 	if req.PreviousResponseID != "" {
 		runtime, stateful, err = s.runtimeForProviderRequest(ctx, sessionID, reqProvider)
-	} else if reqProvider == "" || reqProvider == defaultProvider {
+	} else if !freshProviderRequest {
 		runtime, stateful, err = s.runtimeForRequest(ctx, sessionID)
 	} else {
-		runtime, stateful, err = s.runtimeForProviderRequest(ctx, sessionID, reqProvider)
+		runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, reqProvider)
 	}
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
+	}
+	if freshProviderRequest {
+		s.syncPersistedSessionRuntime(ctx, sessionID, runtime)
 	}
 
 	// Enforce chaining from the latest response only. Stale response IDs that

--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -272,6 +272,24 @@ func (m *serveSessionManager) GetOrCreateWith(ctx context.Context, id string, cr
 	return inflight.rt, nil
 }
 
+// DeleteIfIdle removes a session runtime only when it is not active.
+func (m *serveSessionManager) DeleteIfIdle(id string) (*serveRuntime, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if inflight, ok := m.creating[id]; ok && inflight != nil {
+		return nil, errServeSessionBusy
+	}
+	rt, ok := m.sessions[id]
+	if !ok {
+		return nil, nil
+	}
+	if rt.hasActiveRun() {
+		return nil, errServeSessionBusy
+	}
+	delete(m.sessions, id)
+	return rt, nil
+}
+
 // ActiveSessionIDs returns the set of session IDs that currently have an
 // active run (activeInterrupt != nil). Unlike Get, this does NOT touch
 // runtimes, so it won't extend their TTL.

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3371,6 +3371,95 @@ func TestHandleResponses_PreviousResponseIDRestoresPersistedProviderAfterRuntime
 	}
 }
 
+func TestHandleResponses_FreshProviderRequestCanReuseSessionID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	var defaultCreates atomic.Int32
+	var otherCreates atomic.Int32
+
+	newRuntime := func(providerName, response string) *serveRuntime {
+		provider := llm.NewMockProvider(providerName).AddTextResponse(response)
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  providerName,
+			engine:       engine,
+			defaultModel: providerName + "-model",
+			store:        store,
+		}
+		rt.Touch()
+		return rt
+	}
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		createNum := defaultCreates.Add(1)
+		return newRuntime("default", fmt.Sprintf("default response %d", createNum)), nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfgRef:     &config.Config{DefaultProvider: "default"},
+		sessionMgr: manager,
+		store:      store,
+		runtimeFactory: func(ctx context.Context, providerName string, model string) (*serveRuntime, error) {
+			createNum := otherCreates.Add(1)
+			return newRuntime(providerName, fmt.Sprintf("%s response %d", providerName, createNum)), nil
+		},
+	}
+
+	code, _ := doResponsesWithHeader(t, srv, `{"input":"hello"}`, "provider-reuse")
+	if code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", code)
+	}
+
+	code, resp := doResponsesWithHeader(t, srv, `{"input":"fresh","provider":"other"}`, "provider-reuse")
+	if code != http.StatusOK {
+		t.Fatalf("fresh provider request status = %d, want 200", code)
+	}
+
+	output, ok := resp["output"].([]any)
+	if !ok || len(output) == 0 {
+		t.Fatalf("response output = %#v, want assistant message", resp["output"])
+	}
+	msg, ok := output[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first output item = %#v, want object", output[0])
+	}
+	content, ok := msg["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("message content = %#v, want output_text", msg["content"])
+	}
+	part, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first content part = %#v, want object", content[0])
+	}
+	if got := part["text"]; got != "other response 1" {
+		t.Fatalf("response text = %v, want %q", got, "other response 1")
+	}
+
+	sess, err := store.Get(context.Background(), "provider-reuse")
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected persisted session")
+	}
+	if sess.ProviderKey != "other" {
+		t.Fatalf("ProviderKey = %q, want other", sess.ProviderKey)
+	}
+	if got := defaultCreates.Load(); got != 1 {
+		t.Fatalf("default provider factory calls = %d, want 1", got)
+	}
+	if got := otherCreates.Load(); got != 1 {
+		t.Fatalf("other provider factory calls = %d, want 1", got)
+	}
+}
+
 func TestHandleResponses_NoPreviousResponseIDStartsFresh(t *testing.T) {
 	// Each runtime gets 2 responses so it can handle being reused
 	srv := newTestServeServer("reply1", "reply2")


### PR DESCRIPTION
## What

- treat `/v1/responses` requests without `previous_response_id` as fresh even when they reuse an existing `session_id` and specify a non-default provider
- replace any cached runtime that was created for a different provider before creating the fresh-provider runtime
- sync persisted session provider metadata for the fresh conversation and add a regression test covering the reused-session case

## Why

Fresh `/v1/responses` requests are documented to start a new conversation unless they explicitly chain with `previous_response_id`. Before this change, a request could still be rejected with `session already uses provider X` just because the same `session_id` had previously been used with another provider. This caused incorrect 4xx responses for valid fresh conversations.
