### PR TITLE
fix: Non-streaming Responses API replies return response IDs that cannot be fetched afterward

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -239,10 +239,14 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 
 	setSessionNumberHeader(w, runtime)
 
-	respID := "resp_" + randomSuffix()
-	s.registerResponseID(runtime, respID, sessionID)
+	created := time.Now().Unix()
+	respID, err := s.storeCompletedResponseRun(runtime, sessionID, req.PreviousResponseID, model, created, result)
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
 
-	writeJSON(w, http.StatusOK, responsesFinalResponse(result, model, respID))
+	writeJSON(w, http.StatusOK, responsesFinalResponse(result, model, respID, created))
 }
 
 func (s *serveServer) populateResponsesToolResultNames(ctx context.Context, sessionID string, runtime *serveRuntime, messages []llm.Message) {

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
@@ -188,7 +187,7 @@ func parseRequestedFunctionTool(generic map[string]json.RawMessage) (llm.ToolSpe
 	return spec, true
 }
 
-func responsesFinalResponse(result serveRunResult, model string, respID string) map[string]any {
+func responsesFinalResponse(result serveRunResult, model string, respID string, created int64) map[string]any {
 	output := []map[string]any{}
 	if result.Text.Len() > 0 {
 		output = append(output, map[string]any{
@@ -214,7 +213,7 @@ func responsesFinalResponse(result serveRunResult, model string, respID string) 
 	return map[string]any{
 		"id":      respID,
 		"object":  "response",
-		"created": time.Now().Unix(),
+		"created": created,
 		"model":   model,
 		"output":  output,
 		"usage": map[string]any{

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -895,6 +895,59 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 	}
 }
 
+func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID, previousResponseID, model string, created int64, result serveRunResult) (string, error) {
+	mgr := s.ensureResponseRuns()
+
+	respID := "resp_" + randomSuffix()
+	run := newResponseRun(respID, sessionID, previousResponseID, model, created, nil)
+	if err := mgr.create(run); err != nil {
+		return "", err
+	}
+
+	cleanup := func() {
+		mgr.delete(respID)
+	}
+	if err := run.appendEvent("response.created", map[string]any{
+		"response": map[string]any{
+			"id":      respID,
+			"object":  "response",
+			"created": created,
+			"model":   model,
+			"status":  "in_progress",
+		},
+	}); err != nil {
+		cleanup()
+		return "", err
+	}
+	if result.Text.Len() > 0 {
+		if err := run.appendEvent("response.output_text.delta", map[string]any{
+			"output_index": 0,
+			"delta":        result.Text.String(),
+		}); err != nil {
+			cleanup()
+			return "", err
+		}
+	}
+	if err := run.complete(map[string]any{
+		"response": map[string]any{
+			"id":            respID,
+			"object":        "response",
+			"created":       created,
+			"model":         model,
+			"status":        "completed",
+			"usage":         usagePayload(result.Usage),
+			"session_usage": usagePayload(result.SessionUsage),
+		},
+	}, result.Usage, result.SessionUsage); err != nil {
+		cleanup()
+		return "", err
+	}
+
+	mgr.scheduleCleanup(respID)
+	s.registerResponseID(runtime, respID, sessionID)
+	return respID, nil
+}
+
 func (s *serveServer) handleResponseByID(w http.ResponseWriter, r *http.Request) {
 	mgr := s.ensureResponseRuns()
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4187,6 +4187,94 @@ func TestHandleResponses_ReturnsStableResponseID(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_NonStreamingResponseIDCanBeFetchedAndReplayed(t *testing.T) {
+	srv := newTestServeServer("hello")
+	defer srv.sessionMgr.Close()
+
+	ts := newServeHTTPTestServer(srv)
+	defer ts.Close()
+
+	code, resp := doResponses(t, srv, `{"input":"hi"}`)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+
+	responseID, _ := resp["id"].(string)
+	if responseID == "" {
+		t.Fatal("response missing id")
+	}
+
+	statusResp, err := ts.Client().Get(ts.URL + "/v1/responses/" + responseID)
+	if err != nil {
+		t.Fatalf("get response by id failed: %v", err)
+	}
+	statusBody, _ := io.ReadAll(statusResp.Body)
+	statusResp.Body.Close()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("status code = %d, want 200 (body=%s)", statusResp.StatusCode, string(statusBody))
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(statusBody, &snapshot); err != nil {
+		t.Fatalf("unmarshal response snapshot: %v", err)
+	}
+	if got, _ := snapshot["id"].(string); got != responseID {
+		t.Fatalf("snapshot id = %q, want %q", got, responseID)
+	}
+	if got, _ := snapshot["status"].(string); got != "completed" {
+		t.Fatalf("snapshot status = %q, want completed", got)
+	}
+
+	eventsResp, err := ts.Client().Get(ts.URL + "/v1/responses/" + responseID + "/events")
+	if err != nil {
+		t.Fatalf("get response events failed: %v", err)
+	}
+	defer eventsResp.Body.Close()
+	if eventsResp.StatusCode != http.StatusOK {
+		eventsBody, _ := io.ReadAll(eventsResp.Body)
+		t.Fatalf("events status code = %d, want 200 (body=%s)", eventsResp.StatusCode, string(eventsBody))
+	}
+
+	scanner := bufio.NewScanner(eventsResp.Body)
+	sawCreated := false
+	sawDelta := false
+	sawCompleted := false
+	for {
+		eventName, data, ok := readSSEEvent(t, scanner)
+		if !ok {
+			break
+		}
+		if data == "[DONE]" {
+			break
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			t.Fatalf("unmarshal SSE payload: %v", err)
+		}
+		switch eventName {
+		case "response.created":
+			sawCreated = true
+			response, _ := payload["response"].(map[string]any)
+			if got, _ := response["id"].(string); got != responseID {
+				t.Fatalf("created event id = %q, want %q", got, responseID)
+			}
+		case "response.output_text.delta":
+			sawDelta = fmt.Sprint(payload["delta"]) == "hello"
+		case "response.completed":
+			sawCompleted = true
+		}
+	}
+	if !sawCreated {
+		t.Fatal("response.created event not found")
+	}
+	if !sawDelta {
+		t.Fatal("response.output_text.delta event not found")
+	}
+	if !sawCompleted {
+		t.Fatal("response.completed event not found")
+	}
+}
+
 func TestHandleResponses_IncludesSessionUsage(t *testing.T) {
 	srv := newTestServeServer("hello")
 	defer srv.sessionMgr.Close()


### PR DESCRIPTION
## What

- create and retain a completed response-run entry for non-streaming `/v1/responses` replies
- register the response ID only after the completed run has been stored
- reuse the same `created` timestamp for the returned response body and the stored response-run events
- add a regression test covering `GET /v1/responses/{id}` and `/v1/responses/{id}/events` for a non-streaming response ID

## Why

Non-streaming responses were returning `resp_*` IDs that were only added to the lightweight session mapping. The lookup and replay endpoints read from the response-run manager, so every non-stream response ID immediately 404ed when clients tried to fetch or replay it.
