### PR TITLE
perf: scope refreshRelativeTimes query to elements.messages

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1131,7 +1131,7 @@ const ensureActiveSession = () => {
 const findMessageElement = (id) => elements.messages.querySelector(`[data-message-id="${id}"]`);
 
 const refreshRelativeTimes = () => {
-  document.querySelectorAll('[data-created]').forEach((node) => {
+  elements.messages.querySelectorAll('[data-created]').forEach((node) => {
     const ts = Number(node.getAttribute('data-created'));
     if (!Number.isFinite(ts)) return;
     node.textContent = relativeTime(ts);

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -63,8 +63,8 @@ function makeNode() {
   };
 }
 
-function loadAppCore() {
-  const nodes = new Map();
+function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [] } = {}) {
+  const nodes = new Map(Object.entries(nodeOverrides));
   const document = {
     body: makeNode(),
     documentElement: makeNode(),
@@ -75,7 +75,7 @@ function loadAppCore() {
     },
     createElement() { return makeNode(); },
     querySelector() { return null; },
-    querySelectorAll() { return []; },
+    querySelectorAll: docQSTracker,
     addEventListener() {},
     removeEventListener() {},
   };
@@ -147,6 +147,10 @@ function loadAppCore() {
   return context.window.TermLLMApp;
 }
 
+function loadAppCore() {
+  return loadAppCoreWith();
+}
+
 const app = loadAppCore();
 
 (function testStripsDuplicateEffortSuffix() {
@@ -174,6 +178,51 @@ const app = loadAppCore();
   const result = app.splitHeaderModelEffort('foo_bar_medium', 'medium');
   if (result.model !== 'foo_bar' || result.effort !== 'medium') {
     fail(name, `got ${JSON.stringify(result)}`, 'want {"model":"foo_bar","effort":"medium"}');
+    return;
+  }
+  pass(name);
+})();
+
+(function testRefreshRelativeTimesUsesMessagesScope() {
+  const name = 'refreshRelativeTimes scopes query to elements.messages';
+
+  const ts = 1_700_000_000_000;
+  const timeNode = {
+    textContent: '',
+    title: '',
+    getAttribute(attr) { return attr === 'data-created' ? String(ts) : null; },
+  };
+
+  let messagesQueried = false;
+  let documentQueried = false;
+
+  const messagesEl = Object.assign(makeNode(), {
+    querySelectorAll(sel) {
+      if (sel === '[data-created]') { messagesQueried = true; return [timeNode]; }
+      return [];
+    },
+  });
+
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { messages: messagesEl },
+    docQSTracker(sel) {
+      if (sel === '[data-created]') documentQueried = true;
+      return [];
+    },
+  });
+
+  testApp.refreshRelativeTimes();
+
+  if (!messagesQueried) {
+    fail(name, 'elements.messages.querySelectorAll was not called with [data-created]');
+    return;
+  }
+  if (documentQueried) {
+    fail(name, 'document.querySelectorAll was consulted — query must be scoped to elements.messages');
+    return;
+  }
+  if (!timeNode.textContent) {
+    fail(name, 'time node textContent was not updated');
     return;
   }
   pass(name);


### PR DESCRIPTION
## What

Scope `refreshRelativeTimes` to query `elements.messages` instead of the entire `document`.

Before:
```js
document.querySelectorAll('[data-created]').forEach(...)
```
After:
```js
elements.messages.querySelectorAll('[data-created]').forEach(...)
```

## Why

`[data-created]` nodes are only ever created inside `elements.messages` (by `createMetaNode`). Searching the whole document is unnecessary work — it walks the entire DOM tree including the sidebar and everything else on the page.

This function is called on every `renderMessages` and also on a 60-second interval timer. Scoping the query to the messages container eliminates the unnecessary full-document walk.

## Test

Added a test in `app_core_test.js` that verifies `elements.messages.querySelectorAll` is invoked (not `document.querySelectorAll`) and that node timestamps are updated.
