### PR TITLE
fix: wait for stream goroutine before snapshotting history on Telegram interrupt

### DIFF
--- a/internal/llm/stream.go
+++ b/internal/llm/stream.go
@@ -10,13 +10,16 @@ type channelStream struct {
 	cancel      context.CancelFunc
 	events      <-chan Event
 	terminalErr <-chan error
+	done        <-chan struct{}
 }
 
 func newEventStream(ctx context.Context, run func(context.Context, chan<- Event) error) Stream {
 	streamCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan Event, 16)
 	terminalErr := make(chan error, 1)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		if err := run(streamCtx, ch); err != nil {
 			// If the consumer has stopped draining and the buffer is full, preserve the
 			// terminal error for Recv() rather than dropping it and reporting clean EOF.
@@ -30,7 +33,7 @@ func newEventStream(ctx context.Context, run func(context.Context, chan<- Event)
 		close(terminalErr)
 		close(ch)
 	}()
-	return &channelStream{ctx: streamCtx, cancel: cancel, events: ch, terminalErr: terminalErr}
+	return &channelStream{ctx: streamCtx, cancel: cancel, events: ch, terminalErr: terminalErr, done: done}
 }
 
 func (s *channelStream) Recv() (Event, error) {
@@ -64,5 +67,6 @@ func (s *channelStream) Recv() (Event, error) {
 
 func (s *channelStream) Close() error {
 	s.cancel()
+	<-s.done
 	return nil
 }

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1413,10 +1413,17 @@ loop:
 
 			// User interrupt: cancel the stream and preserve partial state.
 			stream.Close()
+			// Wait for the Recv goroutine to finish draining anything already in-flight
+			// so history snapshots include the final partial text and callback-produced
+			// messages from the interrupted turn.
+			<-streamDone
 
 			textMu.Lock()
 			partial := textBuf.String()
 			textMu.Unlock()
+			producedMu.Lock()
+			producedSnapshot := append([]llm.Message(nil), produced...)
+			producedMu.Unlock()
 
 			// Edit the Telegram message to show partial text + interrupted marker.
 			display := ""
@@ -1437,14 +1444,12 @@ loop:
 			sendEdit(currentMsgID, display, true)
 
 			// Preserve partial history so conversation context isn't lost.
-			newHistory := make([]llm.Message, 0, len(sess.history)+2+len(produced))
+			newHistory := make([]llm.Message, 0, len(sess.history)+2+len(producedSnapshot))
 			newHistory = append(newHistory, sess.history...)
 			newHistory = append(newHistory, normalizeUserMessageForHistory(userMsg))
-			producedMu.Lock()
-			newHistory = append(newHistory, produced...)
-			producedMu.Unlock()
+			newHistory = append(newHistory, producedSnapshot...)
 			// If we have partial text but no tool turns completed, save it.
-			if len(produced) == 0 && partial != "" {
+			if len(producedSnapshot) == 0 && partial != "" {
 				newHistory = append(newHistory, llm.AssistantText(partial))
 			}
 			sess.history = newHistory

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1040,6 +1040,75 @@ func TestHandleMessage_InterruptPreservesHistory(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_InterruptWaitsForToolCallbackBeforePersistingHistory(t *testing.T) {
+	h := testutil.NewEngineHarness()
+
+	toolStarted := make(chan struct{})
+
+	slowTool := &testutil.MockTool{
+		SpecData: llm.ToolSpec{
+			Name:        "slow_tool",
+			Description: "slow tool for testing",
+			Schema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		ExecuteFn: func(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+			close(toolStarted)
+			<-ctx.Done()
+			time.Sleep(25 * time.Millisecond)
+			return llm.TextOutput("cancelled"), ctx.Err()
+		},
+	}
+	h.Registry.Register(slowTool)
+
+	h.Provider.AddToolCall("call-1", "slow_tool", map[string]any{})
+	h.Provider.AddTextResponse("should not reach")
+
+	mgr, sess := newTestMgrAndSession(h)
+	bot := &fakeBotSender{}
+
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("do slow thing"))
+	}()
+
+	select {
+	case <-toolStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool never started")
+	}
+
+	sess.cancelMu.Lock()
+	cancelFn := sess.streamCancel
+	sess.cancelMu.Unlock()
+	if cancelFn == nil {
+		t.Fatal("expected streamCancel to be set during active stream")
+	}
+	cancelFn()
+
+	if err := <-streamDone; err != nil {
+		t.Fatalf("streamReply should return nil on interrupt, got: %v", err)
+	}
+
+	sess.mu.Lock()
+	history := append([]llm.Message(nil), sess.history...)
+	sess.mu.Unlock()
+
+	foundToolResult := false
+	for _, msg := range history {
+		for _, part := range msg.Parts {
+			if part.Type == llm.PartToolResult && part.ToolResult != nil && part.ToolResult.ID == "call-1" {
+				foundToolResult = true
+			}
+		}
+	}
+	if !foundToolResult {
+		t.Fatalf("expected interrupted history to include cancelled tool result; history len=%d", len(history))
+	}
+}
+
 func TestStreamReply_WatchdogTimeoutIsNotTreatedAsUserInterrupt(t *testing.T) {
 	oldTimeout := streamEventTimeout
 	streamEventTimeout = 25 * time.Millisecond


### PR DESCRIPTION
## What

Fix a race condition in Telegram's interrupt handling: after cancelling an in-flight LLM stream, the interrupt path now waits for the stream goroutine to fully exit before snapshotting `produced[]` and building the history entry.

Changes:
- `internal/llm/stream.go`: `channelStream` gains a `done` channel closed when the goroutine exits. `Close()` blocks on `<-s.done`.
- `internal/serve/telegram.go`: interrupt path waits on `<-streamDone` after `stream.Close()`, then takes a race-free snapshot of `produced` under its mutex.

## Why

`stream.Close()` cancelled the context but returned immediately. The goroutine running `Recv()` could still be appending tool callback results to `produced[]` while the interrupt handler concurrently read and appended that slice — a data race that could drop tool results from the saved history.

## Tests

`TestHandleMessage_InterruptWaitsForToolCallbackBeforePersistingHistory` (new) — starts a slow tool call, fires an interrupt mid-execution, and asserts the cancelled tool result appears in the persisted history.
