### PR TITLE
fix(ui): include server tools in response runs

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -3600,6 +3600,7 @@ const sendMessage = async (options = {}) => {
 
     const body = {
       stream: true,
+      include_server_tools: true,
       input: [{ type: 'message', role: 'user', content: inputContent }]
     };
 

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -895,6 +895,40 @@ async function testSendMessageUsesLocalContinuationIdWithoutPreflightSync() {
     fail(name, `previous_response_id = ${JSON.stringify(body.previous_response_id)}, want ${JSON.stringify(lastResponseId)}`, postCall.body);
     return;
   }
+  if (body.include_server_tools !== true) {
+    fail(name, `include_server_tools = ${JSON.stringify(body.include_server_tools)}, want true`, postCall.body);
+    return;
+  }
+
+  pass(name);
+}
+
+async function testSendMessageIncludesServerToolsForFirstPartyUI() {
+  const name = 'sendMessage includes server tools for first-party UI responses';
+  const harness = createHarness();
+  const { app, elements, fetchCalls, cleanup } = harness;
+  elements.promptInput.value = 'use a tool';
+
+  let sendErr = null;
+  await app.sendMessage().catch((err) => {
+    sendErr = err;
+  });
+  await cleanup();
+
+  if (sendErr) {
+    fail(name, 'sendMessage rejected unexpectedly', String(sendErr));
+    return;
+  }
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (!postCall || !postCall.body) {
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    return;
+  }
+  const body = JSON.parse(postCall.body);
+  if (body.include_server_tools !== true) {
+    fail(name, `include_server_tools = ${JSON.stringify(body.include_server_tools)}, want true`, postCall.body);
+    return;
+  }
 
   pass(name);
 }
@@ -3288,6 +3322,7 @@ function testRestoreLatestDraftMessageDoesNotCrossSessionBoundary() {
   await testConsumeResponseStreamReportsStaleWithoutApplyingEvents();
   await testSendMessageDoesNotResumeAfterStalePostStream();
   await testSendMessageUsesLocalContinuationIdWithoutPreflightSync();
+  await testSendMessageIncludesServerToolsForFirstPartyUI();
   await testSendMessageRecoversStaleContinuationAfterConflict();
   await testSendMessageConsumesPostStreamWhenAvailable();
   await testSendMessageRefreshesHeaderAfterCompletionUnlocksModelPicker();


### PR DESCRIPTION
## What

Set `include_server_tools: true` on first-party Web UI `/v1/responses` sends.

## Why

The Responses API defaults to not exposing server tools unless the caller explicitly opts in. The Web UI is a first-party client and should opt in, otherwise Claude/OpenAI-compatible response runs receive no term-llm tools.

This became catastrophic with the claude-bin hardening change because Claude Code no longer saw the old in-band prompt/tool transcript and had no real MCP tools available, so it started emitting fake `<invoke>` text instead of actual tool calls.

Observed in session 2346:

- persisted messages had only system/developer/user/assistant; no tool messages
- Claude project log under `/home/agent/.claude/projects/-etc-sv-webui/...` showed literal assistant text containing `<invoke name="shell">...` and copied/fabricated tool output
- the UI request path had not set `include_server_tools`, so `responseServerTools(runtime, requestedTools, false)` returned no tools when the browser supplied no explicit tool list

## Verification

- `mise exec node@24.15.0 -- node internal/serveui/static/app_stream_test.js`
- `go test ./cmd ./internal/serveui`
