### PR TITLE
fix: Anthropic stream can deadlock forever on cancellation when the event buffer fills

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -247,6 +247,10 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 			fmt.Fprintln(os.Stderr, "======================================")
 		}
 
+		emit := func(event Event) error {
+			return emitAnthropicEvent(ctx, events, event)
+		}
+
 		var lastUsage *Usage
 		var streamOpts []option.RequestOption
 		if p.use1m {
@@ -264,18 +268,28 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 					}
 				case anthropic.TextDelta:
 					if delta.Text != "" {
-						events <- Event{Type: EventTextDelta, Text: delta.Text}
+						if err := emit(Event{Type: EventTextDelta, Text: delta.Text}); err != nil {
+							return err
+						}
 					}
 				case anthropic.ThinkingDelta:
-					emitReasoningDelta(events, delta.Thinking, "")
+					if err := emitReasoningDelta(ctx, events, delta.Thinking, ""); err != nil {
+						return err
+					}
 				case anthropic.SignatureDelta:
-					emitReasoningDelta(events, "", delta.Signature)
+					if err := emitReasoningDelta(ctx, events, "", delta.Signature); err != nil {
+						return err
+					}
 				}
 			case anthropic.ContentBlockStartEvent:
-				handleAnthropicStartBlockContent(variant.ContentBlock.AsAny(), variant.Index, accumulator, events)
+				if err := handleAnthropicStartBlockContent(ctx, variant.ContentBlock.AsAny(), variant.Index, accumulator, events); err != nil {
+					return err
+				}
 			case anthropic.ContentBlockStopEvent:
 				if toolCall, ok := accumulator.Finish(variant.Index); ok {
-					events <- Event{Type: EventToolCall, Tool: &toolCall}
+					if err := emit(Event{Type: EventToolCall, Tool: &toolCall}); err != nil {
+						return err
+					}
 				}
 			case anthropic.MessageStartEvent:
 				lastUsage = &Usage{
@@ -305,9 +319,13 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 			return fmt.Errorf("anthropic streaming error: %w", err)
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := emit(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }
@@ -385,6 +403,10 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 			fmt.Fprintln(os.Stderr, "================================================")
 		}
 
+		emit := func(event Event) error {
+			return emitAnthropicEvent(ctx, events, event)
+		}
+
 		// Track current server tool use block (web_search, etc.)
 		currentServerTool := ""
 		currentServerToolIndex := int64(-1)
@@ -404,16 +426,24 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 					if delta.Text != "" {
 						// If we were in a server tool, emit tool end event
 						if currentServerTool != "" {
-							events <- Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}
+							if err := emit(Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}); err != nil {
+								return err
+							}
 							currentServerTool = ""
 							currentServerToolIndex = -1
 						}
-						events <- Event{Type: EventTextDelta, Text: delta.Text}
+						if err := emit(Event{Type: EventTextDelta, Text: delta.Text}); err != nil {
+							return err
+						}
 					}
 				case anthropic.BetaThinkingDelta:
-					emitReasoningDelta(events, delta.Thinking, "")
+					if err := emitReasoningDelta(ctx, events, delta.Thinking, ""); err != nil {
+						return err
+					}
 				case anthropic.BetaSignatureDelta:
-					emitReasoningDelta(events, "", delta.Signature)
+					if err := emitReasoningDelta(ctx, events, "", delta.Signature); err != nil {
+						return err
+					}
 				}
 			case anthropic.BetaRawContentBlockStartEvent:
 				blockType := variant.ContentBlock.Type
@@ -423,18 +453,26 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 					toolName := string(serverTool.Name)
 					currentServerTool = toolName
 					currentServerToolIndex = variant.Index
-					events <- Event{Type: EventToolExecStart, ToolName: toolName}
+					if err := emit(Event{Type: EventToolExecStart, ToolName: toolName}); err != nil {
+						return err
+					}
 				} else {
-					handleAnthropicBetaStartBlockContent(variant.ContentBlock.AsAny(), variant.Index, accumulator, events)
+					if err := handleAnthropicBetaStartBlockContent(ctx, variant.ContentBlock.AsAny(), variant.Index, accumulator, events); err != nil {
+						return err
+					}
 				}
 			case anthropic.BetaRawContentBlockStopEvent:
 				if currentServerTool != "" && variant.Index == currentServerToolIndex {
-					events <- Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}
+					if err := emit(Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}); err != nil {
+						return err
+					}
 					currentServerTool = ""
 					currentServerToolIndex = -1
 				}
 				if toolCall, ok := accumulator.Finish(variant.Index); ok {
-					events <- Event{Type: EventToolCall, Tool: &toolCall}
+					if err := emit(Event{Type: EventToolCall, Tool: &toolCall}); err != nil {
+						return err
+					}
 				}
 			case anthropic.BetaRawMessageStartEvent:
 				lastUsage = &Usage{
@@ -464,12 +502,18 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 			return fmt.Errorf("anthropic streaming error: %w", err)
 		}
 		if currentServerTool != "" {
-			events <- Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}
+			if err := emit(Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}); err != nil {
+				return err
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := emit(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }
@@ -916,14 +960,27 @@ func buildAnthropicBetaToolChoice(choice ToolChoice, parallel bool) anthropic.Be
 	}
 }
 
-func handleAnthropicStartBlockContent(block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) {
+func emitAnthropicEvent(ctx context.Context, events chan<- Event, event Event) error {
+	select {
+	case events <- event:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func handleAnthropicStartBlockContent(ctx context.Context, block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) error {
 	switch variant := block.(type) {
 	case anthropic.TextBlock:
 		if variant.Text != "" {
-			events <- Event{Type: EventTextDelta, Text: variant.Text}
+			if err := emitAnthropicEvent(ctx, events, Event{Type: EventTextDelta, Text: variant.Text}); err != nil {
+				return err
+			}
 		}
 	case anthropic.ThinkingBlock:
-		emitReasoningDelta(events, variant.Thinking, variant.Signature)
+		if err := emitReasoningDelta(ctx, events, variant.Thinking, variant.Signature); err != nil {
+			return err
+		}
 	case anthropic.ToolUseBlock:
 		accumulator.Start(index, ToolCall{
 			ID:        variant.ID,
@@ -931,16 +988,21 @@ func handleAnthropicStartBlockContent(block any, index int64, accumulator *toolC
 			Arguments: toolInputToRaw(variant.Input),
 		})
 	}
+	return nil
 }
 
-func handleAnthropicBetaStartBlockContent(block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) {
+func handleAnthropicBetaStartBlockContent(ctx context.Context, block any, index int64, accumulator *toolCallAccumulator, events chan<- Event) error {
 	switch variant := block.(type) {
 	case anthropic.BetaTextBlock:
 		if variant.Text != "" {
-			events <- Event{Type: EventTextDelta, Text: variant.Text}
+			if err := emitAnthropicEvent(ctx, events, Event{Type: EventTextDelta, Text: variant.Text}); err != nil {
+				return err
+			}
 		}
 	case anthropic.BetaThinkingBlock:
-		emitReasoningDelta(events, variant.Thinking, variant.Signature)
+		if err := emitReasoningDelta(ctx, events, variant.Thinking, variant.Signature); err != nil {
+			return err
+		}
 	case anthropic.BetaToolUseBlock:
 		accumulator.Start(index, ToolCall{
 			ID:        variant.ID,
@@ -948,6 +1010,7 @@ func handleAnthropicBetaStartBlockContent(block any, index int64, accumulator *t
 			Arguments: toolInputToRaw(variant.Input),
 		})
 	}
+	return nil
 }
 
 func anthropicToolCall(block anthropic.ContentBlockStartEventContentBlockUnion) (ToolCall, bool) {
@@ -964,15 +1027,15 @@ func anthropicBetaToolCall(block anthropic.BetaRawContentBlockStartEventContentB
 	return ToolCall{}, false
 }
 
-func emitReasoningDelta(events chan<- Event, text, encrypted string) {
+func emitReasoningDelta(ctx context.Context, events chan<- Event, text, encrypted string) error {
 	if text == "" && encrypted == "" {
-		return
+		return nil
 	}
-	events <- Event{
+	return emitAnthropicEvent(ctx, events, Event{
 		Type:                      EventReasoningDelta,
 		Text:                      text,
 		ReasoningEncryptedContent: encrypted,
-	}
+	})
 }
 
 func toolInputToRaw(input any) json.RawMessage {

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -580,9 +581,11 @@ func TestHandleAnthropicStartBlockContent_TextBlockEmitsTextDelta(t *testing.T) 
 	events := make(chan Event, 1)
 	acc := newToolCallAccumulator()
 
-	handleAnthropicStartBlockContent(anthropic.TextBlock{
+	if err := handleAnthropicStartBlockContent(context.Background(), anthropic.TextBlock{
 		Text: "hello from start block",
-	}, 0, acc, events)
+	}, 0, acc, events); err != nil {
+		t.Fatalf("handleAnthropicStartBlockContent error: %v", err)
+	}
 
 	select {
 	case ev := <-events:
@@ -601,11 +604,13 @@ func TestHandleAnthropicStartBlockContent_ToolUseStartsAccumulator(t *testing.T)
 	events := make(chan Event, 1)
 	acc := newToolCallAccumulator()
 
-	handleAnthropicStartBlockContent(anthropic.ToolUseBlock{
+	if err := handleAnthropicStartBlockContent(context.Background(), anthropic.ToolUseBlock{
 		ID:    "call-1",
 		Name:  "read_file",
 		Input: json.RawMessage(`{"path":"README.md"}`),
-	}, 1, acc, events)
+	}, 1, acc, events); err != nil {
+		t.Fatalf("handleAnthropicStartBlockContent error: %v", err)
+	}
 
 	if _, ok := acc.Finish(1); !ok {
 		t.Fatal("expected tool call to be started in accumulator")
@@ -621,9 +626,11 @@ func TestHandleAnthropicBetaStartBlockContent_TextBlockEmitsTextDelta(t *testing
 	events := make(chan Event, 1)
 	acc := newToolCallAccumulator()
 
-	handleAnthropicBetaStartBlockContent(anthropic.BetaTextBlock{
+	if err := handleAnthropicBetaStartBlockContent(context.Background(), anthropic.BetaTextBlock{
 		Text: "hello from beta start block",
-	}, 0, acc, events)
+	}, 0, acc, events); err != nil {
+		t.Fatalf("handleAnthropicBetaStartBlockContent error: %v", err)
+	}
 
 	select {
 	case ev := <-events:
@@ -641,7 +648,9 @@ func TestHandleAnthropicBetaStartBlockContent_TextBlockEmitsTextDelta(t *testing
 func TestEmitReasoningDelta_ProducesReasoningEvent(t *testing.T) {
 	events := make(chan Event, 1)
 
-	emitReasoningDelta(events, "thinking chunk", "sig-123")
+	if err := emitReasoningDelta(context.Background(), events, "thinking chunk", "sig-123"); err != nil {
+		t.Fatalf("emitReasoningDelta error: %v", err)
+	}
 
 	select {
 	case ev := <-events:
@@ -930,6 +939,64 @@ func TestBuildAnthropicBetaMessages_DeveloperRole(t *testing.T) {
 	want := "<developer>\nBe concise\n</developer>\n\nHello"
 	if *got != want {
 		t.Errorf("content = %q, want %q", *got, want)
+	}
+}
+
+func TestAnthropicStreamCloseReturnsWhenBufferFills(t *testing.T) {
+	var sse strings.Builder
+	sse.WriteString("event: message_start\n")
+	sse.WriteString("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-6\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n")
+	sse.WriteString("event: content_block_start\n")
+	sse.WriteString("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+	for i := 0; i < 32; i++ {
+		fmt.Fprintf(&sse, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"chunk-%02d\"}}\n\n", i)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, sse.String())
+	}))
+	defer ts.Close()
+
+	client := anthropic.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(ts.URL))
+	provider := &AnthropicProvider{client: &client, model: "claude-sonnet-4-6"}
+
+	stream, err := provider.streamStandard(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+	})
+	if err != nil {
+		t.Fatalf("streamStandard error: %v", err)
+	}
+
+	channelStream, ok := stream.(*channelStream)
+	if !ok {
+		_ = stream.Close()
+		t.Fatalf("stream type = %T, want *channelStream", stream)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for len(channelStream.events) < cap(channelStream.events) {
+		select {
+		case <-deadline:
+			_ = stream.Close()
+			t.Fatal("timed out waiting for Anthropic event buffer to fill")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- stream.Close()
+	}()
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close hung with a full Anthropic event buffer")
 	}
 }
 


### PR DESCRIPTION
## What

Make Anthropic streaming event emission cancellation-aware so the background worker cannot block forever on a full event buffer.

Add a regression test that fills the stream buffer and verifies `Close()` returns promptly instead of hanging.

## Why

Anthropic's stream worker used plain blocking `events <- ...` sends. If the caller stopped draining and then canceled, one of those sends could remain blocked forever, preventing the worker from exiting and causing `Close()` to hang during teardown.

This change keeps the fix minimal and targeted by wrapping Anthropic event sends in a `select` that also listens for `ctx.Done()`.
