### PR TITLE
fix: Gemini provider can hang Stream.Close when output arrives after the caller cancels

### DIFF
--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -100,6 +100,16 @@ func (p *GeminiProvider) newClient(ctx context.Context) (*genai.Client, error) {
 
 func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
+		sendEvent := func(event Event) error {
+			if safeSendEvent(ctx, events, event) {
+				return nil
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return nil
+		}
+
 		client, err := p.newClient(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create gemini client: %w", err)
@@ -165,7 +175,9 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 					}
 					// Emit text parts (skip thought parts which are internal)
 					if part.Text != "" && !part.Thought {
-						events <- Event{Type: EventTextDelta, Text: part.Text}
+						if err := sendEvent(Event{Type: EventTextDelta, Text: part.Text}); err != nil {
+							return err
+						}
 					}
 					if part.FunctionCall != nil {
 						argsJSON, _ := jsonMarshal(part.FunctionCall.Args)
@@ -174,17 +186,23 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 						if thoughtSig == nil {
 							thoughtSig = lastThoughtSig
 						}
-						events <- Event{Type: EventToolCall, Tool: &ToolCall{
+						if err := sendEvent(Event{Type: EventToolCall, Tool: &ToolCall{
 							ID:         part.FunctionCall.ID,
 							Name:       part.FunctionCall.Name,
 							Arguments:  argsJSON,
 							ThoughtSig: thoughtSig,
-						}}
+						}}); err != nil {
+							return err
+						}
 					}
 				}
 			}
-			emitGeminiUsage(events, resp)
-			events <- Event{Type: EventDone}
+			if err := emitGeminiUsage(ctx, events, resp); err != nil {
+				return err
+			}
+			if err := sendEvent(Event{Type: EventDone}); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -196,7 +214,9 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 			}
 			lastResp = resp
 			if text := resp.Text(); text != "" {
-				events <- Event{Type: EventTextDelta, Text: text}
+				if err := sendEvent(Event{Type: EventTextDelta, Text: text}); err != nil {
+					return err
+				}
 			}
 			if req.Search {
 				for _, cand := range resp.Candidates {
@@ -219,27 +239,40 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 		}
 
 		if len(sources) > 0 {
-			events <- Event{Type: EventTextDelta, Text: "\n\n**Sources:**\n"}
+			if err := sendEvent(Event{Type: EventTextDelta, Text: "\n\n**Sources:**\n"}); err != nil {
+				return err
+			}
 			for _, source := range sources {
-				events <- Event{Type: EventTextDelta, Text: "- " + source + "\n"}
+				if err := sendEvent(Event{Type: EventTextDelta, Text: "- " + source + "\n"}); err != nil {
+					return err
+				}
 			}
 		}
-		emitGeminiUsage(events, lastResp)
-		events <- Event{Type: EventDone}
+		if err := emitGeminiUsage(ctx, events, lastResp); err != nil {
+			return err
+		}
+		if err := sendEvent(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }
 
-func emitGeminiUsage(events chan<- Event, resp *genai.GenerateContentResponse) {
+func emitGeminiUsage(ctx context.Context, events chan<- Event, resp *genai.GenerateContentResponse) error {
 	if resp == nil || resp.UsageMetadata == nil {
-		return
+		return nil
 	}
 	if resp.UsageMetadata.TotalTokenCount > 0 {
-		events <- Event{Type: EventUsage, Use: &Usage{
+		if !safeSendEvent(ctx, events, Event{Type: EventUsage, Use: &Usage{
 			InputTokens:  int(resp.UsageMetadata.PromptTokenCount),
 			OutputTokens: int(resp.UsageMetadata.CandidatesTokenCount),
-		}}
+		}}) {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
 	}
+	return nil
 }
 
 func buildGeminiTools(specs []ToolSpec) []*genai.Tool {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -1,6 +1,13 @@
 package llm
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+)
 
 func TestBuildGeminiContents_DropsDanglingToolCalls(t *testing.T) {
 	_, contents := buildGeminiContents([]Message{
@@ -42,5 +49,35 @@ func TestBuildGeminiContents_DropsDanglingToolCalls(t *testing.T) {
 	}
 	if !sawText {
 		t.Fatalf("expected assistant text to be preserved, got %#v", assistant.Parts)
+	}
+}
+
+func TestEmitGeminiUsage_DoesNotBlockAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	events := make(chan Event, 1)
+	events <- Event{Type: EventTextDelta, Text: "buffer-full"}
+
+	resp := &genai.GenerateContentResponse{
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     3,
+			CandidatesTokenCount: 5,
+			TotalTokenCount:      8,
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- emitGeminiUsage(ctx, events, resp)
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("emitGeminiUsage() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("emitGeminiUsage blocked after context cancellation")
 	}
 }


### PR DESCRIPTION
## What

- update Gemini stream event emission to use context-aware sends instead of plain blocking channel writes
- apply the same cancellation-aware send path to text, tool-call, usage, source, and done events
- add a regression test covering Gemini usage emission when the consumer has stopped draining after cancellation

## Why

Gemini could keep producing events after the caller canceled. If the event buffer filled while the caller was no longer receiving, the worker goroutine could block forever on `events <- ...`, which in turn caused `Stream.Close()` to hang while waiting for the worker to finish. Using `safeSendEvent` lets the worker notice `ctx.Done()` and exit cleanly instead of deadlocking shutdown.

`go build ./...` passes. `go test ./...` still hits an unrelated existing failure in `internal/ui` (`TestTerminalMarkdownWrapNoOrphans/boundary_hyphen_at_limit`), while `go test ./internal/llm/...` passes including the new regression coverage.
