### PR TITLE
fix: Streaming partial markdown reparses and re-renders the entire in-progress segment on every smooth tick

### DIFF
--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -29,8 +29,8 @@ func (sr *StreamRenderer) currentBlockContent() string {
 // renderPartialBlock renders safe content from an incomplete block.
 // In altscreen mode (with termCtrl), it clears and re-renders the partial block
 // in place. For resettable flowing outputs (like TextSegmentRenderer's buffer),
-// it rewrites the full rendered snapshot so View() can show token-by-token text
-// without terminal cursor control.
+// it renders the partial block once and then reuses the previously-rendered
+// prefix so smooth ticks don't have to re-render the full committed snapshot.
 func (sr *StreamRenderer) renderPartialBlock() error {
 	content := sr.currentBlockContent()
 	if len(content) == 0 {
@@ -71,7 +71,7 @@ func (sr *StreamRenderer) renderPartialBlock() error {
 		}
 		sr.partialState.lineCount = sr.termCtrl.CountLines(rendered)
 	} else {
-		snapshot, err := sr.renderPartialSnapshot(safeContent)
+		snapshot, err := sr.renderFlowingPartialSnapshot(safeContent, rendered)
 		if err != nil {
 			return err
 		}
@@ -85,6 +85,26 @@ func (sr *StreamRenderer) renderPartialBlock() error {
 	sr.partialState.safeMarkdown = safeContent
 	sr.partialState.safeRendered = rendered
 	return nil
+}
+
+// renderFlowingPartialSnapshot reuses the already-rendered committed prefix once
+// the first flowing preview for a block has established the correct join between
+// committed content and the active partial block.
+func (sr *StreamRenderer) renderFlowingPartialSnapshot(safeContent, rendered string) ([]byte, error) {
+	if sr.partialState.safeMarkdown != "" && bytes.HasSuffix(sr.lastRendered, []byte(sr.partialState.safeRendered)) {
+		prefixLen := len(sr.lastRendered) - len(sr.partialState.safeRendered)
+		snapshot := make([]byte, 0, prefixLen+len(rendered))
+		snapshot = append(snapshot, sr.lastRendered[:prefixLen]...)
+		snapshot = append(snapshot, rendered...)
+		return snapshot, nil
+	}
+
+	snapshot, err := sr.renderPartialSnapshot(safeContent)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot, nil
 }
 
 func (sr *StreamRenderer) renderPartialSnapshot(safeContent string) ([]byte, error) {

--- a/internal/ui/streaming/partial_test.go
+++ b/internal/ui/streaming/partial_test.go
@@ -473,6 +473,97 @@ func TestPartialRendering_CompleteBoldThenIncomplete(t *testing.T) {
 	}
 }
 
+type recordingRenderer struct {
+	calls [][]byte
+}
+
+func (r *recordingRenderer) Render(source []byte) ([]byte, error) {
+	r.calls = append(r.calls, append([]byte(nil), source...))
+	return append([]byte(nil), source...), nil
+}
+
+func (*recordingRenderer) Resize(int) {}
+
+func (r *recordingRenderer) resetCalls() {
+	r.calls = nil
+}
+
+func TestFlowingPartialPreviewAvoidsFullSnapshotRerenderAfterFirstTick(t *testing.T) {
+	var buf bytes.Buffer
+	renderer := &recordingRenderer{}
+
+	sr, err := NewRendererWithOptions(
+		&buf,
+		renderer,
+		[]StreamRendererOption{WithPartialRendering()},
+	)
+	if err != nil {
+		t.Fatalf("NewRendererWithOptions failed: %v", err)
+	}
+
+	if _, err := sr.Write([]byte("# Title\n\n")); err != nil {
+		t.Fatalf("Write committed block failed: %v", err)
+	}
+
+	renderer.resetCalls()
+	if _, err := sr.Write([]byte("Hello")); err != nil {
+		t.Fatalf("Write first partial failed: %v", err)
+	}
+
+	renderer.resetCalls()
+	if _, err := sr.Write([]byte(" world")); err != nil {
+		t.Fatalf("Write second partial failed: %v", err)
+	}
+
+	if len(renderer.calls) != 1 {
+		var calls []string
+		for _, call := range renderer.calls {
+			calls = append(calls, string(call))
+		}
+		t.Fatalf("expected only the current partial block to be re-rendered, got %d render calls: %q", len(renderer.calls), calls)
+	}
+	if got := string(renderer.calls[0]); got != "Hello world" {
+		t.Fatalf("expected only the current partial markdown to be rendered, got %q", got)
+	}
+	if got := buf.String(); got != "# Title\n\nHello world" {
+		t.Fatalf("buffer = %q, want %q", got, "# Title\n\nHello world")
+	}
+}
+
+func TestFlowingPartialPreviewMatchesFullRenderAcrossUpdates(t *testing.T) {
+	var buf bytes.Buffer
+
+	sr, err := NewRendererWithOptions(
+		&buf,
+		newTestMarkdownRenderer(testRenderWidth),
+		[]StreamRendererOption{WithPartialRendering()},
+	)
+	if err != nil {
+		t.Fatalf("NewRendererWithOptions failed: %v", err)
+	}
+
+	input := "# Title\n\nThis is the first paragraph"
+	for _, chunk := range []string{"# Title\n\n", "This is the first ", "paragraph"} {
+		if _, err := sr.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write(%q) failed: %v", chunk, err)
+		}
+	}
+
+	want, err := newTestMarkdownRenderer(testRenderWidth).Render([]byte(input))
+	if err != nil {
+		t.Fatalf("direct render failed: %v", err)
+	}
+	want = normalizeNewlines(want)
+	stableLen := len(want)
+	for stableLen > 0 && want[stableLen-1] == '\n' {
+		stableLen--
+	}
+
+	if got := buf.String(); got != string(want[:stableLen]) {
+		t.Fatalf("partial preview mismatch\nwant: %q\ngot:  %q", string(want[:stableLen]), got)
+	}
+}
+
 // stripAnsiHelper removes ANSI escape sequences for test assertions.
 // Note: can't use ui.StripANSI here because ui imports streaming (circular).
 func stripAnsiHelper(s string) string {


### PR DESCRIPTION
## What

- avoid re-rendering the full committed markdown snapshot on every flowing partial-preview tick
- reuse the already-rendered committed prefix after the first partial preview for a block, and only re-render the current partial block on subsequent updates
- add regression coverage for both the reduced render behavior and parity with full rendering across partial updates

## Why

Streaming assistant responses were reparsing and re-rendering all committed markdown plus the active partial block on every smooth tick. As segments grew, each token frame became progressively more expensive and streaming could visibly stutter. Reusing the stable rendered prefix keeps the common path bounded to the active partial block while preserving output correctness.