### PR TITLE
feat: native Ollama chat provider (think, options.*)

### DIFF
--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -134,6 +134,13 @@ var builtinProviderMeta = map[string]struct {
 		supportsListModels: true,
 		description:        "Venice AI (private, uncensored inference — OpenAI-compatible)",
 	},
+	"ollama": {
+		credential:         "none",
+		envVar:             "",
+		requiresKey:        false,
+		supportsListModels: true,
+		description:        "Ollama local inference (native /api/chat, supports think/options.*)",
+	},
 }
 
 var providersCmd = &cobra.Command{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ const (
 	ProviderTypeXAI          ProviderType = "xai"
 	ProviderTypeVenice       ProviderType = "venice"
 	ProviderTypeBedrock      ProviderType = "bedrock"
+	ProviderTypeOllama       ProviderType = "ollama"
 )
 
 // builtInProviderTypes maps known provider names to their types
@@ -44,6 +45,7 @@ var builtInProviderTypes = map[string]ProviderType{
 	"xai":        ProviderTypeXAI,
 	"venice":     ProviderTypeVenice,
 	"bedrock":    ProviderTypeBedrock,
+	"ollama":     ProviderTypeOllama,
 }
 
 // InferProviderType returns the provider type for a given provider name
@@ -96,6 +98,14 @@ type ProviderConfig struct {
 	SecretKey    string            `mapstructure:"secret_access_key"` // Explicit AWS secret access key
 	SessionToken string            `mapstructure:"session_token"`     // Optional AWS session token (temporary creds)
 	ModelMap     map[string]string `mapstructure:"model_map"`         // Friendly name -> Bedrock model ID/ARN
+
+	// Ollama-native sampling options (type: ollama only)
+	Think           *bool    `mapstructure:"think"`            // Enable extended thinking / reasoning
+	TopK            *int     `mapstructure:"top_k"`            // Top-K sampling
+	MinP            *float64 `mapstructure:"min_p"`            // Min-P sampling
+	PresencePenalty *float64 `mapstructure:"presence_penalty"` // Presence penalty
+	NumCtx          *int     `mapstructure:"num_ctx"`          // Context window size in tokens
+	NumPredict      *int     `mapstructure:"num_predict"`      // Max tokens to generate (-1 = unlimited)
 
 	// Runtime fields (populated after credential resolution)
 	ResolvedAPIKey string                              `mapstructure:"-"`
@@ -1235,6 +1245,13 @@ var KnownProviderKeys = map[string]bool{
 	"context_window":    true,
 	"max_output_tokens": true,
 	"enable_hooks":      true,
+	// Ollama-native options
+	"think":            true,
+	"top_k":            true,
+	"min_p":            true,
+	"presence_penalty": true,
+	"num_ctx":          true,
+	"num_predict":      true,
 }
 
 // GetDefaults returns a map of all default configuration values

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -141,6 +141,10 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 			}
 			provider := NewGeminiCLIProvider(creds, model)
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
+		case config.ProviderTypeOllama:
+			// ollama connects to a local server; no credentials needed
+			provider := NewOllamaChatProvider("", model, OllamaOptions{})
+			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		default:
 			return nil, fmt.Errorf("provider %q not configured", name)
 		}
@@ -248,6 +252,9 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 				return nil, fmt.Errorf("provider gemini-cli: %w", err)
 			}
 			return NewGeminiCLIProvider(creds, ""), nil
+		case config.ProviderTypeOllama:
+			// ollama connects to a local server; no credentials needed
+			return NewOllamaChatProvider("", "", OllamaOptions{}), nil
 		default:
 			return nil, fmt.Errorf("provider %q not configured", cfg.DefaultProvider)
 		}
@@ -327,6 +334,17 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		provider := NewClaudeBinProvider(cfg.Model, cfg.Env)
 		provider.SetEnableHooks(cfg.EnableHooks)
 		return provider, nil
+
+	case config.ProviderTypeOllama:
+		opts := OllamaOptions{
+			Think:           cfg.Think,
+			TopK:            cfg.TopK,
+			MinP:            cfg.MinP,
+			PresencePenalty: cfg.PresencePenalty,
+			NumCtx:          cfg.NumCtx,
+			NumPredict:      cfg.NumPredict,
+		}
+		return NewOllamaChatProvider(cfg.BaseURL, cfg.Model, opts), nil
 
 	case config.ProviderTypeOpenAICompat:
 		// Use ResolvedURL if available (from srv:// or $() resolution), otherwise use config values

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -161,6 +161,26 @@ var ProviderModels = map[string][]ModelEntry{
 		// Grok 2
 		{ID: "grok-2", InputLimit: 123_000, OutputLimit: 8_192},
 	},
+	"ollama": {
+		// Qwen3 coding/agent (think suffix enables extended reasoning via -think flag)
+		{ID: "qwen2.5-coder:7b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen2.5-coder:14b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen2.5-coder:32b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen3:8b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen3:8b-think", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen3:14b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen3:14b-think", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen3:32b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "qwen3:32b-think", InputLimit: 30_000, OutputLimit: 8_192},
+		// Llama
+		{ID: "llama3.3:70b", InputLimit: 120_000, OutputLimit: 8_192},
+		{ID: "llama3.2:3b", InputLimit: 120_000, OutputLimit: 8_192},
+		{ID: "llama3.2:1b", InputLimit: 120_000, OutputLimit: 8_192},
+		// DeepSeek-R1 (think is always on)
+		{ID: "deepseek-r1:7b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "deepseek-r1:14b", InputLimit: 30_000, OutputLimit: 8_192},
+		{ID: "deepseek-r1:32b", InputLimit: 30_000, OutputLimit: 8_192},
+	},
 	"bedrock": {
 		// AWS Bedrock: same friendly names as anthropic (translated to Bedrock IDs internally)
 		{ID: "claude-opus-4-7", InputLimit: 180_000, OutputLimit: 64_000},
@@ -449,7 +469,7 @@ func SortModelIDsByPopularity(provider, defaultModel string, ids []string) []str
 
 // GetBuiltInProviderNames returns the built-in provider type names
 func GetBuiltInProviderNames() []string {
-	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice"}
+	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice", "ollama"}
 }
 
 // GetProviderNames returns valid provider names from config plus built-in types.

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -1,0 +1,447 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	ollamaChatDefaultModel   = "qwen2.5-coder:7b"
+	ollamaChatDefaultBaseURL = "http://localhost:11434"
+)
+
+// OllamaOptions holds Ollama-native generation knobs that have no equivalent
+// in the shared Request struct.
+type OllamaOptions struct {
+	Think           *bool
+	TopK            *int
+	MinP            *float64
+	PresencePenalty *float64
+	NumCtx          *int
+	NumPredict      *int
+}
+
+// OllamaProvider implements Provider using the native Ollama /api/chat endpoint.
+// It supports the think flag (for extended reasoning models like Qwen3),
+// tool calls, and Ollama-native sampling options.
+type OllamaProvider struct {
+	baseURL string
+	model   string
+	opts    OllamaOptions
+}
+
+// NewOllamaChatProvider creates a native Ollama chat provider.
+// baseURL defaults to http://localhost:11434 and model defaults to qwen2.5-coder:7b.
+func NewOllamaChatProvider(baseURL, model string, opts OllamaOptions) *OllamaProvider {
+	if baseURL == "" {
+		baseURL = ollamaChatDefaultBaseURL
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	if model == "" {
+		model = ollamaChatDefaultModel
+	}
+	return &OllamaProvider{baseURL: baseURL, model: model, opts: opts}
+}
+
+func (p *OllamaProvider) Name() string {
+	return fmt.Sprintf("Ollama (%s)", p.model)
+}
+
+func (p *OllamaProvider) Credential() string {
+	return "free"
+}
+
+func (p *OllamaProvider) Capabilities() Capabilities {
+	return Capabilities{
+		ToolCalls:          true,
+		SupportsToolChoice: false,
+	}
+}
+
+// --- Ollama native API types ---
+
+type ollamaChatRequest struct {
+	Model    string          `json:"model"`
+	Messages []ollamaChatMsg `json:"messages"`
+	Tools    []ollamaTool    `json:"tools,omitempty"`
+	Stream   bool            `json:"stream"`
+	Think    *bool           `json:"think,omitempty"`
+	Options  *ollamaChatOpts `json:"options,omitempty"`
+}
+
+type ollamaChatOpts struct {
+	Temperature     *float64 `json:"temperature,omitempty"`
+	TopP            *float64 `json:"top_p,omitempty"`
+	TopK            *int     `json:"top_k,omitempty"`
+	MinP            *float64 `json:"min_p,omitempty"`
+	PresencePenalty *float64 `json:"presence_penalty,omitempty"`
+	NumCtx          *int     `json:"num_ctx,omitempty"`
+	NumPredict      *int     `json:"num_predict,omitempty"`
+}
+
+type ollamaChatMsg struct {
+	Role      string           `json:"role"`
+	Content   string           `json:"content"`
+	Images    []string         `json:"images,omitempty"` // raw base64, no data: prefix
+	ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
+}
+
+type ollamaToolCall struct {
+	Function ollamaToolCallFn `json:"function"`
+}
+
+type ollamaToolCallFn struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type ollamaTool struct {
+	Type     string        `json:"type"`
+	Function ollamaToolDef `json:"function"`
+}
+
+type ollamaToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// ollamaChatChunk is one line of the NDJSON streaming response.
+type ollamaChatChunk struct {
+	Model           string         `json:"model"`
+	Message         ollamaMsgChunk `json:"message"`
+	Done            bool           `json:"done"`
+	DoneReason      string         `json:"done_reason,omitempty"`
+	PromptEvalCount int            `json:"prompt_eval_count,omitempty"`
+	EvalCount       int            `json:"eval_count,omitempty"`
+	Error           string         `json:"error,omitempty"`
+}
+
+type ollamaMsgChunk struct {
+	Role      string           `json:"role"`
+	Content   string           `json:"content"`
+	Thinking  string           `json:"thinking,omitempty"`
+	ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
+}
+
+// buildOllamaMessages converts internal messages to Ollama's native format.
+// Ollama tool results use role "tool" with plain text content; tool calls have
+// no ID field. Developer-role messages are folded into the next user turn.
+func buildOllamaMessages(messages []Message) []ollamaChatMsg {
+	messages = sanitizeToolHistory(messages)
+
+	var result []ollamaChatMsg
+	var pendingDev string
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case RoleDeveloper:
+			text, _, _ := splitParts(msg.Parts)
+			if text != "" {
+				if pendingDev != "" {
+					pendingDev += "\n\n"
+				}
+				pendingDev += text
+			}
+		case RoleSystem:
+			text, _, _ := splitParts(msg.Parts)
+			if text != "" {
+				result = append(result, ollamaChatMsg{Role: "system", Content: text})
+			}
+		case RoleUser:
+			text, _, _ := splitParts(msg.Parts)
+			if pendingDev != "" {
+				text = fmt.Sprintf("<developer>\n%s\n</developer>\n\n", pendingDev) + text
+				pendingDev = ""
+			}
+			var images []string
+			for _, part := range msg.Parts {
+				if part.Type == PartImage && part.ImageData != nil {
+					images = append(images, part.ImageData.Base64)
+				}
+			}
+			if text == "" && len(images) == 0 {
+				continue
+			}
+			result = append(result, ollamaChatMsg{Role: "user", Content: text, Images: images})
+		case RoleAssistant:
+			text, oaiCalls, _ := splitParts(msg.Parts)
+			if len(oaiCalls) > 0 {
+				var calls []ollamaToolCall
+				for _, tc := range oaiCalls {
+					args := json.RawMessage(tc.Function.Arguments)
+					if !json.Valid(args) {
+						args = json.RawMessage("{}")
+					}
+					calls = append(calls, ollamaToolCall{
+						Function: ollamaToolCallFn{Name: tc.Function.Name, Arguments: args},
+					})
+				}
+				result = append(result, ollamaChatMsg{Role: "assistant", Content: text, ToolCalls: calls})
+			} else if text != "" {
+				result = append(result, ollamaChatMsg{Role: "assistant", Content: text})
+			}
+		case RoleTool:
+			for _, part := range msg.Parts {
+				if part.Type != PartToolResult || part.ToolResult == nil {
+					continue
+				}
+				result = append(result, ollamaChatMsg{
+					Role:    "tool",
+					Content: toolResultTextContent(part.ToolResult),
+				})
+			}
+		}
+	}
+
+	if pendingDev != "" {
+		result = append(result, ollamaChatMsg{
+			Role:    "user",
+			Content: fmt.Sprintf("<developer>\n%s\n</developer>", pendingDev),
+		})
+	}
+	return result
+}
+
+func buildOllamaTools(specs []ToolSpec) ([]ollamaTool, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	tools := make([]ollamaTool, 0, len(specs))
+	for _, spec := range specs {
+		schema, err := json.Marshal(spec.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("marshal tool schema %s: %w", spec.Name, err)
+		}
+		tools = append(tools, ollamaTool{
+			Type: "function",
+			Function: ollamaToolDef{
+				Name:        spec.Name,
+				Description: spec.Description,
+				Parameters:  schema,
+			},
+		})
+	}
+	return tools, nil
+}
+
+func (p *OllamaProvider) Stream(ctx context.Context, req Request) (Stream, error) {
+	// Strip a -think suffix from the model name and enable thinking automatically.
+	model := chooseModel(req.Model, p.model)
+	think := p.opts.Think
+	if strings.HasSuffix(model, "-think") {
+		model = strings.TrimSuffix(model, "-think")
+		t := true
+		think = &t
+	}
+
+	messages := buildOllamaMessages(req.Messages)
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("no messages provided")
+	}
+
+	tools, err := buildOllamaTools(req.Tools)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build options – merge provider-level defaults with per-request overrides.
+	opts := &ollamaChatOpts{
+		TopK:            p.opts.TopK,
+		MinP:            p.opts.MinP,
+		PresencePenalty: p.opts.PresencePenalty,
+		NumCtx:          p.opts.NumCtx,
+	}
+	if req.TemperatureSet || req.Temperature != 0 {
+		v := float64(req.Temperature)
+		opts.Temperature = &v
+	}
+	if req.TopPSet || req.TopP != 0 {
+		v := float64(req.TopP)
+		opts.TopP = &v
+	}
+	// req.MaxOutputTokens takes precedence over provider-level NumPredict.
+	if req.MaxOutputTokens > 0 {
+		v := req.MaxOutputTokens
+		opts.NumPredict = &v
+	} else if p.opts.NumPredict != nil {
+		opts.NumPredict = p.opts.NumPredict
+	}
+	if ollamaOptsEmpty(opts) {
+		opts = nil
+	}
+
+	chatReq := ollamaChatRequest{
+		Model:    model,
+		Messages: messages,
+		Tools:    tools,
+		Stream:   true,
+		Think:    think,
+		Options:  opts,
+	}
+
+	if req.Debug {
+		fmt.Fprintf(os.Stderr, "=== DEBUG: Ollama Stream Request ===\n")
+		fmt.Fprintf(os.Stderr, "URL: %s/api/chat\n", p.baseURL)
+		fmt.Fprintf(os.Stderr, "Model: %s\n", model)
+		fmt.Fprintf(os.Stderr, "Messages: %d\n", len(messages))
+		fmt.Fprintf(os.Stderr, "Tools: %d\n", len(tools))
+		if think != nil && *think {
+			fmt.Fprintf(os.Stderr, "Think: enabled\n")
+		}
+		fmt.Fprintln(os.Stderr, "====================================")
+	}
+
+	body, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := defaultHTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("Ollama request failed (is Ollama running at %s?): %w", p.baseURL, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var errBody struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(raw, &errBody) == nil && errBody.Error != "" {
+			return nil, fmt.Errorf("Ollama API error: %s", errBody.Error)
+		}
+		return nil, fmt.Errorf("Ollama API error (status %d): %s", resp.StatusCode, string(raw))
+	}
+
+	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 1<<20), 1<<20)
+
+		var pendingToolCalls []ollamaToolCall
+		var lastUsage *Usage
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+
+			var chunk ollamaChatChunk
+			if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+				continue
+			}
+
+			if chunk.Error != "" {
+				return fmt.Errorf("Ollama API error: %s", chunk.Error)
+			}
+
+			if chunk.Message.Thinking != "" {
+				if err := send.Send(Event{Type: EventReasoningDelta, Text: chunk.Message.Thinking}); err != nil {
+					return err
+				}
+			}
+
+			if chunk.Message.Content != "" {
+				if err := send.Send(Event{Type: EventTextDelta, Text: chunk.Message.Content}); err != nil {
+					return err
+				}
+			}
+
+			pendingToolCalls = append(pendingToolCalls, chunk.Message.ToolCalls...)
+
+			if chunk.Done && (chunk.PromptEvalCount > 0 || chunk.EvalCount > 0) {
+				lastUsage = &Usage{
+					InputTokens:  chunk.PromptEvalCount,
+					OutputTokens: chunk.EvalCount,
+				}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("Ollama streaming error: %w", err)
+		}
+
+		for i, tc := range pendingToolCalls {
+			args := tc.Function.Arguments
+			if !json.Valid(args) {
+				args = json.RawMessage("{}")
+			}
+			call := ToolCall{
+				ID:        fmt.Sprintf("call_%d", i),
+				Name:      tc.Function.Name,
+				Arguments: args,
+			}
+			if err := send.Send(Event{Type: EventToolCall, Tool: &call}); err != nil {
+				return err
+			}
+		}
+
+		if lastUsage != nil {
+			if err := send.Send(Event{Type: EventUsage, Use: lastUsage}); err != nil {
+				return err
+			}
+		}
+
+		return send.Send(Event{Type: EventDone})
+	}), nil
+}
+
+// ListModels returns locally available Ollama models via /api/tags.
+func (p *OllamaProvider) ListModels(ctx context.Context) ([]ModelInfo, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", p.baseURL+"/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := defaultHTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("Ollama request failed (is Ollama running at %s?): %w", p.baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Ollama API error (status %d): %s", resp.StatusCode, string(raw))
+	}
+
+	var tagsResp struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &tagsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse tags response: %w", err)
+	}
+
+	models := make([]ModelInfo, len(tagsResp.Models))
+	for i, m := range tagsResp.Models {
+		models[i] = ModelInfo{ID: m.Name, OwnedBy: "ollama"}
+	}
+	return models, nil
+}
+
+func ollamaOptsEmpty(o *ollamaChatOpts) bool {
+	return o.Temperature == nil && o.TopP == nil && o.TopK == nil &&
+		o.MinP == nil && o.PresencePenalty == nil &&
+		o.NumCtx == nil && o.NumPredict == nil
+}

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -1,0 +1,427 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOllamaProviderName(t *testing.T) {
+	p := NewOllamaChatProvider("http://localhost:11434", "qwen2.5-coder:7b", OllamaOptions{})
+	name := p.Name()
+	if !strings.Contains(name, "Ollama") {
+		t.Errorf("expected name to contain 'Ollama', got %q", name)
+	}
+	if !strings.Contains(name, "qwen2.5-coder:7b") {
+		t.Errorf("expected name to contain model, got %q", name)
+	}
+}
+
+func TestOllamaProviderDefaults(t *testing.T) {
+	p := NewOllamaChatProvider("", "", OllamaOptions{})
+	if p.baseURL != ollamaChatDefaultBaseURL {
+		t.Errorf("expected baseURL %q, got %q", ollamaChatDefaultBaseURL, p.baseURL)
+	}
+	if p.model != ollamaChatDefaultModel {
+		t.Errorf("expected model %q, got %q", ollamaChatDefaultModel, p.model)
+	}
+}
+
+func TestOllamaProviderCredential(t *testing.T) {
+	p := NewOllamaChatProvider("", "", OllamaOptions{})
+	if p.Credential() != "free" {
+		t.Errorf("expected 'free', got %q", p.Credential())
+	}
+}
+
+func TestOllamaProviderCapabilities(t *testing.T) {
+	p := NewOllamaChatProvider("", "", OllamaOptions{})
+	caps := p.Capabilities()
+	if !caps.ToolCalls {
+		t.Error("expected ToolCalls=true")
+	}
+}
+
+func TestOllamaProviderStream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			http.Error(w, "not found", 404)
+			return
+		}
+		var req ollamaChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", 400)
+			return
+		}
+		if req.Model != "qwen2.5-coder:7b" {
+			t.Errorf("expected model qwen2.5-coder:7b, got %s", req.Model)
+		}
+		if !req.Stream {
+			t.Error("expected stream=true")
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		for _, chunk := range []string{
+			`{"model":"qwen2.5-coder:7b","message":{"role":"assistant","content":"Hello"},"done":false}`,
+			`{"model":"qwen2.5-coder:7b","message":{"role":"assistant","content":" World"},"done":false}`,
+			`{"model":"qwen2.5-coder:7b","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":5}`,
+		} {
+			fmt.Fprintln(w, chunk)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewOllamaChatProvider(srv.URL, "qwen2.5-coder:7b", OllamaOptions{})
+	stream, err := p.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hi")},
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+
+	var texts []string
+	var hasUsage, hasDone bool
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			break
+		}
+		switch event.Type {
+		case EventTextDelta:
+			texts = append(texts, event.Text)
+		case EventUsage:
+			hasUsage = true
+			if event.Use.InputTokens != 10 {
+				t.Errorf("expected input_tokens=10, got %d", event.Use.InputTokens)
+			}
+			if event.Use.OutputTokens != 5 {
+				t.Errorf("expected output_tokens=5, got %d", event.Use.OutputTokens)
+			}
+		case EventDone:
+			hasDone = true
+		}
+	}
+
+	if got := strings.Join(texts, ""); got != "Hello World" {
+		t.Errorf("expected 'Hello World', got %q", got)
+	}
+	if !hasUsage {
+		t.Error("expected usage event")
+	}
+	if !hasDone {
+		t.Error("expected done event")
+	}
+}
+
+func TestOllamaProviderStreamThink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Think == nil || !*req.Think {
+			t.Error("expected think=true in request")
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		for _, chunk := range []string{
+			`{"model":"qwen3:14b","message":{"role":"assistant","content":"","thinking":"Let me think..."},"done":false}`,
+			`{"model":"qwen3:14b","message":{"role":"assistant","content":"The answer is 42"},"done":false}`,
+			`{"model":"qwen3:14b","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":20,"eval_count":10}`,
+		} {
+			fmt.Fprintln(w, chunk)
+		}
+	}))
+	defer srv.Close()
+
+	think := true
+	p := NewOllamaChatProvider(srv.URL, "qwen3:14b", OllamaOptions{Think: &think})
+	stream, err := p.Stream(context.Background(), Request{
+		Messages: []Message{UserText("what is the answer?")},
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+
+	var texts, reasonings []string
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			break
+		}
+		switch event.Type {
+		case EventTextDelta:
+			texts = append(texts, event.Text)
+		case EventReasoningDelta:
+			reasonings = append(reasonings, event.Text)
+		}
+	}
+
+	if got := strings.Join(texts, ""); got != "The answer is 42" {
+		t.Errorf("unexpected text: %q", got)
+	}
+	if got := strings.Join(reasonings, ""); got != "Let me think..." {
+		t.Errorf("unexpected reasoning: %q", got)
+	}
+}
+
+func TestOllamaProviderStreamThinkSuffix(t *testing.T) {
+	var capturedModel string
+	var capturedThink *bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		capturedModel = req.Model
+		capturedThink = req.Think
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"model":"qwen3:14b","message":{"role":"assistant","content":"ok"},"done":false}`)
+		fmt.Fprintln(w, `{"model":"qwen3:14b","message":{"role":"assistant","content":""},"done":true}`)
+	}))
+	defer srv.Close()
+
+	// Model name with -think suffix should strip it and enable think=true
+	p := NewOllamaChatProvider(srv.URL, "qwen3:14b-think", OllamaOptions{})
+	stream, err := p.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	if capturedModel != "qwen3:14b" {
+		t.Errorf("expected model 'qwen3:14b' (suffix stripped), got %q", capturedModel)
+	}
+	if capturedThink == nil || !*capturedThink {
+		t.Error("expected think=true when -think suffix used")
+	}
+}
+
+func TestOllamaProviderStreamToolCalls(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if len(req.Tools) != 1 || req.Tools[0].Function.Name != "get_weather" {
+			t.Errorf("unexpected tools: %+v", req.Tools)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		for _, chunk := range []string{
+			`{"model":"qwen2.5-coder:7b","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"location":"Paris"}}}]},"done":false}`,
+			`{"model":"qwen2.5-coder:7b","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}`,
+		} {
+			fmt.Fprintln(w, chunk)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewOllamaChatProvider(srv.URL, "qwen2.5-coder:7b", OllamaOptions{})
+	stream, err := p.Stream(context.Background(), Request{
+		Messages: []Message{UserText("weather in Paris?")},
+		Tools: []ToolSpec{{
+			Name:        "get_weather",
+			Description: "Get weather for a location",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"location": map[string]interface{}{"type": "string"},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+
+	var calls []ToolCall
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			break
+		}
+		if event.Type == EventToolCall && event.Tool != nil {
+			calls = append(calls, *event.Tool)
+		}
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Name != "get_weather" {
+		t.Errorf("expected 'get_weather', got %q", calls[0].Name)
+	}
+	if calls[0].ID == "" {
+		t.Error("expected non-empty synthetic ID")
+	}
+}
+
+func TestOllamaProviderStreamOptions(t *testing.T) {
+	var capturedOpts *ollamaChatOpts
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		capturedOpts = req.Options
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"ok"},"done":false}`)
+		fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":""},"done":true}`)
+	}))
+	defer srv.Close()
+
+	topK := 40
+	numCtx := 8192
+	minP := 0.05
+	presP := 1.2
+	numPredict := 512
+	p := NewOllamaChatProvider(srv.URL, "test", OllamaOptions{
+		TopK:            &topK,
+		NumCtx:          &numCtx,
+		MinP:            &minP,
+		PresencePenalty: &presP,
+		NumPredict:      &numPredict,
+	})
+
+	stream, err := p.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	if capturedOpts == nil {
+		t.Fatal("expected options to be sent")
+	}
+	if capturedOpts.TopK == nil || *capturedOpts.TopK != 40 {
+		t.Errorf("expected top_k=40, got %v", capturedOpts.TopK)
+	}
+	if capturedOpts.NumCtx == nil || *capturedOpts.NumCtx != 8192 {
+		t.Errorf("expected num_ctx=8192, got %v", capturedOpts.NumCtx)
+	}
+	if capturedOpts.MinP == nil || *capturedOpts.MinP != 0.05 {
+		t.Errorf("expected min_p=0.05, got %v", capturedOpts.MinP)
+	}
+	if capturedOpts.PresencePenalty == nil || *capturedOpts.PresencePenalty != 1.2 {
+		t.Errorf("expected presence_penalty=1.2, got %v", capturedOpts.PresencePenalty)
+	}
+	if capturedOpts.NumPredict == nil || *capturedOpts.NumPredict != 512 {
+		t.Errorf("expected num_predict=512, got %v", capturedOpts.NumPredict)
+	}
+}
+
+func TestOllamaProviderStreamReqMaxOutputTokens(t *testing.T) {
+	var capturedNumPredict *int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Options != nil {
+			capturedNumPredict = req.Options.NumPredict
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"ok"},"done":false}`)
+		fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":""},"done":true}`)
+	}))
+	defer srv.Close()
+
+	p := NewOllamaChatProvider(srv.URL, "test", OllamaOptions{})
+	stream, err := p.Stream(context.Background(), Request{
+		Messages:        []Message{UserText("test")},
+		MaxOutputTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	if capturedNumPredict == nil || *capturedNumPredict != 1024 {
+		t.Errorf("expected num_predict=1024, got %v", capturedNumPredict)
+	}
+}
+
+func TestBuildOllamaMessages(t *testing.T) {
+	msgs := []Message{
+		SystemText("You are helpful"),
+		UserText("Hello"),
+		AssistantText("Hi there"),
+	}
+	result := buildOllamaMessages(msgs)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(result))
+	}
+	if result[0].Role != "system" || result[0].Content != "You are helpful" {
+		t.Errorf("bad system: %+v", result[0])
+	}
+	if result[1].Role != "user" || result[1].Content != "Hello" {
+		t.Errorf("bad user: %+v", result[1])
+	}
+	if result[2].Role != "assistant" || result[2].Content != "Hi there" {
+		t.Errorf("bad assistant: %+v", result[2])
+	}
+}
+
+func TestBuildOllamaMessagesDeveloperRole(t *testing.T) {
+	msgs := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "be concise"}}},
+		UserText("Hello"),
+	}
+	result := buildOllamaMessages(msgs)
+	if len(result) != 1 || result[0].Role != "user" {
+		t.Fatalf("expected 1 user message, got %d messages", len(result))
+	}
+	if !strings.Contains(result[0].Content, "be concise") {
+		t.Errorf("developer content not folded into user turn: %q", result[0].Content)
+	}
+}
+
+func TestOllamaProviderListModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.Error(w, "not found", 404)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"models":[{"name":"qwen2.5-coder:7b"},{"name":"qwen3:14b"}]}`)
+	}))
+	defer srv.Close()
+
+	p := NewOllamaChatProvider(srv.URL, "qwen2.5-coder:7b", OllamaOptions{})
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "qwen2.5-coder:7b" {
+		t.Errorf("expected qwen2.5-coder:7b, got %q", models[0].ID)
+	}
+	if models[1].ID != "qwen3:14b" {
+		t.Errorf("expected qwen3:14b, got %q", models[1].ID)
+	}
+}
+
+func TestOllamaOptsEmpty(t *testing.T) {
+	if !ollamaOptsEmpty(&ollamaChatOpts{}) {
+		t.Error("empty opts should be empty")
+	}
+	v := 1
+	if ollamaOptsEmpty(&ollamaChatOpts{TopK: &v}) {
+		t.Error("non-empty opts should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a first-class native Ollama chat provider using Ollama's `/api/chat` endpoint — NDJSON streaming, not the OpenAI-compat shim. Designed for Qwen3 coding/agent use cases with full access to Ollama-native sampling knobs.

## What's new

### `internal/llm/ollama.go`
- `OllamaProvider` implementing the `Provider` interface (`Name`, `Credential`, `Capabilities`, `Stream`, `ListModels`)
- Native NDJSON streaming via `bufio.Scanner` (not SSE)
- `think` parameter support: set via config **or** by appending `-think` to the model name (suffix is stripped before the request)
- `options.*` sampling knobs: `top_k`, `min_p`, `presence_penalty`, `num_ctx`, `num_predict`
- `temperature` and `top_p` forwarded from `Request.Temperature` / `Request.TopP`
- `req.MaxOutputTokens` → `options.num_predict` (provider-level `num_predict` acts as fallback)
- Tool calls: Ollama omits `id` on tool calls and `tool_call_id` on results — synthetic IDs (`call_0`, `call_1`, …) are generated during streaming and matched on result messages
- `EventReasoningDelta` emitted for `thinking` chunks
- `ListModels` via `GET /api/tags`

### Config (`internal/config/config.go`)
- `ProviderTypeOllama = "ollama"` added to built-in types
- New `ProviderConfig` fields: `think`, `top_k`, `min_p`, `presence_penalty`, `num_ctx`, `num_predict`
- All new keys added to `KnownProviderKeys`

### Factory (`internal/llm/factory.go`)
- `ProviderTypeOllama` case in `createProviderFromConfig`, `NewProviderByName`, and `newProviderInternal`

### Models (`internal/llm/models.go`)
- `"ollama"` added to `GetBuiltInProviderNames()`
- Curated `ProviderModels["ollama"]`: Qwen2.5-coder, Qwen3 (plain + `-think`), Llama3, DeepSeek-R1

### Providers (`cmd/providers.go`)
- `"ollama"` entry in `builtinProviderMeta`: `credential=none`, `supportsListModels=true`

## Example config

```toml
[providers.ollama]
type = "ollama"
base_url = "http://localhost:11434"
model = "qwen3:14b-think"
num_ctx = 32768
think = true
```

Or use the `-think` suffix shorthand:

```toml
[providers.ollama]
type = "ollama"
base_url = "http://localhost:11434"
model = "qwen3:32b-think"
```

## Tests

12 unit tests in `internal/llm/ollama_test.go` using `httptest.NewServer`:

| Test | What it covers |
|------|---------------|
| `TestOllamaProviderName` | `Name()` format |
| `TestOllamaProviderDefaults` | default baseURL + model |
| `TestOllamaProviderCredential` | returns `"free"` |
| `TestOllamaProviderCapabilities` | `ToolCalls: true` |
| `TestOllamaProviderStream` | basic text streaming |
| `TestOllamaProviderStreamThink` | `think=true` in request + `EventReasoningDelta` |
| `TestOllamaProviderStreamThinkSuffix` | `-think` suffix stripped, `think=true` set |
| `TestOllamaProviderStreamToolCalls` | tool call accumulation + synthetic IDs |
| `TestOllamaProviderStreamOptions` | all options knobs forwarded |
| `TestOllamaProviderStreamReqMaxOutputTokens` | `MaxOutputTokens` → `num_predict` |
| `TestOllamaProviderListModels` | `/api/tags` parsing |
| `TestOllamaOptsEmpty` | zero-value `OllamaOptions` omits all option fields |

All pass: `go test ./internal/llm/... -run TestOllama` ✓

## Caveats

- Ollama does not return `tool_call_id` on tool results or `id` on tool calls. Synthetic IDs are generated per-stream; they are stable within a single turn but not persisted across turns. Providers that require stable tool call IDs (e.g. for caching) would need further work.
- `temperature` and `top_p` are passed through from `Request` fields; the config-level equivalents (not yet in `OllamaOptions`) could be added as a follow-up.
- No retry wrapper is applied in `createProviderFromConfig` (consistent with other non-OpenAI providers that go through `newProviderInternal`). Use `NewProviderByName("ollama", model)` if you want the default retry wrapper.
