### PR TITLE
feat: leave no shell-tool descendants behind + make web Stop button responsive

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -904,7 +904,11 @@ if (elements.voiceBtn) {
   });
 }
 elements.stopBtn.addEventListener('click', async () => {
+  if (elements.stopBtn.disabled) return;
   const session = getActiveSession();
+  const originalLabel = elements.stopBtn.textContent;
+  elements.stopBtn.disabled = true;
+  elements.stopBtn.textContent = 'Stopping\u2026';
   try {
     await cancelActiveResponse(session);
   } catch (err) {
@@ -915,6 +919,9 @@ elements.stopBtn.addEventListener('click', async () => {
     if (state.abortController) {
       state.abortController.abort();
     }
+  } finally {
+    elements.stopBtn.disabled = false;
+    elements.stopBtn.textContent = originalLabel || 'Stop';
   }
 });
 

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -840,18 +840,26 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
 
 const cancelActiveResponse = async (session) => {
   const responseId = String(session?.activeResponseId || state.currentStreamResponseId || '').trim();
+
+  // Instant UI feedback: tear down the local stream before the server POST.
+  // If the run is blocked in a tool (e.g. a shell tool hung on cmd.Wait),
+  // the /cancel POST can take seconds to return. Aborting the reader here
+  // makes Stop feel responsive; the POST below still drives the
+  // authoritative server-side cancel.
+  state.expectCanceledRun = true;
+  if (state.abortController) {
+    state.abortController.abort();
+  }
+  setConnectionState('Cancelling\u2026');
+
   if (!responseId) {
     console.warn('[cancel] no responseId available, aborting local controller only');
-    if (state.abortController) {
-      state.abortController.abort();
-    }
     if (session?.id) {
       await refreshSessionFromServerTruth(session, true);
     }
     return;
   }
 
-  state.expectCanceledRun = true;
   let response;
   try {
     response = await fetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/cancel`, {

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -75,6 +75,9 @@ function createHarness(options = {}) {
   const responseId = options.responseId || 'resp_test';
   const postBody = String(options.postBody || '');
   const eventsKeepOpen = Boolean(options.eventsKeepOpen);
+  const cancelDelayMs = Math.max(0, Number(options.cancelDelayMs || 0));
+  let cancelRequested = false;
+  let cancelResolve = null;
   const eventsBody = String(options.eventsBody || [
     'id: 1\n',
     'event: response.created\n',
@@ -199,6 +202,7 @@ function createHarness(options = {}) {
     expectCanceledRun: false,
   };
 
+  const connectionStates = [];
   const app = {
     UI_PREFIX: '/ui',
     STORAGE_KEYS: {
@@ -236,7 +240,7 @@ function createHarness(options = {}) {
     },
     findMessageElement() { return null; },
     scrollToBottom() {},
-    setConnectionState() {},
+    setConnectionState: (text) => { connectionStates.push(String(text || '')); },
     sessionSlug(s) { return s ? s.id : ''; },
     updateURL() {},
     persistAndRefreshShell() {},
@@ -355,6 +359,19 @@ function createHarness(options = {}) {
         headers: { 'x-response-id': responseId },
       });
     }
+    if (url === `/ui/v1/responses/${responseId}/cancel`) {
+      cancelRequested = true;
+      if (cancelDelayMs > 0) {
+        await new Promise((resolve) => {
+          cancelResolve = resolve;
+          setTimeout(resolve, cancelDelayMs);
+        });
+      }
+      return new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
     if (url.startsWith(`/ui/v1/responses/${responseId}/events?after=`)) {
       getEventsStarted = true;
       const signal = options.signal || null;
@@ -392,6 +409,15 @@ function createHarness(options = {}) {
     localStorage,
     getEventsStarted: () => getEventsStarted,
     postStreamCanceled: () => postStreamCanceled,
+    connectionStates,
+    getCancelRequested: () => cancelRequested,
+    releaseCancel: () => {
+      if (cancelResolve) {
+        const r = cancelResolve;
+        cancelResolve = null;
+        r();
+      }
+    },
     closeEventsStream: () => {
       if (eventsStreamController) {
         try { eventsStreamController.close(); } catch (_err) { /* ignore */ }
@@ -774,6 +800,54 @@ async function testConnectTokenPreservesSelectedModelAndProviderFromState() {
   pass(name);
 }
 
+async function testCancelActiveResponseTearsDownLocallyBeforeServerPost() {
+  const name = 'cancelActiveResponse aborts local stream and shows Cancelling pill before /cancel POST returns';
+  const harness = createHarness({ cancelDelayMs: 60000 });
+  const { app, state, connectionStates, getCancelRequested, releaseCancel, cleanup } = harness;
+
+  const controller = new AbortController();
+  state.abortController = controller;
+  state.currentStreamResponseId = 'resp_test';
+  const session = { id: 'session_1', activeResponseId: 'resp_test' };
+  state.sessions = [session];
+  state.activeSessionId = session.id;
+  app.scheduleSessionStatePoll = () => {};
+  app.syncActiveSessionFromServer = async () => {};
+  app.refreshSessionFromServerTruth = async () => {};
+
+  const cancelPromise = app.cancelActiveResponse(session);
+
+  if (!controller.signal.aborted) {
+    fail(name, 'abortController was not aborted synchronously');
+    releaseCancel();
+    await cancelPromise.catch(() => {});
+    await cleanup();
+    return;
+  }
+
+  if (!connectionStates.includes('Cancelling\u2026')) {
+    fail(name, 'expected "Cancelling\u2026" connection state after click', JSON.stringify(connectionStates));
+    releaseCancel();
+    await cancelPromise.catch(() => {});
+    await cleanup();
+    return;
+  }
+
+  const postStarted = await waitFor(() => getCancelRequested(), 75);
+  if (!postStarted) {
+    fail(name, 'cancel POST was never issued');
+    releaseCancel();
+    await cancelPromise.catch(() => {});
+    await cleanup();
+    return;
+  }
+
+  releaseCancel();
+  await cancelPromise;
+  await cleanup();
+  pass(name);
+}
+
 (async () => {
   await testSendMessageHandsOffToEventsStream();
   await testSendMessageIgnoresPostBodyAfterHandoff();
@@ -781,6 +855,7 @@ async function testConnectTokenPreservesSelectedModelAndProviderFromState() {
   await testSendMessageMarksSessionBusyImmediately();
   await testDrainInterruptQueueAfterResumeCompletes();
   await testConnectTokenPreservesSelectedModelAndProviderFromState();
+  await testCancelActiveResponseTearsDownLocallyBeforeServerPost();
 
   if (failures > 0) {
     console.error(`\n${failures} test(s) failed`);

--- a/internal/tools/exec_helpers.go
+++ b/internal/tools/exec_helpers.go
@@ -2,15 +2,25 @@ package tools
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/gobwas/glob"
 	"github.com/samsaffron/term-llm/internal/pathutil"
 )
+
+// shellNonceEnvVar is the environment variable name used to tag every process
+// spawned by a tool command so descendants that escape the process group (via
+// setsid, daemonisation, etc.) can still be reliably reaped on cleanup.
+const shellNonceEnvVar = "TERMLLM_SHELL_NONCE"
 
 type limitedBuffer struct {
 	buf   bytes.Buffer
@@ -49,20 +59,103 @@ func (b *limitedBuffer) Truncated() bool {
 }
 
 func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
+	var stdinCloser func()
 	if cmd.Stdin == nil {
-		devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
-		if err == nil {
+		if devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0); err == nil {
 			cmd.Stdin = devNull
-			cleanup := func() {
-				_ = devNull.Close()
-			}
-			configureCommandProcessGroup(cmd)
-			return cleanup, nil
+			stdinCloser = func() { _ = devNull.Close() }
 		}
 	}
 
 	configureCommandProcessGroup(cmd)
-	return func() {}, nil
+	nonce := tagCommandWithNonce(cmd)
+
+	cleanup := func() {
+		// Tools must leave the world clean: after the command returns (success,
+		// failure, timeout, or cancellation) reap every descendant it spawned.
+		//
+		// First pass: SIGKILL the process group so `nohup foo &` style children
+		// that stayed in our pgid die immediately.
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		// Second pass: walk /proc for any process still alive that inherited
+		// the nonce env var. This catches descendants that escaped the pgroup
+		// via setsid, double-fork daemonisation, or explicit setpgid. We retry
+		// a few times because a process may be mid-exec when we scan.
+		if nonce != "" {
+			killTaggedDescendants(nonce)
+		}
+		if stdinCloser != nil {
+			stdinCloser()
+		}
+	}
+	return cleanup, nil
+}
+
+// tagCommandWithNonce adds a unique TERMLLM_SHELL_NONCE=<hex> entry to cmd.Env
+// so descendants can be identified later by scanning /proc. Returns the nonce
+// value, or "" if it could not be generated (in which case tagging is silently
+// skipped — the pgroup kill still runs).
+func tagCommandWithNonce(cmd *exec.Cmd) string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return ""
+	}
+	nonce := hex.EncodeToString(buf[:])
+	entry := shellNonceEnvVar + "=" + nonce
+	if cmd.Env == nil {
+		cmd.Env = append(os.Environ(), entry)
+	} else {
+		cmd.Env = append(cmd.Env, entry)
+	}
+	return nonce
+}
+
+// killTaggedDescendants SIGKILLs every process whose environment contains the
+// given nonce. Safe no-op on systems without /proc (e.g. macOS in tests).
+// We retry a handful of times with short sleeps to handle races where a
+// descendant forks right as we scan.
+func killTaggedDescendants(nonce string) {
+	needle := []byte(shellNonceEnvVar + "=" + nonce)
+	for attempt := 0; attempt < 3; attempt++ {
+		pids := findPidsWithEnv(needle)
+		if len(pids) == 0 {
+			return
+		}
+		for _, pid := range pids {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// findPidsWithEnv returns PIDs whose /proc/<pid>/environ contains needle.
+// On systems without /proc, returns nil.
+func findPidsWithEnv(needle []byte) []int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	selfPid := os.Getpid()
+	var pids []int
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 1 || pid == selfPid {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "environ"))
+		if err != nil {
+			continue
+		}
+		if bytes.Contains(data, needle) {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
 }
 
 // PrepareCommand configures a command for safe cancellation, including process-group teardown.
@@ -72,6 +165,11 @@ func PrepareCommand(cmd *exec.Cmd) (func(), error) {
 
 func configureCommandProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// WaitDelay unblocks cmd.Wait() when the main process has exited but a
+	// backgrounded descendant still holds the stdout/stderr pipe open. After
+	// the delay Go closes the pipes and returns from Wait, preventing the
+	// tool from hanging indefinitely.
+	cmd.WaitDelay = 2 * time.Second
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil

--- a/internal/tools/shell_leak_repro_test.go
+++ b/internal/tools/shell_leak_repro_test.go
@@ -1,0 +1,103 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestShellTool_BackgroundedChildKilled pins down the session-1708 behaviour:
+// an LLM-issued `nohup foo &` must not leave an orphan process alive after
+// the shell tool returns. The tool call is cancelled mid-flight and the
+// grandchild must be reaped regardless.
+func TestShellTool_BackgroundedChildKilled(t *testing.T) {
+	sentinel := uniqueSentinel(t, "bg")
+	logPath := fmt.Sprintf("/tmp/%s.log", sentinel)
+	defer os.Remove(logPath)
+
+	tool := NewShellTool(nil, nil, DefaultOutputLimits())
+	cmd := fmt.Sprintf(
+		"nohup bash -c 'sleep 120; :%s' >%s 2>&1 & echo pid=$! && sleep 0.1",
+		sentinel, logPath,
+	)
+	runAndAssertReaped(t, tool, cmd, sentinel, true /* cancelMidway */)
+}
+
+// TestShellTool_SetsidDescendantKilled covers the nastier case: a descendant
+// that detaches from the process group via `setsid`. The pgroup kill can't
+// reach it, so cleanup falls back to /proc env scanning by nonce.
+func TestShellTool_SetsidDescendantKilled(t *testing.T) {
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid not available on this platform")
+	}
+	if _, err := os.Stat("/proc/self/environ"); err != nil {
+		t.Skip("no /proc — nonce-based descendant reap is Linux-only")
+	}
+
+	sentinel := uniqueSentinel(t, "setsid")
+	logPath := fmt.Sprintf("/tmp/%s.log", sentinel)
+	defer os.Remove(logPath)
+
+	tool := NewShellTool(nil, nil, DefaultOutputLimits())
+	// setsid detaches the child into its own session + pgroup, so our
+	// first-pass SIGKILL -pgid can't find it. The nonce scan is what saves us.
+	cmd := fmt.Sprintf(
+		"setsid bash -c 'sleep 120; :%s' >%s 2>&1 < /dev/null & echo pid=$! && sleep 0.1",
+		sentinel, logPath,
+	)
+	runAndAssertReaped(t, tool, cmd, sentinel, false /* natural completion */)
+}
+
+func uniqueSentinel(t *testing.T, tag string) string {
+	t.Helper()
+	return fmt.Sprintf("term-llm-leak-%s-%d-%d", tag, os.Getpid(), time.Now().UnixNano())
+}
+
+func runAndAssertReaped(t *testing.T, tool *ShellTool, command, sentinel string, cancelMidway bool) {
+	t.Helper()
+	args := mustMarshalShellArgs(ShellArgs{
+		Command:        command,
+		TimeoutSeconds: 5,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	var output string
+	go func() {
+		out, err := tool.Execute(ctx, args)
+		if err != nil {
+			t.Errorf("unexpected err: %v", err)
+		}
+		output = out.Content
+		close(done)
+	}()
+
+	if cancelMidway {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		_ = exec.Command("pkill", "-f", sentinel).Run()
+		t.Fatal("shell Execute did not return within 10s")
+	}
+
+	// Give cleanup a moment to complete.
+	time.Sleep(250 * time.Millisecond)
+
+	found, _ := exec.Command("pgrep", "-f", sentinel).Output()
+	stray := strings.TrimSpace(string(found))
+	if stray != "" {
+		_ = exec.Command("pkill", "-f", sentinel).Run()
+		t.Fatalf("descendant sentinel process still alive after shell returned:\n  pgrep -f %s -> %q\n  tool output: %s",
+			sentinel, stray, output)
+	}
+}


### PR DESCRIPTION
Two independent bugs that compounded on the stuck session 1708 to make the tab feel completely frozen.

## 1. Shell tool left descendants alive, hanging `cmd.Wait()` forever

Shell-family tools (`shell`, `run_agent_script`, `custom_tool`) now aggressively reap every descendant they spawn when the command returns — success, failure, timeout, or cancellation.

Three changes, all in `internal/tools/exec_helpers.go`:

1. **`cmd.WaitDelay = 2s`** so `cmd.Wait()` stops blocking when the main process has exited but a backgrounded descendant still holds the stdout/stderr pipe open. Go force-closes the inherited pipes after the delay.
2. **First-pass: `SIGKILL -pgid`** on cleanup. Reaps `nohup foo &` style children that stayed in our process group.
3. **Second-pass: nonce-based `/proc` scan.** Every tool command gets tagged with a unique `TERMLLM_SHELL_NONCE=<hex>` env var. On cleanup we walk `/proc/<pid>/environ` and SIGKILL any survivor carrying the nonce, with a short retry loop to catch mid-fork races. This catches descendants that escaped the pgroup via `setsid`, double-fork daemonisation, or explicit `setpgid`.

**Why it mattered:** an LLM-issued `nohup python … &` left a grandchild holding stdout open, so `cmd.Wait()` blocked indefinitely — no `tool_result` ever emitted, session wedged with an orphan `tool_call`, and every follow-up rejected by the model API. The existing pgroup-kill-on-timeout logic worked only on the *timeout* path and couldn't reach detached descendants. Timeouts are timeouts: the shell tool must leave the world clean.

**Tests:** new `internal/tools/shell_leak_repro_test.go`:
- `TestShellTool_BackgroundedChildKilled` — `nohup bash -c 'sleep 120; :SENTINEL' &`, cancel mid-flight, assert `pgrep -f SENTINEL` is empty afterwards.
- `TestShellTool_SetsidDescendantKilled` — `setsid bash -c 'sleep 120; :SENTINEL' & …`, let the tool return naturally, assert no survivor. Linux-only.

Both tests fail against `main` and pass with this patch. Existing `*_TimeoutKillsGrandchildren` tests in `shell_test.go`, `run_agent_script_test.go`, and `custom_tool_test.go` continue to pass.

## 2. Web UI Stop button did nothing visible until cancel POST returned

`stopBtn` click handler `await`ed `POST /v1/responses/{id}/cancel` before changing any pixel on screen. When the server was blocked in the above leak, that await could take seconds, so the user clicked Stop and saw nothing change — button still active, streaming indicator still spinning.

Fix (frontend-only, `internal/serveui/static/`):

- `stopBtn` click handler: disable the button and swap its label to "Stopping…" synchronously on click; restore in `finally`.
- `cancelActiveResponse`: abort the local `AbortController` and set a "Cancelling…" connection-state pill *before* issuing the `/cancel` POST. The POST still drives authoritative server-side state; the local teardown just stops the UI from waiting on it.

**Test:** new `testCancelActiveResponseTearsDownLocallyBeforeServerPost` in `app_stream_test.js` uses a 60-second-delayed `/cancel` fetch and asserts the abort + pill both happen before the POST completes.

---

Full `go test ./...` green. `app_stream_test.js` green.
