### PR TITLE
fix: Job concurrency limits can be bypassed by concurrent trigger/schedule races

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -475,10 +475,11 @@ type jobsV2Manager struct {
 	cleanupInterval      time.Duration
 	lastCleanupCompleted time.Time
 
-	mu      sync.Mutex
-	closed  bool
-	wg      sync.WaitGroup
-	cancels map[string]context.CancelFunc
+	enqueueMu sync.Mutex
+	mu        sync.Mutex
+	closed    bool
+	wg        sync.WaitGroup
+	cancels   map[string]context.CancelFunc
 }
 
 const jobsV2Schema = `
@@ -834,35 +835,61 @@ func (m *jobsV2Manager) countActiveRuns(jobID string) (int, error) {
 	return active, nil
 }
 
+func (m *jobsV2Manager) enqueueRunWithConcurrencyLimit(job jobsV2Job, trigger string, scheduledFor time.Time, onLimit func() error, afterInsert func(string) error) (string, int, bool, error) {
+	m.enqueueMu.Lock()
+	defer m.enqueueMu.Unlock()
+
+	active, err := m.countActiveRuns(job.ID)
+	if err != nil {
+		return "", 0, false, err
+	}
+	limit := jobsV2ConcurrencyLimit(job)
+	if active >= limit {
+		if onLimit != nil {
+			if err := onLimit(); err != nil {
+				return "", 0, false, err
+			}
+		}
+		return "", active, false, nil
+	}
+
+	runID := "run_" + randomSuffix()
+	_, err = m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, runID, job.ID, trigger, scheduledFor.UTC(), jobsV2RunQueued)
+	if err != nil {
+		return "", 0, false, err
+	}
+	if afterInsert != nil {
+		if err := afterInsert(runID); err != nil {
+			return "", 0, false, err
+		}
+	}
+	return runID, active + 1, true, nil
+}
+
 func (m *jobsV2Manager) scheduleOne(job jobsV2Job, now time.Time) error {
 	next, err := computeNextRunAt(job, now)
 	if err != nil {
 		return err
 	}
 
-	active, err := m.countActiveRuns(job.ID)
+	runID, _, queued, err := m.enqueueRunWithConcurrencyLimit(job, "schedule", now, func() error {
+		_, err := m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
+		return err
+	}, func(string) error {
+		if job.TriggerType == jobsV2TriggerOnce {
+			_, err := m.db.Exec(`UPDATE jobs_v2 SET enabled = 0, next_run_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, job.ID)
+			return err
+		}
+		_, err := m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
+		return err
+	})
 	if err != nil {
 		return err
 	}
-	if active >= jobsV2ConcurrencyLimit(job) {
-		_, err = m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
-		return err
+	if queued {
+		_ = m.addRunEvent(runID, "queued", "scheduled run queued", map[string]any{"trigger": "schedule", "attempt": 1})
 	}
-
-	runID := "run_" + randomSuffix()
-	_, err = m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, runID, job.ID, "schedule", now.UTC(), jobsV2RunQueued)
-	if err != nil {
-		return err
-	}
-	_ = m.addRunEvent(runID, "queued", "scheduled run queued", map[string]any{"trigger": "schedule", "attempt": 1})
-
-	if job.TriggerType == jobsV2TriggerOnce {
-		_, err = m.db.Exec(`UPDATE jobs_v2 SET enabled = 0, next_run_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, job.ID)
-		return err
-	}
-
-	_, err = m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
-	return err
+	return nil
 }
 
 func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
@@ -1365,24 +1392,18 @@ func (m *jobsV2Manager) TriggerJob(id string) (jobsV2Run, error) {
 		return jobsV2Run{}, fmt.Errorf("job is disabled")
 	}
 
-	active, err := m.countActiveRuns(id)
+	runID, active, queued, err := m.enqueueRunWithConcurrencyLimit(job, "manual", time.Now().UTC(), nil, nil)
 	if err != nil {
 		return jobsV2Run{}, err
 	}
-	limit := jobsV2ConcurrencyLimit(job)
-	if active >= limit {
+	if !queued {
+		limit := jobsV2ConcurrencyLimit(job)
 		if limit == 1 {
 			return jobsV2Run{}, fmt.Errorf("job already has an active run")
 		}
 		return jobsV2Run{}, fmt.Errorf("job already has %d active runs (max %d)", active, limit)
 	}
 
-	runID := "run_" + randomSuffix()
-	now := time.Now().UTC()
-	_, err = m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, runID, id, "manual", now, jobsV2RunQueued)
-	if err != nil {
-		return jobsV2Run{}, err
-	}
 	_ = m.addRunEvent(runID, "queued", "manual run queued", map[string]any{"trigger": "manual", "attempt": 1})
 	return m.GetRun(runID)
 }

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -790,6 +790,113 @@ func TestJobsV2TriggerJobRespectsMaxConcurrentRuns(t *testing.T) {
 	}
 }
 
+func TestJobsV2EnqueueRunWithConcurrencyLimitSerializesConcurrentEnqueues(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:              "serialized-concurrency-gate",
+		Enabled:           true,
+		RunnerType:        jobsV2RunnerProgram,
+		RunnerConfig:      json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:       jobsV2TriggerManual,
+		TriggerConfig:     json.RawMessage(`{}`),
+		ConcurrencyPolicy: "forbid",
+		MaxConcurrentRuns: 1,
+		TimeoutSeconds:    30,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan struct{})
+
+	var firstRunID string
+	var firstQueued bool
+	var firstErr error
+	go func() {
+		defer close(firstDone)
+		firstRunID, _, firstQueued, firstErr = mgr.enqueueRunWithConcurrencyLimit(job, "manual", time.Now().UTC(), nil, func(string) error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first enqueue to hold the concurrency gate")
+	}
+
+	type enqueueResult struct {
+		runID  string
+		active int
+		queued bool
+		err    error
+	}
+	secondCh := make(chan enqueueResult, 1)
+	go func() {
+		runID, active, queued, err := mgr.enqueueRunWithConcurrencyLimit(job, "manual", time.Now().UTC(), nil, nil)
+		secondCh <- enqueueResult{runID: runID, active: active, queued: queued, err: err}
+	}()
+
+	select {
+	case result := <-secondCh:
+		t.Fatalf("second enqueue returned before first released the concurrency gate: %+v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first enqueue to finish")
+	}
+	if firstErr != nil {
+		t.Fatalf("first enqueue failed: %v", firstErr)
+	}
+	if !firstQueued {
+		t.Fatal("first enqueue should queue a run")
+	}
+	if firstRunID == "" {
+		t.Fatal("first enqueue returned empty run ID")
+	}
+
+	var second enqueueResult
+	select {
+	case second = <-secondCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second enqueue result")
+	}
+	if second.err != nil {
+		t.Fatalf("second enqueue failed: %v", second.err)
+	}
+	if second.queued {
+		t.Fatal("second enqueue should observe the queued run and refuse to queue another")
+	}
+	if second.active != 1 {
+		t.Fatalf("second enqueue saw %d active runs, want 1", second.active)
+	}
+	if second.runID != "" {
+		t.Fatalf("second enqueue returned run ID %q, want empty", second.runID)
+	}
+
+	active, err := mgr.countActiveRuns(job.ID)
+	if err != nil {
+		t.Fatalf("countActiveRuns failed: %v", err)
+	}
+	if active != 1 {
+		t.Fatalf("active runs = %d, want 1", active)
+	}
+}
+
 func TestJobsV2ScheduleOneRespectsMaxConcurrentRuns(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)
 	if err != nil {


### PR DESCRIPTION
## What

Serialize the concurrency-gated run enqueue path in `jobsV2Manager` so manual triggers and scheduled runs can no longer race past `forbid` / `max_concurrent_runs`.

Also adds a regression test that exercises concurrent enqueues against the shared helper and verifies only one run is queued when the limit is 1.

## Why

Before this change, both `scheduleOne` and `TriggerJob` did `countActiveRuns()` and the `INSERT` in separate steps without any coordination. Two concurrent callers could both observe the same active count and both enqueue runs, exceeding the configured concurrency cap.

The new helper keeps that check-and-insert sequence under a shared mutex, making the enqueue decision atomic within the manager and preventing duplicate side-effecting executions caused by trigger/schedule races.
