### PR TITLE
fix: Web UI eagerly base64-encodes and retains every attachment before upload

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2686,19 +2686,45 @@ const readFileAsDataURL = (file, signal) => new Promise((resolve, reject) => {
 });
 
 const materializeAttachmentDataURL = async (att, signal) => {
-  if (att?.dataURL) return { dataURL: att.dataURL, previewURLToRevoke: '' };
-  const previousPreviewURL = String(att?.previewURL || '');
+  const name = String(att?.name || 'attachment');
+  const type = String(att?.type || '');
+  if (att?.dataURL) return { name, type, dataURL: att.dataURL };
   const dataURL = await readFileAsDataURL(att?.file, signal);
   if (!dataURL) {
-    throw new Error(`Failed to read ${att?.name || 'attachment'}.`);
+    throw new Error(`Failed to read ${name}.`);
   }
-  att.dataURL = dataURL;
-  att.previewURL = dataURL;
-  delete att.file;
-  return {
-    dataURL,
-    previewURLToRevoke: previousPreviewURL && previousPreviewURL !== dataURL ? previousPreviewURL : ''
+  return { name, type, dataURL };
+};
+
+const buildAttachmentInputParts = async (attachments, signal) => {
+  const materialized = await Promise.all((attachments || []).map(att => materializeAttachmentDataURL(att, signal)));
+  return materialized.map(att => (
+    att.type.startsWith('image/')
+      ? { type: 'input_image', image_url: att.dataURL, filename: att.name }
+      : { type: 'input_file', file_data: att.dataURL, filename: att.name }
+  ));
+};
+
+const cloneAttachmentForMessage = (att) => {
+  const cloned = {
+    id: String(att?.id || generateId('att')),
+    name: String(att?.name || 'file'),
+    type: String(att?.type || 'application/octet-stream')
   };
+  if (Number.isFinite(Number(att?.size))) {
+    cloned.size = Number(att.size);
+  }
+  const previewURL = String(att?.previewURL || '');
+  if (previewURL) {
+    cloned.previewURL = previewURL;
+  }
+  if (att?.file) {
+    cloned.file = att.file;
+  }
+  if (att?.dataURL) {
+    cloned.dataURL = att.dataURL;
+  }
+  return cloned;
 };
 
 const renderAttachments = () => {
@@ -3102,19 +3128,12 @@ const markToolGroupsDone = (session) => {
 
 // Rebuild a full conversation input array from locally-stored session messages.
 // Used to recover when previous_response_id has expired server-side.
-const rebuildInputFromSession = (session, currentInput) => {
+const rebuildInputFromSession = async (session, currentInput, signal) => {
   const input = [];
   for (const msg of session.messages) {
     if (msg.role === 'user' && !msg.askUser) {
       if (msg.attachments && msg.attachments.length > 0) {
-        const parts = [];
-        for (const att of msg.attachments) {
-          if (att.type && att.type.startsWith('image/') && att.dataURL) {
-            parts.push({ type: 'input_image', image_url: att.dataURL, filename: att.name });
-          } else if (att.dataURL) {
-            parts.push({ type: 'input_file', file_data: att.dataURL, filename: att.name });
-          }
-        }
+        const parts = await buildAttachmentInputParts(msg.attachments, signal);
         if (msg.content) parts.push({ type: 'input_text', text: msg.content });
         input.push({ type: 'message', role: 'user', content: parts });
       } else {
@@ -3200,23 +3219,15 @@ const sendMessage = async (options = {}) => {
   }
 
   const controller = new AbortController();
-  let previewURLsToRevoke = [];
+  let requestAttachmentParts = [];
   if (pendingAttachments.length > 0) {
     try {
-      for (const att of pendingAttachments) {
-        const materialized = await materializeAttachmentDataURL(att, controller.signal);
-        if (materialized.previewURLToRevoke) {
-          previewURLsToRevoke.push(materialized.previewURLToRevoke);
-        }
-      }
-      if (!Array.isArray(options.attachments)) {
-        renderAttachments();
-      }
+      requestAttachmentParts = await buildAttachmentInputParts(pendingAttachments, controller.signal);
     } catch (err) {
-      previewURLsToRevoke.forEach(revokeObjectURLString);
-      previewURLsToRevoke = [];
-      if (!Array.isArray(options.attachments)) {
-        renderAttachments();
+      try {
+        controller.abort();
+      } catch {
+        // Ignore abort failures while tearing down attachment reads.
       }
       const message = err?.message || 'Failed to read attachment.';
       alert(message);
@@ -3254,7 +3265,7 @@ const sendMessage = async (options = {}) => {
   session.lastMessageAt = Date.now();
 
   if (pendingAttachments.length > 0) {
-    userMessage.attachments = pendingAttachments.slice();
+    userMessage.attachments = pendingAttachments.map(cloneAttachmentForMessage);
   } else {
     delete userMessage.attachments;
   }
@@ -3270,10 +3281,6 @@ const sendMessage = async (options = {}) => {
     elements.messages.appendChild(createMessageNode(userMessage));
   } else {
     updateUserNode(userMessage);
-  }
-  if (previewURLsToRevoke.length > 0) {
-    previewURLsToRevoke.forEach(revokeObjectURLString);
-    previewURLsToRevoke = [];
   }
   syncTurnActionPanels();
 
@@ -3298,15 +3305,8 @@ const sendMessage = async (options = {}) => {
   try {
     // Build input content: plain string or array with file/image parts
     let inputContent;
-    if (pendingAttachments.length > 0) {
-      const contentParts = [];
-      for (const att of pendingAttachments) {
-        if (att.type.startsWith('image/')) {
-          contentParts.push({ type: 'input_image', image_url: att.dataURL, filename: att.name });
-        } else {
-          contentParts.push({ type: 'input_file', file_data: att.dataURL, filename: att.name });
-        }
-      }
+    if (requestAttachmentParts.length > 0) {
+      const contentParts = requestAttachmentParts.slice();
       if (prompt) {
         contentParts.push({ type: 'input_text', text: prompt });
       }
@@ -3323,7 +3323,7 @@ const sendMessage = async (options = {}) => {
     if (session.lastResponseId) {
       body.previous_response_id = session.lastResponseId;
     } else if (session.messages.length > 1) {
-      body.input = rebuildInputFromSession(session, inputContent);
+      body.input = await rebuildInputFromSession(session, inputContent, controller.signal);
     }
 
     const normalizeEffortForCompare = (value) => {
@@ -3383,7 +3383,7 @@ const sendMessage = async (options = {}) => {
       if (errMsg.includes('not found') && errMsg.includes('previous_response_id')) {
         delete body.previous_response_id;
         session.lastResponseId = null;
-        body.input = rebuildInputFromSession(session, inputContent);
+        body.input = await rebuildInputFromSession(session, inputContent, controller.signal);
 
         response = await fetch(`${UI_PREFIX}/v1/responses`, {
           method: 'POST',

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -2117,15 +2117,13 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     await cleanup();
     return;
   }
-  if (!revokedURLs.includes('blob:cat.png')) {
-    fail(name, 'expected blob preview URL to be revoked after send', JSON.stringify(revokedURLs));
+  if (revokedURLs.includes('blob:cat.png')) {
+    fail(name, 'blob preview URL should remain available for the sent user message', JSON.stringify(revokedURLs));
     await cleanup();
     return;
   }
-  const createIndex = lifecycleEvents.indexOf(`create:${file.mockDataURL}`);
-  const revokeIndex = lifecycleEvents.indexOf('revoke:blob:cat.png');
-  if (createIndex === -1 || revokeIndex === -1 || createIndex > revokeIndex) {
-    fail(name, 'expected user message to render with data URL before revoking blob preview URL', JSON.stringify(lifecycleEvents));
+  if (!lifecycleEvents.includes('create:blob:cat.png')) {
+    fail(name, 'expected user message to keep rendering from the existing blob preview URL', JSON.stringify(lifecycleEvents));
     await cleanup();
     return;
   }
@@ -2138,18 +2136,18 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     await cleanup();
     return;
   }
-  if (storedAttachment.dataURL !== file.mockDataURL) {
-    fail(name, `stored attachment dataURL = ${JSON.stringify(storedAttachment.dataURL)}, want ${JSON.stringify(file.mockDataURL)}`);
+  if (Object.prototype.hasOwnProperty.call(storedAttachment, 'dataURL')) {
+    fail(name, 'stored attachment should not retain the materialized data URL after send', JSON.stringify(storedAttachment));
     await cleanup();
     return;
   }
-  if (storedAttachment.previewURL !== file.mockDataURL) {
-    fail(name, `stored attachment previewURL = ${JSON.stringify(storedAttachment.previewURL)}, want ${JSON.stringify(file.mockDataURL)}`);
+  if (storedAttachment.previewURL !== 'blob:cat.png') {
+    fail(name, `stored attachment previewURL = ${JSON.stringify(storedAttachment.previewURL)}, want "blob:cat.png"`);
     await cleanup();
     return;
   }
-  if (Object.prototype.hasOwnProperty.call(storedAttachment, 'file')) {
-    fail(name, 'stored attachment should drop the original File reference after materializing', JSON.stringify(storedAttachment));
+  if (!Object.prototype.hasOwnProperty.call(storedAttachment, 'file')) {
+    fail(name, 'stored attachment should retain the original File so retries can rebuild attachment input', JSON.stringify(storedAttachment));
     await cleanup();
     return;
   }
@@ -2273,8 +2271,8 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
     await cleanup();
     return;
   }
-  if (state.attachments[0].dataURL !== firstFile.mockDataURL || Object.prototype.hasOwnProperty.call(state.attachments[0], 'file')) {
-    fail(name, 'successfully read attachment should remain pending as materialized data URL', JSON.stringify(state.attachments[0]));
+  if (state.attachments[0].previewURL !== 'blob:ok.png' || Object.prototype.hasOwnProperty.call(state.attachments[0], 'dataURL') || !Object.prototype.hasOwnProperty.call(state.attachments[0], 'file')) {
+    fail(name, 'successful reads should stay transient when a later attachment fails', JSON.stringify(state.attachments[0]));
     await cleanup();
     return;
   }
@@ -2283,8 +2281,8 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
     await cleanup();
     return;
   }
-  if (!revokedURLs.includes('blob:ok.png')) {
-    fail(name, 'old blob URL for materialized attachment should be revoked on later materialization failure', JSON.stringify(revokedURLs));
+  if (revokedURLs.includes('blob:ok.png')) {
+    fail(name, 'transient materialization should not revoke the pending attachment preview on failure', JSON.stringify(revokedURLs));
     await cleanup();
     return;
   }
@@ -2295,6 +2293,106 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
   }
   if (!alerts.some((message) => message.includes('cannot read bad.png'))) {
     fail(name, 'expected read failure to be shown to the user', JSON.stringify(alerts));
+    await cleanup();
+    return;
+  }
+
+  await cleanup();
+  pass(name);
+}
+
+async function testRebuildInputFromSessionReMaterializesStoredAttachments() {
+  const name = 'rebuildInputFromSession rematerializes stored attachments without retaining data URLs on messages';
+  let readCount = 0;
+
+  class MockFileReader {
+    constructor() {
+      this.result = null;
+      this.error = null;
+      this.onload = null;
+      this.onerror = null;
+      this.onabort = null;
+    }
+
+    readAsDataURL(file) {
+      readCount += 1;
+      this.result = file.mockDataURL;
+      setTimeout(() => {
+        if (this.onload) this.onload();
+      }, 0);
+    }
+
+    abort() {
+      if (this.onabort) this.onabort();
+    }
+  }
+
+  const harness = createHarness({
+    FileReader: MockFileReader,
+    urlAPI: {
+      createObjectURL(file) {
+        return `blob:${file.name}`;
+      },
+      revokeObjectURL() {}
+    }
+  });
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+
+  const file = {
+    name: 'cat.png',
+    type: 'image/png',
+    size: 4,
+    mockDataURL: 'data:image/png;base64,Y2F0'
+  };
+
+  app.handleFiles([file]);
+  elements.promptInput.value = 'first turn';
+  await app.sendMessage();
+
+  const session = state.sessions[0];
+  if (!session) {
+    fail(name, 'expected first send to create a session');
+    await cleanup();
+    return;
+  }
+  session.lastResponseId = null;
+
+  elements.promptInput.value = 'second turn';
+  await app.sendMessage();
+
+  if (readCount !== 2) {
+    fail(name, `expected attachment to be reread for rebuild = 2 total reads, got ${readCount}`);
+    await cleanup();
+    return;
+  }
+
+  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (postCalls.length < 2 || !postCalls[1].body) {
+    fail(name, 'expected a second POST body for the rebuilt conversation', JSON.stringify(fetchCalls));
+    await cleanup();
+    return;
+  }
+
+  let body;
+  try {
+    body = JSON.parse(postCalls[1].body);
+  } catch (err) {
+    fail(name, 'rebuilt response POST body was not valid JSON', String(err));
+    await cleanup();
+    return;
+  }
+
+  const firstUserParts = body.input?.[0]?.content;
+  const imagePart = Array.isArray(firstUserParts) ? firstUserParts.find((part) => part.type === 'input_image') : null;
+  if (!imagePart || imagePart.image_url !== file.mockDataURL) {
+    fail(name, 'rebuilt conversation should include the prior image attachment', JSON.stringify(body));
+    await cleanup();
+    return;
+  }
+
+  const storedAttachment = session.messages[0]?.attachments?.[0];
+  if (!storedAttachment || Object.prototype.hasOwnProperty.call(storedAttachment, 'dataURL')) {
+    fail(name, 'stored session attachment should remain lightweight after rebuild', JSON.stringify(storedAttachment));
     await cleanup();
     return;
   }
@@ -2447,6 +2545,7 @@ function testRestoreLatestDraftMessageDoesNotCrossSessionBoundary() {
   await testSendMessageConsumesPostStreamWhenAvailable();
   await testSendMessageLazilyMaterializesAttachmentDataURLs();
   await testSendMessageKeepsComposerWhenAttachmentMaterializationFails();
+  await testRebuildInputFromSessionReMaterializesStoredAttachments();
   await testFailedSendKeepsSessionDraftAndRestagesComposer();
   await testSuccessfulSendRemovesOnlyMatchingDraft();
   testRestoreDraftMessageForSessionIsSessionBound();


### PR DESCRIPTION
## What

- stop mutating pending Web UI attachments into persistent base64 `data:` URLs before send
- materialize attachment payloads only into transient request parts used for `/v1/responses`
- keep sent message attachments lightweight by preserving their existing preview/file references instead of storing the encoded payload on the session message
- rebuild prior attachment turns on demand when the UI has to reconstruct conversation input, with coverage for both normal sends and attachment read failures

## Why

The old flow eagerly read every attachment into base64, replaced the preview blob URL with that larger string, dropped the original file, and then kept the base64 payload on message/session objects even after the request was sent. That caused long pre-send stalls on multi-attachment turns, multiple in-memory copies of the same file, and persistent client-side memory bloat.

This change keeps the expensive base64 payload transient while preserving current behavior for previews and previous-response recovery.
