### PR TITLE
fix: Telegram drops visible partial replies on stream timeout/error

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1467,6 +1467,38 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		return true
 	}
 
+	salvagePartialHistory := func(persistCtx context.Context, fallbackOp string) {
+		textMu.Lock()
+		partial := textBuf.String()
+		textMu.Unlock()
+		producedMu.Lock()
+		producedSnapshot := append([]llm.Message(nil), produced...)
+		producedMu.Unlock()
+		if partial == "" && len(producedSnapshot) == 0 {
+			return
+		}
+
+		assistantTextCaptured := telegramAssistantTextCaptured(producedSnapshot, partial)
+		newHistory := make([]llm.Message, 0, len(sess.history)+2+len(producedSnapshot))
+		newHistory = append(newHistory, sess.history...)
+		newHistory = append(newHistory, normalizeUserMessageForHistory(userMsg))
+		newHistory = append(newHistory, producedSnapshot...)
+		if partial != "" {
+			assistantMsg := llm.AssistantText(partial)
+			if m.store != nil && sess.meta != nil && !m.persistedAssistantTextMatches(persistCtx, sess.meta.ID, partial) {
+				storeMsg := session.NewMessage(sess.meta.ID, assistantMsg, -1)
+				m.runStoreOpWithoutCancel(persistCtx, sess.meta.ID, fallbackOp, func(storeCtx context.Context) error {
+					return m.store.AddMessage(storeCtx, sess.meta.ID, storeMsg)
+				})
+			}
+			if !assistantTextCaptured {
+				newHistory = append(newHistory, assistantMsg)
+			}
+		}
+		sess.history = newHistory
+		sess.lastActivity = time.Now()
+	}
+
 	var streamErr error
 	userInterrupted := false
 	streamDoneDrained := false
@@ -1585,10 +1617,6 @@ loop:
 		textMu.Lock()
 		partial := textBuf.String()
 		textMu.Unlock()
-		producedMu.Lock()
-		producedSnapshot := append([]llm.Message(nil), produced...)
-		producedMu.Unlock()
-		assistantTextCaptured := telegramAssistantTextCaptured(producedSnapshot, partial)
 
 		// Edit the Telegram message to show partial text + interrupted marker.
 		display := ""
@@ -1609,27 +1637,7 @@ loop:
 		sendEdit(currentMsgID, display, true)
 
 		// Preserve partial history so conversation context isn't lost.
-		newHistory := make([]llm.Message, 0, len(sess.history)+2+len(producedSnapshot))
-		newHistory = append(newHistory, sess.history...)
-		newHistory = append(newHistory, normalizeUserMessageForHistory(userMsg))
-		newHistory = append(newHistory, producedSnapshot...)
-		// If visible partial assistant text was not captured by normal callbacks, keep
-		// in-memory history aligned with what the user saw. Persist independently: a
-		// callback may append to produced before its cancelled store write completes.
-		if partial != "" {
-			assistantMsg := llm.AssistantText(partial)
-			if m.store != nil && sess.meta != nil && !m.persistedAssistantTextMatches(streamCtx, sess.meta.ID, partial) {
-				storeMsg := session.NewMessage(sess.meta.ID, assistantMsg, -1)
-				m.runStoreOpWithoutCancel(streamCtx, sess.meta.ID, "AddMessage(assistant_interrupt_fallback)", func(storeCtx context.Context) error {
-					return m.store.AddMessage(storeCtx, sess.meta.ID, storeMsg)
-				})
-			}
-			if !assistantTextCaptured {
-				newHistory = append(newHistory, assistantMsg)
-			}
-		}
-		sess.history = newHistory
-		sess.lastActivity = time.Now()
+		salvagePartialHistory(streamCtx, "AddMessage(assistant_interrupt_fallback)")
 
 		if m.store != nil && sess.meta != nil {
 			m.runStoreOpWithTimeout(sess.meta.ID, "UpdateStatus(interrupted)", func(storeCtx context.Context) error {
@@ -1640,6 +1648,7 @@ loop:
 	}
 
 	if streamErr != nil {
+		salvagePartialHistory(streamCtx, "AddMessage(assistant_error_fallback)")
 		if strings.Contains(streamErr.Error(), "stream timed out") {
 			_, _ = bot.Send(tgbotapi.NewMessage(chatID, "⌛ Response timed out — please try again."))
 		}

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -134,6 +134,63 @@ func (s *blockingTextStream) Close() error {
 	return nil
 }
 
+type errorAfterTextProvider struct {
+	text           string
+	err            error
+	firstChunkSent chan struct{}
+	allowError     chan struct{}
+}
+
+func newErrorAfterTextProvider(text string, err error) *errorAfterTextProvider {
+	return &errorAfterTextProvider{
+		text:           text,
+		err:            err,
+		firstChunkSent: make(chan struct{}),
+		allowError:     make(chan struct{}),
+	}
+}
+
+func (p *errorAfterTextProvider) Name() string { return "error-after-text" }
+
+func (p *errorAfterTextProvider) Credential() string { return "mock" }
+
+func (p *errorAfterTextProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+
+func (p *errorAfterTextProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	return &errorAfterTextStream{
+		ctx:            ctx,
+		text:           p.text,
+		err:            p.err,
+		firstChunkSent: p.firstChunkSent,
+		allowError:     p.allowError,
+	}, nil
+}
+
+type errorAfterTextStream struct {
+	ctx            context.Context
+	text           string
+	err            error
+	firstChunkSent chan struct{}
+	allowError     chan struct{}
+	chunkSent      bool
+}
+
+func (s *errorAfterTextStream) Recv() (llm.Event, error) {
+	if !s.chunkSent {
+		s.chunkSent = true
+		close(s.firstChunkSent)
+		return llm.Event{Type: llm.EventTextDelta, Text: s.text}, nil
+	}
+	select {
+	case <-s.ctx.Done():
+		return llm.Event{}, s.ctx.Err()
+	case <-s.allowError:
+		return llm.Event{}, s.err
+	}
+}
+
+func (s *errorAfterTextStream) Close() error { return nil }
+
 // newTestMgrAndSession builds a minimal manager and session backed by h's engine.
 func newTestMgrAndSession(h *testutil.EngineHarness) (*telegramSessionMgr, *telegramSession) {
 	mgr := &telegramSessionMgr{
@@ -759,6 +816,116 @@ func TestStreamReply_PersistsInterruptedPartialAssistantReply(t *testing.T) {
 
 	if got := bot.lastText(); !strings.Contains(got, "partial answer") || !strings.Contains(got, "(interrupted)") {
 		t.Fatalf("final telegram text = %q, want partial answer with interrupted marker", got)
+	}
+}
+
+func TestStreamReply_PersistsErroredPartialAssistantReply(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telegram-stream-error.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer store.Close()
+
+	provider := newErrorAfterTextProvider("partial answer", errors.New("upstream unavailable"))
+	mgr := &telegramSessionMgr{
+		sessions:       make(map[int64]*telegramSession),
+		store:          store,
+		tickerInterval: 5 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			Store:    store,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       llm.NewEngine(provider, llm.NewToolRegistry()),
+					ProviderName: "mock",
+					ModelName:    "test",
+				}, nil
+			},
+		},
+	}
+
+	sess, err := mgr.getOrCreate(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("getOrCreate failed: %v", err)
+	}
+
+	bot := &fakeBotSender{}
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hi"))
+	}()
+
+	select {
+	case <-provider.firstChunkSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider never emitted first chunk")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	visible := false
+	for time.Now().Before(deadline) {
+		for _, text := range bot.allTexts() {
+			if strings.Contains(text, "partial answer") {
+				visible = true
+				break
+			}
+		}
+		if visible {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !visible {
+		t.Fatal("telegram never displayed partial answer before stream error")
+	}
+
+	close(provider.allowError)
+
+	select {
+	case err := <-streamDone:
+		if err == nil {
+			t.Fatal("expected streamReply to return stream error")
+		}
+		if !strings.Contains(err.Error(), "upstream unavailable") {
+			t.Fatalf("expected upstream error in streamReply error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamReply did not return after stream error")
+	}
+
+	meta, err := store.Get(context.Background(), sess.meta.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if meta.Status != session.StatusError {
+		t.Fatalf("session status = %s, want %s", meta.Status, session.StatusError)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), sess.meta.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+
+	var foundAssistant bool
+	for _, msg := range msgs {
+		if msg.Role == llm.RoleAssistant && msg.TextContent == "partial answer" {
+			foundAssistant = true
+			break
+		}
+	}
+	if !foundAssistant {
+		t.Fatalf("expected persisted errored partial assistant message, got %#v", msgs)
+	}
+
+	if got := len(sess.history); got < 2 {
+		t.Fatalf("history length = %d, want at least 2", got)
+	}
+	if got := collectUserText(sess.history[len(sess.history)-2]); got != "hi" {
+		t.Fatalf("history user text = %q, want hi", got)
+	}
+	if got := telegramMessageVisibleText(sess.history[len(sess.history)-1]); got != "partial answer" {
+		t.Fatalf("history assistant text = %q, want partial answer", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a small `salvagePartialHistory` helper in `internal/serve/telegram.go` that preserves visible partial assistant output plus callback-produced messages in `sess.history`.
- Reused the existing interrupt salvage behavior for the generic `streamErr != nil` path, including a best-effort fallback `AddMessage` persisted with `runStoreOpWithoutCancel` when partial assistant text was shown but not durably recorded yet.
- Added `TestStreamReply_PersistsErroredPartialAssistantReply` to cover the failure mode where Telegram already displayed partial text and the stream then errors.

## Why this is high-value

Telegram streaming can show partial assistant text to the user before a provider/network/watchdog failure ends the turn. Before this change, the interrupt path salvaged that visible text, but the generic error path only marked the session as `error` and returned. That meant the next turn could resume from history that did not match what the user already saw in Telegram.

This fix makes timeout/error handling preserve the same visible partial reply context that interrupts already preserve, which prevents real chat state loss after flaky streams.

## Validation

- Verified the issue in current code by reading the existing interrupt salvage path versus the generic `streamErr != nil` path in `internal/serve/telegram.go`.
- Added and ran targeted coverage:
  - `go test ./internal/serve -run 'TestStreamReply_(PersistsErroredPartialAssistantReply|PersistsInterruptedPartialAssistantReply)$'`
- Ran formatting and repo validation:
  - `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
  - `go build ./...`
  - `go test ./...`
  - `git diff --check`
