### PR TITLE
fix: preserve blockquote structure in tui

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -246,14 +246,14 @@ func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansi
 		}
 		return wrapANSI(inline, width), nil
 	case *gast.Blockquote:
-		inner, err := r.renderBlockChildren(n, source, max(width-2, 1), styles, "\n")
+		inner, err := r.renderBlockChildren(n, source, max(width-2, 1), styles, "\n\n")
 		if err != nil {
 			return "", err
 		}
 		if strings.TrimSpace(stripANSI(inner)) == "" {
-			return styles.blockquote.Render(" "), nil
+			return styles.blockquote.Render(">"), nil
 		}
-		return prefixLinesWithStyle(inner, "  ", "  ", styles.blockquote), nil
+		return prefixLinesWithStyle(inner, "> ", "> ", styles.blockquote), nil
 	case *gast.List:
 		return r.renderList(n, source, width, styles)
 	case *gast.FencedCodeBlock:

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -66,6 +66,26 @@ func TestRenderString_GoldenVisibleOutput(t *testing.T) {
 	}
 }
 
+func TestRenderString_BlockquotePreservesNestedStructure(t *testing.T) {
+	got, err := RenderString("> outer\n>\n> > inner1\n> >\n> > inner2\n>\n> tail", Config{
+		Palette:           testPalette,
+		Width:             80,
+		WrapOffset:        1,
+		NormalizeTabs:     true,
+		NormalizeNewlines: true,
+		TrimSpace:         true,
+	})
+	if err != nil {
+		t.Fatalf("RenderString error: %v", err)
+	}
+
+	visible := normalizeVisibleOutput(got)
+	want := "> outer\n>\n> > inner1\n> >\n> > inner2\n>\n> tail"
+	if visible != want {
+		t.Fatalf("blockquote structure mismatch\nwant:\n%s\n\ngot:\n%s", want, visible)
+	}
+}
+
 func TestRenderString_ZeroWidthDoesNotError(t *testing.T) {
 	_, err := RenderString("# title", Config{
 		Palette:           testPalette,

--- a/internal/render/markdown/testdata/blockquote_width80.golden
+++ b/internal/render/markdown/testdata/blockquote_width80.golden
@@ -1,1 +1,1 @@
-quote two
+> quote two


### PR DESCRIPTION
## What

Improves TUI blockquote rendering so quote structure stays visible.

## Why

The renderer was prefixing blockquotes with plain spaces, which flattened quote structure and made nested quotes hard to read. This PR:

- adds visible `> ` quote prefixes
- preserves blank quoted separator lines between child blocks
- updates the blockquote golden output and adds a nested blockquote regression test

## Testing

- `go test ./internal/render/markdown`
- `go test ./...`
