### PR TITLE
perf: use []byte for recovery message content to avoid O(n²) string growth

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -33,7 +33,7 @@ type responseRunRecoveryTool struct {
 type responseRunRecoveryMessage struct {
 	ID       string
 	Role     string
-	Content  string
+	Content  []byte
 	Created  int64
 	Tools    []responseRunRecoveryTool
 	Expanded bool
@@ -240,7 +240,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		}
 		r.closeToolGroupLocked()
 		idx := r.ensureAssistantMessageLocked()
-		r.recoveryMessages[idx].Content += delta
+		r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, delta...)
 	case "response.output_text.new_segment":
 		r.closeToolGroupLocked()
 		r.currentAssistant = -1
@@ -324,7 +324,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		}
 		idx := r.ensureAssistantMessageLocked()
 		for _, url := range images {
-			r.recoveryMessages[idx].Content += fmt.Sprintf("\n\n![Generated Image](%s)\n", url)
+			r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, fmt.Sprintf("\n\n![Generated Image](%s)\n", url)...)
 		}
 	case "response.completed":
 		r.closeToolGroupLocked()
@@ -351,7 +351,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		r.recoveryMessages = append(r.recoveryMessages, responseRunRecoveryMessage{
 			ID:      r.nextRecoveryMessageIDLocked("error"),
 			Role:    "error",
-			Content: message,
+			Content: []byte(message),
 			Created: time.Now().UnixMilli(),
 		})
 		r.currentAssistant = -1
@@ -490,8 +490,8 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 			"role":    msg.Role,
 			"created": msg.Created,
 		}
-		if msg.Content != "" {
-			entry["content"] = msg.Content
+		if len(msg.Content) > 0 {
+			entry["content"] = string(msg.Content)
 		}
 		if msg.Status != "" {
 			entry["status"] = msg.Status


### PR DESCRIPTION
## What

Change `responseRunRecoveryMessage.Content` from `string` to `[]byte`, and update all four use sites.

```go
// before
Content  string
// ...
r.recoveryMessages[idx].Content += delta          // O(n) copy per delta
// ...
if msg.Content != "" { entry["content"] = msg.Content }

// after
Content  []byte
// ...
r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, delta...)  // amortized O(1)
// ...
if len(msg.Content) > 0 { entry["content"] = string(msg.Content) }
```

## Why

`applyRecoveryEventLocked` is called for every SSE event including every `response.output_text.delta`. For text streaming, it does `Content += delta` on a `string` field. Go strings are immutable, so each `+=` allocates a new string of size `len(existing) + len(delta)` and copies everything.

For a response with total text length S and individual delta size d, the total bytes copied is roughly S²/(2d). For a 20 KB response with 2-char deltas: ~100 MB of copies during a single streaming response.

Switching to `[]byte` and `append` gives amortized O(1) per delta (slice doubles capacity when full), reducing total copies to ~2S regardless of response length.

The read path (`string(msg.Content)`) only fires when a client reconnects mid-stream to replay recovery state, so the one allocation there is acceptable.
