### PR TITLE
fix: Session search does an extra 2000-row listing pass on every query and still silently drops valid matches

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1051,22 +1051,12 @@ func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	summaries, err := s.store.List(r.Context(), session.ListOptions{
-		Limit:          2000,
-		Archived:       includeArchived,
-		Categories:     categories,
-		SortByActivity: true,
+	matches, err := s.store.Search(r.Context(), session.SearchOptions{
+		Query:      query,
+		Categories: categories,
+		Limit:      limit,
+		Archived:   includeArchived,
 	})
-	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to list sessions")
-		return
-	}
-	allowed := make(map[string]session.SessionSummary, len(summaries))
-	for _, summary := range summaries {
-		allowed[summary.ID] = summary
-	}
-
-	matches, err := s.store.Search(r.Context(), query, limit*4)
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid search query")
 		return
@@ -1090,17 +1080,29 @@ func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Reques
 		MessageID     int64                 `json:"message_id,omitempty"`
 	}
 
-	result := make([]sessionSearchEntry, 0, min(limit, len(matches)))
-	seen := make(map[string]bool, len(matches))
+	result := make([]sessionSearchEntry, 0, len(matches))
 	for _, match := range matches {
-		if seen[match.SessionID] {
-			continue
+		summary := session.SessionSummary{
+			ID:                  match.SessionID,
+			Number:              match.SessionNumber,
+			Name:                match.SessionName,
+			Summary:             match.Summary,
+			GeneratedShortTitle: match.GeneratedShortTitle,
+			GeneratedLongTitle:  match.GeneratedLongTitle,
+			TitleSource:         match.TitleSource,
+			Provider:            match.Provider,
+			ProviderKey:         match.ProviderKey,
+			Model:               match.Model,
+			Mode:                match.Mode,
+			Origin:              match.Origin,
+			Archived:            match.Archived,
+			Pinned:              match.Pinned,
+			MessageCount:        match.MessageCount,
+			Status:              match.Status,
+			CreatedAt:           match.SessionCreatedAt,
+			UpdatedAt:           match.UpdatedAt,
+			LastMessageAt:       match.LastMessageAt,
 		}
-		summary, ok := allowed[match.SessionID]
-		if !ok {
-			continue
-		}
-		seen[match.SessionID] = true
 		lastMessageAt := sessionSummaryLastMessageAt(summary)
 		result = append(result, sessionSearchEntry{
 			ID:            summary.ID,
@@ -1119,9 +1121,6 @@ func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Reques
 			Snippet:       match.Snippet,
 			MessageID:     match.MessageID,
 		})
-		if len(result) >= limit {
-			break
-		}
 	}
 
 	writeJSONConditional(w, r, http.StatusOK, map[string]any{"sessions": result})

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -205,7 +205,7 @@ func (s *serveRuntimeTestStore) List(ctx context.Context, opts session.ListOptio
 	return nil, nil
 }
 
-func (s *serveRuntimeTestStore) Search(ctx context.Context, query string, limit int) ([]session.SearchResult, error) {
+func (s *serveRuntimeTestStore) Search(ctx context.Context, opts session.SearchOptions) ([]session.SearchResult, error) {
 	return nil, nil
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -4129,6 +4129,79 @@ func TestHandleSessionsSearch_UsesFTSAndReturnsSessionSummaries(t *testing.T) {
 	}
 }
 
+func TestHandleSessionsSearch_DoesNotDropOlderMatchesOutsideRecent2000ListWindow(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	base := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	matching := &session.Session{
+		ID:        "older-match",
+		Provider:  "mock",
+		Model:     "mock-model",
+		Mode:      session.ModeChat,
+		Summary:   "older matching session",
+		CreatedAt: base,
+		UpdatedAt: base,
+		Status:    session.StatusActive,
+	}
+	if err := store.Create(ctx, matching); err != nil {
+		t.Fatalf("Create matching session: %v", err)
+	}
+	if err := store.AddMessage(ctx, matching.ID, &session.Message{
+		Role:        llm.RoleUser,
+		TextContent: "needle older searchable session",
+		Parts:       []llm.Part{{Type: llm.PartText, Text: "needle older searchable session"}},
+		CreatedAt:   base,
+	}); err != nil {
+		t.Fatalf("AddMessage matching session: %v", err)
+	}
+
+	for i := 0; i < 2000; i++ {
+		createdAt := base.Add(time.Duration(i+1) * time.Second)
+		sess := &session.Session{
+			ID:        fmt.Sprintf("newer-%04d", i),
+			Provider:  "mock",
+			Model:     "mock-model",
+			Mode:      session.ModeChat,
+			Summary:   fmt.Sprintf("newer session %d", i),
+			CreatedAt: createdAt,
+			UpdatedAt: createdAt,
+			Status:    session.StatusActive,
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatalf("Create newer session %d: %v", i, err)
+		}
+	}
+
+	srv := &serveServer{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/search?q=needle&limit=5", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionsSearch(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		Sessions []struct {
+			ID string `json:"id"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Sessions) != 1 {
+		t.Fatalf("session count = %d, want 1; body: %s", len(body.Sessions), rr.Body.String())
+	}
+	if body.Sessions[0].ID != matching.ID {
+		t.Fatalf("id = %q, want %q", body.Sessions[0].ID, matching.ID)
+	}
+}
+
 func TestHandleSessions_GzipCompressed(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -335,7 +335,7 @@ func runSessionsSearch(cmd *cobra.Command, args []string) error {
 
 	query := strings.Join(args, " ")
 	ctx := context.Background()
-	results, err := store.Search(ctx, query, 20)
+	results, err := store.Search(ctx, session.SearchOptions{Query: query, Limit: 20})
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -44,7 +44,7 @@ func (s *NoopStore) List(ctx context.Context, opts ListOptions) ([]SessionSummar
 	return nil, nil
 }
 
-func (s *NoopStore) Search(ctx context.Context, query string, limit int) ([]SearchResult, error) {
+func (s *NoopStore) Search(ctx context.Context, opts SearchOptions) ([]SearchResult, error) {
 	return nil, nil
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1505,12 +1505,12 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 }
 
 // Search finds sessions containing the query text using FTS5.
-func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]SearchResult, error) {
-	if limit == 0 {
-		limit = 20
+func (s *SQLiteStore) Search(ctx context.Context, opts SearchOptions) ([]SearchResult, error) {
+	if opts.Limit == 0 {
+		opts.Limit = 20
 	}
 
-	ftsQuery := sqlitefts.LiteralQuery(query)
+	ftsQuery := sqlitefts.LiteralQuery(opts.Query)
 	if ftsQuery == "" {
 		return []SearchResult{}, nil
 	}
@@ -1528,15 +1528,99 @@ func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]Se
 		messageCountCol = "(SELECT COUNT(*) FROM messages WHERE session_id = s.id AND role IN ('user', 'assistant')" + countCompactionTailClause + ")"
 	}
 
+	originCol := "'tui'"
+	if s.hasOrigin {
+		originCol = "COALESCE(NULLIF(TRIM(s.origin), ''), 'tui')"
+	}
+	pinnedCol := "FALSE"
+	if s.hasPinned {
+		pinnedCol = "COALESCE(s.pinned, FALSE)"
+	}
+	generatedShortCol := "''"
+	generatedLongCol := "''"
+	titleSourceCol := "''"
+	if s.hasGeneratedTitles {
+		generatedShortCol = "s.generated_short_title"
+		generatedLongCol = "s.generated_long_title"
+		titleSourceCol = "s.title_source"
+	}
+	lastMessageAtCol := "NULL"
+	if s.hasLastMessageAt {
+		lastMessageAtCol = "s.last_message_at"
+	}
+
+	filterClause := ""
+	args := []any{ftsQuery}
+	if len(opts.Categories) > 0 {
+		clauses := make([]string, 0, len(opts.Categories))
+		sawSpecificCategory := false
+		for _, raw := range opts.Categories {
+			category := strings.ToLower(strings.TrimSpace(raw))
+			switch category {
+			case "", "all":
+				clauses = nil
+			case "chat":
+				sawSpecificCategory = true
+				if s.hasOrigin {
+					clauses = append(clauses, "(s.mode = 'chat' AND COALESCE(NULLIF(TRIM(s.origin), ''), 'tui') = 'tui')")
+				} else {
+					clauses = append(clauses, "(s.mode = 'chat')")
+				}
+			case "web":
+				sawSpecificCategory = true
+				if s.hasOrigin {
+					clauses = append(clauses, "(COALESCE(NULLIF(TRIM(s.origin), ''), 'tui') = 'web')")
+				}
+			case "ask", "plan", "exec":
+				sawSpecificCategory = true
+				clauses = append(clauses, "(s.mode = ?)")
+				args = append(args, category)
+			}
+			if clauses == nil {
+				break
+			}
+		}
+		if len(clauses) > 0 {
+			filterClause += " AND (" + strings.Join(clauses, " OR ") + ")"
+		} else if sawSpecificCategory {
+			filterClause += " AND 1 = 0"
+		}
+	}
+	if !opts.Archived {
+		filterClause += " AND s.archived = FALSE"
+	}
+	args = append(args, opts.Limit)
+
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT m.session_id, s.number, m.id, s.name, s.summary, snippet(messages_fts, 0, '**', '**', '...', 32),
-		       s.provider, s.model, s.mode, s.status, `+messageCountCol+` as message_count, s.created_at, s.updated_at, m.created_at
-		FROM messages_fts f
-		JOIN messages m ON m.id = f.rowid
-		JOIN sessions s ON s.id = m.session_id
-		WHERE messages_fts MATCH ?`+compactionTailClause+`
-		ORDER BY rank
-		LIMIT ?`, ftsQuery, limit)
+		WITH raw_matches AS (
+			SELECT rowid AS message_id, rank AS match_rank
+			FROM messages_fts
+			WHERE messages_fts MATCH ?
+		), ranked_matches AS (
+			SELECT m.id AS message_id, m.session_id, raw_matches.match_rank,
+			       ROW_NUMBER() OVER (PARTITION BY m.session_id ORDER BY raw_matches.match_rank, m.id) AS session_row
+			FROM raw_matches
+			JOIN messages m ON m.id = raw_matches.message_id
+			JOIN sessions s ON s.id = m.session_id
+			WHERE 1=1`+compactionTailClause+filterClause+`
+		), session_matches AS (
+			SELECT message_id, session_id, match_rank
+			FROM ranked_matches
+			WHERE session_row = 1
+			ORDER BY match_rank, message_id
+			LIMIT ?
+		)
+		SELECT m.session_id, s.number, m.id, s.name, s.summary, `+generatedShortCol+` AS generated_short_title,
+		       `+generatedLongCol+` AS generated_long_title, `+titleSourceCol+` AS title_source,
+		       snippet(messages_fts, 0, '**', '**', '...', 32) AS snippet, s.provider, COALESCE(s.provider_key, '') AS provider_key,
+		       s.model, s.mode, `+originCol+` AS origin, s.archived, `+pinnedCol+` AS pinned, s.status,
+		       `+messageCountCol+` AS message_count, s.created_at, s.updated_at, `+lastMessageAtCol+` AS last_message_at,
+		       m.created_at AS message_created_at
+		FROM session_matches sm
+		JOIN messages m ON m.id = sm.message_id
+		JOIN sessions s ON s.id = sm.session_id
+		JOIN messages_fts ON messages_fts.rowid = sm.message_id
+		ORDER BY sm.match_rank, sm.message_id`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search messages: %w", err)
 	}
@@ -1546,20 +1630,43 @@ func (s *SQLiteStore) Search(ctx context.Context, query string, limit int) ([]Se
 	for rows.Next() {
 		var r SearchResult
 		var number sql.NullInt64
-		var mode, status sql.NullString
+		var generatedShortTitle, generatedLongTitle, titleSource, providerKey, mode, origin, status sql.NullString
+		var lastMessageAt sql.NullTime
 		err := rows.Scan(&r.SessionID, &number, &r.MessageID, &r.SessionName, &r.Summary,
-			&r.Snippet, &r.Provider, &r.Model, &mode, &status, &r.MessageCount, &r.SessionCreatedAt, &r.UpdatedAt, &r.CreatedAt)
+			&generatedShortTitle, &generatedLongTitle, &titleSource, &r.Snippet, &r.Provider, &providerKey,
+			&r.Model, &mode, &origin, &r.Archived, &r.Pinned, &status, &r.MessageCount,
+			&r.SessionCreatedAt, &r.UpdatedAt, &lastMessageAt, &r.CreatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("scan search result: %w", err)
 		}
 		if number.Valid {
 			r.SessionNumber = number.Int64
 		}
+		if generatedShortTitle.Valid {
+			r.GeneratedShortTitle = generatedShortTitle.String
+		}
+		if generatedLongTitle.Valid {
+			r.GeneratedLongTitle = generatedLongTitle.String
+		}
+		if titleSource.Valid {
+			r.TitleSource = SessionTitleSource(titleSource.String)
+		}
+		if providerKey.Valid {
+			r.ProviderKey = providerKey.String
+		}
 		if mode.Valid {
 			r.Mode = SessionMode(mode.String)
 		}
+		if origin.Valid {
+			r.Origin = SessionOrigin(origin.String)
+		} else {
+			r.Origin = OriginTUI
+		}
 		if status.Valid {
 			r.Status = SessionStatus(status.String)
+		}
+		if lastMessageAt.Valid {
+			r.LastMessageAt = lastMessageAt.Time
 		}
 		results = append(results, r)
 	}

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -233,7 +234,7 @@ func TestSQLiteStorePersistsCompactionTailFlag(t *testing.T) {
 	if len(summaries) != 1 || summaries[0].MessageCount != 1 {
 		t.Fatalf("visible message count = %#v, want only non-tail user counted", summaries)
 	}
-	results, err := store.Search(ctx, "hidden", 10)
+	results, err := store.Search(ctx, SearchOptions{Query: "hidden", Limit: 10})
 	if err != nil {
 		t.Fatalf("Search hidden: %v", err)
 	}
@@ -315,14 +316,14 @@ func TestSQLiteStoreReplaceMessagesPreservesUnchangedPrefix(t *testing.T) {
 		t.Fatalf("suffix texts = %q, %q; want new suffix/new tail", after[2].TextContent, after[3].TextContent)
 	}
 
-	results, err := store.Search(ctx, "old suffix", 10)
+	results, err := store.Search(ctx, SearchOptions{Query: "old suffix", Limit: 10})
 	if err != nil {
 		t.Fatalf("Search old suffix: %v", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("old suffix still in FTS: %#v", results)
 	}
-	results, err = store.Search(ctx, "new suffix", 10)
+	results, err = store.Search(ctx, SearchOptions{Query: "new suffix", Limit: 10})
 	if err != nil {
 		t.Fatalf("Search new suffix: %v", err)
 	}
@@ -385,7 +386,7 @@ func TestSQLiteStoreReplaceMessagesFallsBackForDuplicateSequences(t *testing.T) 
 	if len(got) != 1 || got[0].TextContent != "kept message" {
 		t.Fatalf("messages after duplicate cleanup = %#v, want one kept message", got)
 	}
-	results, err := store.Search(ctx, "stale duplicate", 10)
+	results, err := store.Search(ctx, SearchOptions{Query: "stale duplicate", Limit: 10})
 	if err != nil {
 		t.Fatalf("Search stale duplicate: %v", err)
 	}
@@ -532,7 +533,7 @@ func TestSQLiteStoreSearchEscapesUserQueryForFTS(t *testing.T) {
 		t.Fatalf("AddMessage: %v", err)
 	}
 
-	results, err := store.Search(ctx, "term-llm", 10)
+	results, err := store.Search(ctx, SearchOptions{Query: "term-llm", Limit: 10})
 	if err != nil {
 		t.Fatalf("Search(term-llm) error = %v", err)
 	}
@@ -553,6 +554,116 @@ func TestSQLiteStoreSearchEscapesUserQueryForFTS(t *testing.T) {
 	}
 	if results[0].UpdatedAt.IsZero() {
 		t.Fatal("Search(term-llm) updated_at = zero, want populated timestamp")
+	}
+}
+
+func TestSQLiteStoreSearchReturnsDistinctFilteredSessionMatches(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	sessions := []*Session{
+		{
+			ID:                  "chat-session",
+			Provider:            "test",
+			ProviderKey:         "test",
+			Model:               "test-model",
+			Mode:                ModeChat,
+			Origin:              OriginTUI,
+			GeneratedShortTitle: "Chat result",
+			CreatedAt:           now,
+			UpdatedAt:           now,
+			Status:              StatusActive,
+		},
+		{
+			ID:                  "web-session",
+			Provider:            "test",
+			ProviderKey:         "test",
+			Model:               "test-model",
+			Mode:                ModeChat,
+			Origin:              OriginWeb,
+			GeneratedShortTitle: "Web result",
+			CreatedAt:           now.Add(time.Second),
+			UpdatedAt:           now.Add(time.Second),
+			Status:              StatusActive,
+		},
+		{
+			ID:                  "archived-web-session",
+			Provider:            "test",
+			ProviderKey:         "test",
+			Model:               "test-model",
+			Mode:                ModeChat,
+			Origin:              OriginWeb,
+			GeneratedShortTitle: "Archived web result",
+			CreatedAt:           now.Add(2 * time.Second),
+			UpdatedAt:           now.Add(2 * time.Second),
+			Status:              StatusActive,
+			Archived:            true,
+		},
+	}
+	for _, sess := range sessions {
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatalf("Create(%s): %v", sess.ID, err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := store.AddMessage(ctx, "chat-session", NewMessage("chat-session", llm.UserText(fmt.Sprintf("shared needle duplicate %d", i)), i)); err != nil {
+			t.Fatalf("AddMessage(chat %d): %v", i, err)
+		}
+	}
+	if err := store.AddMessage(ctx, "web-session", NewMessage("web-session", llm.UserText("shared needle web match"), 0)); err != nil {
+		t.Fatalf("AddMessage(web): %v", err)
+	}
+	if err := store.AddMessage(ctx, "archived-web-session", NewMessage("archived-web-session", llm.UserText("shared needle archived match"), 0)); err != nil {
+		t.Fatalf("AddMessage(archived): %v", err)
+	}
+
+	results, err := store.Search(ctx, SearchOptions{Query: "shared needle", Limit: 2})
+	if err != nil {
+		t.Fatalf("Search distinct: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("Search distinct len = %d, want 2", len(results))
+	}
+	seen := map[string]bool{}
+	for _, result := range results {
+		if seen[result.SessionID] {
+			t.Fatalf("duplicate session in results: %#v", results)
+		}
+		seen[result.SessionID] = true
+		if result.Archived {
+			t.Fatalf("unexpected archived result in default search: %#v", result)
+		}
+	}
+	if !seen["chat-session"] || !seen["web-session"] {
+		t.Fatalf("default search ids = %#v, want chat-session and web-session", results)
+	}
+
+	results, err = store.Search(ctx, SearchOptions{Query: "shared needle", Limit: 5, Categories: []string{"web"}})
+	if err != nil {
+		t.Fatalf("Search web category: %v", err)
+	}
+	if len(results) != 1 || results[0].SessionID != "web-session" {
+		t.Fatalf("web category results = %#v, want only web-session", results)
+	}
+
+	results, err = store.Search(ctx, SearchOptions{Query: "shared needle", Limit: 5, Categories: []string{"web"}, Archived: true})
+	if err != nil {
+		t.Fatalf("Search web include archived: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("web include archived len = %d, want 2", len(results))
+	}
+	ids := []string{results[0].SessionID, results[1].SessionID}
+	sort.Strings(ids)
+	if ids[0] != "archived-web-session" || ids[1] != "web-session" {
+		t.Fatalf("web include archived ids = %v, want [archived-web-session web-session]", ids)
 	}
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -31,7 +31,7 @@ type Store interface {
 
 	// Listing and search
 	List(ctx context.Context, opts ListOptions) ([]SessionSummary, error)
-	Search(ctx context.Context, query string, limit int) ([]SearchResult, error)
+	Search(ctx context.Context, opts SearchOptions) ([]SearchResult, error)
 
 	// Message operations - stores full llm.Message with Parts
 	AddMessage(ctx context.Context, sessionID string, msg *Message) error

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -156,22 +156,38 @@ type ListOptions struct {
 	SortByActivity bool          // Sort by last_message_at (web sidebar); defaults to last_user_message_at
 }
 
+// SearchOptions configures session full-text search.
+type SearchOptions struct {
+	Query      string   // Text query to search for
+	Categories []string // Sidebar/web categories (all, chat, web, ask, plan, exec)
+	Limit      int      // Max results (0 = use default)
+	Archived   bool     // Include archived sessions
+}
+
 // SearchResult represents a search match.
 type SearchResult struct {
-	SessionID        string        `json:"session_id"`
-	SessionNumber    int64         `json:"session_number"` // Sequential session number
-	MessageID        int64         `json:"message_id"`
-	SessionName      string        `json:"session_name"`
-	Summary          string        `json:"summary"`
-	Snippet          string        `json:"snippet"` // Matched text snippet
-	Provider         string        `json:"provider"`
-	Model            string        `json:"model"`
-	Mode             SessionMode   `json:"mode,omitempty"`
-	Status           SessionStatus `json:"status,omitempty"`
-	MessageCount     int           `json:"message_count"`
-	SessionCreatedAt time.Time     `json:"session_created_at"`
-	UpdatedAt        time.Time     `json:"updated_at"`
-	CreatedAt        time.Time     `json:"created_at"`
+	SessionID           string             `json:"session_id"`
+	SessionNumber       int64              `json:"session_number"` // Sequential session number
+	MessageID           int64              `json:"message_id"`
+	SessionName         string             `json:"session_name"`
+	Summary             string             `json:"summary"`
+	GeneratedShortTitle string             `json:"generated_short_title,omitempty"`
+	GeneratedLongTitle  string             `json:"generated_long_title,omitempty"`
+	TitleSource         SessionTitleSource `json:"title_source,omitempty"`
+	Snippet             string             `json:"snippet"` // Matched text snippet
+	Provider            string             `json:"provider"`
+	ProviderKey         string             `json:"provider_key,omitempty"`
+	Model               string             `json:"model"`
+	Mode                SessionMode        `json:"mode,omitempty"`
+	Origin              SessionOrigin      `json:"origin,omitempty"`
+	Archived            bool               `json:"archived,omitempty"`
+	Pinned              bool               `json:"pinned,omitempty"`
+	Status              SessionStatus      `json:"status,omitempty"`
+	MessageCount        int                `json:"message_count"`
+	SessionCreatedAt    time.Time          `json:"session_created_at"`
+	UpdatedAt           time.Time          `json:"updated_at"`
+	LastMessageAt       time.Time          `json:"last_message_at,omitempty"`
+	CreatedAt           time.Time          `json:"created_at"`
 }
 
 // NewMessage creates a new Message from an llm.Message with the given session ID and sequence.

--- a/internal/tui/sessions/browse.go
+++ b/internal/tui/sessions/browse.go
@@ -385,7 +385,7 @@ func (m *Model) doRefresh() (tea.Model, tea.Cmd) {
 
 	// If FTS search is enabled and there's a query, use Search
 	if m.ftsEnabled && m.searchQuery != "" {
-		results, err := m.store.Search(ctx, m.searchQuery, 100)
+		results, err := m.store.Search(ctx, session.SearchOptions{Query: m.searchQuery, Limit: 100})
 		if err != nil {
 			m.err = err
 			return m, nil

--- a/internal/tui/sessions/browse_test.go
+++ b/internal/tui/sessions/browse_test.go
@@ -16,7 +16,7 @@ type ftsRefreshStore struct {
 	getMessagesCalls int
 }
 
-func (s *ftsRefreshStore) Search(ctx context.Context, query string, limit int) ([]session.SearchResult, error) {
+func (s *ftsRefreshStore) Search(ctx context.Context, opts session.SearchOptions) ([]session.SearchResult, error) {
 	return s.searchResults, nil
 }
 


### PR DESCRIPTION
## What changed

- Reworked session FTS search to accept structured `SearchOptions` instead of a bare query/limit.
- Pushed archived/category filtering into `internal/session.SQLiteStore.Search(...)` so SQLite filters before limiting.
- Changed the SQLite search query to return one best match per session directly, instead of returning message-level duplicates and relying on handler-side deduping.
- Expanded `SearchResult` with the session metadata the web handler needs, then removed the extra `List(... Limit: 2000, SortByActivity: true)` pass from `handleSessionsSearch`.
- Added regressions for:
  - older matching sessions not being dropped once more than 2000 sessions exist
  - distinct-per-session search limiting and archived/category filtering in the store

## Why this is high-value

The old `/v1/sessions/search` path did two DB queries per request:

1. `List(... Limit: 2000, SortByActivity: true)` to build an allowlist map
2. `Search(query, limit*4)` to get raw FTS hits, then dedupe/filter in Go

That was expensive on an interactive per-keystroke path, and it still produced incorrect results:

- eligible matches older than the first 2000 listed sessions were silently excluded
- repeated hits from one transcript could consume the `limit*4` window before deduping, hiding other sessions

This change removes the extra listing pass entirely and lets SQLite return already-filtered, already-deduped session matches. That cuts handler work, avoids building a 2000-entry map on every search, reduces DB work from two queries to one in the hot path, and fixes the dropped-results bug.

## Validation

- `gofmt -w internal/session/types.go internal/session/store.go internal/session/noop.go internal/session/sqlite.go internal/session/sqlite_test.go cmd/serve_handlers.go cmd/sessions.go cmd/serve_runtime_test.go internal/tui/sessions/browse.go internal/tui/sessions/browse_test.go cmd/serve_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`

New coverage added:

- `TestHandleSessionsSearch_DoesNotDropOlderMatchesOutsideRecent2000ListWindow`
- `TestSQLiteStoreSearchReturnsDistinctFilteredSessionMatches`
