### PR TITLE
perf: use struct marshal for output_text.delta to avoid map key sort

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -163,12 +163,17 @@ func (r *responseRun) appendEventLocked(event string, payload map[string]any, te
 	}
 
 	r.applyRecoveryEventLocked(event, payload)
-
-	stored := responseRunEvent{
+	r.storeEventLocked(responseRunEvent{
 		Sequence: r.lastSequenceNumber,
 		Event:    event,
 		Data:     data,
-	}
+	}, terminal)
+	return nil
+}
+
+// storeEventLocked appends stored to r.events, compacts the buffer, and fans
+// out to all live subscribers. Must be called with r.mu held.
+func (r *responseRun) storeEventLocked(stored responseRunEvent, terminal bool) {
 	r.events = append(r.events, stored)
 	r.compactEventsLocked()
 
@@ -202,7 +207,42 @@ func (r *responseRun) appendEventLocked(event string, payload map[string]any, te
 			delete(r.subscriberWarned, id)
 		}
 	}
+}
 
+type textDeltaPayload struct {
+	OutputIndex    int    `json:"output_index"`
+	Delta          string `json:"delta"`
+	SequenceNumber int64  `json:"sequence_number"`
+}
+
+// appendTextDeltaEvent is a typed fast-path for response.output_text.delta.
+// Using a struct avoids the map-key sort that json.Marshal performs on
+// map[string]any, which fires on every streamed text token.
+func (r *responseRun) appendTextDeltaEvent(outputIndex int, delta string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lastSequenceNumber++
+
+	data, err := json.Marshal(textDeltaPayload{
+		OutputIndex:    outputIndex,
+		Delta:          delta,
+		SequenceNumber: r.lastSequenceNumber,
+	})
+	if err != nil {
+		return err
+	}
+
+	if delta != "" {
+		r.closeToolGroupLocked()
+		idx := r.ensureAssistantMessageLocked()
+		r.recoveryMessages[idx].Content += delta
+	}
+
+	r.storeEventLocked(responseRunEvent{
+		Sequence: r.lastSequenceNumber,
+		Event:    "response.output_text.delta",
+		Data:     data,
+	}, false)
 	return nil
 }
 
@@ -834,10 +874,7 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 			}
 			state.toolsSeen = false
 		}
-		return run.appendEvent("response.output_text.delta", map[string]any{
-			"output_index": state.outputIndex,
-			"delta":        ev.Text,
-		})
+		return run.appendTextDeltaEvent(state.outputIndex, ev.Text)
 	case llm.EventToolCall:
 		if ev.Tool == nil {
 			return nil


### PR DESCRIPTION
## What

Add a typed fast-path for `response.output_text.delta` events — the most frequent event type during text streaming.

1. Extract the store+fan-out block from `appendEventLocked` into `storeEventLocked` (no behaviour change, just refactoring).
2. Add `textDeltaPayload` struct and `appendTextDeltaEvent(outputIndex int, delta string)` that marshals a struct instead of a `map[string]any`.
3. Call `run.appendTextDeltaEvent` from `appendResponseRunEvent` for `llm.EventTextDelta`.

## Why

`json.Marshal` on a `map[string]any` must sort the map keys before encoding to produce deterministic output. For a 3-key text-delta payload `{"output_index", "delta", "sequence_number"}` that is a key-sort plus reflection-based value dispatch on **every streamed token**.

Marshaling the equivalent struct (`textDeltaPayload`) uses pre-computed field offsets and requires no sort — struct fields are always emitted in declaration order.

The output JSON is identical. No other event types are affected.
