### PR TITLE
fix: Web image uploads are decoded, rewritten, resized, re-encoded, and kept inline all in one request

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -222,13 +222,14 @@ func abbreviatePath(path string) string {
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
-// Supported image types are sent inline to the LLM and also saved to disk
-// so tools can reopen the original upload later. Other files are saved to disk
-// and referenced by path in a text part.
+// Supported image types are staged for the LLM and also saved to disk so tools
+// can reopen the original upload later. Other files are saved to disk and
+// referenced by path in a text part.
 //
 // Images exceeding 1 MB are resized/compressed only for the inline LLM payload
 // to avoid provider errors; the saved ImagePath always points at the original
-// uploaded bytes.
+// uploaded bytes, while InlineImagePath points at the bytes that providers
+// should encode and send on demand.
 func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	var parts []map[string]json.RawMessage
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
@@ -271,22 +272,26 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
 					}
 
-					sendB64 := b64
+					inlinePath := path
 					sendMT := mt
 					if len(raw) > maxLLMImageBytes {
 						// Resize only the inline payload sent to the model. Keep ImagePath
 						// pointing at the original upload so tools can inspect high-res data.
 						resized, resMT := resizeImageForLLM(raw, mt)
 						if len(resized) != len(raw) || resMT != mt {
-							sendB64 = base64.StdEncoding.EncodeToString(resized)
+							inlinePath, err = saveUploadedBytes(filename, resized)
+							if err != nil {
+								return llm.Message{}, fmt.Errorf("save inline attachment %q: %w", filename, err)
+							}
 							sendMT = resMT
 						}
 					}
 
 					llmParts = append(llmParts, llm.Part{
-						Type:      llm.PartImage,
-						ImageData: &llm.ToolImageData{MediaType: sendMT, Base64: sendB64},
-						ImagePath: path,
+						Type:            llm.PartImage,
+						ImageData:       &llm.ToolImageData{MediaType: sendMT},
+						ImagePath:       path,
+						InlineImagePath: inlinePath,
 					})
 				} else {
 					fileCount++

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -129,6 +129,9 @@ func TestParseUserMessageContent_InlineImagesAreSavedToUploadsDir(t *testing.T) 
 	if msg.Parts[0].ImagePath == "" {
 		t.Fatal("msg.Parts[0].ImagePath is empty, want saved upload path")
 	}
+	if msg.Parts[0].InlineImagePath == "" {
+		t.Fatal("msg.Parts[0].InlineImagePath is empty, want inline upload path")
+	}
 
 	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
 	entries, err := os.ReadDir(uploadsDir)
@@ -137,6 +140,9 @@ func TestParseUserMessageContent_InlineImagesAreSavedToUploadsDir(t *testing.T) 
 	}
 	if len(entries) != 1 {
 		t.Fatalf("uploads dir has %d files, want 1", len(entries))
+	}
+	if msg.Parts[0].InlineImagePath != msg.Parts[0].ImagePath {
+		t.Fatalf("InlineImagePath = %q, want same as ImagePath for small upload %q", msg.Parts[0].InlineImagePath, msg.Parts[0].ImagePath)
 	}
 }
 
@@ -175,18 +181,27 @@ func TestParseUserMessageContent_LargeImageSavesOriginalButSendsResizedInline(t 
 	if !bytes.Equal(saved, raw) {
 		t.Fatalf("saved image differs from original upload")
 	}
-	if part.ImageData == nil || part.ImageData.Base64 == "" {
+	if part.ImageData == nil {
 		t.Fatalf("ImageData missing")
 	}
-	inline, err := base64.StdEncoding.DecodeString(part.ImageData.Base64)
-	if err != nil {
-		t.Fatalf("decode inline image: %v", err)
-	}
-	if len(inline) >= len(raw) {
-		t.Fatalf("inline image is %d bytes, want resized smaller than original %d", len(inline), len(raw))
+	if part.ImageData.Base64 != "" {
+		t.Fatalf("ImageData.Base64 = %q, want empty so inline payload is loaded lazily", part.ImageData.Base64)
 	}
 	if part.ImageData.MediaType != "image/jpeg" {
 		t.Fatalf("inline media type = %q, want image/jpeg", part.ImageData.MediaType)
+	}
+	if part.InlineImagePath == "" {
+		t.Fatal("InlineImagePath is empty, want saved inline payload path")
+	}
+	if part.InlineImagePath == part.ImagePath {
+		t.Fatalf("InlineImagePath = %q, want separate resized payload path from original %q", part.InlineImagePath, part.ImagePath)
+	}
+	inline, err := os.ReadFile(part.InlineImagePath)
+	if err != nil {
+		t.Fatalf("read inline image: %v", err)
+	}
+	if len(inline) >= len(raw) {
+		t.Fatalf("inline image is %d bytes, want resized smaller than original %d", len(inline), len(raw))
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1089,11 +1089,14 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	if msg.Parts[0].ImageData.MediaType != "image/png" {
 		t.Fatalf("media type = %q, want image/png", msg.Parts[0].ImageData.MediaType)
 	}
-	if msg.Parts[0].ImageData.Base64 != "aGVsbG8=" {
-		t.Fatalf("base64 = %q, want aGVsbG8=", msg.Parts[0].ImageData.Base64)
+	if msg.Parts[0].ImageData.Base64 != "" {
+		t.Fatalf("base64 = %q, want empty inline payload placeholder", msg.Parts[0].ImageData.Base64)
 	}
 	if msg.Parts[0].ImagePath == "" {
 		t.Fatalf("parts[0].ImagePath is empty, want saved upload path")
+	}
+	if msg.Parts[0].InlineImagePath == "" {
+		t.Fatalf("parts[0].InlineImagePath is empty, want saved inline payload path")
 	}
 	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
 	entries, err := os.ReadDir(uploadsDir)
@@ -1102,6 +1105,9 @@ func TestParseResponsesInput_ImageContent(t *testing.T) {
 	}
 	if len(entries) != 1 {
 		t.Fatalf("uploads dir has %d files, want 1", len(entries))
+	}
+	if msg.Parts[0].InlineImagePath != msg.Parts[0].ImagePath {
+		t.Fatalf("InlineImagePath = %q, want same as ImagePath for small upload %q", msg.Parts[0].InlineImagePath, msg.Parts[0].ImagePath)
 	}
 	got, err := os.ReadFile(msg.Parts[0].ImagePath)
 	if err != nil {
@@ -1471,8 +1477,11 @@ func TestParseChatMessages_UserImageContent(t *testing.T) {
 	if msgs[0].Parts[0].Type != llm.PartImage {
 		t.Fatalf("parts[0].type = %s, want image", msgs[0].Parts[0].Type)
 	}
-	if msgs[0].Parts[0].ImageData == nil || msgs[0].Parts[0].ImageData.MediaType != "image/png" || msgs[0].Parts[0].ImageData.Base64 != "aGVsbG8=" {
-		t.Fatalf("parts[0].image = %#v, want png data URL", msgs[0].Parts[0].ImageData)
+	if msgs[0].Parts[0].ImageData == nil || msgs[0].Parts[0].ImageData.MediaType != "image/png" || msgs[0].Parts[0].ImageData.Base64 != "" {
+		t.Fatalf("parts[0].image = %#v, want png inline payload placeholder", msgs[0].Parts[0].ImageData)
+	}
+	if msgs[0].Parts[0].InlineImagePath == "" {
+		t.Fatalf("parts[0].InlineImagePath is empty, want saved inline payload path")
 	}
 	if msgs[0].Parts[1].Type != llm.PartText || msgs[0].Parts[1].Text != "describe this" {
 		t.Fatalf("parts[1] = %+v, want trailing text", msgs[0].Parts[1])
@@ -1510,8 +1519,11 @@ func TestParseChatMessages_AssistantImageContent(t *testing.T) {
 	if msgs[0].Parts[1].Type != llm.PartImage {
 		t.Fatalf("parts[1].type = %s, want image", msgs[0].Parts[1].Type)
 	}
-	if msgs[0].Parts[1].ImageData == nil || msgs[0].Parts[1].ImageData.MediaType != "image/png" || msgs[0].Parts[1].ImageData.Base64 != "aGVsbG8=" {
-		t.Fatalf("parts[1].image = %#v, want png data URL", msgs[0].Parts[1].ImageData)
+	if msgs[0].Parts[1].ImageData == nil || msgs[0].Parts[1].ImageData.MediaType != "image/png" || msgs[0].Parts[1].ImageData.Base64 != "" {
+		t.Fatalf("parts[1].image = %#v, want png inline payload placeholder", msgs[0].Parts[1].ImageData)
+	}
+	if msgs[0].Parts[1].InlineImagePath == "" {
+		t.Fatalf("parts[1].InlineImagePath is empty, want saved inline payload path")
 	}
 }
 

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -656,13 +656,14 @@ func buildAnthropicBlocks(parts []Part, allowToolUse bool) []anthropic.ContentBl
 				blocks = append(blocks, anthropic.NewTextBlock(part.Text))
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mediaType, base64Data, ok := requestImageData(part)
+			if ok {
 				blocks = append(blocks, anthropic.ContentBlockParamUnion{
 					OfImage: &anthropic.ImageBlockParam{
 						Source: anthropic.ImageBlockParamSourceUnion{
 							OfBase64: &anthropic.Base64ImageSourceParam{
-								Data:      part.ImageData.Base64,
-								MediaType: anthropic.Base64ImageSourceMediaType(part.ImageData.MediaType),
+								Data:      base64Data,
+								MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
 							},
 						},
 					},
@@ -696,13 +697,14 @@ func buildAnthropicBetaBlocks(parts []Part, allowToolUse bool) []anthropic.BetaC
 				blocks = append(blocks, anthropic.NewBetaTextBlock(part.Text))
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mediaType, base64Data, ok := requestImageData(part)
+			if ok {
 				blocks = append(blocks, anthropic.BetaContentBlockParamUnion{
 					OfImage: &anthropic.BetaImageBlockParam{
 						Source: anthropic.BetaImageBlockParamSourceUnion{
 							OfBase64: &anthropic.BetaBase64ImageSourceParam{
-								Data:      part.ImageData.Base64,
-								MediaType: anthropic.BetaBase64ImageSourceMediaType(part.ImageData.MediaType),
+								Data:      base64Data,
+								MediaType: anthropic.BetaBase64ImageSourceMediaType(mediaType),
 							},
 						},
 					},

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -1452,9 +1452,10 @@ func (p *ClaudeBinProvider) buildConversationPrompt(messages []Message) string {
 						userParts = append(userParts, part.Text)
 					}
 				case PartImage:
-					// Prefer an existing filesystem path; otherwise materialise the
-					// base64 data into a temp file so Claude CLI can read the image.
-					path := part.ImagePath
+					// Prefer an existing filesystem path that already contains the exact
+					// bytes we want to send; otherwise materialise base64 data into a temp
+					// file so Claude CLI can read the image.
+					path := inlineImagePath(part)
 					if path == "" && part.ImageData != nil && part.ImageData.Base64 != "" {
 						path = p.imageDataToTempFile(part.ImageData.MediaType, part.ImageData.Base64)
 					}
@@ -1804,7 +1805,7 @@ func buildSDKUserContentBlocks(parts []Part) []sdkContentBlock {
 				blocks = append(blocks, sdkContentBlock{Type: "text", Text: part.Text})
 			}
 		case PartImage:
-			imageBlock, imagePath, ok := buildSDKImageBlock(part.ImagePath, part.ImageData)
+			imageBlock, imagePath, ok := buildSDKImageBlock(part)
 			if !ok {
 				continue
 			}
@@ -1840,21 +1841,9 @@ func buildSDKToolResultImageBlocks(result *ToolResult) []sdkContentBlock {
 	return blocks
 }
 
-func buildSDKImageBlock(imagePath string, imageData *ToolImageData) (sdkContentBlock, string, bool) {
-	mediaType, base64Data := "", ""
-	switch {
-	case imageData != nil && imageData.Base64 != "":
-		mediaType = imageData.MediaType
-		base64Data = imageData.Base64
-	case imagePath != "":
-		data, err := os.ReadFile(imagePath)
-		if err != nil {
-			return sdkContentBlock{}, "", false
-		}
-		mediaType = mediaTypeFromPath(imagePath)
-		base64Data = base64.StdEncoding.EncodeToString(data)
-	}
-	if mediaType == "" || base64Data == "" {
+func buildSDKImageBlock(part Part) (sdkContentBlock, string, bool) {
+	mediaType, base64Data, ok := requestImageData(part)
+	if !ok {
 		return sdkContentBlock{}, "", false
 	}
 	return sdkContentBlock{
@@ -1864,7 +1853,7 @@ func buildSDKImageBlock(imagePath string, imageData *ToolImageData) (sdkContentB
 			MediaType: mediaType,
 			Data:      base64Data,
 		},
-	}, imagePath, true
+	}, part.ImagePath, true
 }
 
 // mediaTypeFromPath returns an image MIME type based on the file extension.

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -344,18 +344,16 @@ func buildGeminiContent(role string, parts []Part) *genai.Content {
 				content.Parts = append(content.Parts, &genai.Part{Text: part.Text})
 			}
 		case PartImage:
-			if part.ImageData != nil {
-				imageData, err := base64.StdEncoding.DecodeString(part.ImageData.Base64)
-				if err == nil {
-					content.Parts = append(content.Parts, &genai.Part{
-						InlineData: &genai.Blob{
-							MIMEType: part.ImageData.MediaType,
-							Data:     imageData,
-						},
-					})
-					if part.ImagePath != "" {
-						content.Parts = append(content.Parts, &genai.Part{Text: "[image saved at: " + part.ImagePath + "]"})
-					}
+			mediaType, imageData, ok := requestImageBytes(part)
+			if ok {
+				content.Parts = append(content.Parts, &genai.Part{
+					InlineData: &genai.Blob{
+						MIMEType: mediaType,
+						Data:     imageData,
+					},
+				})
+				if part.ImagePath != "" {
+					content.Parts = append(content.Parts, &genai.Part{Text: "[image saved at: " + part.ImagePath + "]"})
 				}
 			}
 		case PartToolCall:

--- a/internal/llm/gemini_cli.go
+++ b/internal/llm/gemini_cli.go
@@ -988,11 +988,12 @@ func buildGeminiCLIUserContent(parts []Part) map[string]interface{} {
 				apiParts = append(apiParts, map[string]interface{}{"text": part.Text})
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mediaType, base64Data, ok := requestImageData(part)
+			if ok {
 				apiParts = append(apiParts, map[string]interface{}{
 					"inline_data": map[string]interface{}{
-						"mime_type": part.ImageData.MediaType,
-						"data":      part.ImageData.Base64,
+						"mime_type": mediaType,
+						"data":      base64Data,
 					},
 				})
 			}

--- a/internal/llm/image_parts.go
+++ b/internal/llm/image_parts.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+)
+
+func inlineImagePath(part Part) string {
+	if path := strings.TrimSpace(part.InlineImagePath); path != "" {
+		return path
+	}
+	return strings.TrimSpace(part.ImagePath)
+}
+
+func requestImageData(part Part) (mediaType, base64Data string, ok bool) {
+	if part.ImageData != nil {
+		mediaType = strings.TrimSpace(part.ImageData.MediaType)
+		base64Data = strings.TrimSpace(part.ImageData.Base64)
+		if mediaType != "" && base64Data != "" {
+			return mediaType, base64Data, true
+		}
+	}
+
+	path := inlineImagePath(part)
+	if path == "" {
+		return "", "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", false
+	}
+	if mediaType == "" {
+		mediaType = mediaTypeFromPath(path)
+	}
+	if mediaType == "" {
+		return "", "", false
+	}
+	return mediaType, base64.StdEncoding.EncodeToString(data), true
+}
+
+func requestImageBytes(part Part) (mediaType string, data []byte, ok bool) {
+	if part.ImageData != nil {
+		mediaType = strings.TrimSpace(part.ImageData.MediaType)
+		base64Data := strings.TrimSpace(part.ImageData.Base64)
+		if mediaType != "" && base64Data != "" {
+			decoded, err := base64.StdEncoding.DecodeString(base64Data)
+			if err == nil {
+				return mediaType, decoded, true
+			}
+		}
+	}
+
+	path := inlineImagePath(part)
+	if path == "" {
+		return "", nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, false
+	}
+	if mediaType == "" {
+		mediaType = mediaTypeFromPath(path)
+	}
+	if mediaType == "" {
+		return "", nil, false
+	}
+	return mediaType, data, true
+}

--- a/internal/llm/image_parts_test.go
+++ b/internal/llm/image_parts_test.go
@@ -1,0 +1,33 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRequestImageData_LoadsBase64FromInlineImagePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.png")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	part := Part{
+		Type:            PartImage,
+		ImageData:       &ToolImageData{MediaType: "image/png"},
+		ImagePath:       filepath.Join(dir, "original.png"),
+		InlineImagePath: path,
+	}
+
+	mediaType, base64Data, ok := requestImageData(part)
+	if !ok {
+		t.Fatal("requestImageData() = not ok, want ok")
+	}
+	if mediaType != "image/png" {
+		t.Fatalf("mediaType = %q, want image/png", mediaType)
+	}
+	if base64Data != "aGVsbG8=" {
+		t.Fatalf("base64Data = %q, want aGVsbG8=", base64Data)
+	}
+}

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -176,8 +176,12 @@ func buildOllamaMessages(messages []Message) []ollamaChatMsg {
 			}
 			var images []string
 			for _, part := range msg.Parts {
-				if part.Type == PartImage && part.ImageData != nil {
-					images = append(images, part.ImageData.Base64)
+				if part.Type != PartImage {
+					continue
+				}
+				_, base64Data, ok := requestImageData(part)
+				if ok {
+					images = append(images, base64Data)
 				}
 			}
 			if text == "" && len(images) == 0 {

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -704,12 +704,21 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 			if msg.Role == RoleUser {
 				var imageParts []oaiContentPart
 				for _, part := range msg.Parts {
-					if part.Type == PartImage && part.ImageData != nil {
-						dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-						imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: imageDetailWithDefault(part.ImageData.Detail, "auto")}})
-						if part.ImagePath != "" {
-							imageParts = append(imageParts, oaiContentPart{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
-						}
+					if part.Type != PartImage {
+						continue
+					}
+					mediaType, base64Data, ok := requestImageData(part)
+					if !ok {
+						continue
+					}
+					detail := "auto"
+					if part.ImageData != nil {
+						detail = imageDetailWithDefault(part.ImageData.Detail, "auto")
+					}
+					dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, base64Data)
+					imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: detail}})
+					if part.ImagePath != "" {
+						imageParts = append(imageParts, oaiContentPart{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
 					}
 				}
 				if len(imageParts) > 0 {

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -365,10 +365,15 @@ func buildResponsesMessageItems(role string, parts []Part) []ResponsesInputItem 
 				textBuf.WriteString(part.Text)
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mediaType, base64Data, ok := requestImageData(part)
+			if ok {
 				flushText()
-				dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: imageDetail(part.ImageData.Detail)}}
+				detail := ""
+				if part.ImageData != nil {
+					detail = imageDetail(part.ImageData.Detail)
+				}
+				dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, base64Data)
+				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: detail}}
 				if part.ImagePath != "" {
 					imageParts = append(imageParts, ResponsesContentPart{Type: "input_text", Text: "[image saved at: " + part.ImagePath + "]"})
 				}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -119,8 +119,9 @@ type Part struct {
 	ReasoningContent          string         // Reasoning summary text (or thinking content for OpenRouter)
 	ReasoningItemID           string         // Responses API reasoning item ID for replay
 	ReasoningEncryptedContent string         // Responses API encrypted reasoning content for replay
-	ImageData                 *ToolImageData // User-supplied image (base64-encoded)
-	ImagePath                 string         // Local filesystem path to the image (when available, e.g. Telegram uploads)
+	ImageData                 *ToolImageData // User-supplied image metadata/base64 payload
+	ImagePath                 string         // Local filesystem path to the original image upload (when available)
+	InlineImagePath           string         // Optional filesystem path for bytes that should be encoded and sent to the LLM
 	ToolCall                  *ToolCall
 	ToolResult                *ToolResult
 }


### PR DESCRIPTION
## What

Change web image upload parsing to stop retaining inline base64 payloads in memory after request parsing. Uploaded images are still saved to disk, but the model-facing bytes are now staged via `InlineImagePath` and encoded lazily when a provider actually builds the request. For oversized images, the resized/compressed inline payload is written to a separate file so `ImagePath` can keep pointing at the original upload.

This also teaches the LLM provider adapters to load image bytes from `InlineImagePath`/`ImagePath` when `ImageData.Base64` is empty, and adds tests covering the new lazy-loading path.

## Why

The old flow kept multiple copies of each upload alive at once: the original data URL/base64 string, decoded raw bytes, optional resized bytes, and a freshly re-encoded inline base64 payload stored on the message part. Large or multi-image uploads therefore caused avoidable upload-time latency and memory spikes before the first model call started.

Deferring base64 encoding until provider request construction keeps request parsing much lighter while preserving the existing behavior of saving original uploads for tools and resizing oversized inline payloads for provider compatibility.
