### PR TITLE
perf: avoid no-op streaming newline normalization copies

### DIFF
--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -119,10 +119,9 @@ func (sr *StreamRenderer) renderPartial(content string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rendered := string(renderedBytes)
-
 	// Normalize consecutive newlines to fix inconsistent header spacing
-	rendered = string(normalizeNewlines([]byte(rendered)))
+	renderedBytes = normalizeNewlines(renderedBytes)
+	rendered := string(renderedBytes)
 
 	// Strip trailing newlines from partial render since we'll re-render later
 	rendered = strings.TrimRight(rendered, "\n")

--- a/internal/ui/streaming/streaming.go
+++ b/internal/ui/streaming/streaming.go
@@ -19,7 +19,25 @@ var multiNewlineRe = regexp.MustCompile(`\n{3,}`)
 
 // normalizeNewlines reduces 3+ consecutive newlines to 2 (one blank line max).
 func normalizeNewlines(s []byte) []byte {
+	if !hasThreeConsecutiveNewlines(s) {
+		return s
+	}
 	return multiNewlineRe.ReplaceAll(s, []byte("\n\n"))
+}
+
+func hasThreeConsecutiveNewlines(s []byte) bool {
+	run := 0
+	for _, b := range s {
+		if b != '\n' {
+			run = 0
+			continue
+		}
+		run++
+		if run >= 3 {
+			return true
+		}
+	}
+	return false
 }
 
 // blockType represents the type of markdown block being processed.

--- a/internal/ui/streaming/streaming_test.go
+++ b/internal/ui/streaming/streaming_test.go
@@ -105,6 +105,25 @@ func (w *nonResettableWriter) String() string {
 	return w.builder.String()
 }
 
+func TestNormalizeNewlinesNoopReusesInput(t *testing.T) {
+	input := []byte("one\n\ntwo\nthree")
+	got := normalizeNewlines(input)
+	if string(got) != string(input) {
+		t.Fatalf("normalizeNewlines changed no-op input: got %q want %q", got, input)
+	}
+	if &got[0] != &input[0] {
+		t.Fatalf("normalizeNewlines should reuse no-op input backing array")
+	}
+}
+
+func TestNormalizeNewlinesCollapsesRuns(t *testing.T) {
+	got := normalizeNewlines([]byte("one\n\n\ntwo\n\n\n\nthree"))
+	want := "one\n\ntwo\n\nthree"
+	if string(got) != want {
+		t.Fatalf("normalizeNewlines() = %q, want %q", got, want)
+	}
+}
+
 // assertChunkingInvariant verifies that chunked output matches full output.
 func assertChunkingInvariant(t *testing.T, name, input string) {
 	t.Helper()


### PR DESCRIPTION
## What

Avoid copying rendered streaming snapshots when newline normalization has nothing to collapse.

- Add a cheap pre-scan before the regexp-based `\n{3,}` collapse in `internal/ui/streaming`.
- Keep the existing regexp behavior for outputs that really do contain 3+ consecutive newlines.
- Normalize partial-render bytes before converting to string, avoiding an extra string/byte round trip.
- Add tests that lock in both collapse behavior and the allocation-sensitive no-op reuse path.

## Why

Streaming markdown repaint paths call newline normalization for every committed/partial rendered snapshot. In normal chat output, those snapshots usually do not contain 3+ consecutive newlines, so the previous `regexp.ReplaceAll` path scanned and copied the whole rendered buffer despite producing identical bytes.

## Evidence

Focused benchmarks on `linux/amd64`, Intel i9-14900K, `go test ./internal/ui/streaming -bench='BenchmarkStreamRendererLargeNoTabs|BenchmarkStreamingVsDirect|BenchmarkStreamingFull|BenchmarkStreamingChunked' -benchmem -run=^$ -count=5`:

- `BenchmarkStreamingVsDirect/Streaming`: mean `B/op` 724,396 -> 692,077 (~4.5% less), allocs/op 8,978.6 -> 8,936.
- `BenchmarkStreamRendererLargeNoTabs`: mean `B/op` 44,368,332 -> 42,446,554 (~4.3% less).
- `BenchmarkStreamingFull`: mean `B/op` 54,265 -> 52,498 (~3.3% less), allocs/op 848 -> 836.
- `BenchmarkStreamingChunked`: mean `B/op` 54,591 -> 52,942 (~3.0% less), allocs/op 897 -> 885.

Wall time is roughly noise-level unchanged; the win is avoiding repeated rendered-buffer copies in the visible streaming path.

## Verification

- `gofmt -w internal/ui/streaming/streaming.go internal/ui/streaming/partial.go internal/ui/streaming/streaming_test.go`
- `go test ./internal/ui/streaming -count=1`
- `go test ./internal/ui/streaming -bench='BenchmarkStreamRendererLargeNoTabs|BenchmarkStreamingVsDirect|BenchmarkStreamingFull|BenchmarkStreamingChunked' -benchmem -run=^$ -count=5`
- `go build ./...`
- `go test ./...`
