### PR TITLE
fix: keep active sidebar session messages cached

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1172,15 +1172,31 @@ const loadSessions = () => {
   return [];
 };
 
-// Evict messages from in-memory sessions beyond the 10 most-recently-created
-// to cap RAM usage.  Evicted sessions become lazy-load stubs.
+// Evict messages from in-memory sessions beyond the 10 most-recently-used
+// message-bearing sessions to cap RAM usage. Always keep the active session's
+// messages so a lazy-loaded older sidebar entry does not go blank immediately
+// after switchToSession() saves state.
 const MAX_CACHED_MESSAGE_SESSIONS = 10;
 
 const evictStaleSessionMessages = () => {
   const withMessages = state.sessions.filter(s => s.messages && s.messages.length > 0 && !s._serverOnly);
   if (withMessages.length <= MAX_CACHED_MESSAGE_SESSIONS) return;
-  withMessages.sort((a, b) => b.created - a.created);
-  const keep = new Set(withMessages.slice(0, MAX_CACHED_MESSAGE_SESSIONS).map(s => s.id));
+
+  const keep = new Set();
+  const activeSessionId = String(state.activeSessionId || '').trim();
+  if (activeSessionId && withMessages.some(s => s.id === activeSessionId)) {
+    keep.add(activeSessionId);
+  }
+
+  withMessages.sort((a, b) => {
+    const bAt = Number(b.lastMessageAt || b.created || 0);
+    const aAt = Number(a.lastMessageAt || a.created || 0);
+    return bAt - aAt;
+  });
+  for (const session of withMessages) {
+    if (keep.size >= MAX_CACHED_MESSAGE_SESSIONS) break;
+    keep.add(session.id);
+  }
 
   for (const s of state.sessions) {
     if (!keep.has(s.id) && s.messages && s.messages.length > 0) {

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -673,6 +673,55 @@ const app = loadAppCore();
   pass(name);
 })();
 
+(function testMessageEvictionKeepsActiveOlderSession() {
+  const name = 'message eviction keeps active older session loaded';
+  const testApp = loadAppCore();
+  testApp.state.sessions = Array.from({ length: 11 }, (_, index) => ({
+    id: `s${index + 1}`,
+    title: `Session ${index + 1}`,
+    created: 1000 + index,
+    lastMessageAt: 1000 + index,
+    messages: [{ id: `m${index + 1}`, role: 'user', content: 'hi', created: 1000 + index }],
+  }));
+  testApp.state.activeSessionId = 's1';
+
+  testApp.saveSessions();
+
+  const active = testApp.state.sessions.find((session) => session.id === 's1');
+  if (!active || active._serverOnly || active.messages.length !== 1) {
+    fail(name, 'active older session was evicted and would render blank');
+    return;
+  }
+  const loaded = testApp.state.sessions.filter((session) => session.messages.length > 0 && !session._serverOnly);
+  if (loaded.length !== 10) {
+    fail(name, `expected exactly 10 loaded sessions, got ${loaded.length}`);
+    return;
+  }
+  pass(name);
+})();
+
+(function testMessageEvictionUsesRecentActivity() {
+  const name = 'message eviction prefers recent activity over creation time';
+  const testApp = loadAppCore();
+  testApp.state.sessions = Array.from({ length: 11 }, (_, index) => ({
+    id: `s${index + 1}`,
+    title: `Session ${index + 1}`,
+    created: 1000 + index,
+    lastMessageAt: 1000 + index,
+    messages: [{ id: `m${index + 1}`, role: 'user', content: 'hi', created: 1000 + index }],
+  }));
+  testApp.state.sessions[0].lastMessageAt = 10_000;
+
+  testApp.saveSessions();
+
+  const recentlyActive = testApp.state.sessions[0];
+  if (recentlyActive._serverOnly || recentlyActive.messages.length !== 1) {
+    fail(name, 'recently active older-created session was evicted');
+    return;
+  }
+  pass(name);
+})();
+
 if (failures > 0) {
   process.exit(1);
 }


### PR DESCRIPTION
## What

Fix the web sidebar message-cache eviction so the active session is never evicted when the UI caps cached message histories at 10 sessions.

Also prefer `lastMessageAt` over creation time when choosing which non-active sessions stay cached.

## Why

Repro from Sam: click sidebar sessions 1, 2, 3, ... 10, then click session 11. If session 11 sits below the first 10 entries, it opens blank.

The lazy-load path hydrated session 11, then `saveSessions()` immediately evicted its messages because eviction kept the 10 newest-created sessions, not the active session. The render after hydration then had an active `_serverOnly` stub with no messages. Tiny little footgun; very committed to being exactly off-by-one adjacent.

## Tests

- `mise exec node@24.15.0 -- node internal/serveui/static/app_core_test.js`
- all `internal/serveui/static/*_test.js` via `mise exec node@24.15.0 -- node`
- `go build ./...`
- `go test ./internal/tools` passes
- `go test ./...` mostly passed, with one transient failure in `internal/tools` (`TestRunAgentScriptTool_TimeoutKillsGrandchildren`) that passed on direct rerun
