### PR TITLE
fix: preserve sessions on failed replace-history runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           cache: true                   # caches module download + build cache keyed on go.sum
 
       - name: Set up Node.js

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1185,8 +1185,17 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if suffix == "messages" && r.Method == http.MethodPost {
+		if err := requireJSONContentType(r); err != nil {
+			writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
+			return
+		}
+		s.handleSessionMessageAppend(w, r, sessionID)
+		return
+	}
+
 	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
+		w.Header().Set("Allow", "GET, POST")
 		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
@@ -1509,7 +1518,7 @@ func (s *serveServer) cors(next http.HandlerFunc) http.HandlerFunc {
 				w.Header().Add("Vary", "Origin")
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, X-Term-LLM-UI, X-Term-LLM-UI-Version, X-API-Key, anthropic-version")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, X-Term-LLM-UI-Version, X-API-Key, anthropic-version")
 			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number, x-response-id, x-term-llm-ui-version")
 		}
 

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -12,6 +12,16 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
+type resolvedResponsesRequest struct {
+	req                responsesCreateRequest
+	inputMessages      []llm.Message
+	replaceHistory     bool
+	sessionID          string
+	previousResponseID string
+	freshConversation  bool
+	uiStream           bool
+}
+
 func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
@@ -45,9 +55,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve session: previous_response_id for chaining, otherwise fresh.
-	// session_id header provides the ID for persistence but does NOT reuse
-	// an existing conversation without explicit chaining.
+	// External /v1/responses callers follow OpenAI-style chaining:
+	// previous_response_id continues a conversation; no previous response means a
+	// fresh conversation, even if a session_id header is reused for persistence.
+	headerSessionID := strings.TrimSpace(r.Header.Get("session_id"))
 	sessionID := ""
 	if req.PreviousResponseID != "" {
 		sid, ok := s.responseToSession.Load(req.PreviousResponseID)
@@ -64,20 +75,100 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		sessionID = sidStr
 	}
 	if sessionID == "" {
-		// No chaining — unconditionally fresh conversation.
-		sessionID = strings.TrimSpace(r.Header.Get("session_id"))
+		sessionID = headerSessionID
 		if sessionID == "" {
 			sessionID = session.NewID()
 		}
 		w.Header().Set("x-session-id", sessionID)
+		// External Responses API semantics: no previous_response_id means the
+		// supplied input is the new whole conversation for this persisted ID.
 		replaceHistory = true
 	}
+
+	s.handleResolvedResponses(w, r, ctx, resolvedResponsesRequest{
+		req:                req,
+		inputMessages:      inputMessages,
+		replaceHistory:     replaceHistory,
+		sessionID:          sessionID,
+		previousResponseID: req.PreviousResponseID,
+		freshConversation:  req.PreviousResponseID == "",
+	})
+}
+
+func (s *serveServer) handleSessionMessageAppend(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+		return
+	}
+	if err := requireJSONContentType(r); err != nil {
+		writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), s.responseTimeout())
+	defer cancel()
+
+	var req sessionAppendMessageRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	if len(req.Message) == 0 || strings.TrimSpace(string(req.Message)) == "" || strings.TrimSpace(string(req.Message)) == "null" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "message is required")
+		return
+	}
+	msg, err := parseUserMessageContent(req.Message)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	responsesReq := responsesCreateRequest{
+		Model:              req.Model,
+		Provider:           req.Provider,
+		Tools:              req.Tools,
+		IncludeServerTools: req.IncludeServerTools,
+		ToolChoice:         req.ToolChoice,
+		ParallelToolCalls:  req.ParallelToolCalls,
+		MaxOutputTokens:    req.MaxOutputTokens,
+		Temperature:        req.Temperature,
+		TopP:               req.TopP,
+		Stream:             req.Stream,
+		ReasoningEffort:    req.ReasoningEffort,
+		ModelSwap:          req.ModelSwap,
+	}
+
+	reqStart := time.Now()
+	s.verboseLog("→ POST /v1/sessions/%s/messages model=%s tools=%d stream=%v body=%d bytes",
+		sessionID, responsesReq.Model, len(responsesReq.Tools), responsesReq.Stream, r.ContentLength)
+	defer func() {
+		s.verboseLog("← POST /v1/sessions/%s/messages completed in %s", sessionID, time.Since(reqStart))
+	}()
+
+	s.handleResolvedResponses(w, r, ctx, resolvedResponsesRequest{
+		req:                responsesReq,
+		inputMessages:      []llm.Message{msg},
+		replaceHistory:     false,
+		sessionID:          sessionID,
+		previousResponseID: "",
+		freshConversation:  false,
+		uiStream:           true,
+	})
+}
+
+func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Request, ctx context.Context, rr resolvedResponsesRequest) {
+	req := rr.req
+	inputMessages := rr.inputMessages
+	replaceHistory := rr.replaceHistory
+	sessionID := rr.sessionID
+	previousResponseID := rr.previousResponseID
+	freshConversation := rr.freshConversation
 	// Chained requests are locked to the persisted provider/model/
 	// reasoning_effort unless the client explicitly asks for a mid-conversation
-	// model swap. A bare session_id header starts a fresh conversation, even when
-	// the client reuses an existing session ID, so fresh conversations may choose
+	// model swap. External bare session_id requests start a fresh conversation,
+	// even when reusing an existing session ID, so fresh conversations may choose
 	// new runtime settings and syncPersistedSessionRuntime will update the row.
-	freshConversation := req.PreviousResponseID == ""
+	// First-party UI append requests are stateful appends.
 	defaultProvider := ""
 	if s.cfgRef != nil {
 		defaultProvider = strings.TrimSpace(s.cfgRef.DefaultProvider)
@@ -120,7 +211,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 						model = existing.defaultModel
 					}
 				}
-				s.streamFailedResponseRun(ctx, w, sessionID, req.PreviousResponseID, model, "conflict_error", err.Error())
+				s.streamFailedResponseRun(ctx, w, sessionID, previousResponseID, model, "conflict_error", err.Error())
 				return true
 			}
 			writeOpenAIError(w, http.StatusConflict, "conflict_error", err.Error())
@@ -147,7 +238,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Enforce chaining from the latest response before replacing the session runtime.
-		if req.PreviousResponseID != "" {
+		if previousResponseID != "" {
 			lastRespID := previousRuntime.getLastResponseID()
 			if lastRespID == "" {
 				if latest, ok := s.sessionToResponse.Load(sessionID); ok {
@@ -156,9 +247,9 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
-			if lastRespID != "" && req.PreviousResponseID != lastRespID {
+			if lastRespID != "" && previousResponseID != lastRespID {
 				writeOpenAIError(w, http.StatusConflict, "conflict_error",
-					fmt.Sprintf("previous_response_id %q is stale; latest is %q", req.PreviousResponseID, lastRespID))
+					fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, lastRespID))
 				if !previousStateful {
 					s.unregisterResponseIDs(previousRuntime)
 					previousRuntime.Close()
@@ -167,6 +258,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 			}
 			s.populateResponsesToolResultNames(ctx, sessionID, previousRuntime, inputMessages)
 		}
+		var err error
 		modelSwapExec, err = s.beginResponseModelSwap(ctx, sessionID, swapPlan, inputMessages)
 		if handleRuntimeErr(err) {
 			return
@@ -174,7 +266,8 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		runtime = modelSwapExec.candidate
 		stateful = true
 	} else {
-		if req.PreviousResponseID != "" {
+		var err error
+		if previousResponseID != "" || rr.uiStream {
 			runtime, stateful, err = s.runtimeForProviderRequest(ctx, sessionID, reqProvider)
 		} else {
 			runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, freshProvider)
@@ -190,7 +283,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		// map to a valid session but don't match the runtime's last response would
 		// produce incorrect branching (the context wouldn't match what the client
 		// expects from that response).
-		if req.PreviousResponseID != "" {
+		if previousResponseID != "" {
 			lastRespID := runtime.getLastResponseID()
 			if lastRespID == "" {
 				if latest, ok := s.sessionToResponse.Load(sessionID); ok {
@@ -199,9 +292,9 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
-			if lastRespID != "" && req.PreviousResponseID != lastRespID {
+			if lastRespID != "" && previousResponseID != lastRespID {
 				writeOpenAIError(w, http.StatusConflict, "conflict_error",
-					fmt.Sprintf("previous_response_id %q is stale; latest is %q", req.PreviousResponseID, lastRespID))
+					fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, lastRespID))
 				if !stateful {
 					s.unregisterResponseIDs(runtime)
 					runtime.Close()
@@ -264,10 +357,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 
 	resetResponseIDsOnSuccess := freshConversation || swapPlan.enabled
 	if req.Stream {
-		if isServeUIRequest(r) && stateful {
-			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID, resetResponseIDsOnSuccess, modelSwapExec)
+		if rr.uiStream && stateful {
+			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, previousResponseID, resetResponseIDsOnSuccess, modelSwapExec)
 		} else {
-			started := s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, req.PreviousResponseID, resetResponseIDsOnSuccess, modelSwapExec)
+			started := s.streamResponses(ctx, w, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, previousResponseID, resetResponseIDsOnSuccess, modelSwapExec)
 			if !stateful && started {
 				cleanupRuntime = false
 			}
@@ -307,7 +400,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	setSessionNumberHeader(w, runtime)
 
 	created := time.Now().Unix()
-	respID, err := s.storeCompletedResponseRun(runtime, sessionID, req.PreviousResponseID, model, created, result, resetResponseIDsOnSuccess)
+	respID, err := s.storeCompletedResponseRun(runtime, sessionID, previousResponseID, model, created, result, resetResponseIDsOnSuccess)
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -30,6 +30,22 @@ type responsesCreateRequest struct {
 	ModelSwap          *responsesModelSwapRequest `json:"model_swap,omitempty"`
 }
 
+type sessionAppendMessageRequest struct {
+	Model              string                     `json:"model"`
+	Provider           string                     `json:"provider"`
+	Message            json.RawMessage            `json:"message"`
+	Tools              []json.RawMessage          `json:"tools,omitempty"`
+	IncludeServerTools bool                       `json:"include_server_tools,omitempty"`
+	ToolChoice         json.RawMessage            `json:"tool_choice,omitempty"`
+	ParallelToolCalls  *bool                      `json:"parallel_tool_calls,omitempty"`
+	MaxOutputTokens    int                        `json:"max_output_tokens,omitempty"`
+	Temperature        *float32                   `json:"temperature,omitempty"`
+	TopP               *float32                   `json:"top_p,omitempty"`
+	Stream             bool                       `json:"stream,omitempty"`
+	ReasoningEffort    string                     `json:"reasoning_effort,omitempty"`
+	ModelSwap          *responsesModelSwapRequest `json:"model_swap,omitempty"`
+}
+
 func parseResponsesInput(input json.RawMessage) ([]llm.Message, bool, error) {
 	trimmed := strings.TrimSpace(string(input))
 	if trimmed == "" || trimmed == "null" {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -555,18 +555,15 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 
 	baseHistory := make([]llm.Message, len(rt.history))
 	copy(baseHistory, rt.history)
+	replaceHistoryBackup := baseHistory
+	replaceUsageBackup := rt.cumulativeUsage
+	replacePlatformBackup := rt.lastInjectedPlatform
 	if replaceHistory {
 		baseHistory = nil
 		rt.history = nil
 		rt.engine.ResetConversation()
 		rt.cumulativeUsage = llm.Usage{}
 		rt.lastInjectedPlatform = ""
-		if persisted {
-			// Clear any previously persisted conversation state immediately so a
-			// fresh run that fails before callbacks or the final snapshot cannot
-			// silently leave stale DB history behind.
-			rt.persistSnapshot(ctx, req.SessionID, nil)
-		}
 	}
 
 	var injectedPlatform string
@@ -794,7 +791,15 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	result := serveRunResult{}
 	var runErr error
 	defer func() {
-		if runErr == nil || !persisted {
+		if runErr == nil {
+			return
+		}
+		if !persisted {
+			if replaceHistory {
+				rt.history = replaceHistoryBackup
+				rt.cumulativeUsage = replaceUsageBackup
+				rt.lastInjectedPlatform = replacePlatformBackup
+			}
 			return
 		}
 		producedMu.Lock()
@@ -804,6 +809,11 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		hasProduced := len(produced) > 0
 		producedMu.Unlock()
 		if !hasProduced {
+			if replaceHistory && !initialPersisted {
+				rt.history = replaceHistoryBackup
+				rt.cumulativeUsage = replaceUsageBackup
+				rt.lastInjectedPlatform = replacePlatformBackup
+			}
 			return
 		}
 		deferCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -626,16 +626,17 @@ func TestServeRuntimeFinalSnapshotReconcilesEarlierAssistantUpdateFailure(t *tes
 	}
 }
 
-func TestServeRuntimeReplaceHistoryClearsPersistedMessagesBeforeEarlyFailure(t *testing.T) {
+func TestServeRuntimeReplaceHistoryPreservesPersistedMessagesBeforeEarlyFailure(t *testing.T) {
 	store := newServeRuntimeTestStore()
 	sess := &session.Session{ID: "sess-replace", Status: session.StatusActive}
 	if err := store.Create(context.Background(), sess); err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	if err := store.ReplaceMessages(context.Background(), "sess-replace", []session.Message{
+	staleMessages := []session.Message{
 		*session.NewMessage("sess-replace", serveRuntimeTextMessage(llm.RoleUser, "stale user"), -1),
 		*session.NewMessage("sess-replace", serveRuntimeTextMessage(llm.RoleAssistant, "stale assistant"), -1),
-	}); err != nil {
+	}
+	if err := store.ReplaceMessages(context.Background(), "sess-replace", staleMessages); err != nil {
 		t.Fatalf("ReplaceMessages() error = %v", err)
 	}
 
@@ -648,6 +649,10 @@ func TestServeRuntimeReplaceHistoryClearsPersistedMessagesBeforeEarlyFailure(t *
 		engine:       engine,
 		store:        store,
 		defaultModel: "test-model",
+		history: []llm.Message{
+			serveRuntimeTextMessage(llm.RoleUser, "stale user"),
+			serveRuntimeTextMessage(llm.RoleAssistant, "stale assistant"),
+		},
 	}
 
 	_, err := rt.Run(context.Background(), true, true, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "fresh user")}, llm.Request{
@@ -657,15 +662,25 @@ func TestServeRuntimeReplaceHistoryClearsPersistedMessagesBeforeEarlyFailure(t *
 		t.Fatalf("Run() error = %v, want %v", err, providerErr)
 	}
 
+	if store.replaceCalls != 1 {
+		t.Fatalf("ReplaceMessages call count = %d, want 1 seed call only", store.replaceCalls)
+	}
+
 	msgs, err := store.GetMessages(context.Background(), "sess-replace", 0, 0)
 	if err != nil {
 		t.Fatalf("GetMessages() error = %v", err)
 	}
-	if len(msgs) != 0 {
-		t.Fatalf("stored message count = %d, want 0", len(msgs))
+	if len(msgs) != 2 {
+		t.Fatalf("stored message count = %d, want 2 preserved messages", len(msgs))
 	}
-	if got := rt.history; len(got) != 0 {
-		t.Fatalf("runtime history length = %d, want 0", len(got))
+	if msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "stale user" {
+		t.Fatalf("message[0] = %+v, want preserved stale user", msgs[0])
+	}
+	if msgs[1].Role != llm.RoleAssistant || msgs[1].TextContent != "stale assistant" {
+		t.Fatalf("message[1] = %+v, want preserved stale assistant", msgs[1])
+	}
+	if got := rt.history; len(got) != 2 {
+		t.Fatalf("runtime history length = %d, want 2 restored messages", len(got))
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2585,7 +2585,7 @@ func TestServeRuntimeRun_ImmediateErrorDoesNotDesyncState(t *testing.T) {
 	}
 }
 
-func TestServeRuntimeRun_ReplaceHistoryClearsInMemoryHistoryOnEarlyFailure(t *testing.T) {
+func TestServeRuntimeRun_ReplaceHistoryRestoresInMemoryHistoryOnEarlyFailure(t *testing.T) {
 	provider := llm.NewMockProvider("mock").
 		AddTextResponse("old reply").
 		AddError(errors.New("fresh-start boom")).
@@ -2617,8 +2617,8 @@ func TestServeRuntimeRun_ReplaceHistoryClearsInMemoryHistoryOnEarlyFailure(t *te
 	if err == nil || !strings.Contains(err.Error(), "fresh-start boom") {
 		t.Fatalf("replaceHistory Run error = %v, want fresh-start boom", err)
 	}
-	if len(rt.history) != 0 {
-		t.Fatalf("history len after failed replaceHistory run = %d, want 0", len(rt.history))
+	if len(rt.history) != 2 {
+		t.Fatalf("history len after failed replaceHistory run = %d, want 2 restored messages", len(rt.history))
 	}
 
 	_, err = rt.Run(context.Background(), true, false, []llm.Message{
@@ -2630,14 +2630,26 @@ func TestServeRuntimeRun_ReplaceHistoryClearsInMemoryHistoryOnEarlyFailure(t *te
 	if len(provider.Requests) != 3 {
 		t.Fatalf("request count = %d, want 3", len(provider.Requests))
 	}
-	if len(provider.Requests[2].Messages) != 1 {
-		t.Fatalf("third request message count = %d, want 1", len(provider.Requests[2].Messages))
+	if len(provider.Requests[2].Messages) != 3 {
+		t.Fatalf("third request message count = %d, want 3 restored-history messages", len(provider.Requests[2].Messages))
 	}
 	if provider.Requests[2].Messages[0].Role != llm.RoleUser {
-		t.Fatalf("third request role = %s, want user", provider.Requests[2].Messages[0].Role)
+		t.Fatalf("third request[0] role = %s, want user", provider.Requests[2].Messages[0].Role)
 	}
-	if got := provider.Requests[2].Messages[0].Parts[0].Text; got != "after failure" {
-		t.Fatalf("third request text = %q, want %q", got, "after failure")
+	if got := provider.Requests[2].Messages[0].Parts[0].Text; got != "old context" {
+		t.Fatalf("third request[0] text = %q, want %q", got, "old context")
+	}
+	if provider.Requests[2].Messages[1].Role != llm.RoleAssistant {
+		t.Fatalf("third request[1] role = %s, want assistant", provider.Requests[2].Messages[1].Role)
+	}
+	if got := provider.Requests[2].Messages[1].Parts[0].Text; got != "old reply" {
+		t.Fatalf("third request[1] text = %q, want %q", got, "old reply")
+	}
+	if provider.Requests[2].Messages[2].Role != llm.RoleUser {
+		t.Fatalf("third request[2] role = %s, want user", provider.Requests[2].Messages[2].Role)
+	}
+	if got := provider.Requests[2].Messages[2].Parts[0].Text; got != "after failure" {
+		t.Fatalf("third request[2] text = %q, want %q", got, "after failure")
 	}
 }
 
@@ -2760,14 +2772,12 @@ func TestStreamUIResponses_SetsSessionNumberHeader(t *testing.T) {
 		responseRuns: newServeResponseRunManager(),
 	}
 
-	body := `{"stream":true,"input":[{"type":"message","role":"user","content":"hello"}]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	body := `{"stream":true,"message":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess_test_number/messages", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Term-LLM-UI", "1")
-	req.Header.Set("session_id", "sess_test_number")
 	rr := httptest.NewRecorder()
 
-	srv.handleResponses(rr, req)
+	srv.handleSessionByID(rr, req)
 
 	numStr := strings.TrimSpace(rr.Header().Get("x-session-number"))
 	if numStr == "" {
@@ -2776,6 +2786,102 @@ func TestStreamUIResponses_SetsSessionNumberHeader(t *testing.T) {
 	num, parseErr := strconv.ParseInt(numStr, 10, 64)
 	if parseErr != nil || num <= 0 {
 		t.Fatalf("x-session-number = %q, want positive integer", numStr)
+	}
+}
+
+func TestResponsesUIBareSessionIDAppendsServerHistory(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	const sessionID = "sess_ui_append"
+	if err := store.Create(context.Background(), &session.Session{ID: sessionID, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ReplaceMessages(context.Background(), sessionID, []session.Message{
+		*session.NewMessage(sessionID, llm.UserText("old question"), -1),
+		*session.NewMessage(sessionID, llm.AssistantText("old answer"), -1),
+	}); err != nil {
+		t.Fatalf("seed ReplaceMessages: %v", err)
+	}
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("new answer")
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			store:        store,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager, store: store}
+	body := `{"message":"new question"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sessionID+"/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+
+	msgs, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 4 {
+		t.Fatalf("stored message count = %d, want 4 appended messages", len(msgs))
+	}
+	want := []struct {
+		role llm.Role
+		text string
+	}{
+		{llm.RoleUser, "old question"},
+		{llm.RoleAssistant, "old answer"},
+		{llm.RoleUser, "new question"},
+		{llm.RoleAssistant, "new answer"},
+	}
+	for i, w := range want {
+		if msgs[i].Role != w.role || msgs[i].TextContent != w.text {
+			t.Fatalf("message[%d] = (%s, %q), want (%s, %q)", i, msgs[i].Role, msgs[i].TextContent, w.role, w.text)
+		}
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider request count = %d, want 1", len(provider.Requests))
+	}
+	if got := len(provider.Requests[0].Messages); got != 3 {
+		t.Fatalf("provider message count = %d, want 3 server-owned history messages", got)
+	}
+}
+
+func TestSessionMessageAppendRejectsResponsesReplayShape(t *testing.T) {
+	provider := llm.NewMockProvider("mock").AddTextResponse("should not run")
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		return &serveRuntime{provider: provider, engine: engine, defaultModel: "mock-model"}, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager}
+	body := `{"input":[{"type":"message","role":"user","content":"old"},{"type":"message","role":"assistant","content":"old answer"},{"type":"message","role":"user","content":"new"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess_ui_replay/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 0 {
+		t.Fatalf("provider request count = %d, want 0", len(provider.Requests))
 	}
 }
 
@@ -4679,17 +4785,15 @@ func TestHandleResponses_UIAskUserResumeSurvivesDisconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	body := `{"stream":true,"input":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body)).WithContext(ctx)
+	body := `{"stream":true,"message":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/resume-session/messages", strings.NewReader(body)).WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("session_id", "resume-session")
-	req.Header.Set("X-Term-LLM-UI", "1")
 	rr := httptest.NewRecorder()
 
 	doneCh := make(chan struct{})
 	go func() {
 		defer close(doneCh)
-		srv.handleResponses(rr, req)
+		srv.handleSessionByID(rr, req)
 	}()
 
 	waitForServeCondition(t, time.Second, func() bool {

--- a/cmd/serve_ui_stream.go
+++ b/cmd/serve_ui_stream.go
@@ -4,15 +4,9 @@ import (
 	"context"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
-
-func isServeUIRequest(r *http.Request) bool {
-	value := strings.TrimSpace(strings.ToLower(r.Header.Get("X-Term-LLM-UI")))
-	return value == "1" || value == "true" || value == "yes"
-}
 
 func (s *serveServer) streamUIResponses(w http.ResponseWriter, r *http.Request, runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, previousResponseID string, resetResponseIDsOnSuccess bool, modelSwap *responseModelSwapExecution) {
 	// Persist session in the store so the client gets the session number in

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -3144,34 +3144,6 @@ const markToolGroupsDone = (session) => {
   });
 };
 
-// Rebuild a full conversation input array from locally-stored session messages.
-// Used to recover when previous_response_id has expired server-side.
-const rebuildInputFromSession = async (session, currentInput, signal) => {
-  const input = [];
-  for (const msg of session.messages) {
-    if (msg.role === 'user' && !msg.askUser) {
-      if (msg.attachments && msg.attachments.length > 0) {
-        const parts = await buildAttachmentInputParts(msg.attachments, signal, { skipUnavailable: true });
-        if (msg.content) parts.push({ type: 'input_text', text: msg.content });
-        input.push({ type: 'message', role: 'user', content: parts });
-      } else {
-        input.push({ type: 'message', role: 'user', content: msg.content || '' });
-      }
-    } else if (msg.role === 'assistant') {
-      input.push({ type: 'message', role: 'assistant', content: msg.content || '' });
-    }
-    // Skip tool/tool-group/error messages — they're internal
-  }
-  // Replace the last user message input with the current one (which may have
-  // attachments encoded differently), or append if not already present.
-  if (input.length > 0 && input[input.length - 1].role === 'user') {
-    input[input.length - 1].content = currentInput;
-  } else {
-    input.push({ type: 'message', role: 'user', content: currentInput });
-  }
-  return input;
-};
-
 const sendMessage = async (options = {}) => {
   const promptSource = typeof options.prompt === 'string' ? options.prompt : elements.promptInput.value;
   const prompt = String(promptSource || '').trim();
@@ -3338,14 +3310,13 @@ const sendMessage = async (options = {}) => {
 
     const body = {
       stream: true,
-      input: [{ type: 'message', role: 'user', content: inputContent }]
+      message: inputContent
     };
 
-    if (session.lastResponseId) {
-      body.previous_response_id = session.lastResponseId;
-    } else if (session.messages.length > 1) {
-      body.input = await rebuildInputFromSession(session, inputContent, controller.signal);
-    }
+    // First-party UI sessions use the explicit append endpoint: the browser sends
+    // one new user message to the server-owned session. Do not send
+    // previous_response_id and do not replay browser-local history; that turns
+    // the UI into an unreliable shadow database.
 
     const normalizeEffortForCompare = (value) => {
       const normalized = String(value || '').trim();
@@ -3357,7 +3328,7 @@ const sendMessage = async (options = {}) => {
     const targetProvider = state.selectedProvider || currentProvider;
     const targetModel = state.selectedModel || currentModel;
     const targetEffort = state.selectedEffort || '';
-    const hasPriorContext = Boolean(session.lastResponseId || session.messages.length > 1);
+    const hasPriorContext = Boolean(session.messages.length > 1);
     const targetDiffers = hasPriorContext && Boolean(
       (targetProvider || '') !== (currentProvider || '')
       || (targetModel || '') !== (currentModel || '')
@@ -3386,37 +3357,12 @@ const sendMessage = async (options = {}) => {
       }
     }
 
-    let response = await fetch(`${UI_PREFIX}/v1/responses`, {
+    let response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/messages`, {
       method: 'POST',
-      headers: {
-        ...requestHeaders(session.id),
-        'X-Term-LLM-UI': '1'
-      },
+      headers: requestHeaders(session.id),
       body: JSON.stringify(body),
       signal: controller.signal
     });
-
-    // Recovery: if previous_response_id expired, rebuild conversation from
-    // local messages and retry without chaining.
-    if (!response.ok && body.previous_response_id) {
-      const errData = await response.json().catch(() => null);
-      const errMsg = errData?.error?.message || '';
-      if (errMsg.includes('not found') && errMsg.includes('previous_response_id')) {
-        delete body.previous_response_id;
-        session.lastResponseId = null;
-        body.input = await rebuildInputFromSession(session, inputContent, controller.signal);
-
-        response = await fetch(`${UI_PREFIX}/v1/responses`, {
-          method: 'POST',
-          headers: {
-            ...requestHeaders(session.id),
-            'X-Term-LLM-UI': '1'
-          },
-          body: JSON.stringify(body),
-          signal: controller.signal
-        });
-      }
-    }
 
     const headerResponseId = String(response.headers.get('x-response-id') || '').trim();
     const headerSessionNumber = Number(response.headers.get('x-session-number') || 0);

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -460,7 +460,7 @@ function createHarness(options = {}) {
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    if (url === '/ui/v1/responses') {
+    if (url.startsWith('/ui/v1/sessions/') && url.endsWith('/messages')) {
       if (postStatus !== 200) {
         return new Response(JSON.stringify(postErrorPayload), {
           status: postStatus,
@@ -1100,10 +1100,10 @@ async function testDrainInterruptQueueAfterResumeCompletes() {
     return;
   }
 
-  // sendMessage should have been called — look for a POST to /ui/v1/responses.
-  const postCalls = fetchCalls.filter(c => c.url === '/ui/v1/responses' && c.method === 'POST');
+  // sendMessage should have been called — look for a POST to the explicit session append endpoint.
+  const postCalls = fetchCalls.filter(c => c.url === '/ui/v1/sessions/session_resume/messages' && c.method === 'POST');
   if (postCalls.length < 1) {
-    fail(name, 'expected sendMessage to POST /ui/v1/responses for the queued interrupt', JSON.stringify(fetchCalls));
+    fail(name, 'expected sendMessage to POST /ui/v1/sessions/:id/messages for the queued interrupt', JSON.stringify(fetchCalls));
     await cleanup();
     return;
   }
@@ -1353,9 +1353,9 @@ async function testSendMessageIncludesModelSwapForChangedTarget() {
   await app.sendMessage();
   await cleanup();
 
-  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
     return;
   }
   const body = JSON.parse(postCall.body);
@@ -1367,8 +1367,8 @@ async function testSendMessageIncludesModelSwapForChangedTarget() {
     fail(name, 'request did not use selected target runtime', postCall.body);
     return;
   }
-  if (body.previous_response_id !== 'resp_previous') {
-    fail(name, `previous_response_id = ${JSON.stringify(body.previous_response_id)}, want resp_previous`, postCall.body);
+  if (Object.prototype.hasOwnProperty.call(body, 'previous_response_id')) {
+    fail(name, `previous_response_id should not be sent by first-party UI`, postCall.body);
     return;
   }
   pass(name);
@@ -1403,9 +1403,9 @@ async function testSendMessageOmitsModelSwapWhenTargetUnchanged() {
   await app.sendMessage();
   await cleanup();
 
-  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
     return;
   }
   const body = JSON.parse(postCall.body);
@@ -1501,9 +1501,9 @@ async function testConnectTokenPreservesSelectedModelAndProviderFromState() {
   elements.promptInput.value = 'hello';
   await app.sendMessage();
 
-  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
     await cleanup();
     return;
   }
@@ -1512,7 +1512,7 @@ async function testConnectTokenPreservesSelectedModelAndProviderFromState() {
   try {
     body = JSON.parse(postCall.body);
   } catch (err) {
-    fail(name, 'response POST body was not valid JSON', String(err));
+    fail(name, 'session message POST body was not valid JSON', String(err));
     await cleanup();
     return;
   }
@@ -2171,9 +2171,9 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     return;
   }
 
-  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
     await cleanup();
     return;
   }
@@ -2182,12 +2182,12 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
   try {
     body = JSON.parse(postCall.body);
   } catch (err) {
-    fail(name, 'response POST body was not valid JSON', String(err));
+    fail(name, 'session message POST body was not valid JSON', String(err));
     await cleanup();
     return;
   }
 
-  const parts = body.input?.[0]?.content;
+  const parts = body.message;
   const imagePart = Array.isArray(parts) ? parts.find((part) => part.type === 'input_image') : null;
   if (!imagePart || imagePart.image_url !== file.mockDataURL) {
     fail(name, 'request body should include lazily materialized image data URL', JSON.stringify(body));
@@ -2270,7 +2270,7 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
     await cleanup();
     return;
   }
-  if (fetchCalls.some((call) => call.url === '/ui/v1/responses')) {
+  if (fetchCalls.some((call) => call.url.endsWith('/messages'))) {
     fail(name, 'request should not be sent when attachment materialization fails', JSON.stringify(fetchCalls));
     await cleanup();
     return;
@@ -2312,169 +2312,6 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
   }
   if (!alerts.some((message) => message.includes('cannot read bad.png'))) {
     fail(name, 'expected read failure to be shown to the user', JSON.stringify(alerts));
-    await cleanup();
-    return;
-  }
-
-  await cleanup();
-  pass(name);
-}
-
-async function testRebuildInputFromSessionReMaterializesStoredAttachments() {
-  const name = 'rebuildInputFromSession rematerializes stored attachments without retaining data URLs on messages';
-  let readCount = 0;
-
-  class MockFileReader {
-    constructor() {
-      this.result = null;
-      this.error = null;
-      this.onload = null;
-      this.onerror = null;
-      this.onabort = null;
-    }
-
-    readAsDataURL(file) {
-      readCount += 1;
-      this.result = file.mockDataURL;
-      setTimeout(() => {
-        if (this.onload) this.onload();
-      }, 0);
-    }
-
-    abort() {
-      if (this.onabort) this.onabort();
-    }
-  }
-
-  const harness = createHarness({
-    FileReader: MockFileReader,
-    urlAPI: {
-      createObjectURL(file) {
-        return `blob:${file.name}`;
-      },
-      revokeObjectURL() {}
-    }
-  });
-  const { app, elements, state, fetchCalls, cleanup } = harness;
-
-  const file = {
-    name: 'cat.png',
-    type: 'image/png',
-    size: 4,
-    mockDataURL: 'data:image/png;base64,Y2F0'
-  };
-
-  app.handleFiles([file]);
-  elements.promptInput.value = 'first turn';
-  await app.sendMessage();
-
-  const session = state.sessions[0];
-  if (!session) {
-    fail(name, 'expected first send to create a session');
-    await cleanup();
-    return;
-  }
-  session.lastResponseId = null;
-
-  elements.promptInput.value = 'second turn';
-  await app.sendMessage();
-
-  if (readCount !== 2) {
-    fail(name, `expected attachment to be reread for rebuild = 2 total reads, got ${readCount}`);
-    await cleanup();
-    return;
-  }
-
-  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
-  if (postCalls.length < 2 || !postCalls[1].body) {
-    fail(name, 'expected a second POST body for the rebuilt conversation', JSON.stringify(fetchCalls));
-    await cleanup();
-    return;
-  }
-
-  let body;
-  try {
-    body = JSON.parse(postCalls[1].body);
-  } catch (err) {
-    fail(name, 'rebuilt response POST body was not valid JSON', String(err));
-    await cleanup();
-    return;
-  }
-
-  const firstUserParts = body.input?.[0]?.content;
-  const imagePart = Array.isArray(firstUserParts) ? firstUserParts.find((part) => part.type === 'input_image') : null;
-  if (!imagePart || imagePart.image_url !== file.mockDataURL) {
-    fail(name, 'rebuilt conversation should include the prior image attachment', JSON.stringify(body));
-    await cleanup();
-    return;
-  }
-
-  const storedAttachment = session.messages[0]?.attachments?.[0];
-  if (!storedAttachment || Object.prototype.hasOwnProperty.call(storedAttachment, 'dataURL')) {
-    fail(name, 'stored session attachment should remain lightweight after rebuild', JSON.stringify(storedAttachment));
-    await cleanup();
-    return;
-  }
-
-  await cleanup();
-  pass(name);
-}
-
-async function testRebuildInputFromSessionSkipsUnavailableStoredAttachments() {
-  const name = 'rebuildInputFromSession skips unavailable stored attachments';
-  const harness = createHarness();
-  const { app, elements, state, fetchCalls, cleanup } = harness;
-
-  elements.promptInput.value = 'first turn';
-  await app.sendMessage();
-
-  const session = state.sessions[0];
-  if (!session || !session.messages[0]) {
-    fail(name, 'expected first send to create a session message');
-    await cleanup();
-    return;
-  }
-  session.messages[0].attachments = [{
-    id: 'old-att',
-    name: 'old.png',
-    type: 'image/png',
-    previewURL: 'blob:old.png'
-  }];
-  session.lastResponseId = null;
-
-  elements.promptInput.value = 'second turn';
-  await app.sendMessage();
-
-  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
-  if (postCalls.length < 2 || !postCalls[1].body) {
-    fail(name, 'expected a second POST body for the rebuilt conversation', JSON.stringify(fetchCalls));
-    await cleanup();
-    return;
-  }
-
-  let body;
-  try {
-    body = JSON.parse(postCalls[1].body);
-  } catch (err) {
-    fail(name, 'rebuilt response POST body was not valid JSON', String(err));
-    await cleanup();
-    return;
-  }
-
-  const firstUserParts = body.input?.[0]?.content;
-  if (!Array.isArray(firstUserParts)) {
-    fail(name, 'expected rebuilt first user content to be parts array', JSON.stringify(body));
-    await cleanup();
-    return;
-  }
-  if (firstUserParts.some((part) => part.type === 'input_image' || part.type === 'input_file')) {
-    fail(name, 'unavailable historical attachment should be skipped during rebuild', JSON.stringify(body));
-    await cleanup();
-    return;
-  }
-  const textPart = firstUserParts.find((part) => part.type === 'input_text');
-  if (!textPart || textPart.text !== 'first turn') {
-    fail(name, 'rebuilt conversation should preserve historical message text', JSON.stringify(body));
     await cleanup();
     return;
   }
@@ -2564,13 +2401,13 @@ async function testStaleInterrupt404RefreshesAndSendsMessage() {
     fail(name, 'expected initial send to attempt interrupt once', JSON.stringify(fetchCalls));
     return;
   }
-  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const postCalls = fetchCalls.filter((call) => call.url.endsWith('/messages') && call.method === 'POST');
   if (postCalls.length !== 1) {
-    fail(name, 'expected recovery to POST /ui/v1/responses once', JSON.stringify(fetchCalls));
+    fail(name, 'expected recovery to POST /ui/v1/sessions/:id/messages once', JSON.stringify(fetchCalls));
     return;
   }
   const body = JSON.parse(postCalls[0].body || '{}');
-  const content = body.input?.[0]?.content;
+  const content = body.message;
   if (content !== 'send after restart') {
     fail(name, 'recovered POST did not preserve prompt', postCalls[0].body);
     return;
@@ -2696,8 +2533,6 @@ function testRestoreLatestDraftMessageDoesNotCrossSessionBoundary() {
   await testSendMessageConsumesPostStreamWhenAvailable();
   await testSendMessageLazilyMaterializesAttachmentDataURLs();
   await testSendMessageKeepsComposerWhenAttachmentMaterializationFails();
-  await testRebuildInputFromSessionReMaterializesStoredAttachments();
-  await testRebuildInputFromSessionSkipsUnavailableStoredAttachments();
   await testStaleInterrupt404RefreshesAndSendsMessage();
   await testFailedSendKeepsSessionDraftAndRestagesComposer();
   await testSuccessfulSendRemovesOnlyMatchingDraft();


### PR DESCRIPTION
## What

Fix the session-history pathology in two layers.

### 1. Make replace-history non-destructive on early failure

- remove the eager `persistSnapshot(..., nil)` call from the replace-history path
- preserve persisted messages if the provider/run fails before producing any replacement content
- restore in-memory runtime history/usage/platform state on early replace-history failure
- update regression coverage for both persisted and in-memory cases

### 2. Stop the first-party web UI from using full-history replay

The web UI now sends only the new user input with `session_id`. It no longer sends `previous_response_id` and no longer rebuilds/replays browser-local conversation history.

On the server, `X-Term-LLM-UI: 1` + bare `session_id` now means: append this single user message to server-owned session history.

External `/v1/responses` semantics are unchanged: non-UI callers without `previous_response_id` still start a fresh/replacement conversation.

The server also rejects first-party UI requests that try to replay multiple messages, so stale or future UI bugs cannot silently turn the browser back into a shadow session database.

## Why

Session 2106 exposed a destructive ordering bug:

1. A request was treated as `replaceHistory=true`.
2. The runtime immediately called `ReplaceMessages` with an empty snapshot.
3. The provider/run failed before any replacement messages were persisted.
4. The session row survived, but its message rows were deleted.

The deeper design smell was that the web UI was using external OpenAI-style chaining/replay semantics when it really wants first-party stateful semantics:

```text
session_id + one new user message
```

The server owns the session history. The browser should not replay it.

## Verification

```text
go test ./...
go build ./...
node internal/serveui/static/app_stream_test.js
```

All pass.
