### PR TITLE
fix: Streaming partial markdown reparses and re-renders the entire in-progress segment on every frame

### DIFF
--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -7,10 +7,21 @@ import (
 
 // partialState tracks the state of partial block rendering for re-rendering.
 type partialState struct {
-	safeMarkdown string // Markdown content up to incomplete syntax
-	safeRendered string // Rendered output currently displayed
-	lineCount    int    // Terminal lines occupied by partial output
-	outputLen    int    // Bytes already written (for flowing mode)
+	safeMarkdown     string // Markdown content up to incomplete syntax
+	safeRendered     string // Rendered output currently displayed
+	lineCount        int    // Terminal lines occupied by partial output
+	outputLen        int    // Bytes already written (for flowing mode)
+	flowingPrefix    []byte // Stable rendered prefix before the flowing partial block
+	flowingPrefixSet bool   // Whether flowingPrefix was derived for the active partial block
+}
+
+func (ps partialState) isZero() bool {
+	return ps.safeMarkdown == "" &&
+		ps.safeRendered == "" &&
+		ps.lineCount == 0 &&
+		ps.outputLen == 0 &&
+		len(ps.flowingPrefix) == 0 &&
+		!ps.flowingPrefixSet
 }
 
 // currentBlockContent returns the current incomplete block content
@@ -71,7 +82,7 @@ func (sr *StreamRenderer) renderPartialBlock() error {
 		}
 		sr.partialState.lineCount = sr.termCtrl.CountLines(rendered)
 	} else {
-		snapshot, err := sr.renderPartialSnapshot(safeContent)
+		snapshot, err := sr.renderPartialSnapshot(safeContent, rendered)
 		if err != nil {
 			return err
 		}
@@ -87,7 +98,18 @@ func (sr *StreamRenderer) renderPartialBlock() error {
 	return nil
 }
 
-func (sr *StreamRenderer) renderPartialSnapshot(safeContent string) ([]byte, error) {
+func (sr *StreamRenderer) renderPartialSnapshot(safeContent, renderedPartial string) ([]byte, error) {
+	if sr.partialState.flowingPrefixSet {
+		// After the first flowing preview for a block we know the exact rendered
+		// prefix before the partial content, so later token updates only need to
+		// re-render the active block instead of reparsing all committed markdown.
+		prefixLen := len(sr.partialState.flowingPrefix)
+		snapshot := make([]byte, prefixLen+len(renderedPartial))
+		copy(snapshot, sr.partialState.flowingPrefix)
+		copy(snapshot[prefixLen:], renderedPartial)
+		return snapshot, nil
+	}
+
 	markdown := append([]byte(nil), sr.normalizedMarkdown()...)
 	if sr.hasTabs {
 		markdown = append(markdown, bytes.ReplaceAll([]byte(safeContent), []byte("\t"), []byte("  "))...)
@@ -107,7 +129,22 @@ func (sr *StreamRenderer) renderPartialSnapshot(safeContent string) ([]byte, err
 		stableLen--
 	}
 
-	return rendered[:stableLen], nil
+	snapshot := rendered[:stableLen]
+	sr.cacheFlowingPartialPrefix(snapshot, renderedPartial)
+	return snapshot, nil
+}
+
+func (sr *StreamRenderer) cacheFlowingPartialPrefix(snapshot []byte, renderedPartial string) {
+	renderedPartialBytes := []byte(renderedPartial)
+	if !bytes.HasSuffix(snapshot, renderedPartialBytes) {
+		sr.partialState.flowingPrefix = nil
+		sr.partialState.flowingPrefixSet = false
+		return
+	}
+
+	prefixLen := len(snapshot) - len(renderedPartialBytes)
+	sr.partialState.flowingPrefix = append(sr.partialState.flowingPrefix[:0], snapshot[:prefixLen]...)
+	sr.partialState.flowingPrefixSet = true
 }
 
 // renderPartial renders safe content with appropriate context.
@@ -377,7 +414,7 @@ func (sr *StreamRenderer) clearPartialState() error {
 }
 
 func (sr *StreamRenderer) suppressPartialPreview() error {
-	if sr.partialState == (partialState{}) && bytes.Equal(sr.lastRendered, sr.lastCommittedRendered) {
+	if sr.partialState.isZero() && bytes.Equal(sr.lastRendered, sr.lastCommittedRendered) {
 		return nil
 	}
 

--- a/internal/ui/streaming/partial_test.go
+++ b/internal/ui/streaming/partial_test.go
@@ -279,6 +279,69 @@ func TestNewRendererWithOptionsFlowingMode(t *testing.T) {
 	}
 }
 
+type countingRenderer struct {
+	inputs [][]byte
+}
+
+func (r *countingRenderer) Render(source []byte) ([]byte, error) {
+	r.inputs = append(r.inputs, append([]byte(nil), source...))
+	return append([]byte(nil), source...), nil
+}
+
+func (r *countingRenderer) Resize(width int) {}
+
+func TestPartialRenderingFlowingModeCachesCommittedPrefixPerBlock(t *testing.T) {
+	var buf bytes.Buffer
+	renderer := &countingRenderer{}
+
+	sr, err := NewRendererWithOptions(
+		&buf,
+		renderer,
+		[]StreamRendererOption{
+			WithPartialRendering(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRendererWithOptions failed: %v", err)
+	}
+
+	if _, err := sr.Write([]byte("Intro\n\n")); err != nil {
+		t.Fatalf("failed to write committed block: %v", err)
+	}
+
+	renderer.inputs = nil
+
+	if _, err := sr.Write([]byte("Hello")); err != nil {
+		t.Fatalf("failed to write first partial chunk: %v", err)
+	}
+
+	if len(renderer.inputs) != 2 {
+		t.Fatalf("first partial update render count = %d, want 2", len(renderer.inputs))
+	}
+	if got := string(renderer.inputs[0]); got != "Hello" {
+		t.Fatalf("first partial block render input = %q, want %q", got, "Hello")
+	}
+	if got := string(renderer.inputs[1]); got != "Intro\n\nHello" {
+		t.Fatalf("first flowing snapshot render input = %q, want %q", got, "Intro\n\nHello")
+	}
+
+	renderer.inputs = nil
+
+	if _, err := sr.Write([]byte(" world")); err != nil {
+		t.Fatalf("failed to write second partial chunk: %v", err)
+	}
+
+	if len(renderer.inputs) != 1 {
+		t.Fatalf("second partial update render count = %d, want 1", len(renderer.inputs))
+	}
+	if got := string(renderer.inputs[0]); got != "Hello world" {
+		t.Fatalf("second partial block render input = %q, want %q", got, "Hello world")
+	}
+	if got := buf.String(); got != "Intro\n\nHello world" {
+		t.Fatalf("flowing output = %q, want %q", got, "Intro\n\nHello world")
+	}
+}
+
 func TestPartialRenderingBackwardsCompatibility(t *testing.T) {
 	// Test that the basic NewRenderer still works without partial rendering
 	var buf bytes.Buffer


### PR DESCRIPTION
## What

- stop full-document markdown re-renders on every flowing partial update once a block preview is established
- cache the stable rendered prefix before the active partial block and reuse it for later token updates in the same block
- add a regression test that verifies flowing partial updates stop calling the renderer with committed markdown on every frame

## Why

`TextSegmentRenderer` uses flowing partial rendering on the Bubble Tea path, and every token update was rebuilding a synthetic markdown document from all committed content plus the current safe partial block. That made streaming work scale with already-rendered history and caused visible jank as responses grew.

This keeps the first flowing partial render exact, then reuses its stable prefix so subsequent updates only re-render the active block instead of reparsing committed markdown on every frame.
