### PR TITLE
feat: add Venice text-to-speech audio command

### DIFF
--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -1,0 +1,251 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/audio"
+	"github.com/samsaffron/term-llm/internal/signal"
+	"github.com/spf13/cobra"
+)
+
+var (
+	audioProvider    string
+	audioOutput      string
+	audioModel       string
+	audioVoice       string
+	audioLanguage    string
+	audioPrompt      string
+	audioFormat      string
+	audioSpeed       float64
+	audioStreaming   bool
+	audioTemperature float64
+	audioTopP        float64
+	audioJSON        bool
+	audioDebug       bool
+)
+
+var audioCmd = &cobra.Command{
+	Use:   "audio <text>",
+	Short: "Generate speech audio with Venice AI",
+	Long: `Generate speech audio using Venice AI's text-to-speech API.
+
+By default:
+  - Saves to ~/Music/term-llm/
+  - Uses Venice tts-kokoro with voice af_sky
+  - Emits MP3 audio
+
+Examples:
+  term-llm audio "hello from term-llm"
+  term-llm audio "quick smoke test" --output smoke.mp3
+  term-llm audio "sad robot noises" --model tts-qwen3-0-6b --voice Vivian --prompt "Sad and slow."
+  term-llm audio "faster" --speed 1.25 --format wav
+  echo "pipe me" | term-llm audio --voice af_bella -o - > out.mp3
+  term-llm audio "machine readable" --json`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runAudio,
+}
+
+func init() {
+	audioCmd.Flags().StringVarP(&audioProvider, "provider", "p", "venice", "Audio provider override (currently only venice)")
+	audioCmd.Flags().StringVarP(&audioOutput, "output", "o", "", "Custom output path, or - for stdout")
+	audioCmd.Flags().StringVar(&audioModel, "model", "", "Venice TTS model to use")
+	audioCmd.Flags().StringVar(&audioVoice, "voice", "", "Voice to use (model-specific; also accepts Venice cloned voice handles vv_<id>)")
+	audioCmd.Flags().StringVar(&audioLanguage, "language", "", "Optional language hint (model-specific; e.g. English or en)")
+	audioCmd.Flags().StringVar(&audioPrompt, "prompt", "", "Optional style prompt for supported models")
+	audioCmd.Flags().StringVar(&audioFormat, "format", "", "Response format (mp3, opus, aac, flac, wav, pcm; default mp3)")
+	audioCmd.Flags().Float64Var(&audioSpeed, "speed", audio.DefaultSpeed, "Speech speed (0.25 to 4.0)")
+	audioCmd.Flags().BoolVar(&audioStreaming, "streaming", false, "Ask Venice to stream generation sentence by sentence; output is still collected before saving")
+	audioCmd.Flags().Float64Var(&audioTemperature, "temperature", -1, "Sampling temperature for supported models (0 to 2); -1 omits it")
+	audioCmd.Flags().Float64Var(&audioTopP, "top-p", -1, "Nucleus sampling for supported models (0 to 1); -1 omits it")
+	audioCmd.Flags().BoolVar(&audioJSON, "json", false, "Emit machine-readable JSON to stdout")
+	audioCmd.Flags().BoolVarP(&audioDebug, "debug", "d", false, "Show debug information")
+
+	rootCmd.AddCommand(audioCmd)
+}
+
+func runAudio(cmd *cobra.Command, args []string) error {
+	if audioProvider != "" && audioProvider != "venice" {
+		return fmt.Errorf("unsupported audio provider %q (currently only venice)", audioProvider)
+	}
+	if strings.TrimSpace(audioFormat) != "" {
+		if err := audio.ValidateFormat(audioFormat); err != nil {
+			return err
+		}
+	}
+	if err := audio.ValidateSpeed(audioSpeed); err != nil {
+		return err
+	}
+	var temperature *float64
+	if audioTemperature >= 0 {
+		if err := audio.ValidateTemperature(audioTemperature); err != nil {
+			return err
+		}
+		temperature = &audioTemperature
+	}
+	var topP *float64
+	if audioTopP >= 0 {
+		if err := audio.ValidateTopP(audioTopP); err != nil {
+			return err
+		}
+		topP = &audioTopP
+	}
+
+	text, err := resolveAudioText(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+
+	cfg, err := loadConfigWithSetup()
+	if err != nil {
+		return err
+	}
+	initThemeFromConfig(cfg)
+
+	apiKey := strings.TrimSpace(cfg.Audio.Venice.APIKey)
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(cfg.Image.Venice.APIKey)
+	}
+	if apiKey == "" {
+		return fmt.Errorf("VENICE_API_KEY not configured. Set environment variable or add to audio.venice.api_key in config")
+	}
+
+	model := firstNonEmpty(audioModel, cfg.Audio.Venice.Model, audio.DefaultModel)
+	voice := firstNonEmpty(audioVoice, cfg.Audio.Venice.Voice, audio.DefaultVoice)
+	format := firstNonEmpty(audioFormat, cfg.Audio.Venice.Format, audio.DefaultFormat)
+	if err := audio.ValidateFormat(format); err != nil {
+		return err
+	}
+
+	provider := audio.NewVeniceProvider(apiKey)
+	result, err := provider.Generate(ctx, audio.Request{
+		Input:          text,
+		Model:          model,
+		Voice:          voice,
+		Language:       audioLanguage,
+		Prompt:         audioPrompt,
+		ResponseFormat: format,
+		Speed:          audioSpeed,
+		Streaming:      audioStreaming,
+		Temperature:    temperature,
+		TopP:           topP,
+		Debug:          audioDebug,
+		DebugRaw:       debugRaw,
+	})
+	if err != nil {
+		return fmt.Errorf("audio generation failed: %w", err)
+	}
+
+	if audioOutput == "-" {
+		if _, err := cmd.OutOrStdout().Write(result.Data); err != nil {
+			return fmt.Errorf("write audio to stdout: %w", err)
+		}
+		return nil
+	}
+
+	outputPath, err := saveAudioOutput(cfg.Audio.OutputDir, text, audioOutput, format, result.Data)
+	if err != nil {
+		return err
+	}
+	if !audioJSON {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Saved to: %s\n", outputPath)
+	}
+	return emitAudioJSON(cmd, audioJSONResult{
+		Provider: "venice",
+		Text:     text,
+		Model:    model,
+		Voice:    voice,
+		Format:   format,
+		Output: &audioJSONOutput{
+			Path:     outputPath,
+			MimeType: result.MimeType,
+			Bytes:    len(result.Data),
+		},
+	})
+}
+
+func resolveAudioText(cmd *cobra.Command, args []string) (string, error) {
+	if len(args) > 0 {
+		text := strings.TrimSpace(strings.Join(args, " "))
+		if text == "" {
+			return "", fmt.Errorf("text is required")
+		}
+		return text, nil
+	}
+	stat, err := os.Stdin.Stat()
+	if err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+		data, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		text := strings.TrimSpace(string(data))
+		if text != "" {
+			return text, nil
+		}
+	}
+	return "", fmt.Errorf("text is required")
+}
+
+func saveAudioOutput(outputDir, text, outputPath, format string, data []byte) (string, error) {
+	if strings.TrimSpace(outputPath) == "" {
+		return audio.Save(data, outputDir, text, format)
+	}
+	path := expandOutputPath(outputPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write audio: %w", err)
+	}
+	return path, nil
+}
+
+func expandOutputPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+type audioJSONResult struct {
+	Provider string           `json:"provider"`
+	Text     string           `json:"text"`
+	Model    string           `json:"model"`
+	Voice    string           `json:"voice"`
+	Format   string           `json:"format"`
+	Output   *audioJSONOutput `json:"output,omitempty"`
+}
+
+type audioJSONOutput struct {
+	Path     string `json:"path"`
+	MimeType string `json:"mime_type"`
+	Bytes    int    `json:"bytes"`
+}
+
+func emitAudioJSON(cmd *cobra.Command, result audioJSONResult) error {
+	if !audioJSON {
+		return nil
+	}
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}

--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -15,23 +15,38 @@ import (
 )
 
 var (
-	audioProvider    string
-	audioOutput      string
-	audioModel       string
-	audioVoice       string
-	audioVoice1      string
-	audioVoice2      string
-	audioSpeaker1    string
-	audioSpeaker2    string
-	audioLanguage    string
-	audioPrompt      string
-	audioFormat      string
-	audioSpeed       float64
-	audioStreaming   bool
-	audioTemperature float64
-	audioTopP        float64
-	audioJSON        bool
-	audioDebug       bool
+	audioProvider                       string
+	audioOutput                         string
+	audioModel                          string
+	audioVoice                          string
+	audioVoice1                         string
+	audioVoice2                         string
+	audioSpeaker1                       string
+	audioSpeaker2                       string
+	audioLanguage                       string
+	audioPrompt                         string
+	audioFormat                         string
+	audioSpeed                          float64
+	audioStreaming                      bool
+	audioTemperature                    float64
+	audioTopP                           float64
+	audioStability                      float64
+	audioSimilarityBoost                float64
+	audioStyle                          float64
+	audioUseSpeakerBoost                bool
+	audioSeed                           string
+	audioPreviousText                   string
+	audioNextText                       string
+	audioPreviousRequestIDs             string
+	audioNextRequestIDs                 string
+	audioPronunciationDictionaries      string
+	audioUsePVCAsIVC                    bool
+	audioApplyTextNormalization         string
+	audioApplyLanguageTextNormalization bool
+	audioOptimizeStreamingLatency       int
+	audioEnableLogging                  bool
+	audioJSON                           bool
+	audioDebug                          bool
 )
 
 var audioCmd = &cobra.Command{
@@ -42,7 +57,7 @@ var audioCmd = &cobra.Command{
 By default:
   - Saves to ~/Music/term-llm/
   - Uses Venice tts-kokoro with voice af_sky unless audio.provider is configured
-  - Emits MP3 audio for Venice, WAV audio for Gemini
+  - Emits MP3 audio for Venice/ElevenLabs, WAV audio for Gemini
 
 Examples:
   term-llm audio "hello from term-llm"
@@ -50,6 +65,7 @@ Examples:
   term-llm audio "sad robot noises" --model tts-qwen3-0-6b --voice Vivian --prompt "Sad and slow."
   term-llm audio "faster" --speed 1.25 --format wav
   term-llm audio "Say cheerfully: hello" --provider gemini --voice Kore
+  term-llm audio "eleven labs smoke test" --provider elevenlabs --model eleven_flash_v2_5 --voice Rachel --format mp3_44100_128
   term-llm audio "TTS the following conversation between Joe and Jane: Joe: Hi. Jane: Hi." --provider gemini --speaker1 Joe --voice1 Kore --speaker2 Jane --voice2 Puck
   echo "pipe me" | term-llm audio --voice af_bella -o - > out.mp3
   term-llm audio "machine readable" --json`,
@@ -58,29 +74,45 @@ Examples:
 }
 
 func init() {
-	audioCmd.Flags().StringVarP(&audioProvider, "provider", "p", "", "Audio provider override (venice, gemini)")
+	audioCmd.Flags().StringVarP(&audioProvider, "provider", "p", "", "Audio provider override (venice, gemini, elevenlabs)")
 	audioCmd.Flags().StringVarP(&audioOutput, "output", "o", "", "Custom output path, or - for stdout")
 	audioCmd.Flags().StringVar(&audioModel, "model", "", "TTS model to use")
-	audioCmd.Flags().StringVar(&audioVoice, "voice", "", "Voice to use (provider/model-specific; also accepts Venice cloned voice handles vv_<id>)")
+	audioCmd.Flags().StringVar(&audioVoice, "voice", "", "Voice to use (provider/model-specific; ElevenLabs accepts voice_id or account voice name; Venice cloned voice handles vv_<id>)")
 	audioCmd.Flags().StringVar(&audioVoice1, "voice1", "", "Gemini multi-speaker voice for --speaker1")
 	audioCmd.Flags().StringVar(&audioVoice2, "voice2", "", "Gemini multi-speaker voice for --speaker2")
 	audioCmd.Flags().StringVar(&audioSpeaker1, "speaker1", "", "Gemini multi-speaker label for the first speaker")
 	audioCmd.Flags().StringVar(&audioSpeaker2, "speaker2", "", "Gemini multi-speaker label for the second speaker")
 	audioCmd.Flags().StringVar(&audioLanguage, "language", "", "Optional language hint (Venice model-specific; e.g. English or en)")
 	audioCmd.Flags().StringVar(&audioPrompt, "prompt", "", "Optional style prompt for supported models")
-	audioCmd.Flags().StringVar(&audioFormat, "format", "", "Response format (Venice: mp3, opus, aac, flac, wav, pcm; Gemini: wav, pcm)")
-	audioCmd.Flags().Float64Var(&audioSpeed, "speed", audio.DefaultSpeed, "Speech speed for Venice (0.25 to 4.0)")
-	audioCmd.Flags().BoolVar(&audioStreaming, "streaming", false, "Ask Venice to stream generation sentence by sentence; output is still collected before saving")
+	audioCmd.Flags().StringVar(&audioFormat, "format", "", "Response format (Venice: mp3, opus, aac, flac, wav, pcm; Gemini: wav, pcm; ElevenLabs: mp3_44100_128, pcm_24000, wav_44100, etc.)")
+	audioCmd.Flags().Float64Var(&audioSpeed, "speed", audio.DefaultSpeed, "Speech speed (Venice: 0.25 to 4.0; ElevenLabs: 0.7 to 1.2)")
+	audioCmd.Flags().BoolVar(&audioStreaming, "streaming", false, "Ask supported providers to stream; output is still collected before saving")
 	audioCmd.Flags().Float64Var(&audioTemperature, "temperature", -1, "Sampling temperature for supported models (0 to 2); -1 omits it")
 	audioCmd.Flags().Float64Var(&audioTopP, "top-p", -1, "Nucleus sampling for supported models (0 to 1); -1 omits it")
+	audioCmd.Flags().Float64Var(&audioStability, "stability", -1, "ElevenLabs voice stability (0 to 1); -1 omits it")
+	audioCmd.Flags().Float64Var(&audioSimilarityBoost, "similarity-boost", -1, "ElevenLabs similarity boost (0 to 1); -1 omits it")
+	audioCmd.Flags().Float64Var(&audioStyle, "style", -1, "ElevenLabs style exaggeration (0 to 1); -1 omits it")
+	audioCmd.Flags().BoolVar(&audioUseSpeakerBoost, "speaker-boost", true, "ElevenLabs speaker boost voice setting")
+	audioCmd.Flags().StringVar(&audioSeed, "seed", "", "ElevenLabs deterministic seed (0 to 4294967295)")
+	audioCmd.Flags().StringVar(&audioPreviousText, "previous-text", "", "ElevenLabs continuity hint: text before this request")
+	audioCmd.Flags().StringVar(&audioNextText, "next-text", "", "ElevenLabs continuity hint: text after this request")
+	audioCmd.Flags().StringVar(&audioPreviousRequestIDs, "previous-request-ids", "", "ElevenLabs comma-separated previous request IDs for continuity")
+	audioCmd.Flags().StringVar(&audioNextRequestIDs, "next-request-ids", "", "ElevenLabs comma-separated next request IDs for continuity")
+	audioCmd.Flags().StringVar(&audioPronunciationDictionaries, "pronunciation-dictionaries", "", "ElevenLabs comma-separated pronunciation dictionary IDs, optionally id:version")
+	audioCmd.Flags().BoolVar(&audioUsePVCAsIVC, "use-pvc-as-ivc", false, "ElevenLabs workaround to use IVC instead of PVC for lower latency")
+	audioCmd.Flags().StringVar(&audioApplyTextNormalization, "apply-text-normalization", "", "ElevenLabs text normalization (auto, on, off)")
+	audioCmd.Flags().BoolVar(&audioApplyLanguageTextNormalization, "apply-language-text-normalization", false, "ElevenLabs language text normalization, currently mainly Japanese")
+	audioCmd.Flags().IntVar(&audioOptimizeStreamingLatency, "optimize-streaming-latency", -1, "ElevenLabs latency optimization level (0 to 4); -1 omits it")
+	audioCmd.Flags().BoolVar(&audioEnableLogging, "enable-logging", true, "ElevenLabs request logging/history; set false for zero-retention-capable accounts")
 	audioCmd.Flags().BoolVar(&audioJSON, "json", false, "Emit machine-readable JSON to stdout")
 	audioCmd.Flags().BoolVarP(&audioDebug, "debug", "d", false, "Show debug information")
-	_ = audioCmd.RegisterFlagCompletionFunc("provider", staticCompletion("venice", "gemini"))
+	_ = audioCmd.RegisterFlagCompletionFunc("provider", staticCompletion("venice", "gemini", "elevenlabs"))
 	_ = audioCmd.RegisterFlagCompletionFunc("model", audioModelCompletion)
 	_ = audioCmd.RegisterFlagCompletionFunc("voice", audioVoiceCompletion)
 	_ = audioCmd.RegisterFlagCompletionFunc("voice1", audioGeminiVoiceCompletion)
 	_ = audioCmd.RegisterFlagCompletionFunc("voice2", audioGeminiVoiceCompletion)
 	_ = audioCmd.RegisterFlagCompletionFunc("format", audioFormatCompletion)
+	_ = audioCmd.RegisterFlagCompletionFunc("apply-text-normalization", staticCompletion(audio.ElevenLabsTextNormalization...))
 
 	rootCmd.AddCommand(audioCmd)
 }
@@ -121,8 +153,10 @@ func runAudio(cmd *cobra.Command, args []string) error {
 		return runVeniceAudio(cmd, cfg, text, temperature, topP)
 	case "gemini":
 		return runGeminiAudio(cmd, cfg, text, temperature, topP)
+	case "elevenlabs":
+		return runElevenLabsAudio(cmd, cfg, text)
 	default:
-		return fmt.Errorf("unsupported audio provider %q (allowed: venice, gemini)", providerName)
+		return fmt.Errorf("unsupported audio provider %q (allowed: venice, gemini, elevenlabs)", providerName)
 	}
 }
 
@@ -215,6 +249,66 @@ func runGeminiAudio(cmd *cobra.Command, cfg *config.Config, text string, tempera
 		return fmt.Errorf("audio generation failed: %w", err)
 	}
 	return writeAudioResult(cmd, cfg.Audio.OutputDir, "gemini", text, model, voice, format, result)
+}
+
+func runElevenLabsAudio(cmd *cobra.Command, cfg *config.Config, text string) error {
+	apiKey := strings.TrimSpace(cfg.Audio.ElevenLabs.APIKey)
+	if apiKey == "" {
+		if elevenLabsProvider := cfg.GetProviderConfig("elevenlabs"); elevenLabsProvider != nil {
+			apiKey = strings.TrimSpace(elevenLabsProvider.ResolvedAPIKey)
+		}
+	}
+	if apiKey == "" {
+		return fmt.Errorf("ELEVENLABS_API_KEY not configured. Set environment variable or add to audio.elevenlabs.api_key in config")
+	}
+	if strings.TrimSpace(audioPrompt) != "" {
+		return fmt.Errorf("ElevenLabs TTS does not support --prompt; include style instructions in the text or use voice settings")
+	}
+	if audioTemperature >= 0 || audioTopP >= 0 {
+		return fmt.Errorf("ElevenLabs TTS does not support --temperature or --top-p")
+	}
+
+	model := firstNonEmpty(audioModel, cfg.Audio.ElevenLabs.Model, "eleven_multilingual_v2")
+	voice := firstNonEmpty(audioVoice, cfg.Audio.ElevenLabs.Voice, "JBFqnCBsd6RMkjVDRZzb")
+	format := firstNonEmpty(audioFormat, cfg.Audio.ElevenLabs.Format, "mp3_44100_128")
+	if err := audio.ValidateElevenLabsFormat(format); err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+	provider := audio.NewElevenLabsProvider(apiKey)
+	result, err := provider.Generate(ctx, audio.Request{
+		Input:                          text,
+		Model:                          model,
+		Voice:                          voice,
+		Language:                       audioLanguage,
+		ResponseFormat:                 format,
+		Speed:                          audioSpeed,
+		Streaming:                      audioStreaming,
+		Stability:                      audioStability,
+		SimilarityBoost:                audioSimilarityBoost,
+		Style:                          audioStyle,
+		UseSpeakerBoost:                audioUseSpeakerBoost,
+		UseSpeakerBoostSet:             cmd.Flags().Changed("speaker-boost"),
+		Seed:                           audioSeed,
+		PreviousText:                   audioPreviousText,
+		NextText:                       audioNextText,
+		PreviousRequestIDs:             audioPreviousRequestIDs,
+		NextRequestIDs:                 audioNextRequestIDs,
+		PronunciationDictionaries:      audioPronunciationDictionaries,
+		UsePVCAsIVC:                    audioUsePVCAsIVC,
+		ApplyTextNormalization:         audioApplyTextNormalization,
+		ApplyLanguageTextNormalization: audioApplyLanguageTextNormalization,
+		OptimizeStreamingLatency:       audioOptimizeStreamingLatency,
+		EnableLogging:                  audioEnableLogging,
+		Debug:                          audioDebug,
+		DebugRaw:                       debugRaw,
+	})
+	if err != nil {
+		return fmt.Errorf("audio generation failed: %w", err)
+	}
+	return writeAudioResult(cmd, cfg.Audio.OutputDir, "elevenlabs", text, model, voice, format, result)
 }
 
 func writeAudioResult(cmd *cobra.Command, outputDir, providerName, text, model, voice, format string, result *audio.Result) error {
@@ -336,6 +430,9 @@ func audioModelCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, c
 	if provider == "gemini" {
 		return audio.GeminiModels, cobra.ShellCompDirectiveNoFileComp
 	}
+	if provider == "elevenlabs" {
+		return audio.ElevenLabsModels, cobra.ShellCompDirectiveNoFileComp
+	}
 	return audio.VeniceModels, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -343,6 +440,9 @@ func audioVoiceCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, c
 	provider := completionProvider(cmd)
 	if provider == "gemini" {
 		return audio.GeminiVoices, cobra.ShellCompDirectiveNoFileComp
+	}
+	if provider == "elevenlabs" {
+		return audio.ElevenLabsVoices, cobra.ShellCompDirectiveNoFileComp
 	}
 	return audio.VeniceVoices, cobra.ShellCompDirectiveNoFileComp
 }
@@ -355,6 +455,9 @@ func audioFormatCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, 
 	provider := completionProvider(cmd)
 	if provider == "gemini" {
 		return audio.GeminiFormats, cobra.ShellCompDirectiveNoFileComp
+	}
+	if provider == "elevenlabs" {
+		return audio.ElevenLabsFormats, cobra.ShellCompDirectiveNoFileComp
 	}
 	return audio.VeniceFormats, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/samsaffron/term-llm/internal/audio"
+	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/spf13/cobra"
 )
@@ -18,6 +19,10 @@ var (
 	audioOutput      string
 	audioModel       string
 	audioVoice       string
+	audioVoice1      string
+	audioVoice2      string
+	audioSpeaker1    string
+	audioSpeaker2    string
 	audioLanguage    string
 	audioPrompt      string
 	audioFormat      string
@@ -31,19 +36,21 @@ var (
 
 var audioCmd = &cobra.Command{
 	Use:   "audio <text>",
-	Short: "Generate speech audio with Venice AI",
-	Long: `Generate speech audio using Venice AI's text-to-speech API.
+	Short: "Generate speech audio",
+	Long: `Generate speech audio using a configured text-to-speech provider.
 
 By default:
   - Saves to ~/Music/term-llm/
-  - Uses Venice tts-kokoro with voice af_sky
-  - Emits MP3 audio
+  - Uses Venice tts-kokoro with voice af_sky unless audio.provider is configured
+  - Emits MP3 audio for Venice, WAV audio for Gemini
 
 Examples:
   term-llm audio "hello from term-llm"
   term-llm audio "quick smoke test" --output smoke.mp3
   term-llm audio "sad robot noises" --model tts-qwen3-0-6b --voice Vivian --prompt "Sad and slow."
   term-llm audio "faster" --speed 1.25 --format wav
+  term-llm audio "Say cheerfully: hello" --provider gemini --voice Kore
+  term-llm audio "TTS the following conversation between Joe and Jane: Joe: Hi. Jane: Hi." --provider gemini --speaker1 Joe --voice1 Kore --speaker2 Jane --voice2 Puck
   echo "pipe me" | term-llm audio --voice af_bella -o - > out.mp3
   term-llm audio "machine readable" --json`,
 	Args: cobra.ArbitraryArgs,
@@ -51,32 +58,34 @@ Examples:
 }
 
 func init() {
-	audioCmd.Flags().StringVarP(&audioProvider, "provider", "p", "venice", "Audio provider override (currently only venice)")
+	audioCmd.Flags().StringVarP(&audioProvider, "provider", "p", "", "Audio provider override (venice, gemini)")
 	audioCmd.Flags().StringVarP(&audioOutput, "output", "o", "", "Custom output path, or - for stdout")
-	audioCmd.Flags().StringVar(&audioModel, "model", "", "Venice TTS model to use")
-	audioCmd.Flags().StringVar(&audioVoice, "voice", "", "Voice to use (model-specific; also accepts Venice cloned voice handles vv_<id>)")
-	audioCmd.Flags().StringVar(&audioLanguage, "language", "", "Optional language hint (model-specific; e.g. English or en)")
+	audioCmd.Flags().StringVar(&audioModel, "model", "", "TTS model to use")
+	audioCmd.Flags().StringVar(&audioVoice, "voice", "", "Voice to use (provider/model-specific; also accepts Venice cloned voice handles vv_<id>)")
+	audioCmd.Flags().StringVar(&audioVoice1, "voice1", "", "Gemini multi-speaker voice for --speaker1")
+	audioCmd.Flags().StringVar(&audioVoice2, "voice2", "", "Gemini multi-speaker voice for --speaker2")
+	audioCmd.Flags().StringVar(&audioSpeaker1, "speaker1", "", "Gemini multi-speaker label for the first speaker")
+	audioCmd.Flags().StringVar(&audioSpeaker2, "speaker2", "", "Gemini multi-speaker label for the second speaker")
+	audioCmd.Flags().StringVar(&audioLanguage, "language", "", "Optional language hint (Venice model-specific; e.g. English or en)")
 	audioCmd.Flags().StringVar(&audioPrompt, "prompt", "", "Optional style prompt for supported models")
-	audioCmd.Flags().StringVar(&audioFormat, "format", "", "Response format (mp3, opus, aac, flac, wav, pcm; default mp3)")
-	audioCmd.Flags().Float64Var(&audioSpeed, "speed", audio.DefaultSpeed, "Speech speed (0.25 to 4.0)")
+	audioCmd.Flags().StringVar(&audioFormat, "format", "", "Response format (Venice: mp3, opus, aac, flac, wav, pcm; Gemini: wav, pcm)")
+	audioCmd.Flags().Float64Var(&audioSpeed, "speed", audio.DefaultSpeed, "Speech speed for Venice (0.25 to 4.0)")
 	audioCmd.Flags().BoolVar(&audioStreaming, "streaming", false, "Ask Venice to stream generation sentence by sentence; output is still collected before saving")
 	audioCmd.Flags().Float64Var(&audioTemperature, "temperature", -1, "Sampling temperature for supported models (0 to 2); -1 omits it")
 	audioCmd.Flags().Float64Var(&audioTopP, "top-p", -1, "Nucleus sampling for supported models (0 to 1); -1 omits it")
 	audioCmd.Flags().BoolVar(&audioJSON, "json", false, "Emit machine-readable JSON to stdout")
 	audioCmd.Flags().BoolVarP(&audioDebug, "debug", "d", false, "Show debug information")
+	_ = audioCmd.RegisterFlagCompletionFunc("provider", staticCompletion("venice", "gemini"))
+	_ = audioCmd.RegisterFlagCompletionFunc("model", audioModelCompletion)
+	_ = audioCmd.RegisterFlagCompletionFunc("voice", audioVoiceCompletion)
+	_ = audioCmd.RegisterFlagCompletionFunc("voice1", audioGeminiVoiceCompletion)
+	_ = audioCmd.RegisterFlagCompletionFunc("voice2", audioGeminiVoiceCompletion)
+	_ = audioCmd.RegisterFlagCompletionFunc("format", audioFormatCompletion)
 
 	rootCmd.AddCommand(audioCmd)
 }
 
 func runAudio(cmd *cobra.Command, args []string) error {
-	if audioProvider != "" && audioProvider != "venice" {
-		return fmt.Errorf("unsupported audio provider %q (currently only venice)", audioProvider)
-	}
-	if strings.TrimSpace(audioFormat) != "" {
-		if err := audio.ValidateFormat(audioFormat); err != nil {
-			return err
-		}
-	}
 	if err := audio.ValidateSpeed(audioSpeed); err != nil {
 		return err
 	}
@@ -100,15 +109,24 @@ func runAudio(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, stop := signal.NotifyContext()
-	defer stop()
-
 	cfg, err := loadConfigWithSetup()
 	if err != nil {
 		return err
 	}
 	initThemeFromConfig(cfg)
 
+	providerName := firstNonEmpty(audioProvider, cfg.Audio.Provider, "venice")
+	switch providerName {
+	case "venice":
+		return runVeniceAudio(cmd, cfg, text, temperature, topP)
+	case "gemini":
+		return runGeminiAudio(cmd, cfg, text, temperature, topP)
+	default:
+		return fmt.Errorf("unsupported audio provider %q (allowed: venice, gemini)", providerName)
+	}
+}
+
+func runVeniceAudio(cmd *cobra.Command, cfg *config.Config, text string, temperature, topP *float64) error {
 	apiKey := strings.TrimSpace(cfg.Audio.Venice.APIKey)
 	if apiKey == "" {
 		apiKey = strings.TrimSpace(cfg.Image.Venice.APIKey)
@@ -124,6 +142,8 @@ func runAudio(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	ctx, stop := signal.NotifyContext()
+	defer stop()
 	provider := audio.NewVeniceProvider(apiKey)
 	result, err := provider.Generate(ctx, audio.Request{
 		Input:          text,
@@ -142,7 +162,62 @@ func runAudio(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("audio generation failed: %w", err)
 	}
+	return writeAudioResult(cmd, cfg.Audio.OutputDir, "venice", text, model, voice, format, result)
+}
 
+func runGeminiAudio(cmd *cobra.Command, cfg *config.Config, text string, temperature, topP *float64) error {
+	apiKey := strings.TrimSpace(cfg.Audio.Gemini.APIKey)
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(cfg.Image.Gemini.APIKey)
+	}
+	if apiKey == "" {
+		if geminiProvider := cfg.GetProviderConfig("gemini"); geminiProvider != nil {
+			apiKey = strings.TrimSpace(geminiProvider.ResolvedAPIKey)
+		}
+	}
+	if apiKey == "" {
+		return fmt.Errorf("GEMINI_API_KEY not configured. Set environment variable or add to audio.gemini.api_key in config")
+	}
+	if strings.TrimSpace(audioLanguage) != "" {
+		return fmt.Errorf("Gemini TTS auto-detects language and does not support --language")
+	}
+	if audioSpeed != 0 && audioSpeed != audio.DefaultSpeed {
+		return fmt.Errorf("Gemini TTS does not support --speed; use --prompt for pacing instructions")
+	}
+
+	model := firstNonEmpty(audioModel, cfg.Audio.Gemini.Model, "gemini-3.1-flash-tts-preview")
+	voice := firstNonEmpty(audioVoice, cfg.Audio.Gemini.Voice, "Kore")
+	format := firstNonEmpty(audioFormat, cfg.Audio.Gemini.Format, "wav")
+	if err := audio.ValidateGeminiFormat(format); err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+	provider := audio.NewGeminiProvider(apiKey)
+	result, err := provider.Generate(ctx, audio.Request{
+		Input:          text,
+		Model:          model,
+		Voice:          voice,
+		Voice1:         audioVoice1,
+		Voice2:         audioVoice2,
+		Speaker1:       audioSpeaker1,
+		Speaker2:       audioSpeaker2,
+		Prompt:         audioPrompt,
+		ResponseFormat: format,
+		Streaming:      audioStreaming,
+		Temperature:    temperature,
+		TopP:           topP,
+		Debug:          audioDebug,
+		DebugRaw:       debugRaw,
+	})
+	if err != nil {
+		return fmt.Errorf("audio generation failed: %w", err)
+	}
+	return writeAudioResult(cmd, cfg.Audio.OutputDir, "gemini", text, model, voice, format, result)
+}
+
+func writeAudioResult(cmd *cobra.Command, outputDir, providerName, text, model, voice, format string, result *audio.Result) error {
 	if audioOutput == "-" {
 		if _, err := cmd.OutOrStdout().Write(result.Data); err != nil {
 			return fmt.Errorf("write audio to stdout: %w", err)
@@ -150,7 +225,7 @@ func runAudio(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	outputPath, err := saveAudioOutput(cfg.Audio.OutputDir, text, audioOutput, format, result.Data)
+	outputPath, err := saveAudioOutput(outputDir, text, audioOutput, format, result.Data)
 	if err != nil {
 		return err
 	}
@@ -158,7 +233,7 @@ func runAudio(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Saved to: %s\n", outputPath)
 	}
 	return emitAudioJSON(cmd, audioJSONResult{
-		Provider: "venice",
+		Provider: providerName,
 		Text:     text,
 		Model:    model,
 		Voice:    voice,
@@ -248,4 +323,46 @@ func emitAudioJSON(cmd *cobra.Command, result audioJSONResult) error {
 	encoder := json.NewEncoder(cmd.OutOrStdout())
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(result)
+}
+
+func staticCompletion(values ...string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return values, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func audioModelCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	provider := completionProvider(cmd)
+	if provider == "gemini" {
+		return audio.GeminiModels, cobra.ShellCompDirectiveNoFileComp
+	}
+	return audio.VeniceModels, cobra.ShellCompDirectiveNoFileComp
+}
+
+func audioVoiceCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	provider := completionProvider(cmd)
+	if provider == "gemini" {
+		return audio.GeminiVoices, cobra.ShellCompDirectiveNoFileComp
+	}
+	return audio.VeniceVoices, cobra.ShellCompDirectiveNoFileComp
+}
+
+func audioGeminiVoiceCompletion(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return audio.GeminiVoices, cobra.ShellCompDirectiveNoFileComp
+}
+
+func audioFormatCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	provider := completionProvider(cmd)
+	if provider == "gemini" {
+		return audio.GeminiFormats, cobra.ShellCompDirectiveNoFileComp
+	}
+	return audio.VeniceFormats, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completionProvider(cmd *cobra.Command) string {
+	provider, _ := cmd.Flags().GetString("provider")
+	if strings.TrimSpace(provider) != "" {
+		return strings.TrimSpace(provider)
+	}
+	return "venice"
 }

--- a/cmd/audio_test.go
+++ b/cmd/audio_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveAudioTextFromArgs(t *testing.T) {
+	text, err := resolveAudioText(&cobra.Command{}, []string{"hello", "world"})
+	if err != nil {
+		t.Fatalf("resolveAudioText: %v", err)
+	}
+	if text != "hello world" {
+		t.Fatalf("text = %q, want hello world", text)
+	}
+}
+
+func TestSaveAudioOutputCustomPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clip.mp3")
+	got, err := saveAudioOutput(dir, "hello", path, "mp3", []byte("audio-bytes"))
+	if err != nil {
+		t.Fatalf("saveAudioOutput: %v", err)
+	}
+	if got != path {
+		t.Fatalf("path = %q, want %q", got, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) != "audio-bytes" {
+		t.Fatalf("data = %q, want audio-bytes", string(data))
+	}
+}
+
+func TestEmitAudioJSON(t *testing.T) {
+	oldJSON := audioJSON
+	audioJSON = true
+	defer func() { audioJSON = oldJSON }()
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	err := emitAudioJSON(cmd, audioJSONResult{
+		Provider: "venice",
+		Text:     "hello",
+		Model:    "tts-kokoro",
+		Voice:    "af_sky",
+		Format:   "mp3",
+		Output:   &audioJSONOutput{Path: "clip.mp3", MimeType: "audio/mpeg", Bytes: 5},
+	})
+	if err != nil {
+		t.Fatalf("emitAudioJSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["provider"] != "venice" || got["voice"] != "af_sky" {
+		t.Fatalf("unexpected json: %#v", got)
+	}
+}

--- a/docs-site/content/guides/audio-generation.md
+++ b/docs-site/content/guides/audio-generation.md
@@ -1,11 +1,11 @@
 ---
 title: "Audio generation"
 weight: 5
-description: "Generate speech audio with Venice AI text-to-speech models."
+description: "Generate speech audio with Venice AI and Gemini text-to-speech models."
 kicker: "Media"
 ---
 
-Generate speech audio using Venice AI's text-to-speech API.
+Generate speech audio using a configured text-to-speech provider.
 
 ```bash
 term-llm audio "hello from term-llm"
@@ -16,23 +16,35 @@ By default, audio clips are:
 - Generated with Venice `tts-kokoro`
 - Rendered as MP3 using voice `af_sky`
 
+You can also use Gemini TTS:
+
+```bash
+term-llm audio "Say cheerfully: hello from Gemini" --provider gemini --voice Kore
+```
+
 ### Audio Flags
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--provider` | `-p` | Audio provider override; currently `venice` |
+| `--provider` | `-p` | Audio provider override: `venice`, `gemini` |
 | `--output` | `-o` | Custom output path, or `-` for stdout |
-| `--model` | | Venice TTS model override |
+| `--model` | | TTS model override |
 | `--voice` | | Model-specific voice, or a Venice cloned voice handle like `vv_<id>` |
-| `--language` | | Optional language hint (`English`, `en`, etc.; model-specific) |
+| `--voice1` | | Gemini multi-speaker voice for `--speaker1` |
+| `--voice2` | | Gemini multi-speaker voice for `--speaker2` |
+| `--speaker1` | | Gemini multi-speaker label for the first speaker |
+| `--speaker2` | | Gemini multi-speaker label for the second speaker |
+| `--language` | | Optional Venice language hint (`English`, `en`, etc.; model-specific) |
 | `--prompt` | | Style/emotion prompt for models that support it |
-| `--format` | | Response format: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm` |
-| `--speed` | | Speech speed, `0.25` to `4.0` |
+| `--format` | | Venice: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`; Gemini: `wav`, `pcm` |
+| `--speed` | | Venice speech speed, `0.25` to `4.0` |
 | `--streaming` | | Ask Venice to stream sentence-by-sentence; term-llm still collects before saving |
 | `--temperature` | | Sampling temperature for supported models, `0` to `2`; omitted by default |
 | `--top-p` | | Nucleus sampling for supported models, `0` to `1`; omitted by default |
 | `--json` | | Emit machine-readable JSON to stdout |
 | `--debug` | `-d` | Show debug information |
+
+`--model`, `--voice`, `--voice1`, `--voice2`, `--format`, and `--provider` include shell completion candidates.
 
 ### Examples
 
@@ -44,6 +56,17 @@ term-llm audio "sad robot noises" \
   --model tts-qwen3-0-6b \
   --voice Vivian \
   --prompt "Sad and slow."
+
+term-llm audio "Say cheerfully: have a wonderful day" \
+  --provider gemini \
+  --model gemini-3.1-flash-tts-preview \
+  --voice Kore \
+  --format wav
+
+term-llm audio "TTS the following conversation between Joe and Jane: Joe: Hi Jane. Jane: Hi Joe." \
+  --provider gemini \
+  --speaker1 Joe --voice1 Kore \
+  --speaker2 Jane --voice2 Puck
 
 echo "pipe me" | term-llm audio --voice af_bella -o - > out.mp3
 ```
@@ -67,6 +90,20 @@ term-llm includes the Venice text-to-speech model catalog:
 
 Voices are model-specific. If a model rejects a voice, Venice returns the API error directly.
 
+### Gemini TTS Models
+
+| Model | Single speaker | Multi-speaker |
+|-------|----------------|---------------|
+| `gemini-3.1-flash-tts-preview` | Yes | Yes |
+| `gemini-2.5-flash-preview-tts` | Yes | Yes |
+| `gemini-2.5-pro-preview-tts` | Yes | Yes |
+
+Gemini TTS returns 24 kHz mono PCM. term-llm can save it directly as `pcm`, or wrap it as a `wav` file. Gemini TTS does not support streaming; language is auto-detected.
+
+Gemini prebuilt voices:
+
+`Zephyr`, `Puck`, `Charon`, `Kore`, `Fenrir`, `Leda`, `Orus`, `Aoede`, `Callirrhoe`, `Autonoe`, `Enceladus`, `Iapetus`, `Umbriel`, `Algieba`, `Despina`, `Erinome`, `Algenib`, `Rasalgethi`, `Laomedeia`, `Achernar`, `Alnilam`, `Schedar`, `Gacrux`, `Pulcherrima`, `Achird`, `Zubenelgenubi`, `Vindemiatrix`, `Sadachbia`, `Sadaltager`, `Sulafat`.
+
 ### JSON Output
 
 `--json` prints a single structured object to stdout after saving the file.
@@ -88,7 +125,9 @@ Voices are model-specific. If a model rejects a voice, Venice returns the API er
 
 ### Credentials and Config
 
-`term-llm audio` reads credentials from `VENICE_API_KEY`, `audio.venice.api_key`, or the existing `image.venice.api_key` fallback.
+`term-llm audio` reads Venice credentials from `VENICE_API_KEY`, `audio.venice.api_key`, or the existing `image.venice.api_key` fallback.
+
+Gemini credentials are read from `GEMINI_API_KEY`, `audio.gemini.api_key`, `image.gemini.api_key`, or the configured `providers.gemini` API key.
 
 ```yaml
 audio:
@@ -99,4 +138,9 @@ audio:
     model: tts-kokoro
     voice: af_sky
     format: mp3
+  gemini:
+    api_key: $GEMINI_API_KEY
+    model: gemini-3.1-flash-tts-preview
+    voice: Kore
+    format: wav
 ```

--- a/docs-site/content/guides/audio-generation.md
+++ b/docs-site/content/guides/audio-generation.md
@@ -1,0 +1,102 @@
+---
+title: "Audio generation"
+weight: 5
+description: "Generate speech audio with Venice AI text-to-speech models."
+kicker: "Media"
+---
+
+Generate speech audio using Venice AI's text-to-speech API.
+
+```bash
+term-llm audio "hello from term-llm"
+```
+
+By default, audio clips are:
+- Saved to `~/Music/term-llm/` with timestamped filenames
+- Generated with Venice `tts-kokoro`
+- Rendered as MP3 using voice `af_sky`
+
+### Audio Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--provider` | `-p` | Audio provider override; currently `venice` |
+| `--output` | `-o` | Custom output path, or `-` for stdout |
+| `--model` | | Venice TTS model override |
+| `--voice` | | Model-specific voice, or a Venice cloned voice handle like `vv_<id>` |
+| `--language` | | Optional language hint (`English`, `en`, etc.; model-specific) |
+| `--prompt` | | Style/emotion prompt for models that support it |
+| `--format` | | Response format: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm` |
+| `--speed` | | Speech speed, `0.25` to `4.0` |
+| `--streaming` | | Ask Venice to stream sentence-by-sentence; term-llm still collects before saving |
+| `--temperature` | | Sampling temperature for supported models, `0` to `2`; omitted by default |
+| `--top-p` | | Nucleus sampling for supported models, `0` to `1`; omitted by default |
+| `--json` | | Emit machine-readable JSON to stdout |
+| `--debug` | `-d` | Show debug information |
+
+### Examples
+
+```bash
+term-llm audio "hello from term-llm"
+term-llm audio "quick smoke test" --output smoke.mp3
+term-llm audio "faster please" --speed 1.25 --format wav
+term-llm audio "sad robot noises" \
+  --model tts-qwen3-0-6b \
+  --voice Vivian \
+  --prompt "Sad and slow."
+
+echo "pipe me" | term-llm audio --voice af_bella -o - > out.mp3
+```
+
+### Venice TTS Models
+
+term-llm includes the Venice text-to-speech model catalog:
+
+| Model | Notes |
+|-------|-------|
+| `tts-kokoro` | Default, cheap general TTS |
+| `tts-qwen3-0-6b` | Qwen 3 TTS, supports style prompt / sampling options |
+| `tts-qwen3-1-7b` | Larger Qwen 3 TTS |
+| `tts-xai-v1` | xAI TTS v1 |
+| `tts-inworld-1-5-max` | Inworld TTS-1.5 Max |
+| `tts-chatterbox-hd` | Chatterbox HD; supports cloned voices |
+| `tts-orpheus` | Orpheus TTS |
+| `tts-elevenlabs-turbo-v2-5` | ElevenLabs Turbo v2.5 |
+| `tts-minimax-speech-02-hd` | MiniMax Speech-02 HD |
+| `tts-gemini-3-1-flash` | Gemini 3.1 Flash TTS |
+
+Voices are model-specific. If a model rejects a voice, Venice returns the API error directly.
+
+### JSON Output
+
+`--json` prints a single structured object to stdout after saving the file.
+
+```json
+{
+  "provider": "venice",
+  "text": "hello from term-llm",
+  "model": "tts-kokoro",
+  "voice": "af_sky",
+  "format": "mp3",
+  "output": {
+    "path": "/home/me/Music/term-llm/20260502-120000-hello_from_term-llm.mp3",
+    "mime_type": "audio/mpeg",
+    "bytes": 12345
+  }
+}
+```
+
+### Credentials and Config
+
+`term-llm audio` reads credentials from `VENICE_API_KEY`, `audio.venice.api_key`, or the existing `image.venice.api_key` fallback.
+
+```yaml
+audio:
+  provider: venice
+  output_dir: ~/Music/term-llm
+  venice:
+    api_key: $VENICE_API_KEY
+    model: tts-kokoro
+    voice: af_sky
+    format: mp3
+```

--- a/docs-site/content/guides/audio-generation.md
+++ b/docs-site/content/guides/audio-generation.md
@@ -1,7 +1,7 @@
 ---
 title: "Audio generation"
 weight: 5
-description: "Generate speech audio with Venice AI and Gemini text-to-speech models."
+description: "Generate speech audio with Venice AI, Gemini, and ElevenLabs text-to-speech models."
 kicker: "Media"
 ---
 
@@ -16,35 +16,49 @@ By default, audio clips are:
 - Generated with Venice `tts-kokoro`
 - Rendered as MP3 using voice `af_sky`
 
-You can also use Gemini TTS:
+You can also use Gemini or ElevenLabs TTS:
 
 ```bash
 term-llm audio "Say cheerfully: hello from Gemini" --provider gemini --voice Kore
+term-llm audio "Hello from ElevenLabs" --provider elevenlabs --voice Rachel --model eleven_flash_v2_5
 ```
 
 ### Audio Flags
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--provider` | `-p` | Audio provider override: `venice`, `gemini` |
+| `--provider` | `-p` | Audio provider override: `venice`, `gemini`, `elevenlabs` |
 | `--output` | `-o` | Custom output path, or `-` for stdout |
 | `--model` | | TTS model override |
-| `--voice` | | Model-specific voice, or a Venice cloned voice handle like `vv_<id>` |
+| `--voice` | | Model-specific voice; ElevenLabs accepts a voice ID or account voice name; Venice accepts cloned voice handles like `vv_<id>` |
 | `--voice1` | | Gemini multi-speaker voice for `--speaker1` |
 | `--voice2` | | Gemini multi-speaker voice for `--speaker2` |
 | `--speaker1` | | Gemini multi-speaker label for the first speaker |
 | `--speaker2` | | Gemini multi-speaker label for the second speaker |
-| `--language` | | Optional Venice language hint (`English`, `en`, etc.; model-specific) |
+| `--language` | | Optional provider language hint (`English`, `en`, etc.; provider/model-specific) |
 | `--prompt` | | Style/emotion prompt for models that support it |
-| `--format` | | Venice: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`; Gemini: `wav`, `pcm` |
-| `--speed` | | Venice speech speed, `0.25` to `4.0` |
-| `--streaming` | | Ask Venice to stream sentence-by-sentence; term-llm still collects before saving |
+| `--format` | | Venice: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`; Gemini: `wav`, `pcm`; ElevenLabs: `mp3_44100_128`, `pcm_24000`, `wav_44100`, etc. |
+| `--speed` | | Venice speech speed `0.25` to `4.0`; ElevenLabs voice speed `0.7` to `1.2` |
+| `--streaming` | | Ask supported providers to stream; term-llm still collects before saving |
 | `--temperature` | | Sampling temperature for supported models, `0` to `2`; omitted by default |
 | `--top-p` | | Nucleus sampling for supported models, `0` to `1`; omitted by default |
+| `--stability` | | ElevenLabs voice stability, `0` to `1`; omitted by default |
+| `--similarity-boost` | | ElevenLabs similarity boost, `0` to `1`; omitted by default |
+| `--style` | | ElevenLabs style exaggeration, `0` to `1`; omitted by default |
+| `--speaker-boost` | | ElevenLabs speaker boost voice setting |
+| `--seed` | | ElevenLabs deterministic seed |
+| `--previous-text` / `--next-text` | | ElevenLabs continuity context |
+| `--previous-request-ids` / `--next-request-ids` | | ElevenLabs comma-separated request IDs for continuity |
+| `--pronunciation-dictionaries` | | ElevenLabs comma-separated pronunciation dictionary IDs, optionally `id:version` |
+| `--use-pvc-as-ivc` | | ElevenLabs lower-latency PVC workaround |
+| `--apply-text-normalization` | | ElevenLabs text normalization: `auto`, `on`, `off` |
+| `--apply-language-text-normalization` | | ElevenLabs language text normalization |
+| `--optimize-streaming-latency` | | ElevenLabs latency optimization level, `0` to `4` |
+| `--enable-logging` | | ElevenLabs request logging/history; set false for zero-retention-capable accounts |
 | `--json` | | Emit machine-readable JSON to stdout |
 | `--debug` | `-d` | Show debug information |
 
-`--model`, `--voice`, `--voice1`, `--voice2`, `--format`, and `--provider` include shell completion candidates.
+`--model`, `--voice`, `--voice1`, `--voice2`, `--format`, `--provider`, and `--apply-text-normalization` include shell completion candidates.
 
 ### Examples
 
@@ -67,6 +81,14 @@ term-llm audio "TTS the following conversation between Joe and Jane: Joe: Hi Jan
   --provider gemini \
   --speaker1 Joe --voice1 Kore \
   --speaker2 Jane --voice2 Puck
+
+term-llm audio "A one second ElevenLabs smoke test." \
+  --provider elevenlabs \
+  --model eleven_flash_v2_5 \
+  --voice Rachel \
+  --format mp3_44100_128 \
+  --stability 0.5 \
+  --similarity-boost 0.75
 
 echo "pipe me" | term-llm audio --voice af_bella -o - > out.mp3
 ```
@@ -104,6 +126,27 @@ Gemini prebuilt voices:
 
 `Zephyr`, `Puck`, `Charon`, `Kore`, `Fenrir`, `Leda`, `Orus`, `Aoede`, `Callirrhoe`, `Autonoe`, `Enceladus`, `Iapetus`, `Umbriel`, `Algieba`, `Despina`, `Erinome`, `Algenib`, `Rasalgethi`, `Laomedeia`, `Achernar`, `Alnilam`, `Schedar`, `Gacrux`, `Pulcherrima`, `Achird`, `Zubenelgenubi`, `Vindemiatrix`, `Sadachbia`, `Sadaltager`, `Sulafat`.
 
+### ElevenLabs TTS Models
+
+term-llm includes the documented ElevenLabs text-to-speech models:
+
+| Model | Notes |
+|-------|-------|
+| `eleven_v3` | Latest expressive speech model |
+| `eleven_multilingual_v2` | Default high-quality multilingual speech |
+| `eleven_flash_v2_5` | Low-latency multilingual speech |
+| `eleven_flash_v2` | Low-latency English speech |
+| `eleven_turbo_v2_5` | Deprecated predecessor of Flash v2.5 |
+| `eleven_turbo_v2` | Deprecated predecessor of Flash v2 |
+| `eleven_monolingual_v1` | Deprecated English-only model |
+| `eleven_multilingual_v1` | Deprecated multilingual model |
+
+ElevenLabs voices are account-specific. `--voice` accepts either a raw `voice_id` or an exact voice name from the account; name lookup uses the ElevenLabs voices API before generating speech.
+
+ElevenLabs output formats:
+
+`alaw_8000`, `mp3_22050_32`, `mp3_24000_48`, `mp3_44100_32`, `mp3_44100_64`, `mp3_44100_96`, `mp3_44100_128`, `mp3_44100_192`, `opus_48000_32`, `opus_48000_64`, `opus_48000_96`, `opus_48000_128`, `opus_48000_192`, `pcm_8000`, `pcm_16000`, `pcm_22050`, `pcm_24000`, `pcm_32000`, `pcm_44100`, `pcm_48000`, `ulaw_8000`, `wav_8000`, `wav_16000`, `wav_22050`, `wav_24000`, `wav_32000`, `wav_44100`, `wav_48000`.
+
 ### JSON Output
 
 `--json` prints a single structured object to stdout after saving the file.
@@ -129,6 +172,8 @@ Gemini prebuilt voices:
 
 Gemini credentials are read from `GEMINI_API_KEY`, `audio.gemini.api_key`, `image.gemini.api_key`, or the configured `providers.gemini` API key.
 
+ElevenLabs credentials are read from `ELEVENLABS_API_KEY`, `XI_API_KEY`, or `audio.elevenlabs.api_key`.
+
 ```yaml
 audio:
   provider: venice
@@ -143,4 +188,9 @@ audio:
     model: gemini-3.1-flash-tts-preview
     voice: Kore
     format: wav
+  elevenlabs:
+    api_key: $ELEVENLABS_API_KEY
+    model: eleven_multilingual_v2
+    voice: JBFqnCBsd6RMkjVDRZzb
+    format: mp3_44100_128
 ```

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -32,7 +32,7 @@ A typical config has a few major parts:
 - `default_provider` for the global LLM default
 - `providers` for model-specific credentials and routing
 - per-command blocks such as `exec`, `ask`, and `edit`
-- feature-specific blocks such as `image`, `embed`, `search`, `sessions`, `tools`, and `skills`
+- feature-specific blocks such as `image`, `audio`, `embed`, `search`, `sessions`, `tools`, and `skills`
 
 ## Example
 
@@ -145,18 +145,27 @@ search:
 
 Search is large enough to deserve its own page; see [Search](/guides/search/).
 
-## Image and embedding config
+## Image, audio, and embedding config
 
 ```yaml
 image:
   provider: gemini
   output_dir: ~/Pictures/term-llm
 
+audio:
+  provider: venice
+  output_dir: ~/Music/term-llm
+  venice:
+    api_key: ${VENICE_API_KEY}
+    model: tts-kokoro
+    voice: af_sky
+    format: mp3
+
 embed:
   provider: gemini
 ```
 
-Each feature block can hold provider-specific credentials and defaults. The image and embedding providers are independent of the main text provider.
+Each feature block can hold provider-specific credentials and defaults. The image, audio, and embedding providers are independent of the main text provider.
 
 ## Provider-specific environment overrides
 

--- a/internal/audio/elevenlabs.go
+++ b/internal/audio/elevenlabs.go
@@ -1,0 +1,362 @@
+package audio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	elevenLabsBaseURL       = "https://api.elevenlabs.io"
+	elevenLabsDefaultModel  = "eleven_multilingual_v2"
+	elevenLabsDefaultVoice  = "JBFqnCBsd6RMkjVDRZzb"
+	elevenLabsDefaultFormat = "mp3_44100_128"
+	elevenLabsHTTPTimeout   = 2 * time.Minute
+)
+
+var (
+	ElevenLabsModels = []string{
+		"eleven_v3",
+		"eleven_multilingual_v2",
+		"eleven_flash_v2_5",
+		"eleven_flash_v2",
+		"eleven_turbo_v2_5",
+		"eleven_turbo_v2",
+		"eleven_monolingual_v1",
+		"eleven_multilingual_v1",
+	}
+	ElevenLabsFormats = []string{
+		"alaw_8000",
+		"mp3_22050_32", "mp3_24000_48", "mp3_44100_32", "mp3_44100_64", "mp3_44100_96", "mp3_44100_128", "mp3_44100_192",
+		"opus_48000_32", "opus_48000_64", "opus_48000_96", "opus_48000_128", "opus_48000_192",
+		"pcm_8000", "pcm_16000", "pcm_22050", "pcm_24000", "pcm_32000", "pcm_44100", "pcm_48000",
+		"ulaw_8000",
+		"wav_8000", "wav_16000", "wav_22050", "wav_24000", "wav_32000", "wav_44100", "wav_48000",
+	}
+	ElevenLabsVoices = []string{
+		"JBFqnCBsd6RMkjVDRZzb",
+		"21m00Tcm4TlvDq8ikWAM",
+		"Rachel",
+		"Aria",
+		"Roger",
+		"Sarah",
+		"Laura",
+		"Charlie",
+		"George",
+		"Callum",
+		"River",
+		"Liam",
+		"Charlotte",
+		"Alice",
+		"Matilda",
+		"Will",
+		"Jessica",
+		"Eric",
+		"Chris",
+		"Brian",
+		"Daniel",
+		"Lily",
+		"Bill",
+	}
+	ElevenLabsTextNormalization = []string{"auto", "on", "off"}
+)
+
+type ElevenLabsProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+func NewElevenLabsProvider(apiKey string) *ElevenLabsProvider {
+	return &ElevenLabsProvider{
+		apiKey:  strings.TrimSpace(apiKey),
+		baseURL: elevenLabsBaseURL,
+		client:  &http.Client{Timeout: elevenLabsHTTPTimeout},
+	}
+}
+
+func (p *ElevenLabsProvider) Generate(ctx context.Context, req Request) (*Result, error) {
+	if strings.TrimSpace(req.Input) == "" {
+		return nil, fmt.Errorf("input text is required")
+	}
+	model := firstTrimmed(req.Model, elevenLabsDefaultModel)
+	voice := firstTrimmed(req.Voice, elevenLabsDefaultVoice)
+	format := firstTrimmed(req.ResponseFormat, elevenLabsDefaultFormat)
+	if err := ValidateElevenLabsFormat(format); err != nil {
+		return nil, err
+	}
+	if err := ValidateElevenLabsVoiceSettings(req); err != nil {
+		return nil, err
+	}
+
+	voiceID, err := p.resolveVoiceID(ctx, voice, req.Debug || req.DebugRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{
+		"text":     req.Input,
+		"model_id": model,
+	}
+	if strings.TrimSpace(req.Language) != "" {
+		payload["language_code"] = strings.TrimSpace(req.Language)
+	}
+	if settings := elevenLabsVoiceSettings(req); len(settings) > 0 {
+		payload["voice_settings"] = settings
+	}
+	if strings.TrimSpace(req.Seed) != "" {
+		payload["seed"] = strings.TrimSpace(req.Seed)
+	}
+	if strings.TrimSpace(req.PreviousText) != "" {
+		payload["previous_text"] = strings.TrimSpace(req.PreviousText)
+	}
+	if strings.TrimSpace(req.NextText) != "" {
+		payload["next_text"] = strings.TrimSpace(req.NextText)
+	}
+	if ids := splitCSV(req.PreviousRequestIDs); len(ids) > 0 {
+		payload["previous_request_ids"] = ids
+	}
+	if ids := splitCSV(req.NextRequestIDs); len(ids) > 0 {
+		payload["next_request_ids"] = ids
+	}
+	if dictionaries := parsePronunciationDictionaries(req.PronunciationDictionaries); len(dictionaries) > 0 {
+		payload["pronunciation_dictionary_locators"] = dictionaries
+	}
+	if req.UsePVCAsIVC {
+		payload["use_pvc_as_ivc"] = true
+	}
+	if strings.TrimSpace(req.ApplyTextNormalization) != "" {
+		payload["apply_text_normalization"] = strings.TrimSpace(req.ApplyTextNormalization)
+	}
+	if req.ApplyLanguageTextNormalization {
+		payload["apply_language_text_normalization"] = true
+	}
+
+	body, contentType, err := p.doSpeech(ctx, voiceID, format, req.Streaming, req.EnableLogging, req.OptimizeStreamingLatency, payload, req.Debug || req.DebugRaw)
+	if err != nil {
+		return nil, err
+	}
+	mimeType := normalizeMime(contentType)
+	if mimeType == "" || mimeType == "application/octet-stream" {
+		mimeType = MimeTypeForFormat(format)
+	}
+	return &Result{Data: body, MimeType: mimeType, Format: format}, nil
+}
+
+func (p *ElevenLabsProvider) doSpeech(ctx context.Context, voiceID, format string, streaming, enableLogging bool, optimizeStreamingLatency int, payload any, debug bool) ([]byte, string, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal ElevenLabs request: %w", err)
+	}
+	query := url.Values{}
+	query.Set("output_format", format)
+	if !enableLogging {
+		query.Set("enable_logging", "false")
+	}
+	if optimizeStreamingLatency >= 0 {
+		query.Set("optimize_streaming_latency", fmt.Sprintf("%d", optimizeStreamingLatency))
+	}
+	path := fmt.Sprintf("/v1/text-to-speech/%s", url.PathEscape(voiceID))
+	if streaming {
+		path += "/stream"
+	}
+	endpoint := p.baseURL + path + "?" + query.Encode()
+	if debug {
+		debugLog("ElevenLabs Audio Request", "POST %s\n%s", endpoint, string(jsonBody))
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, "", fmt.Errorf("create ElevenLabs request: %w", err)
+	}
+	httpReq.Header.Set("xi-api-key", p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "audio/*")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, "", elevenLabsRequestError(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read ElevenLabs response: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if debug {
+		debugLog("ElevenLabs Audio Response", "status=%d content-type=%s body_len=%d", resp.StatusCode, contentType, len(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("ElevenLabs API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, contentType, nil
+}
+
+func (p *ElevenLabsProvider) resolveVoiceID(ctx context.Context, voice string, debug bool) (string, error) {
+	voice = strings.TrimSpace(voice)
+	if voice == "" {
+		return elevenLabsDefaultVoice, nil
+	}
+	if looksLikeElevenLabsVoiceID(voice) {
+		return voice, nil
+	}
+
+	voices, err := p.listVoices(ctx, debug)
+	if err != nil {
+		return "", fmt.Errorf("resolve ElevenLabs voice %q: pass a voice_id or fix voice lookup: %w", voice, err)
+	}
+	for _, candidate := range voices {
+		if strings.EqualFold(candidate.Name, voice) || strings.EqualFold(candidate.VoiceID, voice) {
+			return candidate.VoiceID, nil
+		}
+	}
+	return "", fmt.Errorf("ElevenLabs voice %q not found; pass a voice_id or one of your account voice names", voice)
+}
+
+type elevenLabsVoice struct {
+	VoiceID string `json:"voice_id"`
+	Name    string `json:"name"`
+}
+
+func (p *ElevenLabsProvider) listVoices(ctx context.Context, debug bool) ([]elevenLabsVoice, error) {
+	endpoint := p.baseURL + "/v2/voices"
+	if debug {
+		debugLog("ElevenLabs Voices Request", "GET %s", endpoint)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create ElevenLabs voices request: %w", err)
+	}
+	httpReq.Header.Set("xi-api-key", p.apiKey)
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, elevenLabsRequestError(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read ElevenLabs voices response: %w", err)
+	}
+	if debug {
+		debugLog("ElevenLabs Voices Response", "status=%d body_len=%d", resp.StatusCode, len(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ElevenLabs voices API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var decoded struct {
+		Voices []elevenLabsVoice `json:"voices"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("decode ElevenLabs voices response: %w", err)
+	}
+	return decoded.Voices, nil
+}
+
+func ValidateElevenLabsFormat(format string) error {
+	return validateEnum("ElevenLabs output format", format, ElevenLabsFormats)
+}
+
+func ValidateElevenLabsTextNormalization(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return validateEnum("ElevenLabs text normalization", value, ElevenLabsTextNormalization)
+}
+
+func ValidateElevenLabsVoiceSettings(req Request) error {
+	for name, value := range map[string]float64{
+		"stability":        req.Stability,
+		"similarity-boost": req.SimilarityBoost,
+		"style":            req.Style,
+	} {
+		if value != -1 && (value < 0 || value > 1) {
+			return fmt.Errorf("invalid %s %.2f (allowed: 0 to 1)", name, value)
+		}
+	}
+	if req.Speed != 0 && (req.Speed < 0.7 || req.Speed > 1.2) {
+		return fmt.Errorf("invalid ElevenLabs speed %.2f (allowed: 0.7 to 1.2)", req.Speed)
+	}
+	if req.OptimizeStreamingLatency < -1 || req.OptimizeStreamingLatency > 4 {
+		return fmt.Errorf("invalid optimize-streaming-latency %d (allowed: 0 to 4)", req.OptimizeStreamingLatency)
+	}
+	if err := ValidateElevenLabsTextNormalization(req.ApplyTextNormalization); err != nil {
+		return err
+	}
+	return nil
+}
+
+func elevenLabsVoiceSettings(req Request) map[string]any {
+	settings := map[string]any{}
+	if req.Stability >= 0 {
+		settings["stability"] = req.Stability
+	}
+	if req.SimilarityBoost >= 0 {
+		settings["similarity_boost"] = req.SimilarityBoost
+	}
+	if req.Style >= 0 {
+		settings["style"] = req.Style
+	}
+	if req.Speed != 0 && req.Speed != 1.0 {
+		settings["speed"] = req.Speed
+	}
+	if req.UseSpeakerBoostSet {
+		settings["use_speaker_boost"] = req.UseSpeakerBoost
+	}
+	return settings
+}
+
+func looksLikeElevenLabsVoiceID(voice string) bool {
+	if len(voice) < 16 {
+		return false
+	}
+	for _, r := range voice {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func splitCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func parsePronunciationDictionaries(value string) []map[string]string {
+	parts := splitCSV(value)
+	out := make([]map[string]string, 0, len(parts))
+	for _, part := range parts {
+		id, version, ok := strings.Cut(part, ":")
+		locator := map[string]string{"pronunciation_dictionary_id": strings.TrimSpace(id)}
+		if ok && strings.TrimSpace(version) != "" {
+			locator["version_id"] = strings.TrimSpace(version)
+		}
+		if locator["pronunciation_dictionary_id"] != "" {
+			out = append(out, locator)
+		}
+	}
+	return out
+}
+
+func elevenLabsRequestError(err error) error {
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("ElevenLabs request timed out: %w", err)
+	}
+	return fmt.Errorf("ElevenLabs request failed: %w", err)
+}

--- a/internal/audio/elevenlabs_test.go
+++ b/internal/audio/elevenlabs_test.go
@@ -1,0 +1,133 @@
+package audio
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestElevenLabsModelsIncludeDocumentedTTSModels(t *testing.T) {
+	want := []string{
+		"eleven_v3",
+		"eleven_multilingual_v2",
+		"eleven_flash_v2_5",
+		"eleven_flash_v2",
+		"eleven_turbo_v2_5",
+		"eleven_turbo_v2",
+		"eleven_monolingual_v1",
+		"eleven_multilingual_v1",
+	}
+	for _, model := range want {
+		if !contains(ElevenLabsModels, model) {
+			t.Fatalf("ElevenLabsModels missing %s", model)
+		}
+	}
+}
+
+func TestElevenLabsProviderGenerateWithVoiceID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/text-to-speech/JBFqnCBsd6RMkjVDRZzb" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("xi-api-key"); got != "test-key" {
+			t.Fatalf("xi-api-key = %q", got)
+		}
+		if got := r.URL.Query().Get("output_format"); got != "mp3_44100_128" {
+			t.Fatalf("output_format = %q", got)
+		}
+		if got := r.URL.Query().Get("optimize_streaming_latency"); got != "1" {
+			t.Fatalf("optimize_streaming_latency = %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["text"] != "hello" || body["model_id"] != "eleven_flash_v2_5" || body["language_code"] != "en" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		settings, ok := body["voice_settings"].(map[string]any)
+		if !ok || settings["stability"] != 0.5 || settings["similarity_boost"] != 0.75 || settings["use_speaker_boost"] != true {
+			t.Fatalf("unexpected voice settings: %#v", body["voice_settings"])
+		}
+		dictionaries, ok := body["pronunciation_dictionary_locators"].([]any)
+		if !ok || len(dictionaries) != 1 {
+			t.Fatalf("unexpected pronunciation dictionaries: %#v", body["pronunciation_dictionary_locators"])
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("fake-mp3"))
+	}))
+	defer server.Close()
+
+	provider := NewElevenLabsProvider("test-key")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+
+	result, err := provider.Generate(context.Background(), Request{
+		Input:                     "hello",
+		Model:                     "eleven_flash_v2_5",
+		Voice:                     "JBFqnCBsd6RMkjVDRZzb",
+		Language:                  "en",
+		ResponseFormat:            "mp3_44100_128",
+		Stability:                 0.5,
+		SimilarityBoost:           0.75,
+		UseSpeakerBoost:           true,
+		UseSpeakerBoostSet:        true,
+		PronunciationDictionaries: "dict1:v2",
+		OptimizeStreamingLatency:  1,
+		EnableLogging:             true,
+	})
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if result.MimeType != "audio/mpeg" {
+		t.Fatalf("MimeType = %q, want audio/mpeg", result.MimeType)
+	}
+	if string(result.Data) != "fake-mp3" {
+		t.Fatalf("Data = %q, want fake-mp3", string(result.Data))
+	}
+}
+
+func TestElevenLabsProviderResolvesVoiceName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/voices":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"voices":[{"voice_id":"voice123456789012","name":"Rachel"}]}`))
+		case "/v1/text-to-speech/voice123456789012":
+			_, _ = w.Write([]byte("fake-mp3"))
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewElevenLabsProvider("test-key")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+	_, err := provider.Generate(context.Background(), Request{
+		Input:          "hello",
+		Voice:          "Rachel",
+		ResponseFormat: "mp3_44100_128",
+		EnableLogging:  true,
+	})
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+}
+
+func TestElevenLabsValidation(t *testing.T) {
+	if err := ValidateElevenLabsFormat("wav_44100"); err != nil {
+		t.Fatalf("ValidateElevenLabsFormat(wav_44100): %v", err)
+	}
+	if err := ValidateElevenLabsFormat("wav"); err == nil {
+		t.Fatal("expected invalid ElevenLabs format")
+	}
+	if err := ValidateElevenLabsTextNormalization("auto"); err != nil {
+		t.Fatalf("ValidateElevenLabsTextNormalization(auto): %v", err)
+	}
+	if err := ValidateElevenLabsTextNormalization("maybe"); err == nil {
+		t.Fatal("expected invalid text normalization")
+	}
+}

--- a/internal/audio/gemini.go
+++ b/internal/audio/gemini.go
@@ -1,0 +1,252 @@
+package audio
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	geminiBaseURL       = "https://generativelanguage.googleapis.com/v1beta/models"
+	geminiDefaultModel  = "gemini-3.1-flash-tts-preview"
+	geminiDefaultVoice  = "Kore"
+	geminiDefaultFormat = "wav"
+	geminiHTTPTimeout   = 2 * time.Minute
+	geminiSampleRate    = 24000
+	geminiChannels      = 1
+	geminiSampleWidth   = 2
+)
+
+var (
+	GeminiModels = []string{
+		"gemini-3.1-flash-tts-preview",
+		"gemini-2.5-flash-preview-tts",
+		"gemini-2.5-pro-preview-tts",
+	}
+	GeminiFormats = []string{"wav", "pcm"}
+	GeminiVoices  = []string{
+		"Zephyr", "Puck", "Charon", "Kore", "Fenrir", "Leda", "Orus", "Aoede", "Callirrhoe", "Autonoe", "Enceladus", "Iapetus", "Umbriel", "Algieba", "Despina", "Erinome", "Algenib", "Rasalgethi", "Laomedeia", "Achernar", "Alnilam", "Schedar", "Gacrux", "Pulcherrima", "Achird", "Zubenelgenubi", "Vindemiatrix", "Sadachbia", "Sadaltager", "Sulafat",
+	}
+)
+
+type GeminiProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+func NewGeminiProvider(apiKey string) *GeminiProvider {
+	return &GeminiProvider{
+		apiKey:  strings.TrimSpace(apiKey),
+		baseURL: geminiBaseURL,
+		client: &http.Client{
+			Timeout: geminiHTTPTimeout,
+		},
+	}
+}
+
+func (p *GeminiProvider) Generate(ctx context.Context, req Request) (*Result, error) {
+	if strings.TrimSpace(req.Input) == "" {
+		return nil, fmt.Errorf("input text is required")
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		model = geminiDefaultModel
+	}
+	voice := strings.TrimSpace(req.Voice)
+	if voice == "" {
+		voice = geminiDefaultVoice
+	}
+	format := strings.TrimSpace(req.ResponseFormat)
+	if format == "" {
+		format = geminiDefaultFormat
+	}
+	if err := ValidateGeminiFormat(format); err != nil {
+		return nil, err
+	}
+	if req.Streaming {
+		return nil, fmt.Errorf("Gemini TTS does not support streaming")
+	}
+
+	prompt := strings.TrimSpace(req.Input)
+	if strings.TrimSpace(req.Prompt) != "" {
+		prompt = strings.TrimSpace(req.Prompt) + "\n\n### TRANSCRIPT\n" + prompt
+	}
+
+	generationConfig := map[string]any{
+		"responseModalities": []string{"AUDIO"},
+		"speechConfig":       geminiSpeechConfig(req, voice),
+	}
+	if req.Temperature != nil {
+		generationConfig["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		generationConfig["topP"] = *req.TopP
+	}
+
+	payload := map[string]any{
+		"contents": []map[string]any{{
+			"parts": []map[string]string{{"text": prompt}},
+		}},
+		"generationConfig": generationConfig,
+		"model":            model,
+	}
+
+	pcm, mimeType, err := p.do(ctx, model, payload, req.Debug || req.DebugRaw)
+	if err != nil {
+		return nil, err
+	}
+	if format == "wav" {
+		return &Result{Data: wrapPCMAsWAV(pcm), MimeType: "audio/wav", Format: format}, nil
+	}
+	return &Result{Data: pcm, MimeType: normalizeMime(mimeType), Format: format}, nil
+}
+
+func geminiSpeechConfig(req Request, voice string) map[string]any {
+	if strings.TrimSpace(req.Speaker1) != "" || strings.TrimSpace(req.Speaker2) != "" {
+		speakers := []map[string]any{}
+		if strings.TrimSpace(req.Speaker1) != "" {
+			speakers = append(speakers, geminiSpeakerVoiceConfig(req.Speaker1, firstTrimmed(req.Voice1, voice)))
+		}
+		if strings.TrimSpace(req.Speaker2) != "" {
+			speakers = append(speakers, geminiSpeakerVoiceConfig(req.Speaker2, firstTrimmed(req.Voice2, voice)))
+		}
+		return map[string]any{
+			"multiSpeakerVoiceConfig": map[string]any{
+				"speakerVoiceConfigs": speakers,
+			},
+		}
+	}
+	return map[string]any{
+		"voiceConfig": map[string]any{
+			"prebuiltVoiceConfig": map[string]string{"voiceName": voice},
+		},
+	}
+}
+
+func geminiSpeakerVoiceConfig(speaker, voice string) map[string]any {
+	return map[string]any{
+		"speaker": strings.TrimSpace(speaker),
+		"voiceConfig": map[string]any{
+			"prebuiltVoiceConfig": map[string]string{"voiceName": strings.TrimSpace(voice)},
+		},
+	}
+}
+
+func (p *GeminiProvider) do(ctx context.Context, model string, payload any, debug bool) ([]byte, string, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal Gemini request: %w", err)
+	}
+	endpoint := fmt.Sprintf("%s/%s:generateContent", p.baseURL, model)
+	if debug {
+		debugLog("Gemini Audio Request", "POST %s\n%s", endpoint, string(jsonBody))
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, "", fmt.Errorf("create Gemini request: %w", err)
+	}
+	httpReq.Header.Set("x-goog-api-key", p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, "", geminiRequestError(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read Gemini response: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if debug {
+		debugLog("Gemini Audio Response", "status=%d content-type=%s body_len=%d", resp.StatusCode, contentType, len(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("Gemini API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					InlineData struct {
+						MimeType string `json:"mimeType"`
+						Data     string `json:"data"`
+					} `json:"inlineData"`
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, "", fmt.Errorf("decode Gemini response: %w", err)
+	}
+	for _, candidate := range decoded.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if part.InlineData.Data == "" {
+				continue
+			}
+			pcm, err := base64.StdEncoding.DecodeString(part.InlineData.Data)
+			if err != nil {
+				return nil, "", fmt.Errorf("decode Gemini audio: %w", err)
+			}
+			return pcm, part.InlineData.MimeType, nil
+		}
+	}
+	return nil, "", fmt.Errorf("Gemini response did not contain audio")
+}
+
+func ValidateGeminiFormat(format string) error {
+	return validateEnum("Gemini response format", format, GeminiFormats)
+}
+
+func wrapPCMAsWAV(pcm []byte) []byte {
+	var buf bytes.Buffer
+	dataSize := uint32(len(pcm))
+	byteRate := uint32(geminiSampleRate * geminiChannels * geminiSampleWidth)
+	blockAlign := uint16(geminiChannels * geminiSampleWidth)
+
+	buf.WriteString("RIFF")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(36)+dataSize)
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(16))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(geminiChannels))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(geminiSampleRate))
+	_ = binary.Write(&buf, binary.LittleEndian, byteRate)
+	_ = binary.Write(&buf, binary.LittleEndian, blockAlign)
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(geminiSampleWidth*8))
+	buf.WriteString("data")
+	_ = binary.Write(&buf, binary.LittleEndian, dataSize)
+	buf.Write(pcm)
+	return buf.Bytes()
+}
+
+func geminiRequestError(err error) error {
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("Gemini request timed out: %w", err)
+	}
+	return fmt.Errorf("Gemini request failed: %w", err)
+}
+
+func firstTrimmed(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/audio/gemini_test.go
+++ b/internal/audio/gemini_test.go
@@ -1,0 +1,121 @@
+package audio
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGeminiModelsIncludeSupportedTTSModels(t *testing.T) {
+	want := []string{
+		"gemini-3.1-flash-tts-preview",
+		"gemini-2.5-flash-preview-tts",
+		"gemini-2.5-pro-preview-tts",
+	}
+	for _, model := range want {
+		if !contains(GeminiModels, model) {
+			t.Fatalf("GeminiModels missing %s", model)
+		}
+	}
+}
+
+func TestGeminiProviderGenerateSingleSpeakerWAV(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gemini-3.1-flash-tts-preview:generateContent" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "test-key" {
+			t.Fatalf("x-goog-api-key = %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["model"] != "gemini-3.1-flash-tts-preview" {
+			t.Fatalf("model = %#v", body["model"])
+		}
+		config := body["generationConfig"].(map[string]any)
+		speech := config["speechConfig"].(map[string]any)
+		voice := speech["voiceConfig"].(map[string]any)
+		prebuilt := voice["prebuiltVoiceConfig"].(map[string]any)
+		if prebuilt["voiceName"] != "Kore" {
+			t.Fatalf("voiceName = %#v", prebuilt["voiceName"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{
+				"content": map[string]any{
+					"parts": []map[string]any{{
+						"inlineData": map[string]string{
+							"mimeType": "audio/l16; rate=24000; channels=1",
+							"data":     "AQIDBA==",
+						},
+					}},
+				},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewGeminiProvider("test-key")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+
+	result, err := provider.Generate(context.Background(), Request{Input: "hello", ResponseFormat: "wav"})
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if result.MimeType != "audio/wav" || result.Format != "wav" {
+		t.Fatalf("result = %#v", result)
+	}
+	if !strings.HasPrefix(string(result.Data), "RIFF") {
+		t.Fatalf("expected WAV header, got %q", result.Data[:4])
+	}
+}
+
+func TestGeminiProviderGenerateMultiSpeakerPCM(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		config := body["generationConfig"].(map[string]any)
+		speech := config["speechConfig"].(map[string]any)
+		multi := speech["multiSpeakerVoiceConfig"].(map[string]any)
+		speakers := multi["speakerVoiceConfigs"].([]any)
+		if len(speakers) != 2 {
+			t.Fatalf("speaker count = %d", len(speakers))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{
+				"content": map[string]any{
+					"parts": []map[string]any{{
+						"inlineData": map[string]string{"mimeType": "audio/l16; rate=24000; channels=1", "data": "AQIDBA=="},
+					}},
+				},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewGeminiProvider("test-key")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+
+	result, err := provider.Generate(context.Background(), Request{
+		Input:          "Joe: hi\nJane: hello",
+		ResponseFormat: "pcm",
+		Speaker1:       "Joe",
+		Voice1:         "Kore",
+		Speaker2:       "Jane",
+		Voice2:         "Puck",
+	})
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if string(result.Data) != "\x01\x02\x03\x04" {
+		t.Fatalf("Data = %q", result.Data)
+	}
+}

--- a/internal/audio/venice.go
+++ b/internal/audio/venice.go
@@ -1,0 +1,335 @@
+package audio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+const (
+	veniceBaseURL        = "https://api.venice.ai/api/v1"
+	veniceSpeechEndpoint = "/audio/speech"
+	veniceDefaultModel   = "tts-kokoro"
+	veniceDefaultVoice   = "af_sky"
+	veniceDefaultFormat  = "mp3"
+	veniceDefaultSpeed   = 1.0
+	veniceHTTPTimeout    = 2 * time.Minute
+)
+
+const (
+	DefaultModel  = veniceDefaultModel
+	DefaultVoice  = veniceDefaultVoice
+	DefaultFormat = veniceDefaultFormat
+	DefaultSpeed  = veniceDefaultSpeed
+)
+
+var (
+	VeniceModels = []string{
+		"tts-kokoro",
+		"tts-qwen3-0-6b",
+		"tts-qwen3-1-7b",
+		"tts-xai-v1",
+		"tts-inworld-1-5-max",
+		"tts-chatterbox-hd",
+		"tts-orpheus",
+		"tts-elevenlabs-turbo-v2-5",
+		"tts-minimax-speech-02-hd",
+		"tts-gemini-3-1-flash",
+	}
+	VeniceFormats = []string{"mp3", "opus", "aac", "flac", "wav", "pcm"}
+	VeniceVoices  = []string{
+		"af_alloy", "af_aoede", "af_bella", "af_heart", "af_jadzia", "af_jessica", "af_kore", "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky",
+		"am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael", "am_onyx", "am_puck", "am_santa",
+		"bf_alice", "bf_emma", "bf_lily", "bm_daniel", "bm_fable", "bm_george", "bm_lewis",
+		"zf_xiaobei", "zf_xiaoni", "zf_xiaoxiao", "zf_xiaoyi", "zm_yunjian", "zm_yunxi", "zm_yunxia", "zm_yunyang",
+		"ff_siwis", "hf_alpha", "hf_beta", "hm_omega", "hm_psi", "if_sara", "im_nicola", "jf_alpha", "jf_gongitsune", "jf_nezumi", "jf_tebukuro", "jm_kumo", "pf_dora", "pm_alex", "pm_santa", "ef_dora", "em_alex", "em_santa",
+		"Vivian", "Serena", "Ono_Anna", "Sohee", "Uncle_Fu", "Dylan", "Eric", "Ryan", "Aiden",
+		"eve", "ara", "rex", "sal", "leo",
+		"Craig", "Ashley", "Olivia", "Sarah", "Elizabeth", "Priya", "Alex", "Edward", "Theodore", "Ronald", "Mark", "Hades", "Luna", "Pixie",
+		"Aurora", "Britney", "Siobhan", "Vicky", "Blade", "Carl", "Cliff", "Richard", "Rico",
+		"tara", "leah", "jess", "mia", "zoe", "dan", "zac",
+		"Rachel", "Aria", "Laura", "Charlotte", "Alice", "Matilda", "Jessica", "Lily", "Roger", "Charlie", "George", "Callum", "River", "Liam", "Will", "Chris", "Brian", "Daniel", "Bill",
+		"WiseWoman", "FriendlyPerson", "InspirationalGirl", "CalmWoman", "LivelyGirl", "LovelyGirl", "SweetGirl", "ExuberantGirl", "DeepVoiceMan", "CasualGuy", "PatientMan", "YoungKnight", "DeterminedMan", "ImposingManner", "ElegantMan",
+		"Achernar", "Achird", "Algenib", "Algieba", "Alnilam", "Aoede", "Autonoe", "Callirrhoe", "Charon", "Despina", "Enceladus", "Erinome", "Fenrir", "Gacrux", "Iapetus", "Kore", "Laomedeia", "Leda", "Orus", "Pulcherrima", "Puck", "Rasalgethi", "Sadachbia", "Sadaltager", "Schedar", "Sulafat", "Umbriel", "Vindemiatrix", "Zephyr", "Zubenelgenubi",
+	}
+)
+
+type Request struct {
+	Input          string
+	Model          string
+	Voice          string
+	Language       string
+	Prompt         string
+	ResponseFormat string
+	Speed          float64
+	Streaming      bool
+	Temperature    *float64
+	TopP           *float64
+	Debug          bool
+	DebugRaw       bool
+}
+
+type Result struct {
+	Data     []byte
+	MimeType string
+	Format   string
+}
+
+type VeniceProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+func NewVeniceProvider(apiKey string) *VeniceProvider {
+	return &VeniceProvider{
+		apiKey:  config.NormalizeVeniceAPIKey(apiKey),
+		baseURL: veniceBaseURL,
+		client: &http.Client{
+			Timeout: veniceHTTPTimeout,
+		},
+	}
+}
+
+func (p *VeniceProvider) Generate(ctx context.Context, req Request) (*Result, error) {
+	if strings.TrimSpace(req.Input) == "" {
+		return nil, fmt.Errorf("input text is required")
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		model = veniceDefaultModel
+	}
+	voice := strings.TrimSpace(req.Voice)
+	if voice == "" {
+		voice = veniceDefaultVoice
+	}
+	format := strings.TrimSpace(req.ResponseFormat)
+	if format == "" {
+		format = veniceDefaultFormat
+	}
+	if err := ValidateFormat(format); err != nil {
+		return nil, err
+	}
+	if err := ValidateSpeed(req.Speed); err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{
+		"input":           req.Input,
+		"model":           model,
+		"voice":           voice,
+		"response_format": format,
+	}
+	if strings.TrimSpace(req.Language) != "" {
+		payload["language"] = req.Language
+	}
+	if strings.TrimSpace(req.Prompt) != "" {
+		payload["prompt"] = req.Prompt
+	}
+	if req.Speed != 0 && req.Speed != veniceDefaultSpeed {
+		payload["speed"] = req.Speed
+	}
+	if req.Streaming {
+		payload["streaming"] = true
+	}
+	if req.Temperature != nil {
+		payload["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		payload["top_p"] = *req.TopP
+	}
+
+	body, contentType, err := p.do(ctx, http.MethodPost, veniceSpeechEndpoint, payload, req.Debug || req.DebugRaw)
+	if err != nil {
+		return nil, err
+	}
+	mimeType := normalizeMime(contentType)
+	if mimeType == "" {
+		mimeType = MimeTypeForFormat(format)
+	}
+	return &Result{Data: body, MimeType: mimeType, Format: format}, nil
+}
+
+func (p *VeniceProvider) do(ctx context.Context, method, endpoint string, payload any, debug bool) ([]byte, string, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal Venice request: %w", err)
+	}
+	if debug {
+		debugLog("Venice Audio Request", "%s %s\n%s", method, p.baseURL+endpoint, string(jsonBody))
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, p.baseURL+endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, "", fmt.Errorf("create Venice request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, "", veniceRequestError(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read Venice response: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if debug {
+		debugLog("Venice Audio Response", "status=%d content-type=%s body_len=%d", resp.StatusCode, contentType, len(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("Venice API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, contentType, nil
+}
+
+func ValidateFormat(format string) error {
+	return validateEnum("response format", format, VeniceFormats)
+}
+
+func ValidateSpeed(speed float64) error {
+	if speed == 0 {
+		return nil
+	}
+	if speed < 0.25 || speed > 4.0 {
+		return fmt.Errorf("invalid speed %.2f (allowed: 0.25 to 4.0)", speed)
+	}
+	return nil
+}
+
+func ValidateTemperature(temperature float64) error {
+	if temperature < 0 || temperature > 2 {
+		return fmt.Errorf("invalid temperature %.2f (allowed: 0 to 2)", temperature)
+	}
+	return nil
+}
+
+func ValidateTopP(topP float64) error {
+	if topP < 0 || topP > 1 {
+		return fmt.Errorf("invalid top-p %.2f (allowed: 0 to 1)", topP)
+	}
+	return nil
+}
+
+func Save(data []byte, outputDir, text, format string) (string, error) {
+	dir := expandPath(outputDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	filename := generateFilename(text, format)
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write audio: %w", err)
+	}
+	return path, nil
+}
+
+func MimeTypeForFormat(format string) string {
+	switch format {
+	case "mp3":
+		return "audio/mpeg"
+	case "opus":
+		return "audio/opus"
+	case "aac":
+		return "audio/aac"
+	case "flac":
+		return "audio/flac"
+	case "wav":
+		return "audio/wav"
+	case "pcm":
+		return "audio/L16"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func ExtensionForFormat(format string) string {
+	if format == "" {
+		return veniceDefaultFormat
+	}
+	return format
+}
+
+func generateFilename(text, format string) string {
+	timestamp := time.Now().Format("20060102-150405")
+	safe := sanitizeForFilename(text)
+	if len(safe) > 30 {
+		safe = safe[:30]
+	}
+	if safe == "" {
+		safe = "audio"
+	}
+	return fmt.Sprintf("%s-%s.%s", timestamp, safe, ExtensionForFormat(format))
+}
+
+func sanitizeForFilename(s string) string {
+	replacer := strings.NewReplacer(" ", "_", "/", "", "\\", "", ":", "", "?", "", "*", "", "\"", "", "<", "", ">", "", "|", "")
+	s = replacer.Replace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	lastUnderscore := false
+	for _, r := range strings.ToLower(s) {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum || r == '-' {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if r == '_' && !lastUnderscore {
+			b.WriteRune(r)
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func expandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+func normalizeMime(contentType string) string {
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		return contentType[:idx]
+	}
+	return contentType
+}
+
+func validateEnum(name, value string, allowed []string) error {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid %s %q (allowed: %s)", name, value, strings.Join(allowed, ", "))
+}
+
+func veniceRequestError(err error) error {
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("Venice request timed out: %w", err)
+	}
+	return fmt.Errorf("Venice request failed: %w", err)
+}
+
+func debugLog(title, format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "\n=== %s ===\n%s\n", title, fmt.Sprintf(format, args...))
+}

--- a/internal/audio/venice.go
+++ b/internal/audio/venice.go
@@ -65,22 +65,38 @@ var (
 )
 
 type Request struct {
-	Input          string
-	Model          string
-	Voice          string
-	Voice1         string
-	Voice2         string
-	Speaker1       string
-	Speaker2       string
-	Language       string
-	Prompt         string
-	ResponseFormat string
-	Speed          float64
-	Streaming      bool
-	Temperature    *float64
-	TopP           *float64
-	Debug          bool
-	DebugRaw       bool
+	Input                          string
+	Model                          string
+	Voice                          string
+	Voice1                         string
+	Voice2                         string
+	Speaker1                       string
+	Speaker2                       string
+	Language                       string
+	Prompt                         string
+	ResponseFormat                 string
+	Speed                          float64
+	Streaming                      bool
+	Temperature                    *float64
+	TopP                           *float64
+	Stability                      float64
+	SimilarityBoost                float64
+	Style                          float64
+	UseSpeakerBoost                bool
+	UseSpeakerBoostSet             bool
+	Seed                           string
+	PreviousText                   string
+	NextText                       string
+	PreviousRequestIDs             string
+	NextRequestIDs                 string
+	PronunciationDictionaries      string
+	UsePVCAsIVC                    bool
+	ApplyTextNormalization         string
+	ApplyLanguageTextNormalization bool
+	OptimizeStreamingLatency       int
+	EnableLogging                  bool
+	Debug                          bool
+	DebugRaw                       bool
 }
 
 type Result struct {
@@ -242,19 +258,23 @@ func Save(data []byte, outputDir, text, format string) (string, error) {
 }
 
 func MimeTypeForFormat(format string) string {
-	switch format {
-	case "mp3":
+	switch {
+	case format == "mp3" || strings.HasPrefix(format, "mp3_"):
 		return "audio/mpeg"
-	case "opus":
+	case format == "opus" || strings.HasPrefix(format, "opus_"):
 		return "audio/opus"
-	case "aac":
+	case format == "aac":
 		return "audio/aac"
-	case "flac":
+	case format == "flac":
 		return "audio/flac"
-	case "wav":
+	case format == "wav" || strings.HasPrefix(format, "wav_"):
 		return "audio/wav"
-	case "pcm":
+	case format == "pcm" || strings.HasPrefix(format, "pcm_"):
 		return "audio/L16"
+	case strings.HasPrefix(format, "ulaw_"):
+		return "audio/basic"
+	case strings.HasPrefix(format, "alaw_"):
+		return "audio/alaw"
 	default:
 		return "application/octet-stream"
 	}
@@ -263,6 +283,9 @@ func MimeTypeForFormat(format string) string {
 func ExtensionForFormat(format string) string {
 	if format == "" {
 		return veniceDefaultFormat
+	}
+	if idx := strings.Index(format, "_"); idx > 0 {
+		return format[:idx]
 	}
 	return format
 }

--- a/internal/audio/venice.go
+++ b/internal/audio/venice.go
@@ -68,6 +68,10 @@ type Request struct {
 	Input          string
 	Model          string
 	Voice          string
+	Voice1         string
+	Voice2         string
+	Speaker1       string
+	Speaker2       string
 	Language       string
 	Prompt         string
 	ResponseFormat string

--- a/internal/audio/venice_test.go
+++ b/internal/audio/venice_test.go
@@ -1,0 +1,135 @@
+package audio
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
+	provider := NewVeniceProvider("  Bearer test-key\n")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
+func TestValidateOptions(t *testing.T) {
+	if err := ValidateFormat("wav"); err != nil {
+		t.Fatalf("ValidateFormat(wav): %v", err)
+	}
+	if err := ValidateFormat("ogg"); err == nil {
+		t.Fatal("expected invalid format error")
+	}
+	if err := ValidateSpeed(0.25); err != nil {
+		t.Fatalf("ValidateSpeed(0.25): %v", err)
+	}
+	if err := ValidateSpeed(4.01); err == nil {
+		t.Fatal("expected invalid speed error")
+	}
+	if err := ValidateTemperature(2); err != nil {
+		t.Fatalf("ValidateTemperature(2): %v", err)
+	}
+	if err := ValidateTemperature(2.1); err == nil {
+		t.Fatal("expected invalid temperature error")
+	}
+	if err := ValidateTopP(1); err != nil {
+		t.Fatalf("ValidateTopP(1): %v", err)
+	}
+	if err := ValidateTopP(1.1); err == nil {
+		t.Fatal("expected invalid top-p error")
+	}
+}
+
+func TestVeniceModelsIncludeAllDocumentedTTSModels(t *testing.T) {
+	want := []string{
+		"tts-kokoro",
+		"tts-qwen3-0-6b",
+		"tts-qwen3-1-7b",
+		"tts-xai-v1",
+		"tts-inworld-1-5-max",
+		"tts-chatterbox-hd",
+		"tts-orpheus",
+		"tts-elevenlabs-turbo-v2-5",
+		"tts-minimax-speech-02-hd",
+		"tts-gemini-3-1-flash",
+	}
+	for _, model := range want {
+		if !contains(VeniceModels, model) {
+			t.Fatalf("VeniceModels missing %s", model)
+		}
+	}
+}
+
+func TestVeniceProviderGenerate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != veniceSpeechEndpoint {
+			t.Fatalf("path = %s, want %s", r.URL.Path, veniceSpeechEndpoint)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["input"] != "hello" || body["model"] != "tts-qwen3-0-6b" || body["voice"] != "Vivian" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		if body["language"] != "English" || body["prompt"] != "Very happy." || body["response_format"] != "wav" {
+			t.Fatalf("missing options in body: %#v", body)
+		}
+		if body["streaming"] != true || body["temperature"] != 0.9 || body["top_p"] != 0.8 {
+			t.Fatalf("missing sampling options in body: %#v", body)
+		}
+		w.Header().Set("Content-Type", "audio/wav; charset=binary")
+		_, _ = w.Write([]byte("fake-wav"))
+	}))
+	defer server.Close()
+
+	temperature := 0.9
+	topP := 0.8
+	provider := NewVeniceProvider("test-key")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+
+	result, err := provider.Generate(context.Background(), Request{
+		Input:          "hello",
+		Model:          "tts-qwen3-0-6b",
+		Voice:          "Vivian",
+		Language:       "English",
+		Prompt:         "Very happy.",
+		ResponseFormat: "wav",
+		Speed:          1.25,
+		Streaming:      true,
+		Temperature:    &temperature,
+		TopP:           &topP,
+	})
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if result.MimeType != "audio/wav" {
+		t.Fatalf("MimeType = %q, want audio/wav", result.MimeType)
+	}
+	if string(result.Data) != "fake-wav" {
+		t.Fatalf("Data = %q, want fake-wav", string(result.Data))
+	}
+}
+
+func TestGenerateRequiresInput(t *testing.T) {
+	_, err := NewVeniceProvider("test-key").Generate(context.Background(), Request{Input: "   "})
+	if err == nil || !strings.Contains(err.Error(), "input text is required") {
+		t.Fatalf("err = %v, want input text required", err)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -363,10 +363,11 @@ type ImageDebugConfig struct {
 
 // AudioConfig configures speech/audio generation settings.
 type AudioConfig struct {
-	Provider  string            `mapstructure:"provider"`   // default audio provider: venice or gemini
-	OutputDir string            `mapstructure:"output_dir"` // default save directory
-	Venice    AudioVeniceConfig `mapstructure:"venice"`
-	Gemini    AudioGeminiConfig `mapstructure:"gemini"`
+	Provider   string                `mapstructure:"provider"`   // default audio provider: venice, gemini, or elevenlabs
+	OutputDir  string                `mapstructure:"output_dir"` // default save directory
+	Venice     AudioVeniceConfig     `mapstructure:"venice"`
+	Gemini     AudioGeminiConfig     `mapstructure:"gemini"`
+	ElevenLabs AudioElevenLabsConfig `mapstructure:"elevenlabs"`
 }
 
 // AudioVeniceConfig configures Venice AI text-to-speech generation.
@@ -379,6 +380,14 @@ type AudioVeniceConfig struct {
 
 // AudioGeminiConfig configures Gemini text-to-speech generation.
 type AudioGeminiConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
+	Voice  string `mapstructure:"voice"`
+	Format string `mapstructure:"format"`
+}
+
+// AudioElevenLabsConfig configures ElevenLabs text-to-speech generation.
+type AudioElevenLabsConfig struct {
 	APIKey string `mapstructure:"api_key"`
 	Model  string `mapstructure:"model"`
 	Voice  string `mapstructure:"voice"`
@@ -1054,6 +1063,13 @@ func resolveAudioCredentials(cfg *AudioConfig) {
 	cfg.Gemini.APIKey = expandEnv(cfg.Gemini.APIKey)
 	if cfg.Gemini.APIKey == "" {
 		cfg.Gemini.APIKey = os.Getenv("GEMINI_API_KEY")
+	}
+	cfg.ElevenLabs.APIKey = expandEnv(cfg.ElevenLabs.APIKey)
+	if cfg.ElevenLabs.APIKey == "" {
+		cfg.ElevenLabs.APIKey = os.Getenv("ELEVENLABS_API_KEY")
+	}
+	if cfg.ElevenLabs.APIKey == "" {
+		cfg.ElevenLabs.APIKey = os.Getenv("XI_API_KEY")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	Chat            ChatConfig                `mapstructure:"chat"`
 	Edit            EditConfig                `mapstructure:"edit"`
 	Image           ImageConfig               `mapstructure:"image"`
+	Audio           AudioConfig               `mapstructure:"audio"`
 	Transcription   TranscriptionConfig       `mapstructure:"transcription"`
 	Embed           EmbedConfig               `mapstructure:"embed"`
 	Search          SearchConfig              `mapstructure:"search"`
@@ -360,6 +361,21 @@ type ImageDebugConfig struct {
 	Delay float64 `mapstructure:"delay"` // delay in seconds before returning (e.g., 1.5)
 }
 
+// AudioConfig configures speech/audio generation settings.
+type AudioConfig struct {
+	Provider  string            `mapstructure:"provider"`   // default audio provider: venice
+	OutputDir string            `mapstructure:"output_dir"` // default save directory
+	Venice    AudioVeniceConfig `mapstructure:"venice"`
+}
+
+// AudioVeniceConfig configures Venice AI text-to-speech generation.
+type AudioVeniceConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
+	Voice  string `mapstructure:"voice"`
+	Format string `mapstructure:"format"`
+}
+
 // TranscriptionConfig configures audio transcription settings.
 type TranscriptionConfig struct {
 	Provider string `mapstructure:"provider"` // named provider from providers map; default "openai"
@@ -492,6 +508,7 @@ func Load() (*Config, error) {
 	}
 
 	resolveImageCredentials(&cfg.Image)
+	resolveAudioCredentials(&cfg.Audio)
 	resolveEmbedCredentials(&cfg.Embed)
 	resolveSearchCredentials(&cfg.Search)
 
@@ -1019,6 +1036,14 @@ func resolveImageCredentials(cfg *ImageConfig) {
 	}
 }
 
+// resolveAudioCredentials resolves API credentials for audio providers.
+func resolveAudioCredentials(cfg *AudioConfig) {
+	cfg.Venice.APIKey = expandEnv(cfg.Venice.APIKey)
+	if cfg.Venice.APIKey == "" {
+		cfg.Venice.APIKey = os.Getenv("VENICE_API_KEY")
+	}
+}
+
 // resolveEmbedCredentials resolves API credentials for all embedding providers
 func resolveEmbedCredentials(cfg *EmbedConfig) {
 	// OpenAI embed credentials
@@ -1181,6 +1206,7 @@ var KnownKeys = map[string]bool{
 	"chat":             true,
 	"edit":             true,
 	"image":            true,
+	"audio":            true,
 	"transcription":    true,
 	"search":           true,
 	"theme":            true,
@@ -1259,6 +1285,15 @@ var KnownKeys = map[string]bool{
 	"image.openrouter.model":   true,
 	"image.debug":              true,
 	"image.debug.delay":        true,
+
+	// Audio
+	"audio.provider":       true,
+	"audio.output_dir":     true,
+	"audio.venice":         true,
+	"audio.venice.api_key": true,
+	"audio.venice.model":   true,
+	"audio.venice.voice":   true,
+	"audio.venice.format":  true,
 
 	// Transcription
 	"transcription.provider": true,
@@ -1411,6 +1446,11 @@ func GetDefaults() map[string]any {
 		"image.flux.model":                "flux-2-pro",
 		"image.openrouter.model":          "google/gemini-2.5-flash-image",
 		"image.debug.delay":               0.0,
+		"audio.provider":                  "venice",
+		"audio.output_dir":                "~/Music/term-llm",
+		"audio.venice.model":              "tts-kokoro",
+		"audio.venice.voice":              "af_sky",
+		"audio.venice.format":             "mp3",
 		"embed.openai.model":              "text-embedding-3-small",
 		"embed.gemini.model":              "gemini-embedding-001",
 		"embed.jina.model":                "jina-embeddings-v3",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -363,13 +363,22 @@ type ImageDebugConfig struct {
 
 // AudioConfig configures speech/audio generation settings.
 type AudioConfig struct {
-	Provider  string            `mapstructure:"provider"`   // default audio provider: venice
+	Provider  string            `mapstructure:"provider"`   // default audio provider: venice or gemini
 	OutputDir string            `mapstructure:"output_dir"` // default save directory
 	Venice    AudioVeniceConfig `mapstructure:"venice"`
+	Gemini    AudioGeminiConfig `mapstructure:"gemini"`
 }
 
 // AudioVeniceConfig configures Venice AI text-to-speech generation.
 type AudioVeniceConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
+	Voice  string `mapstructure:"voice"`
+	Format string `mapstructure:"format"`
+}
+
+// AudioGeminiConfig configures Gemini text-to-speech generation.
+type AudioGeminiConfig struct {
 	APIKey string `mapstructure:"api_key"`
 	Model  string `mapstructure:"model"`
 	Voice  string `mapstructure:"voice"`
@@ -1041,6 +1050,10 @@ func resolveAudioCredentials(cfg *AudioConfig) {
 	cfg.Venice.APIKey = expandEnv(cfg.Venice.APIKey)
 	if cfg.Venice.APIKey == "" {
 		cfg.Venice.APIKey = os.Getenv("VENICE_API_KEY")
+	}
+	cfg.Gemini.APIKey = expandEnv(cfg.Gemini.APIKey)
+	if cfg.Gemini.APIKey == "" {
+		cfg.Gemini.APIKey = os.Getenv("GEMINI_API_KEY")
 	}
 }
 


### PR DESCRIPTION
## What

Adds `term-llm audio <text>` for text-to-speech generation.

Providers:
- Venice via `/audio/speech`
- Gemini via `generateContent` with `responseModalities: ["AUDIO"]`
- ElevenLabs via `/v1/text-to-speech/{voice_id}` and `/stream`

Venice support includes:
- All current Venice TTS models
- Voices catalog / shell completion candidates
- `--model`, `--voice`, `--language`, `--prompt`, `--format`, `--speed`, `--streaming`, `--temperature`, `--top-p`

Gemini support includes:
- `gemini-3.1-flash-tts-preview`
- `gemini-2.5-flash-preview-tts`
- `gemini-2.5-pro-preview-tts`
- Prebuilt Gemini voices
- Single-speaker TTS via `--voice`
- Multi-speaker TTS via `--speaker1/--voice1` and `--speaker2/--voice2`
- `wav` output by wrapping Gemini's 24 kHz mono PCM, plus raw `pcm`

ElevenLabs support includes:
- TTS models: `eleven_v3`, `eleven_multilingual_v2`, `eleven_flash_v2_5`, `eleven_flash_v2`, plus deprecated turbo/v1 IDs for compatibility
- Full documented speech options exposed as flags: output format, language, voice settings, seed, previous/next text, previous/next request IDs, pronunciation dictionaries, PVC/IVC switch, text normalization, logging, latency optimization, streaming
- Voice IDs directly, or account voice names via `/v2/voices` lookup
- All documented output formats as completion candidates

General command behavior:
- Positional text wins
- If no positional text is supplied, piped stdin is used
- `-o -` writes audio bytes to stdout
- `--json` emits a machine-readable result after saving
- Shell completion for provider/model/voice/format values

## Config

Adds:

```yaml
audio:
  provider: venice
  output_dir: ~/Music/term-llm
  venice:
    api_key: $VENICE_API_KEY
    model: tts-kokoro
    voice: af_sky
    format: mp3
  gemini:
    api_key: $GEMINI_API_KEY
    model: gemini-3.1-flash-tts-preview
    voice: Kore
    format: wav
  elevenlabs:
    api_key: $ELEVENLABS_API_KEY
    model: eleven_multilingual_v2
    voice: JBFqnCBsd6RMkjVDRZzb
    format: mp3_44100_128
```

Gemini credentials also fall back to existing `image.gemini.api_key` and configured `providers.gemini` credentials.

ElevenLabs credentials read from `audio.elevenlabs.api_key`, `ELEVENLABS_API_KEY`, `XI_API_KEY`, or configured `providers.elevenlabs` credentials.

## Verification

```sh
go build ./...
go test ./...
```

Live Venice smoke test:

```json
{
  "provider": "venice",
  "text": "hi",
  "model": "tts-kokoro",
  "voice": "af_sky",
  "format": "mp3",
  "output": {
    "path": "/tmp/tmp.TEEQApMvRw/hi.mp3",
    "mime_type": "audio/mpeg",
    "bytes": 4365
  }
}
```

Live Gemini smoke test:

```json
{
  "provider": "gemini",
  "text": "Say clearly: hi",
  "model": "gemini-3.1-flash-tts-preview",
  "voice": "Kore",
  "format": "wav",
  "output": {
    "path": "/tmp/gemini-term-llm-hi.wav",
    "mime_type": "audio/wav",
    "bytes": 51884
  }
}
```

ElevenLabs local checks:

```sh
term-llm __complete audio --provider elevenlabs --model ''
term-llm __complete audio --provider elevenlabs --format ''
term-llm audio 'one second elevenlabs smoke test' --provider elevenlabs --model eleven_flash_v2_5 --voice JBFqnCBsd6RMkjVDRZzb --format mp3_44100_128 --json -o /tmp/eleven-smoke.mp3
```

The first two confirm completion values. The live generation path currently stops at credential resolution on this container: no `ELEVENLABS_API_KEY` / `XI_API_KEY` / `audio.elevenlabs.api_key` is configured here.
