### PR TITLE
fix: /v1/models has no cache and can block initial /chat startup on upstream provider model listing

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -944,8 +944,9 @@ type serveServer struct {
 	shutdownOnce      sync.Once
 	modelsMu          sync.Mutex
 	modelsProviders   map[string]llm.Provider // keyed by provider name
-	responseToSession sync.Map                // response_id (string) → session_id (string)
-	sessionToResponse sync.Map                // session_id (string) → latest response_id (string)
+	modelsCache       map[string]serveModelsCacheEntry
+	responseToSession sync.Map // response_id (string) → session_id (string)
+	sessionToResponse sync.Map // session_id (string) → latest response_id (string)
 	responseRunsOnce  sync.Once
 	responseRuns      *responseRunManager
 	webrtcEnabled     bool
@@ -1097,6 +1098,7 @@ func (s *serveServer) Stop(ctx context.Context) error {
 		}
 	}
 	s.modelsProviders = nil
+	s.modelsCache = nil
 	s.modelsMu.Unlock()
 	return s.server.Shutdown(ctx)
 }

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1164,6 +1164,13 @@ func (s *serveServer) handleProviders(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+const serveModelsCacheTTL = 15 * time.Minute
+
+type serveModelsCacheEntry struct {
+	models    []llm.ModelInfo
+	expiresAt time.Time
+}
+
 func (s *serveServer) handleModels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
@@ -1178,11 +1185,8 @@ func (s *serveServer) handleModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
-	defer cancel()
-
 	models := make([]llm.ModelInfo, 0)
-	// Openrouter ships hundreds of models — going to the upstream API on every
+	// OpenRouter ships hundreds of models — going to the upstream API on every
 	// popover open would block the UI and cost tokens. The warm cache (6h TTL,
 	// background refresh on stale) gives us snappy opens after the first hit.
 	pc, hasCfg := s.cfgRef.Providers[effectiveName]
@@ -1197,33 +1201,26 @@ func (s *serveServer) handleModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(models) == 0 {
+		models = s.getCachedModelsForProvider(effectiveName)
+	}
+	if len(models) == 0 {
+		// Prefer the already-available local model lists exposed by /v1/providers
+		// (config + curated defaults) so the web UI can finish booting without
+		// waiting on an upstream model-list round trip.
+		models = s.getLocalModelsForProvider(effectiveName, queryProvider)
+	}
+	if len(models) == 0 {
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
 		if lister, ok := provider.(interface {
 			ListModels(context.Context) ([]llm.ModelInfo, error)
 		}); ok {
 			listed, err := lister.ListModels(ctx)
 			if err == nil {
+				s.setCachedModelsForProvider(effectiveName, listed)
 				models = listed
 			} else if !errors.Is(err, llm.ErrListModelsUnsupported) {
 				s.verboseLog("ListModels(%q) failed: %v", effectiveName, err)
-			}
-		}
-	}
-
-	if len(models) == 0 {
-		if pc, ok := s.cfgRef.Providers[effectiveName]; ok {
-			if pc.Model != "" {
-				models = append(models, llm.ModelInfo{ID: pc.Model})
-			}
-		} else if queryProvider == "" {
-			if providerCfg := s.cfgRef.GetActiveProviderConfig(); providerCfg != nil {
-				if providerCfg.Model != "" {
-					models = append(models, llm.ModelInfo{ID: providerCfg.Model})
-				}
-			}
-		}
-		if curated := llm.ResolveProviderModelIDs(effectiveName); len(curated) > 0 {
-			for _, id := range curated {
-				models = append(models, llm.ModelInfo{ID: id})
 			}
 		}
 	}
@@ -1273,6 +1270,74 @@ func (s *serveServer) handleModels(w http.ResponseWriter, r *http.Request) {
 		"object": "list",
 		"data":   items,
 	})
+}
+
+func appendModelIDs(dst []llm.ModelInfo, ids []string) []llm.ModelInfo {
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		dst = append(dst, llm.ModelInfo{ID: id})
+	}
+	return dst
+}
+
+func cloneModelInfos(models []llm.ModelInfo) []llm.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	cloned := make([]llm.ModelInfo, len(models))
+	copy(cloned, models)
+	return cloned
+}
+
+func (s *serveServer) getLocalModelsForProvider(effectiveName, queryProvider string) []llm.ModelInfo {
+	models := make([]llm.ModelInfo, 0)
+	if pc, ok := s.cfgRef.Providers[effectiveName]; ok {
+		models = appendModelIDs(models, pc.Models)
+		if id := strings.TrimSpace(pc.Model); id != "" {
+			models = append(models, llm.ModelInfo{ID: id})
+		}
+	} else if queryProvider == "" {
+		if providerCfg := s.cfgRef.GetActiveProviderConfig(); providerCfg != nil {
+			models = appendModelIDs(models, providerCfg.Models)
+			if id := strings.TrimSpace(providerCfg.Model); id != "" {
+				models = append(models, llm.ModelInfo{ID: id})
+			}
+		}
+	}
+	return appendModelIDs(models, llm.ResolveProviderModelIDs(effectiveName))
+}
+
+func (s *serveServer) getCachedModelsForProvider(name string) []llm.ModelInfo {
+	s.modelsMu.Lock()
+	defer s.modelsMu.Unlock()
+
+	if entry, ok := s.modelsCache[name]; ok {
+		if time.Now().Before(entry.expiresAt) {
+			return cloneModelInfos(entry.models)
+		}
+		delete(s.modelsCache, name)
+	}
+	return nil
+}
+
+func (s *serveServer) setCachedModelsForProvider(name string, models []llm.ModelInfo) {
+	if len(models) == 0 {
+		return
+	}
+
+	s.modelsMu.Lock()
+	defer s.modelsMu.Unlock()
+
+	if s.modelsCache == nil {
+		s.modelsCache = make(map[string]serveModelsCacheEntry)
+	}
+	s.modelsCache[name] = serveModelsCacheEntry{
+		models:    cloneModelInfos(models),
+		expiresAt: time.Now().Add(serveModelsCacheTTL),
+	}
 }
 
 func (s *serveServer) getModelsProvider(name string) (llm.Provider, string, error) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -78,6 +78,33 @@ type stagedProvider struct {
 	closeFirst    sync.Once
 }
 
+type countingListModelsProvider struct {
+	name   string
+	models []llm.ModelInfo
+	calls  int32
+}
+
+func (p *countingListModelsProvider) Name() string { return p.name }
+
+func (p *countingListModelsProvider) Credential() string { return "mock" }
+
+func (p *countingListModelsProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+
+func (p *countingListModelsProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	return nil, errors.New("not used in test")
+}
+
+func (p *countingListModelsProvider) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	atomic.AddInt32(&p.calls, 1)
+	out := make([]llm.ModelInfo, len(p.models))
+	copy(out, p.models)
+	return out, nil
+}
+
+func (p *countingListModelsProvider) CallCount() int {
+	return int(atomic.LoadInt32(&p.calls))
+}
+
 func newStagedProvider(firstChunk, secondChunk string) *stagedProvider {
 	return &stagedProvider{
 		firstChunk:    firstChunk,
@@ -8260,6 +8287,87 @@ func TestHandleModels_WithProviderParam(t *testing.T) {
 	srv.handleModels(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 for unknown provider", rr.Code)
+	}
+}
+
+func TestHandleModels_PrefersLocalModelsWithoutUpstreamList(t *testing.T) {
+	provider := &countingListModelsProvider{
+		name:   "acme",
+		models: []llm.ModelInfo{{ID: "from-upstream"}},
+	}
+	srv := &serveServer{
+		cfgRef: &config.Config{
+			DefaultProvider: "acme",
+			Providers: map[string]config.ProviderConfig{
+				"acme": {
+					Type:    config.ProviderTypeOpenAICompat,
+					BaseURL: "http://example.invalid/v1",
+					Model:   "acme-pro",
+					Models:  []string{"acme-fast", "acme-pro"},
+				},
+			},
+		},
+		modelsProviders: map[string]llm.Provider{"acme": provider},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rr := httptest.NewRecorder()
+	srv.handleModels(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if calls := provider.CallCount(); calls != 0 {
+		t.Fatalf("ListModels call count = %d, want 0", calls)
+	}
+
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	got := make([]string, 0, len(result.Data))
+	for _, item := range result.Data {
+		got = append(got, item.ID)
+	}
+	if !reflect.DeepEqual(got, []string{"acme-pro", "acme-fast"}) {
+		t.Fatalf("model ids = %v, want [acme-pro acme-fast]", got)
+	}
+}
+
+func TestHandleModels_CachesUpstreamListResults(t *testing.T) {
+	provider := &countingListModelsProvider{
+		name: "custom",
+		models: []llm.ModelInfo{
+			{ID: "custom-a"},
+			{ID: "custom-b"},
+		},
+	}
+	srv := &serveServer{
+		cfgRef: &config.Config{
+			DefaultProvider: "custom",
+			Providers: map[string]config.ProviderConfig{
+				"custom": {
+					Type:    config.ProviderTypeOpenAICompat,
+					BaseURL: "http://example.invalid/v1",
+				},
+			},
+		},
+		modelsProviders: map[string]llm.Provider{"custom": provider},
+	}
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		rr := httptest.NewRecorder()
+		srv.handleModels(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200; body: %s", i+1, rr.Code, rr.Body.String())
+		}
+	}
+	if calls := provider.CallCount(); calls != 1 {
+		t.Fatalf("ListModels call count = %d, want 1", calls)
 	}
 }
 


### PR DESCRIPTION
## What

- make `/v1/models` prefer already-available local model lists (`providers.*.models`, configured default model, curated built-in lists) before attempting upstream `ListModels`
- add a small in-memory cache for upstream `ListModels` responses when `/v1/models` does need to fetch dynamically
- add regression tests covering the fast local path and the new memoized upstream path

## Why

The web UI waits on `/v1/models` during startup. Before this change, the handler could spend up to 15 seconds blocking on an upstream model-list API call even though `/v1/providers` already exposed enough model data for the UI to render immediately. This makes first-load latency provider-dependent and especially painful for slow model-list endpoints.

Serving the local/configured model list first removes that startup round trip in the common case, while memoizing dynamic listings avoids repeating the same slow upstream request for providers that truly need it.
