### PR TITLE
fix: Inline image uploads are base64-decoded twice and synchronously written to disk before any model request starts

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"net/http"
 	"os"
@@ -108,9 +107,28 @@ const (
 	maxAttachmentBytes = 20 << 20 // 20 MB per file (decoded)
 )
 
+func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return nil, fmt.Errorf("decode base64: %w", err)
+	}
+	if len(raw) > maxAttachmentBytes {
+		return nil, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+	return raw, nil
+}
+
 // saveUploadedFile decodes base64 data and writes it to the uploads directory,
 // returning the full filesystem path. Uses O_CREATE|O_EXCL for atomic uniqueness.
 func saveUploadedFile(filename, b64Data string) (string, error) {
+	raw, err := decodeUploadedFile(filename, b64Data)
+	if err != nil {
+		return "", err
+	}
+	return saveUploadedBytes(filename, raw)
+}
+
+func saveUploadedBytes(filename string, raw []byte) (string, error) {
 	dataDir, err := session.GetDataDir()
 	if err != nil {
 		return "", fmt.Errorf("get data dir: %w", err)
@@ -120,10 +138,6 @@ func saveUploadedFile(filename, b64Data string) (string, error) {
 		return "", fmt.Errorf("create uploads dir: %w", err)
 	}
 
-	raw, err := base64.StdEncoding.DecodeString(b64Data)
-	if err != nil {
-		return "", fmt.Errorf("decode base64: %w", err)
-	}
 	if len(raw) > maxAttachmentBytes {
 		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
 	}
@@ -173,12 +187,11 @@ func abbreviatePath(path string) string {
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
-// Supported image types are sent inline to the LLM; all other files are saved to disk
+// Supported image types are kept inline for the LLM; all other files are saved to disk
 // and referenced by path in a text part.
 //
-// All uploaded images are saved to disk unconditionally as originals before any
-// processing. Images exceeding 1 MB are resized/compressed before being sent to
-// the LLM to avoid provider errors.
+// Images exceeding 1 MB are resized/compressed before being sent to the LLM to avoid
+// provider errors.
 func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	var parts []map[string]json.RawMessage
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
@@ -207,27 +220,13 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					if fileCount > maxAttachments {
 						return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
 					}
-					// Always save the original to disk first.
 					if filename == "" {
 						filename = "image"
 					}
-					path, err := saveUploadedFile(filename, b64)
-					if err != nil {
-						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
-					}
-					savedPath := path
 
-					// Decode raw bytes for possible resize.
-					raw, err := base64.StdEncoding.DecodeString(b64)
+					raw, err := decodeUploadedFile(filename, b64)
 					if err != nil {
-						// Shouldn't happen — b64 was just parsed — but fall back gracefully.
-						log.Printf("[web] warning: base64 re-decode failed for %q: %v", filename, err)
-						llmParts = append(llmParts, llm.Part{
-							Type:      llm.PartImage,
-							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
-							ImagePath: savedPath,
-						})
-						continue
+						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
 					}
 
 					// Resize if over 1 MB before sending to the model.
@@ -239,7 +238,6 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					llmParts = append(llmParts, llm.Part{
 						Type:      llm.PartImage,
 						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64},
-						ImagePath: savedPath,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -58,6 +60,29 @@ func TestParseUserMessageContent_RejectsOversizedInlineImage(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d MB limit", maxAttachmentBytes>>20)) {
 		t.Fatalf("parseUserMessageContent() error = %v, want size limit error", err)
+	}
+}
+
+func TestParseUserMessageContent_InlineImagesDoNotHitUploadsDir(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	content := marshalInlineImageParts(t, 1)
+
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	if len(msg.Parts) != 1 {
+		t.Fatalf("len(msg.Parts) = %d, want 1", len(msg.Parts))
+	}
+	if msg.Parts[0].ImagePath != "" {
+		t.Fatalf("msg.Parts[0].ImagePath = %q, want empty", msg.Parts[0].ImagePath)
+	}
+
+	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
+	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
+		t.Fatalf("uploads dir stat err = %v, want not exist", err)
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -926,11 +926,12 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
 		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
 	}
-	if msg.Parts[0].ImagePath == "" {
-		t.Fatal("parts[0].ImagePath = empty, want saved upload path")
+	if msg.Parts[0].ImagePath != "" {
+		t.Fatalf("parts[0].ImagePath = %q, want empty for inline upload", msg.Parts[0].ImagePath)
 	}
-	if _, err := os.Stat(msg.Parts[0].ImagePath); err != nil {
-		t.Fatalf("saved upload missing at %q: %v", msg.Parts[0].ImagePath, err)
+	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
+	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
+		t.Fatalf("uploads dir stat err = %v, want not exist for inline image upload", err)
 	}
 	if msg.Parts[1].Type != llm.PartText {
 		t.Fatalf("parts[1].type = %s, want text", msg.Parts[1].Type)


### PR DESCRIPTION
## What

Stop persisting inline LLM-native image uploads to the uploads directory on the request hot path, and stop decoding their base64 payload twice.

This change:
- decodes inline image uploads once for size validation and optional resize/compression
- keeps LLM-native images inline in the request instead of writing an original copy to disk first
- leaves non-image / non-native upload handling unchanged
- adds coverage that inline image uploads no longer touch the uploads directory

## Why

Large or multi-image prompts were doing unnecessary work before any provider request started:
- one full base64 decode inside `saveUploadedFile`
- a second full base64 decode immediately afterward for resize decisions
- synchronous filesystem writes of the original image even though the provider only needed the inline payload

Removing that extra decode and hot-path disk write reduces CPU, memory churn, and request latency for web image uploads while preserving existing file-upload behavior for attachments that still need a saved path.
