### PR TITLE
fix: Remote image_url inputs are silently discarded instead of being processed or rejected

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -195,8 +195,11 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 			case "input_image", "image_url":
 				imageURL := jsonImageURL(part["image_url"])
 				filename := jsonString(part["filename"])
-				if !strings.HasPrefix(imageURL, "data:") {
+				if imageURL == "" {
 					continue
+				}
+				if !strings.HasPrefix(imageURL, "data:") {
+					return llm.Message{}, fmt.Errorf("remote image URLs are not supported; provide image_url as a data URL")
 				}
 				mt, b64 := parseDataURL(imageURL)
 				if mt == "" || b64 == "" {

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -37,6 +37,21 @@ func TestParseUserMessageContent_RejectsTooManyInlineImages(t *testing.T) {
 	}
 }
 
+func TestParseUserMessageContent_RejectsRemoteImageURL(t *testing.T) {
+	content := json.RawMessage(`[
+		{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}},
+		{"type":"text","text":"describe this"}
+	]`)
+
+	_, err := parseUserMessageContent(content)
+	if err == nil {
+		t.Fatal("parseUserMessageContent() error = nil, want remote image URL error")
+	}
+	if !strings.Contains(err.Error(), "remote image URLs are not supported") {
+		t.Fatalf("parseUserMessageContent() error = %v, want remote image URL error", err)
+	}
+}
+
 func marshalInlineImageParts(t *testing.T, count int) json.RawMessage {
 	t.Helper()
 


### PR DESCRIPTION
## What

- reject non-`data:` `image_url` parts in `parseUserMessageContent` instead of silently skipping them
- keep the existing behavior for inline data URLs
- add a regression test covering remote `image_url` inputs

## Why

Remote `http`/`https` image URLs were previously accepted by the parser but then dropped on the floor because only `data:` URLs are handled downstream. That caused multimodal requests to be processed as if the image was never sent, with no validation error for API clients. Returning an explicit error makes the unsupported input diagnosable and avoids incorrect silent behavior.
