### PR TITLE
feat: prefer device-code flow for ChatGPT sign-in

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -85,7 +86,10 @@ func NewChatGPTProviderWithCreds(creds *credentials.ChatGPTCredentials, model st
 	}
 }
 
-// promptForChatGPTAuth prompts the user to authenticate with ChatGPT
+// promptForChatGPTAuth prompts the user to authenticate with ChatGPT.
+// Prefers the device-code flow so auth works on headless/remote/containerized
+// boxes; falls back to the localhost browser flow if the backend doesn't
+// advertise device-code support.
 func promptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 	// Check if stdin is a terminal - if not, we can't do interactive auth
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -94,39 +98,63 @@ func promptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 	}
 
 	fmt.Println("ChatGPT provider requires authentication.")
-	fmt.Print("Press Enter to open browser and sign in with your ChatGPT account...")
 
-	if err := waitForEnterOrInterrupt(); err != nil {
-		return nil, err
-	}
-
-	// Wire Ctrl-C through to the OAuth wait so the user can cancel
-	// while we're blocked waiting for the browser callback.
+	// Wire Ctrl-C through to the full auth wait (device-code poll OR
+	// browser callback). The 15-minute cap matches the server-side
+	// device-code expiry.
 	sigCtx, stopSig := signal.NotifyContext()
 	defer stopSig()
-	ctx, cancel := context.WithTimeout(sigCtx, 5*time.Minute)
+	ctx, cancel := context.WithTimeout(sigCtx, 15*time.Minute)
 	defer cancel()
 
-	oauthCreds, err := oauth.AuthenticateChatGPT(ctx)
+	oauthCreds, err := runChatGPTDeviceCodeFlow(ctx)
+	if errors.Is(err, oauth.ErrChatGPTDeviceCodeNotEnabled) {
+		fmt.Println("(device-code login unavailable — falling back to browser flow)")
+		oauthCreds, err = runChatGPTBrowserFlow(ctx)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("authentication failed: %w", err)
 	}
 
-	// Convert oauth credentials to stored credentials format
 	creds := &credentials.ChatGPTCredentials{
 		AccessToken:  oauthCreds.AccessToken,
 		RefreshToken: oauthCreds.RefreshToken,
 		ExpiresAt:    oauthCreds.ExpiresAt,
 		AccountID:    oauthCreds.AccountID,
 	}
-
-	// Save credentials
 	if err := credentials.SaveChatGPTCredentials(creds); err != nil {
 		return nil, fmt.Errorf("failed to save credentials: %w", err)
 	}
 
 	fmt.Println("Authentication successful!")
 	return creds, nil
+}
+
+func runChatGPTDeviceCodeFlow(ctx context.Context) (*oauth.ChatGPTCredentials, error) {
+	dc, err := oauth.RequestChatGPTDeviceCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("\nTo sign in with ChatGPT:\n")
+	fmt.Printf("  1. Open this URL in any browser: %s\n", dc.VerificationURL)
+	fmt.Printf("  2. Enter this one-time code:     %s\n\n", dc.UserCode)
+	fmt.Print("Waiting for approval (Ctrl-C to cancel)...")
+
+	creds, err := oauth.AuthenticateChatGPTDevice(ctx, dc)
+	if err != nil {
+		fmt.Println()
+		return nil, err
+	}
+	fmt.Println(" done!")
+	return creds, nil
+}
+
+func runChatGPTBrowserFlow(ctx context.Context) (*oauth.ChatGPTCredentials, error) {
+	fmt.Print("Press Enter to open browser and sign in with your ChatGPT account...")
+	if err := waitForEnterOrInterrupt(); err != nil {
+		return nil, err
+	}
+	return oauth.AuthenticateChatGPT(ctx)
 }
 
 func (p *ChatGPTProvider) Name() string {

--- a/internal/oauth/chatgpt_device.go
+++ b/internal/oauth/chatgpt_device.go
@@ -1,0 +1,268 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// The device code flow talks to OpenAI's /deviceauth endpoints. It is
+// the same flow codex uses for headless/remote sign-in — no local
+// callback server, no browser redirect to localhost, just a URL + code
+// the user visits on any device.
+const (
+	ChatGPTDeviceAuthBaseURL     = "https://auth.openai.com/api/accounts"
+	ChatGPTDeviceVerificationURL = "https://auth.openai.com/codex/device"
+	ChatGPTDeviceRedirectURI     = "https://auth.openai.com/deviceauth/callback"
+)
+
+// ErrChatGPTDeviceCodeNotEnabled is returned when the backend does not
+// advertise device-code login (HTTP 404). Callers should fall back to
+// the interactive browser flow.
+var ErrChatGPTDeviceCodeNotEnabled = errors.New("chatgpt device code login is not enabled")
+
+// ChatGPTDeviceCode is the user-facing output of the usercode request.
+type ChatGPTDeviceCode struct {
+	VerificationURL string
+	UserCode        string
+
+	deviceAuthID string
+	interval     time.Duration
+}
+
+type deviceUserCodeResp struct {
+	DeviceAuthID string `json:"device_auth_id"`
+	UserCode     string `json:"user_code"`
+	// The server has been observed returning interval as a string in
+	// some deployments — accept either representation.
+	Interval json.RawMessage `json:"interval"`
+}
+
+type deviceCodeSuccessResp struct {
+	AuthorizationCode string `json:"authorization_code"`
+	CodeChallenge     string `json:"code_challenge"`
+	CodeVerifier      string `json:"code_verifier"`
+}
+
+// RequestChatGPTDeviceCode asks OpenAI for a new device-auth pair.
+// Returns ErrChatGPTDeviceCodeNotEnabled when the server returns 404.
+func RequestChatGPTDeviceCode(ctx context.Context) (*ChatGPTDeviceCode, error) {
+	body, err := json.Marshal(map[string]string{"client_id": ChatGPTClientID})
+	if err != nil {
+		return nil, fmt.Errorf("encode usercode request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		ChatGPTDeviceAuthBaseURL+"/deviceauth/usercode",
+		strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("build usercode request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("usercode request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrChatGPTDeviceCodeNotEnabled
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("usercode request returned status %s", resp.Status)
+	}
+
+	var parsed deviceUserCodeResp
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode usercode response: %w", err)
+	}
+	if parsed.DeviceAuthID == "" || parsed.UserCode == "" {
+		return nil, fmt.Errorf("usercode response missing required fields")
+	}
+
+	interval, err := parseDeviceInterval(parsed.Interval)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChatGPTDeviceCode{
+		VerificationURL: ChatGPTDeviceVerificationURL,
+		UserCode:        parsed.UserCode,
+		deviceAuthID:    parsed.DeviceAuthID,
+		interval:        interval,
+	}, nil
+}
+
+// parseDeviceInterval decodes the usercode "interval" field, which the
+// server may return as a JSON number or a JSON string. Falls back to 5s
+// when unset or zero — matches codex's behavior.
+func parseDeviceInterval(raw json.RawMessage) (time.Duration, error) {
+	const fallback = 5 * time.Second
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return fallback, nil
+	}
+	if strings.HasPrefix(trimmed, "\"") {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return 0, fmt.Errorf("decode interval string: %w", err)
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return fallback, nil
+		}
+		n, err := strconv.ParseUint(s, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("parse interval string: %w", err)
+		}
+		if n == 0 {
+			return fallback, nil
+		}
+		return time.Duration(n) * time.Second, nil
+	}
+	var n uint64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, fmt.Errorf("decode interval number: %w", err)
+	}
+	if n == 0 {
+		return fallback, nil
+	}
+	return time.Duration(n) * time.Second, nil
+}
+
+// pollForDeviceToken blocks until the user approves the code or ctx is
+// cancelled / the device code expires (server-side, ~15 minutes).
+func pollForDeviceToken(ctx context.Context, dc *ChatGPTDeviceCode) (*deviceCodeSuccessResp, error) {
+	body, err := json.Marshal(map[string]string{
+		"device_auth_id": dc.deviceAuthID,
+		"user_code":      dc.UserCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode token poll request: %w", err)
+	}
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, "POST",
+			ChatGPTDeviceAuthBaseURL+"/deviceauth/token",
+			strings.NewReader(string(body)))
+		if err != nil {
+			return nil, fmt.Errorf("build token poll request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := oauthHTTPClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("token poll request failed: %w", err)
+		}
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var parsed deviceCodeSuccessResp
+			if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+				resp.Body.Close()
+				return nil, fmt.Errorf("decode token poll response: %w", err)
+			}
+			resp.Body.Close()
+			return &parsed, nil
+
+		case http.StatusForbidden, http.StatusNotFound:
+			// Still waiting for user approval.
+			resp.Body.Close()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(dc.interval):
+			}
+
+		default:
+			status := resp.Status
+			resp.Body.Close()
+			return nil, fmt.Errorf("device auth poll failed: %s", status)
+		}
+	}
+}
+
+// exchangeDeviceCodeForTokens performs the final /oauth/token call,
+// using the authorization_code + code_verifier returned by the poll
+// endpoint. The redirect_uri must match what the auth server expects
+// for device flow (auth.openai.com/deviceauth/callback), not the
+// localhost URI used by the browser flow.
+func exchangeDeviceCodeForTokens(ctx context.Context, resp *deviceCodeSuccessResp) (*ChatGPTTokenResponse, error) {
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {ChatGPTClientID},
+		"code":          {resp.AuthorizationCode},
+		"redirect_uri":  {ChatGPTDeviceRedirectURI},
+		"code_verifier": {resp.CodeVerifier},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", ChatGPTTokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build device token exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpResp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device token exchange request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		json.NewDecoder(httpResp.Body).Decode(&errResp)
+		if errResp.ErrorDescription != "" {
+			return nil, fmt.Errorf("device token exchange failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+		}
+		return nil, fmt.Errorf("device token exchange failed: %s", httpResp.Status)
+	}
+
+	var tokenResp ChatGPTTokenResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("decode device token response: %w", err)
+	}
+	return &tokenResp, nil
+}
+
+// AuthenticateChatGPTDevice runs the full device-code OAuth flow. The
+// caller is responsible for printing the verification URL + user code
+// between RequestChatGPTDeviceCode and this call — taking a callback
+// here keeps the prompt UX out of the oauth package.
+func AuthenticateChatGPTDevice(ctx context.Context, dc *ChatGPTDeviceCode) (*ChatGPTCredentials, error) {
+	codeResp, err := pollForDeviceToken(ctx, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenResp, err := exchangeDeviceCodeForTokens(ctx, codeResp)
+	if err != nil {
+		return nil, err
+	}
+
+	accountID := ""
+	if tokenResp.IDToken != "" {
+		accountID = extractAccountIDFromJWT(tokenResp.IDToken)
+	}
+	if accountID == "" && tokenResp.AccessToken != "" {
+		accountID = extractAccountIDFromJWT(tokenResp.AccessToken)
+	}
+
+	return &ChatGPTCredentials{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresAt:    time.Now().Unix() + int64(tokenResp.ExpiresIn),
+		AccountID:    accountID,
+	}, nil
+}


### PR DESCRIPTION
## What

Replace the browser-only ChatGPT auth flow with a device-code flow as the default, keeping the old browser flow as a fallback.

Follow-up to #407 — while that made the browser flow a bit less painful on headless boxes (URL printed, Ctrl-C works), it still fundamentally requires that the user's browser can reach `localhost:1455` on the machine running term-llm. In a container, over SSH, or on any remote host, that just doesn't work — the browser hits the user's own localhost, the callback never arrives, and the user is left with a `?code=…` URL they have nowhere to paste.

## How

This mirrors the flow openai/codex already ships for the same scenario (`codex login --device-auth` / `run_login_with_device_code_fallback_to_browser`). Same OpenAI endpoints, same client_id term-llm was already reusing.

1. `POST https://auth.openai.com/api/accounts/deviceauth/usercode` with `{client_id}` → `{device_auth_id, user_code, interval}`
2. Print the verification URL (`https://auth.openai.com/codex/device`) and the one-time `user_code` to the terminal.
3. Poll `POST .../deviceauth/token` with `{device_auth_id, user_code}` every `interval` seconds. HTTP 403/404 means "still waiting"; 200 means approved and returns `{authorization_code, code_challenge, code_verifier}` (server-side PKCE).
4. Normal `POST /oauth/token` exchange with `redirect_uri=https://auth.openai.com/deviceauth/callback` to get the real `{access_token, refresh_token, id_token}` — same shape as the browser flow, so the existing refresh path is unchanged.

If the usercode endpoint returns 404 (backend says device-code isn't enabled), fall back to the existing browser flow. This matches codex's own fallback behavior.

## Why this is strictly better than browser-only

- No local port to bind (no `1455` collisions, no firewall surprises)
- No "browser on a different machine than term-llm" failure mode — the whole problem that motivated #407 disappears
- Works natively over SSH, in containers, in WSL, in tmux on a remote host
- Token shape identical → nothing else in the codebase changes

## Files

- `internal/oauth/chatgpt_device.go` — new: device-code request / poll / exchange
- `internal/llm/chatgpt.go` — prefer device-code, fall back on `ErrChatGPTDeviceCodeNotEnabled`

## Sample UX

```
ChatGPT provider requires authentication.

To sign in with ChatGPT:
  1. Open this URL in any browser: https://auth.openai.com/codex/device
  2. Enter this one-time code:     QAED-Y39VP

Waiting for approval (Ctrl-C to cancel)...
```

## Verified live

```
$ curl -X POST https://auth.openai.com/api/accounts/deviceauth/usercode \
    -H 'Content-Type: application/json' \
    -d '{"client_id":"app_EMoamEEZ73f0CkXaXp7hrann"}'
HTTP 200
{ "device_auth_id": "...", "user_code": "QAED-Y39VP", "interval": "5", "expires_at": "..." }

$ curl -X POST .../deviceauth/token -d '{"device_auth_id":"...","user_code":"QAED-Y39VP"}'
HTTP 403 — {"error":{"code":"deviceauth_authorization_unknown"}}   # still waiting, code unhandled
```

Interval is returned as a JSON string in the wild (`"5"`), not a number — parser handles both.
