### PR TITLE
fix: Telegram stream persistence can stall event ingestion and trip the watchdog

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -31,6 +31,8 @@ const minEditInterval = 3 * time.Second
 
 // defaultStreamEventTimeout is used when telegramSessionMgr.streamEventTimeout is zero.
 const defaultStreamEventTimeout = 10 * time.Minute
+const telegramCallbackStoreQueueSize = 16
+const telegramCallbackStoreDrainTimeout = 250 * time.Millisecond
 
 const telegramMaxConcurrentHandlers = 8
 const telegramMaxPhotoDownloadBytes int64 = 25 << 20
@@ -852,6 +854,67 @@ func closeTelegramSession(sess *telegramSession) {
 	}
 }
 
+type telegramAsyncStoreQueue struct {
+	ops       chan func()
+	pending   sync.WaitGroup
+	closeOnce sync.Once
+}
+
+func newTelegramAsyncStoreQueue() *telegramAsyncStoreQueue {
+	q := &telegramAsyncStoreQueue{
+		ops: make(chan func(), telegramCallbackStoreQueueSize),
+	}
+	go func() {
+		for fn := range q.ops {
+			if fn != nil {
+				fn()
+			}
+		}
+	}()
+	return q
+}
+
+func (q *telegramAsyncStoreQueue) Enqueue(fn func()) {
+	if q == nil || fn == nil {
+		return
+	}
+	q.pending.Add(1)
+	q.ops <- func() {
+		defer q.pending.Done()
+		fn()
+	}
+}
+
+func (q *telegramAsyncStoreQueue) Wait(timeout time.Duration) bool {
+	if q == nil {
+		return true
+	}
+	done := make(chan struct{})
+	go func() {
+		q.pending.Wait()
+		close(done)
+	}()
+	if timeout <= 0 {
+		<-done
+		return true
+	}
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (q *telegramAsyncStoreQueue) Close() {
+	if q == nil {
+		return
+	}
+	q.closeOnce.Do(func() {
+		close(q.ops)
+	})
+}
+
 func (m *telegramSessionMgr) runStoreOp(ctx context.Context, sessionID, op string, fn func(context.Context) error) {
 	if m.store == nil || fn == nil {
 		return
@@ -1268,6 +1331,12 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		})
 	}
 
+	var callbackStoreQueue *telegramAsyncStoreQueue
+	if m.store != nil && sess.meta != nil {
+		callbackStoreQueue = newTelegramAsyncStoreQueue()
+		defer callbackStoreQueue.Close()
+	}
+
 	// Collect assistant and tool-result messages via callbacks.
 	// ResponseCompletedCallback captures assistant messages (with tool call parts)
 	// before tool execution. TurnCompletedCallback captures tool results after
@@ -1282,10 +1351,12 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		produced = append(produced, assistantMsg)
 		assistantCapturedForTurnCB = true
 		producedMu.Unlock()
-		if m.store != nil && sess.meta != nil {
+		if callbackStoreQueue != nil {
 			sessionMsg := session.NewMessage(sess.meta.ID, assistantMsg, -1)
-			m.runStoreOp(cbCtx, sess.meta.ID, "AddMessage(response)", func(storeCtx context.Context) error {
-				return m.store.AddMessage(storeCtx, sess.meta.ID, sessionMsg)
+			callbackStoreQueue.Enqueue(func() {
+				m.runStoreOpWithoutCancel(cbCtx, sess.meta.ID, "AddMessage(response)", func(storeCtx context.Context) error {
+					return m.store.AddMessage(storeCtx, sess.meta.ID, sessionMsg)
+				})
 			})
 		}
 		return nil
@@ -1302,23 +1373,29 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		}
 		assistantCapturedForTurnCB = false
 		producedMu.Unlock()
-		if m.store != nil && sess.meta != nil {
-			for _, msg := range msgs[appendStart:] {
-				sessionMsg := session.NewMessage(sess.meta.ID, msg, -1)
-				m.runStoreOp(cbCtx, sess.meta.ID, "AddMessage(turn)", func(storeCtx context.Context) error {
-					return m.store.AddMessage(storeCtx, sess.meta.ID, sessionMsg)
-				})
-			}
-			m.runStoreOp(cbCtx, sess.meta.ID, "UpdateMetrics", func(storeCtx context.Context) error {
-				return m.store.UpdateMetrics(storeCtx, sess.meta.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
-			})
-			if total, count := sess.runtime.Engine.ContextEstimateBaseline(); total > 0 && count > 0 {
+		if callbackStoreQueue != nil {
+			persistMsgs := append([]llm.Message(nil), msgs[appendStart:]...)
+			total, count := sess.runtime.Engine.ContextEstimateBaseline()
+			if total > 0 && count > 0 {
 				sess.meta.LastTotalTokens = total
 				sess.meta.LastMessageCount = count
-				m.runStoreOp(cbCtx, sess.meta.ID, "UpdateContextEstimate", func(storeCtx context.Context) error {
-					return m.store.UpdateContextEstimate(storeCtx, sess.meta.ID, total, count)
-				})
 			}
+			callbackStoreQueue.Enqueue(func() {
+				for _, msg := range persistMsgs {
+					sessionMsg := session.NewMessage(sess.meta.ID, msg, -1)
+					m.runStoreOpWithoutCancel(cbCtx, sess.meta.ID, "AddMessage(turn)", func(storeCtx context.Context) error {
+						return m.store.AddMessage(storeCtx, sess.meta.ID, sessionMsg)
+					})
+				}
+				m.runStoreOpWithoutCancel(cbCtx, sess.meta.ID, "UpdateMetrics", func(storeCtx context.Context) error {
+					return m.store.UpdateMetrics(storeCtx, sess.meta.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
+				})
+				if total > 0 && count > 0 {
+					m.runStoreOpWithoutCancel(cbCtx, sess.meta.ID, "UpdateContextEstimate", func(storeCtx context.Context) error {
+						return m.store.UpdateContextEstimate(storeCtx, sess.meta.ID, total, count)
+					})
+				}
+			})
 		}
 		return nil
 	})
@@ -1698,6 +1775,9 @@ loop:
 		if !streamDoneDrained {
 			<-streamDone
 		}
+		if callbackStoreQueue != nil && !callbackStoreQueue.Wait(telegramCallbackStoreDrainTimeout) {
+			log.Printf("[telegram] callback persistence still busy for %s after interrupt; continuing with fallback", sessionID)
+		}
 
 		textMu.Lock()
 		partial := textBuf.String()
@@ -1733,6 +1813,9 @@ loop:
 	}
 
 	if streamErr != nil {
+		if callbackStoreQueue != nil && !callbackStoreQueue.Wait(telegramCallbackStoreDrainTimeout) {
+			log.Printf("[telegram] callback persistence still busy for %s after stream error; continuing with fallback", sessionID)
+		}
 		salvagePartialHistory(streamCtx, "AddMessage(assistant_error_fallback)")
 		if strings.Contains(streamErr.Error(), "stream timed out") {
 			_, _ = bot.Send(tgbotapi.NewMessage(chatID, "⌛ Response timed out — please try again."))

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -108,6 +108,31 @@ func (f *fakeBotSender) allTexts() []string {
 	return out
 }
 
+type blockingAssistantStore struct {
+	*session.NoopStore
+	startOnce sync.Once
+	started   chan struct{}
+	release   chan struct{}
+}
+
+func newBlockingAssistantStore() *blockingAssistantStore {
+	return &blockingAssistantStore{
+		NoopStore: &session.NoopStore{},
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+}
+
+func (s *blockingAssistantStore) AddMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	if msg != nil && msg.Role == llm.RoleAssistant {
+		s.startOnce.Do(func() {
+			close(s.started)
+		})
+		<-s.release
+	}
+	return nil
+}
+
 type blockingTextProvider struct {
 	text           string
 	firstChunkSent chan struct{}
@@ -1927,6 +1952,66 @@ func TestStreamReply_WatchdogTimeoutIsNotTreatedAsUserInterrupt(t *testing.T) {
 	sess.mu.Unlock()
 	if historyLen != 2 {
 		t.Fatalf("watchdog timeout should not persist partial history; got %d messages", historyLen)
+	}
+}
+
+func TestStreamReply_CallbackPersistenceDoesNotBlockToolProgress(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	slowTool := testutil.NewMockToolWithSchema(
+		"slow_tool",
+		"mock slow tool",
+		map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{},
+		},
+		func(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+			select {
+			case <-ctx.Done():
+				return llm.ToolOutput{}, ctx.Err()
+			case <-time.After(30 * time.Millisecond):
+				return llm.TextOutput("tool output"), nil
+			}
+		},
+	)
+	h.AddTool(slowTool)
+	h.Provider.AddToolCall("call-1", "slow_tool", map[string]any{})
+	h.Provider.AddTextResponse("done")
+
+	mgr, sess := newTestMgrAndSession(h)
+	mgr.streamEventTimeout = 100 * time.Millisecond
+	store := newBlockingAssistantStore()
+	mgr.store = store
+	bot := &fakeBotSender{}
+	sess.meta = &session.Session{ID: "sess-1"}
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("run tool"))
+	}()
+
+	select {
+	case <-store.started:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for assistant persistence to block")
+	}
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Fatalf("streamReply returned error while assistant persistence was blocked: %v", err)
+		}
+	case <-time.After(400 * time.Millisecond):
+		t.Fatal("streamReply did not complete while assistant persistence was blocked")
+	}
+
+	close(store.release)
+	if slowTool.InvocationCount() != 1 {
+		t.Fatalf("expected tool to run once, got %d", slowTool.InvocationCount())
+	}
+	for _, text := range bot.allTexts() {
+		if strings.Contains(text, "Response timed out") {
+			t.Fatalf("unexpected timeout message with blocked callback persistence: %v", bot.allTexts())
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- moved Telegram response/turn callback persistence off the callback hot path into a small per-stream async queue
- kept callback writes serialized so assistant/tool-result message ordering is preserved
- retained bounded `runStoreOpWithoutCancel` persistence for queued callback writes
- added a regression test that blocks assistant `AddMessage` persistence and verifies the stream still completes instead of timing out before tool progress can continue
- on interrupt/error paths, added a short best-effort drain before fallback persistence so already-queued callback writes get a chance to land first

## Why this is high-value

Telegram streaming callbacks were doing session store writes inline. If assistant persistence stalled inside `AddMessage`/`UpdateMetrics`, the engine could stop advancing before the next tool-progress event reached the Telegram watchdog path. That turns a local persistence stall into a user-visible `stream timed out` failure and truncated replies.

This fix isolates persistence from event ingestion with the smallest targeted change in `internal/serve/telegram.go`, so slow or stuck store writes no longer directly block stream/tool progress.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./...`
- added `TestStreamReply_CallbackPersistenceDoesNotBlockToolProgress` covering the blocked-persistence failure mode
