### PR TITLE
fix: show subtle diff stats in changes toggle

### DIFF
--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -371,7 +371,19 @@ const renderDiffTotals = (ds) => {
   if (adds > 0) summary.push(`+${adds}`);
   if (dels > 0) summary.push(`−${dels}`);
   if (elements.diffSidebarTotals) elements.diffSidebarTotals.textContent = summary.join(' ');
-  if (elements.diffToggleBadge) elements.diffToggleBadge.textContent = String(ds.files.size || '');
+  if (elements.diffToggleBadge) {
+    const parts = [];
+    if (adds > 0) parts.push(createEl('span', 'diff-toggle-stat-add', `+${adds}`));
+    if (dels > 0) parts.push(createEl('span', 'diff-toggle-stat-del', `−${dels}`));
+    if (parts.length === 0) parts.push(createEl('span', 'diff-toggle-stat-neutral', String(ds.files.size || '')));
+    elements.diffToggleBadge.replaceChildren(...parts);
+  }
+  if (elements.diffToggleBtn) {
+    const fileCount = ds.files.size || 0;
+    const fileLabel = `${fileCount} changed ${fileCount === 1 ? 'file' : 'files'}`;
+    elements.diffToggleBtn.title = summary.length > 0 ? `${fileLabel} (${summary.join(' ')})` : fileLabel;
+    elements.diffToggleBtn.setAttribute?.('aria-label', `Toggle file changes: ${elements.diffToggleBtn.title}`);
+  }
 };
 
 const renderDiffFileBody = (sessionId, ds, path) => {

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -477,31 +477,25 @@
       position: relative;
       margin-left: 0.45rem;
       width: auto;
-      min-width: 42px;
-      height: 32px;
-      padding: 0 0.42rem;
-      gap: 0.28rem;
-      border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-      background: linear-gradient(135deg,
-        color-mix(in srgb, var(--accent) 16%, var(--surface-2)),
-        color-mix(in srgb, var(--accent-strong) 10%, var(--surface)));
+      min-width: 92px;
+      height: 30px;
+      padding: 0 0.62rem;
+      gap: 0;
+      border-color: var(--border);
+      background: var(--surface-2);
       color: var(--text);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 1px 2px rgba(0, 0, 0, 0.12);
+      box-shadow: var(--shadow-soft);
     }
 
     .diff-toggle:hover,
     .diff-toggle.active {
-      border-color: color-mix(in srgb, var(--accent) 70%, var(--border-strong));
-      background: linear-gradient(135deg,
-        color-mix(in srgb, var(--accent) 24%, var(--surface-3)),
-        color-mix(in srgb, var(--accent-strong) 16%, var(--surface-2)));
+      border-color: var(--border-strong);
+      background: var(--surface-3);
       color: var(--text);
     }
 
     .diff-toggle svg {
-      width: 15px;
-      height: 15px;
-      stroke-width: 2.2;
+      display: none;
     }
 
     /* .icon-btn sets display:inline-flex, which defeats the UA stylesheet's
@@ -511,21 +505,21 @@
     }
 
     .diff-toggle-badge {
-      min-width: 1.18rem;
-      height: 1.18rem;
-      padding: 0 0.32rem;
-      border-radius: 999px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-size: 0.68rem;
+      gap: 0.62rem;
+      font-size: 0.75rem;
       font-weight: 800;
       line-height: 1;
-      color: var(--btn-accent-text);
-      background: var(--gradient-accent-strong);
       margin-left: 0;
       font-variant-numeric: tabular-nums;
+      white-space: nowrap;
     }
+
+    .diff-toggle-stat-add { color: var(--accent-green); }
+    .diff-toggle-stat-del { color: var(--danger); }
+    .diff-toggle-stat-neutral { color: var(--text-muted); }
 
     /* Mid-width viewports: a third grid column would crush the chat column,
        so the diff panel becomes a right-side drawer opened via the toggle.

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -226,6 +226,12 @@ function createHarness(options = {}) {
   return { app, elements, state, localStorage, storage, timers, fetchCalls, flushTimers, setDrawer, media, windowObj: context.window };
 }
 
+function elementText(node) {
+  if (!node) return '';
+  if (!node.children || node.children.length === 0) return node.textContent || '';
+  return node.children.map(elementText).join('');
+}
+
 async function run(name, fn) {
   try {
     await fn();
@@ -273,7 +279,7 @@ async function run(name, fn) {
     assert(elements.appShell.classList.contains('diff-open'), 'grid opens third column');
     assert(!elements.diffToggleBtn.hidden, 'toggle button visible');
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'one file row rendered');
-    assertEqual(elements.diffToggleBadge.textContent, '1', 'badge shows file count');
+    assertEqual(elementText(elements.diffToggleBadge), '+3', 'badge shows diff stat');
   });
 
   await run('stale seq replays are idempotent', () => {
@@ -560,7 +566,7 @@ async function run(name, fn) {
 
     await app.fetchSessionFileChanges('s1');
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'server refresh replaced stale live row instead of adding a duplicate');
-    assertEqual(elements.diffToggleBadge.textContent, '1', 'badge counts unique files');
+    assertEqual(elementText(elements.diffToggleBadge), '−3', 'badge shows cumulative diff stat');
   });
 
   await run('fresh page load activates the sidebar for the restored session', async () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -238,7 +238,6 @@
             <span class="header-tokens" id="headerTokens"></span>
           </div>
           <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 3.5h7l3 3V20a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z"/><path d="M14 3.5V7h3.5"/><path d="M9 12h6"/><path d="M9 15h2"/><path d="M13.5 15H15"/></svg>
             <span class="diff-toggle-badge" id="diffToggleBadge"></span>
           </button>
         </div>


### PR DESCRIPTION
## What

- Replaces the file-change toggle’s icon/count badge with the selected subtle diff-stat pill.
- Shows cumulative `+adds` and `−dels` in the header toggle, using the existing green/red theme colors.
- Falls back to a neutral changed-file count when retained diff stats are unavailable.
- Updates the toggle title / aria-label with changed-file and diff-stat details.

## Why

The previous white square + black count badge looked too much like a notification wart. This version is quieter and more directly communicates the magnitude of the current session diff.

## Testing

```text
for f in internal/serveui/static/*_test.js; do mise x node@24.15.0 -- node "$f" || exit 1; done
go test ./...
go build ./...
```
