### PR TITLE
fix: Resetting a Responses conversation can be undone by a late stream completion

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 const maxResponsesAPIErrorBodyBytes = 64 * 1024
@@ -33,6 +34,9 @@ type ResponsesClient struct {
 	// If it returns nil (success), the request is retried with fresh credentials.
 	// If it returns an error, that error is returned to the caller.
 	OnAuthRetry func(ctx context.Context) error
+
+	responseStateMu         sync.Mutex
+	responseStateGeneration uint64
 }
 
 // ResponsesRequest follows the Open Responses spec
@@ -428,13 +432,38 @@ func readResponsesAPIErrorBody(resp *http.Response) []byte {
 	return truncated
 }
 
+func (c *ResponsesClient) responseState() (lastResponseID string, generation uint64) {
+	c.responseStateMu.Lock()
+	defer c.responseStateMu.Unlock()
+	return c.LastResponseID, c.responseStateGeneration
+}
+
+func (c *ResponsesClient) clearLastResponseIDIfGeneration(generation uint64) {
+	c.responseStateMu.Lock()
+	defer c.responseStateMu.Unlock()
+	if c.responseStateGeneration != generation {
+		return
+	}
+	c.LastResponseID = ""
+}
+
+func (c *ResponsesClient) setLastResponseIDIfGeneration(generation uint64, responseID string) {
+	c.responseStateMu.Lock()
+	defer c.responseStateMu.Unlock()
+	if c.responseStateGeneration != generation {
+		return
+	}
+	c.LastResponseID = responseID
+}
+
 // Stream makes a streaming request to the Responses API and returns events via a Stream
 func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debugRaw bool) (Stream, error) {
 	fullInput := req.Input
+	lastResponseID, responseStateGeneration := c.responseState()
 
 	// Use server state: send previous_response_id if we have one (unless disabled)
-	if !c.DisableServerState && c.LastResponseID != "" {
-		req.PreviousResponseID = c.LastResponseID
+	if !c.DisableServerState && lastResponseID != "" {
+		req.PreviousResponseID = lastResponseID
 		// When continuing a conversation, only send the new input items for this turn.
 		req.Input = filterToNewInput(req.Input)
 	}
@@ -509,9 +538,9 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		}
 
 		// Check for previous_response_id not found error
-		if resp.StatusCode == http.StatusNotFound && c.LastResponseID != "" {
+		if resp.StatusCode == http.StatusNotFound && lastResponseID != "" {
 			// Clear state and retry with full history
-			c.LastResponseID = ""
+			c.clearLastResponseIDIfGeneration(responseStateGeneration)
 			req.PreviousResponseID = ""
 			req.Input = fullInput
 			// Re-marshal without previous_response_id
@@ -728,7 +757,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 				if err := json.Unmarshal([]byte(data), &completedEvent); err == nil {
 					// Store response ID for conversation continuity (unless disabled)
 					if !client.DisableServerState && completedEvent.Response.ID != "" {
-						client.LastResponseID = completedEvent.Response.ID
+						client.setLastResponseIDIfGeneration(responseStateGeneration, completedEvent.Response.ID)
 					}
 					if completedEvent.Response.Usage != nil {
 						cached := completedEvent.Response.Usage.InputTokensDetails.CachedTokens
@@ -778,6 +807,9 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 
 // ResetConversation clears server state (called on /clear or new conversation)
 func (c *ResponsesClient) ResetConversation() {
+	c.responseStateMu.Lock()
+	defer c.responseStateMu.Unlock()
+	c.responseStateGeneration++
 	c.LastResponseID = ""
 }
 

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -1147,6 +1147,115 @@ func TestResponsesClientStream_AllowsLargeSSEDataLines(t *testing.T) {
 	t.Fatal("expected EventDone")
 }
 
+func TestResponsesClientResetConversationIgnoresLateStreamCompletion(t *testing.T) {
+	type capturedRequest struct {
+		PreviousResponseID string `json:"previous_response_id"`
+	}
+
+	allowCompletion := make(chan struct{})
+	callCount := 0
+	requests := make([]capturedRequest, 0, 2)
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			callCount++
+			defer r.Body.Close()
+
+			var payload capturedRequest
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read request body: %w", err)
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return nil, fmt.Errorf("failed to decode request body: %w", err)
+			}
+			requests = append(requests, payload)
+
+			if callCount == 1 {
+				pr, pw := io.Pipe()
+				go func() {
+					defer pw.Close()
+					_, _ = io.WriteString(pw,
+						"event: response.output_text.delta\n"+
+							"data: {\"delta\":\"hello\"}\n\n",
+					)
+					<-allowCompletion
+					_, _ = io.WriteString(pw,
+						"event: response.completed\n"+
+							"data: {\"response\":{\"id\":\"resp_old\"}}\n\n"+
+							"data: [DONE]\n\n",
+					)
+				}()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+					Body:       pr,
+				}, nil
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+
+	event, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("stream recv failed: %v", err)
+	}
+	if event.Type != EventTextDelta || event.Text != "hello" {
+		t.Fatalf("expected initial text delta, got %+v", event)
+	}
+
+	client.ResetConversation()
+	close(allowCompletion)
+	drainStreamToDone(t, stream)
+
+	if client.LastResponseID != "" {
+		t.Fatalf("expected ResetConversation to keep LastResponseID cleared, got %q", client.LastResponseID)
+	}
+
+	nextStream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "new conversation"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("second stream creation failed: %v", err)
+	}
+	defer nextStream.Close()
+	drainStreamToDone(t, nextStream)
+
+	if callCount != 2 {
+		t.Fatalf("expected 2 HTTP calls, got %d", callCount)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 captured requests, got %d", len(requests))
+	}
+	if requests[1].PreviousResponseID != "" {
+		t.Fatalf("expected new conversation request to omit previous_response_id, got %q", requests[1].PreviousResponseID)
+	}
+}
+
 func assertResponsesAPIErrorBodyTruncated(t *testing.T, err error, prefix string) {
 	t.Helper()
 


### PR DESCRIPTION
## What

Add generation-guarded synchronization around `ResponsesClient.LastResponseID` so `ResetConversation` cannot be undone by a late `response.completed` event from an older stream.

Also add a regression test that resets the conversation mid-stream and verifies the next request does not send a stale `previous_response_id`.

## Why

Without this, clearing or starting a new conversation while an older Responses API stream is still finishing can restore the old response ID after the reset. The next request then chains onto the wrong server-side conversation and corrupts conversation state across threads.
