### PR TITLE
fix: UI throws away the initial POST SSE stream and immediately opens a second /events stream

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -129,16 +129,6 @@ const parseSSEStream = async (stream, onEvent) => {
   }
 };
 
-const cancelResponseBody = async (response) => {
-  if (!response?.body || typeof response.body.cancel !== 'function') return;
-  try {
-    await response.body.cancel();
-  } catch {
-    // Ignore body cancellation failures; the resumable /events stream is the
-    // authoritative source once we know the response ID.
-  }
-};
-
 const sleep = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
 const setActiveResponseTracking = (session, responseId, sequenceNumber = null) => {
@@ -3029,22 +3019,23 @@ const sendMessage = async (options = {}) => {
 
     if (headerResponseId) {
       setActiveResponseTracking(session, headerResponseId, 0);
+      attachResponseStream(session, headerResponseId, controller);
       saveSessions();
+    }
 
-      // The POST stream is only used to create the run and surface the
-      // response ID. After that, use the resumable events endpoint so a
-      // stalled transport does not strand the UI until reload.
-      await cancelResponseBody(response);
-      await resumeActiveResponse(session, { streamState, responseId: headerResponseId });
-    } else {
-      if (!response.body) {
-        throw { status: 0, message: 'No response body from server.' };
-      }
+    if (!response.body) {
+      throw { status: 0, message: 'No response body from server.' };
+    }
 
-      const terminal = await consumeResponseStream(response.body, session, streamState);
-      if (!terminal && session.activeResponseId) {
-        await resumeActiveResponse(session, { streamState });
-      }
+    // Keep consuming the initial POST SSE stream we already opened. If it
+    // stalls or ends before the response reaches a terminal state, fall back
+    // to the resumable /events endpoint from the last seen sequence number.
+    const terminal = await consumeResponseStream(response.body, session, streamState);
+    if (!terminal && session.activeResponseId) {
+      await resumeActiveResponse(session, {
+        streamState,
+        responseId: headerResponseId || session.activeResponseId
+      });
     }
 
     if (sendGeneration === state.streamGeneration) {


### PR DESCRIPTION
## What

Keep consuming the initial `POST /v1/responses` SSE stream after a successful send instead of immediately cancelling it and reconnecting to `GET /v1/responses/{id}/events` from `after=0`.

Also update the active stream tracking with the header response ID so the existing POST stream remains the tracked live transport, and only fall back to the resumable `/events` endpoint if the initial stream ends before reaching a terminal event.

## Why

The UI server path always returns `x-response-id` before streaming, so the previous flow created a POST stream, aborted it, and then replayed the same response from the start over a second SSE connection for every message.

That doubled the streaming HTTP work, delayed first visible output, and forced unnecessary reconnect/replay handling in the browser. This change preserves the existing resumable recovery path without paying for a second stream unless it is actually needed.
