### PR TITLE
perf: index memory vector search embeddings

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -128,6 +128,8 @@ CREATE TABLE IF NOT EXISTS memory_embeddings (
     PRIMARY KEY (fragment_id, provider, model)
 );
 
+CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model_dimensions ON memory_embeddings(provider, model, dimensions);
+
 CREATE TABLE IF NOT EXISTS memory_mining_state (
     session_id         TEXT PRIMARY KEY,
     agent              TEXT NOT NULL,
@@ -1065,7 +1067,16 @@ func (s *Store) GetFragmentsNeedingEmbedding(ctx context.Context, agent, provide
 	return out, nil
 }
 
-// VectorSearch performs a full cosine similarity scan over embeddings.
+const vectorSearchSQL = `
+		SELECT f.id, f.agent, f.path, f.content, f.source, f.created_at, f.updated_at,
+		       f.accessed_at, f.access_count, f.decay_score, f.pinned,
+		       e.vector
+		FROM memory_embeddings e
+		JOIN memory_fragments f ON f.id = e.fragment_id
+		WHERE e.provider = ? AND e.model = ? AND e.dimensions = ?
+		  AND (? = '' OR f.agent = ?)`
+
+// VectorSearch performs a cosine similarity scan over embeddings matching provider, model, and dimensions.
 func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string, queryVec []float64, limit int) ([]ScoredFragment, error) {
 	if len(queryVec) == 0 {
 		return nil, fmt.Errorf("query vector cannot be empty")
@@ -1079,14 +1090,7 @@ func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string,
 		limit = 24
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT f.id, f.agent, f.path, f.content, f.source, f.created_at, f.updated_at,
-		       f.accessed_at, f.access_count, f.decay_score, f.pinned,
-		       e.vector
-		FROM memory_embeddings e
-		JOIN memory_fragments f ON f.id = e.fragment_id
-		WHERE e.provider = ? AND e.model = ? AND e.dimensions = ?
-		  AND (? = '' OR f.agent = ?)`,
+	rows, err := s.db.QueryContext(ctx, vectorSearchSQL,
 		provider, model, len(queryVec), strings.TrimSpace(agent), strings.TrimSpace(agent))
 	if err != nil {
 		return nil, fmt.Errorf("vector search query: %w", err)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -524,6 +524,56 @@ func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
 	}
 }
 
+func TestStoreVectorSearchUsesProviderModelDimensionsIndex(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	rows, err := store.db.Query("EXPLAIN QUERY PLAN "+vectorSearchSQL,
+		"gemini", "gemini-embedding-001", 4, "jarvis", "jarvis")
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan query plan row: %v", err)
+		}
+		details = append(details, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("query plan rows error = %v", err)
+	}
+
+	plan := strings.Join(details, "\n")
+	if !strings.Contains(plan, "idx_memory_embeddings_provider_model_dimensions") {
+		t.Fatalf("VectorSearch query plan does not use provider/model/dimensions index:\n%s", plan)
+	}
+}
+
+func BenchmarkStoreVectorSearchProviderModelFilter(b *testing.B) {
+	ctx := context.Background()
+	store := newTestStore(b)
+	defer store.Close()
+	seedVectorSearchBenchmark(b, store, 50000, 250)
+
+	queryVec := []float64{1, 0, 0, 0}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, err := store.VectorSearch(ctx, "jarvis", "gemini", "gemini-embedding-001", queryVec, 10)
+		if err != nil {
+			b.Fatalf("VectorSearch() error = %v", err)
+		}
+		if len(results) != 10 {
+			b.Fatalf("VectorSearch() len = %d, want 10", len(results))
+		}
+	}
+}
+
 func TestStoreMiningState(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
@@ -1086,6 +1136,61 @@ func BenchmarkListFragmentPathsForMiningTool(b *testing.B) {
 			}
 		}
 	})
+}
+
+func seedVectorSearchBenchmark(b *testing.B, store *Store, total, matching int) {
+	b.Helper()
+	if matching <= 0 || matching > total {
+		b.Fatalf("invalid matching count %d for total %d", matching, total)
+	}
+
+	tx, err := store.db.Begin()
+	if err != nil {
+		b.Fatalf("begin seed transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	fragStmt, err := tx.Prepare(`
+		INSERT INTO memory_fragments (id, agent, path, content, source, created_at, updated_at, decay_score)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1.0)`)
+	if err != nil {
+		b.Fatalf("prepare fragment seed insert: %v", err)
+	}
+	defer fragStmt.Close()
+
+	embStmt, err := tx.Prepare(`
+		INSERT INTO memory_embeddings (fragment_id, provider, model, dimensions, vector, embedded_at)
+		VALUES (?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		b.Fatalf("prepare embedding seed insert: %v", err)
+	}
+	defer embStmt.Close()
+
+	now := time.Now().UTC()
+	matchingVector := []byte(`[1,0,0,0]`)
+	otherVector := []byte(`[0,1,0,0]`)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("vector-frag-%05d", i)
+		if _, err := fragStmt.Exec(id, "jarvis", fmt.Sprintf("vectors/%05d.md", i), "benchmark content", DefaultSourceMine, now, now); err != nil {
+			b.Fatalf("seed fragment %d: %v", i, err)
+		}
+
+		provider := "openai"
+		model := "text-embedding-3-large"
+		vector := otherVector
+		if i < matching {
+			provider = "gemini"
+			model = "gemini-embedding-001"
+			vector = matchingVector
+		}
+		if _, err := embStmt.Exec(id, provider, model, 4, vector, now); err != nil {
+			b.Fatalf("seed embedding %d: %v", i, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit seed transaction: %v", err)
+	}
 }
 
 func seedListFragmentPathBenchmark(b *testing.B, store *Store, count int) {


### PR DESCRIPTION
## What

- Add an idempotent SQLite index on `memory_embeddings(provider, model, dimensions)`.
- Reuse the VectorSearch SQL in an EXPLAIN query-plan regression test so the test guards the production query shape.
- Add a representative VectorSearch benchmark with 50,000 embeddings and 250 matches for the requested provider/model/dimensions.

## Why

`VectorSearch` filters embeddings by provider, model, and dimensions before joining fragments and computing cosine similarity. The existing primary key starts with `fragment_id`, so SQLite could not use it for those leading predicates and planned a full scan of `memory_embeddings`.

## Evidence

Before the index, `EXPLAIN QUERY PLAN` for the VectorSearch query reported `SCAN e` on `memory_embeddings`. With the new index it reports `SEARCH e USING INDEX idx_memory_embeddings_provider_model_dimensions (provider=? AND model=? AND dimensions=?)`.

Benchmark on linux/amd64, Intel i9-14900K, 50k embeddings / 250 matching rows:

```text
# before
BenchmarkStoreVectorSearchProviderModelFilter-32    436-462    2.59-2.62 ms/op    405686 B/op    8788 allocs/op

# after
BenchmarkStoreVectorSearchProviderModelFilter-32    1249-1312  0.848-0.893 ms/op  405686 B/op    8788 allocs/op
```

## Verification

- `go test ./internal/memory -run 'TestStoreVectorSearch(AndBumpAccess|UsesProviderModelDimensionsIndex)$' -bench '^BenchmarkStoreVectorSearchProviderModelFilter$' -benchmem -count=3`
- `go build ./...`
- `go test ./...`

Note: an earlier full test run hit a transient timeout in `internal/tools`; rerunning that test and the final full suite passed.
