### PR TITLE
test: skip Responses WebSocket retry sleeps

### DIFF
--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+func withResponsesWebSocketBaseBackoff(t *testing.T, backoff time.Duration) {
+	t.Helper()
+	oldBackoff := responsesWebSocketBaseBackoff
+	responsesWebSocketBaseBackoff = backoff
+	t.Cleanup(func() { responsesWebSocketBaseBackoff = oldBackoff })
+}
+
 func TestResponsesWebSocketURL(t *testing.T) {
 	tests := []struct {
 		in   string
@@ -358,9 +365,7 @@ func TestResponsesClientWebSocketFunctionCall(t *testing.T) {
 }
 
 func TestResponsesClientWebSocketConnectFailureFallsBackToHTTP(t *testing.T) {
-	oldBackoff := responsesWebSocketBaseBackoff
-	responsesWebSocketBaseBackoff = 0
-	defer func() { responsesWebSocketBaseBackoff = oldBackoff }()
+	withResponsesWebSocketBaseBackoff(t, 0)
 
 	var wsAttempts atomic.Int32
 	var httpAttempts atomic.Int32
@@ -442,9 +447,7 @@ func assertSecondStreamUsesHTTPFallbackOnly(t *testing.T, client *ResponsesClien
 }
 
 func TestResponsesClientWebSocketReadFailureBeforeEventsRetriesWebSocketThenFallsBackToHTTP(t *testing.T) {
-	oldBackoff := responsesWebSocketBaseBackoff
-	responsesWebSocketBaseBackoff = 0
-	defer func() { responsesWebSocketBaseBackoff = oldBackoff }()
+	withResponsesWebSocketBaseBackoff(t, 0)
 
 	var wsAttempts atomic.Int32
 	var httpAttempts atomic.Int32
@@ -506,9 +509,7 @@ func TestResponsesClientWebSocketReadFailureBeforeEventsRetriesWebSocketThenFall
 }
 
 func TestResponsesClientWebSocketReadFailureBeforeEventsRetryCanRecover(t *testing.T) {
-	oldBackoff := responsesWebSocketBaseBackoff
-	responsesWebSocketBaseBackoff = 0
-	defer func() { responsesWebSocketBaseBackoff = oldBackoff }()
+	withResponsesWebSocketBaseBackoff(t, 0)
 
 	var wsAttempts atomic.Int32
 	var httpAttempts atomic.Int32
@@ -572,9 +573,7 @@ func TestResponsesClientWebSocketReadFailureBeforeEventsRetryCanRecover(t *testi
 }
 
 func TestResponsesClientWebSocketReadFailureAfterEventsReturnsIncomplete(t *testing.T) {
-	oldBackoff := responsesWebSocketBaseBackoff
-	responsesWebSocketBaseBackoff = 0
-	defer func() { responsesWebSocketBaseBackoff = oldBackoff }()
+	withResponsesWebSocketBaseBackoff(t, 0)
 
 	var wsAttempts atomic.Int32
 	var httpAttempts atomic.Int32
@@ -632,9 +631,7 @@ func TestResponsesClientWebSocketReadFailureAfterEventsReturnsIncomplete(t *test
 }
 
 func TestResponsesClientWebSocketBackoffHonorsContextCancellation(t *testing.T) {
-	oldBackoff := responsesWebSocketBaseBackoff
-	responsesWebSocketBaseBackoff = time.Hour
-	defer func() { responsesWebSocketBaseBackoff = oldBackoff }()
+	withResponsesWebSocketBaseBackoff(t, time.Hour)
 
 	var wsAttempts atomic.Int32
 	upgrader := websocket.Upgrader{}
@@ -679,6 +676,8 @@ func TestResponsesClientWebSocketBackoffHonorsContextCancellation(t *testing.T) 
 }
 
 func TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput(t *testing.T) {
+	withResponsesWebSocketBaseBackoff(t, 0)
+
 	var httpReq map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {


### PR DESCRIPTION
## What

Removes an accidental real-time retry delay from `TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput` by reusing a test helper that temporarily overrides the Responses WebSocket retry backoff.

The helper also replaces the existing repeated save/restore blocks in the neighboring WebSocket retry tests so future tests are less likely to miss the zero-backoff setup.

## Why

This test is validating HTTP fallback request state, not production retry timing. With the default `responsesWebSocketBaseBackoff` it waited through the normal retry sleeps (250ms + 500ms) before reaching the fallback path on every run.

## Evidence

Targeted timing before this change:

```text
go test -count=3 -v -run TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput ./internal/llm
--- PASS: TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput (0.75s)
--- PASS: TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput (0.75s)
--- PASS: TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput (0.75s)
ok   github.com/samsaffron/term-llm/internal/llm  2.271s
```

After this change:

```text
go test -count=3 -v -run TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput ./internal/llm
--- PASS: TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput (0.00s)
--- PASS: TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput (0.00s)
--- PASS: TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput (0.00s)
ok   github.com/samsaffron/term-llm/internal/llm  0.016s
```

A 5-run check went from `3.776s` before to `0.013s` after.

## Verification

- `gofmt -w internal/llm/responses_websocket_test.go`
- `go test -count=3 -v -run TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput ./internal/llm`
- `go test -count=5 -run TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput ./internal/llm`
- `go test -count=1 -run 'TestResponsesClient(WebSocket|HTTPFallbackWithWebSocketOnlyServerState)|TestResponsesWebSocket|TestResponsesJSONEventType' ./internal/llm`
- `go test ./internal/llm`
- `go build ./...`
- `go test ./...`
- `go test -count=1 ./...`
