### PR TITLE
fix: parallel tool execution has no global concurrency limit

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	defaultMaxTurns       = 20
-	stopSearchToolHint    = "IMPORTANT: Do not call any tools. Use the information already retrieved and answer directly."
-	callbackTimeout       = 5 * time.Second
-	toolHeartbeatInterval = 10 * time.Second
+	defaultMaxTurns             = 20
+	defaultMaxParallelToolCalls = 4
+	stopSearchToolHint          = "IMPORTANT: Do not call any tools. Use the information already retrieved and answer directly."
+	callbackTimeout             = 5 * time.Second
+	toolHeartbeatInterval       = 10 * time.Second
 )
 
 // getMaxTurns returns the max turns from request, with fallback to default
@@ -28,6 +29,16 @@ func getMaxTurns(req Request) int {
 		return req.MaxTurns
 	}
 	return defaultMaxTurns
+}
+
+func maxParallelToolWorkers(callCount int) int {
+	if callCount <= 0 {
+		return 0
+	}
+	if callCount < defaultMaxParallelToolCalls {
+		return callCount
+	}
+	return defaultMaxParallelToolCalls
 }
 
 // TurnMetrics contains metrics collected during a turn.
@@ -1544,33 +1555,43 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		return results, nil
 	}
 
-	// Parallel execution for multiple calls (events may arrive out of order)
+	// Parallel execution for multiple calls (events may arrive out of order), but
+	// cap worker count so a single model turn cannot flood the process with tool
+	// executions all at once.
 	type toolResult struct {
 		index   int
 		message Message
 	}
 
 	resultChan := make(chan toolResult, len(calls))
+	workerCount := maxParallelToolWorkers(len(calls))
+	var nextCall atomic.Uint32
 
-	for i, call := range calls {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		go func(idx int, c ToolCall) {
-			defer func() {
-				if r := recover(); r != nil {
-					errMsg := fmt.Sprintf("Error: tool panicked: %v", r)
-					_ = send.Send(Event{Type: EventToolExecEnd, ToolCallID: c.ID, ToolName: c.Name, ToolSuccess: false})
-					resultChan <- toolResult{index: idx, message: ToolErrorMessage(c.ID, c.Name, errMsg, c.ThoughtSig)}
+	for worker := 0; worker < workerCount; worker++ {
+		go func() {
+			for {
+				if err := ctx.Err(); err != nil {
+					return
 				}
-			}()
-			msgs, _ := e.executeSingleToolCall(ctx, c, send, debug, debugRaw)
-			msg := ToolErrorMessage(c.ID, c.Name, "tool returned no result", c.ThoughtSig)
-			if len(msgs) > 0 {
-				msg = msgs[0]
+
+				idx := int(nextCall.Add(1)) - 1
+				if idx >= len(calls) {
+					return
+				}
+
+				if err := ctx.Err(); err != nil {
+					return
+				}
+
+				call := calls[idx]
+				msgs, _ := e.executeSingleToolCallSafe(ctx, call, send, debug, debugRaw)
+				msg := ToolErrorMessage(call.ID, call.Name, "tool returned no result", call.ThoughtSig)
+				if len(msgs) > 0 {
+					msg = msgs[0]
+				}
+				resultChan <- toolResult{index: idx, message: msg}
 			}
-			resultChan <- toolResult{index: idx, message: msg}
-		}(i, call)
+		}()
 	}
 
 	// Collect results and maintain original order. If the caller cancels while

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -943,6 +943,63 @@ func (t *delayingTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+// blockingTool simulates a tool that blocks until released so tests can
+// deterministically observe peak concurrency.
+type blockingTool struct {
+	started chan struct{}
+	release chan struct{}
+
+	mu           sync.Mutex
+	calls        int
+	concurrentAt int
+	current      int
+}
+
+func newBlockingTool(buffer int) *blockingTool {
+	return &blockingTool{
+		started: make(chan struct{}, buffer),
+		release: make(chan struct{}),
+	}
+}
+
+func (t *blockingTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "blocking_tool",
+		Description: "A tool that blocks until released",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (t *blockingTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	t.mu.Lock()
+	t.current++
+	if t.current > t.concurrentAt {
+		t.concurrentAt = t.current
+	}
+	t.calls++
+	t.mu.Unlock()
+
+	t.started <- struct{}{}
+
+	select {
+	case <-t.release:
+	case <-ctx.Done():
+	}
+
+	t.mu.Lock()
+	t.current--
+	t.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return ToolOutput{}, err
+	}
+	return TextOutput("done"), nil
+}
+
+func (t *blockingTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 type cancellableDelayTool struct {
 	delay time.Duration
 }
@@ -1048,6 +1105,87 @@ func TestEngineParallelToolExecution(t *testing.T) {
 	}
 
 	t.Logf("Parallel execution: peak concurrent=%d, elapsed=%v", tool.concurrentAt, elapsed)
+}
+
+func TestEngineParallelToolExecutionRespectsGlobalLimit(t *testing.T) {
+	totalCalls := defaultMaxParallelToolCalls + 3
+	tool := newBlockingTool(totalCalls)
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				events := make([]Event, 0, totalCalls+1)
+				for i := 0; i < totalCalls; i++ {
+					events = append(events, Event{Type: EventToolCall, Tool: &ToolCall{ID: fmt.Sprintf("call-%d", i), Name: "blocking_tool", Arguments: json.RawMessage(`{}`)}})
+				}
+				events = append(events, Event{Type: EventDone})
+				return events
+			default:
+				return []Event{
+					{Type: EventTextDelta, Text: "done"},
+					{Type: EventDone},
+				}
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages:          []Message{UserText("run tools")},
+		Tools:             []ToolSpec{tool.Spec()},
+		ParallelToolCalls: true,
+		ToolChoice:        ToolChoice{Mode: ToolChoiceAuto},
+	})
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	for i := 0; i < defaultMaxParallelToolCalls; i++ {
+		select {
+		case <-tool.started:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timed out waiting for tool start %d", i+1)
+		}
+	}
+
+	select {
+	case <-tool.started:
+		t.Fatalf("started more than %d tools before release", defaultMaxParallelToolCalls)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	tool.mu.Lock()
+	peak := tool.concurrentAt
+	tool.mu.Unlock()
+	if peak != defaultMaxParallelToolCalls {
+		t.Fatalf("peak concurrency = %d, want %d", peak, defaultMaxParallelToolCalls)
+	}
+
+	close(tool.release)
+
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv error: %v", err)
+		}
+		if event.Type == EventError && event.Err != nil {
+			t.Fatalf("event error: %v", event.Err)
+		}
+	}
+
+	tool.mu.Lock()
+	calls := tool.calls
+	tool.mu.Unlock()
+	if calls != totalCalls {
+		t.Fatalf("executed %d tools, want %d", calls, totalCalls)
+	}
 }
 
 func TestExecuteToolCallsParallelReturnsOnContextCancel(t *testing.T) {


### PR DESCRIPTION
## What

Cap parallel tool execution in `Engine.executeToolCalls` with a small worker pool instead of launching one goroutine per tool call.

Also add a regression test that proves a response with more tool calls than the limit does not start more than the configured number at once.

## Why

With `ParallelToolCalls` enabled, a single model response could previously start an unbounded number of shells, greps, reads, or subagents immediately. That could oversubscribe CPU and disk, hurt TUI responsiveness, and reduce overall throughput due to contention.

A fixed concurrency cap keeps useful parallelism for common multi-tool turns while preventing one response from flooding the process.
