### PR TITLE
fix: Inline image uploads bypass the configured max attachment size limit

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -211,12 +211,11 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					if filename == "" {
 						filename = "image"
 					}
-					savedPath := ""
-					if path, err := saveUploadedFile(filename, b64); err != nil {
-						log.Printf("[web] warning: could not save uploaded image %q: %v", filename, err)
-					} else {
-						savedPath = path
+					path, err := saveUploadedFile(filename, b64)
+					if err != nil {
+						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
 					}
+					savedPath := path
 
 					// Decode raw bytes for possible resize.
 					raw, err := base64.StdEncoding.DecodeString(b64)

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -34,6 +36,28 @@ func TestParseUserMessageContent_RejectsTooManyInlineImages(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), fmt.Sprintf("too many attachments (max %d)", maxAttachments)) {
 		t.Fatalf("parseUserMessageContent() error = %v, want attachment limit error", err)
+	}
+}
+
+func TestParseUserMessageContent_RejectsOversizedInlineImage(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	raw := bytes.Repeat([]byte("a"), maxAttachmentBytes+1)
+	content, err := json.Marshal([]map[string]any{{
+		"type":      "input_image",
+		"image_url": "data:image/png;base64," + base64.StdEncoding.EncodeToString(raw),
+		"filename":  "too-large.png",
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	_, err = parseUserMessageContent(content)
+	if err == nil {
+		t.Fatal("parseUserMessageContent() error = nil, want size limit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d MB limit", maxAttachmentBytes>>20)) {
+		t.Fatalf("parseUserMessageContent() error = %v, want size limit error", err)
 	}
 }
 


### PR DESCRIPTION
## What

Reject inline image uploads when saving the original attachment fails, instead of logging and continuing.
Added a regression test covering oversized inline images that exceed the configured per-file attachment limit.

## Why

Inline native image parts were still decoded and embedded into the LLM request after `saveUploadedFile` rejected them for exceeding `maxAttachmentBytes`.
That bypassed the intended 20 MB limit and allowed oversized request bodies to reach providers, wasting memory and causing avoidable failures.
