### PR TITLE
fix: Unlocked session metadata reads race with live serve runtime updates

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -573,8 +573,8 @@ func ensureSessionID(w http.ResponseWriter) string {
 }
 
 func setSessionNumberHeader(w http.ResponseWriter, rt *serveRuntime) {
-	if rt != nil && rt.sessionMeta != nil && rt.sessionMeta.Number > 0 {
-		w.Header().Set("x-session-number", strconv.FormatInt(rt.sessionMeta.Number, 10))
+	if number := rt.SessionNumber(); number > 0 {
+		w.Header().Set("x-session-number", strconv.FormatInt(number, 10))
 	}
 }
 

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -8,13 +8,24 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 const onePixelPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+KDvV3wAAAABJRU5ErkJggg=="
+
+func TestSetSessionNumberHeader(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	setSessionNumberHeader(recorder, &serveRuntime{sessionMeta: &session.Session{Number: 42}})
+	if got := recorder.Header().Get("x-session-number"); got != "42" {
+		t.Fatalf("x-session-number = %q, want 42", got)
+	}
+}
 
 func TestParseUserMessageContent_AllowsUpToMaxInlineImages(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -83,6 +83,11 @@ func (rt *serveRuntime) LastUsed() time.Time {
 }
 
 func (rt *serveRuntime) SessionNumber() int64 {
+	if rt == nil {
+		return 0
+	}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 	if rt.sessionMeta != nil {
 		return rt.sessionMeta.Number
 	}

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -14,6 +14,47 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
+func TestServeRuntimeSessionNumberConcurrentAccess(t *testing.T) {
+	rt := &serveRuntime{
+		sessionMeta: &session.Session{ID: "sess", Number: 1},
+	}
+
+	const readers = 4
+	const iterations = 1000
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				_ = rt.SessionNumber()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 1; i <= iterations; i++ {
+			rt.mu.Lock()
+			rt.sessionMeta = &session.Session{ID: "sess", Number: int64(i)}
+			rt.mu.Unlock()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+
+	if got := rt.SessionNumber(); got != iterations {
+		t.Fatalf("SessionNumber() = %d, want %d", got, iterations)
+	}
+}
+
 type serveRuntimeTestStream struct {
 	events []llm.Event
 	index  int


### PR DESCRIPTION
## What changed

- Wrapped `serveRuntime.SessionNumber()` in `rt.mu` so session-number reads follow the same lock discipline as live runtime writes to `rt.sessionMeta`.
- Updated `setSessionNumberHeader` to read via `SessionNumber()` instead of dereferencing `rt.sessionMeta` directly.
- Added coverage for the header behavior and a concurrent-access test that is race-detector friendly.

## Why this is high-value

`serveRuntime.run()` already holds `rt.mu` for the full live request and mutates `rt.sessionMeta` throughout persistence, compaction, and metrics updates. Unlocked readers of `rt.sessionMeta.Number` could therefore race with active serve updates, producing undefined Go race behavior on the web/API path. This fix removes that unsynchronized read path with a minimal change and keeps session metadata access consistent.

## Validation

- `gofmt -w cmd/serve_runtime.go cmd/serve_protocol.go cmd/serve_runtime_test.go cmd/serve_protocol_test.go`
- `go test ./cmd -run 'TestServeRuntimeSessionNumberConcurrentAccess|TestSetSessionNumberHeader'`
- `go test -race ./cmd -run TestServeRuntimeSessionNumberConcurrentAccess`
- `go build ./...`
- `go test ./...`
- `git diff --check`
