### PR TITLE
fix: prevent sidebar title descender clipping

### DIFF
--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -562,7 +562,7 @@
 
     .session-title {
       font-size: 0.9rem;
-      line-height: 1.2;
+      line-height: 1.3;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
## What

Increase the sidebar session title line-height from `1.2` to `1.3`.

## Why

Session titles use `overflow: hidden` for single-line ellipsis. With the previous line-height, descenders like the bottom of `g` could be clipped by the line box in the web UI sidebar.

## Test

```sh
go test ./...
```
