### PR TITLE
fix: Stream reads are deferred behind smooth-render ticks

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1577,14 +1577,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// When smooth text is already buffered behind a pending render tick,
-		// defer the next stream read until that tick gets a chance to run.
+		// Keep stream ingestion driven by provider output; smooth rendering is
+		// already coalesced behind m.smoothBuffer and m.smoothTickPending.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			if ev.Type == ui.StreamEventText && m.smoothTickPending {
-				m.deferredStreamRead = true
-			} else {
-				cmds = append(cmds, m.listenForStreamEvents())
-			}
+			m.deferredStreamRead = false
+			cmds = append(cmds, m.listenForStreamEvents())
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -130,28 +131,29 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
+func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
 	model.streamChan = make(chan ui.StreamEvent)
 
 	_, cmd := model.Update(streamEventMsg{event: ui.TextEvent("hello world")})
 	if cmd == nil {
-		t.Fatal("expected text event to schedule a smooth tick")
+		t.Fatal("expected text event to schedule follow-up commands")
 	}
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if !model.deferredStreamRead {
-		t.Fatal("expected next stream read to be deferred until the smooth tick")
+	if model.deferredStreamRead {
+		t.Fatal("expected next stream read to be re-armed immediately")
 	}
 
-	_, cmd = model.Update(ui.SmoothTickMsg{})
-	if model.deferredStreamRead {
-		t.Fatal("expected deferred stream read to clear after smooth tick")
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected smooth tick and stream read to be batched together, got %T", msg)
 	}
-	if cmd == nil {
-		t.Fatal("expected smooth tick to resume stream reading")
+	if len(batch) != 2 {
+		t.Fatalf("expected exactly two follow-up commands (smooth tick + stream read), got %d", len(batch))
 	}
 }
 


### PR DESCRIPTION
## What

- stop deferring the next chat stream read behind `ui.SmoothTickMsg`
- keep smooth rendering coalesced via the existing smooth buffer / single pending smooth tick
- update the chat perf test to assert that text events now schedule both the smooth tick and the next stream read immediately

## Why

Text events were pacing stream ingestion behind the 16ms smooth-render tick. Because provider output flows through a bounded `StreamAdapter` channel with blocking sends, bursty streams could fill the buffer and stall `ProcessStream`, delaying later token deltas plus tool/phase/done events and causing visible streaming jank. Re-arming the read immediately keeps ingestion driven by provider output while preserving the existing render coalescing behavior.
