### PR TITLE
fix: MCP server startup can hang indefinitely and leak stuck subprocesses because `Enable` depends on caller context

### DIFF
--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
@@ -19,6 +20,8 @@ const (
 	StatusReady    ServerStatus = "ready"
 	StatusFailed   ServerStatus = "failed"
 )
+
+var mcpStartupTimeout = 30 * time.Second
 
 // ServerState holds the state of a managed MCP server.
 type ServerState struct {
@@ -35,11 +38,17 @@ type StatusUpdate struct {
 	Error  error
 }
 
+type serverStartup struct {
+	client *Client
+	cancel context.CancelFunc
+}
+
 // Manager handles MCP server lifecycle and provides tools to LLM.
 type Manager struct {
 	config   *Config
 	clients  map[string]*Client
 	statuses map[string]*ServerState
+	startups map[string]*serverStartup
 	mu       sync.RWMutex
 
 	// Channel for status updates (optional, for UI notifications)
@@ -54,6 +63,7 @@ func NewManager() *Manager {
 	return &Manager{
 		clients:  make(map[string]*Client),
 		statuses: make(map[string]*ServerState),
+		startups: make(map[string]*serverStartup),
 	}
 }
 
@@ -192,7 +202,11 @@ func (m *Manager) Enable(ctx context.Context, name string) error {
 		m.samplingHandler.SetServerConfig(name, serverCfg)
 	}
 
+	startCtx, cancel := context.WithTimeout(ctx, mcpStartupTimeout)
+	startup := &serverStartup{client: client, cancel: cancel}
+
 	m.clients[name] = client
+	m.startups[name] = startup
 	m.statuses[name] = &ServerState{
 		Name:   name,
 		Status: StatusStarting,
@@ -204,25 +218,31 @@ func (m *Manager) Enable(ctx context.Context, name string) error {
 
 	// Start in background
 	go func() {
-		err := client.Start(ctx)
+		err := client.Start(startCtx)
+		cancel()
 
 		m.mu.Lock()
+		if currentStartup, ok := m.startups[name]; ok && currentStartup == startup {
+			delete(m.startups, name)
+		}
 		state, ok := m.statuses[name]
-		if !ok {
+		if !ok || state.Client != client {
 			m.mu.Unlock()
 			client.Stop()
 			return
 		}
+
+		status := StatusReady
 		if err != nil {
-			state.Status = StatusFailed
+			status = StatusFailed
 			state.Error = err
 		} else {
-			state.Status = StatusReady
 			state.Error = nil
 		}
+		state.Status = status
 		m.mu.Unlock()
 
-		m.sendStatus(name, state.Status, err)
+		m.sendStatus(name, status, err)
 	}()
 
 	return nil
@@ -231,6 +251,10 @@ func (m *Manager) Enable(ctx context.Context, name string) error {
 // Disable stops an MCP server.
 func (m *Manager) Disable(name string) error {
 	m.mu.Lock()
+	if startup, ok := m.startups[name]; ok {
+		delete(m.startups, name)
+		startup.cancel()
+	}
 	client, ok := m.clients[name]
 	if !ok {
 		m.mu.Unlock()
@@ -264,8 +288,12 @@ func (m *Manager) StopAll() {
 	for _, c := range m.clients {
 		clients = append(clients, c)
 	}
+	for _, startup := range m.startups {
+		startup.cancel()
+	}
 	m.clients = make(map[string]*Client)
 	m.statuses = make(map[string]*ServerState)
+	m.startups = make(map[string]*serverStartup)
 	m.mu.Unlock()
 
 	for _, c := range clients {

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -1,0 +1,117 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestManagerEnable_TimesOutStartupWithBackgroundContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+
+	oldTimeout := mcpStartupTimeout
+	mcpStartupTimeout = 100 * time.Millisecond
+	defer func() { mcpStartupTimeout = oldTimeout }()
+
+	manager := NewManager()
+	manager.config = &Config{Servers: map[string]ServerConfig{
+		"sleepy": {
+			Command: "sh",
+			Args:    []string{"-c", "sleep 10"},
+		},
+	}}
+	defer manager.StopAll()
+
+	if err := manager.Enable(context.Background(), "sleepy"); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+
+	status, err := waitForServerStatus(t, manager, "sleepy", StatusFailed, 3*time.Second)
+	if status != StatusFailed {
+		t.Fatalf("status = %s, want %s", status, StatusFailed)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("status error = %v, want wrapped context deadline exceeded", err)
+	}
+}
+
+func TestManagerDisable_CancelsInFlightStartup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+
+	oldTimeout := mcpStartupTimeout
+	mcpStartupTimeout = 5 * time.Second
+	defer func() { mcpStartupTimeout = oldTimeout }()
+
+	manager := NewManager()
+	manager.config = &Config{Servers: map[string]ServerConfig{
+		"sleepy": {
+			Command: "sh",
+			Args:    []string{"-c", "sleep 10"},
+		},
+	}}
+	defer manager.StopAll()
+
+	enableCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.Enable(enableCtx, "sleepy"); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Disable("sleepy")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Disable returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		cancel()
+		err := <-done
+		t.Fatalf("Disable blocked waiting for startup to finish: %v", err)
+	}
+
+	status, err := manager.ServerStatus("sleepy")
+	if status != StatusStopped {
+		t.Fatalf("status immediately after Disable = %s, want %s", status, StatusStopped)
+	}
+	if err != nil {
+		t.Fatalf("status error immediately after Disable = %v, want nil", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	status, err = manager.ServerStatus("sleepy")
+	if status != StatusStopped {
+		t.Fatalf("status after canceled startup settled = %s, want %s", status, StatusStopped)
+	}
+	if err != nil {
+		t.Fatalf("status error after canceled startup settled = %v, want nil", err)
+	}
+}
+
+func waitForServerStatus(t *testing.T, manager *Manager, name string, want ServerStatus, timeout time.Duration) (ServerStatus, error) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		status, err := manager.ServerStatus(name)
+		if status == want {
+			return status, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	status, err := manager.ServerStatus(name)
+	t.Fatalf("timed out waiting for status %s; last status=%s err=%v", want, status, err)
+	return status, err
+}


### PR DESCRIPTION
## What changed

- Added a manager-owned startup timeout for MCP servers so `Enable` no longer depends on the caller passing a cancelable context.
- Stored per-server startup cancel functions in `Manager` and invoked them from `Disable`/`StopAll` so an in-flight startup can be interrupted.
- Ignored stale startup completions after a server has been disabled or replaced, which prevents canceled starts from flipping the server back to `failed`/`ready`.
- Added regression tests covering:
  - background-context startup timing out instead of hanging forever
  - `Disable` canceling an in-flight startup and leaving the server in `stopped`

## Why this is high-value

Today several TUI call sites use `context.Background()` when enabling/restarting MCP servers. A misbehaving stdio server can therefore hang forever inside `Client.Start`, keep the server stuck in `starting`, and block reliable cleanup because `Disable` had no manager-level way to cancel that startup.

This fix makes MCP startup self-bounded and recoverable from the manager layer, which is important for long-running interactive sessions where a broken MCP server should not require a full app restart.

## Validation

- `gofmt -w internal/mcp/manager.go internal/mcp/manager_test.go`
- `go build ./...`
- `go test ./...`
- Added `internal/mcp/manager_test.go` regression coverage for both timeout and disable-cancel behavior.
