### PR TITLE
optimize session snapshot replacement

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1648,10 +1648,17 @@ func (s *SQLiteStore) ClearCompactionBoundary(ctx context.Context, id string) er
 	})
 }
 
-// ReplaceMessages deletes all existing messages for the session and inserts
-// the new set in a single transaction. Because the replacement snapshot becomes
-// the complete persisted history, any previous compaction boundary is cleared.
+// ReplaceMessages reconciles the complete persisted history for a session.
+// It preserves any unchanged prefix and rewrites only the changed suffix, avoiding
+// a DELETE+INSERT of long histories when serve/web persists an appended snapshot.
+// Because the replacement snapshot becomes the complete persisted history, any
+// previous compaction boundary is cleared.
 func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, messages []Message) error {
+	partsJSON, err := prepareReplacementMessageParts(messages)
+	if err != nil {
+		return err
+	}
+
 	return retryOnBusy(ctx, 5, func() error {
 		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
@@ -1659,36 +1666,44 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 		}
 		defer tx.Rollback()
 
-		// Delete all existing messages for this session
-		if _, err := tx.ExecContext(ctx, "DELETE FROM messages WHERE session_id = ?", sessionID); err != nil {
-			return fmt.Errorf("delete existing messages: %w", err)
-		}
-
-		insertStmt, err := tx.PrepareContext(ctx, `
-			INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+		commonPrefix, fullDelete, err := replacementCommonPrefix(ctx, tx, sessionID, messages, partsJSON)
 		if err != nil {
-			return fmt.Errorf("prepare message insert: %w", err)
+			return err
 		}
-		defer insertStmt.Close()
 
-		// Insert new messages with sequential sequence numbers
-		for i, msg := range messages {
-			msg.SessionID = sessionID
-			msg.Sequence = i
-			if msg.CreatedAt.IsZero() {
-				msg.CreatedAt = time.Now()
+		// Drop the first changed row and any stale suffix. Unchanged prefix rows keep
+		// their rowids, FTS entries, and created_at values; triggers update FTS and
+		// message_count only for rows that actually changed. If legacy/corrupt rows
+		// have duplicate or negative sequence numbers, fall back to the old full
+		// rewrite so replacement remains a complete-history operation.
+		if fullDelete {
+			if _, err := tx.ExecContext(ctx, "DELETE FROM messages WHERE session_id = ?", sessionID); err != nil {
+				return fmt.Errorf("delete existing messages: %w", err)
 			}
+		} else if _, err := tx.ExecContext(ctx, "DELETE FROM messages WHERE session_id = ? AND sequence >= ?", sessionID, commonPrefix); err != nil {
+			return fmt.Errorf("delete changed messages: %w", err)
+		}
 
-			partsJSON, err := msg.PartsJSON()
+		if commonPrefix < len(messages) {
+			insertStmt, err := tx.PrepareContext(ctx, `
+				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
 			if err != nil {
-				return fmt.Errorf("serialize parts for message %d: %w", i, err)
+				return fmt.Errorf("prepare message insert: %w", err)
 			}
+			defer insertStmt.Close()
 
-			_, err = insertStmt.ExecContext(ctx,
-				sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence)
-			if err != nil {
-				return fmt.Errorf("insert message %d: %w", i, err)
+			for i := commonPrefix; i < len(messages); i++ {
+				msg := messages[i]
+				createdAt := msg.CreatedAt
+				if createdAt.IsZero() {
+					createdAt = time.Now()
+				}
+				_, err = insertStmt.ExecContext(ctx,
+					sessionID, string(msg.Role), partsJSON[i], msg.TextContent, msg.DurationMs, msg.TurnIndex, createdAt, i)
+				if err != nil {
+					return fmt.Errorf("insert message %d: %w", i, err)
+				}
 			}
 		}
 
@@ -1713,6 +1728,88 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 
 		return tx.Commit()
 	})
+}
+
+func prepareReplacementMessageParts(messages []Message) ([]string, error) {
+	partsJSON := make([]string, len(messages))
+	for i := range messages {
+		parts, err := messages[i].PartsJSON()
+		if err != nil {
+			return nil, fmt.Errorf("serialize parts for message %d: %w", i, err)
+		}
+		partsJSON[i] = parts
+	}
+	return partsJSON, nil
+}
+
+func replacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID string, desired []Message, desiredPartsJSON []string) (prefix int, fullDelete bool, err error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT sequence, role, parts, text_content, duration_ms, turn_index
+		FROM messages
+		WHERE session_id = ?
+		ORDER BY sequence ASC, id ASC`, sessionID)
+	if err != nil {
+		return 0, false, fmt.Errorf("query existing messages: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sequence int
+		var role, partsJSON string
+		var textContent sql.NullString
+		var durationMs sql.NullInt64
+		var turnIndex sql.NullInt64
+		if err := rows.Scan(&sequence, &role, &partsJSON, &textContent, &durationMs, &turnIndex); err != nil {
+			return 0, false, fmt.Errorf("scan existing message: %w", err)
+		}
+		if sequence < 0 {
+			return 0, true, nil
+		}
+
+		if prefix >= len(desired) {
+			if sequence < prefix {
+				return 0, true, nil
+			}
+			break
+		}
+		if sequence != prefix {
+			// A duplicate/out-of-order sequence below the already accepted prefix
+			// cannot be removed by deleting sequence >= prefix, so fall back to a full
+			// rewrite. Gaps above the prefix are safely truncated from the gap onward.
+			if sequence < prefix {
+				return 0, true, nil
+			}
+			break
+		}
+
+		want := desired[prefix]
+		if role != string(want.Role) ||
+			partsJSON != desiredPartsJSON[prefix] ||
+			nullStringValue(textContent) != want.TextContent ||
+			nullInt64Value(durationMs) != want.DurationMs ||
+			int(nullInt64Value(turnIndex)) != want.TurnIndex {
+			break
+		}
+		prefix++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, false, err
+	}
+	return prefix, false, nil
+}
+
+func nullStringValue(v sql.NullString) string {
+	if !v.Valid {
+		return ""
+	}
+	return v.String
+}
+
+func nullInt64Value(v sql.NullInt64) int64 {
+	if !v.Valid {
+		return 0
+	}
+	return v.Int64
 }
 
 // CompactMessages appends compacted messages to the session, preserving old

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -74,6 +74,165 @@ func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreReplaceMessagesPreservesUnchangedPrefix(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	messages := []Message{
+		*NewMessage(sess.ID, llm.UserText("stable user"), 0),
+		*NewMessage(sess.ID, llm.AssistantText("stable assistant"), 1),
+		*NewMessage(sess.ID, llm.UserText("old suffix"), 2),
+	}
+	for i := range messages {
+		messages[i].CreatedAt = base.Add(time.Duration(i) * time.Second)
+		messages[i].TurnIndex = i
+	}
+	if err := store.ReplaceMessages(ctx, sess.ID, messages); err != nil {
+		t.Fatalf("initial ReplaceMessages: %v", err)
+	}
+	before, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages before: %v", err)
+	}
+	if len(before) != 3 {
+		t.Fatalf("initial message count = %d, want 3", len(before))
+	}
+
+	replacement := []Message{
+		*NewMessage(sess.ID, llm.UserText("stable user"), 0),
+		*NewMessage(sess.ID, llm.AssistantText("stable assistant"), 1),
+		*NewMessage(sess.ID, llm.UserText("new suffix"), 2),
+		*NewMessage(sess.ID, llm.AssistantText("new tail"), 3),
+	}
+	for i := range replacement {
+		// Simulate serve/web rebuilding a fresh snapshot for unchanged history: the
+		// content is identical, but CreatedAt is newly allocated and should not force
+		// a full rewrite of the prefix.
+		replacement[i].CreatedAt = base.Add(time.Duration(i+100) * time.Second)
+		replacement[i].TurnIndex = i
+	}
+	if _, err := store.db.ExecContext(ctx, "UPDATE sessions SET compaction_seq = 5, compaction_count = 1 WHERE id = ?", sess.ID); err != nil {
+		t.Fatalf("seed compaction boundary: %v", err)
+	}
+	if err := store.ReplaceMessages(ctx, sess.ID, replacement); err != nil {
+		t.Fatalf("replacement ReplaceMessages: %v", err)
+	}
+
+	after, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after: %v", err)
+	}
+	if len(after) != 4 {
+		t.Fatalf("final message count = %d, want 4", len(after))
+	}
+	if after[0].ID != before[0].ID || after[1].ID != before[1].ID {
+		t.Fatalf("unchanged prefix row IDs = [%d %d], want [%d %d]", after[0].ID, after[1].ID, before[0].ID, before[1].ID)
+	}
+	if after[2].ID == before[2].ID {
+		t.Fatalf("changed suffix row kept old ID %d; want rewritten suffix", after[2].ID)
+	}
+	if after[2].TextContent != "new suffix" || after[3].TextContent != "new tail" {
+		t.Fatalf("suffix texts = %q, %q; want new suffix/new tail", after[2].TextContent, after[3].TextContent)
+	}
+
+	results, err := store.Search(ctx, "old suffix", 10)
+	if err != nil {
+		t.Fatalf("Search old suffix: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("old suffix still in FTS: %#v", results)
+	}
+	results, err = store.Search(ctx, "new suffix", 10)
+	if err != nil {
+		t.Fatalf("Search new suffix: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("new suffix FTS matches = %d, want 1", len(results))
+	}
+	meta, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get meta: %v", err)
+	}
+	if meta.CompactionSeq != -1 || meta.CompactionCount != 0 {
+		t.Fatalf("compaction boundary = seq %d count %d, want cleared", meta.CompactionSeq, meta.CompactionCount)
+	}
+	summaries, err := store.List(ctx, ListOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].MessageCount != 4 {
+		t.Fatalf("summary count = len %d message_count %d, want len 1 count 4", len(summaries), summaries[0].MessageCount)
+	}
+}
+
+func TestSQLiteStoreReplaceMessagesFallsBackForDuplicateSequences(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	desired := []Message{*NewMessage(sess.ID, llm.UserText("kept message"), 0)}
+	if err := store.ReplaceMessages(ctx, sess.ID, desired); err != nil {
+		t.Fatalf("initial ReplaceMessages: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `DROP INDEX IF EXISTS idx_messages_session_sequence`); err != nil {
+		t.Fatalf("drop sequence index for duplicate fixture: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence)
+		VALUES (?, 'user', ?, 'stale duplicate', 0, 0, ?, 0)`,
+		sess.ID, `[{"type":"text","text":"stale duplicate"}]`, time.Now().UTC()); err != nil {
+		t.Fatalf("insert duplicate sequence row: %v", err)
+	}
+
+	if err := store.ReplaceMessages(ctx, sess.ID, desired); err != nil {
+		t.Fatalf("ReplaceMessages with duplicate sequence: %v", err)
+	}
+
+	got, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(got) != 1 || got[0].TextContent != "kept message" {
+		t.Fatalf("messages after duplicate cleanup = %#v, want one kept message", got)
+	}
+	results, err := store.Search(ctx, "stale duplicate", 10)
+	if err != nil {
+		t.Fatalf("Search stale duplicate: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("stale duplicate still in FTS: %#v", results)
+	}
+	summaries, err := store.List(ctx, ListOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].MessageCount != 1 {
+		t.Fatalf("summary count = len %d message_count %d, want len 1 count 1", len(summaries), summaries[0].MessageCount)
+	}
+}
+
 func TestSQLiteStoreReplaceMessagesPreservesTurnIndex(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What

Optimize `SQLiteStore.ReplaceMessages` so full-session snapshot persistence keeps an unchanged message prefix and only deletes/reinserts the changed suffix.

The fallback path still performs a full rewrite if legacy/corrupt rows have duplicate or negative sequence numbers, preserving the complete-history replacement contract.

## Why

Serve/web persistence commonly rebuilds a fresh full snapshot for a session where most prior messages are unchanged. The old implementation deleted every message and reinserted the entire transcript, churning FTS triggers, `message_count` triggers, row IDs, and SQLite writes even when only the tail changed.

This keeps stable history rows in place and avoids reindexing them.

## Evidence

Focused benchmark on an unchanged 120-message snapshot:

- Before: `BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot` ~3.55-3.68 ms/op, ~132 KB/op
- After: `BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot` ~245-249 µs/op, ~131 KB/op

Verification:

- `go test ./internal/session`
- `go test ./internal/session -run '^$' -bench 'BenchmarkSQLiteStoreReplaceMessagesLargeSnapshot' -benchmem -count=3`
- `go test ./...`
- `go build ./...`
