### PR TITLE
feat: expose provider and model in prompt templates

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -219,7 +219,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 
 	// System prompt: CLI > agent > config
 	if cli.SystemMessage != "" {
-		templateCtx := agents.NewTemplateContextForTemplate(cli.SystemMessage).WithFiles(cli.Files).WithPlatform(cli.Platform)
+		templateCtx := agents.NewTemplateContextForTemplate(cli.SystemMessage).WithFiles(cli.Files).WithPlatform(cli.Platform).WithLLM(s.Provider, s.Model)
 		cwd, err := systemPromptCWDBaseDir()
 		if err != nil {
 			return s, err
@@ -234,7 +234,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 		if err != nil {
 			return s, fmt.Errorf("prepare agent system prompt context: %w", err)
 		}
-		templateCtx = templateCtx.WithPlatform(cli.Platform)
+		templateCtx = templateCtx.WithPlatform(cli.Platform).WithLLM(s.Provider, s.Model)
 		expanded, err := expandSystemPromptWithIncludes(agent.SystemPrompt, templateCtx, includeBaseDir)
 		if err != nil {
 			return s, fmt.Errorf("expand agent system prompt: %w", err)
@@ -248,7 +248,7 @@ func ResolveSettings(cfg *config.Config, agent *agents.Agent, cli CLIFlags, conf
 			}
 		}
 	} else {
-		templateCtx := agents.NewTemplateContextForTemplate(configInstructions).WithFiles(cli.Files).WithPlatform(cli.Platform)
+		templateCtx := agents.NewTemplateContextForTemplate(configInstructions).WithFiles(cli.Files).WithPlatform(cli.Platform).WithLLM(s.Provider, s.Model)
 		cwd, err := systemPromptCWDBaseDir()
 		if err != nil {
 			return s, err

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -178,6 +178,17 @@ func TestResolveSettings_ExpandsPlatformTokenWhenProvided(t *testing.T) {
 	}
 }
 
+func TestResolveSettings_ExpandsLLMTokensWhenProvided(t *testing.T) {
+	cfg := &config.Config{}
+	settings, err := ResolveSettings(cfg, nil, CLIFlags{}, "chatgpt", "gpt-5.4-medium", "surface={{provider}}/{{model}}/{{provider_model}}", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+	if settings.SystemPrompt != "surface=chatgpt/gpt-5.4-medium/chatgpt:gpt-5.4-medium" {
+		t.Fatalf("SystemPrompt = %q, want %q", settings.SystemPrompt, "surface=chatgpt/gpt-5.4-medium/chatgpt:gpt-5.4-medium")
+	}
+}
+
 func TestResolveSettings_LeavesPlatformTokenWhenPlatformUnavailable(t *testing.T) {
 	cfg := &config.Config{}
 	settings, err := ResolveSettings(cfg, nil, CLIFlags{}, "", "", "surface={{platform}}", 0, 20)
@@ -186,6 +197,17 @@ func TestResolveSettings_LeavesPlatformTokenWhenPlatformUnavailable(t *testing.T
 	}
 	if settings.SystemPrompt != "surface={{platform}}" {
 		t.Fatalf("SystemPrompt = %q, want %q", settings.SystemPrompt, "surface={{platform}}")
+	}
+}
+
+func TestResolveSettings_LeavesLLMTokensWhenUnavailable(t *testing.T) {
+	cfg := &config.Config{}
+	settings, err := ResolveSettings(cfg, nil, CLIFlags{}, "", "", "surface={{provider}}/{{model}}/{{provider_model}}", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+	if settings.SystemPrompt != "surface={{provider}}/{{model}}/{{provider_model}}" {
+		t.Fatalf("SystemPrompt = %q, want %q", settings.SystemPrompt, "surface={{provider}}/{{model}}/{{provider_model}}")
 	}
 }
 

--- a/internal/agents/builtin/agent-builder/system.md
+++ b/internal/agents/builtin/agent-builder/system.md
@@ -66,6 +66,7 @@ mcp:
 - `{{git_branch}}`, `{{git_repo}}`, `{{git_diff_stat}}`
 - `{{files}}`, `{{file_count}}` (from -f flags)
 - `{{os}}`, `{{platform}}`, `{{resource_dir}}`
+- `{{provider}}`, `{{model}}`, `{{provider_model}}`
 - `{{agents}}` - Loads project instructions (hierarchical AGENTS.md + fallbacks)
 
 **The `{{agents}}` variable** loads project instructions using:

--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -43,6 +43,11 @@ type TemplateContext struct {
 	// Runtime surface (chat, console, web, telegram, jobs)
 	Platform string
 
+	// Active LLM
+	Provider      string // Current provider name/key
+	Model         string // Current model name
+	ProviderModel string // Combined provider:model string
+
 	// Agent context
 	ResourceDir  string // Directory containing agent resources (for builtin agents)
 	HandoverDir  string // XDG handover directory for the current project
@@ -166,6 +171,23 @@ func (c TemplateContext) WithPlatform(platform string) TemplateContext {
 	return c
 }
 
+// WithLLM sets the active provider/model for template expansion.
+func (c TemplateContext) WithLLM(provider, model string) TemplateContext {
+	c.Provider = strings.TrimSpace(provider)
+	c.Model = strings.TrimSpace(model)
+	switch {
+	case c.Provider != "" && c.Model != "":
+		c.ProviderModel = c.Provider + ":" + c.Model
+	case c.Provider != "":
+		c.ProviderModel = c.Provider
+	case c.Model != "":
+		c.ProviderModel = c.Model
+	default:
+		c.ProviderModel = ""
+	}
+	return c
+}
+
 // ExpandTemplate replaces {{variable}} placeholders with values from context.
 func ExpandTemplate(text string, ctx TemplateContext) string {
 	// Match {{variable}} patterns
@@ -210,6 +232,24 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 				return match
 			}
 			return ctx.Platform
+		case "provider":
+			if ctx.Provider == "" {
+				// Leave token untouched when provider context is unavailable.
+				return match
+			}
+			return ctx.Provider
+		case "model":
+			if ctx.Model == "" {
+				// Leave token untouched when model context is unavailable.
+				return match
+			}
+			return ctx.Model
+		case "provider_model":
+			if ctx.ProviderModel == "" {
+				// Leave token untouched when provider/model context is unavailable.
+				return match
+			}
+			return ctx.ProviderModel
 		case "resource_dir":
 			return ctx.ResourceDir
 		case "handover_dir":

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -11,23 +11,26 @@ import (
 
 func TestExpandTemplate(t *testing.T) {
 	ctx := TemplateContext{
-		Date:         "2026-01-16",
-		DateTime:     "2026-01-16 14:30:00",
-		Time:         "14:30",
-		Year:         "2026",
-		Cwd:          "/home/user/project",
-		CwdName:      "project",
-		Home:         "/home/user",
-		User:         "testuser",
-		GitBranch:    "main",
-		GitRepo:      "term-llm",
-		Files:        "main.go, utils.go",
-		FileCount:    "2",
-		OS:           "linux",
-		Platform:     "chat",
-		ResourceDir:  "/home/user/.cache/term-llm/agents/artist",
-		HandoverDir:  "/home/user/.local/share/term-llm/handover/project-abc123",
-		HandoverPath: "/home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
+		Date:          "2026-01-16",
+		DateTime:      "2026-01-16 14:30:00",
+		Time:          "14:30",
+		Year:          "2026",
+		Cwd:           "/home/user/project",
+		CwdName:       "project",
+		Home:          "/home/user",
+		User:          "testuser",
+		GitBranch:     "main",
+		GitRepo:       "term-llm",
+		Files:         "main.go, utils.go",
+		FileCount:     "2",
+		OS:            "linux",
+		Platform:      "chat",
+		Provider:      "chatgpt",
+		Model:         "gpt-5.4-medium",
+		ProviderModel: "chatgpt:gpt-5.4-medium",
+		ResourceDir:   "/home/user/.cache/term-llm/agents/artist",
+		HandoverDir:   "/home/user/.local/share/term-llm/handover/project-abc123",
+		HandoverPath:  "/home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
 	}
 
 	tests := []struct {
@@ -51,6 +54,21 @@ func TestExpandTemplate(t *testing.T) {
 			expected: "Platform: chat",
 		},
 		{
+			name:     "provider variable",
+			template: "Provider: {{provider}}",
+			expected: "Provider: chatgpt",
+		},
+		{
+			name:     "model variable",
+			template: "Model: {{model}}",
+			expected: "Model: gpt-5.4-medium",
+		},
+		{
+			name:     "provider_model variable",
+			template: "LLM: {{provider_model}}",
+			expected: "LLM: chatgpt:gpt-5.4-medium",
+		},
+		{
 			name:     "no variables",
 			template: "Just plain text",
 			expected: "Just plain text",
@@ -62,8 +80,8 @@ func TestExpandTemplate(t *testing.T) {
 		},
 		{
 			name:     "all variables",
-			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{platform}} {{resource_dir}} {{handover_dir}} {{handover_path}}",
-			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux chat /home/user/.cache/term-llm/agents/artist /home/user/.local/share/term-llm/handover/project-abc123 /home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
+			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{platform}} {{provider}} {{model}} {{provider_model}} {{resource_dir}} {{handover_dir}} {{handover_path}}",
+			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux chat chatgpt gpt-5.4-medium chatgpt:gpt-5.4-medium /home/user/.cache/term-llm/agents/artist /home/user/.local/share/term-llm/handover/project-abc123 /home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
 		},
 		{
 			name:     "handover_dir variable",
@@ -175,10 +193,35 @@ func TestTemplateContext_WithPlatform(t *testing.T) {
 	}
 }
 
+func TestTemplateContext_WithLLM(t *testing.T) {
+	ctx := TemplateContext{}
+
+	ctx2 := ctx.WithLLM("chatgpt", "gpt-5.4-medium")
+	if ctx2.Provider != "chatgpt" {
+		t.Errorf("Provider = %q, want %q", ctx2.Provider, "chatgpt")
+	}
+	if ctx2.Model != "gpt-5.4-medium" {
+		t.Errorf("Model = %q, want %q", ctx2.Model, "gpt-5.4-medium")
+	}
+	if ctx2.ProviderModel != "chatgpt:gpt-5.4-medium" {
+		t.Errorf("ProviderModel = %q, want %q", ctx2.ProviderModel, "chatgpt:gpt-5.4-medium")
+	}
+	if ctx.Provider != "" || ctx.Model != "" || ctx.ProviderModel != "" {
+		t.Errorf("Original context mutated: %+v", ctx)
+	}
+}
+
 func TestExpandTemplate_PlatformTokenUnchangedWhenUnavailable(t *testing.T) {
 	result := ExpandTemplate("Platform={{platform}}", TemplateContext{})
 	if result != "Platform={{platform}}" {
 		t.Fatalf("ExpandTemplate() = %q, want %q", result, "Platform={{platform}}")
+	}
+}
+
+func TestExpandTemplate_LLMTokensUnchangedWhenUnavailable(t *testing.T) {
+	result := ExpandTemplate("Provider={{provider}} Model={{model}} LLM={{provider_model}}", TemplateContext{})
+	if result != "Provider={{provider}} Model={{model}} LLM={{provider_model}}" {
+		t.Fatalf("ExpandTemplate() = %q, want %q", result, "Provider={{provider}} Model={{model}} LLM={{provider_model}}")
 	}
 }
 


### PR DESCRIPTION
## What

Add system-prompt template variables for the active LLM:

- `{{provider}}`
- `{{model}}`
- `{{provider_model}}`

This wires the resolved provider/model through prompt expansion so agent `system.md`, CLI `--system`, and config instructions can reference the active LLM directly.

## Why

Jarvis wanted to know what provider/model it is actually running on without relying on guesswork or out-of-band inspection.

We already support prompt template variables like `{{date}}`, `{{git_repo}}`, and `{{platform}}`, so exposing the active LLM is the natural extension.

This enables prompts like:

```md
Your current LLM: {{provider_model}}
```

## Tests

Ran:

```bash
gofmt -w internal/agents/template.go internal/agents/template_test.go cmd/session.go cmd/session_test.go
go test ./internal/agents ./cmd/...
```
