### PR TITLE
feat: allow video references from stdin

### DIFF
--- a/cmd/video.go
+++ b/cmd/video.go
@@ -52,6 +52,7 @@ Examples:
   term-llm video "cute dog, influencer reacts" -i romeo.png -r pose1.png -r pose2.png
   term-llm video "cyberpunk city, slow dolly shot" --model kling-o3-pro-text-to-video
   term-llm image "robot cat" -o - | term-llm video "animate it" -i -
+  term-llm image "character portrait" -o - | term-llm video "make @Image1 wave" --model happyhorse-1-0-reference-to-video -r - --aspect-ratio 16:9
   term-llm video "cute dog, influencer reacts" -i romeo.png --aspect-ratio 9:16 --duration 10s
   term-llm video "astronaut on mars" --quote-only --json`,
 	Args: cobra.ArbitraryArgs,
@@ -81,8 +82,11 @@ func init() {
 }
 
 func runVideo(cmd *cobra.Command, args []string) error {
-	if videoInput == "-" && len(args) == 0 {
-		return fmt.Errorf("prompt required as an argument when --input - reads image data from stdin")
+	if videoInput == "-" && referencesUseStdin(videoReferences) {
+		return fmt.Errorf("stdin can only be used for one media input: use either --input - or one --reference -")
+	}
+	if (videoInput == "-" || referencesUseStdin(videoReferences)) && len(args) == 0 {
+		return fmt.Errorf("prompt required as an argument when stdin is used for media input")
 	}
 
 	prompt, err := resolveVideoPrompt(args)
@@ -130,7 +134,7 @@ func runVideo(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	references, err := loadVideoReferences(videoReferences)
+	references, err := loadVideoReferences(cmd, videoReferences)
 	if err != nil {
 		return err
 	}
@@ -284,20 +288,49 @@ func loadVideoInput(cmd *cobra.Command, path string) ([]byte, error) {
 	return video.LoadInputImage(path)
 }
 
-func loadVideoReferences(paths []string) ([]video.InputImage, error) {
+func loadVideoReferences(cmd *cobra.Command, paths []string) ([]video.InputImage, error) {
 	if len(paths) == 0 {
 		return nil, nil
+	}
+	if countStdinReferences(paths) > 1 {
+		return nil, fmt.Errorf("only one --reference - is allowed")
 	}
 
 	references := make([]video.InputImage, 0, len(paths))
 	for _, path := range paths {
-		data, err := video.LoadInputImage(path)
-		if err != nil {
-			return nil, err
+		var data []byte
+		var err error
+		if path == "-" {
+			data, err = io.ReadAll(cmd.InOrStdin())
+			if err != nil {
+				return nil, fmt.Errorf("read reference image from stdin: %w", err)
+			}
+			if len(data) == 0 {
+				return nil, fmt.Errorf("read reference image from stdin: no data")
+			}
+		} else {
+			data, err = video.LoadInputImage(path)
+			if err != nil {
+				return nil, err
+			}
 		}
 		references = append(references, video.InputImage{Path: path, Data: data})
 	}
 	return references, nil
+}
+
+func referencesUseStdin(paths []string) bool {
+	return countStdinReferences(paths) > 0
+}
+
+func countStdinReferences(paths []string) int {
+	count := 0
+	for _, path := range paths {
+		if path == "-" {
+			count++
+		}
+	}
+	return count
 }
 
 func saveVideoOutput(defaultDir, prompt, explicitPath string, data []byte) (string, error) {

--- a/cmd/video_test.go
+++ b/cmd/video_test.go
@@ -59,7 +59,7 @@ func TestLoadVideoReferences(t *testing.T) {
 		t.Fatalf("write second: %v", err)
 	}
 
-	references, err := loadVideoReferences([]string{first, second})
+	references, err := loadVideoReferences(&cobra.Command{}, []string{first, second})
 	if err != nil {
 		t.Fatalf("loadVideoReferences: %v", err)
 	}
@@ -71,6 +71,78 @@ func TestLoadVideoReferences(t *testing.T) {
 	}
 	if references[1].Path != second || string(references[1].Data) != "two" {
 		t.Fatalf("unexpected second reference: %+v", references[1])
+	}
+}
+
+func TestLoadVideoReferencesFromStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewReader([]byte("reference-bytes")))
+
+	references, err := loadVideoReferences(cmd, []string{"-"})
+	if err != nil {
+		t.Fatalf("loadVideoReferences stdin: %v", err)
+	}
+	if len(references) != 1 {
+		t.Fatalf("len(references) = %d, want 1", len(references))
+	}
+	if references[0].Path != "-" || string(references[0].Data) != "reference-bytes" {
+		t.Fatalf("unexpected reference: %+v", references[0])
+	}
+}
+
+func TestLoadVideoReferencesFromEmptyStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewReader(nil))
+
+	_, err := loadVideoReferences(cmd, []string{"-"})
+	if err == nil {
+		t.Fatal("expected empty stdin error")
+	}
+}
+
+func TestLoadVideoReferencesRejectsMultipleStdinReferences(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewReader([]byte("reference-bytes")))
+
+	_, err := loadVideoReferences(cmd, []string{"-", "-"})
+	if err == nil {
+		t.Fatal("expected multiple stdin references error")
+	}
+	if !strings.Contains(err.Error(), "only one --reference -") {
+		t.Fatalf("error = %v, want only one --reference -", err)
+	}
+}
+
+func TestRunVideoRequiresArgPromptWhenReferenceUsesStdin(t *testing.T) {
+	oldReferences := videoReferences
+	videoReferences = []string{"-"}
+	defer func() { videoReferences = oldReferences }()
+
+	err := runVideo(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("expected prompt-required error")
+	}
+	if !strings.Contains(err.Error(), "prompt required") {
+		t.Fatalf("error = %v, want prompt required", err)
+	}
+}
+
+func TestRunVideoRejectsInputAndReferenceBothUsingStdin(t *testing.T) {
+	oldInput := videoInput
+	oldReferences := videoReferences
+	videoInput = "-"
+	videoReferences = []string{"-"}
+	defer func() {
+		videoInput = oldInput
+		videoReferences = oldReferences
+	}()
+
+	err := runVideo(&cobra.Command{}, []string{"animate"})
+	if err == nil {
+		t.Fatal("expected stdin conflict error")
+	}
+	if !strings.Contains(err.Error(), "stdin can only be used for one media input") {
+		t.Fatalf("error = %v, want stdin conflict", err)
 	}
 }
 


### PR DESCRIPTION
## What

Adds stdin support for video reference images:

```bash
term-llm image "character portrait" -o - |
  term-llm video "make @Image1 wave" \
    --model happyhorse-1-0-reference-to-video \
    --reference - \
    --aspect-ratio 16:9
```

## Why

The previous media-pipe work made `-i -` work for normal image-to-video models that use Venice's `image_url` field.

Reference-to-video models such as `happyhorse-1-0-reference-to-video` require `reference_image_urls` instead, so `--input -` is the wrong API shape. Supporting `--reference -` completes the pipe story for R2V models without conflating input-image and reference-image semantics.

## Details

- Allows one `--reference -` to read reference image bytes from stdin.
- Rejects multiple `--reference -` values because stdin can only be consumed once.
- Rejects combining `--input -` and `--reference -` in one command.
- Requires the video prompt as an argv argument whenever stdin is used for media, so stdin is not ambiguously both prompt and image bytes.
- Adds a help example for `image -o - | video --reference -`.

## Verification

```bash
go build ./...
go test ./...
```

Compiled binary smoke using debug image provider piped into Venice quote path:

```bash
go build -o /tmp/term-llm-reference-stdin ./
/tmp/term-llm-reference-stdin image "reference stdin smoke image" -p debug -o - |
  /tmp/term-llm-reference-stdin video "animate @Image1 with subtle motion" \
    --model happyhorse-1-0-reference-to-video \
    --reference - \
    --aspect-ratio 16:9 \
    --duration 5s \
    --resolution 720p \
    --quote-only \
    --json
```

Observed:

```json
{
  "provider": "venice",
  "prompt": "animate @Image1 with subtle motion",
  "model": "happyhorse-1-0-reference-to-video",
  "duration": "5s",
  "aspect_ratio": "16:9",
  "resolution": "720p",
  "status": "quoted",
  "quote": {
    "amount": 0.77
  },
  "references": [
    "-"
  ]
}
```
