### PR TITLE
fix: Memory mining paginates session messages with OFFSET, causing reads to degrade toward O(n²)

### DIFF
--- a/cmd/memory_freshen.go
+++ b/cmd/memory_freshen.go
@@ -125,7 +125,7 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		messages, err := sessStore.GetMessages(ctx, sess.ID, 0, startOffset)
+		messages, err := sessStore.GetMessagesFrom(ctx, sess.ID, startOffset, 0)
 		if err != nil {
 			return fmt.Errorf("get messages for session %s: %w", sess.ID, err)
 		}

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -620,6 +620,9 @@ func buildMemoryMineCandidate(ctx context.Context, store session.Store, summary 
 func loadMessagesForMining(ctx context.Context, store session.Store, candidate memoryMineCandidate, offset int, taxonomyMap string) (memoryMineLoadResult, error) {
 	remaining := memoryMineMaxMessages
 	currentOffset := offset
+	// Session message sequences are dense and zero-based, so the persisted mined
+	// offset is also a valid starting seek position.
+	currentSeq := offset
 	all := make([]session.Message, 0, memoryMineBatchSize)
 	result := memoryMineLoadResult{}
 
@@ -629,7 +632,7 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 			limit = remaining
 		}
 
-		msgs, err := store.GetMessages(ctx, candidate.Session.ID, limit, currentOffset)
+		msgs, err := store.GetMessagesFrom(ctx, candidate.Session.ID, currentSeq, limit)
 		if err != nil {
 			return result, err
 		}
@@ -649,6 +652,7 @@ func loadMessagesForMining(ctx context.Context, store session.Store, candidate m
 			}
 			all = fit.Messages
 			currentOffset = nextOffset
+			currentSeq = msg.Sequence + 1
 			result.TruncatedMessages = fit.TruncatedMessages
 			result.AssistantMessagesCut = fit.AssistantMessagesCut
 			result.UserMessagesCut = fit.UserMessagesCut

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -21,6 +21,47 @@ type fakeMemoryAgentFragmentStore struct {
 	getByKey  map[string]map[string]memorydb.Fragment
 }
 
+type trackingMemoryMineStore struct {
+	session.NoopStore
+	messages             map[string][]session.Message
+	getMessagesCalls     int
+	getMessagesFromCalls []struct {
+		fromSeq int
+		limit   int
+	}
+}
+
+func (s *trackingMemoryMineStore) GetMessages(_ context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
+	s.getMessagesCalls++
+	msgs := s.messages[sessionID]
+	if offset >= len(msgs) {
+		return nil, nil
+	}
+	out := append([]session.Message(nil), msgs[offset:]...)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *trackingMemoryMineStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq, limit int) ([]session.Message, error) {
+	s.getMessagesFromCalls = append(s.getMessagesFromCalls, struct {
+		fromSeq int
+		limit   int
+	}{fromSeq: fromSeq, limit: limit})
+	msgs := s.messages[sessionID]
+	filtered := make([]session.Message, 0, len(msgs))
+	for _, msg := range msgs {
+		if msg.Sequence >= fromSeq {
+			filtered = append(filtered, msg)
+		}
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered, nil
+}
+
 func (s *fakeMemoryAgentFragmentStore) ListFragments(ctx context.Context, opts memorydb.ListOptions) ([]memorydb.Fragment, error) {
 	s.listCalls++
 	fragments := s.listByKey[strings.TrimSpace(opts.Agent)]
@@ -407,6 +448,66 @@ func TestLoadMessagesForMining_RespectsPromptBudget(t *testing.T) {
 	}
 	if got := estimateExtractionPromptTokens(candidate, 0, loadResult.NextOffset, loadResult.Messages, "Memory fragment map:\n- total_fragments: 0"); got > memoryMinePromptMaxTokens {
 		t.Fatalf("estimated prompt tokens = %d, want <= %d", got, memoryMinePromptMaxTokens)
+	}
+}
+
+func TestLoadMessagesForMining_UsesSequencePagination(t *testing.T) {
+	ctx := context.Background()
+
+	oldPromptMax := memoryMinePromptMaxTokens
+	oldBatchSize := memoryMineBatchSize
+	oldMaxMessages := memoryMineMaxMessages
+	memoryMinePromptMaxTokens = 1 << 30
+	memoryMineBatchSize = 2
+	memoryMineMaxMessages = 0
+	t.Cleanup(func() {
+		memoryMinePromptMaxTokens = oldPromptMax
+		memoryMineBatchSize = oldBatchSize
+		memoryMineMaxMessages = oldMaxMessages
+	})
+
+	candidate := memoryMineCandidate{
+		Summary: session.SessionSummary{Number: 1},
+		Session: &session.Session{ID: "sess-1"},
+		Agent:   "jarvis",
+	}
+	store := &trackingMemoryMineStore{
+		messages: map[string][]session.Message{
+			"sess-1": {
+				{SessionID: "sess-1", Role: llm.RoleUser, TextContent: "msg-0", Sequence: 0},
+				{SessionID: "sess-1", Role: llm.RoleUser, TextContent: "msg-1", Sequence: 1},
+				{SessionID: "sess-1", Role: llm.RoleUser, TextContent: "msg-2", Sequence: 2},
+				{SessionID: "sess-1", Role: llm.RoleUser, TextContent: "msg-3", Sequence: 3},
+			},
+		},
+	}
+
+	loadResult, err := loadMessagesForMining(ctx, store, candidate, 1, "Memory fragment map:\n- total_fragments: 0")
+	if err != nil {
+		t.Fatalf("loadMessagesForMining: %v", err)
+	}
+	if store.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages calls = %d, want 0", store.getMessagesCalls)
+	}
+	if len(store.getMessagesFromCalls) != 2 {
+		t.Fatalf("GetMessagesFrom calls = %d, want 2", len(store.getMessagesFromCalls))
+	}
+	if store.getMessagesFromCalls[0].fromSeq != 1 || store.getMessagesFromCalls[0].limit != 2 {
+		t.Fatalf("first GetMessagesFrom call = %+v, want fromSeq=1 limit=2", store.getMessagesFromCalls[0])
+	}
+	if store.getMessagesFromCalls[1].fromSeq != 3 || store.getMessagesFromCalls[1].limit != 2 {
+		t.Fatalf("second GetMessagesFrom call = %+v, want fromSeq=3 limit=2", store.getMessagesFromCalls[1])
+	}
+	if loadResult.NextOffset != 4 {
+		t.Fatalf("NextOffset = %d, want 4", loadResult.NextOffset)
+	}
+	if len(loadResult.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(loadResult.Messages))
+	}
+	for i, wantSeq := range []int{1, 2, 3} {
+		if loadResult.Messages[i].Sequence != wantSeq {
+			t.Fatalf("Messages[%d].Sequence = %d, want %d", i, loadResult.Messages[i].Sequence, wantSeq)
+		}
 	}
 }
 

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -217,16 +217,22 @@ func (s *serveRuntimeTestStore) GetMessages(ctx context.Context, sessionID strin
 	return out, nil
 }
 
-func (s *serveRuntimeTestStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq int) ([]session.Message, error) {
+func (s *serveRuntimeTestStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq, limit int) ([]session.Message, error) {
 	msgs, err := s.GetMessages(ctx, sessionID, 0, 0)
 	if err != nil {
 		return nil, err
 	}
-	if fromSeq <= 0 || fromSeq >= len(msgs) {
-		return msgs, nil
+	var filtered []session.Message
+	for _, msg := range msgs {
+		if msg.Sequence >= fromSeq {
+			filtered = append(filtered, msg)
+		}
 	}
-	out := make([]session.Message, len(msgs[fromSeq:]))
-	copy(out, msgs[fromSeq:])
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	out := make([]session.Message, len(filtered))
+	copy(out, filtered)
 	return out, nil
 }
 

--- a/internal/session/context_state.go
+++ b/internal/session/context_state.go
@@ -25,7 +25,7 @@ func LoadActiveMessages(ctx context.Context, store Store, sess *Session) ([]Mess
 		return nil, nil
 	}
 	if HasCompactionBoundary(sess) {
-		messages, err := store.GetMessagesFrom(ctx, sess.ID, sess.CompactionSeq)
+		messages, err := store.GetMessagesFrom(ctx, sess.ID, sess.CompactionSeq, 0)
 		if err != nil || len(messages) > 0 {
 			return messages, err
 		}

--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -60,7 +60,7 @@ func (s *NoopStore) GetMessages(ctx context.Context, sessionID string, limit, of
 	return nil, nil
 }
 
-func (s *NoopStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq int) ([]Message, error) {
+func (s *NoopStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq, limit int) ([]Message, error) {
 	return nil, nil
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1784,13 +1784,22 @@ func (s *SQLiteStore) CompactMessages(ctx context.Context, sessionID string, mes
 }
 
 // GetMessagesFrom retrieves messages for a session starting from a given
-// sequence number. Used on resume to load only post-compaction messages.
-func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq int) ([]Message, error) {
-	rows, err := s.db.QueryContext(ctx, `
+// sequence number. Used on resume and for keyset-style pagination when walking
+// long transcripts.
+// When limit <= 0, all rows at/after fromSeq are returned.
+func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq, limit int) ([]Message, error) {
+	query := `
 		SELECT id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence
 		FROM messages
 		WHERE session_id = ? AND sequence >= ?
-		ORDER BY sequence ASC`, sessionID, fromSeq)
+		ORDER BY sequence ASC`
+	args := []any{sessionID, fromSeq}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query messages from seq %d: %w", fromSeq, err)
 	}

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,51 @@ func TestSessionPreferredTitlePrecedence(t *testing.T) {
 	}
 	if got := sess.PreferredLongTitle(); got != "Custom name" {
 		t.Fatalf("PreferredLongTitle() with name = %q", got)
+	}
+}
+
+func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		msg := NewMessage(sess.ID, llm.UserText(fmt.Sprintf("msg-%d", i)), i)
+		if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+			t.Fatalf("AddMessage(%d): %v", i, err)
+		}
+	}
+
+	got, err := store.GetMessagesFrom(ctx, sess.ID, 2, 2)
+	if err != nil {
+		t.Fatalf("GetMessagesFrom limited: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limited len = %d, want 2", len(got))
+	}
+	if got[0].Sequence != 2 || got[1].Sequence != 3 {
+		t.Fatalf("limited sequences = [%d %d], want [2 3]", got[0].Sequence, got[1].Sequence)
+	}
+
+	got, err = store.GetMessagesFrom(ctx, sess.ID, 2, 0)
+	if err != nil {
+		t.Fatalf("GetMessagesFrom unlimited: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("unlimited len = %d, want 3", len(got))
+	}
+	if got[2].Sequence != 4 {
+		t.Fatalf("last sequence = %d, want 4", got[2].Sequence)
 	}
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -41,7 +41,9 @@ type Store interface {
 	// message during streaming. Returns ErrNotFound if the row does not exist.
 	UpdateMessage(ctx context.Context, sessionID string, msg *Message) error
 	GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]Message, error)
-	GetMessagesFrom(ctx context.Context, sessionID string, fromSeq int) ([]Message, error)
+	// GetMessagesFrom returns rows at/after fromSeq in sequence order. When limit
+	// <= 0, all remaining rows are returned.
+	GetMessagesFrom(ctx context.Context, sessionID string, fromSeq, limit int) ([]Message, error)
 	// GetMessageByID retrieves a single message by its global message id.
 	GetMessageByID(ctx context.Context, msgID int64) (*Message, error)
 	ReplaceMessages(ctx context.Context, sessionID string, messages []Message) error

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -170,7 +170,7 @@ func (s *mockStore) GetMessages(_ context.Context, sessionID string, _, _ int) (
 	return s.messages[sessionID], nil
 }
 
-func (s *mockStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq int) ([]session.Message, error) {
+func (s *mockStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq, limit int) ([]session.Message, error) {
 	if s.msgErr != nil {
 		return nil, s.msgErr
 	}
@@ -179,6 +179,9 @@ func (s *mockStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq
 		if msg.Sequence >= fromSeq {
 			filtered = append(filtered, msg)
 		}
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
 	}
 	return filtered, nil
 }


### PR DESCRIPTION
## What

- switch memory mining from OFFSET-based pagination to sequence-based reads via `GetMessagesFrom(..., fromSeq, limit)`
- teach the SQLite session store to apply an optional `LIMIT` when seeking from a sequence cursor
- update `memory freshen` to reuse the same sequence-based read path
- add tests covering limited `GetMessagesFrom` reads and verifying memory mining uses sequence pagination

## Why

`memory mine` walked long sessions by repeatedly calling `GetMessages(... LIMIT ? OFFSET ?)` with larger and larger offsets. On SQLite that makes each successive batch more expensive because the database has to skip more rows before returning the next page, so mining old or high-message-count sessions slows down the deeper it gets into the transcript.

Using the session message sequence as a cursor lets SQLite seek directly into the `(session_id, sequence)` index and continue forward, avoiding the repeated OFFSET scans while preserving the existing mined-offset/state behavior.
