### PR TITLE
fix: hide active archived web sessions

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -801,6 +801,7 @@ const submitRenameSessionModal = async () => {
   elements.renameSessionSaveBtn.textContent = 'Saving…';
   try {
     const payload = await updateSessionMetadata(session, { name: nextName });
+    reconcileServerSessionIdentity(session, payload);
     applyServerSessionSummary(session, payload);
     session.name = String(payload.name || '').trim();
     persistAndRefreshShell();
@@ -868,10 +869,17 @@ const animateSessionHide = async (sessionId) => {
 const setSessionArchived = async (session, archived) => {
   if (!session?.id) return false;
   try {
+    const wasActive = session.id === state.activeSessionId;
+    const previousId = session.id;
     const payload = await updateSessionMetadata(session, { archived });
+    reconcileServerSessionIdentity(session, payload);
     applyServerSessionSummary(session, payload);
     if (archived && !state.showHiddenSessions) {
-      await animateSessionHide(session.id);
+      await animateSessionHide(previousId);
+      if (session.id !== previousId) await animateSessionHide(session.id);
+      if (wasActive || session.id === state.activeSessionId) {
+        await switchToDraftSession({ closeSidebar: false });
+      }
     }
     persistAndRefreshShell();
     return true;
@@ -889,6 +897,7 @@ const setSessionPinned = async (session, pinned) => {
   if (!session?.id) return false;
   try {
     const payload = await updateSessionMetadata(session, { pinned });
+    reconcileServerSessionIdentity(session, payload);
     applyServerSessionSummary(session, payload);
     persistAndRefreshShell();
     return true;


### PR DESCRIPTION
## What

Fix web session metadata updates to reconcile server session identity before applying returned metadata, and switch back to the draft chat when hiding the currently active session.

## Why

If the browser is opened at a numeric session URL such as `/chat/26`, the web UI creates a temporary local stub with id `"26"`. Hiding that session PATCHes successfully; the server returns the canonical session id and `archived: true`, but the client did not reconcile the id and kept the active URL/session stub around. On refresh or re-sync the archived session could appear to “pop back” even though the backend had archived it.

This keeps rename/pin/hide metadata responses consistent with other server session reconciliation paths and avoids keeping a hidden active session selected when hidden sessions are not shown.

## Test

```bash
go test ./cmd -run 'TestServeSession|TestCustomBasePath|TestHandleSessions'
go build ./...
```
