### PR TITLE
fix: Partial streamed assistant output is lost on agentic-loop stream errors

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -841,6 +841,73 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 		var finishingToolExecuted bool // Track if a finishing tool was executed (agent done)
 		var syncToolCalls []ToolCall   // Track sync tool calls for message building
 		var syncToolResults []Message  // Track sync tool results for message building
+		persistPartialAssistant := func() {
+			hasTextOrReasoning := textBuilder.Len() > 0 || reasoningBuilder.Len() > 0 || reasoningItemID != "" || reasoningEncryptedContent != ""
+			if !hasTextOrReasoning && len(toolCalls) == 0 && len(syncToolCalls) == 0 {
+				return
+			}
+
+			if len(toolCalls) == 0 {
+				if syncToolsExecuted {
+					assistantMsg := buildAssistantMessageWithReasoningMetadata(
+						textBuilder.String(),
+						e.withToolPreview(syncToolCalls),
+						reasoningBuilder.String(),
+						reasoningItemID,
+						reasoningEncryptedContent,
+					)
+					if turnCallback != nil {
+						turnMetrics.ToolCalls = len(syncToolCalls)
+						turnMessages := []Message{assistantMsg}
+						turnMessages = append(turnMessages, syncToolResults...)
+						cbCtx, cancel := callbackContext(ctx)
+						_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
+						cancel()
+					}
+					return
+				}
+				if turnCallback != nil && hasTextOrReasoning {
+					finalMsg := Message{
+						Role: RoleAssistant,
+						Parts: []Part{{
+							Type:                      PartText,
+							Text:                      textBuilder.String(),
+							ReasoningContent:          reasoningBuilder.String(),
+							ReasoningItemID:           reasoningItemID,
+							ReasoningEncryptedContent: reasoningEncryptedContent,
+						}},
+					}
+					cbCtx, cancel := callbackContext(ctx)
+					_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
+					cancel()
+				}
+				return
+			}
+
+			partialToolCalls := ensureToolCallIDs(toolCalls)
+			partialToolCalls = dedupeToolCalls(partialToolCalls)
+			assistantMsg := buildAssistantMessageWithReasoningMetadata(
+				textBuilder.String(),
+				e.withToolPreview(partialToolCalls),
+				reasoningBuilder.String(),
+				reasoningItemID,
+				reasoningEncryptedContent,
+			)
+			if len(assistantMsg.Parts) == 0 {
+				return
+			}
+			if responseCallback != nil {
+				cbCtx, cancel := callbackContext(ctx)
+				_ = responseCallback(cbCtx, attempt, assistantMsg, turnMetrics)
+				cancel()
+				return
+			}
+			if turnCallback != nil {
+				cbCtx, cancel := callbackContext(ctx)
+				_ = turnCallback(cbCtx, attempt, []Message{assistantMsg}, turnMetrics)
+				cancel()
+			}
+		}
 		for {
 			event, err := stream.Recv()
 			if err == io.EOF {
@@ -848,10 +915,12 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 			}
 			if err != nil {
 				stream.Close()
+				persistPartialAssistant()
 				return err
 			}
 			if event.Type == EventError && event.Err != nil {
 				stream.Close()
+				persistPartialAssistant()
 				return event.Err
 			}
 			if req.DebugRaw {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -30,6 +30,30 @@ func (s *sliceStream) Close() error {
 	return nil
 }
 
+type errAfterEventsStream struct {
+	events []Event
+	err    error
+	index  int
+}
+
+func (s *errAfterEventsStream) Recv() (Event, error) {
+	if s.index < len(s.events) {
+		event := s.events[s.index]
+		s.index++
+		return event, nil
+	}
+	if s.err != nil {
+		err := s.err
+		s.err = nil
+		return Event{}, err
+	}
+	return Event{}, io.EOF
+}
+
+func (s *errAfterEventsStream) Close() error {
+	return nil
+}
+
 type concurrentCloseStream struct {
 	mu          sync.Mutex
 	calls       int
@@ -1224,6 +1248,150 @@ func TestEnginePersistsToolInfoInAssistantMessage(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected assistant tool call with persisted tool info in next request")
+	}
+}
+
+func TestRunLoopPersistsPartialAssistantMessageOnStreamRecvError(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &streamProvider{
+		stream: &errAfterEventsStream{
+			events: []Event{{Type: EventTextDelta, Text: "partial"}},
+			err:    errors.New("stream recv failed"),
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+
+	var (
+		callbackCount int
+		persisted     []Message
+	)
+	engine.SetTurnCompletedCallback(func(ctx context.Context, turnIndex int, messages []Message, metrics TurnMetrics) error {
+		callbackCount++
+		persisted = append([]Message(nil), messages...)
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+		Tools:    []ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	var streamErr error
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+		if event.Type == EventError && event.Err != nil {
+			streamErr = event.Err
+			break
+		}
+	}
+
+	if streamErr == nil || !strings.Contains(streamErr.Error(), "stream recv failed") {
+		t.Fatalf("expected stream error to contain recv failure, got %v", streamErr)
+	}
+	if callbackCount != 1 {
+		t.Fatalf("turn callback count = %d, want 1", callbackCount)
+	}
+	if len(persisted) != 1 || persisted[0].Role != RoleAssistant {
+		t.Fatalf("persisted messages = %#v, want single assistant message", persisted)
+	}
+	if len(persisted[0].Parts) != 1 || persisted[0].Parts[0].Type != PartText {
+		t.Fatalf("persisted parts = %#v, want single text part", persisted[0].Parts)
+	}
+	if persisted[0].Parts[0].Text != "partial" {
+		t.Fatalf("persisted text = %q, want %q", persisted[0].Parts[0].Text, "partial")
+	}
+}
+
+func TestRunLoopPersistsPartialAssistantMessageOnEventErrorAfterToolCall(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			return []Event{
+				{Type: EventTextDelta, Text: "partial"},
+				{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "count_tool", Arguments: json.RawMessage(`{}`)}},
+				{Type: EventError, Err: errors.New("provider stream failed")},
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+
+	var (
+		responseCount int
+		turnCount     int
+		persisted     Message
+	)
+	engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg Message, metrics TurnMetrics) error {
+		responseCount++
+		persisted = assistantMsg
+		return nil
+	})
+	engine.SetTurnCompletedCallback(func(ctx context.Context, turnIndex int, messages []Message, metrics TurnMetrics) error {
+		turnCount++
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+		Tools:    []ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	var streamErr error
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+		if event.Type == EventError && event.Err != nil {
+			streamErr = event.Err
+			break
+		}
+	}
+
+	if streamErr == nil || !strings.Contains(streamErr.Error(), "provider stream failed") {
+		t.Fatalf("expected stream error to contain provider failure, got %v", streamErr)
+	}
+	if responseCount != 1 {
+		t.Fatalf("response callback count = %d, want 1", responseCount)
+	}
+	if turnCount != 0 {
+		t.Fatalf("turn callback count = %d, want 0", turnCount)
+	}
+	if len(persisted.Parts) != 2 {
+		t.Fatalf("persisted part count = %d, want 2", len(persisted.Parts))
+	}
+	if persisted.Parts[0].Type != PartText || persisted.Parts[0].Text != "partial" {
+		t.Fatalf("persisted text part = %#v, want partial text", persisted.Parts[0])
+	}
+	if persisted.Parts[1].Type != PartToolCall || persisted.Parts[1].ToolCall == nil {
+		t.Fatalf("persisted tool part = %#v, want tool call", persisted.Parts[1])
+	}
+	if persisted.Parts[1].ToolCall.ID != "call-1" {
+		t.Fatalf("persisted tool call ID = %q, want %q", persisted.Parts[1].ToolCall.ID, "call-1")
 	}
 }
 


### PR DESCRIPTION
## What

Persist partial assistant output from the agentic loop before returning stream errors.

This adds a small error-path callback in `internal/llm/engine.go` so already-streamed assistant text/reasoning is saved when `stream.Recv()` fails or when the provider emits an `EventError` mid-turn. If tool calls were already collected, the partial assistant message is sent through the response callback; otherwise it goes through the turn callback, matching existing persistence behavior as closely as possible.

Also adds regression coverage for both a raw `Recv` error and an `EventError` after partial output.

## Why

Today users can see partial assistant output in the UI, but if the agentic stream errors before normal turn completion that partial message is never persisted. That makes resumes, reconnects, and stored transcripts diverge from what was actually shown.
