### PR TITLE
fix: trust durable response ids over stale runtime tails

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -19,6 +19,7 @@ type resolvedResponsesRequest struct {
 	replaceHistory     bool
 	sessionID          string
 	previousResponseID string
+	previousDurable    bool
 	freshConversation  bool
 	uiStream           bool
 }
@@ -61,6 +62,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	// fresh conversation, even if a session_id header is reused for persistence.
 	headerSessionID := strings.TrimSpace(r.Header.Get("session_id"))
 	sessionID := ""
+	previousDurable := false
 	if req.PreviousResponseID != "" {
 		if durable, status, msg := s.resolveDurablePreviousResponseID(ctx, req.PreviousResponseID, headerSessionID, inputMessages); status != 0 {
 			errType := "invalid_request_error"
@@ -71,6 +73,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 			return
 		} else if durable.sessionID != "" {
 			sessionID = durable.sessionID
+			previousDurable = true
 		} else {
 			sid, ok := s.responseToSession.Load(req.PreviousResponseID)
 			if !ok {
@@ -108,6 +111,7 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		replaceHistory:     replaceHistory,
 		sessionID:          sessionID,
 		previousResponseID: req.PreviousResponseID,
+		previousDurable:    previousDurable,
 		freshConversation:  req.PreviousResponseID == "",
 	})
 }
@@ -118,6 +122,7 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 	replaceHistory := rr.replaceHistory
 	sessionID := rr.sessionID
 	previousResponseID := rr.previousResponseID
+	previousDurable := rr.previousDurable
 	freshConversation := rr.freshConversation
 	// Chained requests are locked to the persisted provider/model/
 	// reasoning_effort unless the client explicitly asks for a mid-conversation
@@ -193,24 +198,29 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 		if handleRuntimeErr(getErr) {
 			return
 		}
-		// Enforce chaining from the latest response before replacing the session runtime.
+		// Durable message-backed response IDs were already validated against the
+		// persisted session tail before we selected a runtime. Do not reject them
+		// because an in-memory runtime still remembers an older ephemeral response
+		// ID from before a restart/resume.
 		if previousResponseID != "" {
-			lastRespID := previousRuntime.getLastResponseID()
-			if lastRespID == "" {
-				if latest, ok := s.sessionToResponse.Load(sessionID); ok {
-					if latestStr, ok := latest.(string); ok {
-						lastRespID = strings.TrimSpace(latestStr)
+			if !previousDurable {
+				lastRespID := previousRuntime.getLastResponseID()
+				if lastRespID == "" {
+					if latest, ok := s.sessionToResponse.Load(sessionID); ok {
+						if latestStr, ok := latest.(string); ok {
+							lastRespID = strings.TrimSpace(latestStr)
+						}
 					}
 				}
-			}
-			if lastRespID != "" && previousResponseID != lastRespID {
-				writeOpenAIError(w, http.StatusConflict, "conflict_error",
-					fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, lastRespID))
-				if !previousStateful {
-					s.unregisterResponseIDs(previousRuntime)
-					previousRuntime.Close()
+				if lastRespID != "" && previousResponseID != lastRespID {
+					writeOpenAIError(w, http.StatusConflict, "conflict_error",
+						fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, lastRespID))
+					if !previousStateful {
+						s.unregisterResponseIDs(previousRuntime)
+						previousRuntime.Close()
+					}
+					return
 				}
-				return
 			}
 			s.populateResponsesToolResultNames(ctx, sessionID, previousRuntime, inputMessages)
 		}
@@ -235,27 +245,29 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 			s.syncPersistedSessionRuntime(ctx, sessionID, runtime, strings.TrimSpace(req.Model), normalizeReasoningEffort(req.ReasoningEffort))
 		}
 
-		// Enforce chaining from the latest response only. Stale response IDs that
-		// map to a valid session but don't match the runtime's last response would
-		// produce incorrect branching (the context wouldn't match what the client
-		// expects from that response).
+		// Enforce chaining from the latest in-memory response only for ephemeral
+		// response IDs. Durable message-backed IDs are checked against the persisted
+		// message tail in resolveDurablePreviousResponseID; the runtime can have an
+		// older lastResponseID after a restart or history reload.
 		if previousResponseID != "" {
-			lastRespID := runtime.getLastResponseID()
-			if lastRespID == "" {
-				if latest, ok := s.sessionToResponse.Load(sessionID); ok {
-					if latestStr, ok := latest.(string); ok {
-						lastRespID = strings.TrimSpace(latestStr)
+			if !previousDurable {
+				lastRespID := runtime.getLastResponseID()
+				if lastRespID == "" {
+					if latest, ok := s.sessionToResponse.Load(sessionID); ok {
+						if latestStr, ok := latest.(string); ok {
+							lastRespID = strings.TrimSpace(latestStr)
+						}
 					}
 				}
-			}
-			if lastRespID != "" && previousResponseID != lastRespID {
-				writeOpenAIError(w, http.StatusConflict, "conflict_error",
-					fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, lastRespID))
-				if !stateful {
-					s.unregisterResponseIDs(runtime)
-					runtime.Close()
+				if lastRespID != "" && previousResponseID != lastRespID {
+					writeOpenAIError(w, http.StatusConflict, "conflict_error",
+						fmt.Sprintf("previous_response_id %q is stale; latest is %q", previousResponseID, lastRespID))
+					if !stateful {
+						s.unregisterResponseIDs(runtime)
+						runtime.Close()
+					}
+					return
 				}
-				return
 			}
 			s.populateResponsesToolResultNames(ctx, sessionID, runtime, inputMessages)
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2880,6 +2880,67 @@ func TestResponsesUIBareSessionIDAppendsServerHistory(t *testing.T) {
 	}
 }
 
+func TestResponsesMessageBackedPreviousResponseIgnoresStaleRuntimeTail(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	const sessionID = "sess_durable_runtime_tail"
+	if err := store.Create(context.Background(), &session.Session{ID: sessionID, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ReplaceMessages(context.Background(), sessionID, []session.Message{
+		*session.NewMessage(sessionID, llm.UserText("old question"), -1),
+		*session.NewMessage(sessionID, llm.AssistantText("old answer"), -1),
+		*session.NewMessage(sessionID, llm.UserText("newer question"), -1),
+		*session.NewMessage(sessionID, llm.AssistantText("newer answer"), -1),
+	}); err != nil {
+		t.Fatalf("seed ReplaceMessages: %v", err)
+	}
+	seed, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	staleRuntimeID := durableResponseIDForMessageID(seed[1].ID)
+	previousID := durableResponseIDForMessageID(seed[len(seed)-1].ID)
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("continued")
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			store:        store,
+			defaultModel: "mock-model",
+		}
+		rt.addResponseID(staleRuntimeID)
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager, store: store}
+	srv.responseToSession.Store(staleRuntimeID, sessionID)
+	srv.sessionToResponse.Store(sessionID, staleRuntimeID)
+
+	body := fmt.Sprintf(`{"input":"continue","previous_response_id":%q}`, previousID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("session_id", sessionID)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider request count = %d, want 1", len(provider.Requests))
+	}
+}
+
 func TestResponsesMessageBackedPreviousResponseRejectsReplayShape(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

Fix `/v1/responses` continuation for message-backed durable `previous_response_id` values when the selected in-memory runtime still has an older response tail cached.

Durable IDs like `resp_msg_787323` are now validated once against the persisted session tail, then allowed through even if `runtime.lastResponseID` or `sessionToResponse` still points at an older in-memory ID.

## Why

A web session could become unable to reply with an error like:

```
previous_response_id "resp_msg_787323" is stale; latest is "resp_msg_787161"
```

That was bogus for durable message IDs. The database already proved `resp_msg_787323` was the latest persisted message. The later runtime guard was re-checking it against stale ephemeral runtime state and rejecting the request anyway.

## Tests

- Added `TestResponsesMessageBackedPreviousResponseIgnoresStaleRuntimeTail`
- `go test ./cmd -run 'TestResponsesMessageBackedPreviousResponse|TestHandleResponses_PreviousResponseIDFunctionCallOutputUsesPersistedToolNameAfterRuntimeRecreation'`
- `go test ./...`
- `go build ./...`
