### PR TITLE
fix: Authorization parser rejects valid non-capitalized Bearer schemes

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -855,10 +855,9 @@ func (s *serveServer) auth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		var gotToken string
-		const prefix = "Bearer "
-		auth := r.Header.Get("Authorization")
-		if strings.HasPrefix(auth, prefix) {
-			gotToken = strings.TrimSpace(strings.TrimPrefix(auth, prefix))
+		auth := strings.TrimSpace(r.Header.Get("Authorization"))
+		if scheme, rest, ok := strings.Cut(auth, " "); ok && strings.EqualFold(scheme, "Bearer") {
+			gotToken = strings.TrimSpace(rest)
 		}
 		if gotToken == "" {
 			if xKey := strings.TrimSpace(r.Header.Get("x-api-key")); xKey != "" {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1195,6 +1195,14 @@ func TestServeAuthMiddleware(t *testing.T) {
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204", rr.Code)
 	}
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "bearer secret")
+	rr = httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("lowercase bearer: status = %d, want 204", rr.Code)
+	}
 }
 
 func TestServeSessionManager_GetOrCreateSingleFactoryCall(t *testing.T) {


### PR DESCRIPTION
## What

Accept case-insensitive `Bearer` authorization schemes in the serve auth middleware.
Added a regression test covering lowercase `bearer` headers.

## Why

HTTP authorization schemes are case-insensitive. Rejecting valid non-capitalized `bearer` headers causes correct credentials to fail with 401s for standards-compliant clients and proxies.
