### PR TITLE
FEATURE: Forward Responses input_file parts to providers

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -316,21 +316,32 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 				if !strings.HasPrefix(fileData, "data:") {
 					continue
 				}
-				_, b64 := parseDataURL(fileData)
-				if b64 == "" {
+				mt, b64 := parseDataURL(fileData)
+				if mt == "" || b64 == "" {
 					continue
 				}
 				fileCount++
 				if fileCount > maxAttachments {
 					return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
 				}
-				path, err := saveUploadedFile(filename, b64)
+				cleanB64 := stripBase64Newlines(b64)
+				raw, err := decodeUploadedFile(filename, cleanB64)
+				if err != nil {
+					return llm.Message{}, fmt.Errorf("decode attachment %q: %w", filename, err)
+				}
+				path, err := saveUploadedBytes(filename, raw)
 				if err != nil {
 					return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
 				}
 				llmParts = append(llmParts, llm.Part{
-					Type: llm.PartText,
+					Type: llm.PartFile,
 					Text: fmt.Sprintf("[User uploaded file: %s — saved to %s]", filename, abbreviatePath(path)),
+					FileData: &llm.ToolFileData{
+						MediaType: mt,
+						Base64:    cleanB64,
+						Filename:  filename,
+					},
+					FilePath: path,
 				})
 			}
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1141,8 +1141,17 @@ func TestParseResponsesInput_FileUploadSavesToDisk(t *testing.T) {
 	if len(msg.Parts) != 2 {
 		t.Fatalf("len(parts) = %d, want 2", len(msg.Parts))
 	}
-	if msg.Parts[0].Type != llm.PartText {
-		t.Fatalf("parts[0].type = %s, want text", msg.Parts[0].Type)
+	if msg.Parts[0].Type != llm.PartFile {
+		t.Fatalf("parts[0].type = %s, want file", msg.Parts[0].Type)
+	}
+	if msg.Parts[0].FileData == nil {
+		t.Fatalf("parts[0].FileData = nil")
+	}
+	if msg.Parts[0].FileData.MediaType != "application/pdf" {
+		t.Fatalf("media type = %q, want application/pdf", msg.Parts[0].FileData.MediaType)
+	}
+	if msg.Parts[0].FileData.Base64 != b64 {
+		t.Fatalf("base64 = %q, want %q", msg.Parts[0].FileData.Base64, b64)
 	}
 	if !strings.Contains(msg.Parts[0].Text, "doc.pdf") {
 		t.Fatalf("parts[0].text = %q, should mention doc.pdf", msg.Parts[0].Text)

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -815,7 +815,7 @@ func splitParts(parts []Part) (string, []oaiToolCall, string) {
 	var reasoning string
 	for _, part := range parts {
 		switch part.Type {
-		case PartText:
+		case PartText, PartFile:
 			if part.Text != "" {
 				textParts = append(textParts, part.Text)
 			}

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -127,6 +127,8 @@ type ResponsesContentPart struct {
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // Plain URL string for Responses API (not object)
 	Detail   string `json:"detail,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data,omitempty"`
 }
 
 // ResponsesTool represents a tool definition in Open Responses format
@@ -377,6 +379,33 @@ func buildResponsesMessageItems(role string, parts []Part) []ResponsesInputItem 
 					Role:    role,
 					Content: imageParts,
 				})
+			}
+		case PartFile:
+			if part.FileData != nil && part.FileData.Base64 != "" {
+				flushText()
+				filename := strings.TrimSpace(part.FileData.Filename)
+				if filename == "" {
+					filename = "upload"
+				}
+				mediaType := strings.TrimSpace(part.FileData.MediaType)
+				if mediaType == "" {
+					mediaType = "application/octet-stream"
+				}
+				fileParts := []ResponsesContentPart{{
+					Type:     "input_file",
+					Filename: filename,
+					FileData: fmt.Sprintf("data:%s;base64,%s", mediaType, part.FileData.Base64),
+				}}
+				if part.FilePath != "" {
+					fileParts = append(fileParts, ResponsesContentPart{Type: "input_text", Text: "[file saved at: " + part.FilePath + "]"})
+				}
+				items = append(items, ResponsesInputItem{
+					Type:    "message",
+					Role:    role,
+					Content: fileParts,
+				})
+			} else if part.Text != "" {
+				textBuf.WriteString(part.Text)
 			}
 		case PartToolCall:
 			if part.ToolCall == nil {

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -103,6 +103,7 @@ type PartType string
 const (
 	PartText       PartType = "text"
 	PartImage      PartType = "image"
+	PartFile       PartType = "file"
 	PartToolCall   PartType = "tool_call"
 	PartToolResult PartType = "tool_result"
 )
@@ -123,6 +124,8 @@ type Part struct {
 	ReasoningEncryptedContent string         // Responses API encrypted reasoning content for replay
 	ImageData                 *ToolImageData // User-supplied image (base64-encoded)
 	ImagePath                 string         // Local filesystem path to the image (when available, e.g. Telegram uploads)
+	FileData                  *ToolFileData  // User-supplied file (base64-encoded)
+	FilePath                  string         // Local filesystem path to the file (when available)
 	ToolCall                  *ToolCall
 	ToolResult                *ToolResult
 }
@@ -195,6 +198,13 @@ type ToolImageData struct {
 	MediaType string `json:"media_type,omitempty"`
 	Base64    string `json:"base64,omitempty"`
 	Detail    string `json:"detail,omitempty"`
+}
+
+// ToolFileData represents base64-encoded file data in user input.
+type ToolFileData struct {
+	MediaType string `json:"media_type,omitempty"`
+	Base64    string `json:"base64,omitempty"`
+	Filename  string `json:"filename,omitempty"`
 }
 
 // ToolContentPart represents one structured piece of tool result content.


### PR DESCRIPTION
Preserve uploaded input_file data as a file part instead of converting it to text-only upload markers.

For Responses-capable providers, forward file parts as input_file content with filename and data URL payload. For chat-compatible providers, keep the existing text marker fallback so unsupported providers still get useful context.

This lets /v1/responses callers send PDFs or other files to models that support native file input while preserving the existing save-to-disk behavior.