### PR TITLE
fix: add test verifying Venice 429 overload errors are retried

### DIFF
--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -3,10 +3,12 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
 )
@@ -370,5 +372,59 @@ func TestVeniceProviderExplicitXSearchUsesVeniceParameters(t *testing.T) {
 	}
 	if _, ok := got.VeniceParameters["enable_web_search"]; ok {
 		t.Fatalf("did not expect enable_web_search alongside explicit x search: %#v", got.VeniceParameters)
+	}
+}
+
+func TestVeniceProvider429IsRetried(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"The model is currently overloaded. Please try again later."}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	inner := &VeniceProvider{OpenAICompatProvider: NewOpenAICompatProvider(ts.URL, "test-key", "venice-uncensored", "Venice")}
+	provider := WrapWithRetry(inner, RetryConfig{MaxAttempts: 5, BaseBackoff: time.Millisecond, MaxBackoff: 10 * time.Millisecond})
+
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	var text string
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventError {
+			t.Fatalf("unexpected EventError after retry: %v", ev.Err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+		if ev.Type == EventTextDelta {
+			text += ev.Text
+		}
+	}
+
+	if callCount != 3 {
+		t.Fatalf("callCount = %d, want 3 (2 × 429 then success)", callCount)
+	}
+	if text != "ok" {
+		t.Fatalf("text = %q, want %q", text, "ok")
 	}
 }


### PR DESCRIPTION
## What

Added `TestVeniceProvider429IsRetried` to `internal/llm/venice_test.go`, which verifies that when Venice returns HTTP 429 "The model is currently overloaded. Please try again later.", the `RetryProvider` wrapper correctly retries the request and succeeds on a subsequent attempt.

## Why

A live debug session (2026-04-19T20-00-11-3ded13) surfaced:

```
Venice API error (status 429): {"error":"The model is currently overloaded. Please try again later."}
```

Investigation confirmed the retry logic in `isRetryable` already matches this error (via the `"429"` and `"overloaded"` substring checks), and the `VeniceProvider.Stream` correctly returns the HTTP-level 429 synchronously — before `newEventStream` — so the `RetryProvider` can catch and retry it.

The real-world error was a case of genuine persistent overload exhausting all 5 retry attempts. However, there was **no test** covering the Venice 429 retry path, meaning a future refactor could silently break it.

## How

- Test spins up a fake server returning 429 twice then a valid SSE stream on the third call.
- Wraps `VeniceProvider` with `WrapWithRetry` (tiny backoffs for test speed).
- Asserts `callCount == 3` and that the final streamed text is `"ok"`.
