### PR TITLE
fix: Response-run cancellation is reported as a failed run instead of a cancelled run

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -120,6 +120,20 @@ func (r *responseRun) complete(payload map[string]any, usage llm.Usage, sessionU
 	return r.appendEventLocked("response.completed", payload, true)
 }
 
+func (r *responseRun) finishCancelled(payload map[string]any) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.cancelRequested {
+		return false, nil
+	}
+	r.status = "cancelled"
+	r.errorType = ""
+	r.errorMessage = ""
+	r.cancel = nil
+	r.cancelRequested = false
+	return true, r.appendEventLocked("response.cancelled", payload, true)
+}
+
 func (r *responseRun) fail(payload map[string]any, errType, errMessage string) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -320,6 +334,8 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 				return
 			}
 		}
+	case "response.cancelled":
+		r.closeToolGroupLocked()
 	case "response.failed":
 		r.closeToolGroupLocked()
 		errPayload := mapValue(payload["error"])
@@ -1099,6 +1115,26 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 			return s.appendResponseRunEvent(runtime, run, streamState, ev)
 		})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				cancelled, cancelErr := run.finishCancelled(map[string]any{
+					"response": map[string]any{
+						"id":      respID,
+						"object":  "response",
+						"created": created,
+						"model":   model,
+						"status":  "cancelled",
+					},
+				})
+				if cancelled {
+					if options.uiSession {
+						runtime.clearLastUIRunError()
+					}
+					if cancelErr != nil {
+						log.Printf("response run %s failed to append cancellation event: %v", respID, cancelErr)
+					}
+					return
+				}
+			}
 			errType := "invalid_request_error"
 			if errors.Is(err, errServeSessionBusy) {
 				errType = "conflict_error"

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4911,8 +4911,36 @@ func TestHandleResponseByID_CancelStopsActiveToolRun(t *testing.T) {
 	}
 
 	snapshot := run.snapshot()
-	if status, _ := snapshot["status"].(string); status == "in_progress" {
-		t.Fatalf("run status remained in_progress after cancel: %#v", snapshot)
+	if status, _ := snapshot["status"].(string); status != "cancelled" {
+		t.Fatalf("run status = %q, want cancelled: %#v", status, snapshot)
+	}
+	if _, ok := snapshot["error"]; ok {
+		t.Fatalf("cancelled run should not include error payload: %#v", snapshot)
+	}
+
+	subscription := run.subscribe(0)
+	if subscription.ch != nil {
+		t.Fatal("terminal cancelled run should replay without live subscription channel")
+	}
+	var sawCancelled bool
+	for _, event := range subscription.replay {
+		if event.Event == "response.failed" {
+			t.Fatalf("cancelled run replay unexpectedly contained response.failed: %+v", event)
+		}
+		if event.Event == "response.cancelled" {
+			sawCancelled = true
+			var payload map[string]any
+			if err := json.Unmarshal(event.Data, &payload); err != nil {
+				t.Fatalf("unmarshal response.cancelled payload: %v", err)
+			}
+			response, _ := payload["response"].(map[string]any)
+			if got := response["status"]; got != "cancelled" {
+				t.Fatalf("response.cancelled status = %v, want cancelled", got)
+			}
+		}
+	}
+	if !sawCancelled {
+		t.Fatal("cancelled run replay missing response.cancelled terminal event")
 	}
 }
 


### PR DESCRIPTION
## What

Persist explicit response-run cancellations as a cancelled terminal state instead of a failed one.

This change adds a dedicated cancelled terminal path in `startResponseRun` when `RunWithEvents` exits with `context.Canceled` or `context.DeadlineExceeded` after `cancelRequested` has been set. Cancelled runs now:
- store `status: "cancelled"`
- emit `response.cancelled`
- avoid attaching a failure error payload
- close recovery tool groups cleanly during replay

It also extends the existing cancel test to assert the persisted snapshot and replayed event stream use the cancelled terminal state.

## Why

`POST /v1/responses/{id}/cancel` was only invoking the run cancel function. When the runtime later exited, the server always persisted the terminal result via `run.fail(...)`, which turned explicit user cancellations into `status: "failed"` with an `invalid_request_error`.

That breaks response API semantics and causes reconnecting/replaying clients to treat a normal cancel as an error. This fix preserves explicit cancellations as cancelled runs while leaving non-cancel context failures on the existing failed path.
