### PR TITLE
fix: Prompt-template git probes can hang session startup because they use uncancelled subprocesses

### DIFF
--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"os/user"
@@ -282,10 +283,13 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 	})
 }
 
+// gitProbeTimeout bounds git subprocesses used during template expansion so prompt construction
+// fails open instead of hanging session startup on unhealthy repositories or filesystems.
+var gitProbeTimeout = 2 * time.Second
+
 // getGitInfo returns the current git branch and repository name, or empty strings if not in a git repo.
 func getGitInfo() (string, string) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD", "--show-toplevel")
-	output, err := cmd.Output()
+	output, err := runGitOutput("", "rev-parse", "--abbrev-ref", "HEAD", "--show-toplevel")
 	if err != nil {
 		return "", ""
 	}
@@ -304,12 +308,10 @@ func getGitInfo() (string, string) {
 // Combines both staged and unstaged changes.
 func getGitDiffStat() string {
 	// Get unstaged changes (--no-color prevents ANSI codes from leaking into prompts)
-	cmd := exec.Command("git", "diff", "--stat", "--stat-width=80", "--no-color")
-	unstaged, _ := cmd.Output()
+	unstaged, _ := runGitOutput("", "diff", "--stat", "--stat-width=80", "--no-color")
 
 	// Get staged changes
-	cmd = exec.Command("git", "diff", "--cached", "--stat", "--stat-width=80", "--no-color")
-	staged, _ := cmd.Output()
+	staged, _ := runGitOutput("", "diff", "--cached", "--stat", "--stat-width=80", "--no-color")
 
 	var result strings.Builder
 	if len(staged) > 0 {
@@ -323,6 +325,15 @@ func getGitDiffStat() string {
 		result.Write(unstaged)
 	}
 	return strings.TrimSpace(result.String())
+}
+
+func runGitOutput(dir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitProbeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	return cmd.Output()
 }
 
 // itoa is a simple int to string conversion.
@@ -460,9 +471,7 @@ func findFallbackInstructions(cwd, repoRoot string) string {
 
 // findGitRoot returns the git repository root for the given path, or empty string if not in a repo.
 func findGitRoot(path string) string {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Dir = path
-	output, err := cmd.Output()
+	output, err := runGitOutput(path, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return ""
 	}

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -194,6 +194,78 @@ func TestNewTemplateContextForTemplate_CoalescesGitLookups(t *testing.T) {
 	}
 }
 
+func TestNewTemplateContextForTemplate_GitInfoTimeoutFailsOpen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git PATH shim test requires a POSIX shell")
+	}
+
+	shimDir := t.TempDir()
+	logPath := filepath.Join(shimDir, "git.log")
+	gitPath := filepath.Join(shimDir, "git")
+	script := "#!/bin/sh\necho invoked >> \"" + logPath + "\"\nwhile :; do :; done\n"
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", shimDir+string(os.PathListSeparator)+origPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	defer os.Setenv("PATH", origPath)
+
+	origTimeout := gitProbeTimeout
+	gitProbeTimeout = 20 * time.Millisecond
+	defer func() { gitProbeTimeout = origTimeout }()
+
+	start := time.Now()
+	ctx := NewTemplateContextForTemplate("{{git_branch}} {{git_repo}}")
+	elapsed := time.Since(start)
+
+	if ctx.GitBranch != "" {
+		t.Fatalf("GitBranch = %q, want empty", ctx.GitBranch)
+	}
+	if ctx.GitRepo != "" {
+		t.Fatalf("GitRepo = %q, want empty", ctx.GitRepo)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("NewTemplateContextForTemplate took %v, want timeout fail-open well under 1s", elapsed)
+	}
+}
+
+func TestNewTemplateContextForTemplate_GitDiffStatTimeoutFailsOpen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git PATH shim test requires a POSIX shell")
+	}
+
+	shimDir := t.TempDir()
+	gitPath := filepath.Join(shimDir, "git")
+	script := "#!/bin/sh\nwhile :; do :; done\n"
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", shimDir+string(os.PathListSeparator)+origPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	defer os.Setenv("PATH", origPath)
+
+	origTimeout := gitProbeTimeout
+	gitProbeTimeout = 20 * time.Millisecond
+	defer func() { gitProbeTimeout = origTimeout }()
+
+	start := time.Now()
+	ctx := NewTemplateContextForTemplate("{{git_diff_stat}}")
+	elapsed := time.Since(start)
+
+	if ctx.GitDiffStat != "" {
+		t.Fatalf("GitDiffStat = %q, want empty", ctx.GitDiffStat)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("NewTemplateContextForTemplate took %v, want timeout fail-open well under 1s", elapsed)
+	}
+}
+
 func TestTemplateVariablesAllowsWhitespace(t *testing.T) {
 	vars := templateVariables("{{ git_repo }}/{{git_branch}} {{ git_diff_stat }} {{ agents }} {{ handover_dir }} {{ handover_path }}")
 	for _, name := range []string{"git_repo", "git_branch", "git_diff_stat", "agents", "handover_dir", "handover_path"} {


### PR DESCRIPTION
## What changed

- Added a shared `runGitOutput` helper in `internal/agents/template.go` that runs git probes with `exec.CommandContext` and a short `gitProbeTimeout`.
- Routed `getGitInfo`, `getGitDiffStat`, and `findGitRoot` through that timeout-bound helper.
- Added focused tests proving template expansion now fails open and returns empty git metadata quickly when git hangs.

## Why this is high-value

Prompt construction runs before any model call starts, and built-in agents commonly use `{{git_branch}}`, `{{git_repo}}`, and `{{git_diff_stat}}`. Before this change, a slow or unhealthy repository/filesystem could block session startup indefinitely because those git subprocesses had no cancellation or timeout. This fix prevents the entire CLI/web/jobs surface from appearing dead by bounding that preflight work and degrading gracefully to empty metadata.

## Validation

- `gofmt -w internal/agents/template.go internal/agents/template_test.go`
- `go build ./...`
- `go test ./...`
- Added timeout regression tests for `{{git_branch}}`/`{{git_repo}}` and `{{git_diff_stat}}`
- `git diff --stat`
- `git diff --check`
