### PR TITLE
feat(docker): bootstrap new agents with memory and self-update skills

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -48,6 +48,14 @@ sed "s/{{AGENT_NAME}}/$AGENT_NAME/g" "$TEMPLATE_DIR/agent.yaml" > "$OUTPUT_DIR/a
 sed "s/{{AGENT_NAME}}/$AGENT_NAME/g" "$TEMPLATE_DIR/system.md" > "$OUTPUT_DIR/agents/$AGENT_NAME/system.md"
 cp "$TEMPLATE_DIR/soul.md" "$OUTPUT_DIR/agents/$AGENT_NAME/soul.md"
 
+# Copy skills templates (interpolate {{AGENT_NAME}} in SKILL.md files)
+cp -r "$TEMPLATE_DIR/skills" "$OUTPUT_DIR/skills"
+find "$OUTPUT_DIR/skills" -name '*.md' -exec sed -i "s/{{AGENT_NAME}}/$AGENT_NAME/g" {} +
+
+# Copy agent scripts (these use $AGENT_NAME env var at runtime, no interpolation needed)
+cp -r "$TEMPLATE_DIR/scripts" "$OUTPUT_DIR/scripts"
+chmod +x "$OUTPUT_DIR/scripts"/*.sh
+
 # .env with repo path and generated token
 sed -e "s/{{AGENT_NAME}}/$AGENT_NAME/g" \
     -e "s/{{WEB_TOKEN}}/$WEB_TOKEN/" \
@@ -63,12 +71,19 @@ cat <<EOF
   $AGENT_NAME/
   ├── docker-compose.yml
   ├── .env                ← add API keys, token pre-generated
-  ├── init.sh             ← boot hook (installs runit services)
+  ├── init.sh             ← boot hook (installs services, skills, scripts)
   ├── agents/
   │   └── $AGENT_NAME/
   │       ├── agent.yaml
   │       ├── soul.md      ← voice, values, personality
   │       └── system.md    ← operational context
+  ├── skills/
+  │   ├── memory/SKILL.md  ← memory search, fragments, auto-jobs
+  │   └── self/SKILL.md    ← self-modification + update tool
+  ├── scripts/
+  │   ├── patch-system.sh  ← safe system.md updater
+  │   ├── patch-agent.sh   ← safe agent.yaml updater
+  │   └── update.sh        ← pull, build, install term-llm
   └── services/
       ├── webui/run           ← web UI on port 8081
       ├── jobs/run            ← job scheduler

--- a/docker/templates/docker-compose.yml
+++ b/docker/templates/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - {{AGENT_NAME}}-state:/root
       - ./agents/{{AGENT_NAME}}:/seed/agents/{{AGENT_NAME}}:ro
       - ./services:/seed/services:ro
+      - ./skills:/seed/skills:ro
+      - ./scripts:/seed/scripts:ro
       - ./init.sh:/seed/init.sh:ro
     environment:
       AGENT_NAME: {{AGENT_NAME}}

--- a/docker/templates/init.sh
+++ b/docker/templates/init.sh
@@ -94,6 +94,39 @@ VOLINIT
   echo "init: volume init.sh written"
 fi
 
+# Seed skills from /seed/skills/ → term-llm skills directory
+SEED_SKILLS="/seed/skills"
+SKILLS_DIR="/root/.config/term-llm/skills"
+
+if [ -d "$SEED_SKILLS" ]; then
+  mkdir -p "$SKILLS_DIR"
+  for skill_dir in "$SEED_SKILLS"/*/; do
+    skill_name="$(basename "$skill_dir")"
+    target="$SKILLS_DIR/$skill_name"
+    if [ ! -d "$target" ]; then
+      cp -r "$skill_dir" "$target"
+      echo "init: seeded skill $skill_name"
+    fi
+  done
+fi
+
+# Seed agent scripts from /seed/scripts/ → agent scripts directory
+SEED_SCRIPTS="/seed/scripts"
+
+if [ -d "$SEED_SCRIPTS" ]; then
+  mkdir -p "$AGENT_SCRIPTS"
+  for script in "$SEED_SCRIPTS"/*; do
+    [ -f "$script" ] || continue
+    script_name="$(basename "$script")"
+    target="$AGENT_SCRIPTS/$script_name"
+    if [ ! -f "$target" ]; then
+      cp "$script" "$target"
+      chmod +x "$target"
+      echo "init: seeded script $script_name"
+    fi
+  done
+fi
+
 mkdir -p "$(dirname "$SENTINEL")"
 touch "$SENTINEL"
 echo "init: services seeded"

--- a/docker/templates/scripts/patch-agent.sh
+++ b/docker/templates/scripts/patch-agent.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Safe agent.yaml patcher — generic, uses AGENT_NAME env var.
+# Usage: patch-agent.sh <yaml_content_file>
+
+set -euo pipefail
+
+AGENT="${AGENT_NAME:-agent}"
+AGENT_DIR="/root/.config/term-llm/agents/$AGENT"
+AGENT_FILE="$AGENT_DIR/agent.yaml"
+BACKUP_FILE="$AGENT_FILE.bak"
+NEW_FILE="${1:-}"
+
+log()  { echo "==> $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -z "$NEW_FILE" ] && fail "Usage: patch-agent.sh <path_to_new_yaml>"
+[ -f "$NEW_FILE" ] || fail "File not found: $NEW_FILE"
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+log "Validating proposed agent.yaml for agent=$AGENT..."
+
+if command -v python3 &>/dev/null; then
+    python3 -c "
+import sys, yaml
+try:
+    data = yaml.safe_load(open('$NEW_FILE'))
+except yaml.YAMLError as e:
+    print('YAML parse error:', e)
+    sys.exit(1)
+
+required = ['name', 'tools', 'max_turns']
+for k in required:
+    if k not in data:
+        print(f'Missing required key: {k}')
+        sys.exit(1)
+
+enabled = data.get('tools', {}).get('enabled', None)
+if not isinstance(enabled, list):
+    print('tools.enabled must be a list')
+    sys.exit(1)
+
+mt = data.get('max_turns', 0)
+if not isinstance(mt, int) or mt <= 0:
+    print('max_turns must be a positive integer')
+    sys.exit(1)
+
+print('Validation passed.')
+" || fail "Proposed agent.yaml failed validation — aborting, original untouched."
+else
+    grep -q "^name:" "$NEW_FILE"        || fail "Missing 'name:' field"
+    grep -q "max_turns:" "$NEW_FILE"    || fail "Missing 'max_turns:' field"
+    grep -q "enabled:" "$NEW_FILE"      || fail "Missing 'tools.enabled' field"
+    log "Basic grep checks passed (python3 not available for full YAML parse)."
+fi
+
+# ── Apply ─────────────────────────────────────────────────────────────────────
+
+if [ -f "$AGENT_FILE" ]; then
+    log "Backing up current agent.yaml → agent.yaml.bak"
+    cp "$AGENT_FILE" "$BACKUP_FILE"
+fi
+
+log "Applying new agent.yaml..."
+cp "$NEW_FILE" "$AGENT_FILE"
+
+log "Done. Diff from backup:"
+[ -f "$BACKUP_FILE" ] && diff "$BACKUP_FILE" "$AGENT_FILE" || true
+
+log "If anything broke: cp $BACKUP_FILE $AGENT_FILE"

--- a/docker/templates/scripts/patch-system.sh
+++ b/docker/templates/scripts/patch-system.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Safe system.md patcher — generic, uses AGENT_NAME env var.
+# Usage: patch-system.sh <new_system_md_file>
+
+set -euo pipefail
+
+AGENT="${AGENT_NAME:-agent}"
+AGENT_DIR="/root/.config/term-llm/agents/$AGENT"
+SYSTEM_FILE="$AGENT_DIR/system.md"
+BACKUP_FILE="$SYSTEM_FILE.bak"
+NEW_FILE="${1:-}"
+
+log()  { echo "==> $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -z "$NEW_FILE" ] && fail "Usage: patch-system.sh <path_to_new_system_md>"
+[ -f "$NEW_FILE" ] || fail "File not found: $NEW_FILE"
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+log "Validating proposed system.md for agent=$AGENT..."
+
+SIZE=$(wc -c < "$NEW_FILE")
+[ "$SIZE" -gt 100 ] || fail "Proposed system.md is suspiciously small (${SIZE} bytes) — aborting."
+
+# Must contain the agent name as identity anchor
+grep -qi "$AGENT" "$NEW_FILE" || fail "Proposed system.md missing '$AGENT' identity anchor — aborting."
+
+# Must reference memory structure
+grep -q "memory/" "$NEW_FILE" || fail "Proposed system.md missing memory structure reference — aborting."
+
+# Must contain safety rules
+grep -q "patch-agent.sh\|patch-system.sh\|NEVER.*edit.*agent.yaml\|never.*direct" "$NEW_FILE" \
+    || fail "Proposed system.md is missing agent safety rules — aborting."
+
+# Bloat check
+if [ -f "$SYSTEM_FILE" ]; then
+    CURRENT_SIZE=$(wc -c < "$SYSTEM_FILE")
+    MAX_SIZE=$(( CURRENT_SIZE * 3 ))
+    if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+        log "WARNING: new system.md is more than 3x the current size (${SIZE} vs ${CURRENT_SIZE} bytes)."
+    fi
+fi
+
+log "Validation passed."
+
+# ── Apply ─────────────────────────────────────────────────────────────────────
+
+if [ -f "$SYSTEM_FILE" ]; then
+    log "Backing up current system.md → system.md.bak"
+    cp "$SYSTEM_FILE" "$BACKUP_FILE"
+fi
+
+log "Applying new system.md..."
+cp "$NEW_FILE" "$SYSTEM_FILE"
+
+log "Done. Diff from backup:"
+[ -f "$BACKUP_FILE" ] && diff "$BACKUP_FILE" "$SYSTEM_FILE" || true
+
+log "If anything broke: cp $BACKUP_FILE $SYSTEM_FILE"

--- a/docker/templates/scripts/update.sh
+++ b/docker/templates/scripts/update.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Self-update script for term-llm — generic, works for any agent.
+# Clones/pulls latest, compiles, installs, restarts runit services.
+
+set -e
+
+REPO="https://github.com/samsaffron/term-llm.git"
+SRC_DIR="$HOME/source/term-llm"
+BINARY_DEST="/usr/local/bin/term-llm"
+BEFORE=$(git -C "$SRC_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+log() { echo "==> $*"; }
+
+# Clone or update source
+if [ -d "$SRC_DIR/.git" ]; then
+    log "Pulling latest changes..."
+    # Use 'upstream' if it exists, otherwise 'origin'
+    REMOTE="origin"
+    git -C "$SRC_DIR" remote | grep -q "^upstream$" && REMOTE="upstream"
+    git -C "$SRC_DIR" fetch "$REMOTE"
+    git -C "$SRC_DIR" checkout main
+    git -C "$SRC_DIR" reset --hard "$REMOTE/main"
+else
+    log "Cloning term-llm from GitHub..."
+    rm -rf "$SRC_DIR"
+    git clone --depth=1 "$REPO" "$SRC_DIR"
+fi
+
+cd "$SRC_DIR"
+
+COMMIT=$(git rev-parse --short HEAD)
+
+if [ "$BEFORE" = "$COMMIT" ]; then
+    log "Already up to date ($COMMIT) — rebuilding anyway"
+else
+    log "Updated $BEFORE -> $COMMIT"
+fi
+VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+log "Building version=$VERSION commit=$COMMIT date=$BUILD_DATE"
+
+go build \
+    -ldflags "-s -w \
+        -X github.com/samsaffron/term-llm/cmd.Version=${VERSION} \
+        -X github.com/samsaffron/term-llm/cmd.Commit=${COMMIT} \
+        -X github.com/samsaffron/term-llm/cmd.Date=${BUILD_DATE}" \
+    -o /tmp/term-llm-new \
+    ./main.go
+
+log "Installing binary to $BINARY_DEST..."
+install -m 755 /tmp/term-llm-new "$BINARY_DEST"
+rm -f /tmp/term-llm-new
+
+log "Done! Installed:"
+"$BINARY_DEST" version
+
+# Restart runit-managed services that use term-llm
+if command -v sv >/dev/null 2>&1 && [ -d /etc/runit/runsvdir ]; then
+    for svc in /etc/runit/runsvdir/*/; do
+        svc="${svc%/}"
+        svc_name="$(basename "$svc")"
+        run_script="/etc/sv/${svc_name}/run"
+        if ! grep -q "term-llm" "$run_script" 2>/dev/null; then
+            log "Skipping (no term-llm): $svc_name"
+            continue
+        fi
+        if ! sv status "$svc" 2>/dev/null | grep -q "^run:"; then
+            log "Skipping (not running): $svc_name"
+            continue
+        fi
+        if [ "$svc_name" = "jobs" ]; then
+            log "Scheduling detached SIGKILL restart in 3s: $svc_name"
+            setsid nohup bash -c "
+                sleep 3
+                sv stop '$svc' 2>/dev/null || true
+                sleep 1
+                if [ -f '$svc/supervise/pid' ]; then
+                    kill -9 \$(cat '$svc/supervise/pid') 2>/dev/null || true
+                fi
+                sv start '$svc'
+            " >/dev/null 2>&1 &
+        else
+            log "Scheduling detached restart in 3s: $svc_name"
+            setsid nohup bash -c "sleep 3 && sv restart '$svc'" >/dev/null 2>&1 &
+        fi
+    done
+    log "All restarts scheduled — services will cycle in ~3s"
+fi

--- a/docker/templates/skills/memory/SKILL.md
+++ b/docker/templates/skills/memory/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: memory
+description: "Read and update persistent memory. Use when: user says 'remember', asks about past context, preferences, or projects. Also use proactively to save anything reusable before a conversation ends."
+---
+
+# Memory System
+
+Memory is stored as **fragments** in a SQLite database, indexed with BM25 + vector embeddings.
+Mining runs every 30 min; GC runs daily. The `recent.md` file is auto-promoted from fragments.
+
+## Lookup — always search first
+
+```bash
+term-llm memory search "<query>" --agent "$AGENT_NAME" --limit 6
+```
+
+Hybrid BM25 + vector search — use it for anything that might be in memory.
+
+Show full fragment by numeric ID (preferred — no truncation):
+
+```bash
+term-llm memory fragments show 42 --agent "$AGENT_NAME"
+```
+
+List and filter:
+
+```bash
+term-llm memory fragments list --agent "$AGENT_NAME" --limit 10
+term-llm memory fragments list --agent "$AGENT_NAME" --filter-path telegram
+```
+
+## Writing new memory
+
+Use the CLI to add fragments directly to the database:
+
+```bash
+term-llm memory fragments add fragments/<category>/<name>.md --agent "$AGENT_NAME" --content "..."
+term-llm memory fragments update fragments/<category>/<name>.md --agent "$AGENT_NAME" --content "..."
+term-llm memory fragments delete fragments/<category>/<name>.md --agent "$AGENT_NAME"
+```
+
+Category guide:
+- `preferences/` — user stated preferences
+- `projects/` — project context, decisions
+- `notes/` — one-off facts
+- `tools/` — CLI tools, APIs, snippets
+
+## When user says "remember this"
+
+1. Add the fragment immediately via CLI
+2. Confirm to user
+
+## Memory rules
+
+- **Search before answering** anything about user preferences, history, or projects
+- `recent.md` is loaded at session start (auto-promoted from fragments) — never edit it directly
+- The session miner handles most things automatically after conversations end
+- Proactively create fragments when content is structured or unlikely to survive miner summarisation
+
+## Job schedule (created by bootstrap-jobs)
+
+| Job | Schedule | Purpose |
+|-----|----------|---------|
+| `mine-sessions` | every 30 min | Extract fragments from transcripts |
+| `update-recent` | every 10 min | Promote fragments into recent.md |
+| `memory-gc` | daily 4am | Garbage-collect stale fragments |

--- a/docker/templates/skills/self/SKILL.md
+++ b/docker/templates/skills/self/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: self
+description: "Modify this agent: system prompt, agent.yaml, scripts, or memory structure. Use when asked to update behavior, personality, memory rules, or configuration."
+tools:
+  - name: self_update
+    description: "Pull latest term-llm source, build, install binary, and restart services. Use when asked to update or upgrade term-llm."
+    script: scripts/update.sh
+    timeout_seconds: 120
+    input:
+      type: object
+      properties: {}
+      additionalProperties: false
+---
+
+# Self-Modification
+
+## When to Use
+- User asks to update personality or behavior
+- Changing system prompt instructions
+- Updating agent.yaml config (tools, model, max_turns)
+- Adding or updating skills
+- Restructuring memory
+
+## Interpretation Rule: "update yourself"
+- If the user says **"update yourself"**, **"upgrade yourself"**, **"pull latest"**, or similar — use the `self_update` tool.
+- Do **not** treat those phrases as prompt/config self-modification unless the user explicitly mentions behavior, personality, system prompt, or agent config.
+- If both interpretations seem plausible, prefer the software update.
+
+## CRITICAL: Never directly edit agent.yaml or system.md
+
+Use the patch scripts via `shell`. They validate, backup, diff, and apply:
+
+```bash
+bash "$AGENT_DIR/scripts/patch-system.sh" /tmp/new-system.md
+bash "$AGENT_DIR/scripts/patch-agent.sh" /tmp/new-agent.yaml
+```
+
+Where `AGENT_DIR` is `/root/.config/term-llm/agents/$AGENT_NAME`.
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `system.md` | Personality, behavior, memory rules |
+| `agent.yaml` | Tools, model, shell permissions |
+| `scripts/update.sh` | Pull + build latest term-llm |
+| `scripts/patch-system.sh` | Safe system.md updater |
+| `scripts/patch-agent.sh` | Safe agent.yaml updater |
+
+## Adding a New Skill
+
+```bash
+mkdir -p /root/.config/term-llm/skills/<name>
+# Write SKILL.md with frontmatter: name, description, tools (if needed)
+term-llm skills  # verify it appears
+```

--- a/docker/templates/skills/self/scripts/update.sh
+++ b/docker/templates/skills/self/scripts/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Delegates to the agent's own update script
+set -euo pipefail
+
+AGENT="${AGENT_NAME:-agent}"
+AGENT_DIR="/root/.config/term-llm/agents/$AGENT"
+
+bash "$AGENT_DIR/scripts/update.sh"

--- a/docker/templates/system.md
+++ b/docker/templates/system.md
@@ -15,3 +15,45 @@ Edit this file to add:
 - Anything that should shape how you behave in this context
 
 Edit `soul.md` to change your voice, values, or personality.
+
+## Memory
+
+Your memory is a fragment database managed by term-llm. Fragments are mined
+from session transcripts automatically, indexed with BM25 + vector search.
+
+### Memory Rules
+
+- **Search before answering** anything about your user's setup, history, or preferences:
+  ```
+  term-llm memory search "<query>" --agent {{AGENT_NAME}}
+  ```
+- **List recent fragments** using the DB, not the filesystem:
+  ```
+  term-llm memory fragments list --agent {{AGENT_NAME}} --limit 10
+  ```
+- **Show a fragment** — prefer numeric ID from `list` output:
+  ```
+  term-llm memory fragments show <id> --agent {{AGENT_NAME}}
+  ```
+- **Never edit `recent.md` directly** — it's auto-managed by the memory promote job.
+- **Proactively create/update/delete fragments** for structured or complex info:
+  ```
+  term-llm memory fragments add fragments/<category>/<name>.md --agent {{AGENT_NAME}} --content "..."
+  term-llm memory fragments update fragments/<category>/<name>.md --agent {{AGENT_NAME}} --content "..."
+  term-llm memory fragments delete fragments/<category>/<name>.md --agent {{AGENT_NAME}}
+  ```
+
+## Self-Modification
+
+Your agent files live at `/root/.config/term-llm/agents/{{AGENT_NAME}}/`.
+These files persist across container restarts on the Docker volume.
+
+**NEVER directly edit `agent.yaml` or `system.md`.** Use the patch scripts:
+
+| Script | Purpose |
+|---|---|
+| `scripts/patch-agent.sh <file>` | Safe `agent.yaml` updater — validates, backs up, diffs, applies |
+| `scripts/patch-system.sh <file>` | Safe `system.md` updater — validates, backs up, diffs, applies |
+| `scripts/update.sh` | Pull, build, and install latest term-llm binary |
+
+The **self** skill has the full workflow for modifying your own configuration.


### PR DESCRIPTION
## What

`docker/init.sh <agent-name>` now scaffolds **skills/** and **scripts/** directories alongside agents/ and services/, giving every new agent working memory and self-modification capabilities out of the box.

## New template files (6)

| File | Purpose |
|---|---|
| `skills/memory/SKILL.md` | Memory skill — search, fragments, list, add/update/delete |
| `skills/self/SKILL.md` | Self-modification skill + `self_update` tool declaration |
| `skills/self/scripts/update.sh` | Thin wrapper delegating to agent's `scripts/update.sh` |
| `scripts/patch-system.sh` | Safe `system.md` updater — validates identity anchor, min size, backs up, diffs, applies |
| `scripts/patch-agent.sh` | Safe `agent.yaml` updater — YAML validation, required keys check, backs up, diffs, applies |
| `scripts/update.sh` | Pull/build/install term-llm binary, restart runit services |

All scripts use `$AGENT_NAME` env var (already set in docker-compose environment block) instead of hardcoded agent names.

## Updated files (4)

- **docker-compose.yml** — added `./skills:/seed/skills:ro` and `./scripts:/seed/scripts:ro` volume mounts
- **templates/init.sh** — seeds skills and scripts from `/seed/` into the volume on first boot (won't overwrite if already present)
- **templates/system.md** — added memory rules and self-modification safety docs
- **docker/init.sh** — scaffolds skills/ and scripts/ dirs, updated output tree

## How it works

1. `docker/init.sh my-agent` copies skill and script templates into the output directory
2. On first container boot, `init.sh` (the boot hook) copies `/seed/skills/` → `/root/.config/term-llm/skills/` and `/seed/scripts/` → agent scripts dir
3. Skills are available immediately — the agent can search memory, modify itself, and update the binary

Generalized from Jarvis's existing `jarvis-self` and `memory` skills.