### PR TITLE
perf: cache tool schema JSON for adapters

### DIFF
--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -229,7 +229,7 @@ func buildOllamaTools(specs []ToolSpec) ([]ollamaTool, error) {
 	}
 	tools := make([]ollamaTool, 0, len(specs))
 	for _, spec := range specs {
-		schema, err := json.Marshal(spec.Schema)
+		schema, err := cachedToolSchemaJSON(spec.Schema)
 		if err != nil {
 			return nil, fmt.Errorf("marshal tool schema %s: %w", spec.Name, err)
 		}

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -816,7 +816,7 @@ func buildCompatTools(specs []ToolSpec) ([]oaiTool, error) {
 	}
 	tools := make([]oaiTool, 0, len(specs))
 	for _, spec := range specs {
-		schema, err := json.Marshal(spec.Schema)
+		schema, err := cachedToolSchemaJSON(spec.Schema)
 		if err != nil {
 			return nil, fmt.Errorf("marshal tool schema %s: %w", spec.Name, err)
 		}

--- a/internal/llm/openai_compat_bench_test.go
+++ b/internal/llm/openai_compat_bench_test.go
@@ -1,0 +1,62 @@
+package llm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkBuildCompatTools(b *testing.B) {
+	specs := make([]ToolSpec, 128)
+	for i := range specs {
+		specs[i] = ToolSpec{
+			Name:        fmt.Sprintf("tool_%03d", i),
+			Description: "benchmark tool",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "path to read",
+					},
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "search query",
+					},
+					"options": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"limit": map[string]interface{}{
+								"type":    "integer",
+								"minimum": 1,
+								"maximum": 100,
+							},
+							"case_sensitive": map[string]interface{}{
+								"type": "boolean",
+							},
+						},
+					},
+				},
+				"required":             []string{"path"},
+				"additionalProperties": false,
+			},
+		}
+	}
+
+	// Warm any immutable-schema caches so the benchmark represents repeated
+	// agentic turns using the same registered tools.
+	if _, err := buildCompatTools(specs); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tools, err := buildCompatTools(specs)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(tools) != len(specs) {
+			b.Fatalf("got %d tools, want %d", len(tools), len(specs))
+		}
+	}
+}

--- a/internal/llm/tool_schema_json_cache.go
+++ b/internal/llm/tool_schema_json_cache.go
@@ -1,0 +1,47 @@
+package llm
+
+import (
+	"encoding/json"
+	"reflect"
+	"sync"
+)
+
+type toolSchemaJSONCacheEntry struct {
+	// Hold a strong reference to the immutable schema map so its identity cannot
+	// be reused for a different schema while the cached JSON remains live.
+	schema map[string]interface{}
+	once   sync.Once
+	raw    json.RawMessage
+	err    error
+}
+
+var toolSchemaJSONCache sync.Map
+
+// cachedToolSchemaJSON returns the JSON encoding of an immutable ToolSpec schema.
+// The cache is keyed by schema map identity, matching ToolRegistry's convention of
+// sharing schema maps across repeated request turns. Entries hold a strong schema
+// reference so that map identity cannot be reused while cached bytes are live.
+//
+// The returned RawMessage shares cached backing bytes and must be treated as
+// immutable; provider request builders only pass it to JSON encoders.
+func cachedToolSchemaJSON(schema map[string]interface{}) (json.RawMessage, error) {
+	var key uintptr
+	if schema != nil {
+		key = reflect.ValueOf(schema).Pointer()
+	}
+
+	cached, _ := toolSchemaJSONCache.LoadOrStore(key, &toolSchemaJSONCacheEntry{schema: schema})
+	entry := cached.(*toolSchemaJSONCacheEntry)
+	entry.once.Do(func() {
+		b, err := json.Marshal(schema)
+		if err != nil {
+			entry.err = err
+			return
+		}
+		entry.raw = json.RawMessage(b)
+	})
+	if entry.err != nil {
+		return nil, entry.err
+	}
+	return entry.raw, nil
+}

--- a/internal/llm/tool_schema_json_cache_test.go
+++ b/internal/llm/tool_schema_json_cache_test.go
@@ -1,0 +1,50 @@
+package llm
+
+import "testing"
+
+type countingSchemaValue struct {
+	count *int
+}
+
+func (v countingSchemaValue) MarshalJSON() ([]byte, error) {
+	*v.count = *v.count + 1
+	return []byte(`"counted"`), nil
+}
+
+func TestToolSchemaJSONCacheReusesImmutableSchema(t *testing.T) {
+	marshalCount := 0
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{},
+		"x-count":    countingSchemaValue{count: &marshalCount},
+	}
+	specs := []ToolSpec{{Name: "cached", Description: "cached schema", Schema: schema}}
+
+	compatTools, err := buildCompatTools(specs)
+	if err != nil {
+		t.Fatalf("buildCompatTools first call: %v", err)
+	}
+	if len(compatTools) != 1 || len(compatTools[0].Function.Parameters) == 0 {
+		t.Fatalf("buildCompatTools returned empty parameters: %#v", compatTools)
+	}
+
+	compatTools, err = buildCompatTools(specs)
+	if err != nil {
+		t.Fatalf("buildCompatTools second call: %v", err)
+	}
+	if len(compatTools) != 1 || len(compatTools[0].Function.Parameters) == 0 {
+		t.Fatalf("buildCompatTools returned empty cached parameters: %#v", compatTools)
+	}
+
+	ollamaTools, err := buildOllamaTools(specs)
+	if err != nil {
+		t.Fatalf("buildOllamaTools: %v", err)
+	}
+	if len(ollamaTools) != 1 || len(ollamaTools[0].Function.Parameters) == 0 {
+		t.Fatalf("buildOllamaTools returned empty cached parameters: %#v", ollamaTools)
+	}
+
+	if marshalCount != 1 {
+		t.Fatalf("schema marshaled %d times, want 1", marshalCount)
+	}
+}


### PR DESCRIPTION
## What

Cache JSON-encoded immutable `ToolSpec.Schema` maps by schema identity and reuse the cached `json.RawMessage` when building tool definitions for OpenAI-compatible chat-completions adapters and Ollama.

This avoids re-marshalling every tool schema on every streaming turn while preserving the existing per-tool error context if encoding fails.

## Why

Provider requests with many registered tools rebuild the same function/tool parameter JSON every agentic turn. `ToolSpec.Schema` is documented as immutable after registration, and `ToolRegistry` intentionally shares schema maps across repeated `AllSpecs()` calls, so this serialization work is redundant in normal usage.

## Evidence

Added `BenchmarkBuildCompatTools` to model repeated turns with 128 registered tools.

Before:

```text
BenchmarkBuildCompatTools-32    306996-313175 ns/op    233096-233104 B/op    6017 allocs/op
```

After:

```text
BenchmarkBuildCompatTools-32      7450-7864 ns/op       18688 B/op            257 allocs/op
```

Also added a unit test proving the same immutable schema is marshaled once and reused across both the OpenAI-compatible and Ollama tool builders.

## Verification

```text
go test ./internal/llm -run='TestToolSchemaJSONCacheReusesImmutableSchema'
go test ./internal/llm -run=^$ -bench=BenchmarkBuildCompatTools -benchmem -count=5
go build ./...
go test ./...
```
