### PR TITLE
feat(contain): add 'reauth' to seed ChatGPT OAuth into a running workspace

### DIFF
--- a/cmd/contain.go
+++ b/cmd/contain.go
@@ -128,6 +128,26 @@ This is destructive and cannot be undone. You must type YES to continue.`,
 	},
 }
 
+var containReauthCmd = &cobra.Command{
+	Use:   "reauth <name>",
+	Short: "Copy the host's ChatGPT OAuth credentials into a running contain workspace",
+	Long: `Copy the host's chatgpt_oauth.json into a running contain workspace.
+
+This reads ~/.config/term-llm/chatgpt_oauth.json on the host and writes it to
+<workspace>/.config/term-llm/chatgpt_oauth.json inside the container via
+docker compose exec. Useful when 'term-llm contain new' ran before the host
+was signed in, or when you want to share a fresh host login with an existing
+workspace without rebuilding the volume.
+
+The workspace must be running. Long-running processes inside the container
+(serve, jobs) may need a restart to pick up the new credentials.`,
+	Args:              requireContainNameArg,
+	ValidArgsFunction: containWorkspaceNameCompletion,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return contain.Reauth(cmd.Context(), containRunner, args[0], cmd.OutOrStdout(), cmd.ErrOrStderr())
+	},
+}
+
 var containRebuildCmd = &cobra.Command{
 	Use:   "rebuild <name>",
 	Short: "Rebuild workspace images and recreate containers without deleting volumes",
@@ -401,6 +421,25 @@ func printContainNextSteps(cmd *cobra.Command, name string, started bool) {
 	fmt.Fprintf(cmd.OutOrStdout(), "  Run command/recipe: term-llm contain exec %s <cmd-or-recipe> [args...]\n", name)
 	fmt.Fprintf(cmd.OutOrStdout(), "  Force raw command if a recipe collides: term-llm contain exec %s -- <cmd...>\n", name)
 	printContainWebUIInfo(cmd, name)
+	printContainChatGPTReauthHint(cmd, name)
+}
+
+func printContainChatGPTReauthHint(cmd *cobra.Command, name string) {
+	dir, err := contain.ContainerDir(name)
+	if err != nil {
+		return
+	}
+	values, err := readContainEnvFile(filepath.Join(dir, ".env"))
+	if err != nil {
+		return
+	}
+	if strings.TrimSpace(values["TERM_LLM_PROVIDER"]) != "chatgpt" {
+		return
+	}
+	if strings.TrimSpace(values["TERM_LLM_CHATGPT_OAUTH_JSON_B64"]) != "" {
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  ChatGPT auth not seeded; after `term-llm auth login chatgpt` on the host run: term-llm contain reauth %s\n", name)
 }
 
 func hasContainExecRecipe(name, recipeName string) bool {
@@ -477,6 +516,7 @@ func init() {
 	containCmd.AddCommand(containRestartCmd)
 	containCmd.AddCommand(containStopCmd)
 	containCmd.AddCommand(containRmCmd)
+	containCmd.AddCommand(containReauthCmd)
 	containCmd.AddCommand(containRebuildCmd)
 	containCmd.AddCommand(containLsCmd)
 	containCmd.AddCommand(containExecCmd)

--- a/cmd/contain_test.go
+++ b/cmd/contain_test.go
@@ -506,6 +506,24 @@ func TestContainNewAgentPrintsNextStepsLastWithWebUI(t *testing.T) {
 	}
 }
 
+func TestContainNewChatGPTWithoutHostAuthAdvertisesReauth(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	containNewTemplate = "agent"
+	if err := containNewCmd.Flags().Set("template", "agent"); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, err := executeRootForContainTest(t, "contain", "new", "noauthbox", "--no-input", "--set", "provider=chatgpt", "--set", "web_port=8484")
+	if err != nil {
+		t.Fatalf("contain new error = %v stderr=%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "ChatGPT auth not seeded") {
+		t.Fatalf("stdout missing reauth hint: %q", stdout)
+	}
+	if !strings.Contains(stdout, "term-llm contain reauth noauthbox") {
+		t.Fatalf("stdout missing reauth command with substituted workspace name: %q", stdout)
+	}
+}
+
 func TestContainImageSyncCommand(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	containImageSyncForce = false

--- a/internal/contain/docker.go
+++ b/internal/contain/docker.go
@@ -1,6 +1,7 @@
 package contain
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/clipboard"
+	"github.com/samsaffron/term-llm/internal/config"
 )
 
 type Runner interface {
@@ -170,6 +172,64 @@ func Rebuild(ctx context.Context, runner Runner, name string, stdout, stderr io.
 	}
 	upArgs := append(append([]string{}, args...), "up", "-d", "--force-recreate")
 	return runner.Run(ctx, "docker", upArgs, RunOptions{Stdout: stdout, Stderr: stderr, Dir: dir})
+}
+
+// Reauth copies the host's chatgpt_oauth.json into a running contain workspace
+// at <workspace>/.config/term-llm/chatgpt_oauth.json so the container's term-llm
+// picks up an already-valid host login without rebuilding the workspace volume.
+func Reauth(ctx context.Context, runner Runner, name string, stdout, stderr io.Writer) error {
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return fmt.Errorf("locate host config dir: %w", err)
+	}
+	src := filepath.Join(configDir, "chatgpt_oauth.json")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no host chatgpt_oauth.json at %s; run 'term-llm auth login chatgpt' on the host first", src)
+		}
+		return fmt.Errorf("read host chatgpt_oauth.json: %w", err)
+	}
+
+	info, dir, err := composeInfoForCommand(name)
+	if err != nil {
+		return err
+	}
+	workspace := strings.TrimSpace(info.Hints.Workspace)
+	if workspace == "" {
+		workspace = "/home/agent"
+	}
+	targetDir := workspace + "/.config/term-llm"
+	target := targetDir + "/chatgpt_oauth.json"
+
+	args, _, err := ComposeBaseArgs(name)
+	if err != nil {
+		return err
+	}
+	service := info.DefaultService()
+	args = append(args, "exec", "-T")
+	if user := info.DefaultUser(service); user != "" {
+		args = append(args, "--user", user)
+	}
+	script := fmt.Sprintf(`set -e
+mkdir -p %q
+umask 077
+cat > %q
+chmod 600 %q
+`, targetDir, target, target)
+	args = append(args, service, "sh", "-c", script)
+
+	fmt.Fprintf(stderr, "Writing host chatgpt_oauth.json into %s:%s\n", name, target)
+	if err := runner.Run(ctx, "docker", args, RunOptions{
+		Stdin:  bytes.NewReader(data),
+		Stdout: stdout,
+		Stderr: stderr,
+		Dir:    dir,
+	}); err != nil {
+		return fmt.Errorf("write chatgpt_oauth.json into container: %w (is the workspace running? try 'term-llm contain start %s')", err, name)
+	}
+	fmt.Fprintln(stderr, "Done. Restart the workspace if a long-running term-llm process (e.g. serve/jobs) cached the previous auth state: term-llm contain restart "+name)
+	return nil
 }
 
 type ShellOptions struct {

--- a/internal/contain/docker_test.go
+++ b/internal/contain/docker_test.go
@@ -18,6 +18,7 @@ type fakeRunner struct {
 	outputsRun [][]string
 	output     []byte
 	outputs    [][]byte
+	stdin      []byte
 }
 
 func (f *fakeRunner) Run(ctx context.Context, name string, args []string, opts RunOptions) error {
@@ -25,6 +26,13 @@ func (f *fakeRunner) Run(ctx context.Context, name string, args []string, opts R
 	f.args = append([]string(nil), args...)
 	f.runs = append(f.runs, append([]string{name}, args...))
 	f.dir = opts.Dir
+	if opts.Stdin != nil {
+		data, err := io.ReadAll(opts.Stdin)
+		if err != nil {
+			return err
+		}
+		f.stdin = data
+	}
 	return nil
 }
 
@@ -382,5 +390,103 @@ func TestRebuildCommand(t *testing.T) {
 	}
 	if !reflect.DeepEqual(r.runs, want) {
 		t.Fatalf("runs = %#v\nwant %#v", r.runs, want)
+	}
+}
+
+func TestReauthWritesHostOAuthIntoContainer(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempHome)
+	clearConsoleEnvForContainTest(t)
+
+	configDir := filepath.Join(tempHome, "term-llm")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oauthPayload := []byte(`{"access_token":"abc","refresh_token":"xyz"}`)
+	if err := os.WriteFile(filepath.Join(configDir, "chatgpt_oauth.json"), oauthPayload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := writeComposeForDockerTest(t, "stan", `x-term-llm:
+  default_service: app
+  workspace: /home/agent
+services:
+  app:
+    image: alpine
+    labels:
+      org.term-llm.contain.user: agent
+`)
+	compose := filepath.Join(dir, "compose.yaml")
+	base := []string{"compose", "-f", compose, "--project-directory", dir, "-p", "term-llm-contain-stan"}
+
+	r := &fakeRunner{}
+	if err := Reauth(context.Background(), r, "stan", io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	if r.name != "docker" {
+		t.Fatalf("name = %q", r.name)
+	}
+	if len(r.args) < len(base)+5 {
+		t.Fatalf("args too short: %#v", r.args)
+	}
+	for i, want := range base {
+		if r.args[i] != want {
+			t.Fatalf("args[%d] = %q, want %q (full: %#v)", i, r.args[i], want, r.args)
+		}
+	}
+	tail := r.args[len(base):]
+	wantHead := []string{"exec", "-T", "--user", "agent", "app", "sh", "-c"}
+	for i, want := range wantHead {
+		if tail[i] != want {
+			t.Fatalf("tail[%d] = %q, want %q (full tail: %#v)", i, tail[i], want, tail)
+		}
+	}
+	if len(tail) != len(wantHead)+1 {
+		t.Fatalf("expected exactly one script arg after %v, got tail: %#v", wantHead, tail)
+	}
+	script := tail[len(wantHead)]
+	for _, needle := range []string{
+		"/home/agent/.config/term-llm",
+		"/home/agent/.config/term-llm/chatgpt_oauth.json",
+		"mkdir -p",
+		"umask 077",
+		"chmod 600",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("script missing %q:\n%s", needle, script)
+		}
+	}
+	if string(r.stdin) != string(oauthPayload) {
+		t.Fatalf("stdin = %q, want %q", r.stdin, oauthPayload)
+	}
+	if r.dir != dir {
+		t.Fatalf("dir = %q, want %q", r.dir, dir)
+	}
+}
+
+func TestReauthFailsWithoutHostOAuthFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	clearConsoleEnvForContainTest(t)
+	writeComposeForDockerTest(t, "stan", `x-term-llm:
+  default_service: app
+  workspace: /home/agent
+services:
+  app:
+    image: alpine
+    labels:
+      org.term-llm.contain.user: agent
+`)
+
+	r := &fakeRunner{}
+	err := Reauth(context.Background(), r, "stan", io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error when host chatgpt_oauth.json is missing")
+	}
+	if !strings.Contains(err.Error(), "chatgpt_oauth.json") {
+		t.Fatalf("error should mention chatgpt_oauth.json, got: %v", err)
+	}
+	if len(r.runs) != 0 {
+		t.Fatalf("expected no docker invocation when host token missing, got: %#v", r.runs)
 	}
 }


### PR DESCRIPTION
Workspaces created with `term-llm contain new` could end up unauthenticated for ChatGPT even when
the host was signed in (later). The container's web UI reported "not signed in" while `term-llm auth status` on the host
showed a fresh token, and the only recovery was `term-llm contain rm` + recreate — which destroys the
workspace's named volume and all its state.

The common path into this state: signing in to ChatGPT on the host *after* creating the workspace. `contain new`
reads ~/.config/term-llm/chatgpt_oauth.json once at create time and bakes its base64 into the rendered .env
(TERM_LLM_CHATGPT_OAUTH_JSON_B64). If the file doesn't exist yet, the slot is rendered empty. The container then
boots, writes a sentinel that blocks any future hydration from .env, and ends up with no credentials. The host
login that happens later never gets copied in — `contain new` already again. And because the empty-slot render
is silent, the user has no in-CLI signal that this trap was set. The same trap also fires when the user picks a
non-chatgpt provider initially or never signs in on the host at all.

Add `term-llm contain reauth <name>`: reads ~/.config/term-llm/chatgpt_oauth.json on the host and writes it to
<workspace>/.config/term-llm/chatgpt_oauth.json inside the container via `docker compose exec -T --user
<label-user> <service> sh -c 'mkdir -p ...; umask 077; cat > ...; chmod 600 ...'`. The container's term-llm
picks it up on the next call; long-running processes (serve, jobs) need a restart, which the command prints as a
follow-up hint.

Also surface the recovery path at the moment the trap is set: `contain new` now ends its "Next steps:" block
with one line when the rendered .env has TERM_LLM_PROVIDER=chatgpt and TERM_LLM_CHATGPT_OAUTH_JSON_B64= empty:

```
  ChatGPT auth not seeded; after `term-llm auth login chatgpt` on
  the host run: term-llm contain reauth <name>
```