### PR TITLE
perf: skip unnecessary work in saveSessions and evictStaleSessionMessages

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -996,10 +996,10 @@ const loadSessions = () => {
 const MAX_CACHED_MESSAGE_SESSIONS = 10;
 
 const evictStaleSessionMessages = () => {
-  const sorted = [...state.sessions]
-    .filter(s => s.messages && s.messages.length > 0 && !s._serverOnly)
-    .sort((a, b) => b.created - a.created);
-  const keep = new Set(sorted.slice(0, MAX_CACHED_MESSAGE_SESSIONS).map(s => s.id));
+  const withMessages = state.sessions.filter(s => s.messages && s.messages.length > 0 && !s._serverOnly);
+  if (withMessages.length <= MAX_CACHED_MESSAGE_SESSIONS) return;
+  withMessages.sort((a, b) => b.created - a.created);
+  const keep = new Set(withMessages.slice(0, MAX_CACHED_MESSAGE_SESSIONS).map(s => s.id));
 
   for (const s of state.sessions) {
     if (!keep.has(s.id) && s.messages && s.messages.length > 0) {
@@ -1008,6 +1008,9 @@ const evictStaleSessionMessages = () => {
     }
   }
 };
+
+let _savedActiveSessionId = /** @type {string|null} */ (null);
+let _savedDraftActive = /** @type {string|null} */ (null);
 
 const saveSessions = () => {
   if (state.sessions.length > 100) {
@@ -1023,9 +1026,18 @@ const saveSessions = () => {
     }
   }
   evictStaleSessionMessages();
+  const nextActiveId = state.activeSessionId || '';
+  const nextDraftActive = state.draftSessionActive ? '1' : '0';
+  if (nextActiveId === _savedActiveSessionId && nextDraftActive === _savedDraftActive) return;
   try {
-    localStorage.setItem(STORAGE_KEYS.activeSession, state.activeSessionId || '');
-    localStorage.setItem(STORAGE_KEYS.draftSessionActive, state.draftSessionActive ? '1' : '0');
+    if (nextActiveId !== _savedActiveSessionId) {
+      localStorage.setItem(STORAGE_KEYS.activeSession, nextActiveId);
+      _savedActiveSessionId = nextActiveId;
+    }
+    if (nextDraftActive !== _savedDraftActive) {
+      localStorage.setItem(STORAGE_KEYS.draftSessionActive, nextDraftActive);
+      _savedDraftActive = nextDraftActive;
+    }
   } catch {
     // storage failure — continue without persistence
   }


### PR DESCRIPTION
## Problem

`saveSessions()` is called multiple times per streaming turn (on `response.created`, tool call completion, turn-end flush, and other session events). Each call unconditionally:

1. Ran `evictStaleSessionMessages()` which always allocated 2 arrays + sort + Set, even when only 1-2 sessions had messages loaded (the common case).
2. Called `localStorage.setItem()` twice (active session ID and draft flag), even when neither value changed since the last call. localStorage writes are **synchronous main-thread I/O** and can cause perceptible jank.

## Changes

### `evictStaleSessionMessages`
- Removes the `[...state.sessions]` spread copy (only `.filter()` is needed)
- Adds an **early exit** when the number of sessions with messages is already ≤ `MAX_CACHED_MESSAGE_SESSIONS` (10). This skips the sort + Set construction + eviction loop for the vast majority of calls.

### `saveSessions`
- Tracks the last-written values of `activeSessionId` and `draftSessionActive`
- Skips `localStorage.setItem` when neither value has changed since the previous write — eliminating the synchronous I/O overhead on every call that doesn't actually change the stored state