### PR TITLE
fix: Status-line token meter rescans the whole conversation on the render hot path

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -73,6 +73,11 @@ type Model struct {
 	// messages are produced. Written from engine callbacks; protected by
 	// contextEstimateMu.
 	contextEstimateMu                sync.Mutex
+	contextEstimateVersion           uint64
+	contextEstimateCachedVersion     uint64
+	contextEstimateCachedTokens      int
+	contextEstimateCachedStreaming   bool
+	contextEstimateCachedValid       bool
 	streamingContextMessages         []llm.Message
 	streamingContextPendingAssistant bool
 

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -921,7 +921,7 @@ func (m *Model) statusLineUsageParts() (string, string) {
 			contextTokens = m.engine.LastTotalTokens()
 		}
 		if contextTokens <= 0 {
-			contextTokens = m.engine.EstimateTokens(m.buildMessagesForContextEstimate())
+			contextTokens = m.estimateContextTokensCached()
 		}
 		limit := m.engine.InputLimit()
 		if contextTokens > 0 && limit > 0 {

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -26,10 +26,25 @@ func copyLLMMessages(messages []llm.Message) []llm.Message {
 	return copied
 }
 
+func (m *Model) invalidateContextEstimateCacheLocked() {
+	m.contextEstimateVersion++
+	m.contextEstimateCachedVersion = 0
+	m.contextEstimateCachedTokens = 0
+	m.contextEstimateCachedStreaming = false
+	m.contextEstimateCachedValid = false
+}
+
+func (m *Model) invalidateContextEstimateCache() {
+	m.contextEstimateMu.Lock()
+	m.invalidateContextEstimateCacheLocked()
+	m.contextEstimateMu.Unlock()
+}
+
 func (m *Model) setStreamingContextMessages(messages []llm.Message) {
 	m.contextEstimateMu.Lock()
 	m.streamingContextMessages = copyLLMMessages(messages)
 	m.streamingContextPendingAssistant = false
+	m.invalidateContextEstimateCacheLocked()
 	m.contextEstimateMu.Unlock()
 }
 
@@ -37,6 +52,7 @@ func (m *Model) clearStreamingContextMessages() {
 	m.contextEstimateMu.Lock()
 	m.streamingContextMessages = nil
 	m.streamingContextPendingAssistant = false
+	m.invalidateContextEstimateCacheLocked()
 	m.contextEstimateMu.Unlock()
 }
 
@@ -45,10 +61,12 @@ func (m *Model) updateStreamingContextAssistant(assistantMsg llm.Message) {
 	defer m.contextEstimateMu.Unlock()
 	if m.streamingContextPendingAssistant && len(m.streamingContextMessages) > 0 {
 		m.streamingContextMessages[len(m.streamingContextMessages)-1] = assistantMsg
+		m.invalidateContextEstimateCacheLocked()
 		return
 	}
 	m.streamingContextMessages = append(m.streamingContextMessages, assistantMsg)
 	m.streamingContextPendingAssistant = true
+	m.invalidateContextEstimateCacheLocked()
 }
 
 func (m *Model) appendStreamingContextTurnMessages(turnMessages []llm.Message) {
@@ -68,6 +86,7 @@ func (m *Model) appendStreamingContextTurnMessages(turnMessages []llm.Message) {
 		m.streamingContextMessages = append(m.streamingContextMessages, turnMessages[appendStart:]...)
 	}
 	m.streamingContextPendingAssistant = false
+	m.invalidateContextEstimateCacheLocked()
 }
 
 // clearStreamCallbacks detaches every engine callback wired in startStream
@@ -579,6 +598,55 @@ func (m *Model) buildMessagesForContextEstimate() []llm.Message {
 	return m.buildMessages()
 }
 
+func (m *Model) estimateContextTokensCached() int {
+	if m == nil || m.engine == nil {
+		return 0
+	}
+
+	m.contextEstimateMu.Lock()
+	version := m.contextEstimateVersion
+	if m.streaming && len(m.streamingContextMessages) > 0 {
+		if m.contextEstimateCachedValid && m.contextEstimateCachedVersion == version && m.contextEstimateCachedStreaming {
+			tokens := m.contextEstimateCachedTokens
+			m.contextEstimateMu.Unlock()
+			return tokens
+		}
+		messages := copyLLMMessages(m.streamingContextMessages)
+		m.contextEstimateMu.Unlock()
+
+		tokens := m.engine.EstimateTokens(messages)
+
+		m.contextEstimateMu.Lock()
+		if m.contextEstimateVersion == version && m.streaming && len(m.streamingContextMessages) > 0 {
+			m.contextEstimateCachedVersion = version
+			m.contextEstimateCachedTokens = tokens
+			m.contextEstimateCachedStreaming = true
+			m.contextEstimateCachedValid = true
+		}
+		m.contextEstimateMu.Unlock()
+		return tokens
+	}
+	if m.contextEstimateCachedValid && m.contextEstimateCachedVersion == version && !m.contextEstimateCachedStreaming {
+		tokens := m.contextEstimateCachedTokens
+		m.contextEstimateMu.Unlock()
+		return tokens
+	}
+	m.contextEstimateMu.Unlock()
+
+	messages := m.buildMessages()
+	tokens := m.engine.EstimateTokens(messages)
+
+	m.contextEstimateMu.Lock()
+	if m.contextEstimateVersion == version && !m.streaming {
+		m.contextEstimateCachedVersion = version
+		m.contextEstimateCachedTokens = tokens
+		m.contextEstimateCachedStreaming = false
+		m.contextEstimateCachedValid = true
+	}
+	m.contextEstimateMu.Unlock()
+	return tokens
+}
+
 func (m *Model) tickEvery() tea.Cmd {
 	return tea.Tick(1*time.Second, func(t time.Time) tea.Msg {
 		return tickMsg(t)
@@ -661,6 +729,7 @@ func (m *Model) invalidateViewCache() {
 	m.viewCache.lastWavePos = 0
 	m.viewCache.lastSetContentAt = time.Time{}
 	m.resetAltScreenStreamingAppendCache()
+	m.invalidateContextEstimateCache()
 	if m.chatRenderer != nil {
 		m.chatRenderer.InvalidateCache()
 	}
@@ -670,6 +739,7 @@ func (m *Model) invalidateViewCache() {
 func (m *Model) invalidateHistoryCache() {
 	m.viewCache.historyValid = false
 	m.resetAltScreenStreamingAppendCache()
+	m.invalidateContextEstimateCache()
 	if m.chatRenderer != nil {
 		m.chatRenderer.InvalidateCache()
 	}

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -54,6 +54,80 @@ func TestStatusLineContextEstimateUsesInProgressStreamingSnapshot(t *testing.T) 
 	}
 }
 
+func TestEstimateContextTokensCached_InvalidatesOnStreamingSnapshotChanges(t *testing.T) {
+	m := newTestChatModel(false)
+	m.engine.SetContextTracking(200_000)
+	m.streaming = true
+	m.setStreamingContextMessages([]llm.Message{llm.UserText("hello")})
+
+	baseline := m.estimateContextTokensCached()
+	if baseline <= 0 {
+		t.Fatalf("baseline cached estimate = %d, want > 0", baseline)
+	}
+	if !m.contextEstimateCachedValid {
+		t.Fatal("expected streaming estimate to populate cache")
+	}
+	version := m.contextEstimateVersion
+
+	m.updateStreamingContextAssistant(llm.AssistantText(strings.Repeat("expanding snapshot ", 1500)))
+	if m.contextEstimateCachedValid {
+		t.Fatal("expected streaming snapshot update to invalidate cached estimate")
+	}
+	if m.contextEstimateVersion <= version {
+		t.Fatalf("context estimate version = %d, want > %d after streaming snapshot update", m.contextEstimateVersion, version)
+	}
+
+	updated := m.estimateContextTokensCached()
+	if updated <= baseline {
+		t.Fatalf("updated cached estimate = %d, want > baseline %d", updated, baseline)
+	}
+	if !m.contextEstimateCachedValid {
+		t.Fatal("expected updated streaming estimate to repopulate cache")
+	}
+}
+
+func TestEstimateContextTokensCached_InvalidatesOnHistoryChanges(t *testing.T) {
+	m := newTestChatModel(false)
+	m.engine.SetContextTracking(200_000)
+	m.messages = []session.Message{{
+		Role:        llm.RoleUser,
+		TextContent: "hello",
+		Parts:       []llm.Part{{Type: llm.PartText, Text: "hello"}},
+	}}
+	m.invalidateHistoryCache()
+
+	baseline := m.estimateContextTokensCached()
+	if baseline <= 0 {
+		t.Fatalf("baseline cached estimate = %d, want > 0", baseline)
+	}
+	if !m.contextEstimateCachedValid {
+		t.Fatal("expected idle estimate to populate cache")
+	}
+	version := m.contextEstimateVersion
+
+	bigger := strings.Repeat("history growth ", 1200)
+	m.messages = append(m.messages, session.Message{
+		Role:        llm.RoleAssistant,
+		TextContent: bigger,
+		Parts:       []llm.Part{{Type: llm.PartText, Text: bigger}},
+	})
+	m.invalidateHistoryCache()
+	if m.contextEstimateCachedValid {
+		t.Fatal("expected history invalidation to clear cached estimate")
+	}
+	if m.contextEstimateVersion <= version {
+		t.Fatalf("context estimate version = %d, want > %d after history change", m.contextEstimateVersion, version)
+	}
+
+	updated := m.estimateContextTokensCached()
+	if updated <= baseline {
+		t.Fatalf("updated cached estimate = %d, want > baseline %d", updated, baseline)
+	}
+	if !m.contextEstimateCachedValid {
+		t.Fatal("expected updated idle estimate to repopulate cache")
+	}
+}
+
 func TestStreamingContextCallbacksUpdateEstimateSnapshotWithoutMutatingMessages(t *testing.T) {
 	m := newTestChatModel(false)
 	m.messages = []session.Message{{Role: llm.RoleUser, Parts: []llm.Part{{Type: llm.PartText, Text: "base"}}, TextContent: "base"}}


### PR DESCRIPTION
## What

- cache the status-line fallback context-token estimate instead of recomputing it on every footer render
- invalidate that cache when conversation history changes or the in-progress streaming snapshot is updated
- add focused tests covering cache invalidation for both idle history changes and streaming snapshot changes

## Why

`renderStatusLine()` runs on hot-path repaints during streaming, typing, spinner ticks, and smooth render ticks. When cached usage was unavailable, it rescanned the full conversation via `EstimateTokens(m.buildMessagesForContextEstimate())` every time, including copying `streamingContextMessages` and rewalking large tool payloads. Caching the fallback estimate removes that O(total conversation size) work from repeated footer redraws while still updating promptly when the underlying context actually changes.
