### PR TITLE
perf: fast path for response.output_text.delta SSE events

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -109,6 +110,67 @@ func (r *responseRun) appendEvent(event string, payload map[string]any) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.appendEventLocked(event, payload, false)
+}
+
+func (r *responseRun) appendTextDeltaEvent(outputIndex int, delta string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.appendTextDeltaEventLocked(outputIndex, delta)
+}
+
+// appendTextDeltaEventLocked is a fast path for response.output_text.delta that avoids
+// allocating a map[string]any and re-parsing it for recovery; called ~100x/sec during streaming.
+func (r *responseRun) appendTextDeltaEventLocked(outputIndex int, delta string) error {
+	r.lastSequenceNumber++
+
+	deltaJSON, err := json.Marshal(delta)
+	if err != nil {
+		return err
+	}
+	data := make([]byte, 0, 64+len(deltaJSON))
+	data = append(data, `{"output_index":`...)
+	data = strconv.AppendInt(data, int64(outputIndex), 10)
+	data = append(data, `,"delta":`...)
+	data = append(data, deltaJSON...)
+	data = append(data, `,"sequence_number":`...)
+	data = strconv.AppendInt(data, r.lastSequenceNumber, 10)
+	data = append(data, '}')
+
+	if delta != "" {
+		r.closeToolGroupLocked()
+		idx := r.ensureAssistantMessageLocked()
+		r.recoveryMessages[idx].Content += delta
+	}
+
+	stored := responseRunEvent{
+		Sequence: r.lastSequenceNumber,
+		Event:    "response.output_text.delta",
+		Data:     data,
+	}
+	r.events = append(r.events, stored)
+	r.compactEventsLocked()
+
+	for id, ch := range r.subscribers {
+		select {
+		case ch <- stored:
+			fill := len(ch)
+			threshold := cap(ch) * 3 / 4
+			if fill > threshold && !r.subscriberWarned[id] {
+				log.Printf("response run %s subscriber %d buffer at %d/%d", r.id, id, fill, cap(ch))
+				r.subscriberWarned[id] = true
+			} else if fill <= threshold/2 && r.subscriberWarned[id] {
+				r.subscriberWarned[id] = false
+			}
+		default:
+			log.Printf("response run %s subscriber fell behind at sequence %d; closing stream", r.id, stored.Sequence)
+			r.subscriberDropped[id] = true
+			close(ch)
+			delete(r.subscribers, id)
+			delete(r.subscriberWarned, id)
+		}
+	}
+
+	return nil
 }
 
 func (r *responseRun) complete(payload map[string]any, usage llm.Usage, sessionUsage llm.Usage) error {
@@ -808,13 +870,7 @@ func cloneJSONValue(value any) any {
 }
 
 func writeStoredResponseEvent(w io.Writer, ev responseRunEvent) error {
-	if _, err := fmt.Fprintf(w, "id: %d\n", ev.Sequence); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "event: %s\n", ev.Event); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(w, "data: %s\n\n", ev.Data)
+	_, err := fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", ev.Sequence, ev.Event, ev.Data)
 	return err
 }
 
@@ -834,10 +890,7 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 			}
 			state.toolsSeen = false
 		}
-		return run.appendEvent("response.output_text.delta", map[string]any{
-			"output_index": state.outputIndex,
-			"delta":        ev.Text,
-		})
+		return run.appendTextDeltaEvent(state.outputIndex, ev.Text)
 	case llm.EventToolCall:
 		if ev.Tool == nil {
 			return nil

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -123,15 +123,13 @@ func (r *responseRun) appendTextDeltaEvent(outputIndex int, delta string) error 
 func (r *responseRun) appendTextDeltaEventLocked(outputIndex int, delta string) error {
 	r.lastSequenceNumber++
 
-	deltaJSON, err := json.Marshal(delta)
-	if err != nil {
-		return err
-	}
-	data := make([]byte, 0, 64+len(deltaJSON))
+	// Build the JSON payload into a single allocation; appendJSONString avoids
+	// the extra []byte that json.Marshal(delta) would allocate.
+	data := make([]byte, 0, 80+len(delta))
 	data = append(data, `{"output_index":`...)
 	data = strconv.AppendInt(data, int64(outputIndex), 10)
 	data = append(data, `,"delta":`...)
-	data = append(data, deltaJSON...)
+	data = appendJSONString(data, delta)
 	data = append(data, `,"sequence_number":`...)
 	data = strconv.AppendInt(data, r.lastSequenceNumber, 10)
 	data = append(data, '}')
@@ -817,6 +815,40 @@ func usagePayload(usage llm.Usage) map[string]any {
 func stringValue(v any) string {
 	s, _ := v.(string)
 	return s
+}
+
+// appendJSONString appends a JSON-encoded string to dst without allocating a
+// separate []byte (unlike json.Marshal). Handles all characters that require
+// escaping in JSON strings; non-ASCII UTF-8 bytes pass through unchanged.
+func appendJSONString(dst []byte, s string) []byte {
+	const hexChars = "0123456789abcdef"
+	dst = append(dst, '"')
+	start := 0
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b >= 0x20 && b != '"' && b != '\\' {
+			continue
+		}
+		dst = append(dst, s[start:i]...)
+		start = i + 1
+		switch b {
+		case '"':
+			dst = append(dst, '\\', '"')
+		case '\\':
+			dst = append(dst, '\\', '\\')
+		case '\n':
+			dst = append(dst, '\\', 'n')
+		case '\r':
+			dst = append(dst, '\\', 'r')
+		case '\t':
+			dst = append(dst, '\\', 't')
+		default:
+			dst = append(dst, '\\', 'u', '0', '0', hexChars[b>>4], hexChars[b&0xf])
+		}
+	}
+	dst = append(dst, s[start:]...)
+	dst = append(dst, '"')
+	return dst
 }
 
 func mapValue(v any) map[string]any {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -34,7 +34,7 @@ type responseRunRecoveryTool struct {
 type responseRunRecoveryMessage struct {
 	ID       string
 	Role     string
-	Content  string
+	Content  []byte
 	Created  int64
 	Tools    []responseRunRecoveryTool
 	Expanded bool
@@ -139,7 +139,7 @@ func (r *responseRun) appendTextDeltaEventLocked(outputIndex int, delta string) 
 	if delta != "" {
 		r.closeToolGroupLocked()
 		idx := r.ensureAssistantMessageLocked()
-		r.recoveryMessages[idx].Content += delta
+		r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, delta...)
 	}
 
 	stored := responseRunEvent{
@@ -302,7 +302,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		}
 		r.closeToolGroupLocked()
 		idx := r.ensureAssistantMessageLocked()
-		r.recoveryMessages[idx].Content += delta
+		r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, delta...)
 	case "response.output_text.new_segment":
 		r.closeToolGroupLocked()
 		r.currentAssistant = -1
@@ -386,7 +386,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		}
 		idx := r.ensureAssistantMessageLocked()
 		for _, url := range images {
-			r.recoveryMessages[idx].Content += fmt.Sprintf("\n\n![Generated Image](%s)\n", url)
+			r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, fmt.Sprintf("\n\n![Generated Image](%s)\n", url)...)
 		}
 	case "response.completed":
 		r.closeToolGroupLocked()
@@ -413,7 +413,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		r.recoveryMessages = append(r.recoveryMessages, responseRunRecoveryMessage{
 			ID:      r.nextRecoveryMessageIDLocked("error"),
 			Role:    "error",
-			Content: message,
+			Content: []byte(message),
 			Created: time.Now().UnixMilli(),
 		})
 		r.currentAssistant = -1
@@ -552,8 +552,8 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 			"role":    msg.Role,
 			"created": msg.Created,
 		}
-		if msg.Content != "" {
-			entry["content"] = msg.Content
+		if len(msg.Content) > 0 {
+			entry["content"] = string(msg.Content)
 		}
 		if msg.Status != "" {
 			entry["status"] = msg.Status


### PR DESCRIPTION
## Summary

Two Go-side optimizations on the SSE streaming hot path, targeting the `response.output_text.delta` event that fires ~100x/sec during token streaming.

### 1. Eliminate `map[string]any` allocation in `appendTextDeltaEventLocked`

Previously, every text delta token required:
- Allocating `map[string]any{"output_index": ..., "delta": ev.Text}`
- Mutating it to add `"sequence_number"`
- `json.Marshal` of the whole map
- Passing the map to `applyRecoveryEventLocked` which re-reads `payload["delta"]`

Now a dedicated `appendTextDeltaEvent(outputIndex int, delta string)` method:
- Builds the JSON payload directly with `strconv.AppendInt` + `json.Marshal(delta)` into a single `[]byte`
- Inlines the recovery update (append delta to `recoveryMessages[idx].Content`) without re-parsing from a map
- Zero map allocations on the token hot path

### 2. Consolidate `writeStoredResponseEvent` from 3 → 1 `fmt.Fprintf` calls

Each SSE event replayed to a reconnecting client previously issued 3 separate `fmt.Fprintf` calls (one per SSE field). Now it's a single formatted write, cutting format-string parsing and potential write overhead by 3x for that path.

### Changes
- `cmd/serve_response_runs.go`: new `appendTextDeltaEvent` / `appendTextDeltaEventLocked` methods; simplified `writeStoredResponseEvent`; updated call site in `appendResponseRunEvent`