### PR TITLE
fix: Live streamed text is buffered until newline/tool boundary instead of appearing token-by-token

### DIFF
--- a/internal/ui/segment_flush_test.go
+++ b/internal/ui/segment_flush_test.go
@@ -393,21 +393,21 @@ func TestPartialTextFlushSpacing(t *testing.T) {
 	}
 }
 
-func TestRenderUnflushed_HidesPendingParagraphContent(t *testing.T) {
+func TestRenderUnflushed_ShowsPendingParagraphContent(t *testing.T) {
 	tracker := NewToolTracker()
 	width := 80
 
-	tracker.AddTextSegment("This paragraph should stay hidden before block completion", width)
+	tracker.AddTextSegment("This paragraph should stream before block completion", width)
 
 	output := stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if strings.Contains(output, "This paragraph should stay hidden before block completion") {
-		t.Fatalf("expected pending paragraph content to stay hidden, got %q", output)
+	if !strings.Contains(output, "This paragraph should stream before block completion") {
+		t.Fatalf("expected pending paragraph content to be visible, got %q", output)
 	}
 
 	tracker.AddTextSegment("\n\n", width)
 	output = stripAnsi(tracker.RenderUnflushed(width, RenderMarkdown, false))
-	if !strings.Contains(output, "This paragraph should stay hidden before block completion") {
-		t.Fatalf("expected paragraph content to appear after block boundary, got %q", output)
+	if !strings.Contains(output, "This paragraph should stream before block completion") {
+		t.Fatalf("expected paragraph content to remain visible after block boundary, got %q", output)
 	}
 }
 

--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"bytes"
 	"strings"
 )
 
@@ -26,18 +27,18 @@ func (sr *StreamRenderer) currentBlockContent() string {
 }
 
 // renderPartialBlock renders safe content from an incomplete block.
-// In altscreen mode (with termCtrl), it clears and re-renders.
-// In flowing mode (no termCtrl), partial rendering is disabled since
-// there is no cursor control to clear and re-render.
+// In altscreen mode (with termCtrl), it clears and re-renders the partial block
+// in place. For resettable flowing outputs (like TextSegmentRenderer's buffer),
+// it rewrites the full rendered snapshot so View() can show token-by-token text
+// without terminal cursor control.
 func (sr *StreamRenderer) renderPartialBlock() error {
-	// Disable partial rendering in flowing mode - it provides no benefit
-	// without cursor control to clear and re-render
-	if sr.termCtrl == nil {
+	content := sr.currentBlockContent()
+	if len(content) == 0 {
 		return nil
 	}
 
-	content := sr.currentBlockContent()
-	if len(content) == 0 {
+	firstPending := sr.firstPendingLine()
+	if strings.HasPrefix(firstPending, "|") || isListMarkerOnly(firstPending) {
 		return nil
 	}
 
@@ -50,29 +51,63 @@ func (sr *StreamRenderer) renderPartialBlock() error {
 		return nil
 	}
 
-	// Clear previous partial output if any
-	if sr.partialState.lineCount > 0 {
-		if err := sr.termCtrl.ClearLines(sr.partialState.lineCount); err != nil {
-			return err
-		}
-	}
-
-	// Render the safe content
+	// Render the safe content so both terminal and flowing paths share
+	// the same inline-safety behavior.
 	rendered, err := sr.renderPartial(safeContent)
 	if err != nil {
 		return err
 	}
 
-	// Write to output
-	if _, err := sr.output.Write([]byte(rendered)); err != nil {
-		return err
+	if sr.termCtrl != nil {
+		// Clear previous partial output if any.
+		if sr.partialState.lineCount > 0 {
+			if err := sr.termCtrl.ClearLines(sr.partialState.lineCount); err != nil {
+				return err
+			}
+		}
+
+		if _, err := sr.output.Write([]byte(rendered)); err != nil {
+			return err
+		}
+		sr.partialState.lineCount = sr.termCtrl.CountLines(rendered)
+	} else {
+		snapshot, err := sr.renderPartialSnapshot(safeContent)
+		if err != nil {
+			return err
+		}
+		if err := sr.applyRenderedSnapshot(snapshot, false); err != nil {
+			return err
+		}
+		sr.partialState.outputLen = len(snapshot)
 	}
 
 	// Update state
 	sr.partialState.safeMarkdown = safeContent
 	sr.partialState.safeRendered = rendered
-	sr.partialState.lineCount = sr.termCtrl.CountLines(rendered)
 	return nil
+}
+
+func (sr *StreamRenderer) renderPartialSnapshot(safeContent string) ([]byte, error) {
+	markdown := append([]byte(nil), sr.normalizedMarkdown()...)
+	if sr.hasTabs {
+		markdown = append(markdown, bytes.ReplaceAll([]byte(safeContent), []byte("\t"), []byte("  "))...)
+	} else {
+		markdown = append(markdown, safeContent...)
+	}
+
+	rendered, err := sr.renderer.Render(markdown)
+	if err != nil {
+		return nil, err
+	}
+
+	rendered = normalizeNewlines(rendered)
+
+	stableLen := len(rendered)
+	for stableLen > 0 && rendered[stableLen-1] == '\n' {
+		stableLen--
+	}
+
+	return rendered[:stableLen], nil
 }
 
 // renderPartial renders safe content with appropriate context.

--- a/internal/ui/streaming/streaming.go
+++ b/internal/ui/streaming/streaming.go
@@ -66,6 +66,10 @@ type StreamRenderer struct {
 	// Last rendered snapshot that has been written to output.
 	// Used to append deltas safely and recover from non-prefix renders.
 	lastRendered []byte
+	// Last committed rendered snapshot (without any partial preview).
+	// Used by callers that need a stable scrollback-safe view while partial
+	// previews are visible in the active buffer.
+	lastCommittedRendered []byte
 
 	// Current state
 	state state
@@ -184,6 +188,12 @@ func (sr *StreamRenderer) Write(p []byte) (n int, err error) {
 // committed as complete blocks. This excludes any pending/incomplete block content.
 func (sr *StreamRenderer) CommittedMarkdownLen() int {
 	return sr.allMarkdown.Len()
+}
+
+// CommittedRendered returns the latest rendered snapshot that contains only
+// committed markdown blocks and excludes any active partial preview.
+func (sr *StreamRenderer) CommittedRendered() string {
+	return string(sr.lastCommittedRendered)
 }
 
 // PendingMarkdown returns the current incomplete block markdown.
@@ -634,6 +644,7 @@ func (sr *StreamRenderer) emitRendered() error {
 	}
 
 	if sr.allMarkdown.Len() == 0 {
+		sr.lastCommittedRendered = nil
 		return nil
 	}
 
@@ -653,6 +664,7 @@ func (sr *StreamRenderer) emitRendered() error {
 		stableLen--
 	}
 
+	sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], rendered[:stableLen]...)
 	return sr.applyRenderedSnapshot(rendered[:stableLen], false)
 }
 
@@ -683,6 +695,7 @@ func (sr *StreamRenderer) Flush() error {
 	sr.state = stateReady
 
 	if sr.allMarkdown.Len() == 0 {
+		sr.lastCommittedRendered = nil
 		return nil
 	}
 
@@ -694,6 +707,7 @@ func (sr *StreamRenderer) Flush() error {
 
 	// Normalize consecutive newlines to fix inconsistent header spacing
 	rendered = normalizeNewlines(rendered)
+	sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], rendered...)
 
 	// Output final render including trailing newlines.
 	return sr.applyRenderedSnapshot(rendered, true)
@@ -744,11 +758,14 @@ func (sr *StreamRenderer) Resize(newWidth int) error {
 			stableLen--
 		}
 
+		sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], rendered[:stableLen]...)
 		if stableLen > 0 {
 			if err := sr.applyRenderedSnapshot(rendered[:stableLen], true); err != nil {
 				return err
 			}
 		}
+	} else {
+		sr.lastCommittedRendered = nil
 	}
 
 	return nil
@@ -871,6 +888,31 @@ func isOrderedListMarkerPrefix(trimmed string) bool {
 		return false
 	}
 	return i+1 == len(trimmed)
+}
+
+// isListMarkerOnly reports whether trimmed contains just a list marker and
+// optional trailing whitespace, with no item content yet.
+func isListMarkerOnly(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+
+	if (trimmed[0] == '-' || trimmed[0] == '+' || trimmed[0] == '*') && len(trimmed) > 1 {
+		if trimmed[1] == ' ' || trimmed[1] == '\t' {
+			return strings.TrimSpace(trimmed[2:]) == ""
+		}
+	}
+
+	i := 0
+	for i < len(trimmed) && i < 9 && trimmed[i] >= '0' && trimmed[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(trimmed) || (trimmed[i] != '.' && trimmed[i] != ')') {
+		return false
+	}
+
+	rest := strings.TrimSpace(trimmed[i+1:])
+	return rest == ""
 }
 
 // isThematicBreak returns true if the line is a thematic break (---, ***, ___).

--- a/internal/ui/text_segment_renderer.go
+++ b/internal/ui/text_segment_renderer.go
@@ -20,7 +20,7 @@ type TextSegmentRenderer struct {
 }
 
 // NewTextSegmentRenderer creates a new TextSegmentRenderer with the given width.
-// Uses flowing mode (no cursor control) since Bubble Tea owns the terminal.
+// Uses partial flowing snapshots (no cursor control) since Bubble Tea owns the terminal.
 func NewTextSegmentRenderer(width int) (*TextSegmentRenderer, error) {
 	var output bytes.Buffer
 	renderer := rendermarkdown.NewANSI(rendermarkdown.Config{
@@ -28,7 +28,13 @@ func NewTextSegmentRenderer(width int) (*TextSegmentRenderer, error) {
 		Width:   width,
 	})
 
-	sr, err := streaming.NewRenderer(&output, renderer)
+	sr, err := streaming.NewRendererWithOptions(
+		&output,
+		renderer,
+		[]streaming.StreamRendererOption{
+			streaming.WithPartialRendering(),
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +92,15 @@ func (r *TextSegmentRenderer) RenderedAll() string {
 	return r.output.String()
 }
 
+// RenderedCommitted returns the latest rendered snapshot that contains only
+// committed markdown blocks and excludes any active partial preview.
+func (r *TextSegmentRenderer) RenderedCommitted() string {
+	if r.sr == nil {
+		return ""
+	}
+	return r.sr.CommittedRendered()
+}
+
 // RenderedUnflushed returns only the portion of rendered output that hasn't
 // been flushed to scrollback yet. Use this in View() to avoid duplicating
 // content that was already printed via FlushStreamingText.
@@ -97,10 +112,14 @@ func (r *TextSegmentRenderer) RenderedUnflushed() string {
 	return safeANSISlice(output, r.flushedRenderedPos)
 }
 
-// MarkFlushed marks the current rendered output length as flushed.
+// MarkFlushed marks the current committed rendered output as flushed.
 // Call this after successfully flushing content to scrollback.
 func (r *TextSegmentRenderer) MarkFlushed() {
-	r.flushedRenderedPos = r.output.Len()
+	if r.sr == nil {
+		r.flushedRenderedPos = r.output.Len()
+		return
+	}
+	r.flushedRenderedPos = len(r.sr.CommittedRendered())
 }
 
 // FlushedRenderedPos returns the current flushed position in the rendered output.

--- a/internal/ui/text_segment_renderer_test.go
+++ b/internal/ui/text_segment_renderer_test.go
@@ -73,6 +73,43 @@ func TestTextSegmentRenderer_Streaming(t *testing.T) {
 	}
 }
 
+func TestTextSegmentRenderer_ShowsPartialPlainTextWithoutNewline(t *testing.T) {
+	renderer, err := NewTextSegmentRenderer(80)
+	if err != nil {
+		t.Fatalf("Failed to create renderer: %v", err)
+	}
+
+	if err := renderer.Write("Hello"); err != nil {
+		t.Fatalf("Failed to write partial text: %v", err)
+	}
+
+	got := stripANSI(renderer.RenderedUnflushed())
+	if got != "Hello" {
+		t.Fatalf("RenderedUnflushed() = %q, want %q", got, "Hello")
+	}
+}
+
+func TestTextSegmentRenderer_PartialMarkdownStaysVisibleAcrossSyntaxCompletion(t *testing.T) {
+	renderer, err := NewTextSegmentRenderer(80)
+	if err != nil {
+		t.Fatalf("Failed to create renderer: %v", err)
+	}
+
+	if err := renderer.Write("Hello **wor"); err != nil {
+		t.Fatalf("Failed to write incomplete markdown: %v", err)
+	}
+	if got := stripANSI(renderer.RenderedUnflushed()); got != "Hello" {
+		t.Fatalf("RenderedUnflushed() after incomplete markdown = %q, want %q", got, "Hello")
+	}
+
+	if err := renderer.Write("ld**"); err != nil {
+		t.Fatalf("Failed to complete markdown: %v", err)
+	}
+	if got := stripANSI(renderer.RenderedUnflushed()); got != "Hello world" {
+		t.Fatalf("RenderedUnflushed() after markdown completion = %q, want %q", got, "Hello world")
+	}
+}
+
 func TestTextSegmentRenderer_Width(t *testing.T) {
 	renderer, err := NewTextSegmentRenderer(80)
 	if err != nil {

--- a/internal/ui/tool_tracker.go
+++ b/internal/ui/tool_tracker.go
@@ -639,14 +639,26 @@ func (t *ToolTracker) FlushStreamingText(threshold int, width int, renderMd func
 			}
 			return FlushStreamingTextResult{}
 		}
-		rendered := seg.StreamRenderer.RenderedUnflushed()
-		if rendered == "" {
+		renderedAll := seg.StreamRenderer.RenderedCommitted()
+		if renderedAll == "" {
 			debugFlushf("stream skip seg=%d reason=empty-rendered committed=%d flushedPos=%d", segIdx, safeBoundary, seg.FlushedPos)
 			// Return any tool content we already flushed
 			if contentBuilder.Len() > 0 {
 				return FlushStreamingTextResult{ToPrint: contentBuilder.String()}
 			}
 			return FlushStreamingTextResult{}
+		}
+
+		rendered := renderedAll
+		if seg.FlushedRenderedPos > 0 {
+			if seg.FlushedRenderedPos >= len(renderedAll) {
+				debugFlushf("stream skip seg=%d reason=rendered-pos>=len committed=%d flushedRenderedPos=%d renderedLen=%d", segIdx, safeBoundary, seg.FlushedRenderedPos, len(renderedAll))
+				if contentBuilder.Len() > 0 {
+					return FlushStreamingTextResult{ToPrint: contentBuilder.String()}
+				}
+				return FlushStreamingTextResult{}
+			}
+			rendered = safeANSISlice(renderedAll, seg.FlushedRenderedPos)
 		}
 
 		if t.HasFlushed && seg.FlushedPos == 0 {
@@ -676,7 +688,7 @@ func (t *ToolTracker) FlushStreamingText(threshold int, width int, renderMd func
 		seg.StreamRenderer.MarkFlushed()
 		seg.FlushedRenderedPos = seg.StreamRenderer.FlushedRenderedPos()
 
-		debugFlushf("stream flush seg=%d committed=%d flushedPos=%d renderedUnflushedLen=%d flushedRenderedPos=%d", segIdx, safeBoundary, seg.FlushedPos, len(rendered), seg.FlushedRenderedPos)
+		debugFlushf("stream flush seg=%d committed=%d flushedPos=%d renderedLen=%d flushedRenderedPos=%d", segIdx, safeBoundary, seg.FlushedPos, len(rendered), seg.FlushedRenderedPos)
 
 		return FlushStreamingTextResult{
 			ToPrint: contentBuilder.String(),


### PR DESCRIPTION
## What

- enable partial streaming rendering for `TextSegmentRenderer` so in-progress prose appears in the live TUI before a newline or tool boundary
- teach the streaming renderer to support flowing, resettable snapshot updates for partial text while keeping list-marker/table previews suppressed
- keep scrollback flushes committed-block-only by tracking a committed rendered snapshot separately from the live partial preview
- add/update tests covering visible partial prose, markdown completion, list/table suppression, and scrollback safety

## Why

The live chat view was reading `RenderedUnflushed()` from a renderer created without partial rendering, so ordinary token deltas inside the current line often produced no visible output until a newline, tool boundary, or final flush. That made assistant text appear frozen and then jump in large chunks. This change restores token-by-token perceived streaming without regressing scrollback flushing or incomplete list/table handling.
