### PR TITLE
perf: cache plain text stream checks

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -606,7 +606,9 @@ const getOrCreateAssistantStreamState = (message, body) => {
       rendering: false,
       rafId: 0,
       timerId: 0,
-      lastRenderAt: 0
+      lastRenderAt: 0,
+      plainTextScanSource: '',
+      plainTextEligible: true
     };
   const containers = createAssistantStreamContainers(body);
   streamState.messageId = message.id;
@@ -745,8 +747,8 @@ const performAssistantStreamRender = (streamState) => {
     if (content) {
       const renderPlainTail = Boolean(
         app.markdownStreaming
-        && typeof app.markdownStreaming.canStreamPlainTextTail === 'function'
-        && app.markdownStreaming.canStreamPlainTextTail(content)
+        && typeof app.markdownStreaming.canStreamPlainTextTailIncremental === 'function'
+        && app.markdownStreaming.canStreamPlainTextTailIncremental(streamState, content)
       );
 
       if (renderPlainTail && !(streamState.stableLength > 0)) {

--- a/internal/serveui/static/markdown-streaming.js
+++ b/internal/serveui/static/markdown-streaming.js
@@ -32,7 +32,9 @@
       rendering: false,
       rafId: 0,
       timerId: 0,
-      lastRenderAt: 0
+      lastRenderAt: 0,
+      plainTextScanSource: '',
+      plainTextEligible: true
     };
   }
 
@@ -253,6 +255,36 @@
     return true;
   }
 
+  function appendedTextIsPlainSafe(text) {
+    // If a streamed delta contains only ordinary prose characters, it cannot
+    // introduce markdown/math syntax by itself or complete syntax that began
+    // in a previously plain prefix. Newlines and punctuation with markdown
+    // meaning fall back to the full scanner.
+    return !/[`\[\]()!*_~<\\$|#>\r\n]/.test(String(text || ''));
+  }
+
+  function canStreamPlainTextTailIncremental(streamState, text) {
+    const value = String(text || '');
+    if (!streamState) return canStreamPlainTextTail(value);
+
+    const previous = String(streamState.plainTextScanSource || '');
+    if (value.startsWith(previous)) {
+      if (streamState.plainTextEligible === false) {
+        streamState.plainTextScanSource = value;
+        return false;
+      }
+      if (streamState.plainTextEligible === true && appendedTextIsPlainSafe(value.slice(previous.length))) {
+        streamState.plainTextScanSource = value;
+        return true;
+      }
+    }
+
+    const eligible = canStreamPlainTextTail(value);
+    streamState.plainTextScanSource = value;
+    streamState.plainTextEligible = eligible;
+    return eligible;
+  }
+
   function containsListOrTableSyntax(text) {
     const value = String(text || '');
     return /^\s{0,3}(?:[-+*]\s|\d+[.)]\s)/m.test(value)
@@ -303,6 +335,8 @@
     areInlineMarkersBalanced,
     areMathDelimitersBalanced,
     findStableMarkdownBoundary,
-    canStreamPlainTextTail
+    canStreamPlainTextTail,
+    canStreamPlainTextTailIncremental,
+    appendedTextIsPlainSafe
   };
 });

--- a/internal/serveui/static/markdown_streaming_test.js
+++ b/internal/serveui/static/markdown_streaming_test.js
@@ -103,6 +103,33 @@ expectFalse(
   streaming.canStreamPlainTextTail('Value: \\(x + y\\)')
 );
 
+expectTrue(
+  'canStreamPlainTextTailIncremental reuses a safe growing plain prefix',
+  (() => {
+    const state = streaming.createStreamingState();
+    if (!streaming.canStreamPlainTextTailIncremental(state, 'plain words')) return false;
+    if (state.plainTextScanSource !== 'plain words') return false;
+    if (!streaming.canStreamPlainTextTailIncremental(state, 'plain words keep growing')) return false;
+    return state.plainTextScanSource === 'plain words keep growing' && state.plainTextEligible === true;
+  })()
+);
+expectFalse(
+  'canStreamPlainTextTailIncremental falls back when punctuation completes a link',
+  (() => {
+    const state = streaming.createStreamingState();
+    if (!streaming.canStreamPlainTextTailIncremental(state, 'See [docs]')) return true;
+    return streaming.canStreamPlainTextTailIncremental(state, 'See [docs](https://example.com)');
+  })()
+);
+expectFalse(
+  'canStreamPlainTextTailIncremental keeps a growing markdown tail in markdown mode',
+  (() => {
+    const state = streaming.createStreamingState();
+    if (streaming.canStreamPlainTextTailIncremental(state, 'This has *emphasis*')) return true;
+    return streaming.canStreamPlainTextTailIncremental(state, 'This has *emphasis* and more plain words');
+  })()
+);
+
 expectEqual(
   'findStableMarkdownBoundary finds blank-line paragraph break',
   streaming.findStableMarkdownBoundary('First paragraph.\n\nSecond paragraph still streaming', 10),


### PR DESCRIPTION
## What

- Adds an incremental plain-text eligibility check for assistant stream tails.
- Reuses the previous plain-text scan result while streamed content grows by ordinary prose characters.
- Falls back to the full markdown/math scanner when punctuation or newlines could introduce markdown syntax.

## Why

During long plain-text responses, the web UI was rescanning the entire streamed assistant body every render just to decide whether it could keep using the cheap text-node append path. That is unnecessary for the common case where deltas are just words/spaces.

This keeps the conservative markdown behavior, but avoids repeated full scans for the boring case. Boring, in UI perf, is where the money is.

## Tests

- `node internal/serveui/static/markdown_streaming_test.js`
- `go test ./internal/serveui ./cmd`
- `go build ./... && go test ./...`
