### PR TITLE
fix: “Fresh” Responses API conversations can silently reuse an old session runtime and provider

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1030,14 +1031,29 @@ func (s *serveServer) runtimeForProviderRequest(ctx context.Context, sessionID s
 	return rt, true, nil
 }
 
-// runtimeForFreshProviderRequest starts a fresh conversation for a non-default
-// provider, even when the caller reuses an existing session ID.
+// runtimeForFreshProviderRequest starts a fresh conversation, optionally using
+// a specific provider, even when the caller reuses an existing session ID.
 func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessionID string, providerName string) (*serveRuntime, bool, error) {
-	if s.runtimeFactory == nil {
-		return s.runtimeForRequest(ctx, sessionID)
+	defaultProvider := ""
+	if s.cfgRef != nil {
+		defaultProvider = strings.TrimSpace(s.cfgRef.DefaultProvider)
+	}
+	providerName = strings.TrimSpace(providerName)
+	desiredProvider := providerName
+	if desiredProvider == "" {
+		desiredProvider = defaultProvider
+	}
+	if s.runtimeFactory == nil && providerName != "" && providerName != defaultProvider {
+		desiredProvider = ""
+	}
+	create := s.sessionMgr.factory
+	if s.runtimeFactory != nil && providerName != "" && providerName != defaultProvider {
+		create = func(ctx context.Context) (*serveRuntime, error) {
+			return s.runtimeFactory(ctx, providerName, "")
+		}
 	}
 	if sessionID == "" {
-		rt, err := s.runtimeFactory(ctx, providerName, "")
+		rt, err := create(ctx)
 		if err != nil {
 			return nil, false, err
 		}
@@ -1045,19 +1061,21 @@ func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessio
 	}
 	rt, err := s.sessionMgr.ReplaceIdleWith(ctx, sessionID,
 		func(existing *serveRuntime) bool {
-			ep := runtimeProviderKey(existing)
-			return ep != "" && providerName != "" && ep != providerName
+			return true
 		},
-		func(ctx context.Context) (*serveRuntime, error) {
-			return s.runtimeFactory(ctx, providerName, "")
-		},
+		create,
 	)
 	if err != nil {
+		if errors.Is(err, errServeSessionBusy) {
+			if existing, ok := s.sessionMgr.Get(sessionID); ok {
+				return existing, true, nil
+			}
+		}
 		return nil, false, err
 	}
 	existingProvider := runtimeProviderKey(rt)
-	if existingProvider != "" && providerName != "" && existingProvider != providerName {
-		return nil, false, fmt.Errorf("session %q already uses provider %q (requested %q)", sessionID, existingProvider, providerName)
+	if existingProvider != "" && desiredProvider != "" && existingProvider != desiredProvider {
+		return nil, false, fmt.Errorf("session %q already uses provider %q (requested %q)", sessionID, existingProvider, desiredProvider)
 	}
 	return rt, true, nil
 }

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -86,17 +86,19 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 	defaultProvider := ""
 	if s.cfgRef != nil {
-		defaultProvider = s.cfgRef.DefaultProvider
+		defaultProvider = strings.TrimSpace(s.cfgRef.DefaultProvider)
 	}
 	var runtime *serveRuntime
 	var stateful bool
-	freshProviderRequest := req.PreviousResponseID == "" && reqProvider != "" && reqProvider != defaultProvider
+	freshConversation := req.PreviousResponseID == ""
+	freshProvider := reqProvider
+	if freshConversation && freshProvider == "" {
+		freshProvider = defaultProvider
+	}
 	if req.PreviousResponseID != "" {
 		runtime, stateful, err = s.runtimeForProviderRequest(ctx, sessionID, reqProvider)
-	} else if !freshProviderRequest {
-		runtime, stateful, err = s.runtimeForRequest(ctx, sessionID)
 	} else {
-		runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, reqProvider)
+		runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, freshProvider)
 	}
 	if err != nil {
 		if errors.Is(err, errServeSessionBusy) || errors.Is(err, errServeSessionLimitReached) {
@@ -106,7 +108,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}
-	if freshProviderRequest {
+	if freshConversation {
 		s.syncPersistedSessionRuntime(ctx, sessionID, runtime)
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3386,6 +3386,31 @@ func doResponsesWithHeader(t *testing.T, srv *serveServer, bodyJSON, sessionID s
 	return rr.Code, result
 }
 
+func responseOutputText(t *testing.T, resp map[string]any) string {
+	t.Helper()
+	output, ok := resp["output"].([]any)
+	if !ok || len(output) == 0 {
+		t.Fatalf("response output = %#v, want assistant message", resp["output"])
+	}
+	msg, ok := output[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first output item = %#v, want object", output[0])
+	}
+	content, ok := msg["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("message content = %#v, want output_text", msg["content"])
+	}
+	part, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first content part = %#v, want object", content[0])
+	}
+	text, _ := part["text"].(string)
+	if text == "" {
+		t.Fatalf("response text missing from %#v", part)
+	}
+	return text
+}
+
 // waitForServeCondition polls until fn returns true or timeout elapses.
 func waitForServeCondition(t *testing.T, timeout time.Duration, fn func() bool, description string) {
 	t.Helper()
@@ -4069,6 +4094,105 @@ func TestHandleResponses_FreshProviderRequestCanReuseSessionID(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_FreshDefaultProviderRequestReplacesExistingRuntime(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	var defaultCreates atomic.Int32
+	var otherCreates atomic.Int32
+
+	newRuntime := func(providerName string, createNum int32) *serveRuntime {
+		provider := llm.NewMockProvider(providerName)
+		provider.AddTextResponse(fmt.Sprintf("%s runtime %d response 1", providerName, createNum))
+		provider.AddTextResponse(fmt.Sprintf("%s runtime %d response 2", providerName, createNum))
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  providerName,
+			engine:       engine,
+			defaultModel: providerName + "-model",
+			store:        store,
+		}
+		rt.Touch()
+		return rt
+	}
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		createNum := defaultCreates.Add(1)
+		return newRuntime("default", createNum), nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfgRef:     &config.Config{DefaultProvider: "default"},
+		sessionMgr: manager,
+		store:      store,
+		runtimeFactory: func(ctx context.Context, providerName string, model string) (*serveRuntime, error) {
+			if providerName == "" || providerName == "default" {
+				t.Fatalf("unexpected runtimeFactory call for default provider %q", providerName)
+			}
+			createNum := otherCreates.Add(1)
+			return newRuntime(providerName, createNum), nil
+		},
+	}
+
+	code, resp := doResponsesWithHeader(t, srv, `{"input":"hello","provider":"other"}`, "provider-default-reuse")
+	if code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", code)
+	}
+	if got := responseOutputText(t, resp); got != "other runtime 1 response 1" {
+		t.Fatalf("first response text = %q, want %q", got, "other runtime 1 response 1")
+	}
+
+	code, resp = doResponsesWithHeader(t, srv, `{"input":"fresh"}`, "provider-default-reuse")
+	if code != http.StatusOK {
+		t.Fatalf("fresh default request status = %d, want 200", code)
+	}
+	if got := responseOutputText(t, resp); got != "default runtime 1 response 1" {
+		t.Fatalf("fresh default response text = %q, want %q", got, "default runtime 1 response 1")
+	}
+
+	sess, err := store.Get(context.Background(), "provider-default-reuse")
+	if err != nil {
+		t.Fatalf("Get session after implicit default: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected persisted session after implicit default request")
+	}
+	if sess.ProviderKey != "default" {
+		t.Fatalf("ProviderKey after implicit default = %q, want default", sess.ProviderKey)
+	}
+
+	code, resp = doResponsesWithHeader(t, srv, `{"input":"fresh again","provider":"default"}`, "provider-default-reuse")
+	if code != http.StatusOK {
+		t.Fatalf("fresh explicit default request status = %d, want 200", code)
+	}
+	if got := responseOutputText(t, resp); got != "default runtime 2 response 1" {
+		t.Fatalf("fresh explicit default response text = %q, want %q", got, "default runtime 2 response 1")
+	}
+
+	sess, err = store.Get(context.Background(), "provider-default-reuse")
+	if err != nil {
+		t.Fatalf("Get session after explicit default: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected persisted session after explicit default request")
+	}
+	if sess.ProviderKey != "default" {
+		t.Fatalf("ProviderKey after explicit default = %q, want default", sess.ProviderKey)
+	}
+	if got := defaultCreates.Load(); got != 2 {
+		t.Fatalf("default provider factory calls = %d, want 2", got)
+	}
+	if got := otherCreates.Load(); got != 1 {
+		t.Fatalf("other provider factory calls = %d, want 1", got)
+	}
+}
+
 func TestFreshProviderRequest_ConcurrentReplace(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
@@ -4165,7 +4289,6 @@ func TestFreshProviderRequest_ConcurrentReplace(t *testing.T) {
 }
 
 func TestHandleResponses_NoPreviousResponseIDStartsFresh(t *testing.T) {
-	// Each runtime gets 2 responses so it can handle being reused
 	srv := newTestServeServer("reply1", "reply2")
 	defer srv.sessionMgr.Close()
 
@@ -4175,42 +4298,44 @@ func TestHandleResponses_NoPreviousResponseIDStartsFresh(t *testing.T) {
 		t.Fatalf("msg1 status = %d, want 200", code1)
 	}
 	respID1, _ := resp1["id"].(string)
+	if got := responseOutputText(t, resp1); got != "reply1" {
+		t.Fatalf("first response text = %q, want %q", got, "reply1")
+	}
 
 	// Second request with same session_id header but no previous_response_id.
-	// Should start fresh (replaceHistory=true), clearing prior conversation.
+	// Should start a fresh conversation with a fresh runtime.
 	code2, resp2 := doResponsesWithHeader(t, srv, `{"input":"msg2"}`, "same-session")
 	if code2 != http.StatusOK {
 		t.Fatalf("msg2 status = %d, want 200; without previous_response_id should start fresh", code2)
 	}
 
-	// Both should succeed and have different response IDs
+	// Both should succeed and have different response IDs.
 	respID2, _ := resp2["id"].(string)
 	if respID1 == respID2 {
 		t.Fatalf("response IDs should differ, both are %q", respID1)
 	}
+	if got := responseOutputText(t, resp2); got != "reply1" {
+		t.Fatalf("second response text = %q, want %q from a fresh runtime", got, "reply1")
+	}
 
-	// Verify that the runtime's history was reset: the second request should
-	// NOT have seen the first request's messages. We check the mock provider's
-	// recorded requests — the second request should have only the system prompt
-	// (if any) + the new user message, not the accumulated history.
+	// Verify that the current runtime only saw the fresh request.
 	rt, err := srv.sessionMgr.GetOrCreate(context.Background(), "same-session")
 	if err != nil {
 		t.Fatalf("GetOrCreate: %v", err)
 	}
 	provider := rt.provider.(*llm.MockProvider)
-	if len(provider.Requests) < 2 {
-		t.Fatalf("expected 2 provider requests, got %d", len(provider.Requests))
+	if len(provider.Requests) != 1 {
+		t.Fatalf("expected 1 provider request on the fresh runtime, got %d", len(provider.Requests))
 	}
-	secondReq := provider.Requests[1]
-	// Count user messages in the second request — should be exactly 1 (fresh start)
+	freshReq := provider.Requests[0]
 	userMsgCount := 0
-	for _, msg := range secondReq.Messages {
+	for _, msg := range freshReq.Messages {
 		if msg.Role == llm.RoleUser {
 			userMsgCount++
 		}
 	}
 	if userMsgCount != 1 {
-		t.Fatalf("second request has %d user messages, want 1 (fresh start)", userMsgCount)
+		t.Fatalf("fresh request has %d user messages, want 1", userMsgCount)
 	}
 }
 


### PR DESCRIPTION
## What

- make fresh `/v1/responses` requests always replace the existing in-memory runtime for that `session_id`, even when no provider is specified or the caller explicitly requests the default provider
- keep chained requests (`previous_response_id`) using the existing session/provider continuity rules
- add regression coverage for fresh default-provider requests and for fresh requests creating a new runtime instead of reusing the old one

## Why

Supplying `session_id` without `previous_response_id` is documented as starting a fresh conversation, but the handler could still reuse an existing runtime via `runtimeForRequest(sessionID)`. That let fresh conversations inherit provider selection, tool/approval state, and other session-local runtime settings from an older conversation. It also meant an explicit default-provider request could continue on a previously non-default runtime.
