### PR TITLE
fix: Chat Completions tool-result follow-up clears session history

### DIFF
--- a/cmd/serve_protocol_chat.go
+++ b/cmd/serve_protocol_chat.go
@@ -58,7 +58,14 @@ type chatToolCall struct {
 func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 	callNameByID := make(map[string]string)
 	result := make([]llm.Message, 0, len(msgs))
-	replaceHistory := len(msgs) > 1
+	allToolMessages := len(msgs) > 0
+	for _, msg := range msgs {
+		if strings.ToLower(strings.TrimSpace(msg.Role)) != "tool" {
+			allToolMessages = false
+			break
+		}
+	}
+	replaceHistory := len(msgs) > 1 && !allToolMessages
 
 	for _, msg := range msgs {
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
@@ -111,7 +118,6 @@ func parseChatMessages(msgs []chatMessage) ([]llm.Message, bool, error) {
 				name = callNameByID[callID]
 			}
 			result = append(result, llm.ToolResultMessage(callID, name, extractMessageText(msg.Content), nil))
-			replaceHistory = true
 		default:
 			return nil, false, fmt.Errorf("unsupported message role: %s", msg.Role)
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1139,13 +1139,16 @@ func TestParseChatMessages_ToolCallAndToolResult(t *testing.T) {
 }
 
 func TestPopulateMissingToolResultNames_UsesHistory(t *testing.T) {
-	messages, _, err := parseChatMessages([]chatMessage{{
+	messages, replaceHistory, err := parseChatMessages([]chatMessage{{
 		Role:       "tool",
 		ToolCallID: "call_1",
 		Content:    json.RawMessage(`"done"`),
 	}})
 	if err != nil {
 		t.Fatalf("parseChatMessages failed: %v", err)
+	}
+	if replaceHistory {
+		t.Fatalf("replaceHistory = true, want false for tool-only follow-up")
 	}
 
 	history := []llm.Message{{
@@ -7785,6 +7788,18 @@ func TestChatCompletions_ToolResultWithoutReplayedToolCallKeepsNameFromSessionHi
 
 	if len(provider.Requests) != 2 {
 		t.Fatalf("provider request count = %d, want 2", len(provider.Requests))
+	}
+	if len(provider.Requests[1].Messages) != 3 {
+		t.Fatalf("second provider request message count = %d, want 3", len(provider.Requests[1].Messages))
+	}
+	if provider.Requests[1].Messages[0].Role != llm.RoleUser || len(provider.Requests[1].Messages[0].Parts) != 1 || provider.Requests[1].Messages[0].Parts[0].Type != llm.PartText || provider.Requests[1].Messages[0].Parts[0].Text != "Hi" {
+		t.Fatalf("second request message[0] = %+v, want original user message", provider.Requests[1].Messages[0])
+	}
+	if provider.Requests[1].Messages[1].Role != llm.RoleAssistant || len(provider.Requests[1].Messages[1].Parts) != 1 || provider.Requests[1].Messages[1].Parts[0].Type != llm.PartToolCall || provider.Requests[1].Messages[1].Parts[0].ToolCall == nil || provider.Requests[1].Messages[1].Parts[0].ToolCall.ID != "call-1" {
+		t.Fatalf("second request message[1] = %+v, want assistant tool call", provider.Requests[1].Messages[1])
+	}
+	if provider.Requests[1].Messages[2].Role != llm.RoleTool || len(provider.Requests[1].Messages[2].Parts) != 1 || provider.Requests[1].Messages[2].Parts[0].Type != llm.PartToolResult || provider.Requests[1].Messages[2].Parts[0].ToolResult == nil || provider.Requests[1].Messages[2].Parts[0].ToolResult.ID != "call-1" {
+		t.Fatalf("second request message[2] = %+v, want tool result", provider.Requests[1].Messages[2])
 	}
 
 	var toolResultName string


### PR DESCRIPTION
## What

Fix Chat Completions parsing so tool-only follow-up requests append to existing session history instead of clearing it.

Also add coverage that verifies a session-scoped tool result follow-up keeps the original user message and assistant tool-call context on the second provider request.

## Why

External function-calling chat-completions clients commonly send a second request with only a `tool` message after the prior assistant response returned `tool_calls`. Marking that follow-up as `replaceHistory` reset the runtime/provider conversation and dropped the original request context, breaking the tool-calling flow.
