### PR TITLE
feat: add timezone-aware prompt template vars

### DIFF
--- a/internal/agents/builtin/agent-builder/system.md
+++ b/internal/agents/builtin/agent-builder/system.md
@@ -61,7 +61,8 @@ mcp:
 ```
 
 **system.md** - System prompt with optional template variables:
-- `{{date}}`, `{{datetime}}`, `{{time}}`, `{{year}}`
+- `{{date}}`, `{{datetime}}`, `{{datetime_rfc3339}}`, `{{time}}`, `{{year}}`, `{{weekday}}`
+- `{{timezone}}`, `{{timezone_abbr}}`, `{{timezone_offset}}`, `{{utc_date}}`, `{{utc_datetime}}`
 - `{{cwd}}`, `{{cwd_name}}`, `{{home}}`, `{{user}}`
 - `{{git_branch}}`, `{{git_repo}}`, `{{git_diff_stat}}`
 - `{{files}}`, `{{file_count}}` (from -f flags)
@@ -198,7 +199,8 @@ Structure system.md with:
 
 1. **Role** - Clear statement of what the agent does
 2. **Context** - Use template variables for dynamic info (date, repo, etc.)
-   - **Always include `Today is {{date}}.`** at the top so the agent knows the current date
+   - **Always include `Current local time: {{weekday}} {{datetime_rfc3339}} ({{timezone}}).`** at the top so the agent knows the current date and timezone
+   - Use `UTC: {{utc_datetime}}.` as well for jobs, logs, or cross-timezone coordination
    - Add `User: {{user}}.` if user context is helpful
    - Add `Working in: {{cwd_name}}` or `Repository: {{git_repo}}` for project-aware agents
 3. **Process** - Step-by-step workflow the agent should follow

--- a/internal/agents/registry.go
+++ b/internal/agents/registry.go
@@ -358,7 +358,7 @@ tools:
 	// Create system.md
 	systemMD := fmt.Sprintf(`You are a helpful assistant for the {{git_repo}} project.
 
-Today is {{date}}. Working directory: {{cwd}}
+Current local time: {{weekday}} {{datetime_rfc3339}} ({{timezone}}). Working directory: {{cwd}}
 
 ## Your Role
 

--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
@@ -21,10 +22,17 @@ var templateVarPattern = regexp.MustCompile(`\{\{\s*(\w+)\s*\}\}`)
 // TemplateContext holds values for template variable expansion.
 type TemplateContext struct {
 	// Time-related
-	Date     string // YYYY-MM-DD
-	DateTime string // YYYY-MM-DD HH:MM:SS
-	Time     string // HH:MM
-	Year     string // YYYY
+	Date            string // YYYY-MM-DD (local time)
+	DateTime        string // YYYY-MM-DD HH:MM:SS (local time)
+	DateTimeRFC3339 string // RFC3339 timestamp with numeric offset
+	Time            string // HH:MM (local time)
+	Year            string // YYYY (local time)
+	Weekday         string // Monday, Tuesday, ... (local time)
+	Timezone        string // IANA timezone when available, otherwise local timezone name
+	TimezoneAbbr    string // Timezone abbreviation (e.g. UTC, AEST, PDT)
+	TimezoneOffset  string // Numeric timezone offset (e.g. +00:00, +10:00, -07:00)
+	UTCDate         string // YYYY-MM-DD in UTC
+	UTCDateTime     string // RFC3339 timestamp in UTC
 
 	// Directory info
 	Cwd     string // Full working directory
@@ -94,13 +102,22 @@ func templateVariables(template string) map[string]bool {
 // newTemplateContext creates a context with optional expensive computations.
 func newTemplateContext(computeGitInfo, computeGitDiffStat, computeAgents, computeHandoverDir bool) TemplateContext {
 	now := time.Now()
+	utcNow := now.UTC()
+	zoneAbbr, zoneOffsetSeconds := now.Zone()
 
 	ctx := TemplateContext{
-		Date:     now.Format("2006-01-02"),
-		DateTime: now.Format("2006-01-02 15:04:05"),
-		Time:     now.Format("15:04"),
-		Year:     now.Format("2006"),
-		OS:       runtime.GOOS,
+		Date:            now.Format("2006-01-02"),
+		DateTime:        now.Format("2006-01-02 15:04:05"),
+		DateTimeRFC3339: now.Format(time.RFC3339),
+		Time:            now.Format("15:04"),
+		Year:            now.Format("2006"),
+		Weekday:         now.Weekday().String(),
+		Timezone:        localTimezoneName(now),
+		TimezoneAbbr:    zoneAbbr,
+		TimezoneOffset:  formatTimezoneOffset(zoneOffsetSeconds),
+		UTCDate:         utcNow.Format("2006-01-02"),
+		UTCDateTime:     utcNow.Format(time.RFC3339),
+		OS:              runtime.GOOS,
 	}
 
 	// Working directory
@@ -220,10 +237,24 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 			return ctx.Date
 		case "datetime":
 			return ctx.DateTime
+		case "datetime_rfc3339":
+			return ctx.DateTimeRFC3339
 		case "time":
 			return ctx.Time
 		case "year":
 			return ctx.Year
+		case "weekday":
+			return ctx.Weekday
+		case "timezone":
+			return ctx.Timezone
+		case "timezone_abbr":
+			return ctx.TimezoneAbbr
+		case "timezone_offset":
+			return ctx.TimezoneOffset
+		case "utc_date":
+			return ctx.UTCDate
+		case "utc_datetime":
+			return ctx.UTCDateTime
 		case "cwd":
 			return ctx.Cwd
 		case "cwd_name":
@@ -330,10 +361,39 @@ func getGitDiffStat() string {
 func runGitOutput(dir string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitProbeTimeout)
 	defer cancel()
-
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	return cmd.Output()
+}
+
+func localTimezoneName(now time.Time) string {
+	if tz := strings.TrimSpace(os.Getenv("TZ")); tz != "" {
+		return tz
+	}
+	if loc := now.Location(); loc != nil {
+		if name := loc.String(); name != "" && name != "Local" {
+			return name
+		}
+	}
+	if target, err := os.Readlink("/etc/localtime"); err == nil {
+		const zoneInfoPrefix = "/usr/share/zoneinfo/"
+		if strings.HasPrefix(target, zoneInfoPrefix) {
+			return strings.TrimPrefix(target, zoneInfoPrefix)
+		}
+	}
+	abbr, _ := now.Zone()
+	return abbr
+}
+
+func formatTimezoneOffset(seconds int) string {
+	sign := "+"
+	if seconds < 0 {
+		sign = "-"
+		seconds = -seconds
+	}
+	hours := seconds / 3600
+	minutes := (seconds % 3600) / 60
+	return fmt.Sprintf("%s%02d:%02d", sign, hours, minutes)
 }
 
 // itoa is a simple int to string conversion.

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -12,26 +12,33 @@ import (
 
 func TestExpandTemplate(t *testing.T) {
 	ctx := TemplateContext{
-		Date:          "2026-01-16",
-		DateTime:      "2026-01-16 14:30:00",
-		Time:          "14:30",
-		Year:          "2026",
-		Cwd:           "/home/user/project",
-		CwdName:       "project",
-		Home:          "/home/user",
-		User:          "testuser",
-		GitBranch:     "main",
-		GitRepo:       "term-llm",
-		Files:         "main.go, utils.go",
-		FileCount:     "2",
-		OS:            "linux",
-		Platform:      "chat",
-		Provider:      "chatgpt",
-		Model:         "gpt-5.4-medium",
-		ProviderModel: "chatgpt:gpt-5.4-medium",
-		ResourceDir:   "/home/user/.cache/term-llm/agents/artist",
-		HandoverDir:   "/home/user/.local/share/term-llm/handover/project-abc123",
-		HandoverPath:  "/home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
+		Date:            "2026-01-16",
+		DateTime:        "2026-01-16 14:30:00",
+		DateTimeRFC3339: "2026-01-16T14:30:00+11:00",
+		Time:            "14:30",
+		Year:            "2026",
+		Weekday:         "Friday",
+		Timezone:        "Australia/Sydney",
+		TimezoneAbbr:    "AEDT",
+		TimezoneOffset:  "+11:00",
+		UTCDate:         "2026-01-16",
+		UTCDateTime:     "2026-01-16T03:30:00Z",
+		Cwd:             "/home/user/project",
+		CwdName:         "project",
+		Home:            "/home/user",
+		User:            "testuser",
+		GitBranch:       "main",
+		GitRepo:         "term-llm",
+		Files:           "main.go, utils.go",
+		FileCount:       "2",
+		OS:              "linux",
+		Platform:        "chat",
+		Provider:        "chatgpt",
+		Model:           "gpt-5.4-medium",
+		ProviderModel:   "chatgpt:gpt-5.4-medium",
+		ResourceDir:     "/home/user/.cache/term-llm/agents/artist",
+		HandoverDir:     "/home/user/.local/share/term-llm/handover/project-abc123",
+		HandoverPath:    "/home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
 	}
 
 	tests := []struct {
@@ -80,9 +87,14 @@ func TestExpandTemplate(t *testing.T) {
 			expected: "Hello {{unknown}}",
 		},
 		{
+			name:     "timezone-aware time variables",
+			template: "{{weekday}} {{datetime_rfc3339}} {{timezone}} {{timezone_abbr}} {{timezone_offset}} UTC={{utc_datetime}}",
+			expected: "Friday 2026-01-16T14:30:00+11:00 Australia/Sydney AEDT +11:00 UTC=2026-01-16T03:30:00Z",
+		},
+		{
 			name:     "all variables",
-			template: "{{date}} {{datetime}} {{time}} {{year}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{platform}} {{provider}} {{model}} {{provider_model}} {{resource_dir}} {{handover_dir}} {{handover_path}}",
-			expected: "2026-01-16 2026-01-16 14:30:00 14:30 2026 /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux chat chatgpt gpt-5.4-medium chatgpt:gpt-5.4-medium /home/user/.cache/term-llm/agents/artist /home/user/.local/share/term-llm/handover/project-abc123 /home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
+			template: "{{date}} {{datetime}} {{datetime_rfc3339}} {{time}} {{year}} {{weekday}} {{timezone}} {{timezone_abbr}} {{timezone_offset}} {{utc_date}} {{utc_datetime}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{platform}} {{provider}} {{model}} {{provider_model}} {{resource_dir}} {{handover_dir}} {{handover_path}}",
+			expected: "2026-01-16 2026-01-16 14:30:00 2026-01-16T14:30:00+11:00 14:30 2026 Friday Australia/Sydney AEDT +11:00 2026-01-16 2026-01-16T03:30:00Z /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux chat chatgpt gpt-5.4-medium chatgpt:gpt-5.4-medium /home/user/.cache/term-llm/agents/artist /home/user/.local/share/term-llm/handover/project-abc123 /home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
 		},
 		{
 			name:     "handover_dir variable",
@@ -291,11 +303,41 @@ func TestNewTemplateContext(t *testing.T) {
 	if ctx.Year == "" {
 		t.Error("Year should not be empty")
 	}
+	if ctx.Weekday == "" {
+		t.Error("Weekday should not be empty")
+	}
+	if ctx.Timezone == "" {
+		t.Error("Timezone should not be empty")
+	}
+	if ctx.TimezoneAbbr == "" {
+		t.Error("TimezoneAbbr should not be empty")
+	}
+	if ctx.TimezoneOffset == "" {
+		t.Error("TimezoneOffset should not be empty")
+	}
+	if ctx.DateTimeRFC3339 == "" {
+		t.Error("DateTimeRFC3339 should not be empty")
+	}
+	if ctx.UTCDate == "" {
+		t.Error("UTCDate should not be empty")
+	}
+	if ctx.UTCDateTime == "" {
+		t.Error("UTCDateTime should not be empty")
+	}
 
-	// Verify date format
+	// Verify date/time formats
 	_, err := time.Parse("2006-01-02", ctx.Date)
 	if err != nil {
 		t.Errorf("Date format invalid: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, ctx.DateTimeRFC3339); err != nil {
+		t.Errorf("DateTimeRFC3339 format invalid: %v", err)
+	}
+	if _, err := time.Parse("2006-01-02", ctx.UTCDate); err != nil {
+		t.Errorf("UTCDate format invalid: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, ctx.UTCDateTime); err != nil {
+		t.Errorf("UTCDateTime format invalid: %v", err)
 	}
 
 	// Check OS
@@ -306,6 +348,32 @@ func TestNewTemplateContext(t *testing.T) {
 	// Check that cwd is populated (should be valid in test)
 	if ctx.Cwd == "" {
 		t.Error("Cwd should not be empty")
+	}
+}
+
+func TestFormatTimezoneOffset(t *testing.T) {
+	tests := []struct {
+		seconds int
+		want    string
+	}{
+		{0, "+00:00"},
+		{10 * 3600, "+10:00"},
+		{11*3600 + 30*60, "+11:30"},
+		{-7 * 3600, "-07:00"},
+		{-(3*3600 + 30*60), "-03:30"},
+	}
+	for _, tt := range tests {
+		if got := formatTimezoneOffset(tt.seconds); got != tt.want {
+			t.Fatalf("formatTimezoneOffset(%d) = %q, want %q", tt.seconds, got, tt.want)
+		}
+	}
+}
+
+func TestLocalTimezoneNamePrefersTZEnv(t *testing.T) {
+	t.Setenv("TZ", "Australia/Sydney")
+	now := time.Date(2026, 6, 11, 14, 30, 0, 0, time.Local)
+	if got := localTimezoneName(now); got != "Australia/Sydney" {
+		t.Fatalf("localTimezoneName() = %q, want Australia/Sydney", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds timezone-aware system prompt template variables so agents can include an unambiguous current local time block instead of only `{{date}}`.

New variables:

- `{{weekday}}`
- `{{datetime_rfc3339}}`
- `{{timezone}}`
- `{{timezone_abbr}}`
- `{{timezone_offset}}`
- `{{utc_date}}`
- `{{utc_datetime}}`

Also updates the default generated `system.md` and the agent-builder guidance to recommend:

```text
Current local time: {{weekday}} {{datetime_rfc3339}} ({{timezone}}).
```

## Why

`{{date}}` is ambiguous for timezone-sensitive tasks. A date-only prompt can make the assistant reason from the wrong day when the process date, user locale, or injected context disagree. Including weekday, RFC3339 offset, and timezone makes school schedules, jobs, logs, and local-day reasoning less footgun-shaped.

## Notes

- Existing `{{date}}`, `{{datetime}}`, `{{time}}`, and `{{year}}` behavior is unchanged.
- `{{timezone}}` prefers `TZ`, then the Go location name, then `/etc/localtime` symlink-derived IANA name, then the timezone abbreviation.

## Tests

```text
go test ./...
```
