### PR TITLE
feat(ui): only syntax-highlight code blocks with explicit language, add copy button

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -153,6 +153,39 @@ func TestAppSessionsJS(t *testing.T) {
 	}
 }
 
+func TestStaticAssetsSupportCodeBlockUX(t *testing.T) {
+	renderJS, err := StaticAsset("app-render.js")
+	if err != nil {
+		t.Fatalf("StaticAsset(app-render.js): %v", err)
+	}
+	renderSrc := string(renderJS)
+	for _, want := range []string{
+		`/\blanguage-\w+/.test(code.className)`,
+		`btn.className = 'code-copy-btn'`,
+		`navigator.clipboard.writeText(text)`,
+		`btn.classList.add('copied')`,
+	} {
+		if !strings.Contains(renderSrc, want) {
+			t.Fatalf("app-render.js missing %q", want)
+		}
+	}
+
+	css, err := StaticAsset("app.css")
+	if err != nil {
+		t.Fatalf("StaticAsset(app.css): %v", err)
+	}
+	cssSrc := string(css)
+	for _, want := range []string{
+		".code-copy-btn",
+		".code-copy-btn.copied",
+		".markdown-body pre:hover .code-copy-btn",
+	} {
+		if !strings.Contains(cssSrc, want) {
+			t.Fatalf("app.css missing %q", want)
+		}
+	}
+}
+
 func TestStaticAssetsSupportSessionStreamDetachOnSwitch(t *testing.T) {
 	sessionsJS, err := StaticAsset("app-sessions.js")
 	if err != nil {

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -380,7 +380,32 @@ const decorateAssistantFragment = (target) => {
     a.rel = 'noopener noreferrer';
   });
   target.querySelectorAll('pre code').forEach((code) => {
-    hljs.highlightElement(code);
+    if (/\blanguage-\w+/.test(code.className)) {
+      hljs.highlightElement(code);
+    }
+  });
+  target.querySelectorAll('pre').forEach((pre) => {
+    if (pre.querySelector('.code-copy-btn')) return;
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'code-copy-btn';
+    btn.title = 'Copy';
+    btn.setAttribute('aria-label', 'Copy code');
+    btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+    btn.addEventListener('click', () => {
+      const code = pre.querySelector('code');
+      const text = code ? code.textContent : pre.textContent;
+      navigator.clipboard.writeText(text).then(() => {
+        btn.classList.add('copied');
+        btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+        }, 1500);
+      });
+    });
+    pre.style.position = 'relative';
+    pre.appendChild(btn);
   });
 };
 

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -833,6 +833,40 @@
       font-size: 0.87rem;
     }
 
+    .code-copy-btn {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      width: 28px;
+      height: 28px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--text-muted);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+      padding: 0;
+      z-index: 1;
+    }
+
+    .markdown-body pre:hover .code-copy-btn {
+      opacity: 1;
+    }
+
+    .code-copy-btn:hover {
+      background: var(--surface-2);
+      color: var(--text);
+    }
+
+    .code-copy-btn.copied {
+      color: var(--accent-green);
+      opacity: 1;
+    }
+
     .markdown-body :not(pre) > code {
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
       background: var(--surface-2);

--- a/internal/serveui/static/markdown_test.js
+++ b/internal/serveui/static/markdown_test.js
@@ -61,6 +61,24 @@ const cases = [
     contains: ['<del>wrong</del>'],
     absent: [],
   },
+  {
+    name: 'fenced code with language gets language class',
+    input: '```ruby\nputs "hello"\n```',
+    contains: ['<code class="language-ruby">'],
+    absent: [],
+  },
+  {
+    name: 'fenced code without language gets no language class',
+    input: '```\nplain text\n```',
+    contains: ['<code>'],
+    absent: ['language-'],
+  },
+  {
+    name: 'fenced code with sql language gets language class',
+    input: '```sql\nSELECT 1;\n```',
+    contains: ['<code class="language-sql">'],
+    absent: [],
+  },
 ];
 
 for (const tc of cases) {


### PR DESCRIPTION
Two web UI improvements for code blocks:

**1. Conditional syntax highlighting**
Plain fenced code blocks (```  with no language) were getting auto-highlighted by hljs, which produced confusing/wrong coloring on plain text output. Now `hljs.highlightElement()` only runs when the `<code>` element has a `language-*` class (i.e. the user specified ```ruby, ```sql, etc).

**2. Copy-to-clipboard button**
Every `<pre>` block gets a copy button (clipboard icon) that appears on hover. Clicking it copies the code text via `navigator.clipboard` and shows a checkmark for 1.5s as confirmation.

**Tests:**
- `markdown_test.js`: 3 new cases verifying marked produces `language-*` classes only when a language is specified
- `embed_test.go`: `TestStaticAssetsSupportCodeBlockUX` asserts the new JS patterns (language gate, copy button, clipboard API) and CSS selectors are present in embedded assets