### PR TITLE
fix: Skills initialization does a full multi-path skill catalog scan before every first prompt

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -326,6 +326,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	}
 	sessionID = ensureRequestSessionID(sessionID, resuming)
 	settings.SessionID = sessionID
+	settings.SystemPrompt = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
 
 	// Initialize local tools if we have any
 	toolMgr, err := settings.SetupToolManager(cfg, engine)
@@ -440,8 +441,6 @@ func runAsk(cmd *cobra.Command, args []string) error {
 
 	// Use system prompt from resolved settings (already expanded)
 	instructions := settings.SystemPrompt
-
-	instructions = InjectSkillsMetadata(instructions, skillsSetup)
 
 	// Build messages in correct order: system -> history -> new user
 	// Providers expect system message first

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -389,11 +389,10 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	}
 	skillsSetup := SetupSkills(&cfg.Skills, chatSkills, agentSkills, cmd.ErrOrStderr())
 
-	RegisterSkillToolWithEngine(engine, toolMgr, skillsSetup)
-
 	// Store resolved instructions in config for chat TUI
-	cfg.Chat.Instructions = settings.SystemPrompt
-	cfg.Chat.Instructions = InjectSkillsMetadata(cfg.Chat.Instructions, skillsSetup)
+	cfg.Chat.Instructions = InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)
+
+	RegisterSkillToolWithEngine(engine, toolMgr, skillsSetup)
 
 	// Determine model name
 	modelName := getModelName(cfg)

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -676,7 +676,14 @@ func RegisterSkillToolWithEngine(engine *llm.Engine, toolMgr *tools.ToolManager,
 
 // InjectSkillsMetadata appends <available_skills> metadata to instructions when available.
 func InjectSkillsMetadata(instructions string, skillsSetup *skills.Setup) string {
-	if skillsSetup == nil || !skillsSetup.HasSkillsXML() || skills.CheckAgentsMdForSkills() {
+	if skillsSetup == nil || skills.CheckAgentsMdForSkills() {
+		return instructions
+	}
+	if err := skillsSetup.EnsurePromptMetadata(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: skills metadata generation failed: %v\n", err)
+		return instructions
+	}
+	if !skillsSetup.HasSkillsXML() {
 		return instructions
 	}
 

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -247,9 +247,45 @@ func (r *Registry) addUserPaths(home, configDir string) {
 	})
 }
 
+// HasAnySkill returns true as soon as a valid skill is found in any search path.
+// This avoids a full catalog scan during startup when callers only need to know
+// whether the skills system should be enabled at all.
+func (r *Registry) HasAnySkill() (bool, error) {
+	for _, sp := range r.searchPaths {
+		entries, err := os.ReadDir(sp.path)
+		if err != nil {
+			continue // Skip directories that don't exist or can't be read
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			skillDir := filepath.Join(sp.path, entry.Name())
+			if !IsSkillDir(skillDir) {
+				continue
+			}
+
+			skill, err := LoadFromDir(skillDir, sp.source, false)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: skipping invalid skill %s: %v\n", skillDir, err)
+				continue
+			}
+			if err := skill.Validate(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: skipping invalid skill %s: %v\n", skillDir, err)
+				continue
+			}
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // Get retrieves a skill by name, loading full content.
 func (r *Registry) Get(name string) (*Skill, error) {
-	// Check cache first
 	if skill, ok := r.cache[name]; ok {
 		// If we have metadata only, load full content
 		if !skill.IsLoaded() {

--- a/internal/skills/setup.go
+++ b/internal/skills/setup.go
@@ -1,9 +1,11 @@
 package skills
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/samsaffron/term-llm/internal/config"
 )
@@ -11,10 +13,17 @@ import (
 // Setup holds the initialized skills system for a session.
 type Setup struct {
 	Registry    *Registry
-	XML         string   // Pregenerated <available_skills> XML
-	Skills      []*Skill // Skills included in metadata
-	TotalSkills int      // Total auto-invocable skills discovered
-	HasOverflow bool     // True when more skills exist than are shown
+	XML         string   // Pregenerated <available_skills> XML (populated lazily)
+	Skills      []*Skill // Skills included in metadata (populated lazily)
+	TotalSkills int      // Total auto-invocable skills discovered (populated lazily)
+	HasOverflow bool     // True when more skills exist than are shown (populated lazily)
+
+	alwaysEnabled        []string
+	metadataBudgetTokens int
+	maxVisibleSkills     int
+
+	metadataOnce sync.Once
+	metadataErr  error
 }
 
 // NewSetup initializes the skills system from config.
@@ -37,46 +46,69 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		return nil, err
 	}
 
-	// List all available skills
-	allSkills, err := registry.List()
+	hasAnySkills, err := registry.HasAnySkill()
 	if err != nil {
 		return nil, err
 	}
-
-	if len(allSkills) == 0 {
+	if !hasAnySkills {
 		return nil, nil
 	}
 
-	// Filter by never_auto for metadata injection (explicit only skills excluded)
-	var autoSkills []*Skill
-	for _, skill := range allSkills {
-		if !registry.IsNeverAuto(skill.Name) {
-			autoSkills = append(autoSkills, skill)
-		}
-	}
-
-	// Apply token budget and max count
-	skills := TruncateSkillsToTokenBudget(
-		autoSkills,
-		cfg.AlwaysEnabled,
-		cfg.MetadataBudgetTokens,
-		cfg.MaxVisibleSkills,
-	)
-
-	// Generate XML
-	xml := GenerateAvailableSkillsXML(skills)
-
-	totalAutoSkills := len(autoSkills)
-	if len(skills) < totalAutoSkills {
-		xml += GenerateSearchHint(len(skills), totalAutoSkills)
-	}
 	return &Setup{
-		Registry:    registry,
-		XML:         xml,
-		Skills:      skills,
-		TotalSkills: totalAutoSkills,
-		HasOverflow: len(skills) < totalAutoSkills,
+		Registry:             registry,
+		alwaysEnabled:        append([]string(nil), cfg.AlwaysEnabled...),
+		metadataBudgetTokens: cfg.MetadataBudgetTokens,
+		maxVisibleSkills:     cfg.MaxVisibleSkills,
 	}, nil
+}
+
+// EnsurePromptMetadata loads and caches prompt-facing skill metadata on demand.
+func (s *Setup) EnsurePromptMetadata() error {
+	if s == nil {
+		return nil
+	}
+	if s.XML != "" || s.Registry == nil {
+		return nil
+	}
+
+	s.metadataOnce.Do(func() {
+		allSkills, err := s.Registry.List()
+		if err != nil {
+			s.metadataErr = fmt.Errorf("list skills: %w", err)
+			return
+		}
+
+		// Filter by never_auto for metadata injection (explicit only skills excluded)
+		var autoSkills []*Skill
+		for _, skill := range allSkills {
+			if !s.Registry.IsNeverAuto(skill.Name) {
+				autoSkills = append(autoSkills, skill)
+			}
+		}
+
+		// Apply token budget and max count
+		skills := TruncateSkillsToTokenBudget(
+			autoSkills,
+			s.alwaysEnabled,
+			s.metadataBudgetTokens,
+			s.maxVisibleSkills,
+		)
+
+		// Generate XML
+		xml := GenerateAvailableSkillsXML(skills)
+
+		totalAutoSkills := len(autoSkills)
+		if len(skills) < totalAutoSkills {
+			xml += GenerateSearchHint(len(skills), totalAutoSkills)
+		}
+
+		s.XML = xml
+		s.Skills = skills
+		s.TotalSkills = totalAutoSkills
+		s.HasOverflow = len(skills) < totalAutoSkills
+	})
+
+	return s.metadataErr
 }
 
 // HasSkillsXML returns true if the setup has skill XML to inject.

--- a/internal/skills/setup_test.go
+++ b/internal/skills/setup_test.go
@@ -1,0 +1,78 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestNewSetupLazilyBuildsPromptMetadata(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("CODEX_HOME", filepath.Join(tmp, ".codex"))
+
+	skillDir := filepath.Join(tmp, ".skills", "test-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: test-skill
+description: "A test skill"
+---
+
+# Test Skill
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setup, err := NewSetup(&config.SkillsConfig{
+		Enabled:               true,
+		AutoInvoke:            true,
+		MetadataBudgetTokens:  8000,
+		MaxVisibleSkills:      8,
+		IncludeProjectSkills:  true,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		t.Fatalf("NewSetup() error = %v", err)
+	}
+	if setup == nil {
+		t.Fatal("NewSetup() = nil, want non-nil")
+	}
+	if setup.XML != "" {
+		t.Fatalf("setup.XML = %q before metadata generation, want empty", setup.XML)
+	}
+	if setup.TotalSkills != 0 {
+		t.Fatalf("setup.TotalSkills = %d before metadata generation, want 0", setup.TotalSkills)
+	}
+
+	if err := setup.EnsurePromptMetadata(); err != nil {
+		t.Fatalf("EnsurePromptMetadata() error = %v", err)
+	}
+	if !setup.HasSkillsXML() {
+		t.Fatal("HasSkillsXML() = false, want true after metadata generation")
+	}
+	if !strings.Contains(setup.XML, "<name>test-skill</name>") {
+		t.Fatalf("setup.XML missing test skill entry: %q", setup.XML)
+	}
+	if setup.TotalSkills != 1 {
+		t.Fatalf("setup.TotalSkills = %d, want 1", setup.TotalSkills)
+	}
+	if setup.HasOverflow {
+		t.Fatal("setup.HasOverflow = true, want false")
+	}
+}


### PR DESCRIPTION
## What

- make `internal/skills.NewSetup` stop calling `registry.List()` eagerly during setup
- add a fast `Registry.HasAnySkill()` probe so startup only confirms that skills exist before enabling the system
- lazily generate `<available_skills>` metadata via `Setup.EnsurePromptMetadata()` when prompt injection actually needs it
- inject skill metadata before registering tools in ask/chat so `HasOverflow` is populated without restoring the eager scan path
- add a regression test covering lazy prompt metadata generation

## Why

`NewSetup` previously did a full multi-path skill catalog scan up front, parsing metadata for every discovered skill before the first prompt just to build `<available_skills>` XML. That adds avoidable startup latency to normal ask/chat/serve flows, especially when multiple project and ecosystem skill directories are present. Deferring the full catalog walk until prompt metadata is actually needed keeps startup lighter while preserving existing skill activation behavior.
