### PR TITLE
test: speed up grep raw cap coverage

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -77,15 +77,17 @@ func autoEnrichContextLines(blockCount int) int {
 
 // GrepTool implements the grep tool.
 type GrepTool struct {
-	approval *ApprovalManager
-	limits   OutputLimits
+	approval        *ApprovalManager
+	limits          OutputLimits
+	rgCaptureLimits ripgrepCaptureLimits
 }
 
 // NewGrepTool creates a new GrepTool.
 func NewGrepTool(approval *ApprovalManager, limits OutputLimits) *GrepTool {
 	return &GrepTool{
-		approval: approval,
-		limits:   limits,
+		approval:        approval,
+		limits:          limits,
+		rgCaptureLimits: defaultRipgrepCaptureLimits(),
 	}
 }
 
@@ -152,7 +154,30 @@ func buildRipgrepArgs(a GrepArgs, searchPath string, contextLines, maxResults in
 	return args
 }
 
-func runRipgrep(ctx context.Context, args []string) ([]byte, bool, error) {
+type ripgrepCaptureLimits struct {
+	maxOutputLines   int
+	maxBufferedBytes int
+}
+
+func defaultRipgrepCaptureLimits() ripgrepCaptureLimits {
+	return ripgrepCaptureLimits{
+		maxOutputLines:   rgHardMaxOutputLines,
+		maxBufferedBytes: rgMaxBufferedBytes,
+	}
+}
+
+func (l ripgrepCaptureLimits) normalize() ripgrepCaptureLimits {
+	if l.maxOutputLines <= 0 {
+		l.maxOutputLines = rgHardMaxOutputLines
+	}
+	if l.maxBufferedBytes <= 0 {
+		l.maxBufferedBytes = rgMaxBufferedBytes
+	}
+	return l
+}
+
+func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits) ([]byte, bool, error) {
+	limits = limits.normalize()
 	cmd := exec.CommandContext(ctx, "rg", args...)
 
 	stdout, err := cmd.StdoutPipe()
@@ -182,7 +207,7 @@ func runRipgrep(ctx context.Context, args []string) ([]byte, bool, error) {
 		line, readErr := reader.ReadBytes('\n')
 		if len(line) > 0 {
 			lineCount++
-			if lineCount > rgHardMaxOutputLines || out.Len()+len(line) > rgMaxBufferedBytes {
+			if lineCount > limits.maxOutputLines || out.Len()+len(line) > limits.maxBufferedBytes {
 				truncated = true
 				_ = cmd.Process.Kill()
 				break
@@ -227,7 +252,7 @@ func runRipgrep(ctx context.Context, args []string) ([]byte, bool, error) {
 // executeRipgrep runs ripgrep and returns matches.
 func (t *GrepTool) executeRipgrep(ctx context.Context, a GrepArgs, searchPath string, contextLines, maxResults int) (ripgrepResult, error) {
 	args := buildRipgrepArgs(a, searchPath, contextLines, maxResults)
-	output, truncated, err := runRipgrep(ctx, args)
+	output, truncated, err := runRipgrep(ctx, args, t.rgCaptureLimits)
 	if err != nil {
 		return ripgrepResult{}, err
 	}

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -675,18 +675,24 @@ func TestGrepTool_RawRipgrepOutputCap_Integration(t *testing.T) {
 		t.Skip("ripgrep not available")
 	}
 
+	const testRawLineCap = 128
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "many.txt")
 	var content strings.Builder
-	for i := 0; i < rgHardMaxOutputLines+500; i++ {
+	for i := 0; i < testRawLineCap+50; i++ {
 		content.WriteString("HARD_CAP_TOKEN\n")
 	}
 	if err := os.WriteFile(path, []byte(content.String()), 0644); err != nil {
 		t.Fatal(err)
 	}
 
+	// Exercise the same Execute path as production, but inject a small raw-output
+	// cap so this fixture proves truncation without forcing rg to emit 10k JSON
+	// records on every test run.
 	tool := NewGrepTool(nil, DefaultOutputLimits())
-	args, _ := json.Marshal(GrepArgs{Pattern: "HARD_CAP_TOKEN", Path: dir, MaxResults: rgHardMaxOutputLines + 500, ContextLines: 0})
+	tool.rgCaptureLimits.maxOutputLines = testRawLineCap
+	args, _ := json.Marshal(GrepArgs{Pattern: "HARD_CAP_TOKEN", Path: dir, MaxResults: testRawLineCap + 50, ContextLines: 0})
 	output, err := tool.Execute(context.Background(), args)
 	if err != nil {
 		t.Fatal(err)
@@ -695,8 +701,9 @@ func TestGrepTool_RawRipgrepOutputCap_Integration(t *testing.T) {
 	if !strings.Contains(output.Content, "[Results truncated at limit]") {
 		t.Fatalf("expected raw ripgrep truncation notice, got:\n%s", output.Content)
 	}
-	if strings.Count(output.Content, "> ") < 1000 {
-		t.Fatalf("expected a large truncated match block, got only %d highlighted lines", strings.Count(output.Content, "> "))
+	highlightedLines := strings.Count(output.Content, "> ")
+	if highlightedLines < testRawLineCap/2 {
+		t.Fatalf("expected a large truncated match block, got only %d highlighted lines", highlightedLines)
 	}
 }
 


### PR DESCRIPTION
## What

Speeds up the grep raw-output cap integration test by making `GrepTool` carry injectable ripgrep capture limits while keeping the production defaults unchanged.

The test still exercises the normal `GrepTool.Execute` path and verifies the truncation notice, but uses a 128-line raw-output cap instead of forcing ripgrep to emit and parse more than 10k JSON records.

## Why

The nightly efficiency scan found `TestGrepTool_RawRipgrepOutputCap_Integration` was one of the slowest individual tests in the developer loop despite only needing to prove cap/truncation behavior.

Representative timings from this worktree:

- `go test -count=1 ./internal/tools -run '^TestGrepTool_RawRipgrepOutputCap_Integration$'`
  - before: 2.04s, 2.12s, 2.03s
  - after: 0.009s, 0.010s, 0.010s
- `go test -count=1 ./internal/tools`
  - before: 7.842s, 7.935s reported package time
  - after: 5.890s, 5.880s reported package time
- `go test -count=1 ./...`
  - before: 13.625s wall
  - after: 8.504s wall

## Verification

- `gofmt -w internal/tools/grep.go internal/tools/grep_test.go`
- `go build ./...`
- `go test -count=1 ./internal/tools -run '^TestGrepTool_RawRipgrepOutputCap_Integration$' -v` (3x)
- `go test -count=1 ./internal/tools` (2x)
- `go test -count=1 ./...`
