### PR TITLE
fix: Chat completions handler reads shared runtime history without locking

### DIFF
--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -61,7 +61,7 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 		defer runtime.Close()
 	}
 
-	populateMissingToolResultNames(messages, runtime.history)
+	populateMissingToolResultNames(messages, runtime.snapshotHistory())
 
 	search := runtime.search
 	requestedTools := parseChatRequestedToolNames(req.Tools)


### PR DESCRIPTION
## What

Use `runtime.snapshotHistory()` in `handleChatCompletions` instead of reading `runtime.history` directly before `runtime.Run` acquires the session lock.

## Why

`runtime.history` is shared mutable state guarded by `rt.mu`. Reading it directly in the chat completions handler races with concurrent requests mutating session history, which can backfill tool result names from an inconsistent snapshot and can trigger undefined behavior. `snapshotHistory()` takes a lock-backed copy when the runtime is idle and safely skips the in-memory history when the session is already busy.
