### PR TITLE
fix(config): show ChatGPT image model

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -218,6 +218,7 @@ func printAnnotatedConfig(defaults map[string]any, rawKeys, unknownKeys map[stri
 			nested: map[string][]string{
 				"gemini":     {"model", "api_key"},
 				"openai":     {"model", "api_key"},
+				"chatgpt":    {"model"},
 				"xai":        {"model", "api_key"},
 				"venice":     {"model", "edit_model", "resolution", "api_key"},
 				"flux":       {"model", "api_key"},


### PR DESCRIPTION
## What

Show `image.chatgpt.model` in `term-llm config` output.

## Why

`image.chatgpt.model` is already a known config key, has a default (`gpt-5.4-mini`), loads correctly, and is used at runtime. The annotated config display had a static image-provider list that included Gemini/OpenAI/xAI/Venice/Flux/OpenRouter but missed ChatGPT, making valid config look invisible.

## Verification

- `go test ./cmd ./internal/config`
- Fixture check:
  - config: `image.provider: chatgpt`, `image.chatgpt.model: gpt-5.4-mini`
  - output now includes:

```yaml
image:
  provider: chatgpt
  chatgpt:
    model: gpt-5.4-mini  # (same as default)
```
