### PR TITLE
fix: Old previous_response_id remains usable after a fresh-conversation reset

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1161,6 +1161,20 @@ func (s *serveServer) unregisterResponseIDs(rt *serveRuntime) {
 	}
 }
 
+func (s *serveServer) unregisterSessionResponseIDs(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	s.sessionToResponse.Delete(sessionID)
+	s.responseToSession.Range(func(key, value any) bool {
+		sid, ok := value.(string)
+		if ok && sid == sessionID {
+			s.responseToSession.Delete(key)
+		}
+		return true
+	})
+}
+
 func (s *serveServer) runtimeForRequest(ctx context.Context, sessionID string) (*serveRuntime, bool, error) {
 	if sessionID == "" {
 		// Ephemeral stateless runtime (fresh per request for isolation)

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -122,7 +122,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if freshConversation {
-		s.sessionToResponse.Delete(sessionID)
+		s.unregisterSessionResponseIDs(sessionID)
 		s.syncPersistedSessionRuntime(ctx, sessionID, runtime, strings.TrimSpace(req.Model), normalizeReasoningEffort(req.ReasoningEffort))
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4215,6 +4215,53 @@ func TestHandleResponses_StalePreviousResponseIDReturnsConflictAfterRuntimeRecre
 	}
 }
 
+func TestHandleResponses_FreshConversationResetRemovesStalePreviousResponseIDs(t *testing.T) {
+	srv := newTestServeServer("reply1", "reply2")
+	defer srv.sessionMgr.Close()
+
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"msg1"}`, "fresh-reset")
+	if code != http.StatusOK {
+		t.Fatalf("msg1 status = %d, want 200", code)
+	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
+
+	// Simulate a recreated runtime while the old response ID mapping survives.
+	srv.sessionMgr.mu.Lock()
+	evicted := srv.sessionMgr.sessions["fresh-reset"]
+	delete(srv.sessionMgr.sessions, "fresh-reset")
+	srv.sessionMgr.mu.Unlock()
+	if evicted != nil {
+		evicted.Close()
+	}
+	if _, ok := srv.responseToSession.Load(respID1); !ok {
+		t.Fatalf("responseToSession should still contain %q before reset", respID1)
+	}
+
+	code, resp2 := doResponsesWithHeader(t, srv, `{"input":"reset"}`, "fresh-reset")
+	if code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200", code)
+	}
+	respID2, _ := resp2["id"].(string)
+	if respID2 == "" {
+		t.Fatal("reset response missing id")
+	}
+
+	if _, ok := srv.responseToSession.Load(respID1); ok {
+		t.Fatalf("stale previous_response_id %q should be removed after fresh reset", respID1)
+	}
+	latest, ok := srv.sessionToResponse.Load("fresh-reset")
+	if !ok {
+		t.Fatal("sessionToResponse missing fresh-reset after reset")
+	}
+	latestID, _ := latest.(string)
+	if latestID != respID2 {
+		t.Fatalf("sessionToResponse = %q, want %q", latestID, respID2)
+	}
+}
+
 func TestHandleResponses_PreviousResponseIDChainsSession(t *testing.T) {
 	// Each runtime gets 2 text responses so it can handle 2 messages
 	srv := newTestServeServer("first reply", "second reply")


### PR DESCRIPTION
## What

- clear all response ID mappings for a session when `/v1/responses` starts a fresh conversation reset
- keep the change targeted by replacing the old `sessionToResponse` delete with a helper that also removes stale `responseToSession` entries for that session
- add a regression test covering the recreated-runtime case where an old response ID mapping survives until a fresh reset

## Why

A fresh conversation reset must fully sever chaining from the old conversation. Before this change, the handler only deleted `sessionToResponse`, so stale `previous_response_id` entries could still resolve through `responseToSession` if the old runtime had already been recreated and the new conversation had not yet registered its first response ID. That could let a reset session chain from a pre-reset response ID and mix two conversations.
