### PR TITLE
fix: grep max_results is applied per file, so common searches still do huge rg scans and buffering

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -132,6 +132,8 @@ func buildRipgrepArgs(a GrepArgs, searchPath string, contextLines, maxResults in
 	} else {
 		args = append(args,
 			"--json",
+			// --max-count is per-file, not global. A streaming stop enforces the
+			// caller's overall max_results limit once enough total matches are found.
 			"--max-count", strconv.Itoa(maxResults),
 			"--context", strconv.Itoa(contextLines),
 		)
@@ -176,12 +178,38 @@ func (l ripgrepCaptureLimits) normalize() ripgrepCaptureLimits {
 	return l
 }
 
+type ripgrepLineConsumer func(line []byte) (stop bool, err error)
+
 func captureRipgrepOutput(stdout io.Reader, limits ripgrepCaptureLimits) ([]byte, bool, error) {
+	return captureRipgrepOutputWithConsumer(stdout, limits, nil)
+}
+
+func captureRipgrepOutputWithConsumer(stdout io.Reader, limits ripgrepCaptureLimits, consumeLine ripgrepLineConsumer) ([]byte, bool, error) {
 	limits = limits.normalize()
 	var out bytes.Buffer
 	var pendingLine bytes.Buffer
 	reader := bufio.NewReader(stdout)
 	lineCount := 0
+
+	commitLine := func() ([]byte, bool, error) {
+		line := pendingLine.Bytes()
+		if consumeLine != nil {
+			stop, err := consumeLine(line)
+			if err != nil {
+				return nil, false, err
+			}
+			if stop {
+				return out.Bytes(), true, nil
+			}
+		}
+		lineCount++
+		if lineCount > limits.maxOutputLines {
+			return out.Bytes(), true, nil
+		}
+		out.Write(line)
+		pendingLine.Reset()
+		return nil, false, nil
+	}
 
 	for {
 		fragment, readErr := reader.ReadSlice('\n')
@@ -194,12 +222,13 @@ func captureRipgrepOutput(stdout io.Reader, limits ripgrepCaptureLimits) ([]byte
 
 		switch {
 		case readErr == nil:
-			lineCount++
-			if lineCount > limits.maxOutputLines {
-				return out.Bytes(), true, nil
+			truncatedOut, truncated, err := commitLine()
+			if err != nil {
+				return nil, false, err
 			}
-			out.Write(pendingLine.Bytes())
-			pendingLine.Reset()
+			if truncated {
+				return truncatedOut, true, nil
+			}
 		case errors.Is(readErr, bufio.ErrBufferFull):
 			continue
 		case errors.Is(readErr, io.EOF):
@@ -207,11 +236,13 @@ func captureRipgrepOutput(stdout io.Reader, limits ripgrepCaptureLimits) ([]byte
 			// deliberately return only prior complete lines so the JSON parser never
 			// sees a partial ripgrep record.
 			if pendingLine.Len() > 0 {
-				lineCount++
-				if lineCount > limits.maxOutputLines {
-					return out.Bytes(), true, nil
+				truncatedOut, truncated, err := commitLine()
+				if err != nil {
+					return nil, false, err
 				}
-				out.Write(pendingLine.Bytes())
+				if truncated {
+					return truncatedOut, true, nil
+				}
 			}
 			return out.Bytes(), false, nil
 		default:
@@ -220,7 +251,53 @@ func captureRipgrepOutput(stdout io.Reader, limits ripgrepCaptureLimits) ([]byte
 	}
 }
 
-func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits) ([]byte, bool, error) {
+type ripgrepResultLimiter struct {
+	maxResults int
+	pending    bool
+	results    int
+}
+
+func newRipgrepResultLimiter(maxResults int) *ripgrepResultLimiter {
+	if maxResults <= 0 {
+		return nil
+	}
+	return &ripgrepResultLimiter{maxResults: maxResults}
+}
+
+func (l *ripgrepResultLimiter) consumeLine(line []byte) (bool, error) {
+	if l == nil {
+		return false, nil
+	}
+
+	var msg rgMatch
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return false, nil
+	}
+
+	switch msg.Type {
+	case "match":
+		if l.pending {
+			l.results++
+			l.pending = false
+			if l.results >= l.maxResults {
+				return true, nil
+			}
+		}
+		l.pending = true
+	case "end":
+		if l.pending {
+			l.results++
+			l.pending = false
+			if l.results >= l.maxResults {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits, maxResults int, filesWithMatches bool) ([]byte, bool, error) {
 	limits = limits.normalize()
 	cmd := exec.CommandContext(ctx, "rg", args...)
 
@@ -242,7 +319,14 @@ func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits)
 		stderrCh <- data
 	}()
 
-	out, truncated, readErr := captureRipgrepOutput(stdout, limits)
+	var consumeLine ripgrepLineConsumer
+	if !filesWithMatches {
+		if limiter := newRipgrepResultLimiter(maxResults); limiter != nil {
+			consumeLine = limiter.consumeLine
+		}
+	}
+
+	out, truncated, readErr := captureRipgrepOutputWithConsumer(stdout, limits, consumeLine)
 	if readErr != nil {
 		_ = cmd.Process.Kill()
 		<-stderrCh
@@ -279,7 +363,7 @@ func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits)
 // executeRipgrep runs ripgrep and returns matches.
 func (t *GrepTool) executeRipgrep(ctx context.Context, a GrepArgs, searchPath string, contextLines, maxResults int) (ripgrepResult, error) {
 	args := buildRipgrepArgs(a, searchPath, contextLines, maxResults)
-	output, truncated, err := runRipgrep(ctx, args, t.rgCaptureLimits)
+	output, truncated, err := runRipgrep(ctx, args, t.rgCaptureLimits, maxResults, a.FilesWithMatches)
 	if err != nil {
 		return ripgrepResult{}, err
 	}

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -43,6 +43,34 @@ func TestCaptureRipgrepOutputPreservesCompleteLinesBeforeOversizedPartial(t *tes
 	}
 }
 
+func TestCaptureRipgrepOutputWithConsumerStopsAtGlobalMaxResults(t *testing.T) {
+	input := buildSyntheticRipgrepJSON(5000)
+	limits := ripgrepCaptureLimits{maxOutputLines: 20000, maxBufferedBytes: len(input) + 1024}
+	limiter := newRipgrepResultLimiter(100)
+
+	out, truncated, err := captureRipgrepOutputWithConsumer(strings.NewReader(string(input)), limits, limiter.consumeLine)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !truncated {
+		t.Fatal("expected capture to stop once the global result cap is satisfied")
+	}
+	if !strings.Contains(string(out), "f00099.go") {
+		t.Fatalf("expected useful prefix to include the 100th result, got:\n%s", string(out))
+	}
+	if strings.Contains(string(out), "f00100.go") {
+		t.Fatalf("expected capture to stop before buffering later results, got:\n%s", string(out))
+	}
+
+	matches, err := parseRipgrepOutput(out, 100, 0)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(matches) != 100 {
+		t.Fatalf("expected 100 matches from the buffered prefix, got %d", len(matches))
+	}
+}
+
 func TestGrepTool_UsesFilePath(t *testing.T) {
 	dir := t.TempDir()
 	token := "unique_grep_token_1234567890"


### PR DESCRIPTION
## What changed

- kept ripgrep's existing `--max-count` behavior as a per-file guard, but stopped treating it as the global `max_results` limiter
- added a streaming stdout consumer in `internal/tools/grep.go` so JSON ripgrep output is inspected line-by-line while it is being captured
- added a small `ripgrepResultLimiter` that mirrors the existing `parseToPending` flush boundaries and tells `runRipgrep` when the requested total match count has already been satisfied
- when that global cap is reached, `runRipgrep` now kills `rg` immediately instead of continuing to scan, emit JSON, buffer output, and only truncate later
- added a regression test that feeds a large synthetic ripgrep stream and verifies capture stops after the 100th global result while still leaving a parseable useful prefix

## Why this is high-value

Today `max_results` only limits ripgrep matches per file, while `term-llm` still captures the full raw `rg` stream before parsing. For common patterns across many files, searches asking for a small number of results can still do a large amount of unnecessary filesystem scanning, JSON serialization, pipe I/O, and memory allocation.

This fix is high-value because it moves the stop condition into the streaming capture path. Once enough total matches are found, we terminate `rg` immediately. That directly reduces wasted work, lowers allocation and buffering pressure, and improves interactive latency for code-review and exploration flows.

## Validation

- `gofmt -w internal/tools/grep.go internal/tools/grep_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
