### PR TITLE
web: lock provider/model/reasoning_effort to first-message values

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1112,12 +1112,17 @@ func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessio
 	return rt, true, nil
 }
 
-func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID string, rt *serveRuntime) {
+// syncPersistedSessionRuntime pins the provider, model, and reasoning_effort
+// on the session row for the first message of a web session. Fields already
+// set on the row are never overwritten; once saved on first message, these
+// values are locked for the remainder of the session. Later requests must use
+// the locked values — cross-provider or cross-model swaps mid-session corrupt
+// saved state (tool call shapes, response chaining, reasoning trace), and
+// handover is a future feature. If the row does not yet exist, it is created
+// here so the client-supplied model and effort are persisted (rather than the
+// runtime defaults that rt would otherwise use when Run creates the row).
+func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID string, rt *serveRuntime, clientModel, reasoningEffort string) {
 	if s.store == nil || sessionID == "" || rt == nil {
-		return
-	}
-	sess, err := s.store.Get(ctx, sessionID)
-	if err != nil || sess == nil {
 		return
 	}
 	providerKey := strings.TrimSpace(rt.providerKey)
@@ -1127,18 +1132,71 @@ func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID
 			providerName = name
 		}
 	}
-	modelName := strings.TrimSpace(rt.defaultModel)
+	// Prefer the client-requested model: the client's first-message choice is
+	// what gets locked. Fall back to the runtime's default only when the
+	// client didn't send one.
+	modelName := strings.TrimSpace(clientModel)
+	if modelName == "" {
+		modelName = strings.TrimSpace(rt.defaultModel)
+	}
+	effort := strings.TrimSpace(reasoningEffort)
+
+	sess, err := s.store.Get(ctx, sessionID)
+	if err != nil {
+		return
+	}
+	if sess == nil {
+		sess = &session.Session{
+			ID:          sessionID,
+			Provider:    providerName,
+			ProviderKey: providerKey,
+			Model:       modelName,
+			Mode:        session.ModeChat,
+			Origin:      session.OriginWeb,
+			Agent:       rt.agentName,
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+			Search:      rt.search,
+			Tools:       rt.toolsSetting,
+			MCP:         rt.mcpSetting,
+			Status:      session.StatusActive,
+		}
+		if effort != "" {
+			sess.ReasoningEffort = effort
+		}
+		if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+			sess.CWD = cwd
+		}
+		if createErr := s.store.Create(ctx, sess); createErr != nil {
+			if existing, getErr := s.store.Get(ctx, sessionID); getErr == nil && existing != nil {
+				sess = existing
+			} else {
+				log.Printf("[serve] session Create failed for %s: %v", sessionID, createErr)
+				return
+			}
+		} else {
+			rt.mu.Lock()
+			rt.sessionMeta = sess
+			rt.mu.Unlock()
+			return
+		}
+	}
+
 	changed := false
-	if providerName != "" && sess.Provider != providerName {
+	if providerName != "" && strings.TrimSpace(sess.Provider) == "" {
 		sess.Provider = providerName
 		changed = true
 	}
-	if providerKey != "" && sess.ProviderKey != providerKey {
+	if providerKey != "" && strings.TrimSpace(sess.ProviderKey) == "" {
 		sess.ProviderKey = providerKey
 		changed = true
 	}
-	if modelName != "" && sess.Model != modelName {
+	if modelName != "" && strings.TrimSpace(sess.Model) == "" {
 		sess.Model = modelName
+		changed = true
+	}
+	if effort != "" && strings.TrimSpace(sess.ReasoningEffort) == "" {
+		sess.ReasoningEffort = effort
 		changed = true
 	}
 	if !changed {

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -72,15 +72,28 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("x-session-id", sessionID)
 		replaceHistory = true
 	}
-	// Use requested provider for new sessions only. For chained requests,
-	// recover the persisted session provider so runtime recreation preserves
-	// the original provider/model continuity after eviction.
+	// Lock provider/model/reasoning_effort to whatever was persisted on the
+	// session row: these fields are only honored from the client on the first
+	// message of a session. Once the row exists with a provider, every later
+	// request for that session uses the saved values, regardless of what the
+	// client sent. Cross-provider or cross-model swaps mid-session corrupt
+	// saved state (tool result shapes, response chaining, reasoning) — the
+	// silent override prevents that. Handover is a future feature.
 	reqProvider := strings.TrimSpace(req.Provider)
-	if req.PreviousResponseID != "" && reqProvider == "" && s.store != nil {
+	if s.store != nil {
 		if sess, getErr := s.store.Get(ctx, sessionID); getErr == nil && sess != nil {
-			reqProvider = strings.TrimSpace(sess.ProviderKey)
-			if reqProvider == "" {
-				reqProvider = resolveSessionProviderKey(s.cfgRef, sess)
+			persistedProvider := strings.TrimSpace(sess.ProviderKey)
+			if persistedProvider == "" {
+				persistedProvider = resolveSessionProviderKey(s.cfgRef, sess)
+			}
+			if persistedProvider != "" {
+				reqProvider = persistedProvider
+				if m := strings.TrimSpace(sess.Model); m != "" {
+					req.Model = m
+				}
+				if e := strings.TrimSpace(sess.ReasoningEffort); e != "" {
+					req.ReasoningEffort = e
+				}
 			}
 		}
 	}
@@ -109,7 +122,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if freshConversation {
-		s.syncPersistedSessionRuntime(ctx, sessionID, runtime)
+		s.syncPersistedSessionRuntime(ctx, sessionID, runtime, strings.TrimSpace(req.Model), normalizeReasoningEffort(req.ReasoningEffort))
 	}
 
 	// Enforce chaining from the latest response only. Stale response IDs that

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4056,7 +4056,12 @@ func TestHandleResponses_PreviousResponseIDRestoresPersistedProviderAfterRuntime
 	}
 }
 
-func TestHandleResponses_FreshProviderRequestCanReuseSessionID(t *testing.T) {
+// After the first message of a web session pins provider=default, a later
+// request on the same session ID that asks for provider=other must be
+// silently overridden back to the persisted provider. Cross-provider swaps
+// mid-session corrupt saved state; the client's provider field is only
+// honored on the very first message.
+func TestHandleResponses_ProviderLockedAfterFirstMessage(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -4107,24 +4112,8 @@ func TestHandleResponses_FreshProviderRequestCanReuseSessionID(t *testing.T) {
 		t.Fatalf("fresh provider request status = %d, want 200", code)
 	}
 
-	output, ok := resp["output"].([]any)
-	if !ok || len(output) == 0 {
-		t.Fatalf("response output = %#v, want assistant message", resp["output"])
-	}
-	msg, ok := output[0].(map[string]any)
-	if !ok {
-		t.Fatalf("first output item = %#v, want object", output[0])
-	}
-	content, ok := msg["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatalf("message content = %#v, want output_text", msg["content"])
-	}
-	part, ok := content[0].(map[string]any)
-	if !ok {
-		t.Fatalf("first content part = %#v, want object", content[0])
-	}
-	if got := part["text"]; got != "other response 1" {
-		t.Fatalf("response text = %v, want %q", got, "other response 1")
+	if got := responseOutputText(t, resp); got != "default response 2" {
+		t.Fatalf("response text = %q, want %q (provider override should be silently locked to default)", got, "default response 2")
 	}
 
 	sess, err := store.Get(context.Background(), "provider-reuse")
@@ -4134,18 +4123,22 @@ func TestHandleResponses_FreshProviderRequestCanReuseSessionID(t *testing.T) {
 	if sess == nil {
 		t.Fatal("expected persisted session")
 	}
-	if sess.ProviderKey != "other" {
-		t.Fatalf("ProviderKey = %q, want other", sess.ProviderKey)
+	if sess.ProviderKey != "default" {
+		t.Fatalf("ProviderKey = %q, want default (locked from first message)", sess.ProviderKey)
 	}
-	if got := defaultCreates.Load(); got != 1 {
-		t.Fatalf("default provider factory calls = %d, want 1", got)
+	if got := defaultCreates.Load(); got != 2 {
+		t.Fatalf("default provider factory calls = %d, want 2", got)
 	}
-	if got := otherCreates.Load(); got != 1 {
-		t.Fatalf("other provider factory calls = %d, want 1", got)
+	if got := otherCreates.Load(); got != 0 {
+		t.Fatalf("other provider factory calls = %d, want 0 (client provider must be ignored)", got)
 	}
 }
 
-func TestHandleResponses_FreshDefaultProviderRequestReplacesExistingRuntime(t *testing.T) {
+// After the first message of a web session pins provider=other, a later
+// request on the same session ID that omits provider (defaulting client-side
+// to "default") must be silently overridden back to the persisted provider,
+// rather than creating a runtime with the server default.
+func TestHandleResponses_ImplicitDefaultLockedToPersistedProvider(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -4203,8 +4196,8 @@ func TestHandleResponses_FreshDefaultProviderRequestReplacesExistingRuntime(t *t
 	if code != http.StatusOK {
 		t.Fatalf("fresh default request status = %d, want 200", code)
 	}
-	if got := responseOutputText(t, resp); got != "default runtime 1 response 1" {
-		t.Fatalf("fresh default response text = %q, want %q", got, "default runtime 1 response 1")
+	if got := responseOutputText(t, resp); got != "other runtime 2 response 1" {
+		t.Fatalf("fresh default response text = %q, want %q (should stay locked to other)", got, "other runtime 2 response 1")
 	}
 
 	sess, err := store.Get(context.Background(), "provider-default-reuse")
@@ -4214,16 +4207,19 @@ func TestHandleResponses_FreshDefaultProviderRequestReplacesExistingRuntime(t *t
 	if sess == nil {
 		t.Fatal("expected persisted session after implicit default request")
 	}
-	if sess.ProviderKey != "default" {
-		t.Fatalf("ProviderKey after implicit default = %q, want default", sess.ProviderKey)
+	if sess.ProviderKey != "other" {
+		t.Fatalf("ProviderKey after implicit default = %q, want other (locked from first message)", sess.ProviderKey)
+	}
+	if got := defaultCreates.Load(); got != 0 {
+		t.Fatalf("default provider factory calls = %d, want 0 (client default must be overridden)", got)
 	}
 
 	code, resp = doResponsesWithHeader(t, srv, `{"input":"fresh again","provider":"default"}`, "provider-default-reuse")
 	if code != http.StatusOK {
 		t.Fatalf("fresh explicit default request status = %d, want 200", code)
 	}
-	if got := responseOutputText(t, resp); got != "default runtime 2 response 1" {
-		t.Fatalf("fresh explicit default response text = %q, want %q", got, "default runtime 2 response 1")
+	if got := responseOutputText(t, resp); got != "other runtime 3 response 1" {
+		t.Fatalf("fresh explicit default response text = %q, want %q (should stay locked to other)", got, "other runtime 3 response 1")
 	}
 
 	sess, err = store.Get(context.Background(), "provider-default-reuse")
@@ -4233,14 +4229,14 @@ func TestHandleResponses_FreshDefaultProviderRequestReplacesExistingRuntime(t *t
 	if sess == nil {
 		t.Fatal("expected persisted session after explicit default request")
 	}
-	if sess.ProviderKey != "default" {
-		t.Fatalf("ProviderKey after explicit default = %q, want default", sess.ProviderKey)
+	if sess.ProviderKey != "other" {
+		t.Fatalf("ProviderKey after explicit default = %q, want other (locked from first message)", sess.ProviderKey)
 	}
-	if got := defaultCreates.Load(); got != 2 {
-		t.Fatalf("default provider factory calls = %d, want 2", got)
+	if got := defaultCreates.Load(); got != 0 {
+		t.Fatalf("default provider factory calls = %d, want 0 (client default must be overridden)", got)
 	}
-	if got := otherCreates.Load(); got != 1 {
-		t.Fatalf("other provider factory calls = %d, want 1", got)
+	if got := otherCreates.Load(); got != 3 {
+		t.Fatalf("other provider factory calls = %d, want 3", got)
 	}
 }
 
@@ -5542,6 +5538,84 @@ func TestResponsesHandler_ReasoningEffortFlowsToProvider(t *testing.T) {
 	}
 	if got := capturedProvider.Requests[0].ReasoningEffort; got != "high" {
 		t.Fatalf("ReasoningEffort = %q, want %q", got, "high")
+	}
+}
+
+// After the first message of a web session pins reasoning_effort=high and
+// model=first-model, later requests on the same session ID that send
+// different values must be silently overridden back to the persisted ones.
+// Mid-session switches of effort/model are disallowed — the first message
+// is the only place where client values are honored.
+func TestHandleResponses_ModelAndEffortLockedAfterFirstMessage(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	providers := make([]*llm.MockProvider, 0, 4)
+	newRuntime := func() *serveRuntime {
+		provider := llm.NewMockProvider("mock")
+		provider.AddTextResponse("r1").AddTextResponse("r2").AddTextResponse("r3")
+		providers = append(providers, provider)
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  "mock",
+			engine:       engine,
+			defaultModel: "mock-default-model",
+			store:        store,
+		}
+		rt.Touch()
+		return rt
+	}
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		return newRuntime(), nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfgRef:     &config.Config{DefaultProvider: "mock"},
+		sessionMgr: manager,
+		store:      store,
+	}
+
+	code, _ := doResponsesWithHeader(t, srv, `{"input":"hi","model":"first-model","reasoning_effort":"high"}`, "lock-effort")
+	if code != http.StatusOK {
+		t.Fatalf("first status = %d", code)
+	}
+
+	code, _ = doResponsesWithHeader(t, srv, `{"input":"again","model":"second-model","reasoning_effort":"low"}`, "lock-effort")
+	if code != http.StatusOK {
+		t.Fatalf("second status = %d", code)
+	}
+
+	if len(providers) == 0 {
+		t.Fatal("expected runtime factory to have been called")
+	}
+	last := providers[len(providers)-1]
+	if len(last.Requests) == 0 {
+		t.Fatal("expected a provider request on second call")
+	}
+	lastReq := last.Requests[len(last.Requests)-1]
+	if lastReq.Model != "first-model" {
+		t.Fatalf("Model on second request = %q, want first-model (locked)", lastReq.Model)
+	}
+	if lastReq.ReasoningEffort != "high" {
+		t.Fatalf("ReasoningEffort on second request = %q, want high (locked)", lastReq.ReasoningEffort)
+	}
+
+	sess, err := store.Get(context.Background(), "lock-effort")
+	if err != nil || sess == nil {
+		t.Fatalf("Get session: err=%v sess=%v", err, sess)
+	}
+	if sess.Model != "first-model" {
+		t.Fatalf("persisted Model = %q, want first-model", sess.Model)
+	}
+	if sess.ReasoningEffort != "high" {
+		t.Fatalf("persisted ReasoningEffort = %q, want high", sess.ReasoningEffort)
 	}
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -26,6 +26,7 @@ type SQLiteStore struct {
 	hasLastUserMessageAt bool // true if sessions table has last_user_message_at column
 	hasLastTotalTokens   bool // true if sessions table has last_total_tokens column
 	hasLastMessageCount  bool // true if sessions table has last_message_count column
+	hasReasoningEffort   bool // true if sessions table has reasoning_effort column
 }
 
 // Schema for the sessions database.
@@ -44,6 +45,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     provider TEXT NOT NULL,
     provider_key TEXT,
     model TEXT NOT NULL,
+    reasoning_effort TEXT,
     mode TEXT DEFAULT 'chat',
     origin TEXT DEFAULT 'tui',
     agent TEXT,
@@ -181,6 +183,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 	store.hasLastUserMessageAt = store.probeColumn("last_user_message_at")
 	store.hasLastTotalTokens = store.probeColumn("last_total_tokens")
 	store.hasLastMessageCount = store.probeColumn("last_message_count")
+	store.hasReasoningEffort = store.probeColumn("reasoning_effort")
 
 	// Run cleanup if configured (read-write mode only).
 	if !cfg.ReadOnly {
@@ -197,7 +200,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 18
+const schemaVersion = 19
 
 // migration represents a schema migration.
 type migration struct {
@@ -618,6 +621,20 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		// Migration 19: Persist reasoning effort on sessions so web sessions
+		// can lock provider/model/effort after the first message.
+		version:     19,
+		description: "add reasoning_effort column for locking web session config",
+		up: func(db *sql.DB) error {
+			if _, err := db.Exec("ALTER TABLE sessions ADD COLUMN reasoning_effort TEXT"); err != nil {
+				if !isDuplicateColumnError(err) {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 func rebuildMessagesTableForDeveloperRole(db *sql.DB) error {
@@ -821,18 +838,30 @@ func (s *SQLiteStore) Create(ctx context.Context, sess *Session) error {
 		// Use a single INSERT statement with a subquery to atomically assign the
 		// next session number. This avoids race conditions where two concurrent
 		// Creates could read the same MAX(number).
-		result, err := s.db.ExecContext(ctx, `
-			INSERT INTO sessions (id, number, name, summary, generated_short_title, generated_long_title, title_source, title_generated_at, title_basis_msg_seq, title_skipped_at,
-			                      provider, provider_key, model, mode, origin, agent, cwd, created_at, updated_at, archived, pinned, parent_id, search, tools, mcp,
-			                      user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens, cache_write_tokens, output_tokens,
-			                      last_total_tokens, last_message_count, status, tags)
-			VALUES (?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		reasoningEffortCol := ""
+		reasoningEffortPlaceholder := ""
+		var reasoningEffortArgs []any
+		if s.hasReasoningEffort {
+			reasoningEffortCol = ", reasoning_effort"
+			reasoningEffortPlaceholder = ", ?"
+			reasoningEffortArgs = []any{nullString(sess.ReasoningEffort)}
+		}
+		insertArgs := []any{
 			sess.ID, sess.Name, sess.Summary, nullString(sess.GeneratedShortTitle), nullString(sess.GeneratedLongTitle), nullString(string(sess.TitleSource)), nullTime(sess.TitleGeneratedAt), sess.TitleBasisMsgSeq, nullTime(sess.TitleSkippedAt),
 			sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(string(sess.Origin)), nullString(sess.Agent), sess.CWD,
 			sess.CreatedAt, sess.UpdatedAt, sess.Archived, sess.Pinned, nullString(sess.ParentID),
 			sess.Search, nullString(sess.Tools), nullString(sess.MCP),
 			sess.UserTurns, sess.LLMTurns, sess.ToolCalls, sess.InputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.OutputTokens,
-			sess.LastTotalTokens, sess.LastMessageCount, string(sess.Status), nullString(sess.Tags))
+			sess.LastTotalTokens, sess.LastMessageCount, string(sess.Status), nullString(sess.Tags),
+		}
+		insertArgs = append(insertArgs, reasoningEffortArgs...)
+		result, err := s.db.ExecContext(ctx, `
+			INSERT INTO sessions (id, number, name, summary, generated_short_title, generated_long_title, title_source, title_generated_at, title_basis_msg_seq, title_skipped_at,
+			                      provider, provider_key, model, mode, origin, agent, cwd, created_at, updated_at, archived, pinned, parent_id, search, tools, mcp,
+			                      user_turns, llm_turns, tool_calls, input_tokens, cached_input_tokens, cache_write_tokens, output_tokens,
+			                      last_total_tokens, last_message_count, status, tags`+reasoningEffortCol+`)
+			VALUES (?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`+reasoningEffortPlaceholder+`)`,
+			insertArgs...)
 		if err != nil {
 			return fmt.Errorf("insert session: %w", err)
 		}
@@ -932,10 +961,14 @@ func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	if s.hasTitleSkippedAt {
 		titleSkippedAtClause = ", title_skipped_at = ?"
 	}
+	reasoningEffortClause := ""
+	if s.hasReasoningEffort {
+		reasoningEffortClause = ", reasoning_effort = ?"
+	}
 	query := `
 		UPDATE sessions SET name = ?, summary = ?, generated_short_title = ?, generated_long_title = ?, title_source = ?, title_generated_at = ?, title_basis_msg_seq = ?` +
 		titleSkippedAtClause + `,
-		       provider = ?, provider_key = ?, model = ?, mode = ?, origin = ?, agent = ?, cwd = ?,
+		       provider = ?, provider_key = ?, model = ?` + reasoningEffortClause + `, mode = ?, origin = ?, agent = ?, cwd = ?,
 		       updated_at = ?, archived = ?, pinned = ?, parent_id = ?, search = ?, tools = ?, mcp = ?,
 		       user_turns = ?, status = ?, tags = ?
 		WHERE id = ?`
@@ -947,7 +980,13 @@ func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 		args = append(args, nullTime(sess.TitleSkippedAt))
 	}
 	args = append(args,
-		sess.Provider, nullString(sess.ProviderKey), sess.Model, string(sess.Mode), nullString(string(sess.Origin)), nullString(sess.Agent), sess.CWD,
+		sess.Provider, nullString(sess.ProviderKey), sess.Model,
+	)
+	if s.hasReasoningEffort {
+		args = append(args, nullString(sess.ReasoningEffort))
+	}
+	args = append(args,
+		string(sess.Mode), nullString(string(sess.Origin)), nullString(sess.Agent), sess.CWD,
 		sess.UpdatedAt, sess.Archived, sess.Pinned, nullString(sess.ParentID),
 		sess.Search, nullString(sess.Tools), nullString(sess.MCP),
 		sess.UserTurns, string(sess.Status), nullString(sess.Tags), sess.ID,
@@ -1643,7 +1682,13 @@ func (s *SQLiteStore) sessionSelectCols() string {
 		}
 	}
 	base += `,
-	       provider, provider_key, model, mode`
+	       provider, provider_key, model`
+	if s.hasReasoningEffort {
+		base += ", reasoning_effort"
+	} else {
+		base += ", NULL AS reasoning_effort"
+	}
+	base += `, mode`
 	if s.hasOrigin {
 		base += ", origin"
 	} else {
@@ -1681,7 +1726,7 @@ func scanSessionRow(row *sql.Row, hasGeneratedTitles, hasCacheWriteTokens, hasCo
 	var name, summary, cwd sql.NullString
 	var generatedShortTitle, generatedLongTitle, titleSource sql.NullString
 	var titleGeneratedAt, titleSkippedAt sql.NullTime
-	var mode, origin, agent, parentID, tools, mcp, status, tags, providerKey sql.NullString
+	var mode, origin, agent, parentID, tools, mcp, status, tags, providerKey, reasoningEffort sql.NullString
 
 	var scanArgs []any
 	scanArgs = append(scanArgs, &sess.ID, &number, &name, &summary)
@@ -1692,7 +1737,7 @@ func scanSessionRow(row *sql.Row, hasGeneratedTitles, hasCacheWriteTokens, hasCo
 		}
 	}
 	scanArgs = append(scanArgs,
-		&sess.Provider, &providerKey, &sess.Model, &mode, &origin, &sess.Pinned,
+		&sess.Provider, &providerKey, &sess.Model, &reasoningEffort, &mode, &origin, &sess.Pinned,
 		&agent, &cwd, &sess.CreatedAt, &sess.UpdatedAt, &sess.Archived, &parentID,
 		&sess.Search, &tools, &mcp,
 		&sess.UserTurns, &sess.LLMTurns, &sess.ToolCalls, &sess.InputTokens, &sess.CachedInputTokens,
@@ -1763,6 +1808,9 @@ func scanSessionRow(row *sql.Row, hasGeneratedTitles, hasCacheWriteTokens, hasCo
 	}
 	if providerKey.Valid {
 		sess.ProviderKey = providerKey.String
+	}
+	if reasoningEffort.Valid {
+		sess.ReasoningEffort = reasoningEffort.String
 	}
 	if agent.Valid {
 		sess.Agent = agent.String

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -58,19 +58,20 @@ type Session struct {
 	TitleBasisMsgSeq    int                `json:"title_basis_msg_seq,omitempty"`
 	TitleSkippedAt      time.Time          `json:"title_skipped_at,omitempty"` // Set when autotitle considers session untitlable; cleared when session is updated
 
-	Provider    string        `json:"provider"`               // Provider display label
-	ProviderKey string        `json:"provider_key,omitempty"` // Canonical provider key (e.g. openai, chatgpt, custom alias)
-	Model       string        `json:"model"`
-	Mode        SessionMode   `json:"mode,omitempty"`   // Session mode (chat, ask, plan, exec)
-	Origin      SessionOrigin `json:"origin,omitempty"` // Session surface/origin (tui, web, telegram)
-	Agent       string        `json:"agent,omitempty"`  // Agent name used for this session
-	CWD         string        `json:"cwd,omitempty"`    // Working directory at session start
-	CreatedAt   time.Time     `json:"created_at"`
-	UpdatedAt   time.Time     `json:"updated_at"`
-	Archived    bool          `json:"archived,omitempty"`
-	Pinned      bool          `json:"pinned,omitempty"`
-	ParentID    string        `json:"parent_id,omitempty"`   // For session branching
-	IsSubagent  bool          `json:"is_subagent,omitempty"` // True if this is a subagent session
+	Provider        string        `json:"provider"`               // Provider display label
+	ProviderKey     string        `json:"provider_key,omitempty"` // Canonical provider key (e.g. openai, chatgpt, custom alias)
+	Model           string        `json:"model"`
+	ReasoningEffort string        `json:"reasoning_effort,omitempty"` // Reasoning effort pinned at session creation (web only)
+	Mode            SessionMode   `json:"mode,omitempty"`             // Session mode (chat, ask, plan, exec)
+	Origin          SessionOrigin `json:"origin,omitempty"`           // Session surface/origin (tui, web, telegram)
+	Agent           string        `json:"agent,omitempty"`            // Agent name used for this session
+	CWD             string        `json:"cwd,omitempty"`              // Working directory at session start
+	CreatedAt       time.Time     `json:"created_at"`
+	UpdatedAt       time.Time     `json:"updated_at"`
+	Archived        bool          `json:"archived,omitempty"`
+	Pinned          bool          `json:"pinned,omitempty"`
+	ParentID        string        `json:"parent_id,omitempty"`   // For session branching
+	IsSubagent      bool          `json:"is_subagent,omitempty"` // True if this is a subagent session
 
 	// Session settings (restored on resume unless overridden)
 	Search bool   `json:"search,omitempty"` // Web search enabled


### PR DESCRIPTION
Fixes session corruption where swapping provider/model/reasoning_effort on an existing web session clobbered saved state.

## The bug

`/v1/responses` accepts `provider`, `model`, and `reasoning_effort` on every request. When a client swaps any of these against a session that already has saved state, the session gets corrupted: tool result shapes, `previous_response_id` chaining, and reasoning traces all assume continuity with the original provider/model. Previously, `syncPersistedSessionRuntime` even silently overwrote the persisted Provider/ProviderKey/Model back to whatever the runtime happened to be using — so a second request with a different provider would flip the saved row.

## The fix

These three fields are now only honored from the client on the **first message** of a session. Once saved, they are locked; later requests get a silent server-side override back to the persisted values. Cross-provider handover is a future feature — no need to error, just honor the saved config.

- **Schema**: add `reasoning_effort TEXT` column (schema v19, migration 19). Provider and Model columns already existed.
- **`handleResponses`**: before runtime resolution, read the persisted session row; when it has a ProviderKey, silently override `reqProvider`, `req.Model`, and `req.ReasoningEffort` from the row.
- **`syncPersistedSessionRuntime`**: creates the session row if missing, using the **client's** first-message model and effort rather than `rt.defaultModel`. On existing rows, only fills empty fields — never overwrites — so locked values are never clobbered.

## Tests

- `TestHandleResponses_ProviderLockedAfterFirstMessage` — `provider=other` on second request is silently overridden back to locked default.
- `TestHandleResponses_ImplicitDefaultLockedToPersistedProvider` — a second request with no provider stays locked to the first-message provider; even an explicit `provider=default` is ignored.
- `TestHandleResponses_ModelAndEffortLockedAfterFirstMessage` — same contract for model and reasoning_effort.

Replaces two tests that documented the old "can switch provider on a reused session" behavior.

## Notes

- The TUI/chat/anthropic endpoints don't use this locking path — they use `runtimeForRequest` without a persisted-config check. Scope is explicitly web-only, per the intent of first-message locking.
- Handover is not yet supported; when it lands, the lock override in `handleResponses` will need an explicit bypass signal.