### PR TITLE
fix: Responses API stream parser can hang forever when the consumer cancels

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -593,7 +593,15 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		reasoningState := newResponsesReasoningState()
 		var lastUsage *Usage
 		var lastEventType string
-		var sawTextDelta bool // Track if any text deltas were emitted
+		sawTextDelta := false // Track if any text deltas were emitted
+		emit := func(event Event) error {
+			select {
+			case events <- event:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 
 		for {
 			line, eof, err := readSSELine(reader)
@@ -634,7 +642,9 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 				}
 				if err := json.Unmarshal([]byte(data), &deltaEvent); err == nil && deltaEvent.Delta != "" {
 					sawTextDelta = true
-					events <- Event{Type: EventTextDelta, Text: deltaEvent.Delta}
+					if err := emit(Event{Type: EventTextDelta, Text: deltaEvent.Delta}); err != nil {
+						return err
+					}
 				}
 
 			case "response.output_item.added":
@@ -672,11 +682,13 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					} else if doneEvent.Item.Type == "reasoning" {
 						reasoningState.Finish(doneEvent.OutputIndex, doneEvent.Item.ID, doneEvent.Item.EncryptedContent, doneEvent.Item.Summary)
 						if part := reasoningState.Part(doneEvent.OutputIndex); part != nil {
-							events <- Event{
+							if err := emit(Event{
 								Type:                      EventReasoningDelta,
 								Text:                      part.ReasoningContent,
 								ReasoningItemID:           part.ReasoningItemID,
 								ReasoningEncryptedContent: part.ReasoningEncryptedContent,
+							}); err != nil {
+								return err
 							}
 						}
 					} else if doneEvent.Item.Type == "message" {
@@ -685,9 +697,13 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 						// Always emit refusals since those may not be streamed.
 						for _, content := range doneEvent.Item.Content {
 							if content.Type == "output_text" && content.Text != "" && !sawTextDelta {
-								events <- Event{Type: EventTextDelta, Text: content.Text}
+								if err := emit(Event{Type: EventTextDelta, Text: content.Text}); err != nil {
+									return err
+								}
 							} else if content.Type == "refusal" && content.Refusal != "" {
-								events <- Event{Type: EventTextDelta, Text: content.Refusal}
+								if err := emit(Event{Type: EventTextDelta, Text: content.Refusal}); err != nil {
+									return err
+								}
 							}
 						}
 					}
@@ -752,12 +768,18 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 
 		// Emit completed tool calls
 		for _, call := range toolState.Calls() {
-			events <- Event{Type: EventToolCall, Tool: &call}
+			if err := emit(Event{Type: EventToolCall, Tool: &call}); err != nil {
+				return err
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := emit(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -491,6 +491,57 @@ func TestResponsesClientStream_SendsSessionHeaderAndPromptCacheKey(t *testing.T)
 	}
 }
 
+func TestResponsesClientStream_CloseReturnsPromptlyWhenConsumerStopsDraining(t *testing.T) {
+	var sse strings.Builder
+	for i := 0; i < 32; i++ {
+		fmt.Fprintf(&sse, "event: response.output_text.delta\ndata: {\"delta\":\"chunk-%02d\"}\n\n", i)
+	}
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+				},
+				Body: io.NopCloser(strings.NewReader(sse.String())),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model: "gpt-5.2",
+		Input: []ResponsesInputItem{
+			{Type: "message", Role: "user", Content: "hello"},
+		},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- stream.Close()
+	}()
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("stream.Close() failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.Close() timed out after consumer stopped draining")
+	}
+}
+
 func TestOpenAIProviderStream_UsesSessionIDForResponsesCaching(t *testing.T) {
 	type capturedRequest struct {
 		SessionID      string


### PR DESCRIPTION
## What

Make the Responses API SSE parser stop using plain blocking sends and emit stream events with a ctx-aware helper instead. This lets the parser exit promptly if the consumer closes the stream or the request context is cancelled.

Also add a regression test that closes a Responses API stream without draining it and verifies Close returns promptly even after enough SSE text deltas are produced to fill the buffered event channel.

## Why

The parser goroutine was sending text, reasoning, fallback message text/refusals, tool calls, usage, and done events with bare `events <- Event{...}` sends. If the consumer stopped reading and closed the stream, those sends could block forever once the event buffer filled, causing `channelStream.Close()` to hang while waiting for the goroutine to finish.
