### PR TITLE
fix: Serve runtime reserializes and rescans the full transcript on every persisted turn

### DIFF
--- a/cmd/serve_model_swap.go
+++ b/cmd/serve_model_swap.go
@@ -230,6 +230,7 @@ func seedRuntimeHistory(rt *serveRuntime, history []llm.Message) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	rt.history = copyLLMMessageSlice(history)
+	rt.historyPersisted = false
 	rt.cumulativeUsage = llm.Usage{}
 	rt.lastInjectedPlatform = ""
 	if rt.engine != nil {
@@ -385,6 +386,7 @@ func appendRuntimeHistoryEvent(rt *serveRuntime, msg llm.Message) {
 	}
 	rt.mu.Lock()
 	rt.history = append(rt.history, msg)
+	rt.historyPersisted = false
 	rt.mu.Unlock()
 }
 
@@ -394,6 +396,7 @@ func setRuntimeHistoryPreserveEngine(rt *serveRuntime, history []llm.Message) {
 	}
 	rt.mu.Lock()
 	rt.history = copyLLMMessageSlice(history)
+	rt.historyPersisted = false
 	rt.mu.Unlock()
 }
 

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -34,6 +34,7 @@ type serveRuntime struct {
 	store                session.Store
 	systemPrompt         string
 	history              []llm.Message
+	historyPersisted     bool // history matches the persisted active transcript and can safely append next turn
 	search               bool
 	toolsSetting         string
 	mcpSetting           string
@@ -289,12 +290,13 @@ func (rt *serveRuntime) ensurePersistedSession(ctx context.Context, sessionID st
 	if existing, err := rt.store.Get(ctx, sessionID); err == nil && existing != nil {
 		rt.sessionMeta = existing
 		if len(rt.history) == 0 {
-			if msgs, loadErr := session.LoadActiveMessages(ctx, rt.store, existing); loadErr == nil && len(msgs) > 0 {
+			if msgs, loadErr := session.LoadActiveMessages(ctx, rt.store, existing); loadErr == nil {
 				llmMsgs := make([]llm.Message, 0, len(msgs))
 				for _, m := range msgs {
 					llmMsgs = append(llmMsgs, m.ToLLMMessage())
 				}
 				rt.history = llmMsgs
+				rt.historyPersisted = true
 			}
 		}
 		return true
@@ -347,13 +349,13 @@ func (rt *serveRuntime) ensurePersistedSession(ctx context.Context, sessionID st
 		}
 		rt.sessionMeta = existing
 		if len(rt.history) == 0 {
-			msgs, loadErr := session.LoadActiveMessages(ctx, rt.store, existing)
-			if loadErr == nil && len(msgs) > 0 {
+			if msgs, loadErr := session.LoadActiveMessages(ctx, rt.store, existing); loadErr == nil {
 				llmMsgs := make([]llm.Message, 0, len(msgs))
 				for _, m := range msgs {
 					llmMsgs = append(llmMsgs, m.ToLLMMessage())
 				}
 				rt.history = llmMsgs
+				rt.historyPersisted = true
 			}
 		}
 		if setErr := rt.store.SetCurrent(ctx, sessionID); setErr != nil {
@@ -594,6 +596,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	if !stateful {
 		rt.engine.ResetConversation()
 		rt.history = nil
+		rt.historyPersisted = false
 	}
 
 	baseHistory := make([]llm.Message, len(rt.history))
@@ -601,12 +604,14 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	replaceHistoryBackup := baseHistory
 	replaceUsageBackup := rt.cumulativeUsage
 	replacePlatformBackup := rt.lastInjectedPlatform
+	replacePersistedBackup := rt.historyPersisted
 	if replaceHistory {
 		baseHistory = nil
 		rt.history = nil
 		rt.engine.ResetConversation()
 		rt.cumulativeUsage = llm.Usage{}
 		rt.lastInjectedPlatform = ""
+		rt.historyPersisted = false
 	}
 	turnIndex := countUserMessages(baseHistory)
 
@@ -683,14 +688,15 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		snapshot := buildSnapshotLocked()
 		if stateful {
 			rt.history = snapshot
+			rt.historyPersisted = false
 		}
 		if persisted {
-			rt.persistSnapshot(persistCtx, req.SessionID, snapshot)
+			rt.historyPersisted = rt.persistSnapshot(persistCtx, req.SessionID, snapshot)
 		}
 		persistPlatformInjectionLocked()
 	}
 
-	appendOnlyPersisted := persisted && !replaceHistory && rt.sessionMeta != nil && session.HasCompactionBoundary(rt.sessionMeta)
+	appendOnlyPersisted := persisted && !replaceHistory && rt.historyPersisted
 	initialPersisted := false
 	initialMessages := make([]llm.Message, 0, len(inputMessages)+1)
 	if systemPromptInjected {
@@ -698,6 +704,14 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	}
 	initialMessages = append(initialMessages, inputMessages...)
 	initialAppendedIdx := 0
+	appendOnlyCaughtUpLocked := func() bool {
+		return appendOnlyPersisted &&
+			initialPersisted &&
+			initialAppendedIdx >= len(initialMessages) &&
+			lastAppendedIdx >= len(produced) &&
+			!assistantSnapshotDirty &&
+			!assistantSnapshotNeedsReconcile
+	}
 	appendInitialInputLocked := func(persistCtx context.Context) bool {
 		if !appendOnlyPersisted || initialAppendedIdx >= len(initialMessages) {
 			initialPersisted = true
@@ -706,6 +720,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		written := rt.appendMessages(persistCtx, req.SessionID, initialMessages[initialAppendedIdx:], turnIndex)
 		initialAppendedIdx += written
 		if initialAppendedIdx < len(initialMessages) {
+			appendOnlyPersisted = false
+			rt.historyPersisted = false
 			return false
 		}
 		initialPersisted = true
@@ -720,6 +736,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	updateStateAndAppendLocked := func(persistCtx context.Context) {
 		if stateful {
 			rt.history = buildSnapshotLocked()
+			rt.historyPersisted = false
 		}
 		if persisted {
 			if appendOnlyPersisted {
@@ -730,6 +747,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				if lastAppendedIdx < len(produced) {
 					written := rt.appendMessages(persistCtx, req.SessionID, produced[lastAppendedIdx:], turnIndex)
 					lastAppendedIdx += written
+					if lastAppendedIdx < len(produced) {
+						appendOnlyPersisted = false
+						rt.historyPersisted = false
+					}
 				}
 				persistPlatformInjectionLocked()
 				return
@@ -800,6 +821,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		assistantSnapshotNeedsReconcile = false
 		if stateful {
 			rt.history = append([]llm.Message(nil), compacted...)
+			rt.historyPersisted = persisted
 		}
 		rt.engine.SetContextEstimateBaseline(0, 0)
 		persistPlatformInjectionLocked()
@@ -821,6 +843,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		assistantSnapshotDirty = true
 		if stateful {
 			rt.history = buildSnapshotLocked()
+			rt.historyPersisted = false
 		}
 		if !persisted {
 			persistPlatformInjectionLocked()
@@ -858,6 +881,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			}
 			if !errors.Is(err, session.ErrNotFound) {
 				assistantSnapshotNeedsReconcile = true
+				appendOnlyPersisted = false
+				rt.historyPersisted = false
 				log.Printf("[serve] session UpdateMessage failed for %s: %v", req.SessionID, err)
 				persistPlatformInjectionLocked()
 				return
@@ -869,6 +894,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		}
 		if err := rt.store.AddMessage(dbCtx, req.SessionID, sessionMsg); err != nil {
 			assistantSnapshotNeedsReconcile = true
+			appendOnlyPersisted = false
+			rt.historyPersisted = false
 			log.Printf("[serve] session AddMessage failed for %s: %v", req.SessionID, err)
 			persistPlatformInjectionLocked()
 			return
@@ -938,6 +965,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				rt.history = replaceHistoryBackup
 				rt.cumulativeUsage = replaceUsageBackup
 				rt.lastInjectedPlatform = replacePlatformBackup
+				rt.historyPersisted = replacePersistedBackup
 			}
 			return
 		}
@@ -952,6 +980,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				rt.history = replaceHistoryBackup
 				rt.cumulativeUsage = replaceUsageBackup
 				rt.lastInjectedPlatform = replacePlatformBackup
+				rt.historyPersisted = replacePersistedBackup
 			}
 			return
 		}
@@ -960,8 +989,12 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		if appendOnlyPersisted {
 			producedMu.Lock()
 			updateStateAndAppendLocked(deferCtx)
+			caughtUp := appendOnlyCaughtUpLocked()
 			producedMu.Unlock()
-			return
+			if caughtUp {
+				rt.historyPersisted = true
+				return
+			}
 		}
 		persistProducedSnapshot(deferCtx)
 	}()
@@ -1051,6 +1084,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	}
 	if stateful {
 		rt.history = newHistory
+		rt.historyPersisted = false
 	}
 	needFinalSnapshot = false
 	if persisted {
@@ -1059,6 +1093,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 				upsertPendingAssistantLocked(ctx, produced[pendingAssistantIdx])
 			}
 			updateStateAndAppendLocked(ctx)
+			needFinalSnapshot = !appendOnlyCaughtUpLocked()
 		} else {
 			needFinalSnapshot = !initialPersisted || lastAppendedIdx < len(produced) || assistantSnapshotDirty || assistantSnapshotNeedsReconcile || synthesizedAssistant
 		}
@@ -1066,7 +1101,9 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	persistPlatformInjectionLocked()
 	producedMu.Unlock()
 	if needFinalSnapshot {
-		rt.persistSnapshot(ctx, req.SessionID, newHistory)
+		rt.historyPersisted = rt.persistSnapshot(ctx, req.SessionID, newHistory)
+	} else if persisted {
+		rt.historyPersisted = true
 	}
 
 	return result, nil

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -91,7 +91,7 @@ func (p *serveRuntimeTestProvider) Capabilities() llm.Capabilities {
 
 func (p *serveRuntimeTestProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
 	var events []llm.Event
-	switch p.calls {
+	switch p.calls % 2 {
 	case 0:
 		events = []llm.Event{
 			{Type: llm.EventToolCall, Tool: &llm.ToolCall{ID: "call-1", Name: "serve_runtime_test_tool", Arguments: json.RawMessage(`{}`)}},
@@ -102,8 +102,6 @@ func (p *serveRuntimeTestProvider) Stream(ctx context.Context, req llm.Request) 
 			{Type: llm.EventTextDelta, Text: "done"},
 			{Type: llm.EventDone},
 		}
-	default:
-		return nil, errors.New("unexpected provider call")
 	}
 	p.calls++
 	return &serveRuntimeTestStream{events: events}, nil
@@ -743,6 +741,143 @@ func TestServeRuntimeSuccessfulRunSkipsFinalSnapshotRewrite(t *testing.T) {
 	}
 	if len(msgs) != 6 {
 		t.Fatalf("stored message count = %d, want 6", len(msgs))
+	}
+	if msgs[5].Role != llm.RoleAssistant || msgs[5].TextContent != "done" {
+		t.Fatalf("message[5] = %+v, want final assistant message", msgs[5])
+	}
+}
+
+func TestServeRuntimeLaterTurnsStayAppendOnlyOnceHistoryPersisted(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	provider := &serveRuntimeTestProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		defaultModel: "test-model",
+		history: []llm.Message{
+			serveRuntimeTextMessage(llm.RoleUser, "previous user"),
+			serveRuntimeTextMessage(llm.RoleAssistant, "previous assistant"),
+		},
+	}
+
+	for i, userText := range []string{"current user", "second user"} {
+		result, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, userText)}, llm.Request{
+			SessionID:   "sess-append-next-turn",
+			Tools:       []llm.ToolSpec{tool.Spec()},
+			ToolChoice:  llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+			MaxTurns:    4,
+			Search:      false,
+			Debug:       false,
+			DebugRaw:    false,
+			Temperature: 0,
+		})
+		if err != nil {
+			t.Fatalf("Run(%d) error = %v", i+1, err)
+		}
+		if got := result.Text.String(); got != "done" {
+			t.Fatalf("Run(%d) result text = %q, want %q", i+1, got, "done")
+		}
+	}
+
+	if store.replaceCalls != 1 {
+		t.Fatalf("ReplaceMessages call count = %d, want 1 across both turns", store.replaceCalls)
+	}
+	if !rt.historyPersisted {
+		t.Fatal("runtime history should remain marked as fully persisted after second turn")
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "sess-append-next-turn", 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 10 {
+		t.Fatalf("stored message count = %d, want 10", len(msgs))
+	}
+	if msgs[6].Role != llm.RoleUser || msgs[6].TextContent != "second user" {
+		t.Fatalf("message[6] = %+v, want second user message", msgs[6])
+	}
+	if msgs[9].Role != llm.RoleAssistant || msgs[9].TextContent != "done" {
+		t.Fatalf("message[9] = %+v, want final assistant message", msgs[9])
+	}
+}
+
+func TestServeRuntimeAppendOnlyTurnFallsBackToSnapshotAfterAssistantUpdateFailure(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	sess := &session.Session{ID: "sess-append-reconcile", Status: session.StatusActive}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	seeded := []llm.Message{
+		serveRuntimeTextMessage(llm.RoleUser, "previous user"),
+		serveRuntimeTextMessage(llm.RoleAssistant, "previous assistant"),
+	}
+	seededMessages := make([]session.Message, 0, len(seeded))
+	for _, msg := range seeded {
+		seededMessages = append(seededMessages, *session.NewMessage(sess.ID, msg, -1))
+	}
+	if err := store.ReplaceMessages(context.Background(), sess.ID, seededMessages); err != nil {
+		t.Fatalf("ReplaceMessages() error = %v", err)
+	}
+	store.replaceCalls = 0
+	store.updateFailures[1] = errors.New("transient update failure")
+
+	provider := &serveRuntimeTestProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:         provider,
+		providerKey:      provider.Name(),
+		engine:           engine,
+		store:            store,
+		sessionMeta:      sess,
+		defaultModel:     "test-model",
+		history:          seeded,
+		historyPersisted: true,
+	}
+
+	result, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID:   sess.ID,
+		Tools:       []llm.ToolSpec{tool.Spec()},
+		ToolChoice:  llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		MaxTurns:    4,
+		Search:      false,
+		Debug:       false,
+		DebugRaw:    false,
+		Temperature: 0,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := result.Text.String(); got != "done" {
+		t.Fatalf("result text = %q, want %q", got, "done")
+	}
+
+	if store.replaceCalls != 1 {
+		t.Fatalf("ReplaceMessages call count = %d, want 1 reconciliation snapshot only", store.replaceCalls)
+	}
+	if !rt.historyPersisted {
+		t.Fatal("runtime history should be marked fully persisted after reconciliation snapshot")
+	}
+
+	msgs, err := store.GetMessages(context.Background(), sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 6 {
+		t.Fatalf("stored message count = %d, want 6", len(msgs))
+	}
+	if msgs[3].Role != llm.RoleAssistant || len(msgs[3].Parts) == 0 || msgs[3].Parts[0].ToolCall == nil {
+		t.Fatalf("message[3] = %+v, want assistant tool-call message", msgs[3])
 	}
 	if msgs[5].Role != llm.RoleAssistant || msgs[5].TextContent != "done" {
 		t.Fatalf("message[5] = %+v, want final assistant message", msgs[5])


### PR DESCRIPTION
## What changed

- Added a `historyPersisted` runtime flag so serve/web sessions can remember when the in-memory active transcript already matches the persisted session state.
- Switched the incremental persistence gate from `HasCompactionBoundary(...)` to that trusted persisted-history flag, so later persisted turns stay on the append-only path instead of reseeding with `ReplaceMessages(...)` every turn.
- Kept conservative fallbacks: the runtime now drops back to a full snapshot if append-only writes miss part of the turn, if an assistant row update/add fails, or if history was mutated outside the normal persistence flow.
- Added focused tests for:
  - two consecutive persisted turns only doing one initial `ReplaceMessages(...)`
  - append-only turns still reconciling with a full snapshot after an injected assistant-update failure

## Why this is high-value

Before this change, non-compacted persisted serve sessions re-ran an O(history size) snapshot replace on the first callback of every turn, which forces full transcript reserialization and a SQLite prefix scan even when only the new suffix changed. That cost grows with conversation length and directly affects the main serve/web path.

After this change, once a session history is known-good in persistence, later turns append only the new input/output rows. That avoids repeated whole-history JSON work and DB reads on long-running sessions while preserving the existing full-snapshot recovery path when persistence falls behind.

## Validation

- `gofmt -w cmd/serve_runtime.go cmd/serve_runtime_test.go cmd/serve_model_swap.go`
- `go build ./...`
- `go test ./cmd -run 'TestServeRuntime(LaterTurnsStayAppendOnlyOnceHistoryPersisted|AppendOnlyTurnFallsBackToSnapshotAfterAssistantUpdateFailure|SuccessfulRunSkipsFinalSnapshotRewrite|FinalSnapshotReconcilesEarlierAssistantUpdateFailure)'`
- `go test ./...`
- `git diff --check`
