### PR TITLE
fix: HTTP MCP clients hard-timeout every tool call and stream at 30s

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -134,22 +135,32 @@ func (c *Client) createStdioTransport(ctx context.Context) mcp.Transport {
 
 // createHTTPTransport creates an HTTP transport for URL-based servers.
 func (c *Client) createHTTPTransport() mcp.Transport {
-	// Create HTTP client with custom headers if specified
-	httpClient := &http.Client{Timeout: 30 * time.Second}
+	// Use transport-level timeouts so caller contexts control the full request
+	// lifetime, including long-running tool calls and streams.
+	baseTransport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   15 * time.Second,
+		ResponseHeaderTimeout: 2 * time.Minute,
+		IdleConnTimeout:       90 * time.Second,
+	}
+
+	httpClient := &http.Client{Transport: baseTransport}
+
+	// If headers are specified, wrap the transport with a custom round tripper.
+	if len(c.config.Headers) > 0 {
+		httpClient.Transport = &headerTransport{
+			base:    baseTransport,
+			headers: c.config.Headers,
+		}
+	}
 
 	// Use StreamableClientTransport (the modern MCP transport)
 	transport := &mcp.StreamableClientTransport{
 		Endpoint:   c.config.URL,
 		HTTPClient: httpClient,
 		MaxRetries: 5,
-	}
-
-	// If headers are specified, wrap the transport with a custom round tripper
-	if len(c.config.Headers) > 0 {
-		httpClient.Transport = &headerTransport{
-			base:    http.DefaultTransport,
-			headers: c.config.Headers,
-		}
 	}
 
 	return transport

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -129,6 +130,76 @@ func TestCreateStdioTransport_EnvOverridesParent(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected overridden env var in subprocess env")
+	}
+}
+
+func TestCreateHTTPTransport_UsesTransportLevelTimeouts(t *testing.T) {
+	client := &Client{
+		name: "test",
+		config: ServerConfig{
+			URL: "https://example.com/mcp",
+		},
+	}
+
+	transport := client.createHTTPTransport()
+	st, ok := transport.(*sdkmcp.StreamableClientTransport)
+	if !ok {
+		t.Fatal("expected sdkmcp.StreamableClientTransport")
+	}
+	if st.HTTPClient == nil {
+		t.Fatal("expected HTTP client")
+	}
+	if st.HTTPClient.Timeout != 0 {
+		t.Fatalf("HTTPClient.Timeout = %v, want 0 so context controls long-running calls", st.HTTPClient.Timeout)
+	}
+
+	ht, ok := st.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("HTTPClient.Transport = %T, want *http.Transport", st.HTTPClient.Transport)
+	}
+	if ht.DialContext == nil {
+		t.Fatal("expected DialContext timeout transport")
+	}
+	if ht.TLSHandshakeTimeout == 0 {
+		t.Fatal("expected TLS handshake timeout")
+	}
+	if ht.ResponseHeaderTimeout == 0 {
+		t.Fatal("expected response header timeout")
+	}
+	if ht.IdleConnTimeout == 0 {
+		t.Fatal("expected idle connection timeout")
+	}
+}
+
+func TestCreateHTTPTransport_HeadersWrapTimeoutTransport(t *testing.T) {
+	client := &Client{
+		name: "test",
+		config: ServerConfig{
+			URL:     "https://example.com/mcp",
+			Headers: map[string]string{"Authorization": "Bearer token"},
+		},
+	}
+
+	transport := client.createHTTPTransport()
+	st := transport.(*sdkmcp.StreamableClientTransport)
+	if st.HTTPClient.Timeout != 0 {
+		t.Fatalf("HTTPClient.Timeout = %v, want 0 so context controls long-running calls", st.HTTPClient.Timeout)
+	}
+
+	ht, ok := st.HTTPClient.Transport.(*headerTransport)
+	if !ok {
+		t.Fatalf("HTTPClient.Transport = %T, want *headerTransport", st.HTTPClient.Transport)
+	}
+	if got := ht.headers["Authorization"]; got != "Bearer token" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer token")
+	}
+
+	base, ok := ht.base.(*http.Transport)
+	if !ok {
+		t.Fatalf("headerTransport.base = %T, want *http.Transport", ht.base)
+	}
+	if base.ResponseHeaderTimeout == 0 {
+		t.Fatal("expected wrapped transport to keep response header timeout")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Removed the 30s `http.Client.Timeout` from `internal/mcp/client.go` for HTTP MCP transports.
- Replaced it with transport-level connection safety timeouts (`DialContext`, `TLSHandshakeTimeout`, `ResponseHeaderTimeout`, `IdleConnTimeout`).
- Kept custom header injection working by wrapping the configured timeout transport instead of falling back to `http.DefaultTransport`.
- Added tests covering that HTTP MCP clients now rely on caller contexts for full request lifetime and still preserve timeout-protected transports when headers are configured.

## Why this is high-value

HTTP MCP is one of the main extensibility paths for term-llm. With `http.Client.Timeout`, every HTTP MCP operation had a hard whole-request deadline of 30 seconds, including reading the response body. That made legitimate long-running tool calls, startup `ListTools` calls, streaming responses, and long-poll style MCP interactions fail even when the caller context intentionally allowed more time.

This change removes that false failure mode while still protecting connection setup and stalled initial responses.

## Validation

- Verified the issue in current code: `createHTTPTransport()` constructed `&http.Client{Timeout: 30 * time.Second}` and passed it to `mcp.StreamableClientTransport`, which is used for both startup tool discovery and live tool execution.
- Ran `gofmt -w internal/mcp/client.go internal/mcp/client_test.go`
- Ran `go build ./...`
- Ran `go test ./...`
- Ran `git diff --stat`
- Ran `git diff --check`
