### PR TITLE
perf: reduce Jobs V2 idle polling

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -221,6 +221,14 @@ var (
 	jobsV2ProgramWaitDelay   time.Duration = time.Second
 )
 
+const (
+	jobsV2SchedulerMinDelay  = 100 * time.Millisecond
+	jobsV2SchedulerIdleDelay = time.Minute
+	jobsV2WorkerMinDelay     = 100 * time.Millisecond
+	jobsV2WorkerIdleDelay    = time.Minute
+	jobsV2WorkerErrorDelay   = 200 * time.Millisecond
+)
+
 type jobsV2ProgramConfig struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args,omitempty"`
@@ -467,7 +475,9 @@ type jobsV2Manager struct {
 	workers  int
 	workerID string
 	runners  map[jobsV2RunnerType]jobsV2Runner
-	tick     time.Duration
+	// Idle timers are only fallbacks; job/run mutations wake the loops immediately.
+	schedulerIdleDelay time.Duration
+	workerIdleDelay    time.Duration
 	// Retention settings for protecting disk usage.
 	retentionRunDays     int
 	retentionEventDays   int
@@ -475,10 +485,13 @@ type jobsV2Manager struct {
 	cleanupInterval      time.Duration
 	lastCleanupCompleted time.Time
 
-	mu      sync.Mutex
-	closed  bool
-	wg      sync.WaitGroup
-	cancels map[string]context.CancelFunc
+	mu            sync.Mutex
+	closed        bool
+	done          chan struct{}
+	schedulerWake chan struct{}
+	workerWake    chan struct{}
+	wg            sync.WaitGroup
+	cancels       map[string]context.CancelFunc
 }
 
 const jobsV2Schema = `
@@ -592,10 +605,11 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 	}
 
 	mgr := &jobsV2Manager{
-		db:       db,
-		workers:  workers,
-		workerID: "worker_" + randomSuffix(),
-		tick:     time.Second,
+		db:                 db,
+		workers:            workers,
+		workerID:           "worker_" + randomSuffix(),
+		schedulerIdleDelay: jobsV2SchedulerIdleDelay,
+		workerIdleDelay:    jobsV2WorkerIdleDelay,
 		// Conservative defaults: enough history for debugging without unbounded growth.
 		retentionRunDays:    30,
 		retentionEventDays:  30,
@@ -605,7 +619,10 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 			jobsV2RunnerProgram: &jobsV2ProgramRunner{},
 			jobsV2RunnerLLM:     &jobsV2LLMRunner{exec: llmExec},
 		},
-		cancels: make(map[string]context.CancelFunc),
+		done:          make(chan struct{}),
+		schedulerWake: make(chan struct{}, 1),
+		workerWake:    make(chan struct{}, max(1, workers)),
+		cancels:       make(map[string]context.CancelFunc),
 	}
 
 	if err := mgr.recoverRuns(); err != nil {
@@ -667,6 +684,9 @@ func (m *jobsV2Manager) Close() error {
 		return nil
 	}
 	m.closed = true
+	if m.done != nil {
+		close(m.done)
+	}
 	cancels := make([]context.CancelFunc, 0, len(m.cancels))
 	for _, cancel := range m.cancels {
 		cancels = append(cancels, cancel)
@@ -682,22 +702,99 @@ func (m *jobsV2Manager) Close() error {
 
 func (m *jobsV2Manager) schedulerLoop() {
 	defer m.wg.Done()
-	ticker := time.NewTicker(m.tick)
-	defer ticker.Stop()
+	timer := time.NewTimer(0)
+	defer timer.Stop()
 
 	for {
+		select {
+		case <-m.doneChan():
+			return
+		case <-timer.C:
+		case <-m.schedulerWake:
+			stopTimer(timer)
+		}
 		if m.isClosed() {
 			return
 		}
-		now := time.Now()
+
+		now := time.Now().UTC()
 		_ = m.scheduleDueRuns(now)
 		_ = m.maybeRunCleanup(now)
+		resetTimer(timer, m.nextSchedulerDelay(time.Now().UTC()))
+	}
+}
+
+func (m *jobsV2Manager) doneChan() <-chan struct{} {
+	if m.done == nil {
+		return nil
+	}
+	return m.done
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
 		select {
-		case <-ticker.C:
+		case <-timer.C:
 		default:
-			time.Sleep(100 * time.Millisecond)
 		}
 	}
+}
+
+func resetTimer(timer *time.Timer, delay time.Duration) {
+	stopTimer(timer)
+	timer.Reset(delay)
+}
+
+func clampJobsV2Delay(delay, minDelay, idleDelay time.Duration) time.Duration {
+	if idleDelay <= 0 {
+		idleDelay = time.Minute
+	}
+	if delay < 0 {
+		delay = 0
+	}
+	if delay > idleDelay {
+		delay = idleDelay
+	}
+	if minDelay > 0 && delay < minDelay {
+		delay = minDelay
+	}
+	return delay
+}
+
+func (m *jobsV2Manager) nextSchedulerDelay(now time.Time) time.Duration {
+	idleDelay := m.schedulerIdleDelay
+	if idleDelay <= 0 {
+		idleDelay = jobsV2SchedulerIdleDelay
+	}
+	delay := idleDelay
+
+	var nextRun sql.NullTime
+	if err := m.db.QueryRow(`SELECT next_run_at FROM jobs_v2 WHERE enabled = 1 AND next_run_at IS NOT NULL ORDER BY next_run_at ASC LIMIT 1`).Scan(&nextRun); err == nil && nextRun.Valid {
+		delay = minDuration(delay, nextRun.Time.UTC().Sub(now.UTC()))
+	}
+
+	if m.cleanupInterval > 0 {
+		m.mu.Lock()
+		lastCleanup := m.lastCleanupCompleted
+		m.mu.Unlock()
+		cleanupDelay := time.Duration(0)
+		if !lastCleanup.IsZero() {
+			cleanupDelay = lastCleanup.Add(m.cleanupInterval).Sub(now.UTC())
+		}
+		delay = minDuration(delay, cleanupDelay)
+	}
+
+	return clampJobsV2Delay(delay, jobsV2SchedulerMinDelay, idleDelay)
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if b < a {
+		return b
+	}
+	return a
 }
 
 func (m *jobsV2Manager) maybeRunCleanup(now time.Time) error {
@@ -766,26 +863,81 @@ func (m *jobsV2Manager) pruneOldData(now time.Time) error {
 func (m *jobsV2Manager) workerLoop() {
 	defer m.wg.Done()
 	for {
-		if m.isClosed() {
+		select {
+		case <-m.doneChan():
 			return
+		default:
 		}
+
 		run, ok, err := m.claimNextRun()
 		if err != nil {
-			time.Sleep(200 * time.Millisecond)
+			if !m.waitForWorkerWake(jobsV2WorkerErrorDelay) {
+				return
+			}
 			continue
 		}
-		if !ok {
-			time.Sleep(200 * time.Millisecond)
+		if ok {
+			m.executeRun(run)
 			continue
 		}
-		m.executeRun(run)
+		if !m.waitForWorkerWake(m.nextWorkerDelay(time.Now().UTC())) {
+			return
+		}
 	}
+}
+
+func (m *jobsV2Manager) waitForWorkerWake(delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer stopTimer(timer)
+	select {
+	case <-m.doneChan():
+		return false
+	case <-m.workerWake:
+		return true
+	case <-timer.C:
+		return true
+	}
+}
+
+func (m *jobsV2Manager) nextWorkerDelay(now time.Time) time.Duration {
+	idleDelay := m.workerIdleDelay
+	if idleDelay <= 0 {
+		idleDelay = jobsV2WorkerIdleDelay
+	}
+	delay := idleDelay
+
+	var nextRun sql.NullTime
+	if err := m.db.QueryRow(`SELECT scheduled_for FROM job_runs_v2 WHERE status = ? ORDER BY scheduled_for ASC LIMIT 1`, jobsV2RunQueued).Scan(&nextRun); err == nil && nextRun.Valid {
+		delay = minDuration(delay, nextRun.Time.UTC().Sub(now.UTC()))
+	}
+
+	return clampJobsV2Delay(delay, jobsV2WorkerMinDelay, idleDelay)
 }
 
 func (m *jobsV2Manager) isClosed() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.closed
+}
+
+func (m *jobsV2Manager) notifyScheduler() {
+	select {
+	case m.schedulerWake <- struct{}{}:
+	default:
+	}
+}
+
+func (m *jobsV2Manager) notifyWorkers(n int) {
+	if n <= 0 {
+		n = 1
+	}
+	for i := 0; i < n; i++ {
+		select {
+		case m.workerWake <- struct{}{}:
+		default:
+			return
+		}
+	}
 }
 
 func (m *jobsV2Manager) scheduleDueRuns(now time.Time) error {
@@ -855,6 +1007,7 @@ func (m *jobsV2Manager) scheduleOne(job jobsV2Job, now time.Time) error {
 		return err
 	}
 	_ = m.addRunEvent(runID, "queued", "scheduled run queued", map[string]any{"trigger": "schedule", "attempt": 1})
+	m.notifyWorkers(1)
 
 	if job.TriggerType == jobsV2TriggerOnce {
 		_, err = m.db.Exec(`UPDATE jobs_v2 SET enabled = 0, next_run_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, job.ID)
@@ -1035,6 +1188,7 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 				"trigger": "retry",
 				"attempt": attempt + 1,
 			})
+			m.notifyWorkers(1)
 		}
 	}
 
@@ -1218,7 +1372,12 @@ func (m *jobsV2Manager) CreateJob(req jobsV2Job) (jobsV2Job, error) {
 	if err != nil {
 		return jobsV2Job{}, err
 	}
-	return m.GetJob(id)
+	created, err := m.GetJob(id)
+	if err != nil {
+		return jobsV2Job{}, err
+	}
+	m.notifyScheduler()
+	return created, nil
 }
 
 func (m *jobsV2Manager) GetJob(id string) (jobsV2Job, error) {
@@ -1338,7 +1497,12 @@ func (m *jobsV2Manager) UpdateJobPatch(id string, req jobsV2JobRequest) (jobsV2J
 	if err != nil {
 		return jobsV2Job{}, err
 	}
-	return m.GetJob(id)
+	updated, err := m.GetJob(id)
+	if err != nil {
+		return jobsV2Job{}, err
+	}
+	m.notifyScheduler()
+	return updated, nil
 }
 
 func (m *jobsV2Manager) DeleteJob(id string, cancelActive bool) error {
@@ -1353,6 +1517,9 @@ func (m *jobsV2Manager) DeleteJob(id string, cancelActive bool) error {
 		}
 	}
 	_, err := m.db.Exec(`DELETE FROM jobs_v2 WHERE id = ?`, id)
+	if err == nil {
+		m.notifyScheduler()
+	}
 	return err
 }
 
@@ -1384,6 +1551,7 @@ func (m *jobsV2Manager) TriggerJob(id string) (jobsV2Run, error) {
 		return jobsV2Run{}, err
 	}
 	_ = m.addRunEvent(runID, "queued", "manual run queued", map[string]any{"trigger": "manual", "attempt": 1})
+	m.notifyWorkers(1)
 	return m.GetRun(runID)
 }
 

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -894,6 +894,74 @@ func TestJobsV2ClaimNextRunSkipsFutureScheduledQueuedRuns(t *testing.T) {
 	}
 }
 
+func TestJobsV2SchedulerAndWorkerDelayUseTimers(t *testing.T) {
+	mgr := newJobsV2ManagerWithoutLoops(t)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	if got := mgr.nextSchedulerDelay(now); got != jobsV2SchedulerIdleDelay {
+		t.Fatalf("empty scheduler delay = %v, want %v", got, jobsV2SchedulerIdleDelay)
+	}
+	if got := mgr.nextWorkerDelay(now); got != jobsV2WorkerIdleDelay {
+		t.Fatalf("empty worker delay = %v, want %v", got, jobsV2WorkerIdleDelay)
+	}
+
+	nextJobRun := now.Add(2500 * time.Millisecond)
+	_, err := mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, next_run_at, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 30, 'skip', ?, ?, ?)`,
+		"job_timer_delay", "timer-delay", jobsV2RunnerProgram, `{"command":"echo","args":["x"]}`, jobsV2TriggerOnce, `{}`, nextJobRun, now, now)
+	if err != nil {
+		t.Fatalf("insert scheduled job: %v", err)
+	}
+	if got := mgr.nextSchedulerDelay(now); got < 2*time.Second || got > 3*time.Second {
+		t.Fatalf("future scheduler delay = %v, want about 2.5s", got)
+	}
+	_, err = mgr.db.Exec(`UPDATE jobs_v2 SET next_run_at = ? WHERE id = ?`, now.Add(-time.Second), "job_timer_delay")
+	if err != nil {
+		t.Fatalf("mark scheduled job overdue: %v", err)
+	}
+	if got := mgr.nextSchedulerDelay(now); got != jobsV2SchedulerMinDelay {
+		t.Fatalf("overdue scheduler delay = %v, want %v", got, jobsV2SchedulerMinDelay)
+	}
+
+	nextQueuedRun := now.Add(1500 * time.Millisecond)
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'retry', ?, ?, ?, ?)`,
+		"run_timer_delay", "job_timer_delay", nextQueuedRun, jobsV2RunQueued, now, now)
+	if err != nil {
+		t.Fatalf("insert queued run: %v", err)
+	}
+	if got := mgr.nextWorkerDelay(now); got < time.Second || got > 2*time.Second {
+		t.Fatalf("future worker delay = %v, want about 1.5s", got)
+	}
+	_, err = mgr.db.Exec(`UPDATE job_runs_v2 SET scheduled_for = ? WHERE id = ?`, now.Add(-time.Second), "run_timer_delay")
+	if err != nil {
+		t.Fatalf("mark queued run overdue: %v", err)
+	}
+	if got := mgr.nextWorkerDelay(now); got != jobsV2WorkerMinDelay {
+		t.Fatalf("overdue worker delay = %v, want %v", got, jobsV2WorkerMinDelay)
+	}
+}
+
+func newJobsV2ManagerWithoutLoops(t *testing.T) *jobsV2Manager {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := execJobsV2Schema(db); err != nil {
+		_ = db.Close()
+		t.Fatalf("execJobsV2Schema failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return &jobsV2Manager{
+		db:                 db,
+		workerID:           "worker_test",
+		schedulerIdleDelay: jobsV2SchedulerIdleDelay,
+		workerIdleDelay:    jobsV2WorkerIdleDelay,
+		cleanupInterval:    0,
+		cancels:            make(map[string]context.CancelFunc),
+	}
+}
+
 type testJobsV2Runner struct {
 	called bool
 }


### PR DESCRIPTION
## What

Replace Jobs V2's fixed idle polling loops with timer-backed waits and explicit wakeups:

- scheduler sleeps until the next enabled `next_run_at` (or a one-minute idle fallback) and wakes immediately when jobs are created/updated/deleted
- workers sleep until the next queued `scheduled_for` (or a one-minute idle fallback) and wake immediately when manual/scheduled/retry runs are queued
- shutdown now closes a manager `done` channel so long sleeps do not delay server stop

## Why

The previous scheduler loop ignored its one-second ticker in practice and hit the DB every ~100ms while idle. Each worker also opened a claim transaction every 200ms while idle. A jobs-enabled server with one worker therefore did roughly 900 idle loop wakeups/DB checks per minute before any real work.

With this change, the same idle path falls back to about one scheduler wake and one worker wake per minute (plus one indexed next-time lookup for each), while API-triggered work remains immediate through non-blocking wake notifications.

## Evidence

- Added `TestJobsV2SchedulerAndWorkerDelayUseTimers` covering idle delays, future due timers, and overdue minimum-delay clamps.
- Focused Jobs V2 tests pass: `go test ./cmd -run 'TestJobsV2|TestParseTriggerConfigCronUsesScheduleTimezone' -count=1`.
- Full verification passes: `go build ./...` and `go test ./...`.
