### PR TITLE
fix: Config saves are non-atomic and can corrupt config.yaml on interruption

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -940,7 +940,44 @@ func rewriteProviderEnvSections(path string, snapshot map[string]map[string]stri
 		return err
 	}
 	enc.Close()
-	return os.WriteFile(path, buf.Bytes(), 0600)
+	return writeFileAtomically(path, buf.Bytes(), 0o600)
+}
+
+func writeFileAtomically(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tf, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := tf.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tf.Write(data); err != nil {
+		_ = tf.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tf.Sync(); err != nil {
+		_ = tf.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tf.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tempPath, perm); err != nil {
+		return fmt.Errorf("set temp file permissions: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	cleanup = false
+	return nil
 }
 
 func findOrCreateChildMapping(parent *yaml.Node, key string) *yaml.Node {
@@ -2165,7 +2202,7 @@ func Save(cfg *Config) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	return os.WriteFile(path, data, 0600)
+	return writeFileAtomically(path, data, 0o600)
 }
 
 // SetAgentPreference sets a preference for a specific agent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -264,6 +265,71 @@ providers:
 	}
 	if got := cfg.Providers["claude-bin"].Env["IS_SANDBOX"]; got != "1" {
 		t.Fatalf("loaded IS_SANDBOX = %q", got)
+	}
+}
+
+func TestWriteFileAtomically_ReplacesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("write old config: %v", err)
+	}
+
+	if err := writeFileAtomically(path, []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomically: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != "new\n" {
+		t.Fatalf("config = %q, want %q", got, "new\n")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode = %o, want %o", info.Mode().Perm(), 0o600)
+	}
+}
+
+func TestWriteFileAtomically_CreateTempFailureLeavesExistingFileUntouched(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions behave differently on Windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("original\n"), 0o600); err != nil {
+		t.Fatalf("write original config: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod dir read-only: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0o755); err != nil {
+			t.Fatalf("restore dir permissions: %v", err)
+		}
+	}()
+
+	err := writeFileAtomically(path, []byte("updated\n"), 0o600)
+	if err == nil {
+		t.Fatal("expected writeFileAtomically to fail")
+	}
+	if !strings.Contains(err.Error(), "create temp file") {
+		t.Fatalf("error = %v, want create temp file", err)
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read original config: %v", readErr)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("config changed on failure: got %q want %q", got, "original\n")
 	}
 }
 


### PR DESCRIPTION
## What changed

- replaced the direct `os.WriteFile` calls used by config saves in `internal/config/config.go` with a small `writeFileAtomically` helper
- the helper writes to a temp file in the same directory, `fsync`s it, applies the expected mode, and then atomically renames it into place
- updated both config write paths covered by this issue:
  - `rewriteProviderEnvSections`
  - `Save`
- added focused tests that verify:
  - atomic writes replace the file contents and enforce `0600`
  - if temp-file creation fails, the existing `config.yaml` contents remain untouched

## Why this is high-value

`~/.config/term-llm/config.yaml` is core persisted state for provider defaults and auth-related settings. Before this change, these saves truncated the live file and then rewrote it in place. If the process was interrupted mid-write, or the write only partially completed, users could be left with an empty or malformed config and broken startup/auth flows.

With the temp-file + sync + rename pattern, the old config stays intact until the replacement file is fully written and ready, which removes the torn-write corruption mode from these paths.

## Validation

- `gofmt -w internal/config/config.go internal/config/config_test.go`
- `go build ./...`
- `go test ./internal/config`
- `go test ./...`
- `git diff --check`
