### PR TITLE
perf: skip redundant skill preload when agents provide metadata

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -652,7 +652,11 @@ func SetupSkills(cfg *config.SkillsConfig, skillsFlag string, agentSkills string
 		return nil
 	}
 
-	setup, err := skills.NewSetup(skillsCfg)
+	promptMetadataSuppressed := skills.CheckAgentsMdForSkills()
+	setup, err := skills.NewSetupWithOptions(skillsCfg, skills.SetupOptions{
+		PromptMetadataSuppressed:       promptMetadataSuppressed,
+		PromptMetadataSuppressionKnown: true,
+	})
 	if err != nil {
 		fmt.Fprintf(errWriter, "warning: skills initialization failed: %v\n", err)
 		return nil
@@ -707,7 +711,10 @@ func RegisterSkillToolWithEngine(engine *llm.Engine, toolMgr *tools.ToolManager,
 
 // InjectSkillsMetadata appends <available_skills> metadata to instructions when available.
 func InjectSkillsMetadata(instructions string, skillsSetup *skills.Setup) string {
-	if skillsSetup == nil || skills.CheckAgentsMdForSkills() {
+	if skillsSetup == nil {
+		return instructions
+	}
+	if suppressed, known := skillsSetup.PromptMetadataSuppressed(); suppressed || (!known && skills.CheckAgentsMdForSkills()) {
 		return instructions
 	}
 	if err := skillsSetup.EnsurePromptMetadata(); err != nil {

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -354,19 +355,19 @@ description: Demo skill
 		t.Fatal(err)
 	}
 
-	setup, err := skills.NewSetup(&config.SkillsConfig{
+	setup := SetupSkills(&config.SkillsConfig{
 		Enabled:               true,
 		AutoInvoke:            true,
 		MetadataBudgetTokens:  8000,
 		MaxVisibleSkills:      8,
 		IncludeProjectSkills:  true,
 		IncludeEcosystemPaths: false,
-	})
-	if err != nil {
-		t.Fatalf("NewSetup() error = %v", err)
-	}
+	}, "", "", io.Discard)
 	if setup == nil {
-		t.Fatal("NewSetup() = nil, want non-nil")
+		t.Fatal("SetupSkills() = nil, want non-nil")
+	}
+	if suppressed, known := setup.PromptMetadataSuppressed(); !known || !suppressed {
+		t.Fatalf("PromptMetadataSuppressed() = (%v, %v), want (true, true)", suppressed, known)
 	}
 
 	got := InjectSkillsMetadata("Base prompt", setup)
@@ -381,6 +382,65 @@ description: Demo skill
 	}
 	if setup.TotalSkills != 0 {
 		t.Fatalf("setup.TotalSkills = %d, want 0 because metadata discovery should be skipped", setup.TotalSkills)
+	}
+}
+
+func BenchmarkSetupSkillsWithAgentsMdSkillMarkup(b *testing.B) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	tmp := b.TempDir()
+	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0755); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("<available_skills>managed elsewhere</available_skills>"), 0644); err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < 500; i++ {
+		skillDir := filepath.Join(tmp, ".skills", fmt.Sprintf("skill-%03d", i))
+		if err := os.MkdirAll(skillDir, 0755); err != nil {
+			b.Fatal(err)
+		}
+		body := fmt.Sprintf(`---
+name: skill-%03d
+description: Skill number %03d
+---
+
+# Skill %03d
+`, i, i, i)
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := os.Chdir(tmp); err != nil {
+		b.Fatal(err)
+	}
+	b.Setenv("HOME", tmp)
+	b.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	b.Setenv("CODEX_HOME", filepath.Join(tmp, ".codex"))
+
+	skillsCfg := &config.SkillsConfig{
+		Enabled:               true,
+		AutoInvoke:            true,
+		MetadataBudgetTokens:  8000,
+		MaxVisibleSkills:      50,
+		IncludeProjectSkills:  true,
+		IncludeEcosystemPaths: false,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		setup := SetupSkills(skillsCfg, "", "", io.Discard)
+		if setup == nil {
+			b.Fatal("SetupSkills() = nil, want non-nil")
+		}
+		if got := InjectSkillsMetadata("Base prompt", setup); got != "Base prompt" {
+			b.Fatalf("InjectSkillsMetadata() = %q, want unchanged prompt", got)
+		}
 	}
 }
 

--- a/internal/skills/setup.go
+++ b/internal/skills/setup.go
@@ -23,13 +23,36 @@ type Setup struct {
 	maxVisibleSkills     int
 	preloadedSkills      []*Skill // Primed startup catalog reused for first prompt metadata build
 
+	promptMetadataSuppressed       bool
+	promptMetadataSuppressionKnown bool
+
 	metadataOnce sync.Once
 	metadataErr  error
+}
+
+// SetupOptions controls optional startup behavior for NewSetupWithOptions.
+type SetupOptions struct {
+	// PromptMetadataSuppressed means the caller already has <available_skills>
+	// metadata from another source (for example AGENTS.md). In that case setup only
+	// verifies that at least one skill exists so activate_skill/search_skills can be
+	// registered, and skips the full prompt catalog preload.
+	PromptMetadataSuppressed bool
+
+	// PromptMetadataSuppressionKnown records whether PromptMetadataSuppressed came
+	// from an actual check. It lets callers avoid repeating the same AGENTS.md read
+	// before deciding whether to inject metadata.
+	PromptMetadataSuppressionKnown bool
 }
 
 // NewSetup initializes the skills system from config.
 // Returns nil if skills are disabled or no skills are available.
 func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
+	return NewSetupWithOptions(cfg, SetupOptions{})
+}
+
+// NewSetupWithOptions initializes the skills system from config.
+// Returns nil if skills are disabled or no skills are available.
+func NewSetupWithOptions(cfg *config.SkillsConfig, opts SetupOptions) (*Setup, error) {
 	if !cfg.Enabled {
 		return nil, nil
 	}
@@ -47,6 +70,30 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 		return nil, err
 	}
 
+	setup := &Setup{
+		Registry:                       registry,
+		alwaysEnabled:                  append([]string(nil), cfg.AlwaysEnabled...),
+		metadataBudgetTokens:           cfg.MetadataBudgetTokens,
+		maxVisibleSkills:               cfg.MaxVisibleSkills,
+		promptMetadataSuppressed:       opts.PromptMetadataSuppressed,
+		promptMetadataSuppressionKnown: opts.PromptMetadataSuppressionKnown,
+	}
+
+	if opts.PromptMetadataSuppressed {
+		// AGENTS.md (or an equivalent caller-owned prompt) already carries skill
+		// metadata. Avoid parsing every SKILL.md just to have InjectSkillsMetadata
+		// immediately skip it; a cheap first-valid-skill probe is enough to decide
+		// whether the runtime skill tools should be registered.
+		hasAny, err := registry.HasAnySkill()
+		if err != nil {
+			return nil, err
+		}
+		if !hasAny {
+			return nil, nil
+		}
+		return setup, nil
+	}
+
 	// Prime the startup skill catalog once so prompt metadata generation can
 	// reuse it without rescanning and reparsing before the first prompt.
 	preloadedSkills, err := registry.List()
@@ -56,14 +103,9 @@ func NewSetup(cfg *config.SkillsConfig) (*Setup, error) {
 	if len(preloadedSkills) == 0 {
 		return nil, nil
 	}
+	setup.preloadedSkills = preloadedSkills
 
-	return &Setup{
-		Registry:             registry,
-		alwaysEnabled:        append([]string(nil), cfg.AlwaysEnabled...),
-		metadataBudgetTokens: cfg.MetadataBudgetTokens,
-		maxVisibleSkills:     cfg.MaxVisibleSkills,
-		preloadedSkills:      preloadedSkills,
-	}, nil
+	return setup, nil
 }
 
 // EnsurePromptMetadata loads and caches prompt-facing skill metadata on demand.
@@ -71,7 +113,7 @@ func (s *Setup) EnsurePromptMetadata() error {
 	if s == nil {
 		return nil
 	}
-	if s.XML != "" || s.Registry == nil {
+	if s.XML != "" || s.Registry == nil || s.promptMetadataSuppressed {
 		return nil
 	}
 
@@ -126,6 +168,15 @@ func (s *Setup) HasSkillsXML() bool {
 		return false
 	}
 	return s.XML != ""
+}
+
+// PromptMetadataSuppressed reports whether the caller already supplies skill
+// metadata and whether that decision came from a completed suppression check.
+func (s *Setup) PromptMetadataSuppressed() (suppressed bool, known bool) {
+	if s == nil {
+		return false, false
+	}
+	return s.promptMetadataSuppressed, s.promptMetadataSuppressionKnown
 }
 
 // CheckAgentsMdForSkills checks if AGENTS.md contains skill system markup.


### PR DESCRIPTION
## What

Skip the eager full skill catalog preload when `AGENTS.md`/`AGENTS.override.md` already supplies skill markup and prompt injection will be suppressed.

- Add `skills.NewSetupWithOptions` so callers can pass a known prompt-metadata suppression decision.
- Let `SetupSkills` cache the `AGENTS.md` check and use a cheap first-valid-skill probe in that suppressed path, preserving `activate_skill`/`search_skills` registration without parsing every `SKILL.md`.
- Keep the existing eager preload path when term-llm will inject `<available_skills>`, so the normal injection path still avoids a second catalog scan.
- Add a regression benchmark for the AGENTS.md-suppressed startup path with 500 local skills.

## Why

Before this change, `SetupSkills` always called `skills.NewSetup`, which parsed every discovered skill's YAML metadata via `registry.List()` even when `InjectSkillsMetadata` would immediately skip prompt metadata because `AGENTS.md` already contains skill-system markup. That made CLI startup pay avoidable disk/YAML work in repositories that manage skills in their agent instructions.

## Evidence

Benchmark added in this PR:

```text
# before
go test ./cmd -run '^$' -bench BenchmarkSetupSkillsWithAgentsMdSkillMarkup -benchmem -count=5
BenchmarkSetupSkillsWithAgentsMdSkillMarkup-32       98-109  10.40-11.81 ms/op  14.36 MB/op  76204-76205 allocs/op

# after
BenchmarkSetupSkillsWithAgentsMdSkillMarkup-32    8456-10000  127.5-134.1 us/op  77.8 KB/op  1121 allocs/op
```

Representative improvement: about 80x lower latency, 184x fewer allocated bytes, and 68x fewer allocations for the suppressed metadata startup path.

## Verification

```text
go test ./internal/skills ./cmd
go test ./...
go build ./...
```
