### PR TITLE
perf: reduce memory vector search row loading

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"container/heap"
 	"context"
 	"crypto/rand"
 	"database/sql"
@@ -1068,13 +1069,38 @@ func (s *Store) GetFragmentsNeedingEmbedding(ctx context.Context, agent, provide
 }
 
 const vectorSearchSQL = `
-		SELECT f.id, f.agent, f.path, f.content, f.source, f.created_at, f.updated_at,
-		       f.accessed_at, f.access_count, f.decay_score, f.pinned,
+		SELECT e.fragment_id,
+		       f.updated_at,
 		       e.vector
 		FROM memory_embeddings e
 		JOIN memory_fragments f ON f.id = e.fragment_id
 		WHERE e.provider = ? AND e.model = ? AND e.dimensions = ?
 		  AND (? = '' OR f.agent = ?)`
+
+type vectorSearchCandidate struct {
+	id        string
+	updatedAt time.Time
+	score     float64
+	vector    []float64
+}
+
+type vectorSearchCandidateHeap []vectorSearchCandidate
+
+func (h vectorSearchCandidateHeap) Len() int { return len(h) }
+func (h vectorSearchCandidateHeap) Less(i, j int) bool {
+	return vectorSearchCandidateWorse(h[i], h[j])
+}
+func (h vectorSearchCandidateHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *vectorSearchCandidateHeap) Push(x any) {
+	*h = append(*h, x.(vectorSearchCandidate))
+}
+func (h *vectorSearchCandidateHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
 
 // VectorSearch performs a cosine similarity scan over embeddings matching provider, model, and dimensions.
 func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string, queryVec []float64, limit int) ([]ScoredFragment, error) {
@@ -1097,11 +1123,124 @@ func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string,
 	}
 	defer rows.Close()
 
-	matches := make([]ScoredFragment, 0, limit)
+	// Keep only the best candidates while scanning. The previous implementation
+	// selected every fragment column (including large content bodies), retained a
+	// ScoredFragment for every embedding, sorted the full slice, and then sliced
+	// to limit. Memory search normally asks for the top 24 candidates, so fetch
+	// heavyweight fragment rows only for those winners after scoring.
+	top := make(vectorSearchCandidateHeap, 0, limit)
+	for rows.Next() {
+		var c vectorSearchCandidate
+		var payload []byte
+		if err := rows.Scan(&c.id, &c.updatedAt, &payload); err != nil {
+			return nil, fmt.Errorf("scan vector search row: %w", err)
+		}
+
+		if err := json.Unmarshal(payload, &c.vector); err != nil {
+			return nil, fmt.Errorf("decode stored vector for fragment %s: %w", c.id, err)
+		}
+		c.score = embedding.CosineSimilarity(queryVec, c.vector)
+
+		if top.Len() < limit {
+			heap.Push(&top, c)
+			continue
+		}
+
+		if vectorSearchCandidateBetter(c, top[0]) {
+			top[0] = c
+			heap.Fix(&top, 0)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(top) == 0 {
+		return []ScoredFragment{}, nil
+	}
+
+	sort.Slice(top, func(i, j int) bool {
+		return vectorSearchCandidateBetter(top[i], top[j])
+	})
+
+	ids := make([]string, 0, len(top))
+	for _, c := range top {
+		ids = append(ids, c.id)
+	}
+	fragments, err := s.getFragmentsByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]ScoredFragment, 0, len(top))
+	for _, c := range top {
+		r, ok := fragments[c.id]
+		if !ok {
+			continue
+		}
+		r.Score = c.score
+		r.Vector = c.vector
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func vectorSearchCandidateBetter(a, b vectorSearchCandidate) bool {
+	if a.score == b.score {
+		return a.updatedAt.After(b.updatedAt)
+	}
+	return a.score > b.score
+}
+
+func vectorSearchCandidateWorse(a, b vectorSearchCandidate) bool {
+	if a.score == b.score {
+		return a.updatedAt.Before(b.updatedAt)
+	}
+	return a.score < b.score
+}
+
+const fragmentByIDBatchSize = 500
+
+func (s *Store) getFragmentsByIDs(ctx context.Context, ids []string) (map[string]ScoredFragment, error) {
+	out := make(map[string]ScoredFragment, len(ids))
+	for start := 0; start < len(ids); start += fragmentByIDBatchSize {
+		end := start + fragmentByIDBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := s.getFragmentsByIDBatch(ctx, ids[start:end], out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (s *Store) getFragmentsByIDBatch(ctx context.Context, ids []string, out map[string]ScoredFragment) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = strings.TrimSuffix(placeholders, ",")
+	query := fmt.Sprintf(`
+		SELECT id, agent, path, content, source, created_at, updated_at,
+		       accessed_at, access_count, decay_score, pinned
+		FROM memory_fragments
+		WHERE id IN (%s)`, placeholders)
+
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("get fragments by ids: %w", err)
+	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var r ScoredFragment
 		var accessedAt sql.NullTime
-		var payload []byte
 		if err := rows.Scan(
 			&r.ID,
 			&r.Agent,
@@ -1114,36 +1253,19 @@ func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string,
 			&r.AccessCount,
 			&r.DecayScore,
 			&r.Pinned,
-			&payload,
 		); err != nil {
-			return nil, fmt.Errorf("scan vector search row: %w", err)
+			return fmt.Errorf("scan fragment by id: %w", err)
 		}
 		if accessedAt.Valid {
 			at := accessedAt.Time
 			r.AccessedAt = &at
 		}
-
-		if err := json.Unmarshal(payload, &r.Vector); err != nil {
-			return nil, fmt.Errorf("decode stored vector for fragment %s: %w", r.ID, err)
-		}
-		r.Score = embedding.CosineSimilarity(queryVec, r.Vector)
-		matches = append(matches, r)
+		out[r.ID] = r
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return err
 	}
-
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].Score == matches[j].Score {
-			return matches[i].UpdatedAt.After(matches[j].UpdatedAt)
-		}
-		return matches[i].Score > matches[j].Score
-	})
-
-	if len(matches) > limit {
-		matches = matches[:limit]
-	}
-	return matches, nil
+	return nil
 }
 
 // BumpAccess marks a fragment as recently accessed, increments access_count,

--- a/internal/memory/vector_search_bench_test.go
+++ b/internal/memory/vector_search_bench_test.go
@@ -1,0 +1,153 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoreVectorSearchLargeLimitFetchesFragmentsInBatches(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewStore(Config{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	count := fragmentByIDBatchSize + 5
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	fragStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO memory_fragments (id, agent, path, content, source, created_at, updated_at, decay_score, pinned)
+		VALUES (?, 'agent', ?, 'content', 'test', ?, ?, 1.0, 0)`)
+	if err != nil {
+		t.Fatalf("prepare fragment insert: %v", err)
+	}
+	defer fragStmt.Close()
+
+	embStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO memory_embeddings (fragment_id, provider, model, dimensions, vector, embedded_at)
+		VALUES (?, 'test', 'model', 2, '[1,0]', ?)`)
+	if err != nil {
+		t.Fatalf("prepare embedding insert: %v", err)
+	}
+	defer embStmt.Close()
+
+	base := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < count; i++ {
+		id := fmt.Sprintf("large-limit-%03d", i)
+		updatedAt := base.Add(time.Duration(i) * time.Second)
+		if _, err := fragStmt.ExecContext(ctx, id, fmt.Sprintf("path/%03d", i), base, updatedAt); err != nil {
+			t.Fatalf("insert fragment %d: %v", i, err)
+		}
+		if _, err := embStmt.ExecContext(ctx, id, updatedAt); err != nil {
+			t.Fatalf("insert embedding %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	results, err := store.VectorSearch(ctx, "agent", "test", "model", []float64{1, 0}, count)
+	if err != nil {
+		t.Fatalf("VectorSearch: %v", err)
+	}
+	if len(results) != count {
+		t.Fatalf("got %d results, want %d", len(results), count)
+	}
+	if want := fmt.Sprintf("large-limit-%03d", count-1); results[0].ID != want {
+		t.Fatalf("top result = %s, want newest tied result %s", results[0].ID, want)
+	}
+}
+
+func BenchmarkStoreVectorSearchLargeCorpus(b *testing.B) {
+	ctx := context.Background()
+	store, err := NewStore(Config{Path: ":memory:"})
+	if err != nil {
+		b.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	const (
+		fragmentCount = 3000
+		dimensions    = 128
+		limit         = 24
+	)
+	seedLargeVectorSearchBenchmark(b, ctx, store, fragmentCount, dimensions)
+	queryVec := largeBenchmarkVector(99_999, dimensions)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results, err := store.VectorSearch(ctx, "agent", "test", "model", queryVec, limit)
+		if err != nil {
+			b.Fatalf("VectorSearch: %v", err)
+		}
+		if len(results) != limit {
+			b.Fatalf("got %d results, want %d", len(results), limit)
+		}
+	}
+}
+
+func seedLargeVectorSearchBenchmark(b *testing.B, ctx context.Context, store *Store, fragmentCount, dimensions int) {
+	b.Helper()
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		b.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	fragStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO memory_fragments (id, agent, path, content, source, created_at, updated_at, decay_score, pinned)
+		VALUES (?, 'agent', ?, ?, 'bench', ?, ?, 1.0, 0)`)
+	if err != nil {
+		b.Fatalf("prepare fragment insert: %v", err)
+	}
+	defer fragStmt.Close()
+
+	embStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO memory_embeddings (fragment_id, provider, model, dimensions, vector, embedded_at)
+		VALUES (?, 'test', 'model', ?, ?, ?)`)
+	if err != nil {
+		b.Fatalf("prepare embedding insert: %v", err)
+	}
+	defer embStmt.Close()
+
+	base := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	content := strings.Repeat("This is representative memory content with enough bytes to make unnecessary row reads visible. ", 32)
+	for i := 0; i < fragmentCount; i++ {
+		id := fmt.Sprintf("frag-%05d", i)
+		updatedAt := base.Add(time.Duration(i) * time.Second)
+		if _, err := fragStmt.ExecContext(ctx, id, fmt.Sprintf("path/%05d", i), content, base, updatedAt); err != nil {
+			b.Fatalf("insert fragment %d: %v", i, err)
+		}
+
+		payload, err := json.Marshal(largeBenchmarkVector(i, dimensions))
+		if err != nil {
+			b.Fatalf("marshal vector %d: %v", i, err)
+		}
+		if _, err := embStmt.ExecContext(ctx, id, dimensions, payload, updatedAt); err != nil {
+			b.Fatalf("insert embedding %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("Commit: %v", err)
+	}
+}
+
+func largeBenchmarkVector(seed, dimensions int) []float64 {
+	v := make([]float64, dimensions)
+	for i := range v {
+		x := float64((seed+1)*(i+17)) * 0.01337
+		v[i] = math.Sin(x) + 0.5*math.Cos(x*0.7)
+	}
+	return v
+}


### PR DESCRIPTION
## What

Optimize memory vector search so it no longer loads full fragment rows for every matching embedding before ranking.

VectorSearch now:
- scans only fragment id, updated_at, and embedding vector while scoring;
- keeps a bounded top-k heap instead of retaining and sorting every match;
- fetches heavyweight fragment fields (including content) only for the winning candidates;
- batches the follow-up fragment fetch so large limits do not exceed SQLite bind-variable limits.

A regression test covers a limit larger than the fragment fetch batch size, and a large-corpus benchmark captures the intended memory-search workload.

## Why

Hybrid memory search usually asks for a small candidate set (24), but the previous VectorSearch path selected large content bodies and built ScoredFragment values for every matching embedding before slicing to the limit. As memory grows, that creates avoidable row I/O, allocations, and sorting work on the interactive memory search path.

## Evidence

Representative benchmark: 3,000 fragments, 128-dimensional embeddings, ~2.8KB fragment content, limit 24.

Before:

```
BenchmarkStoreVectorSearchLargeCorpus-32  14-15  74.5-77.1 ms/op  45.6 MB/op  117044-117045 allocs/op
```

After:

```
BenchmarkStoreVectorSearchLargeCorpus-32  15-16  66.4-68.0 ms/op  23.6 MB/op  63739-63744 allocs/op
```

That is roughly 10% lower latency, 48% less allocated memory, and 45% fewer allocations for the benchmarked path.

## Verification

- `go test ./internal/memory -run 'TestStoreVectorSearch'`
- `go test ./internal/memory -run '^$' -bench BenchmarkStoreVectorSearchLargeCorpus -benchmem -count=5`
- `go test ./...`
- `go build ./...`
