### PR TITLE
perf: cache tool registry specs

### DIFF
--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -40,18 +40,23 @@ type FinishingTool interface {
 
 // ToolRegistry stores tools by name for execution.
 type ToolRegistry struct {
-	mu    sync.RWMutex
-	tools map[string]Tool
+	mu         sync.RWMutex
+	tools      map[string]Tool
+	specsCache []ToolSpec
+	specsDirty bool
 }
 
 func NewToolRegistry() *ToolRegistry {
-	return &ToolRegistry{tools: make(map[string]Tool)}
+	return &ToolRegistry{tools: make(map[string]Tool), specsDirty: true}
 }
 
 func (r *ToolRegistry) Register(tool Tool) {
+	spec := tool.Spec()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.tools[tool.Spec().Name] = tool
+	r.tools[spec.Name] = tool
+	r.specsDirty = true
 }
 
 func (r *ToolRegistry) Get(name string) (Tool, bool) {
@@ -78,25 +83,48 @@ func (r *ToolRegistry) IsFinishingTool(name string) bool {
 func (r *ToolRegistry) Unregister(name string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.tools, name)
+	if _, ok := r.tools[name]; ok {
+		delete(r.tools, name)
+		r.specsDirty = true
+	}
 }
 
 // AllSpecs returns the specs for all registered tools in deterministic name order.
 func (r *ToolRegistry) AllSpecs() []ToolSpec {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	names := make([]string, 0, len(r.tools))
-	for name := range r.tools {
-		names = append(names, name)
+	if !r.specsDirty {
+		specs := copyToolSpecs(r.specsCache)
+		r.mu.RUnlock()
+		return specs
 	}
-	sort.Strings(names)
+	r.mu.RUnlock()
 
-	specs := make([]ToolSpec, 0, len(names))
-	for _, name := range names {
-		specs = append(specs, r.tools[name].Spec())
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.specsDirty {
+		names := make([]string, 0, len(r.tools))
+		for name := range r.tools {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		specs := make([]ToolSpec, 0, len(names))
+		for _, name := range names {
+			specs = append(specs, r.tools[name].Spec())
+		}
+		r.specsCache = specs
+		r.specsDirty = false
 	}
-	return specs
+	return copyToolSpecs(r.specsCache)
+}
+
+// copyToolSpecs protects callers from mutating the cached slice or top-level
+// ToolSpec values. ToolSpec.Schema maps are intentionally shared by the
+// immutability contract on ToolSpec.
+func copyToolSpecs(specs []ToolSpec) []ToolSpec {
+	out := make([]ToolSpec, len(specs))
+	copy(out, specs)
+	return out
 }
 
 // ToolSpecsForRequest returns the tool specs to include in a request,

--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -111,3 +111,58 @@ func TestToolRegistryConcurrentAccess(t *testing.T) {
 	close(start)
 	wg.Wait()
 }
+
+func TestToolRegistryAllSpecsReturnedSliceIsIndependent(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&namedTestTool{name: "alpha"})
+	registry.Register(&namedTestTool{name: "beta"})
+
+	specs := registry.AllSpecs()
+	if len(specs) != 2 {
+		t.Fatalf("len(AllSpecs()) = %d, want 2", len(specs))
+	}
+	specs[0].Name = "mutated"
+
+	got := registry.AllSpecs()
+	if got[0].Name != "alpha" {
+		t.Fatalf("AllSpecs() reused caller-mutated slice, got first name %q", got[0].Name)
+	}
+}
+
+func TestToolRegistryAllSpecsInvalidatesCache(t *testing.T) {
+	registry := NewToolRegistry()
+	registry.Register(&namedTestTool{name: "alpha"})
+
+	_ = registry.AllSpecs()
+	registry.Register(&namedTestTool{name: "beta"})
+	got := registry.AllSpecs()
+	if len(got) != 2 || got[0].Name != "alpha" || got[1].Name != "beta" {
+		t.Fatalf("after Register, AllSpecs() = %#v, want alpha,beta", got)
+	}
+
+	registry.Unregister("alpha")
+	got = registry.AllSpecs()
+	if len(got) != 1 || got[0].Name != "beta" {
+		t.Fatalf("after Unregister, AllSpecs() = %#v, want beta", got)
+	}
+}
+
+func BenchmarkToolRegistryAllSpecs(b *testing.B) {
+	registry := NewToolRegistry()
+	const toolCount = 128
+	for i := 0; i < toolCount; i++ {
+		registry.Register(&namedTestTool{name: fmt.Sprintf("tool-%03d", i)})
+	}
+
+	b.ReportAllocs()
+	if specs := registry.AllSpecs(); len(specs) != toolCount {
+		b.Fatalf("len(AllSpecs()) = %d, want %d", len(specs), toolCount)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		specs := registry.AllSpecs()
+		if len(specs) != toolCount {
+			b.Fatalf("len(AllSpecs()) = %d, want %d", len(specs), toolCount)
+		}
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -124,6 +124,10 @@ type Part struct {
 }
 
 // ToolSpec describes a callable tool.
+//
+// Tool specs are treated as immutable after registration. In particular, Schema
+// maps returned from registries may be shared across calls; provider code that
+// needs to rewrite a schema must copy it first.
 type ToolSpec struct {
 	Name        string
 	Description string


### PR DESCRIPTION
## What

Cache `ToolRegistry.AllSpecs()` results in deterministic name order and invalidate the cache when tools are registered or unregistered.

This keeps the returned slice/top-level `ToolSpec` values independent while documenting the existing immutability contract for `ToolSpec.Schema` maps.

## Why

`AllSpecs()` is called on request-building paths and in local test loops. The previous implementation rebuilt the tool-name slice, sorted it, and called every tool's `Spec()` on every call even when the registry was unchanged.

## Verification

- `go test -run '^$' -bench '^BenchmarkToolRegistryAllSpecs$' -benchmem -count=5 ./internal/llm`
- `go test -count=3 -run '^(TestToolRegistry(AllSpecsSortedByName|AllSpecsReturnedSliceIsIndependent|AllSpecsInvalidatesCache|ConcurrentAccess)|TestToolSpecsForRequestPreservesSortedOrderAfterFiltering)$' -v ./internal/llm`
- `go test ./internal/llm`
- `go build ./...`
- `go test -count=1 ./...`

## Evidence

Representative benchmark (`BenchmarkToolRegistryAllSpecs`, 128 registered tools):

- Before: ~20.3 µs/op, 51.8 KB/op, 258 allocs/op
- After: ~1.0 µs/op, 6.5 KB/op, 1 alloc/op

The concurrent registry stress test also dropped from ~1.29-1.35s per run to ~0.12-0.14s per run in focused `-count=3` runs.
