### PR TITLE
fix: Streamed assistant updates rebuild all turn action panels on every render tick

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -817,7 +817,7 @@ const enqueueAssistantStreamUpdate = (message) => {
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
   syncAssistantUsageNode(node, message);
-  syncTurnActionPanels();
+  syncTurnActionPanelForAssistant(message.id);
   scheduleAssistantStreamRender(streamState);
 };
 
@@ -826,11 +826,11 @@ const finalizeAssistantStreamRender = (message) => {
   if (!node) {
     node = createMessageNode(message);
     elements.messages.appendChild(node);
-    syncTurnActionPanels();
+    syncTurnActionPanelForAssistant(message.id);
     return;
   }
   renderAssistantNodeFully(node, message);
-  syncTurnActionPanels();
+  syncTurnActionPanelForAssistant(message.id);
 };
 
 const createToolCard = (message) => {
@@ -953,11 +953,11 @@ const updateAssistantNode = (message) => {
   if (!node) {
     node = createMessageNode(message);
     elements.messages.appendChild(node);
-    syncTurnActionPanels();
+    syncTurnActionPanelForAssistant(message.id);
     return;
   }
   renderAssistantNodeFully(node, message);
-  syncTurnActionPanels();
+  syncTurnActionPanelForAssistant(message.id);
 };
 
 const updateUserNode = (message) => {
@@ -1404,6 +1404,82 @@ const createTurnActionPanel = (turn) => {
   return panel;
 };
 
+const removeTurnActionPanel = (node) => {
+  node?.querySelector('.turn-action-panel')?.remove();
+};
+
+const ensureTurnActionPanel = (node, turn) => {
+  if (!node || !turn?.lastAssistantId) return;
+
+  let panel = node.querySelector('.turn-action-panel');
+  if (!panel) {
+    panel = createTurnActionPanel(turn);
+    const meta = node.querySelector('.message-meta');
+    if (meta) {
+      node.insertBefore(panel, meta);
+    } else {
+      node.appendChild(panel);
+    }
+    return;
+  }
+
+  panel.dataset.turnAssistantId = turn.lastAssistantId;
+  const button = panel.querySelector('.turn-copy-btn');
+  if (button) {
+    button.dataset.turnAssistantId = turn.lastAssistantId;
+  }
+};
+
+const syncTurnActionPanelForAssistant = (assistantId) => {
+  const root = elements.messages;
+  if (!root || !assistantId) return;
+
+  const session = ensureActiveSession();
+  const messages = Array.isArray(session?.messages) ? session.messages : [];
+  let assistantIndex = -1;
+
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.id === assistantId) {
+      assistantIndex = i;
+      break;
+    }
+  }
+
+  if (assistantIndex === -1) return;
+
+  let start = assistantIndex;
+  while (start > 0 && !isNormalUserBoundary(messages[start - 1])) {
+    start -= 1;
+  }
+
+  let end = assistantIndex;
+  while (end + 1 < messages.length && !isNormalUserBoundary(messages[end + 1])) {
+    end += 1;
+  }
+
+  const assistantMessageIds = [];
+  let lastAssistantWithContent = null;
+
+  for (let i = start; i <= end; i += 1) {
+    const message = messages[i];
+    if (message?.role !== 'assistant' || !message.id) continue;
+    assistantMessageIds.push(message.id);
+    if (String(message.content || '').trim()) {
+      lastAssistantWithContent = message;
+    }
+  }
+
+  assistantMessageIds.forEach((id) => {
+    const node = findMessageElement(id);
+    if (!node || !node.classList?.contains('assistant')) return;
+    if (!lastAssistantWithContent || id !== lastAssistantWithContent.id) {
+      removeTurnActionPanel(node);
+      return;
+    }
+    ensureTurnActionPanel(node, { lastAssistantId: lastAssistantWithContent.id });
+  });
+};
+
 const syncTurnActionPanels = () => {
   const root = elements.messages;
   if (!root) return;
@@ -1414,13 +1490,7 @@ const syncTurnActionPanels = () => {
     if (!turn.lastAssistantId) return;
     const node = findMessageElement(turn.lastAssistantId);
     if (!node || !node.classList?.contains('assistant')) return;
-    const panel = createTurnActionPanel(turn);
-    const meta = node.querySelector('.message-meta');
-    if (meta) {
-      node.insertBefore(panel, meta);
-    } else {
-      node.appendChild(panel);
-    }
+    ensureTurnActionPanel(node, turn);
   });
 };
 

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -569,6 +569,49 @@ async function run(name, fn) {
     assert(!button.classList.contains('copied'), 'copied class resets');
   });
 
+  await run('stream updates only resync the affected turn action panel', () => {
+    const { app, session, messages } = createHarness();
+    const streamingMessage = {
+      id: 'a3',
+      role: 'assistant',
+      content: '',
+      created: Date.now(),
+    };
+    session.messages = [
+      { id: 'u1', role: 'user', content: 'first' },
+      { id: 'a1', role: 'assistant', content: 'First turn answer' },
+      { id: 'u2', role: 'user', content: 'second' },
+      { id: 'a2', role: 'assistant', content: 'Earlier assistant in active turn' },
+      { id: 'tg1', role: 'tool-group', tools: [
+        { id: 't1', name: 'grep', status: 'done', arguments: '{"pattern":"needle"}' },
+      ] },
+      streamingMessage,
+    ];
+    ['a1', 'a2', 'a3'].forEach((id) => messages.appendChild(messageNode(id, 'assistant')));
+
+    app.syncTurnActionPanels();
+
+    const firstTurnPanel = messages.children[0].querySelector('.turn-action-panel');
+    const activeTurnPanel = messages.children[1].querySelector('.turn-action-panel');
+    assert(firstTurnPanel, 'first turn panel rendered');
+    assert(activeTurnPanel, 'active turn panel starts on earlier assistant while stream is empty');
+    assertEqual(messages.children[2].querySelectorAll('.turn-action-panel').length, 0, 'empty streaming assistant has no panel yet');
+
+    streamingMessage.content = 'Streaming reply';
+    app.enqueueAssistantStreamUpdate(streamingMessage);
+
+    const streamedPanel = messages.children[2].querySelector('.turn-action-panel');
+    assertEqual(messages.children[0].querySelector('.turn-action-panel'), firstTurnPanel, 'unrelated earlier turn panel preserved');
+    assertEqual(messages.children[1].querySelectorAll('.turn-action-panel').length, 0, 'panel removed from earlier assistant in same turn');
+    assert(streamedPanel, 'panel moved onto streaming assistant');
+
+    streamingMessage.content += ' with more text';
+    app.enqueueAssistantStreamUpdate(streamingMessage);
+
+    assertEqual(messages.children[0].querySelector('.turn-action-panel'), firstTurnPanel, 'earlier turn panel still preserved on later stream ticks');
+    assertEqual(messages.children[2].querySelector('.turn-action-panel'), streamedPanel, 'streaming assistant panel is reused across ticks');
+  });
+
   await run('renders markdown without eager optional libraries for plain markdown', () => {
     const { app, document } = createHarness();
     const target = new Element('div');


### PR DESCRIPTION
## What

Avoid full turn-action-panel teardown/rebuild during assistant streaming updates by incrementally syncing only the affected turn.
Add a focused render test that verifies streaming moves/reuses the active turn panel without recreating unrelated panels.

## Why

`syncTurnActionPanels()` was being called on every assistant stream tick, which removed every turn action panel, rescanned the full session, and rebuilt all panels even when only one assistant message changed. On long chats this adds avoidable DOM churn and layout work, causing visible streaming jank as history grows.
