### PR TITLE
perf: reduce smooth buffer drain copying

### DIFF
--- a/internal/ui/smooth_buffer.go
+++ b/internal/ui/smooth_buffer.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -16,6 +17,8 @@ const (
 	SmoothMinWordsPerFrame = 1
 	SmoothMaxWordsPerFrame = 5
 	SmoothMaxWordLength    = 12 // Chunk words longer than this
+
+	smoothBufferCompactThreshold = 4096
 )
 
 // SmoothTickMsg is sent to trigger the next frame of smooth text rendering
@@ -25,9 +28,10 @@ type SmoothTickMsg struct{}
 // Text is buffered and released word-by-word at a pace that adapts to
 // the incoming content rate.
 type SmoothBuffer struct {
-	mu        sync.Mutex
-	buffer    strings.Builder
-	inputDone bool
+	mu         sync.Mutex
+	buffer     []byte
+	readOffset int
+	inputDone  bool
 }
 
 // NewSmoothBuffer creates a new SmoothBuffer
@@ -39,7 +43,7 @@ func NewSmoothBuffer() *SmoothBuffer {
 func (b *SmoothBuffer) Write(text string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.buffer.WriteString(text)
+	b.buffer = append(b.buffer, text...)
 }
 
 // MarkDone signals that the input stream has ended
@@ -53,14 +57,14 @@ func (b *SmoothBuffer) MarkDone() {
 func (b *SmoothBuffer) IsDrained() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.inputDone && b.buffer.Len() == 0
+	return b.inputDone && b.unreadLen() == 0
 }
 
 // Len returns the current buffer size in bytes
 func (b *SmoothBuffer) Len() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.buffer.Len()
+	return b.unreadLen()
 }
 
 // IsEmpty returns true if the buffer is empty
@@ -68,10 +72,14 @@ func (b *SmoothBuffer) IsEmpty() bool {
 	return b.Len() == 0
 }
 
+func (b *SmoothBuffer) unreadLen() int {
+	return len(b.buffer) - b.readOffset
+}
+
 // wordsPerFrame calculates how many words to emit based on buffer fill level
 func (b *SmoothBuffer) wordsPerFrame() int {
 	// No lock needed - caller should hold lock or this is called internally
-	bufLen := b.buffer.Len()
+	bufLen := b.unreadLen()
 	fillRatio := float64(bufLen) / float64(SmoothBufferCapacity)
 
 	if fillRatio < 0.2 {
@@ -89,19 +97,16 @@ func (b *SmoothBuffer) NextWords() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.buffer.Len() == 0 {
+	if b.unreadLen() == 0 {
 		return ""
 	}
 
-	content := b.buffer.String()
 	numWords := b.wordsPerFrame()
 
-	// Extract words with preserved whitespace
-	result, remaining := extractWords(content, numWords)
-
-	// Update buffer with remaining content
-	b.buffer.Reset()
-	b.buffer.WriteString(remaining)
+	// Extract words with preserved whitespace.
+	result, consumed := extractWordsFromBytes(b.buffer[b.readOffset:], numWords)
+	b.readOffset += consumed
+	b.compactIfNeeded()
 
 	return result
 }
@@ -111,8 +116,9 @@ func (b *SmoothBuffer) FlushAll() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	content := b.buffer.String()
-	b.buffer.Reset()
+	content := string(b.buffer[b.readOffset:])
+	b.buffer = nil
+	b.readOffset = 0
 	return content
 }
 
@@ -120,8 +126,33 @@ func (b *SmoothBuffer) FlushAll() string {
 func (b *SmoothBuffer) Reset() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.buffer.Reset()
+	b.buffer = nil
+	b.readOffset = 0
 	b.inputDone = false
+}
+
+func (b *SmoothBuffer) compactIfNeeded() {
+	if b.readOffset == 0 {
+		return
+	}
+	unread := b.unreadLen()
+	if unread == 0 {
+		b.buffer = nil
+		b.readOffset = 0
+		return
+	}
+	if b.readOffset < smoothBufferCompactThreshold || b.readOffset < unread {
+		return
+	}
+
+	remaining := b.buffer[b.readOffset:]
+	if cap(b.buffer) > unread*2+smoothBufferCompactThreshold {
+		b.buffer = append([]byte(nil), remaining...)
+	} else {
+		copy(b.buffer, remaining)
+		b.buffer = b.buffer[:unread]
+	}
+	b.readOffset = 0
 }
 
 // SmoothTick returns a tea.Cmd that sends a SmoothTickMsg after the frame interval
@@ -138,48 +169,75 @@ func extractWords(content string, n int) (string, string) {
 		return "", content
 	}
 
-	runes := []rune(content)
+	result, consumed := extractWordsFromBytes([]byte(content), n)
+	return result, content[consumed:]
+}
+
+func extractWordsFromBytes(content []byte, n int) (string, int) {
+	if len(content) == 0 || n <= 0 {
+		return "", 0
+	}
+
 	pos := 0
 	wordsExtracted := 0
 	var result strings.Builder
+	result.Grow(initialSmoothResultCapacity(len(content), n))
 
-	for pos < len(runes) && wordsExtracted < n {
+	for pos < len(content) && wordsExtracted < n {
 		// Skip and collect leading whitespace
 		wsStart := pos
-		for pos < len(runes) && unicode.IsSpace(runes[pos]) {
-			pos++
+		for pos < len(content) {
+			r, size := decodeSmoothRune(content[pos:])
+			if !unicode.IsSpace(r) {
+				break
+			}
+			pos += size
 		}
 		if pos > wsStart {
-			result.WriteString(string(runes[wsStart:pos]))
+			result.Write(content[wsStart:pos])
 		}
 
-		if pos >= len(runes) {
+		if pos >= len(content) {
 			break
 		}
 
 		// Collect word characters
 		wordStart := pos
-		for pos < len(runes) && !unicode.IsSpace(runes[pos]) {
-			pos++
+		chunkEnd := pos
+		wordRunes := 0
+		for pos < len(content) {
+			r, size := decodeSmoothRune(content[pos:])
+			if unicode.IsSpace(r) {
+				break
+			}
+			if wordRunes < SmoothMaxWordLength {
+				chunkEnd = pos + size
+			}
+			wordRunes++
+			pos += size
+			if wordRunes > SmoothMaxWordLength {
+				result.Write(content[wordStart:chunkEnd])
+				return result.String(), chunkEnd
+			}
 		}
 
 		if pos > wordStart {
-			word := runes[wordStart:pos]
-
-			// Chunk long words
-			if len(word) > SmoothMaxWordLength {
-				// Take only a chunk
-				chunk := word[:SmoothMaxWordLength]
-				result.WriteString(string(chunk))
-				// Put the rest back
-				remaining := string(word[SmoothMaxWordLength:]) + string(runes[pos:])
-				return result.String(), remaining
-			}
-
-			result.WriteString(string(word))
+			result.Write(content[wordStart:pos])
 			wordsExtracted++
 		}
 	}
 
-	return result.String(), string(runes[pos:])
+	return result.String(), pos
+}
+
+func decodeSmoothRune(content []byte) (rune, int) {
+	return utf8.DecodeRune(content)
+}
+
+func initialSmoothResultCapacity(contentLen, n int) int {
+	capacity := n*(SmoothMaxWordLength+1) + 16
+	if capacity > contentLen {
+		return contentLen
+	}
+	return capacity
 }

--- a/internal/ui/smooth_buffer_bench_test.go
+++ b/internal/ui/smooth_buffer_bench_test.go
@@ -1,0 +1,40 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkSmoothBufferDrainBacklog(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{"4KB", 4 * 1024},
+		{"16KB", 16 * 1024},
+		{"64KB", 64 * 1024},
+	} {
+		content := strings.Repeat("word ", tc.size/len("word "))
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(content)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				buf := NewSmoothBuffer()
+				buf.Write(content)
+
+				emitted := 0
+				for !buf.IsEmpty() {
+					chunk := buf.NextWords()
+					if chunk == "" {
+						b.Fatal("NextWords returned empty chunk before buffer drained")
+					}
+					emitted += len(chunk)
+				}
+				if emitted != len(content) {
+					b.Fatalf("emitted %d bytes, want %d", emitted, len(content))
+				}
+			}
+		})
+	}
+}

--- a/internal/ui/smooth_buffer_test.go
+++ b/internal/ui/smooth_buffer_test.go
@@ -149,6 +149,59 @@ func TestSmoothBuffer_EmptyBuffer(t *testing.T) {
 	}
 }
 
+func TestSmoothBuffer_WriteAfterPartialRead(t *testing.T) {
+	b := NewSmoothBuffer()
+	b.Write("one two three")
+
+	first := b.NextWords()
+	if first == "" {
+		t.Fatal("expected first chunk")
+	}
+	if b.readOffset == 0 {
+		t.Fatal("expected non-zero readOffset after partial read")
+	}
+
+	b.Write(" four")
+	if got := first + b.FlushAll(); got != "one two three four" {
+		t.Fatalf("combined output = %q, want original order", got)
+	}
+}
+
+func TestSmoothBuffer_CompactPreservesUnreadAndShrinksLargeBacking(t *testing.T) {
+	remaining := " tail one two"
+	backing := make([]byte, smoothBufferCompactThreshold+len(remaining), 64*1024)
+	for i := 0; i < smoothBufferCompactThreshold; i++ {
+		backing[i] = 'x'
+	}
+	copy(backing[smoothBufferCompactThreshold:], remaining)
+
+	b := &SmoothBuffer{
+		buffer:     backing,
+		readOffset: smoothBufferCompactThreshold,
+	}
+	oldCap := cap(b.buffer)
+
+	b.compactIfNeeded()
+
+	if b.readOffset != 0 {
+		t.Fatalf("readOffset = %d, want 0", b.readOffset)
+	}
+	if got := string(b.buffer); got != remaining {
+		t.Fatalf("buffer = %q, want %q", got, remaining)
+	}
+	if got := b.Len(); got != len(remaining) {
+		t.Fatalf("Len() = %d, want %d", got, len(remaining))
+	}
+	if cap(b.buffer) >= oldCap {
+		t.Fatalf("cap after compact = %d, want less than old cap %d", cap(b.buffer), oldCap)
+	}
+
+	b.Write(" three")
+	if got := b.FlushAll(); got != " tail one two three" {
+		t.Fatalf("FlushAll after compact/write = %q", got)
+	}
+}
+
 func TestExtractWords_Basic(t *testing.T) {
 	tests := []struct {
 		content   string
@@ -185,6 +238,18 @@ func TestExtractWords_LongWord(t *testing.T) {
 	}
 	if rem != longWord[SmoothMaxWordLength:] {
 		t.Errorf("remaining = %q, want %q", rem, longWord[SmoothMaxWordLength:])
+	}
+}
+
+func TestExtractWords_LongWordChunksByRune(t *testing.T) {
+	longWord := strings.Repeat("界", SmoothMaxWordLength+3)
+	got, rem := extractWords(longWord, 1)
+
+	if got != strings.Repeat("界", SmoothMaxWordLength) {
+		t.Errorf("got %q, want first %d runes", got, SmoothMaxWordLength)
+	}
+	if rem != strings.Repeat("界", 3) {
+		t.Errorf("remaining = %q, want 3 runes", rem)
 	}
 }
 


### PR DESCRIPTION
## What

Reduce `SmoothBuffer.NextWords` backlog drain work in the terminal streaming path.

The old implementation converted the entire pending buffer to a string, converted that whole string to `[]rune`, extracted a few words, then rebuilt the buffer with the remaining text on every 60fps tick. This made draining large provider bursts roughly quadratic in the unread backlog.

This PR changes `SmoothBuffer` to keep a byte slice plus read offset, scan only the emitted prefix using UTF-8 decoding, and compact occasionally. Compaction drops oversized backing arrays when a large burst has mostly drained, so the offset-based buffer does not retain peak memory indefinitely.

It also adds regression coverage for:

- appending after a partial read,
- compaction preserving unread bytes and shrinking oversized backing storage,
- long-word chunking by rune for multi-byte text,
- backlog drain benchmark coverage.

## Why

`SmoothBuffer` sits in the visible terminal streaming path for ask/chat. Fast providers can enqueue large bursts, and the UI then releases a handful of words per frame. Avoiding full-buffer copies and full-buffer rune conversion per frame makes streaming repaint lighter and less latency-prone under backlog.

## Evidence

Added `BenchmarkSmoothBufferDrainBacklog` and ran before/after with `-benchtime=100ms -count=3` on linux/amd64 i9-14900K.

Representative results:

| Backlog | Before | After |
| --- | ---: | ---: |
| 4KB | ~1.48-1.62 ms/op, ~2.17 MB/op, 1090 allocs/op | ~28.7-29.9 µs/op, ~20.3 KB/op, 196 allocs/op |
| 16KB | ~21.0-21.9 ms/op, ~34.5 MB/op, 4040 allocs/op | ~108.7-110.2 µs/op, ~83.8 KB/op, 689 allocs/op |
| 64KB | ~315-329 ms/op, ~538 MB/op, ~15840 allocs/op | ~449-480 µs/op, ~338 KB/op, 2656 allocs/op |

## Verification

- `gofmt -w internal/ui/smooth_buffer.go internal/ui/smooth_buffer_test.go internal/ui/smooth_buffer_bench_test.go`
- `go test ./internal/ui`
- `go test ./internal/ui -run '^$' -bench '^BenchmarkSmoothBufferDrainBacklog$' -benchmem -benchtime=100ms -count=3`
- `go build ./...`
- `go test ./...`
