### PR TITLE
fix: open search-only sidebar sessions

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1072,6 +1072,10 @@ let _savedDraftActive = /** @type {string|null} */ (null);
 
 const saveSessions = () => {
   if (state.sessions.length > 100) {
+    const activeSessionId = state.activeSessionId || '';
+    const activeSession = activeSessionId
+      ? state.sessions.find((s) => s.id === activeSessionId) || null
+      : null;
     state.sessions.sort((a, b) => {
       if (Boolean(a.pinned) !== Boolean(b.pinned)) {
         return Number(Boolean(a.pinned)) - Number(Boolean(b.pinned));
@@ -1079,6 +1083,10 @@ const saveSessions = () => {
       return a.created - b.created;
     });
     state.sessions = state.sessions.slice(-100);
+    if (activeSession && !state.sessions.find((s) => s.id === activeSession.id)) {
+      state.sessions = state.sessions.slice(1);
+      state.sessions.push(activeSession);
+    }
     if (!state.draftSessionActive && !state.sessions.find((s) => s.id === state.activeSessionId)) {
       state.activeSessionId = '';
     }

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -254,7 +254,14 @@ const switchToSession = async (sessionId, options = {}) => {
   const previousActiveSessionId = String(state.activeSessionId || '').trim();
   const previousComposerSessionId = state.draftSessionActive ? '' : previousActiveSessionId;
   stageCurrentComposerForSession(previousComposerSessionId);
-  const session = state.sessions.find((item) => item.id === nextId);
+  let session = state.sessions.find((item) => item.id === nextId);
+  if (!session && Array.isArray(state.sidebarSearchResults)) {
+    const searchResult = state.sidebarSearchResults.find((item) => item?.id === nextId) || null;
+    if (searchResult) {
+      session = { ...searchResult };
+      state.sessions.push(session);
+    }
+  }
   if (!session) return null;
 
   stopSessionStatePoll();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -1685,6 +1685,84 @@ async function testSanitizeSessionPreservesLastMessageAt() {
   pass(name);
 }
 
+async function testSwitchToSearchOnlySessionHydratesResult() {
+  const name = 'switching to a search-only session adds it to local state before hydration';
+  const fetchCalls = [];
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      if (url === '/ui/v1/sessions/sess_search_only/messages') {
+        return new Response(JSON.stringify({
+          messages: [
+            { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'waterparks' }], created_at: 1710000000000 },
+            { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'loaded from server' }], created_at: 1710000001000 }
+          ]
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+
+  app.state.sessions = Array.from({ length: 101 }, (_, index) => ({
+    id: `sess_existing_${index}`,
+    title: `Existing ${index}`,
+    created: 1800000000000 + index,
+    lastMessageAt: 1800000000000 + index,
+    messages: [],
+    origin: 'web',
+  }));
+  app.state.sidebarSearchQuery = 'waterparks';
+  app.state.sidebarSearchResults = [{
+    id: 'sess_search_only',
+    title: 'top 10 waterparks in the us',
+    created: 1710000000000,
+    lastMessageAt: 1710000001000,
+    messages: [],
+    _serverOnly: true,
+  }];
+
+  const session = await app.switchToSession('sess_search_only', { sync: false });
+
+  if (!session) {
+    fail(name, 'expected switchToSession to return the search result session');
+    return;
+  }
+  if (!app.state.sessions.some((item) => item.id === 'sess_search_only')) {
+    fail(name, 'expected search-only session to be added to state.sessions');
+    return;
+  }
+  if (app.state.activeSessionId !== 'sess_search_only') {
+    fail(name, `activeSessionId=${app.state.activeSessionId}, want sess_search_only`);
+    return;
+  }
+  if (session._serverOnly) {
+    fail(name, 'expected search-only session to be hydrated and no longer server-only');
+    return;
+  }
+  if (session.messages.length !== 2 || session.messages[1].content !== 'loaded from server') {
+    fail(name, 'expected hydrated server messages to be loaded', JSON.stringify(session.messages));
+    return;
+  }
+  if (!fetchCalls.includes('/ui/v1/sessions/sess_search_only/messages')) {
+    fail(name, 'expected messages endpoint to be fetched', JSON.stringify(fetchCalls));
+    return;
+  }
+
+  pass(name);
+}
+
 (async () => {
   await testSwitchingSessionsStagesCurrentComposerBeforeRestore();
   await testSwitchToSessionSyncsSelectedRuntime();
@@ -1696,6 +1774,7 @@ async function testSanitizeSessionPreservesLastMessageAt() {
   await testSwitchToSessionSyncsWithoutTokenAndResumes();
   await testSwitchToSessionRecoversChangedActiveResponseFromSnapshot();
   await testSwitchToLazyLoadedSessionFetchesMessagesOnce();
+  await testSwitchToSearchOnlySessionHydratesResult();
   await testSwitchToSessionClearsStaleActiveResponseWithoutToken();
   await testSessionState404ClearsStaleActiveResponse();
   await testIdleSessionSyncRescuesPendingInterruptCommit();


### PR DESCRIPTION
## What

Fix sidebar search results that exist only in `sidebarSearchResults` but not yet in local `state.sessions`.

When opening one of those results, copy the search result into local session state before continuing with normal server-only hydration.

## Why

Recent sessions worked because they were already present in local sidebar state. Older search results came back from `/v1/sessions/search` but `switchToSession()` immediately bailed out if the ID was missing from `state.sessions`, so the click looked dead.

## Test

- `node internal/serveui/static/app_sessions_test.js`
- `go test ./...`
