### PR TITLE
fix: Command-help overlay keeps the LLM stream running after the user quits

### DIFF
--- a/internal/ui/postexec.go
+++ b/internal/ui/postexec.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,7 +18,8 @@ import (
 
 // ShowCommandHelp renders scrollable help for a command
 func ShowCommandHelp(command, shell string, engine *llm.Engine) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Build the help request. Keep detailed instructions in a system message so
 	// Responses-style providers that require an explicit instructions field (for
@@ -42,11 +44,24 @@ func ShowCommandHelp(command, shell string, engine *llm.Engine) error {
 		tea.WithoutSignalHandler(),
 	)
 
-	// Stream content in background, sending chunks to the program
+	streamDone := streamCommandHelp(ctx, engine, req, p.Send)
+
+	_, err = p.Run()
+	cancel()
+	<-streamDone
+	return err
+}
+
+func streamCommandHelp(ctx context.Context, engine *llm.Engine, req llm.Request, send func(tea.Msg)) <-chan struct{} {
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
+
 		stream, err := engine.Stream(ctx, req)
 		if err != nil {
-			p.Send(errorMsg{err})
+			if ctx.Err() == nil {
+				send(errorMsg{err})
+			}
 			return
 		}
 		defer stream.Close()
@@ -54,25 +69,31 @@ func ShowCommandHelp(command, shell string, engine *llm.Engine) error {
 		for {
 			event, err := stream.Recv()
 			if err == io.EOF {
-				p.Send(doneMsg{})
+				if ctx.Err() == nil {
+					send(doneMsg{})
+				}
 				return
 			}
 			if err != nil {
-				p.Send(errorMsg{err})
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+					return
+				}
+				send(errorMsg{err})
 				return
 			}
 			if event.Type == llm.EventError && event.Err != nil {
-				p.Send(errorMsg{event.Err})
+				if errors.Is(event.Err, context.Canceled) || errors.Is(event.Err, context.DeadlineExceeded) || ctx.Err() != nil {
+					return
+				}
+				send(errorMsg{event.Err})
 				return
 			}
 			if event.Type == llm.EventTextDelta && event.Text != "" {
-				p.Send(contentMsg(event.Text))
+				send(contentMsg(event.Text))
 			}
 		}
 	}()
-
-	_, err = p.Run()
-	return err
+	return done
 }
 
 func buildCommandHelpRequest(command, shell string) llm.Request {

--- a/internal/ui/postexec_test.go
+++ b/internal/ui/postexec_test.go
@@ -1,9 +1,12 @@
 package ui
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/llm"
 )
 
@@ -25,6 +28,48 @@ func TestBuildCommandHelpRequestUsesSystemInstructions(t *testing.T) {
 	user := req.Messages[1].Parts[0].Text
 	if !strings.Contains(user, "ls -la") {
 		t.Fatalf("user prompt missing command: %q", user)
+	}
+}
+
+func TestStreamCommandHelpStopsOnContextCancel(t *testing.T) {
+	provider := &blockingHelpProvider{started: make(chan context.Context, 1)}
+	engine := llm.NewEngine(provider, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sent := make(chan tea.Msg, 1)
+	streamDone := streamCommandHelp(ctx, engine, buildCommandHelpRequest("ls -la", "bash"), func(msg tea.Msg) {
+		select {
+		case sent <- msg:
+		default:
+		}
+	})
+
+	var providerCtx context.Context
+	select {
+	case providerCtx = <-provider.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider stream did not start")
+	}
+
+	cancel()
+
+	select {
+	case <-providerCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider context was not cancelled")
+	}
+
+	select {
+	case <-streamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("help stream goroutine did not exit after cancellation")
+	}
+
+	select {
+	case msg := <-sent:
+		t.Fatalf("unexpected message after cancellation: %T", msg)
+	default:
 	}
 }
 
@@ -78,3 +123,32 @@ func TestPostexecRenderMarkdown_TabsMatchSharedRenderer(t *testing.T) {
 		t.Fatalf("postexec render must preserve trailing newline, got %q", got)
 	}
 }
+
+type blockingHelpProvider struct {
+	started chan context.Context
+}
+
+func (p *blockingHelpProvider) Name() string { return "blocking-help" }
+
+func (p *blockingHelpProvider) Credential() string { return "test" }
+
+func (p *blockingHelpProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+
+func (p *blockingHelpProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	select {
+	case p.started <- ctx:
+	default:
+	}
+	return blockingHelpStream{ctx: ctx}, nil
+}
+
+type blockingHelpStream struct {
+	ctx context.Context
+}
+
+func (s blockingHelpStream) Recv() (llm.Event, error) {
+	<-s.ctx.Done()
+	return llm.Event{}, s.ctx.Err()
+}
+
+func (s blockingHelpStream) Close() error { return nil }


### PR DESCRIPTION
## What changed

- switched `ShowCommandHelp` from `context.Background()` to `context.WithCancel(...)`
- extracted the background help-stream reader into `streamCommandHelp`
- cancel the help-stream context when the Bubble Tea program exits and wait for the stream goroutine to finish before returning
- suppress cancellation-shaped stream errors during shutdown so quitting the overlay does not surface a spurious error
- added a targeted test that proves the help stream stops promptly when its context is cancelled

## Why this is high-value

Dismissing the command-help overlay previously left the provider stream running in the background until the LLM request finished on its own. That leaked in-flight network/token work after the UI was gone, and repeated quick exits could accumulate hidden streams in the same CLI session.

This fix makes overlay exit deterministic: quitting now cancels the provider request and waits for cleanup before returning.

## Validation

- `gofmt -w internal/ui/postexec.go internal/ui/postexec_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
