### PR TITLE
perf: reduce debug log scanner allocations

### DIFF
--- a/internal/debuglog/parser.go
+++ b/internal/debuglog/parser.go
@@ -1,7 +1,6 @@
 package debuglog
 
 import (
-	"bufio"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -80,10 +79,7 @@ func parseSessionSummary(filePath string) (SessionSummary, error) {
 		FileSize: info.Size(),
 	}
 
-	scanner := bufio.NewScanner(file)
-	// Increase buffer size for large log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner := newDebugLogScanner(file)
 
 	requestSeen := false
 
@@ -145,9 +141,7 @@ func ParseSession(filePath string) (*Session, error) {
 		FilePath: filePath,
 	}
 
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner := newDebugLogScanner(file)
 
 	for scanner.Scan() {
 		var entry rawEntry
@@ -316,9 +310,7 @@ func ParseRawLines(filePath string) ([]json.RawMessage, error) {
 	defer file.Close()
 
 	var lines []json.RawMessage
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner := newDebugLogScanner(file)
 
 	for scanner.Scan() {
 		line := scanner.Bytes()

--- a/internal/debuglog/scanner.go
+++ b/internal/debuglog/scanner.go
@@ -1,0 +1,19 @@
+package debuglog
+
+import (
+	"bufio"
+	"io"
+)
+
+const (
+	// Most debug log lines are small event records; start with Scanner's
+	// default-sized buffer and retain the old 1 MiB ceiling for large payloads.
+	debugLogScannerInitialBuffer = 4 * 1024
+	debugLogScannerMaxBuffer     = 1024 * 1024
+)
+
+func newDebugLogScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, debugLogScannerInitialBuffer), debugLogScannerMaxBuffer)
+	return scanner
+}

--- a/internal/debuglog/search.go
+++ b/internal/debuglog/search.go
@@ -1,7 +1,6 @@
 package debuglog
 
 import (
-	"bufio"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -153,9 +152,7 @@ func firstSessionTimestamp(filePath string) (time.Time, error) {
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner := newDebugLogScanner(file)
 	for scanner.Scan() {
 		var entry rawEntry
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
@@ -182,9 +179,7 @@ func searchSessionTextQuery(filePath, query string) ([]SearchResult, error) {
 	queryASCII := isASCII(queryLower)
 
 	var results []SearchResult
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner := newDebugLogScanner(file)
 
 	lineNum := 0
 	for scanner.Scan() {
@@ -347,9 +342,7 @@ func searchSession(filePath string, opts SearchOptions) ([]SearchResult, error) 
 	sessionID := strings.TrimSuffix(filepath.Base(filePath), ".jsonl")
 
 	var results []SearchResult
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	scanner := newDebugLogScanner(file)
 
 	lineNum := 0
 	for scanner.Scan() {

--- a/internal/debuglog/search_test.go
+++ b/internal/debuglog/search_test.go
@@ -39,6 +39,27 @@ func TestSearchTextQueryFiltersByDaysAndReturnsMatches(t *testing.T) {
 	}
 }
 
+func TestSearchTextQueryHandlesLargeLogLine(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+	largeText := strings.Repeat("x", 70*1024) + " NeedLe past the old initial scanner buffer"
+
+	writeDebugSearchFixture(t, dir, "large", now.Add(-time.Minute), []string{
+		debugSearchEventLine(now.Add(-30*time.Second), "large", "text_delta", fmt.Sprintf(`{"text":%q}`, largeText)),
+	})
+
+	results, err := Search(dir, SearchOptions{Query: "needle", Days: 1})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1: %#v", len(results), results)
+	}
+	if !strings.Contains(strings.ToLower(results[0].Match), "needle") {
+		t.Fatalf("Match = %q, want snippet containing needle", results[0].Match)
+	}
+}
+
 func BenchmarkSearchTextQuery(b *testing.B) {
 	dir := b.TempDir()
 	base := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)


### PR DESCRIPTION
## What

Reduce debug log JSONL scanner allocation overhead by centralizing scanner construction with a 4 KiB initial buffer while keeping the existing 1 MiB maximum line size.

## Why

A whole-repo benchmark pass showed `internal/debuglog` text search allocating about 1.6 MB per search. The hot path opens each JSONL file twice in the text-query fast path, and every scan preallocated a 64 KiB buffer even though ordinary debug event lines are much smaller.

Starting at the standard scanner-sized 4 KiB buffer lets small-line scans stay light while preserving large-line support via the same 1 MiB cap.

## Evidence

Focused benchmark (`go test ./internal/debuglog -run '^$' -bench BenchmarkSearchTextQuery -benchmem -count=5`):

Before:
- 1.136-1.164 ms/op
- ~1,608,829-1,609,066 B/op
- 464 allocs/op

After:
- 0.820-0.844 ms/op
- ~127,772-127,829 B/op
- 462 allocs/op

This is roughly 92% less allocated bytes/op and about 27% lower latency on the benchmark fixture.

## Verification

- `go test ./internal/debuglog -run TestSearchTextQuery -bench BenchmarkSearchTextQuery -benchmem -count=5`
- `go test ./...`
- `go build ./...`
