### PR TITLE
fix: Every shell/custom-tool run scans all of /proc to reap descendants, adding avoidable latency to the hottest tool path

### DIFF
--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -119,7 +119,7 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 	}
 	cmd.Env = env
 
-	cleanup, prepErr := prepareToolCommand(cmd)
+	cleanup, prepErr := prepareToolCommand(cmd, true)
 	if prepErr != nil {
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script setup error: %v", prepErr))), nil
 	}

--- a/internal/tools/exec_helpers.go
+++ b/internal/tools/exec_helpers.go
@@ -4,23 +4,30 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/gobwas/glob"
 	"github.com/samsaffron/term-llm/internal/pathutil"
+	"golang.org/x/sys/unix"
 )
 
 // shellNonceEnvVar is the environment variable name used to tag every process
 // spawned by a tool command so descendants that escape the process group (via
 // setsid, daemonisation, etc.) can still be reliably reaped on cleanup.
 const shellNonceEnvVar = "TERMLLM_SHELL_NONCE"
+
+const descendantLivenessGracePeriod = 20 * time.Millisecond
+
+var taggedDescendantReaper = killTaggedDescendants
 
 type limitedBuffer struct {
 	buf   bytes.Buffer
@@ -58,7 +65,7 @@ func (b *limitedBuffer) Truncated() bool {
 	return b.total > int64(b.buf.Len())
 }
 
-func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
+func prepareToolCommand(cmd *exec.Cmd, sweepTaggedDescendantsOnSuccess bool) (func(), error) {
 	var stdinCloser func()
 	if cmd.Stdin == nil {
 		if devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0); err == nil {
@@ -68,29 +75,109 @@ func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
 	}
 
 	configureCommandProcessGroup(cmd)
+
+	var cancelCalled atomic.Bool
+	if cmd.Cancel != nil {
+		cancel := cmd.Cancel
+		cmd.Cancel = func() error {
+			cancelCalled.Store(true)
+			return cancel()
+		}
+	}
+
 	nonce := tagCommandWithNonce(cmd)
+	probe, probeErr := installDescendantLivenessProbe(cmd)
 
 	cleanup := func() {
+		if probe != nil {
+			probe.closeParentWriter()
+		}
+
 		// Tools must leave the world clean: after the command returns (success,
 		// failure, timeout, or cancellation) reap every descendant it spawned.
 		//
 		// First pass: SIGKILL the process group so `nohup foo &` style children
 		// that stayed in our pgid die immediately.
+		var pgroupKillErr error
 		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			pgroupKillErr = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		}
-		// Second pass: walk /proc for any process still alive that inherited
-		// the nonce env var. This catches descendants that escaped the pgroup
-		// via setsid, double-fork daemonisation, or explicit setpgid. We retry
-		// a few times because a process may be mid-exec when we scan.
-		if nonce != "" {
-			killTaggedDescendants(nonce)
+
+		// Second pass: only pay for the expensive /proc nonce sweep when we have
+		// evidence the fast-path process-group reap was not enough, or when the
+		// caller explicitly asked us to preserve the old always-sweep semantics.
+		shouldSweepTaggedDescendants := cancelCalled.Load() || probeErr != nil || sweepTaggedDescendantsOnSuccess
+		if !shouldSweepTaggedDescendants && pgroupKillErr != nil && !errors.Is(pgroupKillErr, syscall.ESRCH) {
+			shouldSweepTaggedDescendants = true
+		}
+		if !shouldSweepTaggedDescendants && probe != nil && probe.descendantsLikelyAlive(descendantLivenessGracePeriod) {
+			shouldSweepTaggedDescendants = true
+		}
+		if shouldSweepTaggedDescendants && nonce != "" {
+			taggedDescendantReaper(nonce)
+		}
+
+		if probe != nil {
+			probe.close()
 		}
 		if stdinCloser != nil {
 			stdinCloser()
 		}
 	}
 	return cleanup, nil
+}
+
+type descendantLivenessProbe struct {
+	readEnd  *os.File
+	writeEnd *os.File
+}
+
+func installDescendantLivenessProbe(cmd *exec.Cmd) (*descendantLivenessProbe, error) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	cmd.ExtraFiles = append(cmd.ExtraFiles, writeEnd)
+	return &descendantLivenessProbe{readEnd: readEnd, writeEnd: writeEnd}, nil
+}
+
+func (p *descendantLivenessProbe) closeParentWriter() {
+	if p == nil || p.writeEnd == nil {
+		return
+	}
+	_ = p.writeEnd.Close()
+	p.writeEnd = nil
+}
+
+func (p *descendantLivenessProbe) descendantsLikelyAlive(timeout time.Duration) bool {
+	if p == nil || p.readEnd == nil {
+		return false
+	}
+
+	pollTimeout := int(timeout / time.Millisecond)
+	if timeout > 0 && pollTimeout == 0 {
+		pollTimeout = 1
+	}
+	pollFds := []unix.PollFd{{Fd: int32(p.readEnd.Fd()), Events: unix.POLLIN | unix.POLLHUP | unix.POLLERR}}
+	n, err := unix.Poll(pollFds, pollTimeout)
+	if err != nil {
+		return true
+	}
+	if n == 0 {
+		return true
+	}
+	return pollFds[0].Revents&unix.POLLHUP == 0
+}
+
+func (p *descendantLivenessProbe) close() {
+	if p == nil {
+		return
+	}
+	p.closeParentWriter()
+	if p.readEnd != nil {
+		_ = p.readEnd.Close()
+		p.readEnd = nil
+	}
 }
 
 // tagCommandWithNonce adds a unique TERMLLM_SHELL_NONCE=<hex> entry to cmd.Env
@@ -160,7 +247,7 @@ func findPidsWithEnv(needle []byte) []int {
 
 // PrepareCommand configures a command for safe cancellation, including process-group teardown.
 func PrepareCommand(cmd *exec.Cmd) (func(), error) {
-	return prepareToolCommand(cmd)
+	return prepareToolCommand(cmd, true)
 }
 
 func configureCommandProcessGroup(cmd *exec.Cmd) {

--- a/internal/tools/exec_helpers_test.go
+++ b/internal/tools/exec_helpers_test.go
@@ -1,9 +1,13 @@
 package tools
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestResolveToolPath_TildeExpanded verifies that resolveToolPath correctly
@@ -35,5 +39,89 @@ func TestResolveToolPath_TildeSlashExpanded(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, home) {
 		t.Errorf("resolveToolPath(~/) = %q, expected prefix %q", got, home)
+	}
+}
+
+func TestPrepareToolCommand_SkipsTaggedSweepForForegroundCommand(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	origReaper := taggedDescendantReaper
+	t.Cleanup(func() { taggedDescendantReaper = origReaper })
+
+	sweeps := 0
+	taggedDescendantReaper = func(nonce string) {
+		sweeps++
+		origReaper(nonce)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "bash", "-c", "pwd >/dev/null")
+	cleanup, err := prepareToolCommand(cmd, false)
+	if err != nil {
+		t.Fatalf("prepareToolCommand returned error: %v", err)
+	}
+
+	if err := cmd.Run(); err != nil {
+		cleanup()
+		t.Fatalf("cmd.Run returned error: %v", err)
+	}
+	cleanup()
+
+	if sweeps != 0 {
+		t.Fatalf("tagged descendant sweep ran %d times for a foreground command, want 0", sweeps)
+	}
+}
+
+func TestPrepareToolCommand_SweepsTaggedDescendantsWhenDetachedChildSurvives(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid not available")
+	}
+	if _, err := os.Stat("/proc/self/environ"); err != nil {
+		t.Skip("no /proc — nonce-based descendant reap is Linux-only")
+	}
+
+	origReaper := taggedDescendantReaper
+	t.Cleanup(func() { taggedDescendantReaper = origReaper })
+
+	sweeps := 0
+	taggedDescendantReaper = func(nonce string) {
+		sweeps++
+		origReaper(nonce)
+	}
+
+	sentinel := uniqueSentinel(t, "probe")
+	logPath := fmt.Sprintf("/tmp/%s.log", sentinel)
+	defer os.Remove(logPath)
+
+	cmd := exec.CommandContext(
+		context.Background(),
+		"bash",
+		"-c",
+		fmt.Sprintf("setsid bash -c 'sleep 120; :%s' >%s 2>&1 < /dev/null & echo ok", sentinel, logPath),
+	)
+	cleanup, err := prepareToolCommand(cmd, true)
+	if err != nil {
+		t.Fatalf("prepareToolCommand returned error: %v", err)
+	}
+
+	if err := cmd.Run(); err != nil {
+		cleanup()
+		t.Fatalf("cmd.Run returned error: %v", err)
+	}
+	cleanup()
+
+	if sweeps == 0 {
+		t.Fatal("expected nonce-based descendant sweep for detached child, got 0 sweeps")
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	found, _ := exec.Command("pgrep", "-f", sentinel).Output()
+	if stray := strings.TrimSpace(string(found)); stray != "" {
+		_ = exec.Command("pkill", "-f", sentinel).Run()
+		t.Fatalf("detached sentinel process still alive after cleanup: %q", stray)
 	}
 }

--- a/internal/tools/run_agent_script.go
+++ b/internal/tools/run_agent_script.go
@@ -169,7 +169,7 @@ func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 	cmd := exec.CommandContext(execCtx, realScript, argv...)
 	cmd.Dir = workDir
 
-	cleanup, prepErr := prepareToolCommand(cmd)
+	cleanup, prepErr := prepareToolCommand(cmd, true)
 	if prepErr != nil {
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script setup error: %v", prepErr))), nil
 	}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -237,7 +237,7 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	cleanup, prepErr := prepareToolCommand(cmd)
+	cleanup, prepErr := prepareToolCommand(cmd, hasUnsafeShellSyntax(a.Command))
 	if prepErr != nil {
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "command setup error: %v", prepErr))), nil
 	}


### PR DESCRIPTION
## What changed

- Added a `sweepTaggedDescendantsOnSuccess` policy knob to `prepareToolCommand`.
- The shell tool now only keeps the old always-scan behavior for commands that actually use shell operators (`&`, pipes, redirects, subshells, etc.).
- Simple foreground shell commands like `pwd`, `ls`, and `git status` now skip the nonce-based `/proc` walk on normal success.
- Timeouts/cancellations still force the nonce-based reap, and custom tools / run-agent scripts keep the existing always-sweep behavior.
- Added tests that pin down both sides of the behavior:
  - a foreground command no longer triggers the tagged descendant sweep
  - a detached `setsid` child still gets reaped when the caller opts into the always-sweep path

## Why this is high-value

The shell tool is one of the hottest paths in term-llm. Before this change, every successful shell invocation paid for a full `/proc` scan and `/proc/<pid>/environ` reads just to confirm there was nothing to reap.

That work is O(number of processes on the host), adds avoidable I/O and cache churn, and can dominate trivial commands. Skipping that scan for normal foreground shell commands removes the expensive teardown work from the common case while preserving the stricter cleanup path for cancellations and shell commands that are actually likely to create background descendants.

## Validation

- `gofmt -w internal/tools/exec_helpers.go internal/tools/exec_helpers_test.go internal/tools/shell.go internal/tools/custom_tool.go internal/tools/run_agent_script.go`
- `go build ./...`
- `go test ./...`
- Added focused tests in `internal/tools/exec_helpers_test.go` covering:
  - no tagged sweep for a simple foreground command
  - tagged sweep still occurring for a detached `setsid` child when always-sweep mode is enabled
