### PR TITLE
fix: OpenAI-compatible backends mis-handle trailing developer messages as user turns

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -537,12 +537,23 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 
 	var result []oaiMessage
 	var pendingDev string
+	flushPendingDev := func() {
+		if pendingDev == "" {
+			return
+		}
+		result = append(result, oaiMessage{
+			Role:    "system",
+			Content: fmt.Sprintf("<developer>\n%s\n</developer>", pendingDev),
+		})
+		pendingDev = ""
+	}
 	for _, msg := range messages {
 		switch msg.Role {
 		case RoleDeveloper:
 			// OpenAI-compatible backends have no native developer role.
 			// Buffer the text and prepend it into the next user turn
-			// wrapped in <developer> tags.
+			// wrapped in <developer> tags. If there is no following user turn,
+			// flush it as a synthetic system message to preserve ordering.
 			text, _, _ := splitParts(msg.Parts)
 			if text != "" {
 				if pendingDev != "" {
@@ -555,6 +566,8 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 			if msg.Role == RoleUser && pendingDev != "" {
 				text = fmt.Sprintf("<developer>\n%s\n</developer>\n\n", pendingDev) + text
 				pendingDev = ""
+			} else if pendingDev != "" {
+				flushPendingDev()
 			}
 			if msg.Role == RoleAssistant && len(toolCalls) > 0 {
 				result = append(result, oaiMessage{
@@ -593,6 +606,7 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 			role := string(msg.Role)
 			result = append(result, oaiMessage{Role: role, Content: text, ReasoningContent: reasoning})
 		case RoleTool:
+			flushPendingDev()
 			for _, part := range msg.Parts {
 				if part.Type != PartToolResult || part.ToolResult == nil {
 					continue
@@ -630,12 +644,7 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 		}
 	}
 	// Trailing developer message with no following user turn.
-	if pendingDev != "" {
-		result = append(result, oaiMessage{
-			Role:    "user",
-			Content: fmt.Sprintf("<developer>\n%s\n</developer>", pendingDev),
-		})
-	}
+	flushPendingDev()
 	return result
 }
 

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -878,18 +878,62 @@ func TestBuildCompatMessages_TrailingDeveloperMessage(t *testing.T) {
 	oaiMsgs := buildCompatMessages(messages)
 
 	if len(oaiMsgs) != 3 {
-		t.Fatalf("expected 3 messages (user, assistant, synthetic user), got %d", len(oaiMsgs))
+		t.Fatalf("expected 3 messages (user, assistant, synthetic system), got %d", len(oaiMsgs))
 	}
 	trailing := oaiMsgs[2]
-	if trailing.Role != "user" {
-		t.Errorf("expected trailing message role 'user', got %q", trailing.Role)
+	if trailing.Role != "system" {
+		t.Errorf("expected trailing message role 'system', got %q", trailing.Role)
 	}
 	content, ok := trailing.Content.(string)
 	if !ok {
 		t.Fatalf("expected trailing content to be string, got %T", trailing.Content)
 	}
 	if !strings.Contains(content, "<developer>") || !strings.Contains(content, "Be concise from now on.") {
-		t.Errorf("expected developer text in trailing user message, got %q", content)
+		t.Errorf("expected developer text in trailing system message, got %q", content)
+	}
+}
+
+func TestBuildCompatMessages_DeveloperMessagePreservesOrderingBeforeAssistant(t *testing.T) {
+	messages := []Message{
+		{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "Hello"}},
+		},
+		{
+			Role:  RoleDeveloper,
+			Parts: []Part{{Type: PartText, Text: "Be concise from now on."}},
+		},
+		{
+			Role:  RoleAssistant,
+			Parts: []Part{{Type: PartText, Text: "Working on it."}},
+		},
+		{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "Continue"}},
+		},
+	}
+
+	oaiMsgs := buildCompatMessages(messages)
+
+	if len(oaiMsgs) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(oaiMsgs))
+	}
+	if oaiMsgs[1].Role != "system" {
+		t.Fatalf("expected developer message to flush as system before assistant, got %q", oaiMsgs[1].Role)
+	}
+	devContent, ok := oaiMsgs[1].Content.(string)
+	if !ok {
+		t.Fatalf("expected developer flush content to be string, got %T", oaiMsgs[1].Content)
+	}
+	if !strings.Contains(devContent, "Be concise from now on.") {
+		t.Fatalf("expected developer text to be preserved, got %q", devContent)
+	}
+	userContent, ok := oaiMsgs[3].Content.(string)
+	if !ok {
+		t.Fatalf("expected final user content to be string, got %T", oaiMsgs[3].Content)
+	}
+	if strings.Contains(userContent, "Be concise from now on.") {
+		t.Fatalf("expected later user turn not to absorb delayed developer text, got %q", userContent)
 	}
 }
 


### PR DESCRIPTION
## What

Preserve developer-role message ordering in `buildCompatMessages()` for OpenAI-compatible backends.

When a buffered developer message is not immediately followed by a user turn, the code now flushes it as a synthetic `system` message instead of delaying it until a later user message or converting it into a trailing synthetic user turn. Added regression coverage for both trailing developer messages and developer messages that appear before an assistant turn.

## Why

Trailing or intervening developer messages were being misrepresented as user input, which could delay internal instructions past assistant/tool messages or cause the model to treat privileged guidance as ordinary user intent. Flushing them as `system` messages preserves ordering and keeps the instruction in a privileged role for OpenAI-compatible APIs.
