### PR TITLE
fix: In-progress assistant text is dropped from the render path until a newline or boundary completes it

### DIFF
--- a/internal/ui/segment.go
+++ b/internal/ui/segment.go
@@ -701,7 +701,7 @@ func RenderSegmentsWithLeadingAndImageRenderer(leading *Segment, segments []*Seg
 			if seg.Complete && seg.Rendered != "" {
 				rendered = seg.Rendered
 			} else if seg.StreamRenderer != nil {
-				rendered = seg.StreamRenderer.RenderedUnflushed()
+				rendered = seg.StreamRenderer.RenderedView()
 			} else {
 				text := seg.GetText()
 				if text == "" {

--- a/internal/ui/segment_flush_test.go
+++ b/internal/ui/segment_flush_test.go
@@ -393,21 +393,21 @@ func TestPartialTextFlushSpacing(t *testing.T) {
 	}
 }
 
-func TestRenderUnflushed_HidesPendingParagraphContent(t *testing.T) {
+func TestRenderUnflushed_ShowsPendingParagraphContentImmediately(t *testing.T) {
 	tracker := NewToolTracker()
 	width := 80
 
-	tracker.AddTextSegment("This paragraph should stay hidden before block completion", width)
+	tracker.AddTextSegment("This paragraph should stay visible before block completion", width)
 
 	output := stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if strings.Contains(output, "This paragraph should stay hidden before block completion") {
-		t.Fatalf("expected pending paragraph content to stay hidden, got %q", output)
+	if !strings.Contains(output, "This paragraph should stay visible before block completion") {
+		t.Fatalf("expected pending paragraph content to be visible, got %q", output)
 	}
 
 	tracker.AddTextSegment("\n\n", width)
 	output = stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if !strings.Contains(output, "This paragraph should stay hidden before block completion") {
-		t.Fatalf("expected paragraph content to appear after block boundary, got %q", output)
+	if !strings.Contains(output, "This paragraph should stay visible before block completion") {
+		t.Fatalf("expected paragraph content to remain visible after block boundary, got %q", output)
 	}
 }
 

--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"bytes"
 	"strings"
 )
 
@@ -23,6 +24,50 @@ func (sr *StreamRenderer) currentBlockContent() string {
 		content.WriteString(sr.lineBuf.String())
 	}
 	return content.String()
+}
+
+// PreviewRendered returns a full rendered snapshot including any safe preview of
+// the current incomplete block. It does not mutate the renderer's output state.
+// The boolean reports whether the returned snapshot includes preview content from
+// the current incomplete block.
+func (sr *StreamRenderer) PreviewRendered() (string, bool, error) {
+	content := sr.currentBlockContent()
+	if content == "" {
+		return string(sr.lastRendered), false, nil
+	}
+
+	safePoint := sr.findSafePoint(content)
+	if safePoint <= 0 {
+		return string(sr.lastRendered), false, nil
+	}
+
+	rendered, err := sr.renderPreviewDocument(content[:safePoint])
+	if err != nil {
+		return "", false, err
+	}
+
+	return string(rendered), true, nil
+}
+
+func (sr *StreamRenderer) renderPreviewDocument(safeContent string) ([]byte, error) {
+	var markdown bytes.Buffer
+	markdown.Grow(sr.allMarkdown.Len() + len(safeContent))
+	markdown.Write(sr.allMarkdown.Bytes())
+	markdown.WriteString(safeContent)
+
+	input := markdown.Bytes()
+	if sr.hasTabs {
+		input = bytes.ReplaceAll(input, []byte("\t"), []byte("  "))
+	}
+
+	rendered, err := sr.renderer.Render(input)
+	if err != nil {
+		return nil, err
+	}
+
+	rendered = normalizeNewlines(rendered)
+	rendered = bytes.TrimRight(rendered, "\n")
+	return rendered, nil
 }
 
 // renderPartialBlock renders safe content from an incomplete block.

--- a/internal/ui/text_segment_renderer.go
+++ b/internal/ui/text_segment_renderer.go
@@ -28,7 +28,9 @@ func NewTextSegmentRenderer(width int) (*TextSegmentRenderer, error) {
 		Width:   width,
 	})
 
-	sr, err := streaming.NewRenderer(&output, renderer)
+	sr, err := streaming.NewRendererWithOptions(&output, renderer, []streaming.StreamRendererOption{
+		streaming.WithPartialRendering(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +86,21 @@ func (r *TextSegmentRenderer) Rendered() string {
 // RenderedAll returns the full rendered output including already-flushed content.
 func (r *TextSegmentRenderer) RenderedAll() string {
 	return r.output.String()
+}
+
+// RenderedView returns the current view of the segment, including a safe preview
+// of any in-progress block when available, while still excluding content that
+// was already flushed to scrollback.
+func (r *TextSegmentRenderer) RenderedView() string {
+	if r.sr != nil && !r.sr.PendingIsTable() && !r.sr.PendingIsList() {
+		if preview, _, err := r.sr.PreviewRendered(); err == nil && preview != "" {
+			if r.flushedRenderedPos >= len(preview) {
+				return ""
+			}
+			return safeANSISlice(preview, r.flushedRenderedPos)
+		}
+	}
+	return r.RenderedUnflushed()
 }
 
 // RenderedUnflushed returns only the portion of rendered output that hasn't

--- a/internal/ui/tool_tracker_test.go
+++ b/internal/ui/tool_tracker_test.go
@@ -527,6 +527,35 @@ func TestMarkCurrentTextComplete_SyncsRendererFlushedOffsetBeforeBoundaryFlush(t
 	}
 }
 
+func TestStreamingViewShowsInProgressParagraphWithoutNewline(t *testing.T) {
+	tracker := NewToolTracker()
+	tracker.AddTextSegment("Streaming text is visible immediately", 80)
+
+	segments := tracker.CompletedSegments()
+	content := StripANSI(RenderSegments(segments, 80, -1, nil, false, false))
+	if !strings.Contains(content, "Streaming text is visible immediately") {
+		t.Fatalf("expected in-progress paragraph text in view, got %q", content)
+	}
+}
+
+func TestStreamingViewPreservesSpacingBeforePendingParagraph(t *testing.T) {
+	tracker := NewToolTracker()
+	tracker.AddTextSegment("# Heading\n\n", 80)
+	tracker.AddTextSegment("Next paragraph is still streaming", 80)
+
+	segments := tracker.CompletedSegments()
+	content := StripANSI(RenderSegments(segments, 80, -1, nil, false, false))
+	if !strings.Contains(content, "Heading") {
+		t.Fatalf("expected heading in view, got %q", content)
+	}
+	if !strings.Contains(content, "Next paragraph is still streaming") {
+		t.Fatalf("expected pending paragraph in view, got %q", content)
+	}
+	if strings.Contains(content, "HeadingNext paragraph") {
+		t.Fatalf("expected rendered spacing between committed and pending blocks, got %q", content)
+	}
+}
+
 // TestDebugStreamingSimulation simulates streaming where text accumulates
 // in a single segment. With the streaming renderer, complete blocks are
 // rendered immediately as they arrive.


### PR DESCRIPTION
## What

- switch the live `SegmentText` render path to use a view-specific streaming preview instead of only `RenderedUnflushed()`
- teach the streaming renderer to build a safe full-document preview for the current incomplete block without changing scrollback flush behavior
- keep pending list/table prefixes on the old hidden path, and add regression coverage for in-progress paragraph rendering and committed-to-pending block spacing

## Why

The TUI was dropping ordinary in-progress assistant prose from the render path until a newline, tool boundary, or final flush committed the block. That made streaming responses look frozen and then jump in chunks. This change keeps normal prose visible immediately while preserving the existing committed-only flush semantics and avoiding noisy previews for incomplete list/table structures.
