### PR TITLE
fix: Responses tool schemas are reparsed and fully normalized on every request instead of being cached

### DIFF
--- a/internal/llm/json_schema_lowering.go
+++ b/internal/llm/json_schema_lowering.go
@@ -1,5 +1,10 @@
 package llm
 
+import (
+	"reflect"
+	"sync"
+)
+
 // ToOpenResponsesParameters serializes the typed schema into the provider-neutral
 // Open Responses function-tool `parameters` shape. It intentionally avoids
 // OpenAI-specific strict-schema rewrites such as forcing every property into
@@ -66,10 +71,36 @@ func scrubUnsupportedOpenAISchemaKeywords(value interface{}) {
 	}
 }
 
+type openAIParametersCacheKey struct {
+	schemaPtr uintptr
+	strict    bool
+}
+
+type openAIParametersCacheEntry struct {
+	// Hold a strong reference to the immutable schema map so its identity cannot
+	// be reused for a different schema while the cached lowered parameters remain
+	// live.
+	schema map[string]interface{}
+	once   sync.Once
+	params map[string]interface{}
+}
+
+var openAIParametersCache sync.Map
+
 func openAIParametersFromToolSchema(schema map[string]interface{}, strict bool) map[string]interface{} {
-	parsed, err := ParseToolJSONSchemaMap(schema)
-	if err != nil {
-		parsed, _ = ParseToolJSONSchemaMap(nil)
+	key := openAIParametersCacheKey{strict: strict}
+	if len(schema) > 0 {
+		key.schemaPtr = reflect.ValueOf(schema).Pointer()
 	}
-	return parsed.ToOpenAIParameters(strict)
+
+	cached, _ := openAIParametersCache.LoadOrStore(key, &openAIParametersCacheEntry{schema: schema})
+	entry := cached.(*openAIParametersCacheEntry)
+	entry.once.Do(func() {
+		parsed, err := ParseToolJSONSchemaMap(schema)
+		if err != nil {
+			parsed, _ = ParseToolJSONSchemaMap(nil)
+		}
+		entry.params = parsed.ToOpenAIParameters(strict)
+	})
+	return entry.params
 }

--- a/internal/llm/json_schema_model_test.go
+++ b/internal/llm/json_schema_model_test.go
@@ -1,6 +1,9 @@
 package llm
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseToolJSONSchemaMap_SanitizesAndPreservesExtras(t *testing.T) {
 	schema := map[string]interface{}{
@@ -66,5 +69,29 @@ func TestSanitizedResponsesParametersSchema_DefaultsEmptyObject(t *testing.T) {
 	props, ok := got["properties"].(map[string]interface{})
 	if !ok || len(props) != 0 {
 		t.Fatalf("properties = %#v, want empty map", got["properties"])
+	}
+}
+
+func TestOpenAIParametersFromToolSchema_CachesLoweredParametersBySchemaIdentityAndStrictness(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"name": map[string]interface{}{"type": "string"},
+		},
+	}
+
+	firstStrict := openAIParametersFromToolSchema(schema, true)
+	secondStrict := openAIParametersFromToolSchema(schema, true)
+	if reflect.ValueOf(firstStrict).Pointer() != reflect.ValueOf(secondStrict).Pointer() {
+		t.Fatalf("strict cache miss: first=%#v second=%#v", firstStrict, secondStrict)
+	}
+
+	firstNonStrict := openAIParametersFromToolSchema(schema, false)
+	secondNonStrict := openAIParametersFromToolSchema(schema, false)
+	if reflect.ValueOf(firstNonStrict).Pointer() != reflect.ValueOf(secondNonStrict).Pointer() {
+		t.Fatalf("non-strict cache miss: first=%#v second=%#v", firstNonStrict, secondNonStrict)
+	}
+	if reflect.ValueOf(firstStrict).Pointer() == reflect.ValueOf(firstNonStrict).Pointer() {
+		t.Fatalf("strict and non-strict schemas should be cached separately")
 	}
 }


### PR DESCRIPTION
## What

Cache the lowered OpenAI Responses `parameters` map per immutable tool schema identity and `strict` flag instead of reparsing and renormalizing it on every request.

Also add a unit test covering cache reuse for the same schema in strict and non-strict modes.

## Why

Large MCP toolsets were paying the full `ParseToolJSONSchemaMap` + `ToOpenAIParameters` normalization cost on every turn even though `ToolSpec.Schema` is documented as immutable and the lowered output is deterministic for a given `strict` value. Reusing the lowered schema removes that repeated CPU/allocation work from request construction and improves TTFT for Responses requests with many or large tool schemas.
