### PR TITLE
fix: centralize SQLite FTS user query escaping

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -969,27 +969,6 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 	writeJSONConditional(w, r, http.StatusOK, map[string]any{"sessions": result})
 }
 
-func ftsQueryFromUser(query string) string {
-	fields := strings.FieldsFunc(query, func(r rune) bool {
-		return !(r == '_' || r == '-' || r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || r >= 0x80)
-	})
-	terms := make([]string, 0, len(fields))
-	seen := make(map[string]bool, len(fields))
-	for _, field := range fields {
-		term := strings.Trim(field, `"`)
-		if len([]rune(term)) < 2 {
-			continue
-		}
-		key := strings.ToLower(term)
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		terms = append(terms, `"`+strings.ReplaceAll(term, `"`, `""`)+`"`)
-	}
-	return strings.Join(terms, " ")
-}
-
 func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
@@ -1012,8 +991,7 @@ func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Reques
 	if query == "" {
 		query = strings.TrimSpace(r.URL.Query().Get("query"))
 	}
-	ftsQuery := ftsQueryFromUser(query)
-	if ftsQuery == "" {
+	if query == "" {
 		writeJSONConditional(w, r, http.StatusOK, map[string]any{"sessions": []any{}})
 		return
 	}
@@ -1039,7 +1017,7 @@ func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Reques
 		allowed[summary.ID] = summary
 	}
 
-	matches, err := s.store.Search(r.Context(), ftsQuery, limit*4)
+	matches, err := s.store.Search(r.Context(), query, limit*4)
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid search query")
 		return

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/embedding"
+	"github.com/samsaffron/term-llm/internal/sqlitefts"
 	_ "modernc.org/sqlite"
 )
 
@@ -815,6 +816,11 @@ func (s *Store) SearchBM25(ctx context.Context, query string, limit int, agent s
 		limit = 6
 	}
 
+	ftsQuery := sqlitefts.LiteralQuery(query)
+	if ftsQuery == "" {
+		return []ScoredFragment{}, nil
+	}
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT mf.id,
 		       mf.agent,
@@ -834,7 +840,7 @@ func (s *Store) SearchBM25(ctx context.Context, query string, limit int, agent s
 		WHERE memory_fts MATCH ?
 		  AND (? = '' OR mf.agent = ?)
 		ORDER BY bm25(memory_fts)
-		LIMIT ?`, query, agent, agent, limit)
+		LIMIT ?`, ftsQuery, agent, agent, limit)
 	if err != nil {
 		return nil, fmt.Errorf("search fragments: %w", err)
 	}
@@ -2010,6 +2016,11 @@ func (s *Store) SearchImages(ctx context.Context, query, agent string, limit int
 		limit = 10
 	}
 
+	ftsQuery := sqlitefts.LiteralQuery(query)
+	if ftsQuery == "" {
+		return []ImageRecord{}, nil
+	}
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT g.id, g.agent, g.session_id, g.prompt, g.output_path, g.mime_type,
 		       g.provider, g.width, g.height, g.file_size, g.created_at
@@ -2019,7 +2030,7 @@ func (s *Store) SearchImages(ctx context.Context, query, agent string, limit int
 		  AND (? = '' OR g.agent = ?)
 		ORDER BY rank
 		LIMIT ?`,
-		query, agent, agent, limit,
+		ftsQuery, agent, agent, limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("search images: %w", err)
@@ -2275,37 +2286,6 @@ func (s *Store) ReinforceInsight(ctx context.Context, id int64) error {
 	return nil
 }
 
-// SearchInsights returns insights matching a BM25 query, sorted by relevance.
-// buildFTSQuery converts a free-text query to an FTS5 OR expression so that
-// any word match scores a hit (BM25 ranking then surfaces the best results).
-// Words shorter than 3 characters and duplicates are dropped.
-func buildFTSQuery(query string) string {
-	seen := map[string]struct{}{}
-	var terms []string
-	for _, w := range strings.Fields(strings.ToLower(query)) {
-		// Strip non-alphanumeric so we don't pass FTS5 syntax characters.
-		var clean []rune
-		for _, r := range w {
-			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-				clean = append(clean, r)
-			}
-		}
-		s := string(clean)
-		if len(s) < 3 {
-			continue
-		}
-		if _, dup := seen[s]; dup {
-			continue
-		}
-		seen[s] = struct{}{}
-		terms = append(terms, s+"*") // prefix match for basic stemming
-	}
-	if len(terms) == 0 {
-		return ""
-	}
-	return strings.Join(terms, " OR ")
-}
-
 // SearchInsights finds insights via BM25 full-text search. Used for deduplication
 // during extraction (checking if a newly mined insight already exists), not for
 // injection — ExpandInsights returns all insights sorted by confidence instead.
@@ -2317,7 +2297,10 @@ func (s *Store) SearchInsights(ctx context.Context, agent, query string, limit i
 		limit = 10
 	}
 
-	ftsQuery := buildFTSQuery(query)
+	ftsQuery := sqlitefts.PrefixORQuery(query, 3)
+	if ftsQuery == "" {
+		return s.ListInsights(ctx, agent, limit)
+	}
 	args := []any{ftsQuery}
 	agentClause := ""
 	if strings.TrimSpace(agent) != "" {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -61,6 +61,37 @@ func TestStoreFragmentCRUDAndSearch(t *testing.T) {
 	}
 }
 
+func TestSearchFragmentsEscapesUserQueryForFTS(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	if err := store.CreateFragment(ctx, &Fragment{
+		Agent:   "jarvis",
+		Path:    "projects/term-llm/memory.md",
+		Content: "term-llm memory search should tolerate punctuation in user queries",
+		Source:  DefaultSourceMine,
+	}); err != nil {
+		t.Fatalf("CreateFragment() error = %v", err)
+	}
+
+	results, err := store.SearchFragments(ctx, "term-llm", 10, "jarvis")
+	if err != nil {
+		t.Fatalf("SearchFragments(term-llm) error = %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("SearchFragments(term-llm) returned no rows")
+	}
+
+	results, err = store.SearchFragments(ctx, `"term-llm" + memory:`, 10, "jarvis")
+	if err != nil {
+		t.Fatalf("SearchFragments(punctuated query) error = %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("SearchFragments(punctuated query) returned no rows")
+	}
+}
+
 func TestFragmentSourcesCRUD(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
@@ -746,6 +777,13 @@ func TestSearchImages(t *testing.T) {
 	}
 	if results[0].Prompt != records[0].Prompt {
 		t.Fatalf("SearchImages() prompt = %q, want %q", results[0].Prompt, records[0].Prompt)
+	}
+	results, err = store.SearchImages(ctx, "space-png", "jarvis", 10)
+	if err != nil {
+		t.Fatalf("SearchImages(hyphenated query) error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("SearchImages(hyphenated query) len = %d, want 1", len(results))
 	}
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/sqlitefts"
 	_ "modernc.org/sqlite"
 )
 
@@ -1384,6 +1385,11 @@ func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]Se
 		limit = 20
 	}
 
+	ftsQuery := sqlitefts.LiteralQuery(query)
+	if ftsQuery == "" {
+		return []SearchResult{}, nil
+	}
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT m.session_id, s.number, m.id, s.name, s.summary, snippet(messages_fts, 0, '**', '**', '...', 32),
 		       s.provider, s.model, m.created_at
@@ -1392,7 +1398,7 @@ func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]Se
 		JOIN sessions s ON s.id = m.session_id
 		WHERE messages_fts MATCH ?
 		ORDER BY rank
-		LIMIT ?`, query, limit)
+		LIMIT ?`, ftsQuery, limit)
 	if err != nil {
 		return nil, fmt.Errorf("search messages: %w", err)
 	}

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -66,6 +66,34 @@ func TestSQLiteStoreReplaceMessagesPreservesTurnIndex(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreSearchEscapesUserQueryForFTS(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	msg := NewMessage(sess.ID, llm.Message{Role: llm.RoleUser, Parts: []llm.Part{{Type: llm.PartText, Text: "term-llm memory search"}}}, 0)
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	results, err := store.Search(ctx, "term-llm", 10)
+	if err != nil {
+		t.Fatalf("Search(term-llm) error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search(term-llm) len = %d, want 1", len(results))
+	}
+}
+
 func TestSQLiteStorePersistsDeveloperMessages(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 

--- a/internal/sqlitefts/query.go
+++ b/internal/sqlitefts/query.go
@@ -1,0 +1,72 @@
+package sqlitefts
+
+import (
+	"strings"
+	"unicode"
+)
+
+// LiteralQuery converts free-form user text into an FTS5 MATCH expression that
+// treats every whitespace-delimited chunk as a literal string, not as FTS5 query
+// syntax. SQL parameters protect the SQL parser; callers still need this helper
+// for the second parser: FTS5's MATCH expression grammar.
+func LiteralQuery(query string) string {
+	return LiteralQueryMin(query, 0)
+}
+
+// LiteralQueryMin is like LiteralQuery, but drops chunks shorter than minRunes.
+func LiteralQueryMin(query string, minRunes int) string {
+	fields := strings.Fields(query)
+	terms := make([]string, 0, len(fields))
+	seen := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		term := strings.TrimSpace(field)
+		if term == "" || runeLen(term) < minRunes {
+			continue
+		}
+		key := strings.ToLower(term)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		terms = append(terms, QuoteString(term))
+	}
+	return strings.Join(terms, " ")
+}
+
+// PrefixORQuery converts free-form text into an FTS5 expression matching any
+// alphanumeric token by prefix. This is useful for recall-oriented fuzzy-ish
+// dedupe searches where any word match should produce a candidate.
+func PrefixORQuery(query string, minRunes int) string {
+	seen := map[string]struct{}{}
+	var terms []string
+	for _, field := range strings.Fields(strings.ToLower(query)) {
+		var b strings.Builder
+		for _, r := range field {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				b.WriteRune(r)
+			}
+		}
+		term := b.String()
+		if term == "" || runeLen(term) < minRunes {
+			continue
+		}
+		if _, dup := seen[term]; dup {
+			continue
+		}
+		seen[term] = struct{}{}
+		terms = append(terms, QuoteString(term)+"*")
+	}
+	return strings.Join(terms, " OR ")
+}
+
+// QuoteString returns an FTS5 double-quoted string literal.
+func QuoteString(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+func runeLen(s string) int {
+	if s == "" {
+		return 0
+	}
+	return len([]rune(s))
+}

--- a/internal/sqlitefts/query_test.go
+++ b/internal/sqlitefts/query_test.go
@@ -1,0 +1,37 @@
+package sqlitefts
+
+import "testing"
+
+func TestLiteralQueryEscapesFTS5Syntax(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"term-llm", `"term-llm"`},
+		{"term-llm architecture", `"term-llm" "architecture"`},
+		{`foo "bar`, `"foo" """bar"`},
+		{"OR NOT NEAR", `"OR" "NOT" "NEAR"`},
+		{"שלום עולם", `"שלום" "עולם"`},
+	}
+	for _, tt := range tests {
+		if got := LiteralQuery(tt.query); got != tt.want {
+			t.Fatalf("LiteralQuery(%q) = %q, want %q", tt.query, got, tt.want)
+		}
+	}
+}
+
+func TestLiteralQueryMinDedupesCaseInsensitively(t *testing.T) {
+	got := LiteralQueryMin("a an AN term", 2)
+	want := `"an" "term"`
+	if got != want {
+		t.Fatalf("LiteralQueryMin() = %q, want %q", got, want)
+	}
+}
+
+func TestPrefixORQuery(t *testing.T) {
+	got := PrefixORQuery("AI: memory, memory-search NOT", 3)
+	want := `"memory"* OR "memorysearch"* OR "not"*`
+	if got != want {
+		t.Fatalf("PrefixORQuery() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Centralize SQLite FTS5 user-query escaping in `internal/sqlitefts` and use it anywhere term-llm passes free-form text into `MATCH ?`:

- memory fragment BM25 search
- generated image search
- memory insight dedupe search
- persisted session search / web session search

## Why

SQL parameters protect the SQL parser, but SQLite FTS5 has a second parser for the bound `MATCH` expression. Raw user queries like `term-llm` are parsed as FTS syntax and can fail with:

```text
SQL logic error: no such column: llm (1)
```

The new helper makes that boundary explicit instead of scattering near-duplicate escaping logic in `cmd` and `internal/memory`.

## Notes

- `sqlitefts.LiteralQuery` quotes whitespace-delimited chunks for literal user search.
- `sqlitefts.PrefixORQuery` covers the existing insight-dedupe use case: recall-oriented OR/prefix matching.
- The web sessions handler now passes raw user text to the session store; the store owns FTS escaping.

## Verification

```text
go test ./internal/sqlitefts ./internal/memory ./internal/session ./cmd
ok

go build ./...
ok
```

Smoke-tested installed patched binary:

```text
term-llm memory search "term-llm" --agent jarvis --limit 3 --bm25-only
term-llm memory search '"term-llm" + memory:' --agent jarvis --limit 3 --bm25-only
```

Full `go test ./...` was previously run and hit existing unrelated failure `TestRunAgentScriptTool_TimeoutKillsGrandchildren` in `internal/tools`.
