### PR TITLE
perf: replace O(n²) JSON.parse guard in tool-arg delta handler with argumentsFinalized flag

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -612,20 +612,10 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
         const entry = exactEntry
           || [...tools].reverse().find((tool) => tool.status !== 'done')
           || tools[tools.length - 1];
-        if (entry) {
-          const current = String(entry.arguments || '');
-          let currentIsCompleteJSON = false;
-          if (current) {
-            try {
-              JSON.parse(current);
-              currentIsCompleteJSON = true;
-            } catch {}
-          }
-          if (!currentIsCompleteJSON) {
-            entry.arguments = current + delta;
-            updateVisibleToolGroupNode(session, streamState.currentToolGroup);
-            scheduleStreamPersistence();
-          }
+        if (entry && !entry.argumentsFinalized) {
+          entry.arguments = (entry.arguments || '') + delta;
+          updateVisibleToolGroupNode(session, streamState.currentToolGroup);
+          scheduleStreamPersistence();
         }
       }
     }
@@ -641,6 +631,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
         : streamState.currentToolGroup.tools.find((tool) => tool.name === String(item.name || '') && tool.status === 'running');
       if (entry) {
         entry.arguments = String(item.arguments || entry.arguments || '');
+        entry.argumentsFinalized = true;
       }
       updateVisibleToolGroupNode(session, streamState.currentToolGroup);
       saveSessions();


### PR DESCRIPTION
## What

In `response.function_call_arguments.delta`, the handler previously called `JSON.parse(entry.arguments)` on every delta to detect whether the arguments string had already been finalized (a guard for stream replay scenarios). This is O(n) per delta, making the total cost O(n²) over the life of a streaming tool call with large arguments.

Replace this with an `argumentsFinalized` boolean flag set on the tool entry when `response.output_item.done` fires. The delta handler checks this flag in O(1) and skips stale deltas without parsing.

## Why

For tool calls with large arguments (e.g. file-write with multi-KB content), the O(n²) JSON.parse cost becomes measurable — each delta re-parses the entire accumulated string so far. The flag is also more correct: the old check would incorrectly treat any intermediate delta sequence that happened to form valid JSON as finalized, while the flag only triggers after the authoritative `output_item.done` event.
