### PR TITLE
fix: Session pre-persistence reads runtime state without locking, causing real races with active runs

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -189,45 +189,68 @@ func (rt *serveRuntime) Interrupt(ctx context.Context, msg string, fastProvider 
 }
 
 // ensureSessionInStore creates the session record in the database if it doesn't
-// exist yet and returns the assigned session number. Unlike ensurePersistedSession,
-// this does NOT mutate runtime state (sessionMeta, history), so it is safe to call
-// without holding rt.mu.
+// exist yet and returns the assigned session number. It never mutates runtime
+// state. When the runtime lock is unavailable because a run is active, it
+// falls back to store-only lookup rather than racing live runtime fields.
 func (rt *serveRuntime) ensureSessionInStore(ctx context.Context, sessionID string, inputMessages []llm.Message) int64 {
 	if rt.store == nil || sessionID == "" {
 		return 0
 	}
-	// Fast path: runtime already hydrated under rt.mu by a prior run.
-	if meta := rt.sessionMeta; meta != nil && meta.ID == sessionID {
-		return meta.Number
+
+	providerName := "unknown"
+	modelName := "unknown"
+	providerKey := ""
+	agentName := ""
+	toolsSetting := ""
+	mcpSetting := ""
+	search := false
+	haveSnapshot := false
+
+	if rt.mu.TryLock() {
+		if meta := rt.sessionMeta; meta != nil && meta.ID == sessionID {
+			number := meta.Number
+			rt.mu.Unlock()
+			return number
+		}
+		if rt.provider != nil {
+			if name := strings.TrimSpace(rt.provider.Name()); name != "" {
+				providerName = name
+			}
+		}
+		if name := strings.TrimSpace(rt.defaultModel); name != "" {
+			modelName = name
+		}
+		providerKey = strings.TrimSpace(rt.providerKey)
+		agentName = rt.agentName
+		search = rt.search
+		toolsSetting = rt.toolsSetting
+		mcpSetting = rt.mcpSetting
+		haveSnapshot = true
+		rt.mu.Unlock()
 	}
+
 	// Check DB for existing session.
 	if existing, err := rt.store.Get(ctx, sessionID); err == nil && existing != nil {
 		return existing.Number
 	}
+	if !haveSnapshot {
+		return 0
+	}
+
 	// Build and insert a new session record.
-	providerName := "unknown"
-	if rt.provider != nil {
-		if name := strings.TrimSpace(rt.provider.Name()); name != "" {
-			providerName = name
-		}
-	}
-	modelName := strings.TrimSpace(rt.defaultModel)
-	if modelName == "" {
-		modelName = "unknown"
-	}
 	sess := &session.Session{
 		ID:          sessionID,
 		Provider:    providerName,
-		ProviderKey: strings.TrimSpace(rt.providerKey),
+		ProviderKey: providerKey,
 		Model:       modelName,
 		Mode:        session.ModeChat,
 		Origin:      session.OriginWeb,
-		Agent:       rt.agentName,
+		Agent:       agentName,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
-		Search:      rt.search,
-		Tools:       rt.toolsSetting,
-		MCP:         rt.mcpSetting,
+		Search:      search,
+		Tools:       toolsSetting,
+		MCP:         mcpSetting,
 		Status:      session.StatusActive,
 	}
 	if cwd, err := os.Getwd(); err == nil {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2214,6 +2214,47 @@ func TestHandleResponses_GeneratesSessionIDHeaderWhenMissing(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionInStore_BusyRuntimeFallsBackToStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{
+		ID:        "busy-session",
+		Provider:  "mock",
+		Model:     "mock-model",
+		Mode:      session.ModeChat,
+		Origin:    session.OriginWeb,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Status:    session.StatusActive,
+	}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	rt := &serveRuntime{store: store}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	resultCh := make(chan int64, 1)
+	go func() {
+		resultCh <- rt.ensureSessionInStore(context.Background(), sess.ID, nil)
+	}()
+
+	select {
+	case num := <-resultCh:
+		if num != sess.Number {
+			t.Fatalf("ensureSessionInStore = %d, want %d", num, sess.Number)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ensureSessionInStore blocked on busy runtime")
+	}
+}
+
 func TestStreamUIResponses_SetsSessionNumberHeader(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

- snapshot the runtime fields used by `ensureSessionInStore` only while `rt.mu` is available
- avoid reading `sessionMeta` and related runtime config directly when another run is active
- fall back to store lookup when the runtime is busy, and add a regression test that verifies the helper does not block on a busy runtime

## Why

`streamUIResponses` calls `ensureSessionInStore` before it knows whether the runtime is idle. The old code read live runtime state without synchronization, which can race with an active run mutating that state under `rt.mu`. Using `TryLock` for the snapshot keeps the helper non-blocking for the UI path while removing the unsafe unsynchronized reads.
