### PR TITLE
perf: omit app-webrtc.js from page load when WebRTC is disabled

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -182,7 +182,11 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if assetName == "sw.js" {
-		serveEmbeddedUIBytes(w, r, serveui.RenderServiceWorker(), "text/javascript", "no-cache", true)
+		sw := serveui.RenderServiceWorker()
+		if s.webrtcHeadSnippet == "" {
+			sw = dropSWShellAssetContaining(sw, "app-webrtc.js")
+		}
+		serveEmbeddedUIBytes(w, r, sw, "text/javascript", "no-cache", true)
 		return
 	}
 	if assetName != "" && !strings.Contains(assetName, "..") {
@@ -210,6 +214,64 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 	serveEmbeddedUIBytes(w, r, s.renderIndexHTML(), "text/html; charset=utf-8", "no-cache, no-store, must-revalidate", false)
 }
 
+// dropScriptTagContaining removes the first <script> tag whose src attribute
+// contains needle from html. Used to omit app-webrtc.js when WebRTC is off.
+func dropScriptTagContaining(html []byte, needle string) []byte {
+	open := []byte(`<script src="`)
+	close := []byte(`</script>`)
+	for i := 0; i < len(html); {
+		j := bytes.Index(html[i:], open)
+		if j < 0 {
+			break
+		}
+		j += i
+		k := bytes.Index(html[j:], close)
+		if k < 0 {
+			break
+		}
+		end := j + k + len(close)
+		if bytes.Contains(html[j:end], []byte(needle)) {
+			// Also consume a trailing newline so we don't leave a blank line.
+			if end < len(html) && html[end] == '\n' {
+				end++
+			}
+			html = append(html[:j], html[end:]...)
+			return html
+		}
+		i = end
+	}
+	return html
+}
+
+// dropSWShellAssetContaining removes the first quoted entry in the service
+// worker's SHELL_ASSETS array whose value contains needle.
+func dropSWShellAssetContaining(sw []byte, needle string) []byte {
+	i := bytes.Index(sw, []byte(needle))
+	if i < 0 {
+		return sw
+	}
+	// Walk back to the opening quote of the entry.
+	start := i
+	for start > 0 && sw[start] != '\'' {
+		start--
+	}
+	// Walk forward to the closing quote + comma.
+	end := i + len(needle)
+	for end < len(sw) && sw[end] != '\'' {
+		end++
+	}
+	if end < len(sw) {
+		end++ // consume closing '
+	}
+	if end < len(sw) && sw[end] == ',' {
+		end++ // consume trailing comma
+	}
+	if end < len(sw) && sw[end] == '\n' {
+		end++ // consume trailing newline
+	}
+	return append(sw[:start], sw[end:]...)
+}
+
 func (s *serveServer) renderIndexHTML() []byte {
 	// Inject UI prefix so JS can prefix all API calls with it.
 	// Also inject VAPID public key for web push if configured.
@@ -231,7 +293,11 @@ func (s *serveServer) renderIndexHTML() []byte {
 		}
 	}
 	headSnippet += s.webrtcHeadSnippet
-	return serveui.RenderIndexHTML(s.cfg.basePath, headSnippet)
+	html := serveui.RenderIndexHTML(s.cfg.basePath, headSnippet)
+	if s.webrtcHeadSnippet == "" {
+		html = dropScriptTagContaining(html, "app-webrtc.js")
+	}
+	return html
 }
 
 func (s *serveServer) imageOutputDir() string {

--- a/cmd/serve_webrtc_test.go
+++ b/cmd/serve_webrtc_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"github.com/samsaffron/term-llm/internal/serveui"
 )
 
 // TestServeWebRTC_HeadSnippetAbsent verifies that renderIndexHTML does not
@@ -35,5 +37,72 @@ func TestServeWebRTC_InjectsHeadSnippet(t *testing.T) {
 	}
 	if !strings.Contains(html, "relay.example.com") {
 		t.Error("renderIndexHTML should contain the signaling URL when snippet is set")
+	}
+}
+
+func TestRenderIndexHTML_DropsWebRTCScriptWhenDisabled(t *testing.T) {
+	s := &serveServer{
+		cfg:               serveServerConfig{basePath: "/ui"},
+		webrtcHeadSnippet: "",
+	}
+	html := string(s.renderIndexHTML())
+	if strings.Contains(html, "app-webrtc.js") {
+		t.Error("renderIndexHTML should omit app-webrtc.js script tag when WebRTC is disabled")
+	}
+}
+
+func TestRenderIndexHTML_KeepsWebRTCScriptWhenEnabled(t *testing.T) {
+	snippet := `<script>window.__WEBRTC_ENABLED__=true;</script>`
+	s := &serveServer{
+		cfg:               serveServerConfig{basePath: "/ui"},
+		webrtcHeadSnippet: snippet,
+	}
+	html := string(s.renderIndexHTML())
+	if !strings.Contains(html, "app-webrtc.js") {
+		t.Error("renderIndexHTML should include app-webrtc.js script tag when WebRTC is enabled")
+	}
+}
+
+func TestDropScriptTagContaining(t *testing.T) {
+	html := []byte(`<body>
+  <script src="app-core.js?v=abc"></script>
+  <script src="app-webrtc.js?v=abc"></script>
+  <script src="app-sessions.js?v=abc"></script>
+</body>`)
+	got := dropScriptTagContaining(html, "app-webrtc.js")
+	if strings.Contains(string(got), "app-webrtc.js") {
+		t.Errorf("app-webrtc.js should have been removed, got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "app-core.js") {
+		t.Error("app-core.js should remain")
+	}
+	if !strings.Contains(string(got), "app-sessions.js") {
+		t.Error("app-sessions.js should remain")
+	}
+}
+
+func TestDropScriptTagContaining_NeedleAbsent(t *testing.T) {
+	html := []byte(`<body><script src="app-core.js"></script></body>`)
+	got := dropScriptTagContaining(html, "app-webrtc.js")
+	if string(got) != string(html) {
+		t.Errorf("html should be unchanged when needle absent")
+	}
+}
+
+func TestDropSWShellAssetContaining(t *testing.T) {
+	sw := serveui.RenderServiceWorker()
+	if !strings.Contains(string(sw), "app-webrtc.js") {
+		t.Fatal("RenderServiceWorker should contain app-webrtc.js entry")
+	}
+	stripped := dropSWShellAssetContaining(sw, "app-webrtc.js")
+	if strings.Contains(string(stripped), "app-webrtc.js") {
+		t.Error("app-webrtc.js should have been removed from SHELL_ASSETS")
+	}
+	// Other assets should remain intact.
+	if !strings.Contains(string(stripped), "app-core.js") {
+		t.Error("app-core.js should remain in SHELL_ASSETS")
+	}
+	if !strings.Contains(string(stripped), "app-sessions.js") {
+		t.Error("app-sessions.js should remain in SHELL_ASSETS")
 	}
 }


### PR DESCRIPTION
## What

Omit `app-webrtc.js` from the page and service worker when WebRTC is not enabled.

- Strip the `<script src="app-webrtc.js?v=...">` tag from the rendered `index.html`
- Remove `'./app-webrtc.js?v=...'` from the service worker's `SHELL_ASSETS` list

WebRTC-enabled deployments (`--webrtc` flag / `TERM_LLM_WEBRTC_*` env) are **unaffected** — the script tag is preserved and the SW still precaches the asset.

## Why

`app-webrtc.js` is 21 KB uncompressed (~6 KB gzip). It is an IIFE that checks `window.__WEBRTC_ENABLED__` at startup and exits immediately when the flag is absent. Without the flag the entire file is dead code: the browser fetches it, parses it, executes it — and nothing happens.

For the vast majority of deployments (no `--webrtc` flag), this saves:
- ~6 KB of network transfer per page load
- JS parse + execute time for 21 KB of unused code (~10–15 ms on mid-range devices)
- One network request during service worker install

## Tests

- `TestRenderIndexHTML_DropsWebRTCScriptWhenDisabled` — script tag absent when `webrtcHeadSnippet` is empty
- `TestRenderIndexHTML_KeepsWebRTCScriptWhenEnabled` — script tag present when snippet is set
- `TestDropScriptTagContaining` — helper removes correct tag, leaves others
- `TestDropScriptTagContaining_NeedleAbsent` — no-op when needle not found
- `TestDropSWShellAssetContaining` — removes webrtc entry from real rendered SW, other assets intact
