### PR TITLE
fix: Responses API streaming aborts on any SSE line larger than 1MB

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -586,9 +586,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
 		defer resp.Body.Close()
 
-		scanner := bufio.NewScanner(resp.Body)
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		reader := bufio.NewReader(resp.Body)
 
 		// Tool call state for accumulating streaming function calls
 		toolState := newResponsesToolState()
@@ -597,13 +595,26 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		var lastEventType string
 		var sawTextDelta bool // Track if any text deltas were emitted
 
-		for scanner.Scan() {
-			line := scanner.Text()
+		for {
+			line, eof, err := readSSELine(reader)
+			if err != nil {
+				return fmt.Errorf("Responses API streaming error: %w", err)
+			}
+			if eof && line == "" {
+				break
+			}
+
 			if strings.HasPrefix(line, "event: ") {
 				lastEventType = strings.TrimPrefix(line, "event: ")
+				if eof {
+					break
+				}
 				continue
 			}
 			if !strings.HasPrefix(line, "data: ") {
+				if eof {
+					break
+				}
 				continue
 			}
 			data := strings.TrimPrefix(line, "data: ")
@@ -734,10 +745,9 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 			}
 
 			lastEventType = ""
-		}
-
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("Responses API streaming error: %w", err)
+			if eof {
+				break
+			}
 		}
 
 		// Emit completed tool calls

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -1026,6 +1026,76 @@ func TestResponsesClient_NoOnAuthRetry_Returns401Error(t *testing.T) {
 	}
 }
 
+func TestResponsesClientStream_AllowsLargeSSEDataLines(t *testing.T) {
+	largeDelta := strings.Repeat("x", 1024*1024+32)
+	deltaJSON, err := json.Marshal(struct {
+		Delta string `json:"delta"`
+	}{Delta: largeDelta})
+	if err != nil {
+		t.Fatalf("marshal delta event: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body: io.NopCloser(strings.NewReader(
+					"event: response.output_text.delta\n" +
+						"data: " + string(deltaJSON) + "\n\n" +
+						"event: response.completed\n" +
+						"data: {\"response\":{\"id\":\"resp_large\"}}\n\n" +
+						"data: [DONE]\n\n",
+				)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+
+	var got strings.Builder
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("stream recv failed: %v", recvErr)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			got.WriteString(event.Text)
+		case EventError:
+			t.Fatalf("unexpected error event: %v", event.Err)
+		case EventDone:
+			if got.String() != largeDelta {
+				t.Fatalf("expected %d bytes of text delta, got %d", len(largeDelta), got.Len())
+			}
+			if client.LastResponseID != "resp_large" {
+				t.Fatalf("expected LastResponseID resp_large, got %q", client.LastResponseID)
+			}
+			return
+		}
+	}
+
+	t.Fatal("expected EventDone")
+}
+
 func assertResponsesAPIErrorBodyTruncated(t *testing.T, err error, prefix string) {
 	t.Helper()
 


### PR DESCRIPTION
## What

Replace the Responses API SSE stream reader with a `bufio.Reader` line reader so `data:` lines are no longer capped at Scanner's 1MB token limit.

Add a regression test that streams a single `response.output_text.delta` event with a payload larger than 1MB and verifies the full text and final response ID are delivered.

## Why

Providers can emit valid SSE `data:` lines larger than 1MB for long reasoning output, large tool arguments, or large text segments. The previous `bufio.Scanner`-based reader aborted those streams with `token too long`, cutting off text, tool calls, and usage data mid-response.
