### PR TITLE
fix: Responses API stream parser is not SSE-compliant and breaks on multi-line events

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -661,59 +661,58 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		reasoningState := newResponsesReasoningState()
 		var lastUsage *Usage
 		var lastEventType string
+		var eventData []string
 		sawTextDelta := false // Track if any text deltas were emitted
 
-		for {
-			line, eof, err := readSSELine(reader)
-			if err != nil {
-				return fmt.Errorf("Responses API streaming error: %w", err)
-			}
-			if eof && line == "" {
-				break
+		flushEvent := func() (bool, error) {
+			if len(eventData) == 0 {
+				lastEventType = ""
+				return false, nil
 			}
 
-			if strings.HasPrefix(line, "event: ") {
-				lastEventType = strings.TrimPrefix(line, "event: ")
-				if eof {
-					break
+			data := strings.Join(eventData, "\n")
+			eventType := lastEventType
+			if eventType == "" {
+				var sseEvent responsesSSEEvent
+				if err := json.Unmarshal([]byte(data), &sseEvent); err == nil && sseEvent.Type != "" {
+					eventType = sseEvent.Type
 				}
-				continue
 			}
-			if !strings.HasPrefix(line, "data: ") {
-				if eof {
-					break
-				}
-				continue
-			}
-			data := strings.TrimPrefix(line, "data: ")
+			eventData = nil
+			lastEventType = ""
+
 			if data == "[DONE]" {
-				break
+				return true, nil
 			}
 
+			eventLabel := eventType
+			if eventLabel == "" {
+				eventLabel = "unknown"
+			}
 			if debugRaw {
-				DebugRawSection(debugRaw, "Responses API SSE Line (event="+lastEventType+")", data)
+				DebugRawSection(debugRaw, "Responses API SSE Event (event="+eventLabel+")", data)
 			}
 
 			unmarshalEvent := func(dst any) error {
 				if err := json.Unmarshal([]byte(data), dst); err != nil {
-					return fmt.Errorf("decode Responses API %s event: %w", lastEventType, err)
+					return fmt.Errorf("decode Responses API %s event: %w", eventLabel, err)
 				}
 				return nil
 			}
 
 			// Handle different SSE event types based on event name
-			switch lastEventType {
+			switch eventType {
 			case "response.output_text.delta":
 				var deltaEvent struct {
 					Delta string `json:"delta"`
 				}
 				if err := unmarshalEvent(&deltaEvent); err != nil {
-					return err
+					return false, err
 				}
 				if deltaEvent.Delta != "" {
 					sawTextDelta = true
 					if err := send.Send(Event{Type: EventTextDelta, Text: deltaEvent.Delta}); err != nil {
-						return err
+						return false, err
 					}
 				}
 
@@ -723,7 +722,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					OutputIndex int                 `json:"output_index"`
 				}
 				if err := unmarshalEvent(&itemEvent); err != nil {
-					return err
+					return false, err
 				}
 				if itemEvent.Item.Type == "function_call" {
 					// Use output_index as tracking key (stable across events), Item.CallID as the actual call ID
@@ -738,7 +737,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					Delta       string `json:"delta"`
 				}
 				if err := unmarshalEvent(&argEvent); err != nil {
-					return err
+					return false, err
 				}
 				toolState.AppendArguments(argEvent.OutputIndex, argEvent.Delta)
 
@@ -748,7 +747,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					OutputIndex int                 `json:"output_index"`
 				}
 				if err := unmarshalEvent(&doneEvent); err != nil {
-					return err
+					return false, err
 				}
 				if doneEvent.Item.Type == "function_call" {
 					// Complete the tool call with final arguments using output_index
@@ -762,7 +761,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 							ReasoningItemID:           part.ReasoningItemID,
 							ReasoningEncryptedContent: part.ReasoningEncryptedContent,
 						}); err != nil {
-							return err
+							return false, err
 						}
 					}
 				} else if doneEvent.Item.Type == "message" {
@@ -772,11 +771,11 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					for _, content := range doneEvent.Item.Content {
 						if content.Type == "output_text" && content.Text != "" && !sawTextDelta {
 							if err := send.Send(Event{Type: EventTextDelta, Text: content.Text}); err != nil {
-								return err
+								return false, err
 							}
 						} else if content.Type == "refusal" && content.Refusal != "" {
 							if err := send.Send(Event{Type: EventTextDelta, Text: content.Refusal}); err != nil {
-								return err
+								return false, err
 							}
 						}
 					}
@@ -784,7 +783,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					if doneEvent.Item.Result != "" {
 						decoded, err := base64.StdEncoding.DecodeString(doneEvent.Item.Result)
 						if err != nil {
-							return fmt.Errorf("decode image_generation_call result: %w", err)
+							return false, fmt.Errorf("decode image_generation_call result: %w", err)
 						}
 						if err := send.Send(Event{
 							Type:          EventImageGenerated,
@@ -792,7 +791,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 							ImageMimeType: "image/png",
 							RevisedPrompt: doneEvent.Item.RevisedPrompt,
 						}); err != nil {
-							return err
+							return false, err
 						}
 					}
 				}
@@ -802,7 +801,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					OutputIndex int `json:"output_index"`
 				}
 				if err := unmarshalEvent(&partEvent); err != nil {
-					return err
+					return false, err
 				}
 				reasoningState.Ensure(partEvent.OutputIndex)
 
@@ -812,7 +811,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					Delta       string `json:"delta"`
 				}
 				if err := unmarshalEvent(&summaryDeltaEvent); err != nil {
-					return err
+					return false, err
 				}
 				reasoningState.AppendSummary(summaryDeltaEvent.OutputIndex, summaryDeltaEvent.Delta)
 
@@ -824,7 +823,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					} `json:"response"`
 				}
 				if err := unmarshalEvent(&completedEvent); err != nil {
-					return err
+					return false, err
 				}
 				// Store response ID for conversation continuity (unless disabled)
 				if !client.DisableServerState && completedEvent.Response.ID != "" {
@@ -849,16 +848,83 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 					Error *responsesError `json:"error"`
 				}
 				if err := unmarshalEvent(&errorEvent); err != nil {
-					return err
+					return false, err
 				}
 				if errorEvent.Error != nil {
-					return fmt.Errorf("Responses API error: %s", errorEvent.Error.Message)
+					return false, fmt.Errorf("Responses API error: %s", errorEvent.Error.Message)
 				}
-				return fmt.Errorf("Responses API error: unknown error")
+				return false, fmt.Errorf("Responses API error: unknown error")
 			}
 
-			lastEventType = ""
+			return false, nil
+		}
+
+		for {
+			line, eof, err := readSSELine(reader)
+			if err != nil {
+				return fmt.Errorf("Responses API streaming error: %w", err)
+			}
+
+			if line == "" {
+				stop, err := flushEvent()
+				if err != nil {
+					return err
+				}
+				if stop || eof {
+					break
+				}
+				continue
+			}
+
+			field, value, ok := strings.Cut(line, ":")
+			if ok {
+				if strings.HasPrefix(value, " ") {
+					value = value[1:]
+				}
+				if field == "event" && len(eventData) > 0 {
+					stop, err := flushEvent()
+					if err != nil {
+						return err
+					}
+					if stop {
+						break
+					}
+				}
+				if field == "data" && value == "[DONE]" && len(eventData) > 0 {
+					stop, err := flushEvent()
+					if err != nil {
+						return err
+					}
+					if stop {
+						break
+					}
+				}
+				switch field {
+				case "event":
+					lastEventType = value
+				case "data":
+					eventData = append(eventData, value)
+				}
+				if field == "data" && value == "[DONE]" {
+					stop, err := flushEvent()
+					if err != nil {
+						return err
+					}
+					if stop || eof {
+						break
+					}
+					continue
+				}
+			}
+
 			if eof {
+				stop, err := flushEvent()
+				if err != nil {
+					return err
+				}
+				if stop {
+					break
+				}
 				break
 			}
 		}

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -544,6 +544,147 @@ func TestResponsesClientStream_CloseReturnsPromptlyWhenConsumerStopsDraining(t *
 	}
 }
 
+func TestResponsesClientStream_ParsesMultilineSSEEvents(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: response.output_text.delta",
+		"data: {",
+		`data:   "delta": "hello"`,
+		"data: }",
+		"",
+		"event: response.completed",
+		"data: {",
+		`data:   "response": {`,
+		`data:     "id": "resp_multiline",`,
+		`data:     "usage": {`,
+		`data:       "input_tokens": 11,`,
+		`data:       "output_tokens": 22,`,
+		`data:       "input_tokens_details": {"cached_tokens": 3},`,
+		`data:       "output_tokens_details": {"reasoning_tokens": 4},`,
+		`data:       "total_tokens": 33`,
+		`data:     }`,
+		`data:   }`,
+		"data: }",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+				},
+				Body: io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+	defer stream.Close()
+
+	var gotText strings.Builder
+	var gotUsage *Usage
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("stream recv failed: %v", recvErr)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			gotText.WriteString(event.Text)
+		case EventUsage:
+			gotUsage = event.Use
+		case EventError:
+			t.Fatalf("stream returned error event: %v", event.Err)
+		case EventDone:
+			goto done
+		}
+	}
+
+done:
+	if gotText.String() != "hello" {
+		t.Fatalf("expected streamed text hello, got %q", gotText.String())
+	}
+	if client.LastResponseID != "resp_multiline" {
+		t.Fatalf("expected last response id resp_multiline, got %q", client.LastResponseID)
+	}
+	if gotUsage == nil {
+		t.Fatal("expected usage event from response.completed")
+	}
+	if gotUsage.InputTokens != 8 || gotUsage.CachedInputTokens != 3 || gotUsage.OutputTokens != 22 || gotUsage.ProviderTotalTokens != 33 || gotUsage.ReasoningTokens != 4 {
+		t.Fatalf("unexpected usage: %+v", gotUsage)
+	}
+}
+
+func TestResponsesClientStream_ParsesMultilineSSEErrorEvent(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: error",
+		"data: {",
+		`data:   "error": {`,
+		`data:     "message": "boom"`,
+		`data:   }`,
+		"data: }",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+				},
+				Body: io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		}),
+	}
+
+	client := &ResponsesClient{
+		BaseURL:       "https://example.test/v1/responses",
+		GetAuthHeader: func() string { return "Bearer test-token" },
+		HTTPClient:    httpClient,
+	}
+
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model:  "gpt-5.2",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hello"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+	defer stream.Close()
+
+	event, recvErr := stream.Recv()
+	if recvErr != nil {
+		t.Fatalf("stream recv failed: %v", recvErr)
+	}
+	if event.Type != EventError {
+		t.Fatalf("expected error event, got %+v", event)
+	}
+	if event.Err == nil || !strings.Contains(event.Err.Error(), "boom") {
+		t.Fatalf("expected boom error, got %v", event.Err)
+	}
+}
+
 func TestOpenAIProviderStream_UsesSessionIDForResponsesCaching(t *testing.T) {
 	type capturedRequest struct {
 		SessionID      string


### PR DESCRIPTION
## What

Fix the Responses API stream parser to accumulate SSE events until the blank-line terminator instead of decoding each `data:` line independently. The parser now concatenates multi-line `data:` payloads, keeps the `event:` type for the whole event, and still tolerates the repo's existing single-line/no-blank-line stream fixtures.

Also add regression coverage for multi-line successful and error SSE events.

## Why

Real SSE servers are allowed to split one event across multiple `data:` lines. The old parser assumed one `event:` line followed by one complete JSON `data:` line, so pretty-printed or split JSON payloads could be decoded as partial JSON or associated with the wrong event type, breaking streamed Responses API output.
