### PR TITLE
perf: speed up session store startup

### DIFF
--- a/internal/session/list_bench_test.go
+++ b/internal/session/list_bench_test.go
@@ -34,6 +34,28 @@ func BenchmarkSQLiteStoreListWithLargeHistories(b *testing.B) {
 	}
 }
 
+func BenchmarkNewSQLiteStoreExistingDB(b *testing.B) {
+	dbPath := filepath.Join(b.TempDir(), "sessions.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		b.Fatalf("NewSQLiteStore setup: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		b.Fatalf("Close setup store: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store, err := NewSQLiteStore(Config{Enabled: true, Path: dbPath})
+		if err != nil {
+			b.Fatalf("NewSQLiteStore: %v", err)
+		}
+		if err := store.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+	}
+}
+
 func seedSQLiteStoreListBenchmark(b *testing.B, ctx context.Context, store *SQLiteStore, sessionCount, messagesPerSession int, base time.Time) {
 	b.Helper()
 	tx, err := store.db.BeginTx(ctx, nil)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -175,19 +175,15 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 
 	store := &SQLiteStore{db: db, cfg: cfg}
 
-	// Probe for optional columns. Read-write mode always has them after
-	// migration, but read-only mode skips migrations and may open an older DB.
-	store.hasGeneratedTitles = store.probeColumn("generated_short_title")
-	store.hasCompactionSeq = store.probeColumn("compaction_seq")
-	store.hasCacheWriteTokens = store.probeColumn("cache_write_tokens")
-	store.hasOrigin = store.probeColumn("origin")
-	store.hasPinned = store.probeColumn("pinned")
-	store.hasTitleSkippedAt = store.probeColumn("title_skipped_at")
-	store.hasLastUserMessageAt = store.probeColumn("last_user_message_at")
-	store.hasLastMessageAt = store.probeColumn("last_message_at")
-	store.hasLastTotalTokens = store.probeColumn("last_total_tokens")
-	store.hasLastMessageCount = store.probeColumn("last_message_count")
-	store.hasReasoningEffort = store.probeColumn("reasoning_effort")
+	// Read-write stores have just created or migrated the schema above, so the
+	// current optional columns are known to be present. Read-only stores skip
+	// migrations and may be pointed at an older DB, so probe the sessions table
+	// once and derive every compatibility flag from that single scan.
+	if cfg.ReadOnly {
+		store.probeSessionColumns()
+	} else {
+		store.setCurrentSessionColumns()
+	}
 
 	// Run cleanup if configured (read-write mode only).
 	if !cfg.ReadOnly {
@@ -1791,15 +1787,33 @@ func (s *SQLiteStore) Close() error {
 	return s.db.Close()
 }
 
-// probeColumn checks whether the sessions table has a given column.
-// This is necessary for read-only mode, which skips migrations and
-// may open a database created before the column was added.
-func (s *SQLiteStore) probeColumn(colName string) bool {
+// setCurrentSessionColumns records optional columns that are guaranteed to
+// exist after read-write initialization/migration reaches the current schema.
+func (s *SQLiteStore) setCurrentSessionColumns() {
+	s.hasGeneratedTitles = true
+	s.hasCompactionSeq = true
+	s.hasCacheWriteTokens = true
+	s.hasOrigin = true
+	s.hasPinned = true
+	s.hasTitleSkippedAt = true
+	s.hasLastUserMessageAt = true
+	s.hasLastMessageAt = true
+	s.hasLastTotalTokens = true
+	s.hasLastMessageCount = true
+	s.hasReasoningEffort = true
+}
+
+// probeSessionColumns checks optional session columns in a single PRAGMA scan.
+// Read-only mode skips migrations and may open a database created before one or
+// more optional columns existed, so callers use these flags to build compatible
+// SELECT/UPDATE statements.
+func (s *SQLiteStore) probeSessionColumns() {
 	rows, err := s.db.Query("PRAGMA table_info(sessions)")
 	if err != nil {
-		return false
+		return
 	}
 	defer rows.Close()
+
 	for rows.Next() {
 		var cid int
 		var name, typ string
@@ -1807,13 +1821,33 @@ func (s *SQLiteStore) probeColumn(colName string) bool {
 		var dfltValue sql.NullString
 		var pk int
 		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
-			return false
+			return
 		}
-		if name == colName {
-			return true
+		switch name {
+		case "generated_short_title":
+			s.hasGeneratedTitles = true
+		case "compaction_seq":
+			s.hasCompactionSeq = true
+		case "cache_write_tokens":
+			s.hasCacheWriteTokens = true
+		case "origin":
+			s.hasOrigin = true
+		case "pinned":
+			s.hasPinned = true
+		case "title_skipped_at":
+			s.hasTitleSkippedAt = true
+		case "last_user_message_at":
+			s.hasLastUserMessageAt = true
+		case "last_message_at":
+			s.hasLastMessageAt = true
+		case "last_total_tokens":
+			s.hasLastTotalTokens = true
+		case "last_message_count":
+			s.hasLastMessageCount = true
+		case "reasoning_effort":
+			s.hasReasoningEffort = true
 		}
 	}
-	return false
 }
 
 // sessionSelectCols returns the SELECT column list for session queries.


### PR DESCRIPTION
## What

Speed up session store initialization by avoiding repeated optional-column probes:

- read-write stores now trust the schema immediately after create/migrate
- read-only stores still support older databases, but derive all compatibility flags from one `PRAGMA table_info(sessions)` scan instead of one scan per column
- add a benchmark covering repeated opens of an existing sessions DB

## Why

Opening the session DB is on the CLI startup/resume path and the prior code scanned the same `sessions` schema 11 times per `NewSQLiteStore` call. That created avoidable SQLite work and allocations even though read-write stores have just reached the current schema.

## Evidence

`go test ./internal/session -run '^$' -bench 'BenchmarkNewSQLiteStoreExistingDB' -benchmem -count=5`

Before:

- 630896-650600 ns/op
- ~49.3 KB/op
- 2836 allocs/op

After:

- 269048-276489 ns/op
- ~4.9 KB/op
- 81 allocs/op

Verification:

- `go test ./internal/session -run 'TestReadOnlyOldDBWithoutCompactionSeq|TestSQLiteStoreMigratesProviderKeyColumn'`
- `go test ./internal/session`
- `go build ./...`
- `go test ./...`
