### PR TITLE
fix: Client.Stop does not terminate stdio MCP server processes, so direct callers leak subprocesses

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -32,6 +33,7 @@ type Client struct {
 	session         *mcp.ClientSession
 	tools           []ToolSpec
 	samplingHandler *SamplingHandler
+	processCancel   context.CancelFunc
 	mu              sync.RWMutex
 	running         bool
 }
@@ -96,6 +98,7 @@ func (c *Client) start(ctx, processCtx context.Context) error {
 
 	session, err := c.client.Connect(ctx, transport, nil)
 	if err != nil {
+		c.processCancel = nil
 		return fmt.Errorf("connect to MCP server %s: %w", c.name, err)
 	}
 	c.session = session
@@ -104,6 +107,7 @@ func (c *Client) start(ctx, processCtx context.Context) error {
 	if err := c.refreshTools(ctx); err != nil {
 		c.session.Close()
 		c.session = nil
+		c.processCancel = nil
 		return fmt.Errorf("list tools from %s: %w", c.name, err)
 	}
 
@@ -113,7 +117,10 @@ func (c *Client) start(ctx, processCtx context.Context) error {
 
 // createStdioTransport creates a stdio transport for command-based servers.
 func (c *Client) createStdioTransport(ctx context.Context) mcp.Transport {
-	cmd := exec.CommandContext(ctx, c.config.Command, c.config.Args...)
+	processCtx, processCancel := context.WithCancel(ctx)
+	c.processCancel = processCancel
+
+	cmd := exec.CommandContext(processCtx, c.config.Command, c.config.Args...)
 	cmd.WaitDelay = mcpCommandWaitDelay
 	procutil.ConfigureCommandProcessGroup(cmd)
 	if len(c.config.Env) > 0 {
@@ -164,20 +171,43 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // Stop closes the MCP server connection.
 func (c *Client) Stop() error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if !c.running {
+		c.mu.Unlock()
 		return nil
 	}
 
-	var err error
-	if c.session != nil {
-		err = c.session.Close()
-		c.session = nil
-	}
+	session := c.session
+	processCancel := c.processCancel
+	c.session = nil
+	c.processCancel = nil
 	c.running = false
 	c.tools = nil
+	c.mu.Unlock()
+
+	if processCancel != nil {
+		processCancel()
+	}
+
+	var err error
+	if session != nil {
+		err = session.Close()
+	}
+
+	if processCancel != nil && isExpectedStdioStopError(err) {
+		return nil
+	}
 	return err
+}
+
+func isExpectedStdioStopError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
 }
 
 // IsRunning returns whether the client is connected.

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -2,8 +2,13 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -148,4 +153,117 @@ func TestCreateStdioTransport_ConfiguresProcessGroupCancellation(t *testing.T) {
 	if ct.Command.WaitDelay != time.Second {
 		t.Fatalf("WaitDelay = %v, want %v", ct.Command.WaitDelay, time.Second)
 	}
+	if client.processCancel == nil {
+		t.Fatalf("expected client to retain a stdio process cancel func")
+	}
+}
+
+func TestClientStop_CancelsStdioProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	client := NewClient("greeter", ServerConfig{
+		Command: "sh",
+		Args: []string{
+			"-c",
+			"sleep 30 >/dev/null 2>&1 & echo $! > \"$1\"; exec \"$2\"",
+			"sh",
+			pidFile,
+			os.Args[0],
+		},
+		Env: map[string]string{
+			runMCPManagerTestServerEnv: "1",
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	pid := waitForRecordedPID(t, pidFile)
+	defer killProcessIfRunning(pid)
+
+	if err := client.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	waitForMCPProcessExit(t, pid)
+}
+
+func waitForRecordedPID(t *testing.T, path string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pidText := strings.TrimSpace(string(data))
+			if pidText != "" {
+				pid, convErr := strconv.Atoi(pidText)
+				if convErr != nil {
+					t.Fatalf("parse pid %q: %v", pidText, convErr)
+				}
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for pid file %s", path)
+	return 0
+}
+
+func waitForMCPProcessExit(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mcpProcessHasExited(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for process %d to exit", pid)
+}
+
+func killProcessIfRunning(pid int) {
+	if pid <= 0 || mcpProcessHasExited(pid) {
+		return
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}
+
+func mcpProcessHasExited(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err != nil {
+		return errors.Is(err, syscall.ESRCH)
+	}
+	if runtime.GOOS == "linux" {
+		state, ok := linuxMCPProcState(pid)
+		return ok && state == 'Z'
+	}
+	return false
+}
+
+func linuxMCPProcState(pid int) (byte, bool) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return 0, false
+	}
+	return mcpProcStatState(data)
+}
+
+func mcpProcStatState(data []byte) (byte, bool) {
+	stat := string(data)
+	end := strings.LastIndex(stat, ")")
+	if end == -1 || end+2 >= len(stat) {
+		return 0, false
+	}
+	return stat[end+2], true
 }


### PR DESCRIPTION
## What changed

- taught `internal/mcp.Client` to retain a stdio process cancel func when it starts command-based MCP servers
- updated `Client.Stop()` to invoke that cancel func before closing the MCP session, so direct callers stop the stdio process group instead of only closing the protocol session
- normalized expected shutdown errors from intentional stdio cancellation so `Stop()` still behaves like a clean stop
- added a regression test that starts a real stdio MCP server through a wrapper shell which backgrounds a child process, then verifies `Client.Stop()` also terminates that leaked child

## Why this is high-value

Direct `client.Start(...); defer client.Stop()` call sites in `term-llm mcp ...` and the MCP browser/test flows were relying on `Stop()` to clean up stdio servers, but `Stop()` previously only closed the MCP session. Because the command itself was tied to a cancelable context that `Stop()` did not own, direct callers could leave behind helper subprocesses or descendant daemons after returning.

This is high-value because leaked MCP helper processes accumulate over time, keep ports and file descriptors open, and can make later MCP interactions flaky or interfere with authenticated/background services.

## Validation

- `gofmt -w internal/mcp/client.go internal/mcp/client_test.go`
- `go build ./...`
- `go test ./...`
- added `TestClientStop_CancelsStdioProcessGroup` covering the specific leak path
