### PR TITLE
fix: `recent.md` maintenance does unlocked read-modify-write overwrites, so overlapping runs can silently discard memory updates

### DIFF
--- a/cmd/memory_freshen.go
+++ b/cmd/memory_freshen.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -164,10 +163,6 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	existingRecent, err := loadRecentContent(recentPath)
-	if err != nil {
-		return err
-	}
 
 	fragmentsText, err := loadRecentFragmentsText(ctx, store, agentName, memoryUpdateRecentFragmentChars)
 	if err != nil {
@@ -180,16 +175,27 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 	}
 	engine := newEngine(provider, cfg)
 
-	updatedRecent, err := runMemoryUpdateRecentRequest(ctx, engine, reqModel, inputBuilder.String(), existingRecent, fragmentsText, memoryUpdateRecentTargetTokens, targetChars)
-	if err != nil {
-		return err
-	}
-	updatedRecent, err = fitUpdatedRecentWithinBudget(ctx, engine, reqModel, updatedRecent, memoryUpdateRecentTargetTokens, targetChars, highWaterChars)
-	if err != nil {
-		return err
+	buildUpdatedRecent := func(existingRecent string) (string, error) {
+		updatedRecent, err := runMemoryUpdateRecentRequest(ctx, engine, reqModel, inputBuilder.String(), existingRecent, fragmentsText, memoryUpdateRecentTargetTokens, targetChars)
+		if err != nil {
+			return "", err
+		}
+		updatedRecent, err = fitUpdatedRecentWithinBudget(ctx, engine, reqModel, updatedRecent, memoryUpdateRecentTargetTokens, targetChars, highWaterChars)
+		if err != nil {
+			return "", err
+		}
+		return updatedRecent, nil
 	}
 
 	if memoryDryRun {
+		existingRecent, err := loadRecentContent(recentPath)
+		if err != nil {
+			return err
+		}
+		updatedRecent, err := buildUpdatedRecent(existingRecent)
+		if err != nil {
+			return err
+		}
 		fmt.Print(updatedRecent)
 		if !strings.HasSuffix(updatedRecent, "\n") {
 			fmt.Println()
@@ -197,27 +203,39 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(recentPath), 0755); err != nil {
-		return fmt.Errorf("create memory directory: %w", err)
-	}
-	if err := os.WriteFile(recentPath, []byte(updatedRecent), 0644); err != nil {
-		return fmt.Errorf("write recent.md: %w", err)
-	}
-
-	sessionIDs := make([]string, 0, len(trackedOffsets))
-	for sessionID := range trackedOffsets {
-		sessionIDs = append(sessionIDs, sessionID)
-	}
-	sort.Strings(sessionIDs)
-	for _, sessionID := range sessionIDs {
-		if err := store.SetMeta(ctx, updateRecentOffsetMetaKey(sessionID), strconv.Itoa(trackedOffsets[sessionID])); err != nil {
-			return fmt.Errorf("persist update-recent offset for session %s: %w", sessionID, err)
+	if err := withLockedRecentFile(recentPath, func() error {
+		existingRecent, err := loadRecentContent(recentPath)
+		if err != nil {
+			return err
 		}
-	}
 
-	now := time.Now().UTC()
-	if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), now.Format(time.RFC3339)); err != nil {
-		return fmt.Errorf("update last update-recent timestamp: %w", err)
+		updatedRecent, err := buildUpdatedRecent(existingRecent)
+		if err != nil {
+			return err
+		}
+		if err := writeRecentFileAtomically(recentPath, updatedRecent); err != nil {
+			return fmt.Errorf("write recent.md: %w", err)
+		}
+
+		sessionIDs := make([]string, 0, len(trackedOffsets))
+		for sessionID := range trackedOffsets {
+			sessionIDs = append(sessionIDs, sessionID)
+		}
+		sort.Strings(sessionIDs)
+		for _, sessionID := range sessionIDs {
+			if err := store.SetMeta(ctx, updateRecentOffsetMetaKey(sessionID), strconv.Itoa(trackedOffsets[sessionID])); err != nil {
+				return fmt.Errorf("persist update-recent offset for session %s: %w", sessionID, err)
+			}
+		}
+
+		now := time.Now().UTC()
+		if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), now.Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("update last update-recent timestamp: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/memory_promote.go
+++ b/cmd/memory_promote.go
@@ -143,19 +143,24 @@ func runMemoryPromoteFlow(ctx context.Context, cfg *config.Config, engine *llm.E
 		return 0, err
 	}
 
-	existingRecent, err := loadRecentContent(recentPath)
-	if err != nil {
-		return 0, err
+	buildUpdatedRecent := func(existingRecent string) (string, error) {
+		prompt := buildPromotePrompt(changed, existingRecent)
+		updatedRecent, err := runMemoryPromoteRequest(ctx, engine, strings.TrimSpace(opts.Model), prompt, maxWords)
+		if err != nil {
+			return "", err
+		}
+		return truncatePromotedRecent(updatedRecent, maxBytes), nil
 	}
-
-	prompt := buildPromotePrompt(changed, existingRecent)
-	updatedRecent, err := runMemoryPromoteRequest(ctx, engine, strings.TrimSpace(opts.Model), prompt, maxWords)
-	if err != nil {
-		return 0, err
-	}
-	updatedRecent = truncatePromotedRecent(updatedRecent, maxBytes)
 
 	if opts.DryRun {
+		existingRecent, err := loadRecentContent(recentPath)
+		if err != nil {
+			return 0, err
+		}
+		updatedRecent, err := buildUpdatedRecent(existingRecent)
+		if err != nil {
+			return 0, err
+		}
 		fmt.Print(updatedRecent)
 		if !strings.HasSuffix(updatedRecent, "\n") {
 			fmt.Println()
@@ -163,15 +168,27 @@ func runMemoryPromoteFlow(ctx context.Context, cfg *config.Config, engine *llm.E
 		return len(changed), nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(recentPath), 0755); err != nil {
-		return 0, fmt.Errorf("create memory directory: %w", err)
-	}
-	if err := os.WriteFile(recentPath, []byte(updatedRecent), 0644); err != nil {
-		return 0, fmt.Errorf("write recent.md: %w", err)
-	}
+	if err := withLockedRecentFile(recentPath, func() error {
+		existingRecent, err := loadRecentContent(recentPath)
+		if err != nil {
+			return err
+		}
 
-	if err := store.SetMeta(ctx, memoryPromoteMetaKey(agentName), now.Format(time.RFC3339)); err != nil {
-		return 0, fmt.Errorf("update last promoted timestamp: %w", err)
+		updatedRecent, err := buildUpdatedRecent(existingRecent)
+		if err != nil {
+			return err
+		}
+		if err := writeRecentFileAtomically(recentPath, updatedRecent); err != nil {
+			return fmt.Errorf("write recent.md: %w", err)
+		}
+
+		if err := store.SetMeta(ctx, memoryPromoteMetaKey(agentName), now.Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("update last promoted timestamp: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return 0, err
 	}
 
 	fmt.Printf("Promoted %d fragments into recent.md\n", len(changed))

--- a/cmd/memory_recent_file.go
+++ b/cmd/memory_recent_file.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func withLockedRecentFile(recentPath string, fn func() error) (err error) {
+	if err := os.MkdirAll(filepath.Dir(recentPath), 0o755); err != nil {
+		return fmt.Errorf("create memory directory: %w", err)
+	}
+
+	unlock, err := lockRecentFile(recentPath + ".lock")
+	if err != nil {
+		return fmt.Errorf("lock recent.md: %w", err)
+	}
+	defer func() {
+		if unlockErr := unlock(); err == nil && unlockErr != nil {
+			err = unlockErr
+		}
+	}()
+
+	return fn()
+}
+
+func writeRecentFileAtomically(recentPath, content string) error {
+	dir := filepath.Dir(recentPath)
+	base := filepath.Base(recentPath)
+	tf, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := tf.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tf.WriteString(content); err != nil {
+		_ = tf.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tf.Sync(); err != nil {
+		_ = tf.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tf.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tempPath, 0o644); err != nil {
+		return fmt.Errorf("set temp file permissions: %w", err)
+	}
+	if err := os.Rename(tempPath, recentPath); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	cleanup = false
+	return nil
+}

--- a/cmd/memory_recent_file_test.go
+++ b/cmd/memory_recent_file_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWithLockedRecentFile_SerializesConcurrentAccess(t *testing.T) {
+	recentPath := filepath.Join(t.TempDir(), "memory", "recent.md")
+
+	firstAcquired := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondAcquired := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- withLockedRecentFile(recentPath, func() error {
+			close(firstAcquired)
+			<-releaseFirst
+			return nil
+		})
+	}()
+
+	select {
+	case <-firstAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first lock was not acquired")
+	}
+
+	go func() {
+		errCh <- withLockedRecentFile(recentPath, func() error {
+			close(secondAcquired)
+			return nil
+		})
+	}()
+
+	select {
+	case <-secondAcquired:
+		t.Fatal("second lock acquired before first lock released")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-secondAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second lock was not acquired after first lock released")
+	}
+
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("withLockedRecentFile: %v", err)
+		}
+	}
+}
+
+func TestWriteRecentFileAtomically_ReplacesContentWithoutLeakingTemps(t *testing.T) {
+	dir := t.TempDir()
+	recentPath := filepath.Join(dir, "recent.md")
+	if err := os.WriteFile(recentPath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed recent.md: %v", err)
+	}
+
+	if err := writeRecentFileAtomically(recentPath, "new content"); err != nil {
+		t.Fatalf("writeRecentFileAtomically: %v", err)
+	}
+
+	data, err := os.ReadFile(recentPath)
+	if err != nil {
+		t.Fatalf("read recent.md: %v", err)
+	}
+	if string(data) != "new content" {
+		t.Fatalf("got %q, want %q", string(data), "new content")
+	}
+
+	info, err := os.Stat(recentPath)
+	if err != nil {
+		t.Fatalf("stat recent.md: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("mode = %o, want 644", got)
+	}
+
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".recent.md.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("unexpected temp files left behind: %v", leftovers)
+	}
+}

--- a/cmd/memory_recent_lock_unix.go
+++ b/cmd/memory_recent_lock_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func lockRecentFile(lockPath string) (func() error, error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("acquire file lock: %w", err)
+	}
+
+	return func() error {
+		unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		closeErr := file.Close()
+		if unlockErr != nil {
+			if closeErr != nil {
+				return fmt.Errorf("unlock file lock: %v; close lock file: %w", unlockErr, closeErr)
+			}
+			return fmt.Errorf("unlock file lock: %w", unlockErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close lock file: %w", closeErr)
+		}
+		return nil
+	}, nil
+}

--- a/cmd/memory_recent_lock_windows.go
+++ b/cmd/memory_recent_lock_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockRecentFile(lockPath string) (func() error, error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("acquire file lock: %w", err)
+	}
+
+	return func() error {
+		unlockErr := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+		closeErr := file.Close()
+		if unlockErr != nil {
+			if closeErr != nil {
+				return fmt.Errorf("unlock file lock: %v; close lock file: %w", unlockErr, closeErr)
+			}
+			return fmt.Errorf("unlock file lock: %w", unlockErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close lock file: %w", closeErr)
+		}
+		return nil
+	}, nil
+}


### PR DESCRIPTION
## What changed

- Added a shared `recent.md` update helper that acquires a per-file advisory lock before reloading `recent.md`, holds it across the LLM-based read/modify/write flow, and releases it after the write and related metadata updates complete.
- Switched both `memory update-recent` and `memory promote` to use that helper so overlapping maintenance runs no longer compute from the same stale `recent.md` snapshot and then blindly overwrite each other.
- Replaced direct `os.WriteFile` calls for `recent.md` with temp-file + rename writes so readers see either the old file or the fully written new file, never a partially written one.
- Added tests covering lock serialization and atomic `recent.md` replacement behavior.

## Why this is high-value

`recent.md` is Jarvis's current working memory. Before this change, `update-recent` and `promote` both did unlocked read-LLM-write cycles against the same file, so two overlapping runs could each read the same old content and the later writer would silently discard the earlier run's newly computed memory updates. Because these commands are natural scheduled-job/manual-maintenance paths, overlap is realistic and the failure mode is persistent memory loss.

This fix prevents that exact failure by serializing writers per `recent.md` path and making the final file replacement atomic.

## Validation

- `gofmt -w cmd/memory_freshen.go cmd/memory_promote.go cmd/memory_recent_file.go cmd/memory_recent_lock_unix.go cmd/memory_recent_lock_windows.go cmd/memory_recent_file_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
