### PR TITLE
fix: Session history loads the entire transcript, inlines image blobs, and returns it as one giant response

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -655,6 +656,126 @@ func serveUploadsDir() string {
 	return filepath.Join(dataDir, "uploads")
 }
 
+const sessionMessagesPageSize = 200
+
+func parseSessionMessagesLimit(raw string) int {
+	limit, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || limit <= 0 {
+		return sessionMessagesPageSize
+	}
+	if limit > sessionMessagesPageSize {
+		return sessionMessagesPageSize
+	}
+	return limit
+}
+
+func parseSessionMessagesOffset(raw string) int {
+	offset, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || offset < 0 {
+		return 0
+	}
+	return offset
+}
+
+func imageExtensionForMediaType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.ToLower(contentType))
+	}
+	exts, err := mime.ExtensionsByType(mediaType)
+	if err == nil {
+		for _, ext := range exts {
+			if ext != "" {
+				return ext
+			}
+		}
+	}
+	switch mediaType {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/svg+xml":
+		return ".svg"
+	default:
+		return ".img"
+	}
+}
+
+func (s *serveServer) materializeInlineSessionImage(mediaType, base64Data string) (string, bool) {
+	outputDir := s.imageOutputDir()
+	absDir, err := canonicalizeServeDirForWrite(outputDir)
+	if err != nil {
+		log.Printf("[serve] materializeInlineSessionImage: resolve dir %s: %v", outputDir, err)
+		return "", false
+	}
+	if err := os.MkdirAll(absDir, 0755); err != nil {
+		log.Printf("[serve] materializeInlineSessionImage: mkdir %s: %v", absDir, err)
+		return "", false
+	}
+
+	mediaType = strings.TrimSpace(mediaType)
+	base64Data = strings.TrimSpace(base64Data)
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, mediaType)
+	_, _ = io.WriteString(hash, "\n")
+	_, _ = io.WriteString(hash, base64Data)
+	sum := hash.Sum(nil)
+	destName := "history-" + hex.EncodeToString(sum[:16]) + imageExtensionForMediaType(mediaType)
+	destPath := filepath.Join(absDir, destName)
+	if info, err := os.Stat(destPath); err == nil && !info.IsDir() {
+		return destPath, true
+	}
+
+	tmpPath := destPath + ".tmp-" + randomSuffix()
+	dst, err := os.Create(tmpPath)
+	if err != nil {
+		log.Printf("[serve] materializeInlineSessionImage: create %s: %v", tmpPath, err)
+		return "", false
+	}
+	dec := base64.NewDecoder(base64.StdEncoding, strings.NewReader(base64Data))
+	if _, err := io.Copy(dst, dec); err != nil {
+		dst.Close()
+		os.Remove(tmpPath)
+		log.Printf("[serve] materializeInlineSessionImage: decode %s: %v", destPath, err)
+		return "", false
+	}
+	if err := dst.Close(); err != nil {
+		os.Remove(tmpPath)
+		log.Printf("[serve] materializeInlineSessionImage: close %s: %v", tmpPath, err)
+		return "", false
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		if _, statErr := os.Stat(destPath); statErr == nil {
+			os.Remove(tmpPath)
+			return destPath, true
+		}
+		os.Remove(tmpPath)
+		log.Printf("[serve] materializeInlineSessionImage: rename %s -> %s: %v", tmpPath, destPath, err)
+		return "", false
+	}
+	return destPath, true
+}
+
+func (s *serveServer) sessionMessageImageURL(part llm.Part) string {
+	if part.ImagePath != "" {
+		if served, ok := s.ensureImageServeable(part.ImagePath); ok {
+			return serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served)
+		}
+	}
+	if part.ImageData == nil || strings.TrimSpace(part.ImageData.Base64) == "" {
+		return ""
+	}
+	if served, ok := s.materializeInlineSessionImage(part.ImageData.MediaType, part.ImageData.Base64); ok {
+		return serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served)
+	}
+	return ""
+}
+
 func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
@@ -830,13 +951,18 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	msgs, err := s.store.GetMessages(r.Context(), sessionID, limit, offset)
+	limit := parseSessionMessagesLimit(r.URL.Query().Get("limit"))
+	offset := parseSessionMessagesOffset(r.URL.Query().Get("offset"))
+	msgs, err := s.store.GetMessages(r.Context(), sessionID, limit+1, offset)
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get messages")
 		return
 	}
+	hasMore := len(msgs) > limit
+	if hasMore {
+		msgs = msgs[:limit]
+	}
+	nextOffset := offset + len(msgs)
 
 	type partEntry struct {
 		Type       string `json:"type"`
@@ -852,6 +978,12 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		Role      string      `json:"role"`
 		Parts     []partEntry `json:"parts"`
 		CreatedAt int64       `json:"created_at"`
+	}
+
+	type messagesResponse struct {
+		Messages   []messageEntry `json:"messages"`
+		HasMore    bool           `json:"has_more"`
+		NextOffset int            `json:"next_offset,omitempty"`
 	}
 
 	result := make([]messageEntry, 0, len(msgs))
@@ -890,11 +1022,15 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 					})
 				}
 			case llm.PartImage:
-				if p.ImageData != nil && p.ImageData.Base64 != "" {
+				if imageURL := s.sessionMessageImageURL(p); imageURL != "" {
+					mimeType := ""
+					if p.ImageData != nil {
+						mimeType = p.ImageData.MediaType
+					}
 					entry.Parts = append(entry.Parts, partEntry{
 						Type:     "image",
-						ImageURL: "data:" + p.ImageData.MediaType + ";base64," + p.ImageData.Base64,
-						MimeType: p.ImageData.MediaType,
+						ImageURL: imageURL,
+						MimeType: mimeType,
 					})
 				}
 			case llm.PartToolCall:
@@ -919,18 +1055,31 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		result = append(result, entry)
 	}
 
-	body, _ := json.Marshal(map[string]any{"messages": result})
-	hash := sha256.Sum256(body)
-	etag := `"` + hex.EncodeToString(hash[:8]) + `"`
-	w.Header().Set("ETag", etag)
+	resp := messagesResponse{Messages: result, HasMore: hasMore}
+	if hasMore {
+		resp.NextOffset = nextOffset
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	etagHash := sha256.New()
+	if meta, metaErr := s.store.Get(r.Context(), sessionID); metaErr == nil && meta != nil {
+		_, _ = io.WriteString(etagHash, strconv.FormatInt(meta.UpdatedAt.UnixMilli(), 10))
+		_, _ = io.WriteString(etagHash, "\n")
+	}
+	_, _ = etagHash.Write(body)
+	etag := `"` + hex.EncodeToString(etagHash.Sum(nil)) + `"`
 	w.Header().Set("Cache-Control", "no-cache")
-	if r.Header.Get("If-None-Match") == etag {
+	w.Header().Set("ETag", etag)
+	if uiETagMatches(r.Header.Get("If-None-Match"), etag) {
+		w.Header().Set("Content-Type", "application/json")
+		uiAddVary(w.Header(), "Accept-Encoding")
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(body)
+	writeJSONGzipBody(w, r, http.StatusOK, body)
 }
 
 func (s *serveServer) handleSessionInterrupt(w http.ResponseWriter, r *http.Request, sessionID string) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3711,6 +3711,103 @@ func TestHandleSessionMessages_ReturnsStructuredParts(t *testing.T) {
 	}
 }
 
+func TestHandleSessionMessages_DefaultPagination(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &session.Session{
+		ID:        "sess-page",
+		Provider:  "mock",
+		Model:     "mock-model",
+		Mode:      session.ModeChat,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Status:    session.StatusActive,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for i := 0; i < sessionMessagesPageSize+5; i++ {
+		msg := session.NewMessage("sess-page", llm.UserText(fmt.Sprintf("msg-%03d", i)), -1)
+		if err := store.AddMessage(ctx, "sess-page", msg); err != nil {
+			t.Fatalf("AddMessage(%d): %v", i, err)
+		}
+	}
+
+	srv := &serveServer{store: store}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-page/messages", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var body struct {
+		Messages []struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"messages"`
+		HasMore    bool `json:"has_more"`
+		NextOffset int  `json:"next_offset"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Messages) != sessionMessagesPageSize {
+		t.Fatalf("message count = %d, want %d", len(body.Messages), sessionMessagesPageSize)
+	}
+	if !body.HasMore {
+		t.Fatal("expected has_more=true for truncated history page")
+	}
+	if body.NextOffset != sessionMessagesPageSize {
+		t.Fatalf("next_offset = %d, want %d", body.NextOffset, sessionMessagesPageSize)
+	}
+	if got := body.Messages[0].Parts[0].Text; got != "msg-000" {
+		t.Fatalf("first message text = %q, want msg-000", got)
+	}
+	if got := body.Messages[len(body.Messages)-1].Parts[0].Text; got != fmt.Sprintf("msg-%03d", sessionMessagesPageSize-1) {
+		t.Fatalf("last message text = %q, want %q", got, fmt.Sprintf("msg-%03d", sessionMessagesPageSize-1))
+	}
+
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sessions/sess-page/messages?limit=%d&offset=%d", sessionMessagesPageSize, sessionMessagesPageSize), nil)
+	rr = httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d, want 200", rr.Code)
+	}
+	body = struct {
+		Messages []struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"messages"`
+		HasMore    bool `json:"has_more"`
+		NextOffset int  `json:"next_offset"`
+	}{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode page 2: %v", err)
+	}
+	if len(body.Messages) != 5 {
+		t.Fatalf("page 2 message count = %d, want 5", len(body.Messages))
+	}
+	if body.HasMore {
+		t.Fatal("expected has_more=false on final page")
+	}
+	if body.NextOffset != 0 {
+		t.Fatalf("final next_offset = %d, want 0", body.NextOffset)
+	}
+	if got := body.Messages[0].Parts[0].Text; got != fmt.Sprintf("msg-%03d", sessionMessagesPageSize) {
+		t.Fatalf("page 2 first message text = %q, want %q", got, fmt.Sprintf("msg-%03d", sessionMessagesPageSize))
+	}
+}
+
 func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
@@ -3739,7 +3836,9 @@ func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 		t.Fatalf("AddMessage: %v", err)
 	}
 
-	srv := &serveServer{store: store}
+	outputDir := t.TempDir()
+	srv := &serveServer{store: store, cfgRef: &config.Config{}}
+	srv.cfgRef.Image.OutputDir = outputDir
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-image/messages", nil)
 	rr := httptest.NewRecorder()
@@ -3776,14 +3875,24 @@ func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 	if m.Parts[0].Type != "image" {
 		t.Fatalf("part[0].type = %q, want image", m.Parts[0].Type)
 	}
-	if m.Parts[0].ImageURL != "data:image/png;base64,aGVsbG8=" {
-		t.Fatalf("part[0].image_url = %q, want data URL", m.Parts[0].ImageURL)
+	if !strings.HasPrefix(m.Parts[0].ImageURL, "/images/history-") {
+		t.Fatalf("part[0].image_url = %q, want /images/history-*", m.Parts[0].ImageURL)
 	}
 	if m.Parts[0].MimeType != "image/png" {
 		t.Fatalf("part[0].mime_type = %q, want image/png", m.Parts[0].MimeType)
 	}
 	if m.Parts[1].Type != "text" || m.Parts[1].Text != "describe this" {
 		t.Fatalf("part[1] = %+v, want trailing text part", m.Parts[1])
+	}
+
+	imgReq := httptest.NewRequest(http.MethodGet, m.Parts[0].ImageURL, nil)
+	imgRR := httptest.NewRecorder()
+	srv.handleImage(imgRR, imgReq)
+	if imgRR.Code != http.StatusOK {
+		t.Fatalf("image status = %d, want 200", imgRR.Code)
+	}
+	if got := imgRR.Body.String(); got != "hello" {
+		t.Fatalf("image body = %q, want %q", got, "hello")
 	}
 }
 

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -342,21 +342,54 @@ const convertServerMessages = (serverMessages) => {
 };
 
 const sessionMessagesEtag = new Map();
+const SESSION_MESSAGES_PAGE_SIZE = 200;
+
+const fetchServerSessionMessagesPage = async (sessionId, { limit = 0, offset = 0, etag = '' } = {}) => {
+  const headers = {};
+  if (state.token) headers.Authorization = `Bearer ${state.token}`;
+  if (etag) headers['If-None-Match'] = etag;
+
+  const params = new URLSearchParams();
+  if (limit > 0) params.set('limit', String(limit));
+  if (offset > 0) params.set('offset', String(offset));
+  const query = params.toString();
+
+  const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/messages${query ? `?${query}` : ''}`, { headers });
+  if (resp.status === 304) return false;
+  if (!resp.ok) return null;
+
+  const data = await resp.json().catch(() => null);
+  if (!data || !Array.isArray(data.messages)) return null;
+  return {
+    data,
+    etag: resp.headers.get('ETag') || ''
+  };
+};
 
 const loadServerSessionMessages = async (sessionId) => {
   try {
-    const headers = {};
-    if (state.token) headers.Authorization = `Bearer ${state.token}`;
-    const etag = sessionMessagesEtag.get(sessionId);
-    if (etag) headers['If-None-Match'] = etag;
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/messages`, { headers });
-    if (resp.status === 304) return false;
-    if (!resp.ok) return null;
-    const newEtag = resp.headers.get('ETag');
-    if (newEtag) sessionMessagesEtag.set(sessionId, newEtag);
-    const data = await resp.json();
-    if (!Array.isArray(data.messages)) return null;
-    return convertServerMessages(data.messages);
+    const first = await fetchServerSessionMessagesPage(sessionId, { etag: sessionMessagesEtag.get(sessionId) || '' });
+    if (first === false) return false;
+    if (!first) return null;
+
+    if (first.etag) sessionMessagesEtag.set(sessionId, first.etag);
+
+    const allMessages = first.data.messages.slice();
+    let hasMore = first.data.has_more === true;
+    let nextOffset = Number(first.data.next_offset);
+    const seenOffsets = new Set();
+
+    while (hasMore) {
+      if (!Number.isFinite(nextOffset) || nextOffset < 0 || seenOffsets.has(nextOffset)) return null;
+      seenOffsets.add(nextOffset);
+      const page = await fetchServerSessionMessagesPage(sessionId, { limit: SESSION_MESSAGES_PAGE_SIZE, offset: nextOffset });
+      if (!page) return null;
+      allMessages.push(...page.data.messages);
+      hasMore = page.data.has_more === true;
+      nextOffset = Number(page.data.next_offset);
+    }
+
+    return convertServerMessages(allMessages);
   } catch {
     return null;
   }

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -433,6 +433,79 @@ async function testDeveloperMessagesAreHidden() {
   pass(name);
 }
 
+async function testSessionHistoryPaginationLoadsAdditionalPages() {
+  const name = 'session history pagination loads additional pages';
+  const fetchCalls = [];
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/77',
+    fetchImpl: async (url) => {
+      fetchCalls.push(url);
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: 'sess_page',
+            number: 77,
+            short_title: 'Paged session',
+            long_title: 'Paged session',
+            mode: 'chat',
+            origin: 'web',
+            archived: false,
+            pinned: false,
+            created_at: 1710000000000,
+            message_count: 201,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_page/messages') {
+        return new Response(JSON.stringify({
+          messages: [{
+            role: 'user',
+            created_at: 1710000000000,
+            parts: [{ type: 'text', text: 'first page' }],
+          }],
+          has_more: true,
+          next_offset: 200,
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"sess-page-v1"' } });
+      }
+      if (url === '/ui/v1/sessions/sess_page/messages?limit=200&offset=200') {
+        return new Response(JSON.stringify({
+          messages: [{
+            role: 'assistant',
+            created_at: 1710000001000,
+            parts: [{ type: 'text', text: 'second page' }],
+          }],
+          has_more: false,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_page/state') {
+        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+
+  if (!fetchCalls.includes('/ui/v1/sessions/sess_page/messages?limit=200&offset=200')) {
+    fail(name, 'expected follow-up paginated fetch', JSON.stringify(fetchCalls));
+    return;
+  }
+
+  const session = app.state.sessions.find((item) => item.id === 'sess_page');
+  if (!session) {
+    fail(name, 'session not found after paginated load');
+    return;
+  }
+  if (session.messages.length !== 2) {
+    fail(name, `expected 2 merged messages, got ${session.messages.length}`);
+    return;
+  }
+  if (session.messages[0].content !== 'first page' || session.messages[1].content !== 'second page') {
+    fail(name, 'expected both pages to merge in order', JSON.stringify(session.messages));
+    return;
+  }
+
+  pass(name);
+}
+
 async function testSwitchToSessionSyncsWithoutTokenAndResumes() {
   const name = 'sidebar session switch syncs with server and resumes without token';
   const fetchCalls = [];
@@ -1280,6 +1353,7 @@ async function testSanitizeSessionPreservesLastMessageAt() {
   await testSwitchingSessionsStagesCurrentComposerBeforeRestore();
   await testNumericDeepLinkResolvesRealSessionId();
   await testDeveloperMessagesAreHidden();
+  await testSessionHistoryPaginationLoadsAdditionalPages();
   await testSwitchToSessionSyncsWithoutTokenAndResumes();
   await testSwitchToSessionRecoversChangedActiveResponseFromSnapshot();
   await testSwitchToSessionClearsStaleActiveResponseWithoutToken();


### PR DESCRIPTION
## What

- paginate `/v1/sessions/{id}/messages` with a bounded page size and `has_more` / `next_offset` metadata instead of returning one unbounded response
- materialize stored inline image blobs into served `/images/` files so session history JSON no longer embeds large `data:` URLs
- preserve conditional reloads by hashing the response body together with the session `updated_at`, and teach the web UI to follow paginated history pages when needed
- add Go and serve-ui tests covering pagination and served image history payloads

## Why

Large transcripts were being loaded as one giant JSON payload, including base64 image blobs, whenever the web UI opened or reconciled a session. That scaled browser/server work with the full transcript size, caused avoidable memory churn, and made large chats noticeably slower to open and refresh. Paging the history and serving images out-of-band keeps each response bounded while preserving full session history and image rendering.
