### PR TITLE
fix: WebRTC data-channel requests spawn unbounded handler goroutines

### DIFF
--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -34,6 +34,10 @@ import (
 
 const maxFrameBytes = 10 * 1024 * 1024 // 10 MB
 
+// Cap per-channel HTTP dispatches so one client cannot create an unbounded
+// number of expensive handler goroutines.
+const maxDataChannelConcurrentRequests = 8
+
 // signalingMsg is a message exchanged via the signaling server.
 type signalingMsg struct {
 	SessionID string `json:"session_id"`
@@ -520,6 +524,15 @@ func (p *peer) runDataChannel(ctx context.Context, dc *datachannel.DataChannel) 
 
 	// Signal idle resets via channel so we avoid concurrent Timer.Reset / Timer.C access.
 	activity := make(chan struct{}, 1)
+	requestSlots := make(chan struct{}, maxDataChannelConcurrentRequests)
+	stop := make(chan struct{})
+	var stopOnce sync.Once
+	stopDataChannel := func() {
+		stopOnce.Do(func() {
+			close(stop)
+			_ = dc.Close()
+		})
+	}
 
 	var wg sync.WaitGroup
 	readDone := make(chan struct{})
@@ -544,18 +557,23 @@ func (p *peer) runDataChannel(ctx context.Context, dc *datachannel.DataChannel) 
 			case activity <- struct{}{}:
 			default:
 			}
+			if !acquireDataChannelRequestSlot(ctx, stop, requestSlots) {
+				return
+			}
 			wg.Add(1)
-			go func() {
+			go func(data []byte) {
 				defer wg.Done()
+				defer func() { <-requestSlots }()
 				p.dispatchRequest(ctx, send, data)
-			}()
+			}(data)
 		}
 	}()
 
 	for {
 		select {
 		case <-ctx.Done():
-			_ = dc.Close()
+			stopDataChannel()
+			<-readDone
 			wg.Wait()
 			return
 		case <-readDone:
@@ -571,10 +589,24 @@ func (p *peer) runDataChannel(ctx context.Context, dc *datachannel.DataChannel) 
 			idle.Reset(p.cfg.IdleTimeout)
 		case <-idle.C:
 			log.Printf("webrtc: connection idle timeout, closing data channel")
-			_ = dc.Close()
+			stopDataChannel()
+			<-readDone
 			wg.Wait()
 			return
 		}
+	}
+}
+
+// acquireDataChannelRequestSlot bounds per-channel request concurrency and
+// unblocks promptly when the peer is shutting down.
+func acquireDataChannelRequestSlot(ctx context.Context, stop <-chan struct{}, slots chan struct{}) bool {
+	select {
+	case slots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-stop:
+		return false
 	}
 }
 

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestPeer creates a peer wired to handler with the given basePath,
@@ -49,6 +50,60 @@ func encodeRequest(id, method, path string, headers map[string]string, body stri
 	}
 	data, _ := json.Marshal(f)
 	return data
+}
+
+func TestAcquireDataChannelRequestSlot_BlocksUntilReleased(t *testing.T) {
+	slots := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	if !acquireDataChannelRequestSlot(context.Background(), stop, slots) {
+		t.Fatal("first slot acquire returned false")
+	}
+
+	acquired := make(chan bool, 1)
+	go func() {
+		acquired <- acquireDataChannelRequestSlot(context.Background(), stop, slots)
+	}()
+
+	select {
+	case ok := <-acquired:
+		t.Fatalf("second acquire completed before release: %v", ok)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	<-slots
+
+	select {
+	case ok := <-acquired:
+		if !ok {
+			t.Fatal("second acquire returned false after release")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second acquire did not complete after release")
+	}
+}
+
+func TestAcquireDataChannelRequestSlot_StopsWhenConnectionClosing(t *testing.T) {
+	slots := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	if !acquireDataChannelRequestSlot(context.Background(), stop, slots) {
+		t.Fatal("first slot acquire returned false")
+	}
+
+	acquired := make(chan bool, 1)
+	go func() {
+		acquired <- acquireDataChannelRequestSlot(context.Background(), stop, slots)
+	}()
+
+	close(stop)
+
+	select {
+	case ok := <-acquired:
+		if ok {
+			t.Fatal("acquire returned true after connection stop")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("acquire did not unblock after connection stop")
+	}
 }
 
 // --- validPath tests ---


### PR DESCRIPTION
## What changed

- Bounded WebRTC data-channel request handling to a fixed per-channel concurrency limit instead of spawning an unbounded goroutine for every incoming frame.
- Added a request-slot gate in `runDataChannel()` so once the per-channel limit is reached, the read loop blocks and backpressures the client instead of creating more handler goroutines.
- Added a shutdown-aware stop path so a saturated connection still exits cleanly when the peer is canceled or the idle timeout closes the channel.
- Added unit tests covering both behaviors: blocking when all slots are busy, and prompt unblock when the connection is stopping.

## Why this is high-value

Each WebRTC frame can become a full HTTP request plus `ServeHTTP()` execution. Before this change, a bursty or buggy client could cause `runDataChannel()` to create an unbounded number of goroutines, while writes were still serialized behind a single `sendMu`. That made the transport vulnerable to per-client goroutine and memory blowups, with queued response state piling up behind one writer.

This fix makes the work per connection bounded. At most `maxDataChannelConcurrentRequests` handlers can run at once for a given data channel, and additional frames are naturally backpressured by stopping reads until capacity is available.

## Validation

- Read and verified the current code path in `internal/webrtc/peer.go` did `wg.Add(1)` + `go p.dispatchRequest(...)` for every frame with no bound.
- Ran `gofmt -w internal/webrtc/peer.go internal/webrtc/peer_test.go`
- Ran `go build ./...`
- Ran `go test ./...`
- Ran `git diff --stat`
- Ran `git diff --check`
