### PR TITLE
perf: O(1) session lookups in mergeServerSessions and early eviction skip

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -996,10 +996,10 @@ const loadSessions = () => {
 const MAX_CACHED_MESSAGE_SESSIONS = 10;
 
 const evictStaleSessionMessages = () => {
-  const sorted = [...state.sessions]
-    .filter(s => s.messages && s.messages.length > 0 && !s._serverOnly)
-    .sort((a, b) => b.created - a.created);
-  const keep = new Set(sorted.slice(0, MAX_CACHED_MESSAGE_SESSIONS).map(s => s.id));
+  const withMessages = state.sessions.filter(s => s.messages && s.messages.length > 0 && !s._serverOnly);
+  if (withMessages.length <= MAX_CACHED_MESSAGE_SESSIONS) return;
+  withMessages.sort((a, b) => b.created - a.created);
+  const keep = new Set(withMessages.slice(0, MAX_CACHED_MESSAGE_SESSIONS).map(s => s.id));
 
   for (const s of state.sessions) {
     if (!keep.has(s.id) && s.messages && s.messages.length > 0) {

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -604,19 +604,6 @@ const applyServerSessionSummary = (target, serverSession) => {
   return target;
 };
 
-const findMatchingServerSessionStub = (serverSession) => {
-  if (!serverSession) return null;
-
-  const exact = state.sessions.find((item) => item.id === serverSession.id) || null;
-  if (exact) return exact;
-
-  const num = Number(serverSession.number || 0);
-  if (num <= 0) return null;
-
-  return state.sessions.find((item) => Number(item.number || 0) === num
-    && /^\d+$/.test(item.id)) || null;
-};
-
 const reconcileServerSessionIdentity = (session, serverSession) => {
   if (!session || !serverSession) return session;
 
@@ -655,8 +642,18 @@ const mergeServerSessions = async (options = {}) => {
     const data = await resp.json();
     if (!Array.isArray(data.sessions)) return;
 
+    const localById = new Map(state.sessions.map(s => [s.id, s]));
+    const localByNumber = new Map(
+      state.sessions
+        .filter(s => Number(s.number) > 0 && /^\d+$/.test(s.id))
+        .map(s => [Number(s.number), s])
+    );
+
     for (const serverSession of data.sessions) {
-      let local = findMatchingServerSessionStub(serverSession);
+      const sNum = Number(serverSession.number || 0);
+      let local = localById.get(serverSession.id) ||
+        (sNum > 0 ? localByNumber.get(sNum) : null) ||
+        null;
       if (local) {
         reconcileServerSessionIdentity(local, serverSession);
         applyServerSessionSummary(local, serverSession);


### PR DESCRIPTION
## What

Two small optimizations to session state management:

**1. O(1) lookups in `mergeServerSessions`**

Previously, for each server session in the startup sync response, `findMatchingServerSessionStub` scanned `state.sessions` linearly — once by ID, and optionally again by session number. For a user with N local sessions and M server sessions, this is O(N×M).

This PR removes `findMatchingServerSessionStub` and builds two Maps from `state.sessions` once before the loop:
- `localById`: `Map<id, session>` for O(1) exact-ID lookup
- `localByNumber`: `Map<number, session>` for O(1) numeric-stub lookup (used for legacy TUI sessions)

The per-iteration match is now two Map.get calls.

**2. Early return in `evictStaleSessionMessages`**

`evictStaleSessionMessages` is called on every `saveSessions()`. It previously always ran a filter + sort + Set construction regardless of whether any eviction was needed.

Added an early return after the filter: if fewer than `MAX_CACHED_MESSAGE_SESSIONS` (10) sessions have messages loaded, nothing can be evicted and the sort and Set are skipped.

Also removed the redundant `[...state.sessions]` spread — `.filter()` already returns a new array.

## Why

`mergeServerSessions` runs on startup and whenever the status poll discovers unknown sessions. The O(N×M) cost matters at startup for users with many sessions. `evictStaleSessionMessages` runs on every save call (throttled to ~1/sec during streaming); the early return avoids unnecessary work in the common case where few sessions have messages loaded.
