### PR TITLE
fix: Serve mode rewrites the full session message history after every run

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -608,6 +608,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	var produced []llm.Message
 	var producedMu sync.Mutex
 	var lastAppendedIdx int // tracks how many produced messages have been incrementally persisted
+	assistantSnapshotDirty := false
 
 	// Persist-as-we-go: snapshot callback fires per streamed tool call. The
 	// pending row lives at produced[pendingAssistantIdx] and is upserted in
@@ -687,6 +688,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		} else {
 			produced[pendingAssistantIdx] = assistantMsg
 		}
+		assistantSnapshotDirty = true
 		if stateful {
 			rt.history = buildSnapshotLocked()
 		}
@@ -714,6 +716,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			sessionMsg.ID = pendingAssistantMsgID
 			err := rt.store.UpdateMessage(dbCtx, req.SessionID, sessionMsg)
 			if err == nil {
+				assistantSnapshotDirty = false
 				persistPlatformInjectionLocked()
 				return
 			}
@@ -732,6 +735,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			return
 		}
 		pendingAssistantMsgID = sessionMsg.ID
+		assistantSnapshotDirty = false
 		// Reserve produced[pendingAssistantIdx] so plain append-path writes
 		// skip it on subsequent callbacks.
 		if pendingAssistantIdx+1 > lastAppendedIdx {
@@ -782,8 +786,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// Safety net: on error exits, persist a full snapshot so the final DB
 	// state is consistent. If streamed text was shown before any callback fired,
 	// synthesize an assistant message from result.Text so the partial reply is
-	// not dropped. Skipped on success since the happy path already does its own
-	// full replace.
+	// not dropped. Successful runs stay on the incremental path unless a
+	// fallback snapshot is still needed to reconcile missed writes.
 	result := serveRunResult{}
 	var runErr error
 	defer func() {
@@ -877,19 +881,22 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	result.SessionUsage = rt.cumulativeUsage
 
 	var newHistory []llm.Message
+	var needFinalSnapshot bool
 	producedMu.Lock()
 	newHistory = buildSnapshotLocked()
-	if len(produced) == 0 && result.Text.Len() > 0 {
+	synthesizedAssistant := len(produced) == 0 && result.Text.Len() > 0
+	if synthesizedAssistant {
 		newHistory = append(newHistory, llm.AssistantText(result.Text.String()))
 	}
 	if stateful {
 		rt.history = newHistory
 	}
-	if persisted {
-		rt.persistSnapshot(ctx, req.SessionID, newHistory)
-	}
+	needFinalSnapshot = persisted && (!initialPersisted || lastAppendedIdx < len(produced) || assistantSnapshotDirty || synthesizedAssistant)
 	persistPlatformInjectionLocked()
 	producedMu.Unlock()
+	if needFinalSnapshot {
+		rt.persistSnapshot(ctx, req.SessionID, newHistory)
+	}
 
 	return result, nil
 }

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -443,7 +443,6 @@ func TestServeRuntimeCloseCancelsActiveRun(t *testing.T) {
 func TestServeRuntimeRetriesInitialSnapshotBeforeAppending(t *testing.T) {
 	store := newServeRuntimeTestStore()
 	store.replaceFailures[1] = errors.New("initial snapshot failed")
-	store.replaceFailures[3] = errors.New("final snapshot failed")
 
 	provider := &serveRuntimeTestProvider{}
 	tool := &serveRuntimeTestTool{}
@@ -480,8 +479,8 @@ func TestServeRuntimeRetriesInitialSnapshotBeforeAppending(t *testing.T) {
 		t.Fatalf("result text = %q, want %q", got, "done")
 	}
 
-	if store.replaceCalls != 3 {
-		t.Fatalf("ReplaceMessages call count = %d, want 3", store.replaceCalls)
+	if store.replaceCalls != 2 {
+		t.Fatalf("ReplaceMessages call count = %d, want 2", store.replaceCalls)
 	}
 
 	msgs, err := store.GetMessages(context.Background(), "sess-1", 0, 0)
@@ -506,6 +505,59 @@ func TestServeRuntimeRetriesInitialSnapshotBeforeAppending(t *testing.T) {
 	}
 	if msgs[4].Role != llm.RoleTool || len(msgs[4].Parts) != 1 || msgs[4].Parts[0].Type != llm.PartToolResult {
 		t.Fatalf("message[4] = %+v, want tool result message", msgs[4])
+	}
+	if msgs[5].Role != llm.RoleAssistant || msgs[5].TextContent != "done" {
+		t.Fatalf("message[5] = %+v, want final assistant message", msgs[5])
+	}
+}
+
+func TestServeRuntimeSuccessfulRunSkipsFinalSnapshotRewrite(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	provider := &serveRuntimeTestProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+		history: []llm.Message{
+			serveRuntimeTextMessage(llm.RoleUser, "previous user"),
+			serveRuntimeTextMessage(llm.RoleAssistant, "previous assistant"),
+		},
+	}
+
+	result, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID:   "sess-no-rewrite",
+		Tools:       []llm.ToolSpec{tool.Spec()},
+		ToolChoice:  llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		MaxTurns:    4,
+		Search:      false,
+		Debug:       false,
+		DebugRaw:    false,
+		Temperature: 0,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := result.Text.String(); got != "done" {
+		t.Fatalf("result text = %q, want %q", got, "done")
+	}
+
+	if store.replaceCalls != 1 {
+		t.Fatalf("ReplaceMessages call count = %d, want 1 initial snapshot only", store.replaceCalls)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "sess-no-rewrite", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 6 {
+		t.Fatalf("stored message count = %d, want 6", len(msgs))
 	}
 	if msgs[5].Role != llm.RoleAssistant || msgs[5].TextContent != "done" {
 		t.Fatalf("message[5] = %+v, want final assistant message", msgs[5])


### PR DESCRIPTION
## What

- stop serve mode from doing an unconditional full `ReplaceMessages` rewrite after every successful run
- keep the existing incremental `AddMessage`/`UpdateMessage` persistence path as the normal success path
- only fall back to a final full snapshot when incremental persistence never started, missed writes, or left the in-flight assistant row dirty
- add regression coverage proving successful runs no longer rewrite the whole transcript and that initial-snapshot retry behavior still works

## Why

Serve mode was rebuilding and rewriting the entire session transcript after each run even though the same run had already been persisted incrementally during streaming. In long, tool-heavy sessions this turned every new turn into O(total history) serialization and database work while the per-session runtime lock was still held. Skipping the redundant rewrite keeps persistence incremental on the happy path, preserving correctness while preventing later turns from getting progressively slower.
