### PR TITLE
perf: use Kitty file transfers for direct images

### DIFF
--- a/internal/termimage/kitty.go
+++ b/internal/termimage/kitty.go
@@ -2,9 +2,14 @@ package termimage
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
+	"hash/fnv"
 	stdimage "image"
 	imagedraw "image/draw"
+	"image/png"
+	"os"
+	"path/filepath"
 )
 
 // rowColDiacritics contains Unicode combining characters used to encode
@@ -162,32 +167,20 @@ func KittyPlacementForPath(req Request, imageID uint32) (Result, error) {
 
 func renderKittyDirect(img stdimage.Image, cols, rows int, cacheKey string) (Result, error) {
 	imageID := nextImageID()
-	b64Data, err := encodePNGBase64(img)
+	path, err := writeKittyTempPNG(img, cacheKey)
 	if err != nil {
-		return Result{}, fmt.Errorf("encode PNG: %w", err)
+		return Result{}, fmt.Errorf("write Kitty temp PNG: %w", err)
 	}
+	pathData := base64.StdEncoding.EncodeToString([]byte(path))
 
 	var out bytes.Buffer
-	// One-shot Kitty rendering is used for normal scrollback/CLI output, not for
-	// Bubble Tea viewports. Do not use Unicode placeholders here: a direct visible
-	// placement avoids the double-rendering behavior seen when placeholder grids are
-	// printed in ordinary terminal output.
+	// One-shot Kitty rendering is used for normal scrollback/CLI output and for
+	// the chat post-frame compositor. Send a file reference instead of inline PNG
+	// bytes so redraws/scrolled slices do not flood the terminal with base64 image
+	// payloads. The terminal process runs on the same host and can read the temp
+	// file directly.
 	fmt.Fprintf(&out, "\x1b_Ga=d,i=%d,q=2\x1b\\", imageID)
-	const chunkSize = 4096
-	for i := 0; i < len(b64Data); i += chunkSize {
-		end := i + chunkSize
-		more := 1
-		if end >= len(b64Data) {
-			end = len(b64Data)
-			more = 0
-		}
-		chunk := b64Data[i:end]
-		if i == 0 {
-			fmt.Fprintf(&out, "\x1b_Ga=T,t=d,f=100,i=%d,c=%d,r=%d,q=2,m=%d;%s\x1b\\", imageID, cols, rows, more, chunk)
-		} else {
-			fmt.Fprintf(&out, "\x1b_Gm=%d;%s\x1b\\", more, chunk)
-		}
-	}
+	fmt.Fprintf(&out, "\x1b_Ga=T,t=f,f=100,i=%d,c=%d,r=%d,q=2;%s\x1b\\", imageID, cols, rows, pathData)
 
 	s := out.String()
 	return Result{
@@ -200,6 +193,32 @@ func renderKittyDirect(img stdimage.Image, cols, rows int, cacheKey string) (Res
 		PlacementID: 0,
 		CacheKey:    fmt.Sprintf("%s|kitty-id=%d", cacheKey, imageID),
 	}, nil
+}
+
+func writeKittyTempPNG(img stdimage.Image, cacheKey string) (string, error) {
+	dir := filepath.Join(os.TempDir(), "term-llm-kitty-images")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(cacheKey))
+	path := filepath.Join(dir, fmt.Sprintf("%x.png", h.Sum64()))
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return path, nil
+		}
+		return "", err
+	}
+	defer f.Close()
+	if err := png.Encode(f, img); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
 }
 
 func kittyPlaceholderGrid(imageID uint32, cols, rows int) string {

--- a/internal/tui/chat/image_render_test.go
+++ b/internal/tui/chat/image_render_test.go
@@ -129,7 +129,7 @@ func TestAltScreenImageUploadCmdUsesPostFrameComposition(t *testing.T) {
 func TestAltScreenKittyPartialImageCanInjectAndUpload(t *testing.T) {
 	m := newTestChatModel(true)
 	m.viewportImageArtifacts = map[string]viewportImageArtifact{
-		"t": {Key: "t", Upload: "\x1b_Ga=T,t=d,f=100;data\x1b\\", Rows: []string{"row0\U0010eeee", "row1\U0010eeee"}, WidthCells: 4, HeightCells: 2},
+		"t": {Key: "t", Upload: "\x1b_Ga=T;data\x1b\\", Rows: []string{"row0\U0010eeee", "row1\U0010eeee"}, WidthCells: 4, HeightCells: 2},
 	}
 	m.viewportImageBlocks = []viewportImageBlock{{Key: "t", StartLine: 0, WidthCells: 4, HeightCells: 2}}
 	visible := []string{"    "}
@@ -137,7 +137,7 @@ func TestAltScreenKittyPartialImageCanInjectAndUpload(t *testing.T) {
 	if strings.Contains(strings.Join(visible, "\n"), "\U0010eeee") {
 		t.Fatalf("partial Kitty image should not inject placeholders before upload flush: %q", visible)
 	}
-	if upload := strings.Join(m.pendingImageUploads, ""); !strings.Contains(upload, "a=T,t=d,f=100") {
+	if upload := strings.Join(m.pendingImageUploads, ""); !strings.Contains(upload, "a=T") {
 		t.Fatalf("partial visible Kitty image should upload, got %q", upload)
 	}
 	m.uploadedImageKeys[m.viewportImageUploadKey("t")] = struct{}{}
@@ -167,14 +167,14 @@ func TestAltScreenKittyUploadQueuedOnlyWhenImageVisible(t *testing.T) {
 	m.viewport.SetContent(content)
 	m.viewport.SetYOffset(0)
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
-	if seq := m.TakePostFrameImageSequence(); strings.Contains(seq, "a=T,t=d,f=100") {
+	if seq := m.TakePostFrameImageSequence(); strings.Contains(seq, "a=T") {
 		t.Fatalf("offscreen Kitty image should not render yet, got %q", seq)
 	}
 
 	m.viewport.SetYOffset(20)
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
 	seq := m.TakePostFrameImageSequence()
-	if !strings.Contains(seq, "a=T,t=d,f=100") {
+	if !strings.Contains(seq, "a=T") {
 		t.Fatalf("visible Kitty image should queue post-frame render, got %q", seq)
 	}
 }
@@ -237,7 +237,7 @@ func TestAltScreenImageResizeQueuesCleanupAndReupload(t *testing.T) {
 	if !strings.Contains(upload, "a=d") {
 		t.Fatalf("resize should queue Kitty cleanup before reupload, got %q", upload)
 	}
-	if strings.Contains(upload, "a=T,t=d,f=100") {
+	if strings.Contains(upload, "a=T") {
 		t.Fatalf("resize cleanup frame must not reupload while old placeholders may still be on screen: %q", upload)
 	}
 	cmd := m.drainPendingImageUploadCmd()
@@ -250,7 +250,7 @@ func TestAltScreenImageResizeQueuesCleanupAndReupload(t *testing.T) {
 	m.viewCache.lastSetContentAt = time.Time{}
 	_ = m.viewAltScreen()
 	seq := m.TakePostFrameImageSequence()
-	if !strings.Contains(seq, "a=T,t=d,f=100") {
+	if !strings.Contains(seq, "a=T") {
 		t.Fatalf("post-cleanup frame should queue Kitty post-frame render for new dimensions, got %q", seq)
 	}
 	content = m.viewCache.lastContentStr
@@ -330,7 +330,7 @@ func TestAltScreenImageHeightResizeQueuesCleanupAndReupload(t *testing.T) {
 	if !strings.Contains(upload, "a=d") {
 		t.Fatalf("height resize should queue Kitty cleanup, got %q", upload)
 	}
-	if strings.Contains(upload, "a=T,t=d,f=100") {
+	if strings.Contains(upload, "a=T") {
 		t.Fatalf("height resize cleanup frame must not reupload immediately, got %q", upload)
 	}
 }
@@ -361,7 +361,7 @@ func TestAltScreenNewImageDoesNotCleanupExistingImages(t *testing.T) {
 	if strings.Contains(seq, "a=d,d=A") {
 		t.Fatalf("adding a later image must not globally cleanup/delete already-visible images: %q", seq)
 	}
-	if got := strings.Count(seq, "a=T,t=d,f=100"); got == 0 {
+	if got := strings.Count(seq, "a=T"); got == 0 {
 		t.Fatalf("later image should queue post-frame Kitty render, got %d in %q", got, seq)
 	}
 }


### PR DESCRIPTION
## What

Speeds up direct Kitty image rendering by sending file references (`t=f`) instead of inline PNG payloads (`t=d`) for one-shot/direct Kitty images.

This targets the post-frame compositor path merged in #672. That path redraws visible image slices after Bubble Tea paints the frame; sending full base64 PNG payloads on redraw makes scrolling painfully slow.

The new path:

- writes the cropped/scaled PNG slice to a temp file under:
  ```text
  /tmp/term-llm-kitty-images/
  ```
- keys the temp file by the render cache key
- emits a short Kitty file-transfer command pointing at that PNG
- reuses existing temp files for repeated redraws of the same slice

## Why

The post-frame compositor fixed correctness but was slow because each scroll/redraw sent thousands of bytes of base64 image data through the terminal. File-transfer mode shrinks those repeated commands to a small path reference.

Representative debug output from the visual smoke went from ~4KB direct displays to ~116 bytes for repeated post-frame direct Kitty images.

## Tests

```text
go test ./...
```

## Visual smoke

Ran the same Kitty/Xvfb forced-Kitty fixture after this change:

```bash
TERM=xterm-kitty \
TERM_LLM_IMAGE_PROTOCOL=kitty \
/tmp/term-llm-fastkitty-test --session-db /tmp/termllm-image-test-fastkitty/sessions.db \
  chat --resume termllm-image-viewport-test --provider mock --tools none
```

Captured bottom/page-up/wheel-up screenshots; rendering remained clean while scroll responsiveness improved substantially.
