### PR TITLE
fix: Claude CLI conversation state survives resets and leaks old history into new chats

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -204,6 +204,13 @@ func (p *ClaudeBinProvider) SetToolExecutor(executor func(ctx context.Context, n
 	}
 }
 
+// ResetConversation clears Claude CLI resume state so the next turn starts a
+// fresh conversation instead of resuming the previous CLI session.
+func (p *ClaudeBinProvider) ResetConversation() {
+	p.sessionID = ""
+	p.messagesSent = 0
+}
+
 func (p *ClaudeBinProvider) Name() string {
 	model := p.model
 	if model == "" {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -676,6 +676,26 @@ func TestClaudeBinProvider_SystemPromptForTurn(t *testing.T) {
 	}
 }
 
+func TestClaudeBinProvider_ResetConversationClearsResumeState(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	p.sessionID = "resume-abc"
+	p.messagesSent = 3
+
+	p.ResetConversation()
+
+	if p.sessionID != "" {
+		t.Fatalf("sessionID = %q, want empty after reset", p.sessionID)
+	}
+	if p.messagesSent != 0 {
+		t.Fatalf("messagesSent = %d, want 0 after reset", p.messagesSent)
+	}
+
+	args, _ := p.buildArgs(context.Background(), Request{}, eventSender{})
+	if joined := strings.Join(args, " "); strings.Contains(joined, "--resume") {
+		t.Fatalf("buildArgs() = %q, want no --resume after reset", joined)
+	}
+}
+
 func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "should-be-cleared")
 	t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "medium")


### PR DESCRIPTION
## What

Add a `ResetConversation()` hook to `ClaudeBinProvider` that clears the persisted Claude CLI resume state (`sessionID` and `messagesSent`) so fresh conversations do not reuse the previous Claude session. Also add a regression test covering the reset behavior.

## Why

`Engine.ResetConversation()` already forwards resets to providers that implement a reset hook, but `ClaudeBinProvider` was not implementing one even though it caches resume state across turns. That let supposedly fresh conversations keep resuming the old Claude CLI session, skip re-sending the full prompt/system instructions, and leak stale context into new chats.
