### PR TITLE
fix: AddMessage still loses messages on concurrent sequence conflicts

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -1787,6 +1787,62 @@ func (s *SQLiteStore) Search(ctx context.Context, opts SearchOptions) ([]SearchR
 	return results, rows.Err()
 }
 
+// addMessageQueryer is the subset of *sql.Tx/*sql.Conn used by AddMessage.
+type addMessageQueryer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (s *SQLiteStore) addMessageInTx(ctx context.Context, q addMessageQueryer, sessionID string, msg *Message, partsJSON string, autoSequence bool) error {
+	// Auto-allocate sequence if not specified (Sequence < 0)
+	if autoSequence {
+		var maxSeq sql.NullInt64
+		err := q.QueryRowContext(ctx,
+			`SELECT MAX(sequence) FROM messages WHERE session_id = ?`,
+			sessionID).Scan(&maxSeq)
+		if err != nil {
+			return fmt.Errorf("get max sequence: %w", err)
+		}
+		if maxSeq.Valid {
+			msg.Sequence = int(maxSeq.Int64) + 1
+		} else {
+			msg.Sequence = 0
+		}
+	}
+
+	result, err := q.ExecContext(ctx, `
+		INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence, msg.CompactionTail)
+	if err != nil {
+		return fmt.Errorf("insert message: %w", err)
+	}
+
+	// Get the inserted ID
+	id, _ := result.LastInsertId()
+	msg.ID = id
+
+	// Update session's updated_at. Preserve the existing sidebar activity
+	// semantics here: user/assistant role rows bump last_message_at, while
+	// tool/developer/system/event rows do not. message_count is maintained by
+	// triggers with the stricter chat-bubble predicate above, so tool-call-only
+	// assistant rows may affect activity ordering without increasing the count.
+	bumpLastMessageAt := s.hasLastMessageAt && !msg.CompactionTail && (msg.Role == "user" || msg.Role == "assistant")
+	if bumpLastMessageAt {
+		_, err = q.ExecContext(ctx,
+			"UPDATE sessions SET updated_at = ?, last_message_at = ? WHERE id = ?",
+			time.Now(), msg.CreatedAt, sessionID)
+	} else {
+		_, err = q.ExecContext(ctx, "UPDATE sessions SET updated_at = ? WHERE id = ?",
+			time.Now(), sessionID)
+	}
+	if err != nil {
+		return fmt.Errorf("update session timestamp: %w", err)
+	}
+
+	return nil
+}
+
 // AddMessage adds a message to a session.
 // If msg.Sequence < 0, the sequence number is auto-allocated atomically.
 func (s *SQLiteStore) AddMessage(ctx context.Context, sessionID string, msg *Message) error {
@@ -1803,59 +1859,47 @@ func (s *SQLiteStore) AddMessage(ctx context.Context, sessionID string, msg *Mes
 	// Track whether we need to auto-allocate sequence
 	autoSequence := msg.Sequence < 0
 
-	// Retry the entire transaction on SQLITE_BUSY
+	// Retry the entire transaction on SQLITE_BUSY. Auto-sequenced inserts use
+	// BEGIN IMMEDIATE so only one writer can allocate the next sequence at a
+	// time, avoiding read→write upgrade conflicts under concurrent appends.
 	return retryOnBusy(ctx, 5, func() error {
-		// Use transaction for atomic sequence allocation
+		if autoSequence {
+			conn, err := s.db.Conn(ctx)
+			if err != nil {
+				return fmt.Errorf("acquire transaction connection: %w", err)
+			}
+			defer conn.Close()
+
+			if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+				return fmt.Errorf("begin immediate transaction: %w", err)
+			}
+			committed := false
+			defer func() {
+				if !committed {
+					_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+				}
+			}()
+
+			if err := s.addMessageInTx(ctx, conn, sessionID, msg, partsJSON, autoSequence); err != nil {
+				return err
+			}
+
+			if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+				return fmt.Errorf("commit transaction: %w", err)
+			}
+			committed = true
+			return nil
+		}
+
+		// Use transaction for explicit sequence inserts.
 		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("begin transaction: %w", err)
 		}
 		defer tx.Rollback()
 
-		// Auto-allocate sequence if not specified (Sequence < 0)
-		if autoSequence {
-			var maxSeq sql.NullInt64
-			err = tx.QueryRowContext(ctx,
-				`SELECT MAX(sequence) FROM messages WHERE session_id = ?`,
-				sessionID).Scan(&maxSeq)
-			if err != nil {
-				return fmt.Errorf("get max sequence: %w", err)
-			}
-			if maxSeq.Valid {
-				msg.Sequence = int(maxSeq.Int64) + 1
-			} else {
-				msg.Sequence = 0
-			}
-		}
-
-		result, err := tx.ExecContext(ctx, `
-			INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence, msg.CompactionTail)
-		if err != nil {
-			return fmt.Errorf("insert message: %w", err)
-		}
-
-		// Get the inserted ID
-		id, _ := result.LastInsertId()
-		msg.ID = id
-
-		// Update session's updated_at. Preserve the existing sidebar activity
-		// semantics here: user/assistant role rows bump last_message_at, while
-		// tool/developer/system/event rows do not. message_count is maintained by
-		// triggers with the stricter chat-bubble predicate above, so tool-call-only
-		// assistant rows may affect activity ordering without increasing the count.
-		bumpLastMessageAt := s.hasLastMessageAt && !msg.CompactionTail && (msg.Role == "user" || msg.Role == "assistant")
-		if bumpLastMessageAt {
-			_, err = tx.ExecContext(ctx,
-				"UPDATE sessions SET updated_at = ?, last_message_at = ? WHERE id = ?",
-				time.Now(), msg.CreatedAt, sessionID)
-		} else {
-			_, err = tx.ExecContext(ctx, "UPDATE sessions SET updated_at = ? WHERE id = ?",
-				time.Now(), sessionID)
-		}
-		if err != nil {
-			return fmt.Errorf("update session timestamp: %w", err)
+		if err := s.addMessageInTx(ctx, tx, sessionID, msg, partsJSON, autoSequence); err != nil {
+			return err
 		}
 
 		if err := tx.Commit(); err != nil {

--- a/internal/session/update_message_test.go
+++ b/internal/session/update_message_test.go
@@ -270,3 +270,61 @@ func TestSQLiteStoreUpdateMessageConcurrent(t *testing.T) {
 		t.Errorf("final text = %q, want %q", msgs[0].Parts[0].Text, "concurrent")
 	}
 }
+
+// TestSQLiteStoreAddMessageConcurrentAutoSequence verifies that concurrent
+// auto-sequenced appends to the same session do not lose messages or leak
+// SQLITE_BUSY errors under contention.
+func TestSQLiteStoreAddMessageConcurrentAutoSequence(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	const workers = 24
+	const rounds = 25
+
+	for round := 0; round < rounds; round++ {
+		start := make(chan struct{})
+		errs := make(chan error, workers)
+		var wg sync.WaitGroup
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				msg := NewMessage(sess.ID, llm.UserText("concurrent"), -1)
+				errs <- store.AddMessage(ctx, sess.ID, msg)
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("round %d AddMessage error: %v", round, err)
+			}
+		}
+	}
+
+	msgs, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if got, want := len(msgs), workers*rounds; got != want {
+		t.Fatalf("message count = %d, want %d", got, want)
+	}
+	for i, msg := range msgs {
+		if msg.Sequence != i {
+			t.Fatalf("message[%d] sequence = %d, want %d", i, msg.Sequence, i)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- changed `SQLiteStore.AddMessage` so auto-sequenced appends run inside `BEGIN IMMEDIATE` on a pinned connection before reading `MAX(sequence)`
- factored the shared insert/session-timestamp logic into a small helper used by both the auto-sequence and explicit-sequence paths
- added `TestSQLiteStoreAddMessageConcurrentAutoSequence`, a same-session concurrent append stress test that verifies all messages persist with contiguous sequences and no leaked `SQLITE_BUSY` errors

## Why this is high-value

`AddMessage` is on the live persistence path for chat history. Under concurrent appends to the same session, the old deferred transaction could let multiple writers read the same max sequence and then fail during the read→write upgrade window, which I reproduced as escaped `database is locked` / `SQLITE_BUSY` errors. When that happens, a user/assistant/tool message is dropped entirely.

Starting the transaction with `BEGIN IMMEDIATE` moves writer serialization to the start of allocation, so only one writer can reserve the next sequence at a time and the append either waits/retries cleanly or succeeds without losing a message.

## Validation

- `gofmt -w internal/session/sqlite.go internal/session/update_message_test.go`
- `go build ./...`
- `go test ./internal/session -run TestSQLiteStoreAddMessageConcurrentAutoSequence -count=3`
- `go test ./...`
- `git diff --check`
