### PR TITLE
feat: add codegen benchmark harness

### DIFF
--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -54,6 +54,9 @@ Current suite:
 | `go_json_format` | Go | stdlib/API correctness and error handling |
 | `go_concurrent_counter` | Go | concurrency correctness under `-race` |
 | `go_dedupe_perf` | Go | correctness plus `go test -bench -benchmem` output |
+| `go_web_chat_1000` | Go | in-memory HTTP chat handler with 1000 concurrent users under `-race` |
+
+The web chat task is intentionally heavier than the toy tasks. It drives one generated `http.Handler` with 1000 concurrent `POST /rooms/{room}/messages` requests through `httptest`, verifies per-room sequence ordering and message retention, then fetches the room. If you run it on a slow box, raise `-score-timeout` rather than weakening the concurrency signal.
 
 This is deliberately repo-local and boring to run. Add Ruby/Rails, SQL/Postgres, Python, and TypeScript suites the same way: prompt, isolated workspace, deterministic scorer.
 

--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -101,7 +101,7 @@ Every important flag has an env var so the same command is easy to run from jobs
 | `-concurrency` | `BENCH_CONCURRENCY` | `2` |
 | `-budget` | `BENCH_BUDGET` | `4h` |
 | `-timeout` | `BENCH_TASK_TIMEOUT` | `5m` |
-| `-score-timeout` | `BENCH_SCORE_TIMEOUT` | `20s` |
+| `-score-timeout` | `BENCH_SCORE_TIMEOUT` | `60s` |
 | `-out` | `BENCH_OUT` | `benchmarks/codegen/results` |
 
 ## Running via term-llm jobs

--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -37,6 +37,7 @@ Each task produces a JSON record with:
 - compile/test pass/fail
 - scalar score (`0.0` or `1.0` for the first suite)
 - benchmark output where a task has a perf component
+- parsed runtime/allocation metrics when the scorer can extract them
 - input/output/cache/reasoning token counts when the provider reports them
 - estimated USD cost using term-llm's LiteLLM pricing cache when the model can be matched
 - generated code, stdout, stderr, and failure detail for postmortems
@@ -54,9 +55,10 @@ Current suite:
 | `go_json_format` | Go | stdlib/API correctness and error handling |
 | `go_concurrent_counter` | Go | concurrency correctness under `-race` |
 | `go_dedupe_perf` | Go | correctness plus `go test -bench -benchmem` output |
-| `go_web_chat_1000` | Go | in-memory HTTP chat handler with 1000 concurrent users under `-race` |
+| `go_web_chat_1000` | Go | in-memory HTTP chat handler with 1000 concurrent users under `-race`, plus `benchmem` runtime/allocation metrics |
+| `node_web_chat_1000` | JavaScript/Node | equivalent 1000-concurrent-user HTTP chat server using only Node stdlib |
 
-The web chat task is intentionally heavier than the toy tasks. It drives one generated `http.Handler` with 1000 concurrent `POST /rooms/{room}/messages` requests through `httptest`, verifies per-room sequence ordering and message retention, then fetches the room. If you run it on a slow box, raise `-score-timeout` rather than weakening the concurrency signal.
+The web chat tasks are intentionally heavier than the toy tasks. Go drives one generated `http.Handler` with 1000 concurrent `POST /rooms/{room}/messages` requests through `httptest`, verifies per-room sequence ordering and message retention, then fetches the room under `go test -race`. Node starts a generated stdlib HTTP listener on localhost and drives the same API with 1000 concurrent `fetch()` calls. If you run them on a slow box, raise `-score-timeout` rather than weakening the concurrency signal.
 
 This is deliberately repo-local and boring to run. Add Ruby/Rails, SQL/Postgres, Python, and TypeScript suites the same way: prompt, isolated workspace, deterministic scorer.
 
@@ -66,8 +68,20 @@ Artifacts are written to `benchmarks/codegen/results/` by default:
 
 ```text
 benchmarks/codegen/results/YYYYMMDDTHHMMSSZ_provider-model.json
+benchmarks/codegen/results/YYYYMMDDTHHMMSSZ_provider-model_dashboard.html
+benchmarks/codegen/results/YYYYMMDDTHHMMSSZ_provider-model_dashboard.svg
+benchmarks/codegen/results/latest_dashboard.html
+benchmarks/codegen/results/latest_dashboard.svg
 benchmarks/codegen/results/history.jsonl
 ```
+
+The dashboard visualizes the three numbers that matter together:
+
+- **quality**: pass/fail and scalar score
+- **cost to generate**: estimated USD from token usage/pricing
+- **performance**: generated runtime metrics when available, otherwise scorer duration as a fallback
+
+The SVG is easy to paste into reports; the HTML adds summary cards and the sortable-by-eyeball result table. Bigger bubbles cost more, higher bubbles are faster, green bubbles passed, red bubbles failed. Yes, this is intentionally judgemental.
 
 Use a throwaway output directory for experiments:
 

--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -55,12 +55,17 @@ Current suite:
 | `go_json_format` | Go | stdlib/API correctness and error handling |
 | `go_concurrent_counter` | Go | concurrency correctness under `-race` |
 | `go_dedupe_perf` | Go | correctness plus `go test -bench -benchmem` output |
-| `go_web_chat_1000` | Go | in-memory HTTP chat handler with 1000 concurrent users under `-race`, plus `benchmem` runtime/allocation metrics |
-| `node_web_chat_1000` | JavaScript/Node | equivalent 1000-concurrent-user HTTP chat server using only Node stdlib |
+| `go_web_chat_1000` | Go | in-memory HTTP chat handler with 1000 concurrent users under `-race`, plus post-warmup runtime/allocation/memory metrics |
+| `node_web_chat_1000` | JavaScript/Node | equivalent 1000-concurrent-user HTTP chat server using only Node stdlib, with warmup and RSS memory |
+| `ruby_web_chat_1000` | Ruby | equivalent 1000-thread in-memory chat callable using only Ruby stdlib, with warmup and RSS memory |
+| `python_web_chat_1000` | Python | equivalent 1000-thread in-memory chat callable using only Python stdlib, with warmup and max RSS memory |
+| `asm_sum_positive_perf` | x86-64 assembly | System V ABI assembly correctness plus warmed perf loop and max RSS memory |
 
-The web chat tasks are intentionally heavier than the toy tasks. Go drives one generated `http.Handler` with 1000 concurrent `POST /rooms/{room}/messages` requests through `httptest`, verifies per-room sequence ordering and message retention, then fetches the room under `go test -race`. Node starts a generated stdlib HTTP listener on localhost and drives the same API with 1000 concurrent `fetch()` calls. If you run them on a slow box, raise `-score-timeout` rather than weakening the concurrency signal.
+The web chat tasks are intentionally heavier than the toy tasks. Go drives one generated `http.Handler` with warmup traffic, then 1000 concurrent `POST /rooms/{room}/messages` requests through `httptest`, verifies per-room sequence ordering and message retention, then fetches the room under `go test -race`. Node starts a generated stdlib HTTP listener on localhost and drives the same API with warmup traffic plus 1000 concurrent `fetch()` calls. Ruby and Python use the same semantic contract through an in-memory callable so we can hammer 1000 threads without turning the benchmark into a framework shootout. The scorers record post-warmup runtime and memory where the runtime exposes it. If you run them on a slow box, raise `-score-timeout` rather than weakening the concurrency signal.
 
-This is deliberately repo-local and boring to run. Add Ruby/Rails, SQL/Postgres, Python, and TypeScript suites the same way: prompt, isolated workspace, deterministic scorer.
+Assembly is deliberately not pretending to be a web stack. It tests whether the model can emit linkable x86-64 System V ABI code that survives a C harness, then records warmed loop runtime and process RSS. Different beast, same dashboard: quality, cost, speed, memory.
+
+This is deliberately repo-local and boring to run. Add Ruby/Rails, SQL/Postgres, and TypeScript suites the same way: prompt, isolated workspace, deterministic scorer.
 
 ## Results
 
@@ -79,7 +84,8 @@ The dashboard visualizes the three numbers that matter together:
 
 - **quality**: pass/fail and scalar score
 - **cost to generate**: estimated USD from token usage/pricing
-- **performance**: generated runtime metrics when available, otherwise scorer duration as a fallback
+- **performance**: post-warmup generated runtime metrics when available, otherwise scorer duration as a fallback
+- **memory**: RSS/max-RSS or benchmark allocation metrics where available
 
 The SVG is easy to paste into reports; the HTML adds summary cards and the sortable-by-eyeball result table. Bigger bubbles cost more, higher bubbles are faster, green bubbles passed, red bubbles failed. Yes, this is intentionally judgemental.
 

--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -1,0 +1,119 @@
+# Codegen benchmark
+
+Execution-based code generation benchmark for term-llm providers. It asks a provider to generate code, compiles/runs the result in an isolated temp directory, records correctness/perf signals, and estimates cost from token usage when pricing is known.
+
+The first target is `claude-bin`; provider swaps are just a flag.
+
+## Quick start
+
+```bash
+go run ./benchmarks/codegen \
+  -provider claude-bin \
+  -concurrency 2 \
+  -budget 4h
+```
+
+Run fewer tasks while iterating:
+
+```bash
+go run ./benchmarks/codegen \
+  -provider claude-bin \
+  -tasks go_fizzbuzz,go_binary_search
+```
+
+Run another provider/model:
+
+```bash
+go run ./benchmarks/codegen -provider anthropic:claude-sonnet-4-6
+go run ./benchmarks/codegen -provider openai:gpt-5.2
+go run ./benchmarks/codegen -provider gemini:gemini-3-pro
+go run ./benchmarks/codegen -provider ollama:qwen3-coder
+```
+
+## What it measures
+
+Each task produces a JSON record with:
+
+- compile/test pass/fail
+- scalar score (`0.0` or `1.0` for the first suite)
+- benchmark output where a task has a perf component
+- input/output/cache/reasoning token counts when the provider reports them
+- estimated USD cost using term-llm's LiteLLM pricing cache when the model can be matched
+- generated code, stdout, stderr, and failure detail for postmortems
+
+The summary includes cost and cost-per-pass. That number is intentionally crude but useful: a model that gets 5/5 for $0.03 and one that gets 5/5 for $3.00 are not the same beast.
+
+## Tasks
+
+Current suite:
+
+| Task | Language | Signal |
+|---|---|---|
+| `go_fizzbuzz` | Go | easy correctness |
+| `go_binary_search` | Go | edge-case correctness |
+| `go_json_format` | Go | stdlib/API correctness and error handling |
+| `go_concurrent_counter` | Go | concurrency correctness under `-race` |
+| `go_dedupe_perf` | Go | correctness plus `go test -bench -benchmem` output |
+
+This is deliberately repo-local and boring to run. Add Ruby/Rails, SQL/Postgres, Python, and TypeScript suites the same way: prompt, isolated workspace, deterministic scorer.
+
+## Results
+
+Artifacts are written to `benchmarks/codegen/results/` by default:
+
+```text
+benchmarks/codegen/results/YYYYMMDDTHHMMSSZ_provider-model.json
+benchmarks/codegen/results/history.jsonl
+```
+
+Use a throwaway output directory for experiments:
+
+```bash
+go run ./benchmarks/codegen -out /tmp/codegen-bench
+```
+
+## Flags and environment
+
+Every important flag has an env var so the same command is easy to run from jobs.
+
+| Flag | Env var | Default |
+|---|---|---|
+| `-provider` | `BENCH_PROVIDER` | `claude-bin` |
+| `-tasks` | `BENCH_TASKS` | `all` |
+| `-runs` | `BENCH_RUNS` | `1` |
+| `-concurrency` | `BENCH_CONCURRENCY` | `2` |
+| `-budget` | `BENCH_BUDGET` | `4h` |
+| `-timeout` | `BENCH_TASK_TIMEOUT` | `5m` |
+| `-score-timeout` | `BENCH_SCORE_TIMEOUT` | `20s` |
+| `-out` | `BENCH_OUT` | `benchmarks/codegen/results` |
+
+## Running via term-llm jobs
+
+Create a manual program job:
+
+```bash
+term-llm jobs create --file benchmarks/codegen/jobs/codegen-benchmark.json
+```
+
+Trigger it:
+
+```bash
+term-llm jobs trigger codegen-benchmark
+```
+
+The checked-in job uses:
+
+```text
+BENCH_PROVIDER=claude-bin
+BENCH_CONCURRENCY=2
+BENCH_BUDGET=4h
+```
+
+To benchmark another provider, either run the command directly with `BENCH_PROVIDER=...`, or update the job definition with a different environment value.
+
+## Adding a task
+
+1. Add a `Task` implementation in `tasks.go` or split it into a new file.
+2. Register it in `allTasks()`.
+3. Make `Score()` compile/run something deterministic.
+4. Prefer real execution signals over model-judged grading. If a result cannot fail mechanically, it is probably a vibes benchmark wearing a fake moustache.

--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -21,6 +21,16 @@ go run ./benchmarks/codegen \
   -tasks go_fizzbuzz,go_binary_search
 ```
 
+Run the optional Zig task when `zig` is installed:
+
+```bash
+go run ./benchmarks/codegen \
+  -provider claude-bin \
+  -tasks zig_sum_positive_perf
+```
+
+`-tasks all` runs the default suite and intentionally excludes optional toolchain-dependent tasks like Zig.
+
 Run another provider/model:
 
 ```bash
@@ -55,15 +65,16 @@ Current suite:
 | `go_json_format` | Go | stdlib/API correctness and error handling |
 | `go_concurrent_counter` | Go | concurrency correctness under `-race` |
 | `go_dedupe_perf` | Go | correctness plus `go test -bench -benchmem` output |
-| `go_web_chat_1000` | Go | in-memory HTTP chat handler with 1000 concurrent users under `-race`, plus post-warmup runtime/allocation/memory metrics |
-| `node_web_chat_1000` | JavaScript/Node | equivalent 1000-concurrent-user HTTP chat server using only Node stdlib, with warmup and RSS memory |
-| `ruby_web_chat_1000` | Ruby | equivalent 1000-thread in-memory chat callable using only Ruby stdlib, with warmup and RSS memory |
-| `python_web_chat_1000` | Python | equivalent 1000-thread in-memory chat callable using only Python stdlib, with warmup and max RSS memory |
+| `go_web_chat_1000` | Go | generated chat server exercised over real localhost HTTP by the common Go harness |
+| `node_web_chat_1000` | JavaScript/Node | same common localhost HTTP harness against a generated Node stdlib server |
+| `ruby_web_chat_1000` | Ruby | same common localhost HTTP harness against a Ruby stdlib adapter around the generated callable |
+| `python_web_chat_1000` | Python | same common localhost HTTP harness against a Python stdlib adapter around the generated callable |
 | `asm_sum_positive_perf` | x86-64 assembly | System V ABI assembly correctness plus warmed perf loop and max RSS memory |
+| `zig_sum_positive_perf` | Zig | optional explicit task; exported C ABI function linked to the same C perf harness as assembly; requires `zig` installed |
 
-The web chat tasks are intentionally heavier than the toy tasks. Go drives one generated `http.Handler` with warmup traffic, then 1000 concurrent `POST /rooms/{room}/messages` requests through `httptest`, verifies per-room sequence ordering and message retention, then fetches the room under `go test -race`. Node starts a generated stdlib HTTP listener on localhost and drives the same API with warmup traffic plus 1000 concurrent `fetch()` calls. Ruby and Python use the same semantic contract through an in-memory callable so we can hammer 1000 threads without turning the benchmark into a framework shootout. The scorers record post-warmup runtime and memory where the runtime exposes it. If you run them on a slow box, raise `-score-timeout` rather than weakening the concurrency signal.
+The web chat tasks are intentionally heavier than the toy tasks and now use one common performance harness. Each generated solution is launched as a localhost HTTP server on `127.0.0.1:$PORT`; the same Go load driver sends the bad-input check, 100-post warmup, 1000 concurrent `POST /rooms/{room}/messages` requests, a validating `GET`, and the empty-room check. That means Go, Node, Ruby, and Python are measured through the same client, the same concurrency shape, and the same correctness assertions. Ruby/Python still generate a small callable to avoid framework lottery; checked-in stdlib adapters expose that callable over real HTTP for the shared harness.
 
-Assembly is deliberately not pretending to be a web stack. It tests whether the model can emit linkable x86-64 System V ABI code that survives a C harness, then records warmed loop runtime and process RSS. Different beast, same dashboard: quality, cost, speed, memory.
+Assembly and Zig are deliberately not pretending to be web stacks. They test whether the model can emit linkable low-level code that survives a C harness, then records warmed loop runtime and process RSS. Zig is registered as an explicit optional task (`-tasks zig_sum_positive_perf`) because this container/CI may not have `zig` installed. Different beast, same dashboard: quality, cost, speed, memory.
 
 This is deliberately repo-local and boring to run. Add Ruby/Rails, SQL/Postgres, and TypeScript suites the same way: prompt, isolated workspace, deterministic scorer.
 

--- a/benchmarks/codegen/README.md
+++ b/benchmarks/codegen/README.md
@@ -54,6 +54,8 @@ Each task produces a JSON record with:
 
 The summary includes cost and cost-per-pass. That number is intentionally crude but useful: a model that gets 5/5 for $0.03 and one that gets 5/5 for $3.00 are not the same beast.
 
+The prompt explicitly tells every provider to self-validate before returning code: exact signature/export, imports/header, syntax, edge/error cases, concurrency safety, and stated perf constraints. The model still returns only code; the benchmark records whether that private check was worth a damn by running the scorer. Nice because it encourages agentic discipline without turning failures into a model-judged therapy session.
+
 ## Tasks
 
 Current suite:

--- a/benchmarks/codegen/common_http.go
+++ b/benchmarks/codegen/common_http.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type httpServerSpec struct {
+	Prefix string
+	Files  map[string]string
+	Cmd    []string
+}
+
+type wireMessage struct {
+	Seq  int    `json:"seq"`
+	User string `json:"user"`
+	Text string `json:"text"`
+}
+
+func scoreHTTPServer(response string, timeout time.Duration, spec httpServerSpec) ScoreResult {
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", spec.Prefix+"-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+	for name, content := range spec.Files {
+		if content == "{{CODE}}" {
+			content = code
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	port, err := freePort()
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	cmd := exec.CommandContext(ctx, spec.Cmd[0], spec.Cmd[1:]...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "PORT="+port)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+	base := "http://127.0.0.1:" + port
+	if err := waitForHTTP(ctx, base+"/rooms/__health__/messages"); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: "server did not start: " + err.Error(), Stdout: stdout.String(), Stderr: stderr.String(), GeneratedCode: code}
+	}
+
+	warmup, runtimeMS, _, err := exerciseHTTPChat(ctx, base)
+	memoryKB := processRSSKB(cmd.Process.Pid)
+	out := stdout.String() + fmt.Sprintf("BENCH_WARMUP_MS=%.3f\nBENCH_RUNTIME_MS=%.3f\n", warmup, runtimeMS)
+	if memoryKB > 0 {
+		out += fmt.Sprintf("BENCH_MEMORY_KB=%.0f\n", memoryKB)
+	}
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: stderr.String() + err.Error(), GeneratedCode: code}
+	}
+	metrics := parseRuntimeBench(out)
+	detail := fmt.Sprintf("runtime %.2f ms", metrics.RuntimeMS)
+	return ScoreResult{Pass: true, Score: 1, Details: detail, Stdout: out, Stderr: stderr.String(), GeneratedCode: code, Metrics: metrics}
+}
+
+func freePort() (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	defer ln.Close()
+	return fmt.Sprint(ln.Addr().(*net.TCPAddr).Port), nil
+}
+
+func processRSSKB(pid int) float64 {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "VmRSS:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				kb, _ := strconv.ParseFloat(fields[1], 64)
+				return kb
+			}
+		}
+	}
+	return 0
+}
+
+func waitForHTTP(ctx context.Context, url string) error {
+	client := &http.Client{Timeout: 200 * time.Millisecond}
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		res, err := client.Do(req)
+		if err == nil {
+			io.Copy(io.Discard, res.Body)
+			res.Body.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(25 * time.Millisecond)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("timeout")
+}
+
+func exerciseHTTPChat(ctx context.Context, base string) (float64, float64, float64, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	badStatus, _, err := postChat(ctx, client, base, "lobby", "", "hello")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if badStatus < 400 || badStatus > 499 {
+		return 0, 0, 0, fmt.Errorf("empty user status %d, want 4xx", badStatus)
+	}
+	warmup, err := exerciseHTTPRoom(ctx, client, base, "warmup", 100)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("warmup: %w", err)
+	}
+	runtimeMS, err := exerciseHTTPRoom(ctx, client, base, "lobby", 1000)
+	if err != nil {
+		return warmup, 0, 0, err
+	}
+	status, body, err := getHTTP(ctx, client, base+"/rooms/empty/messages")
+	if err != nil {
+		return warmup, runtimeMS, 0, err
+	}
+	if status != http.StatusOK || strings.TrimSpace(string(body)) != "[]" {
+		var xs []wireMessage
+		if json.Unmarshal(body, &xs) != nil || len(xs) != 0 {
+			return warmup, runtimeMS, 0, fmt.Errorf("empty room status=%d body=%q", status, string(body))
+		}
+	}
+	return warmup, runtimeMS, 0, nil
+}
+
+func exerciseHTTPRoom(ctx context.Context, client *http.Client, base, room string, users int) (float64, error) {
+	started := time.Now()
+	var wg sync.WaitGroup
+	errs := make(chan error, users)
+	for i := 0; i < users; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			status, msg, err := postChat(ctx, client, base, room, fmt.Sprintf("user-%d", i), fmt.Sprintf("hello-%d", i))
+			if err != nil {
+				errs <- err
+				return
+			}
+			if status != http.StatusCreated {
+				errs <- fmt.Errorf("POST %d status %d", i, status)
+				return
+			}
+			if msg.Seq < 1 || msg.Seq > users || msg.User != fmt.Sprintf("user-%d", i) || msg.Text != fmt.Sprintf("hello-%d", i) {
+				errs <- fmt.Errorf("bad stored message: %#v", msg)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			return 0, err
+		}
+	}
+	status, body, err := getHTTP(ctx, client, base+"/rooms/"+room+"/messages")
+	if err != nil {
+		return 0, err
+	}
+	if status != http.StatusOK {
+		return 0, fmt.Errorf("GET status %d body=%s", status, string(body))
+	}
+	var messages []wireMessage
+	if err := json.Unmarshal(body, &messages); err != nil {
+		return 0, fmt.Errorf("decode GET response: %w", err)
+	}
+	if len(messages) != users {
+		return 0, fmt.Errorf("message count = %d, want %d", len(messages), users)
+	}
+	seenSeq := make(map[int]bool, users)
+	seenUsers := make(map[string]bool, users)
+	lastSeq := 0
+	for _, msg := range messages {
+		if msg.Seq <= lastSeq {
+			return 0, fmt.Errorf("messages not in seq order around seq %d after %d", msg.Seq, lastSeq)
+		}
+		lastSeq = msg.Seq
+		if msg.Seq < 1 || msg.Seq > users || seenSeq[msg.Seq] {
+			return 0, fmt.Errorf("bad or duplicate seq: %d", msg.Seq)
+		}
+		seenSeq[msg.Seq] = true
+		seenUsers[msg.User] = true
+	}
+	for i := 0; i < users; i++ {
+		if !seenUsers[fmt.Sprintf("user-%d", i)] {
+			return 0, fmt.Errorf("missing user-%d", i)
+		}
+	}
+	return float64(time.Since(started).Microseconds()) / 1000.0, nil
+}
+
+func postChat(ctx context.Context, client *http.Client, base, room, user, text string) (int, wireMessage, error) {
+	body, _ := json.Marshal(map[string]string{"user": user, "text": text})
+	status, resBody, err := postHTTP(ctx, client, base+"/rooms/"+room+"/messages", body)
+	if err != nil || status != http.StatusCreated {
+		return status, wireMessage{}, err
+	}
+	var msg wireMessage
+	if err := json.Unmarshal(resBody, &msg); err != nil {
+		return status, wireMessage{}, err
+	}
+	return status, msg, nil
+}
+
+func postHTTP(ctx context.Context, client *http.Client, url string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer res.Body.Close()
+	resBody, err := io.ReadAll(res.Body)
+	return res.StatusCode, resBody, err
+}
+
+func getHTTP(ctx context.Context, client *http.Client, url string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	return res.StatusCode, body, err
+}

--- a/benchmarks/codegen/jobs/codegen-benchmark.json
+++ b/benchmarks/codegen/jobs/codegen-benchmark.json
@@ -1,0 +1,20 @@
+{
+  "name": "codegen-benchmark",
+  "enabled": true,
+  "runner_type": "program",
+  "runner_config": {
+    "command": "cd \"${TERM_LLM_REPO:-/root/source/term-llm}\" && exec bash benchmarks/codegen/jobs/run-codegen-benchmark.sh",
+    "shell": true,
+    "env": [
+      "BENCH_PROVIDER=claude-bin",
+      "BENCH_CONCURRENCY=2",
+      "BENCH_BUDGET=4h",
+      "BENCH_OUT=/root/.local/share/term-llm/codegen-benchmark/results"
+    ]
+  },
+  "trigger_type": "manual",
+  "trigger_config": {},
+  "concurrency_policy": "forbid",
+  "timeout_seconds": 14400,
+  "misfire_policy": "skip"
+}

--- a/benchmarks/codegen/jobs/run-codegen-benchmark.sh
+++ b/benchmarks/codegen/jobs/run-codegen-benchmark.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/../../.." rev-parse --show-toplevel)"
+cd "$ROOT"
+
+exec go run ./benchmarks/codegen \
+  -provider "${BENCH_PROVIDER:-claude-bin}" \
+  -tasks "${BENCH_TASKS:-all}" \
+  -runs "${BENCH_RUNS:-1}" \
+  -concurrency "${BENCH_CONCURRENCY:-2}" \
+  -budget "${BENCH_BUDGET:-4h}" \
+  -timeout "${BENCH_TASK_TIMEOUT:-5m}" \
+  -score-timeout "${BENCH_SCORE_TIMEOUT:-20s}" \
+  -out "${BENCH_OUT:-benchmarks/codegen/results}"

--- a/benchmarks/codegen/main.go
+++ b/benchmarks/codegen/main.go
@@ -104,7 +104,7 @@ func main() {
 	concurrency := flag.Int("concurrency", envInt("BENCH_CONCURRENCY", 2), "maximum concurrent LLM requests")
 	budget := flag.Duration("budget", envDuration("BENCH_BUDGET", 4*time.Hour), "wall-clock budget for the run")
 	timeout := flag.Duration("timeout", envDuration("BENCH_TASK_TIMEOUT", 5*time.Minute), "timeout per LLM task")
-	scoreTimeout := flag.Duration("score-timeout", envDuration("BENCH_SCORE_TIMEOUT", 20*time.Second), "timeout for compile/test scoring")
+	scoreTimeout := flag.Duration("score-timeout", envDuration("BENCH_SCORE_TIMEOUT", 60*time.Second), "timeout for compile/test scoring")
 	outDir := flag.String("out", envOr("BENCH_OUT", "benchmarks/codegen/results"), "directory for JSON artifacts")
 	jsonOnly := flag.Bool("json", false, "print only the final JSON report")
 	flag.Parse()

--- a/benchmarks/codegen/main.go
+++ b/benchmarks/codegen/main.go
@@ -29,6 +29,8 @@ type Task interface {
 
 type ScoreMetrics struct {
 	RuntimeMS   float64 `json:"runtime_ms,omitempty"`
+	WarmupMS    float64 `json:"warmup_ms,omitempty"`
+	MemoryKB    float64 `json:"memory_kb,omitempty"`
 	NSPerOp     float64 `json:"ns_per_op,omitempty"`
 	BytesPerOp  float64 `json:"bytes_per_op,omitempty"`
 	AllocsPerOp float64 `json:"allocs_per_op,omitempty"`
@@ -389,7 +391,7 @@ func printReport(w io.Writer, report RunReport) {
 	}
 	fmt.Fprintf(w, "Provider: %s (%s)   Tasks: %d   Concurrency: %d\n", report.Provider, model, report.Total, report.Concurrency)
 	fmt.Fprintln(w, "────────────────────────────────────────────────────────────────────────────")
-	fmt.Fprintf(w, "%-24s %-10s %-6s %-7s %-10s %-11s %-8s %s\n", "Task", "Lang", "Pass", "Score", "Cost", "Runtime", "LLM", "Detail")
+	fmt.Fprintf(w, "%-24s %-10s %-6s %-7s %-10s %-11s %-10s %-10s %-8s %s\n", "Task", "Lang", "Pass", "Score", "Cost", "Runtime", "Warmup", "Memory", "LLM", "Detail")
 	for _, t := range report.Tasks {
 		pass := "✗"
 		if t.Pass {
@@ -399,7 +401,7 @@ func printReport(w io.Writer, report RunReport) {
 		if t.Error != "" {
 			detail = t.Error
 		}
-		fmt.Fprintf(w, "%-24s %-10s %-6s %-7.2f $%-9.4f %-11s %-8s %s\n", t.Task, t.Language, pass, t.Score, t.EstimatedCost, displayRuntime(t), time.Duration(t.LLMDurationMS)*time.Millisecond, detail)
+		fmt.Fprintf(w, "%-24s %-10s %-6s %-7.2f $%-9.4f %-11s %-10s %-10s %-8s %s\n", t.Task, t.Language, pass, t.Score, t.EstimatedCost, displayRuntime(t), displayWarmup(t), displayMemory(t), time.Duration(t.LLMDurationMS)*time.Millisecond, detail)
 	}
 	fmt.Fprintln(w, "────────────────────────────────────────────────────────────────────────────")
 	fmt.Fprintf(w, "Pass rate: %d/%d (%.0f%%)   Mean score: %.2f   Cost: $%.4f   Cost/pass: $%.4f   Total: %s\n", report.Passes, report.Total, report.PassRate*100, report.MeanScore, report.EstimatedCostUSD, report.EstimatedCostPerPass, time.Duration(report.TotalDurationMS)*time.Millisecond)

--- a/benchmarks/codegen/main.go
+++ b/benchmarks/codegen/main.go
@@ -27,31 +27,42 @@ type Task interface {
 	Score(response string, timeout time.Duration) ScoreResult
 }
 
+type ScoreMetrics struct {
+	RuntimeMS   float64 `json:"runtime_ms,omitempty"`
+	NSPerOp     float64 `json:"ns_per_op,omitempty"`
+	BytesPerOp  float64 `json:"bytes_per_op,omitempty"`
+	AllocsPerOp float64 `json:"allocs_per_op,omitempty"`
+}
+
 type ScoreResult struct {
-	Pass          bool    `json:"pass"`
-	Score         float64 `json:"score"`
-	Details       string  `json:"details,omitempty"`
-	Stdout        string  `json:"stdout,omitempty"`
-	Stderr        string  `json:"stderr,omitempty"`
-	GeneratedCode string  `json:"generated_code,omitempty"`
+	Pass          bool         `json:"pass"`
+	Score         float64      `json:"score"`
+	Details       string       `json:"details,omitempty"`
+	Stdout        string       `json:"stdout,omitempty"`
+	Stderr        string       `json:"stderr,omitempty"`
+	GeneratedCode string       `json:"generated_code,omitempty"`
+	Metrics       ScoreMetrics `json:"metrics,omitempty"`
 }
 
 type TaskResult struct {
-	Task          string     `json:"task"`
-	Language      string     `json:"language"`
-	Difficulty    string     `json:"difficulty"`
-	Provider      string     `json:"provider"`
-	Model         string     `json:"model,omitempty"`
-	Pass          bool       `json:"pass"`
-	Score         float64    `json:"score"`
-	Details       string     `json:"details,omitempty"`
-	DurationMS    int64      `json:"duration_ms"`
-	Usage         TokenUsage `json:"usage"`
-	EstimatedCost float64    `json:"estimated_cost_usd,omitempty"`
-	Stdout        string     `json:"stdout,omitempty"`
-	Stderr        string     `json:"stderr,omitempty"`
-	GeneratedCode string     `json:"generated_code,omitempty"`
-	Error         string     `json:"error,omitempty"`
+	Task            string       `json:"task"`
+	Language        string       `json:"language"`
+	Difficulty      string       `json:"difficulty"`
+	Provider        string       `json:"provider"`
+	Model           string       `json:"model,omitempty"`
+	Pass            bool         `json:"pass"`
+	Score           float64      `json:"score"`
+	Details         string       `json:"details,omitempty"`
+	DurationMS      int64        `json:"duration_ms"`
+	LLMDurationMS   int64        `json:"llm_duration_ms"`
+	ScoreDurationMS int64        `json:"score_duration_ms"`
+	Usage           TokenUsage   `json:"usage"`
+	EstimatedCost   float64      `json:"estimated_cost_usd,omitempty"`
+	Metrics         ScoreMetrics `json:"metrics,omitempty"`
+	Stdout          string       `json:"stdout,omitempty"`
+	Stderr          string       `json:"stderr,omitempty"`
+	GeneratedCode   string       `json:"generated_code,omitempty"`
+	Error           string       `json:"error,omitempty"`
 }
 
 type TokenUsage struct {
@@ -205,9 +216,10 @@ func runTask(parent context.Context, provider llm.Provider, providerName, model 
 	defer cancel()
 
 	res := TaskResult{Task: task.Name(), Language: task.Language(), Difficulty: task.Difficulty(), Provider: providerName, Model: model}
-	askPrompt := buildPrompt(task)
-	answer, err := ask(ctx, provider, model, askPrompt, pricing)
-	res.DurationMS = time.Since(started).Milliseconds()
+	taskPrompt := buildPrompt(task)
+	answer, err := ask(ctx, provider, model, taskPrompt, pricing)
+	res.LLMDurationMS = time.Since(started).Milliseconds()
+	res.DurationMS = res.LLMDurationMS
 	if err != nil {
 		res.Error = err.Error()
 		res.Details = "llm request failed"
@@ -216,13 +228,17 @@ func runTask(parent context.Context, provider llm.Provider, providerName, model 
 	res.Usage = answer.Usage
 	res.EstimatedCost = answer.Cost
 
+	scoreStarted := time.Now()
 	score := task.Score(answer.Text, scoreTimeout)
+	res.ScoreDurationMS = time.Since(scoreStarted).Milliseconds()
+	res.DurationMS = time.Since(started).Milliseconds()
 	res.Pass = score.Pass
 	res.Score = score.Score
 	res.Details = score.Details
 	res.Stdout = trimForJSON(score.Stdout)
 	res.Stderr = trimForJSON(score.Stderr)
 	res.GeneratedCode = trimForJSON(score.GeneratedCode)
+	res.Metrics = score.Metrics
 	return res
 }
 
@@ -269,11 +285,12 @@ func ask(ctx context.Context, provider llm.Provider, model, prompt string, prici
 			}
 		}
 	}
-	cost := estimateCost(model, use, pricing)
+	cost := estimateCost(provider.Name(), model, use, pricing)
 	return askResult{Text: b.String(), Usage: use, Cost: cost}, nil
 }
 
-func estimateCost(model string, use TokenUsage, pricing *usage.PricingFetcher) float64 {
+func estimateCost(providerName, model string, use TokenUsage, pricing *usage.PricingFetcher) float64 {
+	model = pricingModelAlias(providerName, model)
 	if strings.TrimSpace(model) == "" {
 		return 0
 	}
@@ -283,6 +300,22 @@ func estimateCost(model string, use TokenUsage, pricing *usage.PricingFetcher) f
 		return 0
 	}
 	return cost
+}
+
+func pricingModelAlias(providerName, model string) string {
+	if providerName != "claude-bin" {
+		return model
+	}
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "sonnet", "claude-sonnet", "claude-code-sonnet":
+		return "claude-sonnet-4-6"
+	case "opus", "claude-opus", "claude-code-opus":
+		return "claude-opus-4-5"
+	case "haiku", "claude-haiku", "claude-code-haiku":
+		return "claude-3-5-haiku-20241022"
+	default:
+		return model
+	}
 }
 
 func buildPrompt(task Task) string {
@@ -343,7 +376,10 @@ func writeArtifacts(outDir string, report RunReport) error {
 	}
 	defer f.Close()
 	_, err = f.Write(append(line, '\n'))
-	return err
+	if err != nil {
+		return err
+	}
+	return writeVisualizations(outDir, report)
 }
 
 func printReport(w io.Writer, report RunReport) {
@@ -353,7 +389,7 @@ func printReport(w io.Writer, report RunReport) {
 	}
 	fmt.Fprintf(w, "Provider: %s (%s)   Tasks: %d   Concurrency: %d\n", report.Provider, model, report.Total, report.Concurrency)
 	fmt.Fprintln(w, "────────────────────────────────────────────────────────────────────────────")
-	fmt.Fprintf(w, "%-24s %-8s %-6s %-9s %-10s %s\n", "Task", "Lang", "Pass", "Score", "Cost", "Detail")
+	fmt.Fprintf(w, "%-24s %-10s %-6s %-7s %-10s %-11s %-8s %s\n", "Task", "Lang", "Pass", "Score", "Cost", "Runtime", "LLM", "Detail")
 	for _, t := range report.Tasks {
 		pass := "✗"
 		if t.Pass {
@@ -363,7 +399,7 @@ func printReport(w io.Writer, report RunReport) {
 		if t.Error != "" {
 			detail = t.Error
 		}
-		fmt.Fprintf(w, "%-24s %-8s %-6s %-9.2f $%-9.4f %s\n", t.Task, t.Language, pass, t.Score, t.EstimatedCost, detail)
+		fmt.Fprintf(w, "%-24s %-10s %-6s %-7.2f $%-9.4f %-11s %-8s %s\n", t.Task, t.Language, pass, t.Score, t.EstimatedCost, displayRuntime(t), time.Duration(t.LLMDurationMS)*time.Millisecond, detail)
 	}
 	fmt.Fprintln(w, "────────────────────────────────────────────────────────────────────────────")
 	fmt.Fprintf(w, "Pass rate: %d/%d (%.0f%%)   Mean score: %.2f   Cost: $%.4f   Cost/pass: $%.4f   Total: %s\n", report.Passes, report.Total, report.PassRate*100, report.MeanScore, report.EstimatedCostUSD, report.EstimatedCostPerPass, time.Duration(report.TotalDurationMS)*time.Millisecond)

--- a/benchmarks/codegen/main.go
+++ b/benchmarks/codegen/main.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/usage"
+)
+
+type Task interface {
+	Name() string
+	Language() string
+	Difficulty() string
+	Prompt() string
+	Score(response string, timeout time.Duration) ScoreResult
+}
+
+type ScoreResult struct {
+	Pass          bool    `json:"pass"`
+	Score         float64 `json:"score"`
+	Details       string  `json:"details,omitempty"`
+	Stdout        string  `json:"stdout,omitempty"`
+	Stderr        string  `json:"stderr,omitempty"`
+	GeneratedCode string  `json:"generated_code,omitempty"`
+}
+
+type TaskResult struct {
+	Task          string     `json:"task"`
+	Language      string     `json:"language"`
+	Difficulty    string     `json:"difficulty"`
+	Provider      string     `json:"provider"`
+	Model         string     `json:"model,omitempty"`
+	Pass          bool       `json:"pass"`
+	Score         float64    `json:"score"`
+	Details       string     `json:"details,omitempty"`
+	DurationMS    int64      `json:"duration_ms"`
+	Usage         TokenUsage `json:"usage"`
+	EstimatedCost float64    `json:"estimated_cost_usd,omitempty"`
+	Stdout        string     `json:"stdout,omitempty"`
+	Stderr        string     `json:"stderr,omitempty"`
+	GeneratedCode string     `json:"generated_code,omitempty"`
+	Error         string     `json:"error,omitempty"`
+}
+
+type TokenUsage struct {
+	InputTokens       int `json:"input_tokens"`
+	OutputTokens      int `json:"output_tokens"`
+	CachedInputTokens int `json:"cached_input_tokens"`
+	CacheWriteTokens  int `json:"cache_write_tokens"`
+	ReasoningTokens   int `json:"reasoning_tokens"`
+}
+
+type RunReport struct {
+	ID                   string       `json:"id"`
+	Provider             string       `json:"provider"`
+	Model                string       `json:"model,omitempty"`
+	StartedAt            time.Time    `json:"started_at"`
+	FinishedAt           time.Time    `json:"finished_at"`
+	TotalDurationMS      int64        `json:"total_duration_ms"`
+	Concurrency          int          `json:"concurrency"`
+	Budget               string       `json:"budget"`
+	Tasks                []TaskResult `json:"tasks"`
+	Passes               int          `json:"passes"`
+	Total                int          `json:"total"`
+	PassRate             float64      `json:"pass_rate"`
+	MeanScore            float64      `json:"mean_score"`
+	EstimatedCostUSD     float64      `json:"estimated_cost_usd,omitempty"`
+	EstimatedCostPerPass float64      `json:"estimated_cost_per_pass_usd,omitempty"`
+}
+
+type askResult struct {
+	Text  string
+	Usage TokenUsage
+	Cost  float64
+}
+
+func main() {
+	providerFlag := flag.String("provider", envOr("BENCH_PROVIDER", "claude-bin"), "provider[:model] to benchmark")
+	tasksFlag := flag.String("tasks", envOr("BENCH_TASKS", "all"), "comma-separated task names or all")
+	runs := flag.Int("runs", envInt("BENCH_RUNS", 1), "repeat each selected task N times")
+	concurrency := flag.Int("concurrency", envInt("BENCH_CONCURRENCY", 2), "maximum concurrent LLM requests")
+	budget := flag.Duration("budget", envDuration("BENCH_BUDGET", 4*time.Hour), "wall-clock budget for the run")
+	timeout := flag.Duration("timeout", envDuration("BENCH_TASK_TIMEOUT", 5*time.Minute), "timeout per LLM task")
+	scoreTimeout := flag.Duration("score-timeout", envDuration("BENCH_SCORE_TIMEOUT", 20*time.Second), "timeout for compile/test scoring")
+	outDir := flag.String("out", envOr("BENCH_OUT", "benchmarks/codegen/results"), "directory for JSON artifacts")
+	jsonOnly := flag.Bool("json", false, "print only the final JSON report")
+	flag.Parse()
+
+	if *runs < 1 {
+		fatalf("-runs must be >= 1")
+	}
+	if *concurrency < 1 {
+		fatalf("-concurrency must be >= 1")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		fatalf("load config: %v", err)
+	}
+	providerName, model, err := llm.ParseProviderModel(*providerFlag, cfg)
+	if err != nil {
+		fatalf("parse provider: %v", err)
+	}
+	provider, err := llm.NewProviderByName(cfg, providerName, model)
+	if err != nil {
+		fatalf("create provider: %v", err)
+	}
+	if model == "" {
+		if pc := cfg.GetProviderConfig(providerName); pc != nil {
+			model = pc.Model
+		}
+	}
+
+	selected, err := selectTasks(*tasksFlag)
+	if err != nil {
+		fatalf("select tasks: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *budget)
+	defer cancel()
+
+	started := time.Now()
+	report := RunReport{
+		ID:          started.UTC().Format("20060102T150405Z"),
+		Provider:    providerName,
+		Model:       model,
+		StartedAt:   started.UTC(),
+		Concurrency: *concurrency,
+		Budget:      budget.String(),
+	}
+
+	jobs := make(chan Task, len(selected)**runs)
+	results := make(chan TaskResult, len(selected)**runs)
+	var wg sync.WaitGroup
+	pricing := usage.NewPricingFetcher()
+
+	for i := 0; i < *concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for task := range jobs {
+				results <- runTask(ctx, provider, providerName, model, task, *timeout, *scoreTimeout, pricing)
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for i := 0; i < *runs; i++ {
+			for _, task := range selected {
+				select {
+				case <-ctx.Done():
+					return
+				case jobs <- task:
+				}
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for r := range results {
+		report.Tasks = append(report.Tasks, r)
+	}
+
+	report.FinishedAt = time.Now().UTC()
+	report.TotalDurationMS = time.Since(started).Milliseconds()
+	summarize(&report)
+	sort.Slice(report.Tasks, func(i, j int) bool {
+		if report.Tasks[i].Task == report.Tasks[j].Task {
+			return report.Tasks[i].DurationMS < report.Tasks[j].DurationMS
+		}
+		return report.Tasks[i].Task < report.Tasks[j].Task
+	})
+
+	if err := writeArtifacts(*outDir, report); err != nil {
+		fatalf("write artifacts: %v", err)
+	}
+
+	if *jsonOnly {
+		_ = json.NewEncoder(os.Stdout).Encode(report)
+		return
+	}
+	printReport(os.Stdout, report)
+}
+
+func runTask(parent context.Context, provider llm.Provider, providerName, model string, task Task, llmTimeout, scoreTimeout time.Duration, pricing *usage.PricingFetcher) TaskResult {
+	started := time.Now()
+	ctx, cancel := context.WithTimeout(parent, llmTimeout)
+	defer cancel()
+
+	res := TaskResult{Task: task.Name(), Language: task.Language(), Difficulty: task.Difficulty(), Provider: providerName, Model: model}
+	askPrompt := buildPrompt(task)
+	answer, err := ask(ctx, provider, model, askPrompt, pricing)
+	res.DurationMS = time.Since(started).Milliseconds()
+	if err != nil {
+		res.Error = err.Error()
+		res.Details = "llm request failed"
+		return res
+	}
+	res.Usage = answer.Usage
+	res.EstimatedCost = answer.Cost
+
+	score := task.Score(answer.Text, scoreTimeout)
+	res.Pass = score.Pass
+	res.Score = score.Score
+	res.Details = score.Details
+	res.Stdout = trimForJSON(score.Stdout)
+	res.Stderr = trimForJSON(score.Stderr)
+	res.GeneratedCode = trimForJSON(score.GeneratedCode)
+	return res
+}
+
+func ask(ctx context.Context, provider llm.Provider, model, prompt string, pricing *usage.PricingFetcher) (askResult, error) {
+	stream, err := provider.Stream(ctx, llm.Request{
+		Model: model,
+		Messages: []llm.Message{
+			llm.SystemText("You are in a code-generation benchmark. Follow the requested function signatures exactly. Return only a single fenced code block in the requested language, no explanation."),
+			llm.UserText(prompt),
+		},
+		Temperature:     0,
+		TemperatureSet:  true,
+		MaxOutputTokens: 4096,
+	})
+	if err != nil {
+		return askResult{}, err
+	}
+	defer stream.Close()
+
+	var b strings.Builder
+	var use TokenUsage
+	for {
+		ev, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return askResult{}, err
+		}
+		switch ev.Type {
+		case llm.EventTextDelta:
+			b.WriteString(ev.Text)
+		case llm.EventUsage:
+			if ev.Use != nil {
+				use.InputTokens += ev.Use.InputTokens
+				use.OutputTokens += ev.Use.OutputTokens
+				use.CachedInputTokens += ev.Use.CachedInputTokens
+				use.CacheWriteTokens += ev.Use.CacheWriteTokens
+				use.ReasoningTokens += ev.Use.ReasoningTokens
+			}
+		case llm.EventError:
+			if ev.Err != nil {
+				return askResult{}, ev.Err
+			}
+		}
+	}
+	cost := estimateCost(model, use, pricing)
+	return askResult{Text: b.String(), Usage: use, Cost: cost}, nil
+}
+
+func estimateCost(model string, use TokenUsage, pricing *usage.PricingFetcher) float64 {
+	if strings.TrimSpace(model) == "" {
+		return 0
+	}
+	entry := usage.UsageEntry{Model: model, InputTokens: use.InputTokens, OutputTokens: use.OutputTokens, CacheReadTokens: use.CachedInputTokens, CacheWriteTokens: use.CacheWriteTokens, ReasoningTokens: use.ReasoningTokens}
+	cost, err := pricing.CalculateCost(entry)
+	if err != nil {
+		return 0
+	}
+	return cost
+}
+
+func buildPrompt(task Task) string {
+	return fmt.Sprintf(`# Code generation benchmark task
+
+Task: %s
+Language: %s
+Difficulty: %s
+
+%s
+
+Return only one fenced %s code block containing a complete source file when the language has imports/package declarations. Include every import your code needs. No prose.`, task.Name(), task.Language(), task.Difficulty(), task.Prompt(), task.Language())
+}
+
+func summarize(report *RunReport) {
+	report.Total = len(report.Tasks)
+	var score float64
+	for _, t := range report.Tasks {
+		if t.Pass {
+			report.Passes++
+		}
+		score += t.Score
+		report.EstimatedCostUSD += t.EstimatedCost
+	}
+	if report.Total > 0 {
+		report.PassRate = float64(report.Passes) / float64(report.Total)
+		report.MeanScore = score / float64(report.Total)
+	}
+	if report.Passes > 0 {
+		report.EstimatedCostPerPass = report.EstimatedCostUSD / float64(report.Passes)
+	}
+}
+
+func writeArtifacts(outDir string, report RunReport) error {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+	providerSlug := strings.NewReplacer(":", "-", "/", "-", " ", "-").Replace(report.Provider)
+	if report.Model != "" {
+		providerSlug += "-" + strings.NewReplacer(":", "-", "/", "-", " ", "-").Replace(report.Model)
+	}
+	path := filepath.Join(outDir, fmt.Sprintf("%s_%s.json", report.ID, providerSlug))
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return err
+	}
+	historyPath := filepath.Join(outDir, "history.jsonl")
+	line, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(historyPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+func printReport(w io.Writer, report RunReport) {
+	model := report.Model
+	if model == "" {
+		model = "default"
+	}
+	fmt.Fprintf(w, "Provider: %s (%s)   Tasks: %d   Concurrency: %d\n", report.Provider, model, report.Total, report.Concurrency)
+	fmt.Fprintln(w, "────────────────────────────────────────────────────────────────────────────")
+	fmt.Fprintf(w, "%-24s %-8s %-6s %-9s %-10s %s\n", "Task", "Lang", "Pass", "Score", "Cost", "Detail")
+	for _, t := range report.Tasks {
+		pass := "✗"
+		if t.Pass {
+			pass = "✓"
+		}
+		detail := t.Details
+		if t.Error != "" {
+			detail = t.Error
+		}
+		fmt.Fprintf(w, "%-24s %-8s %-6s %-9.2f $%-9.4f %s\n", t.Task, t.Language, pass, t.Score, t.EstimatedCost, detail)
+	}
+	fmt.Fprintln(w, "────────────────────────────────────────────────────────────────────────────")
+	fmt.Fprintf(w, "Pass rate: %d/%d (%.0f%%)   Mean score: %.2f   Cost: $%.4f   Cost/pass: $%.4f   Total: %s\n", report.Passes, report.Total, report.PassRate*100, report.MeanScore, report.EstimatedCostUSD, report.EstimatedCostPerPass, time.Duration(report.TotalDurationMS)*time.Millisecond)
+}
+
+func trimForJSON(s string) string {
+	const limit = 32 * 1024
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "\n... truncated ..."
+}
+
+func envOr(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/benchmarks/codegen/main.go
+++ b/benchmarks/codegen/main.go
@@ -248,7 +248,7 @@ func ask(ctx context.Context, provider llm.Provider, model, prompt string, prici
 	stream, err := provider.Stream(ctx, llm.Request{
 		Model: model,
 		Messages: []llm.Message{
-			llm.SystemText("You are in a code-generation benchmark. Follow the requested function signatures exactly. Return only a single fenced code block in the requested language, no explanation."),
+			llm.SystemText("You are in a code-generation benchmark. Follow the requested function signatures exactly. Before answering, privately self-validate the solution against the prompt: required signature/export, imports, syntax, edge cases, concurrency safety, and the stated performance constraints. Fix any issue you find. Return only a single fenced code block in the requested language, no explanation."),
 			llm.UserText(prompt),
 		},
 		Temperature:     0,
@@ -329,7 +329,14 @@ Difficulty: %s
 
 %s
 
-Return only one fenced %s code block containing a complete source file when the language has imports/package declarations. Include every import your code needs. No prose.`, task.Name(), task.Language(), task.Difficulty(), task.Prompt(), task.Language())
+Return only one fenced %s code block containing a complete source file when the language has imports/package declarations. Include every import your code needs. No prose.
+
+Self-validation requirement before final output:
+- Check that the required function/type/export name is present exactly as specified.
+- Check that the code is syntactically valid for %s and includes every required import/header.
+- Check the listed edge cases and error cases against your implementation.
+- Check any concurrency or performance requirement explicitly, including locking/shared state where relevant.
+- If you find a problem, fix it before returning the code block.`, task.Name(), task.Language(), task.Difficulty(), task.Prompt(), task.Language(), task.Language())
 }
 
 func summarize(report *RunReport) {

--- a/benchmarks/codegen/results/.gitignore
+++ b/benchmarks/codegen/results/.gitignore
@@ -1,0 +1,5 @@
+*.json
+*.jsonl
+*.log
+!.gitignore
+!.gitkeep

--- a/benchmarks/codegen/scorer.go
+++ b/benchmarks/codegen/scorer.go
@@ -13,9 +13,11 @@ import (
 	"time"
 )
 
-var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang|javascript|js|node)?\\s*\\n(.*?)\\n```")
+var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang|javascript|js|node|ruby|rb|python|py|asm|assembly|x86_64-assembly|s)?\\s*\\n(.*?)\\n```")
 var goBenchRe = regexp.MustCompile(`BenchmarkGenerated\S*\s+\d+\s+([0-9.]+)\s+ns/op(?:\s+([0-9.]+)\s+B/op)?(?:\s+([0-9.]+)\s+allocs/op)?`)
-var nodeBenchRe = regexp.MustCompile(`BENCH_RUNTIME_MS=([0-9.]+)`)
+var runtimeBenchRe = regexp.MustCompile(`BENCH_RUNTIME_MS=([0-9.]+)`)
+var warmupBenchRe = regexp.MustCompile(`BENCH_WARMUP_MS=([0-9.]+)`)
+var memoryBenchRe = regexp.MustCompile(`BENCH_MEMORY_KB=([0-9.]+)`)
 
 func extractCode(response string) (string, error) {
 	response = strings.TrimSpace(response)
@@ -27,7 +29,7 @@ func extractCode(response string) (string, error) {
 		return strings.TrimSpace(matches[1]), nil
 	}
 	// Accept raw code as a convenience for providers that obey "no prose" literally.
-	if strings.Contains(response, "func ") || strings.Contains(response, "type ") || strings.Contains(response, "export function") || strings.Contains(response, "module.exports") {
+	if strings.Contains(response, "func ") || strings.Contains(response, "type ") || strings.Contains(response, "export function") || strings.Contains(response, "module.exports") || strings.Contains(response, "def ") || strings.Contains(response, "class ") || strings.Contains(response, ".globl") || strings.Contains(response, ".global") {
 		return response, nil
 	}
 	return "", fmt.Errorf("no code block found")
@@ -67,7 +69,7 @@ func scoreGo(response string, timeout time.Duration, race bool, testBody string,
 		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
 	}
 
-	args := []string{"test", ".", "-run", "TestGenerated", "-bench", "BenchmarkGenerated", "-benchmem", "-count", "1"}
+	args := []string{"test", "-v", ".", "-run", "TestGenerated", "-bench", "BenchmarkGenerated", "-benchmem", "-count", "1"}
 	if race {
 		args = append([]string{"test", "-race"}, args[1:]...)
 	}
@@ -88,6 +90,16 @@ func scoreGo(response string, timeout time.Duration, race bool, testBody string,
 		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: errOut, GeneratedCode: code}
 	}
 	metrics := parseGoBench(out)
+	markers := parseRuntimeBench(out)
+	if markers.RuntimeMS > 0 {
+		metrics.RuntimeMS = markers.RuntimeMS
+	}
+	if markers.WarmupMS > 0 {
+		metrics.WarmupMS = markers.WarmupMS
+	}
+	if markers.MemoryKB > 0 {
+		metrics.MemoryKB = markers.MemoryKB
+	}
 	return ScoreResult{Pass: true, Score: 1, Details: perfSummary(out), Stdout: out, Stderr: errOut, GeneratedCode: code, Metrics: metrics}
 }
 
@@ -123,7 +135,99 @@ func scoreNode(response string, timeout time.Duration, testSource string) ScoreR
 	if err != nil {
 		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: errOut, GeneratedCode: code}
 	}
-	metrics := parseNodeBench(out)
+	metrics := parseRuntimeBench(out)
+	detail := "ok"
+	if metrics.RuntimeMS > 0 {
+		detail = fmt.Sprintf("runtime %.2f ms", metrics.RuntimeMS)
+	}
+	return ScoreResult{Pass: true, Score: 1, Details: detail, Stdout: out, Stderr: errOut, GeneratedCode: code, Metrics: metrics}
+}
+
+func scoreRuby(response string, timeout time.Duration, testSource string) ScoreResult {
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", "term-llm-codegen-bench-ruby-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, "solution.rb"), []byte(code), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "solution_test.rb"), []byte(testSource), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	return runScriptScore(timeout, dir, code, "ruby", "solution_test.rb")
+}
+
+func scorePython(response string, timeout time.Duration, testSource string) ScoreResult {
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", "term-llm-codegen-bench-python-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, "solution.py"), []byte(code), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "solution_test.py"), []byte(testSource), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	return runScriptScore(timeout, dir, code, "python3", "solution_test.py")
+}
+
+func scoreAssembly(response string, timeout time.Duration, testSource string) ScoreResult {
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", "term-llm-codegen-bench-asm-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, "solution.s"), []byte(code), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "test.c"), []byte(testSource), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-lc", "gcc -O2 -Wall -Wextra -no-pie solution.s test.c -o test && ./test")
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	return scriptResult(ctx, err, stdout.String(), stderr.String(), code)
+}
+
+func runScriptScore(timeout time.Duration, dir, code, name string, args ...string) ScoreResult {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return scriptResult(ctx, err, stdout.String(), stderr.String(), code)
+}
+
+func scriptResult(ctx context.Context, err error, out, errOut, code string) ScoreResult {
+	if ctx.Err() == context.DeadlineExceeded {
+		return ScoreResult{Pass: false, Score: 0, Details: "scoring timed out", Stdout: out, Stderr: errOut, GeneratedCode: code}
+	}
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: errOut, GeneratedCode: code}
+	}
+	metrics := parseRuntimeBench(out)
 	detail := "ok"
 	if metrics.RuntimeMS > 0 {
 		detail = fmt.Sprintf("runtime %.2f ms", metrics.RuntimeMS)
@@ -179,11 +283,16 @@ func parseGoBench(out string) ScoreMetrics {
 	return metrics
 }
 
-func parseNodeBench(out string) ScoreMetrics {
-	match := nodeBenchRe.FindStringSubmatch(out)
-	if len(match) == 0 {
-		return ScoreMetrics{}
+func parseRuntimeBench(out string) ScoreMetrics {
+	metrics := ScoreMetrics{}
+	if match := runtimeBenchRe.FindStringSubmatch(out); len(match) > 0 {
+		metrics.RuntimeMS, _ = strconv.ParseFloat(match[1], 64)
 	}
-	ms, _ := strconv.ParseFloat(match[1], 64)
-	return ScoreMetrics{RuntimeMS: ms}
+	if match := warmupBenchRe.FindStringSubmatch(out); len(match) > 0 {
+		metrics.WarmupMS, _ = strconv.ParseFloat(match[1], 64)
+	}
+	if match := memoryBenchRe.FindStringSubmatch(out); len(match) > 0 {
+		metrics.MemoryKB, _ = strconv.ParseFloat(match[1], 64)
+	}
+	return metrics
 }

--- a/benchmarks/codegen/scorer.go
+++ b/benchmarks/codegen/scorer.go
@@ -8,11 +8,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
 
-var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang)?\\s*\\n(.*?)\\n```")
+var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang|javascript|js|node)?\\s*\\n(.*?)\\n```")
+var goBenchRe = regexp.MustCompile(`BenchmarkGenerated\S*\s+\d+\s+([0-9.]+)\s+ns/op(?:\s+([0-9.]+)\s+B/op)?(?:\s+([0-9.]+)\s+allocs/op)?`)
+var nodeBenchRe = regexp.MustCompile(`BENCH_RUNTIME_MS=([0-9.]+)`)
 
 func extractCode(response string) (string, error) {
 	response = strings.TrimSpace(response)
@@ -24,10 +27,10 @@ func extractCode(response string) (string, error) {
 		return strings.TrimSpace(matches[1]), nil
 	}
 	// Accept raw code as a convenience for providers that obey "no prose" literally.
-	if strings.Contains(response, "func ") || strings.Contains(response, "type ") {
+	if strings.Contains(response, "func ") || strings.Contains(response, "type ") || strings.Contains(response, "export function") || strings.Contains(response, "module.exports") {
 		return response, nil
 	}
-	return "", fmt.Errorf("no Go code block found")
+	return "", fmt.Errorf("no code block found")
 }
 
 func scoreGoFunction(response string, timeout time.Duration, testBody string, imports ...string) ScoreResult {
@@ -84,7 +87,48 @@ func scoreGo(response string, timeout time.Duration, race bool, testBody string,
 	if err != nil {
 		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: errOut, GeneratedCode: code}
 	}
-	return ScoreResult{Pass: true, Score: 1, Details: perfSummary(out), Stdout: out, Stderr: errOut, GeneratedCode: code}
+	metrics := parseGoBench(out)
+	return ScoreResult{Pass: true, Score: 1, Details: perfSummary(out), Stdout: out, Stderr: errOut, GeneratedCode: code, Metrics: metrics}
+}
+
+func scoreNode(response string, timeout time.Duration, testSource string) ScoreResult {
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", "term-llm-codegen-bench-node-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, "solution.mjs"), []byte(code), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "solution.test.mjs"), []byte(testSource), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "node", "--test", "solution.test.mjs")
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	out := stdout.String()
+	errOut := stderr.String()
+	if ctx.Err() == context.DeadlineExceeded {
+		return ScoreResult{Pass: false, Score: 0, Details: "scoring timed out", Stdout: out, Stderr: errOut, GeneratedCode: code}
+	}
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: errOut, GeneratedCode: code}
+	}
+	metrics := parseNodeBench(out)
+	detail := "ok"
+	if metrics.RuntimeMS > 0 {
+		detail = fmt.Sprintf("runtime %.2f ms", metrics.RuntimeMS)
+	}
+	return ScoreResult{Pass: true, Score: 1, Details: detail, Stdout: out, Stderr: errOut, GeneratedCode: code, Metrics: metrics}
 }
 
 func buildTestSource(testBody string, imports ...string) string {
@@ -114,4 +158,32 @@ func perfSummary(out string) string {
 		}
 	}
 	return "ok"
+}
+
+func parseGoBench(out string) ScoreMetrics {
+	match := goBenchRe.FindStringSubmatch(out)
+	if len(match) == 0 {
+		return ScoreMetrics{}
+	}
+	metrics := ScoreMetrics{}
+	metrics.NSPerOp, _ = strconv.ParseFloat(match[1], 64)
+	if len(match) > 2 {
+		metrics.BytesPerOp, _ = strconv.ParseFloat(match[2], 64)
+	}
+	if len(match) > 3 {
+		metrics.AllocsPerOp, _ = strconv.ParseFloat(match[3], 64)
+	}
+	if metrics.NSPerOp > 0 {
+		metrics.RuntimeMS = metrics.NSPerOp / 1_000_000
+	}
+	return metrics
+}
+
+func parseNodeBench(out string) ScoreMetrics {
+	match := nodeBenchRe.FindStringSubmatch(out)
+	if len(match) == 0 {
+		return ScoreMetrics{}
+	}
+	ms, _ := strconv.ParseFloat(match[1], 64)
+	return ScoreMetrics{RuntimeMS: ms}
 }

--- a/benchmarks/codegen/scorer.go
+++ b/benchmarks/codegen/scorer.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang)?\\s*\\n(.*?)\\n```")
+
+func extractCode(response string) (string, error) {
+	response = strings.TrimSpace(response)
+	if response == "" {
+		return "", fmt.Errorf("empty response")
+	}
+	matches := fencedBlockRe.FindStringSubmatch(response)
+	if len(matches) >= 2 {
+		return strings.TrimSpace(matches[1]), nil
+	}
+	// Accept raw code as a convenience for providers that obey "no prose" literally.
+	if strings.Contains(response, "func ") || strings.Contains(response, "type ") {
+		return response, nil
+	}
+	return "", fmt.Errorf("no Go code block found")
+}
+
+func scoreGoFunction(response string, timeout time.Duration, testBody string, imports ...string) ScoreResult {
+	return scoreGo(response, timeout, false, testBody, imports...)
+}
+
+func scoreGoFunctionWithRace(response string, timeout time.Duration, testBody string, imports ...string) ScoreResult {
+	return scoreGo(response, timeout, true, testBody, imports...)
+}
+
+func scoreGo(response string, timeout time.Duration, race bool, testBody string, imports ...string) ScoreResult {
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", "term-llm-codegen-bench-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+
+	if !strings.Contains(code, "package ") {
+		code = "package main\n\n" + code
+	}
+	if err := os.WriteFile(filepath.Join(dir, "solution.go"), []byte(code), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+
+	testSource := buildTestSource(testBody, imports...)
+	if err := os.WriteFile(filepath.Join(dir, "solution_test.go"), []byte(testSource), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module benchsolution\n\ngo 1.22\n"), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+
+	args := []string{"test", ".", "-run", "TestGenerated", "-bench", "BenchmarkGenerated", "-benchmem", "-count", "1"}
+	if race {
+		args = append([]string{"test", "-race"}, args[1:]...)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	out := stdout.String()
+	errOut := stderr.String()
+	if ctx.Err() == context.DeadlineExceeded {
+		return ScoreResult{Pass: false, Score: 0, Details: "scoring timed out", Stdout: out, Stderr: errOut, GeneratedCode: code}
+	}
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: "tests failed", Stdout: out, Stderr: errOut, GeneratedCode: code}
+	}
+	return ScoreResult{Pass: true, Score: 1, Details: perfSummary(out), Stdout: out, Stderr: errOut, GeneratedCode: code}
+}
+
+func buildTestSource(testBody string, imports ...string) string {
+	seen := map[string]bool{"testing": true}
+	all := []string{"testing"}
+	for _, imp := range imports {
+		imp = strings.TrimSpace(imp)
+		if imp != "" && !seen[imp] {
+			seen[imp] = true
+			all = append(all, imp)
+		}
+	}
+	var b strings.Builder
+	b.WriteString("package main\n\nimport (\n")
+	for _, imp := range all {
+		fmt.Fprintf(&b, "\t%q\n", imp)
+	}
+	b.WriteString(")\n")
+	b.WriteString(testBody)
+	return b.String()
+}
+
+func perfSummary(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "BenchmarkGenerated") {
+			return strings.Join(strings.Fields(line), " ")
+		}
+	}
+	return "ok"
+}

--- a/benchmarks/codegen/scorer.go
+++ b/benchmarks/codegen/scorer.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang|javascript|js|node|ruby|rb|python|py|asm|assembly|x86_64-assembly|s)?\\s*\\n(.*?)\\n```")
+var fencedBlockRe = regexp.MustCompile("(?s)```(?:go|golang|javascript|js|node|ruby|rb|python|py|asm|assembly|x86_64-assembly|zig|s)?\\s*\\n(.*?)\\n```")
 var goBenchRe = regexp.MustCompile(`BenchmarkGenerated\S*\s+\d+\s+([0-9.]+)\s+ns/op(?:\s+([0-9.]+)\s+B/op)?(?:\s+([0-9.]+)\s+allocs/op)?`)
 var runtimeBenchRe = regexp.MustCompile(`BENCH_RUNTIME_MS=([0-9.]+)`)
 var warmupBenchRe = regexp.MustCompile(`BENCH_WARMUP_MS=([0-9.]+)`)
@@ -29,7 +29,7 @@ func extractCode(response string) (string, error) {
 		return strings.TrimSpace(matches[1]), nil
 	}
 	// Accept raw code as a convenience for providers that obey "no prose" literally.
-	if strings.Contains(response, "func ") || strings.Contains(response, "type ") || strings.Contains(response, "export function") || strings.Contains(response, "module.exports") || strings.Contains(response, "def ") || strings.Contains(response, "class ") || strings.Contains(response, ".globl") || strings.Contains(response, ".global") {
+	if strings.Contains(response, "func ") || strings.Contains(response, "type ") || strings.Contains(response, "export function") || strings.Contains(response, "module.exports") || strings.Contains(response, "def ") || strings.Contains(response, "class ") || strings.Contains(response, ".globl") || strings.Contains(response, ".global") || strings.Contains(response, "export fn") {
 		return response, nil
 	}
 	return "", fmt.Errorf("no code block found")
@@ -200,6 +200,36 @@ func scoreAssembly(response string, timeout time.Duration, testSource string) Sc
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bash", "-lc", "gcc -O2 -Wall -Wextra -no-pie solution.s test.c -o test && ./test")
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	return scriptResult(ctx, err, stdout.String(), stderr.String(), code)
+}
+
+func scoreZig(response string, timeout time.Duration, testSource string) ScoreResult {
+	if _, err := exec.LookPath("zig"); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: "zig executable not found", GeneratedCode: response}
+	}
+	code, err := extractCode(response)
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: response}
+	}
+	dir, err := os.MkdirTemp("", "term-llm-codegen-bench-zig-*")
+	if err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, "solution.zig"), []byte(code), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "test.c"), []byte(testSource), 0o644); err != nil {
+		return ScoreResult{Pass: false, Score: 0, Details: err.Error(), GeneratedCode: code}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-lc", "zig build-lib -O ReleaseFast -dynamic -femit-bin=libsolution.so solution.zig && gcc -O2 -Wall -Wextra test.c -L. -lsolution -Wl,-rpath,. -o test && ./test")
 	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -106,7 +106,7 @@ func (s *chatServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 `
-	result := webChat1000Task{}.Score(code, 20*time.Second)
+	result := webChat1000Task{}.Score(code, 60*time.Second)
 	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 {
 		t.Fatalf("expected pass with runtime metric, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
 	}
@@ -164,7 +164,7 @@ export function newChatServer() {
   }
 }
 `
-	result := nodeWebChat1000Task{}.Score(code, 20*time.Second)
+	result := nodeWebChat1000Task{}.Score(code, 60*time.Second)
 	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 {
 		t.Fatalf("expected pass with runtime metric, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
 	}

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -16,6 +16,16 @@ func TestExtractCodeFencedGoBlock(t *testing.T) {
 	}
 }
 
+func TestExtractCodeFencedJSBlock(t *testing.T) {
+	code, err := extractCode("```javascript\nexport function newChatServer() {}\n```")
+	if err != nil {
+		t.Fatalf("extractCode failed: %v", err)
+	}
+	if !strings.Contains(code, "newChatServer") {
+		t.Fatalf("unexpected code: %q", code)
+	}
+}
+
 func TestScoreGoFunctionPasses(t *testing.T) {
 	result := scoreGoFunction(`package main
 
@@ -97,7 +107,65 @@ func (s *chatServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 `
 	result := webChat1000Task{}.Score(code, 20*time.Second)
-	if !result.Pass || result.Score != 1 {
-		t.Fatalf("expected pass, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 {
+		t.Fatalf("expected pass with runtime metric, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	}
+}
+
+func TestNodeWebChat1000TaskReferenceImplementationPasses(t *testing.T) {
+	code := `
+import { URL } from 'node:url';
+
+const rooms = new Map();
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.setEncoding('utf8');
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function send(res, status, value) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(value));
+}
+
+export function newChatServer() {
+  return async function handler(req, res) {
+    const url = new URL(req.url, 'http://localhost');
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length !== 3 || parts[0] !== 'rooms' || parts[2] !== 'messages' || !parts[1]) {
+      res.writeHead(404).end();
+      return;
+    }
+    const room = parts[1];
+    if (req.method === 'POST') {
+      let body;
+      try { body = JSON.parse(await readBody(req)); } catch { res.writeHead(400).end(); return; }
+      if (!body || typeof body.user !== 'string' || body.user === '' || typeof body.text !== 'string' || body.text === '') {
+        res.writeHead(400).end();
+        return;
+      }
+      const messages = rooms.get(room) || [];
+      const msg = { seq: messages.length + 1, user: body.user, text: body.text };
+      messages.push(msg);
+      rooms.set(room, messages);
+      send(res, 201, msg);
+      return;
+    }
+    if (req.method === 'GET') {
+      send(res, 200, rooms.get(room) || []);
+      return;
+    }
+    res.writeHead(405).end();
+  }
+}
+`
+	result := nodeWebChat1000Task{}.Score(code, 20*time.Second)
+	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 {
+		t.Fatalf("expected pass with runtime metric, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
 	}
 }

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -169,3 +169,108 @@ export function newChatServer() {
 		t.Fatalf("expected pass with runtime metric, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
 	}
 }
+
+func TestRubyWebChat1000TaskReferenceImplementationPasses(t *testing.T) {
+	code := `
+require 'json'
+require 'thread'
+
+def new_chat_server
+  mutex = Mutex.new
+  rooms = Hash.new { |h, k| h[k] = [] }
+  lambda do |method, path, body|
+    parts = path.split('/').reject(&:empty?)
+    return [404, '{}'] unless parts.length == 3 && parts[0] == 'rooms' && parts[2] == 'messages' && !parts[1].empty?
+    room = parts[1]
+    case method
+    when 'POST'
+      data = JSON.parse(body)
+      return [400, '{}'] unless data['user'].is_a?(String) && data['text'].is_a?(String) && data['user'] != '' && data['text'] != ''
+      msg = nil
+      mutex.synchronize do
+        msg = {'seq' => rooms[room].length + 1, 'user' => data['user'], 'text' => data['text']}
+        rooms[room] << msg
+      end
+      [201, JSON.generate(msg)]
+    when 'GET'
+      messages = mutex.synchronize { rooms[room].map(&:dup) }
+      [200, JSON.generate(messages)]
+    else
+      [405, '{}']
+    end
+  end
+end
+`
+	result := rubyWebChat1000Task{}.Score(code, 60*time.Second)
+	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 || result.Metrics.WarmupMS <= 0 || result.Metrics.MemoryKB <= 0 {
+		t.Fatalf("expected pass with runtime/warmup/memory, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	}
+}
+
+func TestPythonWebChat1000TaskReferenceImplementationPasses(t *testing.T) {
+	code := `
+import json
+import threading
+
+class ChatServer:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.rooms = {}
+    def __call__(self, method, path, body):
+        parts = [p for p in path.split('/') if p]
+        if len(parts) != 3 or parts[0] != 'rooms' or parts[2] != 'messages' or not parts[1]:
+            return 404, '{}'
+        room = parts[1]
+        if method == 'POST':
+            try:
+                data = json.loads(body)
+            except Exception:
+                return 400, '{}'
+            if not isinstance(data.get('user'), str) or not data['user'] or not isinstance(data.get('text'), str) or not data['text']:
+                return 400, '{}'
+            with self.lock:
+                messages = self.rooms.setdefault(room, [])
+                msg = {'seq': len(messages) + 1, 'user': data['user'], 'text': data['text']}
+                messages.append(msg)
+            return 201, json.dumps(msg)
+        if method == 'GET':
+            with self.lock:
+                messages = list(self.rooms.get(room, []))
+            return 200, json.dumps(messages)
+        return 405, '{}'
+
+def new_chat_server():
+    return ChatServer()
+`
+	result := pythonWebChat1000Task{}.Score(code, 60*time.Second)
+	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 || result.Metrics.WarmupMS <= 0 || result.Metrics.MemoryKB <= 0 {
+		t.Fatalf("expected pass with runtime/warmup/memory, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	}
+}
+
+func TestAssemblySumPositiveTaskReferenceImplementationPasses(t *testing.T) {
+	code := `
+.text
+.globl sum_positive
+.type sum_positive, @function
+sum_positive:
+    xor %rax, %rax
+    test %rsi, %rsi
+    jle .done
+.loop:
+    mov (%rdi), %rdx
+    test %rdx, %rdx
+    jle .skip
+    add %rdx, %rax
+.skip:
+    add $8, %rdi
+    dec %rsi
+    jne .loop
+.done:
+    ret
+`
+	result := assemblySumPositiveTask{}.Score(code, 60*time.Second)
+	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 || result.Metrics.WarmupMS <= 0 || result.Metrics.MemoryKB <= 0 {
+		t.Fatalf("expected pass with runtime/warmup/memory, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	}
+}

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -38,3 +38,66 @@ func TestGenerated(t *testing.T) {
 		t.Fatalf("expected pass, got %#v", result)
 	}
 }
+
+func TestWebChat1000TaskReferenceImplementationPasses(t *testing.T) {
+	code := `package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type storedMessage struct {
+	Seq  int    ` + "`" + `json:"seq"` + "`" + `
+	User string ` + "`" + `json:"user"` + "`" + `
+	Text string ` + "`" + `json:"text"` + "`" + `
+}
+
+type chatServer struct {
+	mu    sync.Mutex
+	rooms map[string][]storedMessage
+}
+
+func NewChatServer() http.Handler {
+	return &chatServer{rooms: make(map[string][]storedMessage)}
+}
+
+func (s *chatServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) != 3 || parts[0] != "rooms" || parts[2] != "messages" || parts[1] == "" {
+		http.NotFound(w, r)
+		return
+	}
+	room := parts[1]
+	w.Header().Set("Content-Type", "application/json")
+	switch r.Method {
+	case http.MethodPost:
+		var in struct { User, Text string }
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil || in.User == "" || in.Text == "" {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		s.mu.Lock()
+		msg := storedMessage{Seq: len(s.rooms[room]) + 1, User: in.User, Text: in.Text}
+		s.rooms[room] = append(s.rooms[room], msg)
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(msg)
+	case http.MethodGet:
+		s.mu.Lock()
+		messages := append([]storedMessage(nil), s.rooms[room]...)
+		s.mu.Unlock()
+		if messages == nil { messages = []storedMessage{} }
+		_ = json.NewEncoder(w).Encode(messages)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+`
+	result := webChat1000Task{}.Score(code, 20*time.Second)
+	if !result.Pass || result.Score != 1 {
+		t.Fatalf("expected pass, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	}
+}

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -270,6 +271,28 @@ sum_positive:
     ret
 `
 	result := assemblySumPositiveTask{}.Score(code, 60*time.Second)
+	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 || result.Metrics.WarmupMS <= 0 || result.Metrics.MemoryKB <= 0 {
+		t.Fatalf("expected pass with runtime/warmup/memory, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
+	}
+}
+
+func TestZigSumPositiveTaskReferenceImplementationPasses(t *testing.T) {
+	if _, err := exec.LookPath("zig"); err != nil {
+		t.Skip("zig not installed")
+	}
+	code := `
+export fn sum_positive(xs: [*]const i64, n: isize) i64 {
+    if (n <= 0) return 0;
+    var sum: i64 = 0;
+    var i: isize = 0;
+    while (i < n) : (i += 1) {
+        const v = xs[@intCast(i)];
+        if (v > 0) sum += v;
+    }
+    return sum;
+}
+`
+	result := zigSumPositiveTask{}.Score(code, 60*time.Second)
 	if !result.Pass || result.Score != 1 || result.Metrics.RuntimeMS <= 0 || result.Metrics.WarmupMS <= 0 || result.Metrics.MemoryKB <= 0 {
 		t.Fatalf("expected pass with runtime/warmup/memory, detail=%s stdout=%s stderr=%s", result.Details, result.Stdout, result.Stderr)
 	}

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -7,6 +7,21 @@ import (
 	"time"
 )
 
+func TestBuildPromptRequiresSelfValidation(t *testing.T) {
+	prompt := buildPrompt(fizzBuzzTask{})
+	checks := []string{
+		"Self-validation requirement before final output",
+		"required function/type/export name",
+		"includes every required import/header",
+		"If you find a problem, fix it before returning the code block",
+	}
+	for _, check := range checks {
+		if !strings.Contains(prompt, check) {
+			t.Fatalf("prompt missing %q:\n%s", check, prompt)
+		}
+	}
+}
+
 func TestExtractCodeFencedGoBlock(t *testing.T) {
 	code, err := extractCode("prose\n```go\npackage main\nfunc X() {}\n```\nmore")
 	if err != nil {

--- a/benchmarks/codegen/scorer_test.go
+++ b/benchmarks/codegen/scorer_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExtractCodeFencedGoBlock(t *testing.T) {
+	code, err := extractCode("prose\n```go\npackage main\nfunc X() {}\n```\nmore")
+	if err != nil {
+		t.Fatalf("extractCode failed: %v", err)
+	}
+	if !strings.Contains(code, "func X") {
+		t.Fatalf("unexpected code: %q", code)
+	}
+}
+
+func TestScoreGoFunctionPasses(t *testing.T) {
+	result := scoreGoFunction(`package main
+
+func BinarySearch(xs []int, target int) int {
+	lo, hi := 0, len(xs)-1
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		if xs[mid] == target { return mid }
+		if xs[mid] < target { lo = mid + 1 } else { hi = mid - 1 }
+	}
+	return -1
+}`, 10*time.Second, `
+func TestGenerated(t *testing.T) {
+	if got := BinarySearch([]int{1, 3, 5}, 3); got != 1 {
+		t.Fatalf("got %d", got)
+	}
+}
+`)
+	if !result.Pass || result.Score != 1 {
+		t.Fatalf("expected pass, got %#v", result)
+	}
+}

--- a/benchmarks/codegen/tasks.go
+++ b/benchmarks/codegen/tasks.go
@@ -15,6 +15,7 @@ func allTasks() []Task {
 		concurrentCounterTask{},
 		allocationTask{},
 		webChat1000Task{},
+		nodeWebChat1000Task{},
 	}
 }
 

--- a/benchmarks/codegen/tasks.go
+++ b/benchmarks/codegen/tasks.go
@@ -16,6 +16,9 @@ func allTasks() []Task {
 		allocationTask{},
 		webChat1000Task{},
 		nodeWebChat1000Task{},
+		rubyWebChat1000Task{},
+		pythonWebChat1000Task{},
+		assemblySumPositiveTask{},
 	}
 }
 

--- a/benchmarks/codegen/tasks.go
+++ b/benchmarks/codegen/tasks.go
@@ -14,6 +14,7 @@ func allTasks() []Task {
 		jsonFormatTask{},
 		concurrentCounterTask{},
 		allocationTask{},
+		webChat1000Task{},
 	}
 }
 

--- a/benchmarks/codegen/tasks.go
+++ b/benchmarks/codegen/tasks.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+func allTasks() []Task {
+	return []Task{
+		fizzBuzzTask{},
+		binarySearchTask{},
+		jsonFormatTask{},
+		concurrentCounterTask{},
+		allocationTask{},
+	}
+}
+
+func selectTasks(spec string) ([]Task, error) {
+	tasks := allTasks()
+	if strings.TrimSpace(spec) == "" || strings.EqualFold(strings.TrimSpace(spec), "all") {
+		return tasks, nil
+	}
+	byName := make(map[string]Task, len(tasks))
+	var names []string
+	for _, t := range tasks {
+		byName[t.Name()] = t
+		names = append(names, t.Name())
+	}
+	var selected []Task
+	for _, raw := range strings.Split(spec, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		t, ok := byName[name]
+		if !ok {
+			sort.Strings(names)
+			return nil, fmt.Errorf("unknown task %q; available: %s", name, strings.Join(names, ", "))
+		}
+		selected = append(selected, t)
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no tasks selected")
+	}
+	return selected, nil
+}
+
+type fizzBuzzTask struct{}
+
+func (fizzBuzzTask) Name() string       { return "go_fizzbuzz" }
+func (fizzBuzzTask) Language() string   { return "go" }
+func (fizzBuzzTask) Difficulty() string { return "easy-correctness" }
+func (fizzBuzzTask) Prompt() string {
+	return `Write a complete Go source file for package main, including any imports, that defines exactly this function:
+
+func FizzBuzz(n int) []string
+
+For 1..n return decimal numbers, except multiples of 3 are "Fizz", multiples of 5 are "Buzz", and multiples of both are "FizzBuzz". Include an import block if you use strconv, fmt, or any other package. Do not include a main function.`
+}
+func (fizzBuzzTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreGoFunction(response, timeout, `
+func TestGenerated(t *testing.T) {
+	got := FizzBuzz(16)
+	want := []string{"1","2","Fizz","4","Buzz","Fizz","7","8","Fizz","Buzz","11","Fizz","13","14","FizzBuzz","16"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FizzBuzz(16) = %#v, want %#v", got, want)
+	}
+	if len(FizzBuzz(0)) != 0 {
+		t.Fatalf("FizzBuzz(0) should be empty")
+	}
+}
+`, "reflect")
+}
+
+type binarySearchTask struct{}
+
+func (binarySearchTask) Name() string       { return "go_binary_search" }
+func (binarySearchTask) Language() string   { return "go" }
+func (binarySearchTask) Difficulty() string { return "medium-correctness" }
+func (binarySearchTask) Prompt() string {
+	return `Write a complete Go source file for package main, including any imports, that defines exactly this function:
+
+func BinarySearch(xs []int, target int) int
+
+Return the index of target in the sorted slice, or -1 when absent. It must handle empty slices, one-element slices, negative numbers, and large slices without recursion. Do not include a main function.`
+}
+func (binarySearchTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreGoFunction(response, timeout, `
+func TestGenerated(t *testing.T) {
+	cases := []struct{
+		xs []int
+		target int
+		want int
+	}{
+		{[]int{}, 1, -1},
+		{[]int{7}, 7, 0},
+		{[]int{7}, 8, -1},
+		{[]int{-9,-4,0,3,8,12}, -4, 1},
+		{[]int{-9,-4,0,3,8,12}, 12, 5},
+		{[]int{-9,-4,0,3,8,12}, 2, -1},
+	}
+	for _, c := range cases {
+		if got := BinarySearch(c.xs, c.target); got != c.want {
+			t.Fatalf("BinarySearch(%v, %d) = %d, want %d", c.xs, c.target, got, c.want)
+		}
+	}
+}
+`)
+}
+
+type jsonFormatTask struct{}
+
+func (jsonFormatTask) Name() string       { return "go_json_format" }
+func (jsonFormatTask) Language() string   { return "go" }
+func (jsonFormatTask) Difficulty() string { return "medium-api" }
+func (jsonFormatTask) Prompt() string {
+	return `Write a complete Go source file for package main, including any imports, that defines exactly this function:
+
+func FormatPersonJSON(input string) (string, error)
+
+The input is a JSON object with fields "name" (string) and "age" (integer). Return "Name: <name>, Age: <age>". Return an error for invalid JSON, missing name, or negative age. Do not include a main function.`
+}
+func (jsonFormatTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreGoFunction(response, timeout, `
+func TestGenerated(t *testing.T) {
+	got, err := FormatPersonJSON(`+"`"+`{"name":"Ada","age":37}`+"`"+`)
+	if err != nil || got != "Name: Ada, Age: 37" {
+		t.Fatalf("valid person = %q, %v", got, err)
+	}
+	got, err = FormatPersonJSON(`+"`"+` { "age": 5, "name": "Grace" } `+"`"+`)
+	if err != nil || got != "Name: Grace, Age: 5" {
+		t.Fatalf("valid reordered person = %q, %v", got, err)
+	}
+	bad := []string{`+"`"+`not json`+"`"+`, `+"`"+`{"name":"Ada","age":-1}`+"`"+`, `+"`"+`{"age":10}`+"`"+`}
+	for _, input := range bad {
+		if _, err := FormatPersonJSON(input); err == nil {
+			t.Fatalf("FormatPersonJSON(%s) returned nil error", input)
+		}
+	}
+}
+`)
+}
+
+type concurrentCounterTask struct{}
+
+func (concurrentCounterTask) Name() string       { return "go_concurrent_counter" }
+func (concurrentCounterTask) Language() string   { return "go" }
+func (concurrentCounterTask) Difficulty() string { return "hard-correctness-race" }
+func (concurrentCounterTask) Prompt() string {
+	return `Write a complete Go source file for package main, including any imports, that defines a concurrency-safe Counter type with exactly these methods:
+
+type Counter struct { ... }
+func (c *Counter) Inc()
+func (c *Counter) Value() int64
+
+It must be safe under concurrent use by many goroutines. Do not include a main function.`
+}
+func (concurrentCounterTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreGoFunctionWithRace(response, timeout, `
+func TestGenerated(t *testing.T) {
+	var c Counter
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				c.Inc()
+			}
+		}()
+	}
+	wg.Wait()
+	if got := c.Value(); got != 100000 {
+		t.Fatalf("Value() = %d, want 100000", got)
+	}
+}
+`, "sync")
+}
+
+type allocationTask struct{}
+
+func (allocationTask) Name() string       { return "go_dedupe_perf" }
+func (allocationTask) Language() string   { return "go" }
+func (allocationTask) Difficulty() string { return "perf" }
+func (allocationTask) Prompt() string {
+	return `Write a complete Go source file for package main, including any imports, that defines exactly this function:
+
+func DedupeStable(xs []string) []string
+
+Return the first occurrence of each string while preserving order. It must not mutate the input. Optimize for correctness and reasonable allocations on 10k-item slices with many duplicates. Do not include a main function.`
+}
+func (allocationTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreGoFunction(response, timeout, `
+func TestGenerated(t *testing.T) {
+	in := []string{"b","a","b","c","a","d"}
+	got := DedupeStable(in)
+	want := []string{"b","a","c","d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DedupeStable = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(in, []string{"b","a","b","c","a","d"}) {
+		t.Fatalf("input mutated: %#v", in)
+	}
+}
+
+func BenchmarkGenerated(b *testing.B) {
+	xs := make([]string, 10000)
+	for i := range xs {
+		xs[i] = fmt.Sprintf("key-%d", i%250)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got := DedupeStable(xs)
+		if len(got) != 250 {
+			b.Fatalf("len=%d", len(got))
+		}
+	}
+}
+`, "fmt", "reflect")
+}

--- a/benchmarks/codegen/tasks.go
+++ b/benchmarks/codegen/tasks.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func allTasks() []Task {
+func defaultTasks() []Task {
 	return []Task{
 		fizzBuzzTask{},
 		binarySearchTask{},
@@ -22,10 +22,20 @@ func allTasks() []Task {
 	}
 }
 
+func optionalTasks() []Task {
+	return []Task{
+		zigSumPositiveTask{},
+	}
+}
+
+func allTasks() []Task {
+	return append(defaultTasks(), optionalTasks()...)
+}
+
 func selectTasks(spec string) ([]Task, error) {
 	tasks := allTasks()
 	if strings.TrimSpace(spec) == "" || strings.EqualFold(strings.TrimSpace(spec), "all") {
-		return tasks, nil
+		return defaultTasks(), nil
 	}
 	byName := make(map[string]Task, len(tasks))
 	var names []string

--- a/benchmarks/codegen/tasks_assembly.go
+++ b/benchmarks/codegen/tasks_assembly.go
@@ -1,0 +1,90 @@
+package main
+
+import "time"
+
+type assemblySumPositiveTask struct{}
+
+func (assemblySumPositiveTask) Name() string       { return "asm_sum_positive_perf" }
+func (assemblySumPositiveTask) Language() string   { return "x86_64-assembly" }
+func (assemblySumPositiveTask) Difficulty() string { return "medium-perf-correctness" }
+func (assemblySumPositiveTask) Prompt() string {
+	return `Write a complete x86-64 GNU assembler source file for Linux using AT&T syntax that defines exactly this exported function:
+
+long sum_positive(long *xs, long n);
+
+System V AMD64 ABI:
+- xs is in %rdi
+- n is in %rsi
+- return value is in %rax
+
+The function must return the sum of all positive values in xs[0:n]. Ignore zero and negative values. If n <= 0, return 0.
+
+Requirements:
+- Use only assembly; do not include C code.
+- Export the symbol as sum_positive.
+- Do not call libc or any external function.
+- Must be correct for negative numbers, empty arrays, and mixed values.
+- Prefer a simple fast loop over cleverness.`
+}
+
+func (assemblySumPositiveTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreAssembly(response, timeout, `
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <time.h>
+
+long sum_positive(long *xs, long n);
+
+static void check(const char *name, long *xs, long n, long want) {
+  long got = sum_positive(xs, n);
+  if (got != want) {
+    fprintf(stderr, "%s: got %ld want %ld\n", name, got, want);
+    exit(1);
+  }
+}
+
+static double elapsed_ms(struct timespec start, struct timespec end) {
+  return (double)(end.tv_sec - start.tv_sec) * 1000.0 + (double)(end.tv_nsec - start.tv_nsec) / 1000000.0;
+}
+
+int main(void) {
+  long empty[] = {1};
+  long mixed[] = {-5, 0, 7, -2, 9, 1};
+  long negatives[] = {-9, -8, -7};
+  check("n<=0", empty, 0, 0);
+  check("mixed", mixed, 6, 17);
+  check("negative", negatives, 3, 0);
+
+  const long n = 4096;
+  long *xs = malloc(sizeof(long) * n);
+  if (!xs) return 1;
+  long want = 0;
+  for (long i = 0; i < n; i++) {
+    long v = (i % 11) - 5;
+    xs[i] = v;
+    if (v > 0) want += v;
+  }
+  check("bulk", xs, n, want);
+
+  volatile long sink = 0;
+  struct timespec a, b;
+  clock_gettime(CLOCK_MONOTONIC, &a);
+  for (int i = 0; i < 10000; i++) sink += sum_positive(xs, n);
+  clock_gettime(CLOCK_MONOTONIC, &b);
+  printf("BENCH_WARMUP_MS=%.3f\n", elapsed_ms(a, b));
+
+  clock_gettime(CLOCK_MONOTONIC, &a);
+  for (int i = 0; i < 200000; i++) sink += sum_positive(xs, n);
+  clock_gettime(CLOCK_MONOTONIC, &b);
+  if (sink == 42) puts("impossible");
+  printf("BENCH_RUNTIME_MS=%.3f\n", elapsed_ms(a, b));
+  struct rusage usage;
+  getrusage(RUSAGE_SELF, &usage);
+  printf("BENCH_MEMORY_KB=%ld\n", usage.ru_maxrss);
+  free(xs);
+  return 0;
+}
+`)
+}

--- a/benchmarks/codegen/tasks_node_web_chat.go
+++ b/benchmarks/codegen/tasks_node_web_chat.go
@@ -56,13 +56,13 @@ async function postJSON(base, path, body) {
   });
 }
 
-async function exerciseChat(base, users) {
-  const bad = await postJSON(base, '/rooms/lobby/messages', { user: '', text: 'hello' });
+async function exerciseChat(base, room, users) {
+  const bad = await postJSON(base, '/rooms/' + room + '/messages', { user: '', text: 'hello' });
   assert.ok(bad.status >= 400 && bad.status <= 499, `+"`"+`empty user status ${bad.status}, want 4xx`+"`"+`);
 
   const started = performance.now();
   const responses = await Promise.all(Array.from({ length: users }, async (_, i) => {
-    const res = await postJSON(base, '/rooms/lobby/messages', { user: `+"`"+`user-${i}`+"`"+`, text: `+"`"+`hello-${i}`+"`"+` });
+    const res = await postJSON(base, '/rooms/' + room + '/messages', { user: `+"`"+`user-${i}`+"`"+`, text: `+"`"+`hello-${i}`+"`"+` });
     const text = await res.text();
     assert.equal(res.status, 201, `+"`"+`POST ${i} status ${res.status} body=${text}`+"`"+`);
     const msg = JSON.parse(text);
@@ -73,7 +73,7 @@ async function exerciseChat(base, users) {
   }));
   assert.equal(responses.length, users);
 
-  const get = await fetch(base + '/rooms/lobby/messages');
+  const get = await fetch(base + '/rooms/' + room + '/messages');
   assert.equal(get.status, 200);
   const messages = await get.json();
   assert.equal(messages.length, users);
@@ -99,8 +99,11 @@ async function exerciseChat(base, users) {
 test('generated Node chat server handles 1000 concurrent posters', async () => {
   const { server, base } = await startServer();
   try {
-    const runtime = await exerciseChat(base, 1000);
-    console.log(`+"`"+`BENCH_RUNTIME_MS=${runtime.toFixed(3)}`+"`"+`);
+    const warmup = await exerciseChat(base, 'warmup', 100);
+    console.log('BENCH_WARMUP_MS=' + warmup.toFixed(3));
+    const runtime = await exerciseChat(base, 'lobby', 1000);
+    console.log('BENCH_RUNTIME_MS=' + runtime.toFixed(3));
+    console.log('BENCH_MEMORY_KB=' + (process.memoryUsage().rss / 1024).toFixed(0));
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }

--- a/benchmarks/codegen/tasks_node_web_chat.go
+++ b/benchmarks/codegen/tasks_node_web_chat.go
@@ -1,0 +1,109 @@
+package main
+
+import "time"
+
+type nodeWebChat1000Task struct{}
+
+func (nodeWebChat1000Task) Name() string       { return "node_web_chat_1000" }
+func (nodeWebChat1000Task) Language() string   { return "javascript" }
+func (nodeWebChat1000Task) Difficulty() string { return "hard-web-concurrency" }
+func (nodeWebChat1000Task) Prompt() string {
+	return `Write a complete Node.js ES module using only the Node standard library that exports exactly this function:
+
+export function newChatServer()
+
+Return an HTTP request listener suitable for http.createServer(newChatServer()).
+
+Implement a tiny in-memory multi-room web chat API.
+
+Required endpoints:
+
+POST /rooms/{room}/messages
+- Request body JSON: {"user":"alice","text":"hello"}
+- user and text must be non-empty strings
+- Append the message to that room and assign a monotonically increasing seq number starting at 1 per room
+- Return HTTP 201 with the stored message as JSON: {"seq":1,"user":"alice","text":"hello"}
+
+GET /rooms/{room}/messages
+- Return HTTP 200 with a JSON array of all stored messages for that room in seq order
+- Unknown rooms return an empty JSON array []
+
+Anything else should return an appropriate 4xx status.
+
+The handler must survive 1000 concurrent users posting at the same time. Do not start a server or read stdin.`
+}
+
+func (nodeWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreNode(response, timeout, `
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { performance } from 'node:perf_hooks';
+import { newChatServer } from './solution.mjs';
+
+async function startServer() {
+  const server = http.createServer(newChatServer());
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return { server, base: `+"`"+`http://127.0.0.1:${address.port}`+"`"+` };
+}
+
+async function postJSON(base, path, body) {
+  return fetch(base + path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function exerciseChat(base, users) {
+  const bad = await postJSON(base, '/rooms/lobby/messages', { user: '', text: 'hello' });
+  assert.ok(bad.status >= 400 && bad.status <= 499, `+"`"+`empty user status ${bad.status}, want 4xx`+"`"+`);
+
+  const started = performance.now();
+  const responses = await Promise.all(Array.from({ length: users }, async (_, i) => {
+    const res = await postJSON(base, '/rooms/lobby/messages', { user: `+"`"+`user-${i}`+"`"+`, text: `+"`"+`hello-${i}`+"`"+` });
+    const text = await res.text();
+    assert.equal(res.status, 201, `+"`"+`POST ${i} status ${res.status} body=${text}`+"`"+`);
+    const msg = JSON.parse(text);
+    assert.ok(msg.seq >= 1 && msg.seq <= users, `+"`"+`bad seq ${msg.seq}`+"`"+`);
+    assert.equal(msg.user, `+"`"+`user-${i}`+"`"+`);
+    assert.equal(msg.text, `+"`"+`hello-${i}`+"`"+`);
+    return msg;
+  }));
+  assert.equal(responses.length, users);
+
+  const get = await fetch(base + '/rooms/lobby/messages');
+  assert.equal(get.status, 200);
+  const messages = await get.json();
+  assert.equal(messages.length, users);
+  const seenSeq = new Set();
+  const seenUsers = new Set();
+  let lastSeq = 0;
+  for (const msg of messages) {
+    assert.ok(msg.seq > lastSeq, `+"`"+`messages not in seq order around ${msg.seq}`+"`"+`);
+    lastSeq = msg.seq;
+    assert.ok(msg.seq >= 1 && msg.seq <= users, `+"`"+`bad seq ${msg.seq}`+"`"+`);
+    assert.ok(!seenSeq.has(msg.seq), `+"`"+`duplicate seq ${msg.seq}`+"`"+`);
+    seenSeq.add(msg.seq);
+    seenUsers.add(msg.user);
+  }
+  for (let i = 0; i < users; i++) assert.ok(seenUsers.has(`+"`"+`user-${i}`+"`"+`), `+"`"+`missing user-${i}`+"`"+`);
+
+  const empty = await fetch(base + '/rooms/empty/messages');
+  assert.equal(empty.status, 200);
+  assert.deepEqual(await empty.json(), []);
+  return performance.now() - started;
+}
+
+test('generated Node chat server handles 1000 concurrent posters', async () => {
+  const { server, base } = await startServer();
+  try {
+    const runtime = await exerciseChat(base, 1000);
+    console.log(`+"`"+`BENCH_RUNTIME_MS=${runtime.toFixed(3)}`+"`"+`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+`)
+}

--- a/benchmarks/codegen/tasks_node_web_chat.go
+++ b/benchmarks/codegen/tasks_node_web_chat.go
@@ -34,79 +34,18 @@ The handler must survive 1000 concurrent users posting at the same time. Do not 
 }
 
 func (nodeWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
-	return scoreNode(response, timeout, `
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import http from 'node:http';
-import { performance } from 'node:perf_hooks';
+	return scoreHTTPServer(response, timeout, httpServerSpec{
+		Prefix: "term-llm-codegen-bench-node-http",
+		Files: map[string]string{
+			"solution.mjs": "{{CODE}}",
+			"server.mjs": `import http from 'node:http';
 import { newChatServer } from './solution.mjs';
 
-async function startServer() {
-  const server = http.createServer(newChatServer());
-  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  return { server, base: `+"`"+`http://127.0.0.1:${address.port}`+"`"+` };
-}
-
-async function postJSON(base, path, body) {
-  return fetch(base + path, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-}
-
-async function exerciseChat(base, room, users) {
-  const bad = await postJSON(base, '/rooms/' + room + '/messages', { user: '', text: 'hello' });
-  assert.ok(bad.status >= 400 && bad.status <= 499, `+"`"+`empty user status ${bad.status}, want 4xx`+"`"+`);
-
-  const started = performance.now();
-  const responses = await Promise.all(Array.from({ length: users }, async (_, i) => {
-    const res = await postJSON(base, '/rooms/' + room + '/messages', { user: `+"`"+`user-${i}`+"`"+`, text: `+"`"+`hello-${i}`+"`"+` });
-    const text = await res.text();
-    assert.equal(res.status, 201, `+"`"+`POST ${i} status ${res.status} body=${text}`+"`"+`);
-    const msg = JSON.parse(text);
-    assert.ok(msg.seq >= 1 && msg.seq <= users, `+"`"+`bad seq ${msg.seq}`+"`"+`);
-    assert.equal(msg.user, `+"`"+`user-${i}`+"`"+`);
-    assert.equal(msg.text, `+"`"+`hello-${i}`+"`"+`);
-    return msg;
-  }));
-  assert.equal(responses.length, users);
-
-  const get = await fetch(base + '/rooms/' + room + '/messages');
-  assert.equal(get.status, 200);
-  const messages = await get.json();
-  assert.equal(messages.length, users);
-  const seenSeq = new Set();
-  const seenUsers = new Set();
-  let lastSeq = 0;
-  for (const msg of messages) {
-    assert.ok(msg.seq > lastSeq, `+"`"+`messages not in seq order around ${msg.seq}`+"`"+`);
-    lastSeq = msg.seq;
-    assert.ok(msg.seq >= 1 && msg.seq <= users, `+"`"+`bad seq ${msg.seq}`+"`"+`);
-    assert.ok(!seenSeq.has(msg.seq), `+"`"+`duplicate seq ${msg.seq}`+"`"+`);
-    seenSeq.add(msg.seq);
-    seenUsers.add(msg.user);
-  }
-  for (let i = 0; i < users; i++) assert.ok(seenUsers.has(`+"`"+`user-${i}`+"`"+`), `+"`"+`missing user-${i}`+"`"+`);
-
-  const empty = await fetch(base + '/rooms/empty/messages');
-  assert.equal(empty.status, 200);
-  assert.deepEqual(await empty.json(), []);
-  return performance.now() - started;
-}
-
-test('generated Node chat server handles 1000 concurrent posters', async () => {
-  const { server, base } = await startServer();
-  try {
-    const warmup = await exerciseChat(base, 'warmup', 100);
-    console.log('BENCH_WARMUP_MS=' + warmup.toFixed(3));
-    const runtime = await exerciseChat(base, 'lobby', 1000);
-    console.log('BENCH_RUNTIME_MS=' + runtime.toFixed(3));
-    console.log('BENCH_MEMORY_KB=' + (process.memoryUsage().rss / 1024).toFixed(0));
-  } finally {
-    await new Promise((resolve) => server.close(resolve));
-  }
-});
-`)
+const port = Number(process.env.PORT || 8080);
+const server = http.createServer(newChatServer());
+server.listen(port, '127.0.0.1');
+`,
+		},
+		Cmd: []string{"node", "server.mjs"},
+	})
 }

--- a/benchmarks/codegen/tasks_python_web_chat.go
+++ b/benchmarks/codegen/tasks_python_web_chat.go
@@ -1,0 +1,117 @@
+package main
+
+import "time"
+
+type pythonWebChat1000Task struct{}
+
+func (pythonWebChat1000Task) Name() string       { return "python_web_chat_1000" }
+func (pythonWebChat1000Task) Language() string   { return "python" }
+func (pythonWebChat1000Task) Difficulty() string { return "hard-concurrency" }
+func (pythonWebChat1000Task) Prompt() string {
+	return `Write a complete Python 3 source file using only the Python standard library that defines exactly this function:
+
+def new_chat_server():
+
+Return a callable object/function. The benchmark will call it as:
+
+status, json_body = server(method, path, json_request_body)
+
+Implement a tiny in-memory multi-room chat API.
+
+Required operations:
+
+POST /rooms/{room}/messages
+- Request body JSON: {"user":"alice","text":"hello"}
+- user and text must be non-empty strings
+- Append the message to that room and assign a monotonically increasing seq number starting at 1 per room
+- Return (201, JSON string like {"seq":1,"user":"alice","text":"hello"})
+
+GET /rooms/{room}/messages
+- Return (200, JSON array string) with all stored messages for that room in seq order
+- Unknown rooms return []
+
+Anything else should return an appropriate 4xx status and a JSON body.
+
+The callable must be safe for 1000 concurrent Python threads posting at the same time. Do not start a server, read stdin, or print anything.`
+}
+
+func (pythonWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
+	return scorePython(response, timeout, `
+import json
+import resource
+import threading
+import time
+from solution import new_chat_server
+
+server = new_chat_server()
+if not callable(server):
+    raise SystemExit('new_chat_server must return a callable object')
+
+bad_status, _ = server('POST', '/rooms/lobby/messages', json.dumps({'user': '', 'text': 'hello'}))
+if not isinstance(bad_status, int) or bad_status < 400 or bad_status > 499:
+    raise SystemExit(f'empty user status {bad_status!r}, want 4xx')
+
+def exercise(room, users):
+    started = time.perf_counter()
+    responses = [None] * users
+    errors = []
+    lock = threading.Lock()
+
+    def worker(i):
+        try:
+            status, body = server('POST', f'/rooms/{room}/messages', json.dumps({'user': f'user-{i}', 'text': f'hello-{i}'}))
+            if status != 201:
+                raise RuntimeError(f'POST {i} status {status!r} body={body!r}')
+            msg = json.loads(body)
+            if not isinstance(msg.get('seq'), int) or msg['seq'] < 1 or msg['seq'] > users:
+                raise RuntimeError(f'bad seq {msg.get("seq")!r}')
+            if msg.get('user') != f'user-{i}' or msg.get('text') != f'hello-{i}':
+                raise RuntimeError(f'bad user/text {msg!r}')
+            responses[i] = msg
+        except Exception as e:
+            with lock:
+                errors.append(str(e))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(users)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    if errors:
+        raise SystemExit(errors[0])
+    if sum(1 for r in responses if r is not None) != users:
+        raise SystemExit('missing responses')
+
+    status, body = server('GET', f'/rooms/{room}/messages', None)
+    if status != 200:
+        raise SystemExit(f'GET status {status!r} body={body!r}')
+    messages = json.loads(body)
+    if len(messages) != users:
+        raise SystemExit(f'message count {len(messages)}, want {users}')
+    seen_seq = set()
+    seen_users = set()
+    last_seq = 0
+    for msg in messages:
+        seq = msg['seq']
+        if seq <= last_seq:
+            raise SystemExit(f'messages not in seq order around {seq} after {last_seq}')
+        last_seq = seq
+        if seq < 1 or seq > users or seq in seen_seq:
+            raise SystemExit(f'bad or duplicate seq {seq!r}')
+        seen_seq.add(seq)
+        seen_users.add(msg['user'])
+    for i in range(users):
+        if f'user-{i}' not in seen_users:
+            raise SystemExit(f'missing user-{i}')
+    return (time.perf_counter() - started) * 1000.0
+
+warmup = exercise('warmup', 100)
+print(f'BENCH_WARMUP_MS={warmup:.3f}')
+runtime = exercise('lobby', 1000)
+print(f'BENCH_RUNTIME_MS={runtime:.3f}')
+status, body = server('GET', '/rooms/empty/messages', None)
+if status != 200 or json.loads(body) != []:
+    raise SystemExit(f'empty room status={status!r} body={body!r}')
+print(f'BENCH_MEMORY_KB={resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}')
+`)
+}

--- a/benchmarks/codegen/tasks_python_web_chat.go
+++ b/benchmarks/codegen/tasks_python_web_chat.go
@@ -6,15 +6,17 @@ type pythonWebChat1000Task struct{}
 
 func (pythonWebChat1000Task) Name() string       { return "python_web_chat_1000" }
 func (pythonWebChat1000Task) Language() string   { return "python" }
-func (pythonWebChat1000Task) Difficulty() string { return "hard-concurrency" }
+func (pythonWebChat1000Task) Difficulty() string { return "hard-web-concurrency" }
 func (pythonWebChat1000Task) Prompt() string {
 	return `Write a complete Python 3 source file using only the Python standard library that defines exactly this function:
 
 def new_chat_server():
 
-Return a callable object/function. The benchmark will call it as:
+Return a callable object/function. The benchmark adapter will call it as:
 
-status, json_body = server(method, path, json_request_body)
+status, json_body = server(method, path, raw_json_request_body)
+
+The third argument is a raw JSON string for POST requests; parse it with json.loads.
 
 Implement a tiny in-memory multi-room chat API.
 
@@ -32,86 +34,56 @@ GET /rooms/{room}/messages
 
 Anything else should return an appropriate 4xx status and a JSON body.
 
-The callable must be safe for 1000 concurrent Python threads posting at the same time. Do not start a server, read stdin, or print anything.`
+The callable must be safe for 1000 concurrent HTTP requests posting at the same time. Do not start a server, read stdin, or print anything.`
 }
 
 func (pythonWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
-	return scorePython(response, timeout, `
-import json
-import resource
-import threading
-import time
+	return scoreHTTPServer(response, timeout, httpServerSpec{
+		Prefix: "term-llm-codegen-bench-python-http",
+		Files: map[string]string{
+			"solution.py": "{{CODE}}",
+			"server.py": `import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from solution import new_chat_server
 
-server = new_chat_server()
-if not callable(server):
-    raise SystemExit('new_chat_server must return a callable object')
+app = new_chat_server()
 
-bad_status, _ = server('POST', '/rooms/lobby/messages', json.dumps({'user': '', 'text': 'hello'}))
-if not isinstance(bad_status, int) or bad_status < 400 or bad_status > 499:
-    raise SystemExit(f'empty user status {bad_status!r}, want 4xx')
-
-def exercise(room, users):
-    started = time.perf_counter()
-    responses = [None] * users
-    errors = []
-    lock = threading.Lock()
-
-    def worker(i):
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+    def log_message(self, fmt, *args):
+        pass
+    def _dispatch(self):
+        length = int(self.headers.get('content-length', '0'))
+        body = self.rfile.read(length).decode('utf-8') if length else None
         try:
-            status, body = server('POST', f'/rooms/{room}/messages', json.dumps({'user': f'user-{i}', 'text': f'hello-{i}'}))
-            if status != 201:
-                raise RuntimeError(f'POST {i} status {status!r} body={body!r}')
-            msg = json.loads(body)
-            if not isinstance(msg.get('seq'), int) or msg['seq'] < 1 or msg['seq'] > users:
-                raise RuntimeError(f'bad seq {msg.get("seq")!r}')
-            if msg.get('user') != f'user-{i}' or msg.get('text') != f'hello-{i}':
-                raise RuntimeError(f'bad user/text {msg!r}')
-            responses[i] = msg
-        except Exception as e:
-            with lock:
-                errors.append(str(e))
+            status, response = app(self.command, self.path, body)
+            response = str(response).encode('utf-8')
+            self.send_response(int(status))
+            self.send_header('content-type', 'application/json')
+            self.send_header('content-length', str(len(response)))
+            self.send_header('connection', 'close')
+            self.end_headers()
+            self.wfile.write(response)
+        except Exception:
+            response = b'{"error":"server"}'
+            self.send_response(500)
+            self.send_header('content-type', 'application/json')
+            self.send_header('content-length', str(len(response)))
+            self.send_header('connection', 'close')
+            self.end_headers()
+            self.wfile.write(response)
+    def do_GET(self):
+        self._dispatch()
+    def do_POST(self):
+        self._dispatch()
 
-    threads = [threading.Thread(target=worker, args=(i,)) for i in range(users)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
-    if errors:
-        raise SystemExit(errors[0])
-    if sum(1 for r in responses if r is not None) != users:
-        raise SystemExit('missing responses')
+class Server(ThreadingHTTPServer):
+    request_queue_size = 2048
 
-    status, body = server('GET', f'/rooms/{room}/messages', None)
-    if status != 200:
-        raise SystemExit(f'GET status {status!r} body={body!r}')
-    messages = json.loads(body)
-    if len(messages) != users:
-        raise SystemExit(f'message count {len(messages)}, want {users}')
-    seen_seq = set()
-    seen_users = set()
-    last_seq = 0
-    for msg in messages:
-        seq = msg['seq']
-        if seq <= last_seq:
-            raise SystemExit(f'messages not in seq order around {seq} after {last_seq}')
-        last_seq = seq
-        if seq < 1 or seq > users or seq in seen_seq:
-            raise SystemExit(f'bad or duplicate seq {seq!r}')
-        seen_seq.add(seq)
-        seen_users.add(msg['user'])
-    for i in range(users):
-        if f'user-{i}' not in seen_users:
-            raise SystemExit(f'missing user-{i}')
-    return (time.perf_counter() - started) * 1000.0
-
-warmup = exercise('warmup', 100)
-print(f'BENCH_WARMUP_MS={warmup:.3f}')
-runtime = exercise('lobby', 1000)
-print(f'BENCH_RUNTIME_MS={runtime:.3f}')
-status, body = server('GET', '/rooms/empty/messages', None)
-if status != 200 or json.loads(body) != []:
-    raise SystemExit(f'empty room status={status!r} body={body!r}')
-print(f'BENCH_MEMORY_KB={resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}')
-`)
+port = int(os.environ['PORT'])
+Server(('127.0.0.1', port), Handler).serve_forever()
+`,
+		},
+		Cmd: []string{"python3", "server.py"},
+	})
 }

--- a/benchmarks/codegen/tasks_ruby_web_chat.go
+++ b/benchmarks/codegen/tasks_ruby_web_chat.go
@@ -1,0 +1,102 @@
+package main
+
+import "time"
+
+type rubyWebChat1000Task struct{}
+
+func (rubyWebChat1000Task) Name() string       { return "ruby_web_chat_1000" }
+func (rubyWebChat1000Task) Language() string   { return "ruby" }
+func (rubyWebChat1000Task) Difficulty() string { return "hard-concurrency" }
+func (rubyWebChat1000Task) Prompt() string {
+	return `Write a complete Ruby source file using only the Ruby standard library that defines exactly this method:
+
+def new_chat_server
+
+Return a callable object/lambda/proc. The benchmark will call it as:
+
+status, json_body = server.call(method, path, json_request_body)
+
+Implement a tiny in-memory multi-room chat API.
+
+Required operations:
+
+POST /rooms/{room}/messages
+- Request body JSON: {"user":"alice","text":"hello"}
+- user and text must be non-empty strings
+- Append the message to that room and assign a monotonically increasing seq number starting at 1 per room
+- Return [201, JSON.generate({seq: 1, user: "alice", text: "hello"})]
+
+GET /rooms/{room}/messages
+- Return [200, JSON array string] with all stored messages for that room in seq order
+- Unknown rooms return []
+
+Anything else should return an appropriate 4xx status and a JSON body.
+
+The callable must be safe for 1000 concurrent Ruby threads posting at the same time. Do not start a server, read stdin, or print anything.`
+}
+
+func (rubyWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreRuby(response, timeout, `
+require 'json'
+require 'set'
+require 'thread'
+require_relative './solution'
+
+server = new_chat_server
+unless server.respond_to?(:call)
+  warn "new_chat_server must return a callable object"
+  exit 1
+end
+
+bad_status, = server.call('POST', '/rooms/lobby/messages', JSON.generate({user: '', text: 'hello'}))
+unless bad_status.is_a?(Integer) && bad_status >= 400 && bad_status <= 499
+  warn "empty user status #{bad_status.inspect}, want 4xx"
+  exit 1
+end
+
+def exercise(server, room, users)
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  responses = Array.new(users)
+  threads = users.times.map do |i|
+    Thread.new do
+      status, body = server.call('POST', "/rooms/#{room}/messages", JSON.generate({user: "user-#{i}", text: "hello-#{i}"}))
+      raise "POST #{i} status #{status.inspect} body=#{body.inspect}" unless status == 201
+      msg = JSON.parse(body)
+      raise "bad seq #{msg['seq'].inspect}" unless msg['seq'].is_a?(Integer) && msg['seq'] >= 1 && msg['seq'] <= users
+      raise "bad user/text #{msg.inspect}" unless msg['user'] == "user-#{i}" && msg['text'] == "hello-#{i}"
+      responses[i] = msg
+    end
+  end
+  threads.each(&:join)
+  raise "missing responses" unless responses.compact.length == users
+
+  status, body = server.call('GET', "/rooms/#{room}/messages", nil)
+  raise "GET status #{status.inspect} body=#{body.inspect}" unless status == 200
+  messages = JSON.parse(body)
+  raise "message count #{messages.length}, want #{users}" unless messages.length == users
+  seen_seq = Set.new
+  seen_users = Set.new
+  last_seq = 0
+  messages.each do |msg|
+    seq = msg['seq']
+    raise "messages not in seq order around #{seq} after #{last_seq}" unless seq > last_seq
+    last_seq = seq
+    raise "bad or duplicate seq #{seq.inspect}" if seq < 1 || seq > users || seen_seq.include?(seq)
+    seen_seq.add(seq)
+    seen_users.add(msg['user'])
+  end
+  users.times { |i| raise "missing user-#{i}" unless seen_users.include?("user-#{i}") }
+  (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000.0
+end
+
+warmup_ms = exercise(server, 'warmup', 100)
+puts "BENCH_WARMUP_MS=#{format('%.3f', warmup_ms)}"
+runtime_ms = exercise(server, 'lobby', 1000)
+puts "BENCH_RUNTIME_MS=#{format('%.3f', runtime_ms)}"
+
+status, body = server.call('GET', '/rooms/empty/messages', nil)
+raise "empty room status=#{status.inspect} body=#{body.inspect}" unless status == 200 && JSON.parse(body) == []
+rss_kb = File.read('/proc/self/status')[/^VmRSS:\s+(\d+)\s+kB$/, 1].to_i
+puts "BENCH_MEMORY_KB=#{rss_kb}"
+`)
+}

--- a/benchmarks/codegen/tasks_ruby_web_chat.go
+++ b/benchmarks/codegen/tasks_ruby_web_chat.go
@@ -6,15 +6,17 @@ type rubyWebChat1000Task struct{}
 
 func (rubyWebChat1000Task) Name() string       { return "ruby_web_chat_1000" }
 func (rubyWebChat1000Task) Language() string   { return "ruby" }
-func (rubyWebChat1000Task) Difficulty() string { return "hard-concurrency" }
+func (rubyWebChat1000Task) Difficulty() string { return "hard-web-concurrency" }
 func (rubyWebChat1000Task) Prompt() string {
 	return `Write a complete Ruby source file using only the Ruby standard library that defines exactly this method:
 
 def new_chat_server
 
-Return a callable object/lambda/proc. The benchmark will call it as:
+Return a callable object/lambda/proc. The benchmark adapter will call it as:
 
-status, json_body = server.call(method, path, json_request_body)
+status, json_body = server.call(method, path, raw_json_request_body)
+
+The third argument is a raw JSON string for POST requests; parse it with JSON.parse.
 
 Implement a tiny in-memory multi-room chat API.
 
@@ -32,71 +34,67 @@ GET /rooms/{room}/messages
 
 Anything else should return an appropriate 4xx status and a JSON body.
 
-The callable must be safe for 1000 concurrent Ruby threads posting at the same time. Do not start a server, read stdin, or print anything.`
+The callable must be safe for 1000 concurrent HTTP requests posting at the same time. Do not start a server, read stdin, or print anything.`
 }
 
 func (rubyWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
-	return scoreRuby(response, timeout, `
-require 'json'
-require 'set'
-require 'thread'
+	return scoreHTTPServer(response, timeout, httpServerSpec{
+		Prefix: "term-llm-codegen-bench-ruby-http",
+		Files: map[string]string{
+			"solution.rb": "{{CODE}}",
+			"server.rb": `require 'socket'
 require_relative './solution'
 
-server = new_chat_server
-unless server.respond_to?(:call)
-  warn "new_chat_server must return a callable object"
-  exit 1
+server_impl = new_chat_server
+port = Integer(ENV.fetch('PORT'))
+listener = TCPServer.new('127.0.0.1', port)
+
+trap('TERM') { listener.close rescue nil; exit }
+
+def read_request(socket)
+  first = socket.gets("\r\n")
+  return nil unless first
+  method, path, = first.split(' ', 3)
+  headers = {}
+  while (line = socket.gets("\r\n"))
+    line = line.chomp
+    break if line.empty?
+    key, value = line.split(':', 2)
+    headers[key.downcase] = value.strip if key && value
+  end
+  len = headers.fetch('content-length', '0').to_i
+  body = len > 0 ? socket.read(len) : nil
+  [method, path, body]
 end
 
-bad_status, = server.call('POST', '/rooms/lobby/messages', JSON.generate({user: '', text: 'hello'}))
-unless bad_status.is_a?(Integer) && bad_status >= 400 && bad_status <= 499
-  warn "empty user status #{bad_status.inspect}, want 4xx"
-  exit 1
+def write_response(socket, status, body)
+  body = body.to_s
+  reason = {200=>'OK', 201=>'Created', 400=>'Bad Request', 404=>'Not Found', 405=>'Method Not Allowed'}[status] || 'OK'
+  socket.write "HTTP/1.1 #{status} #{reason}\r\ncontent-type: application/json\r\ncontent-length: #{body.bytesize}\r\nconnection: close\r\n\r\n#{body}"
 end
 
-def exercise(server, room, users)
-  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-  responses = Array.new(users)
-  threads = users.times.map do |i|
-    Thread.new do
-      status, body = server.call('POST', "/rooms/#{room}/messages", JSON.generate({user: "user-#{i}", text: "hello-#{i}"}))
-      raise "POST #{i} status #{status.inspect} body=#{body.inspect}" unless status == 201
-      msg = JSON.parse(body)
-      raise "bad seq #{msg['seq'].inspect}" unless msg['seq'].is_a?(Integer) && msg['seq'] >= 1 && msg['seq'] <= users
-      raise "bad user/text #{msg.inspect}" unless msg['user'] == "user-#{i}" && msg['text'] == "hello-#{i}"
-      responses[i] = msg
+loop do
+  begin
+    sock = listener.accept
+  rescue IOError
+    break
+  end
+  Thread.new(sock) do |socket|
+    begin
+      req = read_request(socket)
+      if req
+        status, body = server_impl.call(*req)
+        write_response(socket, Integer(status), body)
+      end
+    rescue => e
+      write_response(socket, 500, '{"error":"server"}') rescue nil
+    ensure
+      socket.close rescue nil
     end
   end
-  threads.each(&:join)
-  raise "missing responses" unless responses.compact.length == users
-
-  status, body = server.call('GET', "/rooms/#{room}/messages", nil)
-  raise "GET status #{status.inspect} body=#{body.inspect}" unless status == 200
-  messages = JSON.parse(body)
-  raise "message count #{messages.length}, want #{users}" unless messages.length == users
-  seen_seq = Set.new
-  seen_users = Set.new
-  last_seq = 0
-  messages.each do |msg|
-    seq = msg['seq']
-    raise "messages not in seq order around #{seq} after #{last_seq}" unless seq > last_seq
-    last_seq = seq
-    raise "bad or duplicate seq #{seq.inspect}" if seq < 1 || seq > users || seen_seq.include?(seq)
-    seen_seq.add(seq)
-    seen_users.add(msg['user'])
-  end
-  users.times { |i| raise "missing user-#{i}" unless seen_users.include?("user-#{i}") }
-  (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000.0
 end
-
-warmup_ms = exercise(server, 'warmup', 100)
-puts "BENCH_WARMUP_MS=#{format('%.3f', warmup_ms)}"
-runtime_ms = exercise(server, 'lobby', 1000)
-puts "BENCH_RUNTIME_MS=#{format('%.3f', runtime_ms)}"
-
-status, body = server.call('GET', '/rooms/empty/messages', nil)
-raise "empty room status=#{status.inspect} body=#{body.inspect}" unless status == 200 && JSON.parse(body) == []
-rss_kb = File.read('/proc/self/status')[/^VmRSS:\s+(\d+)\s+kB$/, 1].to_i
-puts "BENCH_MEMORY_KB=#{rss_kb}"
-`)
+`,
+		},
+		Cmd: []string{"ruby", "server.rb"},
+	})
 }

--- a/benchmarks/codegen/tasks_web_chat.go
+++ b/benchmarks/codegen/tasks_web_chat.go
@@ -41,20 +41,28 @@ type chatMessage struct {
 
 func TestGenerated(t *testing.T) {
 	h := NewChatServer()
-	exerciseGoChatHandler(t, h, 1000)
+	warmStart := time.Now()
+	exerciseGoChatHandler(t, h, "warmup", 100)
+	fmt.Printf("BENCH_WARMUP_MS=%.3f\n", float64(time.Since(warmStart).Microseconds())/1000.0)
+	started := time.Now()
+	exerciseGoChatHandler(t, h, "lobby", 1000)
+	fmt.Printf("BENCH_RUNTIME_MS=%.3f\n", float64(time.Since(started).Microseconds())/1000.0)
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	fmt.Printf("BENCH_MEMORY_KB=%.0f\n", float64(mem.Alloc)/1024.0)
 }
 
 func BenchmarkGenerated(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h := NewChatServer()
-		exerciseGoChatHandler(b, h, 1000)
+		exerciseGoChatHandler(b, h, "lobby", 1000)
 	}
 }
 
-func exerciseGoChatHandler(tb testing.TB, h http.Handler, users int) {
+func exerciseGoChatHandler(tb testing.TB, h http.Handler, room string, users int) {
 	tb.Helper()
 	// Basic validation first: bad JSON and empty fields should not be accepted.
-	badReq := httptest.NewRequest(http.MethodPost, "/rooms/lobby/messages", strings.NewReader(`+"`"+`{"user":"","text":"hello"}`+"`"+`))
+	badReq := httptest.NewRequest(http.MethodPost, "/rooms/"+room+"/messages", strings.NewReader(`+"`"+`{"user":"","text":"hello"}`+"`"+`))
 	badReq.Header.Set("Content-Type", "application/json")
 	badRec := httptest.NewRecorder()
 	h.ServeHTTP(badRec, badReq)
@@ -68,8 +76,8 @@ func exerciseGoChatHandler(tb testing.TB, h http.Handler, users int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			body := fmt.Sprintf(`+"`"+`{"user":"user-%d","text":"hello-%d"}`+"`"+`, i, i)
-			req := httptest.NewRequest(http.MethodPost, "/rooms/lobby/messages", strings.NewReader(body))
+			body := fmt.Sprintf("{\"user\":\"user-%d\",\"text\":\"hello-%d\"}", i, i)
+			req := httptest.NewRequest(http.MethodPost, "/rooms/"+room+"/messages", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
@@ -89,7 +97,7 @@ func exerciseGoChatHandler(tb testing.TB, h http.Handler, users int) {
 	}
 	wg.Wait()
 
-	req := httptest.NewRequest(http.MethodGet, "/rooms/lobby/messages", nil)
+	req := httptest.NewRequest(http.MethodGet, "/rooms/"+room+"/messages", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -129,5 +137,5 @@ func exerciseGoChatHandler(tb testing.TB, h http.Handler, users int) {
 		tb.Fatalf("empty room = status %d body %q, want 200 []", rec.Code, rec.Body.String())
 	}
 }
-`, "encoding/json", "fmt", "net/http", "net/http/httptest", "strings", "sync")
+`, "encoding/json", "fmt", "net/http", "net/http/httptest", "runtime", "strings", "sync", "time")
 }

--- a/benchmarks/codegen/tasks_web_chat.go
+++ b/benchmarks/codegen/tasks_web_chat.go
@@ -1,0 +1,123 @@
+package main
+
+import "time"
+
+type webChat1000Task struct{}
+
+func (webChat1000Task) Name() string       { return "go_web_chat_1000" }
+func (webChat1000Task) Language() string   { return "go" }
+func (webChat1000Task) Difficulty() string { return "hard-web-concurrency" }
+func (webChat1000Task) Prompt() string {
+	return `Write a complete Go source file for package main, including any imports, that defines exactly this function:
+
+func NewChatServer() http.Handler
+
+Implement a tiny in-memory multi-room web chat API using only the Go standard library.
+
+Required endpoints:
+
+POST /rooms/{room}/messages
+- Request body JSON: {"user":"alice","text":"hello"}
+- user and text must be non-empty strings
+- Append the message to that room and assign a monotonically increasing seq number starting at 1 per room
+- Return HTTP 201 with the stored message as JSON: {"seq":1,"user":"alice","text":"hello"}
+
+GET /rooms/{room}/messages
+- Return HTTP 200 with a JSON array of all stored messages for that room in seq order
+- Unknown rooms return an empty JSON array []
+
+Anything else should return an appropriate 4xx status.
+
+The handler must be safe for 1000 concurrent users posting at the same time. Do not include a main function.`
+}
+
+func (webChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreGoFunctionWithRace(response, timeout, `
+type chatMessage struct {
+	Seq  int    `+"`"+`json:"seq"`+"`"+`
+	User string `+"`"+`json:"user"`+"`"+`
+	Text string `+"`"+`json:"text"`+"`"+`
+}
+
+func TestGenerated(t *testing.T) {
+	h := NewChatServer()
+
+	// Basic validation first: bad JSON and empty fields should not be accepted.
+	badReq := httptest.NewRequest(http.MethodPost, "/rooms/lobby/messages", strings.NewReader(`+"`"+`{"user":"","text":"hello"}`+"`"+`))
+	badReq.Header.Set("Content-Type", "application/json")
+	badRec := httptest.NewRecorder()
+	h.ServeHTTP(badRec, badReq)
+	if badRec.Code < 400 || badRec.Code > 499 {
+		t.Fatalf("empty user status = %d, want 4xx", badRec.Code)
+	}
+
+	const users = 1000
+	var wg sync.WaitGroup
+	for i := 0; i < users; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			body := fmt.Sprintf(`+"`"+`{"user":"user-%d","text":"hello-%d"}`+"`"+`, i, i)
+			req := httptest.NewRequest(http.MethodPost, "/rooms/lobby/messages", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusCreated {
+				t.Errorf("POST status = %d body=%s", rec.Code, rec.Body.String())
+				return
+			}
+			var msg chatMessage
+			if err := json.NewDecoder(rec.Body).Decode(&msg); err != nil {
+				t.Errorf("decode POST response: %v", err)
+				return
+			}
+			if msg.Seq < 1 || msg.Seq > users || msg.User != fmt.Sprintf("user-%d", i) || msg.Text != fmt.Sprintf("hello-%d", i) {
+				t.Errorf("bad stored message: %#v", msg)
+			}
+		}()
+	}
+	wg.Wait()
+
+	req := httptest.NewRequest(http.MethodGet, "/rooms/lobby/messages", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var messages []chatMessage
+	if err := json.NewDecoder(rec.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	if len(messages) != users {
+		t.Fatalf("message count = %d, want %d", len(messages), users)
+	}
+	seenSeq := make(map[int]bool, users)
+	seenUsers := make(map[string]bool, users)
+	lastSeq := 0
+	for _, msg := range messages {
+		if msg.Seq <= lastSeq {
+			t.Fatalf("messages not in seq order around seq %d after %d", msg.Seq, lastSeq)
+		}
+		lastSeq = msg.Seq
+		if msg.Seq < 1 || msg.Seq > users || seenSeq[msg.Seq] {
+			t.Fatalf("bad or duplicate seq: %d", msg.Seq)
+		}
+		seenSeq[msg.Seq] = true
+		seenUsers[msg.User] = true
+	}
+	for i := 0; i < users; i++ {
+		if !seenUsers[fmt.Sprintf("user-%d", i)] {
+			t.Fatalf("missing user-%d", i)
+		}
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/rooms/empty/messages", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "[]" {
+		t.Fatalf("empty room = status %d body %q, want 200 []", rec.Code, rec.Body.String())
+	}
+}
+`, "encoding/json", "fmt", "net/http", "net/http/httptest", "strings", "sync")
+}

--- a/benchmarks/codegen/tasks_web_chat.go
+++ b/benchmarks/codegen/tasks_web_chat.go
@@ -41,17 +41,27 @@ type chatMessage struct {
 
 func TestGenerated(t *testing.T) {
 	h := NewChatServer()
+	exerciseGoChatHandler(t, h, 1000)
+}
 
+func BenchmarkGenerated(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		h := NewChatServer()
+		exerciseGoChatHandler(b, h, 1000)
+	}
+}
+
+func exerciseGoChatHandler(tb testing.TB, h http.Handler, users int) {
+	tb.Helper()
 	// Basic validation first: bad JSON and empty fields should not be accepted.
 	badReq := httptest.NewRequest(http.MethodPost, "/rooms/lobby/messages", strings.NewReader(`+"`"+`{"user":"","text":"hello"}`+"`"+`))
 	badReq.Header.Set("Content-Type", "application/json")
 	badRec := httptest.NewRecorder()
 	h.ServeHTTP(badRec, badReq)
 	if badRec.Code < 400 || badRec.Code > 499 {
-		t.Fatalf("empty user status = %d, want 4xx", badRec.Code)
+		tb.Fatalf("empty user status = %d, want 4xx", badRec.Code)
 	}
 
-	const users = 1000
 	var wg sync.WaitGroup
 	for i := 0; i < users; i++ {
 		i := i
@@ -64,16 +74,16 @@ func TestGenerated(t *testing.T) {
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != http.StatusCreated {
-				t.Errorf("POST status = %d body=%s", rec.Code, rec.Body.String())
+				tb.Errorf("POST status = %d body=%s", rec.Code, rec.Body.String())
 				return
 			}
 			var msg chatMessage
 			if err := json.NewDecoder(rec.Body).Decode(&msg); err != nil {
-				t.Errorf("decode POST response: %v", err)
+				tb.Errorf("decode POST response: %v", err)
 				return
 			}
 			if msg.Seq < 1 || msg.Seq > users || msg.User != fmt.Sprintf("user-%d", i) || msg.Text != fmt.Sprintf("hello-%d", i) {
-				t.Errorf("bad stored message: %#v", msg)
+				tb.Errorf("bad stored message: %#v", msg)
 			}
 		}()
 	}
@@ -83,32 +93,32 @@ func TestGenerated(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("GET status = %d body=%s", rec.Code, rec.Body.String())
+		tb.Fatalf("GET status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	var messages []chatMessage
 	if err := json.NewDecoder(rec.Body).Decode(&messages); err != nil {
-		t.Fatalf("decode GET response: %v", err)
+		tb.Fatalf("decode GET response: %v", err)
 	}
 	if len(messages) != users {
-		t.Fatalf("message count = %d, want %d", len(messages), users)
+		tb.Fatalf("message count = %d, want %d", len(messages), users)
 	}
 	seenSeq := make(map[int]bool, users)
 	seenUsers := make(map[string]bool, users)
 	lastSeq := 0
 	for _, msg := range messages {
 		if msg.Seq <= lastSeq {
-			t.Fatalf("messages not in seq order around seq %d after %d", msg.Seq, lastSeq)
+			tb.Fatalf("messages not in seq order around seq %d after %d", msg.Seq, lastSeq)
 		}
 		lastSeq = msg.Seq
 		if msg.Seq < 1 || msg.Seq > users || seenSeq[msg.Seq] {
-			t.Fatalf("bad or duplicate seq: %d", msg.Seq)
+			tb.Fatalf("bad or duplicate seq: %d", msg.Seq)
 		}
 		seenSeq[msg.Seq] = true
 		seenUsers[msg.User] = true
 	}
 	for i := 0; i < users; i++ {
 		if !seenUsers[fmt.Sprintf("user-%d", i)] {
-			t.Fatalf("missing user-%d", i)
+		tb.Fatalf("missing user-%d", i)
 		}
 	}
 
@@ -116,7 +126,7 @@ func TestGenerated(t *testing.T) {
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "[]" {
-		t.Fatalf("empty room = status %d body %q, want 200 []", rec.Code, rec.Body.String())
+		tb.Fatalf("empty room = status %d body %q, want 200 []", rec.Code, rec.Body.String())
 	}
 }
 `, "encoding/json", "fmt", "net/http", "net/http/httptest", "strings", "sync")

--- a/benchmarks/codegen/tasks_web_chat.go
+++ b/benchmarks/codegen/tasks_web_chat.go
@@ -32,110 +32,28 @@ The handler must be safe for 1000 concurrent users posting at the same time. Do 
 }
 
 func (webChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
-	return scoreGoFunctionWithRace(response, timeout, `
-type chatMessage struct {
-	Seq  int    `+"`"+`json:"seq"`+"`"+`
-	User string `+"`"+`json:"user"`+"`"+`
-	Text string `+"`"+`json:"text"`+"`"+`
+	return scoreHTTPServer(response, timeout, httpServerSpec{
+		Prefix: "term-llm-codegen-bench-go-http",
+		Files: map[string]string{
+			"solution.go": "{{CODE}}",
+			"go.mod":      "module benchsolution\n\ngo 1.22\n",
+			"main.go": `package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe("127.0.0.1:"+port, NewChatServer()))
 }
-
-func TestGenerated(t *testing.T) {
-	h := NewChatServer()
-	warmStart := time.Now()
-	exerciseGoChatHandler(t, h, "warmup", 100)
-	fmt.Printf("BENCH_WARMUP_MS=%.3f\n", float64(time.Since(warmStart).Microseconds())/1000.0)
-	started := time.Now()
-	exerciseGoChatHandler(t, h, "lobby", 1000)
-	fmt.Printf("BENCH_RUNTIME_MS=%.3f\n", float64(time.Since(started).Microseconds())/1000.0)
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
-	fmt.Printf("BENCH_MEMORY_KB=%.0f\n", float64(mem.Alloc)/1024.0)
-}
-
-func BenchmarkGenerated(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		h := NewChatServer()
-		exerciseGoChatHandler(b, h, "lobby", 1000)
-	}
-}
-
-func exerciseGoChatHandler(tb testing.TB, h http.Handler, room string, users int) {
-	tb.Helper()
-	// Basic validation first: bad JSON and empty fields should not be accepted.
-	badReq := httptest.NewRequest(http.MethodPost, "/rooms/"+room+"/messages", strings.NewReader(`+"`"+`{"user":"","text":"hello"}`+"`"+`))
-	badReq.Header.Set("Content-Type", "application/json")
-	badRec := httptest.NewRecorder()
-	h.ServeHTTP(badRec, badReq)
-	if badRec.Code < 400 || badRec.Code > 499 {
-		tb.Fatalf("empty user status = %d, want 4xx", badRec.Code)
-	}
-
-	var wg sync.WaitGroup
-	for i := 0; i < users; i++ {
-		i := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			body := fmt.Sprintf("{\"user\":\"user-%d\",\"text\":\"hello-%d\"}", i, i)
-			req := httptest.NewRequest(http.MethodPost, "/rooms/"+room+"/messages", strings.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, req)
-			if rec.Code != http.StatusCreated {
-				tb.Errorf("POST status = %d body=%s", rec.Code, rec.Body.String())
-				return
-			}
-			var msg chatMessage
-			if err := json.NewDecoder(rec.Body).Decode(&msg); err != nil {
-				tb.Errorf("decode POST response: %v", err)
-				return
-			}
-			if msg.Seq < 1 || msg.Seq > users || msg.User != fmt.Sprintf("user-%d", i) || msg.Text != fmt.Sprintf("hello-%d", i) {
-				tb.Errorf("bad stored message: %#v", msg)
-			}
-		}()
-	}
-	wg.Wait()
-
-	req := httptest.NewRequest(http.MethodGet, "/rooms/"+room+"/messages", nil)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		tb.Fatalf("GET status = %d body=%s", rec.Code, rec.Body.String())
-	}
-	var messages []chatMessage
-	if err := json.NewDecoder(rec.Body).Decode(&messages); err != nil {
-		tb.Fatalf("decode GET response: %v", err)
-	}
-	if len(messages) != users {
-		tb.Fatalf("message count = %d, want %d", len(messages), users)
-	}
-	seenSeq := make(map[int]bool, users)
-	seenUsers := make(map[string]bool, users)
-	lastSeq := 0
-	for _, msg := range messages {
-		if msg.Seq <= lastSeq {
-			tb.Fatalf("messages not in seq order around seq %d after %d", msg.Seq, lastSeq)
-		}
-		lastSeq = msg.Seq
-		if msg.Seq < 1 || msg.Seq > users || seenSeq[msg.Seq] {
-			tb.Fatalf("bad or duplicate seq: %d", msg.Seq)
-		}
-		seenSeq[msg.Seq] = true
-		seenUsers[msg.User] = true
-	}
-	for i := 0; i < users; i++ {
-		if !seenUsers[fmt.Sprintf("user-%d", i)] {
-		tb.Fatalf("missing user-%d", i)
-		}
-	}
-
-	req = httptest.NewRequest(http.MethodGet, "/rooms/empty/messages", nil)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK || strings.TrimSpace(rec.Body.String()) != "[]" {
-		tb.Fatalf("empty room = status %d body %q, want 200 []", rec.Code, rec.Body.String())
-	}
-}
-`, "encoding/json", "fmt", "net/http", "net/http/httptest", "runtime", "strings", "sync", "time")
+`,
+		},
+		Cmd: []string{"go", "run", "."},
+	})
 }

--- a/benchmarks/codegen/tasks_zig.go
+++ b/benchmarks/codegen/tasks_zig.go
@@ -1,0 +1,85 @@
+package main
+
+import "time"
+
+type zigSumPositiveTask struct{}
+
+func (zigSumPositiveTask) Name() string       { return "zig_sum_positive_perf" }
+func (zigSumPositiveTask) Language() string   { return "zig" }
+func (zigSumPositiveTask) Difficulty() string { return "medium-perf-correctness" }
+func (zigSumPositiveTask) Prompt() string {
+	return `Write a complete Zig source file that exports exactly this C ABI function:
+
+export fn sum_positive(xs: [*]const i64, n: isize) i64
+
+The function must return the sum of all positive values in xs[0:n]. Ignore zero and negative values. If n <= 0, return 0.
+
+Requirements:
+- Must compile with zig build-lib.
+- Export the symbol as sum_positive using the C ABI.
+- Do not allocate memory.
+- Must be correct for negative numbers, empty arrays, and mixed values.
+- Prefer a simple fast loop over cleverness.`
+}
+
+func (zigSumPositiveTask) Score(response string, timeout time.Duration) ScoreResult {
+	return scoreZig(response, timeout, `
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <time.h>
+
+long sum_positive(long *xs, long n);
+
+static void check(const char *name, long *xs, long n, long want) {
+  long got = sum_positive(xs, n);
+  if (got != want) {
+    fprintf(stderr, "%s: got %ld want %ld\n", name, got, want);
+    exit(1);
+  }
+}
+
+static double elapsed_ms(struct timespec start, struct timespec end) {
+  return (double)(end.tv_sec - start.tv_sec) * 1000.0 + (double)(end.tv_nsec - start.tv_nsec) / 1000000.0;
+}
+
+int main(void) {
+  long empty[] = {1};
+  long mixed[] = {-5, 0, 7, -2, 9, 1};
+  long negatives[] = {-9, -8, -7};
+  check("n<=0", empty, 0, 0);
+  check("mixed", mixed, 6, 17);
+  check("negative", negatives, 3, 0);
+
+  const long n = 4096;
+  long *xs = malloc(sizeof(long) * n);
+  if (!xs) return 1;
+  long want = 0;
+  for (long i = 0; i < n; i++) {
+    long v = (i % 11) - 5;
+    xs[i] = v;
+    if (v > 0) want += v;
+  }
+  check("bulk", xs, n, want);
+
+  volatile long sink = 0;
+  struct timespec a, b;
+  clock_gettime(CLOCK_MONOTONIC, &a);
+  for (int i = 0; i < 10000; i++) sink += sum_positive(xs, n);
+  clock_gettime(CLOCK_MONOTONIC, &b);
+  printf("BENCH_WARMUP_MS=%.3f\n", elapsed_ms(a, b));
+
+  clock_gettime(CLOCK_MONOTONIC, &a);
+  for (int i = 0; i < 200000; i++) sink += sum_positive(xs, n);
+  clock_gettime(CLOCK_MONOTONIC, &b);
+  if (sink == 42) puts("impossible");
+  printf("BENCH_RUNTIME_MS=%.3f\n", elapsed_ms(a, b));
+  struct rusage usage;
+  getrusage(RUSAGE_SELF, &usage);
+  printf("BENCH_MEMORY_KB=%ld\n", usage.ru_maxrss);
+  free(xs);
+  return 0;
+}
+`)
+}

--- a/benchmarks/codegen/visualize.go
+++ b/benchmarks/codegen/visualize.go
@@ -47,8 +47,10 @@ func renderDashboardHTML(report RunReport, svg string) string {
 			pass = "✓"
 		}
 		perf := displayRuntime(t)
-		fmt.Fprintf(&rows, `<tr><td>%s</td><td>%s</td><td class="pass">%s</td><td>%.2f</td><td>$%.4f</td><td>%s</td><td>%dms</td><td>%dms</td><td>%s</td></tr>`+"\n",
-			html.EscapeString(t.Task), html.EscapeString(t.Language), pass, t.Score, t.EstimatedCost, html.EscapeString(perf), t.LLMDurationMS, t.ScoreDurationMS, html.EscapeString(firstNonEmpty(t.Details, t.Error)))
+		warmup := displayWarmup(t)
+		memory := displayMemory(t)
+		fmt.Fprintf(&rows, `<tr><td>%s</td><td>%s</td><td class="pass">%s</td><td>%.2f</td><td>$%.4f</td><td>%s</td><td>%s</td><td>%s</td><td>%dms</td><td>%dms</td><td>%s</td></tr>`+"\n",
+			html.EscapeString(t.Task), html.EscapeString(t.Language), pass, t.Score, t.EstimatedCost, html.EscapeString(perf), html.EscapeString(warmup), html.EscapeString(memory), t.LLMDurationMS, t.ScoreDurationMS, html.EscapeString(firstNonEmpty(t.Details, t.Error)))
 	}
 	return fmt.Sprintf(`<!doctype html>
 <html>
@@ -85,9 +87,9 @@ func renderDashboardHTML(report RunReport, svg string) string {
     <div class="card"><div class="label">Wall time</div><div class="value">%s</div></div>
   </section>
   <section class="viz">%s</section>
-  <div class="note">Bubble chart: x = generation cost, y = measured runtime speed when available, otherwise scoring speed. Green passes. Red fails. Bigger bubbles cost more. The chart intentionally punishes expensive slow failures because so should we.</div>
+  <div class="note">Bubble chart: x = generation cost, y = post-warmup measured runtime speed when available, otherwise scoring speed. Green passes. Red fails. Bigger bubbles cost more. The chart intentionally punishes expensive slow failures because so should we.</div>
   <table>
-    <thead><tr><th>Task</th><th>Lang</th><th>Pass</th><th>Score</th><th>Cost</th><th>Runtime</th><th>LLM</th><th>Score time</th><th>Detail</th></tr></thead>
+    <thead><tr><th>Task</th><th>Lang</th><th>Pass</th><th>Score</th><th>Cost</th><th>Runtime</th><th>Warmup</th><th>Memory</th><th>LLM</th><th>Score time</th><th>Detail</th></tr></thead>
     <tbody>%s</tbody>
   </table>
 </main>
@@ -220,6 +222,26 @@ func displayRuntime(t TaskResult) string {
 	return "n/a"
 }
 
+func displayWarmup(t TaskResult) string {
+	if t.Metrics.WarmupMS > 0 {
+		return fmt.Sprintf("%.2fms", t.Metrics.WarmupMS)
+	}
+	return "n/a"
+}
+
+func displayMemory(t TaskResult) string {
+	if t.Metrics.MemoryKB > 0 {
+		if t.Metrics.MemoryKB >= 1024 {
+			return fmt.Sprintf("%.1fMB", t.Metrics.MemoryKB/1024)
+		}
+		return fmt.Sprintf("%.0fKB", t.Metrics.MemoryKB)
+	}
+	if t.Metrics.BytesPerOp > 0 {
+		return fmt.Sprintf("%.1fKB/op", t.Metrics.BytesPerOp/1024)
+	}
+	return "n/a"
+}
+
 func perfForChart(t TaskResult) float64 {
 	if t.Metrics.RuntimeMS > 0 {
 		return t.Metrics.RuntimeMS
@@ -236,6 +258,9 @@ func perfForChart(t TaskResult) float64 {
 func shortTaskName(name string) string {
 	name = strings.TrimPrefix(name, "go_")
 	name = strings.TrimPrefix(name, "node_")
+	name = strings.TrimPrefix(name, "ruby_")
+	name = strings.TrimPrefix(name, "python_")
+	name = strings.TrimPrefix(name, "asm_")
 	name = strings.ReplaceAll(name, "_", " ")
 	if len(name) > 24 {
 		return name[:21] + "…"

--- a/benchmarks/codegen/visualize.go
+++ b/benchmarks/codegen/visualize.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func writeVisualizations(outDir string, report RunReport) error {
+	if len(report.Tasks) == 0 {
+		return nil
+	}
+	svg := renderDashboardSVG(report)
+	htmlDoc := renderDashboardHTML(report, svg)
+	base := fmt.Sprintf("%s_%s", report.ID, safeSlug(report.ProviderModel()))
+	if err := os.WriteFile(filepath.Join(outDir, base+"_dashboard.svg"), []byte(svg), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, base+"_dashboard.html"), []byte(htmlDoc), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "latest_dashboard.svg"), []byte(svg), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, "latest_dashboard.html"), []byte(htmlDoc), 0o644)
+}
+
+func (r RunReport) ProviderModel() string {
+	if strings.TrimSpace(r.Model) == "" {
+		return r.Provider
+	}
+	return r.Provider + "-" + r.Model
+}
+
+func renderDashboardHTML(report RunReport, svg string) string {
+	var rows strings.Builder
+	tasks := append([]TaskResult(nil), report.Tasks...)
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Task < tasks[j].Task })
+	for _, t := range tasks {
+		pass := "✗"
+		if t.Pass {
+			pass = "✓"
+		}
+		perf := displayRuntime(t)
+		fmt.Fprintf(&rows, `<tr><td>%s</td><td>%s</td><td class="pass">%s</td><td>%.2f</td><td>$%.4f</td><td>%s</td><td>%dms</td><td>%dms</td><td>%s</td></tr>`+"\n",
+			html.EscapeString(t.Task), html.EscapeString(t.Language), pass, t.Score, t.EstimatedCost, html.EscapeString(perf), t.LLMDurationMS, t.ScoreDurationMS, html.EscapeString(firstNonEmpty(t.Details, t.Error)))
+	}
+	return fmt.Sprintf(`<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>term-llm codegen benchmark %s</title>
+<style>
+  body { margin: 0; background: #f6f7fb; color: #151923; font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  main { max-width: 1180px; margin: 0 auto; padding: 28px; }
+  h1 { margin: 0 0 4px; font-size: 28px; }
+  .muted { color: #667085; }
+  .cards { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin: 20px 0; }
+  .card { background: white; border: 1px solid #e4e7ec; border-radius: 16px; padding: 14px 16px; box-shadow: 0 1px 2px rgb(16 24 40 / 5%%); }
+  .label { color: #667085; font-size: 12px; text-transform: uppercase; letter-spacing: .06em; }
+  .value { font-size: 24px; font-weight: 760; margin-top: 4px; }
+  .viz { background: white; border: 1px solid #e4e7ec; border-radius: 20px; padding: 12px; box-shadow: 0 12px 30px rgb(16 24 40 / 8%%); overflow: auto; }
+  table { width: 100%%; border-collapse: collapse; margin-top: 20px; background: white; border-radius: 16px; overflow: hidden; box-shadow: 0 1px 2px rgb(16 24 40 / 5%%); }
+  th, td { padding: 10px 12px; border-bottom: 1px solid #eaecf0; text-align: left; white-space: nowrap; }
+  th { background: #f9fafb; color: #475467; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  td.pass { font-size: 18px; }
+  .note { margin-top: 12px; color: #667085; }
+  @media (max-width: 900px) { .cards { grid-template-columns: repeat(2, 1fr); } main { padding: 16px; } }
+</style>
+</head>
+<body>
+<main>
+  <h1>Codegen benchmark dashboard</h1>
+  <div class="muted">%s · provider %s · concurrency %d · budget %s</div>
+  <section class="cards">
+    <div class="card"><div class="label">Quality</div><div class="value">%.0f%%</div></div>
+    <div class="card"><div class="label">Passes</div><div class="value">%d/%d</div></div>
+    <div class="card"><div class="label">Cost</div><div class="value">$%.4f</div></div>
+    <div class="card"><div class="label">Cost / pass</div><div class="value">$%.4f</div></div>
+    <div class="card"><div class="label">Wall time</div><div class="value">%s</div></div>
+  </section>
+  <section class="viz">%s</section>
+  <div class="note">Bubble chart: x = generation cost, y = measured runtime speed when available, otherwise scoring speed. Green passes. Red fails. Bigger bubbles cost more. The chart intentionally punishes expensive slow failures because so should we.</div>
+  <table>
+    <thead><tr><th>Task</th><th>Lang</th><th>Pass</th><th>Score</th><th>Cost</th><th>Runtime</th><th>LLM</th><th>Score time</th><th>Detail</th></tr></thead>
+    <tbody>%s</tbody>
+  </table>
+</main>
+</body>
+</html>`, html.EscapeString(report.ID), html.EscapeString(report.ID), html.EscapeString(report.ProviderModel()), report.Concurrency, html.EscapeString(report.Budget), report.PassRate*100, report.Passes, report.Total, report.EstimatedCostUSD, report.EstimatedCostPerPass, (time.Duration(report.TotalDurationMS) * time.Millisecond).String(), svg, rows.String())
+}
+
+func renderDashboardSVG(report RunReport) string {
+	const width = 1120
+	const height = 680
+	const left = 82
+	const top = 72
+	const plotW = 650
+	const plotH = 500
+
+	tasks := append([]TaskResult(nil), report.Tasks...)
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Task < tasks[j].Task })
+
+	maxCost := 0.0001
+	minPerf := math.MaxFloat64
+	maxPerf := 0.0
+	for _, t := range tasks {
+		maxCost = math.Max(maxCost, t.EstimatedCost)
+		p := perfForChart(t)
+		minPerf = math.Min(minPerf, p)
+		maxPerf = math.Max(maxPerf, p)
+	}
+	if minPerf == math.MaxFloat64 {
+		minPerf = 0
+	}
+	if maxPerf <= minPerf {
+		maxPerf = minPerf + 1
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="100%%" height="auto">`, width, height))
+	b.WriteString(`<rect width="100%" height="100%" fill="#ffffff"/>`)
+	b.WriteString(`<defs><filter id="shadow" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#101828" flood-opacity="0.16"/></filter></defs>`)
+	b.WriteString(`<text x="40" y="38" font-size="25" font-weight="800" fill="#101828">Cost × performance × quality</text>`)
+	b.WriteString(fmt.Sprintf(`<text x="40" y="60" font-size="13" fill="#667085">%s · %s</text>`, esc(report.ProviderModel()), esc(report.ID)))
+
+	// Plot panel.
+	b.WriteString(fmt.Sprintf(`<rect x="%d" y="%d" width="%d" height="%d" rx="18" fill="#f8fafc" stroke="#e4e7ec"/>`, left-30, top-30, plotW+60, plotH+70))
+	for i := 0; i <= 4; i++ {
+		x := left + i*plotW/4
+		y := top + i*plotH/4
+		b.WriteString(fmt.Sprintf(`<line x1="%d" y1="%d" x2="%d" y2="%d" stroke="#e4e7ec"/>`, x, top, x, top+plotH))
+		b.WriteString(fmt.Sprintf(`<line x1="%d" y1="%d" x2="%d" y2="%d" stroke="#e4e7ec"/>`, left, y, left+plotW, y))
+	}
+	b.WriteString(fmt.Sprintf(`<text x="%d" y="%d" font-size="12" fill="#667085">cheaper generation →</text>`, left+plotW-130, top+plotH+36))
+	b.WriteString(fmt.Sprintf(`<text transform="translate(%d,%d) rotate(-90)" font-size="12" fill="#667085">faster runtime / scoring →</text>`, left-48, top+150))
+
+	for _, t := range tasks {
+		costRatio := 0.0
+		if maxCost > 0 {
+			costRatio = t.EstimatedCost / maxCost
+		}
+		perf := perfForChart(t)
+		perfRatio := (maxPerf - perf) / (maxPerf - minPerf)
+		if math.IsNaN(perfRatio) || math.IsInf(perfRatio, 0) {
+			perfRatio = 0.5
+		}
+		x := float64(left) + costRatio*float64(plotW)
+		y := float64(top+plotH) - perfRatio*float64(plotH)
+		r := 8 + math.Sqrt(math.Max(t.EstimatedCost, 0)/maxCost)*18
+		fill := "#12b76a"
+		stroke := "#087443"
+		if !t.Pass {
+			fill = "#f04438"
+			stroke = "#b42318"
+		} else if t.Score < 1 {
+			fill = "#fdb022"
+			stroke = "#b54708"
+		}
+		b.WriteString(fmt.Sprintf(`<circle cx="%.1f" cy="%.1f" r="%.1f" fill="%s" stroke="%s" stroke-width="2" opacity="0.88" filter="url(#shadow)"><title>%s cost $%.4f runtime %s score %.2f</title></circle>`, x, y, r, fill, stroke, esc(t.Task), t.EstimatedCost, esc(displayRuntime(t)), t.Score))
+		b.WriteString(fmt.Sprintf(`<text x="%.1f" y="%.1f" font-size="11" font-weight="700" fill="#101828">%s</text>`, x+r+4, y+4, esc(shortTaskName(t.Task))))
+	}
+
+	// Right-side bar scoreboard.
+	panelX := 790
+	b.WriteString(fmt.Sprintf(`<rect x="%d" y="72" width="290" height="538" rx="18" fill="#101828"/>`, panelX))
+	b.WriteString(fmt.Sprintf(`<text x="%d" y="105" font-size="18" font-weight="800" fill="#ffffff">Scoreboard</text>`, panelX+24))
+	barY := 132
+	for _, t := range tasks {
+		label := shortTaskName(t.Task)
+		costW := 0.0
+		if maxCost > 0 {
+			costW = 110 * t.EstimatedCost / maxCost
+		}
+		qualityW := 110 * math.Max(0, math.Min(1, t.Score))
+		color := "#12b76a"
+		if !t.Pass {
+			color = "#f04438"
+		}
+		b.WriteString(fmt.Sprintf(`<text x="%d" y="%d" font-size="11" fill="#d0d5dd">%s</text>`, panelX+24, barY, esc(label)))
+		b.WriteString(fmt.Sprintf(`<rect x="%d" y="%d" width="110" height="7" rx="4" fill="#344054"/><rect x="%d" y="%d" width="%.1f" height="7" rx="4" fill="%s"/>`, panelX+24, barY+8, panelX+24, barY+8, qualityW, color))
+		b.WriteString(fmt.Sprintf(`<rect x="%d" y="%d" width="110" height="7" rx="4" fill="#344054"/><rect x="%d" y="%d" width="%.1f" height="7" rx="4" fill="#7c3aed"/>`, panelX+150, barY+8, panelX+150, barY+8, costW))
+		barY += 48
+	}
+	b.WriteString(fmt.Sprintf(`<text x="%d" y="585" font-size="11" fill="#98a2b3">left bars: quality · right bars: relative cost</text>`, panelX+24))
+	b.WriteString(`</svg>`)
+	return b.String()
+}
+
+func safeSlug(s string) string {
+	return strings.NewReplacer(":", "-", "/", "-", " ", "-", "_", "-").Replace(s)
+}
+
+func esc(s string) string { return html.EscapeString(s) }
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func displayRuntime(t TaskResult) string {
+	if t.Metrics.RuntimeMS > 0 {
+		return fmt.Sprintf("%.2fms", t.Metrics.RuntimeMS)
+	}
+	if t.Metrics.NSPerOp > 0 {
+		return fmt.Sprintf("%.0fns/op", t.Metrics.NSPerOp)
+	}
+	if t.ScoreDurationMS > 0 {
+		return fmt.Sprintf("score %dms", t.ScoreDurationMS)
+	}
+	return "n/a"
+}
+
+func perfForChart(t TaskResult) float64 {
+	if t.Metrics.RuntimeMS > 0 {
+		return t.Metrics.RuntimeMS
+	}
+	if t.Metrics.NSPerOp > 0 {
+		return t.Metrics.NSPerOp / 1_000_000
+	}
+	if t.ScoreDurationMS > 0 {
+		return float64(t.ScoreDurationMS)
+	}
+	return float64(maxInt64(t.DurationMS, 1))
+}
+
+func shortTaskName(name string) string {
+	name = strings.TrimPrefix(name, "go_")
+	name = strings.TrimPrefix(name, "node_")
+	name = strings.ReplaceAll(name, "_", " ")
+	if len(name) > 24 {
+		return name[:21] + "…"
+	}
+	return name
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## What

Adds a repo-local execution-based code generation benchmark under `benchmarks/codegen`.

The benchmark:

- runs against any term-llm provider via `-provider provider[:model]`
- defaults to `claude-bin`
- supports `-concurrency 2` and `-budget 4h` out of the box, matching Sam's requested run shape
- scores generated code by compiling and running isolated tests/benchmarks
- records token usage and estimated cost when provider usage/pricing is available
- writes timestamped JSON artifacts plus `history.jsonl`
- generates dashboard HTML/SVG artifacts for quality/cost/perf/memory
- includes a manual term-llm jobs definition and wrapper script

Current task suite:

- Go correctness/perf: `go_fizzbuzz`, `go_binary_search`, `go_json_format`, `go_concurrent_counter`, `go_dedupe_perf`
- shared localhost HTTP chat harness: `go_web_chat_1000`, `node_web_chat_1000`, `python_web_chat_1000`, `ruby_web_chat_1000`
- low-level perf/correctness: `asm_sum_positive_perf`, optional `zig_sum_positive_perf`

## Why

Codegen quality can be measured with hard signals: compile, tests, race detector, benchmark output, token usage, and cost/pass. This gives us a repeatable way to answer "what code is this model best at generating?" instead of vibes with a clipboard.

## Web chat benchmark numbers

Command:

```text
go run ./benchmarks/codegen -provider claude-bin -tasks go_web_chat_1000,node_web_chat_1000,python_web_chat_1000,ruby_web_chat_1000,zig_sum_positive_perf -concurrency 2 -budget 4h -timeout 5m -score-timeout 60s -out benchmarks/codegen/results
```

Result artifact: `benchmarks/codegen/results/20260505T224941Z_claude-bin-sonnet.json`

| Task | Pass | Score | Cost | Warmup | Runtime | Memory | LLM | Detail |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| `go_web_chat_1000` | ✓ | 1.00 | $0.0653 | 3.60 ms | 28.53 ms | 34.9 MB | 45.50 s | runtime 28.53 ms |
| `node_web_chat_1000` | ✓ | 1.00 | $0.0107 | 22.69 ms | 261.01 ms | 84.4 MB | 8.00 s | runtime 261.01 ms |
| `python_web_chat_1000` | ✓ | 1.00 | $0.0193 | 21.48 ms | 204.04 ms | 20.1 MB | 13.73 s | runtime 204.04 ms |
| `ruby_web_chat_1000` | ✓ | 1.00 | $0.0223 | 12.80 ms | 76.41 ms | 16.8 MB | 15.47 s | runtime 76.41 ms |
| `zig_sum_positive_perf` | ✓ | 1.00 | $0.0153 | 10.64 ms | 129.24 ms | 100.0 MB | 10.75 s | runtime 129.24 ms |

Pass rate: 5/5 (100%) · Mean score: 1.00 · Total cost: $0.1329 · Cost/pass: $0.0266 · Total: 50.76 s

Important correction: the Zig row above is **not** `zig_web_chat_1000`. It is `zig_sum_positive_perf`, the low-level C ABI perf harness. Useful as a Zig sanity check, but it is not comparable to the HTTP web-chat tasks.

## Zig web chat status

I started adding the missing Zig web-chat task locally but did not get a completed benchmark run in this container.

Uncommitted local files in `/root/source/term-llm-wt/codegen-bench`:

```text
 M benchmarks/codegen/README.md
 M benchmarks/codegen/tasks.go
?? benchmarks/codegen/tasks_zig_web_chat.go
```

The local task registration is:

```go
func optionalTasks() []Task {
	return []Task{
		zigSumPositiveTask{},
		zigWebChat1000Task{},
	}
}
```

The local Zig web-chat scorer is:

```go
func (zigWebChat1000Task) Score(response string, timeout time.Duration) ScoreResult {
	return scoreHTTPServer(response, timeout, httpServerSpec{
		Prefix: "term-llm-codegen-bench-zig-http",
		Files: map[string]string{
			"solution.zig": "{{CODE}}",
		},
		Cmd: []string{"zig", "run", "solution.zig"},
	})
}
```

Suggested local run:

```text
go run ./benchmarks/codegen -provider claude-bin -tasks zig_web_chat_1000 -concurrency 1 -budget 4h -timeout 15m -score-timeout 180s -out benchmarks/codegen/results
```

Expected breakdown fields are already emitted by the shared HTTP scorer when the generated server passes:

```text
BENCH_WARMUP_MS
BENCH_RUNTIME_MS
BENCH_MEMORY_KB
```

Container status: `term-llm ask -p claude-bin hi` works, Zig is available as `zig 0.16.0`, and config resolves to `/root/.config/term-llm/config.yaml`. Foreground benchmark attempts produced no final result before the harness shell cap, so the actual `zig_web_chat_1000` warmup/runtime numbers are still pending.

## Smoke tests

```text
go test ./benchmarks/codegen
go test ./...
go run ./benchmarks/codegen -provider debug:fast -tasks go_fizzbuzz -budget 30s -timeout 20s -out /tmp/codegen-bench-results
go run ./benchmarks/codegen -provider claude-bin -tasks go_fizzbuzz -budget 2m -timeout 2m -out /tmp/codegen-bench-claude-smoke3
```

Claude smoke result:

```text
Provider: claude-bin (sonnet)   Tasks: 1   Concurrency: 2
Task                     Lang     Pass   Score     Cost       Detail
go_fizzbuzz              go       ✓      1.00      $0.0032    ok
Pass rate: 1/1 (100%)   Mean score: 1.00   Cost: $0.0032   Cost/pass: $0.0032   Total: 4.648s
```
