### PR TITLE
fix: prevent ask_user modal reset and spurious heartbeat aborts during user input

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -173,6 +173,11 @@ const startHeartbeatMonitor = () => {
       stopHeartbeatMonitor();
       return;
     }
+    // While an ask_user or approval modal is open the server is intentionally
+    // silent — it is blocked waiting for user input.  A stale-heartbeat abort
+    // here would needlessly reconnect the SSE stream and replay the prompt
+    // event, resetting any partial answer the user has typed.
+    if (state.askUser || state.approval) return;
     if (Date.now() - state.lastEventTime > HEARTBEAT_STALE_THRESHOLD) {
       if (state.abortController) {
         state.abortController._heartbeatAbort = true;
@@ -445,7 +450,12 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     const callId = String(payload.call_id || '').trim();
     const questions = Array.isArray(payload.questions) ? payload.questions : [];
     if (callId && questions.length > 0) {
-      openAskUserModal(session.id, callId, questions);
+      const samePrompt = state.askUser
+        && state.askUser.sessionId === session.id
+        && state.askUser.callId === callId;
+      if (!samePrompt) {
+        openAskUserModal(session.id, callId, questions);
+      }
     }
     return { terminal: false };
   }


### PR DESCRIPTION
## Problem

When `ask_user.prompt` arrives via SSE, the server blocks waiting for user input — emitting no further SSE events. Two bugs conspired to make it impossible to answer the prompt in the web UI.

**Bug 1 — heartbeat aborts the connection while user is typing**

The heartbeat monitor fires every 10s and aborts the SSE stream if no bytes have been received in 45s (`HEARTBEAT_STALE_THRESHOLD = 45000`). But when an `ask_user` modal is open, server silence is *expected* — the server is blocked waiting for user input. The abort triggers the retry loop in `resumeActiveResponseInner`, which reconnects and fetches `?after=<lastSequenceNumber>`. If the `ask_user.prompt` event is replayed (or its sequence number didn't advance `lastSequenceNumber`), the modal handler fires again — resetting `state.askUser`, re-rendering the modal, and losing any partial input the user had typed. This repeated every 45s, making it impossible to submit an answer.

**Bug 2 — no samePrompt guard in the SSE path**

The poll path (`syncActiveSessionFromServer`) already has a `samePrompt` check that skips re-opening the modal if the same `callId` is already displayed. The SSE path (`applyResponseStreamEvent`) had no such guard — it unconditionally called `openAskUserModal` on every `response.ask_user.prompt` event.

## Fix

Two complementary changes in `app-stream.js`:

**1. samePrompt guard in `applyResponseStreamEvent`** — mirrors the existing guard in `syncActiveSessionFromServer`. If the modal is already showing the same `callId`, skip re-opening it.

**2. Suppress heartbeat abort while a modal is open** — if `state.askUser` or `state.approval` is set, the heartbeat interval returns early without aborting. Server silence is intentional during user interaction.

These two changes together ensure the modal stays stable while the user types, and the stream reconnects cleanly after the answer is submitted.