### PR TITLE
fix: Progressive runs ignore cancellation while persisting synthetic follow-up/finalization turns

### DIFF
--- a/cmd/progressive.go
+++ b/cmd/progressive.go
@@ -19,9 +19,10 @@ const (
 	progressiveStopWhenDone    progressiveStopWhen = "done"
 	progressiveStopWhenTimeout progressiveStopWhen = "timeout"
 
-	progressiveDefaultFinalizeGrace = 5 * time.Minute
-	progressiveMaxFinalizeBudget    = 5 * time.Minute
-	progressiveMinFinalizeBudget    = 5 * time.Second
+	progressiveDefaultFinalizeGrace    = 5 * time.Minute
+	progressiveMaxFinalizeBudget       = 5 * time.Minute
+	progressiveMinFinalizeBudget       = 5 * time.Second
+	progressiveSyntheticMessageTimeout = 5 * time.Second
 )
 
 type askProgressiveOptions struct {
@@ -296,7 +297,10 @@ func runProgressiveSession(ctx context.Context, engine *llm.Engine, req llm.Requ
 		continueMsg := llm.UserText(expandProgressiveTemplate(opts.ContinueWith, mainCtx))
 		history = append(history, continueMsg)
 		if opts.OnSyntheticUserMessage != nil {
-			if err := opts.OnSyntheticUserMessage(context.Background(), continueMsg); err != nil {
+			msgCtx, cancel := progressiveSyntheticUserMessageContext(mainCtx)
+			err := opts.OnSyntheticUserMessage(msgCtx, continueMsg)
+			cancel()
+			if err != nil {
 				return buildProgressiveRunResult(opts.SessionID, exitReasonNatural, false, tracker.latest, lastText), err
 			}
 		}
@@ -425,7 +429,10 @@ func attemptProgressiveFinalization(parentCtx context.Context, engine *llm.Engin
 	finalPrompt := buildProgressiveFinalizePrompt(tracker.latest)
 	finalizeMsg := llm.UserText(finalPrompt)
 	if opts.OnSyntheticUserMessage != nil {
-		if err := opts.OnSyntheticUserMessage(context.Background(), finalizeMsg); err != nil {
+		msgCtx, cancel := progressiveSyntheticUserMessageContext(finalizeCtx)
+		err := opts.OnSyntheticUserMessage(msgCtx, finalizeMsg)
+		cancel()
+		if err != nil {
 			return false, ""
 		}
 	}
@@ -511,6 +518,15 @@ func progressiveHasRemainingBudget(parent context.Context, reserve time.Duration
 		return false
 	}
 	return time.Until(deadline) > reserve
+}
+
+// progressiveSyntheticUserMessageContext caps synthetic user-message persistence
+// to a short window while still honoring the caller's cancellation/deadline.
+func progressiveSyntheticUserMessageContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, progressiveSyntheticMessageTimeout)
 }
 
 func progressiveFinalizeReserve(total time.Duration) time.Duration {

--- a/cmd/progressive_test.go
+++ b/cmd/progressive_test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
+	toolpkg "github.com/samsaffron/term-llm/internal/tools"
 )
 
 type progressiveTestTool struct{}
@@ -172,6 +174,87 @@ func TestRunProgressiveSessionTimeoutDoesNotStartDetachedFinalizationAfterDeadli
 	}
 	if len(provider.Requests) != 1 {
 		t.Fatalf("provider saw %d requests, want timeout to skip detached finalization pass", len(provider.Requests))
+	}
+}
+
+func TestRunProgressiveSessionSyntheticContinuationPersistenceHonorsContext(t *testing.T) {
+	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{
+		ToolCalls:          true,
+		SupportsToolChoice: true,
+	})
+	provider.AddToolCall("progress-1", "update_progress", map[string]any{
+		"state": map[string]any{
+			"step": "draft",
+		},
+		"reason":  "milestone",
+		"message": "draft saved",
+	})
+	provider.AddTextResponse("draft answer")
+
+	engine := llm.NewEngine(provider, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5050*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runProgressiveSession(ctx, engine, llm.Request{
+			Messages: []llm.Message{llm.UserText("Investigate X")},
+			MaxTurns: 8,
+			ToolChoice: llm.ToolChoice{
+				Mode: llm.ToolChoiceAuto,
+			},
+		}, progressiveRunOptions{
+			StopWhen: progressiveStopWhenTimeout,
+			OnSyntheticUserMessage: func(ctx context.Context, msg llm.Message) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("runProgressiveSession error = %v, want deadline exceeded", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("synthetic continuation persistence did not stop when its context expired")
+	}
+}
+
+func TestAttemptProgressiveFinalizationSyntheticPersistenceHonorsContext(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	engine := llm.NewEngine(provider, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		finalized, text := attemptProgressiveFinalization(ctx, engine, toolpkg.NewFinalizeProgressTool(), llm.Request{
+			Messages: []llm.Message{llm.UserText("Investigate X")},
+		}, nil, progressiveRunOptions{
+			OnSyntheticUserMessage: func(ctx context.Context, msg llm.Message) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}, newProgressTracker(), 20*time.Millisecond, exitReasonTimeout)
+		if finalized {
+			t.Errorf("finalized = true, want false")
+		}
+		if text != "" {
+			t.Errorf("text = %q, want empty", text)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if len(provider.Requests) != 0 {
+			t.Fatalf("provider saw %d requests, want synthetic persistence failure to stop finalization before the model call", len(provider.Requests))
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("synthetic finalization persistence did not stop when its context expired")
 	}
 }
 


### PR DESCRIPTION
## What changed

- replaced `context.Background()` for progressive synthetic continuation/finalization persistence with a short derived context that honors the active progressive run's cancellation/deadline
- added `progressiveSyntheticUserMessageContext` to bound `OnSyntheticUserMessage` callbacks to 5 seconds at most, while still stopping immediately when the parent progressive context is canceled or times out
- added regression tests covering both synthetic continuation persistence and synthetic finalization persistence so these callbacks cannot block forever on a detached background context

## Why this is high-value

Progressive runs persist synthetic user turns through callbacks that ultimately write to the session SQLite store. Those writes can block behind SQLite busy/retry handling. Before this change, those two persistence calls used `context.Background()`, so a timed-out run, canceled job, or Ctrl-C could stay stuck persisting synthetic turns long after the progressive run was supposed to stop.

This fix closes that shutdown hole on the real `ask --progressive` / progressive jobs path without changing the broader progressive control flow.

## Validation

- `gofmt -w cmd/progressive.go cmd/progressive_test.go`
- `go build ./...`
- targeted regression tests passed:
  - `go test ./cmd -run 'TestRunProgressiveSessionSyntheticContinuationPersistenceHonorsContext|TestAttemptProgressiveFinalizationSyntheticPersistenceHonorsContext|TestRunProgressiveSessionTimeoutDoesNotStartDetachedFinalizationAfterDeadline|TestRunProgressiveSessionFinalizesOnNaturalCompletion'`
- `git diff --check`
- `go test ./...` was run twice; the suite still hits the pre-existing unrelated flaky failure in `internal/tools` (`TestRunAgentScriptTool_TimeoutKillsGrandchildren`) when the entire repo is run together, but that test passes when rerun in isolation via `go test ./internal/tools -run TestRunAgentScriptTool_TimeoutKillsGrandchildren -count=1 -v`
