### PR TITLE
fix: Fresh /v1/responses requests delete response-id mappings before the run succeeds

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -120,7 +120,6 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if freshConversation {
-		s.unregisterSessionResponseIDs(sessionID)
 		s.syncPersistedSessionRuntime(ctx, sessionID, runtime, strings.TrimSpace(req.Model), normalizeReasoningEffort(req.ReasoningEffort))
 	}
 
@@ -200,9 +199,9 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 
 	if req.Stream {
 		if isServeUIRequest(r) && stateful {
-			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID)
+			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID, freshConversation)
 		} else {
-			started := s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID)
+			started := s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID, freshConversation)
 			if !stateful && started {
 				cleanupRuntime = false
 			}
@@ -238,7 +237,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	setSessionNumberHeader(w, runtime)
 
 	created := time.Now().Unix()
-	respID, err := s.storeCompletedResponseRun(runtime, sessionID, req.PreviousResponseID, model, created, result)
+	respID, err := s.storeCompletedResponseRun(runtime, sessionID, req.PreviousResponseID, model, created, result, freshConversation)
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
@@ -342,8 +341,9 @@ func appendResponsePassthroughTools(serverTools []llm.ToolSpec, passthroughTools
 	return serverTools
 }
 
-func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string) bool {
+func (s *serveServer) streamResponses(ctx context.Context, w http.ResponseWriter, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string, resetResponseIDsOnSuccess bool) bool {
 	return s.streamResponseRun(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, startResponseRunOptions{
-		previousResponseID: previousResponseID,
+		previousResponseID:        previousResponseID,
+		resetResponseIDsOnSuccess: resetResponseIDsOnSuccess,
 	})
 }

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -80,8 +80,9 @@ type responseRun struct {
 }
 
 type startResponseRunOptions struct {
-	previousResponseID string
-	uiSession          bool
+	previousResponseID        string
+	uiSession                 bool
+	resetResponseIDsOnSuccess bool
 }
 
 func newResponseRun(respID, sessionID, previousResponseID, model string, created int64, cancel context.CancelFunc) *responseRun {
@@ -909,7 +910,7 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 	}
 }
 
-func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID, previousResponseID, model string, created int64, result serveRunResult) (string, error) {
+func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID, previousResponseID, model string, created int64, result serveRunResult, resetResponseIDsOnSuccess bool) (string, error) {
 	mgr := s.ensureResponseRuns()
 
 	respID := "resp_" + randomSuffix()
@@ -958,6 +959,9 @@ func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID
 	}
 
 	mgr.scheduleCleanup(respID)
+	if resetResponseIDsOnSuccess {
+		s.unregisterSessionResponseIDs(sessionID)
+	}
 	s.registerResponseID(runtime, respID, sessionID)
 	return respID, nil
 }
@@ -1238,6 +1242,9 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 
 		if options.uiSession {
 			runtime.clearLastUIRunError()
+		}
+		if options.resetResponseIDsOnSuccess {
+			s.unregisterSessionResponseIDs(sessionID)
 		}
 		s.registerResponseID(runtime, respID, sessionID)
 		if err := run.complete(map[string]any{

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4486,6 +4486,55 @@ func TestHandleResponses_FreshConversationResetRemovesStalePreviousResponseIDs(t
 	}
 }
 
+func TestHandleResponses_FreshConversationResetPreservesPreviousResponseIDsWhenRunFails(t *testing.T) {
+	srv := newTestServeServer("reply1", "reply2")
+	defer srv.sessionMgr.Close()
+
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"msg1"}`, "fresh-reset-busy")
+	if code != http.StatusOK {
+		t.Fatalf("msg1 status = %d, want 200", code)
+	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
+
+	rt, ok := srv.sessionMgr.Get("fresh-reset-busy")
+	if !ok || rt == nil {
+		t.Fatal("expected runtime for fresh-reset-busy")
+	}
+
+	busyState := &runtimeInterruptState{cancel: func() {}, done: make(chan struct{})}
+	rt.mu.Lock()
+	rt.setActiveInterrupt(busyState)
+	defer func() {
+		rt.clearActiveInterrupt(busyState)
+		rt.mu.Unlock()
+	}()
+
+	code, _ = doResponsesWithHeader(t, srv, `{"input":"reset"}`, "fresh-reset-busy")
+	if code != http.StatusConflict {
+		t.Fatalf("reset status = %d, want 409", code)
+	}
+
+	mapped, ok := srv.responseToSession.Load(respID1)
+	if !ok {
+		t.Fatalf("responseToSession missing %q after failed fresh reset", respID1)
+	}
+	mappedSessionID, _ := mapped.(string)
+	if mappedSessionID != "fresh-reset-busy" {
+		t.Fatalf("responseToSession[%q] = %q, want %q", respID1, mappedSessionID, "fresh-reset-busy")
+	}
+	latest, ok := srv.sessionToResponse.Load("fresh-reset-busy")
+	if !ok {
+		t.Fatal("sessionToResponse missing fresh-reset-busy after failed reset")
+	}
+	latestID, _ := latest.(string)
+	if latestID != respID1 {
+		t.Fatalf("sessionToResponse = %q, want %q", latestID, respID1)
+	}
+}
+
 func TestHandleResponses_PreviousResponseIDChainsSession(t *testing.T) {
 	// Each runtime gets 2 text responses so it can handle 2 messages
 	srv := newTestServeServer("first reply", "second reply")

--- a/cmd/serve_ui_stream.go
+++ b/cmd/serve_ui_stream.go
@@ -14,7 +14,7 @@ func isServeUIRequest(r *http.Request) bool {
 	return value == "1" || value == "true" || value == "yes"
 }
 
-func (s *serveServer) streamUIResponses(w http.ResponseWriter, r *http.Request, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string) {
+func (s *serveServer) streamUIResponses(w http.ResponseWriter, r *http.Request, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string, resetResponseIDsOnSuccess bool) {
 	// Persist session in the store so the client gets the session number in
 	// headers before the streaming body begins. This is a store-only operation
 	// that does NOT mutate runtime state (safe without rt.mu).
@@ -23,8 +23,9 @@ func (s *serveServer) streamUIResponses(w http.ResponseWriter, r *http.Request, 
 	}
 
 	s.streamResponseRun(r.Context(), w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, startResponseRunOptions{
-		previousResponseID: previousResponseID,
-		uiSession:          true,
+		previousResponseID:        previousResponseID,
+		uiSession:                 true,
+		resetResponseIDsOnSuccess: resetResponseIDsOnSuccess,
 	})
 }
 


### PR DESCRIPTION
## What

Delay fresh `/v1/responses` response-id reset until the replacement run actually succeeds.

This moves `unregisterSessionResponseIDs(sessionID)` out of the handler's eager fresh-conversation setup and into the successful completion paths for both non-streaming and streaming responses, so old mappings are only cleared immediately before the new response ID is registered.

Also adds a regression test that reuses a `session_id` for a fresh request while the existing session is busy and verifies the prior `response_id -> session_id` mappings remain intact after the failed reset.

## Why

Fresh requests were deleting all response-id mappings for the session before the new run had started or finished successfully. If the reset request then failed, previously valid `previous_response_id` values stopped resolving even though the replacement conversation never completed.
