### PR TITLE
perf: grow chat render cache for histories

### DIFF
--- a/internal/render/chat/cache.go
+++ b/internal/render/chat/cache.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+const maxBlockCacheSize = 2000
+
 // BlockCache is an LRU cache for rendered MessageBlocks.
 // It keeps memory bounded while avoiding re-rendering unchanged messages.
 type BlockCache struct {
@@ -24,6 +26,9 @@ type cacheEntry struct {
 func NewBlockCache(maxSize int) *BlockCache {
 	if maxSize <= 0 {
 		maxSize = 100
+	}
+	if maxSize > maxBlockCacheSize {
+		maxSize = maxBlockCacheSize
 	}
 	return &BlockCache{
 		maxSize: maxSize,
@@ -91,6 +96,31 @@ func (c *BlockCache) Remove(key string) {
 		delete(c.cache, key)
 		c.lruList.Remove(elem)
 	}
+}
+
+// EnsureCapacity grows the cache capacity, capped by maxBlockCacheSize.
+// It never shrinks the cache: renders can move between small and large histories,
+// and shrinking would evict warm blocks only to re-grow on the next full-history view.
+func (c *BlockCache) EnsureCapacity(size int) {
+	if size <= 0 {
+		return
+	}
+	if size > maxBlockCacheSize {
+		size = maxBlockCacheSize
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if size > c.maxSize {
+		c.maxSize = size
+	}
+}
+
+// MaxSize returns the configured maximum number of cached blocks.
+func (c *BlockCache) MaxSize() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.maxSize
 }
 
 // InvalidateAll clears the entire cache.

--- a/internal/render/chat/cache_test.go
+++ b/internal/render/chat/cache_test.go
@@ -95,6 +95,24 @@ func TestBlockCache_Remove(t *testing.T) {
 	}
 }
 
+func TestBlockCache_EnsureCapacityGrowsOnly(t *testing.T) {
+	cache := NewBlockCache(3)
+	cache.EnsureCapacity(5)
+	if cache.MaxSize() != 5 {
+		t.Fatalf("MaxSize() after grow = %d, want 5", cache.MaxSize())
+	}
+
+	cache.EnsureCapacity(2)
+	if cache.MaxSize() != 5 {
+		t.Fatalf("MaxSize() after smaller ensure = %d, want 5", cache.MaxSize())
+	}
+
+	cache.EnsureCapacity(maxBlockCacheSize + 100)
+	if cache.MaxSize() != maxBlockCacheSize {
+		t.Fatalf("MaxSize() after capped grow = %d, want %d", cache.MaxSize(), maxBlockCacheSize)
+	}
+}
+
 func TestBlockCache_InvalidateAll(t *testing.T) {
 	cache := NewBlockCache(10)
 

--- a/internal/render/chat/renderer.go
+++ b/internal/render/chat/renderer.go
@@ -143,8 +143,8 @@ func NewRenderer(width, height int) *Renderer {
 	cacheSize := (height / 5) * 3
 	if cacheSize < 50 {
 		cacheSize = 50
-	} else if cacheSize > 2000 {
-		cacheSize = 2000
+	} else if cacheSize > maxBlockCacheSize {
+		cacheSize = maxBlockCacheSize
 	}
 	r := &Renderer{
 		width:      width,
@@ -340,6 +340,13 @@ func (r *Renderer) renderHistory(state RenderState) string {
 		vp := NewVirtualViewport(r.width, state.Viewport.Height)
 		start, end = vp.GetVisibleRange(state.Messages, state.Viewport.ScrollOffset)
 	}
+
+	// Alt-screen renders the full history into Bubble Tea's viewport. A viewport-sized
+	// cache thrashes in that mode because one render pass evicts blocks needed by
+	// the next pass. Grow the cache to cover the current rendered range (bounded by
+	// maxBlockCacheSize) so warm frames reuse rendered markdown instead of
+	// re-rendering every message on each View().
+	r.blockCache.EnsureCapacity(end - start)
 
 	// Render only visible messages using cache
 	// Skip system and tool messages (they render as empty anyway)

--- a/internal/render/chat/renderer_test.go
+++ b/internal/render/chat/renderer_test.go
@@ -154,6 +154,38 @@ func TestRenderer_CacheHit(t *testing.T) {
 	}
 }
 
+func TestRenderer_AltScreenLargeHistoryCacheDoesNotThrash(t *testing.T) {
+	renderer := NewRenderer(80, 24)
+	markdownCalls := 0
+	renderer.SetMarkdownRenderer(func(content string, width int) string {
+		markdownCalls++
+		return simpleMarkdownRenderer(content, width)
+	})
+
+	messages := generateMessages(120)
+	state := RenderState{
+		Messages: messages,
+		Viewport: ViewportState{Height: 24},
+		Mode:     RenderModeAltScreen,
+		Width:    80,
+		Height:   24,
+	}
+
+	renderer.Render(state)
+	firstCalls := markdownCalls
+	if firstCalls == 0 {
+		t.Fatal("first render made no markdown calls; test setup is invalid")
+	}
+	if got := renderer.blockCache.MaxSize(); got < len(messages) {
+		t.Fatalf("block cache max size = %d, want at least %d", got, len(messages))
+	}
+
+	renderer.Render(state)
+	if markdownCalls != firstCalls {
+		t.Fatalf("warm render made %d additional markdown calls; cache thrashed for large alt-screen history", markdownCalls-firstCalls)
+	}
+}
+
 func TestRenderer_CacheInvalidateOnResize(t *testing.T) {
 	renderer := NewRenderer(80, 24)
 	renderer.SetMarkdownRenderer(simpleMarkdownRenderer)


### PR DESCRIPTION
## What

Grow the chat `MessageBlock` cache to cover the currently rendered history range, bounded by the existing 2000-entry cap.

Alt-screen mode renders the full message history into Bubble Tea's viewport. The cache was initialized from viewport height (50 entries at a 24-row terminal), so rendering a 500-message history would evict the warmed tail while walking from the beginning on every frame. That made the warm cache effectively miss every message.

This PR adds a bounded `EnsureCapacity` path and calls it from `renderHistory` before rendering the current range. Small inline/virtualized ranges keep the existing small cache; large full-history views can retain their rendered blocks.

## Why

Warm alt-screen frames should reuse rendered markdown/message blocks instead of re-rendering an entire history on every `View()` repaint.

## Evidence

Before on `origin/main` / branch baseline:

```text
BenchmarkRender500MessagesCached-32   ~3.36-3.43 ms/op   ~1.401 MB/op   14672 allocs/op
```

After this change:

```text
BenchmarkRender500MessagesCached-32   ~175.7-183.4 µs/op   ~663 KB/op   1421 allocs/op
```

Representative focused benchmark command:

```bash
go test ./internal/render/chat -bench='BenchmarkRender500Messages|BenchmarkRender500MessagesCached|BenchmarkRender500MessagesScrolling' -benchmem -run=^$ -count=5
```

## Tests

- Added regression tests for bounded cache growth and large alt-screen warm-cache reuse.
- `gofmt` on changed Go files.
- `go test ./internal/render/chat`
- `go build ./...`
- `go test ./...` (first run hit an unrelated flaky `internal/llm` websocket test; immediate rerun passed)
