### PR TITLE
Add SambaNova Cloud as a built-in provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you already have a provider key:
 
 ```bash
 export ANTHROPIC_API_KEY=your-key
-# or OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY
+# or OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY / SAMBANOVA_API_KEY
 ```
 
 ## Read the docs

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -134,6 +134,13 @@ var builtinProviderMeta = map[string]struct {
 		supportsListModels: true,
 		description:        "Venice AI (private, uncensored inference — OpenAI-compatible)",
 	},
+	"sambanova": {
+		credential:         "api_key",
+		envVar:             "SAMBANOVA_API_KEY",
+		requiresKey:        true,
+		supportsListModels: true,
+		description:        "SambaNova Cloud (RDU-hosted inference — OpenAI-compatible)",
+	},
 	"ollama": {
 		credential:         "none",
 		envVar:             "",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ const (
 	ProviderTypeOpenAICompat ProviderType = "openai_compatible"
 	ProviderTypeXAI          ProviderType = "xai"
 	ProviderTypeVenice       ProviderType = "venice"
+	ProviderTypeSambaNova    ProviderType = "sambanova"
 	ProviderTypeBedrock      ProviderType = "bedrock"
 	ProviderTypeOllama       ProviderType = "ollama"
 )
@@ -46,6 +47,7 @@ var builtInProviderTypes = map[string]ProviderType{
 	"claude-bin": ProviderTypeClaudeBin,
 	"xai":        ProviderTypeXAI,
 	"venice":     ProviderTypeVenice,
+	"sambanova":  ProviderTypeSambaNova,
 	"bedrock":    ProviderTypeBedrock,
 	"ollama":     ProviderTypeOllama,
 }
@@ -903,6 +905,12 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 			cfg.ResolvedAPIKey = os.Getenv("VENICE_API_KEY")
 		}
 
+	case ProviderTypeSambaNova:
+		cfg.ResolvedAPIKey = expandEnv(cfg.APIKey)
+		if cfg.ResolvedAPIKey == "" {
+			cfg.ResolvedAPIKey = os.Getenv("SAMBANOVA_API_KEY")
+		}
+
 	case ProviderTypeBedrock:
 		// Expand env vars in non-lazy credential fields (skip $() which is resolved later)
 		if !needsLazyResolve(cfg.AccessKey) {
@@ -1043,6 +1051,8 @@ func DescribeCredentialSource(name string, cfg *ProviderConfig) (string, bool) {
 		return describeEnvKeyCredential(cfg, "XAI_API_KEY")
 	case ProviderTypeVenice:
 		return describeEnvKeyCredential(cfg, "VENICE_API_KEY")
+	case ProviderTypeSambaNova:
+		return describeEnvKeyCredential(cfg, "SAMBANOVA_API_KEY")
 	case ProviderTypeClaudeBin:
 		return "claude-bin CLI (no key needed)", true
 	case ProviderTypeChatGPT:

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -111,6 +111,13 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 			}
 			provider := NewVeniceProvider(apiKey, model)
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
+		case config.ProviderTypeSambaNova:
+			apiKey := strings.TrimSpace(os.Getenv("SAMBANOVA_API_KEY"))
+			if apiKey == "" {
+				return nil, fmt.Errorf("provider %q requires SAMBANOVA_API_KEY or explicit config", name)
+			}
+			provider := NewSambaNovaProvider(apiKey, model)
+			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		case config.ProviderTypeGemini:
 			// gemini can use GEMINI_API_KEY env var
 			apiKey := os.Getenv("GEMINI_API_KEY")
@@ -237,6 +244,12 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 				return nil, fmt.Errorf("provider %q requires VENICE_API_KEY environment variable or explicit config", cfg.DefaultProvider)
 			}
 			return NewVeniceProvider(apiKey, ""), nil
+		case config.ProviderTypeSambaNova:
+			apiKey := strings.TrimSpace(os.Getenv("SAMBANOVA_API_KEY"))
+			if apiKey == "" {
+				return nil, fmt.Errorf("provider %q requires SAMBANOVA_API_KEY environment variable or explicit config", cfg.DefaultProvider)
+			}
+			return NewSambaNovaProvider(apiKey, ""), nil
 		case config.ProviderTypeChatGPT:
 			// chatgpt uses native OAuth with interactive authentication
 			return NewChatGPTProvider("")
@@ -332,6 +345,16 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 			return nil, fmt.Errorf("provider %q requires VENICE_API_KEY or explicit config", name)
 		}
 		return NewVeniceProvider(apiKey, cfg.Model), nil
+
+	case config.ProviderTypeSambaNova:
+		apiKey := strings.TrimSpace(cfg.ResolvedAPIKey)
+		if apiKey == "" {
+			apiKey = strings.TrimSpace(os.Getenv("SAMBANOVA_API_KEY"))
+		}
+		if apiKey == "" {
+			return nil, fmt.Errorf("provider %q requires SAMBANOVA_API_KEY or explicit config", name)
+		}
+		return NewSambaNovaProvider(apiKey, cfg.Model), nil
 
 	case config.ProviderTypeBedrock:
 		return NewBedrockProvider(cfg.Model, cfg.Region, cfg.Profile, cfg.AccessKey, cfg.SecretKey, cfg.SessionToken, cfg.ModelMap)

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -276,6 +276,15 @@ var ProviderModels = map[string][]ModelEntry{
 		{ID: "nvidia-nemotron-3-nano-30b-a3b", InputLimit: 128_000, OutputLimit: 16_384},
 		{ID: "nvidia-nemotron-cascade-2-30b-a3b", InputLimit: 256_000, OutputLimit: 32_768},
 	},
+	"sambanova": {
+		// SambaCloud-hosted models on RDU. Limits per https://docs.sambanova.ai/cloud/docs/get-started/supported-models
+		{ID: "gpt-oss-120b", InputLimit: 131_072, OutputLimit: 8_192},
+		{ID: "DeepSeek-V3.1", InputLimit: 131_072, OutputLimit: 8_192},
+		{ID: "DeepSeek-V3.2", InputLimit: 131_072, OutputLimit: 8_192},
+		{ID: "Meta-Llama-3.3-70B-Instruct", InputLimit: 131_072, OutputLimit: 8_192},
+		{ID: "MiniMax-M2.5", InputLimit: 131_072, OutputLimit: 8_192},
+		{ID: "MiniMax-M2.7", InputLimit: 131_072, OutputLimit: 8_192},
+	},
 }
 
 // ProviderModelIDs returns just the model ID strings for a provider.
@@ -321,6 +330,7 @@ var ProviderFastModels = map[string]string{
 	"zen":        "minimax-m2.5-free",
 	"bedrock":    "claude-haiku-4-5",
 	"venice":     "llama-3.2-3b",
+	"sambanova":  "Meta-Llama-3.3-70B-Instruct",
 	"openrouter": "anthropic/claude-haiku-4-5",
 	"claude-bin": "haiku",
 	"ollama":     ollamaChatDefaultModel,
@@ -478,7 +488,7 @@ func SortModelIDsByPopularity(provider, defaultModel string, ids []string) []str
 
 // GetBuiltInProviderNames returns the built-in provider type names
 func GetBuiltInProviderNames() []string {
-	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice", "ollama"}
+	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice", "sambanova", "ollama"}
 }
 
 // GetProviderNames returns valid provider names from config plus built-in types.

--- a/internal/llm/sambanova.go
+++ b/internal/llm/sambanova.go
@@ -1,0 +1,41 @@
+package llm
+
+import (
+	"context"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+const sambaNovaBaseURL = "https://api.sambanova.ai/v1"
+
+type SambaNovaProvider struct {
+	*OpenAICompatProvider
+}
+
+func NewSambaNovaProvider(apiKey, model string) *SambaNovaProvider {
+	apiKey = config.NormalizeVeniceAPIKey(apiKey)
+	if model == "" {
+		model = "gpt-oss-120b"
+	}
+	return &SambaNovaProvider{OpenAICompatProvider: NewOpenAICompatProvider(sambaNovaBaseURL, apiKey, model, "SambaNova")}
+}
+
+func (p *SambaNovaProvider) Capabilities() Capabilities {
+	return Capabilities{
+		NativeWebSearch:    false,
+		NativeWebFetch:     false,
+		ToolCalls:          true,
+		SupportsToolChoice: true,
+	}
+}
+
+func (p *SambaNovaProvider) ListModels(ctx context.Context) ([]ModelInfo, error) {
+	models, err := p.OpenAICompatProvider.ListModels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range models {
+		models[i].InputLimit = InputLimitForProviderModel("sambanova", models[i].ID)
+	}
+	return models, nil
+}

--- a/internal/llm/sambanova_test.go
+++ b/internal/llm/sambanova_test.go
@@ -1,0 +1,132 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestNewProviderByName_ResolvesConfiguredSambaNovaCredentialsOnDemand(t *testing.T) {
+	t.Setenv("SAMBANOVA_API_KEY", "")
+
+	cfg := &config.Config{
+		DefaultProvider: "openai",
+		Providers: map[string]config.ProviderConfig{
+			"sambanova": {
+				APIKey: "  test-key\n",
+				Model:  "gpt-oss-120b",
+			},
+		},
+	}
+
+	provider, err := NewProviderByName(cfg, "sambanova", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected provider")
+	}
+	if got := strings.TrimSpace(cfg.Providers["sambanova"].ResolvedAPIKey); got != "test-key" {
+		t.Fatalf("ResolvedAPIKey = %q, want %q", got, "test-key")
+	}
+}
+
+func TestNewSambaNovaProviderTrimsAPIKey(t *testing.T) {
+	provider := NewSambaNovaProvider("  test-key\n", "")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
+func TestNewSambaNovaProviderStripsBearerPrefix(t *testing.T) {
+	provider := NewSambaNovaProvider("  Bearer test-key\n", "")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
+func TestNewSambaNovaProviderDefaultsModel(t *testing.T) {
+	provider := NewSambaNovaProvider("k", "")
+	if provider.model != "gpt-oss-120b" {
+		t.Fatalf("model = %q, want gpt-oss-120b", provider.model)
+	}
+}
+
+func TestCreateProviderFromConfig_SambaNovaRequiresAPIKey(t *testing.T) {
+	t.Setenv("SAMBANOVA_API_KEY", "")
+
+	_, err := createProviderFromConfig("sambanova", &config.ProviderConfig{Model: "gpt-oss-120b"})
+	if err == nil {
+		t.Fatal("expected missing SambaNova API key to return an error")
+	}
+	if !strings.Contains(err.Error(), "SAMBANOVA_API_KEY") {
+		t.Fatalf("expected SAMBANOVA_API_KEY guidance, got %v", err)
+	}
+}
+
+func TestCreateProviderFromConfig_SambaNovaTrimsConfiguredAPIKey(t *testing.T) {
+	t.Setenv("SAMBANOVA_API_KEY", "")
+
+	provider, err := createProviderFromConfig("sambanova", &config.ProviderConfig{
+		ResolvedAPIKey: "  test-key\n",
+		Model:          "gpt-oss-120b",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sn, ok := provider.(*SambaNovaProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *SambaNovaProvider", provider)
+	}
+	if sn.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", sn.apiKey, "test-key")
+	}
+}
+
+func TestSambaNovaProviderCapabilities(t *testing.T) {
+	provider := NewSambaNovaProvider("key", "")
+	caps := provider.Capabilities()
+	if caps.NativeWebSearch {
+		t.Fatal("expected NativeWebSearch=false")
+	}
+	if caps.NativeWebFetch {
+		t.Fatal("expected NativeWebFetch=false")
+	}
+	if !caps.ToolCalls {
+		t.Fatal("expected ToolCalls=true")
+	}
+	if !caps.SupportsToolChoice {
+		t.Fatal("expected SupportsToolChoice=true")
+	}
+}
+
+func TestSambaNovaProviderListModelsUsesProviderScopedLimits(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-oss-120b","object":"model","created":1,"owned_by":"sambanova"},{"id":"DeepSeek-V3.1","object":"model","created":1,"owned_by":"sambanova"}]}`))
+	}))
+	defer ts.Close()
+
+	provider := &SambaNovaProvider{OpenAICompatProvider: NewOpenAICompatProvider(ts.URL, "test-key", "gpt-oss-120b", "SambaNova")}
+	models, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("ListModels() returned %d models, want 2", len(models))
+	}
+	if models[0].InputLimit != 131_072 {
+		t.Fatalf("gpt-oss-120b InputLimit = %d, want 131072", models[0].InputLimit)
+	}
+	if models[1].InputLimit != 131_072 {
+		t.Fatalf("DeepSeek-V3.1 InputLimit = %d, want 131072", models[1].InputLimit)
+	}
+}

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -64,6 +64,12 @@ func detectAvailableProviders() []providerOption {
 			hint:      "set VENICE_API_KEY",
 		},
 		{
+			name:      "SambaNova - SAMBANOVA_API_KEY",
+			value:     "sambanova",
+			available: os.Getenv("SAMBANOVA_API_KEY") != "",
+			hint:      "set SAMBANOVA_API_KEY",
+		},
+		{
 			name:      "OpenRouter - OPENROUTER_API_KEY",
 			value:     "openrouter",
 			available: os.Getenv("OPENROUTER_API_KEY") != "",
@@ -206,6 +212,7 @@ func RunHeadlessSetup() (*config.Config, error) {
 			"codeassist": {Model: "gemini-3.1-pro"},
 			"xai":        {Model: "grok-4-20"},
 			"venice":     {Model: "minimax-m27"},
+			"sambanova":  {Model: "gpt-oss-120b"},
 			"zen":        {Model: "minimax-m2.5-free"},
 		},
 		Exec: config.ExecConfig{
@@ -384,6 +391,9 @@ func RunSetupWizard() (*config.Config, error) {
 			},
 			"venice": {
 				Model: "venice-uncensored",
+			},
+			"sambanova": {
+				Model: "gpt-oss-120b",
 			},
 			"zen": {
 				Model: "minimax-m2.1-free",


### PR DESCRIPTION
## Summary
- Adds **SambaNova Cloud** as a first-class built-in provider (RDU-hosted inference over the OpenAI-compatible API).
- Mirrors the existing Venice integration pattern across every surface area (factory, config, models registry, providers metadata, setup wizard, tests).
- A user can drop in `default_provider: sambanova` with only a model (or just `SAMBANOVA_API_KEY` in the environment) and term-llm wires everything else automatically — no `base_url`, no `type:`.

## What's included
- `internal/llm/sambanova.go` — `SambaNovaProvider` embedding `OpenAICompatProvider`. API key normalised (trim + Bearer-prefix strip) for parity with Venice. Default model `gpt-oss-120b`.
- `internal/config/config.go` — `ProviderTypeSambaNova` const, entry in `builtInProviderTypes`, credential resolution from `cfg.APIKey` / `${SAMBANOVA_API_KEY}`, credential-source description.
- `internal/llm/factory.go` — three switch sites (`NewProvider`, `NewProviderByName`, `createProviderFromConfig`).
- `internal/llm/models.go` — curated model list with `InputLimit`/`OutputLimit`, `ProviderFastModels["sambanova"]`, inclusion in `GetBuiltInProviderNames` so `--provider sambanova` parses without an explicit config block.
- `cmd/providers.go` — `builtinProviderMeta["sambanova"]` so `term-llm providers` lists it.
- `internal/ui/wizard.go` — wizard lists SambaNova as a selectable provider with a default model.
- `README.md` — `SAMBANOVA_API_KEY` mentioned alongside the other env-var hints.
- `internal/llm/sambanova_test.go` — 8 tests covering credential resolution, key normalisation, default model, capabilities, and provider-scoped input-limit lookup.

## Test plan
- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go test ./...` — full suite green
- [x] `go test ./internal/llm/ -run SambaNova -v` — 8/8 pass
- [x] Manual: `term-llm providers --builtin` lists `sambanova   SAMBANOVA_API_KEY (required)`
- [x] Manual: end-to-end `term-llm ask --provider sambanova` returns a real response from SambaCloud (verified with `gpt-oss-120b` and `DeepSeek-V3.1`).

## Notes
- Default model is `gpt-oss-120b` rather than a MiniMax variant, because not every SambaCloud account is entitled to the MiniMax tier (testing surfaced `422 Couldn't find valid service tier`). `gpt-oss-120b` is broadly available.
- No image/audio/video sub-package — SambaCloud is text-only today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)