### PR TITLE
fix: Inline image uploads are decoded twice and synchronously written to disk before provider upload starts

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"net/http"
 	"os"
@@ -108,6 +107,17 @@ const (
 	maxAttachmentBytes = 20 << 20 // 20 MB per file (decoded)
 )
 
+func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return nil, fmt.Errorf("decode base64: %w", err)
+	}
+	if len(raw) > maxAttachmentBytes {
+		return nil, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+	return raw, nil
+}
+
 // saveUploadedFile decodes base64 data and writes it to the uploads directory,
 // returning the full filesystem path. Uses O_CREATE|O_EXCL for atomic uniqueness.
 func saveUploadedFile(filename, b64Data string) (string, error) {
@@ -120,12 +130,9 @@ func saveUploadedFile(filename, b64Data string) (string, error) {
 		return "", fmt.Errorf("create uploads dir: %w", err)
 	}
 
-	raw, err := base64.StdEncoding.DecodeString(b64Data)
+	raw, err := decodeUploadedFile(filename, b64Data)
 	if err != nil {
-		return "", fmt.Errorf("decode base64: %w", err)
-	}
-	if len(raw) > maxAttachmentBytes {
-		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+		return "", err
 	}
 
 	safeName := filepath.Base(filename)
@@ -173,12 +180,11 @@ func abbreviatePath(path string) string {
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
-// Supported image types are sent inline to the LLM; all other files are saved to disk
-// and referenced by path in a text part.
+// Supported image types stay in memory and are sent inline to the LLM; all other
+// uploads are saved to disk and referenced by path in a text part.
 //
-// All uploaded images are saved to disk unconditionally as originals before any
-// processing. Images exceeding 1 MB are resized/compressed before being sent to
-// the LLM to avoid provider errors.
+// Images exceeding 1 MB are resized/compressed before being sent to the LLM to
+// avoid provider errors.
 func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	var parts []map[string]json.RawMessage
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
@@ -207,27 +213,13 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					if fileCount > maxAttachments {
 						return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
 					}
-					// Always save the original to disk first.
 					if filename == "" {
 						filename = "image"
 					}
-					path, err := saveUploadedFile(filename, b64)
-					if err != nil {
-						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
-					}
-					savedPath := path
 
-					// Decode raw bytes for possible resize.
-					raw, err := base64.StdEncoding.DecodeString(b64)
+					raw, err := decodeUploadedFile(filename, b64)
 					if err != nil {
-						// Shouldn't happen — b64 was just parsed — but fall back gracefully.
-						log.Printf("[web] warning: base64 re-decode failed for %q: %v", filename, err)
-						llmParts = append(llmParts, llm.Part{
-							Type:      llm.PartImage,
-							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
-							ImagePath: savedPath,
-						})
-						continue
+						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
 					}
 
 					// Resize if over 1 MB before sending to the model.
@@ -239,7 +231,6 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					llmParts = append(llmParts, llm.Part{
 						Type:      llm.PartImage,
 						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64},
-						ImagePath: savedPath,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -926,11 +926,12 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
 		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
 	}
-	if msg.Parts[0].ImagePath == "" {
-		t.Fatal("parts[0].ImagePath = empty, want saved upload path")
+	if msg.Parts[0].ImagePath != "" {
+		t.Fatalf("parts[0].ImagePath = %q, want empty for inline image", msg.Parts[0].ImagePath)
 	}
-	if _, err := os.Stat(msg.Parts[0].ImagePath); err != nil {
-		t.Fatalf("saved upload missing at %q: %v", msg.Parts[0].ImagePath, err)
+	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
+	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
+		t.Fatalf("inline image unexpectedly wrote uploads dir %q: %v", uploadsDir, err)
 	}
 	if msg.Parts[1].Type != llm.PartText {
 		t.Fatalf("parts[1].type = %s, want text", msg.Parts[1].Type)


### PR DESCRIPTION
## What

Stop saving supported inline images to disk during `parseUserMessageContent`, and decode them only once in-memory before optional resize/compression for the provider payload.

## Why

Supported inline images already travel upstream as base64 image parts, so writing the original to disk on the request hot path was unnecessary work. This change removes blocking filesystem I/O for those uploads and avoids a second full base64 decode/allocation before image-generation or edit requests are sent.
