### PR TITLE
fix: Closing or resetting a Telegram session does not stop an in-flight LLM reply

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -510,9 +510,7 @@ func (m *telegramSessionMgr) getOrCreate(ctx context.Context, chatID int64) (*te
 	m.mu.Lock()
 	if existing, ok := m.sessions[chatID]; ok {
 		m.mu.Unlock()
-		created.mu.Lock()
 		closeTelegramSession(created)
-		created.mu.Unlock()
 		return existing, nil
 	}
 	m.sessions[chatID] = created
@@ -535,18 +533,14 @@ func (m *telegramSessionMgr) resetSessionIfCurrent(ctx context.Context, chatID i
 	current := m.sessions[chatID]
 	if expected != nil && current != nil && current != expected {
 		m.mu.Unlock()
-		created.mu.Lock()
 		closeTelegramSession(created)
-		created.mu.Unlock()
 		return current, false, nil
 	}
 	m.sessions[chatID] = created
 	m.mu.Unlock()
 
 	if current != nil {
-		current.mu.Lock()
 		closeTelegramSession(current)
-		current.mu.Unlock()
 	}
 	return created, true, nil
 }
@@ -697,17 +691,30 @@ func (m *telegramSessionMgr) closeAllSessions() {
 	m.mu.Unlock()
 
 	for _, sess := range sessions {
-		sess.mu.Lock()
 		closeTelegramSession(sess)
-		sess.mu.Unlock()
 	}
 }
 
 func closeTelegramSession(sess *telegramSession) {
-	if sess == nil || sess.runtime == nil || sess.runtime.Cleanup == nil {
+	if sess == nil {
 		return
 	}
-	sess.runtime.Cleanup()
+
+	sess.cancelMu.Lock()
+	cancelFn := sess.streamCancel
+	doneCh := sess.replyDone
+	sess.cancelMu.Unlock()
+
+	if cancelFn != nil {
+		cancelFn()
+		if doneCh != nil {
+			<-doneCh
+		}
+	}
+
+	if sess.runtime != nil && sess.runtime.Cleanup != nil {
+		sess.runtime.Cleanup()
+	}
 }
 
 func (m *telegramSessionMgr) runStoreOp(ctx context.Context, sessionID, op string, fn func(context.Context) error) {

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -681,6 +681,112 @@ func TestTelegramSessionMgrResetSessionIfCurrent_RejectsStaleExpectedSession(t *
 	}
 }
 
+func TestTelegramSessionMgrResetSessionIfCurrent_CancelsActiveStream(t *testing.T) {
+	h := testutil.NewEngineHarness()
+
+	toolStarted := make(chan struct{})
+	slowTool := &testutil.MockTool{
+		SpecData: llm.ToolSpec{
+			Name:        "slow_tool",
+			Description: "slow tool for testing",
+			Schema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		ExecuteFn: func(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+			close(toolStarted)
+			<-ctx.Done()
+			return llm.TextOutput("cancelled"), ctx.Err()
+		},
+	}
+	h.Registry.Register(slowTool)
+	h.Provider.AddToolCall("id-1", "slow_tool", map[string]any{})
+	h.Provider.AddTextResponse("final answer")
+
+	var cleanupCalls atomic.Int32
+	mgr := &telegramSessionMgr{
+		sessions:       make(map[int64]*telegramSession),
+		tickerInterval: 5 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       h.Engine,
+					ProviderName: "mock",
+					ModelName:    "replacement",
+				}, nil
+			},
+		},
+	}
+	original := &telegramSession{
+		runtime: &SessionRuntime{
+			Engine:       h.Engine,
+			ProviderName: "mock",
+			ModelName:    "test",
+			Cleanup: func() {
+				cleanupCalls.Add(1)
+			},
+		},
+	}
+	mgr.sessions[42] = original
+
+	bot := &fakeBotSender{}
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- mgr.streamReply(context.Background(), bot, original, 42, llm.UserText("do something slow"))
+	}()
+
+	select {
+	case <-toolStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool never started")
+	}
+
+	resetDone := make(chan struct{})
+	var (
+		replacement *telegramSession
+		replaced    bool
+		resetErr    error
+	)
+	go func() {
+		replacement, replaced, resetErr = mgr.resetSessionIfCurrent(context.Background(), 42, original)
+		close(resetDone)
+	}()
+
+	select {
+	case <-resetDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resetSessionIfCurrent did not return after cancelling active stream")
+	}
+
+	if resetErr != nil {
+		t.Fatalf("resetSessionIfCurrent failed: %v", resetErr)
+	}
+	if !replaced {
+		t.Fatal("expected reset to replace the active session")
+	}
+	if replacement == nil || replacement == original {
+		t.Fatal("expected a new replacement session")
+	}
+
+	select {
+	case err := <-streamDone:
+		if err != nil {
+			t.Fatalf("streamReply should return nil after session reset interruption, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamReply did not stop after session reset")
+	}
+
+	if cleanupCalls.Load() != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", cleanupCalls.Load())
+	}
+	if got := mgr.sessions[42]; got != replacement {
+		t.Fatal("expected replacement session to be current")
+	}
+}
+
 func TestTelegramSessionMgrResetSessionIfCurrent_RestoresHistoryFromDB(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

- make `closeTelegramSession` cancel any active Telegram reply stream via `sess.streamCancel`
- wait for the in-flight reply goroutine to finish before running runtime cleanup
- stop locking `sess.mu` around session close paths so reset/close can cancel an active stream immediately
- add a regression test covering `resetSessionIfCurrent` while a reply is actively streaming

## Why

Telegram replies are streamed directly through `sess.runtime.Engine.Stream(...)`, so the runtime cleanup hook alone does not stop an in-flight reply. That allowed `/reset`, idle-session replacement, or shutdown to swap out a session while the old reply goroutine kept editing Telegram messages and persisting output into the stale session. Cancelling the stream first and waiting for it to exit ensures the old session is actually stopped before it is considered closed or replaced.
