### PR TITLE
perf: skip redundant messages fetch in syncActiveSessionFromServer when already preloaded

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -442,7 +442,7 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
   }, delay);
 };
 
-const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
+const syncActiveSessionFromServer = async (session, pollOnActive = false, { skipMessagesFetch = false } = {}) => {
   if (!session) return null;
 
   const busyBefore = sessionHasInProgressState(session);
@@ -563,12 +563,14 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
     setSessionOptimisticBusy(session, false);
     setSessionServerActiveRun(session, false);
     updateBusySidebar();
-    const serverMessages = await loadServerSessionMessages(session.id);
-    if (Array.isArray(serverMessages)) {
-      mergeServerMessagesWithLocalState(session, serverMessages);
-      persistAndRefreshShell();
-      if (session.id === state.activeSessionId) {
-        renderMessages(true);
+    if (!skipMessagesFetch) {
+      const serverMessages = await loadServerSessionMessages(session.id);
+      if (Array.isArray(serverMessages)) {
+        mergeServerMessagesWithLocalState(session, serverMessages);
+        persistAndRefreshShell();
+        if (session.id === state.activeSessionId) {
+          renderMessages(true);
+        }
       }
     }
     if (runtimeState.last_error) {
@@ -868,6 +870,7 @@ const hydrateActiveSessionAfterStartup = async () => {
   const active = getActiveSession();
   if (!active) return;
 
+  let messagesPreloaded = false;
   if (active._serverOnly) {
     const msgs = await loadServerSessionMessages(active.id);
     if (Array.isArray(msgs)) {
@@ -875,10 +878,11 @@ const hydrateActiveSessionAfterStartup = async () => {
       saveSessions();
       renderSidebar();
       renderMessages(true);
+      messagesPreloaded = true;
     }
   }
 
-  await syncActiveSessionFromServer(active, true);
+  await syncActiveSessionFromServer(active, true, { skipMessagesFetch: messagesPreloaded });
 };
 
 const initialize = async () => {


### PR DESCRIPTION
## Problem

For sessions stored as `_serverOnly` (messages not cached in localStorage), `hydrateActiveSessionAfterStartup` fetches messages from the server to display them early, before the state sync completes. Then `syncActiveSessionFromServer` is called and — finding an idle session — unconditionally fetches messages again from the same endpoint. This doubles the network requests for the most common startup case.

## Fix

Add an optional `{ skipMessagesFetch }` parameter to `syncActiveSessionFromServer` (defaults to `false`, fully backwards-compatible). When `hydrateActiveSessionAfterStartup` successfully loads and merges messages, it sets `messagesPreloaded = true` and passes `{ skipMessagesFetch: true }` to the subsequent `syncActiveSessionFromServer` call — avoiding the redundant fetch and the second `mergeServerMessagesWithLocalState` + `renderMessages` cycle.

If the initial message load fails (returns `null`), `messagesPreloaded` stays `false` and `syncActiveSessionFromServer` still fetches normally.

All other call sites pass no options and are unaffected.