### PR TITLE
perf: stop runaway shell output early

### DIFF
--- a/internal/tools/exec_helpers.go
+++ b/internal/tools/exec_helpers.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -22,21 +24,85 @@ import (
 // setsid, daemonisation, etc.) can still be reliably reaped on cleanup.
 const shellNonceEnvVar = "TERMLLM_SHELL_NONCE"
 
+// outputLimitCanceler shares a raw-output budget across stdout and stderr.
+// Once the budget is crossed it invokes onLimit exactly once, allowing callers
+// to stop commands that would otherwise keep streaming discarded bytes until a
+// timeout fires.
+type outputLimitCanceler struct {
+	limit    int64
+	onLimit  func()
+	total    atomic.Int64
+	exceeded atomic.Bool
+	once     sync.Once
+}
+
+func newOutputLimitCanceler(limit int64, onLimit func()) *outputLimitCanceler {
+	if limit <= 0 {
+		return nil
+	}
+	return &outputLimitCanceler{limit: limit, onLimit: onLimit}
+}
+
+func (c *outputLimitCanceler) add(n int) {
+	if c == nil || n <= 0 {
+		return
+	}
+	if c.total.Add(int64(n)) <= c.limit {
+		return
+	}
+	c.exceeded.Store(true)
+	c.once.Do(func() {
+		if c.onLimit != nil {
+			c.onLimit()
+		}
+	})
+}
+
+func (c *outputLimitCanceler) Exceeded() bool {
+	return c != nil && c.exceeded.Load()
+}
+
 type limitedBuffer struct {
-	buf   bytes.Buffer
-	limit int64
-	total int64
+	buf     bytes.Buffer
+	limit   int64
+	total   int64
+	limiter *outputLimitCanceler
 }
 
 func newLimitedBuffer(limit int64) *limitedBuffer {
+	return newLimitedBufferWithLimiter(limit, nil)
+}
+
+func newLimitedBufferWithLimiter(limit int64, limiter *outputLimitCanceler) *limitedBuffer {
 	if limit < 0 {
 		limit = 0
 	}
-	return &limitedBuffer{limit: limit}
+	return &limitedBuffer{limit: limit, limiter: limiter}
+}
+
+// commandOutputHardLimit returns the raw bytes a command may emit before the
+// tool cancels it. MaxBytes remains the capture/display cap; the hard drain cap
+// is intentionally much larger so normal over-limit commands can finish while
+// runaway output producers return promptly.
+func commandOutputHardLimit(limits OutputLimits) int64 {
+	hard := limits.CumulativeHard
+	if limits.MaxBytes > 0 {
+		scaled := limits.MaxBytes * 128
+		if hard < scaled {
+			hard = scaled
+		}
+	}
+	if limits.MaxBytes > 0 && hard < limits.MaxBytes {
+		hard = limits.MaxBytes
+	}
+	return hard
 }
 
 func (b *limitedBuffer) Write(p []byte) (int, error) {
 	origLen := len(p)
+	if b.limiter != nil {
+		b.limiter.add(origLen)
+	}
 	b.total += int64(origLen)
 
 	remaining := b.limit - int64(b.buf.Len())

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -76,12 +76,13 @@ type ShellArgs struct {
 
 // ShellResult contains the result of a shell command.
 type ShellResult struct {
-	Stdout          string `json:"stdout"`
-	Stderr          string `json:"stderr"`
-	ExitCode        int    `json:"exit_code"`
-	TimedOut        bool   `json:"timed_out,omitempty"`
-	StdoutTruncated bool   `json:"stdout_truncated,omitempty"`
-	StderrTruncated bool   `json:"stderr_truncated,omitempty"`
+	Stdout              string `json:"stdout"`
+	Stderr              string `json:"stderr"`
+	ExitCode            int    `json:"exit_code"`
+	TimedOut            bool   `json:"timed_out,omitempty"`
+	OutputLimitExceeded bool   `json:"output_limit_exceeded,omitempty"`
+	StdoutTruncated     bool   `json:"stdout_truncated,omitempty"`
+	StderrTruncated     bool   `json:"stderr_truncated,omitempty"`
 }
 
 func (t *ShellTool) Spec() llm.ToolSpec {
@@ -236,8 +237,9 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 	}
 	defer cleanup()
 
-	stdout := newLimitedBuffer(t.limits.MaxBytes)
-	stderr := newLimitedBuffer(t.limits.MaxBytes)
+	outputLimiter := newOutputLimitCanceler(commandOutputHardLimit(t.limits), cancel)
+	stdout := newLimitedBufferWithLimiter(t.limits.MaxBytes, outputLimiter)
+	stderr := newLimitedBufferWithLimiter(t.limits.MaxBytes, outputLimiter)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
@@ -245,26 +247,36 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 	err := cmd.Run()
 
 	result := ShellResult{
-		Stdout:          stdout.String(),
-		Stderr:          stderr.String(),
-		ExitCode:        0,
-		StdoutTruncated: stdout.Truncated(),
-		StderrTruncated: stderr.Truncated(),
+		Stdout:              stdout.String(),
+		Stderr:              stderr.String(),
+		ExitCode:            0,
+		OutputLimitExceeded: outputLimiter.Exceeded(),
+		StdoutTruncated:     stdout.Truncated(),
+		StderrTruncated:     stderr.Truncated(),
 	}
 
-	// Check for timeout
-	if execCtx.Err() != nil {
+	// Get exit code when the process was terminated by the shell or our output cap.
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		} else if !result.OutputLimitExceeded && execCtx.Err() == nil {
+			return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "command error: %v", err))), nil
+		}
+	}
+
+	if execCtx.Err() == context.DeadlineExceeded {
 		result.TimedOut = true
 		return llm.ToolOutput{Content: warning + formatShellResult(result, t.limits), TimedOut: true}, nil
 	}
 
-	// Get exit code
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			result.ExitCode = exitErr.ExitCode()
-		} else {
-			return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "command error: %v", err))), nil
-		}
+	if result.OutputLimitExceeded {
+		return textOutput(formatShellResult(result, t.limits)), nil
+	}
+
+	// Preserve the existing cancellation behavior for parent context cancellation.
+	if execCtx.Err() != nil {
+		result.TimedOut = true
+		return llm.ToolOutput{Content: warning + formatShellResult(result, t.limits), TimedOut: true}, nil
 	}
 
 	return textOutput(formatShellResult(result, t.limits)), nil
@@ -290,6 +302,8 @@ func formatShellResult(result ShellResult, limits OutputLimits) string {
 
 	if result.TimedOut {
 		sb.WriteString("[Command timed out]\n\n")
+	} else if result.OutputLimitExceeded {
+		sb.WriteString("[Command stopped after exceeding output limit]\n\n")
 	}
 
 	if stdout != "" {

--- a/internal/tools/shell_runaway_bench_test.go
+++ b/internal/tools/shell_runaway_bench_test.go
@@ -1,0 +1,59 @@
+package tools
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestShellTool_RunawayOutputStopsAtHardLimit(t *testing.T) {
+	if _, err := exec.LookPath("yes"); err != nil {
+		t.Skip("yes not available")
+	}
+
+	limits := DefaultOutputLimits()
+	limits.MaxBytes = 32
+	limits.CumulativeHard = 256
+	tool := NewShellTool(nil, nil, limits)
+	args := mustMarshalShellArgs(ShellArgs{Command: "yes x", TimeoutSeconds: 5})
+
+	start := time.Now()
+	output, err := tool.Execute(context.Background(), args)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("runaway output should stop at hard output limit quickly; elapsed=%s output=%s", elapsed, output.Content)
+	}
+	if output.TimedOut {
+		t.Fatalf("output-limit cancellation should not be reported as timeout; output=%s", output.Content)
+	}
+	if !strings.Contains(output.Content, "[Command stopped after exceeding output limit]") {
+		t.Fatalf("expected output-limit marker, got: %s", output.Content)
+	}
+	if !strings.Contains(output.Content, "[Output truncated due to size limit]") {
+		t.Fatalf("expected truncation marker, got: %s", output.Content)
+	}
+}
+
+func BenchmarkShellToolRunawayOutputSmallLimit(b *testing.B) {
+	if _, err := exec.LookPath("yes"); err != nil {
+		b.Skip("yes not available")
+	}
+
+	limits := DefaultOutputLimits()
+	limits.MaxBytes = 16
+	limits.CumulativeHard = 256
+	tool := NewShellTool(nil, nil, limits)
+	args := mustMarshalShellArgs(ShellArgs{Command: "yes x", TimeoutSeconds: 1})
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := tool.Execute(context.Background(), args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What

Stop runaway shell commands that exceed a raw stdout/stderr drain budget instead of continuing to stream discarded bytes until the timeout fires.

- Shares a hard raw-output budget across stdout and stderr for `ShellTool`.
- Cancels the command context once the budget is crossed, while still retaining the existing bounded captured output.
- Reports a clear `[Command stopped after exceeding output limit]` marker separately from real timeouts.
- Adds a regression test and benchmark for infinite-output shell commands.

## Why

The existing `limitedBuffer` protected memory by retaining only `MaxBytes`, but it returned success for every subsequent write. A command like `yes x` with a small output cap still ran until `timeout_seconds`, burning wall-clock time and CPU even though no more useful output would be sent to the model.

Representative benchmark with `yes x`, `MaxBytes=16`, `CumulativeHard=256`, `timeout_seconds=1`:

- Before: `BenchmarkShellToolRunawayOutputSmallLimit-32  3  1000577260 ns/op`
- After: `BenchmarkShellToolRunawayOutputSmallLimit-32  3  3327777 ns/op`

## Verification

- `go test ./internal/tools -run 'TestShellTool_RunawayOutputStopsAtHardLimit' -count=1`
- `go test ./internal/tools -run '^$' -bench BenchmarkShellToolRunawayOutputSmallLimit -benchtime=3x -count=1`
- `go build ./...`
- `go test ./...`
