### PR TITLE
feat: dedupe effort-suffixed model aliases from web /v1/models

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -875,13 +875,25 @@ func (s *serveServer) handleModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	seen := map[string]bool{}
-	items := make([]map[string]any, 0, len(models))
+	ids := make([]string, 0, len(models))
+	byID := make(map[string]llm.ModelInfo, len(models))
 	for _, m := range models {
-		if m.ID == "" || seen[m.ID] {
+		if m.ID == "" {
 			continue
 		}
-		seen[m.ID] = true
+		if _, ok := byID[m.ID]; ok {
+			continue
+		}
+		byID[m.ID] = m
+		ids = append(ids, m.ID)
+	}
+	// The web UI has a dedicated reasoning-effort selector, so drop
+	// "<base>-<effort>" aliases when the base model is also present.
+	ids = llm.DedupeEffortVariants(ids)
+
+	items := make([]map[string]any, 0, len(ids))
+	for _, id := range ids {
+		m := byID[id]
 		items = append(items, map[string]any{
 			"id":      m.ID,
 			"object":  "model",

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -6422,6 +6422,51 @@ func TestHandleModels_WithProviderParam(t *testing.T) {
 	}
 }
 
+func TestHandleModels_DropsEffortSuffixDuplicates(t *testing.T) {
+	cfg := &config.Config{
+		DefaultProvider: "claude-bin",
+		Providers:       map[string]config.ProviderConfig{"claude-bin": {}},
+	}
+	// Use the MockProvider so ListModels returns nothing and we fall back
+	// to the curated claude-bin list (which contains opus-low/medium/high/...).
+	mock := llm.NewMockProvider("claude-bin")
+	srv := &serveServer{
+		cfgRef:          cfg,
+		modelsProviders: map[string]llm.Provider{"claude-bin": mock},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models?provider=claude-bin", nil)
+	rr := httptest.NewRecorder()
+	srv.handleModels(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var result struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	got := make(map[string]bool, len(result.Data))
+	for _, m := range result.Data {
+		id, _ := m["id"].(string)
+		got[id] = true
+	}
+	// Base models must remain.
+	for _, want := range []string{"opus", "sonnet", "haiku"} {
+		if !got[want] {
+			t.Errorf("expected %q in models response, got %v", want, got)
+		}
+	}
+	// Effort-suffixed aliases must be filtered out — the web UI has a
+	// dedicated reasoning-effort selector for these.
+	for _, banned := range []string{"opus-low", "opus-medium", "opus-high", "opus-xhigh", "opus-max", "sonnet-low", "sonnet-medium", "sonnet-high"} {
+		if got[banned] {
+			t.Errorf("unexpected %q in models response (should be deduped by effort selector)", banned)
+		}
+	}
+}
+
 func TestHandleResponses_WithProviderField(t *testing.T) {
 	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
 	factory := func(ctx context.Context) (*serveRuntime, error) {

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -336,6 +336,38 @@ func hasEffortSuffix(model string) bool {
 	return false
 }
 
+// knownEffortSuffixes is the union of reasoning-effort suffixes recognised
+// across providers (gpt-5, claude-bin opus/sonnet). Used to detect
+// "<base>-<effort>" aliases that duplicate a base model when effort is
+// picked separately.
+var knownEffortSuffixes = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
+
+// DedupeEffortVariants removes effort-suffixed aliases (e.g. "opus-high",
+// "gpt-5.4-medium") when the base model is also present in the list.
+// Used by UIs that expose reasoning effort through a dedicated selector,
+// where "<base>-<effort>" entries just duplicate what the selector covers.
+// Order is preserved; entries without a matching base are kept as-is.
+func DedupeEffortVariants(ids []string) []string {
+	have := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		have[id] = true
+	}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		drop := false
+		for _, suffix := range knownEffortSuffixes {
+			if strings.HasSuffix(id, "-"+suffix) && have[strings.TrimSuffix(id, "-"+suffix)] {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // GetBuiltInProviderNames returns the built-in provider type names
 func GetBuiltInProviderNames() []string {
 	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice"}

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -307,6 +307,41 @@ func TestEffortVariantLimitsMatchBase(t *testing.T) {
 	}
 }
 
+func TestDedupeEffortVariants(t *testing.T) {
+	// claude-bin curated list has base + effort-suffixed aliases; the
+	// suffixed ones should be dropped when the base is present.
+	in := []string{
+		"opus", "opus-low", "opus-medium", "opus-high", "opus-xhigh", "opus-max",
+		"sonnet", "sonnet-low", "sonnet-medium", "sonnet-high",
+		"haiku",
+	}
+	got := DedupeEffortVariants(in)
+	want := []string{"opus", "sonnet", "haiku"}
+	if len(got) != len(want) {
+		t.Fatalf("DedupeEffortVariants: got %v, want %v", got, want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Errorf("index %d: got %q, want %q", i, got[i], id)
+		}
+	}
+
+	// Effort-suffixed entries without a base are preserved (e.g. some
+	// provider might expose only the suffixed variant).
+	in2 := []string{"gpt-5.4-high", "gpt-5.4-mini"}
+	got2 := DedupeEffortVariants(in2)
+	if len(got2) != 2 || got2[0] != "gpt-5.4-high" || got2[1] != "gpt-5.4-mini" {
+		t.Errorf("expected both entries preserved, got %v", got2)
+	}
+
+	// Unrelated "-high"/"-low"/etc. suffixes without a base are preserved.
+	in3 := []string{"claude-sonnet-4-6", "gpt-5.4"}
+	got3 := DedupeEffortVariants(in3)
+	if len(got3) != 2 {
+		t.Errorf("expected both entries preserved, got %v", got3)
+	}
+}
+
 func containsModelID(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {


### PR DESCRIPTION
## What

Drop `<base>-<effort>` aliases (e.g. `opus-high`, `opus-medium`, `opus-low`, `opus-xhigh`, `opus-max`, `sonnet-high`, `sonnet-medium`, `sonnet-low`) from the web UI's model dropdown when the base model is also present.

## Why

The web UI now has a dedicated reasoning-effort selector (added in session 1687). The curated `claude-bin` list still exposes every `opus-<effort>` and `sonnet-<effort>` alias, so the dropdown is cluttered with entries that duplicate what the effort selector already covers.

## How

- New helper `llm.DedupeEffortVariants([]string) []string` drops entries whose suffix is in the union of known effort levels (`minimal`/`low`/`medium`/`high`/`xhigh`/`max`) **only when** the base model (suffix removed) is also in the list. Standalone effort-suffixed entries are preserved.
- `handleModels` applies it after gathering the provider's model list (ListModels + config + curated fallback), before writing the response.
- Scoped to the HTTP models endpoint — CLI tab-completion, `term-llm models`, and `parseClaudeEffort` are untouched, so `claude-bin:opus-high` still works as a config/model string.

## Tests

- `TestDedupeEffortVariants` — unit test for the helper, covering the claude-bin curated list plus edge cases where the base is absent.
- `TestHandleModels_DropsEffortSuffixDuplicates` — end-to-end check that `/v1/models?provider=claude-bin` returns `opus`/`sonnet`/`haiku` and none of the eight effort-suffixed aliases.

```
$ go test -run 'TestHandleModels|TestDedupeEffortVariants' ./cmd/... ./internal/llm/...
ok  	github.com/samsaffron/term-llm/cmd	0.011s
ok  	github.com/samsaffron/term-llm/internal/llm	0.014s
```
