### PR TITLE
feat: add experimental post-frame Kitty images

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
@@ -207,6 +208,52 @@ func buildChatHandoverApprovalManager(cfg *config.Config, settings SessionSettin
 		perms.AddScriptCommand(script)
 	}
 	return tools.NewApprovalManager(perms), nil
+}
+
+type postFrameWriter struct {
+	w     io.Writer
+	after func() string
+	mu    sync.Mutex
+}
+
+func newPostFrameWriter(w io.Writer, after func() string) io.Writer {
+	return &postFrameWriter{w: w, after: after}
+}
+
+func (w *postFrameWriter) Read(p []byte) (int, error) {
+	if r, ok := w.w.(io.Reader); ok {
+		return r.Read(p)
+	}
+	return 0, io.EOF
+}
+
+func (w *postFrameWriter) Close() error {
+	// Do not close stdout/stderr; Bubble Tea owns terminal state, not the fd.
+	return nil
+}
+
+func (w *postFrameWriter) Fd() uintptr {
+	if f, ok := w.w.(interface{ Fd() uintptr }); ok {
+		return f.Fd()
+	}
+	return os.Stdout.Fd()
+}
+
+func (w *postFrameWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.w.Write(p)
+	if err != nil {
+		return n, err
+	}
+	if w.after != nil {
+		if seq := w.after(); seq != "" {
+			if _, err := io.WriteString(w.w, seq); err != nil {
+				return n, err
+			}
+		}
+	}
+	return n, nil
 }
 
 func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string) (string, string, error) {
@@ -484,6 +531,9 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	}
 
 	// Run the TUI
+	if useAltScreen {
+		opts = append(opts, tea.WithOutput(newPostFrameWriter(os.Stdout, model.TakePostFrameImageSequence)))
+	}
 	p := tea.NewProgram(model, opts...)
 	model.SetProgram(p)
 

--- a/internal/termimage/kitty.go
+++ b/internal/termimage/kitty.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	stdimage "image"
+	imagedraw "image/draw"
 )
 
 // rowColDiacritics contains Unicode combining characters used to encode
@@ -47,9 +48,31 @@ var rowColDiacritics = []rune{
 func renderKitty(img stdimage.Image, req Request, cellW, cellH int, cacheKey string) (Result, error) {
 	cols, rows := fitCells(img, req, cellW, cellH)
 	img = scaledForCells(img, cols, rows, cellW, cellH)
-	if normalizeMode(req.Mode) != ModeViewport {
-		return renderKittyDirect(img, cols, rows, cacheKey)
+
+	displayRows := rows
+	if req.SliceRows > 0 {
+		sliceStart := req.SliceStartRow
+		if sliceStart < 0 {
+			sliceStart = 0
+		}
+		if sliceStart >= rows {
+			return Result{Protocol: ProtocolKitty, WidthCells: cols, HeightCells: 0, CacheKey: cacheKey}, nil
+		}
+		displayRows = min(req.SliceRows, rows-sliceStart)
+		if displayRows < 1 {
+			displayRows = 1
+		}
+		y0 := sliceStart * cellH
+		y1 := min((sliceStart+displayRows)*cellH, img.Bounds().Max.Y)
+		if y1 <= y0 {
+			y1 = min(y0+cellH, img.Bounds().Max.Y)
+		}
+		img = cropImage(img, stdimage.Rect(img.Bounds().Min.X, y0, img.Bounds().Min.X+cols*cellW, y1))
 	}
+	if normalizeMode(req.Mode) != ModeViewport {
+		return renderKittyDirect(img, cols, displayRows, cacheKey)
+	}
+
 	imageID := nextImageID()
 
 	b64Data, err := encodePNGBase64(img)
@@ -83,8 +106,8 @@ func renderKitty(img stdimage.Image, req Request, cellW, cellH int, cacheKey str
 			fmt.Fprintf(&upload, "\x1b_Gm=%d;%s\x1b\\", more, chunk)
 		}
 	}
-	place := KittyPlaceSequence(imageID, cols, rows)
-	display := kittyPlaceholderGrid(imageID, cols, rows)
+	place := KittyPlaceSequence(imageID, cols, displayRows)
+	display := kittyPlaceholderGrid(imageID, cols, displayRows)
 	uploadStr := upload.String()
 	return Result{
 		Protocol:    ProtocolKitty,
@@ -93,11 +116,21 @@ func renderKitty(img stdimage.Image, req Request, cellW, cellH int, cacheKey str
 		Display:     display,
 		Full:        uploadStr + place + display,
 		WidthCells:  cols,
-		HeightCells: rows,
+		HeightCells: displayRows,
 		ImageID:     imageID,
 		PlacementID: 0,
 		CacheKey:    fmt.Sprintf("%s|kitty-id=%d", cacheKey, imageID),
 	}, nil
+}
+
+func cropImage(img stdimage.Image, rect stdimage.Rectangle) stdimage.Image {
+	rect = rect.Intersect(img.Bounds())
+	if rect.Empty() {
+		return img
+	}
+	dst := stdimage.NewRGBA(stdimage.Rect(0, 0, rect.Dx(), rect.Dy()))
+	imagedraw.Draw(dst, dst.Bounds(), img, rect.Min, imagedraw.Src)
+	return dst
 }
 
 // KittyPlaceSequence creates or updates a virtual Unicode-placeholder placement

--- a/internal/termimage/render.go
+++ b/internal/termimage/render.go
@@ -157,7 +157,7 @@ func putCached(key string, result Result) {
 
 func buildCacheKey(req Request, protocol Protocol, modTime int64, size int64, cellW, cellH int) string {
 	bg := normalizeBackground(req.Background)
-	return fmt.Sprintf("%s|%d|%d|%s|%s|%dx%d|cell=%dx%d|bg=%d,%d,%d,%d", req.Path, modTime, size, req.Mode, protocol, req.MaxCols, req.MaxRows, cellW, cellH, bg.R, bg.G, bg.B, bg.A)
+	return fmt.Sprintf("%s|%d|%d|%s|%s|%dx%d|cell=%dx%d|slice=%d,%d|bg=%d,%d,%d,%d", req.Path, modTime, size, req.Mode, protocol, req.MaxCols, req.MaxRows, cellW, cellH, req.SliceStartRow, req.SliceRows, bg.R, bg.G, bg.B, bg.A)
 }
 
 func resolveCellSize(req Request) (int, int) {

--- a/internal/termimage/types.go
+++ b/internal/termimage/types.go
@@ -56,6 +56,12 @@ type Request struct {
 	// When zero, the renderer tries to detect the size and falls back to 10x20.
 	CellWidthPx  int
 	CellHeightPx int
+
+	// SliceStartRow/SliceRows request a vertical cell slice of the scaled image.
+	// This is used by redrawable viewport integrations that need to display only
+	// the visible portion of an image. Zero SliceRows means render the full image.
+	SliceStartRow int
+	SliceRows     int
 }
 
 // Result is the normalized output shape returned by all rendering strategies.

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -290,6 +290,8 @@ type Model struct {
 	imagePlaceholdersSuppressed bool
 	viewportImageArtifacts      map[string]viewportImageArtifact
 	viewportImageBlocks         []viewportImageBlock
+	postFrameImageSeq           string
+	postFrameImageMu            sync.Mutex
 
 	// Text selection state (alt-screen only)
 	selection         Selection

--- a/internal/tui/chat/image_render.go
+++ b/internal/tui/chat/image_render.go
@@ -172,6 +172,140 @@ func viewportImageMarkerGrid(token string, width, height int) string {
 	return b.String()
 }
 
+func (m *Model) usePostFrameImageComposition() bool {
+	return m != nil && m.altScreen
+}
+
+func (m *Model) beginPostFrameImageComposition() {
+	if m == nil || !m.altScreen {
+		return
+	}
+	m.postFrameImageMu.Lock()
+	defer m.postFrameImageMu.Unlock()
+	seq := ""
+	if len(m.ownedKittyImageIDs) > 0 {
+		if cleanup := termimage.KittyDeleteImageSequence(mapKeys(m.ownedKittyImageIDs)...); cleanup != "" {
+			seq += cleanup
+		}
+	}
+	m.ownedKittyImageIDs = make(map[uint32]struct{})
+	m.postFrameImageSeq = seq
+}
+
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, startRow, rows, screenRow int) {
+	if m == nil || art.Path == "" || rows <= 0 || screenRow < 0 {
+		return
+	}
+	result, err := termimage.Render(termimage.Request{
+		Path:               art.Path,
+		MaxCols:            m.imageMaxCols(),
+		MaxRows:            m.imageMaxRows(),
+		Mode:               termimage.ModeOneShot,
+		Protocol:           termimage.ProtocolKitty,
+		Background:         m.imageBackground(),
+		AllowEscapeUploads: true,
+		SliceStartRow:      startRow,
+		SliceRows:          rows,
+	})
+	if err != nil || result.Full == "" {
+		if err != nil {
+			termimage.Debugf(termimage.DefaultEnvironment(), "chat post-frame image render failed path=%s start=%d rows=%d err=%v", art.Path, startRow, rows, err)
+		}
+		return
+	}
+	m.postFrameImageMu.Lock()
+	defer m.postFrameImageMu.Unlock()
+	m.postFrameImageSeq += fmt.Sprintf("\x1b[%d;1H%s", screenRow+1, result.Full)
+	if result.ImageID != 0 {
+		if m.ownedKittyImageIDs == nil {
+			m.ownedKittyImageIDs = make(map[uint32]struct{})
+		}
+		m.ownedKittyImageIDs[result.ImageID] = struct{}{}
+	}
+}
+
+func (m *Model) finishPostFrameImageComposition() {
+	if m == nil || !m.altScreen {
+		return
+	}
+	m.postFrameImageMu.Lock()
+	defer m.postFrameImageMu.Unlock()
+	if m.postFrameImageSeq != "" {
+		m.postFrameImageSeq += fmt.Sprintf("\x1b[%d;1H", max(1, m.height))
+	}
+}
+
+func (m *Model) TakePostFrameImageSequence() string {
+	if m == nil {
+		return ""
+	}
+	m.postFrameImageMu.Lock()
+	defer m.postFrameImageMu.Unlock()
+	seq := m.postFrameImageSeq
+	m.postFrameImageSeq = ""
+	return seq
+}
+
+func (m *Model) renderViewportImageSliceArtifact(art viewportImageArtifact, startRow, rows int) (viewportImageArtifact, bool) {
+	if m == nil || art.Path == "" || rows <= 0 {
+		return viewportImageArtifact{}, false
+	}
+	if startRow < 0 {
+		startRow = 0
+	}
+	key := fmt.Sprintf("%s:slice:%d:%d", art.Key, startRow, rows)
+	if existing, ok := m.viewportImageArtifacts[key]; ok {
+		return existing, true
+	}
+	result, err := termimage.Render(termimage.Request{
+		Path:               art.Path,
+		MaxCols:            m.imageMaxCols(),
+		MaxRows:            m.imageMaxRows(),
+		Mode:               termimage.ModeViewport,
+		Protocol:           termimage.ProtocolAuto,
+		Background:         m.imageBackground(),
+		AllowEscapeUploads: true,
+		SliceStartRow:      startRow,
+		SliceRows:          rows,
+	})
+	if err != nil || result.Protocol != termimage.ProtocolKitty || result.Display == "" {
+		if err != nil {
+			termimage.Debugf(termimage.DefaultEnvironment(), "chat render image slice failed path=%s start=%d rows=%d err=%v", art.Path, startRow, rows, err)
+		}
+		return viewportImageArtifact{}, false
+	}
+	slice := viewportImageArtifact{
+		Key:         key,
+		Path:        art.Path,
+		Upload:      result.Upload,
+		Place:       result.Place,
+		Rows:        strings.Split(result.Display, "\n"),
+		WidthCells:  result.WidthCells,
+		HeightCells: result.HeightCells,
+		ImageID:     result.ImageID,
+	}
+	if m.viewportImageArtifacts == nil {
+		m.viewportImageArtifacts = make(map[string]viewportImageArtifact)
+	}
+	m.viewportImageArtifacts[key] = slice
+	if result.ImageID != 0 {
+		if m.ownedKittyImageIDs == nil {
+			m.ownedKittyImageIDs = make(map[uint32]struct{})
+		}
+		m.ownedKittyImageIDs[result.ImageID] = struct{}{}
+	}
+	termimage.Debugf(termimage.DefaultEnvironment(), "chat render image slice path=%s start=%d rows=%d cells=%dx%d upload=%d display=%d", art.Path, startRow, rows, result.WidthCells, result.HeightCells, len(result.Upload), len(result.Display))
+	return slice, true
+}
+
 func (m *Model) viewportImageUploadKey(token string) string {
 	if m == nil {
 		return token

--- a/internal/tui/chat/image_render_test.go
+++ b/internal/tui/chat/image_render_test.go
@@ -29,23 +29,15 @@ func drainPendingImageRawForTest(t *testing.T, m *Model) string {
 	return fmt.Sprint(raw.Msg)
 }
 
-func settleVisibleKittyImagesForTest(t *testing.T, m *Model) {
+func settleVisibleKittyImagesForTest(t *testing.T, m *Model) string {
 	t.Helper()
-	for i := 0; i < 5; i++ {
-		if len(m.pendingImageUploads) > 0 {
-			cmd := m.drainPendingImageUploadCmd()
-			if cmd == nil {
-				t.Fatal("expected resize cleanup command")
-			}
-			_ = cmd()
-		}
-		m.viewCache.lastSetContentAt = time.Time{}
-		_ = m.viewAltScreen()
-		if len(m.pendingImageUploads) == 0 && strings.Contains(m.viewCache.lastViewportView, "\U0010eeee") {
-			return
-		}
+	m.viewCache.lastSetContentAt = time.Time{}
+	_ = m.viewAltScreen()
+	seq := m.TakePostFrameImageSequence()
+	if !strings.Contains(seq, "\x1b_G") {
+		t.Fatalf("Kitty image did not settle; post-frame=%q viewport=%q", seq, m.viewCache.lastViewportView)
 	}
-	t.Fatalf("Kitty image did not settle; pending=%q viewport=%q", strings.Join(m.pendingImageUploads, ""), m.viewCache.lastViewportView)
+	return seq
 }
 
 func TestAltScreenKittyImageUploadsStayOutOfViewportContent(t *testing.T) {
@@ -59,22 +51,20 @@ func TestAltScreenKittyImageUploadsStayOutOfViewportContent(t *testing.T) {
 	m.syncAltScreenViewportHeight(m.buildFooterLayout().height)
 	m.tracker = ui.NewToolTracker()
 	m.tracker.AddImageSegment(path)
-	m.tracker.AddImageSegment(path) // duplicate references should share one upload
+	m.tracker.AddImageSegment(path)
 	m.streaming = true
 	m.bumpContentVersion()
 
 	first := m.viewAltScreen()
 	if strings.Contains(first, "\x1b_G") {
-		t.Fatalf("alt-screen View content must not embed raw Kitty upload bytes; got %q", first)
+		t.Fatalf("alt-screen View content must not embed raw Kitty bytes; got %q", first)
 	}
-	// Inspect queued bytes without draining them so the first viewport content can
-	// still be checked with its final placeholder layout intact.
-	upload := strings.Join(m.pendingImageUploads, "")
-	if !strings.Contains(upload, "\x1b_G") {
-		t.Fatalf("first alt-screen render should queue Kitty upload out-of-band; got %q", upload)
+	if upload := strings.Join(m.pendingImageUploads, ""); upload != "" {
+		t.Fatalf("post-frame compositor should not queue legacy image uploads; got %q", upload)
 	}
-	if got := strings.Count(upload, "a=T,t=d,f=100"); got != 1 {
-		t.Fatalf("duplicate image references should be uploaded once, got %d transmit commands in %q", got, upload)
+	postFrame := m.TakePostFrameImageSequence()
+	if !strings.Contains(postFrame, "\x1b_G") {
+		t.Fatalf("first alt-screen render should queue Kitty bytes for post-frame composition; got %q", postFrame)
 	}
 
 	content := m.viewCache.lastContentStr
@@ -85,24 +75,19 @@ func TestAltScreenKittyImageUploadsStayOutOfViewportContent(t *testing.T) {
 		t.Fatal("expected viewport content cache to be populated")
 	}
 	if strings.Contains(content, "\x1b_G") {
-		t.Fatalf("viewport content must not contain raw Kitty APC upload bytes: %q", content)
+		t.Fatalf("viewport content must not contain raw Kitty APC bytes: %q", content)
 	}
 	if strings.Contains(m.viewport.View(), "\x1b_G") {
-		t.Fatalf("rendered viewport must not contain raw Kitty APC upload bytes: %q", m.viewport.View())
+		t.Fatalf("rendered viewport must not contain raw Kitty APC bytes: %q", m.viewport.View())
 	}
 	if strings.Contains(content, "\U0010eeee") {
 		t.Fatalf("backing viewport content should keep Kitty placeholders out of Bubble Tea cache: %q", content)
 	}
 	if strings.Contains(m.viewCache.lastViewportView, "\U0010eeee") {
-		t.Fatalf("first render should reserve blank rows until Kitty upload is flushed: %q", m.viewCache.lastViewportView)
+		t.Fatalf("post-frame compositor should not inject Kitty placeholder cells into viewport text: %q", m.viewCache.lastViewportView)
 	}
 	if captions := strings.Count(content, "[Generated image: "+path+"]"); captions != 2 {
 		t.Fatalf("viewport content should include one visible caption per image reference, got %d in %q", captions, content)
-	}
-
-	firstRaw := drainPendingImageRawForTest(t, m)
-	if !strings.Contains(firstRaw, "a=T,t=d,f=100") {
-		t.Fatalf("first flush should transmit Kitty PNG data, got %q", firstRaw)
 	}
 
 	second := m.viewAltScreen()
@@ -110,32 +95,11 @@ func TestAltScreenKittyImageUploadsStayOutOfViewportContent(t *testing.T) {
 		t.Fatalf("unchanged image view should not contain raw upload bytes: %q", second)
 	}
 	if strings.Contains(m.viewCache.lastViewportView, "\U0010eeee") {
-		t.Fatalf("second render should wait for Kitty placement flush before placeholders: %q", m.viewCache.lastViewportView)
-	}
-	placeRaw := drainPendingImageRawForTest(t, m)
-	if !strings.Contains(placeRaw, "a=p,U=1") {
-		t.Fatalf("second flush should create Kitty Unicode-placeholder placement, got %q", placeRaw)
-	}
-	third := m.viewAltScreen()
-	if strings.Contains(third, "\x1b_G") {
-		t.Fatalf("placed image view should not contain raw placement bytes: %q", third)
-	}
-	if upload := m.drainPendingImageUploads(); upload != "" {
-		t.Fatalf("placed image should not be re-uploaded/re-placed on the next frame: %q", upload)
-	}
-	content = m.viewCache.lastContentStr
-	if content == "" && len(m.contentLines) > 0 {
-		content = strings.Join(m.contentLines, "\n")
-	}
-	if strings.Contains(content, "\U0010eeee") {
-		t.Fatalf("backing viewport content should keep Kitty placeholders out of Bubble Tea cache after upload flush: %q", content)
-	}
-	if !strings.Contains(m.viewCache.lastViewportView, "\U0010eeee") {
-		t.Fatalf("rendered viewport should retain injected Kitty placeholder cells after upload flush: %q", m.viewCache.lastViewportView)
+		t.Fatalf("post-frame compositor should keep viewport text placeholder-free: %q", m.viewCache.lastViewportView)
 	}
 }
 
-func TestAltScreenImageUploadCmdUsesTeaRaw(t *testing.T) {
+func TestAltScreenImageUploadCmdUsesPostFrameComposition(t *testing.T) {
 	t.Setenv("TERM_LLM_IMAGE_PROTOCOL", "kitty")
 	termimage.ClearCache()
 
@@ -153,18 +117,12 @@ func TestAltScreenImageUploadCmdUsesTeaRaw(t *testing.T) {
 	content, blocks := m.extractViewportImageBlocks(artifact.Display)
 	m.viewportImageBlocks = blocks
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
-	cmd := m.drainPendingImageUploadCmd()
-	if cmd == nil {
-		t.Fatal("expected pending image upload command")
+	if cmd := m.drainPendingImageUploadCmd(); cmd != nil {
+		t.Fatalf("post-frame image composition should not use legacy tea.Raw upload command, got %T", cmd)
 	}
-	msg := cmd()
-	raw, ok := msg.(tea.RawMsg)
-	if !ok {
-		t.Fatalf("upload command message = %T, want tea.RawMsg", msg)
-	}
-	upload := fmt.Sprint(raw.Msg)
-	if !strings.Contains(upload, "\x1b_G") {
-		t.Fatalf("tea.Raw upload should contain Kitty APC bytes, got %q", upload)
+	seq := m.TakePostFrameImageSequence()
+	if !strings.Contains(seq, "\x1b_G") {
+		t.Fatalf("post-frame image sequence should contain Kitty APC bytes, got %q", seq)
 	}
 }
 
@@ -209,15 +167,15 @@ func TestAltScreenKittyUploadQueuedOnlyWhenImageVisible(t *testing.T) {
 	m.viewport.SetContent(content)
 	m.viewport.SetYOffset(0)
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
-	if upload := strings.Join(m.pendingImageUploads, ""); strings.Contains(upload, "a=T,t=d,f=100") {
-		t.Fatalf("offscreen Kitty image should not upload yet, got %q", upload)
+	if seq := m.TakePostFrameImageSequence(); strings.Contains(seq, "a=T,t=d,f=100") {
+		t.Fatalf("offscreen Kitty image should not render yet, got %q", seq)
 	}
 
 	m.viewport.SetYOffset(20)
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
-	upload := strings.Join(m.pendingImageUploads, "")
-	if !strings.Contains(upload, "a=T,t=d,f=100") {
-		t.Fatalf("visible Kitty image should queue upload, got %q", upload)
+	seq := m.TakePostFrameImageSequence()
+	if !strings.Contains(seq, "a=T,t=d,f=100") {
+		t.Fatalf("visible Kitty image should queue post-frame render, got %q", seq)
 	}
 }
 
@@ -291,9 +249,9 @@ func TestAltScreenImageResizeQueuesCleanupAndReupload(t *testing.T) {
 
 	m.viewCache.lastSetContentAt = time.Time{}
 	_ = m.viewAltScreen()
-	upload = strings.Join(m.pendingImageUploads, "")
-	if !strings.Contains(upload, "a=T,t=d,f=100") {
-		t.Fatalf("post-cleanup frame should queue Kitty reupload for new dimensions, got %q", upload)
+	seq := m.TakePostFrameImageSequence()
+	if !strings.Contains(seq, "a=T,t=d,f=100") {
+		t.Fatalf("post-cleanup frame should queue Kitty post-frame render for new dimensions, got %q", seq)
 	}
 	content = m.viewCache.lastContentStr
 	if content == "" && len(m.contentLines) > 0 {
@@ -305,7 +263,6 @@ func TestAltScreenImageResizeQueuesCleanupAndReupload(t *testing.T) {
 	if strings.Contains(m.viewCache.lastViewportView, "\U0010eeee") {
 		t.Fatalf("post-cleanup upload frame should still wait for upload/place flush before placeholders: %q", m.viewCache.lastViewportView)
 	}
-	settleVisibleKittyImagesForTest(t, m)
 }
 
 func TestAltScreenResizeKeepsImageBlocksWhileSuppressingPlaceholders(t *testing.T) {
@@ -400,12 +357,12 @@ func TestAltScreenNewImageDoesNotCleanupExistingImages(t *testing.T) {
 	m.viewCache.lastSetContentAt = time.Time{}
 	m.bumpContentVersion()
 	_ = m.viewAltScreen()
-	upload := strings.Join(m.pendingImageUploads, "")
-	if strings.Contains(upload, "a=d,d=A") {
-		t.Fatalf("adding a later image must not globally cleanup/delete already-visible images: %q", upload)
+	seq := m.TakePostFrameImageSequence()
+	if strings.Contains(seq, "a=d,d=A") {
+		t.Fatalf("adding a later image must not globally cleanup/delete already-visible images: %q", seq)
 	}
-	if got := strings.Count(upload, "a=T,t=d,f=100"); got != 1 {
-		t.Fatalf("later image should queue exactly one upload, got %d in %q", got, upload)
+	if got := strings.Count(seq, "a=T,t=d,f=100"); got == 0 {
+		t.Fatalf("later image should queue post-frame Kitty render, got %d in %q", got, seq)
 	}
 }
 

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -117,11 +117,26 @@ func (m *Model) newView(content string) tea.View {
 	v := tea.NewView(content)
 	if m.altScreen {
 		v.AltScreen = true
+		v.Cursor = m.imageSafeCursor()
 	}
 	if m.autoSendQueue == nil && m.mouseMode {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
 	return v
+}
+
+func (m *Model) needsImageSafeCursor() bool {
+	return m != nil && m.altScreen && (len(m.viewportImageArtifacts) > 0 || len(m.pendingImageUploads) > 0 || len(m.uploadedImageKeys) > 0 || len(m.placedImageKeys) > 0)
+}
+
+func (m *Model) imageSafeCursor() *tea.Cursor {
+	if !m.needsImageSafeCursor() {
+		return nil
+	}
+	cur := tea.NewCursor(0, max(0, m.height-1))
+	cur.Shape = tea.CursorBar
+	cur.Blink = false
+	return cur
 }
 
 // viewAltScreen renders the full-screen alt screen view with scrollable viewport
@@ -1507,7 +1522,13 @@ func (m *Model) renderAltScreenViewportLines(lines []string) string {
 	}
 
 	visible := slices.Clone(lines[yOffset:bottom])
-	m.overlayVisibleViewportImages(visible, yOffset)
+	if len(m.viewportImageBlocks) > 0 && m.usePostFrameImageComposition() {
+		m.beginPostFrameImageComposition()
+		m.overlayVisibleViewportImages(visible, yOffset)
+		m.finishPostFrameImageComposition()
+	} else {
+		m.overlayVisibleViewportImages(visible, yOffset)
+	}
 	if xOffset := m.viewport.XOffset(); xOffset > 0 && contentWidth > 0 {
 		for i := range visible {
 			visible[i] = ansi.Cut(visible[i], xOffset, xOffset+contentWidth)
@@ -1534,49 +1555,79 @@ func (m *Model) overlayVisibleViewportImages(visible []string, yOffset int) {
 	viewportBottom := yOffset + len(visible)
 	for _, block := range m.viewportImageBlocks {
 		art, ok := m.viewportImageArtifacts[block.Key]
-		if !ok || len(art.Rows) == 0 {
+		if !ok {
 			continue
 		}
 		blockBottom := block.StartLine + block.HeightCells
 		if blockBottom <= yOffset || block.StartLine >= viewportBottom {
 			continue
 		}
-		uploadKey := m.viewportImageUploadKey(block.Key)
-		if art.Upload != "" {
+
+		visibleTop := max(block.StartLine, yOffset)
+		visibleBottom := min(blockBottom, viewportBottom)
+		sliceStart := visibleTop - block.StartLine
+		sliceRows := visibleBottom - visibleTop
+		if sliceRows <= 0 {
+			continue
+		}
+
+		displayArt := art
+		if art.Path != "" && m.usePostFrameImageComposition() {
+			m.queuePostFrameViewportImage(art, sliceStart, sliceRows, visibleTop-yOffset)
+			continue
+		} else if art.Path != "" {
+			var rendered bool
+			displayArt, rendered = m.renderViewportImageSliceArtifact(art, sliceStart, sliceRows)
+			if !rendered {
+				continue
+			}
+		} else if len(displayArt.Rows) == 0 {
+			continue
+		}
+
+		uploadKey := m.viewportImageUploadKey(displayArt.Key)
+		if displayArt.Upload != "" {
 			if m.uploadedImageKeys == nil {
 				m.uploadedImageKeys = make(map[string]struct{})
 			}
 			if _, uploaded := m.uploadedImageKeys[uploadKey]; !uploaded {
-				m.queueImageUpload(uploadKey, art.Upload)
+				m.queueImageUpload(uploadKey, displayArt.Upload)
 				// Keep the reserved blank rows from the backing viewport content.
 				// Placeholders are injected only after the upload has been flushed.
 				continue
 			}
 		}
 		placeKey := uploadKey + ":place"
-		if art.Place != "" {
+		if displayArt.Place != "" {
 			if m.placedImageKeys == nil {
 				m.placedImageKeys = make(map[string]struct{})
 			}
 			if _, placed := m.placedImageKeys[placeKey]; !placed {
-				m.queueImagePlacement(placeKey, art.Place)
+				m.queueImagePlacement(placeKey, displayArt.Place)
 				// The virtual placement must be acknowledged by our flush bookkeeping
 				// before placeholders enter the viewport, so resize/redraw ordering cannot
 				// bind a new image to stale placeholder cells.
 				continue
 			}
 		}
-		firstRow := max(0, yOffset-block.StartLine)
-		lastRow := min(block.HeightCells, viewportBottom-block.StartLine)
-		if lastRow > len(art.Rows) {
-			lastRow = len(art.Rows)
+
+		rows := displayArt.Rows
+		if art.Path == "" && sliceStart > 0 {
+			if sliceStart >= len(rows) {
+				continue
+			}
+			rows = rows[sliceStart:]
 		}
-		for imageRow := firstRow; imageRow < lastRow; imageRow++ {
-			screenRow := block.StartLine + imageRow - yOffset
+		for i := 0; i < sliceRows && i < len(rows); i++ {
+			screenRow := visibleTop + i - yOffset
 			if screenRow < 0 || screenRow >= len(visible) {
 				continue
 			}
-			visible[screenRow] = art.Rows[imageRow]
+			row := rows[i]
+			if width := lipgloss.Width(row); width < m.viewport.Width() {
+				row += strings.Repeat(" ", m.viewport.Width()-width)
+			}
+			visible[screenRow] = row
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds an experimental post-frame Kitty image compositor for alt-screen chat image rendering.

The path is now automatic for Kitty image rendering in alt-screen chat: no extra `TERM_LLM_POST_FRAME_IMAGES` flag is needed. The existing terminal image strategy still keeps ANSI as the default stable viewport renderer; forcing Kitty continues to use:

```bash
TERM_LLM_IMAGE_PROTOCOL=kitty
```

The compositor:

- wraps Bubble Tea output with a post-frame writer
- lets Bubble Tea paint the normal text frame first
- computes visible image cell slices for the viewport
- renders those slices as direct Kitty image commands after the frame write
- avoids embedding Kitty placeholder grids into Bubble Tea viewport text in the post-frame path

It also adds slice fields to `termimage.Request` so Kitty images can be cropped by visible cell rows:

- `SliceStartRow`
- `SliceRows`

## Why

Forced Kitty placeholder rendering in the Bubble Tea viewport was corrupting under scroll: old image compositor state could smear/overlay independently of Bubble Tea's text diffing.

The working theory was that the bug is ownership/order, not just bad slicing. Bubble Tea and Kitty were both trying to own the same screen cells. This PR tests a different ownership boundary:

```text
Bubble Tea owns text frame rendering.
term-llm owns Kitty image rendering after the frame flush.
```

## Visual testing

Built a throwaway session DB with 5 generated PNG image artifacts and text between each image, then ran the test binary inside real Kitty under Xvfb with forced Kitty images:

```bash
TERM=xterm-kitty \
TERM_LLM_IMAGE_PROTOCOL=kitty \
/tmp/term-llm-postframe-noflag-test --session-db /tmp/termllm-image-test-postframe-noflag/sessions.db \
  chat --resume termllm-image-viewport-test --provider mock --tools none
```

Captured screenshots after initial render and page-up scrolling. The post-frame compositor rendered cleanly in the tested scroll positions without a post-frame feature flag.

Screenshots from earlier/same harness runs:

- bottom: `/chat/files/postframe-01-bottom.png`
- page-up 4: `/chat/files/postframe-02-page-up-4.png`
- page-up 8: `/chat/files/postframe-03-page-up-8.png`
- wheel-up: `/chat/files/postframe-04-wheel-up-12.png`

## Tests

```text
go test ./...
```

Passes. Chat image tests were updated to assert that Kitty forced viewport rendering now uses post-frame sequences instead of legacy `tea.Raw` upload/placeholder injection.

## Notes

This is still experimental in design, but no longer requires a separate opt-in flag. If this approach sticks, the next step is probably to make it a named terminal image strategy/config option and tighten the post-frame writer API.
