### PR TITLE
perf: defer tool heartbeat goroutines

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	defaultMaxTurns    = 20
-	stopSearchToolHint = "IMPORTANT: Do not call any tools. Use the information already retrieved and answer directly."
-	callbackTimeout    = 5 * time.Second
+	defaultMaxTurns       = 20
+	stopSearchToolHint    = "IMPORTANT: Do not call any tools. Use the information already retrieved and answer directly."
+	callbackTimeout       = 5 * time.Second
+	toolHeartbeatInterval = 10 * time.Second
 )
 
 // getMaxTurns returns the max turns from request, with fallback to default
@@ -1601,6 +1602,39 @@ func (e *Engine) executeSingleToolCallSafe(ctx context.Context, call ToolCall, s
 	return e.executeSingleToolCall(ctx, call, send, debug, debugRaw)
 }
 
+// startToolHeartbeat emits heartbeat events only if a tool is still running
+// after toolHeartbeatInterval. Most tools complete quickly, so using AfterFunc
+// avoids starting a goroutine and ticker on every tool invocation.
+func startToolHeartbeat(ctx context.Context, callID, toolName string, send eventSender) func() {
+	if send.ch == nil {
+		return func() {}
+	}
+
+	var stopped atomic.Bool
+	heartbeat := Event{Type: EventHeartbeat, ToolCallID: callID, ToolName: toolName}
+
+	timer := time.AfterFunc(toolHeartbeatInterval, func() {
+		ticker := time.NewTicker(toolHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			if stopped.Load() {
+				return
+			}
+			send.TrySend(heartbeat)
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	return func() {
+		stopped.Store(true)
+		timer.Stop()
+	}
+}
+
 // executeSingleToolCall executes a single tool call and returns the result message.
 func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send eventSender, debug bool, debugRaw bool) ([]Message, error) {
 	tool, ok := e.tools.Get(call.Name)
@@ -1622,22 +1656,8 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send 
 	// Add call ID to context for spawn_agent event bubbling
 	toolCtx := ContextWithCallID(ctx, call.ID)
 
-	heartbeatDone := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				send.TrySend(Event{Type: EventHeartbeat, ToolCallID: call.ID, ToolName: call.Name})
-			case <-heartbeatDone:
-				return
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-	defer close(heartbeatDone)
+	stopHeartbeat := startToolHeartbeat(ctx, call.ID, call.Name, send)
+	defer stopHeartbeat()
 
 	output, err := tool.Execute(toolCtx, call.Arguments)
 	info := e.getToolPreview(call)

--- a/internal/llm/engine_benchmark_test.go
+++ b/internal/llm/engine_benchmark_test.go
@@ -1,0 +1,66 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fastBenchmarkTool struct{}
+
+func (t *fastBenchmarkTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "fast_benchmark_tool",
+		Description: "fast no-op benchmark tool",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (t *fastBenchmarkTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	return TextOutput("ok"), nil
+}
+
+func (t *fastBenchmarkTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
+func BenchmarkExecuteSingleToolCallFast(b *testing.B) {
+	registry := NewToolRegistry()
+	registry.Register(&fastBenchmarkTool{})
+	engine := NewEngine(&fakeProvider{}, registry)
+	call := ToolCall{
+		ID:        "call-bench",
+		Name:      "fast_benchmark_tool",
+		Arguments: json.RawMessage(`{}`),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := make(chan Event, 1024)
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			select {
+			case <-events:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	send := eventSender{ctx: ctx, ch: events}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msgs, err := engine.executeSingleToolCall(ctx, call, send, false, false)
+		if err != nil {
+			b.Fatalf("executeSingleToolCall returned error: %v", err)
+		}
+		if len(msgs) != 1 {
+			b.Fatalf("executeSingleToolCall returned %d messages, want 1", len(msgs))
+		}
+	}
+	b.StopTimer()
+	cancel()
+	<-drained
+}


### PR DESCRIPTION
## What

Defers per-tool heartbeat machinery until a tool has actually been running for `toolHeartbeatInterval`.

Previously every tool execution immediately spawned a goroutine and ticker just in case it lasted long enough to need heartbeat events. Most terminal tools complete well under 10 seconds, so that work was paid on the hot path and usually did nothing.

This change keeps the same heartbeat interval and event shape, but schedules the heartbeat loop with `time.AfterFunc`; fast tools stop the timer before any heartbeat goroutine/ticker starts.

## Why

Agentic turns can execute many quick tools (`read_file`, `grep`, small shell commands). Avoiding an unconditional heartbeat goroutine reduces per-tool scheduling overhead in the provider/tool streaming path.

## Evidence

Added `BenchmarkExecuteSingleToolCallFast` to exercise a fast tool execution with an event channel.

Before:

```text
BenchmarkExecuteSingleToolCallFast-32  ~981-1038 ns/op  1144 B/op  14 allocs/op
```

After:

```text
BenchmarkExecuteSingleToolCallFast-32  ~737-759 ns/op   1184 B/op  14 allocs/op
```

Representative focused run after the change:

```text
go test ./internal/llm -run 'TestExecuteSingleToolCallDoesNotDeadlockOnBlockedToolExecEndWhenCancelled|TestExecuteToolCallsParallelReturnsOnContextCancel|TestEngineParallelToolExecution' -bench BenchmarkExecuteSingleToolCallFast -benchmem -count=10
```

## Verification

```text
gofmt -w internal/llm/engine.go internal/llm/engine_benchmark_test.go
go test ./internal/llm
go build ./...
go test ./...
```
