### PR TITLE
fix: drain in-flight spawn runners before closing session store

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -250,7 +250,13 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	// Initialize session store and handle --resume BEFORE tool/MCP initialization
 	// so that session settings can override settings.Tools, settings.MCP, etc.
 	store, storeCleanup := InitSessionStore(cfg, cmd.ErrOrStderr())
-	defer storeCleanup()
+	var spawnRunner *SpawnAgentRunner
+	defer func() {
+		if spawnRunner != nil {
+			spawnRunner.Wait()
+		}
+		storeCleanup()
+	}()
 	var sess *session.Session
 	var sessionMessages []llm.Message
 
@@ -336,8 +342,10 @@ func runAsk(cmd *cobra.Command, args []string) error {
 
 		// Wire spawn_agent runner if enabled (with session tracking)
 		parentSessionID := sessionID
-		if err := WireSpawnAgentRunnerWithStore(cfg, toolMgr, askYolo, store, parentSessionID); err != nil {
-			return err
+		var wireErr error
+		spawnRunner, wireErr = WireSpawnAgentRunnerWithStore(cfg, toolMgr, askYolo, store, parentSessionID)
+		if wireErr != nil {
+			return wireErr
 		}
 
 	}

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -175,7 +175,15 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 
 	// Initialize session store EARLY so resume can override settings before tool/MCP setup
 	store, storeCleanup := InitSessionStore(cfg, cmd.ErrOrStderr())
-	defer storeCleanup()
+	var spawnRunner *SpawnAgentRunner
+	defer func() {
+		// Drain in-flight sub-agent runs before closing the store to avoid
+		// "database is closed" warnings from callbacks that outlive the store.
+		if spawnRunner != nil {
+			spawnRunner.Wait()
+		}
+		storeCleanup()
+	}()
 
 	var sess *session.Session
 	if resumeRequested {
@@ -315,11 +323,13 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 		if sess != nil {
 			parentSessionID = sess.ID
 		}
-		if err := WireSpawnAgentRunnerWithStore(cfg, toolMgr, chatYolo, store, parentSessionID); err != nil {
+		var wireErr error
+		spawnRunner, wireErr = WireSpawnAgentRunnerWithStore(cfg, toolMgr, chatYolo, store, parentSessionID)
+		if wireErr != nil {
 			if debugLogger != nil {
 				debugLogger.Close()
 			}
-			return "", "", err
+			return "", "", wireErr
 		}
 	} else if chatYolo {
 		approvalMgr.SetYoloMode(true)
@@ -559,6 +569,9 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 
 	// Handle /reload: close the store, then re-exec under the (potentially new) binary.
 	if m, ok := finalModel.(*chat.Model); ok && m.WantsReload() {
+		if spawnRunner != nil {
+			spawnRunner.Wait()
+		}
 		storeCleanup() // flush & close DB before replacing the process
 		sessionID := m.ReloadSessionID()
 		if execErr := execReload(sessionID); execErr != nil {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -415,25 +415,27 @@ func (s *SessionSettings) SetupToolManager(cfg *config.Config, engine *llm.Engin
 // The toolMgr's ApprovalMgr is passed to sub-agents so they inherit session approvals
 // and can use the parent's prompt function for interactive approvals.
 func WireSpawnAgentRunner(cfg *config.Config, toolMgr *tools.ToolManager, yoloMode bool) error {
-	return WireSpawnAgentRunnerWithStore(cfg, toolMgr, yoloMode, nil, "")
+	_, err := WireSpawnAgentRunnerWithStore(cfg, toolMgr, yoloMode, nil, "")
+	return err
 }
 
 // WireSpawnAgentRunnerWithStore sets up the spawn_agent runner with session tracking.
 // store is used to save subagent turns, parentSessionID links child sessions to parent.
-func WireSpawnAgentRunnerWithStore(cfg *config.Config, toolMgr *tools.ToolManager, yoloMode bool, store session.Store, parentSessionID string) error {
+// Returns the runner so callers can call Wait() to drain in-flight runs before closing the store.
+func WireSpawnAgentRunnerWithStore(cfg *config.Config, toolMgr *tools.ToolManager, yoloMode bool, store session.Store, parentSessionID string) (*SpawnAgentRunner, error) {
 	if toolMgr == nil {
-		return nil
+		return nil, nil
 	}
 	spawnTool := toolMgr.GetSpawnAgentTool()
 	if spawnTool == nil {
-		return nil
+		return nil, nil
 	}
 	runner, err := NewSpawnAgentRunnerWithStore(cfg, yoloMode, toolMgr.ApprovalMgr, store, parentSessionID)
 	if err != nil {
-		return fmt.Errorf("setup spawn_agent: %w", err)
+		return nil, fmt.Errorf("setup spawn_agent: %w", err)
 	}
 	spawnTool.SetRunner(runner)
-	return nil
+	return runner, nil
 }
 
 func sessionStoreConfig(cfg *config.Config) session.Config {

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/agents"
@@ -26,6 +27,7 @@ type SpawnAgentRunner struct {
 	store             session.Store // Session store for tracking subagent turns
 	parentSessionID   string        // Parent session ID for child session linking
 	warnFunc          func(format string, args ...any)
+	wg                *sync.WaitGroup // tracks in-flight agent runs so callers can drain before closing the store
 }
 
 // NewSpawnAgentRunner creates a new SpawnAgentRunner.
@@ -55,6 +57,7 @@ func NewSpawnAgentRunnerWithStore(cfg *config.Config, yoloMode bool, parentAppro
 		parentApprovalMgr: parentApprovalMgr,
 		store:             store,
 		parentSessionID:   parentSessionID,
+		wg:                &sync.WaitGroup{},
 	}, nil
 }
 
@@ -73,6 +76,12 @@ func (r *SpawnAgentRunner) warn(format string, args ...any) {
 	}
 }
 
+// Wait blocks until all in-flight agent runs have completed.
+// Call this before closing the session store to avoid use-after-close errors.
+func (r *SpawnAgentRunner) Wait() {
+	r.wg.Wait()
+}
+
 // RunAgent loads and runs a sub-agent with the given prompt.
 // It returns the text output from the agent.
 func (r *SpawnAgentRunner) RunAgent(ctx context.Context, agentName string, prompt string, depth int) (tools.SpawnAgentRunResult, error) {
@@ -88,6 +97,9 @@ func (r *SpawnAgentRunner) RunAgentWithCallback(ctx context.Context, agentName s
 // runAgentInternal is the shared implementation for running sub-agents.
 func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName string, prompt string, depth int,
 	callID string, cb tools.SubagentEventCallback) (tools.SpawnAgentRunResult, error) {
+	r.wg.Add(1)
+	defer r.wg.Done()
+
 	emptyResult := tools.SpawnAgentRunResult{}
 
 	// Load the agent
@@ -410,6 +422,7 @@ func (r *SpawnAgentRunner) setupAgentTools(cfg *config.Config, engine *llm.Engin
 			store:             r.store,
 			parentSessionID:   childSessionID, // This agent's session becomes parent for nested agents
 			warnFunc:          r.warnFunc,
+			wg:                r.wg, // share parent's WaitGroup so all nested runs are tracked
 		}
 		spawnTool.SetRunner(childRunner)
 	}


### PR DESCRIPTION
## What

Drain in-flight spawn agent runs before closing the session store, fixing the "sql: database is closed" warnings seen during `/handover`.

## Why

`SpawnAgentRunner` callbacks (response-completed, turn-completed) capture the session store in closures. When `runChatOnce` returns (e.g. on `/handover`), `defer storeCleanup()` closes the store while these callbacks may still be executing, causing:

```
session AddMessage failed: begin transaction: sql: database is closed
session UpdateMetrics failed: sql: database is closed
```

## How

- Add a `sync.WaitGroup` to `SpawnAgentRunner` that tracks all in-flight `runAgentInternal` calls
- Child runners share the parent's WaitGroup pointer so nested agent runs are also tracked
- `WireSpawnAgentRunnerWithStore` now returns `(*SpawnAgentRunner, error)` so callers can access `Wait()`
- In `chat.go` and `ask.go`, call `spawnRunner.Wait()` before `storeCleanup()` — both the normal exit and `/reload` paths are covered

This follows the same drain pattern used by `jobsV2Manager.Close()` which calls `wg.Wait()` before `db.Close()`.
