### PR TITLE
fix: Anthropic message parsing reorders tool results ahead of user text

### DIFF
--- a/cmd/serve_protocol_anthropic.go
+++ b/cmd/serve_protocol_anthropic.go
@@ -161,22 +161,29 @@ func parseAnthropicMessages(msgs []anthropicMessage) ([]llm.Message, error) {
 		switch role {
 		case "user":
 			// Anthropic puts tool_result blocks in user messages.
-			// Split them out into RoleTool messages so the OpenAI-compat
-			// provider can emit proper {"role":"tool"} entries.
-			var userParts, toolParts []llm.Part
-			for _, p := range parts {
-				if p.Type == llm.PartToolResult {
-					toolParts = append(toolParts, p)
-				} else {
-					userParts = append(userParts, p)
+			// Preserve the original mixed-content ordering while still splitting
+			// tool_result runs into RoleTool messages for OpenAI-compat providers.
+			var currentRole llm.Role
+			var currentParts []llm.Part
+			flush := func() {
+				if len(currentParts) == 0 {
+					return
 				}
+				result = append(result, llm.Message{Role: currentRole, Parts: currentParts})
+				currentParts = nil
 			}
-			if len(toolParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleTool, Parts: toolParts})
+			for _, p := range parts {
+				nextRole := llm.RoleUser
+				if p.Type == llm.PartToolResult {
+					nextRole = llm.RoleTool
+				}
+				if len(currentParts) > 0 && currentRole != nextRole {
+					flush()
+				}
+				currentRole = nextRole
+				currentParts = append(currentParts, p)
 			}
-			if len(userParts) > 0 {
-				result = append(result, llm.Message{Role: llm.RoleUser, Parts: userParts})
-			}
+			flush()
 		case "assistant":
 			result = append(result, llm.Message{Role: llm.RoleAssistant, Parts: parts})
 		default:

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -7501,6 +7501,38 @@ func TestParseAnthropicMessages_ToolUseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAnthropicMessages_PreservesMixedUserToolResultOrdering(t *testing.T) {
+	msgs, err := parseAnthropicMessages([]anthropicMessage{
+		{Role: "user", Content: json.RawMessage(`[
+			{"type":"text","text":"before"},
+			{"type":"tool_result","tool_use_id":"call_1","content":"result 1"},
+			{"type":"tool_result","tool_use_id":"call_2","content":"result 2"},
+			{"type":"text","text":"after"}
+		]`)},
+	})
+	if err != nil {
+		t.Fatalf("parseAnthropicMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("len = %d, want 3", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleUser || len(msgs[0].Parts) != 1 || msgs[0].Parts[0].Text != "before" {
+		t.Fatalf("message[0] = %+v, want initial user text", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleTool || len(msgs[1].Parts) != 2 {
+		t.Fatalf("message[1] = %+v, want grouped tool results", msgs[1])
+	}
+	if msgs[1].Parts[0].ToolResult == nil || msgs[1].Parts[0].ToolResult.ID != "call_1" || msgs[1].Parts[0].ToolResult.Content != "result 1" {
+		t.Fatalf("message[1].parts[0] = %+v, want first tool result", msgs[1].Parts[0])
+	}
+	if msgs[1].Parts[1].ToolResult == nil || msgs[1].Parts[1].ToolResult.ID != "call_2" || msgs[1].Parts[1].ToolResult.Content != "result 2" {
+		t.Fatalf("message[1].parts[1] = %+v, want second tool result", msgs[1].Parts[1])
+	}
+	if msgs[2].Role != llm.RoleUser || len(msgs[2].Parts) != 1 || msgs[2].Parts[0].Text != "after" {
+		t.Fatalf("message[2] = %+v, want trailing user text", msgs[2])
+	}
+}
+
 func TestParseAnthropicSystem(t *testing.T) {
 	// String form
 	if got := parseAnthropicSystem(json.RawMessage(`"Be helpful"`)); got != "Be helpful" {


### PR DESCRIPTION
## What

Preserve the original ordering of mixed Anthropic user content when parsing `tool_result` blocks.

The parser now emits consecutive runs of user parts and tool-result parts as separate `llm.Message` entries in the same order they appeared, instead of collecting all tool results first and all remaining user content afterward.

Also adds a regression test covering `text -> tool_result -> tool_result -> text` input.

## Why

Anthropic user messages can legally interleave text and `tool_result` blocks. The previous parser rewrote those messages into `RoleTool` followed by `RoleUser`, which changed conversation semantics and could associate tool results with the wrong surrounding text. Preserving run order keeps the reconstructed conversation faithful to the client payload while still producing `RoleTool` messages for downstream providers.
