### PR TITLE
fix: count conversation messages in web sidebar

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -144,6 +144,19 @@ let sidebarRenderKey = '';
 
 const sidebarScrollContainer = () => elements.sidebarContent || elements.sessionGroups?.parentElement || null;
 
+const conversationMessageCount = (session) => {
+  if (typeof session?.messageCount === 'number' && Number.isFinite(session.messageCount)) {
+    return Math.max(session.messageCount, 0);
+  }
+  const messages = Array.isArray(session?.messages) ? session.messages : [];
+  return messages.filter((message) => message?.role === 'user' || message?.role === 'assistant').length;
+};
+
+const formatSessionMessageCount = (session) => {
+  const count = conversationMessageCount(session);
+  return `${count} message${count === 1 ? '' : 's'}`;
+};
+
 const restoreSidebarScroll = (scroller, scrollTop) => {
   if (!scroller || !Number.isFinite(scrollTop)) return;
   if (scroller.scrollTop !== scrollTop) scroller.scrollTop = scrollTop;
@@ -170,7 +183,7 @@ const computeSidebarKey = (sorted) =>
     [
       s.id, s.title, s.longTitle || '', s.searchSnippet || '',
       s.pinned ? 1 : 0, s.archived ? 1 : 0,
-      s.messageCount || s.messages.length || 0,
+      conversationMessageCount(s),
       s.lastMessageAt || s.created,
       sessionHasInProgressState(s) ? 1 : 0,
       s.id === state.activeSessionId ? 1 : 0
@@ -212,8 +225,7 @@ const buildCachedSessionRow = (session) => {
     metaEl.textContent = session.searchSnippet;
     metaEl.title = session.searchSnippet;
   } else {
-    const msgCount = session.messageCount || session.messages.filter(m => m.role !== 'tool-group').length || 0;
-    const metaParts = [`${msgCount} message${msgCount === 1 ? '' : 's'}`];
+    const metaParts = [formatSessionMessageCount(session)];
     if (session.archived) metaParts.push('hidden');
     const activityAt = session.lastMessageAt || session.created;
     metaParts.push(relativeTime(activityAt));
@@ -323,8 +335,7 @@ const updateCachedSessionRow = (session, cached) => {
     newMeta = session.searchSnippet;
     newMetaTitle = session.searchSnippet;
   } else {
-    const msgCount = session.messageCount || session.messages.filter(m => m.role !== 'tool-group').length || 0;
-    const metaParts = [`${msgCount} message${msgCount === 1 ? '' : 's'}`];
+    const metaParts = [formatSessionMessageCount(session)];
     if (session.archived) metaParts.push('hidden');
     const activityAt = session.lastMessageAt || session.created;
     metaParts.push(relativeTime(activityAt));

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -1017,6 +1017,74 @@ async function run(name, fn) {
     assertEqual(rows[1].querySelector('.session-title').textContent, 'Beta', 'second row title');
   });
 
+  await run('renderSidebar trusts server conversation message count over loaded client rows', () => {
+    const sessions = [
+      { id: 'a', title: 'Alpha', created: 2000, pinned: false, archived: false, lastMessageAt: 2000, messageCount: 2, messages: [
+        { id: 'u1', role: 'user', content: 'run tools' },
+        { id: 't1', role: 'tool', name: 'grep' },
+        { id: 't2', role: 'tool', name: 'read_file' },
+        { id: 't3', role: 'tool', name: 'shell' },
+        { id: 't4', role: 'tool', name: 'edit_file' },
+        { id: 'a1', role: 'assistant', content: 'done' },
+      ] },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+
+    app.renderSidebar();
+
+    const metaEl = app.elements.sessionGroups.querySelector('.session-meta');
+    assert(metaEl.textContent.startsWith('2 messages'), 'meta uses server conversation count');
+  });
+
+  await run('renderSidebar counts only user and assistant messages for unsynced local sessions', () => {
+    const sessions = [
+      { id: 'a', title: 'Alpha', created: 2000, pinned: false, archived: false, lastMessageAt: 2000, messages: [
+        { id: 'u1', role: 'user', content: 'run tools' },
+        { id: 't1', role: 'tool', name: 'grep' },
+        { id: 'tg1', role: 'tool-group', tools: [{ id: 't2' }, { id: 't3' }, { id: 't4' }] },
+        { id: 'a1', role: 'assistant', content: 'done' },
+      ] },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+
+    app.renderSidebar();
+
+    const metaEl = app.elements.sessionGroups.querySelector('.session-meta');
+    assert(metaEl.textContent.startsWith('2 messages'), 'meta counts user/assistant only');
+    assert(!metaEl.textContent.includes('/'), 'meta does not show raw/tool count');
+  });
+
+  await run('renderSidebar trusts explicit zero server conversation message count', () => {
+    const sessions = [
+      { id: 'a', title: 'Alpha', created: 2000, pinned: false, archived: false, lastMessageAt: 2000, messageCount: 0, messages: [
+        { id: 'u1', role: 'user', content: 'locally loaded but server says zero' },
+        { id: 'a1', role: 'assistant', content: 'locally loaded but server says zero' },
+      ] },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+
+    app.renderSidebar();
+
+    const metaEl = app.elements.sessionGroups.querySelector('.session-meta');
+    assert(metaEl.textContent.startsWith('0 messages'), 'explicit server zero is authoritative');
+  });
+
+  await run('renderSidebar falls back to local count when server count is absent', () => {
+    const sessions = [
+      { id: 'a', title: 'Alpha', created: 2000, pinned: false, archived: false, lastMessageAt: 2000, messageCount: null, messages: [
+        { id: 'u1', role: 'user', content: 'run tools' },
+        { id: 'tg1', role: 'tool-group', tools: [{ id: 't1' }, { id: 't2' }, { id: 't3' }, { id: 't4' }] },
+        { id: 'a1', role: 'assistant', content: 'done' },
+      ] },
+    ];
+    const { app } = createHarness({ visibleSessions: () => sessions });
+
+    app.renderSidebar();
+
+    const metaEl = app.elements.sessionGroups.querySelector('.session-meta');
+    assert(metaEl.textContent.startsWith('2 messages'), 'null server count falls back to local conversation count');
+  });
+
   await run('renderSidebar skips re-render when nothing changed', () => {
     const session = { id: 'a', title: 'Alpha', created: 1000, messages: [], pinned: false, archived: false, messageCount: 2, lastMessageAt: 1000 };
     const { app } = createHarness({ visibleSessions: () => [session] });


### PR DESCRIPTION
## What

- Treats server `message_count` as the sidebar contract for conversation-message count.
- The existing server/store `message_count` is user/assistant-only, so the UI now trusts it when present.
- Only falls back to local role counting for unsynced local sessions that do not yet have a server count.
- Removes client-side `messages.length`/tool-row counting from sidebar metadata.

## Why

A session with `1 user + 4 tools + 1 assistant` should show `2 messages`, not `6 messages`. The server-side count is the right contract because the client may only have a partial history window loaded.

## Verification

- `go build ./...`
- `go test ./...`
- `for f in internal/serveui/static/*test.js; do mise exec node@24.15.0 -- node "$f"; done`
