### PR TITLE
fix: Interrupted Telegram replies are only kept in RAM and are dropped from persisted session history

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1521,6 +1521,13 @@ loop:
 		producedMu.Lock()
 		producedSnapshot := append([]llm.Message(nil), produced...)
 		producedMu.Unlock()
+		assistantPersisted := false
+		for _, msg := range producedSnapshot {
+			if msg.Role == llm.RoleAssistant {
+				assistantPersisted = true
+				break
+			}
+		}
 
 		// Edit the Telegram message to show partial text + interrupted marker.
 		display := ""
@@ -1545,8 +1552,21 @@ loop:
 		newHistory = append(newHistory, sess.history...)
 		newHistory = append(newHistory, normalizeUserMessageForHistory(userMsg))
 		newHistory = append(newHistory, producedSnapshot...)
-		// If we have partial text but no tool turns completed, save it.
-		if len(producedSnapshot) == 0 && partial != "" {
+		// If we have partial text but no assistant message was durably captured yet, save it.
+		if !assistantPersisted && partial != "" {
+			if m.store != nil && sess.meta != nil {
+				storeCtx := ctx
+				if storeCtx == nil {
+					storeCtx = context.Background()
+				}
+				persistCtx, cancel := context.WithTimeout(context.WithoutCancel(storeCtx), 5*time.Second)
+				assistantMsg := session.NewMessage(sess.meta.ID, llm.AssistantText(partial), -1)
+				err := m.store.AddMessage(persistCtx, sess.meta.ID, assistantMsg)
+				cancel()
+				if err != nil {
+					log.Printf("[telegram] AddMessage(interrupted_assistant) failed for %s: %v", sess.meta.ID, err)
+				}
+			}
 			newHistory = append(newHistory, llm.AssistantText(partial))
 		}
 		sess.history = newHistory

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,6 +70,68 @@ func (f *fakeBotSender) allTexts() []string {
 	out := make([]string, len(f.sent))
 	copy(out, f.sent)
 	return out
+}
+
+type blockingTextProvider struct {
+	text           string
+	firstChunkSent chan struct{}
+}
+
+func newBlockingTextProvider(text string) *blockingTextProvider {
+	return &blockingTextProvider{
+		text:           text,
+		firstChunkSent: make(chan struct{}),
+	}
+}
+
+func (p *blockingTextProvider) Name() string { return "blocking-text" }
+
+func (p *blockingTextProvider) Credential() string { return "mock" }
+
+func (p *blockingTextProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+
+func (p *blockingTextProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	return &blockingTextStream{
+		ctx:            ctx,
+		text:           p.text,
+		firstChunkSent: p.firstChunkSent,
+		closed:         make(chan struct{}),
+	}, nil
+}
+
+type blockingTextStream struct {
+	ctx            context.Context
+	text           string
+	firstChunkSent chan struct{}
+	closed         chan struct{}
+	closeOnce      sync.Once
+	chunkSent      bool
+	done           bool
+}
+
+func (s *blockingTextStream) Recv() (llm.Event, error) {
+	if !s.chunkSent {
+		s.chunkSent = true
+		close(s.firstChunkSent)
+		return llm.Event{Type: llm.EventTextDelta, Text: s.text}, nil
+	}
+	if s.done {
+		return llm.Event{}, io.EOF
+	}
+	s.done = true
+	select {
+	case <-s.ctx.Done():
+		return llm.Event{}, s.ctx.Err()
+	case <-s.closed:
+		return llm.Event{}, io.EOF
+	}
+}
+
+func (s *blockingTextStream) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.closed)
+	})
+	return nil
 }
 
 // newTestMgrAndSession builds a minimal manager and session backed by h's engine.
@@ -580,6 +643,94 @@ func TestStreamReply_StreamEventErrorReturnsError(t *testing.T) {
 		if text == "(no response)" || text == "(done)" {
 			t.Fatalf("unexpected fallback text after stream error: %q", text)
 		}
+	}
+}
+
+func TestStreamReply_PersistsInterruptedPartialAssistantReply(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telegram-interrupt.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer store.Close()
+
+	provider := newBlockingTextProvider("partial answer")
+	mgr := &telegramSessionMgr{
+		sessions:       make(map[int64]*telegramSession),
+		store:          store,
+		tickerInterval: 5 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       llm.NewEngine(provider, llm.NewToolRegistry()),
+					ProviderName: "mock",
+					ModelName:    "test",
+				}, nil
+			},
+		},
+	}
+
+	sess, err := mgr.getOrCreate(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("getOrCreate failed: %v", err)
+	}
+
+	bot := &fakeBotSender{}
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hi"))
+	}()
+
+	select {
+	case <-provider.firstChunkSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider never emitted first chunk")
+	}
+
+	sess.cancelMu.Lock()
+	cancel := sess.streamCancel
+	sess.cancelMu.Unlock()
+	if cancel == nil {
+		t.Fatal("expected stream cancel function to be set")
+	}
+	cancel()
+
+	select {
+	case err := <-streamDone:
+		if err != nil {
+			t.Fatalf("streamReply returned error after interrupt: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamReply did not return after interrupt")
+	}
+
+	meta, err := store.Get(context.Background(), sess.meta.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if meta.Status != session.StatusInterrupted {
+		t.Fatalf("session status = %s, want %s", meta.Status, session.StatusInterrupted)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), sess.meta.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+
+	var foundAssistant bool
+	for _, msg := range msgs {
+		if msg.Role == llm.RoleAssistant && msg.TextContent == "partial answer" {
+			foundAssistant = true
+			break
+		}
+	}
+	if !foundAssistant {
+		t.Fatalf("expected persisted partial assistant message, got %#v", msgs)
+	}
+
+	if got := bot.lastText(); !strings.Contains(got, "partial answer") || !strings.Contains(got, "(interrupted)") {
+		t.Fatalf("final telegram text = %q, want partial answer with interrupted marker", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Persist the partial assistant reply in the Telegram interrupt path when streaming was canceled before any assistant message had been durably written.
- Use a short timeout with `context.WithoutCancel(...)` for that best-effort write so the interrupt itself does not cancel the save.
- Keep in-memory history aligned with the persisted fallback logic by treating "assistant already captured" separately from "any produced messages exist".
- Add a regression test covering an interrupted plain-text Telegram reply and asserting the partial assistant text is stored with interrupted session status.

## Why this is high-value

Interrupting an in-flight Telegram reply is a normal user action. Before this change, the user could see a partial answer plus an interrupted marker in Telegram, but that assistant text was never saved to the session store if streaming stopped before completion callbacks fired. After a restart or when restoring history from disk, the visible assistant output was lost. This change closes that real data-loss path with a minimal, targeted fallback.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./...`
- Added `TestStreamReply_PersistsInterruptedPartialAssistantReply`
- `git diff --stat`
- `git diff --check`
