### PR TITLE
fix: retry on claude API 'terminated' error

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -270,7 +270,8 @@ func isRetryable(err error) bool {
 		strings.Contains(errStr, "bad gateway") ||
 		strings.Contains(errStr, "503") ||
 		strings.Contains(errStr, "service unavailable") ||
-		strings.Contains(errStr, "overloaded") {
+		strings.Contains(errStr, "overloaded") ||
+		strings.Contains(errStr, "api error: terminated") {
 		return true
 	}
 

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -138,6 +138,24 @@ func TestIsRetryable_500InternalServerError(t *testing.T) {
 	}
 }
 
+func TestIsRetryable_APIErrorTerminated(t *testing.T) {
+	cases := []struct {
+		msg       string
+		retryable bool
+	}{
+		{"claude API error: API Error: terminated", true},
+		{"claude api error: api error: terminated", true},
+		{"API Error: terminated", true},
+		{"some other api error: bad request", false},
+	}
+	for _, tc := range cases {
+		got := isRetryable(errors.New(tc.msg))
+		if got != tc.retryable {
+			t.Errorf("isRetryable(%q) = %v, want %v", tc.msg, got, tc.retryable)
+		}
+	}
+}
+
 // toolThenErrorProvider emits a synchronous tool call then a retryable error.
 // The retry loop must NOT retry after the tool call has been committed.
 type toolThenErrorProvider struct {


### PR DESCRIPTION
## What

Adds `"api error: terminated"` to the `isRetryable()` function so that the `RetryProvider` automatically retries when the Claude CLI reports a terminated API connection.

## Why

The Claude CLI emits a `result` JSON message with `is_error: true` and `result: "API Error: terminated"` when the Anthropic API stream is terminated mid-request — a transient infrastructure event (server-side stream cut, network hiccup, etc.). `handleClaudeLine` in `claude_bin.go` surfaces this as `fmt.Errorf("claude API error: %s", resultMsg.Result)`.

Before this fix, `isRetryable()` did not recognise the substring `"api error: terminated"`, so `RetryProvider` treated it as a permanent failure and surfaced the error to the user immediately — with no retry. This caused live sessions (e.g. the daily digest job) to fail hard on what is actually a transient condition.

## How

- `internal/llm/retry.go`: added `strings.Contains(errStr, "api error: terminated")` to the retryable HTTP/service-error block.
- `internal/llm/retry_test.go`: added `TestIsRetryable_APIErrorTerminated` covering the exact error string produced in production as well as case-insensitive variants.
