### PR TITLE
perf: reduce SSE streaming parser allocations

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -338,36 +338,131 @@ func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]ModelInfo, err
 }
 
 func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
-	line, err = reader.ReadString('\n')
+	lineBytes, eof, err := readSSELineBytes(reader)
 	if err != nil {
-		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-			return strings.TrimRight(line, "\r\n"), true, nil
-		}
 		return "", false, err
 	}
-	return strings.TrimRight(line, "\r\n"), false, nil
+	return string(lineBytes), eof, nil
 }
 
+func readSSELineBytes(reader *bufio.Reader) (line []byte, eof bool, err error) {
+	var owned []byte
+	for {
+		chunk, readErr := reader.ReadSlice('\n')
+		if len(chunk) > 0 {
+			if owned != nil {
+				owned = append(owned, chunk...)
+			} else if errors.Is(readErr, bufio.ErrBufferFull) {
+				owned = append(owned, chunk...)
+			} else {
+				line = chunk
+			}
+		}
+
+		switch {
+		case readErr == nil:
+			if owned != nil {
+				line = owned
+			}
+			return bytes.TrimRight(line, "\r\n"), false, nil
+		case errors.Is(readErr, bufio.ErrBufferFull):
+			continue
+		case errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF):
+			if owned != nil {
+				line = owned
+			} else if len(chunk) > 0 {
+				line = chunk
+			}
+			return bytes.TrimRight(line, "\r\n"), true, nil
+		default:
+			return nil, false, readErr
+		}
+	}
+}
+
+var (
+	sseEventField = []byte("event")
+	sseDataField  = []byte("data")
+	sseDoneData   = []byte("[DONE]")
+)
+
 func readSSEEvent(reader *bufio.Reader) (eventType, data string, eof bool, err error) {
-	var dataLines []string
+	var dataBuilder strings.Builder
+	dataLines := 0
+
+	appendData := func(value []byte) {
+		if dataLines == 0 {
+			data = string(value)
+			dataLines = 1
+			return
+		}
+		if dataLines == 1 {
+			dataBuilder.WriteString(data)
+			data = ""
+		}
+		dataBuilder.WriteByte('\n')
+		dataBuilder.Write(value)
+		dataLines++
+	}
 
 	for {
-		line, lineEOF, err := readSSELine(reader)
+		line, lineEOF, err := readSSELineBytes(reader)
 		if err != nil {
 			return "", "", false, err
 		}
-		if line == "" {
-			return eventType, strings.Join(dataLines, "\n"), lineEOF, nil
+		if len(line) == 0 {
+			if dataLines > 1 {
+				data = dataBuilder.String()
+			}
+			return eventType, data, lineEOF, nil
 		}
-		if strings.HasPrefix(line, "event:") {
-			eventType = strings.TrimPrefix(line, "event:")
-			eventType = strings.TrimPrefix(eventType, " ")
-		} else if strings.HasPrefix(line, "data:") {
-			dataLine := strings.TrimPrefix(line, "data:")
-			dataLines = append(dataLines, strings.TrimPrefix(dataLine, " "))
+		if i := bytes.IndexByte(line, ':'); i >= 0 {
+			field, value := line[:i], line[i+1:]
+			if len(value) > 0 && value[0] == ' ' {
+				value = value[1:]
+			}
+			switch {
+			case bytes.Equal(field, sseEventField):
+				eventType = string(value)
+			case bytes.Equal(field, sseDataField):
+				appendData(value)
+			}
 		}
 		if lineEOF {
-			return eventType, strings.Join(dataLines, "\n"), true, nil
+			if dataLines > 1 {
+				data = dataBuilder.String()
+			}
+			return eventType, data, true, nil
+		}
+	}
+}
+
+func readSSEEventBytes(reader *bufio.Reader) (eventType string, data []byte, eof bool, err error) {
+	for {
+		line, lineEOF, err := readSSELineBytes(reader)
+		if err != nil {
+			return "", nil, false, err
+		}
+		if len(line) == 0 {
+			return eventType, data, lineEOF, nil
+		}
+		if i := bytes.IndexByte(line, ':'); i >= 0 {
+			field, value := line[:i], line[i+1:]
+			if len(value) > 0 && value[0] == ' ' {
+				value = value[1:]
+			}
+			switch {
+			case bytes.Equal(field, sseEventField):
+				eventType = string(value)
+			case bytes.Equal(field, sseDataField):
+				if len(data) > 0 {
+					data = append(data, '\n')
+				}
+				data = append(data, value...)
+			}
+		}
+		if lineEOF {
+			return eventType, data, true, nil
 		}
 	}
 }
@@ -468,25 +563,25 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 		var reasoningBuilder strings.Builder
 
 		for {
-			eventType, data, eof, err := readSSEEvent(reader)
+			eventType, data, eof, err := readSSEEventBytes(reader)
 			if err != nil {
 				return fmt.Errorf("%s streaming error: %w", p.name, err)
 			}
-			if eof && eventType == "" && data == "" {
+			if eof && eventType == "" && len(data) == 0 {
 				break
 			}
-			if strings.TrimSpace(data) == "" {
+			if len(bytes.TrimSpace(data)) == 0 {
 				if eof {
 					break
 				}
 				continue
 			}
-			if data == "[DONE]" {
+			if bytes.Equal(data, sseDoneData) {
 				break
 			}
 
 			var chatResp oaiChatResponse
-			if err := json.Unmarshal([]byte(data), &chatResp); err != nil {
+			if err := json.Unmarshal(data, &chatResp); err != nil {
 				return fmt.Errorf("%s streaming error: invalid JSON chunk: %w", p.name, err)
 			}
 

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -714,7 +714,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		reader := bufio.NewReader(resp.Body)
 
 		var lastEventType string
-		var eventData []string
+		var eventData []byte
 		handler := newResponsesStreamEventHandler(client, responseStateGeneration, debugRaw, "Responses API SSE", !client.DisableServerState)
 
 		flushEvent := func() (bool, error) {
@@ -723,21 +723,22 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 				return false, nil
 			}
 
-			data := strings.Join(eventData, "\n")
+			data := eventData
 			eventType := lastEventType
-			eventData = nil
 			lastEventType = ""
 
-			return handler.HandleJSONEvent([]byte(data), eventType, send)
+			stop, err := handler.HandleJSONEvent(data, eventType, send)
+			eventData = data[:0]
+			return stop, err
 		}
 
 		for {
-			line, eof, err := readSSELine(reader)
+			line, eof, err := readSSELineBytes(reader)
 			if err != nil {
 				return fmt.Errorf("Responses API streaming error: %w", err)
 			}
 
-			if line == "" {
+			if len(line) == 0 {
 				stop, err := flushEvent()
 				if err != nil {
 					return err
@@ -748,12 +749,12 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 				continue
 			}
 
-			field, value, ok := strings.Cut(line, ":")
-			if ok {
-				if strings.HasPrefix(value, " ") {
+			if i := bytes.IndexByte(line, ':'); i >= 0 {
+				field, value := line[:i], line[i+1:]
+				if len(value) > 0 && value[0] == ' ' {
 					value = value[1:]
 				}
-				if field == "event" && len(eventData) > 0 {
+				if bytes.Equal(field, sseEventField) && len(eventData) > 0 {
 					stop, err := flushEvent()
 					if err != nil {
 						return err
@@ -762,7 +763,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 						break
 					}
 				}
-				if field == "data" && value == "[DONE]" && len(eventData) > 0 {
+				if bytes.Equal(field, sseDataField) && bytes.Equal(value, sseDoneData) && len(eventData) > 0 {
 					stop, err := flushEvent()
 					if err != nil {
 						return err
@@ -771,13 +772,16 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 						break
 					}
 				}
-				switch field {
-				case "event":
-					lastEventType = value
-				case "data":
-					eventData = append(eventData, value)
+				switch {
+				case bytes.Equal(field, sseEventField):
+					lastEventType = string(value)
+				case bytes.Equal(field, sseDataField):
+					if len(eventData) > 0 {
+						eventData = append(eventData, '\n')
+					}
+					eventData = append(eventData, value...)
 				}
-				if field == "data" && value == "[DONE]" {
+				if bytes.Equal(field, sseDataField) && bytes.Equal(value, sseDoneData) {
 					stop, err := flushEvent()
 					if err != nil {
 						return err

--- a/internal/llm/responses_event_handler.go
+++ b/internal/llm/responses_event_handler.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -40,7 +41,7 @@ func (h *responsesStreamEventHandler) OutputItems() []ResponsesInputItem {
 }
 
 func (h *responsesStreamEventHandler) HandleJSONEvent(data []byte, eventType string, send eventSender) (bool, error) {
-	if string(data) == "[DONE]" {
+	if bytes.Equal(data, sseDoneData) {
 		return true, nil
 	}
 	if eventType == "" {

--- a/internal/llm/sse_benchmark_test.go
+++ b/internal/llm/sse_benchmark_test.go
@@ -1,0 +1,39 @@
+package llm
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func BenchmarkReadSSEEventChatCompletions(b *testing.B) {
+	const chunk = `data: {"choices":[{"delta":{"content":"hello world"}}]}` + "\n\n"
+	payload := strings.Repeat(chunk, 128) + "data: [DONE]\n\n"
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		reader := bufio.NewReader(strings.NewReader(payload))
+		for {
+			_, data, eof, err := readSSEEvent(reader)
+			if err != nil {
+				b.Fatalf("readSSEEvent: %v", err)
+			}
+			if eof && data == "" {
+				break
+			}
+			if data == "" {
+				if eof {
+					break
+				}
+				continue
+			}
+			if data == "[DONE]" {
+				break
+			}
+			if eof {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Reduce allocation churn in provider SSE streaming paths by parsing SSE lines as byte slices instead of strings:

- add a byte-oriented SSE line/event parser based on `bufio.Reader.ReadSlice`
- use byte payloads directly for OpenAI-compatible JSON chunk unmarshalling
- accumulate Responses API SSE `data:` lines into a reusable byte buffer and avoid string join / `[]byte(string)` round-trips
- keep the existing string-returning helpers for tests/compatibility and add a benchmark for the parser hot path

## Why

Streaming providers process many small SSE frames per response. The old path allocated strings for every SSE line, joined `data:` lines into a string, then copied back to bytes before JSON decoding. This adds avoidable allocation and latency on the critical token streaming path.

## Evidence

`go test ./internal/llm -run '^$' -bench 'BenchmarkReadSSEEventChatCompletions' -benchmem -count=5`

Before:

- 9270-16090 ns/op
- 13,368 B/op
- 260 allocs/op

After:

- 6780-6958 ns/op
- 12,328 B/op
- 131 allocs/op

## Verification

- `go test ./internal/llm -run 'TestReadSSEEvent|TestResponsesClientStream_ParsesMultilineSSE|TestResponsesClientStream_ParsesMultilineSSEErrorEvent|TestOpenAICompatStream_HandlesMultiLineSSEPayload'`
- `go test ./internal/llm`
- `go test ./...`
- `go build ./...`
