### PR TITLE
fix: Inline image uploads are decoded twice and always synchronously written to disk before the model call

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"net/http"
 	"os"
@@ -108,9 +107,34 @@ const (
 	maxAttachmentBytes = 20 << 20 // 20 MB per file (decoded)
 )
 
+func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return nil, fmt.Errorf("decode base64: %w", err)
+	}
+	if len(raw) > maxAttachmentBytes {
+		return nil, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+	return raw, nil
+}
+
 // saveUploadedFile decodes base64 data and writes it to the uploads directory,
-// returning the full filesystem path. Uses O_CREATE|O_EXCL for atomic uniqueness.
+// returning the full filesystem path.
 func saveUploadedFile(filename, b64Data string) (string, error) {
+	raw, err := decodeUploadedFile(filename, b64Data)
+	if err != nil {
+		return "", err
+	}
+	return saveUploadedBytes(filename, raw)
+}
+
+// saveUploadedBytes writes decoded upload data to the uploads directory,
+// returning the full filesystem path. Uses O_CREATE|O_EXCL for atomic uniqueness.
+func saveUploadedBytes(filename string, raw []byte) (string, error) {
+	if len(raw) > maxAttachmentBytes {
+		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+
 	dataDir, err := session.GetDataDir()
 	if err != nil {
 		return "", fmt.Errorf("get data dir: %w", err)
@@ -118,14 +142,6 @@ func saveUploadedFile(filename, b64Data string) (string, error) {
 	uploadsDir := filepath.Join(dataDir, "uploads")
 	if err := os.MkdirAll(uploadsDir, 0o700); err != nil {
 		return "", fmt.Errorf("create uploads dir: %w", err)
-	}
-
-	raw, err := base64.StdEncoding.DecodeString(b64Data)
-	if err != nil {
-		return "", fmt.Errorf("decode base64: %w", err)
-	}
-	if len(raw) > maxAttachmentBytes {
-		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
 	}
 
 	safeName := filepath.Base(filename)
@@ -173,12 +189,11 @@ func abbreviatePath(path string) string {
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
-// Supported image types are sent inline to the LLM; all other files are saved to disk
+// Supported image types are kept inline for the LLM; all other files are saved to disk
 // and referenced by path in a text part.
 //
-// All uploaded images are saved to disk unconditionally as originals before any
-// processing. Images exceeding 1 MB are resized/compressed before being sent to
-// the LLM to avoid provider errors.
+// Images exceeding 1 MB are resized/compressed before being sent to the LLM to
+// avoid provider errors.
 func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	var parts []map[string]json.RawMessage
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
@@ -207,27 +222,12 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					if fileCount > maxAttachments {
 						return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
 					}
-					// Always save the original to disk first.
 					if filename == "" {
 						filename = "image"
 					}
-					path, err := saveUploadedFile(filename, b64)
+					raw, err := decodeUploadedFile(filename, b64)
 					if err != nil {
-						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
-					}
-					savedPath := path
-
-					// Decode raw bytes for possible resize.
-					raw, err := base64.StdEncoding.DecodeString(b64)
-					if err != nil {
-						// Shouldn't happen — b64 was just parsed — but fall back gracefully.
-						log.Printf("[web] warning: base64 re-decode failed for %q: %v", filename, err)
-						llmParts = append(llmParts, llm.Part{
-							Type:      llm.PartImage,
-							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
-							ImagePath: savedPath,
-						})
-						continue
+						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
 					}
 
 					// Resize if over 1 MB before sending to the model.
@@ -239,7 +239,6 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					llmParts = append(llmParts, llm.Part{
 						Type:      llm.PartImage,
 						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64},
-						ImagePath: savedPath,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -926,11 +926,20 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
 		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
 	}
-	if msg.Parts[0].ImagePath == "" {
-		t.Fatal("parts[0].ImagePath = empty, want saved upload path")
+	if msg.Parts[0].ImagePath != "" {
+		t.Fatalf("parts[0].ImagePath = %q, want empty for inline LLM image", msg.Parts[0].ImagePath)
 	}
-	if _, err := os.Stat(msg.Parts[0].ImagePath); err != nil {
-		t.Fatalf("saved upload missing at %q: %v", msg.Parts[0].ImagePath, err)
+	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
+	if _, err := os.Stat(uploadsDir); err == nil {
+		entries, readErr := os.ReadDir(uploadsDir)
+		if readErr != nil {
+			t.Fatalf("read uploads dir: %v", readErr)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("uploads dir has %d files, want 0 for inline LLM image", len(entries))
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat uploads dir: %v", err)
 	}
 	if msg.Parts[1].Type != llm.PartText {
 		t.Fatalf("parts[1].type = %s, want text", msg.Parts[1].Type)


### PR DESCRIPTION
## What

- stop saving LLM-native inline image uploads to disk on the request path before the provider call
- decode inline image base64 once, reuse the decoded bytes for size validation and optional resize, and only re-encode if the resized payload changed
- keep the existing save-to-disk behavior for non-native images and file uploads, and update coverage to assert inline LLM images no longer create upload files

## Why

The old upload path decoded every inline image once to save it, then decoded the same base64 again to decide whether it needed resizing, and sometimes encoded it a third time. It also always performed a blocking disk write before the model request even for image types the providers already accept inline. That adds avoidable CPU, memory copying, and filesystem latency to large or multi-image requests. This change keeps the same user-visible behavior for real file uploads while removing the extra decode and synchronous disk write from the hot path for inline LLM images.
