### PR TITLE
fix: Startup blocks behind a fully serialized providers→models→sessions→messages→state waterfall

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -833,6 +833,23 @@ const setSessionPinned = async (session, pinned) => {
 };
 
 // ===== Initialization =====
+const hydrateActiveSessionAfterStartup = async () => {
+  const active = getActiveSession();
+  if (!active) return;
+
+  if (active._serverOnly) {
+    const msgs = await loadServerSessionMessages(active.id);
+    if (msgs !== null) {
+      mergeServerMessagesWithLocalState(active, msgs);
+      saveSessions();
+      renderSidebar();
+      renderMessages(true);
+    }
+  }
+
+  await syncActiveSessionFromServer(active, true);
+};
+
 const initialize = async () => {
   setStartupStatus('Loading your chat shell…');
   state.sessions = loadSessions();
@@ -887,19 +904,20 @@ const initialize = async () => {
     setStartupStatus(state.token ? 'Checking your token…' : 'Connecting…');
     setConnectionState(state.token ? 'Validating token…' : 'Connecting…');
 
+    const sessionsPromise = mergeServerSessions();
+
     // Fetch providers first so we can validate the stored selection.
     state.providers = await fetchProviders();
     normalizeSelectedProvider();
     renderProviderOptions();
 
-    state.models = await fetchModels('', state.selectedProvider);
+    const modelsPromise = fetchModels('', state.selectedProvider);
+    setStartupStatus('Syncing sessions…');
+
+    [state.models] = await Promise.all([modelsPromise, sessionsPromise]);
     state.connected = true;
     renderModelOptions();
     setConnectionState('', '');
-    setStartupStatus('Syncing sessions…');
-
-    // Merge server-side sessions after successful auth
-    await mergeServerSessions();
     startSidebarStatusPoll();
     if (!state.draftSessionActive && !getActiveSession()) {
       ensureActiveSession();
@@ -913,20 +931,8 @@ const initialize = async () => {
       subscribeToPush();
     }
 
-    // Lazy-load messages for URL-targeted server session
-    const active = getActiveSession();
-    if (active && active._serverOnly) {
-      const msgs = await loadServerSessionMessages(active.id);
-      if (msgs !== null) {
-        mergeServerMessagesWithLocalState(active, msgs);
-        saveSessions();
-        renderSidebar();
-        renderMessages(true);
-      }
-    }
-    if (active) {
-      await syncActiveSessionFromServer(active, true);
-    }
+    hideStartupSplash();
+    await hydrateActiveSessionAfterStartup().catch(() => {});
   } catch (err) {
     const message = err?.message || 'Unable to validate token.';
     setStartupStatus(message);


### PR DESCRIPTION
## What

- start the providers/models path and the server sessions merge in parallel during `/chat` startup
- move active-session message/state hydration into a small post-splash helper so the fixed startup overlay can disappear once the shell, auth, providers, models, and session list are ready
- preserve the existing session hydration behavior by continuing to await that follow-up work after the splash is hidden

## Why

Startup was blocked behind a fully serialized providers → models → sessions → messages → state waterfall. That meant one slow endpoint could keep the entire UI looking "not ready" for much longer than necessary. This change shortens the critical path by overlapping independent requests and removes active-session hydration from the splash-gated path, so the chat UI becomes usable sooner without a broad refactor.
