### PR TITLE
fix: Every follow-up message blocks on a full server sync before streaming can begin

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -52,6 +52,27 @@ const normalizeError = async (response) => {
   return { status: response.status, message };
 };
 
+const hasSessionContinuationContext = (session) => Boolean(
+  session && (
+    Number(session.number || 0) > 0
+    || (Array.isArray(session.messages) && session.messages.length > 0)
+  )
+);
+
+const classifyRecoverableContinuationFailure = (error, previousResponseId = '') => {
+  const status = Number(error?.status || 0);
+  const message = String(error?.message || '').trim();
+  const lowered = message.toLowerCase();
+
+  if (previousResponseId && (status === 400 || status === 409) && lowered.includes('previous_response_id')) {
+    return 'previous_response_id';
+  }
+  if (lowered.includes('session is busy processing another request')) {
+    return 'session_busy';
+  }
+  return '';
+};
+
 const fetchProviders = async (tokenOverride = '') => {
   const headers = {};
   const token = tokenOverride || state.token;
@@ -785,6 +806,10 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   if (event === 'response.failed') {
     const errorMessage = payload?.error?.message || 'The response failed.';
     const lowered = errorMessage.toLowerCase();
+    const recoverableContinuationFailure = classifyRecoverableContinuationFailure(
+      { message: errorMessage },
+      session.lastResponseId
+    );
     const canceledByInterrupt = state.expectCanceledRun && (
       lowered.includes('context canceled') ||
       lowered.includes('context cancelled') ||
@@ -792,7 +817,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       lowered.includes('canceled')
     );
 
-    if (!canceledByInterrupt) {
+    if (!canceledByInterrupt && !recoverableContinuationFailure) {
       addErrorMessage(errorMessage, session);
     }
     state.expectCanceledRun = false;
@@ -811,7 +836,12 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     renderSidebar();
     app.refreshSidebarStatusPoll?.();
     scrollVisibleStreamToBottom(session, true);
-    return { terminal: true };
+    return {
+      terminal: true,
+      error: recoverableContinuationFailure
+        ? { message: errorMessage, recoverableContinuationFailure }
+        : null
+    };
   }
 
   return { terminal: false };
@@ -821,6 +851,7 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
   let sawTerminal = false;
   let sawDone = false;
   let stale = false;
+  let terminalError = null;
   const generation = Number.isFinite(Number(options.generation)) ? Number(options.generation) : state.streamGeneration;
   const sessionId = String(session?.id || '').trim();
   const expectedResponseId = String(options.responseId || '').trim();
@@ -865,6 +896,9 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
     if (result?.terminal) {
       sawTerminal = true;
     }
+    if (result?.error) {
+      terminalError = result.error;
+    }
     if (!streamIsCurrent()) {
       stale = true;
       return false;
@@ -872,7 +906,7 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
     return true;
   });
 
-  return { terminal: sawTerminal || sawDone || !session.activeResponseId, stale };
+  return { terminal: sawTerminal || sawDone || !session.activeResponseId, stale, error: stale ? null : terminalError };
 };
 
 const fetchResponseSnapshot = async (session, responseId) => {
@@ -3255,20 +3289,19 @@ const sendMessage = async (options = {}) => {
     updateURL(sessionSlug(session));
   }
 
-  const shouldRefreshContinuation = !options._skipContinuationRefresh && Boolean(
-    session && !session.activeResponseId && (
-      String(session.lastResponseId || '').trim()
-      || Number(session.number || 0) > 0
-      || (Array.isArray(session.messages) && session.messages.length > 0)
-    )
+  const shouldRefreshMissingContinuation = !options._skipContinuationRefresh && Boolean(
+    session
+    && !session.activeResponseId
+    && !String(session.lastResponseId || '').trim()
+    && hasSessionContinuationContext(session)
   );
-  if (shouldRefreshContinuation && typeof app.syncActiveSessionFromServer === 'function') {
+  if (shouldRefreshMissingContinuation && typeof app.syncActiveSessionFromServer === 'function') {
     try {
-      await app.syncActiveSessionFromServer(session, false);
+      await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
       session = getActiveSession() || session;
     } catch (_err) {
-      // Best effort only: the stale-ID guard below still uses the latest
-      // continuation ID we have if the state refresh is unavailable.
+      // Best effort only: if the continuation cursor is still unavailable we
+      // fall back to the local session state below.
     }
     if (state.streaming || session.activeResponseId) {
       return sendMessage({ ...options, _skipContinuationRefresh: true });
@@ -3333,6 +3366,7 @@ const sendMessage = async (options = {}) => {
   setStreaming(true);
   app.refreshSidebarStatusPoll?.();
   const streamState = createResponseStreamState(session);
+  let previousResponseId = '';
 
   try {
     // Build input content: plain string or array with file/image parts
@@ -3352,7 +3386,7 @@ const sendMessage = async (options = {}) => {
       input: [{ type: 'message', role: 'user', content: inputContent }]
     };
 
-    const previousResponseId = String(session.lastResponseId || '').trim();
+    previousResponseId = String(session.lastResponseId || '').trim();
     if (previousResponseId) {
       body.previous_response_id = previousResponseId;
     }
@@ -3431,6 +3465,9 @@ const sendMessage = async (options = {}) => {
     } else {
       const responseId = headerResponseId || session.activeResponseId;
       const result = await consumeResponseStream(response.body, session, streamState, { generation: sendGeneration, responseId });
+      if (!result.stale && result.error) {
+        throw result.error;
+      }
       if (!result.stale && !result.terminal && sendGeneration === state.streamGeneration && session.activeResponseId) {
         await resumeActiveResponse(session, { streamState, responseId });
       }
@@ -3464,6 +3501,51 @@ const sendMessage = async (options = {}) => {
       await resumeActiveResponse(session, { streamState });
       persistAndRefreshShell();
       return;
+    }
+
+    const recoverableContinuationFailure = !options._skipContinuationRefresh
+      ? (err?.recoverableContinuationFailure || classifyRecoverableContinuationFailure(err, previousResponseId))
+      : '';
+    if (recoverableContinuationFailure && typeof app.syncActiveSessionFromServer === 'function') {
+      if (state.abortController === controller) {
+        state.abortController = null;
+      }
+
+      let continuationRefreshed = false;
+      try {
+        await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
+        session = getActiveSession() || session;
+        continuationRefreshed = true;
+      } catch {
+        continuationRefreshed = false;
+      }
+
+      if (state.streaming || session.activeResponseId) {
+        const retryOptions = {
+          ...options,
+          _skipContinuationRefresh: true,
+          reuseMessageId: userMessage.id
+        };
+        if (Array.isArray(userMessage.attachments) && userMessage.attachments.length > 0) {
+          retryOptions.attachments = userMessage.attachments.map(cloneAttachmentForMessage);
+        }
+        detachResponseStream();
+        return sendMessage(retryOptions);
+      }
+
+      const continuationChanged = String(session.lastResponseId || '').trim() !== previousResponseId;
+      if (continuationRefreshed && (recoverableContinuationFailure === 'session_busy' || continuationChanged)) {
+        const retryOptions = {
+          ...options,
+          _skipContinuationRefresh: true,
+          reuseMessageId: userMessage.id
+        };
+        if (Array.isArray(userMessage.attachments) && userMessage.attachments.length > 0) {
+          retryOptions.attachments = userMessage.attachments.map(cloneAttachmentForMessage);
+        }
+        detachResponseStream();
+        return sendMessage(retryOptions);
+      }
     }
 
     // Clear our own controller so syncActiveSessionFromServer can act on

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -451,12 +451,23 @@ function createHarness(options = {}) {
   windowObj.document = document;
   windowObj.localStorage = localStorage;
   windowObj.URL = urlAPI;
-  windowObj.fetch = async function fetch(url, options = {}) {
+  windowObj.fetch = async function fetch(url, requestOptions = {}) {
     fetchCalls.push({
       url,
-      method: options.method || 'GET',
-      body: typeof options.body === 'string' ? options.body : null,
+      method: requestOptions.method || 'GET',
+      body: typeof requestOptions.body === 'string' ? requestOptions.body : null,
     });
+    if (typeof options.fetchImpl === 'function') {
+      return options.fetchImpl(url, requestOptions, {
+        Response,
+        ReadableStream,
+        Headers,
+        TextEncoder,
+        TextDecoder,
+        encoder,
+        responseId,
+      });
+    }
     if (url.includes('/ui/v1/sessions/') && url.endsWith('/interrupt')) {
       if (interruptStatus !== 200) {
         return new Response(JSON.stringify(interruptErrorPayload), {
@@ -469,14 +480,14 @@ function createHarness(options = {}) {
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    if (url === '/ui/v1/responses' && (options.method || 'GET') === 'POST') {
+    if (url === '/ui/v1/responses' && (requestOptions.method || 'GET') === 'POST') {
       if (postStatus !== 200) {
         return new Response(JSON.stringify(postErrorPayload), {
           status: postStatus,
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      const signal = options.signal || null;
+      const signal = requestOptions.signal || null;
       return new Response(new ReadableStream({
         start(controller) {
           postStreamController = controller;
@@ -520,7 +531,7 @@ function createHarness(options = {}) {
     }
     if (url.startsWith(`/ui/v1/responses/${responseId}/events?after=`)) {
       getEventsStarted = true;
-      const signal = options.signal || null;
+      const signal = requestOptions.signal || null;
       if (eventsStatus !== 200) {
         return new Response(JSON.stringify(eventsErrorPayload), {
           status: eventsStatus,
@@ -819,18 +830,107 @@ async function testSendMessageDoesNotResumeAfterStalePostStream() {
   pass(name);
 }
 
-async function testSendMessageRefreshesContinuationIdBeforePosting() {
-  const name = 'sendMessage refreshes stale continuation id before posting';
+async function testSendMessageUsesLocalContinuationIdWithoutPreflightSync() {
+  const name = 'sendMessage uses the local continuation id without preflight sync';
+  const lastResponseId = 'resp_msg_796651';
+  let syncCalls = 0;
+  const harness = createHarness({
+    onSyncActiveSessionFromServer() {
+      syncCalls += 1;
+      return { active_run: false, lastResponseId };
+    },
+  });
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+  const session = {
+    id: 'session_local_previous',
+    title: 'Local previous',
+    messages: [{ id: 'msg_old', role: 'user', content: 'old', created: Date.now() - 1000 }],
+    lastResponseId,
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 42,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  elements.promptInput.value = 'follow up';
+
+  let sendErr = null;
+  await app.sendMessage().catch((err) => {
+    sendErr = err;
+  });
+  await cleanup();
+
+  if (sendErr) {
+    fail(name, 'sendMessage rejected unexpectedly', String(sendErr));
+    return;
+  }
+  if (syncCalls !== 0) {
+    fail(name, `expected no preflight sync, got ${syncCalls}`);
+    return;
+  }
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (!postCall || !postCall.body) {
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    return;
+  }
+  const body = JSON.parse(postCall.body);
+  if (body.previous_response_id !== lastResponseId) {
+    fail(name, `previous_response_id = ${JSON.stringify(body.previous_response_id)}, want ${JSON.stringify(lastResponseId)}`, postCall.body);
+    return;
+  }
+
+  pass(name);
+}
+
+async function testSendMessageRecoversStaleContinuationAfterConflict() {
+  const name = 'sendMessage recovers stale continuation after conflict without preflight sync';
   const staleId = 'resp_msg_796607';
   const latestId = 'resp_msg_796651';
   let syncCalls = 0;
+  let syncOpts = null;
+  let postAttempts = 0;
   const harness = createHarness({
-    onSyncActiveSessionFromServer(session) {
-      syncCalls += 1;
-      if (session.lastResponseId === staleId) {
-        session.lastResponseId = latestId;
+    fetchImpl: async (url, requestOptions, helpers) => {
+      if (url === '/ui/v1/responses' && (requestOptions.method || 'GET') === 'POST') {
+        postAttempts += 1;
+        if (postAttempts === 1) {
+          return new helpers.Response(JSON.stringify({
+            error: { message: `previous_response_id ${JSON.stringify(staleId)} is stale; latest is ${JSON.stringify(latestId)}` }
+          }), {
+            status: 409,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        const responseBody = [
+          'id: 1\n',
+          'event: response.created\n',
+          `data: {"response":{"id":"${latestId}","model":"test-model","status":"in_progress"},"sequence_number":1}\n\n`,
+          'id: 2\n',
+          'event: response.output_text.delta\n',
+          'data: {"delta":"hello","sequence_number":2}\n\n',
+          'id: 3\n',
+          'event: response.completed\n',
+          `data: {"response":{"id":"${latestId}","model":"test-model","status":"completed"},"sequence_number":3}\n\n`,
+          'data: [DONE]\n\n',
+        ].join('');
+        return new helpers.Response(new helpers.ReadableStream({
+          start(controller) {
+            controller.enqueue(helpers.encoder.encode(responseBody));
+            controller.close();
+          },
+        }), {
+          status: 200,
+          headers: { 'x-response-id': latestId },
+        });
       }
-      return { active_run: false, lastResponseId: session.lastResponseId };
+      throw new Error(`unexpected fetch: ${url}`);
+    },
+    onSyncActiveSessionFromServer(session, _pollOnActive, opts) {
+      syncCalls += 1;
+      syncOpts = opts || null;
+      session.lastResponseId = latestId;
+      return { active_run: false, lastResponseId: latestId };
     },
   });
   const { app, elements, state, fetchCalls, cleanup } = harness;
@@ -858,17 +958,30 @@ async function testSendMessageRefreshesContinuationIdBeforePosting() {
     return;
   }
   if (syncCalls !== 1) {
-    fail(name, `expected one preflight sync, got ${syncCalls}`);
+    fail(name, `expected one recovery sync, got ${syncCalls}`);
     return;
   }
-  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
-  if (!postCall || !postCall.body) {
-    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+  if (!syncOpts || syncOpts.skipMessagesFetch !== true) {
+    fail(name, 'expected recovery sync to skip message fetches', JSON.stringify(syncOpts));
     return;
   }
-  const body = JSON.parse(postCall.body);
-  if (body.previous_response_id !== latestId) {
-    fail(name, `previous_response_id = ${JSON.stringify(body.previous_response_id)}, want ${JSON.stringify(latestId)}`, postCall.body);
+  if (postAttempts !== 2) {
+    fail(name, `expected two POST attempts, got ${postAttempts}`);
+    return;
+  }
+  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (postCalls.length !== 2) {
+    fail(name, 'expected two POST /ui/v1/responses calls', JSON.stringify(fetchCalls));
+    return;
+  }
+  const firstBody = JSON.parse(postCalls[0].body || '{}');
+  const secondBody = JSON.parse(postCalls[1].body || '{}');
+  if (firstBody.previous_response_id !== staleId) {
+    fail(name, `first previous_response_id = ${JSON.stringify(firstBody.previous_response_id)}, want ${JSON.stringify(staleId)}`, postCalls[0].body);
+    return;
+  }
+  if (secondBody.previous_response_id !== latestId) {
+    fail(name, `second previous_response_id = ${JSON.stringify(secondBody.previous_response_id)}, want ${JSON.stringify(latestId)}`, postCalls[1].body);
     return;
   }
 
@@ -2801,7 +2914,8 @@ function testRestoreLatestDraftMessageDoesNotCrossSessionBoundary() {
   await testInactiveSessionFailureDoesNotAppendToVisibleDOM();
   await testConsumeResponseStreamReportsStaleWithoutApplyingEvents();
   await testSendMessageDoesNotResumeAfterStalePostStream();
-  await testSendMessageRefreshesContinuationIdBeforePosting();
+  await testSendMessageUsesLocalContinuationIdWithoutPreflightSync();
+  await testSendMessageRecoversStaleContinuationAfterConflict();
   await testSendMessageConsumesPostStreamWhenAvailable();
   await testSendMessageRefreshesHeaderAfterCompletionUnlocksModelPicker();
   await testSendMessageLazilyMaterializesAttachmentDataURLs();


### PR DESCRIPTION
## What

Stop blocking normal follow-up sends on an unconditional preflight session sync.

This narrows the pre-send refresh to the cases that actually need it: when a session has prior context but is missing a local `lastResponseId`. That refresh now also skips message-history reloads.

For sessions that already have a local continuation cursor, `sendMessage` posts immediately. If the server later reports that the cursor is stale or that the session is already busy, the UI does a lightweight state refresh and retries once with the existing drafted user message instead of surfacing an avoidable error.

Also add focused browser-side tests covering the no-preflight fast path and stale-continuation recovery.

## Why

The previous flow awaited `syncActiveSessionFromServer(session, false)` for almost every existing conversation before starting `/v1/responses`. That meant first-token latency for a simple follow-up was gated on an extra `/state` round trip and, when idle syncs reloaded history, potentially many paginated message fetches.

This change keeps the important correctness safeguards for missing/stale continuation IDs and hidden active runs, but removes the unconditional sync from the common case so follow-up prompts can start streaming sooner.