### PR TITLE
perf: skip redundant array copy in sort callers and DOM query in stream handler

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1106,7 +1106,7 @@ const ensureActiveSession = () => {
     return active;
   }
 
-  const sorted = [...visibleSessions()].sort((a, b) => {
+  const sorted = visibleSessions().sort((a, b) => {
     if (Boolean(a.pinned) !== Boolean(b.pinned)) {
       return Number(Boolean(b.pinned)) - Number(Boolean(a.pinned));
     }

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -141,7 +141,7 @@ const renderSidebar = () => {
     Older: []
   };
 
-  const sorted = [...visibleSessions()].sort((a, b) => {
+  const sorted = visibleSessions().sort((a, b) => {
     const aAt = a.lastMessageAt || a.created;
     const bAt = b.lastMessageAt || b.created;
     return bAt - aAt;
@@ -816,7 +816,7 @@ const enqueueAssistantStreamUpdate = (message) => {
   const streamState = getOrCreateAssistantStreamState(message, body);
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
-  syncAssistantUsageNode(node, message);
+  if (message.usage) syncAssistantUsageNode(node, message);
   syncTurnActionPanelForAssistant(message.id);
   scheduleAssistantStreamRender(streamState);
 };


### PR DESCRIPTION
## What

Two small allocation/DOM-query eliminations in render hot paths:

**1. Skip redundant array copy in `visibleSessions().sort()` callers**

`visibleSessions()` is defined as `state.sessions.filter(...)`, which already returns a new array. Both callers wrapped it in `[...visibleSessions()]` before sorting, creating a second throwaway copy on every sidebar render. Changed to `visibleSessions().sort(...)` directly — `sort` mutates the new array from `filter`, not `state.sessions`.

**2. Guard `syncAssistantUsageNode` querySelector in streaming hot path**

`enqueueAssistantStreamUpdate` calls `syncAssistantUsageNode(node, message)` on every SSE text delta chunk. That function unconditionally calls `node.querySelector('.usage-line')` even when `message.usage` is null, which it always is during streaming (usage only arrives with the final response event). Added `if (message.usage)` guard at the call site to skip the querySelector entirely on the ~99% of chunks that carry no usage.

## Why

Both are zero-risk no-ops on the codepath where nothing changes. The querySelector guard is especially relevant since `enqueueAssistantStreamUpdate` is called synchronously on every streamed token.
