### PR TITLE
feat: add widgets skill to contain agent

### DIFF
--- a/docs-site/content/guides/agent-containers.md
+++ b/docs-site/content/guides/agent-containers.md
@@ -187,7 +187,7 @@ They are served under:
 /chat/widgets/<widget-name>/
 ```
 
-The bundled `widgets` skill documents the operational workflow: inspect widget support, create manifests, restart `webui` if needed, and smoke-test routes.
+The bundled `widgets` skill documents the operational workflow: inspect widget support, create manifests, reload the widget registry through `/chat/admin/widgets/reload`, and smoke-test routes. You do not need to restart the Web UI just to add or update a widget; restart it only for service flag changes, binary upgrades, or if the admin reload endpoint is unavailable.
 
 ## Updating
 

--- a/docs-site/content/guides/agent-containers.md
+++ b/docs-site/content/guides/agent-containers.md
@@ -73,7 +73,9 @@ Shells open as the non-root `agent` user in `/home/agent`. Use explicit password
 
 ## What gets bootstrapped
 
-The Compose service builds the managed agent image and mounts one persistent Docker volume at `/home/agent`. On first boot, the image copies bootstrap files from `/opt/term-llm/bootstrap` into that volume:
+The Compose service builds the managed agent image and mounts one persistent Docker volume at `/home/agent`. On first boot, the image copies bootstrap files from `/opt/term-llm/bootstrap` into that volume. The image also seeds the term-llm source checkout at `/home/agent/source/term-llm`, with documentation under `/home/agent/source/term-llm/docs-site/content`.
+
+Use `/home/agent/source/<project>` for source checkouts and code projects you want to persist. Use `/home/agent/Files` for downloadable files served by the Web UI. Avoid putting durable work in `/tmp`, `/root`, or other image-only paths.
 
 ```text
 /home/agent/.config/term-llm/
@@ -92,6 +94,8 @@ The Compose service builds the managed agent image and mounts one persistent Doc
 │   ├── memory/SKILL.md
 │   ├── self/SKILL.md
 │   └── widgets/SKILL.md
+├── source/
+│   └── term-llm/        # runtime source and docs-site/content documentation
 └── init.sh
 ```
 

--- a/docs-site/content/guides/agent-containers.md
+++ b/docs-site/content/guides/agent-containers.md
@@ -1,183 +1,229 @@
 ---
 title: "Agent Containers"
 weight: 15
-description: "Run independent term-llm agents in Docker: one container per agent, fully isolated, no image rebuild needed."
+description: "Create isolated, persistent term-llm agents with the built-in Docker Compose workspace manager."
 kicker: "Deploy agents"
 ---
 
-Each agent gets its own Docker container, its own compose file, and its own state volume. Adding a new agent never touches an existing one.
+`term-llm contain` creates named Docker Compose workspaces for long-running agents. Each workspace has its own compose file, `.env`, Docker volume, Web UI, jobs service, memory database, sessions, skills, and agent configuration.
+
+The current happy path is `term-llm contain new` followed by `term-llm contain start`. You do not need to clone the term-llm repo or hand-copy seed directories.
 
 ## Prerequisites
 
 - Docker with Compose v2
-- A clone of the term-llm repo
-- At least one LLM API key (Anthropic, OpenAI, Venice, etc.)
+- `term-llm` installed on the host
+- At least one provider credential, or a plan to configure credentials inside the container later
 
-## Scaffold a new agent
-
-From the term-llm repo root:
+## Create an agent workspace
 
 ```bash
-docker/init.sh myagent
+term-llm contain new myagent
 ```
 
-This creates a standalone project directory:
+By default this uses the managed `agent` template. It creates a global workspace under your term-llm config directory:
 
-```
-myagent/
-├── docker-compose.yml
-├── .env                ← API keys, web token
-├── init.sh             ← boot hook (installs runit services)
-├── agents/
-│   └── myagent/
-│       ├── agent.yaml
-│       ├── soul.md      ← voice, values, personality
-│       └── system.md    ← operational context
-└── services/
-    ├── webui/run           ← web UI on port 8081
-    ├── jobs/run            ← job scheduler
-    └── bootstrap-jobs/run  ← creates default jobs on first boot
+```text
+~/.config/term-llm/containers/myagent/
+├── compose.yaml       # source of truth for Docker Compose
+├── .env               # provider credentials, Web UI token/port, image settings
+└── README.md          # workspace-specific commands and notes
 ```
 
-You can also specify a custom output directory:
+`contain new` prompts for provider credentials and useful settings unless you pass `--no-input` and `--set` values:
 
 ```bash
-docker/init.sh myagent ~/agents/myagent
+term-llm contain new myagent \
+  --no-input \
+  --set provider=anthropic \
+  --set web_port=8081
 ```
 
-## Configure
+The generated `.env` is private (`0600`). It contains the selected provider, optional API keys/OAuth bootstrap data, `WEB_PORT`, `WEB_BASE_PATH`, and a generated `WEB_TOKEN` for bearer-authenticated Web UI access.
 
-### API keys
+## Start and open it
 
-Edit `.env` and add at least one API key:
+If you did not start it from the creation prompt:
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-...
+term-llm contain start myagent
 ```
 
-The `.env` file also has a pre-generated `WEB_TOKEN` for authenticating the web UI and a `WEB_PORT` you can change if running multiple agents.
+The Web UI is exposed at:
 
-### Personality
-
-The scaffold separates personality from operations:
-
-- **`soul.md`**: voice, values, and boundaries. This is who the agent *is*. Edit it to change tone, principles, or guardrails.
-- **`system.md`**: operational context. Who the user is, what tools are available, domain-specific instructions. Edit it to change what the agent *knows about its environment*.
-
-Both files are bind-mounted into the container as seed files. On first boot they are copied into the agent's config directory on the state volume. After that, the container owns them. Your local copies are the seed, not the live version.
-
-### Agent settings
-
-`agent.yaml` controls model, tools, and behavior:
-
-```yaml
-name: myagent
-description: "AI assistant"
-include: ["soul.md"]
-tools:
-  enabled: [read_file, write_file, edit_file, glob, grep, shell, ...]
-shell:
-  auto_run: true
-  allow: ["*"]
-max_turns: 200
-search: true
+```text
+http://localhost:<WEB_PORT>/chat
 ```
 
-The `include` field loads additional markdown files (like `soul.md`) after the system prompt. See [Agents](/guides/agents/) for the full configuration reference.
+Use the bearer token printed by `contain new` or stored in the workspace `.env`.
 
-## Start
+You can also chat from the terminal using the built-in exec recipe:
 
 ```bash
-cd myagent
-docker compose up -d
+term-llm contain exec myagent agent
 ```
 
-The web UI will be at `http://localhost:8081/chat` (or whatever `WEB_PORT` you set).
+Open a shell inside the workspace:
 
-Authenticate with the bearer token from `.env`:
-
-```
-Authorization: Bearer <WEB_TOKEN>
+```bash
+term-llm contain shell myagent
 ```
 
-## How it works
+Shells open as the non-root `agent` user in `/home/agent`. Use explicit passwordless `sudo` when root privileges are needed.
 
-The container uses the same term-llm Docker image for every agent. No agent-specific files are baked into the image.
+## What gets bootstrapped
 
-On first boot, the entrypoint:
+The Compose service builds the managed agent image and mounts one persistent Docker volume at `/home/agent`. On first boot, the image copies bootstrap files from `/opt/term-llm/bootstrap` into that volume:
 
-1. Copies seed files from `/seed/` into the state volume (only if they don't already exist)
-2. Runs `/seed/init.sh` which installs runit services (web UI, job scheduler, job bootstrapper)
-3. Starts runit as PID 1
+```text
+/home/agent/.config/term-llm/
+├── agents/myagent/
+│   ├── agent.yaml
+│   ├── system.md
+│   ├── soul.md
+│   ├── memory/recent.md
+│   └── scripts/
+├── services/
+│   ├── webui/run
+│   ├── jobs/run
+│   └── bootstrap-jobs/run
+├── skills/
+│   ├── jobs/SKILL.md
+│   ├── memory/SKILL.md
+│   ├── self/SKILL.md
+│   └── widgets/SKILL.md
+└── init.sh
+```
 
-After the first boot, the state volume owns all agent config. Your local `agents/` directory remains the seed. Edit it and delete the volume to re-seed, or edit the live files inside the container directly.
+After first boot, the volume is the source of truth. Future boots ignore image bootstrap files and run `/home/agent/.config/term-llm/init.sh`, which reinstalls persisted runit service definitions into `/etc/sv` and links them into `/etc/runit/runsvdir`.
 
-The built-in `term-llm contain new` agent image keeps PID 1 and runit supervision as root so services can be linked under `/etc`, but the Web UI, jobs service, bootstrap jobs, interactive shells, and normal agent work run as the non-root Linux user `agent` with home `/home/agent`. Use explicit passwordless `sudo` inside the container for package maintenance or other root-only operations.
+The service supervisor runs as root. The Web UI, jobs server, bootstrap jobs, shells, and normal agent work run as the `agent` Linux user.
 
-### Services
+## Services
 
 | Service | What it does |
 |---|---|
-| `webui` | Web UI and HTTP API on port 8081 |
-| `jobs` | Background job scheduler |
-| `bootstrap-jobs` | Creates default scheduled jobs on first boot, then sleeps |
+| `webui` | Runs `term-llm serve web` on port `8081` inside the container. |
+| `jobs` | Runs `term-llm serve jobs` on port `8080` inside the container. |
+| `bootstrap-jobs` | Creates default scheduled jobs on first boot, then sleeps. |
 
-On first boot, the `bootstrap-jobs` service waits for the jobs API, then creates four default jobs:
+The Web UI service starts with file serving and widgets enabled:
+
+```bash
+term-llm serve web \
+  --agent myagent \
+  --base-path /chat \
+  --host 0.0.0.0 \
+  --port 8081 \
+  --auth bearer \
+  --yolo \
+  --files-dir /home/agent/Files \
+  --enable-widgets \
+  --widgets-dir /home/agent/.config/term-llm/widgets
+```
+
+Check service status from the host:
+
+```bash
+term-llm contain exec myagent -- sv status /etc/runit/runsvdir/webui/
+term-llm contain exec myagent -- sv status /etc/runit/runsvdir/jobs/
+```
+
+Restart a service:
+
+```bash
+term-llm contain exec myagent -- sudo sv restart /etc/runit/runsvdir/webui/
+```
+
+## Default jobs
+
+On first boot, `bootstrap-jobs` waits for the jobs API and creates:
 
 | Job | Schedule | What it does |
 |---|---|---|
-| `mine-sessions` | Every 30 min | Extracts memory fragments from session transcripts |
-| `update-recent` | Every 10 min | Promotes recent fragments into the agent's context |
-| `memory-gc` | Daily at 4am UTC | Garbage-collects stale or duplicate memory fragments |
-| `system-upgrade` | Daily at 5am | Keeps the container's distro packages current (`pacman` on Arch, `dnf` on Fedora) |
+| `mine-sessions` | Every 30 min | Mines session transcripts into memory fragments. |
+| `update-recent` | Every 10 min | Promotes recent fragments into `memory/recent.md`. |
+| `memory-gc` | Daily at 04:00 UTC | Garbage-collects stale or duplicate memory fragments. |
+| `system-upgrade` | Daily at 05:00 UTC | Upgrades distro packages (`pacman` on Arch, `dnf` on Fedora). |
 
-These jobs are yours after creation. Edit or delete them with `term-llm jobs list` and `term-llm jobs update`.
-
-All services are managed by runit. Check status:
+Inspect and operate them inside the workspace:
 
 ```bash
-docker exec myagent sv status /etc/runit/runsvdir/webui/
+term-llm contain exec myagent -- term-llm jobs list
+term-llm contain exec myagent -- term-llm jobs runs mine-sessions --limit 10
+term-llm contain exec myagent -- term-llm jobs update mine-sessions --data '{"enabled": false}'
 ```
 
-## Running multiple agents
+## Skills and memory
 
-Each scaffolded directory is fully independent. Run as many as you like:
+Fresh agent containers include a small default skill set:
 
-```bash
-docker/init.sh agent-a
-docker/init.sh agent-b ~/agents/agent-b
+| Skill | Purpose |
+|---|---|
+| `jobs` | Inspect and manage jobs and runit services. |
+| `memory` | Search and update persistent memory fragments. |
+| `self` | Safely modify the agent's own prompt/config/scripts. |
+| `widgets` | Build, install, inspect, and debug Web UI widgets. |
+
+Skills are copied to `/home/agent/.config/term-llm/skills/` and the first-boot `config.yaml` enables the skills system with auto-invocation.
+
+Memory fragments live in term-llm's database on the persistent volume. `memory/recent.md` is seeded empty and then maintained by the default jobs; do not edit it directly.
+
+## Widgets
+
+Add widget apps under:
+
+```text
+/home/agent/.config/term-llm/widgets/
 ```
 
-Set different `WEB_PORT` values in each `.env` to avoid port conflicts:
+They are served under:
 
-```bash
-# agent-a/.env
-WEB_PORT=8081
-
-# agent-b/.env
-WEB_PORT=8082
+```text
+/chat/widgets/<widget-name>/
 ```
 
-Each agent gets its own Docker volume for state, its own compose project, and its own container. They share only the term-llm image.
+The bundled `widgets` skill documents the operational workflow: inspect widget support, create manifests, restart `webui` if needed, and smoke-test routes.
 
 ## Updating
 
-When you pull a new version of term-llm, rebuild the image and restart:
+Update the host `term-llm` first, then rebuild/recreate the workspace image:
 
 ```bash
-cd myagent
-docker compose up -d --build
+term-llm contain rebuild myagent
 ```
 
-The state volume persists across rebuilds. Agent config, memory, and session history are preserved. The `init.sh` boot hook re-installs runit services on every boot, so new services added to your `services/` directory will be picked up automatically.
+State is preserved in the Docker volume. Rebuilds update the managed image and binary but do not overwrite the live agent config already copied into `/home/agent`.
 
-## Transcript access
+## Removing a workspace
 
-Session transcripts are stored in the state volume. To access them from the host:
+Stopping preserves state:
 
 ```bash
-docker exec myagent term-llm sessions list --agent myagent
-docker exec myagent term-llm sessions show <session-id> --agent myagent
+term-llm contain stop myagent
 ```
 
-The `mine-sessions` job automatically extracts key facts from transcripts into searchable memory fragments. See the bootstrapped jobs above for the full list of default scheduled tasks.
+Removal is destructive and asks for confirmation:
+
+```bash
+term-llm contain rm myagent
+```
+
+This runs Docker Compose down with volumes and deletes the workspace config directory.
+
+## Running multiple agents
+
+Each workspace is independent:
+
+```bash
+term-llm contain new agent-a --set web_port=8081
+term-llm contain new agent-b --set web_port=8082
+term-llm contain start agent-a
+term-llm contain start agent-b
+```
+
+Each gets its own Compose project, persistent volume, Web UI token, jobs, memory, sessions, and live agent files.
+
+## Advanced: custom bootstrap seed
+
+The managed image supports an optional static `/seed` mount containing `bootstrap.yaml`. If present, `/seed` replaces the image bootstrap source for first boot only. After the bootstrap sentinel exists on the volume, `/seed` is ignored. For normal use, prefer the built-in `contain new` template and edit the live files through the agent's self-modification workflow.

--- a/internal/contain/images/agent/README.md
+++ b/internal/contain/images/agent/README.md
@@ -26,7 +26,7 @@ This directory is a complete Docker build context. It contains:
     bootstrap/system.md
     bootstrap/soul.md
     bootstrap/services/
-    bootstrap/skills/
+    bootstrap/skills/          # default skills: jobs, memory, self, widgets
     bootstrap/scripts/
 
 The image bakes those bootstrap files into `/opt/term-llm/bootstrap`.

--- a/internal/contain/images/agent/bootstrap/services/jobs/run
+++ b/internal/contain/images/agent/bootstrap/services/jobs/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ "$(id -un)" != "agent" ]; then
-  exec sudo -Hu agent env \
+  exec sudo -E -Hu agent env \
     AGENT_NAME="${AGENT_NAME:-agent}" \
     TERM_LLM_PROVIDER="${TERM_LLM_PROVIDER:-}" \
     "$0" "$@"

--- a/internal/contain/images/agent/bootstrap/services/webui/run
+++ b/internal/contain/images/agent/bootstrap/services/webui/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ "$(id -un)" != "agent" ]; then
-  exec sudo -Hu agent env \
+  exec sudo -E -Hu agent env \
     AGENT_NAME="${AGENT_NAME:-agent}" \
     WEB_BASE_PATH="${WEB_BASE_PATH:-/chat}" \
     WEB_TOKEN="${WEB_TOKEN:-}" \
@@ -17,7 +17,8 @@ set -- serve web \
   --token "${WEB_TOKEN:?Set WEB_TOKEN in .env}" \
   --yolo \
   --files-dir /home/agent/Files \
-  --enable-widgets
+  --enable-widgets \
+  --widgets-dir /home/agent/.config/term-llm/widgets
 
 if [ -n "${TERM_LLM_PROVIDER:-}" ] && [ "${TERM_LLM_PROVIDER}" != "skip" ]; then
   set -- "$@" --provider "${TERM_LLM_PROVIDER}"

--- a/internal/contain/images/agent/bootstrap/skills/widgets/SKILL.md
+++ b/internal/contain/images/agent/bootstrap/skills/widgets/SKILL.md
@@ -58,13 +58,23 @@ rg "widget.yaml|enable-widgets|widgets-dir" /home/agent/source/term-llm
 ```
 
 2. Add or edit files under the widgets directory.
-3. Restart the Web UI service if the manager does not pick up the change:
+3. Reload the widget registry; do not restart the whole Web UI just to pick up a new widget:
 
 ```bash
-sudo sv restart /etc/runit/runsvdir/webui
+curl -fsS -X POST \
+  -H "Authorization: Bearer ${WEB_TOKEN}" \
+  http://127.0.0.1:8081/chat/admin/widgets/reload
 ```
 
-4. Smoke the route:
+4. Inspect widget status and load errors:
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer ${WEB_TOKEN}" \
+  http://127.0.0.1:8081/chat/admin/widgets/status
+```
+
+5. Smoke the route:
 
 ```bash
 curl -i http://127.0.0.1:8081/chat/widgets/<widget-name>/
@@ -77,4 +87,5 @@ For authenticated browser access use the Web UI token from the workspace `.env`.
 - Keep widget state and source in the persistent `/home/agent/.config/term-llm/widgets` directory unless the user asks for a project-local mount.
 - Prefer small, inspectable apps over framework sprawl.
 - Do not expose secrets through static assets or client-side JavaScript.
-- After changing widgets or service flags, restart `webui` and smoke test the widget route.
+- After adding, removing, or changing widget manifests, use `/chat/admin/widgets/reload`; do not restart `webui` just to rescan widgets.
+- Restart `webui` only for service flag changes, binary upgrades, or if the admin reload endpoint itself is unavailable.

--- a/internal/contain/images/agent/bootstrap/skills/widgets/SKILL.md
+++ b/internal/contain/images/agent/bootstrap/skills/widgets/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: widgets
+description: "Build, install, inspect, and debug term-llm Web UI widgets. Use when adding local widget apps, editing widget manifests, checking widget routes, or explaining how /chat/widgets works."
+---
+
+# Widgets
+
+Widgets are local web apps proxied by `term-llm serve web` under the Web UI base path.
+In this container the `webui` service starts with widgets enabled:
+
+```bash
+term-llm serve web \
+  --base-path "${WEB_BASE_PATH:-/chat}" \
+  --enable-widgets \
+  --widgets-dir /home/agent/.config/term-llm/widgets
+```
+
+Default widget directory:
+
+```bash
+/home/agent/.config/term-llm/widgets
+```
+
+Public route shape:
+
+```text
+/chat/widgets/<widget-name>/
+```
+
+Adjust `/chat` if `WEB_BASE_PATH` is set differently.
+
+## Widget layout
+
+Create one subdirectory per widget:
+
+```text
+/home/agent/.config/term-llm/widgets/
+└── example/
+    ├── widget.yaml
+    └── ... app files ...
+```
+
+`widget.yaml` is the manifest. Inspect existing widgets or the term-llm source for the exact supported fields before inventing a shape.
+
+Useful source paths:
+
+```bash
+/home/agent/source/term-llm/internal/widgets
+/home/agent/source/term-llm/cmd/serve.go
+```
+
+## Workflow
+
+1. Inspect existing widget support first:
+
+```bash
+rg "widget.yaml|enable-widgets|widgets-dir" /home/agent/source/term-llm
+```
+
+2. Add or edit files under the widgets directory.
+3. Restart the Web UI service if the manager does not pick up the change:
+
+```bash
+sudo sv restart /etc/runit/runsvdir/webui
+```
+
+4. Smoke the route:
+
+```bash
+curl -i http://127.0.0.1:8081/chat/widgets/<widget-name>/
+```
+
+For authenticated browser access use the Web UI token from the workspace `.env`.
+
+## Rules
+
+- Keep widget state and source in the persistent `/home/agent/.config/term-llm/widgets` directory unless the user asks for a project-local mount.
+- Prefer small, inspectable apps over framework sprawl.
+- Do not expose secrets through static assets or client-side JavaScript.
+- After changing widgets or service flags, restart `webui` and smoke test the widget route.

--- a/internal/contain/images/agent/bootstrap/system.md
+++ b/internal/contain/images/agent/bootstrap/system.md
@@ -16,8 +16,28 @@ The term-llm source code is checked out inside this container at:
 # also available as: ~/source/term-llm
 ```
 
+Documentation lives in that source tree at:
+
+```bash
+/home/agent/source/term-llm/docs-site/content
+```
+
 Use that source tree when you need to understand your runtime, available tools,
-agent configuration, memory system, jobs runner, or container bootstrap behavior.
+agent configuration, memory system, jobs runner, widgets, or container bootstrap
+behavior.
+
+## Workspace conventions
+
+Use persistent paths under `/home/agent` for user work. Put source checkouts and
+code projects under:
+
+```bash
+/home/agent/source/<project>
+```
+
+Do not put durable work in `/tmp`, `/root`, or image-only paths; those may vanish
+on rebuilds or are outside the normal non-root agent workspace. Use
+`/home/agent/Files` for files meant to be downloaded through the Web UI.
 
 ## REMOVE AFTER ONBOARDING
 

--- a/internal/contain/images/agent/bootstrap/system.md
+++ b/internal/contain/images/agent/bootstrap/system.md
@@ -73,13 +73,16 @@ Services are runit-managed processes installed under `/home/agent/.config/term-l
 
 ## Getting started
 
-Edit this file to add:
+Use this file to record operational context:
 - Who your user is and what they care about
 - What tools and services you have access to
 - Domain-specific instructions or constraints
 - Anything that should shape how you behave in this context
 
-Edit `soul.md` to change your voice, values, or personality.
+Do **not** edit `system.md` or `agent.yaml` directly. When the user asks you to
+change your behavior, context, tools, or model settings, use the self skill and
+patch scripts described below. Update `soul.md` for voice, values, or personality
+changes, again through the documented self-modification workflow.
 
 ## Memory
 

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -119,8 +119,8 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			t.Fatalf("bootstrap jobs should run as agent and use sudo for package upgrades")
 		}
 		if rel == "bootstrap/system.md" {
-			if !strings.Contains(string(data), "~/source/term-llm") {
-				t.Fatalf("system prompt missing term-llm source path")
+			if !strings.Contains(string(data), "~/source/term-llm") || !strings.Contains(string(data), "/home/agent/source/<project>") || !strings.Contains(string(data), "/home/agent/source/term-llm/docs-site/content") {
+				t.Fatalf("system prompt missing source workspace/docs paths")
 			}
 			for _, want := range []string{"## REMOVE AFTER ONBOARDING", "Learn what the user prefers to be called", "persistent memory", "## /REMOVE AFTER ONBOARDING"} {
 				if !strings.Contains(string(data), want) {

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -163,7 +163,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			}
 		}
 		if rel == "bootstrap/skills/widgets/SKILL.md" {
-			for _, want := range []string{"name: widgets", "--enable-widgets", "--widgets-dir /home/agent/.config/term-llm/widgets", "/chat/widgets/<widget-name>/", "sudo sv restart /etc/runit/runsvdir/webui"} {
+			for _, want := range []string{"name: widgets", "--enable-widgets", "--widgets-dir /home/agent/.config/term-llm/widgets", "/chat/widgets/<widget-name>/", "/chat/admin/widgets/reload", "/chat/admin/widgets/status"} {
 				if !strings.Contains(string(data), want) {
 					t.Fatalf("widgets skill missing %q", want)
 				}

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -132,6 +132,16 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 					t.Fatalf("system prompt missing action discipline detail %q", want)
 				}
 			}
+			for _, want := range []string{"Do **not** edit `system.md` or `agent.yaml` directly", "use the self skill", "patch scripts described below"} {
+				if !strings.Contains(string(data), want) {
+					t.Fatalf("system prompt missing self-modification guidance %q", want)
+				}
+			}
+			for _, forbidden := range []string{"Edit this file to add:", "Edit `soul.md` to change"} {
+				if strings.Contains(string(data), forbidden) {
+					t.Fatalf("system prompt still contains direct-edit guidance %q", forbidden)
+				}
+			}
 			for _, want := range []string{"## Jobs and Services", "term-llm jobs list", "bootstrap-jobs", "runit", "memory/recent.md"} {
 				if !strings.Contains(string(data), want) {
 					t.Fatalf("system prompt missing jobs/services detail %q", want)

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -47,7 +47,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			t.Fatalf("Dockerfile.fedora missing %q", want)
 		}
 	}
-	for _, rel := range []string{"entrypoint.sh", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh"} {
+	for _, rel := range []string{"entrypoint.sh", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh"} {
 		data, err := os.ReadFile(filepath.Join(result.Dir, rel))
 		if err != nil {
 			t.Fatalf("missing synced asset %s: %v", rel, err)
@@ -103,14 +103,17 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 		if (rel == "bootstrap/services/webui/run" || rel == "bootstrap/services/jobs/run") && !strings.Contains(string(data), "TERM_LLM_PROVIDER") {
 			t.Fatalf("service %s missing TERM_LLM_PROVIDER forwarding", rel)
 		}
-		if (rel == "bootstrap/services/webui/run" || rel == "bootstrap/services/jobs/run") && !strings.Contains(string(data), "exec sudo -Hu agent") {
-			t.Fatalf("service %s should re-exec as agent user", rel)
+		if (rel == "bootstrap/services/webui/run" || rel == "bootstrap/services/jobs/run") && !strings.Contains(string(data), "exec sudo -E -Hu agent") {
+			t.Fatalf("service %s should re-exec as agent user while preserving provider credentials", rel)
 		}
 		if rel == "bootstrap/services/webui/run" && !strings.Contains(string(data), "--files-dir /home/agent/Files") {
 			t.Fatalf("webui should serve files from agent home")
 		}
 		if rel == "bootstrap/services/webui/run" && !strings.Contains(string(data), "--enable-widgets") {
 			t.Fatalf("webui should enable widgets")
+		}
+		if rel == "bootstrap/services/webui/run" && !strings.Contains(string(data), "--widgets-dir /home/agent/.config/term-llm/widgets") {
+			t.Fatalf("webui should use the persistent agent widgets dir")
 		}
 		if rel == "bootstrap/services/bootstrap-jobs/run" && (!strings.Contains(string(data), "exec sudo -Hu agent") || !strings.Contains(string(data), `\"command\": \"sudo\"`) || !strings.Contains(string(data), `\"system-upgrade\"`) || !strings.Contains(string(data), `"pacman"`) || !strings.Contains(string(data), `"dnf"`)) {
 			t.Fatalf("bootstrap jobs should run as agent and use sudo for package upgrades")
@@ -146,6 +149,13 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			for _, want := range []string{"name: jobs", "term-llm jobs create", "term-llm jobs runs", "runner_type"} {
 				if !strings.Contains(string(data), want) {
 					t.Fatalf("jobs skill missing %q", want)
+				}
+			}
+		}
+		if rel == "bootstrap/skills/widgets/SKILL.md" {
+			for _, want := range []string{"name: widgets", "--enable-widgets", "--widgets-dir /home/agent/.config/term-llm/widgets", "/chat/widgets/<widget-name>/", "sudo sv restart /etc/runit/runsvdir/webui"} {
+				if !strings.Contains(string(data), want) {
+					t.Fatalf("widgets skill missing %q", want)
 				}
 			}
 		}

--- a/internal/contain/templates/agent/README.md
+++ b/internal/contain/templates/agent/README.md
@@ -61,9 +61,11 @@ term-llm contain stop {{name}}
 
 ## Widgets
 
-The Web UI starts with term-llm widgets enabled. Add widget apps under
-`/home/agent/.config/term-llm/widgets/` inside the container and open them from
-`/chat/widgets/` (or your configured `WEB_BASE_PATH` plus `/widgets/`).
+The Web UI starts with term-llm widgets enabled and uses
+`/home/agent/.config/term-llm/widgets/` as the widget directory. Add widget apps
+there and open them from `/chat/widgets/` (or your configured `WEB_BASE_PATH`
+plus `/widgets/`). The bundled `widgets` skill contains the operational workflow
+for creating, inspecting, restarting, and smoke-testing widget apps.
 
 ## Bootstrap model
 


### PR DESCRIPTION
## What

- Add a bundled `widgets` skill to the managed contain agent bootstrap.
- Make the `webui` service pass an explicit persistent widgets directory:
  `--widgets-dir /home/agent/.config/term-llm/widgets`.
- Preserve Docker `.env` provider credentials when `webui` and `jobs` re-exec from root to the `agent` user via `sudo -E`.
- Update the agent/image READMEs and image sync tests for the new widget skill and service flags.
- Refresh the docs-site Agent Containers guide around the current `term-llm contain new/start` flow instead of the stale `docker/init.sh` seed flow.
- Clean up bootstrap `system.md` so Getting Started points at the safe self-modification workflow instead of telling the agent to directly edit `system.md`.
- Clarify workspace conventions for new agents:
  - user source/code projects go under `/home/agent/source/<project>`
  - term-llm source lives at `/home/agent/source/term-llm`
  - term-llm docs live at `/home/agent/source/term-llm/docs-site/content`
- Document the widget admin reload/status endpoints so adding/updating widgets does not require restarting `webui`.

## Review notes

Concrete base-template fixes included here:

- Missing widget skill despite widgets being enabled.
- Explicit `--widgets-dir` on the Web UI service.
- Provider credential preservation across the root → `agent` service user switch.
- Stale Agent Containers docs.
- Contradictory direct-edit guidance in the bootstrap system prompt.
- Missing persistent workspace/source path guidance.
- Widget workflow now uses `/chat/admin/widgets/reload` instead of bouncing the Web UI.

Remaining plausible follow-ups, not included here to keep this PR bounded:

- Add a small notifications skill/docs for `term-llm notify`.
- Consider whether the explicit bootstrap tool allowlist should include newer tools such as `unified_diff` / `initiate_handover`, or move to a less drift-prone pattern if supported.

## Verification

- `go test ./internal/contain ./cmd`
- `go build ./...`
- `go test ./internal/llm ./internal/tools` after full-suite flakes
- Smoke: `XDG_CONFIG_HOME=$(mktemp -d) go run . contain image sync agent` and verified:
  - `bootstrap/skills/widgets/SKILL.md` is synced
  - `bootstrap/services/webui/run` contains `--widgets-dir /home/agent/.config/term-llm/widgets`

`go test ./...` hit unrelated flaky failures in `internal/llm` and `internal/tools`; both packages passed on rerun.
