### PR TITLE
fix: keep default prompt date context cache-stable

### DIFF
--- a/internal/agents/builtin/agent-builder/system.md
+++ b/internal/agents/builtin/agent-builder/system.md
@@ -61,16 +61,16 @@ mcp:
 ```
 
 **system.md** - System prompt with optional template variables:
-- `{{date}}`, `{{datetime}}`, `{{datetime_rfc3339}}`, `{{time}}`, `{{year}}`, `{{weekday}}`
-- `{{timezone}}`, `{{timezone_abbr}}`, `{{timezone_offset}}`, `{{utc_date}}`, `{{utc_datetime}}`
-- `{{cwd}}`, `{{cwd_name}}`, `{{home}}`, `{{user}}`
-- `{{git_branch}}`, `{{git_repo}}`, `{{git_diff_stat}}`
-- `{{files}}`, `{{file_count}}` (from -f flags)
-- `{{os}}`, `{{platform}}`, `{{resource_dir}}`
-- `{{provider}}`, `{{model}}`, `{{provider_model}}`
-- `{{agents}}` - Loads project instructions (hierarchical AGENTS.md + fallbacks)
+- `{{!date}}`, `{{!datetime}}`, `{{!datetime_rfc3339}}`, `{{!time}}`, `{{!year}}`, `{{!weekday}}`
+- `{{!timezone}}`, `{{!timezone_abbr}}`, `{{!timezone_offset}}`, `{{!utc_date}}`, `{{!utc_datetime}}`
+- `{{!cwd}}`, `{{!cwd_name}}`, `{{!home}}`, `{{!user}}`
+- `{{!git_branch}}`, `{{!git_repo}}`, `{{!git_diff_stat}}`
+- `{{!files}}`, `{{!file_count}}` (from -f flags)
+- `{{!os}}`, `{{!platform}}`, `{{!resource_dir}}`
+- `{{!provider}}`, `{{!model}}`, `{{!provider_model}}`
+- `{{!agents}}` - Loads project instructions (hierarchical AGENTS.md + fallbacks)
 
-**The `{{agents}}` variable** loads project instructions using:
+**The `{{!agents}}` variable** loads project instructions using:
 1. User-level: `~/.config/term-llm/AGENTS.md` (always included if present)
 2. Project-level: AGENTS.md hierarchy from repo root → cwd (at each level, AGENTS.override.md takes precedence over AGENTS.md)
 3. Fallback (only if no AGENTS.md found): CLAUDE.md, .github/copilot-instructions.md, .cursor/rules, CONTRIBUTING.md
@@ -109,7 +109,7 @@ tools:
 - Use `custom` instead of `run_agent_script` when the tool has a clear name/schema the LLM should understand natively
 - No directory paths are exposed to the LLM — scripts are resolved from the agent's own directory
 - No permission prompts — scripts in the agent directory are implicitly trusted
-- This replaces the old `{{agent_dir}}` shell allow pattern approach which never worked
+- This replaces the old `{{!agent_dir}}` shell allow pattern approach which never worked
 - Scripts must be executable files (not symlinks to outside the agent directory)
 
 **Additional .md files** - Include reference material:
@@ -199,10 +199,10 @@ Structure system.md with:
 
 1. **Role** - Clear statement of what the agent does
 2. **Context** - Use template variables for dynamic info (date, repo, etc.)
-   - **Always include `Current local date: {{weekday}} {{date}} ({{timezone}}).`** at the top so the agent knows the current local date without changing every minute and breaking prompt caches
-   - Add `{{time}}`, `{{datetime_rfc3339}}`, or `UTC: {{utc_datetime}}.` only for agents that genuinely need time-of-day precision, logs, jobs, or cross-timezone coordination
-   - Add `User: {{user}}.` if user context is helpful
-   - Add `Working in: {{cwd_name}}` or `Repository: {{git_repo}}` for project-aware agents
+   - **Always include `Current local date: {{!weekday}} {{!date}} ({{!timezone}}).`** at the top so the agent knows the current local date without changing every minute and breaking prompt caches
+   - Add `{{!time}}`, `{{!datetime_rfc3339}}`, or `UTC: {{!utc_datetime}}.` only for agents that genuinely need time-of-day precision, logs, jobs, or cross-timezone coordination
+   - Add `User: {{!user}}.` if user context is helpful
+   - Add `Working in: {{!cwd_name}}` or `Repository: {{!git_repo}}` for project-aware agents
 3. **Process** - Step-by-step workflow the agent should follow
 4. **Guidelines** - Best practices and constraints
 5. **Output format** - How to structure responses (if relevant)

--- a/internal/agents/builtin/agent-builder/system.md
+++ b/internal/agents/builtin/agent-builder/system.md
@@ -199,8 +199,8 @@ Structure system.md with:
 
 1. **Role** - Clear statement of what the agent does
 2. **Context** - Use template variables for dynamic info (date, repo, etc.)
-   - **Always include `Current local time: {{weekday}} {{datetime_rfc3339}} ({{timezone}}).`** at the top so the agent knows the current date and timezone
-   - Use `UTC: {{utc_datetime}}.` as well for jobs, logs, or cross-timezone coordination
+   - **Always include `Current local date: {{weekday}} {{date}} ({{timezone}}).`** at the top so the agent knows the current local date without changing every minute and breaking prompt caches
+   - Add `{{time}}`, `{{datetime_rfc3339}}`, or `UTC: {{utc_datetime}}.` only for agents that genuinely need time-of-day precision, logs, jobs, or cross-timezone coordination
    - Add `User: {{user}}.` if user context is helpful
    - Add `Working in: {{cwd_name}}` or `Repository: {{git_repo}}` for project-aware agents
 3. **Process** - Step-by-step workflow the agent should follow

--- a/internal/agents/registry.go
+++ b/internal/agents/registry.go
@@ -358,7 +358,7 @@ tools:
 	// Create system.md
 	systemMD := fmt.Sprintf(`You are a helpful assistant for the {{git_repo}} project.
 
-Current local time: {{weekday}} {{datetime_rfc3339}} ({{timezone}}). Working directory: {{cwd}}
+Current local date: {{weekday}} {{date}} ({{timezone}}). Working directory: {{cwd}}
 
 ## Your Role
 

--- a/internal/agents/template.go
+++ b/internal/agents/template.go
@@ -19,6 +19,10 @@ import (
 // templateVarPattern matches {{variable}} tokens, allowing optional whitespace inside delimiters.
 var templateVarPattern = regexp.MustCompile(`\{\{\s*(\w+)\s*\}\}`)
 
+// escapedTemplateVarPattern matches {{!variable}} tokens. Escaped variables render as
+// literal {{variable}} text so prompts can document template syntax without expanding it.
+var escapedTemplateVarPattern = regexp.MustCompile(`\{\{\s*!\s*(\w+)\s*\}\}`)
+
 // TemplateContext holds values for template variable expansion.
 type TemplateContext struct {
 	// Time-related
@@ -223,8 +227,9 @@ func (c TemplateContext) WithLLM(provider, model string) TemplateContext {
 }
 
 // ExpandTemplate replaces {{variable}} placeholders with values from context.
+// Use {{!variable}} to render a literal {{variable}} without expanding it.
 func ExpandTemplate(text string, ctx TemplateContext) string {
-	return templateVarPattern.ReplaceAllStringFunc(text, func(match string) string {
+	expanded := templateVarPattern.ReplaceAllStringFunc(text, func(match string) string {
 		// Extract variable name.
 		matches := templateVarPattern.FindStringSubmatch(match)
 		if len(matches) != 2 {
@@ -312,6 +317,7 @@ func ExpandTemplate(text string, ctx TemplateContext) string {
 			return match
 		}
 	})
+	return escapedTemplateVarPattern.ReplaceAllString(expanded, "{{$1}}")
 }
 
 // gitProbeTimeout bounds git subprocesses used during template expansion so prompt construction

--- a/internal/agents/template_test.go
+++ b/internal/agents/template_test.go
@@ -92,6 +92,16 @@ func TestExpandTemplate(t *testing.T) {
 			expected: "Friday 2026-01-16T14:30:00+11:00 Australia/Sydney AEDT +11:00 UTC=2026-01-16T03:30:00Z",
 		},
 		{
+			name:     "escaped variable renders literally",
+			template: "Document {{!date}} and {{ ! timezone }}; expand {{date}}",
+			expected: "Document {{date}} and {{timezone}}; expand 2026-01-16",
+		},
+		{
+			name:     "escaped unknown variable renders literally",
+			template: "Old token {{!agent_dir}}",
+			expected: "Old token {{agent_dir}}",
+		},
+		{
 			name:     "all variables",
 			template: "{{date}} {{datetime}} {{datetime_rfc3339}} {{time}} {{year}} {{weekday}} {{timezone}} {{timezone_abbr}} {{timezone_offset}} {{utc_date}} {{utc_datetime}} {{cwd}} {{cwd_name}} {{home}} {{user}} {{git_branch}} {{git_repo}} {{files}} {{file_count}} {{os}} {{platform}} {{provider}} {{model}} {{provider_model}} {{resource_dir}} {{handover_dir}} {{handover_path}}",
 			expected: "2026-01-16 2026-01-16 14:30:00 2026-01-16T14:30:00+11:00 14:30 2026 Friday Australia/Sydney AEDT +11:00 2026-01-16 2026-01-16T03:30:00Z /home/user/project project /home/user testuser main term-llm main.go, utils.go 2 linux chat chatgpt gpt-5.4-medium chatgpt:gpt-5.4-medium /home/user/.cache/term-llm/agents/artist /home/user/.local/share/term-llm/handover/project-abc123 /home/user/.local/share/term-llm/handover/project-abc123/2026-01-16-amber-creek-bloom.md",
@@ -279,11 +289,14 @@ func TestNewTemplateContextForTemplate_GitDiffStatTimeoutFailsOpen(t *testing.T)
 }
 
 func TestTemplateVariablesAllowsWhitespace(t *testing.T) {
-	vars := templateVariables("{{ git_repo }}/{{git_branch}} {{ git_diff_stat }} {{ agents }} {{ handover_dir }} {{ handover_path }}")
+	vars := templateVariables("{{ git_repo }}/{{git_branch}} {{ git_diff_stat }} {{ agents }} {{ handover_dir }} {{ handover_path }} {{!date}}")
 	for _, name := range []string{"git_repo", "git_branch", "git_diff_stat", "agents", "handover_dir", "handover_path"} {
 		if !vars[name] {
 			t.Fatalf("templateVariables missing %q in %#v", name, vars)
 		}
+	}
+	if vars["date"] {
+		t.Fatalf("templateVariables should ignore escaped variable {{!date}}: %#v", vars)
 	}
 }
 


### PR DESCRIPTION
## What

Keeps the default generated system prompt and agent-builder guidance cache-stable by recommending date-level context instead of a timestamp with seconds.

Changes the default generated prompt from:

```text
Current local time: {{weekday}} {{datetime_rfc3339}} ({{timezone}}).
```

to:

```text
Current local date: {{weekday}} {{date}} ({{timezone}}).
```

Also adds escaped template variables:

```text
{{!date}} -> {{date}}
```

This lets prompts document template syntax without expanding it in the documenting agent's own system prompt. The agent-builder prompt now uses escaped examples internally, so the model sees literal `{{date}}` / `{{timezone}}` examples instead of the current values.

Agent-builder guidance now says to only add `{{time}}`, `{{datetime_rfc3339}}`, or `{{utc_datetime}}` for agents that genuinely need time-of-day precision, logs, jobs, or cross-timezone coordination.

## Why

The timezone-aware variables from #795 are useful, but using second-level timestamps in always-loaded system prompts creates unnecessary prompt-cache churn. Weekday + local date + timezone is enough for normal day-sensitive reasoning while staying stable for the whole local day.

The first guidance pass also had the classic self-referential template bug: examples like `{{date}}` inside `agent-builder/system.md` are themselves expanded before the agent sees them. Escaping fixes that directly instead of relying on awkward prose workarounds.

## Tests

```text
go test ./internal/agents
```
