### PR TITLE
feat(serve): honor TERM_LLM_SERVE_TOKEN env var

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -119,7 +120,7 @@ func init() {
 
 	serveCmd.Flags().StringVar(&serveHost, "host", "127.0.0.1", "Bind host")
 	serveCmd.Flags().IntVar(&servePort, "port", 8080, "Bind port")
-	serveCmd.Flags().StringVar(&serveToken, "token", "", "Bearer token for API auth (auto-generated if omitted)")
+	serveCmd.Flags().StringVar(&serveToken, "token", "", "Bearer token for API auth (defaults to $TERM_LLM_SERVE_TOKEN, else auto-generated)")
 	serveCmd.Flags().BoolVar(&serveAllowNoAuth, "no-auth", false, "Disable auth (only allowed on loopback host)")
 	serveCmd.Flags().BoolVar(&serveAllowNoAuth, "allow-no-auth", false, "Disable auth (alias for --no-auth)")
 	_ = serveCmd.Flags().MarkHidden("allow-no-auth")
@@ -218,13 +219,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--auth none is only allowed on loopback hosts (got %q)", serveHost)
 	}
 
-	token := strings.TrimSpace(serveToken)
-	if requireAuth && token == "" {
-		generated, err := generateServeToken()
-		if err != nil {
-			return fmt.Errorf("generate auth token: %w", err)
-		}
-		token = generated
+	token, tokenSource, err := resolveServeToken(serveToken, os.Getenv("TERM_LLM_SERVE_TOKEN"), requireAuth, generateServeToken)
+	if err != nil {
+		return err
 	}
 
 	ctx, stop := signal.NotifyContext()
@@ -584,7 +581,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.ErrOrStderr(), "term-llm serve listening on http://%s:%d\n", serveHost, servePort)
 		fmt.Fprintf(cmd.ErrOrStderr(), "auth: %s\n", authSummary(requireAuth))
 		if requireAuth {
-			fmt.Fprintf(cmd.ErrOrStderr(), "token: %s\n", token)
+			switch tokenSource {
+			case tokenSourceGenerated:
+				fmt.Fprintf(cmd.ErrOrStderr(), "token: %s (auto-generated; export TERM_LLM_SERVE_TOKEN to persist)\n", token)
+			case tokenSourceEnv:
+				fmt.Fprintf(cmd.ErrOrStderr(), "token: %s (from $TERM_LLM_SERVE_TOKEN)\n", token)
+			default:
+				fmt.Fprintf(cmd.ErrOrStderr(), "token: %s\n", token)
+			}
 		}
 		fmt.Fprintf(cmd.ErrOrStderr(), "ui: %v\n", s.cfg.ui)
 		if hasJobs {
@@ -798,6 +802,34 @@ func resolveServeAuthMode(authFlagSet bool, authMode string, allowNoAuthSet bool
 func isLoopbackHost(host string) bool {
 	h := strings.TrimSpace(strings.ToLower(host))
 	return h == "127.0.0.1" || h == "localhost" || h == "::1"
+}
+
+// Sources reported by resolveServeToken for use in the startup banner.
+const (
+	tokenSourceNone      = ""
+	tokenSourceFlag      = "flag"
+	tokenSourceEnv       = "env"
+	tokenSourceGenerated = "generated"
+)
+
+// resolveServeToken returns the bearer token to use for the serve command.
+// Precedence: --token flag > TERM_LLM_SERVE_TOKEN env > auto-generated.
+// When requireAuth is false, returns an empty token and tokenSourceNone.
+func resolveServeToken(flagValue, envValue string, requireAuth bool, generate func() (string, error)) (string, string, error) {
+	if !requireAuth {
+		return "", tokenSourceNone, nil
+	}
+	if t := strings.TrimSpace(flagValue); t != "" {
+		return t, tokenSourceFlag, nil
+	}
+	if t := strings.TrimSpace(envValue); t != "" {
+		return t, tokenSourceEnv, nil
+	}
+	t, err := generate()
+	if err != nil {
+		return "", tokenSourceNone, fmt.Errorf("generate auth token: %w", err)
+	}
+	return t, tokenSourceGenerated, nil
 }
 
 func generateServeToken() (string, error) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -10555,3 +10555,103 @@ func TestHandleSessions_ETagConditional(t *testing.T) {
 		t.Fatalf("second request (same etag) status = %d, want 304", rr2.Code)
 	}
 }
+
+func TestResolveServeToken(t *testing.T) {
+	gen := func() (string, error) { return "generated-token", nil }
+	genErr := func() (string, error) { return "", errors.New("rng broken") }
+
+	tests := []struct {
+		name        string
+		flag        string
+		env         string
+		requireAuth bool
+		generate    func() (string, error)
+		wantToken   string
+		wantSource  string
+		wantErr     bool
+	}{
+		{
+			name:        "auth disabled returns empty",
+			flag:        "flag-token",
+			env:         "env-token",
+			requireAuth: false,
+			generate:    gen,
+			wantToken:   "",
+			wantSource:  tokenSourceNone,
+		},
+		{
+			name:        "flag wins over env",
+			flag:        "flag-token",
+			env:         "env-token",
+			requireAuth: true,
+			generate:    gen,
+			wantToken:   "flag-token",
+			wantSource:  tokenSourceFlag,
+		},
+		{
+			name:        "env used when no flag",
+			flag:        "",
+			env:         "env-token",
+			requireAuth: true,
+			generate:    gen,
+			wantToken:   "env-token",
+			wantSource:  tokenSourceEnv,
+		},
+		{
+			name:        "env whitespace trimmed",
+			flag:        "",
+			env:         "  env-token  ",
+			requireAuth: true,
+			generate:    gen,
+			wantToken:   "env-token",
+			wantSource:  tokenSourceEnv,
+		},
+		{
+			name:        "flag whitespace falls back to env",
+			flag:        "   ",
+			env:         "env-token",
+			requireAuth: true,
+			generate:    gen,
+			wantToken:   "env-token",
+			wantSource:  tokenSourceEnv,
+		},
+		{
+			name:        "auto-generated when nothing set",
+			flag:        "",
+			env:         "",
+			requireAuth: true,
+			generate:    gen,
+			wantToken:   "generated-token",
+			wantSource:  tokenSourceGenerated,
+		},
+		{
+			name:        "generate error propagates",
+			flag:        "",
+			env:         "",
+			requireAuth: true,
+			generate:    genErr,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, source, err := resolveServeToken(tc.flag, tc.env, tc.requireAuth, tc.generate)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok != tc.wantToken {
+				t.Errorf("token = %q, want %q", tok, tc.wantToken)
+			}
+			if source != tc.wantSource {
+				t.Errorf("source = %q, want %q", source, tc.wantSource)
+			}
+		})
+	}
+}

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -89,6 +89,31 @@ term-llm serve web --token "$TOKEN"
 
 If you omit `--token`, term-llm can generate one automatically.
 
+### Persist the token across restarts
+
+Without `--token`, a fresh bearer token is generated on every start, which means any saved client config (browser tabs, scripts, API clients) breaks after a restart. Set `TERM_LLM_SERVE_TOKEN` in your environment to keep the same token across restarts.
+
+Note that `export FOO=...` only persists for the current shell session — close the terminal or reboot and the value is gone. To survive across sessions, add it to your shell's startup file:
+
+```bash
+# bash / zsh: append to your rc file
+echo "export TERM_LLM_SERVE_TOKEN=\"$(openssl rand -hex 32)\"" >> ~/.bashrc
+# (or ~/.zshrc)
+```
+
+```fish
+# fish: -U makes it a universal variable (persists across sessions), -x exports it
+set -Ux TERM_LLM_SERVE_TOKEN (openssl rand -hex 32)
+```
+
+Then start the server in a new shell:
+
+```bash
+term-llm serve web
+```
+
+Precedence: `--token` > `$TERM_LLM_SERVE_TOKEN` > auto-generated.
+
 You can disable auth only on loopback hosts:
 
 ```bash


### PR DESCRIPTION
Let users pin a stable bearer token across `term-llm serve` runs by exporting TERM_LLM_SERVE_TOKEN. The web UI persists the token in localStorage, so a stable server-side value means users paste the token once per browser instead of after every restart. API clients and scripts with the token saved in config see the same benefit.

Precedence: --token > $TERM_LLM_SERVE_TOKEN > auto-generated. When neither flag nor env var is set, behavior is unchanged. Containerized `term-llm contain` workspaces are unaffected — their webui service already passes `--token` explicitly from each workspace's .env file, which keeps top precedence.

- Flag help advertises the env var.
- Startup banner annotates the token line with its source: "(from $TERM_LLM_SERVE_TOKEN)" when read from the env, or "(auto-generated; export TERM_LLM_SERVE_TOKEN to persist)" when freshly generated.
- New "Persist the token across restarts" subsection in the web UI guide with bash/zsh and fish examples.