### PR TITLE
feat(serve): allow longer web response runs by default

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -728,7 +728,7 @@ const (
 	defaultResponseRunRetention        = 5 * time.Minute
 	defaultResponseRunReplayLimit      = 2048
 	defaultResponseRunSubscriberBuffer = 256
-	defaultServeRequestTimeout         = 30 * time.Minute
+	defaultServeRequestTimeout         = 2 * time.Hour
 )
 
 func responseRunTimeoutMessage(timeout time.Duration) string {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -7812,7 +7812,7 @@ func TestResolveServeResponseTimeout(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: defaultServeRequestTimeout,
+			want: 2 * time.Hour,
 		},
 		{
 			name:    "flag wins",

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -143,7 +143,7 @@ Relevant options include:
 - `--mcp`
 - `--tools`, `--read-dir`, `--write-dir`, `--shell-allow`
 - `--base-path`
-- `--response-timeout` (defaults to `30m`; also configurable as `serve.response_timeout` with Go durations like `45m` or `1h`)
+- `--response-timeout` (defaults to `2h`; also configurable as `serve.response_timeout` with Go durations like `45m` or `3h`)
 - `--cors-origin`
 - `--webrtc`, `--webrtc-signaling-url`, `--webrtc-token` (see [WebRTC direct routing](/guides/webrtc-direct-routing/))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2017,7 +2017,7 @@ func GetDefaults() map[string]any {
 		"skills.always_enabled":           []string{},
 		"skills.never_auto":               []string{},
 		"agents_md.enabled":               true,
-		"serve.response_timeout":          "30m",
+		"serve.response_timeout":          "2h",
 		"auto_compact":                    true,
 	}
 }


### PR DESCRIPTION
## What

Raise the default `serve.response_timeout` / `--response-timeout` from `30m` to `2h`.

## Why

Long-running web chat runs with high-reasoning models can legitimately exceed 30 minutes, especially when they are doing tool-heavy work: editing, validating, screenshotting, building, deploying, and verifying.

The previous 30 minute default caused the run to hit the server-side deadline and require a manual `continue`. That is hostile to the exact future-shaped loop we want to support.

This keeps the feature minimal:

- no new job orchestration yet
- no UI churn
- still bounded by a clear timeout
- still configurable down or up with `serve.response_timeout` / `--response-timeout`

## Validation

```text
go test ./cmd -run 'TestResolveServeResponseTimeout|TestResponseRunTimeoutUsesServeConfig'
go test ./cmd ./internal/config
go build ./...
```
