### PR TITLE
fix: Uploaded images are fully decoded, saved, optionally resized, re-encoded, and kept inline before inference

### DIFF
--- a/cmd/image_resize.go
+++ b/cmd/image_resize.go
@@ -8,6 +8,7 @@ import (
 	_ "image/png"
 	"log"
 	"math"
+	"os"
 
 	"golang.org/x/image/draw"
 	_ "golang.org/x/image/webp"
@@ -32,6 +33,41 @@ func resizeImageForLLM(data []byte, mediaType string) ([]byte, string) {
 		return data, mediaType
 	}
 
+	resized, ok := encodeResizedImageForLLM(img, len(data))
+	if !ok {
+		log.Printf("[web] resizeImageForLLM: all attempts failed — sending original (%d bytes)", len(data))
+		return data, mediaType
+	}
+	return resized, "image/jpeg"
+}
+
+func resizeImageFileForLLM(path string, originalSize int, mediaType string) ([]byte, string, bool) {
+	if originalSize <= maxLLMImageBytes {
+		return nil, mediaType, false
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		log.Printf("[web] resizeImageForLLM: open failed (%v) — sending original (%d bytes)", err, originalSize)
+		return nil, mediaType, false
+	}
+	defer f.Close()
+
+	img, _, err := image.Decode(f)
+	if err != nil {
+		log.Printf("[web] resizeImageForLLM: decode failed (%v) — sending original (%d bytes)", err, originalSize)
+		return nil, mediaType, false
+	}
+
+	resized, ok := encodeResizedImageForLLM(img, originalSize)
+	if !ok {
+		log.Printf("[web] resizeImageForLLM: all attempts failed — sending original (%d bytes)", originalSize)
+		return nil, mediaType, false
+	}
+	return resized, "image/jpeg", true
+}
+
+func encodeResizedImageForLLM(img image.Image, originalSize int) ([]byte, bool) {
 	// Compute scale factor: we want pixel area such that a rough 3-bytes-per-pixel
 	// JPEG estimate fits within the target. Use a conservative 4 bpp for safety.
 	bounds := img.Bounds()
@@ -64,8 +100,8 @@ func resizeImageForLLM(data []byte, mediaType string) ([]byte, string) {
 		}
 		if buf.Len() <= maxLLMImageBytes {
 			log.Printf("[web] resizeImageForLLM: resized %dx%d→%dx%d q=%d (%d→%d bytes)",
-				origW, origH, newW, newH, quality, len(data), buf.Len())
-			return buf.Bytes(), "image/jpeg"
+				origW, origH, newW, newH, quality, originalSize, buf.Len())
+			return buf.Bytes(), true
 		}
 	}
 
@@ -73,9 +109,8 @@ func resizeImageForLLM(data []byte, mediaType string) ([]byte, string) {
 	var buf bytes.Buffer
 	if err := jpeg.Encode(&buf, dst, &jpeg.Options{Quality: 40}); err == nil {
 		log.Printf("[web] resizeImageForLLM: could not reach ≤1MB, sending best effort (%d bytes)", buf.Len())
-		return buf.Bytes(), "image/jpeg"
+		return buf.Bytes(), true
 	}
 
-	log.Printf("[web] resizeImageForLLM: all attempts failed — sending original (%d bytes)", len(data))
-	return data, mediaType
+	return nil, false
 }

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -153,28 +153,14 @@ func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
 	return raw[:n], nil
 }
 
-// saveUploadedFile decodes base64 data and writes it to the uploads directory,
-// returning the full filesystem path. Uses O_CREATE|O_EXCL for atomic uniqueness.
-func saveUploadedFile(filename, b64Data string) (string, error) {
-	raw, err := decodeUploadedFile(filename, b64Data)
-	if err != nil {
-		return "", err
-	}
-	return saveUploadedBytes(filename, raw)
-}
-
-func saveUploadedBytes(filename string, raw []byte) (string, error) {
+func createUploadedFile(filename string) (*os.File, string, error) {
 	dataDir, err := session.GetDataDir()
 	if err != nil {
-		return "", fmt.Errorf("get data dir: %w", err)
+		return nil, "", fmt.Errorf("get data dir: %w", err)
 	}
 	uploadsDir := filepath.Join(dataDir, "uploads")
 	if err := os.MkdirAll(uploadsDir, 0o700); err != nil {
-		return "", fmt.Errorf("create uploads dir: %w", err)
-	}
-
-	if len(raw) > maxAttachmentBytes {
-		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+		return nil, "", fmt.Errorf("create uploads dir: %w", err)
 	}
 
 	safeName := filepath.Base(filename)
@@ -186,15 +172,59 @@ func saveUploadedBytes(filename string, raw []byte) (string, error) {
 
 	f, err := os.CreateTemp(uploadsDir, prefix+"*"+ext)
 	if err != nil {
-		return "", fmt.Errorf("create temp file: %w", err)
+		return nil, "", fmt.Errorf("create temp file: %w", err)
 	}
 	dest := f.Name()
 
 	if err := f.Chmod(0o600); err != nil {
 		f.Close()
 		os.Remove(dest)
-		return "", fmt.Errorf("chmod: %w", err)
+		return nil, "", fmt.Errorf("chmod: %w", err)
 	}
+
+	return f, dest, nil
+}
+
+// saveUploadedFile decodes base64 data and writes it to the uploads directory,
+// returning the full filesystem path. Uses O_CREATE|O_EXCL for atomic uniqueness.
+func saveUploadedFile(filename, b64Data string) (string, error) {
+	b64Data = stripBase64Newlines(b64Data)
+	decodedLen, err := decodedBase64Len(b64Data)
+	if err != nil {
+		return "", err
+	}
+	if decodedLen > maxAttachmentBytes {
+		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+
+	f, dest, err := createUploadedFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64Data))
+	if _, err := io.Copy(f, decoder); err != nil {
+		f.Close()
+		os.Remove(dest)
+		return "", fmt.Errorf("decode base64: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(dest)
+		return "", fmt.Errorf("close file: %w", err)
+	}
+	return dest, nil
+}
+
+func saveUploadedBytes(filename string, raw []byte) (string, error) {
+	if len(raw) > maxAttachmentBytes {
+		return "", fmt.Errorf("file %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+	}
+
+	f, dest, err := createUploadedFile(filename)
+	if err != nil {
+		return "", err
+	}
+
 	if _, err := f.Write(raw); err != nil {
 		f.Close()
 		os.Remove(dest)
@@ -262,22 +292,25 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 					}
 
 					b64 = stripBase64Newlines(b64)
-					raw, err := decodeUploadedFile(filename, b64)
+					decodedLen, err := decodedBase64Len(b64)
 					if err != nil {
 						return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
 					}
-					path, err := saveUploadedBytes(filename, raw)
+					if decodedLen > maxAttachmentBytes {
+						return llm.Message{}, fmt.Errorf("attachment %q exceeds %d MB limit", filename, maxAttachmentBytes>>20)
+					}
+					path, err := saveUploadedFile(filename, b64)
 					if err != nil {
 						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
 					}
 
 					sendB64 := b64
 					sendMT := mt
-					if len(raw) > maxLLMImageBytes {
+					if decodedLen > maxLLMImageBytes {
 						// Resize only the inline payload sent to the model. Keep ImagePath
 						// pointing at the original upload so tools can inspect high-res data.
-						resized, resMT := resizeImageForLLM(raw, mt)
-						if len(resized) != len(raw) || resMT != mt {
+						resized, resMT, ok := resizeImageFileForLLM(path, decodedLen, mt)
+						if ok {
 							sendB64 = base64.StdEncoding.EncodeToString(resized)
 							sendMT = resMT
 						}

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -87,6 +87,37 @@ func TestParseUserMessageContent_RejectsInvalidSmallInlineImage(t *testing.T) {
 	}
 }
 
+func TestParseUserMessageContent_InvalidSmallInlineImageDoesNotLeaveUpload(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	content, err := json.Marshal([]map[string]any{{
+		"type":      "input_image",
+		"image_url": "data:image/png;base64,!!!=",
+		"filename":  "bad.png",
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	_, err = parseUserMessageContent(content)
+	if err == nil {
+		t.Fatal("parseUserMessageContent() error = nil, want decode error")
+	}
+
+	uploadsDir := filepath.Join(dataHome, "term-llm", "uploads")
+	entries, readErr := os.ReadDir(uploadsDir)
+	if os.IsNotExist(readErr) {
+		return
+	}
+	if readErr != nil {
+		t.Fatalf("read uploads dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("uploads dir has %d files, want 0", len(entries))
+	}
+}
+
 func TestDecodeUploadedFile_AllowsWrappedBase64(t *testing.T) {
 	wrapped := "aGVs\r\nbG8="
 	raw, err := decodeUploadedFile("hello.txt", wrapped)


### PR DESCRIPTION
## What

- stream base64 uploads directly to the uploads directory instead of decoding the whole image into an intermediate raw buffer first
- only decode/resize large inline images after the original upload has been saved, using the saved file as the resize source
- factor upload temp-file creation so both raw-byte and streamed-base64 saves share the same atomic write path
- add a regression test to ensure invalid inline image uploads do not leave temp files behind

## Why

The previous image-upload hot path eagerly decoded every inline image, kept a full raw copy in memory, wrote that copy to disk, and then sometimes decoded/resized/re-encoded another copy before inference even started. For large or multi-image requests this caused avoidable CPU work, extra memory pressure, and slower upload/start latency.

This change preserves existing behavior — original uploads are still saved to disk and oversized inline payloads are still compressed for providers — while eliminating the full decoded in-memory copy for normal uploads and avoiding an extra raw-image buffer on the save path for large ones.
