### PR TITLE
perf: reuse OpenAI SSE event buffers

### DIFF
--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -437,14 +437,40 @@ func readSSEEvent(reader *bufio.Reader) (eventType, data string, eof bool, err e
 	}
 }
 
+type sseEventReader struct {
+	reader *bufio.Reader
+	data   []byte
+}
+
+func newSSEEventReader(reader *bufio.Reader) *sseEventReader {
+	return &sseEventReader{reader: reader}
+}
+
 func readSSEEventBytes(reader *bufio.Reader) (eventType string, data []byte, eof bool, err error) {
+	return newSSEEventReader(reader).readEventBytes()
+}
+
+// readEventBytes returns data backed by the sseEventReader's reusable buffer.
+// Callers must consume it before the next readEventBytes call.
+func (r *sseEventReader) readEventBytes() (eventType string, data []byte, eof bool, err error) {
+	r.data = r.data[:0]
+	dataLines := 0
+
+	appendData := func(value []byte) {
+		if dataLines > 0 {
+			r.data = append(r.data, '\n')
+		}
+		r.data = append(r.data, value...)
+		dataLines++
+	}
+
 	for {
-		line, lineEOF, err := readSSELineBytes(reader)
+		line, lineEOF, err := readSSELineBytes(r.reader)
 		if err != nil {
 			return "", nil, false, err
 		}
 		if len(line) == 0 {
-			return eventType, data, lineEOF, nil
+			return eventType, r.data, lineEOF, nil
 		}
 		if i := bytes.IndexByte(line, ':'); i >= 0 {
 			field, value := line[:i], line[i+1:]
@@ -455,14 +481,11 @@ func readSSEEventBytes(reader *bufio.Reader) (eventType string, data []byte, eof
 			case bytes.Equal(field, sseEventField):
 				eventType = string(value)
 			case bytes.Equal(field, sseDataField):
-				if len(data) > 0 {
-					data = append(data, '\n')
-				}
-				data = append(data, value...)
+				appendData(value)
 			}
 		}
 		if lineEOF {
-			return eventType, data, true, nil
+			return eventType, r.data, true, nil
 		}
 	}
 }
@@ -556,7 +579,7 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
-		reader := bufio.NewReader(resp.Body)
+		reader := newSSEEventReader(bufio.NewReader(resp.Body))
 
 		toolState := newCompatToolState()
 		var lastUsage *Usage
@@ -565,7 +588,7 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 		sawToolCallsFinish := false
 
 		for {
-			eventType, data, eof, err := readSSEEventBytes(reader)
+			eventType, data, eof, err := reader.readEventBytes()
 			if err != nil {
 				return fmt.Errorf("%s streaming error: %w", p.name, err)
 			}

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -38,6 +38,70 @@ func TestReadSSEEvent_AllowsEventAndDataLinesWithoutSpace(t *testing.T) {
 	}
 }
 
+func TestReadSSEEventBytes_AllowsEventAndDataLinesWithoutSpace(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("event:error\ndata:{\"error\":{\"message\":\"boom\"}}\n\n"))
+
+	eventType, data, eof, err := readSSEEventBytes(reader)
+	if err != nil {
+		t.Fatalf("readSSEEventBytes: %v", err)
+	}
+	if eof {
+		t.Fatal("expected event separator, not EOF")
+	}
+	if eventType != "error" {
+		t.Fatalf("expected event type %q, got %q", "error", eventType)
+	}
+	if string(data) != "{\"error\":{\"message\":\"boom\"}}" {
+		t.Fatalf("expected data %q, got %q", "{\"error\":{\"message\":\"boom\"}}", string(data))
+	}
+}
+
+func TestReadSSEEventBytes_JoinsMultipleDataLines(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("data: first\ndata: second\n\n"))
+
+	_, data, eof, err := readSSEEventBytes(reader)
+	if err != nil {
+		t.Fatalf("readSSEEventBytes: %v", err)
+	}
+	if eof {
+		t.Fatal("expected event separator, not EOF")
+	}
+	if string(data) != "first\nsecond" {
+		t.Fatalf("expected joined data %q, got %q", "first\nsecond", string(data))
+	}
+}
+
+func TestSSEEventReaderReadEventBytes_KeepsDataStableAfterSeparatorRefill(t *testing.T) {
+	// The first line is exactly 16 bytes including the newline, matching the
+	// bufio.Reader size below. An implementation that returned ReadSlice-backed
+	// data directly would have that data invalidated when reading the blank
+	// separator refills the buffer with the next event.
+	raw := strings.NewReader("data: 123456789\n\ndata: second\n\n")
+	reader := newSSEEventReader(bufio.NewReaderSize(raw, 16))
+
+	_, data, eof, err := reader.readEventBytes()
+	if err != nil {
+		t.Fatalf("readEventBytes first: %v", err)
+	}
+	if eof {
+		t.Fatal("expected first event separator, not EOF")
+	}
+	if string(data) != "123456789" {
+		t.Fatalf("expected first data %q, got %q", "123456789", string(data))
+	}
+
+	_, data, eof, err = reader.readEventBytes()
+	if err != nil {
+		t.Fatalf("readEventBytes second: %v", err)
+	}
+	if eof {
+		t.Fatal("expected second event separator, not EOF")
+	}
+	if string(data) != "second" {
+		t.Fatalf("expected second data %q, got %q", "second", string(data))
+	}
+}
+
 func TestReadSSEEvent_StripsOnlyOptionalSingleSpaceAfterColon(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("data:  leading-space\n\n"))
 

--- a/internal/llm/sse_benchmark_test.go
+++ b/internal/llm/sse_benchmark_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"bufio"
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -29,6 +30,38 @@ func BenchmarkReadSSEEventChatCompletions(b *testing.B) {
 				continue
 			}
 			if data == "[DONE]" {
+				break
+			}
+			if eof {
+				break
+			}
+		}
+	}
+}
+
+func BenchmarkReadSSEEventBytesChatCompletions(b *testing.B) {
+	const chunk = `data: {"choices":[{"delta":{"content":"hello world"}}]}` + "\n\n"
+	payload := strings.Repeat(chunk, 128) + "data: [DONE]\n\n"
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		reader := newSSEEventReader(bufio.NewReader(strings.NewReader(payload)))
+		for {
+			_, data, eof, err := reader.readEventBytes()
+			if err != nil {
+				b.Fatalf("readSSEEventBytes: %v", err)
+			}
+			if eof && len(data) == 0 {
+				break
+			}
+			if len(data) == 0 {
+				if eof {
+					break
+				}
+				continue
+			}
+			if bytes.Equal(data, sseDoneData) {
 				break
 			}
 			if eof {


### PR DESCRIPTION
## What

Reuse an owned SSE event data buffer in the OpenAI-compatible streaming parser instead of allocating a fresh `[]byte` for every `data:` event.

The streaming hot path now constructs one `sseEventReader` per HTTP response and reuses its data buffer for each event. The parser still copies `bufio.Reader` slices before continuing to read the event separator, so the returned data is safe until the next event read.

## Why

A broad benchmark/profile pass showed SSE parsing as a small but real allocation hotspot in token streaming. OpenAI-compatible streams commonly deliver one JSON payload per SSE `data:` event, so per-event allocations add avoidable GC pressure and latency during long responses.

## Evidence

New benchmark over a 128-event chat-completions SSE payload:

Before:

```text
BenchmarkReadSSEEventBytesChatCompletions-32  156698-178912  7086-7227 ns/op  12328 B/op  131 allocs/op
```

After:

```text
BenchmarkReadSSEEventBytesChatCompletions-32  242428-250070  4775-4989 ns/op   4288 B/op    4 allocs/op
```

Representative improvement: about 31% lower parser time, 65% fewer allocated bytes, and 127 fewer allocations per 128-event payload.

## Verification

```text
go test ./internal/llm -run 'TestReadSSEEvent|TestSSEEventReader|TestOpenAICompatStream_AllowsLargeSSEDataLines'
go test ./internal/llm -run 'TestReadSSEEvent|TestOpenAICompatStream_AllowsLargeSSEDataLines' -bench 'BenchmarkReadSSEEvent(Bytes)?ChatCompletions' -benchmem -count=5
go build ./...
go test ./...
```
