### PR TITLE
fix: Non-append transcript updates rebuild the entire chat DOM and reparse all markdown

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1863,6 +1863,93 @@ const updateToolGroupNode = (message) => {
 
 let _lastRenderedSessionId = null;
 let _lastRenderedMessageIds = [];
+let _lastRenderedMessageKeys = new Map();
+
+const messageRenderKey = (message) => {
+  switch (message.role) {
+    case 'assistant':
+      return JSON.stringify({
+        role: message.role,
+        content: message.content || '',
+        created: message.created || 0,
+        usage: message.usage || null
+      });
+    case 'user':
+      return JSON.stringify({
+        role: message.role,
+        content: message.content || '',
+        created: message.created || 0,
+        interruptState: sanitizeInterruptState(message.interruptState),
+        attachments: Array.isArray(message.attachments)
+          ? message.attachments.map((attachment) => ({
+            name: attachment?.name || '',
+            type: attachment?.type || '',
+            previewURL: attachment?.previewURL || '',
+            dataURL: attachment?.dataURL || ''
+          }))
+          : []
+      });
+    case 'tool':
+      return JSON.stringify({
+        role: message.role,
+        name: message.name || '',
+        status: message.status || '',
+        arguments: message.arguments || '',
+        expanded: Boolean(message.expanded),
+        created: message.created || 0,
+        images: Array.isArray(message.images) ? message.images : []
+      });
+    case 'tool-group':
+      return JSON.stringify({
+        role: message.role,
+        status: message.status || '',
+        expanded: Boolean(message.expanded),
+        created: message.created || 0,
+        images: Array.isArray(message.images) ? message.images : [],
+        tools: Array.isArray(message.tools)
+          ? message.tools.map((tool) => ({
+            id: tool?.id || '',
+            name: tool?.name || '',
+            status: tool?.status || '',
+            arguments: tool?.arguments || '',
+            argumentsFinalized: Boolean(tool?.argumentsFinalized),
+            images: Array.isArray(tool?.images) ? tool.images : []
+          }))
+          : []
+      });
+    default:
+      return JSON.stringify({
+        role: message.role,
+        content: message.content || '',
+        created: message.created || 0
+      });
+  }
+};
+
+const messageNodeMatchesRole = (node, message) => {
+  if (!node || !message?.role) return false;
+  return node.classList?.contains(message.role);
+};
+
+const updateMessageNode = (message) => {
+  switch (message.role) {
+    case 'assistant':
+      updateAssistantNode(message);
+      break;
+    case 'tool':
+      updateToolNode(message);
+      break;
+    case 'tool-group':
+      updateToolGroupNode(message);
+      break;
+    case 'model-swap':
+      updateModelSwapNode(message);
+      break;
+    default:
+      updateUserNode(message);
+      break;
+  }
+};
 
 const renderMessages = (forceScroll = false) => {
   const session = ensureActiveSession();
@@ -1879,6 +1966,7 @@ const renderMessages = (forceScroll = false) => {
     elements.messages.appendChild(empty);
     _lastRenderedSessionId = sessionId;
     _lastRenderedMessageIds = [];
+    _lastRenderedMessageKeys = new Map();
     syncTurnActionPanels();
     refreshRelativeTimes();
     scrollToBottom(forceScroll);
@@ -1887,7 +1975,7 @@ const renderMessages = (forceScroll = false) => {
   }
 
   // Fast path: same session, messages only appended at the end
-  if (sessionId === _lastRenderedSessionId && messages.length >= _lastRenderedMessageIds.length) {
+  if (sessionId === _lastRenderedSessionId && messages.length > _lastRenderedMessageIds.length) {
     let canAppend = true;
     for (let i = 0; i < _lastRenderedMessageIds.length; i++) {
       if (_lastRenderedMessageIds[i] !== messages[i].id) {
@@ -1901,6 +1989,7 @@ const renderMessages = (forceScroll = false) => {
       for (let i = _lastRenderedMessageIds.length; i < messages.length; i++) {
         elements.messages.appendChild(createMessageNode(messages[i]));
         _lastRenderedMessageIds.push(messages[i].id);
+        _lastRenderedMessageKeys.set(messages[i].id, messageRenderKey(messages[i]));
       }
       syncTurnActionPanels();
       refreshRelativeTimes();
@@ -1910,6 +1999,54 @@ const renderMessages = (forceScroll = false) => {
     }
   }
 
+  if (sessionId === _lastRenderedSessionId) {
+    const emptyState = elements.messages.querySelector('.empty-state');
+    if (emptyState) emptyState.remove();
+
+    const existingNodes = new Map(
+      Array.from(elements.messages.querySelectorAll('.message[data-message-id]'))
+        .map((node) => [node.dataset.messageId, node])
+    );
+    const nextMessageIds = [];
+    const nextMessageKeys = new Map();
+
+    messages.forEach((message, index) => {
+      const renderKey = messageRenderKey(message);
+      nextMessageIds.push(message.id);
+      nextMessageKeys.set(message.id, renderKey);
+
+      let node = existingNodes.get(message.id) || null;
+      if (!node) {
+        node = createMessageNode(message);
+      } else if (!messageNodeMatchesRole(node, message)) {
+        const replacement = createMessageNode(message);
+        node.replaceWith(replacement);
+        node = replacement;
+      } else if (_lastRenderedMessageKeys.get(message.id) !== renderKey) {
+        updateMessageNode(message);
+        node = findMessageElement(message.id) || node;
+      }
+
+      const currentChild = elements.messages.children[index] || null;
+      if (currentChild !== node) {
+        elements.messages.insertBefore(node, currentChild);
+      }
+
+      existingNodes.delete(message.id);
+    });
+
+    existingNodes.forEach((node) => node.remove());
+    _lastRenderedSessionId = sessionId;
+    _lastRenderedMessageIds = nextMessageIds;
+    _lastRenderedMessageKeys = nextMessageKeys;
+
+    syncTurnActionPanels();
+    refreshRelativeTimes();
+    scrollToBottom(forceScroll);
+    updateHeader();
+    return;
+  }
+
   // Full rebuild
   elements.messages.innerHTML = '';
   messages.forEach((message) => {
@@ -1917,6 +2054,7 @@ const renderMessages = (forceScroll = false) => {
   });
   _lastRenderedSessionId = sessionId;
   _lastRenderedMessageIds = messages.map((m) => m.id);
+  _lastRenderedMessageKeys = new Map(messages.map((message) => [message.id, messageRenderKey(message)]));
 
   syncTurnActionPanels();
   refreshRelativeTimes();

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -275,6 +275,7 @@ function createHarness(appOverrides = {}) {
   const timers = [];
   let timerId = 0;
   const copied = [];
+  const parseCalls = [];
 
   const app = {
     STORAGE_KEYS: { sidebarCollapsed: 'sidebar' },
@@ -344,6 +345,7 @@ function createHarness(appOverrides = {}) {
     navigator: { clipboard: { async writeText(text) { copied.push(text); } } },
     marked: { parse(text) {
       const value = String(text || '');
+      parseCalls.push(value);
       const code = value.match(/^```([A-Za-z0-9_-]+)?\n([\s\S]*?)\n```\s*$/);
       if (code) {
         const lang = code[1] ? ` class="language-${code[1]}"` : '';
@@ -362,7 +364,7 @@ function createHarness(appOverrides = {}) {
   windowObj.localStorage = context.localStorage;
 
   vm.runInNewContext(source, context, { filename: 'app-render.js' });
-  return { app, session, messages, document, timers, copied };
+  return { app, session, messages, document, timers, copied, parseCalls };
 }
 
 function messageNode(id, role) {
@@ -1122,24 +1124,49 @@ async function run(name, fn) {
     assertEqual(messages.children[0].dataset.messageId, 'b1', 'new session node has correct id');
   });
 
-  await run('renderMessages: full rebuild when message list changes non-incrementally', () => {
-    const { app, session, messages } = createHarness();
+  await run('renderMessages: non-append updates reuse unchanged assistant nodes', () => {
+    const { app, session, messages, parseCalls } = createHarness();
     session.messages = [
-      { id: 'x1', role: 'user', content: 'a', created: Date.now() },
-      { id: 'x2', role: 'assistant', content: 'b', created: Date.now() },
+      { id: 'u1', role: 'user', content: 'a', created: Date.now() },
+      { id: 'a1', role: 'assistant', content: 'b', created: Date.now() },
     ];
     app.renderMessages();
     assertEqual(messages.children.length, 2, 'two nodes initially');
-    const firstNode = messages.children[0];
+    const originalUserNode = messages.children[0];
+    const originalAssistantNode = messages.children[1];
+    assertEqual(parseCalls.length, 1, 'assistant markdown parsed once on initial render');
 
-    // Replace the messages (non-append: different IDs)
     session.messages = [
-      { id: 'y1', role: 'user', content: 'new', created: Date.now() },
+      { id: 'u0', role: 'user', content: 'history', created: Date.now() - 1000 },
+      session.messages[0],
+      session.messages[1],
     ];
     app.renderMessages();
-    assertEqual(messages.children.length, 1, 'one node after non-incremental update');
-    assert(messages.children[0] !== firstNode, 'node was recreated');
-    assertEqual(messages.children[0].dataset.messageId, 'y1', 'rebuilt node has correct id');
+
+    assertEqual(messages.children.length, 3, 'history insert keeps all messages rendered');
+    assertEqual(messages.children[0].dataset.messageId, 'u0', 'new history node inserted at the front');
+    assert(messages.children[1] === originalUserNode, 'existing user node reused after front insertion');
+    assert(messages.children[2] === originalAssistantNode, 'existing assistant node reused after front insertion');
+    assertEqual(parseCalls.length, 1, 'unchanged assistant markdown was not reparsed');
+  });
+
+  await run('renderMessages: same-length updates still refresh changed assistant content', () => {
+    const { app, session, messages, parseCalls } = createHarness();
+    session.messages = [
+      { id: 'u1', role: 'user', content: 'prompt', created: Date.now() },
+      { id: 'a1', role: 'assistant', content: 'old', created: Date.now() },
+    ];
+    app.renderMessages();
+    assertEqual(parseCalls.length, 1, 'assistant parsed on initial render');
+
+    session.messages = [
+      session.messages[0],
+      { ...session.messages[1], content: 'new' },
+    ];
+    app.renderMessages();
+
+    assertEqual(parseCalls.length, 2, 'assistant reparsed when content changes without any append');
+    assertEqual(messages.children[1].querySelector('.message-body').textContent, 'new', 'assistant content updated');
   });
 
   await run('updateSidebarStatus finds local session by id using Map lookup', () => {


### PR DESCRIPTION
## What

- keep the append fast path for pure tail growth, but reconcile same-session non-append transcript changes by message id instead of clearing `elements.messages`
- reuse existing message nodes when their render-relevant data is unchanged, only update/create/remove the specific nodes that actually changed
- track per-message render keys so unchanged assistant messages keep their existing markdown DOM instead of being reparsed
- add regression coverage for history insertion reuse and same-length assistant-content refreshes

## Why

Non-append transcript updates currently tear down and rebuild the entire chat subtree for the active session. On large conversations that reparses every assistant markdown block, recreates the whole DOM, and causes visible jank during history merges, reconnect recovery, and hydration. Reusing keyed message nodes makes those updates much cheaper while preserving the existing full rebuild behavior on actual session switches.
