### PR TITLE
fix: emit on_complete output as JSON events

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -933,7 +934,25 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		}
 
 		if output != "" {
-			if err := runOnComplete(agent.OnComplete, output); err != nil {
+			if askJSON {
+				if err := emitOnCompleteStarted(jsonEmit); err != nil {
+					return err
+				}
+				result, err := runOnCompleteCapture(agent.OnComplete, output)
+				if result.Stdout != "" {
+					if emitErr := emitOnCompleteOutput(jsonEmit, result.Stdout); emitErr != nil {
+						return emitErr
+					}
+				}
+				if err != nil {
+					if emitErr := emitOnCompleteFailed(jsonEmit, result.Stderr, err); emitErr != nil {
+						return emitErr
+					}
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: on_complete failed: %v\n", err)
+				} else if err := emitOnCompleteCompleted(jsonEmit, result.Stderr); err != nil {
+					return err
+				}
+			} else if err := runOnComplete(agent.OnComplete, output); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: on_complete failed: %v\n", err)
 			}
 		}
@@ -2450,10 +2469,14 @@ func writeCommitEditMsg(message string) error {
 	return os.WriteFile(guiPath, data, 0644)
 }
 
-// runOnComplete executes the on_complete shell command with input piped to stdin.
-// Runs in the git repo root if available, else cwd.
-func runOnComplete(command, input string) error {
-	// Run in git repo root if available, else cwd
+type onCompleteResult struct {
+	Stdout string
+	Stderr string
+}
+
+// runOnCompleteCapture executes the on_complete shell command with input piped to stdin
+// and captures stdout/stderr. Runs in the git repo root if available, else cwd.
+func runOnCompleteCapture(command, input string) (onCompleteResult, error) {
 	dir := "."
 	if gitInfo := tools.DetectGitRepo("."); gitInfo.IsRepo {
 		dir = gitInfo.Root
@@ -2462,10 +2485,26 @@ func runOnComplete(command, input string) error {
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(input)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return onCompleteResult{Stdout: stdout.String(), Stderr: stderr.String()}, err
+}
+
+// runOnComplete executes the on_complete shell command with input piped to stdin.
+// Runs in the git repo root if available, else cwd.
+func runOnComplete(command, input string) error {
+	result, err := runOnCompleteCapture(command, input)
+	if result.Stdout != "" {
+		fmt.Fprint(os.Stdout, result.Stdout)
+	}
+	if result.Stderr != "" {
+		fmt.Fprint(os.Stderr, result.Stderr)
+	}
+	return err
 }
 
 func progressiveOutputText(result progressiveRunResult) string {

--- a/cmd/ask_json.go
+++ b/cmd/ask_json.go
@@ -291,6 +291,47 @@ func emitProgressiveResult(e *jsonEmitter, result progressiveRunResult) error {
 	return e.emit("progressive.result", payload)
 }
 
+// emitOnCompleteStarted writes the lifecycle event for an agent on_complete hook.
+func emitOnCompleteStarted(e *jsonEmitter) error {
+	return e.emit("on_complete.started", map[string]any{})
+}
+
+// emitOnCompleteOutput writes captured on_complete stdout as a typed JSONL event.
+// The raw stdout is always available as text; valid JSON stdout is also decoded
+// into the json field for consumers that want structured output directly.
+func emitOnCompleteOutput(e *jsonEmitter, stdout string) error {
+	payload := map[string]any{"text": stdout}
+	var decoded any
+	if err := json.Unmarshal([]byte(stdout), &decoded); err == nil {
+		payload["json"] = decoded
+	}
+	return e.emit("on_complete.output", payload)
+}
+
+// emitOnCompleteCompleted writes the successful terminal lifecycle event for an
+// agent on_complete hook. stderr is included when present.
+func emitOnCompleteCompleted(e *jsonEmitter, stderr string) error {
+	payload := map[string]any{}
+	if stderr != "" {
+		payload["stderr"] = stderr
+	}
+	return e.emit("on_complete.completed", payload)
+}
+
+// emitOnCompleteFailed writes the failed lifecycle event for an agent
+// on_complete hook. The command failure remains non-fatal to preserve
+// historical ask behavior.
+func emitOnCompleteFailed(e *jsonEmitter, stderr string, err error) error {
+	payload := map[string]any{"message": ""}
+	if err != nil {
+		payload["message"] = err.Error()
+	}
+	if stderr != "" {
+		payload["stderr"] = stderr
+	}
+	return e.emit("on_complete.failed", payload)
+}
+
 // emitFatalError emits a fatal error event, then stats/done so consumers
 // always see a clean terminal record.
 func emitFatalError(e *jsonEmitter, stats *ui.SessionStats, err error) error {

--- a/cmd/ask_json_test.go
+++ b/cmd/ask_json_test.go
@@ -506,6 +506,95 @@ func TestEmitProgressiveResult_OmitsEmptyOptionals(t *testing.T) {
 	}
 }
 
+func TestEmitOnCompleteOutput_JSONStdoutIncludesDecodedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newJSONEmitter(&buf)
+	stdout := `{"title":"Set","tracks":[{"spotify_uri":"spotify:track:123"}]}`
+
+	if err := emitOnCompleteOutput(emitter, stdout); err != nil {
+		t.Fatalf("emitOnCompleteOutput error: %v", err)
+	}
+
+	events := parseJSONL(t, buf.String())
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev["type"] != "on_complete.output" {
+		t.Fatalf("type = %v", ev["type"])
+	}
+	if ev["text"] != stdout {
+		t.Errorf("text = %v, want %q", ev["text"], stdout)
+	}
+	decoded, ok := ev["json"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected json object, got %T: %v", ev["json"], ev["json"])
+	}
+	if decoded["title"] != "Set" {
+		t.Errorf("json.title = %v", decoded["title"])
+	}
+}
+
+func TestEmitOnCompleteOutput_TextStdoutOmitsDecodedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newJSONEmitter(&buf)
+	stdout := "plain text\n"
+
+	if err := emitOnCompleteOutput(emitter, stdout); err != nil {
+		t.Fatalf("emitOnCompleteOutput error: %v", err)
+	}
+
+	events := parseJSONL(t, buf.String())
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev["type"] != "on_complete.output" {
+		t.Fatalf("type = %v", ev["type"])
+	}
+	if ev["text"] != stdout {
+		t.Errorf("text = %v, want %q", ev["text"], stdout)
+	}
+	if _, ok := ev["json"]; ok {
+		t.Errorf("expected no json field for plain text stdout, got %v", ev["json"])
+	}
+}
+
+func TestEmitOnCompleteCompletedAndFailedIncludeStderr(t *testing.T) {
+	var buf bytes.Buffer
+	emitter := newJSONEmitter(&buf)
+
+	if err := emitOnCompleteStarted(emitter); err != nil {
+		t.Fatalf("emitOnCompleteStarted error: %v", err)
+	}
+	if err := emitOnCompleteCompleted(emitter, "note\n"); err != nil {
+		t.Fatalf("emitOnCompleteCompleted error: %v", err)
+	}
+	if err := emitOnCompleteFailed(emitter, "bad\n", errors.New("exit status 7")); err != nil {
+		t.Fatalf("emitOnCompleteFailed error: %v", err)
+	}
+
+	events := parseJSONL(t, buf.String())
+	wantTypes := []string{"on_complete.started", "on_complete.completed", "on_complete.failed"}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("events = %v, want %d", events, len(wantTypes))
+	}
+	for i, want := range wantTypes {
+		if events[i]["type"] != want {
+			t.Errorf("event %d type = %v, want %q", i, events[i]["type"], want)
+		}
+	}
+	if events[1]["stderr"] != "note\n" {
+		t.Errorf("completed stderr = %v", events[1]["stderr"])
+	}
+	if events[2]["stderr"] != "bad\n" {
+		t.Errorf("failed stderr = %v", events[2]["stderr"])
+	}
+	if events[2]["message"] != "exit status 7" {
+		t.Errorf("failed message = %v", events[2]["message"])
+	}
+}
+
 // signalWriter wraps an io.Writer and sends (non-blocking) on ready
 // after each successful write. Used in tests to sync on "first flush"
 // without relying on time.Sleep.

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -32,6 +32,32 @@ Some nice syntax improvements:
 
 It's an exciting release that balances new experimental features with practical improvements!`
 
+func TestRunOnCompleteCapture_CapturesStdout(t *testing.T) {
+	result, err := runOnCompleteCapture("cat", "hello")
+	if err != nil {
+		t.Fatalf("runOnCompleteCapture error: %v", err)
+	}
+	if result.Stdout != "hello" {
+		t.Errorf("stdout = %q, want %q", result.Stdout, "hello")
+	}
+	if result.Stderr != "" {
+		t.Errorf("stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func TestRunOnCompleteCapture_CapturesStderrAndError(t *testing.T) {
+	result, err := runOnCompleteCapture("echo err >&2; exit 7", "")
+	if err == nil {
+		t.Fatal("expected command error, got nil")
+	}
+	if result.Stdout != "" {
+		t.Errorf("stdout = %q, want empty", result.Stdout)
+	}
+	if result.Stderr != "err\n" {
+		t.Errorf("stderr = %q, want %q", result.Stderr, "err\n")
+	}
+}
+
 func TestMarkdownRendering(t *testing.T) {
 	width := 80
 


### PR DESCRIPTION
## What

Makes `term-llm ask --json` keep `agent.on_complete` stdout inside the typed JSONL event stream.

Adds lifecycle/output events:

- `on_complete.started`
- `on_complete.output` with raw `text`, plus decoded `json` when stdout is valid JSON
- `on_complete.completed`
- `on_complete.failed`

Non-JSON `ask` behavior is preserved by replaying captured stdout/stderr to the original streams.

## Why

Agents using `output_tool` + `on_complete` currently emit typed progress events and then append raw untyped JSON/text to stdout after `done`. That forces `--json` consumers to special-case the final line. This keeps the whole output consumable as JSONL events while preserving the existing non-fatal warning behavior for failed `on_complete` hooks.

## Tests

- `go test ./cmd`
- `go test ./...`
- `go build ./...`
