### PR TITLE
feat: improve image transcription handling

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -276,20 +276,23 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					if decodedLen > maxAttachmentBytes {
 						return llm.Message{}, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
 					}
-					if decodedLen <= maxLLMImageBytes {
-						if err := validateBase64Data(b64); err != nil {
-							return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
-						}
-						llmParts = append(llmParts, llm.Part{
-							Type:      llm.PartImage,
-							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
-						})
-						continue
-					}
 
 					raw, err := decodeUploadedFile(filename, b64)
 					if err != nil {
 						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
+					}
+					path, err := saveUploadedBytes(filename, raw)
+					if err != nil {
+						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
+					}
+
+					if decodedLen <= maxLLMImageBytes {
+						llmParts = append(llmParts, llm.Part{
+							Type:      llm.PartImage,
+							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64, Detail: "high"},
+							ImagePath: path,
+						})
+						continue
 					}
 
 					// Resize if over 1 MB before sending to the model.
@@ -300,7 +303,8 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					}
 					llmParts = append(llmParts, llm.Part{
 						Type:      llm.PartImage,
-						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64},
+						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64, Detail: "high"},
+						ImagePath: path,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -110,7 +110,7 @@ func TestDecodeUploadedFile_RejectsOversizedPayloadBeforeDecode(t *testing.T) {
 	}
 }
 
-func TestParseUserMessageContent_InlineImagesDoNotHitUploadsDir(t *testing.T) {
+func TestParseUserMessageContent_InlineImagesAreSavedForToolReuse(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)
 
@@ -123,13 +123,20 @@ func TestParseUserMessageContent_InlineImagesDoNotHitUploadsDir(t *testing.T) {
 	if len(msg.Parts) != 1 {
 		t.Fatalf("len(msg.Parts) = %d, want 1", len(msg.Parts))
 	}
-	if msg.Parts[0].ImagePath != "" {
-		t.Fatalf("msg.Parts[0].ImagePath = %q, want empty", msg.Parts[0].ImagePath)
+	if msg.Parts[0].ImagePath == "" {
+		t.Fatal("msg.Parts[0].ImagePath is empty, want saved upload path")
+	}
+	if msg.Parts[0].ImageData == nil || msg.Parts[0].ImageData.Detail != "high" {
+		t.Fatalf("image detail = %#v, want high", msg.Parts[0].ImageData)
 	}
 
 	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
-	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
-		t.Fatalf("uploads dir stat err = %v, want not exist", err)
+	entries, err := os.ReadDir(uploadsDir)
+	if err != nil {
+		t.Fatalf("read uploads dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("uploads dir has %d files, want 1", len(entries))
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1088,12 +1088,19 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
 		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
 	}
-	if msg.Parts[0].ImagePath != "" {
-		t.Fatalf("parts[0].ImagePath = %q, want empty for inline upload", msg.Parts[0].ImagePath)
+	if msg.Parts[0].ImagePath == "" {
+		t.Fatal("parts[0].ImagePath is empty, want saved path for inline upload")
+	}
+	if msg.Parts[0].ImageData.Detail != "high" {
+		t.Fatalf("parts[0].ImageData.Detail = %q, want high", msg.Parts[0].ImageData.Detail)
 	}
 	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
-	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
-		t.Fatalf("uploads dir stat err = %v, want not exist for inline image upload", err)
+	entries, err := os.ReadDir(uploadsDir)
+	if err != nil {
+		t.Fatalf("read uploads dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("uploads dir has %d files, want 1", len(entries))
 	}
 	if msg.Parts[1].Type != llm.PartText {
 		t.Fatalf("parts[1].type = %s, want text", msg.Parts[1].Type)

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -116,6 +116,7 @@ type ResponsesContentPart struct {
 	Type     string `json:"type"`
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // Plain URL string for Responses API (not object)
+	Detail   string `json:"detail,omitempty"`
 }
 
 // ResponsesTool represents a tool definition in Open Responses format
@@ -357,7 +358,8 @@ func buildResponsesMessageItems(role string, parts []Part) []ResponsesInputItem 
 			if part.ImageData != nil {
 				flushText()
 				dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL}}
+				detail := normalizeVisionDetail(part.ImageData.Detail)
+				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: detail}}
 				if part.ImagePath != "" {
 					imageParts = append(imageParts, ResponsesContentPart{Type: "input_text", Text: "[image saved at: " + part.ImagePath + "]"})
 				}

--- a/internal/llm/tool_result_content.go
+++ b/internal/llm/tool_result_content.go
@@ -92,7 +92,8 @@ func toolResultResponsesImageParts(result *ToolResult) (parts []ResponsesContent
 		}
 		hasImage = true
 		dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data)
-		parts = append(parts, ResponsesContentPart{Type: "input_image", ImageURL: dataURL})
+		detail := normalizeVisionDetail(contentPart.ImageData.Detail)
+		parts = append(parts, ResponsesContentPart{Type: "input_image", ImageURL: dataURL, Detail: detail})
 	}
 	return parts, hasImage
 }

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -190,6 +190,7 @@ const (
 type ToolImageData struct {
 	MediaType string `json:"media_type,omitempty"`
 	Base64    string `json:"base64,omitempty"`
+	Detail    string `json:"detail,omitempty"` // Optional vision detail hint: low, high, or auto.
 }
 
 // ToolContentPart represents one structured piece of tool result content.

--- a/internal/llm/vision_detail.go
+++ b/internal/llm/vision_detail.go
@@ -1,0 +1,10 @@
+package llm
+
+func normalizeVisionDetail(detail string) string {
+	switch detail {
+	case "low", "high", "auto":
+		return detail
+	default:
+		return ""
+	}
+}

--- a/internal/tools/view_image.go
+++ b/internal/tools/view_image.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
+	imagedraw "image/draw"
 	_ "image/gif" // GIF decode support
 	"image/jpeg"
 	"image/png"
@@ -34,8 +35,18 @@ func NewViewImageTool(approval *ApprovalManager) *ViewImageTool {
 
 // ViewImageArgs are the arguments for view_image.
 type ViewImageArgs struct {
-	FilePath string `json:"file_path"`
-	Detail   string `json:"detail,omitempty"` // "low", "high", or "auto"
+	FilePath string     `json:"file_path"`
+	Detail   string     `json:"detail,omitempty"` // "low", "high", or "auto"
+	Region   string     `json:"region,omitempty"` // optional: full, left_half, right_half, top_half, bottom_half
+	Crop     *ImageCrop `json:"crop,omitempty"`   // optional pixel crop before sending
+	Scale    int        `json:"scale,omitempty"`  // optional 1-4x upscale after crop, useful for tiny text
+}
+
+type ImageCrop struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
 }
 
 const (
@@ -73,9 +84,34 @@ func (t *ViewImageTool) Spec() llm.ToolSpec {
 				},
 				"detail": map[string]interface{}{
 					"type":        "string",
-					"description": "Detail level: 'low', 'high', or 'auto' (default: 'auto')",
+					"description": "Vision detail level: 'low', 'high', or 'auto' (default: 'auto'). Use 'high' for handwriting, small text, charts, and OCR/transcription.",
 					"enum":        []string{"low", "high", "auto"},
 					"default":     "auto",
+				},
+				"region": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional common crop before viewing. Useful for two-page notebook photos: view left_half and right_half separately.",
+					"enum":        []string{"full", "left_half", "right_half", "top_half", "bottom_half"},
+					"default":     "full",
+				},
+				"crop": map[string]interface{}{
+					"type":        "object",
+					"description": "Optional pixel crop before viewing: x, y, width, height.",
+					"properties": map[string]interface{}{
+						"x":      map[string]interface{}{"type": "integer", "minimum": 0},
+						"y":      map[string]interface{}{"type": "integer", "minimum": 0},
+						"width":  map[string]interface{}{"type": "integer", "minimum": 1},
+						"height": map[string]interface{}{"type": "integer", "minimum": 1},
+					},
+					"required":             []string{"x", "y", "width", "height"},
+					"additionalProperties": false,
+				},
+				"scale": map[string]interface{}{
+					"type":        "integer",
+					"description": "Optional 1-4x upscale after crop before sending to the model. Use 2 or 3 for tiny handwriting/text.",
+					"minimum":     1,
+					"maximum":     4,
+					"default":     1,
 				},
 			},
 			"required":             []string{"file_path"},
@@ -155,8 +191,8 @@ func (t *ViewImageTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrUnsupportedFormat, "unsupported format: %s (supported: PNG, JPEG, GIF, WebP)", mimeType))), nil
 	}
 
-	// Process image: resize if needed, ensure under size limit
-	processedData, processedMime, resized, err := processImage(data, mimeType)
+	// Process image: crop/upscale if requested, then resize if needed and ensure under size limit
+	processedData, processedMime, resized, processedDesc, err := processImage(data, mimeType, a.Region, a.Crop, a.Scale)
 	if err != nil {
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to process image: %v", err))), nil
 	}
@@ -175,10 +211,12 @@ func (t *ViewImageTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 	textResult := fmt.Sprintf(`Image loaded: %s
 Format: %s
 %s
+Dimensions: %s
 Detail: %s`,
 		a.FilePath,
 		processedMime,
 		sizeInfo,
+		processedDesc,
 		getDetail(a.Detail),
 	)
 
@@ -191,6 +229,7 @@ Detail: %s`,
 				ImageData: &llm.ToolImageData{
 					MediaType: processedMime,
 					Base64:    encoded,
+					Detail:    getDetail(a.Detail),
 				},
 			},
 		},
@@ -198,12 +237,12 @@ Detail: %s`,
 }
 
 // processImage checks if an image needs resizing and processes it accordingly.
-// Returns the (possibly resized) image data, mime type, whether it was resized, and any error.
-func processImage(data []byte, originalMime string) ([]byte, string, bool, error) {
+// Returns the (possibly resized) image data, mime type, whether it was resized, a dimension summary, and any error.
+func processImage(data []byte, originalMime, region string, crop *ImageCrop, scale int) ([]byte, string, bool, string, error) {
 	// Decode image to check dimensions
 	img, format, err := image.Decode(bytes.NewReader(data))
 	if err != nil {
-		return nil, "", false, fmt.Errorf("failed to decode image: %w", err)
+		return nil, "", false, "", fmt.Errorf("failed to decode image: %w", err)
 	}
 
 	detectedMime := mimeTypeFromDecodedFormat(format)
@@ -211,18 +250,44 @@ func processImage(data []byte, originalMime string) ([]byte, string, bool, error
 		detectedMime = originalMime
 	}
 
-	bounds := img.Bounds()
-	width := bounds.Dx()
-	height := bounds.Dy()
+	origBounds := img.Bounds()
+	origWidth := origBounds.Dx()
+	origHeight := origBounds.Dy()
+	processed := img
+	processedBounds := origBounds
+	changed := false
+
+	if rect, ok, err := requestedCropRect(origBounds, region, crop); err != nil {
+		return nil, "", false, "", err
+	} else if ok && rect.Dx() > 0 && rect.Dy() > 0 && rect != origBounds {
+		processed = cropImage(processed, rect)
+		processedBounds = processed.Bounds()
+		changed = true
+	}
+
+	if scale < 1 {
+		scale = 1
+	}
+	if scale > 4 {
+		scale = 4
+	}
+	if scale > 1 {
+		processed = resizeImage(processed, processedBounds.Dx()*scale, processedBounds.Dy()*scale)
+		processedBounds = processed.Bounds()
+		changed = true
+	}
+
+	width := processedBounds.Dx()
+	height := processedBounds.Dy()
 
 	// Check if resizing is needed
 	needsResize := width > maxDimension || height > maxDimension || len(data) > maxImageSize
 
-	if !needsResize {
-		return data, detectedMime, false, nil
+	if !needsResize && !changed {
+		desc := fmt.Sprintf("%dx%d", origWidth, origHeight)
+		return data, detectedMime, false, desc, nil
 	}
 
-	// Calculate new dimensions maintaining aspect ratio
 	newWidth, newHeight := width, height
 	if width > maxDimension || height > maxDimension {
 		if width > height {
@@ -232,61 +297,91 @@ func processImage(data []byte, originalMime string) ([]byte, string, bool, error
 			newHeight = maxDimension
 			newWidth = int(float64(width) * float64(maxDimension) / float64(height))
 		}
+		processed = resizeImage(processed, newWidth, newHeight)
+		processedBounds = processed.Bounds()
+		changed = true
 	}
 
-	// Resize the image
-	resized := resizeImage(img, newWidth, newHeight)
-
-	// Encode to appropriate format
-	// Use JPEG for most cases (better compression), PNG if original was PNG/GIF (transparency)
-	var buf bytes.Buffer
-	var outputMime string
-
-	switch format {
-	case "png", "gif":
-		// Keep PNG for formats that might have transparency
-		if err := png.Encode(&buf, resized); err != nil {
-			return nil, "", false, fmt.Errorf("failed to encode PNG: %w", err)
-		}
-		outputMime = "image/png"
-	default:
-		// Use JPEG for better compression
-		if err := jpeg.Encode(&buf, resized, &jpeg.Options{Quality: jpegQuality}); err != nil {
-			return nil, "", false, fmt.Errorf("failed to encode JPEG: %w", err)
-		}
-		outputMime = "image/jpeg"
+	result, outputMime, err := encodeProcessedImage(processed, format, jpegQuality)
+	if err != nil {
+		return nil, "", false, "", err
 	}
-
-	result := buf.Bytes()
 
 	// If still too large after resizing, try more aggressive compression
 	if len(result) > maxImageSize {
-		// Try JPEG with lower quality
-		buf.Reset()
-		if err := jpeg.Encode(&buf, resized, &jpeg.Options{Quality: 70}); err != nil {
-			return nil, "", false, fmt.Errorf("failed to encode JPEG: %w", err)
+		result, outputMime, err = encodeProcessedImage(processed, "jpeg", 70)
+		if err != nil {
+			return nil, "", false, "", err
 		}
-		result = buf.Bytes()
-		outputMime = "image/jpeg"
 
 		// If still too large, reduce dimensions further
 		if len(result) > maxImageSize {
-			smallerWidth := newWidth * 3 / 4
-			smallerHeight := newHeight * 3 / 4
-			resized = resizeImage(img, smallerWidth, smallerHeight)
-			buf.Reset()
-			if err := jpeg.Encode(&buf, resized, &jpeg.Options{Quality: 70}); err != nil {
-				return nil, "", false, fmt.Errorf("failed to encode JPEG: %w", err)
+			smallerWidth := processedBounds.Dx() * 3 / 4
+			smallerHeight := processedBounds.Dy() * 3 / 4
+			processed = resizeImage(processed, smallerWidth, smallerHeight)
+			processedBounds = processed.Bounds()
+			result, outputMime, err = encodeProcessedImage(processed, "jpeg", 70)
+			if err != nil {
+				return nil, "", false, "", err
 			}
-			result = buf.Bytes()
 		}
 	}
 
 	if len(result) > maxImageSize {
-		return nil, "", false, fmt.Errorf("image still exceeds 5MB after resizing (%d bytes)", len(result))
+		return nil, "", false, "", fmt.Errorf("image still exceeds 5MB after resizing (%d bytes)", len(result))
 	}
 
-	return result, outputMime, true, nil
+	desc := fmt.Sprintf("%dx%d → %dx%d", origWidth, origHeight, processedBounds.Dx(), processedBounds.Dy())
+	return result, outputMime, true, desc, nil
+}
+
+func requestedCropRect(bounds image.Rectangle, region string, crop *ImageCrop) (image.Rectangle, bool, error) {
+	if crop != nil {
+		rect := image.Rect(bounds.Min.X+crop.X, bounds.Min.Y+crop.Y, bounds.Min.X+crop.X+crop.Width, bounds.Min.Y+crop.Y+crop.Height)
+		rect = rect.Intersect(bounds)
+		if rect.Empty() {
+			return image.Rectangle{}, false, fmt.Errorf("crop is outside image bounds")
+		}
+		return rect, true, nil
+	}
+
+	w, h := bounds.Dx(), bounds.Dy()
+	switch region {
+	case "", "full":
+		return bounds, false, nil
+	case "left_half":
+		return image.Rect(bounds.Min.X, bounds.Min.Y, bounds.Min.X+w/2, bounds.Min.Y+h), true, nil
+	case "right_half":
+		return image.Rect(bounds.Min.X+w/2, bounds.Min.Y, bounds.Max.X, bounds.Min.Y+h), true, nil
+	case "top_half":
+		return image.Rect(bounds.Min.X, bounds.Min.Y, bounds.Min.X+w, bounds.Min.Y+h/2), true, nil
+	case "bottom_half":
+		return image.Rect(bounds.Min.X, bounds.Min.Y+h/2, bounds.Min.X+w, bounds.Max.Y), true, nil
+	default:
+		return image.Rectangle{}, false, fmt.Errorf("unsupported region %q", region)
+	}
+}
+
+func cropImage(src image.Image, rect image.Rectangle) image.Image {
+	dst := image.NewRGBA(image.Rect(0, 0, rect.Dx(), rect.Dy()))
+	imagedraw.Draw(dst, dst.Bounds(), src, rect.Min, imagedraw.Src)
+	return dst
+}
+
+func encodeProcessedImage(img image.Image, format string, quality int) ([]byte, string, error) {
+	var buf bytes.Buffer
+	switch format {
+	case "png", "gif":
+		if err := png.Encode(&buf, img); err != nil {
+			return nil, "", fmt.Errorf("failed to encode PNG: %w", err)
+		}
+		return buf.Bytes(), "image/png", nil
+	default:
+		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: quality}); err != nil {
+			return nil, "", fmt.Errorf("failed to encode JPEG: %w", err)
+		}
+		return buf.Bytes(), "image/jpeg", nil
+	}
 }
 
 func mimeTypeFromDecodedFormat(format string) string {


### PR DESCRIPTION
## What

Improve image transcription/OCR handling in three places:

- Persist web-uploaded images to the uploads directory even when they are small enough to send inline.
- Mark user-supplied images and `view_image` outputs with Responses API `detail: "high"` when requested/appropriate.
- Extend `view_image` with `region`, `crop`, and `scale` options so agents can inspect notebook pages, small handwriting, and dense diagrams in focused chunks.

## Why

Noa uploaded a two-page notebook photo for transcription. The stored upload was only 591×443 / 55 KB, so the model could not reliably read it from the inline image alone. Saving the upload path lets the agent re-open it with tools, and crop/upscale support lets it split two-page photos into left/right pages before sending them back to vision.

## Verification

- `go test ./...`
- Built patched binary and tested against the failed upload with:
  - `view_image detail=high region=left_half scale=3`
  - `view_image detail=high region=right_half scale=3`

The result was still limited by the tiny source image, but produced a materially better partial transcription instead of only asking for a new photo.
