### PR TITLE
fix: Chat smooth-buffer streaming still triggers a full Bubble Tea pass for every provider delta

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1629,11 +1629,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// Keep stream ingestion driven by provider output; smooth rendering is
-		// already coalesced behind m.smoothBuffer and m.smoothTickPending.
+		// When a smooth tick is already pending for streamed text, defer the next
+		// blocking stream read until that tick so Bubble Tea can coalesce provider
+		// deltas into frame-paced updates.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			m.deferredStreamRead = false
-			cmds = append(cmds, m.listenForStreamEvents())
+			if ev.Type == ui.StreamEventText && m.smoothTickPending {
+				m.deferredStreamRead = true
+			} else {
+				cmds = append(cmds, m.listenForStreamEvents())
+			}
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -131,7 +130,7 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
+func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
 	model.streamChan = make(chan ui.StreamEvent)
@@ -143,17 +142,16 @@ func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if model.deferredStreamRead {
-		t.Fatal("expected next stream read to be re-armed immediately")
+	if !model.deferredStreamRead {
+		t.Fatal("expected next stream read to be deferred until the smooth tick")
 	}
 
-	msg := cmd()
-	batch, ok := msg.(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("expected smooth tick and stream read to be batched together, got %T", msg)
+	_, cmd = model.Update(ui.SmoothTickMsg{})
+	if model.deferredStreamRead {
+		t.Fatal("expected deferred stream read to clear after smooth tick")
 	}
-	if len(batch) != 2 {
-		t.Fatalf("expected exactly two follow-up commands (smooth tick + stream read), got %d", len(batch))
+	if cmd == nil {
+		t.Fatal("expected smooth tick to resume stream reading")
 	}
 }
 


### PR DESCRIPTION
## What

Defer the next chat stream read when a smooth tick is already pending for streamed text, so provider deltas are drained on the smooth-buffer cadence instead of forcing a Bubble Tea update/render pass for every chunk.

Also update the chat regression test to assert the deferred-read behavior and that the smooth tick resumes stream consumption.

## Why

The chat model had smooth-buffer plumbing but still immediately re-armed `listenForStreamEvents()` for every non-terminal event. That bypassed the intended coalescing path, causing render storms and stream-channel backpressure under fast token streams. Deferring the blocking read until `ui.SmoothTickMsg` restores frame-paced batching, improving streaming smoothness and keeping input/scroll responsiveness closer to the ask command behavior.
