### PR TITLE
fix: populate model in debug log from provider name when req.Model is unset

### DIFF
--- a/internal/llm/debug_logger.go
+++ b/internal/llm/debug_logger.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -184,6 +185,17 @@ func (l *DebugLogger) LogRequest(provider, model string, req Request) {
 	if logModel == "" {
 		logModel = model
 	}
+	if logModel == "" {
+		if s := strings.Index(provider, "("); s >= 0 {
+			if e := strings.LastIndex(provider, ")"); e > s {
+				m := strings.TrimSpace(provider[s+1 : e])
+				if ci := strings.Index(m, ","); ci >= 0 {
+					m = strings.TrimSpace(m[:ci])
+				}
+				logModel = m
+			}
+		}
+	}
 	replayParts, encryptedParts := countReasoningReplayParts(req.Messages)
 
 	entry := debugRequestEntry{
@@ -240,6 +252,17 @@ func (l *DebugLogger) LogTurnRequest(turn int, provider, model string, req Reque
 	logModel := req.Model
 	if logModel == "" {
 		logModel = model
+	}
+	if logModel == "" {
+		if s := strings.Index(provider, "("); s >= 0 {
+			if e := strings.LastIndex(provider, ")"); e > s {
+				m := strings.TrimSpace(provider[s+1 : e])
+				if ci := strings.Index(m, ","); ci >= 0 {
+					m = strings.TrimSpace(m[:ci])
+				}
+				logModel = m
+			}
+		}
 	}
 	replayParts, encryptedParts := countReasoningReplayParts(req.Messages)
 


### PR DESCRIPTION
## What

When an OpenAI-compatible provider (e.g. Ollama, LM Studio) is configured with a default model and no per-request model override is set, `LogRequest` and `LogTurnRequest` in `debug_logger.go` recorded an empty `model` field in the debug log. This caused the exported Markdown report to show a blank **Model:** line.

## Why

`engine.go` calls `e.debugLogger.LogRequest(e.provider.Name(), req.Model, req)`, passing `req.Model` as *both* the primary model and the fallback model argument. When using the provider's configured default (`req.Model == ""`), the fallback is also empty, so `logModel` stays `""`.

The fix adds a third fallback: if `logModel` is still empty after the `req.Model`/`model` checks, extract the model from the provider display name. All providers format their name as `"DisplayName (model)"` or `"DisplayName (model, effort=X)"`, so a simple index-based parse recovers the model string (e.g. `"Ollama (gemma4:26b)"` → `"gemma4:26b"`).

## Changes

- `internal/llm/debug_logger.go`: added `"strings"` import; added provider-name extraction fallback in both `LogRequest` and `LogTurnRequest`.

No callers, structs, or log formats changed.
