### PR TITLE
test: parallelize tools timeout tests

### DIFF
--- a/internal/tools/custom_tool_test.go
+++ b/internal/tools/custom_tool_test.go
@@ -288,6 +288,8 @@ echo "$INPUT" | grep -o '"name":"[^"]*"'
 }
 
 func TestCustomScriptTool_TimeoutKillsGrandchildren(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	writeScript(t, dir, "hang.sh", "#!/bin/sh\nsleep 60 & wait\n")
 

--- a/internal/tools/run_agent_script_test.go
+++ b/internal/tools/run_agent_script_test.go
@@ -224,6 +224,8 @@ func TestRunAgentScriptTool_ScriptPathWithSpaces(t *testing.T) {
 }
 
 func TestRunAgentScriptTool_TimeoutKillsGrandchildren(t *testing.T) {
+	t.Parallel()
+
 	agentDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(agentDir, "hang.sh"), []byte("#!/bin/sh\nsleep 60 & wait\n"), 0755); err != nil {
 		t.Fatalf("write script: %v", err)

--- a/internal/tools/shell_leak_repro_test.go
+++ b/internal/tools/shell_leak_repro_test.go
@@ -15,6 +15,8 @@ import (
 // the shell tool returns. The tool call is cancelled mid-flight and the
 // grandchild must be reaped regardless.
 func TestShellTool_BackgroundedChildKilled(t *testing.T) {
+	t.Parallel()
+
 	sentinel := uniqueSentinel(t, "bg")
 	logPath := fmt.Sprintf("/tmp/%s.log", sentinel)
 	defer os.Remove(logPath)
@@ -37,6 +39,7 @@ func TestShellTool_SetsidDescendantKilled(t *testing.T) {
 	if _, err := os.Stat("/proc/self/environ"); err != nil {
 		t.Skip("no /proc — nonce-based descendant reap is Linux-only")
 	}
+	t.Parallel()
 
 	sentinel := uniqueSentinel(t, "setsid")
 	logPath := fmt.Sprintf("/tmp/%s.log", sentinel)

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -259,6 +259,8 @@ func TestShellTool_WorkingDirIsFile(t *testing.T) {
 }
 
 func TestShellTool_Timeout(t *testing.T) {
+	t.Parallel()
+
 	t.Run("default timeout is 30 seconds", func(t *testing.T) {
 		tool := NewShellTool(nil, nil, DefaultOutputLimits())
 		// Just verify the tool executes a fast command successfully
@@ -388,6 +390,8 @@ func TestEnvMap_EmptyKeyReturnsError(t *testing.T) {
 }
 
 func TestShellTool_TimeoutKillsGrandchildren(t *testing.T) {
+	t.Parallel()
+
 	tool := NewShellTool(nil, nil, DefaultOutputLimits())
 	// sh -c spawns sleep as a grandchild; without the fix cmd.Run() blocks forever
 	// because the grandchild holds the pipe write-ends open after the shell is killed.


### PR DESCRIPTION
## What

Parallelize the independent timeout/process-reaping tests in `internal/tools` with `t.Parallel()`.

## Why

These tests intentionally wait on real command timeouts (mostly one second). They do not share mutable state, use per-test temp dirs/sentinels, and can run safely side-by-side instead of serializing the developer loop.

## Evidence

Measured with `go test -count=1 -json`:

- Before: `github.com/samsaffron/term-llm/internal/tools` elapsed `5.888s`
- After: `github.com/samsaffron/term-llm/internal/tools` elapsed `1.746s` (representative focused rerun `1.785s`)

Verification:

- `go build ./...`
- `go test -count=1 ./...`
- `go test ./...`
- `go test -race ./internal/tools`
