### PR TITLE
fix: Failed provider replacement destroys the existing session runtime

### DIFF
--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -294,19 +294,11 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 			m.mu.Unlock()
 			return nil, errServeSessionBusy
 		}
-		delete(m.sessions, id)
 		replaced = rt
 	}
 
 	if inflight, ok := m.creating[id]; ok {
 		m.mu.Unlock()
-		// Clean up the replaced session outside the lock.
-		if replaced != nil {
-			if m.onEvict != nil {
-				m.onEvict(replaced)
-			}
-			replaced.Close()
-		}
 		select {
 		case <-inflight.done:
 		case <-ctx.Done():
@@ -322,17 +314,13 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 		return inflight.rt, nil
 	}
 
+	if replaced != nil {
+		delete(m.sessions, id)
+	}
+
 	inflight := &sessionCreateInFlight{done: make(chan struct{})}
 	m.creating[id] = inflight
 	m.mu.Unlock()
-
-	// Clean up the replaced session outside the lock.
-	if replaced != nil {
-		if m.onEvict != nil {
-			m.onEvict(replaced)
-		}
-		replaced.Close()
-	}
 
 	rt, err := create(ctx)
 	m.mu.Lock()
@@ -340,26 +328,49 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 
 	var duplicate *serveRuntime
 	var evicted *serveRuntime
+	var cleanupReplaced *serveRuntime
 	switch {
 	case err != nil:
 		inflight.err = err
+		if replaced != nil {
+			if m.closed {
+				cleanupReplaced = replaced
+			} else if existing, ok := m.sessions[id]; ok {
+				if existing != replaced {
+					cleanupReplaced = replaced
+				}
+			} else {
+				m.sessions[id] = replaced
+			}
+		}
 	case m.closed:
 		inflight.err = fmt.Errorf("session manager closed")
+		cleanupReplaced = replaced
 	default:
 		if existing, ok := m.sessions[id]; ok {
 			existing.Touch()
 			inflight.rt = existing
 			duplicate = rt
+			if replaced != nil && existing != replaced {
+				cleanupReplaced = replaced
+			}
 		} else {
 			rt.Touch()
 			evicted = m.evictOldestIdleLocked()
 			m.sessions[id] = rt
 			inflight.rt = rt
+			cleanupReplaced = replaced
 		}
 	}
 	close(inflight.done)
 	m.mu.Unlock()
 
+	if cleanupReplaced != nil {
+		if m.onEvict != nil {
+			m.onEvict(cleanupReplaced)
+		}
+		cleanupReplaced.Close()
+	}
 	if duplicate != nil {
 		duplicate.Close()
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4937,6 +4937,53 @@ func TestServeSessionManager_Get_MissingSession(t *testing.T) {
 	}
 }
 
+func TestServeSessionManager_ReplaceIdleWithFailedCreatePreservesSession(t *testing.T) {
+	mgr := newServeSessionManager(time.Minute, 10, nil)
+	defer mgr.Close()
+
+	original := &serveRuntime{providerKey: "default"}
+	original.Touch()
+
+	mgr.mu.Lock()
+	mgr.sessions["sess-1"] = original
+	mgr.mu.Unlock()
+
+	var evictions atomic.Int32
+	mgr.onEvict = func(rt *serveRuntime) {
+		evictions.Add(1)
+	}
+
+	wantErr := errors.New("provider init failed")
+	replaced, err := mgr.ReplaceIdleWith(context.Background(), "sess-1",
+		func(existing *serveRuntime) bool {
+			return true
+		},
+		func(ctx context.Context) (*serveRuntime, error) {
+			return nil, wantErr
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ReplaceIdleWith error = %v, want %v", err, wantErr)
+	}
+	if replaced != nil {
+		t.Fatalf("ReplaceIdleWith returned runtime %v, want nil", replaced)
+	}
+
+	got, ok := mgr.Get("sess-1")
+	if !ok {
+		t.Fatal("expected original session to remain after failed replacement")
+	}
+	if got != original {
+		t.Fatal("expected failed replacement to preserve original runtime")
+	}
+	if got.providerKey != "default" {
+		t.Fatalf("providerKey = %q, want default", got.providerKey)
+	}
+	if got := evictions.Load(); got != 0 {
+		t.Fatalf("evictions = %d, want 0", got)
+	}
+}
+
 func TestServeSessionManager_GetOrCreate_RespectsContextCancel(t *testing.T) {
 	// Factory blocks until told to proceed.
 	proceed := make(chan struct{})


### PR DESCRIPTION
## What

- preserve the existing session runtime while `ReplaceIdleWith` attempts to create a replacement
- only evict and close the old runtime after a replacement is successfully installed
- restore the original runtime when replacement creation fails, and add a regression test covering that path

## Why

A failed fresh-provider replacement could delete and close the live in-memory session before the new runtime was successfully created. That meant transient provider startup/config errors could permanently wipe the current conversation state even though no replacement was available.
