### PR TITLE
perf: incremental renderMessages — skip full DOM rebuild on same-session message append

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1569,21 +1569,62 @@ const updateToolGroupNode = (message) => {
   }
 };
 
+let _lastRenderedSessionId = null;
+let _lastRenderedMessageIds = [];
+
 const renderMessages = (forceScroll = false) => {
   const session = ensureActiveSession();
   resetAssistantStreamRenders();
-  elements.messages.innerHTML = '';
 
-  if (!session || !session.messages.length) {
+  const sessionId = session ? session.id : null;
+  const messages = session ? session.messages : [];
+
+  if (!session || !messages.length) {
+    elements.messages.innerHTML = '';
     const empty = document.createElement('div');
     empty.className = 'empty-state';
     empty.textContent = 'How can I help you today?';
     elements.messages.appendChild(empty);
-  } else {
-    session.messages.forEach((message) => {
-      elements.messages.appendChild(createMessageNode(message));
-    });
+    _lastRenderedSessionId = sessionId;
+    _lastRenderedMessageIds = [];
+    syncTurnActionPanels();
+    refreshRelativeTimes();
+    scrollToBottom(forceScroll);
+    updateHeader();
+    return;
   }
+
+  // Fast path: same session, messages only appended at the end
+  if (sessionId === _lastRenderedSessionId && messages.length >= _lastRenderedMessageIds.length) {
+    let canAppend = true;
+    for (let i = 0; i < _lastRenderedMessageIds.length; i++) {
+      if (_lastRenderedMessageIds[i] !== messages[i].id) {
+        canAppend = false;
+        break;
+      }
+    }
+    if (canAppend) {
+      const emptyState = elements.messages.querySelector('.empty-state');
+      if (emptyState) emptyState.remove();
+      for (let i = _lastRenderedMessageIds.length; i < messages.length; i++) {
+        elements.messages.appendChild(createMessageNode(messages[i]));
+        _lastRenderedMessageIds.push(messages[i].id);
+      }
+      syncTurnActionPanels();
+      refreshRelativeTimes();
+      scrollToBottom(forceScroll);
+      updateHeader();
+      return;
+    }
+  }
+
+  // Full rebuild
+  elements.messages.innerHTML = '';
+  messages.forEach((message) => {
+    elements.messages.appendChild(createMessageNode(message));
+  });
+  _lastRenderedSessionId = sessionId;
+  _lastRenderedMessageIds = messages.map((m) => m.id);
 
   syncTurnActionPanels();
   refreshRelativeTimes();

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -710,6 +710,64 @@ async function run(name, fn) {
     assert(body.innerHTML.includes('First paragraph'), 'full markdown render remains');
   });
 
+  await run('renderMessages: incremental append reuses existing nodes', () => {
+    const { app, session, messages } = createHarness();
+    session.messages = [
+      { id: 'm1', role: 'user', content: 'hello', created: Date.now() },
+      { id: 'm2', role: 'assistant', content: 'hi', created: Date.now() },
+    ];
+    app.renderMessages();
+    assertEqual(messages.children.length, 2, 'two nodes after first render');
+    const firstNode = messages.children[0];
+
+    // Append a new message and re-render
+    session.messages.push({ id: 'm3', role: 'user', content: 'again', created: Date.now() });
+    app.renderMessages();
+    assertEqual(messages.children.length, 3, 'three nodes after incremental render');
+    assert(messages.children[0] === firstNode, 'first node is the same object (not recreated)');
+    assertEqual(messages.children[2].dataset.messageId, 'm3', 'new node has correct id');
+  });
+
+  await run('renderMessages: full rebuild on session switch', () => {
+    const { app, session, messages } = createHarness();
+    session.messages = [
+      { id: 'a1', role: 'user', content: 'first', created: Date.now() },
+    ];
+    app.renderMessages();
+    assertEqual(messages.children.length, 1, 'one node for session s1');
+    const originalNode = messages.children[0];
+
+    // Simulate switching sessions by mutating the session object the harness returns
+    session.id = 's2';
+    session.messages = [
+      { id: 'b1', role: 'user', content: 'other', created: Date.now() },
+    ];
+    app.renderMessages();
+    assertEqual(messages.children.length, 1, 'one node after session switch');
+    assert(messages.children[0] !== originalNode, 'node was recreated after session switch');
+    assertEqual(messages.children[0].dataset.messageId, 'b1', 'new session node has correct id');
+  });
+
+  await run('renderMessages: full rebuild when message list changes non-incrementally', () => {
+    const { app, session, messages } = createHarness();
+    session.messages = [
+      { id: 'x1', role: 'user', content: 'a', created: Date.now() },
+      { id: 'x2', role: 'assistant', content: 'b', created: Date.now() },
+    ];
+    app.renderMessages();
+    assertEqual(messages.children.length, 2, 'two nodes initially');
+    const firstNode = messages.children[0];
+
+    // Replace the messages (non-append: different IDs)
+    session.messages = [
+      { id: 'y1', role: 'user', content: 'new', created: Date.now() },
+    ];
+    app.renderMessages();
+    assertEqual(messages.children.length, 1, 'one node after non-incremental update');
+    assert(messages.children[0] !== firstNode, 'node was recreated');
+    assertEqual(messages.children[0].dataset.messageId, 'y1', 'rebuilt node has correct id');
+  });
+
   if (failures > 0) {
     process.exit(1);
   }


### PR DESCRIPTION
## What

`renderMessages` previously did `elements.messages.innerHTML = ''` followed by a full `createMessageNode` loop on every call — even when the active session hadn't changed and only new messages were appended.

This PR adds an incremental fast path: when `renderMessages` is called for the same session and the message list is a strict append of what was already rendered, it skips the teardown and only appends the new nodes.

Two module-level variables track state:
- `_lastRenderedSessionId` — the session ID of the most recent full or incremental render
- `_lastRenderedMessageIds` — the message IDs in render order

On each call the prefix of `session.messages` is compared against `_lastRenderedMessageIds`. If all previously-rendered IDs still match in order, only the tail is appended. Any other change (session switch, deletion, reorder, replacement) falls back to the full rebuild path.

## Why

`renderMessages` is called after every server sync that touches the active session. For a long session with 50+ messages, the old code would destroy and recreate all DOM nodes — including running `renderAssistantMarkdown` for every assistant message — even when only one new message arrived. The fast path makes this O(new messages) instead of O(all messages).

## Tests

Three new behavioral tests in `app_render_test.js`:
- Incremental append reuses the same node objects for existing messages
- Session switch forces a full rebuild
- Non-incremental change (deletion/reorder) forces a full rebuild
