### PR TITLE
speed up memory vector search

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -901,6 +902,114 @@ func (s *Store) SearchFragments(ctx context.Context, query string, limit int, ag
 	return out, nil
 }
 
+const embeddingVectorBinaryMagic = "tllmf64\x01"
+
+func hasEmbeddingVectorBinaryMagic(payload []byte) bool {
+	if len(payload) < len(embeddingVectorBinaryMagic) {
+		return false
+	}
+	for i := 0; i < len(embeddingVectorBinaryMagic); i++ {
+		if payload[i] != embeddingVectorBinaryMagic[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func encodeEmbeddingVector(vec []float64) []byte {
+	headerLen := len(embeddingVectorBinaryMagic) + 4
+	payload := make([]byte, headerLen+len(vec)*8)
+	copy(payload, embeddingVectorBinaryMagic)
+	binary.LittleEndian.PutUint32(payload[len(embeddingVectorBinaryMagic):headerLen], uint32(len(vec)))
+
+	offset := headerLen
+	for _, v := range vec {
+		binary.LittleEndian.PutUint64(payload[offset:offset+8], math.Float64bits(v))
+		offset += 8
+	}
+	return payload
+}
+
+func decodeEmbeddingVector(payload []byte) ([]float64, error) {
+	if hasEmbeddingVectorBinaryMagic(payload) {
+		return decodeBinaryEmbeddingVector(payload)
+	}
+
+	var vec []float64
+	if err := json.Unmarshal(payload, &vec); err != nil {
+		return nil, err
+	}
+	return vec, nil
+}
+
+func decodeBinaryEmbeddingVector(payload []byte) ([]float64, error) {
+	dims, offset, err := parseBinaryEmbeddingVectorHeader(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	vec := make([]float64, dims)
+	for i := range vec {
+		vec[i] = math.Float64frombits(binary.LittleEndian.Uint64(payload[offset : offset+8]))
+		offset += 8
+	}
+	return vec, nil
+}
+
+func parseBinaryEmbeddingVectorHeader(payload []byte) (dims, offset int, err error) {
+	headerLen := len(embeddingVectorBinaryMagic) + 4
+	if len(payload) < headerLen {
+		return 0, 0, fmt.Errorf("truncated binary embedding vector header")
+	}
+	encodedDims := binary.LittleEndian.Uint32(payload[len(embeddingVectorBinaryMagic):headerLen])
+	if encodedDims > uint32((len(payload)-headerLen)/8) {
+		return 0, 0, fmt.Errorf("binary embedding vector declares %d dimensions but payload has %d value bytes", encodedDims, len(payload)-headerLen)
+	}
+	dims = int(encodedDims)
+	wantLen := headerLen + dims*8
+	if len(payload) != wantLen {
+		return 0, 0, fmt.Errorf("binary embedding vector length = %d, want %d for %d dimensions", len(payload), wantLen, dims)
+	}
+	return dims, headerLen, nil
+}
+
+func cosineSimilarityPayload(queryVec []float64, payload []byte) (float64, error) {
+	if hasEmbeddingVectorBinaryMagic(payload) {
+		return cosineSimilarityBinaryPayload(queryVec, payload)
+	}
+
+	vec, err := decodeEmbeddingVector(payload)
+	if err != nil {
+		return 0, err
+	}
+	return embedding.CosineSimilarity(queryVec, vec), nil
+}
+
+func cosineSimilarityBinaryPayload(queryVec []float64, payload []byte) (float64, error) {
+	dims, offset, err := parseBinaryEmbeddingVectorHeader(payload)
+	if err != nil {
+		return 0, err
+	}
+	if dims != len(queryVec) || dims == 0 {
+		return 0, nil
+	}
+
+	var dotProduct, normA, normB float64
+	for _, a := range queryVec {
+		b := math.Float64frombits(binary.LittleEndian.Uint64(payload[offset : offset+8]))
+		offset += 8
+		dotProduct += a * b
+		normA += a * a
+		normB += b * b
+	}
+
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0, nil
+	}
+	return dotProduct / denom, nil
+}
+
 // UpsertEmbedding inserts or updates an embedding vector for a fragment.
 func (s *Store) UpsertEmbedding(ctx context.Context, fragmentID, provider, model string, dims int, vec []float64) error {
 	fragmentID = strings.TrimSpace(fragmentID)
@@ -925,12 +1034,9 @@ func (s *Store) UpsertEmbedding(ctx context.Context, fragmentID, provider, model
 		return fmt.Errorf("vector dimensions mismatch: got %d values, dims=%d", len(vec), dims)
 	}
 
-	payload, err := json.Marshal(vec)
-	if err != nil {
-		return fmt.Errorf("encode embedding vector: %w", err)
-	}
+	payload := encodeEmbeddingVector(vec)
 
-	_, err = s.db.ExecContext(ctx, `
+	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO memory_embeddings(fragment_id, provider, model, dimensions, vector, embedded_at)
 		VALUES(?, ?, ?, ?, ?, ?)
 		ON CONFLICT(fragment_id, provider, model) DO UPDATE SET
@@ -966,8 +1072,8 @@ func (s *Store) GetEmbedding(ctx context.Context, fragmentID, provider, model st
 		return nil, fmt.Errorf("get embedding: %w", err)
 	}
 
-	var vec []float64
-	if err := json.Unmarshal(payload, &vec); err != nil {
+	vec, err := decodeEmbeddingVector(payload)
+	if err != nil {
 		return nil, fmt.Errorf("decode embedding vector: %w", err)
 	}
 	return vec, nil
@@ -1022,12 +1128,12 @@ func (s *Store) GetEmbeddingsByIDs(ctx context.Context, fragmentIDs []string, pr
 	out := make(map[string][]float64, len(ids))
 	for rows.Next() {
 		var id string
-		var payload []byte
+		var payload sql.RawBytes
 		if err := rows.Scan(&id, &payload); err != nil {
 			return nil, fmt.Errorf("scan embedding row: %w", err)
 		}
-		var vec []float64
-		if err := json.Unmarshal(payload, &vec); err != nil {
+		vec, err := decodeEmbeddingVector(payload)
+		if err != nil {
 			return nil, fmt.Errorf("decode embedding vector: %w", err)
 		}
 		out[id] = vec
@@ -1137,22 +1243,31 @@ func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string,
 	top := make(vectorSearchCandidateHeap, 0, limit)
 	for rows.Next() {
 		var c vectorSearchCandidate
-		var payload []byte
+		var payload sql.RawBytes
 		if err := rows.Scan(&c.id, &c.updatedAt, &payload); err != nil {
 			return nil, fmt.Errorf("scan vector search row: %w", err)
 		}
 
-		if err := json.Unmarshal(payload, &c.vector); err != nil {
-			return nil, fmt.Errorf("decode stored vector for fragment %s: %w", c.id, err)
+		score, err := cosineSimilarityPayload(queryVec, payload)
+		if err != nil {
+			return nil, fmt.Errorf("score stored vector for fragment %s: %w", c.id, err)
 		}
-		c.score = embedding.CosineSimilarity(queryVec, c.vector)
+		c.score = score
 
 		if top.Len() < limit {
+			c.vector, err = decodeEmbeddingVector(payload)
+			if err != nil {
+				return nil, fmt.Errorf("decode stored vector for fragment %s: %w", c.id, err)
+			}
 			heap.Push(&top, c)
 			continue
 		}
 
 		if vectorSearchCandidateBetter(c, top[0]) {
+			c.vector, err = decodeEmbeddingVector(payload)
+			if err != nil {
+				return nil, fmt.Errorf("decode stored vector for fragment %s: %w", c.id, err)
+			}
 			top[0] = c
 			heap.Fix(&top, 0)
 		}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -276,6 +276,16 @@ func TestStoreEmbeddingMethods(t *testing.T) {
 	if err := store.UpsertEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001", len(vec), vec); err != nil {
 		t.Fatalf("UpsertEmbedding() error = %v", err)
 	}
+	var rawPayload []byte
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT vector FROM memory_embeddings
+		WHERE fragment_id = ? AND provider = ? AND model = ?`,
+		frag.ID, "gemini", "gemini-embedding-001").Scan(&rawPayload); err != nil {
+		t.Fatalf("query raw embedding payload: %v", err)
+	}
+	if !hasEmbeddingVectorBinaryMagic(rawPayload) {
+		t.Fatalf("embedding payload prefix = %q, want binary vector magic", rawPayload[:min(len(rawPayload), len(embeddingVectorBinaryMagic))])
+	}
 
 	got, err := store.GetEmbedding(ctx, frag.ID, "gemini", "gemini-embedding-001")
 	if err != nil {
@@ -313,6 +323,37 @@ func TestStoreEmbeddingMethods(t *testing.T) {
 	}
 	if got != nil {
 		t.Fatalf("expected stale embedding to be cleared on update, got %v", got)
+	}
+}
+
+func TestStoreGetEmbeddingSupportsLegacyJSONVectors(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	frag := &Fragment{Agent: "jarvis", Path: "legacy/json-vector", Content: "legacy vector"}
+	if err := store.CreateFragment(ctx, frag); err != nil {
+		t.Fatalf("CreateFragment() error = %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO memory_embeddings(fragment_id, provider, model, dimensions, vector, embedded_at)
+		VALUES (?, 'legacy', 'json', 2, ?, ?)`, frag.ID, []byte(`[0.25,0.75]`), time.Now()); err != nil {
+		t.Fatalf("insert legacy JSON embedding: %v", err)
+	}
+
+	got, err := store.GetEmbedding(ctx, frag.ID, "legacy", "json")
+	if err != nil {
+		t.Fatalf("GetEmbedding() error = %v", err)
+	}
+	want := []float64{0.25, 0.75}
+	if len(got) != len(want) {
+		t.Fatalf("embedding length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-9 {
+			t.Fatalf("embedding[%d] = %f, want %f", i, got[i], want[i])
+		}
 	}
 }
 
@@ -405,25 +446,34 @@ func TestStoreGetEmbeddingsByIDs(t *testing.T) {
 
 	vec1 := []float64{0.4, 0.5}
 	vec2 := []float64{0.6, 0.7}
+	vec3 := []float64{0.8, 0.9}
 	if err := store.UpsertEmbedding(ctx, f1.ID, "gemini", "gemini-embedding-001", len(vec1), vec1); err != nil {
 		t.Fatalf("UpsertEmbedding(f1) error = %v", err)
 	}
 	if err := store.UpsertEmbedding(ctx, f2.ID, "gemini", "gemini-embedding-001", len(vec2), vec2); err != nil {
 		t.Fatalf("UpsertEmbedding(f2) error = %v", err)
 	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO memory_embeddings(fragment_id, provider, model, dimensions, vector, embedded_at)
+		VALUES (?, 'gemini', 'gemini-embedding-001', 2, ?, ?)`, f3.ID, []byte(`[0.8,0.9]`), time.Now()); err != nil {
+		t.Fatalf("insert legacy JSON embedding: %v", err)
+	}
 
 	got, err := store.GetEmbeddingsByIDs(ctx, []string{f1.ID, f2.ID, f3.ID, f2.ID}, "gemini", "gemini-embedding-001")
 	if err != nil {
 		t.Fatalf("GetEmbeddingsByIDs() error = %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("GetEmbeddingsByIDs() len = %d, want 2", len(got))
+	if len(got) != 3 {
+		t.Fatalf("GetEmbeddingsByIDs() len = %d, want 3", len(got))
 	}
 	if vec, ok := got[f1.ID]; !ok || len(vec) != len(vec1) {
 		t.Fatalf("GetEmbeddingsByIDs() missing f1 or wrong length: %#v", got)
 	}
 	if vec, ok := got[f2.ID]; !ok || len(vec) != len(vec2) {
 		t.Fatalf("GetEmbeddingsByIDs() missing f2 or wrong length: %#v", got)
+	}
+	if vec, ok := got[f3.ID]; !ok || len(vec) != len(vec3) {
+		t.Fatalf("GetEmbeddingsByIDs() missing f3 legacy JSON vector or wrong length: %#v", got)
 	}
 	for i := range vec1 {
 		if math.Abs(got[f1.ID][i]-vec1[i]) > 1e-9 {
@@ -433,6 +483,11 @@ func TestStoreGetEmbeddingsByIDs(t *testing.T) {
 	for i := range vec2 {
 		if math.Abs(got[f2.ID][i]-vec2[i]) > 1e-9 {
 			t.Fatalf("f2 embedding[%d] = %f, want %f", i, got[f2.ID][i], vec2[i])
+		}
+	}
+	for i := range vec3 {
+		if math.Abs(got[f3.ID][i]-vec3[i]) > 1e-9 {
+			t.Fatalf("f3 legacy embedding[%d] = %f, want %f", i, got[f3.ID][i], vec3[i])
 		}
 	}
 }
@@ -511,6 +566,9 @@ func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
 	}
 	if results[0].ID != f1.ID {
 		t.Fatalf("VectorSearch() top ID = %s, want %s", results[0].ID, f1.ID)
+	}
+	if len(results[0].Vector) != 2 || math.Abs(results[0].Vector[0]-1) > 1e-9 || math.Abs(results[0].Vector[1]) > 1e-9 {
+		t.Fatalf("VectorSearch() top vector = %#v, want [1 0]", results[0].Vector)
 	}
 	if results[0].Score < results[1].Score {
 		t.Fatalf("scores out of order: %f < %f", results[0].Score, results[1].Score)
@@ -1205,8 +1263,8 @@ func seedVectorSearchBenchmark(b *testing.B, store *Store, total, matching int) 
 	defer embStmt.Close()
 
 	now := time.Now().UTC()
-	matchingVector := []byte(`[1,0,0,0]`)
-	otherVector := []byte(`[0,1,0,0]`)
+	matchingVector := encodeEmbeddingVector([]float64{1, 0, 0, 0})
+	otherVector := encodeEmbeddingVector([]float64{0, 1, 0, 0})
 	for i := 0; i < total; i++ {
 		id := fmt.Sprintf("vector-frag-%05d", i)
 		if _, err := fragStmt.Exec(id, "jarvis", fmt.Sprintf("vectors/%05d.md", i), "benchmark content", DefaultSourceMine, now, now); err != nil {

--- a/internal/memory/vector_search_bench_test.go
+++ b/internal/memory/vector_search_bench_test.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -65,6 +64,9 @@ func TestStoreVectorSearchLargeLimitFetchesFragmentsInBatches(t *testing.T) {
 	}
 	if want := fmt.Sprintf("large-limit-%03d", count-1); results[0].ID != want {
 		t.Fatalf("top result = %s, want newest tied result %s", results[0].ID, want)
+	}
+	if len(results[0].Vector) != 2 || results[0].Vector[0] != 1 || results[0].Vector[1] != 0 {
+		t.Fatalf("top legacy JSON vector = %#v, want [1 0]", results[0].Vector)
 	}
 }
 
@@ -130,10 +132,7 @@ func seedLargeVectorSearchBenchmark(b *testing.B, ctx context.Context, store *St
 			b.Fatalf("insert fragment %d: %v", i, err)
 		}
 
-		payload, err := json.Marshal(largeBenchmarkVector(i, dimensions))
-		if err != nil {
-			b.Fatalf("marshal vector %d: %v", i, err)
-		}
+		payload := encodeEmbeddingVector(largeBenchmarkVector(i, dimensions))
 		if _, err := embStmt.ExecContext(ctx, id, dimensions, payload, updatedAt); err != nil {
 			b.Fatalf("insert embedding %d: %v", i, err)
 		}


### PR DESCRIPTION
## What

- Store newly generated memory embeddings as compact little-endian float64 blobs instead of JSON arrays.
- Decode both the new binary payloads and existing legacy JSON payloads, preserving compatibility with current memory DBs.
- Score binary vectors directly from SQLite row payloads during vector search and use `sql.RawBytes` to avoid an extra per-row blob copy.
- Update vector-search benchmarks to seed the current binary format and add regression coverage for legacy JSON decoding paths.

## Why

A whole-stack benchmark/profile pass found memory vector search spending most CPU in `encoding/json` float parsing/validation and allocating heavily while scanning embedding rows. New embeddings should avoid JSON parse overhead on every search.

## Evidence

Baseline profile/benchmark before this change:

```text
BenchmarkStoreVectorSearchLargeCorpus-32    15    68104829 ns/op    23586128 B/op    63742 allocs/op
```

CPU profile showed `encoding/json.checkValid`, `encoding/json.(*decodeState).literalStore`, and `internal/strconv.ParseFloat/readFloat` as the dominant samples.

After this change:

```text
BenchmarkStoreVectorSearchLargeCorpus-32              1046     5697180 ns/op    4458357 B/op    30857 allocs/op
BenchmarkStoreVectorSearchProviderModelFilter-32     14804      404316 ns/op     104990 B/op     3111 allocs/op
```

The provider/model filter benchmark baseline from the broad pass was `563569 ns/op`, `152773 B/op`, `4601 allocs/op`.

## Verification

```text
go test ./internal/memory
go test ./internal/memory -run '^$' -bench 'BenchmarkStoreVectorSearch(LargeCorpus|ProviderModelFilter)' -benchmem -benchtime=5s -count=1
go test ./...
go build ./...
```
