### PR TITLE
perf: hoist early-return guard in scheduleAssistantStreamRender before closure and Date.now() alloc

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -618,23 +618,21 @@ const getOrCreateAssistantStreamState = (message, body) => {
 };
 
 const scheduleAssistantStreamRender = (streamState) => {
-  if (!streamState) return;
+  if (!streamState || streamState.rendering || streamState.rafId || streamState.timerId) return;
   const renderDelay = app.markdownStreaming && typeof app.markdownStreaming.nextStreamingRenderDelay === 'function'
     ? app.markdownStreaming.nextStreamingRenderDelay(streamState.latestContent.length)
     : 33;
   const elapsed = Date.now() - streamState.lastRenderAt;
-  const enqueueFrame = () => {
-    streamState.timerId = 0;
-    if (streamState.rafId) return;
-    streamState.rafId = window.requestAnimationFrame(() => performAssistantStreamRender(streamState));
-  };
-
-  if (streamState.rendering || streamState.rafId || streamState.timerId) return;
   if (elapsed >= renderDelay) {
-    enqueueFrame();
+    streamState.rafId = window.requestAnimationFrame(() => performAssistantStreamRender(streamState));
     return;
   }
-  streamState.timerId = window.setTimeout(enqueueFrame, renderDelay - elapsed);
+  streamState.timerId = window.setTimeout(() => {
+    streamState.timerId = 0;
+    if (!streamState.rafId) {
+      streamState.rafId = window.requestAnimationFrame(() => performAssistantStreamRender(streamState));
+    }
+  }, renderDelay - elapsed);
 };
 
 const clearAssistantTailRender = (streamState) => {


### PR DESCRIPTION
## What

Hoist the "already scheduled" guard to the top of `scheduleAssistantStreamRender`, before the work that the old code did unconditionally.

```js
// before
const scheduleAssistantStreamRender = (streamState) => {
  if (!streamState) return;
  const renderDelay = ...nextStreamingRenderDelay(streamState.latestContent.length)...;  // Date.now() + property lookups
  const elapsed = Date.now() - streamState.lastRenderAt;
  const enqueueFrame = () => { ... };  // closure allocation

  if (streamState.rendering || streamState.rafId || streamState.timerId) return;  // guard was HERE
  ...
};

// after
const scheduleAssistantStreamRender = (streamState) => {
  if (!streamState || streamState.rendering || streamState.rafId || streamState.timerId) return;  // guard FIRST
  const renderDelay = ...;  // only computed when actually needed
  const elapsed = Date.now() - streamState.lastRenderAt;
  ...
};
```

## Why

`scheduleAssistantStreamRender` is called on every `response.output_text.delta` event. A RAF or timer is scheduled after the first delta in each render cycle (~33 ms window). Every subsequent delta in that window hits the `rendering || rafId || timerId` guard and returns early.

In the original code the guard was placed *after* three pieces of work:
1. Computing `renderDelay` — a conditional property lookup chain with a `typeof` check
2. Calling `Date.now()` — a system-time read
3. Allocating the `enqueueFrame` closure — captures `streamState`

All three happen on every delta in the busy path, then the closure is immediately discarded. At 60–200 deltas/second, this is measurable overhead.

Moving the guard to the top makes the common case (RAF already pending) a single three-property boolean check. Also inlines `enqueueFrame` since it's now used in at most one place per call.
