### PR TITLE
perf: avoid double decoding response websocket events

### DIFF
--- a/internal/llm/responses_event_handler.go
+++ b/internal/llm/responses_event_handler.go
@@ -40,14 +40,118 @@ func (h *responsesStreamEventHandler) OutputItems() []ResponsesInputItem {
 	return append([]ResponsesInputItem(nil), h.outputItems...)
 }
 
+// responsesJSONEventType reads the top-level Responses event type without
+// unmarshalling the full event envelope on the common WebSocket path where a
+// known "type" is the first object field. Frames still get decoded by
+// HandleJSONEvent below; this avoids an extra json.Unmarshal on hot events while
+// falling back to json.Unmarshal for uncommon field orderings, unknown event
+// types, and malformed JSON.
+func responsesJSONEventType(data []byte) (string, error) {
+	if typ, ok := fastResponsesJSONEventType(data); ok && knownResponsesEventType(typ) {
+		return typ, nil
+	}
+
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return "", err
+	}
+	return envelope.Type, nil
+}
+
+func knownResponsesEventType(typ string) bool {
+	switch typ {
+	case "response.output_text.delta",
+		"response.output_item.added",
+		"response.function_call_arguments.delta",
+		"response.output_item.done",
+		"response.reasoning_summary_part.added",
+		"response.reasoning_summary_text.delta",
+		"response.completed",
+		"response.failed",
+		"error":
+		return true
+	default:
+		return false
+	}
+}
+
+func fastResponsesJSONEventType(data []byte) (string, bool) {
+	i := skipJSONWhitespace(data, 0)
+	if i >= len(data) || data[i] != '{' {
+		return "", false
+	}
+	i = skipJSONWhitespace(data, i+1)
+	if i >= len(data) || data[i] == '}' {
+		return "", false
+	}
+
+	keyEnd, err := skipJSONString(data, i)
+	if err != nil {
+		return "", false
+	}
+	if !bytes.Equal(data[i:keyEnd], []byte(`"type"`)) {
+		return "", false
+	}
+	i = skipJSONWhitespace(data, keyEnd)
+	if i >= len(data) || data[i] != ':' {
+		return "", false
+	}
+	i = skipJSONWhitespace(data, i+1)
+
+	valueEnd, err := skipJSONString(data, i)
+	if err != nil {
+		return "", false
+	}
+	raw := data[i:valueEnd]
+	if len(raw) >= 2 && bytes.IndexByte(raw[1:len(raw)-1], '\\') < 0 {
+		return string(raw[1 : len(raw)-1]), true
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func skipJSONWhitespace(data []byte, i int) int {
+	for i < len(data) {
+		switch data[i] {
+		case ' ', '\n', '\r', '\t':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func skipJSONString(data []byte, i int) (int, error) {
+	if i >= len(data) || data[i] != '"' {
+		return 0, fmt.Errorf("expected JSON string")
+	}
+	for i++; i < len(data); i++ {
+		switch data[i] {
+		case '\\':
+			i++
+			if i >= len(data) {
+				return 0, fmt.Errorf("unterminated JSON escape")
+			}
+		case '"':
+			return i + 1, nil
+		}
+	}
+	return 0, fmt.Errorf("unterminated JSON string")
+}
+
 func (h *responsesStreamEventHandler) HandleJSONEvent(data []byte, eventType string, send eventSender) (bool, error) {
 	if bytes.Equal(data, sseDoneData) {
 		return true, nil
 	}
 	if eventType == "" {
-		var sseEvent responsesSSEEvent
-		if err := json.Unmarshal(data, &sseEvent); err == nil && sseEvent.Type != "" {
-			eventType = sseEvent.Type
+		if typ, err := responsesJSONEventType(data); err == nil && typ != "" {
+			eventType = typ
 		}
 	}
 	eventLabel := eventType

--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -156,14 +156,12 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 				return fmt.Errorf("Responses WebSocket returned unsupported frame type %d", messageType)
 			}
 
-			var envelope struct {
-				Type string `json:"type"`
-			}
-			if err := json.Unmarshal(data, &envelope); err != nil {
+			eventType, err := responsesJSONEventType(data)
+			if err != nil {
 				c.discardWebSocketLocked()
 				return fmt.Errorf("decode Responses WebSocket event envelope: %w", err)
 			}
-			completed, err := handler.HandleJSONEvent(data, envelope.Type, send)
+			completed, err := handler.HandleJSONEvent(data, eventType, send)
 			if err != nil {
 				if wsErr, ok := err.(*responsesAPIEventError); ok && wsErr.APIError != nil {
 					switch wsErr.APIError.Code {

--- a/internal/llm/responses_websocket_bench_test.go
+++ b/internal/llm/responses_websocket_bench_test.go
@@ -1,0 +1,25 @@
+package llm
+
+import "testing"
+
+func BenchmarkResponsesWebSocketTextDeltaDispatch(b *testing.B) {
+	data := []byte(`{"type":"response.output_text.delta","delta":"hello world"}`)
+	handler := newResponsesStreamEventHandler(&ResponsesClient{}, 0, false, "bench", false)
+	send := eventSender{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		eventType, err := responsesJSONEventType(data)
+		if err != nil {
+			b.Fatalf("decode event type: %v", err)
+		}
+		completed, err := handler.HandleJSONEvent(data, eventType, send)
+		if err != nil {
+			b.Fatalf("HandleJSONEvent: %v", err)
+		}
+		if completed {
+			b.Fatal("unexpected completion")
+		}
+	}
+}

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -61,6 +61,73 @@ func TestResponsesWebSocketRequestOmitsTransportFields(t *testing.T) {
 	}
 }
 
+func TestResponsesJSONEventType(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "top level first",
+			data: `{"type":"response.output_text.delta","delta":"hello"}`,
+			want: "response.output_text.delta",
+		},
+		{
+			name: "whitespace around first field",
+			data: " { \n \t \"type\" : \"response.completed\", \"response\": {\"id\": \"resp_1\"} } ",
+			want: "response.completed",
+		},
+		{
+			name: "escaped first type",
+			data: `{"type":"response.output_text.\u0064elta","delta":"hello"}`,
+			want: "response.output_text.delta",
+		},
+		{
+			name: "nested type before top level",
+			data: `{"item":{"type":"function_call"},"output_index":0,"type":"response.output_item.added"}`,
+			want: "response.output_item.added",
+		},
+		{
+			name: "unknown first type falls back to unmarshal semantics",
+			data: `{"type":"unknown.event","type":"response.completed","response":{"id":"resp_1"}}`,
+			want: "response.completed",
+		},
+		{
+			name: "missing type",
+			data: `{"delta":"hello"}`,
+		},
+		{
+			name:    "malformed",
+			data:    `{"type":`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown malformed first type falls back to validation",
+			data:    `{"type":"unknown.event",`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := responsesJSONEventType([]byte(tt.data))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("responsesJSONEventType: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("type = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResponsesWebSocketPrepareClearsStalePreviousResponseID(t *testing.T) {
 	client := &ResponsesClient{LastResponseID: ""}
 	fullInput := []ResponsesInputItem{


### PR DESCRIPTION
## What

- Add a fast path for extracting known top-level Responses WebSocket `type` fields without a preliminary full `json.Unmarshal`.
- Reuse the same event type extractor for SSE payloads that omit an explicit `event:` line.
- Fall back to `json.Unmarshal` for uncommon field orderings, unknown event types, duplicate-key compatibility cases, and malformed JSON.
- Add unit coverage for nested/escaped/malformed event-type extraction and a benchmark for WebSocket text-delta dispatch.

## Why

Responses-over-WebSocket previously decoded every frame once just to read the envelope `type`, then decoded the same payload again in the shared event handler. Text deltas are the hottest streaming event path, so removing that extra decode lowers per-frame CPU and allocations.

## Evidence

Benchmark on this machine (`go test ./internal/llm -run '^$' -bench BenchmarkResponsesWebSocketTextDeltaDispatch -benchmem`):

- Before: ~905-947 ns/op, 512 B/op, 12 allocs/op
- After: ~510-523 ns/op, 280 B/op, 7 allocs/op

## Verification

- `go test ./internal/llm -run 'TestResponses(JSONEventType|ClientStream_|WebSocket)' -count=1`
- `go test ./internal/llm -run '^$' -bench BenchmarkResponsesWebSocketTextDeltaDispatch -benchmem -count=5`
- `go test ./...`
- `go build ./...`
