### PR TITLE
fix(contain): build runit from void-linux source on arch agent image

### DIFF
--- a/internal/contain/images/agent/Dockerfile
+++ b/internal/contain/images/agent/Dockerfile
@@ -92,16 +92,27 @@ RUN useradd -m -s /bin/zsh -G wheel agent && \
     chown agent:agent /home/agent/.zshrc && \
     sudo -Hu agent playwright install chromium
 
-# runit from Void Linux's maintained runit tree. Arch's AUR PKGBUILD fetches
-# the upstream tarball from smarden.org, which is frequently unreachable; the
-# Void fork carries modern compiler fixes while preserving runit semantics.
-RUN git clone --depth 1 https://github.com/void-linux/runit.git /tmp/runit && \
-    cd /tmp/runit/src && \
-    printf '%s\n' 'gcc -std=gnu17 -O2 -Wall -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration' > conf-cc && \
-    sed -i '1i#include <grp.h>' chkshsgr.c && \
-    make runsvdir runsv sv utmpset && \
-    install -m 0755 runsvdir runsv sv utmpset /usr/local/bin/ && \
-    rm -rf /tmp/runit
+# Unprivileged user for AUR builds (makepkg refuses to run as root).
+RUN useradd -m -G wheel aur && \
+    echo "aur ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/aur && \
+    chmod 0440 /etc/sudoers.d/aur
+
+# yay (AUR helper)
+RUN sudo -u aur bash -c " \
+      git clone https://aur.archlinux.org/yay.git /tmp/yay && \
+      cd /tmp/yay && \
+      makepkg -si --noconfirm && \
+      rm -rf /tmp/yay"
+
+# runit, packaged from Void Linux's maintained tree so pacman owns every binary.
+# The stock AUR runit PKGBUILD pulls its source tarball from smarden.org, which
+# is frequently unreachable; this local PKGBUILD points at the Void fork (modern
+# compiler fixes, same runit semantics) and installs via makepkg, so no stray
+# binaries land under /usr/local/bin.
+COPY packaging/runit/PKGBUILD /tmp/runit-pkg/PKGBUILD
+RUN chown -R aur:aur /tmp/runit-pkg && \
+    sudo -u aur bash -c "cd /tmp/runit-pkg && makepkg -si --noconfirm" && \
+    rm -rf /tmp/runit-pkg
 
 # mise (polyglot version manager — node, python, ruby, etc.)
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh

--- a/internal/contain/images/agent/Dockerfile
+++ b/internal/contain/images/agent/Dockerfile
@@ -92,20 +92,16 @@ RUN useradd -m -s /bin/zsh -G wheel agent && \
     chown agent:agent /home/agent/.zshrc && \
     sudo -Hu agent playwright install chromium
 
-# Unprivileged user for AUR builds (makepkg refuses root)
-RUN useradd -m -G wheel aur && \
-    echo "aur ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/aur && \
-    chmod 0440 /etc/sudoers.d/aur
-
-# yay (AUR helper)
-RUN sudo -u aur bash -c " \
-      git clone https://aur.archlinux.org/yay.git /tmp/yay && \
-      cd /tmp/yay && \
-      makepkg -si --noconfirm && \
-      rm -rf /tmp/yay"
-
-# runit is AUR-only on Arch
-RUN sudo -u aur yay -S --noconfirm runit
+# runit from Void Linux's maintained runit tree. Arch's AUR PKGBUILD fetches
+# the upstream tarball from smarden.org, which is frequently unreachable; the
+# Void fork carries modern compiler fixes while preserving runit semantics.
+RUN git clone --depth 1 https://github.com/void-linux/runit.git /tmp/runit && \
+    cd /tmp/runit/src && \
+    printf '%s\n' 'gcc -std=gnu17 -O2 -Wall -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration' > conf-cc && \
+    sed -i '1i#include <grp.h>' chkshsgr.c && \
+    make runsvdir runsv sv utmpset && \
+    install -m 0755 runsvdir runsv sv utmpset /usr/local/bin/ && \
+    rm -rf /tmp/runit
 
 # mise (polyglot version manager — node, python, ruby, etc.)
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh

--- a/internal/contain/images/agent/Dockerfile.arch
+++ b/internal/contain/images/agent/Dockerfile.arch
@@ -92,16 +92,27 @@ RUN useradd -m -s /bin/zsh -G wheel agent && \
     chown agent:agent /home/agent/.zshrc && \
     sudo -Hu agent playwright install chromium
 
-# runit from Void Linux's maintained runit tree. Arch's AUR PKGBUILD fetches
-# the upstream tarball from smarden.org, which is frequently unreachable; the
-# Void fork carries modern compiler fixes while preserving runit semantics.
-RUN git clone --depth 1 https://github.com/void-linux/runit.git /tmp/runit && \
-    cd /tmp/runit/src && \
-    printf '%s\n' 'gcc -std=gnu17 -O2 -Wall -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration' > conf-cc && \
-    sed -i '1i#include <grp.h>' chkshsgr.c && \
-    make runsvdir runsv sv utmpset && \
-    install -m 0755 runsvdir runsv sv utmpset /usr/local/bin/ && \
-    rm -rf /tmp/runit
+# Unprivileged user for AUR builds (makepkg refuses to run as root).
+RUN useradd -m -G wheel aur && \
+    echo "aur ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/aur && \
+    chmod 0440 /etc/sudoers.d/aur
+
+# yay (AUR helper)
+RUN sudo -u aur bash -c " \
+      git clone https://aur.archlinux.org/yay.git /tmp/yay && \
+      cd /tmp/yay && \
+      makepkg -si --noconfirm && \
+      rm -rf /tmp/yay"
+
+# runit, packaged from Void Linux's maintained tree so pacman owns every binary.
+# The stock AUR runit PKGBUILD pulls its source tarball from smarden.org, which
+# is frequently unreachable; this local PKGBUILD points at the Void fork (modern
+# compiler fixes, same runit semantics) and installs via makepkg, so no stray
+# binaries land under /usr/local/bin.
+COPY packaging/runit/PKGBUILD /tmp/runit-pkg/PKGBUILD
+RUN chown -R aur:aur /tmp/runit-pkg && \
+    sudo -u aur bash -c "cd /tmp/runit-pkg && makepkg -si --noconfirm" && \
+    rm -rf /tmp/runit-pkg
 
 # mise (polyglot version manager — node, python, ruby, etc.)
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh

--- a/internal/contain/images/agent/Dockerfile.arch
+++ b/internal/contain/images/agent/Dockerfile.arch
@@ -92,20 +92,16 @@ RUN useradd -m -s /bin/zsh -G wheel agent && \
     chown agent:agent /home/agent/.zshrc && \
     sudo -Hu agent playwright install chromium
 
-# Unprivileged user for AUR builds (makepkg refuses root)
-RUN useradd -m -G wheel aur && \
-    echo "aur ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/aur && \
-    chmod 0440 /etc/sudoers.d/aur
-
-# yay (AUR helper)
-RUN sudo -u aur bash -c " \
-      git clone https://aur.archlinux.org/yay.git /tmp/yay && \
-      cd /tmp/yay && \
-      makepkg -si --noconfirm && \
-      rm -rf /tmp/yay"
-
-# runit is AUR-only on Arch
-RUN sudo -u aur yay -S --noconfirm runit
+# runit from Void Linux's maintained runit tree. Arch's AUR PKGBUILD fetches
+# the upstream tarball from smarden.org, which is frequently unreachable; the
+# Void fork carries modern compiler fixes while preserving runit semantics.
+RUN git clone --depth 1 https://github.com/void-linux/runit.git /tmp/runit && \
+    cd /tmp/runit/src && \
+    printf '%s\n' 'gcc -std=gnu17 -O2 -Wall -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration' > conf-cc && \
+    sed -i '1i#include <grp.h>' chkshsgr.c && \
+    make runsvdir runsv sv utmpset && \
+    install -m 0755 runsvdir runsv sv utmpset /usr/local/bin/ && \
+    rm -rf /tmp/runit
 
 # mise (polyglot version manager — node, python, ruby, etc.)
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh

--- a/internal/contain/images/agent/packaging/runit/PKGBUILD
+++ b/internal/contain/images/agent/packaging/runit/PKGBUILD
@@ -1,0 +1,31 @@
+# Local runit package built from the Void Linux source tree.
+#
+# Arch ships no runit in the official repos, and the stock AUR PKGBUILD fetches
+# the upstream tarball from smarden.org, which is frequently unreachable. The
+# Void fork carries modern compiler fixes while preserving runit's semantics, so
+# we build from it here and let pacman own the resulting binaries rather than
+# scattering them under /usr/local/bin.
+pkgname=runit
+pkgver=2.1.2
+pkgrel=1
+pkgdesc='UNIX init scheme with service supervision (Void Linux source)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/void-linux/runit'
+license=('BSD')
+makedepends=('git')
+provides=('runit')
+source=('runit::git+https://github.com/void-linux/runit.git')
+sha256sums=('SKIP')
+
+build() {
+	cd "$srcdir/runit/src"
+	printf '%s\n' 'gcc -std=gnu17 -O2 -Wall -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration' > conf-cc
+	sed -i '1i#include <grp.h>' chkshsgr.c
+	make
+}
+
+package() {
+	cd "$srcdir/runit/src"
+	install -d "$pkgdir/usr/bin"
+	install -m0755 chpst runit runit-init runsv runsvchdir runsvdir sv svlogd utmpset "$pkgdir/usr/bin/"
+}

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -47,7 +47,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			t.Fatalf("Dockerfile.fedora missing %q", want)
 		}
 	}
-	for _, rel := range []string{"entrypoint.sh", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh", "bootstrap/scripts/patch-system.sh", "bootstrap/scripts/patch-soul.sh", "bootstrap/scripts/patch-agent.sh"} {
+	for _, rel := range []string{"entrypoint.sh", "packaging/runit/PKGBUILD", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh", "bootstrap/scripts/patch-system.sh", "bootstrap/scripts/patch-soul.sh", "bootstrap/scripts/patch-agent.sh"} {
 		data, err := os.ReadFile(filepath.Join(result.Dir, rel))
 		if err != nil {
 			t.Fatalf("missing synced asset %s: %v", rel, err)


### PR DESCRIPTION
The Arch agent Dockerfile installed runit via `yay -S runit`, whose AUR PKGBUILD downloads the upstream source tarball from smarden.org. smarden.org is frequently unreachable; `term-llm contain new` stalled for ~17 minutes on step 7/16 of a fresh build before the curl retry loop timed out:

`curl: (28) Failed to connect to smarden.org port 80 after 134517 ms`

Switch to cloning github.com/void-linux/runit and building runsvdir/ runsv/sv/utmpset in place, matching what Dockerfile.fedora already does. Since runit was the only AUR dependency, also drops the `aur` user, sudoers entry, and yay install.