### PR TITLE
perf: cache rendered index HTML with sync.Once

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -947,6 +947,8 @@ type serveServer struct {
 	sessionToResponse sync.Map                // session_id (string) → latest response_id (string)
 	responseRunsOnce  sync.Once
 	responseRuns      *responseRunManager
+	indexHTMLOnce     sync.Once
+	indexHTMLBytes    []byte
 	webrtcHeadSnippet string // injected into index.html <head>; empty when WebRTC disabled
 	runtimeFactory    func(ctx context.Context, providerName string, model string) (*serveRuntime, error)
 	widgetsMgr        *widgets.Manager

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -211,27 +211,30 @@ func (s *serveServer) handleUI(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *serveServer) renderIndexHTML() []byte {
-	// Inject UI prefix so JS can prefix all API calls with it.
-	// Also inject VAPID public key for web push if configured.
-	var headSnippet string
-	escaped, _ := json.Marshal(s.cfg.basePath)
-	headSnippet += `<script>window.TERM_LLM_UI_PREFIX=` + string(escaped) + `;</script>`
-	versionEscaped, _ := json.Marshal(serveui.AssetVersion())
-	headSnippet += `<script>window.TERM_LLM_UI_VERSION=` + string(versionEscaped) + `;</script>`
-	sidebarSessions := s.cfg.sidebarSessions
-	if len(sidebarSessions) == 0 {
-		sidebarSessions = []string{"all"}
-	}
-	sidebarEscaped, _ := json.Marshal(sidebarSessions)
-	headSnippet += `<script>window.TERM_LLM_SIDEBAR_SESSIONS=` + string(sidebarEscaped) + `;</script>`
-	if s.cfgRef != nil {
-		if vapidKey := s.cfgRef.Serve.WebPush.VAPIDPublicKey; vapidKey != "" {
-			vapidEscaped, _ := json.Marshal(vapidKey)
-			headSnippet += `<script>window.TERM_LLM_VAPID_PUBLIC_KEY=` + string(vapidEscaped) + `;</script>`
+	s.indexHTMLOnce.Do(func() {
+		// Inject UI prefix so JS can prefix all API calls with it.
+		// Also inject VAPID public key for web push if configured.
+		var headSnippet string
+		escaped, _ := json.Marshal(s.cfg.basePath)
+		headSnippet += `<script>window.TERM_LLM_UI_PREFIX=` + string(escaped) + `;</script>`
+		versionEscaped, _ := json.Marshal(serveui.AssetVersion())
+		headSnippet += `<script>window.TERM_LLM_UI_VERSION=` + string(versionEscaped) + `;</script>`
+		sidebarSessions := s.cfg.sidebarSessions
+		if len(sidebarSessions) == 0 {
+			sidebarSessions = []string{"all"}
 		}
-	}
-	headSnippet += s.webrtcHeadSnippet
-	return serveui.RenderIndexHTML(s.cfg.basePath, headSnippet)
+		sidebarEscaped, _ := json.Marshal(sidebarSessions)
+		headSnippet += `<script>window.TERM_LLM_SIDEBAR_SESSIONS=` + string(sidebarEscaped) + `;</script>`
+		if s.cfgRef != nil {
+			if vapidKey := s.cfgRef.Serve.WebPush.VAPIDPublicKey; vapidKey != "" {
+				vapidEscaped, _ := json.Marshal(vapidKey)
+				headSnippet += `<script>window.TERM_LLM_VAPID_PUBLIC_KEY=` + string(vapidEscaped) + `;</script>`
+			}
+		}
+		headSnippet += s.webrtcHeadSnippet
+		s.indexHTMLBytes = serveui.RenderIndexHTML(s.cfg.basePath, headSnippet)
+	})
+	return s.indexHTMLBytes
 }
 
 func (s *serveServer) imageOutputDir() string {


### PR DESCRIPTION
## What

Wrap `renderIndexHTML()` in `sync.Once` so the rendered HTML is computed once and reused for every subsequent request.

## Why

`renderIndexHTML()` rebuilds the same ~19 KB byte slice on every page navigation:
- Marshals `basePath`, asset version, sidebar config, and optional VAPID/WebRTC snippets into JSON
- Runs a table of ~12 `bytes.ReplaceAll` calls over the 19 KB template to inject versioned asset URLs

All inputs are fixed at server startup:
- `cfg.basePath`, `cfg.sidebarSessions` — set once from flags/config
- `serveui.AssetVersion()` — already uses its own `sync.Once`
- `cfgRef.Serve.WebPush.VAPIDPublicKey`, `webrtcHeadSnippet` — set at startup

The output is therefore identical on every call. Caching it eliminates repeated string manipulation and allocations on every page load.

## Notes

Follows the same `xOnce`/`xField` pattern already used by `responseRunsOnce`/`responseRuns` in `serveServer`.
