### PR TITLE
fix: Durable response ID lookups load and deserialize entire session histories on hot response paths

### DIFF
--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -83,15 +83,14 @@ func (s *serveServer) resolveDurablePreviousResponseID(ctx context.Context, prev
 	if headerSessionID != "" && headerSessionID != msg.SessionID {
 		return durablePreviousResponseResolution{}, http.StatusConflict, fmt.Sprintf("session_id %q conflicts with previous_response_id session %q", headerSessionID, msg.SessionID)
 	}
-	msgs, err := s.store.GetMessages(ctx, msg.SessionID, 0, 0)
+	latestMsgID, found, err := s.store.GetLatestVisibleMessageID(ctx, msg.SessionID)
 	if err != nil {
 		return durablePreviousResponseResolution{}, http.StatusBadRequest, fmt.Sprintf("previous_response_id %q not found", previousResponseID)
 	}
-	latest, ok := latestVisibleMessage(msgs)
-	if !ok || latest.ID != msg.ID {
+	if !found || latestMsgID != msg.ID {
 		latestID := ""
-		if ok {
-			latestID = durableResponseIDForMessageID(latest.ID)
+		if found {
+			latestID = durableResponseIDForMessageID(latestMsgID)
 		}
 		if latestID == "" {
 			latestID = "unknown"
@@ -123,9 +122,9 @@ func (s *serveServer) latestDurableResponseIDForSession(ctx context.Context, ses
 	if s == nil || s.store == nil || sessionID == "" {
 		return ""
 	}
-	msgs, err := s.store.GetMessages(ctx, sessionID, 0, 0)
-	if err != nil {
+	msgID, found, err := s.store.GetLatestVisibleMessageID(ctx, sessionID)
+	if err != nil || !found {
 		return ""
 	}
-	return latestDurableResponseID(msgs)
+	return durableResponseIDForMessageID(msgID)
 }

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -236,6 +236,18 @@ func (s *serveRuntimeTestStore) GetMessagesFrom(ctx context.Context, sessionID s
 	return out, nil
 }
 
+func (s *serveRuntimeTestStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	msgs := s.messages[sessionID]
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == llm.RoleUser || msgs[i].Role == llm.RoleAssistant {
+			return msgs[i].ID, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
 func (s *serveRuntimeTestStore) GetMessageByID(ctx context.Context, msgID int64) (*session.Message, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -77,6 +77,15 @@ func (s *LoggingStore) UpdateMessage(ctx context.Context, sessionID string, msg 
 	return err
 }
 
+// GetLatestVisibleMessageID wraps Store.GetLatestVisibleMessageID with error logging.
+func (s *LoggingStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, bool, error) {
+	id, found, err := s.Store.GetLatestVisibleMessageID(ctx, sessionID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		s.logOnce("GetLatestVisibleMessageID", err)
+	}
+	return id, found, err
+}
+
 // GetMessageByID wraps Store.GetMessageByID with error logging.
 func (s *LoggingStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, error) {
 	msg, err := s.Store.GetMessageByID(ctx, msgID)

--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -64,6 +64,10 @@ func (s *NoopStore) GetMessagesFrom(ctx context.Context, sessionID string, fromS
 	return nil, nil
 }
 
+func (s *NoopStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, bool, error) {
+	return 0, false, nil
+}
+
 func (s *NoopStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, error) {
 	return nil, ErrNotFound
 }

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1923,6 +1923,26 @@ func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fro
 	return messages, rows.Err()
 }
 
+// GetLatestVisibleMessageID retrieves the newest persisted user/assistant
+// message id for a session without deserializing the full transcript.
+func (s *SQLiteStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, bool, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND role IN ('user', 'assistant')
+		ORDER BY sequence DESC
+		LIMIT 1`, sessionID)
+	var id int64
+	err := row.Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("scan latest visible message id: %w", err)
+	}
+	return id, true, nil
+}
+
 // GetMessageByID retrieves a single message by its global message id.
 func (s *SQLiteStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, error) {
 	row := s.db.QueryRowContext(ctx, `

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -74,6 +74,53 @@ func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreGetLatestVisibleMessageIDSkipsNonVisibleTail(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	messages := []*Message{
+		NewMessage(sess.ID, llm.UserText("first"), 0),
+		NewMessage(sess.ID, llm.AssistantText("second"), 1),
+		NewMessage(sess.ID, llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartText, Text: "tool result"}}}, 2),
+		NewMessage(sess.ID, llm.Message{Role: llm.RoleEvent, Parts: []llm.Part{{Type: llm.PartText, Text: "event marker"}}}, 3),
+	}
+	for i, msg := range messages {
+		if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+			t.Fatalf("AddMessage(%d): %v", i, err)
+		}
+	}
+
+	gotID, found, err := store.GetLatestVisibleMessageID(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetLatestVisibleMessageID: %v", err)
+	}
+	if !found {
+		t.Fatal("GetLatestVisibleMessageID found = false, want true")
+	}
+	if gotID != messages[1].ID {
+		t.Fatalf("latest visible id = %d, want %d", gotID, messages[1].ID)
+	}
+
+	gotID, found, err = store.GetLatestVisibleMessageID(ctx, NewID())
+	if err != nil {
+		t.Fatalf("GetLatestVisibleMessageID missing session: %v", err)
+	}
+	if found || gotID != 0 {
+		t.Fatalf("missing session latest visible = (%d, %v), want (0, false)", gotID, found)
+	}
+}
+
 func TestSQLiteStoreReplaceMessagesPreservesUnchangedPrefix(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -44,6 +44,9 @@ type Store interface {
 	// GetMessagesFrom returns rows at/after fromSeq in sequence order. When limit
 	// <= 0, all remaining rows are returned.
 	GetMessagesFrom(ctx context.Context, sessionID string, fromSeq, limit int) ([]Message, error)
+	// GetLatestVisibleMessageID returns the newest persisted user/assistant
+	// message id for the session. found=false means no visible message exists.
+	GetLatestVisibleMessageID(ctx context.Context, sessionID string) (id int64, found bool, err error)
 	// GetMessageByID retrieves a single message by its global message id.
 	GetMessageByID(ctx context.Context, msgID int64) (*Message, error)
 	ReplaceMessages(ctx context.Context, sessionID string, messages []Message) error


### PR DESCRIPTION
## What changed

- Added `GetLatestVisibleMessageID` to the session store interface.
- Implemented it in `internal/session/sqlite.go` as a targeted single-row query over the `messages` table:
  - filters to visible continuation roles (`user`, `assistant`)
  - orders by newest sequence
  - returns only the latest message ID
- Replaced the full-history `GetMessages(..., 0, 0)` calls in `cmd/serve_responses_durable.go` with the new targeted lookup for:
  - durable `previous_response_id` validation
  - latest durable response ID reporting for a session
- Added a SQLite test covering the behavior that non-visible tail rows (for example `tool` or `event`) are skipped.
- Updated the no-op, logging, and test store implementations to satisfy the new store interface.

## Why this is high-value

These durable response ID helpers sit on hot Responses/web paths, including completion finalization, continuation validation, and ask-user state reporting. Before this change they loaded the entire persisted transcript for the session and deserialized every message `parts` JSON blob just to answer a tail question.

This fix reduces that work from:

- O(n) row reads over the whole session history
- O(n) JSON deserialization/allocation for message parts

…to a single small SQL lookup that returns one ID.

That directly cuts latency and allocation cost for long-lived persisted sessions, which are exactly the sessions most likely to hit this path repeatedly.

## Validation

- Verified the issue in current code by inspecting `cmd/serve_responses_durable.go` and `internal/session/sqlite.go`.
- `gofmt -w` on changed files
- `go build ./...`
- `go test ./...`
- `git diff --check`
