### PR TITLE
fix: Built-in agents always extract embedded resources to disk during prompt setup

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
+
+var builtinAgentFileIncludePattern = regexp.MustCompile(`\{\{\s*file\s*:`)
 
 // SessionSettings holds the resolved settings for a session, merged from
 // config defaults, agent settings, and CLI flags.
@@ -353,10 +356,22 @@ func systemPromptCWDBaseDir() (string, error) {
 	return cwd, nil
 }
 
+func builtinAgentPromptNeedsExtractedResources(prompt string) bool {
+	return strings.Contains(prompt, "{{resource_dir}}") || builtinAgentFileIncludePattern.MatchString(prompt)
+}
+
 func agentPromptTemplateContextAndBaseDir(agent *agents.Agent, files []string) (agents.TemplateContext, string, error) {
 	templateCtx := agents.NewTemplateContextForTemplate(agent.SystemPrompt).WithFiles(files)
 
 	if agent.Source == agents.SourceBuiltin {
+		if !builtinAgentPromptNeedsExtractedResources(agent.SystemPrompt) {
+			cwd, err := systemPromptCWDBaseDir()
+			if err != nil {
+				return agents.TemplateContext{}, "", err
+			}
+			return templateCtx, cwd, nil
+		}
+
 		resourceDir, err := agents.ExtractBuiltinResources(agent.Name)
 		if err != nil {
 			return agents.TemplateContext{}, "", fmt.Errorf("extract builtin resources for %q: %w", agent.Name, err)

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -147,6 +147,85 @@ func TestResolveSettings_AgentSystemPromptIncludeUsesAgentDir(t *testing.T) {
 	}
 }
 
+func TestAgentPromptTemplateContextAndBaseDir_BuiltinWithoutExtractedResourcesSkipsExtraction(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	agent := &agents.Agent{
+		Name:         "developer",
+		Source:       agents.SourceBuiltin,
+		SystemPrompt: "Today is {{date}}.",
+	}
+
+	templateCtx, baseDir, err := agentPromptTemplateContextAndBaseDir(agent, nil)
+	if err != nil {
+		t.Fatalf("agentPromptTemplateContextAndBaseDir() error = %v", err)
+	}
+	if templateCtx.ResourceDir != "" {
+		t.Fatalf("templateCtx.ResourceDir = %q, want empty", templateCtx.ResourceDir)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseDir != cwd {
+		t.Fatalf("baseDir = %q, want %q", baseDir, cwd)
+	}
+
+	resourceRoot, err := agents.GetBuiltinResourceDir()
+	if err != nil {
+		t.Fatalf("GetBuiltinResourceDir() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(resourceRoot, agent.Name)); !os.IsNotExist(err) {
+		t.Fatalf("expected builtin resource extraction to be skipped, stat err = %v", err)
+	}
+}
+
+func TestResolveSettings_BuiltinAgentResourceDirStillExtractsResources(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	agent := &agents.Agent{
+		Name:         "artist",
+		Source:       agents.SourceBuiltin,
+		SystemPrompt: "Read {{resource_dir}}/styles.md",
+	}
+
+	settings, err := ResolveSettings(&config.Config{}, agent, CLIFlags{}, "", "", "", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+
+	resourceRoot, err := agents.GetBuiltinResourceDir()
+	if err != nil {
+		t.Fatalf("GetBuiltinResourceDir() error = %v", err)
+	}
+	expectedPath := filepath.Join(resourceRoot, "artist", "styles.md")
+	if !strings.HasPrefix(settings.SystemPrompt, "Read "+expectedPath) {
+		t.Fatalf("SystemPrompt = %q, want prefix %q", settings.SystemPrompt, "Read "+expectedPath)
+	}
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected extracted resource at %q: %v", expectedPath, err)
+	}
+}
+
+func TestResolveSettings_BuiltinAgentFileIncludeStillExtractsResources(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	agent := &agents.Agent{
+		Name:         "artist",
+		Source:       agents.SourceBuiltin,
+		SystemPrompt: "X {{ file:styles.md }} Y",
+	}
+
+	settings, err := ResolveSettings(&config.Config{}, agent, CLIFlags{}, "", "", "", 0, 20)
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+	if !strings.Contains(settings.SystemPrompt, "# Art Styles & Techniques Reference") {
+		t.Fatalf("SystemPrompt = %q, want embedded styles.md content", settings.SystemPrompt)
+	}
+}
+
 func TestResolveSettings_AppendsInsightsToSystemPrompt(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "memory.db")
 	t.Setenv("TERM_LLM_MEMORY_DB", dbPath)


### PR DESCRIPTION
## What

- skip builtin resource extraction during prompt setup unless the builtin prompt actually needs extracted files
- continue extracting when the prompt uses `{{resource_dir}}` or builtin-relative `{{file:...}}` includes
- add regression coverage for the skipped-extraction path and both extraction-required cases

## Why

`agentPromptTemplateContextAndBaseDir` was extracting embedded builtin resources on every launch, even for common builtins like `@developer`, `@reviewer`, `@editor`, and `@commit-message` that do not use extracted files. That caused avoidable filesystem work before the first visible response. This change removes that startup churn while preserving the prompts that genuinely depend on extracted resources.
