### PR TITLE
fix: Detached stateless /v1/responses runs are cancelled on client disconnect

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -126,8 +126,12 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if !stateful {
+	cleanupRuntime := !stateful
+	if cleanupRuntime {
 		defer func() {
+			if !cleanupRuntime {
+				return
+			}
 			runtime.Close()
 			s.unregisterResponseIDs(runtime)
 		}()
@@ -175,7 +179,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		if isServeUIRequest(r) && stateful {
 			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID)
 		} else {
-			s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID)
+			started := s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID)
+			if !stateful && started {
+				cleanupRuntime = false
+			}
 		}
 		return
 	}
@@ -237,8 +244,8 @@ func appendResponsePassthroughTools(serverTools []llm.ToolSpec, passthroughTools
 	return serverTools
 }
 
-func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string) {
-	s.streamResponseRun(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, startResponseRunOptions{
+func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string) bool {
+	return s.streamResponseRun(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, startResponseRunOptions{
 		previousResponseID: previousResponseID,
 	})
 }

--- a/cmd/serve_ui_stream.go
+++ b/cmd/serve_ui_stream.go
@@ -28,12 +28,13 @@ func (s *serveServer) streamUIResponses(w http.ResponseWriter, r *http.Request, 
 	})
 }
 
-func (s *serveServer) streamResponseRun(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, options startResponseRunOptions) {
+func (s *serveServer) streamResponseRun(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, options startResponseRunOptions) bool {
 	run, err := s.startResponseRun(runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, options)
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
-		return
+		return false
 	}
 	w.Header().Set("x-response-id", run.id)
 	s.streamResponseRunEvents(ctx, w, run, 0)
+	return true
 }


### PR DESCRIPTION
## What

Prevent `handleResponses` from tearing down a stateless runtime after a detached streaming `/v1/responses` run has successfully started. The handler now keeps its cleanup defer for non-streaming/stateless requests and only releases ownership when the detached stream setup succeeds, letting the background run own runtime cleanup.

## Why

Detached response runs are intentionally meant to outlive the original HTTP connection so clients can reconnect and resume SSE events after disconnects. Closing the runtime from the request handler cancelled those runs early and removed response ID mappings before the background work finished.
