### PR TITLE
perf: hoist response.output_text.delta branch first and inline sequence update in applyResponseStreamEvent

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -472,6 +472,20 @@ const createResponseStreamState = (session) => {
 };
 
 const applyResponseStreamEvent = (session, streamState, event, payload) => {
+  if (event === 'response.output_text.delta') {
+    const seq = payload.sequence_number;
+    if (seq > session.lastSequenceNumber) session.lastSequenceNumber = seq;
+    const delta = payload.delta || '';
+    if (delta) {
+      streamState.closeToolGroup();
+      const msg = streamState.ensureAssistantMessage();
+      msg.content += delta;
+      scheduleStreamPersistence();
+      enqueueVisibleAssistantStreamUpdate(session, msg);
+    }
+    return { terminal: false };
+  }
+
   updateResponseSequence(session, payload);
 
   if (event === 'response.created') {
@@ -537,18 +551,6 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       }
       scheduleStreamPersistence();
       scrollVisibleStreamToBottom(session);
-    }
-    return { terminal: false };
-  }
-
-  if (event === 'response.output_text.delta') {
-    const delta = String(payload.delta || '');
-    if (delta) {
-      streamState.closeToolGroup();
-      const msg = streamState.ensureAssistantMessage();
-      msg.content += delta;
-      scheduleStreamPersistence();
-      enqueueVisibleAssistantStreamUpdate(session, msg);
     }
     return { terminal: false };
   }


### PR DESCRIPTION
## What

Hoist `response.output_text.delta` to the top of `applyResponseStreamEvent` and inline a cheaper sequence number update for the delta case.

## Why

`response.output_text.delta` is the most frequent SSE event — one per streaming token. The previous dispatch order checked `response.created` and `response.model_swap.progress` first (both rare), burning two string comparisons per token before reaching the delta branch.

The generic `updateResponseSequence` called at the top of the function also has unnecessary overhead for delta events:
- `Number(payload.sequence_number)` — redundant, the value is already a JS number after `JSON.parse`
- `Number(session.lastSequenceNumber || 0)` — redundant, always a number
- `Number.isFinite` guard — always true for a positive integer from the server
- `Math.max(current, seq)` — replaced with a plain `if` comparison

Changes:
- Move `response.output_text.delta` branch before `updateResponseSequence` and all other event checks
- Inline sequence update as `if (seq > session.lastSequenceNumber) session.lastSequenceNumber = seq`
- Remove `String()` coercion on `payload.delta` which is always a string from JSON

At 50–100 tokens/sec this shaves two string comparisons and two `Number()` coercions off the tightest inner loop.
