### PR TITLE
fix: Stream ingestion is throttled to UI frame rate, creating backpressure and delayed events

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1577,14 +1577,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// When smooth text is already buffered behind a pending render tick,
-		// defer the next stream read until that tick gets a chance to run.
+		// Smooth ticks should only pace rendering, not stream ingestion, otherwise
+		// fast providers can fill the bounded stream buffer and block later events
+		// behind the UI frame rate.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			if ev.Type == ui.StreamEventText && m.smoothTickPending {
-				m.deferredStreamRead = true
-			} else {
-				cmds = append(cmds, m.listenForStreamEvents())
-			}
+			m.deferredStreamRead = false
+			cmds = append(cmds, m.listenForStreamEvents())
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -130,28 +131,29 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
+func TestModelContinuesStreamReadingWhileSmoothTickPending(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
 	model.streamChan = make(chan ui.StreamEvent)
 
 	_, cmd := model.Update(streamEventMsg{event: ui.TextEvent("hello world")})
 	if cmd == nil {
-		t.Fatal("expected text event to schedule a smooth tick")
+		t.Fatal("expected text event to schedule follow-up commands")
 	}
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if !model.deferredStreamRead {
-		t.Fatal("expected next stream read to be deferred until the smooth tick")
+	if model.deferredStreamRead {
+		t.Fatal("expected stream reads to continue immediately instead of being deferred to the next smooth tick")
 	}
 
-	_, cmd = model.Update(ui.SmoothTickMsg{})
-	if model.deferredStreamRead {
-		t.Fatal("expected deferred stream read to clear after smooth tick")
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected batched smooth-tick and stream-read commands, got %T", msg)
 	}
-	if cmd == nil {
-		t.Fatal("expected smooth tick to resume stream reading")
+	if len(batch) != 2 {
+		t.Fatalf("expected smooth-tick and stream-read commands to be scheduled together, got %d commands", len(batch))
 	}
 }
 


### PR DESCRIPTION
## What

- stop gating chat stream reads on `ui.SmoothTickMsg` when smooth text rendering is already pending
- keep smooth ticks responsible for render pacing only, while immediately arming the next `listenForStreamEvents()` after non-terminal stream events
- update the chat regression test to assert that text events schedule both the smooth tick and the next stream read together

## Why

Deferring the next stream read until the next UI frame made stream ingestion run at render cadence instead of provider cadence. Under fast small-delta streams, that let the bounded stream buffer fill up and block `ProcessStream`, which delayed later text deltas as well as tool/phase/done events and caused visible "stuck then catch up" behavior. This change removes that backpressure source while preserving coalesced smooth rendering.
