### PR TITLE
fix: polish file change tracking UI

### DIFF
--- a/cmd/serve_file_changes_test.go
+++ b/cmd/serve_file_changes_test.go
@@ -71,6 +71,9 @@ func TestSessionFileChangesEndpoints(t *testing.T) {
 		if entry["adds"].(float64) != 3 {
 			t.Fatalf("adds = %v, want 3 (cumulative baseline → current)", entry["adds"])
 		}
+		if entry["seq"].(float64) != 2 {
+			t.Fatalf("seq = %v, want latest path sequence 2", entry["seq"])
+		}
 	})
 
 	t.Run("diff", func(t *testing.T) {

--- a/docs-site/content/reference/built-in-tools.md
+++ b/docs-site/content/reference/built-in-tools.md
@@ -22,7 +22,7 @@ term-llm exec --tools read_file,write_file,edit_file,shell,grep,glob,view_image
 | `read_file` | Read file contents (with line ranges) |
 | `write_file` | Create/overwrite files |
 | `edit_file` | Edit existing files |
-| `shell` | Execute shell commands |
+| `shell` | Execute shell commands; accepts optional `affected_paths` hints so file-change tracking can snapshot generated/modified files reliably |
 | `grep` | Search file contents (uses ripgrep) |
 | `glob` | Find files by glob pattern |
 | `view_image` | Display images in terminal (icat) |
@@ -32,6 +32,20 @@ term-llm exec --tools read_file,write_file,edit_file,shell,grep,glob,view_image
 | `spawn_agent` | Spawn child agents for parallel tasks |
 | `run_agent_script` | Run a script bundled in the agent directory |
 | `activate_skill` | Activate a skill by name |
+
+### File-change tracking hints
+
+When [file change tracking](/reference/sessions/#file-change-history/) is enabled, direct write tools (`write_file`, `edit_file`, `unified_diff`) are recorded automatically. The `shell` tool can also record files it creates, modifies, or deletes. For shell commands that generate files, pass `affected_paths` so term-llm can snapshot exactly what matters before and after the command:
+
+```json
+{
+  "command": "npm run build",
+  "working_dir": "/path/to/project",
+  "affected_paths": ["dist/**", "package-lock.json"]
+}
+```
+
+Hints may be files or glob patterns, relative to `working_dir` or absolute. Without hints, shell tracking falls back to `git status` in repositories and files already touched by the session, which is useful but intentionally best-effort.
 
 ### Custom Tools
 

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -242,6 +242,14 @@ file_tracking:
 
 Opt-in. When enabled, term-llm records the before/after contents of files that agent tools create, modify, or delete, so the web UI can show a live per-session diff sidebar.
 
+Enable it with:
+
+```bash
+term-llm config set file_tracking.enabled true
+```
+
+or by adding the YAML above to your config file.
+
 **Privacy note:** this persists actual file contents (not just paths) to a local SQLite database at `~/.local/share/term-llm/file_history.db`, separate from `sessions.db`. Contents are gzip-compressed and content-addressed. Files larger than `max_file_bytes`, binary files, and changes beyond the per-session budget are recorded as metadata only ("content not retained"). History for deleted sessions is swept on startup, following `sessions.max_age_days`; if the database still exceeds `max_total_bytes`, the least recently changed sessions' history is pruned until it fits.
 
 Shell-made changes are tracked best-effort: commands that declare an `affected_paths` hint are snapshotted precisely; otherwise term-llm relies on `git status` (when inside a repository) and re-checking files the session already touched. Broad scripts writing to non-git directories without a hint may not appear in the diff sidebar.

--- a/docs-site/content/reference/sessions.md
+++ b/docs-site/content/reference/sessions.md
@@ -54,6 +54,35 @@ term-llm chat --no-session
 term-llm ask --session-db /tmp/term-llm.db ...
 ```
 
+## File change history
+
+When `file_tracking.enabled` is true, term-llm records file changes made by agent tools and exposes them in the web UI as a per-session **Changes** panel. The panel opens automatically on wide screens when the active session changes files; on narrower screens it stays behind the file-changes button so it does not crush the chat column.
+
+```yaml
+file_tracking:
+  enabled: true
+```
+
+Tracked changes include:
+
+- `write_file`, `edit_file`, and `unified_diff` writes
+- files created, modified, or deleted by `shell` commands when they are detectable
+- cumulative before/after diffs for the session, not just the last tool call
+
+Shell tracking is best with explicit `affected_paths` hints:
+
+```json
+{
+  "command": "go generate ./...",
+  "working_dir": "/path/to/repo",
+  "affected_paths": ["**/*.go", "go.mod", "go.sum"]
+}
+```
+
+Without hints, term-llm falls back to `git status` in repositories and to paths already touched in the session. That catches common repo work, but broad scripts writing outside git need hints if you want reliable history.
+
+The file-change store keeps actual file contents, subject to the configured byte caps. Large files, binary files, and over-budget sessions are still listed as metadata-only changes, but their full diffs are not retained. See [Configuration](/reference/configuration/#file-change-tracking-config/) for retention and privacy details.
+
 ## Context compaction
 
 Long sessions do not keep sending the entire transcript forever. When `auto_compact` is enabled (the default) and term-llm knows the model's input limit, the engine tracks an estimated prompt size and compacts before the active context would grow too large.

--- a/internal/filetrack/store.go
+++ b/internal/filetrack/store.go
@@ -83,6 +83,7 @@ type CumulativeChange struct {
 	Adds      int    `json:"adds"`
 	Dels      int    `json:"dels"`
 	Truncated bool   `json:"truncated"`
+	Seq       int64  `json:"seq"` // latest change sequence for this path in the session
 }
 
 // FileDiffContent holds the baseline and current contents for one file.
@@ -493,11 +494,12 @@ type pathSpan struct {
 	firstBeforeHash string
 	lastKind        string
 	lastAfterHash   string
+	lastSeq         int64
 }
 
 func (s *Store) sessionSpans(ctx context.Context, sessionID string) ([]*pathSpan, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT path, kind, COALESCE(before_hash, ''), COALESCE(after_hash, '')
+		SELECT seq, path, kind, COALESCE(before_hash, ''), COALESCE(after_hash, '')
 		FROM file_changes WHERE session_id = ? ORDER BY seq`, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("query session changes: %w", err)
@@ -507,8 +509,9 @@ func (s *Store) sessionSpans(ctx context.Context, sessionID string) ([]*pathSpan
 	spans := make(map[string]*pathSpan)
 	var order []string
 	for rows.Next() {
+		var seq int64
 		var path, kind, beforeHash, afterHash string
-		if err := rows.Scan(&path, &kind, &beforeHash, &afterHash); err != nil {
+		if err := rows.Scan(&seq, &path, &kind, &beforeHash, &afterHash); err != nil {
 			return nil, err
 		}
 		path = normalizePath(path)
@@ -523,6 +526,7 @@ func (s *Store) sessionSpans(ctx context.Context, sessionID string) ([]*pathSpan
 		}
 		span.lastKind = kind
 		span.lastAfterHash = afterHash
+		span.lastSeq = seq
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -583,7 +587,7 @@ func (s *Store) ListSessionChanges(ctx context.Context, sessionID string) ([]Cum
 			continue
 		}
 
-		change := CumulativeChange{Path: sp.path, Kind: kind}
+		change := CumulativeChange{Path: sp.path, Kind: kind, Seq: sp.lastSeq}
 		needBefore, needAfter := blobsNeeded(kind)
 
 		var before, after []byte

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -55,6 +55,8 @@ const isDiffDrawerViewport = () => {
   }
 };
 
+const currentDiffState = () => (state.activeSessionId ? diffStateBySession.get(state.activeSessionId) || null : null);
+
 // ===== Pure model building (node-tested) =====
 
 // buildDiffRowModel flattens server hunks into renderable rows with old/new
@@ -190,7 +192,7 @@ const fetchSessionFileChanges = async (sessionId) => {
         adds: Number(entry.adds) || 0,
         dels: Number(entry.dels) || 0,
         truncated: Boolean(entry.truncated),
-        lastSeq: prev?.lastSeq || 0
+        lastSeq: Number(entry.seq) || prev?.lastSeq || 0
       });
     });
     ds.files.forEach((entry, path) => {
@@ -281,8 +283,8 @@ const applyDiffSidebarVisibility = (ds) => {
     } else {
       elements.diffSidebar.setAttribute?.('hidden', '');
       elements.diffSidebar.hidden = true;
-      elements.diffSidebar.classList.remove('open');
     }
+    if (!drawer || !hasChanges) elements.diffSidebar.classList.remove('open');
   }
   elements.appShell?.classList.toggle('diff-open', visible);
 
@@ -290,6 +292,7 @@ const applyDiffSidebarVisibility = (ds) => {
     elements.diffToggleBtn.hidden = !hasChanges;
     if (hasChanges) elements.diffToggleBtn.removeAttribute?.('hidden');
     else elements.diffToggleBtn.setAttribute?.('hidden', '');
+    elements.diffToggleBtn.classList.toggle('active', visible || (drawer && elements.diffSidebar?.classList.contains('open')));
   }
 };
 
@@ -647,8 +650,49 @@ const initDiffResize = () => {
   handle.addEventListener('pointercancel', finishDrag);
 };
 
+const isInsideDiffResizeHandle = (target) => {
+  let node = target;
+  while (node) {
+    if (node === elements.diffResizeHandle || node.classList?.contains?.('diff-resize-handle')) return true;
+    node = node.parentNode;
+  }
+  return false;
+};
+
+const initDiffCloseGesture = () => {
+  const panel = elements.diffSidebar;
+  if (!panel?.addEventListener) return;
+  let startX = 0;
+  let startY = 0;
+  let tracking = false;
+
+  panel.addEventListener('pointerdown', (event) => {
+    if (!isDiffDrawerViewport()) return;
+    if (!panel.classList.contains('open')) return;
+    if (isInsideDiffResizeHandle(event.target)) return;
+    startX = Number(event.clientX) || 0;
+    startY = Number(event.clientY) || 0;
+    tracking = true;
+  });
+
+  panel.addEventListener('pointerup', (event) => {
+    if (!tracking) return;
+    tracking = false;
+    const dx = (Number(event.clientX) || 0) - startX;
+    const dy = Math.abs((Number(event.clientY) || 0) - startY);
+    // Right-side drawer: a decisive rightward swipe closes it. Keep the
+    // threshold high enough that ordinary vertical diff scrolling is ignored.
+    if (dx > 70 && dx > dy * 1.4) closeDiffDrawer();
+  });
+
+  panel.addEventListener('pointercancel', () => {
+    tracking = false;
+  });
+};
+
 restoreDiffSidebarWidth();
 initDiffResize();
+initDiffCloseGesture();
 
 // Fresh page load: session switches activate the sidebar, but the boot path
 // never goes through switchToSession. This script loads last, after app-core
@@ -659,6 +703,41 @@ if (state.activeSessionId && !state.draftSessionActive) {
 }
 
 // ===== Wiring =====
+
+const handleDiffViewportChange = () => {
+  const ds = currentDiffState();
+  if (!ds) {
+    elements.appShell?.classList.remove('diff-open');
+    elements.diffSidebar?.classList.remove('open');
+    return;
+  }
+
+  // Drawer mode (narrow) and grid-column mode (wide) use different visibility
+  // mechanics. Re-apply immediately when crossing the breakpoint so a drawer
+  // opened on mobile becomes a real column on desktop, and a desktop column
+  // becomes a closed drawer instead of lingering in an in-between state.
+  if (!isDiffDrawerViewport()) {
+    elements.diffSidebar?.classList.remove('open');
+  }
+  renderDiffSidebar(state.activeSessionId);
+  if (!ds.hidden) scheduleDiffRefresh(state.activeSessionId);
+};
+
+const diffViewportMedia = (() => {
+  try {
+    return typeof window.matchMedia === 'function' ? window.matchMedia('(max-width: 1099px)') : null;
+  } catch {
+    return null;
+  }
+})();
+if (diffViewportMedia) {
+  if (typeof diffViewportMedia.addEventListener === 'function') {
+    diffViewportMedia.addEventListener('change', handleDiffViewportChange);
+  } else if (typeof diffViewportMedia.addListener === 'function') {
+    diffViewportMedia.addListener(handleDiffViewportChange);
+  }
+}
+window.addEventListener?.('resize', handleDiffViewportChange);
 
 elements.diffToggleBtn?.addEventListener?.('click', toggleDiffSidebar);
 elements.diffSidebarCloseBtn?.addEventListener?.('click', () => {

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -475,9 +475,33 @@
 
     .diff-toggle {
       position: relative;
-      margin-left: 0.4rem;
+      margin-left: 0.45rem;
       width: auto;
-      padding: 0 0.5rem;
+      min-width: 42px;
+      height: 32px;
+      padding: 0 0.42rem;
+      gap: 0.28rem;
+      border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+      background: linear-gradient(135deg,
+        color-mix(in srgb, var(--accent) 16%, var(--surface-2)),
+        color-mix(in srgb, var(--accent-strong) 10%, var(--surface)));
+      color: var(--text);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 1px 2px rgba(0, 0, 0, 0.12);
+    }
+
+    .diff-toggle:hover,
+    .diff-toggle.active {
+      border-color: color-mix(in srgb, var(--accent) 70%, var(--border-strong));
+      background: linear-gradient(135deg,
+        color-mix(in srgb, var(--accent) 24%, var(--surface-3)),
+        color-mix(in srgb, var(--accent-strong) 16%, var(--surface-2)));
+      color: var(--text);
+    }
+
+    .diff-toggle svg {
+      width: 15px;
+      height: 15px;
+      stroke-width: 2.2;
     }
 
     /* .icon-btn sets display:inline-flex, which defeats the UA stylesheet's
@@ -487,10 +511,19 @@
     }
 
     .diff-toggle-badge {
+      min-width: 1.18rem;
+      height: 1.18rem;
+      padding: 0 0.32rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       font-size: 0.68rem;
-      font-weight: 700;
-      color: var(--text-muted);
-      margin-left: 0.2rem;
+      font-weight: 800;
+      line-height: 1;
+      color: var(--btn-accent-text);
+      background: var(--gradient-accent-strong);
+      margin-left: 0;
       font-variant-numeric: tabular-nums;
     }
 
@@ -510,13 +543,43 @@
       .diff-sidebar {
         position: fixed;
         top: var(--app-offset-top);
-        bottom: 0;
+        bottom: auto;
         right: 0;
-        width: min(var(--diff-sidebar-user-width, 440px), 92vw);
+        height: var(--app-height);
+        width: min(440px, calc(100vw - var(--safe-left)), 90vw);
         z-index: 60;
         transform: translateX(100%);
         transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
         box-shadow: none;
+        padding: var(--safe-top) var(--safe-right) var(--safe-bottom) 0;
+        touch-action: pan-y;
+      }
+
+      .diff-sidebar.open::before {
+        content: '›';
+        position: absolute;
+        left: -11px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 22px;
+        height: 54px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--surface-elevated, var(--surface)) 90%, transparent);
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.25rem;
+        font-weight: 700;
+        line-height: 1;
+        box-shadow: var(--shadow-strong);
+        pointer-events: none;
+        opacity: 0.9;
+      }
+
+      .diff-resize-handle {
+        display: none;
       }
 
       .diff-sidebar.open {

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -139,6 +139,28 @@ function createHarness(options = {}) {
       : { file_changes: [] })
   }));
 
+  let drawerMatches = Boolean(options.drawer);
+  const mediaListeners = [];
+  const media = {
+    get matches() { return drawerMatches; },
+    addEventListener(type, listener) { if (type === 'change') mediaListeners.push(listener); },
+    removeEventListener(type, listener) {
+      if (type !== 'change') return;
+      const idx = mediaListeners.indexOf(listener);
+      if (idx !== -1) mediaListeners.splice(idx, 1);
+    },
+    addListener(listener) { mediaListeners.push(listener); },
+    removeListener(listener) {
+      const idx = mediaListeners.indexOf(listener);
+      if (idx !== -1) mediaListeners.splice(idx, 1);
+    }
+  };
+  const windowListeners = new Map();
+  const setDrawer = (value) => {
+    drawerMatches = Boolean(value);
+    mediaListeners.slice().forEach((listener) => listener({ matches: drawerMatches }));
+  };
+
   const app = {
     UI_PREFIX: '/chat',
     STORAGE_KEYS: { diffSidebarWidth: 'term_llm_diff_sidebar_width' },
@@ -153,7 +175,22 @@ function createHarness(options = {}) {
     window: {
       TermLLMApp: app,
       innerWidth: options.innerWidth || 1280,
-      matchMedia: () => ({ matches: Boolean(options.drawer) }),
+      matchMedia: () => media,
+      addEventListener(type, listener) {
+        const listeners = windowListeners.get(type) || [];
+        listeners.push(listener);
+        windowListeners.set(type, listeners);
+      },
+      removeEventListener(type, listener) {
+        const listeners = windowListeners.get(type) || [];
+        const idx = listeners.indexOf(listener);
+        if (idx !== -1) listeners.splice(idx, 1);
+        windowListeners.set(type, listeners);
+      },
+      dispatchEvent(event) {
+        const listeners = windowListeners.get(event?.type || '') || [];
+        listeners.slice().forEach((listener) => listener(event));
+      },
       ...(options.hljs ? { hljs: options.hljs } : {})
     },
     document,
@@ -186,7 +223,7 @@ function createHarness(options = {}) {
     await new Promise((resolve) => setImmediate(resolve));
   };
 
-  return { app, elements, state, localStorage, storage, timers, fetchCalls, flushTimers };
+  return { app, elements, state, localStorage, storage, timers, fetchCalls, flushTimers, setDrawer, media, windowObj: context.window };
 }
 
 async function run(name, fn) {
@@ -438,6 +475,55 @@ async function run(name, fn) {
 
     app.toggleDiffSidebar();
     assert(!elements.diffSidebar.classList.contains('open'), 'second toggle closes the drawer');
+  });
+
+  await run('drawer to wide viewport reopens diff as a grid column', async () => {
+    const { app, elements, setDrawer, flushTimers } = createHarness({ drawer: true });
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/work/a.go', kind: 'create', adds: 3, dels: 0, seq: 1 });
+    await flushTimers();
+
+    assert(elements.diffSidebar.hidden, 'narrow drawer stays closed after live change');
+    assert(!elements.appShell.classList.contains('diff-open'), 'narrow mode does not add a grid column');
+
+    setDrawer(false);
+    assert(!elements.diffSidebar.hidden, 'wide mode reveals the panel');
+    assert(!elements.diffSidebar.classList.contains('open'), 'drawer-open class is cleared in wide mode');
+    assert(elements.appShell.classList.contains('diff-open'), 'wide mode adds the grid diff column');
+  });
+
+  await run('wide to drawer viewport closes column but keeps toggle available', () => {
+    const { app, elements, setDrawer } = createHarness();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/work/a.go', kind: 'create', adds: 3, dels: 0, seq: 1 });
+    assert(!elements.diffSidebar.hidden, 'wide panel starts visible');
+    assert(elements.appShell.classList.contains('diff-open'), 'wide mode has a diff column');
+
+    setDrawer(true);
+    assert(elements.diffSidebar.hidden, 'narrow drawer is closed after crossing breakpoint');
+    assert(!elements.appShell.classList.contains('diff-open'), 'narrow mode removes the grid diff column');
+    assert(!elements.diffToggleBtn.hidden, 'toggle remains available in drawer mode');
+  });
+
+  await run('drawer swipe right closes the diff drawer', async () => {
+    const { app, elements, flushTimers } = createHarness({ drawer: true });
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/work/a.go', kind: 'create', adds: 3, dels: 0, seq: 1 });
+    await flushTimers();
+    app.toggleDiffSidebar();
+    assert(elements.diffSidebar.classList.contains('open'), 'drawer starts open');
+
+    await elements.diffSidebar.dispatchEvent({ type: 'pointerdown', target: elements.diffSidebar, clientX: 120, clientY: 40 });
+    await elements.diffSidebar.dispatchEvent({ type: 'pointerup', target: elements.diffSidebar, clientX: 215, clientY: 48 });
+    assert(!elements.diffSidebar.classList.contains('open'), 'rightward swipe closes drawer');
+  });
+
+  await run('drawer vertical scroll gesture does not close the diff drawer', async () => {
+    const { app, elements, flushTimers } = createHarness({ drawer: true });
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/work/a.go', kind: 'create', adds: 3, dels: 0, seq: 1 });
+    await flushTimers();
+    app.toggleDiffSidebar();
+
+    await elements.diffSidebar.dispatchEvent({ type: 'pointerdown', target: elements.diffSidebar, clientX: 120, clientY: 40 });
+    await elements.diffSidebar.dispatchEvent({ type: 'pointerup', target: elements.diffSidebar, clientX: 150, clientY: 150 });
+    assert(elements.diffSidebar.classList.contains('open'), 'mostly vertical gesture keeps drawer open');
   });
 
   await run('clampDiffWidth bounds the panel width', () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -238,7 +238,7 @@
             <span class="header-tokens" id="headerTokens"></span>
           </div>
           <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v6"/><path d="M9 6l3-3 3 3"/><path d="M12 21v-6"/><path d="M9 18l3 3 3-3"/><line x1="4" y1="12" x2="20" y2="12"/></svg>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 3.5h7l3 3V20a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z"/><path d="M14 3.5V7h3.5"/><path d="M9 12h6"/><path d="M9 15h2"/><path d="M13.5 15H15"/></svg>
             <span class="diff-toggle-badge" id="diffToggleBadge"></span>
           </button>
         </div>


### PR DESCRIPTION
## What

- Expands documentation for opt-in file-change tracking:
  - session docs now describe the Changes panel, retained contents, cumulative diffs, and shell `affected_paths` hints
  - config docs include the `term-llm config set file_tracking.enabled true` enablement path
  - built-in tools docs document shell `affected_paths` for reliable generated-file tracking
- Polishes the file changes button with a clearer document/diff icon, pill badge, active styling, and a less “bolted on by a raccoon” visual treatment.
- Fixes diff panel breakpoint transitions:
  - narrow drawer → wide grid column now re-applies visibility immediately
  - wide grid column → narrow drawer now closes the drawer state cleanly while keeping the toggle available

## Testing

```text
mise x node@24.15.0 -- node internal/serveui/static/app_diffs_test.js
for f in internal/serveui/static/*_test.js; do mise x node@24.15.0 -- node "$f" || exit 1; done
go build ./...
go test ./...
```
