### PR TITLE
fix: Tool-reported file paths are blindly republished as web-accessible files

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -199,6 +199,46 @@ func serveRoutePath(baseRoute, baseDir, servedPath string) string {
 	return baseRoute + filepath.ToSlash(relPath)
 }
 
+func canonicalizeServeExistingPath(p string) (string, error) {
+	absPath, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func canonicalizeServeDirForWrite(dir string) (string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absDir)
+	if err == nil {
+		return filepath.Clean(resolved), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	parent := filepath.Dir(absDir)
+	resolvedParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return filepath.Clean(absDir), nil
+		}
+		return "", err
+	}
+	return filepath.Join(filepath.Clean(resolvedParent), filepath.Base(absDir)), nil
+}
+
+func pathWithinDir(path, dir string) bool {
+	return path == dir || strings.HasPrefix(path, dir+string(filepath.Separator))
+}
+
 func (s *serveServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set("Allow", "GET, HEAD")
@@ -242,29 +282,51 @@ func (s *serveServer) handleFile(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, absFile)
 }
 
-// ensureFileServeable copies the given file into the configured files-dir
-// so that the files handler can serve it. Returns the serveable path and true
-// on success, or ("", false) if the file could not be made serveable.
+// ensureFileServeable makes the given file available from the configured
+// files-dir when it already comes from an approved output directory. Returns
+// the serveable path and true on success, or ("", false) if the file could
+// not be made serveable.
 func (s *serveServer) ensureFileServeable(filePath string) (string, bool) {
 	filesDir := s.cfg.filesDir
 	if filesDir == "" {
 		return "", false
 	}
 
-	absDir, err := filepath.Abs(filesDir)
+	absDir, err := canonicalizeServeDirForWrite(filesDir)
 	if err != nil {
-		log.Printf("[serve] ensureFileServeable: abs(%s): %v", filesDir, err)
+		log.Printf("[serve] ensureFileServeable: resolve dir %s: %v", filesDir, err)
 		return "", false
 	}
-	absFile, err := filepath.Abs(filePath)
+	absFile, err := canonicalizeServeExistingPath(filePath)
 	if err != nil {
-		log.Printf("[serve] ensureFileServeable: abs(%s): %v", filePath, err)
+		log.Printf("[serve] ensureFileServeable: resolve %s: %v", filePath, err)
 		return "", false
 	}
 
-	// Already under the files dir — nothing to do.
-	if strings.HasPrefix(absFile, absDir+string(filepath.Separator)) {
-		return filePath, true
+	if pathWithinDir(absFile, absDir) {
+		return absFile, true
+	}
+
+	approvedSourceDirs := []string{absDir}
+	if imageOutputDir := s.imageOutputDir(); imageOutputDir != "" {
+		absImageOutputDir, err := canonicalizeServeDirForWrite(imageOutputDir)
+		if err != nil {
+			log.Printf("[serve] ensureFileServeable: resolve image output dir %s: %v", imageOutputDir, err)
+			return "", false
+		}
+		approvedSourceDirs = append(approvedSourceDirs, absImageOutputDir)
+	}
+
+	approved := false
+	for _, dir := range approvedSourceDirs {
+		if pathWithinDir(absFile, dir) {
+			approved = true
+			break
+		}
+	}
+	if !approved {
+		log.Printf("[serve] ensureFileServeable: rejecting %s outside approved dirs", absFile)
+		return "", false
 	}
 
 	if err := os.MkdirAll(absDir, 0755); err != nil {
@@ -301,64 +363,29 @@ func (s *serveServer) ensureFileServeable(filePath string) (string, bool) {
 	return destPath, true
 }
 
-// ensureImageServeable ensures the given image path is under the serveable
-// image output directory. If the file is already there, the path is returned
-// as-is. Otherwise the file is copied into the output dir so that the
-// images handler (mounted at basePath/images/) can serve it. Returns the
-// serveable path and true on success, or ("", false) if the image could not
-// be made serveable.
+// ensureImageServeable ensures the given image path is already under the
+// configured image output directory. Returns the serveable path and true on
+// success, or ("", false) if the image could not be made serveable.
 func (s *serveServer) ensureImageServeable(imgPath string) (string, bool) {
 	outputDir := s.imageOutputDir()
 
-	absDir, err := filepath.Abs(outputDir)
+	absDir, err := canonicalizeServeDirForWrite(outputDir)
 	if err != nil {
-		log.Printf("[serve] ensureImageServeable: abs(%s): %v", outputDir, err)
+		log.Printf("[serve] ensureImageServeable: resolve dir %s: %v", outputDir, err)
 		return "", false
 	}
-	absImg, err := filepath.Abs(imgPath)
+	absImg, err := canonicalizeServeExistingPath(imgPath)
 	if err != nil {
-		log.Printf("[serve] ensureImageServeable: abs(%s): %v", imgPath, err)
+		log.Printf("[serve] ensureImageServeable: resolve %s: %v", imgPath, err)
 		return "", false
 	}
 
-	// Already under the output dir — nothing to do.
-	if strings.HasPrefix(absImg, absDir+string(filepath.Separator)) {
-		return imgPath, true
-	}
-
-	// Copy the file into the output dir with a unique prefix to avoid collisions.
-	if err := os.MkdirAll(absDir, 0755); err != nil {
-		log.Printf("[serve] ensureImageServeable: mkdir %s: %v", absDir, err)
+	if !pathWithinDir(absImg, absDir) {
+		log.Printf("[serve] ensureImageServeable: rejecting %s outside %s", absImg, absDir)
 		return "", false
 	}
 
-	src, err := os.Open(absImg)
-	if err != nil {
-		log.Printf("[serve] ensureImageServeable: open %s: %v", absImg, err)
-		return "", false
-	}
-	defer src.Close()
-
-	destName := fmt.Sprintf("serve-%s-%s", randomSuffix(), filepath.Base(absImg))
-	destPath := filepath.Join(absDir, destName)
-	dst, err := os.Create(destPath)
-	if err != nil {
-		log.Printf("[serve] ensureImageServeable: create %s: %v", destPath, err)
-		return "", false
-	}
-	if _, err := io.Copy(dst, src); err != nil {
-		dst.Close()
-		os.Remove(destPath)
-		log.Printf("[serve] ensureImageServeable: copy to %s: %v", destPath, err)
-		return "", false
-	}
-	if err := dst.Close(); err != nil {
-		os.Remove(destPath)
-		log.Printf("[serve] ensureImageServeable: close %s: %v", destPath, err)
-		return "", false
-	}
-
-	return destPath, true
+	return absImg, true
 }
 
 func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2420,17 +2420,17 @@ func TestHandleImage_ServesFileAndRejectsTraversal(t *testing.T) {
 	}
 }
 
-func TestEnsureImageServeable_CopiesExternalFile(t *testing.T) {
+func TestEnsureImageServeable_RejectsExternalFile(t *testing.T) {
 	outputDir := t.TempDir()
 	externalDir := t.TempDir()
 
-	// Create a file outside the image output directory
+	// Create a file outside the image output directory.
 	externalImg := filepath.Join(externalDir, "photo.png")
 	if err := os.WriteFile(externalImg, []byte("external-image-data"), 0644); err != nil {
 		t.Fatalf("write external image: %v", err)
 	}
 
-	// Create a file already inside the output directory
+	// Create a file already inside the output directory.
 	internalImg := filepath.Join(outputDir, "generated.png")
 	if err := os.WriteFile(internalImg, []byte("internal-image-data"), 0644); err != nil {
 		t.Fatalf("write internal image: %v", err)
@@ -2439,48 +2439,30 @@ func TestEnsureImageServeable_CopiesExternalFile(t *testing.T) {
 	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui"}, cfgRef: &config.Config{}}
 	srv.cfgRef.Image.OutputDir = outputDir
 
-	// External file should be copied
-	result, ok := srv.ensureImageServeable(externalImg)
-	if !ok {
-		t.Fatal("ensureImageServeable should succeed for external image")
-	}
-	if result == externalImg {
-		t.Fatal("external image should have been copied, but path is unchanged")
-	}
-	absResult, _ := filepath.Abs(result)
-	absOutputDir, _ := filepath.Abs(outputDir)
-	if !strings.HasPrefix(absResult, absOutputDir+string(filepath.Separator)) {
-		t.Fatalf("copied image %q should be under output dir %q", absResult, absOutputDir)
-	}
-	// Verify the copied file contains the correct data
-	data, err := os.ReadFile(result)
-	if err != nil {
-		t.Fatalf("read copied image: %v", err)
-	}
-	if string(data) != "external-image-data" {
-		t.Fatalf("copied data = %q, want %q", string(data), "external-image-data")
+	// External files should be rejected instead of republished.
+	if result, ok := srv.ensureImageServeable(externalImg); ok || result != "" {
+		t.Fatalf("ensureImageServeable should reject external image, got result=%q ok=%v", result, ok)
 	}
 
-	// Internal file should be returned as-is
-	result, ok = srv.ensureImageServeable(internalImg)
+	// Internal file should be returned as an absolute, serveable path.
+	result, ok := srv.ensureImageServeable(internalImg)
 	if !ok {
 		t.Fatal("ensureImageServeable should succeed for internal image")
 	}
-	if result != internalImg {
-		t.Fatalf("internal image should be unchanged, got %q want %q", result, internalImg)
+	absInternalImg, err := filepath.EvalSymlinks(internalImg)
+	if err != nil {
+		t.Fatalf("resolve internal image: %v", err)
+	}
+	if result != absInternalImg {
+		t.Fatalf("internal image should be unchanged apart from canonicalization, got %q want %q", result, absInternalImg)
 	}
 
-	// Verify the copied file is actually serveable via handleImage
-	copied, ok := srv.ensureImageServeable(externalImg)
-	if !ok {
-		t.Fatal("ensureImageServeable should succeed for second external copy")
-	}
-	copiedName := filepath.Base(copied)
-	req := httptest.NewRequest(http.MethodGet, "/images/"+copiedName, nil)
+	// Verify the internal file is actually serveable via handleImage.
+	req := httptest.NewRequest(http.MethodGet, "/images/"+filepath.Base(result), nil)
 	rr := httptest.NewRecorder()
 	srv.handleImage(rr, req)
 	if rr.Code != http.StatusOK {
-		t.Fatalf("serve copied image: status = %d, want 200", rr.Code)
+		t.Fatalf("serve internal image: status = %d, want 200", rr.Code)
 	}
 }
 
@@ -2566,7 +2548,7 @@ func TestServeRoutePath_PreservesNestedRelativePaths(t *testing.T) {
 	}
 }
 
-func TestEnsureFileServeable_CopiesExternalFile(t *testing.T) {
+func TestEnsureFileServeable_RejectsExternalFile(t *testing.T) {
 	filesDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -2582,16 +2564,61 @@ func TestEnsureFileServeable_CopiesExternalFile(t *testing.T) {
 
 	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui", filesDir: filesDir}}
 
-	// External file should be copied
-	result, ok := srv.ensureFileServeable(externalFile)
+	// External files should be rejected instead of republished.
+	if result, ok := srv.ensureFileServeable(externalFile); ok || result != "" {
+		t.Fatalf("ensureFileServeable should reject external file, got result=%q ok=%v", result, ok)
+	}
+
+	// Internal file should be returned as an absolute, serveable path.
+	result, ok := srv.ensureFileServeable(internalFile)
 	if !ok {
-		t.Fatal("ensureFileServeable should succeed for external file")
+		t.Fatal("ensureFileServeable should succeed for internal file")
 	}
-	if result == externalFile {
-		t.Fatal("external file should have been copied, but path is unchanged")
+	absInternalFile, err := filepath.EvalSymlinks(internalFile)
+	if err != nil {
+		t.Fatalf("resolve internal file: %v", err)
 	}
-	absResult, _ := filepath.Abs(result)
-	absFilesDir, _ := filepath.Abs(filesDir)
+	if result != absInternalFile {
+		t.Fatalf("internal file should be unchanged apart from canonicalization, got %q want %q", result, absInternalFile)
+	}
+
+	// No files-dir → fails.
+	srv2 := &serveServer{cfg: serveServerConfig{basePath: "/ui"}}
+	_, ok = srv2.ensureFileServeable(externalFile)
+	if ok {
+		t.Fatal("ensureFileServeable should fail when filesDir is empty")
+	}
+}
+
+func TestEnsureFileServeable_CopiesFromImageOutputDir(t *testing.T) {
+	filesDir := t.TempDir()
+	outputDir := t.TempDir()
+	generatedImg := filepath.Join(outputDir, "generated.png")
+	if err := os.WriteFile(generatedImg, []byte("image-data"), 0644); err != nil {
+		t.Fatalf("write generated image: %v", err)
+	}
+
+	srv := &serveServer{
+		cfg:    serveServerConfig{basePath: "/ui", filesDir: filesDir},
+		cfgRef: &config.Config{},
+	}
+	srv.cfgRef.Image.OutputDir = outputDir
+
+	result, ok := srv.ensureFileServeable(generatedImg)
+	if !ok {
+		t.Fatal("ensureFileServeable should allow files from image output dir")
+	}
+	if result == generatedImg {
+		t.Fatal("image output file should have been copied into filesDir")
+	}
+	absResult, err := filepath.EvalSymlinks(result)
+	if err != nil {
+		t.Fatalf("resolve copied file: %v", err)
+	}
+	absFilesDir, err := filepath.EvalSymlinks(filesDir)
+	if err != nil {
+		t.Fatalf("resolve files dir: %v", err)
+	}
 	if !strings.HasPrefix(absResult, absFilesDir+string(filepath.Separator)) {
 		t.Fatalf("copied file %q should be under files dir %q", absResult, absFilesDir)
 	}
@@ -2599,24 +2626,8 @@ func TestEnsureFileServeable_CopiesExternalFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read copied file: %v", err)
 	}
-	if string(data) != "pdf-data" {
-		t.Fatalf("copied data = %q, want %q", string(data), "pdf-data")
-	}
-
-	// Internal file should be returned as-is
-	result, ok = srv.ensureFileServeable(internalFile)
-	if !ok {
-		t.Fatal("ensureFileServeable should succeed for internal file")
-	}
-	if result != internalFile {
-		t.Fatalf("internal file should be unchanged, got %q want %q", result, internalFile)
-	}
-
-	// No files-dir → fails
-	srv2 := &serveServer{cfg: serveServerConfig{basePath: "/ui"}}
-	_, ok = srv2.ensureFileServeable(externalFile)
-	if ok {
-		t.Fatal("ensureFileServeable should fail when filesDir is empty")
+	if string(data) != "image-data" {
+		t.Fatalf("copied data = %q, want %q", string(data), "image-data")
 	}
 }
 


### PR DESCRIPTION
## What

- stop `ensureImageServeable` from copying arbitrary tool-reported image paths into the web-served image directory
- tighten `ensureFileServeable` so it only republishes files already inside the configured files dir or the configured image output dir
- canonicalize paths with symlink resolution before validating containment, and add regression coverage for rejected external paths plus the allowed image-output-dir copy path

## Why

Tool results should not be able to turn an arbitrary readable host path into a `/files` or `/images` URL. This change closes that local-file disclosure path while preserving the intended serve flow for generated images that originate from the configured image output directory.

Note: `go build ./...` passes. `go test ./...` still hits a pre-existing unrelated failure in `internal/serveui` (`TestStaticAssetsSupportEffortDropdown`).
