### PR TITLE
perf: incremental sidebar render — reuse DOM nodes, skip no-op renders

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -135,6 +135,175 @@ document.addEventListener('click', (event) => {
   }
 });
 
+// ===== Incremental sidebar render =====
+// Caches keyed by session ID / group label so DOM nodes are reused across
+// renders instead of being destroyed and recreated on every call.
+const sidebarRowCache = new Map();
+const sidebarGroupCache = new Map();
+let sidebarRenderKey = '';
+
+const computeSidebarKey = (sorted) =>
+  sorted.map((s) =>
+    [
+      s.id, s.title, s.longTitle || '',
+      s.pinned ? 1 : 0, s.archived ? 1 : 0,
+      s.messageCount || s.messages.length || 0,
+      s.lastMessageAt || s.created,
+      sessionHasInProgressState(s) ? 1 : 0,
+      s.id === state.activeSessionId ? 1 : 0
+    ].join(':')
+  ).join('|');
+
+const getOrCreateGroupSection = (label) => {
+  if (sidebarGroupCache.has(label)) return sidebarGroupCache.get(label);
+  const section = document.createElement('section');
+  section.className = 'session-group';
+  const h3 = document.createElement('h3');
+  h3.textContent = label;
+  section.appendChild(h3);
+  sidebarGroupCache.set(label, section);
+  return section;
+};
+
+const buildCachedSessionRow = (session) => {
+  const row = document.createElement('div');
+  row.className = 'session-row';
+  row.dataset.sessionId = session.id;
+  row.classList.toggle('is-active', sessionHasInProgressState(session));
+
+  const btn = document.createElement('button');
+  btn.className = 'session-btn';
+  if (session.id === state.activeSessionId) btn.classList.add('active');
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'session-title';
+  titleEl.textContent = session.title || 'New chat';
+  if (session.longTitle) titleEl.title = session.longTitle;
+
+  const metaEl = document.createElement('div');
+  metaEl.className = 'session-meta';
+  const msgCount = session.messageCount || session.messages.filter(m => m.role !== 'tool-group').length || 0;
+  const metaParts = [`${msgCount} message${msgCount === 1 ? '' : 's'}`];
+  if (session.archived) metaParts.push('hidden');
+  const activityAt = session.lastMessageAt || session.created;
+  metaParts.push(relativeTime(activityAt));
+  metaEl.textContent = metaParts.join(' · ');
+  metaEl.title = fullDate(activityAt);
+
+  btn.appendChild(titleEl);
+  btn.appendChild(metaEl);
+  btn.addEventListener('click', async () => {
+    await app.switchToSession(session.id);
+  });
+
+  const menuWrap = document.createElement('div');
+  menuWrap.className = 'session-row-menu';
+
+  const actionBtn = document.createElement('button');
+  actionBtn.className = 'session-menu-trigger';
+  actionBtn.type = 'button';
+  actionBtn.textContent = '⋯';
+  actionBtn.title = 'Session actions';
+  actionBtn.setAttribute('aria-label', 'Session actions');
+  actionBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const willOpen = !row.classList.contains('menu-open');
+    closeAllSessionMenus();
+    row.classList.toggle('menu-open', willOpen);
+  });
+
+  const menu = document.createElement('div');
+  menu.className = 'session-menu';
+
+  const renameBtn = createSessionMenuButton('Rename', 'rename', async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    closeAllSessionMenus();
+    await app.promptRenameSession(session);
+  });
+
+  const pinBtn = createSessionMenuButton(
+    session.pinned ? 'Unpin' : 'Pin',
+    session.pinned ? 'unpin' : 'pin',
+    async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      closeAllSessionMenus();
+      await app.setSessionPinned(session, !session.pinned);
+    }
+  );
+  const pinIconEl = pinBtn.querySelector('.session-menu-icon');
+  const pinLabelEl = pinBtn.querySelector('.session-menu-label');
+
+  const archiveBtn = createSessionMenuButton(
+    session.archived ? 'Unhide' : 'Hide',
+    session.archived ? 'unhide' : 'hide',
+    async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      closeAllSessionMenus();
+      await app.setSessionArchived(session, !session.archived);
+    }
+  );
+  const archiveIconEl = archiveBtn.querySelector('.session-menu-icon');
+  const archiveLabelEl = archiveBtn.querySelector('.session-menu-label');
+
+  menu.appendChild(renameBtn);
+  menu.appendChild(pinBtn);
+  menu.appendChild(archiveBtn);
+  menuWrap.appendChild(actionBtn);
+  menuWrap.appendChild(menu);
+
+  row.appendChild(btn);
+  row.appendChild(menuWrap);
+
+  sidebarRowCache.set(session.id, {
+    row, btn, titleEl, metaEl,
+    pinIconEl, pinLabelEl,
+    archiveIconEl, archiveLabelEl,
+    prevPinned: session.pinned,
+    prevArchived: session.archived
+  });
+
+  return row;
+};
+
+const updateCachedSessionRow = (session, cached) => {
+  const { row, btn, titleEl, metaEl, pinIconEl, pinLabelEl, archiveIconEl, archiveLabelEl } = cached;
+
+  row.classList.toggle('is-active', sessionHasInProgressState(session));
+  btn.classList.toggle('active', session.id === state.activeSessionId);
+
+  const newTitle = session.title || 'New chat';
+  if (titleEl.textContent !== newTitle) titleEl.textContent = newTitle;
+  const newLongTitle = session.longTitle || '';
+  if (titleEl.title !== newLongTitle) titleEl.title = newLongTitle;
+
+  const msgCount = session.messageCount || session.messages.filter(m => m.role !== 'tool-group').length || 0;
+  const metaParts = [`${msgCount} message${msgCount === 1 ? '' : 's'}`];
+  if (session.archived) metaParts.push('hidden');
+  const activityAt = session.lastMessageAt || session.created;
+  metaParts.push(relativeTime(activityAt));
+  const newMeta = metaParts.join(' · ');
+  if (metaEl.textContent !== newMeta) {
+    metaEl.textContent = newMeta;
+    metaEl.title = fullDate(activityAt);
+  }
+
+  if (session.pinned !== cached.prevPinned) {
+    pinLabelEl.textContent = session.pinned ? 'Unpin' : 'Pin';
+    pinIconEl.innerHTML = SESSION_MENU_ICONS[session.pinned ? 'unpin' : 'pin'];
+    cached.prevPinned = session.pinned;
+  }
+
+  if (session.archived !== cached.prevArchived) {
+    archiveLabelEl.textContent = session.archived ? 'Unhide' : 'Hide';
+    archiveIconEl.innerHTML = SESSION_MENU_ICONS[session.archived ? 'unhide' : 'hide'];
+    cached.prevArchived = session.archived;
+  }
+};
+
 const renderSidebar = () => {
   const grouped = {
     Pinned: [],
@@ -157,112 +326,40 @@ const renderSidebar = () => {
     }
   });
 
-  const sidebarFrag = document.createDocumentFragment();
+  const key = computeSidebarKey(sorted);
+  if (key === sidebarRenderKey) return;
+  sidebarRenderKey = key;
+
+  const newGroupSections = [];
+  const visibleIds = new Set();
 
   Object.entries(grouped).forEach(([label, sessions]) => {
     if (!sessions.length) return;
 
-    const groupEl = document.createElement('section');
-    groupEl.className = 'session-group';
-
-    const heading = document.createElement('h3');
-    heading.textContent = label;
-    groupEl.appendChild(heading);
+    const groupEl = getOrCreateGroupSection(label);
+    // Detach all session rows from this group section, keeping only the h3 heading.
+    groupEl.replaceChildren(groupEl.firstElementChild);
 
     sessions.forEach((session) => {
-      const row = document.createElement('div');
-      row.className = 'session-row';
-      row.dataset.sessionId = session.id;
-      row.classList.toggle('is-active', sessionHasInProgressState(session));
-
-      const btn = document.createElement('button');
-      btn.className = 'session-btn';
-      if (session.id === state.activeSessionId) {
-        btn.classList.add('active');
+      visibleIds.add(session.id);
+      const cached = sidebarRowCache.get(session.id);
+      if (cached) {
+        updateCachedSessionRow(session, cached);
+        groupEl.appendChild(cached.row);
+      } else {
+        groupEl.appendChild(buildCachedSessionRow(session));
       }
-
-      const title = document.createElement('div');
-      title.className = 'session-title';
-      title.textContent = session.title || 'New chat';
-      if (session.longTitle) {
-        title.title = session.longTitle;
-      }
-
-      const meta = document.createElement('div');
-      meta.className = 'session-meta';
-      const msgCount = session.messageCount || session.messages.filter(m => m.role !== 'tool-group').length || 0;
-      const metaParts = [`${msgCount} message${msgCount === 1 ? '' : 's'}`];
-      if (session.archived) {
-        metaParts.push('hidden');
-      }
-      const activityAt = session.lastMessageAt || session.created;
-      metaParts.push(relativeTime(activityAt));
-      meta.textContent = metaParts.join(' · ');
-      meta.title = fullDate(activityAt);
-
-      btn.appendChild(title);
-      btn.appendChild(meta);
-      btn.addEventListener('click', async () => {
-        await app.switchToSession(session.id);
-      });
-
-      const menuWrap = document.createElement('div');
-      menuWrap.className = 'session-row-menu';
-
-      const actionBtn = document.createElement('button');
-      actionBtn.className = 'session-menu-trigger';
-      actionBtn.type = 'button';
-      actionBtn.textContent = '⋯';
-      actionBtn.title = 'Session actions';
-      actionBtn.setAttribute('aria-label', 'Session actions');
-      actionBtn.addEventListener('click', (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        const willOpen = !row.classList.contains('menu-open');
-        closeAllSessionMenus();
-        row.classList.toggle('menu-open', willOpen);
-      });
-
-      const menu = document.createElement('div');
-      menu.className = 'session-menu';
-
-      const renameBtn = createSessionMenuButton('Rename', 'rename', async (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        closeAllSessionMenus();
-        await app.promptRenameSession(session);
-      });
-
-      const pinBtn = createSessionMenuButton(session.pinned ? 'Unpin' : 'Pin', session.pinned ? 'unpin' : 'pin', async (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        closeAllSessionMenus();
-        await app.setSessionPinned(session, !session.pinned);
-      });
-
-      const archiveBtn = createSessionMenuButton(session.archived ? 'Unhide' : 'Hide', session.archived ? 'unhide' : 'hide', async (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        closeAllSessionMenus();
-        await app.setSessionArchived(session, !session.archived);
-      });
-
-      menu.appendChild(renameBtn);
-      menu.appendChild(pinBtn);
-      menu.appendChild(archiveBtn);
-      menuWrap.appendChild(actionBtn);
-      menuWrap.appendChild(menu);
-
-      row.appendChild(btn);
-      row.appendChild(menuWrap);
-      groupEl.appendChild(row);
     });
 
-    sidebarFrag.appendChild(groupEl);
+    newGroupSections.push(groupEl);
   });
 
-  elements.sessionGroups.innerHTML = '';
-  elements.sessionGroups.appendChild(sidebarFrag);
+  elements.sessionGroups.replaceChildren(...newGroupSections);
+
+  // Prune cache entries for sessions no longer visible.
+  for (const id of sidebarRowCache.keys()) {
+    if (!visibleIds.has(id)) sidebarRowCache.delete(id);
+  }
 };
 
 // ===== Message rendering =====

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1769,16 +1769,8 @@ const updateSidebarStatus = (statusSessions) => {
   let changed = false;
   let orderChanged = false;
 
-  // Build O(1) lookup maps once to avoid O(n) find and per-entry querySelector calls.
+  // Build O(1) lookup once to avoid O(n) find calls per status entry.
   const localById = new Map(state.sessions.map((s) => [s.id, s]));
-  const rowDataById = new Map();
-  elements.sessionGroups.querySelectorAll('.session-row[data-session-id]').forEach((row) => {
-    rowDataById.set(row.dataset.sessionId, {
-      row,
-      titleEl: row.querySelector('.session-title'),
-      metaEl: row.querySelector('.session-meta'),
-    });
-  });
 
   for (const entry of statusSessions) {
     const local = localById.get(entry.id) || null;
@@ -1798,23 +1790,22 @@ const updateSidebarStatus = (statusSessions) => {
       }
     }
 
-    const rowData = rowDataById.get(entry.id);
-    const row = rowData?.row;
-    if (row) {
-      row.classList.toggle('is-active', nextActive);
+    const cached = sidebarRowCache.get(entry.id);
+    if (cached) {
+      cached.row.classList.toggle('is-active', nextActive);
     }
     if (wasActive !== nextActive) changed = true;
 
-    if (!row) continue;
+    if (!cached) continue;
 
-    const { titleEl, metaEl } = rowData;
-    if (titleEl && entry.short_title && titleEl.textContent !== entry.short_title) {
+    const { titleEl, metaEl } = cached;
+    if (entry.short_title && titleEl.textContent !== entry.short_title) {
       titleEl.textContent = entry.short_title;
       if (entry.long_title) titleEl.title = entry.long_title;
       changed = true;
     }
 
-    if (metaEl && entry.message_count != null) {
+    if (entry.message_count != null) {
       const count = entry.message_count;
       if (local) {
         if (entry.short_title) local.title = entry.short_title;

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -108,10 +108,24 @@ class Element {
     }
   }
 
+  get firstElementChild() {
+    return this.children[0] || null;
+  }
+
   appendChild(child) {
+    if (child.parentNode) {
+      const idx = child.parentNode.children.indexOf(child);
+      if (idx !== -1) child.parentNode.children.splice(idx, 1);
+    }
     child.parentNode = this;
     this.children.push(child);
     return child;
+  }
+
+  replaceChildren(...nodes) {
+    this.children.forEach((child) => { child.parentNode = null; });
+    this.children = [];
+    nodes.forEach((node) => { if (node != null) this.appendChild(node); });
   }
 
   insertBefore(child, reference) {
@@ -249,7 +263,7 @@ function findByMessageId(root, id) {
   return null;
 }
 
-function createHarness() {
+function createHarness(appOverrides = {}) {
   const document = createDocument();
   const messages = new Element('div');
   document.body.appendChild(messages);
@@ -292,6 +306,7 @@ function createHarness() {
     sessionHasInProgressState() { return false; },
     setSessionServerActiveRun() {},
     openLightbox() {},
+    ...appOverrides,
   };
 
   const windowObj = {
@@ -807,6 +822,105 @@ async function run(name, fn) {
     for (const [text, expected, label] of cases) {
       assertEqual(app.directionForText(text), expected, label);
     }
+  });
+
+  await run('renderSidebar creates group sections and session rows', () => {
+    const sessions = [
+      { id: 'a', title: 'Alpha', created: 2000, messages: [], pinned: false, archived: false, messageCount: 3, lastMessageAt: 2000 },
+      { id: 'b', title: 'Beta',  created: 1000, messages: [], pinned: false, archived: false, messageCount: 1, lastMessageAt: 1000 },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+
+    app.renderSidebar();
+
+    const groups = app.elements.sessionGroups.children;
+    assertEqual(groups.length, 1, 'one group section');
+    const rows = groups[0].querySelectorAll('.session-row');
+    assertEqual(rows.length, 2, 'two session rows');
+    assertEqual(rows[0].querySelector('.session-title').textContent, 'Alpha', 'first row title');
+    assertEqual(rows[1].querySelector('.session-title').textContent, 'Beta', 'second row title');
+  });
+
+  await run('renderSidebar skips re-render when nothing changed', () => {
+    const session = { id: 'a', title: 'Alpha', created: 1000, messages: [], pinned: false, archived: false, messageCount: 2, lastMessageAt: 1000 };
+    const { app } = createHarness({ visibleSessions: () => [session] });
+
+    app.renderSidebar();
+    const rowBefore = app.elements.sessionGroups.children[0].querySelectorAll('.session-row')[0];
+
+    app.renderSidebar();
+    const rowAfter = app.elements.sessionGroups.children[0].querySelectorAll('.session-row')[0];
+
+    assert(rowBefore === rowAfter, 'identical fingerprint: no DOM change, same row node');
+  });
+
+  await run('renderSidebar updates title in-place, reusing the row DOM node', () => {
+    const session = { id: 'a', title: 'Before', created: 1000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 1000 };
+    const { app } = createHarness({ visibleSessions: () => [session] });
+
+    app.renderSidebar();
+    const rowBefore = app.elements.sessionGroups.children[0].querySelectorAll('.session-row')[0];
+
+    session.title = 'After';
+    app.renderSidebar();
+    const rowAfter = app.elements.sessionGroups.children[0].querySelectorAll('.session-row')[0];
+
+    assert(rowBefore === rowAfter, 'same row DOM node reused');
+    assertEqual(rowAfter.querySelector('.session-title').textContent, 'After', 'title updated in-place');
+  });
+
+  await run('renderSidebar updates active button class on session switch', () => {
+    const sessions = [
+      { id: 'a', title: 'A', created: 2000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 2000 },
+      { id: 'b', title: 'B', created: 1000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 1000 },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+    app.state.activeSessionId = 'a';
+
+    app.renderSidebar();
+
+    const rows = app.elements.sessionGroups.querySelectorAll('.session-row');
+    assert(rows[0].querySelector('.session-btn').classList.contains('active'), 'session A btn is active initially');
+    assert(!rows[1].querySelector('.session-btn').classList.contains('active'), 'session B btn is not active');
+
+    app.state.activeSessionId = 'b';
+    app.renderSidebar();
+
+    assert(!rows[0].querySelector('.session-btn').classList.contains('active'), 'session A btn no longer active');
+    assert(rows[1].querySelector('.session-btn').classList.contains('active'), 'session B btn now active');
+  });
+
+  await run('renderSidebar marks in-progress session row with is-active', () => {
+    const sessions = [
+      { id: 'a', title: 'A', created: 2000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 2000 },
+      { id: 'b', title: 'B', created: 1000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 1000 },
+    ];
+    const { app } = createHarness({
+      visibleSessions: () => sessions,
+      sessionHasInProgressState: (s) => s.id === 'a',
+    });
+
+    app.renderSidebar();
+    const rows = app.elements.sessionGroups.querySelectorAll('.session-row');
+    assert(rows[0].classList.contains('is-active'), 'in-progress row has is-active');
+    assert(!rows[1].classList.contains('is-active'), 'idle row does not have is-active');
+  });
+
+  await run('renderSidebar separates pinned sessions into their own group', () => {
+    const sessions = [
+      { id: 'p', title: 'Pinned', created: 1000, messages: [], pinned: true,  archived: false, messageCount: 0, lastMessageAt: 1000 },
+      { id: 'n', title: 'Normal', created: 900,  messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 900 },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+
+    app.renderSidebar();
+
+    const groups = app.elements.sessionGroups.children;
+    assertEqual(groups.length, 2, 'two groups: Pinned and Today');
+    assertEqual(groups[0].querySelector('h3').textContent, 'Pinned', 'first group is Pinned');
+    assertEqual(groups[1].querySelector('h3').textContent, 'Today', 'second group is Today');
+    assertEqual(groups[0].querySelectorAll('.session-row').length, 1, 'one pinned row');
+    assertEqual(groups[1].querySelectorAll('.session-row').length, 1, 'one today row');
   });
 
   if (failures > 0) {

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -923,6 +923,71 @@ async function run(name, fn) {
     assertEqual(groups[1].querySelectorAll('.session-row').length, 1, 'one today row');
   });
 
+  await run('updateSidebarStatus updates title and meta via cache', () => {
+    const session = { id: 'x', title: 'Old', created: 1000, messages: [], pinned: false, archived: false, messageCount: 1, lastMessageAt: 1000 };
+    const { app } = createHarness({ visibleSessions: () => [session] });
+    app.state.sessions = [session];
+
+    app.renderSidebar();
+
+    const result = app.updateSidebarStatus([{
+      id: 'x',
+      short_title: 'New Title',
+      long_title: 'Full new title',
+      message_count: 7,
+      active_run: false,
+    }]);
+
+    assert(result === true || result === false, 'updateSidebarStatus returns a boolean');
+    const rows = app.elements.sessionGroups.querySelectorAll('.session-row');
+    assertEqual(rows.length, 1, 'one row rendered');
+    const titleEl = rows[0].querySelector('.session-title');
+    assertEqual(titleEl.textContent, 'New Title', 'title updated from status');
+    assertEqual(titleEl.title, 'Full new title', 'long title set on title element');
+    const metaEl = rows[0].querySelector('.session-meta');
+    assert(metaEl.textContent.startsWith('7 messages'), 'meta shows updated message count');
+  });
+
+  await run('updateSidebarStatus toggles is-active class on cached row', () => {
+    const session = { id: 'y', title: 'Busy', created: 2000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 2000 };
+    let activeRun = false;
+    const { app } = createHarness({
+      visibleSessions: () => [session],
+      sessionHasInProgressState: () => activeRun,
+      setSessionServerActiveRun: (_target, val) => { activeRun = val; },
+    });
+    app.state.sessions = [session];
+
+    app.renderSidebar();
+    const row = app.elements.sessionGroups.querySelector('.session-row');
+    assert(!row.classList.contains('is-active'), 'not active before status update');
+
+    activeRun = false;
+    app.updateSidebarStatus([{ id: 'y', active_run: true }]);
+    assert(row.classList.contains('is-active'), 'row gains is-active when active_run is set');
+
+    app.updateSidebarStatus([{ id: 'y', active_run: false }]);
+    assert(!row.classList.contains('is-active'), 'row loses is-active when active_run cleared');
+  });
+
+  await run('updateSidebarStatus ignores sessions not in cache', () => {
+    const session = { id: 'z', title: 'Z', created: 3000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 3000 };
+    const { app } = createHarness({ visibleSessions: () => [session] });
+    app.state.sessions = [session];
+
+    app.renderSidebar();
+
+    let threw = false;
+    try {
+      app.updateSidebarStatus([{ id: 'unknown-id', short_title: 'Ghost', message_count: 99 }]);
+    } catch (_) {
+      threw = true;
+    }
+    assert(!threw, 'updateSidebarStatus must not throw for unknown session id');
+    const row = app.elements.sessionGroups.querySelector('.session-row');
+    assertEqual(row.querySelector('.session-title').textContent, 'Z', 'known session row unchanged');
+  });
+
   if (failures > 0) {
     process.exit(1);
   }


### PR DESCRIPTION
## What

Replace the full DOM teardown-and-rebuild in `renderSidebar` with an incremental approach that reuses existing DOM nodes across renders.

**New module-level caches in `app-render.js`:**
- `sidebarRowCache` — `Map<sessionId, refs>` holding the row element and named refs to mutable child nodes (title, meta, pin/archive icon+label spans)
- `sidebarGroupCache` — `Map<label, sectionElement>` for the five group `<section>` nodes
- `sidebarRenderKey` — fingerprint string; `renderSidebar` returns immediately when unchanged

**Per-render behaviour:**
- `computeSidebarKey` serialises every visible session's display-relevant fields (title, pinned, archived, messageCount, lastMessageAt, in-progress state, active flag) into a string; identical fingerprint → early return
- `buildCachedSessionRow` runs the same DOM construction as before but stores element refs in `sidebarRowCache`
- `updateCachedSessionRow` patches only changed fields with equality guards — `classList.toggle`, conditional `textContent` assignment, SVG icon swap for pin/archive label flips
- Group sections are cleared with `replaceChildren(heading)` then re-populated by appending rows from cache (or newly built); `elements.sessionGroups.replaceChildren(...sections)` finalises order

## Why

`renderSidebar` is called at every `response.completed`, `response.failed`, and snapshot event, on every session switch, and from `persistAndRefreshShell`. With ~100 sessions in the sidebar, each call previously created and discarded ~700 DOM nodes and bound ~500 event listeners. The fingerprint check also eliminates a redundant double-call that occurs in `applyServerSessionSnapshot` when the snapshot is for a background session (`renderSidebar()` directly, then again via `persistAndRefreshShell()`).

## Test changes

- Added `appOverrides` parameter to `createHarness` (spread last into the `app` object before VM runs — backward compatible, all existing tests unaffected)
- Added `firstElementChild` getter, `replaceChildren` method, and move-aware `appendChild` (removes from old parent first) to the test `Element` class
- 6 new `renderSidebar` test cases: initial render, fingerprint no-op skip, in-place title update with node identity check, active-class update on session switch, `is-active` class for in-progress sessions, Pinned/Today group separation
