### PR TITLE
fix: don't retry on connection refused errors

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -304,8 +304,7 @@ func isRetryable(err error) bool {
 	}
 
 	// Connection errors
-	if strings.Contains(errStr, "connection refused") ||
-		strings.Contains(errStr, "connection reset") ||
+	if strings.Contains(errStr, "connection reset") ||
 		strings.Contains(errStr, "timeout") ||
 		strings.Contains(errStr, "deadline exceeded") ||
 		strings.Contains(errStr, "temporary failure") ||

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -118,6 +118,23 @@ func (p *syncToolProvider) Stream(ctx context.Context, req Request) (Stream, err
 	}), nil
 }
 
+func TestIsRetryable_ConnectionRefused(t *testing.T) {
+	cases := []struct {
+		msg       string
+		retryable bool
+	}{
+		{`Qwen36local API request failed: Post "http://127.0.0.1:8001/v1/chat/completions": dial tcp 127.0.0.1:8001: connect: connection refused`, false},
+		{`openai API request failed: Post "http://localhost:11434/v1/chat/completions": dial tcp [::1]:11434: connect: connection refused`, false},
+		{"connection reset by peer", true},
+	}
+	for _, tc := range cases {
+		got := isRetryable(errors.New(tc.msg))
+		if got != tc.retryable {
+			t.Errorf("isRetryable(%q) = %v, want %v", tc.msg, got, tc.retryable)
+		}
+	}
+}
+
 func TestIsRetryable_500InternalServerError(t *testing.T) {
 	cases := []struct {
 		msg       string


### PR DESCRIPTION
## What

Remove `"connection refused"` from the list of retryable error strings in `isRetryable` (`internal/llm/retry.go`).

## Why

When a local LLM provider (e.g. `Qwen36local` at `http://127.0.0.1:8001`) is not running, the HTTP client returns a `connect: connection refused` error. The retry wrapper was incorrectly treating this as a transient error, causing 5 retry attempts with exponential backoff (up to ~2 minutes of waiting) before finally surfacing the failure.

`connection refused` means nothing is listening on that port — it is a permanent failure, not a transient one. The server will not spontaneously start between retries. This is especially true for localhost/127.0.0.1 endpoints (local LLM servers like Ollama, vLLM, llama.cpp), but also holds for remote APIs where connection refused almost always indicates misconfiguration rather than a transient blip.

Other connection errors like `connection reset`, `timeout`, and `no such host` remain retryable as they can represent genuinely transient network conditions.

## How

- Removed `strings.Contains(errStr, "connection refused")` from the `isRetryable` function.
- Added test cases covering the exact error pattern from the live session, a localhost variant, and confirming `connection reset` remains retryable.
