### PR TITLE
fix: Memory mining paginates long sessions with OFFSET, making reads degrade toward O(n²)

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -623,21 +623,24 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 	all := make([]session.Message, 0, memoryMineBatchSize)
 	result := memoryMineLoadResult{}
 
-	for {
+	// Mine from the last processed sequence so SQLite can seek on the
+	// (session_id, sequence) index instead of repeatedly rescanning with OFFSET.
+	msgs, err := store.GetMessagesFrom(ctx, candidate.Session.ID, offset)
+	if err != nil {
+		return result, err
+	}
+
+	for start := 0; start < len(msgs); {
 		limit := memoryMineBatchSize
 		if remaining > 0 && remaining < limit {
 			limit = remaining
 		}
-
-		msgs, err := store.GetMessages(ctx, candidate.Session.ID, limit, currentOffset)
-		if err != nil {
-			return result, err
+		if limit <= 0 || limit > len(msgs)-start {
+			limit = len(msgs) - start
 		}
-		if len(msgs) == 0 {
-			break
-		}
+		batch := msgs[start : start+limit]
 
-		for _, msg := range msgs {
+		for _, msg := range batch {
 			candidateMessages := append(cloneMessages(all), msg)
 			nextOffset := currentOffset + 1
 			fit, ok := fitMessagesForPromptBudget(candidate, offset, nextOffset, candidateMessages, taxonomyMap)
@@ -666,9 +669,7 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 			}
 		}
 
-		if len(msgs) < limit {
-			break
-		}
+		start += len(batch)
 	}
 
 	result.Messages = all

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -21,6 +21,22 @@ type fakeMemoryAgentFragmentStore struct {
 	getByKey  map[string]map[string]memorydb.Fragment
 }
 
+type memoryMiningSeekSpyStore struct {
+	session.Store
+	getMessagesCalls     int
+	getMessagesFromCalls []int
+}
+
+func (s *memoryMiningSeekSpyStore) GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
+	s.getMessagesCalls++
+	return s.Store.GetMessages(ctx, sessionID, limit, offset)
+}
+
+func (s *memoryMiningSeekSpyStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq int) ([]session.Message, error) {
+	s.getMessagesFromCalls = append(s.getMessagesFromCalls, fromSeq)
+	return s.Store.GetMessagesFrom(ctx, sessionID, fromSeq)
+}
+
 func (s *fakeMemoryAgentFragmentStore) ListFragments(ctx context.Context, opts memorydb.ListOptions) ([]memorydb.Fragment, error) {
 	s.listCalls++
 	fragments := s.listByKey[strings.TrimSpace(opts.Agent)]
@@ -349,6 +365,68 @@ func TestBuildTaxonomyMap_RespectsBudget(t *testing.T) {
 	}
 	if !strings.Contains(got, "total_fragments") {
 		t.Fatalf("taxonomy map missing summary: %s", got)
+	}
+}
+
+func TestLoadMessagesForMining_UsesSequenceSeekInsteadOfOffsetPagination(t *testing.T) {
+	ctx := context.Background()
+	sessStore, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer sessStore.Close()
+
+	sess := &session.Session{
+		ID:        session.NewID(),
+		Provider:  "test",
+		Model:     "test-model",
+		Mode:      session.ModeChat,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := sessStore.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		msg := session.NewMessage(sess.ID, llm.UserText("message body"), -1)
+		if err := sessStore.AddMessage(ctx, sess.ID, msg); err != nil {
+			t.Fatalf("AddMessage(%d): %v", i, err)
+		}
+	}
+
+	oldPromptMax := memoryMinePromptMaxTokens
+	oldBatchSize := memoryMineBatchSize
+	oldMaxMessages := memoryMineMaxMessages
+	memoryMinePromptMaxTokens = 10_000
+	memoryMineBatchSize = 2
+	memoryMineMaxMessages = 0
+	t.Cleanup(func() {
+		memoryMinePromptMaxTokens = oldPromptMax
+		memoryMineBatchSize = oldBatchSize
+		memoryMineMaxMessages = oldMaxMessages
+	})
+
+	candidate := memoryMineCandidate{
+		Summary: session.SessionSummary{Number: 1},
+		Session: sess,
+		Agent:   "jarvis",
+	}
+	spyStore := &memoryMiningSeekSpyStore{Store: sessStore}
+	loadResult, err := loadMessagesForMining(ctx, spyStore, candidate, 2, "Memory fragment map:\n- total_fragments: 0")
+	if err != nil {
+		t.Fatalf("loadMessagesForMining: %v", err)
+	}
+	if spyStore.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages calls = %d, want 0", spyStore.getMessagesCalls)
+	}
+	if len(spyStore.getMessagesFromCalls) != 1 || spyStore.getMessagesFromCalls[0] != 2 {
+		t.Fatalf("GetMessagesFrom calls = %v, want [2]", spyStore.getMessagesFromCalls)
+	}
+	if loadResult.NextOffset != 5 {
+		t.Fatalf("nextOffset = %d, want 5", loadResult.NextOffset)
+	}
+	if len(loadResult.Messages) != 3 {
+		t.Fatalf("messages loaded = %d, want 3", len(loadResult.Messages))
 	}
 }
 


### PR DESCRIPTION
## What

Change memory mining to load session messages from the last mined sequence with `GetMessagesFrom` instead of repeatedly calling `GetMessages(..., OFFSET ...)` as the offset grows.

Also add a regression test that verifies mining uses sequence-based reads rather than offset pagination.

## Why

The previous implementation re-ran `ORDER BY sequence ASC LIMIT ? OFFSET ?` for every batch and incremented the offset one message at a time. On long sessions that makes SQLite skip more and more rows on each batch, so catch-up mining work gets progressively slower and wastes database effort.

Using a sequence seek lets SQLite use the `(session_id, sequence)` index directly and keeps reads linear as sessions get larger.
