### PR TITLE
fix: The UI only dequeues one stream event per frame, creating avoidable backlog and upstream backpressure

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -88,7 +88,6 @@ type Model struct {
 	// Smooth text buffer for 60fps rendering
 	smoothBuffer            *ui.SmoothBuffer
 	smoothTickPending       bool
-	deferredStreamRead      bool
 	streamRenderTickPending bool
 	newlineCompactor        *ui.StreamingNewlineCompactor
 
@@ -1421,10 +1420,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmds = append(cmds, ui.SmoothTick())
 				}
 			}
-			if m.deferredStreamRead && m.streaming {
-				m.deferredStreamRead = false
-				cmds = append(cmds, m.listenForStreamEvents())
-			}
 			if m.streamPerf != nil {
 				m.streamPerf.RecordSmoothTickHandled(hadWords, m.smoothBuffer.Len())
 				m.streamPerf.RecordDuration(durationMetricSmoothTick, time.Since(tickStart))
@@ -1454,7 +1449,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.smoothBuffer.Reset()
 				}
 				m.smoothTickPending = false
-				m.deferredStreamRead = false
 				// This resets local scheduling state for the next stream.
 				// An already in-flight render tick may still arrive and no-op.
 				m.streamRenderTickPending = false
@@ -1653,7 +1647,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.smoothBuffer.Reset()
 			}
 			m.smoothTickPending = false
-			m.deferredStreamRead = false
 			m.streamRenderTickPending = false
 			if m.tracker != nil {
 				m.tracker.DiscardAttempt()
@@ -1871,7 +1864,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.newlineCompactor = nil
 			m.smoothTickPending = false
-			m.deferredStreamRead = false
 			// This resets local scheduling state for the next stream.
 			// An already in-flight render tick may still arrive and no-op.
 			m.streamRenderTickPending = false
@@ -1930,15 +1922,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Continue listening for more events unless we're done or got an error.
-		// When a smooth tick is already pending for streamed text, defer the next
-		// blocking stream read until that tick so Bubble Tea can coalesce provider
-		// deltas into frame-paced updates.
+		// Keep draining the provider stream immediately even when text rendering is
+		// frame-paced, so bursty deltas don't back up behind the bounded adapter channel.
 		if ev.Type != ui.StreamEventDone && ev.Type != ui.StreamEventError {
-			if ev.Type == ui.StreamEventText && m.smoothTickPending {
-				m.deferredStreamRead = true
-			} else {
-				cmds = append(cmds, m.listenForStreamEvents())
-			}
+			cmds = append(cmds, m.listenForStreamEvents())
 		}
 		if m.streamPerf != nil {
 			m.streamPerf.RecordDuration(durationMetricStreamEvent, time.Since(streamEventStart))

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -571,7 +571,6 @@ func (m *Model) cmdClear() (tea.Model, tea.Cmd) {
 		m.smoothBuffer.Reset()
 	}
 	m.smoothTickPending = false
-	m.deferredStreamRead = false
 	m.streamRenderTickPending = false
 
 	// Reset stats for new session

--- a/internal/tui/chat/perf_telemetry_test.go
+++ b/internal/tui/chat/perf_telemetry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -131,10 +132,12 @@ func TestModelCoalescesSmoothTickSchedulingForBurstTextEvents(t *testing.T) {
 	}
 }
 
-func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
+func TestModelSchedulesNextStreamReadImmediatelyDuringSmoothStreaming(t *testing.T) {
 	model := newTestChatModel(false)
 	model.streaming = true
-	model.streamChan = make(chan ui.StreamEvent)
+	streamChan := make(chan ui.StreamEvent, 1)
+	streamChan <- ui.TextEvent("next chunk")
+	model.streamChan = streamChan
 
 	_, cmd := model.Update(streamEventMsg{event: ui.TextEvent("hello world")})
 	if cmd == nil {
@@ -143,16 +146,14 @@ func TestModelDefersNextStreamReadUntilSmoothTick(t *testing.T) {
 	if !model.smoothTickPending {
 		t.Fatal("expected smooth tick to be pending after text event")
 	}
-	if !model.deferredStreamRead {
-		t.Fatal("expected next stream read to be deferred until the smooth tick")
-	}
 
-	_, cmd = model.Update(ui.SmoothTickMsg{})
-	if model.deferredStreamRead {
-		t.Fatal("expected deferred stream read to clear after smooth tick")
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected batched follow-up commands, got %T", msg)
 	}
-	if cmd == nil {
-		t.Fatal("expected smooth tick to resume stream reading")
+	if len(batch) != 2 {
+		t.Fatalf("expected smooth tick and immediate stream read, got %d commands", len(batch))
 	}
 }
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -407,7 +407,6 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	}
 	m.newlineCompactor = ui.NewStreamingNewlineCompactor(ui.MaxStreamingConsecutiveNewlines)
 	m.smoothTickPending = false
-	m.deferredStreamRead = false
 	m.streamRenderTickPending = false
 
 	// Start the stream


### PR DESCRIPTION
## What

- keep scheduling the next chat stream read immediately after each non-terminal stream event, even while smooth text rendering is already frame-paced
- remove the now-unused deferred stream-read path from the chat TUI
- update the chat perf test to assert we keep both the smooth tick and the immediate follow-up read scheduled

## Why

The previous logic only dequeued one stream event per smooth-render frame when text deltas were arriving quickly. That let the bounded stream adapter channel back up and apply avoidable upstream backpressure, which added latency to token display and delayed follow-up tool/done events. Draining the stream continuously preserves the existing coalesced rendering behavior without making providers wait on the UI.
