### PR TITLE
fix: Claude Bin stream can deadlock forever when the event consumer stops reading

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -776,6 +776,12 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		toolReqCh: make(chan claudeToolRequest, 64),
 		done:      make(chan struct{}),
 	}
+	var bridgeDoneOnce sync.Once
+	stopScanner := func() {
+		bridgeDoneOnce.Do(func() {
+			close(bridge.done)
+		})
+	}
 	p.eventsMu.Lock()
 	p.currentBridge = bridge
 	p.currentEvents = send.ch
@@ -787,7 +793,7 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 			p.currentEvents = nil
 		}
 		p.eventsMu.Unlock()
-		close(bridge.done)
+		stopScanner()
 	}()
 
 	// Capture stderr in a bounded ring buffer so we can include a tail
@@ -850,6 +856,10 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 
 	lastUsage, toolsExecuted, handledTerminalResult, err := p.dispatchClaudeEvents(ctx, lineCh, bridge.toolReqCh, debug, send)
 	if err != nil {
+		// Unblock the stdout scanner before waiting on scanErrCh. If the
+		// downstream event consumer stopped reading, the scanner may be stuck
+		// trying to send into a full lineCh after dispatch returns early.
+		stopScanner()
 		// Kill the process if dispatch failed (e.g., context cancelled)
 		// to avoid orphan processes.
 		cmd.Process.Kill()

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -500,6 +500,47 @@ func TestHandleClaudeLine_ContextCancelledDoesNotBlock(t *testing.T) {
 	}
 }
 
+func TestRunClaudeCommand_UnblocksScannerWhenEventConsumerStopsReading(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	dir := t.TempDir()
+	scriptPath := dir + "/claude"
+	script := `#!/bin/sh
+	i=0
+	while [ "$i" -lt 400 ]; do
+		printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"x"}}}'
+		i=$((i+1))
+	done
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	path := dir
+	if existing := os.Getenv("PATH"); existing != "" {
+		path += ":" + existing
+	}
+	t.Setenv("PATH", path)
+
+	events := make(chan Event)
+	close(events)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- provider.runClaudeCommand(context.Background(), nil, "", "prompt", false, eventSender{ctx: context.Background(), ch: events})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected stream closed error")
+		}
+		if !strings.Contains(err.Error(), "stream closed") {
+			t.Fatalf("expected stream closed error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runClaudeCommand hung waiting for stdout scanner to stop")
+	}
+}
+
 func TestClaudeBinProvider_ToolExecutorIsWired(t *testing.T) {
 	provider := NewClaudeBinProvider("sonnet", nil)
 	registry := NewToolRegistry()


### PR DESCRIPTION
## What changed

- close the Claude stdout scanner bridge as soon as `dispatchClaudeEvents(...)` returns an error, instead of waiting for the deferred cleanup at function exit
- guard `bridge.done` with `sync.Once` so the early unblock and deferred cleanup can safely share the same close path
- add a regression test that uses a fake `claude` binary to verify `runClaudeCommand` returns instead of hanging when the event consumer has stopped reading and Claude keeps streaming output

## Why this is high-value

A downstream streaming write failure could previously wedge Claude-backed requests forever. The failure mode was:

1. event delivery failed and `dispatchClaudeEvents(...)` returned early
2. the stdout scanner goroutine kept trying to enqueue parsed lines into `lineCh`
3. once `lineCh` filled, the scanner blocked forever because `bridge.done` was still only scheduled to close in deferred cleanup
4. `runClaudeCommand` then waited forever on `scanErrCh`

That can strand in-flight Claude executions in serve/TUI/Telegram flows after client disconnects or other stream write failures. Unblocking the scanner immediately on the error path prevents the deadlock.

## Validation

- `gofmt -w internal/llm/claude_bin.go internal/llm/claude_bin_test.go`
- `go build ./...`
- `go test ./...`
- added regression test: `TestRunClaudeCommand_UnblocksScannerWhenEventConsumerStopsReading`
