### PR TITLE
perf: return promptly on cancelled parallel tools

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1514,6 +1514,10 @@ func buildAssistantMessageWithReasoningMetadata(text string, toolCalls []ToolCal
 // may arrive in non-deterministic order. Consumers should use ToolCallID to correlate
 // start/end events rather than relying on ordering.
 func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, parallel bool, send eventSender, debug bool, debugRaw bool) ([]Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Fast path: single call, no concurrency overhead
 	if len(calls) == 1 {
 		return e.executeSingleToolCallSafe(ctx, calls[0], send, debug, debugRaw)
@@ -1522,6 +1526,9 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 	if !parallel {
 		results := make([]Message, 0, len(calls))
 		for _, call := range calls {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			msgs, err := e.executeSingleToolCallSafe(ctx, call, send, debug, debugRaw)
 			if err != nil {
 				return nil, err
@@ -1541,13 +1548,13 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		message Message
 	}
 
-	var wg sync.WaitGroup
 	resultChan := make(chan toolResult, len(calls))
 
 	for i, call := range calls {
-		wg.Add(1)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		go func(idx int, c ToolCall) {
-			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					errMsg := fmt.Sprintf("Error: tool panicked: %v", r)
@@ -1564,16 +1571,18 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		}(i, call)
 	}
 
-	// Close channel when all goroutines complete
-	go func() {
-		wg.Wait()
-		close(resultChan)
-	}()
-
-	// Collect results and maintain original order
+	// Collect results and maintain original order. If the caller cancels while
+	// non-cooperative tools are still running, return promptly instead of waiting
+	// for every goroutine to finish. The buffered channel is sized for one result
+	// per tool, so late tool completions cannot block after cancellation.
 	results := make([]Message, len(calls))
-	for r := range resultChan {
-		results[r.index] = r.message
+	for remaining := len(calls); remaining > 0; remaining-- {
+		select {
+		case r := <-resultChan:
+			results[r.index] = r.message
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	return results, nil

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1050,6 +1050,36 @@ func TestEngineParallelToolExecution(t *testing.T) {
 	t.Logf("Parallel execution: peak concurrent=%d, elapsed=%v", tool.concurrentAt, elapsed)
 }
 
+func TestExecuteToolCallsParallelReturnsOnContextCancel(t *testing.T) {
+	tool := &delayingTool{delay: 300 * time.Millisecond}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	engine := NewEngine(&fakeProvider{}, registry)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelTimer := time.AfterFunc(25*time.Millisecond, cancel)
+	defer cancelTimer.Stop()
+
+	calls := []ToolCall{
+		{ID: "call-1", Name: "delay_tool", Arguments: json.RawMessage(`{}`)},
+		{ID: "call-2", Name: "delay_tool", Arguments: json.RawMessage(`{}`)},
+		{ID: "call-3", Name: "delay_tool", Arguments: json.RawMessage(`{}`)},
+	}
+
+	start := time.Now()
+	_, err := engine.executeToolCalls(ctx, calls, true, eventSender{}, false, false)
+	elapsed := time.Since(start)
+	t.Logf("parallel tool execution returned after cancellation in %v", elapsed)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("executeToolCalls error = %v, want context.Canceled", err)
+	}
+	if elapsed >= 200*time.Millisecond {
+		t.Fatalf("executeToolCalls returned after %v; want prompt return on cancellation", elapsed)
+	}
+}
+
 // namedTool is a simple tool with a configurable name for testing
 type namedTool struct {
 	name string


### PR DESCRIPTION
## What

Make the parallel tool execution path observe context cancellation while waiting for tool results. When a caller cancels during parallel tool execution, the engine now returns promptly instead of waiting for every non-cooperative tool goroutine to finish.

The change also removes the extra waiter goroutine/WaitGroup used only to close the result channel; the buffered result channel is sized to hold one completion per tool, so late completions cannot block after cancellation.

## Why

In real terminal usage, cancelling an in-flight agent should release the UI/session quickly. Previously, a parallel batch containing tools that ignored context cancellation kept `executeToolCalls` blocked until the slowest tool returned.

## Evidence

Baseline probe on `upstream/main`: 3 parallel blocking tools sleeping 200ms, cancellation after 20ms, returned in 200.735ms / 200.495ms / 200.641ms.

After this change, the committed regression test with 3 parallel blocking tools sleeping 300ms, cancellation after 25ms, returns in 25.137ms / 25.309ms / 25.442ms.

Verification run:

- `go test ./internal/llm -run TestExecuteToolCallsParallelReturnsOnContextCancel -count=3 -v`
- `go test ./internal/llm`
- `go build ./...`
- `go test ./...`
