### PR TITLE
perf: compact event buffer in-place to eliminate per-event slice allocation

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -221,9 +221,13 @@ func (r *responseRun) compactEventsLocked() {
 		r.minReplayAfter = nextReplayAfter
 	}
 
-	trimmed := make([]responseRunEvent, len(r.events)-dropCount)
-	copy(trimmed, r.events[dropCount:])
-	r.events = trimmed
+	keep := len(r.events) - dropCount
+	copy(r.events, r.events[dropCount:])
+	tail := r.events[keep:]
+	for i := range tail {
+		tail[i] = responseRunEvent{}
+	}
+	r.events = r.events[:keep]
 }
 
 func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]any) {


### PR DESCRIPTION
## What

Replace the `make + copy` pattern in `compactEventsLocked` with an in-place shift.

```go
// before: allocates a new backing array on every compaction
trimmed := make([]responseRunEvent, len(r.events)-dropCount)
copy(trimmed, r.events[dropCount:])
r.events = trimmed

// after: shifts in place, zeroes the tail, no allocation
keep := len(r.events) - dropCount
copy(r.events, r.events[dropCount:])
tail := r.events[keep:]
for i := range tail {
    tail[i] = responseRunEvent{}
}
r.events = r.events[:keep]
```

## Why

`compactEventsLocked` is called on every call to `appendEventLocked`. Once the event buffer reaches `maxRetainedEvents` (default 256), compaction fires on every new event — which means once per text delta during streaming.

Each compaction previously allocated a new `[]responseRunEvent` of `maxRetainedEvents` length. A `responseRunEvent` is 48 bytes (int64 + string + []byte slice header), so each compaction allocated ~12 KB. For a long 1000-delta response, this totals ~12 MB of short-lived allocations and equivalent GC pressure.

The in-place approach copies elements forward into the existing backing array (same copy count as before), then zeroes the tail to release the `Data []byte` references so the GC can collect the old JSON payloads. The backing array itself is retained across compactions but is bounded to `maxRetainedEvents * 2` capacity at most, adding at most ~12 KB of steady-state overhead.

`copy` handles overlapping source and destination slices correctly when the destination starts before the source.
