### PR TITLE
fix: Widget shutdown only kills the parent PID and leaks child processes

### DIFF
--- a/internal/widgets/manager.go
+++ b/internal/widgets/manager.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/procutil"
 )
 
 const (
@@ -309,11 +311,12 @@ func (e *widgetEntry) startProcess(basePath string) error {
 		e.mu.Unlock()
 	}
 
-	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd := exec.CommandContext(context.Background(), argv[0], argv[1:]...)
 	cmd.Dir = mf.Dir
 	cmd.Env = env
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
+	procutil.ConfigureCommandProcessGroup(cmd)
 
 	if err := cmd.Start(); err != nil {
 		return e.setError(fmt.Errorf("start process: %w", err))
@@ -360,7 +363,7 @@ func (e *widgetEntry) startProcess(basePath string) error {
 		p := e.proc
 		e.mu.Unlock()
 		if p != nil {
-			_ = p.Kill()
+			killProcessGroup(p, syscall.SIGKILL)
 		}
 		return e.setError(fmt.Errorf("did not respond within %s: %v", startupTimeout, lastErr))
 	}
@@ -391,7 +394,7 @@ func (e *widgetEntry) stopProcess() {
 	if proc == nil {
 		return
 	}
-	_ = proc.Signal(syscall.SIGTERM)
+	killProcessGroup(proc, syscall.SIGTERM)
 	done := make(chan struct{})
 	go func() {
 		proc.Wait()
@@ -400,10 +403,19 @@ func (e *widgetEntry) stopProcess() {
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
-		_ = proc.Kill()
+		killProcessGroup(proc, syscall.SIGKILL)
 	}
 	if mode, _ := e.manifest.PlaceholderMode(); mode == "socket" {
 		_ = os.Remove(filepath.Join(socketRuntimeDir, e.manifest.ID+".sock"))
+	}
+}
+
+func killProcessGroup(proc *os.Process, sig syscall.Signal) {
+	if proc == nil {
+		return
+	}
+	if err := syscall.Kill(-proc.Pid, sig); err != nil {
+		_ = proc.Signal(sig)
 	}
 }
 

--- a/internal/widgets/manager_test.go
+++ b/internal/widgets/manager_test.go
@@ -1,0 +1,87 @@
+package widgets
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestWidgetStopProcessReapsChildProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are Unix-specific")
+	}
+
+	t.Setenv("TERM_LLM_WIDGET_TEST_CHILD", "1")
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "wrapper.sh")
+	script := "#!/bin/sh\n\"$1\" -test.run=TestWidgetChildHTTPServer -- \"$2\" >/dev/null 2>&1 &\nwait\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+
+	e := &widgetEntry{
+		manifest: &Manifest{
+			ID:      "test-widget",
+			Title:   "Test Widget",
+			Mount:   "test-widget",
+			Dir:     dir,
+			Command: []string{scriptPath, os.Args[0], "$PORT"},
+		},
+		state: stateStopped,
+	}
+
+	if err := e.startProcess("/chat"); err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+
+	e.mu.Lock()
+	port := e.port
+	e.mu.Unlock()
+	if port == 0 {
+		t.Fatal("widget did not record a port")
+	}
+
+	e.stopProcess()
+
+	client := &http.Client{Timeout: 200 * time.Millisecond}
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err != nil {
+			return
+		}
+		resp.Body.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("widget child process still serving after stop on %s", url)
+}
+
+func TestWidgetChildHTTPServer(t *testing.T) {
+	if os.Getenv("TERM_LLM_WIDGET_TEST_CHILD") != "1" {
+		t.Skip("helper process")
+	}
+
+	var port string
+	for i, arg := range os.Args {
+		if arg == "--" && i+1 < len(os.Args) {
+			port = os.Args[i+1]
+			break
+		}
+	}
+	if port == "" {
+		log.Fatal("missing port")
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	log.Fatal(http.ListenAndServe("127.0.0.1:"+port, handler))
+}


### PR DESCRIPTION
## What changed

- Start widget subprocesses with `exec.CommandContext(..., context.Background(), ...)` plus `procutil.ConfigureCommandProcessGroup(cmd)` so each widget runs in its own process group.
- On widget startup timeout, kill the whole process group instead of only the parent PID.
- On widget stop, send `SIGTERM` to the process group, then fall back to `SIGKILL` for the group after the existing timeout.
- Added `TestWidgetStopProcessReapsChildProcessGroup`, which launches a widget through a shell wrapper that backgrounds a child HTTP server and verifies `stopProcess()` shuts down the child too.

## Why this is high-value

Widgets are commonly launched through shell/npm/dev-server wrappers that spawn child processes. Before this change, the widget manager only tracked and terminated the parent PID, so idle reaping, restarts, shutdown, or startup-timeout cleanup could leave children behind still holding ports and serving stale code. That turns `/chat/widgets` restarts flaky over time and leaks CPU/RAM on the host.

This fix is small and targeted, but it closes a real reliability hole by aligning widget process lifecycle management with the process-group handling already used elsewhere in the codebase.

## Validation

- `gofmt -w internal/widgets/manager.go internal/widgets/manager_test.go`
- `go build ./...`
- `go test ./internal/widgets -run 'TestWidgetStopProcessReapsChildProcessGroup|TestWidgetChildHTTPServer' -count=1 -v`
- `go test ./...`
- `git diff --check`
