### PR TITLE
perf: avoid redundant markdown normalization

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"bytes"
 	"fmt"
 	"html"
 	"regexp"
@@ -22,6 +23,8 @@ import (
 )
 
 // Renderer renders complete markdown content for a terminal target.
+// Implementations must treat source as read-only and must not retain it after
+// Render returns; streaming callers may pass slices backed by reusable buffers.
 type Renderer interface {
 	Render(source []byte) ([]byte, error)
 	Resize(width int)
@@ -77,19 +80,19 @@ var markdownParser = goldmark.New(
 
 // Render renders markdown to ANSI bytes.
 func (r *ANSI) Render(source []byte) ([]byte, error) {
-	content := string(source)
-	if r.config.NormalizeTabs {
+	renderSource := source
+	if r.config.NormalizeTabs && bytes.IndexByte(renderSource, '\t') >= 0 {
 		// Deliberately 2 spaces, not the CommonMark-spec 4.
 		// Keeps terminal output compact while remaining readable.
-		content = strings.ReplaceAll(content, "\t", "  ")
+		renderSource = bytes.ReplaceAll(renderSource, []byte("\t"), []byte("  "))
 	}
-	if strings.TrimSpace(content) == "" {
+	if len(bytes.TrimSpace(renderSource)) == 0 {
 		return []byte(""), nil
 	}
 
-	doc := markdownParser.Parser().Parse(gtext.NewReader([]byte(content)))
+	doc := markdownParser.Parser().Parse(gtext.NewReader(renderSource))
 	styles := newANSIStyles(r.config.Palette)
-	rendered, err := r.renderBlockChildren(doc, []byte(content), r.wrapWidth(), styles, "\n\n")
+	rendered, err := r.renderBlockChildren(doc, renderSource, r.wrapWidth(), styles, "\n\n")
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +992,25 @@ func bytesOrEmpty(v []byte) []byte {
 var multiNewlineRe = regexp.MustCompile(`\n{3,}`)
 
 func normalizeNewlines(s string) string {
+	if !hasThreeConsecutiveNewlines(s) {
+		return s
+	}
 	return multiNewlineRe.ReplaceAllString(s, "\n\n")
+}
+
+func hasThreeConsecutiveNewlines(s string) bool {
+	run := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\n' {
+			run = 0
+			continue
+		}
+		run++
+		if run >= 3 {
+			return true
+		}
+	}
+	return false
 }
 
 // backslashEscapeRe matches a backslash followed by an ASCII punctuation character.
@@ -999,8 +1020,16 @@ var backslashEscapeRe = regexp.MustCompile(`\\([!"#$%&'()*+,\-./:;<=>?@\[\\\]^_{
 // 1. Strips CommonMark backslash escapes (\* → *)
 // 2. Decodes HTML entities (&amp; → &, &ouml; → ö)
 func decodeInlineText(s string) string {
-	s = backslashEscapeRe.ReplaceAllString(s, "$1")
-	return html.UnescapeString(s)
+	if strings.IndexAny(s, "\\&") < 0 {
+		return s
+	}
+	if strings.IndexByte(s, '\\') >= 0 {
+		s = backslashEscapeRe.ReplaceAllString(s, "$1")
+	}
+	if strings.IndexByte(s, '&') >= 0 {
+		s = html.UnescapeString(s)
+	}
+	return s
 }
 
 type codeHighlighter struct {

--- a/internal/render/markdown/ansi_bench_test.go
+++ b/internal/render/markdown/ansi_bench_test.go
@@ -1,0 +1,28 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkANSIRenderLargeNoTabs(b *testing.B) {
+	source := strings.Repeat("## Heading\n\nParagraph with **bold** text, `code`, and a link to [example](https://example.com) that wraps across the terminal width.\n\n", 128)
+	renderer := NewANSI(Config{
+		Palette:           testPalette,
+		Width:             100,
+		WrapOffset:        2,
+		NormalizeTabs:     true,
+		NormalizeNewlines: true,
+		TrimSpace:         true,
+	})
+	input := []byte(source)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := renderer.Render(input); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -117,6 +117,23 @@ func TestRenderString_ThematicBreakUsesRenderWidth(t *testing.T) {
 	}
 }
 
+func TestRenderString_DecodesEscapesAndEntities(t *testing.T) {
+	got, err := RenderString(`Use \* literal &amp; entity`, Config{
+		Palette:           testPalette,
+		Width:             80,
+		WrapOffset:        1,
+		NormalizeTabs:     true,
+		NormalizeNewlines: true,
+		TrimSpace:         true,
+	})
+	if err != nil {
+		t.Fatalf("RenderString failed: %v", err)
+	}
+	if visible := normalizeVisibleOutput(got); visible != "Use * literal & entity" {
+		t.Fatalf("visible output = %q, want %q", visible, "Use * literal & entity")
+	}
+}
+
 func TestRenderString_BlockquotePreservesNestedStructure(t *testing.T) {
 	got, err := RenderString("> outer\n>\n> > inner1\n> >\n> > inner2\n>\n> tail", Config{
 		Palette:           testPalette,

--- a/internal/ui/streaming/streaming.go
+++ b/internal/ui/streaming/streaming.go
@@ -59,6 +59,7 @@ type StreamRenderer struct {
 
 	// All markdown received so far (for re-rendering)
 	allMarkdown bytes.Buffer
+	hasTabs     bool // True once input contains a tab, enabling tab normalization only when needed
 
 	// How many bytes of rendered output we've already written
 	renderedLen int
@@ -139,12 +140,19 @@ func NewRendererWithOptions(
 // This preserves legacy terminal rendering behaviour for code blocks.
 func (sr *StreamRenderer) normalizedMarkdown() []byte {
 	content := sr.allMarkdown.Bytes()
+	if !sr.hasTabs {
+		return content
+	}
 	return bytes.ReplaceAll(content, []byte("\t"), []byte("  "))
 }
 
 // Write accepts markdown chunks and renders complete blocks immediately.
 // It implements io.Writer.
 func (sr *StreamRenderer) Write(p []byte) (n int, err error) {
+	if !sr.hasTabs && bytes.IndexByte(p, '\t') >= 0 {
+		sr.hasTabs = true
+	}
+
 	// Add incoming bytes to line buffer
 	sr.lineBuf.Write(p)
 

--- a/internal/ui/streaming/streaming_bench_test.go
+++ b/internal/ui/streaming/streaming_bench_test.go
@@ -1,0 +1,35 @@
+package streaming
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func BenchmarkStreamRendererLargeNoTabs(b *testing.B) {
+	block := "## Heading\n\nParagraph with **bold** text, `code`, and a link to [example](https://example.com) that wraps across the terminal width.\n\n"
+	input := []byte(strings.Repeat(block, 64))
+	chunks := bytes.SplitAfter(input, []byte("\n"))
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		sr, err := NewRenderer(&buf, newTestMarkdownRenderer(testRenderWidth))
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, chunk := range chunks {
+			if len(chunk) == 0 {
+				continue
+			}
+			if _, err := sr.Write(chunk); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := sr.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What

- Avoid full input copies in the ANSI markdown renderer when tab normalization is configured but the input contains no tabs.
- Skip regex newline normalization and inline escape/entity decoding when the rendered/text fragments do not contain the relevant markers.
- Let the streaming markdown renderer pass its accumulated markdown buffer through without `bytes.ReplaceAll` when the stream has not seen tabs.
- Add focused benchmarks for ANSI markdown rendering and streaming markdown rendering in the common no-tab path.

## Why

Terminal rendering frequently re-renders markdown while responses stream. Most model output contains no tabs, no 3+ newline runs, and many inline text fragments without escapes/entities. The previous path still performed full-buffer copies or regex passes in those no-op cases.

## Evidence

On this machine (`Intel(R) Core(TM) i9-14900K`, `go test -benchmem -count=5`):

- `go test ./internal/render/markdown -run '^$' -bench BenchmarkANSIRenderLargeNoTabs -benchmem -count=5`
  - Before: ~2.42-2.49 ms/op, ~1.507-1.512 MB/op, 16075-16076 allocs/op
  - After: ~2.36-2.44 ms/op, ~1.276-1.279 MB/op, 12988-12989 allocs/op
- `go test ./internal/ui/streaming -run '^$' -bench BenchmarkStreamRendererLargeNoTabs -benchmem -count=5`
  - Before: ~82.1-84.3 ms/op, ~46.15-46.27 MB/op, 528829-528849 allocs/op
  - After: ~79.4-81.1 ms/op, ~44.01-44.17 MB/op, 428634-428659 allocs/op

## Verification

- `go test ./internal/render/markdown ./internal/ui/streaming`
- `go build ./...`
- `go test ./...`
