### PR TITLE
fix: Gemini tool-enabled turns are forced onto a non-streaming code path

### DIFF
--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -150,53 +150,7 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 			fmt.Fprintln(os.Stderr, "====================================")
 		}
 
-		if len(req.Tools) > 0 {
-			resp, err := client.Models.GenerateContent(ctx, chooseModel(req.Model, p.model), contents, config)
-			if err != nil {
-				return fmt.Errorf("gemini API error: %w", err)
-			}
-			// Extract text and function calls with thought signatures from Parts
-			// Gemini 3 returns thought signature that must be passed back with tool results
-			var lastThoughtSig []byte
-			if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil {
-				for _, part := range resp.Candidates[0].Content.Parts {
-					// Capture thought signature from thought parts
-					if part.Thought && len(part.ThoughtSignature) > 0 {
-						lastThoughtSig = part.ThoughtSignature
-					}
-					// Emit text parts (skip thought parts which are internal)
-					if part.Text != "" && !part.Thought {
-						if err := send.Send(Event{Type: EventTextDelta, Text: part.Text}); err != nil {
-							return err
-						}
-					}
-					if part.FunctionCall != nil {
-						argsJSON, _ := jsonMarshal(part.FunctionCall.Args)
-						// Use thought signature from this part or preceding thought part
-						thoughtSig := part.ThoughtSignature
-						if thoughtSig == nil {
-							thoughtSig = lastThoughtSig
-						}
-						if err := send.Send(Event{Type: EventToolCall, Tool: &ToolCall{
-							ID:         part.FunctionCall.ID,
-							Name:       part.FunctionCall.Name,
-							Arguments:  argsJSON,
-							ThoughtSig: thoughtSig,
-						}}); err != nil {
-							return err
-						}
-					}
-				}
-			}
-			if err := emitGeminiUsage(send, resp); err != nil {
-				return err
-			}
-			if err := send.Send(Event{Type: EventDone}); err != nil {
-				return err
-			}
-			return nil
-		}
-
+		var lastThoughtSig []byte
 		var sources []string
 		var lastResp *genai.GenerateContentResponse
 		for resp, err := range client.Models.GenerateContentStream(ctx, chooseModel(req.Model, p.model), contents, config) {
@@ -204,8 +158,8 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 				return fmt.Errorf("gemini streaming error: %w", err)
 			}
 			lastResp = resp
-			if text := resp.Text(); text != "" {
-				if err := send.Send(Event{Type: EventTextDelta, Text: text}); err != nil {
+			if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil {
+				if err := emitGeminiParts(send, resp.Candidates[0].Content.Parts, &lastThoughtSig); err != nil {
 					return err
 				}
 			}
@@ -247,6 +201,57 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 		}
 		return nil
 	}), nil
+}
+
+func emitGeminiParts(send eventSender, parts []*genai.Part, lastThoughtSig *[]byte) error {
+	var text strings.Builder
+	flushText := func() error {
+		if text.Len() == 0 {
+			return nil
+		}
+		if err := send.Send(Event{Type: EventTextDelta, Text: text.String()}); err != nil {
+			return err
+		}
+		text.Reset()
+		return nil
+	}
+
+	for _, part := range parts {
+		if part == nil {
+			continue
+		}
+		if part.Thought && len(part.ThoughtSignature) > 0 {
+			*lastThoughtSig = append((*lastThoughtSig)[:0], part.ThoughtSignature...)
+		}
+		if part.Text != "" && !part.Thought {
+			text.WriteString(part.Text)
+			continue
+		}
+		if part.FunctionCall == nil {
+			continue
+		}
+		if err := flushText(); err != nil {
+			return err
+		}
+		argsJSON, _ := jsonMarshal(part.FunctionCall.Args)
+		thoughtSig := part.ThoughtSignature
+		if len(thoughtSig) == 0 {
+			thoughtSig = *lastThoughtSig
+		}
+		if len(thoughtSig) > 0 {
+			thoughtSig = append([]byte(nil), thoughtSig...)
+		}
+		if err := send.Send(Event{Type: EventToolCall, Tool: &ToolCall{
+			ID:         part.FunctionCall.ID,
+			Name:       part.FunctionCall.Name,
+			Arguments:  argsJSON,
+			ThoughtSig: thoughtSig,
+		}}); err != nil {
+			return err
+		}
+	}
+
+	return flushText()
 }
 
 func emitGeminiUsage(send eventSender, resp *genai.GenerateContentResponse) error {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -52,6 +52,55 @@ func TestBuildGeminiContents_DropsDanglingToolCalls(t *testing.T) {
 	}
 }
 
+func TestEmitGeminiParts_StreamsTextAndToolCallsInOrder(t *testing.T) {
+	thoughtSig := []byte{1, 2, 3}
+	events := make(chan Event, 4)
+	var lastThoughtSig []byte
+
+	err := emitGeminiParts(eventSender{ctx: context.Background(), ch: events}, []*genai.Part{
+		{Thought: true, ThoughtSignature: thoughtSig},
+		{Text: "Working"},
+		{Text: "..."},
+		{FunctionCall: &genai.FunctionCall{
+			ID:   "call_1",
+			Name: "lookup",
+			Args: map[string]any{"q": "weather"},
+		}},
+		{Text: "done"},
+	}, &lastThoughtSig)
+	if err != nil {
+		t.Fatalf("emitGeminiParts() error = %v", err)
+	}
+	close(events)
+
+	var got []Event
+	for event := range events {
+		got = append(got, event)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(got))
+	}
+	if got[0].Type != EventTextDelta || got[0].Text != "Working..." {
+		t.Fatalf("first event = %+v, want text delta %q", got[0], "Working...")
+	}
+	if got[1].Type != EventToolCall || got[1].Tool == nil {
+		t.Fatalf("second event = %+v, want tool call", got[1])
+	}
+	if got[1].Tool.ID != "call_1" || got[1].Tool.Name != "lookup" || string(got[1].Tool.Arguments) != `{"q":"weather"}` {
+		t.Fatalf("tool call = %+v", got[1].Tool)
+	}
+	if string(got[1].Tool.ThoughtSig) != string(thoughtSig) {
+		t.Fatalf("tool thought signature = %v, want %v", got[1].Tool.ThoughtSig, thoughtSig)
+	}
+	if got[2].Type != EventTextDelta || got[2].Text != "done" {
+		t.Fatalf("third event = %+v, want text delta %q", got[2], "done")
+	}
+	if string(lastThoughtSig) != string(thoughtSig) {
+		t.Fatalf("lastThoughtSig = %v, want %v", lastThoughtSig, thoughtSig)
+	}
+}
+
 func TestEmitGeminiUsage_DoesNotBlockAfterCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## What

Keep Gemini on the streaming `GenerateContentStream` path even when tools are enabled, and parse streamed response parts for both text deltas and tool calls. Added a focused regression test covering streamed text/tool ordering and thought-signature propagation.

## Why

Tool-enabled Gemini turns were being forced onto blocking `GenerateContent`, so users saw no incremental output until the full model response finished. This restores lower time-to-first-token and makes agentic Gemini sessions feel responsive again while preserving tool call metadata needed for follow-up tool results.
