### PR TITLE
fix: Memory vector search does a full embedding-table scan, JSON decode, and full sort on every query

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -127,6 +126,9 @@ CREATE TABLE IF NOT EXISTS memory_embeddings (
     embedded_at DATETIME NOT NULL,
     PRIMARY KEY (fragment_id, provider, model)
 );
+
+CREATE INDEX IF NOT EXISTS idx_embeddings_provider_model_dimensions
+    ON memory_embeddings(provider, model, dimensions, fragment_id);
 
 CREATE TABLE IF NOT EXISTS memory_mining_state (
     session_id         TEXT PRIMARY KEY,
@@ -1065,13 +1067,15 @@ func (s *Store) GetFragmentsNeedingEmbedding(ctx context.Context, agent, provide
 	return out, nil
 }
 
-// VectorSearch performs a full cosine similarity scan over embeddings.
+// VectorSearch streams matching embeddings, keeps only the top-k scores in memory,
+// and fetches full fragment rows only for the winners.
 func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string, queryVec []float64, limit int) ([]ScoredFragment, error) {
 	if len(queryVec) == 0 {
 		return nil, fmt.Errorf("query vector cannot be empty")
 	}
 	provider = strings.TrimSpace(provider)
 	model = strings.TrimSpace(model)
+	agent = strings.TrimSpace(agent)
 	if provider == "" || model == "" {
 		return nil, fmt.Errorf("provider and model are required")
 	}
@@ -1079,67 +1083,155 @@ func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string,
 		limit = 24
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT f.id, f.agent, f.path, f.content, f.source, f.created_at, f.updated_at,
-		       f.accessed_at, f.access_count, f.decay_score, f.pinned,
-		       e.vector
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("begin vector search transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT e.fragment_id, f.updated_at, e.vector
 		FROM memory_embeddings e
 		JOIN memory_fragments f ON f.id = e.fragment_id
 		WHERE e.provider = ? AND e.model = ? AND e.dimensions = ?
 		  AND (? = '' OR f.agent = ?)`,
-		provider, model, len(queryVec), strings.TrimSpace(agent), strings.TrimSpace(agent))
+		provider, model, len(queryVec), agent, agent)
 	if err != nil {
 		return nil, fmt.Errorf("vector search query: %w", err)
 	}
-	defer rows.Close()
 
-	matches := make([]ScoredFragment, 0, limit)
+	topHits := make([]vectorSearchHit, 0, limit)
 	for rows.Next() {
-		var r ScoredFragment
-		var accessedAt sql.NullTime
+		var hit vectorSearchHit
 		var payload []byte
-		if err := rows.Scan(
-			&r.ID,
-			&r.Agent,
-			&r.Path,
-			&r.Content,
-			&r.Source,
-			&r.CreatedAt,
-			&r.UpdatedAt,
-			&accessedAt,
-			&r.AccessCount,
-			&r.DecayScore,
-			&r.Pinned,
-			&payload,
-		); err != nil {
+		if err := rows.Scan(&hit.ID, &hit.UpdatedAt, &payload); err != nil {
+			_ = rows.Close()
 			return nil, fmt.Errorf("scan vector search row: %w", err)
 		}
-		if accessedAt.Valid {
-			at := accessedAt.Time
-			r.AccessedAt = &at
+		if err := json.Unmarshal(payload, &hit.Vector); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("decode stored vector for fragment %s: %w", hit.ID, err)
 		}
+		hit.Score = embedding.CosineSimilarity(queryVec, hit.Vector)
+		topHits = insertVectorSearchHit(topHits, hit, limit)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close vector search rows: %w", err)
+	}
+	if len(topHits) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit vector search transaction: %w", err)
+		}
+		return []ScoredFragment{}, nil
+	}
 
-		if err := json.Unmarshal(payload, &r.Vector); err != nil {
-			return nil, fmt.Errorf("decode stored vector for fragment %s: %w", r.ID, err)
+	matches, err := fetchVectorSearchFragments(ctx, tx, topHits)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit vector search transaction: %w", err)
+	}
+	return matches, nil
+}
+
+type vectorSearchHit struct {
+	ID        string
+	UpdatedAt time.Time
+	Score     float64
+	Vector    []float64
+}
+
+func insertVectorSearchHit(hits []vectorSearchHit, hit vectorSearchHit, limit int) []vectorSearchHit {
+	if limit <= 0 {
+		return hits
+	}
+
+	insertAt := len(hits)
+	for i := range hits {
+		if vectorSearchHitBetter(hit, hits[i]) {
+			insertAt = i
+			break
 		}
-		r.Score = embedding.CosineSimilarity(queryVec, r.Vector)
-		matches = append(matches, r)
+	}
+	if len(hits) == limit && insertAt == len(hits) {
+		return hits
+	}
+
+	hits = append(hits, vectorSearchHit{})
+	copy(hits[insertAt+1:], hits[insertAt:])
+	hits[insertAt] = hit
+	if len(hits) > limit {
+		hits = hits[:limit]
+	}
+	return hits
+}
+
+func vectorSearchHitBetter(a, b vectorSearchHit) bool {
+	if a.Score == b.Score {
+		return a.UpdatedAt.After(b.UpdatedAt)
+	}
+	return a.Score > b.Score
+}
+
+func fetchVectorSearchFragments(ctx context.Context, tx *sql.Tx, hits []vectorSearchHit) ([]ScoredFragment, error) {
+	placeholders := strings.Repeat("?,", len(hits))
+	placeholders = strings.TrimSuffix(placeholders, ",")
+
+	args := make([]any, 0, len(hits))
+	for _, hit := range hits {
+		args = append(args, hit.ID)
+	}
+
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, agent, path, content, source, created_at, updated_at,
+		       accessed_at, access_count, decay_score, pinned
+		FROM memory_fragments
+		WHERE id IN (%s)`, placeholders), args...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch vector search fragments: %w", err)
+	}
+	defer rows.Close()
+
+	fragments := make(map[string]*Fragment, len(hits))
+	for rows.Next() {
+		frag, err := scanFragment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan vector search fragment: %w", err)
+		}
+		fragments[frag.ID] = frag
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].Score == matches[j].Score {
-			return matches[i].UpdatedAt.After(matches[j].UpdatedAt)
+	out := make([]ScoredFragment, 0, len(hits))
+	for _, hit := range hits {
+		frag := fragments[hit.ID]
+		if frag == nil {
+			continue
 		}
-		return matches[i].Score > matches[j].Score
-	})
-
-	if len(matches) > limit {
-		matches = matches[:limit]
+		out = append(out, ScoredFragment{
+			ID:          frag.ID,
+			Agent:       frag.Agent,
+			Path:        frag.Path,
+			Content:     frag.Content,
+			Source:      frag.Source,
+			CreatedAt:   frag.CreatedAt,
+			UpdatedAt:   frag.UpdatedAt,
+			AccessedAt:  frag.AccessedAt,
+			AccessCount: frag.AccessCount,
+			DecayScore:  frag.DecayScore,
+			Pinned:      frag.Pinned,
+			Score:       hit.Score,
+			Vector:      hit.Vector,
+		})
 	}
-	return matches, nil
+	return out, nil
 }
 
 // BumpAccess marks a fragment as recently accessed, increments access_count,

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -524,6 +524,42 @@ func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
 	}
 }
 
+func TestStoreVectorSearchBreaksTiesByUpdatedAt(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	olderTime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	newerTime := olderTime.Add(30 * time.Minute)
+	older := &Fragment{Agent: "jarvis", Path: "older", Content: "Older tie", CreatedAt: olderTime, UpdatedAt: olderTime}
+	newer := &Fragment{Agent: "jarvis", Path: "newer", Content: "Newer tie", CreatedAt: newerTime, UpdatedAt: newerTime}
+	for _, f := range []*Fragment{older, newer} {
+		if err := store.CreateFragment(ctx, f); err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", f.Path, err)
+		}
+		if err := store.UpsertEmbedding(ctx, f.ID, "gemini", "gemini-embedding-001", 2, []float64{1, 0}); err != nil {
+			t.Fatalf("UpsertEmbedding(%s) error = %v", f.Path, err)
+		}
+	}
+
+	results, err := store.VectorSearch(ctx, "jarvis", "gemini", "gemini-embedding-001", []float64{1, 0}, 1)
+	if err != nil {
+		t.Fatalf("VectorSearch() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("VectorSearch() len = %d, want 1", len(results))
+	}
+	if results[0].ID != newer.ID {
+		t.Fatalf("VectorSearch() top ID = %s, want newer %s", results[0].ID, newer.ID)
+	}
+	if results[0].Content != newer.Content {
+		t.Fatalf("VectorSearch() content = %q, want %q", results[0].Content, newer.Content)
+	}
+	if len(results[0].Vector) != 2 {
+		t.Fatalf("VectorSearch() vector len = %d, want 2", len(results[0].Vector))
+	}
+}
+
 func TestStoreMiningState(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)


### PR DESCRIPTION
## What

- add a memory_embeddings index on `(provider, model, dimensions, fragment_id)` so vector lookups stop scanning the whole embeddings table before scoring
- change `Store.VectorSearch` to stream matching embeddings, keep only the current top-k hits in memory, and fetch full fragment rows only for those winners
- add a regression test covering score ties so the updated_at tie-break still works after the top-k pruning change

## Why

The old vector search path joined full fragment rows for every candidate, JSON-decoded every matching vector, accumulated every scored result, then sorted the whole slice before applying the limit. As the memory corpus grows, that makes interactive retrieval increasingly expensive in both CPU and memory.

This keeps the change targeted while materially reducing query cost:
- SQLite can narrow the candidate set with an index instead of scanning the whole embeddings table
- Go only retains the best `limit` matches instead of every scored fragment
- large fragment content is loaded only for the final winners, not for the entire candidate set
