### PR TITLE
fix: Context compaction/handover corrupts stateful Responses-API conversations

### DIFF
--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -88,6 +88,30 @@ A previous conversation was compacted to fit within the context window. Below is
 Summary:
 `
 
+// isolatedConversationProvider returns a provider instance that can service
+// helper requests like compaction/handover without mutating the live
+// provider-side conversation state.
+func isolatedConversationProvider(provider Provider) Provider {
+	switch p := provider.(type) {
+	case *RetryProvider:
+		return &RetryProvider{inner: isolatedConversationProvider(p.inner), config: p.config}
+	case *OpenAIProvider:
+		clone := *p
+		clone.responsesClient = cloneResponsesClientFreshConversation(p.responsesClient)
+		return &clone
+	case *ChatGPTProvider:
+		clone := *p
+		clone.responsesClient = cloneResponsesClientFreshConversation(p.responsesClient)
+		return &clone
+	case *CopilotProvider:
+		clone := *p
+		clone.responsesClient = cloneResponsesClientFreshConversation(p.responsesClient)
+		return &clone
+	default:
+		return provider
+	}
+}
+
 // Compact generates a summary of the conversation history and returns a
 // compacted message list: [system] + [summary as user] + [recent user messages].
 //
@@ -142,8 +166,10 @@ func Compact(ctx context.Context, provider Provider, model, systemPrompt string,
 	// individually, but doing it here provides belt-and-suspenders safety.
 	budget = ClampOutputTokens(budget, model)
 
-	// Call provider with no tools, enforcing output budget.
-	stream, err := provider.Stream(ctx, Request{
+	// Call provider with no tools, enforcing output budget. Use an isolated
+	// provider instance so the helper turn doesn't overwrite live server-side
+	// conversation state (for example previous_response_id on Responses API clients).
+	stream, err := isolatedConversationProvider(provider).Stream(ctx, Request{
 		Model:           model,
 		Messages:        reqMessages,
 		MaxOutputTokens: budget,
@@ -254,7 +280,7 @@ func Handover(ctx context.Context, provider Provider, model, currentSystemPrompt
 	budget := 12_000 // Slightly larger budget than compaction for handover precision
 	budget = ClampOutputTokens(budget, model)
 
-	stream, err := provider.Stream(ctx, Request{
+	stream, err := isolatedConversationProvider(provider).Stream(ctx, Request{
 		Model:           model,
 		Messages:        reqMessages,
 		MaxOutputTokens: budget,

--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -2,9 +2,13 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestEstimateTokens(t *testing.T) {
@@ -644,6 +648,140 @@ func TestCompactRecompactsAlreadyCompacted(t *testing.T) {
 	}
 	if !strings.Contains(result.NewMessages[1].Parts[0].Text, "New combined summary") {
 		t.Error("new summary should contain the LLM's response")
+	}
+}
+
+func newIsolatedResponsesProvider(t *testing.T, responseText, responseID string) (Provider, *OpenAIProvider, <-chan struct {
+	PreviousResponseID string
+	Input              []ResponsesInputItem
+}) {
+	t.Helper()
+
+	captured := make(chan struct {
+		PreviousResponseID string
+		Input              []ResponsesInputItem
+	}, 1)
+
+	sse := strings.Join([]string{
+		"event: response.output_text.delta",
+		fmt.Sprintf(`data: {"delta":%q}`, responseText),
+		"",
+		"event: response.completed",
+		fmt.Sprintf(`data: {"response":{"id":%q}}`, responseID),
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			defer r.Body.Close()
+
+			var payload struct {
+				PreviousResponseID string               `json:"previous_response_id"`
+				Input              []ResponsesInputItem `json:"input"`
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return nil, err
+			}
+			captured <- struct {
+				PreviousResponseID string
+				Input              []ResponsesInputItem
+			}{
+				PreviousResponseID: payload.PreviousResponseID,
+				Input:              payload.Input,
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+				},
+				Body: io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		}),
+	}
+
+	provider := &OpenAIProvider{
+		apiKey: "test-key",
+		model:  "gpt-5.2",
+		responsesClient: &ResponsesClient{
+			BaseURL:        "https://example.test/v1/responses",
+			GetAuthHeader:  func() string { return "Bearer test-key" },
+			HTTPClient:     httpClient,
+			LastResponseID: "resp_live",
+		},
+	}
+
+	return WrapWithRetry(provider, DefaultRetryConfig()), provider, captured
+}
+
+func TestCompactUsesIsolatedProviderConversationState(t *testing.T) {
+	provider, liveProvider, captured := newIsolatedResponsesProvider(t, "summary", "resp_compact")
+
+	result, err := Compact(context.Background(), provider, "gpt-5.2", "sys", []Message{
+		UserText("hello"),
+		AssistantText("hi"),
+		UserText("please summarize"),
+	}, DefaultCompactionConfig())
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+	if result.Summary != "summary" {
+		t.Fatalf("summary = %q, want %q", result.Summary, "summary")
+	}
+
+	if liveProvider.responsesClient.LastResponseID != "resp_live" {
+		t.Fatalf("live LastResponseID = %q, want %q", liveProvider.responsesClient.LastResponseID, "resp_live")
+	}
+
+	select {
+	case req := <-captured:
+		if req.PreviousResponseID != "" {
+			t.Fatalf("compaction previous_response_id = %q, want empty", req.PreviousResponseID)
+		}
+		if len(req.Input) < 4 {
+			t.Fatalf("compaction input length = %d, want full history plus prompt", len(req.Input))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for compaction request capture")
+	}
+}
+
+func TestHandoverUsesIsolatedProviderConversationState(t *testing.T) {
+	provider, liveProvider, captured := newIsolatedResponsesProvider(t, "handover doc", "resp_handover")
+
+	result, err := Handover(context.Background(), provider, "gpt-5.2", "current sys", "new sys", []Message{
+		UserText("hello"),
+		AssistantText("hi"),
+		UserText("prepare handover"),
+	}, "source", "target", DefaultCompactionConfig())
+	if err != nil {
+		t.Fatalf("Handover failed: %v", err)
+	}
+	if result.Document != "handover doc" {
+		t.Fatalf("document = %q, want %q", result.Document, "handover doc")
+	}
+
+	if liveProvider.responsesClient.LastResponseID != "resp_live" {
+		t.Fatalf("live LastResponseID = %q, want %q", liveProvider.responsesClient.LastResponseID, "resp_live")
+	}
+
+	select {
+	case req := <-captured:
+		if req.PreviousResponseID != "" {
+			t.Fatalf("handover previous_response_id = %q, want empty", req.PreviousResponseID)
+		}
+		if len(req.Input) < 4 {
+			t.Fatalf("handover input length = %d, want full history plus prompt", len(req.Input))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for handover request capture")
 	}
 }
 

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -456,6 +456,30 @@ func (c *ResponsesClient) setLastResponseIDIfGeneration(generation uint64, respo
 	c.LastResponseID = responseID
 }
 
+func cloneResponsesClientFreshConversation(c *ResponsesClient) *ResponsesClient {
+	if c == nil {
+		return nil
+	}
+
+	var extraHeaders map[string]string
+	if c.ExtraHeaders != nil {
+		extraHeaders = make(map[string]string, len(c.ExtraHeaders))
+		for key, value := range c.ExtraHeaders {
+			extraHeaders[key] = value
+		}
+	}
+
+	return &ResponsesClient{
+		BaseURL:            c.BaseURL,
+		GetAuthHeader:      c.GetAuthHeader,
+		ExtraHeaders:       extraHeaders,
+		HTTPClient:         c.HTTPClient,
+		DisableServerState: c.DisableServerState,
+		HandleError:        c.HandleError,
+		OnAuthRetry:        c.OnAuthRetry,
+	}
+}
+
 // Stream makes a streaming request to the Responses API and returns events via a Stream
 func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debugRaw bool) (Stream, error) {
 	fullInput := req.Input


### PR DESCRIPTION
## What

Isolate compaction and handover helper requests from the live provider conversation state.

This makes `Compact()` and `Handover()` use a fresh provider copy for Responses-API-backed providers (including retry-wrapped ones), so helper turns do not reuse or overwrite the active `previous_response_id` chain.

Also adds regression coverage proving these helper calls do not send `previous_response_id`, do not collapse the request down to only the helper prompt, and do not mutate the live provider's stored response ID.

## Why

Compaction and handover append helper prompts onto the existing message history and call `provider.Stream()`.

For stateful Responses-API providers, the live provider instance carries server-side conversation state. Reusing it for compaction/handover caused the helper request itself to become part of the active conversation and overwrite the stored last response ID. The next real user turn could then chain from the compaction/handover response instead of the actual conversation, corrupting follow-up behavior and losing context.
