### PR TITLE
fix(serve): cancel active SSE streams on shutdown to prevent SIGTERM hang

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -951,6 +951,25 @@ func (s *serveServer) httpHandler() http.Handler {
 	return mux
 }
 
+// contextWithShutdown returns a derived context that is cancelled when either
+// the parent context is done or shutdownCh is closed. This lets streaming
+// handlers exit promptly on server shutdown rather than holding server.Shutdown
+// open until the full timeout expires.
+func (s *serveServer) contextWithShutdown(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	if s.shutdownCh == nil {
+		return ctx, cancel
+	}
+	go func() {
+		select {
+		case <-s.shutdownCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
 func (s *serveServer) Stop(ctx context.Context) error {
 	if s.server == nil {
 		return nil

--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -193,6 +193,9 @@ func (s *serveServer) streamAnthropicMessages(ctx context.Context, w http.Respon
 
 	pingMu, stopPing := sseKeepalive(w, flusher, 20*time.Second)
 
+	ctx, cancelShutdown := s.contextWithShutdown(ctx)
+	defer cancelShutdown()
+
 	var (
 		blockIndex int
 		openBlock  string // "", "text", or "thinking"

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -172,6 +172,9 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 
 	pingMu, stopPing := sseKeepalive(w, flusher, 20*time.Second)
 
+	ctx, cancelShutdown := s.contextWithShutdown(ctx)
+	defer cancelShutdown()
+
 	first := true
 	toolCallSeen := false
 	toolCallIndex := 0


### PR DESCRIPTION
## What

Add `contextWithShutdown()` helper to `serveServer` and wire it into `streamChatCompletions` and `streamAnthropicMessages`.

## Why

When an active LLM chat stream is in progress during a server shutdown, `server.Shutdown()` blocks waiting for the SSE connection to drain. The HTTP request context (`ctx`) passed to `RunWithEvents` is not cancelled when `shutdownCh` fires — only the response-runs SSE handler was wired to `shutdownCh`.

This caused `server.Shutdown()` to hold open for up to 10 seconds (the shutdown context timeout). runit's `sv restart` only waits 7 seconds before giving up. The process would eventually exit at 10s, but by then runit had already marked the service as "want down" — no auto-restart would fire.

The symptom: after 7 consecutive self-updates with an active chat stream, the webui service required a manual `SIGKILL` to unstick.

## Fix

`contextWithShutdown(ctx)` returns a derived context cancelled by whichever fires first: the parent context or `shutdownCh`. Both streaming handlers now use this context for `RunWithEvents`, so active LLM streams are cancelled immediately when shutdown is signalled. `server.Shutdown()` then completes well within runit's 7-second window.
