### PR TITLE
perf: use Set for O(1) unknown-session check in pollSidebarStatus

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -101,9 +101,8 @@ const pollSidebarStatus = async () => {
       if (Array.isArray(data.sessions)) {
         updateSidebarStatus(data.sessions);
         // Discover sessions created in other tabs/devices
-        const hasUnknown = data.sessions.some(
-          (entry) => !state.sessions.find((s) => s.id === entry.id)
-        );
+        const localIds = new Set(state.sessions.map((s) => s.id));
+        const hasUnknown = data.sessions.some((entry) => !localIds.has(entry.id));
         if (hasUnknown) mergeServerSessions();
       }
     }


### PR DESCRIPTION
## Problem

In `pollSidebarStatus`, after processing status updates, the code checks whether the server returned any sessions not yet known locally:

```js
const hasUnknown = data.sessions.some(
  (entry) => !state.sessions.find((s) => s.id === entry.id)
);
```

`data.sessions` contains up to 100 entries; `state.sessions` also holds up to 100 sessions. The nested `find` makes this O(n×m) — up to 10,000 string comparisons — on every poll cycle (every 2s when active, every few seconds when idle).

## Fix

Build a `Set` of local session IDs before the check, reducing it to O(n+m):

```js
const localIds = new Set(state.sessions.map((s) => s.id));
const hasUnknown = data.sessions.some((entry) => !localIds.has(entry.id));
```