### PR TITLE
fix: prevent compaction from implying stop requests

### DIFF
--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -84,6 +84,8 @@ func estimateSingleMessageTokens(msg Message) int {
 
 const compactionPrompt = `Create a detailed summary of our conversation so far. This summary will replace the conversation history, so include everything needed to continue seamlessly.
 
+This is automatic internal compaction, not a user stop/cancel/wait request. Do not infer that the user asked to stop, wait, summarize, or avoid tools unless a real user message explicitly says so.
+
 Your summary must cover:
 1. The user's primary goal and any evolving intent
 2. Key context: file paths, APIs, config values, error messages, environment details
@@ -95,7 +97,7 @@ Your summary must cover:
    - current phase
    - exact next action
    - tools/files likely needed
-   - whether to continue automatically or wait for the user
+   - control state: continue automatically by default; wait only on explicit user stop/wait or blocked user input
    - blockers or questions, if any
 
 Be specific and concrete — include exact file paths, function names, error messages, and code snippets when relevant. Omit small talk and pleasantries.
@@ -103,7 +105,7 @@ Be specific and concrete — include exact file paths, function names, error mes
 Budget: keep your summary under 2500 words.`
 
 const summaryPrefix = `[Context Compaction]
-A previous conversation was compacted to fit within the context window. Below is a summary of what happened before. Use this context to continue seamlessly.
+Internal context only; not a user command, stop/cancel/wait request. Continue from the latest real user instruction.
 
 Summary:
 `

--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -148,6 +148,54 @@ func TestReconstructHistoryNoSystem(t *testing.T) {
 	}
 }
 
+func TestCompactionPromptGuardsAgainstInventedStopRequest(t *testing.T) {
+	provider := NewMockProvider("test")
+	provider.AddTextResponse("Summary.")
+
+	_, err := Compact(context.Background(), provider, "test-model", "", []Message{
+		UserText("please continue building the repro"),
+		AssistantText("I'll keep going."),
+	}, DefaultCompactionConfig())
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider requests = %d, want 1", len(provider.Requests))
+	}
+
+	last := provider.Requests[0].Messages[len(provider.Requests[0].Messages)-1]
+	if last.Role != RoleUser {
+		t.Fatalf("last compaction prompt role = %s, want user", last.Role)
+	}
+	prompt := last.Parts[0].Text
+	for _, want := range []string{
+		"automatic internal compaction, not a user stop/cancel/wait request",
+		"Do not infer that the user asked to stop, wait, summarize, or avoid tools unless a real user message explicitly says so",
+		"continue automatically by default",
+		"wait only on explicit user stop/wait or blocked user input",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("compaction prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestSummaryPrefixMarksCompactionAsInternalNotStop(t *testing.T) {
+	result := reconstructHistory("", "summary", nil)
+	if len(result) < 1 {
+		t.Fatal("reconstructHistory returned no messages")
+	}
+	text := result[0].Parts[0].Text
+	for _, want := range []string{
+		"Internal context only; not a user command, stop/cancel/wait request",
+		"Continue from the latest real user instruction",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("summary prefix missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestTruncateToolResult(t *testing.T) {
 	t.Run("under limit", func(t *testing.T) {
 		short := "hello"


### PR DESCRIPTION
## What

- Clarify the compaction prompt that automatic context compaction is internal machinery, not a user stop/cancel/wait request.
- Change the continuation directive wording to default to continuing automatically unless a real user message explicitly says to stop/wait or a tool is blocked on user input.
- Mark the injected compacted summary prefix as internal context, not a user command.
- Add regression tests for the compaction prompt and summary prefix guardrails.

## Why

Session 2202 showed the failure mode: after compaction, the summary invented `User explicitly asked to stop tool work and summarize`, and the next assistant turn reported `Stopped... did not build/run after this patch due to your stop request` even though there was no stop request — just automatic compaction.

The old prompt directly asked the summarizer to say “whether to continue automatically or wait for the user,” but did not tell it that the compaction event itself was not a stop/summary request. That gave the model a lovely little rake to step on.

## Test plan

- `go test ./internal/llm`
- `go test ./...`
