### PR TITLE
fix: use errors.Is for EOF checks in readSSELine to handle wrapped errors

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -331,7 +331,7 @@ func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]ModelInfo, err
 func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
 	line, err = reader.ReadString('\n')
 	if err != nil {
-		if err == io.EOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return strings.TrimRight(line, "\r\n"), true, nil
 		}
 		return "", false, err

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -331,7 +332,7 @@ func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]ModelInfo, err
 func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
 	line, err = reader.ReadString('\n')
 	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return strings.TrimRight(line, "\r\n"), true, nil
 		}
 		return "", false, err

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"io"
@@ -1229,6 +1230,61 @@ func TestOpenAICompatProviderStreamSendsReasoningEffort(t *testing.T) {
 			}
 			if got.ReasoningEffort != tt.wantEffort {
 				t.Errorf("reasoning_effort = %q, want %q", got.ReasoningEffort, tt.wantEffort)
+			}
+		})
+	}
+}
+
+// unexpectedEOFReader wraps a reader and substitutes io.ErrUnexpectedEOF for
+// the final io.EOF, mimicking Go's HTTP chunked-encoding transport when a local
+// inference server (e.g. Ollama) drops the connection without a proper terminator.
+type unexpectedEOFReader struct {
+	r io.Reader
+}
+
+func (u *unexpectedEOFReader) Read(p []byte) (int, error) {
+	n, err := u.r.Read(p)
+	if err == io.EOF {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func TestReadSSELine_TreatsUnexpectedEOFAsEOF(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantLine string
+	}{
+		{
+			name:     "done marker without trailing newline",
+			input:    "data: [DONE]",
+			wantLine: "data: [DONE]",
+		},
+		{
+			name:     "data line without trailing newline",
+			input:    `data: {"choices":[]}`,
+			wantLine: `data: {"choices":[]}`,
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			wantLine: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := bufio.NewReader(&unexpectedEOFReader{r: strings.NewReader(tc.input)})
+			line, eof, err := readSSELine(r)
+			if err != nil {
+				t.Fatalf("expected nil error for io.ErrUnexpectedEOF, got %v", err)
+			}
+			if !eof {
+				t.Fatal("expected eof=true")
+			}
+			if line != tc.wantLine {
+				t.Fatalf("expected line %q, got %q", tc.wantLine, line)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Use `errors.Is()` instead of `==` when checking for `io.EOF` and `io.ErrUnexpectedEOF` in `readSSELine` (`internal/llm/openai_compat.go`).

## Why

Go's `net/http` chunked transfer decoder can return `io.ErrUnexpectedEOF` wrapped inside another error (e.g. via `fmt.Errorf("...: %w", io.ErrUnexpectedEOF)`). The direct `==` comparison fails for wrapped errors, so the error escaped `readSSELine` as a non-nil `err` return and was formatted into:

```
Qwen36local streaming error: unexpected EOF
```

This caused the stream to abort with an error instead of being treated as a clean end-of-stream — even when the local model server had finished sending all its data and simply closed the connection.

## How

- Added `"errors"` import to `openai_compat.go`
- Changed `err == io.EOF || err == io.ErrUnexpectedEOF` → `errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)`

All existing tests pass.
