### PR TITLE
fix(serve): allow nested file and image routes

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -129,6 +130,74 @@ func (s *serveServer) renderIndexHTML() []byte {
 	return serveui.RenderIndexHTML(s.cfg.basePath, headSnippet)
 }
 
+func (s *serveServer) imageOutputDir() string {
+	if s != nil && s.cfgRef != nil {
+		if outputDir := image.ExpandPath(s.cfgRef.Image.OutputDir); outputDir != "" {
+			return outputDir
+		}
+	}
+	return image.ExpandPath("~/Pictures/term-llm")
+}
+
+func resolveServeRequestPath(baseDir, requestPath, routePrefix string) (string, error) {
+	requested := strings.TrimPrefix(requestPath, routePrefix)
+	requested = strings.TrimPrefix(requested, "/")
+	if requested == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	for _, segment := range strings.Split(requested, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", fmt.Errorf("invalid path segment")
+		}
+	}
+
+	cleaned := path.Clean("/" + requested)
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	if cleaned == "" || cleaned == "." {
+		return "", fmt.Errorf("empty path")
+	}
+
+	absDir, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("eval base dir: %w", err)
+	}
+
+	filePath := filepath.Join(absDir, filepath.FromSlash(cleaned))
+	absFile, err := filepath.EvalSymlinks(filePath)
+	if err != nil {
+		return "", fmt.Errorf("eval file: %w", err)
+	}
+	if absFile != absDir && !strings.HasPrefix(absFile, absDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes base dir")
+	}
+
+	return absFile, nil
+}
+
+func serveRoutePath(baseRoute, baseDir, servedPath string) string {
+	absDir, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		absDir, err = filepath.Abs(baseDir)
+		if err != nil {
+			return baseRoute + filepath.Base(servedPath)
+		}
+	}
+	absServed, err := filepath.EvalSymlinks(servedPath)
+	if err != nil {
+		absServed, err = filepath.Abs(servedPath)
+		if err != nil {
+			return baseRoute + filepath.Base(servedPath)
+		}
+	}
+
+	relPath, err := filepath.Rel(absDir, absServed)
+	if err != nil || relPath == "." || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return baseRoute + filepath.Base(servedPath)
+	}
+
+	return baseRoute + filepath.ToSlash(relPath)
+}
+
 func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set("Allow", "GET, HEAD")
@@ -136,30 +205,10 @@ func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// basePath is already stripped by http.StripPrefix; URL.Path is "/images/filename".
-	filename := strings.TrimPrefix(r.URL.Path, "/images/")
-	if filename == "" || strings.Contains(filename, "/") || strings.Contains(filename, "..") {
-		http.NotFound(w, r)
-		return
-	}
+	outputDir := s.imageOutputDir()
 
-	outputDir := image.ExpandPath(s.cfgRef.Image.OutputDir)
-	if outputDir == "" {
-		outputDir = image.ExpandPath("~/Pictures/term-llm")
-	}
-
-	filePath := filepath.Join(outputDir, filename)
-	absDir, err := filepath.EvalSymlinks(outputDir)
+	absFile, err := resolveServeRequestPath(outputDir, r.URL.Path, "/images/")
 	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	absFile, err := filepath.EvalSymlinks(filePath)
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	if !strings.HasPrefix(absFile, absDir+string(filepath.Separator)) {
 		http.NotFound(w, r)
 		return
 	}
@@ -176,28 +225,14 @@ func (s *serveServer) handleFile(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
-	filename := strings.TrimPrefix(r.URL.Path, "/files/")
-	if filename == "" || strings.Contains(filename, "/") || strings.Contains(filename, "..") {
-		http.NotFound(w, r)
-		return
-	}
 	filesDir := s.cfg.filesDir
 	if filesDir == "" {
 		http.NotFound(w, r)
 		return
 	}
-	absDir, err := filepath.EvalSymlinks(filesDir)
+
+	absFile, err := resolveServeRequestPath(filesDir, r.URL.Path, "/files/")
 	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	filePath := filepath.Join(absDir, filename)
-	absFile, err := filepath.EvalSymlinks(filePath)
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	if !strings.HasPrefix(absFile, absDir+string(filepath.Separator)) {
 		http.NotFound(w, r)
 		return
 	}
@@ -272,10 +307,7 @@ func (s *serveServer) ensureFileServeable(filePath string) (string, bool) {
 // serveable path and true on success, or ("", false) if the image could not
 // be made serveable.
 func (s *serveServer) ensureImageServeable(imgPath string) (string, bool) {
-	outputDir := image.ExpandPath(s.cfgRef.Image.OutputDir)
-	if outputDir == "" {
-		outputDir = image.ExpandPath("~/Pictures/term-llm")
-	}
+	outputDir := s.imageOutputDir()
 
 	absDir, err := filepath.Abs(outputDir)
 	if err != nil {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -869,11 +868,11 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 			for _, imgPath := range ev.ToolImages {
 				if s.cfg.filesDir != "" {
 					if served, ok := s.ensureFileServeable(imgPath); ok {
-						imageURLs = append(imageURLs, s.cfg.filesRoute()+filepath.Base(served))
+						imageURLs = append(imageURLs, serveRoutePath(s.cfg.filesRoute(), s.cfg.filesDir, served))
 					}
 				} else {
 					if served, ok := s.ensureImageServeable(imgPath); ok {
-						imageURLs = append(imageURLs, s.cfg.imagesRoute()+filepath.Base(served))
+						imageURLs = append(imageURLs, serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served))
 					}
 				}
 			}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2356,6 +2356,12 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "cat.png"), []byte("fake-png"), 0644); err != nil {
 		t.Fatalf("write test image: %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(dir, "benchmarks", "go"), 0755); err != nil {
+		t.Fatalf("mkdir nested image dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "benchmarks", "go", "board.png"), []byte("nested-png"), 0644); err != nil {
+		t.Fatalf("write nested image: %v", err)
+	}
 
 	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui"}, cfgRef: &config.Config{}}
 	srv.cfgRef.Image.OutputDir = dir
@@ -2376,6 +2382,17 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	}
 	if vary := rr.Header().Get("Vary"); vary == "" {
 		t.Fatalf("missing Vary header")
+	}
+
+	// Nested file
+	req = httptest.NewRequest(http.MethodGet, "/images/benchmarks/go/board.png", nil)
+	rr = httptest.NewRecorder()
+	srv.handleImage(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("nested file: status = %d, want 200", rr.Code)
+	}
+	if got := rr.Body.String(); got != "nested-png" {
+		t.Fatalf("nested body = %q, want %q", got, "nested-png")
 	}
 
 	// Path traversal with ..
@@ -2472,6 +2489,12 @@ func TestHandleFile_ServesFileAndRejectsTraversal(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "video.mp4"), []byte("fake-video"), 0644); err != nil {
 		t.Fatalf("write test file: %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(dir, "qwen36-go-benchmark"), 0755); err != nil {
+		t.Fatalf("mkdir nested file dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "qwen36-go-benchmark", "board.html"), []byte("<html>nested-board</html>"), 0644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
 
 	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui", filesDir: dir}}
 
@@ -2487,6 +2510,17 @@ func TestHandleFile_ServesFileAndRejectsTraversal(t *testing.T) {
 	}
 	if cc := rr.Header().Get("Cache-Control"); !strings.Contains(cc, "private") {
 		t.Fatalf("Cache-Control = %q, want 'private'", cc)
+	}
+
+	// Nested file
+	req = httptest.NewRequest(http.MethodGet, "/files/qwen36-go-benchmark/board.html", nil)
+	rr = httptest.NewRecorder()
+	srv.handleFile(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("nested file: status = %d, want 200", rr.Code)
+	}
+	if got := rr.Body.String(); got != "<html>nested-board</html>" {
+		t.Fatalf("nested body = %q, want %q", got, "<html>nested-board</html>")
 	}
 
 	// Path traversal
@@ -2512,6 +2546,23 @@ func TestHandleFile_ServesFileAndRejectsTraversal(t *testing.T) {
 	srv2.handleFile(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("no files-dir: status = %d, want 404", rr.Code)
+	}
+}
+
+func TestServeRoutePath_PreservesNestedRelativePaths(t *testing.T) {
+	baseDir := t.TempDir()
+	servedPath := filepath.Join(baseDir, "qwen36-go-benchmark", "board.html")
+	if err := os.MkdirAll(filepath.Dir(servedPath), 0755); err != nil {
+		t.Fatalf("mkdir served path dir: %v", err)
+	}
+	if err := os.WriteFile(servedPath, []byte("ok"), 0644); err != nil {
+		t.Fatalf("write served path file: %v", err)
+	}
+
+	got := serveRoutePath("/chat/files/", baseDir, servedPath)
+	want := "/chat/files/qwen36-go-benchmark/board.html"
+	if got != want {
+		t.Fatalf("serveRoutePath() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

- allow `/chat/files/...` and `/chat/images/...` to serve nested paths under the configured files and image directories
- keep traversal protection by rejecting empty, `.` and `..` path segments and verifying the resolved target stays inside the configured base directory
- preserve nested relative paths when emitting web URLs for tool-generated images/files instead of flattening everything to `filepath.Base(...)`
- add coverage for nested file/image serving and nested route generation

## Why

The web UI currently rejects any file or image URL containing `/`, so valid nested paths like `/chat/files/qwen36-go-benchmark/board.html` 404 even when the file exists under `/root/Files`. That forces callers to flatten filenames, which is annoying and unnecessary.

This keeps the security boundary the same while making the route actually match the on-disk directory structure.

## Verification

- `gofmt -w cmd/serve_handlers.go cmd/serve_response_runs.go cmd/serve_test.go`
- `go build ./...`
- `go test ./...`
