### PR TITLE
fix: Evicting a session runtime breaks valid previous_response_id chaining

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -12,6 +12,28 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
+func (s *serveServer) resolveResponseSessionID(respID string) (string, bool) {
+	if sid, ok := s.responseToSession.Load(respID); ok {
+		if sidStr, isStr := sid.(string); isStr && sidStr != "" {
+			return sidStr, true
+		}
+	}
+
+	// Keep previous_response_id chaining working after idle runtime eviction:
+	// the runtime may be gone, but the retained /v1/responses object still knows
+	// which persisted session it belongs to.
+	run, ok := s.ensureResponseRuns().get(respID)
+	if !ok || run == nil {
+		return "", false
+	}
+	sessionID := strings.TrimSpace(run.sessionID)
+	if sessionID == "" {
+		return "", false
+	}
+	s.responseToSession.Store(respID, sessionID)
+	return sessionID, true
+}
+
 func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
@@ -50,15 +72,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	// an existing conversation without explicit chaining.
 	sessionID := ""
 	if req.PreviousResponseID != "" {
-		sid, ok := s.responseToSession.Load(req.PreviousResponseID)
+		sidStr, ok := s.resolveResponseSessionID(req.PreviousResponseID)
 		if !ok {
 			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error",
 				fmt.Sprintf("previous_response_id %q not found (session may have expired)", req.PreviousResponseID))
-			return
-		}
-		sidStr, isStr := sid.(string)
-		if !isStr || sidStr == "" {
-			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "corrupted session mapping")
 			return
 		}
 		sessionID = sidStr

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4486,6 +4486,98 @@ func TestHandleResponses_FreshConversationResetRemovesStalePreviousResponseIDs(t
 	}
 }
 
+func TestHandleResponses_PreviousResponseIDChainsAfterRuntimeEviction(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	var created atomic.Int32
+	providers := map[int32]*llm.MockProvider{}
+
+	manager := newServeSessionManager(time.Minute, 100, func(ctx context.Context) (*serveRuntime, error) {
+		createNum := created.Add(1)
+		provider := llm.NewMockProvider("mock").AddTextResponse(fmt.Sprintf("reply%d", createNum))
+		providers[createNum] = provider
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  "mock",
+			engine:       engine,
+			defaultModel: "mock-model",
+			store:        store,
+		}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager, store: store}
+	manager.onEvict = func(rt *serveRuntime) {
+		for _, rid := range rt.getResponseIDs() {
+			srv.responseToSession.Delete(rid)
+		}
+	}
+
+	code, resp1 := doResponsesWithHeader(t, srv, `{"input":"msg1"}`, "resume-after-evict")
+	if code != http.StatusOK {
+		t.Fatalf("msg1 status = %d, want 200", code)
+	}
+	respID1, _ := resp1["id"].(string)
+	if respID1 == "" {
+		t.Fatal("first response missing id")
+	}
+
+	manager.mu.Lock()
+	evicted := manager.sessions["resume-after-evict"]
+	delete(manager.sessions, "resume-after-evict")
+	manager.mu.Unlock()
+	if evicted != nil {
+		if manager.onEvict != nil {
+			manager.onEvict(evicted)
+		}
+		evicted.Close()
+	}
+	if _, ok := srv.responseToSession.Load(respID1); ok {
+		t.Fatalf("responseToSession should not contain %q after eviction", respID1)
+	}
+
+	code, _ = doResponses(t, srv, `{"input":"msg2","previous_response_id":"`+respID1+`"}`)
+	if code != http.StatusOK {
+		t.Fatalf("msg2 status after eviction = %d, want 200", code)
+	}
+
+	provider := providers[2]
+	if provider == nil {
+		t.Fatal("expected recreated runtime provider")
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("recreated provider request count = %d, want 1", len(provider.Requests))
+	}
+
+	var sawMsg1, sawReply1, sawMsg2 bool
+	for _, msg := range provider.Requests[0].Messages {
+		for _, part := range msg.Parts {
+			if part.Type != llm.PartText {
+				continue
+			}
+			switch part.Text {
+			case "msg1":
+				sawMsg1 = true
+			case "reply1":
+				sawReply1 = true
+			case "msg2":
+				sawMsg2 = true
+			}
+		}
+	}
+	if !sawMsg1 || !sawReply1 || !sawMsg2 {
+		t.Fatalf("rehydrated request missing persisted history: sawMsg1=%v sawReply1=%v sawMsg2=%v", sawMsg1, sawReply1, sawMsg2)
+	}
+}
+
 func TestHandleResponses_PreviousResponseIDChainsSession(t *testing.T) {
 	// Each runtime gets 2 text responses so it can handle 2 messages
 	srv := newTestServeServer("first reply", "second reply")


### PR DESCRIPTION
## What

- fall back to retained response-run metadata when resolving `previous_response_id` to a session after the runtime has been evicted
- repopulate the in-memory response-to-session cache from that retained response object
- add a regression test covering continuation of a persisted conversation after runtime eviction

## Why

Idle runtime eviction was deleting the in-memory `response_id -> session_id` mapping. That made valid chained `/v1/responses` requests fail with `previous_response_id ... not found` before the server had a chance to recreate the runtime from persisted session history. Retained response objects already know their session, so using them as a fallback preserves normal chaining without changing the broader runtime lifecycle.
