### PR TITLE
fix: Persisted serve sessions omit the effective system prompt

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -581,7 +581,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	}()
 
 	messages := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+1)
-	if rt.systemPrompt != "" && !containsSystemMessage(baseHistory) && !containsSystemMessage(inputMessages) {
+	systemPromptInjected := rt.systemPrompt != "" && !containsSystemMessage(baseHistory) && !containsSystemMessage(inputMessages)
+	if systemPromptInjected {
 		messages = append(messages, llm.SystemText(rt.systemPrompt))
 	}
 	messages = append(messages, baseHistory...)
@@ -602,7 +603,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		}
 	}
 	buildSnapshotLocked := func() []llm.Message {
-		snapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+len(produced))
+		snapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+len(produced)+1)
+		if systemPromptInjected {
+			snapshot = append(snapshot, llm.SystemText(rt.systemPrompt))
+		}
 		snapshot = append(snapshot, baseHistory...)
 		snapshot = append(snapshot, inputMessages...)
 		snapshot = append(snapshot, produced...)
@@ -637,7 +641,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			// On the first callback, persist the full base snapshot so
 			// incremental AddMessage calls have the correct starting state.
 			if !initialPersisted {
-				initialSnapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages))
+				initialSnapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+1)
+				if systemPromptInjected {
+					initialSnapshot = append(initialSnapshot, llm.SystemText(rt.systemPrompt))
+				}
 				initialSnapshot = append(initialSnapshot, baseHistory...)
 				initialSnapshot = append(initialSnapshot, inputMessages...)
 				initialPersisted = rt.persistSnapshot(persistCtx, req.SessionID, initialSnapshot)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3249,6 +3249,48 @@ func TestHandleSessionMessages_OmitsSystemAndDeveloperMessages(t *testing.T) {
 	}
 }
 
+func TestRun_PersistsInjectedSystemPromptInHistoryAndStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("hi there")
+	rt := &serveRuntime{
+		store:        store,
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		defaultModel: "mock-model",
+		systemPrompt: "server system prompt",
+	}
+
+	ctx := context.Background()
+	_, err = rt.Run(ctx, true, false, []llm.Message{llm.UserText("hello")}, llm.Request{SessionID: "persist-system"})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if len(rt.history) != 3 {
+		t.Fatalf("history len = %d, want 3", len(rt.history))
+	}
+	if rt.history[0].Role != llm.RoleSystem || rt.history[0].Parts[0].Text != "server system prompt" {
+		t.Fatalf("history[0] = %+v, want injected system prompt", rt.history[0])
+	}
+
+	msgs, err := store.GetMessages(ctx, "persist-system", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("stored message count = %d, want 3", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleSystem || msgs[0].TextContent != "server system prompt" {
+		t.Fatalf("stored first message = %+v, want injected system prompt", msgs[0])
+	}
+}
+
 func TestEnsurePersistedSession_RestoresHistory(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

Persist the effective serve runtime system prompt whenever it is injected into a run.

This updates the runtime snapshot builders so the injected system message is included in in-memory history, the initial persisted snapshot, and the final persisted session snapshot. It also adds a regression test covering persisted serve sessions.

## Why

Serve runs already prepend `rt.systemPrompt` to the request when history and input do not contain a system message, but persisted session snapshots previously omitted that injected message. After eviction, restart, export, or later prompt/config changes, the restored session could continue under different instructions than the ones that originally governed the conversation.
