### PR TITLE
fix: Responses API cancel requests can still end as completed

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -127,6 +127,19 @@ func (r *responseRun) appendEvent(event string, payload map[string]any) error {
 func (r *responseRun) complete(payload map[string]any, usage llm.Usage, sessionUsage llm.Usage) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.cancelRequested {
+		r.status = "cancelled"
+		r.errorType = ""
+		r.errorMessage = ""
+		r.cancel = nil
+		r.cancelRequested = false
+		if response := mapValue(payload["response"]); len(response) > 0 {
+			response["status"] = "cancelled"
+			delete(response, "usage")
+			delete(response, "session_usage")
+		}
+		return r.appendEventLocked("response.cancelled", payload, true)
+	}
 	r.status = "completed"
 	r.errorType = ""
 	r.errorMessage = ""

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -129,6 +129,62 @@ func TestResponseRunSubscriberDroppedWhenBufferFull(t *testing.T) {
 	}
 }
 
+func TestResponseRunCompleteHonorsPendingCancellation(t *testing.T) {
+	run := newResponseRun("resp_cancelled", "sess_test", "", "mock", time.Now().Unix(), func() {})
+
+	if !run.cancelRun() {
+		t.Fatal("expected cancelRun to succeed")
+	}
+
+	if err := run.complete(map[string]any{
+		"response": map[string]any{
+			"id":            run.id,
+			"object":        "response",
+			"created":       run.created,
+			"model":         run.model,
+			"status":        "completed",
+			"usage":         usagePayload(llm.Usage{InputTokens: 3, OutputTokens: 4}),
+			"session_usage": usagePayload(llm.Usage{InputTokens: 5, OutputTokens: 6}),
+		},
+	}, llm.Usage{InputTokens: 3, OutputTokens: 4}, llm.Usage{InputTokens: 5, OutputTokens: 6}); err != nil {
+		t.Fatalf("complete failed: %v", err)
+	}
+
+	run.mu.Lock()
+	defer run.mu.Unlock()
+
+	if run.status != "cancelled" {
+		t.Fatalf("run status = %q, want cancelled", run.status)
+	}
+	if run.cancelRequested {
+		t.Fatal("cancelRequested should be cleared after terminal transition")
+	}
+	if len(run.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(run.events))
+	}
+	if run.events[0].Event != "response.cancelled" {
+		t.Fatalf("event = %q, want response.cancelled", run.events[0].Event)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(run.events[0].Data, &payload); err != nil {
+		t.Fatalf("unmarshal terminal payload: %v", err)
+	}
+	response, ok := payload["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("response payload type = %T", payload["response"])
+	}
+	if response["status"] != "cancelled" {
+		t.Fatalf("response status = %v, want cancelled", response["status"])
+	}
+	if _, ok := response["usage"]; ok {
+		t.Fatalf("cancelled payload unexpectedly retained usage: %#v", response["usage"])
+	}
+	if _, ok := response["session_usage"]; ok {
+		t.Fatalf("cancelled payload unexpectedly retained session_usage: %#v", response["session_usage"])
+	}
+}
+
 func TestResponseRunCompactionKeepsReplayWindowInOrder(t *testing.T) {
 	run := newResponseRun("resp_compact", "sess_test", "", "mock", time.Now().Unix(), func() {})
 	run.maxRetainedEvents = 3


### PR DESCRIPTION
## What changed

- Updated `responseRun.complete` to give pending cancellation precedence over completion.
- When a cancel request has already been recorded, the run now transitions to `cancelled`, emits `response.cancelled`, and strips completion-only usage fields from the terminal response payload.
- Added a regression test covering the race where `cancelRun()` wins just before `complete()` finalizes the run.

## Why this is high-value

This fixes a user-visible correctness bug in the Responses API: a client could successfully POST `/cancel` and still receive `response.completed` if generation had already finished but the final completion transition had not run yet. That made cancellation flaky on long-running web/API sessions, left the run snapshot looking successful, and could mislead reconnecting SSE clients.

## Validation

- `gofmt -w cmd/serve_response_runs.go cmd/serve_response_runs_test.go`
- `go build ./...`
- `go test ./...`
- Added `TestResponseRunCompleteHonorsPendingCancellation` to verify cancellation wins over completion.
- `git diff --check`
