### PR TITLE
perf: skip logging lock for text deltas

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1942,17 +1942,34 @@ type loggingStream struct {
 func (s *loggingStream) Recv() (Event, error) {
 	event, err := s.inner.Recv()
 
-	s.mu.Lock()
-	if err == nil && event.Type == EventUsage && event.Use != nil {
-		s.totalInput += event.Use.InputTokens
-		s.totalOutput += event.Use.OutputTokens
-		s.totalCacheRead += event.Use.CachedInputTokens
-		s.totalCacheWrite += event.Use.CacheWriteTokens
+	if err == nil {
+		switch event.Type {
+		case EventUsage:
+			if event.Use != nil {
+				s.mu.Lock()
+				s.totalInput += event.Use.InputTokens
+				s.totalOutput += event.Use.OutputTokens
+				s.totalCacheRead += event.Use.CachedInputTokens
+				s.totalCacheWrite += event.Use.CacheWriteTokens
+				s.mu.Unlock()
+			}
+		case EventDone:
+			s.mu.Lock()
+			if !s.logged {
+				s.flushLocked()
+			}
+			s.mu.Unlock()
+		}
+		return event, nil
 	}
-	if (err == io.EOF || (err == nil && event.Type == EventDone)) && !s.logged {
-		s.flushLocked()
+
+	if err == io.EOF {
+		s.mu.Lock()
+		if !s.logged {
+			s.flushLocked()
+		}
+		s.mu.Unlock()
 	}
-	s.mu.Unlock()
 
 	return event, err
 }

--- a/internal/llm/engine_benchmark_test.go
+++ b/internal/llm/engine_benchmark_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"testing"
 )
 
@@ -63,4 +64,44 @@ func BenchmarkExecuteSingleToolCallFast(b *testing.B) {
 	b.StopTimer()
 	cancel()
 	<-drained
+}
+
+type benchmarkEventStream struct {
+	events []Event
+	idx    int
+}
+
+func (s *benchmarkEventStream) Recv() (Event, error) {
+	if s.idx >= len(s.events) {
+		return Event{}, io.EOF
+	}
+	event := s.events[s.idx]
+	s.idx++
+	return event, nil
+}
+
+func (s *benchmarkEventStream) Close() error { return nil }
+
+func BenchmarkLoggingStreamTextDeltas(b *testing.B) {
+	const textEvents = 2048
+	events := make([]Event, 0, textEvents+1)
+	for i := 0; i < textEvents; i++ {
+		events = append(events, Event{Type: EventTextDelta, Text: "x"})
+	}
+	events = append(events, Event{Type: EventDone})
+
+	b.SetBytes(textEvents)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		stream := &loggingStream{inner: &benchmarkEventStream{events: events}}
+		for {
+			_, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatalf("Recv returned error: %v", err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## What

Avoid taking `loggingStream`'s mutex for every streamed text delta. The usage logger only mutates shared counters on `EventUsage` and flushes on terminal events, so ordinary token/text events can pass through without lock/unlock overhead.

Also adds a benchmark covering a representative high-volume text-delta stream through `loggingStream`.

## Why

`loggingStream` wraps provider streams globally. Streaming responses can produce thousands of `EventTextDelta` events, but the previous implementation locked a mutex for every event even though text deltas do not affect usage accounting. Skipping that lock on the hot path reduces local per-token overhead without changing synchronization around usage accumulation or flushing.

## Evidence

`go test ./internal/llm -run '^$' -bench '^BenchmarkLoggingStreamTextDeltas$' -benchmem -count=5`

Before:

```text
BenchmarkLoggingStreamTextDeltas-32  72188-72534 ns/op  28.24-28.37 MB/s  202-203 B/op  2 allocs/op
```

After:

```text
BenchmarkLoggingStreamTextDeltas-32  56205-56240 ns/op  36.42-36.44 MB/s  193 B/op      2 allocs/op
```

Verification:

```text
go test ./internal/llm -run 'Test.*Stream|Test.*Usage|Test.*Tool|Test.*Callback|Test.*Engine'
go test ./...
go build ./...
```
