### PR TITLE
perf: cache message node in streamState to skip DOM lookups per stream chunk

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -803,6 +803,16 @@ const enqueueAssistantStreamUpdate = (message) => {
     return;
   }
 
+  const existingState = assistantStreamStates.get(message.id);
+  if (existingState) {
+    existingState.latestContent = String(message.content || '');
+    existingState.dirty = true;
+    syncAssistantUsageNode(existingState.node, message);
+    syncTurnActionPanelForAssistant(message.id);
+    scheduleAssistantStreamRender(existingState);
+    return;
+  }
+
   let node = findMessageElement(message.id);
   if (!node) {
     node = createMessageNode({ ...message, content: '' });
@@ -814,6 +824,7 @@ const enqueueAssistantStreamUpdate = (message) => {
 
   body.classList.add('markdown-body');
   const streamState = getOrCreateAssistantStreamState(message, body);
+  streamState.node = node;
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
   syncAssistantUsageNode(node, message);

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -710,6 +710,24 @@ async function run(name, fn) {
     assert(body.innerHTML.includes('First paragraph'), 'full markdown render remains');
   });
 
+  await run('enqueueAssistantStreamUpdate reuses cached node on subsequent calls', () => {
+    const { app, session, messages } = createHarness();
+    const message = { id: 'cached-node', role: 'assistant', content: 'hello', created: Date.now() };
+    session.messages = [message];
+
+    app.enqueueAssistantStreamUpdate(message);
+    assertEqual(messages.children.length, 1, 'node created on first call');
+
+    // Remove node from DOM: old code would re-query (find null) and create a new node;
+    // new code uses existingState.node directly and adds nothing.
+    messages.children[0].remove();
+    assertEqual(messages.children.length, 0, 'node removed from messages');
+
+    message.content = 'hello world';
+    app.enqueueAssistantStreamUpdate(message);
+    assertEqual(messages.children.length, 0, 'fast path does not re-query or create a new node');
+  });
+
   if (failures > 0) {
     process.exit(1);
   }


### PR DESCRIPTION
## What

In `enqueueAssistantStreamUpdate`, add a fast path that skips two DOM lookups when `streamState` already exists for the message.

**Before:** every SSE streaming chunk called:
1. `findMessageElement(message.id)` — `querySelector('[data-message-id="..."]')` scan over the entire messages container
2. `node.querySelector('.message-body')` — child query on the found node

Both happen even though `assistantStreamStates` already holds all the information needed after the first chunk.

**After:** on the first chunk, `streamState.node` is stored alongside the existing `streamState.body`. On all subsequent chunks, the fast path reads `existingState.node` directly — no DOM queries.

## Why

`enqueueAssistantStreamUpdate` is called synchronously on every SSE delta chunk, outside the rAF rate-limiter. For a response with hundreds of chunks, this was hundreds of unnecessary DOM traversals. The fix eliminates both queries from every chunk after the first with no semantic change.
