### PR TITLE
fix: OpenAI-compatible streaming adapter can deadlock on interrupted streams

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -408,6 +408,14 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 		var lastUsage *Usage
 		var lastEventType string
 		var reasoningBuilder strings.Builder
+		emit := func(event Event) error {
+			select {
+			case events <- event:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 
 		for {
 			line, eof, err := readSSELine(reader)
@@ -466,12 +474,16 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 			for _, choice := range chatResp.Choices {
 				if choice.Delta != nil {
 					if content, ok := choice.Delta.Content.(string); ok && content != "" {
-						events <- Event{Type: EventTextDelta, Text: content}
+						if err := emit(Event{Type: EventTextDelta, Text: content}); err != nil {
+							return err
+						}
 					}
 					// Capture reasoning from thinking models (OpenRouter streaming uses "reasoning" field)
 					if choice.Delta.Reasoning != "" {
 						reasoningBuilder.WriteString(choice.Delta.Reasoning)
-						events <- Event{Type: EventReasoningDelta, Text: choice.Delta.Reasoning}
+						if err := emit(Event{Type: EventReasoningDelta, Text: choice.Delta.Reasoning}); err != nil {
+							return err
+						}
 					}
 					if len(choice.Delta.ToolCalls) > 0 {
 						toolState.Add(choice.Delta.ToolCalls)
@@ -486,12 +498,18 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 		}
 
 		for _, call := range toolState.Calls() {
-			events <- Event{Type: EventToolCall, Tool: &call}
+			if err := emit(Event{Type: EventToolCall, Tool: &call}); err != nil {
+				return err
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := emit(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDefaultHTTPClient_HasNoOverallTimeout(t *testing.T) {
@@ -79,6 +80,76 @@ func TestOpenAICompatStream_AllowsLargeSSEDataLines(t *testing.T) {
 	}
 	if !sawDone {
 		t.Fatal("expected EventDone")
+	}
+}
+
+func TestOpenAICompatStream_CloseDoesNotHangWhenConsumerStopsReceiving(t *testing.T) {
+	chunk, err := json.Marshal(oaiChatResponse{
+		Choices: []oaiChoice{{
+			Delta: &oaiMessage{Content: "x"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal chunk: %v", err)
+	}
+
+	wroteChunks := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("expected response writer to implement http.Flusher")
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		for i := 0; i < 64; i++ {
+			if _, err := w.Write([]byte("data: ")); err != nil {
+				return
+			}
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+			if _, err := w.Write([]byte("\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+		close(wroteChunks)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	provider := NewOpenAICompatProvider(server.URL, "", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "hello"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	select {
+	case <-wroteChunks:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE chunks to be written")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- stream.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("stream.Close() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.Close() blocked while stream goroutine was trying to emit events")
 	}
 }
 


### PR DESCRIPTION
## What

Add context-aware event emission to the OpenAI-compatible streaming adapter so its SSE reader goroutine stops trying to send when the stream context is canceled.

Also add a regression test that fills the stream buffer without draining it and verifies `stream.Close()` still returns promptly.

## Why

The adapter previously used raw `events <- ...` sends for text deltas, reasoning deltas, tool calls, usage, and the final done event. If the consumer stopped receiving during cancellation or disconnect handling, those sends could block forever and `stream.Close()` would hang while waiting for the goroutine to exit.
