### PR TITLE
fix: Anthropic mixed user/tool-result messages are reordered incorrectly when parsed

### DIFF
--- a/cmd/serve_protocol_anthropic.go
+++ b/cmd/serve_protocol_anthropic.go
@@ -163,20 +163,29 @@ func parseAnthropicMessages(msgs []anthropicMessage) ([]llm.Message, error) {
 			// Anthropic puts tool_result blocks in user messages.
 			// Split them out into RoleTool messages so the OpenAI-compat
 			// provider can emit proper {"role":"tool"} entries.
-			var userParts, toolParts []llm.Part
-			for _, p := range parts {
-				if p.Type == llm.PartToolResult {
-					toolParts = append(toolParts, p)
-				} else {
-					userParts = append(userParts, p)
+			// Preserve the original block ordering by flushing contiguous
+			// runs of tool_result vs non-tool_result parts as separate messages.
+			var currentRole llm.Role
+			var currentParts []llm.Part
+			flush := func() {
+				if len(currentParts) == 0 {
+					return
 				}
+				result = append(result, llm.Message{Role: currentRole, Parts: currentParts})
+				currentParts = nil
 			}
-			if len(toolParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleTool, Parts: toolParts})
+			for _, p := range parts {
+				nextRole := llm.RoleUser
+				if p.Type == llm.PartToolResult {
+					nextRole = llm.RoleTool
+				}
+				if len(currentParts) > 0 && currentRole != nextRole {
+					flush()
+				}
+				currentRole = nextRole
+				currentParts = append(currentParts, p)
 			}
-			if len(userParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleUser, Parts: userParts})
-			}
+			flush()
 		case "assistant":
 			result = append(result, llm.Message{Role: llm.RoleAssistant, Parts: parts})
 		default:

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -7112,6 +7112,40 @@ func TestParseAnthropicMessages_ToolUseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAnthropicMessages_UserToolResultsPreserveOrder(t *testing.T) {
+	msgs, err := parseAnthropicMessages([]anthropicMessage{
+		{Role: "user", Content: json.RawMessage(`[
+			{"type":"text","text":"before"},
+			{"type":"tool_result","tool_use_id":"call_1","content":"result 1"},
+			{"type":"text","text":"between"},
+			{"type":"tool_result","tool_use_id":"call_2","content":"result 2"},
+			{"type":"text","text":"after"}
+		]`)},
+	})
+	if err != nil {
+		t.Fatalf("parseAnthropicMessages: %v", err)
+	}
+	if len(msgs) != 5 {
+		t.Fatalf("len = %d, want 5", len(msgs))
+	}
+
+	if msgs[0].Role != llm.RoleUser || len(msgs[0].Parts) != 1 || msgs[0].Parts[0].Text != "before" {
+		t.Fatalf("message[0] = %+v, want user text before", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleTool || len(msgs[1].Parts) != 1 || msgs[1].Parts[0].ToolResult == nil || msgs[1].Parts[0].ToolResult.ID != "call_1" {
+		t.Fatalf("message[1] = %+v, want tool result call_1", msgs[1])
+	}
+	if msgs[2].Role != llm.RoleUser || len(msgs[2].Parts) != 1 || msgs[2].Parts[0].Text != "between" {
+		t.Fatalf("message[2] = %+v, want user text between", msgs[2])
+	}
+	if msgs[3].Role != llm.RoleTool || len(msgs[3].Parts) != 1 || msgs[3].Parts[0].ToolResult == nil || msgs[3].Parts[0].ToolResult.ID != "call_2" {
+		t.Fatalf("message[3] = %+v, want tool result call_2", msgs[3])
+	}
+	if msgs[4].Role != llm.RoleUser || len(msgs[4].Parts) != 1 || msgs[4].Parts[0].Text != "after" {
+		t.Fatalf("message[4] = %+v, want user text after", msgs[4])
+	}
+}
+
 func TestParseAnthropicSystem(t *testing.T) {
 	// String form
 	if got := parseAnthropicSystem(json.RawMessage(`"Be helpful"`)); got != "Be helpful" {


### PR DESCRIPTION
## What

Fix Anthropic user-message parsing so mixed text/tool_result content preserves the original block order.

When a user message contains interleaved normal content and `tool_result` blocks, the parser now flushes contiguous runs into separate `user` and `tool` messages in request order instead of collecting all tool results first and all user parts second.

Also adds a regression test covering interleaved text and tool results.

## Why

Reordering mixed user/tool-result blocks rewrites the conversation history compared with what the client sent. That can subtly change continuation semantics and model behavior. Preserving the original ordering keeps Anthropic request parsing faithful while still emitting `RoleTool` messages for downstream OpenAI-compatible handling.
