### PR TITLE
perf: skip syncAssistantUsageNode DOM query when usage is null during streaming

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -816,7 +816,7 @@ const enqueueAssistantStreamUpdate = (message) => {
   const streamState = getOrCreateAssistantStreamState(message, body);
   streamState.latestContent = String(message.content || '');
   streamState.dirty = true;
-  syncAssistantUsageNode(node, message);
+  if (message.usage) syncAssistantUsageNode(node, message);
   syncTurnActionPanelForAssistant(message.id);
   scheduleAssistantStreamRender(streamState);
 };


### PR DESCRIPTION
## Summary

`message.usage` is always `null` during token streaming (`response.output_text.delta` events). Every call to `enqueueAssistantStreamUpdate` — roughly 100×/sec during active streaming — was unconditionally calling `syncAssistantUsageNode`, which does a `node.querySelector('.usage-line')` DOM query against null usage.

This PR guards the call:

```js
// before
syncAssistantUsageNode(node, message);

// after
if (message.usage) syncAssistantUsageNode(node, message);
```

## Impact

Eliminates ~100 unnecessary `querySelector` DOM calls per second during streaming. Usage stats are still synced at completion via `finalizeAssistantStreamRender` → `renderAssistantNodeFully`, so the displayed token counts are unaffected.