### PR TITLE
fix: use 127.0.0.1 instead of localhost for Ollama default URL

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -401,7 +401,7 @@ type EmbedVoyageConfig struct {
 
 // EmbedOllamaConfig configures Ollama embedding generation
 type EmbedOllamaConfig struct {
-	BaseURL string `mapstructure:"base_url"` // default: http://localhost:11434
+	BaseURL string `mapstructure:"base_url"` // default: http://127.0.0.1:11434
 	Model   string `mapstructure:"model"`    // nomic-embed-text (default)
 }
 
@@ -1300,7 +1300,7 @@ func GetDefaults() map[string]any {
 		"embed.jina.model":                "jina-embeddings-v3",
 		"embed.voyage.model":              "voyage-3.5",
 		"embed.ollama.model":              "nomic-embed-text",
-		"embed.ollama.base_url":           "http://localhost:11434",
+		"embed.ollama.base_url":           "http://127.0.0.1:11434",
 		"search.provider":                 "duckduckgo",
 		"search.force_external":           false,
 		"tools.enabled":                   []string{},

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -113,7 +113,7 @@ func NewEmbeddingProvider(cfg *config.Config, providerOverride string) (Embeddin
 	case "ollama":
 		baseURL := cfg.Embed.Ollama.BaseURL
 		if baseURL == "" {
-			baseURL = "http://localhost:11434"
+			baseURL = "http://127.0.0.1:11434"
 		}
 		p := NewOllamaProvider(baseURL)
 		if model != "" {

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	ollamaChatDefaultModel   = "qwen2.5-coder:7b"
-	ollamaChatDefaultBaseURL = "http://localhost:11434"
+	ollamaChatDefaultBaseURL = "http://127.0.0.1:11434"
 )
 
 // OllamaOptions holds Ollama-native generation knobs that have no equivalent
@@ -38,7 +38,7 @@ type OllamaProvider struct {
 }
 
 // NewOllamaChatProvider creates a native Ollama chat provider.
-// baseURL defaults to http://localhost:11434 and model defaults to qwen2.5-coder:7b.
+// baseURL defaults to http://127.0.0.1:11434 and model defaults to qwen2.5-coder:7b.
 func NewOllamaChatProvider(baseURL, model string, opts OllamaOptions) *OllamaProvider {
 	if baseURL == "" {
 		baseURL = ollamaChatDefaultBaseURL


### PR DESCRIPTION
## What

Replace `http://localhost:11434` with `http://127.0.0.1:11434` as the default Ollama base URL in three places:

- `internal/llm/ollama.go` — `ollamaChatDefaultBaseURL` constant
- `internal/config/config.go` — default value for `embed.ollama.base_url`
- `internal/embedding/provider.go` — fallback in the embedding provider factory

## Why

On Linux (and other dual-stack systems), Go's DNS resolver resolves `localhost` to the IPv6 address `::1` before falling back to `127.0.0.1`. Ollama's default listener binds to `0.0.0.0:11434` (IPv4 only on many installs), so connections to `[::1]:11434` are refused even when Ollama is running fine.

Live session error:
```
dial tcp [::1]:11434: connect: connection refused
```

Using the explicit IPv4 loopback `127.0.0.1` bypasses the IPv6 resolution entirely and connects directly to where Ollama is listening.

## How

Minimal constant/default change — no logic altered. All existing tests pass.
