### PR TITLE
fix: Gemini provider can hang stream shutdown after cancellation due to blocking event sends

### DIFF
--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -100,6 +100,10 @@ func (p *GeminiProvider) newClient(ctx context.Context) (*genai.Client, error) {
 
 func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
+		emit := func(event Event) error {
+			return emitGeminiEvent(ctx, events, event)
+		}
+
 		client, err := p.newClient(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create gemini client: %w", err)
@@ -165,7 +169,9 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 					}
 					// Emit text parts (skip thought parts which are internal)
 					if part.Text != "" && !part.Thought {
-						events <- Event{Type: EventTextDelta, Text: part.Text}
+						if err := emit(Event{Type: EventTextDelta, Text: part.Text}); err != nil {
+							return err
+						}
 					}
 					if part.FunctionCall != nil {
 						argsJSON, _ := jsonMarshal(part.FunctionCall.Args)
@@ -174,17 +180,23 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 						if thoughtSig == nil {
 							thoughtSig = lastThoughtSig
 						}
-						events <- Event{Type: EventToolCall, Tool: &ToolCall{
+						if err := emit(Event{Type: EventToolCall, Tool: &ToolCall{
 							ID:         part.FunctionCall.ID,
 							Name:       part.FunctionCall.Name,
 							Arguments:  argsJSON,
 							ThoughtSig: thoughtSig,
-						}}
+						}}); err != nil {
+							return err
+						}
 					}
 				}
 			}
-			emitGeminiUsage(events, resp)
-			events <- Event{Type: EventDone}
+			if err := emitGeminiUsage(ctx, events, resp); err != nil {
+				return err
+			}
+			if err := emit(Event{Type: EventDone}); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -196,7 +208,9 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 			}
 			lastResp = resp
 			if text := resp.Text(); text != "" {
-				events <- Event{Type: EventTextDelta, Text: text}
+				if err := emit(Event{Type: EventTextDelta, Text: text}); err != nil {
+					return err
+				}
 			}
 			if req.Search {
 				for _, cand := range resp.Candidates {
@@ -219,27 +233,45 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 		}
 
 		if len(sources) > 0 {
-			events <- Event{Type: EventTextDelta, Text: "\n\n**Sources:**\n"}
+			if err := emit(Event{Type: EventTextDelta, Text: "\n\n**Sources:**\n"}); err != nil {
+				return err
+			}
 			for _, source := range sources {
-				events <- Event{Type: EventTextDelta, Text: "- " + source + "\n"}
+				if err := emit(Event{Type: EventTextDelta, Text: "- " + source + "\n"}); err != nil {
+					return err
+				}
 			}
 		}
-		emitGeminiUsage(events, lastResp)
-		events <- Event{Type: EventDone}
+		if err := emitGeminiUsage(ctx, events, lastResp); err != nil {
+			return err
+		}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }
 
-func emitGeminiUsage(events chan<- Event, resp *genai.GenerateContentResponse) {
+func emitGeminiEvent(ctx context.Context, events chan<- Event, event Event) error {
+	select {
+	case events <- event:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func emitGeminiUsage(ctx context.Context, events chan<- Event, resp *genai.GenerateContentResponse) error {
 	if resp == nil || resp.UsageMetadata == nil {
-		return
+		return nil
 	}
 	if resp.UsageMetadata.TotalTokenCount > 0 {
-		events <- Event{Type: EventUsage, Use: &Usage{
+		return emitGeminiEvent(ctx, events, Event{Type: EventUsage, Use: &Usage{
 			InputTokens:  int(resp.UsageMetadata.PromptTokenCount),
 			OutputTokens: int(resp.UsageMetadata.CandidatesTokenCount),
-		}}
+		}})
 	}
+	return nil
 }
 
 func buildGeminiTools(specs []ToolSpec) []*genai.Tool {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -1,6 +1,10 @@
 package llm
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 func TestBuildGeminiContents_DropsDanglingToolCalls(t *testing.T) {
 	_, contents := buildGeminiContents([]Message{
@@ -42,5 +46,28 @@ func TestBuildGeminiContents_DropsDanglingToolCalls(t *testing.T) {
 	}
 	if !sawText {
 		t.Fatalf("expected assistant text to be preserved, got %#v", assistant.Parts)
+	}
+}
+
+func TestEmitGeminiEvent_ReturnsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan Event, 1)
+	events <- Event{Type: EventTextDelta, Text: "buffer full"}
+	cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- emitGeminiEvent(ctx, events, Event{Type: EventDone})
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("emitGeminiEvent() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("emitGeminiEvent() blocked after context cancellation")
 	}
 }


### PR DESCRIPTION
## What

- add a small Gemini-specific emit helper that stops sending events once the stream context is canceled
- route Gemini text, tool call, usage, sources, and done events through that helper instead of writing directly to the shared event channel
- add a regression test covering the canceled-context/full-buffer case

## Why

Gemini could block forever trying to send a final event after the consumer stopped reading. That leaves the Gemini worker goroutine stuck, and `Close()` can then hang waiting for the worker to exit during interrupt/shutdown paths.
