### PR TITLE
fix: debounce post-frame Kitty image state

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -295,7 +295,9 @@ type Model struct {
 	postFrameImagePlaceSeq      string
 	postFrameImageMu            sync.Mutex
 	postFrameVisibleImages      map[string]postFrameImageState
+	postFramePendingImages      map[string]postFrameImageState
 	postFrameCurrentImages      map[string]postFrameImageState
+	postFrameRenderCache        map[string]postFrameImageState
 	postFrameQueuedImages       map[uint32]struct{}
 	postFrameTransmittedImages  map[uint32]struct{}
 
@@ -659,6 +661,7 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 		visibleImageKeys:           make(map[string]struct{}),
 		ownedKittyImageIDs:         make(map[uint32]struct{}),
 		postFrameVisibleImages:     make(map[string]postFrameImageState),
+		postFrameRenderCache:       make(map[string]postFrameImageState),
 		postFrameTransmittedImages: make(map[uint32]struct{}),
 		viewportImageArtifacts:     make(map[string]viewportImageArtifact),
 		selectedImage:              -1,
@@ -828,7 +831,9 @@ func (m *Model) applyWindowSize(msg tea.WindowSizeMsg) {
 			m.viewportImageBlocks = nil
 			m.ownedKittyImageIDs = make(map[uint32]struct{})
 			m.postFrameVisibleImages = make(map[string]postFrameImageState)
+			m.postFramePendingImages = nil
 			m.postFrameCurrentImages = nil
+			m.postFrameRenderCache = make(map[string]postFrameImageState)
 			m.postFrameQueuedImages = nil
 			m.postFrameTransmittedImages = make(map[uint32]struct{})
 			m.resetUploadedImageKeys()

--- a/internal/tui/chat/image_render.go
+++ b/internal/tui/chat/image_render.go
@@ -40,6 +40,8 @@ type postFrameImageState struct {
 	PlacementID uint32
 	WidthCells  int
 	HeightCells int
+	ScreenRow   int
+	Upload      string
 }
 
 func (m *Model) configureImageRenderer() {
@@ -192,9 +194,11 @@ func (m *Model) beginPostFrameImageComposition() {
 	if m.postFrameTransmittedImages == nil {
 		m.postFrameTransmittedImages = make(map[uint32]struct{})
 	}
+	if m.postFrameRenderCache == nil {
+		m.postFrameRenderCache = make(map[string]postFrameImageState)
+	}
 	m.postFrameCurrentImages = make(map[string]postFrameImageState)
 	m.postFrameQueuedImages = make(map[uint32]struct{})
-	m.postFrameImageSeq = ""
 	m.postFrameImageUploadSeq = ""
 	m.postFrameImagePlaceSeq = ""
 }
@@ -211,27 +215,42 @@ func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, blockStar
 	if m == nil || art.Path == "" || rows <= 0 || screenRow < 0 {
 		return
 	}
-	key := fmt.Sprintf("%s:direct:%d:%d:%d", art.Key, blockStartLine, startRow, rows)
-	placementID := postFramePlacementID(key)
-	result, err := termimage.Render(termimage.Request{
-		Path:               art.Path,
-		MaxCols:            m.imageMaxCols(),
-		MaxRows:            m.imageMaxRows(),
-		Mode:               termimage.ModeOneShot,
-		Protocol:           termimage.ProtocolKitty,
-		Background:         m.imageBackground(),
-		AllowEscapeUploads: true,
-		SliceStartRow:      startRow,
-		SliceRows:          rows,
-	})
-	if err != nil || result.ImageID == 0 {
-		if err != nil {
-			termimage.Debugf(termimage.DefaultEnvironment(), "chat post-frame image render failed path=%s start=%d rows=%d err=%v", art.Path, startRow, rows, err)
+	placementKey := fmt.Sprintf("%s:direct:%d:%d:%d", art.Key, blockStartLine, startRow, rows)
+	renderKey := fmt.Sprintf("%s:direct-render:%d:%d", art.Key, startRow, rows)
+	placementID := postFramePlacementID(placementKey)
+
+	m.postFrameImageMu.Lock()
+	state, cached := m.postFrameRenderCache[renderKey]
+	m.postFrameImageMu.Unlock()
+	if !cached {
+		result, err := termimage.Render(termimage.Request{
+			Path:               art.Path,
+			MaxCols:            m.imageMaxCols(),
+			MaxRows:            m.imageMaxRows(),
+			Mode:               termimage.ModeOneShot,
+			Protocol:           termimage.ProtocolKitty,
+			Background:         m.imageBackground(),
+			AllowEscapeUploads: true,
+			SliceStartRow:      startRow,
+			SliceRows:          rows,
+		})
+		if err != nil || result.ImageID == 0 {
+			if err != nil {
+				termimage.Debugf(termimage.DefaultEnvironment(), "chat post-frame image render failed path=%s start=%d rows=%d err=%v", art.Path, startRow, rows, err)
+			}
+			return
 		}
-		return
+		state = postFrameImageState{ImageID: result.ImageID, WidthCells: result.WidthCells, HeightCells: result.HeightCells, Upload: result.Upload}
+		m.postFrameImageMu.Lock()
+		if m.postFrameRenderCache == nil {
+			m.postFrameRenderCache = make(map[string]postFrameImageState)
+		}
+		m.postFrameRenderCache[renderKey] = state
+		m.postFrameImageMu.Unlock()
 	}
 
-	place := termimage.KittyDirectPlaceSequence(result.ImageID, placementID, result.WidthCells, result.HeightCells)
+	state.PlacementID = placementID
+	state.ScreenRow = screenRow
 	m.postFrameImageMu.Lock()
 	defer m.postFrameImageMu.Unlock()
 	if m.postFrameCurrentImages == nil {
@@ -240,31 +259,12 @@ func (m *Model) queuePostFrameViewportImage(art viewportImageArtifact, blockStar
 	if m.postFrameTransmittedImages == nil {
 		m.postFrameTransmittedImages = make(map[uint32]struct{})
 	}
-	m.postFrameCurrentImages[key] = postFrameImageState{ImageID: result.ImageID, PlacementID: placementID, WidthCells: result.WidthCells, HeightCells: result.HeightCells}
-	if _, transmitted := m.postFrameTransmittedImages[result.ImageID]; !transmitted {
-		if _, queued := m.postFrameQueuedImages[result.ImageID]; !queued {
-			if result.Upload != "" {
-				m.postFrameImageUploadSeq += result.Upload
-				m.postFrameQueuedImages[result.ImageID] = struct{}{}
-			} else {
-				m.postFrameImageUploadSeq += result.Full
-				m.postFrameQueuedImages[result.ImageID] = struct{}{}
-				if result.ImageID != 0 {
-					if m.ownedKittyImageIDs == nil {
-						m.ownedKittyImageIDs = make(map[uint32]struct{})
-					}
-					m.ownedKittyImageIDs[result.ImageID] = struct{}{}
-				}
-				return
-			}
-		}
-	}
-	m.postFrameImagePlaceSeq += fmt.Sprintf("\x1b[%d;1H%s", screenRow+1, place)
-	if result.ImageID != 0 {
+	m.postFrameCurrentImages[placementKey] = state
+	if state.ImageID != 0 {
 		if m.ownedKittyImageIDs == nil {
 			m.ownedKittyImageIDs = make(map[uint32]struct{})
 		}
-		m.ownedKittyImageIDs[result.ImageID] = struct{}{}
+		m.ownedKittyImageIDs[state.ImageID] = struct{}{}
 	}
 }
 
@@ -289,15 +289,37 @@ func (m *Model) finishPostFrameImageComposition() {
 			m.postFrameImagePlaceSeq += termimage.KittyDeletePlacementSequence(previous.ImageID, previous.PlacementID)
 		}
 	}
-	m.postFrameVisibleImages = m.postFrameCurrentImages
+	for _, current := range m.postFrameCurrentImages {
+		if _, transmitted := m.postFrameTransmittedImages[current.ImageID]; !transmitted {
+			if _, queued := m.postFrameQueuedImages[current.ImageID]; !queued {
+				m.postFrameImageUploadSeq += current.Upload
+				m.postFrameQueuedImages[current.ImageID] = struct{}{}
+			}
+		}
+		place := termimage.KittyDirectPlaceSequence(current.ImageID, current.PlacementID, current.WidthCells, current.HeightCells)
+		m.postFrameImagePlaceSeq += fmt.Sprintf("\x1b[%d;1H%s", current.ScreenRow+1, place)
+	}
+	m.postFramePendingImages = clonePostFrameImageStates(m.postFrameCurrentImages)
 	m.postFrameCurrentImages = nil
 	if m.postFrameImageUploadSeq != "" || m.postFrameImagePlaceSeq != "" {
 		m.postFrameImageSeq = m.postFrameImageUploadSeq + "\x1b[s" + m.postFrameImagePlaceSeq + "\x1b[u"
 	} else {
 		m.postFrameImageSeq = ""
+		m.postFramePendingImages = nil
 	}
 	m.postFrameImageUploadSeq = ""
 	m.postFrameImagePlaceSeq = ""
+}
+
+func clonePostFrameImageStates(src map[string]postFrameImageState) map[string]postFrameImageState {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]postFrameImageState, len(src))
+	for key, state := range src {
+		dst[key] = state
+	}
+	return dst
 }
 
 func (m *Model) TakePostFrameImageSequence() string {
@@ -311,11 +333,13 @@ func (m *Model) TakePostFrameImageSequence() string {
 		if m.postFrameTransmittedImages == nil {
 			m.postFrameTransmittedImages = make(map[uint32]struct{})
 		}
-		for _, image := range m.postFrameVisibleImages {
+		for _, image := range m.postFramePendingImages {
 			if image.ImageID != 0 {
 				m.postFrameTransmittedImages[image.ImageID] = struct{}{}
 			}
 		}
+		m.postFrameVisibleImages = m.postFramePendingImages
+		m.postFramePendingImages = nil
 	}
 	m.postFrameImageSeq = ""
 	return seq
@@ -652,7 +676,9 @@ func (m *Model) resetImageUploadState() {
 	m.visibleImageKeys = make(map[string]struct{})
 	m.ownedKittyImageIDs = make(map[uint32]struct{})
 	m.postFrameVisibleImages = make(map[string]postFrameImageState)
+	m.postFramePendingImages = nil
 	m.postFrameCurrentImages = nil
+	m.postFrameRenderCache = make(map[string]postFrameImageState)
 	m.postFrameQueuedImages = nil
 	m.postFrameTransmittedImages = make(map[uint32]struct{})
 	m.viewportImageArtifacts = make(map[string]viewportImageArtifact)

--- a/internal/tui/chat/image_render_test.go
+++ b/internal/tui/chat/image_render_test.go
@@ -179,6 +179,26 @@ func TestAltScreenKittyUploadQueuedOnlyWhenImageVisible(t *testing.T) {
 	}
 }
 
+func TestAltScreenPostFrameKeepsStaleDeletesUntilFlush(t *testing.T) {
+	m := newTestChatModel(true)
+	m.postFrameVisibleImages = map[string]postFrameImageState{
+		"old": {ImageID: 42, PlacementID: 77, WidthCells: 4, HeightCells: 2},
+	}
+
+	m.beginPostFrameImageComposition()
+	m.finishPostFrameImageComposition()
+	// A second render can happen before the debounced post-frame writer flushes.
+	// The stale placement must still be deleted; otherwise old Kitty images bleed
+	// over later frames while the model has already forgotten them.
+	m.beginPostFrameImageComposition()
+	m.finishPostFrameImageComposition()
+
+	seq := m.TakePostFrameImageSequence()
+	if !strings.Contains(seq, "a=d,d=i,i=42,p=77") {
+		t.Fatalf("stale placement delete should survive pre-flush rerenders, got %q", seq)
+	}
+}
+
 func TestAltScreenPostFrameRendersMultipleVisibleKittyImages(t *testing.T) {
 	t.Setenv("TERM_LLM_IMAGE_PROTOCOL", "kitty")
 	termimage.ClearCache()


### PR DESCRIPTION
## What

Follow-up to #674 for the remaining Kitty image issues Sam saw in real TUI use:

- stop losing pending post-frame deletes/re-placements when Bubble Tea renders again before the 16ms post-frame writer flush fires
- keep a pending visible-image snapshot until the raw post-frame sequence is actually taken/flushed
- cache post-frame direct image render state by image slice so repeated frames do not call `termimage.Render` for every visible image on every repaint
- assemble upload/place/delete output in `finishPostFrameImageComposition`, then mark images transmitted only after `TakePostFrameImageSequence` drains the sequence
- add regression coverage for the bleed case: stale placement delete survives pre-flush rerenders

The bleed in the screenshot is consistent with this race: model state was advanced to “new frame has no/other images” before the debounced post-frame writer had emitted the delete for the previous Kitty placement. If another render happened inside that debounce window, the delete sequence got overwritten. Kitty then kept showing old image placements over fresh text. Delightful in the same way a rake is delightful.

## Perf / perftools

Real chat TUI pprof with Kitty + two real images + rapid PageUp/PageDown scroll:

```text
/tmp/termllm-perf-profile/cpu.pprof
Duration: 9.36s, Total samples = 100ms
Top samples were Bubble Tea/lipgloss/textarea/render buffer; termimage.Render did not show up after warm-up.
```

Microbench of the warmed two-visible-image post-frame path:

Before this PR, after #674:

```text
~82.0-85.2 µs/op, ~31.8 KB/op, 568 allocs/op
```

After this PR:

```text
~79.4-81.1 µs/op, ~31.3 KB/op, 541 allocs/op
```

The bigger practical win is terminal I/O/state behavior: repeated frames reuse cached post-frame render state and only emit small placement commands after the initial upload instead of re-entering image render/crop/write paths.

## Visual check

Rapid scroll stress with two visible images:

- `/root/Files/kitty-rapid-scroll-fixed.png`

Both images remain placed and the footer/input line stays intact.

## Tests

```text
go test ./...
```
