### PR TITLE
feat: add insight mining stats

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -348,11 +348,14 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			if len(insightCandidates) > 0 {
 				fmt.Printf("Insight extraction: %d unprocessed session(s) selected\n", len(insightCandidates))
 			}
-			insightCount, err := runInsightExtractionPass(ctx, cfg, engine, sessStore, memStore, insightCandidates)
+			insightCount, insightStats, err := runInsightExtractionPass(ctx, cfg, engine, sessStore, memStore, insightCandidates)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: insight extraction failed: %v\n", err)
 			} else {
 				fmt.Printf("insights: %d created/reinforced\n", insightCount)
+				if memoryMineShowStats {
+					insightStats.print()
+				}
 			}
 		}
 		// After extraction, apply decay and prune stale insights.
@@ -647,7 +650,7 @@ func runExtractionRequest(ctx context.Context, engine *llm.Engine, store *memory
 	return collector.result(finalText), nil
 }
 
-func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string, stats *memoryExtractionStats, tools ...llm.ToolSpec) (string, error) {
+func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, systemPrompt, prompt string, stats extractionRequestStats, tools ...llm.ToolSpec) (string, error) {
 	req := llm.Request{
 		Model:           strings.TrimSpace(memoryMineModel),
 		Messages:        []llm.Message{llm.SystemText(systemPrompt), llm.UserText(prompt)},
@@ -686,12 +689,8 @@ func runExtractionRequestWithSystem(ctx context.Context, engine *llm.Engine, sys
 				stats.noteToolCall(strings.TrimSpace(ev.Tool.Name))
 			}
 		case llm.EventUsage:
-			if stats != nil && ev.Use != nil {
-				stats.ToolTurns++
-				stats.InputTokens += ev.Use.InputTokens
-				stats.CachedInputTokens += ev.Use.CachedInputTokens
-				stats.CacheWriteTokens += ev.Use.CacheWriteTokens
-				stats.OutputTokens += ev.Use.OutputTokens
+			if stats != nil {
+				stats.noteUsage(ev.Use)
 			}
 		case llm.EventError:
 			if ev.Err != nil {
@@ -1209,7 +1208,11 @@ func trimTextToTokenBudget(text string, budget int) string {
 }
 
 func buildInsightExtractionPrompt(agent string, messages []session.Message, existing []*memorydb.Insight) string {
-	transcriptJSON, _ := json.MarshalIndent(buildInsightTranscript(messages), "", "  ")
+	return buildInsightExtractionPromptFromTranscript(agent, buildInsightTranscript(messages), existing)
+}
+
+func buildInsightExtractionPromptFromTranscript(agent string, transcript []transcriptMessage, existing []*memorydb.Insight) string {
+	transcriptJSON, _ := json.MarshalIndent(transcript, "", "  ")
 
 	// Pass a summary of existing insights so the LLM can deduplicate.
 	type existingSummary struct {
@@ -1231,7 +1234,7 @@ func buildInsightExtractionPrompt(agent string, messages []session.Message, exis
 Existing insights (do not duplicate these patterns):
 %s
 
-Transcript (user messages in full; assistant text abbreviated; tool output omitted):
+Transcript (user messages in full; assistant text abbreviated; tool output summarized):
 %s
 
 Return strict JSON only:
@@ -1258,8 +1261,9 @@ func runInsightExtractionPass(
 	sessStore session.Store,
 	memStore *memorydb.Store,
 	candidates []memoryMineCandidate,
-) (int, error) {
+) (int, insightExtractionSummaryStats, error) {
 	total := 0
+	var summary insightExtractionSummaryStats
 	for _, candidate := range candidates {
 		// Skip sessions already processed for insights — avoids redundant LLM
 		// calls and duplicate extraction. MarkInsightMined is called on success.
@@ -1288,10 +1292,18 @@ func runInsightExtractionPass(
 			existing = nil
 		}
 
-		prompt := buildInsightExtractionPrompt(candidate.Agent, messages, existing)
-		raw, err := runExtractionRequestWithSystem(ctx, engine, insightExtractionSystemPrompt, prompt, nil)
+		transcript := buildInsightTranscript(messages)
+		prompt := buildInsightExtractionPromptFromTranscript(candidate.Agent, transcript, existing)
+		stats := newInsightExtractionStats(candidate, messages, transcript, len(existing), prompt)
+		start := time.Now()
+		raw, err := runExtractionRequestWithSystem(ctx, engine, insightExtractionSystemPrompt, prompt, &stats)
+		stats.Duration = time.Since(start)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: llm call: %v\n", candidate.Session.ID, err)
+			if memoryMineShowStats {
+				fmt.Printf("  [insight] #%d %s\n", candidate.Summary.Number, stats.oneLine())
+				summary.add(stats)
+			}
 			continue
 		}
 		raw = stripMarkdownFences(raw)
@@ -1300,9 +1312,14 @@ func runInsightExtractionPass(
 		decoder := json.NewDecoder(strings.NewReader(raw))
 		if err := decoder.Decode(&resp); err != nil {
 			fmt.Fprintf(os.Stderr, "  [insight] skip %s: decode: %v\n", candidate.Session.ID, err)
+			if memoryMineShowStats {
+				fmt.Printf("  [insight] #%d %s\n", candidate.Summary.Number, stats.oneLine())
+				summary.add(stats)
+			}
 			continue
 		}
 
+		sessionInsights := 0
 		for _, item := range resp.Insights {
 			rule := strings.TrimSpace(item.Rule)
 			if rule == "" {
@@ -1319,6 +1336,7 @@ func runInsightExtractionPass(
 					_ = memStore.ReinforceInsight(ctx, similar[0].ID)
 					fmt.Printf("  [insight] reinforced id=%d (conf=%.2f)\n", similar[0].ID, similar[0].Confidence+0.1)
 					total++
+					sessionInsights++
 					continue
 				}
 			}
@@ -1340,6 +1358,13 @@ func runInsightExtractionPass(
 			}
 			fmt.Printf("  [insight] created id=%d cat=%s conf=%.2f\n", ins.ID, ins.Category, ins.Confidence)
 			total++
+			sessionInsights++
+		}
+
+		stats.CreatedOrReinforced = sessionInsights
+		if memoryMineShowStats {
+			fmt.Printf("  [insight] #%d %s\n", candidate.Summary.Number, stats.oneLine())
+			summary.add(stats)
 		}
 
 		// Mark this session as insight-mined so future runs skip it.
@@ -1347,7 +1372,7 @@ func runInsightExtractionPass(
 			fmt.Fprintf(os.Stderr, "  [insight] warning: mark mined failed for %s: %v\n", candidate.Session.ID, err)
 		}
 	}
-	return total, nil
+	return total, summary, nil
 }
 
 // isSimilarInsight uses Jaccard similarity on keywords (words >3 chars) to

--- a/cmd/memory_mine_stats.go
+++ b/cmd/memory_mine_stats.go
@@ -29,6 +29,11 @@ type memoryMineLoadResult struct {
 	SingleMessageClipped bool
 }
 
+type extractionRequestStats interface {
+	noteToolCall(name string)
+	noteUsage(use *llm.Usage)
+}
+
 type memoryExtractionStats struct {
 	SessionID                 string
 	SessionNumber             int64
@@ -172,6 +177,17 @@ func (s *memoryExtractionStats) noteToolCall(name string) {
 	sort.Strings(s.ToolNames)
 }
 
+func (s *memoryExtractionStats) noteUsage(use *llm.Usage) {
+	if use == nil {
+		return
+	}
+	s.ToolTurns++
+	s.InputTokens += use.InputTokens
+	s.CachedInputTokens += use.CachedInputTokens
+	s.CacheWriteTokens += use.CacheWriteTokens
+	s.OutputTokens += use.OutputTokens
+}
+
 func (s memoryExtractionStats) oneLine() string {
 	tools := "-"
 	if len(s.ToolNames) > 0 {
@@ -249,6 +265,204 @@ func (m memoryMineSummaryStats) print() {
 				s.ToolCalls,
 				strings.Join(s.ToolNames, ","),
 				s.PromptBudgetHit,
+			)
+		}
+	}
+}
+
+type insightTranscriptStats struct {
+	Messages               int
+	UserTokens             int
+	AssistantTokens        int
+	ToolTokens             int
+	NonUserTokens          int
+	RawUserTokens          int
+	RawAssistantTokens     int
+	RawToolTokens          int
+	DroppedSystem          int
+	DroppedAssistantTokens int
+	DroppedToolTokens      int
+}
+
+type insightExtractionStats struct {
+	SessionID             string
+	SessionNumber         int64
+	Agent                 string
+	Duration              time.Duration
+	PromptEstimatedTokens int
+	SystemTokens          int
+	ExistingInsights      int
+	Transcript            insightTranscriptStats
+	InputTokens           int
+	CachedInputTokens     int
+	CacheWriteTokens      int
+	OutputTokens          int
+	CreatedOrReinforced   int
+	SkippedShort          bool
+}
+
+type insightExtractionSummaryStats struct {
+	Sessions             int
+	TotalDuration        time.Duration
+	TotalPromptTokens    int
+	TotalInputTokens     int
+	TotalOutputTokens    int
+	CreatedOrReinforced  int
+	TotalUserTokens      int
+	TotalAssistantTokens int
+	TotalToolTokens      int
+	TotalNonUserTokens   int
+	BudgetViolations     int
+	Slowest              []insightExtractionStats
+}
+
+func newInsightExtractionStats(candidate memoryMineCandidate, messages []session.Message, transcript []transcriptMessage, existingInsights int, prompt string) insightExtractionStats {
+	transcriptStats := summarizeInsightTranscriptStats(messages, transcript)
+	return insightExtractionStats{
+		SessionID:             candidate.Session.ID,
+		SessionNumber:         candidate.Summary.Number,
+		Agent:                 candidate.Agent,
+		PromptEstimatedTokens: llm.EstimateTokens(insightExtractionSystemPrompt) + llm.EstimateTokens(prompt),
+		SystemTokens:          llm.EstimateTokens(insightExtractionSystemPrompt),
+		ExistingInsights:      existingInsights,
+		Transcript:            transcriptStats,
+	}
+}
+
+func summarizeInsightTranscriptStats(messages []session.Message, transcript []transcriptMessage) insightTranscriptStats {
+	stats := insightTranscriptStats{Messages: len(transcript)}
+	for _, msg := range messages {
+		text := strings.TrimSpace(msg.TextContent)
+		switch msg.Role {
+		case llm.RoleSystem:
+			stats.DroppedSystem++
+		case llm.RoleUser:
+			stats.RawUserTokens += llm.EstimateTokens(text)
+		case llm.RoleAssistant:
+			stats.RawAssistantTokens += llm.EstimateTokens(text)
+			for _, summary := range summarizeInsightToolCalls(msg) {
+				stats.RawToolTokens += llm.EstimateTokens(summary)
+			}
+		case llm.RoleTool:
+			for _, summary := range summarizeInsightToolResults(msg) {
+				stats.RawToolTokens += llm.EstimateTokens(summary)
+			}
+		}
+	}
+	for _, msg := range transcript {
+		tokens := llm.EstimateTokens(strings.TrimSpace(msg.Text))
+		switch msg.Role {
+		case string(llm.RoleUser):
+			stats.UserTokens += tokens
+		case string(llm.RoleTool):
+			stats.ToolTokens += tokens
+		default:
+			stats.AssistantTokens += tokens
+		}
+	}
+	stats.NonUserTokens = stats.AssistantTokens + stats.ToolTokens
+	if stats.RawAssistantTokens > stats.AssistantTokens {
+		stats.DroppedAssistantTokens = stats.RawAssistantTokens - stats.AssistantTokens
+	}
+	if stats.RawToolTokens > stats.ToolTokens {
+		stats.DroppedToolTokens = stats.RawToolTokens - stats.ToolTokens
+	}
+	return stats
+}
+
+func (s *insightExtractionStats) noteToolCall(name string) {}
+
+func (s *insightExtractionStats) noteUsage(use *llm.Usage) {
+	if use == nil {
+		return
+	}
+	s.InputTokens += use.InputTokens
+	s.CachedInputTokens += use.CachedInputTokens
+	s.CacheWriteTokens += use.CacheWriteTokens
+	s.OutputTokens += use.OutputTokens
+}
+
+func (s insightExtractionStats) oneLine() string {
+	return fmt.Sprintf("insight stats: wall=%s prompt≈%dt system=%dt existing=%d transcript_msgs=%d transcript=%dt(user=%dt assistant=%dt tool=%dt non_user=%dt raw_user=%dt raw_assistant=%dt raw_tool=%dt dropped_assistant=%dt dropped_tool=%dt budget_ok=%t usage[in=%d cached=%d out=%d write=%d] insights=%d",
+		s.Duration.Round(time.Millisecond),
+		s.PromptEstimatedTokens,
+		s.SystemTokens,
+		s.ExistingInsights,
+		s.Transcript.Messages,
+		s.Transcript.UserTokens+s.Transcript.NonUserTokens,
+		s.Transcript.UserTokens,
+		s.Transcript.AssistantTokens,
+		s.Transcript.ToolTokens,
+		s.Transcript.NonUserTokens,
+		s.Transcript.RawUserTokens,
+		s.Transcript.RawAssistantTokens,
+		s.Transcript.RawToolTokens,
+		s.Transcript.DroppedAssistantTokens,
+		s.Transcript.DroppedToolTokens,
+		s.Transcript.NonUserTokens <= s.Transcript.UserTokens,
+		s.InputTokens,
+		s.CachedInputTokens,
+		s.OutputTokens,
+		s.CacheWriteTokens,
+		s.CreatedOrReinforced,
+	)
+}
+
+func (m *insightExtractionSummaryStats) add(s insightExtractionStats) {
+	m.Sessions++
+	m.TotalDuration += s.Duration
+	m.TotalPromptTokens += s.PromptEstimatedTokens
+	m.TotalInputTokens += s.InputTokens + s.CachedInputTokens
+	m.TotalOutputTokens += s.OutputTokens
+	m.CreatedOrReinforced += s.CreatedOrReinforced
+	m.TotalUserTokens += s.Transcript.UserTokens
+	m.TotalAssistantTokens += s.Transcript.AssistantTokens
+	m.TotalToolTokens += s.Transcript.ToolTokens
+	m.TotalNonUserTokens += s.Transcript.NonUserTokens
+	if s.Transcript.NonUserTokens > s.Transcript.UserTokens {
+		m.BudgetViolations++
+	}
+	m.Slowest = append(m.Slowest, s)
+	sort.Slice(m.Slowest, func(i, j int) bool { return m.Slowest[i].Duration > m.Slowest[j].Duration })
+	if len(m.Slowest) > 5 {
+		m.Slowest = m.Slowest[:5]
+	}
+}
+
+func (m insightExtractionSummaryStats) print() {
+	if m.Sessions == 0 {
+		return
+	}
+	avgPrompt := m.TotalPromptTokens / m.Sessions
+	avgDuration := time.Duration(int64(m.TotalDuration) / int64(m.Sessions))
+	fmt.Printf("\n--- INSIGHT EXTRACTION STATS ---\n")
+	fmt.Printf("sessions=%d total_wall=%s avg_wall=%s avg_prompt≈%dt total_input=%d total_output=%d insights=%d transcript_tokens(user=%d assistant=%d tool=%d non_user=%d) budget_violations=%d\n",
+		m.Sessions,
+		m.TotalDuration.Round(time.Millisecond),
+		avgDuration.Round(time.Millisecond),
+		avgPrompt,
+		m.TotalInputTokens,
+		m.TotalOutputTokens,
+		m.CreatedOrReinforced,
+		m.TotalUserTokens,
+		m.TotalAssistantTokens,
+		m.TotalToolTokens,
+		m.TotalNonUserTokens,
+		m.BudgetViolations,
+	)
+	if len(m.Slowest) > 0 {
+		fmt.Println("slowest insight sessions:")
+		for _, s := range m.Slowest {
+			fmt.Printf("- #%d wall=%s prompt≈%dt transcript(user=%dt assistant=%dt tool=%dt non_user=%dt) budget_ok=%t insights=%d\n",
+				s.SessionNumber,
+				s.Duration.Round(time.Millisecond),
+				s.PromptEstimatedTokens,
+				s.Transcript.UserTokens,
+				s.Transcript.AssistantTokens,
+				s.Transcript.ToolTokens,
+				s.Transcript.NonUserTokens,
+				s.Transcript.NonUserTokens <= s.Transcript.UserTokens,
+				s.CreatedOrReinforced,
 			)
 		}
 	}

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -72,6 +72,26 @@ func TestBuildInsightTranscriptWeightsUserTextOverAssistantAndSummarizesTools(t 
 	if nonUserTokens > userTokens {
 		t.Fatalf("non-user tokens = %d, user tokens = %d; context must not dominate\n%+v", nonUserTokens, userTokens, got)
 	}
+
+	stats := summarizeInsightTranscriptStats(messages, got)
+	if stats.UserTokens != userTokens {
+		t.Fatalf("stats.UserTokens = %d, want %d", stats.UserTokens, userTokens)
+	}
+	if stats.NonUserTokens != nonUserTokens {
+		t.Fatalf("stats.NonUserTokens = %d, want %d", stats.NonUserTokens, nonUserTokens)
+	}
+	if stats.ToolTokens == 0 {
+		t.Fatalf("expected stats to count retained tool summaries: %+v", stats)
+	}
+	if stats.RawAssistantTokens <= stats.AssistantTokens {
+		t.Fatalf("expected raw assistant tokens to show pruning: %+v", stats)
+	}
+	if stats.RawToolTokens < stats.ToolTokens || stats.RawToolTokens == 0 {
+		t.Fatalf("expected raw tool summary tokens to cover retained tool summaries: %+v", stats)
+	}
+	if stats.NonUserTokens > stats.UserTokens {
+		t.Fatalf("stats reported budget violation: %+v", stats)
+	}
 }
 
 func TestValidateFragmentPath(t *testing.T) {


### PR DESCRIPTION
## What

Adds `--stats` coverage for the insight extraction phase of `term-llm memory mine --insights`.

The new stats print:

- per-session insight extraction wall time
- estimated prompt tokens
- existing insight count used for dedupe context
- transcript role budgets: user, assistant, tool summary, non-user
- raw assistant/tool summary token counts before pruning
- dropped assistant/tool tokens
- explicit `budget_ok` / aggregate `budget_violations`
- provider usage tokens and created/reinforced insight count

## Why

Sam's rule for insight mining is that the mined context must be user-dominated: if assistant/tool context exceeds user signal, that is a failure. The tests enforce this, but the live scheduled job had no cockpit readout for the invariant.

This wires the invariant into runtime stats so scheduled mining output can show whether pruning is actually doing the right thing.

## Verification

```text
go test ./cmd -run 'TestBuildInsightTranscript|TestCollectInsightCandidates'
go test ./...
go build ./...
```

Smoke-tested against copied production DBs, no live memory mutation:

```text
--- INSIGHT EXTRACTION ---
Insight extraction: 1 unprocessed session(s) selected
  [insight] #1953 insight stats: wall=2.822s prompt≈2390t system=293t existing=48 transcript_msgs=2 transcript=8t(user=4t assistant=0t tool=4t non_user=4t raw_user=4t raw_assistant=80t raw_tool=112t dropped_assistant=80t dropped_tool=108t budget_ok=true usage[in=3 cached=2131 out=8 write=0] insights=0
insights: 0 created/reinforced

--- INSIGHT EXTRACTION STATS ---
sessions=1 total_wall=2.822s avg_wall=2.822s avg_prompt≈2390t total_input=2134 total_output=8 insights=0 transcript_tokens(user=4 assistant=0 tool=4 non_user=4) budget_violations=0
```
