### PR TITLE
fix: retry without tools when Ollama model doesn't support tool calls

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -416,7 +416,25 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, string(body))
+		errBody := string(body)
+		// Some Ollama models don't support tool calls. Retry without tools so
+		// the model can still produce a plain-text response.
+		if resp.StatusCode == 400 && strings.Contains(errBody, "does not support tools") && len(tools) > 0 {
+			chatReq.Tools = nil
+			chatReq.ToolChoice = nil
+			chatReq.ParallelToolCalls = nil
+			resp, err = p.makeChatRequest(ctx, chatReq)
+			if err != nil {
+				return nil, fmt.Errorf("%s API request failed: %w", p.name, err)
+			}
+			if resp.StatusCode != 200 {
+				body, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, string(body))
+			}
+		} else {
+			return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, errBody)
+		}
 	}
 
 	// Only create async stream for successful HTTP responses


### PR DESCRIPTION
## What

When an Ollama model doesn't support tool calls, the API returns a `400` error:

```
{"error":{"message":"registry.ollama.ai/library/qwen36-q4:latest does not support tools","type":"invalid_request_error"}}
```

This caused the session to fail immediately and repeatedly (8 identical failures in the debug session).

The fix detects this specific error in `OpenAICompatProvider.Stream()` and retries the request without tools, allowing the model to respond as a plain-text model instead of crashing.

## Why

Not all Ollama models support the OpenAI tool-calling extension. The `OpenAICompatProvider` assumed universal tool support and had no fallback. This meant any session using a tool-less Ollama model would fail on every turn.

## How

In `internal/llm/openai_compat.go`, after receiving a `400` response, check if the error body contains `"does not support tools"`. If so, clear `Tools`, `ToolChoice`, and `ParallelToolCalls` from the request and retry. Any subsequent `400` on the retry is propagated as a normal error.
