### PR TITLE
fix: WebSocket continuation rebuilds and deep-compares the entire transcript before every reused request

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -52,7 +52,6 @@ type ResponsesClient struct {
 	wsMu                    sync.Mutex
 	wsConn                  *websocket.Conn
 	wsLastRequest           *ResponsesRequest
-	wsLastResponseItems     []ResponsesInputItem
 	// HandleError, if set, is called for non-200 responses before default handling.
 	// Return a non-nil error to short-circuit; return nil to fall through to defaults.
 	HandleError func(statusCode int, body []byte, headers http.Header) error
@@ -655,7 +654,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 						if err := sleepWithContext(ctx, wait); err != nil {
 							return nil, err
 						}
-						return c.streamWebSocketPrepared(ctx, wsReq, buildFullInput, debugRaw, responseStateGeneration)
+						return c.streamWebSocketPrepared(ctx, wsReq, buildContinuationInput, buildFullInput, debugRaw, responseStateGeneration)
 					},
 				})
 			}
@@ -672,7 +671,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 			return fallbacks
 		}
 
-		stream, err := c.streamWebSocketPrepared(ctx, wsReq, buildFullInput, debugRaw, responseStateGeneration)
+		stream, err := c.streamWebSocketPrepared(ctx, wsReq, buildContinuationInput, buildFullInput, debugRaw, responseStateGeneration)
 		if err == nil {
 			return &responsesWebSocketFallbackStream{
 				current:   stream,
@@ -689,7 +688,7 @@ func (c *ResponsesClient) Stream(ctx context.Context, req ResponsesRequest, debu
 			if err := sleepWithContext(ctx, wait); err != nil {
 				return nil, err
 			}
-			stream, err = c.streamWebSocketPrepared(ctx, wsReq, buildFullInput, debugRaw, responseStateGeneration)
+			stream, err = c.streamWebSocketPrepared(ctx, wsReq, buildContinuationInput, buildFullInput, debugRaw, responseStateGeneration)
 			if err == nil {
 				return &responsesWebSocketFallbackStream{
 					current:   stream,
@@ -1097,7 +1096,6 @@ func (c *ResponsesClient) ResetConversation() {
 	c.LastResponseID = ""
 	c.websocketDisabled = false
 	c.wsLastRequest = nil
-	c.wsLastResponseItems = nil
 }
 
 func (c *ResponsesClient) websocketServerStateEnabled() bool {

--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -102,9 +102,9 @@ func (c *ResponsesClient) writeResponsesWebSocketRequestLocked(conn *websocket.C
 	return nil
 }
 
-func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req ResponsesRequest, buildFullInput func() []ResponsesInputItem, debugRaw bool, responseStateGeneration uint64) (Stream, error) {
+func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req ResponsesRequest, buildContinuationInput func() []ResponsesInputItem, buildFullInput func() []ResponsesInputItem, debugRaw bool, responseStateGeneration uint64) (Stream, error) {
 	c.wsMu.Lock()
-	wireReq := c.prepareWebSocketContinuationLocked(req, buildFullInput)
+	wireReq := c.prepareWebSocketContinuationLocked(req, buildContinuationInput, buildFullInput)
 
 	conn, reused, err := c.ensureWebSocket(ctx, wireReq)
 	if err != nil {
@@ -179,7 +179,6 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 					retriedFullState = true
 					c.clearLastResponseIDIfGeneration(responseStateGeneration)
 					c.wsLastRequest = nil
-					c.wsLastResponseItems = nil
 					wireReq.PreviousResponseID = ""
 					wireReq.Input = buildFullInput()
 					handler = newResponsesStreamEventHandler(c, responseStateGeneration, debugRaw, "Responses WebSocket", c.websocketServerStateEnabled())
@@ -207,7 +206,6 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 		fullReq.Input = append([]ResponsesInputItem(nil), buildFullInput()...)
 		fullReq.PreviousResponseID = ""
 		c.wsLastRequest = &fullReq
-		c.wsLastResponseItems = handler.OutputItems()
 		return nil
 	}), nil
 }
@@ -225,7 +223,7 @@ func isPreviousResponseIDRejected(err error) bool {
 	return strings.Contains(msg, "previous_response_id") && (strings.Contains(msg, "unsupported") || strings.Contains(msg, "not found"))
 }
 
-func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesRequest, buildFullInput func() []ResponsesInputItem) ResponsesRequest {
+func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesRequest, buildContinuationInput func() []ResponsesInputItem, buildFullInput func() []ResponsesInputItem) ResponsesRequest {
 	if !c.websocketServerStateEnabled() || c.LastResponseID == "" {
 		req.PreviousResponseID = ""
 		req.Input = buildFullInput()
@@ -236,10 +234,23 @@ func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesReques
 		req.PreviousResponseID = c.LastResponseID
 	}
 
-	if c.wsLastRequest == nil {
+	useFullInput := func() ResponsesRequest {
 		req.PreviousResponseID = ""
 		req.Input = buildFullInput()
 		return req
+	}
+
+	if c.wsLastRequest == nil {
+		if req.Input != nil {
+			return req
+		}
+		// Reuse the already-incremental continuation when available so a resumed
+		// previous_response_id chain does not rebuild the full transcript locally.
+		if continuation := buildContinuationInput(); len(continuation) > 0 {
+			req.Input = continuation
+			return req
+		}
+		return useFullInput()
 	}
 
 	prevComparable := responsesRequestNonInputComparable(*c.wsLastRequest)
@@ -247,38 +258,21 @@ func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesReques
 	if !reflect.DeepEqual(prevComparable, currentComparable) {
 		// Tool schemas, model parameters, or other non-input fields changed. Start a
 		// fresh chain instead of risking previous_response_id with incompatible state.
-		req.PreviousResponseID = ""
-		req.Input = buildFullInput()
-		return req
+		return useFullInput()
 	}
 
 	if req.Input != nil {
 		return req
 	}
 
-	fullInput := buildFullInput()
-
-	baseline := append([]ResponsesInputItem{}, c.wsLastRequest.Input...)
-	baseline = append(baseline, c.wsLastResponseItems...)
-	if responsesInputHasPrefix(fullInput, baseline) {
-		req.PreviousResponseID = c.LastResponseID
-		req.Input = append([]ResponsesInputItem(nil), fullInput[len(baseline):]...)
+	// The caller already knows how to build an incremental continuation; prefer
+	// that over rebuilding and rescanning the full transcript on every follow-up.
+	if continuation := buildContinuationInput(); len(continuation) > 0 {
+		req.Input = continuation
 		return req
 	}
 
-	// Fall back to the historical suffix filter for providers that do not echo
-	// response output in exactly the same shape as our local transcript, but only
-	// when the suffix is non-empty and obviously a new user/tool continuation.
-	filtered := filterToNewInput(fullInput)
-	if len(filtered) > 0 && len(filtered) < len(fullInput) {
-		req.PreviousResponseID = c.LastResponseID
-		req.Input = filtered
-		return req
-	}
-
-	req.PreviousResponseID = ""
-	req.Input = fullInput
-	return req
+	return useFullInput()
 }
 
 func responsesRequestNonInputComparable(req ResponsesRequest) any {
@@ -351,18 +345,6 @@ func normalizeDecodedJSONForCompare(v any) any {
 func allStrings(values []any) bool {
 	for _, value := range values {
 		if _, ok := value.(string); !ok {
-			return false
-		}
-	}
-	return true
-}
-
-func responsesInputHasPrefix(input, prefix []ResponsesInputItem) bool {
-	if len(prefix) > len(input) {
-		return false
-	}
-	for i := range prefix {
-		if !reflect.DeepEqual(input[i], prefix[i]) {
 			return false
 		}
 	}
@@ -477,5 +459,4 @@ func (c *ResponsesClient) discardWebSocketLocked() {
 	_ = c.wsConn.Close()
 	c.wsConn = nil
 	c.wsLastRequest = nil
-	c.wsLastResponseItems = nil
 }

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -140,13 +140,49 @@ func TestResponsesWebSocketPrepareClearsStalePreviousResponseID(t *testing.T) {
 		Model:              "gpt-test",
 		PreviousResponseID: "resp_stale",
 		Input:              []ResponsesInputItem{{Type: "message", Role: "user", Content: "new"}},
-	}, func() []ResponsesInputItem { return fullInput })
+	}, func() []ResponsesInputItem {
+		return []ResponsesInputItem{{Type: "message", Role: "user", Content: "new"}}
+	}, func() []ResponsesInputItem {
+		return fullInput
+	})
 
 	if prepared.PreviousResponseID != "" {
 		t.Fatalf("PreviousResponseID = %q, want empty", prepared.PreviousResponseID)
 	}
 	if len(prepared.Input) != len(fullInput) || prepared.Input[0].Content != "old" || prepared.Input[1].Content != "new" {
 		t.Fatalf("Input = %#v, want full input %#v", prepared.Input, fullInput)
+	}
+}
+
+func TestResponsesWebSocketPrepareUsesContinuationWithoutFullInputRebuild(t *testing.T) {
+	client := &ResponsesClient{
+		LastResponseID: "resp_prev",
+		wsLastRequest: &ResponsesRequest{
+			Model: "gpt-test",
+			Input: []ResponsesInputItem{{Type: "message", Role: "user", Content: "old"}},
+		},
+	}
+	fullInputCalls := 0
+
+	prepared := client.prepareWebSocketContinuationLocked(ResponsesRequest{Model: "gpt-test"}, func() []ResponsesInputItem {
+		return []ResponsesInputItem{{Type: "message", Role: "user", Content: "new"}}
+	}, func() []ResponsesInputItem {
+		fullInputCalls++
+		return []ResponsesInputItem{
+			{Type: "message", Role: "user", Content: "old"},
+			{Type: "message", Role: "assistant", Content: "done"},
+			{Type: "message", Role: "user", Content: "new"},
+		}
+	})
+
+	if fullInputCalls != 0 {
+		t.Fatalf("buildFullInput calls = %d, want 0", fullInputCalls)
+	}
+	if prepared.PreviousResponseID != "resp_prev" {
+		t.Fatalf("PreviousResponseID = %q, want resp_prev", prepared.PreviousResponseID)
+	}
+	if len(prepared.Input) != 1 || prepared.Input[0].Content != "new" {
+		t.Fatalf("Input = %#v, want only continuation input", prepared.Input)
 	}
 }
 
@@ -802,6 +838,67 @@ func TestResponsesClientWebSocketPreviousResponseRejectedRetriesFullState(t *tes
 	input, ok := secondRequest["input"].([]any)
 	if !ok || len(input) != 2 {
 		t.Fatalf("full-state retry input = %#v, want both input items", secondRequest["input"])
+	}
+}
+
+func TestResponsesClientWebSocketUsesPreviousResponseIDWithoutLocalBaseline(t *testing.T) {
+	var gotReq map[string]any
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read request: %v", err)
+			return
+		}
+		if err := json.Unmarshal(msg, &gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_next"}})
+	}))
+	defer server.Close()
+
+	client := &ResponsesClient{
+		BaseURL:        server.URL,
+		UseWebSocket:   true,
+		LastResponseID: "resp_prev",
+	}
+	stream, err := client.Stream(context.Background(), ResponsesRequest{
+		Model: "gpt-test",
+		Input: []ResponsesInputItem{
+			{Type: "message", Role: "assistant", Content: "old"},
+			{Type: "message", Role: "user", Content: "new"},
+		},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		if event.Type == EventDone {
+			break
+		}
+	}
+
+	if gotReq["previous_response_id"] != "resp_prev" {
+		t.Fatalf("previous_response_id = %#v, want resp_prev", gotReq["previous_response_id"])
+	}
+	input, ok := gotReq["input"].([]any)
+	if !ok || len(input) != 1 || !strings.Contains(toJSON(input[0]), "new") {
+		t.Fatalf("input = %#v, want only continuation input", gotReq["input"])
 	}
 }
 


### PR DESCRIPTION
## What

- stop rebuilding the full transcript in WebSocket continuation preparation when an incremental continuation is already available
- pass the continuation builder into the WebSocket preparation path and prefer it over local full-history prefix reconstruction
- preserve `previous_response_id` for WebSocket requests even when there is no local `wsLastRequest` baseline yet
- remove the now-unused WebSocket response-item baseline bookkeeping and add regression coverage for both the no-full-rebuild path and the no-local-baseline path

## Why

Responses-over-WebSocket already has server-side conversation state, so rebuilding and deep-comparing the entire local transcript before each follow-up adds avoidable pre-network latency that grows with chat size. Using the already-incremental continuation keeps follow-up requests cheap, improves time-to-first-token in long chats, and still falls back to full input when request shape changes or incremental input is unavailable.
