### PR TITLE
fix: unblock provider stream close during SSE reads

### DIFF
--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -340,7 +340,7 @@ func (p *OllamaProvider) Stream(ctx context.Context, req Request) (Stream, error
 		return nil, fmt.Errorf("Ollama API error (status %d): %s", resp.StatusCode, string(raw))
 	}
 
-	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
 		scanner := bufio.NewScanner(resp.Body)

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -553,7 +553,7 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	}
 
 	// Only create async stream for successful HTTP responses
-	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
 		reader := bufio.NewReader(resp.Body)

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -227,6 +227,79 @@ func TestOpenAICompatStream_HandlesMultiLineErrorEvent(t *testing.T) {
 	t.Fatal("expected EventError")
 }
 
+func TestOpenAICompatStream_CloseUnblocksPendingRead(t *testing.T) {
+	origClient := defaultHTTPClient
+	defer func() { defaultHTTPClient = origClient }()
+
+	chunk, err := json.Marshal(oaiChatResponse{
+		Choices: []oaiChoice{{
+			Delta: &oaiMessage{Content: "hello"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal chunk: %v", err)
+	}
+
+	bodyReader, bodyWriter := io.Pipe()
+	defer bodyReader.Close()
+	defer bodyWriter.Close()
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     make(http.Header),
+				Body:       bodyReader,
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	provider := NewOpenAICompatProvider("https://example.test/v1", "", "test-model", "Test")
+	stream, err := provider.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	sseChunk := append(append([]byte("data: "), chunk...), []byte("\n\n")...)
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := bodyWriter.Write(sseChunk)
+		writeDone <- err
+	}()
+
+	event, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv first event: %v", err)
+	}
+	if event.Type != EventTextDelta || event.Text != "hello" {
+		t.Fatalf("first event = %+v, want text delta %q", event, "hello")
+	}
+
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("write initial SSE chunk: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream goroutine did not consume the initial SSE chunk")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- stream.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("stream.Close() error = %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream.Close() blocked while the provider goroutine was waiting for more SSE bytes")
+	}
+}
+
 func TestOpenAICompatStream_CloseDoesNotHangWhenConsumerStopsReceiving(t *testing.T) {
 	chunk, err := json.Marshal(oaiChatResponse{
 		Choices: []oaiChoice{{

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -873,7 +873,7 @@ func (c *ResponsesClient) streamHTTPPrepared(ctx context.Context, httpPayload Re
 	client := c
 
 	// Create async stream for successful response
-	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
 		reader := bufio.NewReader(resp.Body)

--- a/internal/llm/stream.go
+++ b/internal/llm/stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 )
 
 // eventSender provides safe event sending for stream producers.
@@ -73,12 +74,22 @@ func safeSendEvent(ctx context.Context, ch chan<- Event, event Event) (sent bool
 type channelStream struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
+	cancelHook  func()
+	closeOnce   sync.Once
 	events      <-chan Event
 	terminalErr <-chan error
 	done        <-chan struct{}
 }
 
 func newEventStream(ctx context.Context, run func(context.Context, eventSender) error) Stream {
+	return newEventStreamWithCancelHook(ctx, nil, run)
+}
+
+// newEventStreamWithCancelHook is like newEventStream, with an extra hook
+// invoked by Close after canceling the stream context. Providers that create
+// blocking resources before the stream goroutine (for example, an HTTP response
+// body whose request used the parent context) can use the hook to unblock reads.
+func newEventStreamWithCancelHook(ctx context.Context, cancelHook func(), run func(context.Context, eventSender) error) Stream {
 	streamCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan Event, 16)
 	terminalErr := make(chan error, 1)
@@ -86,7 +97,7 @@ func newEventStream(ctx context.Context, run func(context.Context, eventSender) 
 	go func() {
 		defer close(done)
 		sender := eventSender{ctx: streamCtx, ch: ch}
-		if err := run(streamCtx, sender); err != nil {
+		if err := run(streamCtx, sender); err != nil && streamCtx.Err() == nil {
 			// If the consumer has stopped draining and the buffer is full, preserve the
 			// terminal error for Recv() rather than dropping it and reporting clean EOF.
 			select {
@@ -98,7 +109,7 @@ func newEventStream(ctx context.Context, run func(context.Context, eventSender) 
 		close(terminalErr)
 		close(ch)
 	}()
-	return &channelStream{ctx: streamCtx, cancel: cancel, events: ch, terminalErr: terminalErr, done: done}
+	return &channelStream{ctx: streamCtx, cancel: cancel, cancelHook: cancelHook, events: ch, terminalErr: terminalErr, done: done}
 }
 
 func (s *channelStream) Recv() (Event, error) {
@@ -131,7 +142,12 @@ func (s *channelStream) Recv() (Event, error) {
 }
 
 func (s *channelStream) Close() error {
-	s.cancel()
+	s.closeOnce.Do(func() {
+		s.cancel()
+		if s.cancelHook != nil {
+			s.cancelHook()
+		}
+	})
 	<-s.done
 	return nil
 }

--- a/internal/llm/venice.go
+++ b/internal/llm/venice.go
@@ -118,7 +118,7 @@ func (p *VeniceProvider) Stream(ctx context.Context, req Request) (Stream, error
 		return nil, fmt.Errorf("%s API error (status %d): %s", p.name, resp.StatusCode, string(body))
 	}
 
-	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
 		scanner := bufio.NewScanner(resp.Body)

--- a/internal/llm/xai.go
+++ b/internal/llm/xai.go
@@ -119,7 +119,7 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 		return nil, fmt.Errorf("xAI API error (status %d): %s", resp.StatusCode, string(body))
 	}
 
-	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
 		reader := bufio.NewReader(resp.Body)
@@ -275,7 +275,7 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 		return nil, fmt.Errorf("xAI Responses API error (status %d): %s", resp.StatusCode, string(body))
 	}
 
-	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
 		reader := bufio.NewReader(resp.Body)


### PR DESCRIPTION
## What

- Add a cancellable stream close hook to `newEventStream` so providers can unblock resources that were opened before the stream goroutine starts.
- Use that hook to close HTTP response bodies for OpenAI-compatible, Responses API HTTP, Venice, xAI, and Ollama streaming adapters when `Stream.Close()` is called.
- Suppress expected close-induced read errors after the stream context has already been canceled.
- Add a deterministic OpenAI-compatible regression test using `io.Pipe` to verify `stream.Close()` returns while the provider goroutine is blocked waiting for more SSE bytes.

## Why

Some HTTP/SSE adapters perform the initial request synchronously, then hand the already-open `resp.Body` to `newEventStream`. `Stream.Close()` previously only canceled the child stream context; it did not cancel the original HTTP request context or close the response body. If the stream goroutine was blocked in a body read waiting for more SSE bytes, `Close()` could wait indefinitely, adding avoidable latency/hangs during cancellation or early stream shutdown.

## Evidence

- Before the fix, the new regression scenario timed out after 500ms: `stream.Close() blocked while the provider goroutine was waiting for more SSE bytes`.
- After the fix: `go test ./internal/llm -run '^TestOpenAICompatStream_CloseUnblocksPendingRead$' -count=5` passes in 0.012s.
- Full verification: `go build ./...` and `go test ./...` pass.
