### PR TITLE
perf: replace O(n) regex match in directionForText with early-exit charCodeAt scan

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -12,11 +12,15 @@ const isMobileViewport = () => window.matchMedia('(max-width: 767px)').matches;
 
 const directionForText = (value) => {
   const text = String(value || '');
-  const strongChars = text.match(/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F\u0590-\u08FF]/g);
-  if (!strongChars || strongChars.length === 0) return 'auto';
-  for (const ch of strongChars) {
-    if (/[\u0590-\u08FF]/.test(ch)) return 'rtl';
-    if (/[A-Za-z\u00C0-\u02AF\u0370-\u03FF\u0400-\u052F]/.test(ch)) return 'ltr';
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if (c >= 0x0590 && c <= 0x08FF) return 'rtl';
+    if (
+      (c >= 0x41 && c <= 0x5A) ||
+      (c >= 0x61 && c <= 0x7A) ||
+      (c >= 0xC0 && c <= 0x02AF) ||
+      (c >= 0x0370 && c <= 0x052F)
+    ) return 'ltr';
   }
   return 'auto';
 };


### PR DESCRIPTION
## What

Replace the O(n) `text.match(/.../g)` scan in `directionForText` with an early-exit `charCodeAt` loop.

## Why

`directionForText` is called on every RAF frame during streaming via `performAssistantStreamRender`, and also when rendering static messages.

The old implementation called `text.match(/[A-Za-zÀ-ʯͰ-ϿЀ-ԯ֐-ࣿ]/g)`, which:
1. Scans the **entire** string and allocates an array of every matching character
2. Then iterates that array and returns on the **very first** element
3. Creates two temporary `RegExp` objects per loop iteration inside the `for…of`

For a growing 1000-char English response, this allocates ~1000-element arrays at up to 30fps (~30,000 elements/sec), and the useful work is just checking a single character code.

The replacement `charCodeAt` loop:
- Allocates nothing
- Returns on the first strong-directional character (char 0 or 1 for English → O(1))
- Has the same Unicode range coverage: RTL `0x0590–0x08FF` checked first, then LTR (A–Z, a–z, Latin Extended, Greek, Cyrillic)
