### PR TITLE
perf: throttle saveSessions on tool event boundaries via scheduleStreamPersistence

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -594,7 +594,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       }
 
       streamState.currentAssistantMessage = null;
-      saveSessions();
+      scheduleStreamPersistence();
       scrollVisibleStreamToBottom(session);
     }
     return { terminal: false };
@@ -643,7 +643,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
         entry.arguments = String(item.arguments || entry.arguments || '');
       }
       updateVisibleToolGroupNode(session, streamState.currentToolGroup);
-      saveSessions();
+      scheduleStreamPersistence();
     }
     return { terminal: false };
   }


### PR DESCRIPTION
## Problem

During streaming, `response.output_text.delta` events already use `scheduleStreamPersistence()` — a throttled save that fires at most once per second. However, two tool-related events called `saveSessions()` directly:

- `response.output_item.added` (line 597): fires when a new function call starts  
- `response.output_item.done` (line 646): fires when a function call finishes

In agentic sessions with many tool calls, these fire frequently. Each direct `saveSessions()` runs the full pipeline: `evictStaleSessionMessages()` (filter + sort + Set allocation) followed by two synchronous `localStorage.setItem` calls.

## Fix

Replace both direct `saveSessions()` calls with `scheduleStreamPersistence()`, matching the pattern used for text deltas. The existing `flushStreamPersistence()` call in `detachResponseStream()` ensures all pending data is flushed to localStorage before the stream ends.

The `response.created` handler (line 482) retains its direct `saveSessions()` call since immediately persisting the `activeResponseId` is important for crash recovery.