### PR TITLE
fix: tool persistence callbacks run synchronously on the tool-dispatch hot path

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -546,7 +546,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	var persistResponseCompleted llm.ResponseCompletedCallback
 	var persistTurnCompleted llm.TurnCompletedCallback
 	var persistSyntheticUserMessage func(context.Context, llm.Message) error
+	var persistQueue *asyncCallbackQueue
 	if store != nil && sess != nil {
+		persistQueue = newAsyncCallbackQueue()
 		// Save system message first if this is a new session with instructions
 		if instructions != "" && !historyHasSystem {
 			sysMsg := &session.Message{
@@ -583,31 +585,62 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		persistResponseCompleted = func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
 			// Calculate duration from stream start
 			durationMs := time.Since(turnStartTime).Milliseconds()
-
-			sessionMsg := session.NewMessage(sess.ID, assistantMsg, -1)
-			sessionMsg.DurationMs = durationMs
-			_ = store.AddMessage(ctx, sess.ID, sessionMsg)
+			queuedAssistantMsg := assistantMsg
+			if persistQueue == nil {
+				sessionMsg := session.NewMessage(sess.ID, queuedAssistantMsg, -1)
+				sessionMsg.DurationMs = durationMs
+				_ = store.AddMessage(ctx, sess.ID, sessionMsg)
+				return nil
+			}
+			persistQueue.Enqueue(func() {
+				cbCtx, cancel := asyncCallbackContext(ctx)
+				defer cancel()
+				sessionMsg := session.NewMessage(sess.ID, queuedAssistantMsg, -1)
+				sessionMsg.DurationMs = durationMs
+				_ = store.AddMessage(cbCtx, sess.ID, sessionMsg)
+			})
 			return nil
 		}
 
 		// Set up turn callback for tool result messages and metrics
 		persistTurnCompleted = func(ctx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
-			// Save messages (tool results, or assistant message when no tools were executed)
-			for _, msg := range turnMessages {
-				sessionMsg := session.NewMessage(sess.ID, msg, -1)
-				// Set duration for assistant messages (when responseCallback didn't run)
-				if msg.Role == llm.RoleAssistant {
-					sessionMsg.DurationMs = time.Since(turnStartTime).Milliseconds()
+			queuedMessages := append([]llm.Message(nil), turnMessages...)
+			assistantDurationMs := time.Since(turnStartTime).Milliseconds()
+			total, count := engine.ContextEstimateBaseline()
+			if persistQueue == nil {
+				for _, msg := range queuedMessages {
+					sessionMsg := session.NewMessage(sess.ID, msg, -1)
+					if msg.Role == llm.RoleAssistant {
+						sessionMsg.DurationMs = assistantDurationMs
+					}
+					_ = store.AddMessage(ctx, sess.ID, sessionMsg)
 				}
-				_ = store.AddMessage(ctx, sess.ID, sessionMsg)
+				_ = store.UpdateMetrics(ctx, sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
+				if total > 0 && count > 0 {
+					_ = store.UpdateContextEstimate(ctx, sess.ID, total, count)
+					sess.LastTotalTokens = total
+					sess.LastMessageCount = count
+				}
+				return nil
 			}
-			// Update metrics
-			_ = store.UpdateMetrics(ctx, sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
-			if total, count := engine.ContextEstimateBaseline(); total > 0 && count > 0 {
-				_ = store.UpdateContextEstimate(ctx, sess.ID, total, count)
-				sess.LastTotalTokens = total
-				sess.LastMessageCount = count
-			}
+			persistQueue.Enqueue(func() {
+				cbCtx, cancel := asyncCallbackContext(ctx)
+				defer cancel()
+				for _, msg := range queuedMessages {
+					sessionMsg := session.NewMessage(sess.ID, msg, -1)
+					// Set duration for assistant messages (when responseCallback didn't run)
+					if msg.Role == llm.RoleAssistant {
+						sessionMsg.DurationMs = assistantDurationMs
+					}
+					_ = store.AddMessage(cbCtx, sess.ID, sessionMsg)
+				}
+				_ = store.UpdateMetrics(cbCtx, sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
+				if total > 0 && count > 0 {
+					_ = store.UpdateContextEstimate(cbCtx, sess.ID, total, count)
+					sess.LastTotalTokens = total
+					sess.LastMessageCount = count
+				}
+			})
 			return nil
 		}
 		persistSyntheticUserMessage = func(ctx context.Context, msg llm.Message) error {
@@ -621,6 +654,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	applyPersistedContextEstimate(engine, sess)
 
 	var jsonInfo sessionInfo
+	if persistQueue != nil {
+		defer persistQueue.Drain()
+	}
 	if askJSON {
 		agentName := ""
 		if agent != nil {
@@ -726,6 +762,10 @@ func runAsk(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		if persistQueue != nil {
+			persistQueue.Drain()
+		}
+
 		progressiveResult = progressiveRun.Result
 		progressiveStatus := session.StatusComplete
 		switch progressiveResult.ExitReason {
@@ -808,6 +848,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		engine.SetTurnCompletedCallback(nil)
 
 		streamErr := <-errChan
+		if persistQueue != nil {
+			persistQueue.Drain()
+		}
 		if streamErr != nil {
 			// Update session status based on error type
 			if store != nil && sess != nil {

--- a/cmd/async_callback_queue.go
+++ b/cmd/async_callback_queue.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const asyncCallbackQueueTimeout = 5 * time.Second
+
+type asyncCallbackQueue struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	jobs   []func()
+	closed bool
+	wg     sync.WaitGroup
+	once   sync.Once
+}
+
+func newAsyncCallbackQueue() *asyncCallbackQueue {
+	q := &asyncCallbackQueue{}
+	q.cond = sync.NewCond(&q.mu)
+	go q.run()
+	return q
+}
+
+func (q *asyncCallbackQueue) run() {
+	for {
+		q.mu.Lock()
+		for len(q.jobs) == 0 && !q.closed {
+			q.cond.Wait()
+		}
+		if len(q.jobs) == 0 && q.closed {
+			q.mu.Unlock()
+			return
+		}
+		job := q.jobs[0]
+		q.jobs[0] = nil
+		q.jobs = q.jobs[1:]
+		q.mu.Unlock()
+
+		job()
+		q.wg.Done()
+	}
+}
+
+func (q *asyncCallbackQueue) Enqueue(job func()) bool {
+	if q == nil || job == nil {
+		return true
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return false
+	}
+	q.jobs = append(q.jobs, job)
+	q.wg.Add(1)
+	q.cond.Signal()
+	return true
+}
+
+func (q *asyncCallbackQueue) Drain() {
+	if q == nil {
+		return
+	}
+	q.once.Do(func() {
+		q.mu.Lock()
+		q.closed = true
+		q.cond.Broadcast()
+		q.mu.Unlock()
+		q.wg.Wait()
+	})
+}
+
+func asyncCallbackContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), asyncCallbackQueueTimeout)
+}

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -740,20 +740,47 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		persistPlatformInjectionLocked()
 	}
 
+	var persistQueue *asyncCallbackQueue
+	if persisted {
+		persistQueue = newAsyncCallbackQueue()
+	}
+
 	// Snapshot fires before each EventToolCall so partial content survives a
 	// consumer cancellation mid-turn.
 	rt.engine.SetAssistantSnapshotCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message) error {
-		producedMu.Lock()
-		defer producedMu.Unlock()
-		upsertPendingAssistantLocked(cbCtx, assistantMsg)
+		queuedAssistantMsg := assistantMsg
+		if persistQueue == nil {
+			producedMu.Lock()
+			defer producedMu.Unlock()
+			upsertPendingAssistantLocked(cbCtx, queuedAssistantMsg)
+			return nil
+		}
+		persistQueue.Enqueue(func() {
+			persistCtx, cancel := asyncCallbackContext(cbCtx)
+			defer cancel()
+			producedMu.Lock()
+			defer producedMu.Unlock()
+			upsertPendingAssistantLocked(persistCtx, queuedAssistantMsg)
+		})
 		return nil
 	})
 	defer rt.engine.SetAssistantSnapshotCallback(nil)
 
 	rt.engine.SetResponseCompletedCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message, _ llm.TurnMetrics) error {
-		producedMu.Lock()
-		defer producedMu.Unlock()
-		upsertPendingAssistantLocked(cbCtx, assistantMsg)
+		queuedAssistantMsg := assistantMsg
+		if persistQueue == nil {
+			producedMu.Lock()
+			defer producedMu.Unlock()
+			upsertPendingAssistantLocked(cbCtx, queuedAssistantMsg)
+			return nil
+		}
+		persistQueue.Enqueue(func() {
+			persistCtx, cancel := asyncCallbackContext(cbCtx)
+			defer cancel()
+			producedMu.Lock()
+			defer producedMu.Unlock()
+			upsertPendingAssistantLocked(persistCtx, queuedAssistantMsg)
+		})
 		return nil
 	})
 	defer rt.engine.SetResponseCompletedCallback(nil)
@@ -762,19 +789,31 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// plain-append the rest (tool results or interjections). Reset pending at
 	// end of turn.
 	rt.engine.SetTurnCompletedCallback(func(cbCtx context.Context, _ int, msgs []llm.Message, _ llm.TurnMetrics) error {
-		producedMu.Lock()
-		defer producedMu.Unlock()
-		appendStart := 0
-		if len(msgs) > 0 && msgs[0].Role == llm.RoleAssistant {
-			upsertPendingAssistantLocked(cbCtx, msgs[0])
-			appendStart = 1
+		queuedMsgs := append([]llm.Message(nil), msgs...)
+		persistTurn := func(persistCtx context.Context) {
+			producedMu.Lock()
+			defer producedMu.Unlock()
+			appendStart := 0
+			if len(queuedMsgs) > 0 && queuedMsgs[0].Role == llm.RoleAssistant {
+				upsertPendingAssistantLocked(persistCtx, queuedMsgs[0])
+				appendStart = 1
+			}
+			if appendStart < len(queuedMsgs) {
+				produced = append(produced, queuedMsgs[appendStart:]...)
+				updateStateAndAppendLocked(persistCtx)
+			}
+			pendingAssistantIdx = -1
+			pendingAssistantMsgID = 0
 		}
-		if appendStart < len(msgs) {
-			produced = append(produced, msgs[appendStart:]...)
-			updateStateAndAppendLocked(cbCtx)
+		if persistQueue == nil {
+			persistTurn(cbCtx)
+			return nil
 		}
-		pendingAssistantIdx = -1
-		pendingAssistantMsgID = 0
+		persistQueue.Enqueue(func() {
+			persistCtx, cancel := asyncCallbackContext(cbCtx)
+			defer cancel()
+			persistTurn(persistCtx)
+		})
 		return nil
 	})
 	defer rt.engine.SetTurnCompletedCallback(nil)
@@ -803,6 +842,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		defer cancel()
 		persistProducedSnapshot(deferCtx)
 	}()
+
+	if persistQueue != nil {
+		defer persistQueue.Drain()
+	}
 
 	stream, err := rt.engine.Stream(runCtx, req)
 	if err != nil {
@@ -861,6 +904,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				return serveRunResult{}, ev.Err
 			}
 		}
+	}
+
+	if persistQueue != nil {
+		persistQueue.Drain()
 	}
 
 	if text := rt.engine.DrainInterjection(); text != "" {

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -92,6 +92,8 @@ type serveRuntimeTestStore struct {
 	updateMessageCalls int
 	updateStatusCalls  int
 	nextID             int64
+	blockAddMessage    <-chan struct{}
+	addMessageStarted  chan struct{}
 }
 
 var _ session.Store = (*serveRuntimeTestStore)(nil)
@@ -166,6 +168,20 @@ func (s *serveRuntimeTestStore) Search(ctx context.Context, query string, limit 
 }
 
 func (s *serveRuntimeTestStore) AddMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	if s.addMessageStarted != nil {
+		select {
+		case s.addMessageStarted <- struct{}{}:
+		default:
+		}
+	}
+	if s.blockAddMessage != nil {
+		select {
+		case <-s.blockAddMessage:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.nextID++
@@ -437,6 +453,74 @@ func TestServeRuntimeCloseCancelsActiveRun(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("run did not exit after Close")
+	}
+}
+
+func TestServeRuntimeToolCallEventNotBlockedBySlowPersistence(t *testing.T) {
+	blockAddMessage := make(chan struct{})
+	store := newServeRuntimeTestStore()
+	store.blockAddMessage = blockAddMessage
+	store.addMessageStarted = make(chan struct{}, 1)
+
+	provider := &serveRuntimeTestProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+	}
+
+	toolEventSeen := make(chan struct{}, 1)
+	runDone := make(chan error, 1)
+	go func() {
+		_, err := rt.RunWithEvents(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+			SessionID:   "sess-slow-persist",
+			Tools:       []llm.ToolSpec{tool.Spec()},
+			ToolChoice:  llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+			MaxTurns:    4,
+			Search:      false,
+			Debug:       false,
+			DebugRaw:    false,
+			Temperature: 0,
+		}, func(ev llm.Event) error {
+			if ev.Type == llm.EventToolCall {
+				select {
+				case toolEventSeen <- struct{}{}:
+				default:
+				}
+			}
+			return nil
+		})
+		runDone <- err
+	}()
+
+	select {
+	case <-store.addMessageStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for queued persistence to start")
+	}
+
+	select {
+	case <-toolEventSeen:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("tool call event was blocked by persistence callback")
+	}
+
+	close(blockAddMessage)
+
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("RunWithEvents() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for runtime to finish")
 	}
 }
 

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -223,38 +223,54 @@ func (r *SpawnAgentRunner) runAgentInternal(ctx context.Context, agentName strin
 	// Set up callbacks to save messages incrementally (after tools setup)
 	// Track when streaming starts for duration calculation
 	streamStartTime := time.Now()
+	var persistQueue *asyncCallbackQueue
 	if persistChildSession {
+		persistQueue = newAsyncCallbackQueue()
+		defer persistQueue.Drain()
 		// Response callback saves assistant message immediately (before tool execution)
 		// This ensures the message is persisted even if tool execution fails/crashes
 		engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
-			sessionMsg := session.NewMessage(childSessionID, assistantMsg, -1)
-			sessionMsg.DurationMs = time.Since(streamStartTime).Milliseconds()
-			if err := r.store.AddMessage(ctx, childSessionID, sessionMsg); err != nil {
-				r.warn("session AddMessage failed: %v", err)
-			}
+			durationMs := time.Since(streamStartTime).Milliseconds()
+			queuedAssistantMsg := assistantMsg
+			persistQueue.Enqueue(func() {
+				cbCtx, cancel := asyncCallbackContext(ctx)
+				defer cancel()
+				sessionMsg := session.NewMessage(childSessionID, queuedAssistantMsg, -1)
+				sessionMsg.DurationMs = durationMs
+				if err := r.store.AddMessage(cbCtx, childSessionID, sessionMsg); err != nil {
+					r.warn("session AddMessage failed: %v", err)
+				}
+			})
 			return nil
 		})
 
 		// Turn callback saves tool result messages and updates metrics
 		engine.SetTurnCompletedCallback(func(ctx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
-			for _, msg := range turnMessages {
-				sessionMsg := session.NewMessage(childSessionID, msg, -1)
-				// Set duration for assistant messages (when responseCallback didn't run)
-				if msg.Role == llm.RoleAssistant {
-					sessionMsg.DurationMs = time.Since(streamStartTime).Milliseconds()
+			queuedMessages := append([]llm.Message(nil), turnMessages...)
+			assistantDurationMs := time.Since(streamStartTime).Milliseconds()
+			total, count := engine.ContextEstimateBaseline()
+			persistQueue.Enqueue(func() {
+				cbCtx, cancel := asyncCallbackContext(ctx)
+				defer cancel()
+				for _, msg := range queuedMessages {
+					sessionMsg := session.NewMessage(childSessionID, msg, -1)
+					// Set duration for assistant messages (when responseCallback didn't run)
+					if msg.Role == llm.RoleAssistant {
+						sessionMsg.DurationMs = assistantDurationMs
+					}
+					if err := r.store.AddMessage(cbCtx, childSessionID, sessionMsg); err != nil {
+						r.warn("session AddMessage failed: %v", err)
+					}
 				}
-				if err := r.store.AddMessage(ctx, childSessionID, sessionMsg); err != nil {
-					r.warn("session AddMessage failed: %v", err)
+				if err := r.store.UpdateMetrics(cbCtx, childSessionID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens); err != nil {
+					r.warn("session UpdateMetrics failed: %v", err)
 				}
-			}
-			if err := r.store.UpdateMetrics(ctx, childSessionID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens); err != nil {
-				r.warn("session UpdateMetrics failed: %v", err)
-			}
-			if total, count := engine.ContextEstimateBaseline(); total > 0 && count > 0 {
-				if err := r.store.UpdateContextEstimate(ctx, childSessionID, total, count); err != nil {
-					r.warn("session UpdateContextEstimate failed: %v", err)
+				if total > 0 && count > 0 {
+					if err := r.store.UpdateContextEstimate(cbCtx, childSessionID, total, count); err != nil {
+						r.warn("session UpdateContextEstimate failed: %v", err)
+					}
 				}
-			}
+			})
 			return nil
 		})
 	}


### PR DESCRIPTION
## What

- move the blocking session-persistence work in `ask`, `serve_runtime`, and `spawn_runner` off the engine callback hot path by enqueueing callback work onto a per-run async queue
- refresh callback contexts when queued work actually runs so persistence still gets a bounded post-cancel window
- wait for queued callback work at safe completion points so persisted/session state stays correct
- add a regression test proving a slow `serve_runtime` store write no longer blocks `EventToolCall` delivery

## Why

`internal/llm/engine.go` invokes snapshot/response/turn callbacks inline while it is streaming output and dispatching tools. In real runtimes those callbacks were doing synchronous SQLite-backed session writes, so lock contention could stall tool-call emission and tool execution for seconds.

This change keeps callback registration semantics intact, but makes the real blocking persistence paths cheap from the engine's perspective. Tool events can keep flowing immediately while persistence happens in ordered background work, and the runtimes still flush that work before they consume the final persisted state.
