### PR TITLE
fix: synchronous tool execution can panic the whole process

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1642,7 +1642,14 @@ func (e *Engine) handleSyncToolExecution(ctx context.Context, event Event, send 
 		err = fmt.Errorf("tool '%s' is not in the active skill's allowed-tools list", call.Name)
 	} else {
 		toolCtx := ContextWithCallID(ctx, callID)
-		result, err = tool.Execute(toolCtx, call.Arguments)
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("Error: tool panicked: %v", r)
+				}
+			}()
+			result, err = tool.Execute(toolCtx, call.Arguments)
+		}()
 	}
 
 	// Truncate large tool outputs (global limit, then compaction limit).

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -2795,6 +2795,83 @@ func TestEnginePanickingToolParallelCalls(t *testing.T) {
 	}
 }
 
+func TestEnginePanickingToolSyncCall(t *testing.T) {
+	tool := &panickingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				responseCh := make(chan ToolExecutionResponse, 1)
+				return []Event{
+					{
+						Type:         EventToolCall,
+						ToolCallID:   "call-1",
+						ToolName:     "panic_tool",
+						Tool:         &ToolCall{ID: "call-1", Name: "panic_tool", Arguments: json.RawMessage(`{}`)},
+						ToolResponse: responseCh,
+					},
+					{Type: EventDone},
+				}
+			default:
+				return []Event{
+					{Type: EventTextDelta, Text: "recovered"},
+					{Type: EventDone},
+				}
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages:   []Message{UserText("run panicking tool")},
+		Tools:      []ToolSpec{tool.Spec()},
+		ToolChoice: ToolChoice{Mode: ToolChoiceAuto},
+	}
+
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	var text strings.Builder
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+		if event.Type == EventTextDelta {
+			text.WriteString(event.Text)
+		}
+	}
+
+	if text.String() != "recovered" {
+		t.Fatalf("expected 'recovered', got %q", text.String())
+	}
+
+	if len(provider.calls) < 2 {
+		t.Fatalf("expected at least 2 provider calls, got %d", len(provider.calls))
+	}
+	lastReq := provider.calls[1]
+	for _, msg := range lastReq.Messages {
+		for _, part := range msg.Parts {
+			if part.Type == PartToolResult && part.ToolResult != nil && part.ToolResult.IsError {
+				if !strings.Contains(part.ToolResult.Content, "tool panicked") {
+					t.Fatalf("expected panic error message, got: %s", part.ToolResult.Content)
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("expected a tool error result containing 'tool panicked'")
+}
+
 func TestEngineNormalizesToolCallID(t *testing.T) {
 	// When a provider sets ToolCallID on the event but leaves Tool.ID empty,
 	// the engine should copy ToolCallID into Tool.ID so downstream consumers


### PR DESCRIPTION
## What

Add panic recovery around synchronous tool execution in `handleSyncToolExecution` so panicking server tools are converted into tool errors instead of unwinding the stream goroutine.

Also add a regression test covering the synchronous tool path and verifying the engine continues and feeds a `tool panicked` error result back into the next provider turn.

## Why

The normal async tool execution paths already recover from tool panics, but the synchronous provider-driven path called `tool.Execute` directly. A panic there could crash the whole `term-llm` process instead of surfacing as a tool error, especially for claude-bin/MCP driven tool calls.
