### PR TITLE
fix: back queued agent tools with jobs v2

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -247,7 +247,7 @@ func AddMaxOutputTokensFlag(cmd *cobra.Command, dest *int) {
 
 // AddToolFlags adds tool-related flags (--tools, --read-dir, --write-dir, --shell-allow)
 func AddToolFlags(cmd *cobra.Command, tools *string, readDirs, writeDirs, shellAllow *[]string) {
-	cmd.Flags().StringVar(tools, "tools", "", "Enable local tools (comma-separated, or 'all'): read_file,write_file,edit_file,shell,grep,glob,view_image,show_image,image_generate,ask_user,spawn_agent")
+	cmd.Flags().StringVar(tools, "tools", "", "Enable local tools (comma-separated, or 'all'): read_file,write_file,edit_file,shell,grep,glob,view_image,show_image,image_generate,ask_user,spawn_agent,queue_agent,wait_for_agent")
 	cmd.Flags().StringArrayVar(readDirs, "read-dir", nil, "Directories for read_file/grep/glob/view_image tools (repeatable)")
 	cmd.Flags().StringArrayVar(writeDirs, "write-dir", nil, "Directories for write_file/edit_file tools (repeatable)")
 	cmd.Flags().StringArrayVar(shellAllow, "shell-allow", nil, "Shell command patterns to allow (repeatable, glob syntax)")

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -301,8 +301,14 @@ func (r *LocalToolRegistry) RegisterCustomTools(defs []agents.CustomToolDef, age
 			return fmt.Errorf("custom tool %q: name must match ^[a-z][a-z0-9_]*$", def.Name)
 		}
 
-		// Check for collision with built-in tool names
-		if ValidToolName(def.Name) {
+		// Check for collision with already-registered tools. Legacy Jarvis installs
+		// shipped queue_agent/wait_for_agent as custom script tools before they became
+		// built-ins, so those names may be overridden when the built-in tool was not
+		// explicitly enabled.
+		if _, exists := r.tools[def.Name]; exists {
+			return fmt.Errorf("custom tool %q collides with a built-in tool name", def.Name)
+		}
+		if ValidToolName(def.Name) && def.Name != QueueAgentToolName && def.Name != WaitForAgentToolName {
 			return fmt.Errorf("custom tool %q collides with a built-in tool name", def.Name)
 		}
 

--- a/internal/tools/custom_tool_test.go
+++ b/internal/tools/custom_tool_test.go
@@ -322,6 +322,35 @@ func TestRegisterCustomTools_BuiltinCollision(t *testing.T) {
 	}
 }
 
+func TestRegisterCustomTools_LegacyQueuedAgentNameAllowedWhenBuiltinDisabled(t *testing.T) {
+	r := &LocalToolRegistry{
+		tools: make(map[string]llm.Tool),
+	}
+
+	err := r.RegisterCustomTools([]agents.CustomToolDef{
+		{Name: QueueAgentToolName, Description: "legacy", Script: "queue-agent.sh"},
+		{Name: WaitForAgentToolName, Description: "legacy", Script: "wait-for-agent.sh"},
+	}, "/agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRegisterCustomTools_QueuedAgentNameCollidesWhenBuiltinEnabled(t *testing.T) {
+	r := &LocalToolRegistry{
+		tools: map[string]llm.Tool{
+			QueueAgentToolName: NewQueueAgentTool(),
+		},
+	}
+
+	err := r.RegisterCustomTools([]agents.CustomToolDef{
+		{Name: QueueAgentToolName, Description: "legacy", Script: "queue-agent.sh"},
+	}, "/agent")
+	if err == nil {
+		t.Fatal("expected error for enabled queue_agent collision")
+	}
+}
+
 func TestRegisterCustomTools_InvalidName(t *testing.T) {
 	r := &LocalToolRegistry{
 		tools: make(map[string]llm.Tool),

--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -1,0 +1,524 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+const (
+	defaultQueuedAgentTimeout      = 3600
+	defaultQueuedAgentPollInterval = 5
+	defaultJobsServerBaseURL       = "http://127.0.0.1:8080"
+)
+
+type QueueAgentArgs struct {
+	AgentName      string `json:"agent,omitempty"`
+	AgentNameAlias string `json:"agent_name,omitempty"`
+	Prompt         string `json:"prompt"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Cwd            string `json:"cwd,omitempty"`
+}
+
+type QueueAgentResult struct {
+	JobID     string `json:"job_id"`
+	RunID     string `json:"run_id"`
+	AgentName string `json:"agent"`
+}
+
+type WaitForAgentArgs struct {
+	PollIntervalSeconds int      `json:"poll_interval_seconds,omitempty"`
+	RunIDs              []string `json:"run_ids"`
+}
+
+type QueuedAgentRunResult struct {
+	RunID           string   `json:"run_id"`
+	JobID           string   `json:"job_id,omitempty"`
+	Status          string   `json:"status"`
+	ExitReason      string   `json:"exit_reason,omitempty"`
+	Truncated       bool     `json:"truncated,omitempty"`
+	TurnCount       *int     `json:"turn_count,omitempty"`
+	InputTokens     *int     `json:"input_tokens,omitempty"`
+	OutputTokens    *int     `json:"output_tokens,omitempty"`
+	DurationSeconds *float64 `json:"duration_seconds,omitempty"`
+	Response        string   `json:"response,omitempty"`
+	Stdout          string   `json:"stdout,omitempty"`
+	Error           string   `json:"error,omitempty"`
+	ExitCode        *int     `json:"exit_code,omitempty"`
+	StartedAt       string   `json:"started_at,omitempty"`
+	FinishedAt      string   `json:"finished_at,omitempty"`
+}
+
+type jobsBackedAgentClient struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+type jobsV2AgentJobPayload struct {
+	Name              string         `json:"name"`
+	Enabled           bool           `json:"enabled"`
+	RunnerType        string         `json:"runner_type"`
+	RunnerConfig      map[string]any `json:"runner_config"`
+	TriggerType       string         `json:"trigger_type"`
+	TriggerConfig     map[string]any `json:"trigger_config,omitempty"`
+	ConcurrencyPolicy string         `json:"concurrency_policy"`
+	TimeoutSeconds    int            `json:"timeout_seconds"`
+	MisfirePolicy     string         `json:"misfire_policy"`
+}
+
+type jobsV2AgentJobResponse struct {
+	ID string `json:"id"`
+}
+
+type jobsV2AgentRunResponse struct {
+	ID           string `json:"id"`
+	JobID        string `json:"job_id"`
+	Status       string `json:"status"`
+	ExitReason   string `json:"exit_reason"`
+	Truncated    bool   `json:"truncated"`
+	TurnCount    *int   `json:"turn_count"`
+	InputTokens  *int   `json:"input_tokens"`
+	OutputTokens *int   `json:"output_tokens"`
+	Response     string `json:"response"`
+	Stdout       string `json:"stdout"`
+	Error        string `json:"error"`
+	ExitCode     *int   `json:"exit_code"`
+	StartedAt    string `json:"started_at"`
+	FinishedAt   string `json:"finished_at"`
+}
+
+type jobsV2ErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
+}
+
+type QueueAgentTool struct {
+	client *jobsBackedAgentClient
+}
+
+func NewQueueAgentTool() *QueueAgentTool {
+	return NewQueueAgentToolWithClient(newJobsBackedAgentClientFromEnv())
+}
+
+func NewQueueAgentToolWithClient(client *jobsBackedAgentClient) *QueueAgentTool {
+	return &QueueAgentTool{client: client}
+}
+
+func (t *QueueAgentTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        QueueAgentToolName,
+		Description: `Spawn a sub-agent as a background jobs-v2 LLM run and return immediately. Use wait_for_agent to retrieve the result later.`,
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"agent": map[string]any{
+					"type":        "string",
+					"description": "Agent name, e.g. developer, reviewer, codebase, web-researcher, or jarvis",
+				},
+				"prompt": map[string]any{
+					"type":        "string",
+					"description": "Instructions for the sub-agent",
+				},
+				"timeout_seconds": map[string]any{
+					"type":        "integer",
+					"description": "Maximum runtime in seconds (default 3600)",
+					"minimum":     10,
+				},
+				"model": map[string]any{
+					"type":        "string",
+					"description": "Optional model override for this sub-agent call",
+				},
+				"cwd": map[string]any{
+					"type":        "string",
+					"description": "Optional working directory/root for the jobs v2 LLM run. Defaults to TERM_LLM_QUEUE_AGENT_CWD or the current process directory.",
+				},
+			},
+			"required":             []string{"agent", "prompt"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *QueueAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var a QueueAgentArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+	}
+	agentName := strings.TrimSpace(a.AgentName)
+	if agentName == "" {
+		agentName = strings.TrimSpace(a.AgentNameAlias)
+	}
+	if agentName == "" {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "agent is required")), nil
+	}
+	if strings.TrimSpace(a.Prompt) == "" {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "prompt is required")), nil
+	}
+	timeout := a.TimeoutSeconds
+	if timeout <= 0 {
+		timeout = defaultQueuedAgentTimeout
+	}
+	if timeout < 10 {
+		timeout = 10
+	}
+	cwd, err := queueAgentCwd(a.Cwd)
+	if err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, err.Error())), nil
+	}
+
+	job, err := t.client.createAgentJob(ctx, agentName, a.Prompt, strings.TrimSpace(a.Model), cwd, timeout)
+	if err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+	}
+	run, err := t.client.triggerJob(ctx, job.ID)
+	if err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+	}
+
+	data, _ := json.Marshal(QueueAgentResult{JobID: job.ID, RunID: run.ID, AgentName: agentName})
+	return llm.TextOutput(string(data)), nil
+}
+
+func (t *QueueAgentTool) Preview(args json.RawMessage) string {
+	var a QueueAgentArgs
+	_ = json.Unmarshal(args, &a)
+	agentName := a.AgentName
+	if agentName == "" {
+		agentName = a.AgentNameAlias
+	}
+	if agentName == "" {
+		return "queue agent"
+	}
+	return fmt.Sprintf("queue %s", agentName)
+}
+
+type WaitForAgentTool struct {
+	client *jobsBackedAgentClient
+}
+
+func NewWaitForAgentTool() *WaitForAgentTool {
+	return NewWaitForAgentToolWithClient(newJobsBackedAgentClientFromEnv())
+}
+
+func NewWaitForAgentToolWithClient(client *jobsBackedAgentClient) *WaitForAgentTool {
+	return &WaitForAgentTool{client: client}
+}
+
+func (t *WaitForAgentTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        WaitForAgentToolName,
+		Description: `Wait for one or more queued agent jobs-v2 runs to finish and return their results.`,
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"poll_interval_seconds": map[string]any{
+					"type":        "integer",
+					"description": "How often to poll run status (default 5)",
+					"minimum":     1,
+				},
+				"run_ids": map[string]any{
+					"type":        "array",
+					"description": "Run IDs returned by queue_agent",
+					"items":       map[string]any{"type": "string"},
+					"minItems":    1,
+				},
+			},
+			"required":             []string{"run_ids"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *WaitForAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var a WaitForAgentArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+	}
+	if len(a.RunIDs) == 0 {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "run_ids is required")), nil
+	}
+	pollInterval := a.PollIntervalSeconds
+	if pollInterval <= 0 {
+		pollInterval = defaultQueuedAgentPollInterval
+	}
+
+	results := make([]QueuedAgentRunResult, 0, len(a.RunIDs))
+	for _, runID := range a.RunIDs {
+		runID = strings.TrimSpace(runID)
+		if runID == "" {
+			results = append(results, QueuedAgentRunResult{Status: "not_found", Error: "blank run_id"})
+			continue
+		}
+		run, err := t.client.waitForRun(ctx, runID, time.Duration(pollInterval)*time.Second)
+		if err != nil {
+			results = append(results, QueuedAgentRunResult{RunID: runID, Status: "failed", Error: err.Error()})
+			continue
+		}
+		results = append(results, queuedAgentRunResultFromJobsRun(run))
+	}
+	data, _ := json.Marshal(results)
+	return llm.TextOutput(string(data)), nil
+}
+
+func (t *WaitForAgentTool) Preview(args json.RawMessage) string {
+	var a WaitForAgentArgs
+	_ = json.Unmarshal(args, &a)
+	return fmt.Sprintf("wait for %d agent run(s)", len(a.RunIDs))
+}
+
+func newJobsBackedAgentClientFromEnv() *jobsBackedAgentClient {
+	baseURL := strings.TrimSpace(os.Getenv("TERM_LLM_JOBS_SERVER"))
+	if baseURL == "" {
+		baseURL = defaultJobsServerBaseURL
+	}
+	baseURL = strings.TrimRight(strings.TrimSuffix(strings.TrimSuffix(baseURL, "/ui"), "/chat"), "/")
+	return &jobsBackedAgentClient{
+		baseURL:    baseURL,
+		token:      strings.TrimSpace(os.Getenv("TERM_LLM_JOBS_TOKEN")),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *jobsBackedAgentClient) createAgentJob(ctx context.Context, agentName, prompt, model, cwd string, timeout int) (jobsV2AgentJobResponse, error) {
+	instructions := prompt + `
+
+---
+Before your final message, state your completion status on its own line in this exact format:
+STATUS: COMPLETE
+or
+STATUS: BLOCKED — <brief reason you could not complete the task>
+or
+STATUS: PARTIAL — <what was done and what is still missing>
+
+Choose COMPLETE only if you fully accomplished the task. Do not omit this line.`
+
+	runnerConfig := map[string]any{
+		"agent_name":   agentName,
+		"instructions": instructions,
+		"cwd":          cwd,
+	}
+	if model != "" {
+		runnerConfig["model"] = model
+	}
+
+	payload := jobsV2AgentJobPayload{
+		Name:              fmt.Sprintf("agent-%s-%d", sanitizeJobNamePart(agentName), time.Now().UnixNano()),
+		Enabled:           true,
+		RunnerType:        "llm",
+		RunnerConfig:      runnerConfig,
+		TriggerType:       "manual",
+		ConcurrencyPolicy: "allow",
+		TimeoutSeconds:    timeout,
+		MisfirePolicy:     "run",
+	}
+
+	var job jobsV2AgentJobResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/v2/jobs", payload, &job); err != nil {
+		return jobsV2AgentJobResponse{}, err
+	}
+	if job.ID == "" {
+		return jobsV2AgentJobResponse{}, fmt.Errorf("jobs server returned job without id")
+	}
+	return job, nil
+}
+
+func (c *jobsBackedAgentClient) triggerJob(ctx context.Context, jobID string) (jobsV2AgentRunResponse, error) {
+	var run jobsV2AgentRunResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/v2/jobs/"+jobID+"/trigger", map[string]any{}, &run); err != nil {
+		return jobsV2AgentRunResponse{}, err
+	}
+	if run.ID == "" {
+		return jobsV2AgentRunResponse{}, fmt.Errorf("jobs server returned run without id")
+	}
+	return run, nil
+}
+
+func (c *jobsBackedAgentClient) waitForRun(ctx context.Context, runID string, pollInterval time.Duration) (jobsV2AgentRunResponse, error) {
+	if pollInterval <= 0 {
+		pollInterval = defaultQueuedAgentPollInterval * time.Second
+	}
+	for {
+		run, err := c.getRun(ctx, runID)
+		if err != nil {
+			return jobsV2AgentRunResponse{}, err
+		}
+		if isQueuedAgentTerminalStatus(run.Status) {
+			return run, nil
+		}
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return run, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *jobsBackedAgentClient) getRun(ctx context.Context, runID string) (jobsV2AgentRunResponse, error) {
+	var run jobsV2AgentRunResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/v2/runs/"+runID, nil, &run); err != nil {
+		return jobsV2AgentRunResponse{}, err
+	}
+	if run.ID == "" {
+		run.ID = runID
+	}
+	return run, nil
+}
+
+func (c *jobsBackedAgentClient) doJSON(ctx context.Context, method, path string, payload any, out any) error {
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode jobs request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("jobs %s %s failed: %s", method, path, jobsErrorMessage(resp.StatusCode, data))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode jobs response: %w", err)
+	}
+	return nil
+}
+
+func jobsErrorMessage(statusCode int, data []byte) string {
+	var errResp jobsV2ErrorResponse
+	if err := json.Unmarshal(data, &errResp); err == nil && errResp.Error.Message != "" {
+		if errResp.Error.Type != "" {
+			return fmt.Sprintf("HTTP %d: %s (%s)", statusCode, errResp.Error.Message, errResp.Error.Type)
+		}
+		return fmt.Sprintf("HTTP %d: %s", statusCode, errResp.Error.Message)
+	}
+	body := strings.TrimSpace(string(data))
+	if body == "" {
+		return fmt.Sprintf("HTTP %d", statusCode)
+	}
+	return fmt.Sprintf("HTTP %d: %s", statusCode, body)
+}
+
+func queueAgentCwd(explicit string) (string, error) {
+	cwd := strings.TrimSpace(explicit)
+	if cwd == "" {
+		cwd = strings.TrimSpace(os.Getenv("TERM_LLM_QUEUE_AGENT_CWD"))
+	}
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve cwd: %w", err)
+		}
+	}
+	if cwd == "" {
+		return "", fmt.Errorf("cwd is required")
+	}
+	return cwd, nil
+}
+
+func queuedAgentRunResultFromJobsRun(run jobsV2AgentRunResponse) QueuedAgentRunResult {
+	return QueuedAgentRunResult{
+		RunID:           run.ID,
+		JobID:           run.JobID,
+		Status:          run.Status,
+		ExitReason:      run.ExitReason,
+		Truncated:       run.Truncated,
+		TurnCount:       run.TurnCount,
+		InputTokens:     run.InputTokens,
+		OutputTokens:    run.OutputTokens,
+		DurationSeconds: durationSeconds(run.StartedAt, run.FinishedAt),
+		Response:        run.Response,
+		Stdout:          run.Stdout,
+		Error:           run.Error,
+		ExitCode:        run.ExitCode,
+		StartedAt:       run.StartedAt,
+		FinishedAt:      run.FinishedAt,
+	}
+}
+
+func durationSeconds(started, finished string) *float64 {
+	if started == "" || finished == "" {
+		return nil
+	}
+	start, err := time.Parse(time.RFC3339Nano, started)
+	if err != nil {
+		return nil
+	}
+	finish, err := time.Parse(time.RFC3339Nano, finished)
+	if err != nil {
+		return nil
+	}
+	seconds := finish.Sub(start).Seconds()
+	return &seconds
+}
+
+func isQueuedAgentTerminalStatus(status string) bool {
+	switch status {
+	case "succeeded", "failed", "cancelled", "timed_out":
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeJobNamePart(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	result := strings.Trim(b.String(), "-_")
+	if result == "" {
+		return "agent"
+	}
+	return result
+}
+
+func formatQueuedAgentError(errType ToolErrorType, message string) string {
+	data, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"type":    errType,
+			"message": message,
+		},
+	})
+	return string(data)
+}

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -1,0 +1,178 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestQueueAgentCreatesAndTriggersJobsBackedLLMRun(t *testing.T) {
+	var sawCreate bool
+	var sawTrigger bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs":
+			sawCreate = true
+			var payload jobsV2AgentJobPayload
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create payload: %v", err)
+			}
+			if payload.RunnerType != "llm" {
+				t.Fatalf("runner_type = %q, want llm", payload.RunnerType)
+			}
+			if payload.RunnerConfig["agent_name"] != "developer" {
+				t.Fatalf("agent_name = %#v, want developer", payload.RunnerConfig["agent_name"])
+			}
+			if !strings.Contains(payload.RunnerConfig["instructions"].(string), "do it") {
+				t.Fatalf("instructions missing prompt: %#v", payload.RunnerConfig["instructions"])
+			}
+			if !strings.Contains(payload.RunnerConfig["instructions"].(string), "STATUS: COMPLETE") {
+				t.Fatalf("instructions missing status footer: %#v", payload.RunnerConfig["instructions"])
+			}
+			if payload.RunnerConfig["cwd"] != "/tmp/work" {
+				t.Fatalf("cwd = %#v, want /tmp/work", payload.RunnerConfig["cwd"])
+			}
+			if payload.RunnerConfig["model"] != "fast" {
+				t.Fatalf("model = %#v, want fast", payload.RunnerConfig["model"])
+			}
+			if payload.TimeoutSeconds != 60 {
+				t.Fatalf("timeout = %d, want 60", payload.TimeoutSeconds)
+			}
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_123"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs/job_123/trigger":
+			sawTrigger = true
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_123", JobID: "job_123", Status: "queued"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewQueueAgentToolWithClient(client)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"agent":"developer","prompt":"do it","timeout_seconds":60,"model":"fast","cwd":"/tmp/work"}`))
+	if err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+	var result QueueAgentResult
+	if err := json.Unmarshal([]byte(out.Content), &result); err != nil {
+		t.Fatalf("queue output is not JSON: %v; %s", err, out.Content)
+	}
+	if result.JobID != "job_123" || result.RunID != "run_123" || result.AgentName != "developer" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if !sawCreate || !sawTrigger {
+		t.Fatalf("sawCreate=%v sawTrigger=%v", sawCreate, sawTrigger)
+	}
+}
+
+func TestWaitForAgentPollsUntilTerminal(t *testing.T) {
+	var polls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/runs/run_123" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		count := atomic.AddInt32(&polls, 1)
+		if count == 1 {
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_123", JobID: "job_123", Status: "running"})
+			return
+		}
+		exitCode := 0
+		turnCount := 1
+		inputTokens := 10
+		outputTokens := 3
+		writeJSON(t, w, jobsV2AgentRunResponse{
+			ID:           "run_123",
+			JobID:        "job_123",
+			Status:       "succeeded",
+			ExitReason:   "natural_completion",
+			TurnCount:    &turnCount,
+			InputTokens:  &inputTokens,
+			OutputTokens: &outputTokens,
+			Response:     "STATUS: COMPLETE\nOK",
+			ExitCode:     &exitCode,
+			StartedAt:    "2026-06-07T07:15:51.314202856Z",
+			FinishedAt:   "2026-06-07T07:16:49.259958355Z",
+		})
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewWaitForAgentToolWithClient(client)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"run_ids":["run_123"],"poll_interval_seconds":1}`))
+	if err != nil {
+		t.Fatalf("wait Execute() error = %v", err)
+	}
+	var results []QueuedAgentRunResult
+	if err := json.Unmarshal([]byte(out.Content), &results); err != nil {
+		t.Fatalf("wait output is not JSON: %v; %s", err, out.Content)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	result := results[0]
+	if result.Status != "succeeded" || result.Response != "STATUS: COMPLETE\nOK" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.DurationSeconds == nil || *result.DurationSeconds < 57.9 || *result.DurationSeconds > 58.0 {
+		t.Fatalf("duration = %#v, want about 57.9", result.DurationSeconds)
+	}
+	if polls != 2 {
+		t.Fatalf("polls = %d, want 2", polls)
+	}
+}
+
+func TestQueueAgentSurfacesJobsErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"llm runner_config.cwd is required","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewQueueAgentToolWithClient(client)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"agent":"developer","prompt":"do it","cwd":"/tmp/work"}`))
+	if err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+	if !strings.Contains(out.Content, "llm runner_config.cwd is required") {
+		t.Fatalf("output did not include jobs error body: %s", out.Content)
+	}
+}
+
+func TestWaitForAgentContextCancellationReturnsPartialError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_123", JobID: "job_123", Status: "running"})
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewWaitForAgentToolWithClient(client)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	out, err := tool.Execute(ctx, json.RawMessage(`{"run_ids":["run_123"],"poll_interval_seconds":1}`))
+	if err != nil {
+		t.Fatalf("wait Execute() error = %v", err)
+	}
+	var results []QueuedAgentRunResult
+	if err := json.Unmarshal([]byte(out.Content), &results); err != nil {
+		t.Fatalf("wait output is not JSON: %v; %s", err, out.Content)
+	}
+	if len(results) != 1 || !strings.Contains(results[0].Error, "context deadline exceeded") {
+		t.Fatalf("unexpected result: %+v", results)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -114,6 +114,10 @@ func (r *LocalToolRegistry) registerTool(specName string) error {
 	case SpawnAgentToolName:
 		// SpawnAgentTool requires a runner to be set later via SetRunner
 		tool = NewSpawnAgentTool(r.config.Spawn, 0)
+	case QueueAgentToolName:
+		tool = NewQueueAgentTool()
+	case WaitForAgentToolName:
+		tool = NewWaitForAgentTool()
 	case RunAgentScriptToolName:
 		tool = NewRunAgentScriptTool(r.config, r.limits)
 	case InitiateHandoverToolName:

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -125,6 +125,8 @@ const (
 	ImageGenerateToolName    = "image_generate"
 	AskUserToolName          = "ask_user"
 	SpawnAgentToolName       = "spawn_agent"
+	QueueAgentToolName       = "queue_agent"
+	WaitForAgentToolName     = "wait_for_agent"
 	RunAgentScriptToolName   = "run_agent_script"
 	InitiateHandoverToolName = "initiate_handover"
 )
@@ -145,6 +147,8 @@ func AllToolNames() []string {
 		ImageGenerateToolName,
 		AskUserToolName,
 		SpawnAgentToolName,
+		QueueAgentToolName,
+		WaitForAgentToolName,
 		RunAgentScriptToolName,
 		InitiateHandoverToolName,
 	}
@@ -165,6 +169,8 @@ var validToolNames = map[string]bool{
 	ImageGenerateToolName:    true,
 	AskUserToolName:          true,
 	SpawnAgentToolName:       true,
+	QueueAgentToolName:       true,
+	WaitForAgentToolName:     true,
 	RunAgentScriptToolName:   true,
 	InitiateHandoverToolName: true,
 }
@@ -189,7 +195,7 @@ func GetToolKind(specName string) ToolKind {
 		return KindImage
 	case AskUserToolName:
 		return KindInteractive
-	case SpawnAgentToolName, InitiateHandoverToolName:
+	case SpawnAgentToolName, QueueAgentToolName, WaitForAgentToolName, InitiateHandoverToolName:
 		return KindAgent
 	case RunAgentScriptToolName:
 		return KindExecute


### PR DESCRIPTION
## What

Adds native `queue_agent` / `wait_for_agent` tools backed by jobs v2:

- `queue_agent` creates a `runner_type: "llm"` jobs-v2 job, includes required `runner_config.cwd`, triggers it, and returns `{job_id, run_id, agent}` immediately.
- `wait_for_agent` polls `/v2/runs/:id` until each run reaches a terminal state and returns rich run details: status, response, stdout/error, exit reason/code, token counts, turn count, timestamps, and duration.
- Jobs endpoint defaults to `TERM_LLM_JOBS_SERVER` or `http://127.0.0.1:8080`; bearer token uses `TERM_LLM_JOBS_TOKEN` if present.
- Run cwd defaults to explicit `cwd`, then `TERM_LLM_QUEUE_AGENT_CWD`, then the current process cwd.
- Keeps legacy custom script-backed `queue_agent` / `wait_for_agent` tools working when the new built-ins are not explicitly enabled, so existing Jarvis installs do not break on startup.

## Why

Jarvis already advertises `queue_agent` / `wait_for_agent`, but the live custom script failed with exit code 22 after jobs v2 started requiring `runner_config.cwd` for native `llm` jobs. The interim script fix is easy, but the proper implementation should preserve the jobs boundary: queued agents should run through the jobs service, potentially in another process, not as in-process goroutines in the web server.

This makes the architecture explicit while removing the brittle shell-script layer:

```text
queue_agent -> jobs v2 create llm job -> trigger -> run_id
wait_for_agent -> jobs v2 run polling -> terminal result
```

## Testing

```text
go test ./internal/tools ./cmd
go test ./...
go build ./...
```

Covered in tests:

- `queue_agent` creates an LLM job with `agent_name`, status footer, model override, timeout, and required `cwd`, then triggers it.
- `wait_for_agent` polls non-terminal runs until terminal and parses RFC3339Nano durations.
- jobs API error bodies are surfaced instead of disappearing as curl-style `exit 22`.
- context cancellation returns a partial failed wait result.
- legacy custom `queue_agent` / `wait_for_agent` names remain allowed unless the built-ins are explicitly enabled.

Live interim script fix also verified separately:

```text
queue_agent -> {"job_id": "...", "run_id": "..."}
wait_for_agent -> succeeded, response: STATUS: COMPLETE / OK_FROM_QUEUE_AGENT
```
