### PR TITLE
fix: Concurrent Telegram session creation persists orphan sessions and can clobber current_session

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -518,6 +518,7 @@ func (m *telegramSessionMgr) getOrCreate(ctx context.Context, chatID int64) (*te
 		return existing, nil
 	}
 	m.sessions[chatID] = created
+	m.persistSession(ctx, created)
 	m.mu.Unlock()
 	return created, nil
 }
@@ -541,6 +542,7 @@ func (m *telegramSessionMgr) resetSessionIfCurrent(ctx context.Context, chatID i
 		return current, false, nil
 	}
 	m.sessions[chatID] = created
+	m.persistSession(ctx, created)
 	m.mu.Unlock()
 
 	if current != nil {
@@ -792,19 +794,25 @@ func (m *telegramSessionMgr) newSession(ctx context.Context, chatID int64) (*tel
 	}
 
 	if m.store != nil {
-		m.runStoreOp(ctx, meta.ID, "Create", func(storeCtx context.Context) error {
-			return m.store.Create(storeCtx, meta)
-		})
-		m.runStoreOp(ctx, meta.ID, "SetCurrent", func(storeCtx context.Context) error {
-			return m.store.SetCurrent(storeCtx, meta.ID)
-		})
-	}
-
-	if m.store != nil {
 		m.restoreHistoryFromDB(ctx, chatID, sess)
 	}
 
 	return sess, nil
+}
+
+// persistSession writes the already-published session metadata while the caller
+// still holds m.mu, so a replacement for the same chat cannot race in and
+// clobber current_session with a discarded runtime.
+func (m *telegramSessionMgr) persistSession(ctx context.Context, sess *telegramSession) {
+	if m.store == nil || sess == nil || sess.meta == nil {
+		return
+	}
+	m.runStoreOp(ctx, sess.meta.ID, "Create", func(storeCtx context.Context) error {
+		return m.store.Create(storeCtx, sess.meta)
+	})
+	m.runStoreOp(ctx, sess.meta.ID, "SetCurrent", func(storeCtx context.Context) error {
+		return m.store.SetCurrent(storeCtx, sess.meta.ID)
+	})
 }
 
 func (m *telegramSessionMgr) closeAllSessions() {

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1023,11 +1023,118 @@ func TestTelegramSessionMgrGetOrCreate_DoesNotBlockOtherChatsWhileCreating(t *te
 	}
 }
 
+func TestTelegramSessionMgrGetOrCreate_PersistsOnlyWinningConcurrentSession(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telegram-concurrent-create.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer store.Close()
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	results := make(chan struct {
+		sess *telegramSession
+		err  error
+	}, 2)
+	var cleanupCalls atomic.Int32
+
+	mgr := &telegramSessionMgr{
+		sessions: make(map[int64]*telegramSession),
+		store:    store,
+		settings: Settings{
+			Store: store,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				started <- struct{}{}
+				<-release
+				return &SessionRuntime{
+					ProviderName: "mock",
+					ModelName:    "model",
+					Cleanup: func() {
+						cleanupCalls.Add(1)
+					},
+				}, nil
+			},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		go func() {
+			sess, err := mgr.getOrCreate(context.Background(), 42)
+			results <- struct {
+				sess *telegramSession
+				err  error
+			}{sess: sess, err: err}
+		}()
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("NewSession call %d did not start", i+1)
+		}
+	}
+
+	close(release)
+
+	var first *telegramSession
+	for i := 0; i < 2; i++ {
+		select {
+		case result := <-results:
+			if result.err != nil {
+				t.Fatalf("getOrCreate returned error: %v", result.err)
+			}
+			if first == nil {
+				first = result.sess
+				continue
+			}
+			if result.sess != first {
+				t.Fatal("concurrent getOrCreate returned different sessions for the same chat")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent getOrCreate results")
+		}
+	}
+
+	if cleanupCalls.Load() != 1 {
+		t.Fatalf("cleanup calls = %d, want 1 for the discarded duplicate runtime", cleanupCalls.Load())
+	}
+
+	sessions, err := store.List(context.Background(), session.ListOptions{Name: "telegram:42", Limit: 10})
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("persisted session count = %d, want 1", len(sessions))
+	}
+
+	current, err := store.GetCurrent(context.Background())
+	if err != nil {
+		t.Fatalf("GetCurrent failed: %v", err)
+	}
+	if current == nil {
+		t.Fatal("expected current session to be set")
+	}
+	if current.ID != first.meta.ID {
+		t.Fatalf("current session ID = %s, want %s", current.ID, first.meta.ID)
+	}
+}
+
 func TestTelegramSessionMgrResetSessionIfCurrent_RejectsStaleExpectedSession(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telegram-reset-stale.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer store.Close()
+
 	var cleanupCalls atomic.Int32
 	mgr := &telegramSessionMgr{
 		sessions: make(map[int64]*telegramSession),
+		store:    store,
 		settings: Settings{
+			Store: store,
 			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
 				return &SessionRuntime{
 					ProviderName: "mock",
@@ -1068,6 +1175,25 @@ func TestTelegramSessionMgrResetSessionIfCurrent_RejectsStaleExpectedSession(t *
 	}
 	if cleanupCalls.Load() != 2 {
 		t.Fatalf("cleanup calls = %d, want 2 (original closed + stale duplicate closed)", cleanupCalls.Load())
+	}
+
+	sessions, err := store.List(context.Background(), session.ListOptions{Name: "telegram:42", Limit: 10})
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("persisted session count = %d, want 2 (original + replacement)", len(sessions))
+	}
+
+	current, err := store.GetCurrent(context.Background())
+	if err != nil {
+		t.Fatalf("GetCurrent failed: %v", err)
+	}
+	if current == nil {
+		t.Fatal("expected current session to be set")
+	}
+	if current.ID != replacement.meta.ID {
+		t.Fatalf("current session ID = %s, want %s", current.ID, replacement.meta.ID)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Stopped `telegramSessionMgr.newSession` from eagerly persisting a Telegram session before it has actually won publication in `m.sessions`.
- Added a small `persistSession` helper and now call it only after the session has been installed as the active runtime for that chat.
- Kept that persistence step under `m.mu` so a same-chat reset cannot race in between publication and `SetCurrent`, which would otherwise let a discarded runtime clobber `metadata.current_session` again.
- Added regression coverage for:
  - concurrent `getOrCreate` on the same chat only persisting the winning session, and
  - stale `resetSessionIfCurrent` calls not leaving behind an extra persisted row or changing the current-session marker.

## Why this is high-value

Telegram updates are handled concurrently, so two quick messages from the same chat can overlap session creation. Before this change, each contender eagerly wrote a fresh `telegram:<chatID>` row and set `current_session` before the winner was known. The losing runtime was closed in memory, but its persisted row remained, and `current_session` could point at that discarded session.

That is a real reliability bug because it fragments persisted chat history, breaks current-session semantics, and can interfere with carryover restore logic that only scans a small recent window of sessions for the chat.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./...`
- Added targeted regression tests in `internal/serve/telegram_test.go` covering the concurrent creation and stale reset failure modes.
