### PR TITLE
speed up memory store opens

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -243,7 +243,15 @@ func NewStore(cfg Config) (*Store, error) {
 	return &Store{db: db}, nil
 }
 
+const memorySchemaVersion = 1
+
 func initSchema(db *sql.DB) error {
+	if current, err := isSchemaCurrent(db); err != nil {
+		return err
+	} else if current {
+		return nil
+	}
+
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("initialize memory schema: %w", err)
 	}
@@ -264,7 +272,19 @@ func initSchema(db *sql.DB) error {
 		return fmt.Errorf("initialize memory fts: %w", err)
 	}
 
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", memorySchemaVersion)); err != nil {
+		return fmt.Errorf("set memory schema version: %w", err)
+	}
+
 	return nil
+}
+
+func isSchemaCurrent(db *sql.DB) (bool, error) {
+	var version int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		return false, fmt.Errorf("get memory schema version: %w", err)
+	}
+	return version >= memorySchemaVersion, nil
 }
 
 func ensureFTSInitialized(db *sql.DB) error {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -521,6 +521,38 @@ func TestStoreMiningState(t *testing.T) {
 	}
 }
 
+func TestStoreSchemaVersionRecorded(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	store, err := NewStore(Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	var version int
+	if err := store.db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		store.Close()
+		t.Fatalf("PRAGMA user_version: %v", err)
+	}
+	if version != memorySchemaVersion {
+		store.Close()
+		t.Fatalf("user_version = %d, want %d", version, memorySchemaVersion)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	store, err = NewStore(Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("reopen NewStore() error = %v", err)
+	}
+	defer store.Close()
+	if err := store.db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatalf("PRAGMA user_version after reopen: %v", err)
+	}
+	if version != memorySchemaVersion {
+		t.Fatalf("user_version after reopen = %d, want %d", version, memorySchemaVersion)
+	}
+}
+
 func TestStoreMetaGetSet(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
@@ -1004,6 +1036,29 @@ func newTestStore(t *testing.T) *Store {
 		t.Fatalf("NewStore() error = %v", err)
 	}
 	return store
+}
+
+func BenchmarkNewStoreExistingDB(b *testing.B) {
+	dbPath := filepath.Join(b.TempDir(), "memory.db")
+	store, err := NewStore(Config{Path: dbPath})
+	if err != nil {
+		b.Fatalf("seed NewStore() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		b.Fatalf("seed Close() error = %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store, err := NewStore(Config{Path: dbPath})
+		if err != nil {
+			b.Fatalf("NewStore() error = %v", err)
+		}
+		if err := store.Close(); err != nil {
+			b.Fatalf("Close() error = %v", err)
+		}
+	}
 }
 
 // ── Insight tests ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Speed up `internal/memory.NewStore` for existing `memory.db` files by recording the memory schema state in SQLite `PRAGMA user_version` and taking a fast path when it is already current.

The first open of an existing database still runs the full idempotent schema/FTS initialization and then stores the version. Later opens skip the repeated multi-statement schema DDL and migration probe.

## Why

Memory commands, completions, mining/status flows, and agent insight injection all open the memory store. Before this change, each open re-ran the full schema block and duplicate-column migration check even when the database was already initialized.

## Evidence

Added `BenchmarkNewStoreExistingDB`:

- Before: ~356 µs/op, ~5.45 KB/op, 113 allocs/op
- After: ~260 µs/op, ~4.87 KB/op, 84 allocs/op

Representative benchmark runs after change:

```text
BenchmarkNewStoreExistingDB-32  4545  264146 ns/op  4914 B/op  84 allocs/op
BenchmarkNewStoreExistingDB-32  4532  262852 ns/op  4871 B/op  84 allocs/op
BenchmarkNewStoreExistingDB-32  4479  259747 ns/op  4866 B/op  84 allocs/op
BenchmarkNewStoreExistingDB-32  4581  262328 ns/op  4868 B/op  84 allocs/op
BenchmarkNewStoreExistingDB-32  4737  252823 ns/op  4866 B/op  84 allocs/op
```

## Verification

- `go test ./internal/memory -run 'TestStoreSchemaVersionRecorded|TestStoreFragmentCRUDAndSearch|TestInsightListAndSearch'`
- `go test ./internal/memory`
- `go test ./internal/memory -run '^$' -bench BenchmarkNewStoreExistingDB -benchmem -count=5`
- `go build ./...`
- `go test ./...`
- `git diff --check`
