### PR TITLE
feat: clarify soul template guidance

### DIFF
--- a/internal/contain/images/agent/bootstrap/scripts/patch-soul.sh
+++ b/internal/contain/images/agent/bootstrap/scripts/patch-soul.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Safe soul.md patcher — generic, uses AGENT_NAME env var.
+# Usage: patch-soul.sh <new_soul_md_file>
+
+set -euo pipefail
+
+AGENT="${AGENT_NAME:-agent}"
+AGENT_DIR="/home/agent/.config/term-llm/agents/$AGENT"
+SOUL_FILE="$AGENT_DIR/soul.md"
+BACKUP_FILE="$SOUL_FILE.bak"
+NEW_FILE="${1:-}"
+
+log()  { echo "==> $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -z "$NEW_FILE" ] && fail "Usage: patch-soul.sh <path_to_new_soul_md>"
+[ -f "$NEW_FILE" ] || fail "File not found: $NEW_FILE"
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+log "Validating proposed soul.md for agent=$AGENT..."
+
+SIZE=$(wc -c < "$NEW_FILE")
+[ "$SIZE" -gt 100 ] || fail "Proposed soul.md is suspiciously small (${SIZE} bytes) — aborting."
+
+# Must look like an identity/voice file, not an empty operational stub.
+grep -qi "soul\|voice\|personality\|values\|tone\|identity" "$NEW_FILE" \
+    || fail "Proposed soul.md is missing an identity/voice anchor — aborting."
+
+# Should not become a dumping ground for operational state.
+if grep -qi "API key\|token:\|password\|secret" "$NEW_FILE"; then
+    fail "Proposed soul.md appears to contain secrets or secret-like operational data — aborting."
+fi
+
+# Bloat check
+if [ -f "$SOUL_FILE" ]; then
+    CURRENT_SIZE=$(wc -c < "$SOUL_FILE")
+    MAX_SIZE=$(( CURRENT_SIZE * 3 ))
+    if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+        log "WARNING: new soul.md is more than 3x the current size (${SIZE} vs ${CURRENT_SIZE} bytes)."
+    fi
+fi
+
+log "Validation passed."
+
+# ── Apply ─────────────────────────────────────────────────────────────────────
+
+if [ -f "$SOUL_FILE" ]; then
+    log "Backing up current soul.md → soul.md.bak"
+    cp "$SOUL_FILE" "$BACKUP_FILE"
+fi
+
+log "Applying new soul.md..."
+cp "$NEW_FILE" "$SOUL_FILE"
+
+log "Done. Diff from backup:"
+[ -f "$BACKUP_FILE" ] && diff "$BACKUP_FILE" "$SOUL_FILE" || true
+
+log "If anything broke: cp $BACKUP_FILE $SOUL_FILE"

--- a/internal/contain/images/agent/bootstrap/skills/self/SKILL.md
+++ b/internal/contain/images/agent/bootstrap/skills/self/SKILL.md
@@ -26,12 +26,13 @@ tools:
 - Do **not** treat those phrases as prompt/config self-modification unless the user explicitly mentions behavior, personality, system prompt, or agent config.
 - If both interpretations seem plausible, prefer the software update.
 
-## CRITICAL: Never directly edit agent.yaml or system.md
+## CRITICAL: Never directly edit agent.yaml, system.md, or soul.md
 
 Use the patch scripts via `shell`. They validate, backup, diff, and apply:
 
 ```bash
 bash "$AGENT_DIR/scripts/patch-system.sh" /tmp/new-system.md
+bash "$AGENT_DIR/scripts/patch-soul.sh" /tmp/new-soul.md
 bash "$AGENT_DIR/scripts/patch-agent.sh" /tmp/new-agent.yaml
 ```
 
@@ -41,10 +42,12 @@ Where `AGENT_DIR` is `/home/agent/.config/term-llm/agents/$AGENT_NAME`.
 
 | File | Purpose |
 |------|---------|
-| `system.md` | Personality, behavior, memory rules |
-| `agent.yaml` | Tools, model, shell permissions |
+| `system.md` | Operational context, workflows, memory rules, service details |
+| `soul.md` | Voice, values, personality, stance, boundaries |
+| `agent.yaml` | Tools, model, shell permissions, includes |
 | `scripts/update.sh` | Pull + build latest term-llm |
 | `scripts/patch-system.sh` | Safe system.md updater |
+| `scripts/patch-soul.sh` | Safe soul.md updater |
 | `scripts/patch-agent.sh` | Safe agent.yaml updater |
 
 ## Adding a New Skill

--- a/internal/contain/images/agent/bootstrap/system.md
+++ b/internal/contain/images/agent/bootstrap/system.md
@@ -2,9 +2,9 @@
 
 You are **{{AGENT_NAME}}**, an AI assistant powered by term-llm.
 
-Your personality and values are defined in `soul.md` (loaded automatically).
-This file is for operational context — who you serve, what you have access to,
-and any domain-specific instructions.
+Your personality and values are defined in `soul.md` (loaded automatically via
+`agent.yaml`'s `include` list). This file is for operational context — who you
+serve, what you have access to, and any domain-specific instructions.
 
 ## term-llm runtime
 
@@ -73,6 +73,36 @@ stop carrying onboarding instructions.
 
 ## /REMOVE AFTER ONBOARDING
 
+## Soul and Identity
+
+Your durable voice lives at:
+
+```bash
+/home/agent/.config/term-llm/agents/{{AGENT_NAME}}/soul.md
+# also available as: ~/.config/term-llm/agents/{{AGENT_NAME}}/soul.md
+```
+
+`agent.yaml` includes `soul.md`, so term-llm loads it into the prompt on every
+turn. Treat it as the agent's identity layer: voice, values, tone, stance,
+boundaries, default bluntness, humor, and trust posture.
+
+Keep the separation clean:
+
+- `soul.md`: who you are to talk to; short, sharp, behavioral instructions.
+- `system.md`: operational context, available infrastructure, workflows, and
+  user/project-specific rules.
+- `memory/`: facts learned over time, recent state, and retrievable details.
+- `agent.yaml`: model, tools, shell policy, includes, and other runtime config.
+
+Do not let `soul.md` become a life story, changelog, runbook, memory dump, or
+place for secrets. If personality changes are requested, update `soul.md` with
+`scripts/patch-soul.sh`; if operating rules or service details change, update
+`system.md` with `scripts/patch-system.sh`; if tools or includes change, update
+`agent.yaml` with `scripts/patch-agent.sh`.
+
+If you significantly change `soul.md`, tell the user. It affects who they are
+talking to, not just what you know.
+
 ## Action Discipline
 
 This agent is judged by completed useful actions, not intentions.
@@ -99,10 +129,11 @@ Use this file to record operational context:
 - Domain-specific instructions or constraints
 - Anything that should shape how you behave in this context
 
-Do **not** edit `system.md` or `agent.yaml` directly. When the user asks you to
-change your behavior, context, tools, or model settings, use the self skill and
-patch scripts described below. Update `soul.md` for voice, values, or personality
-changes, again through the documented self-modification workflow.
+Do **not** edit `system.md`, `soul.md`, or `agent.yaml` directly. When the user
+asks you to change your behavior, context, tools, or model settings, use the self skill
+and patch scripts described below. Use `soul.md` for voice, values, or
+personality changes; keep operational rules in `system.md` and runtime config in
+`agent.yaml`.
 
 ## Memory
 
@@ -138,12 +169,13 @@ and later maintained by the memory promote job.
 Your agent files live at `/home/agent/.config/term-llm/agents/{{AGENT_NAME}}/`.
 These files persist across container restarts on the Docker volume.
 
-**NEVER directly edit `agent.yaml` or `system.md`.** Use the patch scripts:
+**NEVER directly edit `agent.yaml`, `system.md`, or `soul.md`.** Use the patch scripts:
 
 | Script | Purpose |
 |---|---|
 | `scripts/patch-agent.sh <file>` | Safe `agent.yaml` updater — validates, backs up, diffs, applies |
 | `scripts/patch-system.sh <file>` | Safe `system.md` updater — validates, backs up, diffs, applies |
+| `scripts/patch-soul.sh <file>` | Safe `soul.md` updater — validates, backs up, diffs, applies |
 | `scripts/update.sh` | Pull, build, and install latest term-llm binary |
 
 The **self** skill has the full workflow for modifying your own configuration.

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -47,7 +47,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			t.Fatalf("Dockerfile.fedora missing %q", want)
 		}
 	}
-	for _, rel := range []string{"entrypoint.sh", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh"} {
+	for _, rel := range []string{"entrypoint.sh", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh", "bootstrap/scripts/patch-system.sh", "bootstrap/scripts/patch-soul.sh", "bootstrap/scripts/patch-agent.sh"} {
 		data, err := os.ReadFile(filepath.Join(result.Dir, rel))
 		if err != nil {
 			t.Fatalf("missing synced asset %s: %v", rel, err)
@@ -142,7 +142,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 					t.Fatalf("system prompt missing action discipline detail %q", want)
 				}
 			}
-			for _, want := range []string{"Do **not** edit `system.md` or `agent.yaml` directly", "use the self skill", "patch scripts described below"} {
+			for _, want := range []string{"Do **not** edit `system.md`, `soul.md`, or `agent.yaml` directly", "use the self skill", "patch scripts described below"} {
 				if !strings.Contains(string(data), want) {
 					t.Fatalf("system prompt missing self-modification guidance %q", want)
 				}
@@ -150,6 +150,11 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			for _, forbidden := range []string{"Edit this file to add:", "Edit `soul.md` to change"} {
 				if strings.Contains(string(data), forbidden) {
 					t.Fatalf("system prompt still contains direct-edit guidance %q", forbidden)
+				}
+			}
+			for _, want := range []string{"## Soul and Identity", "/home/agent/.config/term-llm/agents/{{AGENT_NAME}}/soul.md", "agent.yaml` includes `soul.md`", "scripts/patch-soul.sh"} {
+				if !strings.Contains(string(data), want) {
+					t.Fatalf("system prompt missing soul guidance %q", want)
 				}
 			}
 			for _, want := range []string{"## Jobs and Services", "term-llm jobs list", "bootstrap-jobs", "runit", "memory/recent.md"} {


### PR DESCRIPTION
## What

Strengthens the default container agent template around `soul.md`:

- Adds an explicit **Soul and Identity** section to the default `system.md`.
- Documents the live path: `/home/agent/.config/term-llm/agents/{{AGENT_NAME}}/soul.md`.
- Explains that `agent.yaml` includes `soul.md`, so term-llm loads it every turn.
- Separates responsibilities:
  - `soul.md` = voice, values, tone, stance, boundaries
  - `system.md` = operational context and workflows
  - `memory/` = learned facts and retrievable state
  - `agent.yaml` = runtime config
- Adds `scripts/patch-soul.sh` so the prompt's self-modification guidance has a safe workflow for soul edits.
- Updates the bundled self skill and image asset test coverage.

## Why

Sam pointed out the default agent prompt did not clearly tell the agent how to treat `soul.md` or where it lives. That leaves the most important identity file under-specified: it exists and is included, but the agent is not taught the working contract.

OpenClaw is sharper here: its docs treat `SOUL.md` as the persona/tone/boundaries layer, injected into normal sessions, while warning not to turn it into a runbook, changelog, or wall of vibes. Hermes also seeds a default `SOUL.md`, stores it under the agent home, loads it as the identity slot, and treats profile cloning of `SOUL.md` as part of continuity.

This PR pulls the useful parts of both patterns into term-llm's default agent template without copying the whole OpenClaw workspace model.

## Notes from comparison

- **OpenClaw**
  - `SOUL.md` is a workspace bootstrap file.
  - Docs describe it as persona, boundaries, tone.
  - System prompt docs say it is routed to developer/system-level context depending on harness.
  - The personality guide is explicit: short beats long; keep operational rules elsewhere.

- **Hermes**
  - Seeds `~/.hermes/SOUL.md` on first run.
  - Loads it independently as the agent identity layer.
  - Profile clone/export behavior treats `SOUL.md` as continuity-bearing config.

## Verification

```text
go build ./...
go test ./...
```
