### PR TITLE
fix(serve): session state endpoint blocks on active run's mutex

### DIFF
--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -13,6 +13,8 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 	}
 
 	var persistedProvider, persistedModel, persistedEffort string
+	var runtimeDefaultModel string
+	runtimeMetaRead := false
 
 	if s.sessionMgr != nil {
 		if rt, ok := s.sessionMgr.Get(sessionID); ok && rt != nil {
@@ -34,14 +36,17 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 				})
 				persistedProvider = resolved
 			}
-			rt.mu.Lock()
-			if rt.sessionMeta != nil {
-				persistedModel = strings.TrimSpace(rt.sessionMeta.Model)
-				persistedEffort = strings.TrimSpace(rt.sessionMeta.ReasoningEffort)
-			}
-			rt.mu.Unlock()
-			if persistedModel == "" {
-				persistedModel = strings.TrimSpace(rt.defaultModel)
+			runtimeDefaultModel = strings.TrimSpace(rt.defaultModel)
+			// rt.mu is held for the entire duration of a run; take it only
+			// non-blockingly so state polls never stall a busy session. When
+			// the lock is held, fall through to the DB for model/effort.
+			if rt.mu.TryLock() {
+				if rt.sessionMeta != nil {
+					persistedModel = strings.TrimSpace(rt.sessionMeta.Model)
+					persistedEffort = strings.TrimSpace(rt.sessionMeta.ReasoningEffort)
+				}
+				rt.mu.Unlock()
+				runtimeMetaRead = true
 			}
 			if !activeRun {
 				if lastErr := rt.consumeLastUIRunError(); lastErr != "" {
@@ -51,8 +56,10 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 		}
 	}
 
-	// Fall back to DB when the runtime is not loaded (e.g. after a page reload).
-	if s.store != nil && (persistedProvider == "" || persistedModel == "") {
+	// Fall back to the DB when the runtime was not loaded (e.g. after a
+	// page reload) or we could not read sessionMeta because a run held
+	// rt.mu. The DB has the last persisted model/effort for the session.
+	if s.store != nil && (!runtimeMetaRead || persistedProvider == "" || persistedModel == "") {
 		if sess, err := s.store.Get(r.Context(), sessionID); err == nil && sess != nil {
 			if persistedProvider == "" {
 				pk := strings.TrimSpace(sess.ProviderKey)
@@ -68,6 +75,10 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 				persistedEffort = strings.TrimSpace(sess.ReasoningEffort)
 			}
 		}
+	}
+
+	if persistedModel == "" {
+		persistedModel = runtimeDefaultModel
 	}
 
 	if persistedProvider != "" {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3729,6 +3729,85 @@ func TestHandleSessionState_FallsBackToDBWhenRuntimeNotLoaded(t *testing.T) {
 	}
 }
 
+func TestHandleSessionState_DoesNotBlockWhileRunHoldsRuntimeMutex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{
+		ID:              "sess-busy",
+		ProviderKey:     "openai",
+		Model:           "gpt-5",
+		ReasoningEffort: "medium",
+		Mode:            session.ModeChat,
+		Origin:          session.OriginWeb,
+	}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rt := &serveRuntime{
+		providerKey:  "openai",
+		defaultModel: "gpt-5",
+		store:        store,
+		sessionMeta:  sess,
+	}
+
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return rt, nil
+	})
+	defer mgr.Close()
+	mgr.mu.Lock()
+	mgr.sessions[sess.ID] = rt
+	mgr.mu.Unlock()
+
+	srv := &serveServer{sessionMgr: mgr, store: store}
+
+	// Simulate an active run by holding rt.mu while the handler runs. Release
+	// before mgr.Close() so the runtime can finalize without deadlocking.
+	rt.mu.Lock()
+	lockReleased := false
+	releaseLock := func() {
+		if !lockReleased {
+			lockReleased = true
+			rt.mu.Unlock()
+		}
+	}
+	defer releaseLock()
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sess.ID+"/state", nil)
+		rr := httptest.NewRecorder()
+		srv.handleSessionByID(rr, req)
+		done <- rr
+	}()
+
+	select {
+	case rr := <-done:
+		releaseLock()
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d", rr.Code)
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, `"model":"gpt-5"`) {
+			t.Errorf("expected model from DB fallback while rt.mu held, got %s", body)
+		}
+		if !strings.Contains(body, `"reasoning_effort":"medium"`) {
+			t.Errorf("expected reasoning_effort from DB fallback while rt.mu held, got %s", body)
+		}
+		if !strings.Contains(body, `"provider":"openai"`) {
+			t.Errorf("expected provider while rt.mu held, got %s", body)
+		}
+	case <-time.After(2 * time.Second):
+		releaseLock()
+		t.Fatal("handleSessionState blocked while rt.mu was held by a run")
+	}
+}
+
 func TestHandleResponses_ReturnsStableResponseID(t *testing.T) {
 	srv := newTestServeServer("hello")
 	defer srv.sessionMgr.Close()


### PR DESCRIPTION
## Symptom

Web UI sidebar gets stuck on "syncing sessions…" as soon as one session has a long-running response in progress. All other sessions become unresponsive in the UI until that run finishes.

## Cause

`handleSessionState` takes `rt.mu.Lock()` to snapshot `sessionMeta.Model` and `sessionMeta.ReasoningEffort` (added in #396). The same `rt.mu` is held for the entire duration of a run — `rt.run()` at `cmd/serve_runtime.go:530` does `rt.mu.TryLock()` and `defer rt.mu.Unlock()` around the whole streaming loop, including tool execution.

The web UI polls `/v1/sessions/<id>/state` every 1.2s to drive the active-session sync. During a busy run, every poll blocks on the run's mutex, so the sync promise never resolves and the UI shows "syncing sessions…" indefinitely.

Reproduced locally: `curl /v1/sessions/<busy-session>/state` hangs past 30s, while the same endpoint for an idle session returns in ~12ms.

## Fix

Swap the blocking `rt.mu.Lock()` for `rt.mu.TryLock()`. When the lock is held (i.e. a run is active), fall through to the DB, which already holds the last persisted `Model` / `ReasoningEffort` (they are written by `ensurePersistedSession` before streaming starts). The runtime's `defaultModel` remains the final fallback when neither runtime meta nor DB yields a model.

Every other state field the handler reads (`hasActiveRun`, `pendingAskUserPrompts`, `pendingApprovalPrompts`, `consumeLastUIRunError`) already uses a finer-grained mutex — only the `sessionMeta` read was colliding with the run-scoped lock.

## Test

Added `TestHandleSessionState_DoesNotBlockWhileRunHoldsRuntimeMutex`:

1. Create a session, persist it in the DB store.
2. Hold `rt.mu` to simulate an active run.
3. Call the handler from a goroutine with a 2s deadline.
4. Assert it returns `model` / `effort` / `provider` from the DB fallback within the deadline.

Verified the test fails against `main` (times out at 2s with "handleSessionState blocked while rt.mu was held by a run") and passes with this fix.

Existing state-handler tests still pass (including the one that reads `sessionMeta` from the runtime on the happy path — `TryLock` acquires immediately when the mutex is free).
