### PR TITLE
perf: stream read file ranges

### DIFF
--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -1,11 +1,15 @@
 package tools
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -110,71 +114,171 @@ func (t *ReadFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.T
 		return textOutput(formatToolError(NewToolErrorf(ErrInvalidParams, "cannot resolve path: %v", err))), nil
 	}
 
-	// Read file
-	data, err := os.ReadFile(resolvedPath)
+	output, err := readLineNumberedFile(ctx, resolvedPath, a.Path, a.StartLine, a.EndLine, t.limits)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return textOutput(formatToolError(NewToolError(ErrFileNotFound, a.Path))), nil
+		if toolErr, ok := err.(*ToolError); ok {
+			return textOutput(formatToolError(toolErr)), nil
 		}
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "read error: %v", err))), nil
 	}
 
-	// Check for binary file
-	if isBinaryContent(data) {
-		return textOutput(formatToolError(NewToolErrorf(ErrBinaryFile, "%s appears to be a binary file", a.Path))), nil
+	return textOutput(output), nil
+}
+
+func readLineNumberedFile(ctx context.Context, resolvedPath, displayPath string, startLine, endLine int, limits OutputLimits) (string, error) {
+	file, err := os.Open(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", NewToolError(ErrFileNotFound, displayPath)
+		}
+		return "", fmt.Errorf("open: %w", err)
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+
+	// Check for binary file using only the sniffing prefix.  Peek leaves the
+	// bytes buffered so paged reads can continue without a second read or seek,
+	// and without requiring the path to be seekable.
+	sample, err := reader.Peek(512)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, bufio.ErrBufferFull) {
+		return "", fmt.Errorf("read sample: %w", err)
+	}
+	if isBinaryContent(sample) {
+		return "", NewToolErrorf(ErrBinaryFile, "%s appears to be a binary file", displayPath)
 	}
 
-	content := string(data)
-	lines := strings.Split(content, "\n")
-	totalLines := len(lines)
+	return streamLineNumberedRange(ctx, reader, startLine, endLine, limits)
+}
 
-	// Handle line range
-	start := 0
-	if a.StartLine > 0 {
-		start = a.StartLine - 1
-	}
-	if start >= totalLines {
-		return textOutput(formatToolError(NewToolErrorf(ErrInvalidParams, "start_line %d exceeds file length %d", a.StartLine, totalLines))), nil
+func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLine, endLine int, limits OutputLimits) (string, error) {
+	requestedStart := startLine
+	if startLine <= 0 {
+		startLine = 1
 	}
 
-	end := totalLines
-	if a.EndLine > 0 && a.EndLine < totalLines {
-		end = a.EndLine
-	}
-
-	if start >= end {
-		return textOutput("No content in requested range."), nil
-	}
-
-	selectedLines := lines[start:end]
-
-	// Check limits
-	truncated := false
-	if len(selectedLines) > t.limits.MaxLines {
-		selectedLines = selectedLines[:t.limits.MaxLines]
-		truncated = true
-	}
-
-	// Format output with line numbers
 	var sb strings.Builder
-	for i, line := range selectedLines {
-		lineNum := start + i + 1 // 1-indexed
-		sb.WriteString(fmt.Sprintf("%d: %s\n", lineNum, line))
+	if limits.MaxBytes > 0 {
+		grow := limits.MaxBytes
+		if grow > 4*1024 {
+			grow = 4 * 1024
+		}
+		sb.Grow(int(grow))
 	}
 
-	output := strings.TrimSuffix(sb.String(), "\n")
+	totalLines := 0
+	selectedLines := 0
+	writtenLines := 0
+	truncated := false
+	byteCapped := false
+	emittedAny := false
+	lastEndedNewline := false
 
-	// Check byte limit
-	if int64(len(output)) > t.limits.MaxBytes {
-		output = output[:t.limits.MaxBytes]
-		truncated = true
+	appendOutput := func(s string) {
+		if byteCapped {
+			return
+		}
+		if limits.MaxBytes <= 0 {
+			if len(s) > 0 {
+				truncated = true
+				byteCapped = true
+			}
+			return
+		}
+		remaining := int(limits.MaxBytes) - sb.Len()
+		if remaining <= 0 {
+			if len(s) > 0 {
+				truncated = true
+				byteCapped = true
+			}
+			return
+		}
+		if len(s) > remaining {
+			sb.WriteString(s[:remaining])
+			truncated = true
+			byteCapped = true
+			return
+		}
+		sb.WriteString(s)
 	}
 
+	processLine := func(line string) bool {
+		totalLines++
+		lineNum := totalLines
+
+		inRange := lineNum >= startLine && (endLine <= 0 || lineNum <= endLine)
+		if inRange {
+			selectedLines++
+			if selectedLines > limits.MaxLines {
+				truncated = true
+			} else {
+				if writtenLines > 0 {
+					appendOutput("\n")
+				}
+				appendOutput(strconv.Itoa(lineNum))
+				appendOutput(": ")
+				appendOutput(line)
+				writtenLines++
+			}
+		}
+
+		if truncated {
+			return true // Keep scanning so the truncation note can report total lines.
+		}
+		if endLine > 0 {
+			if startLine <= endLine && lineNum >= endLine {
+				return false
+			}
+			if startLine > endLine && lineNum >= startLine {
+				return false
+			}
+		}
+		return true
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		line, readErr := reader.ReadString('\n')
+		if len(line) > 0 {
+			emittedAny = true
+			if strings.HasSuffix(line, "\n") {
+				line = strings.TrimSuffix(line, "\n")
+				lastEndedNewline = true
+			} else {
+				lastEndedNewline = false
+			}
+			if !processLine(line) {
+				break
+			}
+		}
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				if !emittedAny || lastEndedNewline {
+					processLine("")
+				}
+				break
+			}
+			return "", readErr
+		}
+	}
+
+	if requestedStart > 0 && startLine > totalLines {
+		return "", NewToolErrorf(ErrInvalidParams, "start_line %d exceeds file length %d", requestedStart, totalLines)
+	}
+
+	if selectedLines == 0 {
+		return "No content in requested range.", nil
+	}
+
+	output := sb.String()
 	if truncated {
 		output += fmt.Sprintf("\n\n[Output truncated. Total lines: %d. Use start_line/end_line for pagination.]", totalLines)
 	}
-
-	return textOutput(output), nil
+	return output, nil
 }
 
 // isBinaryContent detects if content is binary using http.DetectContentType.

--- a/internal/tools/read_test.go
+++ b/internal/tools/read_test.go
@@ -1,0 +1,217 @@
+package tools
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadFileToolLineRange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	if err := os.WriteFile(path, []byte("alpha\nbeta\ngamma\ndelta\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewReadFileTool(nil, DefaultOutputLimits())
+	args, _ := json.Marshal(ReadFileArgs{Path: path, StartLine: 2, EndLine: 3})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	want := "2: beta\n3: gamma"
+	if out.Content != want {
+		t.Fatalf("unexpected output:\nwant %q\n got %q", want, out.Content)
+	}
+}
+
+func TestReadFileToolPreservesTrailingEmptyLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewReadFileTool(nil, DefaultOutputLimits())
+	args, _ := json.Marshal(ReadFileArgs{Path: path})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	want := "1: alpha\n2: "
+	if out.Content != want {
+		t.Fatalf("unexpected output:\nwant %q\n got %q", want, out.Content)
+	}
+}
+
+func TestReadFileToolStartLineBeyondEOF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	if err := os.WriteFile(path, []byte("alpha\nbeta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewReadFileTool(nil, DefaultOutputLimits())
+	args, _ := json.Marshal(ReadFileArgs{Path: path, StartLine: 4})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	want := "Error [INVALID_PARAMS]: start_line 4 exceeds file length 2"
+	if out.Content != want {
+		t.Fatalf("unexpected output:\nwant %q\n got %q", want, out.Content)
+	}
+}
+
+func TestReadFileToolTruncatesWithTotalLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\nfour"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	limits := DefaultOutputLimits()
+	limits.MaxLines = 2
+	tool := NewReadFileTool(nil, limits)
+	args, _ := json.Marshal(ReadFileArgs{Path: path})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	want := "1: one\n2: two\n\n[Output truncated. Total lines: 4. Use start_line/end_line for pagination.]"
+	if out.Content != want {
+		t.Fatalf("unexpected output:\nwant %q\n got %q", want, out.Content)
+	}
+}
+
+func TestStreamLineNumberedRangeMatchesLegacyFormatting(t *testing.T) {
+	baseLimits := DefaultOutputLimits()
+	smallLineLimit := baseLimits
+	smallLineLimit.MaxLines = 2
+	smallByteLimit := baseLimits
+	smallByteLimit.MaxBytes = 10
+
+	tests := []struct {
+		name      string
+		content   string
+		startLine int
+		endLine   int
+		limits    OutputLimits
+	}{
+		{name: "empty file", content: "", limits: baseLimits},
+		{name: "trailing newline", content: "alpha\n", limits: baseLimits},
+		{name: "range", content: "alpha\nbeta\ngamma\ndelta\n", startLine: 2, endLine: 3, limits: baseLimits},
+		{name: "end beyond eof", content: "alpha\nbeta", startLine: 1, endLine: 10, limits: baseLimits},
+		{name: "start after end", content: "alpha\nbeta\ngamma\ndelta", startLine: 4, endLine: 2, limits: baseLimits},
+		{name: "start beyond eof", content: "alpha\nbeta", startLine: 4, limits: baseLimits},
+		{name: "line truncated", content: "one\ntwo\nthree\nfour", limits: smallLineLimit},
+		{name: "byte truncated", content: "abcdefghij\nklmnop", limits: smallByteLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, wantErr := legacyReadFileFormatting(tt.content, tt.startLine, tt.endLine, tt.limits)
+			got, gotErr := streamLineNumberedRange(context.Background(), bufio.NewReader(strings.NewReader(tt.content)), tt.startLine, tt.endLine, tt.limits)
+			if (gotErr != nil) != (wantErr != nil) {
+				t.Fatalf("error mismatch: got %v want %v", gotErr, wantErr)
+			}
+			if gotErr != nil && gotErr.Error() != wantErr.Error() {
+				t.Fatalf("error mismatch: got %v want %v", gotErr, wantErr)
+			}
+			if got != want {
+				t.Fatalf("output mismatch:\nwant %q\n got %q", want, got)
+			}
+		})
+	}
+}
+
+func legacyReadFileFormatting(content string, startLine, endLine int, limits OutputLimits) (string, error) {
+	lines := strings.Split(content, "\n")
+	totalLines := len(lines)
+
+	start := 0
+	if startLine > 0 {
+		start = startLine - 1
+	}
+	if start >= totalLines {
+		return "", NewToolErrorf(ErrInvalidParams, "start_line %d exceeds file length %d", startLine, totalLines)
+	}
+
+	end := totalLines
+	if endLine > 0 && endLine < totalLines {
+		end = endLine
+	}
+
+	if start >= end {
+		return "No content in requested range.", nil
+	}
+
+	selectedLines := lines[start:end]
+
+	truncated := false
+	if len(selectedLines) > limits.MaxLines {
+		selectedLines = selectedLines[:limits.MaxLines]
+		truncated = true
+	}
+
+	var sb strings.Builder
+	for i, line := range selectedLines {
+		lineNum := start + i + 1
+		sb.WriteString(fmt.Sprintf("%d: %s\n", lineNum, line))
+	}
+
+	output := strings.TrimSuffix(sb.String(), "\n")
+
+	if int64(len(output)) > limits.MaxBytes {
+		output = output[:limits.MaxBytes]
+		truncated = true
+	}
+
+	if truncated {
+		output += fmt.Sprintf("\n\n[Output truncated. Total lines: %d. Use start_line/end_line for pagination.]", totalLines)
+	}
+
+	return output, nil
+}
+
+func BenchmarkReadFileToolStartRangeLargeFile(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "large.txt")
+	file, err := os.Create(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	linePayload := strings.Repeat("x", 96)
+	for i := 0; i < 200_000; i++ {
+		if _, err := fmt.Fprintf(file, "line %06d %s\n", i, linePayload); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		b.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tool := NewReadFileTool(nil, DefaultOutputLimits())
+	args, _ := json.Marshal(ReadFileArgs{Path: path, StartLine: 1, EndLine: 20})
+
+	b.ReportAllocs()
+	b.SetBytes(info.Size())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := tool.Execute(context.Background(), args)
+		if err != nil {
+			b.Fatalf("Execute returned error: %v", err)
+		}
+		if !strings.Contains(out.Content, "20: line 000019") {
+			b.Fatalf("range output missing final line: %q", out.Content)
+		}
+	}
+}


### PR DESCRIPTION
## What

Stream `read_file` output from a buffered reader instead of loading the entire file into memory with `os.ReadFile`, converting it to a string, and splitting every line up front.

This keeps the existing line-numbered formatting, binary sniffing, pagination semantics, trailing-newline behavior, and truncation messages, while allowing explicit `start_line`/`end_line` reads to stop as soon as the requested range is complete.

## Why

Agents commonly page through large files by asking for a small line range. The previous path still read and allocated the whole file before returning those lines, which made small reads from large files unnecessarily slow and allocation-heavy.

## Evidence

Benchmark added in `internal/tools/read_test.go` reads the first 20 lines from a 200,000-line / ~21.8MB file.

Before:

```text
BenchmarkReadFileToolStartRangeLargeFile-32  8.7-9.7 ms/op  46.8 MB/op  97 allocs/op
```

After:

```text
BenchmarkReadFileToolStartRangeLargeFile-32  10.6-11.4 µs/op  13 KB/op  63 allocs/op
```

## Verification

```text
go test ./internal/tools -run 'Test(ReadFileTool|StreamLineNumberedRange)' -bench BenchmarkReadFileToolStartRangeLargeFile -benchmem -count=5
go test ./...
go build ./...
```
