### PR TITLE
perf: avoid string cache keys in chat renderer

### DIFF
--- a/internal/render/chat/cache.go
+++ b/internal/render/chat/cache.go
@@ -7,18 +7,28 @@ import (
 
 const maxBlockCacheSize = 2000
 
+// blockCacheKey identifies a cached render without allocating per-frame key
+// strings. It is intentionally fixed-width/comparable so map lookups in the
+// hot View() path don't need strconv or string concatenation for every message.
+type blockCacheKey struct {
+	messageID      int64
+	width          int
+	toolsExpanded  bool
+	partsSignature uint64
+}
+
 // BlockCache is an LRU cache for rendered MessageBlocks.
 // It keeps memory bounded while avoiding re-rendering unchanged messages.
 type BlockCache struct {
 	mu      sync.RWMutex
 	maxSize int
-	cache   map[string]*list.Element
+	cache   map[blockCacheKey]*list.Element
 	lruList *list.List
 }
 
 // cacheEntry holds a cache key-value pair for the LRU list.
 type cacheEntry struct {
-	key   string
+	key   blockCacheKey
 	block *MessageBlock
 }
 
@@ -32,14 +42,14 @@ func NewBlockCache(maxSize int) *BlockCache {
 	}
 	return &BlockCache{
 		maxSize: maxSize,
-		cache:   make(map[string]*list.Element),
+		cache:   make(map[blockCacheKey]*list.Element),
 		lruList: list.New(),
 	}
 }
 
 // Get retrieves a block from the cache, returning nil if not found.
 // Accessing a block moves it to the front of the LRU list.
-func (c *BlockCache) Get(key string) *MessageBlock {
+func (c *BlockCache) Get(key blockCacheKey) *MessageBlock {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -53,7 +63,7 @@ func (c *BlockCache) Get(key string) *MessageBlock {
 
 // Put adds a block to the cache, evicting the least recently used
 // block if the cache is at capacity.
-func (c *BlockCache) Put(key string, block *MessageBlock) {
+func (c *BlockCache) Put(key blockCacheKey, block *MessageBlock) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -88,7 +98,7 @@ func (c *BlockCache) evictOldest() {
 }
 
 // Remove removes a specific key from the cache.
-func (c *BlockCache) Remove(key string) {
+func (c *BlockCache) Remove(key blockCacheKey) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -129,7 +139,7 @@ func (c *BlockCache) InvalidateAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.cache = make(map[string]*list.Element)
+	c.cache = make(map[blockCacheKey]*list.Element)
 	c.lruList.Init()
 }
 

--- a/internal/render/chat/cache_test.go
+++ b/internal/render/chat/cache_test.go
@@ -4,6 +4,14 @@ import (
 	"testing"
 )
 
+func testBlockCacheKey(id int64) blockCacheKey {
+	return blockCacheKey{
+		messageID:      id,
+		width:          80,
+		partsSignature: uint64(id),
+	}
+}
+
 func TestBlockCache_PutAndGet(t *testing.T) {
 	cache := NewBlockCache(3)
 
@@ -11,22 +19,25 @@ func TestBlockCache_PutAndGet(t *testing.T) {
 	block1 := &MessageBlock{MessageID: 1, Rendered: "block1", Height: 5}
 	block2 := &MessageBlock{MessageID: 2, Rendered: "block2", Height: 3}
 
-	cache.Put("key1", block1)
-	cache.Put("key2", block2)
+	key1 := testBlockCacheKey(1)
+	key2 := testBlockCacheKey(2)
+	key3 := testBlockCacheKey(3)
+	cache.Put(key1, block1)
+	cache.Put(key2, block2)
 
 	// Verify retrieval
-	got1 := cache.Get("key1")
+	got1 := cache.Get(key1)
 	if got1 == nil || got1.MessageID != 1 {
 		t.Errorf("Get(key1) = %v, want block1", got1)
 	}
 
-	got2 := cache.Get("key2")
+	got2 := cache.Get(key2)
 	if got2 == nil || got2.MessageID != 2 {
 		t.Errorf("Get(key2) = %v, want block2", got2)
 	}
 
 	// Non-existent key
-	got3 := cache.Get("key3")
+	got3 := cache.Get(key3)
 	if got3 != nil {
 		t.Errorf("Get(key3) = %v, want nil", got3)
 	}
@@ -35,28 +46,33 @@ func TestBlockCache_PutAndGet(t *testing.T) {
 func TestBlockCache_LRUEviction(t *testing.T) {
 	cache := NewBlockCache(3)
 
+	keyA := testBlockCacheKey(1)
+	keyB := testBlockCacheKey(2)
+	keyC := testBlockCacheKey(3)
+	keyD := testBlockCacheKey(4)
+
 	// Fill the cache
-	cache.Put("a", &MessageBlock{MessageID: 1})
-	cache.Put("b", &MessageBlock{MessageID: 2})
-	cache.Put("c", &MessageBlock{MessageID: 3})
+	cache.Put(keyA, &MessageBlock{MessageID: 1})
+	cache.Put(keyB, &MessageBlock{MessageID: 2})
+	cache.Put(keyC, &MessageBlock{MessageID: 3})
 
 	// Access "a" to make it recently used
-	cache.Get("a")
+	cache.Get(keyA)
 
 	// Add a new item, should evict "b" (least recently used)
-	cache.Put("d", &MessageBlock{MessageID: 4})
+	cache.Put(keyD, &MessageBlock{MessageID: 4})
 
 	// "a" and "c" should still be there, "b" should be evicted
-	if cache.Get("a") == nil {
+	if cache.Get(keyA) == nil {
 		t.Error("'a' should not have been evicted")
 	}
-	if cache.Get("c") == nil {
+	if cache.Get(keyC) == nil {
 		t.Error("'c' should not have been evicted")
 	}
-	if cache.Get("d") == nil {
+	if cache.Get(keyD) == nil {
 		t.Error("'d' should be in cache")
 	}
-	if cache.Get("b") != nil {
+	if cache.Get(keyB) != nil {
 		t.Error("'b' should have been evicted")
 	}
 }
@@ -64,13 +80,14 @@ func TestBlockCache_LRUEviction(t *testing.T) {
 func TestBlockCache_Update(t *testing.T) {
 	cache := NewBlockCache(3)
 
+	key := testBlockCacheKey(1)
 	block1 := &MessageBlock{MessageID: 1, Rendered: "original"}
 	block2 := &MessageBlock{MessageID: 1, Rendered: "updated"}
 
-	cache.Put("key", block1)
-	cache.Put("key", block2)
+	cache.Put(key, block1)
+	cache.Put(key, block2)
 
-	got := cache.Get("key")
+	got := cache.Get(key)
 	if got == nil || got.Rendered != "updated" {
 		t.Errorf("Get(key).Rendered = %v, want 'updated'", got)
 	}
@@ -84,10 +101,11 @@ func TestBlockCache_Update(t *testing.T) {
 func TestBlockCache_Remove(t *testing.T) {
 	cache := NewBlockCache(3)
 
-	cache.Put("key", &MessageBlock{MessageID: 1})
-	cache.Remove("key")
+	key := testBlockCacheKey(1)
+	cache.Put(key, &MessageBlock{MessageID: 1})
+	cache.Remove(key)
 
-	if cache.Get("key") != nil {
+	if cache.Get(key) != nil {
 		t.Error("Get(key) after Remove should return nil")
 	}
 	if cache.Size() != 0 {
@@ -117,7 +135,7 @@ func TestBlockCache_InvalidateAll(t *testing.T) {
 	cache := NewBlockCache(10)
 
 	for i := 0; i < 5; i++ {
-		cache.Put(string(rune('a'+i)), &MessageBlock{MessageID: int64(i)})
+		cache.Put(testBlockCacheKey(int64(i)), &MessageBlock{MessageID: int64(i)})
 	}
 
 	if cache.Size() != 5 {
@@ -132,8 +150,8 @@ func TestBlockCache_InvalidateAll(t *testing.T) {
 
 	// Verify all keys are gone
 	for i := 0; i < 5; i++ {
-		if cache.Get(string(rune('a'+i))) != nil {
-			t.Errorf("Key %c should be nil after InvalidateAll", 'a'+i)
+		if cache.Get(testBlockCacheKey(int64(i))) != nil {
+			t.Errorf("Key %d should be nil after InvalidateAll", i)
 		}
 	}
 }
@@ -145,7 +163,7 @@ func TestBlockCache_ConcurrentAccess(t *testing.T) {
 	// Writer goroutine
 	go func() {
 		for i := 0; i < 1000; i++ {
-			cache.Put(string(rune(i%100)), &MessageBlock{MessageID: int64(i)})
+			cache.Put(testBlockCacheKey(int64(i%100)), &MessageBlock{MessageID: int64(i)})
 		}
 		done <- true
 	}()
@@ -153,7 +171,7 @@ func TestBlockCache_ConcurrentAccess(t *testing.T) {
 	// Reader goroutine
 	go func() {
 		for i := 0; i < 1000; i++ {
-			cache.Get(string(rune(i % 100)))
+			cache.Get(testBlockCacheKey(int64(i % 100)))
 		}
 		done <- true
 	}()

--- a/internal/render/chat/renderer.go
+++ b/internal/render/chat/renderer.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"strconv"
 	"strings"
 	"sync"
 
@@ -405,12 +404,13 @@ func (r *Renderer) getOrRenderBlock(msg *session.Message, index int, messages []
 // blockCacheKey generates a cache key for a message.
 // Key includes a content fingerprint, not just message ID, so stale blocks
 // cannot survive same-ID content changes.
-func (r *Renderer) blockCacheKey(msg *session.Message, index int) string {
-	expanded := "0"
-	if r.toolsExpanded {
-		expanded = "1"
+func (r *Renderer) blockCacheKey(msg *session.Message, index int) blockCacheKey {
+	return blockCacheKey{
+		messageID:      msg.ID,
+		width:          r.width,
+		toolsExpanded:  r.toolsExpanded,
+		partsSignature: r.cachedPartsSignature(msg),
 	}
-	return strconv.FormatInt(msg.ID, 10) + ":" + strconv.Itoa(r.width) + ":" + expanded + ":" + strconv.FormatUint(r.cachedPartsSignature(msg), 16)
 }
 
 // cachedPartsSignature returns the parts signature for a message, using a


### PR DESCRIPTION
## What

Replace rendered chat history `BlockCache` string keys with a fixed-width comparable struct key.

## Why

`Renderer.Render` checks the block cache for every visible/history message on each View() call. The previous key path formatted and concatenated strings for every message, even on warm-cache frames where no markdown was rendered. The new key preserves the same dimensions/content fingerprint while avoiding per-message `strconv` and string allocation work.

## Evidence

Focused benchmark on `internal/render/chat` (`go test ./internal/render/chat -run '^$' -bench 'BenchmarkRender500Messages(Cached)?$|BenchmarkRender500MessagesScrolling$' -benchmem`):

- Before: `BenchmarkRender500MessagesCached` ~170.7-178.9µs/op, ~663.3KB/op, 1421 allocs/op
- After: `BenchmarkRender500MessagesCached` ~141.4-149.0µs/op, ~638.9KB/op, 20 allocs/op

## Verification

- `go test ./internal/render/chat -run 'TestBlockCache|TestRenderer_BlockCacheKey'`
- `go test ./internal/render/chat`
- `go build ./...`
- `go test ./...`
