### PR TITLE
fix: Streamed prose can disappear until a newline/tool boundary because incomplete text only renders from the markdown stream buffer

### DIFF
--- a/internal/ui/segment.go
+++ b/internal/ui/segment.go
@@ -701,7 +701,7 @@ func RenderSegmentsWithLeadingAndImageRenderer(leading *Segment, segments []*Seg
 			if seg.Complete && seg.Rendered != "" {
 				rendered = seg.Rendered
 			} else if seg.StreamRenderer != nil {
-				rendered = seg.StreamRenderer.RenderedUnflushed()
+				rendered = seg.StreamRenderer.PreviewUnflushed()
 			} else {
 				text := seg.GetText()
 				if text == "" {

--- a/internal/ui/segment_flush_test.go
+++ b/internal/ui/segment_flush_test.go
@@ -393,21 +393,21 @@ func TestPartialTextFlushSpacing(t *testing.T) {
 	}
 }
 
-func TestRenderUnflushed_HidesPendingParagraphContent(t *testing.T) {
+func TestRenderUnflushed_ShowsPendingParagraphContent(t *testing.T) {
 	tracker := NewToolTracker()
 	width := 80
 
-	tracker.AddTextSegment("This paragraph should stay hidden before block completion", width)
+	tracker.AddTextSegment("This paragraph should stay visible before block completion", width)
 
 	output := stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if strings.Contains(output, "This paragraph should stay hidden before block completion") {
-		t.Fatalf("expected pending paragraph content to stay hidden, got %q", output)
+	if !strings.Contains(output, "This paragraph should stay visible before block completion") {
+		t.Fatalf("expected pending paragraph content to stay visible, got %q", output)
 	}
 
 	tracker.AddTextSegment("\n\n", width)
 	output = stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if !strings.Contains(output, "This paragraph should stay hidden before block completion") {
-		t.Fatalf("expected paragraph content to appear after block boundary, got %q", output)
+	if !strings.Contains(output, "This paragraph should stay visible before block completion") {
+		t.Fatalf("expected paragraph content to remain visible after block boundary, got %q", output)
 	}
 }
 
@@ -435,15 +435,15 @@ func TestRenderUnflushed_HidesPendingListMarkerContent(t *testing.T) {
 	}
 }
 
-func TestRenderUnflushed_HidesPendingAsteriskPrefix(t *testing.T) {
+func TestRenderUnflushed_ShowsPendingAsteriskPrefix(t *testing.T) {
 	tracker := NewToolTracker()
 	width := 80
 
 	tracker.AddTextSegment("*", width)
 
 	output := stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if strings.Contains(output, "*") {
-		t.Fatalf("expected pending asterisk prefix to stay hidden, got %q", output)
+	if !strings.Contains(output, "*") {
+		t.Fatalf("expected pending asterisk prefix to stay visible, got %q", output)
 	}
 }
 

--- a/internal/ui/text_segment_renderer.go
+++ b/internal/ui/text_segment_renderer.go
@@ -97,6 +97,22 @@ func (r *TextSegmentRenderer) RenderedUnflushed() string {
 	return safeANSISlice(output, r.flushedRenderedPos)
 }
 
+// PreviewUnflushed returns the unflushed rendered output plus a raw preview of
+// the current incomplete block when it is safe to do so. This keeps prose
+// streaming smoothly between markdown block boundaries without forcing a full
+// text snapshot refresh in the hot View() path.
+func (r *TextSegmentRenderer) PreviewUnflushed() string {
+	rendered := r.RenderedUnflushed()
+	pending := r.PendingMarkdown()
+	if pending == "" || r.PendingIsTable() || r.PendingIsList() {
+		return rendered
+	}
+	if rendered == "" {
+		return pending
+	}
+	return rendered + pending
+}
+
 // MarkFlushed marks the current rendered output length as flushed.
 // Call this after successfully flushing content to scrollback.
 func (r *TextSegmentRenderer) MarkFlushed() {

--- a/internal/ui/tool_tracker_test.go
+++ b/internal/ui/tool_tracker_test.go
@@ -586,6 +586,23 @@ func TestDebugStreamingSimulation(t *testing.T) {
 	}
 }
 
+func TestStreamingTextSegmentsAreVisibleBetweenBlockBoundaries(t *testing.T) {
+	tracker := NewToolTracker()
+	width := 80
+
+	tracker.AddTextSegment("# Header\n\n", width)
+	tracker.AddTextSegment("Trailing prose is still streaming", width)
+
+	segments := tracker.CompletedSegments()
+	content := StripANSI(RenderSegments(segments, width, -1, nil, false, false))
+	if !strings.Contains(content, "Header") {
+		t.Fatalf("expected rendered heading during streaming, got %q", content)
+	}
+	if !strings.Contains(content, "Trailing prose is still streaming") {
+		t.Fatalf("expected pending prose preview during streaming, got %q", content)
+	}
+}
+
 // TestStreamingThenComplete verifies that streaming text is rendered progressively
 // by the streaming renderer, then finalized on completion.
 func TestStreamingThenComplete(t *testing.T) {


### PR DESCRIPTION
## What

- add a `PreviewUnflushed` path for streaming text segments that keeps already-rendered markdown blocks and appends a raw preview of the current incomplete prose block
- switch `RenderSegmentsWithLeadingAndImageRenderer` to use that preview instead of only `RenderedUnflushed()`
- add coverage for visible pending prose during streaming while still suppressing unstable table/list previews

## Why

`TextSegmentRenderer` uses the non-partial streaming markdown renderer, so incomplete paragraphs often remain buffered until a newline or tool boundary. The View path was only reading `RenderedUnflushed()`, which made streamed prose appear to freeze and then jump in large chunks. This change preserves smooth token-by-token prose updates without forcing snapshot refreshes in the hot render path or exposing unstable table/list partials.
