### PR TITLE
perf(ui): smooth assistant stream tail rendering

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -804,10 +804,21 @@ const getOrCreateAssistantStreamState = (message, body) => {
   return streamState;
 };
 
+const assistantStreamMutableLength = (streamState) => {
+  const content = String(streamState?.latestContent || '');
+  const stableLength = Math.max(0, Number(streamState?.stableLength) || 0);
+  if (stableLength <= 0) return content.length;
+
+  const stableSource = String(streamState?.stableSource || '');
+  if (stableSource && !content.startsWith(stableSource)) return content.length;
+  return Math.max(0, content.length - Math.min(stableLength, content.length));
+};
+
 const scheduleAssistantStreamRender = (streamState) => {
   if (!streamState || streamState.rendering || streamState.rafId || streamState.timerId) return;
+  const renderLength = assistantStreamMutableLength(streamState);
   const renderDelay = app.markdownStreaming && typeof app.markdownStreaming.nextStreamingRenderDelay === 'function'
-    ? app.markdownStreaming.nextStreamingRenderDelay(streamState.latestContent.length)
+    ? app.markdownStreaming.nextStreamingRenderDelay(renderLength)
     : 33;
   const elapsed = Date.now() - streamState.lastRenderAt;
   if (elapsed >= renderDelay) {
@@ -896,7 +907,14 @@ const renderAssistantTailPlainText = (streamState, tail) => {
 
   const prevLen = (streamState.lastTailSource || '').length;
   if (prevLen > 0 && tail.length > prevLen) {
-    textNode.textContent += tail.slice(prevLen);
+    const delta = tail.slice(prevLen);
+    if (typeof textNode.appendData === 'function') {
+      textNode.appendData(delta);
+    } else {
+      textNode.textContent += delta;
+    }
+  } else if ('data' in textNode) {
+    textNode.data = tail;
   } else {
     textNode.textContent = tail;
   }

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -244,6 +244,13 @@ function createDocument() {
     createTextNode(text) {
       const node = new Element('#text');
       node.textContent = String(text || '');
+      node.appendData = function appendData(value) {
+        this.textContent += String(value || '');
+      };
+      Object.defineProperty(node, 'data', {
+        get() { return this.textContent; },
+        set(value) { this.textContent = String(value || ''); },
+      });
       return node;
     },
     addEventListener() {},
@@ -692,6 +699,68 @@ async function run(name, fn) {
 
     assertEqual(messages.children[0].querySelector('.turn-action-panel'), firstTurnPanel, 'earlier turn panel still preserved on later stream ticks');
     assertEqual(messages.children[2].querySelector('.turn-action-panel'), streamedPanel, 'streaming assistant panel is reused across ticks');
+  });
+
+  await run('plain streaming tail appends text node data instead of replacing full text', () => {
+    const { app, document, timers } = createHarness();
+    const appended = [];
+    document.createTextNode = (text) => {
+      const node = new Element('#text');
+      node.textContent = String(text || '');
+      node.appendData = (value) => {
+        appended.push(String(value || ''));
+        node.textContent += String(value || '');
+      };
+      Object.defineProperty(node, 'data', {
+        get() { return node.textContent; },
+        set(value) { node.textContent = String(value || ''); },
+      });
+      return node;
+    };
+
+    const message = { id: 'stream-plain', role: 'assistant', content: 'Hello', created: Date.now() };
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    message.content = 'Hello world';
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    assertEqual(appended.length, 1, 'one incremental text append');
+    assertEqual(appended[0], ' world', 'only new delta is appended');
+  });
+
+  await run('stream render cadence uses mutable tail length after stable markdown promotion', () => {
+    const observedLengths = [];
+    const streamingHelpers = {
+      ...markdownStreaming,
+      nextStreamingRenderDelay(length) {
+        observedLengths.push(length);
+        return markdownStreaming.nextStreamingRenderDelay(length);
+      },
+    };
+    const { app, timers } = createHarness({ markdownStreaming: streamingHelpers });
+    const paragraph = 'Stable paragraph with enough prose to be markdown-rendered later.\n\n';
+    const stablePrefix = paragraph.repeat(180);
+    const message = {
+      id: 'stream-stable-tail',
+      role: 'assistant',
+      content: `${stablePrefix}Live markdown tail with **formatting** that keeps streaming.`,
+      created: Date.now(),
+    };
+
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    message.content += ' more plain tail';
+    app.enqueueAssistantStreamUpdate(message);
+
+    const lastObservedLength = observedLengths[observedLengths.length - 1];
+    assert(lastObservedLength > 0, 'scheduler should inspect a non-empty mutable tail');
+    assert(
+      lastObservedLength < 1000,
+      `expected cadence to use mutable tail length, got ${lastObservedLength}`
+    );
   });
 
   await run('done finalized tool args are not rebuilt on later group updates', () => {


### PR DESCRIPTION
## What

- Append plain-text stream deltas with `Text.appendData()` instead of rebuilding the full text node string.
- Base assistant stream render cadence on the mutable tail length after stable markdown has been promoted, rather than the full accumulated message length.
- Add UI tests covering incremental text-node appends and short-tail cadence after stable markdown promotion.

## Why

The web UI already splits streaming assistant markdown into stable and tail containers. Once stable markdown has been promoted, the remaining mutable tail can be small even when the full assistant message is large. Using the full message length for throttling makes long-but-mostly-stable responses unnecessarily chunky.

The plain-text fast path was also doing `textContent += delta`, which still reads and rewrites the text node's full string. `appendData()` keeps the operation truly incremental for ordinary prose streaming.

## Tests

```text
node internal/serveui/static/app_render_test.js
node internal/serveui/static/markdown_streaming_test.js
for f in internal/serveui/static/*_test.js; do node "$f"; done
go test ./cmd ./internal/serveui/...
go test ./...
```
