### PR TITLE
feat: volume init takeover — agent self-bootstraps runit on every rebuild

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-AGENT_NAME="${AGENT_NAME:-agent}"
+export AGENT_NAME="${AGENT_NAME:-agent}"
 AGENT_DIR="/root/.config/term-llm/agents/$AGENT_NAME"
 SEED_DIR="/seed/agents/$AGENT_NAME"
 
@@ -22,7 +22,7 @@ if [ -f /seed/init.sh ]; then
   bash /seed/init.sh
 fi
 
-# Volume init hook (for manual one-time setup after deploy)
+# Volume init hook (runs every container start)
 if [ -f /root/.config/term-llm/init.sh ]; then
   bash /root/.config/term-llm/init.sh
 fi

--- a/docker/templates/init.sh
+++ b/docker/templates/init.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Boot hook — runs every container start via entrypoint.
-# Installs runit services from /seed/services/ on first boot only.
+# On first boot: installs runit services from /seed/services/ and generates
+# a volume-side bootstrap-services.sh so the agent owns service setup on
+# every subsequent boot/rebuild, independent of the seed bind-mount.
 
 SEED_SERVICES="/seed/services"
 SV_DIR="/etc/sv"
@@ -27,6 +29,70 @@ for svc_dir in "$SEED_SERVICES"/*/; do
 
   ln -sf "$target" "$RUNSVDIR/$svc_name"
 done
+
+# Generate a volume-side bootstrap script that embeds each service's run script.
+# This lets the agent recreate ephemeral /etc/sv/ and /etc/runit/runsvdir/
+# on every container rebuild without needing the seed bind-mount.
+AGENT_NAME="${AGENT_NAME:-agent}"
+AGENT_SCRIPTS="/root/.config/term-llm/agents/$AGENT_NAME/scripts"
+BOOTSTRAP="$AGENT_SCRIPTS/bootstrap-services.sh"
+
+if [ ! -f "$BOOTSTRAP" ]; then
+  mkdir -p "$AGENT_SCRIPTS"
+
+  {
+    cat << 'SCRIPT_HEADER'
+#!/bin/bash
+set -euo pipefail
+RUNSVDIR="/etc/runit/runsvdir"
+SVDIR="/etc/sv"
+mkdir -p "$RUNSVDIR" "$SVDIR"
+SCRIPT_HEADER
+
+    for svc_dir in "$SEED_SERVICES"/*/; do
+      svc_name="$(basename "$svc_dir")"
+      run_src="$SV_DIR/$svc_name/run"
+      [ -f "$run_src" ] || continue
+      encoded=$(base64 -w 0 < "$run_src")
+      printf '\n# service: %s\n' "$svc_name"
+      printf 'mkdir -p "$SVDIR/%s"\n' "$svc_name"
+      printf 'base64 -d << '"'"'%s'"'"' > "$SVDIR/%s/run"\n' "EOF_$svc_name" "$svc_name"
+      printf '%s\n' "$encoded"
+      printf '%s\n' "EOF_$svc_name"
+      printf 'chmod 755 "$SVDIR/%s/run"\n' "$svc_name"
+      printf 'rm -f "$SVDIR/%s/down"\n' "$svc_name"
+      printf 'ln -snf "$SVDIR/%s" "$RUNSVDIR/%s"\n' "$svc_name" "$svc_name"
+    done
+
+    cat << 'SCRIPT_FOOTER'
+
+if command -v sv >/dev/null 2>&1; then
+  for _svc in "$RUNSVDIR"/*/; do
+    _status="$(sv status "$_svc" 2>&1 || true)"
+    case "$_status" in
+      run:*) ;;
+      *) sv start "$_svc" >/dev/null 2>&1 || true ;;
+    esac
+  done
+fi
+SCRIPT_FOOTER
+  } > "$BOOTSTRAP"
+  chmod 755 "$BOOTSTRAP"
+  echo "init: bootstrap-services.sh written to $BOOTSTRAP"
+fi
+
+# Write the volume init.sh to call bootstrap on every boot (if not already present).
+# Guards against overwriting a custom init.sh the agent may already have.
+VOLUME_INIT="/root/.config/term-llm/init.sh"
+if [ ! -f "$VOLUME_INIT" ]; then
+  cat > "$VOLUME_INIT" << VOLINIT
+#!/bin/bash
+set -euo pipefail
+bash "$BOOTSTRAP"
+VOLINIT
+  chmod 755 "$VOLUME_INIT"
+  echo "init: volume init.sh written"
+fi
 
 mkdir -p "$(dirname "$SENTINEL")"
 touch "$SENTINEL"


### PR DESCRIPTION
## What

On first boot, `docker/templates/init.sh` now generates two files on the persistent volume:

1. `$AGENT_DIR/scripts/bootstrap-services.sh` — embeds each seed service's `run` script (base64-encoded) with an idempotent install loop that recreates `/etc/sv/<name>/` and `/etc/runit/runsvdir/<name>` symlinks.
2. `/root/.config/term-llm/init.sh` — calls `bootstrap-services.sh` on every container start.

Also: `export AGENT_NAME` in `entrypoint.sh` so child scripts inherit it; fix misleading comment on the volume init hook.

## Why

`/etc/sv/` and `/etc/runit/runsvdir/` are ephemeral — they live in the container's writable layer and are gone after a rebuild. The seed bind-mount installs services on first boot, but the sentinel file persists on the volume so subsequent boots skip it. Without a volume-side bootstrap, a container rebuild leaves runit with nothing to supervise.

This pattern (volume `init.sh` → `bootstrap-services.sh`) is already what Jarvis uses to self-heal after rebuilds. This PR bakes it into the generic template so any new agent gets the same resilience automatically, without manual post-deploy steps.

**Boot flow after this change:**
- **First boot:** seed installs services + generates bootstrap files + touches sentinel
- **Every subsequent boot / rebuild:** entrypoint runs volume `init.sh` → `bootstrap-services.sh` → runit services recreated from embedded run scripts

Guards:
- `bootstrap-services.sh` only generated if not present (agent can replace/customise it)
- Volume `init.sh` only written if not already present (preserves any existing custom init)
