### PR TITLE
perf: cover session message count lookups

### DIFF
--- a/internal/session/list_bench_test.go
+++ b/internal/session/list_bench_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func BenchmarkSQLiteStoreListWithLargeHistories(b *testing.B) {
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "sessions.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		b.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	const sessionCount = 120
+	const messagesPerSession = 400
+	base := time.Now().Add(-time.Duration(sessionCount) * time.Minute).UTC().Truncate(time.Second)
+	seedSQLiteStoreListBenchmark(b, ctx, store, sessionCount, messagesPerSession, base)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		summaries, err := store.List(ctx, ListOptions{Limit: 50, SortByActivity: true})
+		if err != nil {
+			b.Fatalf("List: %v", err)
+		}
+		if len(summaries) != 50 {
+			b.Fatalf("got %d summaries, want 50", len(summaries))
+		}
+	}
+}
+
+func seedSQLiteStoreListBenchmark(b *testing.B, ctx context.Context, store *SQLiteStore, sessionCount, messagesPerSession int, base time.Time) {
+	b.Helper()
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		b.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	sessStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO sessions (id, number, name, summary, provider, model, mode, origin, created_at, updated_at, last_user_message_at, last_message_at, archived, pinned, status)
+		VALUES (?, ?, '', '', 'test', 'test-model', 'chat', 'web', ?, ?, ?, ?, FALSE, FALSE, 'active')`)
+	if err != nil {
+		b.Fatalf("prepare session insert: %v", err)
+	}
+	defer sessStmt.Close()
+
+	msgStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO messages (session_id, role, parts, text_content, created_at, sequence)
+		VALUES (?, ?, '[]', 'hello', ?, ?)`)
+	if err != nil {
+		b.Fatalf("prepare message insert: %v", err)
+	}
+	defer msgStmt.Close()
+
+	for i := 0; i < sessionCount; i++ {
+		sessionID := fmt.Sprintf("sess-%03d", i)
+		createdAt := base.Add(time.Duration(i) * time.Minute)
+		lastVisibleAt := createdAt.Add(time.Duration(messagesPerSession-1) * time.Second)
+		if _, err := sessStmt.ExecContext(ctx, sessionID, i+1, createdAt, lastVisibleAt, createdAt, lastVisibleAt); err != nil {
+			b.Fatalf("insert session %d: %v", i, err)
+		}
+		for j := 0; j < messagesPerSession; j++ {
+			role := "user"
+			if j%2 == 1 {
+				role = "assistant"
+			}
+			if j%10 == 0 {
+				role = "tool"
+			}
+			if _, err := msgStmt.ExecContext(ctx, sessionID, role, createdAt.Add(time.Duration(j)*time.Second), j); err != nil {
+				b.Fatalf("insert message %d/%d: %v", i, j, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("Commit: %v", err)
+	}
+}

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE INDEX IF NOT EXISTS idx_sessions_updated_at ON sessions(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_mode ON sessions(mode);
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, sequence);
+CREATE INDEX IF NOT EXISTS idx_messages_session_role ON messages(session_id, role);
 
 -- Metadata table for current session tracking
 CREATE TABLE IF NOT EXISTS metadata (
@@ -203,7 +204,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 20
+const schemaVersion = 21
 
 // migration represents a schema migration.
 type migration struct {
@@ -669,6 +670,23 @@ var migrations = []migration{
 			_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_sessions_last_message ON sessions(last_message_at DESC)`)
 			if err != nil {
 				return fmt.Errorf("create last_message_at index: %w", err)
+			}
+			return nil
+		},
+	},
+	{
+		// Migration 21: Add a covering index for List()'s per-session visible
+		// message counts. The existing (session_id, sequence) index is ideal for
+		// ordered history reads, but COUNT(*) WHERE session_id=? AND role IN (...)
+		// otherwise has to visit every row for the session and read role from the
+		// table. Keeping role in the index lets SQLite satisfy the sidebar count
+		// subquery from the index alone.
+		version:     21,
+		description: "add covering index for visible message counts",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_messages_session_role ON messages(session_id, role)`)
+			if err != nil {
+				return fmt.Errorf("create messages session role index: %w", err)
 			}
 			return nil
 		},

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -664,6 +664,40 @@ func TestUpdateDoesNotClobberTokenMetrics(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreCreatesMessagesSessionRoleIndex(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	rows, err := store.db.Query(`PRAGMA index_list(messages)`)
+	if err != nil {
+		t.Fatalf("PRAGMA index_list(messages): %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var seq int
+		var name string
+		var unique int
+		var origin string
+		var partial int
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			t.Fatalf("scan index_list row: %v", err)
+		}
+		if name == "idx_messages_session_role" {
+			return
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate index_list: %v", err)
+	}
+	t.Fatal("idx_messages_session_role index was not created")
+}
+
 func TestSQLiteStoreCustomPath(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "custom", "sessions.db")
 


### PR DESCRIPTION
## What

Adds a covering SQLite index on `messages(session_id, role)` and migration v21 so session listing can compute visible user/assistant message counts from an index instead of walking each session's ordered history rows.

Also adds:
- a schema test asserting the new index exists
- a benchmark for `SQLiteStore.List` with many sessions that each have large histories

## Why

`SQLiteStore.List` returns the sidebar/session-list `message_count` using a correlated subquery:

```sql
SELECT COUNT(*) FROM messages
WHERE session_id = s.id AND role IN ('user', 'assistant')
```

The existing `messages(session_id, sequence)` index is optimized for ordered transcript reads, but it does not cover `role`; on large histories SQLite has to visit each row for every listed session to apply the visible-role filter. The new index keeps `role` next to `session_id`, making that count lookup index-only while preserving the existing transcript ordering index.

## Evidence

Focused benchmark on this machine (`go test ./internal/session -run '^$' -bench BenchmarkSQLiteStoreListWithLargeHistories -benchmem -count=3`) with 120 sessions × 400 messages, listing the 50 most recent web/activity sessions:

Before:

```text
BenchmarkSQLiteStoreListWithLargeHistories-32    478   2485910 ns/op   102906 B/op   2049 allocs/op
BenchmarkSQLiteStoreListWithLargeHistories-32    471   2492009 ns/op   102905 B/op   2049 allocs/op
BenchmarkSQLiteStoreListWithLargeHistories-32    483   2467169 ns/op   102904 B/op   2049 allocs/op
```

After:

```text
BenchmarkSQLiteStoreListWithLargeHistories-32    954   1078408 ns/op   102910 B/op   2049 allocs/op
BenchmarkSQLiteStoreListWithLargeHistories-32   1014   1066302 ns/op   102905 B/op   2049 allocs/op
BenchmarkSQLiteStoreListWithLargeHistories-32   1064   1054205 ns/op   102910 B/op   2049 allocs/op
```

That is roughly a 2.3× faster `List` path for large session histories, with unchanged allocations.

## Verification

```text
go test ./internal/session
go build ./...
go test ./...
```
