### PR TITLE
perf: avoid duplicate skill registry scan

### DIFF
--- a/internal/skills/parser.go
+++ b/internal/skills/parser.go
@@ -280,7 +280,10 @@ func extractExtrasFromNode(node *yaml.Node) (map[string]any, error) {
 // LoadFromDir loads a skill from a directory containing SKILL.md.
 // If loadBody is false, only metadata is loaded (for discovery).
 func LoadFromDir(dir string, source SkillSource, loadBody bool) (*Skill, error) {
-	// Try SKILL.md first, then skill.md (with warning)
+	// Try SKILL.md first, then skill.md (with warning). Preserve the historical
+	// behavior of falling back to lowercase only when the preferred file is known
+	// to be absent, so permission/symlink errors on SKILL.md are surfaced by the
+	// open below instead of being masked by skill.md.
 	skillPath := filepath.Join(dir, "SKILL.md")
 	if _, err := os.Stat(skillPath); os.IsNotExist(err) {
 		lowerPath := filepath.Join(dir, "skill.md")
@@ -291,7 +294,46 @@ func LoadFromDir(dir string, source SkillSource, loadBody bool) (*Skill, error) 
 			return nil, fmt.Errorf("SKILL.md not found in %s", dir)
 		}
 	}
+	return loadFromSkillFile(skillPath, dir, source, loadBody)
+}
 
+var skillManifestNames = [...]string{"SKILL.md", "skill.md"}
+
+type skillManifest struct {
+	fileName string
+	path     string
+	info     os.FileInfo
+}
+
+func findSkillManifest(dir string) (skillManifest, bool) {
+	upperPath := filepath.Join(dir, skillManifestNames[0])
+	info, err := os.Stat(upperPath)
+	if err == nil {
+		if !info.IsDir() {
+			return skillManifest{fileName: skillManifestNames[0], path: upperPath, info: info}, true
+		}
+		return skillManifest{}, false
+	}
+	if !os.IsNotExist(err) {
+		return skillManifest{}, false
+	}
+
+	lowerPath := filepath.Join(dir, skillManifestNames[1])
+	info, err = os.Stat(lowerPath)
+	if err == nil && !info.IsDir() {
+		return skillManifest{fileName: skillManifestNames[1], path: lowerPath, info: info}, true
+	}
+	return skillManifest{}, false
+}
+
+func loadFromSkillManifest(dir string, manifest skillManifest, source SkillSource, loadBody bool) (*Skill, error) {
+	if manifest.fileName == "skill.md" {
+		fmt.Fprintf(os.Stderr, "warning: skill.md should be SKILL.md: %s\n", manifest.path)
+	}
+	return loadFromSkillFile(manifest.path, dir, source, loadBody)
+}
+
+func loadFromSkillFile(skillPath, dir string, source SkillSource, loadBody bool) (*Skill, error) {
 	skill, err := ParseSkillMD(skillPath, loadBody)
 	if err != nil {
 		return nil, err
@@ -340,13 +382,11 @@ func discoverFiles(skillDir, subdir string) []string {
 
 // IsSkillDir checks if a directory contains a SKILL.md file.
 func IsSkillDir(dir string) bool {
-	// Check for SKILL.md (preferred)
-	if info, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil && !info.IsDir() {
-		return true
-	}
-	// Check for skill.md (lowercase, allowed with warning)
-	if info, err := os.Stat(filepath.Join(dir, "skill.md")); err == nil && !info.IsDir() {
-		return true
+	for _, fileName := range skillManifestNames {
+		info, err := os.Stat(filepath.Join(dir, fileName))
+		if err == nil && !info.IsDir() {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -271,11 +271,12 @@ func (r *Registry) HasAnySkill() (bool, error) {
 			}
 
 			skillDir := filepath.Join(sp.path, entry.Name())
-			if !IsSkillDir(skillDir) {
+			manifest, ok := findSkillManifest(skillDir)
+			if !ok {
 				continue
 			}
 
-			skill, err := LoadFromDir(skillDir, sp.source, false)
+			skill, err := loadFromSkillManifest(skillDir, manifest, sp.source, false)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: skipping invalid skill %s: %v\n", skillDir, err)
 				continue
@@ -298,19 +299,24 @@ func (r *Registry) Get(name string) (*Skill, error) {
 		// If we have metadata only, load full content. If that cached path went
 		// stale, discard it and fall through to normal search-path resolution.
 		if !skill.IsLoaded() {
-			fullSkill, err := LoadFromDir(skill.SourcePath, skill.Source, true)
-			if err == nil {
-				if err := fullSkill.Validate(); err != nil {
-					delete(r.cache, name)
+			manifest, ok := findSkillManifest(skill.SourcePath)
+			if ok {
+				fullSkill, err := loadFromSkillManifest(skill.SourcePath, manifest, skill.Source, true)
+				if err == nil {
+					if err := fullSkill.Validate(); err != nil {
+						delete(r.cache, name)
+					} else {
+						r.cache[name] = fullSkill
+						return fullSkill, nil
+					}
 				} else {
-					r.cache[name] = fullSkill
-					return fullSkill, nil
+					delete(r.cache, name)
 				}
 			} else {
 				delete(r.cache, name)
 			}
 		} else {
-			if !IsSkillDir(skill.SourcePath) {
+			if _, ok := findSkillManifest(skill.SourcePath); !ok {
 				delete(r.cache, name)
 			} else {
 				return skill, nil
@@ -321,8 +327,9 @@ func (r *Registry) Get(name string) (*Skill, error) {
 	// The common case is a directory named after the skill.
 	for _, sp := range r.searchPaths {
 		skillDir := filepath.Join(sp.path, name)
-		if IsSkillDir(skillDir) {
-			skill, err := LoadFromDir(skillDir, sp.source, true)
+		manifest, ok := findSkillManifest(skillDir)
+		if ok {
+			skill, err := loadFromSkillManifest(skillDir, manifest, sp.source, true)
 			if err != nil {
 				return nil, fmt.Errorf("load skill %s: %w", name, err)
 			}
@@ -364,19 +371,27 @@ func (r *Registry) Get(name string) (*Skill, error) {
 // List returns all available skills (metadata only).
 // Each skill appears only once, with first-found taking precedence.
 func (r *Registry) List() ([]*Skill, error) {
-	fingerprint := r.searchPathsFingerprint()
-	if r.listCache != nil && fingerprint == r.listCacheFingerprint {
-		return cloneSkillSlice(r.listCache), nil
+	if r.listCache != nil {
+		fingerprint := r.searchPathsFingerprint()
+		if fingerprint == r.listCacheFingerprint {
+			return cloneSkillSlice(r.listCache), nil
+		}
 	}
 
 	seen := make(map[string]bool)
 	r.shadowCounts = make(map[string]int)
 	var skills []*Skill
+	var fingerprint strings.Builder
 
-	// Scan filesystem paths
+	// Scan filesystem paths, building the cache fingerprint from the same stat
+	// calls used to discover manifests. The first List() call is usually on a CLI
+	// startup path, so avoid an eager fingerprint pass that rereads every directory
+	// and stats every SKILL.md before immediately scanning again.
 	for _, sp := range r.searchPaths {
-		found, err := r.scanDir(sp.path, sp.source)
+		writeSearchPathFingerprintHeader(&fingerprint, sp)
+		found, err := r.scanDirWithFingerprint(sp.path, sp.source, &fingerprint)
 		if err != nil {
+			fingerprint.WriteString("!missing\n")
 			continue // Skip directories that don't exist or can't be read
 		}
 
@@ -398,7 +413,7 @@ func (r *Registry) List() ([]*Skill, error) {
 		return skills[i].Name < skills[j].Name
 	})
 
-	r.listCacheFingerprint = fingerprint
+	r.listCacheFingerprint = fingerprint.String()
 	r.listCache = cloneSkillSlice(skills)
 
 	return cloneSkillSlice(skills), nil
@@ -551,10 +566,7 @@ func cloneSkillToolDefs(in []SkillToolDef) []SkillToolDef {
 func (r *Registry) searchPathsFingerprint() string {
 	var sb strings.Builder
 	for _, sp := range r.searchPaths {
-		sb.WriteString(sp.path)
-		sb.WriteByte('\x00')
-		sb.WriteString(sp.source.SourceName())
-		sb.WriteByte('\n')
+		writeSearchPathFingerprintHeader(&sb, sp)
 
 		entries, err := os.ReadDir(sp.path)
 		if err != nil {
@@ -565,35 +577,40 @@ func (r *Registry) searchPathsFingerprint() string {
 			if !entry.IsDir() {
 				continue
 			}
-			fileName, info, ok := skillFileInfo(filepath.Join(sp.path, entry.Name()))
+			manifest, ok := findSkillManifest(filepath.Join(sp.path, entry.Name()))
 			if !ok {
 				continue
 			}
-			sb.WriteString(entry.Name())
-			sb.WriteByte('\x00')
-			sb.WriteString(fileName)
-			sb.WriteByte('\x00')
-			sb.WriteString(strconv.FormatInt(info.ModTime().UnixNano(), 10))
-			sb.WriteByte('\x00')
-			sb.WriteString(strconv.FormatInt(info.Size(), 10))
-			sb.WriteByte('\n')
+			writeSkillFingerprint(&sb, entry.Name(), manifest)
 		}
 	}
 	return sb.String()
 }
 
-func skillFileInfo(dir string) (string, os.FileInfo, bool) {
-	for _, fileName := range []string{"SKILL.md", "skill.md"} {
-		info, err := os.Stat(filepath.Join(dir, fileName))
-		if err == nil && !info.IsDir() {
-			return fileName, info, true
-		}
-	}
-	return "", nil, false
+func writeSearchPathFingerprintHeader(sb *strings.Builder, sp searchPath) {
+	sb.WriteString(sp.path)
+	sb.WriteByte('\x00')
+	sb.WriteString(sp.source.SourceName())
+	sb.WriteByte('\n')
+}
+
+func writeSkillFingerprint(sb *strings.Builder, dirName string, manifest skillManifest) {
+	sb.WriteString(dirName)
+	sb.WriteByte('\x00')
+	sb.WriteString(manifest.fileName)
+	sb.WriteByte('\x00')
+	sb.WriteString(strconv.FormatInt(manifest.info.ModTime().UnixNano(), 10))
+	sb.WriteByte('\x00')
+	sb.WriteString(strconv.FormatInt(manifest.info.Size(), 10))
+	sb.WriteByte('\n')
 }
 
 // scanDir scans a directory for skill subdirectories.
 func (r *Registry) scanDir(dir string, source SkillSource) ([]*Skill, error) {
+	return r.scanDirWithFingerprint(dir, source, nil)
+}
+
+func (r *Registry) scanDirWithFingerprint(dir string, source SkillSource, fingerprint *strings.Builder) ([]*Skill, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -606,12 +623,16 @@ func (r *Registry) scanDir(dir string, source SkillSource) ([]*Skill, error) {
 		}
 
 		skillDir := filepath.Join(dir, entry.Name())
-		if !IsSkillDir(skillDir) {
+		manifest, ok := findSkillManifest(skillDir)
+		if !ok {
 			continue
+		}
+		if fingerprint != nil {
+			writeSkillFingerprint(fingerprint, entry.Name(), manifest)
 		}
 
 		// Load metadata only for listing
-		skill, err := LoadFromDir(skillDir, source, false)
+		skill, err := loadFromSkillManifest(skillDir, manifest, source, false)
 		if err != nil {
 			// Skip invalid skills with a diagnostic
 			fmt.Fprintf(os.Stderr, "warning: skipping invalid skill %s: %v\n", skillDir, err)

--- a/internal/skills/registry_test.go
+++ b/internal/skills/registry_test.go
@@ -757,36 +757,8 @@ func TestDefaultRegistryConfig(t *testing.T) {
 func BenchmarkRegistryListRepeated(b *testing.B) {
 	const skillCount = 200
 
-	tmpDir := b.TempDir()
-	skillsDir := filepath.Join(tmpDir, "skills")
-	for i := 0; i < skillCount; i++ {
-		name := fmt.Sprintf("bench-skill-%03d", i)
-		skillDir := filepath.Join(skillsDir, name)
-		if err := os.MkdirAll(skillDir, 0o755); err != nil {
-			b.Fatalf("mkdir skill dir: %v", err)
-		}
-		content := fmt.Sprintf(`---
-name: %s
-description: "Benchmark skill %03d for repeated registry listing"
----
-
-# %s
-
-Instructions.
-`, name, i, name)
-		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
-			b.Fatalf("write SKILL.md: %v", err)
-		}
-	}
-
-	registry, err := NewRegistry(RegistryConfig{
-		IncludeProjectSkills:  false,
-		IncludeEcosystemPaths: false,
-	})
-	if err != nil {
-		b.Fatalf("NewRegistry: %v", err)
-	}
-	registry.searchPaths = []searchPath{{path: skillsDir, source: SourceUser}}
+	skillsDir := createBenchmarkSkills(b, skillCount)
+	registry := newBenchmarkRegistry(b, skillsDir)
 
 	if skills, err := registry.List(); err != nil {
 		b.Fatalf("warm List: %v", err)
@@ -805,4 +777,64 @@ Instructions.
 			b.Fatalf("List returned %d skills, want %d", len(skills), skillCount)
 		}
 	}
+}
+
+func BenchmarkRegistryListCold(b *testing.B) {
+	const skillCount = 200
+
+	skillsDir := createBenchmarkSkills(b, skillCount)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		registry := newBenchmarkRegistry(b, skillsDir)
+		skills, err := registry.List()
+		if err != nil {
+			b.Fatalf("List: %v", err)
+		}
+		if len(skills) != skillCount {
+			b.Fatalf("List returned %d skills, want %d", len(skills), skillCount)
+		}
+	}
+}
+
+func createBenchmarkSkills(b *testing.B, skillCount int) string {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	skillsDir := filepath.Join(tmpDir, "skills")
+	for i := 0; i < skillCount; i++ {
+		name := fmt.Sprintf("bench-skill-%03d", i)
+		skillDir := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			b.Fatalf("mkdir skill dir: %v", err)
+		}
+		content := fmt.Sprintf(`---
+name: %s
+description: "Benchmark skill %03d for registry listing"
+---
+
+# %s
+
+Instructions.
+`, name, i, name)
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			b.Fatalf("write SKILL.md: %v", err)
+		}
+	}
+	return skillsDir
+}
+
+func newBenchmarkRegistry(b *testing.B, skillsDir string) *Registry {
+	b.Helper()
+
+	registry, err := NewRegistry(RegistryConfig{
+		IncludeProjectSkills:  false,
+		IncludeEcosystemPaths: false,
+	})
+	if err != nil {
+		b.Fatalf("NewRegistry: %v", err)
+	}
+	registry.searchPaths = []searchPath{{path: skillsDir, source: SourceUser}}
+	return registry
 }


### PR DESCRIPTION
## What

- Build the skill registry `List()` cache fingerprint during the first discovery scan instead of doing a separate pre-scan when the list cache is empty.
- Reuse the already-statted `SKILL.md`/`skill.md` manifest path when loading skill metadata during registry discovery.
- Add a cold `Registry.List()` benchmark alongside the existing repeated-list benchmark.

## Why

Short-lived CLI commands and completions commonly hit the skill catalog with a fresh registry, so the previous list cache could not help the first call. That first call fingerprinted every skill path, then immediately scanned the same directories again, then `IsSkillDir`/`LoadFromDir` statted the same manifest again before parsing metadata.

This keeps cache invalidation behavior for subsequent calls while removing redundant filesystem work from the first-use startup path.

## Evidence

Synthetic catalog: 1000 `.skills/*/SKILL.md` entries, running `term-llm skills` under `strace -qq -f -c -e trace=%file`.

- Before: 3038 `newfstatat`, 1019 `openat`, 4061 total file syscalls, 0.008045s reported syscall time.
- After: 1038 `newfstatat`, 1015 `openat`, 2057 total file syscalls, 0.002716s reported syscall time.

Focused benchmark after the change (`go test ./internal/skills -bench 'BenchmarkRegistryList(Cold|Repeated)$' -benchmem -run '^$' -count=3`):

- `BenchmarkRegistryListCold`: ~1.97-2.03 ms/op for 200 skills.
- `BenchmarkRegistryListRepeated`: ~233-259 µs/op for 200 skills.

## Verification

- `gofmt -w internal/skills/parser.go internal/skills/registry.go internal/skills/registry_test.go`
- `go build ./...`
- `go test ./...`
- `go test ./internal/skills -bench 'BenchmarkRegistryList(Cold|Repeated)$' -benchmem -run '^$' -count=3`
