### PR TITLE
fix: spawn_agent timeout does not include time spent waiting for a parallelism slot

### DIFF
--- a/internal/tools/spawn_agent.go
+++ b/internal/tools/spawn_agent.go
@@ -253,24 +253,29 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 		timeout = 3600 // Cap at 60 minutes
 	}
 
+	start := time.Now()
+
+	// Create child context with timeout before waiting on the semaphore so queued
+	// sub-agents spend their timeout budget both waiting for a slot and doing work.
+	childCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
 	// Acquire semaphore (blocks if at max concurrency)
 	select {
 	case t.semaphore <- struct{}{}:
 		defer func() { <-t.semaphore }()
-	case <-ctx.Done():
-		// Distinguish between deadline exceeded (timeout) and manual cancellation
-		if ctx.Err() == context.DeadlineExceeded {
-			return llm.TextOutput(t.formatError(ErrTimeout, "context deadline exceeded while waiting for agent slot")), nil
+	case <-childCtx.Done():
+		duration := time.Since(start).Milliseconds()
+		if ctx.Err() == context.Canceled {
+			return llm.TextOutput(t.formatErrorWithDuration(ErrExecutionFailed, "context cancelled while waiting for agent slot", duration)), nil
 		}
-		return llm.TextOutput(t.formatError(ErrExecutionFailed, "context cancelled while waiting for agent slot")), nil
+		if ctx.Err() == context.DeadlineExceeded {
+			return llm.TextOutput(t.formatErrorWithDuration(ErrTimeout, "context deadline exceeded while waiting for agent slot", duration)), nil
+		}
+		return llm.TextOutput(t.formatErrorWithDuration(ErrTimeout, fmt.Sprintf("agent '%s' timed out after %d seconds while waiting for agent slot", a.AgentName, timeout), duration)), nil
 	}
 
-	// Create child context with timeout
-	childCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-	defer cancel()
-
 	// Run the sub-agent (with callback if available)
-	start := time.Now()
 	var runResult SpawnAgentRunResult
 	var err error
 

--- a/internal/tools/spawn_agent_test.go
+++ b/internal/tools/spawn_agent_test.go
@@ -628,6 +628,79 @@ func TestSpawnAgentTool_SemaphoreLimiting(t *testing.T) {
 	}
 }
 
+func TestSpawnAgentTool_WaitForSlotCountsTowardDuration(t *testing.T) {
+	config := SpawnConfig{
+		MaxParallel:    1,
+		MaxDepth:       5,
+		DefaultTimeout: 300,
+	}
+	tool := NewSpawnAgentTool(config, 0)
+
+	runner := newMockRunner().SetDelay(20 * time.Millisecond)
+	tool.SetRunner(runner)
+
+	tool.semaphore <- struct{}{}
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		<-tool.semaphore
+	}()
+
+	result, err := tool.Execute(context.Background(), makeSpawnArgs("agent", "task", 30))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := parseResult(t, result.Content)
+	if r.Error != "" {
+		t.Fatalf("unexpected tool error: %s", r.Error)
+	}
+	if r.Duration < 50 {
+		t.Fatalf("duration = %dms, want wait time to be included", r.Duration)
+	}
+}
+
+func TestSpawnAgentTool_TimesOutWhileWaitingForSlot(t *testing.T) {
+	config := SpawnConfig{
+		MaxParallel:    1,
+		MaxDepth:       5,
+		DefaultTimeout: 300,
+	}
+	tool := NewSpawnAgentTool(config, 0)
+
+	runner := newMockRunner()
+	tool.SetRunner(runner)
+
+	tool.semaphore <- struct{}{}
+	defer func() { <-tool.semaphore }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	result, err := tool.Execute(ctx, makeSpawnArgs("agent", "task", 10))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	r := parseResult(t, result.Content)
+	if r.Error == "" {
+		t.Fatal("expected timeout while waiting for agent slot")
+	}
+	if r.Type != string(ErrTimeout) {
+		t.Fatalf("expected error type %s, got %s", ErrTimeout, r.Type)
+	}
+	if !contains(r.Error, "waiting for agent slot") {
+		t.Fatalf("expected wait-for-slot error message, got %q", r.Error)
+	}
+	if elapsed >= 11*time.Second {
+		t.Fatalf("Execute took %v, want timeout before parent context deadline", elapsed)
+	}
+	if runner.GetCallCount() != 0 {
+		t.Fatalf("runner should not be called while waiting for a slot, got %d calls", runner.GetCallCount())
+	}
+}
+
 func TestSpawnAgentTool_RunnerNotConfigured(t *testing.T) {
 	config := DefaultSpawnConfig()
 	tool := NewSpawnAgentTool(config, 0)


### PR DESCRIPTION
## What

- start the spawn_agent timeout before waiting on the MaxParallel semaphore
- use the child timeout context while queued for a slot, so waiting time counts against the tool timeout
- include queued time in reported duration/error results
- add regression tests for queued duration accounting and timeout while waiting for a slot

## Why

When MaxParallel is saturated, queued spawn_agent calls were waiting on the semaphore with only the parent context. That meant the tool's requested/default timeout did not apply until after a slot was acquired, so queued agents could appear hung for far longer than their timeout budget. This restores expected timeout semantics and improves responsiveness under parallel sub-agent workloads.
