### PR TITLE
fix: filesDir serving duplicates generated media under a new random filename on every call

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -541,22 +541,42 @@ func (s *serveServer) ensureFileServeable(filePath string) (string, bool) {
 	}
 	defer src.Close()
 
-	destName := fmt.Sprintf("serve-%s-%s", randomSuffix(), filepath.Base(absFile))
-	destPath := filepath.Join(absDir, destName)
-	dst, err := os.Create(destPath)
+	// Use a deterministic content-derived name so repeated tool-event emits or
+	// history replays don't mint fresh file URLs or leak duplicate copies into
+	// the files dir.
+	tmpPath := filepath.Join(absDir, fmt.Sprintf("serve-%s-%s.tmp", randomSuffix(), filepath.Base(absFile)))
+	dst, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
-		log.Printf("[serve] ensureFileServeable: create %s: %v", destPath, err)
+		log.Printf("[serve] ensureFileServeable: create %s: %v", tmpPath, err)
 		return "", false
 	}
-	if _, err := io.Copy(dst, src); err != nil {
+	hash := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(dst, hash), src); err != nil {
 		dst.Close()
-		os.Remove(destPath)
-		log.Printf("[serve] ensureFileServeable: copy to %s: %v", destPath, err)
+		os.Remove(tmpPath)
+		log.Printf("[serve] ensureFileServeable: copy to %s: %v", tmpPath, err)
 		return "", false
 	}
 	if err := dst.Close(); err != nil {
-		os.Remove(destPath)
-		log.Printf("[serve] ensureFileServeable: close %s: %v", destPath, err)
+		os.Remove(tmpPath)
+		log.Printf("[serve] ensureFileServeable: close %s: %v", tmpPath, err)
+		return "", false
+	}
+
+	sum := hash.Sum(nil)
+	destName := fmt.Sprintf("serve-%s-%s", hex.EncodeToString(sum[:16]), filepath.Base(absFile))
+	destPath := filepath.Join(absDir, destName)
+	if info, err := os.Stat(destPath); err == nil && !info.IsDir() {
+		os.Remove(tmpPath)
+		return destPath, true
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		if _, statErr := os.Stat(destPath); statErr == nil {
+			os.Remove(tmpPath)
+			return destPath, true
+		}
+		os.Remove(tmpPath)
+		log.Printf("[serve] ensureFileServeable: rename %s -> %s: %v", tmpPath, destPath, err)
 		return "", false
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3290,6 +3290,21 @@ func TestEnsureFileServeable_CopiesFromImageOutputDir(t *testing.T) {
 	if string(data) != "image-data" {
 		t.Fatalf("copied data = %q, want %q", string(data), "image-data")
 	}
+
+	secondResult, ok := srv.ensureFileServeable(generatedImg)
+	if !ok {
+		t.Fatal("second ensureFileServeable should also succeed")
+	}
+	if secondResult != result {
+		t.Fatalf("repeat ensureFileServeable should reuse the same copied path, got %q want %q", secondResult, result)
+	}
+	entries, err := os.ReadDir(filesDir)
+	if err != nil {
+		t.Fatalf("read files dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("files dir should contain exactly one copied file after repeat calls, got %d", len(entries))
+	}
 }
 
 func TestEnsureFileServeable_CopiesFromWriteDir(t *testing.T) {


### PR DESCRIPTION
## What

Use a deterministic content-derived filename when `ensureFileServeable` has to materialize an approved file into `filesDir`, and reuse the existing copy when that content is already present.

Also add a regression test covering repeated calls for the same generated file so they return the same path and leave only one copied file in `filesDir`.

## Why

The old code always copied approved files to `filesDir` as `serve-<random>-<basename>`, so the same generated media could be recopied on every tool-event emission or replay. That wasted disk writes and storage, produced a new URL every time, and defeated browser caching when reopening or redownloading generated media.
