### PR TITLE
fix: Claude multimodal support leaks temporary image files indefinitely

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -60,6 +60,11 @@ type ClaudeBinProvider struct {
 	// currentEvents is kept for fallback/direct execution paths.
 	currentEvents chan<- Event
 	eventsMu      sync.Mutex
+
+	// tempFiles tracks image files materialised for Claude CLI prompts/tool results
+	// so they can be removed when the current turn finishes.
+	tempFiles   []string
+	tempFilesMu sync.Mutex
 }
 
 type claudeToolRequest struct {
@@ -231,6 +236,8 @@ func (p *ClaudeBinProvider) Capabilities() Capabilities {
 
 func (p *ClaudeBinProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+		defer p.cleanupTempFiles()
+
 		// Build the command arguments, passing events channel for tool execution routing.
 		// MCP server is kept alive across turns - caller should call CleanupMCP() when done.
 		args, effort := p.buildArgs(ctx, req, send)
@@ -880,6 +887,7 @@ func (p *ClaudeBinProvider) CleanupMCP() {
 		os.Remove(p.mcpConfigPath)
 		p.mcpConfigPath = ""
 	}
+	p.cleanupTempFiles()
 }
 
 // createHTTPMCPConfig starts an HTTP MCP server and creates a config file pointing to it.
@@ -1077,7 +1085,7 @@ func (p *ClaudeBinProvider) buildConversationPrompt(messages []Message) string {
 					// base64 data into a temp file so Claude CLI can read the image.
 					path := part.ImagePath
 					if path == "" && part.ImageData != nil && part.ImageData.Base64 != "" {
-						path = imageDataToTempFile(part.ImageData.MediaType, part.ImageData.Base64)
+						path = p.imageDataToTempFile(part.ImageData.MediaType, part.ImageData.Base64)
 					}
 					if path != "" {
 						userParts = append(userParts, path)
@@ -1176,7 +1184,7 @@ func (p *ClaudeBinProvider) processToolResultContent(result *ToolResult) string 
 			if !ok {
 				continue
 			}
-			path := imageDataToTempFile(mediaType, base64Data)
+			path := p.imageDataToTempFile(mediaType, base64Data)
 			if path != "" {
 				parts = append(parts, path)
 			}
@@ -1189,8 +1197,8 @@ func (p *ClaudeBinProvider) processToolResultContent(result *ToolResult) string 
 }
 
 // imageDataToTempFile decodes base64 image data, writes it to a temporary file,
-// and returns the file path. Returns empty string on any error.
-func imageDataToTempFile(mediaType, base64Data string) string {
+// tracks it for cleanup, and returns the file path. Returns empty string on any error.
+func (p *ClaudeBinProvider) imageDataToTempFile(mediaType, base64Data string) string {
 	raw, err := base64.StdEncoding.DecodeString(base64Data)
 	if err != nil {
 		return ""
@@ -1205,7 +1213,30 @@ func imageDataToTempFile(mediaType, base64Data string) string {
 		os.Remove(f.Name())
 		return ""
 	}
-	return f.Name()
+	return p.trackTempFile(f.Name())
+}
+
+func (p *ClaudeBinProvider) trackTempFile(path string) string {
+	if path == "" {
+		return ""
+	}
+	p.tempFilesMu.Lock()
+	p.tempFiles = append(p.tempFiles, path)
+	p.tempFilesMu.Unlock()
+	return path
+}
+
+func (p *ClaudeBinProvider) cleanupTempFiles() {
+	p.tempFilesMu.Lock()
+	paths := p.tempFiles
+	p.tempFiles = nil
+	p.tempFilesMu.Unlock()
+
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.Warn("claude-bin failed to remove temp image file", "path", path, "err", err)
+		}
+	}
 }
 
 // mediaTypeToExt maps an image MIME type to a file extension.

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -66,6 +66,24 @@ func TestClaudeBinProvider_CleanupMCP_Safe(t *testing.T) {
 	provider.CleanupMCP()
 }
 
+func TestClaudeBinProvider_CleanupMCP_RemovesTrackedTempFiles(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+
+	path := provider.imageDataToTempFile("image/png", "aGVsbG8=")
+	if path == "" {
+		t.Fatal("expected temp file path")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected temp file to exist before cleanup: %v", err)
+	}
+
+	provider.CleanupMCP()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected temp file to be removed, got err=%v", err)
+	}
+}
+
 func TestSafeSendEvent_ClosedChannel(t *testing.T) {
 	// Test that safeSendEvent doesn't panic on closed channel
 	ch := make(chan Event)


### PR DESCRIPTION
## What

Track Claude CLI temp image files created from multimodal prompt/tool-result data and remove them when the turn or provider session finishes.

## Why

Without cleanup, every uploaded image or tool-result image materialized into `/tmp` is leaked indefinitely. Repeated multimodal use can eventually exhaust disk space and break later requests.
