### PR TITLE
fix: keep web sidebar scroll stable

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -164,6 +164,7 @@ installUIVersionFetchGuard();
 const elements = {
   appShell: document.getElementById('appShell'),
   sidebar: document.getElementById('sidebar'),
+  sidebarContent: document.getElementById('sidebarContent'),
   sidebarBackdrop: document.getElementById('sidebarBackdrop'),
   sidebarToggleBtn: document.getElementById('sidebarToggleBtn'),
   sidebarPanelToggleBtn: document.getElementById('sidebarPanelToggleBtn'),

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -142,6 +142,29 @@ const sidebarRowCache = new Map();
 const sidebarGroupCache = new Map();
 let sidebarRenderKey = '';
 
+const sidebarScrollContainer = () => elements.sidebarContent || elements.sessionGroups?.parentElement || null;
+
+const restoreSidebarScroll = (scroller, scrollTop) => {
+  if (!scroller || !Number.isFinite(scrollTop)) return;
+  if (scroller.scrollTop !== scrollTop) scroller.scrollTop = scrollTop;
+};
+
+const preserveSidebarScroll = (callback) => {
+  const scroller = sidebarScrollContainer();
+  const scrollTop = scroller && Number.isFinite(scroller.scrollTop) ? scroller.scrollTop : null;
+  const result = callback();
+  if (scrollTop !== null) {
+    restoreSidebarScroll(scroller, scrollTop);
+    // Browsers may apply focus/scroll anchoring adjustments after DOM mutation.
+    // Put the sidebar back once more on the next frame so session switches do
+    // not unexpectedly jump the list.
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => restoreSidebarScroll(scroller, scrollTop));
+    }
+  }
+  return result;
+};
+
 const computeSidebarKey = (sorted) =>
   sorted.map((s) =>
     [
@@ -200,6 +223,9 @@ const buildCachedSessionRow = (session) => {
 
   btn.appendChild(titleEl);
   btn.appendChild(metaEl);
+  btn.addEventListener('mousedown', (event) => {
+    if (event.button === 0) event.preventDefault();
+  });
   btn.addEventListener('click', async () => {
     await app.switchToSession(sessionId);
   });
@@ -356,33 +382,35 @@ const renderSidebar = () => {
   const newGroupSections = [];
   const visibleIds = new Set();
 
-  Object.entries(grouped).forEach(([label, sessions]) => {
-    if (!sessions.length) return;
+  preserveSidebarScroll(() => {
+    Object.entries(grouped).forEach(([label, sessions]) => {
+      if (!sessions.length) return;
 
-    const groupEl = getOrCreateGroupSection(label);
-    // Detach all session rows from this group section, keeping only the h3 heading.
-    groupEl.replaceChildren(groupEl.firstElementChild);
+      const groupEl = getOrCreateGroupSection(label);
+      // Detach all session rows from this group section, keeping only the h3 heading.
+      groupEl.replaceChildren(groupEl.firstElementChild);
 
-    sessions.forEach((session) => {
-      visibleIds.add(session.id);
-      const cached = sidebarRowCache.get(session.id);
-      if (cached) {
-        updateCachedSessionRow(session, cached);
-        groupEl.appendChild(cached.row);
-      } else {
-        groupEl.appendChild(buildCachedSessionRow(session));
-      }
+      sessions.forEach((session) => {
+        visibleIds.add(session.id);
+        const cached = sidebarRowCache.get(session.id);
+        if (cached) {
+          updateCachedSessionRow(session, cached);
+          groupEl.appendChild(cached.row);
+        } else {
+          groupEl.appendChild(buildCachedSessionRow(session));
+        }
+      });
+
+      newGroupSections.push(groupEl);
     });
 
-    newGroupSections.push(groupEl);
+    elements.sessionGroups.replaceChildren(...newGroupSections);
+
+    // Prune cache entries for sessions no longer visible.
+    for (const id of sidebarRowCache.keys()) {
+      if (!visibleIds.has(id)) sidebarRowCache.delete(id);
+    }
   });
-
-  elements.sessionGroups.replaceChildren(...newGroupSections);
-
-  // Prune cache entries for sessions no longer visible.
-  for (const id of sidebarRowCache.keys()) {
-    if (!visibleIds.has(id)) sidebarRowCache.delete(id);
-  }
 };
 
 // ===== Message rendering =====

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -325,6 +325,7 @@
       display: flex;
       flex-direction: column;
       overflow-y: auto;
+      overflow-anchor: none;
       padding: 0.45rem 0 0.75rem;
     }
 

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -282,6 +282,10 @@ function createHarness(appOverrides = {}) {
   const document = createDocument();
   const messages = new Element('div');
   document.body.appendChild(messages);
+  const sidebarContent = new Element('div');
+  sidebarContent.scrollTop = 0;
+  const sessionGroups = new Element('div');
+  sidebarContent.appendChild(sessionGroups);
   const session = { id: 's1', title: 'Chat', created: Date.now(), messages: [] };
   const state = { activeSessionId: 's1', sessions: [session], sidebarCollapsed: false };
   const timers = [];
@@ -306,7 +310,8 @@ function createHarness(appOverrides = {}) {
       widgetsModalList: new Element('div'),
       widgetsModalCloseBtn: new Element('button'),
       sidebarSearchInput: new Element('input'),
-      sessionGroups: new Element('div'),
+      sidebarContent,
+      sessionGroups,
     },
     INTERRUPT_BADGE_META: {},
     sanitizeInterruptState(value) { return value || ''; },
@@ -1059,6 +1064,42 @@ async function run(name, fn) {
 
     assert(!rows[0].querySelector('.session-btn').classList.contains('active'), 'session A btn no longer active');
     assert(rows[1].querySelector('.session-btn').classList.contains('active'), 'session B btn now active');
+  });
+
+  await run('renderSidebar preserves sidebar scroll through rerenders', () => {
+    const sessions = [
+      { id: 'a', title: 'A', created: 2000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 2000 },
+      { id: 'b', title: 'B', created: 1000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 1000 },
+    ];
+    const { app, timers } = createHarness({ visibleSessions: () => sessions });
+    app.elements.sidebarContent.scrollTop = 420;
+
+    app.renderSidebar();
+    sessions[1].title = 'B changed';
+    app.renderSidebar();
+
+    assertEqual(app.elements.sidebarContent.scrollTop, 420, 'scrollTop restored immediately');
+    app.elements.sidebarContent.scrollTop = 99;
+    runAllPendingTimers(timers);
+    assertEqual(app.elements.sidebarContent.scrollTop, 420, 'scrollTop restored again on animation frame');
+  });
+
+  await run('session row mouse activation does not focus-scroll the sidebar button', async () => {
+    const session = { id: 'a', title: 'A', created: 1000, messages: [], pinned: false, archived: false, messageCount: 0, lastMessageAt: 1000 };
+    let switchedTo = '';
+    const { app } = createHarness({
+      visibleSessions: () => [session],
+      async switchToSession(id) { switchedTo = id; },
+    });
+
+    app.renderSidebar();
+    const btn = app.elements.sessionGroups.querySelector('.session-btn');
+    let prevented = false;
+    await btn.dispatchEvent({ type: 'mousedown', button: 0, preventDefault() { prevented = true; } });
+    await btn.dispatchEvent({ type: 'click' });
+
+    assert(prevented, 'primary mouse down prevents browser focus scrolling');
+    assertEqual(switchedTo, 'a', 'click still switches sessions');
   });
 
   await run('renderSidebar marks in-progress session row with is-active', () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -161,7 +161,7 @@
             <button class="icon-btn sidebar-close" id="sidebarCloseBtn" title="Close sidebar" aria-label="Close sidebar">✕</button>
           </div>
         </div>
-        <div class="sidebar-content">
+        <div class="sidebar-content" id="sidebarContent">
           <div class="sidebar-actions">
             <button class="new-chat-btn" id="newChatBtn" type="button">
               <svg class="sidebar-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
## What

- Preserve the web sidebar scroll position while the session list rerenders/reorders.
- Disable browser scroll anchoring for the sidebar scroller.
- Prevent mouse activation of session rows from focusing the row button, which can trigger browser focus-scroll during the subsequent session switch.

## Why

Clicking a conversation in a long sidebar should not make the whole sidebar jump. The active-row update, status sync, or list reorder can currently mutate the sidebar DOM just after the click, and the browser may helpfully-but-not-helpfully adjust the scroll position.

## Tests

- `mise exec -- node internal/serveui/static/app_render_test.js`
- `mise exec -- go test ./internal/serveui`
- `go build ./...`
- `mise exec -- go test ./...`
- `go vet ./...`
