### PR TITLE
fix: Anthropic endpoint unconditionally exposes all local server tools to remote clients

### DIFF
--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -74,21 +74,27 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 	}
 
 	search := runtime.search
+	requestedTools := parseAnthropicRequestedToolNames(req.Tools)
 	toolChoice := parseAnthropicToolChoice(req.ToolChoice)
 
-	// Merge server tools (engine can execute) with client tools (passthrough).
-	// Server tools win on name collision so the engine executes its own version.
-	// Client tools the engine doesn't recognise are forwarded to the LLM and
-	// returned as tool_use blocks for the client to handle.
+	// Merge requested server tools (engine can execute) with client tools
+	// (passthrough). Server tools win on name collision so the engine executes
+	// its own version. Client tools the engine doesn't recognise are forwarded
+	// to the LLM and returned as tool_use blocks for the client to handle.
 	//
 	// ToolMap targets (e.g. "search" when mapping "WebSearch" → "search") are
 	// excluded from the server list — the LLM will see the client's tool name
 	// and the engine redirects execution via ToolMap.
-	serverTools := runtime.selectTools(nil) // all registered server tools
+	serverTools := []llm.ToolSpec(nil)
+	if len(requestedTools) > 0 {
+		serverTools = runtime.selectTools(requestedTools)
+	}
 	mappedTargets := make(map[string]bool)
 	if runtime.toolMap != nil {
-		for _, target := range runtime.toolMap {
-			mappedTargets[target] = true
+		for name := range requestedTools {
+			if mapped, ok := runtime.toolMap[name]; ok {
+				mappedTargets[mapped] = true
+			}
 		}
 	}
 	serverNames := make(map[string]bool, len(serverTools))

--- a/cmd/serve_protocol_anthropic.go
+++ b/cmd/serve_protocol_anthropic.go
@@ -230,6 +230,18 @@ func anthropicToolsToSpecs(tools []anthropicToolDef) []llm.ToolSpec {
 	return specs
 }
 
+func parseAnthropicRequestedToolNames(tools []anthropicToolDef) map[string]bool {
+	requested := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		name := strings.TrimSpace(t.Name)
+		if name == "" {
+			continue
+		}
+		requested[name] = true
+	}
+	return requested
+}
+
 // parseAnthropicToolChoice parses Anthropic-format tool_choice into llm.ToolChoice.
 func parseAnthropicToolChoice(raw json.RawMessage) llm.ToolChoice {
 	if len(raw) == 0 {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -6318,6 +6318,102 @@ func TestHandleAnthropicMessages_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestHandleAnthropicMessages_DoesNotExposeUnrequestedServerTools(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	registry := llm.NewToolRegistry()
+	registry.Register(&echoTool{})
+	engine := llm.NewEngine(provider, registry)
+
+	factory := func(_ context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	srv := &serveServer{sessionMgr: mgr}
+
+	body := `{
+		"model": "test",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hi"}],
+		"tools": [{
+			"name": "client_tool",
+			"description": "Client-defined passthrough tool",
+			"input_schema": {
+				"type": "object",
+				"properties": {
+					"query": {"type": "string"}
+				},
+				"required": ["query"]
+			}
+		}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleAnthropicMessages(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("expected 1 provider request, got %d", len(provider.Requests))
+	}
+	tools := provider.Requests[0].Tools
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 passthrough tool, got %d", len(tools))
+	}
+	if tools[0].Name != "client_tool" {
+		t.Fatalf("expected tool name client_tool, got %q", tools[0].Name)
+	}
+	if tools[0].Description != "Client-defined passthrough tool" {
+		t.Fatalf("unexpected tool description: %q", tools[0].Description)
+	}
+}
+
+func TestHandleAnthropicMessages_NoToolsDoesNotExposeServerTools(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	registry := llm.NewToolRegistry()
+	registry.Register(&echoTool{})
+	engine := llm.NewEngine(provider, registry)
+
+	factory := func(_ context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	srv := &serveServer{sessionMgr: mgr}
+
+	body := `{
+		"model": "test",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hi"}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleAnthropicMessages(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("expected 1 provider request, got %d", len(provider.Requests))
+	}
+	if got := len(provider.Requests[0].Tools); got != 0 {
+		t.Fatalf("expected 0 tools, got %d", got)
+	}
+}
+
 func TestHandleAnthropicMessages_StreamText(t *testing.T) {
 	srv := newTestServeServer("streamed text")
 	body := `{"model":"test","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"Hi"}]}`


### PR DESCRIPTION
## What

- stop the Anthropic `/v1/messages` handler from injecting all registered server tools into every request
- only include server-executed tools when the client explicitly names them in the Anthropic `tools` array
- add regression coverage to verify unrequested server tools are not exposed, including requests with no tools at all

## Why

The previous handler always called `runtime.selectTools(nil)`, which exposed every local server tool to remote Anthropic clients. That broke the privilege boundary between client-defined passthrough tools and host-local executable tools, and could let authenticated clients unexpectedly trigger local tool execution on the server.
