### PR TITLE
fix: keep iPhone chip picker inside visual viewport

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1726,19 +1726,36 @@ const positionChipPopover = (triggerEl) => {
   const pop = elements.chipPopover;
   if (!pop || !triggerEl?.getBoundingClientRect) return;
   pop.hidden = false;
-  if (window.innerWidth <= 540) {
-    pop.style.top = '';
-    pop.style.left = '';
-    pop.style.right = '';
-    pop.style.bottom = '';
+
+  const vv = window.visualViewport;
+  const viewportWidth = vv ? Math.round(vv.width) : window.innerWidth;
+  const viewportHeight = vv ? Math.round(vv.height) : window.innerHeight;
+  const viewportOffsetLeft = vv ? Math.max(0, Math.round(vv.offsetLeft)) : 0;
+  const viewportOffsetTop = vv ? Math.max(0, Math.round(vv.offsetTop)) : 0;
+
+  if (viewportWidth <= 540) {
+    // On iPhone Safari the on-screen keyboard shrinks the visual viewport, but
+    // CSS vh units and fixed bottom sheets can still end up underneath it. Pin
+    // the picker to the visible viewport instead of the layout viewport so the
+    // whole sheet stays inside the safe area while typing in the filter box.
+    pop.style.left = `calc(${viewportOffsetLeft}px + 0.5rem + var(--safe-left))`;
+    pop.style.top = `calc(${viewportOffsetTop}px + 0.5rem + var(--safe-top))`;
+    pop.style.right = 'auto';
+    pop.style.bottom = 'auto';
+    pop.style.width = `calc(${viewportWidth}px - 1rem - var(--safe-left) - var(--safe-right))`;
     pop.style.minWidth = '';
+    pop.style.maxWidth = 'none';
+    pop.style.maxHeight = `calc(${viewportHeight}px - 1rem - var(--safe-top) - var(--safe-bottom))`;
     return;
   }
+
+  pop.style.width = '';
   const rect = triggerEl.getBoundingClientRect();
   const margin = 6;
   pop.style.minWidth = `${Math.max(180, rect.width)}px`;
-  pop.style.right = '';
-  pop.style.bottom = '';
+  pop.style.maxWidth = '';
+  pop.style.right = 'auto';
+  pop.style.bottom = 'auto';
   const popRect = pop.getBoundingClientRect();
   let left = rect.left;
   if (left + popRect.width > window.innerWidth - margin) {
@@ -1751,6 +1768,7 @@ const positionChipPopover = (triggerEl) => {
   }
   pop.style.left = `${Math.max(margin, left)}px`;
   pop.style.top = `${Math.max(margin, top)}px`;
+  pop.style.maxHeight = '';
 };
 
 const closeChipPopover = () => {
@@ -1994,9 +2012,16 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-window.addEventListener('resize', () => {
+const repositionChipPopover = () => {
   if (chipPopoverState.triggerEl) positionChipPopover(chipPopoverState.triggerEl);
-});
+};
+
+window.addEventListener('resize', repositionChipPopover);
+window.addEventListener('orientationchange', repositionChipPopover);
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', repositionChipPopover);
+  window.visualViewport.addEventListener('scroll', repositionChipPopover);
+}
 
 // ===== Model picker =====
 const populateModelSelectOptions = (sel, models, previous) => {

--- a/internal/serveui/static/chip_picker_test.js
+++ b/internal/serveui/static/chip_picker_test.js
@@ -33,6 +33,18 @@ function makeClassList() {
   };
 }
 
+function makeStyle(initial = {}) {
+  const style = Object.assign({}, initial);
+  style.setProperty = (key, value) => {
+    style[key] = String(value);
+  };
+  style.getPropertyValue = (key) => style[key] || '';
+  style.removeProperty = (key) => {
+    delete style[key];
+  };
+  return style;
+}
+
 function makeNode(extra = {}) {
   const attrs = {};
   const listeners = {};
@@ -87,7 +99,7 @@ function makeNode(extra = {}) {
     focus() {},
     classList: makeClassList(),
     children: [],
-    style: {},
+    style: makeStyle(),
     dataset: {},
     options: [],
     value: '',
@@ -124,7 +136,7 @@ function makeOption(value, text) {
   return { value, textContent: text || value };
 }
 
-function makeContext() {
+function makeContext(options = {}) {
   const elementMap = {};
   const document = {
     activeElement: null,
@@ -172,6 +184,7 @@ function makeContext() {
     history: { replaceState() {}, pushState() {} },
     fetch: async () => ({ ok: true, status: 200, headers: { get: () => null }, json: async () => ({}), text: async () => '' }),
   };
+  Object.assign(windowObj, options.window || {});
   windowObj.document = document;
   windowObj.localStorage = localStorage;
 
@@ -205,15 +218,15 @@ function makeContext() {
   return { ctx, document, localStorage, windowObj, elementMap };
 }
 
-function loadCore() {
-  const { ctx, elementMap, windowObj } = makeContext();
+function loadCore(options = {}) {
+  const { ctx, elementMap, windowObj } = makeContext(options);
   vm.runInNewContext(coreSource, ctx, { filename: 'app-core.js' });
   const app = ctx.window.TermLLMApp;
   return { ctx, app, elementMap, windowObj };
 }
 
-function loadCoreAndStream() {
-  const { ctx, elementMap, windowObj } = makeContext();
+function loadCoreAndStream(options = {}) {
+  const { ctx, elementMap, windowObj } = makeContext(options);
   vm.runInNewContext(coreSource, ctx, { filename: 'app-core.js' });
   vm.runInNewContext(streamSource, ctx, { filename: 'app-stream.js' });
   const app = ctx.window.TermLLMApp;
@@ -494,6 +507,58 @@ function testFilterInputHidesNonMatchingItems() {
   pass(name);
 }
 
+function testMobilePopoverUsesVisualViewportSafeBounds() {
+  const name = 'mobile popover tracks the visual viewport so it stays above the iPhone keyboard';
+  const vvListeners = { resize: [], scroll: [] };
+  const visualViewport = {
+    width: 390,
+    height: 720,
+    offsetTop: 12,
+    offsetLeft: 0,
+    addEventListener(type, fn) {
+      (vvListeners[type] = vvListeners[type] || []).push(fn);
+    },
+    removeEventListener() {},
+  };
+
+  const { app, elementMap } = loadCoreAndStream({
+    window: {
+      innerWidth: 390,
+      innerHeight: 844,
+      visualViewport,
+    },
+  });
+  app.updateHeader = () => {};
+
+  const opts = [];
+  for (let i = 0; i < 15; i++) opts.push(makeOption(`gpt-${i}`, `gpt-${i}`));
+  const popover = openModelPopover(elementMap, opts);
+  if (!popover) return fail(name, 'no click listener on chipModelTrigger');
+
+  if (popover.style.top !== 'calc(12px + 0.5rem + var(--safe-top))') {
+    fail(name, `expected mobile top to use visual viewport offset, got ${popover.style.top}`);
+    return;
+  }
+  if (popover.style.width !== 'calc(390px - 1rem - var(--safe-left) - var(--safe-right))') {
+    fail(name, `expected mobile width to fit safe area, got ${popover.style.width}`);
+    return;
+  }
+  if (popover.style.maxHeight !== 'calc(720px - 1rem - var(--safe-top) - var(--safe-bottom))') {
+    fail(name, `expected mobile maxHeight to use visual viewport height, got ${popover.style.maxHeight}`);
+    return;
+  }
+
+  visualViewport.height = 352;
+  vvListeners.resize.forEach((fn) => fn());
+
+  if (popover.style.maxHeight !== 'calc(352px - 1rem - var(--safe-top) - var(--safe-bottom))') {
+    fail(name, `expected popover to shrink after keyboard resize, got ${popover.style.maxHeight}`);
+    return;
+  }
+  pass(name);
+}
+
+
 testSplitHeaderModelEffortDetectsKnownEffortSuffix();
 testUpdateSessionUsageDisplayUsesProviderDefaultModel();
 testUpdateSessionUsageDisplayFallsBackToFirstModelWithoutDefault();
@@ -502,6 +567,7 @@ testPopoverItemSelectionDispatchesChangeAndCloses();
 testPopoverHidesFilterInputBelowThreshold();
 testPopoverShowsFilterInputAboveThreshold();
 testFilterInputHidesNonMatchingItems();
+testMobilePopoverUsesVisualViewportSafeBounds();
 
 if (failures > 0) {
   console.error(`\n${failures} test(s) failed`);


### PR DESCRIPTION
## What

- position the mobile chip picker against the `visualViewport` instead of relying on a fixed bottom sheet
- size the picker with safe-area-aware `calc(...)` values so it stays within the visible iPhone viewport
- re-run the positioning logic on `visualViewport` resize/scroll so the picker shrinks when the keyboard opens
- add a regression test covering the iPhone keyboard / visual viewport case

## Why

On iPhone Safari, opening the model picker can autofocus the filter box and bring up the keyboard. The old mobile layout used a fixed bottom sheet with `vh`-based sizing, so parts of the picker could end up under the keyboard / outside the visible safe area.

This keeps the selector inside the actual visible viewport instead of the larger layout viewport.

## Testing

- `node internal/serveui/static/chip_picker_test.js`
- `go test ./internal/serveui/...`
- `go build ./...`
- `go test ./...`
