### PR TITLE
feat: add music generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Common entry points:
 - [Memory](https://term-llm.com/guides/memory/)
 - [Jobs](https://term-llm.com/guides/job-runner/)
 - [Text embeddings](https://term-llm.com/guides/text-embeddings/)
+- [Audio generation](https://term-llm.com/guides/audio-generation/)
+- [Music generation](https://term-llm.com/guides/music-generation/)
 - [Usage tracking](https://term-llm.com/reference/usage-tracking/)
 - [Transcription](https://term-llm.com/guides/transcription/)
 - [Notifications](https://term-llm.com/guides/notifications/)

--- a/cmd/music.go
+++ b/cmd/music.go
@@ -1,0 +1,339 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/music"
+	"github.com/samsaffron/term-llm/internal/signal"
+	"github.com/spf13/cobra"
+)
+
+var (
+	musicProvider                 string
+	musicOutput                   string
+	musicModel                    string
+	musicFormat                   string
+	musicDuration                 int
+	musicLyrics                   string
+	musicLyricsFile               string
+	musicLyricsOptimizer          bool
+	musicVoice                    string
+	musicLanguage                 string
+	musicSpeed                    float64
+	musicStreaming                bool
+	musicDetailed                 bool
+	musicCompositionPlanFile      string
+	musicSeed                     string
+	musicForceInstrumental        bool
+	musicRespectSectionsDurations bool
+	musicStoreForInpainting       bool
+	musicSignWithC2PA             bool
+	musicWithTimestamps           bool
+	musicDeleteMediaOnCompletion  bool
+	musicQuote                    bool
+	musicPollInterval             time.Duration
+	musicPollTimeout              time.Duration
+	musicJSON                     bool
+	musicDebug                    bool
+)
+
+var musicCmd = &cobra.Command{
+	Use:   "music <prompt>",
+	Short: "Generate music or sound effects",
+	Long: `Generate music, songs, or sound effects using Venice or ElevenLabs.
+
+By default:
+  - Saves to ~/Music/term-llm/
+  - Uses Venice elevenlabs-sound-effects-v2 so short smoke clips are cheap and fast
+  - Reads prompt text from stdin when no positional prompt is supplied
+
+Examples:
+  term-llm music "a one second clean synth blip" --duration 1
+  term-llm music "upbeat chiptune victory sting" --provider venice --model mmaudio-v2-text-to-audio --duration 1
+  term-llm music "polished instrumental funk loop" --provider elevenlabs --duration 3 --force-instrumental
+  term-llm music "80s synth pop song" --model minimax-music-v25 --lyrics "Verse 1: Neon lights..." --duration 60
+  term-llm music "quote this first" --quote --duration 1
+  echo "cinematic whoosh" | term-llm music -o - > whoosh.mp3
+  term-llm music "machine readable" --json`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runMusic,
+}
+
+func init() {
+	musicCmd.Flags().StringVarP(&musicProvider, "provider", "p", "", "Music provider override (venice, elevenlabs)")
+	musicCmd.Flags().StringVarP(&musicOutput, "output", "o", "", "Custom output path, or - for stdout")
+	musicCmd.Flags().StringVar(&musicModel, "model", "", "Music model to use")
+	musicCmd.Flags().StringVar(&musicFormat, "format", "", "Output format (Venice: mp3, wav, flac by model; ElevenLabs: mp3_44100_128, pcm_24000, wav_44100, etc.)")
+	musicCmd.Flags().IntVar(&musicDuration, "duration", 0, "Requested duration in seconds (Venice model-specific; ElevenLabs prompt mode: 3 to 600)")
+	musicCmd.Flags().StringVar(&musicLyrics, "lyrics", "", "Lyrics prompt/text for lyric-capable Venice models")
+	musicCmd.Flags().StringVar(&musicLyricsFile, "lyrics-file", "", "Read lyrics prompt/text from a file")
+	musicCmd.Flags().BoolVar(&musicLyricsOptimizer, "lyrics-optimizer", false, "Venice: auto-generate lyrics from prompt where supported")
+	musicCmd.Flags().StringVar(&musicVoice, "voice", "", "Voice for Venice voice-enabled models")
+	musicCmd.Flags().StringVar(&musicLanguage, "language", "", "Language code for Venice models that support language_code")
+	musicCmd.Flags().Float64Var(&musicSpeed, "speed", 0, "Speed multiplier for Venice models that support speed")
+	musicCmd.Flags().BoolVar(&musicStreaming, "streaming", false, "ElevenLabs: use streaming music endpoint")
+	musicCmd.Flags().BoolVar(&musicDetailed, "detailed", false, "ElevenLabs: use detailed endpoint and keep metadata when returned")
+	musicCmd.Flags().StringVar(&musicCompositionPlanFile, "composition-plan-file", "", "ElevenLabs: JSON composition plan file; cannot be combined with prompt-only seed")
+	musicCmd.Flags().StringVar(&musicSeed, "seed", "", "ElevenLabs: deterministic seed (0 to 2147483647); cannot be used with prompt per API docs")
+	musicCmd.Flags().BoolVar(&musicForceInstrumental, "force-instrumental", false, "Force instrumental generation where supported")
+	musicCmd.Flags().BoolVar(&musicRespectSectionsDurations, "respect-sections-durations", true, "ElevenLabs composition-plan mode: strictly respect section durations")
+	musicCmd.Flags().BoolVar(&musicStoreForInpainting, "store-for-inpainting", false, "ElevenLabs enterprise: store generated song for inpainting")
+	musicCmd.Flags().BoolVar(&musicSignWithC2PA, "sign-with-c2pa", false, "ElevenLabs: sign generated mp3 with C2PA")
+	musicCmd.Flags().BoolVar(&musicWithTimestamps, "with-timestamps", false, "ElevenLabs detailed endpoint: include word timestamps")
+	musicCmd.Flags().BoolVar(&musicDeleteMediaOnCompletion, "delete-media-on-completion", true, "Venice: delete queued media from provider storage after retrieval")
+	musicCmd.Flags().BoolVar(&musicQuote, "quote", false, "Venice: return price quote instead of queueing generation")
+	musicCmd.Flags().DurationVar(&musicPollInterval, "poll-interval", 2*time.Second, "Venice poll interval")
+	musicCmd.Flags().DurationVar(&musicPollTimeout, "poll-timeout", 10*time.Minute, "Venice poll timeout")
+	musicCmd.Flags().BoolVar(&musicJSON, "json", false, "Emit machine-readable JSON to stdout")
+	musicCmd.Flags().BoolVarP(&musicDebug, "debug", "d", false, "Show debug information")
+	_ = musicCmd.RegisterFlagCompletionFunc("provider", staticCompletion("venice", "elevenlabs"))
+	_ = musicCmd.RegisterFlagCompletionFunc("model", musicModelCompletion)
+	_ = musicCmd.RegisterFlagCompletionFunc("format", musicFormatCompletion)
+	_ = musicCmd.RegisterFlagCompletionFunc("voice", staticCompletion(music.VeniceVoices...))
+
+	rootCmd.AddCommand(musicCmd)
+}
+
+func runMusic(cmd *cobra.Command, args []string) error {
+	prompt, err := resolveMusicPrompt(cmd, args)
+	if err != nil {
+		return err
+	}
+	lyrics, err := resolveMusicLyrics()
+	if err != nil {
+		return err
+	}
+	plan, err := readOptionalFile(musicCompositionPlanFile)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := loadConfigWithSetup()
+	if err != nil {
+		return err
+	}
+	initThemeFromConfig(cfg)
+
+	providerName := firstNonEmpty(musicProvider, cfg.Music.Provider, "venice")
+	req := music.Request{
+		Prompt:                      prompt,
+		CompositionPlan:             plan,
+		Format:                      musicFormat,
+		DurationSeconds:             musicDuration,
+		LyricsPrompt:                lyrics,
+		LyricsOptimizer:             musicLyricsOptimizer,
+		LyricsOptimizerSet:          cmd.Flags().Changed("lyrics-optimizer"),
+		Voice:                       musicVoice,
+		LanguageCode:                musicLanguage,
+		Speed:                       musicSpeed,
+		Streaming:                   musicStreaming,
+		Detailed:                    musicDetailed,
+		Seed:                        musicSeed,
+		ForceInstrumental:           musicForceInstrumental,
+		ForceInstrumentalSet:        cmd.Flags().Changed("force-instrumental"),
+		RespectSectionsDurations:    musicRespectSectionsDurations,
+		RespectSectionsDurationsSet: cmd.Flags().Changed("respect-sections-durations"),
+		StoreForInpainting:          musicStoreForInpainting,
+		SignWithC2PA:                musicSignWithC2PA,
+		WithTimestamps:              musicWithTimestamps,
+		DeleteMediaOnCompletion:     musicDeleteMediaOnCompletion,
+		QuoteOnly:                   musicQuote,
+		PollInterval:                musicPollInterval,
+		PollTimeout:                 musicPollTimeout,
+		Debug:                       musicDebug,
+		DebugRaw:                    debugRaw,
+	}
+
+	switch providerName {
+	case "venice":
+		return runVeniceMusic(cmd, cfg, req)
+	case "elevenlabs":
+		return runElevenLabsMusic(cmd, cfg, req)
+	default:
+		return fmt.Errorf("unsupported music provider %q (allowed: venice, elevenlabs)", providerName)
+	}
+}
+
+func runVeniceMusic(cmd *cobra.Command, cfg *config.Config, req music.Request) error {
+	apiKey := strings.TrimSpace(cfg.Music.Venice.APIKey)
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(cfg.Audio.Venice.APIKey)
+	}
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(cfg.Image.Venice.APIKey)
+	}
+	if apiKey == "" {
+		return fmt.Errorf("VENICE_API_KEY not configured. Set environment variable or add to music.venice.api_key in config")
+	}
+	req.Model = firstNonEmpty(musicModel, cfg.Music.Venice.Model, "elevenlabs-sound-effects-v2")
+	if req.Format == "" {
+		req.Format = firstNonEmpty(cfg.Music.Venice.Format, music.VeniceDefaultFormatForModel(req.Model))
+	}
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+	result, err := music.NewVeniceProvider(apiKey).Generate(ctx, req)
+	if err != nil {
+		return fmt.Errorf("music generation failed: %w", err)
+	}
+	return writeMusicResult(cmd, cfg.Music.OutputDir, "venice", req.Prompt, req.Model, req.Format, result)
+}
+
+func runElevenLabsMusic(cmd *cobra.Command, cfg *config.Config, req music.Request) error {
+	apiKey := strings.TrimSpace(cfg.Music.ElevenLabs.APIKey)
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(cfg.Audio.ElevenLabs.APIKey)
+	}
+	if apiKey == "" {
+		if elevenLabsProvider := cfg.GetProviderConfig("elevenlabs"); elevenLabsProvider != nil {
+			apiKey = strings.TrimSpace(elevenLabsProvider.ResolvedAPIKey)
+		}
+	}
+	if apiKey == "" {
+		return fmt.Errorf("ELEVENLABS_API_KEY not configured. Set environment variable or add to music.elevenlabs.api_key in config")
+	}
+	req.Model = firstNonEmpty(musicModel, cfg.Music.ElevenLabs.Model, "music_v1")
+	if req.Format == "" {
+		req.Format = firstNonEmpty(cfg.Music.ElevenLabs.Format, "mp3_44100_128")
+	}
+	ctx, stop := signal.NotifyContext()
+	defer stop()
+	result, err := music.NewElevenLabsProvider(apiKey).Generate(ctx, req)
+	if err != nil {
+		return fmt.Errorf("music generation failed: %w", err)
+	}
+	return writeMusicResult(cmd, cfg.Music.OutputDir, "elevenlabs", req.Prompt, req.Model, req.Format, result)
+}
+
+func resolveMusicPrompt(cmd *cobra.Command, args []string) (string, error) {
+	if len(args) > 0 {
+		text := strings.TrimSpace(strings.Join(args, " "))
+		if text == "" {
+			return "", fmt.Errorf("prompt is required")
+		}
+		return text, nil
+	}
+	stat, err := os.Stdin.Stat()
+	if err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+		data, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		text := strings.TrimSpace(string(data))
+		if text != "" {
+			return text, nil
+		}
+	}
+	if strings.TrimSpace(musicCompositionPlanFile) != "" {
+		return "", nil
+	}
+	return "", fmt.Errorf("prompt is required")
+}
+
+func resolveMusicLyrics() (string, error) {
+	if strings.TrimSpace(musicLyricsFile) == "" {
+		return musicLyrics, nil
+	}
+	if strings.TrimSpace(musicLyrics) != "" {
+		return "", fmt.Errorf("use either --lyrics or --lyrics-file, not both")
+	}
+	data, err := os.ReadFile(expandOutputPath(musicLyricsFile))
+	if err != nil {
+		return "", fmt.Errorf("read lyrics file: %w", err)
+	}
+	return string(data), nil
+}
+
+func readOptionalFile(path string) ([]byte, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(expandOutputPath(path))
+	if err != nil {
+		return nil, fmt.Errorf("read file %s: %w", path, err)
+	}
+	return data, nil
+}
+
+func writeMusicResult(cmd *cobra.Command, outputDir, providerName, prompt, model, format string, result *music.Result) error {
+	if result.Quote != nil {
+		if musicJSON {
+			return emitMusicJSON(cmd, musicJSONResult{Provider: providerName, Prompt: prompt, Model: model, Format: format, Quote: result.Quote})
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "$%.4f\n", *result.Quote)
+		return nil
+	}
+	if musicOutput == "-" {
+		_, err := cmd.OutOrStdout().Write(result.Data)
+		return err
+	}
+	outputPath, err := saveMusicOutput(outputDir, prompt, musicOutput, result.Format, result.Data)
+	if err != nil {
+		return err
+	}
+	if !musicJSON {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Saved to: %s\n", outputPath)
+	}
+	return emitMusicJSON(cmd, musicJSONResult{Provider: providerName, Prompt: prompt, Model: model, Format: result.Format, Output: &musicJSONOutput{Path: outputPath, MimeType: result.MimeType, Bytes: len(result.Data)}, Metadata: result.Metadata})
+}
+
+func saveMusicOutput(outputDir, prompt, outputPath, format string, data []byte) (string, error) {
+	if strings.TrimSpace(outputPath) == "" {
+		return music.Save(data, outputDir, prompt, format)
+	}
+	path := expandOutputPath(outputPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write music: %w", err)
+	}
+	return path, nil
+}
+
+type musicJSONResult struct {
+	Provider string           `json:"provider"`
+	Prompt   string           `json:"prompt"`
+	Model    string           `json:"model"`
+	Format   string           `json:"format"`
+	Quote    *float64         `json:"quote,omitempty"`
+	Output   *musicJSONOutput `json:"output,omitempty"`
+	Metadata json.RawMessage  `json:"metadata,omitempty"`
+}
+
+type musicJSONOutput struct {
+	Path     string `json:"path"`
+	MimeType string `json:"mime_type"`
+	Bytes    int    `json:"bytes"`
+}
+
+func emitMusicJSON(cmd *cobra.Command, result musicJSONResult) error {
+	if !musicJSON {
+		return nil
+	}
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}
+
+func musicModelCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	provider := completionProvider(cmd)
+	if provider == "elevenlabs" {
+		return music.ElevenLabsModels, cobra.ShellCompDirectiveNoFileComp
+	}
+	return music.VeniceModels, cobra.ShellCompDirectiveNoFileComp
+}
+
+func musicFormatCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	provider := completionProvider(cmd)
+	if provider == "elevenlabs" {
+		return music.ElevenLabsFormats, cobra.ShellCompDirectiveNoFileComp
+	}
+	return music.VeniceFormats, cobra.ShellCompDirectiveNoFileComp
+}

--- a/docs-site/content/guides/music-generation.md
+++ b/docs-site/content/guides/music-generation.md
@@ -1,0 +1,166 @@
+---
+title: "Music generation"
+weight: 6
+description: "Generate music and sound effects with Venice AI and ElevenLabs."
+kicker: "Media"
+---
+
+Generate music, songs, or sound effects from a prompt.
+
+```bash
+term-llm music "single bright xylophone ping" --duration 1
+```
+
+By default, music clips are:
+
+- Saved to `~/Music/term-llm/` with timestamped filenames
+- Generated with Venice `elevenlabs-sound-effects-v2`
+- Returned as MP3
+
+The command also reads the prompt from stdin when no positional prompt is supplied:
+
+```bash
+echo "cinematic whoosh" | term-llm music -o - > whoosh.mp3
+```
+
+### Providers
+
+`term-llm music` supports:
+
+- `venice` — Venice async audio queue for music, songs, sound effects, and Venice-hosted TTS audio models
+- `elevenlabs` — ElevenLabs `/v1/music`, `/v1/music/stream`, and `/v1/music/detailed`
+
+### Music flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--provider` | `-p` | Music provider override: `venice`, `elevenlabs` |
+| `--output` | `-o` | Custom output path, or `-` for stdout |
+| `--model` | | Music model override |
+| `--format` | | Output format. Venice: model-default `mp3`, `wav`, or `flac`; ElevenLabs: `mp3_44100_128`, `pcm_24000`, `wav_44100`, etc. |
+| `--duration` | | Requested duration in seconds. Venice is model-specific; ElevenLabs prompt mode supports 3 to 600 seconds |
+| `--lyrics` / `--lyrics-file` | | Venice lyrics prompt/text for lyric-capable models |
+| `--lyrics-optimizer` | | Venice: auto-generate lyrics from the prompt where supported |
+| `--voice` | | Venice voice for voice-enabled models |
+| `--language` | | Venice language code for models that support `language_code` |
+| `--speed` | | Venice speed multiplier for models that support speed |
+| `--streaming` | | ElevenLabs: use the streaming music endpoint |
+| `--detailed` | | ElevenLabs: use the detailed endpoint and keep returned metadata when available |
+| `--composition-plan-file` | | ElevenLabs: JSON composition plan file |
+| `--seed` | | ElevenLabs deterministic seed |
+| `--force-instrumental` | | Force instrumental generation where supported |
+| `--respect-sections-durations` | | ElevenLabs composition-plan mode: strictly respect section durations |
+| `--store-for-inpainting` | | ElevenLabs enterprise option to store generated song for inpainting |
+| `--sign-with-c2pa` | | ElevenLabs: sign generated MP3 with C2PA |
+| `--with-timestamps` | | ElevenLabs detailed endpoint: include word timestamps |
+| `--delete-media-on-completion` | | Venice: delete queued provider-side media after retrieval; enabled by default |
+| `--quote` | | Venice: return price quote instead of queueing generation |
+| `--poll-interval` / `--poll-timeout` | | Venice async queue polling controls |
+| `--json` | | Emit machine-readable JSON to stdout |
+| `--debug` | `-d` | Show debug information |
+
+`--provider`, `--model`, `--format`, and `--voice` include shell completion candidates.
+
+### Examples
+
+```bash
+term-llm music "single bright xylophone ping" \
+  --provider venice \
+  --model elevenlabs-sound-effects-v2 \
+  --duration 1
+
+term-llm music "upbeat chiptune victory sting" \
+  --provider venice \
+  --model mmaudio-v2-text-to-audio \
+  --duration 1 \
+  --format wav
+
+term-llm music "polished instrumental funk loop" \
+  --provider elevenlabs \
+  --duration 3 \
+  --force-instrumental \
+  --format mp3_44100_128
+
+term-llm music "80s synth pop song" \
+  --provider venice \
+  --model minimax-music-v25 \
+  --lyrics "Verse 1: Neon lights over the avenue" \
+  --duration 60
+
+term-llm music "quote a one second sound effect" \
+  --provider venice \
+  --model elevenlabs-sound-effects-v2 \
+  --duration 1 \
+  --quote
+```
+
+### Venice music models
+
+term-llm includes the Venice music/audio model catalog:
+
+| Model | Default format | Duration support | Notes |
+|-------|----------------|------------------|-------|
+| `ace-step-15` | `flac` | 60–210 seconds | Song generation with optional lyrics |
+| `elevenlabs-music` | `mp3` | 3–600 seconds | High-quality instrumental music; supports `--force-instrumental` |
+| `minimax-music-v2` | `mp3` | Provider default | Requires lyrics |
+| `minimax-music-v25` | `mp3` | Provider default | Lyrics optional; supports lyric optimizer and instrumental mode |
+| `minimax-music-v26` | `mp3` | Provider default | Lyrics optional; supports instrumental mode |
+| `stable-audio-25` | `wav` | 5–190 seconds | Sound effects, ambient textures, short clips |
+| `elevenlabs-sound-effects-v2` | `mp3` | 1–22 seconds | Default; good for one-second smoke clips |
+| `mmaudio-v2-text-to-audio` | `wav` | 1–30 seconds | Text-to-audio / sound effects |
+| `elevenlabs-tts-v3` | `mp3` | Character-priced | Venice-hosted ElevenLabs TTS v3 with voices |
+| `elevenlabs-tts-multilingual-v2` | `mp3` | Character-priced | Venice-hosted ElevenLabs multilingual TTS |
+
+Venice options are model-specific. If a model does not support a supplied field, Venice returns the API error directly.
+
+### ElevenLabs music model
+
+ElevenLabs currently documents one music model for the compose endpoints:
+
+| Model | Notes |
+|-------|-------|
+| `music_v1` | Prompt or composition-plan driven music generation |
+
+ElevenLabs prompt-mode duration is `3` to `600` seconds. So a literal one-second test is not accepted by the direct ElevenLabs music API; use `--duration 3` there. Venice has one-second-capable sound-effect models.
+
+ElevenLabs output formats:
+
+`alaw_8000`, `mp3_22050_32`, `mp3_24000_48`, `mp3_44100_32`, `mp3_44100_64`, `mp3_44100_96`, `mp3_44100_128`, `mp3_44100_192`, `opus_48000_32`, `opus_48000_64`, `opus_48000_96`, `opus_48000_128`, `opus_48000_192`, `pcm_8000`, `pcm_16000`, `pcm_22050`, `pcm_24000`, `pcm_32000`, `pcm_44100`, `pcm_48000`, `ulaw_8000`, `wav_8000`, `wav_16000`, `wav_22050`, `wav_24000`, `wav_32000`, `wav_44100`, `wav_48000`.
+
+### JSON output
+
+`--json` prints a single structured object to stdout after saving the file.
+
+```json
+{
+  "provider": "venice",
+  "prompt": "single bright xylophone ping",
+  "model": "elevenlabs-sound-effects-v2",
+  "format": "mp3",
+  "output": {
+    "path": "/home/me/Music/term-llm/20260503-120000-single_bright_xylophone_ping.mp3",
+    "mime_type": "audio/mpeg",
+    "bytes": 17180
+  }
+}
+```
+
+### Credentials and config
+
+`term-llm music` reads Venice credentials from `VENICE_API_KEY`, `music.venice.api_key`, `audio.venice.api_key`, or the existing `image.venice.api_key` fallback.
+
+ElevenLabs credentials are read from `ELEVENLABS_API_KEY`, `XI_API_KEY`, `music.elevenlabs.api_key`, `audio.elevenlabs.api_key`, or the configured `providers.elevenlabs` API key.
+
+```yaml
+music:
+  provider: venice
+  output_dir: ~/Music/term-llm
+  venice:
+    api_key: $VENICE_API_KEY
+    model: elevenlabs-sound-effects-v2
+    format: mp3
+  elevenlabs:
+    api_key: $ELEVENLABS_API_KEY
+    model: music_v1
+    format: mp3_44100_128
+```

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -32,7 +32,7 @@ A typical config has a few major parts:
 - `default_provider` for the global LLM default
 - `providers` for model-specific credentials and routing
 - per-command blocks such as `exec`, `ask`, and `edit`
-- feature-specific blocks such as `image`, `audio`, `embed`, `search`, `sessions`, `tools`, and `skills`
+- feature-specific blocks such as `image`, `audio`, `music`, `embed`, `search`, `sessions`, `tools`, and `skills`
 
 ## Example
 
@@ -145,7 +145,7 @@ search:
 
 Search is large enough to deserve its own page; see [Search](/guides/search/).
 
-## Image, audio, and embedding config
+## Image, audio, music, and embedding config
 
 ```yaml
 image:
@@ -161,11 +161,23 @@ audio:
     voice: af_sky
     format: mp3
 
+music:
+  provider: venice
+  output_dir: ~/Music/term-llm
+  venice:
+    api_key: ${VENICE_API_KEY}
+    model: elevenlabs-sound-effects-v2
+    format: mp3
+  elevenlabs:
+    api_key: ${ELEVENLABS_API_KEY}
+    model: music_v1
+    format: mp3_44100_128
+
 embed:
   provider: gemini
 ```
 
-Each feature block can hold provider-specific credentials and defaults. The image, audio, and embedding providers are independent of the main text provider.
+Each feature block can hold provider-specific credentials and defaults. The image, audio, music, and embedding providers are independent of the main text provider.
 
 ## Provider-specific environment overrides
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ type Config struct {
 	Edit            EditConfig                `mapstructure:"edit"`
 	Image           ImageConfig               `mapstructure:"image"`
 	Audio           AudioConfig               `mapstructure:"audio"`
+	Music           MusicConfig               `mapstructure:"music"`
 	Transcription   TranscriptionConfig       `mapstructure:"transcription"`
 	Embed           EmbedConfig               `mapstructure:"embed"`
 	Search          SearchConfig              `mapstructure:"search"`
@@ -394,6 +395,28 @@ type AudioElevenLabsConfig struct {
 	Format string `mapstructure:"format"`
 }
 
+// MusicConfig configures music and sound-effect generation settings.
+type MusicConfig struct {
+	Provider   string                `mapstructure:"provider"`   // default music provider: venice or elevenlabs
+	OutputDir  string                `mapstructure:"output_dir"` // default save directory
+	Venice     MusicVeniceConfig     `mapstructure:"venice"`
+	ElevenLabs MusicElevenLabsConfig `mapstructure:"elevenlabs"`
+}
+
+// MusicVeniceConfig configures Venice music/audio generation.
+type MusicVeniceConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
+	Format string `mapstructure:"format"`
+}
+
+// MusicElevenLabsConfig configures ElevenLabs music generation.
+type MusicElevenLabsConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
+	Format string `mapstructure:"format"`
+}
+
 // TranscriptionConfig configures audio transcription settings.
 type TranscriptionConfig struct {
 	Provider string `mapstructure:"provider"` // named provider from providers map; default "openai"
@@ -527,6 +550,7 @@ func Load() (*Config, error) {
 
 	resolveImageCredentials(&cfg.Image)
 	resolveAudioCredentials(&cfg.Audio)
+	resolveMusicCredentials(&cfg.Music)
 	resolveEmbedCredentials(&cfg.Embed)
 	resolveSearchCredentials(&cfg.Search)
 
@@ -1063,6 +1087,21 @@ func resolveAudioCredentials(cfg *AudioConfig) {
 	cfg.Gemini.APIKey = expandEnv(cfg.Gemini.APIKey)
 	if cfg.Gemini.APIKey == "" {
 		cfg.Gemini.APIKey = os.Getenv("GEMINI_API_KEY")
+	}
+	cfg.ElevenLabs.APIKey = expandEnv(cfg.ElevenLabs.APIKey)
+	if cfg.ElevenLabs.APIKey == "" {
+		cfg.ElevenLabs.APIKey = os.Getenv("ELEVENLABS_API_KEY")
+	}
+	if cfg.ElevenLabs.APIKey == "" {
+		cfg.ElevenLabs.APIKey = os.Getenv("XI_API_KEY")
+	}
+}
+
+// resolveMusicCredentials resolves API credentials for music providers.
+func resolveMusicCredentials(cfg *MusicConfig) {
+	cfg.Venice.APIKey = expandEnv(cfg.Venice.APIKey)
+	if cfg.Venice.APIKey == "" {
+		cfg.Venice.APIKey = os.Getenv("VENICE_API_KEY")
 	}
 	cfg.ElevenLabs.APIKey = expandEnv(cfg.ElevenLabs.APIKey)
 	if cfg.ElevenLabs.APIKey == "" {

--- a/internal/music/music.go
+++ b/internal/music/music.go
@@ -1,0 +1,625 @@
+package music
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/audio"
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+const (
+	veniceBaseURL           = "https://api.venice.ai/api/v1"
+	veniceQueueEndpoint     = "/audio/queue"
+	veniceRetrieveEndpoint  = "/audio/retrieve"
+	veniceQuoteEndpoint     = "/audio/quote"
+	veniceDefaultModel      = "elevenlabs-sound-effects-v2"
+	veniceDefaultFormat     = "mp3"
+	elevenLabsBaseURL       = "https://api.elevenlabs.io"
+	elevenLabsDefaultModel  = "music_v1"
+	elevenLabsDefaultFormat = "mp3_44100_128"
+	defaultPollInterval     = 2 * time.Second
+	defaultPollTimeout      = 10 * time.Minute
+)
+
+var (
+	VeniceModels = []string{
+		"ace-step-15",
+		"elevenlabs-music",
+		"minimax-music-v2",
+		"minimax-music-v25",
+		"minimax-music-v26",
+		"stable-audio-25",
+		"elevenlabs-sound-effects-v2",
+		"mmaudio-v2-text-to-audio",
+		"elevenlabs-tts-v3",
+		"elevenlabs-tts-multilingual-v2",
+	}
+	VeniceFormats     = []string{"mp3", "wav", "flac"}
+	VeniceVoices      = []string{"Aria", "Roger", "Sarah", "Laura", "Charlie", "George", "Callum", "River", "Liam", "Charlotte", "Alice", "Matilda", "Will", "Jessica", "Eric", "Chris", "Brian", "Daniel", "Lily", "Bill"}
+	ElevenLabsModels  = []string{"music_v1"}
+	ElevenLabsFormats = []string{
+		"alaw_8000",
+		"mp3_22050_32", "mp3_24000_48", "mp3_44100_32", "mp3_44100_64", "mp3_44100_96", "mp3_44100_128", "mp3_44100_192",
+		"opus_48000_32", "opus_48000_64", "opus_48000_96", "opus_48000_128", "opus_48000_192",
+		"pcm_8000", "pcm_16000", "pcm_22050", "pcm_24000", "pcm_32000", "pcm_44100", "pcm_48000",
+		"ulaw_8000",
+		"wav_8000", "wav_16000", "wav_22050", "wav_24000", "wav_32000", "wav_44100", "wav_48000",
+	}
+)
+
+type Request struct {
+	Prompt                      string
+	CompositionPlan             json.RawMessage
+	Model                       string
+	Format                      string
+	DurationSeconds             int
+	Seed                        string
+	ForceInstrumental           bool
+	ForceInstrumentalSet        bool
+	LyricsPrompt                string
+	LyricsOptimizer             bool
+	LyricsOptimizerSet          bool
+	Voice                       string
+	LanguageCode                string
+	Speed                       float64
+	Streaming                   bool
+	Detailed                    bool
+	WithTimestamps              bool
+	RespectSectionsDurations    bool
+	RespectSectionsDurationsSet bool
+	StoreForInpainting          bool
+	SignWithC2PA                bool
+	DeleteMediaOnCompletion     bool
+	QuoteOnly                   bool
+	PollInterval                time.Duration
+	PollTimeout                 time.Duration
+	Debug                       bool
+	DebugRaw                    bool
+}
+
+type Result struct {
+	Data     []byte
+	MimeType string
+	Format   string
+	Quote    *float64
+	Metadata json.RawMessage
+}
+
+type VeniceProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+func NewVeniceProvider(apiKey string) *VeniceProvider {
+	return &VeniceProvider{apiKey: config.NormalizeVeniceAPIKey(apiKey), baseURL: veniceBaseURL, client: &http.Client{Timeout: 2 * time.Minute}}
+}
+
+func (p *VeniceProvider) Generate(ctx context.Context, req Request) (*Result, error) {
+	if strings.TrimSpace(req.Prompt) == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+	model := firstTrimmed(req.Model, veniceDefaultModel)
+	format := firstTrimmed(req.Format, VeniceDefaultFormatForModel(model))
+	if err := ValidateVeniceFormat(format); err != nil {
+		return nil, err
+	}
+	payload := map[string]any{"model": model, "prompt": strings.TrimSpace(req.Prompt)}
+	if strings.TrimSpace(req.LyricsPrompt) != "" {
+		payload["lyrics_prompt"] = strings.TrimSpace(req.LyricsPrompt)
+	}
+	if req.DurationSeconds > 0 {
+		payload["duration_seconds"] = req.DurationSeconds
+	}
+	if req.ForceInstrumentalSet {
+		payload["force_instrumental"] = req.ForceInstrumental
+	}
+	if req.LyricsOptimizerSet {
+		payload["lyrics_optimizer"] = req.LyricsOptimizer
+	}
+	if strings.TrimSpace(req.Voice) != "" {
+		payload["voice"] = strings.TrimSpace(req.Voice)
+	}
+	if strings.TrimSpace(req.LanguageCode) != "" {
+		payload["language_code"] = strings.TrimSpace(req.LanguageCode)
+	}
+	if req.Speed != 0 {
+		payload["speed"] = req.Speed
+	}
+
+	if req.QuoteOnly {
+		quotePayload := map[string]any{"model": model, "character_count": len(req.Prompt)}
+		if req.DurationSeconds > 0 {
+			quotePayload["duration_seconds"] = req.DurationSeconds
+		}
+		quote, err := p.quote(ctx, quotePayload, req.Debug || req.DebugRaw)
+		if err != nil {
+			return nil, err
+		}
+		return &Result{Quote: &quote, Format: format}, nil
+	}
+
+	var queue struct {
+		Model   string `json:"model"`
+		QueueID string `json:"queue_id"`
+		Status  string `json:"status"`
+	}
+	if err := p.doJSON(ctx, veniceQueueEndpoint, payload, &queue, req.Debug || req.DebugRaw); err != nil {
+		return nil, err
+	}
+	if queue.QueueID == "" {
+		return nil, fmt.Errorf("Venice response did not include queue_id")
+	}
+
+	interval := req.PollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	timeout := req.PollTimeout
+	if timeout <= 0 {
+		timeout = defaultPollTimeout
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		result, done, err := p.retrieve(pollCtx, model, queue.QueueID, req.DeleteMediaOnCompletion, format, req.Debug || req.DebugRaw)
+		if err != nil {
+			return nil, err
+		}
+		if done {
+			return result, nil
+		}
+		select {
+		case <-pollCtx.Done():
+			return nil, fmt.Errorf("timed out waiting for Venice audio queue %s: %w", queue.QueueID, pollCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *VeniceProvider) quote(ctx context.Context, payload any, debug bool) (float64, error) {
+	var result struct {
+		Quote float64 `json:"quote"`
+	}
+	if err := p.doJSON(ctx, veniceQuoteEndpoint, payload, &result, debug); err != nil {
+		return 0, err
+	}
+	return result.Quote, nil
+}
+
+func (p *VeniceProvider) retrieve(ctx context.Context, model, queueID string, deleteMedia bool, format string, debug bool) (*Result, bool, error) {
+	payload := map[string]any{"model": model, "queue_id": queueID, "delete_media_on_completion": deleteMedia}
+	body, contentType, err := p.do(ctx, veniceRetrieveEndpoint, payload, debug)
+	if err != nil {
+		return nil, false, err
+	}
+	mimeType := normalizeMime(contentType)
+	if strings.HasPrefix(mimeType, "audio/") || isLikelyBinary(body) {
+		if detected := formatFromContentType(mimeType); detected != "" {
+			format = detected
+		}
+		if mimeType == "" || mimeType == "application/octet-stream" {
+			mimeType = audio.MimeTypeForFormat(format)
+		}
+		return &Result{Data: body, MimeType: mimeType, Format: format}, true, nil
+	}
+	var status struct {
+		Status      string `json:"status"`
+		Audio       string `json:"audio"`
+		AudioBase64 string `json:"audio_base64"`
+		URL         string `json:"url"`
+		Error       string `json:"error"`
+		Message     string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, false, fmt.Errorf("decode Venice retrieve response: %w", err)
+	}
+	if status.Error != "" || strings.EqualFold(status.Status, "FAILED") || strings.EqualFold(status.Status, "ERROR") {
+		return nil, false, fmt.Errorf("Venice audio generation failed: %s%s", status.Error, status.Message)
+	}
+	if dataString := firstTrimmed(status.Audio, status.AudioBase64); dataString != "" {
+		data, err := base64.StdEncoding.DecodeString(dataString)
+		if err != nil {
+			return nil, false, fmt.Errorf("decode Venice audio: %w", err)
+		}
+		return &Result{Data: data, MimeType: audio.MimeTypeForFormat(format), Format: format, Metadata: body}, true, nil
+	}
+	if strings.TrimSpace(status.URL) != "" {
+		data, mediaType, err := fetchURL(ctx, status.URL)
+		if err != nil {
+			return nil, false, err
+		}
+		if mediaType == "" {
+			mediaType = audio.MimeTypeForFormat(format)
+		}
+		return &Result{Data: data, MimeType: mediaType, Format: format, Metadata: body}, true, nil
+	}
+	return nil, false, nil
+}
+
+func (p *VeniceProvider) doJSON(ctx context.Context, endpoint string, payload any, out any, debug bool) error {
+	body, _, err := p.do(ctx, endpoint, payload, debug)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode Venice response: %w", err)
+	}
+	return nil
+}
+
+func (p *VeniceProvider) do(ctx context.Context, endpoint string, payload any, debug bool) ([]byte, string, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal Venice music request: %w", err)
+	}
+	if debug {
+		debugLog("Venice Music Request", "POST %s\n%s", p.baseURL+endpoint, string(jsonBody))
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, "", fmt.Errorf("create Venice music request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, "", requestError(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read Venice music response: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if debug {
+		debugLog("Venice Music Response", "status=%d content-type=%s body_len=%d", resp.StatusCode, contentType, len(body))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("Venice API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, contentType, nil
+}
+
+type ElevenLabsProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+func NewElevenLabsProvider(apiKey string) *ElevenLabsProvider {
+	return &ElevenLabsProvider{apiKey: strings.TrimSpace(apiKey), baseURL: elevenLabsBaseURL, client: &http.Client{Timeout: 10 * time.Minute}}
+}
+
+func (p *ElevenLabsProvider) Generate(ctx context.Context, req Request) (*Result, error) {
+	if strings.TrimSpace(req.Prompt) == "" && len(req.CompositionPlan) == 0 {
+		return nil, fmt.Errorf("prompt or composition plan is required")
+	}
+	model := firstTrimmed(req.Model, elevenLabsDefaultModel)
+	format := firstTrimmed(req.Format, elevenLabsDefaultFormat)
+	if err := ValidateElevenLabsFormat(format); err != nil {
+		return nil, err
+	}
+	payload := map[string]any{"model_id": model}
+	if strings.TrimSpace(req.Prompt) != "" {
+		payload["prompt"] = strings.TrimSpace(req.Prompt)
+	}
+	if len(req.CompositionPlan) > 0 {
+		var plan any
+		if err := json.Unmarshal(req.CompositionPlan, &plan); err != nil {
+			return nil, fmt.Errorf("decode composition plan: %w", err)
+		}
+		payload["composition_plan"] = plan
+	}
+	if req.DurationSeconds > 0 {
+		payload["music_length_ms"] = req.DurationSeconds * 1000
+	}
+	if strings.TrimSpace(req.Seed) != "" {
+		payload["seed"] = strings.TrimSpace(req.Seed)
+	}
+	if req.ForceInstrumentalSet {
+		payload["force_instrumental"] = req.ForceInstrumental
+	}
+	if req.RespectSectionsDurationsSet {
+		payload["respect_sections_durations"] = req.RespectSectionsDurations
+	}
+	if req.StoreForInpainting {
+		payload["store_for_inpainting"] = true
+	}
+	if req.SignWithC2PA {
+		payload["sign_with_c2pa"] = true
+	}
+	if req.WithTimestamps {
+		payload["with_timestamps"] = true
+	}
+
+	endpoint := "/v1/music"
+	if req.Detailed || req.WithTimestamps {
+		endpoint = "/v1/music/detailed"
+	}
+	if req.Streaming {
+		endpoint = "/v1/music/stream"
+	}
+	query := url.Values{}
+	query.Set("output_format", format)
+	body, contentType, err := p.do(ctx, endpoint+"?"+query.Encode(), payload, req.Debug || req.DebugRaw)
+	if err != nil {
+		return nil, err
+	}
+	mimeType := normalizeMime(contentType)
+	if strings.HasPrefix(mimeType, "multipart/") {
+		data, metadata, detectedFormat, err := extractMultipartAudio(body, contentType)
+		if err != nil {
+			return nil, err
+		}
+		if detectedFormat != "" {
+			format = detectedFormat
+		}
+		return &Result{Data: data, MimeType: audio.MimeTypeForFormat(format), Format: format, Metadata: metadata}, nil
+	}
+	if mimeType == "" || mimeType == "application/octet-stream" {
+		mimeType = audio.MimeTypeForFormat(format)
+	}
+	return &Result{Data: body, MimeType: mimeType, Format: format}, nil
+}
+
+func (p *ElevenLabsProvider) do(ctx context.Context, endpoint string, payload any, debug bool) ([]byte, string, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal ElevenLabs music request: %w", err)
+	}
+	if debug {
+		debugLog("ElevenLabs Music Request", "POST %s\n%s", p.baseURL+endpoint, string(jsonBody))
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, "", fmt.Errorf("create ElevenLabs music request: %w", err)
+	}
+	httpReq.Header.Set("xi-api-key", p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "audio/*")
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, "", requestError(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read ElevenLabs music response: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if debug {
+		debugLog("ElevenLabs Music Response", "status=%d content-type=%s body_len=%d", resp.StatusCode, contentType, len(body))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("ElevenLabs API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, contentType, nil
+}
+
+func Save(data []byte, outputDir, prompt, format string) (string, error) {
+	dir := expandPath(outputDir)
+	if dir == "" {
+		dir = expandPath("~/Music/term-llm/")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	filename := generateFilename(prompt, format)
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write music: %w", err)
+	}
+	return path, nil
+}
+
+func ValidateVeniceFormat(format string) error { return validateEnum("format", format, VeniceFormats) }
+func ValidateElevenLabsFormat(format string) error {
+	return validateEnum("format", format, ElevenLabsFormats)
+}
+
+func VeniceDefaultFormatForModel(model string) string {
+	switch model {
+	case "ace-step-15":
+		return "flac"
+	case "stable-audio-25", "mmaudio-v2-text-to-audio":
+		return "wav"
+	default:
+		return "mp3"
+	}
+}
+
+func ExtensionForFormat(format string) string { return audio.ExtensionForFormat(format) }
+
+func validateEnum(label, value string, allowed []string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid %s %q (allowed: %s)", label, value, strings.Join(allowed, ", "))
+}
+
+func extractMultipartAudio(body []byte, contentType string) ([]byte, json.RawMessage, string, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("parse multipart content type: %w", err)
+	}
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		return nil, nil, "", fmt.Errorf("expected multipart response, got %s", contentType)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil, nil, "", fmt.Errorf("multipart response missing boundary")
+	}
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	var metadata json.RawMessage
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("read multipart response: %w", err)
+		}
+		partData, err := io.ReadAll(part)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("read multipart part: %w", err)
+		}
+		partType := normalizeMime(part.Header.Get("Content-Type"))
+		if strings.HasPrefix(partType, "audio/") || isLikelyBinary(partData) {
+			format := formatFromContentType(partType)
+			return partData, metadata, format, nil
+		}
+		if json.Valid(partData) {
+			metadata = append(metadata[:0], partData...)
+		}
+	}
+	return nil, metadata, "", fmt.Errorf("multipart response did not include audio data")
+}
+
+func fetchURL(ctx context.Context, rawURL string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("create audio download request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", requestError(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read audio download response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("audio download error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, normalizeMime(resp.Header.Get("Content-Type")), nil
+}
+
+func formatFromContentType(contentType string) string {
+	switch normalizeMime(contentType) {
+	case "audio/mpeg", "audio/mp3":
+		return "mp3"
+	case "audio/wav", "audio/x-wav", "audio/wave":
+		return "wav"
+	case "audio/flac", "audio/x-flac":
+		return "flac"
+	case "audio/opus":
+		return "opus"
+	case "audio/aac":
+		return "aac"
+	default:
+		return ""
+	}
+}
+
+func isLikelyBinary(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	limit := len(data)
+	if limit > 256 {
+		limit = 256
+	}
+	for _, b := range data[:limit] {
+		if b == 0 {
+			return true
+		}
+	}
+	trimmed := strings.TrimSpace(string(data[:limit]))
+	return !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[")
+}
+
+func normalizeMime(contentType string) string {
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		return strings.TrimSpace(contentType[:idx])
+	}
+	return strings.TrimSpace(contentType)
+}
+
+func firstTrimmed(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func requestError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("request failed: %w", err)
+}
+
+func generateFilename(prompt, format string) string {
+	timestamp := time.Now().Format("20060102-150405")
+	safe := sanitizeForFilename(prompt)
+	if len(safe) > 30 {
+		safe = safe[:30]
+	}
+	if safe == "" {
+		safe = "music"
+	}
+	return fmt.Sprintf("%s-%s.%s", timestamp, safe, ExtensionForFormat(format))
+}
+
+func sanitizeForFilename(s string) string {
+	replacer := strings.NewReplacer(" ", "_", "/", "", "\\", "", ":", "", "?", "", "*", "", "\"", "", "<", "", ">", "", "|", "")
+	s = replacer.Replace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	lastUnderscore := false
+	for _, r := range strings.ToLower(s) {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum || r == '-' {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if r == '_' && !lastUnderscore {
+			b.WriteRune(r)
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func debugLog(title, format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "\n=== %s ===\n%s\n", title, fmt.Sprintf(format, args...))
+}
+
+func expandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/internal/music/music_test.go
+++ b/internal/music/music_test.go
@@ -1,0 +1,99 @@
+package music
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestVeniceGenerateQueuesAndRetrievesAudio(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/audio/queue":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode queue payload: %v", err)
+			}
+			if payload["model"] != "elevenlabs-sound-effects-v2" || payload["prompt"] != "tiny bell" || payload["duration_seconds"].(float64) != 1 {
+				t.Fatalf("unexpected queue payload: %#v", payload)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"model": payload["model"], "queue_id": "q1", "status": "QUEUED"})
+		case "/audio/retrieve":
+			calls++
+			if calls == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "PROCESSING"})
+				return
+			}
+			w.Header().Set("Content-Type", "audio/mpeg")
+			_, _ = w.Write([]byte("ID3audio"))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewVeniceProvider("key")
+	provider.baseURL = server.URL
+	result, err := provider.Generate(context.Background(), Request{Prompt: "tiny bell", Model: "elevenlabs-sound-effects-v2", DurationSeconds: 1, PollInterval: time.Millisecond})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if string(result.Data) != "ID3audio" || result.MimeType != "audio/mpeg" || result.Format != "mp3" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestVeniceQuote(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/audio/quote" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"quote": 0.0023})
+	}))
+	defer server.Close()
+
+	provider := NewVeniceProvider("key")
+	provider.baseURL = server.URL
+	result, err := provider.Generate(context.Background(), Request{Prompt: "x", Model: "elevenlabs-sound-effects-v2", DurationSeconds: 1, QuoteOnly: true})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if result.Quote == nil || *result.Quote != 0.0023 {
+		t.Fatalf("unexpected quote: %#v", result.Quote)
+	}
+}
+
+func TestElevenLabsGenerateMusic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/music" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("output_format") != "mp3_44100_128" {
+			t.Fatalf("unexpected output format: %s", r.URL.RawQuery)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload["prompt"] != "funk sting" || payload["model_id"] != "music_v1" || payload["music_length_ms"].(float64) != 3000 || payload["force_instrumental"] != true {
+			t.Fatalf("unexpected payload: %#v", payload)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("ID3music"))
+	}))
+	defer server.Close()
+
+	provider := NewElevenLabsProvider("key")
+	provider.baseURL = server.URL
+	result, err := provider.Generate(context.Background(), Request{Prompt: "funk sting", Model: "music_v1", Format: "mp3_44100_128", DurationSeconds: 3, ForceInstrumental: true, ForceInstrumentalSet: true})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if string(result.Data) != "ID3music" || result.MimeType != "audio/mpeg" || result.Format != "mp3_44100_128" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}


### PR DESCRIPTION
## What

Adds `term-llm music <prompt>` as a follow-up to audio generation.

Providers:

- Venice async audio queue/retrieve/quote flow
- ElevenLabs `/v1/music`, `/v1/music/stream`, and `/v1/music/detailed`

Included Venice music/audio models:

- `ace-step-15`
- `elevenlabs-music`
- `minimax-music-v2`
- `minimax-music-v25`
- `minimax-music-v26`
- `stable-audio-25`
- `elevenlabs-sound-effects-v2`
- `mmaudio-v2-text-to-audio`
- `elevenlabs-tts-v3`
- `elevenlabs-tts-multilingual-v2`

Included ElevenLabs music model:

- `music_v1`

Options exposed:

- stdin prompt support when no positional prompt is supplied
- `--provider`, `--model`, `--format`, `--duration`, `--output`, `--json`
- Venice: `--lyrics`, `--lyrics-file`, `--lyrics-optimizer`, `--voice`, `--language`, `--speed`, `--quote`, queue poll controls, `--delete-media-on-completion`
- ElevenLabs: `--streaming`, `--detailed`, `--composition-plan-file`, `--seed`, `--force-instrumental`, `--respect-sections-durations`, `--store-for-inpainting`, `--sign-with-c2pa`, `--with-timestamps`
- shell completion for providers/models/formats/Venice voices

Config:

```yaml
music:
  provider: venice
  output_dir: ~/Music/term-llm
  venice:
    api_key: $VENICE_API_KEY
    model: elevenlabs-sound-effects-v2
    format: mp3
  elevenlabs:
    api_key: $ELEVENLABS_API_KEY
    model: music_v1
    format: mp3_44100_128
```

Credential fallbacks reuse existing audio/image provider keys where appropriate.

## Verification

```sh
go build ./...
go test ./...
```

Live Venice one-second smoke clip passed:

```sh
go run . music "single bright xylophone ping" \
  --provider venice \
  --model elevenlabs-sound-effects-v2 \
  --duration 1 \
  --output /tmp/.../ping.mp3 \
  --json --debug
```

Representative output:

```json
{
  "provider": "venice",
  "prompt": "single bright xylophone ping",
  "model": "elevenlabs-sound-effects-v2",
  "format": "mp3",
  "output": {
    "path": "/tmp/tmp.J9vSnGSyH1/ping.mp3",
    "mime_type": "audio/mpeg",
    "bytes": 17180
  }
}
```

`file` confirmed:

```text
Audio file with ID3 version 2.4.0, contains: MPEG ADTS, layer III, v1, 128 kbps, 44.1 kHz, Stereo
```

Stdin prompt smoke also passed:

```sh
printf 'single tiny camera shutter click' | go run . music \
  --provider venice \
  --model elevenlabs-sound-effects-v2 \
  --duration 1 \
  --output /tmp/.../stdin.mp3 \
  --json
```

ElevenLabs direct live generation was not run because there is still no ElevenLabs key configured in this container. The direct ElevenLabs API documents a 3-second minimum for music prompt mode, so direct ElevenLabs smoke uses `--duration 3` once a key is present. Unit tests cover request construction and binary audio handling via httptest.
