### PR TITLE
fix: Telegram restart carryover loads and converts the entire prior session just to keep a small tail

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -578,26 +578,93 @@ func (m *telegramSessionMgr) restoreHistoryFromDB(ctx context.Context, chatID in
 			continue
 		}
 
-		msgs, loadErr := m.store.GetMessages(ctx, s.ID, 0, 0)
+		history, loadedRows, loadErr := m.loadCarryoverHistory(ctx, s.ID, maxChars)
 		if loadErr != nil {
 			log.Printf("[telegram] restore history: get messages failed for session %s: %v", s.ID, loadErr)
 			continue
 		}
 
-		// Convert all messages, then take only the tail that fits within maxChars.
+		history = sanitizeCarryoverMessages(history)
+		if len(history) > 0 {
+			sess.history = history
+			log.Printf("[telegram] restored %d messages (loaded %d rows) from session %s for chat %d",
+				len(history), loadedRows, s.ID, chatID)
+		}
+		return
+	}
+}
+
+type telegramCarryoverPager interface {
+	GetMessagesPageDescending(ctx context.Context, sessionID string, beforeSeq, limit int) ([]session.Message, error)
+}
+
+func (m *telegramSessionMgr) loadCarryoverHistory(ctx context.Context, sessionID string, maxChars int) ([]llm.Message, int, error) {
+	if m.store == nil || maxChars <= 0 {
+		return nil, 0, nil
+	}
+
+	pager, ok := m.store.(telegramCarryoverPager)
+	if !ok {
+		msgs, err := m.store.GetMessages(ctx, sessionID, 0, 0)
+		if err != nil {
+			return nil, 0, err
+		}
 		all := make([]llm.Message, 0, len(msgs))
 		for _, msg := range msgs {
 			all = append(all, msg.ToLLMMessage())
 		}
-
-		history := sanitizeCarryoverMessages(tailMessages(all, maxChars))
-		if len(history) > 0 {
-			sess.history = history
-			log.Printf("[telegram] restored %d messages (of %d) from session %s for chat %d",
-				len(history), len(all), s.ID, chatID)
-		}
-		return
+		return tailMessages(all, maxChars), len(msgs), nil
 	}
+
+	const initialBatchSize = 32
+
+	selectedRev := make([]llm.Message, 0, initialBatchSize)
+	totalChars := 0
+	loadedRows := 0
+	beforeSeq := 0
+	batchSize := initialBatchSize
+
+	for {
+		msgs, err := pager.GetMessagesPageDescending(ctx, sessionID, beforeSeq, batchSize)
+		if err != nil {
+			return nil, loadedRows, err
+		}
+		if len(msgs) == 0 {
+			break
+		}
+		loadedRows += len(msgs)
+
+		for _, msg := range msgs {
+			llmMsg := msg.ToLLMMessage()
+			text := extractMessageTextWithPlaceholders(llmMsg)
+			n := len([]rune(text))
+			if totalChars+n > maxChars && len(selectedRev) > 0 {
+				return reverseMessages(selectedRev), loadedRows, nil
+			}
+			totalChars += n
+			selectedRev = append(selectedRev, llmMsg)
+		}
+
+		if len(msgs) < batchSize {
+			break
+		}
+		beforeSeq = msgs[len(msgs)-1].Sequence
+		batchSize *= 2
+	}
+
+	return reverseMessages(selectedRev), loadedRows, nil
+}
+
+func reverseMessages(msgs []llm.Message) []llm.Message {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	reversed := make([]llm.Message, len(msgs))
+	for i := range msgs {
+		reversed[len(msgs)-1-i] = msgs[i]
+	}
+	return reversed
 }
 
 // tailMessages returns the largest suffix of msgs whose combined text fits

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,41 @@ import (
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/testutil"
 )
+
+type getMessagesCall struct {
+	sessionID string
+	beforeSeq int
+	limit     int
+}
+
+type carryoverPagingStore struct {
+	*session.NoopStore
+	summaries  []session.SessionSummary
+	messages   map[string][]session.Message
+	calls      []getMessagesCall
+	rowsLoaded int
+}
+
+func (s *carryoverPagingStore) List(ctx context.Context, opts session.ListOptions) ([]session.SessionSummary, error) {
+	return append([]session.SessionSummary(nil), s.summaries...), nil
+}
+
+func (s *carryoverPagingStore) GetMessagesPageDescending(ctx context.Context, sessionID string, beforeSeq, limit int) ([]session.Message, error) {
+	s.calls = append(s.calls, getMessagesCall{sessionID: sessionID, beforeSeq: beforeSeq, limit: limit})
+	msgs := s.messages[sessionID]
+	page := make([]session.Message, 0, limit)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if beforeSeq > 0 && msgs[i].Sequence >= beforeSeq {
+			continue
+		}
+		page = append(page, msgs[i])
+		if limit > 0 && len(page) >= limit {
+			break
+		}
+	}
+	s.rowsLoaded += len(page)
+	return page, nil
+}
 
 // fakeBotSender is a botSender that records all Send calls for test assertions.
 type fakeBotSender struct {
@@ -1960,6 +1996,59 @@ func TestExtractToolResultTextWithPlaceholders_FallsBackToContentWhenNoParts(t *
 	got := extractToolResultTextWithPlaceholders(result)
 	if got != "command output" {
 		t.Fatalf("expected fallback to Content, got %q", got)
+	}
+}
+
+func TestRestoreHistoryFromDB_LoadsCarryoverTailWithoutReadingWholeSession(t *testing.T) {
+	const (
+		chatID       = int64(42)
+		priorID      = "prior-session"
+		currentID    = "current-session"
+		messageCount = 100
+	)
+
+	store := &carryoverPagingStore{
+		NoopStore: &session.NoopStore{},
+		summaries: []session.SessionSummary{{ID: priorID, MessageCount: messageCount}},
+		messages:  map[string][]session.Message{priorID: make([]session.Message, 0, messageCount)},
+	}
+
+	for i := 0; i < messageCount; i++ {
+		role := llm.RoleUser
+		if i%2 == 1 {
+			role = llm.RoleAssistant
+		}
+		msg := session.NewMessage(priorID, llm.Message{Role: role, Parts: []llm.Part{{Type: llm.PartText, Text: fmt.Sprintf("m%03d", i)}}}, i)
+		store.messages[priorID] = append(store.messages[priorID], *msg)
+	}
+
+	mgr := &telegramSessionMgr{
+		store: store,
+		settings: Settings{
+			TelegramCarryoverChars: 8,
+		},
+	}
+	current := &telegramSession{meta: &session.Session{ID: currentID}}
+
+	mgr.restoreHistoryFromDB(context.Background(), chatID, current)
+
+	if len(current.history) != 2 {
+		t.Fatalf("restored history len = %d, want 2", len(current.history))
+	}
+	if got := extractMessageTextWithPlaceholders(current.history[0]); got != "m098" {
+		t.Fatalf("first restored message = %q, want m098", got)
+	}
+	if got := extractMessageTextWithPlaceholders(current.history[1]); got != "m099" {
+		t.Fatalf("second restored message = %q, want m099", got)
+	}
+	if len(store.calls) == 0 {
+		t.Fatal("expected paginated GetMessages calls")
+	}
+	if store.calls[0].limit <= 0 {
+		t.Fatalf("expected bounded GetMessages limit, got %d", store.calls[0].limit)
+	}
+	if store.rowsLoaded >= messageCount {
+		t.Fatalf("loaded %d rows, want fewer than full transcript (%d)", store.rowsLoaded, messageCount)
 	}
 }
 

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -113,6 +113,43 @@ func (s *LoggingStore) GetLatestVisibleMessageID(ctx context.Context, sessionID 
 	return 0, nil
 }
 
+// GetMessagesPageDescending returns a reverse-ordered page of messages when the
+// wrapped store supports it. Falls back to in-memory paging over GetMessages.
+func (s *LoggingStore) GetMessagesPageDescending(ctx context.Context, sessionID string, beforeSeq, limit int) ([]Message, error) {
+	getter, ok := s.Store.(interface {
+		GetMessagesPageDescending(context.Context, string, int, int) ([]Message, error)
+	})
+	if ok {
+		msgs, err := getter.GetMessagesPageDescending(ctx, sessionID, beforeSeq, limit)
+		if err != nil {
+			s.logOnce("GetMessagesPageDescending", err)
+		}
+		return msgs, err
+	}
+
+	msgs, err := s.Store.GetMessages(ctx, sessionID, 0, 0)
+	if err != nil {
+		s.logOnce("GetMessagesPageDescending", err)
+		return nil, err
+	}
+
+	capHint := len(msgs)
+	if limit > 0 && limit < capHint {
+		capHint = limit
+	}
+	page := make([]Message, 0, capHint)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if beforeSeq > 0 && msgs[i].Sequence >= beforeSeq {
+			continue
+		}
+		page = append(page, msgs[i])
+		if limit > 0 && len(page) >= limit {
+			break
+		}
+	}
+	return page, nil
+}
+
 // UpdateMetrics wraps Store.UpdateMetrics with error logging.
 func (s *LoggingStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
 	err := s.Store.UpdateMetrics(ctx, id, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1941,6 +1941,52 @@ func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fro
 	return messages, rows.Err()
 }
 
+// GetMessagesPageDescending retrieves messages for a session in reverse
+// sequence order. When beforeSeq > 0, only rows with sequence < beforeSeq are
+// returned. Used for reverse tail pagination without loading entire sessions.
+func (s *SQLiteStore) GetMessagesPageDescending(ctx context.Context, sessionID string, beforeSeq, limit int) ([]Message, error) {
+	query := `
+		SELECT id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence
+		FROM messages
+		WHERE session_id = ?`
+	args := []any{sessionID}
+	if beforeSeq > 0 {
+		query += " AND sequence < ?"
+		args = append(args, beforeSeq)
+	}
+	query += " ORDER BY sequence DESC"
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query messages descending: %w", err)
+	}
+	defer rows.Close()
+
+	var messages []Message
+	for rows.Next() {
+		var msg Message
+		var partsJSON string
+		var durationMs sql.NullInt64
+		err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
+			&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence)
+		if err != nil {
+			return nil, fmt.Errorf("scan message: %w", err)
+		}
+		if durationMs.Valid {
+			msg.DurationMs = durationMs.Int64
+		}
+		if err := msg.SetPartsFromJSON(partsJSON); err != nil {
+			return nil, fmt.Errorf("deserialize parts: %w", err)
+		}
+		messages = append(messages, msg)
+	}
+	return messages, rows.Err()
+}
+
 // GetMessageByID retrieves a single message by its global message id.
 func (s *SQLiteStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, error) {
 	row := s.db.QueryRowContext(ctx, `

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -86,6 +86,56 @@ func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreGetMessagesPageDescendingHonorsBeforeSeqAndLimit(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	seed := []Message{
+		*NewMessage(sess.ID, llm.UserText("msg-0"), 0),
+		*NewMessage(sess.ID, llm.AssistantText("msg-1"), 1),
+		*NewMessage(sess.ID, llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartText, Text: "tool-2"}}}, 2),
+		*NewMessage(sess.ID, llm.AssistantText("msg-3"), 3),
+	}
+	for i := range seed {
+		if err := store.AddMessage(ctx, sess.ID, &seed[i]); err != nil {
+			t.Fatalf("AddMessage(%d): %v", i, err)
+		}
+	}
+
+	got, err := store.GetMessagesPageDescending(ctx, sess.ID, 0, 2)
+	if err != nil {
+		t.Fatalf("GetMessagesPageDescending latest: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("latest len = %d, want 2", len(got))
+	}
+	if got[0].Sequence != 3 || got[1].Sequence != 2 {
+		t.Fatalf("latest sequences = [%d %d], want [3 2]", got[0].Sequence, got[1].Sequence)
+	}
+
+	got, err = store.GetMessagesPageDescending(ctx, sess.ID, 2, 2)
+	if err != nil {
+		t.Fatalf("GetMessagesPageDescending before seq: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("before seq len = %d, want 2", len(got))
+	}
+	if got[0].Sequence != 1 || got[1].Sequence != 0 {
+		t.Fatalf("before seq sequences = [%d %d], want [1 0]", got[0].Sequence, got[1].Sequence)
+	}
+}
+
 func TestSQLiteStoreGetLatestVisibleMessageIDSkipsInvisibleTail(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- Reworked Telegram carryover restore to page backward from the end of the prior session instead of calling `GetMessages(..., 0, 0)` and materializing the full transcript.
- Added a reverse-order session-store read path (`GetMessagesPageDescending`) on the SQLite store, plus `LoggingStore` forwarding/fallback.
- Stopped converting all persisted rows to `llm.Message`; carryover restore now only converts the suffix needed to satisfy `TelegramCarryoverChars`.
- Added regression tests for:
  - Telegram carryover restoring the right tail without reading the whole transcript
  - Reverse descending pagination in the SQLite session store

## Why this is high-value

Telegram restart recovery runs on the first message after a bot restart/new session handoff, so this path is user-visible and on the critical recovery path.

Before this change, `restoreHistoryFromDB`:

- loaded the entire prior session from SQLite,
- deserialized every message row,
- converted every row to `llm.Message`,
- and only then trimmed to a small carryover tail.

That means long-running Telegram chats paid full-history read/decode/allocation cost even when only a tiny suffix was kept. The new path reduces work and memory pressure by:

- reading only reverse pages from the tail,
- stopping as soon as the carryover character budget is satisfied,
- and converting only the kept suffix (plus at most one overshoot message).

This directly reduces restart latency, unnecessary allocations, GC pressure, and OOM risk for large Telegram histories.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go internal/session/sqlite.go internal/session/sqlite_test.go internal/session/logger.go`
- `go build ./...`
- `go test ./...`
- Added/ran targeted regression tests covering the new paged carryover path and SQLite descending pagination.
