### PR TITLE
fix: Vector memory search scores every stored embedding blob on every query

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -132,6 +132,7 @@ CREATE TABLE IF NOT EXISTS memory_embeddings (
 );
 
 CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model_dimensions ON memory_embeddings(provider, model, dimensions);
+CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model_dimensions_embedded_at ON memory_embeddings(provider, model, dimensions, embedded_at DESC);
 
 CREATE TABLE IF NOT EXISTS memory_mining_state (
     session_id         TEXT PRIMARY KEY,
@@ -1180,6 +1181,11 @@ func (s *Store) GetFragmentsNeedingEmbedding(ctx context.Context, agent, provide
 	return out, nil
 }
 
+const (
+	vectorSearchRecentMultiplier = 256
+	vectorSearchRecentMinScan    = 2048
+)
+
 const vectorSearchSQL = `
 		SELECT e.fragment_id,
 		       f.updated_at,
@@ -1187,7 +1193,9 @@ const vectorSearchSQL = `
 		FROM memory_embeddings e
 		JOIN memory_fragments f ON f.id = e.fragment_id
 		WHERE e.provider = ? AND e.model = ? AND e.dimensions = ?
-		  AND (? = '' OR f.agent = ?)`
+		  AND (? = '' OR f.agent = ?)
+		ORDER BY e.embedded_at DESC
+		LIMIT ?`
 
 type vectorSearchCandidate struct {
 	id        string
@@ -1214,6 +1222,17 @@ func (h *vectorSearchCandidateHeap) Pop() any {
 	return item
 }
 
+func vectorSearchScanLimit(limit int) int {
+	scanLimit := limit * vectorSearchRecentMultiplier
+	if scanLimit < vectorSearchRecentMinScan {
+		scanLimit = vectorSearchRecentMinScan
+	}
+	if scanLimit < limit {
+		scanLimit = limit
+	}
+	return scanLimit
+}
+
 // VectorSearch performs a cosine similarity scan over embeddings matching provider, model, and dimensions.
 func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string, queryVec []float64, limit int) ([]ScoredFragment, error) {
 	if len(queryVec) == 0 {
@@ -1228,18 +1247,20 @@ func (s *Store) VectorSearch(ctx context.Context, agent, provider, model string,
 		limit = 24
 	}
 
+	agent = strings.TrimSpace(agent)
+	scanLimit := vectorSearchScanLimit(limit)
+
 	rows, err := s.db.QueryContext(ctx, vectorSearchSQL,
-		provider, model, len(queryVec), strings.TrimSpace(agent), strings.TrimSpace(agent))
+		provider, model, len(queryVec), agent, agent, scanLimit)
 	if err != nil {
 		return nil, fmt.Errorf("vector search query: %w", err)
 	}
 	defer rows.Close()
 
-	// Keep only the best candidates while scanning. The previous implementation
-	// selected every fragment column (including large content bodies), retained a
-	// ScoredFragment for every embedding, sorted the full slice, and then sliced
-	// to limit. Memory search normally asks for the top 24 candidates, so fetch
-	// heavyweight fragment rows only for those winners after scoring.
+	// Keep only the best candidates while scanning. VectorSearch is used for
+	// interactive memory retrieval, so bound the SQL scan to a generous recent
+	// window instead of rescoring every embedding blob for the model on every
+	// query. Fetch heavyweight fragment rows only for the winners after scoring.
 	top := make(vectorSearchCandidateHeap, 0, limit)
 	for rows.Next() {
 		var c vectorSearchCandidate

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -649,12 +649,12 @@ func TestStoreVectorSearchMixedBinaryAndLegacyJSON(t *testing.T) {
 	}
 }
 
-func TestStoreVectorSearchUsesProviderModelDimensionsIndex(t *testing.T) {
+func TestStoreVectorSearchUsesRecentEmbeddingIndex(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close()
 
 	rows, err := store.db.Query("EXPLAIN QUERY PLAN "+vectorSearchSQL,
-		"gemini", "gemini-embedding-001", 4, "jarvis", "jarvis")
+		"gemini", "gemini-embedding-001", 4, "jarvis", "jarvis", vectorSearchScanLimit(24))
 	if err != nil {
 		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
 	}
@@ -674,8 +674,11 @@ func TestStoreVectorSearchUsesProviderModelDimensionsIndex(t *testing.T) {
 	}
 
 	plan := strings.Join(details, "\n")
-	if !strings.Contains(plan, "idx_memory_embeddings_provider_model_dimensions") {
-		t.Fatalf("VectorSearch query plan does not use provider/model/dimensions index:\n%s", plan)
+	if !strings.Contains(plan, "idx_memory_embeddings_provider_model_dimensions_embedded_at") {
+		t.Fatalf("VectorSearch query plan does not use recent embedding index:\n%s", plan)
+	}
+	if strings.Contains(plan, "USE TEMP B-TREE FOR ORDER BY") {
+		t.Fatalf("VectorSearch query plan fell back to temp sort:\n%s", plan)
 	}
 }
 


### PR DESCRIPTION
## What

- bound `VectorSearch` to a generous recent embedding window instead of rescoring every embedding blob for the provider/model on every query
- order that window by `embedded_at DESC` and add a matching composite index so SQLite can satisfy the prefilter without a temp sort
- keep exact cosine scoring and top-N heap selection inside that bounded candidate set, with the existing fragment fetch-after-score behavior
- add a query-plan test that locks in use of the recent-embedding index

## Why

Vector memory search is used interactively and currently rescored every stored embedding for the selected model as the memory DB grows. On long-lived installs that makes retrieval steadily slower and more expensive even though callers usually only need the top ~24 candidates.

This change caps the amount of blob decoding and cosine work per query while preserving exact scoring within a large recent candidate window, which keeps memory retrieval responsive as the embedding corpus grows.
