### PR TITLE
fix: Job cancellation can be overwritten by a later successful/failed finish

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1365,13 +1365,32 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 	if runErr != nil {
 		errText = runErr.Error()
 	}
-	_, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, finished_at = ?, exit_code = ?, error = ?, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = ?, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
-		status, now, result.ExitCode, errText, result.Stdout, result.Stderr, result.Thinking, result.Response, result.SessionID,
-		exitReason, boolToInt(truncated), result.TurnCount, result.InputTokens, result.OutputTokens,
-		runID)
+	cancelledErrText := context.Canceled.Error()
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?)`,
+		jobsV2RunCancelRequested, jobsV2RunCancelled, status,
+		now, result.ExitCode,
+		jobsV2RunCancelRequested, cancelledErrText, errText,
+		result.Stdout, result.Stderr, result.Thinking, result.Response, result.SessionID,
+		jobsV2RunCancelRequested, exitReasonCancelled, exitReason,
+		boolToInt(truncated), result.TurnCount, result.InputTokens, result.OutputTokens,
+		runID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
 	if err != nil {
 		return err
 	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return nil
+	}
+
+	run, err := m.GetRun(runID)
+	if err != nil {
+		return err
+	}
+	status = run.Status
+	exitReason = run.ExitReason
+	truncated = run.Truncated
+	errText = run.Error
+
 	_ = m.addRunEvent(runID, string(status), "run finished", map[string]any{
 		"status":        status,
 		"attempt":       attempt,
@@ -1387,10 +1406,6 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 	m.notifyRunDone(runID, status, result, exitReason, truncated, errText)
 
 	if status == jobsV2RunFailed || status == jobsV2RunTimedOut {
-		run, err := m.GetRun(runID)
-		if err != nil {
-			return nil
-		}
 		job, err := m.GetJob(run.JobID)
 		if err != nil {
 			return nil

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -300,6 +301,81 @@ func TestJobsV2ManualTriggerAndCancel(t *testing.T) {
 			t.Fatalf("run did not cancel in time, last status=%s", current.Status)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestJobsV2FinishRunDoesNotOverrideCancelRequested(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "cancel-authoritative",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+		RetryPolicy:   json.RawMessage(`{"max_attempts":2}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	if job.ID == "" {
+		t.Fatal("expected created job to have an id")
+	}
+
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+
+	started := time.Now().UTC()
+	if _, err := mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobsV2RunRunning, started, run.ID); err != nil {
+		t.Fatalf("mark run running: %v", err)
+	}
+
+	cancelled, err := mgr.CancelRun(run.ID)
+	if err != nil {
+		t.Fatalf("CancelRun failed: %v", err)
+	}
+	if cancelled.Status != jobsV2RunCancelRequested {
+		t.Fatalf("cancelled status = %s, want %s", cancelled.Status, jobsV2RunCancelRequested)
+	}
+
+	result := jobsV2RunResult{Response: "partial output", ExitCode: 17}
+	if err := mgr.finishRun(run.ID, jobsV2RunFailed, result, errors.New("runner failed after cancel request"), run.Attempt); err != nil {
+		t.Fatalf("finishRun failed: %v", err)
+	}
+
+	current, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if current.Status != jobsV2RunCancelled {
+		t.Fatalf("run status = %s, want %s", current.Status, jobsV2RunCancelled)
+	}
+	if current.ExitReason != exitReasonCancelled {
+		t.Fatalf("exit reason = %q, want %q", current.ExitReason, exitReasonCancelled)
+	}
+	if current.Error != context.Canceled.Error() {
+		t.Fatalf("error = %q, want %q", current.Error, context.Canceled.Error())
+	}
+	if current.Response != result.Response {
+		t.Fatalf("response = %q, want %q", current.Response, result.Response)
+	}
+	if current.FinishedAt == nil {
+		t.Fatal("expected cancelled run to have finished_at set")
+	}
+
+	var retryRuns int
+	if err := mgr.db.QueryRow(`SELECT COUNT(*) FROM job_runs_v2 WHERE job_id = ? AND id != ?`, job.ID, run.ID).Scan(&retryRuns); err != nil {
+		t.Fatalf("count retry runs: %v", err)
+	}
+	if retryRuns != 0 {
+		t.Fatalf("retry runs = %d, want 0", retryRuns)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Made `finishRun` perform a guarded terminal-state update instead of blindly overwriting whatever status is already in `job_runs_v2`.
- If a run has already been marked `cancel_requested`, `finishRun` now persists it as `cancelled` and keeps cancellation authoritative even if the worker later reports `succeeded`, `failed`, or `timed_out`.
- Limited terminal persistence to still-active run states so already-terminal rows are left alone.
- Added a regression test covering the real failure mode: a running job is cancelled, then a later failed finish attempt must not overwrite the cancellation or schedule a retry.

## Why this is high-value

Cancellation is a real user-facing control path. Before this change, there was a race where `CancelRun` could acknowledge cancellation in the DB, but a slightly later worker finish would overwrite that state back to success/failure/timeout. That could:

- show misleading final state to users,
- fire the wrong completion notifications,
- schedule retries for work the user explicitly cancelled.

This fix makes cancellation authoritative at the persistence boundary, which is the smallest safe place to close the race.

## Validation

- Added `TestJobsV2FinishRunDoesNotOverrideCancelRequested`
- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
