### PR TITLE
fix: Fresh conversation on reused session_id keeps stale provider/model pinned in the DB

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1404,14 +1404,13 @@ func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessio
 }
 
 // syncPersistedSessionRuntime pins the provider, model, and reasoning_effort
-// on the session row for the first message of a web session. Fields already
-// set on the row are never overwritten; once saved on first message, these
-// values are locked for the remainder of the session. Later requests must use
-// the locked values — cross-provider or cross-model swaps mid-session corrupt
-// saved state (tool call shapes, response chaining, reasoning trace), and
-// handover is a future feature. If the row does not yet exist, it is created
-// here so the client-supplied model and effort are persisted (rather than the
-// runtime defaults that rt would otherwise use when Run creates the row).
+// for the current fresh web conversation. A client may start a fresh
+// conversation while reusing an existing session ID, so the persisted session
+// row must be updated to match the replacement runtime instead of leaving
+// stale provider/model metadata behind from the prior conversation. If the row
+// does not yet exist, it is created here so the client-supplied model and
+// effort are persisted (rather than the runtime defaults that rt would
+// otherwise use when Run creates the row).
 func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID string, rt *serveRuntime, clientModel, reasoningEffort string) {
 	if s.store == nil || sessionID == "" || rt == nil {
 		return
@@ -1474,19 +1473,19 @@ func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID
 	}
 
 	changed := false
-	if providerName != "" && strings.TrimSpace(sess.Provider) == "" {
+	if strings.TrimSpace(sess.Provider) != providerName {
 		sess.Provider = providerName
 		changed = true
 	}
-	if providerKey != "" && strings.TrimSpace(sess.ProviderKey) == "" {
+	if strings.TrimSpace(sess.ProviderKey) != providerKey {
 		sess.ProviderKey = providerKey
 		changed = true
 	}
-	if modelName != "" && strings.TrimSpace(sess.Model) == "" {
+	if strings.TrimSpace(sess.Model) != modelName {
 		sess.Model = modelName
 		changed = true
 	}
-	if effort != "" && strings.TrimSpace(sess.ReasoningEffort) == "" {
+	if strings.TrimSpace(sess.ReasoningEffort) != effort {
 		sess.ReasoningEffort = effort
 		changed = true
 	}

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -72,15 +72,14 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("x-session-id", sessionID)
 		replaceHistory = true
 	}
-	// Lock provider/model/reasoning_effort to whatever was persisted on the
-	// session row: these fields are only honored from the client on the first
-	// message of a session. Once the row exists with a provider, every later
-	// request for that session uses the saved values, regardless of what the
-	// client sent. Cross-provider or cross-model swaps mid-session corrupt
-	// saved state (tool result shapes, response chaining, reasoning) — the
-	// silent override prevents that. Handover is a future feature.
+	// Chained requests are locked to the persisted provider/model/
+	// reasoning_effort. A bare session_id header starts a fresh conversation,
+	// even when the client reuses an existing session ID, so fresh conversations
+	// may choose new runtime settings and syncPersistedSessionRuntime will
+	// update the session row before the run.
+	freshConversation := req.PreviousResponseID == ""
 	reqProvider := strings.TrimSpace(req.Provider)
-	if s.store != nil {
+	if !freshConversation && s.store != nil {
 		if sess, getErr := s.store.Get(ctx, sessionID); getErr == nil && sess != nil {
 			persistedProvider := strings.TrimSpace(sess.ProviderKey)
 			if persistedProvider == "" {
@@ -103,7 +102,6 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 	var runtime *serveRuntime
 	var stateful bool
-	freshConversation := req.PreviousResponseID == ""
 	freshProvider := reqProvider
 	if freshConversation && freshProvider == "" {
 		freshProvider = defaultProvider

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4754,12 +4754,11 @@ func TestHandleResponses_PreviousResponseIDRestoresPersistedProviderAfterRuntime
 	}
 }
 
-// After the first message of a web session pins provider=default, a later
-// request on the same session ID that asks for provider=other must be
-// silently overridden back to the persisted provider. Cross-provider swaps
-// mid-session corrupt saved state; the client's provider field is only
-// honored on the very first message.
-func TestHandleResponses_ProviderLockedAfterFirstMessage(t *testing.T) {
+// A fresh conversation may reuse an existing session ID and switch to a new
+// provider. The replacement runtime must also update the persisted session row
+// so later chained requests resume on the new provider instead of jumping back
+// to stale DB metadata.
+func TestHandleResponses_FreshConversationReusedSessionIDUpdatesPersistedProvider(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -4805,13 +4804,16 @@ func TestHandleResponses_ProviderLockedAfterFirstMessage(t *testing.T) {
 		t.Fatalf("first request status = %d, want 200", code)
 	}
 
-	code, resp := doResponsesWithHeader(t, srv, `{"input":"fresh","provider":"other"}`, "provider-reuse")
+	code, resp2 := doResponsesWithHeader(t, srv, `{"input":"fresh","provider":"other"}`, "provider-reuse")
 	if code != http.StatusOK {
 		t.Fatalf("fresh provider request status = %d, want 200", code)
 	}
-
-	if got := responseOutputText(t, resp); got != "default response 2" {
-		t.Fatalf("response text = %q, want %q (provider override should be silently locked to default)", got, "default response 2")
+	if got := responseOutputText(t, resp2); got != "other response 1" {
+		t.Fatalf("response text = %q, want %q", got, "other response 1")
+	}
+	respID2, _ := resp2["id"].(string)
+	if respID2 == "" {
+		t.Fatal("fresh provider response missing id")
 	}
 
 	sess, err := store.Get(context.Background(), "provider-reuse")
@@ -4821,22 +4823,37 @@ func TestHandleResponses_ProviderLockedAfterFirstMessage(t *testing.T) {
 	if sess == nil {
 		t.Fatal("expected persisted session")
 	}
-	if sess.ProviderKey != "default" {
-		t.Fatalf("ProviderKey = %q, want default (locked from first message)", sess.ProviderKey)
+	if sess.ProviderKey != "other" {
+		t.Fatalf("ProviderKey = %q, want other", sess.ProviderKey)
 	}
-	if got := defaultCreates.Load(); got != 2 {
-		t.Fatalf("default provider factory calls = %d, want 2", got)
+
+	manager.mu.Lock()
+	evicted := manager.sessions["provider-reuse"]
+	delete(manager.sessions, "provider-reuse")
+	manager.mu.Unlock()
+	if evicted != nil {
+		evicted.Close()
 	}
-	if got := otherCreates.Load(); got != 0 {
-		t.Fatalf("other provider factory calls = %d, want 0 (client provider must be ignored)", got)
+
+	code, resp3 := doResponses(t, srv, `{"input":"resume","previous_response_id":"`+respID2+`"}`)
+	if code != http.StatusOK {
+		t.Fatalf("resume request status = %d, want 200", code)
+	}
+	if got := responseOutputText(t, resp3); got != "other response 2" {
+		t.Fatalf("resume response text = %q, want %q", got, "other response 2")
+	}
+	if got := defaultCreates.Load(); got != 1 {
+		t.Fatalf("default provider factory calls = %d, want 1", got)
+	}
+	if got := otherCreates.Load(); got != 2 {
+		t.Fatalf("other provider factory calls = %d, want 2", got)
 	}
 }
 
-// After the first message of a web session pins provider=other, a later
-// request on the same session ID that omits provider (defaulting client-side
-// to "default") must be silently overridden back to the persisted provider,
-// rather than creating a runtime with the server default.
-func TestHandleResponses_ImplicitDefaultLockedToPersistedProvider(t *testing.T) {
+// When a fresh conversation reuses an old session ID but omits provider, it
+// should fall back to the server default provider rather than inheriting the
+// persisted provider from the prior conversation.
+func TestHandleResponses_FreshConversationWithoutProviderUsesDefaultNotPersistedProvider(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -4875,7 +4892,8 @@ func TestHandleResponses_ImplicitDefaultLockedToPersistedProvider(t *testing.T) 
 		store:      store,
 		runtimeFactory: func(ctx context.Context, providerName string, model string) (*serveRuntime, error) {
 			if providerName == "" || providerName == "default" {
-				t.Fatalf("unexpected runtimeFactory call for default provider %q", providerName)
+				createNum := defaultCreates.Add(1)
+				return newRuntime("default", createNum), nil
 			}
 			createNum := otherCreates.Add(1)
 			return newRuntime(providerName, createNum), nil
@@ -4894,8 +4912,12 @@ func TestHandleResponses_ImplicitDefaultLockedToPersistedProvider(t *testing.T) 
 	if code != http.StatusOK {
 		t.Fatalf("fresh default request status = %d, want 200", code)
 	}
-	if got := responseOutputText(t, resp); got != "other runtime 2 response 1" {
-		t.Fatalf("fresh default response text = %q, want %q (should stay locked to other)", got, "other runtime 2 response 1")
+	if got := responseOutputText(t, resp); got != "default runtime 1 response 1" {
+		t.Fatalf("fresh default response text = %q, want %q", got, "default runtime 1 response 1")
+	}
+	respID, _ := resp["id"].(string)
+	if respID == "" {
+		t.Fatal("fresh default response missing id")
 	}
 
 	sess, err := store.Get(context.Background(), "provider-default-reuse")
@@ -4905,36 +4927,30 @@ func TestHandleResponses_ImplicitDefaultLockedToPersistedProvider(t *testing.T) 
 	if sess == nil {
 		t.Fatal("expected persisted session after implicit default request")
 	}
-	if sess.ProviderKey != "other" {
-		t.Fatalf("ProviderKey after implicit default = %q, want other (locked from first message)", sess.ProviderKey)
-	}
-	if got := defaultCreates.Load(); got != 0 {
-		t.Fatalf("default provider factory calls = %d, want 0 (client default must be overridden)", got)
+	if sess.ProviderKey != "default" {
+		t.Fatalf("ProviderKey after implicit default = %q, want default", sess.ProviderKey)
 	}
 
-	code, resp = doResponsesWithHeader(t, srv, `{"input":"fresh again","provider":"default"}`, "provider-default-reuse")
+	manager.mu.Lock()
+	evicted := manager.sessions["provider-default-reuse"]
+	delete(manager.sessions, "provider-default-reuse")
+	manager.mu.Unlock()
+	if evicted != nil {
+		evicted.Close()
+	}
+
+	code, resp = doResponses(t, srv, `{"input":"resume","previous_response_id":"`+respID+`"}`)
 	if code != http.StatusOK {
-		t.Fatalf("fresh explicit default request status = %d, want 200", code)
+		t.Fatalf("resume request status = %d, want 200", code)
 	}
-	if got := responseOutputText(t, resp); got != "other runtime 3 response 1" {
-		t.Fatalf("fresh explicit default response text = %q, want %q (should stay locked to other)", got, "other runtime 3 response 1")
+	if got := responseOutputText(t, resp); got != "default runtime 2 response 1" {
+		t.Fatalf("resume response text = %q, want %q", got, "default runtime 2 response 1")
 	}
-
-	sess, err = store.Get(context.Background(), "provider-default-reuse")
-	if err != nil {
-		t.Fatalf("Get session after explicit default: %v", err)
+	if got := defaultCreates.Load(); got != 2 {
+		t.Fatalf("default provider factory calls = %d, want 2", got)
 	}
-	if sess == nil {
-		t.Fatal("expected persisted session after explicit default request")
-	}
-	if sess.ProviderKey != "other" {
-		t.Fatalf("ProviderKey after explicit default = %q, want other (locked from first message)", sess.ProviderKey)
-	}
-	if got := defaultCreates.Load(); got != 0 {
-		t.Fatalf("default provider factory calls = %d, want 0 (client default must be overridden)", got)
-	}
-	if got := otherCreates.Load(); got != 3 {
-		t.Fatalf("other provider factory calls = %d, want 3", got)
+	if got := otherCreates.Load(); got != 1 {
+		t.Fatalf("other provider factory calls = %d, want 1", got)
 	}
 }
 
@@ -6240,10 +6256,10 @@ func TestResponsesHandler_ReasoningEffortFlowsToProvider(t *testing.T) {
 }
 
 // After the first message of a web session pins reasoning_effort=high and
-// model=first-model, later requests on the same session ID that send
-// different values must be silently overridden back to the persisted ones.
-// Mid-session switches of effort/model are disallowed — the first message
-// is the only place where client values are honored.
+// model=first-model, chained requests on the same session must be silently
+// overridden back to the persisted values. Mid-session switches of
+// effort/model are disallowed — the first message of a conversation is the
+// only place where client values are honored.
 func TestHandleResponses_ModelAndEffortLockedAfterFirstMessage(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
@@ -6280,12 +6296,16 @@ func TestHandleResponses_ModelAndEffortLockedAfterFirstMessage(t *testing.T) {
 		store:      store,
 	}
 
-	code, _ := doResponsesWithHeader(t, srv, `{"input":"hi","model":"first-model","reasoning_effort":"high"}`, "lock-effort")
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"hi","model":"first-model","reasoning_effort":"high"}`, "lock-effort")
 	if code != http.StatusOK {
 		t.Fatalf("first status = %d", code)
 	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
 
-	code, _ = doResponsesWithHeader(t, srv, `{"input":"again","model":"second-model","reasoning_effort":"low"}`, "lock-effort")
+	code, _ = doResponses(t, srv, `{"input":"again","model":"second-model","reasoning_effort":"low","previous_response_id":"`+respID1+`"}`)
 	if code != http.StatusOK {
 		t.Fatalf("second status = %d", code)
 	}
@@ -6314,6 +6334,97 @@ func TestHandleResponses_ModelAndEffortLockedAfterFirstMessage(t *testing.T) {
 	}
 	if sess.ReasoningEffort != "high" {
 		t.Fatalf("persisted ReasoningEffort = %q, want high", sess.ReasoningEffort)
+	}
+}
+
+func TestHandleResponses_FreshConversationReusedSessionIDUpdatesPersistedModelAndEffort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	providers := make([]*llm.MockProvider, 0, 4)
+	var createNum atomic.Int32
+	newRuntime := func() *serveRuntime {
+		n := createNum.Add(1)
+		provider := llm.NewMockProvider("mock").AddTextResponse(fmt.Sprintf("runtime %d", n))
+		providers = append(providers, provider)
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  "mock",
+			engine:       engine,
+			defaultModel: "mock-default-model",
+			store:        store,
+		}
+		rt.Touch()
+		return rt
+	}
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		return newRuntime(), nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfgRef:     &config.Config{DefaultProvider: "mock"},
+		sessionMgr: manager,
+		store:      store,
+	}
+
+	code, _ := doResponsesWithHeader(t, srv, `{"input":"hi","model":"first-model","reasoning_effort":"high"}`, "reuse-model-effort")
+	if code != http.StatusOK {
+		t.Fatalf("first status = %d", code)
+	}
+
+	code, resp2 := doResponsesWithHeader(t, srv, `{"input":"restart","model":"second-model","reasoning_effort":"low"}`, "reuse-model-effort")
+	if code != http.StatusOK {
+		t.Fatalf("fresh status = %d", code)
+	}
+	respID2, _ := resp2["id"].(string)
+	if respID2 == "" {
+		t.Fatal("fresh response missing id")
+	}
+
+	sess, err := store.Get(context.Background(), "reuse-model-effort")
+	if err != nil || sess == nil {
+		t.Fatalf("Get session: err=%v sess=%v", err, sess)
+	}
+	if sess.Model != "second-model" {
+		t.Fatalf("persisted Model after fresh restart = %q, want second-model", sess.Model)
+	}
+	if sess.ReasoningEffort != "low" {
+		t.Fatalf("persisted ReasoningEffort after fresh restart = %q, want low", sess.ReasoningEffort)
+	}
+
+	manager.mu.Lock()
+	evicted := manager.sessions["reuse-model-effort"]
+	delete(manager.sessions, "reuse-model-effort")
+	manager.mu.Unlock()
+	if evicted != nil {
+		evicted.Close()
+	}
+
+	code, _ = doResponses(t, srv, `{"input":"continue","model":"ignored-model","reasoning_effort":"high","previous_response_id":"`+respID2+`"}`)
+	if code != http.StatusOK {
+		t.Fatalf("resume status = %d", code)
+	}
+
+	if len(providers) < 3 {
+		t.Fatalf("provider count = %d, want at least 3 runtimes", len(providers))
+	}
+	last := providers[len(providers)-1]
+	if len(last.Requests) == 0 {
+		t.Fatal("expected a provider request on resumed call")
+	}
+	lastReq := last.Requests[len(last.Requests)-1]
+	if lastReq.Model != "second-model" {
+		t.Fatalf("Model on resumed request = %q, want second-model", lastReq.Model)
+	}
+	if lastReq.ReasoningEffort != "low" {
+		t.Fatalf("ReasoningEffort on resumed request = %q, want low", lastReq.ReasoningEffort)
 	}
 }
 


### PR DESCRIPTION
## What

- treat `/v1/responses` requests with only a reused `session_id` as fresh conversations instead of reapplying persisted provider/model/effort locks before runtime selection
- update `syncPersistedSessionRuntime` to overwrite the persisted session row with the fresh runtime's provider, provider_key, model, and reasoning_effort
- add regression coverage for fresh-conversation session reuse across provider and model/effort changes, while keeping chained requests locked to persisted settings

## Why

Starting a fresh conversation on an existing `session_id` can replace the in-memory runtime, but the old session row used to keep stale provider/model/effort values. Later requests could then reload those stale values and silently switch the session back to the previous backend/settings. Persisting the fresh runtime settings fixes the continuity bug and keeps future reloads/chained requests on the intended backend.
