### PR TITLE
perf: replace O(n²) session.find loops with Map/Set lookups in status poll

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1595,8 +1595,9 @@ const updateSidebarStatus = (statusSessions) => {
   if (!Array.isArray(statusSessions)) return false;
   let changed = false;
   let orderChanged = false;
+  const localSessionMap = new Map(state.sessions.map((s) => [s.id, s]));
   for (const entry of statusSessions) {
-    const local = state.sessions.find((session) => session.id === entry.id) || null;
+    const local = localSessionMap.get(entry.id) || null;
     const busyTarget = local || entry.id;
     const wasActive = sessionHasInProgressState(busyTarget);
     setSessionServerActiveRun(busyTarget, Boolean(entry.active_run));

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -101,9 +101,8 @@ const pollSidebarStatus = async () => {
       if (Array.isArray(data.sessions)) {
         updateSidebarStatus(data.sessions);
         // Discover sessions created in other tabs/devices
-        const hasUnknown = data.sessions.some(
-          (entry) => !state.sessions.find((s) => s.id === entry.id)
-        );
+        const localIds = new Set(state.sessions.map((s) => s.id));
+        const hasUnknown = data.sessions.some((entry) => !localIds.has(entry.id));
         if (hasUnknown) mergeServerSessions();
       }
     }

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -710,6 +710,21 @@ async function run(name, fn) {
     assert(body.innerHTML.includes('First paragraph'), 'full markdown render remains');
   });
 
+  await run('updateSidebarStatus finds local session by id using Map lookup', () => {
+    const s1 = { id: 'aaa', title: 'A', created: 1000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 1000 };
+    const s2 = { id: 'bbb', title: 'B', created: 2000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 2000 };
+    const s3 = { id: 'ccc', title: 'C', created: 3000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 3000 };
+    const { app } = createHarness({ visibleSessions: () => [s1, s2, s3] });
+    app.state.sessions = [s1, s2, s3];
+
+    const result = app.updateSidebarStatus([{ id: 'bbb', last_message_at: 9999, active_run: false }]);
+
+    assert(result === true, 'returns true when order changed');
+    assertEqual(s2.lastMessageAt, 9999, 'lastMessageAt updated on the matched session');
+    assertEqual(s1.lastMessageAt, 1000, 'first session unchanged');
+    assertEqual(s3.lastMessageAt, 3000, 'third session unchanged');
+  });
+
   if (failures > 0) {
     process.exit(1);
   }


### PR DESCRIPTION
## What

Replace two O(n²) `Array.find` loops in the sidebar status poll hot path with O(n) `Map`/`Set` lookups.

**`app-render.js` — `updateSidebarStatus`:**
```js
// Before — O(n) find per entry × m entries = O(n·m) per poll tick
const local = state.sessions.find((session) => session.id === entry.id) || null;

// After — build Map once, then O(1) per entry
const localSessionMap = new Map(state.sessions.map((s) => [s.id, s]));
const local = localSessionMap.get(entry.id) || null;
```

**`app-sessions.js` — `pollSidebarStatus`:**
```js
// Before — O(n) find per entry × m entries
const hasUnknown = data.sessions.some(
  (entry) => !state.sessions.find((s) => s.id === entry.id)
);

// After — build Set once, then O(1) per entry
const localIds = new Set(state.sessions.map((s) => s.id));
const hasUnknown = data.sessions.some((entry) => !localIds.has(entry.id));
```

## Why

The sidebar status poll fires every **2 seconds** when any session has an active run. With 50+ sessions and 20+ status entries, the old code performed up to 1000+ comparisons per tick. The new code uses O(n + m) instead of O(n·m).
