### PR TITLE
feat(contain): auto-select default web port and reconcile config on start

### DIFF
--- a/internal/contain/docker.go
+++ b/internal/contain/docker.go
@@ -85,14 +85,18 @@ func Start(ctx context.Context, runner Runner, name string, stdout, stderr io.Wr
 	if err := ensureComposeDefinition(name); err != nil {
 		return err
 	}
-	if hasContainers, err := composeHasContainers(ctx, runner, args, dir); err != nil {
+	hasContainers, err := composeHasContainers(ctx, runner, args, dir)
+	if err != nil {
 		return err
-	} else if hasContainers {
-		startArgs := append(append([]string{}, args...), "start")
-		return runner.Run(ctx, "docker", startArgs, RunOptions{Stdout: stdout, Stderr: stderr, Dir: dir})
 	}
-	if err := syncManagedImagesForWorkspace(name); err != nil {
-		return err
+	// Only build/sync managed images when creating containers from scratch; an
+	// existing workspace already has its image. `up -d` is used in both cases so
+	// that config drift (e.g. a changed WEB_PORT in .env) is reconciled — plain
+	// `compose start` would boot the existing container with its stale settings.
+	if !hasContainers {
+		if err := syncManagedImagesForWorkspace(name); err != nil {
+			return err
+		}
 	}
 	upArgs := append(append([]string{}, args...), "up", "-d")
 	return runner.Run(ctx, "docker", upArgs, RunOptions{Stdout: stdout, Stderr: stderr, Dir: dir})

--- a/internal/contain/docker_test.go
+++ b/internal/contain/docker_test.go
@@ -267,11 +267,14 @@ services:
 	}
 }
 
-func TestStartUsesComposeStartWhenContainersExist(t *testing.T) {
+func TestStartReconcilesExistingContainers(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	dir := writeComposeForDockerTest(t, "box", "")
 	compose := filepath.Join(dir, "compose.yaml")
 	base := []string{"docker", "compose", "-f", compose, "--project-directory", dir, "-p", "term-llm-contain-box"}
+	// A non-empty `ps --all -q` output means a container already exists; Start
+	// must still reconcile config drift (e.g. a changed WEB_PORT in .env) via
+	// `up -d` rather than booting the stale container as-is with `compose start`.
 	r := &fakeRunner{output: []byte("abc123\n")}
 	if err := Start(context.Background(), r, "box", io.Discard, io.Discard); err != nil {
 		t.Fatal(err)
@@ -280,7 +283,7 @@ func TestStartUsesComposeStartWhenContainersExist(t *testing.T) {
 	if !reflect.DeepEqual(r.outputsRun, wantOutputs) {
 		t.Fatalf("outputs = %#v\nwant %#v", r.outputsRun, wantOutputs)
 	}
-	wantRuns := [][]string{append(append([]string{}, base...), "start")}
+	wantRuns := [][]string{append(append([]string{}, base...), "up", "-d")}
 	if !reflect.DeepEqual(r.runs, wantRuns) {
 		t.Fatalf("runs = %#v\nwant %#v", r.runs, wantRuns)
 	}

--- a/internal/contain/template_descriptor.go
+++ b/internal/contain/template_descriptor.go
@@ -145,6 +145,9 @@ func resolveGeneratedDefault(m map[string]any) (string, error) {
 	if m["generate"] == "agent_distro" {
 		return defaultAgentDistro(), nil
 	}
+	if m["generate"] == "web_port" {
+		return defaultWebPort(), nil
+	}
 	if m["generate"] == "hex" {
 		bytesN := 24
 		if b, ok := m["bytes"]; ok {

--- a/internal/contain/template_test.go
+++ b/internal/contain/template_test.go
@@ -168,6 +168,12 @@ func TestCreateWorkspaceBuiltinAgentDefaultDistro(t *testing.T) {
 	if !strings.Contains(envText, "AGENT_DISTRO="+wantDistro) {
 		t.Fatalf("default env missing AGENT_DISTRO=%s:\n%s", wantDistro, envText)
 	}
+	// web_port has no provided value, so it must resolve to a real auto-selected
+	// port (>= webPortBase) rather than an unrendered placeholder.
+	port := envWebPortValue(t, envText)
+	if port < webPortBase || port >= webPortBase+webPortScanLimit {
+		t.Fatalf("auto WEB_PORT = %d, want in [%d, %d):\n%s", port, webPortBase, webPortBase+webPortScanLimit, envText)
+	}
 	if wantDistro == "fedora" && (!strings.Contains(envText, "AGENT_PLATFORM="+nativeLinuxPlatform()) || !strings.Contains(envText, "AGENT_BASE_IMAGE=fedora:43")) {
 		t.Fatalf("fedora default env not rendered correctly:\n%s", envText)
 	}

--- a/internal/contain/templates/agent/.template.yaml
+++ b/internal/contain/templates/agent/.template.yaml
@@ -5,7 +5,8 @@ prompts:
   - id: web_port
     label: "Web UI port"
     type: string
-    default: "8081"
+    default:
+      generate: web_port
   - id: web_token
     label: "Web UI bearer token"
     type: secret

--- a/internal/contain/webport.go
+++ b/internal/contain/webport.go
@@ -1,0 +1,102 @@
+package contain
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// webPortBase is the first port term-llm tries to assign to a workspace Web UI.
+const webPortBase = 8081
+
+// webPortScanLimit caps how many candidate ports we probe before giving up and
+// falling back to the base port.
+const webPortScanLimit = 200
+
+// defaultWebPort returns the lowest free Web UI port at or above webPortBase,
+// skipping ports already claimed by existing workspaces and ports that cannot
+// currently be bound on the host. It is best-effort: on any failure it returns
+// the base port so creation can still proceed.
+func defaultWebPort() string {
+	used, err := usedWorkspaceWebPorts()
+	if err != nil {
+		used = map[int]bool{}
+	}
+	return nextWebPort(webPortBase, used, hostPortAvailable)
+}
+
+// nextWebPort walks upward from base and returns the first port that is neither
+// claimed by an existing workspace nor reported unavailable on the host. If no
+// free port is found within webPortScanLimit candidates it returns base.
+func nextWebPort(base int, used map[int]bool, available func(int) bool) string {
+	for port := base; port < base+webPortScanLimit; port++ {
+		if used[port] {
+			continue
+		}
+		if available != nil && !available(port) {
+			continue
+		}
+		return strconv.Itoa(port)
+	}
+	return strconv.Itoa(base)
+}
+
+// usedWorkspaceWebPorts scans existing workspace .env files for WEB_PORT values
+// so newly created workspaces avoid colliding with ones already configured
+// (even when those workspaces are not currently running).
+func usedWorkspaceWebPorts() (map[int]bool, error) {
+	root, err := ContainersRoot()
+	if err != nil {
+		return nil, err
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", ".env"))
+	if err != nil {
+		return nil, err
+	}
+	used := map[int]bool{}
+	for _, envPath := range matches {
+		if port, ok := readEnvWebPort(envPath); ok {
+			used[port] = true
+		}
+	}
+	return used, nil
+}
+
+// readEnvWebPort extracts the WEB_PORT value from a workspace .env file.
+func readEnvWebPort(path string) (int, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "WEB_PORT=") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, "WEB_PORT="))
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			return 0, false
+		}
+		return port, true
+	}
+	return 0, false
+}
+
+// hostPortAvailable reports whether the given TCP port can currently be bound on
+// all interfaces, mirroring how Docker publishes the Web UI port.
+func hostPortAvailable(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}

--- a/internal/contain/webport_test.go
+++ b/internal/contain/webport_test.go
@@ -1,0 +1,108 @@
+package contain
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// envWebPortValue extracts the integer WEB_PORT value from rendered .env text.
+func envWebPortValue(t *testing.T, envText string) int {
+	t.Helper()
+	for _, line := range strings.Split(envText, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "WEB_PORT=") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, "WEB_PORT="))
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			t.Fatalf("WEB_PORT value %q is not numeric: %v", value, err)
+		}
+		return port
+	}
+	t.Fatalf("no WEB_PORT line in env:\n%s", envText)
+	return 0
+}
+
+func TestNextWebPortSkipsUsedAndUnavailable(t *testing.T) {
+	cases := []struct {
+		name      string
+		used      map[int]bool
+		available func(int) bool
+		want      string
+	}{
+		{
+			name:      "base free",
+			used:      map[int]bool{},
+			available: func(int) bool { return true },
+			want:      "8081",
+		},
+		{
+			name:      "skips workspace-claimed port",
+			used:      map[int]bool{8081: true},
+			available: func(int) bool { return true },
+			want:      "8082",
+		},
+		{
+			name:      "skips port in use on host",
+			used:      map[int]bool{},
+			available: func(p int) bool { return p != 8081 },
+			want:      "8082",
+		},
+		{
+			name:      "skips multiple consecutive collisions",
+			used:      map[int]bool{8081: true, 8083: true},
+			available: func(p int) bool { return p != 8082 },
+			want:      "8084",
+		},
+		{
+			name:      "falls back to base when nothing free",
+			used:      map[int]bool{},
+			available: func(int) bool { return false },
+			want:      "8081",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextWebPort(webPortBase, tc.used, tc.available); got != tc.want {
+				t.Fatalf("nextWebPort = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUsedWorkspaceWebPortsScansEnvFiles(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	root, err := ContainersRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWorkspaceEnv(t, root, "alpha", "WEB_PORT=8081\nWEB_TOKEN=abc\n")
+	writeWorkspaceEnv(t, root, "beta", "WEB_TOKEN=def\nWEB_PORT=8090\n")
+	writeWorkspaceEnv(t, root, "gamma", "WEB_TOKEN=ghi\n") // no port
+
+	used, err := usedWorkspaceWebPorts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !used[8081] || !used[8090] {
+		t.Fatalf("used = %v, want 8081 and 8090 present", used)
+	}
+	if len(used) != 2 {
+		t.Fatalf("used = %v, want exactly 2 entries", used)
+	}
+}
+
+func writeWorkspaceEnv(t *testing.T, root, name, contents string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
`contain new` previously defaulted the Web UI port prompt to a hard-coded 8081, so every workspace collided unless the port was typed manually. Add a `generate: web_port` template default that scans existing workspace .env files and probes host port availability, returning the lowest free port at or above 8081. Resolution runs before the workspace directory is created, so it never collides with itself.

The port value was also silently ignored on restart: Start() ran `docker compose start` when a container already existed, which boots the container with its baked-in config and never applies drift from an edited .env/compose.yaml. A workspace whose port was changed kept its stale binding. Switch Start() to `docker compose up -d` in both the create and existing- container paths so config drift is reconciled; managed image build/sync still only runs when creating from scratch. `up -d` is idempotent on an unchanged running container (verified: no recreate, no downtime), and recreates only on genuine drift, where volume-backed state (/home/agent) is preserved.