### PR TITLE
perf: stream ripgrep JSON parsing

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -417,14 +417,23 @@ func parseToPending(output []byte, maxResults, maxAfterContext int) ([]pendingMa
 		return len(result) >= maxResults
 	}
 
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if line == "" {
+	// Walk the raw buffer line-by-line instead of strings.Split(string(output), "\n").
+	// This avoids copying/splitting the entire ripgrep stream up front and lets
+	// maxResults stop parsing after the useful prefix.
+	for len(output) > 0 {
+		line := output
+		if i := bytes.IndexByte(output, '\n'); i >= 0 {
+			line = output[:i]
+			output = output[i+1:]
+		} else {
+			output = nil
+		}
+		if len(line) == 0 {
 			continue
 		}
 
 		var msg rgMatch
-		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		if err := json.Unmarshal(line, &msg); err != nil {
 			continue
 		}
 

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -871,3 +871,31 @@ func TestFormatGrepResults_ByteCap(t *testing.T) {
 		t.Errorf("first file missing from capped output:\n%s", result)
 	}
 }
+
+func BenchmarkParseRipgrepOutputStopsAtMaxResults(b *testing.B) {
+	output := buildSyntheticRipgrepJSON(5000)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(output)))
+	for i := 0; i < b.N; i++ {
+		matches, err := parseRipgrepOutput(output, 100, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(matches) != 100 {
+			b.Fatalf("expected 100 matches, got %d", len(matches))
+		}
+	}
+}
+
+func buildSyntheticRipgrepJSON(matchCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(matchCount * 220)
+	for i := 0; i < matchCount; i++ {
+		path := fmt.Sprintf("f%05d.go", i)
+		line := fmt.Sprintf("needle %05d\n", i)
+		fmt.Fprintf(&sb, `{"type":"match","data":{"path":{"text":%q},"lines":{"text":%q},"line_number":1,"absolute_offset":0,"submatches":[]}}`+"\n", path, line)
+		fmt.Fprintf(&sb, `{"type":"end","data":{"path":{"text":%q}}}`+"\n", path)
+	}
+	return []byte(sb.String())
+}


### PR DESCRIPTION
## What

Stream ripgrep JSON output directly from the raw byte buffer in `parseToPending` instead of first doing `strings.Split(string(output), "\n")`.

This keeps the parser from copying and splitting the entire captured `rg --json` stream when `max_results` lets us return after an early prefix.

## Why

`grep` can capture up to several MB of ripgrep JSON before the formatter applies result limits. The old parser paid an up-front full-buffer string copy and line-slice allocation even when only the first `max_results` matches were needed. The new loop scans one line at a time and stops as soon as the existing max-results logic is satisfied.

## Evidence

Added `BenchmarkParseRipgrepOutputStopsAtMaxResults` with 5,000 synthetic rg matches and `maxResults=100`.

Before:

```text
499-520 µs/op, ~1,334 KB/op, 3634-3636 allocs/op
```

After:

```text
299-305 µs/op, ~181 KB/op, 3426-3427 allocs/op
```

Representative after run:

```text
BenchmarkParseRipgrepOutputStopsAtMaxResults-32  3950  299417 ns/op  181124 B/op  3426 allocs/op
```

## Verification

- `gofmt -w internal/tools/grep.go internal/tools/grep_test.go`
- `go test ./internal/tools -run '^$' -bench 'BenchmarkParseRipgrepOutputStopsAtMaxResults' -benchmem -count=5`
- `go test ./internal/tools`
- `go build ./...`
- `go test ./...`
