### PR TITLE
fix: Gemini edit requests build giant base64+JSON copies in memory

### DIFF
--- a/internal/image/gemini.go
+++ b/internal/image/gemini.go
@@ -63,7 +63,7 @@ func (p *GeminiProvider) Edit(ctx context.Context, req EditRequest) (*ImageResul
 		parts = append(parts, geminiPart{
 			InlineData: &geminiInlineData{
 				MimeType: mimeType,
-				Data:     base64.StdEncoding.EncodeToString(img.Data),
+				Data:     img.Data,
 			},
 		})
 	}
@@ -87,22 +87,23 @@ func (p *GeminiProvider) doRequest(ctx context.Context, parts []geminiPart, size
 		genCfg.ImageConfig = &geminiImageConfig{ImageSize: effectiveSize}
 	}
 
-	reqBody := geminiRequest{
-		Contents:         []geminiContent{{Parts: parts}},
-		GenerationConfig: genCfg,
-	}
-
-	jsonBody, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
 	endpoint := geminiBaseURL + p.model + ":generateContent"
-	if debug {
-		debugRawImageLog(debug, "Gemini Request", "POST %s\n%s", endpoint, truncateBase64InJSON(jsonBody))
+
+	var bodyReader io.Reader
+	if debug || !geminiHasInlineData(parts) {
+		jsonBody, err := buildGeminiRequestBody(parts, genCfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build request: %w", err)
+		}
+		if debug {
+			debugRawImageLog(debug, "Gemini Request", "POST %s\n%s", endpoint, truncateBase64InJSON(jsonBody))
+		}
+		bodyReader = bytes.NewReader(jsonBody)
+	} else {
+		bodyReader = streamGeminiRequestBody(parts, genCfg)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(jsonBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -158,6 +159,102 @@ func (p *GeminiProvider) doRequest(ctx context.Context, parts []geminiPart, size
 	return nil, fmt.Errorf("no image data in response")
 }
 
+func geminiHasInlineData(parts []geminiPart) bool {
+	for _, part := range parts {
+		if part.InlineData != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func buildGeminiRequestBody(parts []geminiPart, genCfg geminiGenerationConfig) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeGeminiRequestJSON(&buf, parts, genCfg); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func streamGeminiRequestBody(parts []geminiPart, genCfg geminiGenerationConfig) io.Reader {
+	pr, pw := io.Pipe()
+	go func() {
+		pw.CloseWithError(writeGeminiRequestJSON(pw, parts, genCfg))
+	}()
+	return pr
+}
+
+func writeGeminiRequestJSON(w io.Writer, parts []geminiPart, genCfg geminiGenerationConfig) error {
+	if _, err := io.WriteString(w, `{"contents":[{"parts":[`); err != nil {
+		return err
+	}
+
+	for i, part := range parts {
+		if i > 0 {
+			if _, err := io.WriteString(w, ","); err != nil {
+				return err
+			}
+		}
+
+		if part.InlineData != nil {
+			mimeType, err := json.Marshal(part.InlineData.MimeType)
+			if err != nil {
+				return fmt.Errorf("marshal mime type: %w", err)
+			}
+			if _, err := io.WriteString(w, `{"inlineData":{"mimeType":`); err != nil {
+				return err
+			}
+			if _, err := w.Write(mimeType); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, `,"data":"`); err != nil {
+				return err
+			}
+			encoder := base64.NewEncoder(base64.StdEncoding, w)
+			if _, err := encoder.Write(part.InlineData.Data); err != nil {
+				encoder.Close()
+				return err
+			}
+			if err := encoder.Close(); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, `"}}`); err != nil {
+				return err
+			}
+			continue
+		}
+
+		text, err := json.Marshal(part.Text)
+		if err != nil {
+			return fmt.Errorf("marshal text: %w", err)
+		}
+		if _, err := io.WriteString(w, `{"text":`); err != nil {
+			return err
+		}
+		if _, err := w.Write(text); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, `}`); err != nil {
+			return err
+		}
+	}
+
+	if _, err := io.WriteString(w, `]}],"generationConfig":`); err != nil {
+		return err
+	}
+	cfg, err := json.Marshal(genCfg)
+	if err != nil {
+		return fmt.Errorf("marshal generation config: %w", err)
+	}
+	if _, err := w.Write(cfg); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, `}`); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Gemini API types
 type geminiRequest struct {
 	Contents         []geminiContent        `json:"contents"`
@@ -175,7 +272,7 @@ type geminiPart struct {
 
 type geminiInlineData struct {
 	MimeType string `json:"mimeType"`
-	Data     string `json:"data"`
+	Data     []byte `json:"data"`
 }
 
 type geminiGenerationConfig struct {

--- a/internal/image/gemini_test.go
+++ b/internal/image/gemini_test.go
@@ -1,10 +1,20 @@
 package image
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
+
+type geminiImageRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f geminiImageRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
 
 func TestNewGeminiProviderDefaults(t *testing.T) {
 	p := NewGeminiProvider("key", "", "")
@@ -73,6 +83,88 @@ func TestGeminiImageConfigSerialization(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGeminiProviderEditStreamsInlineImages(t *testing.T) {
+	oldClient := geminiHTTPClient
+	defer func() { geminiHTTPClient = oldClient }()
+
+	var (
+		capturedBody        []byte
+		capturedContentType string
+		streamedBody        bool
+	)
+	geminiHTTPClient = &http.Client{
+		Transport: geminiImageRoundTripper(func(req *http.Request) (*http.Response, error) {
+			capturedContentType = req.Header.Get("Content-Type")
+			streamedBody = req.GetBody == nil
+			if req.Body != nil {
+				var err error
+				capturedBody, err = io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+			}
+			resp := `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"` + base64.StdEncoding.EncodeToString([]byte("edited")) + `"}}]}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(resp)),
+			}, nil
+		}),
+	}
+
+	prompt := "combine \"these\"\nplease"
+	result, err := NewGeminiProvider("test-key", "", "").Edit(context.Background(), EditRequest{
+		Prompt: prompt,
+		InputImages: []InputImage{
+			{Path: "one.png", Data: []byte("img-1")},
+			{Path: "two.jpg", Data: []byte("img-2")},
+		},
+		Size: "2K",
+	})
+	if err != nil {
+		t.Fatalf("Edit returned error: %v", err)
+	}
+
+	if !streamedBody {
+		t.Fatal("expected edit request with inline images to stream request body")
+	}
+	if capturedContentType != "application/json" {
+		t.Fatalf("content type = %q, want application/json", capturedContentType)
+	}
+
+	body := string(capturedBody)
+	if !strings.Contains(body, `"mimeType":"image/png"`) {
+		t.Fatalf("request body missing png mime type: %s", body)
+	}
+	if !strings.Contains(body, `"mimeType":"image/jpeg"`) {
+		t.Fatalf("request body missing jpeg mime type: %s", body)
+	}
+	if !strings.Contains(body, base64.StdEncoding.EncodeToString([]byte("img-1"))) {
+		t.Fatalf("request body missing first image data: %s", body)
+	}
+	if !strings.Contains(body, base64.StdEncoding.EncodeToString([]byte("img-2"))) {
+		t.Fatalf("request body missing second image data: %s", body)
+	}
+	promptJSON, err := json.Marshal(prompt)
+	if err != nil {
+		t.Fatalf("Marshal(prompt): %v", err)
+	}
+	if !strings.Contains(body, `"text":`+string(promptJSON)) {
+		t.Fatalf("request body missing escaped prompt: %s", body)
+	}
+	if !strings.Contains(body, `"imageSize":"2K"`) {
+		t.Fatalf("request body missing image size: %s", body)
+	}
+
+	if string(result.Data) != "edited" {
+		t.Fatalf("result data = %q, want %q", string(result.Data), "edited")
+	}
+	if result.MimeType != "image/png" {
+		t.Fatalf("result mime type = %q, want %q", result.MimeType, "image/png")
 	}
 }
 


### PR DESCRIPTION
## What

Stream Gemini image-edit request bodies instead of prebuilding a giant in-memory base64+JSON payload.

- keep Gemini edit parts as raw image bytes until upload time
- write request JSON directly to the HTTP body, base64-encoding inline images on the fly
- preserve the existing buffered path for debug logging and text-only requests
- add a regression test that verifies inline-image edits stream the request body and still send the expected payload

## Why

Gemini edits were loading image bytes, then creating a second full-size base64 string copy for every input image, and then marshaling the whole request into another large JSON buffer before upload started. Multi-image edits could therefore hit large memory spikes and noticeable startup delay. Streaming the request body removes the extra pre-upload copy in the normal edit path while keeping the change tightly scoped.
