### PR TITLE
fix: use exponential retry backoff

### DIFF
--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -363,12 +363,14 @@ func TestResponsesClientWebSocketConnectFailureFallsBackToHTTP(t *testing.T) {
 	defer func() { responsesWebSocketBaseBackoff = oldBackoff }()
 
 	var wsAttempts atomic.Int32
+	var httpAttempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
 			wsAttempts.Add(1)
 			http.Error(w, "no websocket", http.StatusBadGateway)
 			return
 		}
+		httpAttempts.Add(1)
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
 		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback\"}\n\n"))
@@ -399,9 +401,42 @@ func TestResponsesClientWebSocketConnectFailureFallsBackToHTTP(t *testing.T) {
 			if wsAttempts.Load() != 3 {
 				t.Fatalf("websocket attempts = %d, want 3", wsAttempts.Load())
 			}
+			if httpAttempts.Load() != 1 {
+				t.Fatalf("http attempts = %d, want 1", httpAttempts.Load())
+			}
+			assertSecondStreamUsesHTTPFallbackOnly(t, client, &wsAttempts, &httpAttempts)
 			return
 		case EventError:
 			t.Fatalf("stream error: %v", event.Err)
+		}
+	}
+}
+
+func assertSecondStreamUsesHTTPFallbackOnly(t *testing.T, client *ResponsesClient, wsAttempts, httpAttempts *atomic.Int32) {
+	t.Helper()
+	wsBefore := wsAttempts.Load()
+	httpBefore := httpAttempts.Load()
+	stream, err := client.Stream(context.Background(), ResponsesRequest{Model: "gpt-test", Input: []ResponsesInputItem{{Type: "message", Role: "user", Content: "again"}}, Stream: true}, false)
+	if err != nil {
+		t.Fatalf("second Stream: %v", err)
+	}
+	defer stream.Close()
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("second Recv: %v", err)
+		}
+		switch event.Type {
+		case EventDone:
+			if got := wsAttempts.Load(); got != wsBefore {
+				t.Fatalf("websocket attempts after fallback disable = %d, want unchanged %d", got, wsBefore)
+			}
+			if got := httpAttempts.Load(); got != httpBefore+1 {
+				t.Fatalf("http attempts after second stream = %d, want %d", got, httpBefore+1)
+			}
+			return
+		case EventError:
+			t.Fatalf("second stream error: %v", event.Err)
 		}
 	}
 }

--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"math/rand"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -323,8 +324,38 @@ func isRetryable(err error) bool {
 	return false
 }
 
-// retryAfterRegex matches Retry-After values in error messages.
-var retryAfterRegex = regexp.MustCompile(`(?i)retry[- ]?after[:\s]+(\d+)`)
+// retryAfterHeaderRegex matches Retry-After header-like values in error messages.
+var retryAfterHeaderRegex = regexp.MustCompile(`(?im)retry[- ]?after[:\s]+([^\r\n]+)`)
+
+func parseRetryAfterDelay(message string, now time.Time) (time.Duration, bool) {
+	matches := retryAfterHeaderRegex.FindStringSubmatch(message)
+	if len(matches) <= 1 {
+		return 0, false
+	}
+	value := strings.TrimSpace(matches[1])
+	if value == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(value); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second, true
+	}
+	if fields := strings.Fields(value); len(fields) > 0 {
+		first := strings.Trim(fields[0], ",;.")
+		if secs, err := strconv.Atoi(first); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second, true
+		}
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		wait := time.Until(when)
+		if !now.IsZero() {
+			wait = when.Sub(now)
+		}
+		if wait > 0 {
+			return wait, true
+		}
+	}
+	return 0, false
+}
 
 // calculateBackoff computes the wait duration for a retry attempt.
 func (r *RetryProvider) calculateBackoff(attempt int, err error) time.Duration {
@@ -338,23 +369,22 @@ func (r *RetryProvider) calculateBackoff(attempt int, err error) time.Duration {
 		return wait
 	}
 
-	// Try to parse Retry-After from error message
+	// Try to parse Retry-After from error message. Accept both numeric
+	// seconds and HTTP-date forms because gateways/providers commonly
+	// surface raw header text in wrapped errors.
 	if err != nil {
-		if matches := retryAfterRegex.FindStringSubmatch(err.Error()); len(matches) > 1 {
-			if secs, parseErr := strconv.Atoi(matches[1]); parseErr == nil && secs > 0 {
-				wait := time.Duration(secs) * time.Second
-				// Cap at max backoff
-				if wait > r.config.MaxBackoff {
-					wait = r.config.MaxBackoff
-				}
-				return wait
+		if wait, ok := parseRetryAfterDelay(err.Error(), time.Now()); ok {
+			if wait > r.config.MaxBackoff {
+				wait = r.config.MaxBackoff
 			}
+			return wait
 		}
 	}
 
-	// Linear backoff with jitter: base * attempt * jitter (jitter in [0.5, 1.5])
+	// Exponential backoff with jitter: base * 2^(attempt-1) * jitter (jitter in [0.5, 1.5])
 	jitter := 0.5 + rand.Float64()
-	delay := time.Duration(float64(r.config.BaseBackoff) * float64(attempt) * jitter)
+	multiplier := 1 << max(attempt-1, 0)
+	delay := time.Duration(float64(r.config.BaseBackoff) * float64(multiplier) * jitter)
 
 	// Cap at max backoff
 	if delay > r.config.MaxBackoff {

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -476,6 +477,64 @@ func (p *noListModelsProvider) Credential() string         { return "mock" }
 func (p *noListModelsProvider) Capabilities() Capabilities { return Capabilities{} }
 func (p *noListModelsProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return nil, errors.New("not used in this test")
+}
+
+func TestRetryProvider_BackoffIsExponentialWithJitter(t *testing.T) {
+	provider := &RetryProvider{config: RetryConfig{
+		BaseBackoff: time.Second,
+		MaxBackoff:  time.Minute,
+	}}
+
+	// attempt 6 => base * 2^(6-1) = 32s, jittered into [16s, 48s].
+	// The old linear formula would be capped to [3s, 9s], so this range
+	// catches regressions without depending on a fixed random seed.
+	got := provider.calculateBackoff(6, errors.New("502 bad gateway"))
+	if got < 16*time.Second || got > 48*time.Second {
+		t.Fatalf("backoff = %s, want exponential jitter range [16s, 48s]", got)
+	}
+}
+
+func TestRetryProvider_BackoffParsesRetryAfterNumericText(t *testing.T) {
+	provider := &RetryProvider{config: RetryConfig{
+		BaseBackoff: time.Second,
+		MaxBackoff:  time.Minute,
+	}}
+
+	for _, message := range []string{
+		"upstream 429: Retry-After: 7",
+		"upstream 429: retry after 7 seconds",
+	} {
+		if got := provider.calculateBackoff(2, errors.New(message)); got != 7*time.Second {
+			t.Fatalf("backoff for %q = %s, want 7s", message, got)
+		}
+	}
+}
+
+func TestRetryProvider_BackoffParsesRetryAfterHTTPDate(t *testing.T) {
+	provider := &RetryProvider{config: RetryConfig{
+		BaseBackoff: time.Second,
+		MaxBackoff:  2 * time.Hour,
+	}}
+	retryAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	err := errors.New("upstream 429: Retry-After: " + retryAt.Format(http.TimeFormat))
+
+	got := provider.calculateBackoff(3, err)
+	if got < 59*time.Minute || got > 61*time.Minute {
+		t.Fatalf("backoff = %s, want about 1h from Retry-After HTTP-date", got)
+	}
+}
+
+func TestRetryProvider_BackoffCapsRetryAfterHTTPDate(t *testing.T) {
+	provider := &RetryProvider{config: RetryConfig{
+		BaseBackoff: time.Second,
+		MaxBackoff:  30 * time.Second,
+	}}
+	retryAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	err := errors.New("upstream 429: Retry-After: " + retryAt.Format(http.TimeFormat))
+
+	if got := provider.calculateBackoff(1, err); got != 30*time.Second {
+		t.Fatalf("backoff = %s, want max backoff cap 30s", got)
+	}
 }
 
 func TestRetryProviderForwardsListModels(t *testing.T) {


### PR DESCRIPTION
## What

- Change provider retry backoff from linear+jitter to exponential+jitter.
- Preserve `Retry-After` numeric handling and add HTTP-date parsing for wrapped retry header text.
- Strengthen Responses WebSocket fallback coverage: after WebSocket setup exhausts its retry budget and falls back to HTTP, assert subsequent streams stay on HTTP instead of probing WebSocket again.

## Why

The comparative pass showed two things:

1. I was wrong about term-llm lacking WS→HTTP fallback — it already exists in `ResponsesClient.Stream`.
2. The generic provider retry loop was still linear, while the other agents mostly use exponential backoff for transient failures.

This makes the generic retry policy less hammer-y under outages, handles more real `Retry-After` formats, and locks in the existing WebSocket fallback behavior with a regression test.

## Validation

- `go test ./internal/llm`
- `go test ./...`
- `go build ./...`
