### PR TITLE
fix(web): preserve selected provider/model on save

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1461,18 +1461,19 @@ const connectToken = async () => {
   const token = elements.authTokenInput.value.trim();
   const nextShowHiddenSessions = Boolean(elements.showHiddenSessionsInput?.checked);
 
-  // Save provider and model selection regardless of token
-  const newProvider = elements.providerSelect.value;
-  state.selectedProvider = newProvider;
-  if (newProvider) {
-    localStorage.setItem(STORAGE_KEYS.selectedProvider, newProvider);
+  // Provider/model selections are committed live via the change handlers.
+  // Re-reading the modal DOM here can clobber a valid in-memory choice if the
+  // selects are temporarily stale (for example while startup/model refresh work
+  // is still settling). Persist the current state instead.
+  const persistedProvider = state.selectedProvider;
+  if (persistedProvider) {
+    localStorage.setItem(STORAGE_KEYS.selectedProvider, persistedProvider);
   } else {
     localStorage.removeItem(STORAGE_KEYS.selectedProvider);
   }
-  const newModel = elements.modelSelect.value;
-  state.selectedModel = newModel;
-  if (newModel) {
-    localStorage.setItem(STORAGE_KEYS.selectedModel, newModel);
+  const persistedModel = state.selectedModel;
+  if (persistedModel) {
+    localStorage.setItem(STORAGE_KEYS.selectedModel, persistedModel);
   } else {
     localStorage.removeItem(STORAGE_KEYS.selectedModel);
   }

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -97,6 +97,19 @@ function createHarness(options = {}) {
     addEventListener() {},
   };
 
+  const storage = new Map();
+  const localStorage = {
+    getItem(key) {
+      return storage.has(key) ? storage.get(key) : null;
+    },
+    setItem(key, value) {
+      storage.set(String(key), String(value));
+    },
+    removeItem(key) {
+      storage.delete(String(key));
+    },
+  };
+
   const elements = {
     promptInput: {
       value: '',
@@ -121,6 +134,33 @@ function createHarness(options = {}) {
       removeAttribute() {},
       setAttribute() {},
     },
+    modelSelect: {
+      value: '',
+      innerHTML: '',
+      appendChild() {},
+      addEventListener() {},
+      removeAttribute() {},
+      setAttribute() {},
+    },
+    effortSelect: {
+      value: '',
+      addEventListener() {},
+      removeAttribute() {},
+      setAttribute() {},
+    },
+    authTokenInput: {
+      value: '',
+      focus() {},
+      removeAttribute() {},
+      setAttribute() {},
+    },
+    authModal: {
+      classList: makeClassList(),
+    },
+    authError: { textContent: '' },
+    authCancelBtn: { style: {}, removeAttribute() {}, setAttribute() {} },
+    authConnectBtn: { disabled: false, textContent: 'Save' },
+    showHiddenSessionsInput: { checked: false, removeAttribute() {}, setAttribute() {} },
     voiceBtn: null,
     voiceStatus: null,
     askUserModal: makeNode(),
@@ -134,6 +174,7 @@ function createHarness(options = {}) {
   const state = {
     token: '',
     connected: true,
+    authRequired: false,
     streaming: false,
     streamGeneration: 0,
     attachments: [],
@@ -151,6 +192,8 @@ function createHarness(options = {}) {
     approval: null,
     selectedModel: '',
     selectedProvider: '',
+    selectedEffort: '',
+    showHiddenSessions: false,
     providers: [],
     lastEventTime: 0,
     expectCanceledRun: false,
@@ -158,7 +201,13 @@ function createHarness(options = {}) {
 
   const app = {
     UI_PREFIX: '/ui',
-    STORAGE_KEYS: {},
+    STORAGE_KEYS: {
+      selectedProvider: 'selectedProvider',
+      selectedModel: 'selectedModel',
+      selectedEffort: 'selectedEffort',
+      showHiddenSessions: 'showHiddenSessions',
+      token: 'token',
+    },
     state,
     elements,
     __busyTransitions: [],
@@ -259,6 +308,7 @@ function createHarness(options = {}) {
     window: windowObj,
     document,
     console,
+    localStorage,
     setTimeout,
     clearTimeout,
     setInterval,
@@ -282,8 +332,13 @@ function createHarness(options = {}) {
   };
   context.globalThis = context;
   windowObj.document = document;
+  windowObj.localStorage = localStorage;
   windowObj.fetch = async function fetch(url, options = {}) {
-    fetchCalls.push({ url, method: options.method || 'GET' });
+    fetchCalls.push({
+      url,
+      method: options.method || 'GET',
+      body: typeof options.body === 'string' ? options.body : null,
+    });
     if (url === '/ui/v1/responses') {
       return new Response(new ReadableStream({
         start(controller) {
@@ -334,6 +389,7 @@ function createHarness(options = {}) {
     elements,
     state,
     fetchCalls,
+    localStorage,
     getEventsStarted: () => getEventsStarted,
     postStreamCanceled: () => postStreamCanceled,
     closeEventsStream: () => {
@@ -655,12 +711,76 @@ async function testDrainInterruptQueueAfterResumeCompletes() {
   pass(name);
 }
 
+async function testConnectTokenPreservesSelectedModelAndProviderFromState() {
+  const name = 'connectToken preserves in-memory provider/model selection when modal DOM is stale';
+  const harness = createHarness();
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+
+  state.token = 'token-123';
+  state.connected = true;
+  state.selectedProvider = 'venice';
+  state.selectedModel = 'claude-opus-4';
+  elements.authTokenInput.value = 'token-123';
+
+  // Simulate a stale modal DOM (for example, before async model loading has
+  // caught up). The live state already reflects the user's real choice.
+  elements.providerSelect.value = '';
+  elements.modelSelect.value = 'claude-sonnet-4-6';
+
+  await app.connectToken();
+
+  if (state.selectedProvider !== 'venice') {
+    fail(name, `selectedProvider = ${JSON.stringify(state.selectedProvider)}, want "venice"`);
+    await cleanup();
+    return;
+  }
+  if (state.selectedModel !== 'claude-opus-4') {
+    fail(name, `selectedModel = ${JSON.stringify(state.selectedModel)}, want "claude-opus-4"`);
+    await cleanup();
+    return;
+  }
+
+  elements.promptInput.value = 'hello';
+  await app.sendMessage();
+
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (!postCall || !postCall.body) {
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    await cleanup();
+    return;
+  }
+
+  let body;
+  try {
+    body = JSON.parse(postCall.body);
+  } catch (err) {
+    fail(name, 'response POST body was not valid JSON', String(err));
+    await cleanup();
+    return;
+  }
+
+  if (body.provider !== 'venice') {
+    fail(name, `request provider = ${JSON.stringify(body.provider)}, want "venice"`, postCall.body);
+    await cleanup();
+    return;
+  }
+  if (body.model !== 'claude-opus-4') {
+    fail(name, `request model = ${JSON.stringify(body.model)}, want "claude-opus-4"`, postCall.body);
+    await cleanup();
+    return;
+  }
+
+  await cleanup();
+  pass(name);
+}
+
 (async () => {
   await testSendMessageHandsOffToEventsStream();
   await testSendMessageIgnoresPostBodyAfterHandoff();
   await testNewChatDuringStreamingClearsStreamingState();
   await testSendMessageMarksSessionBusyImmediately();
   await testDrainInterruptQueueAfterResumeCompletes();
+  await testConnectTokenPreservesSelectedModelAndProviderFromState();
 
   if (failures > 0) {
     console.error(`\n${failures} test(s) failed`);


### PR DESCRIPTION
## What

Fix the web settings modal so saving does not re-read provider/model from the modal DOM.

Provider/model selections are already committed live via the select change handlers. On save we were reading `providerSelect.value` / `modelSelect.value` again and writing them back into state. If those selects were temporarily stale (for example while startup/model-refresh work was still catching up), the save path could clobber the in-memory choice and the next first-turn web request would go out with the provider default model instead of the user's selected one.

This change persists the current in-memory selection instead of re-reading the modal DOM.

## Tests

- add a web UI regression test covering a stale modal DOM with a valid in-memory `venice` / `claude-opus-4` selection
- verify `connectToken()` preserves the chosen provider/model
- verify the next `sendMessage()` POST sends the preserved provider/model in `/v1/responses`
- run `node internal/serveui/static/app_stream_test.js`
- run `go build ./...`
- run `go test ./...`
