### PR TITLE
fix: read_url truncates by bytes and can return invalid UTF-8

### DIFF
--- a/internal/llm/read_url_tool.go
+++ b/internal/llm/read_url_tool.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,9 +14,10 @@ import (
 )
 
 const (
-	ReadURLToolName     = "read_url"
-	maxReadURLChars     = 50000
-	maxReadURLRedirects = 10
+	ReadURLToolName         = "read_url"
+	maxReadURLChars         = 50000
+	maxReadURLRedirects     = 10
+	readURLTruncationSuffix = "\n\n[Content truncated at 50,000 characters]"
 )
 
 var readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
@@ -108,19 +110,42 @@ func (t *ReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOu
 		return TextOutput(fmt.Sprintf("Error: HTTP %d %s - Unable to fetch this URL.", resp.StatusCode, statusText)), nil
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxReadURLChars+1))
+	content, truncated, err := readURLContent(resp.Body)
 	if err != nil {
 		return TextOutput(fmt.Sprintf("Error reading response: %v", err)), nil
 	}
 
-	content := string(body)
-
-	// Truncate if too long
-	if len(content) > maxReadURLChars {
-		content = content[:maxReadURLChars] + "\n\n[Content truncated at 50,000 characters]"
+	if truncated {
+		content += readURLTruncationSuffix
 	}
 
 	return TextOutput(content), nil
+}
+
+func readURLContent(r io.Reader) (string, bool, error) {
+	reader := bufio.NewReader(r)
+	var content strings.Builder
+
+	for i := 0; i < maxReadURLChars; i++ {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				return content.String(), false, nil
+			}
+			return "", false, err
+		}
+		content.WriteRune(r)
+	}
+
+	_, _, err := reader.ReadRune()
+	if err != nil {
+		if err == io.EOF {
+			return content.String(), false, nil
+		}
+		return "", false, err
+	}
+
+	return content.String(), true, nil
 }
 
 func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL string) (string, error) {

--- a/internal/llm/read_url_tool_test.go
+++ b/internal/llm/read_url_tool_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 type failAfterNReadCloser struct {
@@ -96,19 +97,80 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 		t.Fatalf("expected limited read to avoid body read error, got %q", out.Content)
 	}
 
-	const truncationSuffix = "\n\n[Content truncated at 50,000 characters]"
-	if !strings.HasSuffix(out.Content, truncationSuffix) {
-		start := len(out.Content) - len(truncationSuffix) - 20
+	if !strings.HasSuffix(out.Content, readURLTruncationSuffix) {
+		start := len(out.Content) - len(readURLTruncationSuffix) - 20
 		if start < 0 {
 			start = 0
 		}
 		t.Fatalf("expected truncated content suffix, got %q", out.Content[start:])
 	}
-	if got, want := len(out.Content), maxReadURLChars+len(truncationSuffix); got != want {
+	if got, want := len(out.Content), maxReadURLChars+len(readURLTruncationSuffix); got != want {
 		t.Fatalf("expected content length %d, got %d", want, got)
 	}
 	if out.Content[:32] != strings.Repeat("a", 32) {
 		t.Fatalf("expected response body prefix to be preserved")
+	}
+}
+
+func TestReadURLToolExecuteTruncatesByRunes(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
+	body := strings.Repeat("界", maxReadURLChars) + "🙂tail"
+
+	tool := NewReadURLTool()
+	tool.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "example.com":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("ok")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			case "r.jina.ai":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			default:
+				t.Fatalf("unexpected host %q", req.URL.Host)
+				return nil, nil
+			}
+		}),
+	}
+
+	args, err := json.Marshal(map[string]string{"url": "example.com/article"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !utf8.ValidString(out.Content) {
+		t.Fatalf("expected valid UTF-8 output")
+	}
+	if !strings.HasSuffix(out.Content, readURLTruncationSuffix) {
+		t.Fatalf("expected truncation suffix")
+	}
+
+	content := strings.TrimSuffix(out.Content, readURLTruncationSuffix)
+	if got, want := utf8.RuneCountInString(content), maxReadURLChars; got != want {
+		t.Fatalf("expected %d runes before suffix, got %d", want, got)
+	}
+	if strings.ContainsRune(content, '🙂') {
+		t.Fatalf("expected content to exclude runes past the limit")
+	}
+	if strings.ContainsRune(content, '\uFFFD') {
+		t.Fatalf("expected truncation not to introduce replacement characters")
 	}
 }
 


### PR DESCRIPTION
## What

- truncate `read_url` output by runes instead of raw bytes
- read and detect truncation on rune boundaries so the returned content is always valid UTF-8
- add a regression test covering multibyte Unicode content

## Why

`read_url` treated `maxReadURLChars` as a character limit but sliced the response string by bytes. For pages with multibyte Unicode characters, that could split a rune and return invalid UTF-8 or mangled text to the model.
