### PR TITLE
fix: previous_response_id continuations drop newly-added developer/system input items

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -834,16 +834,28 @@ func filterToNewInput(input []ResponsesInputItem) []ResponsesInputItem {
 		break
 	}
 	if sawToolOutput {
-		return input[start:]
+		return filterContinuationInputFrom(input, start)
 	}
 
 	// Otherwise fall back to the latest user message and any following items.
 	for i := len(input) - 1; i >= 0; i-- {
 		if input[i].Role == "user" {
-			return input[i:]
+			return filterContinuationInputFrom(input, i)
 		}
 	}
 	return input
+}
+
+func filterContinuationInputFrom(input []ResponsesInputItem, start int) []ResponsesInputItem {
+	for start > 0 {
+		item := input[start-1]
+		if item.Type == "message" && item.Role == "developer" {
+			start--
+			continue
+		}
+		break
+	}
+	return input[start:]
 }
 
 // responsesToolState tracks streaming tool calls from the Responses API

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -814,6 +814,50 @@ func TestBuildResponsesInput_ConvertsDanglingToolCalls(t *testing.T) {
 	}
 }
 
+func TestFilterToNewInput_PreservesDeveloperItemsBeforeLatestUser(t *testing.T) {
+	input := []ResponsesInputItem{
+		{Type: "message", Role: "developer", Content: "Be concise"},
+		{Type: "message", Role: "user", Content: "old question"},
+		{Type: "message", Role: "assistant", Content: "I'll check"},
+		{Type: "message", Role: "developer", Content: "Use bullet points"},
+		{Type: "message", Role: "user", Content: "new question"},
+	}
+
+	got := filterToNewInput(input)
+
+	if len(got) != 2 {
+		t.Fatalf("expected developer message and latest user message, got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "message" || got[0].Role != "developer" {
+		t.Fatalf("expected first item developer message, got %+v", got[0])
+	}
+	if got[1].Type != "message" || got[1].Role != "user" || got[1].Content != "new question" {
+		t.Fatalf("expected second item latest user message, got %+v", got[1])
+	}
+}
+
+func TestFilterToNewInput_PreservesDeveloperItemsBeforeToolFollowUp(t *testing.T) {
+	input := []ResponsesInputItem{
+		{Type: "message", Role: "developer", Content: "Be concise"},
+		{Type: "message", Role: "user", Content: "old question"},
+		{Type: "message", Role: "assistant", Content: "I'll check"},
+		{Type: "message", Role: "developer", Content: "Summarize the result"},
+		{Type: "function_call_output", CallID: "call_1", Output: "/root/source/term-llm"},
+	}
+
+	got := filterToNewInput(input)
+
+	if len(got) != 2 {
+		t.Fatalf("expected developer message and trailing tool output, got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "message" || got[0].Role != "developer" {
+		t.Fatalf("expected first item developer message, got %+v", got[0])
+	}
+	if got[1].Type != "function_call_output" || got[1].CallID != "call_1" {
+		t.Fatalf("expected second item trailing function_call_output for call_1, got %+v", got[1])
+	}
+}
+
 func TestFilterToNewInput_ToolFollowUpReturnsOnlyNewToolOutputs(t *testing.T) {
 	input := []ResponsesInputItem{
 		{Type: "message", Role: "developer", Content: "Be concise"},


### PR DESCRIPTION
## What

Preserve newly-added developer/system-style input items when trimming input for `previous_response_id` continuations in the Responses client.

## Why

`filterToNewInput()` previously started continuations at the latest user message, or at trailing `function_call_output` items for tool follow-ups. That dropped any new developer/system-style message inserted immediately before the new turn, so updated instructions were silently omitted and the model could continue under stale guidance.
