### PR TITLE
fix: make stream adapter cancellation responsive

### DIFF
--- a/internal/ui/stream_adapter.go
+++ b/internal/ui/stream_adapter.go
@@ -65,35 +65,57 @@ func (a *StreamAdapter) Stats() *SessionStats {
 //
 //	go adapter.ProcessStream(ctx, stream)
 func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	defer close(a.events)
+
+	emit := func(event StreamEvent) bool {
+		if ctx.Err() != nil {
+			return false
+		}
+		select {
+		case a.events <- event:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 
 	var totalTokens int
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		event, err := stream.Recv()
 		if err == io.EOF {
-			a.events <- DoneEvent(totalTokens)
+			emit(DoneEvent(totalTokens))
 			return
 		}
 		if err != nil {
 			// Check if context was cancelled
 			if ctx.Err() != nil {
-				a.events <- DoneEvent(totalTokens)
 				return
 			}
-			a.events <- ErrorEvent(err)
+			emit(ErrorEvent(err))
 			return
 		}
 
 		switch event.Type {
 		case llm.EventError:
 			if event.Err != nil {
-				a.events <- ErrorEvent(event.Err)
+				emit(ErrorEvent(event.Err))
 				return
 			}
 
 		case llm.EventTextDelta:
 			if event.Text != "" {
-				a.events <- TextEvent(event.Text)
+				if !emit(TextEvent(event.Text)) {
+					return
+				}
 			}
 
 		case llm.EventToolCall:
@@ -120,7 +142,9 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 					toolArgs = event.Tool.Arguments
 				}
 				a.stats.ToolStart()
-				a.events <- ToolStartEvent(toolCallID, event.Tool.Name, toolInfo, toolArgs)
+				if !emit(ToolStartEvent(toolCallID, event.Tool.Name, toolInfo, toolArgs)) {
+					return
+				}
 			}
 
 		case llm.EventToolExecStart:
@@ -132,7 +156,9 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 				a.seenToolStarts[event.ToolCallID] = struct{}{}
 			}
 			a.stats.ToolStart()
-			a.events <- ToolStartEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolArgs)
+			if !emit(ToolStartEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolArgs)) {
+				return
+			}
 
 		case llm.EventToolExecEnd:
 			// Skip if already seen. If toolCallID is empty, don't dedupe - treat as unique.
@@ -143,35 +169,49 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 				a.seenToolEnds[event.ToolCallID] = struct{}{}
 			}
 			a.stats.ToolEnd()
-			a.events <- ToolEndEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolSuccess)
+			if !emit(ToolEndEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolSuccess)) {
+				return
+			}
 
 			// Emit image events from structured data
 			for _, imagePath := range event.ToolImages {
-				a.events <- ImageEvent(imagePath)
+				if !emit(ImageEvent(imagePath)) {
+					return
+				}
 			}
 			// Emit diff events from structured data
 			for _, d := range event.ToolDiffs {
-				a.events <- DiffEventWithOperation(d.File, d.Old, d.New, d.Line, d.Operation)
+				if !emit(DiffEventWithOperation(d.File, d.Old, d.New, d.Line, d.Operation)) {
+					return
+				}
 			}
 
 		case llm.EventRetry:
-			a.events <- RetryEvent(event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs)
+			if !emit(RetryEvent(event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs)) {
+				return
+			}
 
 		case llm.EventUsage:
 			if event.Use != nil {
 				totalTokens = event.Use.OutputTokens
 				a.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
-				a.events <- UsageEvent(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
+				if !emit(UsageEvent(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)) {
+					return
+				}
 			}
 
 		case llm.EventPhase:
 			if event.Text != "" {
-				a.events <- PhaseEvent(event.Text)
+				if !emit(PhaseEvent(event.Text)) {
+					return
+				}
 			}
 
 		case llm.EventInterjection:
 			if event.Text != "" {
-				a.events <- InterjectionEvent(event.Text, event.InterjectionID)
+				if !emit(InterjectionEvent(event.Text, event.InterjectionID)) {
+					return
+				}
 			}
 		}
 	}

--- a/internal/ui/stream_adapter_test.go
+++ b/internal/ui/stream_adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
@@ -160,6 +161,43 @@ func TestStreamAdapter_PropagatesInterjectionID(t *testing.T) {
 	}
 	if ev.InterjectionID != "adapter-interject-1" {
 		t.Fatalf("event interjection ID = %q, want %q", ev.InterjectionID, "adapter-interject-1")
+	}
+}
+
+func TestStreamAdapterCancellationUnblocksBlockedSend(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := &testStream{
+		events: []llm.Event{
+			{Type: llm.EventTextDelta, Text: "first"},
+			{Type: llm.EventTextDelta, Text: "second"},
+		},
+	}
+	adapter := NewStreamAdapter(1)
+	done := make(chan struct{})
+	go func() {
+		adapter.ProcessStream(ctx, stream)
+		close(done)
+	}()
+
+	deadline := time.After(500 * time.Millisecond)
+	for len(adapter.events) != 1 {
+		select {
+		case <-done:
+			t.Fatal("ProcessStream returned before filling the event buffer")
+		case <-deadline:
+			t.Fatal("timed out waiting for ProcessStream to fill the event buffer")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("ProcessStream did not return after context cancellation while blocked on send")
 	}
 }
 


### PR DESCRIPTION
## What

Make `ui.StreamAdapter.ProcessStream` use context-aware sends for every translated stream event. If the downstream event channel is full and the caller cancels the stream context, the adapter now exits and closes the event channel instead of staying blocked on a raw channel send.

## Why

The adapter intentionally applies backpressure to provider/tool streams, but raw `a.events <- ...` sends meant cancellation could not unblock the adapter once the UI/JSON consumer stopped draining the channel. In real sessions this can keep provider streaming and tool execution cleanup goroutines alive longer than necessary after an interrupt/disconnect.

## Evidence

Added `TestStreamAdapterCancellationUnblocksBlockedSend`, which fills a one-slot adapter buffer, cancels the context while the second event send is blocked, and asserts `ProcessStream` returns promptly.

Before the fix:

```text
--- FAIL: TestStreamAdapterCancellationUnblocksBlockedSend (0.25s)
    stream_adapter_test.go:200: ProcessStream did not return after context cancellation while blocked on send
```

After the fix:

```text
go test ./internal/ui -run TestStreamAdapterCancellationUnblocksBlockedSend -count=5
ok  github.com/samsaffron/term-llm/internal/ui  0.016s
```

Also verified:

```text
go build ./...
go test ./...
```
