### PR TITLE
perf: reuse message insert statements for snapshots

### DIFF
--- a/internal/session/replace_bench_test.go
+++ b/internal/session/replace_bench_test.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot(b *testing.B) {
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "sessions.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		b.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		b.Fatalf("Create: %v", err)
+	}
+
+	messages := make([]Message, 120)
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := range messages {
+		role := llm.RoleUser
+		if i%2 == 1 {
+			role = llm.RoleAssistant
+		}
+		text := fmt.Sprintf("message %03d from benchmark", i)
+		messages[i] = Message{
+			SessionID:   sess.ID,
+			Role:        role,
+			Parts:       []llm.Part{{Type: llm.PartText, Text: text}},
+			TextContent: text,
+			DurationMs:  int64(i),
+			CreatedAt:   base.Add(time.Duration(i) * time.Millisecond),
+			Sequence:    i,
+		}
+	}
+
+	if err := store.ReplaceMessages(ctx, sess.ID, messages); err != nil {
+		b.Fatalf("seed ReplaceMessages: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.ReplaceMessages(ctx, sess.ID, messages); err != nil {
+			b.Fatalf("ReplaceMessages: %v", err)
+		}
+	}
+}

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1535,6 +1535,14 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 			return fmt.Errorf("delete existing messages: %w", err)
 		}
 
+		insertStmt, err := tx.PrepareContext(ctx, `
+			INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return fmt.Errorf("prepare message insert: %w", err)
+		}
+		defer insertStmt.Close()
+
 		// Insert new messages with sequential sequence numbers
 		for i, msg := range messages {
 			msg.SessionID = sessionID
@@ -1548,9 +1556,7 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 				return fmt.Errorf("serialize parts for message %d: %w", i, err)
 			}
 
-			_, err = tx.ExecContext(ctx, `
-				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
-				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			_, err = insertStmt.ExecContext(ctx,
 				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.CreatedAt, msg.Sequence)
 			if err != nil {
 				return fmt.Errorf("insert message %d: %w", i, err)
@@ -1588,6 +1594,14 @@ func (s *SQLiteStore) CompactMessages(ctx context.Context, sessionID string, mes
 		}
 		startSeq := maxSeq + 1
 
+		insertStmt, err := tx.PrepareContext(ctx, `
+			INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return fmt.Errorf("prepare message insert: %w", err)
+		}
+		defer insertStmt.Close()
+
 		// Insert new messages starting after the existing ones
 		for i, msg := range messages {
 			msg.SessionID = sessionID
@@ -1601,9 +1615,7 @@ func (s *SQLiteStore) CompactMessages(ctx context.Context, sessionID string, mes
 				return fmt.Errorf("serialize parts for message %d: %w", i, err)
 			}
 
-			_, err = tx.ExecContext(ctx, `
-				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
-				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			_, err = insertStmt.ExecContext(ctx,
 				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.CreatedAt, msg.Sequence)
 			if err != nil {
 				return fmt.Errorf("insert message %d: %w", i, err)


### PR DESCRIPTION
## What

- Prepare the repeated `messages` INSERT once per transaction in `ReplaceMessages` and `CompactMessages` instead of reparsing the same SQL for every message row.
- Add an end-to-end `ReplaceMessages` benchmark for a 120-message snapshot.

## Why

`ReplaceMessages` is used for full session snapshot persistence (for example initial web/runtime snapshots and compaction-related rewrites). Large resumed sessions can insert many message rows in a tight loop; preparing the statement once avoids repeated SQLite statement compilation work while preserving the existing transaction and trigger behavior.

## Evidence

Benchmark run on this machine with `go test ./internal/session -run '^$' -bench BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot -benchmem -count=5`:

Before:

```text
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  306  3810567 ns/op  130809 B/op  2308 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  309  3867348 ns/op  130729 B/op  2308 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  312  4097839 ns/op  130691 B/op  2308 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  315  3873892 ns/op  130711 B/op  2308 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  312  3941219 ns/op  130720 B/op  2308 allocs/op
```

After:

```text
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  384  3148421 ns/op  128247 B/op  2194 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  370  3078203 ns/op  128117 B/op  2193 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  367  3145735 ns/op  128115 B/op  2193 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  384  3148701 ns/op  128098 B/op  2193 allocs/op
BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot-32  386  3053750 ns/op  128054 B/op  2193 allocs/op
```

Average: ~3.92 ms/op → ~3.11 ms/op (~20.5% faster), 2308 → ~2193 allocs/op.

## Verification

- `gofmt -w internal/session/sqlite.go internal/session/replace_bench_test.go`
- `go test ./internal/session -run 'Test.*Replace|Test.*Compact|TestSQLiteStoreUpdateMessageOverwrites|TestSQLiteStoreLastMessageAt' -count=1`
- `go test ./internal/session -run '^$' -bench BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot -benchmem -count=5`
- `go test ./...`
- `go build ./...`
