### PR TITLE
fix: xAI streaming can deadlock permanently on client disconnect or cancellation

### DIFF
--- a/internal/llm/xai.go
+++ b/internal/llm/xai.go
@@ -130,6 +130,15 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 		tagStripper := newXAITagStripper()
 		var lastUsage *Usage
 		var lastEventType string
+		emit := func(event Event) error {
+			if safeSendEvent(ctx, events, event) {
+				return nil
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return nil
+		}
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -172,7 +181,9 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 					if content, ok := choice.Delta.Content.(string); ok && content != "" {
 						// Use buffered tag stripper to handle tags split across chunks
 						if stripped := tagStripper.Add(content); stripped != "" {
-							events <- Event{Type: EventTextDelta, Text: stripped}
+							if err := emit(Event{Type: EventTextDelta, Text: stripped}); err != nil {
+								return err
+							}
 						}
 					}
 					if len(choice.Delta.ToolCalls) > 0 {
@@ -182,7 +193,9 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 				if choice.Message != nil {
 					if content, ok := choice.Message.Content.(string); ok && content != "" {
 						if stripped := tagStripper.Add(content); stripped != "" {
-							events <- Event{Type: EventTextDelta, Text: stripped}
+							if err := emit(Event{Type: EventTextDelta, Text: stripped}); err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -193,7 +206,9 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 
 		// Flush any remaining buffered content
 		if remaining := tagStripper.Flush(); remaining != "" {
-			events <- Event{Type: EventTextDelta, Text: remaining}
+			if err := emit(Event{Type: EventTextDelta, Text: remaining}); err != nil {
+				return err
+			}
 		}
 
 		if err := scanner.Err(); err != nil {
@@ -201,12 +216,18 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 		}
 
 		for _, call := range toolState.Calls() {
-			events <- Event{Type: EventToolCall, Tool: &call}
+			if err := emit(Event{Type: EventToolCall, Tool: &call}); err != nil {
+				return err
+			}
 		}
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := emit(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }
@@ -260,6 +281,15 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 
 		var lastUsage *Usage
 		var searchStarted bool
+		emit := func(event Event) error {
+			if safeSendEvent(ctx, events, event) {
+				return nil
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return nil
+		}
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -282,19 +312,25 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 				if event.Item != nil && (event.Item.Type == "web_search_call" || event.Item.Type == "x_search_call") {
 					if !searchStarted {
 						searchStarted = true
-						events <- Event{Type: EventToolExecStart, ToolName: event.Item.Type}
+						if err := emit(Event{Type: EventToolExecStart, ToolName: event.Item.Type}); err != nil {
+							return err
+						}
 					}
 				}
 
 			case "response.output_item.done":
 				// Search tool completed
 				if event.Item != nil && (event.Item.Type == "web_search_call" || event.Item.Type == "x_search_call") {
-					events <- Event{Type: EventToolExecEnd, ToolName: event.Item.Type}
+					if err := emit(Event{Type: EventToolExecEnd, ToolName: event.Item.Type}); err != nil {
+						return err
+					}
 				}
 
 			case "response.output_text.delta":
 				if event.Delta != "" {
-					events <- Event{Type: EventTextDelta, Text: event.Delta}
+					if err := emit(Event{Type: EventTextDelta, Text: event.Delta}); err != nil {
+						return err
+					}
 				}
 
 			case "response.completed":
@@ -315,9 +351,13 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 		}
 
 		if lastUsage != nil {
-			events <- Event{Type: EventUsage, Use: lastUsage}
+			if err := emit(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
 		}
-		events <- Event{Type: EventDone}
+		if err := emit(Event{Type: EventDone}); err != nil {
+			return err
+		}
 		return nil
 	}), nil
 }

--- a/internal/llm/xai_test.go
+++ b/internal/llm/xai_test.go
@@ -1,0 +1,104 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type xaiRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f xaiRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestXAIStreamStandardCloseReturnsWhenConsumerStopsDraining(t *testing.T) {
+	testXAIStreamCloseReturns(t, false)
+}
+
+func TestXAIStreamWithSearchCloseReturnsWhenConsumerStopsDraining(t *testing.T) {
+	testXAIStreamCloseReturns(t, true)
+}
+
+func testXAIStreamCloseReturns(t *testing.T, search bool) {
+	oldClient := defaultHTTPClient
+	var wroteBlockedEvent <-chan struct{}
+	defaultHTTPClient = &http.Client{
+		Transport: xaiRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, signal := newBlockingXAIStreamBody(search)
+			wroteBlockedEvent = signal
+			return &http.Response{
+				StatusCode: 200,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		}),
+	}
+	t.Cleanup(func() {
+		defaultHTTPClient = oldClient
+	})
+
+	provider := NewXAIProvider("test-key", "grok-4-1-fast")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "hello"}},
+		}},
+		Search: search,
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	if wroteBlockedEvent == nil {
+		t.Fatal("test transport did not provide a stream body signal")
+	}
+
+	select {
+	case <-wroteBlockedEvent:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for xAI test stream to fill the event buffer")
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- stream.Close()
+	}()
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() blocked after consumer stopped draining the xAI stream")
+	}
+}
+
+func newBlockingXAIStreamBody(search bool) (io.ReadCloser, <-chan struct{}) {
+
+	pr, pw := io.Pipe()
+	wroteBlockedEvent := make(chan struct{})
+	go func() {
+		defer pw.Close()
+		for i := 0; i < 17; i++ {
+			var line string
+			if search {
+				line = fmt.Sprintf("data: {\"type\":\"response.output_text.delta\",\"delta\":%q}\n\n", strings.Repeat("x", i+1))
+			} else {
+				line = fmt.Sprintf("data: {\"choices\":[{\"delta\":{\"content\":%q}}]}\n\n", strings.Repeat("x", i+1))
+			}
+			if _, err := io.WriteString(pw, line); err != nil {
+				return
+			}
+			if i == 16 {
+				close(wroteBlockedEvent)
+			}
+		}
+	}()
+
+	return pr, wroteBlockedEvent
+}


### PR DESCRIPTION
## What

- make both xAI streaming paths use a context-aware event emitter instead of plain blocking channel sends
- return early when the stream context is cancelled while emitting text, tool execution, usage, or done events
- add regression tests covering both the standard chat stream and the search/responses stream when the consumer stops draining events

## Why

If the caller disconnects or abandons the stream, the 16-event buffer created by `newEventStream` can fill up. The old plain `events <- ...` sends in `internal/llm/xai.go` would then block forever, which prevented `channelStream.Close()` from finishing and left the xAI response body/request wedged. Making those sends context-aware lets cancellation unwind the producer goroutine cleanly.
