### PR TITLE
fix: Responses continuations do a full session DB scan before checking in-memory history

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -402,37 +402,41 @@ func (s *serveServer) populateResponsesToolResultNames(ctx context.Context, sess
 	}
 
 	names := map[string]string{}
+	collectParts := func(parts []llm.Part) {
+		for _, part := range parts {
+			if part.Type != llm.PartToolCall || part.ToolCall == nil {
+				continue
+			}
+			id := strings.TrimSpace(part.ToolCall.ID)
+			if id == "" || !missing[id] || names[id] != "" {
+				continue
+			}
+			if name := strings.TrimSpace(part.ToolCall.Name); name != "" {
+				names[id] = name
+			}
+		}
+	}
 	collect := func(history []llm.Message) {
 		for i := len(history) - 1; i >= 0; i-- {
-			for _, part := range history[i].Parts {
-				if part.Type != llm.PartToolCall || part.ToolCall == nil {
-					continue
-				}
-				id := strings.TrimSpace(part.ToolCall.ID)
-				if id == "" || !missing[id] || names[id] != "" {
-					continue
-				}
-				if name := strings.TrimSpace(part.ToolCall.Name); name != "" {
-					names[id] = name
-				}
-			}
+			collectParts(history[i].Parts)
 			if len(names) == len(missing) {
 				return
 			}
 		}
 	}
 
-	if s.store != nil && sessionID != "" {
-		if stored, err := s.store.GetMessages(ctx, sessionID, 0, 0); err == nil {
-			persisted := make([]llm.Message, 0, len(stored))
-			for _, msg := range stored {
-				persisted = append(persisted, msg.ToLLMMessage())
-			}
-			collect(persisted)
-		}
-	}
-	if len(names) < len(missing) && runtime != nil {
+	if runtime != nil {
 		collect(runtime.snapshotHistory())
+	}
+	if len(names) < len(missing) && s.store != nil && sessionID != "" {
+		if stored, err := s.store.GetMessages(ctx, sessionID, 0, 0); err == nil {
+			for i := len(stored) - 1; i >= 0; i-- {
+				collectParts(stored[i].Parts)
+				if len(names) == len(missing) {
+					break
+				}
+			}
+		}
 	}
 	if len(names) == 0 {
 		return

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -133,6 +133,7 @@ type serveRuntimeTestStore struct {
 	addMessageCalls    int
 	updateMessageCalls int
 	updateFailures     map[int]error
+	getMessagesCalls   int
 	updateStatusCalls  int
 	incrementCalls     int
 	nextID             int64
@@ -253,6 +254,7 @@ func (s *serveRuntimeTestStore) UpdateMessage(ctx context.Context, sessionID str
 func (s *serveRuntimeTestStore) GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.getMessagesCalls++
 	msgs := s.messages[sessionID]
 	out := make([]session.Message, len(msgs))
 	copy(out, msgs)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1444,6 +1444,72 @@ func TestPopulateMissingToolResultNames_UsesHistory(t *testing.T) {
 	}
 }
 
+func TestPopulateResponsesToolResultNames_UsesRuntimeHistoryBeforeStore(t *testing.T) {
+	messages := []llm.Message{{
+		Role: llm.RoleTool,
+		Parts: []llm.Part{{
+			Type: llm.PartToolResult,
+			ToolResult: &llm.ToolResult{
+				ID: "call_1",
+			},
+		}},
+	}}
+	runtime := &serveRuntime{history: []llm.Message{{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{{
+			Type: llm.PartToolCall,
+			ToolCall: &llm.ToolCall{
+				ID:   "call_1",
+				Name: "read_file",
+			},
+		}},
+	}}}
+	store := newServeRuntimeTestStore()
+	srv := &serveServer{store: store}
+
+	srv.populateResponsesToolResultNames(context.Background(), "sess-runtime", runtime, messages)
+
+	if got := messages[0].Parts[0].ToolResult.Name; got != "read_file" {
+		t.Fatalf("tool result name = %q, want %q", got, "read_file")
+	}
+	if store.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages calls = %d, want 0 when runtime history resolves all names", store.getMessagesCalls)
+	}
+}
+
+func TestPopulateResponsesToolResultNames_FallsBackToStoreForUnresolvedNames(t *testing.T) {
+	messages := []llm.Message{{
+		Role: llm.RoleTool,
+		Parts: []llm.Part{{
+			Type: llm.PartToolResult,
+			ToolResult: &llm.ToolResult{
+				ID: "call_2",
+			},
+		}},
+	}}
+	store := newServeRuntimeTestStore()
+	store.messages["sess-store"] = []session.Message{*session.NewMessage("sess-store", llm.Message{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{{
+			Type: llm.PartToolCall,
+			ToolCall: &llm.ToolCall{
+				ID:   "call_2",
+				Name: "bash",
+			},
+		}},
+	}, 0)}
+	srv := &serveServer{store: store}
+
+	srv.populateResponsesToolResultNames(context.Background(), "sess-store", nil, messages)
+
+	if got := messages[0].Parts[0].ToolResult.Name; got != "bash" {
+		t.Fatalf("tool result name = %q, want %q", got, "bash")
+	}
+	if store.getMessagesCalls != 1 {
+		t.Fatalf("GetMessages calls = %d, want 1 when runtime cannot resolve names", store.getMessagesCalls)
+	}
+}
+
 func TestParseChatMessages_DeveloperDoesNotSuppressServerSystemPrompt(t *testing.T) {
 	msgs, replaceHistory, err := parseChatMessages([]chatMessage{
 		{Role: "developer", Content: json.RawMessage(`"Be concise"`)},


### PR DESCRIPTION
## What changed

- Updated `populateResponsesToolResultNames` to consult `runtime.snapshotHistory()` before touching the session store.
- Only fall back to `s.store.GetMessages(...)` when some tool-call IDs are still unresolved after checking in-memory history.
- When the store fallback is needed, scan persisted messages from newest to oldest and stop as soon as every missing tool result name has been found.
- Removed the extra allocation/conversion step that previously rebuilt every persisted row as `llm.Message` before scanning it.
- Added tests covering both the fast path (runtime history resolves names without any DB read) and the fallback path (store still fills unresolved names).

## Why this is high-value

Response continuations call this helper on the request path before streaming starts. Previously, every continuation with unnamed tool results did a full `GetMessages` read for the session and converted every stored row to `llm.Message` before even checking whether the active runtime already had the needed tool-call names in memory.

This change reduces first-token latency and total request work for long-lived serve/web sessions because the common case can now be satisfied entirely from in-memory history, avoiding:

- a full SQLite session-history read
- JSON/row decoding for all persisted messages
- allocation of a second `[]llm.Message` copy of the whole stored history

Even on fallback, the code now stops scanning once all requested tool-call names are found instead of always converting and traversing the entire persisted history.

## Validation

- `gofmt -w cmd/serve_handlers_responses.go cmd/serve_test.go cmd/serve_runtime_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`

Added tests:
- `TestPopulateResponsesToolResultNames_UsesRuntimeHistoryBeforeStore`
- `TestPopulateResponsesToolResultNames_FallsBackToStoreForUnresolvedNames`
