### PR TITLE
fix: preserve explicit math delimiters in web UI

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -596,7 +596,61 @@ const enhanceMathAsync = (target) => {
   ensureKatexLoaded().then((loaded) => {
     if (!loaded || !isAttachedToDocument(target)) return;
     renderMath(target);
+    decorateMathCopyControls(target);
   }).catch(() => {});
+};
+
+const extractRenderedMathText = (mathNode) => {
+  const annotation = mathNode?.querySelector?.('annotation');
+  const text = String(annotation?.textContent || '').trim();
+  if (text) return text;
+  return String(mathNode?.textContent || '').trim();
+};
+
+const decorateMathCopyControls = (target) => {
+  if (!target || typeof target.querySelectorAll !== 'function') return;
+  target.querySelectorAll('.katex-display').forEach((display) => {
+    if (display.querySelector('.math-copy-btn')) return;
+    const mathNode = display.querySelector('.katex');
+    const text = extractRenderedMathText(mathNode || display);
+    if (!text) return;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'math-copy-btn';
+    btn.title = 'Copy math as text';
+    btn.setAttribute('aria-label', 'Copy math as text');
+    btn.textContent = 'Copy TeX';
+    btn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation?.();
+      const clipboard = getClipboardWriter();
+      if (!clipboard) return;
+      btn.disabled = true;
+      try {
+        await clipboard.writeText(text);
+        window.clearTimeout(btn._mathCopyResetTimer);
+        btn.classList.add('copied');
+        btn.textContent = 'Copied';
+        btn._mathCopyResetTimer = window.setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.textContent = 'Copy TeX';
+          btn.disabled = !getClipboardWriter();
+        }, TURN_COPY_RESET_MS);
+      } catch (_err) {
+        btn.textContent = 'Failed';
+        window.setTimeout(() => {
+          btn.textContent = 'Copy TeX';
+          btn.disabled = !getClipboardWriter();
+        }, TURN_COPY_RESET_MS);
+      } finally {
+        if (!btn.classList.contains('copied')) btn.disabled = !getClipboardWriter();
+        else btn.disabled = false;
+      }
+    });
+    if (!getClipboardWriter()) btn.disabled = true;
+    display.appendChild(btn);
+  });
 };
 
 const enhanceHighlightAsync = (target) => {
@@ -2153,6 +2207,8 @@ Object.assign(app, {
   ensureStylesheetLoaded,
   ensureKatexLoaded,
   ensureHighlightLoaded,
+  extractRenderedMathText,
+  decorateMathCopyControls,
   renderAssistantMarkdown,
   enqueueAssistantStreamUpdate,
   finalizeAssistantStreamRender,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1406,10 +1406,51 @@
       overflow-x: auto;
       overflow-y: hidden;
       padding-bottom: 0.1rem;
+      position: relative;
     }
 
     .markdown-body .katex-display > .katex {
       white-space: nowrap;
+    }
+
+    .math-copy-btn {
+      position: sticky;
+      right: 0;
+      float: right;
+      margin-left: 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--surface) 92%, transparent);
+      color: var(--text-muted);
+      font-size: 0.68rem;
+      line-height: 1;
+      padding: 0.28rem 0.45rem;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+      z-index: 1;
+    }
+
+    .markdown-body .katex-display:hover .math-copy-btn,
+    .math-copy-btn:focus-visible,
+    .math-copy-btn.copied {
+      opacity: 1;
+    }
+
+    .math-copy-btn:hover,
+    .math-copy-btn:focus-visible {
+      background: var(--surface-2);
+      color: var(--text);
+      outline: none;
+    }
+
+    .math-copy-btn:disabled {
+      cursor: default;
+      opacity: 0.45;
+    }
+
+    .math-copy-btn.copied {
+      color: var(--accent-green);
     }
 
     .message-meta {

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -624,6 +624,33 @@ async function run(name, fn) {
     assert(!button.classList.contains('copied'), 'copied class resets');
   });
 
+  await run('math copy controls copy rendered TeX source as text', async () => {
+    const { app, document, copied, timers } = createHarness();
+    const root = document.createElement('div');
+    const display = document.createElement('span');
+    display.className = 'katex-display';
+    const katex = document.createElement('span');
+    katex.className = 'katex';
+    const annotation = document.createElement('annotation');
+    annotation.textContent = '\\ell_P = \\sqrt{\\hbar G / c^3}';
+    katex.appendChild(annotation);
+    display.appendChild(katex);
+    root.appendChild(display);
+
+    app.decorateMathCopyControls(root);
+    app.decorateMathCopyControls(root);
+
+    const buttons = display.querySelectorAll('.math-copy-btn');
+    assertEqual(buttons.length, 1, 'decorator is idempotent');
+    await buttons[0].dispatchEvent({ type: 'click', preventDefault() {}, stopPropagation() {} });
+
+    assertEqual(copied.length, 1, 'clipboard writes');
+    assertEqual(copied[0], '\\ell_P = \\sqrt{\\hbar G / c^3}', 'copies TeX source');
+    assert(buttons[0].classList.contains('copied'), 'button gets copied state');
+    const reset = timers.find((timer) => timer.ms === 1500 && !timer.cleared);
+    assert(reset, 'reset timer scheduled');
+  });
+
   await run('stream updates only resync the affected turn action panel', () => {
     const { app, session, messages } = createHarness();
     const streamingMessage = {

--- a/internal/serveui/static/markdown-setup.js
+++ b/internal/serveui/static/markdown-setup.js
@@ -10,9 +10,48 @@
     factory(marked); // eslint-disable-line no-undef
   }
 })(function setupMarkdown(marked) {
+  const escapeHtml = (value) => String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
   marked.use({
     breaks: true,
     gfm: true
+  });
+
+  // KaTeX auto-render runs after markdown has produced sanitized HTML. Marked
+  // treats backslashes before punctuation as markdown escapes, which would turn
+  // explicit math delimiters like \(...\) and \[...\] into plain parentheses
+  // or brackets before KaTeX ever sees them. Preserve those spans as text here;
+  // KaTeX will render them in the later decoration pass. Single-dollar inline
+  // math intentionally remains disabled to avoid mangling currency in LLM prose.
+  marked.use({
+    extensions: [{
+      name: 'math-delimiter-span',
+      level: 'inline',
+      start(src) {
+        const inline = src.indexOf('\\(');
+        const display = src.indexOf('\\[');
+        if (inline === -1) return display;
+        if (display === -1) return inline;
+        return Math.min(inline, display);
+      },
+      tokenizer(src) {
+        const match = /^(\\\((?:.|\n)*?\\\)|\\\[(?:.|\n)*?\\\])/.exec(src);
+        if (!match) return false;
+        return {
+          type: 'math-delimiter-span',
+          raw: match[0],
+          text: match[0]
+        };
+      },
+      renderer(token) {
+        return escapeHtml(token.raw);
+      }
+    }]
   });
 
   // Disable single-tilde strikethrough. GFM's del rule matches both ~text~

--- a/internal/serveui/static/markdown_test.js
+++ b/internal/serveui/static/markdown_test.js
@@ -79,6 +79,30 @@ const cases = [
     contains: ['<code class="language-sql">'],
     absent: [],
   },
+  {
+    name: 'inline escaped math delimiters survive markdown parsing',
+    input: 'Planck length is \\(\\ell_P = \\sqrt{\\hbar G / c^3}\\).',
+    contains: ['\\(\\ell_P = \\sqrt{\\hbar G / c^3}\\)'],
+    absent: ['(\\ell_P = \\sqrt{\\hbar G / c^3})'],
+  },
+  {
+    name: 'display escaped math delimiters survive markdown parsing',
+    input: '\\[\\ell_P = \\sqrt{\\hbar G / c^3}\\]',
+    contains: ['\\[\\ell_P = \\sqrt{\\hbar G / c^3}\\]'],
+    absent: ['[\\ell_P = \\sqrt{\\hbar G / c^3}]'],
+  },
+  {
+    name: 'math delimiter preservation escapes html before katex pass',
+    input: '\\(<img src=x onerror=alert(1)>\\)',
+    contains: ['\\(&lt;img src=x onerror=alert(1)&gt;\\)'],
+    absent: ['<img src=x onerror=alert(1)>'],
+  },
+  {
+    name: 'single dollar math stays ordinary prose',
+    input: 'Cost is $100 and formula is $x + 1$.',
+    contains: ['Cost is $100 and formula is $x + 1$.'],
+    absent: ['katex'],
+  },
 ];
 
 for (const tc of cases) {


### PR DESCRIPTION
## What

Fix web UI math rendering for explicit KaTeX delimiters and add study-friendly copy controls for rendered display equations.

## Changes

- preserve `\(...\)` and `\[...\]` through the marked markdown pass so KaTeX auto-render can still see them
- keep single-dollar `$...$` math disabled, so currency/prose like `$100` remains ordinary text
- HTML-escape preserved math spans before the later DOMPurify/KaTeX pass
- add hover/focus `Copy TeX` controls to rendered display math blocks, copying the KaTeX annotation text instead of the noisy rendered DOM text
- add JS coverage for delimiter preservation, escaping, single-dollar behavior, and math-copy idempotence/clipboard output

## Why

LLMs are finicky about math delimiters. After the stricter math PR, the web UI accepted explicit `\(...\)` / `\[...\]` delimiters in the KaTeX config, but marked stripped those backslashes before KaTeX ran. The result was that explicit inline/display math silently degraded to plain punctuation.

This fixes the pipeline rather than re-enabling ambiguous `$...$` parsing.

## Verification

- `node internal/serveui/static/app_render_test.js`
- `node internal/serveui/static/markdown_test.js`
- `go test ./internal/serveui`
- `go build ./...`
- `go test ./...`
