### PR TITLE
fix: isolate New Chat from in-progress web sessions

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1414,7 +1414,9 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
 
   if (activeRun && !state.abortController) {
     updateBusySidebar();
-    setStreaming(true);
+    if (session.id === state.activeSessionId && !state.draftSessionActive) {
+      setStreaming(true);
+    }
     if (pollOnActive) {
       scheduleSessionStatePoll(session.id);
     }

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -3301,8 +3301,18 @@ const sendMessage = async (options = {}) => {
   }
 
   let session = getActiveSession();
-  const sessionBusy = state.streaming || (session && session.activeResponseId);
-  if (sessionBusy) {
+  const progressEntry = session ? state.sessionProgressById?.[session.id] : null;
+  const ownsLiveStream = Boolean(
+    session
+    && state.currentStreamSessionId === session.id
+    && (state.abortController || state.currentStreamResponseId || state.streaming)
+  );
+  const activeSessionBusy = Boolean(
+    session
+    && !state.draftSessionActive
+    && (session.activeResponseId || progressEntry?.serverActiveRun || ownsLiveStream)
+  );
+  if (activeSessionBusy) {
     const pendingMessageId = generateId('msg');
     let requestAttachmentParts = [];
     if (pendingAttachments.length > 0) {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -2859,6 +2859,49 @@ async function testLateActiveMessagesResponseIgnoredAfterSessionSwitch() {
   pass(name);
 }
 
+async function testLateActiveRunSyncDoesNotMarkDraftStreaming() {
+  const name = 'late active-run sync does not mark New Chat draft as streaming';
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_late_busy/state') {
+        return new Response(JSON.stringify({ active_run: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+  app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_late_busy',
+    title: 'Late busy',
+    origin: 'web',
+    created: 1,
+    messages: [],
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = '';
+  app.state.draftSessionActive = true;
+  app.state.streaming = false;
+
+  await app.syncActiveSessionFromServer(session, false);
+
+  if (app.state.streaming) {
+    fail(name, 'draft New Chat should stay idle even if an inactive session sync reports active_run=true');
+    return;
+  }
+  if (!app.sessionHasInProgressState(session)) {
+    fail(name, 'inactive session should still retain its sidebar busy state');
+    return;
+  }
+
+  pass(name);
+}
+
 async function testOlderPendingTranscriptVersionIsIgnoredOnStatus304() {
   const name = 'older pending transcript version is ignored on status 304';
   let messageCalls = 0;
@@ -3101,6 +3144,7 @@ async function testSwitchToSearchOnlySessionHydratesResult() {
   await testStatusPollUnchangedTranscriptDoesNotFetchMessages();
   await testActiveTranscriptRefreshSkipsBusyStates();
   await testLateActiveMessagesResponseIgnoredAfterSessionSwitch();
+  await testLateActiveRunSyncDoesNotMarkDraftStreaming();
   await testOlderPendingTranscriptVersionIsIgnoredOnStatus304();
   await testSyncActiveSessionIdleUsesTranscriptRefreshHelper();
 

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -1374,6 +1374,63 @@ async function testNewChatDuringStreamingClearsStreamingState() {
   pass(name);
 }
 
+async function testDraftSendIgnoresStaleGlobalStreamingFlag() {
+  const name = 'New Chat draft send ignores stale global streaming flag from previous session';
+  const harness = createHarness();
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+
+  const oldSession = {
+    id: 'session_old_busy',
+    title: 'Old busy',
+    messages: [],
+    lastResponseId: null,
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(oldSession);
+  state.activeSessionId = '';
+  state.draftSessionActive = true;
+  state.streaming = true;
+  state.currentStreamSessionId = '';
+  state.currentStreamResponseId = '';
+  elements.promptInput.value = 'fresh draft message';
+
+  const sendPromise = app.sendMessage().catch(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const interruptCalls = fetchCalls.filter((call) => String(call.url).endsWith('/interrupt'));
+  if (interruptCalls.length !== 0) {
+    fail(name, 'draft send should not post an interjection to an old session', JSON.stringify(fetchCalls));
+    app.detachResponseStream();
+    await sendPromise;
+    await cleanup();
+    return;
+  }
+
+  if (state.sessions.length < 2 || state.sessions[0].id === oldSession.id) {
+    fail(name, 'draft send should create a fresh session', JSON.stringify(state.sessions.map((session) => session.id)));
+    app.detachResponseStream();
+    await sendPromise;
+    await cleanup();
+    return;
+  }
+
+  const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (postCalls.length !== 1) {
+    fail(name, 'draft send should post a normal response request once', JSON.stringify(fetchCalls));
+    app.detachResponseStream();
+    await sendPromise;
+    await cleanup();
+    return;
+  }
+
+  app.detachResponseStream();
+  await sendPromise;
+  await cleanup();
+  pass(name);
+}
+
 async function testSendMessageMarksSessionBusyImmediately() {
   const name = 'sendMessage marks the session busy before polling catches up';
   const harness = createHarness();
@@ -3836,6 +3893,7 @@ function testRestoreLatestDraftMessageDoesNotCrossSessionBoundary() {
   await testNonImageAttachmentsDoNotCreatePreviewObjectURLs();
   await testSendMessageResumesFromEventsAfterPostStreamDrops();
   await testNewChatDuringStreamingClearsStreamingState();
+  await testDraftSendIgnoresStaleGlobalStreamingFlag();
   await testSendMessageMarksSessionBusyImmediately();
   await testDrainInterruptQueueAfterResumeCompletes();
   await testDrainInterruptQueueIgnoresOtherSessionEntries();


### PR DESCRIPTION
## What

Fix New Chat state leakage from in-progress web sessions.

- Treat a send as an interjection only when the currently active, non-draft session owns the busy state.
- Keep inactive session `active_run` status in the sidebar without flipping the global draft composer into streaming mode.
- Add regression coverage for:
  - New Chat draft sends with stale global `streaming=true`
  - late active-run sync responses after switching to New Chat

## Verification

```bash
mise exec node@24 -- node internal/serveui/static/app_stream_test.js
mise exec node@24 -- node internal/serveui/static/app_sessions_test.js
go test ./...
go build ./...
```
