### PR TITLE
fix: callback stream can fire the completion callback twice on concurrent close

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -561,6 +561,7 @@ func wrapCallbackStream(ctx context.Context, inner Stream, cb TurnCompletedCallb
 type callbackStream struct {
 	inner              Stream
 	ctx                context.Context
+	mu                 sync.Mutex
 	text               *strings.Builder
 	reasoning          *strings.Builder
 	reasoningItemID    string
@@ -582,6 +583,9 @@ func (s *callbackStream) Recv() (Event, error) {
 		s.fireCallback()
 		return event, err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	// Accumulate text and usage
 	if event.Type == EventTextDelta && event.Text != "" {
@@ -610,9 +614,17 @@ func (s *callbackStream) Recv() (Event, error) {
 
 // fireCallback invokes the callback once if there's accumulated content.
 func (s *callbackStream) fireCallback() {
+	var (
+		cb      TurnCompletedCallback
+		msg     Message
+		metrics TurnMetrics
+	)
+
+	s.mu.Lock()
 	if s.callback != nil && !s.done && (s.text.Len() > 0 || s.reasoning.Len() > 0 || s.reasoningItemID != "" || s.reasoningEncrypted != "") {
 		s.done = true
-		msg := Message{
+		cb = s.callback
+		msg = Message{
 			Role: RoleAssistant,
 			Parts: []Part{{
 				Type:                      PartText,
@@ -622,9 +634,14 @@ func (s *callbackStream) fireCallback() {
 				ReasoningEncryptedContent: s.reasoningEncrypted,
 			}},
 		}
+		metrics = s.metrics
+	}
+	s.mu.Unlock()
+
+	if cb != nil {
 		cbCtx, cancel := callbackContext(s.ctx)
 		defer cancel()
-		_ = s.callback(cbCtx, 0, []Message{msg}, s.metrics)
+		_ = cb(cbCtx, 0, []Message{msg}, metrics)
 	}
 }
 

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -30,6 +30,46 @@ func (s *sliceStream) Close() error {
 	return nil
 }
 
+type concurrentCloseStream struct {
+	mu          sync.Mutex
+	calls       int
+	recvBlocked chan struct{}
+	releaseEOF  chan struct{}
+	closeOnce   sync.Once
+}
+
+func newConcurrentCloseStream() *concurrentCloseStream {
+	return &concurrentCloseStream{
+		recvBlocked: make(chan struct{}),
+		releaseEOF:  make(chan struct{}),
+	}
+}
+
+func (s *concurrentCloseStream) Recv() (Event, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+
+	switch call {
+	case 1:
+		return Event{Type: EventTextDelta, Text: "hello"}, nil
+	case 2:
+		close(s.recvBlocked)
+		<-s.releaseEOF
+		return Event{}, io.EOF
+	default:
+		return Event{}, io.EOF
+	}
+}
+
+func (s *concurrentCloseStream) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.releaseEOF)
+	})
+	return nil
+}
+
 type fakeProvider struct {
 	script          func(call int, req Request) []Event
 	calls           []Request
@@ -1807,6 +1847,67 @@ func TestEngineInterjection_DrainOnNoPending(t *testing.T) {
 	_ = engine.DrainInterjection()
 	if text := engine.DrainInterjection(); text != "" {
 		t.Fatalf("expected empty string after drain, got %q", text)
+	}
+}
+
+func TestCallbackStream_CloseWhileDrainingFiresCallbackOnce(t *testing.T) {
+	inner := newConcurrentCloseStream()
+
+	var (
+		mu       sync.Mutex
+		calls    int
+		messages []Message
+	)
+
+	stream := wrapCallbackStream(context.Background(), inner, func(ctx context.Context, turnIndex int, got []Message, metrics TurnMetrics) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		messages = append([]Message(nil), got...)
+		return nil
+	})
+
+	event, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("first recv error: %v", err)
+	}
+	if event.Type != EventTextDelta || event.Text != "hello" {
+		t.Fatalf("first recv = %#v, want hello text delta", event)
+	}
+
+	recvDone := make(chan error, 1)
+	go func() {
+		_, err := stream.Recv()
+		recvDone <- err
+	}()
+
+	select {
+	case <-inner.recvBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for recv to block")
+	}
+
+	if err := stream.Close(); err != nil {
+		t.Fatalf("close error: %v", err)
+	}
+
+	select {
+	case err := <-recvDone:
+		if err != io.EOF {
+			t.Fatalf("second recv error = %v, want EOF", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second recv to finish")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if calls != 1 {
+		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+	if len(messages) != 1 || len(messages[0].Parts) != 1 || messages[0].Parts[0].Text != "hello" {
+		t.Fatalf("callback messages = %#v, want single assistant hello message", messages)
 	}
 }
 


### PR DESCRIPTION
## What

Add a mutex around callbackStream's accumulated state so Recv and Close cannot race while deciding whether to fire the completion callback, and add a regression test covering concurrent drain + close.

## Why

callbackStream.fireCallback() could run concurrently from Recv() and Close(), allowing both paths to observe an unfinished stream and invoke the completion callback twice. That duplicated persistence side effects and raced on the shared builders and metrics while constructing the callback payload.
