### PR TITLE
fix: remap retired Venice model kimi-2.7 to kimi-k2-5

### DIFF
--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -15,6 +15,11 @@ import (
 
 const veniceBaseURL = "https://api.venice.ai/api/v1"
 
+// veniceModelRenames maps retired Venice model IDs to their current replacements.
+var veniceModelRenames = map[string]string{
+	"kimi-2.7": "kimi-k2-5",
+}
+
 type VeniceProvider struct {
 	*OpenAICompatProvider
 }
@@ -23,6 +28,9 @@ func NewVeniceProvider(apiKey, model string) *VeniceProvider {
 	apiKey = config.NormalizeVeniceAPIKey(apiKey)
 	if model == "" {
 		model = "venice-uncensored"
+	}
+	if replacement, ok := veniceModelRenames[model]; ok {
+		model = replacement
 	}
 	return &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(veniceBaseURL, apiKey, model, "Venice")}
 }

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestNewVeniceProviderRemapsRenamedModel(t *testing.T) {
+	provider := NewVeniceProvider("test-key", "kimi-2.7")
+	if provider.model != "kimi-k2-5" {
+		t.Fatalf("model = %q, want %q", provider.model, "kimi-k2-5")
+	}
+}
+
 func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
 	provider := NewVeniceProvider("  test-key\n", "")
 	if provider.apiKey != "test-key" {


### PR DESCRIPTION
## What

Add a `veniceModelRenames` map in `internal/llm/venice.go` that remaps the retired model ID `kimi-2.7` to its current replacement `kimi-k2-5` at provider construction time.

## Why

Venice renamed `kimi-2.7` to `kimi-k2-5`. Users who had `kimi-2.7` configured were hitting a 404 from the Venice API:

```
Venice API error (status 404): {"error":"Specified model not found: kimi-2.7. Did you mean: kimi-k2-5, kimi-k2-thinking, minimax-m27?"}
```

## How

- `veniceModelRenames` map in `venice.go` translates old IDs to current ones at `NewVeniceProvider` call time
- Added `TestNewVeniceProviderRemapsRenamedModel` to verify the mapping
