### PR TITLE
fix: Responses API stream corruption can silently synthesize bogus tool calls

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -708,13 +708,14 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					Item        responsesOutputItem `json:"item"`
 					OutputIndex int                 `json:"output_index"`
 				}
-				if err := json.Unmarshal([]byte(data), &itemEvent); err == nil {
-					if itemEvent.Item.Type == "function_call" {
-						// Use output_index as tracking key (stable across events), Item.CallID as the actual call ID
-						toolState.StartCall(itemEvent.OutputIndex, itemEvent.Item.CallID, itemEvent.Item.Name)
-					} else if itemEvent.Item.Type == "reasoning" {
-						reasoningState.Start(itemEvent.OutputIndex, itemEvent.Item.ID, itemEvent.Item.EncryptedContent, itemEvent.Item.Summary)
-					}
+				if err := json.Unmarshal([]byte(data), &itemEvent); err != nil {
+					return fmt.Errorf("decode Responses API %s event: %w", lastEventType, err)
+				}
+				if itemEvent.Item.Type == "function_call" {
+					// Use output_index as tracking key (stable across events), Item.CallID as the actual call ID
+					toolState.StartCall(itemEvent.OutputIndex, itemEvent.Item.CallID, itemEvent.Item.Name)
+				} else if itemEvent.Item.Type == "reasoning" {
+					reasoningState.Start(itemEvent.OutputIndex, itemEvent.Item.ID, itemEvent.Item.EncryptedContent, itemEvent.Item.Summary)
 				}
 
 			case "response.function_call_arguments.delta":
@@ -722,60 +723,62 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					OutputIndex int    `json:"output_index"`
 					Delta       string `json:"delta"`
 				}
-				if err := json.Unmarshal([]byte(data), &argEvent); err == nil {
-					toolState.AppendArguments(argEvent.OutputIndex, argEvent.Delta)
+				if err := json.Unmarshal([]byte(data), &argEvent); err != nil {
+					return fmt.Errorf("decode Responses API %s event: %w", lastEventType, err)
 				}
+				toolState.AppendArguments(argEvent.OutputIndex, argEvent.Delta)
 
 			case "response.output_item.done":
 				var doneEvent struct {
 					Item        responsesOutputItem `json:"item"`
 					OutputIndex int                 `json:"output_index"`
 				}
-				if err := json.Unmarshal([]byte(data), &doneEvent); err == nil {
-					if doneEvent.Item.Type == "function_call" {
-						// Complete the tool call with final arguments using output_index
-						toolState.FinishCall(doneEvent.OutputIndex, doneEvent.Item.CallID, doneEvent.Item.Name, doneEvent.Item.Arguments)
-					} else if doneEvent.Item.Type == "reasoning" {
-						reasoningState.Finish(doneEvent.OutputIndex, doneEvent.Item.ID, doneEvent.Item.EncryptedContent, doneEvent.Item.Summary)
-						if part := reasoningState.Part(doneEvent.OutputIndex); part != nil {
-							if err := send.Send(Event{
-								Type:                      EventReasoningDelta,
-								Text:                      part.ReasoningContent,
-								ReasoningItemID:           part.ReasoningItemID,
-								ReasoningEncryptedContent: part.ReasoningEncryptedContent,
-							}); err != nil {
+				if err := json.Unmarshal([]byte(data), &doneEvent); err != nil {
+					return fmt.Errorf("decode Responses API %s event: %w", lastEventType, err)
+				}
+				if doneEvent.Item.Type == "function_call" {
+					// Complete the tool call with final arguments using output_index
+					toolState.FinishCall(doneEvent.OutputIndex, doneEvent.Item.CallID, doneEvent.Item.Name, doneEvent.Item.Arguments)
+				} else if doneEvent.Item.Type == "reasoning" {
+					reasoningState.Finish(doneEvent.OutputIndex, doneEvent.Item.ID, doneEvent.Item.EncryptedContent, doneEvent.Item.Summary)
+					if part := reasoningState.Part(doneEvent.OutputIndex); part != nil {
+						if err := send.Send(Event{
+							Type:                      EventReasoningDelta,
+							Text:                      part.ReasoningContent,
+							ReasoningItemID:           part.ReasoningItemID,
+							ReasoningEncryptedContent: part.ReasoningEncryptedContent,
+						}); err != nil {
+							return err
+						}
+					}
+				} else if doneEvent.Item.Type == "message" {
+					// Text content is normally streamed via response.output_text.delta events.
+					// Fall back to emitting here if no deltas were seen (provider inconsistency).
+					// Always emit refusals since those may not be streamed.
+					for _, content := range doneEvent.Item.Content {
+						if content.Type == "output_text" && content.Text != "" && !sawTextDelta {
+							if err := send.Send(Event{Type: EventTextDelta, Text: content.Text}); err != nil {
+								return err
+							}
+						} else if content.Type == "refusal" && content.Refusal != "" {
+							if err := send.Send(Event{Type: EventTextDelta, Text: content.Refusal}); err != nil {
 								return err
 							}
 						}
-					} else if doneEvent.Item.Type == "message" {
-						// Text content is normally streamed via response.output_text.delta events.
-						// Fall back to emitting here if no deltas were seen (provider inconsistency).
-						// Always emit refusals since those may not be streamed.
-						for _, content := range doneEvent.Item.Content {
-							if content.Type == "output_text" && content.Text != "" && !sawTextDelta {
-								if err := send.Send(Event{Type: EventTextDelta, Text: content.Text}); err != nil {
-									return err
-								}
-							} else if content.Type == "refusal" && content.Refusal != "" {
-								if err := send.Send(Event{Type: EventTextDelta, Text: content.Refusal}); err != nil {
-									return err
-								}
-							}
+					}
+				} else if doneEvent.Item.Type == "image_generation_call" {
+					if doneEvent.Item.Result != "" {
+						decoded, err := base64.StdEncoding.DecodeString(doneEvent.Item.Result)
+						if err != nil {
+							return fmt.Errorf("decode image_generation_call result: %w", err)
 						}
-					} else if doneEvent.Item.Type == "image_generation_call" {
-						if doneEvent.Item.Result != "" {
-							decoded, err := base64.StdEncoding.DecodeString(doneEvent.Item.Result)
-							if err != nil {
-								return fmt.Errorf("decode image_generation_call result: %w", err)
-							}
-							if err := send.Send(Event{
-								Type:          EventImageGenerated,
-								ImageData:     decoded,
-								ImageMimeType: "image/png",
-								RevisedPrompt: doneEvent.Item.RevisedPrompt,
-							}); err != nil {
-								return err
-							}
+						if err := send.Send(Event{
+							Type:          EventImageGenerated,
+							ImageData:     decoded,
+							ImageMimeType: "image/png",
+							RevisedPrompt: doneEvent.Item.RevisedPrompt,
+						}); err != nil {
+							return err
 						}
 					}
 				}
@@ -838,6 +841,9 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		}
 
 		// Emit completed tool calls
+		if err := toolState.Validate(); err != nil {
+			return err
+		}
 		for _, call := range toolState.Calls() {
 			if err := send.Send(Event{Type: EventToolCall, Tool: &call}); err != nil {
 				return err
@@ -952,6 +958,29 @@ func (s *responsesToolState) FinishCall(outputIndex int, callID, name, finalArgs
 		state.name = name
 	}
 	state.finished = true
+}
+
+func (s *responsesToolState) Validate() error {
+	for _, outputIndex := range s.order {
+		state := s.calls[outputIndex]
+		if state == nil {
+			continue
+		}
+		if !state.finished {
+			return fmt.Errorf("Responses API stream ended before tool call %d completed", outputIndex)
+		}
+		if strings.TrimSpace(state.callID) == "" {
+			return fmt.Errorf("Responses API stream missing call_id for tool call %d", outputIndex)
+		}
+		args := strings.TrimSpace(state.args.String())
+		if args == "" {
+			return fmt.Errorf("Responses API stream missing arguments for tool call %d", outputIndex)
+		}
+		if !json.Valid([]byte(args)) {
+			return fmt.Errorf("Responses API stream invalid arguments for tool call %d", outputIndex)
+		}
+	}
+	return nil
 }
 
 func (s *responsesToolState) Calls() []ToolCall {

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -763,6 +763,131 @@ func TestResponsesToolState_MultipleToolCalls(t *testing.T) {
 	}
 }
 
+func TestResponsesClientStream_ErrorsOnMalformedToolCallDelta(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: response.output_item.added",
+		"data: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_bad\",\"name\":\"search\"}}",
+		"",
+		"event: response.function_call_arguments.delta",
+		"data: {\"output_index\":0,\"delta\":",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+	defer stream.Close()
+
+	toolCalls := 0
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			t.Fatal("expected stream error, got EOF")
+		}
+		if recvErr != nil {
+			t.Fatalf("stream recv failed: %v", recvErr)
+		}
+		switch event.Type {
+		case EventToolCall:
+			toolCalls++
+		case EventDone:
+			t.Fatal("expected stream error, got EventDone")
+		case EventError:
+			if event.Err == nil {
+				t.Fatal("expected EventError.Err to be set")
+			}
+			if !strings.Contains(event.Err.Error(), "decode Responses API response.function_call_arguments.delta event") {
+				t.Fatalf("expected decode error, got: %v", event.Err)
+			}
+			if toolCalls != 0 {
+				t.Fatalf("expected no tool calls before error, got %d", toolCalls)
+			}
+			return
+		}
+	}
+}
+
+func TestResponsesClientStream_ErrorsOnIncompleteToolCallAtEOF(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: response.output_item.added",
+		"data: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_partial\",\"name\":\"search\"}}",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			t.Fatal("expected stream error, got EOF")
+		}
+		if recvErr != nil {
+			t.Fatalf("stream recv failed: %v", recvErr)
+		}
+		switch event.Type {
+		case EventToolCall:
+			t.Fatal("expected incomplete stream to fail before emitting tool call")
+		case EventDone:
+			t.Fatal("expected stream error, got EventDone")
+		case EventError:
+			if event.Err == nil {
+				t.Fatal("expected EventError.Err to be set")
+			}
+			if !strings.Contains(event.Err.Error(), "ended before tool call 0 completed") {
+				t.Fatalf("expected incomplete tool call error, got: %v", event.Err)
+			}
+			return
+		}
+	}
+}
+
 func TestBuildResponsesInput_ConvertsDanglingToolCalls(t *testing.T) {
 	messages := []Message{
 		{


### PR DESCRIPTION
## What

- fail the Responses API stream when tool-call SSE events cannot be decoded instead of silently skipping them
- validate accumulated streamed tool calls before emitting them so incomplete, missing-ID, missing-arguments, or invalid-JSON calls do not get synthesized and returned as success
- add regression coverage for malformed tool-call deltas and truncated streams that previously could emit bogus tool calls

## Why

A truncated or malformed Responses API stream could previously skip `response.output_item.done` or argument delta events, then still flush `toolState.Calls()` at the end with fallback IDs and `{}` arguments. That turned upstream stream corruption into incorrect tool execution and corrupted assistant output instead of surfacing a hard error to the caller.
