### PR TITLE
perf: add ETag caching to session messages endpoint

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -855,7 +855,18 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		result = append(result, entry)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"messages": result})
+	body, _ := json.Marshal(map[string]any{"messages": result})
+	hash := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(hash[:8]) + `"`
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", "no-cache")
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
 }
 
 func (s *serveServer) handleSessionInterrupt(w http.ResponseWriter, r *http.Request, sessionID string) {

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -214,7 +214,7 @@ const switchToSession = async (sessionId, options = {}) => {
 
   if (session._serverOnly) {
     const msgs = await loadServerSessionMessages(session.id);
-    if (msgs !== null) {
+    if (Array.isArray(msgs)) {
       mergeServerMessagesWithLocalState(session, msgs);
     }
   }
@@ -342,12 +342,19 @@ const convertServerMessages = (serverMessages) => {
   return result;
 };
 
+const sessionMessagesEtag = new Map();
+
 const loadServerSessionMessages = async (sessionId) => {
   try {
     const headers = {};
     if (state.token) headers.Authorization = `Bearer ${state.token}`;
+    const etag = sessionMessagesEtag.get(sessionId);
+    if (etag) headers['If-None-Match'] = etag;
     const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/messages`, { headers });
+    if (resp.status === 304) return false;
     if (!resp.ok) return null;
+    const newEtag = resp.headers.get('ETag');
+    if (newEtag) sessionMessagesEtag.set(sessionId, newEtag);
     const data = await resp.json();
     if (!Array.isArray(data.messages)) return null;
     return convertServerMessages(data.messages);
@@ -557,7 +564,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false) => {
     setSessionServerActiveRun(session, false);
     updateBusySidebar();
     const serverMessages = await loadServerSessionMessages(session.id);
-    if (serverMessages !== null) {
+    if (Array.isArray(serverMessages)) {
       mergeServerMessagesWithLocalState(session, serverMessages);
       persistAndRefreshShell();
       if (session.id === state.activeSessionId) {
@@ -863,7 +870,7 @@ const hydrateActiveSessionAfterStartup = async () => {
 
   if (active._serverOnly) {
     const msgs = await loadServerSessionMessages(active.id);
-    if (msgs !== null) {
+    if (Array.isArray(msgs)) {
       mergeServerMessagesWithLocalState(active, msgs);
       saveSessions();
       renderSidebar();


### PR DESCRIPTION
## Problem

The `/ui/v1/sessions/{id}/messages` endpoint returns the full message JSON on every request with no caching headers. Clients that already have an up-to-date copy (e.g. immediately after streaming ends, or when switching back to a recently viewed session) must re-receive, re-parse, and re-merge the same payload.

The `/ui/v1/sessions/status` endpoint already uses this pattern.

## Fix

**Server**: Marshal the response JSON, compute SHA-256 of the first 8 bytes as an ETag, set `ETag` and `Cache-Control: no-cache` headers. Return `304 Not Modified` when the client sends a matching `If-None-Match`.

**Client**: Keep a module-level `Map<sessionId, etag>` of the most recent ETag per session. Send `If-None-Match` on each request and store the returned ETag on 200. On 304, return `false` (a new sentinel distinct from `null`=error). All three call sites (`switchToSession`, `syncActiveSessionFromServer` idle path, `hydrateActiveSessionAfterStartup`) now check `Array.isArray(msgs)` instead of `!== null`, safely ignoring both errors and not-modified responses.

## Impact

- After a stream completes, `syncActiveSessionFromServer` fetches messages to reconcile. If nothing changed (common for idle sessions), this now returns 304 — skipping JSON body transfer, parsing, and the `mergeServerMessagesWithLocalState` + `renderMessages` cycle.
- Switching back to a recently loaded session returns 304 immediately.