### PR TITLE
fix: keep insight mining user-weighted

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -1039,33 +1039,173 @@ type insightExtractionItem struct {
 	Confidence float64 `json:"confidence"`
 }
 
-// buildInsightTranscript builds a lean transcript for insight extraction.
-// Sam's observation: insight extraction only needs user words + minimal buffer.
-// We include user messages in full (up to 800 chars) and assistant text at 200 chars,
-// stripping all tool output. This keeps the prompt compact while preserving the
-// signal that matters — what the user actually typed.
+// buildInsightTranscript builds a lean, user-weighted transcript for insight extraction.
+// Insight extraction learns from what the user said: corrections, preferences,
+// and redirects. Assistant text and tool events are context only, so they are
+// aggressively abbreviated and globally capped so non-user tokens never exceed
+// user tokens. Tool results are summarized by action/outcome only; full output is
+// noise for behavioral mining and can dwarf the actual conversation signal.
 func buildInsightTranscript(messages []session.Message) []transcriptMessage {
-	const maxUser = 800
-	const maxAssistant = 200
-	out := make([]transcriptMessage, 0, len(messages))
+	const maxUserChars = 1200
+	const maxAssistantChars = 120
+	const maxToolEventChars = 80
+
+	type pendingMessage struct {
+		role string
+		text string
+	}
+
+	pending := make([]pendingMessage, 0, len(messages))
+	userTokenBudget := 0
 	for _, msg := range messages {
-		if msg.Role == llm.RoleTool || msg.Role == llm.RoleSystem {
+		if msg.Role == llm.RoleSystem {
 			continue
 		}
+		if msg.Role == llm.RoleTool {
+			for _, summary := range summarizeInsightToolResults(msg) {
+				pending = append(pending, pendingMessage{role: string(llm.RoleTool), text: summary})
+			}
+			continue
+		}
+
 		text := strings.TrimSpace(msg.TextContent)
-		if text == "" {
+		if msg.Role == llm.RoleUser {
+			if text == "" {
+				continue
+			}
+			text = truncateForInsightTranscript(text, maxUserChars)
+			userTokenBudget += llm.EstimateTokens(text)
+			pending = append(pending, pendingMessage{role: string(msg.Role), text: text})
 			continue
 		}
-		limit := maxAssistant
-		if msg.Role == llm.RoleUser {
-			limit = maxUser
+
+		if text != "" {
+			pending = append(pending, pendingMessage{role: string(msg.Role), text: text})
 		}
-		if len(text) > limit {
-			text = text[:limit] + "..."
+		for _, summary := range summarizeInsightToolCalls(msg) {
+			pending = append(pending, pendingMessage{role: string(llm.RoleTool), text: summary})
 		}
-		out = append(out, transcriptMessage{Role: string(msg.Role), Text: text})
+	}
+
+	toolBudget := 0
+	for _, msg := range pending {
+		if msg.role != string(llm.RoleTool) {
+			continue
+		}
+		toolText := truncateForInsightTranscript(msg.text, maxToolEventChars)
+		toolBudget += llm.EstimateTokens(toolText)
+		if toolBudget >= userTokenBudget {
+			toolBudget = userTokenBudget
+			break
+		}
+	}
+	assistantBudget := userTokenBudget - toolBudget
+	out := make([]transcriptMessage, 0, len(pending))
+	for _, msg := range pending {
+		text := msg.text
+		switch msg.role {
+		case string(llm.RoleUser):
+			// User text defines the signal; include it outside the non-user budget.
+		case string(llm.RoleTool):
+			if toolBudget <= 0 {
+				continue
+			}
+			text = truncateForInsightTranscript(text, maxToolEventChars)
+			text = trimTextToTokenBudget(text, toolBudget)
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			toolBudget -= llm.EstimateTokens(text)
+		default:
+			if assistantBudget <= 0 {
+				continue
+			}
+			text = truncateForInsightTranscript(text, maxAssistantChars)
+			text = trimTextToTokenBudget(text, assistantBudget)
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			assistantBudget -= llm.EstimateTokens(text)
+		}
+		out = append(out, transcriptMessage{Role: msg.role, Text: text})
 	}
 	return out
+}
+
+func summarizeInsightToolCalls(msg session.Message) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, part := range msg.Parts {
+		if part.Type != llm.PartToolCall || part.ToolCall == nil {
+			continue
+		}
+		name := strings.TrimSpace(part.ToolCall.Name)
+		if name == "" || seen["call:"+name] {
+			continue
+		}
+		seen["call:"+name] = true
+		info := strings.TrimSpace(part.ToolCall.ToolInfo)
+		if info != "" {
+			out = append(out, fmt.Sprintf("tool called: %s %s", name, info))
+		} else {
+			out = append(out, fmt.Sprintf("tool called: %s", name))
+		}
+	}
+	return out
+}
+
+func summarizeInsightToolResults(msg session.Message) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, part := range msg.Parts {
+		if part.Type != llm.PartToolResult || part.ToolResult == nil {
+			continue
+		}
+		name := strings.TrimSpace(part.ToolResult.Name)
+		if name == "" || seen["result:"+name] {
+			continue
+		}
+		seen["result:"+name] = true
+		status := "ok"
+		if part.ToolResult.IsError {
+			status = "error"
+		}
+		out = append(out, fmt.Sprintf("tool result: %s %s", name, status))
+	}
+	return out
+}
+
+func truncateForInsightTranscript(text string, maxChars int) string {
+	if maxChars <= 0 || len(text) <= maxChars {
+		return text
+	}
+	return strings.TrimSpace(text[:maxChars]) + "..."
+}
+
+func trimTextToTokenBudget(text string, budget int) string {
+	if budget <= 0 || strings.TrimSpace(text) == "" {
+		return ""
+	}
+	if llm.EstimateTokens(text) <= budget {
+		return text
+	}
+
+	lo, hi := 0, len(text)
+	best := ""
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		candidate := strings.TrimSpace(text[:mid])
+		if candidate != "" {
+			candidate += "..."
+		}
+		if candidate != "" && llm.EstimateTokens(candidate) <= budget {
+			best = candidate
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return best
 }
 
 func buildInsightExtractionPrompt(agent string, messages []session.Message, existing []*memorydb.Insight) string {

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -14,6 +14,66 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
+func TestBuildInsightTranscriptWeightsUserTextOverAssistantAndSummarizesTools(t *testing.T) {
+	messages := []session.Message{
+		{Role: llm.RoleSystem, TextContent: strings.Repeat("system ", 100)},
+		{Role: llm.RoleUser, TextContent: "fix it"},
+		{
+			Role:        llm.RoleAssistant,
+			TextContent: strings.Repeat("assistant explanation with lots of irrelevant details ", 200),
+			Parts: []llm.Part{{Type: llm.PartToolCall, ToolCall: &llm.ToolCall{
+				Name:     "read_file",
+				ToolInfo: "(memory_mine.go)",
+			}}},
+		},
+		{
+			Role:        llm.RoleTool,
+			TextContent: strings.Repeat("TOOL_SENTINEL should never appear ", 200),
+			Parts: []llm.Part{{Type: llm.PartToolResult, ToolResult: &llm.ToolResult{
+				Name:    "read_file",
+				Content: strings.Repeat("TOOL_SENTINEL should never appear ", 200),
+			}}},
+		},
+		{Role: llm.RoleAssistant, TextContent: strings.Repeat("second assistant dump ", 200)},
+		{Role: llm.RoleUser, TextContent: "no, mine the user discussion, not the bulky execution transcript"},
+		{Role: llm.RoleAssistant, TextContent: strings.Repeat("third assistant dump ", 200)},
+	}
+
+	got := buildInsightTranscript(messages)
+	var userTokens, nonUserTokens int
+	var sawToolCall, sawToolResult bool
+	for _, msg := range got {
+		if msg.Role == string(llm.RoleSystem) {
+			t.Fatalf("transcript included system message: %+v", msg)
+		}
+		if strings.Contains(msg.Text, "TOOL_SENTINEL") {
+			t.Fatalf("transcript leaked tool output: %q", msg.Text)
+		}
+		if strings.Contains(msg.Text, "tool called: read_file") {
+			sawToolCall = true
+		}
+		if strings.Contains(msg.Text, "tool result: read_file ok") {
+			sawToolResult = true
+		}
+		switch msg.Role {
+		case string(llm.RoleUser):
+			userTokens += llm.EstimateTokens(msg.Text)
+		default:
+			nonUserTokens += llm.EstimateTokens(msg.Text)
+		}
+	}
+
+	if userTokens == 0 {
+		t.Fatalf("expected user tokens in transcript: %+v", got)
+	}
+	if !sawToolCall || !sawToolResult {
+		t.Fatalf("expected abbreviated tool call/result summaries, got %+v", got)
+	}
+	if nonUserTokens > userTokens {
+		t.Fatalf("non-user tokens = %d, user tokens = %d; context must not dominate\n%+v", nonUserTokens, userTokens, got)
+	}
+}
+
 func TestValidateFragmentPath(t *testing.T) {
 	for _, tc := range []struct {
 		path    string


### PR DESCRIPTION
## What

Keeps insight extraction prompts user-weighted while preserving compact execution context:

- omit system messages
- keep user text with a larger per-message cap
- aggressively abbreviate assistant text
- summarize tool calls/results as action/outcome only, e.g. `tool called: read_file (x.go)` / `tool result: read_file ok`
- never include full tool output in insight prompts
- globally cap all non-user context so assistant + tool-summary tokens never exceed user tokens
- reserve budget for tool summaries before assistant prose so `read/write/read was called` survives
- add regression coverage asserting:
  - full tool output cannot leak
  - abbreviated tool call/result summaries are retained
  - non-user context cannot dominate user text

## Why

Insight mining should learn from user corrections, preferences, and redirects. It still needs abbreviated context about what happened — especially tool usage — so it can distinguish "you failed to call read" from "you called read but handled the result badly". Full tool output and verbose assistant transcripts drown that signal and make mining slow.

If insight extraction ever includes more assistant/tool context tokens than user tokens, that is a fail.

## Verification

```text
go test ./cmd -run 'TestBuildInsightTranscript|TestCollectInsightCandidates'
go test ./...
go build ./...
```
