### PR TITLE
perf: replace [...arr].reverse().find() with arr.findLast() in stream handlers

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -419,7 +419,7 @@ const scheduleVisibleStreamScroll = (session) => {
 };
 
 const createResponseStreamState = (session) => {
-  let currentToolGroup = [...session.messages].reverse().find((message) => (
+  let currentToolGroup = session.messages.findLast((message) => (
     message.role === 'tool-group' && message.status === 'running'
   )) || null;
   let currentAssistantMessage = null;
@@ -610,7 +610,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
           ? null
           : tools.find((tool) => tool.outputIndex === outputIndex);
         const entry = exactEntry
-          || [...tools].reverse().find((tool) => tool.status !== 'done')
+          || tools.findLast((tool) => tool.status !== 'done')
           || tools[tools.length - 1];
         if (entry) {
           const current = String(entry.arguments || '');
@@ -753,7 +753,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     }
     updateSessionUsageDisplay(session);
 
-    const lastAssistant = [...session.messages].reverse().find((message) => message.role === 'assistant');
+    const lastAssistant = session.messages.findLast((message) => message.role === 'assistant');
     if (lastAssistant) {
       if (usage) lastAssistant.usage = usage;
       finalizeVisibleAssistantStreamRender(session, lastAssistant);
@@ -790,7 +790,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     setSessionOptimisticBusy(session, false);
     setSessionServerActiveRun(session, false);
 
-    const lastAssistant = [...session.messages].reverse().find((message) => message.role === 'assistant');
+    const lastAssistant = session.messages.findLast((message) => message.role === 'assistant');
     if (lastAssistant) finalizeVisibleAssistantStreamRender(session, lastAssistant);
     flushStreamPersistence();
     saveSessions();
@@ -3416,7 +3416,7 @@ const sendMessage = async (options = {}) => {
     }
 
     if (sendGeneration === state.streamGeneration) {
-      const lastAssistant = [...session.messages].reverse().find(m => m.role === 'assistant');
+      const lastAssistant = session.messages.findLast(m => m.role === 'assistant');
       if (lastAssistant) updateAssistantNode(lastAssistant);
       persistAndRefreshShell();
       scrollToBottom();
@@ -3436,7 +3436,7 @@ const sendMessage = async (options = {}) => {
       return;
     }
 
-    const lastAssistant = [...session.messages].reverse().find(m => m.role === 'assistant');
+    const lastAssistant = session.messages.findLast(m => m.role === 'assistant');
     if (lastAssistant) updateAssistantNode(lastAssistant);
 
     if (session.activeResponseId) {


### PR DESCRIPTION
Six call sites in `app-stream.js` were using the `[...arr].reverse().find()` pattern, which **copies the entire array before searching**. Replace with the native `Array.prototype.findLast` which searches in reverse without allocating a copy.

## Sites fixed

| Line | Array | Call frequency |
|------|-------|---------------|
| 613 | `tools` | **Hot path** — every `response.function_call_arguments.delta` event during tool streaming |
| 422 | `session.messages` | Once per stream start (`createResponseStreamState`) |
| 756 | `session.messages` | Once per `response.completed` |
| 793 | `session.messages` | Once per `response.failed` |
| 3419 | `session.messages` | Once per successful send |
| 3439 | `session.messages` | Once per send error |

## Compatibility

`Array.prototype.findLast` is available in Chrome 97+, Firefox 104+, Safari 15.4+ — global support >96% as of 2026. No polyfill needed.