### PR TITLE
fix: Server decodes full uploaded image payloads even when the original base64 could be reused

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -111,15 +111,46 @@ const (
 	maxAttachmentBytes = 20 << 20 // 20 MB per file (decoded)
 )
 
+func decodedBase64Len(b64Data string) (int, error) {
+	if b64Data == "" {
+		return 0, nil
+	}
+	if len(b64Data)%4 != 0 {
+		return 0, fmt.Errorf("decode base64: invalid length %d", len(b64Data))
+	}
+	decodedLen := base64.StdEncoding.DecodedLen(len(b64Data))
+	if strings.HasSuffix(b64Data, "=") {
+		decodedLen--
+	}
+	if strings.HasSuffix(b64Data, "==") {
+		decodedLen--
+	}
+	return decodedLen, nil
+}
+
+func validateBase64Data(b64Data string) error {
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64Data))
+	var buf [4096]byte
+	if _, err := io.CopyBuffer(io.Discard, decoder, buf[:]); err != nil {
+		return fmt.Errorf("decode base64: %w", err)
+	}
+	return nil
+}
+
 func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
-	raw, err := base64.StdEncoding.DecodeString(b64Data)
+	decodedLen, err := decodedBase64Len(b64Data)
+	if err != nil {
+		return nil, err
+	}
+	if decodedLen > maxAttachmentBytes {
+		return nil, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+	raw := make([]byte, decodedLen)
+	n, err := base64.StdEncoding.Decode(raw, []byte(b64Data))
 	if err != nil {
 		return nil, fmt.Errorf("decode base64: %w", err)
 	}
-	if len(raw) > maxAttachmentBytes {
-		return nil, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
-	}
-	return raw, nil
+	return raw[:n], nil
 }
 
 // saveUploadedFile decodes base64 data and writes it to the uploads directory,
@@ -226,6 +257,24 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					}
 					if filename == "" {
 						filename = "image"
+					}
+
+					decodedLen, err := decodedBase64Len(b64)
+					if err != nil {
+						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
+					}
+					if decodedLen > maxAttachmentBytes {
+						return llm.Message{}, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+					}
+					if decodedLen <= maxLLMImageBytes {
+						if err := validateBase64Data(b64); err != nil {
+							return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
+						}
+						llmParts = append(llmParts, llm.Part{
+							Type:      llm.PartImage,
+							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
+						})
+						continue
 					}
 
 					raw, err := decodeUploadedFile(filename, b64)

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -63,6 +63,42 @@ func TestParseUserMessageContent_RejectsOversizedInlineImage(t *testing.T) {
 	}
 }
 
+func TestParseUserMessageContent_RejectsInvalidSmallInlineImage(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	content, err := json.Marshal([]map[string]any{{
+		"type":      "input_image",
+		"image_url": "data:image/png;base64,!!!=",
+		"filename":  "bad.png",
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	_, err = parseUserMessageContent(content)
+	if err == nil {
+		t.Fatal("parseUserMessageContent() error = nil, want decode error")
+	}
+	if !strings.Contains(err.Error(), "bad.png") || !strings.Contains(err.Error(), "decode base64") {
+		t.Fatalf("parseUserMessageContent() error = %v, want filename + decode error", err)
+	}
+}
+
+func TestDecodeUploadedFile_RejectsOversizedPayloadBeforeDecode(t *testing.T) {
+	b64 := strings.Repeat("A", base64.StdEncoding.EncodedLen(maxAttachmentBytes+1)-1) + "!"
+
+	_, err := decodeUploadedFile("too-large.bin", b64)
+	if err == nil {
+		t.Fatal("decodeUploadedFile() error = nil, want size limit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d MB limit", maxAttachmentBytes>>20)) {
+		t.Fatalf("decodeUploadedFile() error = %v, want size limit error", err)
+	}
+	if strings.Contains(err.Error(), "decode base64") {
+		t.Fatalf("decodeUploadedFile() error = %v, want size check before base64 decode", err)
+	}
+}
+
 func TestParseUserMessageContent_InlineImagesDoNotHitUploadsDir(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)


### PR DESCRIPTION
## What

- preflight uploaded base64 payload sizes from their encoded length before allocating decoded bytes
- keep small LLM-native inline images in their original base64 form instead of eagerly decoding and re-encoding them
- add regression coverage for the fast path and the oversize-before-decode guard

## Why

The web server was fully decoding every uploaded image before enforcing the attachment size limit, and it also routed inline LLM-native images through that decode path even when the original base64 could be sent unchanged. In image-heavy sessions that creates avoidable CPU work and higher peak memory usage on the server.
