### PR TITLE
fix: Fresh session DB initialization always replays the full migration stack

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cwd TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_user_message_at TIMESTAMP,
     last_message_at TIMESTAMP,
     archived BOOLEAN DEFAULT FALSE,
     pinned BOOLEAN DEFAULT FALSE,
@@ -907,6 +908,20 @@ func initSchema(db *sql.DB) error {
 // initSchemaFull handles schema creation and migrations.
 // Only called when schema needs initialization or migration.
 func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
+	needsBootstrapVersion := versionErr != nil && (versionErr == sql.ErrNoRows || strings.Contains(versionErr.Error(), "no such table"))
+	preExistingSessionsTable := false
+	if needsBootstrapVersion {
+		var tableCount int
+		err := db.QueryRow(`
+			SELECT COUNT(*) FROM sqlite_master
+			WHERE type='table' AND name='sessions'
+		`).Scan(&tableCount)
+		if err != nil {
+			return fmt.Errorf("check sessions table before schema init: %w", err)
+		}
+		preExistingSessionsTable = tableCount > 0
+	}
+
 	// Create base schema (uses IF NOT EXISTS, safe to run multiple times)
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("create base schema: %w", err)
@@ -922,20 +937,12 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 		return fmt.Errorf("create schema_version table: %w", err)
 	}
 
-	// Determine current version if we didn't get it earlier
-	// versionErr is non-nil if schema_version table doesn't exist or has no rows
-	if versionErr != nil && (versionErr == sql.ErrNoRows || strings.Contains(versionErr.Error(), "no such table")) {
-		// No version record - check if this is fresh DB or pre-migration DB
-		var tableCount int
-		err = db.QueryRow(`
-			SELECT COUNT(*) FROM sqlite_master
-			WHERE type='table' AND name='sessions'
-		`).Scan(&tableCount)
-		if err != nil {
-			return fmt.Errorf("check sessions table: %w", err)
-		}
-
-		if tableCount > 0 {
+	// Determine current version if we didn't get it earlier.
+	// versionErr is non-nil if schema_version table doesn't exist or has no rows.
+	// For fresh DBs we must use the pre-schema check above; after db.Exec(schema)
+	// the sessions table always exists and cannot distinguish fresh installs.
+	if needsBootstrapVersion {
+		if preExistingSessionsTable {
 			// Pre-migration DB - start at version 0, will run all migrations
 			currentVersion = 0
 		} else {
@@ -966,6 +973,14 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 	}
 
 	// Ensure indexes exist (handles fresh DBs where migrations don't run)
+	_, err = db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_sequence ON messages(session_id, sequence)")
+	if err != nil {
+		return fmt.Errorf("ensure message sequence index: %w", err)
+	}
+	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status)")
+	if err != nil {
+		return fmt.Errorf("ensure status index: %w", err)
+	}
 	_, err = db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_number ON sessions(number)")
 	if err != nil {
 		return fmt.Errorf("ensure number index: %w", err)
@@ -977,6 +992,18 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_pinned ON sessions(pinned)")
 	if err != nil {
 		return fmt.Errorf("ensure pinned index: %w", err)
+	}
+	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_title_skipped ON sessions(archived, title_skipped_at, updated_at DESC)")
+	if err != nil {
+		return fmt.Errorf("ensure title_skipped index: %w", err)
+	}
+	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_last_user_msg ON sessions(last_user_message_at DESC)")
+	if err != nil {
+		return fmt.Errorf("ensure last_user_message_at index: %w", err)
+	}
+	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_last_message ON sessions(last_message_at DESC)")
+	if err != nil {
+		return fmt.Errorf("ensure last_message_at index: %w", err)
 	}
 
 	return nil

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -41,6 +41,92 @@ func TestNewSQLiteStoreMemoryDBUsesSingleConnection(t *testing.T) {
 	}
 }
 
+func TestInitSchemaFreshDBDoesNotRunHistoricalMigrations(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	originalMigrations := migrations
+	migrations = []migration{{
+		version:     1,
+		description: "sentinel migration",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec(`CREATE TABLE migration_sentinel (id INTEGER PRIMARY KEY)`)
+			return err
+		},
+	}}
+	defer func() {
+		migrations = originalMigrations
+	}()
+
+	if err := initSchema(db); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+
+	var version int
+	if err := db.QueryRow(`SELECT version FROM schema_version`).Scan(&version); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, schemaVersion)
+	}
+
+	var sentinelCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type='table' AND name='migration_sentinel'
+	`).Scan(&sentinelCount); err != nil {
+		t.Fatalf("check sentinel table: %v", err)
+	}
+	if sentinelCount != 0 {
+		t.Fatal("fresh DB should not replay historical migrations")
+	}
+}
+
+func TestInitSchemaExistingDBWithoutSchemaVersionRunsMigrations(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("seed schema without version table: %v", err)
+	}
+
+	originalMigrations := migrations
+	migrations = []migration{{
+		version:     1,
+		description: "sentinel migration",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec(`CREATE TABLE migration_sentinel (id INTEGER PRIMARY KEY)`)
+			return err
+		},
+	}}
+	defer func() {
+		migrations = originalMigrations
+	}()
+
+	if err := initSchema(db); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+
+	var sentinelCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type='table' AND name='migration_sentinel'
+	`).Scan(&sentinelCount); err != nil {
+		t.Fatalf("check sentinel table: %v", err)
+	}
+	if sentinelCount != 1 {
+		t.Fatal("existing DB without schema_version should still run migrations")
+	}
+}
+
 func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
@@ -135,7 +221,6 @@ func TestSQLiteStoreGetMessagesPageDescendingHonorsBeforeSeqAndLimit(t *testing.
 		t.Fatalf("before seq sequences = [%d %d], want [1 0]", got[0].Sequence, got[1].Sequence)
 	}
 }
-
 func TestSQLiteStoreGetLatestVisibleMessageIDSkipsInvisibleTail(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- Detect whether the DB is fresh **before** running `db.Exec(schema)` in `initSchemaFull`, so a brand-new DB no longer gets misclassified as a pre-migration database.
- Bootstrap fresh databases directly at `schemaVersion` instead of replaying every historical migration.
- Add `last_user_message_at` to the base `schema` so fresh installs still get the full current sessions table without depending on replayed migrations.
- Ensure the indexes/constraints that fresh DBs previously got via historical migrations are still created after initialization:
  - `idx_messages_session_sequence`
  - `idx_sessions_status`
  - `idx_sessions_title_skipped`
  - `idx_sessions_last_user_msg`
  - `idx_sessions_last_message`
- Add focused tests that prove:
  - fresh DBs do **not** run historical migrations
  - existing DBs that already have tables but lack `schema_version` **do** still run migrations

## Why this is high-value

Fresh session stores were doing unnecessary startup work on every first run because `initSchemaFull` created the current schema first, then checked for the `sessions` table to decide whether the DB was fresh. That check could never detect a truly empty DB after schema creation, so every fresh DB started at version 0 and replayed the entire migration stack.

This wastes work on exactly the hot path for:

- first-run responsiveness
- `:memory:` / ephemeral stores
- tests
- throwaway containers

As more migrations accumulate, the wasted startup time keeps growing. This fix removes that repeated migration/backfill/rebuild work for brand-new databases while preserving migration behavior for older databases.

## Validation

- Verified the bug first with a focused test: on the pre-fix code, a fresh DB incorrectly ended up running a sentinel migration and recording version `1` instead of `26`.
- Added targeted regression tests in `internal/session/sqlite_test.go` for fresh-vs-existing bootstrap behavior.
- `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...` ✅
- `go test ./internal/session` ✅
- `go test ./...` ⚠️ still fails in unrelated pre-existing `cmd` push-subscription tests:
  - `TestHandlePushSubscribe/POST_saves_subscription`
  - `TestHandlePushSubscribe/DELETE_removes_subscription`
  - `TestPushSubscribe_EndToEnd`
- `git diff --check` ✅
