### PR TITLE
fix: Failed provider replacement permanently discards the existing session runtime

### DIFF
--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -300,13 +300,6 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 
 	if inflight, ok := m.creating[id]; ok {
 		m.mu.Unlock()
-		// Clean up the replaced session outside the lock.
-		if replaced != nil {
-			if m.onEvict != nil {
-				m.onEvict(replaced)
-			}
-			replaced.Close()
-		}
 		select {
 		case <-inflight.done:
 		case <-ctx.Done():
@@ -326,23 +319,24 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 	m.creating[id] = inflight
 	m.mu.Unlock()
 
-	// Clean up the replaced session outside the lock.
-	if replaced != nil {
-		if m.onEvict != nil {
-			m.onEvict(replaced)
-		}
-		replaced.Close()
-	}
-
 	rt, err := create(ctx)
 	m.mu.Lock()
 	delete(m.creating, id)
 
 	var duplicate *serveRuntime
 	var evicted *serveRuntime
+	var retired *serveRuntime
+	restoredReplaced := false
 	switch {
 	case err != nil:
 		inflight.err = err
+		if replaced != nil && !m.closed {
+			if _, ok := m.sessions[id]; !ok {
+				replaced.Touch()
+				m.sessions[id] = replaced
+				restoredReplaced = true
+			}
+		}
 	case m.closed:
 		inflight.err = fmt.Errorf("session manager closed")
 	default:
@@ -357,11 +351,20 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 			inflight.rt = rt
 		}
 	}
+	if replaced != nil && !restoredReplaced {
+		retired = replaced
+	}
 	close(inflight.done)
 	m.mu.Unlock()
 
 	if duplicate != nil {
 		duplicate.Close()
+	}
+	if retired != nil {
+		if m.onEvict != nil {
+			m.onEvict(retired)
+		}
+		retired.Close()
 	}
 	if evicted != nil {
 		if m.onEvict != nil {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1384,6 +1384,62 @@ func TestServeSessionManager_GetOrCreateWithDoesNotEvictActiveRunWhenAllSessions
 	}
 }
 
+func TestServeSessionManager_ReplaceIdleWith_RestoresExistingSessionWhenCreateFails(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	defer manager.Close()
+
+	var evictions atomic.Int32
+	manager.onEvict = func(rt *serveRuntime) {
+		evictions.Add(1)
+	}
+
+	existing := &serveRuntime{
+		pendingApprovals: map[string]*servePendingApproval{
+			"appr_1": {
+				ApprovalID: "appr_1",
+				Path:       "/tmp/file.txt",
+				Options: []tools.ApprovalOption{{
+					Label:  "Allow once",
+					Choice: tools.ApprovalChoiceOnce,
+				}},
+				CreatedAt: time.Now(),
+				responseC: make(chan serveApprovalSubmission, 1),
+			},
+		},
+	}
+	putTestSession(manager, "sess", existing)
+
+	replaceErr := errors.New("replacement failed")
+	got, err := manager.ReplaceIdleWith(
+		context.Background(),
+		"sess",
+		func(existing *serveRuntime) bool { return true },
+		func(ctx context.Context) (*serveRuntime, error) {
+			return nil, replaceErr
+		},
+	)
+	if !errors.Is(err, replaceErr) {
+		t.Fatalf("ReplaceIdleWith error = %v, want %v", err, replaceErr)
+	}
+	if got != nil {
+		t.Fatalf("ReplaceIdleWith runtime = %v, want nil", got)
+	}
+
+	restored, ok := manager.Get("sess")
+	if !ok {
+		t.Fatal("expected existing session to remain in manager after replacement failure")
+	}
+	if restored != existing {
+		t.Fatal("expected existing runtime pointer to be preserved after replacement failure")
+	}
+	if prompts := existing.pendingApprovalPrompts(); len(prompts) != 1 {
+		t.Fatalf("pending approvals = %d, want 1", len(prompts))
+	}
+	if got := evictions.Load(); got != 0 {
+		t.Fatalf("evictions = %d, want 0", got)
+	}
+}
+
 func TestRequireJSONContentType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
 	if err := requireJSONContentType(req); err == nil {


### PR DESCRIPTION
## What

- defer closing the replaced session in `ReplaceIdleWith` until after a replacement runtime is successfully installed
- restore the original runtime to `m.sessions` when replacement creation fails, so the live session is preserved
- add a regression test that verifies failed replacement keeps the existing runtime and its in-memory state intact

## Why

A failed fresh-provider replacement currently removes and closes the existing in-memory session before the new runtime is created. If provider initialization fails, the request returns an error but the original runtime is already gone, which silently wipes the live conversation. This change preserves the existing session unless a replacement is actually installed.
