### PR TITLE
fix: Slow response-run subscribers are dropped and falsely told the run is finished

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -42,6 +42,7 @@ type responseRunRecoveryMessage struct {
 }
 
 type responseRunSubscribeResult struct {
+	id               int
 	replay           []responseRunEvent
 	ch               <-chan responseRunEvent
 	snapshotRequired bool
@@ -72,6 +73,7 @@ type responseRun struct {
 	compactionEnabled  bool
 	subscribers        map[int]chan responseRunEvent
 	subscriberWarned   map[int]bool // tracks whether 75% buffer warning was logged
+	subscriberDropped  map[int]bool // tracks subscribers dropped after their live buffer overflowed
 	nextSubscriberID   int
 	cancel             context.CancelFunc
 	cancelRequested    bool
@@ -96,6 +98,7 @@ func newResponseRun(respID, sessionID, previousResponseID, model string, created
 		compactionEnabled:  true,
 		subscribers:        make(map[int]chan responseRunEvent),
 		subscriberWarned:   make(map[int]bool),
+		subscriberDropped:  make(map[int]bool),
 		cancel:             cancel,
 	}
 }
@@ -183,6 +186,7 @@ func (r *responseRun) appendEventLocked(event string, payload map[string]any, te
 			}
 		default:
 			log.Printf("response run %s subscriber fell behind at sequence %d; closing stream", r.id, stored.Sequence)
+			r.subscriberDropped[id] = true
 			close(ch)
 			delete(r.subscribers, id)
 			delete(r.subscriberWarned, id)
@@ -412,7 +416,17 @@ func (r *responseRun) subscribe(after int64) responseRunSubscribeResult {
 	r.nextSubscriberID++
 	ch := make(chan responseRunEvent, defaultResponseRunSubscriberBuffer)
 	r.subscribers[id] = ch
-	return responseRunSubscribeResult{replay: replay, ch: ch}
+	return responseRunSubscribeResult{id: id, replay: replay, ch: ch}
+}
+
+func (r *responseRun) subscriberWasDropped(id int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.subscriberDropped[id] {
+		return false
+	}
+	delete(r.subscriberDropped, id)
+	return true
 }
 
 func (r *responseRun) unsubscribe(ch <-chan responseRunEvent) {
@@ -982,6 +996,7 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 	flusher.Flush()
 	replay := subscription.replay
 	ch := subscription.ch
+	subscriberID := subscription.id
 
 	pingMu, stopPing := sseKeepalive(w, flusher, 20*time.Second)
 	var stopPingOnce sync.Once
@@ -1028,6 +1043,9 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 			return
 		case ev, ok := <-ch:
 			if !ok {
+				if run.subscriberWasDropped(subscriberID) {
+					return
+				}
 				writeDone()
 				return
 			}

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 func TestResponseRunSubscriberSurvivesUpToBufferLimit(t *testing.T) {
@@ -136,5 +142,91 @@ func TestResponseRunConcurrentAppendsPreserveOrder(t *testing.T) {
 		if seq != expected {
 			t.Fatalf("gap at index %d: expected seq %d, got %d", i, expected, seq)
 		}
+	}
+}
+
+type blockingResponseWriter struct {
+	header http.Header
+	gate   <-chan struct{}
+	buf    bytes.Buffer
+}
+
+func (w *blockingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *blockingResponseWriter) WriteHeader(statusCode int) {}
+
+func (w *blockingResponseWriter) Write(p []byte) (int, error) {
+	<-w.gate
+	return w.buf.Write(p)
+}
+
+func (w *blockingResponseWriter) Flush() {}
+
+func waitForResponseRunCondition(t *testing.T, timeout time.Duration, fn func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(message)
+}
+
+func TestStreamResponseRunEventsDoesNotWriteDoneWhenSubscriberOverflows(t *testing.T) {
+	srv := &serveServer{shutdownCh: make(chan struct{})}
+	run := newResponseRun("resp_overflow", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	gate := make(chan struct{})
+	w := &blockingResponseWriter{header: make(http.Header), gate: gate}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	streamDone := make(chan struct{})
+	go func() {
+		srv.streamResponseRunEvents(ctx, w, run, 0)
+		close(streamDone)
+	}()
+
+	waitForResponseRunCondition(t, time.Second, func() bool {
+		run.mu.Lock()
+		defer run.mu.Unlock()
+		return len(run.subscribers) == 1
+	}, "timed out waiting for stream subscriber")
+
+	for i := 0; i < defaultResponseRunSubscriberBuffer+16; i++ {
+		if err := run.appendEvent("response.output_text.delta", map[string]any{"delta": "x"}); err != nil {
+			t.Fatalf("appendEvent failed at %d: %v", i, err)
+		}
+	}
+
+	waitForResponseRunCondition(t, time.Second, func() bool {
+		run.mu.Lock()
+		defer run.mu.Unlock()
+		return len(run.subscribers) == 0
+	}, "timed out waiting for subscriber drop")
+
+	if err := run.complete(map[string]any{
+		"response": map[string]any{"id": run.id},
+	}, llm.Usage{}, llm.Usage{}); err != nil {
+		t.Fatalf("complete failed: %v", err)
+	}
+
+	close(gate)
+
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for overflowed stream to finish")
+	}
+
+	body := w.buf.String()
+	if !strings.Contains(body, "event: response.output_text.delta\n") {
+		t.Fatalf("stream body missing replayed delta events: %q", body)
+	}
+	if strings.Contains(body, "data: [DONE]\n\n") {
+		t.Fatalf("overflowed stream should not emit [DONE], got: %q", body)
 	}
 }


### PR DESCRIPTION
## What

- track response-run subscribers that were dropped because their live SSE buffer overflowed
- stop emitting `data: [DONE]` when a stream ends because that subscriber was dropped rather than because the run delivered a terminal event
- add a regression test covering the overflow case, including the race where the run completes after the subscriber was already dropped

## Why

Slow or briefly stalled clients could overflow the 256-event live buffer, get detached, and then be told the stream ended cleanly with `[DONE]` even though they never received `response.completed` or `response.failed`. That causes silent data loss and incorrect client state. By distinguishing overflow drops from normal terminal closure, clients can treat the stream as interrupted and reconnect using replay/snapshot recovery instead of believing the run finished cleanly.
