### PR TITLE
fix: Anthropic streaming can deadlock forever on cancellation because event sends ignore ctx.Done

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -263,19 +263,27 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 						accumulator.Append(variant.Index, delta.PartialJSON)
 					}
 				case anthropic.TextDelta:
-					if delta.Text != "" {
-						events <- Event{Type: EventTextDelta, Text: delta.Text}
+					if delta.Text != "" && !sendAnthropicEvent(ctx, events, Event{Type: EventTextDelta, Text: delta.Text}) {
+						return nil
 					}
 				case anthropic.ThinkingDelta:
-					emitReasoningDelta(events, delta.Thinking, "")
+					if !emitReasoningDelta(ctx, events, delta.Thinking, "") {
+						return nil
+					}
 				case anthropic.SignatureDelta:
-					emitReasoningDelta(events, "", delta.Signature)
+					if !emitReasoningDelta(ctx, events, "", delta.Signature) {
+						return nil
+					}
 				}
 			case anthropic.ContentBlockStartEvent:
-				handleAnthropicStartBlockContent(variant.ContentBlock.AsAny(), variant.Index, accumulator, events)
+				if !handleAnthropicStartBlockContent(ctx, variant.ContentBlock.AsAny(), variant.Index, accumulator, events) {
+					return nil
+				}
 			case anthropic.ContentBlockStopEvent:
 				if toolCall, ok := accumulator.Finish(variant.Index); ok {
-					events <- Event{Type: EventToolCall, Tool: &toolCall}
+					if !sendAnthropicEvent(ctx, events, Event{Type: EventToolCall, Tool: &toolCall}) {
+						return nil
+					}
 				}
 			case anthropic.MessageStartEvent:
 				lastUsage = &Usage{
@@ -305,9 +313,13 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 			return fmt.Errorf("anthropic streaming error: %w", err)
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if !sendAnthropicEvent(ctx, events, Event{Type: EventUsage, Use: lastUsage}) {
+				return nil
+			}
 		}
-		events <- Event{Type: EventDone}
+		if !sendAnthropicEvent(ctx, events, Event{Type: EventDone}) {
+			return nil
+		}
 		return nil
 	}), nil
 }
@@ -404,16 +416,24 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 					if delta.Text != "" {
 						// If we were in a server tool, emit tool end event
 						if currentServerTool != "" {
-							events <- Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}
+							if !sendAnthropicEvent(ctx, events, Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}) {
+								return nil
+							}
 							currentServerTool = ""
 							currentServerToolIndex = -1
 						}
-						events <- Event{Type: EventTextDelta, Text: delta.Text}
+						if !sendAnthropicEvent(ctx, events, Event{Type: EventTextDelta, Text: delta.Text}) {
+							return nil
+						}
 					}
 				case anthropic.BetaThinkingDelta:
-					emitReasoningDelta(events, delta.Thinking, "")
+					if !emitReasoningDelta(ctx, events, delta.Thinking, "") {
+						return nil
+					}
 				case anthropic.BetaSignatureDelta:
-					emitReasoningDelta(events, "", delta.Signature)
+					if !emitReasoningDelta(ctx, events, "", delta.Signature) {
+						return nil
+					}
 				}
 			case anthropic.BetaRawContentBlockStartEvent:
 				blockType := variant.ContentBlock.Type
@@ -423,18 +443,26 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 					toolName := string(serverTool.Name)
 					currentServerTool = toolName
 					currentServerToolIndex = variant.Index
-					events <- Event{Type: EventToolExecStart, ToolName: toolName}
+					if !sendAnthropicEvent(ctx, events, Event{Type: EventToolExecStart, ToolName: toolName}) {
+						return nil
+					}
 				} else {
-					handleAnthropicBetaStartBlockContent(variant.ContentBlock.AsAny(), variant.Index, accumulator, events)
+					if !handleAnthropicBetaStartBlockContent(ctx, variant.ContentBlock.AsAny(), variant.Index, accumulator, events) {
+						return nil
+					}
 				}
 			case anthropic.BetaRawContentBlockStopEvent:
 				if currentServerTool != "" && variant.Index == currentServerToolIndex {
-					events <- Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}
+					if !sendAnthropicEvent(ctx, events, Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}) {
+						return nil
+					}
 					currentServerTool = ""
 					currentServerToolIndex = -1
 				}
 				if toolCall, ok := accumulator.Finish(variant.Index); ok {
-					events <- Event{Type: EventToolCall, Tool: &toolCall}
+					if !sendAnthropicEvent(ctx, events, Event{Type: EventToolCall, Tool: &toolCall}) {
+						return nil
+					}
 				}
 			case anthropic.BetaRawMessageStartEvent:
 				lastUsage = &Usage{
@@ -464,12 +492,18 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 			return fmt.Errorf("anthropic streaming error: %w", err)
 		}
 		if currentServerTool != "" {
-			events <- Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}
+			if !sendAnthropicEvent(ctx, events, Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}) {
+				return nil
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if !sendAnthropicEvent(ctx, events, Event{Type: EventUsage, Use: lastUsage}) {
+				return nil
+			}
 		}
-		events <- Event{Type: EventDone}
+		if !sendAnthropicEvent(ctx, events, Event{Type: EventDone}) {
+			return nil
+		}
 		return nil
 	}), nil
 }
@@ -916,14 +950,23 @@ func buildAnthropicBetaToolChoice(choice ToolChoice, parallel bool) anthropic.Be
 	}
 }
 
-func handleAnthropicStartBlockContent(block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) {
+func sendAnthropicEvent(ctx context.Context, events chan<- Event, event Event) bool {
+	select {
+	case events <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func handleAnthropicStartBlockContent(ctx context.Context, block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) bool {
 	switch variant := block.(type) {
 	case anthropic.TextBlock:
 		if variant.Text != "" {
-			events <- Event{Type: EventTextDelta, Text: variant.Text}
+			return sendAnthropicEvent(ctx, events, Event{Type: EventTextDelta, Text: variant.Text})
 		}
 	case anthropic.ThinkingBlock:
-		emitReasoningDelta(events, variant.Thinking, variant.Signature)
+		return emitReasoningDelta(ctx, events, variant.Thinking, variant.Signature)
 	case anthropic.ToolUseBlock:
 		accumulator.Start(index, ToolCall{
 			ID:        variant.ID,
@@ -931,16 +974,17 @@ func handleAnthropicStartBlockContent(block any, index int64, accumulator *toolC
 			Arguments: toolInputToRaw(variant.Input),
 		})
 	}
+	return true
 }
 
-func handleAnthropicBetaStartBlockContent(block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) {
+func handleAnthropicBetaStartBlockContent(ctx context.Context, block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) bool {
 	switch variant := block.(type) {
 	case anthropic.BetaTextBlock:
 		if variant.Text != "" {
-			events <- Event{Type: EventTextDelta, Text: variant.Text}
+			return sendAnthropicEvent(ctx, events, Event{Type: EventTextDelta, Text: variant.Text})
 		}
 	case anthropic.BetaThinkingBlock:
-		emitReasoningDelta(events, variant.Thinking, variant.Signature)
+		return emitReasoningDelta(ctx, events, variant.Thinking, variant.Signature)
 	case anthropic.BetaToolUseBlock:
 		accumulator.Start(index, ToolCall{
 			ID:        variant.ID,
@@ -948,6 +992,7 @@ func handleAnthropicBetaStartBlockContent(block any, index int64, accumulator *t
 			Arguments: toolInputToRaw(variant.Input),
 		})
 	}
+	return true
 }
 
 func anthropicToolCall(block anthropic.ContentBlockStartEventContentBlockUnion) (ToolCall, bool) {
@@ -964,15 +1009,15 @@ func anthropicBetaToolCall(block anthropic.BetaRawContentBlockStartEventContentB
 	return ToolCall{}, false
 }
 
-func emitReasoningDelta(events chan<- Event, text, encrypted string) {
+func emitReasoningDelta(ctx context.Context, events chan<- Event, text, encrypted string) bool {
 	if text == "" && encrypted == "" {
-		return
+		return true
 	}
-	events <- Event{
+	return sendAnthropicEvent(ctx, events, Event{
 		Type:                      EventReasoningDelta,
 		Text:                      text,
 		ReasoningEncryptedContent: encrypted,
-	}
+	})
 }
 
 func toolInputToRaw(input any) json.RawMessage {

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -580,9 +581,11 @@ func TestHandleAnthropicStartBlockContent_TextBlockEmitsTextDelta(t *testing.T) 
 	events := make(chan Event, 1)
 	acc := newToolCallAccumulator()
 
-	handleAnthropicStartBlockContent(anthropic.TextBlock{
+	if !handleAnthropicStartBlockContent(context.Background(), anthropic.TextBlock{
 		Text: "hello from start block",
-	}, 0, acc, events)
+	}, 0, acc, events) {
+		t.Fatal("expected text block helper to emit successfully")
+	}
 
 	select {
 	case ev := <-events:
@@ -601,11 +604,13 @@ func TestHandleAnthropicStartBlockContent_ToolUseStartsAccumulator(t *testing.T)
 	events := make(chan Event, 1)
 	acc := newToolCallAccumulator()
 
-	handleAnthropicStartBlockContent(anthropic.ToolUseBlock{
+	if !handleAnthropicStartBlockContent(context.Background(), anthropic.ToolUseBlock{
 		ID:    "call-1",
 		Name:  "read_file",
 		Input: json.RawMessage(`{"path":"README.md"}`),
-	}, 1, acc, events)
+	}, 1, acc, events) {
+		t.Fatal("expected tool use block helper to succeed")
+	}
 
 	if _, ok := acc.Finish(1); !ok {
 		t.Fatal("expected tool call to be started in accumulator")
@@ -621,9 +626,11 @@ func TestHandleAnthropicBetaStartBlockContent_TextBlockEmitsTextDelta(t *testing
 	events := make(chan Event, 1)
 	acc := newToolCallAccumulator()
 
-	handleAnthropicBetaStartBlockContent(anthropic.BetaTextBlock{
+	if !handleAnthropicBetaStartBlockContent(context.Background(), anthropic.BetaTextBlock{
 		Text: "hello from beta start block",
-	}, 0, acc, events)
+	}, 0, acc, events) {
+		t.Fatal("expected beta text block helper to emit successfully")
+	}
 
 	select {
 	case ev := <-events:
@@ -641,7 +648,9 @@ func TestHandleAnthropicBetaStartBlockContent_TextBlockEmitsTextDelta(t *testing
 func TestEmitReasoningDelta_ProducesReasoningEvent(t *testing.T) {
 	events := make(chan Event, 1)
 
-	emitReasoningDelta(events, "thinking chunk", "sig-123")
+	if !emitReasoningDelta(context.Background(), events, "thinking chunk", "sig-123") {
+		t.Fatal("expected reasoning delta helper to emit successfully")
+	}
 
 	select {
 	case ev := <-events:
@@ -1052,5 +1061,49 @@ data: {"type":"message_stop"}
 				t.Errorf("text content = %q, want %q", textContent, tt.wantText)
 			}
 		})
+	}
+}
+
+func TestAnthropicStreamCloseDoesNotDeadlockWhenConsumerStopsDraining(t *testing.T) {
+	var sse strings.Builder
+	sse.WriteString("event: message_start\n")
+	sse.WriteString("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-6\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n")
+	sse.WriteString("event: content_block_start\n")
+	sse.WriteString("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+	for i := 0; i < 64; i++ {
+		sse.WriteString("event: content_block_delta\n")
+		sse.WriteString(fmt.Sprintf("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"chunk-%02d\"}}\n\n", i))
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, sse.String())
+	}))
+	defer ts.Close()
+
+	client := anthropic.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(ts.URL))
+	provider := &AnthropicProvider{client: &client, model: "claude-sonnet-4-6"}
+
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- stream.Close()
+	}()
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("stream.Close() failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.Close() timed out after consumer stopped draining")
 	}
 }


### PR DESCRIPTION
## What

Guard Anthropic stream event sends with `ctx.Done()` so cancellation cannot block forever when the consumer stops draining the buffered event channel.

Also add a regression test that fills the Anthropic stream event buffer and verifies `stream.Close()` still returns promptly.

## Why

`newEventStream.Close()` cancels the stream context and waits for the producer goroutine to exit. Anthropic's streaming worker was doing plain `events <- ...` sends, so if the 16-item buffer filled after the consumer stopped reading, the goroutine could block forever and never observe cancellation. Selecting on `ctx.Done()` during sends lets teardown complete cleanly instead of wedging the session.
