### PR TITLE
fix: Status-line token estimation rescans the whole conversation on the render hot path

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -75,6 +75,7 @@ type Model struct {
 	contextEstimateMu                sync.Mutex
 	streamingContextMessages         []llm.Message
 	streamingContextPendingAssistant bool
+	streamingContextTokenEstimate    int
 
 	// Streaming channels
 	streamChan <-chan ui.StreamEvent

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -917,7 +917,9 @@ func (m *Model) statusLineUsageParts() (string, string) {
 	usageBase := ""
 	if m.engine != nil && m.engine.InputLimit() > 0 {
 		contextTokens := 0
-		if !m.streaming {
+		if m.streaming {
+			contextTokens = m.streamingContextEstimate()
+		} else {
 			contextTokens = m.engine.LastTotalTokens()
 		}
 		if contextTokens <= 0 {

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -26,10 +26,25 @@ func copyLLMMessages(messages []llm.Message) []llm.Message {
 	return copied
 }
 
+func (m *Model) refreshStreamingContextEstimateLocked() {
+	if m.engine == nil || len(m.streamingContextMessages) == 0 {
+		m.streamingContextTokenEstimate = 0
+		return
+	}
+	m.streamingContextTokenEstimate = m.engine.EstimateTokens(m.streamingContextMessages)
+}
+
+func (m *Model) streamingContextEstimate() int {
+	m.contextEstimateMu.Lock()
+	defer m.contextEstimateMu.Unlock()
+	return m.streamingContextTokenEstimate
+}
+
 func (m *Model) setStreamingContextMessages(messages []llm.Message) {
 	m.contextEstimateMu.Lock()
 	m.streamingContextMessages = copyLLMMessages(messages)
 	m.streamingContextPendingAssistant = false
+	m.refreshStreamingContextEstimateLocked()
 	m.contextEstimateMu.Unlock()
 }
 
@@ -37,6 +52,7 @@ func (m *Model) clearStreamingContextMessages() {
 	m.contextEstimateMu.Lock()
 	m.streamingContextMessages = nil
 	m.streamingContextPendingAssistant = false
+	m.streamingContextTokenEstimate = 0
 	m.contextEstimateMu.Unlock()
 }
 
@@ -45,10 +61,12 @@ func (m *Model) updateStreamingContextAssistant(assistantMsg llm.Message) {
 	defer m.contextEstimateMu.Unlock()
 	if m.streamingContextPendingAssistant && len(m.streamingContextMessages) > 0 {
 		m.streamingContextMessages[len(m.streamingContextMessages)-1] = assistantMsg
+		m.refreshStreamingContextEstimateLocked()
 		return
 	}
 	m.streamingContextMessages = append(m.streamingContextMessages, assistantMsg)
 	m.streamingContextPendingAssistant = true
+	m.refreshStreamingContextEstimateLocked()
 }
 
 func (m *Model) appendStreamingContextTurnMessages(turnMessages []llm.Message) {
@@ -68,6 +86,7 @@ func (m *Model) appendStreamingContextTurnMessages(turnMessages []llm.Message) {
 		m.streamingContextMessages = append(m.streamingContextMessages, turnMessages[appendStart:]...)
 	}
 	m.streamingContextPendingAssistant = false
+	m.refreshStreamingContextEstimateLocked()
 }
 
 // clearStreamCallbacks detaches every engine callback wired in startStream

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -46,11 +46,33 @@ func TestStatusLineContextEstimateUsesInProgressStreamingSnapshot(t *testing.T) 
 	if inProgress <= baseline {
 		t.Fatalf("in-progress estimate = %d, want > baseline %d", inProgress, baseline)
 	}
+	if got := m.streamingContextEstimate(); got != inProgress {
+		t.Fatalf("cached streaming estimate = %d, want %d", got, inProgress)
+	}
 
 	status := ui.StripANSI(m.renderStatusLine())
 	wantUsage := "~" + llm.FormatTokenCount(inProgress) + "/" + llm.FormatTokenCount(m.engine.InputLimit())
 	if !strings.Contains(status, wantUsage) {
 		t.Fatalf("status line %q does not contain updated usage %q", status, wantUsage)
+	}
+}
+
+func TestStatusLineUsageParts_StreamingUsesCachedEstimate(t *testing.T) {
+	m := newTestChatModel(false)
+	m.providerName = "openai"
+	m.modelName = "gpt-5"
+	m.engine.ConfigureContextManagement(m.provider, m.providerName, m.modelName, false)
+	m.streaming = true
+	m.setStreamingContextMessages([]llm.Message{llm.UserText("hello")})
+
+	m.contextEstimateMu.Lock()
+	m.streamingContextTokenEstimate = 25_000
+	m.contextEstimateMu.Unlock()
+
+	usageLong, usageShort := m.statusLineUsageParts()
+	want := "~" + llm.FormatTokenCount(25_000) + "/" + llm.FormatTokenCount(m.engine.InputLimit())
+	if usageLong != want || usageShort != want {
+		t.Fatalf("usage parts = %q / %q, want %q", usageLong, usageShort, want)
 	}
 }
 
@@ -60,9 +82,15 @@ func TestStreamingContextCallbacksUpdateEstimateSnapshotWithoutMutatingMessages(
 	baseMessages := []llm.Message{llm.UserText("base")}
 	m.streaming = true
 	m.setStreamingContextMessages(baseMessages)
+	baseEstimate := m.streamingContextEstimate()
 
 	m.updateStreamingContextAssistant(llm.AssistantText("I'll inspect that."))
 	m.updateStreamingContextAssistant(llm.AssistantText("I'll inspect that now."))
+	assistantEstimate := m.streamingContextEstimate()
+	if assistantEstimate <= baseEstimate {
+		t.Fatalf("assistant estimate = %d, want > base estimate %d", assistantEstimate, baseEstimate)
+	}
+
 	m.appendStreamingContextTurnMessages([]llm.Message{
 		llm.AssistantText("I'll inspect that now."),
 		llm.ToolResultMessage("call-1", "read_file", "file contents", nil),
@@ -74,6 +102,10 @@ func TestStreamingContextCallbacksUpdateEstimateSnapshotWithoutMutatingMessages(
 	}
 	if got[1].Role != llm.RoleAssistant || got[2].Role != llm.RoleTool {
 		t.Fatalf("context estimate roles = %v, %v; want assistant, tool", got[1].Role, got[2].Role)
+	}
+	toolEstimate := m.streamingContextEstimate()
+	if toolEstimate <= assistantEstimate {
+		t.Fatalf("tool estimate = %d, want > assistant estimate %d", toolEstimate, assistantEstimate)
 	}
 	if len(m.messages) != 1 {
 		t.Fatalf("m.messages was mutated; len = %d, want 1", len(m.messages))


### PR DESCRIPTION
## What

Cache the streaming status-line context-token estimate in the chat model instead of recomputing it from the full conversation on every render.

- store the latest streaming context estimate alongside the in-progress streaming snapshot
- refresh that cached estimate only when the streaming snapshot changes (stream start, assistant snapshot updates, and completed turn/tool-result appends)
- have `statusLineUsageParts()` read the cached estimate while streaming, with the existing heuristic fallback preserved for non-streaming / unseeded cases
- add regression coverage for cached streaming estimates and cache refreshes

## Why

`renderStatusLine()` runs on the TUI render hot path, including spinner ticks, smooth ticks, wave ticks, and keypresses. During streaming it was calling `EstimateTokens(buildMessagesForContextEstimate())`, which copied and rescanned the entire conversation just to repaint the footer. In long sessions that turns every redraw into O(total transcript size) work and makes streaming/scroll/input feel progressively worse.

By shifting that work to the much less frequent snapshot-update path, the footer stays accurate while avoiding repeated whole-conversation rescans during rendering.
