### PR TITLE
fix: Resetting a conversation leaves stale interjections and queued dynamic tools behind

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -194,15 +194,20 @@ func (e *Engine) Tools() *ToolRegistry {
 
 // ResetConversation clears all conversation-specific state from the engine.
 // Called on /clear or /new to start a fresh conversation. This resets
-// compaction tracking, context notices, and provider-side conversation state
-// (e.g., OpenAI Responses API previous_response_id).
+// compaction tracking, queued interjections, queued dynamic tools, context notices,
+// and provider-side conversation state (e.g., OpenAI Responses API previous_response_id).
 func (e *Engine) ResetConversation() {
 	e.callbackMu.Lock()
 	e.lastTotalTokens = 0
 	e.lastMessageCount = 0
 	e.systemPrompt = ""
+	e.interjection = nil
 	e.contextNoticeEmitted.Store(false)
 	e.callbackMu.Unlock()
+
+	e.pendingToolsMu.Lock()
+	e.pendingToolSpecs = nil
+	e.pendingToolsMu.Unlock()
 
 	// Reset provider-side conversation state if supported
 	type conversationResetter interface {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1772,6 +1772,8 @@ func TestEngineResetConversation(t *testing.T) {
 	e.systemPrompt = "You are a helpful assistant."
 	e.contextNoticeEmitted.Store(true)
 	e.callbackMu.Unlock()
+	e.Interject("stale interjection")
+	e.AddDynamicTool(&countingTool{})
 
 	// Reset conversation
 	e.ResetConversation()
@@ -1791,6 +1793,13 @@ func TestEngineResetConversation(t *testing.T) {
 		t.Error("expected contextNoticeEmitted=false")
 	}
 	e.callbackMu.RUnlock()
+
+	if text := e.DrainInterjection(); text != "" {
+		t.Errorf("expected no pending interjection after reset, got %q", text)
+	}
+	if pending := e.drainPendingToolSpecs(); len(pending) != 0 {
+		t.Errorf("expected no pending dynamic tools after reset, got %d", len(pending))
+	}
 }
 
 func TestEngineResetConversationCallsProvider(t *testing.T) {


### PR DESCRIPTION
## What

Clear pending interjections and queued dynamic tool specs in `Engine.ResetConversation()` so `/clear` and `/new` fully reset conversation-local engine state.

## Why

Without clearing those queues, a fresh conversation can inherit a stale queued user interjection or dynamic tool from the previous conversation before the next turn drains them. That leaks state across supposedly clean sessions and can expose tools or messages the new conversation never requested.
