### PR TITLE
feat: add TUI prompt history recall

### DIFF
--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -68,6 +68,14 @@ func (s *NoopStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, 
 	return nil, ErrNotFound
 }
 
+func (s *NoopStore) PreviousUserPrompt(ctx context.Context, agent string, beforeID int64) (*PromptHistoryEntry, error) {
+	return nil, nil
+}
+
+func (s *NoopStore) NextUserPrompt(ctx context.Context, agent string, afterID int64) (*PromptHistoryEntry, error) {
+	return nil, nil
+}
+
 func (s *NoopStore) ReplaceMessages(ctx context.Context, sessionID string, messages []Message) error {
 	return nil
 }

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -99,6 +99,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_updated_at ON sessions(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_mode ON sessions(mode);
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, sequence);
 CREATE INDEX IF NOT EXISTS idx_messages_session_role ON messages(session_id, role);
+CREATE INDEX IF NOT EXISTS idx_messages_role_id ON messages(role, id);
 
 -- Metadata table for current session tracking
 CREATE TABLE IF NOT EXISTS metadata (
@@ -222,7 +223,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 27
+const schemaVersion = 28
 
 // migration represents a schema migration.
 type migration struct {
@@ -816,6 +817,15 @@ var migrations = []migration{
 				return fmt.Errorf("backfill chat-bubble message_count: %w", err)
 			}
 			return nil
+		},
+	},
+	{
+		// Migration 28: Add an index for cross-session prompt history recall.
+		version:     28,
+		description: "add prompt history role/id index",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_messages_role_id ON messages(role, id)`)
+			return err
 		},
 	},
 }
@@ -2161,6 +2171,54 @@ func (s *SQLiteStore) GetLatestVisibleMessageID(ctx context.Context, sessionID s
 		return 0, fmt.Errorf("query latest visible message id: %w", err)
 	}
 	return msgID, nil
+}
+
+// PreviousUserPrompt returns the newest persisted user prompt older than beforeID.
+// When beforeID <= 0, traversal starts at the newest prompt. History is global
+// across sessions and optionally filtered by agent.
+func (s *SQLiteStore) PreviousUserPrompt(ctx context.Context, agent string, beforeID int64) (*PromptHistoryEntry, error) {
+	query := `
+		SELECT m.id, m.text_content
+		FROM messages m
+		JOIN sessions sess ON sess.id = m.session_id
+		WHERE m.role = 'user'
+		  AND TRIM(COALESCE(m.text_content, ''), char(9) || char(10) || char(11) || char(12) || char(13) || char(32)) <> ''
+		  AND substr(TRIM(COALESCE(m.text_content, ''), char(9) || char(10) || char(11) || char(12) || char(13) || char(32)), 1, ?) <> ?
+		  AND COALESCE(m.compaction_tail, FALSE) = FALSE
+		  AND (? = '' OR COALESCE(sess.agent, '') = ?)
+		  AND (? <= 0 OR m.id < ?)
+		ORDER BY m.id DESC
+		LIMIT 1`
+	return s.queryPromptHistoryEntry(ctx, query, len(internalCompactionSummarySQLPrefix), internalCompactionSummarySQLPrefix, agent, agent, beforeID, beforeID)
+}
+
+// NextUserPrompt returns the oldest persisted user prompt newer than afterID.
+func (s *SQLiteStore) NextUserPrompt(ctx context.Context, agent string, afterID int64) (*PromptHistoryEntry, error) {
+	query := `
+		SELECT m.id, m.text_content
+		FROM messages m
+		JOIN sessions sess ON sess.id = m.session_id
+		WHERE m.role = 'user'
+		  AND TRIM(COALESCE(m.text_content, ''), char(9) || char(10) || char(11) || char(12) || char(13) || char(32)) <> ''
+		  AND substr(TRIM(COALESCE(m.text_content, ''), char(9) || char(10) || char(11) || char(12) || char(13) || char(32)), 1, ?) <> ?
+		  AND COALESCE(m.compaction_tail, FALSE) = FALSE
+		  AND (? = '' OR COALESCE(sess.agent, '') = ?)
+		  AND m.id > ?
+		ORDER BY m.id ASC
+		LIMIT 1`
+	return s.queryPromptHistoryEntry(ctx, query, len(internalCompactionSummarySQLPrefix), internalCompactionSummarySQLPrefix, agent, agent, afterID)
+}
+
+func (s *SQLiteStore) queryPromptHistoryEntry(ctx context.Context, query string, args ...any) (*PromptHistoryEntry, error) {
+	var entry PromptHistoryEntry
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(&entry.ID, &entry.Text)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query prompt history: %w", err)
+	}
+	return &entry, nil
 }
 
 // GetMessages retrieves messages for a session.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -13,6 +13,70 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 )
 
+func TestPromptHistoryCrossSessionTraversal(t *testing.T) {
+	store, err := NewStore(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	sessA := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat, Agent: "jarvis"}
+	if err := store.Create(ctx, sessA); err != nil {
+		t.Fatalf("Create sessA: %v", err)
+	}
+	sessB := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat, Agent: "jarvis"}
+	if err := store.Create(ctx, sessB); err != nil {
+		t.Fatalf("Create sessB: %v", err)
+	}
+	sessOtherAgent := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat, Agent: "other"}
+	if err := store.Create(ctx, sessOtherAgent); err != nil {
+		t.Fatalf("Create sessOtherAgent: %v", err)
+	}
+
+	addPrompt := func(sess *Session, text string) int64 {
+		t.Helper()
+		msg := NewMessage(sess.ID, llm.UserText(text), -1)
+		if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+			t.Fatalf("AddMessage(%q): %v", text, err)
+		}
+		return msg.ID
+	}
+
+	firstID := addPrompt(sessA, "from terminal one")
+	secondID := addPrompt(sessB, "from terminal two")
+	_ = addPrompt(sessOtherAgent, "from other agent")
+
+	history, ok := store.(PromptHistoryStore)
+	if !ok {
+		t.Fatal("store does not implement PromptHistoryStore")
+	}
+
+	latest, err := history.PreviousUserPrompt(ctx, "jarvis", 0)
+	if err != nil {
+		t.Fatalf("PreviousUserPrompt newest: %v", err)
+	}
+	if latest == nil || latest.ID != secondID || latest.Text != "from terminal two" {
+		t.Fatalf("latest = %#v, want id=%d text=%q", latest, secondID, "from terminal two")
+	}
+
+	older, err := history.PreviousUserPrompt(ctx, "jarvis", latest.ID)
+	if err != nil {
+		t.Fatalf("PreviousUserPrompt older: %v", err)
+	}
+	if older == nil || older.ID != firstID || older.Text != "from terminal one" {
+		t.Fatalf("older = %#v, want id=%d text=%q", older, firstID, "from terminal one")
+	}
+
+	newer, err := history.NextUserPrompt(ctx, "jarvis", older.ID)
+	if err != nil {
+		t.Fatalf("NextUserPrompt: %v", err)
+	}
+	if newer == nil || newer.ID != secondID || newer.Text != "from terminal two" {
+		t.Fatalf("newer = %#v, want id=%d text=%q", newer, secondID, "from terminal two")
+	}
+}
+
 func TestSessionPreferredTitlePrecedence(t *testing.T) {
 	sess := Session{Summary: "first message summary", GeneratedShortTitle: "Generated short title", GeneratedLongTitle: "Generated long title"}
 	if got := sess.PreferredShortTitle(); got != "Generated short title" {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -76,6 +76,20 @@ type MessagesDescendingPager interface {
 	GetMessagesPageDescending(ctx context.Context, sessionID string, beforeSeq, limit int) ([]Message, error)
 }
 
+// PromptHistoryEntry is a user prompt recalled from cross-session composer history.
+type PromptHistoryEntry struct {
+	ID   int64
+	Text string
+}
+
+// PromptHistoryStore is an optional Store capability for shell-style composer
+// history recall. Implementations traverse persisted user prompts globally so
+// multiple TUI processes share the same prompt history.
+type PromptHistoryStore interface {
+	PreviousUserPrompt(ctx context.Context, agent string, beforeID int64) (*PromptHistoryEntry, error)
+	NextUserPrompt(ctx context.Context, agent string, afterID int64) (*PromptHistoryEntry, error)
+}
+
 // PushSubscription represents a Web Push subscription stored in the database.
 type PushSubscription struct {
 	ID        string

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -44,6 +44,16 @@ type pendingStreamModelSwitch struct {
 	model    string
 }
 
+type promptHistoryState struct {
+	active       bool
+	cursorID     int64
+	draftText    string
+	draftFiles   []FileAttachment
+	draftImages  []ImageAttachment
+	draftPastes  map[int]string
+	recalledText string
+}
+
 type Model struct {
 	// Dimensions
 	width  int
@@ -178,6 +188,7 @@ type Model struct {
 	activeInterruptSeq      uint64 // Currently active async interrupt classification request
 	pendingInterruptUI      string // UI state of latest pending interjection: "", "deciding", "interject"
 	interruptNotice         string // One-line UI notice for recent interrupt actions
+	promptHistory           promptHistoryState
 	// MCP (Model Context Protocol)
 	mcpManager    *mcp.Manager
 	mcpStatusChan chan mcp.StatusUpdate

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -522,6 +522,14 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Shell-style prompt history: Up/Down first move within the composer, then
+	// recall cross-session persisted user prompts at the visual boundaries. This
+	// runs before viewport scrolling so the streaming interjection composer gets
+	// the same history behavior as the normal composer.
+	if handled, cmd := m.handlePromptHistoryKey(msg); handled {
+		return m, cmd
+	}
+
 	// Handle quit (Ctrl+C copies when text is selected)
 	if key.Matches(msg, m.keyMap.Quit) {
 		if m.selection.Active {
@@ -753,6 +761,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.textarea, cmd = m.textarea.Update(msg)
 		m.updateTextareaHeight()
 		if newVal := m.textarea.Value(); newVal != old {
+			m.resetPromptHistoryIfEdited()
 			if strings.HasPrefix(newVal, "/") {
 				if !m.completions.IsVisible() {
 					m.completions.Show()
@@ -949,6 +958,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// Clear selection when user starts typing
 		if m.selection.Active && m.textarea.Value() != old {
 			m.selection = Selection{}
+		}
+		if m.textarea.Value() != old {
+			m.resetPromptHistoryIfEdited()
 		}
 		m.updateTextareaHeight()
 		// Show argument completions for commands that support them

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -17,6 +17,80 @@ import (
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
+func TestPromptHistoryRecallsCrossSessionDraftAndRestoresLocalDraft(t *testing.T) {
+	store, err := session.NewStore(session.Config{Enabled: true, Path: t.TempDir() + "/sessions.db"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	sess1 := &session.Session{ID: session.NewID(), Provider: "mock", Model: "mock-model", Mode: session.ModeChat, Agent: "jarvis"}
+	if err := store.Create(ctx, sess1); err != nil {
+		t.Fatalf("Create sess1: %v", err)
+	}
+	sess2 := &session.Session{ID: session.NewID(), Provider: "mock", Model: "mock-model", Mode: session.ModeChat, Agent: "jarvis"}
+	if err := store.Create(ctx, sess2); err != nil {
+		t.Fatalf("Create sess2: %v", err)
+	}
+
+	addPrompt := func(sess *session.Session, text string) {
+		t.Helper()
+		msg := session.NewMessage(sess.ID, llm.UserText(text), -1)
+		if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+			t.Fatalf("AddMessage(%q): %v", text, err)
+		}
+	}
+	addPrompt(sess1, "terminal one words")
+	addPrompt(sess2, "terminal two words")
+
+	m := newTestChatModel(false)
+	m.store = store
+	m.sess = sess1
+	m.agentName = "jarvis"
+	m.setTextareaValue("word")
+
+	_, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	if got := m.textarea.Value(); got != "terminal two words" {
+		t.Fatalf("after up textarea = %q, want latest cross-session prompt", got)
+	}
+
+	_, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	if got := m.textarea.Value(); got != "word" {
+		t.Fatalf("after down textarea = %q, want restored draft", got)
+	}
+}
+
+func TestPromptHistoryWorksDuringStreamingInterjectionComposer(t *testing.T) {
+	store, err := session.NewStore(session.Config{Enabled: true, Path: t.TempDir() + "/sessions.db"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	sess := &session.Session{ID: session.NewID(), Provider: "mock", Model: "mock-model", Mode: session.ModeChat, Agent: "jarvis"}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create sess: %v", err)
+	}
+	msg := session.NewMessage(sess.ID, llm.UserText("streaming history prompt"), -1)
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	m := newTestChatModel(false)
+	m.store = store
+	m.sess = sess
+	m.agentName = "jarvis"
+	m.streaming = true
+	m.setTextareaValue("interrupt draft")
+
+	_, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	if got := m.textarea.Value(); got != "streaming history prompt" {
+		t.Fatalf("streaming up textarea = %q, want prompt history", got)
+	}
+}
+
 func TestHandlePasteMsg_SlashPathDoesNotLeaveCompletionsVisible(t *testing.T) {
 	m := newTestChatModel(false)
 

--- a/internal/tui/chat/keys.go
+++ b/internal/tui/chat/keys.go
@@ -75,6 +75,14 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("esc"),
 			key.WithHelp("esc", "cancel"),
 		),
+		HistoryUp: key.NewBinding(
+			key.WithKeys("up"),
+			key.WithHelp("up", "history up"),
+		),
+		HistoryDown: key.NewBinding(
+			key.WithKeys("down"),
+			key.WithHelp("down", "history down"),
+		),
 		Tab: key.NewBinding(
 			key.WithKeys("tab"),
 			key.WithHelp("tab", "complete"),

--- a/internal/tui/chat/prompt_history.go
+++ b/internal/tui/chat/prompt_history.go
@@ -1,0 +1,168 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func (m *Model) handlePromptHistoryKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
+	up := key.Matches(msg, m.keyMap.HistoryUp)
+	down := key.Matches(msg, m.keyMap.HistoryDown)
+	if !up && !down {
+		return false, nil
+	}
+
+	if up {
+		if m.tryMoveTextareaUp() {
+			m.resetPromptHistoryIfEdited()
+			m.updateTextareaHeight()
+			return true, nil
+		}
+		return m.recallPreviousPrompt()
+	}
+
+	if m.tryMoveTextareaDown() {
+		m.resetPromptHistoryIfEdited()
+		m.updateTextareaHeight()
+		return true, nil
+	}
+	return m.recallNextPrompt()
+}
+
+func (m *Model) tryMoveTextareaUp() bool {
+	line := m.textarea.Line()
+	col := m.textarea.Column()
+	y := m.textarea.ScrollYOffset()
+	m.textarea.CursorUp()
+	return m.textarea.Line() != line || m.textarea.Column() != col || m.textarea.ScrollYOffset() != y
+}
+
+func (m *Model) tryMoveTextareaDown() bool {
+	line := m.textarea.Line()
+	col := m.textarea.Column()
+	y := m.textarea.ScrollYOffset()
+	m.textarea.CursorDown()
+	return m.textarea.Line() != line || m.textarea.Column() != col || m.textarea.ScrollYOffset() != y
+}
+
+func (m *Model) recallPreviousPrompt() (bool, tea.Cmd) {
+	history, ok := m.store.(session.PromptHistoryStore)
+	if !ok || history == nil {
+		return false, nil
+	}
+
+	current := m.textarea.Value()
+	if !m.promptHistory.active {
+		m.promptHistory = promptHistoryState{
+			active:      true,
+			draftText:   current,
+			draftFiles:  append([]FileAttachment(nil), m.files...),
+			draftImages: append([]ImageAttachment(nil), m.images...),
+			draftPastes: clonePasteChunks(m.pasteChunks),
+		}
+	} else if current != m.promptHistory.recalledText {
+		m.resetPromptHistory()
+		return false, nil
+	}
+
+	entry, err := history.PreviousUserPrompt(context.Background(), m.agentName, m.promptHistory.cursorID)
+	if err != nil {
+		m.showPromptHistoryError(err)
+		return true, nil
+	}
+	if entry == nil {
+		return true, nil
+	}
+
+	m.applyPromptHistoryEntry(entry)
+	return true, nil
+}
+
+func (m *Model) recallNextPrompt() (bool, tea.Cmd) {
+	if !m.promptHistory.active {
+		return false, nil
+	}
+	if m.textarea.Value() != m.promptHistory.recalledText {
+		m.resetPromptHistory()
+		return false, nil
+	}
+
+	history, ok := m.store.(session.PromptHistoryStore)
+	if !ok || history == nil {
+		m.restorePromptHistoryDraft()
+		return true, nil
+	}
+
+	entry, err := history.NextUserPrompt(context.Background(), m.agentName, m.promptHistory.cursorID)
+	if err != nil {
+		m.showPromptHistoryError(err)
+		return true, nil
+	}
+	if entry == nil {
+		m.restorePromptHistoryDraft()
+		return true, nil
+	}
+
+	m.applyPromptHistoryEntry(entry)
+	m.textarea.MoveToEnd()
+	return true, nil
+}
+
+func (m *Model) applyPromptHistoryEntry(entry *session.PromptHistoryEntry) {
+	m.promptHistory.cursorID = entry.ID
+	m.promptHistory.recalledText = entry.Text
+	m.textarea.SetValue(entry.Text)
+	m.textarea.MoveToBegin()
+	m.updateTextareaHeight()
+
+	// Prompt history rows are text-only. Keep the draft attachments out of the
+	// recalled prompt so Enter does not accidentally send stale files/images.
+	m.files = nil
+	m.images = nil
+	m.selectedImage = -1
+	m.pasteChunks = nil
+}
+
+func (m *Model) restorePromptHistoryDraft() {
+	draftText := m.promptHistory.draftText
+	draftFiles := append([]FileAttachment(nil), m.promptHistory.draftFiles...)
+	draftImages := append([]ImageAttachment(nil), m.promptHistory.draftImages...)
+	draftPastes := clonePasteChunks(m.promptHistory.draftPastes)
+	m.resetPromptHistory()
+	m.textarea.SetValue(draftText)
+	m.textarea.MoveToEnd()
+	m.updateTextareaHeight()
+	m.files = draftFiles
+	m.images = draftImages
+	m.selectedImage = -1
+	m.pasteChunks = draftPastes
+}
+
+func (m *Model) resetPromptHistoryIfEdited() {
+	if m.promptHistory.active && m.textarea.Value() != m.promptHistory.recalledText {
+		m.resetPromptHistory()
+	}
+}
+
+func (m *Model) resetPromptHistory() {
+	m.promptHistory = promptHistoryState{}
+}
+
+func (m *Model) showPromptHistoryError(err error) {
+	m.phase = fmt.Sprintf("Prompt history error: %v", err)
+}
+
+func clonePasteChunks(in map[int]string) map[int]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[int]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -388,6 +388,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	// tea.Println adds newline, no need for extra
 
 	// Clear input and attachments
+	m.resetPromptHistory()
 	m.setTextareaValue("")
 	m.files = nil
 	m.images = nil


### PR DESCRIPTION
## What

Adds shell-style Up/Down prompt history recall in the TUI composer.

- Uses persisted `messages` rows as shared cross-session prompt history
- Traverses global user prompts by monotonic `messages.id`, filtered to the current agent
- Preserves the local unsent draft while browsing history and restores it when moving down past newest
- Lets Up/Down move within multiline composer text before falling back to history
- Works in the streaming interjection composer before viewport arrow scrolling takes over
- Keeps recalled history text-only so stale draft files/images are not accidentally sent

## Why

This matches the expected terminal behavior:

1. terminal 1 sends a prompt
2. terminal 2 sends a prompt in another session
3. terminal 1 types a draft and presses Up
4. terminal 1 recalls terminal 2's newer persisted prompt, and Down restores the draft

## Verification

- `go test ./...`
- `go build ./...`
- `go vet ./...`
