### PR TITLE
fix: Tool execution is blocked on synchronous callback I/O before dispatch continues

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -363,6 +363,88 @@ func callbackContext(ctx context.Context) (context.Context, context.CancelFunc) 
 	return context.WithTimeout(context.WithoutCancel(ctx), callbackTimeout)
 }
 
+type callbackTaskKind uint8
+
+const (
+	callbackTaskSnapshot callbackTaskKind = iota + 1
+	callbackTaskResponse
+	callbackTaskTurn
+)
+
+type callbackTask struct {
+	kind callbackTaskKind
+	run  func(context.Context)
+}
+
+// asyncCallbackQueue runs persistence callbacks off the agent hot path while
+// preserving callback ordering until the stream shuts down.
+type asyncCallbackQueue struct {
+	ctx    context.Context
+	mu     sync.Mutex
+	cond   *sync.Cond
+	queue  []callbackTask
+	closed bool
+	done   chan struct{}
+}
+
+func newAsyncCallbackQueue(ctx context.Context) *asyncCallbackQueue {
+	q := &asyncCallbackQueue{
+		ctx:  ctx,
+		done: make(chan struct{}),
+	}
+	q.cond = sync.NewCond(&q.mu)
+	go q.run()
+	return q
+}
+
+func (q *asyncCallbackQueue) enqueue(kind callbackTaskKind, run func(context.Context)) {
+	if q == nil || run == nil {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+
+	q.queue = append(q.queue, callbackTask{kind: kind, run: run})
+	q.cond.Signal()
+}
+
+func (q *asyncCallbackQueue) wait() {
+	if q == nil {
+		return
+	}
+
+	q.mu.Lock()
+	q.closed = true
+	q.cond.Broadcast()
+	q.mu.Unlock()
+	<-q.done
+}
+
+func (q *asyncCallbackQueue) run() {
+	defer close(q.done)
+	for {
+		q.mu.Lock()
+		for len(q.queue) == 0 && !q.closed {
+			q.cond.Wait()
+		}
+		if len(q.queue) == 0 && q.closed {
+			q.mu.Unlock()
+			return
+		}
+		task := q.queue[0]
+		q.queue = q.queue[1:]
+		q.mu.Unlock()
+
+		cbCtx, cancel := callbackContext(q.ctx)
+		task.run(cbCtx)
+		cancel()
+	}
+}
+
 // SetCompaction enables context compaction with the given input token limit
 // and configuration. Only enable for models with known input limits.
 // Must be called before Stream() or between streams (not during).
@@ -1013,6 +1095,34 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	turnCallback := e.getTurnCallback()
 	responseCallback := e.getResponseCallback()
 	snapshotCallback := e.getSnapshotCallback()
+	callbackQueue := newAsyncCallbackQueue(ctx)
+	defer callbackQueue.wait()
+
+	enqueueSnapshot := func(turnIndex int, assistantMsg Message) {
+		if snapshotCallback == nil {
+			return
+		}
+		callbackQueue.enqueue(callbackTaskSnapshot, func(cbCtx context.Context) {
+			_ = snapshotCallback(cbCtx, turnIndex, assistantMsg)
+		})
+	}
+	enqueueResponse := func(turnIndex int, assistantMsg Message, metrics TurnMetrics) {
+		if responseCallback == nil {
+			return
+		}
+		callbackQueue.enqueue(callbackTaskResponse, func(cbCtx context.Context) {
+			_ = responseCallback(cbCtx, turnIndex, assistantMsg, metrics)
+		})
+	}
+	enqueueTurn := func(turnIndex int, messages []Message, metrics TurnMetrics) {
+		if turnCallback == nil {
+			return
+		}
+		copied := append([]Message(nil), messages...)
+		callbackQueue.enqueue(callbackTaskTurn, func(cbCtx context.Context) {
+			_ = turnCallback(cbCtx, turnIndex, copied, metrics)
+		})
+	}
 
 	e.callbackMu.RLock()
 	compactionConfig := e.compactionConfig
@@ -1284,9 +1394,7 @@ turnLoop:
 			if len(msg.Parts) == 0 {
 				return
 			}
-			cbCtx, cancel := callbackContext(ctx)
-			_ = snapshotCallback(cbCtx, attempt, msg)
-			cancel()
+			enqueueSnapshot(attempt, msg)
 		}
 		// recoverCommittedToolWork journals completed tool-call requests and their
 		// results, then continues the agent loop from the updated transcript. This
@@ -1344,9 +1452,7 @@ turnLoop:
 					turnMetrics.ToolCalls = len(syncToolCalls)
 					turnMessages := []Message{assistantMsg}
 					turnMessages = append(turnMessages, syncToolResults...)
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
-					cancel()
+					enqueueTurn(attempt, turnMessages, turnMetrics)
 				}
 				return true, nil
 			}
@@ -1392,9 +1498,7 @@ turnLoop:
 					req.Messages = append(req.Messages, assistantMsg)
 					recoveredAtMessageCount = len(req.Messages)
 					if turnCallback != nil {
-						cbCtx, cancel := callbackContext(ctx)
-						_ = turnCallback(cbCtx, attempt, []Message{assistantMsg}, turnMetrics)
-						cancel()
+						enqueueTurn(attempt, []Message{assistantMsg}, turnMetrics)
 					}
 				}
 				return false, cause
@@ -1409,9 +1513,7 @@ turnLoop:
 			)
 			maybeCompactAfterLLMCall([]Message{assistantMsg})
 			if responseCallback != nil {
-				cbCtx, cancel := callbackContext(ctx)
-				_ = responseCallback(cbCtx, attempt, assistantMsg, turnMetrics)
-				cancel()
+				enqueueResponse(attempt, assistantMsg, turnMetrics)
 			}
 
 			var origNameByID map[string]string
@@ -1474,9 +1576,7 @@ turnLoop:
 				if responseCallback == nil {
 					turnMessages = append([]Message{assistantMsg}, toolResults...)
 				}
-				cbCtx, cancel := callbackContext(ctx)
-				_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
-				cancel()
+				enqueueTurn(attempt, turnMessages, turnMetrics)
 			}
 			if err := ctx.Err(); err != nil {
 				return false, err
@@ -1837,9 +1937,7 @@ turnLoop:
 				}
 				maybeCompactAfterLLMCall([]Message{finalMsg})
 				if turnCallback != nil {
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
-					cancel()
+					enqueueTurn(attempt, []Message{finalMsg}, turnMetrics)
 				}
 			}
 			if err := send.Send(Event{Type: EventDone}); err != nil {
@@ -1870,9 +1968,7 @@ turnLoop:
 				turnMetrics.ToolCalls = len(syncToolCalls)
 				turnMessages := []Message{assistantMsg}
 				turnMessages = append(turnMessages, syncToolResults...)
-				cbCtx, cancel := callbackContext(ctx)
-				_ = turnCallback(cbCtx, attempt, turnMessages, turnMetrics)
-				cancel()
+				enqueueTurn(attempt, turnMessages, turnMetrics)
 			}
 
 			// Check for user interjection (MCP sync path)
@@ -1880,9 +1976,7 @@ turnLoop:
 				interjectionMsg := UserText(interjection.Text)
 				req.Messages = append(req.Messages, interjectionMsg)
 				if turnCallback != nil {
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, []Message{interjectionMsg}, TurnMetrics{})
-					cancel()
+					enqueueTurn(attempt, []Message{interjectionMsg}, TurnMetrics{})
 				}
 				if err := send.Send(Event{Type: EventInterjection, Text: interjection.Text, InterjectionID: interjection.ID}); err != nil {
 					return err
@@ -1952,9 +2046,7 @@ turnLoop:
 				finalMsg := Message{Role: RoleAssistant, Parts: parts}
 				maybeCompactAfterLLMCall([]Message{finalMsg})
 				if turnCallback != nil {
-					cbCtx, cancel := callbackContext(ctx)
-					_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
-					cancel()
+					enqueueTurn(attempt, []Message{finalMsg}, turnMetrics)
 				}
 			}
 			if err := send.Send(Event{Type: EventDone}); err != nil {
@@ -1982,9 +2074,7 @@ turnLoop:
 		// Call responseCallback BEFORE tool execution to persist assistant message
 		// This ensures the message is saved even if tool execution fails/crashes
 		if responseCallback != nil {
-			cbCtx, cancel := callbackContext(ctx)
-			_ = responseCallback(cbCtx, attempt, assistantMsg, turnMetrics)
-			cancel()
+			enqueueResponse(attempt, assistantMsg, turnMetrics)
 		}
 
 		// ToolMap: swap client tool names to mapped server names for execution.
@@ -2051,9 +2141,7 @@ turnLoop:
 		// Call turn completed callback with tool results for incremental persistence
 		if turnCallback != nil {
 			turnMetrics.ToolCalls = len(registered)
-			cbCtx, cancel := callbackContext(ctx)
-			_ = turnCallback(cbCtx, attempt, toolResults, turnMetrics)
-			cancel()
+			enqueueTurn(attempt, toolResults, turnMetrics)
 		}
 
 		// Exit promptly if caller cancelled while tools were executing.
@@ -2077,9 +2165,7 @@ turnLoop:
 			req.Messages = append(req.Messages, interjectionMsg)
 			// Fire turn callback so the interjection is persisted
 			if turnCallback != nil {
-				cbCtx, cancel := callbackContext(ctx)
-				_ = turnCallback(cbCtx, attempt, []Message{interjectionMsg}, TurnMetrics{})
-				cancel()
+				enqueueTurn(attempt, []Message{interjectionMsg}, TurnMetrics{})
 			}
 			// Emit event so TUI can display the interjection inline
 			if err := send.Send(Event{Type: EventInterjection, Text: interjection.Text, InterjectionID: interjection.ID}); err != nil {

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -3238,6 +3238,241 @@ func TestEngineTurnCallbackContextSurvivesCancellation(t *testing.T) {
 	}
 }
 
+func TestEngineSnapshotCallbackDoesNotBlockToolCallEmission(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				return []Event{{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "count_tool", Arguments: json.RawMessage(`{}`)}}, {Type: EventDone}}
+			default:
+				return []Event{{Type: EventTextDelta, Text: "done"}, {Type: EventDone}}
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	snapshotStarted := make(chan struct{}, 1)
+	releaseSnapshot := make(chan struct{})
+	engine.SetAssistantSnapshotCallback(func(ctx context.Context, turnIndex int, assistantMsg Message) error {
+		select {
+		case snapshotStarted <- struct{}{}:
+		default:
+		}
+		<-releaseSnapshot
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+		Tools:    []ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	toolCallSeen := make(chan struct{}, 1)
+	drainDone := make(chan error, 1)
+	go func() {
+		for {
+			event, err := stream.Recv()
+			if err == io.EOF {
+				drainDone <- nil
+				return
+			}
+			if err != nil {
+				drainDone <- err
+				return
+			}
+			if event.Type == EventToolCall {
+				select {
+				case toolCallSeen <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-snapshotStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for snapshot callback to start")
+	}
+
+	select {
+	case <-toolCallSeen:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("tool call emission blocked on snapshot callback")
+	}
+
+	close(releaseSnapshot)
+	if err := <-drainDone; err != nil {
+		t.Fatalf("drain error: %v", err)
+	}
+}
+
+func TestEngineResponseCallbackDoesNotBlockToolExecution(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				return []Event{{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "count_tool", Arguments: json.RawMessage(`{}`)}}, {Type: EventDone}}
+			default:
+				return []Event{{Type: EventTextDelta, Text: "done"}, {Type: EventDone}}
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	responseStarted := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg Message, metrics TurnMetrics) error {
+		select {
+		case responseStarted <- struct{}{}:
+		default:
+		}
+		<-releaseResponse
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+		Tools:    []ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	execStartSeen := make(chan struct{}, 1)
+	drainDone := make(chan error, 1)
+	go func() {
+		for {
+			event, err := stream.Recv()
+			if err == io.EOF {
+				drainDone <- nil
+				return
+			}
+			if err != nil {
+				drainDone <- err
+				return
+			}
+			if event.Type == EventToolExecStart {
+				select {
+				case execStartSeen <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-responseStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for response callback to start")
+	}
+
+	select {
+	case <-execStartSeen:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("tool execution blocked on response callback")
+	}
+
+	close(releaseResponse)
+	if err := <-drainDone; err != nil {
+		t.Fatalf("drain error: %v", err)
+	}
+}
+
+func TestEngineTurnCallbackDoesNotBlockNextTurn(t *testing.T) {
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	secondTurnStarted := make(chan struct{})
+	provider := &fakeProvider{
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				return []Event{{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "count_tool", Arguments: json.RawMessage(`{}`)}}, {Type: EventDone}}
+			case 1:
+				close(secondTurnStarted)
+				return []Event{{Type: EventTextDelta, Text: "done"}, {Type: EventDone}}
+			default:
+				return nil
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	turnStarted := make(chan struct{}, 1)
+	releaseTurn := make(chan struct{})
+	engine.SetTurnCompletedCallback(func(ctx context.Context, turnIndex int, messages []Message, metrics TurnMetrics) error {
+		for _, msg := range messages {
+			for _, part := range msg.Parts {
+				if part.Type == PartToolResult && part.ToolResult != nil && part.ToolResult.ID == "call-1" {
+					select {
+					case turnStarted <- struct{}{}:
+					default:
+					}
+					<-releaseTurn
+					return nil
+				}
+			}
+		}
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("test")},
+		Tools:    []ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	defer stream.Close()
+
+	drainDone := make(chan error, 1)
+	go func() {
+		for {
+			_, err := stream.Recv()
+			if err == io.EOF {
+				drainDone <- nil
+				return
+			}
+			if err != nil {
+				drainDone <- err
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-turnStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for turn callback to start")
+	}
+
+	select {
+	case <-secondTurnStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("next turn blocked on turn callback")
+	}
+
+	close(releaseTurn)
+	if err := <-drainDone; err != nil {
+		t.Fatalf("drain error: %v", err)
+	}
+}
+
 // TestEngineInterjection_EventEmitted verifies that EventInterjection events
 // are properly emitted through the stream with the correct text.
 func TestEngineInterjection_EventEmitted(t *testing.T) {

--- a/internal/llm/snapshot_callback_test.go
+++ b/internal/llm/snapshot_callback_test.go
@@ -184,15 +184,12 @@ func TestSnapshotFiresCumulativelyPerToolCall(t *testing.T) {
 	}
 }
 
-// TestSnapshotFiresBeforeSendFailure verifies that snapshot is fired before
-// send.Send is attempted. This tests the root cause of PR #426: when the
-// consumer cancels the context, send.Send fails, but the snapshot callback has
-// already persisted the partial assistant state.
-//
-// We trigger this by using a slow snapshot callback that cancels the parent
-// context from within itself — guaranteeing that by the time send.Send runs,
-// the context is already done.
-func TestSnapshotFiresBeforeSendFailure(t *testing.T) {
+// TestSnapshotSurvivesCancellationAfterToolCall verifies that a queued snapshot
+// still persists assistant state when the consumer cancels immediately after the
+// tool-call event is emitted. The callback now runs asynchronously, so the
+// invariant is durability across cancellation, not synchronous completion before
+// send.Send returns.
+func TestSnapshotSurvivesCancellationAfterToolCall(t *testing.T) {
 	tool := &countingTool{}
 	registry := NewToolRegistry()
 	registry.Register(tool)
@@ -213,12 +210,6 @@ func TestSnapshotFiresBeforeSendFailure(t *testing.T) {
 	defer cancel()
 
 	rec := &snapshotRecorder{}
-	// Cancel context from within the snapshot callback so that the subsequent
-	// send.Send for the same EventToolCall races with cancellation. Even under
-	// worst-case ordering, the snapshot must have already been recorded.
-	rec.onInvoke = func() {
-		cancel()
-	}
 	engine.SetAssistantSnapshotCallback(rec.callback())
 
 	stream, err := engine.Stream(ctx, Request{
@@ -228,16 +219,20 @@ func TestSnapshotFiresBeforeSendFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stream error: %v", err)
 	}
-	// Drain until EOF or error — stream will terminate because ctx was cancelled.
+
 	for {
-		if _, err := stream.Recv(); err != nil {
+		event, err := stream.Recv()
+		if err != nil {
 			break
+		}
+		if event.Type == EventToolCall {
+			cancel()
 		}
 	}
 	stream.Close()
 
-	if rec.count() != 1 {
-		t.Fatalf("snapshot calls = %d, want 1 (fired before send.Send)", rec.count())
+	if rec.count() < 1 {
+		t.Fatalf("snapshot calls = %d, want >= 1 after cancellation", rec.count())
 	}
 	msg := rec.at(0)
 	callIDs := extractCallIDs(msg)


### PR DESCRIPTION
## What

- move agent-loop assistant snapshot, response-completed, and turn-completed callbacks onto an asynchronous ordered callback queue instead of running them inline on the hot path
- keep callback ordering stable and drain the queue before the stream fully exits so persistence still gets a best-effort completion window
- add regression coverage showing slow snapshot/response/turn callbacks no longer block tool-call emission, tool execution start, or advancement to the next turn
- update the snapshot cancellation test to assert durability across cancellation under the new asynchronous callback model

## Why

These callbacks are commonly used for real persistence work (session AddMessage/UpdateMessage/UpdateMetrics and snapshot upserts). Running them inline meant a slow database or filesystem write could pause tool dispatch for seconds and stall the whole agent loop between turns. Moving them off the hot path removes that latency while preserving callback order and keeping persistence callbacks alive briefly after cancellation via the existing callback context behavior.
