### PR TITLE
perf: avoid full-tree glob scans

### DIFF
--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -3,7 +3,9 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,6 +43,8 @@ type FileEntry struct {
 }
 
 const maxGlobResults = 200
+
+var errGlobResultLimit = errors.New("glob result limit reached")
 
 func (t *GlobTool) Spec() llm.ToolSpec {
 	return llm.ToolSpec{
@@ -125,41 +129,29 @@ func (t *GlobTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "cannot resolve path: %v", err))), nil
 	}
 
-	// Find matching files by walking the directory
+	// Let doublestar drive the traversal from the pattern instead of walking the
+	// whole tree and matching every path. This keeps exact and prefix-heavy globs
+	// (for example "go.mod" or "cmd/*.go") proportional to the matched subtree.
 	var entries []FileEntry
-	pattern := a.Pattern
+	truncated := false
+	pattern := filepath.ToSlash(a.Pattern)
+	if err := validateGlobPattern(pattern); err != nil {
+		return textOutput(formatToolError(NewToolErrorf(ErrInvalidParams, "invalid pattern: %v", err))), nil
+	}
+	fsys := globContextFS{ctx: ctx, root: absBasePath, fsys: os.DirFS(absBasePath)}
 
-	err = filepath.WalkDir(absBasePath, func(path string, d os.DirEntry, err error) error {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		if err != nil {
-			return nil // Skip errors
-		}
-
-		// Skip hidden directories
-		if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
-			return filepath.SkipDir
+	err = doublestar.GlobWalk(fsys, pattern, func(matchPath string, d fs.DirEntry) error {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 
-		// Skip hidden files
-		if strings.HasPrefix(d.Name(), ".") {
-			return nil
-		}
-
-		// Get relative path for matching
-		relPath, err := filepath.Rel(absBasePath, path)
-		if err != nil {
-			return nil
-		}
-
-		// Check if pattern matches
-		matched, err := doublestar.Match(pattern, relPath)
-		if err != nil {
-			return nil
-		}
-
-		if !matched {
+		// Preserve the historical tool behaviour of ignoring hidden files and
+		// directories even when the pattern names them explicitly. WithNoHidden
+		// handles wildcard traversal; this callback handles exact dot-paths.
+		if hasHiddenPathSegment(matchPath) {
+			if d.IsDir() {
+				return doublestar.SkipDir
+			}
 			return nil
 		}
 
@@ -168,20 +160,28 @@ func (t *GlobTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 			return nil
 		}
 
+		fullPath := absBasePath
+		if matchPath != "." {
+			fullPath = filepath.Join(absBasePath, filepath.FromSlash(matchPath))
+		}
 		entries = append(entries, FileEntry{
-			FilePath:  path,
+			FilePath:  fullPath,
 			IsDir:     d.IsDir(),
 			SizeBytes: info.Size(),
 			ModTime:   info.ModTime(),
 		})
 
 		if len(entries) >= maxGlobResults {
-			return filepath.SkipAll
+			truncated = true
+			return errGlobResultLimit
 		}
 
 		return nil
-	})
+	}, doublestar.WithNoHidden(), doublestar.WithNoFollow(), doublestar.WithFailOnIOErrors())
 
+	if errors.Is(err, errGlobResultLimit) {
+		err = nil
+	}
 	if err != nil {
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "walk error: %v", err))), nil
 	}
@@ -195,7 +195,152 @@ func (t *GlobTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolO
 		return textOutput("No files matched the pattern."), nil
 	}
 
-	return textOutput(formatGlobResults(entries, len(entries) >= maxGlobResults)), nil
+	return textOutput(formatGlobResults(entries, truncated)), nil
+}
+
+func validateGlobPattern(pattern string) error {
+	if pattern == "." {
+		return nil
+	}
+	if strings.Contains(pattern, "..") {
+		return fmt.Errorf("must not contain .. path traversal")
+	}
+	if !fs.ValidPath(pattern) {
+		return fmt.Errorf("must be a relative pattern without . or .. path segments")
+	}
+	return nil
+}
+
+type globContextFS struct {
+	ctx  context.Context
+	root string
+	fsys fs.FS
+}
+
+func (f globContextFS) Open(name string) (fs.File, error) {
+	if _, err := f.lstatPath(name, false); err != nil {
+		return nil, err
+	}
+	file, err := f.fsys.Open(name)
+	if err != nil {
+		if ctxErr := f.ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fs.ErrNotExist
+	}
+	return globContextFile{ctx: f.ctx, File: file}, nil
+}
+
+func (f globContextFS) Stat(name string) (fs.FileInfo, error) {
+	return f.lstatPath(name, true)
+}
+
+func (f globContextFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	info, err := f.lstatPath(name, false)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fs.ErrNotExist
+	}
+
+	var (
+		entries []fs.DirEntry
+		readErr error
+	)
+	if readDirFS, ok := f.fsys.(fs.ReadDirFS); ok {
+		entries, readErr = readDirFS.ReadDir(name)
+	} else {
+		entries, readErr = fs.ReadDir(f.fsys, name)
+	}
+	if readErr != nil {
+		if ctxErr := f.ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, nil
+	}
+	return entries, nil
+}
+
+func (f globContextFS) lstatPath(name string, allowLeafSymlink bool) (fs.FileInfo, error) {
+	if err := f.ctx.Err(); err != nil {
+		return nil, err
+	}
+	if name != "" && name != "." && !fs.ValidPath(name) {
+		return nil, fs.ErrNotExist
+	}
+
+	current := f.root
+	parts := []string{"."}
+	if name != "" && name != "." {
+		parts = strings.Split(filepath.ToSlash(name), "/")
+	}
+
+	var info fs.FileInfo
+	for i, part := range parts {
+		if part == "" || part == "." {
+			current = f.root
+		} else if part == ".." {
+			return nil, fs.ErrNotExist
+		} else {
+			current = filepath.Join(current, filepath.FromSlash(part))
+		}
+
+		var err error
+		info, err = os.Lstat(current)
+		if err != nil {
+			if ctxErr := f.ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, err
+			}
+			return nil, fs.ErrNotExist
+		}
+		if info.Mode()&os.ModeSymlink != 0 && !(allowLeafSymlink && i == len(parts)-1) {
+			return nil, fs.ErrNotExist
+		}
+	}
+	return info, nil
+}
+
+type globContextFile struct {
+	ctx context.Context
+	fs.File
+}
+
+func (f globContextFile) Read(p []byte) (int, error) {
+	if err := f.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return f.File.Read(p)
+}
+
+func (f globContextFile) Stat() (fs.FileInfo, error) {
+	if err := f.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return f.File.Stat()
+}
+
+func (f globContextFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if err := f.ctx.Err(); err != nil {
+		return nil, err
+	}
+	readDirFile, ok := f.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, &fs.PathError{Op: "readdir", Err: errors.ErrUnsupported}
+	}
+	return readDirFile.ReadDir(n)
+}
+
+func hasHiddenPathSegment(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part != "" && part != "." && strings.HasPrefix(part, ".") {
+			return true
+		}
+	}
+	return false
 }
 
 // formatGlobResults formats glob results for the LLM.

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -1,0 +1,200 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGlobToolFindsMatchesAndSkipsHidden(t *testing.T) {
+	dir := t.TempDir()
+	visible := filepath.Join(dir, "visible.txt")
+	hiddenDirFile := filepath.Join(dir, ".hidden", "secret.txt")
+	hiddenFile := filepath.Join(dir, ".secret.txt")
+	if err := os.WriteFile(visible, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(hiddenDirFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hiddenDirFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hiddenFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewGlobTool(nil)
+	args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: "**/*.txt"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !strings.Contains(out.Content, visible) {
+		t.Fatalf("expected visible file in output, got:\n%s", out.Content)
+	}
+	if strings.Contains(out.Content, hiddenDirFile) || strings.Contains(out.Content, hiddenFile) {
+		t.Fatalf("hidden files should be skipped, got:\n%s", out.Content)
+	}
+
+	for _, pattern := range []string{".secret.txt", ".hidden/**"} {
+		t.Run("explicit hidden "+pattern, func(t *testing.T) {
+			args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: pattern})
+			out, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if out.Content != "No files matched the pattern." {
+				t.Fatalf("explicit hidden pattern should be ignored, got:\n%s", out.Content)
+			}
+		})
+	}
+}
+
+func TestGlobToolDoesNotTraverseSymlinkDirectory(t *testing.T) {
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+
+	tool := NewGlobTool(nil)
+	for _, pattern := range []string{"link/*.txt", "link/secret.txt"} {
+		t.Run(pattern, func(t *testing.T) {
+			args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: pattern})
+			out, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if out.Content != "No files matched the pattern." {
+				t.Fatalf("symlink directories must not be traversed, got:\n%s", out.Content)
+			}
+		})
+	}
+}
+
+func TestGlobToolCancelledContext(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tool := NewGlobTool(nil)
+	args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: "missing.txt"})
+	out, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(out.Content, context.Canceled.Error()) {
+		t.Fatalf("expected cancellation to be reported, got:\n%s", out.Content)
+	}
+}
+
+func TestGlobToolTruncatesAtLimit(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < maxGlobResults+5; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("file-%03d.txt", i))
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tool := NewGlobTool(nil)
+	args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: "*.txt"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(out.Content, fmt.Sprintf("[Results truncated at %d files]", maxGlobResults)) {
+		t.Fatalf("expected truncation notice, got:\n%s", out.Content)
+	}
+}
+
+func TestGlobToolRejectsEscapingPattern(t *testing.T) {
+	tool := NewGlobTool(nil)
+	for _, pattern := range []string{"../*.txt", "{..,safe}/*.txt"} {
+		t.Run(pattern, func(t *testing.T) {
+			args, _ := json.Marshal(GlobArgs{Path: t.TempDir(), Pattern: pattern})
+			out, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if !strings.Contains(out.Content, "Error [INVALID_PARAMS]") {
+				t.Fatalf("expected invalid pattern error, got:\n%s", out.Content)
+			}
+		})
+	}
+}
+
+func TestGlobToolExactPattern(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(target, []byte("module example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nested", "go.mod"), []byte("module nested\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewGlobTool(nil)
+	args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: "go.mod"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !strings.Contains(out.Content, target) {
+		t.Fatalf("expected root go.mod in output, got:\n%s", out.Content)
+	}
+	if strings.Contains(out.Content, filepath.Join(dir, "nested", "go.mod")) {
+		t.Fatalf("exact pattern should not match nested go.mod, got:\n%s", out.Content)
+	}
+}
+
+func BenchmarkGlobToolExactPatternLargeTree(b *testing.B) {
+	dir := b.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("target"), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	for d := 0; d < 80; d++ {
+		subdir := filepath.Join(dir, fmt.Sprintf("dir-%03d", d))
+		if err := os.MkdirAll(subdir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		for f := 0; f < 80; f++ {
+			path := filepath.Join(subdir, fmt.Sprintf("file-%03d.txt", f))
+			if err := os.WriteFile(path, []byte("noise"), 0o644); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	tool := NewGlobTool(nil)
+	args, _ := json.Marshal(GlobArgs{Path: dir, Pattern: "target.txt"})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := tool.Execute(context.Background(), args)
+		if err != nil {
+			b.Fatalf("Execute returned error: %v", err)
+		}
+		if !strings.Contains(out.Content, target) {
+			b.Fatalf("glob output missing target: %s", out.Content)
+		}
+	}
+}


### PR DESCRIPTION
## What

Optimize the built-in `glob` tool by replacing the old `filepath.WalkDir` + `doublestar.Match` scan-every-entry loop with pattern-guided `doublestar.GlobWalk` traversal.

The new traversal:
- avoids walking unrelated directories for exact and prefix-heavy patterns such as `go.mod`, `README.md`, or `cmd/*.go`
- preserves hidden-file filtering, result truncation, mtime sorting, and cancellation behavior
- validates glob patterns as relative to the approved base path
- avoids traversing symlink directories from the search root

## Why

The previous implementation walked the entire base tree for sparse globs because it matched every visited path after the fact. A common lookup like `glob(pattern: "go.mod")` still paid for a full repository walk when it only needs a single stat.

## Evidence

Representative benchmark on a temp tree with 6,400 unrelated files and one root `target.txt`:

Before:

```text
BenchmarkGlobToolExactPatternLargeTree-32    ~3.7 ms/op    ~1.43 MB/op    ~20,474 allocs/op
```

After:

```text
BenchmarkGlobToolExactPatternLargeTree-32    ~5.9 µs/op    ~3.2 KB/op     59 allocs/op
```

## Verification

```text
go test ./internal/tools -run 'TestGlobTool' -bench BenchmarkGlobToolExactPatternLargeTree -benchmem -count=5
go test ./...
go build ./...
```
