### PR TITLE
perf: start models fetch in parallel with providers fetch on startup

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -930,12 +930,27 @@ const initialize = async () => {
 
     const sessionsPromise = mergeServerSessions();
 
-    // Fetch providers first so we can validate the stored selection.
+    // Start a speculative models fetch immediately using the provider stored in
+    // localStorage. For returning users this runs in parallel with fetchProviders,
+    // saving one serial round trip. If normalizeSelectedProvider changes the
+    // selection we discard the speculative result and re-fetch.
+    const speculativeProvider = state.selectedProvider;
+    const speculativeModelsPromise = speculativeProvider
+      ? fetchModels('', speculativeProvider)
+      : null;
+
+    // Fetch providers to validate and normalize the stored selection.
     state.providers = await fetchProviders();
     normalizeSelectedProvider();
     renderProviderOptions();
 
-    const modelsPromise = fetchModels('', state.selectedProvider);
+    let modelsPromise;
+    if (speculativeModelsPromise !== null && state.selectedProvider === speculativeProvider) {
+      modelsPromise = speculativeModelsPromise;
+    } else {
+      if (speculativeModelsPromise !== null) speculativeModelsPromise.catch(() => {});
+      modelsPromise = fetchModels('', state.selectedProvider);
+    }
     setStartupStatus('Syncing sessions…');
 
     [state.models] = await Promise.all([modelsPromise, sessionsPromise]);

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1820,9 +1820,22 @@ const connectToken = async () => {
   elements.authError.textContent = '';
 
   try {
+    // Speculative models fetch in parallel with providers — same pattern as startup.
+    const speculativeProvider = state.selectedProvider;
+    const speculativeModelsPromise = speculativeProvider
+      ? fetchModels(token, speculativeProvider)
+      : null;
+
     state.providers = await fetchProviders(token);
     normalizeSelectedProvider();
-    const models = await fetchModels(token, state.selectedProvider);
+
+    let models;
+    if (speculativeModelsPromise !== null && state.selectedProvider === speculativeProvider) {
+      models = await speculativeModelsPromise;
+    } else {
+      if (speculativeModelsPromise !== null) speculativeModelsPromise.catch(() => {});
+      models = await fetchModels(token, state.selectedProvider);
+    }
     state.token = token;
     state.models = models;
     state.connected = true;


### PR DESCRIPTION
## What

On startup, kick off the `/v1/models` fetch immediately using the provider stored in `localStorage`, in parallel with the `/v1/providers` fetch. After providers arrive and `normalizeSelectedProvider()` runs, if the stored provider is still valid the speculative result is used directly. If the provider changed (rare: only when the stored selection is no longer in the server's provider list), the speculative promise is discarded and a fresh fetch is made.

## Why

The current startup sequence is serial:

```
sessions ─────────────────────────────────────────┐
providers ──────────────────┐                      │
                            normalise              │
                            models ─────────────┐  │
                                               await all
```

With this change, returning users (who have a stored provider) get:

```
sessions ──────────────────────────────────────────┐
providers ──────────────────┐                      │
models (speculative) ───────┤                      │
                            normalise              │
                            (reuse speculative) ─┐ │
                                               await all
```

The models fetch now overlaps with the providers fetch instead of waiting for it, cutting one full round-trip off the time-to-interactive for any user who has previously selected a provider.

The fallback is correct and safe: `normalizeSelectedProvider` only ever clears the selection — it never sets it to a different provider — so the comparison `state.selectedProvider === speculativeProvider` correctly detects when the speculative result is unusable.
