### PR TITLE
fix: return promptly on parallel tool cancellation

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1512,8 +1512,13 @@ func buildAssistantMessageWithReasoningMetadata(text string, toolCalls []ToolCal
 // Note: When executing in parallel, EventToolExecStart/EventToolExecEnd events
 // are emitted from concurrent goroutines. While the channel is thread-safe, events
 // may arrive in non-deterministic order. Consumers should use ToolCallID to correlate
-// start/end events rather than relying on ordering.
+// start/end events rather than relying on ordering. If ctx is canceled during
+// parallel execution, it returns promptly without waiting for context-ignoring tools.
 func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, parallel bool, send eventSender, debug bool, debugRaw bool) ([]Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Fast path: single call, no concurrency overhead
 	if len(calls) == 1 {
 		return e.executeSingleToolCallSafe(ctx, calls[0], send, debug, debugRaw)
@@ -1522,6 +1527,9 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 	if !parallel {
 		results := make([]Message, 0, len(calls))
 		for _, call := range calls {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			msgs, err := e.executeSingleToolCallSafe(ctx, call, send, debug, debugRaw)
 			if err != nil {
 				return nil, err
@@ -1541,13 +1549,10 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		message Message
 	}
 
-	var wg sync.WaitGroup
 	resultChan := make(chan toolResult, len(calls))
 
 	for i, call := range calls {
-		wg.Add(1)
 		go func(idx int, c ToolCall) {
-			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					errMsg := fmt.Sprintf("Error: tool panicked: %v", r)
@@ -1564,16 +1569,17 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		}(i, call)
 	}
 
-	// Close channel when all goroutines complete
-	go func() {
-		wg.Wait()
-		close(resultChan)
-	}()
-
-	// Collect results and maintain original order
+	// Collect results and maintain original order. The result channel is buffered
+	// to len(calls), so if the caller cancels we can return immediately without
+	// stranding tool goroutines on their final result send.
 	results := make([]Message, len(calls))
-	for r := range resultChan {
-		results[r.index] = r.message
+	for remaining := len(calls); remaining > 0; remaining-- {
+		select {
+		case r := <-resultChan:
+			results[r.index] = r.message
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	return results, nil

--- a/internal/llm/engine_cancel_test.go
+++ b/internal/llm/engine_cancel_test.go
@@ -1,0 +1,108 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+type cancelIgnoringTool struct {
+	name    string
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (t *cancelIgnoringTool) Spec() ToolSpec {
+	return ToolSpec{Name: t.name}
+}
+
+func (t *cancelIgnoringTool) Execute(context.Context, json.RawMessage) (ToolOutput, error) {
+	if t.started != nil {
+		t.started <- struct{}{}
+	}
+	<-t.release
+	return TextOutput("done"), nil
+}
+
+func (t *cancelIgnoringTool) Preview(json.RawMessage) string {
+	return ""
+}
+
+func TestExecuteToolCallsParallelReturnsOnContextCancel(t *testing.T) {
+	registry := NewToolRegistry()
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	var closeRelease sync.Once
+	defer closeRelease.Do(func() { close(release) })
+
+	registry.Register(&cancelIgnoringTool{name: "blocking_tool", started: started, release: release})
+	engine := NewEngine(NewMockProvider("test"), registry)
+	calls := []ToolCall{
+		{ID: "call-1", Name: "blocking_tool", Arguments: json.RawMessage(`{}`)},
+		{ID: "call-2", Name: "blocking_tool", Arguments: json.RawMessage(`{}`)},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := engine.executeToolCalls(ctx, calls, true, eventSender{}, false, false)
+		done <- err
+	}()
+
+	for i := 0; i < len(calls); i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			cancel()
+			closeRelease.Do(func() { close(release) })
+			t.Fatal("timed out waiting for parallel tool execution to start")
+		}
+	}
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("executeToolCalls() error = %v, want context.Canceled", err)
+		}
+		if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+			t.Fatalf("executeToolCalls() returned after %s, want prompt cancellation", elapsed)
+		}
+	case <-time.After(200 * time.Millisecond):
+		closeRelease.Do(func() { close(release) })
+		<-done
+		t.Fatal("executeToolCalls() waited for context-ignoring parallel tools after cancellation")
+	}
+}
+
+func BenchmarkExecuteToolCallsParallelPreCanceledContext(b *testing.B) {
+	registry := NewToolRegistry()
+	engine := NewEngine(NewMockProvider("test"), registry)
+	calls := []ToolCall{
+		{ID: "call-1", Name: "blocking_tool", Arguments: json.RawMessage(`{}`)},
+		{ID: "call-2", Name: "blocking_tool", Arguments: json.RawMessage(`{}`)},
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		release := make(chan struct{})
+		registry.Register(&cancelIgnoringTool{name: "blocking_tool", release: release})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var closeRelease sync.Once
+		timer := time.AfterFunc(2*time.Millisecond, func() {
+			closeRelease.Do(func() { close(release) })
+		})
+		_, _ = engine.executeToolCalls(ctx, calls, true, eventSender{}, false, false)
+		if timer.Stop() {
+			closeRelease.Do(func() { close(release) })
+		}
+	}
+}


### PR DESCRIPTION
## What

Make parallel tool execution return promptly when its context is canceled instead of waiting for every tool goroutine to finish.

The result channel is already sized to the number of tool calls, so workers can publish their final result after the caller has returned without blocking. This lets cancellation/stream close stop waiting on context-ignoring tools, and also removes the extra goroutine that only waited on a WaitGroup to close the result channel.

## Why

Terminal responsiveness on cancel matters most when tools are slow or stuck. Previously the parallel path waited for all worker goroutines before returning, so a cancellation could still block behind any non-cooperative tool. The new collector selects on `ctx.Done()` while preserving ordered results when all tools finish normally.

## Evidence

- Added `TestExecuteToolCallsParallelReturnsOnContextCancel`, which starts two context-ignoring tools and verifies `executeToolCalls` returns `context.Canceled` promptly after cancellation.
- Benchmark before: `BenchmarkExecuteToolCallsParallelPreCanceledContext` ~2.14 ms/op, ~4.1 KB/op, 48 allocs/op.
- Benchmark after: `BenchmarkExecuteToolCallsParallelPreCanceledContext` ~356 ns/op, 392 B/op, 7 allocs/op.

## Verification

- `gofmt -w internal/llm/engine.go internal/llm/engine_cancel_test.go`
- `go test ./internal/llm -run TestExecuteToolCallsParallelReturnsOnContextCancel -count=1`
- `go test ./internal/llm`
- `go build ./...`
- `go test ./...`
