### PR TITLE
fix: enforce output tool finalization

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -298,6 +298,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	var outputTool *tools.SetOutputTool
+	outputToolParam := "content"
 	if toolMgr != nil {
 		// Enable yolo mode if flag is set
 		if askYolo {
@@ -311,6 +312,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 			if param == "" {
 				param = "content" // default
 			}
+			outputToolParam = param
 			outputTool = toolMgr.Registry.RegisterOutputTool(agentCfg.Name, param, agentCfg.Description)
 			// Re-register tools with engine after output tool was added
 			toolMgr.SetupEngine(engine)
@@ -444,6 +446,15 @@ func runAsk(cmd *cobra.Command, args []string) error {
 			req.Tools = specs
 			req.ToolChoice = llm.ToolChoice{Mode: llm.ToolChoiceAuto}
 		}
+	}
+	if outputTool != nil {
+		req.RequiredToolName = outputTool.Name()
+		req.RequiredToolPrompt = fmt.Sprintf(
+			"The previous response completed without calling `%s`. Do not inspect more files, run more tools, or answer in prose. Call `%s` now with the final output for the configured `%s` parameter.",
+			outputTool.Name(),
+			outputTool.Name(),
+			outputToolParam,
+		)
 	}
 
 	// Check if we're in a TTY and can use glamour
@@ -768,18 +779,28 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// A configured output tool is contractual. Natural assistant prose is useful
+	// session history, but it must not be treated as the durable output value.
+	if outputTool != nil && !outputTool.Called() {
+		return fmt.Errorf("output tool %q was not called", outputTool.Name())
+	}
+
 	// Run on_complete handler if configured
 	if agent != nil && agent.OnComplete != "" {
 		var output string
-		if outputTool != nil && outputTool.Value() != "" {
-			output = outputTool.Value() // Tool output (preferred)
+		hasOutput := false
+		if outputTool != nil {
+			output = outputTool.Value() // Tool output (preferred, may be empty)
+			hasOutput = true
 		} else if collector != nil {
-			output = collector.Text() // Fallback to text
+			output = collector.Text() // Fallback to text only when no output tool exists
+			hasOutput = output != ""
 		} else if askProgressive {
 			output = progressiveOutputText(progressiveResult)
+			hasOutput = output != ""
 		}
 
-		if output != "" {
+		if hasOutput {
 			if err := runOnComplete(agent.OnComplete, output); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: on_complete failed: %v\n", err)
 			}

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -463,6 +463,19 @@ func (e *Engine) IsToolAllowed(name string) bool {
 	return e.allowedTools[name]
 }
 
+func defaultRequiredToolPrompt(toolName string) string {
+	return fmt.Sprintf("The previous response completed without calling `%s`. Do not answer in prose. Call `%s` now with the final output.", toolName, toolName)
+}
+
+func onlyToolSpec(specs []ToolSpec, name string) ([]ToolSpec, bool) {
+	for _, spec := range specs {
+		if spec.Name == name {
+			return []ToolSpec{spec}, true
+		}
+	}
+	return nil, false
+}
+
 // Stream returns a stream, applying external tools when needed.
 func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	if req.DebugRaw {
@@ -681,6 +694,7 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 	}
 
 	var reactiveCompactionDone bool // prevents infinite retry if compacted context still overflows
+	var requiredToolFinalizationAttempted bool
 	for attempt := 0; attempt < maxTurns; attempt++ {
 		// Inject any tool specs registered mid-loop (e.g. via skill activation)
 		if pending := e.drainPendingToolSpecs(); len(pending) > 0 {
@@ -728,8 +742,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 			if req.LastTurnToolChoice != nil {
 				req.ToolChoice = *req.LastTurnToolChoice
 			}
-		} else if attempt > 0 {
-			// Ensure we are in Auto mode for follow-up turns in the loop
+		} else if attempt > 0 && !requiredToolFinalizationAttempted {
+			// Ensure we are in Auto mode for follow-up turns in the loop. Preserve a
+			// forced required-tool choice for the synthetic finalization turn.
 			req.ToolChoice = ToolChoice{Mode: ToolChoiceAuto}
 		}
 
@@ -905,6 +920,60 @@ func (e *Engine) runLoop(ctx context.Context, req Request, events chan<- Event) 
 		req.Search = false
 
 		if len(toolCalls) == 0 && !syncToolsExecuted {
+			// No tools called. If a specific output/finalization tool is required,
+			// preserve the natural response in the conversation and give the model one
+			// constrained turn with only that tool available. This makes output-tool
+			// completion contractual instead of allowing assistant prose to silently
+			// stand in for the configured tool value.
+			if req.RequiredToolName != "" {
+				if requiredToolFinalizationAttempted {
+					return fmt.Errorf("output tool %q was not called", req.RequiredToolName)
+				}
+
+				finalMsg := Message{}
+				if textBuilder.Len() > 0 || reasoningBuilder.Len() > 0 || reasoningItemID != "" || reasoningEncryptedContent != "" {
+					finalMsg = Message{
+						Role: RoleAssistant,
+						Parts: []Part{{
+							Type:                      PartText,
+							Text:                      textBuilder.String(),
+							ReasoningContent:          reasoningBuilder.String(),
+							ReasoningItemID:           reasoningItemID,
+							ReasoningEncryptedContent: reasoningEncryptedContent,
+						}},
+					}
+					if turnCallback != nil {
+						cbCtx, cancel := callbackContext(ctx)
+						_ = turnCallback(cbCtx, attempt, []Message{finalMsg}, turnMetrics)
+						cancel()
+					}
+					req.Messages = append(req.Messages, finalMsg)
+				}
+
+				tools, ok := onlyToolSpec(req.Tools, req.RequiredToolName)
+				if !ok {
+					return fmt.Errorf("output tool %q is not available", req.RequiredToolName)
+				}
+				prompt := strings.TrimSpace(req.RequiredToolPrompt)
+				if prompt == "" {
+					prompt = defaultRequiredToolPrompt(req.RequiredToolName)
+				}
+				promptMsg := UserText(prompt)
+				req.Messages = append(req.Messages, promptMsg)
+				if turnCallback != nil {
+					cbCtx, cancel := callbackContext(ctx)
+					_ = turnCallback(cbCtx, attempt, []Message{promptMsg}, TurnMetrics{})
+					cancel()
+				}
+				req.Tools = tools
+				req.ToolChoice = ToolChoice{Mode: ToolChoiceName, Name: req.RequiredToolName}
+				req.ParallelToolCalls = false
+				req.Search = false
+				req.ForceExternalSearch = false
+				requiredToolFinalizationAttempted = true
+				continue
+			}
+
 			// No tools called - check if we should restore original tool choice and retry once
 			if originalToolChoice.Mode == ToolChoiceName && !restoredToolChoice {
 				req.ToolChoice = originalToolChoice

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -2091,3 +2091,145 @@ func TestEnginePanickingToolParallelCalls(t *testing.T) {
 		t.Fatal("expected a successful tool result from count_tool")
 	}
 }
+
+type finishingCaptureTool struct {
+	calls int
+}
+
+func (t *finishingCaptureTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        "submit_review",
+		Description: "Submit final review",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"review_json": map[string]any{"type": "string"},
+			},
+			"required": []string{"review_json"},
+		},
+	}
+}
+
+func (t *finishingCaptureTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	t.calls++
+	return TextOutput("captured"), nil
+}
+
+func (t *finishingCaptureTool) Preview(args json.RawMessage) string { return "" }
+
+func (t *finishingCaptureTool) IsFinishingTool() bool { return true }
+
+func TestEngineForcesRequiredToolAfterNaturalCompletion(t *testing.T) {
+	tool := &finishingCaptureTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		hasCapabilities: true,
+		capabilities:    Capabilities{ToolCalls: true, SupportsToolChoice: true},
+		script: func(call int, req Request) []Event {
+			switch call {
+			case 0:
+				if req.ToolChoice.Mode != ToolChoiceAuto {
+					t.Fatalf("first turn tool choice = %#v, want auto", req.ToolChoice)
+				}
+				return []Event{{Type: EventTextDelta, Text: "final prose instead of tool"}, {Type: EventDone}}
+			case 1:
+				if req.ToolChoice.Mode != ToolChoiceName || req.ToolChoice.Name != "submit_review" {
+					t.Fatalf("finalization tool choice = %#v, want submit_review", req.ToolChoice)
+				}
+				if len(req.Tools) != 1 || req.Tools[0].Name != "submit_review" {
+					t.Fatalf("finalization tools = %#v, want only submit_review", req.Tools)
+				}
+				last := req.Messages[len(req.Messages)-1]
+				if got := collectTextParts(last.Parts); !strings.Contains(got, "Call `submit_review`") {
+					t.Fatalf("finalization prompt = %q", got)
+				}
+				return []Event{{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: "submit_review", Arguments: json.RawMessage(`{"review_json":"{}"}`)}}, {Type: EventDone}}
+			default:
+				t.Fatalf("unexpected provider call %d", call)
+				return nil
+			}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages:         []Message{UserText("review this")},
+		Tools:            []ToolSpec{tool.Spec()},
+		ToolChoice:       ToolChoice{Mode: ToolChoiceAuto},
+		RequiredToolName: "submit_review",
+	})
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv returned error: %v", err)
+		}
+	}
+
+	if tool.calls != 1 {
+		t.Fatalf("submit_review calls = %d, want 1", tool.calls)
+	}
+	if len(provider.calls) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(provider.calls))
+	}
+}
+
+func TestEngineRequiredToolErrorsWhenFinalizationDoesNotCallTool(t *testing.T) {
+	tool := &finishingCaptureTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+
+	provider := &fakeProvider{
+		hasCapabilities: true,
+		capabilities:    Capabilities{ToolCalls: true, SupportsToolChoice: true},
+		script: func(call int, req Request) []Event {
+			return []Event{{Type: EventTextDelta, Text: "still prose"}, {Type: EventDone}}
+		},
+	}
+
+	engine := NewEngine(provider, registry)
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages:         []Message{UserText("review this")},
+		Tools:            []ToolSpec{tool.Spec()},
+		ToolChoice:       ToolChoice{Mode: ToolChoiceAuto},
+		RequiredToolName: "submit_review",
+	})
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	defer stream.Close()
+
+	var gotErr error
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			gotErr = err
+			break
+		}
+		if event.Type == EventError && event.Err != nil {
+			gotErr = event.Err
+			break
+		}
+	}
+
+	if gotErr == nil || !strings.Contains(gotErr.Error(), `output tool "submit_review" was not called`) {
+		t.Fatalf("expected missing output-tool error, got %v", gotErr)
+	}
+	if tool.calls != 0 {
+		t.Fatalf("submit_review calls = %d, want 0", tool.calls)
+	}
+	if len(provider.calls) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(provider.calls))
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -59,6 +59,8 @@ type Request struct {
 	Tools                   []ToolSpec
 	ToolChoice              ToolChoice
 	LastTurnToolChoice      *ToolChoice // If set, force this tool choice on the last agentic turn
+	RequiredToolName        string      // If set, natural completion triggers one forced finalization turn for this tool
+	RequiredToolPrompt      string      // Optional prompt used for the forced required-tool finalization turn
 	ParallelToolCalls       bool
 	Search                  bool
 	ForceExternalSearch     bool // If true, use external search even if provider supports native

--- a/internal/tools/set_output.go
+++ b/internal/tools/set_output.go
@@ -16,6 +16,7 @@ type SetOutputTool struct {
 	paramName   string // Parameter name to capture (e.g., "message")
 	description string // Tool description
 	value       string // Captured value
+	called      bool   // True once the tool has been invoked, even with an empty value
 }
 
 // NewSetOutputTool creates a tool with custom name/description.
@@ -53,6 +54,7 @@ func (t *SetOutputTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 	if v, ok := params[t.paramName].(string); ok {
 		t.value = v
 	}
+	t.called = true
 	return llm.TextOutput("Output captured."), nil
 }
 
@@ -63,6 +65,12 @@ func (t *SetOutputTool) Preview(args json.RawMessage) string {
 // Value returns the captured output value.
 func (t *SetOutputTool) Value() string {
 	return t.value
+}
+
+// Called returns true once the tool has been invoked. An empty captured value
+// still counts as a real output-tool call.
+func (t *SetOutputTool) Called() bool {
+	return t.called
 }
 
 // Name returns the configured tool name.

--- a/internal/tools/set_output_test.go
+++ b/internal/tools/set_output_test.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestSetOutputToolCalledWithEmptyValue(t *testing.T) {
+	tool := NewSetOutputTool("submit_review", "review_json", "Submit review")
+
+	if tool.Called() {
+		t.Fatal("new output tool should not be marked called")
+	}
+
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"review_json":""}`)); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !tool.Called() {
+		t.Fatal("empty output value should still mark output tool called")
+	}
+	if got := tool.Value(); got != "" {
+		t.Fatalf("Value() = %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
## Summary\n- make configured output tools contractual: natural completion now triggers one constrained finalization turn with only the required output tool available\n- return a typed nonzero error if the output tool still is not called instead of falling back to assistant prose\n- treat empty-string output-tool values as real calls and run on_complete with them\n\n## Tests\n- `go test ./...`