### PR TITLE
fix: session Update clobbers user_turns from stale in-memory structs

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1159,9 +1159,9 @@ func (s *SQLiteStore) GetByPrefix(ctx context.Context, prefix string) (*Session,
 
 // Update modifies an existing session's metadata fields.
 // Token metrics (input_tokens, cached_input_tokens, cache_write_tokens, output_tokens)
-// and turn counters (llm_turns, tool_calls) are intentionally excluded — they are
-// managed exclusively by UpdateMetrics (which uses atomic increments) to prevent
-// stale in-memory values from clobbering accumulated totals.
+// and turn counters (user_turns, llm_turns, tool_calls) are intentionally excluded — they are
+// managed exclusively by atomic update paths to prevent stale in-memory values from clobbering
+// accumulated totals.
 func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	sess.UpdatedAt = time.Now()
 	if sess.Origin == "" {
@@ -1179,9 +1179,9 @@ func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 	query := `
 		UPDATE sessions SET name = ?, summary = ?, generated_short_title = ?, generated_long_title = ?, title_source = ?, title_generated_at = ?, title_basis_msg_seq = ?` +
 		titleSkippedAtClause + `,
-		       provider = ?, provider_key = ?, model = ?` + reasoningEffortClause + `, mode = ?, origin = ?, agent = ?, cwd = ?,
-		       updated_at = ?, archived = ?, pinned = ?, parent_id = ?, search = ?, tools = ?, mcp = ?,
-		       user_turns = ?, status = ?, tags = ?
+			       provider = ?, provider_key = ?, model = ?` + reasoningEffortClause + `, mode = ?, origin = ?, agent = ?, cwd = ?,
+			       updated_at = ?, archived = ?, pinned = ?, parent_id = ?, search = ?, tools = ?, mcp = ?,
+			       status = ?, tags = ?
 		WHERE id = ?`
 
 	args := []any{
@@ -1200,7 +1200,7 @@ func (s *SQLiteStore) Update(ctx context.Context, sess *Session) error {
 		string(sess.Mode), nullString(string(sess.Origin)), nullString(sess.Agent), sess.CWD,
 		sess.UpdatedAt, sess.Archived, sess.Pinned, nullString(sess.ParentID),
 		sess.Search, nullString(sess.Tools), nullString(sess.MCP),
-		sess.UserTurns, string(sess.Status), nullString(sess.Tags), sess.ID,
+		string(sess.Status), nullString(sess.Tags), sess.ID,
 	)
 
 	result, err := s.db.ExecContext(ctx, query, args...)

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -1240,6 +1240,48 @@ func TestUpdateDoesNotClobberTokenMetrics(t *testing.T) {
 	}
 }
 
+func TestUpdateDoesNotClobberUserTurns(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{
+		ID:       NewID(),
+		Provider: "test",
+		Model:    "test-model",
+		Mode:     ModeChat,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatalf("IncrementUserTurns: %v", err)
+	}
+
+	// The in-memory sess still has zero user turns — Update must not write that stale value back.
+	sess.Summary = "updated summary"
+	if err := store.Update(ctx, sess); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	reloaded, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if reloaded.Summary != "updated summary" {
+		t.Errorf("expected summary=%q, got %q", "updated summary", reloaded.Summary)
+	}
+	if reloaded.UserTurns != 1 {
+		t.Errorf("Update clobbered user_turns: expected 1, got %d", reloaded.UserTurns)
+	}
+}
+
 func TestSQLiteStoreCreatesMessagesSessionRoleIndex(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- Removed `user_turns` from `SQLiteStore.Update` so metadata-only updates no longer write a caller-supplied turn count back into `sessions`.
- Updated the method comment to treat `user_turns` like the other counters that must be mutated through atomic store paths.
- Added `TestUpdateDoesNotClobberUserTurns` to cover the failure mode where `IncrementUserTurns` is followed by `Update` on a stale in-memory session struct.

## Why this is high-value

`user_turns` is a durable counter used for user-visible state and downstream logic. In the current code, `IncrementUserTurns` atomically increments the database value, but a later `Update` call can overwrite that increment with a stale in-memory value. The Telegram path already does exactly that when it increments the counter and then persists the first-message summary without first updating `sess.meta.UserTurns`. This fix removes the clobber path entirely and keeps turn-count mutations on the atomic update path.

## Validation

- Verified the issue is real in current code by inspecting `internal/session/sqlite.go` and the Telegram call path in `internal/serve/telegram.go`.
- Added and ran targeted tests:
  - `go test ./internal/session -run 'TestUpdateDoesNotClobber(TokenMetrics|UserTurns)$'`
- Ran full validation:
  - `go build ./...`
  - `go test ./...`
- Ran diff hygiene checks:
  - `git diff --check`
