### PR TITLE
feat(jobs): include last run on job responses

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -94,6 +94,7 @@ type jobsV2Job struct {
 	MisfirePolicy     string            `json:"misfire_policy,omitempty"`
 	Labels            json.RawMessage   `json:"labels,omitempty"`
 	NextRunAt         *time.Time        `json:"next_run_at,omitempty"`
+	LastRun           *jobsV2Run        `json:"last_run,omitempty"`
 	CreatedAt         time.Time         `json:"created_at"`
 	UpdatedAt         time.Time         `json:"updated_at"`
 }
@@ -1482,6 +1483,9 @@ func (m *jobsV2Manager) GetJob(id string) (jobsV2Job, error) {
 	if err != nil {
 		return jobsV2Job{}, err
 	}
+	if err := m.attachLastRuns([]*jobsV2Job{&job}); err != nil {
+		return jobsV2Job{}, err
+	}
 	return job, nil
 }
 
@@ -1515,7 +1519,59 @@ func (m *jobsV2Manager) ListJobs(limit, offset int) ([]jobsV2Job, int, error) {
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
 	}
+	jobPtrs := make([]*jobsV2Job, 0, len(jobs))
+	for i := range jobs {
+		jobPtrs = append(jobPtrs, &jobs[i])
+	}
+	if err := m.attachLastRuns(jobPtrs); err != nil {
+		return nil, 0, err
+	}
 	return jobs, total, nil
+}
+
+func (m *jobsV2Manager) attachLastRuns(jobs []*jobsV2Job) error {
+	ids := make([]string, 0, len(jobs))
+	byID := make(map[string]*jobsV2Job, len(jobs))
+	for _, job := range jobs {
+		if job == nil || strings.TrimSpace(job.ID) == "" {
+			continue
+		}
+		ids = append(ids, job.ID)
+		byID[job.ID] = job
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `SELECT ` + jobsV2RunSummaryColumns + ` FROM (
+		SELECT ` + jobsV2RunSummaryColumns + `,
+			ROW_NUMBER() OVER (PARTITION BY job_id ORDER BY created_at DESC, id DESC) AS rn
+		FROM job_runs_v2
+		WHERE job_id IN (` + strings.Join(placeholders, ",") + `)
+	) WHERE rn = 1`
+	rows, err := m.db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		run, err := scanRunSummaryV2(rows)
+		if err != nil {
+			return err
+		}
+		if job := byID[run.JobID]; job != nil {
+			r := run
+			job.LastRun = &r
+		}
+	}
+	return rows.Err()
 }
 
 func (m *jobsV2Manager) UpdateJob(id string, req jobsV2Job) (jobsV2Job, error) {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -1406,3 +1406,42 @@ func BenchmarkJobsV2LLMRunnerTextDeltaAccumulation(b *testing.B) {
 		}
 	}
 }
+
+func TestJobsV2ListJobsIncludesLastRunSummary(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	now := time.Date(2026, 5, 22, 13, 0, 0, 0, time.UTC)
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 60, 'skip', ?, ?)`,
+		"job_last_run", "last-run", jobsV2RunnerProgram, `{"command":"true"}`, jobsV2TriggerManual, `{}`, now.Add(-time.Hour), now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("insert job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, started_at, finished_at, exit_code, error, created_at, updated_at) VALUES (?, ?, 1, 'schedule', ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"run_old", "job_last_run", now.Add(-2*time.Hour), jobsV2RunSucceeded, now.Add(-2*time.Hour), now.Add(-2*time.Hour).Add(time.Second), 0, "", now.Add(-2*time.Hour), now.Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("insert old run: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, started_at, finished_at, exit_code, error, created_at, updated_at) VALUES (?, ?, 1, 'schedule', ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"run_new", "job_last_run", now, jobsV2RunFailed, now, now.Add(time.Second), 0, "boom", now, now)
+	if err != nil {
+		t.Fatalf("insert new run: %v", err)
+	}
+
+	jobs, _, err := mgr.ListJobs(10, 0)
+	if err != nil {
+		t.Fatalf("ListJobs failed: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].LastRun == nil {
+		t.Fatalf("LastRun = nil, want latest run summary")
+	}
+	if jobs[0].LastRun.ID != "run_new" || jobs[0].LastRun.Status != jobsV2RunFailed || jobs[0].LastRun.Error != "boom" {
+		t.Fatalf("LastRun = %+v, want failed run_new with error", jobs[0].LastRun)
+	}
+}


### PR DESCRIPTION
## What

Adds `last_run` to Jobs V2 job responses (`GET /v2/jobs` and `GET /v2/jobs/:id`). The field contains the latest run summary for each job, including status, timestamps, exit code, error, and token/session summary fields already present in run summaries.

## Why

The job console needs to quickly show whether a scheduled job is currently healthy. Inferring this from the global recent-runs page is wrong: a job can have failed recently but not appear in that limited page, so the UI can incorrectly look green.

Concrete example from the local console: `code-review-nightly` had a latest `failed` run, but the list view did not reliably surface it until querying that job's own run history.

## Implementation

- Adds `LastRun *jobsV2Run` to `jobsV2Job` JSON as `last_run`.
- Attaches latest run summaries in `ListJobs` and `GetJob`.
- Uses a window function over the requested job ids to fetch one latest run per job.
- Adds a regression test confirming `ListJobs` returns the latest failed run rather than an older succeeded run.

## Verification

```text
go test ./...
```

Passed locally.
