### PR TITLE
fix(tui): resolve symlinks on approved dirs in IsPathApproved

### DIFF
--- a/internal/tui/chat/dirs.go
+++ b/internal/tui/chat/dirs.go
@@ -109,8 +109,17 @@ func (d *ApprovedDirs) IsPathApproved(path string) bool {
 			continue
 		}
 
+		// Resolve symlinks on the approved dir as well, so the comparison
+		// is apples-to-apples with realPath. Without this, an approved dir
+		// reached via a symlink (e.g. macOS /var -> /private/var) never
+		// matches files whose paths have been canonicalised above.
+		realDir, err := filepath.EvalSymlinks(absDir)
+		if err != nil {
+			realDir = absDir
+		}
+
 		// Check if path is under this directory
-		if strings.HasPrefix(realPath, absDir+string(filepath.Separator)) || realPath == absDir {
+		if strings.HasPrefix(realPath, realDir+string(filepath.Separator)) || realPath == realDir {
 			return true
 		}
 	}

--- a/internal/tui/chat/files_test.go
+++ b/internal/tui/chat/files_test.go
@@ -68,6 +68,29 @@ func TestApprovedDirsExpandTilde(t *testing.T) {
 	}
 }
 
+// TestApprovedDirsResolvesSymlinks ensures that a file under an approved
+// directory is recognized as approved even when the approved directory itself
+// is reached via a symlink (e.g. macOS /var -> /private/var, or a user-created
+// symlink on Linux). Before the fix, only the file path had its symlinks
+// resolved, so the prefix check against an un-resolved approved dir failed.
+func TestApprovedDirsResolvesSymlinks(t *testing.T) {
+	realDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(realDir, "test.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Create a symlink pointing at realDir and approve the symlink path.
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	dirs := &ApprovedDirs{Directories: []string{linkDir}}
+	if !dirs.IsPathApproved(filepath.Join(realDir, "test.txt")) {
+		t.Fatal("file under symlinked approved dir should be approved")
+	}
+}
+
 func TestCmdFileClearsComposerAfterAttach(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.txt")


### PR DESCRIPTION
IsPathApproved canonicalised the file path with EvalSymlinks but only ran filepath.Abs on each approved directory. When the two sides differ through a symlink, the prefix check fails and the file is treated as unapproved.

In practice this breaks persistent approval on macOS: /tmp and /var/folders are symlinks to /private/tmp and /private/var, so every /file attachment from those paths re-prompts the user to approve a directory they already approved. The stored approval never sticks. Also affects symlinked project dirs on any OS (e.g. ~/code -> /Volumes/SSD/code).

TestCmdFileClearsComposerAfterAttach has been failing on macOS since it was added in efbd3f3 -- t.TempDir() returns a /var/folders path, which is exactly the case that trips this bug. CI on Linux didn't catch it.

Resolve symlinks on the approved dir too, falling back to the absolute path on error. Add TestApprovedDirsResolvesSymlinks with an explicit os.Symlink so the regression is caught on Linux as well.