### PR TITLE
perf: use DocumentFragment for renderMessages and renderSidebar batch inserts

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -154,7 +154,7 @@ const renderSidebar = () => {
     }
   });
 
-  elements.sessionGroups.innerHTML = '';
+  const sidebarFrag = document.createDocumentFragment();
 
   Object.entries(grouped).forEach(([label, sessions]) => {
     if (!sessions.length) return;
@@ -255,8 +255,11 @@ const renderSidebar = () => {
       groupEl.appendChild(row);
     });
 
-    elements.sessionGroups.appendChild(groupEl);
+    sidebarFrag.appendChild(groupEl);
   });
+
+  elements.sessionGroups.innerHTML = '';
+  elements.sessionGroups.appendChild(sidebarFrag);
 };
 
 // ===== Message rendering =====
@@ -1574,16 +1577,18 @@ const renderMessages = (forceScroll = false) => {
   resetAssistantStreamRenders();
   elements.messages.innerHTML = '';
 
+  const msgFrag = document.createDocumentFragment();
   if (!session || !session.messages.length) {
     const empty = document.createElement('div');
     empty.className = 'empty-state';
     empty.textContent = 'How can I help you today?';
-    elements.messages.appendChild(empty);
+    msgFrag.appendChild(empty);
   } else {
     session.messages.forEach((message) => {
-      elements.messages.appendChild(createMessageNode(message));
+      msgFrag.appendChild(createMessageNode(message));
     });
   }
+  elements.messages.appendChild(msgFrag);
 
   syncTurnActionPanels();
   refreshRelativeTimes();


### PR DESCRIPTION
## What

Use `DocumentFragment` to batch DOM insertions in `renderMessages` and `renderSidebar`.

- `renderMessages`: builds all message nodes into a fragment, then does a single `appendChild` onto `elements.messages`
- `renderSidebar`: builds all section group elements into a fragment, then clears `elements.sessionGroups` and does a single `appendChild`

## Why

Previously both functions appended nodes one-by-one directly to the live DOM. Each insertion can trigger style recalculation and layout work. Batching through a `DocumentFragment` defers layout until the single final insertion, reducing layout thrashing proportionally to the number of messages/session groups rendered.
