### PR TITLE
Add NEAR AI Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you already have a provider key:
 
 ```bash
 export ANTHROPIC_API_KEY=your-key
-# or OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY / SAMBANOVA_API_KEY
+# or OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY / NEARAI_API_KEY / SAMBANOVA_API_KEY
 ```
 
 ## Read the docs

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -786,6 +786,10 @@ providers:
   venice:
     model: venice-uncensored
 
+  nearai:
+    model: zai-org/GLM-5.1-FP8
+    fast_model: Qwen/Qwen3.6-35B-A3B-FP8
+
   sambanova:
     model: gpt-oss-120b
     fast_model: Meta-Llama-3.3-70B-Instruct

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -28,6 +28,7 @@ Examples:
   term-llm models                       # list models from current provider
   term-llm models --provider anthropic  # list models from Anthropic
   term-llm models --provider openrouter # list models from OpenRouter
+  term-llm models --provider nearai     # list models from NEAR AI Cloud
   term-llm models --provider sambanova  # list models from SambaNova
   term-llm models --provider venice     # list models from Venice
   term-llm models --provider ollama     # list models from Ollama
@@ -38,7 +39,7 @@ Examples:
 
 func init() {
 	rootCmd.AddCommand(modelsCmd)
-	modelsCmd.Flags().StringVarP(&modelsProvider, "provider", "p", "", "Provider to list models from (anthropic, copilot, openrouter, sambanova, venice, xai, zen, ollama, lmstudio, openai-compat)")
+	modelsCmd.Flags().StringVarP(&modelsProvider, "provider", "p", "", "Provider to list models from (anthropic, copilot, openrouter, nearai, sambanova, venice, xai, zen, ollama, lmstudio, openai-compat)")
 	modelsCmd.Flags().BoolVar(&modelsJSON, "json", false, "Output as JSON")
 	modelsCmd.RegisterFlagCompletionFunc("provider", ProviderFlagCompletion)
 }
@@ -57,6 +58,7 @@ var modelListSupportedTypes = map[config.ProviderType]bool{
 	config.ProviderTypeZen:          true,
 	config.ProviderTypeXAI:          true,
 	config.ProviderTypeVenice:       true,
+	config.ProviderTypeNearAI:       true,
 	config.ProviderTypeSambaNova:    true,
 }
 
@@ -107,7 +109,7 @@ func runModels(cmd *cobra.Command, args []string) error {
 			return printStaticModels(providerName, staticModels)
 		}
 		return fmt.Errorf("provider '%s' (type: %s) does not support model listing.\n"+
-			"Model listing is supported for: anthropic, openai, openrouter, sambanova, xai, venice, zen, copilot, and openai_compatible providers", providerName, providerType)
+			"Model listing is supported for: anthropic, openai, openrouter, nearai, sambanova, xai, venice, zen, copilot, and openai_compatible providers", providerName, providerType)
 	}
 
 	// Create provider to query models
@@ -173,6 +175,12 @@ func runModels(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Venice API key not configured. Set VENICE_API_KEY or configure api_key")
 		}
 		lister = llm.NewVeniceProvider(apiKey, providerCfg.Model)
+	case config.ProviderTypeNearAI:
+		apiKey := providerCfg.ResolvedAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("NEARAI_API_KEY")
+		}
+		lister = llm.NewNearAIProvider(apiKey, providerCfg.Model)
 	case config.ProviderTypeSambaNova:
 		apiKey := providerCfg.ResolvedAPIKey
 		if apiKey == "" {
@@ -222,7 +230,7 @@ func runModels(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Available models from %s:\n\n", providerName)
 
 	// Only these providers return or have known pricing info
-	providerHasPricing := providerType == config.ProviderTypeOpenRouter || providerType == config.ProviderTypeZen || providerType == config.ProviderTypeSambaNova
+	providerHasPricing := providerType == config.ProviderTypeOpenRouter || providerType == config.ProviderTypeZen || providerType == config.ProviderTypeNearAI || providerType == config.ProviderTypeSambaNova
 
 	for _, m := range models {
 		if m.DisplayName != "" {

--- a/cmd/models_test.go
+++ b/cmd/models_test.go
@@ -12,6 +12,12 @@ func TestModelListSupportedTypesIncludesSambaNova(t *testing.T) {
 	}
 }
 
+func TestModelListSupportedTypesIncludesNearAI(t *testing.T) {
+	if !modelListSupportedTypes[config.ProviderTypeNearAI] {
+		t.Fatal("NEAR AI should be wired for dynamic model listing")
+	}
+}
+
 func TestBuiltinProviderMetaSambaNovaSupportsListModels(t *testing.T) {
 	meta, ok := builtinProviderMeta["sambanova"]
 	if !ok {
@@ -22,5 +28,18 @@ func TestBuiltinProviderMetaSambaNovaSupportsListModels(t *testing.T) {
 	}
 	if meta.envVar != "SAMBANOVA_API_KEY" {
 		t.Fatalf("SambaNova env var = %q, want SAMBANOVA_API_KEY", meta.envVar)
+	}
+}
+
+func TestBuiltinProviderMetaNearAISupportsListModels(t *testing.T) {
+	meta, ok := builtinProviderMeta["nearai"]
+	if !ok {
+		t.Fatal("NEAR AI provider metadata missing")
+	}
+	if !meta.supportsListModels {
+		t.Fatal("NEAR AI should advertise model listing support")
+	}
+	if meta.envVar != "NEARAI_API_KEY" {
+		t.Fatalf("NEAR AI env var = %q, want NEARAI_API_KEY", meta.envVar)
 	}
 }

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -134,6 +134,13 @@ var builtinProviderMeta = map[string]struct {
 		supportsListModels: true,
 		description:        "Venice AI (private, uncensored inference — OpenAI-compatible)",
 	},
+	"nearai": {
+		credential:         "api_key",
+		envVar:             "NEARAI_API_KEY",
+		requiresKey:        true,
+		supportsListModels: true,
+		description:        "NEAR AI Cloud (TEE-backed private inference — OpenAI-compatible)",
+	},
 	"sambanova": {
 		credential:         "api_key",
 		envVar:             "SAMBANOVA_API_KEY",

--- a/docs-site/content/getting-started/providers-and-setup.md
+++ b/docs-site/content/getting-started/providers-and-setup.md
@@ -9,7 +9,7 @@ next:
   label: Usage guide
   url: /guides/usage/
 ---
-On first run, term-llm will prompt you to choose a provider (Anthropic, AWS Bedrock, OpenAI, ChatGPT, GitHub Copilot, xAI, Venice, SambaNova, OpenRouter, Gemini, Gemini CLI, Zen, Claude Code (claude-bin), Ollama, or LM Studio).
+On first run, term-llm will prompt you to choose a provider (Anthropic, AWS Bedrock, OpenAI, ChatGPT, GitHub Copilot, xAI, Venice, NEAR AI Cloud, SambaNova, OpenRouter, Gemini, Gemini CLI, Zen, Claude Code (claude-bin), Ollama, or LM Studio).
 
 ### Option 1: Try it free with Zen
 
@@ -46,6 +46,9 @@ export XAI_API_KEY=your-key
 
 # For Venice
 export VENICE_API_KEY=your-key
+
+# For NEAR AI Cloud
+export NEARAI_API_KEY=your-key
 
 # For SambaNova Cloud
 export SAMBANOVA_API_KEY=your-key
@@ -142,7 +145,29 @@ term-llm ask --provider venice:qwen3-coder-480b-a35b-instruct "review this code"
 term-llm models --provider venice
 ```
 
-### Option 6: Use SambaNova Cloud
+### Option 6: Use NEAR AI Cloud
+
+[NEAR AI Cloud](https://cloud.near.ai) provides OpenAI-compatible TEE-backed private inference. Set `NEARAI_API_KEY` or put `api_key` under `providers.nearai`.
+
+```yaml
+# In ~/.config/term-llm/config.yaml
+default_provider: nearai
+
+providers:
+  nearai:
+    model: zai-org/GLM-5.1-FP8
+    fast_model: Qwen/Qwen3.6-35B-A3B-FP8
+```
+
+```bash
+term-llm ask --provider nearai "explain trusted execution environments"
+term-llm ask --provider nearai:Qwen/Qwen3.6-35B-A3B-FP8 "summarize this repository"
+term-llm models --provider nearai
+```
+
+`term-llm models --provider nearai` queries NEAR AI Cloud's public model catalog and shows chat-capable models with context windows and token prices when available.
+
+### Option 7: Use SambaNova Cloud
 
 [SambaNova Cloud](https://cloud.sambanova.ai/) provides fast OpenAI-compatible hosted inference on RDU hardware. Set `SAMBANOVA_API_KEY` or put `api_key` under `providers.sambanova`.
 
@@ -164,7 +189,7 @@ term-llm models --provider sambanova
 
 `term-llm models --provider sambanova` shows known SambaNova token prices when available. The bundled pricing table is synced from SambaNova's public pricing page.
 
-### Option 7: Use OpenRouter
+### Option 8: Use OpenRouter
 
 [OpenRouter](https://openrouter.ai) provides a unified OpenAI-compatible API across many models. term-llm sends attribution headers by default.
 
@@ -186,6 +211,7 @@ List available models from any supported provider:
 ```bash
 term-llm models --provider anthropic  # List Anthropic models
 term-llm models --provider openrouter # List OpenRouter models
+term-llm models --provider nearai     # List NEAR AI Cloud models
 term-llm models --provider sambanova  # List SambaNova models
 term-llm models --provider ollama     # List local Ollama models
 term-llm models --provider lmstudio   # List local LM Studio models
@@ -204,7 +230,7 @@ term-llm providers anthropic       # Show details for specific provider
 term-llm providers --json          # JSON output
 ```
 
-### Option 7: Use AWS Bedrock
+### Option 9: Use AWS Bedrock
 
 [AWS Bedrock](https://aws.amazon.com/bedrock/) provides access to Anthropic Claude models through your AWS account. This is useful for organizations that route AI usage through AWS billing, need VPC/PrivateLink access, or use application inference profiles for rate/cost management.
 
@@ -285,7 +311,7 @@ You can also pass raw Bedrock model IDs directly (e.g., `us.anthropic.claude-son
 | `model_map` | Map of friendly names to Bedrock model IDs or ARNs. |
 | `model` | Default model (friendly name, Bedrock ID, or ARN). |
 
-### Option 8: Use local LLMs (Ollama, LM Studio)
+### Option 10: Use local LLMs (Ollama, LM Studio)
 
 Run models locally with [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai):
 
@@ -354,7 +380,7 @@ providers:
 
 See [Providers and models](/reference/providers-and-models/#configuration-reference) for the full list of OpenAI-compatible provider options.
 
-### Option 9: Use Claude Code (claude-bin)
+### Option 11: Use Claude Code (claude-bin)
 
 If you have [Claude Code](https://claude.ai/code) installed and logged in, you can use the `claude-bin` provider to run completions via the [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk). This requires no API key - it uses Claude Code's existing authentication.
 
@@ -394,7 +420,7 @@ providers:
 - `providers.<name>.env` values support the same deferred resolution as other config values, including `file://...#json.path`, `op://...`, and `$()`
 - Works immediately if Claude Code is installed and logged in
 
-### Option 10: Use existing CLI credentials (gemini-cli)
+### Option 12: Use existing CLI credentials (gemini-cli)
 
 If you have [gemini-cli](https://github.com/google-gemini/gemini-cli) installed and logged in, term-llm can use those credentials directly:
 
@@ -416,7 +442,7 @@ OpenAI-compatible providers support two URL options:
 
 Use `url` when your endpoint doesn't follow the standard `/chat/completions` path, or to paste URLs directly from API documentation.
 
-### Option 11: Use GitHub Copilot
+### Option 13: Use GitHub Copilot
 
 If you have [GitHub Copilot](https://github.com/features/copilot) (free, Individual, or Business), you can use the `copilot` provider with OAuth device flow authentication:
 

--- a/docs-site/content/getting-started/quickstart.md
+++ b/docs-site/content/getting-started/quickstart.md
@@ -33,7 +33,7 @@ If you already use a provider directly, export its API key first:
 
 ```bash
 export ANTHROPIC_API_KEY=your-key
-# or OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY / SAMBANOVA_API_KEY
+# or OPENAI_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY / NEARAI_API_KEY / SAMBANOVA_API_KEY
 ```
 
 ## Try the core modes

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -53,6 +53,10 @@ providers:
   xai:
     model: grok-4-1-fast
 
+  nearai:
+    model: zai-org/GLM-5.1-FP8
+    fast_model: Qwen/Qwen3.6-35B-A3B-FP8
+
   sambanova:
     model: gpt-oss-120b
     fast_model: Meta-Llama-3.3-70B-Instruct

--- a/docs-site/content/reference/providers-and-models.md
+++ b/docs-site/content/reference/providers-and-models.md
@@ -17,6 +17,7 @@ term-llm providers anthropic
 
 term-llm models --provider anthropic
 term-llm models --provider openrouter
+term-llm models --provider nearai
 term-llm models --provider sambanova
 term-llm models --provider ollama
 term-llm models --json
@@ -28,7 +29,7 @@ Use `providers` when you want to know what is available and how it is configured
 
 term-llm supports a mix of provider types:
 
-- hosted API providers such as Anthropic, AWS Bedrock, OpenAI, xAI, Gemini, SambaNova, and OpenRouter
+- hosted API providers such as Anthropic, AWS Bedrock, OpenAI, xAI, Gemini, NEAR AI Cloud, SambaNova, and OpenRouter
 - subscription-backed OAuth providers such as ChatGPT, Copilot, and Gemini CLI
 - local or self-hosted OpenAI-compatible providers such as Ollama, LM Studio, vLLM, or custom endpoints
 
@@ -47,6 +48,7 @@ Most providers use API keys via environment variables. Some use OAuth credential
 | `gemini-cli` | `~/.gemini/oauth_creds.json` | gemini-cli OAuth |
 | `xai` | `XAI_API_KEY` | xAI API key |
 | `venice` | `VENICE_API_KEY` | Venice OpenAI-compatible API key |
+| `nearai` | `NEARAI_API_KEY` | NEAR AI Cloud OpenAI-compatible TEE inference key |
 | `sambanova` | `SAMBANOVA_API_KEY` | SambaNova Cloud OpenAI-compatible API key |
 | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter API key |
 | `zen` | `ZEN_API_KEY` optional | empty is valid for free tier |
@@ -94,6 +96,25 @@ providers:
 ```
 
 The provider uses `https://api.sambanova.ai/v1`, supports tool calls, and has a curated fallback model list. `term-llm models --provider sambanova` queries SambaNova's `/models` endpoint; because the OpenAI-compatible model response does not generally include price metadata, term-llm annotates known SambaNova models with bundled public prices from `https://cloud.sambanova.ai/plans/pricing`. These prices are also used by `term-llm usage` cost calculation for matching SambaNova model IDs.
+
+## NEAR AI Cloud
+
+NEAR AI Cloud is available as a built-in OpenAI-compatible provider for TEE-backed private inference:
+
+```bash
+export NEARAI_API_KEY=your-key
+term-llm ask --provider nearai:zai-org/GLM-5.1-FP8 "quick question"
+term-llm models --provider nearai
+```
+
+```yaml
+providers:
+  nearai:
+    model: zai-org/GLM-5.1-FP8
+    fast_model: Qwen/Qwen3.6-35B-A3B-FP8
+```
+
+The provider uses `https://cloud-api.near.ai/v1`, supports tool calls, and has a curated fallback list of TEE-hosted text models. `term-llm models --provider nearai` queries NEAR AI Cloud's public `/model/list` catalog and filters it to chat-capable models, with token prices shown per 1M tokens when available.
 
 ## OpenAI-compatible providers
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ const (
 	ProviderTypeOpenAICompat ProviderType = "openai_compatible"
 	ProviderTypeXAI          ProviderType = "xai"
 	ProviderTypeVenice       ProviderType = "venice"
+	ProviderTypeNearAI       ProviderType = "nearai"
 	ProviderTypeSambaNova    ProviderType = "sambanova"
 	ProviderTypeBedrock      ProviderType = "bedrock"
 	ProviderTypeOllama       ProviderType = "ollama"
@@ -47,6 +48,7 @@ var builtInProviderTypes = map[string]ProviderType{
 	"claude-bin": ProviderTypeClaudeBin,
 	"xai":        ProviderTypeXAI,
 	"venice":     ProviderTypeVenice,
+	"nearai":     ProviderTypeNearAI,
 	"sambanova":  ProviderTypeSambaNova,
 	"bedrock":    ProviderTypeBedrock,
 	"ollama":     ProviderTypeOllama,
@@ -905,6 +907,12 @@ func resolveProviderCredentials(name string, cfg *ProviderConfig) error {
 			cfg.ResolvedAPIKey = os.Getenv("VENICE_API_KEY")
 		}
 
+	case ProviderTypeNearAI:
+		cfg.ResolvedAPIKey = expandEnv(cfg.APIKey)
+		if cfg.ResolvedAPIKey == "" {
+			cfg.ResolvedAPIKey = os.Getenv("NEARAI_API_KEY")
+		}
+
 	case ProviderTypeSambaNova:
 		cfg.ResolvedAPIKey = expandEnv(cfg.APIKey)
 		if cfg.ResolvedAPIKey == "" {
@@ -1051,6 +1059,8 @@ func DescribeCredentialSource(name string, cfg *ProviderConfig) (string, bool) {
 		return describeEnvKeyCredential(cfg, "XAI_API_KEY")
 	case ProviderTypeVenice:
 		return describeEnvKeyCredential(cfg, "VENICE_API_KEY")
+	case ProviderTypeNearAI:
+		return describeEnvKeyCredential(cfg, "NEARAI_API_KEY")
 	case ProviderTypeSambaNova:
 		return describeEnvKeyCredential(cfg, "SAMBANOVA_API_KEY")
 	case ProviderTypeClaudeBin:
@@ -1601,6 +1611,8 @@ func GetDefaults() map[string]any {
 		"providers.xai.fast_model":        "grok-3-mini-fast",
 		"providers.venice.model":          "venice-uncensored",
 		"providers.venice.fast_model":     "llama-3.2-3b",
+		"providers.nearai.model":          "zai-org/GLM-5.1-FP8",
+		"providers.nearai.fast_model":     "Qwen/Qwen3.6-35B-A3B-FP8",
 		"providers.sambanova.model":       "gpt-oss-120b",
 		"providers.sambanova.fast_model":  "Meta-Llama-3.3-70B-Instruct",
 		"providers.openrouter.model":      "x-ai/grok-code-fast-1",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -317,6 +317,7 @@ func TestInferProviderType(t *testing.T) {
 		{"openai", "", ProviderTypeOpenAI},
 		{"gemini", "", ProviderTypeGemini},
 		{"openrouter", "", ProviderTypeOpenRouter},
+		{"nearai", "", ProviderTypeNearAI},
 		{"zen", "", ProviderTypeZen},
 		{"cerebras", "", ProviderTypeOpenAICompat},
 		{"groq", "", ProviderTypeOpenAICompat},
@@ -469,6 +470,22 @@ func TestGetDefaultsIncludeSambaNovaProviderModel(t *testing.T) {
 	}
 }
 
+func TestGetDefaultsIncludeNearAIProviderModel(t *testing.T) {
+	defaults := GetDefaults()
+
+	got, ok := defaults["providers.nearai.model"].(string)
+	if !ok || got != "zai-org/GLM-5.1-FP8" {
+		t.Fatalf("providers.nearai.model = %v, want zai-org/GLM-5.1-FP8", defaults["providers.nearai.model"])
+	}
+	fast, ok := defaults["providers.nearai.fast_model"].(string)
+	if !ok || fast != "Qwen/Qwen3.6-35B-A3B-FP8" {
+		t.Fatalf("providers.nearai.fast_model = %v, want Qwen/Qwen3.6-35B-A3B-FP8", defaults["providers.nearai.fast_model"])
+	}
+	if !IsKnownKey("providers.nearai.model") {
+		t.Fatal("providers.nearai.model should be a known key")
+	}
+}
+
 func TestDescribeCredentialSource_SambaNova(t *testing.T) {
 	t.Setenv("SAMBANOVA_API_KEY", "sn-env-key")
 
@@ -479,6 +496,19 @@ func TestDescribeCredentialSource_SambaNova(t *testing.T) {
 	}
 	if !strings.Contains(source, "SAMBANOVA_API_KEY") {
 		t.Fatalf("source = %q, want SAMBANOVA_API_KEY", source)
+	}
+}
+
+func TestDescribeCredentialSource_NearAI(t *testing.T) {
+	t.Setenv("NEARAI_API_KEY", "near-env-key")
+
+	cfg := &ProviderConfig{}
+	source, found := DescribeCredentialSource("nearai", cfg)
+	if !found {
+		t.Fatal("expected credential source")
+	}
+	if !strings.Contains(source, "NEARAI_API_KEY") {
+		t.Fatalf("source = %q, want NEARAI_API_KEY", source)
 	}
 }
 

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -111,6 +111,13 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 			}
 			provider := NewVeniceProvider(apiKey, model)
 			return WrapWithRetry(provider, DefaultRetryConfig()), nil
+		case config.ProviderTypeNearAI:
+			apiKey := strings.TrimSpace(os.Getenv("NEARAI_API_KEY"))
+			if apiKey == "" {
+				return nil, fmt.Errorf("provider %q requires NEARAI_API_KEY or explicit config", name)
+			}
+			provider := NewNearAIProvider(apiKey, model)
+			return WrapWithRetry(provider, DefaultRetryConfig()), nil
 		case config.ProviderTypeSambaNova:
 			apiKey := strings.TrimSpace(os.Getenv("SAMBANOVA_API_KEY"))
 			if apiKey == "" {
@@ -244,6 +251,12 @@ func newProviderInternal(cfg *config.Config) (Provider, error) {
 				return nil, fmt.Errorf("provider %q requires VENICE_API_KEY environment variable or explicit config", cfg.DefaultProvider)
 			}
 			return NewVeniceProvider(apiKey, ""), nil
+		case config.ProviderTypeNearAI:
+			apiKey := strings.TrimSpace(os.Getenv("NEARAI_API_KEY"))
+			if apiKey == "" {
+				return nil, fmt.Errorf("provider %q requires NEARAI_API_KEY environment variable or explicit config", cfg.DefaultProvider)
+			}
+			return NewNearAIProvider(apiKey, ""), nil
 		case config.ProviderTypeSambaNova:
 			apiKey := strings.TrimSpace(os.Getenv("SAMBANOVA_API_KEY"))
 			if apiKey == "" {
@@ -345,6 +358,16 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 			return nil, fmt.Errorf("provider %q requires VENICE_API_KEY or explicit config", name)
 		}
 		return NewVeniceProvider(apiKey, cfg.Model), nil
+
+	case config.ProviderTypeNearAI:
+		apiKey := strings.TrimSpace(cfg.ResolvedAPIKey)
+		if apiKey == "" {
+			apiKey = strings.TrimSpace(os.Getenv("NEARAI_API_KEY"))
+		}
+		if apiKey == "" {
+			return nil, fmt.Errorf("provider %q requires NEARAI_API_KEY or explicit config", name)
+		}
+		return NewNearAIProvider(apiKey, cfg.Model), nil
 
 	case config.ProviderTypeSambaNova:
 		apiKey := strings.TrimSpace(cfg.ResolvedAPIKey)

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -276,6 +276,16 @@ var ProviderModels = map[string][]ModelEntry{
 		{ID: "nvidia-nemotron-3-nano-30b-a3b", InputLimit: 128_000, OutputLimit: 16_384},
 		{ID: "nvidia-nemotron-cascade-2-30b-a3b", InputLimit: 256_000, OutputLimit: 32_768},
 	},
+	"nearai": {
+		// TEE-hosted text models synced from NEAR AI Cloud /model/list on 2026-05-21.
+		// Run `term-llm models --provider nearai` for the full live catalog.
+		{ID: "zai-org/GLM-5.1-FP8", InputLimit: 202_752},
+		{ID: "Qwen/Qwen3.6-35B-A3B-FP8", InputLimit: 262_144},
+		{ID: "Qwen/Qwen3-VL-30B-A3B-Instruct", InputLimit: 256_000},
+		{ID: "Qwen/Qwen3-30B-A3B-Instruct-2507", InputLimit: 262_144},
+		{ID: "openai/gpt-oss-120b", InputLimit: 131_000},
+		{ID: "google/gemma-4-31B-it", InputLimit: 262_144},
+	},
 	"sambanova": {
 		// SambaCloud-hosted models on RDU. Limits/prices synced from:
 		// https://docs.sambanova.ai/docs/en/models/sambacloud-models
@@ -299,6 +309,15 @@ type modelPricing struct {
 }
 
 var providerModelPricing = map[string]map[string]modelPricing{
+	"nearai": {
+		// Synced from https://cloud-api.near.ai/v1/model/list on 2026-05-21.
+		"zai-org/GLM-5.1-FP8":              {InputPrice: 0.85, OutputPrice: 3.30},
+		"Qwen/Qwen3.6-35B-A3B-FP8":         {InputPrice: 0.17, OutputPrice: 1.10},
+		"Qwen/Qwen3-VL-30B-A3B-Instruct":   {InputPrice: 0.15, OutputPrice: 0.55},
+		"Qwen/Qwen3-30B-A3B-Instruct-2507": {InputPrice: 0.15, OutputPrice: 0.55},
+		"openai/gpt-oss-120b":              {InputPrice: 0.15, OutputPrice: 0.55},
+		"google/gemma-4-31B-it":            {InputPrice: 0.13, OutputPrice: 0.40},
+	},
 	"sambanova": {
 		// Synced from https://cloud.sambanova.ai/plans/pricing on 2026-05-21.
 		"DeepSeek-R1-Distill-Llama-70B":      {InputPrice: 0.70, OutputPrice: 1.40},
@@ -368,6 +387,7 @@ var ProviderFastModels = map[string]string{
 	"zen":        "minimax-m2.5-free",
 	"bedrock":    "claude-haiku-4-5",
 	"venice":     "llama-3.2-3b",
+	"nearai":     "Qwen/Qwen3.6-35B-A3B-FP8",
 	"sambanova":  "Meta-Llama-3.3-70B-Instruct",
 	"openrouter": "anthropic/claude-haiku-4-5",
 	"claude-bin": "haiku",
@@ -526,7 +546,7 @@ func SortModelIDsByPopularity(provider, defaultModel string, ids []string) []str
 
 // GetBuiltInProviderNames returns the built-in provider type names
 func GetBuiltInProviderNames() []string {
-	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice", "sambanova", "ollama"}
+	return []string{"anthropic", "bedrock", "openai", "chatgpt", "copilot", "openrouter", "gemini", "gemini-cli", "zen", "claude-bin", "xai", "venice", "nearai", "sambanova", "ollama"}
 }
 
 // GetProviderNames returns valid provider names from config plus built-in types.

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -35,6 +35,18 @@ func TestProviderFastModelsUseLatestGPT54LightweightModels(t *testing.T) {
 	}
 }
 
+func TestProviderModelsIncludeNearAICloudDefaults(t *testing.T) {
+	if !containsModelID(ProviderModelIDs("nearai"), "zai-org/GLM-5.1-FP8") {
+		t.Fatalf("nearai models missing zai-org/GLM-5.1-FP8")
+	}
+	if got := ProviderFastModels["nearai"]; got != "Qwen/Qwen3.6-35B-A3B-FP8" {
+		t.Fatalf("ProviderFastModels[nearai] = %q, want Qwen/Qwen3.6-35B-A3B-FP8", got)
+	}
+	if input, output, ok := PricingForProviderModel("nearai", "zai-org/GLM-5.1-FP8"); !ok || input != 0.85 || output != 3.30 {
+		t.Fatalf("NEAR AI GLM pricing = %g/%g ok=%t, want 0.85/3.30 true", input, output, ok)
+	}
+}
+
 func TestProviderModelIDs(t *testing.T) {
 	ids := ProviderModelIDs("anthropic")
 	if len(ids) == 0 {

--- a/internal/llm/nearai.go
+++ b/internal/llm/nearai.go
@@ -1,0 +1,153 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+const nearAIBaseURL = "https://cloud-api.near.ai/v1"
+
+type NearAIProvider struct {
+	*OpenAICompatProvider
+}
+
+func NewNearAIProvider(apiKey, model string) *NearAIProvider {
+	apiKey = config.NormalizeVeniceAPIKey(apiKey)
+	if model == "" {
+		model = "zai-org/GLM-5.1-FP8"
+	}
+	return &NearAIProvider{OpenAICompatProvider: NewOpenAICompatProvider(nearAIBaseURL, apiKey, model, "NEAR AI")}
+}
+
+func (p *NearAIProvider) Capabilities() Capabilities {
+	return Capabilities{
+		NativeWebSearch:    false,
+		NativeWebFetch:     false,
+		ToolCalls:          true,
+		SupportsToolChoice: true,
+	}
+}
+
+func (p *NearAIProvider) ListModels(ctx context.Context) ([]ModelInfo, error) {
+	resp, err := p.makeRequest(ctx, "GET", "/model/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list NEAR AI models: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read NEAR AI models response: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("NEAR AI API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var catalog nearAIModelCatalog
+	if err := json.Unmarshal(body, &catalog); err != nil {
+		return nil, fmt.Errorf("failed to parse NEAR AI models response: %w", err)
+	}
+
+	models := make([]ModelInfo, 0, len(catalog.Models))
+	for _, m := range catalog.Models {
+		if !nearAIModelIsChat(m) {
+			continue
+		}
+		info := ModelInfo{
+			ID:          m.ModelID,
+			DisplayName: m.Metadata.ModelDisplayName,
+			OwnedBy:     m.Metadata.OwnedBy,
+			InputLimit:  m.Metadata.ContextLength,
+			InputPrice:  m.InputCostPerToken.perMillionTokens(),
+			OutputPrice: m.OutputCostPerToken.perMillionTokens(),
+		}
+		if info.InputLimit == 0 {
+			info.InputLimit = InputLimitForProviderModel("nearai", info.ID)
+		}
+		if inputPrice, outputPrice, ok := PricingForProviderModel("nearai", info.ID); ok {
+			if info.InputPrice < 0 {
+				info.InputPrice = inputPrice
+			}
+			if info.OutputPrice < 0 {
+				info.OutputPrice = outputPrice
+			}
+		}
+		models = append(models, info)
+	}
+	return models, nil
+}
+
+type nearAIModelCatalog struct {
+	Models []nearAIModel `json:"models"`
+}
+
+type nearAIModel struct {
+	ModelID            string              `json:"modelId"`
+	InputCostPerToken  nearAITokenPrice    `json:"inputCostPerToken"`
+	OutputCostPerToken nearAITokenPrice    `json:"outputCostPerToken"`
+	Metadata           nearAIModelMetadata `json:"metadata"`
+}
+
+type nearAITokenPrice struct {
+	Amount   float64 `json:"amount"`
+	Scale    int     `json:"scale"`
+	Currency string  `json:"currency"`
+}
+
+func (p nearAITokenPrice) perMillionTokens() float64 {
+	if p.Currency != "" && p.Currency != "USD" {
+		return -1
+	}
+	value := p.Amount * math.Pow10(6-p.Scale)
+	return math.Round(value*1_000_000) / 1_000_000
+}
+
+type nearAIModelMetadata struct {
+	ContextLength    int                     `json:"contextLength"`
+	ModelDisplayName string                  `json:"modelDisplayName"`
+	OwnedBy          string                  `json:"ownedBy"`
+	Architecture     nearAIModelArchitecture `json:"architecture"`
+}
+
+type nearAIModelArchitecture struct {
+	InputModalities  []string `json:"inputModalities"`
+	OutputModalities []string `json:"outputModalities"`
+}
+
+func nearAIModelIsChat(m nearAIModel) bool {
+	modelID := strings.TrimSpace(m.ModelID)
+	if modelID == "" {
+		return false
+	}
+	lowerID := strings.ToLower(modelID)
+	if strings.Contains(lowerID, "privacy-filter") || strings.Contains(lowerID, "reranker") {
+		return false
+	}
+
+	input := lowerStringSet(m.Metadata.Architecture.InputModalities)
+	output := lowerStringSet(m.Metadata.Architecture.OutputModalities)
+	if input["audio"] || output["embedding"] || output["image"] || output["score"] {
+		return false
+	}
+	if len(output) > 0 && !output["text"] {
+		return false
+	}
+	return true
+}
+
+func lowerStringSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			out[value] = true
+		}
+	}
+	return out
+}

--- a/internal/llm/nearai.go
+++ b/internal/llm/nearai.go
@@ -89,8 +89,8 @@ type nearAIModelCatalog struct {
 
 type nearAIModel struct {
 	ModelID            string              `json:"modelId"`
-	InputCostPerToken  nearAITokenPrice    `json:"inputCostPerToken"`
-	OutputCostPerToken nearAITokenPrice    `json:"outputCostPerToken"`
+	InputCostPerToken  *nearAITokenPrice   `json:"inputCostPerToken"`
+	OutputCostPerToken *nearAITokenPrice   `json:"outputCostPerToken"`
 	Metadata           nearAIModelMetadata `json:"metadata"`
 }
 
@@ -100,7 +100,10 @@ type nearAITokenPrice struct {
 	Currency string  `json:"currency"`
 }
 
-func (p nearAITokenPrice) perMillionTokens() float64 {
+func (p *nearAITokenPrice) perMillionTokens() float64 {
+	if p == nil || (p.Amount == 0 && p.Scale == 0 && p.Currency == "") {
+		return -1
+	}
 	if p.Currency != "" && p.Currency != "USD" {
 		return -1
 	}

--- a/internal/llm/nearai_test.go
+++ b/internal/llm/nearai_test.go
@@ -135,6 +135,14 @@ func TestNearAIProviderListModelsUsesCatalogEndpointAndFiltersNonChatModels(t *t
 					"metadata": {"contextLength": 131000, "modelDisplayName": "GPT OSS 120B", "ownedBy": "nearai"}
 				},
 				{
+					"modelId": "Qwen/Qwen3.6-35B-A3B-FP8",
+					"metadata": {"contextLength": 262144, "architecture": {"inputModalities": ["text"], "outputModalities": ["text"]}}
+				},
+				{
+					"modelId": "unknown/text-model",
+					"metadata": {"architecture": {"inputModalities": ["text"], "outputModalities": ["text"]}}
+				},
+				{
 					"modelId": "black-forest-labs/FLUX.2-klein-4B",
 					"inputCostPerToken": {"amount": 1000, "scale": 9, "currency": "USD"},
 					"outputCostPerToken": {"amount": 1000, "scale": 9, "currency": "USD"},
@@ -160,8 +168,8 @@ func TestNearAIProviderListModelsUsesCatalogEndpointAndFiltersNonChatModels(t *t
 	if err != nil {
 		t.Fatalf("ListModels() error = %v", err)
 	}
-	if len(models) != 2 {
-		t.Fatalf("ListModels() returned %d models, want 2: %#v", len(models), models)
+	if len(models) != 4 {
+		t.Fatalf("ListModels() returned %d models, want 4: %#v", len(models), models)
 	}
 	if models[0].ID != "zai-org/GLM-5.1-FP8" {
 		t.Fatalf("first model = %q, want zai-org/GLM-5.1-FP8", models[0].ID)
@@ -180,6 +188,18 @@ func TestNearAIProviderListModelsUsesCatalogEndpointAndFiltersNonChatModels(t *t
 	}
 	if !nearPriceEqual(models[1].InputPrice, 0.15) || !nearPriceEqual(models[1].OutputPrice, 0.55) {
 		t.Fatalf("gpt-oss pricing = %g/%g, want 0.15/0.55", models[1].InputPrice, models[1].OutputPrice)
+	}
+	if models[2].ID != "Qwen/Qwen3.6-35B-A3B-FP8" {
+		t.Fatalf("third model = %q, want Qwen/Qwen3.6-35B-A3B-FP8", models[2].ID)
+	}
+	if !nearPriceEqual(models[2].InputPrice, 0.17) || !nearPriceEqual(models[2].OutputPrice, 1.10) {
+		t.Fatalf("curated fallback pricing = %g/%g, want 0.17/1.10", models[2].InputPrice, models[2].OutputPrice)
+	}
+	if models[3].ID != "unknown/text-model" {
+		t.Fatalf("fourth model = %q, want unknown/text-model", models[3].ID)
+	}
+	if models[3].InputPrice != -1 || models[3].OutputPrice != -1 {
+		t.Fatalf("missing pricing = %g/%g, want -1/-1", models[3].InputPrice, models[3].OutputPrice)
 	}
 }
 

--- a/internal/llm/nearai_test.go
+++ b/internal/llm/nearai_test.go
@@ -1,0 +1,188 @@
+package llm
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestNewProviderByName_ResolvesConfiguredNearAICredentialsOnDemand(t *testing.T) {
+	t.Setenv("NEARAI_API_KEY", "")
+
+	cfg := &config.Config{
+		DefaultProvider: "openai",
+		Providers: map[string]config.ProviderConfig{
+			"nearai": {
+				APIKey: "  test-key\n",
+				Model:  "zai-org/GLM-5.1-FP8",
+			},
+		},
+	}
+
+	provider, err := NewProviderByName(cfg, "nearai", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected provider")
+	}
+	if got := strings.TrimSpace(cfg.Providers["nearai"].ResolvedAPIKey); got != "test-key" {
+		t.Fatalf("ResolvedAPIKey = %q, want %q", got, "test-key")
+	}
+}
+
+func TestNewNearAIProviderTrimsAPIKey(t *testing.T) {
+	provider := NewNearAIProvider("  test-key\n", "")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
+func TestNewNearAIProviderStripsBearerPrefix(t *testing.T) {
+	provider := NewNearAIProvider("  Bearer test-key\n", "")
+	if provider.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", provider.apiKey, "test-key")
+	}
+}
+
+func TestNewNearAIProviderDefaultsModel(t *testing.T) {
+	provider := NewNearAIProvider("k", "")
+	if provider.model != "zai-org/GLM-5.1-FP8" {
+		t.Fatalf("model = %q, want zai-org/GLM-5.1-FP8", provider.model)
+	}
+}
+
+func TestCreateProviderFromConfig_NearAIRequiresAPIKey(t *testing.T) {
+	t.Setenv("NEARAI_API_KEY", "")
+
+	_, err := createProviderFromConfig("nearai", &config.ProviderConfig{Model: "zai-org/GLM-5.1-FP8"})
+	if err == nil {
+		t.Fatal("expected missing NEAR AI API key to return an error")
+	}
+	if !strings.Contains(err.Error(), "NEARAI_API_KEY") {
+		t.Fatalf("expected NEARAI_API_KEY guidance, got %v", err)
+	}
+}
+
+func TestCreateProviderFromConfig_NearAITrimsConfiguredAPIKey(t *testing.T) {
+	t.Setenv("NEARAI_API_KEY", "")
+
+	provider, err := createProviderFromConfig("nearai", &config.ProviderConfig{
+		ResolvedAPIKey: "  test-key\n",
+		Model:          "zai-org/GLM-5.1-FP8",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	nearai, ok := provider.(*NearAIProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *NearAIProvider", provider)
+	}
+	if nearai.apiKey != "test-key" {
+		t.Fatalf("apiKey = %q, want %q", nearai.apiKey, "test-key")
+	}
+}
+
+func TestNearAIProviderCapabilities(t *testing.T) {
+	provider := NewNearAIProvider("key", "")
+	caps := provider.Capabilities()
+	if caps.NativeWebSearch {
+		t.Fatal("expected NativeWebSearch=false")
+	}
+	if caps.NativeWebFetch {
+		t.Fatal("expected NativeWebFetch=false")
+	}
+	if !caps.ToolCalls {
+		t.Fatal("expected ToolCalls=true")
+	}
+	if !caps.SupportsToolChoice {
+		t.Fatal("expected SupportsToolChoice=true")
+	}
+}
+
+func TestNearAIProviderListModelsUsesCatalogEndpointAndFiltersNonChatModels(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/model/list" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("Authorization = %q, want Bearer test-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"models": [
+				{
+					"modelId": "zai-org/GLM-5.1-FP8",
+					"inputCostPerToken": {"amount": 850, "scale": 9, "currency": "USD"},
+					"outputCostPerToken": {"amount": 3300, "scale": 9, "currency": "USD"},
+					"metadata": {
+						"contextLength": 202752,
+						"modelDisplayName": "GLM 5.1",
+						"ownedBy": "nearai",
+						"architecture": {"inputModalities": ["text"], "outputModalities": ["text"]}
+					}
+				},
+				{
+					"modelId": "openai/gpt-oss-120b",
+					"inputCostPerToken": {"amount": 150, "scale": 9, "currency": "USD"},
+					"outputCostPerToken": {"amount": 550, "scale": 9, "currency": "USD"},
+					"metadata": {"contextLength": 131000, "modelDisplayName": "GPT OSS 120B", "ownedBy": "nearai"}
+				},
+				{
+					"modelId": "black-forest-labs/FLUX.2-klein-4B",
+					"inputCostPerToken": {"amount": 1000, "scale": 9, "currency": "USD"},
+					"outputCostPerToken": {"amount": 1000, "scale": 9, "currency": "USD"},
+					"metadata": {"architecture": {"inputModalities": ["text"], "outputModalities": ["image"]}}
+				},
+				{
+					"modelId": "Qwen/Qwen3-Embedding-0.6B",
+					"metadata": {"architecture": {"inputModalities": ["text"], "outputModalities": ["embedding"]}}
+				},
+				{
+					"modelId": "openai/whisper-large-v3",
+					"metadata": {"architecture": {"inputModalities": ["audio"], "outputModalities": ["text"]}}
+				},
+				{"modelId": "Qwen/Qwen3-Reranker-0.6B"},
+				{"modelId": "openai/privacy-filter"}
+			]
+		}`))
+	}))
+	defer ts.Close()
+
+	provider := &NearAIProvider{OpenAICompatProvider: NewOpenAICompatProvider(ts.URL, "test-key", "zai-org/GLM-5.1-FP8", "NEAR AI")}
+	models, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("ListModels() returned %d models, want 2: %#v", len(models), models)
+	}
+	if models[0].ID != "zai-org/GLM-5.1-FP8" {
+		t.Fatalf("first model = %q, want zai-org/GLM-5.1-FP8", models[0].ID)
+	}
+	if models[0].DisplayName != "GLM 5.1" || models[0].OwnedBy != "nearai" {
+		t.Fatalf("first model metadata = %#v", models[0])
+	}
+	if models[0].InputLimit != 202_752 {
+		t.Fatalf("GLM InputLimit = %d, want 202752", models[0].InputLimit)
+	}
+	if !nearPriceEqual(models[0].InputPrice, 0.85) || !nearPriceEqual(models[0].OutputPrice, 3.30) {
+		t.Fatalf("GLM pricing = %g/%g, want 0.85/3.30", models[0].InputPrice, models[0].OutputPrice)
+	}
+	if models[1].ID != "openai/gpt-oss-120b" {
+		t.Fatalf("second model = %q, want openai/gpt-oss-120b", models[1].ID)
+	}
+	if !nearPriceEqual(models[1].InputPrice, 0.15) || !nearPriceEqual(models[1].OutputPrice, 0.55) {
+		t.Fatalf("gpt-oss pricing = %g/%g, want 0.15/0.55", models[1].InputPrice, models[1].OutputPrice)
+	}
+}
+
+func nearPriceEqual(got, want float64) bool {
+	return math.Abs(got-want) < 1e-9
+}

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -71,6 +71,12 @@ func detectAvailableProviders() []providerOption {
 			hint:      "set VENICE_API_KEY",
 		},
 		{
+			name:      "NEAR AI Cloud - NEARAI_API_KEY",
+			value:     "nearai",
+			available: os.Getenv("NEARAI_API_KEY") != "",
+			hint:      "set NEARAI_API_KEY",
+		},
+		{
 			name:      "SambaNova - SAMBANOVA_API_KEY",
 			value:     "sambanova",
 			available: os.Getenv("SAMBANOVA_API_KEY") != "",
@@ -238,6 +244,7 @@ func RunHeadlessSetup() (*config.Config, error) {
 			"codeassist": {Model: "gemini-3.1-pro"},
 			"xai":        {Model: "grok-4-20"},
 			"venice":     {Model: "minimax-m27"},
+			"nearai":     {Model: "zai-org/GLM-5.1-FP8"},
 			"sambanova":  {Model: "gpt-oss-120b"},
 			"zen":        {Model: "minimax-m2.5-free"},
 		},
@@ -425,6 +432,9 @@ func RunSetupWizard() (*config.Config, error) {
 			},
 			"venice": {
 				Model: "venice-uncensored",
+			},
+			"nearai": {
+				Model: "zai-org/GLM-5.1-FP8",
 			},
 			"sambanova": {
 				Model: "gpt-oss-120b",


### PR DESCRIPTION
## Summary

Adds NEAR AI Cloud as a built-in OpenAI-compatible provider.

- Adds the `nearai` provider type using `NEARAI_API_KEY` and `https://cloud-api.near.ai/v1`.
- Wires the provider into config defaults, provider discovery, the setup wizard, model listing, and documentation.
- Adds NEAR AI Cloud model catalog support via `/model/list`, including chat-model filtering, context windows, and token pricing metadata.

## Implementation Notes

This follows the repo's existing built-in OpenAI-compatible provider pattern. Chat completions and tool calls use the shared OpenAI-compatible transport, while model discovery uses NEAR AI Cloud's public catalog endpoint.

The model-listing path filters non-chat catalog entries such as image, embedding, audio, reranker, and privacy-filter models so the LLM provider surface only shows chat-capable models.

## Testing

- `gofmt -l .`
- `go build ./...`
- `go test ./...`
- `term-llm models --provider nearai --json`