### PR TITLE
fix: Pending-tool wave animation forces a full alt-screen viewport content reset every 50ms

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -206,16 +206,17 @@ type Model struct {
 
 	// Render cache for alt screen mode (avoids re-rendering unchanged content)
 	viewCache struct {
-		historyContent      string // Cached rendered history
-		historyMsgCount     int    // Number of messages when cache was built
-		historyWidth        int    // Width when cache was built
-		historyScrollOffset int    // Scroll offset when cache was built
-		historyValid        bool   // Whether cache has been populated
-		lastViewportView    string // Cached viewport.View() output
-		lastYOffset         int    // Viewport Y offset when view was cached
-		lastVPWidth         int    // Viewport width when view was cached
-		lastVPHeight        int    // Viewport height when view was cached
-		lastXOffset         int    // Viewport horizontal offset when view was cached
+		historyContent      string   // Cached rendered history
+		historyLines        []string // Cached split history lines for cheap streaming-tail recomposition
+		historyMsgCount     int      // Number of messages when cache was built
+		historyWidth        int      // Width when cache was built
+		historyScrollOffset int      // Scroll offset when cache was built
+		historyValid        bool     // Whether cache has been populated
+		lastViewportView    string   // Cached viewport.View() output
+		lastYOffset         int      // Viewport Y offset when view was cached
+		lastVPWidth         int      // Viewport width when view was cached
+		lastVPHeight        int      // Viewport height when view was cached
+		lastXOffset         int      // Viewport horizontal offset when view was cached
 		lastSetContentAt    time.Time
 		historySignature    uint64 // Content fingerprint for cached history
 		// completedStream holds rendered streaming content (diffs, tools) that should

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -148,6 +149,7 @@ func (m *Model) viewAltScreen() string {
 		} else {
 			m.resetAltScreenStreamingAppendCache()
 			m.viewCache.historyContent = m.renderHistory()
+			m.viewCache.historyLines = splitViewportContentLines(m.viewCache.historyContent)
 			m.viewCache.historyMsgCount = len(m.messages)
 			m.viewCache.historySignature = historySig
 			m.viewCache.historyWidth = m.width
@@ -164,22 +166,23 @@ func (m *Model) viewAltScreen() string {
 	var contentLines []string
 	var streamingContent string
 	usedIncrementalAppend := false
+	waveOnlyChanged := false
 	if m.streaming {
-		// Only increment version when tracker content or wave position changes
-		// The completed segment rendering is cached, but we still need SetContent
-		// for wave animation updates
 		if m.tracker != nil {
 			trackerVersion := m.tracker.Version
 			if m.streamPerf != nil {
 				m.streamPerf.RecordTrackerVersion(trackerVersion)
 			}
 			wavePos := m.tracker.WavePos
-			contentChanged := trackerVersion != m.viewCache.lastTrackerVersion
+			trackerChanged := trackerVersion != m.viewCache.lastTrackerVersion
 			waveChanged := wavePos != m.viewCache.lastWavePos && m.tracker.HasPending()
-			if contentChanged || waveChanged {
+			if trackerChanged {
 				m.viewCache.lastTrackerVersion = trackerVersion
 				m.viewCache.lastWavePos = wavePos
 				m.bumpContentVersion()
+			} else if waveChanged {
+				m.viewCache.lastWavePos = wavePos
+				waveOnlyChanged = true
 			}
 		}
 	}
@@ -187,10 +190,12 @@ func (m *Model) viewAltScreen() string {
 	// Only call SetContent if content actually changed (expensive operation)
 	// Use version comparison instead of O(n) string comparison
 	contentChanged := m.viewCache.contentVersion != m.viewCache.lastRenderedVersion
+	contentDirty := contentChanged
 
 	// Force update if embedded UI is active (since it's interactive and doesn't affect tracker version)
 	if m.approvalModel != nil || m.askUserModel != nil || m.handoverPreview != nil {
 		contentChanged = true
+		contentDirty = true
 	}
 	if contentChanged {
 		now := time.Now()
@@ -269,10 +274,20 @@ func (m *Model) viewAltScreen() string {
 
 	// Force re-render when selection changes
 	selectionChanged := m.selection != m.viewCache.lastSelection
-	needViewRender := contentChanged || yOffsetChanged || xOffsetChanged || sizeChanged || selectionChanged || m.viewCache.lastViewportView == ""
+	needViewRender := contentChanged || waveOnlyChanged || yOffsetChanged || xOffsetChanged || sizeChanged || selectionChanged || m.viewCache.lastViewportView == ""
 	if needViewRender {
 		viewStart := time.Now()
-		m.viewCache.lastViewportView = m.viewport.View()
+		if waveOnlyChanged && !contentDirty {
+			streamingContent = m.renderStreamingInline()
+			contentLines = m.renderAltScreenStreamingContentLines(streamingContent)
+			m.viewCache.lastViewportView = m.renderAltScreenViewportLines(contentLines)
+			m.viewCache.lastContentStr = ""
+			m.contentLines = contentLines
+			m.viewCache.lastContentHistoryPlusStream = true
+			m.viewCache.lastStreamingContent = streamingContent
+		} else {
+			m.viewCache.lastViewportView = m.viewport.View()
+		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricViewportView, time.Since(viewStart))
 		}
@@ -1417,6 +1432,62 @@ func (m *Model) shouldThrottleSetContent(now time.Time) bool {
 		return false
 	}
 	return now.Sub(m.viewCache.lastSetContentAt) < m.streamRenderMinInterval
+}
+
+func (m *Model) renderAltScreenStreamingContentLines(streamingContent string) []string {
+	return appendViewportContentLines(slices.Clone(m.viewCache.historyLines), streamingContent)
+}
+
+// renderAltScreenViewportLines renders the chat viewport directly from pre-wrapped
+// content lines. It's only used for wave-only tool animation frames, where the
+// visible text changes but the underlying viewport content/line count does not.
+func (m *Model) renderAltScreenViewportLines(lines []string) string {
+	w, h := m.viewport.Width(), m.viewport.Height()
+	if sw := m.viewport.Style.GetWidth(); sw != 0 && sw < w {
+		w = sw
+	}
+	if sh := m.viewport.Style.GetHeight(); sh != 0 && sh < h {
+		h = sh
+	}
+	if w == 0 || h == 0 {
+		return ""
+	}
+
+	contentWidth := w - m.viewport.Style.GetHorizontalFrameSize()
+	contentHeight := h - m.viewport.Style.GetVerticalFrameSize()
+	if contentWidth < 0 {
+		contentWidth = 0
+	}
+	if contentHeight < 0 {
+		contentHeight = 0
+	}
+
+	yOffset := m.viewport.YOffset()
+	if yOffset < 0 {
+		yOffset = 0
+	}
+	if yOffset > len(lines) {
+		yOffset = len(lines)
+	}
+	bottom := yOffset + contentHeight
+	if bottom > len(lines) {
+		bottom = len(lines)
+	}
+
+	visible := slices.Clone(lines[yOffset:bottom])
+	if xOffset := m.viewport.XOffset(); xOffset > 0 && contentWidth > 0 {
+		for i := range visible {
+			visible[i] = ansi.Cut(visible[i], xOffset, xOffset+contentWidth)
+		}
+	}
+
+	rendered := lipgloss.NewStyle().
+		Width(contentWidth).
+		Height(contentHeight).
+		Render(strings.Join(visible, "\n"))
+	return m.viewport.Style.
+		UnsetWidth().UnsetHeight().
+		Render(rendered)
 }
 
 // tryAppendAltScreenStreamingContent reuses the previously rendered viewport

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -64,6 +64,7 @@ func TestTryAppendAltScreenStreamingContent_AppendsTailLines(t *testing.T) {
 
 func TestInvalidateHistoryCache_ResetsAltScreenStreamingAppendCache(t *testing.T) {
 	m := &Model{}
+	m.viewCache.historyLines = []string{"old history"}
 	m.viewCache.lastContentHistoryPlusStream = true
 	m.viewCache.lastContentStr = "old history\nassistant"
 	m.viewCache.lastStreamingContent = "assistant"
@@ -71,6 +72,9 @@ func TestInvalidateHistoryCache_ResetsAltScreenStreamingAppendCache(t *testing.T
 
 	m.invalidateHistoryCache()
 
+	if m.viewCache.historyLines != nil {
+		t.Fatalf("expected cached history lines to be cleared, got %#v", m.viewCache.historyLines)
+	}
 	if m.viewCache.lastContentHistoryPlusStream {
 		t.Fatal("expected append cache to be disabled after history invalidation")
 	}
@@ -93,6 +97,37 @@ func TestTryAppendAltScreenStreamingContent_FallsBackOnRewrite(t *testing.T) {
 
 	if _, ok := m.tryAppendAltScreenStreamingContent("rewritten assistant"); ok {
 		t.Fatal("expected rewrite to force full viewport rebuild")
+	}
+}
+
+func TestViewAltScreen_WaveTickRerendersWithoutSetContent(t *testing.T) {
+	m := newTestChatModel(true)
+	m.width = 80
+	m.height = 20
+	m.syncAltScreenViewportHeight(m.buildFooterLayout().height)
+	m.streaming = true
+	m.tracker.HandleToolStart("call-1", "read_file", "(very-long-file-name.go)", nil)
+	m.tracker.WavePos = 0
+
+	first := m.View().Content
+	firstContentVersion := m.viewCache.contentVersion
+	firstRenderedVersion := m.viewCache.lastRenderedVersion
+	firstSetContentAt := m.viewCache.lastSetContentAt
+
+	_, _ = m.Update(ui.WaveTickMsg{})
+	second := m.View().Content
+
+	if m.viewCache.contentVersion != firstContentVersion {
+		t.Fatalf("wave-only tick should not bump contentVersion: before=%d after=%d", firstContentVersion, m.viewCache.contentVersion)
+	}
+	if m.viewCache.lastRenderedVersion != firstRenderedVersion {
+		t.Fatalf("wave-only tick should not advance lastRenderedVersion: before=%d after=%d", firstRenderedVersion, m.viewCache.lastRenderedVersion)
+	}
+	if !m.viewCache.lastSetContentAt.Equal(firstSetContentAt) {
+		t.Fatalf("wave-only tick should not call SetContent: before=%v after=%v", firstSetContentAt, m.viewCache.lastSetContentAt)
+	}
+	if first == second {
+		t.Fatal("expected wave-only tick to change rendered output")
 	}
 }
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -722,6 +722,7 @@ func (m *Model) maybeRenameHandoverCmd() tea.Cmd {
 
 func (m *Model) invalidateViewCache() {
 	m.viewCache.historyValid = false
+	m.viewCache.historyLines = nil
 	m.viewCache.completedStream = ""
 	m.viewCache.cachedCompletedContent = ""
 	m.viewCache.cachedTrackerVersion = 0
@@ -738,6 +739,7 @@ func (m *Model) invalidateViewCache() {
 
 func (m *Model) invalidateHistoryCache() {
 	m.viewCache.historyValid = false
+	m.viewCache.historyLines = nil
 	m.resetAltScreenStreamingAppendCache()
 	m.invalidateContextEstimateCache()
 	if m.chatRenderer != nil {


### PR DESCRIPTION
## What

- stop treating pending-tool wave animation ticks as viewport content changes in alt-screen mode
- cache split history lines and synthesize wave-only frames directly for the visible viewport instead of calling `viewport.SetContent(...)`
- add regression coverage that wave ticks still repaint the animated row without advancing `contentVersion`/`lastRenderedVersion`

## Why

Pending-tool wave animation was bumping `contentVersion` on every 50ms tick, which forced a full alt-screen viewport content reset even though only the existing tool row styling changed. On long sessions that means repeatedly rebuilding and re-sending the whole history + stream tail through Bubble Tea, causing avoidable tool-execution jank and rougher scrolling. This keeps the animation smooth while leaving the expensive viewport content update path for real content changes only.
