### PR TITLE
fix: Context trimming is O(n²) because it repeatedly rescans token counts while dropping messages

### DIFF
--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -54,23 +54,28 @@ func EstimateTokens(text string) int {
 // EstimateMessageTokens returns an approximate token count for a slice of
 // messages by summing all text content across parts.
 func EstimateMessageTokens(msgs []Message) int {
-	msgs = FilterConversationMessages(msgs)
 	if len(msgs) == 0 {
 		return 0
 	}
 	total := 0
 	for _, msg := range msgs {
-		if len(msg.Parts) == 0 {
-			continue
+		total += estimateSingleMessageTokens(msg)
+	}
+	return total
+}
+
+func estimateSingleMessageTokens(msg Message) int {
+	if msg.Role == RoleEvent || len(msg.Parts) == 0 {
+		return 0
+	}
+	total := 0
+	for _, part := range msg.Parts {
+		total += EstimateTokens(part.Text)
+		if part.ToolCall != nil {
+			total += EstimateTokens(string(part.ToolCall.Arguments))
 		}
-		for _, part := range msg.Parts {
-			total += EstimateTokens(part.Text)
-			if part.ToolCall != nil {
-				total += EstimateTokens(string(part.ToolCall.Arguments))
-			}
-			if part.ToolResult != nil {
-				total += EstimateTokens(part.ToolResult.Content)
-			}
+		if part.ToolResult != nil {
+			total += EstimateTokens(part.ToolResult.Content)
 		}
 	}
 	return total
@@ -406,14 +411,16 @@ func trimMessagesToFit(messages []Message, maxTokens int) []Message {
 func doTrim(messages []Message, preserveEnd, maxTokens int) []Message {
 	prefix := messages[:preserveEnd]
 	conv := messages[preserveEnd:]
-	for len(conv) > 1 && EstimateMessageTokens(prefix)+EstimateMessageTokens(conv) > maxTokens {
+	prefixTokens := EstimateMessageTokens(prefix)
+	convTokens := EstimateMessageTokens(conv)
+	for len(conv) > 1 && prefixTokens+convTokens > maxTokens {
+		convTokens -= estimateSingleMessageTokens(conv[0])
 		conv = conv[1:]
 	}
 
 	// If a single message exceeds budget, truncate its text/tool content.
 	if len(conv) == 1 {
-		prefixTokens := EstimateMessageTokens(prefix)
-		if prefixTokens+EstimateMessageTokens(conv) > maxTokens {
+		if prefixTokens+convTokens > maxTokens {
 			remaining := maxTokens - prefixTokens
 			if remaining > 0 {
 				maxChars := remaining * approxBytesPerToken

--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -80,6 +80,20 @@ func TestEstimateMessageTokensEmpty(t *testing.T) {
 	}
 }
 
+func TestEstimateMessageTokensSkipsEventMessages(t *testing.T) {
+	msgs := []Message{
+		UserText("hello world"),
+		{Role: RoleEvent, Parts: []Part{{Type: PartText, Text: strings.Repeat("x", 100)}}},
+		AssistantText("goodbye world"),
+	}
+
+	got := EstimateMessageTokens(msgs)
+	want := EstimateMessageTokens([]Message{msgs[0], msgs[2]})
+	if got != want {
+		t.Errorf("EstimateMessageTokens should ignore event messages, got %d want %d", got, want)
+	}
+}
+
 func TestReconstructHistory(t *testing.T) {
 	recentUser := []Message{UserText("recent question")}
 


### PR DESCRIPTION
## What

- stop `EstimateMessageTokens` from allocating and re-filtering by skipping event rows inline
- cache the preserved-prefix and remaining-conversation token totals in `doTrim`
- subtract the dropped message's token estimate as trimming advances instead of rescanning the whole suffix each iteration
- add coverage that token estimation still ignores event messages

## Why

`doTrim` previously called `EstimateMessageTokens(prefix)` and `EstimateMessageTokens(conv)` on every loop iteration while dropping old messages. Near the context limit that turned trimming into quadratic work over the longest conversations, adding avoidable latency right before provider requests start. Keeping running totals preserves the existing behavior while making trimming linear in the number of messages.
