### PR TITLE
fix: Web/API sessions never persist user_turns, leaving serve-created session stats permanently wrong

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -369,6 +369,16 @@ func (rt *serveRuntime) ensurePersistedSession(ctx context.Context, sessionID st
 	return true
 }
 
+func countUserTurns(messages []llm.Message) int {
+	userTurns := 0
+	for _, msg := range messages {
+		if msg.Role == llm.RoleUser {
+			userTurns++
+		}
+	}
+	return userTurns
+}
+
 func (rt *serveRuntime) persistSnapshot(ctx context.Context, sessionID string, snapshot []llm.Message) bool {
 	if rt.store == nil || sessionID == "" {
 		return false
@@ -391,17 +401,28 @@ func (rt *serveRuntime) persistSnapshot(ctx context.Context, sessionID string, s
 		log.Printf("[serve] session ReplaceMessages failed for %s: %v", sessionID, err)
 		return false
 	}
-	if rt.sessionMeta != nil && rt.sessionMeta.Summary == "" {
-		for _, msg := range snapshot {
-			if msg.Role != llm.RoleUser {
-				continue
-			}
-			if text := session.NewMessage(sessionID, msg, -1).TextContent; text != "" {
-				rt.sessionMeta.Summary = session.TruncateSummary(text)
-				if updateErr := rt.store.Update(dbCtx, rt.sessionMeta); updateErr != nil {
-					log.Printf("[serve] session Update failed for %s: %v", sessionID, updateErr)
+	userTurns := countUserTurns(snapshot)
+	sessionMetaNeedsUpdate := false
+	if rt.sessionMeta != nil {
+		if rt.sessionMeta.UserTurns != userTurns {
+			rt.sessionMeta.UserTurns = userTurns
+			sessionMetaNeedsUpdate = true
+		}
+		if rt.sessionMeta.Summary == "" {
+			for _, msg := range snapshot {
+				if msg.Role != llm.RoleUser {
+					continue
 				}
-				break
+				if text := session.NewMessage(sessionID, msg, -1).TextContent; text != "" {
+					rt.sessionMeta.Summary = session.TruncateSummary(text)
+					sessionMetaNeedsUpdate = true
+					break
+				}
+			}
+		}
+		if sessionMetaNeedsUpdate {
+			if updateErr := rt.store.Update(dbCtx, rt.sessionMeta); updateErr != nil {
+				log.Printf("[serve] session Update failed for %s: %v", sessionID, updateErr)
 			}
 		}
 	}
@@ -438,6 +459,13 @@ func (rt *serveRuntime) appendMessages(ctx context.Context, sessionID string, me
 			return written
 		}
 		written++
+		if msg.Role == llm.RoleUser {
+			if err := rt.store.IncrementUserTurns(dbCtx, sessionID); err != nil {
+				log.Printf("[serve] session IncrementUserTurns failed for %s: %v", sessionID, err)
+			} else if rt.sessionMeta != nil && rt.sessionMeta.ID == sessionID {
+				rt.sessionMeta.UserTurns++
+			}
+		}
 	}
 	return written
 }

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -354,6 +354,11 @@ func (s *serveRuntimeTestStore) UpdateStatus(ctx context.Context, id string, sta
 }
 
 func (s *serveRuntimeTestStore) IncrementUserTurns(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[id]; ok {
+		sess.UserTurns++
+	}
 	return nil
 }
 
@@ -674,6 +679,89 @@ func TestServeRuntimeSuccessfulRunSkipsFinalSnapshotRewrite(t *testing.T) {
 	}
 	if msgs[5].Role != llm.RoleAssistant || msgs[5].TextContent != "done" {
 		t.Fatalf("message[5] = %+v, want final assistant message", msgs[5])
+	}
+}
+
+func TestServeRuntimePersistSnapshotUpdatesUserTurns(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	sess := &session.Session{ID: "sess-snapshot-user-turns", Status: session.StatusActive}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	rt := &serveRuntime{
+		store:       store,
+		sessionMeta: sess,
+	}
+
+	snapshot := []llm.Message{
+		serveRuntimeTextMessage(llm.RoleUser, "first user"),
+		serveRuntimeTextMessage(llm.RoleAssistant, "first assistant"),
+		serveRuntimeTextMessage(llm.RoleUser, "second user"),
+	}
+	if ok := rt.persistSnapshot(context.Background(), sess.ID, snapshot); !ok {
+		t.Fatal("persistSnapshot() = false, want true")
+	}
+
+	persisted, err := store.Get(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("Get() = nil session")
+	}
+	if persisted.UserTurns != 2 {
+		t.Fatalf("persisted UserTurns = %d, want 2", persisted.UserTurns)
+	}
+	if rt.sessionMeta.UserTurns != 2 {
+		t.Fatalf("runtime UserTurns = %d, want 2", rt.sessionMeta.UserTurns)
+	}
+}
+
+func TestServeRuntimeAppendMessagesIncrementsUserTurns(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	sess := &session.Session{ID: "sess-append-user-turns", Status: session.StatusActive}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	rt := &serveRuntime{
+		store:       store,
+		sessionMeta: sess,
+	}
+
+	written := rt.appendMessages(context.Background(), sess.ID, []llm.Message{
+		serveRuntimeTextMessage(llm.RoleUser, "first user"),
+		serveRuntimeTextMessage(llm.RoleAssistant, "assistant"),
+		serveRuntimeTextMessage(llm.RoleUser, "second user"),
+	}, 7)
+	if written != 3 {
+		t.Fatalf("appendMessages() wrote %d messages, want 3", written)
+	}
+
+	persisted, err := store.Get(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("Get() = nil session")
+	}
+	if persisted.UserTurns != 2 {
+		t.Fatalf("persisted UserTurns = %d, want 2", persisted.UserTurns)
+	}
+	if rt.sessionMeta.UserTurns != 2 {
+		t.Fatalf("runtime UserTurns = %d, want 2", rt.sessionMeta.UserTurns)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("stored message count = %d, want 3", len(msgs))
+	}
+	if msgs[0].TurnIndex != 7 || msgs[1].TurnIndex != 7 || msgs[2].TurnIndex != 7 {
+		t.Fatalf("stored turn indexes = [%d %d %d], want all 7", msgs[0].TurnIndex, msgs[1].TurnIndex, msgs[2].TurnIndex)
 	}
 }
 


### PR DESCRIPTION
## What changed

- fixed `cmd/serve_runtime.go` so serve/web/API snapshot persistence now derives the exact `user_turns` count from the snapshot and persists it alongside any summary update
- fixed incremental serve/web/API message appends so persisted user messages also call `IncrementUserTurns(...)`
- kept the runtime session metadata in sync with the persisted `user_turns` value
- added focused tests covering both the snapshot rewrite path and the incremental append path

## Why this is high-value

This was a real persisted-state corruption bug on the serve/web/API path: messages were being saved correctly, but `user_turns` could stay at `0` or otherwise stale forever. That makes session stats wrong for exported data, inspection, and any logic that depends on user-turn counts. The bug specifically affects long-lived web/API sessions, so fixing it improves reliability for an important surface area without changing broader behavior.

## Validation

- `gofmt -w cmd/serve_runtime.go cmd/serve_runtime_test.go`
- `go build ./...`
- `go test ./...`
- added tests:
  - `TestServeRuntimePersistSnapshotUpdatesUserTurns`
  - `TestServeRuntimeAppendMessagesIncrementsUserTurns`
- `git diff --check`
