### PR TITLE
fix: ensureSessionInStore races on runtime sessionMeta without locking

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -197,9 +197,13 @@ func (rt *serveRuntime) ensureSessionInStore(ctx context.Context, sessionID stri
 		return 0
 	}
 	// Fast path: runtime already hydrated under rt.mu by a prior run.
+	rt.mu.Lock()
 	if meta := rt.sessionMeta; meta != nil && meta.ID == sessionID {
-		return meta.Number
+		number := meta.Number
+		rt.mu.Unlock()
+		return number
 	}
+	rt.mu.Unlock()
 	// Check DB for existing session.
 	if existing, err := rt.store.Get(ctx, sessionID); err == nil && existing != nil {
 		return existing.Number


### PR DESCRIPTION
## What

Lock `rt.mu` around the `ensureSessionInStore` fast path before reading `rt.sessionMeta`, and copy the session number while the lock is held.

## Why

`ensureSessionInStore` is called from the UI streaming path without `rt.mu`, but other code mutates `rt.sessionMeta` under that mutex. Reading it directly was an unsynchronized access to shared runtime state and could race under concurrent requests. Taking the lock for the fast-path read keeps the method safe to call without requiring callers to hold `rt.mu` and avoids stale or torn session metadata when deciding whether to reuse the in-memory session.
