### PR TITLE
fix: cancel standalone web interrupts on fallback

### DIFF
--- a/internal/llm/classify.go
+++ b/internal/llm/classify.go
@@ -90,6 +90,50 @@ func classifyInterruptHeuristic(msg string) (InterruptAction, bool) {
 	return InterruptInterject, false
 }
 
+func classifyInterruptFallback(msg string, activity InterruptActivity) InterruptAction {
+	normalized := strings.ToLower(strings.TrimSpace(msg))
+	if normalized == "" {
+		return InterruptInterject
+	}
+
+	// If the user is obviously amending the current work, keep the current run
+	// alive and inject the note at the next legal boundary.
+	steeringPrefixes := []string{
+		"also", "and ", "plus", "include", "add ", "use ", "make sure", "don't", "dont",
+		"instead", "not ", "actually,", "correction", "wait", "one more", "as well", "what about",
+	}
+	for _, prefix := range steeringPrefixes {
+		if normalized == strings.TrimSpace(prefix) || strings.HasPrefix(normalized, prefix) {
+			return InterruptInterject
+		}
+	}
+
+	active := strings.TrimSpace(activity.ActiveTool) != "" || strings.TrimSpace(activity.CurrentTask) != "" || len(activity.ToolsRun) > 0 || activity.ProseLen > 0
+	if !active {
+		return InterruptInterject
+	}
+
+	// Short standalone prompts sent while the agent is busy are usually the user
+	// replacing the task, not carefully steering the old one. This is especially
+	// important in the web UI where the send button becomes "Interject" during a
+	// stream; defaulting every ambiguous message to interject makes sessions go
+	// off chasing stale work.
+	standalonePrefixes := []string{
+		"who", "what", "when", "where", "why", "how", "can ", "could ", "please ",
+		"make ", "find ", "show ", "tell ", "say ", "list ", "compare ", "write ", "create ",
+	}
+	for _, prefix := range standalonePrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return InterruptCancel
+		}
+	}
+	if strings.Contains(normalized, " vs ") || strings.Contains(normalized, " versus ") || strings.HasSuffix(normalized, "?") {
+		return InterruptCancel
+	}
+
+	return InterruptInterject
+}
+
 // ClassifyInterrupt decides how to handle a new user message while a stream is active.
 // It uses instant heuristics first and then an optional fast LLM call.
 func ClassifyInterrupt(ctx context.Context, fastProvider Provider, msg string, activity InterruptActivity) InterruptAction {
@@ -97,7 +141,7 @@ func ClassifyInterrupt(ctx context.Context, fastProvider Provider, msg string, a
 		return action
 	}
 	if fastProvider == nil {
-		return InterruptInterject
+		return classifyInterruptFallback(msg, activity)
 	}
 
 	toolsRun := "none"
@@ -134,7 +178,7 @@ Reply with exactly one word. If unsure, reply interject.`,
 
 	decision, err := Classify(ctx, fastProvider, prompt, 3*time.Second)
 	if err != nil {
-		return InterruptInterject
+		return classifyInterruptFallback(msg, activity)
 	}
 
 	switch strings.TrimSpace(decision) {

--- a/internal/llm/classify_test.go
+++ b/internal/llm/classify_test.go
@@ -56,3 +56,20 @@ func TestClassifyInterruptFallbackOnError(t *testing.T) {
 		t.Fatalf("ClassifyInterrupt fallback = %v, want InterruptInterject", got)
 	}
 }
+
+func TestClassifyInterruptFallbackTreatsStandalonePromptAsCancel(t *testing.T) {
+	activity := InterruptActivity{CurrentTask: "finding Okinawa photos", ProseLen: 240, ToolsRun: []string{"web_search"}}
+	got := ClassifyInterrupt(context.Background(), nil, "kanazawa vs kyoto", activity)
+	if got != InterruptCancel {
+		t.Fatalf("ClassifyInterrupt fallback = %v, want InterruptCancel for standalone replacement prompt", got)
+	}
+}
+
+func TestClassifyInterruptFallbackKeepsSteeringAsInterjection(t *testing.T) {
+	activity := InterruptActivity{CurrentTask: "finding Okinawa photos", ProseLen: 240, ToolsRun: []string{"web_search"}}
+	for _, msg := range []string{"also include quiet islands", "what about non beach places", "10 non beach places as well"} {
+		if got := ClassifyInterrupt(context.Background(), nil, msg, activity); got != InterruptInterject {
+			t.Fatalf("ClassifyInterrupt(%q) = %v, want InterruptInterject", msg, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fix interrupt classification fallback so standalone replacement prompts sent while a web stream is active cancel the stale run instead of being injected into it.

Tiny repros I used:

- Session #2378 had the bad shape: Sam asked `kanazawa vs kyoto`, but the active run kept chasing the old Okinawa/Places thread.
- Live claude-bin recall chain works when continuation is clean: `231` → `234` → `8733, what previous?` returned `231, 234`.
- Added targeted tests for the failure mode: `kanazawa vs kyoto` during an active Okinawa task now classifies as `cancel`, while steering prompts like `also include quiet islands`, `what about non beach places`, and `10 non beach places as well` remain `interject`.

## Why

The web UI sends messages during an active stream through the interrupt endpoint. If the fast classifier is unavailable or times out, the old fallback always returned `interject`. That is safe for corrections, but terrible for standalone new prompts: they get queued into the stale run and the assistant keeps answering the old task. Technically working. Socially deranged.

## Verification

```text
go test ./internal/llm -run 'TestClassifyInterrupt|TestClassify$|TestClassifyTimeout'
go test ./cmd ./internal/llm
go build ./...
```
