### PR TITLE
feat: preserve image uploads for transcription

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -136,15 +136,6 @@ func decodedBase64Len(b64Data string) (int, error) {
 	return decodedLen, nil
 }
 
-func validateBase64Data(b64Data string) error {
-	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64Data))
-	var buf [4096]byte
-	if _, err := io.CopyBuffer(io.Discard, decoder, buf[:]); err != nil {
-		return fmt.Errorf("decode base64: %w", err)
-	}
-	return nil
-}
-
 func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
 	b64Data = stripBase64Newlines(b64Data)
 	decodedLen, err := decodedBase64Len(b64Data)
@@ -231,11 +222,13 @@ func abbreviatePath(path string) string {
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
-// Supported image types are kept inline for the LLM; all other files are saved to disk
+// Supported image types are sent inline to the LLM and also saved to disk
+// so tools can reopen the original upload later. Other files are saved to disk
 // and referenced by path in a text part.
 //
-// Images exceeding 1 MB are resized/compressed before being sent to the LLM to avoid
-// provider errors.
+// Images exceeding 1 MB are resized/compressed only for the inline LLM payload
+// to avoid provider errors; the saved ImagePath always points at the original
+// uploaded bytes.
 func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	var parts []map[string]json.RawMessage
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
@@ -269,38 +262,31 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					}
 
 					b64 = stripBase64Newlines(b64)
-					decodedLen, err := decodedBase64Len(b64)
-					if err != nil {
-						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
-					}
-					if decodedLen > maxAttachmentBytes {
-						return llm.Message{}, fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
-					}
-					if decodedLen <= maxLLMImageBytes {
-						if err := validateBase64Data(b64); err != nil {
-							return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
-						}
-						llmParts = append(llmParts, llm.Part{
-							Type:      llm.PartImage,
-							ImageData: &llm.ToolImageData{MediaType: mt, Base64: b64},
-						})
-						continue
-					}
-
 					raw, err := decodeUploadedFile(filename, b64)
 					if err != nil {
 						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
 					}
-
-					// Resize if over 1 MB before sending to the model.
-					resized, resMT := resizeImageForLLM(raw, mt)
-					sendB64 := b64
-					if len(resized) != len(raw) || resMT != mt {
-						sendB64 = base64.StdEncoding.EncodeToString(resized)
+					path, err := saveUploadedBytes(filename, raw)
+					if err != nil {
+						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
 					}
+
+					sendB64 := b64
+					sendMT := mt
+					if len(raw) > maxLLMImageBytes {
+						// Resize only the inline payload sent to the model. Keep ImagePath
+						// pointing at the original upload so tools can inspect high-res data.
+						resized, resMT := resizeImageForLLM(raw, mt)
+						if len(resized) != len(raw) || resMT != mt {
+							sendB64 = base64.StdEncoding.EncodeToString(resized)
+							sendMT = resMT
+						}
+					}
+
 					llmParts = append(llmParts, llm.Part{
 						Type:      llm.PartImage,
-						ImageData: &llm.ToolImageData{MediaType: resMT, Base64: sendB64},
+						ImageData: &llm.ToolImageData{MediaType: sendMT, Base64: sendB64},
+						ImagePath: path,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,7 +113,7 @@ func TestDecodeUploadedFile_RejectsOversizedPayloadBeforeDecode(t *testing.T) {
 	}
 }
 
-func TestParseUserMessageContent_InlineImagesDoNotHitUploadsDir(t *testing.T) {
+func TestParseUserMessageContent_InlineImagesAreSavedToUploadsDir(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)
 
@@ -123,14 +126,89 @@ func TestParseUserMessageContent_InlineImagesDoNotHitUploadsDir(t *testing.T) {
 	if len(msg.Parts) != 1 {
 		t.Fatalf("len(msg.Parts) = %d, want 1", len(msg.Parts))
 	}
-	if msg.Parts[0].ImagePath != "" {
-		t.Fatalf("msg.Parts[0].ImagePath = %q, want empty", msg.Parts[0].ImagePath)
+	if msg.Parts[0].ImagePath == "" {
+		t.Fatal("msg.Parts[0].ImagePath is empty, want saved upload path")
 	}
 
 	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
-	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
-		t.Fatalf("uploads dir stat err = %v, want not exist", err)
+	entries, err := os.ReadDir(uploadsDir)
+	if err != nil {
+		t.Fatalf("read uploads dir: %v", err)
 	}
+	if len(entries) != 1 {
+		t.Fatalf("uploads dir has %d files, want 1", len(entries))
+	}
+}
+
+func TestParseUserMessageContent_LargeImageSavesOriginalButSendsResizedInline(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	raw := makeLargeJPEG(t)
+	if len(raw) <= maxLLMImageBytes {
+		t.Fatalf("test JPEG is %d bytes, want > %d", len(raw), maxLLMImageBytes)
+	}
+	content, err := json.Marshal([]map[string]any{{
+		"type":      "input_image",
+		"image_url": "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(raw),
+		"filename":  "page.jpg",
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	if len(msg.Parts) != 1 {
+		t.Fatalf("len(msg.Parts) = %d, want 1", len(msg.Parts))
+	}
+	part := msg.Parts[0]
+	if part.ImagePath == "" {
+		t.Fatal("ImagePath is empty, want saved original upload path")
+	}
+	saved, err := os.ReadFile(part.ImagePath)
+	if err != nil {
+		t.Fatalf("read saved original: %v", err)
+	}
+	if !bytes.Equal(saved, raw) {
+		t.Fatalf("saved image differs from original upload")
+	}
+	if part.ImageData == nil || part.ImageData.Base64 == "" {
+		t.Fatalf("ImageData missing")
+	}
+	inline, err := base64.StdEncoding.DecodeString(part.ImageData.Base64)
+	if err != nil {
+		t.Fatalf("decode inline image: %v", err)
+	}
+	if len(inline) >= len(raw) {
+		t.Fatalf("inline image is %d bytes, want resized smaller than original %d", len(inline), len(raw))
+	}
+	if part.ImageData.MediaType != "image/jpeg" {
+		t.Fatalf("inline media type = %q, want image/jpeg", part.ImageData.MediaType)
+	}
+}
+
+func makeLargeJPEG(t *testing.T) []byte {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, 1800, 1800))
+	for y := 0; y < 1800; y++ {
+		for x := 0; x < 1800; x++ {
+			img.SetRGBA(x, y, color.RGBA{
+				R: uint8((x*17 + y*31) & 0xff),
+				G: uint8((x*47 + y*13) & 0xff),
+				B: uint8((x*7 + y*19) & 0xff),
+				A: 0xff,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 95}); err != nil {
+		t.Fatalf("jpeg.Encode() error = %v", err)
+	}
+	return buf.Bytes()
 }
 
 func marshalInlineImageParts(t *testing.T, count int) json.RawMessage {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1088,12 +1088,23 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
 		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
 	}
-	if msg.Parts[0].ImagePath != "" {
-		t.Fatalf("parts[0].ImagePath = %q, want empty for inline upload", msg.Parts[0].ImagePath)
+	if msg.Parts[0].ImagePath == "" {
+		t.Fatalf("parts[0].ImagePath is empty, want saved upload path")
 	}
 	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
-	if _, err := os.Stat(uploadsDir); !os.IsNotExist(err) {
-		t.Fatalf("uploads dir stat err = %v, want not exist for inline image upload", err)
+	entries, err := os.ReadDir(uploadsDir)
+	if err != nil {
+		t.Fatalf("read uploads dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("uploads dir has %d files, want 1", len(entries))
+	}
+	got, err := os.ReadFile(msg.Parts[0].ImagePath)
+	if err != nil {
+		t.Fatalf("read saved image: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("saved image bytes = %q, want hello", got)
 	}
 	if msg.Parts[1].Type != llm.PartText {
 		t.Fatalf("parts[1].type = %s, want text", msg.Parts[1].Type)

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -691,7 +691,7 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 				for _, part := range msg.Parts {
 					if part.Type == PartImage && part.ImageData != nil {
 						dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-						imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: "auto"}})
+						imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: imageDetailWithDefault(part.ImageData.Detail, "auto")}})
 						if part.ImagePath != "" {
 							imageParts = append(imageParts, oaiContentPart{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
 						}
@@ -738,7 +738,7 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 						continue
 					}
 					dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data)
-					imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: "auto"}})
+					imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: imageDetailWithDefault(contentPart.ImageData.Detail, "auto")}})
 				}
 				if len(imageParts) > 0 {
 					result = append(result, oaiMessage{

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -116,6 +116,7 @@ type ResponsesContentPart struct {
 	Type     string `json:"type"`
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // Plain URL string for Responses API (not object)
+	Detail   string `json:"detail,omitempty"`
 }
 
 // ResponsesTool represents a tool definition in Open Responses format
@@ -357,7 +358,7 @@ func buildResponsesMessageItems(role string, parts []Part) []ResponsesInputItem 
 			if part.ImageData != nil {
 				flushText()
 				dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL}}
+				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: imageDetail(part.ImageData.Detail)}}
 				if part.ImagePath != "" {
 					imageParts = append(imageParts, ResponsesContentPart{Type: "input_text", Text: "[image saved at: " + part.ImagePath + "]"})
 				}

--- a/internal/llm/tool_result_content.go
+++ b/internal/llm/tool_result_content.go
@@ -76,6 +76,22 @@ func isSupportedToolResultImageMediaType(mimeType string) bool {
 	}
 }
 
+func imageDetail(detail string) string {
+	switch strings.TrimSpace(strings.ToLower(detail)) {
+	case "low", "high", "auto":
+		return strings.TrimSpace(strings.ToLower(detail))
+	default:
+		return ""
+	}
+}
+
+func imageDetailWithDefault(detail, defaultValue string) string {
+	if normalized := imageDetail(detail); normalized != "" {
+		return normalized
+	}
+	return defaultValue
+}
+
 // toolResultResponsesImageParts extracts image parts from a tool result
 // and returns Responses API content parts suitable for injection as a
 // synthetic user message. Only image parts are returned — text is already
@@ -92,7 +108,7 @@ func toolResultResponsesImageParts(result *ToolResult) (parts []ResponsesContent
 		}
 		hasImage = true
 		dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data)
-		parts = append(parts, ResponsesContentPart{Type: "input_image", ImageURL: dataURL})
+		parts = append(parts, ResponsesContentPart{Type: "input_image", ImageURL: dataURL, Detail: imageDetail(contentPart.ImageData.Detail)})
 	}
 	return parts, hasImage
 }

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -190,6 +190,7 @@ const (
 type ToolImageData struct {
 	MediaType string `json:"media_type,omitempty"`
 	Base64    string `json:"base64,omitempty"`
+	Detail    string `json:"detail,omitempty"`
 }
 
 // ToolContentPart represents one structured piece of tool result content.

--- a/internal/tools/view_image.go
+++ b/internal/tools/view_image.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
+	"image/draw"
 	_ "image/gif" // GIF decode support
 	"image/jpeg"
 	"image/png"
@@ -16,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/samsaffron/term-llm/internal/llm"
-	"golang.org/x/image/draw"
+	xdraw "golang.org/x/image/draw"
 	_ "golang.org/x/image/webp" // WebP decode support
 )
 
@@ -34,8 +35,18 @@ func NewViewImageTool(approval *ApprovalManager) *ViewImageTool {
 
 // ViewImageArgs are the arguments for view_image.
 type ViewImageArgs struct {
-	FilePath string `json:"file_path"`
-	Detail   string `json:"detail,omitempty"` // "low", "high", or "auto"
+	FilePath string     `json:"file_path"`
+	Detail   string     `json:"detail,omitempty"` // "low", "high", or "auto"
+	Region   string     `json:"region,omitempty"` // "full", "left_half", "right_half", "top_half", "bottom_half"
+	Crop     *ImageCrop `json:"crop,omitempty"`
+	Scale    float64    `json:"scale,omitempty"` // 1-4x upscale after crop/region
+}
+
+type ImageCrop struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
 }
 
 const (
@@ -63,7 +74,7 @@ var supportedImageMimes = map[string]struct{}{
 func (t *ViewImageTool) Spec() llm.ToolSpec {
 	return llm.ToolSpec{
 		Name:        ViewImageToolName,
-		Description: "View and analyze an image file. Returns base64-encoded image for multimodal analysis. Supports PNG, JPEG, GIF, WebP.",
+		Description: "View and analyze an image file. Supports PNG, JPEG, GIF, WebP. For transcription or dense handwriting, crop to a page/region and use high detail.",
 		Schema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -76,6 +87,30 @@ func (t *ViewImageTool) Spec() llm.ToolSpec {
 					"description": "Detail level: 'low', 'high', or 'auto' (default: 'auto')",
 					"enum":        []string{"low", "high", "auto"},
 					"default":     "auto",
+				},
+				"region": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional preset crop before analysis. Use left_half/right_half for two-page notebook spreads.",
+					"enum":        []string{"full", "left_half", "right_half", "top_half", "bottom_half"},
+					"default":     "full",
+				},
+				"crop": map[string]interface{}{
+					"type":        "object",
+					"description": "Optional exact pixel crop before analysis.",
+					"properties": map[string]interface{}{
+						"x":      map[string]interface{}{"type": "integer", "minimum": 0},
+						"y":      map[string]interface{}{"type": "integer", "minimum": 0},
+						"width":  map[string]interface{}{"type": "integer", "minimum": 1},
+						"height": map[string]interface{}{"type": "integer", "minimum": 1},
+					},
+					"required":             []string{"x", "y", "width", "height"},
+					"additionalProperties": false,
+				},
+				"scale": map[string]interface{}{
+					"type":        "number",
+					"description": "Optional 1-4x upscale after crop/region. Useful for small text crops; defaults to 1.",
+					"minimum":     1,
+					"maximum":     4,
 				},
 			},
 			"required":             []string{"file_path"},
@@ -155,6 +190,13 @@ func (t *ViewImageTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrUnsupportedFormat, "unsupported format: %s (supported: PNG, JPEG, GIF, WebP)", mimeType))), nil
 	}
 
+	// Apply optional crop/region/scale before normal provider-size processing.
+	transformDesc := ""
+	data, mimeType, transformDesc, err = transformImageForView(data, mimeType, a)
+	if err != nil {
+		return llm.TextOutput(formatToolError(NewToolErrorf(ErrInvalidParams, "%v", err))), nil
+	}
+
 	// Process image: resize if needed, ensure under size limit
 	processedData, processedMime, resized, err := processImage(data, mimeType)
 	if err != nil {
@@ -170,6 +212,9 @@ func (t *ViewImageTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 		sizeInfo = fmt.Sprintf("Size: %d bytes (resized from %d bytes)", len(processedData), len(data))
 	} else {
 		sizeInfo = fmt.Sprintf("Size: %d bytes", len(processedData))
+	}
+	if transformDesc != "" {
+		sizeInfo += "; " + transformDesc
 	}
 
 	textResult := fmt.Sprintf(`Image loaded: %s
@@ -191,10 +236,121 @@ Detail: %s`,
 				ImageData: &llm.ToolImageData{
 					MediaType: processedMime,
 					Base64:    encoded,
+					Detail:    getDetail(a.Detail),
 				},
 			},
 		},
 	}, nil
+}
+
+// transformImageForView applies crop/region/scale requested by the caller before
+// final provider-size processing. It is intentionally separate from processImage:
+// crop first preserves useful detail for dense handwriting and two-page spreads.
+func transformImageForView(data []byte, mimeType string, args ViewImageArgs) ([]byte, string, string, error) {
+	region := strings.TrimSpace(strings.ToLower(args.Region))
+	if region == "" {
+		region = "full"
+	}
+	scale := args.Scale
+	if scale == 0 {
+		scale = 1
+	}
+	if scale < 1 || scale > 4 {
+		return nil, "", "", fmt.Errorf("scale must be between 1 and 4")
+	}
+	if region == "full" && args.Crop == nil && scale == 1 {
+		return data, mimeType, "", nil
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to decode image: %w", err)
+	}
+	bounds := img.Bounds()
+	cropRect, desc, err := cropRectForView(bounds, region, args.Crop)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	cropped := cropImage(img, cropRect)
+	out := image.Image(cropped)
+	if scale > 1 {
+		w := int(float64(cropRect.Dx()) * scale)
+		h := int(float64(cropRect.Dy()) * scale)
+		if w > maxAbsDimension || h > maxAbsDimension {
+			return nil, "", "", fmt.Errorf("scaled image would be %dx%d, exceeding max dimension %d", w, h, maxAbsDimension)
+		}
+		out = resizeImage(cropped, w, h)
+		desc = strings.TrimSpace(desc + fmt.Sprintf("; scaled %.2gx", scale))
+	}
+
+	encoded, outMime, err := encodeViewedImage(out, format, mimeType)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return encoded, outMime, desc, nil
+}
+
+func cropRectForView(bounds image.Rectangle, region string, crop *ImageCrop) (image.Rectangle, string, error) {
+	if crop != nil {
+		r := image.Rect(bounds.Min.X+crop.X, bounds.Min.Y+crop.Y, bounds.Min.X+crop.X+crop.Width, bounds.Min.Y+crop.Y+crop.Height)
+		r = r.Intersect(bounds)
+		if r.Empty() || r.Dx() != crop.Width || r.Dy() != crop.Height {
+			return image.Rectangle{}, "", fmt.Errorf("crop rectangle is outside image bounds %dx%d", bounds.Dx(), bounds.Dy())
+		}
+		return r, fmt.Sprintf("crop %dx%d at %d,%d", r.Dx(), r.Dy(), crop.X, crop.Y), nil
+	}
+
+	midX := bounds.Min.X + bounds.Dx()/2
+	midY := bounds.Min.Y + bounds.Dy()/2
+	switch region {
+	case "", "full":
+		return bounds, "", nil
+	case "left_half":
+		return image.Rect(bounds.Min.X, bounds.Min.Y, midX, bounds.Max.Y), "region left_half", nil
+	case "right_half":
+		return image.Rect(midX, bounds.Min.Y, bounds.Max.X, bounds.Max.Y), "region right_half", nil
+	case "top_half":
+		return image.Rect(bounds.Min.X, bounds.Min.Y, bounds.Max.X, midY), "region top_half", nil
+	case "bottom_half":
+		return image.Rect(bounds.Min.X, midY, bounds.Max.X, bounds.Max.Y), "region bottom_half", nil
+	default:
+		return image.Rectangle{}, "", fmt.Errorf("unsupported region %q", region)
+	}
+}
+
+func cropImage(src image.Image, rect image.Rectangle) image.Image {
+	if sub, ok := src.(interface {
+		SubImage(image.Rectangle) image.Image
+	}); ok {
+		return sub.SubImage(rect)
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, rect.Dx(), rect.Dy()))
+	draw.Draw(dst, dst.Bounds(), src, rect.Min, draw.Src)
+	return dst
+}
+
+func encodeViewedImage(img image.Image, format, fallbackMime string) ([]byte, string, error) {
+	var buf bytes.Buffer
+	switch format {
+	case "png", "gif":
+		if err := png.Encode(&buf, img); err != nil {
+			return nil, "", fmt.Errorf("failed to encode PNG: %w", err)
+		}
+		return buf.Bytes(), "image/png", nil
+	default:
+		if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: jpegQuality}); err != nil {
+			return nil, "", fmt.Errorf("failed to encode JPEG: %w", err)
+		}
+		outMime := mimeTypeFromDecodedFormat(format)
+		if outMime == "" {
+			outMime = fallbackMime
+		}
+		if outMime != "image/jpeg" {
+			outMime = "image/jpeg"
+		}
+		return buf.Bytes(), outMime, nil
+	}
 }
 
 // processImage checks if an image needs resizing and processes it accordingly.
@@ -307,7 +463,7 @@ func mimeTypeFromDecodedFormat(format string) string {
 // resizeImage resizes an image to the specified dimensions using high-quality interpolation.
 func resizeImage(src image.Image, width, height int) image.Image {
 	dst := image.NewRGBA(image.Rect(0, 0, width, height))
-	draw.CatmullRom.Scale(dst, dst.Bounds(), src, src.Bounds(), draw.Over, nil)
+	xdraw.CatmullRom.Scale(dst, dst.Bounds(), src, src.Bounds(), draw.Over, nil)
 	return dst
 }
 

--- a/internal/tools/view_image_test.go
+++ b/internal/tools/view_image_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -42,7 +43,7 @@ func TestViewImageToolExecute_ReturnsStructuredImageData(t *testing.T) {
 	writeTestPNG(t, filePath)
 
 	tool := NewViewImageTool(nil)
-	args, err := json.Marshal(ViewImageArgs{FilePath: filePath})
+	args, err := json.Marshal(ViewImageArgs{FilePath: filePath, Detail: "high"})
 	if err != nil {
 		t.Fatalf("marshal args: %v", err)
 	}
@@ -77,8 +78,46 @@ func TestViewImageToolExecute_ReturnsStructuredImageData(t *testing.T) {
 	if imagePart.ImageData.MediaType != "image/png" {
 		t.Fatalf("expected media type image/png, got %q", imagePart.ImageData.MediaType)
 	}
+	if imagePart.ImageData.Detail != "high" {
+		t.Fatalf("expected detail high, got %q", imagePart.ImageData.Detail)
+	}
 	if _, err := base64.StdEncoding.DecodeString(imagePart.ImageData.Base64); err != nil {
 		t.Fatalf("image_data base64 should be valid: %v", err)
+	}
+}
+
+func TestViewImageToolExecute_CropsRegionAndScales(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "sample.png")
+	writeTestPNG(t, filePath)
+
+	tool := NewViewImageTool(nil)
+	args, err := json.Marshal(ViewImageArgs{FilePath: filePath, Region: "left_half", Scale: 2})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(out.Content, "region left_half") || !strings.Contains(out.Content, "scaled 2x") {
+		t.Fatalf("expected transform summary in content, got %q", out.Content)
+	}
+	if len(out.ContentParts) < 2 || out.ContentParts[1].ImageData == nil {
+		t.Fatalf("expected image content part in output")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(out.ContentParts[1].ImageData.Base64)
+	if err != nil {
+		t.Fatalf("decode image_data: %v", err)
+	}
+	img, _, err := image.Decode(bytes.NewReader(decoded))
+	if err != nil {
+		t.Fatalf("decode output image: %v", err)
+	}
+	bounds := img.Bounds()
+	if bounds.Dx() != 2 || bounds.Dy() != 4 {
+		t.Fatalf("decoded bounds = %dx%d, want 2x4", bounds.Dx(), bounds.Dy())
 	}
 }
 


### PR DESCRIPTION
## What

Fixes image upload handling for transcription workflows:

- Save supported web image uploads to `uploads/` unconditionally, even when they are also sent inline to the model.
- Preserve the original uploaded bytes on disk while keeping the existing resized/compressed inline payload for >1 MB images.
- Attach `ImagePath` to image parts so agents can reopen the original file with tools.
- Extend `view_image` with transcription-oriented controls:
  - `region`: `left_half`, `right_half`, `top_half`, `bottom_half`, `full`
  - exact pixel `crop`
  - 1-4x `scale`
  - `detail` is propagated into image payloads for Responses/OpenAI-compatible providers.

## Why

Noa/Skrill's failed transcription exposed two separate problems:

1. The browser upload path does not resize images, but the backend was resizing/compressing supported images over 1 MB before storing them in session history.
2. Supported web images were not saved to disk, so when a transcription failed the agent had no original file to reopen/crop with `view_image`.

The web UI can make an image look huge because it previews the browser `File` via an object URL. That preview is not proof the backend persisted the original. Previously, for supported images, it usually did not.

## Verification

```text
go test ./...
```
