### PR TITLE
fix: Session store's supported `:memory:` mode is unsafe with the default `sql.DB` pool

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -172,6 +172,11 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
+	if dbPath == ":memory:" {
+		// Required for raw :memory: databases: keep a single connection so
+		// schema and session data stay visible to every operation.
+		db.SetMaxOpenConns(1)
+	}
 
 	// Initialize schema and run migrations.
 	// Read-only mode skips initialization because it cannot write schema changes.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -29,6 +29,18 @@ func TestSessionPreferredTitlePrecedence(t *testing.T) {
 	}
 }
 
+func TestNewSQLiteStoreMemoryDBUsesSingleConnection(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	if got := store.db.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("MaxOpenConnections = %d, want 1 for :memory: databases", got)
+	}
+}
+
 func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- In `internal/session/sqlite.go`, `NewSQLiteStore` now special-cases `session.path: :memory:` and calls `db.SetMaxOpenConns(1)` immediately after `sql.Open`.
- Added `TestNewSQLiteStoreMemoryDBUsesSingleConnection` to lock in that safeguard for in-memory session stores.

## Why this is high-value

`session.path: :memory:` is explicitly supported, but raw SQLite `:memory:` databases are per-connection. With the default `sql.DB` pool, a second pooled connection can see a different empty database, which makes session persistence flaky under concurrency and can surface as missing rows, missing schema, or apparent data loss.

This fix is small, low-risk, and matches the existing reliability guard already used for the jobs `:memory:` database path.

## Validation

- Inspected current session store code and confirmed it opened raw `:memory:` without constraining the pool.
- `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
