### PR TITLE
fix: Failed jobs cleanup attempts are recorded as successful and skipped for a full interval

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -853,16 +853,22 @@ func (m *jobsV2Manager) maybeRunCleanup(now time.Time) error {
 	if m.cleanupInterval <= 0 {
 		return nil
 	}
+	cleanupStartedAt := now.UTC()
 	m.mu.Lock()
-	if !m.lastCleanupCompleted.IsZero() && now.Sub(m.lastCleanupCompleted) < m.cleanupInterval {
+	if !m.lastCleanupCompleted.IsZero() && cleanupStartedAt.Sub(m.lastCleanupCompleted) < m.cleanupInterval {
 		m.mu.Unlock()
 		return nil
 	}
-	// Optimistically set before running to avoid stampeding.
-	m.lastCleanupCompleted = now
 	m.mu.Unlock()
 
-	return m.pruneOldData(now.UTC())
+	if err := m.pruneOldData(cleanupStartedAt); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	m.lastCleanupCompleted = cleanupStartedAt
+	m.mu.Unlock()
+	return nil
 }
 
 func (m *jobsV2Manager) pruneOldData(now time.Time) error {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -1248,6 +1248,28 @@ func TestJobsV2DelayQueriesUseShortErrorDelay(t *testing.T) {
 	}
 }
 
+func TestJobsV2MaybeRunCleanupRetriesAfterFailure(t *testing.T) {
+	mgr := newJobsV2ManagerWithoutLoops(t)
+	mgr.cleanupInterval = time.Hour
+	mgr.retentionEventDays = 1
+
+	if err := mgr.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := mgr.maybeRunCleanup(now); err == nil {
+		t.Fatal("maybeRunCleanup returned nil error for closed DB")
+	}
+	if !mgr.lastCleanupCompleted.IsZero() {
+		t.Fatalf("lastCleanupCompleted = %v, want zero after failed cleanup", mgr.lastCleanupCompleted)
+	}
+
+	if err := mgr.maybeRunCleanup(now.Add(time.Minute)); err == nil {
+		t.Fatal("maybeRunCleanup suppressed retry after failed cleanup")
+	}
+}
+
 func newJobsV2ManagerWithoutLoops(t *testing.T) *jobsV2Manager {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")


### PR DESCRIPTION
## What changed

- updated `maybeRunCleanup()` to record `lastCleanupCompleted` only after `pruneOldData()` succeeds
- preserved the existing cleanup interval semantics by storing the cleanup start time on success
- added a regression test that forces cleanup to fail and verifies the next attempt is not suppressed

## Why this is high-value

A transient cleanup failure was being treated as a successful cleanup run. That caused the scheduler to skip retention cleanup for the full configured interval, which defeats the existing error-backoff retry path and can let `job_runs_v2` / `job_run_events_v2` grow unchecked for hours or days. This fix ensures failed cleanup attempts keep retrying on the scheduler error delay until pruning succeeds.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
