### PR TITLE
fix: progressive ask can deadlock when the stream consumer exits early

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -777,7 +777,13 @@ func runAsk(cmd *cobra.Command, args []string) error {
 			default:
 				err = streamPlainText(displayCtx, events, false)
 			}
+			if bridge != nil && err != nil {
+				bridge.Shutdown()
+			}
 			progressiveRun = <-runCh
+			if err != nil && errors.Is(progressiveRun.Err, errAskProgressiveBridgeClosed) {
+				progressiveRun.Err = nil
+			}
 		}
 		tools.ClearAskUserHooks() // Safe to call even if hooks weren't set
 

--- a/cmd/ask_progressive.go
+++ b/cmd/ask_progressive.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
 	"github.com/samsaffron/term-llm/internal/ui"
 )
+
+var errAskProgressiveBridgeClosed = errors.New("progressive stream consumer stopped")
 
 type askProgressiveRunResult struct {
 	Result progressiveRunResult
@@ -15,10 +18,12 @@ type askProgressiveRunResult struct {
 
 type askProgressiveBridge struct {
 	events chan ui.StreamEvent
+	done   chan struct{}
 	stats  *ui.SessionStats
 
 	seenToolStarts map[string]struct{}
 	seenToolEnds   map[string]struct{}
+	shutdownOnce   sync.Once
 	closeOnce      sync.Once
 
 	attemptInput          int
@@ -35,6 +40,7 @@ func newAskProgressiveBridge(bufSize int) *askProgressiveBridge {
 	}
 	return &askProgressiveBridge{
 		events:         make(chan ui.StreamEvent, bufSize),
+		done:           make(chan struct{}),
 		stats:          ui.NewSessionStats(),
 		seenToolStarts: make(map[string]struct{}),
 		seenToolEnds:   make(map[string]struct{}),
@@ -59,16 +65,41 @@ func (b *askProgressiveBridge) Stats() *ui.SessionStats {
 	return b.stats
 }
 
+func (b *askProgressiveBridge) Shutdown() {
+	b.shutdownOnce.Do(func() {
+		close(b.done)
+	})
+}
+
+func (b *askProgressiveBridge) send(event ui.StreamEvent) error {
+	select {
+	case <-b.done:
+		return errAskProgressiveBridgeClosed
+	default:
+	}
+
+	select {
+	case <-b.done:
+		return errAskProgressiveBridgeClosed
+	case b.events <- event:
+		return nil
+	}
+}
+
 func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 	switch event.Type {
 	case llm.EventError:
 		if event.Err != nil {
-			b.events <- ui.ErrorEvent(event.Err)
+			if err := b.send(ui.ErrorEvent(event.Err)); err != nil {
+				return err
+			}
 		}
 	case llm.EventTextDelta:
 		b.attemptUsageCommitted = false
 		if event.Text != "" {
-			b.events <- ui.TextEvent(event.Text)
+			if err := b.send(ui.TextEvent(event.Text)); err != nil {
+				return err
+			}
 		}
 	case llm.EventReasoningDelta:
 		b.attemptUsageCommitted = false
@@ -84,7 +115,9 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 		if kind == llm.ReasoningKindSummary && event.Text != "" {
 			title = internalreasoning.ParseReasoningSummary(event.Text).Title
 		}
-		b.events <- ui.ReasoningEvent(kind, event.Text, title, event.ReasoningItemID, event.ReasoningFinal, displayable)
+		if err := b.send(ui.ReasoningEvent(kind, event.Text, title, event.ReasoningItemID, event.ReasoningFinal, displayable)); err != nil {
+			return err
+		}
 	case llm.EventToolCall:
 		b.markAttemptCommitted()
 		if event.Tool == nil {
@@ -112,7 +145,9 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 			toolArgs = event.Tool.Arguments
 		}
 		b.stats.ToolStart()
-		b.events <- ui.ToolStartEvent(toolCallID, event.Tool.Name, toolInfo, toolArgs)
+		if err := b.send(ui.ToolStartEvent(toolCallID, event.Tool.Name, toolInfo, toolArgs)); err != nil {
+			return err
+		}
 	case llm.EventToolExecStart:
 		b.markAttemptCommitted()
 		if isProgressToolName(event.ToolName) {
@@ -125,7 +160,9 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 			b.seenToolStarts[event.ToolCallID] = struct{}{}
 		}
 		b.stats.ToolStart()
-		b.events <- ui.ToolStartEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolArgs)
+		if err := b.send(ui.ToolStartEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolArgs)); err != nil {
+			return err
+		}
 	case llm.EventToolExecEnd:
 		if isProgressToolName(event.ToolName) {
 			break
@@ -138,12 +175,18 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 		}
 		b.stats.ToolEnd()
 		b.resetAttemptUsage()
-		b.events <- ui.ToolEndEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolSuccess)
+		if err := b.send(ui.ToolEndEvent(event.ToolCallID, event.ToolName, event.ToolInfo, event.ToolSuccess)); err != nil {
+			return err
+		}
 		for _, imagePath := range event.ToolImages {
-			b.events <- ui.ImageEvent(imagePath)
+			if err := b.send(ui.ImageEvent(imagePath)); err != nil {
+				return err
+			}
 		}
 		for _, d := range event.ToolDiffs {
-			b.events <- ui.DiffEventWithOperation(d.File, d.Old, d.New, d.Line, d.Operation)
+			if err := b.send(ui.DiffEventWithOperation(d.File, d.Old, d.New, d.Line, d.Operation)); err != nil {
+				return err
+			}
 		}
 	case llm.EventUsage:
 		if event.Use != nil {
@@ -155,23 +198,33 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 				b.attemptCacheWrite += event.Use.CacheWriteTokens
 				b.attemptUsageCalls++
 			}
-			b.events <- ui.UsageEvent(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
+			if err := b.send(ui.UsageEvent(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)); err != nil {
+				return err
+			}
 		}
 	case llm.EventPhase:
 		if event.Text != "" {
-			b.events <- ui.PhaseEvent(event.Text)
+			if err := b.send(ui.PhaseEvent(event.Text)); err != nil {
+				return err
+			}
 		}
 	case llm.EventRetry:
-		b.events <- ui.RetryEvent(event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs)
+		if err := b.send(ui.RetryEvent(event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs)); err != nil {
+			return err
+		}
 	case llm.EventAttemptDiscard:
 		if b.attemptUsageCalls > 0 {
 			b.stats.DiscardUsage(b.attemptInput, b.attemptOutput, b.attemptCached, b.attemptCacheWrite, b.attemptUsageCalls)
 		}
 		b.resetAttemptUsage()
-		b.events <- ui.AttemptDiscardEvent()
+		if err := b.send(ui.AttemptDiscardEvent()); err != nil {
+			return err
+		}
 	case llm.EventInterjection:
 		if event.Text != "" {
-			b.events <- ui.InterjectionEvent(event.Text, event.InterjectionID)
+			if err := b.send(ui.InterjectionEvent(event.Text, event.InterjectionID)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -179,7 +232,7 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 
 func (b *askProgressiveBridge) CloseSuccess() {
 	b.closeOnce.Do(func() {
-		b.events <- ui.DoneEvent(b.stats.OutputTokens)
+		_ = b.send(ui.DoneEvent(b.stats.OutputTokens))
 		close(b.events)
 	})
 }
@@ -187,7 +240,7 @@ func (b *askProgressiveBridge) CloseSuccess() {
 func (b *askProgressiveBridge) CloseError(err error) {
 	b.closeOnce.Do(func() {
 		if err != nil {
-			b.events <- ui.ErrorEvent(err)
+			_ = b.send(ui.ErrorEvent(err))
 		}
 		close(b.events)
 	})

--- a/cmd/ask_progressive_test.go
+++ b/cmd/ask_progressive_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -27,5 +29,40 @@ func TestAskProgressiveBridge_PropagatesInterjectionID(t *testing.T) {
 	}
 	if ev.InterjectionID != "bridge-interject-1" {
 		t.Fatalf("event interjection ID = %q, want %q", ev.InterjectionID, "bridge-interject-1")
+	}
+}
+
+func TestAskProgressiveBridge_ShutdownPreventsBlockedSends(t *testing.T) {
+	bridge := newAskProgressiveBridge(1)
+	if err := bridge.HandleEvent(llm.Event{Type: llm.EventTextDelta, Text: "buffered"}); err != nil {
+		t.Fatalf("HandleEvent() error = %v", err)
+	}
+
+	bridge.Shutdown()
+
+	handleDone := make(chan error, 1)
+	go func() {
+		handleDone <- bridge.HandleEvent(llm.Event{Type: llm.EventTextDelta, Text: "blocked"})
+	}()
+
+	select {
+	case err := <-handleDone:
+		if !errors.Is(err, errAskProgressiveBridgeClosed) {
+			t.Fatalf("HandleEvent() error = %v, want %v", err, errAskProgressiveBridgeClosed)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("HandleEvent() blocked after Shutdown")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		bridge.CloseSuccess()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("CloseSuccess() blocked after Shutdown")
 	}
 }


### PR DESCRIPTION
## What changed

- made `askProgressiveBridge` shutdown-aware with a dedicated `done` signal
- routed progressive bridge event delivery through a helper that stops returning blocking channel sends once shutdown is signaled
- updated `CloseSuccess` / `CloseError` to avoid blocking when the consumer has already exited
- when the progressive display path returns an error, `ask.go` now signals bridge shutdown before waiting for the producer goroutine, and ignores the expected bridge-closed sentinel from that shutdown path
- added a regression test covering the previously blocking `HandleEvent` and `CloseSuccess` cases after shutdown

## Why this is high-value

`term-llm ask --progressive` runs the LLM/tool producer in one goroutine and drains bridge events in another. Before this change, if the display side exited early (for example a JSON write failure, broken output stream, or renderer failure), the producer kept doing blocking channel sends into the bridge. Once the buffer filled, the producer goroutine wedged forever and the caller hung on `<-runCh`.

This fix makes that failure path unwind cleanly instead of deadlocking a primary user-facing streaming command.

## Validation

- verified the issue in current code by inspecting `cmd/ask_progressive.go`: every bridge event send and close path used plain blocking channel writes with no shutdown signal
- `gofmt -w cmd/ask_progressive.go cmd/ask.go cmd/ask_progressive_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
