### PR TITLE
perf: skip skill bodies during metadata discovery

### DIFF
--- a/internal/skills/parser.go
+++ b/internal/skills/parser.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,22 +25,34 @@ type frontmatterData struct {
 // ParseSkillMD parses a SKILL.md file and returns a Skill.
 // The loadBody parameter controls whether to load the full Markdown body.
 func ParseSkillMD(path string, loadBody bool) (*Skill, error) {
+	if !loadBody {
+		frontmatter, err := readSkillMDFrontmatter(path)
+		if err != nil {
+			return nil, err
+		}
+		return parseSkillFrontmatter(frontmatter, "", false)
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read SKILL.md: %w", err)
 	}
 
-	return ParseSkillMDContent(string(data), loadBody)
+	return ParseSkillMDContent(string(data), true)
 }
 
 // ParseSkillMDContent parses SKILL.md content from a string.
 func ParseSkillMDContent(content string, loadBody bool) (*Skill, error) {
 	// Split frontmatter and body
-	frontmatter, body, err := splitFrontmatter(content)
+	frontmatter, body, err := splitFrontmatter(content, loadBody)
 	if err != nil {
 		return nil, err
 	}
 
+	return parseSkillFrontmatter(frontmatter, body, loadBody)
+}
+
+func parseSkillFrontmatter(frontmatter, body string, loadBody bool) (*Skill, error) {
 	// Parse frontmatter into known fields
 	var fm frontmatterData
 	if err := yaml.Unmarshal([]byte(frontmatter), &fm); err != nil {
@@ -77,7 +90,7 @@ func ParseSkillMDContent(content string, loadBody bool) (*Skill, error) {
 
 // splitFrontmatter extracts YAML frontmatter and Markdown body.
 // Frontmatter must be delimited by --- on its own lines.
-func splitFrontmatter(content string) (frontmatter, body string, err error) {
+func splitFrontmatter(content string, loadBody bool) (frontmatter, body string, err error) {
 	scanner := bufio.NewScanner(strings.NewReader(content))
 
 	// Look for opening ---
@@ -106,6 +119,10 @@ func splitFrontmatter(content string) (frontmatter, body string, err error) {
 		return "", "", fmt.Errorf("empty frontmatter in SKILL.md")
 	}
 
+	if !loadBody {
+		return strings.Join(fmLines, "\n"), "", nil
+	}
+
 	// Rest is body
 	var bodyLines []string
 	for scanner.Scan() {
@@ -113,6 +130,55 @@ func splitFrontmatter(content string) (frontmatter, body string, err error) {
 	}
 
 	return strings.Join(fmLines, "\n"), strings.Join(bodyLines, "\n"), nil
+}
+
+func readSkillMDFrontmatter(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("read SKILL.md: %w", err)
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	var fmLines []string
+	inFrontmatter := false
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return "", fmt.Errorf("read SKILL.md: %w", err)
+		}
+		if err == io.EOF && line == "" {
+			break
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+		trimmed := strings.TrimSpace(line)
+
+		if !inFrontmatter {
+			if trimmed == "---" {
+				inFrontmatter = true
+			} else if trimmed != "" {
+				return "", fmt.Errorf("SKILL.md must start with YAML frontmatter (---)")
+			}
+		} else if trimmed == "---" {
+			if len(fmLines) == 0 {
+				return "", fmt.Errorf("empty frontmatter in SKILL.md")
+			}
+			return strings.Join(fmLines, "\n"), nil
+		} else {
+			fmLines = append(fmLines, line)
+		}
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	if len(fmLines) == 0 {
+		return "", fmt.Errorf("empty frontmatter in SKILL.md")
+	}
+	return strings.Join(fmLines, "\n"), nil
 }
 
 // parseAllowedTools handles the various formats for allowed-tools:

--- a/internal/skills/parser_test.go
+++ b/internal/skills/parser_test.go
@@ -3,8 +3,45 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func BenchmarkParseSkillMDMetadataOnlyLargeBody(b *testing.B) {
+	tmpDir := b.TempDir()
+	skillDir := filepath.Join(tmpDir, "large-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		b.Fatal(err)
+	}
+
+	var content strings.Builder
+	content.WriteString("---\n")
+	content.WriteString("name: large-skill\n")
+	content.WriteString("description: metadata-only parsing should not read this large body\n")
+	content.WriteString("allowed-tools: read grep glob\n")
+	content.WriteString("---\n\n")
+	chunk := strings.Repeat("Large body content that should be skipped during discovery.\n", 1024)
+	for i := 0; i < 128; i++ {
+		content.WriteString(chunk)
+	}
+
+	path := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(content.String()), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		skill, err := ParseSkillMD(path, false)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if skill.Body != "" || skill.IsLoaded() {
+			b.Fatalf("metadata-only parse loaded body: loaded=%v bodyLen=%d", skill.IsLoaded(), len(skill.Body))
+		}
+	}
+}
 
 func TestParseSkillMDContent_Valid(t *testing.T) {
 	content := `---


### PR DESCRIPTION
## What

- Change metadata-only skill loading (`ParseSkillMD(..., false)`) to stream just the SKILL.md YAML frontmatter and stop at the closing delimiter.
- Keep full skill activation loading unchanged: `loadBody=true` still reads and parses the complete file.
- Add a benchmark covering discovery of a large SKILL.md where only metadata is needed.

## Why

CLI startup for `ask`, `chat`, `serve`, and skills-aware flows builds the available-skills prompt from metadata only. The previous path read the entire SKILL.md and scanned/allocated the whole body even though discovery discards it, which is wasteful for large instruction bundles.

## Evidence

Benchmark on a large SKILL.md metadata-only parse:

- Before: ~8.7-9.6 ms/op, 43.3 MB/op, 131,274 allocs/op
- After: ~14.3-16.5 µs/op, 22.6 KB/op, 171 allocs/op

Verification:

- `go build ./...`
- `go test ./...`
- `go test ./internal/skills -run '^$' -bench BenchmarkParseSkillMDMetadataOnlyLargeBody -benchmem -count=8`
