### PR TITLE
fix: Web UI turns every attachment into base64 data URLs and keeps multiple full copies in memory

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -938,12 +938,13 @@ const createMessageNode = (message) => {
       const attDiv = document.createElement('div');
       attDiv.className = 'message-attachments';
       message.attachments.forEach(att => {
-        if (att.type && att.type.startsWith('image/') && att.dataURL) {
+        const previewURL = att.previewURL || att.dataURL || '';
+        if (att.type && att.type.startsWith('image/') && previewURL) {
           const img = document.createElement('img');
-          img.src = att.dataURL;
+          img.src = previewURL;
           img.alt = att.name || 'Attached image';
           img.style.cursor = 'pointer';
-          img.addEventListener('click', () => app.openLightbox(att.dataURL));
+          img.addEventListener('click', () => app.openLightbox(previewURL));
           attDiv.appendChild(img);
         } else {
           const badge = document.createElement('span');

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -11,7 +11,7 @@ const {
   connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, isNearBottom,
   openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
   requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD, HEARTBEAT_ABORT_REASON,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, renderAttachments,
+  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, renderAttachments, discardPendingAttachments,
   updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
   moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
   trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner
@@ -155,8 +155,7 @@ const switchToDraftSession = async (options = {}) => {
 
   if (options.clearComposer) {
     elements.promptInput.value = '';
-    state.attachments = [];
-    renderAttachments();
+    discardPendingAttachments();
     autoGrowPrompt();
   }
 

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2425,6 +2425,104 @@ const autoGrowPrompt = () => {
 };
 
 // ===== File attachment =====
+const getAttachmentPreviewURL = (att) => String(att?.previewURL || att?.dataURL || '');
+
+const createAttachmentPreviewURL = (file) => {
+  const urlAPI = window.URL || globalThis.URL;
+  if (!urlAPI || typeof urlAPI.createObjectURL !== 'function') return '';
+  try {
+    return urlAPI.createObjectURL(file);
+  } catch {
+    return '';
+  }
+};
+
+const revokeAttachmentPreviewURL = (att) => {
+  const previewURL = String(att?.previewURL || '');
+  if (!previewURL || previewURL === att?.dataURL) return;
+  const urlAPI = window.URL || globalThis.URL;
+  if (!urlAPI || typeof urlAPI.revokeObjectURL !== 'function') return;
+  try {
+    urlAPI.revokeObjectURL(previewURL);
+  } catch {
+    // Ignore preview cleanup failures.
+  }
+};
+
+const discardPendingAttachments = () => {
+  state.attachments.forEach(revokeAttachmentPreviewURL);
+  state.attachments = [];
+  renderAttachments();
+};
+
+const readFileAsDataURL = (file, signal) => new Promise((resolve, reject) => {
+  if (!file) {
+    resolve('');
+    return;
+  }
+  if (signal?.aborted) {
+    reject(new DOMException('The operation was aborted.', 'AbortError'));
+    return;
+  }
+  if (typeof FileReader !== 'function') {
+    reject(new Error('File uploads are not supported in this browser.'));
+    return;
+  }
+
+  const reader = new FileReader();
+  if (typeof reader.readAsDataURL !== 'function') {
+    reject(new Error('File uploads are not supported in this browser.'));
+    return;
+  }
+  let settled = false;
+
+  const cleanupAbort = () => {
+    if (signal) signal.removeEventListener('abort', handleAbort);
+  };
+
+  const fail = (err) => {
+    if (settled) return;
+    settled = true;
+    cleanupAbort();
+    reject(err);
+  };
+
+  const succeed = (value) => {
+    if (settled) return;
+    settled = true;
+    cleanupAbort();
+    resolve(value);
+  };
+
+  const handleAbort = () => {
+    try {
+      reader.abort();
+    } catch {
+      fail(new DOMException('The operation was aborted.', 'AbortError'));
+    }
+  };
+
+  if (signal) signal.addEventListener('abort', handleAbort, { once: true });
+
+  reader.onload = () => succeed(typeof reader.result === 'string' ? reader.result : '');
+  reader.onerror = () => fail(reader.error || new Error(`Failed to read ${file.name || 'attachment'}.`));
+  reader.onabort = () => fail(new DOMException('The operation was aborted.', 'AbortError'));
+  reader.readAsDataURL(file);
+});
+
+const materializeAttachmentDataURL = async (att, signal) => {
+  if (att?.dataURL) return att.dataURL;
+  const dataURL = await readFileAsDataURL(att?.file, signal);
+  if (!dataURL) {
+    throw new Error(`Failed to read ${att?.name || 'attachment'}.`);
+  }
+  att.dataURL = dataURL;
+  revokeAttachmentPreviewURL(att);
+  att.previewURL = dataURL;
+  delete att.file;
+  return dataURL;
+};
+
 const renderAttachments = () => {
   const strip = elements.attachmentsStrip;
   strip.innerHTML = '';
@@ -2438,10 +2536,13 @@ const renderAttachments = () => {
     chip.className = 'attachment-chip';
 
     if (att.type.startsWith('image/')) {
-      const img = document.createElement('img');
-      img.src = att.dataURL;
-      img.alt = att.name;
-      chip.appendChild(img);
+      const previewURL = getAttachmentPreviewURL(att);
+      if (previewURL) {
+        const img = document.createElement('img');
+        img.src = previewURL;
+        img.alt = att.name;
+        chip.appendChild(img);
+      }
     }
 
     const name = document.createElement('span');
@@ -2455,6 +2556,7 @@ const renderAttachments = () => {
     remove.textContent = '\u00d7';
     remove.title = 'Remove';
     remove.addEventListener('click', () => {
+      revokeAttachmentPreviewURL(att);
       state.attachments = state.attachments.filter(a => a.id !== att.id);
       renderAttachments();
     });
@@ -2478,20 +2580,15 @@ const handleFiles = (fileList) => {
       alert(`${file.name} exceeds the 20 MB file size limit.`);
       continue;
     }
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (state.attachments.length >= MAX_ATTACHMENTS) return;
-      const dataURL = reader.result;
-      state.attachments.push({
-        id: generateId('att'),
-        name: file.name,
-        type: file.type || 'application/octet-stream',
-        size: file.size,
-        dataURL
-      });
-      renderAttachments();
-    };
-    reader.readAsDataURL(file);
+    state.attachments.push({
+      id: generateId('att'),
+      name: file.name,
+      type: file.type || 'application/octet-stream',
+      size: file.size,
+      file,
+      previewURL: createAttachmentPreviewURL(file)
+    });
+    renderAttachments();
   }
 };
 
@@ -2950,11 +3047,7 @@ const sendMessage = async (options = {}) => {
   session.lastMessageAt = Date.now();
 
   if (pendingAttachments.length > 0) {
-    userMessage.attachments = pendingAttachments.map(a => ({
-      name: a.name,
-      type: a.type,
-      dataURL: a.dataURL
-    }));
+    userMessage.attachments = pendingAttachments.slice();
   } else {
     delete userMessage.attachments;
   }
@@ -2992,76 +3085,80 @@ const sendMessage = async (options = {}) => {
   app.refreshSidebarStatusPoll?.();
   const streamState = createResponseStreamState(session);
 
-  // Build input content: plain string or array with file/image parts
-  let inputContent;
-  if (pendingAttachments.length > 0) {
-    const contentParts = [];
-    for (const att of pendingAttachments) {
-      if (att.type.startsWith('image/')) {
-        contentParts.push({ type: 'input_image', image_url: att.dataURL, filename: att.name });
-      } else {
-        contentParts.push({ type: 'input_file', file_data: att.dataURL, filename: att.name });
+  try {
+    // Build input content: plain string or array with file/image parts
+    let inputContent;
+    if (pendingAttachments.length > 0) {
+      for (const att of pendingAttachments) {
+        await materializeAttachmentDataURL(att, controller.signal);
+      }
+
+      const contentParts = [];
+      for (const att of pendingAttachments) {
+        if (att.type.startsWith('image/')) {
+          contentParts.push({ type: 'input_image', image_url: att.dataURL, filename: att.name });
+        } else {
+          contentParts.push({ type: 'input_file', file_data: att.dataURL, filename: att.name });
+        }
+      }
+      if (prompt) {
+        contentParts.push({ type: 'input_text', text: prompt });
+      }
+      inputContent = contentParts;
+    } else {
+      inputContent = prompt;
+    }
+
+    const body = {
+      stream: true,
+      input: [{ type: 'message', role: 'user', content: inputContent }]
+    };
+
+    if (session.lastResponseId) {
+      body.previous_response_id = session.lastResponseId;
+    } else if (session.messages.length > 1) {
+      body.input = rebuildInputFromSession(session, inputContent);
+    }
+
+    const normalizeEffortForCompare = (value) => {
+      const normalized = String(value || '').trim();
+      return normalized.toLowerCase() === 'default' ? '' : normalized;
+    };
+    const currentProvider = session.provider || '';
+    const currentModel = session.activeModel || '';
+    const currentEffort = session.activeEffort || '';
+    const targetProvider = state.selectedProvider || currentProvider;
+    const targetModel = state.selectedModel || currentModel;
+    const targetEffort = state.selectedEffort || '';
+    const hasPriorContext = Boolean(session.lastResponseId || session.messages.length > 1);
+    const targetDiffers = hasPriorContext && Boolean(
+      (targetProvider || '') !== (currentProvider || '')
+      || (targetModel || '') !== (currentModel || '')
+      || normalizeEffortForCompare(targetEffort) !== normalizeEffortForCompare(currentEffort)
+    );
+
+    if (targetModel) {
+      body.model = targetModel;
+    }
+    if (targetDiffers) {
+      body.provider = targetProvider || currentProvider;
+      if (targetEffort) {
+        body.reasoning_effort = targetEffort;
+      }
+      body.model_swap = { mode: 'auto', fallback: 'handover' };
+    } else {
+      const activeEffort = currentEffort || state.selectedEffort;
+      if (activeEffort) {
+        body.reasoning_effort = activeEffort;
+      }
+      if (!session.provider && state.selectedProvider) {
+        session.provider = state.selectedProvider;
+      }
+      if (session.provider) {
+        body.provider = session.provider;
       }
     }
-    if (prompt) {
-      contentParts.push({ type: 'input_text', text: prompt });
-    }
-    inputContent = contentParts;
-  } else {
-    inputContent = prompt;
-  }
 
-  const body = {
-    stream: true,
-    input: [{ type: 'message', role: 'user', content: inputContent }]
-  };
-
-  if (session.lastResponseId) {
-    body.previous_response_id = session.lastResponseId;
-  } else if (session.messages.length > 1) {
-    body.input = rebuildInputFromSession(session, inputContent);
-  }
-
-  const normalizeEffortForCompare = (value) => {
-    const normalized = String(value || '').trim();
-    return normalized.toLowerCase() === 'default' ? '' : normalized;
-  };
-  const currentProvider = session.provider || '';
-  const currentModel = session.activeModel || '';
-  const currentEffort = session.activeEffort || '';
-  const targetProvider = state.selectedProvider || currentProvider;
-  const targetModel = state.selectedModel || currentModel;
-  const targetEffort = state.selectedEffort || '';
-  const hasPriorContext = Boolean(session.lastResponseId || session.messages.length > 1);
-  const targetDiffers = hasPriorContext && Boolean(
-    (targetProvider || '') !== (currentProvider || '')
-    || (targetModel || '') !== (currentModel || '')
-    || normalizeEffortForCompare(targetEffort) !== normalizeEffortForCompare(currentEffort)
-  );
-
-  if (targetModel) {
-    body.model = targetModel;
-  }
-  if (targetDiffers) {
-    body.provider = targetProvider || currentProvider;
-    if (targetEffort) {
-      body.reasoning_effort = targetEffort;
-    }
-    body.model_swap = { mode: 'auto', fallback: 'handover' };
-  } else {
-    const activeEffort = currentEffort || state.selectedEffort;
-    if (activeEffort) {
-      body.reasoning_effort = activeEffort;
-    }
-    if (!session.provider && state.selectedProvider) {
-      session.provider = state.selectedProvider;
-    }
-    if (session.provider) {
-      body.provider = session.provider;
-    }
-  }
-
-  try {
     let response = await fetch(`${UI_PREFIX}/v1/responses`, {
       method: 'POST',
       headers: {
@@ -3252,6 +3349,7 @@ Object.assign(app, {
   stopVoiceRecording,
   toggleVoiceRecording,
   renderAttachments,
+  discardPendingAttachments,
   MAX_ATTACHMENTS,
   MAX_FILE_BYTES,
   handleFiles,

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -390,6 +390,8 @@ function createHarness(options = {}) {
   };
 
   const encoder = new TextEncoder();
+  const fileReaderClass = options.FileReader || class {};
+  const urlAPI = options.urlAPI || URL;
   const context = {
     window: windowObj,
     document,
@@ -406,19 +408,20 @@ function createHarness(options = {}) {
     ReadableStream,
     Response,
     Headers,
-    URL,
+    URL: urlAPI,
     URLSearchParams,
     Blob,
     performance: { now: () => Date.now() },
     navigator: { mediaDevices: null },
     MediaRecorder: undefined,
-    FileReader: class {},
+    FileReader: fileReaderClass,
     alert() {},
     crypto: webcrypto,
   };
   context.globalThis = context;
   windowObj.document = document;
   windowObj.localStorage = localStorage;
+  windowObj.URL = urlAPI;
   windowObj.fetch = async function fetch(url, options = {}) {
     fetchCalls.push({
       url,
@@ -1686,8 +1689,150 @@ async function testArgumentDeltaWithoutOutputIndexUsesLastRunningTool() {
   pass(name);
 }
 
+async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
+  const name = 'sendMessage lazily materializes attachment data URLs only when sending';
+  let readCount = 0;
+  const revokedURLs = [];
+
+  class MockFileReader {
+    constructor() {
+      this.result = null;
+      this.error = null;
+      this.onload = null;
+      this.onerror = null;
+      this.onabort = null;
+    }
+
+    readAsDataURL(file) {
+      readCount += 1;
+      this.result = file.mockDataURL;
+      setTimeout(() => {
+        if (this.onload) this.onload();
+      }, 0);
+    }
+
+    abort() {
+      if (this.onabort) this.onabort();
+    }
+  }
+
+  const harness = createHarness({
+    FileReader: MockFileReader,
+    urlAPI: {
+      createObjectURL(file) {
+        return `blob:${file.name}`;
+      },
+      revokeObjectURL(url) {
+        revokedURLs.push(url);
+      }
+    }
+  });
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+
+  const file = {
+    name: 'cat.png',
+    type: 'image/png',
+    size: 4,
+    mockDataURL: 'data:image/png;base64,Y2F0'
+  };
+
+  app.handleFiles([file]);
+
+  if (readCount !== 0) {
+    fail(name, `expected FileReader reads before send = 0, got ${readCount}`);
+    await cleanup();
+    return;
+  }
+  if (state.attachments.length !== 1) {
+    fail(name, `expected 1 pending attachment, got ${state.attachments.length}`);
+    await cleanup();
+    return;
+  }
+  if (state.attachments[0].dataURL) {
+    fail(name, 'pending attachment should not store a dataURL before send', JSON.stringify(state.attachments[0]));
+    await cleanup();
+    return;
+  }
+  if (state.attachments[0].previewURL !== 'blob:cat.png') {
+    fail(name, `previewURL = ${JSON.stringify(state.attachments[0].previewURL)}, want "blob:cat.png"`);
+    await cleanup();
+    return;
+  }
+
+  elements.promptInput.value = 'describe this image';
+  await app.sendMessage();
+
+  if (readCount !== 1) {
+    fail(name, `expected FileReader reads after send = 1, got ${readCount}`);
+    await cleanup();
+    return;
+  }
+  if (state.attachments.length !== 0) {
+    fail(name, `expected pending attachments to be cleared after send, got ${state.attachments.length}`);
+    await cleanup();
+    return;
+  }
+  if (!revokedURLs.includes('blob:cat.png')) {
+    fail(name, 'expected blob preview URL to be revoked after send', JSON.stringify(revokedURLs));
+    await cleanup();
+    return;
+  }
+
+  const session = state.sessions[0];
+  const userMessage = session && session.messages.find((message) => message.role === 'user');
+  const storedAttachment = userMessage && userMessage.attachments && userMessage.attachments[0];
+  if (!storedAttachment) {
+    fail(name, 'expected stored user attachment after send', JSON.stringify(session));
+    await cleanup();
+    return;
+  }
+  if (storedAttachment.dataURL !== file.mockDataURL) {
+    fail(name, `stored attachment dataURL = ${JSON.stringify(storedAttachment.dataURL)}, want ${JSON.stringify(file.mockDataURL)}`);
+    await cleanup();
+    return;
+  }
+  if (storedAttachment.previewURL !== file.mockDataURL) {
+    fail(name, `stored attachment previewURL = ${JSON.stringify(storedAttachment.previewURL)}, want ${JSON.stringify(file.mockDataURL)}`);
+    await cleanup();
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(storedAttachment, 'file')) {
+    fail(name, 'stored attachment should drop the original File reference after materializing', JSON.stringify(storedAttachment));
+    await cleanup();
+    return;
+  }
+
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (!postCall || !postCall.body) {
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    await cleanup();
+    return;
+  }
+
+  let body;
+  try {
+    body = JSON.parse(postCall.body);
+  } catch (err) {
+    fail(name, 'response POST body was not valid JSON', String(err));
+    await cleanup();
+    return;
+  }
+
+  const parts = body.input?.[0]?.content;
+  const imagePart = Array.isArray(parts) ? parts.find((part) => part.type === 'input_image') : null;
+  if (!imagePart || imagePart.image_url !== file.mockDataURL) {
+    fail(name, 'request body should include lazily materialized image data URL', JSON.stringify(body));
+    await cleanup();
+    return;
+  }
+
+  await cleanup();
+  pass(name);
+}
+
 (async () => {
   await testSendMessageConsumesPostStreamWhenAvailable();
+  await testSendMessageLazilyMaterializesAttachmentDataURLs();
   await testSendMessageResumesFromEventsAfterPostStreamDrops();
   await testNewChatDuringStreamingClearsStreamingState();
   await testSendMessageMarksSessionBusyImmediately();


### PR DESCRIPTION
## What

Stop the Web UI from eagerly base64-encoding selected attachments in the composer.

This keeps pending attachments as `File` objects plus lightweight preview URLs, then only materializes a data URL at send time. The sent user message now reuses the same attachment objects instead of cloning another full base64 copy, and image rendering accepts either a preview URL or a data URL. Clearing a draft composer also revokes any pending blob preview URLs.

Also add a regression test covering the lazy attachment path.

## Why

The old flow created multiple full in-memory copies of every attachment before upload even began:

1. `handleFiles` read each file into a base64 data URL immediately
2. that payload was stored in `state.attachments`
3. it was copied again into `userMessage.attachments`
4. and then copied again into the JSON request body

That made large or multi-image prompts slower and much more memory-hungry in the Web UI. This change defers the expensive conversion until send time and removes the extra persistent copies while preserving previews and resend/rebuild behavior.
