### PR TITLE
fix: Stale previous_response_id is accepted after runtime eviction, branching the wrong conversation

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -824,6 +824,7 @@ type serveServer struct {
 	modelsMu          sync.Mutex
 	modelsProviders   map[string]llm.Provider // keyed by provider name
 	responseToSession sync.Map                // response_id (string) → session_id (string)
+	sessionToResponse sync.Map                // session_id (string) → latest response_id (string)
 	responseRunsOnce  sync.Once
 	responseRuns      *responseRunManager
 	webrtcHeadSnippet string // injected into index.html <head>; empty when WebRTC disabled

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -978,6 +978,9 @@ func sseKeepalive(w http.ResponseWriter, flusher http.Flusher, interval time.Dur
 func (s *serveServer) registerResponseID(rt *serveRuntime, respID, sessionID string) {
 	pruned := rt.addResponseID(respID)
 	s.responseToSession.Store(respID, sessionID)
+	if sessionID != "" {
+		s.sessionToResponse.Store(sessionID, respID)
+	}
 	for _, old := range pruned {
 		s.responseToSession.Delete(old)
 	}

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -109,6 +109,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if freshConversation {
+		s.sessionToResponse.Delete(sessionID)
 		s.syncPersistedSessionRuntime(ctx, sessionID, runtime)
 	}
 
@@ -118,6 +119,13 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	// expects from that response).
 	if req.PreviousResponseID != "" {
 		lastRespID := runtime.getLastResponseID()
+		if lastRespID == "" {
+			if latest, ok := s.sessionToResponse.Load(sessionID); ok {
+				if latestStr, ok := latest.(string); ok {
+					lastRespID = strings.TrimSpace(latestStr)
+				}
+			}
+		}
 		if lastRespID != "" && req.PreviousResponseID != lastRespID {
 			writeOpenAIError(w, http.StatusConflict, "conflict_error",
 				fmt.Sprintf("previous_response_id %q is stale; latest is %q", req.PreviousResponseID, lastRespID))

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3785,6 +3785,43 @@ func TestHandleResponses_StalePreviousResponseIDReturnsConflict(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_StalePreviousResponseIDReturnsConflictAfterRuntimeRecreation(t *testing.T) {
+	srv := newTestServeServer("reply1", "reply2", "reply3")
+	defer srv.sessionMgr.Close()
+
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"msg1"}`, "stale-recreate")
+	if code != http.StatusOK {
+		t.Fatalf("msg1 status = %d, want 200", code)
+	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
+
+	code, resp2 := doResponses(t, srv, `{"input":"msg2","previous_response_id":"`+respID1+`"}`)
+	if code != http.StatusOK {
+		t.Fatalf("msg2 status = %d, want 200", code)
+	}
+	respID2, _ := resp2["id"].(string)
+	if respID2 == "" {
+		t.Fatal("second response missing id")
+	}
+
+	// Simulate runtime recreation without cleaning the server-wide response map.
+	srv.sessionMgr.mu.Lock()
+	evicted := srv.sessionMgr.sessions["stale-recreate"]
+	delete(srv.sessionMgr.sessions, "stale-recreate")
+	srv.sessionMgr.mu.Unlock()
+	if evicted != nil {
+		evicted.Close()
+	}
+
+	code, _ = doResponses(t, srv, `{"input":"msg3","previous_response_id":"`+respID1+`"}`)
+	if code != http.StatusConflict {
+		t.Fatalf("stale previous_response_id after recreation status = %d, want 409", code)
+	}
+}
+
 func TestHandleResponses_PreviousResponseIDChainsSession(t *testing.T) {
 	// Each runtime gets 2 text responses so it can handle 2 messages
 	srv := newTestServeServer("first reply", "second reply")


### PR DESCRIPTION
## What

- track the latest response ID per session outside the runtime so chaining validation survives runtime recreation
- use that server-wide latest response ID as a fallback when a recreated runtime has no in-memory lastResponseID yet
- clear the cached latest response ID when starting a fresh conversation and add a regression test covering stale previous_response_id after runtime recreation

## Why

The stale-chain guard only worked when the live runtime still had lastResponseID in memory. After a runtime was evicted and recreated, older previous_response_id values could still resolve through responseToSession but would skip the stale check, causing the request to run against the wrong conversation state. Persisting the latest response ID at the server level preserves the latest-only chaining check across runtime recreation and prevents silent conversation branching.
