### PR TITLE
fix: Responses requests with tool-call history are misclassified as incremental appends

### DIFF
--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -45,7 +45,15 @@ func parseResponsesInput(input json.RawMessage) ([]llm.Message, bool, error) {
 
 	var messages []llm.Message
 	callNameByID := map[string]string{}
-	replaceHistory := false
+	allToolItems := len(items) > 0
+	for _, item := range items {
+		itemType := jsonString(item["type"])
+		if itemType != "function_call" && itemType != "function_call_output" {
+			allToolItems = false
+			break
+		}
+	}
+	replaceHistory := len(items) > 1 && !allToolItems
 	userCount := 0
 
 	for _, item := range items {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1095,6 +1095,27 @@ func TestParseResponsesInput_FunctionCallOutputDoesNotReplaceHistory(t *testing.
 	}
 }
 
+func TestParseResponsesInput_FunctionCallHistoryWithUserReplacesHistory(t *testing.T) {
+	payload := json.RawMessage(`[
+		{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\"path\":\"a.txt\"}"},
+		{"type":"function_call_output","call_id":"call_1","output":"content"},
+		{"type":"message","role":"user","content":"what next?"}
+	]`)
+	msgs, replaceHistory, err := parseResponsesInput(payload)
+	if err != nil {
+		t.Fatalf("parseResponsesInput failed: %v", err)
+	}
+	if !replaceHistory {
+		t.Fatalf("replaceHistory = false, want true")
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("len(msgs) = %d, want 3", len(msgs))
+	}
+	if msgs[2].Role != llm.RoleUser {
+		t.Fatalf("third role = %s, want user", msgs[2].Role)
+	}
+}
+
 func TestParseChatMessages_ToolCallAndToolResult(t *testing.T) {
 	msgs, replaceHistory, err := parseChatMessages([]chatMessage{
 		{


### PR DESCRIPTION
## What

Treat multi-item Responses input as full-history replacement unless every item is a tool-call/tool-result item. This fixes the case where a client sends prior `function_call` / `function_call_output` history plus the current user turn and the request was incorrectly appended onto the existing session history.

Also adds a regression test covering tool-call history followed by a user message.

## Why

Requests that include prior tool-call history are valid full conversation transcripts. Misclassifying them as incremental appends duplicates earlier turns, breaks tool-call/result pairing, and sends incorrect context to the model.
