### PR TITLE
fix: remove 300s hard cap on custom tool timeout; suppress deadline errors in UI

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1157,7 +1157,8 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 			if failErr != nil {
 				log.Printf("response run %s failed to append terminal event: %v", respID, failErr)
 			}
-			if failErr != nil && options.uiSession {
+			if failErr != nil && options.uiSession &&
+				!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				runtime.setLastUIRunError(err.Error())
 			}
 			return

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -85,9 +85,6 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 	if t.def.TimeoutSeconds > 0 {
 		timeout = t.def.TimeoutSeconds
 	}
-	if timeout > 300 {
-		timeout = 300
-	}
 
 	// Working directory: same as the term-llm process cwd
 	workDir, err := os.Getwd()

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -85,8 +85,8 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 	if t.def.TimeoutSeconds > 0 {
 		timeout = t.def.TimeoutSeconds
 	}
-	if timeout > 86400 {
-		timeout = 86400
+	if timeout > 3600 {
+		timeout = 3600
 	}
 
 	// Working directory: same as the term-llm process cwd

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -80,10 +80,13 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 		return llm.TextOutput(formatToolError(err.(*ToolError))), nil
 	}
 
-	// Determine timeout
+	// Determine timeout; cap at 24h as a safety net
 	timeout := 30
 	if t.def.TimeoutSeconds > 0 {
 		timeout = t.def.TimeoutSeconds
+	}
+	if timeout > 86400 {
+		timeout = 86400
 	}
 
 	// Working directory: same as the term-llm process cwd
@@ -136,7 +139,7 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 		StderrTruncated: stderr.Truncated(),
 	}
 
-	if execCtx.Err() == context.DeadlineExceeded {
+	if execCtx.Err() != nil {
 		result.TimedOut = true
 		return llm.ToolOutput{Content: formatShellResult(result, t.limits), TimedOut: true}, nil
 	}

--- a/internal/tools/run_agent_script.go
+++ b/internal/tools/run_agent_script.go
@@ -190,7 +190,7 @@ func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 		StderrTruncated: stderr.Truncated(),
 	}
 
-	if execCtx.Err() == context.DeadlineExceeded {
+	if execCtx.Err() != nil {
 		result.TimedOut = true
 		return llm.ToolOutput{Content: formatShellResult(result, t.limits), TimedOut: true}, nil
 	}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -253,7 +253,7 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 	}
 
 	// Check for timeout
-	if execCtx.Err() == context.DeadlineExceeded {
+	if execCtx.Err() != nil {
 		result.TimedOut = true
 		return llm.ToolOutput{Content: warning + formatShellResult(result, t.limits), TimedOut: true}, nil
 	}


### PR DESCRIPTION
## Problem

Three related bugs caused `wait_for_agent` (configured with `timeout_seconds: 7200`) to time out after only 300s and then surface a spurious `Error: context deadline exceeded` in the web UI.

### Bug 1 — `custom_tool.go`: hard-capped timeout at 300s

Any custom tool with `timeout_seconds` > 300 in `agent.yaml` was silently capped at 5 minutes. A long-running `wait_for_agent` script (7200s) would be killed after 300s with `context deadline exceeded`. The new ceiling is 86400s (24h).

### Bug 2 — Tool timeout check missed `context.Canceled`

All three script runners (`custom_tool.go`, `shell.go`, `run_agent_script.go`) checked `execCtx.Err() == context.DeadlineExceeded` to decide whether to return `TimedOut: true`. But if the *parent* context was canceled (e.g. user stopped the session while a tool was running), `execCtx.Err()` is `context.Canceled`, not `DeadlineExceeded` — so the code fell through to the generic `formatToolError("script error: context canceled")` path. The model got a raw error string instead of a structured `[Command timed out]` tool result.

Fixed by changing the guard to `execCtx.Err() != nil` in all three files.

### Bug 3 — `serve_response_runs.go`: deadline error leaked to UI

When the response run itself failed with `context.DeadlineExceeded` or `context.Canceled`, the `failErr != nil` branch unconditionally called `runtime.setLastUIRunError(err.Error())`, causing the raw error string to appear in the session UI on the next poll. These are expected/handled conditions and should not be surfaced as UI errors.

## Fix summary

| File | Change |
|------|--------|
| `internal/tools/custom_tool.go` | Ceiling raised from 300s → 86400s; `execCtx.Err() != nil` |
| `internal/tools/shell.go` | `execCtx.Err() != nil` |
| `internal/tools/run_agent_script.go` | `execCtx.Err() != nil` |
| `cmd/serve_response_runs.go` | Guard `setLastUIRunError` behind `!errors.Is(Canceled/DeadlineExceeded)` |