### PR TITLE
feat: support piping image output into video input

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -48,6 +48,7 @@ Examples:
   term-llm image "combine these" -i a.png -i b.png  # multi-image (Gemini/OpenRouter)
   term-llm image "sunset over mountains" --provider flux
   term-llm image "logo design" -o ./output.png --no-display
+  term-llm image "robot cat" -o - | term-llm video "animate it" -i -
   echo "a sunset" | term-llm image                  # prompt from stdin`,
 	Args: cobra.ArbitraryArgs,
 	RunE: runImage,
@@ -55,7 +56,7 @@ Examples:
 
 func init() {
 	imageCmd.Flags().StringArrayVarP(&imageInputs, "input", "i", nil, "Input image(s) to edit (can be specified multiple times)")
-	imageCmd.Flags().StringVarP(&imageProvider, "provider", "p", "", "Override provider (gemini, openai, chatgpt, xai, venice, flux, openrouter)")
+	imageCmd.Flags().StringVarP(&imageProvider, "provider", "p", "", "Override provider (debug, gemini, openai, chatgpt, xai, venice, flux, openrouter)")
 	imageCmd.Flags().StringVarP(&imageOutput, "output", "o", "", "Custom output path")
 	imageCmd.Flags().StringVarP(&imageSize, "size", "s", "", "Image resolution (must be 1K, 2K, or 4K)")
 	imageCmd.Flags().BoolVar(&imageNoDisplay, "no-display", false, "Skip terminal display")
@@ -188,7 +189,12 @@ func runImage(cmd *cobra.Command, args []string) error {
 
 	// Determine output path
 	var outputPath string
-	if imageOutput != "" {
+	if imageOutput == "-" {
+		if _, err := cmd.OutOrStdout().Write(result.Data); err != nil {
+			return fmt.Errorf("failed to write image to stdout: %w", err)
+		}
+		return nil
+	} else if imageOutput != "" {
 		// Custom output path specified
 		outputPath = imageOutput
 		if err := os.WriteFile(outputPath, result.Data, 0644); err != nil {

--- a/cmd/video.go
+++ b/cmd/video.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,6 +51,7 @@ Examples:
   term-llm video "make Romeo blink and wag his tail" -i romeo.png
   term-llm video "cute dog, influencer reacts" -i romeo.png -r pose1.png -r pose2.png
   term-llm video "cyberpunk city, slow dolly shot" --model kling-o3-pro-text-to-video
+  term-llm image "robot cat" -o - | term-llm video "animate it" -i -
   term-llm video "cute dog, influencer reacts" -i romeo.png --aspect-ratio 9:16 --duration 10s
   term-llm video "astronaut on mars" --quote-only --json`,
 	Args: cobra.ArbitraryArgs,
@@ -79,6 +81,10 @@ func init() {
 }
 
 func runVideo(cmd *cobra.Command, args []string) error {
+	if videoInput == "-" && len(args) == 0 {
+		return fmt.Errorf("prompt required as an argument when --input - reads image data from stdin")
+	}
+
 	prompt, err := resolveVideoPrompt(args)
 	if err != nil {
 		return err
@@ -118,7 +124,7 @@ func runVideo(cmd *cobra.Command, args []string) error {
 
 	var inputData []byte
 	if videoInput != "" {
-		inputData, err = video.LoadInputImage(videoInput)
+		inputData, err = loadVideoInput(cmd, videoInput)
 		if err != nil {
 			return err
 		}
@@ -262,6 +268,20 @@ func resolveVideoPrompt(args []string) (string, error) {
 		return "", fmt.Errorf("prompt required: provide as argument or via stdin")
 	}
 	return prompt, nil
+}
+
+func loadVideoInput(cmd *cobra.Command, path string) ([]byte, error) {
+	if path == "-" {
+		data, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, fmt.Errorf("read input image from stdin: %w", err)
+		}
+		if len(data) == 0 {
+			return nil, fmt.Errorf("read input image from stdin: no data")
+		}
+		return data, nil
+	}
+	return video.LoadInputImage(path)
 }
 
 func loadVideoReferences(paths []string) ([]video.InputImage, error) {

--- a/cmd/video_test.go
+++ b/cmd/video_test.go
@@ -5,10 +5,48 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestLoadVideoInputFromStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewReader([]byte("image-bytes")))
+
+	data, err := loadVideoInput(cmd, "-")
+	if err != nil {
+		t.Fatalf("loadVideoInput stdin: %v", err)
+	}
+	if string(data) != "image-bytes" {
+		t.Fatalf("data = %q, want image-bytes", string(data))
+	}
+}
+
+func TestLoadVideoInputFromEmptyStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewReader(nil))
+
+	_, err := loadVideoInput(cmd, "-")
+	if err == nil {
+		t.Fatal("expected empty stdin error")
+	}
+}
+
+func TestRunVideoRequiresArgPromptWhenInputUsesStdin(t *testing.T) {
+	oldInput := videoInput
+	videoInput = "-"
+	defer func() { videoInput = oldInput }()
+
+	err := runVideo(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("expected prompt-required error")
+	}
+	if !strings.Contains(err.Error(), "prompt required") {
+		t.Fatalf("error = %v, want prompt required", err)
+	}
+}
 
 func TestLoadVideoReferences(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/image/debug.go
+++ b/internal/image/debug.go
@@ -3,6 +3,7 @@ package image
 import (
 	"bytes"
 	"context"
+	"hash/fnv"
 	"image"
 	"image/color"
 	"image/png"
@@ -35,15 +36,14 @@ func (p *DebugProvider) SupportsMultiImage() bool {
 }
 
 func (p *DebugProvider) Generate(ctx context.Context, req GenerateRequest) (*ImageResult, error) {
-	return p.generateRandomImage(ctx)
+	return p.generateImage(ctx, req.Prompt)
 }
 
 func (p *DebugProvider) Edit(ctx context.Context, req EditRequest) (*ImageResult, error) {
-	// Edit just generates a random image (ignores input)
-	return p.generateRandomImage(ctx)
+	return p.generateImage(ctx, req.Prompt)
 }
 
-func (p *DebugProvider) generateRandomImage(ctx context.Context) (*ImageResult, error) {
+func (p *DebugProvider) generateImage(ctx context.Context, prompt string) (*ImageResult, error) {
 	// Apply configured delay
 	if p.delay > 0 {
 		select {
@@ -57,8 +57,10 @@ func (p *DebugProvider) generateRandomImage(ctx context.Context) (*ImageResult, 
 	width, height := 512, 512
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 
-	// Fill with random colored rectangles
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Fill with deterministic pseudo-random colored rectangles derived from the prompt.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(prompt))
+	rng := rand.New(rand.NewSource(int64(h.Sum64())))
 
 	// Background color
 	bgColor := color.RGBA{

--- a/internal/image/debug_test.go
+++ b/internal/image/debug_test.go
@@ -1,0 +1,36 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestDebugProviderGeneratesDeterministicImages(t *testing.T) {
+	provider := NewDebugProvider(0)
+	first, err := provider.Generate(context.Background(), GenerateRequest{Prompt: "robot cat"})
+	if err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+	second, err := provider.Generate(context.Background(), GenerateRequest{Prompt: "robot cat"})
+	if err != nil {
+		t.Fatalf("second generate: %v", err)
+	}
+	third, err := provider.Generate(context.Background(), GenerateRequest{Prompt: "different prompt"})
+	if err != nil {
+		t.Fatalf("third generate: %v", err)
+	}
+
+	if first.MimeType != "image/png" {
+		t.Fatalf("MimeType = %q, want image/png", first.MimeType)
+	}
+	if !bytes.Equal(first.Data, second.Data) {
+		t.Fatal("same prompt generated different image bytes")
+	}
+	if bytes.Equal(first.Data, third.Data) {
+		t.Fatal("different prompts generated identical image bytes")
+	}
+	if !bytes.HasPrefix(first.Data, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Fatal("debug provider did not return PNG bytes")
+	}
+}

--- a/internal/video/venice_test.go
+++ b/internal/video/venice_test.go
@@ -56,6 +56,13 @@ func TestValidateEnums(t *testing.T) {
 	}
 }
 
+func TestDataURLSniffsMimeWhenPathHasNoExtension(t *testing.T) {
+	url := dataURL("-", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})
+	if !strings.HasPrefix(url, "data:image/png;base64,") {
+		t.Fatalf("dataURL = %q, want image/png prefix", url)
+	}
+}
+
 func TestVeniceProviderQuoteQueueRetrieve(t *testing.T) {
 	var queueSawImageURL bool
 	var queueSawReferences bool


### PR DESCRIPTION
## What

Adds explicit media stream piping between image and video commands:

```bash
term-llm image "robot cat" -o - | term-llm video "animate it" -i -
```

Changes:

- `term-llm image ... -o -` writes raw image bytes to stdout and returns without saving/displaying/copying, keeping stdout pure for pipes.
- `term-llm video ... -i -` reads image bytes from stdin.
- `video -i -` now requires the prompt as an argument so stdin is not ambiguously both prompt text and image bytes.
- Debug image provider now generates deterministic PNG bytes keyed by prompt, which makes stream tests/smokes repeatable and usable without paid image generation.
- Help examples mention the image-to-video pipeline.

## Why

The text → image → video workflow is a natural CLI pipeline. This keeps the behavior explicit (`-o -` / `-i -`) instead of making default stdout binary or adding magic stdin detection.

## Verification

Normal build/tests:

```bash
go build ./...
go test ./...
```

Compiled binary smoke with the debug image provider:

```bash
go build -o /tmp/term-llm-media-pipe ./

img=/tmp/term-llm-debug-image-final.png
err=/tmp/term-llm-debug-image-final.err
/tmp/term-llm-media-pipe image "robot cat pipeline smoke" -p debug -o - > "$img" 2> "$err"
file "$img"
wc -c "$img"
printf 'stderr bytes: '; wc -c < "$err"

/tmp/term-llm-media-pipe image "robot cat pipeline smoke" -p debug -o - |
  /tmp/term-llm-media-pipe video "animate pipeline smoke" -i - --quote-only --json --timeout 30s
```

Observed output:

```text
/tmp/term-llm-debug-image-final.png: PNG image data, 512 x 512, 8-bit/color RGB, non-interlaced
13551 /tmp/term-llm-debug-image-final.png
stderr bytes: 0
```

```json
{
  "provider": "venice",
  "prompt": "animate pipeline smoke",
  "model": "longcat-distilled-image-to-video",
  "duration": "5s",
  "resolution": "720p",
  "status": "quoted",
  "quote": {
    "amount": 0.09
  },
  "input": "-"
}
```

The smoke confirms `image -o -` emits valid PNG bytes with no stderr chatter and `video -i -` consumes them successfully through the compiled binary.