### PR TITLE
fix: Memory mining reloads the full fragment corpus for the same agent on every session

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -70,6 +70,72 @@ type transcriptMessage struct {
 	ToolCalls []string `json:"tool_calls,omitempty"`
 }
 
+type memoryMineFragmentCache struct {
+	maxTokens int
+	byAgent   map[string]*memoryMineFragmentCacheEntry
+}
+
+type memoryMineFragmentCacheEntry struct {
+	paths       []string
+	seen        map[string]struct{}
+	taxonomyMap string
+}
+
+func newMemoryMineFragmentCache(maxTokens int) *memoryMineFragmentCache {
+	return &memoryMineFragmentCache{
+		maxTokens: maxTokens,
+		byAgent:   map[string]*memoryMineFragmentCacheEntry{},
+	}
+}
+
+func (c *memoryMineFragmentCache) get(ctx context.Context, store *memorydb.Store, agent string) (*memoryMineFragmentCacheEntry, error) {
+	if entry, ok := c.byAgent[agent]; ok {
+		return entry, nil
+	}
+
+	paths, err := store.ListFragmentPaths(ctx, agent, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	entry := newMemoryMineFragmentCacheEntry(paths, c.maxTokens)
+	c.byAgent[agent] = entry
+	return entry, nil
+}
+
+func newMemoryMineFragmentCacheEntry(paths []string, maxTokens int) *memoryMineFragmentCacheEntry {
+	copyPaths := append([]string(nil), paths...)
+	seen := make(map[string]struct{}, len(copyPaths))
+	for _, fragPath := range copyPaths {
+		seen[fragPath] = struct{}{}
+	}
+	return &memoryMineFragmentCacheEntry{
+		paths:       copyPaths,
+		seen:        seen,
+		taxonomyMap: buildTaxonomyMapFromPaths(copyPaths, maxTokens),
+	}
+}
+
+func (e *memoryMineFragmentCacheEntry) noteAffectedPaths(paths []string, maxTokens int) {
+	newPaths := make([]string, 0, len(paths))
+	for _, fragPath := range paths {
+		fragPath = strings.TrimSpace(fragPath)
+		if fragPath == "" {
+			continue
+		}
+		if _, ok := e.seen[fragPath]; ok {
+			continue
+		}
+		e.seen[fragPath] = struct{}{}
+		newPaths = append(newPaths, fragPath)
+	}
+	if len(newPaths) == 0 {
+		return
+	}
+
+	e.paths = append(newPaths, e.paths...)
+	e.taxonomyMap = buildTaxonomyMapFromPaths(e.paths, maxTokens)
+}
+
 func init() {
 	memoryMineCmd.Flags().StringVar(&memoryMineModel, "model", "", "Override model used for memory extraction")
 	memoryMineCmd.Flags().DurationVar(&memoryMineSince, "since", 0, "Only mine sessions updated within this duration (e.g. 24h)")
@@ -199,6 +265,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 
 	var totalCreated, totalUpdated, totalSkipped int
 	var summaryStats memoryMineSummaryStats
+	fragmentCache := newMemoryMineFragmentCache(memoryMineTaxonomyMaxTokens)
 
 	for i, candidate := range candidates {
 		state, err := memStore.GetState(ctx, candidate.Session.ID)
@@ -217,11 +284,11 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		existing, err := memStore.ListFragments(ctx, memorydb.ListOptions{Agent: candidate.Agent})
+		fragmentCacheEntry, err := fragmentCache.get(ctx, memStore, candidate.Agent)
 		if err != nil {
-			return fmt.Errorf("list existing fragments for agent %s: %w", candidate.Agent, err)
+			return fmt.Errorf("list existing fragment paths for agent %s: %w", candidate.Agent, err)
 		}
-		taxonomyMap := buildTaxonomyMap(existing, memoryMineTaxonomyMaxTokens)
+		taxonomyMap := fragmentCacheEntry.taxonomyMap
 
 		loadResult, err := loadMessagesForMining(ctx, sessStore, candidate, startOffset, taxonomyMap)
 		if err != nil {
@@ -233,7 +300,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		}
 
 		promptParts := buildExtractionPromptParts(candidate, startOffset, loadResult.NextOffset, loadResult.Messages, taxonomyMap)
-		batchStats := newMemoryExtractionStats(candidate, startOffset, loadResult.NextOffset, len(existing), loadResult, promptParts)
+		batchStats := newMemoryExtractionStats(candidate, startOffset, loadResult.NextOffset, len(fragmentCacheEntry.paths), loadResult, promptParts)
 		batchStart := time.Now()
 		extractionResult, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, promptParts.Prompt, &batchStats)
 		if err != nil {
@@ -258,6 +325,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			}); err != nil {
 				return fmt.Errorf("update mining state for session %s: %w", candidate.Session.ID, err)
 			}
+			fragmentCacheEntry.noteAffectedPaths(affectedPaths, memoryMineTaxonomyMaxTokens)
 		}
 
 		totalCreated += created

--- a/cmd/memory_mine_budget.go
+++ b/cmd/memory_mine_budget.go
@@ -40,17 +40,6 @@ type transcriptFitResult struct {
 }
 
 func buildTaxonomyMap(fragments []memorydb.Fragment, maxTokens int) string {
-	if maxTokens <= 0 {
-		return "(omitted)"
-	}
-	if len(fragments) == 0 {
-		base := "Memory fragment map:\n- total_fragments: 0\n- no existing fragments"
-		if llm.EstimateTokens(base) <= maxTokens {
-			return base
-		}
-		return "fragment_count=0; use lookup tools"
-	}
-
 	byPath := make([]memorydb.Fragment, len(fragments))
 	copy(byPath, fragments)
 	sort.Slice(byPath, func(i, j int) bool {
@@ -60,9 +49,28 @@ func buildTaxonomyMap(fragments []memorydb.Fragment, maxTokens int) string {
 		return byPath[i].UpdatedAt.After(byPath[j].UpdatedAt)
 	})
 
-	dirCounts := map[string]int{}
+	paths := make([]string, 0, len(byPath))
 	for _, frag := range byPath {
-		dir := path.Dir(frag.Path)
+		paths = append(paths, frag.Path)
+	}
+	return buildTaxonomyMapFromPaths(paths, maxTokens)
+}
+
+func buildTaxonomyMapFromPaths(paths []string, maxTokens int) string {
+	if maxTokens <= 0 {
+		return "(omitted)"
+	}
+	if len(paths) == 0 {
+		base := "Memory fragment map:\n- total_fragments: 0\n- no existing fragments"
+		if llm.EstimateTokens(base) <= maxTokens {
+			return base
+		}
+		return "fragment_count=0; use lookup tools"
+	}
+
+	dirCounts := map[string]int{}
+	for _, fragPath := range paths {
+		dir := path.Dir(fragPath)
 		if dir == "." {
 			dir = "(root)"
 		}
@@ -81,10 +89,10 @@ func buildTaxonomyMap(fragments []memorydb.Fragment, maxTokens int) string {
 
 	var b strings.Builder
 	b.WriteString("Memory fragment map:\n")
-	b.WriteString(fmt.Sprintf("- total_fragments: %d\n", len(byPath)))
+	b.WriteString(fmt.Sprintf("- total_fragments: %d\n", len(paths)))
 	b.WriteString("- note: compact map only; use lookup tools for exact duplicate checks or content inspection\n")
 	if llm.EstimateTokens(b.String()) > maxTokens {
-		return fmt.Sprintf("fragment_count=%d; use lookup tools", len(byPath))
+		return fmt.Sprintf("fragment_count=%d; use lookup tools", len(paths))
 	}
 
 	dirBudget := maxTokens / 3
@@ -107,15 +115,15 @@ func buildTaxonomyMap(fragments []memorydb.Fragment, maxTokens int) string {
 
 	b.WriteString("Known fragment paths (recent-first, partial if needed):\n")
 	addedPaths := 0
-	for _, frag := range byPath {
-		line := "- " + frag.Path + "\n"
+	for _, fragPath := range paths {
+		line := "- " + fragPath + "\n"
 		if llm.EstimateTokens(b.String()+line) > maxTokens {
 			break
 		}
 		b.WriteString(line)
 		addedPaths++
 	}
-	if omitted := len(byPath) - addedPaths; omitted > 0 {
+	if omitted := len(paths) - addedPaths; omitted > 0 {
 		line := fmt.Sprintf("- ... %d more path(s) omitted from map; use lookup tools\n", omitted)
 		if llm.EstimateTokens(b.String()+line) <= maxTokens {
 			b.WriteString(line)

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -244,6 +244,21 @@ func TestBuildTaxonomyMap_RespectsBudget(t *testing.T) {
 	}
 }
 
+func TestMemoryMineFragmentCacheEntryAddsOnlyNewPaths(t *testing.T) {
+	entry := newMemoryMineFragmentCacheEntry([]string{"projects/existing.md"}, 200)
+	entry.noteAffectedPaths([]string{"projects/existing.md", "prefs/new.md", "prefs/new.md"}, 200)
+
+	if len(entry.paths) != 2 {
+		t.Fatalf("len(paths) = %d, want 2 (%#v)", len(entry.paths), entry.paths)
+	}
+	if entry.paths[0] != "prefs/new.md" {
+		t.Fatalf("new path not promoted into cache front: %#v", entry.paths)
+	}
+	if !strings.Contains(entry.taxonomyMap, "total_fragments: 2") {
+		t.Fatalf("taxonomy map not updated with new count: %s", entry.taxonomyMap)
+	}
+}
+
 func TestLoadMessagesForMining_RespectsPromptBudget(t *testing.T) {
 	ctx := context.Background()
 	sessStore, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})


### PR DESCRIPTION
## What

Cache the per-agent memory fragment taxonomy during a mining run instead of reloading the full fragment corpus for every candidate session.

- Switch the mining loop to load fragment paths once per agent via `ListFragmentPaths`
- Reuse a cached taxonomy map and fragment count across that agent's pending sessions
- Incrementally update the in-memory cache when mining creates new fragment paths, so later sessions in the same run still see newly learned memory without another full reload
- Add a focused test covering cache updates

## Why

Previously, every pending session did an unbounded `ListFragments` call for its agent and rebuilt the taxonomy map from the full fragment set before mining that one batch. For agents with many pending sessions, that turned one mining pass into repeated full-corpus database reads, content allocation, and taxonomy string rebuilding.

This keeps the behavior targeted and minimal while removing the repeated hot path. Mining now does one lightweight path load per agent per run and reuses that result across the agent's sessions, which should materially reduce background memory-mining cost as fragment counts grow.
