### PR TITLE
fix: size thematic breaks to render width

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -263,7 +263,7 @@ func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansi
 	case *extast.Table:
 		return r.renderTable(n, source, width, styles)
 	case *gast.ThematicBreak:
-		return styles.rule.Render("--------"), nil
+		return styles.rule.Render(strings.Repeat("─", max(width, 1))), nil
 	case *extast.DefinitionList:
 		return r.renderBlockChildren(n, source, width, styles, "\n")
 	case *extast.DefinitionTerm:

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -66,6 +66,34 @@ func TestRenderString_GoldenVisibleOutput(t *testing.T) {
 	}
 }
 
+func TestRenderString_ThematicBreakUsesRenderWidth(t *testing.T) {
+	for _, tc := range []struct {
+		width    int
+		wrap     int
+		expected int
+	}{
+		{width: 20, wrap: 1, expected: 19},
+		{width: 40, wrap: 2, expected: 38},
+	} {
+		got, err := RenderString("---", Config{
+			Palette:           testPalette,
+			Width:             tc.width,
+			WrapOffset:        tc.wrap,
+			NormalizeTabs:     true,
+			NormalizeNewlines: true,
+			TrimSpace:         true,
+		})
+		if err != nil {
+			t.Fatalf("RenderString error: %v", err)
+		}
+
+		visible := normalizeVisibleOutput(got)
+		if visible != strings.Repeat("─", tc.expected) {
+			t.Fatalf("unexpected rule width for width=%d wrap=%d\nwant: %q\ngot:  %q", tc.width, tc.wrap, strings.Repeat("─", tc.expected), visible)
+		}
+	}
+}
+
 func TestRenderString_ZeroWidthDoesNotError(t *testing.T) {
 	_, err := RenderString("# title", Config{
 		Palette:           testPalette,


### PR DESCRIPTION
## What

Sizes thematic breaks to the effective render width in the TUI markdown renderer.

## Why

The renderer was emitting a hardcoded eight-character rule for all `---` / `***` thematic breaks, which looked stubby and ignored viewport width.

This switches the rule to use the effective render width and adds width-based regression tests.

## Testing

- `go test ./internal/render/markdown`
- `go test ./...`
