### PR TITLE
fix: reload stale web UI after deploy

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -216,6 +216,8 @@ func (s *serveServer) renderIndexHTML() []byte {
 	var headSnippet string
 	escaped, _ := json.Marshal(s.cfg.basePath)
 	headSnippet += `<script>window.TERM_LLM_UI_PREFIX=` + string(escaped) + `;</script>`
+	versionEscaped, _ := json.Marshal(serveui.AssetVersion())
+	headSnippet += `<script>window.TERM_LLM_UI_VERSION=` + string(versionEscaped) + `;</script>`
 	sidebarSessions := s.cfg.sidebarSessions
 	if len(sidebarSessions) == 0 {
 		sidebarSessions = []string{"all"}
@@ -1018,9 +1020,11 @@ func (s *serveServer) cors(next http.HandlerFunc) http.HandlerFunc {
 				w.Header().Add("Vary", "Origin")
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, X-Term-LLM-UI, X-API-Key, anthropic-version")
-			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, X-Term-LLM-UI, X-Term-LLM-UI-Version, X-API-Key, anthropic-version")
+			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number, x-response-id, x-term-llm-ui-version")
 		}
+
+		w.Header().Set("X-Term-LLM-UI-Version", serveui.AssetVersion())
 
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -387,6 +387,9 @@ func TestCustomBasePath_EndToEnd(t *testing.T) {
 	if !strings.Contains(body, `TERM_LLM_SIDEBAR_SESSIONS=["chat","web"]`) {
 		t.Error("/ should inject TERM_LLM_SIDEBAR_SESSIONS")
 	}
+	if !strings.Contains(body, `TERM_LLM_UI_VERSION=`) {
+		t.Error("/ should inject TERM_LLM_UI_VERSION")
+	}
 
 	// 2. /app.css serves static assets
 	req = httptest.NewRequest(http.MethodGet, "/app.css", nil)
@@ -435,6 +438,32 @@ func TestServeHTTPHandler_MountsJobsOnlyAtRoot(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("/ui/healthz status = %d, want 404", rr.Code)
+	}
+}
+
+func TestServeCORSExposesUIVersionHeader(t *testing.T) {
+	srv := &serveServer{
+		cfg: serveServerConfig{
+			corsOrigins: []string{"https://example.com"},
+		},
+	}
+	h := srv.cors(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rr := httptest.NewRecorder()
+
+	h(rr, req)
+
+	if got := rr.Header().Get("X-Term-LLM-UI-Version"); got == "" {
+		t.Fatal("X-Term-LLM-UI-Version header missing")
+	}
+	if got := rr.Header().Get("Access-Control-Expose-Headers"); !strings.Contains(strings.ToLower(got), "x-term-llm-ui-version") {
+		t.Fatalf("Access-Control-Expose-Headers = %q, want x-term-llm-ui-version", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(strings.ToLower(got), "x-term-llm-ui-version") {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want x-term-llm-ui-version", got)
 	}
 }
 

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -8,6 +8,7 @@ app.markdownStreaming = window.TermLLMMarkdownStreaming || null;
 // UI_PREFIX is the base path for all routes (UI + API). Injected by the server
 // into index.html as window.TERM_LLM_UI_PREFIX, defaults to '/ui'.
 const UI_PREFIX = (window.TERM_LLM_UI_PREFIX || '/ui');
+const UI_VERSION = String(window.TERM_LLM_UI_VERSION || '');
 const LEGACY_DRAFT_SESSION_ID = '__draft__';
 
 const parseSidebarSessionCategories = (raw) => {
@@ -95,6 +96,48 @@ const state = {
 if (state.token) {
   document.cookie = `term_llm_token=${encodeURIComponent(state.token)}; path=${UI_PREFIX}/images; SameSite=Strict; max-age=31536000`;
 }
+
+let uiVersionReloading = false;
+
+const apiPathForURL = (url) => {
+  try {
+    const parsed = new URL(typeof url === 'string' ? url : url?.url || String(url), window.location.origin);
+    if (parsed.origin !== window.location.origin) return false;
+    return parsed.pathname.startsWith(`${UI_PREFIX}/v1/`) || parsed.pathname.startsWith(`${UI_PREFIX}/v2/`);
+  } catch {
+    return false;
+  }
+};
+
+const maybeReloadForUIVersion = (response) => {
+  if (!response || !UI_VERSION || uiVersionReloading) return false;
+  const serverVersion = response.headers?.get?.('x-term-llm-ui-version') || '';
+  if (!serverVersion || serverVersion === UI_VERSION) return false;
+
+  uiVersionReloading = true;
+  try { setConnectionState('Updated — reloading…', 'bad'); } catch (_) { /* app may still be booting */ }
+  window.setTimeout(() => window.location.reload(), 50);
+  return true;
+};
+
+const installUIVersionFetchGuard = () => {
+  if (typeof window.fetch !== 'function') return;
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = async (resource, options = {}) => {
+    const tagged = apiPathForURL(resource);
+    let nextOptions = options;
+    if (tagged && UI_VERSION) {
+      const headers = new Headers(options?.headers || (resource instanceof Request ? resource.headers : undefined));
+      headers.set('X-Term-LLM-UI-Version', UI_VERSION);
+      nextOptions = { ...options, headers };
+    }
+    const response = await nativeFetch(resource, nextOptions);
+    if (tagged) maybeReloadForUIVersion(response);
+    return response;
+  };
+};
+
+installUIVersionFetchGuard();
 
 const elements = {
   appShell: document.getElementById('appShell'),
@@ -1206,6 +1249,8 @@ Object.assign(app, {
   updateDocumentTitle,
   syncViewportShell,
   UI_PREFIX,
+  UI_VERSION,
+  maybeReloadForUIVersion,
   parseSidebarSessionCategories,
   isStandalone,
   shouldSuppressPromptAutoFocus,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -24,6 +24,9 @@ const requestHeaders = (sessionId, tokenOverride = '') => {
   if (sessionId) {
     headers.session_id = sessionId;
   }
+  if (app.UI_VERSION) {
+    headers['X-Term-LLM-UI-Version'] = app.UI_VERSION;
+  }
 
   return headers;
 };

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -502,7 +502,11 @@
       pendingRequests.set(reqId, {
         onHeaders(headers, status) {
           markGotResponse();
-          resolveOnce(new Response(nullBodyStatus(status) ? null : stream, { status, headers: new Headers(headers) }));
+          const response = new Response(nullBodyStatus(status) ? null : stream, { status, headers: new Headers(headers) });
+          if (typeof app?.maybeReloadForUIVersion === 'function') {
+            app.maybeReloadForUIVersion(response);
+          }
+          resolveOnce(response);
         },
         onChunk(fragment) {
           markGotResponse();


### PR DESCRIPTION
## What

Adds web UI asset-version handshaking so a browser tab that survived a `term-llm serve web` deploy/restart reloads itself instead of continuing to post with stale JavaScript.

- Injects `window.TERM_LLM_UI_VERSION` from `serveui.AssetVersion()` into the SPA shell.
- Adds `X-Term-LLM-UI-Version` to API responses and CORS expose/allow headers.
- Tags UI API fetches with the loaded client version.
- Auto-reloads the tab when an API response reports a different server UI version.
- Covers both normal HTTPS fetch and the WebRTC fetch transport.

## Why

Today's web sessions show the failure pattern around the webui restart:

- Web sessions were created before the restart, e.g. session 1965 at `09:13`, 1967 at `11:34`.
- `webui` restarted at ~`12:04`.
- Those sessions were then updated after restart (`12:07+`) while the browser could still have the old in-memory JS bundle loaded.
- Reloading fixed it because the browser fetched the new versioned assets.

The debug JSONL logs do not contain an LLM/provider error for these posts, which points at the browser/server UI contract rather than a model failure. Stale SPA code after deploy is the boring culprit. Naturally, the boring culprit was hiding in the exciting place.

## Test plan

- `go test ./cmd ./internal/serveui`
- `go test ./...`

## Notes

This fixes future stale-tab-after-deploy cases once this version is loaded. A browser tab already running a pre-fix bundle cannot magically know to auto-reload; first load after this lands gets the guard.