### PR TITLE
fix: serve shutdown cancels detached response runs but never waits for their goroutines to finish

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -734,6 +734,7 @@ type responseRunManager struct {
 	activeBySession   map[string]string
 	cleanupTimers     map[string]*time.Timer
 	terminalRetention time.Duration
+	runWG             sync.WaitGroup
 	closed            bool
 }
 
@@ -794,10 +795,32 @@ func (m *responseRunManager) create(run *responseRun) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.closed {
+		return fmt.Errorf("server is shutting down")
+	}
 	if _, exists := m.runs[run.id]; exists {
 		return fmt.Errorf("response run %q already exists", run.id)
 	}
 	m.runs[run.id] = run
+	return nil
+}
+
+func (m *responseRunManager) start(fn func()) error {
+	if fn == nil {
+		return fmt.Errorf("response run function is required")
+	}
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return fmt.Errorf("server is shutting down")
+	}
+	m.runWG.Add(1)
+	m.mu.Unlock()
+
+	go func() {
+		defer m.runWG.Done()
+		fn()
+	}()
 	return nil
 }
 
@@ -915,6 +938,7 @@ func (m *responseRunManager) Close() {
 	for _, run := range runs {
 		_ = run.cancelRun()
 	}
+	m.runWG.Wait()
 }
 
 func usagePayload(usage llm.Usage) map[string]any {
@@ -1566,7 +1590,7 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		return nil, err
 	}
 
-	go func() {
+	if err := mgr.start(func() {
 		defer func() {
 			mgr.clearActiveRun(sessionID, respID)
 			mgr.scheduleCleanup(respID)
@@ -1685,7 +1709,12 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		}, result.Usage, result.SessionUsage); err != nil {
 			log.Printf("response run %s failed to append completion event: %v", respID, err)
 		}
-	}()
+	}); err != nil {
+		cancel()
+		mgr.clearActiveRun(sessionID, respID)
+		mgr.delete(respID)
+		return nil, err
+	}
 
 	return run, nil
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -80,6 +80,63 @@ type stagedProvider struct {
 	closeFirst    sync.Once
 }
 
+type shutdownBlockingStream struct {
+	ctx           context.Context
+	release       <-chan struct{}
+	cancelled     chan struct{}
+	cancelledOnce sync.Once
+}
+
+func (s *shutdownBlockingStream) Recv() (llm.Event, error) {
+	<-s.ctx.Done()
+	s.cancelledOnce.Do(func() { close(s.cancelled) })
+	<-s.release
+	return llm.Event{}, s.ctx.Err()
+}
+
+func (s *shutdownBlockingStream) Close() error {
+	return nil
+}
+
+type shutdownBlockingProvider struct {
+	started     chan struct{}
+	cancelled   chan struct{}
+	release     chan struct{}
+	cleanupDone chan struct{}
+	startOnce   sync.Once
+	cleanupOnce sync.Once
+}
+
+func newShutdownBlockingProvider() *shutdownBlockingProvider {
+	return &shutdownBlockingProvider{
+		started:     make(chan struct{}),
+		cancelled:   make(chan struct{}),
+		release:     make(chan struct{}),
+		cleanupDone: make(chan struct{}),
+	}
+}
+
+func (p *shutdownBlockingProvider) Name() string {
+	return "shutdown-blocking"
+}
+
+func (p *shutdownBlockingProvider) Credential() string {
+	return "test"
+}
+
+func (p *shutdownBlockingProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{}
+}
+
+func (p *shutdownBlockingProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	p.startOnce.Do(func() { close(p.started) })
+	return &shutdownBlockingStream{ctx: ctx, release: p.release, cancelled: p.cancelled}, nil
+}
+
+func (p *shutdownBlockingProvider) CleanupMCP() {
+	p.cleanupOnce.Do(func() { close(p.cleanupDone) })
+}
+
 type countingListModelsProvider struct {
 	name   string
 	models []llm.ModelInfo
@@ -8981,6 +9038,68 @@ func TestRegisterResponseID_CapsAtMax(t *testing.T) {
 	expected := fmt.Sprintf("resp_%d", maxResponseIDs+4)
 	if got := rt.getLastResponseID(); got != expected {
 		t.Fatalf("lastResponseID = %q, want %q", got, expected)
+	}
+}
+
+func TestResponseRunManagerCloseWaitsForDetachedRunShutdown(t *testing.T) {
+	provider := newShutdownBlockingProvider()
+	rt := &serveRuntime{
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		defaultModel: "mock-model",
+	}
+	rt.Touch()
+
+	srv := &serveServer{responseRuns: newServeResponseRunManager()}
+
+	if _, err := srv.startResponseRun(rt, false, true, []llm.Message{
+		llm.UserText("hi"),
+	}, llm.Request{Model: "mock-model"}, "", startResponseRunOptions{}); err != nil {
+		t.Fatalf("startResponseRun: %v", err)
+	}
+
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response run to start streaming")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		srv.responseRuns.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-provider.cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response run cancellation")
+	}
+
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned before detached response run finished unwinding")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case <-provider.cleanupDone:
+		t.Fatal("stateless runtime cleanup completed before blocked run was released")
+	default:
+	}
+
+	close(provider.release)
+
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not wait for detached response run goroutine to finish")
+	}
+
+	select {
+	case <-provider.cleanupDone:
+	default:
+		t.Fatal("stateless runtime cleanup was not finished when Close returned")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added detached-run goroutine tracking to `responseRunManager` with a `sync.WaitGroup`.
- Changed `responseRunManager.Close()` to cancel all tracked runs and then wait for their goroutines to finish before returning.
- Wrapped the detached goroutine launch in `startResponseRun()` with manager-owned tracking, and reject new run starts once shutdown has begun.
- Added a regression test that starts a non-stateful detached response run, blocks its cancellation path, and verifies `Close()` does not return until the run goroutine finishes and stateless runtime cleanup has completed.

## Why this is high-value

Serve shutdown already cancels detached `/v1/responses` runs, but before this change it did not wait for the goroutines spawned by `startResponseRun()` to unwind. Those goroutines own important shutdown-time work for non-stateful runs, including `runtime.Close()` and any final persistence/cleanup done after cancellation. That meant `serve` could continue into store/session teardown while detached runs were still persisting final state or cleaning up providers, creating exactly the kind of restart-time flakiness and state loss that is hard to reproduce.

This fix makes shutdown deterministic: once `serveServer.Stop()` returns from `responseRuns.Close()`, all detached response-run goroutines have finished their teardown.

## Validation

- `gofmt -w cmd/serve_response_runs.go cmd/serve_test.go`
- `go build ./...`
- `go test ./...`
- Added regression test: `TestResponseRunManagerCloseWaitsForDetachedRunShutdown`
- `git diff --check`
