### PR TITLE
fix: SSRF protection in read_url is bypassed by the actual Jina fetch

### DIFF
--- a/internal/llm/read_url_tool.go
+++ b/internal/llm/read_url_tool.go
@@ -34,7 +34,7 @@ type readURLTarget struct {
 	ips []net.IP
 }
 
-// ReadURLTool fetches web pages using Jina AI Reader.
+// ReadURLTool fetches web pages with SSRF protections.
 type ReadURLTool struct {
 	client *http.Client
 }
@@ -65,7 +65,7 @@ func (t *ReadURLTool) Preview(args json.RawMessage) string {
 func ReadURLToolSpec() ToolSpec {
 	return ToolSpec{
 		Name:        ReadURLToolName,
-		Description: "Fetch and read a web page. Returns the page content as clean markdown. Use this to read full content from URLs found in search results.",
+		Description: "Fetch and read a web page. Returns the page content. Use this to read full content from URLs found in search results.",
 		Schema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -92,20 +92,19 @@ func (t *ReadURLTool) Execute(ctx context.Context, args json.RawMessage) (ToolOu
 		return ToolOutput{}, fmt.Errorf("url is required")
 	}
 
-	url, err := resolveReadURLTarget(ctx, t.client, payload.URL)
+	target, err := resolveReadURLTarget(ctx, t.client, payload.URL)
 	if err != nil {
 		return ToolOutput{}, err
 	}
 
-	// Fetch via Jina AI Reader
-	jinaURL := "https://r.jina.ai/" + url
+	fetchClient := newReadURLRedirectClient(t.client, target.ips)
 
-	req, err := http.NewRequestWithContext(ctx, "GET", jinaURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.url, nil)
 	if err != nil {
 		return ToolOutput{}, fmt.Errorf("create request: %w", err)
 	}
 
-	resp, err := t.client.Do(req)
+	resp, err := fetchClient.Do(req)
 	if err != nil {
 		return TextOutput(fmt.Sprintf("Error fetching URL: %v", err)), nil
 	}
@@ -158,10 +157,10 @@ func readURLContent(r io.Reader) (string, bool, error) {
 	return content.String(), true, nil
 }
 
-func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL string) (string, error) {
+func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL string) (readURLTarget, error) {
 	target, err := normalizeReadURLTarget(ctx, rawURL)
 	if err != nil {
-		return "", err
+		return readURLTarget{}, err
 	}
 
 	for range maxReadURLRedirects {
@@ -169,36 +168,36 @@ func resolveReadURLTarget(ctx context.Context, client *http.Client, rawURL strin
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.url, nil)
 		if err != nil {
-			return "", fmt.Errorf("create redirect check request: %w", err)
+			return readURLTarget{}, fmt.Errorf("create redirect check request: %w", err)
 		}
 
 		resp, err := redirectClient.Do(req)
 		if err != nil {
-			return "", fmt.Errorf("check url redirects: %w", err)
+			return readURLTarget{}, fmt.Errorf("check url redirects: %w", err)
 		}
 		_ = resp.Body.Close()
 
 		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
-			return target.url, nil
+			return target, nil
 		}
 
 		location := resp.Header.Get("Location")
 		if location == "" {
-			return "", fmt.Errorf("redirect response missing location header")
+			return readURLTarget{}, fmt.Errorf("redirect response missing location header")
 		}
 
 		nextURL, err := req.URL.Parse(location)
 		if err != nil {
-			return "", fmt.Errorf("parse redirect location: %w", err)
+			return readURLTarget{}, fmt.Errorf("parse redirect location: %w", err)
 		}
 
 		target, err = normalizeReadURLTarget(ctx, nextURL.String())
 		if err != nil {
-			return "", err
+			return readURLTarget{}, err
 		}
 	}
 
-	return "", fmt.Errorf("too many redirects")
+	return readURLTarget{}, fmt.Errorf("too many redirects")
 }
 
 func newReadURLRedirectClient(client *http.Client, ips []net.IP) *http.Client {

--- a/internal/llm/read_url_tool_test.go
+++ b/internal/llm/read_url_tool_test.go
@@ -2,11 +2,13 @@ package llm
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -43,22 +45,24 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 	defer func() { readURLLookupIP = origLookup }()
 
 	readErr := errors.New("read past limit")
-	capturedJinaURL := ""
 	capturedTargetURLs := []string{}
 	tool := NewReadURLTool()
 	tool.client = &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			switch req.URL.Host {
-			case "example.com":
-				capturedTargetURLs = append(capturedTargetURLs, req.URL.String())
+			if req.URL.Host != "example.com" {
+				t.Fatalf("unexpected host %q", req.URL.Host)
+			}
+
+			capturedTargetURLs = append(capturedTargetURLs, req.URL.String())
+			switch len(capturedTargetURLs) {
+			case 1:
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader("ok")),
 					Header:     make(http.Header),
 					Request:    req,
 				}, nil
-			case "r.jina.ai":
-				capturedJinaURL = req.URL.String()
+			case 2:
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: &failAfterNReadCloser{
@@ -69,7 +73,7 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 					Request: req,
 				}, nil
 			default:
-				t.Fatalf("unexpected host %q", req.URL.Host)
+				t.Fatalf("unexpected request count %d", len(capturedTargetURLs))
 				return nil, nil
 			}
 		}),
@@ -84,14 +88,13 @@ func TestReadURLToolExecuteLimitsBodyReadBeforeTruncating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if got, want := len(capturedTargetURLs), 1; got != want {
-		t.Fatalf("expected %d target preflight request, got %d (%v)", want, got, capturedTargetURLs)
+	if got, want := len(capturedTargetURLs), 2; got != want {
+		t.Fatalf("expected %d target requests, got %d (%v)", want, got, capturedTargetURLs)
 	}
-	if got, want := capturedTargetURLs[0], "https://example.com/article"; got != want {
-		t.Fatalf("expected preflight URL %q, got %q", want, got)
-	}
-	if got, want := capturedJinaURL, "https://r.jina.ai/https://example.com/article"; got != want {
-		t.Fatalf("expected fetch URL %q, got %q", want, got)
+	for i, got := range capturedTargetURLs {
+		if want := "https://example.com/article"; got != want {
+			t.Fatalf("expected request %d URL %q, got %q", i, want, got)
+		}
 	}
 	if strings.Contains(out.Content, readErr.Error()) {
 		t.Fatalf("expected limited read to avoid body read error, got %q", out.Content)
@@ -120,19 +123,25 @@ func TestReadURLToolExecuteTruncatesByRunes(t *testing.T) {
 	defer func() { readURLLookupIP = origLookup }()
 
 	body := strings.Repeat("界", maxReadURLChars) + "🙂tail"
+	requests := 0
 
 	tool := NewReadURLTool()
 	tool.client = &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			switch req.URL.Host {
-			case "example.com":
+			if req.URL.Host != "example.com" {
+				t.Fatalf("unexpected host %q", req.URL.Host)
+			}
+
+			requests++
+			switch requests {
+			case 1:
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader("ok")),
 					Header:     make(http.Header),
 					Request:    req,
 				}, nil
-			case "r.jina.ai":
+			case 2:
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),
@@ -140,7 +149,7 @@ func TestReadURLToolExecuteTruncatesByRunes(t *testing.T) {
 					Request:    req,
 				}, nil
 			default:
-				t.Fatalf("unexpected host %q", req.URL.Host)
+				t.Fatalf("unexpected request count %d", requests)
 				return nil, nil
 			}
 		}),
@@ -290,7 +299,7 @@ func TestReadURLToolExecuteRejectsRedirectsToBlockedHosts(t *testing.T) {
 	}
 }
 
-func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeJinaFetch(t *testing.T) {
+func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeFetchingContent(t *testing.T) {
 	origLookup := readURLLookupIP
 	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
 		switch host {
@@ -306,7 +315,7 @@ func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeJinaFetch(t *testing.T) 
 	defer func() { readURLLookupIP = origLookup }()
 
 	requests := []string{}
-	capturedJinaURL := ""
+	wwwRequests := 0
 	tool := NewReadURLTool()
 	tool.client = &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -322,17 +331,14 @@ func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeJinaFetch(t *testing.T) 
 					Request: req,
 				}, nil
 			case "www.example.com":
+				wwwRequests++
+				body := "ok"
+				if wwwRequests == 2 {
+					body = "content"
+				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader("ok")),
-					Header:     make(http.Header),
-					Request:    req,
-				}, nil
-			case "r.jina.ai":
-				capturedJinaURL = req.URL.String()
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader("content")),
+					Body:       io.NopCloser(strings.NewReader(body)),
 					Header:     make(http.Header),
 					Request:    req,
 				}, nil
@@ -352,14 +358,73 @@ func TestReadURLToolExecuteFollowsAllowedRedirectsBeforeJinaFetch(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if got, want := capturedJinaURL, "https://r.jina.ai/https://www.example.com/article"; got != want {
-		t.Fatalf("expected Jina fetch URL %q, got %q", want, got)
-	}
 	if got, want := out.Content, "content"; got != want {
 		t.Fatalf("expected content %q, got %q", want, got)
 	}
 	if got, want := len(requests), 3; got != want {
 		t.Fatalf("expected %d total requests, got %d (%v)", want, got, requests)
+	}
+	if got, want := requests[0], "https://example.com/start"; got != want {
+		t.Fatalf("expected first request %q, got %q", want, got)
+	}
+	if got, want := requests[1], "https://www.example.com/article"; got != want {
+		t.Fatalf("expected second request %q, got %q", want, got)
+	}
+	if got, want := requests[2], "https://www.example.com/article"; got != want {
+		t.Fatalf("expected third request %q, got %q", want, got)
+	}
+}
+
+func TestReadURLToolExecutePinsValidatedIPsDuringFetch(t *testing.T) {
+	origLookup := readURLLookupIP
+	readURLLookupIP = func(ctx context.Context, host string) ([]net.IP, error) {
+		if host != "example.com" {
+			t.Fatalf("unexpected host lookup %q", host)
+		}
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	defer func() { readURLLookupIP = origLookup }()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "content")
+	}))
+	defer server.Close()
+
+	origDial := readURLDialContext
+	dialedAddrs := []string{}
+	readURLDialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialedAddrs = append(dialedAddrs, address)
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	defer func() { readURLDialContext = origDial }()
+
+	tool := NewReadURLTool()
+	tool.client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	args, err := json.Marshal(map[string]string{"url": "https://example.com/article"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if got, want := out.Content, "content"; got != want {
+		t.Fatalf("expected content %q, got %q", want, got)
+	}
+	if got, want := len(dialedAddrs), 2; got != want {
+		t.Fatalf("expected %d dial attempts, got %d (%v)", want, got, dialedAddrs)
+	}
+	for i, got := range dialedAddrs {
+		if want := "93.184.216.34:443"; got != want {
+			t.Fatalf("expected dial %d address %q, got %q", i, want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Stop `read_url` from handing the validated target off to `r.jina.ai` for the real fetch.

The tool now:
- keeps the existing host/IP and redirect validation
- returns the final validated URL together with its resolved IPs
- fetches the final URL directly with a transport pinned to those validated IPs
- adds test coverage for direct fetch behavior and IP pinning during the actual fetch

## Why

The old code validated the URL locally, but then asked Jina to resolve and fetch it from Jina's network. That meant the SSRF checks were not enforced at the point of network access, so split-horizon DNS, rebinding, or provider-local internal names could still make Jina reach internal resources.

Fetching the validated final URL directly closes that gap by ensuring the request goes only to the IPs that were checked locally.
