### PR TITLE
fix: keep factual insights out of prompt injection

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2259,6 +2259,9 @@ func (s *Store) ExpandInsights(ctx context.Context, agent, _ string, maxTokens i
 		if ins.Confidence < 0.4 {
 			continue
 		}
+		if !injectableInsightCategory(ins.Category) {
+			continue
+		}
 		n++
 		text := strings.TrimSpace(ins.CompactContent)
 		if text == "" {
@@ -2277,6 +2280,15 @@ func (s *Store) ExpandInsights(ctx context.Context, agent, _ string, maxTokens i
 		return "", nil
 	}
 	return sb.String(), nil
+}
+
+func injectableInsightCategory(category string) bool {
+	switch strings.TrimSpace(category) {
+	case "mining", "user-profile", "infrastructure":
+		return false
+	default:
+		return true
+	}
 }
 
 func scanInsight(scanner interface{ Scan(dest ...any) error }) (*Insight, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1179,11 +1179,11 @@ func TestInsightCRUD(t *testing.T) {
 	}
 
 	// Update content + compact together.
-	if err := store.UpdateInsight(ctx, ins.ID, "Never mention NZBGeek or SABnzbd in public posts.", "No internal tool names in public posts."); err != nil {
+	if err := store.UpdateInsight(ctx, ins.ID, "Never mention private service names in public posts.", "No internal tool names in public posts."); err != nil {
 		t.Fatalf("UpdateInsight: %v", err)
 	}
 	got2, _ := store.GetInsightByID(ctx, ins.ID)
-	if got2.Content != "Never mention NZBGeek or SABnzbd in public posts." {
+	if got2.Content != "Never mention private service names in public posts." {
 		t.Errorf("after update, content = %q", got2.Content)
 	}
 	if got2.CompactContent != "No internal tool names in public posts." {
@@ -1377,6 +1377,26 @@ func TestInsightExpand(t *testing.T) {
 		t.Fatalf("CreateInsight no compact: %v", err)
 	}
 
+	// High-confidence operational/factual insights should remain searchable in
+	// the bank but not burn always-on system prompt budget.
+	for _, tc := range []struct {
+		category string
+		content  string
+	}{
+		{"user-profile", "The user prefers concise weekly summaries."},
+		{"infrastructure", "A private service runs on an internal host."},
+		{"mining", "Mine at message fidelity, not session fidelity."},
+	} {
+		if err := store.CreateInsight(ctx, &Insight{
+			Agent:      "jarvis",
+			Content:    tc.content,
+			Category:   tc.category,
+			Confidence: 0.99,
+		}); err != nil {
+			t.Fatalf("CreateInsight excluded %s: %v", tc.category, err)
+		}
+	}
+
 	out, err := store.ExpandInsights(ctx, "jarvis", "any", 500)
 	if err != nil {
 		t.Fatalf("ExpandInsights: %v", err)
@@ -1397,6 +1417,13 @@ func TestInsightExpand(t *testing.T) {
 	// Insight without compact should show full content.
 	if !strings.Contains(out, "Always confirm before overwriting existing files.") {
 		t.Errorf("full content fallback not working: %q", out)
+	}
+
+	// Non-injectable categories should not appear even with higher confidence.
+	for _, forbidden := range []string{"prefers concise weekly", "private service runs", "Mine at message fidelity"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("non-injectable insight leaked into expansion: %q", out)
+		}
 	}
 
 	// Empty bank for a different agent should return empty.


### PR DESCRIPTION
## What

Keep non-behavioral insight categories out of the always-on injected `<insights>` block.

Excluded from prompt injection:

- `user-profile`
- `infrastructure`
- `mining`

They remain stored, listable, and searchable in the insight bank; they just stop burning system-prompt budget or accidentally turning factual state into behavioral instruction.

## Why

A mined insight incorrectly said Noa attends Ravenswood. The durable fragment already correctly says Reddam House Sydney, but the high-confidence insight was being injected into the system prompt. Factual/profile and infrastructure data should live in memory/search, not become always-on behavior rules.

Mining implementation rules are also useful for debugging the miner, but they are not generally useful in every Jarvis turn.

## Verification

```text
go test ./internal/memory -run TestInsightExpand
go test ./cmd -run 'TestBuildInsightTranscript|TestCollectInsightCandidates'
go test ./...
```

`go test ./...` hit a flaky/pre-existing timeout expectation in `internal/tools` on the first run:

```text
--- FAIL: TestRunAgentScriptTool_TimeoutKillsGrandchildren
    run_agent_script_test.go:246: expected timeout for grandchild-holding script
```

Reran that test directly and it passed 3x, then `go build ./...` passed:

```text
go test ./internal/tools -run TestRunAgentScriptTool_TimeoutKillsGrandchildren -count=3
go build ./...
```
