### PR TITLE
fix: stabilize post-frame Kitty images

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
@@ -210,10 +211,13 @@ func buildChatHandoverApprovalManager(cfg *config.Config, settings SessionSettin
 	return tools.NewApprovalManager(perms), nil
 }
 
+const postFrameFlushDelay = 16 * time.Millisecond
+
 type postFrameWriter struct {
 	w     io.Writer
 	after func() string
 	mu    sync.Mutex
+	timer *time.Timer
 }
 
 func newPostFrameWriter(w io.Writer, after func() string) io.Writer {
@@ -228,6 +232,7 @@ func (w *postFrameWriter) Read(p []byte) (int, error) {
 }
 
 func (w *postFrameWriter) Close() error {
+	w.flushPostFrame()
 	// Do not close stdout/stderr; Bubble Tea owns terminal state, not the fd.
 	return nil
 }
@@ -241,19 +246,36 @@ func (w *postFrameWriter) Fd() uintptr {
 
 func (w *postFrameWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	n, err := w.w.Write(p)
-	if err != nil {
-		return n, err
+	if err == nil {
+		w.schedulePostFrameLocked()
 	}
-	if w.after != nil {
-		if seq := w.after(); seq != "" {
-			if _, err := io.WriteString(w.w, seq); err != nil {
-				return n, err
-			}
-		}
+	w.mu.Unlock()
+	return n, err
+}
+
+func (w *postFrameWriter) schedulePostFrameLocked() {
+	if w.after == nil {
+		return
 	}
-	return n, nil
+	if w.timer == nil {
+		w.timer = time.AfterFunc(postFrameFlushDelay, w.flushPostFrame)
+		return
+	}
+	w.timer.Reset(postFrameFlushDelay)
+}
+
+func (w *postFrameWriter) flushPostFrame() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.after == nil {
+		return
+	}
+	seq := w.after()
+	if seq == "" {
+		return
+	}
+	_, _ = io.WriteString(w.w, seq)
 }
 
 func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string) (string, string, error) {

--- a/internal/image/terminal_test.go
+++ b/internal/image/terminal_test.go
@@ -23,8 +23,8 @@ func TestTerminalImageWrapperUsesTermimageKittyImplementation(t *testing.T) {
 	if result.Full == "" {
 		t.Fatal("expected Kitty terminal image output")
 	}
-	if result.Upload != "" {
-		t.Fatalf("direct terminal wrapper should not split Kitty upload/display bytes, got upload %q", result.Upload)
+	if result.Upload == "" || !strings.Contains(result.Upload, "a=t") {
+		t.Fatalf("direct terminal wrapper should expose reusable Kitty upload bytes, got upload %q", result.Upload)
 	}
 	if !strings.Contains(result.Full, "\x1b_G") {
 		t.Fatalf("expected delegated Kitty graphics command, got %q", result.Full)

--- a/internal/termimage/kitty.go
+++ b/internal/termimage/kitty.go
@@ -165,6 +165,26 @@ func KittyPlacementForPath(req Request, imageID uint32) (Result, error) {
 	return Result{Protocol: ProtocolKitty, Place: place, Display: display, Full: place + display, WidthCells: cols, HeightCells: rows, ImageID: imageID, TextFallback: req.Path}, nil
 }
 
+// KittyDirectPlaceSequence places an already-transmitted image at the current
+// cursor position. If placementID is non-zero, repeating the same image and
+// placement id moves/replaces that placement instead of creating another one.
+func KittyDirectPlaceSequence(imageID, placementID uint32, cols, rows int) string {
+	placement := ""
+	if placementID != 0 {
+		placement = fmt.Sprintf(",p=%d", placementID)
+	}
+	return fmt.Sprintf("\x1b_Ga=p,i=%d%s,c=%d,r=%d,C=1,q=2\x1b\\", imageID, placement, cols, rows)
+}
+
+// KittyDeletePlacementSequence deletes one direct placement while keeping any
+// underlying image data available for later re-placement.
+func KittyDeletePlacementSequence(imageID, placementID uint32) string {
+	if imageID == 0 || placementID == 0 {
+		return ""
+	}
+	return fmt.Sprintf("\x1b_Ga=d,d=i,i=%d,p=%d,q=2\x1b\\", imageID, placementID)
+}
+
 func renderKittyDirect(img stdimage.Image, cols, rows int, cacheKey string) (Result, error) {
 	imageID := nextImageID()
 	path, err := writeKittyTempPNG(img, cacheKey)
@@ -173,18 +193,28 @@ func renderKittyDirect(img stdimage.Image, cols, rows int, cacheKey string) (Res
 	}
 	pathData := base64.StdEncoding.EncodeToString([]byte(path))
 
-	var out bytes.Buffer
+	var upload bytes.Buffer
 	// One-shot Kitty rendering is used for normal scrollback/CLI output and for
 	// the chat post-frame compositor. Send a file reference instead of inline PNG
 	// bytes so redraws/scrolled slices do not flood the terminal with base64 image
 	// payloads. The terminal process runs on the same host and can read the temp
 	// file directly.
-	fmt.Fprintf(&out, "\x1b_Ga=d,i=%d,q=2\x1b\\", imageID)
-	fmt.Fprintf(&out, "\x1b_Ga=T,t=f,f=100,i=%d,c=%d,r=%d,q=2;%s\x1b\\", imageID, cols, rows, pathData)
+	//
+	// File transfers are asynchronous in Kitty. Combining transmit+display (a=T)
+	// with multiple cursor-positioned images in one frame can race such that only
+	// the final image appears at the final cursor position. Transmit first, then
+	// issue an explicit put placement; Kitty preserves the order and places every
+	// image at the cursor position active for its a=p command.
+	fmt.Fprintf(&upload, "\x1b_Ga=d,i=%d,q=2\x1b\\", imageID)
+	fmt.Fprintf(&upload, "\x1b_Ga=t,t=f,f=100,i=%d,q=2;%s\x1b\\", imageID, pathData)
+	place := KittyDirectPlaceSequence(imageID, 0, cols, rows)
 
-	s := out.String()
+	uploadStr := upload.String()
+	s := uploadStr + place
 	return Result{
 		Protocol:    ProtocolKitty,
+		Upload:      uploadStr,
+		Place:       place,
 		Display:     s,
 		Full:        s,
 		WidthCells:  cols,

--- a/internal/termimage/render_test.go
+++ b/internal/termimage/render_test.go
@@ -188,10 +188,13 @@ func TestRenderKittyOneShotUsesDirectPlacement(t *testing.T) {
 	if result.Protocol != ProtocolKitty || result.Full == "" {
 		t.Fatalf("expected Kitty one-shot output, got protocol=%s full=%q", result.Protocol, result.Full)
 	}
-	if result.Upload != "" {
-		t.Fatalf("one-shot Kitty should keep all bytes in Full/Display, got Upload=%q", result.Upload)
+	if result.Upload == "" || !strings.Contains(result.Upload, "a=t") {
+		t.Fatalf("one-shot Kitty should expose reusable file upload bytes, got Upload=%q", result.Upload)
 	}
-	if strings.Contains(result.Full, "\U0010eeee") || strings.Contains(result.Full, "a=p,U=1") {
+	if !strings.Contains(result.Full, "a=p") {
+		t.Fatalf("one-shot Kitty should place transmitted file images explicitly: %q", result.Full)
+	}
+	if strings.Contains(result.Full, "\U0010eeee") || strings.Contains(result.Full, "U=1") {
 		t.Fatalf("one-shot Kitty should not use Unicode placeholders: %q", result.Full)
 	}
 }

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -291,7 +291,13 @@ type Model struct {
 	viewportImageArtifacts      map[string]viewportImageArtifact
 	viewportImageBlocks         []viewportImageBlock
 	postFrameImageSeq           string
+	postFrameImageUploadSeq     string
+	postFrameImagePlaceSeq      string
 	postFrameImageMu            sync.Mutex
+	postFrameVisibleImages      map[string]postFrameImageState
+	postFrameCurrentImages      map[string]postFrameImageState
+	postFrameQueuedImages       map[uint32]struct{}
+	postFrameTransmittedImages  map[uint32]struct{}
 
 	// Text selection state (alt-screen only)
 	selection         Selection
@@ -591,69 +597,71 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 	}
 
 	model := &Model{
-		width:                    width,
-		height:                   height,
-		textarea:                 ta,
-		spinner:                  s,
-		styles:                   styles,
-		keyMap:                   DefaultKeyMap(),
-		store:                    store,
-		sess:                     sess,
-		messages:                 messages,
-		compactionIdx:            compactionIdx,
-		rootCtx:                  context.Background(),
-		provider:                 provider,
-		fastProvider:             fastProvider,
-		engine:                   engine,
-		config:                   cfg,
-		providerName:             provider.Name(),
-		providerKey:              providerKey,
-		modelName:                modelName,
-		agentName:                agentName,
-		platformDeveloperMessage: strings.TrimSpace(platformDeveloperMessage),
-		currentOrigin:            session.OriginTUI,
-		yolo:                     yolo,
-		phase:                    "Thinking",
-		viewportRows:             ui.RemainingLines(height, 8), // Reserve space for input and status
-		tracker:                  tracker,
-		subagentTracker:          subagentTracker,
-		smoothBuffer:             ui.NewSmoothBuffer(),
-		completions:              completions,
-		dialog:                   dialog,
-		approvedDirs:             approvedDirs,
-		mcpManager:               mcpManager,
-		mcpStatusChan:            mcpStatusChan,
-		maxTurns:                 maxTurns,
-		forceExternalSearch:      forceExternalSearch,
-		disableExternalWebFetch:  disableExternalWebFetch,
-		searchEnabled:            searchEnabled,
-		fastMode:                 fastMode,
-		fastProviderDefault:      fastProviderDefault,
-		fastMetadataLoaded:       fastMetadataLoaded,
-		fastMetadataStale:        fastMetadataStale,
-		modelMetadata:            modelMetadata,
-		localTools:               localTools,
-		toolsStr:                 toolsStr,
-		mcpStr:                   mcpStr,
-		showStats:                showStats,
-		stats:                    stats,
-		streamPerf:               newStreamPerfTelemetryFromEnv(),
-		altScreen:                altScreen,
-		mouseMode:                chatMouseModeFromEnv(),
-		viewport:                 vp,
-		streamRenderMinInterval:  chatRenderMinIntervalFromEnv(),
-		chatRenderer:             chatRenderer,
-		autoSendQueue:            autoSendQueue,
-		autoSendExitOnDone:       autoSendExitOnDone,
-		textMode:                 textMode,
-		uploadedImageKeys:        make(map[string]struct{}),
-		placedImageKeys:          make(map[string]struct{}),
-		pendingImageUploadKeys:   make(map[string]struct{}),
-		pendingImagePlaceKeys:    make(map[string]struct{}),
-		visibleImageKeys:         make(map[string]struct{}),
-		ownedKittyImageIDs:       make(map[uint32]struct{}),
-		viewportImageArtifacts:   make(map[string]viewportImageArtifact),
-		selectedImage:            -1,
+		width:                      width,
+		height:                     height,
+		textarea:                   ta,
+		spinner:                    s,
+		styles:                     styles,
+		keyMap:                     DefaultKeyMap(),
+		store:                      store,
+		sess:                       sess,
+		messages:                   messages,
+		compactionIdx:              compactionIdx,
+		rootCtx:                    context.Background(),
+		provider:                   provider,
+		fastProvider:               fastProvider,
+		engine:                     engine,
+		config:                     cfg,
+		providerName:               provider.Name(),
+		providerKey:                providerKey,
+		modelName:                  modelName,
+		agentName:                  agentName,
+		platformDeveloperMessage:   strings.TrimSpace(platformDeveloperMessage),
+		currentOrigin:              session.OriginTUI,
+		yolo:                       yolo,
+		phase:                      "Thinking",
+		viewportRows:               ui.RemainingLines(height, 8), // Reserve space for input and status
+		tracker:                    tracker,
+		subagentTracker:            subagentTracker,
+		smoothBuffer:               ui.NewSmoothBuffer(),
+		completions:                completions,
+		dialog:                     dialog,
+		approvedDirs:               approvedDirs,
+		mcpManager:                 mcpManager,
+		mcpStatusChan:              mcpStatusChan,
+		maxTurns:                   maxTurns,
+		forceExternalSearch:        forceExternalSearch,
+		disableExternalWebFetch:    disableExternalWebFetch,
+		searchEnabled:              searchEnabled,
+		fastMode:                   fastMode,
+		fastProviderDefault:        fastProviderDefault,
+		fastMetadataLoaded:         fastMetadataLoaded,
+		fastMetadataStale:          fastMetadataStale,
+		modelMetadata:              modelMetadata,
+		localTools:                 localTools,
+		toolsStr:                   toolsStr,
+		mcpStr:                     mcpStr,
+		showStats:                  showStats,
+		stats:                      stats,
+		streamPerf:                 newStreamPerfTelemetryFromEnv(),
+		altScreen:                  altScreen,
+		mouseMode:                  chatMouseModeFromEnv(),
+		viewport:                   vp,
+		streamRenderMinInterval:    chatRenderMinIntervalFromEnv(),
+		chatRenderer:               chatRenderer,
+		autoSendQueue:              autoSendQueue,
+		autoSendExitOnDone:         autoSendExitOnDone,
+		textMode:                   textMode,
+		uploadedImageKeys:          make(map[string]struct{}),
+		placedImageKeys:            make(map[string]struct{}),
+		pendingImageUploadKeys:     make(map[string]struct{}),
+		pendingImagePlaceKeys:      make(map[string]struct{}),
+		visibleImageKeys:           make(map[string]struct{}),
+		ownedKittyImageIDs:         make(map[uint32]struct{}),
+		postFrameVisibleImages:     make(map[string]postFrameImageState),
+		postFrameTransmittedImages: make(map[uint32]struct{}),
+		viewportImageArtifacts:     make(map[string]viewportImageArtifact),
+		selectedImage:              -1,
 	}
 	model.configureImageRenderer()
 	model.configureContextManagementForSession()
@@ -819,6 +827,10 @@ func (m *Model) applyWindowSize(msg tea.WindowSizeMsg) {
 			m.viewportImageArtifacts = make(map[string]viewportImageArtifact)
 			m.viewportImageBlocks = nil
 			m.ownedKittyImageIDs = make(map[uint32]struct{})
+			m.postFrameVisibleImages = make(map[string]postFrameImageState)
+			m.postFrameCurrentImages = nil
+			m.postFrameQueuedImages = nil
+			m.postFrameTransmittedImages = make(map[uint32]struct{})
 			m.resetUploadedImageKeys()
 		}
 	} else if m.chatRenderer != nil {

--- a/internal/tui/chat/image_render.go
+++ b/internal/tui/chat/image_render.go
@@ -35,6 +35,13 @@ type viewportImageBlock struct {
 	HeightCells int
 }
 
+type postFrameImageState struct {
+	ImageID     uint32
+	PlacementID uint32
+	WidthCells  int
+	HeightCells int
+}
+
 func (m *Model) configureImageRenderer() {
 	if m == nil || m.chatRenderer == nil {
 		return
@@ -182,14 +189,14 @@ func (m *Model) beginPostFrameImageComposition() {
 	}
 	m.postFrameImageMu.Lock()
 	defer m.postFrameImageMu.Unlock()
-	seq := ""
-	if len(m.ownedKittyImageIDs) > 0 {
-		if cleanup := termimage.KittyDeleteImageSequence(mapKeys(m.ownedKittyImageIDs)...); cleanup != "" {
-			seq += cleanup
-		}
+	if m.postFrameTransmittedImages == nil {
+		m.postFrameTransmittedImages = make(map[uint32]struct{})
 	}
-	m.ownedKittyImageIDs = make(map[uint32]struct{})
-	m.postFrameImageSeq = seq
+	m.postFrameCurrentImages = make(map[string]postFrameImageState)
+	m.postFrameQueuedImages = make(map[uint32]struct{})
+	m.postFrameImageSeq = ""
+	m.postFrameImageUploadSeq = ""
+	m.postFrameImagePlaceSeq = ""
 }
 
 func mapKeys[K comparable, V any](m map[K]V) []K {
@@ -200,10 +207,12 @@ func mapKeys[K comparable, V any](m map[K]V) []K {
 	return keys
 }
 
-func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, startRow, rows, screenRow int) {
+func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, blockStartLine, startRow, rows, screenRow int) {
 	if m == nil || art.Path == "" || rows <= 0 || screenRow < 0 {
 		return
 	}
+	key := fmt.Sprintf("%s:direct:%d:%d:%d", art.Key, blockStartLine, startRow, rows)
+	placementID := postFramePlacementID(key)
 	result, err := termimage.Render(termimage.Request{
 		Path:               art.Path,
 		MaxCols:            m.imageMaxCols(),
@@ -215,15 +224,42 @@ func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, startRow,
 		SliceStartRow:      startRow,
 		SliceRows:          rows,
 	})
-	if err != nil || result.Full == "" {
+	if err != nil || result.ImageID == 0 {
 		if err != nil {
 			termimage.Debugf(termimage.DefaultEnvironment(), "chat post-frame image render failed path=%s start=%d rows=%d err=%v", art.Path, startRow, rows, err)
 		}
 		return
 	}
+
+	place := termimage.KittyDirectPlaceSequence(result.ImageID, placementID, result.WidthCells, result.HeightCells)
 	m.postFrameImageMu.Lock()
 	defer m.postFrameImageMu.Unlock()
-	m.postFrameImageSeq += fmt.Sprintf("\x1b[%d;1H%s", screenRow+1, result.Full)
+	if m.postFrameCurrentImages == nil {
+		m.postFrameCurrentImages = make(map[string]postFrameImageState)
+	}
+	if m.postFrameTransmittedImages == nil {
+		m.postFrameTransmittedImages = make(map[uint32]struct{})
+	}
+	m.postFrameCurrentImages[key] = postFrameImageState{ImageID: result.ImageID, PlacementID: placementID, WidthCells: result.WidthCells, HeightCells: result.HeightCells}
+	if _, transmitted := m.postFrameTransmittedImages[result.ImageID]; !transmitted {
+		if _, queued := m.postFrameQueuedImages[result.ImageID]; !queued {
+			if result.Upload != "" {
+				m.postFrameImageUploadSeq += result.Upload
+				m.postFrameQueuedImages[result.ImageID] = struct{}{}
+			} else {
+				m.postFrameImageUploadSeq += result.Full
+				m.postFrameQueuedImages[result.ImageID] = struct{}{}
+				if result.ImageID != 0 {
+					if m.ownedKittyImageIDs == nil {
+						m.ownedKittyImageIDs = make(map[uint32]struct{})
+					}
+					m.ownedKittyImageIDs[result.ImageID] = struct{}{}
+				}
+				return
+			}
+		}
+	}
+	m.postFrameImagePlaceSeq += fmt.Sprintf("\x1b[%d;1H%s", screenRow+1, place)
 	if result.ImageID != 0 {
 		if m.ownedKittyImageIDs == nil {
 			m.ownedKittyImageIDs = make(map[uint32]struct{})
@@ -232,15 +268,36 @@ func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, startRow,
 	}
 }
 
+func postFramePlacementID(key string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	id := h.Sum32()
+	if id == 0 {
+		return 1
+	}
+	return id
+}
+
 func (m *Model) finishPostFrameImageComposition() {
 	if m == nil || !m.altScreen {
 		return
 	}
 	m.postFrameImageMu.Lock()
 	defer m.postFrameImageMu.Unlock()
-	if m.postFrameImageSeq != "" {
-		m.postFrameImageSeq += fmt.Sprintf("\x1b[%d;1H", max(1, m.height))
+	for key, previous := range m.postFrameVisibleImages {
+		if _, stillVisible := m.postFrameCurrentImages[key]; !stillVisible && previous.ImageID != 0 {
+			m.postFrameImagePlaceSeq += termimage.KittyDeletePlacementSequence(previous.ImageID, previous.PlacementID)
+		}
 	}
+	m.postFrameVisibleImages = m.postFrameCurrentImages
+	m.postFrameCurrentImages = nil
+	if m.postFrameImageUploadSeq != "" || m.postFrameImagePlaceSeq != "" {
+		m.postFrameImageSeq = m.postFrameImageUploadSeq + "\x1b[s" + m.postFrameImagePlaceSeq + "\x1b[u"
+	} else {
+		m.postFrameImageSeq = ""
+	}
+	m.postFrameImageUploadSeq = ""
+	m.postFrameImagePlaceSeq = ""
 }
 
 func (m *Model) TakePostFrameImageSequence() string {
@@ -250,6 +307,16 @@ func (m *Model) TakePostFrameImageSequence() string {
 	m.postFrameImageMu.Lock()
 	defer m.postFrameImageMu.Unlock()
 	seq := m.postFrameImageSeq
+	if seq != "" {
+		if m.postFrameTransmittedImages == nil {
+			m.postFrameTransmittedImages = make(map[uint32]struct{})
+		}
+		for _, image := range m.postFrameVisibleImages {
+			if image.ImageID != 0 {
+				m.postFrameTransmittedImages[image.ImageID] = struct{}{}
+			}
+		}
+	}
 	m.postFrameImageSeq = ""
 	return seq
 }
@@ -584,6 +651,10 @@ func (m *Model) resetImageUploadState() {
 	m.placedImageKeys = make(map[string]struct{})
 	m.visibleImageKeys = make(map[string]struct{})
 	m.ownedKittyImageIDs = make(map[uint32]struct{})
+	m.postFrameVisibleImages = make(map[string]postFrameImageState)
+	m.postFrameCurrentImages = nil
+	m.postFrameQueuedImages = nil
+	m.postFrameTransmittedImages = make(map[uint32]struct{})
 	m.viewportImageArtifacts = make(map[string]viewportImageArtifact)
 	m.viewportImageBlocks = nil
 	m.imageCleanupQueued = false

--- a/internal/tui/chat/image_render_test.go
+++ b/internal/tui/chat/image_render_test.go
@@ -167,15 +167,60 @@ func TestAltScreenKittyUploadQueuedOnlyWhenImageVisible(t *testing.T) {
 	m.viewport.SetContent(content)
 	m.viewport.SetYOffset(0)
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
-	if seq := m.TakePostFrameImageSequence(); strings.Contains(seq, "a=T") {
+	if seq := m.TakePostFrameImageSequence(); strings.Contains(seq, "a=t") || strings.Contains(seq, "a=p") {
 		t.Fatalf("offscreen Kitty image should not render yet, got %q", seq)
 	}
 
 	m.viewport.SetYOffset(20)
 	_ = m.renderAltScreenViewportLines(splitViewportContentLines(content))
 	seq := m.TakePostFrameImageSequence()
-	if !strings.Contains(seq, "a=T") {
-		t.Fatalf("visible Kitty image should queue post-frame render, got %q", seq)
+	if !strings.Contains(seq, "a=t") || !strings.Contains(seq, "a=p") {
+		t.Fatalf("visible Kitty image should queue post-frame upload and placement, got %q", seq)
+	}
+}
+
+func TestAltScreenPostFrameRendersMultipleVisibleKittyImages(t *testing.T) {
+	t.Setenv("TERM_LLM_IMAGE_PROTOCOL", "kitty")
+	termimage.ClearCache()
+
+	pathA := writeChatTestPNG(t)
+	m := newTestChatModel(true)
+	m.width = 80
+	m.height = 30
+	m.syncAltScreenViewportHeight(m.buildFooterLayout().height)
+
+	artifactA := m.renderViewportImageArtifact(pathA)
+	artifactB := m.renderViewportImageArtifact(pathA)
+	content := strings.Join([]string{
+		"before",
+		artifactA.Display,
+		"between",
+		artifactB.Display,
+		"after",
+	}, "\n")
+	content, blocks := m.extractViewportImageBlocks(content)
+	m.viewportImageBlocks = blocks
+	lines := splitViewportContentLines(content)
+
+	_ = m.renderAltScreenViewportLines(lines)
+	seq := m.TakePostFrameImageSequence()
+	if got := strings.Count(seq, "a=t"); got != 1 {
+		t.Fatalf("first post-frame render should transmit shared image data once, got %d in %q", got, seq)
+	}
+	if got := strings.Count(seq, "a=p"); got != 2 {
+		t.Fatalf("first post-frame render should place both visible images, got %d in %q", got, seq)
+	}
+	if !strings.Contains(seq, "\x1b[s") || !strings.Contains(seq, "\x1b[u") {
+		t.Fatalf("post-frame sequence should preserve Bubble Tea cursor/status position, got %q", seq)
+	}
+
+	_ = m.renderAltScreenViewportLines(lines)
+	seq = m.TakePostFrameImageSequence()
+	if strings.Contains(seq, "a=t") {
+		t.Fatalf("second unchanged frame should reuse transmitted Kitty images, got %q", seq)
+	}
+	if got := strings.Count(seq, "a=p"); got != 2 {
+		t.Fatalf("second unchanged frame should only re-place both images after text repaint, got %d in %q", got, seq)
 	}
 }
 
@@ -237,7 +282,7 @@ func TestAltScreenImageResizeQueuesCleanupAndReupload(t *testing.T) {
 	if !strings.Contains(upload, "a=d") {
 		t.Fatalf("resize should queue Kitty cleanup before reupload, got %q", upload)
 	}
-	if strings.Contains(upload, "a=T") {
+	if strings.Contains(upload, "a=t") || strings.Contains(upload, "a=p") {
 		t.Fatalf("resize cleanup frame must not reupload while old placeholders may still be on screen: %q", upload)
 	}
 	cmd := m.drainPendingImageUploadCmd()
@@ -250,8 +295,8 @@ func TestAltScreenImageResizeQueuesCleanupAndReupload(t *testing.T) {
 	m.viewCache.lastSetContentAt = time.Time{}
 	_ = m.viewAltScreen()
 	seq := m.TakePostFrameImageSequence()
-	if !strings.Contains(seq, "a=T") {
-		t.Fatalf("post-cleanup frame should queue Kitty post-frame render for new dimensions, got %q", seq)
+	if !strings.Contains(seq, "a=t") || !strings.Contains(seq, "a=p") {
+		t.Fatalf("post-cleanup frame should queue Kitty post-frame upload and placement for new dimensions, got %q", seq)
 	}
 	content = m.viewCache.lastContentStr
 	if content == "" && len(m.contentLines) > 0 {
@@ -330,7 +375,7 @@ func TestAltScreenImageHeightResizeQueuesCleanupAndReupload(t *testing.T) {
 	if !strings.Contains(upload, "a=d") {
 		t.Fatalf("height resize should queue Kitty cleanup, got %q", upload)
 	}
-	if strings.Contains(upload, "a=T") {
+	if strings.Contains(upload, "a=t") || strings.Contains(upload, "a=p") {
 		t.Fatalf("height resize cleanup frame must not reupload immediately, got %q", upload)
 	}
 }
@@ -361,8 +406,8 @@ func TestAltScreenNewImageDoesNotCleanupExistingImages(t *testing.T) {
 	if strings.Contains(seq, "a=d,d=A") {
 		t.Fatalf("adding a later image must not globally cleanup/delete already-visible images: %q", seq)
 	}
-	if got := strings.Count(seq, "a=T"); got == 0 {
-		t.Fatalf("later image should queue post-frame Kitty render, got %d in %q", got, seq)
+	if got := strings.Count(seq, "a=t"); got == 0 {
+		t.Fatalf("later image should queue post-frame Kitty upload, got %d in %q", got, seq)
 	}
 }
 

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -1573,7 +1573,7 @@ func (m *Model) overlayVisibleViewportImages(visible []string, yOffset int) {
 
 		displayArt := art
 		if art.Path != "" && m.usePostFrameImageComposition() {
-			m.queuePostFrameViewportImage(art, sliceStart, sliceRows, visibleTop-yOffset)
+			m.queuePostFrameViewportImage(art, block.StartLine, sliceStart, sliceRows, visibleTop-yOffset)
 			continue
 		} else if art.Path != "" {
 			var rendered bool


### PR DESCRIPTION
## What

Fixes the post-frame Kitty compositor in alt-screen chat:

- render multiple visible images in one viewport/fold
- preserve Bubble Tea's footer/status/input cursor by writing images only after the frame settles and wrapping placements in cursor save/restore
- split Kitty file rendering into `a=t` transmit + explicit `a=p` placement instead of `a=T`, which races when several file-backed images are placed in one frame
- cache transmitted image IDs after the first successful post-frame flush, then re-place only the visible placements on later frames
- use stable per-occurrence placement IDs so the same image can appear more than once without collapsing into one Kitty placement
- delete stale placements by image+placement id instead of deleting the whole image data

## Reproduction / visual check

Fixture: `two-image-fold-test` with two images visible in one viewport.

Before, only the second image rendered and the first reservation stayed blank:

- `/root/Files/after6-two-images-status.png`

After this PR, both visible images render and the footer/status line remains intact:

- `/root/Files/fixed8-two-images-status.png`

Representative after screenshot shows both blue and pink images painted above the input/status footer.

## Performance notes

The hot path now avoids retransmitting file-backed image data after the initial post-frame flush. On unchanged frames it emits only two small `a=p` placement commands for two visible images, instead of repeating file transmit commands.

Microbench for two visible post-frame Kitty images stayed in the same CPU range, which is expected because the benchmark measures model render work rather than terminal-side image decoding/compositing:

```text
main:  ~81.8-85.6 µs/op, ~32 KB/op, 561 allocs/op
this:  ~82.0-85.2 µs/op, ~32 KB/op, 568 allocs/op
```

The important terminal I/O change is covered by test: first frame transmits once for shared image data and places each occurrence; the next unchanged frame contains no `a=t` upload and only re-places visible images after Bubble Tea repaints text.

## Tests

```text
go test ./...
```
