### PR TITLE
fix(tui): advertise ctrl+c in copy hint

### DIFF
--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -1042,7 +1042,7 @@ func (m *Model) renderStatusLine() string {
 			lines = 0
 		}
 		if lines > 0 {
-			hint := mutedStyle.Render(fmt.Sprintf("%d lines · ctrl+y:copy", lines))
+			hint := mutedStyle.Render(fmt.Sprintf("%d lines · ctrl+c:copy", lines))
 			for i := range candidates {
 				candidates[i] = append(candidates[i], statusSegment{text: hint, priority: 60})
 			}


### PR DESCRIPTION
The selection status hint only mentioned ctrl+y, hiding the fact that ctrl+c also copies when text is selected.

History: 04ab2a4 introduced mouse selection with ctrl+y as the sole copy binding (ctrl+c was reserved for quit). PR #222 (a5ee3f4) later overloaded ctrl+c to copy-and-clear when a selection is active, falling through to quit otherwise — but the hint string was never updated, so users still assume ctrl+y is the only way to copy.

Update the hint to "ctrl+c:copy" since that's the shortcut most users already reach for. The ctrl+y binding still works as an unambiguous dedicated copy key - it's just no longer advertised in the status bar to keep the line short.