### PR TITLE
fix: config set rewrites config.yaml non-atomically and can corrupt the main config on interruption

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1019,6 +1019,13 @@ func configSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get config path: %w", err)
 	}
 
+	writePerm := os.FileMode(0o644)
+	if info, err := os.Stat(configPath); err == nil {
+		writePerm = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat config: %w", err)
+	}
+
 	// Ensure config directory exists
 	configDir := filepath.Dir(configPath)
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -1061,7 +1068,7 @@ func configSet(cmd *cobra.Command, args []string) error {
 	}
 	encoder.Close()
 
-	if err := os.WriteFile(configPath, buf.Bytes(), 0644); err != nil {
+	if err := config.WriteFileAtomically(configPath, buf.Bytes(), writePerm); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestConfigSet_AtomicWriteFailureLeavesExistingConfigUntouched(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions behave differently on Windows")
+	}
+
+	xdgConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	configDir := filepath.Join(xdgConfigHome, "term-llm")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	original := "default_provider: anthropic\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write original config: %v", err)
+	}
+
+	if err := os.Chmod(configDir, 0o555); err != nil {
+		t.Fatalf("chmod config dir read-only: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(configDir, 0o755); err != nil {
+			t.Fatalf("restore config dir permissions: %v", err)
+		}
+	}()
+
+	err := configSet(nil, []string{"default_provider", "openai"})
+	if err == nil {
+		t.Fatal("expected configSet to fail when atomic temp-file creation is blocked")
+	}
+	if !strings.Contains(err.Error(), "create temp file") {
+		t.Fatalf("error = %v, want create temp file", err)
+	}
+
+	got, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read original config: %v", readErr)
+	}
+	if string(got) != original {
+		t.Fatalf("config changed on failed write: got %q want %q", got, original)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -943,6 +943,11 @@ func rewriteProviderEnvSections(path string, snapshot map[string]map[string]stri
 	return writeFileAtomically(path, buf.Bytes(), 0o600)
 }
 
+// WriteFileAtomically replaces path with data via a temp file, fsync, and rename.
+func WriteFileAtomically(path string, data []byte, perm os.FileMode) error {
+	return writeFileAtomically(path, data, perm)
+}
+
 func writeFileAtomically(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)


### PR DESCRIPTION
## What changed

- Replaced `term-llm config set`'s direct `os.WriteFile` rewrite with the existing temp-file + `fsync` + `rename` atomic write path from `internal/config`.
- Preserved the existing config file's mode when replacing an existing `config.yaml`, while still defaulting to `0644` for first-time creation.
- Added a regression test that makes atomic temp-file creation fail and verifies the existing `config.yaml` stays unchanged.

## Why this is high-value

`config.yaml` is shared persisted state for the CLI, serve mode, jobs, Telegram, and provider credentials. Before this change, `config set` truncated and rewrote the file in place, so an interruption during the write could leave the main config empty or partially written and break future startups until the file was repaired manually.

This change prevents that failure mode by only swapping the new file into place after the full contents have been written and synced successfully.

## Validation

- `gofmt -w cmd/config.go cmd/config_test.go internal/config/config.go`
- `go build ./...`
- `go test ./...`
- Added `TestConfigSet_AtomicWriteFailureLeavesExistingConfigUntouched`
- `git diff --check`
