### PR TITLE
speed up jobs event polling

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -562,7 +562,8 @@ CREATE TABLE IF NOT EXISTS job_run_events_v2 (
 	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE INDEX IF NOT EXISTS idx_job_run_events_v2_run_id ON job_run_events_v2(run_id, created_at, id);
+CREATE INDEX IF NOT EXISTS idx_job_run_events_v2_run_id_id ON job_run_events_v2(run_id, id);
+DROP INDEX IF EXISTS idx_job_run_events_v2_run_id;
 `
 
 func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*jobsV2Manager, error) {
@@ -1317,7 +1318,10 @@ func (m *jobsV2Manager) ListRunEvents(runID string, sinceID int64, limit, offset
 	}
 
 	rowsArgs := append(append([]any{}, args...), limit, offset)
-	query := fmt.Sprintf(`SELECT id, run_id, event_type, message, data, created_at FROM job_run_events_v2 %s ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?`, where)
+	// Event IDs are AUTOINCREMENT and match insertion order. Ordering by id lets
+	// since_id polling seek into idx_job_run_events_v2_run_id_id instead of
+	// walking the full per-run created_at timeline on every incremental poll.
+	query := fmt.Sprintf(`SELECT id, run_id, event_type, message, data, created_at FROM job_run_events_v2 %s ORDER BY id ASC LIMIT ? OFFSET ?`, where)
 	rows, err := m.db.Query(query, rowsArgs...)
 	if err != nil {
 		return nil, 0, err

--- a/cmd/serve_jobs_v2_bench_test.go
+++ b/cmd/serve_jobs_v2_bench_test.go
@@ -65,3 +65,72 @@ func BenchmarkJobsV2ListRuns(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkJobsV2ListRunEventsSince(b *testing.B) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		b.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	now := time.Now().UTC()
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 60, 'skip', ?, ?)`,
+		"job_bench_events", "bench-events", jobsV2RunnerProgram, `{"command":"echo","args":["x"]}`, jobsV2TriggerManual, `{}`, now, now)
+	if err != nil {
+		b.Fatalf("insert job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?)`,
+		"run_bench_events", "job_bench_events", now, jobsV2RunRunning, now, now)
+	if err != nil {
+		b.Fatalf("insert run: %v", err)
+	}
+
+	const eventsCount = 100_000
+	tx, err := mgr.db.Begin()
+	if err != nil {
+		b.Fatalf("begin: %v", err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO job_run_events_v2 (run_id, event_type, message, created_at) VALUES (?, 'phase', ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		b.Fatalf("prepare event insert: %v", err)
+	}
+	var sinceID int64
+	for i := 0; i < eventsCount; i++ {
+		createdAt := now.Add(time.Duration(i) * time.Millisecond)
+		res, err := stmt.Exec("run_bench_events", fmt.Sprintf("event %d", i), createdAt)
+		if err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			b.Fatalf("insert event %d: %v", i, err)
+		}
+		if i == eventsCount-100 {
+			firstTailID, err := res.LastInsertId()
+			if err != nil {
+				_ = stmt.Close()
+				_ = tx.Rollback()
+				b.Fatalf("last insert id for event %d: %v", i, err)
+			}
+			sinceID = firstTailID - 1
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		_ = tx.Rollback()
+		b.Fatalf("close event insert stmt: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit events: %v", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		events, total, err := mgr.ListRunEvents("run_bench_events", sinceID, 100, 0)
+		if err != nil {
+			b.Fatalf("ListRunEvents failed: %v", err)
+		}
+		if len(events) != 100 || total != 100 {
+			b.Fatalf("got total=%d len=%d, want total=100 len=100", total, len(events))
+		}
+	}
+}

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -595,6 +595,54 @@ func TestJobsV2RunEventsEndpoint(t *testing.T) {
 	}
 }
 
+func TestJobsV2ListRunEventsSinceIDOrdersByInsertion(t *testing.T) {
+	mgr := newJobsV2ManagerWithoutLoops(t)
+	now := time.Now().UTC()
+
+	_, err := mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 60, 'skip', ?, ?)`,
+		"job_events_since", "events-since", jobsV2RunnerProgram, `{"command":"echo","args":["x"]}`, jobsV2TriggerManual, `{}`, now, now)
+	if err != nil {
+		t.Fatalf("insert job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?)`,
+		"run_events_since", "job_events_since", now, jobsV2RunRunning, now, now)
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+
+	insertEvent := func(message string, createdAt time.Time) int64 {
+		t.Helper()
+		res, err := mgr.db.Exec(`INSERT INTO job_run_events_v2 (run_id, event_type, message, created_at) VALUES (?, 'phase', ?, ?)`,
+			"run_events_since", message, createdAt)
+		if err != nil {
+			t.Fatalf("insert event %q: %v", message, err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("last insert id for %q: %v", message, err)
+		}
+		return id
+	}
+
+	firstID := insertEvent("first", now.Add(3*time.Second))
+	secondID := insertEvent("second", now.Add(2*time.Second))
+	thirdID := insertEvent("third", now.Add(time.Second))
+
+	events, total, err := mgr.ListRunEvents("run_events_since", firstID, 10, 0)
+	if err != nil {
+		t.Fatalf("ListRunEvents failed: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total = %d, want 2", total)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].ID != secondID || events[0].Message != "second" || events[1].ID != thirdID || events[1].Message != "third" {
+		t.Fatalf("events after since_id not returned in id order: %+v", events)
+	}
+}
+
 func TestJobsV2RetentionPrunesOldData(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)
 	if err != nil {


### PR DESCRIPTION
## What

- Change Jobs V2 run event listing to use insertion/event ID order for pagination.
- Add a `(run_id, id)` SQLite index for `/v2/runs/:id/events?since_id=...` polling and drop the obsolete `(run_id, created_at, id)` index.
- Add a functional since_id ordering test and a benchmark for tail polling on a large event stream.

## Why

Incremental event polling was using `WHERE run_id = ? AND id > ?` but still ordered through the `(run_id, created_at, id)` index. For long-running/chatty jobs this made tail polls walk the accumulated per-run timeline before returning the new events. Event IDs are autoincrementing and already match insertion order, which is the natural contract for `since_id` polling.

## Evidence

Representative benchmark with 100k events for one run and `since_id` near the tail:

- Before: `BenchmarkTmpJobsV2ListRunEventsSince-32` ~11.3 ms/op, ~74.7 KB/op, 1749 allocs/op.
- After: `BenchmarkJobsV2ListRunEventsSince-32` ~0.15-0.18 ms/op, ~74.6 KB/op, 1748 allocs/op.

Verification:

- `go test ./cmd -run 'TestJobsV2(ListRunEventsSinceIDOrdersByInsertion|RunEventsEndpoint)$'`
- `go test ./cmd -run '^$' -bench BenchmarkJobsV2ListRunEventsSince -benchmem -count=3`
- `go build ./...`
- `go test ./...`
