### PR TITLE
feat(auth): add 'term-llm auth' command for OAuth sign-in

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,256 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"charm.land/huh/v2"
+	"github.com/samsaffron/term-llm/internal/credentials"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// authProvider describes an OAuth provider we can drive a sign-in flow for.
+// Each provider exposes the four hooks the auth subcommands need; we keep
+// the registry small (just ChatGPT + Copilot) because API-key providers
+// are configured via env vars or `term-llm config set`.
+type authProvider struct {
+	name     string // user-facing label
+	id       string // CLI slug
+	exists   func() bool
+	clear    func() error
+	login    func() error
+	describe func() (string, error)
+}
+
+func authProviders() []authProvider {
+	return []authProvider{
+		{
+			name:   "ChatGPT (Codex)",
+			id:     "chatgpt",
+			exists: credentials.ChatGPTCredentialsExist,
+			clear:  credentials.ClearChatGPTCredentials,
+			login: func() error {
+				_, err := llm.PromptForChatGPTAuth()
+				return err
+			},
+			describe: chatgptAuthStatus,
+		},
+		{
+			name:   "GitHub Copilot",
+			id:     "copilot",
+			exists: credentials.CopilotCredentialsExist,
+			clear:  credentials.ClearCopilotCredentials,
+			login: func() error {
+				_, err := llm.PromptForCopilotAuth()
+				return err
+			},
+			describe: copilotAuthStatus,
+		},
+	}
+}
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Sign in to OAuth providers (ChatGPT, GitHub Copilot)",
+	Long: `Manage OAuth credentials for providers that require interactive sign-in.
+
+API-key providers (Anthropic, OpenAI direct, Gemini, etc.) are configured
+via environment variables or 'term-llm config set'; they do not appear here.
+
+Examples:
+  term-llm auth login                # interactively pick a provider
+  term-llm auth login chatgpt
+  term-llm auth status
+  term-llm auth logout copilot`,
+}
+
+var authLoginCmd = &cobra.Command{
+	Use:               "login [provider]",
+	Short:             "Sign in to an OAuth provider",
+	Args:              cobra.MaximumNArgs(1),
+	RunE:              runAuthLogin,
+	ValidArgsFunction: authProviderCompletion,
+}
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show authentication status for OAuth providers",
+	Args:  cobra.NoArgs,
+	RunE:  runAuthStatus,
+}
+
+var authLogoutCmd = &cobra.Command{
+	Use:               "logout [provider]",
+	Short:             "Clear stored credentials for an OAuth provider",
+	Args:              cobra.MaximumNArgs(1),
+	RunE:              runAuthLogout,
+	ValidArgsFunction: authProviderCompletion,
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+	authCmd.AddCommand(authLoginCmd)
+	authCmd.AddCommand(authStatusCmd)
+	authCmd.AddCommand(authLogoutCmd)
+}
+
+func runAuthLogin(cmd *cobra.Command, args []string) error {
+	p, err := resolveAuthProvider(args, "Sign in to which provider?")
+	if err != nil {
+		return err
+	}
+	return p.login()
+}
+
+func runAuthLogout(cmd *cobra.Command, args []string) error {
+	p, err := resolveAuthProvider(args, "Sign out of which provider?")
+	if err != nil {
+		return err
+	}
+	if !p.exists() {
+		fmt.Fprintf(cmd.OutOrStdout(), "No %s credentials stored.\n", p.name)
+		return nil
+	}
+	if err := p.clear(); err != nil {
+		return fmt.Errorf("clear %s credentials: %w", p.id, err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Cleared %s credentials.\n", p.name)
+	return nil
+}
+
+func runAuthStatus(cmd *cobra.Command, args []string) error {
+	for _, p := range authProviders() {
+		line, err := p.describe()
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "%-18s ERROR: %v\n", p.name, err)
+			continue
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), line)
+	}
+	return nil
+}
+
+// resolveAuthProvider picks a provider from the arg list, falling back to
+// an interactive huh picker that shows current sign-in state next to each
+// provider. Returns an error if no provider is given and stdin isn't a TTY
+// — there's no sensible default since each provider is for a different
+// account.
+func resolveAuthProvider(args []string, prompt string) (authProvider, error) {
+	providers := authProviders()
+	if len(args) == 1 {
+		id := strings.ToLower(args[0])
+		for _, p := range providers {
+			if p.id == id {
+				return p, nil
+			}
+		}
+		return authProvider{}, fmt.Errorf("unknown provider %q (valid: %s)", args[0], providerIDsCSV(providers))
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return authProvider{}, fmt.Errorf("no provider given and stdin is not a terminal; pass one of: %s", providerIDsCSV(providers))
+	}
+
+	options := make([]huh.Option[string], 0, len(providers))
+	for _, p := range providers {
+		label := p.name
+		if p.exists() {
+			label += " ✓"
+		} else {
+			label += " (not signed in)"
+		}
+		options = append(options, huh.NewOption(label, p.id))
+	}
+	var chosen string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(prompt).
+				Options(options...).
+				Value(&chosen),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return authProvider{}, err
+	}
+	for _, p := range providers {
+		if p.id == chosen {
+			return p, nil
+		}
+	}
+	return authProvider{}, fmt.Errorf("no provider selected")
+}
+
+func providerIDsCSV(providers []authProvider) string {
+	ids := make([]string, len(providers))
+	for i, p := range providers {
+		ids[i] = p.id
+	}
+	return strings.Join(ids, ", ")
+}
+
+func authProviderCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) >= 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	providers := authProviders()
+	ids := make([]string, 0, len(providers))
+	for _, p := range providers {
+		ids = append(ids, p.id)
+	}
+	return ids, cobra.ShellCompDirectiveNoFileComp
+}
+
+func chatgptAuthStatus() (string, error) {
+	const label = "ChatGPT (Codex)"
+	if !credentials.ChatGPTCredentialsExist() {
+		return formatAuthStatusLine(label, "not signed in", ""), nil
+	}
+	creds, err := credentials.GetChatGPTCredentials()
+	if err != nil {
+		return "", err
+	}
+	detail := ""
+	if creds.AccountID != "" {
+		detail = "account " + creds.AccountID
+	}
+	return formatAuthStatusLine(label, formatExpiry(creds.ExpiresAt, creds.IsExpired()), detail), nil
+}
+
+func copilotAuthStatus() (string, error) {
+	const label = "GitHub Copilot"
+	if !credentials.CopilotCredentialsExist() {
+		return formatAuthStatusLine(label, "not signed in", ""), nil
+	}
+	creds, err := credentials.GetCopilotCredentials()
+	if err != nil {
+		return "", err
+	}
+	return formatAuthStatusLine(label, formatExpiry(creds.ExpiresAt, creds.IsExpired()), ""), nil
+}
+
+// formatExpiry renders a human-friendly state string given a Unix expiry
+// timestamp. A zero expiry means "no expiry set" (Copilot tokens are
+// long-lived). Expired tokens are still considered "signed in" because the
+// next API call will refresh them transparently.
+func formatExpiry(unix int64, expired bool) string {
+	if unix == 0 {
+		return "signed in (no expiry)"
+	}
+	if expired {
+		return "expired (will refresh on next use)"
+	}
+	return "signed in; expires " + time.Unix(unix, 0).UTC().Format("2006-01-02 15:04 UTC")
+}
+
+func formatAuthStatusLine(name, state, detail string) string {
+	line := fmt.Sprintf("%-18s %s", name, state)
+	if detail != "" {
+		line += " (" + detail + ")"
+	}
+	return line
+}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/credentials"
+)
+
+func TestFormatExpiry(t *testing.T) {
+	cases := []struct {
+		name    string
+		unix    int64
+		expired bool
+		want    string
+	}{
+		{"no expiry", 0, false, "signed in (no expiry)"},
+		{"expired", time.Now().Add(-1 * time.Hour).Unix(), true, "expired (will refresh on next use)"},
+		{"future", time.Date(2030, 1, 2, 15, 4, 0, 0, time.UTC).Unix(), false, "signed in; expires 2030-01-02 15:04 UTC"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := formatExpiry(c.unix, c.expired); got != c.want {
+				t.Fatalf("formatExpiry = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestFormatAuthStatusLine(t *testing.T) {
+	line := formatAuthStatusLine("ChatGPT (Codex)", "signed in", "account abc")
+	if !strings.Contains(line, "ChatGPT (Codex)") || !strings.Contains(line, "signed in") || !strings.Contains(line, "(account abc)") {
+		t.Fatalf("missing parts in %q", line)
+	}
+	noDetail := formatAuthStatusLine("X", "y", "")
+	if strings.Contains(noDetail, "()") {
+		t.Fatalf("empty detail should not render parens: %q", noDetail)
+	}
+}
+
+func TestResolveAuthProviderByArg(t *testing.T) {
+	p, err := resolveAuthProvider([]string{"chatgpt"}, "")
+	if err != nil {
+		t.Fatalf("chatgpt: %v", err)
+	}
+	if p.id != "chatgpt" {
+		t.Fatalf("got %q, want chatgpt", p.id)
+	}
+
+	// Case-insensitive arg.
+	p, err = resolveAuthProvider([]string{"COPILOT"}, "")
+	if err != nil {
+		t.Fatalf("COPILOT: %v", err)
+	}
+	if p.id != "copilot" {
+		t.Fatalf("got %q, want copilot", p.id)
+	}
+
+	// Unknown.
+	if _, err := resolveAuthProvider([]string{"bogus"}, ""); err == nil {
+		t.Fatal("expected error for unknown provider")
+	} else if !strings.Contains(err.Error(), "valid:") {
+		t.Fatalf("error should list valid providers, got: %v", err)
+	}
+}
+
+func TestAuthProviderCompletion(t *testing.T) {
+	out, _ := authProviderCompletion(nil, nil, "")
+	want := map[string]bool{"chatgpt": true, "copilot": true}
+	if len(out) != len(want) {
+		t.Fatalf("completion = %v", out)
+	}
+	for _, id := range out {
+		if !want[id] {
+			t.Fatalf("unexpected completion id %q", id)
+		}
+	}
+	// Once an arg is set, no more completions.
+	out2, _ := authProviderCompletion(nil, []string{"chatgpt"}, "")
+	if len(out2) != 0 {
+		t.Fatalf("expected no completions after arg, got %v", out2)
+	}
+}
+
+func TestRunAuthLogoutNoCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd := authLogoutCmd
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := runAuthLogout(cmd, []string{"chatgpt"}); err != nil {
+		t.Fatalf("logout with no creds should not error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No ChatGPT (Codex) credentials stored.") {
+		t.Fatalf("unexpected output: %q", stdout.String())
+	}
+}
+
+func TestRunAuthLogoutClearsCredentials(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	creds := &credentials.ChatGPTCredentials{
+		AccessToken:  "tok",
+		RefreshToken: "ref",
+		ExpiresAt:    time.Now().Add(1 * time.Hour).Unix(),
+		AccountID:    "acct-1",
+	}
+	if err := credentials.SaveChatGPTCredentials(creds); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	credPath := filepath.Join(dir, "term-llm", "chatgpt_oauth.json")
+	if _, err := os.Stat(credPath); err != nil {
+		t.Fatalf("creds file should exist before logout: %v", err)
+	}
+
+	cmd := authLogoutCmd
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := runAuthLogout(cmd, []string{"chatgpt"}); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Cleared ChatGPT (Codex) credentials.") {
+		t.Fatalf("unexpected output: %q", stdout.String())
+	}
+	if _, err := os.Stat(credPath); !os.IsNotExist(err) {
+		t.Fatalf("creds file should be removed after logout, stat err = %v", err)
+	}
+}
+
+func TestRunAuthStatus(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	// Pre-seed ChatGPT creds with a known future expiry; leave Copilot blank.
+	expires := time.Date(2030, 1, 2, 15, 4, 0, 0, time.UTC).Unix()
+	if err := credentials.SaveChatGPTCredentials(&credentials.ChatGPTCredentials{
+		AccessToken: "tok",
+		ExpiresAt:   expires,
+		AccountID:   "acct-xyz",
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	cmd := authStatusCmd
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := runAuthStatus(cmd, nil); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"ChatGPT (Codex)",
+		"signed in; expires 2030-01-02 15:04 UTC",
+		"(account acct-xyz)",
+		"GitHub Copilot",
+		"not signed in",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("status output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunAuthStatusInvalidStoredFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	// Write a malformed creds file so GetChatGPTCredentials returns an error
+	// even though Exists() reports true. status should surface it without
+	// aborting the whole command.
+	credDir := filepath.Join(dir, "term-llm")
+	if err := os.MkdirAll(credDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, "chatgpt_oauth.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cmd := authStatusCmd
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := runAuthStatus(cmd, nil); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "ERROR") {
+		t.Fatalf("expected per-provider ERROR line for corrupt creds, got:\n%s", out)
+	}
+	if !strings.Contains(out, "GitHub Copilot") {
+		t.Fatalf("status should still report Copilot even when ChatGPT line errors, got:\n%s", out)
+	}
+}
+
+// guard against silent contract drift: each registered provider must
+// expose a non-nil hook for every responsibility.
+func TestAuthProvidersRegistryComplete(t *testing.T) {
+	for _, p := range authProviders() {
+		if p.id == "" || p.name == "" {
+			t.Fatalf("provider missing id/name: %+v", p)
+		}
+		if p.exists == nil || p.clear == nil || p.login == nil || p.describe == nil {
+			t.Fatalf("provider %q has nil hook", p.id)
+		}
+	}
+}
+
+// sanity check that the JSON shape on disk hasn't drifted from what we
+// document in the status output; a future schema change should make this
+// test fail loudly.
+func TestStoredCredentialsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	orig := &credentials.ChatGPTCredentials{
+		AccessToken:  "a",
+		RefreshToken: "r",
+		ExpiresAt:    1234567890,
+		AccountID:    "acct",
+	}
+	if err := credentials.SaveChatGPTCredentials(orig); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "term-llm", "chatgpt_oauth.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"access_token", "refresh_token", "expires_at", "account_id"} {
+		if _, ok := generic[k]; !ok {
+			t.Fatalf("stored creds missing field %q", k)
+		}
+	}
+}

--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -62,7 +62,7 @@ func NewChatGPTProviderWithOptions(model string, opts ChatGPTProviderOptions) (*
 	creds, err := credentials.GetChatGPTCredentials()
 	if err != nil {
 		// No credentials - prompt user to authenticate
-		creds, err = promptForChatGPTAuth()
+		creds, err = PromptForChatGPTAuth()
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func NewChatGPTProviderWithOptions(model string, opts ChatGPTProviderOptions) (*
 		if err := credentials.RefreshChatGPTCredentials(creds); err != nil {
 			// Refresh failed - need to re-authenticate
 			fmt.Println("Token refresh failed. Re-authentication required.")
-			creds, err = promptForChatGPTAuth()
+			creds, err = PromptForChatGPTAuth()
 			if err != nil {
 				return nil, err
 			}
@@ -111,15 +111,16 @@ func NewChatGPTProviderWithCredsAndOptions(creds *credentials.ChatGPTCredentials
 	}
 }
 
-// promptForChatGPTAuth prompts the user to authenticate with ChatGPT.
+// PromptForChatGPTAuth prompts the user to authenticate with ChatGPT.
 // Prefers the device-code flow so auth works on headless/remote/containerized
 // boxes; falls back to the localhost browser flow if the backend doesn't
-// advertise device-code support.
-func promptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
+// advertise device-code support. Exported so `term-llm auth login chatgpt`
+// can drive the same flow used by lazy auth.
+func PromptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 	// Check if stdin is a terminal - if not, we can't do interactive auth
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return nil, fmt.Errorf("ChatGPT authentication required but running in non-interactive mode.\n" +
-			"Run 'term-llm ask --provider chatgpt \"test\"' interactively first to authenticate")
+			"Run 'term-llm auth login chatgpt' interactively first to authenticate")
 	}
 
 	fmt.Println("ChatGPT provider requires authentication.")

--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -85,7 +85,7 @@ func NewCopilotProvider(model string) (*CopilotProvider, error) {
 	creds, err := credentials.GetCopilotCredentials()
 	if err != nil {
 		// No credentials - prompt user to authenticate
-		creds, err = promptForCopilotAuth()
+		creds, err = PromptForCopilotAuth()
 		if err != nil {
 			return nil, err
 		}
@@ -94,7 +94,7 @@ func NewCopilotProvider(model string) (*CopilotProvider, error) {
 	// Check if token is expired (rare for GitHub tokens, but check anyway)
 	if creds.IsExpired() {
 		fmt.Println("Copilot token expired. Re-authentication required.")
-		creds, err = promptForCopilotAuth()
+		creds, err = PromptForCopilotAuth()
 		if err != nil {
 			return nil, err
 		}
@@ -121,13 +121,15 @@ func NewCopilotProviderWithCreds(creds *credentials.CopilotCredentials, model st
 	}
 }
 
-// promptForCopilotAuth prompts the user to authenticate with GitHub Copilot.
+// PromptForCopilotAuth prompts the user to authenticate with GitHub Copilot.
 // Returns an error if running in a non-interactive context (e.g., scripts, CI).
-func promptForCopilotAuth() (*credentials.CopilotCredentials, error) {
+// Exported so `term-llm auth login copilot` can drive the same flow used by
+// lazy auth.
+func PromptForCopilotAuth() (*credentials.CopilotCredentials, error) {
 	// Check if stdin is a terminal - if not, we can't do interactive auth
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return nil, fmt.Errorf("Copilot authentication required but running in non-interactive mode.\n" +
-			"Run 'term-llm ask --provider copilot \"test\"' interactively first to authenticate")
+			"Run 'term-llm auth login copilot' interactively first to authenticate")
 	}
 
 	fmt.Println("GitHub Copilot provider requires authentication.")

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -26,7 +26,7 @@ func detectAvailableProviders() []providerOption {
 			name:      "ChatGPT (Codex) - ChatGPT OAuth",
 			value:     "chatgpt",
 			available: credentials.ChatGPTCredentialsExist(),
-			hint:      "run 'term-llm ask --provider chatgpt \"test\"' to login",
+			hint:      "run 'term-llm auth login chatgpt' to sign in",
 		},
 		{
 			name:      "Anthropic - API key",


### PR DESCRIPTION
ChatGPT and Copilot OAuth previously bootstrapped lazily — the very first `term-llm ask --provider chatgpt ...` would print a device code mid-task and block until the user finished signing in. There was no way to do auth out-of-band, no way to see what's signed in, and no way to sign out without manually deleting the JSON files under ~/.config/term-llm/.

Add a dedicated `auth` command group with three subcommands:

```
term-llm auth login [provider]   # interactive picker if no arg;
                                 # reuses the existing OAuth flow
term-llm auth status             # show signed-in state + expiry
                                 # for every OAuth provider
term-llm auth logout [provider]  # clear stored credentials
```

Scope: ChatGPT (Codex) and GitHub Copilot only. API-key providers (Anthropic, OpenAI direct, Gemini, OpenRouter, XAI, SambaNova, BFL) are intentionally excluded — they're already covered by env vars and `term-llm config set`, so an auth subcommand for them would be a thin "paste your key" wrapper with no UX win.

Implementation:

- Export `PromptForChatGPTAuth` / `PromptForCopilotAuth` so the new command drives the same flow as lazy auth (single source of truth; no duplicated UX, signal handling, or token persistence).
- Lazy auth is unchanged; the non-interactive error messages and the setup-wizard hint now point users at `term-llm auth login` instead of "run an ask interactively first".
- Internal `authProvider` registry keeps the cmd-layer small and makes adding future OAuth providers a single struct entry.
- Status output distinguishes "expired (will refresh on next use)" from "not signed in" — accurate to the actual refresh-token behavior in RefreshChatGPTCredentials.
- Picker uses huh (already a repo dep, same pattern as the setup wizard); stdin-not-a-TTY without an explicit provider returns a clear `pass one of: chatgpt, copilot` error rather than letting huh crash.