### PR TITLE
fix: recover stalled claude-bin tool turns and persist streamed tool calls

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -633,6 +633,47 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// On the first callback, it eagerly persists baseHistory + inputMessages and
 	// only starts incremental appends after that snapshot succeeds.
 	initialPersisted := false
+	currentTurnText := ""
+	var currentTurnToolCalls []llm.ToolCall
+	pendingAssistantIdx := -1
+	toolCallsMatch := func(a, b llm.ToolCall) bool {
+		if strings.TrimSpace(a.ID) != "" && strings.TrimSpace(b.ID) != "" {
+			return strings.TrimSpace(a.ID) == strings.TrimSpace(b.ID)
+		}
+		return strings.TrimSpace(a.Name) == strings.TrimSpace(b.Name) &&
+			strings.TrimSpace(string(a.Arguments)) == strings.TrimSpace(string(b.Arguments))
+	}
+	hasProducedToolCallLocked := func(call llm.ToolCall) bool {
+		for i := len(produced) - 1; i >= 0; i-- {
+			msg := produced[i]
+			if msg.Role != llm.RoleAssistant {
+				continue
+			}
+			for _, part := range msg.Parts {
+				if part.Type != llm.PartToolCall || part.ToolCall == nil {
+					continue
+				}
+				if toolCallsMatch(*part.ToolCall, call) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	buildPendingAssistantLocked := func() (llm.Message, bool) {
+		parts := make([]llm.Part, 0, 1+len(currentTurnToolCalls))
+		if currentTurnText != "" {
+			parts = append(parts, llm.Part{Type: llm.PartText, Text: currentTurnText})
+		}
+		for i := range currentTurnToolCalls {
+			call := currentTurnToolCalls[i]
+			parts = append(parts, llm.Part{Type: llm.PartToolCall, ToolCall: &call})
+		}
+		if len(parts) == 0 {
+			return llm.Message{}, false
+		}
+		return llm.Message{Role: llm.RoleAssistant, Parts: parts}, true
+	}
 	updateStateAndAppendLocked := func(persistCtx context.Context) {
 		if stateful {
 			rt.history = buildSnapshotLocked()
@@ -656,18 +697,49 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		}
 		persistPlatformInjectionLocked()
 	}
+	persistPendingAssistantLocked := func(persistCtx context.Context) {
+		assistantMsg, ok := buildPendingAssistantLocked()
+		if !ok {
+			return
+		}
+		if pendingAssistantIdx >= 0 {
+			produced[pendingAssistantIdx] = assistantMsg
+		} else {
+			produced = append(produced, assistantMsg)
+			pendingAssistantIdx = len(produced) - 1
+		}
+		if stateful {
+			rt.history = buildSnapshotLocked()
+		}
+		if persisted {
+			if rt.persistSnapshot(persistCtx, req.SessionID, buildSnapshotLocked()) {
+				initialPersisted = true
+				lastAppendedIdx = len(produced)
+			}
+		}
+		persistPlatformInjectionLocked()
+	}
 	appendProducedAndUpdateState := func(persistCtx context.Context, msgs ...llm.Message) {
 		producedMu.Lock()
 		defer producedMu.Unlock()
 
-		produced = append(produced, msgs...)
+		if len(msgs) > 0 && msgs[0].Role == llm.RoleAssistant && pendingAssistantIdx >= 0 {
+			produced[pendingAssistantIdx] = msgs[0]
+			pendingAssistantIdx = -1
+			msgs = msgs[1:]
+		}
+		currentTurnText = ""
+		currentTurnToolCalls = nil
+		if len(msgs) > 0 {
+			produced = append(produced, msgs...)
+		}
 		updateStateAndAppendLocked(persistCtx)
 	}
 
-	// ResponseCompletedCallback receives the assistant message (with tool call parts)
-	// immediately after streaming, BEFORE tool execution. Without this, tool calls
-	// are missing from persisted sessions because TurnCompletedCallback only receives
-	// tool results.
+	// ResponseCompletedCallback receives the completed assistant message before
+	// tool execution. EventToolCall snapshots already make tool calls durable as
+	// they stream in; this callback upgrades that provisional assistant message to
+	// the final turn content without duplicating rows.
 	rt.engine.SetResponseCompletedCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message, _ llm.TurnMetrics) error {
 		appendProducedAndUpdateState(cbCtx, assistantMsg)
 		return nil
@@ -738,9 +810,26 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		switch ev.Type {
 		case llm.EventTextDelta:
 			result.Text.WriteString(ev.Text)
+			producedMu.Lock()
+			currentTurnText += ev.Text
+			if pendingAssistantIdx >= 0 {
+				if assistantMsg, ok := buildPendingAssistantLocked(); ok {
+					produced[pendingAssistantIdx] = assistantMsg
+					if stateful {
+						rt.history = buildSnapshotLocked()
+					}
+				}
+			}
+			producedMu.Unlock()
 		case llm.EventToolCall:
 			if ev.Tool != nil {
 				result.ToolCalls = append(result.ToolCalls, *ev.Tool)
+				producedMu.Lock()
+				if !hasProducedToolCallLocked(*ev.Tool) {
+					currentTurnToolCalls = append(currentTurnToolCalls, *ev.Tool)
+					persistPendingAssistantLocked(ctx)
+				}
+				producedMu.Unlock()
 			}
 		case llm.EventUsage:
 			if ev.Use != nil {

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -31,8 +31,53 @@ func (s *serveRuntimeTestStream) Close() error {
 	return nil
 }
 
+type serveRuntimeErrorAfterEventsStream struct {
+	events []llm.Event
+	index  int
+	err    error
+}
+
+func (s *serveRuntimeErrorAfterEventsStream) Recv() (llm.Event, error) {
+	if s.index < len(s.events) {
+		event := s.events[s.index]
+		s.index++
+		return event, nil
+	}
+	return llm.Event{}, s.err
+}
+
+func (s *serveRuntimeErrorAfterEventsStream) Close() error {
+	return nil
+}
+
 type serveRuntimeTestProvider struct {
 	calls int
+}
+
+type serveRuntimeToolCallThenErrorProvider struct {
+	err error
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Name() string {
+	return "serve-runtime-toolcall-error"
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Credential() string {
+	return "test"
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{ToolCalls: true}
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	return &serveRuntimeErrorAfterEventsStream{
+		events: []llm.Event{{
+			Type: llm.EventToolCall,
+			Tool: &llm.ToolCall{ID: "call-err", Name: "serve_runtime_test_tool", Arguments: json.RawMessage(`{"value":1}`)},
+		}},
+		err: p.err,
+	}, nil
 }
 
 func (p *serveRuntimeTestProvider) Name() string {
@@ -525,5 +570,101 @@ func TestServeRuntimeReplaceHistoryClearsPersistedMessagesBeforeEarlyFailure(t *
 	}
 	if got := rt.history; len(got) != 0 {
 		t.Fatalf("runtime history length = %d, want 0", len(got))
+	}
+}
+
+func TestServeRuntimeSnapshotsStreamedToolCallWithoutDuplicatingAssistant(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	provider := &serveRuntimeTestProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+	}
+
+	result, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID:   "sess-streaming-toolcall",
+		Tools:       []llm.ToolSpec{tool.Spec()},
+		ToolChoice:  llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		MaxTurns:    4,
+		Search:      false,
+		Debug:       false,
+		DebugRaw:    false,
+		Temperature: 0,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := result.Text.String(); got != "done" {
+		t.Fatalf("result text = %q, want %q", got, "done")
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "sess-streaming-toolcall", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 4 {
+		t.Fatalf("stored message count = %d, want 4", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "current user" {
+		t.Fatalf("message[0] = %+v, want current user message", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleAssistant || len(msgs[1].Parts) != 1 || msgs[1].Parts[0].Type != llm.PartToolCall {
+		t.Fatalf("message[1] = %+v, want assistant tool call message", msgs[1])
+	}
+	if msgs[2].Role != llm.RoleTool || len(msgs[2].Parts) != 1 || msgs[2].Parts[0].Type != llm.PartToolResult {
+		t.Fatalf("message[2] = %+v, want tool result message", msgs[2])
+	}
+	if msgs[3].Role != llm.RoleAssistant || msgs[3].TextContent != "done" {
+		t.Fatalf("message[3] = %+v, want final assistant message", msgs[3])
+	}
+}
+
+func TestServeRuntimePersistsStreamedToolCallBeforeCallbacks(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	providerErr := errors.New("provider stream failed after tool call")
+	provider := &serveRuntimeToolCallThenErrorProvider{err: providerErr}
+	engine := llm.NewEngine(provider, llm.NewToolRegistry())
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+	}
+
+	_, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID: "sess-toolcall-error",
+	})
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("Run() error = %v, want %v", err, providerErr)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "sess-toolcall-error", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("stored message count = %d, want 2", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "current user" {
+		t.Fatalf("message[0] = %+v, want current user message", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleAssistant || len(msgs[1].Parts) != 1 || msgs[1].Parts[0].Type != llm.PartToolCall {
+		t.Fatalf("message[1] = %+v, want assistant tool call message", msgs[1])
+	}
+	if msgs[1].Parts[0].ToolCall == nil || msgs[1].Parts[0].ToolCall.ID != "call-err" {
+		t.Fatalf("message[1] tool call = %+v, want call-err", msgs[1].Parts[0].ToolCall)
+	}
+	if len(rt.history) != 2 {
+		t.Fatalf("runtime history length = %d, want 2", len(rt.history))
 	}
 }

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -85,6 +86,12 @@ type claudeTurnBridge struct {
 	toolReqCh chan claudeToolRequest
 	// done closes when the active runClaudeCommand turn exits.
 	done chan struct{}
+}
+
+type observedClaudeToolUse struct {
+	id   string
+	name string
+	args json.RawMessage
 }
 
 const (
@@ -550,6 +557,8 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 		linesOpen             = true
 		sawTextDelta          bool
 		assistantFallbackText string
+		observedToolUses      []observedClaudeToolUse
+		executedToolUses      []observedClaudeToolUse
 		toolsExecuted         bool
 	)
 
@@ -564,7 +573,7 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 					break
 				}
 				hadLine = true
-				if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText); err != nil {
+				if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText, &observedToolUses, executedToolUses); err != nil {
 					return nil, false, err
 				}
 			default:
@@ -582,13 +591,15 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 				linesOpen = false
 				continue
 			}
-			if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText); err != nil {
+			if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText, &observedToolUses, executedToolUses); err != nil {
 				return nil, false, err
 			}
 		case req := <-toolReqCh:
-			if err := p.drainClaudeLinesWithGrace(ctx, lineCh, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText); err != nil {
+			if err := p.drainClaudeLinesWithGrace(ctx, lineCh, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText, &observedToolUses, executedToolUses); err != nil {
 				return nil, false, err
 			}
+			consumeObservedClaudeToolUse(&observedToolUses, req.name, req.args)
+			executedToolUses = append(executedToolUses, observedClaudeToolUse{name: strings.TrimSpace(req.name), args: req.args})
 			toolsExecuted = true
 			p.handleClaudeToolRequest(req, send)
 		case <-ctx.Done():
@@ -600,6 +611,8 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 	for {
 		select {
 		case req := <-toolReqCh:
+			consumeObservedClaudeToolUse(&observedToolUses, req.name, req.args)
+			executedToolUses = append(executedToolUses, observedClaudeToolUse{name: strings.TrimSpace(req.name), args: req.args})
 			toolsExecuted = true
 			p.handleClaudeToolRequest(req, send)
 		default:
@@ -608,9 +621,15 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 	}
 drained:
 
+	if len(observedToolUses) > 0 {
+		if err := p.replayObservedClaudeToolUses(observedToolUses, send); err != nil {
+			return nil, false, err
+		}
+		toolsExecuted = true
+	}
+
 	return lastUsage, toolsExecuted, nil
 }
-
 func (p *ClaudeBinProvider) handleClaudeLine(
 	ctx context.Context,
 	line string,
@@ -619,6 +638,8 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 	lastUsage **Usage,
 	sawTextDelta *bool,
 	assistantFallbackText *string,
+	observedToolUses *[]observedClaudeToolUse,
+	executedToolUses []observedClaudeToolUse,
 ) error {
 	var baseMsg struct {
 		Type string `json:"type"`
@@ -675,11 +696,16 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 
 	case "assistant":
 		// Buffer assistant text as a fallback for providers/versions that
-		// don't emit stream_event text deltas.
+		// don't emit stream_event text deltas, and record any tool_use blocks.
 		var assistantMsg claudeAssistantMessage
-		if err := json.Unmarshal([]byte(line), &assistantMsg); err == nil && assistantFallbackText != nil {
-			if text := extractClaudeAssistantText(assistantMsg); text != "" {
-				*assistantFallbackText = text
+		if err := json.Unmarshal([]byte(line), &assistantMsg); err == nil {
+			if assistantFallbackText != nil {
+				if text := extractClaudeAssistantText(assistantMsg); text != "" {
+					*assistantFallbackText = text
+				}
+			}
+			if observedToolUses != nil {
+				recordObservedClaudeToolUses(observedToolUses, extractClaudeAssistantToolUses(assistantMsg), executedToolUses)
 			}
 		}
 
@@ -731,6 +757,116 @@ func (p *ClaudeBinProvider) handleClaudeToolRequest(req claudeToolRequest, send 
 	req.ack <- nil
 }
 
+func recordObservedClaudeToolUses(dst *[]observedClaudeToolUse, calls []observedClaudeToolUse, executed []observedClaudeToolUse) {
+	if dst == nil || len(calls) == 0 {
+		return
+	}
+	for _, call := range calls {
+		if hasObservedClaudeToolUse(executed, call.name, call.args) {
+			continue
+		}
+		duplicate := false
+		for _, existing := range *dst {
+			if existing.id != "" && existing.id == call.id {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			*dst = append(*dst, call)
+		}
+	}
+}
+
+func hasObservedClaudeToolUse(calls []observedClaudeToolUse, name string, args json.RawMessage) bool {
+	wantName := strings.TrimSpace(name)
+	wantArgs := canonicalClaudeToolArgs(args)
+	for _, call := range calls {
+		if call.name == wantName && canonicalClaudeToolArgs(call.args) == wantArgs {
+			return true
+		}
+	}
+	return false
+}
+
+func consumeObservedClaudeToolUse(dst *[]observedClaudeToolUse, name string, args json.RawMessage) {
+	if dst == nil || len(*dst) == 0 {
+		return
+	}
+	wantName := strings.TrimSpace(name)
+	wantArgs := canonicalClaudeToolArgs(args)
+	for i, call := range *dst {
+		if call.name == wantName && canonicalClaudeToolArgs(call.args) == wantArgs {
+			*dst = append((*dst)[:i], (*dst)[i+1:]...)
+			return
+		}
+	}
+}
+
+func (p *ClaudeBinProvider) replayObservedClaudeToolUses(calls []observedClaudeToolUse, send eventSender) error {
+	if len(calls) == 0 {
+		return nil
+	}
+	slog.Warn("claude-bin replaying tool_use blocks without MCP callbacks", "count", len(calls))
+	for i, call := range calls {
+		callID := strings.TrimSpace(call.id)
+		if callID == "" {
+			callID = fmt.Sprintf("observed-tool-%d", i+1)
+		}
+		if len(call.args) == 0 {
+			call.args = json.RawMessage(`{}`)
+		}
+		req := claudeToolRequest{
+			ctx:      context.Background(),
+			callID:   callID,
+			name:     call.name,
+			args:     call.args,
+			response: make(chan ToolExecutionResponse, 1),
+			ack:      make(chan error, 1),
+		}
+		p.handleClaudeToolRequest(req, send)
+		if err := <-req.ack; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func canonicalClaudeToolArgs(args json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(args))
+	if trimmed == "" {
+		return "{}"
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(trimmed)); err == nil {
+		return compact.String()
+	}
+	return trimmed
+}
+
+func extractClaudeAssistantToolUses(msg claudeAssistantMessage) []observedClaudeToolUse {
+	var calls []observedClaudeToolUse
+	for _, block := range msg.Message.Content {
+		if block.Type != "tool_use" {
+			continue
+		}
+		name := mapClaudeToolName(strings.TrimSpace(block.Name))
+		if name == "" {
+			continue
+		}
+		args := block.Input
+		if len(args) == 0 {
+			args = json.RawMessage(`{}`)
+		}
+		calls = append(calls, observedClaudeToolUse{
+			id:   strings.TrimSpace(block.ID),
+			name: name,
+			args: args,
+		})
+	}
+	return calls
+}
+
 func (p *ClaudeBinProvider) drainClaudeLinesWithGrace(
 	ctx context.Context,
 	lineCh <-chan string,
@@ -739,6 +875,8 @@ func (p *ClaudeBinProvider) drainClaudeLinesWithGrace(
 	lastUsage **Usage,
 	sawTextDelta *bool,
 	assistantFallbackText *string,
+	observedToolUses *[]observedClaudeToolUse,
+	executedToolUses []observedClaudeToolUse,
 ) error {
 	// First, drain any already-buffered lines.
 	for {
@@ -747,7 +885,7 @@ func (p *ClaudeBinProvider) drainClaudeLinesWithGrace(
 			if !ok {
 				return nil
 			}
-			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText); err != nil {
+			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText, observedToolUses, executedToolUses); err != nil {
 				return err
 			}
 		default:
@@ -765,7 +903,7 @@ wait:
 			if !ok {
 				return nil
 			}
-			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText); err != nil {
+			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText, observedToolUses, executedToolUses); err != nil {
 				return err
 			}
 			if !timer.Stop() {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -368,12 +368,104 @@ func TestDispatchClaudeEvents_DoesNotDuplicateAssistantFallbackWhenDeltasPresent
 			goto drained
 		}
 	}
+
 drained:
 	if len(got) != 1 {
 		t.Fatalf("expected exactly 1 text event, got %d: %+v", len(got), got)
 	}
 	if got[0].Type != EventTextDelta || got[0].Text != "delta text" {
 		t.Fatalf("unexpected event: %+v", got[0])
+	}
+}
+
+func TestDispatchClaudeEvents_ReplaysObservedInvalidToolUseWithoutMCPCallback(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_bad","name":"mcp__term-llm","input":{}}]}}`
+	close(lines)
+
+	_, toolsExecuted, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if !toolsExecuted {
+		t.Fatal("expected observed tool_use replay to count as tool execution")
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Type != EventToolCall {
+			t.Fatalf("expected EventToolCall, got %+v", ev)
+		}
+		if ev.ToolName != "mcp__term-llm" {
+			t.Fatalf("tool name = %q, want invalid observed name preserved", ev.ToolName)
+		}
+		if ev.ToolCallID != "toolu_bad" {
+			t.Fatalf("tool call id = %q, want observed assistant tool_use id", ev.ToolCallID)
+		}
+		if ev.ToolResponse == nil {
+			t.Fatal("expected replayed tool call to include ToolResponse for sync recovery")
+		}
+	default:
+		t.Fatal("expected replayed tool call event")
+	}
+}
+
+func TestDispatchClaudeEvents_DoesNotReplayObservedToolUseWhenMCPCallbackMatches(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_shell","name":"mcp__term-llm__shell","input":{"command":"pwd"}}]}}`
+	close(lines)
+
+	req := claudeToolRequest{
+		ctx:      context.Background(),
+		callID:   "mcp-shell-1",
+		name:     "shell",
+		args:     json.RawMessage(`{"command":"pwd"}`),
+		response: make(chan ToolExecutionResponse, 1),
+		ack:      make(chan error, 1),
+	}
+	toolReqs <- req
+
+	_, toolsExecuted, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if !toolsExecuted {
+		t.Fatal("expected actual MCP callback to count as tool execution")
+	}
+	if ackErr := <-req.ack; ackErr != nil {
+		t.Fatalf("expected tool request ack to succeed, got %v", ackErr)
+	}
+
+	var got []Event
+	for {
+		select {
+		case ev := <-events:
+			got = append(got, ev)
+		default:
+			goto drainedObserved
+		}
+	}
+
+drainedObserved:
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 tool event, got %d: %+v", len(got), got)
+	}
+	if got[0].Type != EventToolCall {
+		t.Fatalf("expected EventToolCall, got %+v", got[0])
+	}
+	if got[0].ToolCallID != "mcp-shell-1" {
+		t.Fatalf("tool call id = %q, want actual MCP callback id", got[0].ToolCallID)
+	}
+	if got[0].ToolName != "shell" {
+		t.Fatalf("tool name = %q, want mapped local tool name", got[0].ToolName)
 	}
 }
 
@@ -441,6 +533,8 @@ func TestHandleClaudeLine_ContextCancelledDoesNotBlock(t *testing.T) {
 		&usage,
 		&sawTextDelta,
 		&assistantFallbackText,
+		nil,
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected cancellation error")


### PR DESCRIPTION
## What

Fix two related failure modes behind session 1751:

1. `claude-bin` now replays dangling Claude Code `tool_use` blocks when no MCP callback arrives, so malformed calls like `mcp__term-llm` still produce a normal tool error and the outer loop resumes.
2. `serve_runtime` now snapshots streamed `EventToolCall` assistant state to the session DB as the tool call arrives, instead of waiting for later callbacks or the final snapshot.

Specifically:

- record `assistant` `tool_use` blocks from Claude CLI stream-json output
- match them against real MCP callbacks by tool name + canonicalized args
- if the turn ends with unmatched observed tool uses, replay them into the engine as sync tool calls
- preserve invalid tool names so the engine emits a normal tool error result and the next resumed turn can recover
- snapshot in-flight assistant tool-call state from `EventToolCall` into SQLite immediately
- keep runtime history in sync with that provisional assistant message so a later `continue` sees the same tool call history the DB has
- avoid duplicate assistant rows when the normal response callback arrives before or after the streamed tool-call event
- add regression tests for dangling tool uses, streamed tool-call persistence, and the error-before-callback case

## Why

Session 1751 had two separate cracks in the system:

- a malformed Claude Code tool call stalled because `claude-bin` only resumed after a real MCP callback
- streamed tool calls could be visible in provider JSONL but missing from `sessions.db` because the web runtime only made them durable later, during callbacks/final snapshot

That combination is how you end up with a session that both stalls and looks wrong in SQLite.

This patch closes both holes:

- the stalled Claude turn now gets a synthetic tool error and resumes
- streamed tool calls now hit SQLite immediately, so crashes/stalls/continues do not erase them from persisted session history

## Testing

- `go test ./cmd -run 'TestServeRuntime'`
- `go test ./...`
- `go build ./...`
