### PR TITLE
fix: Skills startup scans the entire skill catalog twice before first prompt

### DIFF
--- a/internal/skills/setup.go
+++ b/internal/skills/setup.go
@@ -21,6 +21,7 @@ type Setup struct {
 	alwaysEnabled        []string
 	metadataBudgetTokens int
 	maxVisibleSkills     int
+	preloadedSkills      []*Skill // Primed startup catalog reused for first prompt metadata build
 
 	metadataOnce sync.Once
 	metadataErr  error
@@ -46,11 +47,13 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		return nil, err
 	}
 
-	hasAnySkills, err := registry.HasAnySkill()
+	// Prime the startup skill catalog once so prompt metadata generation can
+	// reuse it without rescanning and reparsing before the first prompt.
+	preloadedSkills, err := registry.List()
 	if err != nil {
 		return nil, err
 	}
-	if !hasAnySkills {
+	if len(preloadedSkills) == 0 {
 		return nil, nil
 	}
 
@@ -59,6 +62,7 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		alwaysEnabled:        append([]string(nil), cfg.AlwaysEnabled...),
 		metadataBudgetTokens: cfg.MetadataBudgetTokens,
 		maxVisibleSkills:     cfg.MaxVisibleSkills,
+		preloadedSkills:      preloadedSkills,
 	}, nil
 }
 
@@ -72,10 +76,15 @@ func (s *Setup) EnsurePromptMetadata() error {
 	}
 
 	s.metadataOnce.Do(func() {
-		allSkills, err := s.Registry.List()
-		if err != nil {
-			s.metadataErr = fmt.Errorf("list skills: %w", err)
-			return
+		allSkills := s.preloadedSkills
+		s.preloadedSkills = nil
+		if allSkills == nil {
+			var err error
+			allSkills, err = s.Registry.List()
+			if err != nil {
+				s.metadataErr = fmt.Errorf("list skills: %w", err)
+				return
+			}
 		}
 
 		// Filter by never_auto for metadata injection (explicit only skills excluded)


### PR DESCRIPTION
## What

- replace the eager `HasAnySkill()` startup probe in `internal/skills/setup.go` with a single `Registry.List()` call
- keep returning `nil` when no valid skills are available, but retain the discovered skill list on `Setup`
- reuse that preloaded catalog in `EnsurePromptMetadata()` so first-prompt skill XML generation does not rescan and reparse the skill trees

## Why

Skills are enabled by default, so startup was walking the configured skill paths twice before the first prompt: once to answer "are there any skills?" and again to build `<available_skills>`. Reusing the initial catalog keeps the fix tightly scoped while removing duplicate directory reads and manifest parsing from cold startup.
