### PR TITLE
fix(claude_bin): bound MCP server shutdown so SIGTERM does not hang webui

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -1226,6 +1226,13 @@ func (p *ClaudeBinProvider) getOrCreateMCPConfig(ctx context.Context, tools []To
 	return configPath
 }
 
+// mcpStopTimeout bounds how long CleanupMCP will wait for the in-process MCP
+// HTTP server to drain in-flight tool calls before forcibly closing connections.
+// Without this bound, an in-flight tool whose result channel has no remaining
+// writer (e.g. the parent stream was cancelled) deadlocks server.Shutdown
+// indefinitely, blocking process exit on SIGTERM during runit-managed restarts.
+const mcpStopTimeout = 5 * time.Second
+
 // CleanupMCP stops the MCP server and removes the config file.
 // This should be called when the conversation is complete (runtime eviction
 // or server shutdown) — NOT per turn, because the MCP server is deliberately
@@ -1234,7 +1241,9 @@ func (p *ClaudeBinProvider) getOrCreateMCPConfig(ctx context.Context, tools []To
 // CleanupTurn was not invoked (e.g. mid-turn abort before stream terminates).
 func (p *ClaudeBinProvider) CleanupMCP() {
 	if p.mcpServer != nil {
-		p.mcpServer.Stop(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), mcpStopTimeout)
+		p.mcpServer.Stop(ctx)
+		cancel()
 		p.mcpServer = nil
 	}
 	if p.mcpConfigPath != "" {

--- a/internal/mcphttp/http_server_test.go
+++ b/internal/mcphttp/http_server_test.go
@@ -131,6 +131,78 @@ func TestServerAuthMiddleware(t *testing.T) {
 	}
 }
 
+// TestServerStopRespectsContextDeadline verifies that Stop returns within the
+// caller-supplied context deadline even when an in-flight tool call's executor
+// is blocked indefinitely.
+//
+// Regression test: ClaudeBinProvider.CleanupMCP previously passed
+// context.Background() to Stop. When a tool call was mid-flight (e.g. a long
+// shell command) and the parent stream had already been cancelled so no writer
+// remained for the result channel, http.Server.Shutdown blocked forever waiting
+// for the active handler — deadlocking process exit on SIGTERM during runit
+// restarts.
+func TestServerStopRespectsContextDeadline(t *testing.T) {
+	executorEntered := make(chan struct{})
+	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+		close(executorEntered)
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	server := NewServer(executor)
+	tools := []ToolSpec{
+		{
+			Name:        "blocking_tool",
+			Description: "A tool whose executor never returns until ctx fires",
+			Schema:      map[string]interface{}{"type": "object"},
+		},
+	}
+
+	url, token, err := server.Start(context.Background(), tools)
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Issue a tool/call that will land in the blocking executor and stay
+	// active. The request body is the minimal MCP JSON-RPC payload that the
+	// stateless StreamableHTTPHandler accepts without prior session setup.
+	go func() {
+		body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"blocking_tool","arguments":{}}}`
+		req, _ := http.NewRequest("POST", url, strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	// Wait until the executor is actually running so server.Shutdown will
+	// see an active handler. Without this we'd race the request setup.
+	select {
+	case <-executorEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("executor never entered — request setup failed; cannot test Stop deadline")
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- server.Stop(stopCtx)
+	}()
+
+	select {
+	case <-stopDone:
+		// Stop returned — graceful shutdown timed out and forced close, exactly
+		// what the production fix relies on.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2s of a 200ms context deadline — server is wedged on active handler")
+	}
+}
+
 func TestServerCannotStartTwice(t *testing.T) {
 	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
 		return "executed", nil


### PR DESCRIPTION
## What

Bound `ClaudeBinProvider.CleanupMCP` to a 5-second timeout when stopping the per-conversation in-process MCP HTTP server, instead of passing `context.Background()`.

## Why — the bug

`mcphttp.Server.Stop` calls `http.Server.Shutdown(ctx)`. With a `Background` context, Shutdown waits for active handlers to return *forever*. When a tool call is mid-flight at SIGTERM, the path that should unblock the handler can race:

1. SSE stream gets cancelled (`responseRuns.Close()` → run ctx cancels).
2. The wrapper executor that owns the tool's MCP HTTP request is still in `select { case <-responseChan: ; case <-ctx.Done(): }`.
3. Its `responseChan` no longer has a writer (the engine stream died), and its `ctx` is the *MCP HTTP request* context — only cancelled when the connection closes.
4. `http.Server.Shutdown(Background)` waits for the handler. The handler waits for ctx. Ctx waits for the connection to close. The connection waits for the handler.

Deadlock. Forever.

## Repro on the homelab

This is the recurring "webui restart on update" hang in `memory/recent.md` — running `update.sh` schedules a detached `sv restart webui`, but webui never exits. Manual `kill -9` is the only way out. Reproduced locally with a `sleep 30` shell tool mid-stream:

```
goroutine 1 [select]:
net/http.(*Server).Shutdown(...)
github.com/samsaffron/term-llm/internal/mcphttp.(*Server).Stop
github.com/samsaffron/term-llm/internal/llm.(*ClaudeBinProvider).CleanupMCP
github.com/samsaffron/term-llm/cmd.(*serveRuntime).Close
github.com/samsaffron/term-llm/cmd.(*serveSessionManager).Close
github.com/samsaffron/term-llm/cmd.runServe
```

The same stack trace appears in the regression-test smoke run when the test passes `Background()` to `Stop`.

## Fix

Pass `context.WithTimeout(Background, 5 * time.Second)` so `server.Shutdown` returns with `DeadlineExceeded`, after which `mcphttp.Server.Stop` already falls through to `server.Close()` — which forcibly closes the active connection, cancels the request ctx, and unblocks the wedged executor.

Five seconds is generous: in the normal path (no in-flight tool, or tool already returned) Shutdown completes in milliseconds. The timeout only matters when something has gone wrong.

## Test

`TestServerStopRespectsContextDeadline` in `internal/mcphttp/http_server_test.go` wires a blocking executor, issues a real `tools/call` JSON-RPC request, waits for the executor to be entered, and asserts `Stop(ctx with 200ms deadline)` returns within 2s. Without the fix in `claude_bin.go` itself the test still passes (the contract being asserted is on `mcphttp.Server`, not on the caller), but the test pins the property the fix relies on, and a parallel smoke test confirmed `Stop(Background())` blocks indefinitely with the exact production stack trace.

`go test ./...` is green.

## Risk

Low. Only changes shutdown behaviour, and only the timeout path. Live shutdown becomes bounded; everything else is unaffected.
