### PR TITLE
feat(memory): consolidate instead of decaying by default

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -27,6 +27,7 @@ var memoryCmd = &cobra.Command{
 Examples:
   term-llm memory mine
   term-llm memory search "retry policy"
+  term-llm memory consolidate --dry-run
   term-llm memory status
   term-llm memory fragments list`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,6 +51,7 @@ func init() {
 	memoryCmd.AddCommand(memoryUpdateRecentCmd)
 	memoryCmd.AddCommand(memorySearchCmd)
 	memoryCmd.AddCommand(memoryPromoteCmd)
+	memoryCmd.AddCommand(memoryConsolidateCmd)
 	memoryCmd.AddCommand(memoryStatusCmd)
 	memoryCmd.AddCommand(memoryFragmentsCmd)
 	memoryCmd.AddCommand(memoryImagesCmd)

--- a/cmd/memory_consolidate.go
+++ b/cmd/memory_consolidate.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var (
+	memoryConsolidateApply          bool
+	memoryConsolidateSince          time.Duration
+	memoryConsolidateRecentMaxBytes int
+	memoryConsolidateModel          string
+	memoryConsolidateHalfLife       float64
+	memoryConsolidateDecayLimit     int
+	memoryConsolidateSkipDecay      bool
+)
+
+var memoryConsolidateCmd = &cobra.Command{
+	Use:   "consolidate",
+	Short: "Safely consolidate changed memory into recent.md",
+	Long: `Safely consolidate changed memory fragments into the agent's current-state
+recent.md summary.
+
+Consolidate is conservative: it defaults to dry-run mode, prints the proposed
+recent.md rewrite, and shows a non-destructive decay preview. It never deletes
+fragments and never rewrites stored decay scores. Pass --apply to write the
+updated recent.md file.`,
+	RunE: runMemoryConsolidate,
+}
+
+func init() {
+	memoryConsolidateCmd.Flags().BoolVar(&memoryConsolidateApply, "apply", false, "Write the consolidated recent.md (default is dry-run preview)")
+	memoryConsolidateCmd.Flags().DurationVar(&memoryConsolidateSince, "since", 0, "Override consolidate lookback window (e.g. 6h)")
+	memoryConsolidateCmd.Flags().IntVar(&memoryConsolidateRecentMaxBytes, "recent-max-bytes", defaultRecentMaxBytes, "Maximum bytes to keep in recent.md")
+	memoryConsolidateCmd.Flags().StringVar(&memoryConsolidateModel, "model", "", "Override model used for consolidation")
+	memoryConsolidateCmd.Flags().Float64Var(&memoryConsolidateHalfLife, "half-life", memorydb.DefaultDecayHalfLifeDays, "Half-life in days for non-destructive decay preview")
+	memoryConsolidateCmd.Flags().IntVar(&memoryConsolidateDecayLimit, "decay-limit", 10, "Maximum low-score fragments to list in decay preview (0 = none)")
+	memoryConsolidateCmd.Flags().BoolVar(&memoryConsolidateSkipDecay, "no-decay-preview", false, "Skip the non-destructive decay preview")
+}
+
+func runMemoryConsolidate(cmd *cobra.Command, args []string) error {
+	if memoryConsolidateRecentMaxBytes <= 0 {
+		return fmt.Errorf("--recent-max-bytes must be > 0")
+	}
+	if memoryConsolidateHalfLife <= 0 {
+		return fmt.Errorf("--half-life must be > 0")
+	}
+	if memoryConsolidateDecayLimit < 0 {
+		return fmt.Errorf("--decay-limit must be >= 0")
+	}
+
+	apply, err := memoryConsolidateApplyMode(memoryDryRun, memoryConsolidateApply)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if err := applyProviderOverridesWithAgent(cfg, cfg.Ask.Provider, cfg.Ask.Model, "", "", ""); err != nil {
+		return err
+	}
+	if strings.TrimSpace(memoryConsolidateModel) != "" {
+		cfg.ApplyOverrides("", strings.TrimSpace(memoryConsolidateModel))
+	}
+
+	provider, err := llm.NewProvider(cfg)
+	if err != nil {
+		return err
+	}
+	engine := newEngine(provider, cfg)
+
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	agentName := strings.TrimSpace(memoryAgent)
+	if agentName == "" {
+		agentName = resolveMemoryAgent("")
+	}
+
+	if !apply {
+		fmt.Println("consolidate: dry-run (no writes). Proposed recent.md follows; rerun with --apply to write it.")
+	}
+
+	promoted, err := runMemoryPromoteFlow(ctx, cfg, engine, store, memoryPromoteOptions{
+		Agent:          agentName,
+		Since:          memoryConsolidateSince,
+		RecentMaxBytes: memoryConsolidateRecentMaxBytes,
+		Model:          strings.TrimSpace(memoryConsolidateModel),
+		DryRun:         !apply,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !memoryConsolidateSkipDecay {
+		if err := printMemoryConsolidateDecayPreview(ctx, store, agentName, memoryConsolidateHalfLife, memoryConsolidateDecayLimit); err != nil {
+			return err
+		}
+	}
+
+	if apply {
+		if memoryConsolidateSkipDecay {
+			fmt.Printf("consolidate: apply complete (promoted=%d). Decay preview skipped; no fragments were deleted.\n", promoted)
+		} else {
+			fmt.Printf("consolidate: apply complete (promoted=%d). Decay preview was non-destructive; no fragments were deleted.\n", promoted)
+		}
+	} else {
+		fmt.Println("consolidate: dry-run complete. No files, fragments, or decay scores were modified.")
+	}
+	return nil
+}
+
+func memoryConsolidateApplyMode(globalDryRun, applyFlag bool) (bool, error) {
+	if globalDryRun && applyFlag {
+		return false, fmt.Errorf("--dry-run and --apply cannot be used together")
+	}
+	return applyFlag && !globalDryRun, nil
+}
+
+func printMemoryConsolidateDecayPreview(ctx context.Context, store *memorydb.Store, agent string, halfLifeDays float64, limit int) error {
+	staleCount, err := store.CountDecayCandidates(ctx, agent, halfLifeDays, memorydb.DefaultDecayGCThreshold)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("decay preview: %d fragment(s) would be below %.2f with half-life %.1f days; no scores changed and no fragments deleted.\n",
+		staleCount, memorydb.DefaultDecayGCThreshold, halfLifeDays)
+	if limit == 0 {
+		return nil
+	}
+
+	previews, err := store.PreviewDecayScores(ctx, agent, halfLifeDays, limit)
+	if err != nil {
+		return err
+	}
+	if len(previews) == 0 {
+		return nil
+	}
+
+	fmt.Println("lowest preview scores:")
+	for _, preview := range previews {
+		fmt.Printf("  %.3f current=%.3f %s\n", preview.PreviewScore, preview.CurrentScore, preview.Path)
+	}
+	return nil
+}

--- a/cmd/memory_consolidate_test.go
+++ b/cmd/memory_consolidate_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "testing"
+
+func TestMemoryConsolidateApplyModeDefaultsToDryRun(t *testing.T) {
+	apply, err := memoryConsolidateApplyMode(false, false)
+	if err != nil {
+		t.Fatalf("memoryConsolidateApplyMode default error = %v", err)
+	}
+	if apply {
+		t.Fatal("memoryConsolidateApplyMode default returned apply=true, want dry-run")
+	}
+}
+
+func TestMemoryConsolidateApplyModeRequiresNoDryRunConflict(t *testing.T) {
+	apply, err := memoryConsolidateApplyMode(false, true)
+	if err != nil {
+		t.Fatalf("memoryConsolidateApplyMode apply error = %v", err)
+	}
+	if !apply {
+		t.Fatal("memoryConsolidateApplyMode apply returned false")
+	}
+
+	if _, err := memoryConsolidateApplyMode(true, true); err == nil {
+		t.Fatal("memoryConsolidateApplyMode with --dry-run and --apply expected error")
+	}
+}

--- a/cmd/memory_fragments.go
+++ b/cmd/memory_fragments.go
@@ -16,14 +16,16 @@ import (
 )
 
 var (
-	memoryFragmentsSince       time.Duration
-	memoryFragmentsLimit       int
-	memoryFragmentsHalfLife    float64
-	memoryFragmentsSyncDir     string
-	memoryFragmentsShowJSON    bool
-	memoryFragmentsShowNoPath  bool
-	memoryFragmentsSourcesJSON bool
-	memoryFragmentsFilterPath  string
+	memoryFragmentsSince        time.Duration
+	memoryFragmentsLimit        int
+	memoryFragmentsHalfLife     float64
+	memoryFragmentsPreviewDecay bool
+	memoryFragmentsDelete       bool
+	memoryFragmentsSyncDir      string
+	memoryFragmentsShowJSON     bool
+	memoryFragmentsShowNoPath   bool
+	memoryFragmentsSourcesJSON  bool
+	memoryFragmentsFilterPath   string
 )
 
 var memoryFragmentsCmd = &cobra.Command{
@@ -55,8 +57,13 @@ var memoryFragmentsSourcesCmd = &cobra.Command{
 
 var memoryFragmentsGCCmd = &cobra.Command{
 	Use:   "gc",
-	Short: "Garbage collect decayed memory fragments",
-	RunE:  runMemoryFragmentsGC,
+	Short: "Garbage collect fragments already below the decay threshold",
+	Long: `Review or explicitly delete non-pinned fragments whose stored decay_score is
+below the GC threshold. By default this command is non-destructive and reports
+what would be removed. Pass --delete to actually delete stored-score candidates.
+This command no longer recalculates decay scores before deleting; use
+--preview-decay for a non-destructive age-based decay preview.`,
+	RunE: runMemoryFragmentsGC,
 }
 
 var memoryFragmentsSyncCmd = &cobra.Command{
@@ -89,7 +96,9 @@ func init() {
 	memoryFragmentsListCmd.Flags().DurationVar(&memoryFragmentsSince, "since", 0, "Only show fragments updated within this duration (e.g. 24h)")
 	memoryFragmentsListCmd.Flags().IntVar(&memoryFragmentsLimit, "limit", 0, "Maximum number of fragments to return (0 = all)")
 	memoryFragmentsListCmd.Flags().StringVar(&memoryFragmentsFilterPath, "filter-path", "", "Filter fragments whose path contains this substring")
-	memoryFragmentsGCCmd.Flags().Float64Var(&memoryFragmentsHalfLife, "half-life", 30.0, "Decay half-life in days for GC recalculation")
+	memoryFragmentsGCCmd.Flags().Float64Var(&memoryFragmentsHalfLife, "half-life", memorydb.DefaultDecayHalfLifeDays, "Decay half-life in days for --preview-decay")
+	memoryFragmentsGCCmd.Flags().BoolVar(&memoryFragmentsPreviewDecay, "preview-decay", false, "Compute non-destructive age-based decay candidates")
+	memoryFragmentsGCCmd.Flags().BoolVar(&memoryFragmentsDelete, "delete", false, "Actually delete fragments already below the stored decay threshold")
 	memoryFragmentsSyncCmd.Flags().StringVar(&memoryFragmentsSyncDir, "dir", "", "Root directory containing .md fragment files (required)")
 	memoryFragmentsShowCmd.Flags().BoolVar(&memoryFragmentsShowJSON, "json", false, "Output fragment as JSON with all metadata")
 	memoryFragmentsShowCmd.Flags().BoolVar(&memoryFragmentsShowNoPath, "no-path", false, "Suppress path header, print content only")
@@ -339,24 +348,32 @@ func runMemoryFragmentsGC(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	agent := strings.TrimSpace(memoryAgent)
 
-	if memoryDryRun {
-		count, err := store.CountGCCandidates(ctx, agent)
+	if memoryFragmentsPreviewDecay {
+		if memoryFragmentsHalfLife <= 0 {
+			return fmt.Errorf("--half-life must be > 0")
+		}
+		count, err := store.CountDecayCandidates(ctx, agent, memoryFragmentsHalfLife, memorydb.DefaultDecayGCThreshold)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("gc: would remove %d fragments (based on current decay scores, no recalc in dry-run)\n", count)
+		fmt.Printf("gc: age-based decay preview would mark %d fragments below %.2f (non-destructive; no scores changed)\n", count, memorydb.DefaultDecayGCThreshold)
 		return nil
 	}
 
-	if _, err := store.RecalcDecayScores(ctx, agent, memoryFragmentsHalfLife); err != nil {
-		return fmt.Errorf("recalculate decay scores: %w", err)
+	count, err := store.CountGCCandidates(ctx, agent)
+	if err != nil {
+		return err
+	}
+	if memoryDryRun || !memoryFragmentsDelete {
+		fmt.Printf("gc: would remove %d fragments (based on stored decay scores; no recalculation). Pass --delete to delete.\n", count)
+		return nil
 	}
 
 	removed, err := store.GCFragments(ctx, agent)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("gc: removed %d fragments\n", removed)
+	fmt.Printf("gc: removed %d fragments (no decay recalculation)\n", removed)
 	return nil
 }
 

--- a/cmd/memory_freshen.go
+++ b/cmd/memory_freshen.go
@@ -354,11 +354,11 @@ The file is a compact current-state working memory, not a changelog.
 
 Rules:
 - Target total output: ~%d tokens (~%d characters). Treat this as a soft ceiling on the whole document.
-- Use this structure when relevant: ## Current state, then compact ### sections such as Deployed / configured, Active work, Open issues / quirks, Recent completed work, Temporary notes.
+- Use this structure when relevant: ## Current state, then compact ### memory-palace rooms such as User / preferences, Projects, Infrastructure / tools, Active work, Open issues / quirks, Recent completed work, Temporary notes.
 - Prefer latest truth over historical sequence.
 - Replace superseded facts instead of keeping old and new versions.
 - Drop resolved or stale items unless they still affect current behaviour over the next few days.
-- Keep durable long-term facts out unless they are actively relevant right now.
+- Keep durable long-term facts out unless they are actively relevant right now or needed to orient the palace.
 - Be extremely terse: facts only, no prose, no filler.
 - Output only the content, no code fences, no commentary.`, targetTokens, targetChars)
 }
@@ -372,6 +372,7 @@ Rules:
 - Target total output: ~%d tokens (~%d characters). Treat this as a hard target.
 - Preserve the newest and most actionable facts.
 - Prefer latest truth over history; replace superseded facts.
+- Keep stable palace rooms only when they help retrieval; merge tiny or empty rooms.
 - Drop resolved, duplicated, stale, or low-value detail aggressively.
 - Keep the file as compact current-state memory, not a dated log or archive.
 - Use short headings and bullets only when they earn their keep.

--- a/cmd/memory_insights.go
+++ b/cmd/memory_insights.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
 	"github.com/spf13/cobra"
@@ -347,6 +349,15 @@ func runMemoryInsightsDecay(cmd *cobra.Command, args []string) error {
 	defer store.Close()
 
 	halfLife, _ := cmd.Flags().GetFloat64("half-life")
+	if memoryDryRun {
+		n, err := countInsightDecayPreview(context.Background(), store, agent, halfLife)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("decay: would update %d insights (half-life=%.1f days; dry-run, no changes)\n", n, halfLife)
+		return nil
+	}
+
 	n, err := store.DecayInsights(context.Background(), agent, halfLife)
 	if err != nil {
 		return err
@@ -365,10 +376,62 @@ func runMemoryInsightsGC(cmd *cobra.Command, args []string) error {
 	defer store.Close()
 
 	minConf, _ := cmd.Flags().GetFloat64("min-confidence")
+	if memoryDryRun {
+		n, err := countInsightGCCandidates(context.Background(), store, agent, minConf)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("gc: would delete %d insights below confidence %.2f (dry-run, no changes)\n", n, minConf)
+		return nil
+	}
+
 	n, err := store.GCInsights(context.Background(), agent, minConf)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("gc: deleted %d insights below confidence %.2f\n", n, minConf)
 	return nil
+}
+
+func countInsightDecayPreview(ctx context.Context, store *memorydb.Store, agent string, halfLifeDays float64) (int, error) {
+	if halfLifeDays <= 0 {
+		halfLifeDays = memorydb.DefaultDecayHalfLifeDays
+	}
+	insights, err := store.ListInsights(ctx, agent, 0)
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now()
+	count := 0
+	for _, ins := range insights {
+		if ins == nil || ins.LastReinforced.IsZero() {
+			continue
+		}
+		daysSince := now.Sub(ins.LastReinforced).Hours() / 24
+		if daysSince < 1 {
+			continue
+		}
+		decayed := ins.Confidence * math.Pow(2, -daysSince/halfLifeDays)
+		if math.Abs(decayed-ins.Confidence) >= 0.001 {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func countInsightGCCandidates(ctx context.Context, store *memorydb.Store, agent string, minConfidence float64) (int, error) {
+	if minConfidence <= 0 {
+		minConfidence = 0.1
+	}
+	insights, err := store.ListInsights(ctx, agent, 0)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, ins := range insights {
+		if ins != nil && ins.Confidence < minConfidence {
+			count++
+		}
+	}
+	return count, nil
 }

--- a/cmd/memory_insights_test.go
+++ b/cmd/memory_insights_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+)
+
+func TestCountInsightMaintenancePreviews(t *testing.T) {
+	ctx := context.Background()
+	store, err := memorydb.NewStore(memorydb.Config{Path: filepath.Join(t.TempDir(), "memory.db")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	old := time.Now().Add(-60 * 24 * time.Hour).UTC()
+	if err := store.CreateInsight(ctx, &memorydb.Insight{
+		Agent:          "jarvis",
+		Content:        "Old low-confidence insight",
+		Category:       "workflow",
+		Confidence:     0.2,
+		CreatedAt:      old,
+		LastReinforced: old,
+	}); err != nil {
+		t.Fatalf("CreateInsight old: %v", err)
+	}
+	if err := store.CreateInsight(ctx, &memorydb.Insight{
+		Agent:      "jarvis",
+		Content:    "Fresh high-confidence insight",
+		Category:   "workflow",
+		Confidence: 0.9,
+	}); err != nil {
+		t.Fatalf("CreateInsight fresh: %v", err)
+	}
+
+	decayCount, err := countInsightDecayPreview(ctx, store, "jarvis", 30)
+	if err != nil {
+		t.Fatalf("countInsightDecayPreview: %v", err)
+	}
+	if decayCount != 1 {
+		t.Fatalf("decay preview count = %d, want 1", decayCount)
+	}
+
+	gcCount, err := countInsightGCCandidates(ctx, store, "jarvis", 0.3)
+	if err != nil {
+		t.Fatalf("countInsightGCCandidates: %v", err)
+	}
+	if gcCount != 1 {
+		t.Fatalf("gc preview count = %d, want 1", gcCount)
+	}
+
+	insights, err := store.ListInsights(ctx, "jarvis", 0)
+	if err != nil {
+		t.Fatalf("ListInsights: %v", err)
+	}
+	if len(insights) != 2 {
+		t.Fatalf("preview helpers mutated insights; count = %d, want 2", len(insights))
+	}
+}

--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -166,7 +166,8 @@ func init() {
 	memoryMineCmd.Flags().StringVar(&memoryMineEmbedProvider, "embed-provider", "", "Override embedding provider used in EMBED phase (optionally provider:model)")
 	memoryMineCmd.Flags().StringVar(&memoryMinePromote, "promote", "never", "Promotion mode: auto|always|never")
 	memoryMineCmd.Flags().DurationVar(&memoryMinePromoteEvery, "promote-every", 6*time.Hour, "Minimum interval between auto-promote runs")
-	memoryMineCmd.Flags().Float64Var(&memoryMineHalfLifeDays, "half-life", 30.0, "Decay half-life in days for post-mine recalculation")
+	memoryMineCmd.Flags().Float64Var(&memoryMineHalfLifeDays, "half-life", 30.0, "Deprecated no-op; decay is no longer applied during memory mine")
+	_ = memoryMineCmd.Flags().MarkDeprecated("half-life", "decay is no longer applied during memory mine; use explicit maintenance commands if needed")
 	memoryMineCmd.Flags().BoolVar(&memoryMineInsights, "insights", false, "Also run insight extraction pass after fragment mining")
 	memoryMineCmd.Flags().IntVar(&memoryMinePromptMaxTokens, "prompt-max-tokens", defaultMemoryMinePromptMaxTokens, "Approximate maximum prompt budget per extraction request")
 	memoryMineCmd.Flags().IntVar(&memoryMineTaxonomyMaxTokens, "taxonomy-max-tokens", defaultMemoryMineTaxonomyMaxTokens, "Approximate maximum tokens for the compact fragment taxonomy map")
@@ -377,16 +378,6 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if !memoryDryRun {
-		decayAgent := strings.TrimSpace(memoryAgent)
-		updated, err := memStore.RecalcDecayScores(ctx, decayAgent, memoryMineHalfLifeDays)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: decay recalc failed: %v\n", err)
-		} else if updated > 0 {
-			fmt.Printf("decay recalculated for %d fragments\n", updated)
-		}
-	}
-
 	if promoteMode != "never" {
 		if memoryDryRun {
 			fmt.Println("Dry run mode: skipping PROMOTE phase.")
@@ -440,14 +431,6 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 					insightStats.print()
 				}
 			}
-		}
-		// After extraction, apply decay and prune stale insights.
-		decayAgent := strings.TrimSpace(memoryAgent)
-		if n, decayErr := memStore.DecayInsights(ctx, decayAgent, memoryMineHalfLifeDays); decayErr == nil && n > 0 {
-			fmt.Printf("insights: decayed %d entries (half-life=%.1f days)\n", n, memoryMineHalfLifeDays)
-		}
-		if n, gcErr := memStore.GCInsights(ctx, decayAgent, 0.1); gcErr == nil && n > 0 {
-			fmt.Printf("insights: gc deleted %d below 0.10 confidence\n", n)
 		}
 	}
 

--- a/cmd/memory_promote.go
+++ b/cmd/memory_promote.go
@@ -30,9 +30,11 @@ Rules:
 - Target **%d words maximum** — treat this as a hard limit, not a guideline.
 - Compress aggressively: merge related facts, drop low-value or stale details, prefer dense bullet points over prose.
 - Prioritise: active projects, recent events, infrastructure facts, preferences, API/config details that would be painful to re-derive.
+- Keep memory-palace shape: group facts into stable rooms such as User / Preferences, Projects, Infrastructure / tools, Open loops, and Recent work when those rooms are useful.
 - Drop: transient observations, resolved issues, one-off tasks, anything already obvious from context.
 - Incorporate new/changed fragments; if they conflict with existing content, prefer the newer version.
-- Preserve structure (dates, headers) but trim ruthlessly within each section.
+- Preserve useful structure (dates, headers, palace rooms) but trim ruthlessly within each section.
+- Replace superseded facts instead of preserving history.
 - Output ONLY the raw markdown — no commentary, no code fences.`
 )
 

--- a/cmd/memory_search.go
+++ b/cmd/memory_search.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/embedding"
 	memorydb "github.com/samsaffron/term-llm/internal/memory"
@@ -23,11 +25,15 @@ const (
 )
 
 var (
-	memorySearchLimit         int
-	memorySearchJSON          bool
-	memorySearchEmbedProvider string
-	memorySearchNoDecay       bool
-	memorySearchBM25Only      bool
+	memorySearchLimit             int
+	memorySearchJSON              bool
+	memorySearchEmbedProvider     string
+	memorySearchNoDecay           bool
+	memorySearchApplyDecay        bool
+	memorySearchFreshness         bool
+	memorySearchFreshnessHalfLife float64
+	memorySearchBM25Only          bool
+	memorySearchTouch             bool
 )
 
 type hybridSearchCandidate struct {
@@ -48,8 +54,14 @@ func init() {
 	memorySearchCmd.Flags().IntVar(&memorySearchLimit, "limit", 6, "Maximum number of results")
 	memorySearchCmd.Flags().BoolVar(&memorySearchJSON, "json", false, "Output as JSON")
 	memorySearchCmd.Flags().StringVar(&memorySearchEmbedProvider, "embed-provider", "", "Override embedding provider for query embedding (optionally provider:model)")
-	memorySearchCmd.Flags().BoolVar(&memorySearchNoDecay, "no-decay", false, "Ignore decay score multiplier")
+	memorySearchCmd.Flags().BoolVar(&memorySearchApplyDecay, "decay", false, "Apply stored decay score multiplier (opt-in)")
+	memorySearchCmd.Flags().BoolVar(&memorySearchFreshness, "freshness", false, "Apply non-persistent timestamp freshness multiplier (opt-in)")
+	memorySearchCmd.Flags().BoolVar(&memorySearchFreshness, "recency", false, "Alias for --freshness")
+	memorySearchCmd.Flags().Float64Var(&memorySearchFreshnessHalfLife, "freshness-half-life", memorydb.DefaultDecayHalfLifeDays, "Freshness half-life in days for --freshness/--recency")
+	memorySearchCmd.Flags().BoolVar(&memorySearchNoDecay, "no-decay", false, "Deprecated no-op; decay is no longer applied by default")
+	_ = memorySearchCmd.Flags().MarkDeprecated("no-decay", "decay is no longer applied by default; use --decay to opt in")
 	memorySearchCmd.Flags().BoolVar(&memorySearchBM25Only, "bm25-only", false, "Force BM25-only retrieval")
+	memorySearchCmd.Flags().BoolVar(&memorySearchTouch, "touch", false, "Record access metadata for returned fragments")
 	memorySearchCmd.RegisterFlagCompletionFunc("embed-provider", EmbedProviderFlagCompletion)
 }
 
@@ -68,6 +80,9 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 	if memorySearchLimit <= 0 {
 		memorySearchLimit = 6
 	}
+	if memorySearchFreshnessHalfLife <= 0 {
+		return fmt.Errorf("--freshness-half-life must be > 0")
+	}
 
 	ctx := context.Background()
 	results, err := searchMemory(ctx, store, query)
@@ -75,7 +90,7 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(results) > 0 {
+	if memorySearchTouch && len(results) > 0 {
 		for _, r := range results {
 			if r.ID == "" {
 				continue
@@ -120,7 +135,15 @@ func searchMemory(ctx context.Context, store *memorydb.Store, query string) ([]m
 	agent := strings.TrimSpace(memoryAgent)
 
 	if memorySearchBM25Only {
-		return store.SearchBM25(ctx, query, memorySearchLimit, agent)
+		bm25Limit := memorySearchLimit
+		if memorySearchUsesScoreModifiers() && bm25Limit < memorySearchCandidateLimit {
+			bm25Limit = memorySearchCandidateLimit
+		}
+		candidates, err := store.SearchBM25(ctx, query, bm25Limit, agent)
+		if err != nil {
+			return nil, err
+		}
+		return limitScoredFragments(applySearchScoreOptions(candidates), memorySearchLimit), nil
 	}
 
 	bm25Candidates, err := store.SearchBM25(ctx, query, memorySearchCandidateLimit, agent)
@@ -136,7 +159,7 @@ func searchMemory(ctx context.Context, store *memorydb.Store, query string) ([]m
 	providerName, modelName, providerSpec := resolveMemoryEmbeddingProvider(cfg, memorySearchEmbedProvider)
 	if providerName == "" || providerSpec == "" {
 		fmt.Fprintln(os.Stderr, "warning: embedding provider unavailable, falling back to BM25-only search")
-		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+		return limitScoredFragments(applySearchScoreOptions(bm25Candidates), memorySearchLimit), nil
 	}
 
 	embedder, err := embedding.NewEmbeddingProvider(cfg, providerSpec)
@@ -145,7 +168,7 @@ func searchMemory(ctx context.Context, store *memorydb.Store, query string) ([]m
 			return nil, err
 		}
 		fmt.Fprintf(os.Stderr, "warning: embedding provider initialization failed (%v), falling back to BM25-only search\n", err)
-		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+		return limitScoredFragments(applySearchScoreOptions(bm25Candidates), memorySearchLimit), nil
 	}
 
 	embRes, err := embedder.Embed(embedding.EmbedRequest{
@@ -158,11 +181,11 @@ func searchMemory(ctx context.Context, store *memorydb.Store, query string) ([]m
 			return nil, err
 		}
 		fmt.Fprintf(os.Stderr, "warning: query embedding failed (%v), falling back to BM25-only search\n", err)
-		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+		return limitScoredFragments(applySearchScoreOptions(bm25Candidates), memorySearchLimit), nil
 	}
 	if len(embRes.Embeddings) == 0 || len(embRes.Embeddings[0].Vector) == 0 {
 		fmt.Fprintln(os.Stderr, "warning: empty query embedding result, falling back to BM25-only search")
-		return limitScoredFragments(bm25Candidates, memorySearchLimit), nil
+		return limitScoredFragments(applySearchScoreOptions(bm25Candidates), memorySearchLimit), nil
 	}
 
 	queryVec := embRes.Embeddings[0].Vector
@@ -247,6 +270,7 @@ func mergeSearchCandidates(ctx context.Context, store *memorydb.Store, provider,
 		}
 	}
 
+	now := time.Now()
 	out := make([]*hybridSearchCandidate, 0, len(merged))
 	for _, candidate := range merged {
 		var score float64
@@ -259,9 +283,7 @@ func mergeSearchCandidates(ctx context.Context, store *memorydb.Store, provider,
 			// BM25-only ones, but BM25-only fragments are no longer buried below minScore.
 			score = candidate.bm25Score
 		}
-		if !memorySearchNoDecay {
-			score *= candidate.fragment.DecayScore
-		}
+		score = applySearchScoreModifiers(score, candidate.fragment, now)
 		candidate.mergedScore = score
 		candidate.fragment.Score = score
 		if candidate.fragment.Snippet == "" {
@@ -363,6 +385,47 @@ func normalizeCosineScore(raw float64) float64 {
 		return 1
 	}
 	return raw
+}
+
+func memorySearchUsesScoreModifiers() bool {
+	return memorySearchApplyDecay || memorySearchFreshness
+}
+
+func applySearchScoreOptions(in []memorydb.ScoredFragment) []memorydb.ScoredFragment {
+	if !memorySearchUsesScoreModifiers() || len(in) == 0 {
+		return in
+	}
+
+	now := time.Now()
+	out := append([]memorydb.ScoredFragment(nil), in...)
+	for i := range out {
+		out[i].Score = applySearchScoreModifiers(out[i].Score, out[i], now)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if math.Abs(out[i].Score-out[j].Score) < 1e-12 {
+			return out[i].UpdatedAt.After(out[j].UpdatedAt)
+		}
+		return out[i].Score > out[j].Score
+	})
+	return out
+}
+
+func applySearchScoreModifiers(score float64, fragment memorydb.ScoredFragment, now time.Time) float64 {
+	if memorySearchApplyDecay {
+		decay := fragment.DecayScore
+		if decay <= 0 {
+			decay = 1.0
+		}
+		score *= decay
+	}
+	if memorySearchFreshness {
+		score *= memorySearchFreshnessMultiplier(fragment, memorySearchFreshnessHalfLife, now)
+	}
+	return score
+}
+
+func memorySearchFreshnessMultiplier(fragment memorydb.ScoredFragment, halfLifeDays float64, now time.Time) float64 {
+	return memorydb.ComputeDecayScore(fragment.UpdatedAt, fragment.AccessedAt, halfLifeDays, now)
 }
 
 func limitScoredFragments(in []memorydb.ScoredFragment, limit int) []memorydb.ScoredFragment {

--- a/cmd/memory_search_test.go
+++ b/cmd/memory_search_test.go
@@ -1,9 +1,98 @@
 package cmd
 
-import "testing"
+import (
+	"math"
+	"testing"
+	"time"
+
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+)
 
 func TestNormalizeCosineScoreNegative(t *testing.T) {
 	if got := normalizeCosineScore(-0.25); got != 0 {
 		t.Fatalf("normalizeCosineScore(-0.25) = %f, want 0", got)
 	}
+}
+
+func TestMemorySearchDoesNotApplyDecayByDefault(t *testing.T) {
+	withMemorySearchScoringFlags(t)
+
+	candidates := []memorydb.ScoredFragment{{
+		ID:         "old",
+		Path:       "fragments/old.md",
+		Score:      10,
+		DecayScore: 0.1,
+		UpdatedAt:  time.Now().Add(-365 * 24 * time.Hour),
+	}}
+
+	merged := mergeSearchCandidates(nil, nil, "", "", candidates, nil)
+	if len(merged) != 1 {
+		t.Fatalf("mergeSearchCandidates len = %d, want 1", len(merged))
+	}
+	if math.Abs(merged[0].mergedScore-0.5) > 1e-9 {
+		t.Fatalf("merged score = %f, want un-decayed BM25 normalization 0.5", merged[0].mergedScore)
+	}
+}
+
+func TestMemorySearchDecayAndFreshnessAreOptIn(t *testing.T) {
+	withMemorySearchScoringFlags(t)
+
+	now := time.Now().UTC()
+	frag := memorydb.ScoredFragment{
+		ID:         "old",
+		Path:       "fragments/old.md",
+		Score:      0.8,
+		DecayScore: 0.25,
+		UpdatedAt:  now.Add(-30 * 24 * time.Hour),
+	}
+
+	if got := applySearchScoreModifiers(frag.Score, frag, now); got != frag.Score {
+		t.Fatalf("default score = %f, want %f", got, frag.Score)
+	}
+
+	memorySearchApplyDecay = true
+	if got := applySearchScoreModifiers(frag.Score, frag, now); math.Abs(got-0.2) > 1e-9 {
+		t.Fatalf("decay opt-in score = %f, want 0.2", got)
+	}
+
+	memorySearchFreshness = true
+	memorySearchFreshnessHalfLife = 30
+	if got := applySearchScoreModifiers(frag.Score, frag, now); math.Abs(got-0.1) > 1e-9 {
+		t.Fatalf("decay+freshness opt-in score = %f, want 0.1", got)
+	}
+}
+
+func TestMemorySearchBM25ModifiersResortResults(t *testing.T) {
+	withMemorySearchScoringFlags(t)
+	memorySearchApplyDecay = true
+
+	in := []memorydb.ScoredFragment{
+		{ID: "stale", Score: 10, DecayScore: 0.1, UpdatedAt: time.Now().Add(-time.Hour)},
+		{ID: "kept", Score: 2, DecayScore: 1.0, UpdatedAt: time.Now()},
+	}
+	out := applySearchScoreOptions(in)
+	if len(out) != 2 {
+		t.Fatalf("applySearchScoreOptions len = %d, want 2", len(out))
+	}
+	if out[0].ID != "kept" {
+		t.Fatalf("top result = %s, want kept after decay modifier", out[0].ID)
+	}
+	if in[0].Score != 10 {
+		t.Fatalf("applySearchScoreOptions mutated input score = %f", in[0].Score)
+	}
+}
+
+func withMemorySearchScoringFlags(t *testing.T) {
+	t.Helper()
+	oldApplyDecay := memorySearchApplyDecay
+	oldFreshness := memorySearchFreshness
+	oldHalfLife := memorySearchFreshnessHalfLife
+	t.Cleanup(func() {
+		memorySearchApplyDecay = oldApplyDecay
+		memorySearchFreshness = oldFreshness
+		memorySearchFreshnessHalfLife = oldHalfLife
+	})
+	memorySearchApplyDecay = false
+	memorySearchFreshness = false
+	memorySearchFreshnessHalfLife = memorydb.DefaultDecayHalfLifeDays
 }

--- a/docs-site/content/guides/agent-containers.md
+++ b/docs-site/content/guides/agent-containers.md
@@ -147,7 +147,6 @@ On first boot, `bootstrap-jobs` waits for the jobs API, creates the defaults, an
 |---|---|---|
 | `mine-sessions` | Every 30 min | Mines session transcripts into memory fragments. |
 | `update-recent` | Every 10 min | Promotes recent fragments into `memory/recent.md`. |
-| `memory-gc` | Daily at 04:00 UTC | Garbage-collects stale or duplicate memory fragments. |
 | `system-upgrade` | Daily at 05:00 UTC | Upgrades distro packages (`pacman` on Arch, `dnf` on Fedora). |
 
 Inspect and operate them inside the workspace:
@@ -171,7 +170,7 @@ Fresh agent containers include a small default skill set:
 
 Skills are copied to `/home/agent/.config/term-llm/skills/` and the first-boot `config.yaml` enables the skills system with auto-invocation.
 
-Memory fragments live in term-llm's database on the persistent volume. `memory/recent.md` is seeded empty and then maintained by the default jobs; do not edit it directly.
+Memory fragments live in term-llm's database on the persistent volume. `memory/recent.md` is seeded empty and maintained by the default jobs. `memory/palace.md` is a small stable-context template for durable, high-value facts. Prefer memory commands over hand-editing generated summaries.
 
 ## Widgets
 

--- a/docs-site/content/guides/memory.md
+++ b/docs-site/content/guides/memory.md
@@ -22,6 +22,7 @@ The distinction matters. Most session content is ephemeral. Memory is meant for 
 ```bash
 term-llm memory status
 term-llm memory search "retry policy"
+term-llm memory consolidate --agent assistant
 term-llm memory fragments list
 term-llm memory insights list --agent assistant
 ```
@@ -76,15 +77,31 @@ Search uses hybrid retrieval when embeddings are available:
 
 - BM25 keyword search
 - vector similarity search
-- reranking and decay-aware scoring
+- MMR reranking
+
+Search is read-only by default. It does not apply decay/freshness scoring unless you opt in, and it does not bump access metadata unless you pass `--touch`.
 
 Useful flags:
 
 ```bash
 term-llm memory search "provider routing" --limit 10
 term-llm memory search "deploy key" --bm25-only
-term-llm memory search "session persistence" --no-decay
+term-llm memory search "session persistence" --freshness
+term-llm memory search "recent deploy issue" --recency --touch
 term-llm memory search "embedding provider" --embed-provider gemini
+```
+
+### Freshness and decay
+
+Freshness is now an explicit retrieval choice, not a default. `--freshness`/`--recency` apply a non-persistent timestamp multiplier at query time. `--decay` applies the stored decay score for compatibility with older databases. Neither option rewrites memory.
+
+Garbage collection is manual and destructive. If you use it, preview first:
+
+```bash
+term-llm memory fragments gc --agent assistant
+term-llm memory fragments gc --agent assistant --preview-decay
+# Destructive cleanup is explicit:
+term-llm memory fragments gc --agent assistant --delete
 ```
 
 ## Inspect fragments directly
@@ -132,6 +149,58 @@ term-llm memory promote --agent assistant --since 6h
 term-llm memory promote --agent assistant --recent-max-bytes 20000
 term-llm memory promote --agent assistant --dry-run
 ```
+
+## Consolidate safely
+
+```bash
+term-llm memory consolidate --agent assistant
+term-llm memory consolidate --agent assistant --apply
+```
+
+`consolidate` is the safer current-state workflow. It defaults to a dry run, prints the proposed `recent.md` rewrite, and shows a non-destructive decay preview. `--apply` writes `recent.md`; it does not delete fragments, move fragments, perform full palace cleanup, or rewrite stored decay scores.
+
+Use it when you want to compact recent working memory without treating age as permission to forget.
+
+### Cadence
+
+A practical schedule is:
+
+- run `memory mine` frequently, such as every 30 minutes, to extract durable candidates from completed sessions
+- run `memory consolidate --apply` daily to keep `recent.md` tidy
+- run deep palace cleanup manually, or as a weekly dry-run/report, because it involves moving/deleting source fragments
+
+Deep palace cleanup means clustering old fragments, backing up source rows, writing a canonical replacement fragment, and explicitly deleting superseded sources after review. It is intentionally not automatic.
+
+## Memory palace template
+
+Fresh agent containers seed `memory/palace.md` alongside `memory/recent.md`. The palace is a tiny, durable map of high-value context that should be visible every session. Keep detailed facts in fragments. Keep `recent.md` for current-state working memory. Keep the palace short enough that every line earns prompt budget.
+
+Recommended room taxonomy:
+
+```text
+fragments/index/        maps and palace navigation
+fragments/preferences/  stable user and agent behavior preferences
+fragments/people/       user/family/profile facts
+fragments/homelab/      infrastructure, services, network, runbooks
+fragments/projects/     long-lived project context, decisions, scars
+fragments/skills/       skill-specific operating notes
+fragments/tools/        external tools, APIs, tool behavior
+fragments/snippets/     reusable commands/workflows
+fragments/notes/        unclassified knowledge; promote periodically
+fragments/bugs/         open bugs or memorable scars
+fragments/feedback/     user corrections; fold into preferences over time
+fragments/credentials/  credential locations and handling rules only
+```
+
+Credential rule: active memory should store **where** to find secrets and how to handle them, not raw secret values.
+
+Backup-before-delete convention for deep cleanup:
+
+```text
+/home/agent/artifacts/memory-consolidation/YYYY-MM-DD/<cluster>.json
+```
+
+Write source rows there before deleting a group of superseded fragments.
 
 ## Behavioral insights
 

--- a/internal/contain/images/agent/bootstrap/bootstrap.yaml
+++ b/internal/contain/images/agent/bootstrap/bootstrap.yaml
@@ -1,6 +1,6 @@
 name: {{AGENT_NAME}}
 description: "AI assistant"
-include: ["soul.md", "memory/recent.md"]
+include: ["soul.md", "memory/palace.md", "memory/recent.md"]
 tools:
   enabled: [read_file, write_file, edit_file, glob, grep, shell, ask_user, spawn_agent, view_image, show_image, image_generate, run_agent_script]
 shell:

--- a/internal/contain/images/agent/bootstrap/memory/palace.md
+++ b/internal/contain/images/agent/bootstrap/memory/palace.md
@@ -1,0 +1,39 @@
+# Memory Palace
+
+Compact stable context that should be visible every session. Keep this file terse;
+prefer fragments for source-of-truth details and `recent.md` for short-term state.
+
+## Shape rules
+
+- Prefer fragment paths shaped like `fragments/<room>/<shelf>/<topic>.md`.
+- Rooms should be few and stable. Shelves should group retrieval intent, not chronology.
+- Avoid per-session, per-PR, and per-update fragments unless they are active work; consolidate them later.
+- Store credential **locations and retrieval rules**, not raw secret values.
+- Before deleting many fragments, back up source rows to `/home/agent/artifacts/memory-consolidation/YYYY-MM-DD/<cluster>.json`.
+
+## Rooms
+
+- `preferences/` — stable user and agent behavior preferences.
+- `people/` — user/family/profile facts.
+- `homelab/` — runtime infrastructure, services, network, runbooks.
+- `projects/` — long-lived project context, decisions, scars.
+- `skills/` — skill-specific operating notes.
+- `tools/` — external tools, APIs, tool behavior.
+- `snippets/` — reusable commands/workflows.
+- `notes/` — unclassified knowledge; promote periodically into better rooms.
+- `bugs/` — open bugs or memorable scars; promote fixed lessons into project/preference fragments.
+- `feedback/` — user corrections; eventually fold into preferences/personality/system rules.
+- `credentials/` — secret locations and handling rules only; never raw secrets.
+- `index/` — maps and palace navigation.
+
+## User / preferences
+
+## People
+
+## Projects
+
+## Homelab / infrastructure
+
+## Tools / skills
+
+## Open loops

--- a/internal/contain/images/agent/bootstrap/services/bootstrap-jobs/run
+++ b/internal/contain/images/agent/bootstrap/services/bootstrap-jobs/run
@@ -65,22 +65,6 @@ term-llm jobs create --data "{
   \"misfire_policy\": \"skip\"
 }"
 
-# memory-gc — garbage-collect stale or duplicate memory fragments
-term-llm jobs create --data "{
-  \"name\": \"memory-gc\",
-  \"enabled\": true,
-  \"runner_type\": \"program\",
-  \"runner_config\": {
-    \"command\": \"/usr/local/bin/term-llm\",
-    \"args\": [\"memory\", \"fragments\", \"gc\", \"--agent\", \"$AGENT\"]
-  },
-  \"trigger_type\": \"cron\",
-  \"trigger_config\": { \"expression\": \"0 4 * * *\", \"timezone\": \"UTC\" },
-  \"concurrency_policy\": \"forbid\",
-  \"timeout_seconds\": 300,
-  \"misfire_policy\": \"skip\"
-}"
-
 SYSTEM_UPGRADE_ARGS='["pacman", "-Syu", "--noconfirm"]'
 case "${AGENT_DISTRO:-arch}" in
   arch)
@@ -111,5 +95,5 @@ term-llm jobs create --data "{
 }"
 
 touch "$SENTINEL"
-echo "bootstrap-jobs: done — 4 jobs created. Edit them with: term-llm jobs list / term-llm jobs update"
+echo "bootstrap-jobs: done — 3 jobs created. Edit them with: term-llm jobs list / term-llm jobs update"
 cleanup_and_exit

--- a/internal/contain/images/agent/bootstrap/skills/jobs/SKILL.md
+++ b/internal/contain/images/agent/bootstrap/skills/jobs/SKILL.md
@@ -23,7 +23,6 @@ Default jobs:
 |---|---|---|
 | `mine-sessions` | every 30 min | Mine session transcripts into memory fragments. |
 | `update-recent` | every 10 min | Promote fragments into `recent.md`. |
-| `memory-gc` | daily 04:00 UTC | Garbage-collect stale or duplicate memory fragments. |
 | `system-upgrade` | Daily 05:00 UTC | Run the distro package upgrade (`pacman -Syu` on Arch, `dnf upgrade` on Fedora). |
 
 ## Inspecting jobs

--- a/internal/contain/images/agent/bootstrap/skills/memory/SKILL.md
+++ b/internal/contain/images/agent/bootstrap/skills/memory/SKILL.md
@@ -6,7 +6,7 @@ description: "Read and update persistent memory. Use when: user says 'remember',
 # Memory System
 
 Memory is stored as **fragments** in a SQLite database, indexed with BM25 + vector embeddings.
-Mining runs every 30 min; GC runs daily. The `recent.md` file is auto-promoted from fragments.
+Mining runs frequently and `recent.md` is refreshed from fragments. Garbage collection is manual only; decay is a review signal, not a deletion policy.
 
 ## Lookup — always search first
 
@@ -14,7 +14,7 @@ Mining runs every 30 min; GC runs daily. The `recent.md` file is auto-promoted f
 term-llm memory search "<query>" --agent "$AGENT_NAME" --limit 6
 ```
 
-Hybrid BM25 + vector search — use it for anything that might be in memory.
+Hybrid BM25 + vector search — use it for anything that might be in memory. Search is relevance-only by default; use `--freshness`/`--recency` only when newer matching facts should win. Use `--touch` only when you explicitly want to record access metadata.
 
 Show full fragment by numeric ID (preferred — no truncation):
 
@@ -31,29 +31,105 @@ term-llm memory fragments list --agent "$AGENT_NAME" --filter-path telegram
 
 ## Writing new memory
 
-Use the CLI to add fragments directly to the database:
+Use the CLI to add or update fragments directly in the database:
 
 ```bash
 term-llm memory fragments add fragments/<category>/<name>.md --agent "$AGENT_NAME" --content "..."
 term-llm memory fragments update fragments/<category>/<name>.md --agent "$AGENT_NAME" --content "..."
+```
+
+Delete only when the user explicitly asks or when replacing a provably wrong fragment:
+
+```bash
 term-llm memory fragments delete fragments/<category>/<name>.md --agent "$AGENT_NAME"
 ```
 
 Category guide:
-- `preferences/` — user stated preferences
-- `projects/` — project context, decisions
-- `notes/` — one-off facts
-- `tools/` — CLI tools, APIs, snippets
+- `preferences/` — stable user and agent behavior preferences
+- `people/` — user/family/profile facts
+- `homelab/` — infrastructure, services, network, runbooks
+- `projects/` — long-lived project context, decisions, scars
+- `skills/` — skill-specific operating notes
+- `tools/` — external tools, APIs, tool behavior
+- `snippets/` — reusable commands/workflows
+- `notes/` — unclassified knowledge; promote periodically into better rooms
+- `bugs/` — open bugs or memorable scars
+- `feedback/` — user corrections; fold into preferences/personality over time
+- `credentials/` — credential locations and handling rules only; never raw secrets
+- `index/` — maps and palace navigation
+
+## Memory palace
+
+Use `memory/palace.md` as the compact map of durable context that should be visible every session. Keep it tiny and room-like:
+
+```md
+## Shape rules
+- Prefer `fragments/<room>/<shelf>/<topic>.md`.
+- Avoid per-session/per-PR/per-update fragments unless they are active work.
+- Store credential locations, not raw secrets.
+
+## User / preferences
+- Stable preferences, collaboration style, durable constraints.
+
+## People
+- User/family/profile facts.
+
+## Projects
+- Long-lived project facts and decisions.
+
+## Homelab / infrastructure
+- Repos, services, commands, credential locations (never secrets).
+
+## Tools / skills
+- Tool behavior and skill operating notes.
+
+## Open loops
+- Durable unresolved work only; remove resolved loops during consolidation.
+```
+
+Do not dump transcripts into the palace. Promote durable facts into fragments first, then consolidate the current-state summary.
+
+## Consolidation
+
+Preview consolidation first:
+
+```bash
+term-llm memory consolidate --agent "$AGENT_NAME"
+```
+
+Apply only when the preview is good:
+
+```bash
+term-llm memory consolidate --agent "$AGENT_NAME" --apply
+```
+
+`memory consolidate` is **current-state consolidation**: it rewrites `recent.md` from changed fragments and prints a non-destructive decay preview. It does not perform full palace cleanup, delete fragments, move fragments, or rewrite stored decay scores.
+
+For full palace cleanup, work room-by-room: back up source rows, create/update a canonical fragment, then explicitly delete superseded source fragments only after verifying search still finds the canonical memory.
+
+Backup convention before deleting many fragments:
+
+```bash
+mkdir -p /home/agent/artifacts/memory-consolidation/$(date +%F)
+# Write source rows for the cluster there before deleting anything.
+```
+
+Recommended cadence:
+- Mine sessions frequently (for example every 30 min).
+- Run `memory consolidate --apply` daily to keep `recent.md` tidy.
+- Run deep palace cleanup manually or as a weekly dry-run/report; apply only with explicit judgment.
 
 ## When user says "remember this"
 
 1. Add the fragment immediately via CLI
-2. Confirm to user
+2. If the fact is stable and globally useful, keep the palace/recent summary in mind for the next consolidation
+3. Confirm to user
 
 ## Memory rules
 
 - **Search before answering** anything about user preferences, history, or projects
-- `recent.md` is loaded at session start (auto-promoted from fragments) — never edit it directly
+- `recent.md` is loaded at session start and maintained from fragments — do not hand-edit it casually
+- Prefer updating source fragments, then consolidating
 - The session miner handles most things automatically after conversations end
 - Proactively create fragments when content is structured or unlikely to survive miner summarisation
 
@@ -63,4 +139,3 @@ Category guide:
 |-----|----------|---------|
 | `mine-sessions` | every 30 min | Extract fragments from transcripts |
 | `update-recent` | every 10 min | Promote fragments into recent.md |
-| `memory-gc` | daily 4am | Garbage-collect stale fragments |

--- a/internal/contain/images/agent/bootstrap/system.md
+++ b/internal/contain/images/agent/bootstrap/system.md
@@ -119,7 +119,7 @@ This agent is judged by completed useful actions, not intentions.
 
 ## Jobs and Services
 
-Services are runit-managed processes installed under `/home/agent/.config/term-llm/services` and linked into `/etc/sv` on each start. The service supervisor runs as root, but normal agent workloads, shells, the Web UI, the jobs server, and bootstrap jobs run as the non-root `agent` Linux user. Use passwordless `sudo` explicitly when root privileges are needed. The default long-running services are `webui` and `jobs`: `webui` serves chat on port 8081, and `jobs` runs the HTTP scheduler on port 8080. A first-boot `bootstrap-jobs` one-shot service creates the default scheduled jobs, removes its persisted service definition, and exits so it will not appear on later boots. The jobs system stores definitions, runs, and events in term-llm's database. Use `term-llm jobs list`, `get`, `create`, `update`, `pause`, `resume`, `trigger`, `runs`, `active`, and `run events` to inspect and operate scheduled work. Default jobs mine sessions, update `recent.md`, garbage-collect memory, and upgrade packages. Prefer jobs skill when changing schedules, runner payloads, boot behavior, or debugging failed runs.
+Services are runit-managed processes installed under `/home/agent/.config/term-llm/services` and linked into `/etc/sv` on each start. The service supervisor runs as root, but normal agent workloads, shells, the Web UI, the jobs server, and bootstrap jobs run as the non-root `agent` Linux user. Use passwordless `sudo` explicitly when root privileges are needed. The default long-running services are `webui` and `jobs`: `webui` serves chat on port 8081, and `jobs` runs the HTTP scheduler on port 8080. A first-boot `bootstrap-jobs` one-shot service creates the default scheduled jobs, removes its persisted service definition, and exits so it will not appear on later boots. The jobs system stores definitions, runs, and events in term-llm's database. Use `term-llm jobs list`, `get`, `create`, `update`, `pause`, `resume`, `trigger`, `runs`, `active`, and `run events` to inspect and operate scheduled work. Default jobs mine sessions, update `recent.md`, and upgrade packages. Memory garbage collection is manual only; run an explicit dry-run before deleting fragments. Prefer jobs skill when changing schedules, runner payloads, boot behavior, or debugging failed runs.
 
 ## Getting started
 
@@ -139,8 +139,12 @@ personality changes; keep operational rules in `system.md` and runtime config in
 
 Your memory is a fragment database managed by term-llm. Fragments are mined
 from session transcripts automatically, indexed with BM25 + vector search. The
-agent config includes `memory/recent.md`, seeded as an empty file on first boot
-and later maintained by the memory promote job.
+agent config includes `memory/palace.md` for compact stable context and
+`memory/recent.md` for current working state. `recent.md` is maintained by the
+update-recent/consolidation workflow; `palace.md` should stay small, durable, and path-findable.
+Use stable rooms such as `preferences/`, `people/`, `homelab/`, `projects/`,
+`skills/`, `tools/`, `snippets/`, `notes/`, `bugs/`, `feedback/`, `credentials/`,
+and `index/`. `notes/` is a temporary shelf, not a permanent dumping ground.
 
 ### Memory Rules
 
@@ -148,6 +152,7 @@ and later maintained by the memory promote job.
   ```
   term-llm memory search "<query>" --agent {{AGENT_NAME}}
   ```
+  Search is relevance-only by default. Use `--freshness`/`--recency` only when the newest matching fact should win.
 - **List recent fragments** using the DB, not the filesystem:
   ```
   term-llm memory fragments list --agent {{AGENT_NAME}} --limit 10
@@ -156,12 +161,14 @@ and later maintained by the memory promote job.
   ```
   term-llm memory fragments show <id> --agent {{AGENT_NAME}}
   ```
-- **Never edit `recent.md` directly** — it's auto-managed by the memory promote job.
-- **Proactively create/update/delete fragments** for structured or complex info:
+- **Consolidate current state before pruning**: use `term-llm memory consolidate --agent {{AGENT_NAME}}` to preview and `--apply` to write `recent.md`. This is current-state consolidation only; it does not perform full palace cleanup or delete fragments. Decay previews are non-destructive.
+- **Deep palace cleanup is explicit**: work room-by-room, back up source rows to `/home/agent/artifacts/memory-consolidation/YYYY-MM-DD/<cluster>.json`, create/update a canonical fragment, then delete superseded source fragments only after review.
+- **Do not store raw secrets in active memory**: store credential locations and handling rules instead.
+- **Do not hand-edit generated summaries casually** — prefer updating source fragments, then consolidate.
+- **Proactively create/update fragments** for structured or complex info; delete only when explicitly asked or when replacing a provably wrong fragment:
   ```
   term-llm memory fragments add fragments/<category>/<name>.md --agent {{AGENT_NAME}} --content "..."
   term-llm memory fragments update fragments/<category>/<name>.md --agent {{AGENT_NAME}} --content "..."
-  term-llm memory fragments delete fragments/<category>/<name>.md --agent {{AGENT_NAME}}
   ```
 
 ## Self-Modification

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -47,7 +47,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			t.Fatalf("Dockerfile.fedora missing %q", want)
 		}
 	}
-	for _, rel := range []string{"entrypoint.sh", "packaging/runit/PKGBUILD", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/scripts/update.sh", "bootstrap/scripts/patch-system.sh", "bootstrap/scripts/patch-soul.sh", "bootstrap/scripts/patch-agent.sh"} {
+	for _, rel := range []string{"entrypoint.sh", "packaging/runit/PKGBUILD", "bootstrap/bootstrap.yaml", "bootstrap/system.md", "bootstrap/soul.md", "bootstrap/services/webui/run", "bootstrap/services/jobs/run", "bootstrap/services/bootstrap-jobs/run", "bootstrap/skills/memory/SKILL.md", "bootstrap/skills/jobs/SKILL.md", "bootstrap/skills/self/SKILL.md", "bootstrap/skills/widgets/SKILL.md", "bootstrap/memory/recent.md", "bootstrap/memory/palace.md", "bootstrap/scripts/update.sh", "bootstrap/scripts/patch-system.sh", "bootstrap/scripts/patch-soul.sh", "bootstrap/scripts/patch-agent.sh"} {
 		data, err := os.ReadFile(filepath.Join(result.Dir, rel))
 		if err != nil {
 			t.Fatalf("missing synced asset %s: %v", rel, err)
@@ -100,6 +100,9 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 		if rel == "bootstrap/bootstrap.yaml" && (!strings.Contains(string(data), "image_generate") || !strings.Contains(string(data), "show_image") || !strings.Contains(string(data), "view_image")) {
 			t.Fatalf("agent bootstrap missing image generation/viewing tools")
 		}
+		if rel == "bootstrap/bootstrap.yaml" && !strings.Contains(string(data), "memory/palace.md") {
+			t.Fatalf("agent bootstrap should include memory palace template")
+		}
 		if (rel == "bootstrap/services/webui/run" || rel == "bootstrap/services/jobs/run") && !strings.Contains(string(data), "TERM_LLM_PROVIDER") {
 			t.Fatalf("service %s missing TERM_LLM_PROVIDER forwarding", rel)
 		}
@@ -119,10 +122,13 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 			t.Fatalf("bootstrap jobs should run as agent and use sudo for package upgrades")
 		}
 		if rel == "bootstrap/services/bootstrap-jobs/run" {
-			for _, want := range []string{"cleanup_and_exit", "rm -rf \"$PERSISTED_SERVICE_DIR\"", "rm -f \"$RUNSVDIR_LINK\"", "rm -rf \"$SV_SERVICE_DIR\""} {
+			for _, want := range []string{"cleanup_and_exit", "rm -rf \"$PERSISTED_SERVICE_DIR\"", "rm -f \"$RUNSVDIR_LINK\"", "rm -rf \"$SV_SERVICE_DIR\"", "3 jobs created"} {
 				if !strings.Contains(string(data), want) {
 					t.Fatalf("bootstrap jobs should self-remove after bootstrapping; missing %q", want)
 				}
+			}
+			if strings.Contains(string(data), "memory-gc") {
+				t.Fatalf("bootstrap jobs should not create the deprecated memory-gc job")
 			}
 			if strings.Contains(string(data), "sleep infinity") {
 				t.Fatalf("bootstrap jobs should exit after self-removal, not sleep forever")
@@ -175,6 +181,19 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 				if !strings.Contains(string(data), want) {
 					t.Fatalf("jobs skill missing %q", want)
 				}
+			}
+			if strings.Contains(string(data), "memory-gc") {
+				t.Fatalf("jobs skill should not document the removed memory-gc default job")
+			}
+		}
+		if rel == "bootstrap/skills/memory/SKILL.md" {
+			for _, want := range []string{"Memory palace", "memory consolidate", "Garbage collection is manual only"} {
+				if !strings.Contains(string(data), want) {
+					t.Fatalf("memory skill missing %q", want)
+				}
+			}
+			if strings.Contains(string(data), "memory-gc") {
+				t.Fatalf("memory skill should not document the removed memory-gc default job")
 			}
 		}
 		if rel == "bootstrap/skills/widgets/SKILL.md" {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1703,8 +1703,9 @@ func (s *Store) getFragmentsByIDBatch(ctx context.Context, ids []string, out map
 	return nil
 }
 
-// BumpAccess marks a fragment as recently accessed, increments access_count,
-// and gives decay_score a small recency boost.
+// BumpAccess marks a fragment as recently accessed and increments access_count.
+// It intentionally does not modify decay_score; recency/freshness is applied as
+// an explicit, non-persistent search-time option.
 func (s *Store) BumpAccess(ctx context.Context, fragmentID string) error {
 	fragmentID = strings.TrimSpace(fragmentID)
 	if fragmentID == "" {
@@ -1714,8 +1715,7 @@ func (s *Store) BumpAccess(ctx context.Context, fragmentID string) error {
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE memory_fragments
 		SET accessed_at = ?,
-		    access_count = access_count + 1,
-		    decay_score = CASE WHEN decay_score + 0.1 > 1.0 THEN 1.0 ELSE decay_score + 0.1 END
+		    access_count = access_count + 1
 		WHERE id = ?`, time.Now(), fragmentID)
 	if err != nil {
 		return fmt.Errorf("bump fragment access: %w", err)
@@ -1726,12 +1726,126 @@ func (s *Store) BumpAccess(ctx context.Context, fragmentID string) error {
 	return nil
 }
 
+const (
+	DefaultDecayHalfLifeDays = 30.0
+	MinDecayScore            = 0.04
+	DefaultDecayGCThreshold  = 0.05
+)
+
+// DecayPreview is a non-persistent age-based decay calculation for a fragment.
+type DecayPreview struct {
+	ID           string
+	Agent        string
+	Path         string
+	UpdatedAt    time.Time
+	AccessedAt   *time.Time
+	CurrentScore float64
+	PreviewScore float64
+}
+
+// ComputeDecayScore returns the age-based decay score that would apply for the
+// supplied timestamps. It is pure: callers decide whether to use it for ranking,
+// reporting, or persistence.
+func ComputeDecayScore(updatedAt time.Time, accessedAt *time.Time, halfLifeDays float64, now time.Time) float64 {
+	if halfLifeDays <= 0 {
+		halfLifeDays = DefaultDecayHalfLifeDays
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	lastActive := updatedAt
+	if accessedAt != nil && accessedAt.After(lastActive) {
+		lastActive = *accessedAt
+	}
+	if lastActive.IsZero() || lastActive.After(now) {
+		return 1.0
+	}
+
+	ageDays := now.Sub(lastActive).Hours() / 24.0
+	if ageDays < 0 {
+		ageDays = 0
+	}
+	decay := math.Pow(0.5, ageDays/halfLifeDays)
+	return math.Max(decay, MinDecayScore)
+}
+
+// PreviewDecayScores calculates age-based decay scores without writing them to
+// the database. Results are sorted from lowest preview score to highest.
+func (s *Store) PreviewDecayScores(ctx context.Context, agent string, halfLifeDays float64, limit int) ([]DecayPreview, error) {
+	agent = strings.TrimSpace(agent)
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, agent, path, updated_at, accessed_at, decay_score
+		FROM memory_fragments
+		WHERE pinned = 0
+		  AND (? = '' OR agent = ?)`, agent, agent)
+	if err != nil {
+		return nil, fmt.Errorf("query fragments for decay preview: %w", err)
+	}
+	defer rows.Close()
+
+	now := time.Now()
+	out := []DecayPreview{}
+	for rows.Next() {
+		var p DecayPreview
+		var accessedAt sql.NullTime
+		if err := rows.Scan(&p.ID, &p.Agent, &p.Path, &p.UpdatedAt, &accessedAt, &p.CurrentScore); err != nil {
+			return nil, fmt.Errorf("scan fragment for decay preview: %w", err)
+		}
+		if accessedAt.Valid {
+			at := accessedAt.Time
+			p.AccessedAt = &at
+		}
+		p.PreviewScore = ComputeDecayScore(p.UpdatedAt, p.AccessedAt, halfLifeDays, now)
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fragments for decay preview: %w", err)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if math.Abs(out[i].PreviewScore-out[j].PreviewScore) < 1e-12 {
+			if out[i].Agent == out[j].Agent {
+				return out[i].Path < out[j].Path
+			}
+			return out[i].Agent < out[j].Agent
+		}
+		return out[i].PreviewScore < out[j].PreviewScore
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// CountDecayCandidates counts fragments that would fall below threshold if
+// age-based decay were applied, without mutating decay_score.
+func (s *Store) CountDecayCandidates(ctx context.Context, agent string, halfLifeDays, threshold float64) (int, error) {
+	if threshold <= 0 {
+		threshold = DefaultDecayGCThreshold
+	}
+	previews, err := s.PreviewDecayScores(ctx, agent, halfLifeDays, 0)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, preview := range previews {
+		if preview.PreviewScore < threshold {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // RecalcDecayScores recalculates decay_score for non-pinned fragments.
 // halfLifeDays defaults to 30 when <= 0.
+// Deprecated: prefer PreviewDecayScores or ComputeDecayScore; routine memory
+// maintenance should not rewrite decay scores.
 func (s *Store) RecalcDecayScores(ctx context.Context, agent string, halfLifeDays float64) (int, error) {
 	agent = strings.TrimSpace(agent)
 	if halfLifeDays <= 0 {
-		halfLifeDays = 30.0
+		halfLifeDays = DefaultDecayHalfLifeDays
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -1765,17 +1879,12 @@ func (s *Store) RecalcDecayScores(ctx context.Context, agent string, halfLifeDay
 			return 0, fmt.Errorf("scan fragment for decay recalculation: %w", err)
 		}
 
-		lastActive := updatedAt
-		if accessedAt.Valid && accessedAt.Time.After(lastActive) {
-			lastActive = accessedAt.Time
+		var accessedAtPtr *time.Time
+		if accessedAt.Valid {
+			at := accessedAt.Time
+			accessedAtPtr = &at
 		}
-
-		ageDays := now.Sub(lastActive).Hours() / 24.0
-		if ageDays < 0 {
-			ageDays = 0
-		}
-		decay := math.Pow(0.5, ageDays/halfLifeDays)
-		finalDecay := math.Max(decay, 0.04)
+		finalDecay := ComputeDecayScore(updatedAt, accessedAtPtr, halfLifeDays, now)
 		updates = append(updates, decayUpdate{id: id, score: finalDecay})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -605,8 +605,8 @@ func TestStoreVectorSearchAndBumpAccess(t *testing.T) {
 	if got.AccessedAt == nil {
 		t.Fatal("accessed_at was not updated")
 	}
-	if math.Abs(got.DecayScore-0.8) > 1e-9 {
-		t.Fatalf("decay_score after bumps = %f, want %f", got.DecayScore, 0.8)
+	if math.Abs(got.DecayScore-0.6) > 1e-9 {
+		t.Fatalf("decay_score after access bumps = %f, want unchanged %f", got.DecayScore, 0.6)
 	}
 
 	if err := store.BumpAccess(ctx, "missing-id"); err == nil {
@@ -1090,6 +1090,69 @@ func TestStoreRecalcDecayScores(t *testing.T) {
 	}
 	if otherGot.DecayScore < 0.04 || otherGot.DecayScore > 1.0 {
 		t.Fatalf("other-agent decay_score after global recalc = %f, want within [0.04,1.0]", otherGot.DecayScore)
+	}
+}
+
+func TestStorePreviewDecayScoresDoesNotMutate(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	now := time.Now().UTC()
+	frag := &Fragment{
+		Agent:      "jarvis",
+		Path:       "decay/preview-only",
+		Content:    "preview only",
+		CreatedAt:  now.Add(-240 * 24 * time.Hour),
+		UpdatedAt:  now.Add(-240 * 24 * time.Hour),
+		DecayScore: 0.9,
+	}
+	pinned := &Fragment{
+		Agent:      "jarvis",
+		Path:       "decay/pinned-preview",
+		Content:    "pinned preview",
+		CreatedAt:  now.Add(-120 * 24 * time.Hour),
+		UpdatedAt:  now.Add(-120 * 24 * time.Hour),
+		Pinned:     true,
+		DecayScore: 0.8,
+	}
+	for _, f := range []*Fragment{frag, pinned} {
+		if err := store.CreateFragment(ctx, f); err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", f.Path, err)
+		}
+	}
+
+	previews, err := store.PreviewDecayScores(ctx, "jarvis", 30.0, 10)
+	if err != nil {
+		t.Fatalf("PreviewDecayScores() error = %v", err)
+	}
+	if len(previews) != 1 {
+		t.Fatalf("PreviewDecayScores() len = %d, want 1 non-pinned fragment", len(previews))
+	}
+	if previews[0].ID != frag.ID {
+		t.Fatalf("PreviewDecayScores()[0].ID = %s, want %s", previews[0].ID, frag.ID)
+	}
+	if previews[0].PreviewScore >= previews[0].CurrentScore {
+		t.Fatalf("preview score = %f, current = %f; want lower age-based score", previews[0].PreviewScore, previews[0].CurrentScore)
+	}
+
+	got, err := store.GetFragment(ctx, "jarvis", "decay/preview-only")
+	if err != nil {
+		t.Fatalf("GetFragment(preview-only) error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetFragment(preview-only) returned nil")
+	}
+	if math.Abs(got.DecayScore-0.9) > 1e-9 {
+		t.Fatalf("PreviewDecayScores mutated decay_score = %f, want 0.9", got.DecayScore)
+	}
+
+	count, err := store.CountDecayCandidates(ctx, "jarvis", 30.0, DefaultDecayGCThreshold)
+	if err != nil {
+		t.Fatalf("CountDecayCandidates() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("CountDecayCandidates() = %d, want 1", count)
 	}
 }
 


### PR DESCRIPTION
## What

This changes memory lifecycle defaults away from decay/deletion and toward explicit consolidation/review.

- Add `term-llm memory consolidate`, defaulting to dry-run and requiring `--apply` to write `recent.md`
- Add a seeded `memory/palace.md` template for durable, room-like agent context
- Remove the default container `memory-gc` scheduled job and update bundled skills/docs/templates
- Make memory search relevance-only by default:
  - `--decay` is opt-in
  - `--freshness` / `--recency` are opt-in non-persistent timestamp multipliers
  - `--touch` is opt-in for access metadata
  - `--no-decay` is kept as a deprecated no-op
- Stop routine memory mining from rewriting decay scores or pruning insights
- Make fragment GC review-first:
  - `memory fragments gc` reports what would be deleted
  - `--preview-decay` computes age-based candidates without writes
  - actual deletion requires explicit `--delete`
- Add dry-run previews for insight decay/GC

## Why

Delete-on-decay is the wrong default for long-term agent memory. Old + quiet is not the same as obsolete; quiet facts are often the load-bearing ones. Decay is now treated as review/freshness metadata, not permission to erase memory.

The requested direction was: raw memory accumulates, consolidation abstracts, archive/review preserves, search retrieves by relevance, decay requests review, deletion remains explicit.

## Validation

Sub-agent build/review:

- Implemented with `chatgpt:gpt-5.5-xhigh`
- Reviewed by `claude-bin:opus`

Local verification:

- `gofmt`
- `git diff --check`
- `go build ./...`
- `go vet ./...`
- `go test ./...`

Live Jarvis DB validation using this branch via `go run .`:

- `memory status --agent jarvis` → 934 fragments, command OK
- `memory search "PM Telegram Discourse" --agent jarvis --bm25-only --limit 5` → relevance-only search OK
- `memory fragments gc --agent jarvis` → reports 0 stored-score candidates; no delete without `--delete`
- `memory fragments gc --agent jarvis --preview-decay --half-life 30` → reports 0 age-based candidates; non-destructive
- Ran three consolidation dry-runs:
  - `--since 24h --recent-max-bytes 12000 --no-decay-preview`
  - `--since 6h --recent-max-bytes 8000 --decay-limit 5`
  - `--since 168h --recent-max-bytes 10000 --decay-limit 5`
- Applied one live Jarvis consolidation run:
  - `memory consolidate --agent jarvis --since 168h --recent-max-bytes 10000 --decay-limit 5 --apply`
  - promoted 9 fragments into `recent.md`
  - decay preview was non-destructive
  - no fragments deleted

## Notes

This does not implement a full archive/supersede database schema yet. The first step is deliberately conservative: remove destructive defaults, add explicit consolidation, seed a palace template, and make freshness/decay opt-in rather than automatic.
