### PR TITLE
fix: Durable response-id lookups load and JSON-decode the entire session transcript on hot response paths

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1297,7 +1297,7 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		result = append(result, entry)
 	}
 
-	resp := messagesResponse{LastResponseID: latestDurableResponseID(msgs), Messages: result, HasMore: hasMore}
+	resp := messagesResponse{LastResponseID: s.latestDurableResponseIDForSession(r.Context(), sessionID), Messages: result, HasMore: hasMore}
 	if hasMore {
 		resp.NextOffset = nextOffset
 	}

--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -13,6 +13,10 @@ import (
 
 const durableResponseMessagePrefix = "resp_msg_"
 
+type latestVisibleMessageIDStore interface {
+	GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, error)
+}
+
 func durableResponseIDForMessageID(id int64) string {
 	if id <= 0 {
 		return ""
@@ -43,6 +47,24 @@ func latestVisibleMessage(messages []session.Message) (session.Message, bool) {
 		}
 	}
 	return session.Message{}, false
+}
+
+func latestVisibleMessageID(ctx context.Context, store session.Store, sessionID string) (int64, error) {
+	if store == nil || sessionID == "" {
+		return 0, nil
+	}
+	if getter, ok := store.(latestVisibleMessageIDStore); ok {
+		return getter.GetLatestVisibleMessageID(ctx, sessionID)
+	}
+	msgs, err := store.GetMessages(ctx, sessionID, 0, 0)
+	if err != nil {
+		return 0, err
+	}
+	msg, ok := latestVisibleMessage(msgs)
+	if !ok {
+		return 0, nil
+	}
+	return msg.ID, nil
 }
 
 func latestDurableResponseID(messages []session.Message) string {
@@ -83,16 +105,12 @@ func (s *serveServer) resolveDurablePreviousResponseID(ctx context.Context, prev
 	if headerSessionID != "" && headerSessionID != msg.SessionID {
 		return durablePreviousResponseResolution{}, http.StatusConflict, fmt.Sprintf("session_id %q conflicts with previous_response_id session %q", headerSessionID, msg.SessionID)
 	}
-	msgs, err := s.store.GetMessages(ctx, msg.SessionID, 0, 0)
+	latestMsgID, err := latestVisibleMessageID(ctx, s.store, msg.SessionID)
 	if err != nil {
 		return durablePreviousResponseResolution{}, http.StatusBadRequest, fmt.Sprintf("previous_response_id %q not found", previousResponseID)
 	}
-	latest, ok := latestVisibleMessage(msgs)
-	if !ok || latest.ID != msg.ID {
-		latestID := ""
-		if ok {
-			latestID = durableResponseIDForMessageID(latest.ID)
-		}
+	if latestMsgID == 0 || latestMsgID != msg.ID {
+		latestID := durableResponseIDForMessageID(latestMsgID)
 		if latestID == "" {
 			latestID = "unknown"
 		}
@@ -123,9 +141,9 @@ func (s *serveServer) latestDurableResponseIDForSession(ctx context.Context, ses
 	if s == nil || s.store == nil || sessionID == "" {
 		return ""
 	}
-	msgs, err := s.store.GetMessages(ctx, sessionID, 0, 0)
+	msgID, err := latestVisibleMessageID(ctx, s.store, sessionID)
 	if err != nil {
 		return ""
 	}
-	return latestDurableResponseID(msgs)
+	return durableResponseIDForMessageID(msgID)
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4437,11 +4437,13 @@ func TestHandleSessionMessages_DefaultPagination(t *testing.T) {
 	if err := store.Create(ctx, sess); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	var latestVisibleID int64
 	for i := 0; i < sessionMessagesPageSize+5; i++ {
 		msg := session.NewMessage("sess-page", llm.UserText(fmt.Sprintf("msg-%03d", i)), -1)
 		if err := store.AddMessage(ctx, "sess-page", msg); err != nil {
 			t.Fatalf("AddMessage(%d): %v", i, err)
 		}
+		latestVisibleID = msg.ID
 	}
 
 	srv := &serveServer{store: store}
@@ -4454,7 +4456,8 @@ func TestHandleSessionMessages_DefaultPagination(t *testing.T) {
 	}
 
 	var body struct {
-		Messages []struct {
+		LastResponseID string `json:"lastResponseId"`
+		Messages       []struct {
 			Parts []struct {
 				Text string `json:"text"`
 			} `json:"parts"`
@@ -4467,6 +4470,9 @@ func TestHandleSessionMessages_DefaultPagination(t *testing.T) {
 	}
 	if len(body.Messages) != sessionMessagesPageSize {
 		t.Fatalf("message count = %d, want %d", len(body.Messages), sessionMessagesPageSize)
+	}
+	if got := body.LastResponseID; got != durableResponseIDForMessageID(latestVisibleID) {
+		t.Fatalf("first page lastResponseId = %q, want %q", got, durableResponseIDForMessageID(latestVisibleID))
 	}
 	if !body.HasMore {
 		t.Fatal("expected has_more=true for truncated history page")
@@ -4488,7 +4494,8 @@ func TestHandleSessionMessages_DefaultPagination(t *testing.T) {
 		t.Fatalf("page 2 status = %d, want 200", rr.Code)
 	}
 	body = struct {
-		Messages []struct {
+		LastResponseID string `json:"lastResponseId"`
+		Messages       []struct {
 			Parts []struct {
 				Text string `json:"text"`
 			} `json:"parts"`
@@ -4501,6 +4508,9 @@ func TestHandleSessionMessages_DefaultPagination(t *testing.T) {
 	}
 	if len(body.Messages) != 5 {
 		t.Fatalf("page 2 message count = %d, want 5", len(body.Messages))
+	}
+	if got := body.LastResponseID; got != durableResponseIDForMessageID(latestVisibleID) {
+		t.Fatalf("page 2 lastResponseId = %q, want %q", got, durableResponseIDForMessageID(latestVisibleID))
 	}
 	if body.HasMore {
 		t.Fatal("expected has_more=false on final page")

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -86,6 +86,33 @@ func (s *LoggingStore) GetMessageByID(ctx context.Context, msgID int64) (*Messag
 	return msg, err
 }
 
+// GetLatestVisibleMessageID returns the latest persisted user/assistant message id for a session.
+func (s *LoggingStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, error) {
+	getter, ok := s.Store.(interface {
+		GetLatestVisibleMessageID(context.Context, string) (int64, error)
+	})
+	if ok {
+		msgID, err := getter.GetLatestVisibleMessageID(ctx, sessionID)
+		if err != nil {
+			s.logOnce("GetLatestVisibleMessageID", err)
+		}
+		return msgID, err
+	}
+
+	msgs, err := s.Store.GetMessages(ctx, sessionID, 0, 0)
+	if err != nil {
+		s.logOnce("GetLatestVisibleMessageID", err)
+		return 0, err
+	}
+	for i := len(msgs) - 1; i >= 0; i-- {
+		role := string(msgs[i].Role)
+		if role == "user" || role == "assistant" {
+			return msgs[i].ID, nil
+		}
+	}
+	return 0, nil
+}
+
 // UpdateMetrics wraps Store.UpdateMetrics with error logging.
 func (s *LoggingStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
 	err := s.Store.UpdateMetrics(ctx, id, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/sqlitefts"
 	_ "modernc.org/sqlite"
 )
@@ -1947,6 +1948,24 @@ func (s *SQLiteStore) GetMessageByID(ctx context.Context, msgID int64) (*Message
 		return nil, fmt.Errorf("deserialize parts: %w", err)
 	}
 	return &msg, nil
+}
+
+// GetLatestVisibleMessageID retrieves the latest persisted user/assistant message id for a session.
+func (s *SQLiteStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, error) {
+	var msgID int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND role IN (?, ?)
+		ORDER BY sequence DESC, id DESC
+		LIMIT 1`, sessionID, string(llm.RoleUser), string(llm.RoleAssistant)).Scan(&msgID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("query latest visible message id: %w", err)
+	}
+	return msgID, nil
 }
 
 // GetMessages retrieves messages for a session.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -74,6 +74,43 @@ func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreGetLatestVisibleMessageIDSkipsInvisibleTail(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	user := NewMessage(sess.ID, llm.UserText("hello"), 0)
+	if err := store.AddMessage(ctx, sess.ID, user); err != nil {
+		t.Fatalf("AddMessage(user): %v", err)
+	}
+	assistant := NewMessage(sess.ID, llm.AssistantText("hi"), 1)
+	if err := store.AddMessage(ctx, sess.ID, assistant); err != nil {
+		t.Fatalf("AddMessage(assistant): %v", err)
+	}
+	tool := NewMessage(sess.ID, llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartText, Text: "invisible tail"}}}, 2)
+	if err := store.AddMessage(ctx, sess.ID, tool); err != nil {
+		t.Fatalf("AddMessage(tool): %v", err)
+	}
+
+	got, err := store.GetLatestVisibleMessageID(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetLatestVisibleMessageID: %v", err)
+	}
+	if got != assistant.ID {
+		t.Fatalf("latest visible message id = %d, want %d", got, assistant.ID)
+	}
+}
+
 func TestSQLiteStoreReplaceMessagesPreservesUnchangedPrefix(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- Added a targeted SQLite lookup for the latest visible persisted message in a session: `GetLatestVisibleMessageID`, which reads a single `user`/`assistant` row ordered by `sequence DESC LIMIT 1`.
- Updated durable response-id resolution to use that lookup instead of loading and JSON-decoding the entire session transcript just to validate whether a `previous_response_id` is the current tail.
- Updated session message pagination responses to compute `lastResponseId` from the full session tail, not from the current page contents.
- Covered the change with tests for both the SQLite lookup semantics and paginated session message responses.

## Why this is high-value

- This removes unnecessary work from a hot persisted-session path: long sessions no longer require `GetMessages(..., 0, 0)` plus per-row JSON decode just to find the last visible response id.
- It fixes a user-visible correctness issue in paginated web session reloads: the first page of `/v1/sessions/:id/messages` could previously return a stale `lastResponseId` from the truncated page, causing continuation conflicts even though the session itself was valid.
- The fix is narrowly scoped and preserves existing behavior everywhere else.

## Validation

- `gofmt -w cmd/serve_responses_durable.go cmd/serve_handlers.go internal/session/sqlite.go internal/session/logger.go internal/session/sqlite_test.go cmd/serve_test.go`
- `go build ./...`
- `go test ./...`
- Added/updated tests:
  - `TestSQLiteStoreGetLatestVisibleMessageIDSkipsInvisibleTail`
  - `TestHandleSessionMessages_DefaultPagination` now asserts `lastResponseId` stays pinned to the latest visible message across pages
