### PR TITLE
build: exclude UI JS fixtures from embed

### DIFF
--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -13,7 +13,12 @@ import (
 	"sync"
 )
 
-//go:embed static/*
+//go:embed static/index.html static/manifest.webmanifest static/icon-512.png static/sw.js
+//go:embed static/app.css
+//go:embed static/app-core.js static/app-render.js static/app-sessions.js static/app-sidebar.js
+//go:embed static/app-stream.js static/app-webrtc.js
+//go:embed static/decoration.js static/markdown-setup.js static/markdown-streaming.js
+//go:embed static/vendor
 var staticFiles embed.FS
 
 var (

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -1,10 +1,12 @@
 package serveui
 
 import (
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -62,6 +64,68 @@ func TestStaticAssetsUseStrictMathDelimiters(t *testing.T) {
 	}
 	if strings.Contains(coreSrc, "{ left: '$', right: '$', display: false }") {
 		t.Fatal("app-core.js still enables single-dollar inline math")
+	}
+}
+
+func TestStaticAssetsEmbedProductionFilesOnly(t *testing.T) {
+	embedded := make(map[string]bool)
+	var testFixtures []string
+	err := fs.WalkDir(staticFiles, "static", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		embedded[path] = true
+		if strings.HasSuffix(path, "_test.js") {
+			testFixtures = append(testFixtures, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded static assets: %v", err)
+	}
+	if len(testFixtures) > 0 {
+		sort.Strings(testFixtures)
+		t.Fatalf("embedded JS test fixtures: %s", strings.Join(testFixtures, ", "))
+	}
+	if _, err := StaticAsset("app_stream_test.js"); err == nil {
+		t.Fatal("StaticAsset(app_stream_test.js) succeeded; JS test fixtures should not be embedded")
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	testDir := filepath.Dir(thisFile)
+	var missing []string
+	err = filepath.WalkDir(filepath.Join(testDir, "static"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(testDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasSuffix(rel, "_test.js") {
+			return nil
+		}
+		if !embedded[rel] {
+			missing = append(missing, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk source static assets: %v", err)
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("production static assets not embedded: %s", strings.Join(missing, ", "))
 	}
 }
 


### PR DESCRIPTION
## What

- Replace the broad `//go:embed static/*` serve UI embed with a production-asset allowlist plus `static/vendor`.
- Add a regression test that embedded static assets contain every non-test production file, but no `*_test.js` JS fixtures.

## Why

The previous embed glob shipped the browser JS test fixtures inside the production binary and included them in `AssetVersion()` hashing, so test-only edits could churn UI cache keys and the binary carried avoidable bytes.

## Evidence

- `internal/serveui/static/*_test.js`: 266,687 source bytes no longer embedded.
- Local `go build -o` binary size: 85,652,576 bytes before vs 85,386,840 bytes after (265,736 bytes smaller).
- Verified with `go test -count=1 ./internal/serveui`, `go build ./...`, and `go test ./...`.
