### PR TITLE
fix: Responses API tool-result follow-up wipes prior conversation state

### DIFF
--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -83,12 +83,10 @@ func parseResponsesInput(input json.RawMessage) ([]llm.Message, bool, error) {
 				Type:     llm.PartToolCall,
 				ToolCall: &llm.ToolCall{ID: id, Name: name, Arguments: json.RawMessage(args)},
 			}}})
-			replaceHistory = true
 		case "function_call_output":
 			id := jsonString(item["call_id"])
 			out := jsonString(item["output"])
 			messages = append(messages, llm.ToolResultMessage(id, callNameByID[id], out, nil))
-			replaceHistory = true
 		}
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1072,7 +1072,7 @@ func TestParseDataURL(t *testing.T) {
 	}
 }
 
-func TestParseResponsesInput_FunctionCallOutput(t *testing.T) {
+func TestParseResponsesInput_FunctionCallOutputDoesNotReplaceHistory(t *testing.T) {
 	payload := json.RawMessage(`[
 		{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\"path\":\"a.txt\"}"},
 		{"type":"function_call_output","call_id":"call_1","output":"content"}
@@ -1081,8 +1081,8 @@ func TestParseResponsesInput_FunctionCallOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseResponsesInput failed: %v", err)
 	}
-	if !replaceHistory {
-		t.Fatalf("replaceHistory = false, want true")
+	if replaceHistory {
+		t.Fatalf("replaceHistory = true, want false")
 	}
 	if len(msgs) != 2 {
 		t.Fatalf("len(msgs) = %d, want 2", len(msgs))
@@ -4555,14 +4555,28 @@ func TestHandleResponses_PreviousResponseIDFunctionCallOutputUsesPriorToolName(t
 		t.Fatalf("provider request count = %d, want 2", len(provider.Requests))
 	}
 
+	var sawUserHi bool
+	var sawToolCall bool
 	var toolResultName string
 	for _, msg := range provider.Requests[1].Messages {
+		if msg.Role == llm.RoleUser && len(msg.Parts) > 0 && msg.Parts[0].Type == llm.PartText && msg.Parts[0].Text == "hi" {
+			sawUserHi = true
+		}
 		for _, part := range msg.Parts {
+			if part.Type == llm.PartToolCall && part.ToolCall != nil && part.ToolCall.ID == "call_1" && part.ToolCall.Name == "read_file" {
+				sawToolCall = true
+			}
 			if part.Type != llm.PartToolResult || part.ToolResult == nil || part.ToolResult.ID != "call_1" {
 				continue
 			}
 			toolResultName = part.ToolResult.Name
 		}
+	}
+	if !sawUserHi {
+		t.Fatal("second provider request missing prior user message")
+	}
+	if !sawToolCall {
+		t.Fatal("second provider request missing prior assistant tool call")
 	}
 	if toolResultName != "read_file" {
 		t.Fatalf("tool result name = %q, want %q", toolResultName, "read_file")


### PR DESCRIPTION
## What

Stop treating Responses API `function_call` and `function_call_output` input items as history replacements. This preserves prior runtime/provider conversation state when a chained `/v1/responses` follow-up submits tool results via `previous_response_id`.

Also add coverage for the parser behavior and for the chained tool-result request preserving earlier user/tool-call context.

## Why

Responses API tool-result follow-ups are incremental inputs, not full transcript replays. Marking them as `replaceHistory=true` cleared the existing conversation and reset provider state before the tool result was appended, so the next model turn could run without the original prompt or assistant tool call context.
