### PR TITLE
fix: Telegram interjections are persisted twice, corrupting stored history

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -913,19 +913,8 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 			case llm.InterruptInterject:
 				sess.runtime.Engine.Interject(newMsgText)
 				_, _ = bot.Send(tgbotapi.NewMessage(chatID, "📝 Noted. I will incorporate that while I continue."))
-				if m.store != nil && sess.meta != nil {
-					text := newMsgText
-					m.runStoreOp(ctx, sess.meta.ID, "AddMessage(interjection)", func(storeCtx context.Context) error {
-						return m.store.AddMessage(storeCtx, sess.meta.ID, &session.Message{
-							SessionID:   sess.meta.ID,
-							Role:        llm.RoleUser,
-							Parts:       []llm.Part{{Type: llm.PartText, Text: text}},
-							TextContent: text,
-							CreatedAt:   time.Now(),
-							Sequence:    -1,
-						})
-					})
-				}
+				// Do not persist here: the engine persists the interjection exactly once
+				// when it drains it into the conversation via TurnCompletedCallback.
 				return
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
## What

Stop persisting Telegram interjections immediately in `handleMessage`.

When an interrupt is classified as an interjection, the message is now only queued into the engine and acknowledged to the user. Persistence is left to the existing `TurnCompletedCallback`, which already saves the interjection when the engine drains it into the conversation.

## Why

The Telegram path was writing the same interjection twice:

1. immediately in `handleMessage`, and
2. again when the engine later drained the interjection and the normal turn-completed persistence path ran.

That duplicated rows in the session store and made restored history diverge from in-memory history after reloads/restarts.
