### PR TITLE
fix: refresh continuation id before web sends

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2889,7 +2889,7 @@ const drainInterruptQueueIfIdle = (session) => {
     const queued = state.queuedInterrupts.shift();
     elements.promptInput.value = queued.prompt;
     autoGrowPrompt();
-    void sendMessage({ prompt: queued.prompt, attachments: [], reuseMessageId: queued.messageId });
+    void sendMessage({ prompt: queued.prompt, attachments: [], reuseMessageId: queued.messageId, _skipContinuationRefresh: true });
   }
 };
 
@@ -3121,7 +3121,8 @@ const recoverInterruptFailure = async (session, prompt, messageId) => {
   removePendingInterjectionById(messageId);
   await sendMessage({
     prompt,
-    attachments: []
+    attachments: [],
+    _skipContinuationRefresh: true
   });
   return true;
 };
@@ -3243,6 +3244,26 @@ const sendMessage = async (options = {}) => {
     state.activeSessionId = session.id;
     state.draftSessionActive = false;
     updateURL(sessionSlug(session));
+  }
+
+  const shouldRefreshContinuation = !options._skipContinuationRefresh && Boolean(
+    session && !session.activeResponseId && (
+      String(session.lastResponseId || '').trim()
+      || Number(session.number || 0) > 0
+      || (Array.isArray(session.messages) && session.messages.length > 0)
+    )
+  );
+  if (shouldRefreshContinuation && typeof app.syncActiveSessionFromServer === 'function') {
+    try {
+      await app.syncActiveSessionFromServer(session, false);
+      session = getActiveSession() || session;
+    } catch (_err) {
+      // Best effort only: the stale-ID guard below still uses the latest
+      // continuation ID we have if the state refresh is unavailable.
+    }
+    if (state.streaming || session.activeResponseId) {
+      return sendMessage({ ...options, _skipContinuationRefresh: true });
+    }
   }
 
   const reuseMessageId = typeof options.reuseMessageId === 'string' ? options.reuseMessageId : '';

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -364,7 +364,12 @@ function createHarness(options = {}) {
     shouldAutoSubscribeToPush() { return false; },
     applyTextDirection() {},
     shouldSuppressPromptAutoFocus() { return false; },
-    syncActiveSessionFromServer: async () => {},
+    syncActiveSessionFromServer: async (session, pollOnActive, opts) => {
+      if (typeof options.onSyncActiveSessionFromServer === 'function') {
+        return options.onSyncActiveSessionFromServer(session, pollOnActive, opts);
+      }
+      return {};
+    },
     scheduleSessionStatePoll() {},
     setSessionOptimisticBusy(sessionOrId, busy) {
       const id = typeof sessionOrId === 'string'
@@ -808,6 +813,62 @@ async function testSendMessageDoesNotResumeAfterStalePostStream() {
   const eventCalls = fetchCalls.filter((call) => call.url.includes('/events?after='));
   if (eventCalls.length !== 0) {
     fail(name, 'stale POST stream should not be resumed via /events', JSON.stringify(fetchCalls));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testSendMessageRefreshesContinuationIdBeforePosting() {
+  const name = 'sendMessage refreshes stale continuation id before posting';
+  const staleId = 'resp_msg_796607';
+  const latestId = 'resp_msg_796651';
+  let syncCalls = 0;
+  const harness = createHarness({
+    onSyncActiveSessionFromServer(session) {
+      syncCalls += 1;
+      if (session.lastResponseId === staleId) {
+        session.lastResponseId = latestId;
+      }
+      return { active_run: false, lastResponseId: session.lastResponseId };
+    },
+  });
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+  const session = {
+    id: 'session_stale_previous',
+    title: 'Stale previous',
+    messages: [{ id: 'msg_old', role: 'user', content: 'old', created: Date.now() - 1000 }],
+    lastResponseId: staleId,
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 42,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  elements.promptInput.value = 'follow up';
+
+  let sendErr = null;
+  await app.sendMessage().catch((err) => {
+    sendErr = err;
+  });
+  await cleanup();
+
+  if (sendErr) {
+    fail(name, 'sendMessage rejected unexpectedly', String(sendErr));
+    return;
+  }
+  if (syncCalls !== 1) {
+    fail(name, `expected one preflight sync, got ${syncCalls}`);
+    return;
+  }
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (!postCall || !postCall.body) {
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    return;
+  }
+  const body = JSON.parse(postCall.body);
+  if (body.previous_response_id !== latestId) {
+    fail(name, `previous_response_id = ${JSON.stringify(body.previous_response_id)}, want ${JSON.stringify(latestId)}`, postCall.body);
     return;
   }
 
@@ -2618,6 +2679,7 @@ function testRestoreLatestDraftMessageDoesNotCrossSessionBoundary() {
   await testInactiveSessionFailureDoesNotAppendToVisibleDOM();
   await testConsumeResponseStreamReportsStaleWithoutApplyingEvents();
   await testSendMessageDoesNotResumeAfterStalePostStream();
+  await testSendMessageRefreshesContinuationIdBeforePosting();
   await testSendMessageConsumesPostStreamWhenAvailable();
   await testSendMessageRefreshesHeaderAfterCompletionUnlocksModelPicker();
   await testSendMessageLazilyMaterializesAttachmentDataURLs();


### PR DESCRIPTION
## What

Fix the web UI sending stale `previous_response_id` values after the local session state falls behind server history.

Before posting a new message to an existing idle session, the UI now does a best-effort session-state sync so `session.lastResponseId` is refreshed from the server. If that sync discovers the session is actually active, the send path re-enters once and uses the active-run/interrupt flow instead of appending against stale state.

Queued interrupt drains and stale-interrupt recovery skip this extra preflight because they have already just synchronized or completed the active run.

## Why

The server correctly rejects stale durable continuations, e.g.:

`previous_response_id "resp_msg_796607" is stale; latest is "resp_msg_796651"`

The frontend could keep an old `lastResponseId` after navigation/backgrounding and use it for the next POST. Refreshing immediately before send makes the server the source of truth at the only moment it matters.

## Tests

- `node internal/serveui/static/app_stream_test.js`
- `go test ./cmd ./internal/serveui`
- `go build ./...`
