### PR TITLE
fix: OpenAI-compatible SSE parser rejects valid `data:` and `event:` lines without a space

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -359,10 +359,12 @@ func readSSEEvent(reader *bufio.Reader) (eventType, data string, eof bool, err e
 		if line == "" {
 			return eventType, strings.Join(dataLines, "\n"), lineEOF, nil
 		}
-		if strings.HasPrefix(line, "event: ") {
-			eventType = strings.TrimPrefix(line, "event: ")
-		} else if strings.HasPrefix(line, "data: ") {
-			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		if strings.HasPrefix(line, "event:") {
+			eventType = strings.TrimPrefix(line, "event:")
+			eventType = strings.TrimPrefix(eventType, " ")
+		} else if strings.HasPrefix(line, "data:") {
+			dataLine := strings.TrimPrefix(line, "data:")
+			dataLines = append(dataLines, strings.TrimPrefix(dataLine, " "))
 		}
 		if lineEOF {
 			return eventType, strings.Join(dataLines, "\n"), true, nil

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -19,6 +19,39 @@ func TestDefaultHTTPClient_HasNoOverallTimeout(t *testing.T) {
 	}
 }
 
+func TestReadSSEEvent_AllowsEventAndDataLinesWithoutSpace(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("event:error\ndata:{\"error\":{\"message\":\"boom\"}}\n\n"))
+
+	eventType, data, eof, err := readSSEEvent(reader)
+	if err != nil {
+		t.Fatalf("readSSEEvent: %v", err)
+	}
+	if eof {
+		t.Fatal("expected event separator, not EOF")
+	}
+	if eventType != "error" {
+		t.Fatalf("expected event type %q, got %q", "error", eventType)
+	}
+	if data != "{\"error\":{\"message\":\"boom\"}}" {
+		t.Fatalf("expected data %q, got %q", "{\"error\":{\"message\":\"boom\"}}", data)
+	}
+}
+
+func TestReadSSEEvent_StripsOnlyOptionalSingleSpaceAfterColon(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("data:  leading-space\n\n"))
+
+	_, data, eof, err := readSSEEvent(reader)
+	if err != nil {
+		t.Fatalf("readSSEEvent: %v", err)
+	}
+	if eof {
+		t.Fatal("expected event separator, not EOF")
+	}
+	if data != " leading-space" {
+		t.Fatalf("expected data %q, got %q", " leading-space", data)
+	}
+}
+
 func TestOpenAICompatStream_AllowsLargeSSEDataLines(t *testing.T) {
 	largeText := strings.Repeat("a", 1024*1024+1024)
 


### PR DESCRIPTION
## What

Fix the OpenAI-compatible SSE parser so it accepts both `event:` / `data:` lines with no space after the colon and the existing `event: ` / `data: ` form.

Add focused regression tests covering no-space field lines and preserving only the optional single space trimming required by SSE.

## Why

The SSE spec allows field lines like `event:error` and `data:{"x":1}`. Some providers and proxies emit that valid format, but term-llm was silently ignoring those lines because it only matched `event: ` and `data: `.

When that happens, streamed text, tool calls, usage, or error events can be dropped even though the upstream stream is valid.
