### PR TITLE
feat: use durable response ids for session continuations

### DIFF
--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -96,6 +96,10 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 		resp["reasoning_effort"] = persistedEffort
 	}
 
+	if lastResponseID := s.latestDurableResponseIDForSession(r.Context(), sessionID); lastResponseID != "" {
+		resp["lastResponseId"] = lastResponseID
+	}
+
 	if s.responseRuns != nil {
 		if activeResponseID := s.responseRuns.activeRunID(sessionID); activeResponseID != "" {
 			resp["active_run"] = true

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1185,15 +1185,6 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if suffix == "messages" && r.Method == http.MethodPost {
-		if err := requireJSONContentType(r); err != nil {
-			writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
-			return
-		}
-		s.handleSessionMessageAppend(w, r, sessionID)
-		return
-	}
-
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET, POST")
 		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
@@ -1233,15 +1224,17 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 	}
 
 	type messageEntry struct {
+		ID        int64       `json:"id"`
 		Role      string      `json:"role"`
 		Parts     []partEntry `json:"parts"`
 		CreatedAt int64       `json:"created_at"`
 	}
 
 	type messagesResponse struct {
-		Messages   []messageEntry `json:"messages"`
-		HasMore    bool           `json:"has_more"`
-		NextOffset int            `json:"next_offset,omitempty"`
+		LastResponseID string         `json:"lastResponseId,omitempty"`
+		Messages       []messageEntry `json:"messages"`
+		HasMore        bool           `json:"has_more"`
+		NextOffset     int            `json:"next_offset,omitempty"`
 	}
 
 	result := make([]messageEntry, 0, len(msgs))
@@ -1251,6 +1244,7 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 			continue
 		}
 		entry := messageEntry{
+			ID:        msg.ID,
 			Role:      string(msg.Role),
 			CreatedAt: msg.CreatedAt.UnixMilli(),
 		}
@@ -1313,7 +1307,7 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		result = append(result, entry)
 	}
 
-	resp := messagesResponse{Messages: result, HasMore: hasMore}
+	resp := messagesResponse{LastResponseID: latestDurableResponseID(msgs), Messages: result, HasMore: hasMore}
 	if hasMore {
 		resp.NextOffset = nextOffset
 	}

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,18 +62,34 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	headerSessionID := strings.TrimSpace(r.Header.Get("session_id"))
 	sessionID := ""
 	if req.PreviousResponseID != "" {
-		sid, ok := s.responseToSession.Load(req.PreviousResponseID)
-		if !ok {
-			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error",
-				fmt.Sprintf("previous_response_id %q not found (session may have expired)", req.PreviousResponseID))
+		if durable, status, msg := s.resolveDurablePreviousResponseID(ctx, req.PreviousResponseID, headerSessionID, inputMessages); status != 0 {
+			errType := "invalid_request_error"
+			if status == http.StatusConflict {
+				errType = "conflict_error"
+			}
+			writeOpenAIError(w, status, errType, msg)
 			return
+		} else if durable.sessionID != "" {
+			sessionID = durable.sessionID
+		} else {
+			sid, ok := s.responseToSession.Load(req.PreviousResponseID)
+			if !ok {
+				writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error",
+					fmt.Sprintf("previous_response_id %q not found (session may have expired)", req.PreviousResponseID))
+				return
+			}
+			sidStr, isStr := sid.(string)
+			if !isStr || sidStr == "" {
+				writeOpenAIError(w, http.StatusInternalServerError, "server_error", "corrupted session mapping")
+				return
+			}
+			if headerSessionID != "" && headerSessionID != sidStr {
+				writeOpenAIError(w, http.StatusConflict, "conflict_error",
+					fmt.Sprintf("session_id %q conflicts with previous_response_id session %q", headerSessionID, sidStr))
+				return
+			}
+			sessionID = sidStr
 		}
-		sidStr, isStr := sid.(string)
-		if !isStr || sidStr == "" {
-			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "corrupted session mapping")
-			return
-		}
-		sessionID = sidStr
 	}
 	if sessionID == "" {
 		sessionID = headerSessionID
@@ -92,67 +109,6 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		sessionID:          sessionID,
 		previousResponseID: req.PreviousResponseID,
 		freshConversation:  req.PreviousResponseID == "",
-	})
-}
-
-func (s *serveServer) handleSessionMessageAppend(w http.ResponseWriter, r *http.Request, sessionID string) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", "POST")
-		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
-		return
-	}
-	if err := requireJSONContentType(r); err != nil {
-		writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
-		return
-	}
-	ctx, cancel := context.WithTimeout(r.Context(), s.responseTimeout())
-	defer cancel()
-
-	var req sessionAppendMessageRequest
-	if err := decodeJSONBody(r, &req); err != nil {
-		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
-		return
-	}
-	if len(req.Message) == 0 || strings.TrimSpace(string(req.Message)) == "" || strings.TrimSpace(string(req.Message)) == "null" {
-		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "message is required")
-		return
-	}
-	msg, err := parseUserMessageContent(req.Message)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
-		return
-	}
-
-	responsesReq := responsesCreateRequest{
-		Model:              req.Model,
-		Provider:           req.Provider,
-		Tools:              req.Tools,
-		IncludeServerTools: req.IncludeServerTools,
-		ToolChoice:         req.ToolChoice,
-		ParallelToolCalls:  req.ParallelToolCalls,
-		MaxOutputTokens:    req.MaxOutputTokens,
-		Temperature:        req.Temperature,
-		TopP:               req.TopP,
-		Stream:             req.Stream,
-		ReasoningEffort:    req.ReasoningEffort,
-		ModelSwap:          req.ModelSwap,
-	}
-
-	reqStart := time.Now()
-	s.verboseLog("→ POST /v1/sessions/%s/messages model=%s tools=%d stream=%v body=%d bytes",
-		sessionID, responsesReq.Model, len(responsesReq.Tools), responsesReq.Stream, r.ContentLength)
-	defer func() {
-		s.verboseLog("← POST /v1/sessions/%s/messages completed in %s", sessionID, time.Since(reqStart))
-	}()
-
-	s.handleResolvedResponses(w, r, ctx, resolvedResponsesRequest{
-		req:                responsesReq,
-		inputMessages:      []llm.Message{msg},
-		replaceHistory:     false,
-		sessionID:          sessionID,
-		previousResponseID: "",
-		freshConversation:  false,
-		uiStream:           true,
 	})
 }
 
@@ -356,6 +312,11 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 	}
 
 	resetResponseIDsOnSuccess := freshConversation || swapPlan.enabled
+	if req.Stream && s.store != nil {
+		if num := runtime.ensureSessionInStore(r.Context(), sessionID, inputMessages); num > 0 {
+			w.Header().Set("x-session-number", strconv.FormatInt(num, 10))
+		}
+	}
 	if req.Stream {
 		if rr.uiStream && stateful {
 			s.streamUIResponses(w, r, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, previousResponseID, resetResponseIDsOnSuccess, modelSwapExec)

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -30,22 +30,6 @@ type responsesCreateRequest struct {
 	ModelSwap          *responsesModelSwapRequest `json:"model_swap,omitempty"`
 }
 
-type sessionAppendMessageRequest struct {
-	Model              string                     `json:"model"`
-	Provider           string                     `json:"provider"`
-	Message            json.RawMessage            `json:"message"`
-	Tools              []json.RawMessage          `json:"tools,omitempty"`
-	IncludeServerTools bool                       `json:"include_server_tools,omitempty"`
-	ToolChoice         json.RawMessage            `json:"tool_choice,omitempty"`
-	ParallelToolCalls  *bool                      `json:"parallel_tool_calls,omitempty"`
-	MaxOutputTokens    int                        `json:"max_output_tokens,omitempty"`
-	Temperature        *float32                   `json:"temperature,omitempty"`
-	TopP               *float32                   `json:"top_p,omitempty"`
-	Stream             bool                       `json:"stream,omitempty"`
-	ReasoningEffort    string                     `json:"reasoning_effort,omitempty"`
-	ModelSwap          *responsesModelSwapRequest `json:"model_swap,omitempty"`
-}
-
 func parseResponsesInput(input json.RawMessage) ([]llm.Message, bool, error) {
 	trimmed := strings.TrimSpace(string(input))
 	if trimmed == "" || trimmed == "null" {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1084,9 +1084,14 @@ func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID
 			return "", err
 		}
 	}
+	durableID := s.latestDurableResponseIDForSession(context.Background(), sessionID)
+	completedID := respID
+	if durableID != "" {
+		completedID = durableID
+	}
 	if err := run.complete(map[string]any{
 		"response": map[string]any{
-			"id":            respID,
+			"id":            completedID,
 			"object":        "response",
 			"created":       created,
 			"model":         model,
@@ -1103,8 +1108,11 @@ func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID
 	if resetResponseIDsOnSuccess {
 		s.unregisterSessionResponseIDs(sessionID)
 	}
-	s.registerResponseID(runtime, respID, sessionID)
-	return respID, nil
+	if completedID != respID {
+		s.registerResponseID(runtime, respID, sessionID)
+	}
+	s.registerResponseID(runtime, completedID, sessionID)
+	return completedID, nil
 }
 
 func (s *serveServer) streamFailedResponseRun(ctx context.Context, w http.ResponseWriter, sessionID, previousResponseID, model, errType, errMessage string) {
@@ -1471,10 +1479,18 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		if options.resetResponseIDsOnSuccess {
 			s.unregisterSessionResponseIDs(sessionID)
 		}
-		s.registerResponseID(runtime, respID, sessionID)
+		durableID := s.latestDurableResponseIDForSession(context.Background(), sessionID)
+		completedID := respID
+		if durableID != "" {
+			completedID = durableID
+		}
+		if completedID != respID {
+			s.registerResponseID(runtime, respID, sessionID)
+		}
+		s.registerResponseID(runtime, completedID, sessionID)
 		if err := run.complete(map[string]any{
 			"response": map[string]any{
-				"id":            respID,
+				"id":            completedID,
 				"object":        "response",
 				"created":       created,
 				"model":         model,

--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+const durableResponseMessagePrefix = "resp_msg_"
+
+func durableResponseIDForMessageID(id int64) string {
+	if id <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s%d", durableResponseMessagePrefix, id)
+}
+
+func parseDurableResponseMessageID(responseID string) (int64, bool) {
+	trimmed := strings.TrimSpace(responseID)
+	if !strings.HasPrefix(trimmed, durableResponseMessagePrefix) {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(strings.TrimPrefix(trimmed, durableResponseMessagePrefix), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+func isVisibleContinuationRole(role llm.Role) bool {
+	return role == llm.RoleUser || role == llm.RoleAssistant
+}
+
+func latestVisibleMessage(messages []session.Message) (session.Message, bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if isVisibleContinuationRole(messages[i].Role) {
+			return messages[i], true
+		}
+	}
+	return session.Message{}, false
+}
+
+func latestDurableResponseID(messages []session.Message) string {
+	msg, ok := latestVisibleMessage(messages)
+	if !ok {
+		return ""
+	}
+	return durableResponseIDForMessageID(msg.ID)
+}
+
+type durablePreviousResponseResolution struct {
+	sessionID string
+	latestID  string
+}
+
+func (s *serveServer) resolveDurablePreviousResponseID(ctx context.Context, previousResponseID, headerSessionID string, inputMessages []llm.Message) (durablePreviousResponseResolution, int, string) {
+	msgID, ok := parseDurableResponseMessageID(previousResponseID)
+	if !ok {
+		return durablePreviousResponseResolution{}, 0, ""
+	}
+	if s.store == nil {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, fmt.Sprintf("previous_response_id %q not found (session history is unavailable)", previousResponseID)
+	}
+	if err := validateDurableContinuationInput(inputMessages); err != nil {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, err.Error()
+	}
+
+	msg, err := getMessageByID(ctx, s.store, msgID)
+	if err != nil || msg.ID == 0 {
+		if _, ok := s.responseToSession.Load(previousResponseID); ok {
+			return durablePreviousResponseResolution{}, 0, ""
+		}
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, fmt.Sprintf("previous_response_id %q not found", previousResponseID)
+	}
+	if !isVisibleContinuationRole(msg.Role) {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, "previous_response_id must refer to a user or assistant message"
+	}
+	if headerSessionID != "" && headerSessionID != msg.SessionID {
+		return durablePreviousResponseResolution{}, http.StatusConflict, fmt.Sprintf("session_id %q conflicts with previous_response_id session %q", headerSessionID, msg.SessionID)
+	}
+	msgs, err := s.store.GetMessages(ctx, msg.SessionID, 0, 0)
+	if err != nil {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, fmt.Sprintf("previous_response_id %q not found", previousResponseID)
+	}
+	latest, ok := latestVisibleMessage(msgs)
+	if !ok || latest.ID != msg.ID {
+		latestID := ""
+		if ok {
+			latestID = durableResponseIDForMessageID(latest.ID)
+		}
+		if latestID == "" {
+			latestID = "unknown"
+		}
+		return durablePreviousResponseResolution{}, http.StatusConflict, fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, latestID)
+	}
+	return durablePreviousResponseResolution{sessionID: msg.SessionID, latestID: durableResponseIDForMessageID(msg.ID)}, 0, ""
+}
+
+func validateDurableContinuationInput(inputMessages []llm.Message) error {
+	if len(inputMessages) != 1 {
+		return fmt.Errorf("message-backed previous_response_id requires exactly one new user message")
+	}
+	if inputMessages[0].Role != llm.RoleUser && inputMessages[0].Role != llm.RoleTool {
+		return fmt.Errorf("message-backed previous_response_id only accepts one new user message or tool result")
+	}
+	return nil
+}
+
+func getMessageByID(ctx context.Context, store session.Store, msgID int64) (session.Message, error) {
+	if getter, ok := store.(interface {
+		GetMessageByID(context.Context, int64) (*session.Message, error)
+	}); ok {
+		msg, err := getter.GetMessageByID(ctx, msgID)
+		if msg != nil {
+			return *msg, err
+		}
+		return session.Message{}, err
+	}
+	return session.Message{}, session.ErrNotFound
+}
+
+func (s *serveServer) latestDurableResponseIDForSession(ctx context.Context, sessionID string) string {
+	if s == nil || s.store == nil || sessionID == "" {
+		return ""
+	}
+	msgs, err := s.store.GetMessages(ctx, sessionID, 0, 0)
+	if err != nil {
+		return ""
+	}
+	return latestDurableResponseID(msgs)
+}

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -398,7 +398,7 @@ func (rt *serveRuntime) persistSnapshot(ctx context.Context, sessionID string, s
 // appends new messages, making each callback commit a small atomic write that
 // survives kill -9. Returns the number of messages successfully written so
 // callers can track progress accurately.
-func (rt *serveRuntime) appendMessages(ctx context.Context, sessionID string, messages []llm.Message) int {
+func (rt *serveRuntime) appendMessages(ctx context.Context, sessionID string, messages []llm.Message, turnIndex int) int {
 	if rt.store == nil || sessionID == "" || len(messages) == 0 {
 		return 0
 	}
@@ -411,6 +411,7 @@ func (rt *serveRuntime) appendMessages(ctx context.Context, sessionID string, me
 			continue
 		}
 		sessionMsg := session.NewMessage(sessionID, msg, -1)
+		sessionMsg.TurnIndex = turnIndex
 		if err := rt.store.AddMessage(dbCtx, sessionID, sessionMsg); err != nil {
 			log.Printf("[serve] session AddMessage failed for %s: %v", sessionID, err)
 			return written
@@ -565,6 +566,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		rt.cumulativeUsage = llm.Usage{}
 		rt.lastInjectedPlatform = ""
 	}
+	turnIndex := countUserMessages(baseHistory)
 
 	var injectedPlatform string
 	if devText := rt.platformMessages.For(rt.platform); devText != "" && rt.lastInjectedPlatform != rt.platform {
@@ -669,7 +671,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				initialPersisted = rt.persistSnapshot(persistCtx, req.SessionID, initialSnapshot)
 			}
 			if initialPersisted && lastAppendedIdx < len(produced) {
-				written := rt.appendMessages(persistCtx, req.SessionID, produced[lastAppendedIdx:])
+				written := rt.appendMessages(persistCtx, req.SessionID, produced[lastAppendedIdx:], turnIndex)
 				lastAppendedIdx += written
 			}
 		}
@@ -710,6 +712,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(persistCtx), 10*time.Second)
 		defer cancel()
 		sessionMsg := session.NewMessage(req.SessionID, assistantMsg, -1)
+		sessionMsg.TurnIndex = turnIndex
 		if pendingAssistantMsgID != 0 {
 			sessionMsg.ID = pendingAssistantMsgID
 			err := rt.store.UpdateMessage(dbCtx, req.SessionID, sessionMsg)
@@ -727,6 +730,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			// Row missing (e.g., compaction). Fall through to re-insert.
 			pendingAssistantMsgID = 0
 			sessionMsg = session.NewMessage(req.SessionID, assistantMsg, -1)
+			sessionMsg.TurnIndex = turnIndex
 		}
 		if err := rt.store.AddMessage(dbCtx, req.SessionID, sessionMsg); err != nil {
 			assistantSnapshotNeedsReconcile = true
@@ -943,6 +947,16 @@ func (rt *serveRuntime) isServerExecutedTool(name string) bool {
 	}
 	_, ok := rt.engine.Tools().Get(lookupName)
 	return ok
+}
+
+func countUserMessages(messages []llm.Message) int {
+	count := 0
+	for _, msg := range messages {
+		if msg.Role == llm.RoleUser {
+			count++
+		}
+	}
+	return count
 }
 
 func lastUserText(messages []llm.Message) string {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2783,12 +2783,13 @@ func TestStreamUIResponses_SetsSessionNumberHeader(t *testing.T) {
 		responseRuns: newServeResponseRunManager(),
 	}
 
-	body := `{"stream":true,"message":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess_test_number/messages", strings.NewReader(body))
+	body := `{"stream":true,"input":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("session_id", "sess_test_number")
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	srv.handleSessionByID(rr, req)
+	srv.handleResponses(rr, req)
 
 	numStr := strings.TrimSpace(rr.Header().Get("x-session-number"))
 	if numStr == "" {
@@ -2833,13 +2834,19 @@ func TestResponsesUIBareSessionIDAppendsServerHistory(t *testing.T) {
 	})
 	defer manager.Close()
 
+	seed, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("seed GetMessages: %v", err)
+	}
+	previousID := durableResponseIDForMessageID(seed[len(seed)-1].ID)
 	srv := &serveServer{sessionMgr: manager, store: store}
-	body := `{"message":"new question"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sessionID+"/messages", strings.NewReader(body))
+	body := fmt.Sprintf(`{"input":"new question","previous_response_id":%q}`, previousID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("session_id", sessionID)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	srv.handleSessionByID(rr, req)
+	srv.handleResponses(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
 	}
@@ -2873,26 +2880,149 @@ func TestResponsesUIBareSessionIDAppendsServerHistory(t *testing.T) {
 	}
 }
 
-func TestSessionMessageAppendRejectsResponsesReplayShape(t *testing.T) {
+func TestResponsesMessageBackedPreviousResponseRejectsReplayShape(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+	const sessionID = "sess_ui_replay"
+	if err := store.Create(context.Background(), &session.Session{ID: sessionID, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ReplaceMessages(context.Background(), sessionID, []session.Message{
+		*session.NewMessage(sessionID, llm.UserText("old"), -1),
+		*session.NewMessage(sessionID, llm.AssistantText("old answer"), -1),
+	}); err != nil {
+		t.Fatalf("seed ReplaceMessages: %v", err)
+	}
+	seed, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	previousID := durableResponseIDForMessageID(seed[len(seed)-1].ID)
 	provider := llm.NewMockProvider("mock").AddTextResponse("should not run")
 	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
 		engine := llm.NewEngine(provider, nil)
-		return &serveRuntime{provider: provider, engine: engine, defaultModel: "mock-model"}, nil
+		return &serveRuntime{provider: provider, engine: engine, store: store, defaultModel: "mock-model"}, nil
 	})
 	defer manager.Close()
 
-	srv := &serveServer{sessionMgr: manager}
-	body := `{"input":[{"type":"message","role":"user","content":"old"},{"type":"message","role":"assistant","content":"old answer"},{"type":"message","role":"user","content":"new"}]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess_ui_replay/messages", strings.NewReader(body))
+	srv := &serveServer{sessionMgr: manager, store: store}
+	body := fmt.Sprintf(`{"previous_response_id":%q,"input":[{"type":"message","role":"user","content":"old"},{"type":"message","role":"assistant","content":"old answer"},{"type":"message","role":"user","content":"new"}]}`, previousID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	srv.handleSessionByID(rr, req)
+	srv.handleResponses(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
 	}
 	if len(provider.Requests) != 0 {
 		t.Fatalf("provider request count = %d, want 0", len(provider.Requests))
+	}
+	msgs, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after reject: %v", err)
+	}
+	if len(msgs) != 2 || msgs[0].TextContent != "old" || msgs[1].TextContent != "old answer" {
+		t.Fatalf("messages changed after rejected replay: %#v", msgs)
+	}
+}
+
+func TestResponsesMessageBackedPreviousResponseRejectsStaleTail(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	const sessionID = "sess_stale_durable"
+	if err := store.Create(context.Background(), &session.Session{ID: sessionID, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ReplaceMessages(context.Background(), sessionID, []session.Message{
+		*session.NewMessage(sessionID, llm.UserText("first"), -1),
+		*session.NewMessage(sessionID, llm.AssistantText("first answer"), -1),
+		*session.NewMessage(sessionID, llm.UserText("second"), -1),
+		*session.NewMessage(sessionID, llm.AssistantText("second answer"), -1),
+	}); err != nil {
+		t.Fatalf("seed ReplaceMessages: %v", err)
+	}
+	seed, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	staleID := durableResponseIDForMessageID(seed[1].ID)
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("should not run")
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		return &serveRuntime{provider: provider, engine: engine, store: store, defaultModel: "mock-model"}, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager, store: store}
+	body := fmt.Sprintf(`{"input":"third","previous_response_id":%q}`, staleID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 0 {
+		t.Fatalf("provider request count = %d, want 0", len(provider.Requests))
+	}
+	msgs, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after stale reject: %v", err)
+	}
+	if len(msgs) != len(seed) {
+		t.Fatalf("message count changed after stale reject: got %d want %d", len(msgs), len(seed))
+	}
+}
+
+func TestResponsesMessageBackedPreviousResponseRejectsConflictingSessionHeader(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	const sessionA = "sess_conflict_a"
+	const sessionB = "sess_conflict_b"
+	for _, id := range []string{sessionA, sessionB} {
+		if err := store.Create(context.Background(), &session.Session{ID: id, Status: session.StatusActive}); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+	if err := store.ReplaceMessages(context.Background(), sessionA, []session.Message{
+		*session.NewMessage(sessionA, llm.UserText("hello"), -1),
+		*session.NewMessage(sessionA, llm.AssistantText("hi"), -1),
+	}); err != nil {
+		t.Fatalf("seed ReplaceMessages: %v", err)
+	}
+	seed, err := store.GetMessages(context.Background(), sessionA, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	previousID := durableResponseIDForMessageID(seed[len(seed)-1].ID)
+
+	srv := &serveServer{store: store}
+	body := fmt.Sprintf(`{"input":"wrong session","previous_response_id":%q}`, previousID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", sessionB)
+	rr := httptest.NewRecorder()
+
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rr.Code, rr.Body.String())
 	}
 }
 
@@ -4689,10 +4819,8 @@ func doResponses(t *testing.T, srv *serveServer, bodyJSON string) (int, map[stri
 	rr := httptest.NewRecorder()
 	srv.handleResponses(rr, req)
 	var result map[string]any
-	if rr.Code == http.StatusOK {
-		if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
-			t.Fatalf("unmarshal response: %v", err)
-		}
+	if rr.Body.Len() > 0 {
+		_ = json.Unmarshal(rr.Body.Bytes(), &result)
 	}
 	return rr.Code, result
 }
@@ -4708,10 +4836,8 @@ func doResponsesWithHeader(t *testing.T, srv *serveServer, bodyJSON, sessionID s
 	rr := httptest.NewRecorder()
 	srv.handleResponses(rr, req)
 	var result map[string]any
-	if rr.Code == http.StatusOK {
-		if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
-			t.Fatalf("unmarshal response: %v", err)
-		}
+	if rr.Body.Len() > 0 {
+		_ = json.Unmarshal(rr.Body.Bytes(), &result)
 	}
 	return rr.Code, result
 }
@@ -4796,15 +4922,16 @@ func TestHandleResponses_UIAskUserResumeSurvivesDisconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	body := `{"stream":true,"message":"hello"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/resume-session/messages", strings.NewReader(body)).WithContext(ctx)
+	body := `{"stream":true,"input":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("session_id", "resume-session")
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
 	doneCh := make(chan struct{})
 	go func() {
 		defer close(doneCh)
-		srv.handleSessionByID(rr, req)
+		srv.handleResponses(rr, req)
 	}()
 
 	waitForServeCondition(t, time.Second, func() bool {

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -3310,13 +3310,13 @@ const sendMessage = async (options = {}) => {
 
     const body = {
       stream: true,
-      message: inputContent
+      input: [{ type: 'message', role: 'user', content: inputContent }]
     };
 
-    // First-party UI sessions use the explicit append endpoint: the browser sends
-    // one new user message to the server-owned session. Do not send
-    // previous_response_id and do not replay browser-local history; that turns
-    // the UI into an unreliable shadow database.
+    const previousResponseId = String(session.lastResponseId || '').trim();
+    if (previousResponseId && session.messages.length > 1) {
+      body.previous_response_id = previousResponseId;
+    }
 
     const normalizeEffortForCompare = (value) => {
       const normalized = String(value || '').trim();
@@ -3357,7 +3357,7 @@ const sendMessage = async (options = {}) => {
       }
     }
 
-    let response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/messages`, {
+    let response = await fetch(`${UI_PREFIX}/v1/responses`, {
       method: 'POST',
       headers: requestHeaders(session.id),
       body: JSON.stringify(body),

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -460,7 +460,7 @@ function createHarness(options = {}) {
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    if (url.startsWith('/ui/v1/sessions/') && url.endsWith('/messages')) {
+    if (url === '/ui/v1/responses' && (options.method || 'GET') === 'POST') {
       if (postStatus !== 200) {
         return new Response(JSON.stringify(postErrorPayload), {
           status: postStatus,
@@ -1101,9 +1101,9 @@ async function testDrainInterruptQueueAfterResumeCompletes() {
   }
 
   // sendMessage should have been called — look for a POST to the explicit session append endpoint.
-  const postCalls = fetchCalls.filter(c => c.url === '/ui/v1/sessions/session_resume/messages' && c.method === 'POST');
+  const postCalls = fetchCalls.filter(c => c.url === '/ui/v1/responses' && c.method === 'POST');
   if (postCalls.length < 1) {
-    fail(name, 'expected sendMessage to POST /ui/v1/sessions/:id/messages for the queued interrupt', JSON.stringify(fetchCalls));
+    fail(name, 'expected sendMessage to POST /ui/v1/responses for the queued interrupt', JSON.stringify(fetchCalls));
     await cleanup();
     return;
   }
@@ -1353,9 +1353,9 @@ async function testSendMessageIncludesModelSwapForChangedTarget() {
   await app.sendMessage();
   await cleanup();
 
-  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
     return;
   }
   const body = JSON.parse(postCall.body);
@@ -1367,8 +1367,8 @@ async function testSendMessageIncludesModelSwapForChangedTarget() {
     fail(name, 'request did not use selected target runtime', postCall.body);
     return;
   }
-  if (Object.prototype.hasOwnProperty.call(body, 'previous_response_id')) {
-    fail(name, `previous_response_id should not be sent by first-party UI`, postCall.body);
+  if (body.previous_response_id !== 'resp_previous') {
+    fail(name, 'expected previous_response_id when continuing', postCall.body);
     return;
   }
   pass(name);
@@ -1403,9 +1403,9 @@ async function testSendMessageOmitsModelSwapWhenTargetUnchanged() {
   await app.sendMessage();
   await cleanup();
 
-  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
     return;
   }
   const body = JSON.parse(postCall.body);
@@ -1501,9 +1501,9 @@ async function testConnectTokenPreservesSelectedModelAndProviderFromState() {
   elements.promptInput.value = 'hello';
   await app.sendMessage();
 
-  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
     await cleanup();
     return;
   }
@@ -2171,9 +2171,9 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     return;
   }
 
-  const postCall = fetchCalls.find((call) => call.url.endsWith('/messages') && call.method === 'POST');
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/sessions/:id/messages body', JSON.stringify(fetchCalls));
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
     await cleanup();
     return;
   }
@@ -2187,7 +2187,7 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     return;
   }
 
-  const parts = body.message;
+	const parts = body.input?.[0]?.content;
   const imagePart = Array.isArray(parts) ? parts.find((part) => part.type === 'input_image') : null;
   if (!imagePart || imagePart.image_url !== file.mockDataURL) {
     fail(name, 'request body should include lazily materialized image data URL', JSON.stringify(body));
@@ -2270,7 +2270,7 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
     await cleanup();
     return;
   }
-  if (fetchCalls.some((call) => call.url.endsWith('/messages'))) {
+  if (fetchCalls.some((call) => call.url === '/ui/v1/responses')) {
     fail(name, 'request should not be sent when attachment materialization fails', JSON.stringify(fetchCalls));
     await cleanup();
     return;
@@ -2401,13 +2401,13 @@ async function testStaleInterrupt404RefreshesAndSendsMessage() {
     fail(name, 'expected initial send to attempt interrupt once', JSON.stringify(fetchCalls));
     return;
   }
-  const postCalls = fetchCalls.filter((call) => call.url.endsWith('/messages') && call.method === 'POST');
+  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   if (postCalls.length !== 1) {
-    fail(name, 'expected recovery to POST /ui/v1/sessions/:id/messages once', JSON.stringify(fetchCalls));
+    fail(name, 'expected recovery to POST /ui/v1/responses once', JSON.stringify(fetchCalls));
     return;
   }
   const body = JSON.parse(postCalls[0].body || '{}');
-  const content = body.message;
+  const content = body.input?.[0]?.content;
   if (content !== 'send after restart') {
     fail(name, 'recovered POST did not preserve prompt', postCalls[0].body);
     return;

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -81,6 +82,7 @@ CREATE TABLE IF NOT EXISTS messages (
     parts TEXT NOT NULL,
     text_content TEXT,
     duration_ms INTEGER,
+    turn_index INTEGER DEFAULT 0,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     sequence INTEGER NOT NULL
 );
@@ -126,6 +128,7 @@ CREATE TABLE messages (
     parts TEXT NOT NULL,
     text_content TEXT,
     duration_ms INTEGER,
+    turn_index INTEGER DEFAULT 0,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     sequence INTEGER NOT NULL
 )`
@@ -200,7 +203,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 22
+const schemaVersion = 23
 
 // migration represents a schema migration.
 type migration struct {
@@ -697,6 +700,18 @@ var migrations = []migration{
 			return rebuildMessagesTableForCurrentRoles(db)
 		},
 	},
+	{
+		// Migration 23: Add turn_index for debugging and per-turn stats.
+		version:     23,
+		description: "add message turn_index column",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec("ALTER TABLE messages ADD COLUMN turn_index INTEGER DEFAULT 0")
+			if err != nil && !isDuplicateColumnError(err) {
+				return err
+			}
+			return nil
+		},
+	},
 }
 
 func rebuildMessagesTableForCurrentRoles(db *sql.DB) error {
@@ -710,8 +725,8 @@ func rebuildMessagesTableForCurrentRoles(db *sql.DB) error {
 		`DROP TABLE IF EXISTS messages_fts`,
 		`ALTER TABLE messages RENAME TO messages_old`,
 		messagesTableSchema,
-		`INSERT INTO messages (id, session_id, role, parts, text_content, duration_ms, created_at, sequence)
-		 SELECT id, session_id, role, parts, text_content, duration_ms, created_at, sequence
+		`INSERT INTO messages (id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
+		 SELECT id, session_id, role, parts, text_content, duration_ms, 0, created_at, sequence
 		 FROM messages_old`,
 		`DROP TABLE messages_old`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, sequence)`,
@@ -1428,9 +1443,9 @@ func (s *SQLiteStore) AddMessage(ctx context.Context, sessionID string, msg *Mes
 		}
 
 		result, err := tx.ExecContext(ctx, `
-			INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`,
-			sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.CreatedAt, msg.Sequence)
+			INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence)
 		if err != nil {
 			return fmt.Errorf("insert message: %w", err)
 		}
@@ -1490,9 +1505,9 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, msg *
 
 		result, err := tx.ExecContext(ctx, `
 			UPDATE messages
-			SET role = ?, parts = ?, text_content = ?, duration_ms = ?
+			SET role = ?, parts = ?, text_content = ?, duration_ms = ?, turn_index = ?
 			WHERE id = ? AND session_id = ?`,
-			string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.ID, sessionID)
+			string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.ID, sessionID)
 		if err != nil {
 			return fmt.Errorf("update message: %w", err)
 		}
@@ -1549,9 +1564,9 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 			}
 
 			_, err = tx.ExecContext(ctx, `
-				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
-				VALUES (?, ?, ?, ?, ?, ?, ?)`,
-				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.CreatedAt, msg.Sequence)
+				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence)
 			if err != nil {
 				return fmt.Errorf("insert message %d: %w", i, err)
 			}
@@ -1602,9 +1617,9 @@ func (s *SQLiteStore) CompactMessages(ctx context.Context, sessionID string, mes
 			}
 
 			_, err = tx.ExecContext(ctx, `
-				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, created_at, sequence)
-				VALUES (?, ?, ?, ?, ?, ?, ?)`,
-				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.CreatedAt, msg.Sequence)
+				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence)
 			if err != nil {
 				return fmt.Errorf("insert message %d: %w", i, err)
 			}
@@ -1626,7 +1641,7 @@ func (s *SQLiteStore) CompactMessages(ctx context.Context, sessionID string, mes
 // sequence number. Used on resume to load only post-compaction messages.
 func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq int) ([]Message, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, session_id, role, parts, text_content, duration_ms, created_at, sequence
+		SELECT id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence
 		FROM messages
 		WHERE session_id = ? AND sequence >= ?
 		ORDER BY sequence ASC`, sessionID, fromSeq)
@@ -1641,7 +1656,7 @@ func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fro
 		var partsJSON string
 		var durationMs sql.NullInt64
 		err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
-			&msg.TextContent, &durationMs, &msg.CreatedAt, &msg.Sequence)
+			&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
@@ -1656,10 +1671,36 @@ func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fro
 	return messages, rows.Err()
 }
 
+// GetMessageByID retrieves a single message by its global message id.
+func (s *SQLiteStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence
+		FROM messages
+		WHERE id = ?`, msgID)
+	var msg Message
+	var partsJSON string
+	var durationMs sql.NullInt64
+	err := row.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
+		&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan message: %w", err)
+	}
+	if durationMs.Valid {
+		msg.DurationMs = durationMs.Int64
+	}
+	if err := msg.SetPartsFromJSON(partsJSON); err != nil {
+		return nil, fmt.Errorf("deserialize parts: %w", err)
+	}
+	return &msg, nil
+}
+
 // GetMessages retrieves messages for a session.
 func (s *SQLiteStore) GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]Message, error) {
 	query := `
-		SELECT id, session_id, role, parts, text_content, duration_ms, created_at, sequence
+		SELECT id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence
 		FROM messages
 		WHERE session_id = ?
 		ORDER BY sequence ASC`
@@ -1689,7 +1730,7 @@ func (s *SQLiteStore) GetMessages(ctx context.Context, sessionID string, limit, 
 		var partsJSON string
 		var durationMs sql.NullInt64
 		err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
-			&msg.TextContent, &durationMs, &msg.CreatedAt, &msg.Sequence)
+			&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -103,6 +103,7 @@ type Message struct {
 	Parts       []llm.Part `json:"parts"`        // Full parts array
 	TextContent string     `json:"text_content"` // Extracted text for display/FTS
 	DurationMs  int64      `json:"duration_ms,omitempty"`
+	TurnIndex   int        `json:"turn_index,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`
 	Sequence    int        `json:"sequence"`
 }


### PR DESCRIPTION
## What

Replaces the first-party `/v1/sessions/:id/messages` append endpoint with durable message-backed `/v1/responses` continuations.

- Adds durable `previous_response_id` tokens backed by persisted message rows (`resp_msg_<messages.id>`).
- Keeps live/random response run IDs for streaming resume/cancel.
- Makes the web UI post to `/v1/responses` again, with one new user message and `previous_response_id` when continuing.
- Removes the browser history replay path and the special append endpoint.
- Rejects stale durable continuations (`continue 100` when the session tail is already `101`) with `409` and leaves the DB unchanged.
- Rejects full-history/replay-shaped input with message-backed continuations before provider calls.
- Rejects conflicting `session_id` headers when the durable response id belongs to another session.
- Adds `messages.turn_index` for longer-term debugging/stats.

## Why

The web UI should be able to use the normal Responses surface without becoming a shadow session database. `previous_response_id` is now durable for persisted sessions because it points at the current persisted message tail, not an in-memory run mapping.

External fresh `/v1/responses` semantics remain intact: no `previous_response_id` still means fresh conversation/replace input.

## Verification

```text
go test ./...
go build ./...
node internal/serveui/static/app_stream_test.js
```
