### PR TITLE
fix: extract error message from JSON body on non-200 OpenAI-compat responses

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -416,7 +416,12 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, string(body))
+		errMsg := string(body)
+		var errResp oaiChatResponse
+		if json.Unmarshal(body, &errResp) == nil && errResp.Error != nil && errResp.Error.Message != "" {
+			errMsg = errResp.Error.Message
+		}
+		return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, errMsg)
 	}
 
 	// Only create async stream for successful HTTP responses


### PR DESCRIPTION
## What

When Ollama (or any OpenAI-compatible server) returns a non-200 HTTP status before streaming begins, the raw JSON error body was being dumped verbatim into the error message. For example:

```
Ollama API error (status 500): {"error":{"message":"model failed to load, this may be due to resource limitations or an internal error, check ollama server logs for details","type":"api_error","param":null,"code":null}}
```

After this fix, the human-readable message is extracted from the JSON:

```
Ollama API error (status 500): model failed to load, this may be due to resource limitations or an internal error, check ollama server logs for details
```

## Why

The streaming path in `openai_compat.go` already extracted `chatResp.Error.Message` when an error event arrived mid-stream (line 468-473), but the synchronous pre-stream error path at line 416-419 skipped that and dumped the raw JSON body. This made error messages hard to read.

The status code is preserved in the error string so `isRetryable` (which checks for `"500"`) continues to work correctly for transient server errors.

## How

In `openai_compat.go`, attempt to unmarshal the error body as `oaiChatResponse`. If parsing succeeds and `.Error.Message` is non-empty, use it as the display message; otherwise fall back to the raw body.
