### PR TITLE
fix: serveServer.Stop panics if called twice

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -816,6 +816,7 @@ type serveServer struct {
 	store             session.Store
 	server            *http.Server
 	shutdownCh        chan struct{}
+	shutdownOnce      sync.Once
 	modelsMu          sync.Mutex
 	modelsProviders   map[string]llm.Provider // keyed by provider name
 	responseToSession sync.Map                // response_id (string) → session_id (string)
@@ -827,6 +828,7 @@ type serveServer struct {
 
 func (s *serveServer) Start() error {
 	s.shutdownCh = make(chan struct{})
+	s.shutdownOnce = sync.Once{}
 	s.server = &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", s.cfg.host, s.cfg.port),
 		Handler: s.httpHandler(),
@@ -918,9 +920,11 @@ func (s *serveServer) Stop(ctx context.Context) error {
 	}
 	// Signal all SSE handlers to return immediately so server.Shutdown
 	// does not block waiting for long-lived streaming connections.
-	if s.shutdownCh != nil {
-		close(s.shutdownCh)
-	}
+	s.shutdownOnce.Do(func() {
+		if s.shutdownCh != nil {
+			close(s.shutdownCh)
+		}
+	})
 	if s.jobsV2 != nil {
 		_ = s.jobsV2.Close()
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -144,6 +144,20 @@ func newServeHTTPTestServer(srv *serveServer) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
+func TestServeServerStopIsIdempotent(t *testing.T) {
+	s := &serveServer{
+		server:     &http.Server{},
+		shutdownCh: make(chan struct{}),
+	}
+
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatalf("first Stop() error = %v", err)
+	}
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
+	}
+}
+
 func readSSEEvent(t *testing.T, scanner *bufio.Scanner) (string, string, bool) {
 	t.Helper()
 


### PR DESCRIPTION
## What

Make `serveServer.Stop` idempotent by guarding shutdown channel closure with `sync.Once`, and add a regression test that calls `Stop` twice.

## Why

`Stop` could panic with `close of closed channel` when shutdown was triggered more than once, which made server teardown brittle in layered cleanup paths.
