### PR TITLE
fix: improve serve timeout errors

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -61,6 +61,7 @@ var (
 	serveFilesDir               string
 	serveEnableWidgets          bool
 	serveWidgetsDir             string
+	serveResponseTimeout        time.Duration
 )
 
 var serveCmd = &cobra.Command{
@@ -138,6 +139,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveFilesDir, "files-dir", "", "Directory for serving arbitrary files (videos, PDFs, etc) at {base}/files/")
 	serveCmd.Flags().BoolVar(&serveEnableWidgets, "enable-widgets", false, "Enable local widget apps proxied under {base}/widgets/<mount>/")
 	serveCmd.Flags().StringVar(&serveWidgetsDir, "widgets-dir", "", "Directory containing widget sub-directories (default: ~/.config/term-llm/widgets)")
+	serveCmd.Flags().DurationVar(&serveResponseTimeout, "response-timeout", defaultServeRequestTimeout, "Maximum duration for API/web response runs before timing out")
 
 	AddCommonFlags(serveCmd,
 		CommonCoreFlags|CommonSearch|CommonNativeSearch|CommonMaxTurns|CommonAgent,
@@ -198,6 +200,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	if serveJobsWorkers <= 0 {
 		return fmt.Errorf("invalid --jobs-workers %d (must be > 0)", serveJobsWorkers)
+	}
+	if cmd.Flags().Changed("response-timeout") && serveResponseTimeout <= 0 {
+		return fmt.Errorf("invalid --response-timeout %s (must be > 0)", serveResponseTimeout)
 	}
 	sidebarSessions, err := parseSidebarSessionCategories(serveSidebarSessions, true)
 	if err != nil {
@@ -262,6 +267,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 		serveBasePath = cfg.Serve.BasePath
 	}
 	serveBasePath, err = normalizeBasePath(serveBasePath)
+	if err != nil {
+		return err
+	}
+
+	responseTimeout, err := resolveServeResponseTimeout(cmd.Flags().Changed("response-timeout"), serveResponseTimeout, cfg.Serve.ResponseTimeout)
 	if err != nil {
 		return err
 	}
@@ -545,6 +555,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 				writeDirs:           resolveServeWriteDirs(serveWriteDirs, cfg),
 				enableWidgets:       serveEnableWidgets,
 				widgetsDir:          serveWidgetsDir,
+				responseTimeout:     responseTimeout,
 			},
 			sessionMgr:     sessionMgr,
 			jobsV2:         jobsV2,
@@ -580,6 +591,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if modelName != "" {
 			fmt.Fprintf(cmd.ErrOrStderr(), "model: %s\n", modelName)
 		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "response timeout: %s\n", humanDuration(responseTimeout))
 	}
 
 	// Start non-web platforms concurrently.
@@ -810,6 +822,7 @@ type serveServerConfig struct {
 	writeDirs           []string // tool write-dirs (CLI + config); tool-reported files inside these are trusted sources for ensureFileServeable
 	enableWidgets       bool
 	widgetsDir          string
+	responseTimeout     time.Duration
 }
 
 // uiRoute returns the base-path with trailing slash, e.g. "/ui/" or "/chat/".
@@ -842,6 +855,33 @@ func resolveWidgetsDir(flagVal string, cfg *config.Config) (string, error) {
 		return "", fmt.Errorf("resolve widgets dir: %w", err)
 	}
 	return cfgDir + "/widgets", nil
+}
+
+func resolveServeResponseTimeout(flagSet bool, flagVal time.Duration, configVal string) (time.Duration, error) {
+	if flagSet {
+		if flagVal <= 0 {
+			return 0, fmt.Errorf("invalid --response-timeout %s (must be > 0)", flagVal)
+		}
+		return flagVal, nil
+	}
+	if strings.TrimSpace(configVal) == "" {
+		return defaultServeRequestTimeout, nil
+	}
+	timeout, err := time.ParseDuration(strings.TrimSpace(configVal))
+	if err != nil {
+		return 0, fmt.Errorf("invalid serve.response_timeout %q (use a Go duration like 30m or 1h): %w", configVal, err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("invalid serve.response_timeout %q (must be > 0)", configVal)
+	}
+	return timeout, nil
+}
+
+func (s *serveServer) responseTimeout() time.Duration {
+	if s == nil || s.cfg.responseTimeout <= 0 {
+		return defaultServeRequestTimeout
+	}
+	return s.cfg.responseTimeout
 }
 
 // resolveServeWriteDirs returns the merged effective write-dirs for the serve runtime,

--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -19,7 +19,7 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 		writeAnthropicError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(r.Context(), s.responseTimeout())
 	defer cancel()
 
 	var req anthropicMessagesRequest
@@ -152,6 +152,10 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 		s.verboseLog("✗ POST /v1/messages error: %v", err)
 		if errors.Is(err, errServeSessionBusy) {
 			writeAnthropicError(w, http.StatusConflict, "api_error", err.Error())
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeAnthropicError(w, http.StatusRequestTimeout, "timeout_error", responseRunTimeoutMessage(s.responseTimeout()))
 			return
 		}
 		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
@@ -343,22 +347,17 @@ func (s *serveServer) streamAnthropicMessages(ctx context.Context, w http.Respon
 	}
 	if err != nil {
 		s.verboseLog("✗ POST /v1/messages stream error: %v", err)
-		if errors.Is(err, errServeSessionBusy) {
-			_ = writeAnthropicSSE(w, "error", map[string]any{
-				"type": "error",
-				"error": map[string]any{
-					"type":    "api_error",
-					"message": err.Error(),
-				},
-			})
-			flusher.Flush()
-			return
+		errType := "api_error"
+		errMessage := err.Error()
+		if errors.Is(err, context.DeadlineExceeded) {
+			errType = "timeout_error"
+			errMessage = responseRunTimeoutMessage(s.responseTimeout())
 		}
 		_ = writeAnthropicSSE(w, "error", map[string]any{
 			"type": "error",
 			"error": map[string]any{
-				"type":    "api_error",
-				"message": err.Error(),
+				"type":    errType,
+				"message": errMessage,
 			},
 		})
 		flusher.Flush()

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -21,7 +21,7 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 		writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(r.Context(), s.responseTimeout())
 	defer cancel()
 
 	var req chatCompletionsRequest
@@ -131,6 +131,10 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		if errors.Is(err, errServeSessionBusy) {
 			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeOpenAIError(w, http.StatusRequestTimeout, "timeout_error", responseRunTimeoutMessage(s.responseTimeout()))
 			return
 		}
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
@@ -272,18 +276,13 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 	stopPing() // wait for keepalive goroutine before any final writes
 
 	if err != nil {
+		errType := "invalid_request_error"
+		errMessage := err.Error()
 		if errors.Is(err, errServeSessionBusy) {
-			_ = writeChatStreamChunk(w, map[string]any{
-				"id":      respID,
-				"object":  "chat.completion.chunk",
-				"created": created,
-				"model":   model,
-				"choices": []map[string]any{{"index": 0, "finish_reason": "error", "delta": map[string]any{}}},
-				"error":   map[string]any{"message": err.Error(), "type": "conflict_error"},
-			})
-			_, _ = io.WriteString(w, "data: [DONE]\n\n")
-			flusher.Flush()
-			return
+			errType = "conflict_error"
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			errType = "timeout_error"
+			errMessage = responseRunTimeoutMessage(s.responseTimeout())
 		}
 		_ = writeChatStreamChunk(w, map[string]any{
 			"id":      respID,
@@ -291,6 +290,7 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 			"created": created,
 			"model":   model,
 			"choices": []map[string]any{{"index": 0, "finish_reason": "error", "delta": map[string]any{}}},
+			"error":   map[string]any{"message": errMessage, "type": errType},
 		})
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 		flusher.Flush()

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -22,7 +22,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(r.Context(), s.responseTimeout())
 	defer cancel()
 
 	var req responsesCreateRequest
@@ -278,6 +278,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, errServeSessionBusy) {
 			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeOpenAIError(w, http.StatusRequestTimeout, "timeout_error", responseRunTimeoutMessage(s.responseTimeout()))
 			return
 		}
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -564,8 +564,30 @@ const (
 	defaultResponseRunRetention        = 5 * time.Minute
 	defaultResponseRunReplayLimit      = 2048
 	defaultResponseRunSubscriberBuffer = 256
-	defaultResponseRunTimeout          = 15 * time.Minute
+	defaultServeRequestTimeout         = 30 * time.Minute
 )
+
+func responseRunTimeoutMessage(timeout time.Duration) string {
+	return fmt.Sprintf("Response run timed out after %s. Continue to resume from saved progress, or move long-running investigations to a background job.", humanDuration(timeout))
+}
+
+func humanDuration(d time.Duration) string {
+	if d%time.Hour == 0 {
+		hours := int(d / time.Hour)
+		if hours == 1 {
+			return "1 hour"
+		}
+		return fmt.Sprintf("%d hours", hours)
+	}
+	if d%time.Minute == 0 {
+		minutes := int(d / time.Minute)
+		if minutes == 1 {
+			return "1 minute"
+		}
+		return fmt.Sprintf("%d minutes", minutes)
+	}
+	return d.String()
+}
 
 func newServeResponseRunManager() *responseRunManager {
 	return newServeResponseRunManagerWithRetention(defaultResponseRunRetention)
@@ -1174,8 +1196,8 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 	//  - Clients reconnect via GET /v1/responses/{id}/events?after=N and replay
 	//    events they missed, which only works if the run kept going.
 	//  - Explicit cancellation is available via POST /v1/responses/{id}/cancel.
-	//  - defaultResponseRunTimeout bounds orphan-run lifetime.
-	runCtx, cancel := context.WithTimeout(context.Background(), defaultResponseRunTimeout)
+	//  - serve.response_timeout bounds orphan-run lifetime.
+	runCtx, cancel := context.WithTimeout(context.Background(), s.responseTimeout())
 	run := newResponseRun(respID, sessionID, options.previousResponseID, model, created, cancel)
 	if err := mgr.create(run); err != nil {
 		cancel()
@@ -1246,7 +1268,7 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 			return s.appendResponseRunEvent(runtime, run, streamState, ev)
 		})
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if errors.Is(err, context.Canceled) {
 				cancelled, cancelErr := run.finishCancelled(map[string]any{
 					"response": map[string]any{
 						"id":      respID,
@@ -1267,31 +1289,34 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 				}
 			}
 			errType := "invalid_request_error"
-			if errors.Is(err, errServeSessionBusy) {
+			errMessage := err.Error()
+			if errors.Is(err, context.DeadlineExceeded) {
+				errType = "timeout_error"
+				errMessage = responseRunTimeoutMessage(s.responseTimeout())
+			} else if errors.Is(err, errServeSessionBusy) {
 				errType = "conflict_error"
 			}
 			hadSubscribers, failErr := run.fail(map[string]any{
 				"error": map[string]any{
-					"message": err.Error(),
+					"message": errMessage,
 					"type":    errType,
 				},
-			}, errType, err.Error())
+			}, errType, errMessage)
 			if options.uiSession {
 				switch {
 				case hadSubscribers:
 					runtime.clearLastUIRunError()
-				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+				case errors.Is(err, context.Canceled):
 					runtime.clearLastUIRunError()
 				default:
-					runtime.setLastUIRunError(err.Error())
+					runtime.setLastUIRunError(errMessage)
 				}
 			}
 			if failErr != nil {
 				log.Printf("response run %s failed to append terminal event: %v", respID, failErr)
 			}
-			if failErr != nil && options.uiSession &&
-				!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-				runtime.setLastUIRunError(err.Error())
+			if failErr != nil && options.uiSession && !errors.Is(err, context.Canceled) {
+				runtime.setLastUIRunError(errMessage)
 			}
 			return
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -6610,6 +6610,139 @@ func TestHandleResponseByID_CancelStopsActiveToolRun(t *testing.T) {
 	}
 }
 
+func TestResolveServeResponseTimeout(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagSet   bool
+		flagVal   time.Duration
+		configVal string
+		want      time.Duration
+		wantErr   string
+	}{
+		{
+			name: "default",
+			want: defaultServeRequestTimeout,
+		},
+		{
+			name:    "flag wins",
+			flagSet: true,
+			flagVal: 90 * time.Minute,
+			want:    90 * time.Minute,
+		},
+		{
+			name:      "config",
+			configVal: "1h15m",
+			want:      75 * time.Minute,
+		},
+		{
+			name:      "invalid config",
+			configVal: "eventually",
+			wantErr:   "invalid serve.response_timeout",
+		},
+		{
+			name:      "non-positive config",
+			configVal: "0s",
+			wantErr:   "must be > 0",
+		},
+		{
+			name:    "non-positive flag",
+			flagSet: true,
+			flagVal: 0,
+			wantErr: "invalid --response-timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveServeResponseTimeout(tt.flagSet, tt.flagVal, tt.configVal)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("timeout = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartResponseRunDeadlineExceededFailsWithHelpfulTimeoutMessage(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddError(context.DeadlineExceeded)
+	engine := llm.NewEngine(provider, nil)
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  "mock",
+		engine:       engine,
+		defaultModel: "mock-model",
+	}
+	rt.Touch()
+
+	srv := &serveServer{
+		cfg: serveServerConfig{
+			responseTimeout: 45 * time.Minute,
+		},
+		responseRuns: newServeResponseRunManager(),
+	}
+	defer srv.responseRuns.Close()
+
+	run, err := srv.startResponseRun(rt, true, false, []llm.Message{
+		llm.UserText("take too long"),
+	}, llm.Request{SessionID: "sess_timeout"}, "sess_timeout", startResponseRunOptions{})
+	if err != nil {
+		t.Fatalf("startResponseRun failed: %v", err)
+	}
+
+	waitForServeCondition(t, time.Second, func() bool {
+		snapshot := run.snapshot()
+		status, _ := snapshot["status"].(string)
+		return status == "failed"
+	}, "deadline-exceeded response run to fail")
+
+	snapshot := run.snapshot()
+	if status, _ := snapshot["status"].(string); status != "failed" {
+		t.Fatalf("run status = %q, want failed: %#v", status, snapshot)
+	}
+	errPayload, _ := snapshot["error"].(map[string]any)
+	if got := errPayload["type"]; got != "timeout_error" {
+		t.Fatalf("error type = %v, want timeout_error: %#v", got, snapshot)
+	}
+	message, _ := errPayload["message"].(string)
+	if !strings.Contains(message, "timed out after 45 minutes") {
+		t.Fatalf("timeout message = %q, want configured 45 minute explanation", message)
+	}
+	if strings.Contains(message, "context deadline exceeded") {
+		t.Fatalf("timeout message leaked raw context error: %q", message)
+	}
+
+	subscription := run.subscribe(0)
+	if subscription.ch != nil {
+		t.Fatal("terminal failed run should replay without live subscription channel")
+	}
+	var sawFailed bool
+	for _, event := range subscription.replay {
+		if event.Event != "response.failed" {
+			continue
+		}
+		sawFailed = true
+		var payload map[string]any
+		if err := json.Unmarshal(event.Data, &payload); err != nil {
+			t.Fatalf("unmarshal response.failed payload: %v", err)
+		}
+		eventErr, _ := payload["error"].(map[string]any)
+		if got := eventErr["message"]; got != message {
+			t.Fatalf("response.failed message = %v, want %q", got, message)
+		}
+	}
+	if !sawFailed {
+		t.Fatal("deadline-exceeded run replay missing response.failed terminal event")
+	}
+}
+
 func TestHandleResponseByID_CancelStopsShellToolRun(t *testing.T) {
 	provider := llm.NewMockProvider("mock")
 	provider.AddToolCall("call_1", tools.ShellToolName, map[string]any{

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -103,6 +103,7 @@ Relevant options include:
 - `--mcp`
 - `--tools`, `--read-dir`, `--write-dir`, `--shell-allow`
 - `--base-path`
+- `--response-timeout` (defaults to `30m`; also configurable as `serve.response_timeout` with Go durations like `45m` or `1h`)
 - `--cors-origin`
 - `--webrtc`, `--webrtc-signaling-url`, `--webrtc-token` (see [WebRTC direct routing](/guides/webrtc-direct-routing/))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,12 +147,13 @@ type Config struct {
 
 // ServeConfig holds configuration for the serve command platforms.
 type ServeConfig struct {
-	Platforms  []string            `mapstructure:"platforms" yaml:"platforms,omitempty"`
-	BasePath   string              `mapstructure:"base_path" yaml:"base_path,omitempty"`
-	FilesDir   string              `mapstructure:"files_dir" yaml:"files_dir,omitempty"`
-	WidgetsDir string              `mapstructure:"widgets_dir" yaml:"widgets_dir,omitempty"`
-	Telegram   TelegramServeConfig `mapstructure:"telegram" yaml:"telegram,omitempty"`
-	WebPush    WebPushConfig       `mapstructure:"web_push" yaml:"web_push,omitempty"`
+	Platforms       []string            `mapstructure:"platforms" yaml:"platforms,omitempty"`
+	BasePath        string              `mapstructure:"base_path" yaml:"base_path,omitempty"`
+	FilesDir        string              `mapstructure:"files_dir" yaml:"files_dir,omitempty"`
+	WidgetsDir      string              `mapstructure:"widgets_dir" yaml:"widgets_dir,omitempty"`
+	ResponseTimeout string              `mapstructure:"response_timeout" yaml:"response_timeout,omitempty"` // Go duration string, e.g. "30m" or "1h"
+	Telegram        TelegramServeConfig `mapstructure:"telegram" yaml:"telegram,omitempty"`
+	WebPush         WebPushConfig       `mapstructure:"web_push" yaml:"web_push,omitempty"`
 }
 
 // WebPushConfig holds VAPID keys for Web Push notifications.
@@ -1478,6 +1479,24 @@ var KnownKeys = map[string]bool{
 	// AGENTS.md
 	"agents_md.enabled": true,
 
+	// Serve
+	"serve":                            true,
+	"serve.platforms":                  true,
+	"serve.base_path":                  true,
+	"serve.files_dir":                  true,
+	"serve.widgets_dir":                true,
+	"serve.response_timeout":           true,
+	"serve.telegram":                   true,
+	"serve.telegram.token":             true,
+	"serve.telegram.allowed_user_ids":  true,
+	"serve.telegram.allowed_usernames": true,
+	"serve.telegram.idle_timeout":      true,
+	"serve.telegram.interrupt_timeout": true,
+	"serve.web_push":                   true,
+	"serve.web_push.vapid_public_key":  true,
+	"serve.web_push.vapid_private_key": true,
+	"serve.web_push.subject":           true,
+
 	// Auto-compaction
 	"auto_compact": true,
 }
@@ -1593,6 +1612,7 @@ func GetDefaults() map[string]any {
 		"skills.always_enabled":           []string{},
 		"skills.never_auto":               []string{},
 		"agents_md.enabled":               true,
+		"serve.response_timeout":          "30m",
 		"auto_compact":                    true,
 	}
 }


### PR DESCRIPTION
## What

- Increase serve response/request timeout from 15 minutes to 30 minutes so attended Jarvis/web runs have more room before being cancelled.
- Replace raw `context deadline exceeded` failures with a helpful timeout error:
  - HTTP 408
  - `timeout_error`
  - message says the response run timed out after 30 minutes and suggests continuing or moving long investigations to a background job.
- Apply the same nicer timeout message to chat completions, responses, Anthropic messages, and response-run event streams.
- Add regression coverage for the deadline-exceeded path.

## Why

Sam hit a web UI failure where a long tool-heavy run ended with only:

`context deadline exceeded`

That is technically true and emotionally useless. The UI should explain what happened, how long the limit was, and what the user can do next. The requested limit was 30 minutes.

## Verification

```sh
go test ./cmd -run 'TestStartResponseRunDeadlineExceededFailsWithHelpfulTimeoutMessage|TestResponseRunTimeoutMessage|TestHandleChatCompletions|TestHandleResponses'
go test ./cmd
go build ./...
```
