### PR TITLE
feat: add GPT-5.5 to OpenAI models

### DIFF
--- a/internal/llm/context_window.go
+++ b/internal/llm/context_window.go
@@ -367,6 +367,7 @@ var inputLimitTable = []limitEntry{
 	{"anthropic.claude-sonnet-4", 180_000},
 
 	// OpenAI GPT-5 family
+	{"gpt-5.5", 922_000},             // 1,050,000 ctx - 128,000 out
 	{"gpt-5.4-mini", 272_000},        // 400K ctx - 128K out
 	{"gpt-5.4-nano", 272_000},        // 400K ctx - 128K out
 	{"gpt-5.4", 922_000},             // 1,050,000 ctx - 128,000 out
@@ -542,6 +543,7 @@ var outputLimitTable = []limitEntry{
 	{"anthropic.claude-sonnet-4", 64_000},
 
 	// OpenAI GPT-5 family
+	{"gpt-5.5", 128_000},
 	{"gpt-5.4-mini", 128_000},
 	{"gpt-5.4-nano", 128_000},
 	{"gpt-5.4", 128_000},

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -40,6 +40,7 @@ var ProviderModels = map[string][]ModelEntry{
 		{ID: "claude-haiku-4-5-thinking", InputLimit: 180_000, OutputLimit: 64_000},
 	},
 	"openai": {
+		{ID: "gpt-5.5", InputLimit: 922_000, OutputLimit: 128_000},
 		{ID: "gpt-5.4", InputLimit: 922_000, OutputLimit: 128_000},
 		{ID: "gpt-5.4-mini", InputLimit: 272_000, OutputLimit: 128_000},
 		{ID: "gpt-5.4-nano", InputLimit: 272_000, OutputLimit: 128_000},

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -2,7 +2,16 @@ package llm
 
 import "testing"
 
-func TestProviderModelsIncludeGPT54MiniAndNano(t *testing.T) {
+func TestProviderModelsIncludeLatestOpenAIModels(t *testing.T) {
+	if !containsModelID(ProviderModelIDs("openai"), "gpt-5.5") {
+		t.Fatalf("openai models missing gpt-5.5")
+	}
+	if got := InputLimitForProviderModel("openai", "gpt-5.5"); got != 922_000 {
+		t.Fatalf("openai gpt-5.5 input limit = %d, want %d", got, 922_000)
+	}
+	if got := OutputLimitForModel("gpt-5.5"); got != 128_000 {
+		t.Fatalf("gpt-5.5 output limit = %d, want %d", got, 128_000)
+	}
 	if !containsModelID(ProviderModelIDs("openai"), "gpt-5.4-mini") {
 		t.Fatalf("openai models missing gpt-5.4-mini")
 	}


### PR DESCRIPTION
## What

- Add `gpt-5.5` to the curated OpenAI model list so it appears for OpenAI when the UI/CLI falls back to local models.
- Add canonical `gpt-5.5` token limits: `1,050,000` context minus `128,000` max output = `922,000` effective input tokens.
- Cover the new OpenAI entry and limits in model tests.

## Why

OpenAI's model catalog now lists `gpt-5.5` with a `1,050,000` context window and `128,000` max output tokens. The ChatGPT provider already exposed `gpt-5.5`, but the OpenAI provider's curated fallback list did not, so the model picker could miss it for OpenAI-backed usage.

## Test plan

- `go test ./internal/llm`
- `go build ./...`
- `go test ./...`
