### PR TITLE
feat: add Venice and ElevenLabs transcription

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -22,6 +22,8 @@ var (
 	transcribeLanguage       string
 	transcribePorcelain      bool
 	transcribeProvider       string
+	transcribeModel          string
+	transcribeTimestamps     bool
 	transcribeCLIOutputLimit int64         = 1 << 20
 	transcribeCLIWaitDelay   time.Duration = time.Second
 	transcribeTruncator                    = llm.TruncateTranscriptIfImplausible
@@ -29,7 +31,7 @@ var (
 
 var transcribeCmd = &cobra.Command{
 	Use:   "transcribe <file>",
-	Short: "Transcribe an audio file to text using Whisper",
+	Short: "Transcribe an audio file to text",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runTranscribe,
 }
@@ -114,10 +116,27 @@ func transcribeWhisperCLI(ctx context.Context, cfg *config.Config, filePath, lan
 
 func init() {
 	transcribeCmd.Flags().StringVar(&transcribeLanguage, "language", "", "Language hint for transcription (e.g. \"en\", \"ja\")")
+	transcribeCmd.Flags().StringVar(&transcribeModel, "model", "", "Transcription model override")
+	transcribeCmd.Flags().BoolVar(&transcribeTimestamps, "timestamps", false, "Venice: request timestamp metadata before extracting transcript text")
 	transcribeCmd.Flags().BoolVar(&transcribePorcelain, "porcelain", false, "Output only the transcript text")
-	transcribeCmd.Flags().StringVar(&transcribeProvider, "provider", "", `Transcription provider override: "openai", "mistral" (Voxtral), "local" (whisper.cpp server), "whisper-cli". Defaults to transcription.provider in config, or "openai".`)
+	transcribeCmd.Flags().StringVar(&transcribeProvider, "provider", "", `Transcription provider override: "openai", "mistral" (Voxtral), "venice", "elevenlabs", "local" (whisper.cpp server), "whisper-cli". Defaults to transcription.provider in config, or "openai".`)
+	_ = transcribeCmd.RegisterFlagCompletionFunc("provider", staticCompletion("openai", "mistral", "venice", "elevenlabs", "local", "whisper-cli"))
+	_ = transcribeCmd.RegisterFlagCompletionFunc("model", transcribeModelCompletion)
 
 	rootCmd.AddCommand(transcribeCmd)
+}
+
+func transcribeModelCompletion(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	switch completionProvider(cmd) {
+	case "venice":
+		return []string{"nvidia/parakeet-tdt-0.6b-v3", "openai/whisper-large-v3", "fal-ai/wizper", "elevenlabs/scribe-v2", "stt-xai-v1"}, cobra.ShellCompDirectiveNoFileComp
+	case "elevenlabs":
+		return []string{"scribe_v2", "scribe_v1"}, cobra.ShellCompDirectiveNoFileComp
+	case "mistral":
+		return []string{"voxtral-mini-latest", "voxtral-small-latest"}, cobra.ShellCompDirectiveNoFileComp
+	default:
+		return []string{"whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"}, cobra.ShellCompDirectiveNoFileComp
+	}
 }
 
 func runTranscribe(cmd *cobra.Command, args []string) error {
@@ -178,5 +197,11 @@ func detectAudioMimeType(filePath string) (string, error) {
 
 func transcribeAudio(ctx context.Context, cfg *config.Config, filePath, language string) (string, error) {
 	providerOverride := strings.TrimSpace(transcribeProvider)
+	if strings.TrimSpace(transcribeModel) != "" {
+		cfg.Transcription.Model = strings.TrimSpace(transcribeModel)
+	}
+	if transcribeTimestamps {
+		cfg.Transcription.Timestamps = true
+	}
 	return llm.TranscribeWithConfig(ctx, cfg, filePath, language, providerOverride)
 }

--- a/docs-site/content/guides/transcription.md
+++ b/docs-site/content/guides/transcription.md
@@ -1,7 +1,7 @@
 ---
 title: "Transcription"
 weight: 8
-description: "Transcribe audio files to text with OpenAI, Mistral Voxtral, a local Whisper server, or whisper.cpp CLI."
+description: "Transcribe audio files to text with OpenAI, Mistral Voxtral, Venice, ElevenLabs, a local Whisper server, or whisper.cpp CLI."
 kicker: "Audio"
 featured: true
 next:
@@ -30,6 +30,8 @@ Supported input extensions include:
 term-llm transcribe interview.mp3 --language en
 term-llm transcribe note.m4a --provider openai
 term-llm transcribe memo.wav --provider mistral
+term-llm transcribe hello.mp3 --provider venice --model nvidia/parakeet-tdt-0.6b-v3
+term-llm transcribe hello.mp3 --provider elevenlabs --model scribe_v2
 term-llm transcribe call.ogg --provider whisper-cli --porcelain
 ```
 
@@ -37,6 +39,8 @@ Key options:
 
 - `--language` for a language hint such as `en` or `ja`
 - `--provider` to select the transcription backend
+- `--model` to override the configured transcription model
+- `--timestamps` to ask Venice for timestamp metadata before extracting the transcript text
 - `--porcelain` to output only transcript text
 
 ## Provider options
@@ -45,10 +49,47 @@ term-llm supports several transcription backends:
 
 - `openai`
 - `mistral` (Voxtral)
+- `venice`
+- `elevenlabs`
 - `local` for a local Whisper-compatible server
 - `whisper-cli` for `whisper.cpp`
 
 If you omit `--provider`, term-llm uses the configured transcription provider or falls back to OpenAI.
+
+### Venice models
+
+Venice uses `POST /api/v1/audio/transcriptions` and supports:
+
+- `nvidia/parakeet-tdt-0.6b-v3`
+- `openai/whisper-large-v3`
+- `fal-ai/wizper`
+- `elevenlabs/scribe-v2`
+- `stt-xai-v1`
+
+### ElevenLabs models
+
+ElevenLabs uses `POST /v1/speech-to-text` and supports:
+
+- `scribe_v2`
+- `scribe_v1`
+
+## Configuration
+
+```yaml
+transcription:
+  provider: venice
+  venice:
+    api_key: ${VENICE_API_KEY}
+    model: nvidia/parakeet-tdt-0.6b-v3
+  elevenlabs:
+    api_key: ${ELEVENLABS_API_KEY}
+    model: scribe_v2
+```
+
+Credential fallback order:
+
+- Venice: `transcription.venice.api_key`, `VENICE_API_KEY`, `audio.venice.api_key`, `image.venice.api_key`, or `providers.venice.api_key`
+- ElevenLabs: `transcription.elevenlabs.api_key`, `ELEVENLABS_API_KEY`, `XI_API_KEY`, `audio.elevenlabs.api_key`, or `providers.elevenlabs.api_key`
 
 ## whisper.cpp CLI mode
 

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -145,7 +145,7 @@ search:
 
 Search is large enough to deserve its own page; see [Search](/guides/search/).
 
-## Image, audio, music, and embedding config
+## Image, audio, music, transcription, and embedding config
 
 ```yaml
 image:
@@ -173,11 +173,20 @@ music:
     model: music_v1
     format: mp3_44100_128
 
+transcription:
+  provider: venice
+  venice:
+    api_key: ${VENICE_API_KEY}
+    model: nvidia/parakeet-tdt-0.6b-v3
+  elevenlabs:
+    api_key: ${ELEVENLABS_API_KEY}
+    model: scribe_v2
+
 embed:
   provider: gemini
 ```
 
-Each feature block can hold provider-specific credentials and defaults. The image, audio, music, and embedding providers are independent of the main text provider.
+Each feature block can hold provider-specific credentials and defaults. The image, audio, music, transcription, and embedding providers are independent of the main text provider.
 
 ## Provider-specific environment overrides
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -419,9 +419,24 @@ type MusicElevenLabsConfig struct {
 
 // TranscriptionConfig configures audio transcription settings.
 type TranscriptionConfig struct {
-	Provider string `mapstructure:"provider"` // named provider from providers map; default "openai"
-	Model    string `mapstructure:"model"`    // optional model override
-	SaveDir  string `mapstructure:"save_dir"` // if set, persist each uploaded audio file here
+	Provider   string                        `mapstructure:"provider"`   // named provider from providers map; default "openai"
+	Model      string                        `mapstructure:"model"`      // optional model override
+	SaveDir    string                        `mapstructure:"save_dir"`   // if set, persist each uploaded audio file here
+	Timestamps bool                          `mapstructure:"timestamps"` // Venice: request timestamp metadata
+	Venice     TranscriptionVeniceConfig     `mapstructure:"venice"`
+	ElevenLabs TranscriptionElevenLabsConfig `mapstructure:"elevenlabs"`
+}
+
+// TranscriptionVeniceConfig configures Venice speech-to-text.
+type TranscriptionVeniceConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
+}
+
+// TranscriptionElevenLabsConfig configures ElevenLabs speech-to-text.
+type TranscriptionElevenLabsConfig struct {
+	APIKey string `mapstructure:"api_key"`
+	Model  string `mapstructure:"model"`
 }
 
 // EmbedConfig configures text embedding generation
@@ -551,6 +566,7 @@ func Load() (*Config, error) {
 	resolveImageCredentials(&cfg.Image)
 	resolveAudioCredentials(&cfg.Audio)
 	resolveMusicCredentials(&cfg.Music)
+	resolveTranscriptionCredentials(&cfg.Transcription)
 	resolveEmbedCredentials(&cfg.Embed)
 	resolveSearchCredentials(&cfg.Search)
 
@@ -1112,7 +1128,22 @@ func resolveMusicCredentials(cfg *MusicConfig) {
 	}
 }
 
-// resolveEmbedCredentials resolves API credentials for all embedding providers
+// resolveTranscriptionCredentials resolves API credentials for transcription providers.
+func resolveTranscriptionCredentials(cfg *TranscriptionConfig) {
+	cfg.Venice.APIKey = expandEnv(cfg.Venice.APIKey)
+	if cfg.Venice.APIKey == "" {
+		cfg.Venice.APIKey = os.Getenv("VENICE_API_KEY")
+	}
+	cfg.ElevenLabs.APIKey = expandEnv(cfg.ElevenLabs.APIKey)
+	if cfg.ElevenLabs.APIKey == "" {
+		cfg.ElevenLabs.APIKey = os.Getenv("ELEVENLABS_API_KEY")
+	}
+	if cfg.ElevenLabs.APIKey == "" {
+		cfg.ElevenLabs.APIKey = os.Getenv("XI_API_KEY")
+	}
+}
+
+// resolveEmbedCredentials resolves credentials for all embedding providers
 func resolveEmbedCredentials(cfg *EmbedConfig) {
 	// OpenAI embed credentials
 	cfg.OpenAI.APIKey = expandEnv(cfg.OpenAI.APIKey)
@@ -1364,9 +1395,14 @@ var KnownKeys = map[string]bool{
 	"audio.venice.format":  true,
 
 	// Transcription
-	"transcription.provider": true,
-	"transcription.model":    true,
-	"transcription.save_dir": true,
+	"transcription.provider":           true,
+	"transcription.model":              true,
+	"transcription.save_dir":           true,
+	"transcription.timestamps":         true,
+	"transcription.venice.api_key":     true,
+	"transcription.venice.model":       true,
+	"transcription.elevenlabs.api_key": true,
+	"transcription.elevenlabs.model":   true,
 
 	// Embed
 	"embed.provider":        true,
@@ -1519,6 +1555,9 @@ func GetDefaults() map[string]any {
 		"audio.venice.model":              "tts-kokoro",
 		"audio.venice.voice":              "af_sky",
 		"audio.venice.format":             "mp3",
+		"transcription.provider":          "openai",
+		"transcription.venice.model":      "nvidia/parakeet-tdt-0.6b-v3",
+		"transcription.elevenlabs.model":  "scribe_v2",
 		"embed.openai.model":              "text-embedding-3-small",
 		"embed.gemini.model":              "gemini-embedding-001",
 		"embed.jina.model":                "jina-embeddings-v3",

--- a/internal/llm/transcribe.go
+++ b/internal/llm/transcribe.go
@@ -9,13 +9,15 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
-// TranscribeWithConfig transcribes an audio file using the provider configured in cfg.
-// providerOverride, if non-empty, overrides cfg.Transcription.Provider.
-//
-// Supported provider names: "openai" (default), "mistral" (Voxtral), "local" (whisper.cpp server),
-// "whisper-cli" (whisper.cpp CLI binary). The whisper-cli case is delegated back to cmd via
-// the transcribeWhisperCLI function — callers that don't support it (e.g. Telegram) will get
-// an unsupported-provider error, which is intentional.
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 func transcribeAndTruncate(ctx context.Context, filePath string, opts TranscribeOptions) (string, error) {
 	transcript, err := TranscribeFile(ctx, filePath, opts)
 	if err != nil {
@@ -24,6 +26,13 @@ func transcribeAndTruncate(ctx context.Context, filePath string, opts Transcribe
 	return TruncateTranscriptIfImplausible(ctx, filePath, transcript), nil
 }
 
+// TranscribeWithConfig transcribes an audio file using the provider configured in cfg.
+// providerOverride, if non-empty, overrides cfg.Transcription.Provider.
+//
+// Supported provider names: "openai" (default), "mistral" (Voxtral), "venice", "elevenlabs", "local" (whisper.cpp server),
+// "whisper-cli" (whisper.cpp CLI binary). The whisper-cli case is delegated back to cmd via
+// the transcribeWhisperCLI function — callers that don't support it (e.g. Telegram) will get
+// an unsupported-provider error, which is intentional.
 func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, language, providerOverride string) (string, error) {
 	providerName := providerOverride
 	if providerName == "" {
@@ -82,6 +91,83 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 			Language: language,
 		})
 
+	case "venice":
+		apiKey := cfg.Transcription.Venice.APIKey
+		if apiKey == "" {
+			apiKey = cfg.Audio.Venice.APIKey
+		}
+		if apiKey == "" {
+			apiKey = cfg.Image.Venice.APIKey
+		}
+		if apiKey == "" {
+			if p, ok := cfg.Providers["venice"]; ok {
+				apiKey = p.ResolvedAPIKey
+			}
+		}
+		if apiKey == "" {
+			apiKey = os.Getenv("VENICE_API_KEY")
+		}
+		if apiKey == "" {
+			return "", fmt.Errorf("transcription provider %q has no API key configured (transcription.venice.api_key, VENICE_API_KEY, audio.venice.api_key, image.venice.api_key, or providers.venice.api_key)", providerName)
+		}
+		endpoint := "https://api.venice.ai/api/v1/audio/transcriptions"
+		if p, ok := cfg.Providers["venice"]; ok {
+			baseURL := p.ResolvedURL
+			if baseURL == "" {
+				baseURL = p.BaseURL
+			}
+			if baseURL != "" {
+				endpoint = strings.TrimRight(baseURL, "/") + "/audio/transcriptions"
+			}
+		}
+		model := firstNonEmptyString(modelOverride, cfg.Transcription.Venice.Model, "nvidia/parakeet-tdt-0.6b-v3")
+		return transcribeAndTruncate(ctx, filePath, TranscribeOptions{
+			APIKey:     apiKey,
+			Endpoint:   endpoint,
+			Model:      model,
+			Language:   language,
+			Provider:   "venice",
+			Timestamps: cfg.Transcription.Timestamps,
+		})
+
+	case "elevenlabs":
+		apiKey := cfg.Transcription.ElevenLabs.APIKey
+		if apiKey == "" {
+			apiKey = cfg.Audio.ElevenLabs.APIKey
+		}
+		if apiKey == "" {
+			if p, ok := cfg.Providers["elevenlabs"]; ok {
+				apiKey = p.ResolvedAPIKey
+			}
+		}
+		if apiKey == "" {
+			apiKey = os.Getenv("ELEVENLABS_API_KEY")
+		}
+		if apiKey == "" {
+			apiKey = os.Getenv("XI_API_KEY")
+		}
+		if apiKey == "" {
+			return "", fmt.Errorf("transcription provider %q has no API key configured (transcription.elevenlabs.api_key, ELEVENLABS_API_KEY, XI_API_KEY, audio.elevenlabs.api_key, or providers.elevenlabs.api_key)", providerName)
+		}
+		endpoint := "https://api.elevenlabs.io/v1/speech-to-text"
+		if p, ok := cfg.Providers["elevenlabs"]; ok {
+			baseURL := p.ResolvedURL
+			if baseURL == "" {
+				baseURL = p.BaseURL
+			}
+			if baseURL != "" {
+				endpoint = strings.TrimRight(baseURL, "/") + "/speech-to-text"
+			}
+		}
+		model := firstNonEmptyString(modelOverride, cfg.Transcription.ElevenLabs.Model, "scribe_v2")
+		return transcribeAndTruncate(ctx, filePath, TranscribeOptions{
+			APIKey:   apiKey,
+			Endpoint: endpoint,
+			Model:    model,
+			Language: language,
+			Provider: "elevenlabs",
+		})
+
 	case "openai":
 		// Named provider entry takes precedence over env var
 		if p, ok := cfg.Providers[string(config.ProviderTypeOpenAI)]; ok && p.ResolvedAPIKey != "" {
@@ -132,6 +218,6 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 				Language: language,
 			})
 		}
-		return "", fmt.Errorf("transcription provider %q not found in providers config (supported builtins: openai, mistral, local, whisper-cli)", providerName)
+		return "", fmt.Errorf("transcription provider %q not found in providers config (supported builtins: openai, mistral, venice, elevenlabs, local, whisper-cli)", providerName)
 	}
 }

--- a/internal/llm/whisper.go
+++ b/internal/llm/whisper.go
@@ -12,10 +12,12 @@ import (
 )
 
 type TranscribeOptions struct {
-	APIKey   string
-	Endpoint string // full URL, e.g. "http://localhost:8080/inference" or "https://api.mistral.ai/v1/audio/transcriptions"
-	Model    string // optional, overrides default model name sent to API
-	Language string // optional, e.g. "en"
+	APIKey     string
+	Endpoint   string // full URL, e.g. "http://localhost:8080/inference" or "https://api.mistral.ai/v1/audio/transcriptions"
+	Model      string // optional, overrides default model name sent to API
+	Language   string // optional, e.g. "en"
+	Provider   string // optional request dialect: "openai" (default), "venice", or "elevenlabs"
+	Timestamps bool   // Venice: request timestamp metadata in JSON responses
 }
 
 type whisperResponse struct {
@@ -35,7 +37,14 @@ func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions
 
 	model := opts.Model
 	if model == "" {
-		model = "whisper-1"
+		switch opts.Provider {
+		case "venice":
+			model = "nvidia/parakeet-tdt-0.6b-v3"
+		case "elevenlabs":
+			model = "scribe_v2"
+		default:
+			model = "whisper-1"
+		}
 	}
 
 	endpoint := opts.Endpoint
@@ -43,14 +52,18 @@ func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions
 		endpoint = "https://api.openai.com/v1/audio/transcriptions"
 	}
 
-	bodyReader, contentType := newTranscriptionBody(filePath, f, model, opts.Language)
+	bodyReader, contentType := newTranscriptionBody(filePath, f, opts.Provider, model, opts.Language, opts.Timestamps)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bodyReader)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
 	}
 	if opts.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+		if opts.Provider == "elevenlabs" {
+			req.Header.Set("xi-api-key", opts.APIKey)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+		}
 	}
 	req.Header.Set("Content-Type", contentType)
 
@@ -72,19 +85,19 @@ func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions
 	return result.Text, nil
 }
 
-func newTranscriptionBody(filePath string, file io.Reader, model, language string) (io.Reader, string) {
+func newTranscriptionBody(filePath string, file io.Reader, provider, model, language string, timestamps bool) (io.Reader, string) {
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 
 	go func() {
-		err := writeTranscriptionBody(mw, filePath, file, model, language)
+		err := writeTranscriptionBody(mw, filePath, file, provider, model, language, timestamps)
 		_ = pw.CloseWithError(err)
 	}()
 
 	return pr, mw.FormDataContentType()
 }
 
-func writeTranscriptionBody(mw *multipart.Writer, filePath string, file io.Reader, model, language string) (err error) {
+func writeTranscriptionBody(mw *multipart.Writer, filePath string, file io.Reader, provider, model, language string, timestamps bool) (err error) {
 	defer func() {
 		closeErr := mw.Close()
 		if err == nil {
@@ -99,14 +112,27 @@ func writeTranscriptionBody(mw *multipart.Writer, filePath string, file io.Reade
 	if _, err := io.Copy(fw, file); err != nil {
 		return fmt.Errorf("write form file: %w", err)
 	}
-	if err := mw.WriteField("model", model); err != nil {
+	modelField := "model"
+	languageField := "language"
+	if provider == "elevenlabs" {
+		modelField = "model_id"
+		languageField = "language_code"
+	}
+	if err := mw.WriteField(modelField, model); err != nil {
 		return fmt.Errorf("write model field: %w", err)
 	}
-	if err := mw.WriteField("response_format", "json"); err != nil {
-		return fmt.Errorf("write response format field: %w", err)
+	if provider != "elevenlabs" {
+		if err := mw.WriteField("response_format", "json"); err != nil {
+			return fmt.Errorf("write response format field: %w", err)
+		}
+	}
+	if provider == "venice" && timestamps {
+		if err := mw.WriteField("timestamps", "true"); err != nil {
+			return fmt.Errorf("write timestamps field: %w", err)
+		}
 	}
 	if language != "" {
-		if err := mw.WriteField("language", language); err != nil {
+		if err := mw.WriteField(languageField, language); err != nil {
 			return fmt.Errorf("write language field: %w", err)
 		}
 	}

--- a/internal/llm/whisper_test.go
+++ b/internal/llm/whisper_test.go
@@ -111,6 +111,156 @@ func TestTranscribeFile_StreamsMultipartBody(t *testing.T) {
 	}
 }
 
+func TestTranscribeFile_ElevenLabsDialect(t *testing.T) {
+	origClient := defaultHTTPClient
+	defer func() {
+		defaultHTTPClient = origClient
+	}()
+
+	audioFile, err := os.CreateTemp(t.TempDir(), "audio-*.mp3")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	if _, err := audioFile.WriteString("audio-bytes"); err != nil {
+		t.Fatalf("write temp audio: %v", err)
+	}
+	if err := audioFile.Close(); err != nil {
+		t.Fatalf("close temp audio: %v", err)
+	}
+
+	var contentType string
+	var bodyBytes []byte
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("xi-api-key"); got != "test-key" {
+				t.Fatalf("xi-api-key = %q, want test-key", got)
+			}
+			if got := req.Header.Get("Authorization"); got != "" {
+				t.Fatalf("Authorization = %q, want empty", got)
+			}
+			contentType = req.Header.Get("Content-Type")
+			bodyBytes, _ = io.ReadAll(req.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"text":"hello"}`)),
+			}, nil
+		}),
+	}
+
+	text, err := TranscribeFile(context.Background(), audioFile.Name(), TranscribeOptions{
+		APIKey:   "test-key",
+		Endpoint: "https://api.elevenlabs.io/v1/speech-to-text",
+		Model:    "scribe_v2",
+		Language: "en",
+		Provider: "elevenlabs",
+	})
+	if err != nil {
+		t.Fatalf("TranscribeFile failed: %v", err)
+	}
+	if text != "hello" {
+		t.Fatalf("text = %q, want hello", text)
+	}
+
+	fields := readMultipartFields(t, contentType, bodyBytes)
+	if fields["model_id"] != "scribe_v2" {
+		t.Fatalf("model_id = %q, want scribe_v2", fields["model_id"])
+	}
+	if fields["language_code"] != "en" {
+		t.Fatalf("language_code = %q, want en", fields["language_code"])
+	}
+	if _, ok := fields["response_format"]; ok {
+		t.Fatalf("response_format should not be sent to ElevenLabs")
+	}
+}
+
+func TestTranscribeFile_VeniceDialect(t *testing.T) {
+	origClient := defaultHTTPClient
+	defer func() {
+		defaultHTTPClient = origClient
+	}()
+
+	audioFile, err := os.CreateTemp(t.TempDir(), "audio-*.mp3")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	if _, err := audioFile.WriteString("audio-bytes"); err != nil {
+		t.Fatalf("write temp audio: %v", err)
+	}
+	if err := audioFile.Close(); err != nil {
+		t.Fatalf("close temp audio: %v", err)
+	}
+
+	var contentType string
+	var bodyBytes []byte
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Authorization"); got != "Bearer test-key" {
+				t.Fatalf("Authorization = %q, want Bearer test-key", got)
+			}
+			contentType = req.Header.Get("Content-Type")
+			bodyBytes, _ = io.ReadAll(req.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"text":"hello"}`)),
+			}, nil
+		}),
+	}
+
+	_, err = TranscribeFile(context.Background(), audioFile.Name(), TranscribeOptions{
+		APIKey:     "test-key",
+		Endpoint:   "https://api.venice.ai/api/v1/audio/transcriptions",
+		Model:      "nvidia/parakeet-tdt-0.6b-v3",
+		Provider:   "venice",
+		Timestamps: true,
+	})
+	if err != nil {
+		t.Fatalf("TranscribeFile failed: %v", err)
+	}
+
+	fields := readMultipartFields(t, contentType, bodyBytes)
+	if fields["model"] != "nvidia/parakeet-tdt-0.6b-v3" {
+		t.Fatalf("model = %q, want nvidia/parakeet-tdt-0.6b-v3", fields["model"])
+	}
+	if fields["response_format"] != "json" {
+		t.Fatalf("response_format = %q, want json", fields["response_format"])
+	}
+	if fields["timestamps"] != "true" {
+		t.Fatalf("timestamps = %q, want true", fields["timestamps"])
+	}
+}
+
+func readMultipartFields(t *testing.T, contentType string, bodyBytes []byte) map[string]string {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("ParseMediaType failed: %v", err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("media type = %q, want multipart/form-data", mediaType)
+	}
+	reader := multipart.NewReader(bytes.NewReader(bodyBytes), params["boundary"])
+	fields := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart failed: %v", err)
+		}
+		data, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("ReadAll part failed: %v", err)
+		}
+		if part.FormName() != "file" {
+			fields[part.FormName()] = string(data)
+		}
+	}
+	return fields
+}
+
 func TestTranscribeFile_LimitsErrorBody(t *testing.T) {
 	origClient := defaultHTTPClient
 	defer func() {


### PR DESCRIPTION
## What

Adds Venice and ElevenLabs as built-in transcription providers for `term-llm transcribe`.

- `--provider venice`
  - Endpoint: `POST https://api.venice.ai/api/v1/audio/transcriptions`
  - Models:
    - `nvidia/parakeet-tdt-0.6b-v3`
    - `openai/whisper-large-v3`
    - `fal-ai/wizper`
    - `elevenlabs/scribe-v2`
    - `stt-xai-v1`
- `--provider elevenlabs`
  - Endpoint: `POST https://api.elevenlabs.io/v1/speech-to-text`
  - Models:
    - `scribe_v2`
    - `scribe_v1`
- Adds `--model` override and shell completion for transcription providers/models.
- Adds Venice `--timestamps` request support.
- Adds transcription-specific config blocks:

```yaml
transcription:
  provider: venice
  venice:
    api_key: ${VENICE_API_KEY}
    model: nvidia/parakeet-tdt-0.6b-v3
  elevenlabs:
    api_key: ${ELEVENLABS_API_KEY}
    model: scribe_v2
```

- Updates transcription docs and configuration reference.

## Verification

```sh
go build ./...
go test ./...
```

Live Venice round-trip smoke tested by generating `hello` and transcribing it:

```sh
term-llm audio "hello" \
  --provider venice \
  --model tts-kokoro \
  --voice af_sky \
  --format mp3 \
  --output /tmp/.../hello.mp3 \
  --json

term-llm transcribe /tmp/.../hello.mp3 \
  --provider venice \
  --model nvidia/parakeet-tdt-0.6b-v3 \
  --language en \
  --porcelain
```

Output:

```text
Hello?
```

Live ElevenLabs round-trip smoke tested by generating `hello` and transcribing it:

```sh
term-llm audio "hello" \
  --provider elevenlabs \
  --model eleven_flash_v2_5 \
  --voice JBFqnCBsd6RMkjVDRZzb \
  --format mp3_44100_128 \
  --output /tmp/.../hello-eleven.mp3 \
  --json

term-llm transcribe /tmp/.../hello-eleven.mp3 \
  --provider elevenlabs \
  --model scribe_v2 \
  --language en \
  --porcelain
```

Output:

```text
Hello?
```
