### PR TITLE
fix: Stream consumption is intentionally stalled to one event per smooth-tick, causing upstream backpressure and delayed tool/done events

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1930,15 +1930,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// When a smooth tick is already pending for streamed text, defer the next
-		// blocking stream read until that tick so Bubble Tea can coalesce provider
-		// deltas into frame-paced updates.
+		// Keep dequeuing provider events immediately so tiny text deltas don't
+		// build backpressure behind a pending smooth render tick. Rendering is
+		// still coalesced by the smooth buffer/tick path above.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			if ev.Type == ui.StreamEventText && m.smoothTickPending {
-				m.deferredStreamRead = true
-			} else {
-				cmds = append(cmds, m.listenForStreamEvents())
-			}
+			cmds = append(cmds, m.listenForStreamEvents())
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -131,7 +132,7 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
+func TestModelKeepsStreamReadActiveWhileSmoothTickPending(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
 	model.streamChan = make(chan ui.StreamEvent)
@@ -143,16 +144,17 @@ func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if !model.deferredStreamRead {
-		t.Fatal("expected next stream read to be deferred until the smooth tick")
+	if model.deferredStreamRead {
+		t.Fatal("expected next stream read to continue immediately, not be deferred")
 	}
 
-	_, cmd = model.Update(ui.SmoothTickMsg{})
-	if model.deferredStreamRead {
-		t.Fatal("expected deferred stream read to clear after smooth tick")
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected text event to keep smooth tick and stream read scheduled, got %T", msg)
 	}
-	if cmd == nil {
-		t.Fatal("expected smooth tick to resume stream reading")
+	if len(batch) != 2 {
+		t.Fatalf("expected smooth tick and stream read commands, got %d", len(batch))
 	}
 }
 


### PR DESCRIPTION
## What

Stop deferring the next chat stream read behind a pending smooth tick. The chat TUI now keeps listening for the next provider event immediately after handling any non-terminal stream event, while still using the smooth buffer/tick path to coalesce visible text rendering. Updated the regression test to assert that streamed text keeps both the smooth tick and the follow-up stream read scheduled.

## Why

Deferring reads to one per smooth tick capped stream consumption at roughly one event every 16ms whenever providers emitted lots of tiny text deltas. That let backlog accumulate in the buffered adapter channel, eventually pushed back on the stream goroutine itself, and delayed tool start/end visibility plus final done transitions. Continuing to dequeue immediately removes that backpressure without giving up frame-paced rendering.
