### PR TITLE
feat: return model/effort from session state; sync to frontend on session switch

### DIFF
--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -12,6 +12,8 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 		"active_run": false,
 	}
 
+	var persistedProvider, persistedModel, persistedEffort string
+
 	if s.sessionMgr != nil {
 		if rt, ok := s.sessionMgr.Get(sessionID); ok && rt != nil {
 			activeRun := rt.hasActiveRun()
@@ -25,15 +27,21 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 				resp["pending_approval"] = approvals[0]
 			}
 			if pk := strings.TrimSpace(rt.providerKey); pk != "" {
-				resp["provider"] = pk
+				persistedProvider = pk
 			} else if rt.provider != nil {
-				// Resolve display label to canonical key.
 				resolved := resolveSessionProviderKey(s.cfgRef, &session.Session{
 					Provider: strings.TrimSpace(rt.provider.Name()),
 				})
-				if resolved != "" {
-					resp["provider"] = resolved
-				}
+				persistedProvider = resolved
+			}
+			rt.mu.Lock()
+			if rt.sessionMeta != nil {
+				persistedModel = strings.TrimSpace(rt.sessionMeta.Model)
+				persistedEffort = strings.TrimSpace(rt.sessionMeta.ReasoningEffort)
+			}
+			rt.mu.Unlock()
+			if persistedModel == "" {
+				persistedModel = strings.TrimSpace(rt.defaultModel)
 			}
 			if !activeRun {
 				if lastErr := rt.consumeLastUIRunError(); lastErr != "" {
@@ -42,11 +50,38 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 			}
 		}
 	}
+
+	// Fall back to DB when the runtime is not loaded (e.g. after a page reload).
+	if s.store != nil && (persistedProvider == "" || persistedModel == "") {
+		if sess, err := s.store.Get(r.Context(), sessionID); err == nil && sess != nil {
+			if persistedProvider == "" {
+				pk := strings.TrimSpace(sess.ProviderKey)
+				if pk == "" {
+					pk = resolveSessionProviderKey(s.cfgRef, sess)
+				}
+				persistedProvider = pk
+			}
+			if persistedModel == "" {
+				persistedModel = strings.TrimSpace(sess.Model)
+			}
+			if persistedEffort == "" {
+				persistedEffort = strings.TrimSpace(sess.ReasoningEffort)
+			}
+		}
+	}
+
+	if persistedProvider != "" {
+		resp["provider"] = persistedProvider
+	}
+	if persistedModel != "" {
+		resp["model"] = persistedModel
+	}
+	if persistedEffort != "" {
+		resp["reasoning_effort"] = persistedEffort
+	}
+
 	if s.responseRuns != nil {
 		if activeResponseID := s.responseRuns.activeRunID(sessionID); activeResponseID != "" {
-			// Detached response runs outlive the browser request, so they are the
-			// durable source of truth for reload/reconnect even if runtime polling
-			// has not observed the active run yet.
 			resp["active_run"] = true
 			resp["active_response_id"] = activeResponseID
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3646,6 +3646,89 @@ func TestHandleSessionState_ConsumesDeferredUIRunError(t *testing.T) {
 	}
 }
 
+func TestHandleSessionState_ReturnsModelAndEffortFromRuntime(t *testing.T) {
+	rt := &serveRuntime{
+		providerKey:  "anthropic",
+		defaultModel: "claude-3-5-sonnet",
+	}
+	rt.mu.Lock()
+	rt.sessionMeta = &session.Session{
+		Model:           "claude-opus-4",
+		ReasoningEffort: "high",
+	}
+	rt.mu.Unlock()
+
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return rt, nil
+	})
+	defer mgr.Close()
+	mgr.mu.Lock()
+	mgr.sessions["sess-model"] = rt
+	mgr.mu.Unlock()
+
+	srv := &serveServer{sessionMgr: mgr}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-model/state", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `"model":"claude-opus-4"`) {
+		t.Errorf("expected model from sessionMeta in state, got %s", body)
+	}
+	if !strings.Contains(body, `"reasoning_effort":"high"`) {
+		t.Errorf("expected reasoning_effort from sessionMeta in state, got %s", body)
+	}
+	if !strings.Contains(body, `"provider":"anthropic"`) {
+		t.Errorf("expected provider in state, got %s", body)
+	}
+}
+
+func TestHandleSessionState_FallsBackToDBWhenRuntimeNotLoaded(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{
+		ID:              "sess-db-fallback",
+		ProviderKey:     "openai",
+		Model:           "gpt-5",
+		ReasoningEffort: "medium",
+		Mode:            session.ModeChat,
+		Origin:          session.OriginWeb,
+	}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return &serveRuntime{}, nil
+	})
+	defer mgr.Close()
+
+	srv := &serveServer{sessionMgr: mgr, store: store}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-db-fallback/state", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `"model":"gpt-5"`) {
+		t.Errorf("expected model from DB fallback in state, got %s", body)
+	}
+	if !strings.Contains(body, `"reasoning_effort":"medium"`) {
+		t.Errorf("expected reasoning_effort from DB fallback in state, got %s", body)
+	}
+	if !strings.Contains(body, `"provider":"openai"`) {
+		t.Errorf("expected provider from DB fallback in state, got %s", body)
+	}
+}
+
 func TestHandleResponses_ReturnsStableResponseID(t *testing.T) {
 	srv := newTestServeServer("hello")
 	defer srv.sessionMgr.Close()

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -420,7 +420,7 @@ const updateSessionUsageDisplay = (session) => {
   const lu = session?.lastUsage;
   const model = session?.activeModel || state.selectedModel || '';
   const provider = session?.provider || state.selectedProvider || '';
-  const effort = state.selectedEffort || '';
+  const effort = session?.activeEffort || state.selectedEffort || '';
   const headerModelEffort = splitHeaderModelEffort(model, effort);
 
   const parts = [];
@@ -801,7 +801,8 @@ const sanitizeSession = (session) => {
     lastSequenceNumber: Number.isFinite(Number(session.lastSequenceNumber)) ? Number(session.lastSequenceNumber) : 0,
     sessionUsage: session.sessionUsage && typeof session.sessionUsage === 'object' ? session.sessionUsage : null,
     lastUsage: session.lastUsage && typeof session.lastUsage === 'object' ? session.lastUsage : null,
-    activeModel: typeof session.activeModel === 'string' ? session.activeModel : ''
+    activeModel: typeof session.activeModel === 'string' ? session.activeModel : '',
+    activeEffort: typeof session.activeEffort === 'string' ? session.activeEffort : ''
   };
   if (session._serverOnly) result._serverOnly = true;
   if (typeof session.number === 'number' && session.number > 0) result.number = session.number;

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -371,8 +371,23 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
   const runtimeState = await loadServerSessionState(session.id);
   if (!runtimeState) return null;
 
+  let sessionChanged = false;
   if (runtimeState.provider && runtimeState.provider !== session.provider) {
     session.provider = runtimeState.provider;
+    sessionChanged = true;
+  }
+  if (runtimeState.model && runtimeState.model !== session.activeModel) {
+    session.activeModel = runtimeState.model;
+    sessionChanged = true;
+  }
+  if (runtimeState.reasoning_effort !== undefined) {
+    const effort = String(runtimeState.reasoning_effort || '');
+    if (effort !== (session.activeEffort || '')) {
+      session.activeEffort = effort;
+      sessionChanged = true;
+    }
+  }
+  if (sessionChanged) {
     saveSessions();
   }
 

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2376,11 +2376,13 @@ const sendMessage = async (options = {}) => {
     body.input = rebuildInputFromSession(session, inputContent);
   }
 
-  if (state.selectedModel) {
-    body.model = state.selectedModel;
+  const activeModel = session.activeModel || state.selectedModel;
+  if (activeModel) {
+    body.model = activeModel;
   }
-  if (state.selectedEffort) {
-    body.reasoning_effort = state.selectedEffort;
+  const activeEffort = session.activeEffort || state.selectedEffort;
+  if (activeEffort) {
+    body.reasoning_effort = activeEffort;
   }
   if (!session.provider && state.selectedProvider) {
     session.provider = state.selectedProvider;


### PR DESCRIPTION
## What

Follow-up to #395. When switching to an existing session, the UI now correctly reflects that session's saved model, effort, and provider rather than the current UI dropdown values.

## Changes

**Server** (`serve_ask_user_state_handler.go`):
- `/v1/sessions/{id}/state` now returns `model` and `reasoning_effort` alongside `provider`
- Primary source: live runtime's `sessionMeta` (the locked values set on first message)
- Falls back to DB when the runtime isn't loaded in memory (e.g. after a page reload)

**Frontend** (`app-sessions.js`):
- `syncActiveSessionFromServer` now applies `runtimeState.model` → `session.activeModel` and `runtimeState.reasoning_effort` → `session.activeEffort` when switching sessions

**Frontend** (`app-core.js`):
- `sanitizeSession` adds `activeEffort` field (parallel to `activeModel`)
- `updateStatsBar` uses `session?.activeEffort || state.selectedEffort` so the header reflects the session's effort, not the UI dropdown

**Frontend** (`app-stream.js`):
- `sendMessage` builds the request body using `session.activeModel || state.selectedModel` and `session.activeEffort || state.selectedEffort`, so existing sessions send their locked values

## Tests

Two new tests:
- `TestHandleSessionState_ReturnsModelAndEffortFromRuntime` — live runtime path
- `TestHandleSessionState_FallsBackToDBWhenRuntimeNotLoaded` — DB fallback path
