### PR TITLE
fix: keep claude-bin permission bypass as root

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -409,20 +409,27 @@ func (p *ClaudeBinProvider) Stream(ctx context.Context, req Request) (Stream, er
 }
 
 func (p *ClaudeBinProvider) buildCommandEnv(effort string) []string {
+	runningAsRoot := getEuid() == 0
 	env := os.Environ()
 	filtered := env[:0]
 	for _, e := range env {
-		if p.preferOAuth && strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
+		key := e
+		if idx := strings.IndexByte(e, '='); idx >= 0 {
+			key = e[:idx]
+		}
+		if p.preferOAuth && key == "ANTHROPIC_API_KEY" {
 			continue
 		}
-		if effort != "" && strings.HasPrefix(e, "CLAUDE_CODE_EFFORT_LEVEL=") {
+		if effort != "" && key == "CLAUDE_CODE_EFFORT_LEVEL" {
+			continue
+		}
+		// Claude Code refuses bypassPermissions as root unless it sees an
+		// explicit sandbox marker. term-llm owns tool execution, so force the
+		// inert IS_SANDBOX marker below rather than inheriting a stale value.
+		if runningAsRoot && key == "IS_SANDBOX" {
 			continue
 		}
 		if len(p.extraEnv) > 0 {
-			key := e
-			if idx := strings.IndexByte(e, '='); idx >= 0 {
-				key = e[:idx]
-			}
 			if _, ok := p.extraEnv[key]; ok {
 				continue
 			}
@@ -439,9 +446,26 @@ func (p *ClaudeBinProvider) buildCommandEnv(effort string) []string {
 		if effort != "" && k == "CLAUDE_CODE_EFFORT_LEVEL" {
 			continue
 		}
+		if runningAsRoot && k == "IS_SANDBOX" {
+			continue
+		}
 		filtered = append(filtered, k+"="+v)
 	}
+	if runningAsRoot && !envHasTruthy(filtered, "CLAUDE_CODE_BUBBLEWRAP") {
+		filtered = append(filtered, "IS_SANDBOX=1")
+	}
 	return filtered
+}
+
+func envHasTruthy(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			v := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(e, prefix)))
+			return v != "" && v != "0" && v != "false"
+		}
+	}
+	return false
 }
 
 func (p *ClaudeBinProvider) newClaudeCommandError(cmdErr error, exitCode int, args []string, effort, userPrompt string, toolsExecuted bool, stdoutTail, stderrTail []string) *ClaudeCommandError {
@@ -690,7 +714,7 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		scanErrCh <- scanner.Err()
 	}()
 
-	lastUsage, toolsExecuted, err := p.dispatchClaudeEvents(ctx, lineCh, bridge.toolReqCh, debug, send)
+	lastUsage, toolsExecuted, handledTerminalResult, err := p.dispatchClaudeEvents(ctx, lineCh, bridge.toolReqCh, debug, send)
 	if err != nil {
 		// Kill the process if dispatch failed (e.g., context cancelled)
 		// to avoid orphan processes.
@@ -729,7 +753,8 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		// Any other non-zero exit (crashes, OOMs, auth failures, etc.) must
 		// still surface — don't swallow those just because tools ran.
 		expectedToolExit := toolsExecuted && exitCode == 1
-		if !expectedToolExit {
+		expectedHandledTerminalResult := handledTerminalResult && exitCode == 1
+		if !expectedToolExit && !expectedHandledTerminalResult {
 			claudeErr := p.newClaudeCommandError(cmdErr, exitCode, args, effort, userPrompt, toolsExecuted, stdoutSnapshot, stderrSnapshot)
 			slog.Error("claude command failed",
 				"exit_code", exitCode,
@@ -759,13 +784,14 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 	toolReqCh <-chan claudeToolRequest,
 	debug bool,
 	send eventSender,
-) (*Usage, bool, error) {
+) (*Usage, bool, bool, error) {
 	var (
 		lastUsage             *Usage
 		linesOpen             = true
 		sawTextDelta          bool
 		assistantFallbackText string
 		toolsExecuted         bool
+		handledTerminalResult bool
 	)
 
 	for linesOpen {
@@ -779,8 +805,8 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 					break
 				}
 				hadLine = true
-				if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText); err != nil {
-					return nil, false, err
+				if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText, &handledTerminalResult); err != nil {
+					return nil, false, false, err
 				}
 			default:
 				goto drainDone
@@ -797,17 +823,17 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 				linesOpen = false
 				continue
 			}
-			if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText); err != nil {
-				return nil, false, err
+			if err := p.handleClaudeLine(ctx, line, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText, &handledTerminalResult); err != nil {
+				return nil, false, false, err
 			}
 		case req := <-toolReqCh:
-			if err := p.drainClaudeLinesWithGrace(ctx, lineCh, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText); err != nil {
-				return nil, false, err
+			if err := p.drainClaudeLinesWithGrace(ctx, lineCh, debug, send, &lastUsage, &sawTextDelta, &assistantFallbackText, &handledTerminalResult); err != nil {
+				return nil, false, false, err
 			}
 			toolsExecuted = true
 			p.handleClaudeToolRequest(req, send)
 		case <-ctx.Done():
-			return nil, false, ctx.Err()
+			return nil, false, false, ctx.Err()
 		}
 	}
 
@@ -823,7 +849,7 @@ func (p *ClaudeBinProvider) dispatchClaudeEvents(
 	}
 drained:
 
-	return lastUsage, toolsExecuted, nil
+	return lastUsage, toolsExecuted, handledTerminalResult, nil
 }
 
 func (p *ClaudeBinProvider) handleClaudeLine(
@@ -834,6 +860,7 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 	lastUsage **Usage,
 	sawTextDelta *bool,
 	assistantFallbackText *string,
+	handledTerminalResult *bool,
 ) error {
 	var baseMsg struct {
 		Type string `json:"type"`
@@ -901,8 +928,11 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 	case "result":
 		var resultMsg claudeResultMessage
 		if err := json.Unmarshal([]byte(line), &resultMsg); err == nil {
-			// Check for API errors (rate limits, auth issues, etc.)
-			if resultMsg.IsError && resultMsg.Result != "" {
+			permissionDenied := resultMsg.hasPermissionDenial()
+			// Check for API errors (rate limits, auth issues, etc.). Claude Code
+			// reports permission denials as terminal result errors too; surface
+			// those as model-visible text so the conversation can fail gracefully.
+			if resultMsg.IsError && resultMsg.Result != "" && !permissionDenied {
 				return fmt.Errorf("claude API error: %s", resultMsg.Result)
 			}
 
@@ -912,6 +942,12 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 			}
 			if fallbackText == "" {
 				fallbackText = strings.TrimSpace(resultMsg.Result)
+			}
+			if permissionDenied && fallbackText == "" {
+				fallbackText = "Claude Code denied a tool call before term-llm could execute it."
+			}
+			if permissionDenied && handledTerminalResult != nil {
+				*handledTerminalResult = true
 			}
 			if sawTextDelta != nil && !*sawTextDelta && fallbackText != "" {
 				if err := send.Send(Event{Type: EventTextDelta, Text: fallbackText}); err != nil {
@@ -954,6 +990,7 @@ func (p *ClaudeBinProvider) drainClaudeLinesWithGrace(
 	lastUsage **Usage,
 	sawTextDelta *bool,
 	assistantFallbackText *string,
+	handledTerminalResult *bool,
 ) error {
 	// First, drain any already-buffered lines.
 	for {
@@ -962,7 +999,7 @@ func (p *ClaudeBinProvider) drainClaudeLinesWithGrace(
 			if !ok {
 				return nil
 			}
-			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText); err != nil {
+			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText, handledTerminalResult); err != nil {
 				return err
 			}
 		default:
@@ -980,7 +1017,7 @@ wait:
 			if !ok {
 				return nil
 			}
-			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText); err != nil {
+			if err := p.handleClaudeLine(ctx, line, debug, send, lastUsage, sawTextDelta, assistantFallbackText, handledTerminalResult); err != nil {
 				return err
 			}
 			if !timer.Stop() {
@@ -1002,28 +1039,24 @@ wait:
 // The events channel is passed to the MCP server for routing tool execution events.
 // The MCP server is kept alive across turns - call CleanupMCP() when the conversation ends.
 // Returns the args and the effective reasoning effort (if any).
-func (p *ClaudeBinProvider) claudeSandboxEnabled() bool {
-	if v, ok := p.extraEnv["IS_SANDBOX"]; ok {
-		return strings.TrimSpace(v) == "1"
-	}
-	if v, ok := p.extraEnv["CLAUDE_CODE_BUBBLEWRAP"]; ok {
-		return strings.TrimSpace(v) == "1"
-	}
-	return strings.TrimSpace(os.Getenv("IS_SANDBOX")) == "1" || strings.TrimSpace(os.Getenv("CLAUDE_CODE_BUBBLEWRAP")) == "1"
-}
-
 func (p *ClaudeBinProvider) buildArgs(ctx context.Context, req Request, send eventSender) ([]string, string) {
 	args := []string{
 		"--print",
 		"--output-format", "stream-json",
 		"--include-partial-messages", // Stream text as it arrives
 		"--verbose",
-		"--strict-mcp-config",       // Ignore Claude's configured MCPs
-		"--setting-sources", "user", // Skip project CLAUDE.md files (term-llm provides its own context)
+		"--strict-mcp-config", // Ignore Claude's configured MCPs
+		// Ignore user/project/local settings so Claude Code cannot apply its own
+		// permission rules or hooks. flagSettings (--settings below) and managed
+		// policy settings are still loaded by Claude Code.
+		"--setting-sources", "",
 	}
 	if getEuid() != 0 {
 		args = append(args, "--dangerously-skip-permissions")
-	} else if p.claudeSandboxEnabled() {
+	} else {
+		// Claude Code rejects --dangerously-skip-permissions when running as root.
+		// Use the equivalent permission mode explicitly so claude-bin remains
+		// non-interactive in rootful containers too.
 		args = append(args, "--permission-mode", "bypassPermissions")
 	}
 	if !p.enableHooks {
@@ -1776,15 +1809,25 @@ type claudeStreamlinedTextMessage struct {
 }
 
 type claudeResultMessage struct {
-	Type    string `json:"type"`
-	IsError bool   `json:"is_error"`
-	Result  string `json:"result"`
-	Usage   struct {
+	Type              string            `json:"type"`
+	IsError           bool              `json:"is_error"`
+	Result            string            `json:"result"`
+	PermissionDenials []json.RawMessage `json:"permission_denials"`
+	Usage             struct {
 		InputTokens          int `json:"input_tokens"`
 		OutputTokens         int `json:"output_tokens"`
 		CacheReadInputTokens int `json:"cache_read_input_tokens"`
 	} `json:"usage"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
+}
+
+func (m claudeResultMessage) hasPermissionDenial() bool {
+	if len(m.PermissionDenials) > 0 {
+		return true
+	}
+	text := strings.ToLower(strings.TrimSpace(m.Result))
+	return strings.Contains(text, "permission") &&
+		(strings.Contains(text, "denied") || strings.Contains(text, "requires approval"))
 }
 
 type claudeStreamEvent struct {

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -103,6 +103,40 @@ type ClaudeCommandError struct {
 	StderrTail     string
 }
 
+type UserFacingProviderError struct {
+	Summary string
+	Detail  string
+	Cause   error
+}
+
+func (e *UserFacingProviderError) Error() string {
+	if e == nil {
+		return "provider error"
+	}
+	if e.Detail != "" {
+		return e.Summary + ": " + e.Detail
+	}
+	return e.Summary
+}
+
+func (e *UserFacingProviderError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func (e *UserFacingProviderError) DebugFields() map[string]any {
+	if e == nil || e.Cause == nil {
+		return nil
+	}
+	fieldsErr, ok := e.Cause.(interface{ DebugFields() map[string]any })
+	if !ok {
+		return nil
+	}
+	return fieldsErr.DebugFields()
+}
+
 func (e *ClaudeCommandError) Error() string {
 	if e == nil {
 		return "claude command failed"
@@ -493,6 +527,65 @@ func (p *ClaudeBinProvider) newClaudeCommandError(cmdErr error, exitCode int, ar
 	}
 }
 
+func (p *ClaudeBinProvider) userFacingClaudeCommandError(err *ClaudeCommandError) error {
+	if err == nil {
+		return nil
+	}
+	detail := firstUsefulClaudeDiagnosticLine(err.StderrTail)
+	if detail == "" {
+		detail = firstUsefulClaudeDiagnosticLine(err.StdoutTail)
+	}
+	if detail == "" && err.Err != nil {
+		detail = err.Err.Error()
+	}
+
+	combined := strings.ToLower(strings.TrimSpace(err.StderrTail + "\n" + err.StdoutTail))
+	summary := fmt.Sprintf("Claude Code exited before completing the turn (exit %d)", err.ExitCode)
+	switch {
+	case strings.Contains(combined, "cannot be used with root/sudo privileges"):
+		summary = "Claude Code refused permission bypass while running as root"
+		if detail == "" {
+			detail = "term-llm should set IS_SANDBOX=1 for root claude-bin runs"
+		}
+	case strings.Contains(combined, "not logged in") || strings.Contains(combined, "please run /login"):
+		summary = "Claude Code is not logged in"
+	case strings.Contains(combined, "bypasspermissions") &&
+		(strings.Contains(combined, "policy") || strings.Contains(combined, "managed") || strings.Contains(combined, "disabled")):
+		summary = "Claude Code managed policy blocked permission bypass"
+	case strings.Contains(combined, "permission") &&
+		(strings.Contains(combined, "denied") || strings.Contains(combined, "requires approval") || strings.Contains(combined, "refused")):
+		summary = "Claude Code denied a tool call before term-llm could execute it"
+	}
+
+	return &UserFacingProviderError{
+		Summary: summary,
+		Detail:  detail,
+		Cause:   err,
+	}
+}
+
+func firstUsefulClaudeDiagnosticLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "{") {
+			continue
+		}
+		return truncateOneLine(line, 240)
+	}
+	return ""
+}
+
+func truncateOneLine(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes]) + "…"
+}
+
 func (p *ClaudeBinProvider) commandEnvDebugFields(effort string) (map[string]string, []string) {
 	env := make(map[string]string)
 	removed := make([]string, 0, 2)
@@ -766,7 +859,7 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 				"stderr_tail", claudeErr.StderrTail,
 				"stdout_tail", claudeErr.StdoutTail,
 			)
-			return claudeErr
+			return p.userFacingClaudeCommandError(claudeErr)
 		}
 	}
 
@@ -937,7 +1030,9 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 			}
 
 			fallbackText := ""
-			if assistantFallbackText != nil {
+			if permissionDenied {
+				fallbackText = resultMsg.permissionDenialText()
+			} else if assistantFallbackText != nil {
 				fallbackText = strings.TrimSpace(*assistantFallbackText)
 			}
 			if fallbackText == "" {
@@ -1828,6 +1923,48 @@ func (m claudeResultMessage) hasPermissionDenial() bool {
 	text := strings.ToLower(strings.TrimSpace(m.Result))
 	return strings.Contains(text, "permission") &&
 		(strings.Contains(text, "denied") || strings.Contains(text, "requires approval"))
+}
+
+func (m claudeResultMessage) permissionDenialText() string {
+	tools := m.permissionDenialTools()
+	if len(tools) == 0 {
+		result := strings.TrimSpace(m.Result)
+		if result != "" {
+			return result
+		}
+		return "Claude Code denied a tool call before term-llm could execute it."
+	}
+
+	quoted := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		quoted = append(quoted, "`"+tool+"`")
+	}
+	return fmt.Sprintf("Claude Code denied %s before term-llm could execute it.\nterm-llm did not execute the tool call.", strings.Join(quoted, ", "))
+}
+
+func (m claudeResultMessage) permissionDenialTools() []string {
+	seen := make(map[string]struct{}, len(m.PermissionDenials))
+	var tools []string
+	for _, raw := range m.PermissionDenials {
+		var denial map[string]any
+		if err := json.Unmarshal(raw, &denial); err != nil {
+			continue
+		}
+		for _, key := range []string{"tool_name", "toolName", "name", "tool"} {
+			tool, ok := denial[key].(string)
+			tool = strings.TrimSpace(tool)
+			if !ok || tool == "" {
+				continue
+			}
+			if _, exists := seen[tool]; exists {
+				continue
+			}
+			seen[tool] = struct{}{}
+			tools = append(tools, tool)
+			break
+		}
+	}
+	return tools
 }
 
 type claudeStreamEvent struct {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -198,7 +198,7 @@ func TestDispatchClaudeEvents_PrioritizesTextOverToolRequest(t *testing.T) {
 	toolReqs <- req
 	close(lines)
 
-	_, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	_, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestDispatchClaudeEvents_PrioritizesSlightlyDelayedTextOverToolRequest(t *t
 		close(lines)
 	}()
 
-	_, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	_, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestDispatchClaudeEvents_FallsBackToAssistantTextWhenNoDeltas(t *testing.T)
 	lines <- `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":0}}`
 	close(lines)
 
-	_, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	_, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestDispatchClaudeEvents_FallsBackToResultTextWhenNoAssistantOrDeltas(t *te
 	lines <- `{"type":"result","subtype":"success","is_error":false,"result":"result fallback text","usage":{"input_tokens":1,"output_tokens":3,"cache_read_input_tokens":0}}`
 	close(lines)
 
-	_, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	_, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -315,6 +315,54 @@ func TestDispatchClaudeEvents_FallsBackToResultTextWhenNoAssistantOrDeltas(t *te
 	}
 }
 
+func TestDispatchClaudeEvents_SurfacesPermissionDenialResult(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"result","subtype":"success","is_error":true,"result":"Permission denied to use mcp__term_llm__shell","permission_denials":[{"tool_name":"mcp__term_llm__shell"}],"usage":{"input_tokens":1,"output_tokens":3,"cache_read_input_tokens":0}}`
+	close(lines)
+
+	_, _, handled, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected permission denial result to be marked handled")
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Type != EventTextDelta {
+			t.Fatalf("expected EventTextDelta, got %+v", ev)
+		}
+		if ev.Text != "Permission denied to use mcp__term_llm__shell" {
+			t.Fatalf("unexpected permission denial text: %q", ev.Text)
+		}
+	default:
+		t.Fatal("expected permission denial result text event")
+	}
+}
+
+func TestDispatchClaudeEvents_LeavesAuthResultAsError(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	events := make(chan Event, 8)
+	lines := make(chan string, 2)
+	toolReqs := make(chan claudeToolRequest, 1)
+
+	lines <- `{"type":"result","subtype":"success","is_error":true,"result":"Not logged in · Please run /login","permission_denials":[],"usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0}}`
+	close(lines)
+
+	_, _, handled, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	if err == nil {
+		t.Fatal("expected auth result to remain an error")
+	}
+	if handled {
+		t.Fatal("did not expect auth error to be marked handled")
+	}
+}
+
 func TestDispatchClaudeEvents_EmitsStreamlinedText(t *testing.T) {
 	provider := NewClaudeBinProvider("sonnet", nil)
 	events := make(chan Event, 8)
@@ -325,7 +373,7 @@ func TestDispatchClaudeEvents_EmitsStreamlinedText(t *testing.T) {
 	lines <- `{"type":"result","subtype":"success","is_error":false,"result":"ignored final result","usage":{"input_tokens":1,"output_tokens":3,"cache_read_input_tokens":0}}`
 	close(lines)
 
-	_, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	_, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -354,7 +402,7 @@ func TestDispatchClaudeEvents_DoesNotDuplicateAssistantFallbackWhenDeltasPresent
 	lines <- `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":0}}`
 	close(lines)
 
-	_, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	_, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -386,7 +434,7 @@ func TestDispatchClaudeEvents_SeparatesCachedInputTokensInUsage(t *testing.T) {
 	lines <- `{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":11,"output_tokens":7,"cache_read_input_tokens":5}}`
 	close(lines)
 
-	usage, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
+	usage, _, _, err := provider.dispatchClaudeEvents(context.Background(), lines, toolReqs, false, eventSender{ctx: context.Background(), ch: events})
 	if err != nil {
 		t.Fatalf("dispatch failed: %v", err)
 	}
@@ -441,6 +489,7 @@ func TestHandleClaudeLine_ContextCancelledDoesNotBlock(t *testing.T) {
 		&usage,
 		&sawTextDelta,
 		&assistantFallbackText,
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected cancellation error")
@@ -590,6 +639,15 @@ func TestClaudeBinProvider_BuildArgsDisablesHooksByDefault(t *testing.T) {
 	if !strings.Contains(joined, `{"disableAllHooks":true}`) {
 		t.Fatal("expected claude-bin args to disable hooks by default")
 	}
+	for i, arg := range args {
+		if arg == "--setting-sources" {
+			if i+1 >= len(args) || args[i+1] != "" {
+				t.Fatalf("--setting-sources = %q, want empty", args[i+1])
+			}
+			return
+		}
+	}
+	t.Fatal("expected claude-bin args to include --setting-sources")
 }
 
 func TestClaudeBinProvider_BuildArgsDangerousPermissionsRespectsEuid(t *testing.T) {
@@ -609,20 +667,7 @@ func TestClaudeBinProvider_BuildArgsDangerousPermissionsRespectsEuid(t *testing.
 		}
 	})
 
-	t.Run("root sandbox uses bypass permission mode", func(t *testing.T) {
-		getEuid = func() int { return 0 }
-		p := NewClaudeBinProvider("sonnet", map[string]string{"IS_SANDBOX": "1"})
-		args, _ := p.buildArgs(context.Background(), Request{}, eventSender{})
-		joined := strings.Join(args, "\n")
-		if strings.Contains(joined, "--dangerously-skip-permissions") {
-			t.Fatal("expected claude-bin args to omit --dangerously-skip-permissions when running as root")
-		}
-		if !strings.Contains(joined, "--permission-mode\nbypassPermissions") {
-			t.Fatal("expected root sandbox runs to request bypassPermissions mode")
-		}
-	})
-
-	t.Run("root outside sandbox omits bypass flags", func(t *testing.T) {
+	t.Run("root uses bypass permission mode", func(t *testing.T) {
 		getEuid = func() int { return 0 }
 		p := NewClaudeBinProvider("sonnet", nil)
 		args, _ := p.buildArgs(context.Background(), Request{}, eventSender{})
@@ -630,8 +675,8 @@ func TestClaudeBinProvider_BuildArgsDangerousPermissionsRespectsEuid(t *testing.
 		if strings.Contains(joined, "--dangerously-skip-permissions") {
 			t.Fatal("expected claude-bin args to omit --dangerously-skip-permissions when running as root")
 		}
-		if strings.Contains(joined, "--permission-mode\nbypassPermissions") {
-			t.Fatal("did not expect bypassPermissions mode outside sandbox")
+		if !strings.Contains(joined, "--permission-mode\nbypassPermissions") {
+			t.Fatal("expected root runs to request bypassPermissions mode")
 		}
 	})
 }
@@ -761,6 +806,10 @@ func TestClaudeBinProvider_ResetConversationClearsResumeState(t *testing.T) {
 }
 
 func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
+	origGetEuid := getEuid
+	defer func() { getEuid = origGetEuid }()
+	getEuid = func() int { return 1000 }
+
 	t.Setenv("ANTHROPIC_API_KEY", "should-be-cleared")
 	t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "medium")
 	t.Setenv("PATH", os.Getenv("PATH"))
@@ -792,6 +841,47 @@ func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
 	}
 	if !strings.Contains(joined, "CLAUDE_CODE_EFFORT_LEVEL=max") {
 		t.Fatal("expected model-derived effort level to be present")
+	}
+}
+
+func TestClaudeBinProvider_BuildCommandEnvRootForcesSandboxMarker(t *testing.T) {
+	origGetEuid := getEuid
+	defer func() { getEuid = origGetEuid }()
+	getEuid = func() int { return 0 }
+
+	t.Setenv("IS_SANDBOX", "0")
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	p := NewClaudeBinProvider("sonnet", map[string]string{"IS_SANDBOX": "0"})
+	env := p.buildCommandEnv("")
+	joined := strings.Join(env, "\n")
+
+	if strings.Contains(joined, "IS_SANDBOX=0") {
+		t.Fatal("expected stale IS_SANDBOX=0 values to be removed for root bypass")
+	}
+	if !strings.Contains(joined, "IS_SANDBOX=1") {
+		t.Fatal("expected IS_SANDBOX=1 to be forced for root bypass")
+	}
+}
+
+func TestClaudeBinProvider_BuildCommandEnvRootPreservesBubblewrapMarker(t *testing.T) {
+	origGetEuid := getEuid
+	defer func() { getEuid = origGetEuid }()
+	getEuid = func() int { return 0 }
+
+	t.Setenv("IS_SANDBOX", "0")
+	t.Setenv("CLAUDE_CODE_BUBBLEWRAP", "1")
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	p := NewClaudeBinProvider("sonnet", nil)
+	env := p.buildCommandEnv("")
+	joined := strings.Join(env, "\n")
+
+	if strings.Contains(joined, "IS_SANDBOX=1") {
+		t.Fatal("did not expect forced IS_SANDBOX=1 when CLAUDE_CODE_BUBBLEWRAP is already set")
+	}
+	if !strings.Contains(joined, "CLAUDE_CODE_BUBBLEWRAP=1") {
+		t.Fatal("expected inherited CLAUDE_CODE_BUBBLEWRAP=1 to be preserved")
 	}
 }
 

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -337,7 +338,7 @@ func TestDispatchClaudeEvents_SurfacesPermissionDenialResult(t *testing.T) {
 		if ev.Type != EventTextDelta {
 			t.Fatalf("expected EventTextDelta, got %+v", ev)
 		}
-		if ev.Text != "Permission denied to use mcp__term_llm__shell" {
+		if ev.Text != "Claude Code denied `mcp__term_llm__shell` before term-llm could execute it.\nterm-llm did not execute the tool call." {
 			t.Fatalf("unexpected permission denial text: %q", ev.Text)
 		}
 	default:
@@ -882,6 +883,40 @@ func TestClaudeBinProvider_BuildCommandEnvRootPreservesBubblewrapMarker(t *testi
 	}
 	if !strings.Contains(joined, "CLAUDE_CODE_BUBBLEWRAP=1") {
 		t.Fatal("expected inherited CLAUDE_CODE_BUBBLEWRAP=1 to be preserved")
+	}
+}
+
+func TestClaudeBinProvider_UserFacingCommandErrorKeepsDiagnosticsOutOfErrorString(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	claudeErr := p.newClaudeCommandError(
+		fmt.Errorf("exit status 1"),
+		1,
+		[]string{"--print"},
+		"",
+		"User: hello",
+		false,
+		[]string{`{"type":"result","is_error":true}`},
+		[]string{"", "permission denied by managed policy", "extra stderr detail"},
+	)
+
+	err := p.userFacingClaudeCommandError(claudeErr)
+	msg := err.Error()
+	if !strings.Contains(msg, "Claude Code denied a tool call before term-llm could execute it") {
+		t.Fatalf("unexpected user-facing error: %q", msg)
+	}
+	if strings.Contains(msg, "extra stderr detail") || strings.Contains(msg, `{"type":"result"}`) {
+		t.Fatalf("user-facing error leaked diagnostic tail: %q", msg)
+	}
+	fieldsErr, ok := err.(interface{ DebugFields() map[string]any })
+	if !ok {
+		t.Fatal("expected user-facing error to expose debug fields")
+	}
+	fields := fieldsErr.DebugFields()
+	if got := fields["stderr_tail"].(string); !strings.Contains(got, "extra stderr detail") {
+		t.Fatalf("debug fields lost stderr tail: %q", got)
+	}
+	if !errors.Is(err, claudeErr) {
+		t.Fatal("expected user-facing error to unwrap to ClaudeCommandError")
 	}
 }
 


### PR DESCRIPTION
## What

Fix `claude-bin` permission bypass when term-llm is running as root, and keep Claude Code out of the permission business for this provider.

- Non-root still uses `--dangerously-skip-permissions`
- Root uses `--permission-mode bypassPermissions`
- Root subprocess env now forces `IS_SANDBOX=1` unless `CLAUDE_CODE_BUBBLEWRAP` is already truthy, because Claude Code rejects bypass mode as UID 0 without one of those markers
- `--setting-sources` is now empty, so Claude Code does not load user/project/local settings that can inject permission rules or hooks
- `--settings {"disableAllHooks":true}` remains as flag settings; Claude Code always still loads flag settings and managed policy settings
- If Claude Code still returns a terminal permission-denial result, surface that result text instead of turning it into an opaque provider failure

## Why

I extracted the current native Claude Code package (`@anthropic-ai/claude-code-linux-x64` 2.1.119) and checked the bundled source behavior.

Claude Code has this root guard:

```js
if (permissionMode === "bypassPermissions" || dangerouslySkipPermissions) {
  if (process.getuid() === 0 && process.env.IS_SANDBOX !== "1" && !truthy(process.env.CLAUDE_CODE_BUBBLEWRAP)) {
    console.error("--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons")
    process.exit(1)
  }
}
```

It also evaluates deny/ask rules and tool `checkPermissions` before allowing through `bypassPermissions`, so inherited user/project/local settings can still interfere. For `claude-bin`, term-llm provides the tools and approval layer; Claude Code should be a model transport plus MCP client, not a second permission oracle.

MCP tools themselves return `behavior: "passthrough"` from Claude Code's permission hook, so with bypass mode active they are allowed. The remaining edge case is managed policy or some future Claude-side denial returning a terminal result; that is now converted into visible text instead of a hard command error.

## Verify

```sh
go build ./...
go test ./internal/llm
go test ./internal/tui/chat
```

`go test ./...` passed except for one transient `TestRunHandoverScript_CancelKillsProcessGroup` timeout in `internal/tui/chat`; rerunning that package passed.
