### PR TITLE
perf: stream read_file long lines in chunks

### DIFF
--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -172,8 +172,10 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 	writtenLines := 0
 	truncated := false
 	byteCapped := false
-	emittedAny := false
+	sawData := false
 	lastEndedNewline := false
+	lineOpen := false
+	lineWriting := false
 
 	appendOutput := func(s string) {
 		if byteCapped {
@@ -203,34 +205,78 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 		sb.WriteString(s)
 	}
 
-	processLine := func(line string) bool {
+	appendOutputBytes := func(p []byte) {
+		if byteCapped {
+			return
+		}
+		if limits.MaxBytes <= 0 {
+			if len(p) > 0 {
+				truncated = true
+				byteCapped = true
+			}
+			return
+		}
+		remaining := int(limits.MaxBytes) - sb.Len()
+		if remaining <= 0 {
+			if len(p) > 0 {
+				truncated = true
+				byteCapped = true
+			}
+			return
+		}
+		if len(p) > remaining {
+			_, _ = sb.Write(p[:remaining])
+			truncated = true
+			byteCapped = true
+			return
+		}
+		_, _ = sb.Write(p)
+	}
+
+	startNewLine := func() {
 		totalLines++
+		lineOpen = true
+		lineWriting = false
 		lineNum := totalLines
 
 		inRange := lineNum >= startLine && (endLine <= 0 || lineNum <= endLine)
-		if inRange {
-			selectedLines++
-			if selectedLines > limits.MaxLines {
-				truncated = true
-			} else {
-				if writtenLines > 0 {
-					appendOutput("\n")
-				}
-				appendOutput(strconv.Itoa(lineNum))
-				appendOutput(": ")
-				appendOutput(line)
-				writtenLines++
-			}
+		if !inRange {
+			return
 		}
+
+		selectedLines++
+		if selectedLines > limits.MaxLines {
+			truncated = true
+			return
+		}
+
+		if writtenLines > 0 {
+			appendOutput("\n")
+		}
+		appendOutput(strconv.Itoa(lineNum))
+		appendOutput(": ")
+		writtenLines++
+		lineWriting = true
+	}
+
+	writeLineFragment := func(fragment []byte) {
+		if lineWriting && len(fragment) > 0 {
+			appendOutputBytes(fragment)
+		}
+	}
+
+	finishLine := func() bool {
+		lineOpen = false
+		lineWriting = false
 
 		if truncated {
 			return false // Stop immediately once truncation is known; don't scan the rest of the file.
 		}
 		if endLine > 0 {
-			if startLine <= endLine && lineNum >= endLine {
+			if startLine <= endLine && totalLines >= endLine {
 				return false
 			}
-			if startLine > endLine && lineNum >= startLine {
+			if startLine > endLine && totalLines >= startLine {
 				return false
 			}
 		}
@@ -242,30 +288,48 @@ func streamLineNumberedRange(ctx context.Context, reader *bufio.Reader, startLin
 			return "", err
 		}
 
-		line, readErr := reader.ReadString('\n')
-		if len(line) > 0 {
-			emittedAny = true
-			if strings.HasSuffix(line, "\n") {
-				line = strings.TrimSuffix(line, "\n")
+		fragment, readErr := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			sawData = true
+			lineEnded := fragment[len(fragment)-1] == '\n'
+			if lineEnded {
+				fragment = fragment[:len(fragment)-1]
 				lastEndedNewline = true
 			} else {
 				lastEndedNewline = false
 			}
-			if !processLine(line) {
+
+			if !lineOpen {
+				startNewLine()
+			}
+			writeLineFragment(fragment)
+
+			if lineEnded {
+				if !finishLine() {
+					break
+				}
+			} else if truncated {
 				break
 			}
 		}
 
-		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
-				if !emittedAny || lastEndedNewline {
-					processLine("")
-				}
-				totalLinesKnown = true
-				break
-			}
-			return "", readErr
+		if readErr == nil {
+			continue
 		}
+		if errors.Is(readErr, bufio.ErrBufferFull) {
+			continue
+		}
+		if errors.Is(readErr, io.EOF) {
+			if lineOpen {
+				finishLine()
+			} else if !sawData || lastEndedNewline {
+				startNewLine()
+				finishLine()
+			}
+			totalLinesKnown = true
+			break
+		}
+		return "", readErr
 	}
 
 	if totalLinesKnown && requestedStart > 0 && startLine > totalLines {

--- a/internal/tools/read_test.go
+++ b/internal/tools/read_test.go
@@ -109,6 +109,48 @@ func TestStreamLineNumberedRangeStopsReadingAfterTruncation(t *testing.T) {
 	}
 }
 
+func TestStreamLineNumberedRangeStopsReadingLongLineAfterByteCap(t *testing.T) {
+	limits := DefaultOutputLimits()
+	limits.MaxBytes = 10
+
+	reader := &chunkReader{
+		chunks: []string{
+			strings.Repeat("x", 64),
+			strings.Repeat("y", 64),
+			strings.Repeat("z", 64),
+		},
+	}
+	got, err := streamLineNumberedRange(context.Background(), bufio.NewReaderSize(reader, 16), 1, 0, limits)
+	if err != nil {
+		t.Fatalf("streamLineNumberedRange returned error: %v", err)
+	}
+	if reader.index != 1 {
+		t.Fatalf("expected byte cap to stop within first chunk, read %d chunks", reader.index)
+	}
+	if strings.Contains(got, "y") || strings.Contains(got, "z") {
+		t.Fatalf("output includes content read after cap: %q", got)
+	}
+	if !strings.Contains(got, "[Output truncated") {
+		t.Fatalf("expected truncation notice, got %q", got)
+	}
+}
+
+func TestStreamLineNumberedRangeReassemblesBufferedLongLine(t *testing.T) {
+	limits := DefaultOutputLimits()
+	limits.MaxBytes = 512
+	content := strings.Repeat("x", 128)
+
+	got, err := streamLineNumberedRange(context.Background(), bufio.NewReaderSize(strings.NewReader(content), 16), 1, 0, limits)
+	if err != nil {
+		t.Fatalf("streamLineNumberedRange returned error: %v", err)
+	}
+
+	want := "1: " + content
+	if got != want {
+		t.Fatalf("unexpected output:\nwant %q\n got %q", want, got)
+	}
+}
+
 func TestStreamLineNumberedRangeMatchesLegacyFormatting(t *testing.T) {
 	baseLimits := DefaultOutputLimits()
 	smallLineLimit := baseLimits
@@ -232,6 +274,32 @@ func BenchmarkReadFileToolStartRangeLargeFile(b *testing.B) {
 		}
 		if !strings.Contains(out.Content, "20: line 000019") {
 			b.Fatalf("range output missing final line: %q", out.Content)
+		}
+	}
+}
+
+func BenchmarkReadFileToolHugeSingleLineCapped(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "huge-line.txt")
+	const lineSize = 8 * 1024 * 1024
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", lineSize)), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	limits := DefaultOutputLimits()
+	limits.MaxBytes = 1024
+	tool := NewReadFileTool(nil, limits)
+	args, _ := json.Marshal(ReadFileArgs{Path: path})
+
+	b.ReportAllocs()
+	b.SetBytes(lineSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := tool.Execute(context.Background(), args)
+		if err != nil {
+			b.Fatalf("Execute returned error: %v", err)
+		}
+		if !strings.Contains(out.Content, "[Output truncated") {
+			b.Fatalf("expected truncation notice, got: %.200q", out.Content)
 		}
 	}
 }


### PR DESCRIPTION
## What

Stream `read_file` line-numbered output with `bufio.Reader.ReadSlice` fragments instead of `ReadString`, so a single oversized line can be capped without allocating or scanning the whole logical line.

This keeps the existing line-numbered formatting but emits each line number once, appends line content in chunks, and stops immediately when the configured byte/line limit is reached.

## Why

`ReadString('\n')` must accumulate an entire logical line before the existing output byte cap can apply. For minified/generated files with multi-MB single lines, `read_file` paid the allocation and latency cost even when only the first 50KB (or less) could be returned.

## Evidence

Focused benchmark on an 8 MiB single-line file with `MaxBytes=1024`:

- Before: `2.17–3.33 ms/op`, `16,943,686–16,944,245 B/op`, `2098–2099 allocs/op`
- After: `9.67–10.50 µs/op`, `8,816 B/op`, `37 allocs/op`

Benchmark command:

```bash
go test ./internal/tools -run '^$' -bench BenchmarkReadFileToolHugeSingleLineCapped -benchmem -benchtime=10x -count=3
```

## Tests

- Added regression coverage for stopping within the first chunk after a byte cap.
- Added regression coverage for reassembling untruncated lines split across the bufio buffer.
- `go test ./internal/tools -run 'Test(ReadFileTool|StreamLineNumberedRange)' -count=1`
- `go build ./...`
- `go test ./...`
