### PR TITLE
fix: xAI streaming breaks on SSE lines larger than 1 MiB

### DIFF
--- a/internal/llm/xai.go
+++ b/internal/llm/xai.go
@@ -122,22 +122,32 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
-		scanner := bufio.NewScanner(resp.Body)
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		reader := bufio.NewReader(resp.Body)
 
 		toolState := newCompatToolState()
 		tagStripper := newXAITagStripper()
 		var lastUsage *Usage
 		var lastEventType string
 
-		for scanner.Scan() {
-			line := scanner.Text()
+		for {
+			line, eof, err := readSSELine(reader)
+			if err != nil {
+				return fmt.Errorf("xAI streaming error: %w", err)
+			}
+			if eof && line == "" {
+				break
+			}
 			if strings.HasPrefix(line, "event: ") {
 				lastEventType = strings.TrimPrefix(line, "event: ")
+				if eof {
+					break
+				}
 				continue
 			}
 			if !strings.HasPrefix(line, "data: ") {
+				if eof {
+					break
+				}
 				continue
 			}
 			data := strings.TrimPrefix(line, "data: ")
@@ -147,6 +157,9 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 
 			var chatResp oaiChatResponse
 			if err := json.Unmarshal([]byte(data), &chatResp); err != nil {
+				if eof {
+					break
+				}
 				continue
 			}
 
@@ -193,6 +206,9 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 			}
 
 			lastEventType = ""
+			if eof {
+				break
+			}
 		}
 
 		// Flush any remaining buffered content
@@ -200,10 +216,6 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 			if err := send.Send(Event{Type: EventTextDelta, Text: remaining}); err != nil {
 				return err
 			}
-		}
-
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("xAI streaming error: %w", err)
 		}
 
 		for _, call := range toolState.Calls() {
@@ -263,16 +275,23 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
-		scanner := bufio.NewScanner(resp.Body)
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		reader := bufio.NewReader(resp.Body)
 
 		var lastUsage *Usage
 		var searchStarted bool
 
-		for scanner.Scan() {
-			line := scanner.Text()
+		for {
+			line, eof, err := readSSELine(reader)
+			if err != nil {
+				return fmt.Errorf("xAI Responses streaming error: %w", err)
+			}
+			if eof && line == "" {
+				break
+			}
 			if !strings.HasPrefix(line, "data: ") {
+				if eof {
+					break
+				}
 				continue
 			}
 			data := strings.TrimPrefix(line, "data: ")
@@ -282,6 +301,9 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 
 			var event xaiResponsesEvent
 			if err := json.Unmarshal([]byte(data), &event); err != nil {
+				if eof {
+					break
+				}
 				continue
 			}
 
@@ -323,10 +345,9 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 			case "error":
 				return fmt.Errorf("xAI Responses API error: %s", event.Error)
 			}
-		}
-
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("xAI Responses streaming error: %w", err)
+			if eof {
+				break
+			}
 		}
 
 		if lastUsage != nil {

--- a/internal/llm/xai_test.go
+++ b/internal/llm/xai_test.go
@@ -1,0 +1,210 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestXAIStreamStandard_AllowsLargeSSEDataLines(t *testing.T) {
+	origClient := defaultHTTPClient
+	defer func() {
+		defaultHTTPClient = origClient
+	}()
+
+	largeText := strings.Repeat("a", 1024*1024+1024)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+
+		chunk, err := json.Marshal(oaiChatResponse{
+			Choices: []oaiChoice{{
+				Delta: &oaiMessage{Content: largeText},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("marshal chunk: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if _, err := w.Write([]byte("data: ")); err != nil {
+			t.Fatalf("write prefix: %v", err)
+		}
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("write chunk: %v", err)
+		}
+		if _, err := w.Write([]byte("\n\ndata: [DONE]\n\n")); err != nil {
+			t.Fatalf("write done: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			cloned := req.Clone(req.Context())
+			urlCopy := *req.URL
+			cloned.URL = &urlCopy
+			cloned.URL.Scheme = serverURL.Scheme
+			cloned.URL.Host = serverURL.Host
+			return server.Client().Transport.RoundTrip(cloned)
+		}),
+	}
+
+	provider := NewXAIProvider("test-key", "test-model")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	var got strings.Builder
+	var sawDone bool
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			got.WriteString(event.Text)
+		case EventDone:
+			sawDone = true
+		case EventError:
+			t.Fatalf("unexpected stream error: %v", event.Err)
+		}
+	}
+
+	if got.String() != largeText {
+		t.Fatalf("expected %d bytes of streamed text, got %d", len(largeText), got.Len())
+	}
+	if !sawDone {
+		t.Fatal("expected EventDone")
+	}
+}
+
+func TestXAIStreamWithSearch_AllowsLargeSSEDataLines(t *testing.T) {
+	origClient := defaultHTTPClient
+	defer func() {
+		defaultHTTPClient = origClient
+	}()
+
+	largeText := strings.Repeat("b", 1024*1024+1024)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+
+		delta, err := json.Marshal(xaiResponsesEvent{
+			Type:  "response.output_text.delta",
+			Delta: largeText,
+		})
+		if err != nil {
+			t.Fatalf("marshal delta: %v", err)
+		}
+
+		completed, err := json.Marshal(xaiResponsesEvent{
+			Type: "response.completed",
+			Response: &xaiResponsesCompletion{
+				Usage: &xaiResponsesUsage{InputTokens: 10, OutputTokens: 20},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal completed: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if _, err := w.Write([]byte("data: ")); err != nil {
+			t.Fatalf("write prefix: %v", err)
+		}
+		if _, err := w.Write(delta); err != nil {
+			t.Fatalf("write delta: %v", err)
+		}
+		if _, err := w.Write([]byte("\n\ndata: ")); err != nil {
+			t.Fatalf("write separator: %v", err)
+		}
+		if _, err := w.Write(completed); err != nil {
+			t.Fatalf("write completed: %v", err)
+		}
+		if _, err := w.Write([]byte("\n\ndata: [DONE]\n\n")); err != nil {
+			t.Fatalf("write done: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			cloned := req.Clone(req.Context())
+			urlCopy := *req.URL
+			cloned.URL = &urlCopy
+			cloned.URL.Scheme = serverURL.Scheme
+			cloned.URL.Host = serverURL.Host
+			return server.Client().Transport.RoundTrip(cloned)
+		}),
+	}
+
+	provider := NewXAIProvider("test-key", "test-model")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+		Search:   true,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	var got strings.Builder
+	var gotUsage *Usage
+	var sawDone bool
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			got.WriteString(event.Text)
+		case EventUsage:
+			gotUsage = event.Use
+		case EventDone:
+			sawDone = true
+		case EventError:
+			t.Fatalf("unexpected stream error: %v", event.Err)
+		}
+	}
+
+	if got.String() != largeText {
+		t.Fatalf("expected %d bytes of streamed text, got %d", len(largeText), got.Len())
+	}
+	if gotUsage == nil || gotUsage.InputTokens != 10 || gotUsage.OutputTokens != 20 {
+		t.Fatalf("unexpected usage: %+v", gotUsage)
+	}
+	if !sawDone {
+		t.Fatal("expected EventDone")
+	}
+}


### PR DESCRIPTION
## What

- replace both xAI streaming paths in `internal/llm/xai.go` to read SSE lines with `bufio.Reader` + `readSSELine` instead of `bufio.Scanner`
- preserve existing streaming behavior while removing the 1 MiB scanner token limit that aborted valid large `data:` events
- add regression tests covering large (>1 MiB) SSE `data:` lines for both standard chat-completions streaming and Responses API search streaming

## Why

`bufio.Scanner` stops with `ErrTooLong` when a single SSE line exceeds its configured token size. xAI can legally emit very large `data:` lines for tool-call JSON, long text chunks, or search output, which caused valid streams to fail with a spurious provider error.

Using `bufio.Reader` avoids that hard per-line limit and matches the existing OpenAI-compatible SSE handling.

Verification:
- `gofmt -w internal/llm/xai.go internal/llm/xai_test.go`
- `go build ./...` ✅
- `go test ./internal/llm -run '^TestXAI'` ✅
- `go test ./...` currently fails due to a pre-existing unrelated test failure in `internal/llm/models_test.go` (`TestSortModelIDsByPopularity/resolves_provider_aliases_for_ranking`)
