### PR TITLE
fix: Jobs v2 serializes all DB traffic onto a single SQLite connection

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -593,8 +593,10 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 	if err != nil {
 		return nil, fmt.Errorf("open jobs db: %w", err)
 	}
-	// Required for :memory: databases: keep a single connection so schema/data persist.
-	db.SetMaxOpenConns(1)
+	if dbPath == ":memory:" {
+		// Required for :memory: databases: keep a single connection so schema/data persist.
+		db.SetMaxOpenConns(1)
+	}
 	if err := execJobsV2Schema(db); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("init jobs schema: %w", err)

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -6,12 +6,26 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
+
+func TestNewJobsV2ManagerDoesNotForceSingleConnectionForFileBackedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jobs_v2.db")
+	mgr, err := newJobsV2Manager(dbPath, 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	if got := mgr.db.Stats().MaxOpenConnections; got != 0 {
+		t.Fatalf("MaxOpenConnections = %d, want 0 for file-backed DB", got)
+	}
+}
 
 func TestJobsV2OnceProgramRunLifecycle(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)


### PR DESCRIPTION
## What

Only force `jobsV2` onto a single SQLite connection when the DB path is `:memory:`.

Also add a regression test covering the file-backed case so `newJobsV2Manager` keeps the default connection pool behavior for normal `jobs_v2.db` deployments.

## Why

The existing code unconditionally called `db.SetMaxOpenConns(1)` even though that restriction is only needed for `:memory:` databases. On file-backed SQLite databases this serialized the scheduler, workers, HTTP handlers, cleanup, and run-event persistence through one connection, causing avoidable head-of-line blocking and limiting the benefit of higher `--jobs-workers` settings.
