### PR TITLE
perf: speed up global jobs run summaries

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -613,13 +613,23 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 	for _, migration := range migrations {
 		_, _ = db.Exec(migration)
 	}
-	// Replace the narrow job_id/created_at index with a covering index for the
+	// Replace the narrow job_id/created_at index with covering indexes for the
 	// run-summary API. Large stdout/stderr/thinking/response columns sit before
-	// summary metadata in the table record; without a covering index, SQLite
-	// walks overflow payload pages just to list recent runs.
-	if _, err := db.Exec(jobsV2RunSummaryIndexSQL); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("init jobs run summary index: %w", err)
+	// summary metadata in the table record; without covering indexes, SQLite
+	// walks overflow payload pages just to list recent runs. The job-scoped index
+	// serves /v2/runs?job_id=..., while the global index avoids a temp sort for
+	// all-job summaries used by the jobs CLI/status views.
+	for _, index := range []struct {
+		name string
+		sql  string
+	}{
+		{name: jobsV2RunSummaryIndexName, sql: jobsV2RunSummaryIndexSQL},
+		{name: jobsV2RunGlobalSummaryIndexName, sql: jobsV2RunGlobalSummaryIndexSQL},
+	} {
+		if _, err := db.Exec(index.sql); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("init jobs run summary index %s: %w", index.name, err)
+		}
 	}
 	_, _ = db.Exec(`DROP INDEX IF EXISTS idx_job_runs_v2_job_id`)
 
@@ -1651,6 +1661,10 @@ func (m *jobsV2Manager) ListRunSummaries(jobID string, limit, offset int) ([]job
 const jobsV2RunSummaryIndexName = "idx_job_runs_v2_summary_by_job_created"
 
 const jobsV2RunSummaryIndexSQL = "CREATE INDEX IF NOT EXISTS " + jobsV2RunSummaryIndexName + " ON job_runs_v2(job_id, created_at DESC, id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, exit_reason, truncated, turn_count, input_tokens, output_tokens, updated_at)"
+
+const jobsV2RunGlobalSummaryIndexName = "idx_job_runs_v2_summary_created"
+
+const jobsV2RunGlobalSummaryIndexSQL = "CREATE INDEX IF NOT EXISTS " + jobsV2RunGlobalSummaryIndexName + " ON job_runs_v2(created_at DESC, id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, exit_reason, truncated, turn_count, input_tokens, output_tokens, updated_at)"
 
 const jobsV2RunFullColumns = "id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at"
 

--- a/cmd/serve_jobs_v2_bench_test.go
+++ b/cmd/serve_jobs_v2_bench_test.go
@@ -66,6 +66,68 @@ func BenchmarkJobsV2ListRuns(b *testing.B) {
 	})
 }
 
+func BenchmarkJobsV2ListRunSummariesGlobal(b *testing.B) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		b.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	now := time.Now().UTC()
+	const jobs = 100
+	const rows = 100_000
+	const limit = 100
+	for j := 0; j < jobs; j++ {
+		_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 60, 'skip', ?, ?)`,
+			fmt.Sprintf("job_bench_global_%03d", j), fmt.Sprintf("bench-global-%03d", j), jobsV2RunnerProgram, `{"command":"echo","args":["x"]}`, jobsV2TriggerManual, `{}`, now, now)
+		if err != nil {
+			b.Fatalf("insert job %d: %v", j, err)
+		}
+	}
+	payload := strings.Repeat("x", 128)
+	tx, err := mgr.db.Begin()
+	if err != nil {
+		b.Fatalf("begin: %v", err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, started_at, finished_at, exit_code, stdout, stderr, thinking, response, exit_reason, turn_count, input_tokens, output_tokens, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 2, 100, 20, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		b.Fatalf("prepare: %v", err)
+	}
+	for i := 0; i < rows; i++ {
+		created := now.Add(-time.Duration(i) * time.Second)
+		jobID := fmt.Sprintf("job_bench_global_%03d", i%jobs)
+		_, err = stmt.Exec(fmt.Sprintf("run_bench_global_%06d", i), jobID, created, jobsV2RunSucceeded, created, created, payload, payload, payload, payload, exitReasonNatural, created, created)
+		if err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			b.Fatalf("insert run %d: %v", i, err)
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		_ = tx.Rollback()
+		b.Fatalf("close: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit: %v", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		runs, total, err := mgr.ListRunSummaries("", limit, 0)
+		if err != nil {
+			b.Fatalf("ListRunSummaries failed: %v", err)
+		}
+		if total != rows || len(runs) != limit {
+			b.Fatalf("got total=%d len=%d, want total=%d len=%d", total, len(runs), rows, limit)
+		}
+		if runs[0].Stdout != "" || runs[0].Response != "" {
+			b.Fatalf("summary list loaded output payloads")
+		}
+	}
+}
+
 func BenchmarkJobsV2ListRunEventsSince(b *testing.B) {
 	mgr, err := newJobsV2Manager(":memory:", 0, nil)
 	if err != nil {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -34,9 +34,33 @@ func TestJobsV2RunSummaryUsesCoveringIndex(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	rows, err := mgr.db.Query("EXPLAIN QUERY PLAN SELECT "+jobsV2RunSummaryColumns+" FROM job_runs_v2 WHERE job_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?", "job_test", 50, 0)
+	plan := jobsV2ExplainPlan(t, mgr.db, "EXPLAIN QUERY PLAN SELECT "+jobsV2RunSummaryColumns+" FROM job_runs_v2 WHERE job_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?", "job_test", 50, 0)
+	if !strings.Contains(plan, "USING COVERING INDEX "+jobsV2RunSummaryIndexName) {
+		t.Fatalf("summary query plan = %q, want covering summary index", plan)
+	}
+}
+
+func TestJobsV2GlobalRunSummaryUsesCoveringIndex(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
 	if err != nil {
-		t.Fatalf("explain summary query: %v", err)
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	plan := jobsV2ExplainPlan(t, mgr.db, "EXPLAIN QUERY PLAN SELECT "+jobsV2RunSummaryColumns+" FROM job_runs_v2 ORDER BY created_at DESC LIMIT ? OFFSET ?", 50, 0)
+	if !strings.Contains(plan, "USING COVERING INDEX "+jobsV2RunGlobalSummaryIndexName) {
+		t.Fatalf("global summary query plan = %q, want covering global summary index", plan)
+	}
+	if strings.Contains(plan, "USE TEMP B-TREE") {
+		t.Fatalf("global summary query plan = %q, want no temp sort", plan)
+	}
+}
+
+func jobsV2ExplainPlan(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		t.Fatalf("explain query: %v", err)
 	}
 	defer rows.Close()
 
@@ -52,11 +76,7 @@ func TestJobsV2RunSummaryUsesCoveringIndex(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatalf("explain rows: %v", err)
 	}
-
-	plan := strings.Join(details, "\n")
-	if !strings.Contains(plan, "USING COVERING INDEX "+jobsV2RunSummaryIndexName) {
-		t.Fatalf("summary query plan = %q, want covering summary index", plan)
-	}
+	return strings.Join(details, "\n")
 }
 
 func TestJobsV2OnceProgramRunLifecycle(t *testing.T) {


### PR DESCRIPTION
## What

Add a global covering index for Jobs V2 run-summary listing:

- keeps the existing job-scoped covering index for `/v2/runs?job_id=...`
- adds `idx_job_runs_v2_summary_created` for all-job summaries ordered by `created_at DESC`
- adds an EXPLAIN test to verify the global summary query uses the covering index and avoids a temp B-tree sort
- adds a benchmark for global run-summary listing across 100 jobs / 100k runs

## Why

The CLI/status path fetches recent run summaries across all jobs (`/v2/runs?summary=true` without `job_id`). The existing covering index starts with `job_id`, so SQLite could not use it to satisfy the global `ORDER BY created_at DESC`; it scanned/sorted the summary rows via a temp B-tree.

This keeps the endpoint behavior unchanged while reducing latency for real jobs/status listing as run history grows.

## Evidence

Representative benchmark over 100 jobs / 100k runs, listing the newest 100 global summaries:

- Before: ~10.6-11.9 ms/op, ~227 KB/op, 5246 allocs/op
- After: ~1.55 ms/op, ~229 KB/op, 5246 allocs/op

The new EXPLAIN test asserts the global summary query uses `USING COVERING INDEX idx_job_runs_v2_summary_created` and does not emit `USE TEMP B-TREE`.

## Verification

- `go test ./cmd -run 'TestJobsV2(RunSummary|GlobalRunSummary)'`
- `go test ./cmd -run '^$' -bench '^BenchmarkJobsV2ListRunSummariesGlobal$' -benchmem -count=3`
- `go build ./...`
- `go test ./...`
