### PR TITLE
perf: write SSE event data bytes directly, reduce fmt.Fprintf calls

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -808,13 +808,13 @@ func cloneJSONValue(value any) any {
 }
 
 func writeStoredResponseEvent(w io.Writer, ev responseRunEvent) error {
-	if _, err := fmt.Fprintf(w, "id: %d\n", ev.Sequence); err != nil {
+	if _, err := fmt.Fprintf(w, "id: %d\nevent: %s\ndata: ", ev.Sequence, ev.Event); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w, "event: %s\n", ev.Event); err != nil {
+	if _, err := w.Write(ev.Data); err != nil {
 		return err
 	}
-	_, err := fmt.Fprintf(w, "data: %s\n\n", ev.Data)
+	_, err := io.WriteString(w, "\n\n")
 	return err
 }
 


### PR DESCRIPTION
## What

Collapse `writeStoredResponseEvent` from three `fmt.Fprintf` calls into one `fmt.Fprintf` for the structured prefix, a direct `w.Write(ev.Data)` for the JSON payload, and an `io.WriteString` for the trailing `"\n\n"`.

## Why

`writeStoredResponseEvent` is called on every SSE event sent to the browser — for a text-streaming response that includes hundreds of `response.output_text.delta` events, this is the most frequently executed write function in the server.

**Before:**
```go
fmt.Fprintf(w, "id: %d\n", ev.Sequence)
fmt.Fprintf(w, "event: %s\n", ev.Event)
fmt.Fprintf(w, "data: %s\n\n", ev.Data)  // ev.Data is []byte
```

- 3 separate `fmt.Fprintf` calls → 3× format-string parse + pp-pool acquire/release
- The `%s` verb on a `[]byte` argument routes through fmt's byte-formatting path rather than a direct `Write`

**After:**
```go
fmt.Fprintf(w, "id: %d\nevent: %s\ndata: ", ev.Sequence, ev.Event)
w.Write(ev.Data)          // direct []byte write, no fmt overhead
io.WriteString(w, "\n\n")
```

- 1 `fmt.Fprintf` call (fixed-width prefix only)
- `ev.Data` written directly as bytes with no fmt processing
- Output is byte-identical; no behavioural change
