### PR TITLE
fix: Each streamed text append clones the entire accumulated response

### DIFF
--- a/internal/ui/segment.go
+++ b/internal/ui/segment.go
@@ -58,9 +58,9 @@ type Segment struct {
 	// Streaming text accumulation (O(1) append instead of O(n) string concat)
 	TextBuilder *strings.Builder // Used during streaming; nil when Complete
 
-	// Text snapshot cache - updated on append to avoid repeated String() calls
-	TextSnapshot    string // Cached result of TextBuilder.String()
-	TextSnapshotLen int    // Length when snapshot was taken (0 = invalid)
+	// Text snapshot cache - refreshed lazily when callers need stable text.
+	TextSnapshot    string // Cached clone of TextBuilder contents
+	TextSnapshotLen int    // Builder length when TextSnapshot was captured (-1 = stale)
 
 	// Streaming markdown renderer - renders complete blocks as they arrive
 	StreamRenderer *TextSegmentRenderer // Active streaming renderer; nil when Complete
@@ -99,16 +99,15 @@ type SubagentDiff struct {
 }
 
 // GetText returns the current text content of a segment.
-// During streaming, it uses the cached TextSnapshot; after completion, it reads from Text.
-// The snapshot is updated by AddTextSegment when content changes, avoiding
-// repeated O(n) String() allocations on every render tick.
+// During streaming, it uses a cached cloned snapshot when one matches the
+// current builder length; otherwise it refreshes the snapshot lazily.
 func (s *Segment) GetText() string {
 	if s.TextBuilder != nil {
 		// Return cached snapshot if valid (length matches current builder length)
 		if s.TextSnapshotLen == s.TextBuilder.Len() {
 			return s.TextSnapshot
 		}
-		// Snapshot is stale - update it (should rarely happen, AddTextSegment updates it)
+		// Snapshot is stale - update it on demand.
 		// IMPORTANT: Clone to prevent corruption from subsequent WriteString calls
 		// (strings.Builder.String() shares memory with internal buffer)
 		s.TextSnapshot = strings.Clone(s.TextBuilder.String())
@@ -575,19 +574,20 @@ func RenderSegmentsWithLeading(leading *Segment, segments []*Segment, width int,
 		var rendered string
 		switch seg.Type {
 		case SegmentText:
-			text := seg.GetText()
-			if text == "" {
-				continue
-			}
-
 			if seg.Complete && seg.Rendered != "" {
 				rendered = seg.Rendered
 			} else if seg.StreamRenderer != nil {
 				rendered = seg.StreamRenderer.RenderedUnflushed()
-			} else if seg.Complete && renderMarkdown != nil {
-				rendered = renderMarkdown(text, width)
 			} else {
-				rendered = text
+				text := seg.GetText()
+				if text == "" {
+					continue
+				}
+				if seg.Complete && renderMarkdown != nil {
+					rendered = renderMarkdown(text, width)
+				} else {
+					rendered = text
+				}
 			}
 
 			// If this is a completed segment that was partially flushed,

--- a/internal/ui/tool_tracker.go
+++ b/internal/ui/tool_tracker.go
@@ -323,8 +323,7 @@ func (t *ToolTracker) AddTextSegment(text string, width int) bool {
 				last.Text = ""
 			}
 			last.TextBuilder.WriteString(text)
-			last.TextSnapshot = strings.Clone(last.TextBuilder.String())
-			last.TextSnapshotLen = last.TextBuilder.Len()
+			last.TextSnapshotLen = -1
 
 			// Write to streaming renderer if present
 			if last.StreamRenderer != nil {

--- a/internal/ui/tool_tracker_test.go
+++ b/internal/ui/tool_tracker_test.go
@@ -129,8 +129,11 @@ func TestTextSnapshotNotCorrupted(t *testing.T) {
 	tracker.AddTextSegment("How are you?", 80)
 
 	// text1 should still be "Hello " (not corrupted)
-	// NOTE: We can't check text1 directly since the snapshot was updated,
-	// but we verify the current snapshot is correct
+	if text1 != "Hello " {
+		t.Fatalf("original snapshot corrupted after append: got %q", text1)
+	}
+
+	// Verify the lazily refreshed snapshot is correct.
 	text2 := seg.GetText()
 	expected := "Hello world! How are you?"
 	if text2 != expected {
@@ -145,6 +148,52 @@ func TestTextSnapshotNotCorrupted(t *testing.T) {
 	}
 	if !strings.HasPrefix(text2, "Hello ") {
 		t.Error("detected corruption: prefix corrupted")
+	}
+}
+
+func TestTextSnapshotRefreshIsDeferredUntilNeeded(t *testing.T) {
+	tracker := NewToolTracker()
+	tracker.AddTextSegment("Hello", 80)
+
+	seg := &tracker.Segments[0]
+	if got := seg.GetText(); got != "Hello" {
+		t.Fatalf("initial GetText = %q, want %q", got, "Hello")
+	}
+
+	tracker.AddTextSegment(" world", 80)
+
+	if seg.TextSnapshot != "Hello" {
+		t.Fatalf("snapshot updated eagerly = %q, want previous stable clone", seg.TextSnapshot)
+	}
+	if seg.TextSnapshotLen == seg.TextBuilder.Len() {
+		t.Fatalf("snapshot unexpectedly refreshed on append: len=%d", seg.TextSnapshotLen)
+	}
+
+	if got := seg.GetText(); got != "Hello world" {
+		t.Fatalf("GetText after append = %q, want %q", got, "Hello world")
+	}
+	if seg.TextSnapshotLen != len("Hello world") {
+		t.Fatalf("snapshot len = %d, want %d after lazy refresh", seg.TextSnapshotLen, len("Hello world"))
+	}
+}
+
+func TestRenderSegmentsDoesNotRefreshStreamingSnapshot(t *testing.T) {
+	tracker := NewToolTracker()
+	tracker.AddTextSegment("Hello", 80)
+
+	seg := &tracker.Segments[0]
+	if seg.StreamRenderer == nil {
+		t.Fatal("expected streaming renderer for width > 0")
+	}
+	if got := seg.GetText(); got != "Hello" {
+		t.Fatalf("initial GetText = %q, want %q", got, "Hello")
+	}
+
+	tracker.AddTextSegment(" world", 80)
+	RenderSegments([]*Segment{seg}, 80, -1, nil, true, false)
+
+	if seg.TextSnapshotLen == seg.TextBuilder.Len() {
+		t.Fatalf("RenderSegments eagerly refreshed snapshot during streaming")
 	}
 }
 


### PR DESCRIPTION
## What

- stop cloning the entire accumulated response on every streamed append in `ToolTracker.AddTextSegment`
- mark text snapshots stale and refresh them lazily only when stable raw text is actually needed
- avoid forcing snapshot refresh from `RenderSegments` while a streaming renderer is active, and add regression coverage for the new lazy behavior

## Why

The old hot path copied the full response-so-far for every incoming chunk, which turned long streamed replies into quadratic allocation/copy work on the UI goroutine. Deferring snapshot refresh and letting streaming renders use the incremental renderer directly keeps token streaming, scrolling, and input more responsive for large answers.
