### PR TITLE
fix: server-executed tools ignore ParallelToolCalls=false and always run concurrently

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1361,7 +1361,7 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 			}
 		}
 
-		toolResults, err := e.executeToolCalls(ctx, registered, send, req.Debug, req.DebugRaw)
+		toolResults, err := e.executeToolCalls(ctx, registered, req.ParallelToolCalls, send, req.Debug, req.DebugRaw)
 		if err != nil {
 			return err
 		}
@@ -1468,10 +1468,26 @@ func buildAssistantMessageWithReasoningMetadata(text string, toolCalls []ToolCal
 // are emitted from concurrent goroutines. While the channel is thread-safe, events
 // may arrive in non-deterministic order. Consumers should use ToolCallID to correlate
 // start/end events rather than relying on ordering.
-func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, send eventSender, debug bool, debugRaw bool) ([]Message, error) {
+func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, parallel bool, send eventSender, debug bool, debugRaw bool) ([]Message, error) {
 	// Fast path: single call, no concurrency overhead
 	if len(calls) == 1 {
 		return e.executeSingleToolCallSafe(ctx, calls[0], send, debug, debugRaw)
+	}
+
+	if !parallel {
+		results := make([]Message, 0, len(calls))
+		for _, call := range calls {
+			msgs, err := e.executeSingleToolCallSafe(ctx, call, send, debug, debugRaw)
+			if err != nil {
+				return nil, err
+			}
+			msg := ToolErrorMessage(call.ID, call.Name, "tool returned no result", call.ThoughtSig)
+			if len(msgs) > 0 {
+				msg = msgs[0]
+			}
+			results = append(results, msg)
+		}
+		return results, nil
 	}
 
 	// Parallel execution for multiple calls (events may arrive out of order)

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -210,6 +210,40 @@ func (t *countingTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+type overlapDetectTool struct {
+	active    atomic.Int64
+	maxActive atomic.Int64
+}
+
+func (t *overlapDetectTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "overlap_tool",
+		Description: "Detects overlapping executions",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (t *overlapDetectTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	active := t.active.Add(1)
+	for {
+		maxActive := t.maxActive.Load()
+		if active <= maxActive {
+			break
+		}
+		if t.maxActive.CompareAndSwap(maxActive, active) {
+			break
+		}
+	}
+	defer t.active.Add(-1)
+
+	time.Sleep(50 * time.Millisecond)
+	return TextOutput("ok"), nil
+}
+
+func (t *overlapDetectTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 type signalTool struct {
 	started chan struct{}
 }
@@ -394,6 +428,61 @@ func TestEngineDedupesToolCallsByID(t *testing.T) {
 
 	if tool.calls.Load() != 1 {
 		t.Fatalf("expected 1 tool execution, got %d", tool.calls.Load())
+	}
+}
+
+func TestEngineExecutesServerToolsSequentiallyWhenParallelToolCallsDisabled(t *testing.T) {
+	tool := &overlapDetectTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				return []Event{
+					{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "overlap_tool", Arguments: json.RawMessage(`{}`)}},
+					{Type: EventToolCall, Tool: &ToolCall{ID: "call-2", Name: "overlap_tool", Arguments: json.RawMessage(`{}`)}},
+					{Type: EventDone},
+				}
+			default:
+				return []Event{
+					{Type: EventTextDelta, Text: "done"},
+					{Type: EventDone},
+				}
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	req := Request{
+		Messages:          []Message{UserText("run tools")},
+		Tools:             []ToolSpec{tool.Spec()},
+		ToolChoice:        ToolChoice{Mode: ToolChoiceAuto},
+		ParallelToolCalls: false,
+	}
+
+	stream, err := engine.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+		if event.Type == EventError && event.Err != nil {
+			t.Fatalf("event error: %v", event.Err)
+		}
+	}
+
+	if tool.maxActive.Load() != 1 {
+		t.Fatalf("expected server-executed tools to run sequentially when parallel_tool_calls=false, got max concurrency %d", tool.maxActive.Load())
 	}
 }
 


### PR DESCRIPTION
## What

- pass `req.ParallelToolCalls` through to server-side tool execution in `runLoop`
- execute registered tool calls sequentially when `parallel_tool_calls=false`
- add a regression test covering multiple server-executed tool calls with parallel execution disabled

## Why

Clients can explicitly disable parallel tool calls at the API layer, but the engine was still always executing multiple registered tools concurrently on the server. That could reorder effects and cause races for tools that rely on sequential execution. This change makes local tool execution honor the request flag consistently.
