### PR TITLE
fix: normalise localhost to 127.0.0.1 for local LLM providers

### DIFF
--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -52,6 +52,11 @@ func NewOllamaChatProvider(baseURL, model string, opts OllamaOptions) *OllamaPro
 		}
 	}
 	baseURL = strings.TrimSuffix(baseURL, "/")
+	// Ollama binds to 127.0.0.1 (IPv4) by default. If the caller passes
+	// "localhost", Go may resolve it to ::1 (IPv6) on dual-stack systems,
+	// causing "connect: connection refused" even when Ollama is running.
+	// Normalise to the explicit IPv4 loopback address to match the default.
+	baseURL = strings.Replace(baseURL, "://localhost:", "://127.0.0.1:", 1)
 	if model == "" {
 		model = ollamaChatDefaultModel
 	}

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -31,6 +31,13 @@ func TestOllamaProviderDefaults(t *testing.T) {
 	}
 }
 
+func TestOllamaProviderLocalhostNormalization(t *testing.T) {
+	p := NewOllamaChatProvider("http://localhost:11434", "test", OllamaOptions{})
+	if p.baseURL != "http://127.0.0.1:11434" {
+		t.Errorf("expected localhost to be normalised to 127.0.0.1, got %q", p.baseURL)
+	}
+}
+
 func TestOllamaProviderCredential(t *testing.T) {
 	p := NewOllamaChatProvider("", "", OllamaOptions{})
 	if p.Credential() != "free" {

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -69,6 +69,11 @@ func NewOpenAICompatProviderFull(baseURL, chatURL, apiKey, model, name string, h
 		baseURL = strings.TrimSuffix(baseURL, "/")
 		baseURL = strings.TrimSuffix(baseURL, "/chat/completions")
 		baseURL = strings.TrimSuffix(baseURL, "/") // In case URL was .../v1/chat/completions
+		// Local LLM servers (Ollama, LM Studio, vLLM, etc.) bind to 127.0.0.1
+		// (IPv4) by default. If the user passes "localhost", Go may resolve it to
+		// ::1 (IPv6) on dual-stack systems, causing connection refused even when
+		// the server is running. Normalise to the explicit IPv4 loopback address.
+		baseURL = strings.Replace(baseURL, "://localhost:", "://127.0.0.1:", 1)
 	}
 	// Normalize chatURL - just strip trailing slash
 	if chatURL != "" {


### PR DESCRIPTION
## What

Normalise `localhost` → `127.0.0.1` in both `NewOllamaChatProvider` and `NewOpenAICompatProviderFull` when the base URL contains `localhost`.

## Why

Ollama (and other local LLM servers like LM Studio, vLLM) bind to `127.0.0.1` (IPv4 loopback) by default. On dual-stack Linux systems, Go resolves the `localhost` hostname to `::1` (IPv6) before `127.0.0.1` (IPv4). This causes a `dial tcp [::1]:11434: connect: connection refused` error even when Ollama is running, because nothing is listening on the IPv6 loopback port.

Live session that triggered this bug:
```
Ollama API request failed: Post "http://localhost:11434/v1/chat/completions": dial tcp [::1]:11434: connect: connection refused
```

The native `OllamaProvider` already uses `http://127.0.0.1:11434` as its default, but a user-supplied `base_url: http://localhost:11434` (or `OLLAMA_HOST=localhost:11434`) bypassed that protection. The same issue affects the OpenAI-compatible path used when `type: openai_compatible` points to a local server.

## How

- `internal/llm/ollama.go`: replace `://localhost:` with `://127.0.0.1:` after base URL normalisation in `NewOllamaChatProvider`
- `internal/llm/openai_compat.go`: same replacement in `NewOpenAICompatProviderFull` base URL normalisation block, covering Ollama's OpenAI-compat endpoint and other local servers
- `internal/llm/ollama_test.go`: add `TestOllamaProviderLocalhostNormalization` to verify the rewrite
