### PR TITLE
fix: Glob traversal re-Lstats every ancestor path on every filesystem access---BUG---

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1613,7 +1613,7 @@ func (e *Engine) executeSingleToolCallSafe(ctx context.Context, call ToolCall, s
 	defer func() {
 		if r := recover(); r != nil {
 			errMsg := fmt.Sprintf("Error: tool panicked: %v", r)
-			_ = send.Send(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolSuccess: false})
+			send.TrySend(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolSuccess: false})
 			msgs = []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}
 			err = nil
 		}
@@ -1660,7 +1660,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send 
 	if !ok {
 		errMsg := fmt.Sprintf("Error: tool not registered: %s", call.Name)
 		DebugToolResult(debug, call.ID, call.Name, errMsg)
-		_ = send.Send(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false})
+		send.TrySend(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false})
 		return []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}, nil
 	}
 
@@ -1668,7 +1668,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send 
 	if !e.IsToolAllowed(call.Name) {
 		errMsg := fmt.Sprintf("Error: tool '%s' is not in the active skill's allowed-tools list", call.Name)
 		DebugToolResult(debug, call.ID, call.Name, errMsg)
-		_ = send.Send(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false})
+		send.TrySend(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: e.getToolPreview(call), ToolSuccess: false})
 		return []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}, nil
 	}
 
@@ -1689,13 +1689,14 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send 
 	if err != nil {
 		errMsg := fmt.Sprintf("Error: %v", err)
 		DebugToolResult(debug, call.ID, call.Name, errMsg)
-		_ = send.Send(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: info, ToolSuccess: false})
+		send.TrySend(Event{Type: EventToolExecEnd, ToolCallID: call.ID, ToolName: call.Name, ToolInfo: info, ToolSuccess: false})
 		return []Message{ToolErrorMessage(call.ID, call.Name, errMsg, call.ThoughtSig)}, nil
 	}
 
 	DebugToolResult(debug, call.ID, call.Name, output.Content)
 	DebugRawToolResult(debugRaw, call.ID, call.Name, output.Content)
-	_ = send.Send(Event{
+	// Best-effort: don't let a slow event consumer stall completed tool workers.
+	send.TrySend(Event{
 		Type:        EventToolExecEnd,
 		ToolCallID:  call.ID,
 		ToolName:    call.Name,

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1899,6 +1899,57 @@ func TestExecuteSingleToolCallDoesNotDeadlockOnBlockedToolExecEndWhenCancelled(t
 	}
 }
 
+func TestExecuteToolCallsParallelDoesNotBlockOnFullToolExecEndBuffer(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	engine := NewEngine(&fakeProvider{}, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan Event, 1)
+	events <- Event{Type: EventHeartbeat, ToolCallID: "buffer-full"}
+
+	calls := []ToolCall{
+		{ID: "call-1", Name: "count_tool", Arguments: json.RawMessage(`{}`)},
+		{ID: "call-2", Name: "count_tool", Arguments: json.RawMessage(`{}`)},
+		{ID: "call-3", Name: "count_tool", Arguments: json.RawMessage(`{}`)},
+	}
+
+	type result struct {
+		msgs []Message
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		msgs, err := engine.executeToolCalls(ctx, calls, true, eventSender{ctx: ctx, ch: events}, false, false)
+		resultCh <- result{msgs: msgs, err: err}
+	}()
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("expected nil error, got %v", res.err)
+		}
+		if len(res.msgs) != len(calls) {
+			t.Fatalf("expected %d tool result messages, got %d", len(calls), len(res.msgs))
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		select {
+		case <-resultCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("parallel tool execution remained blocked after cancellation")
+		}
+		t.Fatal("parallel tool execution blocked on a full tool-exec-end event buffer")
+	}
+
+	if tool.calls.Load() != int64(len(calls)) {
+		t.Fatalf("expected %d tool executions, got %d", len(calls), tool.calls.Load())
+	}
+}
+
 // imageTool returns structured ToolOutput with Images and Diffs.
 type imageTool struct{}
 


### PR DESCRIPTION
## What

- make `EventToolExecEnd` emission in `executeSingleToolCall` best-effort/non-blocking by switching those sends to `TrySend`
- apply the same non-blocking behavior to the panic-recovery path in `executeSingleToolCallSafe`
- add a regression test covering parallel tool execution with a full event buffer so completed tools still return results instead of stalling workers

## Why

Parallel tool workers were sending `EventToolExecEnd` with a blocking channel send before returning their tool result. When the event buffer filled because of a slow SSE/WebSocket/UI consumer, completed workers could block at the finish line and stop picking up more work, collapsing effective tool concurrency and stretching agent latency. These end events were already best-effort in practice because send errors were ignored, so making them explicitly non-blocking fixes the stall without changing tool-result delivery.
