### PR TITLE
perf: skip String coercion and trim in streamIsCurrent hot path

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -813,9 +813,9 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
 
   const streamIsCurrent = () => {
     if (generation !== state.streamGeneration) return false;
-    const currentSessionId = String(state.currentStreamSessionId || '').trim();
+    const currentSessionId = state.currentStreamSessionId;
     if (currentSessionId && sessionId && currentSessionId !== sessionId) return false;
-    const currentResponseId = String(state.currentStreamResponseId || '').trim();
+    const currentResponseId = state.currentStreamResponseId;
     if (expectedResponseId && currentResponseId && currentResponseId !== expectedResponseId) return false;
     return true;
   };


### PR DESCRIPTION
## Summary

`streamIsCurrent` is called 3× per SSE event (~300×/sec during streaming) to detect whether the stream has become stale mid-processing.

Each call previously allocated two trimmed strings:

```js
// before
const currentSessionId = String(state.currentStreamSessionId || '').trim();
// ...
const currentResponseId = String(state.currentStreamResponseId || '').trim();
```

Both `currentStreamSessionId` and `currentStreamResponseId` are already normalized (trimmed) at assignment time in `attachResponseStream` (`String(session?.id || '').trim()`) and reset to `''` in `detachResponseStream`. Reading them without `String().trim()` is safe.

```js
// after
const currentSessionId = state.currentStreamSessionId;
// ...
const currentResponseId = state.currentStreamResponseId;
```

## Impact

Eliminates ~600 unnecessary string allocations per second during active streaming (2 allocations × 3 calls/token × 100 tokens/sec).