### PR TITLE
perf: skip DOM update during tool argument streaming deltas

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -623,7 +623,6 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
           }
           if (!currentIsCompleteJSON) {
             entry.arguments = current + delta;
-            updateVisibleToolGroupNode(session, streamState.currentToolGroup);
             scheduleStreamPersistence();
           }
         }


### PR DESCRIPTION
## What

Remove `updateVisibleToolGroupNode` from the `response.function_call_arguments.delta` handler in `app-stream.js`.

## Why

During tool argument streaming, `updateToolGroupNode` was called on every delta chunk but produced zero visible changes:

- `formatToolArgs` calls `JSON.parse` on the arguments string. Partial JSON (mid-stream) throws — returning `null`. So `buildArgsNode` always returns `null` during streaming, meaning the args display never updates.
- `toolGroupSummaryText` returns the same string ("Running N tool(s)… (0/N done)") — the tool count and done count don't change during argument streaming.
- The status badge already shows "running…" and doesn't change.

The result was 7 DOM queries + a `JSON.parse` throw per delta, all writing nothing. For agentic sessions where a tool writes a large file (hundreds of argument deltas), this was hundreds of wasted DOM traversals.

The `response.output_item.done` event already calls `updateVisibleToolGroupNode` with the complete, valid arguments — so the args display updates correctly at completion.
