### PR TITLE
fix: Response-run replay disables compaction forever after approvals/interjections and can retain every streamed token event

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -34,14 +34,20 @@ type responseRunRecoveryTool struct {
 }
 
 type responseRunRecoveryMessage struct {
-	ID       string
-	Role     string
-	Content  []byte
-	Created  int64
-	Tools    []responseRunRecoveryTool
-	Expanded bool
-	Status   string
-	Usage    map[string]any
+	ID             string
+	Role           string
+	Content        []byte
+	Created        int64
+	Tools          []responseRunRecoveryTool
+	Expanded       bool
+	Status         string
+	Usage          map[string]any
+	InterruptState string
+}
+
+type responseRunRecoveryEvent struct {
+	Event   string
+	Payload map[string]any
 }
 
 type responseRunSubscribeResult struct {
@@ -72,6 +78,7 @@ type responseRun struct {
 	minReplayAfter     int64
 	maxRetainedEvents  int
 	recoveryMessages   []responseRunRecoveryMessage
+	recoveryEvents     []responseRunRecoveryEvent
 	nextMessageOrdinal int64
 	currentAssistant   int
 	currentToolGroup   int
@@ -312,8 +319,26 @@ func (r *responseRun) activeEventsLocked() []responseRunEvent {
 
 func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]any) {
 	switch event {
-	case "response.ask_user.prompt", "response.approval.prompt", "response.interjection":
-		r.compactionEnabled = false
+	case "response.ask_user.prompt", "response.approval.prompt":
+		r.recoveryEvents = append(r.recoveryEvents, responseRunRecoveryEvent{
+			Event:   event,
+			Payload: cloneJSONMap(payload),
+		})
+	case "response.interjection":
+		text := stringValue(payload["text"])
+		if text == "" {
+			return
+		}
+		r.closeToolGroupLocked()
+		r.currentAssistant = -1
+		r.recoveryMessages = append(r.recoveryMessages, responseRunRecoveryMessage{
+			ID:             r.nextRecoveryMessageIDLocked("user"),
+			Role:           "user",
+			Content:        []byte(text),
+			Created:        time.Now().UnixMilli(),
+			InterruptState: "interject",
+		})
+		return
 	}
 
 	switch event {
@@ -558,7 +583,7 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 		"sequence_number":  r.lastSequenceNumber,
 		"min_replay_after": r.minReplayAfter,
 	}
-	if len(r.recoveryMessages) == 0 {
+	if len(r.recoveryMessages) == 0 && len(r.recoveryEvents) == 0 {
 		return recovery
 	}
 
@@ -574,6 +599,9 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 		}
 		if msg.Status != "" {
 			entry["status"] = msg.Status
+		}
+		if msg.InterruptState != "" {
+			entry["interruptState"] = msg.InterruptState
 		}
 		if msg.Expanded {
 			entry["expanded"] = msg.Expanded
@@ -605,6 +633,17 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 		messages = append(messages, entry)
 	}
 	recovery["messages"] = messages
+	if len(r.recoveryEvents) > 0 {
+		events := make([]map[string]any, 0, len(r.recoveryEvents))
+		for _, ev := range r.recoveryEvents {
+			entry := map[string]any{"event": ev.Event}
+			if payload := cloneJSONMap(ev.Payload); len(payload) > 0 {
+				entry["payload"] = payload
+			}
+			events = append(events, entry)
+		}
+		recovery["events"] = events
+	}
 	return recovery
 }
 
@@ -630,9 +669,8 @@ func (r *responseRun) cancelRun() bool {
 }
 
 func (r *responseRun) disableCompaction() {
-	r.mu.Lock()
-	r.compactionEnabled = false
-	r.mu.Unlock()
+	// Interactive prompt/interjection state is preserved via response snapshots
+	// and runtime state, so the raw replay log should stay bounded.
 }
 
 type responseRunManager struct {

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -231,6 +231,124 @@ func TestResponseRunRecoveryStoresToolImagesAsArtifacts(t *testing.T) {
 	}
 }
 
+func TestResponseRunInteractiveRecoveryDoesNotDisableCompaction(t *testing.T) {
+	run := newResponseRun("resp_interactive", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	run.maxRetainedEvents = 3
+	run.disableCompaction()
+
+	if err := run.appendEvent("response.ask_user.prompt", map[string]any{
+		"call_id": "call_ask",
+		"questions": []any{
+			map[string]any{"header": "Color", "question": "Pick one"},
+		},
+	}); err != nil {
+		t.Fatalf("append ask_user prompt: %v", err)
+	}
+	if err := run.appendEvent("response.approval.prompt", map[string]any{
+		"approval_id": "appr_1",
+		"path":        "/tmp/file.txt",
+		"options": []any{
+			map[string]any{"index": 0, "choice": "once"},
+		},
+	}); err != nil {
+		t.Fatalf("append approval prompt: %v", err)
+	}
+
+	promptRecovery := run.recoveryPayloadLocked()
+	promptEvents, ok := promptRecovery["events"].([]map[string]any)
+	if !ok {
+		t.Fatalf("prompt recovery events type = %T", promptRecovery["events"])
+	}
+	if len(promptEvents) != 2 {
+		t.Fatalf("prompt recovery event count = %d, want 2", len(promptEvents))
+	}
+
+	for i := 0; i < 6; i++ {
+		if err := run.appendTextDeltaEvent(0, "x"); err != nil {
+			t.Fatalf("appendTextDeltaEvent failed at %d: %v", i, err)
+		}
+	}
+
+	run.mu.Lock()
+	activeLen := len(run.events) - run.eventStart
+	storageLen := len(run.events)
+	minReplayAfter := run.minReplayAfter
+	run.mu.Unlock()
+
+	if activeLen != 3 {
+		t.Fatalf("active retained events = %d, want 3", activeLen)
+	}
+	if storageLen > 6 {
+		t.Fatalf("storage length = %d, want bounded near replay window", storageLen)
+	}
+	if minReplayAfter != 5 {
+		t.Fatalf("minReplayAfter = %d, want 5", minReplayAfter)
+	}
+
+	recovery := run.recoveryPayloadLocked()
+	events, ok := recovery["events"].([]map[string]any)
+	if !ok {
+		t.Fatalf("recovery events type = %T", recovery["events"])
+	}
+	if len(events) != 2 {
+		t.Fatalf("recovery event count = %d, want 2", len(events))
+	}
+	if events[0]["event"] != "response.ask_user.prompt" {
+		t.Fatalf("recovery events[0] = %#v, want ask_user prompt", events[0])
+	}
+	payload, ok := events[0]["payload"].(map[string]any)
+	if !ok || payload["call_id"] != "call_ask" {
+		t.Fatalf("ask_user recovery payload = %#v", events[0]["payload"])
+	}
+	if events[1]["event"] != "response.approval.prompt" {
+		t.Fatalf("recovery events[1] = %#v, want approval prompt", events[1])
+	}
+}
+
+func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
+	run := newResponseRun("resp_interjection", "sess_test", "", "mock", time.Now().Unix(), func() {})
+
+	if err := run.appendTextDeltaEvent(0, "before"); err != nil {
+		t.Fatalf("appendTextDeltaEvent before: %v", err)
+	}
+	if err := run.appendEvent("response.interjection", map[string]any{"text": "check X"}); err != nil {
+		t.Fatalf("append interjection: %v", err)
+	}
+	if err := run.appendTextDeltaEvent(0, "after"); err != nil {
+		t.Fatalf("appendTextDeltaEvent after: %v", err)
+	}
+
+	recovery := run.recoveryPayloadLocked()
+	messages, ok := recovery["messages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("recovery messages type = %T", recovery["messages"])
+	}
+	if len(messages) != 3 {
+		t.Fatalf("recovery message count = %d, want 3", len(messages))
+	}
+	if got := messages[0]["role"]; got != "assistant" {
+		t.Fatalf("messages[0].role = %v, want assistant", got)
+	}
+	if got := messages[0]["content"]; got != "before" {
+		t.Fatalf("messages[0].content = %v, want before", got)
+	}
+	if got := messages[1]["role"]; got != "user" {
+		t.Fatalf("messages[1].role = %v, want user", got)
+	}
+	if got := messages[1]["content"]; got != "check X" {
+		t.Fatalf("messages[1].content = %v, want check X", got)
+	}
+	if got := messages[1]["interruptState"]; got != "interject" {
+		t.Fatalf("messages[1].interruptState = %v, want interject", got)
+	}
+	if got := messages[2]["role"]; got != "assistant" {
+		t.Fatalf("messages[2].role = %v, want assistant", got)
+	}
+	if got := messages[2]["content"]; got != "after" {
+		t.Fatalf("messages[2].content = %v, want after", got)
+	}
+}
+
 func TestResponseRunConcurrentAppendsPreserveOrder(t *testing.T) {
 	const totalEvents = 200
 	const numWriters = 4


### PR DESCRIPTION
## What changed

- Kept response-run event compaction enabled even after `response.ask_user.prompt`, `response.approval.prompt`, and `response.interjection` so the raw replay log still respects `maxRetainedEvents`.
- Preserved interactive recovery state separately from the raw event buffer:
  - ask-user and approval prompt payloads are now retained in `recovery.events`
  - interjections are now captured in `recovery.messages` as a user message with `interruptState: "interject"`, which also correctly splits assistant output across the interruption
- Added focused tests covering:
  - compaction still happening after interactive prompts / `disableCompaction()` call sites
  - prompt-only recovery snapshots retaining interactive events
  - interjections surviving snapshot recovery and splitting assistant messages correctly

## Why this is high-value

Before this change, any approval, ask-user prompt, or interjection permanently disabled response-run compaction. After that point, long runs retained every `response.output_text.delta` event in memory until run cleanup, so per-run heap usage and replay work grew linearly with streamed output size.

This fix restores the bounded 2048-event replay window for interactive runs while still preserving the interactive state needed for snapshot-based recovery. That reduces retained allocations, GC pressure, and reconnect replay cost for the long-running serve process, especially on agentic runs that stream lots of tokens after an approval or interruption.

## Validation

- `gofmt -w cmd/serve_response_runs.go cmd/serve_response_runs_test.go`
- `go build ./...`
- `go test ./...`
- Added/ran targeted tests in `cmd/serve_response_runs_test.go` for the compaction and recovery behavior above.
