### PR TITLE
fix: Tool-history sanitization deep-clones the entire conversation on every provider call

### DIFF
--- a/internal/llm/tool_history_sanitize.go
+++ b/internal/llm/tool_history_sanitize.go
@@ -30,11 +30,96 @@ func FilterConversationMessages(messages []Message) []Message {
 // sanitizeToolHistory removes dangling tool calls and orphan tool results.
 // It preserves non-tool content while enforcing call/result pair integrity.
 func sanitizeToolHistory(messages []Message) []Message {
-	messages = FilterConversationMessages(messages)
 	if len(messages) == 0 {
 		return nil
 	}
 
+	filtered := messages
+	for _, msg := range messages {
+		if msg.Role != RoleEvent {
+			continue
+		}
+		filtered = FilterConversationMessages(messages)
+		break
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+
+	if toolHistoryAlreadyValid(filtered) {
+		return filtered[:len(filtered):len(filtered)]
+	}
+
+	return sanitizeToolHistorySlow(filtered)
+}
+
+func toolHistoryAlreadyValid(messages []Message) bool {
+	var pendingCalls map[string]int
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case RoleAssistant:
+			for _, part := range msg.Parts {
+				if !isSanitizablePart(part) {
+					return false
+				}
+				if part.Type != PartToolCall {
+					continue
+				}
+
+				callID := strings.TrimSpace(part.ToolCall.ID)
+				if callID == "" {
+					return false
+				}
+				if pendingCalls == nil {
+					pendingCalls = make(map[string]int)
+				}
+				pendingCalls[callID]++
+			}
+
+		case RoleTool:
+			for _, part := range msg.Parts {
+				if !isSanitizablePart(part) {
+					return false
+				}
+				if part.Type != PartToolResult {
+					continue
+				}
+
+				resultID := strings.TrimSpace(part.ToolResult.ID)
+				if resultID == "" || pendingCalls[resultID] == 0 {
+					return false
+				}
+				pendingCalls[resultID]--
+				if pendingCalls[resultID] == 0 {
+					delete(pendingCalls, resultID)
+				}
+			}
+
+		default:
+			for _, part := range msg.Parts {
+				if !isSanitizablePart(part) {
+					return false
+				}
+			}
+		}
+	}
+
+	return len(pendingCalls) == 0
+}
+
+func isSanitizablePart(part Part) bool {
+	switch part.Type {
+	case PartToolCall:
+		return part.ToolCall != nil
+	case PartToolResult:
+		return part.ToolResult != nil
+	default:
+		return true
+	}
+}
+
+func sanitizeToolHistorySlow(messages []Message) []Message {
 	sanitized := make([]Message, 0, len(messages))
 	pendingCalls := make(map[string][]toolCallRef)
 	matchedCalls := make(map[int]map[int]bool)

--- a/internal/llm/tool_history_sanitize_test.go
+++ b/internal/llm/tool_history_sanitize_test.go
@@ -1,0 +1,90 @@
+package llm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeToolHistory_ReusesValidHistory(t *testing.T) {
+	toolCall := &ToolCall{
+		ID:         "call-1",
+		Name:       "read_file",
+		Arguments:  json.RawMessage(`{"path":"main.go"}`),
+		ThoughtSig: []byte("call-thought"),
+	}
+	toolResult := &ToolResult{
+		ID:      "call-1",
+		Name:    "read_file",
+		Content: "package main",
+		ContentParts: []ToolContentPart{
+			{Type: ToolContentPartText, Text: "package main"},
+			{Type: ToolContentPartImageData, ImageData: &ToolImageData{MediaType: "image/png", Base64: "abc"}},
+		},
+		Diffs:      []DiffData{{File: "main.go", Old: "old", New: "new", Line: 1}},
+		Images:     []string{"/tmp/main.png"},
+		ThoughtSig: []byte("result-thought"),
+	}
+
+	messages := []Message{
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "Inspect main.go"}}},
+		{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "Checking"}, {Type: PartToolCall, ToolCall: toolCall}}},
+		{Role: RoleTool, Parts: []Part{{Type: PartToolResult, ToolResult: toolResult}}},
+		{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "Done"}}},
+	}
+
+	sanitized := sanitizeToolHistory(messages)
+	if len(sanitized) != len(messages) {
+		t.Fatalf("expected %d messages, got %d", len(messages), len(sanitized))
+	}
+
+	if sanitized[1].Parts[1].ToolCall != toolCall {
+		t.Fatal("expected valid tool call to be reused without cloning")
+	}
+	if sanitized[2].Parts[0].ToolResult != toolResult {
+		t.Fatal("expected valid tool result to be reused without cloning")
+	}
+	if sanitized[2].Parts[0].ToolResult.ContentParts[1].ImageData != toolResult.ContentParts[1].ImageData {
+		t.Fatal("expected nested tool result image data to be reused without cloning")
+	}
+}
+
+func TestSanitizeToolHistory_RepairsOrphanedToolCalls(t *testing.T) {
+	messages := []Message{
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "Run a tool"}}},
+		{
+			Role: RoleAssistant,
+			Parts: []Part{
+				{Type: PartText, Text: "Working on it"},
+				{
+					Type: PartToolCall,
+					ToolCall: &ToolCall{
+						ID:        "call-1",
+						Name:      "shell",
+						Arguments: json.RawMessage(`{"command":"sleep 10"}`),
+					},
+				},
+			},
+		},
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "new request"}}},
+	}
+
+	sanitized := sanitizeToolHistory(messages)
+	if len(sanitized) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(sanitized))
+	}
+
+	assistant := sanitized[1]
+	if len(assistant.Parts) != 2 {
+		t.Fatalf("expected assistant message to contain preserved text and interruption stub, got %d parts", len(assistant.Parts))
+	}
+	if assistant.Parts[1].Type != PartText {
+		t.Fatalf("expected orphaned tool call to become text, got %q", assistant.Parts[1].Type)
+	}
+	if !strings.Contains(assistant.Parts[1].Text, "[tool call interrupted") {
+		t.Fatalf("expected interruption stub, got %q", assistant.Parts[1].Text)
+	}
+	if messages[1].Parts[1].ToolCall == nil {
+		t.Fatal("expected original message to remain unchanged")
+	}
+}


### PR DESCRIPTION
## What

- add a fast path in `sanitizeToolHistory` that returns already-valid histories without deep-cloning every message part
- only fall back to the existing clone-and-rewrite logic when event rows must be filtered or tool call/result history actually needs repair
- add tests covering both the zero-clone fast path and orphaned tool-call repair behavior

## Why

`sanitizeToolHistory` runs in multiple hot request-preparation paths before provider calls. Deep-cloning every `ToolCall`, `ToolResult`, raw args blob, diff, image, and thought signature on every request adds avoidable allocation churn and startup latency for long sessions. This change keeps the existing sanitization behavior for invalid histories while making the common valid-history case allocation-light.
