### PR TITLE
fix: Copilot refreshes its session token after only 5 minutes, adding an avoidable pre-request roundtrip

### DIFF
--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -36,13 +36,13 @@ const copilotTokenURL = "https://api.github.com/copilot_internal/v2/token"
 // for specific client identifiers. We use the VS Code Copilot extension's identifiers
 // as this is the standard approach used by third-party Copilot clients.
 const (
-	copilotUserAgent        = "GitHubCopilotChat/0.26.7"
-	copilotEditorVersion    = "vscode/1.96.0"
-	copilotPluginVersion    = "copilot-chat/0.26.7"
-	copilotIntegrationID    = "vscode-chat"
-	copilotAPIVersion       = "2025-04-01"
-	copilotOpenAIIntent     = "conversation-panel"
-	copilotSessionRefreshIn = 20 * time.Minute // Refresh session token before expiry (tokens last ~25min)
+	copilotUserAgent          = "GitHubCopilotChat/0.26.7"
+	copilotEditorVersion      = "vscode/1.96.0"
+	copilotPluginVersion      = "copilot-chat/0.26.7"
+	copilotIntegrationID      = "vscode-chat"
+	copilotAPIVersion         = "2025-04-01"
+	copilotOpenAIIntent       = "conversation-panel"
+	copilotSessionRefreshSkew = 1 * time.Minute // Refresh shortly before expiry to avoid unnecessary token roundtrips.
 )
 
 // copilotHTTPClient is a shared HTTP client with transport-level timeouts.
@@ -610,8 +610,8 @@ func (e *copilotAPIError) Is404() bool {
 // ensureValidSession ensures we have a valid session token, refreshing if needed.
 // Session tokens typically expire after ~25 minutes.
 func (p *CopilotProvider) ensureValidSession(ctx context.Context) error {
-	// Check if we need to refresh (no token, or approaching expiry)
-	if p.sessionToken == "" || time.Now().After(p.sessionTokenExpiry.Add(-copilotSessionRefreshIn)) {
+	// Check if we need to refresh (no token, missing expiry, or close to expiry).
+	if p.sessionToken == "" || p.sessionTokenExpiry.IsZero() || time.Until(p.sessionTokenExpiry) <= copilotSessionRefreshSkew {
 		return p.refreshSession(ctx)
 	}
 	return nil

--- a/internal/llm/copilot_test.go
+++ b/internal/llm/copilot_test.go
@@ -1,0 +1,98 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/credentials"
+)
+
+func TestEnsureValidSessionKeepsUnexpiredToken(t *testing.T) {
+	origClient := copilotHTTPClient
+	defer func() {
+		copilotHTTPClient = origClient
+	}()
+
+	requests := 0
+	copilotHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			requests++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+					`{"token":"fresh-token","expires_at":%d,"refresh_in":1500,"endpoints":{"api":"https://api.githubcopilot.com"}}`,
+					time.Now().Add(25*time.Minute).Unix(),
+				))),
+			}, nil
+		}),
+	}
+
+	provider := &CopilotProvider{
+		creds:              &credentials.CopilotCredentials{AccessToken: "oauth-token"},
+		sessionToken:       "existing-token",
+		sessionTokenExpiry: time.Now().Add(10 * time.Minute),
+	}
+
+	if err := provider.ensureValidSession(context.Background()); err != nil {
+		t.Fatalf("ensureValidSession returned error: %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected no token refresh request, got %d", requests)
+	}
+	if provider.sessionToken != "existing-token" {
+		t.Fatalf("expected existing session token to be kept, got %q", provider.sessionToken)
+	}
+}
+
+func TestEnsureValidSessionRefreshesNearExpiry(t *testing.T) {
+	origClient := copilotHTTPClient
+	defer func() {
+		copilotHTTPClient = origClient
+	}()
+
+	requests := 0
+	copilotHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			requests++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+					`{"token":"fresh-token","expires_at":%d,"refresh_in":1500,"endpoints":{"api":"https://api.business.githubcopilot.com"}}`,
+					time.Now().Add(25*time.Minute).Unix(),
+				))),
+			}, nil
+		}),
+	}
+
+	provider := &CopilotProvider{
+		creds:              &credentials.CopilotCredentials{AccessToken: "oauth-token"},
+		sessionToken:       "stale-token",
+		sessionTokenExpiry: time.Now().Add(30 * time.Second),
+	}
+
+	if err := provider.ensureValidSession(context.Background()); err != nil {
+		t.Fatalf("ensureValidSession returned error: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected 1 token refresh request, got %d", requests)
+	}
+	if provider.sessionToken != "fresh-token" {
+		t.Fatalf("expected session token to be refreshed, got %q", provider.sessionToken)
+	}
+	if provider.apiBaseURL != "https://api.business.githubcopilot.com" {
+		t.Fatalf("expected api base URL to be updated from token response, got %q", provider.apiBaseURL)
+	}
+}


### PR DESCRIPTION
## What

- reduce Copilot's session-token refresh lead time from 20 minutes to 1 minute
- refresh when the token is missing, has no tracked expiry, or is actually close to expiring
- add regression tests covering both the keep-existing-token and near-expiry refresh paths

## Why

Copilot session tokens last about 25 minutes, but the previous logic refreshed them after roughly 5 minutes by checking `expiry - 20m`. That added an unnecessary `copilot_internal/v2/token` roundtrip to many prompts, directly hurting request startup latency and TTFT even though the existing session token was still valid.
