### PR TITLE
fix: Agentic tool loop can deadlock on cancellation because it does blocking event sends

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -665,6 +665,18 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 	maxTurns := getMaxTurns(req)
 	originalToolChoice := req.ToolChoice
 	restoredToolChoice := false
+	sendEvent := func(event Event) error {
+		if events == nil {
+			return nil
+		}
+		if safeSendEvent(ctx, events, event) {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// Snapshot callbacks and compaction config at start — protects against
 	// concurrent modification from the UI thread (e.g., SetCompaction called
@@ -713,7 +725,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 		if compactionConfig != nil && attempt > 0 {
 			threshold := int(float64(inputLimit) * compactionConfig.ThresholdRatio)
 			if e.estimatedTokens(req.Messages) >= threshold {
-				events <- Event{Type: EventPhase, Text: "Compacting context..."}
+				if err := sendEvent(Event{Type: EventPhase, Text: "Compacting context..."}); err != nil {
+					return err
+				}
 				result, err := Compact(ctx, e.provider, req.Model, systemPrompt, nonSystemMessages(req.Messages), *compactionConfig)
 				if err == nil {
 					req.Messages = result.NewMessages
@@ -737,7 +751,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			if est >= threshold {
 				e.contextNoticeEmitted.Store(true)
 				pct := int(100 * float64(est) / float64(inputLimit))
-				events <- Event{Type: EventPhase, Text: fmt.Sprintf(WarningPhasePrefix+"context is %d%% full. Add auto_compact: true to your config to enable automatic compaction.", pct)}
+				if err := sendEvent(Event{Type: EventPhase, Text: fmt.Sprintf(WarningPhasePrefix+"context is %d%% full. Add auto_compact: true to your config to enable automatic compaction.", pct)}); err != nil {
+					return err
+				}
 			}
 		}
 		// Prepare turn
@@ -767,7 +783,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			// Reactive compaction: if this is a context overflow error, try compacting and retrying (once)
 			if compactionConfig != nil && isContextOverflowError(err) && !reactiveCompactionDone {
 				reactiveCompactionDone = true
-				events <- Event{Type: EventPhase, Text: "Compacting context..."}
+				if err := sendEvent(Event{Type: EventPhase, Text: "Compacting context..."}); err != nil {
+					return err
+				}
 				result, compactErr := Compact(ctx, e.provider, req.Model, systemPrompt, nonSystemMessages(req.Messages), *compactionConfig)
 				if compactErr == nil {
 					req.Messages = result.NewMessages
@@ -787,7 +805,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			// Warn when compaction is disabled and we hit context overflow
 			if compactionConfig == nil && inputLimit > 0 && !e.contextNoticeEmitted.Load() && isContextOverflowError(err) {
 				e.contextNoticeEmitted.Store(true)
-				events <- Event{Type: EventPhase, Text: WarningPhasePrefix + "context overflow. Add auto_compact: true to your config to enable automatic compaction."}
+				if err := sendEvent(Event{Type: EventPhase, Text: WarningPhasePrefix + "context overflow. Add auto_compact: true to your config to enable automatic compaction."}); err != nil {
+					return err
+				}
 			}
 			return err
 		}
@@ -870,7 +890,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 						ToolName:   event.ToolName,
 						Tool:       event.Tool,
 					}
-					events <- forwardEvent
+					if err := sendEvent(forwardEvent); err != nil {
+						return err
+					}
 
 					// Handle synchronous execution: emit events to TUI and send result back
 					call, result, execErr := e.handleSyncToolExecution(ctx, event, events, req.Debug, req.DebugRaw)
@@ -906,19 +928,23 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 				toolCalls = append(toolCalls, *event.Tool)
 
 				info := e.getToolPreview(*event.Tool)
-				events <- Event{
+				if err := sendEvent(Event{
 					Type:       EventToolCall,
 					ToolCallID: toolCallID,
 					ToolName:   event.Tool.Name,
 					Tool:       event.Tool,
 					ToolInfo:   info,
+				}); err != nil {
+					return err
 				}
 				continue
 			}
 			if event.Type == EventDone {
 				continue
 			}
-			events <- event
+			if err := sendEvent(event); err != nil {
+				return err
+			}
 		}
 		stream.Close()
 
@@ -955,7 +981,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 				_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
 				cancel()
 			}
-			events <- Event{Type: EventDone}
+			if err := sendEvent(Event{Type: EventDone}); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -995,13 +1023,17 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 					cancel()
 				}
 				if events != nil {
-					events <- Event{Type: EventInterjection, Text: text}
+					if err := sendEvent(Event{Type: EventInterjection, Text: text}); err != nil {
+						return err
+					}
 				}
 			}
 
 			// If a finishing tool was executed, we're done (agent completed its task)
 			if finishingToolExecuted {
-				events <- Event{Type: EventDone}
+				if err := sendEvent(Event{Type: EventDone}); err != nil {
+					return err
+				}
 				return nil
 			}
 
@@ -1063,7 +1095,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 					cancel()
 				}
 			}
-			events <- Event{Type: EventDone}
+			if err := sendEvent(Event{Type: EventDone}); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -1170,7 +1204,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 		}
 
 		if finishingToolExecuted {
-			events <- Event{Type: EventDone}
+			if err := sendEvent(Event{Type: EventDone}); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -1187,7 +1223,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			}
 			// Emit event so TUI can display the interjection inline
 			if events != nil {
-				events <- Event{Type: EventInterjection, Text: text}
+				if err := sendEvent(Event{Type: EventInterjection, Text: text}); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -103,6 +103,50 @@ func (p *fakeProvider) Stream(ctx context.Context, req Request) (Stream, error) 
 	return &sliceStream{events: events}, nil
 }
 
+type streamProvider struct {
+	stream          Stream
+	capabilities    Capabilities
+	hasCapabilities bool
+}
+
+func (p *streamProvider) Name() string {
+	return "fake"
+}
+
+func (p *streamProvider) Credential() string {
+	return "test"
+}
+
+func (p *streamProvider) Capabilities() Capabilities {
+	if p.hasCapabilities {
+		return p.capabilities
+	}
+	return Capabilities{ToolCalls: true}
+}
+
+func (p *streamProvider) Stream(ctx context.Context, req Request) (Stream, error) {
+	return p.stream, nil
+}
+
+type signalRecvStream struct {
+	recvCalled chan struct{}
+	event      Event
+	sent       bool
+}
+
+func (s *signalRecvStream) Recv() (Event, error) {
+	if s.sent {
+		return Event{}, io.EOF
+	}
+	s.sent = true
+	close(s.recvCalled)
+	return s.event, nil
+}
+
+func (s *signalRecvStream) Close() error {
+	return nil
+}
+
 type countingSearchTool struct {
 	calls int
 }
@@ -1185,6 +1229,49 @@ func TestEngineEmitsToolCallAndExecStartForEachTool(t *testing.T) {
 		if _, ok := toolExecStartEvents[id]; !ok {
 			t.Errorf("EventToolCall ID %q has no matching EventToolExecStart", id)
 		}
+	}
+}
+
+func TestRunLoopDoesNotDeadlockOnBlockedToolCallForwardingWhenCancelled(t *testing.T) {
+	stream := &signalRecvStream{
+		recvCalled: make(chan struct{}),
+		event: Event{
+			Type: EventToolCall,
+			Tool: &ToolCall{
+				Name:      "count_tool",
+				Arguments: json.RawMessage(`{"input":"test"}`),
+			},
+		},
+	}
+	engine := NewEngine(&streamProvider{stream: stream}, NewToolRegistry())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan Event, 1)
+	events <- Event{Type: EventPhase, Text: "buffer-full"}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- engine.runLoop(ctx, Request{
+			Messages: []Message{UserText("test")},
+		}, events)
+	}()
+
+	select {
+	case <-stream.recvCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for tool call event")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runLoop remained blocked after cancellation")
 	}
 }
 


### PR DESCRIPTION
## What

- make agentic `runLoop` use cancellation-aware event sends instead of raw blocking `events <- ...` writes
- cover phase updates, tool-call forwarding, interjections, streamed event forwarding, and final done events
- add a regression test that fills the event channel, cancels the context, and verifies `runLoop` exits instead of hanging while forwarding a tool call

## Why

The stream implementation cancels the producer context and then waits for the producer goroutine to exit when a caller disconnects or stops consuming events. In the agentic loop, several direct channel sends could block forever if the event buffer was full and the consumer was no longer draining it. Using the existing cancellation-aware send path lets tool-enabled requests terminate cleanly during interrupts, disconnects, and shutdown.
