### PR TITLE
perf: skip redundant turn action panel sync on streaming chunks after first placement

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -817,7 +817,10 @@ const enqueueAssistantStreamUpdate = (message) => {
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
   syncAssistantUsageNode(node, message);
-  syncTurnActionPanelForAssistant(message.id);
+  if (!streamState.turnPanelSynced) {
+    syncTurnActionPanelForAssistant(message.id);
+    if (String(message.content || '').trim()) streamState.turnPanelSynced = true;
+  }
   scheduleAssistantStreamRender(streamState);
 };
 


### PR DESCRIPTION
## What

Skip `syncTurnActionPanelForAssistant` on every streaming chunk after the turn action panel has been placed once.

```js
// Before — called on every SSE chunk (potentially 50+/sec)
syncTurnActionPanelForAssistant(message.id);

// After — called only until content is non-empty (once per streaming message)
if (!streamState.turnPanelSynced) {
  syncTurnActionPanelForAssistant(message.id);
  if (String(message.content || '').trim()) streamState.turnPanelSynced = true;
}
```

## Why

`syncTurnActionPanelForAssistant` runs O(n) work on every call: it scans backwards through the message array, walks turn boundaries, then calls `findMessageElement` (a DOM `querySelectorAll` walk) for each assistant message in the turn.

This function is called inside `enqueueAssistantStreamUpdate`, which runs synchronously on **every SSE streaming chunk** — completely bypassing the rAF rate-limiting used for the actual markdown render. During a fast LLM response this can fire 50+ times per second.

The panel position doesn't change after it's first placed on the streaming assistant node. All subsequent calls during the same response are pure redundant DOM work. The `turnPanelSynced` flag on `streamState` records that placement has happened, skipping all subsequent per-chunk syncs. `finalizeAssistantStreamRender` always re-syncs once at response end to ensure the final state is correct.

## Verification

Existing test `'stream updates only resync the affected turn action panel'` covers the key invariant: the panel is placed correctly on the first content chunk and remains on the correct node across all subsequent chunks.
