### PR TITLE
fix: Claude CLI subprocesses are launched without process-group cleanup or WaitDelay

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/mcphttp"
+	"github.com/samsaffron/term-llm/internal/procutil"
 )
 
 // claudeStderrTailMaxLines caps the number of trailing stderr lines we retain
@@ -61,6 +63,8 @@ var mcpCallCounter atomic.Int64
 
 // getEuid returns the effective user ID. Overridable in tests.
 var getEuid = os.Geteuid
+
+var claudeCommandWaitDelay = time.Second
 
 // ClaudeBinProvider implements Provider using the claude CLI binary.
 // This provider shells out to the claude command for inference,
@@ -724,6 +728,24 @@ func shellQuote(s string) string {
 	return s
 }
 
+func (p *ClaudeBinProvider) prepareClaudeCommand(ctx context.Context, args []string, effort string) (*exec.Cmd, io.WriteCloser, func(), error) {
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.WaitDelay = claudeCommandWaitDelay
+	cmd.Env = p.buildCommandEnv(effort)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get stdin pipe: %w", err)
+	}
+
+	cleanup, err := procutil.PrepareCommand(cmd)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to prepare claude command: %w", err)
+	}
+
+	return cmd, stdin, cleanup, nil
+}
+
 // runClaudeCommand executes the claude CLI binary with the given arguments and prompt,
 // parsing its streaming JSON output into events. Returns nil on success.
 func (p *ClaudeBinProvider) runClaudeCommand(
@@ -749,14 +771,11 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		fmt.Fprintln(os.Stderr, "=================================")
 	}
 
-	cmd := exec.CommandContext(ctx, "claude", args...)
-	cmd.Env = p.buildCommandEnv(effort)
-
-	// Set up stdin pipe for the prompt
-	stdin, err := cmd.StdinPipe()
+	cmd, stdin, cleanup, err := p.prepareClaudeCommand(ctx, args, effort)
 	if err != nil {
-		return fmt.Errorf("failed to get stdin pipe: %w", err)
+		return err
 	}
+	defer cleanup()
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -850,9 +869,13 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 
 	lastUsage, toolsExecuted, handledTerminalResult, err := p.dispatchClaudeEvents(ctx, lineCh, bridge.toolReqCh, debug, send)
 	if err != nil {
-		// Kill the process if dispatch failed (e.g., context cancelled)
-		// to avoid orphan processes.
-		cmd.Process.Kill()
+		// Kill the entire process group if dispatch failed (e.g., context cancelled)
+		// so helper descendants do not keep the stdio pipes open.
+		if cmd.Cancel != nil {
+			_ = cmd.Cancel()
+		} else if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
 	}
 
 	// Wait for scanner to finish BEFORE cmd.Wait().

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -131,6 +131,27 @@ func TestClaudeBinProvider_CleanupTurn_DoesNotStopMCPServer(t *testing.T) {
 	}
 }
 
+func TestClaudeBinProvider_prepareClaudeCommand_ConfiguresProcessGroupAndWaitDelay(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+
+	cmd, stdin, cleanup, err := provider.prepareClaudeCommand(context.Background(), []string{"--version"}, "")
+	if err != nil {
+		t.Fatalf("prepareClaudeCommand failed: %v", err)
+	}
+	defer cleanup()
+	defer stdin.Close()
+
+	if cmd.WaitDelay != claudeCommandWaitDelay {
+		t.Fatalf("WaitDelay = %v, want %v", cmd.WaitDelay, claudeCommandWaitDelay)
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatal("expected claude subprocess to run in its own process group")
+	}
+	if cmd.Cancel == nil {
+		t.Fatal("expected claude subprocess to install process-group cancellation")
+	}
+}
+
 func TestSafeSendEvent_ClosedChannel(t *testing.T) {
 	// Test that safeSendEvent doesn't panic on closed channel
 	ch := make(chan Event)


### PR DESCRIPTION
## What changed

- added a small `prepareClaudeCommand` helper in `internal/llm/claude_bin.go`
- configured Claude CLI subprocesses with the same hygiene used elsewhere in the repo:
  - `procutil.PrepareCommand(cmd)` so the command runs in its own process group and context cancellation targets the whole group
  - `cmd.WaitDelay = time.Second` to bound teardown when descendants keep stdio pipes open
- changed the dispatch-error cleanup path to call `cmd.Cancel()` instead of killing only the direct Claude pid
- added a unit test that verifies Claude command setup includes process-group isolation, process-group cancellation, and `WaitDelay`

## Why this is high-value

Claude-backed sessions are a core interactive path for TUI, serve, and Telegram. Before this change, a cancelled or failed Claude turn only killed the immediate `claude` process. Any helper or MCP-related descendants could survive cancellation, keep stdout/stderr pipe fds open, and leave behind orphaned processes or stuck teardown. This fix makes cancellation hit the whole subprocess tree and adds the same bounded-wait behavior already used in other long-running runners in the codebase.

## Validation

- `gofmt -w internal/llm/claude_bin.go internal/llm/claude_bin_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
