### PR TITLE
fix: read_url SSRF protection is bypassable via DNS rebinding during redirect checks

### DIFF
--- a/internal/llm/read_url_tool.go
+++ b/internal/llm/read_url_tool.go
@@ -24,6 +24,16 @@ var readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
 	return net.DefaultResolver.LookupIP(ctx, "ip", host)
 }
 
+var readURLDialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, network, address)
+}
+
+type readURLTarget struct {
+	url string
+	ips []net.IP
+}
+
 // ReadURLTool fetches web pages using Jina AI Reader.
 type ReadURLTool struct {
 	client *http.Client
@@ -149,18 +159,15 @@ func readURLContent(r io.Reader) (string, bool, error) {
 }
 
 func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL string) (string, error) {
-	targetURL, err := normalizeReadURLTarget(ctx, rawURL)
+	target, err := normalizeReadURLTarget(ctx, rawURL)
 	if err != nil {
 		return "", err
 	}
 
-	redirectClient := *client
-	redirectClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-
 	for range maxReadURLRedirects {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+		redirectClient := newReadURLRedirectClient(client, target.ips)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.url, nil)
 		if err != nil {
 			return "", fmt.Errorf("create redirect check request: %w", err)
 		}
@@ -172,7 +179,7 @@ func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL strin
 		_ = resp.Body.Close()
 
 		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
-			return targetURL, nil
+			return target.url, nil
 		}
 
 		location := resp.Header.Get("Location")
@@ -185,7 +192,7 @@ func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL strin
 			return "", fmt.Errorf("parse redirect location: %w", err)
 		}
 
-		targetURL, err = normalizeReadURLTarget(ctx, nextURL.String())
+		target, err = normalizeReadURLTarget(ctx, nextURL.String())
 		if err != nil {
 			return "", err
 		}
@@ -194,7 +201,64 @@ func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL strin
 	return "", fmt.Errorf("too many redirects")
 }
 
-func normalizeReadURLTarget(ctx context.Context, rawURL string) (string, error) {
+func newReadURLRedirectClient(client *http.Client, ips []net.IP) *http.Client {
+	redirectClient := *client
+	redirectClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	transport := cloneReadURLTransport(client.Transport)
+	if transport == nil {
+		return &redirectClient
+	}
+
+	dialContext := readURLDialContext
+	if transport.DialContext != nil {
+		dialContext = transport.DialContext
+	}
+	transport.DialTLSContext = nil
+	transport.DialTLS = nil
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		var lastErr error
+		for _, ip := range ips {
+			conn, err := dialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no resolved IPs available")
+	}
+	redirectClient.Transport = transport
+
+	return &redirectClient
+}
+
+func cloneReadURLTransport(rt http.RoundTripper) *http.Transport {
+	if rt == nil {
+		transport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil
+		}
+		return transport.Clone()
+	}
+
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		return nil
+	}
+	return transport.Clone()
+}
+
+func normalizeReadURLTarget(ctx context.Context, rawURL string) (readURLTarget, error) {
 	targetURL := rawURL
 	if !strings.HasPrefix(strings.ToLower(targetURL), "http://") && !strings.HasPrefix(strings.ToLower(targetURL), "https://") {
 		targetURL = "https://" + targetURL
@@ -202,38 +266,41 @@ func normalizeReadURLTarget(ctx context.Context, rawURL string) (string, error) 
 
 	parsedURL, err := url.Parse(targetURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid url: %w", err)
+		return readURLTarget{}, fmt.Errorf("invalid url: %w", err)
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return "", fmt.Errorf("url scheme must be http or https")
+		return readURLTarget{}, fmt.Errorf("url scheme must be http or https")
 	}
 
 	host := strings.TrimSuffix(strings.ToLower(parsedURL.Hostname()), ".")
 	if host == "" {
-		return "", fmt.Errorf("url host is required")
+		return readURLTarget{}, fmt.Errorf("url host is required")
 	}
 	if isBlockedReadURLHost(host) {
-		return "", fmt.Errorf("url host is not allowed")
+		return readURLTarget{}, fmt.Errorf("url host is not allowed")
 	}
 
 	if ip := net.ParseIP(host); ip != nil {
 		if isBlockedReadURLIP(ip) {
-			return "", fmt.Errorf("url host is not allowed")
+			return readURLTarget{}, fmt.Errorf("url host is not allowed")
 		}
-		return targetURL, nil
+		return readURLTarget{url: targetURL, ips: []net.IP{ip}}, nil
 	}
 
 	ips, err := readURLLookupIP(ctx, host)
 	if err != nil {
-		return "", fmt.Errorf("resolve url host: %w", err)
+		return readURLTarget{}, fmt.Errorf("resolve url host: %w", err)
+	}
+	if len(ips) == 0 {
+		return readURLTarget{}, fmt.Errorf("resolve url host: no IP addresses found")
 	}
 	for _, ip := range ips {
 		if isBlockedReadURLIP(ip) {
-			return "", fmt.Errorf("url host is not allowed")
+			return readURLTarget{}, fmt.Errorf("url host is not allowed")
 		}
 	}
 
-	return targetURL, nil
+	return readURLTarget{url: targetURL, ips: ips}, nil
 }
 
 func isBlockedReadURLHost(host string) bool {

--- a/internal/llm/read_url_tool_test.go
+++ b/internal/llm/read_url_tool_test.go
@@ -363,4 +363,34 @@ func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeJinaFetch(t *testing.T) 
 	}
 }
 
+func TestResolveReadURLTargetPinsValidatedIPsDuringRedirectCheck(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		if host != "example.com" {
+			t.Fatalf("unexpected host lookup %q", host)
+		}
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
+	origDial := readURLDialContext
+	dialedAddrs := []string{}
+	readURLDialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialedAddrs = append(dialedAddrs, address)
+		return nil, errors.New("dial blocked for test")
+	}
+	defer func() { readURLDialContext = origDial }()
+
+	_, err := resolveReadURLTarget(context.Background(), &http.Client{Transport: &http.Transport{}}, "https://example.com/article")
+	if err == nil || !strings.Contains(err.Error(), "check url redirects") {
+		t.Fatalf("expected redirect check error, got %v", err)
+	}
+	if got, want := len(dialedAddrs), 1; got != want {
+		t.Fatalf("expected %d dial attempt, got %d (%v)", want, got, dialedAddrs)
+	}
+	if got, want := dialedAddrs[0], "93.184.216.34:443"; got != want {
+		t.Fatalf("expected pinned dial address %q, got %q", want, got)
+	}
+}
+
 var _ io.ReadCloser = (*failAfterNReadCloser)(nil)


### PR DESCRIPTION
## What

Pin redirect-check connections in `read_url` to the exact IPs that were validated during SSRF checks, and re-validate/pin each redirect target before probing it. Also add a regression test that verifies the redirect probe dials the resolved IP instead of performing a fresh hostname lookup.

## Why

`read_url` previously resolved a hostname during validation, but the actual redirect probe used a normal HTTP client that performed a new DNS lookup at connect time. That made the SSRF protection bypassable via DNS rebinding, including during redirect handling. Pinning the probe to the validated IPs closes that gap.
