### PR TITLE
perf: reduce Jobs V2 streaming accumulation overhead

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -352,14 +352,16 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 	cfg.StopWhen = string(progressiveOpts.StopWhen)
 	cfg.ContinueWith = progressiveOpts.ContinueWith
 	res := jobsV2RunResult{SessionID: cfg.SessionID}
+	var thinkingBuilder strings.Builder
+	var responseBuilder strings.Builder
 	progressTracker := newProgressTracker()
 	execResult, err := r.exec(ctx, cfg, func(ev llm.Event) {
 		switch ev.Type {
 		case llm.EventReasoningDelta:
-			res.Thinking += ev.Text
+			thinkingBuilder.WriteString(ev.Text)
 		case llm.EventTextDelta:
 			if !cfg.Progressive {
-				res.Response += ev.Text
+				responseBuilder.WriteString(ev.Text)
 			}
 		case llm.EventToolCall:
 			if ev.Tool != nil && cfg.Progressive && isProgressToolName(ev.Tool.Name) {
@@ -373,7 +375,7 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 				// Flush accumulated response to DB after each turn so callers can see partial output.
 				if pw != nil {
 					if !cfg.Progressive {
-						pw("response_flush", res.Response, nil)
+						pw("response_flush", responseBuilder.String(), nil)
 					}
 					pw("turn_complete", fmt.Sprintf("turn %d complete (%d in, %d out tokens)", res.TurnCount, ev.Use.InputTokens, ev.Use.OutputTokens), map[string]any{
 						"turn":          res.TurnCount,
@@ -404,7 +406,7 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 					if message == "" {
 						message = "progress updated"
 					}
-					envelope := buildProgressiveRunResult(cfg.SessionID, "", commit.Final, commit, res.Response)
+					envelope := buildProgressiveRunResult(cfg.SessionID, "", commit.Final, commit, responseBuilder.String())
 					pw("progress_update", message, envelope)
 				}
 				return
@@ -426,6 +428,10 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 			}
 		}
 	})
+	res.Thinking = thinkingBuilder.String()
+	if !cfg.Progressive {
+		res.Response = responseBuilder.String()
+	}
 	if execResult.Progressive != nil {
 		if strings.TrimSpace(execResult.Progressive.SessionID) == "" {
 			execResult.Progressive.SessionID = cfg.SessionID

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -971,3 +971,62 @@ func TestJobsV2ExecuteRunDoesNotStartWhenManagerClosed(t *testing.T) {
 		t.Fatal("started_at was set even though closed manager should not start the run")
 	}
 }
+
+func TestJobsV2LLMRunnerAccumulatesStreamingDeltas(t *testing.T) {
+	runner := &jobsV2LLMRunner{exec: func(ctx context.Context, cfg jobsV2LLMConfig, onEvent func(llm.Event)) (serveJobsExecResult, error) {
+		onEvent(llm.Event{Type: llm.EventReasoningDelta, Text: "thinking"})
+		onEvent(llm.Event{Type: llm.EventTextDelta, Text: "hel"})
+		onEvent(llm.Event{Type: llm.EventTextDelta, Text: "lo"})
+		onEvent(llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 3, OutputTokens: 5}})
+		return serveJobsExecResult{}, nil
+	}}
+	job := jobsV2Job{RunnerConfig: json.RawMessage(`{"agent_name":"test","instructions":"say hello"}`)}
+
+	var flushes []string
+	res, err := runner.Run(context.Background(), job, func(eventType, message string, data any) {
+		if eventType == "response_flush" {
+			flushes = append(flushes, message)
+		}
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if res.Response != "hello" {
+		t.Fatalf("Response = %q, want %q", res.Response, "hello")
+	}
+	if res.Thinking != "thinking" {
+		t.Fatalf("Thinking = %q, want %q", res.Thinking, "thinking")
+	}
+	if len(flushes) != 1 || flushes[0] != "hello" {
+		t.Fatalf("response flushes = %#v, want [hello]", flushes)
+	}
+	if res.TurnCount != 1 || res.InputTokens != 3 || res.OutputTokens != 5 {
+		t.Fatalf("usage = turns:%d input:%d output:%d, want turns:1 input:3 output:5", res.TurnCount, res.InputTokens, res.OutputTokens)
+	}
+}
+
+func BenchmarkJobsV2LLMRunnerTextDeltaAccumulation(b *testing.B) {
+	const deltas = 4096
+	const delta = "0123456789abcdef"
+	wantLen := deltas * len(delta)
+
+	runner := &jobsV2LLMRunner{exec: func(ctx context.Context, cfg jobsV2LLMConfig, onEvent func(llm.Event)) (serveJobsExecResult, error) {
+		for i := 0; i < deltas; i++ {
+			onEvent(llm.Event{Type: llm.EventTextDelta, Text: delta})
+		}
+		return serveJobsExecResult{}, nil
+	}}
+	job := jobsV2Job{RunnerConfig: json.RawMessage(`{"agent_name":"bench","instructions":"bench"}`)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := runner.Run(context.Background(), job, nil)
+		if err != nil {
+			b.Fatalf("Run failed: %v", err)
+		}
+		if len(res.Response) != wantLen {
+			b.Fatalf("response length = %d, want %d", len(res.Response), wantLen)
+		}
+	}
+}


### PR DESCRIPTION
## What

Replace per-delta string concatenation in the Jobs V2 LLM runner with `strings.Builder` accumulation for streamed response and reasoning text.

Also adds:
- a regression test for response/reasoning accumulation and response_flush behavior
- a benchmark covering many small text deltas from a Jobs V2 LLM run

## Why

Jobs V2 LLM runs receive streamed text as many small `EventTextDelta` / `EventReasoningDelta` events. Appending each delta with `res.Response += ev.Text` and `res.Thinking += ev.Text` repeatedly copies the accumulated string, making long streamed runs quadratic in bytes copied and allocation-heavy.

Using builders keeps accumulation linear while preserving the same final `jobsV2RunResult` fields and partial `response_flush` behavior.

## Evidence

Focused benchmark on 4096 x 16-byte text deltas:

Before:
- 15.4–17.1 ms/op
- ~144.4 MB/op
- 4118–4119 allocs/op

After:
- 66.4–68.3 µs/op
- ~286.7 KB/op
- 39 allocs/op

Commands run:
- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go test ./cmd -run 'TestJobsV2LLMRunnerAccumulatesStreamingDeltas|JobsV2'`
- `go test ./cmd -run '^$' -bench BenchmarkJobsV2LLMRunnerTextDeltaAccumulation -benchmem -count=3`
- `go build ./...`
- `go test ./...`
