### PR TITLE
fix: preserve web UI scrollback after compaction

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -802,6 +802,24 @@ const convertedMessagesFromHistory = (history) => {
   return converted;
 };
 
+const compactedTailRefreshPreservedPrefix = (previousRaw, rawTail, compactionSeq) => {
+  const boundary = Number(compactionSeq);
+  if (!Number.isFinite(boundary) || boundary < 0) return [];
+  if (!Array.isArray(previousRaw) || previousRaw.length === 0) return [];
+  if (!Array.isArray(rawTail) || rawTail.length === 0) return [];
+
+  // A compaction appends a new active-context suffix to the server log. During
+  // the completion/state refresh that follows, the tail window may no longer
+  // overlap the scrollback the browser already loaded. Do not throw away the
+  // pre-compaction transcript in that case; it is still valid display history
+  // and may be the only copy the user can scroll back through without another
+  // page fetch.
+  return previousRaw.filter((msg) => {
+    const seq = serverMessageSequence(msg);
+    return seq !== null && seq < boundary;
+  });
+};
+
 const applyTailMessagesToSessionHistory = (sessionId, data) => {
   const rawTail = Array.isArray(data?.messages) ? data.messages.slice() : [];
   const lastResponseId = String(data?.lastResponseId || '').trim();
@@ -815,32 +833,39 @@ const applyTailMessagesToSessionHistory = (sessionId, data) => {
 
   const history = ensureSessionHistory(session);
   const hadRawMessages = history.rawMessages.length > 0;
+  const previousRawMessages = hadRawMessages ? history.rawMessages.slice() : [];
   const overlapsExisting = hadRawMessages && rawServerMessagesOverlap(history.rawMessages, rawTail);
+  const preservedCompactionPrefix = overlapsExisting
+    ? []
+    : compactedTailRefreshPreservedPrefix(previousRawMessages, rawTail, compactionMeta.compactionSeq);
+  const preservesExistingScrollback = preservedCompactionPrefix.length > 0;
   const previousHasMoreOlder = history.hasMoreOlder === true;
   const previousOldestSeq = Number(history.oldestSeq) || 0;
 
   history.rawMessages = overlapsExisting
     ? mergeRawServerMessages(history.rawMessages, rawTail)
-    : mergeRawServerMessages(rawTail);
+    : mergeRawServerMessages(preservedCompactionPrefix, rawTail);
   history.loadedTail = true;
   history.loadingOlder = false;
   history.lastResponseId = lastResponseId;
   history.compactionSeq = compactionMeta.compactionSeq;
   history.compactionCount = compactionMeta.compactionCount;
 
-  if (overlapsExisting) {
-    history.hasMoreOlder = previousHasMoreOlder;
+  if (overlapsExisting || preservesExistingScrollback) {
+    history.hasMoreOlder = previousHasMoreOlder || data?.has_more === true;
   } else {
     history.hasMoreOlder = data?.has_more === true;
   }
 
   const oldestSeq = oldestSequenceFromRawMessages(history.rawMessages);
   const responseCursor = nextBeforeSeqFromResponse(data);
-  if (overlapsExisting && previousOldestSeq > 0) {
+  if ((overlapsExisting || preservesExistingScrollback) && previousOldestSeq > 0) {
     // Tail refreshes can overlap the loaded window after older pages have been
     // prepended. Keep the existing older cursor; the tail page cursor only
     // describes the oldest row in the tail page, not the oldest row already
-    // loaded in the combined window.
+    // loaded in the combined window. The same applies after compaction: a
+    // non-overlapping compacted tail must not make the browser forget the
+    // pre-compaction scrollback it already has.
     history.oldestSeq = previousOldestSeq;
   } else {
     history.oldestSeq = history.hasMoreOlder && responseCursor !== null
@@ -848,7 +873,11 @@ const applyTailMessagesToSessionHistory = (sessionId, data) => {
       : (oldestSeq !== null ? oldestSeq : (responseCursor !== null ? responseCursor : 0));
   }
 
-  return convertedMessagesFromHistory(history);
+  const converted = convertedMessagesFromHistory(history);
+  if (!overlapsExisting && compactionMeta.compactionSeq >= 0) {
+    converted.preserveLocalCompactionScrollback = true;
+  }
+  return converted;
 };
 
 const fetchServerSessionMessagesPage = async (sessionId, { limit = 0, offset = 0, tail = false, beforeSeq = 0, etag = '' } = {}) => {
@@ -993,6 +1022,22 @@ const loadServerSessionState = async (sessionId) => {
   }
 };
 
+const localCompactionScrollbackPrefix = (session, serverMessages) => {
+  if (!session || !Array.isArray(session.messages) || session.messages.length === 0) return [];
+  if (!Array.isArray(serverMessages) || serverMessages.preserveLocalCompactionScrollback !== true) return [];
+
+  const existingKeys = new Set(serverMessages.map(messageDedupeKey).filter(Boolean));
+  const prefix = [];
+  for (const message of session.messages) {
+    if (!message || message.transient || message.role === 'phase' || message.role === 'error') continue;
+    const key = messageDedupeKey(message);
+    if (key && existingKeys.has(key)) continue;
+    prefix.push({ ...message });
+    if (key) existingKeys.add(key);
+  }
+  return prefix;
+};
+
 const mergeServerMessagesWithLocalState = (session, serverMessages) => {
   if (!session || !Array.isArray(serverMessages)) return;
 
@@ -1000,7 +1045,11 @@ const mergeServerMessagesWithLocalState = (session, serverMessages) => {
     .filter((message) => message?.askUser && message.role === 'user' && message.content)
     .map((message) => ({ ...message }));
 
-  const merged = serverMessages.map((message) => ({ ...message }));
+  const preservedCompactionScrollback = localCompactionScrollbackPrefix(session, serverMessages);
+  const merged = [
+    ...preservedCompactionScrollback,
+    ...serverMessages.map((message) => ({ ...message }))
+  ];
   if (syntheticAskUserMessages.length > 0) {
     const insertAfter = (() => {
       for (let i = merged.length - 1; i >= 0; i -= 1) {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -1163,6 +1163,154 @@ async function testTailRefreshPreservesOlderHistoryCursor() {
   pass(name);
 }
 
+async function testCompactedTailRefreshPreservesPreCompactionScrollback() {
+  const name = 'compacted tail refresh preserves loaded pre-compaction scrollback without overlap';
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_compacted_refresh')) {
+        return new Response(JSON.stringify({
+          messages: [
+            {
+              id: 50,
+              sequence: 50,
+              role: 'user',
+              created_at: 1710000050000,
+              parts: [{ type: 'text', text: '[Context Compaction]\n\n<SUMMARY_AND_NEXT_ACTIONS>\ncontinue\n</SUMMARY_AND_NEXT_ACTIONS>' }],
+            },
+            {
+              id: 51,
+              sequence: 51,
+              role: 'assistant',
+              created_at: 1710000051000,
+              parts: [{ type: 'text', text: 'post compact answer' }],
+            },
+          ],
+          has_more: false,
+          compaction_seq: 50,
+          compaction_count: 1,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ messages: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+
+  const session = {
+    id: 'sess_compacted_refresh',
+    title: 'Compacted refresh',
+    origin: 'web',
+    created: 1710000000000,
+    messages: [],
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  // Seed history like a user who already had pre-compaction scrollback loaded.
+  session._history = {
+    rawMessages: [
+      { id: 1, sequence: 1, role: 'user', created_at: 1710000001000, parts: [{ type: 'text', text: 'pre compact prompt' }] },
+      { id: 2, sequence: 2, role: 'assistant', created_at: 1710000002000, parts: [{ type: 'text', text: 'pre compact reply' }] },
+    ],
+    oldestSeq: 1,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadedTail: true,
+    lastResponseId: '',
+    compactionSeq: -1,
+    compactionCount: 0,
+  };
+
+  const refreshed = await app.loadServerSessionMessages(session.id);
+  app.mergeServerMessagesWithLocalState(session, refreshed);
+
+  const contents = session.messages.map((message) => `${message.role}:${message.content}`);
+  const want = [
+    'user:pre compact prompt',
+    'assistant:pre compact reply',
+    'compaction:Context compacted',
+    'assistant:post compact answer',
+  ];
+  if (JSON.stringify(contents) !== JSON.stringify(want)) {
+    fail(name, 'expected pre-compaction messages to survive non-overlapping compacted tail refresh', JSON.stringify(session.messages));
+    return;
+  }
+  if (session._history.oldestSeq !== 1 || session._history.hasMoreOlder) {
+    fail(name, 'expected old scrollback cursor to remain intact', JSON.stringify(session._history));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testCompactedTailRefreshPreservesLocalScrollbackWithoutRawHistory() {
+  const name = 'compacted tail refresh preserves local scrollback when raw history was never loaded';
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_local_compacted_refresh')) {
+        return new Response(JSON.stringify({
+          messages: [
+            {
+              id: 50,
+              sequence: 50,
+              role: 'user',
+              created_at: 1710000050000,
+              parts: [{ type: 'text', text: '[Context Compaction]\n\n<SUMMARY_AND_NEXT_ACTIONS>\ncontinue\n</SUMMARY_AND_NEXT_ACTIONS>' }],
+            },
+            {
+              id: 51,
+              sequence: 51,
+              role: 'assistant',
+              created_at: 1710000051000,
+              parts: [{ type: 'text', text: 'post compact answer' }],
+            },
+          ],
+          has_more: false,
+          compaction_seq: 50,
+          compaction_count: 1,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ messages: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+
+  const session = {
+    id: 'sess_local_compacted_refresh',
+    title: 'Local compacted refresh',
+    origin: 'web',
+    created: 1710000000000,
+    messages: [
+      { id: 'local_1', role: 'user', content: 'local pre compact prompt', created: 1710000001000 },
+      { id: 'local_2', role: 'assistant', content: 'local pre compact reply', created: 1710000002000 },
+    ],
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const refreshed = await app.loadServerSessionMessages(session.id);
+  app.mergeServerMessagesWithLocalState(session, refreshed);
+
+  const contents = session.messages.map((message) => `${message.role}:${message.content}`);
+  const want = [
+    'user:local pre compact prompt',
+    'assistant:local pre compact reply',
+    'compaction:Context compacted',
+    'assistant:post compact answer',
+  ];
+  if (JSON.stringify(contents) !== JSON.stringify(want)) {
+    fail(name, 'expected visible local scrollback to survive compacted tail refresh', JSON.stringify(session.messages));
+    return;
+  }
+
+  pass(name);
+}
+
 async function testOlderPageFailureAllowsRetryWithoutCorruptingTail() {
   const name = 'failed older-page fetch allows retry without corrupting loaded tail';
   const fetchCalls = [];
@@ -2439,6 +2587,8 @@ async function testSwitchToSearchOnlySessionHydratesResult() {
   await testSessionHistoryInitialLoadRequestsTailOnly();
   await testScrollNearTopLoadsOlderPageAndPreservesViewport();
   await testTailRefreshPreservesOlderHistoryCursor();
+  await testCompactedTailRefreshPreservesPreCompactionScrollback();
+  await testCompactedTailRefreshPreservesLocalScrollbackWithoutRawHistory();
   await testOlderPageFailureAllowsRetryWithoutCorruptingTail();
   await testSwitchToSessionSyncsWithoutTokenAndResumes();
   await testSwitchToSessionRecoversChangedActiveResponseFromSnapshot();


### PR DESCRIPTION
## What

Fix the web UI session-history tail refresh path so a compaction refresh cannot discard already-loaded pre-compaction scrollback when the refreshed tail window no longer overlaps the browser's local history.

## Why

After context compaction, the server appends a compacted active-context suffix and reports `compaction_seq`. A post-run tail refresh can be non-overlapping with the browser's currently loaded pre-compaction transcript. The old merge path treated that as a brand-new tail and replaced local history, leaving nothing to scroll up to.

## Verification

- `mise exec node@24 -- node internal/serveui/static/app_sessions_test.js`
- `go build ./...`
- `go test ./...`
