### PR TITLE
perf: slim Jobs V2 run listings

### DIFF
--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -310,7 +310,18 @@ func (c *jobsClient) listJobs(ctx context.Context) ([]jobsV2Job, error) {
 }
 
 func (c *jobsClient) listRuns(ctx context.Context, jobID string, limit, offset int) ([]jobsV2Run, error) {
+	return c.listRunsWithSummary(ctx, jobID, limit, offset, false)
+}
+
+func (c *jobsClient) listRunSummaries(ctx context.Context, jobID string, limit, offset int) ([]jobsV2Run, error) {
+	return c.listRunsWithSummary(ctx, jobID, limit, offset, true)
+}
+
+func (c *jobsClient) listRunsWithSummary(ctx context.Context, jobID string, limit, offset int, summary bool) ([]jobsV2Run, error) {
 	path := fmt.Sprintf("/v2/runs?limit=%d&offset=%d", limit, offset)
+	if summary {
+		path += "&summary=true"
+	}
 	if strings.TrimSpace(jobID) != "" {
 		path += "&job_id=" + jobID
 	}
@@ -331,7 +342,7 @@ func (c *jobsClient) listActiveRuns(ctx context.Context) ([]jobsActiveRun, error
 	for _, job := range jobs {
 		offset := 0
 		for {
-			runs, err := c.listRuns(ctx, job.ID, jobsActiveRunsPageSize, offset)
+			runs, err := c.listRunSummaries(ctx, job.ID, jobsActiveRunsPageSize, offset)
 			if err != nil {
 				return nil, err
 			}
@@ -531,7 +542,7 @@ func runJobsList(cmd *cobra.Command, args []string) error {
 		lastRun   *jobsV2Run // most recent terminal run
 	}
 	summaries := make(map[string]*jobRunSummary)
-	recentRuns, _ := client.listRuns(ctx, "", 500, 0)
+	recentRuns, _ := client.listRunSummaries(ctx, "", 500, 0)
 	for i := range recentRuns {
 		r := &recentRuns[i]
 		s, ok := summaries[r.JobID]
@@ -846,7 +857,12 @@ func runJobsRuns(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	items, err := client.listRuns(cmd.Context(), jobID, jobsRunsLimit, jobsRunsOffset)
+	var items []jobsV2Run
+	if jobsJSON {
+		items, err = client.listRuns(cmd.Context(), jobID, jobsRunsLimit, jobsRunsOffset)
+	} else {
+		items, err = client.listRunSummaries(cmd.Context(), jobID, jobsRunsLimit, jobsRunsOffset)
+	}
 	if err != nil {
 		return err
 	}
@@ -948,7 +964,7 @@ func runsArgCompletion(cmd *cobra.Command, args []string, toComplete string) ([]
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	runs, err := client.listRuns(ctx, "", 200, 0)
+	runs, err := client.listRunSummaries(ctx, "", 200, 0)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/jobs_test.go
+++ b/cmd/jobs_test.go
@@ -180,10 +180,10 @@ func TestRunJobsActive_JSONFiltersActiveRunsAndUsesPagedRequests(t *testing.T) {
 
 	expectedRequests := []string{
 		"/v2/jobs?limit=500",
-		"/v2/runs?limit=10&offset=0&job_id=job_alpha",
-		"/v2/runs?limit=10&offset=10&job_id=job_alpha",
-		"/v2/runs?limit=10&offset=20&job_id=job_alpha",
-		"/v2/runs?limit=10&offset=0&job_id=job_beta",
+		"/v2/runs?limit=10&offset=0&summary=true&job_id=job_alpha",
+		"/v2/runs?limit=10&offset=10&summary=true&job_id=job_alpha",
+		"/v2/runs?limit=10&offset=20&summary=true&job_id=job_alpha",
+		"/v2/runs?limit=10&offset=0&summary=true&job_id=job_beta",
 	}
 	if !reflect.DeepEqual(requests, expectedRequests) {
 		t.Fatalf("requests = %#v, want %#v", requests, expectedRequests)

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1579,7 +1579,7 @@ func (m *jobsV2Manager) UpdateJobPatch(id string, req jobsV2JobRequest) (jobsV2J
 
 func (m *jobsV2Manager) DeleteJob(id string, cancelActive bool) error {
 	if cancelActive {
-		runs, _, err := m.ListRuns(id, 200, 0)
+		runs, _, err := m.ListRunSummaries(id, 200, 0)
 		if err == nil {
 			for _, run := range runs {
 				if run.Status == jobsV2RunRunning || run.Status == jobsV2RunClaimed || run.Status == jobsV2RunQueued {
@@ -1627,6 +1627,18 @@ func (m *jobsV2Manager) GetRun(id string) (jobsV2Run, error) {
 }
 
 func (m *jobsV2Manager) ListRuns(jobID string, limit, offset int) ([]jobsV2Run, int, error) {
+	return m.listRuns(jobID, limit, offset, true)
+}
+
+func (m *jobsV2Manager) ListRunSummaries(jobID string, limit, offset int) ([]jobsV2Run, int, error) {
+	return m.listRuns(jobID, limit, offset, false)
+}
+
+const jobsV2RunFullColumns = "id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at"
+
+const jobsV2RunSummaryColumns = "id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, NULL AS stdout, NULL AS stderr, NULL AS thinking, NULL AS response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at"
+
+func (m *jobsV2Manager) listRuns(jobID string, limit, offset int, includeOutput bool) ([]jobsV2Run, int, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -1647,14 +1659,18 @@ func (m *jobsV2Manager) ListRuns(jobID string, limit, offset int) ([]jobsV2Run, 
 	if err := m.db.QueryRow(countQuery, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
-	query := "SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2" + where + " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+	columns := jobsV2RunSummaryColumns
+	if includeOutput {
+		columns = jobsV2RunFullColumns
+	}
+	query := "SELECT " + columns + " FROM job_runs_v2" + where + " ORDER BY created_at DESC LIMIT ? OFFSET ?"
 	args = append(args, limit, offset)
 	rows, err := m.db.Query(query, args...)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer rows.Close()
-	runs := make([]jobsV2Run, 0)
+	runs := make([]jobsV2Run, 0, limit)
 	for rows.Next() {
 		run, err := scanRunV2(rows)
 		if err != nil {
@@ -2273,7 +2289,13 @@ func (s *serveServer) handleRunsV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jobID := strings.TrimSpace(r.URL.Query().Get("job_id"))
-	items, total, err := s.jobsV2.ListRuns(jobID, limit, offset)
+	var items []jobsV2Run
+	var total int
+	if queryBool(r, "summary") {
+		items, total, err = s.jobsV2.ListRunSummaries(jobID, limit, offset)
+	} else {
+		items, total, err = s.jobsV2.ListRuns(jobID, limit, offset)
+	}
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
@@ -2374,6 +2396,11 @@ func (s *serveServer) handleRunV2ByID(w http.ResponseWriter, r *http.Request) {
 func newServeJobsV2Manager(cfg *config.Config, workers int) (*jobsV2Manager, error) {
 	_ = cfg
 	return newJobsV2Manager("", workers, newServeJobsExecutor(cfg))
+}
+
+func queryBool(r *http.Request, key string) bool {
+	value := strings.TrimSpace(r.URL.Query().Get(key))
+	return strings.EqualFold(value, "1") || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes")
 }
 
 func parseNonNegativeIntQuery(r *http.Request, key string, defaultValue int) (int, error) {

--- a/cmd/serve_jobs_v2_bench_test.go
+++ b/cmd/serve_jobs_v2_bench_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func BenchmarkJobsV2ListRuns(b *testing.B) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		b.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	now := time.Now().UTC()
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 60, 'skip', ?, ?)`,
+		"job_bench_runs", "bench-runs", jobsV2RunnerProgram, `{"command":"echo","args":["x"]}`, jobsV2TriggerManual, `{}`, now, now)
+	if err != nil {
+		b.Fatalf("insert job: %v", err)
+	}
+
+	payload := strings.Repeat("x", 64<<10)
+	const rows = 100
+	const limit = 50
+	for i := 0; i < rows; i++ {
+		created := now.Add(-time.Duration(i) * time.Second)
+		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, started_at, finished_at, exit_code, stdout, stderr, thinking, response, exit_reason, turn_count, input_tokens, output_tokens, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 2, 100, 20, ?, ?)`,
+			fmt.Sprintf("run_bench_%03d", i), "job_bench_runs", created, jobsV2RunSucceeded, created, created, payload, payload, payload, payload, exitReasonNatural, created, created)
+		if err != nil {
+			b.Fatalf("insert run %d: %v", i, err)
+		}
+	}
+
+	b.Run("full", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			runs, total, err := mgr.ListRuns("job_bench_runs", limit, 0)
+			if err != nil {
+				b.Fatalf("ListRuns failed: %v", err)
+			}
+			if total != rows || len(runs) != limit {
+				b.Fatalf("got total=%d len=%d, want total=%d len=%d", total, len(runs), rows, limit)
+			}
+			if len(runs[0].Stdout) != len(payload) || len(runs[0].Response) != len(payload) {
+				b.Fatalf("full list did not load output payloads")
+			}
+		}
+	})
+
+	b.Run("summary", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			runs, total, err := mgr.ListRunSummaries("job_bench_runs", limit, 0)
+			if err != nil {
+				b.Fatalf("ListRunSummaries failed: %v", err)
+			}
+			if total != rows || len(runs) != limit {
+				b.Fatalf("got total=%d len=%d, want total=%d len=%d", total, len(runs), rows, limit)
+			}
+			if runs[0].Stdout != "" || runs[0].Response != "" {
+				b.Fatalf("summary list loaded output payloads")
+			}
+		}
+	})
+}

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -95,6 +95,72 @@ func TestJobsV2OnceProgramRunLifecycle(t *testing.T) {
 	}
 }
 
+func TestJobsV2RunsSummaryOmitsOutputPayload(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "summary-payload",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	now := time.Now().UTC()
+	payload := strings.Repeat("payload", 1024)
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?, 7, 'sample error', ?, ?, ?, ?, ?, 1, 3, 100, 20, ?, ?)`,
+		"run_summary_payload", job.ID, now, jobsV2RunFailed, now, now, payload, payload, payload, payload, exitReasonException, now, now)
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+
+	srv := &serveServer{jobsV2: mgr}
+	listReq := httptest.NewRequest(http.MethodGet, "/v2/runs?summary=1&job_id="+job.ID, nil)
+	listRR := httptest.NewRecorder()
+	srv.handleRunsV2(listRR, listReq)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("summary runs status = %d, want 200 body=%s", listRR.Code, listRR.Body.String())
+	}
+	var listResp struct {
+		Data []jobsV2Run `json:"data"`
+	}
+	if err := json.Unmarshal(listRR.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode summary runs list: %v", err)
+	}
+	if len(listResp.Data) != 1 {
+		t.Fatalf("summary runs len = %d, want 1", len(listResp.Data))
+	}
+	summary := listResp.Data[0]
+	if summary.Stdout != "" || summary.Stderr != "" || summary.Thinking != "" || summary.Response != "" {
+		t.Fatalf("summary included output payloads: stdout=%d stderr=%d thinking=%d response=%d", len(summary.Stdout), len(summary.Stderr), len(summary.Thinking), len(summary.Response))
+	}
+	if summary.Error != "sample error" || summary.ExitReason != exitReasonException || !summary.Truncated || summary.TurnCount != 3 || summary.InputTokens != 100 || summary.OutputTokens != 20 {
+		t.Fatalf("summary lost metadata: %+v", summary)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/v2/runs/run_summary_payload", nil)
+	detailRR := httptest.NewRecorder()
+	srv.handleRunV2ByID(detailRR, detailReq)
+	if detailRR.Code != http.StatusOK {
+		t.Fatalf("detail run status = %d, want 200 body=%s", detailRR.Code, detailRR.Body.String())
+	}
+	var detail jobsV2Run
+	if err := json.Unmarshal(detailRR.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode detail run: %v", err)
+	}
+	if detail.Stdout != payload || detail.Stderr != payload || detail.Thinking != payload || detail.Response != payload {
+		t.Fatalf("detail run did not preserve full payloads")
+	}
+}
+
 func TestJobsV2ManualTriggerAndCancel(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)
 	if err != nil {


### PR DESCRIPTION
## What

- Add an opt-in `summary=true` mode to `GET /v2/runs` that selects run metadata while substituting `NULL` for `stdout`, `stderr`, `thinking`, and `response`.
- Route Jobs V2 CLI list/status paths that only need metadata (`jobs list`, `jobs active`, non-JSON `jobs runs`, and run-id shell completion) through the summary mode.
- Keep full payload behavior for default `/v2/runs`, `/v2/runs/{id}`, and `jobs runs --json`.
- Add a regression test for summary-vs-detail payload behavior and a benchmark comparing full vs summary run listings.

## Why

Jobs V2 run rows can carry large output/response columns. Common list/status/completion paths only need metadata, but previously pulled and decoded those payloads anyway, wasting SQLite I/O, JSON bytes, and client/server heap.

## Evidence

Benchmark with 100 stored runs and a 50-row page where each run has 64 KiB in each output field:

```text
BenchmarkJobsV2ListRuns/full-32     ~8.19 ms/op   26.34 MB/op   3654 allocs/op
BenchmarkJobsV2ListRuns/summary-32  ~0.416 ms/op  0.121 MB/op   2854 allocs/op
```

That is about 20x faster and about 218x less allocated memory for the metadata-only listing path.

## Verification

- `go test ./cmd -run 'TestJobsV2RunsSummaryOmitsOutputPayload|TestRunJobsActive_JSONFiltersActiveRunsAndUsesPagedRequests|TestRunJobsActive_TableOutput|TestRunJobsList'`
- `go test ./cmd -run '^$' -bench '^BenchmarkJobsV2ListRuns$' -benchmem -count=5`
- `go build ./...`
- `go test ./...`
