### PR TITLE
fix: Runtime Close cannot cancel an active run and can hang shutdown for minutes

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -108,13 +108,15 @@ func (rt *serveRuntime) configureContextManagementForRequest(req llm.Request) {
 }
 
 func (rt *serveRuntime) Close() {
+	rt.interruptMu.Lock()
+	state := rt.activeInterrupt
+	rt.interruptMu.Unlock()
+	if state != nil && state.cancel != nil {
+		state.cancel()
+	}
+
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	rt.interruptMu.Lock()
-	if rt.activeInterrupt != nil && rt.activeInterrupt.cancel != nil {
-		rt.activeInterrupt.cancel()
-	}
-	rt.interruptMu.Unlock()
 	rt.clearPendingAskUsers()
 	rt.clearPendingApprovals()
 	if rt.mcpManager != nil {

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -296,6 +296,103 @@ func serveRuntimeTextMessage(role llm.Role, text string) llm.Message {
 	}
 }
 
+type serveRuntimeBlockingStream struct {
+	ctx context.Context
+}
+
+func (s *serveRuntimeBlockingStream) Recv() (llm.Event, error) {
+	<-s.ctx.Done()
+	return llm.Event{}, s.ctx.Err()
+}
+
+func (s *serveRuntimeBlockingStream) Close() error {
+	return nil
+}
+
+type serveRuntimeBlockingProvider struct {
+	startOnce     sync.Once
+	streamStarted chan struct{}
+}
+
+func (p *serveRuntimeBlockingProvider) Name() string {
+	return "serve-runtime-blocking"
+}
+
+func (p *serveRuntimeBlockingProvider) Credential() string {
+	return "test"
+}
+
+func (p *serveRuntimeBlockingProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{}
+}
+
+func (p *serveRuntimeBlockingProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	p.startOnce.Do(func() {
+		close(p.streamStarted)
+	})
+	return &serveRuntimeBlockingStream{ctx: ctx}, nil
+}
+
+func TestServeRuntimeCloseCancelsActiveRun(t *testing.T) {
+	provider := &serveRuntimeBlockingProvider{streamStarted: make(chan struct{})}
+	engine := llm.NewEngine(provider, llm.NewToolRegistry())
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		defaultModel: "test-model",
+	}
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		_, err := rt.Run(context.Background(), false, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "hello")}, llm.Request{
+			SessionID: "sess-close",
+		})
+		runErrCh <- err
+	}()
+
+	select {
+	case <-provider.streamStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not start streaming")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rt.interruptMu.Lock()
+		active := rt.activeInterrupt
+		rt.interruptMu.Unlock()
+		if active != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("run did not publish interrupt state")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		rt.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after canceling active run")
+	}
+
+	select {
+	case err := <-runErrCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not exit after Close")
+	}
+}
+
 func TestServeRuntimeRetriesInitialSnapshotBeforeAppending(t *testing.T) {
 	store := newServeRuntimeTestStore()
 	store.replaceFailures[1] = errors.New("initial snapshot failed")


### PR DESCRIPTION
## What

- cancel any active runtime interrupt before waiting on `rt.mu` in `serveRuntime.Close()`
- keep the existing shutdown cleanup sequence unchanged after the active run has been canceled
- add a regression test that starts a blocking run and verifies `Close()` cancels it and returns promptly

## Why

`serveRuntime.run()` holds `rt.mu` for the full lifetime of a run. `Close()` previously tried to take that same mutex before canceling `activeInterrupt`, so shutdown could block behind the running session and never reach the cancellation path. For detached/background runs, that could hang teardown until the run timed out naturally. Canceling first lets the in-flight run exit and release the mutex so shutdown can complete promptly.
