### PR TITLE
fix: Loading legacy compacted sessions does quadratic duplicate-tail detection on every open

### DIFF
--- a/internal/session/context_state.go
+++ b/internal/session/context_state.go
@@ -52,6 +52,17 @@ func clearCompactionBoundary(ctx context.Context, store Store, sess *Session) {
 	}
 }
 
+func persistCompactionTailHints(ctx context.Context, store Store, sess *Session, messageIDs []int64) {
+	if store == nil || sess == nil || len(messageIDs) == 0 {
+		return
+	}
+	if persister, ok := store.(interface {
+		PersistCompactionTailHints(context.Context, string, []int64) error
+	}); ok {
+		_ = persister.PersistCompactionTailHints(ctx, sess.ID, messageIDs)
+	}
+}
+
 // LoadScrollbackWithBoundary loads all persisted messages for display while
 // also returning the index where active LLM context begins.
 func LoadScrollbackWithBoundary(ctx context.Context, store Store, sess *Session) ([]Message, int, error) {
@@ -67,7 +78,9 @@ func LoadScrollbackWithBoundary(ctx context.Context, store Store, sess *Session)
 	}
 	for i, msg := range messages {
 		if msg.Sequence >= sess.CompactionSeq {
-			messages = markCompactionDisplayTails(messages)
+			var persistedTailIDs []int64
+			messages, persistedTailIDs = markCompactionDisplayTailsForPersistence(messages)
+			persistCompactionTailHints(ctx, store, sess, persistedTailIDs)
 			return messages, i, nil
 		}
 	}
@@ -151,20 +164,29 @@ func markNewCompactionTailRows(messages []Message) {
 }
 
 func markCompactionDisplayTails(messages []Message) []Message {
+	marked, _ := markCompactionDisplayTailsForPersistence(messages)
+	return marked
+}
+
+func markCompactionDisplayTailsForPersistence(messages []Message) ([]Message, []int64) {
 	if len(messages) == 0 {
-		return messages
+		return messages, nil
 	}
 	out := append([]Message(nil), messages...)
-	fingerprints := make([]string, len(out))
-	for i := range out {
-		fingerprints[i] = messageDisplayFingerprint(out[i])
-	}
+	var fingerprints []string
+	var persistedTailIDs []int64
 	for i := 0; i < len(out); i++ {
 		if !isInternalCompactionSummaryMessage(out[i]) {
 			continue
 		}
 		if persistedCompactionTailAlreadyMarked(out, i) {
 			continue
+		}
+		if fingerprints == nil {
+			fingerprints = make([]string, len(out))
+			for j := range out {
+				fingerprints[j] = messageDisplayFingerprint(out[j])
+			}
 		}
 		start, dupLen := compactionDuplicateTailRange(out, fingerprints, i)
 		if dupLen > 0 {
@@ -173,15 +195,24 @@ func markCompactionDisplayTails(messages []Message) []Message {
 			// but are already visible in the pre-compaction transcript, so display
 			// renderers should suppress them instead of echoing them a second time.
 			for j := i + 1; j < start+dupLen && j < len(out); j++ {
+				if out[j].CompactionTail {
+					continue
+				}
 				out[j].CompactionTail = true
+				if out[j].ID != 0 {
+					persistedTailIDs = append(persistedTailIDs, out[j].ID)
+				}
 			}
 			continue
 		}
-		if i+1 < len(out) && isSyntheticCompactionAckMessage(out[i+1]) {
+		if i+1 < len(out) && isSyntheticCompactionAckMessage(out[i+1]) && !out[i+1].CompactionTail {
 			out[i+1].CompactionTail = true
+			if out[i+1].ID != 0 {
+				persistedTailIDs = append(persistedTailIDs, out[i+1].ID)
+			}
 		}
 	}
-	return out
+	return out, persistedTailIDs
 }
 
 func persistedCompactionTailAlreadyMarked(messages []Message, summaryIdx int) bool {

--- a/internal/session/context_state_test.go
+++ b/internal/session/context_state_test.go
@@ -299,6 +299,14 @@ func TestLoadScrollbackWithBoundaryMarksRetainedRawSuffixHiddenFromDisplay(t *te
 		t.Fatalf("post-compaction ack/tail rows should be hidden from display: %#v", all[6:])
 	}
 
+	persisted, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after backfill: %v", err)
+	}
+	if !persisted[6].CompactionTail || !persisted[7].CompactionTail || !persisted[8].CompactionTail {
+		t.Fatalf("legacy compaction tail hints were not persisted: %#v", persisted[6:])
+	}
+
 	active, err := LoadActiveMessages(ctx, store, refreshed)
 	if err != nil {
 		t.Fatalf("LoadActiveMessages: %v", err)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1700,6 +1700,46 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, msg *
 	})
 }
 
+func (s *SQLiteStore) PersistCompactionTailHints(ctx context.Context, sessionID string, messageIDs []int64) error {
+	if !s.hasMessageCompactionTail || len(messageIDs) == 0 {
+		return nil
+	}
+
+	args := make([]any, 0, len(messageIDs)+1)
+	args = append(args, sessionID)
+	placeholders := make([]string, 0, len(messageIDs))
+	seen := make(map[int64]struct{}, len(messageIDs))
+	for _, id := range messageIDs {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		placeholders = append(placeholders, "?")
+		args = append(args, id)
+	}
+	if len(placeholders) == 0 {
+		return nil
+	}
+
+	query := `
+		UPDATE messages
+		SET compaction_tail = TRUE
+		WHERE session_id = ?
+		  AND COALESCE(compaction_tail, FALSE) = FALSE
+		  AND id IN (` + strings.Join(placeholders, ",") + `)`
+
+	return retryOnBusy(ctx, 5, func() error {
+		_, err := s.db.ExecContext(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("persist compaction tail hints: %w", err)
+		}
+		return nil
+	})
+}
+
 func (s *SQLiteStore) ClearCompactionBoundary(ctx context.Context, id string) error {
 	if !s.hasCompactionSeq {
 		return nil


### PR DESCRIPTION
## What changed

- Backfill `messages.compaction_tail` the first time `LoadScrollbackWithBoundary()` discovers legacy retained-tail rows for an older compacted session.
- Add a SQLite-only `PersistCompactionTailHints` write path that flips those discovered rows to `compaction_tail=TRUE` without touching session timestamps.
- Make `markCompactionDisplayTails()` build message fingerprints lazily, only when an unmarked compaction summary actually needs duplicate-tail detection.
- Extend the session test to verify that loading a legacy compacted session now persists the discovered tail markers.

## Why this is high-value

Opening a long pre-migration compacted session was still doing expensive duplicate-tail detection on every load because the display hints were never written back. This keeps the load path hot for exactly the users with the longest histories.

This fix is high-value because it turns that repeated work into a one-time migration-on-read:

- first open: detect the retained tail once using the already-loaded messages, then persist the discovered `compaction_tail` hints
- later opens: skip the fallback detection path entirely because the persisted flags are already present
- already-fixed sessions: also avoid unnecessary JSON fingerprinting, because fingerprints are now built lazily only when an unmarked summary is encountered

That reduces repeated JSON marshaling, duplicate-tail comparisons, and user-visible latency when reopening/resuming long compacted chats.

## Validation

- Added/updated test coverage in `internal/session/context_state_test.go` to verify legacy compaction-tail hints are persisted after load.
- `gofmt -w internal/session/context_state.go internal/session/context_state_test.go internal/session/sqlite.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
