### PR TITLE
fix: raise web tool summary arg cap

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1578,6 +1578,8 @@ const isBlankToolArgValue = (value) => {
   return false;
 };
 
+const TOOL_SUMMARY_ARG_LIMIT = 10;
+
 const formatToolArgs = (tool) => {
   if (!tool.arguments) return null;
   let args;
@@ -1598,7 +1600,7 @@ const formatToolArgs = (tool) => {
 
   if (name === 'ask_user') {
     const questions = Array.isArray(args.questions) ? args.questions : [];
-    return questions.slice(0, 4).map((question, index) => [
+    return questions.slice(0, TOOL_SUMMARY_ARG_LIMIT).map((question, index) => [
       question.header || `question_${index + 1}`,
       question.question || ''
     ]);
@@ -1619,7 +1621,7 @@ const formatToolArgs = (tool) => {
     if (inputCount > 0) {
       entries.push(['input', `${inputCount} attached image${inputCount === 1 ? '' : 's'}`]);
     }
-    return entries.slice(0, 4);
+    return entries.slice(0, TOOL_SUMMARY_ARG_LIMIT);
   }
 
   // Pick the most relevant key(s) per tool type
@@ -1648,7 +1650,7 @@ const formatToolArgs = (tool) => {
     entries = allEntries;
   }
 
-  return entries.slice(0, 4); // Cap at 4 args to keep it compact
+  return entries.slice(0, TOOL_SUMMARY_ARG_LIMIT); // Keep tool summaries bounded without hiding useful context
 };
 
 const buildArgsNode = (tool) => {

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -484,6 +484,22 @@ async function run(name, fn) {
     assert(!lines[1].includes('extra:'), 'detail should not include excess keys');
   });
 
+  await run('tool summaries are capped at ten visible arguments', () => {
+    const { app } = createHarness();
+    const entries = app.formatToolArgs({
+      name: 'misc_tool',
+      status: 'done',
+      arguments: JSON.stringify({
+        a1: 'v1', a2: 'v2', a3: 'v3', a4: 'v4', a5: 'v5',
+        a6: 'v6', a7: 'v7', a8: 'v8', a9: 'v9', a10: 'v10', a11: 'v11',
+      }),
+    });
+
+    assertEqual(entries.length, 10, 'tool summaries should show up to ten args');
+    assertEqual(entries[9][0], 'a10', 'tenth arg should still be visible');
+    assert(!entries.some(([key]) => key === 'a11'), 'eleventh arg should be capped');
+  });
+
   await run('image generation tool summaries prioritize prompt and hide blanks', () => {
     const { app } = createHarness();
     const entries = app.formatToolArgs({


### PR DESCRIPTION
## What

Raise the web UI compact tool summary cap from 4 visible arguments to 10.

## Why

The previous cap was too low. In particular, tools with several metadata fields could hide important later arguments like `prompt`.

## Details

- Adds a `TOOL_SUMMARY_ARG_LIMIT = 10` constant.
- Applies it to generic tool summaries, `ask_user`, and `image_generate`.
- No tool-specific `queue_agent` formatting.
- Adds a JS regression test proving the tenth arg is visible and the eleventh is capped.

## Verification

- `mise exec node@24 -- node internal/serveui/static/app_render_test.js`
- `go test ./internal/serveui`
