### PR TITLE
docs: remove pointless em dashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@
 - Add permission checks in `internal/tools/permissions.go`
 
 ## Web UI (internal/serveui/static/)
-- `markdown-setup.js` — **single source of truth for marked.js configuration**. Both the browser (loaded as a `<script>` before `app-core.js`) and the Node.js test suite (`require()`) use this file. Do not put `marked.use(...)` calls anywhere else.
-- `markdown_test.js` — Node.js test runner for markdown rendering rules; run via `TestMarkdownSetupJS` in `embed_test.go`. Add cases here when changing markdown behaviour.
+- `markdown-setup.js`: **single source of truth for marked.js configuration**. Both the browser (loaded as a `<script>` before `app-core.js`) and the Node.js test suite (`require()`) use this file. Do not put `marked.use(...)` calls anywhere else.
+- `markdown_test.js`: Node.js test runner for markdown rendering rules; run via `TestMarkdownSetupJS` in `embed_test.go`. Add cases here when changing markdown behaviour.
 - When adding a new first-party JS file, wire it into: `index.html` (script tag), `sw.js` (SHELL_ASSETS), `embed.go` (`RenderIndexHTML` and `RenderServiceWorker` replacement tables).
 - JS tests run automatically as part of `go test ./...` if `node` is in PATH.
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ command: ["npm", "run", "dev", "--", "--port", "$PORT"]
 **Required fields:** `title`, `command`
 
 **`command`** must contain exactly one of:
-- `$SOCKET` — term-llm creates a Unix domain socket and passes the path in argv and as env vars `TERM_LLM_WIDGET_SOCKET` / `SOCKET`
-- `$PORT` — term-llm allocates a free localhost port and passes it as `TERM_LLM_WIDGET_PORT` / `PORT`
+- `$SOCKET`: term-llm creates a Unix domain socket and passes the path in argv and as env vars `TERM_LLM_WIDGET_SOCKET` / `SOCKET`
+- `$PORT`: term-llm allocates a free localhost port and passes it as `TERM_LLM_WIDGET_PORT` / `PORT`
 
 The widget process is started lazily on first request and stopped after 10 minutes of idle time.
 

--- a/docs-site/content/architecture/overview.md
+++ b/docs-site/content/architecture/overview.md
@@ -47,7 +47,7 @@ That gives term-llm a way to accumulate reusable context without pretending ever
 
 Built-in tools handle common filesystem and shell tasks. MCP servers extend that with external capabilities such as browser automation, GitHub, or custom APIs.
 
-In practice that means the model is not just generating text — it can interrogate files, run commands, call external tools, and then keep going.
+In practice that means the model is not just generating text. It can interrogate files, run commands, call external tools, and then keep going.
 
 ## Jobs turn it into a runtime, not just a CLI
 

--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -215,7 +215,7 @@ providers:
     model: claude-sonnet-4-6-thinking
 ```
 
-**Application inference profiles** — use `model_map` to alias friendly model names to Bedrock ARNs or model IDs. The `-thinking` and `-1m` suffixes work with mapped names:
+**Application inference profiles**: use `model_map` to alias friendly model names to Bedrock ARNs or model IDs. The `-thinking` and `-1m` suffixes work with mapped names:
 
 ```yaml
 providers:
@@ -232,7 +232,7 @@ providers:
 
 With this config, `--provider bedrock:claude-opus-4-6-1m-thinking` strips the suffixes, resolves `claude-opus-4-6` through `model_map` to the ARN, and enables adaptive thinking + 1M context.
 
-**Available models** (same as direct Anthropic — translated to Bedrock IDs automatically):
+**Available models** (same as direct Anthropic, translated to Bedrock IDs automatically):
 
 | Model | Suffixes | Description |
 |-------|----------|-------------|
@@ -240,11 +240,11 @@ With this config, `--provider bedrock:claude-opus-4-6-1m-thinking` strips the su
 | `claude-opus-4-6` | `-thinking`, `-1m` | Latest Opus |
 | `claude-haiku-4-5` | `-thinking` | Fast, lightweight |
 
-The geographic prefix (`us.`, `eu.`, `ap.`) is derived from your configured region — `eu-west-1` produces `eu.anthropic.*` IDs, etc. This ensures data residency matches your region.
+The geographic prefix (`us.`, `eu.`, `ap.`) is derived from your configured region. For example, `eu-west-1` produces `eu.anthropic.*` IDs, etc. This ensures data residency matches your region.
 
-You can also pass raw Bedrock model IDs directly (e.g., `us.anthropic.claude-sonnet-4-6` or full ARNs) — these bypass the translation layer.
+You can also pass raw Bedrock model IDs directly (e.g., `us.anthropic.claude-sonnet-4-6` or full ARNs). These bypass the translation layer.
 
-**Features:** full parity with the direct Anthropic provider — streaming, tool use, extended thinking, 1M context, images, prompt caching, web search/fetch all work through Bedrock.
+**Features:** full parity with the direct Anthropic provider: streaming, tool use, extended thinking, 1M context, images, prompt caching, web search/fetch all work through Bedrock.
 
 | Config field | Description |
 |---|---|

--- a/docs-site/content/guides/agent-containers.md
+++ b/docs-site/content/guides/agent-containers.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent Containers"
 weight: 15
-description: "Run independent term-llm agents in Docker — one container per agent, fully isolated, no image rebuild needed."
+description: "Run independent term-llm agents in Docker: one container per agent, fully isolated, no image rebuild needed."
 kicker: "Deploy agents"
 ---
 
@@ -61,10 +61,10 @@ The `.env` file also has a pre-generated `WEB_TOKEN` for authenticating the web 
 
 The scaffold separates personality from operations:
 
-- **`soul.md`** — voice, values, and boundaries. This is who the agent *is*. Edit it to change tone, principles, or guardrails.
-- **`system.md`** — operational context. Who the user is, what tools are available, domain-specific instructions. Edit it to change what the agent *knows about its environment*.
+- **`soul.md`**: voice, values, and boundaries. This is who the agent *is*. Edit it to change tone, principles, or guardrails.
+- **`system.md`**: operational context. Who the user is, what tools are available, domain-specific instructions. Edit it to change what the agent *knows about its environment*.
 
-Both files are bind-mounted into the container as seed files. On first boot they are copied into the agent's config directory on the state volume. After that, the container owns them — your local copies are the seed, not the live version.
+Both files are bind-mounted into the container as seed files. On first boot they are copied into the agent's config directory on the state volume. After that, the container owns them. Your local copies are the seed, not the live version.
 
 ### Agent settings
 
@@ -110,7 +110,7 @@ On first boot, the entrypoint:
 2. Runs `/seed/init.sh` which installs runit services (web UI, job scheduler, job bootstrapper)
 3. Starts runit as PID 1
 
-After the first boot, the state volume owns all agent config. Your local `agents/` directory remains the seed — edit it and delete the volume to re-seed, or edit the live files inside the container directly.
+After the first boot, the state volume owns all agent config. Your local `agents/` directory remains the seed. Edit it and delete the volume to re-seed, or edit the live files inside the container directly.
 
 The built-in `term-llm contain new` agent image keeps PID 1 and runit supervision as root so services can be linked under `/etc`, but the Web UI, jobs service, bootstrap jobs, interactive shells, and normal agent work run as the non-root Linux user `agent` with home `/home/agent`. Use explicit passwordless `sudo` inside the container for package maintenance or other root-only operations.
 
@@ -131,7 +131,7 @@ On first boot, the `bootstrap-jobs` service waits for the jobs API, then creates
 | `memory-gc` | Daily at 4am UTC | Garbage-collects stale or duplicate memory fragments |
 | `system-upgrade` | Daily at 5am | Keeps the container's distro packages current (`pacman` on Arch, `dnf` on Fedora) |
 
-These jobs are yours after creation — edit or delete them with `term-llm jobs list` and `term-llm jobs update`.
+These jobs are yours after creation. Edit or delete them with `term-llm jobs list` and `term-llm jobs update`.
 
 All services are managed by runit. Check status:
 
@@ -169,7 +169,7 @@ cd myagent
 docker compose up -d --build
 ```
 
-The state volume persists across rebuilds — agent config, memory, and session history are preserved. The `init.sh` boot hook re-installs runit services on every boot, so new services added to your `services/` directory will be picked up automatically.
+The state volume persists across rebuilds. Agent config, memory, and session history are preserved. The `init.sh` boot hook re-installs runit services on every boot, so new services added to your `services/` directory will be picked up automatically.
 
 ## Transcript access
 

--- a/docs-site/content/guides/agents.md
+++ b/docs-site/content/guides/agents.md
@@ -135,7 +135,7 @@ Supported platform keys:
 | `chat_developer_message` | CLI chat | `term-llm chat` |
 | `jobs_developer_message` | Scheduled/background jobs | `term-llm serve --platform jobs` |
 
-Messages are injected as `developer` role messages before the first user turn. If no message is configured for the active platform, nothing is injected. Each key is optional — define only the platforms you need.
+Messages are injected as `developer` role messages before the first user turn. If no message is configured for the active platform, nothing is injected. Each key is optional. Define only the platforms you need.
 
 ## System prompt file includes
 

--- a/docs-site/content/guides/autonomous-loops.md
+++ b/docs-site/content/guides/autonomous-loops.md
@@ -8,7 +8,7 @@ next:
   label: Job runner
   url: /guides/job-runner/
 ---
-Run an agent in a loop until a completion condition is met. State persists in the filesystem—the agent reads/writes files to track progress, and each iteration starts with fresh context.
+Run an agent in a loop until a completion condition is met. State persists in the filesystem. The agent reads/writes files to track progress, and each iteration starts with fresh context.
 
 ```bash
 # Run until tests pass

--- a/docs-site/content/guides/mcp-servers.md
+++ b/docs-site/content/guides/mcp-servers.md
@@ -9,7 +9,7 @@ next:
   label: Agents
   url: /guides/agents/
 ---
-[MCP (Model Context Protocol)](https://modelcontextprotocol.io) lets you extend term-llm with external tools—browser automation, database access, API integrations, and more.
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io) lets you extend term-llm with external tools: browser automation, database access, API integrations, and more.
 
 ```bash
 # Add from registry
@@ -133,6 +133,6 @@ HTTP transport uses [Streamable HTTP](https://modelcontextprotocol.io/specificat
 
 ### Serving tools via MCP
 
-`term-llm serve mcp` runs an MCP server over HTTP, exposing term-llm's tools to any MCP client. This is the inverse of the client workflows above — instead of consuming external tools, you are publishing your local tools for remote use.
+`term-llm serve mcp` runs an MCP server over HTTP, exposing term-llm's tools to any MCP client. This is the inverse of the client workflows above. Instead of consuming external tools, you are publishing your local tools for remote use.
 
 See the dedicated [Serving tools via MCP](/guides/serve-mcp/) guide for full details, flags, and examples.

--- a/docs-site/content/guides/music-generation.md
+++ b/docs-site/content/guides/music-generation.md
@@ -27,8 +27,8 @@ echo "cinematic whoosh" | term-llm music -o - > whoosh.mp3
 
 `term-llm music` supports:
 
-- `venice` — Venice async audio queue for music, songs, sound effects, and Venice-hosted TTS audio models
-- `elevenlabs` — ElevenLabs `/v1/music`, `/v1/music/stream`, and `/v1/music/detailed`
+- `venice`: Venice async audio queue for music, songs, sound effects, and Venice-hosted TTS audio models
+- `elevenlabs`: ElevenLabs `/v1/music`, `/v1/music/stream`, and `/v1/music/detailed`
 
 ### Music flags
 

--- a/docs-site/content/guides/serve-mcp.md
+++ b/docs-site/content/guides/serve-mcp.md
@@ -33,7 +33,7 @@ auth token: abc123...
 tools: edit_file, glob, grep, read_file, shell, web_search, write_file, ...
 ```
 
-When binding to a wildcard address (`0.0.0.0` or `::`), the printed URL uses `127.0.0.1` for convenience — remote clients should use the machine's actual hostname or IP.
+When binding to a wildcard address (`0.0.0.0` or `::`), the printed URL uses `127.0.0.1` for convenience. Remote clients should use the machine's actual hostname or IP.
 
 ## Connecting a client
 
@@ -55,7 +55,7 @@ term-llm mcp add http://localhost:8080/mcp
 
 ## Available tools
 
-The `--tools` flag is **required**. Pass a comma-separated list of tool names, or `all`. Only the tools listed below are accepted — internal tools like `ask_user`, `spawn_agent`, and `view_image` are not available in MCP server mode.
+The `--tools` flag is **required**. Pass a comma-separated list of tool names, or `all`. Only the tools listed below are accepted. Internal tools like `ask_user`, `spawn_agent`, and `view_image` are not available in MCP server mode.
 
 ### File & search
 
@@ -95,7 +95,7 @@ Tools whose backing provider isn't configured (e.g. `web_search` without a searc
 |------|---------|-------------|
 | `--tools` | *(required)* | Comma-separated tool names or `all` |
 | `--edit-format` | `edit_file` | Edit tool flavor: `edit_file` (find/replace) or `diff` (unified diff) |
-| `--host` | `127.0.0.1` | Bind address — use `0.0.0.0` for remote access |
+| `--host` | `127.0.0.1` | Bind address; use `0.0.0.0` for remote access |
 | `--port` | `8080` | Bind port |
 | `--token` | *(auto-generated)* | Bearer token for auth |
 | `--read-dir` | *(none)* | Allowed read directories (repeatable) |
@@ -119,9 +119,9 @@ term-llm serve mcp --tools all --edit-format diff
 ## Security
 
 - **Auth**: Bearer token authentication on every request (constant-time comparison). Token is auto-generated if not provided.
-- **Localhost by default**: Binds to `127.0.0.1` — you must explicitly pass `--host 0.0.0.0` to accept remote connections.
+- **Localhost by default**: Binds to `127.0.0.1`. You must explicitly pass `--host 0.0.0.0` to accept remote connections.
 - **Transport security**: The server uses plain HTTP. When exposing beyond localhost, use an SSH tunnel, VPN, or TLS-terminating reverse proxy to protect traffic in transit.
-- **Permissions**: `--read-dir`, `--write-dir`, and `--shell-allow` restrict what the tools can access. Without these flags (and without `--yolo`), tools will prompt for approval — but since the server is non-interactive, you should pre-configure permissions via flags.
+- **Permissions**: `--read-dir`, `--write-dir`, and `--shell-allow` restrict what the tools can access. Without these flags (and without `--yolo`), tools will prompt for approval. Since the server is non-interactive, you should pre-configure permissions via flags.
 - **No `ask_user`**: The server runs non-interactively. Use `--yolo` or permission flags to pre-authorize operations.
 
 ## Examples
@@ -137,7 +137,7 @@ term-llm serve mcp --tools all \
   --write-dir ~/project \
   --shell-allow "go *" --shell-allow "git *" --shell-allow "make *"
 
-# CI/container use — auto-approve everything
+# CI/container use: auto-approve everything
 term-llm serve mcp --tools all --yolo
 
 # Custom port and token

--- a/docs-site/content/guides/skills.md
+++ b/docs-site/content/guides/skills.md
@@ -9,7 +9,7 @@ next:
   label: Built-in tools
   url: /reference/built-in-tools/
 ---
-Skills are portable instruction bundles that provide specialized knowledge for specific tasks. Unlike agents, skills don't change the provider or model—they just add context.
+Skills are portable instruction bundles that provide specialized knowledge for specific tasks. Unlike agents, skills don't change the provider or model. They just add context.
 
 ### Using Skills
 
@@ -66,7 +66,7 @@ skills:
   enabled: false
 ```
 
-The `--skills` flag on any command implicitly enables the system for that invocation, so `term-llm ask --skills git "..."` works even when skills are disabled in config. Agents can also enable skills via their `skills` field — all built-in agents set `skills: "all"`, so skills are active whenever you use a built-in agent.
+The `--skills` flag on any command implicitly enables the system for that invocation, so `term-llm ask --skills git "..."` works even when skills are disabled in config. Agents can also enable skills via their `skills` field. All built-in agents set `skills: "all"`, so skills are active whenever you use a built-in agent.
 
 Full configuration reference:
 
@@ -113,14 +113,14 @@ When `skills.enabled` is `true`, this happens at startup:
 2. Skills in `never_auto` are excluded from the metadata list
 3. The remaining skills are truncated to fit `max_visible_skills` and `metadata_budget_tokens` (skills in `always_enabled` are never truncated)
 4. An `<available_skills>` XML block is injected into the system prompt with skill names and descriptions
-5. The `activate_skill` tool is registered — when the model calls it, the full skill body is loaded and returned
+5. The `activate_skill` tool is registered. When the model calls it, the full skill body is loaded and returned
 6. If there are more skills than shown, the `search_skills` tool is also registered and a hint is added to the system prompt telling the model to use it
 
-When `auto_invoke` is `false`, the `<available_skills>` block is still injected but the model won't call `activate_skill` on its own — it only fires when you pass `--skills name`.
+When `auto_invoke` is `false`, the `<available_skills>` block is still injected but the model won't call `activate_skill` on its own. It only fires when you pass `--skills name`.
 
 ### Skill Tools
 
-Skills can declare script-backed tools in their frontmatter. When the skill is activated via `activate_skill`, those tools are dynamically registered with the engine—the LLM can then call them directly, with no hardcoded paths anywhere.
+Skills can declare script-backed tools in their frontmatter. When the skill is activated via `activate_skill`, those tools are dynamically registered with the engine. The LLM can then call them directly, with no hardcoded paths anywhere.
 
 ```markdown
 ---
@@ -161,7 +161,7 @@ tools:
 
 # Google Maps Skill
 
-API key is embedded in the scripts—no need to handle it here.
+API key is embedded in the scripts. No need to handle it here.
 ...
 ```
 
@@ -176,7 +176,7 @@ MODE=$(echo "$INPUT" | jq -r '.mode // "DRIVE"')
 # ... call the API
 ```
 
-This is the recommended pattern for skills that need API keys or other secrets—the key lives only in the script, never in the SKILL.md body that gets injected into the LLM context.
+This is the recommended pattern for skills that need API keys or other secrets. The key lives only in the script, never in the SKILL.md body that gets injected into the LLM context.
 
 **Field reference** (same as agent custom tools):
 
@@ -189,4 +189,4 @@ This is the recommended pattern for skills that need API keys or other secrets�
 | `timeout_seconds` | | Execution timeout (default 30, max 300) |
 | `env` | | Extra environment variables when running the script |
 
-Scripts run with `TERM_LLM_AGENT_DIR` set to the skill's directory and `TERM_LLM_TOOL_NAME` set to the tool name. Symlinks are resolved and containment-checked—scripts cannot escape the skill directory.
+Scripts run with `TERM_LLM_AGENT_DIR` set to the skill's directory and `TERM_LLM_TOOL_NAME` set to the tool name. Symlinks are resolved and containment-checked. Scripts cannot escape the skill directory.

--- a/docs-site/content/guides/telegram-bot.md
+++ b/docs-site/content/guides/telegram-bot.md
@@ -17,7 +17,7 @@ A Telegram bot that runs your agent. You send a message from your phone or deskt
 
 1. Open Telegram and start a chat with [@BotFather](https://t.me/BotFather)
 2. Send `/newbot` and follow the prompts (name + username)
-3. Copy the token BotFather gives you — it looks like `123456789:ABCdef...`
+3. Copy the token BotFather gives you. It looks like `123456789:ABCdef...`
 
 ## Step 2: Configure the token
 
@@ -123,6 +123,6 @@ serve:
 
 ## Related pages
 
-- [Notifications](/guides/notifications/) — send one-off Telegram messages via `term-llm notify`
-- [Web UI and API](/guides/web-ui-and-api/) — run the browser UI alongside the bot
-- [Agents](/guides/agents/) — configure which agent handles bot conversations
+- [Notifications](/guides/notifications/): send one-off Telegram messages via `term-llm notify`
+- [Web UI and API](/guides/web-ui-and-api/): run the browser UI alongside the bot
+- [Agents](/guides/agents/): configure which agent handles bot conversations

--- a/docs-site/content/guides/text-embeddings.md
+++ b/docs-site/content/guides/text-embeddings.md
@@ -53,7 +53,7 @@ term-llm embed "query text" -f corpus.txt
 term-llm embed "hello"
 # → {"model": "gemini-embedding-001", "dimensions": 3072, "embeddings": [...]}
 
-# Bare JSON array(s) — one per input, for piping
+# Bare JSON array(s), one per input, for piping
 term-llm embed "hello" --format array
 # → [0.0023, -0.0094, 0.0156, ...]
 
@@ -114,7 +114,7 @@ term-llm embed -f doc.txt --task-type RETRIEVAL_DOCUMENT -p gemini
 
 Embedding providers use their own credentials, separate from text and image providers. The default provider is auto-detected from your LLM provider (Gemini users → Gemini, OpenAI users → OpenAI, Anthropic users → Voyage if configured, otherwise Gemini).
 
-**Jina AI** is a great choice for getting started — sign up at [jina.ai/embeddings](https://jina.ai/embeddings/) for a free API key with 10M tokens, no credit card required.
+**Jina AI** is a great choice for getting started. Sign up at [jina.ai/embeddings](https://jina.ai/embeddings/) for a free API key with 10M tokens, no credit card required.
 
 **Voyage AI** is Anthropic's recommended embedding partner (acquired by MongoDB, Feb 2025). The API remains fully available.
 

--- a/docs-site/content/guides/usage.md
+++ b/docs-site/content/guides/usage.md
@@ -168,7 +168,7 @@ term-llm video "astronaut on mars" --quote-only
 ### JSON event stream (`ask --json`)
 
 `term-llm ask --json` emits a newline-delimited JSON (JSONL) event stream on
-stdout — one event per line — for scripting and automation. It implies `--text`
+stdout, one event per line, for scripting and automation. It implies `--text`
 (no rich terminal rendering) and is incompatible with `--debug-raw`. Human
 progress and warnings stay on stderr.
 
@@ -183,7 +183,7 @@ Event types, in typical order:
 | Type | Payload |
 |------|---------|
 | `session.started` | `session_id`, `provider`, `model`, `agent`, `tools`, `mcp`, `yolo`, `search`, `resuming` |
-| `text.delta` | `text` — one chunk of streamed response |
+| `text.delta` | `text`, one chunk of streamed response |
 | `tool.started` | `call_id`, `name`, `info`, `args` (raw JSON or `null`) |
 | `tool.completed` | `call_id`, `name`, `info`, `success` |
 | `usage` | `input_tokens`, `output_tokens`, `cached_input_tokens`, `cache_write_tokens` |

--- a/docs-site/content/guides/webrtc-direct-routing.md
+++ b/docs-site/content/guides/webrtc-direct-routing.md
@@ -87,8 +87,8 @@ WebRTC direct routing does not weaken the existing auth model:
 
 The signaling server needs to implement two endpoints:
 
-1. **`POST /session`** — creates a session and returns `{ "session_id": "..." }` along with optional STUN/TURN credentials.
-2. **`POST /signal`** and **`GET /signal`** — exchange SDP offers and answers keyed by session ID.
+1. **`POST /session`**: creates a session and returns `{ "session_id": "..." }` along with optional STUN/TURN credentials.
+2. **`POST /signal`** and **`GET /signal`**: exchange SDP offers and answers keyed by session ID.
 
 The browser creates a WebRTC offer, posts it via the signaling server. term-llm polls for offers, generates an answer, and posts it back. Once both sides have each other's SDP (which includes ICE candidates), they establish a direct UDP connection. After that, the signaling server is no longer involved.
 
@@ -114,16 +114,16 @@ This logs the full connection lifecycle with timestamps:
 [webrtc] +6217ms answer received
 [webrtc] +6218ms ICE state=checking
 [webrtc] +6224ms ICE state=connected
-[webrtc] +6243ms data channel open — fetch patched
+[webrtc] +6243ms data channel open; fetch patched
 [webrtc] +9904ms → GET /chat/v1/sessions/abc123/state (0b)
 [webrtc] +9922ms ← 200 GET /chat/v1/sessions/abc123/state (512b, 17ms)
 ```
 
 Key things to look for:
 
-- **ICE candidates** — `host` means a local interface, `srflx` is a STUN-discovered public address (direct), `relay` is a TURN relay. Direct connections use host or srflx candidates.
-- **Signaling timing** — the `(Nms)` after session creation and offer sent shows how long the signaling server took. High values suggest network latency to the signaling server.
-- **Per-request latency** — each `←` line shows status, response size, and round-trip time. Compare against the HTTPS path to confirm WebRTC is faster.
+- **ICE candidates**: `host` means a local interface, `srflx` is a STUN-discovered public address (direct), `relay` is a TURN relay. Direct connections use host or srflx candidates.
+- **Signaling timing**: the `(Nms)` after session creation and offer sent shows how long the signaling server took. High values suggest network latency to the signaling server.
+- **Per-request latency**: each `←` line shows status, response size, and round-trip time. Compare against the HTTPS path to confirm WebRTC is faster.
 
 You can also set `window.__WEBRTC_DIAGNOSTICS__ = true` in the browser console before page load for the same effect.
 
@@ -141,7 +141,7 @@ This sets `iceTransportPolicy=relay` on the RTCPeerConnection. Only relay (TURN)
 - Verifying your TURN server is working
 - Testing the fallback path without leaving your LAN
 
-With diagnostics enabled, you'll see only `relay` candidates gathered — no `host` or `srflx`.
+With diagnostics enabled, you'll see only `relay` candidates gathered, with no `host` or `srflx`.
 
 ### Server-side logging
 
@@ -158,14 +158,14 @@ If connections fail silently, check these logs for DTLS handshake errors or SCTP
 
 ## Troubleshooting
 
-**No lightning bolt in the UI** — WebRTC negotiation failed silently. Check:
+**No lightning bolt in the UI**: WebRTC negotiation failed silently. Check:
 - The signaling URL is reachable from both the browser and the home machine
 - The signaling token is correct
 - STUN servers are reachable (corporate firewalls sometimes block UDP)
 - Both sides can reach each other via UDP (symmetric NAT on both sides will prevent direct connections without a TURN relay)
 - Enable `?webrtc_diag=1` to see where the process stalls
 
-**Works locally but not remotely** — you likely need a TURN relay for NAT traversal. Add a TURN server URL via `--webrtc-stun`:
+**Works locally but not remotely**: you likely need a TURN relay for NAT traversal. Add a TURN server URL via `--webrtc-stun`:
 
 ```bash
 term-llm serve web --webrtc \
@@ -173,14 +173,14 @@ term-llm serve web --webrtc \
   --webrtc-stun "turn:turn.example.com:3478?transport=udp"
 ```
 
-**High latency despite direct connection** — enable `?webrtc_diag=1` and check:
+**High latency despite direct connection**: enable `?webrtc_diag=1` and check:
 - The ICE candidate pair should use `host` or `srflx`, not `relay`
 - If you see only `relay` candidates, your STUN server may be unreachable
 - Use `?webrtc_turn=1` to confirm TURN adds measurable latency, then compare without it
 
-**ICE gathering takes 40+ seconds** — likely IPv6 STUN timeouts or TCP TURN candidates. Ensure your TURN URL includes `?transport=udp` to prevent TCP fallback attempts. The browser caps gathering at 4 seconds to mitigate this, but broken STUN servers can still delay the process.
+**ICE gathering takes 40+ seconds**: likely IPv6 STUN timeouts or TCP TURN candidates. Ensure your TURN URL includes `?transport=udp` to prevent TCP fallback attempts. The browser caps gathering at 4 seconds to mitigate this, but broken STUN servers can still delay the process.
 
-**Data channel opens then immediately closes** — check server logs for panics. Common causes include missing SRTP protection profiles in the DTLS config (Chrome always negotiates `use_srtp` even for data channels) or nil pointer dereferences in pion library initialization.
+**Data channel opens then immediately closes**: check server logs for panics. Common causes include missing SRTP protection profiles in the DTLS config (Chrome always negotiates `use_srtp` even for data channels) or nil pointer dereferences in pion library initialization.
 
 ## Related pages
 

--- a/docs-site/content/reference/built-in-tools.md
+++ b/docs-site/content/reference/built-in-tools.md
@@ -35,7 +35,7 @@ term-llm exec --tools read_file,write_file,edit_file,shell,grep,glob,view_image
 
 ### Custom Tools
 
-Agents can declare named, schema-bearing tools backed by shell scripts in the agent directory. These appear to the LLM as first-class tools with their own descriptions and typed parameters—no more asking the LLM to invoke `run_agent_script` with a magic filename.
+Agents can declare named, schema-bearing tools backed by shell scripts in the agent directory. These appear to the LLM as first-class tools with their own descriptions and typed parameters. No more asking the LLM to invoke `run_agent_script` with a magic filename.
 
 ```yaml
 tools:
@@ -97,7 +97,7 @@ sqlite3 "$DB_PATH" \
 | `timeout_seconds` | | Execution timeout (default 30, max 300) |
 | `env` | | Extra environment variables to set when running the script |
 
-Scripts run with `TERM_LLM_AGENT_DIR` and `TERM_LLM_TOOL_NAME` set. Symlinks are resolved and containment-checked—scripts cannot escape the agent directory. No approval prompt is shown; scripts in the agent directory are implicitly trusted.
+Scripts run with `TERM_LLM_AGENT_DIR` and `TERM_LLM_TOOL_NAME` set. Symlinks are resolved and containment-checked. Scripts cannot escape the agent directory. No approval prompt is shown; scripts in the agent directory are implicitly trusted.
 
 ### Tool Permissions
 

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -288,7 +288,7 @@ skills:
   never_auto: [expensive-api-skill]
 ```
 
-Controls the skills system — portable instruction bundles that inject task-specific context into the system prompt. Skills are disabled by default; set `enabled: true` to allow auto-invocation, or use `--skills` on any command for one-off activation. See [Skills](/guides/skills/) for the full guide.
+Controls the skills system: portable instruction bundles that inject task-specific context into the system prompt. Skills are disabled by default; set `enabled: true` to allow auto-invocation, or use `--skills` on any command for one-off activation. See [Skills](/guides/skills/) for the full guide.
 
 ## Diagnostics
 

--- a/docs-site/content/reference/providers-and-models.md
+++ b/docs-site/content/reference/providers-and-models.md
@@ -112,7 +112,7 @@ Use `base_url` when the standard `/chat/completions` path should be appended aut
 | `fast_provider` | string | Provider key to use for `fast_model` if it lives on a different provider. |
 | `context_window` | int | Override context window size in tokens. Use this for self-hosted models not in the built-in token limit tables. |
 | `max_output_tokens` | int | Override maximum output tokens. Same use case as `context_window`. |
-| `no_stream_options` | bool | When `true`, don't send `stream_options` in the request. Use this for servers that reject the field. Default `false` — most OpenAI-compatible servers (vLLM, Ollama, LM Studio) support it and need it to report token usage. |
+| `no_stream_options` | bool | When `true`, don't send `stream_options` in the request. Use this for servers that reject the field. Default `false`; most OpenAI-compatible servers (vLLM, Ollama, LM Studio) support it and need it to report token usage. |
 | `use_websocket` | bool | Reserved for providers with native Responses WebSocket support. Defaults to `true` only for built-in `openai` and `chatgpt`; OpenAI-compatible providers default to HTTP/SSE. |
 
 ### Full example
@@ -204,7 +204,7 @@ providers:
 
 Suffixes are stripped before lookup, so `claude-sonnet-4-6-1m-thinking` strips to `claude-sonnet-4-6`, resolves through `model_map`, then re-applies thinking and 1M context.
 
-The geographic prefix (`us.`, `eu.`, `ap.`) is derived from the configured region automatically — `eu-west-1` produces `eu.anthropic.*` IDs, `ap-southeast-1` produces `ap.anthropic.*`, etc. This ensures data residency matches your region without manual override.
+The geographic prefix (`us.`, `eu.`, `ap.`) is derived from the configured region automatically. For example, `eu-west-1` produces `eu.anthropic.*` IDs, `ap-southeast-1` produces `ap.anthropic.*`, etc. This ensures data residency matches your region without manual override.
 
 Raw Bedrock model IDs (`us.anthropic.claude-sonnet-4-6`, `anthropic.claude-sonnet-4-6`) and full ARNs are passed through without translation.
 

--- a/docs-site/content/reference/sessions.md
+++ b/docs-site/content/reference/sessions.md
@@ -77,7 +77,7 @@ term-llm sessions autotitle --force
 term-llm sessions autotitle --min-age 10m
 ```
 
-The command is safe to run repeatedly — it skips sessions that already have a generated title or a custom name (unless `--force` is used), and does not contact the LLM provider when there is nothing to do. Sessions updated less than 3 minutes ago are skipped by default (`--min-age 3m`) so the conversation has time to develop before titling.
+The command is safe to run repeatedly. It skips sessions that already have a generated title or a custom name (unless `--force` is used), and does not contact the LLM provider when there is nothing to do. Sessions updated less than 3 minutes ago are skipped by default (`--min-age 3m`) so the conversation has time to develop before titling.
 
 When displaying sessions (in `list`, `show`, `export`, and `browse`), titles are chosen in priority order:
 


### PR DESCRIPTION
## What

Remove pointless em dashes from the public docs and contributor docs, replacing them with clearer punctuation:

- colons for label/definition patterns
- periods where a sentence split reads cleaner
- commas/semicolons for simple inline clauses

Table placeholders that use `—` to mean “not applicable” are intentionally left alone.

## Why

The docs had enough prose em dashes to feel a bit AI-polished. This keeps the wording the same while making the punctuation less noisy.

## Verification

- `git diff --check`
