### PR TITLE
fix: Skills setup does a full multi-path skill discovery and metadata parse on every startup

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -667,16 +667,19 @@ func RegisterSkillToolWithEngine(engine *llm.Engine, toolMgr *tools.ToolManager,
 	}
 	engine.Tools().Register(skillTool)
 
-	// Register search_skills tool when there are more skills than shown in the prompt
-	if skillsSetup.HasOverflow {
-		searchTool := tools.NewSearchSkillsTool(skillsSetup.Registry)
-		engine.Tools().Register(searchTool)
-	}
+	// Register search_skills whenever the skills system is available. This avoids
+	// eager startup discovery just to determine whether the prompt metadata will
+	// overflow, while still letting the model search the catalog on demand.
+	searchTool := tools.NewSearchSkillsTool(skillsSetup.Registry)
+	engine.Tools().Register(searchTool)
 }
 
 // InjectSkillsMetadata appends <available_skills> metadata to instructions when available.
 func InjectSkillsMetadata(instructions string, skillsSetup *skills.Setup) string {
-	if skillsSetup == nil || !skillsSetup.HasSkillsXML() || skills.CheckAgentsMdForSkills() {
+	if skillsSetup == nil || skills.CheckAgentsMdForSkills() {
+		return instructions
+	}
+	if !skillsSetup.HasSkillsXML() {
 		return instructions
 	}
 

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -205,6 +205,64 @@ func TestInjectSkillsMetadata_KeepsInsightsAtTail(t *testing.T) {
 	}
 }
 
+func TestInjectSkillsMetadata_SkipsLazyDiscoveryWhenAgentsProvidesSkills(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	tmp := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, ".skills", "demo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".skills", "demo", "SKILL.md"), []byte(`---
+name: demo
+description: Demo skill
+---
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("<available_skills>managed elsewhere</available_skills>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	setup, err := skills.NewSetup(&config.SkillsConfig{
+		Enabled:               true,
+		AutoInvoke:            true,
+		MetadataBudgetTokens:  8000,
+		MaxVisibleSkills:      8,
+		IncludeProjectSkills:  true,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		t.Fatalf("NewSetup() error = %v", err)
+	}
+	if setup == nil {
+		t.Fatal("NewSetup() = nil, want non-nil")
+	}
+
+	got := InjectSkillsMetadata("Base prompt", setup)
+	if got != "Base prompt" {
+		t.Fatalf("InjectSkillsMetadata() = %q, want unchanged instructions", got)
+	}
+	if setup.XML != "" {
+		t.Fatalf("setup.XML = %q, want empty because AGENTS.md short-circuits metadata discovery", setup.XML)
+	}
+	if len(setup.Skills) != 0 {
+		t.Fatalf("len(setup.Skills) = %d, want 0 because metadata discovery should be skipped", len(setup.Skills))
+	}
+	if setup.TotalSkills != 0 {
+		t.Fatalf("setup.TotalSkills = %d, want 0 because metadata discovery should be skipped", setup.TotalSkills)
+	}
+}
+
 func TestResolveSettings_MissingIncludeIsLeftUnchanged(t *testing.T) {
 	origWD, err := os.Getwd()
 	if err != nil {
@@ -395,6 +453,9 @@ Fixture content.
 
 			if _, ok := engine.Tools().Get(tools.ActivateSkillToolName); !ok {
 				t.Fatalf("expected %q tool to be registered", tools.ActivateSkillToolName)
+			}
+			if _, ok := engine.Tools().Get(tools.SearchSkillsToolName); !ok {
+				t.Fatalf("expected %q tool to be registered", tools.SearchSkillsToolName)
 			}
 
 			instructions := InjectSkillsMetadata(settings.SystemPrompt, skillsSetup)

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -306,6 +306,40 @@ func (r *Registry) Get(name string) (*Skill, error) {
 	return nil, fmt.Errorf("skill not found: %s", name)
 }
 
+// HasAvailableSkills returns true when at least one valid skill is discoverable.
+// It stops after the first valid metadata load instead of parsing the entire catalog.
+func (r *Registry) HasAvailableSkills() (bool, error) {
+	for _, sp := range r.searchPaths {
+		entries, err := os.ReadDir(sp.path)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			skillDir := filepath.Join(sp.path, entry.Name())
+			if !IsSkillDir(skillDir) {
+				continue
+			}
+
+			skill, err := LoadFromDir(skillDir, sp.source, false)
+			if err != nil {
+				continue
+			}
+			if err := skill.Validate(); err != nil {
+				continue
+			}
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // List returns all available skills (metadata only).
 // Each skill appears only once, with first-found taking precedence.
 func (r *Registry) List() ([]*Skill, error) {

--- a/internal/skills/setup.go
+++ b/internal/skills/setup.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/samsaffron/term-llm/internal/config"
 )
@@ -15,6 +16,10 @@ type Setup struct {
 	Skills      []*Skill // Skills included in metadata
 	TotalSkills int      // Total auto-invocable skills discovered
 	HasOverflow bool     // True when more skills exist than are shown
+
+	cfg          config.SkillsConfig
+	metadataOnce sync.Once
+	metadataErr  error
 }
 
 // NewSetup initializes the skills system from config.
@@ -37,51 +42,77 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		return nil, err
 	}
 
-	// List all available skills
-	allSkills, err := registry.List()
+	hasSkills, err := registry.HasAvailableSkills()
 	if err != nil {
 		return nil, err
 	}
-
-	if len(allSkills) == 0 {
+	if !hasSkills {
 		return nil, nil
 	}
 
-	// Filter by never_auto for metadata injection (explicit only skills excluded)
-	var autoSkills []*Skill
-	for _, skill := range allSkills {
-		if !registry.IsNeverAuto(skill.Name) {
-			autoSkills = append(autoSkills, skill)
-		}
-	}
-
-	// Apply token budget and max count
-	skills := TruncateSkillsToTokenBudget(
-		autoSkills,
-		cfg.AlwaysEnabled,
-		cfg.MetadataBudgetTokens,
-		cfg.MaxVisibleSkills,
-	)
-
-	// Generate XML
-	xml := GenerateAvailableSkillsXML(skills)
-
-	totalAutoSkills := len(autoSkills)
-	if len(skills) < totalAutoSkills {
-		xml += GenerateSearchHint(len(skills), totalAutoSkills)
-	}
 	return &Setup{
-		Registry:    registry,
-		XML:         xml,
-		Skills:      skills,
-		TotalSkills: totalAutoSkills,
-		HasOverflow: len(skills) < totalAutoSkills,
+		Registry: registry,
+		cfg:      *cfg,
 	}, nil
+}
+
+func (s *Setup) ensureMetadata() error {
+	if s == nil {
+		return nil
+	}
+
+	s.metadataOnce.Do(func() {
+		allSkills, err := s.Registry.List()
+		if err != nil {
+			s.metadataErr = err
+			return
+		}
+
+		// Filter by never_auto for metadata injection (explicit only skills excluded)
+		var autoSkills []*Skill
+		for _, skill := range allSkills {
+			if !s.Registry.IsNeverAuto(skill.Name) {
+				autoSkills = append(autoSkills, skill)
+			}
+		}
+
+		// Apply token budget and max count
+		skills := TruncateSkillsToTokenBudget(
+			autoSkills,
+			s.cfg.AlwaysEnabled,
+			s.cfg.MetadataBudgetTokens,
+			s.cfg.MaxVisibleSkills,
+		)
+
+		// Generate XML
+		xml := GenerateAvailableSkillsXML(skills)
+
+		totalAutoSkills := len(autoSkills)
+		if len(skills) < totalAutoSkills {
+			xml += GenerateSearchHint(len(skills), totalAutoSkills)
+		}
+
+		s.XML = xml
+		s.Skills = skills
+		s.TotalSkills = totalAutoSkills
+		s.HasOverflow = len(skills) < totalAutoSkills
+	})
+
+	return s.metadataErr
 }
 
 // HasSkillsXML returns true if the setup has skill XML to inject.
 func (s *Setup) HasSkillsXML() bool {
-	return s != nil && s.XML != ""
+	if s == nil {
+		return false
+	}
+	if s.XML != "" {
+		return true
+	}
+	if s.Registry == nil {
+		return false
+	}
+	return s.ensureMetadata() == nil && s.XML != ""
 }
 
 // CheckAgentsMdForSkills checks if AGENTS.md contains skill system markup.

--- a/internal/skills/setup_test.go
+++ b/internal/skills/setup_test.go
@@ -1,0 +1,122 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestNewSetupLazilyBuildsPromptMetadata(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("CODEX_HOME", filepath.Join(tmp, ".codex"))
+	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, ".skills", "demo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".skills", "demo", "SKILL.md"), []byte(`---
+name: demo
+description: Demo skill
+---
+
+# Demo
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	setup, err := NewSetup(&config.SkillsConfig{
+		Enabled:               true,
+		AutoInvoke:            true,
+		MetadataBudgetTokens:  8000,
+		MaxVisibleSkills:      8,
+		IncludeProjectSkills:  true,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		t.Fatalf("NewSetup() error = %v", err)
+	}
+	if setup == nil {
+		t.Fatal("NewSetup() = nil, want non-nil")
+	}
+
+	if setup.XML != "" {
+		t.Fatalf("setup.XML = %q, want empty before first metadata use", setup.XML)
+	}
+	if len(setup.Skills) != 0 {
+		t.Fatalf("len(setup.Skills) = %d, want 0 before first metadata use", len(setup.Skills))
+	}
+	if setup.TotalSkills != 0 {
+		t.Fatalf("setup.TotalSkills = %d, want 0 before first metadata use", setup.TotalSkills)
+	}
+	if setup.HasOverflow {
+		t.Fatal("setup.HasOverflow = true, want false before first metadata use")
+	}
+
+	if !setup.HasSkillsXML() {
+		t.Fatal("setup.HasSkillsXML() = false, want true")
+	}
+	if !strings.Contains(setup.XML, "<available_skills>") {
+		t.Fatalf("setup.XML missing <available_skills>: %q", setup.XML)
+	}
+	if setup.TotalSkills != 1 {
+		t.Fatalf("setup.TotalSkills = %d, want 1", setup.TotalSkills)
+	}
+}
+
+func TestNewSetupReturnsNilWhenNoValidSkillsExist(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("CODEX_HOME", filepath.Join(tmp, ".codex"))
+	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, ".skills", "broken"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".skills", "broken", "SKILL.md"), []byte(`---
+name: Broken
+---
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	setup, err := NewSetup(&config.SkillsConfig{
+		Enabled:               true,
+		AutoInvoke:            true,
+		MetadataBudgetTokens:  8000,
+		MaxVisibleSkills:      8,
+		IncludeProjectSkills:  true,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		t.Fatalf("NewSetup() error = %v", err)
+	}
+	if setup != nil {
+		t.Fatalf("NewSetup() = %#v, want nil when no valid skills are available", setup)
+	}
+}


### PR DESCRIPTION
## What

- make `internal/skills.NewSetup` lazy-load prompt metadata instead of calling `registry.List()` during startup
- add a cheap `HasAvailableSkills()` probe so we still skip setup when no valid skills exist without parsing the full catalog
- defer `<available_skills>` generation until it is actually needed, and short-circuit metadata injection earlier when `AGENTS.md` already provides skills markup
- always register `search_skills` when the skills system is available so we no longer need eager overflow detection at engine setup time
- add regression tests covering lazy metadata generation, AGENTS.md short-circuiting, and search tool registration

## Why

Skills setup was doing a full multi-path discovery plus frontmatter parse of every discovered skill on every startup, even before the first prompt and even when the session would never inject term-llm's own `<available_skills>` block. This makes startup slower, especially in repos or home directories with many skills installed across multiple ecosystems.

This change preserves behavior while removing the unconditional catalog walk from startup. We now pay the full metadata cost only when prompt injection actually needs it, and AGENTS-managed skill prompts avoid that work entirely.
