### PR TITLE
fix: Subagent progress uses one goroutine per UI event, removing backpressure and allowing message storms

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -1230,7 +1230,8 @@ func newAskRendererProgram(cfg *config.Config, toolMgr *tools.ToolManager, store
 
 	if spawnTool := toolMgr.GetSpawnAgentTool(); spawnTool != nil {
 		spawnTool.SetEventCallback(func(callID string, event tools.SubagentEvent) {
-			go teaProgram.Send(askSubagentProgressMsg{CallID: callID, Event: event})
+			// Send synchronously so the TUI naturally backpressures bursty subagent updates.
+			teaProgram.Send(askSubagentProgressMsg{CallID: callID, Event: event})
 		})
 	}
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -491,8 +491,8 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	if toolMgr != nil {
 		if spawnTool := toolMgr.GetSpawnAgentTool(); spawnTool != nil {
 			spawnTool.SetEventCallback(func(callID string, event tools.SubagentEvent) {
-				// Use goroutine to avoid blocking subagent execution if TUI message channel backs up
-				go p.Send(chat.SubagentProgressMsg{CallID: callID, Event: event})
+				// Send synchronously so the TUI naturally backpressures bursty subagent updates.
+				p.Send(chat.SubagentProgressMsg{CallID: callID, Event: event})
 			})
 		}
 	}


### PR DESCRIPTION
## What

- stop wrapping each subagent progress `Program.Send` call in its own goroutine
- send `spawn_agent` progress updates synchronously in both the chat TUI and ask renderer paths
- keep the fix narrowly scoped to the subagent progress callback wiring

## Why

`spawn_runner` emits `SubagentEventText` for every streamed text delta. Launching a fresh goroutine for every UI event removes Bubble Tea's natural backpressure, so a busy subagent can build up an unbounded backlog of goroutines and stale progress messages whenever the UI falls behind.

Sending these progress messages synchronously restores backpressure, preventing message storms from amplifying latency and jitter in the parent UI. The same callback pattern existed in the ask renderer, so it was fixed there as well to avoid the same behavior outside chat.
