### PR TITLE
fix: return 409 when session limit reached and all sessions are busy

### DIFF
--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -62,6 +62,10 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 	}
 	runtime, stateful, err := s.runtimeForRequest(ctx, sessionID)
 	if err != nil {
+		if errors.Is(err, errServeSessionBusy) || errors.Is(err, errServeSessionLimitReached) {
+			writeAnthropicError(w, http.StatusConflict, "api_error", err.Error())
+			return
+		}
 		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -50,6 +50,10 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 	}
 	runtime, stateful, err := s.runtimeForRequest(ctx, sessionID)
 	if err != nil {
+		if errors.Is(err, errServeSessionBusy) || errors.Is(err, errServeSessionLimitReached) {
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
+			return
+		}
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -99,6 +99,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, reqProvider)
 	}
 	if err != nil {
+		if errors.Is(err, errServeSessionBusy) || errors.Is(err, errServeSessionLimitReached) {
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
+			return
+		}
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -470,7 +470,10 @@ type serveRunResult struct {
 	SessionUsage llm.Usage
 }
 
-var errServeSessionBusy = errors.New("session is busy processing another request")
+var (
+	errServeSessionBusy         = errors.New("session is busy processing another request")
+	errServeSessionLimitReached = errors.New("session limit reached: all sessions are busy")
+)
 
 func (rt *serveRuntime) Run(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request) (serveRunResult, error) {
 	return rt.run(ctx, stateful, replaceHistory, inputMessages, req, nil)

--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -99,6 +99,19 @@ func (m *serveSessionManager) evictOldestIdleLocked() *serveRuntime {
 	return evicted
 }
 
+func (m *serveSessionManager) makeRoomForNewSessionLocked() (*serveRuntime, error) {
+	if len(m.sessions) < m.max {
+		return nil, nil
+	}
+
+	evicted := m.evictOldestIdleLocked()
+	if evicted != nil {
+		return evicted, nil
+	}
+
+	return nil, errServeSessionLimitReached
+}
+
 // Get returns an existing session runtime without creating one.
 // Returns (nil, false) if the session does not exist.
 func (m *serveSessionManager) Get(id string) (*serveRuntime, bool) {
@@ -160,9 +173,11 @@ func (m *serveSessionManager) GetOrCreate(ctx context.Context, id string) (*serv
 			duplicate = rt
 		} else {
 			rt.Touch()
-			evicted = m.evictOldestIdleLocked()
-			m.sessions[id] = rt
-			inflight.rt = rt
+			evicted, inflight.err = m.makeRoomForNewSessionLocked()
+			if inflight.err == nil {
+				m.sessions[id] = rt
+				inflight.rt = rt
+			}
 		}
 	}
 	close(inflight.done)
@@ -242,9 +257,11 @@ func (m *serveSessionManager) GetOrCreateWith(ctx context.Context, id string, cr
 			duplicate = rt
 		} else {
 			rt.Touch()
-			evicted = m.evictOldestIdleLocked()
-			m.sessions[id] = rt
-			inflight.rt = rt
+			evicted, inflight.err = m.makeRoomForNewSessionLocked()
+			if inflight.err == nil {
+				m.sessions[id] = rt
+				inflight.rt = rt
+			}
 		}
 	}
 	close(inflight.done)
@@ -352,9 +369,11 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 			duplicate = rt
 		} else {
 			rt.Touch()
-			evicted = m.evictOldestIdleLocked()
-			m.sessions[id] = rt
-			inflight.rt = rt
+			evicted, inflight.err = m.makeRoomForNewSessionLocked()
+			if inflight.err == nil {
+				m.sessions[id] = rt
+				inflight.rt = rt
+			}
 		}
 	}
 	close(inflight.done)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1326,7 +1326,65 @@ func TestServeSessionManager_GetOrCreateSkipsEvictingActiveRunAtCapacity(t *test
 	}
 }
 
-func TestServeSessionManager_GetOrCreateWithDoesNotEvictActiveRunWhenAllSessionsAreBusy(t *testing.T) {
+func TestServeSessionManager_GetOrCreateReturnsErrorWhenAllSessionsAreBusyAtCapacity(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 1, func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	var evictions atomic.Int32
+	manager.onEvict = func(rt *serveRuntime) {
+		evictions.Add(1)
+	}
+
+	busyCtx, busyCancel := context.WithCancel(context.Background())
+	defer busyCancel()
+
+	busy := &serveRuntime{}
+	busy.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+	busyState := &runtimeInterruptState{cancel: busyCancel, done: make(chan struct{})}
+	busy.setActiveInterrupt(busyState)
+
+	manager.mu.Lock()
+	manager.sessions["busy"] = busy
+	manager.mu.Unlock()
+
+	created, err := manager.GetOrCreate(context.Background(), "new")
+	if !errors.Is(err, errServeSessionLimitReached) {
+		t.Fatalf("error = %v, want %v", err, errServeSessionLimitReached)
+	}
+	if created != nil {
+		t.Fatal("expected no runtime to be created")
+	}
+
+	manager.mu.Lock()
+	_, busyOK := manager.sessions["busy"]
+	_, newOK := manager.sessions["new"]
+	sessionCount := len(manager.sessions)
+	manager.mu.Unlock()
+
+	if !busyOK {
+		t.Fatal("expected active session to remain in manager")
+	}
+	if newOK {
+		t.Fatal("expected new session not to be stored when all sessions are busy")
+	}
+	if sessionCount != 1 {
+		t.Fatalf("session count = %d, want 1", sessionCount)
+	}
+	if got := evictions.Load(); got != 0 {
+		t.Fatalf("evictions = %d, want 0", got)
+	}
+	select {
+	case <-busyCtx.Done():
+		t.Fatal("expected active session not to be cancelled during capacity check")
+	default:
+	}
+}
+
+func TestServeSessionManager_GetOrCreateWithReturnsErrorWhenAllSessionsAreBusyAtCapacity(t *testing.T) {
 	manager := newServeSessionManager(time.Minute, 1, nil)
 	defer manager.Close()
 
@@ -1352,11 +1410,11 @@ func TestServeSessionManager_GetOrCreateWithDoesNotEvictActiveRunWhenAllSessions
 		rt.Touch()
 		return rt, nil
 	})
-	if err != nil {
-		t.Fatalf("GetOrCreateWith error: %v", err)
+	if !errors.Is(err, errServeSessionLimitReached) {
+		t.Fatalf("error = %v, want %v", err, errServeSessionLimitReached)
 	}
-	if created == nil {
-		t.Fatal("expected created runtime")
+	if created != nil {
+		t.Fatal("expected no runtime to be created")
 	}
 
 	manager.mu.Lock()
@@ -1368,18 +1426,18 @@ func TestServeSessionManager_GetOrCreateWithDoesNotEvictActiveRunWhenAllSessions
 	if !busyOK {
 		t.Fatal("expected active session to remain in manager")
 	}
-	if !newOK {
-		t.Fatal("expected new session to be stored in manager")
+	if newOK {
+		t.Fatal("expected new session not to be stored when all sessions are busy")
 	}
-	if sessionCount != 2 {
-		t.Fatalf("session count = %d, want 2", sessionCount)
+	if sessionCount != 1 {
+		t.Fatalf("session count = %d, want 1", sessionCount)
 	}
 	if got := evictions.Load(); got != 0 {
 		t.Fatalf("evictions = %d, want 0", got)
 	}
 	select {
 	case <-busyCtx.Done():
-		t.Fatal("expected active session not to be cancelled during capacity eviction")
+		t.Fatal("expected active session not to be cancelled during capacity check")
 	default:
 	}
 }


### PR DESCRIPTION
## What

When the session manager is at capacity and all existing sessions are actively busy (no idle session can be evicted), `GetOrCreate`/`GetOrCreateWith`/`ReplaceIdleWith` now return `errServeSessionLimitReached` instead of silently adding a new session and exceeding the configured limit.

All three HTTP handler paths (Anthropic messages, Chat completions, Responses API) propagate this as a `409 Conflict` response.

## Why

The previous behaviour bypassed `max` entirely when all sessions were active — a client could create an unbounded number of sessions by hammering a busy server. The fix makes capacity enforcement complete: evict an idle session if possible, otherwise reject with a 409.

## Tests

- `TestServeSessionManager_GetOrCreateReturnsErrorWhenAllSessionsAreBusyAtCapacity` (new)
- `TestServeSessionManager_GetOrCreateWithReturnsErrorWhenAllSessionsAreBusyAtCapacity` (updated — previously asserted the wrong behaviour)
