### PR TITLE
fix: Smooth-buffered streaming still triggers one full Bubble Tea cycle per provider delta

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1629,11 +1629,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// Keep stream ingestion driven by provider output; smooth rendering is
-		// already coalesced behind m.smoothBuffer and m.smoothTickPending.
+		// When smooth text rendering is already pending, defer the next blocking
+		// provider read until that tick fires so bursty text deltas can coalesce
+		// behind a single Bubble Tea update/view pass.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			m.deferredStreamRead = false
-			cmds = append(cmds, m.listenForStreamEvents())
+			if ev.Type == ui.StreamEventText && m.smoothTickPending {
+				m.deferredStreamRead = true
+			} else {
+				cmds = append(cmds, m.listenForStreamEvents())
+			}
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -131,7 +130,7 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
+func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
 	model.streamChan = make(chan ui.StreamEvent)
@@ -143,17 +142,16 @@ func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if model.deferredStreamRead {
-		t.Fatal("expected next stream read to be re-armed immediately")
+	if !model.deferredStreamRead {
+		t.Fatal("expected next stream read to be deferred until the smooth tick")
 	}
 
-	msg := cmd()
-	batch, ok := msg.(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("expected smooth tick and stream read to be batched together, got %T", msg)
+	_, cmd = model.Update(ui.SmoothTickMsg{})
+	if model.deferredStreamRead {
+		t.Fatal("expected deferred stream read to clear after smooth tick")
 	}
-	if len(batch) != 2 {
-		t.Fatalf("expected exactly two follow-up commands (smooth tick + stream read), got %d", len(batch))
+	if cmd == nil {
+		t.Fatal("expected smooth tick to resume stream reading")
 	}
 }
 


### PR DESCRIPTION
## What

- defer the next blocking stream read when a text delta has already scheduled a smooth rendering tick
- let `ui.SmoothTickMsg` resume provider ingestion after releasing buffered words
- update the chat perf test to cover the deferred-read behavior

## Why

The chat TUI buffered text for smooth 60fps rendering, but it still immediately re-armed `listenForStreamEvents()` after every text delta. That kept forcing one Bubble Tea update/view cycle per provider chunk, defeating the intended coalescing path and causing unnecessary render churn under chatty providers. Deferring the next read until the pending smooth tick fires restores the intended batching and improves streaming/input responsiveness.
