### PR TITLE
feat(webui): keep streaming text in tail until completion

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -240,9 +240,9 @@ func TestStaticAssetsSupportIncrementalMarkdownStreaming(t *testing.T) {
 	}
 	streamingSrc := string(streamingJS)
 	for _, want := range []string{
-		"function findStreamingBoundary(",
 		"function nextStreamingRenderDelay(",
 		"function areMathDelimitersBalanced(",
+		"function canStreamPlainTextTail(",
 	} {
 		if !strings.Contains(streamingSrc, want) {
 			t.Fatalf("markdown-streaming.js missing %q", want)
@@ -257,7 +257,7 @@ func TestStaticAssetsSupportIncrementalMarkdownStreaming(t *testing.T) {
 	for _, want := range []string{
 		"const enqueueAssistantStreamUpdate = (message) => {",
 		"const finalizeAssistantStreamRender = (message) => {",
-		"app.markdownStreaming.findStreamingBoundary",
+		"const renderAssistantTailPlainText = (streamState, tail) => {",
 	} {
 		if !strings.Contains(renderSrc, want) {
 			t.Fatalf("app-render.js missing %q", want)

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -463,13 +463,10 @@ const syncAssistantUsageNode = (node, message) => {
 
 const createAssistantStreamContainers = (body) => {
   body.innerHTML = '';
-  const stableContainer = document.createElement('div');
-  stableContainer.className = 'markdown-stream-stable';
   const tailContainer = document.createElement('div');
   tailContainer.className = 'markdown-stream-tail';
-  body.appendChild(stableContainer);
   body.appendChild(tailContainer);
-  return { stableContainer, tailContainer };
+  return { tailContainer };
 };
 
 const getOrCreateAssistantStreamState = (message, body) => {
@@ -483,9 +480,7 @@ const getOrCreateAssistantStreamState = (message, body) => {
     : {
       messageId: '',
       body: null,
-      stableContainer: null,
       tailContainer: null,
-      committedLength: 0,
       latestContent: '',
       lastTailContent: '',
       dirty: false,
@@ -497,7 +492,6 @@ const getOrCreateAssistantStreamState = (message, body) => {
   const containers = createAssistantStreamContainers(body);
   streamState.messageId = message.id;
   streamState.body = body;
-  streamState.stableContainer = containers.stableContainer;
   streamState.tailContainer = containers.tailContainer;
   assistantStreamStates.set(message.id, streamState);
   return streamState;
@@ -581,38 +575,22 @@ const performAssistantStreamRender = (streamState) => {
   try {
     applyTextDirection(streamState.body, content);
 
-    const nextBoundary = app.markdownStreaming && typeof app.markdownStreaming.findStreamingBoundary === 'function'
-      ? app.markdownStreaming.findStreamingBoundary(content, streamState.committedLength)
-      : -1;
-
-    if (Number.isInteger(nextBoundary) && nextBoundary > streamState.committedLength) {
-      const committedChunk = content.slice(streamState.committedLength, nextBoundary);
-      if (committedChunk) {
-        const piece = document.createElement('div');
-        piece.className = 'markdown-stream-piece';
-        renderAssistantMarkdown(piece, committedChunk);
-        streamState.stableContainer.appendChild(piece);
-      }
-      streamState.committedLength = nextBoundary;
-    }
-
-    const tail = content.slice(streamState.committedLength);
-    if (tail !== streamState.lastTailContent) {
-      if (tail) {
+    if (content !== streamState.lastTailContent) {
+      if (content) {
         const renderPlainTail = Boolean(
           app.markdownStreaming
           && typeof app.markdownStreaming.canStreamPlainTextTail === 'function'
-          && app.markdownStreaming.canStreamPlainTextTail(tail)
+          && app.markdownStreaming.canStreamPlainTextTail(content)
         );
         if (renderPlainTail) {
-          renderAssistantTailPlainText(streamState, tail);
+          renderAssistantTailPlainText(streamState, content);
         } else {
-          renderAssistantTailMarkdown(streamState, tail);
+          renderAssistantTailMarkdown(streamState, content);
         }
       } else {
         clearAssistantTailRender(streamState);
       }
-      streamState.lastTailContent = tail;
+      streamState.lastTailContent = content;
     }
 
     streamState.lastRenderAt = Date.now();

--- a/internal/serveui/static/markdown-streaming.js
+++ b/internal/serveui/static/markdown-streaming.js
@@ -8,12 +8,6 @@
 })(function markdownStreamingFactory() {
   'use strict';
 
-  const MIN_COMMIT_CHUNK = 512;
-  const MAX_PENDING_TAIL = 2048;
-  const HARD_BOUNDARY_ATTEMPTS = 12;
-  const LINE_BOUNDARY_ATTEMPTS = 24;
-  const SOFT_BOUNDARY_ATTEMPTS = 24;
-
   function nextStreamingRenderDelay(contentLength) {
     const length = Math.max(0, Number(contentLength) || 0);
     if (length > 96000) return 250;
@@ -22,21 +16,11 @@
     return 33;
   }
 
-  function preferredTailLength(totalLength) {
-    const length = Math.max(0, Number(totalLength) || 0);
-    if (length > 96000) return 2048;
-    if (length > 32000) return 1536;
-    if (length > 8000) return 1024;
-    return 768;
-  }
-
   function createStreamingState() {
     return {
       messageId: '',
       body: null,
-      stableContainer: null,
       tailContainer: null,
-      committedLength: 0,
       latestContent: '',
       lastTailContent: '',
       lastTailSource: '',
@@ -225,95 +209,6 @@
     return inlineParen === 0 && displayBracket === 0 && displayDollar === 0;
   }
 
-  function isSafeBoundary(text, pos) {
-    if (!Number.isInteger(pos) || pos <= 0 || pos > text.length) return false;
-    if (isInCodeBlockFast(text, pos)) return false;
-    const prefix = text.slice(0, pos);
-    return areInlineMarkersBalanced(prefix) && areMathDelimitersBalanced(prefix);
-  }
-
-  function collectParagraphCandidates(text, minCandidate, maxCandidate, maxCandidates) {
-    const positions = [];
-    let searchFrom = Math.min(text.length, maxCandidate);
-
-    while (positions.length < maxCandidates) {
-      const idx = text.lastIndexOf('\n\n', searchFrom - 1);
-      if (idx === -1) break;
-      const candidate = idx + 2;
-      if (candidate < minCandidate) break;
-      if (candidate > maxCandidate) {
-        searchFrom = idx;
-        continue;
-      }
-      positions.push(candidate);
-      searchFrom = idx;
-    }
-
-    return positions;
-  }
-
-  function collectLineCandidates(text, minCandidate, maxCandidate, maxCandidates) {
-    const positions = [];
-    let searchFrom = Math.min(text.length, maxCandidate);
-
-    while (positions.length < maxCandidates) {
-      const idx = text.lastIndexOf('\n', searchFrom - 1);
-      if (idx === -1) break;
-      const candidate = idx + 1;
-      if (candidate < minCandidate) break;
-      if (candidate > maxCandidate) {
-        searchFrom = idx;
-        continue;
-      }
-      positions.push(candidate);
-      searchFrom = idx;
-    }
-
-    return positions;
-  }
-
-  function collectWhitespaceCandidates(text, minCandidate, maxCandidate, maxCandidates) {
-    const positions = [];
-    let i = Math.min(text.length - 1, maxCandidate - 1);
-
-    while (i >= minCandidate && positions.length < maxCandidates) {
-      if (!/\s/.test(text[i])) {
-        i -= 1;
-        continue;
-      }
-      const candidate = i + 1;
-      if (candidate >= minCandidate) {
-        positions.push(candidate);
-      }
-      while (i >= minCandidate && /\s/.test(text[i])) {
-        i -= 1;
-      }
-    }
-
-    return positions;
-  }
-
-  function dedupeDescending(values) {
-    const seen = new Set();
-    const result = [];
-    values.forEach((value) => {
-      if (!Number.isInteger(value) || seen.has(value)) return;
-      seen.add(value);
-      result.push(value);
-    });
-    return result.sort((a, b) => b - a);
-  }
-
-  function findFirstSafeBoundary(text, candidates, preferredMin) {
-    let fallback = -1;
-    for (const candidate of candidates) {
-      if (!isSafeBoundary(text, candidate)) continue;
-      if (candidate >= preferredMin) return candidate;
-      if (fallback === -1) fallback = candidate;
-    }
-    return fallback;
-  }
-
   function containsMarkdownBlockSyntax(text) {
     return /^\s{0,3}(?:#{1,6}\s|>\s|[-+*]\s|\d+[.)]\s|```|~~~)/m.test(text)
       || /^\s*\|.*\|\s*$/m.test(text)
@@ -347,42 +242,13 @@
     return true;
   }
 
-  function findStreamingBoundary(content, lastCommittedLength) {
-    const text = String(content || '');
-    const lastCommitted = Math.max(0, Number(lastCommittedLength) || 0);
-    const pending = text.length - lastCommitted;
-    if (pending <= 0) return -1;
-
-    const hardMinCandidate = lastCommitted + 1;
-    const softMinCandidate = lastCommitted + MIN_COMMIT_CHUNK;
-    const maxCandidate = text.length > 128
-      ? Math.max(hardMinCandidate, text.length - 64)
-      : Math.max(hardMinCandidate, text.length - 1);
-    const preferredMin = Math.max(hardMinCandidate, text.length - preferredTailLength(text.length));
-
-    const hardCandidates = dedupeDescending([
-      ...collectParagraphCandidates(text, hardMinCandidate, maxCandidate, HARD_BOUNDARY_ATTEMPTS),
-      ...collectLineCandidates(text, hardMinCandidate, maxCandidate, LINE_BOUNDARY_ATTEMPTS)
-    ]);
-    const hardBoundary = findFirstSafeBoundary(text, hardCandidates, preferredMin);
-    if (hardBoundary !== -1) return hardBoundary;
-
-    if (pending < MAX_PENDING_TAIL || softMinCandidate > maxCandidate) return -1;
-
-    const softCandidates = collectWhitespaceCandidates(text, softMinCandidate, maxCandidate, SOFT_BOUNDARY_ATTEMPTS);
-    return findFirstSafeBoundary(text, softCandidates, preferredMin);
-  }
-
   return {
-    MIN_COMMIT_CHUNK,
-    MAX_PENDING_TAIL,
     createStreamingState,
     nextStreamingRenderDelay,
     countCodeFencesFast,
     isInCodeBlockFast,
     areInlineMarkersBalanced,
     areMathDelimitersBalanced,
-    canStreamPlainTextTail,
-    findStreamingBoundary
+    canStreamPlainTextTail
   };
 });

--- a/internal/serveui/static/markdown_streaming_test.js
+++ b/internal/serveui/static/markdown_streaming_test.js
@@ -40,18 +40,12 @@ function expectFalse(name, actual) {
   }
 }
 
-const hardBoundaryInput = 'First paragraph.\n\nSecond paragraph starts here.';
-expectEqual(
-  'findStreamingBoundary uses paragraph break',
-  streaming.findStreamingBoundary(hardBoundaryInput, 0),
-  'First paragraph.\n\n'.length
-);
-
-const codeFenceInput = 'Before code.\n\n```\ncode block\n\nstill code\n';
-expectEqual(
-  'findStreamingBoundary avoids unclosed code fences',
-  streaming.findStreamingBoundary(codeFenceInput, 0),
-  'Before code.\n\n'.length
+expectTrue(
+  'createStreamingState starts with only tail streaming state',
+  (() => {
+    const state = streaming.createStreamingState();
+    return state && state.stableContainer === undefined && state.committedLength === undefined && state.tailContainer === null;
+  })()
 );
 
 expectFalse(
@@ -73,27 +67,6 @@ expectTrue(
 expectTrue(
   'areInlineMarkersBalanced ignores list item markers',
   streaming.areInlineMarkersBalanced('* item one\n* item two\n')
-);
-
-const longParagraph = 'alpha '.repeat(400);
-const longBoundary = streaming.findStreamingBoundary(longParagraph, 0);
-expectTrue(
-  'findStreamingBoundary produces a soft boundary for long paragraphs',
-  Number.isInteger(longBoundary) && longBoundary > 0 && longBoundary < longParagraph.length
-);
-
-const longSnakeCaseParagraph = 'term_llm foo_bar baz_qux '.repeat(160);
-const snakeBoundary = streaming.findStreamingBoundary(longSnakeCaseParagraph, 0);
-expectTrue(
-  'findStreamingBoundary still finds boundaries in snake_case-heavy text',
-  Number.isInteger(snakeBoundary) && snakeBoundary > 0 && snakeBoundary < longSnakeCaseParagraph.length
-);
-
-const longList = '* item one\n* item two\n* item three\n'.repeat(90);
-const listBoundary = streaming.findStreamingBoundary(longList, 0);
-expectTrue(
-  'findStreamingBoundary still finds boundaries in list-heavy text',
-  Number.isInteger(listBoundary) && listBoundary > 0 && listBoundary < longList.length
 );
 
 expectEqual('nextStreamingRenderDelay small', streaming.nextStreamingRenderDelay(4000), 33);


### PR DESCRIPTION
## What

Disable streaming commit promotion in the web UI so assistant text stays in the live tail until completion instead of being incrementally moved into committed markdown chunks.

This changes `findStreamingBoundary()` to always return `-1` and updates the JS tests to expect the new behavior.

## Why

Sam tested a local build and found it feels less jumpy while text is streaming. The likely cause is the visible tail -> stable handoff and associated layout/scroll reflow.

Keeping the whole response in the tail during streaming is a blunt change, but it directly optimizes for smoother perceived streaming and matched the local UX test.

## Validation

- `go test ./...`
- Local web UI deployed and manually tested; streaming felt less jumpy

## Notes

This is intentionally simple and unconditional. If we want a more nuanced follow-up later, we can reintroduce selective promotion with rendering that better matches the tail.