### PR TITLE
fix: Crash recovery requeues already-started jobs, so restarts can duplicate side effects

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -229,6 +229,8 @@ const (
 	jobsV2WorkerMinDelay      = 100 * time.Millisecond
 	jobsV2WorkerIdleDelay     = time.Minute
 	jobsV2WorkerErrorDelay    = 200 * time.Millisecond
+
+	jobsV2RecoveryWorkerLostError = "worker lost during crash recovery; run may have partially completed"
 )
 
 type jobsV2ProgramConfig struct {
@@ -686,24 +688,76 @@ func execJobsV2Schema(db *sql.DB) error {
 }
 
 func (m *jobsV2Manager) recoverRuns() error {
-	_, err := m.db.Exec(`
-		UPDATE job_runs_v2
-		SET status = CASE
-				WHEN status = ? THEN ?
-				ELSE ?
-			END,
-			finished_at = CASE
-				WHEN status = ? THEN CURRENT_TIMESTAMP
-				ELSE finished_at
-			END,
-			updated_at = CURRENT_TIMESTAMP
-		WHERE status IN (?, ?, ?, ?)`,
-		jobsV2RunCancelRequested, jobsV2RunCancelled,
-		jobsV2RunQueued,
-		jobsV2RunCancelRequested,
-		jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
+	rows, err := m.db.Query(`SELECT `+jobsV2RunFullColumns+` FROM job_runs_v2 WHERE status IN (?, ?)`, jobsV2RunClaimed, jobsV2RunRunning)
 	if err != nil {
-		return fmt.Errorf("recover runs: %w", err)
+		return fmt.Errorf("list interrupted runs: %w", err)
+	}
+
+	var interrupted []jobsV2Run
+	for rows.Next() {
+		run, err := scanRunV2(rows)
+		if err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan interrupted run: %w", err)
+		}
+		interrupted = append(interrupted, run)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate interrupted runs: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close interrupted runs: %w", err)
+	}
+
+	_, err = m.db.Exec(`
+		UPDATE job_runs_v2
+		SET status = ?,
+			finished_at = CURRENT_TIMESTAMP,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE status = ?`,
+		jobsV2RunCancelled, jobsV2RunCancelRequested)
+	if err != nil {
+		return fmt.Errorf("recover cancelled runs: %w", err)
+	}
+
+	for _, run := range interrupted {
+		res, err := m.db.Exec(`
+			UPDATE job_runs_v2
+			SET status = ?,
+				error = ?,
+				exit_reason = ?,
+				finished_at = CURRENT_TIMESTAMP,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE id = ? AND status IN (?, ?)`,
+			jobsV2RunFailed,
+			jobsV2RecoveryWorkerLostError,
+			exitReasonException,
+			run.ID,
+			jobsV2RunClaimed,
+			jobsV2RunRunning)
+		if err != nil {
+			return fmt.Errorf("recover interrupted run %s: %w", run.ID, err)
+		}
+		affected, _ := res.RowsAffected()
+		if affected == 0 {
+			continue
+		}
+		_ = m.addRunEvent(run.ID, string(jobsV2RunFailed), "run finished", map[string]any{
+			"status":        jobsV2RunFailed,
+			"attempt":       run.Attempt,
+			"session_id":    run.SessionID,
+			"exit_code":     run.ExitCode,
+			"error":         jobsV2RecoveryWorkerLostError,
+			"exit_reason":   exitReasonException,
+			"truncated":     run.Truncated,
+			"turn_count":    run.TurnCount,
+			"input_tokens":  run.InputTokens,
+			"output_tokens": run.OutputTokens,
+		})
+		if err := m.scheduleRetryIfNeeded(run.ID, jobsV2RunFailed, run.Attempt, time.Now().UTC()); err != nil {
+			return fmt.Errorf("recover interrupted run %s retry: %w", run.ID, err)
+		}
 	}
 	return nil
 }
@@ -1273,33 +1327,44 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		"output_tokens": result.OutputTokens,
 	})
 
-	if status == jobsV2RunFailed || status == jobsV2RunTimedOut {
-		run, err := m.GetRun(runID)
-		if err != nil {
-			return nil
-		}
-		job, err := m.GetJob(run.JobID)
-		if err != nil {
-			return nil
-		}
-		policy := decodeRetryPolicy(job.RetryPolicy)
-		if attempt < policy.MaxAttempts {
-			delay := computeRetryDelay(policy, attempt)
-			retryID := "run_" + randomSuffix()
-			_, _ = m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, retryID, job.ID, attempt+1, "retry", now.Add(delay), jobsV2RunQueued)
-			_ = m.addRunEvent(runID, "retry_scheduled", "retry run scheduled", map[string]any{
-				"retry_run_id": retryID,
-				"next_attempt": attempt + 1,
-				"delay":        delay.String(),
-			})
-			_ = m.addRunEvent(retryID, "queued", "retry run queued", map[string]any{
-				"trigger": "retry",
-				"attempt": attempt + 1,
-			})
-			m.notifyWorkers(1)
-		}
+	if err := m.scheduleRetryIfNeeded(runID, status, attempt, now); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+func (m *jobsV2Manager) scheduleRetryIfNeeded(runID string, status jobsV2RunStatus, attempt int, now time.Time) error {
+	if status != jobsV2RunFailed && status != jobsV2RunTimedOut {
+		return nil
+	}
+	run, err := m.GetRun(runID)
+	if err != nil {
+		return nil
+	}
+	job, err := m.GetJob(run.JobID)
+	if err != nil {
+		return nil
+	}
+	policy := decodeRetryPolicy(job.RetryPolicy)
+	if attempt >= policy.MaxAttempts {
+		return nil
+	}
+	delay := computeRetryDelay(policy, attempt)
+	retryID := "run_" + randomSuffix()
+	if _, err := m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, retryID, job.ID, attempt+1, "retry", now.Add(delay), jobsV2RunQueued); err != nil {
+		return err
+	}
+	_ = m.addRunEvent(runID, "retry_scheduled", "retry run scheduled", map[string]any{
+		"retry_run_id": retryID,
+		"next_attempt": attempt + 1,
+		"delay":        delay.String(),
+	})
+	_ = m.addRunEvent(retryID, "queued", "retry run queued", map[string]any{
+		"trigger": "retry",
+		"attempt": attempt + 1,
+	})
+	m.notifyWorkers(1)
 	return nil
 }
 

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -489,6 +489,106 @@ func TestJobsV2RecoverRunsCancelsCancelRequestedRuns(t *testing.T) {
 	}
 }
 
+func TestJobsV2RecoverRunsFailsInterruptedRunsAndQueuesRetry(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "recover-interrupted-runs",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+		RetryPolicy:   json.RawMessage(`{"max_attempts":2,"initial_delay":"1s"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	startedAt := now.Add(-2 * time.Second)
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, worker_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"run_claimed_recover", job.ID, 1, "manual", now, jobsV2RunClaimed, "worker_old", now, now)
+	if err != nil {
+		t.Fatalf("insert claimed run: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, response, turn_count, input_tokens, output_tokens, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"run_running_recover", job.ID, 1, "manual", now, jobsV2RunRunning, "worker_old", "sess_recover", startedAt, "partial response", 3, 11, 7, now, now)
+	if err != nil {
+		t.Fatalf("insert running run: %v", err)
+	}
+
+	if err := mgr.recoverRuns(); err != nil {
+		t.Fatalf("recoverRuns failed: %v", err)
+	}
+
+	for _, runID := range []string{"run_claimed_recover", "run_running_recover"} {
+		recovered, err := mgr.GetRun(runID)
+		if err != nil {
+			t.Fatalf("GetRun(%s) failed: %v", runID, err)
+		}
+		if recovered.Status != jobsV2RunFailed {
+			t.Fatalf("run %s status = %s, want %s", runID, recovered.Status, jobsV2RunFailed)
+		}
+		if recovered.Error != jobsV2RecoveryWorkerLostError {
+			t.Fatalf("run %s error = %q, want %q", runID, recovered.Error, jobsV2RecoveryWorkerLostError)
+		}
+		if recovered.ExitReason != exitReasonException {
+			t.Fatalf("run %s exit_reason = %q, want %q", runID, recovered.ExitReason, exitReasonException)
+		}
+		if recovered.FinishedAt == nil {
+			t.Fatalf("run %s finished_at was not set", runID)
+		}
+	}
+
+	running, err := mgr.GetRun("run_running_recover")
+	if err != nil {
+		t.Fatalf("GetRun(run_running_recover) failed: %v", err)
+	}
+	if running.Response != "partial response" {
+		t.Fatalf("running response = %q, want partial response", running.Response)
+	}
+
+	var originalQueued int
+	err = mgr.db.QueryRow(`SELECT COUNT(1) FROM job_runs_v2 WHERE id IN (?, ?) AND status = ?`, "run_claimed_recover", "run_running_recover", jobsV2RunQueued).Scan(&originalQueued)
+	if err != nil {
+		t.Fatalf("count original queued runs: %v", err)
+	}
+	if originalQueued != 0 {
+		t.Fatalf("original queued runs = %d, want 0", originalQueued)
+	}
+
+	rows, err := mgr.db.Query(`SELECT attempt, trigger, status FROM job_runs_v2 WHERE job_id = ? AND trigger = ? ORDER BY id`, job.ID, "retry")
+	if err != nil {
+		t.Fatalf("list retry runs: %v", err)
+	}
+	defer rows.Close()
+
+	var retryCount int
+	for rows.Next() {
+		var attempt int
+		var trigger string
+		var status string
+		if err := rows.Scan(&attempt, &trigger, &status); err != nil {
+			t.Fatalf("scan retry run: %v", err)
+		}
+		if attempt != 2 || trigger != "retry" || status != string(jobsV2RunQueued) {
+			t.Fatalf("retry run = attempt:%d trigger:%s status:%s, want attempt 2 trigger retry status queued", attempt, trigger, status)
+		}
+		retryCount++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate retry runs: %v", err)
+	}
+	if retryCount != 2 {
+		t.Fatalf("retry run count = %d, want 2", retryCount)
+	}
+}
+
 func TestJobsV2CronValidation(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 1, nil)
 	if err != nil {


### PR DESCRIPTION
## What changed

- Changed `jobsV2Manager.recoverRuns()` so crash recovery no longer rewrites `claimed` and `running` runs back to `queued`.
- Recovery now:
  - leaves existing `queued` runs alone,
  - converts `cancel_requested` runs to `cancelled`, and
  - marks interrupted `claimed`/`running` runs as `failed` with a clear worker-lost error and `exit_reason=exception`.
- Extracted retry scheduling into a shared helper so recovered failed runs still get a fresh retry attempt when the job's retry policy allows it.
- Added a regression test covering interrupted `claimed` and `running` runs, verifying they are not silently requeued, preserve partial output, and create a new retry run instead.

## Why this is high-value

Before this change, a daemon restart or crash could cause an already-started job to run from scratch again, because recovery rewrote in-flight runs back to `queued`. That can duplicate side effects from program and LLM jobs: repeated notifications, repeated shell commands, repeated file writes, and repeated external API calls.

This fix makes restart behavior safer by treating lost workers as a terminal failure for the affected run instead of pretending the run never started. If retries are configured, the system schedules a fresh follow-up attempt explicitly, which preserves retry semantics without silently duplicating the original in-flight execution.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
