### PR TITLE
feat: log and surface claude-bin non-zero exits with stderr tail

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -17,6 +18,11 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/mcphttp"
 )
+
+// claudeStderrTailMaxLines caps the number of trailing stderr lines we retain
+// from the claude CLI subprocess for inclusion in error logs. Older lines are
+// discarded so memory stays bounded even if the CLI is chatty.
+const claudeStderrTailMaxLines = 40
 
 // mcpCallCounter generates unique IDs for MCP tool calls
 var mcpCallCounter atomic.Int64
@@ -398,8 +404,16 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		close(bridge.done)
 	}()
 
-	// Log stderr in background (claude CLI outputs progress/errors here)
+	// Capture stderr in a bounded ring buffer so we can include a tail
+	// in error logs when claude exits non-zero. Also forward live to our
+	// stderr in debug mode.
+	var (
+		stderrMu   sync.Mutex
+		stderrTail []string
+	)
+	stderrDone := make(chan struct{})
 	go func() {
+		defer close(stderrDone)
 		stderrScanner := bufio.NewScanner(stderr)
 		stderrScanner.Buffer(make([]byte, 64*1024), 1024*1024)
 		for stderrScanner.Scan() {
@@ -407,6 +421,12 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 			if debug {
 				fmt.Fprintf(os.Stderr, "[claude stderr] %s\n", line)
 			}
+			stderrMu.Lock()
+			stderrTail = append(stderrTail, line)
+			if len(stderrTail) > claudeStderrTailMaxLines {
+				stderrTail = stderrTail[len(stderrTail)-claudeStderrTailMaxLines:]
+			}
+			stderrMu.Unlock()
 		}
 	}()
 
@@ -456,17 +476,44 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 	// Now safe to call Wait() — all pipe reads are done.
 	cmdErr := cmd.Wait()
 
+	// Wait for the stderr scanner goroutine to finish so the tail buffer
+	// is fully populated before we format error messages or log diagnostics.
+	<-stderrDone
+
 	if err != nil {
 		return err
 	}
 	if scanErr != nil {
 		return fmt.Errorf("error reading claude output: %w", scanErr)
 	}
-	// When MCP tools were executed, the CLI exits with code 1 because
-	// --max-turns 1 is exhausted after the tool call. This is expected;
-	// the engine's outer loop will re-invoke us with the tool results.
-	if cmdErr != nil && !toolsExecuted {
-		return fmt.Errorf("claude command failed: %w", cmdErr)
+	if cmdErr != nil {
+		exitCode := -1
+		var exitErr *exec.ExitError
+		if errors.As(cmdErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		stderrMu.Lock()
+		tail := strings.Join(stderrTail, "\n")
+		stderrMu.Unlock()
+
+		// When MCP tools were executed, the CLI exits with code 1 because
+		// --max-turns 1 is exhausted after the tool call. This is expected;
+		// the engine's outer loop will re-invoke us with the tool results.
+		// Any other non-zero exit (crashes, OOMs, auth failures, etc.) must
+		// still surface — don't swallow those just because tools ran.
+		expectedToolExit := toolsExecuted && exitCode == 1
+		if !expectedToolExit {
+			slog.Error("claude command failed",
+				"exit_code", exitCode,
+				"tools_executed", toolsExecuted,
+				"effort", effort,
+				"stderr_tail", tail,
+			)
+			if tail != "" {
+				return fmt.Errorf("claude command failed (exit %d): %w\nstderr:\n%s", exitCode, cmdErr, tail)
+			}
+			return fmt.Errorf("claude command failed (exit %d): %w", exitCode, cmdErr)
+		}
 	}
 
 	if lastUsage != nil {


### PR DESCRIPTION
## What

When the `claude` CLI subprocess exits non-zero, `claude_bin.go` used to return a bare `claude command failed: exit status N` — no stderr, no exit code detail, no structured log. Stderr was only forwarded when `--debug` was set, otherwise scanned and discarded. And any tool-executed run swallowed *every* non-zero exit, not just the expected `exit=1` from `--max-turns 1` exhaustion.

This PR:

1. **Captures stderr into a bounded ring buffer** (last 40 lines) in all modes, not just debug. Debug mode still forwards live to our stderr.
2. **Waits on the stderr goroutine** before formatting errors, so the tail is complete.
3. **Emits `slog.Error`** on non-zero exit with `exit_code`, `tools_executed`, `effort`, and `stderr_tail`.
4. **Returns an error that includes exit code + stderr tail**, wrapping the original `*exec.ExitError` with `%w` so callers can still `errors.As` it.
5. **Tightens the tools-executed carve-out** to `exitCode == 1` specifically — genuine crashes (segfaults, OOMs, auth failures, exit=2+) no longer vanish just because a tool ran during the turn.

## Why

Sam hit debugging friction on claude-bin failures and noticed the error path was effectively silent. `exit status 1` with no context is useless when the CLI is the inference engine — you can't tell OAuth token expiry from a parse error from a rate limit.

## Testing

- `go build ./...` clean
- `go test ./internal/llm/...` passes (2.5s)
- Diff is 53+/6- in a single file, no API changes
