### PR TITLE
fix: read_url host blocking can be bypassed through redirects

### DIFF
--- a/internal/llm/read_url_tool.go
+++ b/internal/llm/read_url_tool.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	ReadURLToolName = "read_url"
-	maxReadURLChars = 50000
+	ReadURLToolName     = "read_url"
+	maxReadURLChars     = 50000
+	maxReadURLRedirects = 10
 )
 
 var readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
@@ -79,7 +80,7 @@ func (t *ReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOu
 		return ToolOutput{}, fmt.Errorf("url is required")
 	}
 
-	url, err := normalizeReadURLTarget(ctx, payload.URL)
+	url, err := resolveReadURLTarget(ctx, t.client, payload.URL)
 	if err != nil {
 		return ToolOutput{}, err
 	}
@@ -120,6 +121,52 @@ func (t *ReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOu
 	}
 
 	return TextOutput(content), nil
+}
+
+func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL string) (string, error) {
+	targetURL, err := normalizeReadURLTarget(ctx, rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	redirectClient := *client
+	redirectClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	for range maxReadURLRedirects {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+		if err != nil {
+			return "", fmt.Errorf("create redirect check request: %w", err)
+		}
+
+		resp, err := redirectClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("check url redirects: %w", err)
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+			return targetURL, nil
+		}
+
+		location := resp.Header.Get("Location")
+		if location == "" {
+			return "", fmt.Errorf("redirect response missing location header")
+		}
+
+		nextURL, err := req.URL.Parse(location)
+		if err != nil {
+			return "", fmt.Errorf("parse redirect location: %w", err)
+		}
+
+		targetURL, err = normalizeReadURLTarget(ctx, nextURL.String())
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return "", fmt.Errorf("too many redirects")
 }
 
 func normalizeReadURLTarget(ctx context.Context, rawURL string) (string, error) {

--- a/internal/llm/read_url_tool_test.go
+++ b/internal/llm/read_url_tool_test.go
@@ -42,19 +42,35 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 	defer func() { readURLLookupIP = origLookup }()
 
 	readErr := errors.New("read past limit")
-	capturedURL := ""
+	capturedJinaURL := ""
+	capturedTargetURLs := []string{}
 	tool := NewReadURLTool()
 	tool.client = &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			capturedURL = req.URL.String()
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body: &failAfterNReadCloser{
-					remaining: maxReadURLChars + 1,
-					err:       readErr,
-				},
-				Header: make(http.Header),
-			}, nil
+			switch req.URL.Host {
+			case "example.com":
+				capturedTargetURLs = append(capturedTargetURLs, req.URL.String())
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("ok")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			case "r.jina.ai":
+				capturedJinaURL = req.URL.String()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: &failAfterNReadCloser{
+						remaining: maxReadURLChars + 1,
+						err:       readErr,
+					},
+					Header:  make(http.Header),
+					Request: req,
+				}, nil
+			default:
+				t.Fatalf("unexpected host %q", req.URL.Host)
+				return nil, nil
+			}
 		}),
 	}
 
@@ -67,7 +83,13 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if got, want := capturedURL, "https://r.jina.ai/https://example.com/article"; got != want {
+	if got, want := len(capturedTargetURLs), 1; got != want {
+		t.Fatalf("expected %d target preflight request, got %d (%v)", want, got, capturedTargetURLs)
+	}
+	if got, want := capturedTargetURLs[0], "https://example.com/article"; got != want {
+		t.Fatalf("expected preflight URL %q, got %q", want, got)
+	}
+	if got, want := capturedJinaURL, "https://r.jina.ai/https://example.com/article"; got != want {
 		t.Fatalf("expected fetch URL %q, got %q", want, got)
 	}
 	if strings.Contains(out.Content, readErr.Error()) {
@@ -157,6 +179,125 @@ func TestReadURLToolExecuteRejectsHostsResolvingToPrivateIPs(t *testing.T) {
 	}
 	if called {
 		t.Fatalf("expected blocked host to prevent outbound request")
+	}
+}
+
+func TestReadURLToolExecuteRejectsRedirectsToBlockedHosts(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		if host != "example.com" {
+			t.Fatalf("unexpected host lookup %q", host)
+		}
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
+	requests := []string{}
+	tool := NewReadURLTool()
+	tool.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests = append(requests, req.URL.String())
+			if req.URL.Host != "example.com" {
+				t.Fatalf("unexpected request to %q", req.URL.String())
+			}
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Body:       io.NopCloser(strings.NewReader("redirect")),
+				Header: http.Header{
+					"Location": []string{"http://127.0.0.1/admin"},
+				},
+				Request: req,
+			}, nil
+		}),
+	}
+
+	args, err := json.Marshal(map[string]string{"url": "https://example.com/article"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	_, err = tool.Execute(context.Background(), args)
+	if err == nil || !strings.Contains(err.Error(), "url host is not allowed") {
+		t.Fatalf("expected blocked redirect host error, got %v", err)
+	}
+	if got, want := len(requests), 1; got != want {
+		t.Fatalf("expected %d outbound request before rejection, got %d (%v)", want, got, requests)
+	}
+	if got, want := requests[0], "https://example.com/article"; got != want {
+		t.Fatalf("expected redirect check against %q, got %q", want, got)
+	}
+}
+
+func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeJinaFetch(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "example.com":
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		case "www.example.com":
+			return []net.IP{net.ParseIP("93.184.216.35")}, nil
+		default:
+			t.Fatalf("unexpected host lookup %q", host)
+			return nil, nil
+		}
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
+	requests := []string{}
+	capturedJinaURL := ""
+	tool := NewReadURLTool()
+	tool.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests = append(requests, req.URL.String())
+			switch req.URL.Host {
+			case "example.com":
+				return &http.Response{
+					StatusCode: http.StatusMovedPermanently,
+					Body:       io.NopCloser(strings.NewReader("redirect")),
+					Header: http.Header{
+						"Location": []string{"https://www.example.com/article"},
+					},
+					Request: req,
+				}, nil
+			case "www.example.com":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("ok")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			case "r.jina.ai":
+				capturedJinaURL = req.URL.String()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("content")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			default:
+				t.Fatalf("unexpected host %q", req.URL.Host)
+				return nil, nil
+			}
+		}),
+	}
+
+	args, err := json.Marshal(map[string]string{"url": "https://example.com/start"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if got, want := capturedJinaURL, "https://r.jina.ai/https://www.example.com/article"; got != want {
+		t.Fatalf("expected Jina fetch URL %q, got %q", want, got)
+	}
+	if got, want := out.Content, "content"; got != want {
+		t.Fatalf("expected content %q, got %q", want, got)
+	}
+	if got, want := len(requests), 3; got != want {
+		t.Fatalf("expected %d total requests, got %d (%v)", want, got, requests)
 	}
 }
 


### PR DESCRIPTION
## What

- preflight `read_url` targets without following redirects automatically
- validate each redirect hop with the existing blocked-host and blocked-IP checks
- pass the final validated URL to Jina AI Reader
- add tests covering blocked redirect targets and allowed redirect chains

## Why

`read_url` only validated the initial host before handing the URL to `r.jina.ai`. If that URL redirected to localhost, metadata endpoints, or private IPs, the redirect target was never revalidated and the SSRF guard could be bypassed. Following the redirect chain locally and validating every hop closes that gap.
