### PR TITLE
fix: Chat Completions usage accounting returns impossible token counts

### DIFF
--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -306,6 +306,8 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 		"choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": finishReason}},
 	})
 	if streamOpts != nil && streamOpts.IncludeUsage {
+		promptTokens := result.Usage.InputTokens + result.Usage.CachedInputTokens
+		totalTokens := promptTokens + result.Usage.OutputTokens
 		_ = writeChatStreamChunk(w, map[string]any{
 			"id":      respID,
 			"object":  "chat.completion.chunk",
@@ -313,9 +315,9 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 			"model":   model,
 			"choices": []map[string]any{},
 			"usage": map[string]any{
-				"prompt_tokens":     result.Usage.InputTokens,
+				"prompt_tokens":     promptTokens,
 				"completion_tokens": result.Usage.OutputTokens,
-				"total_tokens":      result.Usage.InputTokens + result.Usage.CachedInputTokens + result.Usage.CacheWriteTokens + result.Usage.OutputTokens,
+				"total_tokens":      totalTokens,
 				"prompt_tokens_details": map[string]any{
 					"cached_tokens":      result.Usage.CachedInputTokens,
 					"cache_write_tokens": result.Usage.CacheWriteTokens,

--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -272,6 +272,9 @@ func chatCompletionFinalResponse(result serveRunResult, model string) map[string
 		message["tool_calls"] = toolCalls
 	}
 
+	promptTokens := result.Usage.InputTokens + result.Usage.CachedInputTokens
+	totalTokens := promptTokens + result.Usage.OutputTokens
+
 	return map[string]any{
 		"id":      "chatcmpl_" + randomSuffix(),
 		"object":  "chat.completion",
@@ -283,9 +286,9 @@ func chatCompletionFinalResponse(result serveRunResult, model string) map[string
 			"finish_reason": finishReason,
 		}},
 		"usage": map[string]any{
-			"prompt_tokens":     result.Usage.InputTokens,
+			"prompt_tokens":     promptTokens,
 			"completion_tokens": result.Usage.OutputTokens,
-			"total_tokens":      result.Usage.InputTokens + result.Usage.CachedInputTokens + result.Usage.CacheWriteTokens + result.Usage.OutputTokens,
+			"total_tokens":      totalTokens,
 			"prompt_tokens_details": map[string]any{
 				"cached_tokens":      result.Usage.CachedInputTokens,
 				"cache_write_tokens": result.Usage.CacheWriteTokens,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -7679,6 +7679,119 @@ func TestNonStreamingChat_ShowsServerExecutedToolCalls(t *testing.T) {
 	}
 }
 
+func TestChatCompletionFinalResponse_UsageIncludesCachedPromptTokens(t *testing.T) {
+	var result serveRunResult
+	result.Text.WriteString("done")
+	result.Usage = llm.Usage{
+		InputTokens:       100,
+		CachedInputTokens: 20,
+		CacheWriteTokens:  5,
+		OutputTokens:      7,
+	}
+
+	response := chatCompletionFinalResponse(result, "test-model")
+	usage := response["usage"].(map[string]any)
+
+	if got := usage["prompt_tokens"]; got != 120 {
+		t.Fatalf("prompt_tokens = %v, want 120", got)
+	}
+	if got := usage["completion_tokens"]; got != 7 {
+		t.Fatalf("completion_tokens = %v, want 7", got)
+	}
+	if got := usage["total_tokens"]; got != 127 {
+		t.Fatalf("total_tokens = %v, want 127", got)
+	}
+
+	details := usage["prompt_tokens_details"].(map[string]any)
+	if got := details["cached_tokens"]; got != 20 {
+		t.Fatalf("cached_tokens = %v, want 20", got)
+	}
+	if got := details["cache_write_tokens"]; got != 5 {
+		t.Fatalf("cache_write_tokens = %v, want 5", got)
+	}
+}
+
+func TestStreamingChatIncludeUsage_UsageIncludesCachedPromptTokens(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddTurn(llm.MockTurn{
+		Text: "done",
+		Usage: llm.Usage{
+			InputTokens:       100,
+			CachedInputTokens: 20,
+			CacheWriteTokens:  5,
+			OutputTokens:      7,
+		},
+	})
+	engine := llm.NewEngine(provider, nil)
+
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	srv := &serveServer{sessionMgr: mgr}
+
+	body := `{
+		"model": "test",
+		"stream": true,
+		"stream_options": {"include_usage": true},
+		"messages": [{"role": "user", "content": "Hi"}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleChatCompletions(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rr.Code, rr.Body.String())
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(rr.Body.Bytes()))
+	for {
+		_, data, ok := readSSEEvent(t, scanner)
+		if !ok {
+			t.Fatal("stream ended before usage chunk")
+		}
+		if data == "[DONE]" {
+			break
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			t.Fatalf("unmarshal stream chunk: %v", err)
+		}
+
+		usageVal, ok := payload["usage"]
+		if !ok {
+			continue
+		}
+		usage := usageVal.(map[string]any)
+		if got := usage["prompt_tokens"].(float64); got != 120 {
+			t.Fatalf("prompt_tokens = %v, want 120", got)
+		}
+		if got := usage["completion_tokens"].(float64); got != 7 {
+			t.Fatalf("completion_tokens = %v, want 7", got)
+		}
+		if got := usage["total_tokens"].(float64); got != 127 {
+			t.Fatalf("total_tokens = %v, want 127", got)
+		}
+		details := usage["prompt_tokens_details"].(map[string]any)
+		if got := details["cached_tokens"].(float64); got != 20 {
+			t.Fatalf("cached_tokens = %v, want 20", got)
+		}
+		if got := details["cache_write_tokens"].(float64); got != 5 {
+			t.Fatalf("cache_write_tokens = %v, want 5", got)
+		}
+		return
+	}
+
+	t.Fatal("did not find usage chunk in stream")
+}
+
 func TestNonStreamingResponses_FiltersServerExecutedToolCalls(t *testing.T) {
 	provider := llm.NewMockProvider("mock").
 		AddToolCall("call-1", "echo", map[string]any{"input": "hi"}).


### PR DESCRIPTION
## What

Fix Chat Completions usage accounting so `prompt_tokens` includes cached prompt tokens and `total_tokens` no longer adds `cache_write_tokens`.

Also add regression coverage for both the non-streaming response helper and streaming `include_usage` chunks.

## Why

The previous usage block could report impossible numbers by omitting cached prompt tokens from `prompt_tokens` while adding `cache_write_tokens` into `total_tokens`. That made `total_tokens` inconsistent with `prompt_tokens + completion_tokens` and broke OpenAI-compatible usage accounting for clients that rely on it for quotas, billing, or telemetry.
