### PR TITLE
fix: Stale context-window settings leak across model changes

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -345,24 +345,24 @@ func (e *Engine) SetContextTracking(inputLimit int) {
 
 // ConfigureContextManagement enables compaction or context tracking based on
 // the provider/model's input limit and the autoCompact setting.
-// Skips setup if the provider manages its own context (e.g., claude-bin).
+// Providers that manage their own context, or models without a known limit,
+// clear engine-side tracking/compaction to avoid leaking stale settings.
 // Both inputLimit and compactionConfig are set atomically under a single lock.
 func (e *Engine) ConfigureContextManagement(provider Provider, providerName, modelName string, autoCompact bool) {
-	if provider.Capabilities().ManagesOwnContext {
-		return
+	limit := 0
+	var compactionConfig *CompactionConfig
+
+	if !provider.Capabilities().ManagesOwnContext {
+		limit = InputLimitForProviderModel(providerName, modelName)
+		if limit > 0 && autoCompact {
+			cfg := DefaultCompactionConfig()
+			compactionConfig = &cfg
+		}
 	}
-	limit := InputLimitForProviderModel(providerName, modelName)
-	if limit <= 0 {
-		return
-	}
+
 	e.callbackMu.Lock()
 	e.inputLimit = limit
-	if autoCompact {
-		cfg := DefaultCompactionConfig()
-		e.compactionConfig = &cfg
-	} else {
-		e.compactionConfig = nil
-	}
+	e.compactionConfig = compactionConfig
 	e.callbackMu.Unlock()
 }
 

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1949,6 +1949,55 @@ func TestEngineResetConversationSkipsNonResettableProvider(t *testing.T) {
 	e.ResetConversation()
 }
 
+func TestConfigureContextManagementClearsUnknownLimit(t *testing.T) {
+	RegisterConfigLimits([]ConfigModelLimit{{Provider: "mock", Model: "known-model", InputLimit: 1234}})
+	defer RegisterConfigLimits(nil)
+
+	provider := NewMockProvider("mock")
+	e := NewEngine(provider, nil)
+
+	e.ConfigureContextManagement(provider, "mock", "known-model", true)
+	if got := e.InputLimit(); got != 1234 {
+		t.Fatalf("InputLimit() after known model = %d, want 1234", got)
+	}
+	if e.compactionConfig == nil {
+		t.Fatal("compactionConfig = nil after known model, want enabled")
+	}
+
+	e.ConfigureContextManagement(provider, "mock", "unknown-model", true)
+	if got := e.InputLimit(); got != 0 {
+		t.Fatalf("InputLimit() after unknown model = %d, want 0", got)
+	}
+	if e.compactionConfig != nil {
+		t.Fatal("compactionConfig != nil after unknown model, want cleared")
+	}
+}
+
+func TestConfigureContextManagementClearsManagedContextProvider(t *testing.T) {
+	RegisterConfigLimits([]ConfigModelLimit{{Provider: "mock", Model: "known-model", InputLimit: 1234}})
+	defer RegisterConfigLimits(nil)
+
+	provider := NewMockProvider("mock")
+	e := NewEngine(provider, nil)
+
+	e.ConfigureContextManagement(provider, "mock", "known-model", true)
+	if got := e.InputLimit(); got != 1234 {
+		t.Fatalf("InputLimit() after known model = %d, want 1234", got)
+	}
+	if e.compactionConfig == nil {
+		t.Fatal("compactionConfig = nil after known model, want enabled")
+	}
+
+	managedProvider := provider.WithCapabilities(Capabilities{ToolCalls: true, ManagesOwnContext: true})
+	e.ConfigureContextManagement(managedProvider, "mock", "known-model", true)
+	if got := e.InputLimit(); got != 0 {
+		t.Fatalf("InputLimit() after managed-context provider = %d, want 0", got)
+	}
+	if e.compactionConfig != nil {
+		t.Fatal("compactionConfig != nil after managed-context provider, want cleared")
+	}
+}
+
 func TestLastTotalTokensIncludesCachedTokens(t *testing.T) {
 	// Provider returns a text response with usage that has cached tokens.
 	// Uses a tool spec so the engine enters the agentic runLoop path


### PR DESCRIPTION
## What

Clear engine-side context tracking and compaction settings when switching to a model without a known input limit, or to a provider that manages its own context.

Also add regression coverage for both transitions so stale limits do not leak across model/provider changes.

## Why

`ConfigureContextManagement` previously returned early in those cases and left the prior `inputLimit` and compaction config intact. Reusing an engine across requests could therefore emit bogus context-full warnings or run compaction against the wrong limit after a model switch.
