### PR TITLE
fix: preserve loose list spacing

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -294,6 +294,12 @@ func (r *ANSI) renderList(list *gast.List, source []byte, width int, styles ansi
 	if number <= 0 {
 		number = 1
 	}
+	itemSeparator := "\n"
+	bodySeparator := "\n"
+	if !list.IsTight {
+		itemSeparator = "\n\n"
+		bodySeparator = "\n\n"
+	}
 	for itemNode := list.FirstChild(); itemNode != nil; itemNode = itemNode.NextSibling() {
 		item, ok := itemNode.(*gast.ListItem)
 		if !ok {
@@ -306,7 +312,7 @@ func (r *ANSI) renderList(list *gast.List, source []byte, width int, styles ansi
 			number++
 		}
 		innerWidth := max(width-visibleWidth(prefix), 1)
-		body, err := r.renderBlockChildren(item, source, innerWidth, styles, "\n")
+		body, err := r.renderBlockChildren(item, source, innerWidth, styles, bodySeparator)
 		if err != nil {
 			return "", err
 		}
@@ -317,7 +323,7 @@ func (r *ANSI) renderList(list *gast.List, source []byte, width int, styles ansi
 		}
 		items = append(items, prefixExistingLines(body, prefix, strings.Repeat(" ", visibleWidth(prefix))))
 	}
-	return strings.Join(items, "\n"), nil
+	return strings.Join(items, itemSeparator), nil
 }
 
 func (r *ANSI) renderTable(table *extast.Table, source []byte, width int, styles ansiStyles) (string, error) {

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -66,6 +66,26 @@ func TestRenderString_GoldenVisibleOutput(t *testing.T) {
 	}
 }
 
+func TestRenderString_LooseListsKeepBlankLinesBetweenItems(t *testing.T) {
+	got, err := RenderString("- First item\n\n- Second item\n\n- Third item", Config{
+		Palette:           testPalette,
+		Width:             80,
+		WrapOffset:        1,
+		NormalizeTabs:     true,
+		NormalizeNewlines: true,
+		TrimSpace:         true,
+	})
+	if err != nil {
+		t.Fatalf("RenderString error: %v", err)
+	}
+
+	visible := normalizeVisibleOutput(got)
+	want := "• First item\n\n• Second item\n\n• Third item"
+	if visible != want {
+		t.Fatalf("loose list spacing mismatch\nwant:\n%s\n\ngot:\n%s", want, visible)
+	}
+}
+
 func TestRenderString_ZeroWidthDoesNotError(t *testing.T) {
 	_, err := RenderString("# title", Config{
 		Palette:           testPalette,


### PR DESCRIPTION
## What

Preserves loose-list spacing in the TUI markdown renderer.

## Why

Loose lists were rendering exactly like tight lists, which dropped the blank-line paragraph spacing implied by markdown like:

```markdown
- First item

- Second item

- Third item
```

This PR respects `list.IsTight` when joining list item bodies and list items, and adds a regression test covering the loose-list case.

## Testing

- `go test ./internal/render/markdown`
- `go test ./...`
