### PR TITLE
fix: Response-run active-session tracking is overwritten by busy concurrent runs

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1133,7 +1133,6 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		cancel()
 		return nil, err
 	}
-	mgr.setActiveRun(sessionID, respID)
 
 	if options.uiSession {
 		runtime.clearLastUIRunError()
@@ -1181,7 +1180,9 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		}()
 
 		streamState := &responseRunStreamState{}
-		result, err := runtime.RunWithEvents(runCtx, stateful, replaceHistory, inputMessages, llmReq, func(ev llm.Event) error {
+		result, err := runtime.RunWithEventsAndStart(runCtx, stateful, replaceHistory, inputMessages, llmReq, func() {
+			mgr.setActiveRun(sessionID, respID)
+		}, func(ev llm.Event) error {
 			return s.appendResponseRunEvent(runtime, run, streamState, ev)
 		})
 		if err != nil {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -519,18 +519,25 @@ var (
 )
 
 func (rt *serveRuntime) Run(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request) (serveRunResult, error) {
-	return rt.run(ctx, stateful, replaceHistory, inputMessages, req, nil)
+	return rt.run(ctx, stateful, replaceHistory, inputMessages, req, nil, nil)
 }
 
 func (rt *serveRuntime) RunWithEvents(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request, onEvent func(llm.Event) error) (serveRunResult, error) {
-	return rt.run(ctx, stateful, replaceHistory, inputMessages, req, onEvent)
+	return rt.run(ctx, stateful, replaceHistory, inputMessages, req, nil, onEvent)
 }
 
-func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request, onEvent func(llm.Event) error) (serveRunResult, error) {
+func (rt *serveRuntime) RunWithEventsAndStart(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request, onStart func(), onEvent func(llm.Event) error) (serveRunResult, error) {
+	return rt.run(ctx, stateful, replaceHistory, inputMessages, req, onStart, onEvent)
+}
+
+func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request, onStart func(), onEvent func(llm.Event) error) (serveRunResult, error) {
 	if !rt.mu.TryLock() {
 		return serveRunResult{}, errServeSessionBusy
 	}
 	defer rt.mu.Unlock()
+	if onStart != nil {
+		onStart()
+	}
 	rt.Touch()
 	persisted := rt.ensurePersistedSession(ctx, req.SessionID, inputMessages)
 	if persisted {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -6506,6 +6506,61 @@ func TestStartResponseRun_StatelessCleanupRemovesResponseIDMapping(t *testing.T)
 	}, "stateless response ID cleanup")
 }
 
+func TestStartResponseRun_BusyConcurrentRunKeepsActiveSessionTracking(t *testing.T) {
+	provider := newStagedProvider("hello ", "world")
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  "staged",
+		engine:       llm.NewEngine(provider, nil),
+		defaultModel: "mock-model",
+	}
+	rt.Touch()
+
+	srv := &serveServer{responseRuns: newServeResponseRunManager()}
+	defer srv.responseRuns.Close()
+
+	const sessionID = "sess_busy_active_tracking"
+	run1, err := srv.startResponseRun(rt, true, false, []llm.Message{
+		llm.UserText("first"),
+	}, llm.Request{SessionID: sessionID}, sessionID, startResponseRunOptions{})
+	if err != nil {
+		t.Fatalf("startResponseRun first: %v", err)
+	}
+
+	waitForServeCondition(t, time.Second, func() bool {
+		return rt.hasActiveRun() && srv.responseRuns.activeRunID(sessionID) == run1.id
+	}, "first response run to become active")
+
+	run2, err := srv.startResponseRun(rt, true, false, []llm.Message{
+		llm.UserText("second"),
+	}, llm.Request{SessionID: sessionID}, sessionID, startResponseRunOptions{})
+	if err != nil {
+		t.Fatalf("startResponseRun second: %v", err)
+	}
+
+	waitForServeCondition(t, time.Second, func() bool {
+		snapshot := run2.snapshot()
+		status, _ := snapshot["status"].(string)
+		return status == "failed"
+	}, "second busy response run failure")
+
+	if got := srv.responseRuns.activeRunID(sessionID); got != run1.id {
+		t.Fatalf("activeRunID after concurrent busy run = %q, want %q", got, run1.id)
+	}
+
+	close(provider.releaseSecond)
+
+	waitForServeCondition(t, time.Second, func() bool {
+		snapshot := run1.snapshot()
+		status, _ := snapshot["status"].(string)
+		return status == "completed"
+	}, "first response run completion")
+
+	waitForServeCondition(t, time.Second, func() bool {
+		return srv.responseRuns.activeRunID(sessionID) == ""
+	}, "active response run cleanup")
+}
+
 func TestServeSessionManager_Get_ExistingSession(t *testing.T) {
 	factory := func(ctx context.Context) (*serveRuntime, error) {
 		rt := &serveRuntime{}


### PR DESCRIPTION
## What

Delay `activeBySession` updates until a response run actually acquires the runtime lock and starts, instead of marking the session active before the goroutine can fail with `session is busy`.

Also add a regression test covering a busy concurrent response run while another run is still active for the same session.

## Why

A concurrent response request could overwrite the session's active run mapping before it actually started. If that request then failed with `session is busy`, its deferred cleanup removed the mapping entirely, leaving the real in-flight run undiscoverable via `activeRunID(sessionID)`.
