### PR TITLE
perf: cache gzipped UI assets

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -49,6 +49,23 @@ func uiAssetETag(data []byte) string {
 	return `"` + hex.EncodeToString(sum[:]) + `"`
 }
 
+var uiGzipAssetCache sync.Map // map[string][]byte keyed by the uncompressed body ETag
+
+func uiGzipAsset(data []byte) []byte {
+	cacheKey := uiAssetETag(data)
+	if cached, ok := uiGzipAssetCache.Load(cacheKey); ok {
+		return cached.([]byte)
+	}
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, _ = gz.Write(data)
+	_ = gz.Close()
+	body := compressed.Bytes()
+	cached, _ := uiGzipAssetCache.LoadOrStore(cacheKey, body)
+	return cached.([]byte)
+}
+
 func uiETagMatches(headerValue, etag string) bool {
 	if headerValue == "" || etag == "" {
 		return false
@@ -135,11 +152,7 @@ func serveEmbeddedUIBytes(w http.ResponseWriter, r *http.Request, data []byte, c
 	body := data
 	if compressible {
 		if uiAcceptsGzip(r.Header.Get("Accept-Encoding")) {
-			var compressed bytes.Buffer
-			gz := gzip.NewWriter(&compressed)
-			_, _ = gz.Write(data)
-			_ = gz.Close()
-			body = compressed.Bytes()
+			body = uiGzipAsset(data)
 			header.Set("Content-Encoding", "gzip")
 		}
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -728,6 +728,32 @@ func TestHandleUI_StaticAssetCompressionAndConditionalCaching(t *testing.T) {
 	}
 }
 
+func TestUIGzipAssetCachesCompressedBodies(t *testing.T) {
+	body := []byte("body unique to gzip cache test body unique to gzip cache test")
+	first := uiGzipAsset(body)
+	second := uiGzipAsset(body)
+	if len(first) == 0 || len(second) == 0 {
+		t.Fatalf("expected compressed bodies")
+	}
+	if &first[0] != &second[0] {
+		t.Fatalf("expected second gzip call to reuse cached body")
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(first))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	decompressed, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("ReadAll gzip: %v", err)
+	}
+	if err := zr.Close(); err != nil {
+		t.Fatalf("Close gzip: %v", err)
+	}
+	if !bytes.Equal(decompressed, body) {
+		t.Fatalf("decompressed body mismatch")
+	}
+}
+
 func TestHandleUI_ServiceWorkerCompressionKeepsNoCache(t *testing.T) {
 	srv := &serveServer{cfg: serveServerConfig{ui: true, basePath: "/ui"}}
 


### PR DESCRIPTION
## What

- Caches gzip-compressed embedded UI asset bodies by the uncompressed body ETag.
- Reuses cached compressed bytes for repeated `Accept-Encoding: gzip` requests.
- Keeps existing cache-control, ETag, conditional request, and HEAD behavior unchanged.

## Why

The UI assets are embedded and versioned, but the server recompressed compressible assets on every request. That is wasted CPU for hot assets like `app.css`, `app-*.js`, `sw.js`, and the manifest.

The cache key is the content hash already used for ETags, so asset updates naturally get fresh compressed bodies.

## Tests

- `go test ./cmd`
- `go build ./... && go test ./...`
