### PR TITLE
perf: defer skill metadata catalog loading

### DIFF
--- a/internal/skills/setup.go
+++ b/internal/skills/setup.go
@@ -21,7 +21,6 @@ type Setup struct {
 	alwaysEnabled        []string
 	metadataBudgetTokens int
 	maxVisibleSkills     int
-	preloadedSkills      []*Skill // Primed startup catalog reused for first prompt metadata build
 
 	metadataOnce sync.Once
 	metadataErr  error
@@ -47,13 +46,15 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		return nil, err
 	}
 
-	// Prime the startup skill catalog once so prompt metadata generation can
-	// reuse it without rescanning and reparsing before the first prompt.
-	preloadedSkills, err := registry.List()
+	// Check availability cheaply. Prompt metadata is generated lazily so commands
+	// whose AGENTS.md already supplies skill markup, or other startup paths that
+	// only need the activation/search tools, do not scan and parse the full skill
+	// catalog before it is actually needed.
+	hasSkills, err := registry.HasAnySkill()
 	if err != nil {
 		return nil, err
 	}
-	if len(preloadedSkills) == 0 {
+	if !hasSkills {
 		return nil, nil
 	}
 
@@ -62,7 +63,6 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		alwaysEnabled:        append([]string(nil), cfg.AlwaysEnabled...),
 		metadataBudgetTokens: cfg.MetadataBudgetTokens,
 		maxVisibleSkills:     cfg.MaxVisibleSkills,
-		preloadedSkills:      preloadedSkills,
 	}, nil
 }
 
@@ -76,15 +76,10 @@ func (s *Setup) EnsurePromptMetadata() error {
 	}
 
 	s.metadataOnce.Do(func() {
-		allSkills := s.preloadedSkills
-		s.preloadedSkills = nil
-		if allSkills == nil {
-			var err error
-			allSkills, err = s.Registry.List()
-			if err != nil {
-				s.metadataErr = fmt.Errorf("list skills: %w", err)
-				return
-			}
+		allSkills, err := s.Registry.List()
+		if err != nil {
+			s.metadataErr = fmt.Errorf("list skills: %w", err)
+			return
 		}
 
 		// Filter by never_auto for metadata injection (explicit only skills excluded)

--- a/internal/skills/setup_test.go
+++ b/internal/skills/setup_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,20 @@ description: "A test skill"
 		t.Fatal("HasSkillsXML() = true before metadata generation, want false")
 	}
 
+	secondSkillDir := filepath.Join(tmp, ".skills", "late-skill")
+	if err := os.MkdirAll(secondSkillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secondSkillDir, "SKILL.md"), []byte(`---
+name: late-skill
+description: "A skill added after setup creation"
+---
+
+# Late Skill
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := setup.EnsurePromptMetadata(); err != nil {
 		t.Fatalf("EnsurePromptMetadata() error = %v", err)
 	}
@@ -82,8 +97,11 @@ description: "A test skill"
 	if !strings.Contains(setup.XML, "<name>test-skill</name>") {
 		t.Fatalf("setup.XML missing test skill entry: %q", setup.XML)
 	}
-	if setup.TotalSkills != 1 {
-		t.Fatalf("setup.TotalSkills = %d, want 1", setup.TotalSkills)
+	if !strings.Contains(setup.XML, "<name>late-skill</name>") {
+		t.Fatalf("setup.XML missing late skill entry: %q", setup.XML)
+	}
+	if setup.TotalSkills != 2 {
+		t.Fatalf("setup.TotalSkills = %d, want 2", setup.TotalSkills)
 	}
 	if setup.HasOverflow {
 		t.Fatal("setup.HasOverflow = true, want false")
@@ -130,5 +148,69 @@ name: Broken
 	}
 	if setup != nil {
 		t.Fatalf("NewSetup() = %#v, want nil when no valid skills are available", setup)
+	}
+}
+
+func BenchmarkNewSetupWithoutPromptMetadata(b *testing.B) {
+	const skillCount = 200
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	root := b.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		b.Fatalf("mkdir .git: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		b.Fatalf("chdir: %v", err)
+	}
+
+	b.Setenv("HOME", root)
+	b.Setenv("XDG_CONFIG_HOME", filepath.Join(root, ".config"))
+	b.Setenv("CODEX_HOME", filepath.Join(root, ".codex"))
+
+	for i := 0; i < skillCount; i++ {
+		name := fmt.Sprintf("bench-skill-%03d", i)
+		skillDir := filepath.Join(root, ".skills", name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			b.Fatalf("mkdir skill dir: %v", err)
+		}
+		content := fmt.Sprintf(`---
+name: %s
+description: "Benchmark skill %03d for lazy setup"
+---
+
+# %s
+`, name, i, name)
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			b.Fatalf("write SKILL.md: %v", err)
+		}
+	}
+
+	cfg := &config.SkillsConfig{
+		Enabled:               true,
+		AutoInvoke:            true,
+		MetadataBudgetTokens:  8000,
+		MaxVisibleSkills:      50,
+		IncludeProjectSkills:  true,
+		IncludeEcosystemPaths: false,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		setup, err := NewSetup(cfg)
+		if err != nil {
+			b.Fatalf("NewSetup: %v", err)
+		}
+		if setup == nil {
+			b.Fatal("NewSetup returned nil, want setup for discovered skills")
+		}
+		if setup.XML != "" || len(setup.Skills) != 0 || setup.TotalSkills != 0 {
+			b.Fatalf("NewSetup built prompt metadata eagerly: XML=%q skills=%d total=%d", setup.XML, len(setup.Skills), setup.TotalSkills)
+		}
 	}
 }


### PR DESCRIPTION
## What

Defer the expensive skills catalog scan during `skills.NewSetup`.

`NewSetup` now uses `Registry.HasAnySkill()` as a cheap availability probe and leaves the full `Registry.List()` catalog load/parsing until `EnsurePromptMetadata()` is actually called. This keeps the activation/search tools available without eagerly parsing every `SKILL.md` on startup paths where metadata injection is skipped (for example when AGENTS.md already provides skills markup).

## Why

The startup skills setup path was still doing a full metadata catalog load just to decide whether skills existed. With large skill directories this repeats disk reads/YAML parsing before the prompt metadata is known to be needed.

## Evidence

Added `BenchmarkNewSetupWithoutPromptMetadata` with 200 project skills.

Before:

```text
BenchmarkNewSetupWithoutPromptMetadata-32  262-289 iters  4.12-4.30 ms/op  ~5.82 MB/op  31,743-31,744 allocs/op
```

After:

```text
BenchmarkNewSetupWithoutPromptMetadata-32  22,485-24,496 iters  49.7-53.5 us/op  ~41.6 KB/op  508 allocs/op
```

Also verified:

```text
go build ./...
go test ./...
go test ./internal/skills -run '^$' -bench 'BenchmarkNewSetupWithoutPromptMetadata|BenchmarkRegistryListRepeated|BenchmarkRegistryListCold' -benchmem -count=5
```
