### PR TITLE
perf: speed up debug log text search

### DIFF
--- a/internal/debuglog/search.go
+++ b/internal/debuglog/search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -32,6 +33,10 @@ type SearchResult struct {
 
 // Search searches across all sessions for matching entries
 func Search(dir string, opts SearchOptions) ([]SearchResult, error) {
+	if canUseTextQueryFastPath(opts) {
+		return searchTextQuerySessions(dir, opts)
+	}
+
 	sessions, err := ListSessions(dir)
 	if err != nil {
 		return nil, err
@@ -81,6 +86,254 @@ func Search(dir string, opts SearchOptions) ([]SearchResult, error) {
 	}
 
 	return results, nil
+}
+
+func canUseTextQueryFastPath(opts SearchOptions) bool {
+	// Plain text search is the common case for `debug-log search`. It does not
+	// need provider/error summaries, so avoid ListSessions' full JSON parse of
+	// every log before scanning the same files again.
+	return opts.Query != "" && opts.ToolName == "" && opts.Provider == "" && !opts.ErrorsOnly
+}
+
+func searchTextQuerySessions(dir string, opts SearchOptions) ([]SearchResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	cutoff := time.Time{}
+	if opts.Days > 0 {
+		cutoff = time.Now().AddDate(0, 0, -opts.Days)
+	}
+
+	sessions := make([]SessionSummary, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
+			continue
+		}
+
+		filePath := filepath.Join(dir, entry.Name())
+		startTime, err := firstSessionTimestamp(filePath)
+		if err != nil {
+			continue
+		}
+		if opts.Days > 0 && (startTime.IsZero() || !startTime.After(cutoff)) {
+			continue
+		}
+
+		sessions = append(sessions, SessionSummary{
+			ID:        strings.TrimSuffix(entry.Name(), ".jsonl"),
+			FilePath:  filePath,
+			StartTime: startTime,
+		})
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].StartTime.After(sessions[j].StartTime)
+	})
+
+	var results []SearchResult
+	for _, session := range sessions {
+		sessionResults, err := searchSessionTextQuery(session.FilePath, opts.Query)
+		if err != nil {
+			continue
+		}
+		results = append(results, sessionResults...)
+	}
+	return results, nil
+}
+
+func firstSessionTimestamp(filePath string) (time.Time, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		var entry rawEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
+		if err != nil {
+			continue
+		}
+		return ts, nil
+	}
+	return time.Time{}, scanner.Err()
+}
+
+func searchSessionTextQuery(filePath, query string) ([]SearchResult, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	sessionID := strings.TrimSuffix(filepath.Base(filePath), ".jsonl")
+	queryLower := strings.ToLower(query)
+	queryASCII := isASCII(queryLower)
+
+	var results []SearchResult
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Bytes()
+
+		match, matchStr := matchTextQueryLine(line, query, queryLower, queryASCII)
+		if !match {
+			continue
+		}
+
+		var entry rawEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+
+		ts, _ := time.Parse(time.RFC3339Nano, entry.Timestamp)
+		context := entry.EventType
+		if context == "" {
+			context = entry.Type
+		}
+
+		results = append(results, SearchResult{
+			SessionID: sessionID,
+			FilePath:  filePath,
+			LineNum:   lineNum,
+			Timestamp: ts,
+			EntryType: entry.Type,
+			EventType: entry.EventType,
+			Match:     matchStr,
+			Context:   context,
+		})
+	}
+	return results, scanner.Err()
+}
+
+func matchTextQueryLine(line []byte, query, queryLower string, queryASCII bool) (bool, string) {
+	if query == "" {
+		return false, ""
+	}
+
+	if queryASCII {
+		idx := indexFoldASCII(line, queryLower)
+		if idx < 0 {
+			return false, ""
+		}
+		return true, snippetBytes(line, idx, len(query))
+	}
+
+	lineStr := string(line)
+	lineLower := strings.ToLower(lineStr)
+	idx := strings.Index(lineLower, queryLower)
+	if idx < 0 || idx > len(lineStr) {
+		return false, ""
+	}
+	return true, snippetString(lineStr, idx, len(queryLower), len(lineLower))
+}
+
+func snippetBytes(line []byte, idx, queryLen int) string {
+	start := idx - 30
+	if start < 0 {
+		start = 0
+	}
+	end := idx + queryLen + 30
+	if end > len(line) {
+		end = len(line)
+	}
+
+	matchStr := string(line[start:end])
+	if start > 0 {
+		matchStr = "..." + matchStr
+	}
+	if end < len(line) {
+		matchStr += "..."
+	}
+	return matchStr
+}
+
+func snippetString(line string, idx, queryLen, lowerLen int) string {
+	start := idx - 30
+	if start < 0 {
+		start = 0
+	}
+	end := idx + queryLen + 30
+	if end > lowerLen {
+		end = lowerLen
+	}
+	if end > len(line) {
+		end = len(line)
+	}
+	if start > len(line) {
+		start = len(line)
+	}
+	if end < start {
+		end = start
+	}
+
+	matchStr := line[start:end]
+	if start > 0 {
+		matchStr = "..." + matchStr
+	}
+	if end < len(line) {
+		matchStr += "..."
+	}
+	return matchStr
+}
+
+func indexFoldASCII(line []byte, queryLower string) int {
+	if len(queryLower) == 0 {
+		return 0
+	}
+	if len(queryLower) > len(line) {
+		return -1
+	}
+
+	first := queryLower[0]
+	limit := len(line) - len(queryLower)
+	for i := 0; i <= limit; i++ {
+		if asciiLower(line[i]) != first {
+			continue
+		}
+		matched := true
+		for j := 1; j < len(queryLower); j++ {
+			if asciiLower(line[i+j]) != queryLower[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return i
+		}
+	}
+	return -1
+}
+
+func asciiLower(b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 // searchSession searches a single session file
@@ -175,29 +428,9 @@ func matchEntry(entry rawEntry, line []byte, opts SearchOptions) (bool, string, 
 
 	// Text query
 	if opts.Query != "" {
-		query := strings.ToLower(opts.Query)
-		lineStr := strings.ToLower(string(line))
-
-		if strings.Contains(lineStr, query) {
-			// Find the actual matching part
-			idx := strings.Index(lineStr, query)
-			start := idx - 30
-			if start < 0 {
-				start = 0
-			}
-			end := idx + len(query) + 30
-			if end > len(lineStr) {
-				end = len(lineStr)
-			}
-
-			matchStr := string(line)[start:end]
-			if start > 0 {
-				matchStr = "..." + matchStr
-			}
-			if end < len(lineStr) {
-				matchStr = matchStr + "..."
-			}
-
+		queryLower := strings.ToLower(opts.Query)
+		match, matchStr := matchTextQueryLine(line, opts.Query, queryLower, isASCII(queryLower))
+		if match {
 			context := entry.EventType
 			if context == "" {
 				context = entry.Type

--- a/internal/debuglog/search_test.go
+++ b/internal/debuglog/search_test.go
@@ -1,0 +1,94 @@
+package debuglog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSearchTextQueryFiltersByDaysAndReturnsMatches(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	writeDebugSearchFixture(t, dir, "recent", now.Add(-1*time.Hour), []string{
+		debugSearchEventLine(now.Add(-59*time.Minute), "recent", "text_delta", `{"text":"The NeedLe is here"}`),
+	})
+	writeDebugSearchFixture(t, dir, "old", now.Add(-48*time.Hour), []string{
+		debugSearchEventLine(now.Add(-48*time.Hour+time.Minute), "old", "text_delta", `{"text":"needle but too old"}`),
+	})
+
+	results, err := Search(dir, SearchOptions{Query: "needle", Days: 1})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1: %#v", len(results), results)
+	}
+	got := results[0]
+	if got.SessionID != "recent" {
+		t.Fatalf("SessionID = %q, want recent", got.SessionID)
+	}
+	if got.EntryType != "event" || got.EventType != "text_delta" {
+		t.Fatalf("entry = %s/%s, want event/text_delta", got.EntryType, got.EventType)
+	}
+	if !strings.Contains(strings.ToLower(got.Match), "needle") {
+		t.Fatalf("Match = %q, want snippet containing needle", got.Match)
+	}
+}
+
+func BenchmarkSearchTextQuery(b *testing.B) {
+	dir := b.TempDir()
+	base := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	const sessionCount = 12
+	const eventsPerSession = 500
+	for i := 0; i < sessionCount; i++ {
+		sessionID := fmt.Sprintf("bench-%02d", i)
+		start := base.Add(time.Duration(i) * time.Minute)
+		extra := make([]string, 0, eventsPerSession)
+		for j := 0; j < eventsPerSession; j++ {
+			text := fmt.Sprintf("ordinary debug event session=%d line=%d", i, j)
+			if j == eventsPerSession-1 {
+				text = fmt.Sprintf("ordinary debug event with needle session=%d", i)
+			}
+			extra = append(extra, debugSearchEventLine(start.Add(time.Duration(j+1)*time.Second), sessionID, "text_delta", fmt.Sprintf(`{"text":%q}`, text)))
+		}
+		writeDebugSearchFixture(b, dir, sessionID, start, extra)
+	}
+
+	opts := SearchOptions{Query: "needle", Days: 7}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, err := Search(dir, opts)
+		if err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+		if len(results) != sessionCount {
+			b.Fatalf("got %d results, want %d", len(results), sessionCount)
+		}
+	}
+}
+
+func writeDebugSearchFixture(tb testing.TB, dir, sessionID string, start time.Time, extraLines []string) {
+	tb.Helper()
+	path := filepath.Join(dir, sessionID+".jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		tb.Fatalf("create fixture: %v", err)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, `{"timestamp":%q,"session_id":%q,"type":"session_start","command":"term-llm","args":[],"cwd":"/tmp"}`+"\n", start.Format(time.RFC3339Nano), sessionID)
+	fmt.Fprintf(f, `{"timestamp":%q,"session_id":%q,"type":"request","provider":"mock","model":"mock-model","request":{"messages":[]}}`+"\n", start.Add(time.Millisecond).Format(time.RFC3339Nano), sessionID)
+	for _, line := range extraLines {
+		fmt.Fprintln(f, line)
+	}
+}
+
+func debugSearchEventLine(ts time.Time, sessionID, eventType, data string) string {
+	return fmt.Sprintf(`{"timestamp":%q,"session_id":%q,"type":"event","event_type":%q,"data":%s}`,
+		ts.Format(time.RFC3339Nano), sessionID, eventType, data)
+}


### PR DESCRIPTION
## What

Adds a fast path for plain `debug-log search <query>` calls:

- skips the expensive `ListSessions` full-log preparse when no provider/tool/error filters are requested
- filters `--days` from the first session timestamp, preserving recent-first session order
- scans raw JSONL lines with an allocation-light case-insensitive ASCII matcher before decoding JSON
- decodes only matching lines to populate timestamps, event types, and snippets

Also adds a regression test for query/day filtering and a representative benchmark.

## Why

The previous query-only search path parsed every debug log into summaries, then scanned the selected logs again and JSON-decoded every line before checking whether the text query appeared. For normal text searches over large debug logs, that meant duplicate full-file reads and avoidable JSON work on nearly every non-matching line.

## Evidence

`go test ./internal/debuglog -run '^$' -bench 'BenchmarkSearchTextQuery' -benchmem`

Before:

- 17.05-17.87 ms/op
- ~10.19 MB/op
- 144,859 allocs/op

After:

- 1.10-1.12 ms/op
- ~1.61 MB/op
- 464 allocs/op

Verification:

- `go test ./internal/debuglog`
- `go build ./...`
- `go test ./...`
