### PR TITLE
fix: spawn_agent drops partial subagent output and child session ID on timeout/error

### DIFF
--- a/internal/tools/spawn_agent.go
+++ b/internal/tools/spawn_agent.go
@@ -311,18 +311,18 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 
 	if err != nil {
 		if llm.IsMaxTurnsExceeded(err) {
-			return llm.TextOutput(t.formatErrorWithDuration(ErrExecutionFailed, fmt.Sprintf("agent '%s' stopped after reaching max turns: %v", a.AgentName, err), duration)), nil
+			return llm.TextOutput(t.formatErrorResultWithDuration(ErrExecutionFailed, fmt.Sprintf("agent '%s' stopped after reaching max turns: %v", a.AgentName, err), duration, runResult)), nil
 		}
 		// Check for specific error types - check the error itself first, then context state
 		if errors.Is(err, context.DeadlineExceeded) ||
 			ctx.Err() == context.DeadlineExceeded || childCtx.Err() == context.DeadlineExceeded {
-			return llm.TextOutput(t.formatErrorWithDuration(ErrTimeout, fmt.Sprintf("agent '%s' timed out after %d seconds", a.AgentName, timeout), duration)), nil
+			return llm.TextOutput(t.formatErrorResultWithDuration(ErrTimeout, fmt.Sprintf("agent '%s' timed out after %d seconds", a.AgentName, timeout), duration, runResult)), nil
 		}
 		if errors.Is(err, context.Canceled) ||
 			ctx.Err() == context.Canceled || childCtx.Err() == context.Canceled {
-			return llm.TextOutput(t.formatErrorWithDuration(ErrExecutionFailed, "agent execution cancelled", duration)), nil
+			return llm.TextOutput(t.formatErrorResultWithDuration(ErrExecutionFailed, "agent execution cancelled", duration, runResult)), nil
 		}
-		return llm.TextOutput(t.formatErrorWithDuration(ErrExecutionFailed, fmt.Sprintf("agent execution failed: %v", err), duration)), nil
+		return llm.TextOutput(t.formatErrorResultWithDuration(ErrExecutionFailed, fmt.Sprintf("agent execution failed: %v", err), duration, runResult)), nil
 	}
 
 	// Return success result
@@ -365,10 +365,17 @@ func (t *SpawnAgentTool) formatError(errType ToolErrorType, message string) stri
 
 // formatErrorWithDuration formats an error result with duration.
 func (t *SpawnAgentTool) formatErrorWithDuration(errType ToolErrorType, message string, durationMs int64) string {
+	return t.formatErrorResultWithDuration(errType, message, durationMs, SpawnAgentRunResult{})
+}
+
+// formatErrorResultWithDuration formats an error result with duration and any partial subagent result.
+func (t *SpawnAgentTool) formatErrorResultWithDuration(errType ToolErrorType, message string, durationMs int64, runResult SpawnAgentRunResult) string {
 	result := SpawnAgentResult{
-		Error:    message,
-		Type:     string(errType),
-		Duration: durationMs,
+		Error:     message,
+		Type:      string(errType),
+		Duration:  durationMs,
+		Output:    runResult.Output,
+		SessionID: runResult.SessionID,
 	}
 	data, _ := json.Marshal(result)
 	return string(data)

--- a/internal/tools/spawn_agent_test.go
+++ b/internal/tools/spawn_agent_test.go
@@ -681,6 +681,66 @@ func TestSpawnAgentTool_RunnerError(t *testing.T) {
 	// Duration is included (may be 0 for very fast operations, which is valid)
 }
 
+func TestSpawnAgentTool_RunnerErrorPreservesPartialResult(t *testing.T) {
+	config := DefaultSpawnConfig()
+	tool := NewSpawnAgentTool(config, 0)
+
+	runner := newMockRunner().
+		SetOutput("partial analysis").
+		SetSessionID("child-session-123").
+		SetError(errors.New("agent failed to initialize"))
+	tool.SetRunner(runner)
+
+	ctx := context.Background()
+	args := makeSpawnArgs("test-agent", "do something", 0)
+
+	result, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := parseResult(t, result.Content)
+	if r.Type != string(ErrExecutionFailed) {
+		t.Fatalf("expected error type %s, got %s", ErrExecutionFailed, r.Type)
+	}
+	if r.Output != "partial analysis" {
+		t.Errorf("expected partial output to be preserved, got %q", r.Output)
+	}
+	if r.SessionID != "child-session-123" {
+		t.Errorf("expected session ID to be preserved, got %q", r.SessionID)
+	}
+}
+
+func TestSpawnAgentTool_TimeoutPreservesPartialResult(t *testing.T) {
+	config := DefaultSpawnConfig()
+	tool := NewSpawnAgentTool(config, 0)
+
+	runner := newMockRunner().
+		SetOutput("partial timeout output").
+		SetSessionID("child-session-timeout").
+		SetError(context.DeadlineExceeded)
+	tool.SetRunner(runner)
+
+	ctx := context.Background()
+	args := makeSpawnArgs("test-agent", "do something", 10)
+
+	result, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	r := parseResult(t, result.Content)
+	if r.Type != string(ErrTimeout) {
+		t.Fatalf("expected error type %s, got %s", ErrTimeout, r.Type)
+	}
+	if r.Output != "partial timeout output" {
+		t.Errorf("expected partial output to be preserved, got %q", r.Output)
+	}
+	if r.SessionID != "child-session-timeout" {
+		t.Errorf("expected session ID to be preserved, got %q", r.SessionID)
+	}
+}
+
 func TestSpawnAgentTool_MaxTurnsErrorIsExplicit(t *testing.T) {
 	config := DefaultSpawnConfig()
 	tool := NewSpawnAgentTool(config, 0)


### PR DESCRIPTION
## What changed

- Updated `SpawnAgentTool.Execute` to preserve `runResult.Output` and `runResult.SessionID` when the subagent runner returns an error.
- Added a small helper so timeout, cancellation, max-turns, and generic execution-failure responses keep the existing structured error fields while also carrying any partial subagent result.
- Added tests covering both generic failures and timeout-classified failures with partial output/session IDs.

## Why this is high-value

`cmd/spawn_runner.go` already returns partial subagent output plus the child session ID on failure. Before this change, `spawn_agent` threw that away in every error branch and returned only synthesized error JSON. That meant a timed-out or failing delegated investigation could do useful work, create a child session, and still lose all user-visible output and the session link. This fix prevents that data loss without changing the success path or broadening behavior elsewhere.

## Validation

- `gofmt -w internal/tools/spawn_agent.go internal/tools/spawn_agent_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
