### PR TITLE
fix: keep loading sessions blank in web UI

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -2039,13 +2039,16 @@ const renderMessages = (forceScroll = false) => {
 
   const sessionId = session ? session.id : null;
   const messages = session ? session.messages : [];
+  const sessionHistoryLoading = Boolean(session?._serverOnly);
 
   if (!session || !messages.length) {
     elements.messages.innerHTML = '';
-    const empty = document.createElement('div');
-    empty.className = 'empty-state';
-    empty.textContent = 'How can I help you today?';
-    elements.messages.appendChild(empty);
+    if (!sessionHistoryLoading) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'How can I help you today?';
+      elements.messages.appendChild(empty);
+    }
     _lastRenderedSessionId = sessionId;
     _lastRenderedMessageIds = [];
     _lastRenderedMessageKeys = new Map();

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -1187,6 +1187,28 @@ async function run(name, fn) {
     assertEqual(row.querySelector('.session-title').textContent, 'Z', 'known session row unchanged');
   });
 
+  await run('renderMessages: leaves server-only sessions blank while messages load', () => {
+    const { app, session, messages } = createHarness();
+    session.messages = [];
+    session._serverOnly = true;
+
+    app.renderMessages();
+
+    assertEqual(messages.children.length, 0, 'server-only loading session should not show the new-chat empty state');
+    assertEqual(messages.textContent, '', 'server-only loading session should be visually blank');
+  });
+
+  await run('renderMessages: empty local session shows new-chat prompt', () => {
+    const { app, session, messages } = createHarness();
+    session.messages = [];
+
+    app.renderMessages();
+
+    assertEqual(messages.children.length, 1, 'empty local session should show one empty-state node');
+    assertEqual(messages.children[0].className, 'empty-state', 'empty local session uses empty-state class');
+    assertEqual(messages.children[0].textContent, 'How can I help you today?', 'empty local session keeps the new-chat prompt');
+  });
+
   await run('renderMessages: incremental append reuses existing nodes', () => {
     const { app, session, messages } = createHarness();
     session.messages = [


### PR DESCRIPTION
## What

- Keep server-only/lazy-loaded sessions visually blank while their message history is loading.
- Preserve the "How can I help you today?" empty state for actual empty local/new sessions.
- Add render tests for both paths.

## Why

When clicking into a session whose messages are still loading, showing the new-chat prompt briefly reads like a glitch. Blank is better than lying; a loader can be layered on later without changing the state distinction.

## Verification

```sh
mise exec node@24.15.0 -- node internal/serveui/static/app_render_test.js
go test ./internal/serveui/...
go build ./... && go test ./...
```
