### PR TITLE
fix: Telegram history carryover can reload huge image payloads despite a tiny carryover budget

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -586,7 +586,7 @@ func (m *telegramSessionMgr) restoreHistoryFromDB(ctx context.Context, chatID in
 			all = append(all, msg.ToLLMMessage())
 		}
 
-		history := tailMessages(all, maxChars)
+		history := sanitizeCarryoverMessages(tailMessages(all, maxChars))
 		if len(history) > 0 {
 			sess.history = history
 			log.Printf("[telegram] restored %d messages (of %d) from session %s for chat %d",
@@ -617,6 +617,63 @@ func tailMessages(msgs []llm.Message, maxChars int) []llm.Message {
 		start = i
 	}
 	return msgs[start:]
+}
+
+func sanitizeCarryoverMessages(msgs []llm.Message) []llm.Message {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	sanitized := make([]llm.Message, 0, len(msgs))
+	for _, msg := range msgs {
+		sanitized = append(sanitized, sanitizeCarryoverMessage(msg))
+	}
+	return sanitized
+}
+
+func sanitizeCarryoverMessage(msg llm.Message) llm.Message {
+	sanitized := llm.Message{
+		Role:        msg.Role,
+		CacheAnchor: msg.CacheAnchor,
+		Parts:       make([]llm.Part, 0, len(msg.Parts)),
+	}
+
+	for _, part := range msg.Parts {
+		switch part.Type {
+		case llm.PartImage:
+			sanitized.Parts = append(sanitized.Parts, llm.Part{Type: llm.PartText, Text: "[image uploaded]"})
+		case llm.PartToolCall:
+			if part.ToolCall == nil {
+				continue
+			}
+			call := *part.ToolCall
+			if len(call.Arguments) > 0 {
+				call.Arguments = append([]byte(nil), call.Arguments...)
+			}
+			if len(call.ThoughtSig) > 0 {
+				call.ThoughtSig = append([]byte(nil), call.ThoughtSig...)
+			}
+			sanitized.Parts = append(sanitized.Parts, llm.Part{Type: llm.PartToolCall, ToolCall: &call})
+		case llm.PartToolResult:
+			if part.ToolResult == nil {
+				continue
+			}
+			result := &llm.ToolResult{
+				ID:      part.ToolResult.ID,
+				Name:    part.ToolResult.Name,
+				Content: extractToolResultTextWithPlaceholders(part.ToolResult),
+				IsError: part.ToolResult.IsError,
+			}
+			if len(part.ToolResult.ThoughtSig) > 0 {
+				result.ThoughtSig = append([]byte(nil), part.ToolResult.ThoughtSig...)
+			}
+			sanitized.Parts = append(sanitized.Parts, llm.Part{Type: llm.PartToolResult, ToolResult: result})
+		default:
+			sanitized.Parts = append(sanitized.Parts, part)
+		}
+	}
+
+	return sanitized
 }
 
 func (m *telegramSessionMgr) newSession(ctx context.Context, chatID int64) (*telegramSession, error) {
@@ -1650,6 +1707,31 @@ func buildHistoryContextTail(history []llm.Message, maxChars int) string {
 	return tailRunes(strings.Join(lines, "\n"), maxChars)
 }
 
+func extractToolResultTextWithPlaceholders(result *llm.ToolResult) string {
+	if result == nil {
+		return ""
+	}
+
+	var parts []string
+	if strings.TrimSpace(result.Content) != "" {
+		parts = append(parts, result.Content)
+	}
+	for _, p := range result.ContentParts {
+		switch p.Type {
+		case llm.ToolContentPartText:
+			if strings.TrimSpace(p.Text) != "" {
+				parts = append(parts, p.Text)
+			}
+		case llm.ToolContentPartImageData:
+			parts = append(parts, "[image uploaded]")
+		}
+	}
+	for range result.Images {
+		parts = append(parts, "[image uploaded]")
+	}
+	return strings.Join(parts, "\n")
+}
+
 func extractMessageTextWithPlaceholders(msg llm.Message) string {
 	var parts []string
 	for _, part := range msg.Parts {
@@ -1661,25 +1743,8 @@ func extractMessageTextWithPlaceholders(msg llm.Message) string {
 		case llm.PartImage:
 			parts = append(parts, "[image uploaded]")
 		case llm.PartToolResult:
-			if part.ToolResult == nil {
-				continue
-			}
-			result := part.ToolResult
-			if strings.TrimSpace(result.Content) != "" {
-				parts = append(parts, result.Content)
-			}
-			for _, p := range result.ContentParts {
-				switch p.Type {
-				case llm.ToolContentPartText:
-					if strings.TrimSpace(p.Text) != "" {
-						parts = append(parts, p.Text)
-					}
-				case llm.ToolContentPartImageData:
-					parts = append(parts, "[image uploaded]")
-				}
-			}
-			for range result.Images {
-				parts = append(parts, "[image uploaded]")
+			if text := extractToolResultTextWithPlaceholders(part.ToolResult); strings.TrimSpace(text) != "" {
+				parts = append(parts, text)
 			}
 		}
 	}

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -858,6 +858,132 @@ func TestTelegramSessionMgrResetSessionIfCurrent_RestoresHistoryFromDB(t *testin
 	}
 }
 
+func TestTelegramSessionMgrResetSessionIfCurrent_RestoresSanitizedCarryoverHistory(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer store.Close()
+
+	mgr := &telegramSessionMgr{
+		sessions: make(map[int64]*telegramSession),
+		store:    store,
+		settings: Settings{
+			TelegramCarryoverChars: 200,
+			Store:                  store,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					ProviderName: "mock",
+					ModelName:    "model",
+				}, nil
+			},
+		},
+	}
+
+	ctx := context.Background()
+	original, err := mgr.getOrCreate(ctx, 42)
+	if err != nil {
+		t.Fatalf("getOrCreate failed: %v", err)
+	}
+
+	hugeBase64 := strings.Repeat("a", 128*1024)
+	persisted := []llm.Message{
+		llm.UserImageMessage("image/jpeg", hugeBase64, "caption text"),
+		{
+			Role: llm.RoleAssistant,
+			Parts: []llm.Part{{
+				Type: llm.PartToolCall,
+				ToolCall: &llm.ToolCall{
+					ID:        "call-1",
+					Name:      "view_image",
+					Arguments: json.RawMessage(`{"file_path":"photo.jpg"}`),
+				},
+			}},
+		},
+		{
+			Role: llm.RoleTool,
+			Parts: []llm.Part{{
+				Type: llm.PartToolResult,
+				ToolResult: &llm.ToolResult{
+					ID:      "call-1",
+					Name:    "view_image",
+					Content: "loaded",
+					ContentParts: []llm.ToolContentPart{{
+						Type: llm.ToolContentPartImageData,
+						ImageData: &llm.ToolImageData{
+							MediaType: "image/jpeg",
+							Base64:    hugeBase64,
+						},
+					}},
+				},
+			}},
+		},
+	}
+	for _, msg := range persisted {
+		if err := store.AddMessage(ctx, original.meta.ID, session.NewMessage(original.meta.ID, msg, -1)); err != nil {
+			t.Fatalf("add message: %v", err)
+		}
+	}
+
+	replacement, replaced, err := mgr.resetSessionIfCurrent(ctx, 42, original)
+	if err != nil {
+		t.Fatalf("resetSessionIfCurrent failed: %v", err)
+	}
+	if !replaced {
+		t.Fatalf("expected reset to replace session")
+	}
+	if len(replacement.history) != len(persisted) {
+		t.Fatalf("expected %d restored messages, got %d", len(persisted), len(replacement.history))
+	}
+
+	userMsg := replacement.history[0]
+	if userMsg.Role != llm.RoleUser {
+		t.Fatalf("expected first restored message role %q, got %q", llm.RoleUser, userMsg.Role)
+	}
+	userText := collectUserText(userMsg)
+	if !strings.Contains(userText, "[image uploaded]") {
+		t.Fatalf("expected user carryover placeholder, got %q", userText)
+	}
+	if !strings.Contains(userText, "caption text") {
+		t.Fatalf("expected user carryover caption, got %q", userText)
+	}
+	for _, part := range userMsg.Parts {
+		if part.Type == llm.PartImage {
+			t.Fatalf("restored carryover should not keep image parts: %+v", userMsg.Parts)
+		}
+	}
+
+	assistantMsg := replacement.history[1]
+	if assistantMsg.Role != llm.RoleAssistant {
+		t.Fatalf("expected second restored message role %q, got %q", llm.RoleAssistant, assistantMsg.Role)
+	}
+	if len(assistantMsg.Parts) != 1 || assistantMsg.Parts[0].Type != llm.PartToolCall || assistantMsg.Parts[0].ToolCall == nil {
+		t.Fatalf("expected assistant tool call to be preserved, got %+v", assistantMsg.Parts)
+	}
+	if assistantMsg.Parts[0].ToolCall.ID != "call-1" {
+		t.Fatalf("expected preserved tool call id call-1, got %q", assistantMsg.Parts[0].ToolCall.ID)
+	}
+
+	toolMsg := replacement.history[2]
+	if toolMsg.Role != llm.RoleTool {
+		t.Fatalf("expected third restored message role %q, got %q", llm.RoleTool, toolMsg.Role)
+	}
+	if len(toolMsg.Parts) != 1 || toolMsg.Parts[0].Type != llm.PartToolResult || toolMsg.Parts[0].ToolResult == nil {
+		t.Fatalf("expected tool result to be preserved, got %+v", toolMsg.Parts)
+	}
+	toolResult := toolMsg.Parts[0].ToolResult
+	if !strings.Contains(toolResult.Content, "loaded") || !strings.Contains(toolResult.Content, "[image uploaded]") {
+		t.Fatalf("expected sanitized tool result content with placeholder, got %q", toolResult.Content)
+	}
+	if len(toolResult.ContentParts) != 0 {
+		t.Fatalf("expected sanitized tool result to drop content parts, got %+v", toolResult.ContentParts)
+	}
+	if len(toolResult.Images) != 0 {
+		t.Fatalf("expected sanitized tool result to drop images, got %+v", toolResult.Images)
+	}
+}
+
 func TestTelegramSessionMgrResetSession_ZeroCarryoverDisablesHistory(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

- sanitize restored Telegram carryover history before storing it in `sess.history`
- replace carried-over user image parts with the existing `[image uploaded]` placeholder text
- strip image payloads from carried-over tool results while preserving the tool result structure/IDs
- add a regression test covering restored user-image and tool-result history with large image payloads

## Why

`restoreHistoryFromDB` chose the carryover suffix using placeholder text, but then restored the original `llm.Message` objects. That let a tiny `[image uploaded]` placeholder sneak megabytes of base64 image data back into memory and subsequent model requests after a restart or idle reset.

This keeps the carryover budget aligned with what is actually restored, while preserving enough structure for follow-up turns.

Note: `go test ./...` still reports an existing unrelated failure in `internal/serveui` (`TestStaticAssetsSupportEffortDropdown`).