### PR TITLE
fix: One transient WebSocket setup failure permanently disables the faster Responses transport

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -40,7 +40,6 @@ type ResponsesClient struct {
 	WebSocketConnectTimeout time.Duration
 	WebSocketWriteTimeout   time.Duration
 	WebSocketIdleTimeout    time.Duration
-	websocketDisabled       bool
 	wsMu                    sync.Mutex
 	wsConn                  *websocket.Conn
 	wsLastRequest           *ResponsesRequest
@@ -551,12 +550,13 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		httpPayload.Input = filterToNewInput(httpPayload.Input)
 	}
 
-	if c.UseWebSocket && !c.websocketDisabled {
+	if c.UseWebSocket {
 		stream, err := c.streamWebSocketPrepared(ctx, wsReq, fullInput, debugRaw, responseStateGeneration)
 		if err == nil {
 			return stream, nil
 		}
-		c.websocketDisabled = true
+		// Fall back to HTTP/SSE for this turn, but keep WebSocket enabled so the
+		// next turn can retry the faster transport after transient setup failures.
 		c.closeWebSocket()
 		if debugRaw {
 			DebugRawSection(debugRaw, "Responses WebSocket Fallback", err.Error())
@@ -812,7 +812,6 @@ func (c *ResponsesClient) ResetConversation() {
 	defer c.responseStateMu.Unlock()
 	c.responseStateGeneration++
 	c.LastResponseID = ""
-	c.websocketDisabled = false
 	c.wsLastRequest = nil
 	c.wsLastResponseItems = nil
 }

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -313,6 +313,70 @@ func TestResponsesClientWebSocketConnectFailureFallsBackToHTTP(t *testing.T) {
 	}
 }
 
+func TestResponsesClientTransientWebSocketSetupFailureDoesNotDisableFutureAttempts(t *testing.T) {
+	var wsAttempts atomic.Int32
+	var httpCalls atomic.Int32
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			if wsAttempts.Add(1) == 1 {
+				http.Error(w, "temporary websocket failure", http.StatusBadGateway)
+				return
+			}
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Errorf("upgrade: %v", err)
+				return
+			}
+			defer conn.Close()
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Errorf("read request: %v", err)
+				return
+			}
+			_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_ws"}})
+			return
+		}
+
+		httpCalls.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_http\"}}\n\n"))
+	}))
+	defer server.Close()
+
+	client := &ResponsesClient{BaseURL: server.URL, UseWebSocket: true}
+	for i, content := range []string{"first", "second"} {
+		stream, err := client.Stream(context.Background(), ResponsesRequest{
+			Model:  "gpt-test",
+			Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: content}},
+			Stream: true,
+		}, false)
+		if err != nil {
+			t.Fatalf("Stream %d: %v", i, err)
+		}
+		for {
+			event, err := stream.Recv()
+			if err != nil {
+				t.Fatalf("Recv %d: %v", i, err)
+			}
+			if event.Type == EventDone {
+				break
+			}
+			if event.Type == EventError {
+				t.Fatalf("stream error %d: %v", i, event.Err)
+			}
+		}
+		_ = stream.Close()
+	}
+
+	if wsAttempts.Load() != 2 {
+		t.Fatalf("websocket attempts = %d, want 2", wsAttempts.Load())
+	}
+	if httpCalls.Load() != 1 {
+		t.Fatalf("HTTP fallback calls = %d, want 1", httpCalls.Load())
+	}
+}
+
 func TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput(t *testing.T) {
 	var httpReq map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Stop permanently disabling Responses-over-WebSocket after a single setup fallback. If WebSocket setup fails for one turn, the client now falls back to HTTP/SSE for that turn only and retries WebSocket on the next turn.

Also add a regression test that simulates a transient WebSocket setup failure followed by a successful WebSocket turn, ensuring the faster transport is retried instead of being latched off for the rest of the conversation.

## Why

OpenAI and ChatGPT commonly run with `use_websocket` enabled because the WebSocket transport improves TTFT and, for ChatGPT, preserves connection-local continuation state. Previously, any transient connect/handshake/write failure set a sticky disable flag that was only cleared by `ResetConversation`, silently degrading the rest of the conversation to slower HTTP/SSE requests.

Retaining WebSocket eligibility across transient setup failures restores the intended fast path automatically without requiring the user to clear the conversation.
