### PR TITLE
fix: Standard remote image_url inputs are silently dropped from API requests

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -23,6 +23,8 @@ type sessionInterruptRequest struct {
 	Message string `json:"message"`
 }
 
+var remoteImageURLHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 func writeChatStreamChunk(w io.Writer, payload any) error {
 	b, err := json.Marshal(payload)
 	if err != nil {
@@ -91,6 +93,70 @@ func parseDataURL(dataURL string) (mediaType, base64Data string) {
 		return "", ""
 	}
 	return rest[:idx], rest[idx+8:]
+}
+
+func fetchRemoteImageURL(imageURL string) (mediaType, base64Data, filename string, err error) {
+	req, err := http.NewRequest(http.MethodGet, imageURL, nil)
+	if err != nil {
+		return "", "", "", fmt.Errorf("invalid image URL: %w", err)
+	}
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+		return "", "", "", fmt.Errorf("unsupported image URL scheme %q", req.URL.Scheme)
+	}
+
+	resp, err := remoteImageURLHTTPClient.Do(req)
+	if err != nil {
+		return "", "", "", fmt.Errorf("download image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return "", "", "", fmt.Errorf("download image: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if resp.ContentLength > maxAttachmentBytes {
+		return "", "", "", fmt.Errorf("image file too large: %d bytes (max %d)", resp.ContentLength, maxAttachmentBytes)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxAttachmentBytes+1))
+	if err != nil {
+		return "", "", "", fmt.Errorf("read image data: %w", err)
+	}
+	if len(raw) > maxAttachmentBytes {
+		return "", "", "", fmt.Errorf("image file too large: exceeds %d bytes", maxAttachmentBytes)
+	}
+
+	mediaType = strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if mediaType != "" {
+		parsedType, _, parseErr := mime.ParseMediaType(mediaType)
+		if parseErr == nil {
+			mediaType = parsedType
+		}
+	}
+	if mediaType == "" || mediaType == "application/octet-stream" {
+		mediaType = http.DetectContentType(raw)
+	}
+	if !strings.HasPrefix(mediaType, "image/") {
+		detected := http.DetectContentType(raw)
+		if strings.HasPrefix(detected, "image/") {
+			mediaType = detected
+		} else {
+			return "", "", "", fmt.Errorf("download image: unexpected content type %q", mediaType)
+		}
+	}
+
+	filename = filepath.Base(req.URL.Path)
+	if filename == "." || filename == "/" || filename == "" {
+		filename = "image"
+	}
+	if filepath.Ext(filename) == "" {
+		extensions, extErr := mime.ExtensionsByType(mediaType)
+		if extErr == nil && len(extensions) > 0 {
+			filename += extensions[0]
+		}
+	}
+
+	return mediaType, base64.StdEncoding.EncodeToString(raw), filename, nil
 }
 
 // isLLMImageType returns true for image media types that LLM providers handle natively.
@@ -195,10 +261,23 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 			case "input_image", "image_url":
 				imageURL := jsonImageURL(part["image_url"])
 				filename := jsonString(part["filename"])
-				if !strings.HasPrefix(imageURL, "data:") {
-					continue
+				var mt, b64 string
+				if strings.HasPrefix(imageURL, "data:") {
+					mt, b64 = parseDataURL(imageURL)
+					if mt == "" || b64 == "" {
+						continue
+					}
+				} else {
+					var fetchedFilename string
+					var err error
+					mt, b64, fetchedFilename, err = fetchRemoteImageURL(imageURL)
+					if err != nil {
+						return llm.Message{}, fmt.Errorf("fetch image_url %q: %w", imageURL, err)
+					}
+					if filename == "" {
+						filename = fetchedFilename
+					}
 				}
-				mt, b64 := parseDataURL(imageURL)
 				if mt == "" || b64 == "" {
 					continue
 				}

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -5,8 +5,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 const onePixelPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+KDvV3wAAAABJRU5ErkJggg=="
@@ -59,6 +64,119 @@ func TestParseUserMessageContent_RejectsOversizedInlineImage(t *testing.T) {
 	if !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d MB limit", maxAttachmentBytes>>20)) {
 		t.Fatalf("parseUserMessageContent() error = %v, want size limit error", err)
 	}
+}
+
+func TestParseUserMessageContent_DownloadsRemoteResponsesImageURL(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	raw := mustDecodeDataURLBase64(t, onePixelPNGDataURL)
+	server := newRemoteImageServer(t, "image/png", raw)
+	defer server.Close()
+
+	content, err := json.Marshal([]map[string]any{
+		{
+			"type":      "input_image",
+			"image_url": server.URL + "/pixel.png",
+		},
+		{
+			"type": "input_text",
+			"text": "describe this image",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	assertRemoteImagePart(t, msg, raw)
+	if msg.Parts[1].Type != llm.PartText || msg.Parts[1].Text != "describe this image" {
+		t.Fatalf("parts[1] = %+v, want trailing text", msg.Parts[1])
+	}
+}
+
+func TestParseUserMessageContent_DownloadsRemoteChatImageURL(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	raw := mustDecodeDataURLBase64(t, onePixelPNGDataURL)
+	server := newRemoteImageServer(t, "image/png", raw)
+	defer server.Close()
+
+	content, err := json.Marshal([]map[string]any{
+		{
+			"type":      "image_url",
+			"image_url": map[string]any{"url": server.URL + "/pixel.png"},
+		},
+		{
+			"type": "text",
+			"text": "describe this image",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	assertRemoteImagePart(t, msg, raw)
+	if msg.Parts[1].Type != llm.PartText || msg.Parts[1].Text != "describe this image" {
+		t.Fatalf("parts[1] = %+v, want trailing text", msg.Parts[1])
+	}
+}
+
+func assertRemoteImagePart(t *testing.T, msg llm.Message, raw []byte) {
+	t.Helper()
+
+	if msg.Role != llm.RoleUser {
+		t.Fatalf("msg.Role = %q, want %q", msg.Role, llm.RoleUser)
+	}
+	if len(msg.Parts) != 2 {
+		t.Fatalf("len(msg.Parts) = %d, want 2", len(msg.Parts))
+	}
+	if msg.Parts[0].Type != llm.PartImage {
+		t.Fatalf("parts[0].Type = %q, want %q", msg.Parts[0].Type, llm.PartImage)
+	}
+	if msg.Parts[0].ImageData == nil {
+		t.Fatal("parts[0].ImageData = nil, want image data")
+	}
+	if msg.Parts[0].ImageData.MediaType != "image/png" {
+		t.Fatalf("parts[0].ImageData.MediaType = %q, want image/png", msg.Parts[0].ImageData.MediaType)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(msg.Parts[0].ImageData.Base64)
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Fatal("decoded image bytes do not match downloaded image")
+	}
+	if msg.Parts[0].ImagePath == "" {
+		t.Fatal("parts[0].ImagePath = empty, want saved upload path")
+	}
+	if _, err := os.Stat(msg.Parts[0].ImagePath); err != nil {
+		t.Fatalf("saved upload missing at %q: %v", msg.Parts[0].ImagePath, err)
+	}
+}
+
+func newRemoteImageServer(t *testing.T, mediaType string, body []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", mediaType)
+		_, _ = w.Write(body)
+	}))
+}
+
+func mustDecodeDataURLBase64(t *testing.T, dataURL string) []byte {
+	t.Helper()
+	_, b64 := parseDataURL(dataURL)
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	return data
 }
 
 func marshalInlineImageParts(t *testing.T, count int) json.RawMessage {


### PR DESCRIPTION
## What

- download standard `http(s)` `image_url` inputs instead of silently dropping them when parsing user message content
- keep the existing inline `data:` URL behavior unchanged
- add focused tests for both responses-style `input_image` parts and chat-completions-style `image_url` parts

## Why

`parseUserMessageContent` claimed to accept standard `image_url` content parts, but only handled `data:` URLs and `continue`d on normal remote URLs. That made standards-compliant multimodal requests appear to succeed while the model never received the image. Downloading the remote image restores compatibility for both request shapes and preserves the existing attachment/save-to-disk flow.
