### PR TITLE
perf: run session state sync in parallel with messages fetch during startup hydration

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -861,6 +861,10 @@ const hydrateActiveSessionAfterStartup = async () => {
   const active = getActiveSession();
   if (!active) return;
 
+  // Start state sync immediately so the server round-trip overlaps with the
+  // messages fetch instead of serialising after it.
+  const statePromise = syncActiveSessionFromServer(active, true);
+
   if (active._serverOnly) {
     const msgs = await loadServerSessionMessages(active.id);
     if (msgs !== null) {
@@ -871,7 +875,7 @@ const hydrateActiveSessionAfterStartup = async () => {
     }
   }
 
-  await syncActiveSessionFromServer(active, true);
+  await statePromise;
 };
 
 const initialize = async () => {


### PR DESCRIPTION
## Problem

`hydrateActiveSessionAfterStartup` runs two network requests sequentially:

1. `loadServerSessionMessages` — fetches the session's message history
2. `syncActiveSessionFromServer` — fetches `/v1/sessions/{id}/state` to determine if a response is active

These two requests are **completely independent**: neither depends on the result of the other. The current serial order wastes one full HTTP round-trip (~100–300 ms) every time a user loads the UI with a specific session URL.

## Fix

Start `syncActiveSessionFromServer` immediately (before awaiting the messages fetch). The state round-trip now overlaps with the messages fetch instead of waiting for it.

```
Before: fetch_messages ──→ render ──→ fetch_state ──→ process
After:  fetch_messages ─────────────────────────────→ render
        fetch_state ──→ process (in parallel)
```

## Impact

- Saves ~1 HTTP round-trip latency on every startup that hydrates a `_serverOnly` session (direct URL navigation, page reload)
- No change in behavior — JS is single-threaded so there are no data races