### PR TITLE
fix: Chat smooth-buffer streaming still processes one Bubble Tea cycle per incoming stream event

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1629,11 +1629,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// Keep stream ingestion driven by provider output; smooth rendering is
-		// already coalesced behind m.smoothBuffer and m.smoothTickPending.
+		// When smooth rendering is already pending for a text chunk, defer the
+		// next blocking stream read until after that frame so chatty providers
+		// don't force a full Bubble Tea update/view cycle per token.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			m.deferredStreamRead = false
-			cmds = append(cmds, m.listenForStreamEvents())
+			if ev.Type == ui.StreamEventText && m.smoothTickPending {
+				m.deferredStreamRead = true
+			} else {
+				cmds = append(cmds, m.listenForStreamEvents())
+			}
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -131,7 +130,7 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
+func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
 	model.streamChan = make(chan ui.StreamEvent)
@@ -143,17 +142,16 @@ func TestModelKeepsStreamReadsAheadOfSmoothTick(t *testing.T) {
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if model.deferredStreamRead {
-		t.Fatal("expected next stream read to be re-armed immediately")
+	if !model.deferredStreamRead {
+		t.Fatal("expected next stream read to be deferred until the smooth tick")
 	}
 
-	msg := cmd()
-	batch, ok := msg.(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("expected smooth tick and stream read to be batched together, got %T", msg)
+	_, cmd = model.Update(ui.SmoothTickMsg{})
+	if model.deferredStreamRead {
+		t.Fatal("expected deferred stream read to clear after smooth tick")
 	}
-	if len(batch) != 2 {
-		t.Fatalf("expected exactly two follow-up commands (smooth tick + stream read), got %d", len(batch))
+	if cmd == nil {
+		t.Fatal("expected smooth tick to resume stream reading")
 	}
 }
 


### PR DESCRIPTION
## What

- defer the next chat stream read when a text event has already scheduled a smooth render tick
- let `ui.SmoothTickMsg` resume the blocked stream read after the frame, matching the existing ask-mode behavior
- update the chat regression test to cover deferred stream reads instead of immediate re-arming

## Why

Chat buffered streamed text into `m.smoothBuffer`, but still re-armed `listenForStreamEvents()` after every non-terminal event. Under chatty providers that meant each token chunk still forced a full Bubble Tea update/view cycle and kept the stream channel hot, which caused redraw storms, extra backpressure, and worse typing/scrolling smoothness. Deferring the next read until the pending smooth tick coalesces those render passes without broad refactoring.
