### PR TITLE
feat: require configured output tools

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -17,6 +17,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/input"
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -851,15 +852,29 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		collector.Wait()
 	}
 
+	if requiredOutputMissing(agent, outputTool) {
+		var assistantText string
+		if collector != nil {
+			assistantText = collector.Text()
+		} else if askProgressive {
+			assistantText = progressiveOutputText(progressiveResult)
+		}
+		if err := runRequiredOutputFinalization(ctx, provider, req, outputTool, assistantText); err != nil {
+			return err
+		}
+	}
+
 	// Run on_complete handler if configured
 	if agent != nil && agent.OnComplete != "" {
 		var output string
 		if outputTool != nil && outputTool.Value() != "" {
 			output = outputTool.Value() // Tool output (preferred)
-		} else if collector != nil {
-			output = collector.Text() // Fallback to text
-		} else if askProgressive {
-			output = progressiveOutputText(progressiveResult)
+		} else if outputTool == nil || !agent.OutputTool.Required {
+			if collector != nil {
+				output = collector.Text() // Fallback to text
+			} else if askProgressive {
+				output = progressiveOutputText(progressiveResult)
+			}
 		}
 
 		if output != "" {
@@ -891,6 +906,95 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func requiredOutputMissing(agent *agents.Agent, outputTool *tools.SetOutputTool) bool {
+	return agent != nil && agent.OutputTool.Required && outputTool != nil && outputTool.Value() == ""
+}
+
+func runRequiredOutputFinalization(ctx context.Context, provider llm.Provider, baseReq llm.Request, outputTool *tools.SetOutputTool, assistantText string) error {
+	if outputTool == nil || outputTool.Value() != "" {
+		return nil
+	}
+
+	toolName := outputTool.Name()
+	messages := append([]llm.Message{}, baseReq.Messages...)
+	if strings.TrimSpace(assistantText) != "" {
+		messages = append(messages, llm.AssistantText(assistantText))
+	}
+	messages = append(messages, llm.UserText(fmt.Sprintf(
+		"You completed the task but did not call the required output tool %q. Using only facts already established in this session, call %s now. Do not inspect more files, do not call any other tools, and do not add prose.",
+		toolName,
+		toolName,
+	)))
+
+	registry := llm.NewToolRegistry()
+	registry.Register(outputTool)
+	finalEngine := llm.NewEngine(provider, registry)
+	finalReq := llm.Request{
+		Model:             baseReq.Model,
+		SessionID:         baseReq.SessionID,
+		Messages:          messages,
+		Tools:             []llm.ToolSpec{outputTool.Spec()},
+		ToolChoice:        llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		ParallelToolCalls: false,
+		MaxTurns:          2,
+		MaxOutputTokens:   baseReq.MaxOutputTokens,
+		Debug:             baseReq.Debug,
+		DebugRaw:          baseReq.DebugRaw,
+	}
+	if provider.Capabilities().SupportsToolChoice {
+		finalReq.ToolChoice = llm.ToolChoice{Mode: llm.ToolChoiceName, Name: toolName}
+	}
+
+	stream, err := finalEngine.Stream(ctx, finalReq)
+	if err != nil {
+		if outputTool.Value() != "" && isRequiredOutputFinalizationMiss(err) {
+			return nil
+		}
+		if outputTool.Value() == "" && isRequiredOutputFinalizationMiss(err) {
+			return fmt.Errorf("required output tool %q was not called", toolName)
+		}
+		return fmt.Errorf("required output finalization failed: %w", err)
+	}
+	defer stream.Close()
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if outputTool.Value() != "" && isRequiredOutputFinalizationMiss(err) {
+				break
+			}
+			if outputTool.Value() == "" && isRequiredOutputFinalizationMiss(err) {
+				return fmt.Errorf("required output tool %q was not called", toolName)
+			}
+			return fmt.Errorf("required output finalization failed: %w", err)
+		}
+		if event.Type == llm.EventError && event.Err != nil {
+			if outputTool.Value() != "" && isRequiredOutputFinalizationMiss(event.Err) {
+				break
+			}
+			if outputTool.Value() == "" && isRequiredOutputFinalizationMiss(event.Err) {
+				return fmt.Errorf("required output tool %q was not called", toolName)
+			}
+			return fmt.Errorf("required output finalization failed: %w", event.Err)
+		}
+	}
+
+	if outputTool.Value() == "" {
+		return fmt.Errorf("required output tool %q was not called", toolName)
+	}
+	return nil
+}
+
+func isRequiredOutputFinalizationMiss(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "agentic loop ended unexpectedly") || strings.Contains(msg, "agentic loop exceeded max turns") || strings.Contains(msg, "no more turns configured")
 }
 
 // streamPlainText streams text directly without formatting

--- a/cmd/ask_required_output_test.go
+++ b/cmd/ask_required_output_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/agents"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func TestRequiredOutputMissing(t *testing.T) {
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	agent := &agents.Agent{OutputTool: agents.OutputToolConfig{Name: "submit_result", Required: true}}
+
+	if !requiredOutputMissing(agent, outputTool) {
+		t.Fatal("expected required output to be missing before the tool captures a value")
+	}
+
+	args, _ := json.Marshal(map[string]string{"result_json": `{"ok":true}`})
+	if _, err := outputTool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if requiredOutputMissing(agent, outputTool) {
+		t.Fatal("did not expect required output to be missing after the tool captures a value")
+	}
+}
+
+func TestRequiredOutputMissingIgnoresOptionalOutputTool(t *testing.T) {
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	agent := &agents.Agent{OutputTool: agents.OutputToolConfig{Name: "submit_result"}}
+
+	if requiredOutputMissing(agent, outputTool) {
+		t.Fatal("optional output tools should preserve existing fallback behavior")
+	}
+}
+
+func TestRunRequiredOutputFinalizationForcesOnlyOutputTool(t *testing.T) {
+	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true})
+	provider.AddToolCall("call_1", "submit_result", map[string]string{"result_json": `{"status":"ok"}`})
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	baseReq := llm.Request{
+		Model: "mock-model",
+		Messages: []llm.Message{
+			llm.SystemText("You are a test agent."),
+			llm.UserText("Review the thing."),
+		},
+		Tools: []llm.ToolSpec{
+			outputTool.Spec(),
+			{Name: "read_file", Description: "Read a file"},
+		},
+		ToolChoice:        llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		ParallelToolCalls: true,
+		MaxTurns:          20,
+	}
+
+	if err := runRequiredOutputFinalization(context.Background(), provider, baseReq, outputTool, "The review is complete."); err != nil {
+		t.Fatalf("runRequiredOutputFinalization() error = %v", err)
+	}
+	if got := outputTool.Value(); got != `{"status":"ok"}` {
+		t.Fatalf("outputTool.Value() = %q", got)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider saw %d requests, want 1", len(provider.Requests))
+	}
+	finalReq := provider.Requests[0]
+	if len(finalReq.Tools) != 1 || finalReq.Tools[0].Name != "submit_result" {
+		t.Fatalf("finalizer tools = %#v, want only submit_result", finalReq.Tools)
+	}
+	if finalReq.ToolChoice.Mode != llm.ToolChoiceName || finalReq.ToolChoice.Name != "submit_result" {
+		t.Fatalf("ToolChoice = %#v, want forced submit_result", finalReq.ToolChoice)
+	}
+	if finalReq.ParallelToolCalls {
+		t.Fatal("finalizer should disable parallel tool calls")
+	}
+	if finalReq.MaxTurns != 2 {
+		t.Fatalf("MaxTurns = %d, want 2", finalReq.MaxTurns)
+	}
+	last := finalReq.Messages[len(finalReq.Messages)-1]
+	if last.Role != llm.RoleUser || !strings.Contains(last.Parts[0].Text, "did not call the required output tool") {
+		t.Fatalf("finalizer prompt = %#v", last)
+	}
+}
+
+func TestRunRequiredOutputFinalizationFailsWhenToolStillMissing(t *testing.T) {
+	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true})
+	provider.AddTextResponse("Done.")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	baseReq := llm.Request{Messages: []llm.Message{llm.UserText("Review the thing.")}}
+
+	err := runRequiredOutputFinalization(context.Background(), provider, baseReq, outputTool, "Done.")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `required output tool "submit_result" was not called`) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -237,9 +237,10 @@ type MemoryConfig struct {
 
 // OutputToolConfig configures a tool for capturing structured output.
 type OutputToolConfig struct {
-	Name        string `yaml:"name"`        // Tool name (e.g., "set_commit_message")
-	Param       string `yaml:"param"`       // Parameter to capture (default: "content")
-	Description string `yaml:"description"` // Tool description
+	Name        string `yaml:"name"`               // Tool name (e.g., "set_commit_message")
+	Param       string `yaml:"param"`              // Parameter to capture (default: "content")
+	Description string `yaml:"description"`        // Tool description
+	Required    bool   `yaml:"required,omitempty"` // When true, ask fails unless this tool captures output
 }
 
 // IsConfigured returns true if the output tool is configured.


### PR DESCRIPTION
## Summary

Adds an explicit required-output contract for agents that use `output_tool`.

Today, `output_tool` registers a finishing tool and captures its value if the model calls it. But an agent can still naturally complete without calling that tool, causing `term-llm ask` to exit successfully while downstream automation never receives the structured artifact it expected.

This is risky for automation, scanner, and reviewer workflows where success means “a validated machine-readable output was produced,” not merely “the model process exited 0.”

## Changes

- Adds `output_tool.required` to agent configuration.
- When required output is missing, `ask` runs a finalization pass with only the output tool registered.
- Forces named tool choice during finalization when the provider supports it.
- Fails nonzero with a clear error if the required output tool still does not capture a value.
- Prevents required output tools from falling back to freeform collector text for `on_complete`.
- Adds tests for:
  - required output detection
  - optional-output backward compatibility
  - finalization with only the output tool available
  - hard failure when finalization still does not call the tool

## Test plan

```bash
go test ./cmd ./internal/agents ./internal/tools ./internal/llm
go test ./...
```
