### PR TITLE
perf: scope refreshRelativeTimes to messages container instead of full document

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1131,7 +1131,7 @@ const ensureActiveSession = () => {
 const findMessageElement = (id) => elements.messages.querySelector(`[data-message-id="${id}"]`);
 
 const refreshRelativeTimes = () => {
-  document.querySelectorAll('[data-created]').forEach((node) => {
+  elements.messages.querySelectorAll('[data-created]').forEach((node) => {
     const ts = Number(node.getAttribute('data-created'));
     if (!Number.isFinite(ts)) return;
     node.textContent = relativeTime(ts);


### PR DESCRIPTION
## Problem

`refreshRelativeTimes` runs every 60 seconds and on every `renderMessages` call. It uses `document.querySelectorAll('[data-created]')` which traverses the entire document DOM tree each time.

## Fix

The `[data-created]` attribute is only set on `<span>` nodes inside `createMetaNode` (app-render.js:301), which are rendered exclusively into the `#messages` container. The sidebar does not use `[data-created]` — it inlines `relativeTime()` directly into `.session-meta` text content.

Scope the query to `elements.messages` instead of `document`, eliminating the full-document traversal on every tick and on every render.

```js
// before
document.querySelectorAll('[data-created]').forEach(...)

// after
elements.messages.querySelectorAll('[data-created]').forEach(...)
```