### PR TITLE
fix: MCP tool completion cold-starts external servers on TAB

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -61,7 +59,8 @@ func MCPServerArgCompletion(cmd *cobra.Command, args []string, toComplete string
 
 // MCPRunArgCompletion provides completions for "mcp run <server> <tool> [key=val] ...".
 // Completes server names for the first arg, tool names and key= params for subsequent args.
-// Tool/param data comes from a local cache populated by "mcp info" and "mcp run".
+// Tool/param data comes only from the local cache populated by "mcp info" and "mcp run".
+// Shell completion must stay fast and must not cold-start external MCP servers.
 func MCPRunArgCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	noFile := cobra.ShellCompDirectiveNoFileComp
 
@@ -73,11 +72,7 @@ func MCPRunArgCompletion(cmd *cobra.Command, args []string, toComplete string) (
 	serverName := args[0]
 	tools := mcp.LoadCachedTools(serverName)
 	if tools == nil {
-		// No cache — start the server to populate it
-		tools = mcpFetchAndCacheTools(serverName)
-		if tools == nil {
-			return nil, noFile
-		}
+		return nil, noFile
 	}
 
 	// Figure out the "current tool" by scanning args after the server name.
@@ -125,28 +120,6 @@ func MCPRunArgCompletion(cmd *cobra.Command, args []string, toComplete string) (
 
 	sort.Strings(completions)
 	return completions, noFile | cobra.ShellCompDirectiveNoSpace
-}
-
-// mcpFetchAndCacheTools starts an MCP server, fetches its tools, caches them, and returns them.
-func mcpFetchAndCacheTools(serverName string) []mcp.ToolSpec {
-	cfg, err := mcp.LoadConfig()
-	if err != nil || cfg == nil {
-		return nil
-	}
-	serverCfg, ok := cfg.Servers[serverName]
-	if !ok {
-		return nil
-	}
-	client := mcp.NewClient(serverName, serverCfg)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := client.Start(ctx); err != nil {
-		return nil
-	}
-	defer client.Stop()
-	tools := client.Tools()
-	mcp.CacheTools(serverName, tools)
-	return tools
 }
 
 // MCPFlagCompletion provides completions for --mcp flag with comma-separated support.

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -4,8 +4,81 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/samsaffron/term-llm/internal/mcp"
+	"github.com/spf13/cobra"
 )
 
+func TestMCPRunArgCompletionDoesNotStartServerOnCacheMiss(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	marker := filepath.Join(configHome, "server-started")
+	script := filepath.Join(configHome, "start-server.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho started > \"$1\"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &mcp.Config{Servers: map[string]mcp.ServerConfig{
+		"demo": {
+			Command: script,
+			Args:    []string{marker},
+		},
+	}}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	completions, directive := MCPRunArgCompletion(nil, []string{"demo"}, "")
+	if len(completions) != 0 {
+		t.Fatalf("expected no completions on cache miss, got %v", completions)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want %v", directive, cobra.ShellCompDirectiveNoFileComp)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		if err != nil {
+			t.Fatalf("stat marker: %v", err)
+		}
+		t.Fatalf("expected completion not to start server, but marker %q was created", marker)
+	}
+}
+
+func TestMCPRunArgCompletionUsesCachedTools(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	if err := os.MkdirAll(filepath.Join(configHome, "term-llm"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mcp.CacheTools("demo", []mcp.ToolSpec{
+		{
+			Name: "fetch",
+			Schema: map[string]any{
+				"properties": map[string]any{
+					"path":    map[string]any{"type": "string"},
+					"pattern": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{Name: "format", Schema: map[string]any{}},
+	})
+
+	completions, directive := MCPRunArgCompletion(nil, []string{"demo", "fetch"}, "p")
+	want := []string{"path=", "pattern="}
+	if len(completions) != len(want) {
+		t.Fatalf("len(completions) = %d, want %d (%v)", len(completions), len(want), completions)
+	}
+	for i := range want {
+		if completions[i] != want[i] {
+			t.Fatalf("completions[%d] = %q, want %q (all=%v)", i, completions[i], want[i], completions)
+		}
+	}
+	wantDirective := cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	if directive != wantDirective {
+		t.Fatalf("directive = %v, want %v", directive, wantDirective)
+	}
+}
 func TestParseValue(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## What

Stop `term-llm mcp run` shell completion from starting MCP servers on a cache miss. `MCPRunArgCompletion` now returns cached tool completions only, and otherwise exits immediately without spawning external processes. Added tests to verify completion stays on the cache-only path and still returns cached tool parameter completions.

## Why

Shell completion is on the interactive cold path, so a first `<TAB>` must stay instant. The previous behavior could block for up to 10 seconds while starting an MCP server and handshaking just to compute completions, which made tab completion feel hung and launched external processes unexpectedly.
