### PR TITLE
feat: ChatGPT auth — print URL fallback and honor Ctrl-C

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/credentials"
 	"github.com/samsaffron/term-llm/internal/oauth"
+	"github.com/samsaffron/term-llm/internal/signal"
 	"golang.org/x/term"
 )
 
@@ -99,7 +100,11 @@ func promptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// Wire Ctrl-C through to the OAuth wait so the user can cancel
+	// while we're blocked waiting for the browser callback.
+	sigCtx, stopSig := signal.NotifyContext()
+	defer stopSig()
+	ctx, cancel := context.WithTimeout(sigCtx, 5*time.Minute)
 	defer cancel()
 
 	oauthCreds, err := oauth.AuthenticateChatGPT(ctx)

--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/credentials"
 	"github.com/samsaffron/term-llm/internal/oauth"
+	"github.com/samsaffron/term-llm/internal/signal"
 	"golang.org/x/term"
 )
 
@@ -135,7 +136,11 @@ func promptForCopilotAuth() (*credentials.CopilotCredentials, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// Wire Ctrl-C through to the OAuth wait so the user can cancel
+	// while we're polling for the device-code grant.
+	sigCtx, stopSig := signal.NotifyContext()
+	defer stopSig()
+	ctx, cancel := context.WithTimeout(sigCtx, 5*time.Minute)
 	defer cancel()
 
 	oauthCreds, err := oauth.AuthenticateCopilot(ctx)

--- a/internal/oauth/chatgpt.go
+++ b/internal/oauth/chatgpt.go
@@ -321,9 +321,13 @@ func AuthenticateChatGPT(ctx context.Context) (*ChatGPTCredentials, error) {
 
 	defer server.Shutdown(context.Background())
 
-	// Open browser
+	// Always print the URL so the user has a fallback if the browser
+	// doesn't actually open (e.g. headless container, xdg-open returning
+	// success with no DISPLAY, remote SSH session).
+	fmt.Printf("\nIf your browser does not open automatically, visit this URL to sign in:\n\n  %s\n\n", authURL)
+
 	if err := openBrowser(authURL); err != nil {
-		fmt.Printf("Could not open browser. Please visit this URL:\n%s\n", authURL)
+		fmt.Printf("(Could not launch browser automatically: %v)\n", err)
 	}
 
 	// Wait for callback or timeout


### PR DESCRIPTION
## What

Two small fixes to the ChatGPT (and Copilot) auth UX so it degrades sanely on headless/SSH/no-DISPLAY boxes.

### 1. Always print the auth URL as a console fallback

Today we try `xdg-open` / `open` / `rundll32` and only print the URL if the command returns an error. That's insufficient:

- Headless containers / remote SSH — `xdg-open` exits 0 but no browser opens.
- No `DISPLAY` set — same silent failure.
- Anywhere the OS "successfully" hands the URL to a broken or missing handler.

In those cases the user saw `ChatGPT provider requires authentication.` followed by a hang with no URL to visit. The Copilot device-code flow already prints its URL unconditionally; this brings ChatGPT to parity.

Before:
```
ChatGPT provider requires authentication.
Press Enter to open browser and sign in with your ChatGPT account...
<hang — no URL shown>
```

After:
```
ChatGPT provider requires authentication.
Press Enter to open browser and sign in with your ChatGPT account...

If your browser does not open automatically, visit this URL to sign in:

  https://auth.openai.com/oauth/authorize?...

```

### 2. Ctrl-C now cancels the OAuth wait

`promptForChatGPTAuth` / `promptForCopilotAuth` built their 5-minute wait from `context.Background()` with no signal wiring, so once the user pressed Enter to start the flow, Ctrl-C was ignored until the 5-minute timeout elapsed.

Use `signal.NotifyContext()` (the project helper that already exists) as the parent. The existing `<-ctx.Done()` branches in `AuthenticateChatGPT` / `AuthenticateCopilot` then handle the cancel immediately.

## Files

- `internal/oauth/chatgpt.go` — print URL unconditionally
- `internal/llm/chatgpt.go` — signal-aware ctx
- `internal/llm/copilot.go` — signal-aware ctx
