### PR TITLE
feat(serve): hand long chat work to jobs

### DIFF
--- a/cmd/job_handoff_test.go
+++ b/cmd/job_handoff_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +62,56 @@ func TestServeJobHandoffCreatesManualLLMRun(t *testing.T) {
 	}
 	if run.Status != jobsV2RunQueued {
 		t.Fatalf("run status = %s, want queued", run.Status)
+	}
+}
+
+func TestServeJobHandoffCanUseRemoteJobsProcess(t *testing.T) {
+	oldServer, oldToken, oldTimeout := jobsServerURL, jobsToken, jobsTimeout
+	defer func() {
+		jobsServerURL, jobsToken, jobsTimeout = oldServer, oldToken, oldTimeout
+	}()
+
+	var created jobsV2JobRequest
+	srvHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs":
+			if err := json.NewDecoder(r.Body).Decode(&created); err != nil {
+				t.Fatalf("decode create: %v", err)
+			}
+			job := created.toJob(true)
+			job.ID = "job_remote"
+			job.CreatedAt = time.Now()
+			job.UpdatedAt = job.CreatedAt
+			_ = json.NewEncoder(w).Encode(job)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs/job_remote/trigger":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(jobsV2Run{ID: "run_remote", JobID: "job_remote", Status: jobsV2RunQueued})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srvHTTP.Close()
+	jobsServerURL = srvHTTP.URL
+	jobsToken = ""
+	jobsTimeout = time.Second
+
+	srv := &serveServer{cfg: serveServerConfig{agentName: "jarvis"}}
+	res, err := srv.jobHandoffFunc("sess_parent", "jarvis")(context.Background(), tools.JobHandoffRequest{
+		Instructions: "remote work",
+	})
+	if err != nil {
+		t.Fatalf("handoff error: %v", err)
+	}
+	if res.JobID != "job_remote" || res.RunID != "run_remote" || res.SessionID == "" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(created.RunnerConfig, &cfg); err != nil {
+		t.Fatalf("runner config: %v", err)
+	}
+	if cfg.ReplyToSessionID != "sess_parent" || cfg.Instructions != "remote work" || cfg.AgentName != "jarvis" {
+		t.Fatalf("unexpected config: %+v", cfg)
 	}
 }
 

--- a/cmd/job_handoff_test.go
+++ b/cmd/job_handoff_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func TestServeJobHandoffCreatesManualLLMRun(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	srv := &serveServer{
+		jobsV2: mgr,
+		cfg:    serveServerConfig{agentName: "jarvis"},
+	}
+
+	res, err := srv.jobHandoffFunc("sess_parent", "jarvis")(context.Background(), tools.JobHandoffRequest{
+		Instructions:   "finish the long task",
+		Name:           "long task",
+		TimeoutSeconds: 30, // should be protected upward to 60s
+	})
+	if err != nil {
+		t.Fatalf("handoff error: %v", err)
+	}
+	if res.Status != "started" || res.JobID == "" || res.RunID == "" || res.SessionID == "" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+
+	job, err := mgr.GetJob(res.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.RunnerType != jobsV2RunnerLLM || job.TriggerType != jobsV2TriggerManual {
+		t.Fatalf("unexpected job type: %+v", job)
+	}
+	if job.TimeoutSeconds != 60 {
+		t.Fatalf("TimeoutSeconds = %d, want 60", job.TimeoutSeconds)
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(job.RunnerConfig, &cfg); err != nil {
+		t.Fatalf("runner config: %v", err)
+	}
+	if cfg.AgentName != "jarvis" || cfg.Instructions != "finish the long task" || cfg.ReplyToSessionID != "sess_parent" || cfg.SessionID != res.SessionID {
+		t.Fatalf("unexpected runner config: %+v", cfg)
+	}
+
+	run, err := mgr.GetRun(res.RunID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.Status != jobsV2RunQueued {
+		t.Fatalf("run status = %s, want queued", run.Status)
+	}
+}
+
+func TestJobReplyHandlerAppendsCompletionToParentSession(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: t.TempDir() + "/sessions.db"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	parent := &session.Session{ID: "sess_parent", Provider: "test", Model: "test", Mode: session.ModeChat, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := store.Create(ctx, parent); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cfg, _ := json.Marshal(jobsV2LLMConfig{ReplyToSessionID: parent.ID})
+	handler := makeJobReplyHandler(store)
+	handler(jobsV2Run{ID: "run_123", Status: jobsV2RunSucceeded, SessionID: "sess_child", Response: "done from job"}, jobsV2Job{Name: "long task", RunnerType: jobsV2RunnerLLM, RunnerConfig: cfg})
+
+	msgs, err := store.GetMessages(ctx, parent.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(messages) = %d, want 1", len(msgs))
+	}
+	if msgs[0].Role != llm.RoleAssistant || !strings.Contains(msgs[0].TextContent, "done from job") || !strings.Contains(msgs[0].TextContent, "run_123") {
+		t.Fatalf("unexpected message: role=%s text=%q", msgs[0].Role, msgs[0].TextContent)
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -518,7 +518,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if hasHTTP {
 		var jobsV2 *jobsV2Manager
 		if hasJobs {
-			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers)
+			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers, store)
 			if err != nil {
 				return fmt.Errorf("initialize jobs v2 manager: %w", err)
 			}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1905,6 +1905,7 @@ func (s *serveServer) runtimeForRequest(ctx context.Context, sessionID string) (
 		if err != nil {
 			return nil, false, err
 		}
+		s.attachJobHandoff(rt, sessionID)
 		return rt, false, nil
 	}
 	// Stateful sessions should persist beyond a single HTTP request, but
@@ -1913,6 +1914,7 @@ func (s *serveServer) runtimeForRequest(ctx context.Context, sessionID string) (
 	if err != nil {
 		return nil, false, err
 	}
+	s.attachJobHandoff(rt, sessionID)
 	return rt, true, nil
 }
 
@@ -1943,6 +1945,7 @@ func (s *serveServer) runtimeForProviderModelRequest(ctx context.Context, sessio
 		if err != nil {
 			return nil, false, err
 		}
+		s.attachJobHandoff(rt, sessionID)
 		return rt, false, nil
 	}
 	// Check persisted session provider before creating/reusing a runtime.
@@ -1972,6 +1975,7 @@ func (s *serveServer) runtimeForProviderModelRequest(ctx context.Context, sessio
 	if existingProvider != "" && providerName != "" && existingProvider != providerName {
 		return nil, false, fmt.Errorf("session %q already uses provider %q (requested %q)", sessionID, existingProvider, providerName)
 	}
+	s.attachJobHandoff(rt, sessionID)
 	return rt, true, nil
 }
 

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -2617,7 +2617,7 @@ func (s *serveServer) attachJobHandoff(rt *serveRuntime, sessionID string) {
 }
 
 func (s *serveServer) jobHandoffFunc(parentSessionID, defaultAgent string) tools.JobHandoffFunc {
-	if s == nil || s.jobsV2 == nil {
+	if s == nil {
 		return nil
 	}
 	return func(ctx context.Context, req tools.JobHandoffRequest) (tools.JobHandoffResult, error) {
@@ -2637,56 +2637,96 @@ func (s *serveServer) jobHandoffFunc(parentSessionID, defaultAgent string) tools
 			}
 		}
 
-		timeout := req.TimeoutSeconds
-		if timeout <= 0 {
-			timeout = 2 * 60 * 60
+		jobReq := buildJobHandoffJob(req, agentName, strings.TrimSpace(parentSessionID))
+		if s.jobsV2 != nil {
+			return s.createLocalJobHandoff(jobReq)
 		}
-		if timeout > 6*60*60 {
-			timeout = 6 * 60 * 60
-		}
-		if timeout < 60 {
-			timeout = 60
-		}
-
-		childSessionID := session.NewID()
-		runnerConfig, _ := json.Marshal(jobsV2LLMConfig{
-			AgentName:        agentName,
-			Instructions:     req.Instructions,
-			SessionID:        childSessionID,
-			ReplyToSessionID: strings.TrimSpace(parentSessionID),
-		})
-		labels, _ := json.Marshal(map[string]string{
-			"kind":                "chat_handoff",
-			"reply_to_session_id": strings.TrimSpace(parentSessionID),
-		})
-		name := strings.TrimSpace(req.Name)
-		if name == "" {
-			name = defaultHandoffJobName(req.Instructions)
-		}
-		job, err := s.jobsV2.CreateJob(jobsV2Job{
-			Name:           name,
-			Enabled:        true,
-			RunnerType:     jobsV2RunnerLLM,
-			RunnerConfig:   runnerConfig,
-			TriggerType:    jobsV2TriggerManual,
-			TriggerConfig:  json.RawMessage(`{}`),
-			TimeoutSeconds: timeout,
-			Labels:         labels,
-		})
-		if err != nil {
-			return tools.JobHandoffResult{}, err
-		}
-		run, err := s.jobsV2.TriggerJob(job.ID)
-		if err != nil {
-			return tools.JobHandoffResult{}, err
-		}
-		return tools.JobHandoffResult{
-			Status:    "started",
-			JobID:     job.ID,
-			RunID:     run.ID,
-			SessionID: childSessionID,
-		}, nil
+		return createRemoteJobHandoff(ctx, jobReq)
 	}
+}
+
+func buildJobHandoffJob(req tools.JobHandoffRequest, agentName, parentSessionID string) jobsV2Job {
+	timeout := req.TimeoutSeconds
+	if timeout <= 0 {
+		timeout = 2 * 60 * 60
+	}
+	if timeout > 6*60*60 {
+		timeout = 6 * 60 * 60
+	}
+	if timeout < 60 {
+		timeout = 60
+	}
+
+	childSessionID := session.NewID()
+	runnerConfig, _ := json.Marshal(jobsV2LLMConfig{
+		AgentName:        agentName,
+		Instructions:     req.Instructions,
+		SessionID:        childSessionID,
+		ReplyToSessionID: parentSessionID,
+	})
+	labels, _ := json.Marshal(map[string]string{
+		"kind":                "chat_handoff",
+		"reply_to_session_id": parentSessionID,
+	})
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = defaultHandoffJobName(req.Instructions)
+	}
+	return jobsV2Job{
+		Name:           name,
+		Enabled:        true,
+		RunnerType:     jobsV2RunnerLLM,
+		RunnerConfig:   runnerConfig,
+		TriggerType:    jobsV2TriggerManual,
+		TriggerConfig:  json.RawMessage(`{}`),
+		TimeoutSeconds: timeout,
+		Labels:         labels,
+	}
+}
+
+func (s *serveServer) createLocalJobHandoff(jobReq jobsV2Job) (tools.JobHandoffResult, error) {
+	job, err := s.jobsV2.CreateJob(jobReq)
+	if err != nil {
+		return tools.JobHandoffResult{}, err
+	}
+	run, err := s.jobsV2.TriggerJob(job.ID)
+	if err != nil {
+		return tools.JobHandoffResult{}, err
+	}
+	return tools.JobHandoffResult{
+		Status:    "started",
+		JobID:     job.ID,
+		RunID:     run.ID,
+		SessionID: handoffSessionID(job.RunnerConfig),
+	}, nil
+}
+
+func createRemoteJobHandoff(ctx context.Context, jobReq jobsV2Job) (tools.JobHandoffResult, error) {
+	client, err := newJobsClient()
+	if err != nil {
+		return tools.JobHandoffResult{}, err
+	}
+	payload, _ := json.Marshal(jobsV2JobToRequest(jobReq))
+	var job jobsV2Job
+	if err := client.do(ctx, http.MethodPost, "/v2/jobs", payload, &job); err != nil {
+		return tools.JobHandoffResult{}, fmt.Errorf("create remote job: %w", err)
+	}
+	var run jobsV2Run
+	if err := client.do(ctx, http.MethodPost, "/v2/jobs/"+job.ID+"/trigger", nil, &run); err != nil {
+		return tools.JobHandoffResult{}, fmt.Errorf("trigger remote job: %w", err)
+	}
+	return tools.JobHandoffResult{
+		Status:    "started",
+		JobID:     job.ID,
+		RunID:     run.ID,
+		SessionID: handoffSessionID(job.RunnerConfig),
+	}, nil
+}
+
+func handoffSessionID(raw json.RawMessage) string {
+	var cfg jobsV2LLMConfig
+	_ = json.Unmarshal(raw, &cfg)
+	return strings.TrimSpace(cfg.SessionID)
 }
 
 func defaultHandoffJobName(instructions string) string {

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -21,6 +21,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/procutil"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
 	_ "modernc.org/sqlite"
 )
 
@@ -312,13 +313,14 @@ type jobsV2LLMRunner struct {
 }
 
 type jobsV2LLMConfig struct {
-	AgentName      string `json:"agent_name"`
-	Instructions   string `json:"instructions"`
-	Progressive    bool   `json:"progressive,omitempty"`
-	StopWhen       string `json:"stop_when,omitempty"`
-	ContinueWith   string `json:"continue_with,omitempty"`
-	PersistSession *bool  `json:"persist_session,omitempty"`
-	SessionID      string `json:"session_id,omitempty"`
+	AgentName        string `json:"agent_name"`
+	Instructions     string `json:"instructions"`
+	Progressive      bool   `json:"progressive,omitempty"`
+	StopWhen         string `json:"stop_when,omitempty"`
+	ContinueWith     string `json:"continue_with,omitempty"`
+	PersistSession   *bool  `json:"persist_session,omitempty"`
+	SessionID        string `json:"session_id,omitempty"`
+	ReplyToSessionID string `json:"reply_to_session_id,omitempty"`
 }
 
 func (c jobsV2LLMConfig) sessionPersistenceEnabled() bool {
@@ -487,6 +489,7 @@ type jobsV2Manager struct {
 	workers  int
 	workerID string
 	runners  map[jobsV2RunnerType]jobsV2Runner
+	onFinish func(run jobsV2Run, job jobsV2Job)
 	// Idle timers are only fallbacks; job/run mutations wake the loops immediately.
 	schedulerIdleDelay time.Duration
 	workerIdleDelay    time.Duration
@@ -1314,6 +1317,14 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		"input_tokens":  result.InputTokens,
 		"output_tokens": result.OutputTokens,
 	})
+
+	if m.onFinish != nil {
+		if run, runErr := m.GetRun(runID); runErr == nil {
+			if job, jobErr := m.GetJob(run.JobID); jobErr == nil {
+				m.onFinish(run, job)
+			}
+		}
+	}
 
 	if status == jobsV2RunFailed || status == jobsV2RunTimedOut {
 		run, err := m.GetRun(runID)
@@ -2589,9 +2600,150 @@ func (s *serveServer) handleRunV2ByID(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, run)
 }
 
-func newServeJobsV2Manager(cfg *config.Config, workers int) (*jobsV2Manager, error) {
-	_ = cfg
-	return newJobsV2Manager("", workers, newServeJobsExecutor(cfg))
+func newServeJobsV2Manager(cfg *config.Config, workers int, store session.Store) (*jobsV2Manager, error) {
+	mgr, err := newJobsV2Manager("", workers, newServeJobsExecutor(cfg))
+	if err != nil {
+		return nil, err
+	}
+	mgr.onFinish = makeJobReplyHandler(store)
+	return mgr, nil
+}
+
+func (s *serveServer) attachJobHandoff(rt *serveRuntime, sessionID string) {
+	if rt == nil {
+		return
+	}
+	rt.jobHandoff = s.jobHandoffFunc(sessionID, rt.agentName)
+}
+
+func (s *serveServer) jobHandoffFunc(parentSessionID, defaultAgent string) tools.JobHandoffFunc {
+	if s == nil || s.jobsV2 == nil {
+		return nil
+	}
+	return func(ctx context.Context, req tools.JobHandoffRequest) (tools.JobHandoffResult, error) {
+		agentName := strings.TrimSpace(req.AgentName)
+		if agentName == "" {
+			agentName = strings.TrimSpace(defaultAgent)
+		}
+		if agentName == "" && s.cfg.agentName != "" {
+			agentName = s.cfg.agentName
+		}
+		if agentName == "" {
+			return tools.JobHandoffResult{}, fmt.Errorf("agent_name is required")
+		}
+		if s.cfgRef != nil {
+			if _, err := LoadAgent(agentName, s.cfgRef); err != nil {
+				return tools.JobHandoffResult{}, err
+			}
+		}
+
+		timeout := req.TimeoutSeconds
+		if timeout <= 0 {
+			timeout = 2 * 60 * 60
+		}
+		if timeout > 6*60*60 {
+			timeout = 6 * 60 * 60
+		}
+		if timeout < 60 {
+			timeout = 60
+		}
+
+		childSessionID := session.NewID()
+		runnerConfig, _ := json.Marshal(jobsV2LLMConfig{
+			AgentName:        agentName,
+			Instructions:     req.Instructions,
+			SessionID:        childSessionID,
+			ReplyToSessionID: strings.TrimSpace(parentSessionID),
+		})
+		labels, _ := json.Marshal(map[string]string{
+			"kind":                "chat_handoff",
+			"reply_to_session_id": strings.TrimSpace(parentSessionID),
+		})
+		name := strings.TrimSpace(req.Name)
+		if name == "" {
+			name = defaultHandoffJobName(req.Instructions)
+		}
+		job, err := s.jobsV2.CreateJob(jobsV2Job{
+			Name:           name,
+			Enabled:        true,
+			RunnerType:     jobsV2RunnerLLM,
+			RunnerConfig:   runnerConfig,
+			TriggerType:    jobsV2TriggerManual,
+			TriggerConfig:  json.RawMessage(`{}`),
+			TimeoutSeconds: timeout,
+			Labels:         labels,
+		})
+		if err != nil {
+			return tools.JobHandoffResult{}, err
+		}
+		run, err := s.jobsV2.TriggerJob(job.ID)
+		if err != nil {
+			return tools.JobHandoffResult{}, err
+		}
+		return tools.JobHandoffResult{
+			Status:    "started",
+			JobID:     job.ID,
+			RunID:     run.ID,
+			SessionID: childSessionID,
+		}, nil
+	}
+}
+
+func defaultHandoffJobName(instructions string) string {
+	line := strings.TrimSpace(strings.Split(strings.TrimSpace(instructions), "\n")[0])
+	if line == "" {
+		return "chat handoff"
+	}
+	if len(line) > 64 {
+		line = line[:64]
+	}
+	return "handoff: " + line
+}
+
+func makeJobReplyHandler(store session.Store) func(run jobsV2Run, job jobsV2Job) {
+	if store == nil {
+		return nil
+	}
+	return func(run jobsV2Run, job jobsV2Job) {
+		if job.RunnerType != jobsV2RunnerLLM {
+			return
+		}
+		var cfg jobsV2LLMConfig
+		if err := json.Unmarshal(job.RunnerConfig, &cfg); err != nil {
+			return
+		}
+		target := strings.TrimSpace(cfg.ReplyToSessionID)
+		if target == "" {
+			return
+		}
+		body := jobReplyMessage(run, job)
+		if strings.TrimSpace(body) == "" {
+			return
+		}
+		msg := session.NewMessage(target, llm.AssistantText(body), -1)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = store.AddMessage(ctx, target, msg)
+	}
+}
+
+func jobReplyMessage(run jobsV2Run, job jobsV2Job) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Background job `%s` finished with status `%s`.", run.ID, run.Status)
+	if strings.TrimSpace(run.SessionID) != "" {
+		fmt.Fprintf(&b, " Session: `%s`.", run.SessionID)
+	}
+	b.WriteString("\n\n")
+	if strings.TrimSpace(run.Error) != "" {
+		b.WriteString(run.Error)
+		return b.String()
+	}
+	if strings.TrimSpace(run.Response) != "" {
+		b.WriteString(strings.TrimSpace(run.Response))
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Job `%s` completed without a text response.", job.Name)
+	return b.String()
 }
 
 func queryBool(r *http.Request, key string) bool {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -59,6 +59,7 @@ type serveRuntime struct {
 	platform             string
 	platformMessages     agents.PlatformMessagesConfig
 	lastInjectedPlatform string
+	jobHandoff           tools.JobHandoffFunc
 }
 
 type runtimeInterruptState struct {
@@ -620,6 +621,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
 	runCtx = tools.ContextWithAskUserUIFunc(runCtx, rt.awaitAskUser)
+	runCtx = tools.ContextWithJobHandoffFunc(runCtx, rt.jobHandoff)
 
 	intState := &runtimeInterruptState{
 		cancel:      runCancel,

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -124,11 +124,14 @@ term-llm serve web --auth none --host 127.0.0.1
 
 ## Chat handoff to jobs
 
-When the web server is started with the `jobs` platform, agents can use the `handoff_to_job` tool to move long-running work out of the foreground chat response and into a durable manual LLM job:
+When the web server can reach a jobs runner, agents can use the `handoff_to_job` tool to move long-running work out of the foreground chat response and into a durable manual LLM job:
 
 ```bash
-term-llm serve web jobs
+term-llm serve web          # foreground chat process
+term-llm serve jobs         # separate durable jobs process, default http://127.0.0.1:8080
 ```
+
+`handoff_to_job` uses an in-process jobs manager when `web jobs` are served together, otherwise it talks to the jobs API configured by `TERM_LLM_JOBS_SERVER` / `TERM_LLM_JOBS_TOKEN` (the same settings used by `term-llm jobs`).
 
 The tool creates and triggers a background job, returns the job/run/session IDs to the chat, and appends the job's final result back to the originating chat session when it finishes. This is intended for long tool-heavy loops where the user should not have to keep a live response open.
 

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -122,6 +122,16 @@ term-llm serve web --auth none --host 127.0.0.1
 
 `--allow-no-auth` and `--auth none` are only valid for loopback use. Exposing an unauthenticated server beyond localhost would be idiotic.
 
+## Chat handoff to jobs
+
+When the web server is started with the `jobs` platform, agents can use the `handoff_to_job` tool to move long-running work out of the foreground chat response and into a durable manual LLM job:
+
+```bash
+term-llm serve web jobs
+```
+
+The tool creates and triggers a background job, returns the job/run/session IDs to the chat, and appends the job's final result back to the originating chat session when it finishes. This is intended for long tool-heavy loops where the user should not have to keep a live response open.
+
 ## Useful flags
 
 ```bash

--- a/internal/tools/job_handoff.go
+++ b/internal/tools/job_handoff.go
@@ -1,0 +1,129 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+// JobHandoffFunc starts a durable background job for work that should leave the
+// foreground chat response.
+type JobHandoffFunc func(ctx context.Context, req JobHandoffRequest) (JobHandoffResult, error)
+
+type jobHandoffContextKey struct{}
+
+// ContextWithJobHandoffFunc stores a request-scoped job handoff handler in ctx.
+func ContextWithJobHandoffFunc(ctx context.Context, fn JobHandoffFunc) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, jobHandoffContextKey{}, fn)
+}
+
+func jobHandoffFuncFromContext(ctx context.Context) JobHandoffFunc {
+	if ctx == nil {
+		return nil
+	}
+	fn, _ := ctx.Value(jobHandoffContextKey{}).(JobHandoffFunc)
+	return fn
+}
+
+// JobHandoffRequest is the tool payload for handoff_to_job.
+type JobHandoffRequest struct {
+	Instructions   string `json:"instructions"`
+	AgentName      string `json:"agent_name,omitempty"`
+	Name           string `json:"name,omitempty"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+}
+
+// JobHandoffResult is returned by handoff_to_job.
+type JobHandoffResult struct {
+	Status    string `json:"status"`
+	JobID     string `json:"job_id,omitempty"`
+	RunID     string `json:"run_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// JobHandoffTool implements the handoff_to_job tool.
+type JobHandoffTool struct{}
+
+func NewJobHandoffTool() *JobHandoffTool { return &JobHandoffTool{} }
+
+func (t *JobHandoffTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name: JobHandoffToolName,
+		Description: `Hand long-running work off from the current foreground chat response to a durable background LLM job.
+
+Use this when the task is likely to run for a long time, use many tool loops, or no longer needs to block the live chat response. The background job can continue independently and report its final result back to the originating chat session.
+
+Provide concise but complete instructions: include the current goal, important findings so far, files/URLs/session context needed to continue, and the expected final deliverable.`,
+		Schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"instructions": map[string]interface{}{
+					"type":        "string",
+					"description": "Complete instructions for the background job, including current context and expected final deliverable.",
+				},
+				"agent_name": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional agent to run as. Defaults to the current agent.",
+				},
+				"name": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional short job name shown in jobs UI/CLI.",
+				},
+				"timeout_seconds": map[string]interface{}{
+					"type":        "integer",
+					"description": "Optional run timeout in seconds. Defaults to 7200 and is capped by server policy.",
+				},
+			},
+			"required":             []string{"instructions"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *JobHandoffTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var req JobHandoffRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return llm.TextOutput(formatJobHandoffResult(JobHandoffResult{Status: "error", Error: fmt.Sprintf("failed to parse arguments: %v", err)})), nil
+	}
+	req.Instructions = strings.TrimSpace(req.Instructions)
+	req.AgentName = strings.TrimSpace(req.AgentName)
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Instructions == "" {
+		return llm.TextOutput(formatJobHandoffResult(JobHandoffResult{Status: "error", Error: "instructions is required"})), nil
+	}
+	fn := jobHandoffFuncFromContext(ctx)
+	if fn == nil {
+		return llm.TextOutput(formatJobHandoffResult(JobHandoffResult{Status: "error", Error: "job handoff is not available"})), nil
+	}
+	res, err := fn(ctx, req)
+	if err != nil {
+		return llm.TextOutput(formatJobHandoffResult(JobHandoffResult{Status: "error", Error: err.Error()})), nil
+	}
+	if strings.TrimSpace(res.Status) == "" {
+		res.Status = "started"
+	}
+	return llm.TextOutput(formatJobHandoffResult(res)), nil
+}
+
+func (t *JobHandoffTool) Preview(args json.RawMessage) string {
+	var req JobHandoffRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return ""
+	}
+	if name := strings.TrimSpace(req.Name); name != "" {
+		return name
+	}
+	return "background job"
+}
+
+func formatJobHandoffResult(res JobHandoffResult) string {
+	data, _ := json.Marshal(res)
+	return string(data)
+}

--- a/internal/tools/job_handoff_test.go
+++ b/internal/tools/job_handoff_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestJobHandoffToolUsesContextHandler(t *testing.T) {
+	tool := NewJobHandoffTool()
+	called := false
+	ctx := ContextWithJobHandoffFunc(context.Background(), func(ctx context.Context, req JobHandoffRequest) (JobHandoffResult, error) {
+		called = true
+		if req.Instructions != "continue carefully" {
+			t.Fatalf("instructions = %q", req.Instructions)
+		}
+		if req.AgentName != "developer" {
+			t.Fatalf("agent_name = %q", req.AgentName)
+		}
+		return JobHandoffResult{Status: "started", JobID: "job_1", RunID: "run_1", SessionID: "sess_1"}, nil
+	})
+
+	args, _ := json.Marshal(JobHandoffRequest{Instructions: " continue carefully ", AgentName: " developer "})
+	out, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !called {
+		t.Fatal("handler was not called")
+	}
+	if !strings.Contains(out.Content, `"job_id":"job_1"`) || !strings.Contains(out.Content, `"run_id":"run_1"`) {
+		t.Fatalf("unexpected output: %s", out.Content)
+	}
+}
+
+func TestJobHandoffToolRequiresHandler(t *testing.T) {
+	tool := NewJobHandoffTool()
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"instructions":"go long"}`))
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !strings.Contains(out.Content, "job handoff is not available") {
+		t.Fatalf("unexpected output: %s", out.Content)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -118,6 +118,8 @@ func (r *LocalToolRegistry) registerTool(specName string) error {
 		tool = NewRunAgentScriptTool(r.config, r.limits)
 	case InitiateHandoverToolName:
 		tool = NewInitiateHandoverTool()
+	case JobHandoffToolName:
+		tool = NewJobHandoffTool()
 	default:
 		return NewToolErrorf(ErrInvalidParams, "unimplemented tool: %s", specName)
 	}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -127,6 +127,7 @@ const (
 	SpawnAgentToolName       = "spawn_agent"
 	RunAgentScriptToolName   = "run_agent_script"
 	InitiateHandoverToolName = "initiate_handover"
+	JobHandoffToolName       = "handoff_to_job"
 )
 
 // AllToolNames returns all standard tool spec names that can be registered directly.
@@ -147,6 +148,7 @@ func AllToolNames() []string {
 		SpawnAgentToolName,
 		RunAgentScriptToolName,
 		InitiateHandoverToolName,
+		JobHandoffToolName,
 	}
 }
 


### PR DESCRIPTION
## What

Add a first-class chat → jobs handoff path for long-running work.

This introduces a new server tool:

- `handoff_to_job`

When the web runtime is started with jobs enabled (`term-llm serve web jobs`), an agent can call this tool to:

1. create a manual LLM job
2. trigger it immediately
3. return `{job_id, run_id, session_id}` to the current chat
4. have the job append its final result back to the originating chat session when it finishes

## Why

Some foreground chat runs legitimately become long tool-heavy loops. The right fix is not just "raise the timeout"; it is to let the live chat hand control to a durable job and return a handle immediately.

This is deliberately minimal:

- no new UI surface
- no new scheduler model
- uses the existing jobs runner
- uses normal session persistence for the completion reply
- bounded default timeout: 2h, capped at 6h for handoff requests

## Notes

The tool is only available when jobs are present in the same serve process. That keeps the first version small and avoids inventing cross-process job RPC/config.

## Validation

```text
go test ./cmd ./internal/tools
go build ./...
```
