### PR TITLE
perf: replace per-entry find and querySelector in updateSidebarStatus with upfront Maps

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1595,8 +1595,20 @@ const updateSidebarStatus = (statusSessions) => {
   if (!Array.isArray(statusSessions)) return false;
   let changed = false;
   let orderChanged = false;
+
+  // Build O(1) lookup maps once to avoid O(n) find and per-entry querySelector calls.
+  const localById = new Map(state.sessions.map((s) => [s.id, s]));
+  const rowDataById = new Map();
+  elements.sessionGroups.querySelectorAll('.session-row[data-session-id]').forEach((row) => {
+    rowDataById.set(row.dataset.sessionId, {
+      row,
+      titleEl: row.querySelector('.session-title'),
+      metaEl: row.querySelector('.session-meta'),
+    });
+  });
+
   for (const entry of statusSessions) {
-    const local = state.sessions.find((session) => session.id === entry.id) || null;
+    const local = localById.get(entry.id) || null;
     const busyTarget = local || entry.id;
     const wasActive = sessionHasInProgressState(busyTarget);
     setSessionServerActiveRun(busyTarget, Boolean(entry.active_run));
@@ -1613,7 +1625,8 @@ const updateSidebarStatus = (statusSessions) => {
       }
     }
 
-    const row = elements.sessionGroups.querySelector(`.session-row[data-session-id="${CSS.escape(entry.id)}"]`);
+    const rowData = rowDataById.get(entry.id);
+    const row = rowData?.row;
     if (row) {
       row.classList.toggle('is-active', nextActive);
     }
@@ -1621,14 +1634,13 @@ const updateSidebarStatus = (statusSessions) => {
 
     if (!row) continue;
 
-    const titleEl = row.querySelector('.session-title');
+    const { titleEl, metaEl } = rowData;
     if (titleEl && entry.short_title && titleEl.textContent !== entry.short_title) {
       titleEl.textContent = entry.short_title;
       if (entry.long_title) titleEl.title = entry.long_title;
       changed = true;
     }
 
-    const metaEl = row.querySelector('.session-meta');
     if (metaEl && entry.message_count != null) {
       const count = entry.message_count;
       if (local) {


### PR DESCRIPTION
## Problem

`updateSidebarStatus` is called every 2 s while sessions are active (and on every sidebar status poll response). It processes up to 100 entries from the server. For each entry the current code does:

1. `state.sessions.find((s) => s.id === entry.id)` — O(n_sessions) array scan per entry
2. `elements.sessionGroups.querySelector(`.session-row[data-session-id="..."])` — full subtree DOM query per entry
3. `row.querySelector('.session-title')` — DOM sub-query per entry
4. `row.querySelector('.session-meta')` — DOM sub-query per entry

With 100 sessions and 100 status entries that is **10 000 array comparisons + 300 DOM queries** every 2 seconds.

## Fix

Build two lookup Maps once before the loop:

- **`localById`** — `Map<id, session>` from `state.sessions` in a single O(n) pass
- **`rowDataById`** — `Map<id, {row, titleEl, metaEl}>` from a single `querySelectorAll('.session-row[data-session-id]')` on the sidebar container

Each per-entry lookup is now O(1). All title/meta element lookups are amortised into the one `querySelectorAll`.

## Result

- Array work: O(n×k) → O(n+k)
- DOM queries: k individual `querySelector` calls → 1 `querySelectorAll` + k Map lookups