### PR TITLE
fix: treat io.ErrUnexpectedEOF as soft EOF in readSSELine

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -331,7 +331,7 @@ func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]ModelInfo, err
 func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
 	line, err = reader.ReadString('\n')
 	if err != nil {
-		if err == io.EOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return strings.TrimRight(line, "\r\n"), true, nil
 		}
 		return "", false, err

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"io"
@@ -1229,6 +1230,61 @@ func TestOpenAICompatProviderStreamSendsReasoningEffort(t *testing.T) {
 			}
 			if got.ReasoningEffort != tt.wantEffort {
 				t.Errorf("reasoning_effort = %q, want %q", got.ReasoningEffort, tt.wantEffort)
+			}
+		})
+	}
+}
+
+// unexpectedEOFReader wraps a reader and substitutes io.ErrUnexpectedEOF for
+// the final io.EOF, mimicking Go's HTTP chunked-encoding transport when a local
+// inference server (e.g. Ollama) drops the connection without a proper terminator.
+type unexpectedEOFReader struct {
+	r io.Reader
+}
+
+func (u *unexpectedEOFReader) Read(p []byte) (int, error) {
+	n, err := u.r.Read(p)
+	if err == io.EOF {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func TestReadSSELine_TreatsUnexpectedEOFAsEOF(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantLine string
+	}{
+		{
+			name:     "done marker without trailing newline",
+			input:    "data: [DONE]",
+			wantLine: "data: [DONE]",
+		},
+		{
+			name:     "data line without trailing newline",
+			input:    `data: {"choices":[]}`,
+			wantLine: `data: {"choices":[]}`,
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			wantLine: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := bufio.NewReader(&unexpectedEOFReader{r: strings.NewReader(tc.input)})
+			line, eof, err := readSSELine(r)
+			if err != nil {
+				t.Fatalf("expected nil error for io.ErrUnexpectedEOF, got %v", err)
+			}
+			if !eof {
+				t.Fatal("expected eof=true")
+			}
+			if line != tc.wantLine {
+				t.Fatalf("expected line %q, got %q", tc.wantLine, line)
 			}
 		})
 	}


### PR DESCRIPTION
## What

In `readSSELine`, handle `io.ErrUnexpectedEOF` the same way as `io.EOF` — return the partial line with `eof=true` rather than propagating it as an error.

## Why

Local inference servers (e.g. Ollama running Qwen3) sometimes close the HTTP connection after the final token without sending a proper chunked-transfer terminating chunk. Go's `net/http` transport surfaces this as `io.ErrUnexpectedEOF` (not `io.EOF`) from reads on the response body. Previously `readSSELine` only caught `io.EOF` as a soft end-of-stream; `io.ErrUnexpectedEOF` fell through to the error path, producing the user-visible error:

```
Qwen36local streaming error: unexpected EOF
```

This caused the entire session to fail even though the model had successfully generated its full response. The fix is a one-line change: add `|| err == io.ErrUnexpectedEOF` to the existing `io.EOF` check. `readSSELine` is shared by the OpenAI-compat, xAI, and Responses API streaming loops, so all three benefit.

## How

- `internal/llm/openai_compat.go`: add `io.ErrUnexpectedEOF` to the soft-EOF branch in `readSSELine`
- `internal/llm/openai_compat_test.go`: add `TestReadSSELine_TreatsUnexpectedEOFAsEOF` with a custom reader that substitutes `io.ErrUnexpectedEOF` for the final `io.EOF`, covering three cases (done marker, data line, empty input)
