### PR TITLE
feat: notify queue_agent requesters on completion

### DIFF
--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -193,6 +193,7 @@ func logTelegramNotifySession(ctx context.Context, cfg *config.Config, chatID in
 			Provider: "telegram-notify",
 			Model:    "push",
 			Mode:     session.ModeChat,
+			Origin:   session.OriginTelegram,
 			Status:   session.StatusActive,
 		}
 		if err := store.Create(ctx, sess); err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -517,12 +517,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var s *serveServer
 	if hasHTTP {
 		var jobsV2 *jobsV2Manager
-		if hasJobs {
-			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers)
-			if err != nil {
-				return fmt.Errorf("initialize jobs v2 manager: %w", err)
-			}
-		}
 		serveUI := hasWeb
 
 		var widgetsMgr *widgets.Manager
@@ -561,6 +555,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 			store:          store,
 			runtimeFactory: runtimeFactory,
 			widgetsMgr:     widgetsMgr,
+		}
+		if hasJobs {
+			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers, s.notifyJobsV2RunDone)
+			if err != nil {
+				return fmt.Errorf("initialize jobs v2 manager: %w", err)
+			}
+			s.jobsV2 = jobsV2
 		}
 		sessionMgr.onEvict = func(rt *serveRuntime) {
 			for _, rid := range rt.getResponseIDs() {

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -217,6 +217,8 @@ type jobsV2Runner interface {
 	Run(ctx context.Context, job jobsV2Job, pw progressWriter) (jobsV2RunResult, error)
 }
 
+type jobsV2RunDoneNotifier func(ctx context.Context, run jobsV2Run, job jobsV2Job, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) error
+
 type jobsV2ProgramRunner struct{}
 
 var (
@@ -312,14 +314,22 @@ type jobsV2LLMRunner struct {
 	exec serveJobsExecutor
 }
 
-type jobsV2LLMConfig struct {
-	AgentName      string `json:"agent_name"`
-	Instructions   string `json:"instructions"`
-	Progressive    bool   `json:"progressive,omitempty"`
-	StopWhen       string `json:"stop_when,omitempty"`
-	ContinueWith   string `json:"continue_with,omitempty"`
-	PersistSession *bool  `json:"persist_session,omitempty"`
+type jobsV2NotifyOrigin struct {
+	Origin         string `json:"origin,omitempty"`
 	SessionID      string `json:"session_id,omitempty"`
+	TelegramChatID int64  `json:"telegram_chat_id,omitempty"`
+}
+
+type jobsV2LLMConfig struct {
+	AgentName      string              `json:"agent_name"`
+	Instructions   string              `json:"instructions"`
+	Progressive    bool                `json:"progressive,omitempty"`
+	StopWhen       string              `json:"stop_when,omitempty"`
+	ContinueWith   string              `json:"continue_with,omitempty"`
+	PersistSession *bool               `json:"persist_session,omitempty"`
+	SessionID      string              `json:"session_id,omitempty"`
+	NotifyWhenDone bool                `json:"notify_when_done,omitempty"`
+	NotifyOrigin   *jobsV2NotifyOrigin `json:"notify_origin,omitempty"`
 
 	// cwd is REQUIRED: it roots this run's file/shell tools at a directory so a
 	// job never silently inherits the jobs server's process working directory.
@@ -537,10 +547,11 @@ func classifyRunError(err error, result jobsV2RunResult) (exitReason string, tru
 }
 
 type jobsV2Manager struct {
-	db       *sql.DB
-	workers  int
-	workerID string
-	runners  map[jobsV2RunnerType]jobsV2Runner
+	db         *sql.DB
+	workers    int
+	workerID   string
+	runners    map[jobsV2RunnerType]jobsV2Runner
+	notifyDone jobsV2RunDoneNotifier
 	// Idle timers are only fallbacks; job/run mutations wake the loops immediately.
 	schedulerIdleDelay time.Duration
 	workerIdleDelay    time.Duration
@@ -626,6 +637,10 @@ DROP INDEX IF EXISTS idx_job_run_events_v2_run_id;
 `
 
 func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*jobsV2Manager, error) {
+	return newJobsV2ManagerWithNotifier(dbPath, workers, llmExec, nil)
+}
+
+func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
 	if workers < 0 {
 		workers = 1
 	}
@@ -697,6 +712,7 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 		db:                 db,
 		workers:            workers,
 		workerID:           "worker_" + randomSuffix(),
+		notifyDone:         notifyDone,
 		schedulerIdleDelay: jobsV2SchedulerIdleDelay,
 		workerIdleDelay:    jobsV2WorkerIdleDelay,
 		// Conservative defaults: enough history for debugging without unbounded growth.
@@ -1368,6 +1384,7 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		"input_tokens":  result.InputTokens,
 		"output_tokens": result.OutputTokens,
 	})
+	m.notifyRunDone(runID, status, result, exitReason, truncated, errText)
 
 	if status == jobsV2RunFailed || status == jobsV2RunTimedOut {
 		run, err := m.GetRun(runID)
@@ -1397,6 +1414,34 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 	}
 
 	return nil
+}
+
+func jobsV2NotifyTerminalStatus(status jobsV2RunStatus) bool {
+	switch status {
+	case jobsV2RunSucceeded, jobsV2RunFailed, jobsV2RunCancelled, jobsV2RunTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *jobsV2Manager) notifyRunDone(runID string, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) {
+	if m == nil || m.notifyDone == nil || !jobsV2NotifyTerminalStatus(status) {
+		return
+	}
+	run, err := m.GetRun(runID)
+	if err != nil {
+		return
+	}
+	job, err := m.GetJob(run.JobID)
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := m.notifyDone(ctx, run, job, status, result, exitReason, truncated, errText); err != nil {
+		_ = m.addRunEvent(runID, "notify_failed", "completion notification failed", map[string]any{"error": err.Error()})
+	}
 }
 
 func (m *jobsV2Manager) addRunEvent(runID, eventType, message string, payload any) error {
@@ -2478,6 +2523,9 @@ func (s *serveServer) handleCreateJobV2(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	jobReq := req.toJob(true)
+	if jobReq.RunnerType == jobsV2RunnerLLM {
+		jobReq.RunnerConfig = sanitizeJobsV2LLMNotifyOriginForRequest(r, jobReq.RunnerConfig)
+	}
 	if s.cfgRef != nil && jobReq.RunnerType == jobsV2RunnerLLM {
 		var llmCfg jobsV2LLMConfig
 		_ = json.Unmarshal(jobReq.RunnerConfig, &llmCfg)
@@ -2649,9 +2697,9 @@ func (s *serveServer) handleRunV2ByID(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, run)
 }
 
-func newServeJobsV2Manager(cfg *config.Config, workers int) (*jobsV2Manager, error) {
+func newServeJobsV2Manager(cfg *config.Config, workers int, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
 	_ = cfg
-	return newJobsV2Manager("", workers, newServeJobsExecutor(cfg))
+	return newJobsV2ManagerWithNotifier("", workers, newServeJobsExecutor(cfg), notifyDone)
 }
 
 func queryBool(r *http.Request, key string) bool {

--- a/cmd/serve_jobs_v2_notify.go
+++ b/cmd/serve_jobs_v2_notify.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+const queuedAgentNotificationExcerptRunes = 240
+
+func sanitizeJobsV2LLMNotifyOriginForRequest(r *http.Request, raw json.RawMessage) json.RawMessage {
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return raw
+	}
+	if !cfg.NotifyWhenDone && cfg.NotifyOrigin == nil {
+		return raw
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+	delete(obj, "notify_origin")
+	if cfg.NotifyWhenDone {
+		if origin := trustedQueueAgentNotifyOriginFromRequest(r); origin != nil {
+			if data, err := json.Marshal(origin); err == nil {
+				obj["notify_origin"] = data
+			}
+		}
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return data
+}
+
+func trustedQueueAgentNotifyOriginFromRequest(r *http.Request) *jobsV2NotifyOrigin {
+	// Notify targets are trusted only from same-host runtime calls created by
+	// queue_agent. Authenticated remote callers may request notify_when_done, but
+	// they must not be able to choose an arbitrary session or Telegram chat.
+	if r == nil || !isLoopbackRemoteAddr(r.RemoteAddr) {
+		return nil
+	}
+	origin := strings.TrimSpace(r.Header.Get(tools.QueueAgentNotifyOriginHeader))
+	switch origin {
+	case tools.QueueAgentOriginWeb:
+		sessionID := strings.TrimSpace(r.Header.Get(tools.QueueAgentNotifySessionIDHeader))
+		if sessionID == "" {
+			return nil
+		}
+		return &jobsV2NotifyOrigin{Origin: origin, SessionID: sessionID}
+	case tools.QueueAgentOriginTelegram:
+		chatID, err := strconv.ParseInt(strings.TrimSpace(r.Header.Get(tools.QueueAgentNotifyTelegramChatIDHeader)), 10, 64)
+		if err != nil || chatID == 0 {
+			return nil
+		}
+		return &jobsV2NotifyOrigin{Origin: origin, TelegramChatID: chatID}
+	default:
+		return nil
+	}
+}
+
+func isLoopbackRemoteAddr(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(remoteAddr))
+	if err != nil {
+		host = strings.TrimSpace(remoteAddr)
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func (s *serveServer) notifyJobsV2RunDone(ctx context.Context, run jobsV2Run, job jobsV2Job, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) error {
+	_ = truncated
+	if job.RunnerType != jobsV2RunnerLLM {
+		return nil
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(job.RunnerConfig, &cfg); err != nil {
+		return nil
+	}
+	if !cfg.NotifyWhenDone {
+		return nil
+	}
+	origin := cfg.NotifyOrigin
+	if origin == nil {
+		return nil
+	}
+	message := formatQueuedAgentDoneNotification(job.ID, cfg.AgentName, status, result, exitReason, errText)
+	switch strings.TrimSpace(origin.Origin) {
+	case tools.QueueAgentOriginWeb:
+		return s.notifyQueuedAgentWeb(ctx, run.ID, origin.SessionID, message)
+	case tools.QueueAgentOriginTelegram:
+		return s.notifyQueuedAgentTelegram(ctx, origin.TelegramChatID, message)
+	default:
+		return nil
+	}
+}
+
+func formatQueuedAgentDoneNotification(jobID, agentName string, status jobsV2RunStatus, result jobsV2RunResult, exitReason, errText string) string {
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		jobID = "unknown"
+	}
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		agentName = "agent"
+	}
+	base := fmt.Sprintf("Queued job %s (%s) %s", jobID, agentName, strings.TrimSpace(string(status)))
+	if detail := queuedAgentNotificationExcerpt(result, exitReason, errText); detail != "" {
+		return base + ": " + detail
+	}
+	return base
+}
+
+func queuedAgentNotificationExcerpt(result jobsV2RunResult, exitReason, errText string) string {
+	candidates := []string{errText}
+	if strings.TrimSpace(exitReason) != "" && strings.TrimSpace(exitReason) != exitReasonNatural {
+		candidates = append(candidates, exitReason)
+	}
+	candidates = append(candidates, result.Response, result.Stdout, result.Stderr, result.Thinking)
+	for _, candidate := range candidates {
+		if excerpt := compactNotificationExcerpt(candidate, queuedAgentNotificationExcerptRunes); excerpt != "" {
+			return excerpt
+		}
+	}
+	return ""
+}
+
+func compactNotificationExcerpt(text string, limit int) string {
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(strings.ToUpper(line), "STATUS:") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	text = strings.Join(kept, " ")
+	text = strings.Join(strings.Fields(text), " ")
+	if limit <= 0 || utf8.RuneCountInString(text) <= limit {
+		return text
+	}
+	runes := []rune(text)
+	if limit <= 1 {
+		return string(runes[:limit])
+	}
+	return strings.TrimSpace(string(runes[:limit-1])) + "…"
+}
+
+func (s *serveServer) notifyQueuedAgentWeb(ctx context.Context, runID, sessionID, message string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	if s != nil && s.sessionMgr != nil {
+		if rt, ok := s.sessionMgr.Get(sessionID); ok && rt != nil {
+			if rt.hasActiveRun() {
+				// Job completion is delivered as an interjection only while the
+				// originating session is already generating. Pass no classifier
+				// provider so this best-effort notice cannot be upgraded into a
+				// cancel/interrupt decision for the user's active run.
+				if _, err := rt.InterruptMessage(ctx, llm.UserText(message), message, "job_notify_"+strings.TrimSpace(runID), nil); err == nil {
+					return nil
+				}
+			}
+			if err := rt.appendNotificationMessage(ctx, sessionID, message); err == nil {
+				return nil
+			}
+		}
+	}
+	if s == nil {
+		return nil
+	}
+	return appendQueuedAgentNotificationToStore(ctx, s.store, sessionID, message)
+}
+
+func (rt *serveRuntime) appendNotificationMessage(ctx context.Context, sessionID, message string) error {
+	if rt == nil || strings.TrimSpace(message) == "" {
+		return nil
+	}
+	if !rt.mu.TryLock() {
+		return errServeSessionBusy
+	}
+	defer rt.mu.Unlock()
+
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" && rt.sessionMeta != nil {
+		sessionID = rt.sessionMeta.ID
+	}
+	msg := llm.AssistantText(message)
+	rt.history = append(rt.history, msg)
+	if rt.store == nil || sessionID == "" {
+		return nil
+	}
+	dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := rt.store.AddMessage(dbCtx, sessionID, session.NewMessage(sessionID, msg, -1)); err != nil {
+		return err
+	}
+	_ = rt.store.SetCurrent(dbCtx, sessionID)
+	return nil
+}
+
+func appendQueuedAgentNotificationToStore(ctx context.Context, store session.Store, sessionID, message string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	message = strings.TrimSpace(message)
+	if store == nil || sessionID == "" || message == "" {
+		return nil
+	}
+	dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if sess, err := store.Get(dbCtx, sessionID); err != nil || sess == nil {
+		return nil
+	}
+	if err := store.AddMessage(dbCtx, sessionID, session.NewMessage(sessionID, llm.AssistantText(message), -1)); err != nil {
+		return err
+	}
+	_ = store.SetCurrent(dbCtx, sessionID)
+	return nil
+}
+
+func (s *serveServer) notifyQueuedAgentTelegram(ctx context.Context, chatID int64, message string) error {
+	if s == nil || s.cfgRef == nil || chatID == 0 || strings.TrimSpace(message) == "" {
+		return nil
+	}
+	token := strings.TrimSpace(s.cfgRef.Serve.Telegram.Token)
+	if token == "" {
+		return nil
+	}
+	if err := sendTelegramMessage(ctx, token, chatID, message, ""); err != nil {
+		return err
+	}
+	logTelegramNotifySession(ctx, s.cfgRef, chatID, message, io.Discard)
+	return nil
+}

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -1,0 +1,260 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func TestJobsV2CreateJobSanitizesNotifyOriginFromBody(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	srv := &serveServer{jobsV2: mgr}
+	body := `{
+		"name":"sanitize-notify-origin",
+		"enabled":true,
+		"runner_type":"llm",
+		"runner_config":{
+			"agent_name":"developer",
+			"instructions":"do it",
+			"cwd":"/tmp/work",
+			"notify_when_done":true,
+			"notify_origin":{"origin":"web","session_id":"attacker-session"}
+		},
+		"trigger_type":"manual",
+		"trigger_config":{},
+		"timeout_seconds":30
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v2/jobs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.10:54321"
+	rr := httptest.NewRecorder()
+	srv.handleJobsV2(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201 body=%s", rr.Code, rr.Body.String())
+	}
+	var created jobsV2Job
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created job: %v", err)
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(created.RunnerConfig, &cfg); err != nil {
+		t.Fatalf("decode runner config: %v", err)
+	}
+	if !cfg.NotifyWhenDone {
+		t.Fatal("notify_when_done was not preserved")
+	}
+	if cfg.NotifyOrigin != nil {
+		t.Fatalf("notify_origin should be stripped from request body, got %+v", cfg.NotifyOrigin)
+	}
+}
+
+func TestJobsV2CreateJobInjectsLoopbackNotifyOriginHeaders(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	srv := &serveServer{jobsV2: mgr}
+	body := `{
+		"name":"inject-notify-origin",
+		"enabled":true,
+		"runner_type":"llm",
+		"runner_config":{
+			"agent_name":"developer",
+			"instructions":"do it",
+			"cwd":"/tmp/work",
+			"notify_when_done":true
+		},
+		"trigger_type":"manual",
+		"trigger_config":{},
+		"timeout_seconds":30
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v2/jobs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(tools.QueueAgentNotifyOriginHeader, tools.QueueAgentOriginWeb)
+	req.Header.Set(tools.QueueAgentNotifySessionIDHeader, "sess-from-runtime")
+	req.RemoteAddr = "127.0.0.1:54321"
+	rr := httptest.NewRecorder()
+	srv.handleJobsV2(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201 body=%s", rr.Code, rr.Body.String())
+	}
+	var created jobsV2Job
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created job: %v", err)
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(created.RunnerConfig, &cfg); err != nil {
+		t.Fatalf("decode runner config: %v", err)
+	}
+	if cfg.NotifyOrigin == nil || cfg.NotifyOrigin.Origin != "web" || cfg.NotifyOrigin.SessionID != "sess-from-runtime" {
+		t.Fatalf("notify_origin = %+v, want injected web session", cfg.NotifyOrigin)
+	}
+}
+
+func TestJobsV2CreateJobIgnoresNonLoopbackNotifyOriginHeaders(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	srv := &serveServer{jobsV2: mgr}
+	body := `{
+		"name":"ignore-remote-notify-origin",
+		"enabled":true,
+		"runner_type":"llm",
+		"runner_config":{
+			"agent_name":"developer",
+			"instructions":"do it",
+			"cwd":"/tmp/work",
+			"notify_when_done":true
+		},
+		"trigger_type":"manual",
+		"trigger_config":{},
+		"timeout_seconds":30
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v2/jobs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(tools.QueueAgentNotifyOriginHeader, tools.QueueAgentOriginWeb)
+	req.Header.Set(tools.QueueAgentNotifySessionIDHeader, "attacker-session")
+	req.RemoteAddr = "203.0.113.10:54321"
+	rr := httptest.NewRecorder()
+	srv.handleJobsV2(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201 body=%s", rr.Code, rr.Body.String())
+	}
+	var created jobsV2Job
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created job: %v", err)
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(created.RunnerConfig, &cfg); err != nil {
+		t.Fatalf("decode runner config: %v", err)
+	}
+	if !cfg.NotifyWhenDone {
+		t.Fatal("notify_when_done was not preserved")
+	}
+	if cfg.NotifyOrigin != nil {
+		t.Fatalf("notify_origin should ignore non-loopback headers, got %+v", cfg.NotifyOrigin)
+	}
+}
+
+func TestJobsV2NotifyWhenDoneAppendsWebNotificationToIdleSession(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	if err := store.Create(context.Background(), &session.Session{ID: "sess-origin", Origin: session.OriginWeb, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	srv := &serveServer{store: store}
+	mgr, err := newJobsV2ManagerWithNotifier(":memory:", 0, nil, srv.notifyJobsV2RunDone)
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	runnerConfig, _ := json.Marshal(jobsV2LLMConfig{
+		AgentName:      "developer",
+		Instructions:   "do work",
+		Cwd:            "/tmp/work",
+		NotifyWhenDone: true,
+		NotifyOrigin:   &jobsV2NotifyOrigin{Origin: "web", SessionID: "sess-origin"},
+	})
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "notify-web",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerLLM,
+		RunnerConfig:  runnerConfig,
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+
+	result := jobsV2RunResult{Response: "STATUS: COMPLETE\nImplemented the feature and verified tests."}
+	if err := mgr.finishRun(run.ID, jobsV2RunSucceeded, result, nil, run.Attempt); err != nil {
+		t.Fatalf("finishRun: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	msgs := store.messages["sess-origin"]
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %d, want 1: %#v", len(msgs), msgs)
+	}
+	if msgs[0].Role != llm.RoleAssistant {
+		t.Fatalf("notification role = %s, want assistant", msgs[0].Role)
+	}
+	text := msgs[0].TextContent
+	if !strings.Contains(text, job.ID) || !strings.Contains(text, "developer") || !strings.Contains(text, "succeeded") || !strings.Contains(text, "Implemented the feature") {
+		t.Fatalf("notification text = %q, missing compact job summary", text)
+	}
+	if strings.Contains(text, "STATUS: COMPLETE") {
+		t.Fatalf("notification text should omit status footer, got %q", text)
+	}
+}
+
+func TestJobsV2NotifyFailureDoesNotChangeRunStatus(t *testing.T) {
+	mgr, err := newJobsV2ManagerWithNotifier(":memory:", 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		return errors.New("notify failed")
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "notify-failure",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+
+	if err := mgr.finishRun(run.ID, jobsV2RunSucceeded, jobsV2RunResult{Stdout: "ok"}, nil, run.Attempt); err != nil {
+		t.Fatalf("finishRun: %v", err)
+	}
+	updated, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if updated.Status != jobsV2RunSucceeded {
+		t.Fatalf("status = %s, want succeeded", updated.Status)
+	}
+	events, _, err := mgr.ListRunEvents(run.ID, 0, 20, 0)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	foundNotifyFailure := false
+	for _, ev := range events {
+		if ev.EventType == "notify_failed" {
+			foundNotifyFailure = true
+		}
+	}
+	if !foundNotifyFailure {
+		t.Fatalf("expected notify_failed event, got %#v", events)
+	}
+}

--- a/cmd/serve_jobs_v2_parity_test.go
+++ b/cmd/serve_jobs_v2_parity_test.go
@@ -26,6 +26,7 @@ func sliceHasString(items []string, want string) bool {
 // survives a JSON marshal/unmarshal round-trip under the documented key names.
 func TestJobsV2LLMConfigParityRoundTrip(t *testing.T) {
 	persist := false
+	notifyOrigin := &jobsV2NotifyOrigin{Origin: "web", SessionID: "sess-parent"}
 	full := jobsV2LLMConfig{
 		AgentName:       "developer",
 		Instructions:    "implement the spec",
@@ -34,6 +35,8 @@ func TestJobsV2LLMConfigParityRoundTrip(t *testing.T) {
 		ContinueWith:    "keep going",
 		PersistSession:  &persist,
 		SessionID:       "sess-1",
+		NotifyWhenDone:  true,
+		NotifyOrigin:    notifyOrigin,
 		Provider:        "claude-bin:opus-max",
 		Model:           "opus-max",
 		Cwd:             "/work/tree",
@@ -61,7 +64,7 @@ func TestJobsV2LLMConfigParityRoundTrip(t *testing.T) {
 	}
 
 	for _, key := range []string{
-		"provider", "model", "cwd", "read_dir", "write_dir", "tools",
+		"provider", "model", "cwd", "notify_when_done", "notify_origin", "read_dir", "write_dir", "tools",
 		"max_turns", "max_output_tokens", "search", "system_message", "skills",
 	} {
 		if !strings.Contains(string(data), `"`+key+`"`) {
@@ -85,8 +88,8 @@ func TestJobsV2LLMConfigBackwardCompatDefaults(t *testing.T) {
 		t.Fatalf("legacy fields not preserved: %+v", cfg)
 	}
 	if cfg.Provider != "" || cfg.Model != "" || cfg.Cwd != "" || cfg.Tools != "" ||
-		cfg.MaxTurns != 0 || cfg.MaxOutputTokens != 0 || cfg.Search ||
-		cfg.SystemMessage != "" || cfg.Skills != "" ||
+		cfg.MaxTurns != 0 || cfg.MaxOutputTokens != 0 || cfg.Search || cfg.NotifyWhenDone ||
+		cfg.SystemMessage != "" || cfg.Skills != "" || cfg.NotifyOrigin != nil ||
 		cfg.ReadDir != nil || cfg.WriteDir != nil {
 		t.Fatalf("new parity fields should default to zero, got: %+v", cfg)
 	}
@@ -101,7 +104,7 @@ func TestJobsV2LLMConfigBackwardCompatDefaults(t *testing.T) {
 	}
 	for _, key := range []string{
 		"provider", "model", "read_dir", "write_dir", "tools",
-		"max_turns", "max_output_tokens", "system_message", "skills",
+		"max_turns", "max_output_tokens", "system_message", "skills", "notify_when_done", "notify_origin",
 	} {
 		if strings.Contains(string(out), `"`+key+`"`) {
 			t.Errorf("omitempty broken: re-serialized legacy config unexpectedly contains %q: %s", key, out)

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -626,6 +626,12 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
 	runCtx = tools.ContextWithAskUserUIFunc(runCtx, rt.awaitAskUser)
+	if rt.platform == "web" && strings.TrimSpace(req.SessionID) != "" {
+		runCtx = tools.ContextWithQueueAgentOrigin(runCtx, tools.QueueAgentOriginContext{
+			Origin:    tools.QueueAgentOriginWeb,
+			SessionID: req.SessionID,
+		})
+	}
 
 	intState := &runtimeInterruptState{
 		cancel:      runCancel,

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	memorystore "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
 )
 
 const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
@@ -1214,6 +1215,13 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	sessionID := ""
 	if sess.meta != nil {
 		sessionID = sess.meta.ID
+	}
+	if sessionID != "" {
+		streamCtx = tools.ContextWithQueueAgentOrigin(streamCtx, tools.QueueAgentOriginContext{
+			Origin:         tools.QueueAgentOriginTelegram,
+			SessionID:      sessionID,
+			TelegramChatID: chatID,
+		})
 	}
 
 	// Persist incoming messages before streaming.

--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,11 +23,12 @@ const (
 )
 
 type QueueAgentArgs struct {
-	AgentName string `json:"agent_name"`
-	Prompt    string `json:"prompt"`
-	Timeout   int    `json:"timeout,omitempty"`
-	Model     string `json:"model,omitempty"`
-	Cwd       string `json:"cwd,omitempty"`
+	AgentName      string `json:"agent_name"`
+	Prompt         string `json:"prompt"`
+	Timeout        int    `json:"timeout,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Cwd            string `json:"cwd,omitempty"`
+	NotifyWhenDone bool   `json:"notify_when_done,omitempty"`
 }
 
 type QueueAgentResult struct {
@@ -147,6 +149,10 @@ func (t *QueueAgentTool) Spec() llm.ToolSpec {
 					"type":        "string",
 					"description": "Optional working directory/root for the jobs-v2 LLM job. Defaults to TERM_LLM_QUEUE_AGENT_CWD or the current process directory.",
 				},
+				"notify_when_done": map[string]any{
+					"type":        "boolean",
+					"description": "When true, notify this request's originating session or chat when the queued job finishes. Defaults to false.",
+				},
 			},
 			"required":             []string{"agent_name", "prompt"},
 			"additionalProperties": false,
@@ -181,7 +187,8 @@ func (t *QueueAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, err.Error())), nil
 	}
 
-	job, err := t.client.createAgentJob(ctx, agentName, a.Prompt, strings.TrimSpace(a.Model), cwd, timeout)
+	origin, _ := QueueAgentOriginFromContext(ctx)
+	job, err := t.client.createAgentJob(ctx, agentName, a.Prompt, strings.TrimSpace(a.Model), cwd, timeout, a.NotifyWhenDone, origin)
 	if err != nil {
 		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
 	}
@@ -290,7 +297,7 @@ func newJobsBackedAgentClientFromEnv() *jobsBackedAgentClient {
 	}
 }
 
-func (c *jobsBackedAgentClient) createAgentJob(ctx context.Context, agentName, prompt, model, cwd string, timeout int) (jobsV2AgentJobResponse, error) {
+func (c *jobsBackedAgentClient) createAgentJob(ctx context.Context, agentName, prompt, model, cwd string, timeout int, notifyWhenDone bool, origin QueueAgentOriginContext) (jobsV2AgentJobResponse, error) {
 	instructions := prompt + `
 
 ---
@@ -311,6 +318,11 @@ Choose COMPLETE only if you fully accomplished the task. Do not omit this line.`
 	if model != "" {
 		runnerConfig["model"] = model
 	}
+	requestHeaders := map[string]string(nil)
+	if notifyWhenDone {
+		runnerConfig["notify_when_done"] = true
+		requestHeaders = queueAgentNotifyOriginHeaders(origin)
+	}
 
 	payload := jobsV2AgentJobPayload{
 		Name:              fmt.Sprintf("agent-%s-%d", sanitizeJobNamePart(agentName), time.Now().UnixNano()),
@@ -324,13 +336,31 @@ Choose COMPLETE only if you fully accomplished the task. Do not omit this line.`
 	}
 
 	var job jobsV2AgentJobResponse
-	if err := c.doJSON(ctx, http.MethodPost, "/v2/jobs", payload, &job); err != nil {
+	if err := c.doJSONWithHeaders(ctx, http.MethodPost, "/v2/jobs", payload, &job, requestHeaders); err != nil {
 		return jobsV2AgentJobResponse{}, err
 	}
 	if job.ID == "" {
 		return jobsV2AgentJobResponse{}, fmt.Errorf("jobs server returned job without id")
 	}
 	return job, nil
+}
+
+func queueAgentNotifyOriginHeaders(origin QueueAgentOriginContext) map[string]string {
+	origin.Origin = strings.TrimSpace(origin.Origin)
+	origin.SessionID = strings.TrimSpace(origin.SessionID)
+	if origin.Origin == "" {
+		return nil
+	}
+	headers := map[string]string{
+		QueueAgentNotifyOriginHeader: origin.Origin,
+	}
+	if origin.SessionID != "" {
+		headers[QueueAgentNotifySessionIDHeader] = origin.SessionID
+	}
+	if origin.TelegramChatID != 0 {
+		headers[QueueAgentNotifyTelegramChatIDHeader] = strconv.FormatInt(origin.TelegramChatID, 10)
+	}
+	return headers
 }
 
 func (c *jobsBackedAgentClient) triggerJob(ctx context.Context, jobID string) (jobsV2AgentRunResponse, error) {
@@ -386,6 +416,10 @@ func (c *jobsBackedAgentClient) latestRunForJob(ctx context.Context, jobID strin
 }
 
 func (c *jobsBackedAgentClient) doJSON(ctx context.Context, method, path string, payload any, out any) error {
+	return c.doJSONWithHeaders(ctx, method, path, payload, out, nil)
+}
+
+func (c *jobsBackedAgentClient) doJSONWithHeaders(ctx context.Context, method, path string, payload any, out any, headers map[string]string) error {
 	var body io.Reader
 	if payload != nil {
 		data, err := json.Marshal(payload)
@@ -403,6 +437,12 @@ func (c *jobsBackedAgentClient) doJSON(ctx context.Context, method, path string,
 	}
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	for name, value := range headers {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			req.Header.Set(name, value)
+		}
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/tools/queue_agent_context.go
+++ b/internal/tools/queue_agent_context.go
@@ -1,0 +1,56 @@
+package tools
+
+import (
+	"context"
+	"strings"
+)
+
+const (
+	QueueAgentOriginWeb      = "web"
+	QueueAgentOriginTelegram = "telegram"
+
+	QueueAgentNotifyOriginHeader         = "X-Term-LLM-Queue-Agent-Origin"
+	QueueAgentNotifySessionIDHeader      = "X-Term-LLM-Queue-Agent-Session-ID"
+	QueueAgentNotifyTelegramChatIDHeader = "X-Term-LLM-Queue-Agent-Telegram-Chat-ID"
+)
+
+// QueueAgentOriginContext carries the trusted runtime origin for queue_agent
+// completion notifications. It is intentionally supplied by runtime code rather
+// than by queue_agent tool arguments, so callers can only opt in to notification,
+// not choose an arbitrary target.
+type QueueAgentOriginContext struct {
+	Origin         string
+	SessionID      string
+	TelegramChatID int64
+}
+
+type queueAgentOriginContextKey struct{}
+
+// ContextWithQueueAgentOrigin stores trusted queue_agent notification origin
+// metadata in ctx for the duration of a request.
+func ContextWithQueueAgentOrigin(ctx context.Context, origin QueueAgentOriginContext) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	origin.Origin = strings.TrimSpace(origin.Origin)
+	origin.SessionID = strings.TrimSpace(origin.SessionID)
+	if origin.Origin == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, queueAgentOriginContextKey{}, origin)
+}
+
+// QueueAgentOriginFromContext returns trusted queue_agent notification origin
+// metadata previously stored by ContextWithQueueAgentOrigin.
+func QueueAgentOriginFromContext(ctx context.Context) (QueueAgentOriginContext, bool) {
+	if ctx == nil {
+		return QueueAgentOriginContext{}, false
+	}
+	origin, ok := ctx.Value(queueAgentOriginContextKey{}).(QueueAgentOriginContext)
+	if !ok || strings.TrimSpace(origin.Origin) == "" {
+		return QueueAgentOriginContext{}, false
+	}
+	origin.Origin = strings.TrimSpace(origin.Origin)
+	origin.SessionID = strings.TrimSpace(origin.SessionID)
+	return origin, true
+}

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -75,6 +75,51 @@ func TestQueueAgentCreatesAndTriggersJobsBackedLLMJob(t *testing.T) {
 	}
 }
 
+func TestQueueAgentNotifyWhenDonePersistsTrustedOrigin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs":
+			var payload jobsV2AgentJobPayload
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create payload: %v", err)
+			}
+			if payload.RunnerConfig["notify_when_done"] != true {
+				t.Fatalf("notify_when_done = %#v, want true", payload.RunnerConfig["notify_when_done"])
+			}
+			if _, exists := payload.RunnerConfig["notify_origin"]; exists {
+				t.Fatalf("notify_origin should not be caller-controlled in runner_config: %#v", payload.RunnerConfig["notify_origin"])
+			}
+			if r.Header.Get(QueueAgentNotifyOriginHeader) != QueueAgentOriginWeb || r.Header.Get(QueueAgentNotifySessionIDHeader) != "sess-web-1" {
+				t.Fatalf("notify origin headers = origin:%q session:%q, want web sess-web-1", r.Header.Get(QueueAgentNotifyOriginHeader), r.Header.Get(QueueAgentNotifySessionIDHeader))
+			}
+			if got := r.Header.Get(QueueAgentNotifyTelegramChatIDHeader); got != "" {
+				t.Fatalf("telegram header = %q, want empty", got)
+			}
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_notify"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs/job_notify/trigger":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_notify", JobID: "job_notify", Status: "queued"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewQueueAgentToolWithClient(client)
+	ctx := ContextWithQueueAgentOrigin(context.Background(), QueueAgentOriginContext{Origin: QueueAgentOriginWeb, SessionID: "sess-web-1"})
+	out, err := tool.Execute(ctx, json.RawMessage(`{"agent_name":"developer","prompt":"do it","cwd":"/tmp/work","notify_when_done":true}`))
+	if err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+	var result QueueAgentResult
+	if err := json.Unmarshal([]byte(out.Content), &result); err != nil {
+		t.Fatalf("queue output is not JSON: %v; %s", err, out.Content)
+	}
+	if result.JobID != "job_notify" {
+		t.Fatalf("job_id = %q, want job_notify", result.JobID)
+	}
+}
+
 func TestWaitForJobsPollsUntilTerminal(t *testing.T) {
 	var polls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Adds a minimal `notify_when_done` option to the native `queue_agent` tool.

When enabled, queued agent jobs notify their original requester after reaching a terminal state: succeeded, failed, cancelled, or timed out.

Delivery is intentionally simple:

- web origin + active session: deliver through the existing interjection path
- web origin + idle session: append a compact assistant notification to the session
- Telegram origin: send a compact message to the originating chat when Telegram is configured
- CLI/API/no live target: safe no-op/store-only behavior

The notification includes the job id, agent name, terminal status, and a short excerpt. Full output stays in job storage.

## Why

This avoids forcing callers to block on `wait_for_jobs` just to learn that background work finished. `queue_agent` becomes a usable async primitive instead of a polling chore dressed as parallelism.

## Safety

- The public tool only exposes `notify_when_done`; callers cannot provide arbitrary notification targets.
- Origin metadata is captured from trusted runtime context.
- `/v2/jobs` strips body-supplied `notify_origin`.
- Runtime notify-origin headers are accepted only from loopback requests.
- Notification delivery is best-effort and never changes the job status.

## Verification

```text
gofmt -w cmd/serve_jobs_v2_notify.go cmd/serve_jobs_v2_notify_test.go
go test ./cmd -run 'JobsV2(CreateJob|Notify)'
go test ./internal/tools ./internal/serve
go build ./...
go test ./...
```

## Review

Built by `chatgpt:gpt-5.5-xhigh`.

Reviewed by `claude-bin:opus-max`; no blockers. I folded in the high-value review nits before opening this PR:

- added a non-loopback header spoofing test
- documented the trusted-loopback origin boundary
- documented why active web delivery passes no interrupt classifier provider
