### PR TITLE
feat: add proxied widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,61 @@ Common entry points:
 - [Transcription](https://term-llm.com/guides/transcription/)
 - [Notifications](https://term-llm.com/guides/notifications/)
 
+## Proxied Widgets
+
+Widgets are local web apps that are mounted inside the chat UI and proxied by term-llm. They are opt-in and disabled by default.
+
+### Enabling widgets
+
+```bash
+term-llm serve web --enable-widgets
+```
+
+Widgets are discovered from `~/.config/term-llm/widgets/` (override with `--widgets-dir` or `serve.widgets_dir` in config.yaml). Each sub-directory with a `widget.yaml` manifest becomes a widget.
+
+### widget.yaml
+
+```yaml
+title: "Sam's Hebrew Keyboard"
+mount: hebrew                          # optional; defaults to directory name
+description: "On-screen Hebrew keyboard"
+command: ["uv", "run", "python", "server.py", "--socket", "$SOCKET"]
+```
+
+```yaml
+title: "Dev Server Widget"
+command: ["npm", "run", "dev", "--", "--port", "$PORT"]
+```
+
+**Required fields:** `title`, `command`
+
+**`command`** must contain exactly one of:
+- `$SOCKET` — term-llm creates a Unix domain socket and passes the path in argv and as env vars `TERM_LLM_WIDGET_SOCKET` / `SOCKET`
+- `$PORT` — term-llm allocates a free localhost port and passes it as `TERM_LLM_WIDGET_PORT` / `PORT`
+
+The widget process is started lazily on first request and stopped after 10 minutes of idle time.
+
+### Environment variables set for widget processes
+
+| Variable | Value |
+|---|---|
+| `TERM_LLM_WIDGET_ID` | directory basename |
+| `TERM_LLM_WIDGET_MOUNT` | mount path segment |
+| `TERM_LLM_WIDGET_BASE_PATH` / `BASE_PATH` | full URL prefix for the widget |
+| `TERM_LLM_WIDGET_SOCKET` / `SOCKET` | socket path (socket mode) |
+| `TERM_LLM_WIDGET_HOST` / `HOST` | `127.0.0.1` (port mode) |
+| `TERM_LLM_WIDGET_PORT` / `PORT` | allocated port (port mode) |
+
+### Routes (under `--base-path`, default `/ui`)
+
+| Path | Description |
+|---|---|
+| `GET {base}/widgets/` | HTML index listing all widgets |
+| `{base}/widgets/<mount>/` | Proxied widget (lazy-started on first hit) |
+| `GET {base}/admin/widgets/status` | JSON status of all widgets |
+| `POST {base}/admin/widgets/reload` | Re-scan widgets directory |
+| `POST {base}/admin/widgets/<mount>/stop` | Stop a running widget process |
+
 ## License
 
 MIT

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/tools"
+	"github.com/samsaffron/term-llm/internal/widgets"
 	"github.com/spf13/cobra"
 )
 
@@ -58,6 +59,8 @@ var (
 	serveSidebarSessions        string
 	serveToolMap                []string
 	serveFilesDir               string
+	serveEnableWidgets          bool
+	serveWidgetsDir             string
 )
 
 var serveCmd = &cobra.Command{
@@ -133,6 +136,8 @@ func init() {
 	serveCmd.Flags().StringArrayVar(&serveToolMap, "tool-map", nil, "Map client tool name to server tool (repeatable, format ClientName:ServerName)")
 	serveCmd.Flags().BoolVar(&serveFilterServerTools, "suppress-server-tool-calls", false, "Hide server-executed tool calls from API responses (use when proxying to external clients)")
 	serveCmd.Flags().StringVar(&serveFilesDir, "files-dir", "", "Directory for serving arbitrary files (videos, PDFs, etc) at {base}/files/")
+	serveCmd.Flags().BoolVar(&serveEnableWidgets, "enable-widgets", false, "Enable local widget apps proxied under {base}/widgets/<mount>/")
+	serveCmd.Flags().StringVar(&serveWidgetsDir, "widgets-dir", "", "Directory containing widget sub-directories (default: ~/.config/term-llm/widgets)")
 
 	AddCommonFlags(serveCmd,
 		CommonCoreFlags|CommonSearch|CommonNativeSearch|CommonMaxTurns|CommonAgent,
@@ -512,6 +517,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 		}
 		serveUI := hasWeb
+
+		var widgetsMgr *widgets.Manager
+		if serveEnableWidgets && (hasWeb || hasAPI) {
+			wDir, wErr := resolveWidgetsDir(serveWidgetsDir, cfg)
+			if wErr != nil {
+				return wErr
+			}
+			widgetsMgr = widgets.NewManager(wDir, serveBasePath)
+			log.Printf("widgets enabled, dir: %s", wDir)
+		}
+
 		s = &serveServer{
 			cfg: serveServerConfig{
 				host:                serveHost,
@@ -527,12 +543,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 				corsOrigins:         append([]string(nil), serveCORSOrigins...),
 				filesDir:            resolveFilesDir(serveFilesDir, cfg),
 				writeDirs:           resolveServeWriteDirs(serveWriteDirs, cfg),
+				enableWidgets:       serveEnableWidgets,
+				widgetsDir:          serveWidgetsDir,
 			},
 			sessionMgr:     sessionMgr,
 			jobsV2:         jobsV2,
 			cfgRef:         cfg,
 			store:          store,
 			runtimeFactory: runtimeFactory,
+			widgetsMgr:     widgetsMgr,
 		}
 		sessionMgr.onEvict = func(rt *serveRuntime) {
 			for _, rid := range rt.getResponseIDs() {
@@ -789,6 +808,8 @@ type serveServerConfig struct {
 	corsOrigins         []string
 	filesDir            string   // opt-in directory for serving arbitrary files (videos, PDFs, etc)
 	writeDirs           []string // tool write-dirs (CLI + config); tool-reported files inside these are trusted sources for ensureFileServeable
+	enableWidgets       bool
+	widgetsDir          string
 }
 
 // uiRoute returns the base-path with trailing slash, e.g. "/ui/" or "/chat/".
@@ -806,6 +827,21 @@ func resolveFilesDir(flagVal string, cfg *config.Config) string {
 		return flagVal
 	}
 	return cfg.Serve.FilesDir
+}
+
+// resolveWidgetsDir returns the widgets directory, defaulting to ~/.config/term-llm/widgets.
+func resolveWidgetsDir(flagVal string, cfg *config.Config) (string, error) {
+	if flagVal != "" {
+		return flagVal, nil
+	}
+	if cfg.Serve.WidgetsDir != "" {
+		return cfg.Serve.WidgetsDir, nil
+	}
+	cfgDir, err := config.GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve widgets dir: %w", err)
+	}
+	return cfgDir + "/widgets", nil
 }
 
 // resolveServeWriteDirs returns the merged effective write-dirs for the serve runtime,
@@ -873,6 +909,7 @@ type serveServer struct {
 	responseRuns      *responseRunManager
 	webrtcHeadSnippet string // injected into index.html <head>; empty when WebRTC disabled
 	runtimeFactory    func(ctx context.Context, providerName string, model string) (*serveRuntime, error)
+	widgetsMgr        *widgets.Manager
 }
 
 func (s *serveServer) Start() error {
@@ -927,6 +964,9 @@ func (s *serveServer) httpHandler() http.Handler {
 	inner.HandleFunc("/images/", s.auth(s.cors(s.handleImage)))
 	if s.cfg.filesDir != "" {
 		inner.HandleFunc("/files/", s.auth(s.cors(s.handleFile)))
+	}
+	if s.widgetsMgr != nil {
+		s.registerWidgetRoutes(inner)
 	}
 	inner.HandleFunc("/v1/sessions/status", s.auth(s.cors(s.handleSessionsStatus)))
 	inner.HandleFunc("/v1/sessions/", s.auth(s.cors(s.handleSessionByID)))
@@ -998,6 +1038,9 @@ func (s *serveServer) Stop(ctx context.Context) error {
 	}
 	if s.responseRuns != nil {
 		s.responseRuns.Close()
+	}
+	if s.widgetsMgr != nil {
+		s.widgetsMgr.Close()
 	}
 	s.modelsMu.Lock()
 	for _, p := range s.modelsProviders {

--- a/cmd/serve_widgets.go
+++ b/cmd/serve_widgets.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/widgets"
+)
+
+// widgetsRoute returns the widgets sub-route, e.g. "/ui/widgets/".
+func (c serveServerConfig) widgetsRoute() string { return c.basePath + "/widgets/" }
+
+// adminWidgetsRoute returns the admin widgets sub-route, e.g. "/ui/admin/widgets/".
+func (c serveServerConfig) adminWidgetsRoute() string { return c.basePath + "/admin/widgets/" }
+
+// registerWidgetRoutes mounts widget proxy and admin routes on inner mux.
+// inner must be an http.ServeMux with basePath already stripped.
+func (s *serveServer) registerWidgetRoutes(inner *http.ServeMux) {
+	inner.HandleFunc("/widgets/", s.auth(s.handleWidgetProxy))
+	inner.HandleFunc("/admin/widgets/reload", s.auth(s.cors(s.handleAdminWidgetsReload)))
+	inner.HandleFunc("/admin/widgets/status", s.auth(s.cors(s.handleAdminWidgetsStatus)))
+	inner.HandleFunc("/admin/widgets/", s.auth(s.cors(s.handleAdminWidgetStop)))
+	inner.HandleFunc("/widgets", s.auth(s.handleWidgetIndex))
+}
+
+// handleWidgetIndex serves a simple HTML index page listing all widgets.
+func (s *serveServer) handleWidgetIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/widgets" && r.URL.Path != "/widgets/" {
+		http.NotFound(w, r)
+		return
+	}
+	statuses := s.widgetsMgr.Status()
+	errs := s.widgetsMgr.LoadErrors()
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><title>Widgets</title></head><body>`)
+	fmt.Fprintf(w, `<h1>Widgets</h1>`)
+
+	if len(errs) > 0 {
+		fmt.Fprintf(w, `<h2>Load Errors</h2><ul>`)
+		for _, e := range errs {
+			fmt.Fprintf(w, `<li>%s</li>`, html.EscapeString(e.Error()))
+		}
+		fmt.Fprintf(w, `</ul>`)
+	}
+
+	if len(statuses) == 0 {
+		fmt.Fprintf(w, `<p>No widgets loaded.</p>`)
+	} else {
+		fmt.Fprintf(w, `<table border="1" cellpadding="4"><tr><th>Mount</th><th>Title</th><th>State</th><th>Link</th></tr>`)
+		for _, st := range statuses {
+			link := s.cfg.basePath + "/widgets/" + st.Mount + "/"
+			fmt.Fprintf(w, `<tr><td>%s</td><td>%s</td><td>%s</td><td><a href="%s">open</a></td></tr>`,
+				html.EscapeString(st.Mount),
+				html.EscapeString(st.Title),
+				html.EscapeString(st.State),
+				html.EscapeString(link),
+			)
+		}
+		fmt.Fprintf(w, `</table>`)
+	}
+	fmt.Fprintf(w, `</body></html>`)
+}
+
+// handleWidgetProxy proxies requests to the appropriate widget process.
+// Path: /widgets/<mount>/...
+func (s *serveServer) handleWidgetProxy(w http.ResponseWriter, r *http.Request) {
+	// Strip leading /widgets/ to get "mount/rest..."
+	rest := strings.TrimPrefix(r.URL.Path, "/widgets/")
+	if rest == "" {
+		// /widgets/ with no mount - redirect to index
+		http.Redirect(w, r, s.cfg.basePath+"/widgets", http.StatusTemporaryRedirect)
+		return
+	}
+
+	parts := strings.SplitN(rest, "/", 2)
+	mount := parts[0]
+	if mount == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// /widgets/<mount> (no trailing slash) → redirect so relative asset URLs work.
+	if len(parts) == 1 {
+		http.Redirect(w, r, s.cfg.basePath+"/widgets/"+mount+"/", http.StatusTemporaryRedirect)
+		return
+	}
+
+	// Build the widget-relative path: "/" + everything after "mount/"
+	widgetPath := "/" + parts[1]
+
+	// Rewrite request path to the widget-relative path before proxying.
+	r2 := r.Clone(r.Context())
+	r2.URL.Path = widgetPath
+	if r2.URL.RawPath != "" {
+		rawRest := strings.TrimPrefix(r.URL.RawPath, "/widgets/"+mount)
+		if rawRest == "" || rawRest == "/" {
+			rawRest = "/"
+		} else if !strings.HasPrefix(rawRest, "/") {
+			rawRest = "/" + rawRest
+		}
+		r2.URL.RawPath = rawRest
+	}
+
+	s.widgetsMgr.Proxy(mount, w, r2)
+}
+
+// handleAdminWidgetsReload handles POST /admin/widgets/reload.
+func (s *serveServer) handleAdminWidgetsReload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	errs := s.widgetsMgr.Reload()
+	type result struct {
+		OK     bool     `json:"ok"`
+		Errors []string `json:"errors,omitempty"`
+	}
+	res := result{OK: len(errs) == 0}
+	for _, e := range errs {
+		res.Errors = append(res.Errors, e.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(res)
+}
+
+// handleAdminWidgetsStatus handles GET /admin/widgets/status.
+func (s *serveServer) handleAdminWidgetsStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	type statusResponse struct {
+		Widgets    []widgets.WidgetStatus `json:"widgets"`
+		LoadErrors []string               `json:"load_errors,omitempty"`
+	}
+	resp := statusResponse{
+		Widgets: s.widgetsMgr.Status(),
+	}
+	for _, e := range s.widgetsMgr.LoadErrors() {
+		resp.LoadErrors = append(resp.LoadErrors, e.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleAdminWidgetStop handles POST /admin/widgets/<mount>/stop.
+func (s *serveServer) handleAdminWidgetStop(w http.ResponseWriter, r *http.Request) {
+	// Path under inner mux: /admin/widgets/<mount>/stop
+	rest := strings.TrimPrefix(r.URL.Path, "/admin/widgets/")
+	mount, action, ok := strings.Cut(rest, "/")
+	if !ok || action != "stop" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := s.widgetsMgr.StopMount(mount); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"ok":true}`)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,11 +147,12 @@ type Config struct {
 
 // ServeConfig holds configuration for the serve command platforms.
 type ServeConfig struct {
-	Platforms []string            `mapstructure:"platforms" yaml:"platforms,omitempty"`
-	BasePath  string              `mapstructure:"base_path" yaml:"base_path,omitempty"`
-	FilesDir  string              `mapstructure:"files_dir" yaml:"files_dir,omitempty"`
-	Telegram  TelegramServeConfig `mapstructure:"telegram" yaml:"telegram,omitempty"`
-	WebPush   WebPushConfig       `mapstructure:"web_push" yaml:"web_push,omitempty"`
+	Platforms  []string            `mapstructure:"platforms" yaml:"platforms,omitempty"`
+	BasePath   string              `mapstructure:"base_path" yaml:"base_path,omitempty"`
+	FilesDir   string              `mapstructure:"files_dir" yaml:"files_dir,omitempty"`
+	WidgetsDir string              `mapstructure:"widgets_dir" yaml:"widgets_dir,omitempty"`
+	Telegram   TelegramServeConfig `mapstructure:"telegram" yaml:"telegram,omitempty"`
+	WebPush    WebPushConfig       `mapstructure:"web_push" yaml:"web_push,omitempty"`
 }
 
 // WebPushConfig holds VAPID keys for Web Push notifications.

--- a/internal/widgets/manager.go
+++ b/internal/widgets/manager.go
@@ -1,0 +1,459 @@
+package widgets
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	idleTimeout      = 10 * time.Minute
+	startupTimeout   = 10 * time.Second
+	socketRuntimeDir = "/tmp/term-llm-widgets"
+)
+
+type processState int
+
+const (
+	stateStopped processState = iota
+	stateStarting
+	stateRunning
+	stateError
+)
+
+type widgetEntry struct {
+	manifest *Manifest
+
+	mu      sync.Mutex
+	startMu sync.Mutex // serializes concurrent start attempts
+	state   processState
+	errMsg  string
+	proc    *os.Process
+	proxy   *httputil.ReverseProxy
+	lastReq time.Time
+	port    int
+}
+
+func (e *widgetEntry) setError(err error) error {
+	e.mu.Lock()
+	e.state = stateError
+	e.errMsg = err.Error()
+	e.mu.Unlock()
+	return err
+}
+
+// Manager discovers and manages widget sub-processes.
+type Manager struct {
+	widgetsDir string
+	basePath   string
+
+	mu       sync.RWMutex
+	entries  map[string]*widgetEntry // mount → entry
+	loadErrs []error
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+// NewManager creates a manager, scans widgetsDir, and starts the idle reaper.
+func NewManager(widgetsDir, basePath string) *Manager {
+	m := &Manager{
+		widgetsDir: widgetsDir,
+		basePath:   basePath,
+		entries:    make(map[string]*widgetEntry),
+		stopCh:     make(chan struct{}),
+	}
+	m.scan()
+	go m.idleLoop()
+	return m
+}
+
+func (m *Manager) scan() {
+	manifests, errs := ScanDir(m.widgetsDir)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	newMounts := make(map[string]bool, len(manifests))
+	for _, mf := range manifests {
+		newMounts[mf.Mount] = true
+	}
+	for mount, e := range m.entries {
+		if !newMounts[mount] {
+			go e.stopProcess()
+		}
+	}
+
+	newEntries := make(map[string]*widgetEntry, len(manifests))
+	for _, mf := range manifests {
+		if existing, ok := m.entries[mf.Mount]; ok {
+			existing.mu.Lock()
+			existing.manifest = mf
+			if existing.state == stateError {
+				existing.state = stateStopped
+				existing.errMsg = ""
+			}
+			existing.mu.Unlock()
+			newEntries[mf.Mount] = existing
+		} else {
+			newEntries[mf.Mount] = &widgetEntry{
+				manifest: mf,
+				state:    stateStopped,
+				lastReq:  time.Now(),
+			}
+		}
+	}
+	m.entries = newEntries
+	m.loadErrs = errs
+}
+
+// Reload re-scans widgetsDir and returns any load errors.
+func (m *Manager) Reload() []error {
+	m.scan()
+	m.mu.RLock()
+	errs := append([]error(nil), m.loadErrs...)
+	m.mu.RUnlock()
+	return errs
+}
+
+// WidgetStatus describes the current state of a widget.
+type WidgetStatus struct {
+	ID          string `json:"id"`
+	Mount       string `json:"mount"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	State       string `json:"state"`
+	Error       string `json:"error,omitempty"`
+	Port        int    `json:"port,omitempty"`
+}
+
+// Status returns current status for all loaded widgets.
+func (m *Manager) Status() []WidgetStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]WidgetStatus, 0, len(m.entries))
+	for _, e := range m.entries {
+		e.mu.Lock()
+		s := WidgetStatus{
+			ID:          e.manifest.ID,
+			Mount:       e.manifest.Mount,
+			Title:       e.manifest.Title,
+			Description: e.manifest.Description,
+			Port:        e.port,
+		}
+		switch e.state {
+		case stateStopped:
+			s.State = "stopped"
+		case stateStarting:
+			s.State = "starting"
+		case stateRunning:
+			s.State = "running"
+		case stateError:
+			s.State = "error"
+			s.Error = e.errMsg
+		}
+		e.mu.Unlock()
+		out = append(out, s)
+	}
+	return out
+}
+
+// LoadErrors returns errors from the last scan.
+func (m *Manager) LoadErrors() []error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return append([]error(nil), m.loadErrs...)
+}
+
+// StopMount stops the process for the named mount.
+func (m *Manager) StopMount(mount string) error {
+	m.mu.RLock()
+	e, ok := m.entries[mount]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("widget %q not found", mount)
+	}
+	e.stopProcess()
+	return nil
+}
+
+// Proxy forwards r to the widget identified by mount.
+// The path in r must already have the /widgets/<mount> prefix stripped.
+func (m *Manager) Proxy(mount string, w http.ResponseWriter, r *http.Request) {
+	m.mu.RLock()
+	e, ok := m.entries[mount]
+	m.mu.RUnlock()
+	if !ok {
+		http.Error(w, "widget not found: "+mount, http.StatusNotFound)
+		return
+	}
+
+	if err := m.ensureRunning(e); err != nil {
+		http.Error(w, fmt.Sprintf("widget %s: %v", mount, err), http.StatusBadGateway)
+		return
+	}
+
+	e.mu.Lock()
+	e.lastReq = time.Now()
+	proxy := e.proxy
+	e.mu.Unlock()
+
+	if proxy == nil {
+		http.Error(w, "widget proxy not initialized", http.StatusBadGateway)
+		return
+	}
+
+	// Clone request and strip sensitive headers before forwarding.
+	r2 := r.Clone(r.Context())
+	r2.Header.Del("Authorization")
+	r2.Header.Del("Cookie")
+	r2.Header.Set("X-Forwarded-Prefix", m.basePath+"/widgets/"+mount)
+	r2.Header.Set("X-Forwarded-Host", r.Host)
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	r2.Header.Set("X-Forwarded-Proto", scheme)
+	r2.Header.Set("X-Term-LLM-Widget", e.manifest.ID)
+
+	proxy.ServeHTTP(w, r2)
+}
+
+func (m *Manager) ensureRunning(e *widgetEntry) error {
+	e.startMu.Lock()
+	defer e.startMu.Unlock()
+
+	e.mu.Lock()
+	state := e.state
+	errMsg := e.errMsg
+	e.mu.Unlock()
+
+	switch state {
+	case stateRunning:
+		return nil
+	case stateError:
+		return fmt.Errorf("in error state: %s (use reload to reset)", errMsg)
+	}
+	return e.startProcess(m.basePath)
+}
+
+func (e *widgetEntry) startProcess(basePath string) error {
+	mf := e.manifest
+	mode, _ := mf.PlaceholderMode()
+
+	e.mu.Lock()
+	e.state = stateStarting
+	e.mu.Unlock()
+
+	var (
+		transport  http.RoundTripper
+		targetBase string
+		argv       []string
+	)
+
+	env := append(os.Environ(),
+		"TERM_LLM_WIDGET_ID="+mf.ID,
+		"TERM_LLM_WIDGET_MOUNT="+mf.Mount,
+		"TERM_LLM_WIDGET_BASE_PATH="+basePath+"/widgets/"+mf.Mount,
+		"BASE_PATH="+basePath+"/widgets/"+mf.Mount,
+	)
+
+	switch mode {
+	case "socket":
+		if err := os.MkdirAll(socketRuntimeDir, 0700); err != nil {
+			return e.setError(fmt.Errorf("create socket dir: %w", err))
+		}
+		sockPath := filepath.Join(socketRuntimeDir, mf.ID+".sock")
+		_ = os.Remove(sockPath)
+
+		argv = SubstArgs(mf.Command, "$SOCKET", sockPath)
+		env = append(env,
+			"TERM_LLM_WIDGET_SOCKET="+sockPath,
+			"SOCKET="+sockPath,
+		)
+		transport = &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		}
+		targetBase = "http://widget"
+
+	case "port":
+		port, err := freePort()
+		if err != nil {
+			return e.setError(fmt.Errorf("allocate port: %w", err))
+		}
+		portStr := fmt.Sprintf("%d", port)
+		argv = SubstArgs(mf.Command, "$PORT", portStr)
+		env = append(env,
+			"TERM_LLM_WIDGET_HOST=127.0.0.1",
+			"TERM_LLM_WIDGET_PORT="+portStr,
+			"HOST=127.0.0.1",
+			"PORT="+portStr,
+		)
+		transport = http.DefaultTransport
+		targetBase = "http://127.0.0.1:" + portStr
+
+		e.mu.Lock()
+		e.port = port
+		e.mu.Unlock()
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Dir = mf.Dir
+	cmd.Env = env
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return e.setError(fmt.Errorf("start process: %w", err))
+	}
+
+	e.mu.Lock()
+	e.proc = cmd.Process
+	e.mu.Unlock()
+
+	go func() {
+		_ = cmd.Wait()
+		e.mu.Lock()
+		if e.state == stateRunning || e.state == stateStarting {
+			e.state = stateStopped
+			e.proc = nil
+			e.proxy = nil
+		}
+		e.mu.Unlock()
+		log.Printf("[widget] %s process exited", mf.Mount)
+	}()
+
+	// Poll / until the widget responds or the timeout expires.
+	client := &http.Client{Transport: transport, Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(startupTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		e.mu.Lock()
+		alive := e.proc != nil
+		e.mu.Unlock()
+		if !alive {
+			return e.setError(fmt.Errorf("process exited during startup"))
+		}
+		resp, err := client.Get(targetBase + "/")
+		if err == nil {
+			resp.Body.Close()
+			lastErr = nil
+			break
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	if lastErr != nil {
+		e.mu.Lock()
+		p := e.proc
+		e.mu.Unlock()
+		if p != nil {
+			_ = p.Kill()
+		}
+		return e.setError(fmt.Errorf("did not respond within %s: %v", startupTimeout, lastErr))
+	}
+
+	targetURL, _ := url.Parse(targetBase)
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	proxy.Transport = transport
+
+	e.mu.Lock()
+	e.state = stateRunning
+	e.proxy = proxy
+	e.lastReq = time.Now()
+	e.mu.Unlock()
+
+	log.Printf("[widget] %s started (mode=%s)", mf.Mount, mode)
+	return nil
+}
+
+func (e *widgetEntry) stopProcess() {
+	e.mu.Lock()
+	proc := e.proc
+	e.state = stateStopped
+	e.proc = nil
+	e.proxy = nil
+	e.port = 0
+	e.mu.Unlock()
+
+	if proc == nil {
+		return
+	}
+	_ = proc.Signal(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		proc.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		_ = proc.Kill()
+	}
+	if mode, _ := e.manifest.PlaceholderMode(); mode == "socket" {
+		_ = os.Remove(filepath.Join(socketRuntimeDir, e.manifest.ID+".sock"))
+	}
+}
+
+func (m *Manager) idleLoop() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.reapIdle()
+		}
+	}
+}
+
+func (m *Manager) reapIdle() {
+	m.mu.RLock()
+	var toStop []*widgetEntry
+	for _, e := range m.entries {
+		e.mu.Lock()
+		if e.state == stateRunning && time.Since(e.lastReq) > idleTimeout {
+			toStop = append(toStop, e)
+		}
+		e.mu.Unlock()
+	}
+	m.mu.RUnlock()
+	for _, e := range toStop {
+		log.Printf("[widget] idle timeout, stopping %s", e.manifest.Mount)
+		e.stopProcess()
+	}
+}
+
+// Close stops all widget processes and the idle reaper.
+func (m *Manager) Close() {
+	m.stopOnce.Do(func() {
+		close(m.stopCh)
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		for _, e := range m.entries {
+			e.stopProcess()
+		}
+	})
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/internal/widgets/manifest.go
+++ b/internal/widgets/manifest.go
@@ -1,0 +1,142 @@
+package widgets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var mountRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+
+// Manifest is the parsed contents of a widget.yaml file.
+type Manifest struct {
+	Title       string   `yaml:"title"`
+	Command     []string `yaml:"command"`
+	Mount       string   `yaml:"mount"`
+	Description string   `yaml:"description"`
+
+	// Set by ScanDir, not from YAML.
+	ID  string
+	Dir string
+}
+
+// PlaceholderMode returns "socket" or "port" based on which placeholder appears
+// in Command. Returns an error if both or neither are present.
+func (m *Manifest) PlaceholderMode() (string, error) {
+	hasSocket, hasPort := false, false
+	for _, arg := range m.Command {
+		if strings.Contains(arg, "$SOCKET") {
+			hasSocket = true
+		}
+		if strings.Contains(arg, "$PORT") {
+			hasPort = true
+		}
+	}
+	switch {
+	case hasSocket && hasPort:
+		return "", fmt.Errorf("command must contain $SOCKET or $PORT, not both")
+	case !hasSocket && !hasPort:
+		return "", fmt.Errorf("command must contain exactly one of $SOCKET or $PORT")
+	case hasSocket:
+		return "socket", nil
+	default:
+		return "port", nil
+	}
+}
+
+// SubstArgs returns a copy of argv with all occurrences of placeholder replaced by value.
+func SubstArgs(argv []string, placeholder, value string) []string {
+	out := make([]string, len(argv))
+	for i, a := range argv {
+		out[i] = strings.ReplaceAll(a, placeholder, value)
+	}
+	return out
+}
+
+// ScanDir scans widgetsDir for widget.yaml manifests.
+// Directories without widget.yaml are silently skipped.
+// Returns valid manifests (sorted by directory name) and any per-widget errors.
+// A missing widgetsDir is treated as no widgets (no error).
+func ScanDir(widgetsDir string) ([]*Manifest, []error) {
+	entries, err := os.ReadDir(widgetsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []error{fmt.Errorf("scan widgets dir: %w", err)}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	var manifests []*Manifest
+	var errs []error
+	seenMounts := make(map[string]string)
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		dir := filepath.Join(widgetsDir, id)
+		yamlPath := filepath.Join(dir, "widget.yaml")
+
+		data, err := os.ReadFile(yamlPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("widget %s: read widget.yaml: %w", id, err))
+			continue
+		}
+
+		var m Manifest
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			errs = append(errs, fmt.Errorf("widget %s: parse widget.yaml: %w", id, err))
+			continue
+		}
+
+		m.ID = id
+		m.Dir = dir
+
+		if err := validateManifest(&m); err != nil {
+			errs = append(errs, fmt.Errorf("widget %s: %w", id, err))
+			continue
+		}
+
+		if prev, ok := seenMounts[m.Mount]; ok {
+			errs = append(errs, fmt.Errorf("widget %s: duplicate mount %q (already used by %s), skipping", id, m.Mount, prev))
+			continue
+		}
+		seenMounts[m.Mount] = id
+		manifests = append(manifests, &m)
+	}
+	return manifests, errs
+}
+
+func validateManifest(m *Manifest) error {
+	if strings.TrimSpace(m.Title) == "" {
+		return fmt.Errorf("title is required")
+	}
+	if len(m.Command) == 0 {
+		return fmt.Errorf("command is required and must be non-empty")
+	}
+	if m.Mount == "" {
+		m.Mount = m.ID
+	}
+	if strings.Contains(m.Mount, "/") {
+		return fmt.Errorf("mount %q must not contain a slash", m.Mount)
+	}
+	if !mountRe.MatchString(m.Mount) {
+		return fmt.Errorf("mount %q does not match required pattern ^[a-z0-9][a-z0-9-]{0,63}$", m.Mount)
+	}
+	if _, err := m.PlaceholderMode(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/widgets/manifest_test.go
+++ b/internal/widgets/manifest_test.go
@@ -1,0 +1,217 @@
+package widgets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlaceholderMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		command []string
+		want    string
+		wantErr bool
+	}{
+		{"socket", []string{"cmd", "--socket", "$SOCKET"}, "socket", false},
+		{"port", []string{"cmd", "--port", "$PORT"}, "port", false},
+		{"port inline", []string{"cmd", "--port=$PORT"}, "port", false},
+		{"both", []string{"cmd", "$SOCKET", "$PORT"}, "", true},
+		{"neither", []string{"cmd", "--arg"}, "", true},
+		{"socket in argv0", []string{"$SOCKET"}, "socket", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manifest{Command: tc.command}
+			got, err := m.PlaceholderMode()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("PlaceholderMode() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("PlaceholderMode() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSubstArgs(t *testing.T) {
+	argv := []string{"cmd", "--socket=$SOCKET", "extra"}
+	got := SubstArgs(argv, "$SOCKET", "/tmp/test.sock")
+	if got[1] != "--socket=/tmp/test.sock" {
+		t.Errorf("SubstArgs() = %v, want --socket=/tmp/test.sock", got[1])
+	}
+	if got[2] != "extra" {
+		t.Errorf("SubstArgs() mutated unrelated arg: %v", got[2])
+	}
+	// original unchanged
+	if argv[1] != "--socket=$SOCKET" {
+		t.Errorf("SubstArgs() mutated original argv")
+	}
+}
+
+func TestScanDir_Missing(t *testing.T) {
+	manifests, errs := ScanDir("/nonexistent-dir-xyz")
+	if len(manifests) != 0 || len(errs) != 0 {
+		t.Errorf("missing dir should return empty results, got %v %v", manifests, errs)
+	}
+}
+
+func TestScanDir_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeWidget(t, dir, "my-widget", `
+title: "My Widget"
+command: ["python", "server.py", "--socket", "$SOCKET"]
+description: "A test widget"
+`)
+	manifests, errs := ScanDir(dir)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(manifests) != 1 {
+		t.Fatalf("expected 1 manifest, got %d", len(manifests))
+	}
+	m := manifests[0]
+	if m.ID != "my-widget" {
+		t.Errorf("ID = %q, want my-widget", m.ID)
+	}
+	if m.Mount != "my-widget" {
+		t.Errorf("Mount = %q, want my-widget (defaulted from ID)", m.Mount)
+	}
+	if m.Title != "My Widget" {
+		t.Errorf("Title = %q, want 'My Widget'", m.Title)
+	}
+}
+
+func TestScanDir_ExplicitMount(t *testing.T) {
+	dir := t.TempDir()
+	writeWidget(t, dir, "my-widget", `
+title: "My Widget"
+mount: hebrew
+command: ["uv", "run", "python", "server.py", "--socket", "$SOCKET"]
+`)
+	manifests, errs := ScanDir(dir)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if manifests[0].Mount != "hebrew" {
+		t.Errorf("Mount = %q, want hebrew", manifests[0].Mount)
+	}
+}
+
+func TestScanDir_InvalidMount(t *testing.T) {
+	cases := []struct{ name, mount string }{
+		{"slash", "foo/bar"},
+		{"uppercase", "FooBar"},
+		{"space", "foo bar"},
+		{"leading-dash", "-foo"},
+		{"too-long", "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01234"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			yaml := "title: T\ncommand: [\"cmd\", \"$SOCKET\"]\nmount: " + tc.mount + "\n"
+			writeWidget(t, dir, "w", yaml)
+			manifests, errs := ScanDir(dir)
+			if len(errs) == 0 {
+				t.Errorf("expected error for mount %q, got none; manifests=%v", tc.mount, manifests)
+			}
+		})
+	}
+}
+
+func TestScanDir_MissingTitle(t *testing.T) {
+	dir := t.TempDir()
+	writeWidget(t, dir, "w", `command: ["cmd", "$PORT"]`)
+	_, errs := ScanDir(dir)
+	if len(errs) == 0 {
+		t.Error("expected error for missing title")
+	}
+}
+
+func TestScanDir_MissingCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeWidget(t, dir, "w", `title: T`)
+	_, errs := ScanDir(dir)
+	if len(errs) == 0 {
+		t.Error("expected error for missing command")
+	}
+}
+
+func TestScanDir_BothPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	writeWidget(t, dir, "w", `title: T
+command: ["cmd", "$SOCKET", "$PORT"]`)
+	_, errs := ScanDir(dir)
+	if len(errs) == 0 {
+		t.Error("expected error for both $SOCKET and $PORT")
+	}
+}
+
+func TestScanDir_DuplicateMount(t *testing.T) {
+	dir := t.TempDir()
+	// Both widgets default their mount to "aaa" and "bbb" but explicit mount "foo" collides
+	writeWidget(t, dir, "aaa", `title: A
+mount: foo
+command: ["cmd", "$PORT"]`)
+	writeWidget(t, dir, "bbb", `title: B
+mount: foo
+command: ["cmd", "$PORT"]`)
+	manifests, errs := ScanDir(dir)
+	if len(manifests) != 1 {
+		t.Errorf("expected 1 manifest (first wins), got %d", len(manifests))
+	}
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error (duplicate), got %d", len(errs))
+	}
+	if manifests[0].ID != "aaa" {
+		t.Errorf("expected first (aaa) to win, got %s", manifests[0].ID)
+	}
+}
+
+func TestScanDir_SortedDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	writeWidget(t, dir, "zz", `title: Z
+command: ["cmd", "$PORT"]`)
+	writeWidget(t, dir, "aa", `title: A
+command: ["cmd", "$PORT"]`)
+	writeWidget(t, dir, "mm", `title: M
+command: ["cmd", "$PORT"]`)
+	manifests, errs := ScanDir(dir)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	want := []string{"aa", "mm", "zz"}
+	for i, m := range manifests {
+		if m.ID != want[i] {
+			t.Errorf("manifests[%d].ID = %q, want %q", i, m.ID, want[i])
+		}
+	}
+}
+
+func TestScanDir_SkipsNonDirs(t *testing.T) {
+	dir := t.TempDir()
+	// Create a regular file (not a directory) - should be skipped
+	if err := os.WriteFile(filepath.Join(dir, "notadir"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeWidget(t, dir, "real", `title: R
+command: ["cmd", "$PORT"]`)
+	manifests, errs := ScanDir(dir)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(manifests) != 1 {
+		t.Errorf("expected 1 manifest, got %d", len(manifests))
+	}
+}
+
+func writeWidget(t *testing.T, base, id, yaml string) {
+	t.Helper()
+	d := filepath.Join(base, id)
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "widget.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a proxied widgets system: local web apps that are mounted inside the chat UI and reverse-proxied by term-llm. Widgets are **opt-in** — nothing runs unless `--enable-widgets` is passed.

## Design

### Manifest (`widget.yaml`)

Each widget lives in its own directory under `~/.config/term-llm/widgets/` (or `--widgets-dir`). A `widget.yaml` declares:

```yaml
title: "Sam's Hebrew Keyboard"
mount: hebrew                    # optional; defaults to directory basename
command: ["uv", "run", "python", "server.py", "--socket", "$SOCKET"]
```

```yaml
title: "Dev Server Widget"
command: ["npm", "run", "dev", "--", "--port", "$PORT"]
```

**Rules:**
- `title` and `command` are required
- `command` must contain exactly one of `$SOCKET` or `$PORT` (both or neither → validation error)
- `mount` must match `^[a-z0-9][a-z0-9-]{0,63}$`, no slash
- Duplicate mounts: first (alphabetically) wins, rest are skipped with an error
- Invalid widgets are skipped and surfaced in `/admin/widgets/status` — they never crash serve

### Launch / Proxy

- Routes live under `{base-path}/widgets/<mount>/` — uses the existing base-path abstraction, not hardcoded `/chat`
- `/widgets/<mount>` (no trailing slash) redirects to `/widgets/<mount>/` so relative asset URLs work
- Processes start **lazily** on first request; a per-entry mutex prevents duplicate starts
- `$SOCKET` mode: Unix domain socket at `/tmp/term-llm-widgets/<id>.sock`; stale socket unlinked before start
- `$PORT` mode: free localhost port allocated via `net.Listen("tcp", "127.0.0.1:0")`
- Health check: polls `/` every 100ms, up to 10s timeout
- Startup env: `TERM_LLM_WIDGET_ID`, `TERM_LLM_WIDGET_MOUNT`, `TERM_LLM_WIDGET_BASE_PATH`, `BASE_PATH`, and mode-specific vars (`SOCKET`/`PORT` etc.)
- `Authorization` and `Cookie` headers are stripped before forwarding (term-llm authenticates; widget does not receive browser credentials)
- Idle timeout: 10 minutes; SIGTERM → 3s grace → SIGKILL; socket cleaned up on stop
- All widget processes stopped on `term-llm serve` shutdown

### Routes (under `--base-path`, default `/ui`)

| Path | Description |
|---|---|
| `GET {base}/widgets/` | HTML index listing all widgets and their state |
| `{base}/widgets/<mount>/` | Proxied widget (lazy-started on first hit) |
| `GET {base}/admin/widgets/status` | JSON status of all widgets + load errors |
| `POST {base}/admin/widgets/reload` | Re-scan widgets directory without restart |
| `POST {base}/admin/widgets/<mount>/stop` | Stop a specific widget process |

## Opting in

```bash
term-llm serve web --enable-widgets
term-llm serve web --enable-widgets --widgets-dir /path/to/widgets
```

Or in `config.yaml`:
```yaml
serve:
  widgets_dir: ~/.config/term-llm/widgets
```

When `--enable-widgets` is not set: no widget routes, no directory scan, no processes.

## Reload behavior

`POST {base}/admin/widgets/reload` re-runs the directory scan. Processes for removed/changed mounts are stopped. Error-state widgets are reset to `stopped` so they retry on next request. Running processes are not restarted unless their mount disappears and reappears.

## Tests run

- `go build ./...` — clean
- `go test ./internal/widgets/...` — 14 tests, all pass
- `go test ./...` — all pass (one pre-existing flaky test `TestRunAgentScriptTool_TimeoutKillsGrandchildren` unrelated to this PR)

## Intentionally omitted / follow-ups

- **CLI commands** (`term-llm widget list/status/reload/stop`): skipped in v1 as they require client-side HTTP plumbing to talk to a running server. The admin HTTP endpoints cover the same functionality. Follow-up PR.
- **Config-level idle timeout**: `idleTimeout` is a constant (10m) in v1. Can be made configurable in `serve.widgets_idle_timeout` in a follow-up.
- **WebSocket proxying**: `httputil.ReverseProxy` handles most cases; explicit WebSocket upgrade proxying can be added if needed.
- **Windows**: `$SOCKET` (Unix domain socket) mode will not work on Windows; `$PORT` mode is cross-platform.
- **Widget-level health check path**: hardcoded to `/` in v1; could be a `health` field in manifest.
