### PR TITLE
perf: cache skill registry metadata

### DIFF
--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +22,13 @@ type Registry struct {
 
 	// Shadow counts for visibility
 	shadowCounts map[string]int
+
+	// Cache of the last metadata-only List result. The fingerprint is built from
+	// search paths plus SKILL.md file mtimes/sizes, so repeated prompt/search
+	// metadata generation avoids reparsing YAML while still noticing ordinary
+	// skill add/remove/edit changes.
+	listCache            []*Skill
+	listCacheFingerprint string
 
 	// Pre-built sets for O(1) lookup
 	neverAutoSet     map[string]bool
@@ -287,16 +295,23 @@ func (r *Registry) HasAnySkill() (bool, error) {
 // Get retrieves a skill by name, loading full content.
 func (r *Registry) Get(name string) (*Skill, error) {
 	if skill, ok := r.cache[name]; ok {
-		// If we have metadata only, load full content
+		// If we have metadata only, load full content. If that cached path went
+		// stale, discard it and fall through to normal search-path resolution.
 		if !skill.IsLoaded() {
 			fullSkill, err := LoadFromDir(skill.SourcePath, skill.Source, true)
-			if err != nil {
-				return nil, err
+			if err == nil {
+				if err := fullSkill.Validate(); err != nil {
+					delete(r.cache, name)
+				} else {
+					r.cache[name] = fullSkill
+					return fullSkill, nil
+				}
+			} else {
+				delete(r.cache, name)
 			}
-			r.cache[name] = fullSkill
-			return fullSkill, nil
+		} else {
+			return skill, nil
 		}
-		return skill, nil
 	}
 
 	// The common case is a directory named after the skill.
@@ -345,6 +360,11 @@ func (r *Registry) Get(name string) (*Skill, error) {
 // List returns all available skills (metadata only).
 // Each skill appears only once, with first-found taking precedence.
 func (r *Registry) List() ([]*Skill, error) {
+	fingerprint := r.searchPathsFingerprint()
+	if r.listCache != nil && fingerprint == r.listCacheFingerprint {
+		return cloneSkillSlice(r.listCache), nil
+	}
+
 	seen := make(map[string]bool)
 	r.shadowCounts = make(map[string]int)
 	var skills []*Skill
@@ -362,6 +382,9 @@ func (r *Registry) List() ([]*Skill, error) {
 			} else {
 				seen[skill.Name] = true
 				skills = append(skills, skill)
+				if cached, ok := r.cache[skill.Name]; !ok || !cached.IsLoaded() {
+					r.cache[skill.Name] = skill
+				}
 			}
 		}
 	}
@@ -371,7 +394,10 @@ func (r *Registry) List() ([]*Skill, error) {
 		return skills[i].Name < skills[j].Name
 	})
 
-	return skills, nil
+	r.listCacheFingerprint = fingerprint
+	r.listCache = cloneSkillSlice(skills)
+
+	return cloneSkillSlice(skills), nil
 }
 
 // ListAll returns all skills from all paths without shadowing.
@@ -425,8 +451,100 @@ func (r *Registry) ShadowCount(name string) int {
 func (r *Registry) Reload() error {
 	r.cache = make(map[string]*Skill)
 	r.shadowCounts = make(map[string]int)
+	r.listCache = nil
+	r.listCacheFingerprint = ""
 	r.searchPaths = nil
 	return r.buildSearchPaths()
+}
+
+func cloneSkillSlice(in []*Skill) []*Skill {
+	out := make([]*Skill, len(in))
+	for i, skill := range in {
+		out[i] = cloneSkill(skill)
+	}
+	return out
+}
+
+func cloneSkill(skill *Skill) *Skill {
+	if skill == nil {
+		return nil
+	}
+	clone := *skill
+	clone.AllowedTools = append([]string(nil), skill.AllowedTools...)
+	clone.References = append([]string(nil), skill.References...)
+	clone.Scripts = append([]string(nil), skill.Scripts...)
+	clone.Assets = append([]string(nil), skill.Assets...)
+	clone.Metadata = cloneStringMap(skill.Metadata)
+	clone.Extras = cloneAnyMap(skill.Extras)
+	clone.Tools = cloneSkillToolDefs(skill.Tools)
+	return &clone
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneSkillToolDefs(in []SkillToolDef) []SkillToolDef {
+	if in == nil {
+		return nil
+	}
+	out := make([]SkillToolDef, len(in))
+	for i, tool := range in {
+		out[i] = tool
+		out[i].Input = cloneAnyMap(tool.Input)
+		out[i].Env = cloneStringMap(tool.Env)
+	}
+	return out
+}
+
+func (r *Registry) searchPathsFingerprint() string {
+	var sb strings.Builder
+	for _, sp := range r.searchPaths {
+		sb.WriteString(sp.path)
+		sb.WriteByte('\x00')
+		sb.WriteString(sp.source.SourceName())
+		sb.WriteByte('\n')
+
+		entries, err := os.ReadDir(sp.path)
+		if err != nil {
+			sb.WriteString("!missing\n")
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			info, err := os.Stat(filepath.Join(sp.path, entry.Name(), "SKILL.md"))
+			if err != nil || info.IsDir() {
+				continue
+			}
+			sb.WriteString(entry.Name())
+			sb.WriteByte('\x00')
+			sb.WriteString(strconv.FormatInt(info.ModTime().UnixNano(), 10))
+			sb.WriteByte('\x00')
+			sb.WriteString(strconv.FormatInt(info.Size(), 10))
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
 }
 
 // scanDir scans a directory for skill subdirectories.

--- a/internal/skills/registry_test.go
+++ b/internal/skills/registry_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -156,6 +157,124 @@ description: "Directory and frontmatter names differ"
 	}
 	if !skill.IsLoaded() || skill.Body == "" {
 		t.Error("expected full skill body to be loaded")
+	}
+}
+
+func TestRegistryGetFallsBackWhenCachedListMetadataPathStale(t *testing.T) {
+	tmpDir := t.TempDir()
+	highDir := filepath.Join(tmpDir, "high")
+	lowDir := filepath.Join(tmpDir, "low")
+	for _, base := range []string{highDir, lowDir} {
+		skillDir := filepath.Join(base, "same-skill")
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("mkdir skill dir: %v", err)
+		}
+	}
+
+	highContent := `---
+name: same-skill
+description: "High priority version"
+---
+
+# High
+`
+	lowContent := `---
+name: same-skill
+description: "Low priority version"
+---
+
+# Low
+`
+	if err := os.WriteFile(filepath.Join(highDir, "same-skill", "SKILL.md"), []byte(highContent), 0o644); err != nil {
+		t.Fatalf("write high skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(lowDir, "same-skill", "SKILL.md"), []byte(lowContent), 0o644); err != nil {
+		t.Fatalf("write low skill: %v", err)
+	}
+
+	registry, err := NewRegistry(RegistryConfig{
+		IncludeProjectSkills:  false,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	registry.searchPaths = []searchPath{
+		{path: highDir, source: SourceUser},
+		{path: lowDir, source: SourceCodex},
+	}
+
+	listed, err := registry.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Description != "High priority version" {
+		t.Fatalf("List = %#v, want high-priority skill", listed)
+	}
+
+	if err := os.RemoveAll(filepath.Join(highDir, "same-skill")); err != nil {
+		t.Fatalf("remove high skill: %v", err)
+	}
+
+	skill, err := registry.Get("same-skill")
+	if err != nil {
+		t.Fatalf("Get after cached path removal: %v", err)
+	}
+	if skill.Description != "Low priority version" {
+		t.Fatalf("Get description = %q, want low priority fallback", skill.Description)
+	}
+	if skill.SourcePath != filepath.Join(lowDir, "same-skill") {
+		t.Fatalf("SourcePath = %q, want low-priority path", skill.SourcePath)
+	}
+}
+
+func TestRegistryListReturnsDefensiveCopies(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, "skills")
+	skillDir := filepath.Join(skillsDir, "copy-test")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	content := `---
+name: copy-test
+description: "Original description"
+metadata:
+  owner: alice
+---
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	registry, err := NewRegistry(RegistryConfig{
+		IncludeProjectSkills:  false,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	registry.searchPaths = []searchPath{{path: skillsDir, source: SourceUser}}
+
+	first, err := registry.List()
+	if err != nil {
+		t.Fatalf("first List: %v", err)
+	}
+	first[0].Name = "mutated"
+	first[0].Description = "Mutated description"
+	first[0].Metadata["owner"] = "mallory"
+
+	second, err := registry.List()
+	if err != nil {
+		t.Fatalf("second List: %v", err)
+	}
+	if second[0].Name != "copy-test" {
+		t.Fatalf("cached Name = %q, want original", second[0].Name)
+	}
+	if second[0].Description != "Original description" {
+		t.Fatalf("cached Description = %q, want original", second[0].Description)
+	}
+	if second[0].Metadata["owner"] != "alice" {
+		t.Fatalf("cached metadata owner = %q, want alice", second[0].Metadata["owner"])
 	}
 }
 
@@ -353,7 +472,7 @@ description: "New skill"
 		t.Fatalf("failed to write new SKILL.md: %v", err)
 	}
 
-	// List will scan the directory again (List doesn't cache)
+	// List notices the search path changed and refreshes its metadata cache.
 	// So we expect 2 skills now
 	skills, _ = registry.List()
 	if len(skills) != 2 {
@@ -494,5 +613,58 @@ func TestDefaultRegistryConfig(t *testing.T) {
 
 	if !cfg.IncludeEcosystemPaths {
 		t.Error("expected IncludeEcosystemPaths to be true")
+	}
+}
+
+func BenchmarkRegistryListRepeated(b *testing.B) {
+	const skillCount = 200
+
+	tmpDir := b.TempDir()
+	skillsDir := filepath.Join(tmpDir, "skills")
+	for i := 0; i < skillCount; i++ {
+		name := fmt.Sprintf("bench-skill-%03d", i)
+		skillDir := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			b.Fatalf("mkdir skill dir: %v", err)
+		}
+		content := fmt.Sprintf(`---
+name: %s
+description: "Benchmark skill %03d for repeated registry listing"
+---
+
+# %s
+
+Instructions.
+`, name, i, name)
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			b.Fatalf("write SKILL.md: %v", err)
+		}
+	}
+
+	registry, err := NewRegistry(RegistryConfig{
+		IncludeProjectSkills:  false,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		b.Fatalf("NewRegistry: %v", err)
+	}
+	registry.searchPaths = []searchPath{{path: skillsDir, source: SourceUser}}
+
+	if skills, err := registry.List(); err != nil {
+		b.Fatalf("warm List: %v", err)
+	} else if len(skills) != skillCount {
+		b.Fatalf("warm List returned %d skills, want %d", len(skills), skillCount)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		skills, err := registry.List()
+		if err != nil {
+			b.Fatalf("List: %v", err)
+		}
+		if len(skills) != skillCount {
+			b.Fatalf("List returned %d skills, want %d", len(skills), skillCount)
+		}
 	}
 }


### PR DESCRIPTION
## What

Cache metadata-only `skills.Registry.List()` results behind a lightweight fingerprint of the configured skill search paths and each discovered `SKILL.md` file's mtime/size.

Also:
- reuse metadata discovered during prompt/search listing for later `Get()` activation, including frontmatter-name aliases
- fall back to normal search-path resolution if cached metadata points at a stale path
- return defensive copies from cached lists so callers cannot mutate registry cache state
- add tests for stale-cache fallback, defensive copies, and cache refresh on added skills
- add `BenchmarkRegistryListRepeated`

## Why

Chat/serve startup injects skill metadata, and long-running sessions can call `search_skills` repeatedly. Before this change each `List()` reparsed every `SKILL.md` frontmatter even when the registry contents had not changed. The new cache keeps the cheap filesystem freshness check but avoids repeated YAML parsing and allocation-heavy metadata reconstruction.

## Evidence

Benchmark with 200 temp skills, repeated metadata listing after warmup:

```text
# before (temp checkout of HEAD + benchmark)
BenchmarkRegistryListRepeated-32   513-606 iters   2.09-2.23 ms/op   ~2.87-2.89 MB/op   16251 allocs/op

# after
BenchmarkRegistryListRepeated-32   5228-5832 iters 201-208 µs/op     ~188-191 KiB/op    1626 allocs/op
```

Representative improvement: ~10x faster repeated listing and ~93% fewer allocations.

## Verification

```text
go test ./internal/skills
go test ./internal/skills -run '^$' -bench BenchmarkRegistryListRepeated -benchmem -count=5
go build ./...
go test ./...
```
