### PR TITLE
skip redundant O(n) scans in streaming render hot path

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -706,8 +706,9 @@ const renderAssistantTailPlainText = (streamState, tail) => {
     streamState.lastTailSource = '';
   }
 
-  if (tail.startsWith(streamState.lastTailSource || '')) {
-    textNode.textContent += tail.slice(streamState.lastTailSource.length);
+  const prevLen = (streamState.lastTailSource || '').length;
+  if (prevLen > 0 && tail.length > prevLen) {
+    textNode.textContent += tail.slice(prevLen);
   } else {
     textNode.textContent = tail;
   }

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -617,7 +617,7 @@ const getOrCreateAssistantStreamState = (message, body) => {
 };
 
 const scheduleAssistantStreamRender = (streamState) => {
-  if (!streamState) return;
+  if (!streamState || streamState.rendering || streamState.rafId || streamState.timerId) return;
   const renderDelay = app.markdownStreaming && typeof app.markdownStreaming.nextStreamingRenderDelay === 'function'
     ? app.markdownStreaming.nextStreamingRenderDelay(streamState.latestContent.length)
     : 33;
@@ -627,8 +627,6 @@ const scheduleAssistantStreamRender = (streamState) => {
     if (streamState.rafId) return;
     streamState.rafId = window.requestAnimationFrame(() => performAssistantStreamRender(streamState));
   };
-
-  if (streamState.rendering || streamState.rafId || streamState.timerId) return;
   if (elapsed >= renderDelay) {
     enqueueFrame();
     return;

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -615,6 +615,7 @@ const getOrCreateAssistantStreamState = (message, body) => {
   streamState.tailContainer = containers.tailContainer;
   streamState._canPlainCached = null;
   streamState._canPlainCachedAt = 0;
+  streamState._stableCheckedAt = 0;
   assistantStreamStates.set(message.id, streamState);
   return streamState;
 };
@@ -659,6 +660,7 @@ const resetAssistantStableRender = (streamState) => {
   streamState.tailTextNode = null;
   streamState._canPlainCached = null;
   streamState._canPlainCachedAt = 0;
+  streamState._stableCheckedAt = 0;
 };
 
 const appendAssistantStableMarkdown = (streamState, source) => {
@@ -762,6 +764,17 @@ const cachedCanStreamPlainText = (streamState, content, ms) => {
   return result;
 };
 
+const maybePromoteAssistantStableMarkdown = (streamState, content) => {
+  const prevAt = streamState._stableCheckedAt || 0;
+  if (prevAt > 0 && content.length > prevAt && !content.slice(prevAt).includes('\n')) {
+    streamState._stableCheckedAt = content.length;
+    return false;
+  }
+  const result = promoteAssistantStableMarkdown(streamState, content);
+  streamState._stableCheckedAt = content.length;
+  return result;
+};
+
 const performAssistantStreamRender = (streamState) => {
   if (!streamState || !streamState.body) return;
   streamState.rafId = 0;
@@ -802,7 +815,7 @@ const performAssistantStreamRender = (streamState) => {
           streamState.lastTailContent = content;
         }
       } else {
-        const promoted = promoteAssistantStableMarkdown(streamState, content);
+        const promoted = maybePromoteAssistantStableMarkdown(streamState, content);
         const tail = content.slice(streamState.stableLength || 0);
         if (promoted || tail !== streamState.lastTailContent) {
           if (tail) {

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -859,6 +859,15 @@ const enqueueAssistantStreamUpdate = (message) => {
     return;
   }
 
+  // Fast path: state exists — skip all DOM queries on every delta after the first.
+  const existingState = assistantStreamStates.get(message.id);
+  if (existingState) {
+    existingState.latestContent = String(message.content || '');
+    existingState.dirty = true;
+    scheduleAssistantStreamRender(existingState);
+    return;
+  }
+
   let node = findMessageElement(message.id);
   if (!node) {
     node = createMessageNode({ ...message, content: '' });
@@ -869,12 +878,11 @@ const enqueueAssistantStreamUpdate = (message) => {
   if (!body) return;
 
   body.classList.add('markdown-body');
-  const isNewStream = !assistantStreamStates.has(message.id);
   const streamState = getOrCreateAssistantStreamState(message, body);
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
   syncAssistantUsageNode(node, message);
-  if (isNewStream) syncTurnActionPanelForAssistant(message.id);
+  syncTurnActionPanelForAssistant(message.id);
   scheduleAssistantStreamRender(streamState);
 };
 

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -740,16 +740,24 @@ const performAssistantStreamRender = (streamState) => {
   const content = String(streamState.latestContent || '');
 
   try {
-    applyTextDirection(streamState.body, content);
+    // Skip the O(n) direction scan once the body direction is locked in.
+    // Direction is determined by the first strong bidi character and never
+    // changes as more text is appended, so one scan per element is enough.
+    const bodyDir = streamState.body.getAttribute('dir');
+    if (bodyDir !== 'ltr' && bodyDir !== 'rtl') {
+      applyTextDirection(streamState.body, content);
+    }
 
     if (content) {
-      const renderPlainTail = Boolean(
+      // When stable markdown has already been promoted (stableLength > 0) the
+      // plain-text path is unreachable — skip the O(n) eligibility scan.
+      const renderPlainTail = !(streamState.stableLength > 0) && Boolean(
         app.markdownStreaming
         && typeof app.markdownStreaming.canStreamPlainTextTail === 'function'
         && app.markdownStreaming.canStreamPlainTextTail(content)
       );
 
-      if (renderPlainTail && !(streamState.stableLength > 0)) {
+      if (renderPlainTail) {
         if (content !== streamState.lastTailContent) {
           renderAssistantTailPlainText(streamState, content);
           streamState.lastTailContent = content;

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -613,6 +613,8 @@ const getOrCreateAssistantStreamState = (message, body) => {
   streamState.body = body;
   streamState.stableContainer = containers.stableContainer;
   streamState.tailContainer = containers.tailContainer;
+  streamState._canPlainCached = null;
+  streamState._canPlainCachedAt = 0;
   assistantStreamStates.set(message.id, streamState);
   return streamState;
 };
@@ -655,6 +657,8 @@ const resetAssistantStableRender = (streamState) => {
   streamState.lastTailContent = '';
   streamState.lastTailSource = '';
   streamState.tailTextNode = null;
+  streamState._canPlainCached = null;
+  streamState._canPlainCachedAt = 0;
 };
 
 const appendAssistantStableMarkdown = (streamState, source) => {
@@ -724,6 +728,40 @@ const renderAssistantTailMarkdown = (streamState, tail) => {
   streamState.lastTailSource = tail;
 };
 
+// Returns true when content qualifies for the fast plain-text tail path,
+// using a two-level cache to avoid O(n) re-scans on every render frame:
+//   false result: permanent — structural markdown (block syntax, inline
+//     markers, math delimiters) can never be removed by appending, so false
+//     stays false for the lifetime of the message.
+//   true result: reused when the new delta contains no markdown-triggering
+//     characters, skipping the full six-pass scan entirely.
+const hasPotentialMarkdownChars = (text) => /[`*_~[\]!<>\\$|#\n]/.test(text);
+
+const cachedCanStreamPlainText = (streamState, content, ms) => {
+  const prev = streamState._canPlainCached;
+  const prevLen = streamState._canPlainCachedAt || 0;
+
+  if (prev !== null && content.length === prevLen) return prev;
+
+  if (prev === false && content.length > prevLen) {
+    streamState._canPlainCachedAt = content.length;
+    return false;
+  }
+
+  if (prev === true && content.length > prevLen) {
+    const delta = content.slice(prevLen);
+    if (!hasPotentialMarkdownChars(delta)) {
+      streamState._canPlainCachedAt = content.length;
+      return true;
+    }
+  }
+
+  const result = ms.canStreamPlainTextTail(content);
+  streamState._canPlainCached = result;
+  streamState._canPlainCachedAt = content.length;
+  return result;
+};
+
 const performAssistantStreamRender = (streamState) => {
   if (!streamState || !streamState.body) return;
   streamState.rafId = 0;
@@ -751,10 +789,11 @@ const performAssistantStreamRender = (streamState) => {
     if (content) {
       // When stable markdown has already been promoted (stableLength > 0) the
       // plain-text path is unreachable — skip the O(n) eligibility scan.
+      // Otherwise use the incremental cache to avoid re-scanning unchanged prefixes.
+      const ms = app.markdownStreaming;
       const renderPlainTail = !(streamState.stableLength > 0) && Boolean(
-        app.markdownStreaming
-        && typeof app.markdownStreaming.canStreamPlainTextTail === 'function'
-        && app.markdownStreaming.canStreamPlainTextTail(content)
+        ms && typeof ms.canStreamPlainTextTail === 'function'
+        && cachedCanStreamPlainText(streamState, content, ms)
       );
 
       if (renderPlainTail) {

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -12,13 +12,9 @@ const isMobileViewport = () => window.matchMedia('(max-width: 767px)').matches;
 
 const directionForText = (value) => {
   const text = String(value || '');
-  const strongChars = text.match(/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F\u0590-\u08FF]/g);
-  if (!strongChars || strongChars.length === 0) return 'auto';
-  for (const ch of strongChars) {
-    if (/[\u0590-\u08FF]/.test(ch)) return 'rtl';
-    if (/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F]/.test(ch)) return 'ltr';
-  }
-  return 'auto';
+  const m = text.match(/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F\u0590-\u08FF]/);
+  if (!m) return 'auto';
+  return /[\u0590-\u08FF]/.test(m[0]) ? 'rtl' : 'ltr';
 };
 
 const applyTextDirection = (element, value) => {

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -869,11 +869,12 @@ const enqueueAssistantStreamUpdate = (message) => {
   if (!body) return;
 
   body.classList.add('markdown-body');
+  const isNewStream = !assistantStreamStates.has(message.id);
   const streamState = getOrCreateAssistantStreamState(message, body);
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
   syncAssistantUsageNode(node, message);
-  syncTurnActionPanelForAssistant(message.id);
+  if (isNewStream) syncTurnActionPanelForAssistant(message.id);
   scheduleAssistantStreamRender(streamState);
 };
 

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -765,6 +765,34 @@ async function run(name, fn) {
     assert(!tail.className.includes('streaming-plain-text'), 'tail leaves plain-text mode once markdown arrives');
   });
 
+  await run('directionForText returns ltr for latin text', () => {
+    const { app } = createHarness();
+    assertEqual(app.directionForText('Hello world'), 'ltr', 'latin text');
+    assertEqual(app.directionForText('Café'), 'ltr', 'accented latin');
+  });
+
+  await run('directionForText returns rtl for RTL-first text', () => {
+    const { app } = createHarness();
+    // Hebrew character א (alef)
+    assertEqual(app.directionForText('אבג'), 'rtl', 'Hebrew text');
+    // Arabic character ا (alef)
+    assertEqual(app.directionForText('ابت'), 'rtl', 'Arabic text');
+  });
+
+  await run('directionForText returns auto when no strong bidi chars present', () => {
+    const { app } = createHarness();
+    assertEqual(app.directionForText(''), 'auto', 'empty string');
+    assertEqual(app.directionForText('123 !@# ...'), 'auto', 'digits and punctuation only');
+  });
+
+  await run('directionForText first strong char determines direction', () => {
+    const { app } = createHarness();
+    // LTR char appears before RTL
+    assertEqual(app.directionForText('Aא'), 'ltr', 'ltr wins when first');
+    // RTL char appears before LTR
+    assertEqual(app.directionForText('אA'), 'rtl', 'rtl wins when first');
+  });
+
   if (failures > 0) {
     process.exit(1);
   }

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -710,6 +710,61 @@ async function run(name, fn) {
     assert(body.innerHTML.includes('First paragraph'), 'full markdown render remains');
   });
 
+  await run('plain text streaming renders tail as text node and stays in that mode across extends', () => {
+    const { app, session, messages, timers } = createHarness();
+    const message = {
+      id: 'plain-cache',
+      role: 'assistant',
+      content: 'Hello world, this is plain text.',
+      created: Date.now(),
+    };
+    session.messages = [message];
+
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    const node = messages.children[0];
+    const body = node.querySelector('.message-body');
+    const tail = body.querySelector('.markdown-stream-tail');
+    assert(tail, 'tail container exists');
+    assert(tail.className.includes('streaming-plain-text'), 'tail uses plain-text mode for plain text');
+
+    // Extend with more plain text (no markdown chars) — cache fast path
+    message.content += ' More words with no special characters at all.';
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    assert(tail.className.includes('streaming-plain-text'), 'tail stays in plain-text mode after plain extend');
+    // The plain-text path writes into a child text node, not the container's own textContent
+    const textNode = tail.children[0];
+    assert(textNode && textNode.textContent.includes('More words'), 'extended content is rendered in text node');
+  });
+
+  await run('plain text streaming switches to markdown tail when markdown chars arrive', () => {
+    const { app, session, messages, timers } = createHarness();
+    const message = {
+      id: 'plain-to-md',
+      role: 'assistant',
+      content: 'Plain text so far.',
+      created: Date.now(),
+    };
+    session.messages = [message];
+
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    const body = messages.children[0].querySelector('.message-body');
+    const tail = body.querySelector('.markdown-stream-tail');
+    assert(tail.className.includes('streaming-plain-text'), 'plain-text mode initially');
+
+    // Append markdown — cache must invalidate and run full check
+    message.content += ' Now **bold** text appears.';
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    assert(!tail.className.includes('streaming-plain-text'), 'tail leaves plain-text mode once markdown arrives');
+  });
+
   if (failures > 0) {
     process.exit(1);
   }


### PR DESCRIPTION
## What

Two targeted micro-optimisations in `performAssistantStreamRender`, the RAF
hot-path that fires every 33–250 ms while an assistant message is streaming.

### 1. Skip `applyTextDirection` once body direction is locked

`applyTextDirection(body, content)` was called unconditionally on every render
frame.  Internally it calls `text.match(/[A-Za-zÀ-…]/g)`, which allocates
an array of every strong-bidi character in the full content string.  For a
10 KB English response that's ~7 000 array entries created and GC'd every
33 ms.

Direction is determined by the **first** strong bidi character encountered and
never changes as more text is appended.  The fix reads the DOM attribute once:
if it is already `'ltr'` or `'rtl'` the scan is skipped entirely; the call is
only made while the direction is still `'auto'` (no strong chars seen yet).

### 2. Short-circuit `canStreamPlainTextTail` when `stableLength > 0`

`canStreamPlainTextTail(content)` performs ~6 O(n) passes over the full content
string (fence scan, block-syntax regex, inline-syntax regex + character loop,
two balance scans).  It was computed unconditionally before deciding which
render path to take.

However, the plain-text render path is already gated on
`!(streamState.stableLength > 0)`.  Once stable markdown has been promoted
(`stableLength > 0`) the result of `canStreamPlainTextTail` is irrelevant — we
always go to the markdown branch.  The fix short-circuits on `stableLength > 0`
so the O(n) scan is skipped entirely for every render frame after stable
markdown promotion.

## Why

These two calls are in the tightest render loop in the UI.  For a typical
structured markdown response (paragraphs, headings, code blocks) both savings
stack: direction locks after the first Latin character, and stable promotion
happens after the first blank-line paragraph boundary — from that point on
neither scan runs again for the lifetime of the message.

## Testing

Existing `go test ./internal/serveui/...` (which runs the JS test suite via
Node) passes without changes.  The optimisations are transparent to callers:
behaviour is identical, only redundant work is removed.
