### PR TITLE
fix: Future-scheduled retry runs are claimed and executed immediately

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -815,7 +815,8 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	row := tx.QueryRow(`SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2 WHERE status = ? ORDER BY scheduled_for ASC LIMIT 1`, jobsV2RunQueued)
+	now := time.Now().UTC()
+	row := tx.QueryRow(`SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2 WHERE status = ? AND scheduled_for <= ? ORDER BY scheduled_for ASC LIMIT 1`, jobsV2RunQueued, now)
 	run, err := scanRunV2(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -652,3 +652,63 @@ func TestJobsV2ScheduleOneRespectsMaxConcurrentRuns(t *testing.T) {
 		t.Fatalf("active runs = %d, want 2", active)
 	}
 }
+
+func TestJobsV2ClaimNextRunSkipsFutureScheduledQueuedRuns(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:           "claim-next-run",
+		Enabled:        true,
+		RunnerType:     jobsV2RunnerProgram,
+		RunnerConfig:   json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:    jobsV2TriggerManual,
+		TriggerConfig:  json.RawMessage(`{}`),
+		TimeoutSeconds: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'retry', ?, ?, ?, ?)`,
+		"run_future", job.ID, now.Add(5*time.Minute), jobsV2RunQueued, now, now)
+	if err != nil {
+		t.Fatalf("insert future queued run: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?)`,
+		"run_ready", job.ID, now.Add(-time.Second), jobsV2RunQueued, now, now)
+	if err != nil {
+		t.Fatalf("insert ready queued run: %v", err)
+	}
+
+	run, ok, err := mgr.claimNextRun()
+	if err != nil {
+		t.Fatalf("claimNextRun failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("claimNextRun returned no run")
+	}
+	if run.ID != "run_ready" {
+		t.Fatalf("claimed run = %q, want run_ready", run.ID)
+	}
+
+	futureRun, err := mgr.GetRun("run_future")
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if futureRun.Status != jobsV2RunQueued {
+		t.Fatalf("future run status = %s, want %s", futureRun.Status, jobsV2RunQueued)
+	}
+
+	_, ok, err = mgr.claimNextRun()
+	if err != nil {
+		t.Fatalf("second claimNextRun failed: %v", err)
+	}
+	if ok {
+		t.Fatal("claimNextRun should not claim future-scheduled queued runs")
+	}
+}


### PR DESCRIPTION
## What

- restrict the worker claim query to queued runs whose `scheduled_for` is due
- add a regression test that proves future-scheduled queued runs are left queued until their scheduled time

## Why

Retries are inserted as queued runs with a future `scheduled_for` timestamp. Without filtering on that timestamp, workers can claim and execute retry runs immediately, bypassing backoff and causing tight retry loops.
