### PR TITLE
fix: don't retry permanent Ollama 'unknown renderer' errors

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -287,6 +287,11 @@ func isRetryable(err error) bool {
 
 	errStr := strings.ToLower(err.Error())
 
+	// Permanent Ollama errors that look like 500s but will never succeed on retry.
+	if strings.Contains(errStr, "unknown renderer") {
+		return false
+	}
+
 	// HTTP status codes and rate limit messages
 	if strings.Contains(errStr, "429") ||
 		strings.Contains(errStr, "rate limit") ||


### PR DESCRIPTION
## What

Don't retry Ollama `unknown renderer` errors in the retry loop.

## Why

`isRetryable` treats any error containing `"500"` as a transient failure worth
retrying up to 5 times with backoff. When Ollama returns:

```
Ollama API error (status 500): {"error":{"message":"unknown renderer \"qwen3\"",...}}
```

…it means the installed Ollama version doesn't have a template renderer
registered for the Qwen3 model family. This is a permanent configuration error
— upgrading Ollama or using a different model is required. Retrying the exact
same request will always reproduce the same failure, so the 5-attempt retry
loop just burns time (up to ~30 s of backoff) for no benefit.

## How

Added an early-exit guard in `isRetryable` that returns `false` for errors
containing `"unknown renderer"` before the generic `"500"` check fires.
