### PR TITLE
persist web input before first stream event

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -598,6 +598,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 
 	baseHistory := make([]llm.Message, len(rt.history))
 	copy(baseHistory, rt.history)
+	replacingExistingHistory := replaceHistory && len(baseHistory) > 0
 	replaceHistoryBackup := baseHistory
 	replaceUsageBackup := rt.cumulativeUsage
 	replacePlatformBackup := rt.lastInjectedPlatform
@@ -710,6 +711,26 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		}
 		initialPersisted = true
 		return true
+	}
+
+	// Make the submitted user turn durable before waiting for the provider's
+	// first streaming callback. The web UI can navigate away and reload the
+	// session while the model is still thinking; if we only persist on the first
+	// assistant/tool event, the just-submitted prompt temporarily disappears.
+	// For replace-history runs with existing history, keep the old transcript
+	// until the run produces an event so an early provider failure cannot wipe it.
+	if persisted && (!replaceHistory || !replacingExistingHistory) {
+		if appendOnlyPersisted {
+			appendInitialInputLocked(ctx)
+		} else {
+			initialSnapshot := make([]llm.Message, 0, len(baseHistory)+len(inputMessages)+1)
+			if systemPromptInjected {
+				initialSnapshot = append(initialSnapshot, llm.SystemText(rt.systemPrompt))
+			}
+			initialSnapshot = append(initialSnapshot, baseHistory...)
+			initialSnapshot = append(initialSnapshot, inputMessages...)
+			initialPersisted = rt.persistSnapshot(ctx, req.SessionID, initialSnapshot)
+		}
 	}
 
 	// updateStateAndAppend updates in-memory history and incrementally appends

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -625,6 +625,48 @@ func TestServeRuntimeCloseCancelsActiveRun(t *testing.T) {
 	}
 }
 
+type serveRuntimeInspectStoreProvider struct {
+	store     *serveRuntimeTestStore
+	sessionID string
+	t         *testing.T
+}
+
+func (p *serveRuntimeInspectStoreProvider) Name() string                   { return "serve-runtime-inspect" }
+func (p *serveRuntimeInspectStoreProvider) Credential() string             { return "test" }
+func (p *serveRuntimeInspectStoreProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+func (p *serveRuntimeInspectStoreProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	msgs, err := p.store.GetMessages(ctx, p.sessionID, 0, 0)
+	if err != nil {
+		p.t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "slow prompt" {
+		p.t.Fatalf("messages before provider stream = %+v, want durable user prompt", msgs)
+	}
+	return &serveRuntimeTestStream{events: []llm.Event{{Type: llm.EventTextDelta, Text: "ok"}, {Type: llm.EventDone}}}, nil
+}
+
+func TestServeRuntimePersistsInputBeforeFirstProviderEvent(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	provider := &serveRuntimeInspectStoreProvider{store: store, sessionID: "sess-slow", t: t}
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       llm.NewEngine(provider, nil),
+		store:        store,
+		defaultModel: "test-model",
+	}
+
+	result, err := rt.RunWithEvents(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "slow prompt")}, llm.Request{
+		SessionID: "sess-slow",
+	}, func(ev llm.Event) error { return nil })
+	if err != nil {
+		t.Fatalf("RunWithEvents() error = %v", err)
+	}
+	if got := result.Text.String(); got != "ok" {
+		t.Fatalf("result text = %q, want ok", got)
+	}
+}
+
 func TestServeRuntimeRetriesInitialSnapshotBeforeAppending(t *testing.T) {
 	store := newServeRuntimeTestStore()
 	store.replaceFailures[1] = errors.New("initial snapshot failed")

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2722,13 +2722,14 @@ func TestServeRuntimeRun_ImmediateErrorDoesNotDesyncState(t *testing.T) {
 		t.Fatalf("history len after immediate error = %d, want 0", len(rt.history))
 	}
 
-	// DB should have no messages for this session (no eager persist without callback).
+	// DB should have the submitted user message immediately. This keeps the web
+	// session view stable while the provider is slow or fails before emitting.
 	msgs, err := store.GetMessages(context.Background(), sid, 0, 0)
 	if err != nil {
 		t.Fatalf("GetMessages failed: %v", err)
 	}
-	if len(msgs) != 0 {
-		t.Fatalf("persisted message count after immediate error = %d, want 0", len(msgs))
+	if len(msgs) != 1 || msgs[0].Role != llm.RoleUser || msgs[0].TextContent != "hello" {
+		t.Fatalf("persisted messages after immediate error = %+v, want durable user prompt", msgs)
 	}
 
 	// Second run: succeeds — must not be confused by stale DB state.

--- a/cmd/subagent_progress_dispatcher_test.go
+++ b/cmd/subagent_progress_dispatcher_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSubagentProgressDispatcherDoesNotBlockWhenSendStalls(t *testing.T) {
-	enteredSend := make(chan struct{})
+	enteredSend := make(chan struct{}, 1)
 	releaseSend := make(chan struct{})
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(releaseSend) }) }


### PR DESCRIPTION
## What

Persist the submitted input turn before waiting for the provider's first streaming callback.

## Why

The web UI can navigate away and reload the session while a response is still thinking. Previously the server created the session record early, but did not write the user message until the first assistant/tool event. That left a transient empty transcript: navigate away, come back, the OP appears missing; once the reply emits and persistence catches up, a reload shows it again.

This keeps replace-history runs with existing history conservative: old transcript is preserved until a produced event arrives, so an early provider failure does not wipe an existing conversation.

## Verification

- `go test ./...`
- `go build ./...`
