### PR TITLE
fix: Copilot provider can hang forever when a stream consumer goes away

### DIFF
--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -344,6 +344,15 @@ func (p *CopilotProvider) streamChatCompletions(ctx context.Context, req Request
 		var lastUsage *Usage
 		var lastEventType string
 		unmarshalErrors := 0
+		sendEvent := func(event Event) error {
+			if safeSendEvent(ctx, events, event) {
+				return nil
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return fmt.Errorf("failed to emit Copilot event: stream closed")
+		}
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -396,7 +405,9 @@ func (p *CopilotProvider) streamChatCompletions(ctx context.Context, req Request
 			for _, choice := range chatResp.Choices {
 				if choice.Delta != nil {
 					if content, ok := choice.Delta.Content.(string); ok && content != "" {
-						events <- Event{Type: EventTextDelta, Text: content}
+						if err := sendEvent(Event{Type: EventTextDelta, Text: content}); err != nil {
+							return err
+						}
 					}
 					if len(choice.Delta.ToolCalls) > 0 {
 						toolState.Add(choice.Delta.ToolCalls)
@@ -412,12 +423,18 @@ func (p *CopilotProvider) streamChatCompletions(ctx context.Context, req Request
 		}
 
 		for _, call := range toolState.Calls() {
-			events <- Event{Type: EventToolCall, Tool: &call}
+			if err := sendEvent(Event{Type: EventToolCall, Tool: &call}); err != nil {
+				return err
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := sendEvent(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := sendEvent(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }

--- a/internal/llm/copilot_test.go
+++ b/internal/llm/copilot_test.go
@@ -1,0 +1,94 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCopilotChatCompletionsCloseDoesNotHangWhenConsumerStopsReading(t *testing.T) {
+	started := make(chan struct{})
+	wroteMany := make(chan struct{})
+	cancelled := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("response writer does not support flushing")
+			close(started)
+			close(wroteMany)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		close(started)
+
+		for i := 0; i < 64; i++ {
+			_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n")
+			flusher.Flush()
+		}
+		close(wroteMany)
+
+		<-r.Context().Done()
+		close(cancelled)
+	}))
+	defer ts.Close()
+
+	provider := &CopilotProvider{
+		model:              "gpt-4.1",
+		apiBaseURL:         ts.URL,
+		sessionToken:       "test-session",
+		sessionTokenExpiry: time.Now().Add(time.Hour),
+	}
+
+	stream, err := provider.streamChatCompletions(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+	}, "gpt-4.1")
+	if err != nil {
+		t.Fatalf("streamChatCompletions() error = %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive request")
+	}
+
+	select {
+	case <-wroteMany:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not write streaming response")
+	}
+
+	// Give the producer a moment to fill the buffered event channel and block on
+	// a send before we close the stream.
+	time.Sleep(50 * time.Millisecond)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- stream.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() hung while producer was blocked on event send")
+	}
+
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request context was not cancelled")
+	}
+}


### PR DESCRIPTION
## What

- make Copilot chat-completions streaming emit events through a context-aware helper instead of blocking channel sends
- stop the producer loop cleanly when the stream context is cancelled while emitting text, tool-call, usage, or done events
- add a regression test covering stream closure when the consumer stops reading mid-stream

## Why

Copilot was writing directly to the internal event channel. If a consumer disconnected or cancelled and stopped draining events, the buffered channel could fill and leave the producer goroutine blocked forever on `events <- ...`. That prevented `Close()` from finishing, leaked the HTTP response body, and could leave runs or sessions stuck instead of shutting down cleanly.
