### PR TITLE
fix: Telegram stream watchdog can leak a blocked Recv goroutine on timeout/error paths

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1140,6 +1140,12 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 	}
 }
 
+func sendStreamDone(done chan<- error, once *sync.Once, err error) {
+	once.Do(func() {
+		done <- err
+	})
+}
+
 // streamReply streams an LLM response back to the chat via live message editing.
 func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, sess *telegramSession, chatID int64, userMsg llm.Message) error {
 	// We acquire the session lock for the entire streaming call so that
@@ -1355,6 +1361,7 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		otherEvents      int
 		otherTypes       = make(map[llm.EventType]int)
 		streamDone       = make(chan error, 1)
+		streamDoneOnce   sync.Once
 		lastEventPing    = make(chan struct{}, 1)
 		watchdogTimedOut atomic.Bool
 	)
@@ -1380,10 +1387,7 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 				t.Reset(watchdogTimeout)
 			case <-t.C:
 				watchdogTimedOut.Store(true)
-				select {
-				case streamDone <- fmt.Errorf("stream timed out: no events for %s", watchdogTimeout):
-				default:
-				}
+				sendStreamDone(streamDone, &streamDoneOnce, fmt.Errorf("stream timed out: no events for %s", watchdogTimeout))
 				streamCancel()
 				return
 			case <-streamCtx.Done():
@@ -1397,11 +1401,11 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		for {
 			ev, recvErr := stream.Recv()
 			if recvErr == io.EOF {
-				streamDone <- nil
+				sendStreamDone(streamDone, &streamDoneOnce, nil)
 				return
 			}
 			if recvErr != nil {
-				streamDone <- recvErr
+				sendStreamDone(streamDone, &streamDoneOnce, recvErr)
 				return
 			}
 			select {
@@ -1478,7 +1482,7 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 				errorEvents++
 				textMu.Unlock()
 				if ev.Err != nil {
-					streamDone <- ev.Err
+					sendStreamDone(streamDone, &streamDoneOnce, ev.Err)
 					return
 				}
 			default:

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -244,6 +244,35 @@ func newTestMgrAndSession(h *testutil.EngineHarness) (*telegramSessionMgr, *tele
 	return mgr, sess
 }
 
+func TestSendStreamDone_OnlyFirstCompletionSends(t *testing.T) {
+	done := make(chan error, 1)
+	var once sync.Once
+	firstErr := errors.New("first")
+
+	sendStreamDone(done, &once, firstErr)
+
+	returned := make(chan struct{})
+	go func() {
+		sendStreamDone(done, &once, errors.New("second"))
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("second completion send blocked")
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, firstErr) {
+			t.Fatalf("done error = %v, want %v", err, firstErr)
+		}
+	default:
+		t.Fatal("expected first completion to be sent")
+	}
+}
+
 func TestTelegramSessionMgrNewFastProvider_ReturnsFreshProviderEachTime(t *testing.T) {
 	mgr := &telegramSessionMgr{
 		cfg: &config.Config{


### PR DESCRIPTION
## What changed

- Added a `sendStreamDone` helper guarded by `sync.Once` so the Telegram stream watchdog and stream consumer can only publish one terminal result to `streamDone`.
- Switched the watchdog timeout path, `Recv` EOF/error path, and `EventError` path to use that single-completion helper.
- Added a focused regression test that verifies a second completion attempt returns immediately instead of blocking behind the first buffered send.

## Why this is high-value

`streamReply` had multiple concurrent producers writing to a single buffered `streamDone` channel. If one producer filled the channel and `streamReply` returned on another path before draining it, a later blocking send from the stream consumer goroutine could hang forever. In a long-running Telegram bot, repeated stalled or timing-out streams could accumulate leaked goroutines and retained stream state.

This fix is small, low-risk, and directly removes that class of goroutine leak without changing the surrounding stream behavior.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
