### PR TITLE
Collapse whitespace-only diff changes to single ~ line

### DIFF
--- a/internal/ui/inline_diff.go
+++ b/internal/ui/inline_diff.go
@@ -172,6 +172,9 @@ var (
 	// Stronger backgrounds for word-level changes within a line
 	diffAddBgStrong    = [3]int{40, 90, 40} // brighter green for changed words
 	diffRemoveBgStrong = [3]int{90, 40, 40} // brighter red for changed words
+
+	// Subtle background for whitespace-only changes (collapsed to single line)
+	diffWsBg = [3]int{35, 35, 50} // subtle blue-grey tint
 )
 
 // PrintCompactDiff prints a compact diff with 2 lines of context and line numbers

--- a/internal/ui/unified_diff.go
+++ b/internal/ui/unified_diff.go
@@ -56,8 +56,28 @@ func printUnifiedDiffInternal(filePath, oldContent, newContent string, _ bool) {
 
 	// Track current line numbers
 	var oldLineNum, newLineNum int
-	var deletionOffset int // Tracks position within a deletion block
 	hunkCount := 0
+
+	// Buffer for removal lines (to pair with additions)
+	type removal struct {
+		content string
+		lineNum int
+	}
+	var remBuf []removal
+
+	// Flush buffered removals as plain red lines
+	flushRemovals := func() {
+		for _, rem := range remBuf {
+			highlighted := rem.content
+			if highlighter != nil {
+				highlighted = highlighter.HighlightLineWithBg(rem.content, diffRemoveBg)
+			} else {
+				highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffRemoveBg[0], diffRemoveBg[1], diffRemoveBg[2], rem.content)
+			}
+			fmt.Printf("\x1b[38;2;160;80;80m%*d- \x1b[0m%s\n", lineNumWidth, rem.lineNum, highlighted)
+		}
+		remBuf = nil
+	}
 
 	// Regex to parse hunk header: @@ -start,count +start,count @@
 	hunkRe := regexp.MustCompile(`^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
@@ -84,6 +104,7 @@ func printUnifiedDiffInternal(filePath, oldContent, newContent string, _ bool) {
 
 		switch prefix {
 		case '@':
+			flushRemovals()
 			// Parse hunk header to get starting line numbers
 			if matches := hunkRe.FindStringSubmatch(line); matches != nil {
 				oldLineNum, _ = strconv.Atoi(matches[1])
@@ -96,32 +117,57 @@ func printUnifiedDiffInternal(filePath, oldContent, newContent string, _ bool) {
 			hunkCount++
 
 		case '-':
-			// Removed line - red background, show virtual new file position
-			highlighted := content
-			if highlighter != nil {
-				highlighted = highlighter.HighlightLineWithBg(content, diffRemoveBg)
-			} else {
-				highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffRemoveBg[0], diffRemoveBg[1], diffRemoveBg[2], content)
-			}
-			fmt.Printf("\x1b[38;2;160;80;80m%*d- \x1b[0m%s\n", lineNumWidth, newLineNum+deletionOffset, highlighted)
+			// Buffer removal for pairing with additions
+			remBuf = append(remBuf, removal{content: content, lineNum: oldLineNum})
 			oldLineNum++
-			deletionOffset++
 
 		case '+':
-			// Added line - green background with new line number
-			deletionOffset = 0 // Reset deletion offset when we see additions
-			highlighted := content
-			if highlighter != nil {
-				highlighted = highlighter.HighlightLineWithBg(content, diffAddBg)
+			if len(remBuf) > 0 {
+				rem := remBuf[0]
+				remBuf = remBuf[1:]
+
+				if isWhitespaceOnlyChange(rem.content, content) {
+					// Whitespace-only: single ~ line
+					highlighted := content
+					if highlighter != nil {
+						highlighted = highlighter.HighlightLineWithBg(content, diffWsBg)
+					} else {
+						highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffWsBg[0], diffWsBg[1], diffWsBg[2], content)
+					}
+					fmt.Printf("\x1b[38;2;100;100;140m%*d~ \x1b[0m%s\n", lineNumWidth, newLineNum, highlighted)
+				} else {
+					// Different content: render removal then addition
+					highlighted := rem.content
+					if highlighter != nil {
+						highlighted = highlighter.HighlightLineWithBg(rem.content, diffRemoveBg)
+					} else {
+						highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffRemoveBg[0], diffRemoveBg[1], diffRemoveBg[2], rem.content)
+					}
+					fmt.Printf("\x1b[38;2;160;80;80m%*d- \x1b[0m%s\n", lineNumWidth, rem.lineNum, highlighted)
+
+					highlighted = content
+					if highlighter != nil {
+						highlighted = highlighter.HighlightLineWithBg(content, diffAddBg)
+					} else {
+						highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffAddBg[0], diffAddBg[1], diffAddBg[2], content)
+					}
+					fmt.Printf("\x1b[38;2;80;160;80m%*d+ \x1b[0m%s\n", lineNumWidth, newLineNum, highlighted)
+				}
 			} else {
-				highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffAddBg[0], diffAddBg[1], diffAddBg[2], content)
+				// Pure addition
+				highlighted := content
+				if highlighter != nil {
+					highlighted = highlighter.HighlightLineWithBg(content, diffAddBg)
+				} else {
+					highlighted = fmt.Sprintf("\x1b[48;2;%d;%d;%dm%s\x1b[0m", diffAddBg[0], diffAddBg[1], diffAddBg[2], content)
+				}
+				fmt.Printf("\x1b[38;2;80;160;80m%*d+ \x1b[0m%s\n", lineNumWidth, newLineNum, highlighted)
 			}
-			fmt.Printf("\x1b[38;2;80;160;80m%*d+ \x1b[0m%s\n", lineNumWidth, newLineNum, highlighted)
 			newLineNum++
 
 		case ' ':
+			flushRemovals()
 			// Context line - no background, show line number in grey
-			deletionOffset = 0 // Reset deletion offset when we see context
 			highlighted := content
 			if highlighter != nil {
 				highlighted = highlighter.HighlightLine(content)
@@ -135,6 +181,9 @@ func printUnifiedDiffInternal(filePath, oldContent, newContent string, _ bool) {
 			fmt.Println(line)
 		}
 	}
+
+	// Flush any remaining buffered removals
+	flushRemovals()
 }
 
 // HasDiff returns true if old and new content are different
@@ -533,6 +582,11 @@ func buildSegments(words []string, lcs []string) []diffSegment {
 	return segments
 }
 
+// isWhitespaceOnlyChange returns true if two lines differ only in whitespace.
+func isWhitespaceOnlyChange(oldLine, newLine string) bool {
+	return strings.TrimSpace(oldLine) == strings.TrimSpace(newLine)
+}
+
 // shouldUseWordDiff determines if word-level diff should be used for a line pair.
 // Returns true if lines are similar enough (>50% words in common).
 func shouldUseWordDiff(oldLine, newLine string) bool {
@@ -925,8 +979,15 @@ func RenderDiffSegment(filePath, oldContent, newContent string, width int, start
 				rem := removalBuffer[0]
 				removalBuffer = removalBuffer[1:]
 
-				// Check if word-diff should be used
-				if shouldUseWordDiff(rem.content, content) {
+				if isWhitespaceOnlyChange(rem.content, content) {
+					// Whitespace-only change: collapse to single ~ line
+					highlighted := content
+					if highlighter != nil {
+						highlighted = highlighter.HighlightLine(content)
+					}
+					b.WriteString(wrapDiffLine(lineNumWidth, newLineNum, '~', "\x1b[38;2;100;100;140m", highlighted, contentWidth, diffWsBg[:]))
+					renderedLines++
+				} else if shouldUseWordDiff(rem.content, content) {
 					oldSegs, newSegs := wordDiff(rem.content, content)
 					renderRemovalWithWordDiff(rem.content, rem.lineNum, oldSegs)
 					renderAdditionWithWordDiff(content, newLineNum, newSegs)

--- a/internal/ui/unified_diff_test.go
+++ b/internal/ui/unified_diff_test.go
@@ -21,8 +21,8 @@ func TestUnifiedDiffLineNumbers(t *testing.T) {
 			name:       "replacement with fewer lines",
 			oldContent: "line1\nold2\nold3\nold4\nline5\n",
 			newContent: "line1\nnew2\nline5\n",
-			// Context line1 (1), delete old2-old4 (virtual 2,3,4), add new2 (2), context line5 (3)
-			wantLines: []string{"1 ", "2-", "3-", "4-", "2+", "3 "},
+			// Context line1 (1), paired delete+add old2/new2 (2-,2+), remaining deletes (3-,4-), context line5 (3)
+			wantLines: []string{"1 ", "2-", "2+", "3-", "4-", "3 "},
 		},
 		{
 			name:       "replacement with more lines",
@@ -45,11 +45,18 @@ func TestUnifiedDiffLineNumbers(t *testing.T) {
 			// Context line1 (1), add new_line (2), context line2 (3)
 			wantLines: []string{"1 ", "2+", "3 "},
 		},
+		{
+			name:       "whitespace only change collapses to tilde",
+			oldContent: "line1\n    indented\nline3\n",
+			newContent: "line1\n        indented\nline3\n",
+			// Context line1 (1), whitespace-only ~ (2), context line3 (3)
+			wantLines: []string{"1 ", "2~", "3 "},
+		},
 	}
 
 	// Regex to extract line numbers from ANSI-colored output
-	// Matches patterns like "  1  " (context), "  2- " (deletion), "  3+ " (addition)
-	lineNumRe := regexp.MustCompile(`(\d+)([-+ ]) `)
+	// Matches patterns like "  1  " (context), "  2- " (deletion), "  3+ " (addition), "  2~ " (whitespace-only)
+	lineNumRe := regexp.MustCompile(`(\d+)([-+~ ]) `)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -283,6 +290,50 @@ func TestRenderDiffSegmentWordDiff(t *testing.T) {
 	}
 	if !strings.Contains(result, strongGreenBgPattern) {
 		t.Errorf("expected strong green background (40;90;40) for changed word, not found in output")
+	}
+}
+
+func TestIsWhitespaceOnlyChange(t *testing.T) {
+	tests := []struct {
+		old, new string
+		want     bool
+	}{
+		{"  foo", "    foo", true},
+		{"\tfoo", "    foo", true},
+		{"foo", "foo", true},
+		{"foo", "bar", false},
+		{"  foo bar", "foo bar", true},
+		{"  foo", "  bar", false},
+	}
+	for _, tt := range tests {
+		got := isWhitespaceOnlyChange(tt.old, tt.new)
+		if got != tt.want {
+			t.Errorf("isWhitespaceOnlyChange(%q, %q) = %v, want %v", tt.old, tt.new, got, tt.want)
+		}
+	}
+}
+
+func TestRenderDiffSegmentWhitespaceCollapse(t *testing.T) {
+	// Whitespace-only changes should produce a single ~ line with the ws background
+	oldContent := "    indented"
+	newContent := "        indented"
+
+	result := RenderDiffSegment("test.go", oldContent, newContent, 120, 1)
+
+	// Should contain the whitespace-only background color (35;35;50)
+	wsBgPattern := "48;2;35;35;50"
+	if !strings.Contains(result, wsBgPattern) {
+		t.Errorf("expected whitespace-only background (35;35;50), not found in output:\n%s", result)
+	}
+
+	// Should NOT contain the normal red/green removal/addition backgrounds
+	redBg := "48;2;60;30;30"
+	greenBg := "48;2;30;60;30"
+	if strings.Contains(result, redBg) {
+		t.Errorf("should not contain red removal background for whitespace-only change")
+	}
+	if strings.Contains(result, greenBg) {
+		t.Errorf("should not contain green addition background for whitespace-only change")
 	}
 }
 


### PR DESCRIPTION
## Problem

When only indentation changes, diff rendering produces alternating red/green line pairs (zebra striping) that make the diff unreadable. Every line shows as a full removal + addition even though only whitespace changed.

## Fix

When a paired `-`/`+` line differs only in whitespace (`strings.TrimSpace` comparison), collapse them into a single `~` line with a subtle blue-grey background (`rgb(35,35,50)`) instead of two separate red/green lines.

### Rendering paths changed

- **`RenderDiffSegment`** (web UI + TUI chat): already had `removalBuffer` pairing — added whitespace-only check before word-diff
- **`printUnifiedDiffInternal`** (CLI): restructured to add removal buffering (previously processed `-`/`+` independently), with `flushRemovals` on hunk headers, context lines, and end-of-diff

### Not changed

- **`PrintCompactDiff`** (TUI compact mode): renders all removals then all additions per hunk — would need a bigger refactor, deferred

## Tests

- `TestIsWhitespaceOnlyChange` — unit test for the helper
- `TestRenderDiffSegmentWhitespaceCollapse` — verifies `~` line uses ws background, no red/green backgrounds
- `TestUnifiedDiffLineNumbers/whitespace_only_change_collapses_to_tilde` — end-to-end CLI test
- Updated existing test expectation for new interleaved pairing order