### PR TITLE
fix(llm): isolate claude-bin environment

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -38,6 +38,24 @@ const claudeDiagnosticLineMaxBytes = 4 * 1024
 // in a failure event. The full length and SHA-256 are always logged.
 const claudeDiagnosticStdinMaxBytes = 128 * 1024
 
+// forcedClaudeCodeIsolationEnv disables Claude Code surfaces that can inject
+// first-party prompt/tool behavior into claude-bin runs. term-llm owns tools,
+// memory, background jobs, and project instructions for this provider; Claude
+// Code is only the authenticated model transport plus MCP client.
+var forcedClaudeCodeIsolationEnv = map[string]string{
+	"CLAUDE_CODE_DISABLE_WORKFLOWS":            "1",
+	"DISABLE_GROWTHBOOK":                       "1",
+	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+	"CLAUDE_CODE_DISABLE_AGENT_VIEW":           "1",
+	"CLAUDE_CODE_DISABLE_CRON":                 "1",
+	"CLAUDE_CODE_DISABLE_BACKGROUND_TASKS":     "1",
+	"CLAUDE_CODE_DISABLE_AUTO_MEMORY":          "1",
+	"CLAUDE_CODE_DISABLE_CLAUDE_MDS":           "1",
+	"CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS":     "1",
+	"CLAUDE_CODE_DISABLE_ADVISOR_TOOL":         "1",
+	"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS":   "1",
+}
+
 // mcpCallCounter generates unique IDs for MCP tool calls
 var mcpCallCounter atomic.Int64
 
@@ -466,9 +484,9 @@ func (p *ClaudeBinProvider) buildCommandEnv(effort string) []string {
 		if runningAsRoot && key == "IS_SANDBOX" {
 			continue
 		}
-		// Claude Code workflows injected from the user's environment contaminate
-		// term-llm's prompt, so drop any inherited value and force-disable below.
-		if key == "CLAUDE_CODE_DISABLE_WORKFLOWS" {
+		// Claude Code environment flags can enable hidden first-party prompt/tool
+		// surfaces. Drop inherited values and force our isolation defaults below.
+		if _, ok := forcedClaudeCodeIsolationEnv[key]; ok {
 			continue
 		}
 		if len(p.extraEnv) > 0 {
@@ -491,7 +509,7 @@ func (p *ClaudeBinProvider) buildCommandEnv(effort string) []string {
 		if runningAsRoot && k == "IS_SANDBOX" {
 			continue
 		}
-		if k == "CLAUDE_CODE_DISABLE_WORKFLOWS" {
+		if _, ok := forcedClaudeCodeIsolationEnv[k]; ok {
 			continue
 		}
 		filtered = append(filtered, k+"="+v)
@@ -499,9 +517,12 @@ func (p *ClaudeBinProvider) buildCommandEnv(effort string) []string {
 	if runningAsRoot && !envHasTruthy(filtered, "CLAUDE_CODE_BUBBLEWRAP") {
 		filtered = append(filtered, "IS_SANDBOX=1")
 	}
-	// Always disable Claude Code workflows so they cannot bleed into the prompt
-	// term-llm sends; this must win over any inherited or configured value.
-	filtered = append(filtered, "CLAUDE_CODE_DISABLE_WORKFLOWS=1")
+	// Always disable Claude Code features that can bleed first-party prompt/tool
+	// behavior into term-llm runs; these must win over inherited or configured
+	// values.
+	for k, v := range forcedClaudeCodeIsolationEnv {
+		filtered = append(filtered, k+"="+v)
+	}
 	return filtered
 }
 
@@ -614,7 +635,9 @@ func (p *ClaudeBinProvider) commandEnvDebugFields(effort string) (map[string]str
 	if effort != "" {
 		env["CLAUDE_CODE_EFFORT_LEVEL"] = effort
 	}
-	env["CLAUDE_CODE_DISABLE_WORKFLOWS"] = "1"
+	for k, v := range forcedClaudeCodeIsolationEnv {
+		env[k] = v
+	}
 	for k, v := range p.extraEnv {
 		if p.preferOAuth && k == "ANTHROPIC_API_KEY" {
 			continue
@@ -622,7 +645,7 @@ func (p *ClaudeBinProvider) commandEnvDebugFields(effort string) (map[string]str
 		if effort != "" && k == "CLAUDE_CODE_EFFORT_LEVEL" {
 			continue
 		}
-		if k == "CLAUDE_CODE_DISABLE_WORKFLOWS" {
+		if _, ok := forcedClaudeCodeIsolationEnv[k]; ok {
 			continue
 		}
 		env[k] = redactEnvValue(k, v)

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -813,14 +813,18 @@ func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "should-be-cleared")
 	t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "medium")
 	t.Setenv("CLAUDE_CODE_DISABLE_WORKFLOWS", "0")
+	t.Setenv("DISABLE_GROWTHBOOK", "0")
+	t.Setenv("CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS", "0")
 	t.Setenv("PATH", os.Getenv("PATH"))
 
 	p := NewClaudeBinProvider("opus-max", map[string]string{
-		"IS_SANDBOX":                    "1",
-		"CLAUDE_CODE_EFFORT_LEVEL":      "max-from-config-should-be-overridden",
-		"CLAUDE_CODE_DISABLE_WORKFLOWS": "config-value-should-be-overridden",
-		"ANTHROPIC_API_KEY":             "config-value-should-not-survive",
-		"CUSTOM_TERM_LLM_TEST_VALUE":    "ok",
+		"IS_SANDBOX":                           "1",
+		"CLAUDE_CODE_EFFORT_LEVEL":             "max-from-config-should-be-overridden",
+		"CLAUDE_CODE_DISABLE_WORKFLOWS":        "config-value-should-be-overridden",
+		"DISABLE_GROWTHBOOK":                   "config-value-should-be-overridden",
+		"CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": "config-value-should-be-overridden",
+		"ANTHROPIC_API_KEY":                    "config-value-should-not-survive",
+		"CUSTOM_TERM_LLM_TEST_VALUE":           "ok",
 	})
 
 	env := p.buildCommandEnv("max")
@@ -844,14 +848,16 @@ func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
 	if !strings.Contains(joined, "CLAUDE_CODE_EFFORT_LEVEL=max") {
 		t.Fatal("expected model-derived effort level to be present")
 	}
-	if strings.Contains(joined, "CLAUDE_CODE_DISABLE_WORKFLOWS=0") {
-		t.Fatal("expected inherited CLAUDE_CODE_DISABLE_WORKFLOWS to be removed")
-	}
-	if strings.Contains(joined, "CLAUDE_CODE_DISABLE_WORKFLOWS=config-value-should-be-overridden") {
-		t.Fatal("expected config CLAUDE_CODE_DISABLE_WORKFLOWS to be overridden")
-	}
-	if !strings.Contains(joined, "CLAUDE_CODE_DISABLE_WORKFLOWS=1") {
-		t.Fatal("expected CLAUDE_CODE_DISABLE_WORKFLOWS=1 to be forced unconditionally")
+	for key, want := range forcedClaudeCodeIsolationEnv {
+		if strings.Contains(joined, key+"=0") {
+			t.Fatalf("expected inherited %s to be removed", key)
+		}
+		if strings.Contains(joined, key+"=config-value-should-be-overridden") {
+			t.Fatalf("expected config %s to be overridden", key)
+		}
+		if !strings.Contains(joined, key+"="+want) {
+			t.Fatalf("expected %s=%s to be forced unconditionally", key, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Hardens the `claude-bin` subprocess environment beyond workflows:

- keep `CLAUDE_CODE_DISABLE_WORKFLOWS=1`
- add `DISABLE_GROWTHBOOK=1`
- disable Claude Code nonessential traffic, agent view, cron, background tasks, auto-memory, Claude MD/rules, git instructions, advisor tool, and experimental betas
- strip inherited/configured values for these keys before forcing term-llm's isolation values
- include the forced values in command debug fields

## Why

Claude Code 2.1.156 includes first-party surfaces that can inject prompt/tool behavior into SDK/print sessions, including workflow keyword handling and dynamic Workflow/RunWorkflow machinery. `claude-bin` should treat Claude Code as the authenticated model transport plus MCP client only; term-llm owns tools, memory, background work, project instructions, and workflows.

`DISABLE_GROWTHBOOK=1` is part of the isolation because Claude Code uses GrowthBook to gate remote feature flags such as workflow-related `tengu_*` features. Remote Control complains when this is set, but Remote Control is irrelevant for `claude-bin` provider mode.

## Tool isolation findings

I also tested the direct Claude Code tool boundary with a minimal HTTP MCP server.

Confirmed direct Claude Code can run with built-ins disabled and MCP still usable:

- `--tools "" --mcp-config <probe>` exposes and calls `mcp__term-llm__ping`
- `--allowedTools mcp__term-llm__ping --disallowedTools <builtins>` also exposes and calls the MCP tool
- direct Sonnet smoke called the MCP tool and returned `PONG:hello`

The earlier fake tool-call output was reproduced when Claude Code environment isolation was incomplete. With this PR's forced envs, a live term-llm smoke using Sonnet, `--tools ""`, and term-llm MCP tools produced real tool calls:

- `glob` executed through MCP
- `read_file` executed through MCP
- final README summary returned normally

So this PR keeps the existing `--tools ""` MCP strategy and fixes the contamination layer around it rather than replacing the tool flags.

## Tests

- `go test ./internal/llm`
- `go test ./cmd ./internal/llm`
- live smoke with built branch:
  - `/tmp/term-llm-env-isolation ask @developer -p claude-bin --no-session --json --debug --tools glob,read_file --read-dir /home/agent/source/term-llm --yolo --timeout 120s 'summarize readme'`
  - observed real `glob` and `read_file` MCP executions under Sonnet
