### PR TITLE
fix: Memory mining/freshen walks completed sessions with OFFSET pagination, making full scans grow quadratically

### DIFF
--- a/cmd/memory_shared.go
+++ b/cmd/memory_shared.go
@@ -21,14 +21,15 @@ func openReadOnlySessionStore(cfg *config.Config) (session.Store, error) {
 
 func listCompleteSessions(ctx context.Context, store session.Store) ([]session.SessionSummary, error) {
 	const pageSize = 200
-	offset := 0
+	var beforeNumber int64
 	all := make([]session.SessionSummary, 0, pageSize)
 
 	for {
 		page, err := store.List(ctx, session.ListOptions{
-			Status: session.StatusComplete,
-			Limit:  pageSize,
-			Offset: offset,
+			Status:           session.StatusComplete,
+			Limit:            pageSize,
+			BeforeNumber:     beforeNumber,
+			SortByNumberDesc: true,
 		})
 		if err != nil {
 			return nil, err
@@ -40,7 +41,11 @@ func listCompleteSessions(ctx context.Context, store session.Store) ([]session.S
 		if len(page) < pageSize {
 			break
 		}
-		offset += len(page)
+		lastNumber := page[len(page)-1].Number
+		if lastNumber <= 0 {
+			return nil, fmt.Errorf("complete session %s is missing a session number", page[len(page)-1].ID)
+		}
+		beforeNumber = lastNumber
 	}
 
 	return all, nil

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1349,12 +1349,19 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		}
 		messageCountCol = "(SELECT COUNT(*) FROM messages WHERE session_id = s.id AND role IN ('user', 'assistant')" + compactionTailClause + ")"
 	}
+	fromClause := "FROM sessions s"
+	if opts.SortByNumberDesc {
+		// Completed-session walks page by descending session number. Force the
+		// number index so SQLite can continue scanning from the last seen number
+		// instead of picking a filter-only index and re-sorting each page.
+		fromClause = "FROM sessions s INDEXED BY idx_sessions_number"
+	}
 	query := `
 		SELECT s.id, s.number, s.name, s.summary, ` + generatedShortCol + `, ` + generatedLongCol + `, ` + titleSourceCol + `,
 		       s.provider, COALESCE(s.provider_key, ''), s.model, s.mode, ` + originCol + `, s.archived, ` + pinnedCol + `, s.created_at, s.updated_at, ` + lastMessageAtCol + `,
 		       ` + messageCountCol + ` as message_count,
 		       s.user_turns, s.llm_turns, s.tool_calls, s.input_tokens, s.cached_input_tokens, ` + cacheWriteCol + `, s.output_tokens, s.status, s.tags
-		FROM sessions s
+		` + fromClause + `
 		WHERE 1=1`
 	args := []any{}
 
@@ -1418,26 +1425,34 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 			query += " AND 1 = 0"
 		}
 	}
+	if opts.BeforeNumber > 0 {
+		query += " AND s.number < ?"
+		args = append(args, opts.BeforeNumber)
+	}
 	if !opts.Archived {
 		query += " AND s.archived = FALSE"
 	}
 
-	// Sort by last user message time (when the user last interacted), falling back
-	// to created_at for sessions with no user messages yet. This prevents background
-	// activity (autotitle, mining, status changes) from reordering the sidebar.
-	// Web sidebar callers set SortByActivity to use last_message_at instead so
-	// assistant-only turns also surface (keeps the top-N window aligned with the
-	// client-side "any-message" ordering).
-	sortCol := "s.updated_at"
-	if opts.SortByActivity && s.hasLastMessageAt {
-		sortCol = "COALESCE(s.last_message_at, s.last_user_message_at, s.created_at)"
-	} else if s.hasLastUserMessageAt {
-		sortCol = "COALESCE(s.last_user_message_at, s.created_at)"
-	}
-	if s.hasPinned {
-		query += " ORDER BY COALESCE(s.pinned, FALSE) DESC, " + sortCol + " DESC"
+	if opts.SortByNumberDesc {
+		query += " ORDER BY s.number DESC"
 	} else {
-		query += " ORDER BY " + sortCol + " DESC"
+		// Sort by last user message time (when the user last interacted), falling back
+		// to created_at for sessions with no user messages yet. This prevents background
+		// activity (autotitle, mining, status changes) from reordering the sidebar.
+		// Web sidebar callers set SortByActivity to use last_message_at instead so
+		// assistant-only turns also surface (keeps the top-N window aligned with the
+		// client-side "any-message" ordering).
+		sortCol := "s.updated_at"
+		if opts.SortByActivity && s.hasLastMessageAt {
+			sortCol = "COALESCE(s.last_message_at, s.last_user_message_at, s.created_at)"
+		} else if s.hasLastUserMessageAt {
+			sortCol = "COALESCE(s.last_user_message_at, s.created_at)"
+		}
+		if s.hasPinned {
+			query += " ORDER BY COALESCE(s.pinned, FALSE) DESC, " + sortCol + " DESC"
+		} else {
+			query += " ORDER BY " + sortCol + " DESC"
+		}
 	}
 
 	limit := opts.Limit

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +40,117 @@ func TestNewSQLiteStoreMemoryDBUsesSingleConnection(t *testing.T) {
 	if got := store.db.Stats().MaxOpenConnections; got != 1 {
 		t.Fatalf("MaxOpenConnections = %d, want 1 for :memory: databases", got)
 	}
+}
+
+func TestSQLiteStoreListByNumberCursorReturnsCompleteSessions(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	seed := []struct {
+		status   SessionStatus
+		archived bool
+	}{
+		{status: StatusComplete},
+		{status: StatusComplete},
+		{status: StatusActive},
+		{status: StatusComplete},
+		{status: StatusComplete},
+		{status: StatusComplete, archived: true},
+	}
+	for i, tc := range seed {
+		sess := &Session{
+			ID:       NewID(),
+			Provider: "test",
+			Model:    "test-model",
+			Mode:     ModeChat,
+			Status:   tc.status,
+			Archived: tc.archived,
+			Name:     fmt.Sprintf("session-%d", i+1),
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatalf("Create(%d): %v", i, err)
+		}
+	}
+
+	page1, err := store.List(ctx, ListOptions{Status: StatusComplete, Limit: 2, SortByNumberDesc: true})
+	if err != nil {
+		t.Fatalf("List page1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("len(page1) = %d, want 2", len(page1))
+	}
+	if page1[0].Number != 5 || page1[1].Number != 4 {
+		t.Fatalf("page1 numbers = [%d %d], want [5 4]", page1[0].Number, page1[1].Number)
+	}
+
+	page2, err := store.List(ctx, ListOptions{Status: StatusComplete, Limit: 2, BeforeNumber: page1[len(page1)-1].Number, SortByNumberDesc: true})
+	if err != nil {
+		t.Fatalf("List page2: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("len(page2) = %d, want 2", len(page2))
+	}
+	if page2[0].Number != 2 || page2[1].Number != 1 {
+		t.Fatalf("page2 numbers = [%d %d], want [2 1]", page2[0].Number, page2[1].Number)
+	}
+
+	page3, err := store.List(ctx, ListOptions{Status: StatusComplete, Limit: 2, BeforeNumber: page2[len(page2)-1].Number, SortByNumberDesc: true})
+	if err != nil {
+		t.Fatalf("List page3: %v", err)
+	}
+	if len(page3) != 0 {
+		t.Fatalf("len(page3) = %d, want 0", len(page3))
+	}
+}
+
+func TestSQLiteStoreListByNumberCursorUsesSessionNumberIndex(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	plan := sqliteExplainPlan(t, store.db, `EXPLAIN QUERY PLAN
+		SELECT s.id, s.number
+		FROM sessions s INDEXED BY idx_sessions_number
+		WHERE s.status = ? AND s.archived = FALSE AND s.number < ?
+		ORDER BY s.number DESC
+		LIMIT ?`, string(StatusComplete), 1000, 200)
+	if !strings.Contains(plan, "idx_sessions_number") {
+		t.Fatalf("query plan = %q, want session number index", plan)
+	}
+	if strings.Contains(plan, "USE TEMP B-TREE") {
+		t.Fatalf("query plan = %q, want no temp sort", plan)
+	}
+}
+
+func sqliteExplainPlan(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		t.Fatalf("explain query: %v", err)
+	}
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan explain row: %v", err)
+		}
+		details = append(details, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("explain rows: %v", err)
+	}
+	return strings.Join(details, "\n")
 }
 
 func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -143,17 +143,19 @@ type SessionSummary struct {
 
 // ListOptions configures session listing.
 type ListOptions struct {
-	Name           string        // Filter by name
-	Provider       string        // Filter by provider
-	Model          string        // Filter by model
-	Mode           SessionMode   // Filter by mode (chat, ask, plan, exec)
-	Status         SessionStatus // Filter by status
-	Tag            string        // Filter by tag (substring match)
-	Categories     []string      // Sidebar/web categories (all, chat, web, ask, plan, exec)
-	Limit          int           // Max results (0 = use default)
-	Offset         int           // Pagination offset
-	Archived       bool          // Include archived sessions
-	SortByActivity bool          // Sort by last_message_at (web sidebar); defaults to last_user_message_at
+	Name             string        // Filter by name
+	Provider         string        // Filter by provider
+	Model            string        // Filter by model
+	Mode             SessionMode   // Filter by mode (chat, ask, plan, exec)
+	Status           SessionStatus // Filter by status
+	Tag              string        // Filter by tag (substring match)
+	Categories       []string      // Sidebar/web categories (all, chat, web, ask, plan, exec)
+	Limit            int           // Max results (0 = use default)
+	Offset           int           // Pagination offset
+	BeforeNumber     int64         // Keyset cursor: only sessions with number < this value
+	SortByNumberDesc bool          // Order by session number descending instead of activity sort
+	Archived         bool          // Include archived sessions
+	SortByActivity   bool          // Sort by last_message_at (web sidebar); defaults to last_user_message_at
 }
 
 // SearchResult represents a search match.


### PR DESCRIPTION
## What changed

- replaced the memory completed-session full walk in `cmd/memory_shared.go` from `OFFSET` pagination to keyset pagination using the last seen session number
- extended `session.ListOptions` with an opt-in number cursor/order path (`BeforeNumber` + `SortByNumberDesc`)
- taught `internal/session/sqlite.go` to use `ORDER BY s.number DESC` plus `INDEXED BY idx_sessions_number` for that path so SQLite can keep scanning from the cursor instead of re-sorting later pages
- added tests covering both paged behavior and the query plan using the session-number index without a temp sort

## Why this is high-value

`memory_mine`, `memory_freshen`, and `memory_status` all call `listCompleteSessions`, which previously paged through the entire completed-session corpus with `LIMIT 200 OFFSET N`.

On SQLite, later `OFFSET` pages must still walk and skip earlier rows, so a full corpus scan gets more expensive as the session table grows. This made long-running memory jobs repay that skip cost over and over.

The new keyset walk turns that into a forward range scan on the existing session-number index:

- page 1: newest completed sessions
- page 2+: `number < last_seen_number`

That removes the repeated skip work and temp sorting from later pages, cutting DB work from repeated rescans to one linear pass over the completed-session set.

## Validation

- verified the issue in current code: `cmd/memory_shared.go` used `Offset`, and `internal/session/sqlite.go` emitted `LIMIT ? OFFSET ?`
- `gofmt -w cmd/memory_shared.go internal/session/types.go internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- `go test ./...`
- added tests:
  - `TestSQLiteStoreListByNumberCursorReturnsCompleteSessions`
  - `TestSQLiteStoreListByNumberCursorUsesSessionNumberIndex`
