### PR TITLE
fix: Tool dispatch waits for persistence callbacks on the hot path

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -363,6 +363,45 @@ func callbackContext(ctx context.Context) (context.Context, context.CancelFunc) 
 	return context.WithTimeout(context.WithoutCancel(ctx), callbackTimeout)
 }
 
+type orderedCallbackQueue struct {
+	mu   sync.Mutex
+	tail <-chan struct{}
+	wg   sync.WaitGroup
+}
+
+func newOrderedCallbackQueue() *orderedCallbackQueue {
+	done := make(chan struct{})
+	close(done)
+	return &orderedCallbackQueue{tail: done}
+}
+
+func (q *orderedCallbackQueue) Go(fn func()) {
+	if q == nil || fn == nil {
+		return
+	}
+
+	done := make(chan struct{})
+	q.mu.Lock()
+	prev := q.tail
+	q.tail = done
+	q.wg.Add(1)
+	q.mu.Unlock()
+
+	go func(prev <-chan struct{}) {
+		defer q.wg.Done()
+		defer close(done)
+		<-prev
+		fn()
+	}(prev)
+}
+
+func (q *orderedCallbackQueue) Wait() {
+	if q == nil {
+		return
+	}
+	q.wg.Wait()
+}
+
 // SetCompaction enables context compaction with the given input token limit
 // and configuration. Only enable for models with known input limits.
 // Must be called before Stream() or between streams (not during).
@@ -1013,6 +1052,38 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	turnCallback := e.getTurnCallback()
 	responseCallback := e.getResponseCallback()
 	snapshotCallback := e.getSnapshotCallback()
+	callbackQueue := newOrderedCallbackQueue()
+	defer callbackQueue.Wait()
+	queueTurnCallback := func(attempt int, messages []Message, metrics TurnMetrics) {
+		if turnCallback == nil {
+			return
+		}
+		callbackQueue.Go(func() {
+			cbCtx, cancel := callbackContext(ctx)
+			defer cancel()
+			_ = turnCallback(cbCtx, attempt, messages, metrics)
+		})
+	}
+	queueResponseCallback := func(attempt int, assistantMsg Message, metrics TurnMetrics) {
+		if responseCallback == nil {
+			return
+		}
+		callbackQueue.Go(func() {
+			cbCtx, cancel := callbackContext(ctx)
+			defer cancel()
+			_ = responseCallback(cbCtx, attempt, assistantMsg, metrics)
+		})
+	}
+	queueSnapshotCallback := func(attempt int, assistantMsg Message) {
+		if snapshotCallback == nil {
+			return
+		}
+		callbackQueue.Go(func() {
+			cbCtx, cancel := callbackContext(ctx)
+			defer cancel()
+			_ = snapshotCallback(cbCtx, attempt, assistantMsg)
+		})
+	}
 
 	e.callbackMu.RLock()
 	compactionConfig := e.compactionConfig
@@ -1147,6 +1218,13 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	}
 turnLoop:
 	for attempt := 0; attempt < maxTurns; attempt++ {
+		// Keep persistence callbacks ordered but off the hot path for tool dispatch.
+		// Before starting the next provider turn, wait for prior turn bookkeeping to
+		// catch up so external state (e.g. session history) stays in sync.
+		callbackQueue.Wait()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		// Inject any tool specs registered mid-loop (e.g. via skill activation)
 		if pending := e.drainPendingToolSpecs(); len(pending) > 0 {
 			for _, spec := range pending {
@@ -1284,9 +1362,7 @@ turnLoop:
 			if len(msg.Parts) == 0 {
 				return
 			}
-			cbCtx, cancel := callbackContext(ctx)
-			_ = snapshotCallback(cbCtx, attempt, msg)
-			cancel()
+			queueSnapshotCallback(attempt, msg)
 		}
 		// recoverCommittedToolWork journals completed tool-call requests and their
 		// results, then continues the agent loop from the updated transcript. This
@@ -1344,9 +1420,7 @@ turnLoop:
 					turnMetrics.ToolCalls = len(syncToolCalls)
 					turnMessages := []Message{assistantMsg}
 					turnMessages = append(turnMessages, syncToolResults...)
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
-					cancel()
+					queueTurnCallback(attempt, turnMessages, turnMetrics)
 				}
 				return true, nil
 			}
@@ -1392,9 +1466,7 @@ turnLoop:
 					req.Messages = append(req.Messages, assistantMsg)
 					recoveredAtMessageCount = len(req.Messages)
 					if turnCallback != nil {
-						cbCtx, cancel := callbackContext(ctx)
-						_ = turnCallback(cbCtx, attempt, []Message{assistantMsg}, turnMetrics)
-						cancel()
+						queueTurnCallback(attempt, []Message{assistantMsg}, turnMetrics)
 					}
 				}
 				return false, cause
@@ -1408,11 +1480,7 @@ turnLoop:
 				reasoningEncryptedContent,
 			)
 			maybeCompactAfterLLMCall([]Message{assistantMsg})
-			if responseCallback != nil {
-				cbCtx, cancel := callbackContext(ctx)
-				_ = responseCallback(cbCtx, attempt, assistantMsg, turnMetrics)
-				cancel()
-			}
+			queueResponseCallback(attempt, assistantMsg, turnMetrics)
 
 			var origNameByID map[string]string
 			if req.ToolMap != nil {
@@ -1474,9 +1542,7 @@ turnLoop:
 				if responseCallback == nil {
 					turnMessages = append([]Message{assistantMsg}, toolResults...)
 				}
-				cbCtx, cancel := callbackContext(ctx)
-				_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
-				cancel()
+				queueTurnCallback(attempt, turnMessages, turnMetrics)
 			}
 			if err := ctx.Err(); err != nil {
 				return false, err
@@ -1837,9 +1903,7 @@ turnLoop:
 				}
 				maybeCompactAfterLLMCall([]Message{finalMsg})
 				if turnCallback != nil {
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
-					cancel()
+					queueTurnCallback(attempt, []Message{finalMsg}, turnMetrics)
 				}
 			}
 			if err := send.Send(Event{Type: EventDone}); err != nil {
@@ -1870,9 +1934,7 @@ turnLoop:
 				turnMetrics.ToolCalls = len(syncToolCalls)
 				turnMessages := []Message{assistantMsg}
 				turnMessages = append(turnMessages, syncToolResults...)
-				cbCtx, cancel := callbackContext(ctx)
-				_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
-				cancel()
+				queueTurnCallback(attempt, turnMessages, turnMetrics)
 			}
 
 			// Check for user interjection (MCP sync path)
@@ -1880,9 +1942,7 @@ turnLoop:
 				interjectionMsg := UserText(interjection.Text)
 				req.Messages = append(req.Messages, interjectionMsg)
 				if turnCallback != nil {
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, []Message{interjectionMsg}, TurnMetrics{})
-					cancel()
+					queueTurnCallback(attempt, []Message{interjectionMsg}, TurnMetrics{})
 				}
 				if err := send.Send(Event{Type: EventInterjection, Text: interjection.Text, InterjectionID: interjection.ID}); err != nil {
 					return err
@@ -1952,9 +2012,7 @@ turnLoop:
 				finalMsg := Message{Role: RoleAssistant, Parts: parts}
 				maybeCompactAfterLLMCall([]Message{finalMsg})
 				if turnCallback != nil {
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
-					cancel()
+					queueTurnCallback(attempt, []Message{finalMsg}, turnMetrics)
 				}
 			}
 			if err := send.Send(Event{Type: EventDone}); err != nil {
@@ -1981,11 +2039,7 @@ turnLoop:
 
 		// Call responseCallback BEFORE tool execution to persist assistant message
 		// This ensures the message is saved even if tool execution fails/crashes
-		if responseCallback != nil {
-			cbCtx, cancel := callbackContext(ctx)
-			_ = responseCallback(cbCtx, attempt, assistantMsg, turnMetrics)
-			cancel()
-		}
+		queueResponseCallback(attempt, assistantMsg, turnMetrics)
 
 		// ToolMap: swap client tool names to mapped server names for execution.
 		// We save original names keyed by call ID so we can restore them on
@@ -2051,9 +2105,7 @@ turnLoop:
 		// Call turn completed callback with tool results for incremental persistence
 		if turnCallback != nil {
 			turnMetrics.ToolCalls = len(registered)
-			cbCtx, cancel := callbackContext(ctx)
-			_ = turnCallback(cbCtx, attempt, toolResults, turnMetrics)
-			cancel()
+			queueTurnCallback(attempt, toolResults, turnMetrics)
 		}
 
 		// Exit promptly if caller cancelled while tools were executing.
@@ -2077,9 +2129,7 @@ turnLoop:
 			req.Messages = append(req.Messages, interjectionMsg)
 			// Fire turn callback so the interjection is persisted
 			if turnCallback != nil {
-				cbCtx, cancel := callbackContext(ctx)
-				_ = turnCallback(cbCtx, attempt, []Message{interjectionMsg}, TurnMetrics{})
-				cancel()
+				queueTurnCallback(attempt, []Message{interjectionMsg}, TurnMetrics{})
 			}
 			// Emit event so TUI can display the interjection inline
 			if err := send.Send(Event{Type: EventInterjection, Text: interjection.Text, InterjectionID: interjection.ID}); err != nil {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -231,6 +231,31 @@ func (t *countingTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+type startedTool struct {
+	started chan struct{}
+}
+
+func (t *startedTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "started_tool",
+		Description: "Signals when execution begins",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (t *startedTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	select {
+	case <-t.started:
+	default:
+		close(t.started)
+	}
+	return TextOutput("ok"), nil
+}
+
+func (t *startedTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 type overlapDetectTool struct {
 	active    atomic.Int64
 	maxActive atomic.Int64
@@ -1692,6 +1717,146 @@ func TestRunLoopPersistsPartialAssistantMessageOnEventErrorAfterToolCall(t *test
 	if persisted.Parts[1].ToolCall.ID != "call-1" {
 		t.Fatalf("persisted tool call ID = %q, want %q", persisted.Parts[1].ToolCall.ID, "call-1")
 	}
+}
+
+func TestRunLoopToolDispatchDoesNotWaitForPersistenceCallbacks(t *testing.T) {
+	newEngine := func(t *startedTool) *Engine {
+		provider := &fakeProvider{
+			script: func(call int, req Request) []Event {
+				switch call {
+				case 0:
+					return []Event{
+						{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "started_tool", Arguments: json.RawMessage(`{}`)}},
+						{Type: EventDone},
+					}
+				default:
+					return []Event{
+						{Type: EventTextDelta, Text: "done"},
+						{Type: EventDone},
+					}
+				}
+			},
+		}
+		registry := NewToolRegistry()
+		registry.Register(t)
+		return NewEngine(provider, registry)
+	}
+
+	t.Run("snapshot callback", func(t *testing.T) {
+		tool := &startedTool{started: make(chan struct{})}
+		engine := newEngine(tool)
+		release := make(chan struct{})
+		snapshotStarted := make(chan struct{})
+		engine.SetAssistantSnapshotCallback(func(ctx context.Context, turnIndex int, assistantMsg Message) error {
+			close(snapshotStarted)
+			<-release
+			return nil
+		})
+
+		stream, err := engine.Stream(context.Background(), Request{
+			Messages: []Message{UserText("test")},
+			Tools:    []ToolSpec{tool.Spec()},
+		})
+		if err != nil {
+			t.Fatalf("stream error: %v", err)
+		}
+		defer stream.Close()
+
+		errCh := make(chan error, 1)
+		go func() {
+			defer close(errCh)
+			for {
+				event, err := stream.Recv()
+				if err == io.EOF {
+					errCh <- nil
+					return
+				}
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if event.Type == EventError && event.Err != nil {
+					errCh <- event.Err
+					return
+				}
+			}
+		}()
+
+		select {
+		case <-snapshotStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for snapshot callback to start")
+		}
+
+		select {
+		case <-tool.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("tool execution waited for snapshot callback to finish")
+		}
+
+		close(release)
+		if err := <-errCh; err != nil {
+			t.Fatalf("stream recv error: %v", err)
+		}
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		tool := &startedTool{started: make(chan struct{})}
+		engine := newEngine(tool)
+		release := make(chan struct{})
+		responseStarted := make(chan struct{})
+		engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg Message, metrics TurnMetrics) error {
+			close(responseStarted)
+			<-release
+			return nil
+		})
+
+		stream, err := engine.Stream(context.Background(), Request{
+			Messages: []Message{UserText("test")},
+			Tools:    []ToolSpec{tool.Spec()},
+		})
+		if err != nil {
+			t.Fatalf("stream error: %v", err)
+		}
+		defer stream.Close()
+
+		errCh := make(chan error, 1)
+		go func() {
+			defer close(errCh)
+			for {
+				event, err := stream.Recv()
+				if err == io.EOF {
+					errCh <- nil
+					return
+				}
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if event.Type == EventError && event.Err != nil {
+					errCh <- event.Err
+					return
+				}
+			}
+		}()
+
+		select {
+		case <-responseStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for response callback to start")
+		}
+
+		select {
+		case <-tool.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("tool execution waited for response callback to finish")
+		}
+
+		close(release)
+		if err := <-errCh; err != nil {
+			t.Fatalf("stream recv error: %v", err)
+		}
+	})
 }
 
 func TestEngineEmitsToolCallAndExecStartForEachTool(t *testing.T) {


### PR DESCRIPTION
## What

- move runLoop assistant snapshot, response-completed, and turn-completed callbacks onto an ordered background queue
- preserve callback ordering while letting tool execution start without waiting for persistence work to finish
- wait for queued bookkeeping before starting the next provider turn or returning, so external session state still catches up deterministically
- add coverage proving blocked snapshot/response callbacks no longer delay tool execution

## Why

These callbacks often do real persistence work (session AddMessage/UpdateMessage/UpdateMetrics). Running them synchronously on the agent loop meant a slow DB/fs write could add up to the full callback timeout directly onto tool-dispatch latency, making streaming and tool starts feel stalled. Serializing them off the hot path keeps persistence ordering intact while removing that avoidable delay before tools run.
