### PR TITLE
fix: Template context always spawns two git subprocesses even when prompts do not use git variables

### DIFF
--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -63,20 +63,21 @@ type TemplateContext struct {
 // Deprecated: Use NewTemplateContextForTemplate instead to avoid expensive operations
 // when template variables are not used.
 func NewTemplateContext() TemplateContext {
-	return newTemplateContext(true, true, false)
+	return newTemplateContext(true, true, true, false)
 }
 
 // NewTemplateContextForTemplate creates a context, only computing expensive values
-// (like git_diff_stat, agents, handover_dir) if they are actually used in the template.
+// (like git fields, git_diff_stat, agents, handover_dir) if they are actually used in the template.
 func NewTemplateContextForTemplate(template string) TemplateContext {
+	needsGitInfo := strings.Contains(template, "{{git_branch}}") || strings.Contains(template, "{{git_repo}}")
 	needsGitDiffStat := strings.Contains(template, "{{git_diff_stat}}")
 	needsAgents := strings.Contains(template, "{{agents}}")
 	needsHandoverDir := strings.Contains(template, "{{handover_dir}}") || strings.Contains(template, "{{handover_path}}")
-	return newTemplateContext(needsGitDiffStat, needsAgents, needsHandoverDir)
+	return newTemplateContext(needsGitInfo, needsGitDiffStat, needsAgents, needsHandoverDir)
 }
 
 // newTemplateContext creates a context with optional expensive computations.
-func newTemplateContext(computeGitDiffStat, computeAgents, computeHandoverDir bool) TemplateContext {
+func newTemplateContext(computeGitInfo, computeGitDiffStat, computeAgents, computeHandoverDir bool) TemplateContext {
 	now := time.Now()
 
 	ctx := TemplateContext{
@@ -104,8 +105,9 @@ func newTemplateContext(computeGitDiffStat, computeAgents, computeHandoverDir bo
 	}
 
 	// Git info
-	ctx.GitBranch = getGitBranch()
-	ctx.GitRepo = getGitRepoName()
+	if computeGitInfo {
+		ctx.GitBranch, ctx.GitRepo = getGitInfo()
+	}
 
 	// Only compute git diff stat if needed (expensive: runs two git commands)
 	if computeGitDiffStat {
@@ -265,24 +267,22 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 	})
 }
 
-// getGitBranch returns the current git branch, or empty string if not in a git repo.
-func getGitBranch() string {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+// getGitInfo returns the current git branch and repository name, or empty strings if not in a git repo.
+func getGitInfo() (string, string) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	return strings.TrimSpace(string(output))
-}
 
-// getGitRepoName returns the repository name, or empty string if not in a git repo.
-func getGitRepoName() string {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) < 2 {
+		return "", ""
 	}
-	return filepath.Base(strings.TrimSpace(string(output)))
+
+	branch := strings.TrimSpace(lines[0])
+	repo := filepath.Base(strings.TrimSpace(lines[len(lines)-1]))
+	return branch, repo
 }
 
 // getGitDiffStat returns a summary of changed files and line counts.

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -117,6 +118,74 @@ func TestExpandTemplate(t *testing.T) {
 				t.Errorf("ExpandTemplate() = %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestNewTemplateContextForTemplate_SkipsGitWhenTemplateDoesNotUseGitFields(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git PATH shim test requires a POSIX shell")
+	}
+
+	shimDir := t.TempDir()
+	logPath := filepath.Join(shimDir, "git.log")
+	gitPath := filepath.Join(shimDir, "git")
+	script := "#!/bin/sh\necho invoked >> \"" + logPath + "\"\nprintf 'feature/test\\n/tmp/fake-repo\\n'\n"
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", shimDir+string(os.PathListSeparator)+origPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	defer os.Setenv("PATH", origPath)
+
+	ctx := NewTemplateContextForTemplate("You are a helpful assistant. Today's date is {{date}}.")
+	if ctx.GitBranch != "" {
+		t.Fatalf("GitBranch = %q, want empty", ctx.GitBranch)
+	}
+	if ctx.GitRepo != "" {
+		t.Fatalf("GitRepo = %q, want empty", ctx.GitRepo)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("expected git shim to not be invoked, stat err = %v", err)
+	}
+}
+
+func TestNewTemplateContextForTemplate_CoalescesGitLookups(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git PATH shim test requires a POSIX shell")
+	}
+
+	shimDir := t.TempDir()
+	logPath := filepath.Join(shimDir, "git.log")
+	gitPath := filepath.Join(shimDir, "git")
+	script := "#!/bin/sh\necho invoked >> \"" + logPath + "\"\nprintf 'feature/test\\n/tmp/fake-repo\\n'\n"
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", shimDir+string(os.PathListSeparator)+origPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	defer os.Setenv("PATH", origPath)
+
+	ctx := NewTemplateContextForTemplate("{{git_repo}}/{{git_branch}}")
+	if ctx.GitBranch != "feature/test" {
+		t.Fatalf("GitBranch = %q, want %q", ctx.GitBranch, "feature/test")
+	}
+	if ctx.GitRepo != "fake-repo" {
+		t.Fatalf("GitRepo = %q, want %q", ctx.GitRepo, "fake-repo")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read git log: %v", err)
+	}
+	invocations := strings.Count(strings.TrimSpace(string(logData)), "invoked")
+	if invocations != 1 {
+		t.Fatalf("git invoked %d times, want 1", invocations)
 	}
 }
 


### PR DESCRIPTION
## What

Avoid eager git subprocesses when building template context for prompts that do not reference git fields.

- detect `{{git_branch}}` and `{{git_repo}}` usage before computing git metadata
- skip git branch/repo lookup entirely for templates that do not need it
- coalesce branch + repo lookup into a single `git rev-parse` invocation when git fields are needed
- add regression tests covering both the skip path and the single-invocation path

## Why

Default system prompts like `You are a helpful assistant. Today's date is {{date}}.` should not pay the startup latency cost of launching git twice before the first prompt appears. This change removes that unnecessary work on every invocation while preserving existing template behavior when git variables are present.
