### PR TITLE
fix: Venice streaming uses blocking event sends that can wedge cancellation

### DIFF
--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -108,6 +108,16 @@ func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error
 	return newEventStream(ctx, func(ctx context.Context, events chan<- Event) error {
 		defer resp.Body.Close()
 
+		sendEvent := func(event Event) error {
+			if safeSendEvent(ctx, events, event) {
+				return nil
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return nil
+		}
+
 		scanner := bufio.NewScanner(resp.Body)
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, 1024*1024)
@@ -153,11 +163,15 @@ func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error
 			for _, choice := range chatResp.Choices {
 				if choice.Delta != nil {
 					if content, ok := choice.Delta.Content.(string); ok && content != "" {
-						events <- Event{Type: EventTextDelta, Text: content}
+						if err := sendEvent(Event{Type: EventTextDelta, Text: content}); err != nil {
+							return err
+						}
 					}
 					if choice.Delta.Reasoning != "" {
 						reasoningBuilder.WriteString(choice.Delta.Reasoning)
-						events <- Event{Type: EventReasoningDelta, Text: choice.Delta.Reasoning}
+						if err := sendEvent(Event{Type: EventReasoningDelta, Text: choice.Delta.Reasoning}); err != nil {
+							return err
+						}
 					}
 					if len(choice.Delta.ToolCalls) > 0 {
 						toolState.Add(choice.Delta.ToolCalls)
@@ -170,12 +184,18 @@ func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error
 			return fmt.Errorf("%s streaming error: %w", p.name, err)
 		}
 		for _, call := range toolState.Calls() {
-			events <- Event{Type: EventToolCall, Tool: &call}
+			if err := sendEvent(Event{Type: EventToolCall, Tool: &call}); err != nil {
+				return err
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := sendEvent(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := sendEvent(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -3,10 +3,12 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
 )
@@ -275,5 +277,47 @@ func TestVeniceProviderExplicitXSearchUsesVeniceParameters(t *testing.T) {
 	}
 	if _, ok := got.VeniceParameters["enable_web_search"]; ok {
 		t.Fatalf("did not expect enable_web_search alongside explicit x search: %#v", got.VeniceParameters)
+	}
+}
+
+func TestVeniceProviderCloseDoesNotBlockWhenEventBufferIsFull(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("response writer does not support flushing")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		for i := 0; i < 32; i++ {
+			_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":\"chunk-%d\"}}]}\n\n", i)
+			flusher.Flush()
+		}
+
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	provider := &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(ts.URL, "test-key", "venice-uncensored", "Venice")}
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- stream.Close()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() blocked with a full event buffer")
 	}
 }


### PR DESCRIPTION
## What

- replace Venice's raw blocking stream event sends with context-aware sends
- return promptly when cancellation happens while emitting text, reasoning, tool-call, usage, or done events
- add a regression test covering Close() with a full event buffer

## Why

Venice could block forever on an event send if the downstream consumer stopped draining after cancellation or disconnect. That wedged Stream.Close(), leaked the HTTP stream, and could leave the request stuck busy.
