### PR TITLE
fix: respect OLLAMA_HOST env var when no base_url is configured

### DIFF
--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -38,10 +38,18 @@ type OllamaProvider struct {
 }
 
 // NewOllamaChatProvider creates a native Ollama chat provider.
-// baseURL defaults to http://localhost:11434 and model defaults to qwen2.5-coder:7b.
+// baseURL defaults to the OLLAMA_HOST env var, then http://localhost:11434.
+// model defaults to qwen2.5-coder:7b.
 func NewOllamaChatProvider(baseURL, model string, opts OllamaOptions) *OllamaProvider {
 	if baseURL == "" {
-		baseURL = ollamaChatDefaultBaseURL
+		if host := strings.TrimSpace(os.Getenv("OLLAMA_HOST")); host != "" {
+			if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+				host = "http://" + host
+			}
+			baseURL = host
+		} else {
+			baseURL = ollamaChatDefaultBaseURL
+		}
 	}
 	baseURL = strings.TrimSuffix(baseURL, "/")
 	if model == "" {


### PR DESCRIPTION
## What

When the Ollama provider is used without an explicit `base_url` in config, `NewOllamaChatProvider` now checks the `OLLAMA_HOST` environment variable before falling back to `http://localhost:11434`.

## Why

Every official Ollama client respects `OLLAMA_HOST` to locate the server. term-llm was ignoring it, so users who set `OLLAMA_HOST` (e.g. `http://127.0.0.1:11434`) would get a "connection refused" error when using Ollama as a built-in provider without a full config entry.

A common trigger: on Linux systems with systemd-resolved, `localhost` can resolve to `::1` (IPv6 loopback) while Ollama listens on `127.0.0.1` only. Users work around this by setting `OLLAMA_HOST=http://127.0.0.1:11434`, which other Ollama clients honour but term-llm did not.

## How

- In `NewOllamaChatProvider`, when `baseURL` is empty, read `OLLAMA_HOST` and normalise it (prepend `http://` if no scheme is present), then fall back to the hardcoded default.
- Explicit `base_url` in provider config always takes precedence.
- All existing tests pass; the fix is contained to `internal/llm/ollama.go`.
