### PR TITLE
perf: amortize response run replay compaction

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -64,8 +64,10 @@ type responseRun struct {
 	usage              llm.Usage
 	sessionUsage       llm.Usage
 	lastSequenceNumber int64
-	// Retain the raw event stream until the run expires so reconnecting clients can replay by sequence number.
+	// events[eventStart:] is the retained replay window; dropped prefix slots
+	// are zeroed and reclaimed in batches to avoid per-token slice copies.
 	events             []responseRunEvent
+	eventStart         int
 	minReplayAfter     int64
 	maxRetainedEvents  int
 	recoveryMessages   []responseRunRecoveryMessage
@@ -258,27 +260,53 @@ func (r *responseRun) appendTextDeltaEvent(outputIndex int, delta string) error 
 }
 
 func (r *responseRun) compactEventsLocked() {
-	if !r.compactionEnabled || r.maxRetainedEvents <= 0 || len(r.events) <= r.maxRetainedEvents {
+	if !r.compactionEnabled || r.maxRetainedEvents <= 0 {
 		return
 	}
 
-	dropCount := len(r.events) - r.maxRetainedEvents
-	if dropCount <= 0 {
+	activeLen := len(r.events) - r.eventStart
+	if activeLen <= r.maxRetainedEvents {
 		return
 	}
 
-	nextReplayAfter := r.events[dropCount].Sequence - 1
+	dropCount := activeLen - r.maxRetainedEvents
+	firstKept := r.eventStart + dropCount
+
+	nextReplayAfter := r.events[firstKept].Sequence - 1
 	if nextReplayAfter > r.minReplayAfter {
 		r.minReplayAfter = nextReplayAfter
 	}
 
-	keep := len(r.events) - dropCount
-	copy(r.events, r.events[dropCount:])
-	tail := r.events[keep:]
+	for i := r.eventStart; i < firstKept; i++ {
+		r.events[i] = responseRunEvent{}
+	}
+	r.eventStart = firstKept
+	r.compactEventStorageLocked()
+}
+
+// compactEventStorageLocked reclaims the dropped prefix in batches so steady
+// streaming appends avoid copying the replay window on every token while still
+// keeping the backing array bounded to roughly twice maxRetainedEvents.
+func (r *responseRun) compactEventStorageLocked() {
+	if r.eventStart == 0 {
+		return
+	}
+	if r.maxRetainedEvents > 0 && r.eventStart < r.maxRetainedEvents {
+		return
+	}
+
+	activeLen := len(r.events) - r.eventStart
+	copy(r.events, r.events[r.eventStart:])
+	tail := r.events[activeLen:]
 	for i := range tail {
 		tail[i] = responseRunEvent{}
 	}
-	r.events = r.events[:keep]
+	r.events = r.events[:activeLen]
+	r.eventStart = 0
+}
+
+func (r *responseRun) activeEventsLocked() []responseRunEvent {
+	return r.events[r.eventStart:]
 }
 
 func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]any) {
@@ -458,8 +486,9 @@ func (r *responseRun) subscribe(after int64) responseRunSubscribeResult {
 		}
 	}
 
-	replay := make([]responseRunEvent, 0, len(r.events))
-	for _, ev := range r.events {
+	replayEvents := r.activeEventsLocked()
+	replay := make([]responseRunEvent, 0, len(replayEvents))
+	for _, ev := range replayEvents {
 		if ev.Sequence > after {
 			replay = append(replay, ev)
 		}

--- a/cmd/serve_response_runs_bench_test.go
+++ b/cmd/serve_response_runs_bench_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkResponseRunAppendTextDeltaRetainedReplay(b *testing.B) {
+	run := newResponseRun("resp_bench", "sess_bench", "", "mock", time.Now().Unix(), func() {})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := run.appendTextDeltaEvent(0, ""); err != nil {
+			b.Fatalf("appendTextDeltaEvent failed: %v", err)
+		}
+	}
+}

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -102,6 +102,62 @@ func TestResponseRunSubscriberDroppedWhenBufferFull(t *testing.T) {
 	}
 }
 
+func TestResponseRunCompactionKeepsReplayWindowInOrder(t *testing.T) {
+	run := newResponseRun("resp_compact", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	run.maxRetainedEvents = 3
+
+	for i := 0; i < 8; i++ {
+		if err := run.appendTextDeltaEvent(0, ""); err != nil {
+			t.Fatalf("appendTextDeltaEvent failed at %d: %v", i, err)
+		}
+	}
+
+	run.mu.Lock()
+	activeLen := len(run.events) - run.eventStart
+	storageLen := len(run.events)
+	minReplayAfter := run.minReplayAfter
+	run.mu.Unlock()
+
+	if activeLen != 3 {
+		t.Fatalf("active retained events = %d, want 3", activeLen)
+	}
+	if storageLen > 6 {
+		t.Fatalf("storage length = %d, want bounded near replay window", storageLen)
+	}
+	if minReplayAfter != 5 {
+		t.Fatalf("minReplayAfter = %d, want 5", minReplayAfter)
+	}
+
+	stale := run.subscribe(4)
+	if !stale.snapshotRequired || stale.minReplayAfter != 5 {
+		t.Fatalf("subscribe before replay window = %#v, want snapshot required at 5", stale)
+	}
+
+	fresh := run.subscribe(5)
+	if fresh.snapshotRequired {
+		t.Fatalf("subscribe at replay window unexpectedly required snapshot: %#v", fresh)
+	}
+	if len(fresh.replay) != 3 {
+		t.Fatalf("replay length = %d, want 3", len(fresh.replay))
+	}
+	for i, ev := range fresh.replay {
+		expected := int64(i + 6)
+		if ev.Sequence != expected {
+			t.Fatalf("replay[%d].Sequence = %d, want %d", i, ev.Sequence, expected)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(ev.Data, &payload); err != nil {
+			t.Fatalf("replay[%d] payload is invalid JSON: %v", i, err)
+		}
+		if payload["sequence_number"] != float64(expected) {
+			t.Fatalf("replay[%d] payload sequence_number = %v, want %d", i, payload["sequence_number"], expected)
+		}
+	}
+	if fresh.ch != nil {
+		run.unsubscribe(fresh.ch)
+	}
+}
+
 func TestResponseRunConcurrentAppendsPreserveOrder(t *testing.T) {
 	const totalEvents = 200
 	const numWriters = 4


### PR DESCRIPTION
## What

Amortize response run replay-window compaction by tracking a logical `eventStart` offset and reclaiming the dropped prefix in batches instead of copying the entire retained replay window on every streamed event after the replay limit.

This keeps reconnect replay semantics intact by iterating only `events[eventStart:]`, and adds:

- a regression test for replay order, `minReplayAfter`, bounded storage, and encoded payload sequence numbers
- a benchmark for the retained replay append path

## Why

Long streamed responses retain only the last 2048 SSE events for reconnect replay. Once the old slice exceeded that limit, every new text delta copied the full 2048-event replay window while holding the response run mutex. A CPU profile of the new benchmark on the baseline showed `compactEventsLocked`/`runtime.memmove` dominating the append path.

## Evidence

Baseline, before this change:

```text
go test ./cmd -run '^$' -bench '^BenchmarkResponseRunAppendTextDeltaRetainedReplay$' -benchmem -count=5
BenchmarkResponseRunAppendTextDeltaRetainedReplay-32  ~2241-2252 ns/op  80 B/op  1 allocs/op
```

Baseline CPU profile for that benchmark:

```text
runtime.memmove                                      96.60%
github.com/samsaffron/term-llm/cmd.(*responseRun).compactEventsLocked  97.28% cum
```

After this change:

```text
go test ./cmd -run '^$' -bench '^BenchmarkResponseRunAppendTextDeltaRetainedReplay$' -benchmem -count=1
BenchmarkResponseRunAppendTextDeltaRetainedReplay-32  21929305  52.85 ns/op  80 B/op  1 allocs/op
```

Also verified:

```text
go test ./...
go build ./...
```
