### PR TITLE
fix: Memory mining reloads the entire fragment corpus for the same agent on every candidate session

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -64,6 +64,90 @@ type memoryMineCandidate struct {
 	Agent   string
 }
 
+type memoryAgentFragmentStore interface {
+	ListFragments(ctx context.Context, opts memorydb.ListOptions) ([]memorydb.Fragment, error)
+	GetFragment(ctx context.Context, agent, path string) (*memorydb.Fragment, error)
+}
+
+type memoryAgentFragmentCache struct {
+	maxTokens int
+	corpora   map[string]*memoryAgentFragmentCorpus
+}
+
+type memoryAgentFragmentCorpus struct {
+	fragments   []memorydb.Fragment
+	taxonomyMap string
+	byPath      map[string]int
+}
+
+func newMemoryAgentFragmentCache(maxTokens int) *memoryAgentFragmentCache {
+	return &memoryAgentFragmentCache{
+		maxTokens: maxTokens,
+		corpora:   map[string]*memoryAgentFragmentCorpus{},
+	}
+}
+
+func (c *memoryAgentFragmentCache) get(ctx context.Context, store memoryAgentFragmentStore, agent string) ([]memorydb.Fragment, string, error) {
+	agent = strings.TrimSpace(agent)
+	if corpus, ok := c.corpora[agent]; ok {
+		return corpus.fragments, corpus.taxonomyMap, nil
+	}
+
+	fragments, err := store.ListFragments(ctx, memorydb.ListOptions{Agent: agent})
+	if err != nil {
+		return nil, "", err
+	}
+
+	corpus := &memoryAgentFragmentCorpus{
+		fragments:   fragments,
+		taxonomyMap: buildTaxonomyMap(fragments, c.maxTokens),
+		byPath:      make(map[string]int, len(fragments)),
+	}
+	for i, frag := range fragments {
+		corpus.byPath[frag.Path] = i
+	}
+	c.corpora[agent] = corpus
+	return corpus.fragments, corpus.taxonomyMap, nil
+}
+
+func (c *memoryAgentFragmentCache) applyChanges(ctx context.Context, store memoryAgentFragmentStore, agent string, paths []string) error {
+	agent = strings.TrimSpace(agent)
+	corpus, ok := c.corpora[agent]
+	if !ok || len(paths) == 0 {
+		return nil
+	}
+
+	for _, fragPath := range paths {
+		fragPath = strings.TrimSpace(fragPath)
+		if fragPath == "" {
+			continue
+		}
+
+		frag, err := store.GetFragment(ctx, agent, fragPath)
+		if err != nil {
+			return fmt.Errorf("get fragment %s: %w", fragPath, err)
+		}
+		if frag == nil {
+			continue
+		}
+
+		if idx, exists := corpus.byPath[fragPath]; exists {
+			corpus.fragments[idx] = *frag
+			continue
+		}
+
+		corpus.byPath[fragPath] = len(corpus.fragments)
+		corpus.fragments = append(corpus.fragments, *frag)
+	}
+
+	corpus.taxonomyMap = buildTaxonomyMap(corpus.fragments, c.maxTokens)
+	return nil
+}
+
+func (c *memoryAgentFragmentCache) invalidate(agent string) {
+	delete(c.corpora, strings.TrimSpace(agent))
+}
+
 type transcriptMessage struct {
 	Role      string   `json:"role"`
 	Text      string   `json:"text,omitempty"`
@@ -199,6 +283,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 
 	var totalCreated, totalUpdated, totalSkipped int
 	var summaryStats memoryMineSummaryStats
+	fragmentCache := newMemoryAgentFragmentCache(memoryMineTaxonomyMaxTokens)
 
 	for i, candidate := range candidates {
 		state, err := memStore.GetState(ctx, candidate.Session.ID)
@@ -217,11 +302,10 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		existing, err := memStore.ListFragments(ctx, memorydb.ListOptions{Agent: candidate.Agent})
+		existing, taxonomyMap, err := fragmentCache.get(ctx, memStore, candidate.Agent)
 		if err != nil {
 			return fmt.Errorf("list existing fragments for agent %s: %w", candidate.Agent, err)
 		}
-		taxonomyMap := buildTaxonomyMap(existing, memoryMineTaxonomyMaxTokens)
 
 		loadResult, err := loadMessagesForMining(ctx, sessStore, candidate, startOffset, taxonomyMap)
 		if err != nil {
@@ -237,6 +321,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		batchStart := time.Now()
 		extractionResult, err := runExtractionRequest(ctx, engine, memStore, candidate.Agent, promptParts.Prompt, &batchStats)
 		if err != nil {
+			fragmentCache.invalidate(candidate.Agent)
 			fmt.Fprintf(os.Stderr, "warning: skipping session %s batch at offset %d: %v\n", candidate.Session.ID, startOffset, err)
 			continue
 		}
@@ -257,6 +342,10 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 				MinedAt:         time.Now(),
 			}); err != nil {
 				return fmt.Errorf("update mining state for session %s: %w", candidate.Session.ID, err)
+			}
+			if err := fragmentCache.applyChanges(ctx, memStore, candidate.Agent, affectedPaths); err != nil {
+				fragmentCache.invalidate(candidate.Agent)
+				fmt.Fprintf(os.Stderr, "warning: refresh fragment cache for agent %s: %v\n", candidate.Agent, err)
 			}
 		}
 

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -14,6 +14,32 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
+type fakeMemoryAgentFragmentStore struct {
+	listCalls int
+	getCalls  int
+	listByKey map[string][]memorydb.Fragment
+	getByKey  map[string]map[string]memorydb.Fragment
+}
+
+func (s *fakeMemoryAgentFragmentStore) ListFragments(ctx context.Context, opts memorydb.ListOptions) ([]memorydb.Fragment, error) {
+	s.listCalls++
+	fragments := s.listByKey[strings.TrimSpace(opts.Agent)]
+	out := make([]memorydb.Fragment, len(fragments))
+	copy(out, fragments)
+	return out, nil
+}
+
+func (s *fakeMemoryAgentFragmentStore) GetFragment(ctx context.Context, agent, path string) (*memorydb.Fragment, error) {
+	s.getCalls++
+	fragments := s.getByKey[strings.TrimSpace(agent)]
+	frag, ok := fragments[strings.TrimSpace(path)]
+	if !ok {
+		return nil, nil
+	}
+	copyFrag := frag
+	return &copyFrag, nil
+}
+
 func TestBuildInsightTranscriptWeightsUserTextOverAssistantAndSummarizesTools(t *testing.T) {
 	messages := []session.Message{
 		{Role: llm.RoleSystem, TextContent: strings.Repeat("system ", 100)},
@@ -224,6 +250,88 @@ func TestMemoryExtractionCollectorAndTools(t *testing.T) {
 	}
 	if len(res.AffectedPaths) != 1 || res.AffectedPaths[0] != "fragments/new.md" {
 		t.Fatalf("affected paths = %+v", res.AffectedPaths)
+	}
+}
+
+func TestMemoryAgentFragmentCache_ReusesLoadedCorpusAndAppliesIncrementalChanges(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	initial := memorydb.Fragment{
+		Agent:     "jarvis",
+		Path:      "fragments/a.md",
+		Content:   "old content",
+		UpdatedAt: now.Add(-time.Minute),
+	}
+	updated := memorydb.Fragment{
+		Agent:     "jarvis",
+		Path:      "fragments/a.md",
+		Content:   "updated content",
+		UpdatedAt: now,
+	}
+	created := memorydb.Fragment{
+		Agent:     "jarvis",
+		Path:      "fragments/b.md",
+		Content:   "new content",
+		UpdatedAt: now.Add(30 * time.Second),
+	}
+	store := &fakeMemoryAgentFragmentStore{
+		listByKey: map[string][]memorydb.Fragment{
+			"jarvis": {initial},
+		},
+		getByKey: map[string]map[string]memorydb.Fragment{
+			"jarvis": {
+				initial.Path: initial,
+			},
+		},
+	}
+
+	cache := newMemoryAgentFragmentCache(200)
+	fragments, taxonomy, err := cache.get(ctx, store, "jarvis")
+	if err != nil {
+		t.Fatalf("cache.get(initial): %v", err)
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("listCalls after first get = %d, want 1", store.listCalls)
+	}
+	if len(fragments) != 1 || fragments[0].Content != "old content" {
+		t.Fatalf("initial fragments = %+v", fragments)
+	}
+	if !strings.Contains(taxonomy, "total_fragments: 1") {
+		t.Fatalf("initial taxonomy = %q, want total_fragments: 1", taxonomy)
+	}
+
+	store.getByKey["jarvis"][updated.Path] = updated
+	store.getByKey["jarvis"][created.Path] = created
+	if err := cache.applyChanges(ctx, store, "jarvis", []string{updated.Path, created.Path}); err != nil {
+		t.Fatalf("cache.applyChanges: %v", err)
+	}
+
+	fragments, taxonomy, err = cache.get(ctx, store, "jarvis")
+	if err != nil {
+		t.Fatalf("cache.get(updated): %v", err)
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("listCalls after cache reuse = %d, want 1", store.listCalls)
+	}
+	if store.getCalls != 2 {
+		t.Fatalf("getCalls after incremental refresh = %d, want 2", store.getCalls)
+	}
+	if len(fragments) != 2 {
+		t.Fatalf("len(fragments) = %d, want 2", len(fragments))
+	}
+
+	seen := map[string]string{}
+	for _, frag := range fragments {
+		seen[frag.Path] = frag.Content
+	}
+	if seen[updated.Path] != updated.Content {
+		t.Fatalf("updated fragment content = %q, want %q", seen[updated.Path], updated.Content)
+	}
+	if seen[created.Path] != created.Content {
+		t.Fatalf("created fragment content = %q, want %q", seen[created.Path], created.Content)
+	}
+	if !strings.Contains(taxonomy, "total_fragments: 2") {
+		t.Fatalf("updated taxonomy = %q, want total_fragments: 2", taxonomy)
 	}
 }
 


### PR DESCRIPTION
## What

- cache the fragment corpus and taxonomy map per agent during `memory mine` runs instead of reloading all fragments for every candidate session
- incrementally refresh the cached corpus from affected fragment paths after successful create/update operations
- invalidate the cache on extraction errors and add a regression test that verifies corpus reuse and incremental refresh behavior

## Why

Mining multiple sessions for the same agent was repeatedly calling `ListFragments` with no limit and rebuilding the taxonomy map from scratch for each session. That turned one mining pass into repeated full-corpus reads and allocations, which slows long-running memory upkeep and creates avoidable database and GC churn. Reusing the per-agent corpus removes the repeated full reloads while still keeping later batches up to date when memory changes.
