### PR TITLE
fix: Fresh session DB initialization always replays every migration

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -907,6 +907,26 @@ func initSchema(db *sql.DB) error {
 // initSchemaFull handles schema creation and migrations.
 // Only called when schema needs initialization or migration.
 func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
+	noVersionRecord := versionErr != nil && (versionErr == sql.ErrNoRows || strings.Contains(versionErr.Error(), "no such table"))
+	isFreshDB := false
+
+	if noVersionRecord {
+		// Detect fresh DBs before creating the current schema. Once schema has been
+		// installed, sqlite_master can no longer distinguish a new empty DB from an
+		// older DB that predates schema_version.
+		var tableCount int
+		err := db.QueryRow(`
+			SELECT COUNT(*) FROM sqlite_master
+			WHERE type='table' AND name='sessions'
+		`).Scan(&tableCount)
+		if err != nil {
+			return fmt.Errorf("check sessions table: %w", err)
+		}
+		isFreshDB = tableCount == 0
+	} else if versionErr != nil {
+		return fmt.Errorf("get current version: %w", versionErr)
+	}
+
 	// Create base schema (uses IF NOT EXISTS, safe to run multiple times)
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("create base schema: %w", err)
@@ -924,31 +944,22 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 
 	// Determine current version if we didn't get it earlier
 	// versionErr is non-nil if schema_version table doesn't exist or has no rows
-	if versionErr != nil && (versionErr == sql.ErrNoRows || strings.Contains(versionErr.Error(), "no such table")) {
-		// No version record - check if this is fresh DB or pre-migration DB
-		var tableCount int
-		err = db.QueryRow(`
-			SELECT COUNT(*) FROM sqlite_master
-			WHERE type='table' AND name='sessions'
-		`).Scan(&tableCount)
-		if err != nil {
-			return fmt.Errorf("check sessions table: %w", err)
-		}
-
-		if tableCount > 0 {
-			// Pre-migration DB - start at version 0, will run all migrations
-			currentVersion = 0
-		} else {
+	if noVersionRecord {
+		if isFreshDB {
+			if err := ensureFreshSchemaCurrentObjects(db); err != nil {
+				return err
+			}
 			// Fresh DB - schema already has all columns, start at latest
 			currentVersion = schemaVersion
+		} else {
+			// Pre-migration DB - start at version 0, will run all migrations
+			currentVersion = 0
 		}
 
 		// Insert initial version record
 		if _, err := db.Exec("INSERT INTO schema_version (version) VALUES (?)", currentVersion); err != nil {
 			return fmt.Errorf("insert initial version: %w", err)
 		}
-	} else if versionErr != nil {
-		return fmt.Errorf("get current version: %w", versionErr)
 	}
 
 	// Run pending migrations
@@ -977,6 +988,37 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_pinned ON sessions(pinned)")
 	if err != nil {
 		return fmt.Errorf("ensure pinned index: %w", err)
+	}
+
+	return nil
+}
+
+func ensureFreshSchemaCurrentObjects(db *sql.DB) error {
+	if _, err := db.Exec("ALTER TABLE sessions ADD COLUMN last_user_message_at TIMESTAMP"); err != nil {
+		if !isDuplicateColumnError(err) {
+			return fmt.Errorf("ensure last_user_message_at column: %w", err)
+		}
+	}
+
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS push_subscriptions (
+			id TEXT PRIMARY KEY,
+			endpoint TEXT NOT NULL UNIQUE,
+			key_p256dh TEXT NOT NULL,
+			key_auth TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			last_used_at TEXT
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_sequence ON messages(session_id, sequence)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_title_skipped ON sessions(archived, title_skipped_at, updated_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_last_user_msg ON sessions(last_user_message_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_last_message ON sessions(last_message_at DESC)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("ensure current schema objects: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -1465,6 +1465,63 @@ INSERT INTO schema_version(version) VALUES (7);
 	}
 }
 
+func TestInitSchemaFreshDBSkipsMigrations(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	originalMigrations := migrations
+	sentinelRuns := 0
+	migrations = append(append([]migration(nil), originalMigrations...), migration{
+		version:     schemaVersion,
+		description: "test sentinel",
+		up: func(db *sql.DB) error {
+			sentinelRuns++
+			return nil
+		},
+	})
+	defer func() {
+		migrations = originalMigrations
+	}()
+
+	if err := initSchema(db); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+	if sentinelRuns != 0 {
+		t.Fatalf("fresh DB ran migrations, sentinel ran %d times", sentinelRuns)
+	}
+
+	var version int
+	if err := db.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("schema_version = %d, want %d", version, schemaVersion)
+	}
+
+	checks := []struct {
+		name  string
+		query string
+	}{
+		{"last_user_message_at column", "SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'last_user_message_at'"},
+		{"push_subscriptions table", "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='push_subscriptions'"},
+		{"message sequence index", "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_messages_session_sequence'"},
+		{"last user message index", "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_sessions_last_user_msg'"},
+	}
+	for _, check := range checks {
+		var count int
+		if err := db.QueryRow(check.query).Scan(&count); err != nil {
+			t.Fatalf("check %s: %v", check.name, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s count = %d, want 1", check.name, count)
+		}
+	}
+}
+
 func TestReadOnlyOldDBWithoutCompactionSeq(t *testing.T) {
 	// Simulate an old database that doesn't have the compaction_seq column.
 	// A read-only store should still be able to read sessions from it.


### PR DESCRIPTION
## What changed

- Detect fresh session databases **before** executing the current schema, so an empty DB is no longer mistaken for a legacy pre-migration DB.
- For the fresh-DB path, install the remaining current-schema objects that were previously only being created as a side effect of replaying migrations (for example `last_user_message_at`, `push_subscriptions`, and current indexes), then record `schema_version` at the latest version immediately.
- Added `TestInitSchemaFreshDBSkipsMigrations`, which uses a sentinel migration to prove that a brand-new DB now takes the fast path instead of replaying the migration stack.

## Why this is high-value

Fresh DB startup was doing the worst possible thing for first-run latency: it executed the full current schema and then still replayed every migration from version 0. That repeated nontrivial work such as table rebuild migrations, backfill `UPDATE`s, and repeated trigger/index setup even though the database had no user data yet.

This change removes that wasted initialization work for:

- first-run local startup
- ephemeral or in-memory stores
- tests creating temporary DBs
- throwaway containers/environments

The result is less SQL work, fewer writes, less schema churn, and lower startup latency on brand-new databases while preserving the existing migration path for real older databases.

## Validation

- `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- `go test ./...`
- Added regression test: `TestInitSchemaFreshDBSkipsMigrations`
- `git diff --check`
