### PR TITLE
perf: skip buildArgsNode for done tools with existing args in updateToolGroupNode

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1556,13 +1556,14 @@ const updateToolGroupNode = (message) => {
           status.className = `tool-entry-status${tool.status === 'done' ? ' done' : ''}`;
           status.textContent = tool.status === 'done' ? '✓' : '…';
         }
-        // Update or add arguments display
         const existingArgs = entry.querySelector('.tool-entry-args');
-        const newArgs = buildArgsNode(tool);
-        if (existingArgs && newArgs) {
-          existingArgs.replaceWith(newArgs);
-        } else if (!existingArgs && newArgs) {
-          entry.appendChild(newArgs);
+        if (!(tool.status === 'done' && existingArgs)) {
+          const newArgs = buildArgsNode(tool);
+          if (existingArgs && newArgs) {
+            existingArgs.replaceWith(newArgs);
+          } else if (!existingArgs && newArgs) {
+            entry.appendChild(newArgs);
+          }
         }
       }
     });


### PR DESCRIPTION
## What

In `updateToolGroupNode`, skip calling `buildArgsNode` for tool entries that are already `done` and already have an args node in the DOM.

```js
// before: always rebuilds the args DOM node
const existingArgs = entry.querySelector('.tool-entry-args');
const newArgs = buildArgsNode(tool);
if (existingArgs && newArgs) {
  existingArgs.replaceWith(newArgs);
} else if (!existingArgs && newArgs) {
  entry.appendChild(newArgs);
}

// after: skips the rebuild when args are frozen
const existingArgs = entry.querySelector('.tool-entry-args');
if (!(tool.status === 'done' && existingArgs)) {
  const newArgs = buildArgsNode(tool);
  if (existingArgs && newArgs) {
    existingArgs.replaceWith(newArgs);
  } else if (!existingArgs && newArgs) {
    entry.appendChild(newArgs);
  }
}
```

## Why

`updateToolGroupNode` is called at several points in the tool lifecycle (new tool added, `output_item.done`, `function_call.done`, group close). Each call iterates **all** tools in the group — including ones that already completed in previous events.

For each such tool, the old code unconditionally called `buildArgsNode`, which:
1. Calls `formatToolArgs` → `JSON.parse(tool.arguments)` on the finalized (potentially large) args string
2. Builds a new DOM subtree (multiple `createElement` calls)
3. Calls `existingArgs.replaceWith(newArgs)`, triggering a DOM mutation and layout work

Once a tool is `done` and its args node is already in the DOM, the arguments are immutable (finalized at `output_item.done`). Rebuilding the display on every subsequent group update is wasted work. The guard skips all three steps for already-rendered done tools.

In an agentic session with a tool group containing N tools, each lifecycle event after the first completion saves (N−1) redundant rebuilds.
