### PR TITLE
perf: replace three fmt.Fprintf calls in writeStoredResponseEvent with a single buffered Write

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -808,13 +809,15 @@ func cloneJSONValue(value any) any {
 }
 
 func writeStoredResponseEvent(w io.Writer, ev responseRunEvent) error {
-	if _, err := fmt.Fprintf(w, "id: %d\n", ev.Sequence); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "event: %s\n", ev.Event); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(w, "data: %s\n\n", ev.Data)
+	b := make([]byte, 0, 4+20+1+7+len(ev.Event)+1+6+len(ev.Data)+2)
+	b = append(b, "id: "...)
+	b = strconv.AppendInt(b, ev.Sequence, 10)
+	b = append(b, "\nevent: "...)
+	b = append(b, ev.Event...)
+	b = append(b, "\ndata: "...)
+	b = append(b, ev.Data...)
+	b = append(b, "\n\n"...)
+	_, err := w.Write(b)
 	return err
 }
 


### PR DESCRIPTION
## What

Replace three `fmt.Fprintf` calls in `writeStoredResponseEvent` with a single pre-sized `[]byte` buffer written via one `w.Write` call.

## Why

`writeStoredResponseEvent` is called for every SSE event sent to browser clients during streaming (~100 events/sec per active stream, once per token). The previous implementation called `fmt.Fprintf` three times per event:

```go
fmt.Fprintf(w, "id: %d\n", ev.Sequence)
fmt.Fprintf(w, "event: %s\n", ev.Event)
fmt.Fprintf(w, "data: %s\n\n", ev.Data)
```

Each `fmt.Fprintf` call:
- Parses a format string
- Acquires a `pp` struct from `sync.Pool` (atomic CAS)
- Formats arguments via reflection
- Writes to `w`
- Returns `pp` to the pool (atomic CAS)

At 100 events/sec: **300 format parsings/sec** and **6 sync.Pool atomic operations/sec** just for SSE framing overhead.

The replacement builds the full frame in one `make([]byte, 0, preSizedCap)` buffer using `append` and `strconv.AppendInt`, then issues a single `w.Write`. This eliminates all format overhead and reduces writes into the buffered `ResponseWriter` from 3 to 1 per event.
