### PR TITLE
fix: ask persists every assistant turn twice because both engine callbacks append it

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -146,6 +146,13 @@ func init() {
 	rootCmd.AddCommand(askCmd)
 }
 
+func askTurnMessagesAfterResponseCapture(assistantCaptured bool, turnMessages []llm.Message) []llm.Message {
+	if assistantCaptured && len(turnMessages) > 0 && turnMessages[0].Role == llm.RoleAssistant {
+		return turnMessages[1:]
+	}
+	return turnMessages
+}
+
 func runAsk(cmd *cobra.Command, args []string) error {
 	// Extract @agent from args if present
 	atAgent, filteredArgs := ExtractAgentFromArgs(args)
@@ -637,22 +644,46 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	responseCompletedCallback := persistResponseCompleted
-	turnCompletedCallback := persistTurnCompleted
-	if outputTool != nil {
+	var assistantCapturedForTurnMu sync.Mutex
+	assistantCapturedForTurnCB := false
+	markAssistantCapturedForTurn := func() {
+		assistantCapturedForTurnMu.Lock()
+		assistantCapturedForTurnCB = true
+		assistantCapturedForTurnMu.Unlock()
+	}
+	consumeTurnMessages := func(turnMessages []llm.Message) []llm.Message {
+		assistantCapturedForTurnMu.Lock()
+		defer assistantCapturedForTurnMu.Unlock()
+		deduped := askTurnMessagesAfterResponseCapture(assistantCapturedForTurnCB, turnMessages)
+		assistantCapturedForTurnCB = false
+		return deduped
+	}
+
+	var responseCompletedCallback llm.ResponseCompletedCallback
+	if persistResponseCompleted != nil || outputTool != nil {
 		responseCompletedCallback = func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
-			outputToolMessagesMu.Lock()
-			outputToolMessages = append(outputToolMessages, assistantMsg)
-			outputToolMessagesMu.Unlock()
+			markAssistantCapturedForTurn()
+			if outputTool != nil {
+				outputToolMessagesMu.Lock()
+				outputToolMessages = append(outputToolMessages, assistantMsg)
+				outputToolMessagesMu.Unlock()
+			}
 			if persistResponseCompleted != nil {
 				return persistResponseCompleted(ctx, turnIndex, assistantMsg, metrics)
 			}
 			return nil
 		}
+	}
+
+	var turnCompletedCallback llm.TurnCompletedCallback
+	if persistTurnCompleted != nil || outputTool != nil {
 		turnCompletedCallback = func(ctx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
-			outputToolMessagesMu.Lock()
-			outputToolMessages = append(outputToolMessages, turnMessages...)
-			outputToolMessagesMu.Unlock()
+			turnMessages = consumeTurnMessages(turnMessages)
+			if outputTool != nil {
+				outputToolMessagesMu.Lock()
+				outputToolMessages = append(outputToolMessages, turnMessages...)
+				outputToolMessagesMu.Unlock()
+			}
 			if persistTurnCompleted != nil {
 				return persistTurnCompleted(ctx, turnIndex, turnMessages, metrics)
 			}

--- a/cmd/ask_persistence_test.go
+++ b/cmd/ask_persistence_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func TestAskTurnMessagesAfterResponseCaptureSkipsLeadingAssistant(t *testing.T) {
+	turnMessages := []llm.Message{
+		llm.AssistantText("draft"),
+		{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartText, Text: "tool result"}}},
+	}
+
+	got := askTurnMessagesAfterResponseCapture(true, turnMessages)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Role != llm.RoleTool {
+		t.Fatalf("got[0].Role = %q, want %q", got[0].Role, llm.RoleTool)
+	}
+}
+
+func TestAskTurnMessagesAfterResponseCaptureKeepsToolOnlyTurn(t *testing.T) {
+	turnMessages := []llm.Message{
+		{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartText, Text: "tool result"}}},
+	}
+
+	got := askTurnMessagesAfterResponseCapture(true, turnMessages)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Role != llm.RoleTool {
+		t.Fatalf("got[0].Role = %q, want %q", got[0].Role, llm.RoleTool)
+	}
+}
+
+func TestAskTurnMessagesAfterResponseCaptureKeepsAssistantWithoutResponseCallback(t *testing.T) {
+	turnMessages := []llm.Message{
+		llm.AssistantText("final answer"),
+	}
+
+	got := askTurnMessagesAfterResponseCapture(false, turnMessages)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Role != llm.RoleAssistant {
+		t.Fatalf("got[0].Role = %q, want %q", got[0].Role, llm.RoleAssistant)
+	}
+}


### PR DESCRIPTION
## What changed

- Fixed `cmd/ask.go` so the assistant message captured by `SetResponseCompletedCallback` is not appended again when `SetTurnCompletedCallback` receives the same assistant message as the first turn message.
- Applied the same dedupe rule to `outputToolMessages`, so output-tool finalization sees one assistant turn instead of two.
- Added focused tests for the helper that decides when the leading assistant message should be skipped.

## Why this is high-value

`ask` is a primary entrypoint, and persisted sessions were recording every assistant turn twice whenever both engine callbacks fired in the same run. That corrupts resumed history, exported transcripts, memory-mining inputs, and output-tool finalization context. This fix removes a user-visible transcript corruption bug with a very small, low-risk change.

## Validation

- Verified the overlap is real in current code by inspecting `cmd/ask.go` and comparing it with the existing dedupe logic in `internal/serve/telegram.go` and `cmd/serve_runtime.go`.
- `gofmt -w cmd/ask.go cmd/ask_persistence_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
