### PR TITLE
feat(ui): smooth web assistant streaming tail renders

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -371,20 +371,28 @@ const deferEmbeddedVideos = (target) => {
 
 const assistantStreamStates = new Map();
 
-const decorateAssistantFragment = (target) => {
+const decorateAssistantFragment = (target, options = {}) => {
   if (!target) return;
+  const streaming = Boolean(options.streaming);
   deferEmbeddedVideos(target);
-  renderMath(target);
   target.querySelectorAll('a').forEach((a) => {
     a.target = '_blank';
     a.rel = 'noopener noreferrer';
   });
-  target.querySelectorAll('pre code').forEach((code) => {
-    if (/\blanguage-\w+/.test(code.className)) {
-      hljs.highlightElement(code);
-    }
-  });
+  if (!streaming) {
+    renderMath(target);
+    target.querySelectorAll('pre code').forEach((code) => {
+      if (/\blanguage-\w+/.test(code.className)) {
+        hljs.highlightElement(code);
+      }
+    });
+  }
   target.querySelectorAll('pre').forEach((pre) => {
+    if (streaming) {
+      const existingBtn = pre.querySelector('.code-copy-btn');
+      if (existingBtn) existingBtn.remove();
+      return;
+    }
     if (pre.querySelector('.code-copy-btn')) return;
     const btn = document.createElement('button');
     btn.type = 'button';
@@ -409,7 +417,7 @@ const decorateAssistantFragment = (target) => {
   });
 };
 
-const renderAssistantMarkdown = (target, content) => {
+const renderAssistantMarkdown = (target, content, options = {}) => {
   if (!target) return;
   applyTextDirection(target, content || '');
   const html = marked.parse(content || '');
@@ -418,7 +426,7 @@ const renderAssistantMarkdown = (target, content) => {
     ADD_ATTR: ['controls', 'playsinline', 'muted', 'loop', 'autoplay', 'poster', 'preload']
   });
   target.innerHTML = clean;
-  decorateAssistantFragment(target);
+  decorateAssistantFragment(target, options);
 };
 
 const disposeAssistantStreamState = (messageId) => {
@@ -515,6 +523,46 @@ const scheduleAssistantStreamRender = (streamState) => {
   streamState.timerId = window.setTimeout(enqueueFrame, renderDelay - elapsed);
 };
 
+const clearAssistantTailRender = (streamState) => {
+  if (!streamState?.tailContainer) return;
+  streamState.tailContainer.classList.remove('streaming-plain-text');
+  streamState.tailContainer.innerHTML = '';
+  streamState.tailTextNode = null;
+  streamState.lastTailSource = '';
+};
+
+const renderAssistantTailPlainText = (streamState, tail) => {
+  const container = streamState?.tailContainer;
+  if (!container) return;
+  container.classList.add('streaming-plain-text');
+
+  let textNode = streamState.tailTextNode;
+  if (!textNode || textNode.parentNode !== container) {
+    container.innerHTML = '';
+    textNode = document.createTextNode('');
+    container.appendChild(textNode);
+    streamState.tailTextNode = textNode;
+    streamState.lastTailSource = '';
+  }
+
+  if (tail.startsWith(streamState.lastTailSource || '')) {
+    textNode.textContent += tail.slice(streamState.lastTailSource.length);
+  } else {
+    textNode.textContent = tail;
+  }
+
+  streamState.lastTailSource = tail;
+};
+
+const renderAssistantTailMarkdown = (streamState, tail) => {
+  const container = streamState?.tailContainer;
+  if (!container) return;
+  container.classList.remove('streaming-plain-text');
+  streamState.tailTextNode = null;
+  renderAssistantMarkdown(container, tail, { streaming: true });
+  streamState.lastTailSource = tail;
+};
+
 const performAssistantStreamRender = (streamState) => {
   if (!streamState || !streamState.body) return;
   streamState.rafId = 0;
@@ -551,9 +599,18 @@ const performAssistantStreamRender = (streamState) => {
     const tail = content.slice(streamState.committedLength);
     if (tail !== streamState.lastTailContent) {
       if (tail) {
-        renderAssistantMarkdown(streamState.tailContainer, tail);
+        const renderPlainTail = Boolean(
+          app.markdownStreaming
+          && typeof app.markdownStreaming.canStreamPlainTextTail === 'function'
+          && app.markdownStreaming.canStreamPlainTextTail(tail)
+        );
+        if (renderPlainTail) {
+          renderAssistantTailPlainText(streamState, tail);
+        } else {
+          renderAssistantTailMarkdown(streamState, tail);
+        }
       } else {
-        streamState.tailContainer.innerHTML = '';
+        clearAssistantTailRender(streamState);
       }
       streamState.lastTailContent = tail;
     }

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -781,6 +781,10 @@
       display: none;
     }
 
+    .markdown-stream-tail.streaming-plain-text {
+      white-space: pre-wrap;
+    }
+
     .markdown-stream-piece > :first-child {
       margin-top: 0;
     }

--- a/internal/serveui/static/markdown-streaming.js
+++ b/internal/serveui/static/markdown-streaming.js
@@ -39,6 +39,8 @@
       committedLength: 0,
       latestContent: '',
       lastTailContent: '',
+      lastTailSource: '',
+      tailTextNode: null,
       dirty: false,
       rendering: false,
       rafId: 0,
@@ -312,6 +314,39 @@
     return fallback;
   }
 
+  function containsMarkdownBlockSyntax(text) {
+    return /^\s{0,3}(?:#{1,6}\s|>\s|[-+*]\s|\d+[.)]\s|```|~~~)/m.test(text)
+      || /^\s*\|.*\|\s*$/m.test(text)
+      || /^\s*[-:| ]+\|[-:| ]*$/m.test(text);
+  }
+
+  function containsMarkdownInlineSyntax(text) {
+    if (/`/.test(text)) return true;
+    if (/\[[^\]]*\]\([^\n)]+\)/.test(text)) return true;
+    if (/(^|[^\\])!\[[^\]]*\]\([^\n)]+\)/.test(text)) return true;
+    if (/(\*\*|~~)/.test(text)) return true;
+    if (/<[A-Za-z!/][^>]*>/.test(text)) return true;
+    if (/^\s*---+\s*$/m.test(text) || /^\s*===+\s*$/m.test(text)) return true;
+
+    for (let i = 0; i < text.length; i += 1) {
+      const ch = text[i];
+      if (ch === '*' && isSingleAsteriskDelimiter(text, i)) return true;
+      if (ch === '*' && text[i + 1] === '*' && isDoubleAsteriskDelimiter(text, i)) return true;
+      if (ch === '_' && isUnderscoreDelimiter(text, i)) return true;
+    }
+
+    return false;
+  }
+
+  function canStreamPlainTextTail(text) {
+    const value = String(text || '');
+    if (!value) return true;
+    if (isInCodeBlockFast(value, value.length)) return false;
+    if (containsMarkdownBlockSyntax(value)) return false;
+    if (containsMarkdownInlineSyntax(value)) return false;
+    return true;
+  }
+
   function findStreamingBoundary(content, lastCommittedLength) {
     const text = String(content || '');
     const lastCommitted = Math.max(0, Number(lastCommittedLength) || 0);
@@ -347,6 +382,7 @@
     isInCodeBlockFast,
     areInlineMarkersBalanced,
     areMathDelimitersBalanced,
+    canStreamPlainTextTail,
     findStreamingBoundary
   };
 });

--- a/internal/serveui/static/markdown_streaming_test.js
+++ b/internal/serveui/static/markdown_streaming_test.js
@@ -101,6 +101,31 @@ expectEqual('nextStreamingRenderDelay medium', streaming.nextStreamingRenderDela
 expectEqual('nextStreamingRenderDelay large', streaming.nextStreamingRenderDelay(40000), 150);
 expectEqual('nextStreamingRenderDelay huge', streaming.nextStreamingRenderDelay(200000), 250);
 
+expectTrue(
+  'canStreamPlainTextTail accepts ordinary prose',
+  streaming.canStreamPlainTextTail('This is just a steadily growing paragraph\nwith another plain line.')
+);
+expectTrue(
+  'canStreamPlainTextTail accepts snake_case prose',
+  streaming.canStreamPlainTextTail('term_llm keeps file_name.go untouched while streaming prose.')
+);
+expectFalse(
+  'canStreamPlainTextTail rejects emphasis markers',
+  streaming.canStreamPlainTextTail('This has *emphasis* in it.')
+);
+expectFalse(
+  'canStreamPlainTextTail rejects markdown links',
+  streaming.canStreamPlainTextTail('See [docs](https://example.com) for details.')
+);
+expectFalse(
+  'canStreamPlainTextTail rejects list blocks',
+  streaming.canStreamPlainTextTail('- first item\n- second item')
+);
+expectFalse(
+  'canStreamPlainTextTail rejects fenced code blocks',
+  streaming.canStreamPlainTextTail('```js\nconsole.log(1);\n```')
+);
+
 if (failures > 0) {
   console.error('\n' + failures + ' test(s) failed');
   process.exit(1);


### PR DESCRIPTION
## What

Tightens web assistant streaming so the active tail does much less work while a response is still arriving:

- render plain prose tails by appending text instead of reparsing markdown on every update
- skip KaTeX, syntax highlighting, and copy-button work for in-progress markdown tails
- keep the existing full markdown pass for committed blocks and the final completed message
- add tests for the new plain-text tail heuristic

## Why

The current web UI already commits stable blocks incrementally, but it still fully reparses and redecorates the active tail on each update. That is where most of the perceived jank lives during long prose responses and open code fences.

This keeps the high-payoff path simple:

- ordinary prose streams as cheap text appends
- markdown tails still render, but without the expensive final-pass decorations until completion
- completed output still gets the full rich render

## Verification

- `node internal/serveui/static/markdown_streaming_test.js`
- `node internal/serveui/static/app_stream_test.js`
- `node -c internal/serveui/static/app-render.js`
- `go test ./internal/serveui/...`
- `go build ./...`
- `go test ./...`
