### PR TITLE
fix: Image serving re-copies the full source file before checking whether the hashed cache target already exists

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -636,15 +636,38 @@ func (s *serveServer) ensureImageServeable(imgPath string) (string, bool) {
 
 	// Use a deterministic content-derived name so repeated history fetches
 	// don't mint fresh image URLs or leak duplicate copies into the output dir.
+	hash := sha256.New()
+	limited := &io.LimitedReader{R: src, N: maxMaterializedSessionImageBytes + 1}
+	written, err := io.Copy(hash, limited)
+	if err != nil {
+		log.Printf("[serve] ensureImageServeable: hash %s: %v", absImg, err)
+		return "", false
+	}
+	if written > maxMaterializedSessionImageBytes {
+		log.Printf("[serve] ensureImageServeable: refusing image larger than %d bytes: %s", maxMaterializedSessionImageBytes, absImg)
+		return "", false
+	}
+
+	sum := hash.Sum(nil)
+	destName := fmt.Sprintf("serve-%s-%s", hex.EncodeToString(sum[:16]), filepath.Base(absImg))
+	destPath := filepath.Join(absDir, destName)
+	if info, err := os.Stat(destPath); err == nil && !info.IsDir() {
+		return destPath, true
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		log.Printf("[serve] ensureImageServeable: rewind %s: %v", absImg, err)
+		return "", false
+	}
+
 	tmpPath := filepath.Join(absDir, fmt.Sprintf("serve-%s-%s.tmp", randomSuffix(), filepath.Base(absImg)))
 	dst, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		log.Printf("[serve] ensureImageServeable: create %s: %v", tmpPath, err)
 		return "", false
 	}
-	hash := sha256.New()
-	limited := &io.LimitedReader{R: src, N: maxMaterializedSessionImageBytes + 1}
-	written, err := io.Copy(io.MultiWriter(dst, hash), limited)
+	copyHash := sha256.New()
+	limited = &io.LimitedReader{R: src, N: maxMaterializedSessionImageBytes + 1}
+	written, err = io.Copy(io.MultiWriter(dst, copyHash), limited)
 	if err != nil {
 		dst.Close()
 		os.Remove(tmpPath)
@@ -657,19 +680,18 @@ func (s *serveServer) ensureImageServeable(imgPath string) (string, bool) {
 		log.Printf("[serve] ensureImageServeable: refusing image larger than %d bytes: %s", maxMaterializedSessionImageBytes, absImg)
 		return "", false
 	}
+	if !bytes.Equal(copyHash.Sum(nil), sum) {
+		dst.Close()
+		os.Remove(tmpPath)
+		log.Printf("[serve] ensureImageServeable: source changed while materializing %s", absImg)
+		return "", false
+	}
 	if err := dst.Close(); err != nil {
 		os.Remove(tmpPath)
 		log.Printf("[serve] ensureImageServeable: close %s: %v", tmpPath, err)
 		return "", false
 	}
 
-	sum := hash.Sum(nil)
-	destName := fmt.Sprintf("serve-%s-%s", hex.EncodeToString(sum[:16]), filepath.Base(absImg))
-	destPath := filepath.Join(absDir, destName)
-	if info, err := os.Stat(destPath); err == nil && !info.IsDir() {
-		os.Remove(tmpPath)
-		return destPath, true
-	}
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		if _, statErr := os.Stat(destPath); statErr == nil {
 			os.Remove(tmpPath)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3095,6 +3095,47 @@ func TestEnsureImageServeable_CopiesFromWriteDir(t *testing.T) {
 	}
 }
 
+func TestEnsureImageServeable_ReusesExistingMaterializedCopyWithoutDirectoryWrites(t *testing.T) {
+	outputDir := t.TempDir()
+	writeDir := t.TempDir()
+	writeDirImg := filepath.Join(writeDir, "tool-output.png")
+	if err := os.WriteFile(writeDirImg, []byte("tool-png"), 0644); err != nil {
+		t.Fatalf("write writeDir image: %v", err)
+	}
+
+	srv := &serveServer{
+		cfg:    serveServerConfig{writeDirs: []string{writeDir}},
+		cfgRef: &config.Config{},
+	}
+	srv.cfgRef.Image.OutputDir = outputDir
+
+	result, ok := srv.ensureImageServeable(writeDirImg)
+	if !ok {
+		t.Fatal("first ensureImageServeable should accept images from configured writeDirs")
+	}
+
+	fixedTime := time.Unix(123, 0)
+	if err := os.Chtimes(outputDir, fixedTime, fixedTime); err != nil {
+		t.Fatalf("set output dir times: %v", err)
+	}
+
+	resultAgain, ok := srv.ensureImageServeable(writeDirImg)
+	if !ok {
+		t.Fatal("second ensureImageServeable should accept images from configured writeDirs")
+	}
+	if resultAgain != result {
+		t.Fatalf("second ensureImageServeable result = %q, want stable %q", resultAgain, result)
+	}
+
+	info, err := os.Stat(outputDir)
+	if err != nil {
+		t.Fatalf("stat output dir: %v", err)
+	}
+	if !info.ModTime().Equal(fixedTime) {
+		t.Fatalf("output dir modtime = %v, want unchanged %v", info.ModTime(), fixedTime)
+	}
+}
+
 func TestHandleFile_ServesFileAndRejectsTraversal(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "video.mp4"), []byte("fake-video"), 0644); err != nil {


### PR DESCRIPTION
## What

- hash the approved source image first so `ensureImageServeable` can check the deterministic cache path before creating a temp file or copying bytes into the output directory
- only rewind and materialize a temp copy when the hashed destination does not already exist
- verify with a regression test that a repeated call reuses the existing materialized copy without mutating the output directory

## Why

Repeated history fetches and tool result replays were still creating and deleting a temp file after reading the full source image, even when the stable hashed copy had already been materialized. That adds avoidable disk I/O and latency on a hot path. This change preserves the stable content-derived naming while skipping the extra output-directory write work for cache hits.
