### PR TITLE
fix: ChatGPT eagerly rebuilds full Responses input on every turn, defeating lazy continuation

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -235,19 +235,22 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 		tools = append([]any{ResponsesWebSearchTool{Type: "web_search"}}, tools...)
 	}
 
-	// Build input with system messages extracted as instructions
-	instructions, input := BuildResponsesInputWithInstructions(req.Messages)
+	// Send system messages via the instructions field but leave the transcript in
+	// raw message form so the Responses client can lazily build a continuation-only
+	// suffix on follow-up WebSocket turns.
+	instructions := collectRoleText(req.Messages, RoleSystem)
 
 	responsesReq := ResponsesRequest{
-		Model:          model,
-		Instructions:   instructions,
-		Input:          input,
-		Tools:          tools,
-		Include:        []string{"reasoning.encrypted_content"},
-		PromptCacheKey: req.SessionID,
-		Store:          boolPtr(false),
-		Stream:         true,
-		SessionID:      req.SessionID,
+		Model:                           model,
+		Instructions:                    instructions,
+		Messages:                        req.Messages,
+		ExtractInstructionsFromMessages: true,
+		Tools:                           tools,
+		Include:                         []string{"reasoning.encrypted_content"},
+		PromptCacheKey:                  req.SessionID,
+		Store:                           boolPtr(false),
+		Stream:                          true,
+		SessionID:                       req.SessionID,
 	}
 
 	if serviceTier := p.serviceTier; req.ServiceTierSet || strings.TrimSpace(req.ServiceTier) != "" {

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -69,25 +69,26 @@ type ResponsesClient struct {
 
 // ResponsesRequest follows the Open Responses spec
 type ResponsesRequest struct {
-	Model              string               `json:"model"`
-	Instructions       string               `json:"instructions,omitempty"` // System instructions (alternative to developer-role input items)
-	Input              []ResponsesInputItem `json:"input"`
-	Messages           []Message            `json:"-"`               // Optional raw transcript for lazy input materialization
-	Tools              []any                `json:"tools,omitempty"` // Can contain ResponsesTool or ResponsesWebSearchTool
-	ToolChoice         any                  `json:"tool_choice,omitempty"`
-	ParallelToolCalls  *bool                `json:"parallel_tool_calls,omitempty"`
-	MaxOutputTokens    int                  `json:"max_output_tokens,omitempty"`
-	Temperature        *float64             `json:"temperature,omitempty"`
-	TopP               *float64             `json:"top_p,omitempty"`
-	Reasoning          *ResponsesReasoning  `json:"reasoning,omitempty"`
-	Include            []string             `json:"include,omitempty"`
-	PromptCacheKey     string               `json:"prompt_cache_key,omitempty"`
-	Store              *bool                `json:"store,omitempty"`
-	Generate           *bool                `json:"generate,omitempty"` // WebSocket warmup support; omitted for normal HTTP/WS requests
-	Stream             bool                 `json:"stream"`
-	PreviousResponseID string               `json:"previous_response_id,omitempty"`
-	ServiceTier        string               `json:"service_tier,omitempty"`
-	SessionID          string               `json:"-"`
+	Model                           string               `json:"model"`
+	Instructions                    string               `json:"instructions,omitempty"` // System instructions (alternative to developer-role input items)
+	Input                           []ResponsesInputItem `json:"input"`
+	Messages                        []Message            `json:"-"`               // Optional raw transcript for lazy input materialization
+	ExtractInstructionsFromMessages bool                 `json:"-"`               // When lazily materializing Input from Messages, omit system messages because they are sent via Instructions.
+	Tools                           []any                `json:"tools,omitempty"` // Can contain ResponsesTool or ResponsesWebSearchTool
+	ToolChoice                      any                  `json:"tool_choice,omitempty"`
+	ParallelToolCalls               *bool                `json:"parallel_tool_calls,omitempty"`
+	MaxOutputTokens                 int                  `json:"max_output_tokens,omitempty"`
+	Temperature                     *float64             `json:"temperature,omitempty"`
+	TopP                            *float64             `json:"top_p,omitempty"`
+	Reasoning                       *ResponsesReasoning  `json:"reasoning,omitempty"`
+	Include                         []string             `json:"include,omitempty"`
+	PromptCacheKey                  string               `json:"prompt_cache_key,omitempty"`
+	Store                           *bool                `json:"store,omitempty"`
+	Generate                        *bool                `json:"generate,omitempty"` // WebSocket warmup support; omitted for normal HTTP/WS requests
+	Stream                          bool                 `json:"stream"`
+	PreviousResponseID              string               `json:"previous_response_id,omitempty"`
+	ServiceTier                     string               `json:"service_tier,omitempty"`
+	SessionID                       string               `json:"-"`
 }
 
 // ResponsesWebSearchTool represents the web search tool for OpenAI
@@ -592,7 +593,11 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 		if fullInputBuilt {
 			return fullInput
 		}
-		fullInput = BuildResponsesInput(req.Messages)
+		if req.ExtractInstructionsFromMessages {
+			_, fullInput = BuildResponsesInputWithInstructions(req.Messages)
+		} else {
+			fullInput = BuildResponsesInput(req.Messages)
+		}
 		fullInputBuilt = true
 		return fullInput
 	}

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -805,6 +805,94 @@ func TestResponsesClientWebSocketPreviousResponseRejectedRetriesFullState(t *tes
 	}
 }
 
+func TestResponsesClientWebSocketReusesConnectionAndPreviousResponseIDWithInstructionExtraction(t *testing.T) {
+	var handshakeCount atomic.Int32
+	var requests []map[string]any
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshakeCount.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		for i := 0; i < 2; i++ {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var req map[string]any
+			_ = json.Unmarshal(msg, &req)
+			requests = append(requests, req)
+			_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_" + string(rune('1'+i))}})
+		}
+	}))
+	defer server.Close()
+
+	client := &ResponsesClient{BaseURL: server.URL, UseWebSocket: true, WebSocketServerState: true, DisableServerState: true}
+	requestsToSend := []ResponsesRequest{
+		{
+			Model:                           "gpt-test",
+			Instructions:                    "Be concise",
+			Messages:                        []Message{SystemText("Be concise"), UserText("one")},
+			ExtractInstructionsFromMessages: true,
+			Stream:                          true,
+		},
+		{
+			Model:        "gpt-test",
+			Instructions: "Be concise",
+			Messages: []Message{
+				SystemText("Be concise"),
+				UserText("one"),
+				AssistantText("old"),
+				UserText("two"),
+			},
+			ExtractInstructionsFromMessages: true,
+			Stream:                          true,
+		},
+	}
+	for i, req := range requestsToSend {
+		stream, err := client.Stream(context.Background(), req, false)
+		if err != nil {
+			t.Fatalf("Stream %d: %v", i, err)
+		}
+		for {
+			event, err := stream.Recv()
+			if err != nil {
+				t.Fatalf("Recv %d: %v", i, err)
+			}
+			if event.Type == EventDone {
+				break
+			}
+			if event.Type == EventError {
+				t.Fatalf("stream error: %v", event.Err)
+			}
+		}
+		_ = stream.Close()
+	}
+	if handshakeCount.Load() != 1 {
+		t.Fatalf("handshakes = %d, want 1", handshakeCount.Load())
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if requests[0]["instructions"] != "Be concise" {
+		t.Fatalf("first instructions = %#v, want Be concise", requests[0]["instructions"])
+	}
+	firstInput, ok := requests[0]["input"].([]any)
+	if !ok || len(firstInput) != 1 || strings.Contains(toJSON(firstInput[0]), "developer") || !strings.Contains(toJSON(firstInput[0]), "one") {
+		t.Fatalf("first input = %#v, want only user message without duplicated system prompt", requests[0]["input"])
+	}
+	if requests[1]["previous_response_id"] != "resp_1" {
+		t.Fatalf("previous_response_id = %#v", requests[1]["previous_response_id"])
+	}
+	secondInput, ok := requests[1]["input"].([]any)
+	if !ok || len(secondInput) != 1 || !strings.Contains(toJSON(secondInput[0]), "two") {
+		t.Fatalf("second input = %#v, want only newest user item", requests[1]["input"])
+	}
+}
+
 func TestResponsesClientWebSocketReusesConnectionAndPreviousResponseID(t *testing.T) {
 	var handshakeCount atomic.Int32
 	var requests []map[string]any


### PR DESCRIPTION
## What

- stop the ChatGPT provider from eagerly materializing full Responses `input` on every turn
- pass raw `Messages` into `ResponsesClient` and mark that system messages are being sent separately via `instructions`
- teach lazy full-input reconstruction to omit system messages when `instructions` came from the transcript
- add a websocket continuation test covering instruction extraction plus previous-response reuse

## Why

ChatGPT was building the full Responses transcript up front before the client could decide whether only a continuation suffix was needed. On long follow-up turns, especially after tool use, that forced avoidable transcript scanning/allocation into the pre-request path and increased time-to-first-token. This keeps the cheaper message-based continuation path available while preserving the existing ChatGPT wire format when a full-history rebuild is actually required.
