### PR TITLE
docker: run jobs service with yolo

### DIFF
--- a/docker/templates/services/jobs/run
+++ b/docker/templates/services/jobs/run
@@ -2,4 +2,5 @@
 exec /usr/local/bin/term-llm serve jobs \
   --agent "${AGENT_NAME:-agent}" \
   --auth none \
+  --yolo \
   2>&1


### PR DESCRIPTION
## What

Add `--yolo` to the Docker jobs runit service template so generated jobs services start in auto-approve mode.

## Why

The web and Telegram services already run with `--yolo`, but the jobs service template did not. That meant queued/background jobs executed under the jobs runner without yolo, even when they were scheduled from a yolo-enabled surface.

This keeps the generated jobs service aligned with the intended unattended/background behavior.
