### PR TITLE
fix: Alt-screen streaming rebuilds and resets the entire viewport content on each update

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -216,9 +216,11 @@ type Model struct {
 		// persist after streaming ends. Cleared when a new prompt is sent.
 		completedStream string
 		// Content versioning to avoid expensive string comparisons
-		contentVersion      uint64 // Incremented when content changes
-		lastRenderedVersion uint64 // Version that was last rendered to viewport
-		lastTrackerVersion  uint64 // Last seen tracker.Version (to detect content changes)
+		contentVersion               uint64 // Incremented when content changes
+		lastRenderedVersion          uint64 // Version that was last rendered to viewport
+		lastTrackerVersion           uint64 // Last seen tracker.Version (to detect content changes)
+		lastStreamingContent         string // Last rendered streaming tail in alt-screen mode
+		lastContentHistoryPlusStream bool   // Whether the rendered viewport is exactly history + streaming tail
 		// Caching for streaming segments to avoid re-rendering on every frame
 		cachedCompletedContent string // Rendered completed segments
 		cachedTrackerVersion   uint64 // Tracker version when cache was built
@@ -671,6 +673,10 @@ func (m *Model) applyWindowSize(msg tea.WindowSizeMsg) {
 	// Also invalidate history cache because renderHistory() skips the last turn
 	// when completedStream is non-empty — clearing it without rebuilding history
 	// would leave a stale cache that excludes the last assistant message.
+	m.viewCache.lastStreamingContent = ""
+	m.viewCache.lastContentHistoryPlusStream = false
+	m.viewCache.lastContentStr = ""
+	m.contentLines = nil
 	if m.viewCache.completedStream != "" {
 		m.viewCache.completedStream = ""
 		m.invalidateHistoryCache()

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -160,6 +160,9 @@ func (m *Model) viewAltScreen() string {
 	// When throttled, we intentionally skip expensive content reconstruction and
 	// keep the previous viewport content until the next render tick.
 	var contentStr string
+	var contentLines []string
+	var streamingContent string
+	usedIncrementalAppend := false
 	if m.streaming {
 		// Only increment version when tracker content or wave position changes
 		// The completed segment rendering is cached, but we still need SetContent
@@ -200,14 +203,19 @@ func (m *Model) viewAltScreen() string {
 
 	if contentChanged {
 		if m.streaming {
-			streamingContent := m.renderStreamingInline()
-			contentStr = m.viewCache.historyContent + streamingContent
-			if m.approvalModel != nil {
-				contentStr += "\n" + m.approvalModel.View().Content
-			} else if m.askUserModel != nil {
-				contentStr += "\n" + m.askUserModel.View().Content
-			} else if m.handoverPreview != nil {
-				contentStr += m.handoverPreview.View()
+			streamingContent = m.renderStreamingInline()
+			if m.approvalModel == nil && m.askUserModel == nil && m.handoverPreview == nil {
+				contentLines, usedIncrementalAppend = m.tryAppendAltScreenStreamingContent(streamingContent)
+			}
+			if !usedIncrementalAppend {
+				contentStr = m.viewCache.historyContent + streamingContent
+				if m.approvalModel != nil {
+					contentStr += "\n" + m.approvalModel.View().Content
+				} else if m.askUserModel != nil {
+					contentStr += "\n" + m.askUserModel.View().Content
+				} else if m.handoverPreview != nil {
+					contentStr += m.handoverPreview.View()
+				}
 			}
 		} else {
 			contentStr = m.viewCache.historyContent + m.viewCache.completedStream
@@ -223,7 +231,11 @@ func (m *Model) viewAltScreen() string {
 		wasAtBottom := m.viewport.AtBottom()
 		firstRender := m.viewCache.lastViewportView == ""
 		setContentStart := time.Now()
-		m.viewport.SetContent(contentStr)
+		if usedIncrementalAppend {
+			m.viewport.SetContentLines(contentLines)
+		} else {
+			m.viewport.SetContent(contentStr)
+		}
 		setContentEnd := time.Now()
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricSetContent, setContentEnd.Sub(setContentStart))
@@ -273,8 +285,20 @@ func (m *Model) viewAltScreen() string {
 	// Invalidate content lines when content changes — they'll be rebuilt
 	// lazily on demand in extractSelectedText (only needed for selection).
 	if contentChanged {
-		m.viewCache.lastContentStr = contentStr
-		m.contentLines = nil
+		if usedIncrementalAppend {
+			m.viewCache.lastContentStr = ""
+			m.contentLines = contentLines
+			m.viewCache.lastContentHistoryPlusStream = true
+		} else {
+			m.viewCache.lastContentStr = contentStr
+			m.contentLines = nil
+			m.viewCache.lastContentHistoryPlusStream = m.streaming && m.approvalModel == nil && m.askUserModel == nil && m.handoverPreview == nil
+		}
+		if m.streaming {
+			m.viewCache.lastStreamingContent = streamingContent
+		} else {
+			m.viewCache.lastStreamingContent = ""
+		}
 	}
 
 	// Post-process: apply selection highlight
@@ -1354,6 +1378,49 @@ func (m *Model) shouldThrottleSetContent(now time.Time) bool {
 		return false
 	}
 	return now.Sub(m.viewCache.lastSetContentAt) < m.streamRenderMinInterval
+}
+
+func (m *Model) tryAppendAltScreenStreamingContent(streamingContent string) ([]string, bool) {
+	if !m.viewCache.lastContentHistoryPlusStream {
+		return nil, false
+	}
+	if !strings.HasPrefix(streamingContent, m.viewCache.lastStreamingContent) {
+		return nil, false
+	}
+
+	contentLines := m.contentLines
+	if contentLines == nil {
+		contentLines = splitViewportContentLines(m.viewCache.lastContentStr)
+	}
+	if contentLines == nil && m.viewCache.lastContentStr == "" {
+		return nil, false
+	}
+
+	delta := streamingContent[len(m.viewCache.lastStreamingContent):]
+	return appendViewportContentLines(contentLines, delta), true
+}
+
+func splitViewportContentLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	return strings.Split(content, "\n")
+}
+
+func appendViewportContentLines(lines []string, delta string) []string {
+	if len(lines) == 0 {
+		return splitViewportContentLines(delta)
+	}
+	if delta == "" {
+		return lines
+	}
+
+	parts := strings.Split(delta, "\n")
+	lines[len(lines)-1] += parts[0]
+	if len(parts) > 1 {
+		lines = append(lines, parts[1:]...)
+	}
+	return lines
 }
 
 // GetBundledServers returns bundled MCP servers (wrapper for mcp package)

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"errors"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -40,6 +41,34 @@ func TestRenderMarkdown_NarrowWidth_DoesNotFallbackToRaw(t *testing.T) {
 
 	if strings.TrimSpace(got) == strings.TrimSpace(input) {
 		t.Fatalf("expected narrow-width markdown rendering, got raw fallback: %q", got)
+	}
+}
+
+func TestTryAppendAltScreenStreamingContent_AppendsTailLines(t *testing.T) {
+	m := &Model{}
+	m.viewCache.lastContentHistoryPlusStream = true
+	m.viewCache.lastContentStr = "history\nassistant"
+	m.viewCache.lastStreamingContent = "assistant"
+
+	got, ok := m.tryAppendAltScreenStreamingContent("assistant more\nnext")
+	if !ok {
+		t.Fatal("expected append-only streaming update to be reused incrementally")
+	}
+
+	want := []string{"history", "assistant more", "next"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected content lines\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestTryAppendAltScreenStreamingContent_FallsBackOnRewrite(t *testing.T) {
+	m := &Model{}
+	m.viewCache.lastContentHistoryPlusStream = true
+	m.viewCache.lastContentStr = "history\nassistant"
+	m.viewCache.lastStreamingContent = "assistant"
+
+	if _, ok := m.tryAppendAltScreenStreamingContent("rewritten assistant"); ok {
+		t.Fatal("expected rewrite to force full viewport rebuild")
 	}
 }
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -360,8 +360,12 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	m.currentResponse.Reset()
 	m.err = nil // Clear any previous error
 	m.webSearchUsed = false
-	m.viewCache.completedStream = "" // Clear previous response's diffs/tools
+	m.viewCache.completedStream = ""      // Clear previous response's diffs/tools
+	m.viewCache.lastStreamingContent = "" // Streaming tail is width/turn dependent
+	m.viewCache.lastContentHistoryPlusStream = false
 	m.viewCache.lastSetContentAt = time.Time{}
+	m.viewCache.lastContentStr = ""
+	m.contentLines = nil
 	m.bumpContentVersion()
 	if m.smoothBuffer != nil {
 		m.smoothBuffer.Reset()
@@ -657,8 +661,12 @@ func (m *Model) invalidateViewCache() {
 	m.viewCache.cachedCompletedContent = ""
 	m.viewCache.cachedTrackerVersion = 0
 	m.viewCache.lastTrackerVersion = 0
+	m.viewCache.lastStreamingContent = ""
+	m.viewCache.lastContentHistoryPlusStream = false
 	m.viewCache.lastWavePos = 0
 	m.viewCache.lastSetContentAt = time.Time{}
+	m.viewCache.lastContentStr = ""
+	m.contentLines = nil
 	if m.chatRenderer != nil {
 		m.chatRenderer.InvalidateCache()
 	}
@@ -667,6 +675,10 @@ func (m *Model) invalidateViewCache() {
 
 func (m *Model) invalidateHistoryCache() {
 	m.viewCache.historyValid = false
+	m.viewCache.lastStreamingContent = ""
+	m.viewCache.lastContentHistoryPlusStream = false
+	m.viewCache.lastContentStr = ""
+	m.contentLines = nil
 	if m.chatRenderer != nil {
 		m.chatRenderer.InvalidateCache()
 	}


### PR DESCRIPTION
## What

- avoid rebuilding a fresh `historyContent + streamingContent` string on append-only alt-screen streaming updates
- reuse the existing viewport line slice and append only the new streaming tail via `SetContentLines`
- reset the incremental append cache whenever width/history/turn state changes, and add focused tests for append-vs-rewrite behavior

## Why

Alt-screen streaming was re-concatenating the full transcript and forcing the viewport to rebuild from scratch on every streamed text/tool-state update. That makes long chats feel janky because normal token streaming repeatedly pays full-content allocation/splitting costs. This keeps the fast path incremental for append-only streaming while still falling back to the full rebuild path when content is rewritten or embedded UI changes.
