### PR TITLE
fix(ui): default server tools for first-party responses

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -286,7 +286,8 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 	searchFromTools, requestedTools, passthroughTools := parseRequestedTools(req.Tools)
 	search := runtime.search || searchFromTools
 	toolChoice := parseToolChoice(req.ToolChoice)
-	serverTools := responseServerTools(runtime, requestedTools, req.IncludeServerTools)
+	includeServerTools := req.IncludeServerTools || isFirstPartyUIResponseRequest(r)
+	serverTools := responseServerTools(runtime, requestedTools, includeServerTools)
 	tools := appendResponsePassthroughTools(serverTools, passthroughTools, runtime.toolMap)
 	if len(tools) == 0 {
 		toolChoice = llm.ToolChoice{}
@@ -451,6 +452,13 @@ func (s *serveServer) populateResponsesToolResultNames(ctx context.Context, sess
 			}
 		}
 	}
+}
+
+func isFirstPartyUIResponseRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return strings.TrimSpace(r.Header.Get("X-Term-LLM-UI-Version")) != ""
 }
 
 func responseServerTools(runtime *serveRuntime, requested map[string]bool, includeServerTools bool) []llm.ToolSpec {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2276,6 +2276,18 @@ func (e *secondEchoTool) Execute(_ context.Context, _ json.RawMessage) (llm.Tool
 
 func (e *secondEchoTool) Preview(_ json.RawMessage) string { return "" }
 
+func TestResponseServerTools_FirstPartyUIHeaderIncludesServerTools(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/chat/v1/responses", nil)
+	if isFirstPartyUIResponseRequest(req) {
+		t.Fatal("request without UI version header was treated as first-party UI")
+	}
+
+	req.Header.Set("X-Term-LLM-UI-Version", "a154f9083d98")
+	if !isFirstPartyUIResponseRequest(req) {
+		t.Fatal("request with UI version header was not treated as first-party UI")
+	}
+}
+
 func TestResponseServerTools_IncludeServerToolsKeepsAllRegisteredTools(t *testing.T) {
 	registry := llm.NewToolRegistry()
 	registry.Register(&echoTool{})


### PR DESCRIPTION
## What

Default `/v1/responses` to include registered server tools when the request is from the first-party web UI, identified by the UI version header.

## Why

PR #738 fixed the current JS submit path by sending `include_server_tools: true`, but session 2349 still showed fake `<invoke>` calls after a rebuild. The served UI did contain the JS flag, which means relying only on the client flag is too brittle for first-party UI traffic.

The server already receives `X-Term-LLM-UI-Version` from web UI requests. First-party UI calls should always get term-llm tools; external API callers keep the existing explicit opt-in behavior.

## Tests

- `go test ./cmd ./internal/serveui`
- Live hotfix smoke via `/chat/v1/responses` without `include_server_tools`, with `X-Term-LLM-UI-Version: smoke`, confirmed real `activate_skill` execution:
  - `response.output_item.added name=activate_skill`
  - `response.tool_exec.start tool_name=activate_skill`
  - `response.tool_exec.end success=true`
