### PR TITLE
fix: Config load eagerly resolves credentials for every configured provider, not just the active one

### DIFF
--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -205,7 +205,11 @@ func runGeminiAudio(cmd *cobra.Command, cfg *config.Config, text string, tempera
 		apiKey = strings.TrimSpace(cfg.Image.Gemini.APIKey)
 	}
 	if apiKey == "" {
-		if geminiProvider := cfg.GetProviderConfig("gemini"); geminiProvider != nil {
+		geminiProvider, err := cfg.GetResolvedProviderConfig("gemini")
+		if err != nil {
+			return fmt.Errorf("gemini provider: %w", err)
+		}
+		if geminiProvider != nil {
 			apiKey = strings.TrimSpace(geminiProvider.ResolvedAPIKey)
 		}
 	}
@@ -254,7 +258,11 @@ func runGeminiAudio(cmd *cobra.Command, cfg *config.Config, text string, tempera
 func runElevenLabsAudio(cmd *cobra.Command, cfg *config.Config, text string) error {
 	apiKey := strings.TrimSpace(cfg.Audio.ElevenLabs.APIKey)
 	if apiKey == "" {
-		if elevenLabsProvider := cfg.GetProviderConfig("elevenlabs"); elevenLabsProvider != nil {
+		elevenLabsProvider, err := cfg.GetResolvedProviderConfig("elevenlabs")
+		if err != nil {
+			return fmt.Errorf("elevenlabs provider: %w", err)
+		}
+		if elevenLabsProvider != nil {
 			apiKey = strings.TrimSpace(elevenLabsProvider.ResolvedAPIKey)
 		}
 	}

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -61,6 +61,12 @@ func runModels(cmd *cobra.Command, args []string) error {
 
 	// Get provider config - handle built-in providers that may not be explicitly configured
 	providerCfg, ok := cfg.Providers[providerName]
+	if ok {
+		if err := cfg.ResolveProviderCredentials(providerName); err != nil {
+			return fmt.Errorf("provider %q: %w", providerName, err)
+		}
+		providerCfg = cfg.Providers[providerName]
+	}
 
 	// Infer provider type - only use config type if provider is configured
 	var providerType config.ProviderType

--- a/cmd/music.go
+++ b/cmd/music.go
@@ -191,7 +191,11 @@ func runElevenLabsMusic(cmd *cobra.Command, cfg *config.Config, req music.Reques
 		apiKey = strings.TrimSpace(cfg.Audio.ElevenLabs.APIKey)
 	}
 	if apiKey == "" {
-		if elevenLabsProvider := cfg.GetProviderConfig("elevenlabs"); elevenLabsProvider != nil {
+		elevenLabsProvider, err := cfg.GetResolvedProviderConfig("elevenlabs")
+		if err != nil {
+			return fmt.Errorf("elevenlabs provider: %w", err)
+		}
+		if elevenLabsProvider != nil {
 			apiKey = strings.TrimSpace(elevenLabsProvider.ResolvedAPIKey)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,7 +116,9 @@ type ProviderConfig struct {
 	OAuthCreds     *credentials.GeminiOAuthCredentials `mapstructure:"-"`
 	ResolvedURL    string                              `mapstructure:"-"` // Resolved URL (after srv:// lookup)
 
-	// Lazy resolution tracking - these are resolved on-demand before inference
+	// Resolution tracking - provider credential discovery is deferred until needed,
+	// and expensive values are resolved lazily before inference.
+	credentialsResolved bool `mapstructure:"-"`
 	needsLazyResolution bool `mapstructure:"-"`
 }
 
@@ -558,12 +560,8 @@ func Load() (*Config, error) {
 		cfg.Providers = make(map[string]ProviderConfig)
 	}
 
-	// Resolve credentials for all providers
-	for name, providerCfg := range cfg.Providers {
-		if err := resolveProviderCredentials(name, &providerCfg); err != nil {
-			return nil, fmt.Errorf("%s credentials: %w", name, err)
-		}
-		cfg.Providers[name] = providerCfg
+	if err := cfg.ResolveProviderCredentials(cfg.DefaultProvider); err != nil {
+		return nil, fmt.Errorf("%s credentials: %w", cfg.DefaultProvider, err)
 	}
 
 	resolveImageCredentials(&cfg.Image)
@@ -760,6 +758,36 @@ func (c *Config) ApplyOverrides(provider, model string) {
 	}
 }
 
+// ResolveProviderCredentials resolves and caches credentials for the named provider.
+// Missing providers are ignored.
+func (c *Config) ResolveProviderCredentials(name string) error {
+	if c == nil || name == "" {
+		return nil
+	}
+	providerCfg, ok := c.Providers[name]
+	if !ok {
+		return nil
+	}
+	if err := resolveProviderCredentials(name, &providerCfg); err != nil {
+		return err
+	}
+	c.Providers[name] = providerCfg
+	return nil
+}
+
+// GetResolvedProviderConfig returns the config for the specified provider name
+// after resolving any deferred credential discovery needed for that provider.
+// Returns nil if the provider is not configured.
+func (c *Config) GetResolvedProviderConfig(name string) (*ProviderConfig, error) {
+	if err := c.ResolveProviderCredentials(name); err != nil {
+		return nil, err
+	}
+	if cfg, ok := c.Providers[name]; ok {
+		return &cfg, nil
+	}
+	return nil, nil
+}
+
 // GetProviderConfig returns the config for the specified provider name.
 // Returns nil if the provider is not configured.
 func (c *Config) GetProviderConfig(name string) *ProviderConfig {
@@ -786,6 +814,11 @@ func needsLazyResolve(value string) bool {
 // resolveProviderCredentials resolves credentials for a provider based on its type.
 // Expensive operations (op://, file://, srv://, $()) are deferred - call ResolveForInference() before use.
 func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
+	if cfg.credentialsResolved || cfg.ResolvedAPIKey != "" || cfg.ResolvedURL != "" || cfg.OAuthCreds != nil {
+		cfg.credentialsResolved = true
+		return nil
+	}
+
 	providerType := InferProviderType(name, cfg.Type)
 
 	// Check if URL fields need lazy resolution
@@ -806,6 +839,7 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 	// If so, defer resolution until inference time
 	if cfg.APIKey != "" && needsLazyResolve(cfg.APIKey) {
 		cfg.needsLazyResolution = true
+		cfg.credentialsResolved = true
 		return nil
 	}
 
@@ -890,6 +924,7 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 		}
 	}
 
+	cfg.credentialsResolved = true
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,6 +117,47 @@ providers:
 	}
 }
 
+func TestLoad_OnlyResolvesDefaultProviderCredentials(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	homeDir := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("OPENAI_API_KEY", "sk-openai-test")
+
+	configDir := filepath.Join(configHome, "term-llm")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	configYAML := `default_provider: openai
+providers:
+  openai:
+    model: gpt-5.2
+  gemini-cli:
+    model: gemini-2.5-pro
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configYAML), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Providers["openai"].ResolvedAPIKey; got != "sk-openai-test" {
+		t.Fatalf("openai ResolvedAPIKey = %q, want %q", got, "sk-openai-test")
+	}
+	if cfg.Providers["gemini-cli"].OAuthCreds != nil {
+		t.Fatal("expected gemini-cli OAuth creds to remain unresolved until used")
+	}
+	if err := cfg.ResolveProviderCredentials("gemini-cli"); err == nil {
+		t.Fatal("expected deferred gemini-cli credential resolution to fail without oauth creds")
+	}
+}
+
 func TestLoad_PreservesProviderEnvKeyCase(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -150,6 +150,11 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 		}
 	}
 
+	if err := cfg.ResolveProviderCredentials(name); err != nil {
+		return nil, fmt.Errorf("provider %q: %w", name, err)
+	}
+	providerCfg = cfg.Providers[name]
+
 	// Apply model override if provided
 	if model != "" {
 		providerCfg.Model = model
@@ -259,6 +264,10 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 			return nil, fmt.Errorf("provider %q not configured", cfg.DefaultProvider)
 		}
 	}
+	if err := cfg.ResolveProviderCredentials(cfg.DefaultProvider); err != nil {
+		return nil, fmt.Errorf("provider %q: %w", cfg.DefaultProvider, err)
+	}
+	providerCfg = cfg.Providers[cfg.DefaultProvider]
 	return createProviderFromConfig(cfg.DefaultProvider, &providerCfg)
 }
 

--- a/internal/llm/transcribe.go
+++ b/internal/llm/transcribe.go
@@ -43,12 +43,23 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 	}
 
 	modelOverride := cfg.Transcription.Model
+	getProviderConfig := func(name string) (*config.ProviderConfig, error) {
+		providerCfg, err := cfg.GetResolvedProviderConfig(name)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", name, err)
+		}
+		return providerCfg, nil
+	}
 
 	switch providerName {
 	case "local":
 		// whisper.cpp HTTP server — OpenAI-compatible endpoint, typically no auth required
 		endpoint := "http://localhost:8080/inference"
-		if providerCfg, ok := cfg.Providers["local_whisper"]; ok {
+		providerCfg, err := getProviderConfig("local_whisper")
+		if err != nil {
+			return "", err
+		}
+		if providerCfg != nil {
 			baseURL := providerCfg.ResolvedURL
 			if baseURL == "" {
 				baseURL = providerCfg.BaseURL
@@ -64,7 +75,13 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 		})
 
 	case "mistral":
-		mistralCfg := cfg.Providers["mistral"]
+		mistralCfg, err := getProviderConfig("mistral")
+		if err != nil {
+			return "", err
+		}
+		if mistralCfg == nil {
+			mistralCfg = &config.ProviderConfig{}
+		}
 		apiKey := mistralCfg.ResolvedAPIKey
 		if apiKey == "" {
 			apiKey = os.Getenv("MISTRAL_API_KEY")
@@ -92,6 +109,10 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 		})
 
 	case "venice":
+		veniceProvider, err := getProviderConfig("venice")
+		if err != nil {
+			return "", err
+		}
 		apiKey := cfg.Transcription.Venice.APIKey
 		if apiKey == "" {
 			apiKey = cfg.Audio.Venice.APIKey
@@ -99,10 +120,8 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 		if apiKey == "" {
 			apiKey = cfg.Image.Venice.APIKey
 		}
-		if apiKey == "" {
-			if p, ok := cfg.Providers["venice"]; ok {
-				apiKey = p.ResolvedAPIKey
-			}
+		if apiKey == "" && veniceProvider != nil {
+			apiKey = veniceProvider.ResolvedAPIKey
 		}
 		if apiKey == "" {
 			apiKey = os.Getenv("VENICE_API_KEY")
@@ -111,10 +130,10 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 			return "", fmt.Errorf("transcription provider %q has no API key configured (transcription.venice.api_key, VENICE_API_KEY, audio.venice.api_key, image.venice.api_key, or providers.venice.api_key)", providerName)
 		}
 		endpoint := "https://api.venice.ai/api/v1/audio/transcriptions"
-		if p, ok := cfg.Providers["venice"]; ok {
-			baseURL := p.ResolvedURL
+		if veniceProvider != nil {
+			baseURL := veniceProvider.ResolvedURL
 			if baseURL == "" {
-				baseURL = p.BaseURL
+				baseURL = veniceProvider.BaseURL
 			}
 			if baseURL != "" {
 				endpoint = strings.TrimRight(baseURL, "/") + "/audio/transcriptions"
@@ -131,14 +150,16 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 		})
 
 	case "elevenlabs":
+		elevenLabsProvider, err := getProviderConfig("elevenlabs")
+		if err != nil {
+			return "", err
+		}
 		apiKey := cfg.Transcription.ElevenLabs.APIKey
 		if apiKey == "" {
 			apiKey = cfg.Audio.ElevenLabs.APIKey
 		}
-		if apiKey == "" {
-			if p, ok := cfg.Providers["elevenlabs"]; ok {
-				apiKey = p.ResolvedAPIKey
-			}
+		if apiKey == "" && elevenLabsProvider != nil {
+			apiKey = elevenLabsProvider.ResolvedAPIKey
 		}
 		if apiKey == "" {
 			apiKey = os.Getenv("ELEVENLABS_API_KEY")
@@ -150,10 +171,10 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 			return "", fmt.Errorf("transcription provider %q has no API key configured (transcription.elevenlabs.api_key, ELEVENLABS_API_KEY, XI_API_KEY, audio.elevenlabs.api_key, or providers.elevenlabs.api_key)", providerName)
 		}
 		endpoint := "https://api.elevenlabs.io/v1/speech-to-text"
-		if p, ok := cfg.Providers["elevenlabs"]; ok {
-			baseURL := p.ResolvedURL
+		if elevenLabsProvider != nil {
+			baseURL := elevenLabsProvider.ResolvedURL
 			if baseURL == "" {
-				baseURL = p.BaseURL
+				baseURL = elevenLabsProvider.BaseURL
 			}
 			if baseURL != "" {
 				endpoint = strings.TrimRight(baseURL, "/") + "/speech-to-text"
@@ -170,17 +191,21 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 
 	case "openai":
 		// Named provider entry takes precedence over env var
-		if p, ok := cfg.Providers[string(config.ProviderTypeOpenAI)]; ok && p.ResolvedAPIKey != "" {
+		openAIProvider, err := getProviderConfig(string(config.ProviderTypeOpenAI))
+		if err != nil {
+			return "", err
+		}
+		if openAIProvider != nil && openAIProvider.ResolvedAPIKey != "" {
 			endpoint := ""
-			baseURL := p.ResolvedURL
+			baseURL := openAIProvider.ResolvedURL
 			if baseURL == "" {
-				baseURL = p.BaseURL
+				baseURL = openAIProvider.BaseURL
 			}
 			if baseURL != "" {
 				endpoint = strings.TrimRight(baseURL, "/") + "/audio/transcriptions"
 			}
 			return transcribeAndTruncate(ctx, filePath, TranscribeOptions{
-				APIKey:   p.ResolvedAPIKey,
+				APIKey:   openAIProvider.ResolvedAPIKey,
 				Endpoint: endpoint,
 				Model:    modelOverride,
 				Language: language,
@@ -199,17 +224,21 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 
 	default:
 		// Try looking up by name in providers map (allows any openai_compatible provider)
-		if p, ok := cfg.Providers[providerName]; ok {
-			apiKey := p.ResolvedAPIKey
+		providerCfg, err := getProviderConfig(providerName)
+		if err != nil {
+			return "", err
+		}
+		if providerCfg != nil {
+			apiKey := providerCfg.ResolvedAPIKey
 			if apiKey == "" {
 				return "", fmt.Errorf("transcription provider %q has no API key configured", providerName)
 			}
 			endpoint := ""
-			resolvedURL := p.ResolvedURL
+			resolvedURL := providerCfg.ResolvedURL
 			if resolvedURL != "" {
 				endpoint = strings.TrimRight(resolvedURL, "/") + "/audio/transcriptions"
-			} else if p.BaseURL != "" {
-				endpoint = strings.TrimRight(p.BaseURL, "/") + "/audio/transcriptions"
+			} else if providerCfg.BaseURL != "" {
+				endpoint = strings.TrimRight(providerCfg.BaseURL, "/") + "/audio/transcriptions"
 			}
 			return transcribeAndTruncate(ctx, filePath, TranscribeOptions{
 				APIKey:   apiKey,

--- a/internal/llm/venice_test.go
+++ b/internal/llm/venice_test.go
@@ -13,6 +13,31 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestNewProviderByName_ResolvesConfiguredVeniceCredentialsOnDemand(t *testing.T) {
+	t.Setenv("VENICE_API_KEY", "")
+
+	cfg := &config.Config{
+		DefaultProvider: "openai",
+		Providers: map[string]config.ProviderConfig{
+			"venice": {
+				APIKey: "  test-key\n",
+				Model:  "venice-uncensored",
+			},
+		},
+	}
+
+	provider, err := NewProviderByName(cfg, "venice", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected provider")
+	}
+	if got := strings.TrimSpace(cfg.Providers["venice"].ResolvedAPIKey); got != "test-key" {
+		t.Fatalf("ResolvedAPIKey = %q, want %q", got, "test-key")
+	}
+}
+
 func TestNewVeniceProviderTrimsAPIKey(t *testing.T) {
 	provider := NewVeniceProvider("  test-key\n", "")
 	if provider.apiKey != "test-key" {


### PR DESCRIPTION
## What

- stop `config.Load()` from eagerly resolving every configured LLM provider at startup
- resolve credentials only for the default provider during load, then resolve other configured providers on demand when they are actually used
- add targeted regression tests covering the deferred `gemini-cli` case and on-demand resolution for non-default providers

## Why

Resolving every provider on every startup makes cold start latency scale with the total number of configured providers and forces unnecessary work for unused integrations, including provider-specific credential loading like `gemini-cli` OAuth reads. This keeps startup fast while preserving existing behavior once a non-default provider is selected or otherwise accessed.
