### PR TITLE
feat: refresh session titles when conversations change

### DIFF
--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -23,10 +23,12 @@ User-set names always win in the UI and are not overwritten unless --force is pr
 }
 
 var (
-	sessionsAutotitleDryRun  bool
-	sessionsAutotitleForce   bool
-	sessionsAutotitleMinAge  time.Duration
-	sessionsAutotitleVerbose bool
+	sessionsAutotitleDryRun         bool
+	sessionsAutotitleForce          bool
+	sessionsAutotitleMinAge         time.Duration
+	sessionsAutotitleVerbose        bool
+	sessionsAutotitleRefreshChanged bool
+	sessionsAutotitleContextTokens  int
 )
 
 type autotitleSkipStats struct {
@@ -72,6 +74,8 @@ func init() {
 	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleDryRun, "dry-run", false, "Preview generated titles without saving")
 	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleForce, "force", false, "Regenerate even when a custom name already exists")
 	sessionsAutotitleCmd.Flags().DurationVar(&sessionsAutotitleMinAge, "min-age", 3*time.Minute, "Skip sessions updated more recently than this duration")
+	sessionsAutotitleCmd.Flags().BoolVar(&sessionsAutotitleRefreshChanged, "refresh-changed", false, "Regenerate generated titles when newer messages exist beyond the previous title basis")
+	sessionsAutotitleCmd.Flags().IntVar(&sessionsAutotitleContextTokens, "context-tokens", 0, "Approximate conversation-token budget for title generation (0 uses default)")
 	sessionsAutotitleCmd.Flags().BoolVarP(&sessionsAutotitleVerbose, "verbose", "v", false, "Print rejected candidates with rejection reason")
 	sessionsCmd.AddCommand(sessionsAutotitleCmd)
 }
@@ -131,6 +135,17 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		if sess.GeneratedShortTitle != "" && !sessionsAutotitleForce {
+			if sessionsAutotitleRefreshChanged {
+				changed, err := titleHasNewMessages(ctx, store, sess)
+				if err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "#%d refresh-check failed: %v\n", summary.Number, err)
+					continue
+				}
+				if changed {
+					candidates = append(candidates, candidate{summary: summary, sess: sess})
+					continue
+				}
+			}
 			skips.alreadyTitled++
 			continue
 		}
@@ -160,15 +175,19 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 	for _, c := range candidates {
 		sess := c.sess
 
-		// Only the first few user+assistant messages are used for titling.
-		// Fetch at most 50 rows to avoid loading entire large sessions.
-		messages, err := store.GetMessages(ctx, sess.ID, 50, 0)
+		// Default runs keep this cheap; refresh runs can use a larger conversation budget
+		// while still bounding DB reads for pathological long sessions.
+		messageLimit := 50
+		if sessionsAutotitleContextTokens > 0 {
+			messageLimit = 500
+		}
+		messages, err := store.GetMessages(ctx, sess.ID, messageLimit, 0)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "#%d messages failed: %v\n", sess.Number, err)
 			continue
 		}
 
-		cand, err := sessiontitle.Generate(ctx, fastProvider, sess, messages)
+		cand, err := sessiontitle.GenerateWithOptions(ctx, fastProvider, sess, messages, sessiontitle.Options{MaxInputTokens: sessionsAutotitleContextTokens})
 		current := sess.PreferredShortTitle()
 		if strings.TrimSpace(current) == "" {
 			current = "Untitled"
@@ -201,8 +220,10 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 			sess.GeneratedLongTitle = cand.LongTitle
 			sess.TitleSource = session.TitleSourceGenerated
 			sess.TitleGeneratedAt = time.Now().UTC()
-			if len(messages) > 0 {
-				sess.TitleBasisMsgSeq = messages[len(messages)-1].Sequence
+			if basisSeq, err := titleBasisSequence(ctx, store, sess.ID, messages); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "#%d basis-seq failed: %v\n", sess.Number, err)
+			} else if basisSeq > 0 {
+				sess.TitleBasisMsgSeq = basisSeq
 			}
 			if err := store.Update(ctx, sess); err != nil {
 				fmt.Fprintf(cmd.OutOrStdout(), "  save:    failed (%v)\n\n", err)
@@ -221,4 +242,51 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "Generated titles for %d sessions (dry run).\n", generated)
 	}
 	return nil
+}
+
+func titleHasNewMessages(ctx context.Context, store session.Store, sess *session.Session) (bool, error) {
+	if sess == nil || sess.TitleBasisMsgSeq <= 0 {
+		return false, nil
+	}
+	messages, err := store.GetMessagesFrom(ctx, sess.ID, sess.TitleBasisMsgSeq+1, 20)
+	if err != nil {
+		return false, err
+	}
+	for _, msg := range messages {
+		if msg.Role == llm.RoleUser || msg.Role == llm.RoleAssistant {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func titleBasisSequence(ctx context.Context, store session.Store, sessionID string, loaded []session.Message) (int, error) {
+	maxSeq := 0
+	for _, msg := range loaded {
+		if (msg.Role == llm.RoleUser || msg.Role == llm.RoleAssistant) && msg.Sequence > maxSeq {
+			maxSeq = msg.Sequence
+		}
+	}
+	fromSeq := maxSeq + 1
+	if fromSeq <= 1 && len(loaded) > 0 {
+		fromSeq = loaded[len(loaded)-1].Sequence + 1
+	}
+	for {
+		messages, err := store.GetMessagesFrom(ctx, sessionID, fromSeq, 500)
+		if err != nil {
+			return maxSeq, err
+		}
+		if len(messages) == 0 {
+			return maxSeq, nil
+		}
+		for _, msg := range messages {
+			if (msg.Role == llm.RoleUser || msg.Role == llm.RoleAssistant) && msg.Sequence > maxSeq {
+				maxSeq = msg.Sequence
+			}
+		}
+		if len(messages) < 500 {
+			return maxSeq, nil
+		}
+		fromSeq = messages[len(messages)-1].Sequence + 1
+	}
 }

--- a/internal/sessiontitle/generator.go
+++ b/internal/sessiontitle/generator.go
@@ -22,7 +22,18 @@ type Candidate struct {
 	Confidence float64 `json:"confidence"`
 }
 
+type Options struct {
+	// MaxInputTokens caps the approximate prompt input budget for conversation text.
+	// A token is approximated as four UTF-8 bytes; this is deliberately conservative
+	// and provider-agnostic enough for autotitling.
+	MaxInputTokens int
+}
+
 func Generate(ctx context.Context, provider llm.Provider, sess *session.Session, messages []session.Message) (Candidate, error) {
+	return GenerateWithOptions(ctx, provider, sess, messages, Options{})
+}
+
+func GenerateWithOptions(ctx context.Context, provider llm.Provider, sess *session.Session, messages []session.Message, opts Options) (Candidate, error) {
 	if provider == nil {
 		return Candidate{}, fmt.Errorf("provider is nil")
 	}
@@ -30,7 +41,7 @@ func Generate(ctx context.Context, provider llm.Provider, sess *session.Session,
 		return Candidate{}, fmt.Errorf("session is nil")
 	}
 
-	slice := BuildConversationSlice(messages)
+	slice := BuildConversationSliceWithOptions(messages, opts)
 	if strings.TrimSpace(slice) == "" {
 		return Candidate{}, fmt.Errorf("no usable conversation text")
 	}
@@ -71,69 +82,109 @@ Conversation slice:
 }
 
 func BuildConversationSlice(messages []session.Message) string {
+	return BuildConversationSliceWithOptions(messages, Options{})
+}
+
+func BuildConversationSliceWithOptions(messages []session.Message, opts Options) string {
 	if len(messages) == 0 {
 		return ""
 	}
-	var lines []string
-	userWords := 0
-	assistantWords := 0
-
-	appendMsg := func(m session.Message) bool {
-		text := cleanMessageText(m.TextContent)
-		if text == "" {
-			return false
-		}
-		words := len(strings.Fields(text))
-		switch m.Role {
-		case llm.RoleUser:
-			if userWords >= 500 {
-				return false
-			}
-			if userWords+words > 500 {
-				text = truncateWords(text, 500-userWords)
-				words = len(strings.Fields(text))
-			}
-			userWords += words
-			lines = append(lines, "User: "+text)
-			return true
-		case llm.RoleAssistant:
-			if assistantWords >= 200 {
-				return false
-			}
-			if assistantWords+words > 200 {
-				text = truncateWords(text, 200-assistantWords)
-				words = len(strings.Fields(text))
-			}
-			assistantWords += words
-			lines = append(lines, "Assistant: "+text)
-			return true
-		default:
-			return false
-		}
+	maxChars := opts.MaxInputTokens * 4
+	if maxChars <= 0 {
+		maxChars = 2800
 	}
 
-	selected := 0
-	userCount := 0
-	assistantCount := 0
+	type line struct {
+		text  string
+		chars int
+	}
+	var lines []line
 	for _, m := range messages {
-		if m.Role == llm.RoleUser && userCount < 3 {
-			if appendMsg(m) {
-				selected++
-				userCount++
-			}
+		if m.Role != llm.RoleUser && m.Role != llm.RoleAssistant {
 			continue
 		}
-		if m.Role == llm.RoleAssistant && assistantCount < 2 && selected > 0 {
-			if appendMsg(m) {
-				assistantCount++
-			}
+		text := cleanMessageText(m.TextContent)
+		if text == "" {
+			continue
 		}
-		if userCount >= 3 && assistantCount >= 2 {
-			break
+		prefix := "Assistant: "
+		if m.Role == llm.RoleUser {
+			prefix = "User: "
 		}
+		entry := prefix + text
+		lines = append(lines, line{text: entry, chars: len(entry) + 1})
+	}
+	if len(lines) == 0 {
+		return ""
 	}
 
-	return strings.Join(lines, "\n")
+	total := 0
+	for _, l := range lines {
+		total += l.chars
+	}
+	if total <= maxChars {
+		out := make([]string, 0, len(lines))
+		for _, l := range lines {
+			out = append(out, l.text)
+		}
+		return strings.Join(out, "\n")
+	}
+
+	// Keep both the start and the latest turns. The opening usually names the task;
+	// the tail is what lets a later refresh improve an already-generated title.
+	headBudget := maxChars / 2
+	tailBudget := maxChars - headBudget - len("[… earlier middle turns omitted …]\n")
+	if tailBudget < maxChars/4 {
+		tailBudget = maxChars / 2
+		headBudget = maxChars - tailBudget
+	}
+
+	selected := make([]string, 0, len(lines)+1)
+	used := 0
+	headEnd := 0
+	for headEnd < len(lines) {
+		l := lines[headEnd]
+		if used > 0 && used+l.chars > headBudget {
+			break
+		}
+		if l.chars > headBudget && used == 0 {
+			selected = append(selected, truncateRunes(l.text, headBudget))
+			used = headBudget
+			headEnd++
+			break
+		}
+		selected = append(selected, l.text)
+		used += l.chars
+		headEnd++
+	}
+
+	tailStart := len(lines)
+	used = 0
+	for tailStart > headEnd {
+		l := lines[tailStart-1]
+		if used > 0 && used+l.chars > tailBudget {
+			break
+		}
+		if l.chars > tailBudget && used == 0 {
+			tailStart--
+			break
+		}
+		used += l.chars
+		tailStart--
+	}
+	if tailStart > headEnd {
+		selected = append(selected, "[… earlier middle turns omitted …]")
+	}
+	if tailStart < len(lines) {
+		for _, l := range lines[tailStart:] {
+			if l.chars > tailBudget && len(selected) > 0 {
+				selected = append(selected, truncateRunes(l.text, tailBudget))
+				continue
+			}
+			selected = append(selected, l.text)
+		}
+	}
+	return strings.Join(selected, "\n")
 }
 
 func ParseCandidate(raw string) (Candidate, error) {
@@ -244,6 +295,26 @@ func truncateWords(s string, maxWords int) string {
 		return s
 	}
 	return strings.Join(fields[:maxWords], " ")
+}
+
+func truncateRunes(s string, maxChars int) string {
+	if maxChars <= 0 {
+		return ""
+	}
+	if len(s) <= maxChars {
+		return s
+	}
+	out := make([]rune, 0, maxChars)
+	used := 0
+	for _, r := range s {
+		w := len(string(r))
+		if used+w > maxChars {
+			break
+		}
+		out = append(out, r)
+		used += w
+	}
+	return strings.TrimSpace(string(out)) + " …"
 }
 
 func normalizeTitle(s string) string {

--- a/internal/sessiontitle/generator_test.go
+++ b/internal/sessiontitle/generator_test.go
@@ -2,6 +2,7 @@ package sessiontitle
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -217,5 +218,26 @@ func TestGenerateUsesProvider(t *testing.T) {
 	}
 	if cand.ShortTitle != "Delightful resume browser redesign" {
 		t.Fatalf("ShortTitle = %q", cand.ShortTitle)
+	}
+}
+
+func TestBuildConversationSliceWithOptionsIncludesTail(t *testing.T) {
+	messages := []session.Message{
+		{Role: llm.RoleUser, TextContent: "initial request about a boring placeholder task"},
+	}
+	for i := 0; i < 20; i++ {
+		messages = append(messages, session.Message{Role: llm.RoleAssistant, TextContent: "middle filler text that should not consume the entire title prompt budget"})
+	}
+	messages = append(messages, session.Message{Role: llm.RoleUser, TextContent: "final request adds the real topic: refresh generated titles when new messages arrive"})
+
+	slice := BuildConversationSliceWithOptions(messages, Options{MaxInputTokens: 80})
+	if !strings.Contains(slice, "initial request") {
+		t.Fatalf("expected head content in slice, got %q", slice)
+	}
+	if !strings.Contains(slice, "refresh generated titles") {
+		t.Fatalf("expected tail content in slice, got %q", slice)
+	}
+	if !strings.Contains(slice, "omitted") {
+		t.Fatalf("expected omission marker in slice, got %q", slice)
 	}
 }


### PR DESCRIPTION
## What

Adds a refresh mode to `term-llm sessions autotitle`:

- `--refresh-changed` regenerates generated titles only when newer user/assistant messages exist beyond the previous `title_basis_msg_seq`.
- `--context-tokens` lets the refresh pass use a larger approximate conversation budget, e.g. 10k tokens.
- Title context now preserves both the opening turns and recent tail turns when truncated, so changed later data can improve an existing title instead of being invisible.

## Why

Sam suggested a slower improvement pass: roughly every 30 minutes, improve session titles if the data changed, using the fast model with a 10k-token budget.

This keeps cheap missing-title generation separate from the heavier "make it better now that the conversation moved on" path.

## Verification

```text
go test ./internal/sessiontitle ./cmd
ok  github.com/samsaffron/term-llm/internal/sessiontitle
ok  github.com/samsaffron/term-llm/cmd

go build ./...
```
