### PR TITLE
feat: multi-agent gateway with separate-origin widget host (experimental)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ term-llm
 .cache/*
 .gocache/*
 *.lock
+.DS_Store

--- a/cmd/contain.go
+++ b/cmd/contain.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -153,6 +152,41 @@ var containLsCmd = &cobra.Command{
 			return err
 		}
 		return contain.PrintList(entries, cmd.OutOrStdout())
+	},
+}
+
+var containPortCmd = &cobra.Command{
+	Use:               "port <name>",
+	Short:             "Print the web UI port for a contain workspace",
+	Long:              "Print the web UI host port for a contain workspace, read from its .env (WEB_PORT). Defaults to 8081 when unset. Intended for tooling such as a multi-agent gateway that discovers an agent's serve without parsing the 0600 .env directly.",
+	Args:              requireContainNameArg,
+	ValidArgsFunction: containWorkspaceNameCompletion,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		web, err := contain.ReadWebConfig(args[0])
+		if err != nil {
+			return fmt.Errorf("read web config for %q: %w", args[0], err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), web.Port)
+		return nil
+	},
+}
+
+var containTokenCmd = &cobra.Command{
+	Use:               "token <name>",
+	Short:             "Print the web UI bearer token for a contain workspace",
+	Long:              "Print the web UI bearer token for a contain workspace, read from its .env (WEB_TOKEN). Errors when no token is provisioned. Intended for tooling such as a multi-agent gateway that injects the per-agent token server-side.",
+	Args:              requireContainNameArg,
+	ValidArgsFunction: containWorkspaceNameCompletion,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		web, err := contain.ReadWebConfig(args[0])
+		if err != nil {
+			return fmt.Errorf("read web config for %q: %w", args[0], err)
+		}
+		if web.Token == "" {
+			return fmt.Errorf("no web token configured for %q (set WEB_TOKEN in its .env)", args[0])
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), web.Token)
+		return nil
 	},
 }
 
@@ -359,32 +393,15 @@ func parseContainSetFlags(values []string) (map[string]string, error) {
 }
 
 func printContainWebUIInfo(cmd *cobra.Command, name string) {
-	dir, err := contain.ContainerDir(name)
+	web, err := contain.ReadWebConfig(name)
 	if err != nil {
 		return
 	}
-	envPath := filepath.Join(dir, ".env")
-	values, err := readContainEnvFile(envPath)
-	if err != nil {
+	if web.Token == "" {
 		return
 	}
-	token := strings.TrimSpace(values["WEB_TOKEN"])
-	if token == "" || strings.Contains(token, "{{") {
-		return
-	}
-	port := strings.TrimSpace(values["WEB_PORT"])
-	if port == "" || strings.Contains(port, "{{") {
-		port = "8081"
-	}
-	basePath := strings.TrimSpace(values["WEB_BASE_PATH"])
-	if basePath == "" || strings.Contains(basePath, "{{") {
-		basePath = "/chat"
-	}
-	if !strings.HasPrefix(basePath, "/") {
-		basePath = "/" + basePath
-	}
-	fmt.Fprintf(cmd.OutOrStdout(), "  Web UI: http://localhost:%s%s\n", port, basePath)
-	fmt.Fprintf(cmd.OutOrStdout(), "  Web UI bearer token: %s\n", token)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Web UI: http://localhost:%s%s\n", web.Port, web.BasePath)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Web UI bearer token: %s\n", web.Token)
 }
 
 func printContainNextSteps(cmd *cobra.Command, name string, started bool) {
@@ -405,11 +422,11 @@ func printContainNextSteps(cmd *cobra.Command, name string, started bool) {
 }
 
 func printContainAuthSeedHints(cmd *cobra.Command, name string) {
-	dir, err := contain.ContainerDir(name)
+	envPath, err := contain.EnvPath(name)
 	if err != nil {
 		return
 	}
-	values, err := readContainEnvFile(filepath.Join(dir, ".env"))
+	values, err := contain.ReadEnvFile(envPath)
 	if err != nil {
 		return
 	}
@@ -464,31 +481,6 @@ func containCommandInputIsTerminal(cmd *cobra.Command) bool {
 	return containInputIsTerminal(cmd.InOrStdin())
 }
 
-func readContainEnvFile(path string) (map[string]string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	values := map[string]string{}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		key, value, ok := strings.Cut(line, "=")
-		if !ok {
-			continue
-		}
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		value = strings.Trim(value, `"'`)
-		if key != "" {
-			values[key] = value
-		}
-	}
-	return values, nil
-}
-
 func init() {
 	containNewCmd.Flags().StringVar(&containNewTemplate, "template", "agent", "Built-in template name or path to file/directory template")
 	if err := containNewCmd.RegisterFlagCompletionFunc("template", containTemplateFlagCompletion); err != nil {
@@ -506,6 +498,8 @@ func init() {
 	containCmd.AddCommand(containRmCmd)
 	containCmd.AddCommand(containRebuildCmd)
 	containCmd.AddCommand(containLsCmd)
+	containCmd.AddCommand(containPortCmd)
+	containCmd.AddCommand(containTokenCmd)
 	containCmd.AddCommand(containExecCmd)
 	containCmd.AddCommand(containShellCmd)
 	containCmd.AddCommand(containTemplatesCmd)

--- a/cmd/contain_test.go
+++ b/cmd/contain_test.go
@@ -690,3 +690,60 @@ func TestContainDockerCommandsUseFakeRunner(t *testing.T) {
 		t.Fatalf("fake runner calls = %#v", r.calls)
 	}
 }
+
+func writeContainTestEnv(t *testing.T, name, contents string) {
+	t.Helper()
+	dir, err := contain.ContainerDir(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContainPortPrintsWebPort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeContainTestEnv(t, "gw", "WEB_PORT=8222\nWEB_TOKEN=secret-token\nWEB_BASE_PATH=/chat\n")
+
+	stdout, stderr, err := executeRootForContainTest(t, "contain", "port", "gw")
+	if err != nil {
+		t.Fatalf("contain port error = %v stderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "8222" {
+		t.Fatalf("contain port stdout = %q want 8222", stdout)
+	}
+}
+
+func TestContainTokenPrintsWebToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeContainTestEnv(t, "gw", "WEB_PORT=8222\nWEB_TOKEN=secret-token\n")
+
+	stdout, stderr, err := executeRootForContainTest(t, "contain", "token", "gw")
+	if err != nil {
+		t.Fatalf("contain token error = %v stderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "secret-token" {
+		t.Fatalf("contain token stdout = %q want secret-token", stdout)
+	}
+}
+
+func TestContainTokenMissingTokenErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// A freshly templated workspace has no rendered token yet.
+	writeContainTestEnv(t, "gw", "WEB_PORT=8222\nWEB_TOKEN={{web_token}}\n")
+
+	if _, _, err := executeRootForContainTest(t, "contain", "token", "gw"); err == nil {
+		t.Fatal("contain token with no provisioned token succeeded, want error")
+	}
+}
+
+func TestContainPortMissingWorkspaceErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if _, _, err := executeRootForContainTest(t, "contain", "port", "nope"); err == nil {
+		t.Fatal("contain port for missing workspace succeeded, want error")
+	}
+}

--- a/cmd/serve_gateway.go
+++ b/cmd/serve_gateway.go
@@ -1,0 +1,913 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	htmlpkg "html"
+	"html/template"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/contain"
+	"github.com/samsaffron/term-llm/internal/widgets"
+	"github.com/spf13/cobra"
+)
+
+// gateway is a thin multi-agent reverse proxy fronting N per-agent contain
+// serves. An agent's serve is bound to a single agent at startup, so multi-agent
+// access is achieved by fronting many serves rather than routing within one
+// process. The gateway discovers each agent's published port + bearer token
+// from its contain workspace .env (via contain.ReadWebConfig) and injects the
+// token server-side, so the per-agent token is never exposed to the client.
+//
+// Clicking an agent on the landing page opens that agent's full web UI through
+// /agent/<name>/*: the proxy rebases the agent's baked-in URL prefix
+// (window.TERM_LLM_UI_PREFIX and the <base> tag, both /chat) onto /agent/<name>
+// so every SPA-built URL — API calls, the service worker, the auth cookie, and
+// img/iframe subresources — routes back through the proxy, where the per-agent
+// token is injected. The browser therefore never holds the token.
+//
+// Gateway-level authentication ({member-token -> allowed agents}) is
+// intentionally not yet wired. Do NOT expose it beyond loopback until that
+// boundary exists.
+type gateway struct {
+	// resolve returns the web config (port/token/base path) for a named agent.
+	// Overridable in tests.
+	resolve func(name string) (contain.WebConfig, error)
+	// list enumerates discoverable agent workspaces. Overridable in tests.
+	list func() ([]contain.ListEntry, error)
+	// host is the host the agents' serves are published on (loopback in the
+	// current one-container-per-agent shape).
+	host string
+	// widgetHost, when non-empty, is the dedicated origin (e.g.
+	// "widgets.localhost") on which the gateway serves ONLY the widget subtree
+	// (/w/<agent>/<mount>/*). It hosts nothing sensitive — no /agents, no
+	// /agent/*, no landing page — so a widget iframe granted allow-same-origin
+	// gets only its own throwaway origin. Empty disables the widget host.
+	widgetHost string
+	// proxy is the single shared reverse proxy for all agents. Per-request
+	// target data is threaded through the request context (see proxyTarget) so
+	// connections can be pooled across requests rather than allocating a proxy
+	// per request.
+	proxy *httputil.ReverseProxy
+	// fetchWidgets returns an agent's loaded widgets by querying its serve.
+	// Overridable in tests. It reuses widgets.WidgetStatus (the type the serve's
+	// /admin/widgets/status endpoint marshals) rather than a private copy of the
+	// same wire shape; only the mount/title/state fields are rendered.
+	fetchWidgets func(web contain.WebConfig) ([]widgets.WidgetStatus, error)
+}
+
+func newGateway() *gateway {
+	g := &gateway{
+		resolve: newWebConfigCache().get,
+		list:    contain.Definitions,
+		host:    "127.0.0.1",
+	}
+	g.proxy = &httputil.ReverseProxy{
+		Rewrite:        rewriteProxyRequest,
+		ModifyResponse: rebaseProxyResponse,
+		ErrorHandler:   proxyErrorHandler,
+		Transport:      newGatewayTransport(),
+	}
+	g.fetchWidgets = g.fetchWidgetsHTTP
+	return g
+}
+
+// fetchWidgetsHTTP asks an agent's serve for its loaded widgets via the same
+// token-injected channel the proxy uses. The bearer token is sent server-side
+// and the response carries no secrets (mount/title/state only).
+func (g *gateway) fetchWidgetsHTTP(web contain.WebConfig) ([]widgets.WidgetStatus, error) {
+	base := strings.TrimRight(web.BasePath, "/")
+	u := "http://" + net.JoinHostPort(g.host, web.Port) + base + "/admin/widgets/status"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+web.Token)
+
+	client := &http.Client{Transport: g.proxy.Transport, Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("widget status: %s", resp.Status)
+	}
+	var body struct {
+		Widgets []widgets.WidgetStatus `json:"widgets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	return body.Widgets, nil
+}
+
+// newGatewayTransport returns the proxy's HTTP transport with bounded
+// connection and response-header timeouts so a hung backend cannot tie up the
+// proxy indefinitely. It deliberately sets NO whole-response/read deadline:
+// long-lived streams (SSE, WebRTC signalling) must stay open, so only the time
+// to establish the connection and to receive the response *headers* is bounded.
+func newGatewayTransport() *http.Transport {
+	return &http.Transport{
+		// No environment proxy: the gateway dials known agent hosts directly, and
+		// routing a token-injected request (Authorization: Bearer) through an
+		// HTTP_PROXY would leak the per-agent bearer token to that proxy.
+		Proxy: nil,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	}
+}
+
+// webConfigCache memoises per-agent WebConfig lookups so the gateway does not
+// re-read (and re-parse) each agent's 0600 .env on every proxied request. An
+// entry is reused only while the .env's mtime is unchanged; any change — or a
+// failed stat — forces a fresh read, so edits to a workspace are picked up
+// without a restart and a stale entry is never served.
+type webConfigCache struct {
+	mu    sync.Mutex
+	items map[string]webConfigEntry
+	// load reads an agent's web config; stat returns its .env mtime. Both are
+	// fields so tests can substitute deterministic implementations.
+	load func(name string) (contain.WebConfig, error)
+	stat func(name string) (time.Time, error)
+}
+
+type webConfigEntry struct {
+	cfg   contain.WebConfig
+	mtime time.Time
+}
+
+func newWebConfigCache() *webConfigCache {
+	return &webConfigCache{
+		items: map[string]webConfigEntry{},
+		load:  contain.ReadWebConfig,
+		stat:  statEnvMtime,
+	}
+}
+
+// get returns the agent's web config, reusing the cached value while the .env
+// mtime is unchanged. The load happens under the lock: with one container per
+// agent the contention is negligible and it keeps a concurrent miss from
+// stampeding the parser.
+func (c *webConfigCache) get(name string) (contain.WebConfig, error) {
+	mtime, statErr := c.stat(name)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if statErr == nil {
+		if e, ok := c.items[name]; ok && e.mtime.Equal(mtime) {
+			return e.cfg, nil
+		}
+	}
+	cfg, err := c.load(name)
+	if err != nil {
+		return contain.WebConfig{}, err
+	}
+	if statErr == nil {
+		c.items[name] = webConfigEntry{cfg: cfg, mtime: mtime}
+	}
+	return cfg, nil
+}
+
+// statEnvMtime returns the modification time of an agent's workspace .env.
+func statEnvMtime(name string) (time.Time, error) {
+	path, err := contain.EnvPath(name)
+	if err != nil {
+		return time.Time{}, err
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return fi.ModTime(), nil
+}
+
+// proxyTarget carries the per-request reverse-proxy target. It is stashed on the
+// inbound request context by handleProxy and read back in the proxy's Rewrite,
+// ModifyResponse, and ErrorHandler hooks.
+type proxyTarget struct {
+	name       string // agent name (for diagnostics)
+	host       string // backend host:port (loopback)
+	targetPath string // backend path: agent base path + remainder
+	token      string // per-agent bearer token, injected server-side
+	basePath   string // agent's baked-in prefix, e.g. /chat
+	mount      string // gateway-facing prefix, e.g. /agent/<name>
+	// rebaseUI requests the SPA prefix rewrite in ModifyResponse. It is set for
+	// the agent proxy (whose served HTML bakes in window.TERM_LLM_UI_PREFIX and
+	// a <base> tag) and cleared for the widget proxy, whose responses resolve
+	// against their own origin and must pass through untouched.
+	rebaseUI bool
+}
+
+type proxyTargetKey struct{}
+
+func withProxyTarget(ctx context.Context, t *proxyTarget) context.Context {
+	return context.WithValue(ctx, proxyTargetKey{}, t)
+}
+
+func proxyTargetFrom(ctx context.Context) *proxyTarget {
+	t, _ := ctx.Value(proxyTargetKey{}).(*proxyTarget)
+	return t
+}
+
+// agentInfo is the public discovery record for one agent. It deliberately omits
+// the bearer token: the token is injected server-side and must never be sent to
+// a gateway client.
+type agentInfo struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Port      string `json:"port"`
+	BasePath  string `json:"base_path"`
+	ProxyPath string `json:"proxy_path"`
+	// Reachable reports whether the agent has a provisioned web token and can
+	// therefore be proxied.
+	Reachable bool `json:"reachable"`
+}
+
+func (g *gateway) handler() http.Handler {
+	agentMux := http.NewServeMux()
+	agentMux.HandleFunc("/agents", g.handleAgents)
+	agentMux.HandleFunc("/agent/", g.handleProxy)
+	agentMux.HandleFunc("/", g.handleIndex)
+
+	if g.widgetHost == "" {
+		return agentMux
+	}
+
+	// The widget origin exposes ONLY the widget subtree. Every other path 404s
+	// (the default for an otherwise-empty mux), which is the isolation property.
+	widgetMux := http.NewServeMux()
+	widgetMux.HandleFunc("/w/", g.handleWidgetProxy)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if g.isWidgetHost(r.Host) {
+			widgetMux.ServeHTTP(w, r)
+			return
+		}
+		agentMux.ServeHTTP(w, r)
+	})
+}
+
+// isWidgetHost reports whether the request's Host (port stripped) addresses the
+// dedicated widget origin. The same-origin policy is per origin, so routing by
+// host — not just by path — is what isolates widgets from the agent gateway.
+func (g *gateway) isWidgetHost(host string) bool {
+	if g.widgetHost == "" {
+		return false
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.EqualFold(host, g.widgetHost)
+}
+
+// collectAgents enumerates discoverable agents and their resolved web config.
+// The bearer token is never carried on the returned records.
+func (g *gateway) collectAgents() ([]agentInfo, error) {
+	entries, err := g.list()
+	if err != nil {
+		return nil, err
+	}
+	agents := make([]agentInfo, 0, len(entries))
+	for _, e := range entries {
+		info := agentInfo{
+			Name:      e.Name,
+			Status:    e.Status,
+			ProxyPath: "/agent/" + e.Name + "/",
+		}
+		if web, err := g.resolve(e.Name); err == nil {
+			info.Port = web.Port
+			info.BasePath = web.BasePath
+			info.Reachable = web.Token != ""
+		}
+		agents = append(agents, info)
+	}
+	sort.Slice(agents, func(i, j int) bool { return agents[i].Name < agents[j].Name })
+	return agents, nil
+}
+
+func (g *gateway) handleAgents(w http.ResponseWriter, r *http.Request) {
+	agents, err := g.collectAgents()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("list agents: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(struct {
+		Agents []agentInfo `json:"agents"`
+	}{Agents: agents}); err != nil {
+		http.Error(w, fmt.Sprintf("encode agents: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// handleIndex serves the gateway landing page: a list of discoverable agents,
+// each linking to its proxied web UI at /agent/<name>/. Clicking a reachable
+// agent opens its full UI through the proxy with the token injected server-side.
+func (g *gateway) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	agents, err := g.collectAgents()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("list agents: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// Headers are already committed if Execute fails mid-stream; nothing useful
+	// to surface to the client at that point.
+	_ = gatewayIndexTmpl.Execute(w, g.buildIndexView(agents, r.Host))
+}
+
+// gatewayIndexView is the data the landing page renders.
+type gatewayIndexView struct {
+	// CSS is the embedded stylesheet, inlined into the page verbatim.
+	CSS        template.CSS
+	Agents     []indexAgentView
+	WidgetHost string
+	// AnyWidgets is true when at least one agent reported a widget, so the
+	// Widgets section can show the grouped list rather than an empty-state hint.
+	AnyWidgets bool
+}
+
+// indexAgentView is one agent plus its resolved widget links for rendering.
+type indexAgentView struct {
+	agentInfo
+	Widgets []widgetLink
+}
+
+// widgetLink is a single openable widget on the widget origin.
+type widgetLink struct {
+	Title string
+	State string
+	URL   string
+}
+
+// buildIndexView assembles the landing-page data. When the widget host is
+// enabled, it enriches each reachable agent with its widgets, fetched
+// concurrently; a per-agent fetch failure is soft (that agent simply shows no
+// widgets) so one unreachable agent never breaks the page.
+func (g *gateway) buildIndexView(agents []agentInfo, reqHost string) gatewayIndexView {
+	view := gatewayIndexView{
+		CSS:        template.CSS(gatewayIndexCSS),
+		Agents:     make([]indexAgentView, len(agents)),
+		WidgetHost: g.widgetHost,
+	}
+	origin := ""
+	if g.widgetHost != "" {
+		origin = widgetOrigin(reqHost, g.widgetHost)
+	}
+
+	var wg sync.WaitGroup
+	for i, a := range agents {
+		view.Agents[i] = indexAgentView{agentInfo: a}
+		if g.widgetHost == "" || !a.Reachable {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			web, err := g.resolve(name)
+			if err != nil {
+				return
+			}
+			summaries, err := g.fetchWidgets(web)
+			if err != nil {
+				return
+			}
+			links := make([]widgetLink, 0, len(summaries))
+			for _, s := range summaries {
+				links = append(links, widgetLink{
+					Title: s.Title,
+					State: s.State,
+					URL:   origin + "/w/" + name + "/" + s.Mount + "/",
+				})
+			}
+			view.Agents[i].Widgets = links
+		}(i, a.Name)
+	}
+	wg.Wait()
+	for _, a := range view.Agents {
+		if len(a.Widgets) > 0 {
+			view.AnyWidgets = true
+			break
+		}
+	}
+	return view
+}
+
+// widgetOrigin returns the http origin of the widget host, preserving the port
+// the gateway was reached on (so the link resolves to this same listener under
+// the widget hostname).
+func widgetOrigin(reqHost, widgetHost string) string {
+	host := widgetHost
+	if _, port, err := net.SplitHostPort(reqHost); err == nil && port != "" {
+		host = net.JoinHostPort(widgetHost, port)
+	}
+	return "http://" + host
+}
+
+// The landing page markup and styles live in editable .html/.css files so they
+// keep editor support (highlighting, formatting) while the gateway stays a
+// single go:embed binary. The CSS is injected into the page as template.CSS so
+// the page remains self-contained on any origin (no extra stylesheet request).
+//
+//go:embed templates/gateway_index.html
+var gatewayIndexHTML string
+
+//go:embed templates/gateway.css
+var gatewayIndexCSS string
+
+var gatewayIndexTmpl = template.Must(template.New("gateway-index").Parse(gatewayIndexHTML))
+
+func (g *gateway) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Reject encoded path separators outright. They have no legitimate use in a
+	// proxied path and are the encoded-slash traversal vector: r.URL.Path is
+	// already decoded, so %2f would otherwise smuggle a separator the segment
+	// checks below cannot see.
+	if containsEncodedSeparator(r.URL.EscapedPath()) {
+		http.Error(w, "bad request: encoded path separators not allowed", http.StatusBadRequest)
+		return
+	}
+	name, rest, ok := parseAgentPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if err := contain.ValidateName(name); err != nil {
+		http.Error(w, fmt.Sprintf("invalid agent name %q", name), http.StatusBadRequest)
+		return
+	}
+	if hasDotDotSegment(rest) {
+		http.Error(w, "bad request: path traversal not allowed", http.StatusBadRequest)
+		return
+	}
+	web, err := g.resolve(name)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("unknown agent %q", name), http.StatusNotFound)
+		return
+	}
+	if web.Token == "" {
+		http.Error(w, fmt.Sprintf("agent %q has no provisioned web token", name), http.StatusBadGateway)
+		return
+	}
+
+	t := &proxyTarget{
+		name:       name,
+		host:       net.JoinHostPort(g.host, web.Port),
+		targetPath: joinBasePath(web.BasePath, rest),
+		token:      web.Token,
+		basePath:   strings.TrimRight(web.BasePath, "/"),
+		mount:      "/agent/" + name,
+		rebaseUI:   true,
+	}
+	g.serveProxy(w, r, t)
+}
+
+// serveProxy threads the per-request target onto the context and hands the
+// request to the single shared reverse proxy. Both the agent proxy and the
+// widget proxy funnel through here so they share one connection pool, one
+// Transport, and one set of Rewrite/ModifyResponse/ErrorHandler hooks.
+func (g *gateway) serveProxy(w http.ResponseWriter, r *http.Request, t *proxyTarget) {
+	g.proxy.ServeHTTP(w, r.WithContext(withProxyTarget(r.Context(), t)))
+}
+
+// handleWidgetProxy serves the widget origin: it routes /w/<agent>/<mount>/*
+// to that agent's serve at {BasePath}/widgets/<mount>/*, injecting the agent's
+// bearer token server-side (via the shared Rewrite hook). It deliberately
+// proxies ONLY the widgets subtree — never /v1, the session API, or anything
+// else same-origin-sensitive. Responses are passed through without the SPA
+// prefix rebasing: widgets resolve against this origin via relative URLs (a
+// widget that builds absolute URLs from BASE_PATH/X-Forwarded-Prefix would point
+// at the agent-internal /chat/widgets/<mount> path, which 404s here).
+//
+// This mirrors the agent serve's own widget proxy (cmd/serve_widgets.go
+// handleWidgetProxy) but for a different mount shape and across the origin
+// boundary; keep the two mount-parse/trailing-slash behaviors in sync.
+//
+// NOTE: there is no access control here yet — like the agent gateway, this is
+// loopback-only until the Part 2 HMAC access grant lands.
+func (g *gateway) handleWidgetProxy(w http.ResponseWriter, r *http.Request) {
+	// Same encoded-separator guard as the agent proxy: r.URL.Path is decoded,
+	// so reject %2f/%5c before the segment checks can be bypassed.
+	if containsEncodedSeparator(r.URL.EscapedPath()) {
+		http.Error(w, "bad request: encoded path separators not allowed", http.StatusBadRequest)
+		return
+	}
+	agent, mount, rest, ok := parseWidgetPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if err := contain.ValidateName(agent); err != nil {
+		http.Error(w, fmt.Sprintf("invalid agent name %q", agent), http.StatusBadRequest)
+		return
+	}
+	if !widgets.ValidMount(mount) {
+		http.Error(w, fmt.Sprintf("invalid widget mount %q", mount), http.StatusBadRequest)
+		return
+	}
+	// Bare mount with no trailing slash: redirect on the widget origin so the
+	// Location stays here and the widget's relative asset URLs resolve correctly.
+	// Preserve any query string so a widget that reads its initial config from
+	// query params still receives them.
+	if rest == "" {
+		target := "/w/" + agent + "/" + mount + "/"
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+		return
+	}
+	if hasDotDotSegment(rest) {
+		http.Error(w, "bad request: path traversal not allowed", http.StatusBadRequest)
+		return
+	}
+	web, err := g.resolve(agent)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("unknown agent %q", agent), http.StatusNotFound)
+		return
+	}
+	if web.Token == "" {
+		http.Error(w, fmt.Sprintf("agent %q has no provisioned web token", agent), http.StatusBadGateway)
+		return
+	}
+
+	t := &proxyTarget{
+		name:       agent,
+		host:       net.JoinHostPort(g.host, web.Port),
+		targetPath: joinBasePath(web.BasePath, "/widgets/"+mount+rest),
+		token:      web.Token,
+		basePath:   strings.TrimRight(web.BasePath, "/"),
+		mount:      "/w/" + agent + "/" + mount,
+		rebaseUI:   false,
+	}
+	g.serveProxy(w, r, t)
+}
+
+// parseWidgetPath splits "/w/<agent>/<mount>/<rest>" into its parts. <rest>
+// includes its leading slash; "/w/<agent>/<mount>" yields an empty rest (the
+// caller redirects to add the trailing slash). A path missing the mount segment
+// is not ok.
+func parseWidgetPath(p string) (agent, mount, rest string, ok bool) {
+	const prefix = "/w/"
+	if !strings.HasPrefix(p, prefix) {
+		return "", "", "", false
+	}
+	tail := p[len(prefix):]
+	slash := strings.IndexByte(tail, '/')
+	if slash < 0 {
+		return "", "", "", false // "/w/<agent>" with no mount
+	}
+	agent, tail = tail[:slash], tail[slash+1:]
+	if agent == "" {
+		return "", "", "", false
+	}
+	if slash = strings.IndexByte(tail, '/'); slash >= 0 {
+		mount, rest = tail[:slash], tail[slash:]
+	} else {
+		mount, rest = tail, ""
+	}
+	if mount == "" {
+		return "", "", "", false
+	}
+	return agent, mount, rest, true
+}
+
+// rewriteProxyRequest is the shared ReverseProxy Rewrite hook. Using Rewrite (vs
+// the legacy Director) means ReverseProxy does NOT auto-append X-Forwarded-*; we
+// also explicitly drop any client-supplied forwarding/credential headers so they
+// can neither spoof metadata nor reach the backend.
+func rewriteProxyRequest(pr *httputil.ProxyRequest) {
+	t := proxyTargetFrom(pr.In.Context())
+	if t == nil {
+		return
+	}
+	out := pr.Out
+	out.URL.Scheme = "http"
+	out.URL.Host = t.host
+	out.URL.Path = t.targetPath
+	out.URL.RawPath = "" // force Go to re-encode Path from the cleaned value
+	out.Host = t.host
+
+	// Inject the real per-agent token server-side; strip every client-supplied
+	// credential the backend would otherwise honor (Authorization Bearer,
+	// x-api-key, and the term_llm_token cookie).
+	out.Header.Set("Authorization", "Bearer "+t.token)
+	out.Header.Del("Cookie")
+	out.Header.Del("X-Api-Key")
+
+	// Take ownership of response encoding so ModifyResponse sees decompressed
+	// HTML: with Accept-Encoding cleared, the Transport transparently negotiates
+	// and decodes gzip itself.
+	out.Header.Del("Accept-Encoding")
+
+	// Drop spoofable forwarding metadata; the gateway does not advertise itself
+	// as an upstream prefix to the backend.
+	out.Header.Del("X-Forwarded-For")
+	out.Header.Del("X-Forwarded-Host")
+	out.Header.Del("X-Forwarded-Proto")
+	out.Header.Del("X-Forwarded-Prefix")
+	out.Header.Del("Forwarded")
+}
+
+// rebaseProxyResponse rewrites the agent's baked-in /chat prefix onto the
+// gateway mount (/agent/<name>) for the HTML document, and fixes redirect
+// Location headers. Because the SPA derives every URL it builds from the single
+// window.TERM_LLM_UI_PREFIX value and the <base> tag, rebasing those two strings
+// re-homes all subsequent requests onto /agent/<name>/* where the token is
+// injected — with zero JS changes. Non-HTML bodies (JS, JSON, SSE, images) are
+// passed through untouched.
+func rebaseProxyResponse(resp *http.Response) error {
+	t := proxyTargetFrom(resp.Request.Context())
+	if t == nil || !t.rebaseUI || t.basePath == "" || t.basePath == t.mount {
+		return nil
+	}
+
+	rewriteLocationHeader(resp, t)
+
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/html") {
+		return nil
+	}
+	// A HEAD response carries the real Content-Length but no body. Rewriting it
+	// would clobber that length to 0 and fire a spurious drift warning, so leave
+	// it untouched.
+	if resp.Request.Method == http.MethodHead {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if len(body) == 0 {
+		// Empty text/html body (e.g. a needle-less fragment): nothing to rewrite.
+		// Restore the body and skip the rewrite so we neither clobber
+		// Content-Length nor log a false drift warning.
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return nil
+	}
+	rewritten, baseHits, prefixHits := rebaseUIPrefix(body, t.basePath, t.mount)
+	if baseHits == 0 || prefixHits == 0 {
+		// One of the two prefix tokens the SPA bakes into its HTML no longer
+		// matches our needle (serveui's emitted shape drifted). Click-to-open
+		// silently breaks when this happens, so make it loud rather than
+		// failing the response.
+		log.Printf("WARNING: gateway agent %q: UI prefix rebase matched base=%d prefix=%d (expected >=1 each); click-to-open may be broken — check serveui's <base>/TERM_LLM_UI_PREFIX shape",
+			t.name, baseHits, prefixHits)
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(rewritten))
+	resp.ContentLength = int64(len(rewritten))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
+	// The Transport already decoded any gzip (we cleared Accept-Encoding); make
+	// sure no stale encoding header survives the body rewrite.
+	resp.Header.Del("Content-Encoding")
+	return nil
+}
+
+// rebaseUIPrefix replaces the two prefix tokens the agent bakes into its served
+// HTML. The needles are built with the SAME html.EscapeString / json.Marshal
+// shapes the serve uses (internal/serveui/embed.go and cmd/serve_handlers.go) so
+// they match byte-for-byte regardless of the agent's actual base path.
+// It reports how many times each needle matched so the caller can warn loudly
+// if either matched zero times (a sign serveui's emitted shape has drifted and
+// click-to-open has silently broken).
+func rebaseUIPrefix(body []byte, basePath, mount string) (out []byte, baseHits, prefixHits int) {
+	oldBase := []byte(`<base href="` + htmlpkg.EscapeString(basePath) + `/">`)
+	newBase := []byte(`<base href="` + htmlpkg.EscapeString(mount) + `/">`)
+	baseHits = bytes.Count(body, oldBase)
+	body = bytes.ReplaceAll(body, oldBase, newBase)
+
+	oldPrefix, _ := json.Marshal(basePath)
+	newPrefix, _ := json.Marshal(mount)
+	oldPrefixNeedle := []byte("window.TERM_LLM_UI_PREFIX=" + string(oldPrefix))
+	prefixHits = bytes.Count(body, oldPrefixNeedle)
+	body = bytes.ReplaceAll(body, oldPrefixNeedle,
+		[]byte("window.TERM_LLM_UI_PREFIX="+string(newPrefix)))
+	return body, baseHits, prefixHits
+}
+
+// rewriteLocationHeader rebases a root-relative redirect Location that points at
+// the agent base path onto the gateway mount, so backend redirects (e.g. the
+// /chat -> /chat/ normalization) land back inside /agent/<name>/.
+func rewriteLocationHeader(resp *http.Response, t *proxyTarget) {
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return
+	}
+	if loc == t.basePath {
+		resp.Header.Set("Location", t.mount)
+		return
+	}
+	if strings.HasPrefix(loc, t.basePath+"/") {
+		resp.Header.Set("Location", t.mount+loc[len(t.basePath):])
+	}
+}
+
+func proxyErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	name := "agent"
+	if t := proxyTargetFrom(r.Context()); t != nil {
+		name = t.name
+	}
+	w.WriteHeader(http.StatusBadGateway)
+	fmt.Fprintf(w, "gateway: agent %q backend unreachable: %v\n", name, err)
+}
+
+// containsEncodedSeparator reports whether an escaped path smuggles an encoded
+// path separator (%2f) or backslash (%5c).
+func containsEncodedSeparator(escapedPath string) bool {
+	lower := strings.ToLower(escapedPath)
+	return strings.Contains(lower, "%2f") || strings.Contains(lower, "%5c")
+}
+
+// hasDotDotSegment reports whether any segment of the decoded path is "..".
+func hasDotDotSegment(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// parseAgentPath splits "/agent/<name>/<rest>" into name and the remainder
+// (including its leading slash). "/agent/<name>" yields an empty rest.
+func parseAgentPath(p string) (name, rest string, ok bool) {
+	const prefix = "/agent/"
+	if !strings.HasPrefix(p, prefix) {
+		return "", "", false
+	}
+	tail := p[len(prefix):]
+	if tail == "" {
+		return "", "", false
+	}
+	if slash := strings.IndexByte(tail, '/'); slash >= 0 {
+		return tail[:slash], tail[slash:], true
+	}
+	return tail, "", true
+}
+
+// joinBasePath joins an agent's mount base path with the proxied remainder,
+// collapsing the slash seam. An empty remainder targets the base path root.
+func joinBasePath(base, rest string) string {
+	base = strings.TrimRight(base, "/")
+	if rest == "" {
+		return base + "/"
+	}
+	if !strings.HasPrefix(rest, "/") {
+		rest = "/" + rest
+	}
+	return base + rest
+}
+
+var (
+	serveGatewayHost       string
+	serveGatewayPort       int
+	serveGatewayAgentHost  string
+	serveGatewayWidgetHost string
+)
+
+var serveGatewayCmd = &cobra.Command{
+	Use:   "serve-gateway",
+	Short: "Run a multi-agent gateway fronting per-agent contain serves (experimental)",
+	Long: `Run a thin multi-agent gateway that fronts the per-agent web serves of
+contain workspaces.
+
+A term-llm serve binds a single agent at startup, so multi-agent access is
+achieved by fronting many serves rather than routing within one process. The
+gateway discovers each agent's published port and bearer token from its contain
+workspace .env and injects the token server-side, so per-agent tokens are never
+exposed to the client.
+
+Routes (agent origin):
+  GET  /agents              list discoverable agents (never includes tokens)
+  ANY  /agent/<name>/...     reverse proxy to that agent's serve
+
+When --widget-host is set, the gateway also answers on that dedicated origin,
+serving ONLY the widget subtree so a widget iframe is isolated to a throwaway
+origin that hosts nothing sensitive:
+  ANY  /w/<agent>/<mount>/... reverse proxy to the agent's widget (widget origin)
+
+EXPERIMENTAL: gateway-level authentication and the widget access grant are not
+yet implemented. Bind to loopback only.`,
+	Args: cobra.NoArgs,
+	RunE: runServeGateway,
+}
+
+// validateGatewayBind rejects a bind that would expose the gateway unsafely.
+// The gateway has no authentication of its own yet (per-agent tokens are
+// injected server-side, but nothing gates who may reach the gateway), so it
+// must stay on a loopback interface. To serve it publicly, front it with a
+// real authenticating reverse proxy and keep the gateway itself on loopback.
+func validateGatewayBind(host string, port int) error {
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid --port %d (must be 1-65535)", port)
+	}
+	if !isLoopbackHost(host) {
+		return fmt.Errorf("serve-gateway has no authentication yet, so --host must be a loopback address (127.0.0.1, localhost, or ::1); got %q. To expose it, put an authenticating proxy in front and keep the gateway on loopback", host)
+	}
+	return nil
+}
+
+// widgetHostWarning returns a startup warning when the widget host is
+// misconfigured for the gateway's loopback-only posture, or "" when it resolves
+// to loopback addresses only. It flags two cases: the host does not resolve (so
+// a browser can't reach widgets — purely an ergonomics hint), or it resolves to
+// a non-loopback address. The latter is only a heads-up, not a hole: the gateway
+// still binds loopback (validateGatewayBind) and routes by Host header, so an
+// off-host client cannot reach it regardless of what the name resolves to.
+func widgetHostWarning(host string, lookup func(string) ([]string, error)) string {
+	addrs, err := lookup(host)
+	if err != nil || len(addrs) == 0 {
+		return fmt.Sprintf("widget host %q does not resolve; add %q to your hosts file or DNS (e.g. \"127.0.0.1 %s\") so widgets open in the browser", host, host, host)
+	}
+	for _, a := range addrs {
+		ip := net.ParseIP(a)
+		if ip == nil || !ip.IsLoopback() {
+			return fmt.Sprintf("widget host %q resolves to a non-loopback address (%s); the gateway has no authentication and binds loopback only, so point %q at 127.0.0.1/::1", host, a, host)
+		}
+	}
+	return ""
+}
+
+// defaultLookupHost resolves a hostname with a short timeout so a slow resolver
+// cannot stall gateway startup.
+func defaultLookupHost(host string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// validateWidgetHost rejects a widget host that would shadow the agent gateway.
+// The agent origin is served on loopback, so a widget host that is itself a
+// loopback literal (localhost/127.0.0.1/::1) matches the same requests and the
+// widgets-only mux would swallow /agents, /agent/*, and the landing page. The
+// widget host must be a distinct hostname, e.g. widgets.localhost.
+func validateWidgetHost(widgetHost string) error {
+	widgetHost = strings.TrimSpace(widgetHost)
+	if widgetHost == "" {
+		return nil
+	}
+	if isLoopbackHost(strings.ToLower(widgetHost)) {
+		return fmt.Errorf("--widget-host %q must be a distinct hostname, not a loopback literal (it would shadow the agent gateway); use e.g. widgets.localhost", widgetHost)
+	}
+	return nil
+}
+
+func runServeGateway(cmd *cobra.Command, args []string) error {
+	if err := validateGatewayBind(serveGatewayHost, serveGatewayPort); err != nil {
+		return err
+	}
+	if err := validateWidgetHost(serveGatewayWidgetHost); err != nil {
+		return err
+	}
+	g := newGateway()
+	if strings.TrimSpace(serveGatewayAgentHost) != "" {
+		g.host = serveGatewayAgentHost
+	}
+	g.widgetHost = strings.TrimSpace(serveGatewayWidgetHost)
+
+	addr := net.JoinHostPort(serveGatewayHost, strconv.Itoa(serveGatewayPort))
+	srv := &http.Server{Addr: addr, Handler: g.handler()}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "term-llm multi-agent gateway listening on http://%s\n", addr)
+	fmt.Fprintf(cmd.OutOrStdout(), "  GET http://%s/agents\n", addr)
+	fmt.Fprintf(cmd.OutOrStdout(), "  ANY http://%s/agent/<name>/...\n", addr)
+	if g.widgetHost != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "  ANY http://%s:%d/w/<agent>/<mount>/... (widget origin)\n", g.widgetHost, serveGatewayPort)
+		if warn := widgetHostWarning(g.widgetHost, defaultLookupHost); warn != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: %s\n", warn)
+		}
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "WARNING: experimental, no gateway auth or widget grant yet; bind to loopback only.")
+	return srv.ListenAndServe()
+}
+
+func init() {
+	rootCmd.AddCommand(serveGatewayCmd)
+	serveGatewayCmd.Flags().StringVar(&serveGatewayHost, "host", "127.0.0.1", "Bind host")
+	serveGatewayCmd.Flags().IntVar(&serveGatewayPort, "port", 8090, "Bind port")
+	serveGatewayCmd.Flags().StringVar(&serveGatewayAgentHost, "agent-host", "127.0.0.1", "Host the per-agent serves are published on")
+	serveGatewayCmd.Flags().StringVar(&serveGatewayWidgetHost, "widget-host", "widgets.localhost", "Dedicated origin for the widgets-only proxy (empty to disable)")
+}

--- a/cmd/serve_gateway_test.go
+++ b/cmd/serve_gateway_test.go
@@ -1,0 +1,686 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/contain"
+)
+
+// gatewayWithBackend spins up a fake agent serve and returns a gateway that
+// proxies agent "alpha" to it with the given base path and a fixed token.
+func gatewayWithBackend(t *testing.T, basePath string, h http.HandlerFunc) *gateway {
+	t.Helper()
+	backend := httptest.NewServer(h)
+	t.Cleanup(backend.Close)
+	host, port, err := net.SplitHostPort(strings.TrimPrefix(backend.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fakeGateway(host, map[string]contain.WebConfig{
+		"alpha": {Port: port, Token: "tkn-123", BasePath: basePath},
+	})
+}
+
+// fakeGateway builds a gateway whose discovery is backed by static maps so the
+// proxy/list behaviour can be exercised without containers or a config dir.
+func fakeGateway(host string, agents map[string]contain.WebConfig) *gateway {
+	g := newGateway()
+	g.host = host
+	g.resolve = func(name string) (contain.WebConfig, error) {
+		cfg, ok := agents[name]
+		if !ok {
+			return contain.WebConfig{}, fmt.Errorf("workspace %q not found", name)
+		}
+		return cfg, nil
+	}
+	g.list = func() ([]contain.ListEntry, error) {
+		entries := make([]contain.ListEntry, 0, len(agents))
+		for name := range agents {
+			entries = append(entries, contain.ListEntry{Name: name, Status: "missing", Service: "app"})
+		}
+		return entries, nil
+	}
+	return g
+}
+
+func TestWidgetHostWarning(t *testing.T) {
+	lookup := func(addrs []string, err error) func(string) ([]string, error) {
+		return func(string) ([]string, error) { return addrs, err }
+	}
+	cases := []struct {
+		name    string
+		lookup  func(string) ([]string, error)
+		wantMsg bool
+	}{
+		{"loopback-ipv4", lookup([]string{"127.0.0.1"}, nil), false},
+		{"loopback-ipv6", lookup([]string{"::1"}, nil), false},
+		{"loopback-both", lookup([]string{"127.0.0.1", "::1"}, nil), false},
+		{"unresolved", lookup(nil, fmt.Errorf("no such host")), true},
+		{"empty", lookup([]string{}, nil), true},
+		{"public", lookup([]string{"93.184.216.34"}, nil), true},
+		{"mixed-with-public", lookup([]string{"127.0.0.1", "10.0.0.5"}, nil), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := widgetHostWarning("widgets.localhost", tc.lookup)
+			if tc.wantMsg && msg == "" {
+				t.Fatalf("expected a warning, got none")
+			}
+			if !tc.wantMsg && msg != "" {
+				t.Fatalf("expected no warning, got %q", msg)
+			}
+		})
+	}
+}
+
+func TestGatewayHeadDoesNotClobberOrWarn(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	const body = `<base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script>`
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		// Mimic serveEmbeddedUIBytes: real Content-Length, no body on HEAD.
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		io.WriteString(w, body)
+	})
+	rec := httptest.NewRecorder()
+	g.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/agent/alpha/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != fmt.Sprintf("%d", len(body)) {
+		t.Errorf("Content-Length = %q want %d (HEAD response must not be clobbered to 0)", cl, len(body))
+	}
+	if strings.Contains(buf.String(), "click-to-open") {
+		t.Errorf("spurious drift warning on HEAD request: %s", buf.String())
+	}
+}
+
+func TestGatewayTransportNoEnvProxy(t *testing.T) {
+	// The gateway dials known agent hosts directly; honoring HTTP_PROXY could
+	// route a token-injected request (with Authorization: Bearer) through an
+	// external proxy and leak the per-agent token.
+	if newGatewayTransport().Proxy != nil {
+		t.Fatal("gateway transport must not use an environment proxy")
+	}
+}
+
+func TestValidateWidgetHost(t *testing.T) {
+	cases := []struct {
+		host    string
+		wantErr bool
+	}{
+		{"", false},
+		{"widgets.localhost", false},
+		{"widgets.example.com", false},
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"LocalHost", true}, // case-insensitive: would still shadow
+	}
+	for _, tc := range cases {
+		if err := validateWidgetHost(tc.host); (err != nil) != tc.wantErr {
+			t.Errorf("validateWidgetHost(%q) err=%v wantErr=%v", tc.host, err, tc.wantErr)
+		}
+	}
+}
+
+func TestValidateGatewayBind(t *testing.T) {
+	cases := []struct {
+		name    string
+		host    string
+		port    int
+		wantErr bool
+	}{
+		{"loopback-ipv4", "127.0.0.1", 8090, false},
+		{"localhost", "localhost", 8090, false},
+		{"loopback-ipv6", "::1", 8090, false},
+		{"public-bind", "0.0.0.0", 8090, true},
+		{"lan-bind", "192.168.1.20", 8090, true},
+		{"bad-port-zero", "127.0.0.1", 0, true},
+		{"bad-port-high", "127.0.0.1", 70000, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateGatewayBind(tc.host, tc.port)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateGatewayBind(%q,%d) = nil, want error", tc.host, tc.port)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateGatewayBind(%q,%d) = %v, want nil", tc.host, tc.port, err)
+			}
+		})
+	}
+}
+
+func TestWebConfigCacheReusesUnchangedEntry(t *testing.T) {
+	var loads int
+	mtime := time.Unix(1000, 0)
+	c := &webConfigCache{
+		items: map[string]webConfigEntry{},
+		load: func(name string) (contain.WebConfig, error) {
+			loads++
+			return contain.WebConfig{Port: "8081", Token: "t"}, nil
+		},
+		stat: func(name string) (time.Time, error) { return mtime, nil },
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.get("alpha"); err != nil {
+			t.Fatalf("get #%d: %v", i, err)
+		}
+	}
+	if loads != 1 {
+		t.Fatalf("loads = %d, want 1 (cache should reuse the unchanged entry)", loads)
+	}
+
+	// A newer .env mtime invalidates the cache and forces a re-read.
+	mtime = time.Unix(2000, 0)
+	if _, err := c.get("alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if loads != 2 {
+		t.Fatalf("loads = %d, want 2 (changed mtime should force re-read)", loads)
+	}
+}
+
+func TestWebConfigCacheBypassesOnStatError(t *testing.T) {
+	var loads int
+	c := &webConfigCache{
+		items: map[string]webConfigEntry{},
+		load: func(name string) (contain.WebConfig, error) {
+			loads++
+			return contain.WebConfig{Port: "8081", Token: "t"}, nil
+		},
+		// Stat failing (e.g. .env vanished mid-flight) must not serve a stale
+		// cached entry: fall back to loading every time.
+		stat: func(name string) (time.Time, error) { return time.Time{}, fmt.Errorf("nope") },
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := c.get("alpha"); err != nil {
+			t.Fatalf("get #%d: %v", i, err)
+		}
+	}
+	if loads != 2 {
+		t.Fatalf("loads = %d, want 2 (stat error must bypass the cache)", loads)
+	}
+}
+
+func TestGatewayProxyInjectsTokenServerSide(t *testing.T) {
+	var gotAuth, gotPath, gotQuery string
+	var gotCookie string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotCookie = r.Header.Get("Cookie")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "hello from agent")
+	}))
+	defer backend.Close()
+
+	host, port, err := net.SplitHostPort(strings.TrimPrefix(backend.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := fakeGateway(host, map[string]contain.WebConfig{
+		"alpha": {Port: port, Token: "tkn-123", BasePath: "/chat"},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/v1/models?limit=5", nil)
+	// A client-supplied Authorization/Cookie must never reach the backend; the
+	// gateway injects the real per-agent token server-side.
+	req.Header.Set("Authorization", "Bearer client-supplied-should-not-pass")
+	req.Header.Set("Cookie", "term_llm_token=client-cookie")
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer tkn-123" {
+		t.Errorf("backend Authorization = %q want %q", gotAuth, "Bearer tkn-123")
+	}
+	if gotCookie != "" {
+		t.Errorf("backend Cookie = %q want empty (client cookie must be stripped)", gotCookie)
+	}
+	if gotPath != "/chat/v1/models" {
+		t.Errorf("backend path = %q want /chat/v1/models", gotPath)
+	}
+	if gotQuery != "limit=5" {
+		t.Errorf("backend query = %q want limit=5", gotQuery)
+	}
+	if rec.Body.String() != "hello from agent" {
+		t.Errorf("body = %q want hello from agent", rec.Body.String())
+	}
+}
+
+func TestGatewayProxyUnknownAgentIs404(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/ghost/", nil)
+	g.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d want 404", rec.Code)
+	}
+}
+
+func TestGatewayProxyNoTokenIsBadGateway(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "", BasePath: "/chat"},
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/", nil)
+	g.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d want 502", rec.Code)
+	}
+}
+
+func TestGatewayProxyRejectsInvalidName(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{})
+	rec := httptest.NewRecorder()
+	// Path traversal style name must be rejected before any resolution.
+	req := httptest.NewRequest(http.MethodGet, "/agent/..%2f..%2fetc/", nil)
+	g.handler().ServeHTTP(rec, req)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("invalid agent name proxied (status %d), want rejection", rec.Code)
+	}
+}
+
+func TestGatewayListsAgentsWithoutLeakingTokens(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "super-secret", BasePath: "/chat"},
+		"beta":  {Port: "8082", Token: "", BasePath: "/chat"},
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
+	g.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "super-secret") {
+		t.Fatalf("token leaked into /agents response: %s", rec.Body.String())
+	}
+
+	var resp struct {
+		Agents []agentInfo `json:"agents"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode /agents: %v body=%s", err, rec.Body.String())
+	}
+	byName := map[string]agentInfo{}
+	for _, a := range resp.Agents {
+		byName[a.Name] = a
+	}
+	if len(byName) != 2 {
+		t.Fatalf("agents = %#v want 2", resp.Agents)
+	}
+	if !byName["alpha"].Reachable {
+		t.Errorf("alpha should be reachable (has token)")
+	}
+	if byName["beta"].Reachable {
+		t.Errorf("beta should not be reachable (no token)")
+	}
+	if byName["alpha"].ProxyPath != "/agent/alpha/" {
+		t.Errorf("alpha proxy path = %q want /agent/alpha/", byName["alpha"].ProxyPath)
+	}
+	if byName["alpha"].Port != "8081" {
+		t.Errorf("alpha port = %q want 8081", byName["alpha"].Port)
+	}
+}
+
+func TestGatewayIndexListsAgents(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "super-secret", BasePath: "/chat"},
+		"beta":  {Port: "8082", Token: "", BasePath: "/chat"},
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q want text/html", ct)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "super-secret") {
+		t.Fatalf("token leaked into index page: %s", body)
+	}
+	for _, want := range []string{"alpha", "beta", "/agent/alpha/"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("index missing %q\nbody=%s", want, body)
+		}
+	}
+}
+
+func TestGatewayIndexOnlyAtRoot(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{})
+	rec := httptest.NewRecorder()
+	// A stray non-root path that is not an /agent/ or /agents route must 404,
+	// not render the index.
+	req := httptest.NewRequest(http.MethodGet, "/favicon.ico", nil)
+	g.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d want 404 for %q", rec.Code, "/favicon.ico")
+	}
+}
+
+// --- click-to-open: per-agent UI prefix rebasing through the gateway ---
+
+func TestGatewayRewritesUIPrefixInHTML(t *testing.T) {
+	html := `<!doctype html><html><head><meta charset="utf-8">` + "\n  " +
+		`<base href="/chat/">` +
+		`<script>window.TERM_LLM_UI_PREFIX="/chat";</script></head><body>hi</body></html>`
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, html)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `<base href="/agent/alpha/">`) {
+		t.Errorf("<base> not rebased to gateway mount:\n%s", body)
+	}
+	if !strings.Contains(body, `window.TERM_LLM_UI_PREFIX="/agent/alpha"`) {
+		t.Errorf("UI prefix not rebased:\n%s", body)
+	}
+	if strings.Contains(body, "/chat") {
+		t.Errorf("residual /chat after rebase:\n%s", body)
+	}
+}
+
+func TestRebaseUIPrefixReportsHits(t *testing.T) {
+	good := []byte(`<base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script>`)
+	out, baseHits, prefixHits := rebaseUIPrefix(good, "/chat", "/agent/alpha")
+	if baseHits != 1 || prefixHits != 1 {
+		t.Fatalf("good HTML hits = base %d prefix %d, want 1/1", baseHits, prefixHits)
+	}
+	if strings.Contains(string(out), "/chat") {
+		t.Errorf("residual /chat after rebase: %s", out)
+	}
+
+	// serveui's emitted shape drifts (spaces around the assignment): the prefix
+	// needle no longer matches and click-to-open would silently break.
+	drifted := []byte(`<base href="/chat/"><script>window.TERM_LLM_UI_PREFIX = "/chat";</script>`)
+	_, baseHits, prefixHits = rebaseUIPrefix(drifted, "/chat", "/agent/alpha")
+	if baseHits != 1 {
+		t.Errorf("drifted base hits = %d, want 1", baseHits)
+	}
+	if prefixHits != 0 {
+		t.Errorf("drifted prefix hits = %d, want 0 (needle should miss)", prefixHits)
+	}
+}
+
+// TestRebaseMatchesRealServeRender feeds the gateway's rebase needles the ACTUAL
+// HTML the serve renders for its index — the <base> tag from serveui and the
+// window.TERM_LLM_UI_PREFIX script from buildIndexHTML. This makes a drift in
+// either emitter fail the build, instead of only logging a runtime warning.
+func TestRebaseMatchesRealServeRender(t *testing.T) {
+	srv := &serveServer{cfg: serveServerConfig{ui: true, basePath: "/chat", agentName: "x"}}
+	rr := httptest.NewRecorder()
+	srv.handleUI(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handleUI status = %d", rr.Code)
+	}
+	rewritten, baseHits, prefixHits := rebaseUIPrefix(rr.Body.Bytes(), "/chat", "/agent/x")
+	if baseHits < 1 {
+		t.Errorf("<base> needle did not match real serve render — serveui HTML shape drifted")
+	}
+	if prefixHits < 1 {
+		t.Errorf("TERM_LLM_UI_PREFIX needle did not match real serve render — buildIndexHTML shape drifted")
+	}
+	if bytes.Contains(rewritten, []byte(`href="/chat/"`)) || bytes.Contains(rewritten, []byte(`UI_PREFIX="/chat"`)) {
+		t.Errorf("residual /chat after rebase:\n%s", rewritten)
+	}
+}
+
+func TestGatewayWarnsWhenRebaseMatchesNothing(t *testing.T) {
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(prevOut); log.SetFlags(prevFlags) })
+
+	// HTML whose prefix needle has drifted: the rebase will match the <base>
+	// tag but not the UI prefix, so the gateway must log a loud warning.
+	drifted := `<base href="/chat/"><script>window.TERM_LLM_UI_PREFIX = "/chat";</script>`
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		io.WriteString(w, drifted)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "alpha") || !strings.Contains(strings.ToLower(logged), "warn") {
+		t.Fatalf("expected a loud warning naming the agent, got: %q", logged)
+	}
+}
+
+func TestGatewayDoesNotWarnOnCleanHTML(t *testing.T) {
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prevOut) })
+
+	clean := `<base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script>`
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		io.WriteString(w, clean)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	if logged := buf.String(); strings.TrimSpace(logged) != "" {
+		t.Fatalf("unexpected warning on clean HTML: %q", logged)
+	}
+}
+
+func TestGatewayRewritesGzippedHTML(t *testing.T) {
+	htmlBody := `<meta charset="utf-8"><base href="/chat/">` +
+		`<script>window.TERM_LLM_UI_PREFIX="/chat";</script>`
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// The real serve gzips the UI when the request advertises gzip. The
+		// gateway must still see decompressed HTML in order to rebase it.
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			io.WriteString(gz, htmlBody)
+			gz.Close()
+			return
+		}
+		io.WriteString(w, htmlBody)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/", nil)
+	// Client advertises gzip; the gateway must take ownership of encoding so it
+	// can rebase the body.
+	req.Header.Set("Accept-Encoding", "gzip")
+	g.handler().ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `window.TERM_LLM_UI_PREFIX="/agent/alpha"`) {
+		t.Errorf("gzipped HTML was not rebased (gateway likely forwarded client Accept-Encoding):\n%q", body)
+	}
+	if strings.Contains(body, "/chat") {
+		t.Errorf("residual /chat after gzip rebase:\n%q", body)
+	}
+}
+
+func TestGatewayDoesNotRewriteNonHTML(t *testing.T) {
+	js := `const P = window.TERM_LLM_UI_PREFIX; fetch("/chat/v1/models");`
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		io.WriteString(w, js)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/app-core.js", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Body.String() != js {
+		t.Fatalf("non-HTML body was rewritten:\n got=%q\nwant=%q", rec.Body.String(), js)
+	}
+}
+
+func TestGatewayStripsXApiKeyAndInjectsAuth(t *testing.T) {
+	var gotKey, gotAuth string
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/v1/models", nil)
+	req.Header.Set("X-Api-Key", "client-key-should-not-pass")
+	g.handler().ServeHTTP(rec, req)
+
+	if gotKey != "" {
+		t.Errorf("client x-api-key reached backend: %q", gotKey)
+	}
+	if gotAuth != "Bearer tkn-123" {
+		t.Errorf("backend Authorization = %q want Bearer tkn-123", gotAuth)
+	}
+}
+
+func TestGatewayRejectsEncodedSlashTraversal(t *testing.T) {
+	hit := false
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	// Call handleProxy directly so the ServeMux's own path cleaning does not
+	// pre-empt the gateway's encoded-separator guard under test.
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/v1/..%2f..%2fadmin", nil)
+	g.handleProxy(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d want 400", rec.Code)
+	}
+	if hit {
+		t.Fatal("backend received an encoded-slash traversal request")
+	}
+}
+
+func TestGatewayTimesOutHungBackendHeaders(t *testing.T) {
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		// Never send response headers within the timeout window.
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	// The gateway must give its proxy a real *http.Transport (not nil/Default)
+	// so a hung backend can't hang the proxy. Shrink the header timeout so the
+	// test stays fast.
+	tr := g.proxy.Transport.(*http.Transport).Clone()
+	tr.ResponseHeaderTimeout = 50 * time.Millisecond
+	g.proxy.Transport = tr
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/slow", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d want 502 (hung backend should trip the header timeout)", rec.Code)
+	}
+}
+
+func TestGatewayStreamsSSEIncrementally(t *testing.T) {
+	release := make(chan struct{})
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("backend ResponseWriter is not a Flusher")
+			return
+		}
+		io.WriteString(w, "data: first\n\n")
+		fl.Flush()
+		// Block: the client must receive "first" before "second" is ever
+		// written. If the proxy buffered the body, the read below would deadlock.
+		<-release
+		io.WriteString(w, "data: second\n\n")
+		fl.Flush()
+	})
+
+	front := httptest.NewServer(g.handler())
+	defer front.Close()
+
+	resp, err := http.Get(front.URL + "/agent/alpha/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q want text/event-stream", ct)
+	}
+
+	br := bufio.NewReader(resp.Body)
+	if line := readDataLine(t, br); line != "data: first" {
+		t.Fatalf("first event = %q want %q", line, "data: first")
+	}
+	// We got the first event while the backend is still blocked → not buffered.
+	close(release)
+	if line := readDataLine(t, br); line != "data: second" {
+		t.Fatalf("second event = %q want %q", line, "data: second")
+	}
+}
+
+// readDataLine reads lines until it finds an SSE "data:" line and returns it.
+func readDataLine(t *testing.T, br *bufio.Reader) string {
+	t.Helper()
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE stream: %v", err)
+		}
+		if line = strings.TrimRight(line, "\r\n"); strings.HasPrefix(line, "data:") {
+			return line
+		}
+	}
+}
+
+func TestGatewayRewritesLocationHeader(t *testing.T) {
+	g := gatewayWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/chat/v1/foo")
+		w.WriteHeader(http.StatusFound)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agent/alpha/old", nil)
+	g.handler().ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Location"); got != "/agent/alpha/v1/foo" {
+		t.Fatalf("Location = %q want /agent/alpha/v1/foo", got)
+	}
+}

--- a/cmd/serve_widget_host_test.go
+++ b/cmd/serve_widget_host_test.go
@@ -1,0 +1,292 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/contain"
+	"github.com/samsaffron/term-llm/internal/widgets"
+)
+
+// widgetGateway builds a gateway whose widget host is enabled and whose single
+// agent "alpha" proxies to the given backend (simulating that agent's serve).
+func widgetGateway(t *testing.T, basePath string, h http.HandlerFunc) *gateway {
+	t.Helper()
+	backend := httptest.NewServer(h)
+	t.Cleanup(backend.Close)
+	host, port, err := net.SplitHostPort(strings.TrimPrefix(backend.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := fakeGateway(host, map[string]contain.WebConfig{
+		"alpha": {Port: port, Token: "tkn-123", BasePath: basePath},
+	})
+	g.widgetHost = "widgets.localhost"
+	return g
+}
+
+// widgetReq builds a request addressed to the widget-host origin.
+func widgetReq(method, path string) *http.Request {
+	r := httptest.NewRequest(method, path, nil)
+	r.Host = "widgets.localhost"
+	return r
+}
+
+func TestWidgetHostProxiesToAgentWidgetSubtree(t *testing.T) {
+	var gotPath, gotAuth, gotCookie, gotKey string
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotCookie = r.Header.Get("Cookie")
+		gotKey = r.Header.Get("X-Api-Key")
+		io.WriteString(w, "widget asset")
+	})
+
+	rec := httptest.NewRecorder()
+	req := widgetReq(http.MethodGet, "/w/alpha/job-usage/assets/app.js")
+	// Client-supplied credentials must never reach the backend.
+	req.Header.Set("Authorization", "Bearer client-should-not-pass")
+	req.Header.Set("Cookie", "term_llm_token=nope")
+	req.Header.Set("X-Api-Key", "client-key")
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/chat/widgets/job-usage/assets/app.js" {
+		t.Errorf("backend path = %q want /chat/widgets/job-usage/assets/app.js", gotPath)
+	}
+	if gotAuth != "Bearer tkn-123" {
+		t.Errorf("backend Authorization = %q want Bearer tkn-123", gotAuth)
+	}
+	if gotCookie != "" {
+		t.Errorf("client cookie reached backend: %q", gotCookie)
+	}
+	if gotKey != "" {
+		t.Errorf("client x-api-key reached backend: %q", gotKey)
+	}
+	if rec.Body.String() != "widget asset" {
+		t.Errorf("body = %q want widget asset", rec.Body.String())
+	}
+}
+
+func TestWidgetHostRedirectsMissingTrailingSlash(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("backend should not be hit for a bare mount, got %q", r.URL.Path)
+	})
+	rec := httptest.NewRecorder()
+	g.handler().ServeHTTP(rec, widgetReq(http.MethodGet, "/w/alpha/job-usage"))
+
+	if rec.Code != http.StatusTemporaryRedirect && rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d want a redirect", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/w/alpha/job-usage/" {
+		t.Fatalf("Location = %q want /w/alpha/job-usage/", loc)
+	}
+}
+
+func TestWidgetHostRedirectPreservesQuery(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("backend should not be hit for a bare mount, got %q", r.URL.Path)
+	})
+	rec := httptest.NewRecorder()
+	g.handleWidgetProxy(rec, widgetReq(http.MethodGet, "/w/alpha/job-usage?foo=bar&x=1"))
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d want 307", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/w/alpha/job-usage/?foo=bar&x=1" {
+		t.Fatalf("Location = %q want /w/alpha/job-usage/?foo=bar&x=1 (query must be preserved)", loc)
+	}
+}
+
+func TestWidgetHostDoesNotRebaseHTML(t *testing.T) {
+	// A widget that emits the agent's baked-in prefix must be passed through
+	// untouched: widgets resolve against their own origin via relative URLs, and
+	// the widget host must not run the SPA prefix rebasing.
+	html := `<base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script>`
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		io.WriteString(w, html)
+	})
+	rec := httptest.NewRecorder()
+	g.handler().ServeHTTP(rec, widgetReq(http.MethodGet, "/w/alpha/job-usage/"))
+
+	if rec.Body.String() != html {
+		t.Fatalf("widget HTML was rewritten:\n got=%q\nwant=%q", rec.Body.String(), html)
+	}
+}
+
+func TestWidgetHostRejectsInvalidMount(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("backend hit with invalid mount: %q", r.URL.Path)
+	})
+	rec := httptest.NewRecorder()
+	g.handleWidgetProxy(rec, widgetReq(http.MethodGet, "/w/alpha/Bad_Mount/"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d want 400 for invalid mount", rec.Code)
+	}
+}
+
+func TestWidgetHostRejectsEncodedTraversal(t *testing.T) {
+	hit := false
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) { hit = true })
+	rec := httptest.NewRecorder()
+	g.handleWidgetProxy(rec, widgetReq(http.MethodGet, "/w/alpha/job-usage/..%2f..%2fv1/models"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d want 400", rec.Code)
+	}
+	if hit {
+		t.Fatal("backend received an encoded-traversal widget request")
+	}
+}
+
+func TestWidgetHostUnknownAgentIs404(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
+	rec := httptest.NewRecorder()
+	g.handler().ServeHTTP(rec, widgetReq(http.MethodGet, "/w/ghost/job-usage/"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d want 404", rec.Code)
+	}
+}
+
+// The widget origin must host NOTHING sensitive: the agent gateway routes and
+// landing page must not be reachable there. That emptiness is the isolation.
+func TestWidgetHostDoesNotExposeGatewayRoutes(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
+	for _, path := range []string{"/agents", "/agent/alpha/", "/"} {
+		rec := httptest.NewRecorder()
+		g.handler().ServeHTTP(rec, widgetReq(http.MethodGet, path))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("widget host exposed %q (status %d), want 404", path, rec.Code)
+		}
+	}
+}
+
+// Conversely, the widget route must not be reachable on the agent gateway origin.
+func TestGatewayIndexShowsWidgetOriginWhenEnabled(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
+	rec := httptest.NewRecorder()
+	// Landing page is on the agent origin (not the widget host).
+	g.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "widgets.localhost") {
+		t.Errorf("landing page does not surface the widget origin:\n%s", body)
+	}
+}
+
+func TestGatewayIndexListsWidgets(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "t", BasePath: "/chat"},
+	})
+	g.widgetHost = "widgets.localhost"
+	g.fetchWidgets = func(web contain.WebConfig) ([]widgets.WidgetStatus, error) {
+		return []widgets.WidgetStatus{
+			{Mount: "job-usage", Title: "Job Usage", State: "running"},
+			{Mount: "notes", Title: "Notes", State: "running"},
+		}, nil
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:8095"
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Job Usage") || !strings.Contains(body, "Notes") {
+		t.Errorf("widget titles missing from page:\n%s", body)
+	}
+	// Links must target the widget origin (same port, widget hostname).
+	if !strings.Contains(body, "http://widgets.localhost:8095/w/alpha/job-usage/") {
+		t.Errorf("widget link not pointed at the widget origin:\n%s", body)
+	}
+}
+
+func TestGatewayIndexGroupsWidgetsByAgent(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "t", BasePath: "/chat"},
+		"beta":  {Port: "8082", Token: "t", BasePath: "/chat"},
+	})
+	g.widgetHost = "widgets.localhost"
+	g.fetchWidgets = func(web contain.WebConfig) ([]widgets.WidgetStatus, error) {
+		if web.Port == "8081" {
+			return []widgets.WidgetStatus{{Mount: "notes", Title: "Notes", State: "running"}}, nil
+		}
+		return []widgets.WidgetStatus{{Mount: "usage", Title: "Usage", State: "stopped"}}, nil
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:8095"
+	g.handler().ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `class="wgroup"`) {
+		t.Fatalf("expected a grouped Widgets section:\n%s", body)
+	}
+	// Widgets must live in the Widgets section, not leak into the agents list.
+	agentsUL := body[strings.Index(body, `<ul class="agents">`):strings.Index(body, "</ul>")]
+	if strings.Contains(agentsUL, "wpill") {
+		t.Errorf("widget pills leaked into the agents list:\n%s", agentsUL)
+	}
+	// Each agent's widget resolves under its own agent on the widget origin.
+	if !strings.Contains(body, "/w/alpha/notes/") || !strings.Contains(body, "/w/beta/usage/") {
+		t.Errorf("per-agent widget links missing:\n%s", body)
+	}
+}
+
+func TestGatewayIndexWidgetFetchErrorIsSoft(t *testing.T) {
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "t", BasePath: "/chat"},
+	})
+	g.widgetHost = "widgets.localhost"
+	g.fetchWidgets = func(web contain.WebConfig) ([]widgets.WidgetStatus, error) {
+		return nil, fmt.Errorf("agent down")
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:8095"
+	g.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d want 200 (widget fetch failure must not break the page)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "alpha") {
+		t.Errorf("agent still expected on page despite widget fetch error")
+	}
+	if strings.Contains(rec.Body.String(), "/w/alpha/") {
+		t.Errorf("no widget links expected when the fetch failed")
+	}
+}
+
+func TestGatewayIndexOmitsWidgetSectionWhenDisabled(t *testing.T) {
+	// Widget host disabled: no widget origin reference on the landing page.
+	g := fakeGateway("127.0.0.1", map[string]contain.WebConfig{
+		"alpha": {Port: "8081", Token: "t", BasePath: "/chat"},
+	})
+	rec := httptest.NewRecorder()
+	g.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if strings.Contains(rec.Body.String(), "/w/") {
+		t.Errorf("widget section rendered while widget host disabled:\n%s", rec.Body.String())
+	}
+}
+
+func TestAgentHostDoesNotExposeWidgetRoute(t *testing.T) {
+	g := widgetGateway(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
+	rec := httptest.NewRecorder()
+	// Default origin (not the widget host).
+	req := httptest.NewRequest(http.MethodGet, "/w/alpha/job-usage/", nil)
+	g.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("agent origin exposed /w/ route (status %d), want 404", rec.Code)
+	}
+}

--- a/cmd/templates/gateway.css
+++ b/cmd/templates/gateway.css
@@ -1,0 +1,216 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #161b22;
+  --line: #21262d;
+  --fg: #e6edf3;
+  --muted: #8b949e;
+  --link: #6cb6ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font: 15px/1.55 -apple-system, system-ui, "Segoe UI", sans-serif;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem 4rem;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header {
+  margin-bottom: 1.75rem;
+}
+
+h1 {
+  font-size: 1.35rem;
+  margin: 0 0 0.25rem;
+}
+
+h2 {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin: 2rem 0 0.6rem;
+}
+
+.sub {
+  color: var(--muted);
+  margin: 0;
+}
+
+.note {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.banner {
+  border: 1px solid #5a3a00;
+  background: #1d1400;
+  color: #e3b341;
+  border-radius: 8px;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
+.banner strong {
+  color: #f0c674;
+}
+
+ul.agents {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+ul.agents li {
+  padding: 0.7rem 0.95rem;
+  border-top: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--panel);
+}
+
+ul.agents li:first-child {
+  border-top: none;
+}
+
+.name {
+  font-weight: 600;
+}
+
+.endpoint {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.badge {
+  font-size: 0.68rem;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.ok {
+  background: #14431f;
+  color: #7ee787;
+}
+
+.off {
+  background: #3a2d00;
+  color: #e3b341;
+}
+
+code {
+  color: #c9d1d9;
+  background: #1f242c;
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 0.9rem 1rem;
+}
+
+.wgroups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.wgroup {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 0.7rem 0.9rem;
+}
+
+.wgroup-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.55rem;
+}
+
+.wgroup-head .name {
+  font-size: 0.92rem;
+}
+
+.wgroup-head .endpoint {
+  margin-left: auto;
+}
+
+.wpills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.wpill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #1f242c;
+  color: var(--fg);
+  font-size: 0.85rem;
+}
+
+.wpill:hover {
+  border-color: #3d4450;
+  text-decoration: none;
+}
+
+.wpill .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #6e7681;
+  flex: none;
+}
+
+.wpill .dot.on {
+  background: #3fb950;
+}
+
+.wpill .state {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin-top: 0.7rem;
+}
+
+footer {
+  margin-top: 2.5rem;
+}

--- a/cmd/templates/gateway_index.html
+++ b/cmd/templates/gateway_index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>term-llm gateway</title>
+<style>{{.CSS}}</style>
+</head>
+<body>
+<header>
+  <h1>term-llm multi-agent gateway</h1>
+  <p class="sub">Fronts each agent's web UI and injects its token server-side &mdash; the per-agent token never reaches the browser.</p>
+</header>
+
+<div class="banner">
+  <strong>Experimental &mdash; loopback only.</strong> There is no gateway-level authentication yet. Do not expose this beyond a loopback interface.
+</div>
+
+<h2>Agents</h2>
+{{if .Agents}}
+<ul class="agents">
+{{range .Agents}}
+  <li>
+    {{if .Reachable}}<a class="name" href="{{.ProxyPath}}">{{.Name}}</a><span class="badge ok">reachable</span>{{else}}<span class="name">{{.Name}}</span><span class="badge off">no token</span>{{end}}
+    <span class="endpoint">:{{.Port}}{{.BasePath}}</span>
+  </li>
+{{end}}
+</ul>
+<p class="note">Click an agent to open its web UI through the proxy.</p>
+{{else}}
+<div class="panel note">No agents discovered. Create one with <code>term-llm contain new &lt;name&gt; --template agent</code>.</div>
+{{end}}
+
+{{if .WidgetHost}}
+<h2>Widgets</h2>
+{{if .AnyWidgets}}
+<div class="wgroups">
+{{range .Agents}}{{if .Widgets}}
+  <div class="wgroup">
+    <div class="wgroup-head"><span class="name">{{.Name}}</span><span class="endpoint">{{len .Widgets}} widget{{if ne (len .Widgets) 1}}s{{end}}</span></div>
+    <div class="wpills">
+    {{range .Widgets}}<a class="wpill" href="{{.URL}}"><span class="dot{{if eq .State "running"}} on{{end}}"></span>{{.Title}}<span class="state">{{.State}}</span></a>{{end}}
+    </div>
+  </div>
+{{end}}{{end}}
+</div>
+{{else}}
+<div class="panel note">No widgets loaded yet. Add a widget to an agent (see the widgets skill) and it will appear here.</div>
+{{end}}
+<p class="hint">Widgets open on the isolated <code>{{.WidgetHost}}</code> origin &mdash; add <code>{{.WidgetHost}}</code> to your hosts file or DNS so it resolves to this gateway. Pattern: <code>http://{{.WidgetHost}}:&lt;port&gt;/w/&lt;agent&gt;/&lt;mount&gt;/</code></p>
+{{end}}
+
+<footer>
+  <p class="note">JSON: <a href="/agents">/agents</a></p>
+</footer>
+</body>
+</html>

--- a/docs-site/content/guides/multi-agent-gateway.md
+++ b/docs-site/content/guides/multi-agent-gateway.md
@@ -1,0 +1,105 @@
+---
+title: "Multi-agent gateway"
+weight: 16
+description: "Front several per-agent serves behind one origin, inject each agent's token server-side, and serve widgets from an isolated origin."
+kicker: "Run many agents"
+---
+
+`term-llm serve-gateway` is a thin reverse proxy that fronts the per-agent web serves of several [agent containers](/guides/agent-containers/). A `term-llm serve` binds a single agent at startup, so multi-agent access is achieved by *fronting many serves* rather than routing many agents inside one process — which is already the production shape: one container per agent.
+
+The gateway does two jobs:
+
+1. **Agent proxy** — exposes every discoverable agent's web UI under one origin and injects that agent's bearer token server-side, so the per-agent token never reaches the browser.
+2. **Widget host** — optionally serves each agent's widgets from a *separate* origin, so an embedded widget is isolated to a throwaway origin that hosts nothing sensitive.
+
+> **Experimental — loopback only.** The gateway has no authentication of its own yet. It refuses to bind to anything but a loopback address. To expose it, put an authenticating reverse proxy in front and keep the gateway on loopback.
+
+## Quick start
+
+```bash
+# Create and start a couple of agents (see the Agent Containers guide).
+term-llm contain new fam   --template agent
+term-llm contain new ops   --template agent
+term-llm contain start fam
+term-llm contain start ops
+
+# Run the gateway. It discovers agents from their contain workspaces.
+term-llm serve-gateway --port 8090
+```
+
+Open `http://localhost:8090/` for the landing page: a list of discoverable agents, each linking to its full web UI through the proxy. Clicking an agent opens its UI at `/agent/<name>/` with the token injected for you.
+
+## How agent discovery works
+
+The gateway enumerates contain workspaces and reads each one's `.env` for its published port and bearer token (the same values `term-llm contain port <name>` and `term-llm contain token <name>` print). An agent shows as **reachable** once it has a provisioned `WEB_TOKEN`; agents without one are listed but not proxyable.
+
+Routes on the agent origin:
+
+| Route | Purpose |
+| --- | --- |
+| `GET /agents` | JSON list of discoverable agents (**never** includes tokens) |
+| `GET /` | HTML landing page |
+| `ANY /agent/<name>/...` | reverse proxy to that agent's serve |
+
+The proxy injects the per-agent `Authorization: Bearer` token, strips any client-supplied `Authorization`, `Cookie`, and `X-Api-Key`, and drops spoofable `X-Forwarded-*` headers. It also rebases the agent's baked-in `/chat` URL prefix onto `/agent/<name>` so the single-page UI's API calls, service worker, and subresources all route back through the proxy — no changes to the agent needed.
+
+## The widget host (separate origin)
+
+Widgets are live, per-agent web apps. Serving them from the *same* origin as something sensitive is dangerous: a prompt-injected widget granted `allow-same-origin` runs as that origin. The fix is to serve widgets from a dedicated origin that hosts **nothing** except widgets.
+
+Enable it by giving the gateway a widget hostname:
+
+```bash
+term-llm serve-gateway --port 8090 --widget-host widgets.localhost
+```
+
+The same listener now answers on two origins:
+
+- the **agent origin** (e.g. `localhost:8090`) — agents, landing page, `/agents`;
+- the **widget origin** (e.g. `widgets.localhost:8090`) — **only** `/w/<agent>/<mount>/...`. Every other path 404s there.
+
+A widget request to `http://widgets.localhost:8090/w/fam/job-usage/` is proxied to that agent's serve at `{WEB_BASE_PATH}/widgets/job-usage/`, with the token injected exactly as for the agent proxy. Because the browser treats `widgets.localhost:8090` as a distinct origin from `localhost:8090`, a widget iframe is confined to that empty origin.
+
+Widget responses are passed through unchanged — widgets resolve their assets against their own origin via relative URLs, so no prefix rewriting is applied.
+
+When `--widget-host` is set, the landing page also lists each reachable agent's widgets (queried from that agent's serve), grouped under their agent, as links that open directly on the widget origin — so you do not have to construct the URLs by hand.
+
+### Making the widget origin resolve
+
+The same-origin policy is per *origin*, so the widget host must be a real hostname, not just a path. For a browser you need the hostname to resolve to the gateway:
+
+```bash
+# Simplest: a hosts-file entry.
+echo '127.0.0.1 widgets.localhost' | sudo tee -a /etc/hosts
+```
+
+On startup the gateway resolves the widget host and prints a warning if it does not resolve (so you are not left wondering why widget links 404 in the browser), or if it resolves to a non-loopback address.
+
+For CLI testing you can skip DNS entirely by setting the `Host` header:
+
+```bash
+curl -s -H 'Host: widgets.localhost' http://127.0.0.1:8090/w/fam/job-usage/
+```
+
+In production, point a `widgets.<your-host>` subdomain at the gateway.
+
+## Security posture
+
+- **No gateway auth yet.** Anyone who can reach the gateway can reach every discoverable agent. The gateway therefore refuses non-loopback binds — keep it on `127.0.0.1`/`localhost`/`::1` and front it with your own authenticating proxy to expose it.
+- **Tokens stay server-side.** Per-agent tokens are read from each workspace's `0600` `.env` and injected by the proxy; `/agents`, the landing page, and the browser never see them.
+- **Path safety.** Encoded path separators (`%2f`, `%5c`) and `..` segments are rejected; agent names and widget mounts are validated against their allowed character sets before any backend request.
+- **Bounded backends.** The proxy uses bounded dial and response-header timeouts so a hung agent can't tie it up, while leaving streaming responses (SSE) open.
+
+## Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--host` | `127.0.0.1` | Bind host (must be loopback) |
+| `--port` | `8090` | Bind port |
+| `--agent-host` | `127.0.0.1` | Host the per-agent serves are published on |
+| `--widget-host` | `widgets.localhost` | Dedicated origin for the widgets-only proxy (empty to disable) |
+
+## Limitations and roadmap
+
+- **No access grant yet.** The widget origin currently proxies any `/w/<agent>/<mount>/` request (loopback only). A signed, expiring access grant — so a widget link can be handed out and validated cross-origin — is the next step.
+- **Shared widget origin.** All widgets share one origin today, so they can read each other's `localStorage`. Acceptable within one trusted family; a per-agent widget subdomain is later hardening.

--- a/internal/contain/env.go
+++ b/internal/contain/env.go
@@ -1,0 +1,141 @@
+package contain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// defaultWebBasePath is the fallback URL prefix when a workspace .env has no
+// WEB_BASE_PATH. The fallback web port reuses webPortBase (see webport.go) so
+// there is a single source for the base port; note that the dynamic free-port
+// picker defaultWebPort() is for *creating* workspaces, not for reading an
+// existing one's config.
+const defaultWebBasePath = "/chat"
+
+// EnvPath returns the .env path for a named contain workspace. The file is
+// written with 0600 permissions and holds the workspace's web UI settings
+// (WEB_PORT, WEB_TOKEN, WEB_BASE_PATH) among other secrets.
+func EnvPath(name string) (string, error) {
+	dir, err := ContainerDir(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".env"), nil
+}
+
+// ReadEnvFile parses a KEY=VALUE .env file into a map. Blank lines and lines
+// beginning with '#' are ignored, surrounding whitespace is trimmed, and one
+// layer of surrounding single or double quotes is stripped from values. Lines
+// without an '=' are skipped.
+func ReadEnvFile(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	values := map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		if key != "" {
+			values[key] = value
+		}
+	}
+	return values, nil
+}
+
+// WebConfig captures the web UI connection settings for a contain workspace,
+// resolved from its .env file. It is the discovery surface a gateway needs to
+// reach an agent's serve without parsing the 0600 .env ad hoc.
+type WebConfig struct {
+	// Port is the host port the workspace's web UI is published on.
+	Port string
+	// Token is the bearer token guarding the web UI. Empty when not yet
+	// provisioned (e.g. a freshly templated workspace).
+	Token string
+	// BasePath is the URL prefix the web UI is mounted under (always rooted
+	// with a leading slash).
+	BasePath string
+}
+
+// ReadWebConfig reads the workspace .env and returns the resolved web UI
+// settings. Port and BasePath fall back to their template defaults when unset
+// or still holding an unrendered placeholder; Token has no default and is
+// returned empty when not yet provisioned. The error reports a missing or
+// unreadable workspace .env.
+func ReadWebConfig(name string) (WebConfig, error) {
+	if err := ValidateName(name); err != nil {
+		return WebConfig{}, err
+	}
+	envPath, err := EnvPath(name)
+	if err != nil {
+		return WebConfig{}, err
+	}
+	values, err := ReadEnvFile(envPath)
+	if err != nil {
+		return WebConfig{}, err
+	}
+	cfg := WebConfig{
+		Port:     resolveEnvValue(values["WEB_PORT"], strconv.Itoa(webPortBase)),
+		Token:    cleanEnvValue(values["WEB_TOKEN"]),
+		BasePath: resolveEnvValue(values["WEB_BASE_PATH"], defaultWebBasePath),
+	}
+	if err := validatePort(cfg.Port); err != nil {
+		return WebConfig{}, fmt.Errorf("workspace %q: %w", name, err)
+	}
+	if !strings.HasPrefix(cfg.BasePath, "/") {
+		cfg.BasePath = "/" + cfg.BasePath
+	}
+	// Mirror the serve's normalizeBasePath: drop trailing slashes so a workspace
+	// with WEB_BASE_PATH="/chat/" yields the same canonical "/chat" the serve
+	// bakes into its HTML. Guard against collapsing "/" to "".
+	if trimmed := strings.TrimRight(cfg.BasePath, "/"); trimmed != "" {
+		cfg.BasePath = trimmed
+	}
+	return cfg, nil
+}
+
+// validatePort rejects a WEB_PORT that is not a plain decimal TCP port in the
+// 1-65535 range. The default port is itself valid, so this also guards the
+// fallback. strconv.Atoi rejects signs-with-junk, leading "+", and trailing
+// characters, so "80x"/"-1" fail here rather than being silently truncated.
+func validatePort(port string) error {
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("invalid WEB_PORT %q: must be a number 1-65535", port)
+	}
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("invalid WEB_PORT %q: must be 1-65535", port)
+	}
+	return nil
+}
+
+// cleanEnvValue trims a value and discards unrendered template placeholders
+// (e.g. "{{web_token}}"), returning "" in that case.
+func cleanEnvValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || strings.Contains(v, "{{") {
+		return ""
+	}
+	return v
+}
+
+// resolveEnvValue returns the cleaned value, or def when the value is empty or
+// an unrendered placeholder.
+func resolveEnvValue(v, def string) string {
+	if cleaned := cleanEnvValue(v); cleaned != "" {
+		return cleaned
+	}
+	return def
+}

--- a/internal/contain/env_test.go
+++ b/internal/contain/env_test.go
@@ -1,0 +1,151 @@
+package contain
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestReadEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	contents := "" +
+		"# a comment\n" +
+		"\n" +
+		"WEB_PORT=8222\n" +
+		"WEB_TOKEN=\"quoted-secret\"\n" +
+		"  WEB_BASE_PATH = /chat \n" +
+		"MALFORMED\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	values, err := ReadEnvFile(path)
+	if err != nil {
+		t.Fatalf("ReadEnvFile error = %v", err)
+	}
+	if values["WEB_PORT"] != "8222" {
+		t.Errorf("WEB_PORT = %q want 8222", values["WEB_PORT"])
+	}
+	if values["WEB_TOKEN"] != "quoted-secret" {
+		t.Errorf("WEB_TOKEN = %q want quoted-secret", values["WEB_TOKEN"])
+	}
+	if values["WEB_BASE_PATH"] != "/chat" {
+		t.Errorf("WEB_BASE_PATH = %q want /chat", values["WEB_BASE_PATH"])
+	}
+	if _, ok := values["MALFORMED"]; ok {
+		t.Errorf("MALFORMED line should be skipped, got %q", values["MALFORMED"])
+	}
+}
+
+func TestReadWebConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeContainerEnv(t, "gw", "WEB_PORT=8222\nWEB_TOKEN=secret-token\nWEB_BASE_PATH=chat\n")
+
+	cfg, err := ReadWebConfig("gw")
+	if err != nil {
+		t.Fatalf("ReadWebConfig error = %v", err)
+	}
+	if cfg.Port != "8222" {
+		t.Errorf("Port = %q want 8222", cfg.Port)
+	}
+	if cfg.Token != "secret-token" {
+		t.Errorf("Token = %q want secret-token", cfg.Token)
+	}
+	// BasePath without a leading slash should be normalised.
+	if cfg.BasePath != "/chat" {
+		t.Errorf("BasePath = %q want /chat", cfg.BasePath)
+	}
+}
+
+func TestReadWebConfigDefaultsAndTemplates(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// Unrendered template placeholders and missing keys fall back to defaults;
+	// a templated token is treated as absent.
+	writeContainerEnv(t, "fresh", "WEB_PORT={{web_port}}\nWEB_TOKEN={{web_token}}\n")
+
+	cfg, err := ReadWebConfig("fresh")
+	if err != nil {
+		t.Fatalf("ReadWebConfig error = %v", err)
+	}
+	if cfg.Port != strconv.Itoa(webPortBase) {
+		t.Errorf("Port = %q want default %q", cfg.Port, strconv.Itoa(webPortBase))
+	}
+	if cfg.BasePath != defaultWebBasePath {
+		t.Errorf("BasePath = %q want default %q", cfg.BasePath, defaultWebBasePath)
+	}
+	if cfg.Token != "" {
+		t.Errorf("Token = %q want empty (templated placeholder)", cfg.Token)
+	}
+}
+
+func TestReadWebConfigMissingWorkspace(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if _, err := ReadWebConfig("does-not-exist"); err == nil {
+		t.Fatal("ReadWebConfig for missing workspace succeeded, want error")
+	}
+}
+
+func TestReadWebConfigRejectsInvalidPort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cases := []struct {
+		name string
+		env  string
+	}{
+		{"zero", "WEB_PORT=0\nWEB_TOKEN=t\n"},
+		{"too-big", "WEB_PORT=99999\nWEB_TOKEN=t\n"},
+		{"non-numeric", "WEB_PORT=abc\nWEB_TOKEN=t\n"},
+		{"trailing-junk", "WEB_PORT=80x\nWEB_TOKEN=t\n"},
+		{"negative", "WEB_PORT=-1\nWEB_TOKEN=t\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeContainerEnv(t, "gw-"+tc.name, tc.env)
+			if _, err := ReadWebConfig("gw-" + tc.name); err == nil {
+				t.Fatalf("ReadWebConfig with %q succeeded, want error", tc.env)
+			}
+		})
+	}
+}
+
+func TestReadWebConfigAcceptsValidAndDefaultPort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeContainerEnv(t, "ok", "WEB_PORT=8222\nWEB_TOKEN=t\n")
+	if _, err := ReadWebConfig("ok"); err != nil {
+		t.Fatalf("valid port rejected: %v", err)
+	}
+	// An unset / templated port must keep falling back to the default, not error.
+	writeContainerEnv(t, "tmpl", "WEB_PORT={{web_port}}\nWEB_TOKEN=t\n")
+	cfg, err := ReadWebConfig("tmpl")
+	if err != nil || cfg.Port != strconv.Itoa(webPortBase) {
+		t.Fatalf("templated port: cfg.Port=%q err=%v want %q/nil", cfg.Port, err, strconv.Itoa(webPortBase))
+	}
+}
+
+func TestReadWebConfigNormalizesTrailingSlash(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// A trailing slash on WEB_BASE_PATH must normalize to the same canonical
+	// form the serve bakes into its HTML, so the gateway's rebase needles match.
+	writeContainerEnv(t, "ws", "WEB_PORT=8222\nWEB_TOKEN=t\nWEB_BASE_PATH=/chat/\n")
+	cfg, err := ReadWebConfig("ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BasePath != "/chat" {
+		t.Errorf("BasePath = %q want /chat (trailing slash trimmed)", cfg.BasePath)
+	}
+}
+
+func writeContainerEnv(t *testing.T, name, contents string) {
+	t.Helper()
+	dir, err := ContainerDir(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/contain/webport.go
+++ b/internal/contain/webport.go
@@ -1,13 +1,10 @@
 package contain
 
 import (
-	"bufio"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 )
 
 // webPortBase is the first port term-llm tries to assign to a workspace Web UI.
@@ -59,35 +56,17 @@ func usedWorkspaceWebPorts() (map[int]bool, error) {
 	}
 	used := map[int]bool{}
 	for _, envPath := range matches {
-		if port, ok := readEnvWebPort(envPath); ok {
+		// Reuse the single .env parser (ReadEnvFile) rather than a second
+		// hand-rolled scanner, so quote/comment handling stays consistent.
+		values, err := ReadEnvFile(envPath)
+		if err != nil {
+			continue
+		}
+		if port, err := strconv.Atoi(values["WEB_PORT"]); err == nil {
 			used[port] = true
 		}
 	}
 	return used, nil
-}
-
-// readEnvWebPort extracts the WEB_PORT value from a workspace .env file.
-func readEnvWebPort(path string) (int, bool) {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, false
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "WEB_PORT=") {
-			continue
-		}
-		value := strings.TrimSpace(strings.TrimPrefix(line, "WEB_PORT="))
-		port, err := strconv.Atoi(value)
-		if err != nil {
-			return 0, false
-		}
-		return port, true
-	}
-	return 0, false
 }
 
 // hostPortAvailable reports whether the given TCP port can currently be bound on

--- a/internal/widgets/manifest.go
+++ b/internal/widgets/manifest.go
@@ -13,6 +13,14 @@ import (
 
 var mountRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
 
+// ValidMount reports whether s is a valid widget mount identifier: 1-64 chars,
+// starting with a lowercase letter or digit, containing only lowercase letters,
+// digits, and hyphens. It is the single source of truth for the mount charset,
+// shared by manifest validation and any proxy that routes by mount.
+func ValidMount(s string) bool {
+	return mountRe.MatchString(s)
+}
+
 // Manifest is the parsed contents of a widget.yaml file.
 type Manifest struct {
 	Title       string   `yaml:"title"`
@@ -132,7 +140,7 @@ func validateManifest(m *Manifest) error {
 	if strings.Contains(m.Mount, "/") {
 		return fmt.Errorf("mount %q must not contain a slash", m.Mount)
 	}
-	if !mountRe.MatchString(m.Mount) {
+	if !ValidMount(m.Mount) {
 		return fmt.Errorf("mount %q does not match required pattern ^[a-z0-9][a-z0-9-]{0,63}$", m.Mount)
 	}
 	if _, err := m.PlaceholderMode(); err != nil {

--- a/internal/widgets/manifest_test.go
+++ b/internal/widgets/manifest_test.go
@@ -3,8 +3,34 @@ package widgets
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestValidMount(t *testing.T) {
+	cases := []struct {
+		mount string
+		want  bool
+	}{
+		{"job-usage", true},
+		{"a", true},
+		{"0widget", true},
+		{"", false},
+		{"-leading-hyphen", false},
+		{"Upper", false},
+		{"under_score", false},
+		{"has/slash", false},
+		{"has.dot", false},
+		{"..", false},
+		{strings.Repeat("a", 64), true},
+		{strings.Repeat("a", 65), false},
+	}
+	for _, tc := range cases {
+		if got := ValidMount(tc.mount); got != tc.want {
+			t.Errorf("ValidMount(%q) = %v, want %v", tc.mount, got, tc.want)
+		}
+	}
+}
 
 func TestPlaceholderMode(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

Adds `term-llm serve-gateway` — a thin reverse proxy that fronts the per-agent web serves of several contain workspaces under one origin, and (optionally) serves each agent's widgets from a dedicated, isolated origin.

<img width="932" height="890" alt="Screenshot 2026-06-05 at 14 43 47" src="https://github.com/user-attachments/assets/d5f8dd06-3d36-4470-901a-20e480bb58ea" />

A `term-llm serve` binds a single agent at startup, so multi-agent access is achieved by fronting many serves rather than routing agents inside one process (already the production shape: one container per agent). The gateway discovers each agent's published port + bearer token from its workspace `.env` and injects the token **server-side**, so the per-agent token never reaches the browser.

This is the foundation for two things: reaching many agents from one place, and the separate-origin widget host that future work (a signed access grant) will use to safely embed/publish widgets.

## What's included

**Agent proxy**
- `GET /agents` (JSON, never includes tokens), an HTML landing page, and `ANY /agent/<name>/...` reverse-proxied to that agent's serve.
- Injects `Authorization: Bearer <token>`; strips client `Authorization`, `Cookie`, `X-Api-Key`, and spoofable `X-Forwarded-*`.
- Rebases the agent's baked-in `/chat` prefix onto `/agent/<name>` so the SPA's API calls, service worker, and subresources all route back through the proxy — zero changes to the agent.

**Separate-origin widget host** (`--widget-host`, default `widgets.localhost`)
- Serves **only** `/w/<agent>/<mount>/...` on a dedicated origin; every other path 404s there. That emptiness is the isolation property: a widget iframe granted `allow-same-origin` is confined to a throwaway origin that hosts nothing sensitive.
- Routes by `Host` header; the agent origin never exposes `/w/`, and the widget origin never exposes `/agents`, `/agent/*`, or the landing page.

**Discovery + UX**
- New `contain port` / `contain token` subcommands and `contain.ReadWebConfig`, the single source for reading a workspace's web config.
- Landing page lists each reachable agent and its widgets (grouped per agent) with links to the widget origin; markup/styles live in embedded `.html`/`.css` files (matching the `serveui` convention).

**Hardening**
- Refuses non-loopback binds (no gateway auth yet).
- Validates `WEB_PORT`; rejects a loopback-literal `--widget-host` that would shadow the gateway; warns at startup if the widget host doesn't resolve.
- Bounded dial/response-header timeouts that leave SSE streams open; per-agent web-config cache invalidated by `.env` mtime; no environment proxy on the backend transport (avoids leaking the injected token via `HTTP_PROXY`).

**Docs:** new `Multi-agent gateway` guide.

## Security posture

Experimental and **loopback-only** by design:
- **No gateway-level authentication yet** — anyone who can reach the gateway can reach every discoverable agent; the enforced loopback bind is the safety net. To expose it, front it with an authenticating proxy and keep the gateway on loopback.
- **No widget access grant yet** — the widget origin proxies any `/w/<agent>/<mount>/` request (loopback only). A signed, expiring HMAC grant for safe cross-origin use is the next step, and the piece that actually closes the widget-iframe XSS in production.

An independent multi-agent code review was run over the diff; the top findings were fixed (HEAD/empty-body response handling, the `HTTP_PROXY` token-leak path, query-string preservation on the widget redirect, and the widget-host/agent-host shadowing guard).
