### PR TITLE
fix: Fresh conversations reuse stale persisted provider/model state

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1282,14 +1282,13 @@ func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessio
 }
 
 // syncPersistedSessionRuntime pins the provider, model, and reasoning_effort
-// on the session row for the first message of a web session. Fields already
-// set on the row are never overwritten; once saved on first message, these
-// values are locked for the remainder of the session. Later requests must use
-// the locked values — cross-provider or cross-model swaps mid-session corrupt
-// saved state (tool call shapes, response chaining, reasoning trace), and
-// handover is a future feature. If the row does not yet exist, it is created
-// here so the client-supplied model and effort are persisted (rather than the
-// runtime defaults that rt would otherwise use when Run creates the row).
+// on the session row for the first message of a web conversation. Fresh
+// conversations on a reused session ID must overwrite any stale provider/model/
+// reasoning metadata from the prior conversation so later requests reload the
+// active runtime's settings rather than resurrecting old state after resets,
+// evictions, or restarts. If the row does not yet exist, it is created here so
+// the client-supplied model and effort are persisted (rather than the runtime
+// defaults that rt would otherwise use when Run creates the row).
 func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID string, rt *serveRuntime, clientModel, reasoningEffort string) {
 	if s.store == nil || sessionID == "" || rt == nil {
 		return
@@ -1352,23 +1351,26 @@ func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID
 	}
 
 	changed := false
-	if providerName != "" && strings.TrimSpace(sess.Provider) == "" {
+	if providerName != "" && strings.TrimSpace(sess.Provider) != providerName {
 		sess.Provider = providerName
 		changed = true
 	}
-	if providerKey != "" && strings.TrimSpace(sess.ProviderKey) == "" {
+	if strings.TrimSpace(sess.ProviderKey) != providerKey {
 		sess.ProviderKey = providerKey
 		changed = true
 	}
-	if modelName != "" && strings.TrimSpace(sess.Model) == "" {
+	if modelName != "" && strings.TrimSpace(sess.Model) != modelName {
 		sess.Model = modelName
 		changed = true
 	}
-	if effort != "" && strings.TrimSpace(sess.ReasoningEffort) == "" {
+	if strings.TrimSpace(sess.ReasoningEffort) != effort {
 		sess.ReasoningEffort = effort
 		changed = true
 	}
 	if !changed {
+		rt.mu.Lock()
+		rt.sessionMeta = sess
+		rt.mu.Unlock()
 		return
 	}
 	if err := s.store.Update(ctx, sess); err != nil {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3960,6 +3960,67 @@ func TestHandleSessionState_FallsBackToDBWhenRuntimeNotLoaded(t *testing.T) {
 	}
 }
 
+func TestSyncPersistedSessionRuntime_OverwritesStaleFreshConversationState(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	defer store.Close()
+
+	stale := &session.Session{
+		ID:              "sess-reset",
+		Provider:        "anthropic",
+		ProviderKey:     "anthropic",
+		Model:           "claude-3-5-sonnet",
+		ReasoningEffort: "high",
+		Mode:            session.ModeChat,
+		Origin:          session.OriginWeb,
+	}
+	if err := store.Create(context.Background(), stale); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rt := &serveRuntime{
+		provider:     llm.NewMockProvider("openai"),
+		providerKey:  "openai",
+		defaultModel: "gpt-5",
+	}
+	srv := &serveServer{store: store}
+
+	srv.syncPersistedSessionRuntime(context.Background(), stale.ID, rt, "gpt-5-mini", "")
+
+	updated, err := store.Get(context.Background(), stale.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("expected updated session")
+	}
+	if updated.Provider != "openai" {
+		t.Fatalf("provider = %q, want %q", updated.Provider, "openai")
+	}
+	if updated.ProviderKey != "openai" {
+		t.Fatalf("provider_key = %q, want %q", updated.ProviderKey, "openai")
+	}
+	if updated.Model != "gpt-5-mini" {
+		t.Fatalf("model = %q, want %q", updated.Model, "gpt-5-mini")
+	}
+	if updated.ReasoningEffort != "" {
+		t.Fatalf("reasoning_effort = %q, want empty", updated.ReasoningEffort)
+	}
+
+	rt.mu.Lock()
+	meta := rt.sessionMeta
+	rt.mu.Unlock()
+	if meta == nil {
+		t.Fatal("expected runtime session metadata to be updated")
+	}
+	if meta.Provider != "openai" || meta.ProviderKey != "openai" || meta.Model != "gpt-5-mini" || meta.ReasoningEffort != "" {
+		t.Fatalf("runtime session metadata = %+v", meta)
+	}
+}
+
 func TestHandleSessionState_DoesNotBlockWhileRunHoldsRuntimeMutex(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

Overwrite persisted provider, provider_key, model, and reasoning_effort when `/v1/responses` starts a fresh conversation on an existing `session_id`, instead of only filling empty fields.

Also adds a regression test covering reuse of a stale session row.

## Why

Fresh conversations can replace the in-memory runtime with a new provider/model, but the old session row was left unchanged. Later reloads would then pull stale provider/model/reasoning metadata back from the DB and silently force the session onto the wrong runtime settings after resets, evictions, or restarts.
