### PR TITLE
fix: Fresh /v1/responses requests can hijack a busy session and corrupt its response-id state

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1389,11 +1389,6 @@ func (s *serveServer) runtimeForFreshProviderRequest(ctx context.Context, sessio
 		create,
 	)
 	if err != nil {
-		if errors.Is(err, errServeSessionBusy) {
-			if existing, ok := s.sessionMgr.Get(sessionID); ok {
-				return existing, true, nil
-			}
-		}
 		return nil, false, err
 	}
 	existingProvider := runtimeProviderKey(rt)

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -112,7 +112,21 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, freshProvider)
 	}
 	if err != nil {
-		if errors.Is(err, errServeSessionBusy) || errors.Is(err, errServeSessionLimitReached) {
+		if errors.Is(err, errServeSessionBusy) {
+			if req.Stream {
+				model := strings.TrimSpace(req.Model)
+				if model == "" {
+					if existing, ok := s.sessionMgr.Get(sessionID); ok && existing != nil {
+						model = existing.defaultModel
+					}
+				}
+				s.streamFailedResponseRun(ctx, w, sessionID, req.PreviousResponseID, model, "conflict_error", err.Error())
+				return
+			}
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
+			return
+		}
+		if errors.Is(err, errServeSessionLimitReached) {
 			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
 			return
 		}

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -966,6 +966,47 @@ func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID
 	return respID, nil
 }
 
+func (s *serveServer) streamFailedResponseRun(ctx context.Context, w http.ResponseWriter, sessionID, previousResponseID, model, errType, errMessage string) {
+	mgr := s.ensureResponseRuns()
+
+	respID := "resp_" + randomSuffix()
+	created := time.Now().Unix()
+	run := newResponseRun(respID, sessionID, previousResponseID, model, created, nil)
+	if err := mgr.create(run); err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+
+	cleanup := func() {
+		mgr.delete(respID)
+	}
+	if err := run.appendEvent("response.created", map[string]any{
+		"response": map[string]any{
+			"id":      respID,
+			"object":  "response",
+			"created": created,
+			"model":   model,
+			"status":  "in_progress",
+		},
+	}); err != nil {
+		cleanup()
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	if _, err := run.fail(map[string]any{
+		"error": map[string]any{
+			"message": errMessage,
+			"type":    errType,
+		},
+	}, errType, errMessage); err != nil {
+		cleanup()
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	mgr.scheduleCleanup(respID)
+	s.streamResponseRunEvents(ctx, w, run, 0)
+}
+
 func (s *serveServer) handleResponseByID(w http.ResponseWriter, r *http.Request) {
 	mgr := s.ensureResponseRuns()
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4535,6 +4535,90 @@ func TestHandleResponses_FreshConversationResetPreservesPreviousResponseIDsWhenR
 	}
 }
 
+func TestHandleResponses_FreshConversationBusySessionDoesNotOverwritePersistedRuntimeMetadata(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		provider := llm.NewMockProvider("mock")
+		provider.AddTextResponse("reply1")
+		provider.AddTextResponse("reply2")
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			store:        store,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	srv := &serveServer{sessionMgr: mgr, store: store}
+	mgr.onEvict = func(rt *serveRuntime) {
+		for _, rid := range rt.getResponseIDs() {
+			srv.responseToSession.Delete(rid)
+		}
+	}
+	defer mgr.Close()
+
+	code, resp := doResponsesWithHeader(t, srv, `{"input":"msg1","model":"original-model"}`, "fresh-reset-metadata")
+	if code != http.StatusOK {
+		t.Fatalf("msg1 status = %d, want 200", code)
+	}
+	respID, _ := resp["id"].(string)
+	if respID == "" {
+		t.Fatal("first response missing id")
+	}
+
+	sess, err := store.Get(context.Background(), "fresh-reset-metadata")
+	if err != nil {
+		t.Fatalf("Get before busy reset: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected persisted session before busy reset")
+	}
+	if got := strings.TrimSpace(sess.Model); got != "original-model" {
+		t.Fatalf("persisted model before busy reset = %q, want %q", got, "original-model")
+	}
+
+	rt, ok := srv.sessionMgr.Get("fresh-reset-metadata")
+	if !ok || rt == nil {
+		t.Fatal("expected runtime for fresh-reset-metadata")
+	}
+	busyState := &runtimeInterruptState{cancel: func() {}, done: make(chan struct{})}
+	rt.setActiveInterrupt(busyState)
+	defer rt.clearActiveInterrupt(busyState)
+
+	code, _ = doResponsesWithHeader(t, srv, `{"input":"reset","model":"replacement-model"}`, "fresh-reset-metadata")
+	if code != http.StatusConflict {
+		t.Fatalf("reset status = %d, want 409", code)
+	}
+
+	sess, err = store.Get(context.Background(), "fresh-reset-metadata")
+	if err != nil {
+		t.Fatalf("Get after busy reset: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected persisted session after busy reset")
+	}
+	if got := strings.TrimSpace(sess.Model); got != "original-model" {
+		t.Fatalf("persisted model after busy reset = %q, want %q", got, "original-model")
+	}
+	mapped, ok := srv.responseToSession.Load(respID)
+	if !ok {
+		t.Fatalf("responseToSession missing %q after busy reset", respID)
+	}
+	mappedSessionID, _ := mapped.(string)
+	if mappedSessionID != "fresh-reset-metadata" {
+		t.Fatalf("responseToSession[%q] = %q, want %q", respID, mappedSessionID, "fresh-reset-metadata")
+	}
+}
+
 func TestHandleResponses_PreviousResponseIDChainsSession(t *testing.T) {
 	// Each runtime gets 2 text responses so it can handle 2 messages
 	srv := newTestServeServer("first reply", "second reply")


### PR DESCRIPTION
## What

- stop treating `errServeSessionBusy` from `runtimeForFreshProviderRequest` as a successful fresh-session takeover
- return a conflict for busy fresh `/v1/responses` requests before any session metadata or response-id mappings can be reset
- preserve streaming behavior by emitting a synthetic `response.created` + `response.failed` SSE run for busy stream requests
- add a regression test that proves a busy fresh request does not overwrite the persisted model or break existing response-id mappings

## Why

A fresh `/v1/responses` request that reused an existing `session_id` could previously grab the currently active runtime when the session was busy. `handleResponses` then treated that live runtime as the new fresh session and updated persisted provider/model metadata before a replacement run had actually started. That could corrupt `previous_response_id` chaining and reconnect/cancel behavior for the in-flight conversation.
