### PR TITLE
fix: grep raw-output safety cap before full-line allocation

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -176,6 +176,67 @@ func (l ripgrepCaptureLimits) normalize() ripgrepCaptureLimits {
 	return l
 }
 
+func captureRipgrepOutput(stdout io.Reader, kill func() error, limits ripgrepCaptureLimits) ([]byte, bool, error) {
+	limits = limits.normalize()
+
+	var out bytes.Buffer
+	var lineBuf bytes.Buffer
+	reader := bufio.NewReader(stdout)
+	lineCount := 0
+	truncated := false
+
+	flushLine := func() {
+		lineCount++
+		if lineCount > limits.maxOutputLines || out.Len()+lineBuf.Len() > limits.maxBufferedBytes {
+			truncated = true
+			if kill != nil {
+				_ = kill()
+			}
+			lineBuf.Reset()
+			return
+		}
+		_, _ = out.Write(lineBuf.Bytes())
+		lineBuf.Reset()
+	}
+
+	for {
+		fragment, readErr := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			if out.Len()+lineBuf.Len()+len(fragment) > limits.maxBufferedBytes {
+				truncated = true
+				if kill != nil {
+					_ = kill()
+				}
+				break
+			}
+			_, _ = lineBuf.Write(fragment)
+		}
+
+		if readErr != nil {
+			if errors.Is(readErr, bufio.ErrBufferFull) {
+				continue
+			}
+			if errors.Is(readErr, io.EOF) {
+				if lineBuf.Len() > 0 {
+					flushLine()
+				}
+				break
+			}
+			if kill != nil {
+				_ = kill()
+			}
+			return nil, false, readErr
+		}
+
+		flushLine()
+		if truncated {
+			break
+		}
+	}
+
+	return out.Bytes(), truncated, nil
+}
+
 func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits) ([]byte, bool, error) {
 	limits = limits.normalize()
 	cmd := exec.CommandContext(ctx, "rg", args...)
@@ -198,32 +259,11 @@ func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits)
 		stderrCh <- data
 	}()
 
-	var out bytes.Buffer
-	reader := bufio.NewReader(stdout)
-	lineCount := 0
-	truncated := false
-
-	for {
-		line, readErr := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			lineCount++
-			if lineCount > limits.maxOutputLines || out.Len()+len(line) > limits.maxBufferedBytes {
-				truncated = true
-				_ = cmd.Process.Kill()
-				break
-			}
-			out.Write(line)
-		}
-
-		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
-				break
-			}
-			_ = cmd.Process.Kill()
-			<-stderrCh
-			_ = cmd.Wait()
-			return nil, false, readErr
-		}
+	out, truncated, err := captureRipgrepOutput(stdout, cmd.Process.Kill, limits)
+	if err != nil {
+		<-stderrCh
+		_ = cmd.Wait()
+		return nil, false, err
 	}
 
 	waitErr := cmd.Wait()
@@ -231,7 +271,7 @@ func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits)
 
 	if waitErr != nil {
 		if truncated {
-			return out.Bytes(), true, nil
+			return out, true, nil
 		}
 		if ctx.Err() != nil {
 			return nil, false, ctx.Err()
@@ -246,7 +286,7 @@ func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits)
 		return nil, false, waitErr
 	}
 
-	return out.Bytes(), truncated, nil
+	return out, truncated, nil
 }
 
 // executeRipgrep runs ripgrep and returns matches.

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+type countingReader struct {
+	reader    io.Reader
+	bytesRead int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += n
+	return n, err
+}
 
 func TestGrepTool_UsesFilePath(t *testing.T) {
 	dir := t.TempDir()
@@ -142,6 +154,52 @@ func TestBuildRipgrepArgs_FilesWithMatchesOmitsJSONFlags(t *testing.T) {
 		if strings.Contains(joined, unwanted) {
 			t.Fatalf("did not expect %q in args: %s", unwanted, joined)
 		}
+	}
+}
+
+func TestCaptureRipgrepOutput_StopsReadingOversizedLineAtByteCap(t *testing.T) {
+	const (
+		maxBufferedBytes = 1024
+		oversizedLine    = 256 * 1024
+	)
+
+	reader := &countingReader{reader: strings.NewReader(strings.Repeat("x", oversizedLine) + "\n")}
+	killed := false
+
+	output, truncated, err := captureRipgrepOutput(reader, func() error {
+		killed = true
+		return nil
+	}, ripgrepCaptureLimits{maxOutputLines: 100, maxBufferedBytes: maxBufferedBytes})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !truncated {
+		t.Fatal("expected capture to truncate oversized line")
+	}
+	if !killed {
+		t.Fatal("expected capture to request process kill on truncation")
+	}
+	if len(output) != 0 {
+		t.Fatalf("expected oversized partial line to be discarded, got %d buffered bytes", len(output))
+	}
+	if reader.bytesRead > maxBufferedBytes+4096 {
+		t.Fatalf("expected bounded reading near the cap, read %d bytes", reader.bytesRead)
+	}
+}
+
+func TestCaptureRipgrepOutput_PreservesCompletedLinesBeforeOversizedLine(t *testing.T) {
+	const maxBufferedBytes = 1024
+
+	input := "{\"type\":\"begin\"}\n" + strings.Repeat("x", 8*1024) + "\n"
+	output, truncated, err := captureRipgrepOutput(strings.NewReader(input), nil, ripgrepCaptureLimits{maxOutputLines: 100, maxBufferedBytes: maxBufferedBytes})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !truncated {
+		t.Fatal("expected capture to truncate oversized second line")
+	}
+	if got := string(output); got != "{\"type\":\"begin\"}\n" {
+		t.Fatalf("expected only complete lines before truncation, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- replaced `runRipgrep`'s raw stdout capture loop with a chunked `captureRipgrepOutput` helper built on `bufio.Reader.ReadSlice('\n')`
- enforce `rgMaxBufferedBytes` before assembling an entire ripgrep line in memory
- keep only complete lines in the buffered output so truncated captures still hand valid line-delimited data to the existing parser
- added tests covering:
  - stopping reads near the byte cap for a single oversized line
  - preserving completed lines while dropping the oversized partial line that triggered truncation

## Why this is high-value

`grep` is on a hot path for code review and repository exploration. The previous implementation used `ReadBytes('\n')`, which allocates the full line before checking the 8 MB cap. With ripgrep `--json`, one generated/minified source line can become one enormous JSON record, so a single match could force large transient allocations and extra read latency exactly where the code is supposed to stay bounded and responsive.

This change makes the cap real:

- memory is bounded by `out + current line fragment buffer`, instead of an unbounded whole-line allocation
- oversized lines are cut off after roughly one reader-buffer worth of extra input, instead of being fully read first
- truncated output still preserves prior complete records, so behavior stays aligned with the existing parser and formatting pipeline

## Validation

- `gofmt -w internal/tools/grep.go internal/tools/grep_test.go`
- `go build ./...`
- `go test ./internal/tools`
- `go test ./...`
- `git diff --check`
