### PR TITLE
fix: OpenAI-compatible stream parser mishandles multi-line SSE payloads

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -343,6 +343,28 @@ func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
 	return strings.TrimRight(line, "\r\n"), false, nil
 }
 
+func readSSEEvent(reader *bufio.Reader) (eventType, data string, eof bool, err error) {
+	var dataLines []string
+
+	for {
+		line, lineEOF, err := readSSELine(reader)
+		if err != nil {
+			return "", "", false, err
+		}
+		if line == "" {
+			return eventType, strings.Join(dataLines, "\n"), lineEOF, nil
+		}
+		if strings.HasPrefix(line, "event: ") {
+			eventType = strings.TrimPrefix(line, "event: ")
+		} else if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+		if lineEOF {
+			return eventType, strings.Join(dataLines, "\n"), true, nil
+		}
+	}
+}
+
 func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	req.MaxOutputTokens = ClampOutputTokens(req.MaxOutputTokens, chooseModel(req.Model, p.model))
 	// Build messages and tools synchronously
@@ -436,32 +458,16 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 
 		toolState := newCompatToolState()
 		var lastUsage *Usage
-		var lastEventType string
 		var reasoningBuilder strings.Builder
 
 		for {
-			line, eof, err := readSSELine(reader)
+			eventType, data, eof, err := readSSEEvent(reader)
 			if err != nil {
 				return fmt.Errorf("%s streaming error: %w", p.name, err)
 			}
-			if eof && line == "" {
+			if eof && eventType == "" && data == "" {
 				break
 			}
-
-			if strings.HasPrefix(line, "event: ") {
-				lastEventType = strings.TrimPrefix(line, "event: ")
-				if eof {
-					break
-				}
-				continue
-			}
-			if !strings.HasPrefix(line, "data: ") {
-				if eof {
-					break
-				}
-				continue
-			}
-			data := strings.TrimPrefix(line, "data: ")
 			if strings.TrimSpace(data) == "" {
 				if eof {
 					break
@@ -477,7 +483,7 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 				return fmt.Errorf("%s streaming error: invalid JSON chunk: %w", p.name, err)
 			}
 
-			if lastEventType == "error" || chatResp.Error != nil {
+			if eventType == "error" || chatResp.Error != nil {
 				errMsg := "unknown error"
 				if chatResp.Error != nil {
 					errMsg = chatResp.Error.Message
@@ -519,7 +525,6 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 				}
 			}
 
-			lastEventType = ""
 			if eof {
 				break
 			}

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -85,6 +85,114 @@ func TestOpenAICompatStream_AllowsLargeSSEDataLines(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatStream_HandlesMultiLineSSEPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}],\n"+
+				"data: \"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}\n\n"+
+				"data: [DONE]\n\n",
+		)
+	}))
+	defer server.Close()
+
+	provider := NewOpenAICompatProvider(server.URL, "", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "hello"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	var gotText string
+	var gotUsage *Usage
+	var sawDone bool
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			gotText += event.Text
+		case EventUsage:
+			gotUsage = event.Use
+		case EventDone:
+			sawDone = true
+		case EventError:
+			t.Fatalf("unexpected stream error: %v", event.Err)
+		}
+	}
+
+	if gotText != "hello" {
+		t.Fatalf("expected streamed text %q, got %q", "hello", gotText)
+	}
+	if gotUsage == nil {
+		t.Fatal("expected usage event")
+	}
+	if gotUsage.InputTokens != 1 || gotUsage.OutputTokens != 1 || gotUsage.ProviderTotalTokens != 2 {
+		t.Fatalf("unexpected usage: %+v", gotUsage)
+	}
+	if !sawDone {
+		t.Fatal("expected EventDone")
+	}
+}
+
+func TestOpenAICompatStream_HandlesMultiLineErrorEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			"event: error\n"+
+				"data: {\"error\":\n"+
+				"data: {\"message\":\"split backend failure\"}}\n\n",
+		)
+	}))
+	defer server.Close()
+
+	provider := NewOpenAICompatProvider(server.URL, "", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{{
+			Role:  RoleUser,
+			Parts: []Part{{Type: PartText, Text: "hello"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		switch event.Type {
+		case EventError:
+			if event.Err == nil {
+				t.Fatal("expected stream error")
+			}
+			if !strings.Contains(event.Err.Error(), "split backend failure") {
+				t.Fatalf("expected backend error, got %v", event.Err)
+			}
+			return
+		case EventDone:
+			t.Fatal("expected EventError before EventDone")
+		}
+	}
+
+	t.Fatal("expected EventError")
+}
+
 func TestOpenAICompatStream_CloseDoesNotHangWhenConsumerStopsReceiving(t *testing.T) {
 	chunk, err := json.Marshal(oaiChatResponse{
 		Choices: []oaiChoice{{


### PR DESCRIPTION
## What

- assemble OpenAI-compatible SSE events across multiple `data:` lines before decoding JSON
- keep each event's `event:` type associated with the full payload until the blank-line event boundary
- add regression tests for split multi-line payloads and multi-line `event: error` frames

## Why

Some OpenAI-compatible backends emit valid SSE events with JSON split across multiple `data:` lines. The previous parser tried to decode each `data:` line independently and cleared the remembered event type too early, which could break streaming or surface the wrong error for valid providers.
