### PR TITLE
feat: allow responses clients to append tools

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -225,7 +225,8 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	searchFromTools, requestedTools, passthroughTools := parseRequestedTools(req.Tools)
 	search := runtime.search || searchFromTools
 	toolChoice := parseToolChoice(req.ToolChoice)
-	tools := appendResponsePassthroughTools(runtime.selectTools(requestedTools), passthroughTools, runtime.toolMap)
+	serverTools := responseServerTools(runtime, requestedTools, req.IncludeServerTools)
+	tools := appendResponsePassthroughTools(serverTools, passthroughTools, runtime.toolMap)
 	if len(tools) == 0 {
 		toolChoice = llm.ToolChoice{}
 	}
@@ -384,6 +385,13 @@ func (s *serveServer) populateResponsesToolResultNames(ctx context.Context, sess
 			}
 		}
 	}
+}
+
+func responseServerTools(runtime *serveRuntime, requested map[string]bool, includeServerTools bool) []llm.ToolSpec {
+	if includeServerTools {
+		return runtime.selectTools(nil)
+	}
+	return runtime.selectTools(requested)
 }
 
 func appendResponsePassthroughTools(serverTools []llm.ToolSpec, passthroughTools []llm.ToolSpec, toolMap map[string]string) []llm.ToolSpec {

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -18,6 +18,7 @@ type responsesCreateRequest struct {
 	Provider           string                     `json:"provider"`
 	Input              json.RawMessage            `json:"input"`
 	Tools              []json.RawMessage          `json:"tools,omitempty"`
+	IncludeServerTools bool                       `json:"include_server_tools,omitempty"`
 	ToolChoice         json.RawMessage            `json:"tool_choice,omitempty"`
 	ParallelToolCalls  *bool                      `json:"parallel_tool_calls,omitempty"`
 	MaxOutputTokens    int                        `json:"max_output_tokens,omitempty"`

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2170,6 +2170,58 @@ func (e *echoTool) Execute(_ context.Context, _ json.RawMessage) (llm.ToolOutput
 
 func (e *echoTool) Preview(_ json.RawMessage) string { return "" }
 
+type secondEchoTool struct{}
+
+func (e *secondEchoTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        "second_echo",
+		Description: "Echoes input a second way",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (e *secondEchoTool) Execute(_ context.Context, _ json.RawMessage) (llm.ToolOutput, error) {
+	return llm.TextOutput("second echoed"), nil
+}
+
+func (e *secondEchoTool) Preview(_ json.RawMessage) string { return "" }
+
+func TestResponseServerTools_IncludeServerToolsKeepsAllRegisteredTools(t *testing.T) {
+	registry := llm.NewToolRegistry()
+	registry.Register(&echoTool{})
+	registry.Register(&secondEchoTool{})
+	provider := llm.NewMockProvider("mock")
+	rt := &serveRuntime{engine: llm.NewEngine(provider, registry)}
+
+	requested := map[string]bool{"client_music_tool": true}
+	filtered := responseServerTools(rt, requested, false)
+	if len(filtered) != 0 {
+		t.Fatalf("filtered server tools = %d, want 0 for client-only requested tools", len(filtered))
+	}
+
+	included := responseServerTools(rt, requested, true)
+	got := map[string]bool{}
+	for _, spec := range included {
+		got[spec.Name] = true
+	}
+	if !got["echo"] || !got["second_echo"] {
+		t.Fatalf("included server tools = %v, want echo and second_echo", got)
+	}
+}
+
+func TestAppendResponsePassthroughTools_AddsClientToolsWithoutDuplicatingServerTools(t *testing.T) {
+	serverTools := []llm.ToolSpec{{Name: "echo"}}
+	passthrough := []llm.ToolSpec{{Name: "echo"}, {Name: "client_music_tool"}}
+
+	tools := appendResponsePassthroughTools(serverTools, passthrough, nil)
+	if len(tools) != 2 {
+		t.Fatalf("tool count = %d, want 2", len(tools))
+	}
+	if tools[0].Name != "echo" || tools[1].Name != "client_music_tool" {
+		t.Fatalf("tools = %#v, want echo plus client_music_tool", tools)
+	}
+}
+
 func TestServeRuntimeRun_PersistsToolCallMessages(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

Adds an `include_server_tools` boolean to `/v1/responses` requests.

When a Responses API client sends its own function tools today, those tool names are treated as the requested server-tool allowlist. That is useful for API-compatible clients that want to select tools, but it means a mobile/native client cannot append phone-local tools while still letting the server expose its normal tools.

With `include_server_tools: true`, the server:

- includes all registered server tools for the runtime
- appends passthrough client tools that are not server-executed
- keeps the existing default behavior unchanged when the flag is omitted

## Why

The Jarvis iOS app text mode needs to advertise native tools such as Apple Music queue/playlist actions while still keeping main Jarvis server-side tools available, including podcast tools.

Without this flag, advertising `manage_music_playlist` would unintentionally filter out unrelated server tools.

## Tests

```text
go test ./cmd
```
