### PR TITLE
feat: show agent name in web sidebar

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -550,6 +550,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 				verbose:             serveVerbose,
 				basePath:            serveBasePath,
 				sidebarSessions:     append([]string(nil), sidebarSessions...),
+				agentName:           agentName,
 				corsOrigins:         append([]string(nil), serveCORSOrigins...),
 				filesDir:            resolveFilesDir(serveFilesDir, cfg),
 				writeDirs:           resolveServeWriteDirs(serveWriteDirs, cfg),
@@ -818,6 +819,7 @@ type serveServerConfig struct {
 	verbose             bool
 	basePath            string // e.g. "/ui" or "/chat", always without trailing slash
 	sidebarSessions     []string
+	agentName           string
 	corsOrigins         []string
 	filesDir            string   // opt-in directory for serving arbitrary files (videos, PDFs, etc)
 	writeDirs           []string // tool write-dirs (CLI + config); tool-reported files inside these are trusted sources for ensureFileServeable

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -260,6 +260,8 @@ func (s *serveServer) buildIndexHTML() []byte {
 	}
 	sidebarEscaped, _ := json.Marshal(sidebarSessions)
 	headSnippet += `<script>window.TERM_LLM_SIDEBAR_SESSIONS=` + string(sidebarEscaped) + `;</script>`
+	agentEscaped, _ := json.Marshal(s.cfg.agentName)
+	headSnippet += `<script>window.TERM_LLM_AGENT_NAME=` + string(agentEscaped) + `;</script>`
 	if s.cfgRef != nil {
 		if vapidKey := s.cfgRef.Serve.WebPush.VAPIDPublicKey; vapidKey != "" {
 			vapidEscaped, _ := json.Marshal(vapidKey)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -394,6 +394,7 @@ func TestCustomBasePath_EndToEnd(t *testing.T) {
 			ui:              true,
 			basePath:        "/chat",
 			sidebarSessions: []string{"chat", "web"},
+			agentName:       "jarvis",
 		},
 	}
 
@@ -415,6 +416,9 @@ func TestCustomBasePath_EndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(body, `TERM_LLM_SIDEBAR_SESSIONS=["chat","web"]`) {
 		t.Error("/ should inject TERM_LLM_SIDEBAR_SESSIONS")
+	}
+	if !strings.Contains(body, `TERM_LLM_AGENT_NAME="jarvis"`) {
+		t.Error("/ should inject TERM_LLM_AGENT_NAME")
 	}
 	if !strings.Contains(body, `TERM_LLM_UI_VERSION=`) {
 		t.Error("/ should inject TERM_LLM_UI_VERSION")

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -172,6 +172,7 @@ const elements = {
   sidebarRailSettingsBtn: document.getElementById('sidebarRailSettingsBtn'),
   mobileMenuBtn: document.getElementById('mobileMenuBtn'),
   settingsBtn: document.getElementById('settingsBtn'),
+  sidebarBrandText: document.getElementById('sidebarBrandText'),
   newChatBtn: document.getElementById('newChatBtn'),
   widgetsOpenBtn: document.getElementById('widgetsOpenBtn'),
   widgetsModal: document.getElementById('widgetsModal'),
@@ -252,6 +253,23 @@ const elements = {
   startupSplash: document.getElementById('startupSplash'),
   startupStatus: document.getElementById('startupStatus')
 };
+
+const displayAgentName = (name) => {
+  const cleaned = String(name || '').trim();
+  if (!cleaned) return 'Chat';
+  return cleaned
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const applySidebarBrand = () => {
+  if (!elements.sidebarBrandText) return;
+  elements.sidebarBrandText.textContent = displayAgentName(window.TERM_LLM_AGENT_NAME);
+};
+
+applySidebarBrand();
 
 // marked is configured via markdown-setup.js (loaded before this file).
 
@@ -1311,6 +1329,8 @@ Object.assign(app, {
   state,
   elements,
   markdownStreaming: app.markdownStreaming,
+  displayAgentName,
+  applySidebarBrand,
   generateUUID,
   generateId,
   INTERRUPT_BADGE_META,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -351,16 +351,15 @@
       font-weight: 600;
       line-height: 1.25;
       transition: background 0.15s ease, border-color 0.15s ease;
-    }
-
-    .widgets-sidebar-btn {
       display: flex;
       align-items: center;
       gap: 0.55rem;
     }
 
     .sidebar-action-icon {
-      flex: 0 0 auto;
+      flex: 0 0 17px;
+      width: 17px;
+      height: 17px;
       color: currentColor;
     }
 

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -63,7 +63,7 @@ function makeNode() {
   };
 }
 
-function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], navigatorOverrides = {}, initialStorage = {} } = {}) {
+function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], navigatorOverrides = {}, initialStorage = {}, agentName = '' } = {}) {
   const nodes = new Map(Object.entries(nodeOverrides));
   const cookieWrites = [];
   const document = {
@@ -110,6 +110,7 @@ function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], navigato
     TermLLMApp: {},
     TERM_LLM_UI_PREFIX: '/chat',
     TERM_LLM_SIDEBAR_SESSIONS: 'all',
+    TERM_LLM_AGENT_NAME: agentName,
     navigator: navigatorObj,
     visualViewport: null,
     innerHeight: 1000,
@@ -199,6 +200,37 @@ const app = loadAppCore();
   const finalWrite = writes[writes.length - 1] || '';
   if (finalWrite !== 'term_llm_token=initial-token; path=/chat; SameSite=Strict; max-age=31536000') {
     fail(name, `got ${JSON.stringify(finalWrite)}`);
+    return;
+  }
+  pass(name);
+})();
+
+(function testSidebarBrandUsesAgentName() {
+  const name = 'sidebar brand uses injected agent name';
+  const brandNode = makeNode();
+  const testApp = loadAppCoreWith({
+    agentName: 'jarvis',
+    nodeOverrides: { sidebarBrandText: brandNode },
+  });
+
+  if (brandNode.textContent !== 'Jarvis') {
+    fail(name, `got ${JSON.stringify(brandNode.textContent)}`);
+    return;
+  }
+  if (testApp.displayAgentName('web-researcher') !== 'Web Researcher') {
+    fail(name, `hyphenated agent label was ${JSON.stringify(testApp.displayAgentName('web-researcher'))}`);
+    return;
+  }
+  pass(name);
+})();
+
+(function testSidebarBrandFallsBackToChat() {
+  const name = 'sidebar brand falls back to Chat without an agent';
+  const brandNode = makeNode();
+  loadAppCoreWith({ nodeOverrides: { sidebarBrandText: brandNode } });
+
+  if (brandNode.textContent !== 'Chat') {
+    fail(name, `got ${JSON.stringify(brandNode.textContent)}`);
     return;
   }
   pass(name);

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -154,7 +154,7 @@
           <button class="icon-btn" id="sidebarPanelToggleBtn" type="button" aria-label="Collapse sidebar" aria-expanded="true" title="Collapse sidebar">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
           </button>
-          <div class="brand"><span>Chat</span></div>
+          <div class="brand"><span id="sidebarBrandText">Chat</span></div>
           <div class="sidebar-header-actions">
             <button class="icon-btn" id="settingsBtn" title="Token settings" aria-label="Token settings">⚙</button>
             <button class="icon-btn sidebar-close" id="sidebarCloseBtn" title="Close sidebar" aria-label="Close sidebar">✕</button>
@@ -162,7 +162,13 @@
         </div>
         <div class="sidebar-content">
           <div class="sidebar-actions">
-            <button class="new-chat-btn" id="newChatBtn" type="button">✎ New chat</button>
+            <button class="new-chat-btn" id="newChatBtn" type="button">
+              <svg class="sidebar-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M12 20h9"></path>
+                <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
+              </svg>
+              <span>New chat</span>
+            </button>
             <button class="widgets-sidebar-btn hidden" id="widgetsOpenBtn" type="button" aria-label="Open widgets">
               <svg class="sidebar-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>


### PR DESCRIPTION
## What

- Shows the active web serve agent name in the sidebar header instead of the hard-coded `Chat` label.
- Falls back to `Chat` when no agent is configured.
- Replaces the `New chat` glyph with an inline SVG pencil icon and gives `New chat` / `Widgets` the same icon column, sizing, and spacing.

## Why

The sidebar header should identify the current agent, e.g. `Jarvis`, and the action icons should look like they come from the same UI rather than a Unicode junk drawer. No switcher behavior is added yet.

## Verification

- `go build ./...`
- `go test ./...`
- `node internal/serveui/static/app_core_test.js`
