### PR TITLE
perf: limit memory fragment path listing

### DIFF
--- a/cmd/memory_mine_budget.go
+++ b/cmd/memory_mine_budget.go
@@ -430,19 +430,9 @@ func (t *memoryListFragmentsTool) Execute(ctx context.Context, args json.RawMess
 		limit = memoryMineFragmentListLimit
 	}
 
-	fragments, err := t.store.ListFragments(ctx, memorydb.ListOptions{Agent: t.agent})
+	paths, err := t.store.ListFragmentPaths(ctx, t.agent, prefix, limit)
 	if err != nil {
 		return llm.ToolOutput{}, err
-	}
-	paths := make([]string, 0, limit)
-	for _, frag := range fragments {
-		if prefix != "" && !strings.HasPrefix(frag.Path, prefix) {
-			continue
-		}
-		paths = append(paths, frag.Path)
-		if len(paths) >= limit {
-			break
-		}
 	}
 	response := map[string]any{
 		"agent":  t.agent,

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS memory_fragments (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_fragments_agent_path ON memory_fragments(agent, path);
+CREATE INDEX IF NOT EXISTS idx_fragments_agent_created_at ON memory_fragments(agent, created_at DESC);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
     id UNINDEXED,
@@ -731,6 +732,59 @@ func (s *Store) ListFragments(ctx context.Context, opts ListOptions) ([]Fragment
 		return nil, err
 	}
 	return out, nil
+}
+
+// ListFragmentPaths returns only fragment paths for lightweight listings.
+// Results preserve ListFragments' newest-first ordering, but avoid reading large
+// content bodies when callers only need path names (for example, mining tools).
+func (s *Store) ListFragmentPaths(ctx context.Context, agent, prefix string, limit int) ([]string, error) {
+	agent = strings.TrimSpace(agent)
+	prefix = strings.TrimSpace(prefix)
+
+	query := `
+		SELECT path
+		FROM memory_fragments
+		WHERE 1=1`
+	args := []any{}
+	if agent != "" {
+		query += ` AND agent = ?`
+		args = append(args, agent)
+	}
+	if prefix != "" {
+		query += ` AND path >= ?`
+		args = append(args, prefix)
+		if end := sqlitePrefixRangeEnd(prefix); end != "" {
+			query += ` AND path < ?`
+			args = append(args, end)
+		}
+	}
+	query += ` ORDER BY created_at DESC`
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list fragment paths: %w", err)
+	}
+	defer rows.Close()
+
+	paths := []string{}
+	if limit > 0 {
+		paths = make([]string, 0, limit)
+	}
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, fmt.Errorf("scan fragment path: %w", err)
+		}
+		paths = append(paths, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return paths, nil
 }
 
 // ListAgents returns distinct agent names that have stored fragments.
@@ -1856,6 +1910,23 @@ func (s *Store) SearchImages(ctx context.Context, query, agent string, limit int
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// sqlitePrefixRangeEnd returns the exclusive upper bound for a bytewise SQLite
+// range scan over strings with the provided prefix. Empty means there is no
+// representable upper bound.
+func sqlitePrefixRangeEnd(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	b := []byte(prefix)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] != 0xff {
+			b[i]++
+			return string(b[:i+1])
+		}
+	}
+	return ""
 }
 
 // sqliteLikeEscape escapes SQLite LIKE special characters (%, _, \) in a literal string.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"path/filepath"
 	"strings"
@@ -185,6 +186,48 @@ func TestFragmentSourcesCRUD(t *testing.T) {
 	}
 	if len(sources) != 0 {
 		t.Fatalf("GetFragmentSources(after rowid delete) len = %d, want 0", len(sources))
+	}
+}
+
+func TestStoreListFragmentPaths(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	fragments := []Fragment{
+		{Agent: "jarvis", Path: "projects/term_llm/old.md", Content: "old", CreatedAt: now.Add(1 * time.Second)},
+		{Agent: "jarvis", Path: "projects/term_llm/new.md", Content: "new", CreatedAt: now.Add(2 * time.Second)},
+		{Agent: "jarvis", Path: "projects/termXllm/nope.md", Content: "underscore wildcard must not match", CreatedAt: now.Add(3 * time.Second)},
+		{Agent: "jarvis", Path: "notes/elsewhere.md", Content: "elsewhere", CreatedAt: now.Add(4 * time.Second)},
+		{Agent: "other", Path: "projects/term_llm/other.md", Content: "other agent", CreatedAt: now.Add(5 * time.Second)},
+	}
+	for i := range fragments {
+		if err := store.CreateFragment(ctx, &fragments[i]); err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", fragments[i].Path, err)
+		}
+	}
+
+	paths, err := store.ListFragmentPaths(ctx, "jarvis", "projects/term_llm/", 10)
+	if err != nil {
+		t.Fatalf("ListFragmentPaths() error = %v", err)
+	}
+	want := []string{"projects/term_llm/new.md", "projects/term_llm/old.md"}
+	if len(paths) != len(want) {
+		t.Fatalf("ListFragmentPaths() len = %d, want %d: %#v", len(paths), len(want), paths)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Fatalf("ListFragmentPaths()[%d] = %q, want %q (all paths %#v)", i, paths[i], want[i], paths)
+		}
+	}
+
+	paths, err = store.ListFragmentPaths(ctx, "jarvis", "projects/term_llm/", 1)
+	if err != nil {
+		t.Fatalf("ListFragmentPaths(limit) error = %v", err)
+	}
+	if len(paths) != 1 || paths[0] != "projects/term_llm/new.md" {
+		t.Fatalf("ListFragmentPaths(limit) = %#v, want newest matching path only", paths)
 	}
 }
 
@@ -996,7 +1039,100 @@ func TestParseFlexibleTime(t *testing.T) {
 	}
 }
 
-func newTestStore(t *testing.T) *Store {
+func BenchmarkListFragmentPathsForMiningTool(b *testing.B) {
+	ctx := context.Background()
+	store := newTestStore(b)
+	defer store.Close()
+	seedListFragmentPathBenchmark(b, store, 3000)
+
+	const (
+		agent  = "jarvis"
+		prefix = "projects/term-llm/"
+		limit  = 20
+	)
+
+	b.Run("old-list-fragments-filter", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			fragments, err := store.ListFragments(ctx, ListOptions{Agent: agent})
+			if err != nil {
+				b.Fatalf("ListFragments() error = %v", err)
+			}
+			paths := make([]string, 0, limit)
+			for _, frag := range fragments {
+				if !strings.HasPrefix(frag.Path, prefix) {
+					continue
+				}
+				paths = append(paths, frag.Path)
+				if len(paths) >= limit {
+					break
+				}
+			}
+			if len(paths) != limit {
+				b.Fatalf("old path count = %d, want %d", len(paths), limit)
+			}
+		}
+	})
+
+	b.Run("new-list-fragment-paths", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			paths, err := store.ListFragmentPaths(ctx, agent, prefix, limit)
+			if err != nil {
+				b.Fatalf("ListFragmentPaths() error = %v", err)
+			}
+			if len(paths) != limit {
+				b.Fatalf("new path count = %d, want %d", len(paths), limit)
+			}
+		}
+	})
+}
+
+func seedListFragmentPathBenchmark(b *testing.B, store *Store, count int) {
+	b.Helper()
+
+	tx, err := store.db.Begin()
+	if err != nil {
+		b.Fatalf("begin seed transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO memory_fragments (id, agent, path, content, source, created_at, updated_at, decay_score)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1.0)`)
+	if err != nil {
+		b.Fatalf("prepare seed insert: %v", err)
+	}
+	defer stmt.Close()
+
+	content := strings.Repeat("x", 2048)
+	now := time.Now().UTC().Add(-time.Duration(count) * time.Second)
+	for i := 0; i < count; i++ {
+		prefix := "notes/misc"
+		if i%10 == 0 {
+			prefix = "projects/term-llm"
+		}
+		createdAt := now.Add(time.Duration(i) * time.Second)
+		_, err := stmt.Exec(
+			fmt.Sprintf("frag-%04d", i),
+			"jarvis",
+			fmt.Sprintf("%s/%04d.md", prefix, i),
+			content,
+			DefaultSourceMine,
+			createdAt,
+			createdAt,
+		)
+		if err != nil {
+			b.Fatalf("seed insert %d: %v", i, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit seed transaction: %v", err)
+	}
+}
+
+func newTestStore(t testing.TB) *Store {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "memory.db")
 	store, err := NewStore(Config{Path: dbPath})


### PR DESCRIPTION
## What

Optimizes the `memory_list_fragments` mining tool so it asks SQLite for just the fragment paths it needs instead of loading every fragment (including full content) and filtering/limiting in Go.

Changes:
- Added `Store.ListFragmentPaths(ctx, agent, prefix, limit)` with a path-only projection and SQL-level prefix/limit filtering.
- Added an `agent, created_at DESC` index to support newest-first lightweight listings.
- Switched the mining tool runtime to use the new path-only listing.
- Added coverage for prefix matching (including `_` not behaving like a wildcard) and limit behavior.
- Added a benchmark that compares the old full-fragment scan/filter shape with the new path-only query.

## Why

During memory mining, the model can call `memory_list_fragments` repeatedly. The previous code materialized all fragment rows and their content, then kept only up to 20 paths. On stores with many or large fragments this wastes memory bandwidth, allocations, and latency on a tool call that only needs path strings.

## Evidence

Representative benchmark with 3,000 fragments (2 KiB content each), listing 20 paths by prefix:

```
go test ./internal/memory -run '^$' -bench BenchmarkListFragmentPathsForMiningTool -benchmem -count=3
old-list-fragments-filter: ~10.2-10.5 ms/op, 16.1 MB/op, 83,786 allocs/op
new-list-fragment-paths:   ~195 µs/op,     2.9 KB/op,    105 allocs/op
```

## Verification

- `go test ./internal/memory -run TestStoreListFragmentPaths`
- `go test ./internal/memory -run '^$' -bench BenchmarkListFragmentPathsForMiningTool -benchmem -count=3`
- `go build ./...`
- `go test ./...`
