### PR TITLE
fix: Session storage writes full base64 image blobs into every message row

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -656,13 +656,14 @@ func buildAnthropicBlocks(parts []Part, allowToolUse bool) []anthropic.ContentBl
 				blocks = append(blocks, anthropic.NewTextBlock(part.Text))
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mimeType, base64Data, ok := partImageData(part)
+			if ok {
 				blocks = append(blocks, anthropic.ContentBlockParamUnion{
 					OfImage: &anthropic.ImageBlockParam{
 						Source: anthropic.ImageBlockParamSourceUnion{
 							OfBase64: &anthropic.Base64ImageSourceParam{
-								Data:      part.ImageData.Base64,
-								MediaType: anthropic.Base64ImageSourceMediaType(part.ImageData.MediaType),
+								Data:      base64Data,
+								MediaType: anthropic.Base64ImageSourceMediaType(mimeType),
 							},
 						},
 					},
@@ -696,13 +697,14 @@ func buildAnthropicBetaBlocks(parts []Part, allowToolUse bool) []anthropic.BetaC
 				blocks = append(blocks, anthropic.NewBetaTextBlock(part.Text))
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mimeType, base64Data, ok := partImageData(part)
+			if ok {
 				blocks = append(blocks, anthropic.BetaContentBlockParamUnion{
 					OfImage: &anthropic.BetaImageBlockParam{
 						Source: anthropic.BetaImageBlockParamSourceUnion{
 							OfBase64: &anthropic.BetaBase64ImageSourceParam{
-								Data:      part.ImageData.Base64,
-								MediaType: anthropic.BetaBase64ImageSourceMediaType(part.ImageData.MediaType),
+								Data:      base64Data,
+								MediaType: anthropic.BetaBase64ImageSourceMediaType(mimeType),
 							},
 						},
 					},

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -344,12 +344,13 @@ func buildGeminiContent(role string, parts []Part) *genai.Content {
 				content.Parts = append(content.Parts, &genai.Part{Text: part.Text})
 			}
 		case PartImage:
-			if part.ImageData != nil {
-				imageData, err := base64.StdEncoding.DecodeString(part.ImageData.Base64)
+			mimeType, base64Data, ok := partImageData(part)
+			if ok {
+				imageData, err := base64.StdEncoding.DecodeString(base64Data)
 				if err == nil {
 					content.Parts = append(content.Parts, &genai.Part{
 						InlineData: &genai.Blob{
-							MIMEType: part.ImageData.MediaType,
+							MIMEType: mimeType,
 							Data:     imageData,
 						},
 					})

--- a/internal/llm/gemini_cli.go
+++ b/internal/llm/gemini_cli.go
@@ -988,11 +988,12 @@ func buildGeminiCLIUserContent(parts []Part) map[string]interface{} {
 				apiParts = append(apiParts, map[string]interface{}{"text": part.Text})
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mimeType, base64Data, ok := partImageData(part)
+			if ok {
 				apiParts = append(apiParts, map[string]interface{}{
 					"inline_data": map[string]interface{}{
-						"mime_type": part.ImageData.MediaType,
-						"data":      part.ImageData.Base64,
+						"mime_type": mimeType,
+						"data":      base64Data,
 					},
 				})
 			}

--- a/internal/llm/image_data.go
+++ b/internal/llm/image_data.go
@@ -1,0 +1,72 @@
+package llm
+
+import (
+	"encoding/base64"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func partImageData(part Part) (mediaType, base64Data string, ok bool) {
+	if part.Type != PartImage {
+		return "", "", false
+	}
+
+	if part.ImageData != nil {
+		mediaType = strings.TrimSpace(part.ImageData.MediaType)
+		base64Data = strings.TrimSpace(part.ImageData.Base64)
+	}
+	if base64Data != "" {
+		return mediaType, base64Data, true
+	}
+	if strings.TrimSpace(part.ImagePath) == "" {
+		return "", "", false
+	}
+	return imageFileData(part.ImagePath, mediaType)
+}
+
+func imageFileData(path, mediaType string) (string, string, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", "", false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return "", "", false
+	}
+
+	mediaType = strings.TrimSpace(mediaType)
+	if mediaType == "" || mediaType == "application/octet-stream" {
+		mediaType = detectImageMediaType(data, path)
+	}
+	if mediaType == "" {
+		return "", "", false
+	}
+
+	return mediaType, base64.StdEncoding.EncodeToString(data), true
+}
+
+func detectImageMediaType(data []byte, path string) string {
+	if detected := strings.TrimSpace(http.DetectContentType(data)); strings.HasPrefix(detected, "image/") {
+		return detected
+	}
+
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	case ".tif", ".tiff":
+		return "image/tiff"
+	default:
+		return ""
+	}
+}

--- a/internal/llm/image_data_test.go
+++ b/internal/llm/image_data_test.go
@@ -1,0 +1,56 @@
+package llm
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPartImageDataFallsBackToImagePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "sample.png")
+	data := []byte("png-bytes")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	mimeType, base64Data, ok := partImageData(Part{
+		Type:      PartImage,
+		ImagePath: path,
+		ImageData: &ToolImageData{MediaType: "image/png"},
+	})
+	if !ok {
+		t.Fatal("partImageData returned ok=false")
+	}
+	if mimeType != "image/png" {
+		t.Fatalf("mimeType = %q, want image/png", mimeType)
+	}
+	if base64Data != base64.StdEncoding.EncodeToString(data) {
+		t.Fatalf("base64Data = %q, want encoded file bytes", base64Data)
+	}
+}
+
+func TestToolResultImageDataFallsBackToImagePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "sample.png")
+	data := []byte("png-bytes")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	mimeType, base64Data, ok := toolResultImageData(ToolContentPart{
+		Type:      ToolContentPartImageData,
+		ImagePath: path,
+		ImageData: &ToolImageData{MediaType: "image/png"},
+	})
+	if !ok {
+		t.Fatal("toolResultImageData returned ok=false")
+	}
+	if mimeType != "image/png" {
+		t.Fatalf("mimeType = %q, want image/png", mimeType)
+	}
+	if base64Data != base64.StdEncoding.EncodeToString(data) {
+		t.Fatalf("base64Data = %q, want encoded file bytes", base64Data)
+	}
+}

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -176,8 +176,9 @@ func buildOllamaMessages(messages []Message) []ollamaChatMsg {
 			}
 			var images []string
 			for _, part := range msg.Parts {
-				if part.Type == PartImage && part.ImageData != nil {
-					images = append(images, part.ImageData.Base64)
+				_, base64Data, ok := partImageData(part)
+				if ok {
+					images = append(images, base64Data)
 				}
 			}
 			if text == "" && len(images) == 0 {

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -704,12 +704,18 @@ func buildCompatMessages(messages []Message) []oaiMessage {
 			if msg.Role == RoleUser {
 				var imageParts []oaiContentPart
 				for _, part := range msg.Parts {
-					if part.Type == PartImage && part.ImageData != nil {
-						dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-						imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: imageDetailWithDefault(part.ImageData.Detail, "auto")}})
-						if part.ImagePath != "" {
-							imageParts = append(imageParts, oaiContentPart{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
-						}
+					mimeType, base64Data, ok := partImageData(part)
+					if !ok {
+						continue
+					}
+					detail := "auto"
+					if part.ImageData != nil {
+						detail = imageDetailWithDefault(part.ImageData.Detail, "auto")
+					}
+					dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data)
+					imageParts = append(imageParts, oaiContentPart{Type: "image_url", ImageURL: &oaiImageURL{URL: dataURL, Detail: detail}})
+					if part.ImagePath != "" {
+						imageParts = append(imageParts, oaiContentPart{Type: "text", Text: "[image saved at: " + part.ImagePath + "]"})
 					}
 				}
 				if len(imageParts) > 0 {

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -365,10 +365,15 @@ func buildResponsesMessageItems(role string, parts []Part) []ResponsesInputItem 
 				textBuf.WriteString(part.Text)
 			}
 		case PartImage:
-			if part.ImageData != nil {
+			mimeType, base64Data, ok := partImageData(part)
+			if ok {
 				flushText()
-				dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: imageDetail(part.ImageData.Detail)}}
+				detail := ""
+				if part.ImageData != nil {
+					detail = imageDetail(part.ImageData.Detail)
+				}
+				dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data)
+				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: detail}}
 				if part.ImagePath != "" {
 					imageParts = append(imageParts, ResponsesContentPart{Type: "input_text", Text: "[image saved at: " + part.ImagePath + "]"})
 				}

--- a/internal/llm/tool_result_content.go
+++ b/internal/llm/tool_result_content.go
@@ -49,6 +49,12 @@ func toolResultImageData(part ToolContentPart) (mediaType, base64Data string, ok
 
 	mediaType = strings.TrimSpace(part.ImageData.MediaType)
 	base64Data = strings.TrimSpace(part.ImageData.Base64)
+	if base64Data == "" && strings.TrimSpace(part.ImagePath) != "" {
+		mediaType, base64Data, ok = imageFileData(part.ImagePath, mediaType)
+		if !ok {
+			return "", "", false
+		}
+	}
 	if !isSupportedToolResultImageMediaType(mediaType) || base64Data == "" {
 		return "", "", false
 	}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -201,6 +201,7 @@ type ToolContentPart struct {
 	Type      ToolContentPartType `json:"type"`
 	Text      string              `json:"text,omitempty"`
 	ImageData *ToolImageData      `json:"image_data,omitempty"`
+	ImagePath string              `json:"image_path,omitempty"`
 }
 
 // ToolOutput is the structured return type from Tool.Execute().

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,6 +166,128 @@ func TestSQLiteStoreSearchEscapesUserQueryForFTS(t *testing.T) {
 	}
 	if len(results) != 1 {
 		t.Fatalf("Search(term-llm) len = %d, want 1", len(results))
+	}
+}
+
+func TestSQLiteStoreStripsRedundantImageBase64FromStoredParts(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	imgPath := filepath.Join(t.TempDir(), "upload.png")
+	if err := os.WriteFile(imgPath, []byte("fake image bytes"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	userMsg := NewMessage(sess.ID, llm.Message{Role: llm.RoleUser, Parts: []llm.Part{{
+		Type:      llm.PartImage,
+		ImagePath: imgPath,
+		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "dXNlci1pbWFnZQ=="},
+	}}}, -1)
+	if err := store.AddMessage(ctx, sess.ID, userMsg); err != nil {
+		t.Fatalf("AddMessage user image: %v", err)
+	}
+
+	toolMsg := NewMessage(sess.ID, llm.ToolResultMessageFromOutput("call-1", "view_image", llm.ToolOutput{
+		Content: "loaded",
+		ContentParts: []llm.ToolContentPart{{
+			Type:      llm.ToolContentPartImageData,
+			ImagePath: imgPath,
+			ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "dG9vbC1pbWFnZQ=="},
+		}},
+	}, nil), -1)
+	if err := store.AddMessage(ctx, sess.ID, toolMsg); err != nil {
+		t.Fatalf("AddMessage tool image: %v", err)
+	}
+
+	rows, err := store.db.QueryContext(ctx, "SELECT parts FROM messages WHERE session_id = ? ORDER BY sequence ASC", sess.ID)
+	if err != nil {
+		t.Fatalf("query stored parts: %v", err)
+	}
+	defer rows.Close()
+
+	var stored []string
+	for rows.Next() {
+		var partsJSON string
+		if err := rows.Scan(&partsJSON); err != nil {
+			t.Fatalf("scan parts: %v", err)
+		}
+		stored = append(stored, partsJSON)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate stored parts: %v", err)
+	}
+	if len(stored) != 2 {
+		t.Fatalf("stored rows = %d, want 2", len(stored))
+	}
+	if strings.Contains(stored[0], "dXNlci1pbWFnZQ==") {
+		t.Fatalf("user message stored redundant base64 blob: %s", stored[0])
+	}
+	if strings.Contains(stored[1], "dG9vbC1pbWFnZQ==") {
+		t.Fatalf("tool message stored redundant base64 blob: %s", stored[1])
+	}
+	if !strings.Contains(stored[0], imgPath) {
+		t.Fatalf("user message missing image path in stored JSON: %s", stored[0])
+	}
+	if !strings.Contains(stored[1], imgPath) {
+		t.Fatalf("tool message missing image path in stored JSON: %s", stored[1])
+	}
+
+	msgs, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if got := msgs[0].Parts[0].ImageData.Base64; got != "" {
+		t.Fatalf("user image base64 after reload = %q, want empty", got)
+	}
+	toolPart := msgs[1].Parts[0]
+	if toolPart.ToolResult == nil || len(toolPart.ToolResult.ContentParts) != 1 {
+		t.Fatalf("tool result after reload = %#v, want image content part", toolPart.ToolResult)
+	}
+	if got := toolPart.ToolResult.ContentParts[0].ImageData.Base64; got != "" {
+		t.Fatalf("tool image base64 after reload = %q, want empty", got)
+	}
+}
+
+func TestSQLiteStoreKeepsInlineImageBase64WithoutPath(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	msg := NewMessage(sess.ID, llm.Message{Role: llm.RoleUser, Parts: []llm.Part{{
+		Type:      llm.PartImage,
+		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "aW5saW5lLWltYWdl"},
+	}}}, -1)
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	var stored string
+	if err := store.db.QueryRowContext(ctx, "SELECT parts FROM messages WHERE session_id = ?", sess.ID).Scan(&stored); err != nil {
+		t.Fatalf("QueryRow parts: %v", err)
+	}
+	if !strings.Contains(stored, "aW5saW5lLWltYWdl") {
+		t.Fatalf("stored JSON removed base64 for pathless image: %s", stored)
 	}
 }
 

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -95,8 +95,8 @@ type Session struct {
 }
 
 // Message represents a message in a session.
-// The Parts field stores the full llm.Message.Parts as JSON to preserve
-// tool calls and results exactly.
+// The Parts field stores llm.Message.Parts as JSON, omitting redundant image
+// blobs when the same image is already addressable by a persisted file path.
 type Message struct {
 	ID          int64      `json:"id"`
 	SessionID   string     `json:"session_id"`
@@ -205,11 +205,59 @@ func (m *Message) ToLLMMessage() llm.Message {
 
 // PartsJSON returns the Parts field serialized to JSON for database storage.
 func (m *Message) PartsJSON() (string, error) {
-	data, err := json.Marshal(m.Parts)
+	data, err := json.Marshal(partsForStorage(m.Parts))
 	if err != nil {
 		return "", err
 	}
 	return string(data), nil
+}
+
+func partsForStorage(parts []llm.Part) []llm.Part {
+	if len(parts) == 0 {
+		return nil
+	}
+
+	cloned := make([]llm.Part, 0, len(parts))
+	for _, part := range parts {
+		cloned = append(cloned, partForStorage(part))
+	}
+	return cloned
+}
+
+func partForStorage(part llm.Part) llm.Part {
+	cloned := part
+
+	if part.Type == llm.PartImage && part.ImageData != nil && strings.TrimSpace(part.ImagePath) != "" {
+		imageCopy := *part.ImageData
+		imageCopy.Base64 = ""
+		cloned.ImageData = &imageCopy
+	}
+
+	if part.Type == llm.PartToolResult && part.ToolResult != nil {
+		resultCopy := *part.ToolResult
+		resultCopy.ContentParts = toolContentPartsForStorage(part.ToolResult.ContentParts)
+		cloned.ToolResult = &resultCopy
+	}
+
+	return cloned
+}
+
+func toolContentPartsForStorage(parts []llm.ToolContentPart) []llm.ToolContentPart {
+	if len(parts) == 0 {
+		return nil
+	}
+
+	cloned := make([]llm.ToolContentPart, 0, len(parts))
+	for _, part := range parts {
+		copyPart := part
+		if part.Type == llm.ToolContentPartImageData && part.ImageData != nil && strings.TrimSpace(part.ImagePath) != "" {
+			imageCopy := *part.ImageData
+			imageCopy.Base64 = ""
+			copyPart.ImageData = &imageCopy
+		}
+		cloned = append(cloned, copyPart)
+	}
+	return cloned
 }
 
 // SetPartsFromJSON deserializes JSON into the Parts field.

--- a/internal/tools/view_image.go
+++ b/internal/tools/view_image.go
@@ -232,7 +232,8 @@ Detail: %s`,
 		ContentParts: []llm.ToolContentPart{
 			{Type: llm.ToolContentPartText, Text: textResult},
 			{
-				Type: llm.ToolContentPartImageData,
+				Type:      llm.ToolContentPartImageData,
+				ImagePath: a.FilePath,
 				ImageData: &llm.ToolImageData{
 					MediaType: processedMime,
 					Base64:    encoded,

--- a/internal/tools/view_image_test.go
+++ b/internal/tools/view_image_test.go
@@ -81,6 +81,9 @@ func TestViewImageToolExecute_ReturnsStructuredImageData(t *testing.T) {
 	if imagePart.ImageData.Detail != "high" {
 		t.Fatalf("expected detail high, got %q", imagePart.ImageData.Detail)
 	}
+	if imagePart.ImagePath != filePath {
+		t.Fatalf("expected image path %q, got %q", filePath, imagePart.ImagePath)
+	}
 	if _, err := base64.StdEncoding.DecodeString(imagePart.ImageData.Base64); err != nil {
 		t.Fatalf("image_data base64 should be valid: %v", err)
 	}


### PR DESCRIPTION
## What

- stop session persistence from storing redundant base64 image blobs when the same image is already recoverable from a saved file path
- strip persisted base64 for user image parts with `ImagePath` and for tool-result image content parts with `ImagePath`
- teach provider image helpers to lazily reload image bytes from disk when a resumed session only has the file path
- have `view_image` include `ImagePath` in structured image content so its persisted tool results can be de-blobbed too
- add regression coverage for slim storage, pathless-image preservation, and image-path fallback loading

## Why

Session writes were serializing full image base64 into `messages.parts`, so image-heavy sessions stored multi-megabyte blobs inline in SQLite on every add/update/rewrite. That made saves, reloads, and resume/replay paths much slower and more memory-hungry. Persisting only lightweight metadata when a durable file path already exists keeps the database small without breaking multimodal replay after resume.
