### PR TITLE
feat: enumerate contain default skills

### DIFF
--- a/cmd/contain.go
+++ b/cmd/contain.go
@@ -227,6 +227,9 @@ var containImageSyncCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Synced contain image %q to %s\n", result.Name, result.Dir)
+		if skills, err := contain.AgentImageBootstrapSkillNames(); err == nil && len(skills) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Default skills: %s\n", strings.Join(skills, ", "))
+		}
 		for _, file := range result.Files {
 			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", file)
 		}
@@ -346,6 +349,9 @@ func printContainNextSteps(cmd *cobra.Command, name string, started bool) {
 	}
 	if hasContainExecRecipe(name, "agent") {
 		fmt.Fprintf(cmd.OutOrStdout(), "  Chat with agent: term-llm contain exec %s agent\n", name)
+		if skills, err := contain.AgentImageBootstrapSkillNames(); err == nil && len(skills) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "  Default skills: %s\n", strings.Join(skills, ", "))
+		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "  Open shell: term-llm contain shell %s\n", name)
 	fmt.Fprintf(cmd.OutOrStdout(), "  Run command/recipe: term-llm contain exec %s <cmd-or-recipe> [args...]\n", name)

--- a/cmd/contain_test.go
+++ b/cmd/contain_test.go
@@ -98,6 +98,9 @@ func TestContainNewDefaultTemplateIsAgent(t *testing.T) {
 	if !strings.Contains(stdout, "Web UI: http://localhost:8282/chat") || !strings.Contains(stdout, "Web UI bearer token:") {
 		t.Fatalf("stdout missing default agent web UI info/token: %q", stdout)
 	}
+	if !strings.Contains(stdout, "Default skills: jobs, memory, self") {
+		t.Fatalf("stdout missing default skills enumeration: %q", stdout)
+	}
 	composePath, err := contain.ComposePath("defaultagent")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/contain/images.go
+++ b/internal/contain/images.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"embed"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -111,6 +112,32 @@ func BuiltinImageNames() []string {
 	names := append([]string(nil), builtinImageNames...)
 	sort.Strings(names)
 	return names
+}
+
+// AgentImageBootstrapSkillNames returns the term-llm skill names bundled into
+// the managed agent image bootstrap. These are copied into
+// ~/.config/term-llm/skills/ on first boot of an agent contain workspace.
+func AgentImageBootstrapSkillNames() ([]string, error) {
+	base := filepath.ToSlash(filepath.Join("images", "agent", "bootstrap", "skills"))
+	entries, err := embeddedImages.ReadDir(base)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded agent bootstrap skills: %w", err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := embeddedImages.ReadFile(filepath.ToSlash(filepath.Join(base, entry.Name(), "SKILL.md"))); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 // SyncImage writes a managed embedded image asset into the user's config dir.

--- a/internal/contain/images/agent/README.md
+++ b/internal/contain/images/agent/README.md
@@ -26,7 +26,7 @@ This directory is a complete Docker build context. It contains:
     bootstrap/system.md
     bootstrap/soul.md
     bootstrap/services/
-    bootstrap/skills/
+    bootstrap/skills/          # default skills: jobs, memory, self
     bootstrap/scripts/
 
 The image bakes those bootstrap files into `/opt/term-llm/bootstrap`.

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -7,6 +7,18 @@ import (
 	"testing"
 )
 
+func TestAgentImageBootstrapSkillNames(t *testing.T) {
+	names, err := AgentImageBootstrapSkillNames()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(names, ",")
+	want := "jobs,memory,self"
+	if got != want {
+		t.Fatalf("AgentImageBootstrapSkillNames() = %q, want %q", got, want)
+	}
+}
+
 func TestSyncImageWritesAgentAsset(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	result, err := SyncImage("agent", false)

--- a/internal/contain/templates/agent/README.md
+++ b/internal/contain/templates/agent/README.md
@@ -59,6 +59,15 @@ Stop without deleting state:
 term-llm contain stop {{name}}
 ```
 
+## Default skills
+
+The managed agent image seeds these term-llm skills into
+`/home/agent/.config/term-llm/skills/` on first boot:
+
+- `jobs` — inspect and manage scheduled/background jobs
+- `memory` — search and update persistent agent memory
+- `self` — safely modify the agent's own prompt and configuration
+
 ## Widgets
 
 The Web UI starts with term-llm widgets enabled. Add widget apps under


### PR DESCRIPTION
## What

- Add a contain helper that enumerates the managed agent image's bundled bootstrap skills.
- Print the default skills in `term-llm contain new` next steps for agent workspaces.
- Print the default skills from `term-llm contain image sync`.
- Document the seeded default skills in the agent workspace/image READMEs.

## Verification

- `go test ./cmd ./internal/contain`
- `go build ./...`
- Smoke: `XDG_CONFIG_HOME=$(mktemp -d) go run . contain new sample --no-input --set provider=skip`
- `go test ./...` initially hit a flaky `internal/llm` websocket test, then `go test ./internal/llm` passed on rerun.
