### PR TITLE
fix: Chat tool-result messages lose function names unless the matching tool call is replayed

### DIFF
--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -57,6 +57,8 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 		defer runtime.Close()
 	}
 
+	populateMissingToolResultNames(messages, runtime.history)
+
 	search := runtime.search
 	requestedTools := parseChatRequestedToolNames(req.Tools)
 	toolChoice := parseToolChoice(req.ToolChoice)

--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -43,6 +43,7 @@ type chatMessage struct {
 	Content    json.RawMessage `json:"content,omitempty"`
 	ToolCalls  []chatToolCall  `json:"tool_calls,omitempty"`
 	ToolCallID string          `json:"tool_call_id,omitempty"`
+	Name       string          `json:"name,omitempty"`
 }
 
 type chatToolCall struct {
@@ -105,7 +106,10 @@ func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 			if callID == "" {
 				return nil, false, fmt.Errorf("tool message missing tool_call_id")
 			}
-			name := callNameByID[callID]
+			name := strings.TrimSpace(msg.Name)
+			if name == "" {
+				name = callNameByID[callID]
+			}
 			result = append(result, llm.ToolResultMessage(callID, name, extractMessageText(msg.Content), nil))
 			replaceHistory = true
 		default:
@@ -114,6 +118,53 @@ func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 	}
 
 	return result, replaceHistory, nil
+}
+
+func populateMissingToolResultNames(messages []llm.Message, history []llm.Message) {
+	callNameByID := make(map[string]string)
+	collectToolNamesByID(callNameByID, history)
+	if len(callNameByID) == 0 {
+		return
+	}
+	for i := range messages {
+		for j := range messages[i].Parts {
+			part := &messages[i].Parts[j]
+			if part.Type != llm.PartToolResult || part.ToolResult == nil {
+				continue
+			}
+			if strings.TrimSpace(part.ToolResult.Name) != "" {
+				continue
+			}
+			part.ToolResult.Name = callNameByID[strings.TrimSpace(part.ToolResult.ID)]
+		}
+	}
+}
+
+func collectToolNamesByID(callNameByID map[string]string, messages []llm.Message) {
+	for _, msg := range messages {
+		for _, part := range msg.Parts {
+			switch part.Type {
+			case llm.PartToolCall:
+				if part.ToolCall == nil {
+					continue
+				}
+				callID := strings.TrimSpace(part.ToolCall.ID)
+				name := strings.TrimSpace(part.ToolCall.Name)
+				if callID != "" && name != "" {
+					callNameByID[callID] = name
+				}
+			case llm.PartToolResult:
+				if part.ToolResult == nil {
+					continue
+				}
+				callID := strings.TrimSpace(part.ToolResult.ID)
+				name := strings.TrimSpace(part.ToolResult.Name)
+				if callID != "" && name != "" {
+					callNameByID[callID] = name
+				}
+			}
+		}
+	}
 }
 
 func parseChatRequestedToolNames(tools []chatTool) map[string]bool {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1006,6 +1006,35 @@ func TestParseChatMessages_ToolCallAndToolResult(t *testing.T) {
 	}
 }
 
+func TestPopulateMissingToolResultNames_UsesHistory(t *testing.T) {
+	messages, _, err := parseChatMessages([]chatMessage{{
+		Role:       "tool",
+		ToolCallID: "call_1",
+		Content:    json.RawMessage(`"done"`),
+	}})
+	if err != nil {
+		t.Fatalf("parseChatMessages failed: %v", err)
+	}
+
+	history := []llm.Message{{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{{
+			Type: llm.PartToolCall,
+			ToolCall: &llm.ToolCall{
+				ID:        "call_1",
+				Name:      "read_file",
+				Arguments: json.RawMessage(`{"path":"a.txt"}`),
+			},
+		}},
+	}}
+
+	populateMissingToolResultNames(messages, history)
+
+	if got := messages[0].Parts[0].ToolResult.Name; got != "read_file" {
+		t.Fatalf("tool result name = %q, want %q", got, "read_file")
+	}
+}
+
 func TestParseChatMessages_DeveloperDoesNotSuppressServerSystemPrompt(t *testing.T) {
 	msgs, replaceHistory, err := parseChatMessages([]chatMessage{
 		{Role: "developer", Content: json.RawMessage(`"Be concise"`)},
@@ -6116,6 +6145,69 @@ func TestChatCompletions_PreservesClientPassthroughTools(t *testing.T) {
 	}
 	if _, ok := props["query"]; !ok {
 		t.Fatalf("expected query property in schema, got %#v", props)
+	}
+}
+
+func TestChatCompletions_ToolResultWithoutReplayedToolCallKeepsNameFromSessionHistory(t *testing.T) {
+	provider := llm.NewMockProvider("mock").
+		AddToolCall("call-1", "client_tool", map[string]any{"query": "hi"}).
+		AddTextResponse("all set")
+	engine := llm.NewEngine(provider, nil)
+
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	srv := &serveServer{sessionMgr: mgr}
+
+	firstBody := `{
+		"model": "test",
+		"messages": [{"role": "user", "content": "Hi"}],
+		"tools": [{"type": "function", "function": {"name": "client_tool"}}]
+	}`
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(firstBody))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstReq.Header.Set("session_id", "tool-history-session")
+	firstResp := httptest.NewRecorder()
+	srv.handleChatCompletions(firstResp, firstReq)
+	if firstResp.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want 200; body: %s", firstResp.Code, firstResp.Body.String())
+	}
+
+	secondBody := `{
+		"model": "test",
+		"messages": [{"role": "tool", "tool_call_id": "call-1", "content": "done"}]
+	}`
+	secondReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(secondBody))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondReq.Header.Set("session_id", "tool-history-session")
+	secondResp := httptest.NewRecorder()
+	srv.handleChatCompletions(secondResp, secondReq)
+	if secondResp.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want 200; body: %s", secondResp.Code, secondResp.Body.String())
+	}
+
+	if len(provider.Requests) != 2 {
+		t.Fatalf("provider request count = %d, want 2", len(provider.Requests))
+	}
+
+	var toolResultName string
+	for _, msg := range provider.Requests[1].Messages {
+		for _, part := range msg.Parts {
+			if part.Type != llm.PartToolResult || part.ToolResult == nil || part.ToolResult.ID != "call-1" {
+				continue
+			}
+			toolResultName = part.ToolResult.Name
+		}
+	}
+	if toolResultName != "client_tool" {
+		t.Fatalf("tool result name = %q, want %q", toolResultName, "client_tool")
 	}
 }
 


### PR DESCRIPTION
## What

- preserve tool result names from an explicit `name` field when clients send one
- backfill missing chat tool-result names from the session history before running the request
- add regression coverage for both the history backfill helper and the chat-completions session flow

## Why

Chat-completions `role:"tool"` messages were only resolving their function name from assistant `tool_calls` replayed earlier in the same HTTP request. When a client sent a tool result on a later turn without replaying that assistant block, term-llm stored the tool result with an empty name, which corrupted reconstructed tool history for subsequent provider requests.
