### PR TITLE
fix: FTS session-browser refresh loads full transcripts for every hit

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1475,9 +1475,14 @@ func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]Se
 		return []SearchResult{}, nil
 	}
 
+	messageCountCol := "COALESCE(s.message_count, 0)"
+	if !s.hasMessageCount {
+		messageCountCol = "(SELECT COUNT(*) FROM messages WHERE session_id = s.id AND role IN ('user', 'assistant'))"
+	}
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT m.session_id, s.number, m.id, s.name, s.summary, snippet(messages_fts, 0, '**', '**', '...', 32),
-		       s.provider, s.model, m.created_at
+		       s.provider, s.model, s.mode, s.status, `+messageCountCol+` as message_count, s.created_at, s.updated_at, m.created_at
 		FROM messages_fts f
 		JOIN messages m ON m.id = f.rowid
 		JOIN sessions s ON s.id = m.session_id
@@ -1493,13 +1498,20 @@ func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]Se
 	for rows.Next() {
 		var r SearchResult
 		var number sql.NullInt64
+		var mode, status sql.NullString
 		err := rows.Scan(&r.SessionID, &number, &r.MessageID, &r.SessionName, &r.Summary,
-			&r.Snippet, &r.Provider, &r.Model, &r.CreatedAt)
+			&r.Snippet, &r.Provider, &r.Model, &mode, &status, &r.MessageCount, &r.SessionCreatedAt, &r.UpdatedAt, &r.CreatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("scan search result: %w", err)
 		}
 		if number.Valid {
 			r.SessionNumber = number.Int64
+		}
+		if mode.Valid {
+			r.Mode = SessionMode(mode.String)
+		}
+		if status.Valid {
+			r.Status = SessionStatus(status.String)
 		}
 		results = append(results, r)
 	}

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -420,6 +420,21 @@ func TestSQLiteStoreSearchEscapesUserQueryForFTS(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("Search(term-llm) len = %d, want 1", len(results))
 	}
+	if results[0].Mode != ModeChat {
+		t.Fatalf("Search(term-llm) mode = %q, want %q", results[0].Mode, ModeChat)
+	}
+	if results[0].Status != StatusActive {
+		t.Fatalf("Search(term-llm) status = %q, want %q", results[0].Status, StatusActive)
+	}
+	if results[0].MessageCount != 1 {
+		t.Fatalf("Search(term-llm) message_count = %d, want 1", results[0].MessageCount)
+	}
+	if results[0].SessionCreatedAt.IsZero() {
+		t.Fatal("Search(term-llm) session_created_at = zero, want populated timestamp")
+	}
+	if results[0].UpdatedAt.IsZero() {
+		t.Fatal("Search(term-llm) updated_at = zero, want populated timestamp")
+	}
 }
 
 func TestSQLiteStorePersistsDeveloperMessages(t *testing.T) {

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -157,15 +157,20 @@ type ListOptions struct {
 
 // SearchResult represents a search match.
 type SearchResult struct {
-	SessionID     string    `json:"session_id"`
-	SessionNumber int64     `json:"session_number"` // Sequential session number
-	MessageID     int64     `json:"message_id"`
-	SessionName   string    `json:"session_name"`
-	Summary       string    `json:"summary"`
-	Snippet       string    `json:"snippet"` // Matched text snippet
-	Provider      string    `json:"provider"`
-	Model         string    `json:"model"`
-	CreatedAt     time.Time `json:"created_at"`
+	SessionID        string        `json:"session_id"`
+	SessionNumber    int64         `json:"session_number"` // Sequential session number
+	MessageID        int64         `json:"message_id"`
+	SessionName      string        `json:"session_name"`
+	Summary          string        `json:"summary"`
+	Snippet          string        `json:"snippet"` // Matched text snippet
+	Provider         string        `json:"provider"`
+	Model            string        `json:"model"`
+	Mode             SessionMode   `json:"mode,omitempty"`
+	Status           SessionStatus `json:"status,omitempty"`
+	MessageCount     int           `json:"message_count"`
+	SessionCreatedAt time.Time     `json:"session_created_at"`
+	UpdatedAt        time.Time     `json:"updated_at"`
+	CreatedAt        time.Time     `json:"created_at"`
 }
 
 // NewMessage creates a new Message from an llm.Message with the given session ID and sequence.

--- a/internal/tui/sessions/browse.go
+++ b/internal/tui/sessions/browse.go
@@ -390,7 +390,7 @@ func (m *Model) doRefresh() (tea.Model, tea.Cmd) {
 			m.err = err
 			return m, nil
 		}
-		// Convert search results to summaries (need to fetch each session)
+		// Convert search results to summaries using session metadata already returned by search.
 		var summaries []session.SessionSummary
 		seen := make(map[string]bool)
 		for _, r := range results {
@@ -398,28 +398,22 @@ func (m *Model) doRefresh() (tea.Model, tea.Cmd) {
 				continue
 			}
 			seen[r.SessionID] = true
-			// Fetch full session to get summary data
-			sess, err := m.store.Get(ctx, r.SessionID)
-			if err != nil || sess == nil {
-				continue
-			}
 			// Apply status filter
-			if status != "" && sess.Status != status {
+			if status != "" && r.Status != status {
 				continue
 			}
-			msgs, _ := m.store.GetMessages(ctx, sess.ID, 0, 0)
 			summaries = append(summaries, session.SessionSummary{
-				ID:           sess.ID,
-				Number:       sess.Number,
-				Name:         sess.Name,
-				Summary:      sess.Summary,
-				Provider:     sess.Provider,
-				Model:        sess.Model,
-				Mode:         sess.Mode,
-				MessageCount: len(msgs),
-				Status:       sess.Status,
-				CreatedAt:    sess.CreatedAt,
-				UpdatedAt:    sess.UpdatedAt,
+				ID:           r.SessionID,
+				Number:       r.SessionNumber,
+				Name:         r.SessionName,
+				Summary:      r.Summary,
+				Provider:     r.Provider,
+				Model:        r.Model,
+				Mode:         r.Mode,
+				MessageCount: r.MessageCount,
+				Status:       r.Status,
+				CreatedAt:    r.SessionCreatedAt,
+				UpdatedAt:    r.UpdatedAt,
 			})
 		}
 		m.sessions = summaries

--- a/internal/tui/sessions/browse_test.go
+++ b/internal/tui/sessions/browse_test.go
@@ -1,10 +1,34 @@
 package sessions
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/session"
 )
+
+type ftsRefreshStore struct {
+	session.NoopStore
+	searchResults    []session.SearchResult
+	getCalls         int
+	getMessagesCalls int
+}
+
+func (s *ftsRefreshStore) Search(ctx context.Context, query string, limit int) ([]session.SearchResult, error) {
+	return s.searchResults, nil
+}
+
+func (s *ftsRefreshStore) Get(ctx context.Context, id string) (*session.Session, error) {
+	s.getCalls++
+	return nil, session.ErrNotFound
+}
+
+func (s *ftsRefreshStore) GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
+	s.getMessagesCalls++
+	return nil, nil
+}
 
 func TestUpdate_PasteMsgUpdatesSearchInput(t *testing.T) {
 	m := New(nil, 80, 24, nil)
@@ -16,5 +40,60 @@ func TestUpdate_PasteMsgUpdatesSearchInput(t *testing.T) {
 
 	if got := m.searchInput.Value(); got != "release notes" {
 		t.Fatalf("expected pasted search query, got %q", got)
+	}
+}
+
+func TestDoRefresh_FTSSearchUsesSearchMetadataOnly(t *testing.T) {
+	updatedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	store := &ftsRefreshStore{searchResults: []session.SearchResult{
+		{
+			SessionID:        "sess-1",
+			SessionNumber:    42,
+			SessionName:      "Demo",
+			Summary:          "search match",
+			Provider:         "openai",
+			Model:            "gpt-5",
+			Mode:             session.ModeChat,
+			Status:           session.StatusComplete,
+			MessageCount:     7,
+			SessionCreatedAt: updatedAt.Add(-time.Hour),
+			UpdatedAt:        updatedAt,
+		},
+		{
+			SessionID:        "sess-1",
+			SessionNumber:    42,
+			SessionName:      "Demo",
+			Summary:          "search match",
+			Provider:         "openai",
+			Model:            "gpt-5",
+			Mode:             session.ModeChat,
+			Status:           session.StatusComplete,
+			MessageCount:     7,
+			SessionCreatedAt: updatedAt.Add(-time.Hour),
+			UpdatedAt:        updatedAt,
+		},
+	}}
+	m := New(store, 80, 24, nil)
+	m.ftsEnabled = true
+	m.searchQuery = "search"
+	m.statusFilter = StatusComplete
+
+	refreshed, _ := m.doRefresh()
+	m = refreshed.(*Model)
+
+	if store.getCalls != 0 {
+		t.Fatalf("Get called %d times, want 0", store.getCalls)
+	}
+	if store.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages called %d times, want 0", store.getMessagesCalls)
+	}
+	if len(m.sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(m.sessions))
+	}
+	if got := m.sessions[0].MessageCount; got != 7 {
+		t.Fatalf("message count = %d, want 7", got)
+	}
+	if got := m.sessions[0].UpdatedAt; !got.Equal(updatedAt) {
+		t.Fatalf("updated_at = %v, want %v", got, updatedAt)
 	}
 }


### PR DESCRIPTION
## What changed

- extended `session.SearchResult` and `SQLiteStore.Search` to return the lightweight session metadata the browser already needs: mode, status, persisted `message_count`, session created time, and updated time
- updated the TUI sessions browser FTS refresh path to build rows directly from `Search(...)` metadata instead of calling `Get(...)` and `GetMessages(..., 0, 0)` for every deduplicated hit
- added:
  - a TUI unit test proving FTS refresh no longer calls `Get` or `GetMessages`
  - a SQLite search test covering the new metadata fields

## Why this is high-value

Before this change, one FTS refresh could do:
- 1 search query
- plus 1 `Get(...)` per unique session hit
- plus 1 `GetMessages(..., 0, 0)` per unique session hit

That meant loading full transcripts into memory just to compute `len(msgs)` for the browser list, even though `sessions.message_count` is already persisted specifically to avoid per-session counting scans.

This fix removes those per-hit full-history loads and replaces them with metadata already available from the search/listing layer. That reduces DB round-trips, transcript deserialization, allocations, and latency as session histories grow, which directly improves TUI search responsiveness.

## Validation

- `gofmt -w internal/session/types.go internal/session/sqlite.go internal/session/sqlite_test.go internal/tui/sessions/browse.go internal/tui/sessions/browse_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
