### PR TITLE
fix: preserve inline formatting in headings

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -221,12 +221,15 @@ func (r *ANSI) renderBlockChildren(parent gast.Node, source []byte, width int, s
 func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansiStyles) (string, error) {
 	switch n := node.(type) {
 	case *gast.Heading:
-		text := strings.TrimSpace(r.plainInlineChildren(n, source, true))
-		label := strings.Repeat("#", max(n.Level, 1))
-		if text != "" {
-			label += " " + text
+		inline, err := r.renderInlineChildren(n, source, styles)
+		if err != nil {
+			return "", err
 		}
-		return wrapANSI(styles.heading.Render(label), width), nil
+		label := styles.heading.Render(strings.Repeat("#", max(n.Level, 1)))
+		if strings.TrimSpace(stripANSI(inline)) == "" {
+			return wrapANSI(label, width), nil
+		}
+		return wrapANSI(label+" "+inline, width), nil
 	case *gast.Paragraph:
 		inline, err := r.renderInlineChildren(n, source, styles)
 		if err != nil {

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -66,6 +66,29 @@ func TestRenderString_GoldenVisibleOutput(t *testing.T) {
 	}
 }
 
+func TestRenderString_HeadingPreservesInlineFormatting(t *testing.T) {
+	got, err := RenderString("## Why `--flag` matters and **you should care**", Config{
+		Palette:           testPalette,
+		Width:             80,
+		WrapOffset:        1,
+		NormalizeTabs:     true,
+		NormalizeNewlines: true,
+		TrimSpace:         true,
+	})
+	if err != nil {
+		t.Fatalf("RenderString error: %v", err)
+	}
+
+	visible := normalizeVisibleOutput(got)
+	if visible != "## Why --flag matters and you should care" {
+		t.Fatalf("unexpected visible output: %q", visible)
+	}
+
+	if !strings.Contains(got, newANSIStyles(testPalette).code.Render("--flag")) {
+		t.Fatalf("expected heading to preserve inline code styling, got: %q", got)
+	}
+}
+
 func TestRenderString_ZeroWidthDoesNotError(t *testing.T) {
 	_, err := RenderString("# title", Config{
 		Palette:           testPalette,


### PR DESCRIPTION
## What

Preserves inline markdown formatting inside TUI-rendered headings.

## Why

The heading renderer was flattening heading content through `plainInlineChildren`, so inline code and emphasis were lost in output like:

```markdown
## Why `--flag` matters and **you should care**
```

This keeps the `##` heading marker while rendering inline children instead of stripping them to plain text.

## Testing

- `go test ./internal/render/markdown`
- `go test ./...`
