### PR TITLE
fix: Gemini tool-enabled turns are fully non-streaming

### DIFF
--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -150,64 +150,19 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 			fmt.Fprintln(os.Stderr, "====================================")
 		}
 
-		if len(req.Tools) > 0 {
-			resp, err := client.Models.GenerateContent(ctx, chooseModel(req.Model, p.model), contents, config)
-			if err != nil {
-				return fmt.Errorf("gemini API error: %w", err)
-			}
-			// Extract text and function calls with thought signatures from Parts
-			// Gemini 3 returns thought signature that must be passed back with tool results
-			var lastThoughtSig []byte
-			if len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil {
-				for _, part := range resp.Candidates[0].Content.Parts {
-					// Capture thought signature from thought parts
-					if part.Thought && len(part.ThoughtSignature) > 0 {
-						lastThoughtSig = part.ThoughtSignature
-					}
-					// Emit text parts (skip thought parts which are internal)
-					if part.Text != "" && !part.Thought {
-						if err := send.Send(Event{Type: EventTextDelta, Text: part.Text}); err != nil {
-							return err
-						}
-					}
-					if part.FunctionCall != nil {
-						argsJSON, _ := jsonMarshal(part.FunctionCall.Args)
-						// Use thought signature from this part or preceding thought part
-						thoughtSig := part.ThoughtSignature
-						if thoughtSig == nil {
-							thoughtSig = lastThoughtSig
-						}
-						if err := send.Send(Event{Type: EventToolCall, Tool: &ToolCall{
-							ID:         part.FunctionCall.ID,
-							Name:       part.FunctionCall.Name,
-							Arguments:  argsJSON,
-							ThoughtSig: thoughtSig,
-						}}); err != nil {
-							return err
-						}
-					}
-				}
-			}
-			if err := emitGeminiUsage(send, resp); err != nil {
-				return err
-			}
-			if err := send.Send(Event{Type: EventDone}); err != nil {
-				return err
-			}
-			return nil
-		}
-
-		var sources []string
-		var lastResp *genai.GenerateContentResponse
-		for resp, err := range client.Models.GenerateContentStream(ctx, chooseModel(req.Model, p.model), contents, config) {
+		var (
+			sources   []string
+			lastResp  *genai.GenerateContentResponse
+			emitState geminiStreamEmitState
+			modelName = chooseModel(req.Model, p.model)
+		)
+		for resp, err := range client.Models.GenerateContentStream(ctx, modelName, contents, config) {
 			if err != nil {
 				return fmt.Errorf("gemini streaming error: %w", err)
 			}
 			lastResp = resp
-			if text := resp.Text(); text != "" {
-				if err := send.Send(Event{Type: EventTextDelta, Text: text}); err != nil {
-					return err
-				}
+			if err := emitState.emit(send, resp); err != nil {
+				return err
 			}
 			if req.Search {
 				for _, cand := range resp.Candidates {
@@ -247,6 +202,60 @@ func (p *GeminiProvider) Stream(ctx context.Context, req Request) (Stream, error
 		}
 		return nil
 	}), nil
+}
+
+type geminiStreamEmitState struct {
+	lastThoughtSig []byte
+	seenToolCalls  map[string]struct{}
+}
+
+func (s *geminiStreamEmitState) emit(send eventSender, resp *genai.GenerateContentResponse) error {
+	if resp == nil || len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
+		return nil
+	}
+
+	for _, part := range resp.Candidates[0].Content.Parts {
+		if part.Thought && len(part.ThoughtSignature) > 0 {
+			s.lastThoughtSig = part.ThoughtSignature
+		}
+		if part.Text != "" && !part.Thought {
+			if err := send.Send(Event{Type: EventTextDelta, Text: part.Text}); err != nil {
+				return err
+			}
+		}
+		if part.FunctionCall == nil {
+			continue
+		}
+
+		argsJSON, _ := jsonMarshal(part.FunctionCall.Args)
+		thoughtSig := part.ThoughtSignature
+		if len(thoughtSig) == 0 {
+			thoughtSig = s.lastThoughtSig
+		}
+		call := ToolCall{
+			ID:         part.FunctionCall.ID,
+			Name:       part.FunctionCall.Name,
+			Arguments:  argsJSON,
+			ThoughtSig: thoughtSig,
+		}
+		key := geminiToolCallKey(call)
+		if _, seen := s.seenToolCalls[key]; seen {
+			continue
+		}
+		if s.seenToolCalls == nil {
+			s.seenToolCalls = make(map[string]struct{})
+		}
+		s.seenToolCalls[key] = struct{}{}
+		if err := send.Send(Event{Type: EventToolCall, Tool: &call}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func geminiToolCallKey(call ToolCall) string {
+	return call.ID + "\x00" + call.Name + "\x00" + string(call.Arguments) + "\x00" + base64.StdEncoding.EncodeToString(call.ThoughtSig)
 }
 
 func emitGeminiUsage(send eventSender, resp *genai.GenerateContentResponse) error {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -52,6 +52,70 @@ func TestBuildGeminiContents_DropsDanglingToolCalls(t *testing.T) {
 	}
 }
 
+func TestGeminiStreamEmitState_StreamsToolTurnsIncrementally(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan Event, 8)
+	sender := eventSender{ctx: ctx, ch: events}
+	thoughtSig := []byte("thought-sig")
+
+	var state geminiStreamEmitState
+	if err := state.emit(sender, &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Parts: []*genai.Part{
+				{Text: "Thinking out loud..."},
+				{Thought: true, ThoughtSignature: thoughtSig},
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("emit first chunk: %v", err)
+	}
+
+	toolChunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{
+					ID:   "call-1",
+					Name: "lookup_weather",
+					Args: map[string]any{"city": "Sydney"},
+				},
+			}}},
+		}},
+	}
+	if err := state.emit(sender, toolChunk); err != nil {
+		t.Fatalf("emit tool chunk: %v", err)
+	}
+	if err := state.emit(sender, toolChunk); err != nil {
+		t.Fatalf("emit duplicate tool chunk: %v", err)
+	}
+	close(events)
+
+	var got []Event
+	for event := range events {
+		got = append(got, event)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 events, got %d: %#v", len(got), got)
+	}
+	if got[0].Type != EventTextDelta || got[0].Text != "Thinking out loud..." {
+		t.Fatalf("first event = %#v, want text delta", got[0])
+	}
+	if got[1].Type != EventToolCall {
+		t.Fatalf("second event = %#v, want tool call", got[1])
+	}
+	if got[1].Tool == nil {
+		t.Fatal("expected tool call payload")
+	}
+	if got[1].Tool.Name != "lookup_weather" {
+		t.Fatalf("tool name = %q, want lookup_weather", got[1].Tool.Name)
+	}
+	if string(got[1].Tool.Arguments) != `{"city":"Sydney"}` {
+		t.Fatalf("tool args = %s, want %s", got[1].Tool.Arguments, `{"city":"Sydney"}`)
+	}
+	if string(got[1].Tool.ThoughtSig) != string(thoughtSig) {
+		t.Fatalf("tool thought signature = %q, want %q", got[1].Tool.ThoughtSig, thoughtSig)
+	}
+}
+
 func TestEmitGeminiUsage_DoesNotBlockAfterCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## What

Use Gemini's streaming API even when tools are enabled, and parse streamed chunks for visible text plus tool calls/thought signatures as they arrive.

## Why

The previous tool path switched to a blocking `GenerateContent` call, so any agentic Gemini turn lost incremental output entirely and only emitted text/tool events after full model latency. This restores time-to-first-token for tool-heavy turns while preserving Gemini thought-signature propagation for tool results.
