### PR TITLE
fix: Crash recovery requeues already-started jobs and can rerun side effects after restart

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -56,13 +56,16 @@ const (
 )
 
 const (
-	exitReasonNatural   = "natural_completion" // agent finished normally
-	exitReasonMaxTurns  = "max_turns_exceeded" // hit the agentic loop turn limit
-	exitReasonTimeout   = "timeout"            // context deadline exceeded
-	exitReasonCancelled = "cancelled"          // context cancelled
-	exitReasonException = "exception"          // unhandled error
-	exitReasonEmpty     = "empty_response"     // succeeded but produced no output
+	exitReasonNatural    = "natural_completion" // agent finished normally
+	exitReasonMaxTurns   = "max_turns_exceeded" // hit the agentic loop turn limit
+	exitReasonTimeout    = "timeout"            // context deadline exceeded
+	exitReasonCancelled  = "cancelled"          // context cancelled
+	exitReasonException  = "exception"          // unhandled error
+	exitReasonEmpty      = "empty_response"     // succeeded but produced no output
+	exitReasonWorkerLost = "worker_lost"        // worker vanished before run could finish
 )
+
+var errJobsV2WorkerLost = errors.New("worker lost before run could finish")
 
 type jobsV2RetryPolicy struct {
 	MaxAttempts  int    `json:"max_attempts,omitempty"`
@@ -461,6 +464,9 @@ func classifyRunError(err error, result jobsV2RunResult) (exitReason string, tru
 		if errors.Is(err, context.Canceled) {
 			return exitReasonCancelled, truncated
 		}
+		if errors.Is(err, errJobsV2WorkerLost) {
+			return exitReasonWorkerLost, truncated
+		}
 		if llm.IsMaxTurnsExceeded(err) || strings.Contains(err.Error(), "max turns") {
 			return exitReasonMaxTurns, true
 		}
@@ -688,22 +694,49 @@ func execJobsV2Schema(db *sql.DB) error {
 func (m *jobsV2Manager) recoverRuns() error {
 	_, err := m.db.Exec(`
 		UPDATE job_runs_v2
-		SET status = CASE
-				WHEN status = ? THEN ?
-				ELSE ?
-			END,
-			finished_at = CASE
-				WHEN status = ? THEN CURRENT_TIMESTAMP
-				ELSE finished_at
-			END,
+		SET status = ?,
+			finished_at = CURRENT_TIMESTAMP,
 			updated_at = CURRENT_TIMESTAMP
-		WHERE status IN (?, ?, ?, ?)`,
-		jobsV2RunCancelRequested, jobsV2RunCancelled,
-		jobsV2RunQueued,
-		jobsV2RunCancelRequested,
-		jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
+		WHERE status = ?`,
+		jobsV2RunCancelled,
+		jobsV2RunCancelRequested)
 	if err != nil {
-		return fmt.Errorf("recover runs: %w", err)
+		return fmt.Errorf("recover cancelled runs: %w", err)
+	}
+
+	rows, err := m.db.Query(`SELECT `+jobsV2RunFullColumns+` FROM job_runs_v2 WHERE status IN (?, ?)`, jobsV2RunClaimed, jobsV2RunRunning)
+	if err != nil {
+		return fmt.Errorf("load abandoned runs: %w", err)
+	}
+	defer rows.Close()
+
+	var abandoned []jobsV2Run
+	for rows.Next() {
+		run, err := scanRunV2(rows)
+		if err != nil {
+			return fmt.Errorf("scan abandoned run: %w", err)
+		}
+		abandoned = append(abandoned, run)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("load abandoned runs: %w", err)
+	}
+
+	for _, run := range abandoned {
+		result := jobsV2RunResult{
+			Stdout:       run.Stdout,
+			Stderr:       run.Stderr,
+			Thinking:     run.Thinking,
+			Response:     run.Response,
+			SessionID:    run.SessionID,
+			TurnCount:    run.TurnCount,
+			InputTokens:  run.InputTokens,
+			OutputTokens: run.OutputTokens,
+			Truncated:    run.Truncated,
+		}
+		if err := m.finishRun(run.ID, jobsV2RunFailed, result, errJobsV2WorkerLost, run.Attempt); err != nil {
+			return fmt.Errorf("recover abandoned run %s: %w", run.ID, err)
+		}
 	}
 	return nil
 }

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -489,6 +489,163 @@ func TestJobsV2RecoverRunsCancelsCancelRequestedRuns(t *testing.T) {
 	}
 }
 
+func TestJobsV2RecoverRunsFailsAbandonedRuns(t *testing.T) {
+	cases := []struct {
+		name   string
+		status jobsV2RunStatus
+	}{
+		{name: "claimed", status: jobsV2RunClaimed},
+		{name: "running", status: jobsV2RunRunning},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, err := newJobsV2Manager(":memory:", 0, nil)
+			if err != nil {
+				t.Fatalf("newJobsV2Manager failed: %v", err)
+			}
+			defer func() { _ = mgr.Close() }()
+
+			job, err := mgr.CreateJob(jobsV2Job{
+				Name:          "recover-abandoned-" + tc.name,
+				Enabled:       true,
+				RunnerType:    jobsV2RunnerProgram,
+				RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+				TriggerType:   jobsV2TriggerManual,
+				TriggerConfig: json.RawMessage(`{}`),
+			})
+			if err != nil {
+				t.Fatalf("CreateJob failed: %v", err)
+			}
+
+			run, err := mgr.TriggerJob(job.ID)
+			if err != nil {
+				t.Fatalf("TriggerJob failed: %v", err)
+			}
+
+			if tc.status == jobsV2RunRunning {
+				startedAt := time.Now().UTC().Add(-time.Second)
+				_, err = mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, response = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, tc.status, startedAt, "partial output", run.ID)
+			} else {
+				_, err = mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, tc.status, run.ID)
+			}
+			if err != nil {
+				t.Fatalf("mark %s failed: %v", tc.status, err)
+			}
+
+			if err := mgr.recoverRuns(); err != nil {
+				t.Fatalf("recoverRuns failed: %v", err)
+			}
+
+			recovered, err := mgr.GetRun(run.ID)
+			if err != nil {
+				t.Fatalf("GetRun failed: %v", err)
+			}
+			if recovered.Status != jobsV2RunFailed {
+				t.Fatalf("status = %s, want %s", recovered.Status, jobsV2RunFailed)
+			}
+			if recovered.ExitReason != exitReasonWorkerLost {
+				t.Fatalf("exit_reason = %q, want %q", recovered.ExitReason, exitReasonWorkerLost)
+			}
+			if recovered.Error != errJobsV2WorkerLost.Error() {
+				t.Fatalf("error = %q, want %q", recovered.Error, errJobsV2WorkerLost.Error())
+			}
+			if recovered.FinishedAt == nil {
+				t.Fatalf("finished_at was not set for recovered failed run")
+			}
+			if tc.status == jobsV2RunRunning && recovered.Response != "partial output" {
+				t.Fatalf("response = %q, want preserved partial output", recovered.Response)
+			}
+
+			runs, total, err := mgr.ListRuns(job.ID, 10, 0)
+			if err != nil {
+				t.Fatalf("ListRuns failed: %v", err)
+			}
+			if total != 1 {
+				t.Fatalf("total = %d, want 1", total)
+			}
+			if len(runs) != 1 || runs[0].ID != run.ID || runs[0].Status != jobsV2RunFailed {
+				t.Fatalf("runs = %+v, want one failed recovered run", runs)
+			}
+		})
+	}
+}
+
+func TestJobsV2RecoverRunsSchedulesRetryForAbandonedRunWhenConfigured(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "recover-abandoned-retry",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+		RetryPolicy:   json.RawMessage(`{"max_attempts":2,"initial_delay":"1s"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+
+	startedAt := time.Now().UTC().Add(-time.Second)
+	_, err = mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobsV2RunRunning, startedAt, run.ID)
+	if err != nil {
+		t.Fatalf("mark running failed: %v", err)
+	}
+
+	if err := mgr.recoverRuns(); err != nil {
+		t.Fatalf("recoverRuns failed: %v", err)
+	}
+
+	recovered, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if recovered.Status != jobsV2RunFailed {
+		t.Fatalf("status = %s, want %s", recovered.Status, jobsV2RunFailed)
+	}
+	if recovered.ExitReason != exitReasonWorkerLost {
+		t.Fatalf("exit_reason = %q, want %q", recovered.ExitReason, exitReasonWorkerLost)
+	}
+
+	runs, total, err := mgr.ListRuns(job.ID, 10, 0)
+	if err != nil {
+		t.Fatalf("ListRuns failed: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total = %d, want 2", total)
+	}
+
+	var retryRun *jobsV2Run
+	for i := range runs {
+		if runs[i].ID != run.ID {
+			retryRun = &runs[i]
+			break
+		}
+	}
+	if retryRun == nil {
+		t.Fatalf("retry run not found in %+v", runs)
+	}
+	if retryRun.Status != jobsV2RunQueued {
+		t.Fatalf("retry status = %s, want %s", retryRun.Status, jobsV2RunQueued)
+	}
+	if retryRun.Trigger != "retry" {
+		t.Fatalf("retry trigger = %q, want %q", retryRun.Trigger, "retry")
+	}
+	if retryRun.Attempt != 2 {
+		t.Fatalf("retry attempt = %d, want 2", retryRun.Attempt)
+	}
+}
+
 func TestJobsV2CronValidation(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)
 	if err != nil {


### PR DESCRIPTION
## What changed

- Changed `jobsV2Manager.recoverRuns()` so startup recovery no longer rewrites `claimed` and `running` runs back to `queued`.
- Recovery now:
  - keeps `queued` runs untouched,
  - converts `cancel_requested` runs to `cancelled`, and
  - marks abandoned `claimed` / `running` runs as `failed` with `exit_reason=worker_lost` and error text `worker lost before run could finish`.
- Reused normal `finishRun()` handling during recovery so configured retry policy can schedule a fresh retry attempt instead of rerunning the interrupted attempt in place.
- Preserved any partial run output already stored on the abandoned row during recovery.
- Added tests covering:
  - `claimed` and `running` rows becoming terminal `failed` instead of requeued, and
  - retry scheduling for an abandoned run when retry policy allows another attempt.

## Why this is high-value

Before this change, a restart/crash would silently move persisted `claimed` and `running` rows back to `queued`, and workers would execute those same rows from scratch. Because jobs can run arbitrary commands, invoke tools, send notifications, or write files, that recovery path could duplicate real-world side effects.

This fix makes crash recovery safer: interrupted attempts are recorded as terminal worker-loss failures, and only an explicit retry policy can enqueue a new attempt.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
