### PR TITLE
perf: avoid ANSI strip allocations in markdown render

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
@@ -230,7 +232,7 @@ func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansi
 			return "", err
 		}
 		label := styles.heading.Render(strings.Repeat("#", max(n.Level, 1)))
-		if strings.TrimSpace(stripANSI(inline)) == "" {
+		if !hasVisibleNonSpace(inline) {
 			return wrapANSI(label, width), nil
 		}
 		return wrapANSI(label+" "+inline, width), nil
@@ -239,7 +241,7 @@ func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansi
 		if err != nil {
 			return "", err
 		}
-		if strings.TrimSpace(stripANSI(inline)) == "" {
+		if !hasVisibleNonSpace(inline) {
 			return styles.text.Render(" "), nil
 		}
 		return wrapANSI(inline, width), nil
@@ -248,7 +250,7 @@ func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansi
 		if err != nil {
 			return "", err
 		}
-		if strings.TrimSpace(stripANSI(inline)) == "" {
+		if !hasVisibleNonSpace(inline) {
 			return styles.text.Render(" "), nil
 		}
 		return wrapANSI(inline, width), nil
@@ -257,7 +259,7 @@ func (r *ANSI) renderBlock(node gast.Node, source []byte, width int, styles ansi
 		if err != nil {
 			return "", err
 		}
-		if strings.TrimSpace(stripANSI(inner)) == "" {
+		if !hasVisibleNonSpace(inner) {
 			return styles.blockquote.Render(">"), nil
 		}
 		return prefixLinesWithStyle(inner, "> ", "> ", styles.blockquote), nil
@@ -461,7 +463,7 @@ func (r *ANSI) renderTableRecords(header []string, bodyRows [][]string, width in
 		}
 	}
 	for i := range labels {
-		if strings.TrimSpace(stripANSI(labels[i])) == "" {
+		if !hasVisibleNonSpace(labels[i]) {
 			labels[i] = styles.tableHeader.Render(fmt.Sprintf("Column %d", i+1))
 		}
 	}
@@ -655,7 +657,7 @@ func (r *ANSI) renderInline(node gast.Node, source []byte, styles ansiStyles) (s
 		if label == "" {
 			return styles.link.Render(url), nil
 		}
-		if strings.TrimSpace(stripANSI(label)) == url {
+		if ansiTrimmedEqual(label, url) {
 			return styles.link.Render(url), nil
 		}
 		return label + " " + styles.link.Render(url), nil
@@ -979,6 +981,79 @@ var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func stripANSI(text string) string {
 	return ansiEscapeRe.ReplaceAllString(text, "")
+}
+
+func hasVisibleNonSpace(text string) bool {
+	for i := 0; i < len(text); {
+		if next, ok := consumeSGR(text, i); ok {
+			i = next
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if !unicode.IsSpace(r) {
+			return true
+		}
+		i += size
+	}
+	return false
+}
+
+func ansiTrimmedEqual(text, target string) bool {
+	if strings.TrimSpace(target) != target {
+		return false
+	}
+
+	i := 0
+	for i < len(text) {
+		if next, ok := consumeSGR(text, i); ok {
+			i = next
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		i += size
+	}
+
+	targetPos := 0
+	for i < len(text) {
+		if next, ok := consumeSGR(text, i); ok {
+			i = next
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if targetPos >= len(target) {
+			if !unicode.IsSpace(r) {
+				return false
+			}
+			i += size
+			continue
+		}
+		if !strings.HasPrefix(target[targetPos:], text[i:i+size]) {
+			return false
+		}
+		targetPos += size
+		i += size
+	}
+	return targetPos == len(target)
+}
+
+func consumeSGR(text string, start int) (int, bool) {
+	if start+2 >= len(text) || text[start] != '\x1b' || text[start+1] != '[' {
+		return start, false
+	}
+	for i := start + 2; i < len(text); i++ {
+		switch text[i] {
+		case 'm':
+			return i + 1, true
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ';':
+			continue
+		default:
+			return start, false
+		}
+	}
+	return start, false
 }
 
 func bytesOrEmpty(v []byte) []byte {

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -483,6 +483,27 @@ func TestFitColumnWidths_FairShare(t *testing.T) {
 	}
 }
 
+func TestANSIVisibleTextHelpersIgnoreSGRAndWhitespace(t *testing.T) {
+	styledBlank := "\x1b[38;2;1;2;3m \t\n\x1b[0m"
+	if hasVisibleNonSpace(styledBlank) {
+		t.Fatalf("styled whitespace should not count as visible content")
+	}
+
+	styledText := "\x1b[38;5;10m hello \x1b[0m"
+	if !hasVisibleNonSpace(styledText) {
+		t.Fatalf("styled text should count as visible content")
+	}
+	if !ansiTrimmedEqual(styledText, "hello") {
+		t.Fatalf("styled trimmed text should equal plain target")
+	}
+	if ansiTrimmedEqual(styledText, "hell") {
+		t.Fatalf("styled trimmed text must not equal a shorter target")
+	}
+	if ansiTrimmedEqual(styledText, "hello ") {
+		t.Fatalf("styled trimmed text must preserve exact target whitespace semantics")
+	}
+}
+
 func readGolden(t *testing.T, name string) string {
 	t.Helper()
 	path := filepath.Join("testdata", name)


### PR DESCRIPTION
## What

- Replaced hot-path `strings.TrimSpace(stripANSI(...))` checks in the terminal markdown renderer with SGR-aware scanners that test visible content without materializing an ANSI-stripped copy.
- Kept `stripANSI` for the hard-wrap fallback that still needs a stripped string.
- Added coverage for styled whitespace/text and exact trimmed equality semantics.

## Why

Profiling `BenchmarkANSIRenderLargeNoTabs` showed `stripANSI`/regexp replacement was responsible for about 11.66% of allocation objects and 5.91% of allocated bytes while rendering visible markdown output. These checks run for headings, paragraphs, blockquotes, table labels, and link labels during streaming/terminal repaint paths.

## Evidence

Before:

```text
BenchmarkANSIRenderLargeNoTabs-32  475-524  2.342-2.416 ms/op  1,276,307-1,279,212 B/op  12,988-12,989 allocs/op
```

After:

```text
BenchmarkANSIRenderLargeNoTabs-32  620-654  1.869-1.878 ms/op  1,186,308-1,186,366 B/op  11,446-11,447 allocs/op
```

Representative improvement: ~21% faster, ~7% fewer allocated bytes, and ~12% fewer allocations for the benchmarked terminal markdown render path.

## Verification

- `gofmt -w internal/render/markdown/ansi.go internal/render/markdown/ansi_test.go`
- `go test ./internal/render/markdown`
- `go test ./internal/render/markdown -bench=. -benchmem -run '^$' -count=3`
- `go build ./...`
- `go test ./...`
