### PR TITLE
fix: Every follow-up send blocks on a full server resync before the POST stream starts

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -3264,7 +3264,10 @@ const sendMessage = async (options = {}) => {
   );
   if (shouldRefreshContinuation && typeof app.syncActiveSessionFromServer === 'function') {
     try {
-      await app.syncActiveSessionFromServer(session, false);
+      // Before posting a continuation, refresh lightweight runtime state so we
+      // pick up a newer lastResponseId or newly-active run without blocking on a
+      // full paginated history reload.
+      await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
       session = getActiveSession() || session;
     } catch (_err) {
       // Best effort only: the stale-ID guard below still uses the latest

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -824,9 +824,11 @@ async function testSendMessageRefreshesContinuationIdBeforePosting() {
   const staleId = 'resp_msg_796607';
   const latestId = 'resp_msg_796651';
   let syncCalls = 0;
+  let skipMessagesFetch = false;
   const harness = createHarness({
-    onSyncActiveSessionFromServer(session) {
+    onSyncActiveSessionFromServer(session, _pollOnActive, opts) {
       syncCalls += 1;
+      skipMessagesFetch = Boolean(opts?.skipMessagesFetch);
       if (session.lastResponseId === staleId) {
         session.lastResponseId = latestId;
       }
@@ -859,6 +861,10 @@ async function testSendMessageRefreshesContinuationIdBeforePosting() {
   }
   if (syncCalls !== 1) {
     fail(name, `expected one preflight sync, got ${syncCalls}`);
+    return;
+  }
+  if (!skipMessagesFetch) {
+    fail(name, 'expected preflight sync to skip the full messages reload');
     return;
   }
   const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');


### PR DESCRIPTION
## What

- stop `sendMessage` from waiting on a full session message-history reload before posting a normal follow-up
- keep the preflight continuation refresh, but call `syncActiveSessionFromServer(..., { skipMessagesFetch: true })` so it only refreshes lightweight runtime state like `lastResponseId` / active-run status
- extend the app-stream regression test to assert the preflight sync stays state-only

## Why

Follow-up sends in established chats were paying an unnecessary latency tax before the POST stream could even start. The preflight sync was reloading the session's full paginated message history whenever the server considered the run idle, which made first-token latency noticeably worse on longer chats. This change preserves the stale-continuation guard without forcing that expensive history refetch on every send.
