### PR TITLE
fix: OpenAI/Responses turns rebuild the full transcript before applying previous_response_id or WS continuation

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -126,7 +126,7 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req Request) (Stream, error
 
 	responsesReq := ResponsesRequest{
 		Model:          model,
-		Input:          BuildResponsesInput(req.Messages),
+		Messages:       req.Messages,
 		Tools:          tools,
 		Include:        []string{"reasoning.encrypted_content"},
 		PromptCacheKey: req.SessionID,
@@ -157,6 +157,7 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req Request) (Stream, error
 	}
 
 	if req.Debug {
+		responsesReq.Input = BuildResponsesInput(req.Messages)
 		systemPreview := collectRoleText(req.Messages, RoleSystem)
 		userPreview := collectRoleText(req.Messages, RoleUser)
 		fmt.Fprintln(os.Stderr, "=== DEBUG: OpenAI Stream Request ===")

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -35,6 +35,67 @@ func TestParseModelEffort(t *testing.T) {
 	}
 }
 
+func TestOpenAIProviderStreamUsesMessagesForContinuationRequests(t *testing.T) {
+	var got struct {
+		PreviousResponseID string               `json:"previous_response_id,omitempty"`
+		Input              []ResponsesInputItem `json:"input"`
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_next\"}}\n\n"))
+	}))
+	defer ts.Close()
+
+	provider := &OpenAIProvider{
+		apiKey: "test-key",
+		model:  "gpt-4.1",
+		responsesClient: &ResponsesClient{
+			BaseURL:        ts.URL,
+			GetAuthHeader:  func() string { return "Bearer test-key" },
+			HTTPClient:     ts.Client(),
+			LastResponseID: "resp_prev",
+		},
+	}
+
+	stream, err := provider.Stream(context.Background(), Request{
+		Messages: []Message{
+			SystemText("Be concise"),
+			UserText("old question"),
+			AssistantText("old answer"),
+			UserText("new question"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		if ev.Type == EventDone {
+			break
+		}
+	}
+
+	if got.PreviousResponseID != "resp_prev" {
+		t.Fatalf("previous_response_id = %q, want %q", got.PreviousResponseID, "resp_prev")
+	}
+	if len(got.Input) != 1 {
+		t.Fatalf("expected only latest user item, got %d items: %+v", len(got.Input), got.Input)
+	}
+	if got.Input[0].Type != "message" || got.Input[0].Role != "user" || got.Input[0].Content != "new question" {
+		t.Fatalf("unexpected continuation input: %+v", got.Input[0])
+	}
+}
+
 func TestOpenAIProviderStreamSendsExplicitParallelToolCallsFalse(t *testing.T) {
 	var got struct {
 		ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty"`

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -65,6 +65,7 @@ type ResponsesRequest struct {
 	Model              string               `json:"model"`
 	Instructions       string               `json:"instructions,omitempty"` // System instructions (alternative to developer-role input items)
 	Input              []ResponsesInputItem `json:"input"`
+	Messages           []Message            `json:"-"`               // Optional raw transcript for lazy input materialization
 	Tools              []any                `json:"tools,omitempty"` // Can contain ResponsesTool or ResponsesWebSearchTool
 	ToolChoice         any                  `json:"tool_choice,omitempty"`
 	ParallelToolCalls  *bool                `json:"parallel_tool_calls,omitempty"`
@@ -237,9 +238,7 @@ func BuildResponsesInputWithInstructions(messages []Message) (instructions strin
 	return strings.Join(systemParts, "\n\n"), input
 }
 
-// BuildResponsesInput converts []Message to Open Responses input format
-func BuildResponsesInput(messages []Message) []ResponsesInputItem {
-	messages = sanitizeToolHistory(messages)
+func buildResponsesInputItems(messages []Message) []ResponsesInputItem {
 	var inputItems []ResponsesInputItem
 	for _, msg := range messages {
 		if msg.Role == RoleSystem || msg.Role == RoleDeveloper {
@@ -249,6 +248,49 @@ func BuildResponsesInput(messages []Message) []ResponsesInputItem {
 		}
 	}
 	return inputItems
+}
+
+// BuildResponsesInput converts []Message to Open Responses input format.
+func BuildResponsesInput(messages []Message) []ResponsesInputItem {
+	return buildResponsesInputItems(sanitizeToolHistory(messages))
+}
+
+// BuildResponsesContinuationInput converts only the newest turn payload needed for a
+// server-state continuation. Unlike BuildResponsesInput it intentionally skips
+// whole-transcript tool-history sanitization so trailing tool results can be sent
+// back against server-side conversation state without rebuilding earlier turns.
+func BuildResponsesContinuationInput(messages []Message) []ResponsesInputItem {
+	messages = FilterConversationMessages(messages)
+	if len(messages) == 0 {
+		return nil
+	}
+
+	start := len(messages)
+	sawToolResult := false
+	for start > 0 {
+		msg := messages[start-1]
+		if msg.Role == RoleUser && !sawToolResult {
+			start--
+			continue
+		}
+		if msg.Role == RoleTool {
+			sawToolResult = true
+			start--
+			continue
+		}
+		break
+	}
+	if !sawToolResult {
+		start = 0
+		for i := len(messages) - 1; i >= 0; i-- {
+			if messages[i].Role == RoleUser {
+				start = i
+				break
+			}
+		}
+	}
+
+	return buildResponsesInputItems(messages[start:])
 }
 
 // buildResponsesInputForRole converts a single non-system message to input items.
@@ -536,18 +578,55 @@ func cloneResponsesClientFreshConversation(c *ResponsesClient) *ResponsesClient 
 // Stream makes a streaming request to the Responses API and returns events via a Stream
 func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debugRaw bool) (Stream, error) {
 	fullInput := req.Input
+	fullInputBuilt := req.Input != nil
+	buildFullInput := func() []ResponsesInputItem {
+		if fullInputBuilt {
+			return fullInput
+		}
+		fullInput = BuildResponsesInput(req.Messages)
+		fullInputBuilt = true
+		return fullInput
+	}
+
+	continuationInput := []ResponsesInputItem(nil)
+	continuationBuilt := false
+	buildContinuationInput := func() []ResponsesInputItem {
+		if continuationBuilt {
+			return continuationInput
+		}
+		if len(req.Messages) > 0 {
+			continuationInput = BuildResponsesContinuationInput(req.Messages)
+		} else {
+			continuationInput = filterToNewInput(buildFullInput())
+		}
+		continuationBuilt = true
+		return continuationInput
+	}
+
 	lastResponseID, responseStateGeneration := c.responseState()
 
 	wsReq := req
-
 	httpPayload := req
-	if !c.DisableServerState && lastResponseID != "" {
-		httpPayload.PreviousResponseID = lastResponseID
-		httpPayload.Input = filterToNewInput(httpPayload.Input)
+	if lastResponseID != "" {
+		if c.websocketServerStateEnabled() {
+			wsReq.PreviousResponseID = lastResponseID
+			wsReq.Input = buildContinuationInput()
+		} else {
+			wsReq.Input = buildFullInput()
+		}
+		if !c.DisableServerState {
+			httpPayload.PreviousResponseID = lastResponseID
+			httpPayload.Input = buildContinuationInput()
+		} else {
+			httpPayload.Input = buildFullInput()
+		}
+	} else {
+		wsReq.Input = buildFullInput()
+		httpPayload.Input = fullInput
 	}
 
 	if c.UseWebSocket && !c.websocketDisabled {
-		stream, err := c.streamWebSocketPrepared(ctx, wsReq, fullInput, debugRaw, responseStateGeneration)
+		stream, err := c.streamWebSocketPrepared(ctx, wsReq, buildFullInput, debugRaw, responseStateGeneration)
 		if err == nil {
 			return &responsesWebSocketFallbackStream{
 				current: stream,
@@ -556,7 +635,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 						if debugRaw {
 							DebugRawSection(debugRaw, "Responses WebSocket Retry", "stream failed before emitting events")
 						}
-						return c.streamWebSocketPrepared(ctx, wsReq, fullInput, debugRaw, responseStateGeneration)
+						return c.streamWebSocketPrepared(ctx, wsReq, buildFullInput, debugRaw, responseStateGeneration)
 					},
 					func() (Stream, error) {
 						c.websocketDisabled = true
@@ -564,7 +643,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 						if debugRaw {
 							DebugRawSection(debugRaw, "Responses WebSocket Fallback", "stream failed before emitting events")
 						}
-						return c.streamHTTPPrepared(ctx, httpPayload, fullInput, lastResponseID, responseStateGeneration, debugRaw)
+						return c.streamHTTPPrepared(ctx, httpPayload, buildFullInput, lastResponseID, responseStateGeneration, debugRaw)
 					},
 				},
 			}, nil
@@ -576,10 +655,10 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		}
 	}
 
-	return c.streamHTTPPrepared(ctx, httpPayload, fullInput, lastResponseID, responseStateGeneration, debugRaw)
+	return c.streamHTTPPrepared(ctx, httpPayload, buildFullInput, lastResponseID, responseStateGeneration, debugRaw)
 }
 
-func (c *ResponsesClient) streamHTTPPrepared(ctx context.Context, httpPayload ResponsesRequest, fullInput []ResponsesInputItem, lastResponseID string, responseStateGeneration uint64, debugRaw bool) (Stream, error) {
+func (c *ResponsesClient) streamHTTPPrepared(ctx context.Context, httpPayload ResponsesRequest, buildFullInput func() []ResponsesInputItem, lastResponseID string, responseStateGeneration uint64, debugRaw bool) (Stream, error) {
 	body, err := json.Marshal(httpPayload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -655,7 +734,7 @@ func (c *ResponsesClient) streamHTTPPrepared(ctx context.Context, httpPayload Re
 			c.clearLastResponseIDIfGeneration(responseStateGeneration)
 			retryPayload := httpPayload
 			retryPayload.PreviousResponseID = ""
-			retryPayload.Input = fullInput
+			retryPayload.Input = buildFullInput()
 			// Re-marshal without previous_response_id
 			body, err = json.Marshal(retryPayload)
 			if err != nil {

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -1210,6 +1210,61 @@ func TestFilterToNewInput_ToolFollowUpPreservesTrailingOutputsAndUserMessages(t 
 	}
 }
 
+func TestBuildResponsesContinuationInput_ReturnsLatestUserTurn(t *testing.T) {
+	messages := []Message{
+		SystemText("Be concise"),
+		UserText("old question"),
+		AssistantText("old answer"),
+		UserText("new question"),
+	}
+
+	got := BuildResponsesContinuationInput(messages)
+
+	if len(got) != 1 {
+		t.Fatalf("expected only latest user item, got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "message" || got[0].Role != "user" || got[0].Content != "new question" {
+		t.Fatalf("unexpected continuation input: %+v", got[0])
+	}
+}
+
+func TestBuildResponsesContinuationInput_PreservesTrailingToolResults(t *testing.T) {
+	messages := []Message{
+		SystemText("Be concise"),
+		UserText("describe this image"),
+		{
+			Role: RoleAssistant,
+			Parts: []Part{{
+				Type: PartToolCall,
+				ToolCall: &ToolCall{
+					ID:        "call_img",
+					Name:      "view_image",
+					Arguments: []byte(`{"path":"img.png"}`),
+				},
+			}},
+		},
+		ToolResultMessageFromOutput("call_img", "view_image", ToolOutput{
+			Content: "loaded",
+			ContentParts: []ToolContentPart{{
+				Type:      ToolContentPartImageData,
+				ImageData: &ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="},
+			}},
+		}, nil),
+	}
+
+	got := BuildResponsesContinuationInput(messages)
+
+	if len(got) != 2 {
+		t.Fatalf("expected trailing tool output and synthetic user message, got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "function_call_output" || got[0].CallID != "call_img" {
+		t.Fatalf("expected first item function_call_output for call_img, got %+v", got[0])
+	}
+	if got[1].Type != "message" || got[1].Role != "user" {
+		t.Fatalf("expected second item trailing user message, got %+v", got[1])
+	}
+}
+
 func TestResponsesClientStream_Retries404WithFullHistory(t *testing.T) {
 	type capturedRequest struct {
 		PreviousResponseID string               `json:"previous_response_id"`

--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -102,9 +102,9 @@ func (c *ResponsesClient) writeResponsesWebSocketRequestLocked(conn *websocket.C
 	return nil
 }
 
-func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req ResponsesRequest, fullInput []ResponsesInputItem, debugRaw bool, responseStateGeneration uint64) (Stream, error) {
+func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req ResponsesRequest, buildFullInput func() []ResponsesInputItem, debugRaw bool, responseStateGeneration uint64) (Stream, error) {
 	c.wsMu.Lock()
-	wireReq := c.prepareWebSocketContinuationLocked(req, fullInput)
+	wireReq := c.prepareWebSocketContinuationLocked(req, buildFullInput)
 
 	conn, reused, err := c.ensureWebSocket(ctx, wireReq)
 	if err != nil {
@@ -180,7 +180,7 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 					c.wsLastRequest = nil
 					c.wsLastResponseItems = nil
 					wireReq.PreviousResponseID = ""
-					wireReq.Input = fullInput
+					wireReq.Input = buildFullInput()
 					handler = newResponsesStreamEventHandler(c, responseStateGeneration, debugRaw, "Responses WebSocket", c.websocketServerStateEnabled())
 					if debugRaw {
 						DebugRawSection(debugRaw, "Responses WebSocket Full-State Retry", err.Error())
@@ -203,7 +203,7 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 			return err
 		}
 		fullReq := wireReq
-		fullReq.Input = append([]ResponsesInputItem(nil), fullInput...)
+		fullReq.Input = append([]ResponsesInputItem(nil), buildFullInput()...)
 		fullReq.PreviousResponseID = ""
 		c.wsLastRequest = &fullReq
 		c.wsLastResponseItems = handler.OutputItems()
@@ -224,30 +224,39 @@ func isPreviousResponseIDRejected(err error) bool {
 	return strings.Contains(msg, "previous_response_id") && (strings.Contains(msg, "unsupported") || strings.Contains(msg, "not found"))
 }
 
-func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesRequest, fullInput []ResponsesInputItem) ResponsesRequest {
+func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesRequest, buildFullInput func() []ResponsesInputItem) ResponsesRequest {
 	if !c.websocketServerStateEnabled() || c.LastResponseID == "" {
+		if req.Input == nil {
+			req.Input = buildFullInput()
+		}
 		return req
 	}
 
-	fullReq := req
-	fullReq.Input = append([]ResponsesInputItem(nil), fullInput...)
-	fullReq.PreviousResponseID = ""
+	if req.PreviousResponseID == "" {
+		req.PreviousResponseID = c.LastResponseID
+	}
 
 	if c.wsLastRequest == nil {
 		req.PreviousResponseID = ""
-		req.Input = fullInput
+		req.Input = buildFullInput()
 		return req
 	}
 
 	prevComparable := responsesRequestNonInputComparable(*c.wsLastRequest)
-	currentComparable := responsesRequestNonInputComparable(fullReq)
+	currentComparable := responsesRequestNonInputComparable(req)
 	if !reflect.DeepEqual(prevComparable, currentComparable) {
 		// Tool schemas, model parameters, or other non-input fields changed. Start a
 		// fresh chain instead of risking previous_response_id with incompatible state.
 		req.PreviousResponseID = ""
-		req.Input = fullInput
+		req.Input = buildFullInput()
 		return req
 	}
+
+	if req.Input != nil {
+		return req
+	}
+
+	fullInput := buildFullInput()
 
 	baseline := append([]ResponsesInputItem{}, c.wsLastRequest.Input...)
 	baseline = append(baseline, c.wsLastResponseItems...)


### PR DESCRIPTION
## What

- stop `OpenAIProvider.Stream` from eagerly materializing `ResponsesRequest.Input` on every turn
- let `ResponsesClient` build OpenAI Responses input lazily from raw `[]Message` values
- add a continuation-only builder for latest user/tool follow-up payloads so `previous_response_id` and Responses-over-WebSocket continuation can send the incremental turn without paying a full-transcript walk first
- keep full-history reconstruction available for debug logging, 404 full-history retries, and post-stream websocket state tracking
- add regression coverage for continuation payload selection from raw messages

## Why

OpenAI/Responses turns were rebuilding and sanitizing the entire transcript before the shared client decided whether it could continue with `previous_response_id` or websocket state. That meant long conversations still paid the full client-side request-prep cost on every turn, which hurts time-to-first-token even when server-side continuation is available.
