### PR TITLE
fix: Responses API tool follow-up loses the original tool name

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -121,6 +121,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
+		s.populateResponsesToolResultNames(ctx, sessionID, runtime, inputMessages)
 	}
 	if !stateful {
 		defer func() {
@@ -207,6 +208,77 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	s.registerResponseID(runtime, respID, sessionID)
 
 	writeJSON(w, http.StatusOK, responsesFinalResponse(result, model, respID))
+}
+
+func (s *serveServer) populateResponsesToolResultNames(ctx context.Context, sessionID string, runtime *serveRuntime, messages []llm.Message) {
+	missing := map[string]bool{}
+	for _, msg := range messages {
+		for _, part := range msg.Parts {
+			if part.Type != llm.PartToolResult || part.ToolResult == nil {
+				continue
+			}
+			id := strings.TrimSpace(part.ToolResult.ID)
+			if id == "" || strings.TrimSpace(part.ToolResult.Name) != "" {
+				continue
+			}
+			missing[id] = true
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	names := map[string]string{}
+	collect := func(history []llm.Message) {
+		for i := len(history) - 1; i >= 0; i-- {
+			for _, part := range history[i].Parts {
+				if part.Type != llm.PartToolCall || part.ToolCall == nil {
+					continue
+				}
+				id := strings.TrimSpace(part.ToolCall.ID)
+				if id == "" || !missing[id] || names[id] != "" {
+					continue
+				}
+				if name := strings.TrimSpace(part.ToolCall.Name); name != "" {
+					names[id] = name
+				}
+			}
+			if len(names) == len(missing) {
+				return
+			}
+		}
+	}
+
+	if s.store != nil && sessionID != "" {
+		if stored, err := s.store.GetMessages(ctx, sessionID, 0, 0); err == nil {
+			persisted := make([]llm.Message, 0, len(stored))
+			for _, msg := range stored {
+				persisted = append(persisted, msg.ToLLMMessage())
+			}
+			collect(persisted)
+		}
+	}
+	if len(names) < len(missing) && runtime != nil {
+		collect(runtime.snapshotHistory())
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	for msgIndex := range messages {
+		for partIndex := range messages[msgIndex].Parts {
+			part := &messages[msgIndex].Parts[partIndex]
+			if part.Type != llm.PartToolResult || part.ToolResult == nil {
+				continue
+			}
+			if strings.TrimSpace(part.ToolResult.Name) != "" {
+				continue
+			}
+			if name := names[strings.TrimSpace(part.ToolResult.ID)]; name != "" {
+				part.ToolResult.Name = name
+			}
+		}
+	}
 }
 
 func appendResponsePassthroughTools(serverTools []llm.ToolSpec, passthroughTools []llm.ToolSpec, toolMap map[string]string) []llm.ToolSpec {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -463,6 +463,19 @@ func (rt *serveRuntime) getResponseIDs() []string {
 	return append([]string(nil), rt.responseIDs...)
 }
 
+// snapshotHistory returns a copy of the current history when the runtime is idle.
+// If a run is already in progress, it returns nil so callers can fall back to
+// persisted session history or report busy via the normal run path.
+func (rt *serveRuntime) snapshotHistory() []llm.Message {
+	if rt == nil || !rt.mu.TryLock() {
+		return nil
+	}
+	defer rt.mu.Unlock()
+	history := make([]llm.Message, len(rt.history))
+	copy(history, rt.history)
+	return history
+}
+
 type serveRunResult struct {
 	Text         strings.Builder
 	ToolCalls    []llm.ToolCall

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3448,6 +3448,146 @@ func TestHandleResponses_PreviousResponseIDChainsSession(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_PreviousResponseIDFunctionCallOutputUsesPriorToolName(t *testing.T) {
+	provider := llm.NewMockProvider("mock").
+		AddToolCall("call_1", "read_file", map[string]any{"path": "a.txt"}).
+		AddTextResponse("done")
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager}
+	manager.onEvict = func(rt *serveRuntime) {
+		for _, rid := range rt.getResponseIDs() {
+			srv.responseToSession.Delete(rid)
+		}
+	}
+
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"hi","tools":[{"type":"function","name":"read_file","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}]}`, "tool-chain")
+	if code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", code)
+	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
+
+	body2 := `{"input":[{"type":"function_call_output","call_id":"call_1","output":"content"}],"previous_response_id":"` + respID1 + `"}`
+	code, _ = doResponses(t, srv, body2)
+	if code != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200", code)
+	}
+	if len(provider.Requests) != 2 {
+		t.Fatalf("provider request count = %d, want 2", len(provider.Requests))
+	}
+
+	var toolResultName string
+	for _, msg := range provider.Requests[1].Messages {
+		for _, part := range msg.Parts {
+			if part.Type != llm.PartToolResult || part.ToolResult == nil || part.ToolResult.ID != "call_1" {
+				continue
+			}
+			toolResultName = part.ToolResult.Name
+		}
+	}
+	if toolResultName != "read_file" {
+		t.Fatalf("tool result name = %q, want %q", toolResultName, "read_file")
+	}
+}
+
+func TestHandleResponses_PreviousResponseIDFunctionCallOutputUsesPersistedToolNameAfterRuntimeRecreation(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	var created atomic.Int32
+	providers := map[int32]*llm.MockProvider{}
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		createNum := created.Add(1)
+		provider := llm.NewMockProvider("mock")
+		if createNum == 1 {
+			provider.AddToolCall("call_1", "read_file", map[string]any{"path": "a.txt"})
+		} else {
+			provider.AddTextResponse("done")
+		}
+		providers[createNum] = provider
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  "mock",
+			engine:       engine,
+			defaultModel: "mock-model",
+			store:        store,
+		}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager, store: store}
+	manager.onEvict = func(rt *serveRuntime) {
+		for _, rid := range rt.getResponseIDs() {
+			srv.responseToSession.Delete(rid)
+		}
+	}
+
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"hi","tools":[{"type":"function","name":"read_file","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}]}`, "tool-chain-store")
+	if code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", code)
+	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
+
+	manager.mu.Lock()
+	evicted := manager.sessions["tool-chain-store"]
+	delete(manager.sessions, "tool-chain-store")
+	manager.mu.Unlock()
+	if evicted != nil {
+		evicted.Close()
+	}
+
+	body2 := `{"input":[{"type":"function_call_output","call_id":"call_1","output":"content"}],"previous_response_id":"` + respID1 + `"}`
+	code, _ = doResponses(t, srv, body2)
+	if code != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200", code)
+	}
+	provider := providers[2]
+	if provider == nil {
+		t.Fatal("expected recreated runtime provider")
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("recreated provider request count = %d, want 1", len(provider.Requests))
+	}
+
+	var toolResultName string
+	for _, msg := range provider.Requests[0].Messages {
+		for _, part := range msg.Parts {
+			if part.Type != llm.PartToolResult || part.ToolResult == nil || part.ToolResult.ID != "call_1" {
+				continue
+			}
+			toolResultName = part.ToolResult.Name
+		}
+	}
+	if toolResultName != "read_file" {
+		t.Fatalf("persisted tool result name = %q, want %q", toolResultName, "read_file")
+	}
+}
+
 func TestHandleResponses_PreviousResponseIDRestoresPersistedProviderAfterRuntimeRecreation(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

Preserve tool names for Responses API `function_call_output` follow-ups by backfilling missing tool-result names from the prior session history.

This looks up the original `function_call` by `call_id` from persisted session messages when available, with an in-memory runtime history fallback, and applies the recovered name before the next model turn runs.

Also adds regression coverage for both normal chained follow-ups and runtime recreation from persisted history.

## Why

In normal `previous_response_id` follow-up flows, clients often send only a `function_call_output` item. The original code only populated tool names from `function_call` items present in the same request, so the tool result name was lost.

That produced malformed tool-result history for the next model turn, which can break provider validation or cause incorrect continuation because the tool result is no longer reliably tied to the original function call.
