### PR TITLE
fix: read_file keeps reading to EOF after it already knows output is truncated

### DIFF
--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -167,6 +167,7 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 	}
 
 	totalLines := 0
+	totalLinesKnown := false
 	selectedLines := 0
 	writtenLines := 0
 	truncated := false
@@ -223,7 +224,7 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 		}
 
 		if truncated {
-			return true // Keep scanning so the truncation note can report total lines.
+			return false // Stop immediately once truncation is known; don't scan the rest of the file.
 		}
 		if endLine > 0 {
 			if startLine <= endLine && lineNum >= endLine {
@@ -260,13 +261,14 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 				if !emittedAny || lastEndedNewline {
 					processLine("")
 				}
+				totalLinesKnown = true
 				break
 			}
 			return "", readErr
 		}
 	}
 
-	if requestedStart > 0 && startLine > totalLines {
+	if totalLinesKnown && requestedStart > 0 && startLine > totalLines {
 		return "", NewToolErrorf(ErrInvalidParams, "start_line %d exceeds file length %d", requestedStart, totalLines)
 	}
 
@@ -276,7 +278,11 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 
 	output := sb.String()
 	if truncated {
-		output += fmt.Sprintf("\n\n[Output truncated. Total lines: %d. Use start_line/end_line for pagination.]", totalLines)
+		if totalLinesKnown {
+			output += fmt.Sprintf("\n\n[Output truncated. Total lines: %d. Use start_line/end_line for pagination.]", totalLines)
+		} else {
+			output += "\n\n[Output truncated. Use start_line/end_line for pagination.]"
+		}
 	}
 	return output, nil
 }

--- a/internal/tools/read_test.go
+++ b/internal/tools/read_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +70,7 @@ func TestReadFileToolStartLineBeyondEOF(t *testing.T) {
 	}
 }
 
-func TestReadFileToolTruncatesWithTotalLines(t *testing.T) {
+func TestReadFileToolTruncatesWithoutScanningToEOF(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sample.txt")
 	if err := os.WriteFile(path, []byte("one\ntwo\nthree\nfour"), 0o644); err != nil {
 		t.Fatal(err)
@@ -83,9 +85,27 @@ func TestReadFileToolTruncatesWithTotalLines(t *testing.T) {
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	want := "1: one\n2: two\n\n[Output truncated. Total lines: 4. Use start_line/end_line for pagination.]"
+	want := "1: one\n2: two\n\n[Output truncated. Use start_line/end_line for pagination.]"
 	if out.Content != want {
 		t.Fatalf("unexpected output:\nwant %q\n got %q", want, out.Content)
+	}
+}
+
+func TestStreamLineNumberedRangeStopsReadingAfterTruncation(t *testing.T) {
+	limits := DefaultOutputLimits()
+	limits.MaxLines = 2
+
+	got, err := streamLineNumberedRange(context.Background(), bufio.NewReader(&chunkReader{
+		chunks: []string{"one\n", "two\n", "three\n"},
+		err:    errors.New("read past truncation point"),
+	}), 1, 0, limits)
+	if err != nil {
+		t.Fatalf("streamLineNumberedRange returned error: %v", err)
+	}
+
+	want := "1: one\n2: two\n\n[Output truncated. Use start_line/end_line for pagination.]"
+	if got != want {
+		t.Fatalf("unexpected output:\nwant %q\n got %q", want, got)
 	}
 }
 
@@ -173,7 +193,7 @@ func legacyReadFileFormatting(content string, startLine, endLine int, limits Out
 	}
 
 	if truncated {
-		output += fmt.Sprintf("\n\n[Output truncated. Total lines: %d. Use start_line/end_line for pagination.]", totalLines)
+		output += "\n\n[Output truncated. Use start_line/end_line for pagination.]"
 	}
 
 	return output, nil
@@ -214,4 +234,23 @@ func BenchmarkReadFileToolStartRangeLargeFile(b *testing.B) {
 			b.Fatalf("range output missing final line: %q", out.Content)
 		}
 	}
+}
+
+type chunkReader struct {
+	chunks []string
+	index  int
+	err    error
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if r.index >= len(r.chunks) {
+		if r.err != nil {
+			return 0, r.err
+		}
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.chunks[r.index])
+	r.index++
+	return n, nil
 }


### PR DESCRIPTION
## What

- stop `read_file` as soon as it knows output has been truncated instead of continuing to scan the rest of the file
- keep exact file-length validation only when EOF is actually reached
- fall back to a truncation footer without `Total lines` when the reader exits early
- add a regression test that fails if `streamLineNumberedRange` reads past the truncation point

## Why

`read_file` is one of the hottest code-navigation tools. Before this change, hitting `MaxLines` or `MaxBytes` still forced a full scan to EOF just to compute the footer's total-line count. On large source files, logs, and generated assets, that turned a small first-page read into a full-file read, wasting time and deadline budget. This fix keeps the behavior targeted while removing the unnecessary tail scan.
