### PR TITLE
fix: OpenAI-compatible provider creation panics on empty provider name

### DIFF
--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -356,6 +356,9 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		if baseURL == "" && chatURL == "" {
 			return nil, fmt.Errorf("provider %q requires base_url or url", name)
 		}
+		if name == "" {
+			return nil, fmt.Errorf("openai-compatible provider requires a non-empty name")
+		}
 		// Use provider name as display name, with first letter capitalized
 		displayName := strings.ToUpper(name[:1]) + name[1:]
 		p := NewOpenAICompatProviderFull(baseURL, chatURL, cfg.ResolvedAPIKey, cfg.Model, displayName, nil)

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -1,0 +1,28 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestCreateProviderFromConfig_OpenAICompatRequiresProviderName(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("createProviderFromConfig panicked: %v", r)
+		}
+	}()
+
+	_, err := createProviderFromConfig("", &config.ProviderConfig{
+		Type:    config.ProviderTypeOpenAICompat,
+		BaseURL: "https://example.com/v1",
+		Model:   "test-model",
+	})
+	if err == nil {
+		t.Fatal("expected empty provider name to return an error")
+	}
+	if !strings.Contains(err.Error(), "non-empty name") {
+		t.Fatalf("expected empty name guidance, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

- return a normal configuration error when an OpenAI-compatible provider is created with an empty provider name
- add a regression test covering the empty-name path so it returns an error instead of panicking

## Why

An empty provider key could reach the OpenAI-compatible factory branch and panic on `name[:1]`, crashing provider initialization. This change turns that crash into a regular configuration error.
