### PR TITLE
fix(web): persist streamed tool calls immediately

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -633,6 +633,47 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// On the first callback, it eagerly persists baseHistory + inputMessages and
 	// only starts incremental appends after that snapshot succeeds.
 	initialPersisted := false
+	currentTurnText := ""
+	var currentTurnToolCalls []llm.ToolCall
+	pendingAssistantIdx := -1
+	toolCallsMatch := func(a, b llm.ToolCall) bool {
+		if strings.TrimSpace(a.ID) != "" && strings.TrimSpace(b.ID) != "" {
+			return strings.TrimSpace(a.ID) == strings.TrimSpace(b.ID)
+		}
+		return strings.TrimSpace(a.Name) == strings.TrimSpace(b.Name) &&
+			strings.TrimSpace(string(a.Arguments)) == strings.TrimSpace(string(b.Arguments))
+	}
+	hasProducedToolCallLocked := func(call llm.ToolCall) bool {
+		for i := len(produced) - 1; i >= 0; i-- {
+			msg := produced[i]
+			if msg.Role != llm.RoleAssistant {
+				continue
+			}
+			for _, part := range msg.Parts {
+				if part.Type != llm.PartToolCall || part.ToolCall == nil {
+					continue
+				}
+				if toolCallsMatch(*part.ToolCall, call) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	buildPendingAssistantLocked := func() (llm.Message, bool) {
+		parts := make([]llm.Part, 0, 1+len(currentTurnToolCalls))
+		if currentTurnText != "" {
+			parts = append(parts, llm.Part{Type: llm.PartText, Text: currentTurnText})
+		}
+		for i := range currentTurnToolCalls {
+			call := currentTurnToolCalls[i]
+			parts = append(parts, llm.Part{Type: llm.PartToolCall, ToolCall: &call})
+		}
+		if len(parts) == 0 {
+			return llm.Message{}, false
+		}
+		return llm.Message{Role: llm.RoleAssistant, Parts: parts}, true
+	}
 	updateStateAndAppendLocked := func(persistCtx context.Context) {
 		if stateful {
 			rt.history = buildSnapshotLocked()
@@ -656,18 +697,49 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		}
 		persistPlatformInjectionLocked()
 	}
+	persistPendingAssistantLocked := func(persistCtx context.Context) {
+		assistantMsg, ok := buildPendingAssistantLocked()
+		if !ok {
+			return
+		}
+		if pendingAssistantIdx >= 0 {
+			produced[pendingAssistantIdx] = assistantMsg
+		} else {
+			produced = append(produced, assistantMsg)
+			pendingAssistantIdx = len(produced) - 1
+		}
+		if stateful {
+			rt.history = buildSnapshotLocked()
+		}
+		if persisted {
+			if rt.persistSnapshot(persistCtx, req.SessionID, buildSnapshotLocked()) {
+				initialPersisted = true
+				lastAppendedIdx = len(produced)
+			}
+		}
+		persistPlatformInjectionLocked()
+	}
 	appendProducedAndUpdateState := func(persistCtx context.Context, msgs ...llm.Message) {
 		producedMu.Lock()
 		defer producedMu.Unlock()
 
-		produced = append(produced, msgs...)
+		if len(msgs) > 0 && msgs[0].Role == llm.RoleAssistant && pendingAssistantIdx >= 0 {
+			produced[pendingAssistantIdx] = msgs[0]
+			pendingAssistantIdx = -1
+			msgs = msgs[1:]
+		}
+		currentTurnText = ""
+		currentTurnToolCalls = nil
+		if len(msgs) > 0 {
+			produced = append(produced, msgs...)
+		}
 		updateStateAndAppendLocked(persistCtx)
 	}
 
-	// ResponseCompletedCallback receives the assistant message (with tool call parts)
-	// immediately after streaming, BEFORE tool execution. Without this, tool calls
-	// are missing from persisted sessions because TurnCompletedCallback only receives
-	// tool results.
+	// ResponseCompletedCallback receives the completed assistant message before
+	// tool execution. EventToolCall snapshots already make tool calls durable as
+	// they stream in; this callback upgrades that provisional assistant message to
+	// the final turn content without duplicating rows.
 	rt.engine.SetResponseCompletedCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message, _ llm.TurnMetrics) error {
 		appendProducedAndUpdateState(cbCtx, assistantMsg)
 		return nil
@@ -738,9 +810,26 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		switch ev.Type {
 		case llm.EventTextDelta:
 			result.Text.WriteString(ev.Text)
+			producedMu.Lock()
+			currentTurnText += ev.Text
+			if pendingAssistantIdx >= 0 {
+				if assistantMsg, ok := buildPendingAssistantLocked(); ok {
+					produced[pendingAssistantIdx] = assistantMsg
+					if stateful {
+						rt.history = buildSnapshotLocked()
+					}
+				}
+			}
+			producedMu.Unlock()
 		case llm.EventToolCall:
 			if ev.Tool != nil {
 				result.ToolCalls = append(result.ToolCalls, *ev.Tool)
+				producedMu.Lock()
+				if !hasProducedToolCallLocked(*ev.Tool) {
+					currentTurnToolCalls = append(currentTurnToolCalls, *ev.Tool)
+					persistPendingAssistantLocked(ctx)
+				}
+				producedMu.Unlock()
 			}
 		case llm.EventUsage:
 			if ev.Use != nil {

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -31,8 +31,53 @@ func (s *serveRuntimeTestStream) Close() error {
 	return nil
 }
 
+type serveRuntimeErrorAfterEventsStream struct {
+	events []llm.Event
+	index  int
+	err    error
+}
+
+func (s *serveRuntimeErrorAfterEventsStream) Recv() (llm.Event, error) {
+	if s.index < len(s.events) {
+		event := s.events[s.index]
+		s.index++
+		return event, nil
+	}
+	return llm.Event{}, s.err
+}
+
+func (s *serveRuntimeErrorAfterEventsStream) Close() error {
+	return nil
+}
+
 type serveRuntimeTestProvider struct {
 	calls int
+}
+
+type serveRuntimeToolCallThenErrorProvider struct {
+	err error
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Name() string {
+	return "serve-runtime-toolcall-error"
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Credential() string {
+	return "test"
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{ToolCalls: true}
+}
+
+func (p *serveRuntimeToolCallThenErrorProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	return &serveRuntimeErrorAfterEventsStream{
+		events: []llm.Event{{
+			Type: llm.EventToolCall,
+			Tool: &llm.ToolCall{ID: "call-err", Name: "serve_runtime_test_tool", Arguments: json.RawMessage(`{"value":1}`)},
+		}},
+		err: p.err,
+	}, nil
 }
 
 func (p *serveRuntimeTestProvider) Name() string {
@@ -525,5 +570,101 @@ func TestServeRuntimeReplaceHistoryClearsPersistedMessagesBeforeEarlyFailure(t *
 	}
 	if got := rt.history; len(got) != 0 {
 		t.Fatalf("runtime history length = %d, want 0", len(got))
+	}
+}
+
+func TestServeRuntimeSnapshotsStreamedToolCallWithoutDuplicatingAssistant(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	provider := &serveRuntimeTestProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+	}
+
+	result, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID:   "sess-streaming-toolcall",
+		Tools:       []llm.ToolSpec{tool.Spec()},
+		ToolChoice:  llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		MaxTurns:    4,
+		Search:      false,
+		Debug:       false,
+		DebugRaw:    false,
+		Temperature: 0,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := result.Text.String(); got != "done" {
+		t.Fatalf("result text = %q, want %q", got, "done")
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "sess-streaming-toolcall", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 4 {
+		t.Fatalf("stored message count = %d, want 4", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "current user" {
+		t.Fatalf("message[0] = %+v, want current user message", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleAssistant || len(msgs[1].Parts) != 1 || msgs[1].Parts[0].Type != llm.PartToolCall {
+		t.Fatalf("message[1] = %+v, want assistant tool call message", msgs[1])
+	}
+	if msgs[2].Role != llm.RoleTool || len(msgs[2].Parts) != 1 || msgs[2].Parts[0].Type != llm.PartToolResult {
+		t.Fatalf("message[2] = %+v, want tool result message", msgs[2])
+	}
+	if msgs[3].Role != llm.RoleAssistant || msgs[3].TextContent != "done" {
+		t.Fatalf("message[3] = %+v, want final assistant message", msgs[3])
+	}
+}
+
+func TestServeRuntimePersistsStreamedToolCallBeforeCallbacks(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	providerErr := errors.New("provider stream failed after tool call")
+	provider := &serveRuntimeToolCallThenErrorProvider{err: providerErr}
+	engine := llm.NewEngine(provider, llm.NewToolRegistry())
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+	}
+
+	_, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID: "sess-toolcall-error",
+	})
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("Run() error = %v, want %v", err, providerErr)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "sess-toolcall-error", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("stored message count = %d, want 2", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "current user" {
+		t.Fatalf("message[0] = %+v, want current user message", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleAssistant || len(msgs[1].Parts) != 1 || msgs[1].Parts[0].Type != llm.PartToolCall {
+		t.Fatalf("message[1] = %+v, want assistant tool call message", msgs[1])
+	}
+	if msgs[1].Parts[0].ToolCall == nil || msgs[1].Parts[0].ToolCall.ID != "call-err" {
+		t.Fatalf("message[1] tool call = %+v, want call-err", msgs[1].Parts[0].ToolCall)
+	}
+	if len(rt.history) != 2 {
+		t.Fatalf("runtime history length = %d, want 2", len(rt.history))
 	}
 }


### PR DESCRIPTION
## What

Persist streamed assistant tool calls in the web runtime as soon as `EventToolCall` arrives instead of waiting for response/turn callbacks.

Concretely this adds a provisional pending assistant message during streaming and snapshots it to the session DB immediately, then upgrades that same message to the final assistant content when the normal callbacks arrive.

## Why

Session 1751 showed a nasty durability hole:

- the Claude JSONL had real tool activity between `"I want a fantastic writeup"` and `"continue"`
- `sessions.db` did not
- the missing chunk existed because web persistence only became durable later, at callback/final-snapshot time

If the run stalled, errored, or needed a manual continue before those later persistence points, the tool-call portion of the turn could be absent from sqlite even though it really happened.

This makes streamed tool calls durable at event time, so the session DB reflects reality much more closely under stalls/interruption/failures.

## Notes

- avoids duplicating the assistant message when the later response callback arrives
- keeps the existing final snapshot reconciliation path
- includes coverage for:
  - streamed tool call + normal completion
  - streamed tool call + stream error before callbacks
  - initial snapshot retry path still succeeding

## Testing

```bash
go test ./cmd -run 'TestServeRuntime'
go build ./...
go test ./...
```