### PR TITLE
feat: add term-llm Hub and delegation

### DIFF
--- a/cmd/reload_exec.go
+++ b/cmd/reload_exec.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/samsaffron/term-llm/internal/tools"
 )
 
 // execReload replaces the current process with a fresh instance of the same
@@ -45,5 +47,9 @@ func execReload(sessionID string) error {
 		newArgs = append(newArgs, "--resume="+sessionID)
 	}
 
-	return syscall.Exec(exe, newArgs, os.Environ())
+	// Re-exec'ing the SAME binary: hand back any env-provided hub delegation
+	// token that startup scrubbed from the environment, or the next
+	// generation would silently lose hub access. This env goes only to
+	// ourselves, never to tool subprocesses.
+	return syscall.Exec(exe, newArgs, append(os.Environ(), tools.HubDelegationEnviron()...))
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -64,6 +64,9 @@ var (
 	serveEnableWidgets          bool
 	serveWidgetsDir             string
 	serveResponseTimeout        time.Duration
+	serveHubURL                 string
+	serveHubNodeID              string
+	serveHubNodeName            string
 )
 
 var serveCmd = &cobra.Command{
@@ -142,6 +145,9 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveEnableWidgets, "enable-widgets", false, "Enable local widget apps proxied under {base}/widgets/<mount>/")
 	serveCmd.Flags().StringVar(&serveWidgetsDir, "widgets-dir", "", "Directory containing widget sub-directories (default: ~/.config/term-llm/widgets)")
 	serveCmd.Flags().DurationVar(&serveResponseTimeout, "response-timeout", defaultServeRequestTimeout, "Maximum duration for API/web response runs before timing out")
+	serveCmd.Flags().StringVar(&serveHubURL, "hub-url", "", "URL of the term-llm Hub this node belongs to (renders a Back to Hub link in the web UI)")
+	serveCmd.Flags().StringVar(&serveHubNodeID, "hub-node-id", "", "This node's id on the hub (used with --hub-url)")
+	serveCmd.Flags().StringVar(&serveHubNodeName, "hub-node-name", "", "This node's display name on the hub (used with --hub-url)")
 
 	AddCommonFlags(serveCmd,
 		CommonCoreFlags|CommonSearch|CommonNativeSearch|CommonMaxTurns|CommonAgent,
@@ -549,6 +555,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 				enableWidgets:       serveEnableWidgets,
 				widgetsDir:          serveWidgetsDir,
 				responseTimeout:     responseTimeout,
+				hubURL:              strings.TrimSpace(serveHubURL),
+				hubNodeID:           strings.TrimSpace(serveHubNodeID),
+				hubNodeName:         strings.TrimSpace(serveHubNodeName),
 			},
 			sessionMgr:     sessionMgr,
 			jobsV2:         jobsV2,
@@ -860,6 +869,14 @@ type serveServerConfig struct {
 	enableWidgets       bool
 	widgetsDir          string
 	responseTimeout     time.Duration
+	// hubURL/hubNodeID/hubNodeName describe the term-llm Hub this node
+	// belongs to. When hubURL is set, the web UI gets window.TERM_LLM_HUB and
+	// renders a Back to Hub link. The hub proxy injects the same context
+	// server-side, so these are only needed when a node should be hub-aware
+	// even when opened directly.
+	hubURL      string
+	hubNodeID   string
+	hubNodeName string
 }
 
 // uiRoute returns the base-path with trailing slash, e.g. "/ui/" or "/chat/".

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -67,6 +67,7 @@ var (
 	serveHubURL                 string
 	serveHubNodeID              string
 	serveHubNodeName            string
+	serveHubConnect             string
 )
 
 var serveCmd = &cobra.Command{
@@ -148,6 +149,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveHubURL, "hub-url", "", "URL of the term-llm Hub this node belongs to (renders a Back to Hub link in the web UI)")
 	serveCmd.Flags().StringVar(&serveHubNodeID, "hub-node-id", "", "This node's id on the hub (used with --hub-url)")
 	serveCmd.Flags().StringVar(&serveHubNodeName, "hub-node-name", "", "This node's display name on the hub (used with --hub-url)")
+	serveCmd.Flags().StringVar(&serveHubConnect, "hub-connect", "direct", "Hub connection mode for this node: direct or reverse")
 
 	AddCommonFlags(serveCmd,
 		CommonCoreFlags|CommonSearch|CommonNativeSearch|CommonMaxTurns|CommonAgent,
@@ -229,6 +231,25 @@ func runServe(cmd *cobra.Command, args []string) error {
 	token, tokenSource, err := resolveServeToken(serveToken, os.Getenv("TERM_LLM_SERVE_TOKEN"), requireAuth, generateServeToken)
 	if err != nil {
 		return err
+	}
+
+	serveHubConnect = strings.ToLower(strings.TrimSpace(serveHubConnect))
+	if serveHubConnect == "" {
+		serveHubConnect = "direct"
+	}
+	if serveHubConnect != "direct" && serveHubConnect != "reverse" {
+		return fmt.Errorf("invalid --hub-connect %q (use direct or reverse)", serveHubConnect)
+	}
+
+	// Hub-joined nodes: hand the hub context to in-process tools and jobs-v2
+	// runs so hub_delegate/hub_check_delegation work without extra setup. The
+	// node authenticates to the hub with its own serve token. Explicit
+	// TERM_LLM_HUB_* env (captured and scrubbed at startup) wins — only gaps
+	// are filled — and the token stays in process memory, never in the
+	// process environment, browser-facing config, or injected HTML, so tool
+	// subprocesses (shell/custom/widget/MCP) cannot inherit it.
+	if hubURL, hubNodeID := strings.TrimSpace(serveHubURL), strings.TrimSpace(serveHubNodeID); hubURL != "" && hubNodeID != "" && token != "" {
+		tools.ConfigureHubDelegation(hubURL, hubNodeID, token)
 	}
 
 	ctx, stop := signal.NotifyContext()
@@ -587,6 +608,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 		if err := s.Start(); err != nil {
 			return err
+		}
+
+		if serveHubConnect == "reverse" {
+			hubURL := strings.TrimSpace(serveHubURL)
+			hubNodeID := strings.TrimSpace(serveHubNodeID)
+			if hubURL == "" || hubNodeID == "" || token == "" {
+				return fmt.Errorf("--hub-connect reverse requires --hub-url, --hub-node-id, and a bearer --token")
+			}
+			localBase := localHubConnectBase(serveHost, servePort, serveBasePath)
+			go runHubReverseConnector(ctx, hubURL, hubNodeID, token, localBase, serveBasePath, http.DefaultClient)
+			fmt.Fprintf(cmd.ErrOrStderr(), "hub reverse: connecting %s to %s\n", hubNodeID, hubURL)
 		}
 
 		fmt.Fprintf(cmd.ErrOrStderr(), "term-llm serve listening on http://%s:%d\n", serveHost, servePort)

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -43,7 +43,56 @@ func (s *serveServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+	resp := map[string]any{"status": "ok"}
+	// Identity fields (agent, version, capabilities) are only reported to
+	// trusted callers — a valid bearer token, or any caller when auth is
+	// disabled — so the unauthenticated health probe stays anonymous. The hub
+	// prober sends the node token and uses these for its dashboard.
+	if s.healthIdentityTrusted(r) {
+		resp["agent"] = s.cfg.agentName
+		resp["version"] = Version
+		resp["capabilities"] = s.capabilityList()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// healthIdentityTrusted reports whether the health request may receive node
+// identity fields: either auth is disabled (loopback-only serves), or the
+// request carries the serve's bearer token.
+func (s *serveServer) healthIdentityTrusted(r *http.Request) bool {
+	if !s.cfg.requireAuth {
+		return true
+	}
+	if s.cfg.token == "" {
+		return false
+	}
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(auth, prefix)), []byte(s.cfg.token)) == 1
+}
+
+// capabilityList describes what this serve exposes, for hub discovery.
+func (s *serveServer) capabilityList() []string {
+	caps := []string{}
+	if s.cfg.ui {
+		caps = append(caps, "web")
+	}
+	if s.cfg.api {
+		caps = append(caps, "api")
+	}
+	if s.jobsV2 != nil {
+		caps = append(caps, "jobs")
+	}
+	if s.widgetsMgr != nil {
+		caps = append(caps, "widgets")
+	}
+	if s.webrtcEnabled {
+		caps = append(caps, "voice")
+	}
+	return caps
 }
 
 // uiAssetCacheEntry holds the precomputed ETag and gzip-compressed form of an
@@ -262,6 +311,14 @@ func (s *serveServer) buildIndexHTML() []byte {
 	headSnippet += `<script>window.TERM_LLM_SIDEBAR_SESSIONS=` + string(sidebarEscaped) + `;</script>`
 	agentEscaped, _ := json.Marshal(s.cfg.agentName)
 	headSnippet += `<script>window.TERM_LLM_AGENT_NAME=` + string(agentEscaped) + `;</script>`
+	if s.cfg.hubURL != "" {
+		hubEscaped, _ := json.Marshal(map[string]string{
+			"url":      s.cfg.hubURL,
+			"nodeId":   s.cfg.hubNodeID,
+			"nodeName": s.cfg.hubNodeName,
+		})
+		headSnippet += `<script>window.TERM_LLM_HUB=` + string(hubEscaped) + `;</script>`
+	}
 	if s.cfgRef != nil {
 		if vapidKey := s.cfgRef.Serve.WebPush.VAPIDPublicKey; vapidKey != "" {
 			vapidEscaped, _ := json.Marshal(vapidKey)

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -274,11 +274,7 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 		if n.UsesReverseConnection() {
 			connected, connectedAt, lastSeen := s.reverse.status(n.ID)
 			if connected {
-				view.Status = hub.Status{Reachable: true, State: "connected", LatencyMS: 0, Details: map[string]string{
-					"connection":   "reverse",
-					"connected_at": connectedAt.Format(time.RFC3339),
-					"last_seen":    lastSeen.Format(time.RFC3339),
-				}}
+				view.Status = s.probeReverseNode(probeCtx, n, connectedAt, lastSeen)
 			} else {
 				view.Status = hub.Status{State: "disconnected", Error: "waiting for reverse connection", Details: map[string]string{"connection": "reverse"}}
 			}
@@ -289,6 +285,43 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 		views[i].Diagnostics = hubNodeDiagnostics(nodes[i], views[i], nodes)
 	}
 	return views, err
+}
+
+func (s *hubServer) probeReverseNode(ctx context.Context, n hub.Node, connectedAt, lastSeen time.Time) hub.Status {
+	details := map[string]string{
+		"connection":   "reverse",
+		"connected_at": connectedAt.Format(time.RFC3339),
+		"last_seen":    lastSeen.Format(time.RFC3339),
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://reverse.local"+hubJoinBasePath(n.BasePath, "/healthz"), nil)
+	if err != nil {
+		return hub.Status{Reachable: true, State: "connected", Details: details, Error: err.Error()}
+	}
+	if n.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+n.Token)
+	}
+	start := time.Now()
+	resp, err := s.reverse.do(ctx, n, req)
+	if err != nil {
+		return hub.Status{Reachable: true, State: "connected", LatencyMS: time.Since(start).Milliseconds(), Details: details, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	st := hub.Status{Reachable: true, State: "connected", LatencyMS: time.Since(start).Milliseconds(), Details: details}
+	if resp.StatusCode != http.StatusOK {
+		st.Error = fmt.Sprintf("healthz returned %s", resp.Status)
+		return st
+	}
+	var body struct {
+		Version      string   `json:"version"`
+		Agent        string   `json:"agent"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err == nil {
+		st.Version = body.Version
+		st.Agent = body.Agent
+		st.Capabilities = body.Capabilities
+	}
+	return st
 }
 
 func hubNodeDiagnostics(n hub.Node, view hubNodeView, all []hub.Node) []hubNodeDiagnostic {
@@ -336,24 +369,26 @@ func hubPolicyMismatchDiagnostics(n hub.Node, all []hub.Node) []string {
 		return nil
 	}
 	messages := []string{}
-	for _, target := range all {
-		if target.ID == n.ID || !n.CanDelegateTo(target.ID) {
-			continue
-		}
-		if target.Delegation == nil || !target.Delegation.Enabled {
-			messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node has delegation disabled.", target.ID))
-			continue
-		}
-		if strings.TrimSpace(target.Delegation.Workdir) == "" {
-			messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node has no delegation workdir.", target.ID))
-			continue
-		}
-		acceptFrom := target.Delegation.AcceptFrom
-		if len(acceptFrom) == 0 {
-			acceptFrom = []string{"*"}
-		}
-		if !hubNodeListMatches(acceptFrom, n.ID) {
-			messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node does not accept from %q.", target.ID, n.ID))
+	if len(n.Delegation.To) > 0 {
+		for _, target := range all {
+			if target.ID == n.ID || !n.CanDelegateTo(target.ID) {
+				continue
+			}
+			if target.Delegation == nil || !target.Delegation.Enabled {
+				messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node has delegation disabled.", target.ID))
+				continue
+			}
+			if strings.TrimSpace(target.Delegation.Workdir) == "" {
+				messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node has no delegation workdir.", target.ID))
+				continue
+			}
+			acceptFrom := target.Delegation.AcceptFrom
+			if len(acceptFrom) == 0 {
+				acceptFrom = []string{"*"}
+			}
+			if !hubNodeListMatches(acceptFrom, n.ID) {
+				messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node does not accept from %q.", target.ID, n.ID))
+			}
 		}
 	}
 	if len(n.Delegation.AcceptFrom) > 0 && !hubNodeListMatches(n.Delegation.AcceptFrom, "*") && strings.TrimSpace(n.Delegation.Workdir) != "" {

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -1,0 +1,724 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	htmlpkg "html"
+	"html/template"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/appdata"
+	"github.com/samsaffron/term-llm/internal/hub"
+	"github.com/spf13/cobra"
+)
+
+// hubServer is the `term-llm serve hub` control plane: one pane of glass over
+// heterogeneous term-llm web nodes. Nodes come from pluggable resolvers
+// (static config file, local contain workspaces, a local JSON store fed by
+// the dashboard's Add Node form); the hub dashboard lists them with live
+// health, and /node/<id>/* reverse-proxies each node's full web UI with the
+// node's bearer token injected server-side, so node tokens never reach the
+// browser.
+//
+// Routing is path-based (/node/<id>/...) in v1. The proxy target is resolved
+// per request from the node ID prefix, so a host-based router can later map
+// Host -> node and reuse the same proxy plumbing unchanged.
+//
+// Hub-level authentication is intentionally not implemented yet: the hub
+// refuses to bind beyond loopback. TODO(hub): hub auth (member token ->
+// allowed nodes), node self-registration, and mTLS to nodes.
+type hubServer struct {
+	registry *hub.Registry
+	// store backs the dashboard's Add Node form; nil disables mutation.
+	store  *hub.Store
+	prober *hub.Prober
+	proxy  *httputil.ReverseProxy
+}
+
+func newHubServer(registry *hub.Registry, store *hub.Store) *hubServer {
+	transport := newHubTransport()
+	s := &hubServer{
+		registry: registry,
+		store:    store,
+		prober:   hub.NewProber(transport),
+	}
+	s.proxy = &httputil.ReverseProxy{
+		Rewrite:        hubRewriteProxyRequest,
+		ModifyResponse: hubRebaseProxyResponse,
+		ErrorHandler:   hubProxyErrorHandler,
+		Transport:      transport,
+	}
+	return s
+}
+
+// newHubTransport returns the proxy's HTTP transport with bounded connection
+// and response-header timeouts so a hung node cannot tie up the hub. It
+// deliberately sets NO whole-response deadline: long-lived streams (SSE,
+// WebRTC signalling) must stay open, so only connection establishment and
+// response *headers* are bounded.
+func newHubTransport() *http.Transport {
+	return &http.Transport{
+		// No environment proxy: the hub dials known node hosts directly, and
+		// routing a token-injected request through an HTTP_PROXY would leak
+		// the per-node bearer token to that proxy.
+		Proxy: nil,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	}
+}
+
+// hubProxyTarget carries the per-request reverse-proxy target. It is stashed
+// on the inbound request context by handleNodeProxy and read back in the
+// proxy's Rewrite, ModifyResponse, and ErrorHandler hooks.
+type hubProxyTarget struct {
+	nodeID   string // node ID (for diagnostics and hub context)
+	nodeName string // node display name (for hub context)
+	scheme   string // backend scheme (http or https)
+	host     string // backend host:port
+	path     string // backend path: node base path + remainder
+	token    string // per-node bearer token, injected server-side
+	basePath string // node's baked-in prefix, e.g. /chat ("" when root)
+	mount    string // hub-facing prefix, e.g. /node/<id>
+}
+
+type hubProxyTargetKey struct{}
+
+func withHubProxyTarget(ctx context.Context, t *hubProxyTarget) context.Context {
+	return context.WithValue(ctx, hubProxyTargetKey{}, t)
+}
+
+func hubProxyTargetFrom(ctx context.Context) *hubProxyTarget {
+	t, _ := ctx.Value(hubProxyTargetKey{}).(*hubProxyTarget)
+	return t
+}
+
+// hubNodeView is the public record for one node. It deliberately omits the
+// bearer token: tokens are injected server-side and must never be sent to a
+// hub client.
+type hubNodeView struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Source    string `json:"source"`
+	URL       string `json:"url"`
+	BasePath  string `json:"base_path"`
+	ProxyPath string `json:"proxy_path"`
+	// HasToken reports whether the hub holds a bearer token for this node
+	// (without it, a token-guarded node will answer 401 through the proxy).
+	HasToken bool       `json:"has_token"`
+	Status   hub.Status `json:"status"`
+}
+
+func (s *hubServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHubHealth)
+	mux.HandleFunc("/api/nodes/test", s.handleTestNode)
+	mux.HandleFunc("/api/nodes/", s.handleNodeItem)
+	mux.HandleFunc("/api/nodes", s.handleNodes)
+	mux.HandleFunc("/node/", s.handleNodeProxy)
+	mux.HandleFunc("/", s.handleIndex)
+	return mux
+}
+
+// hubBrowserRequestAllowed rejects cross-site browser requests before the hub
+// exercises any token-injecting authority or mutates its node registry. This is
+// not a replacement for real hub auth, but it closes the obvious loopback CSRF
+// path while v1 is loopback-only. Same-origin proxied node content is still
+// trusted in v1; long-term host-based node isolation should remove that caveat.
+func hubBrowserRequestAllowed(r *http.Request, requireJSON bool) bool {
+	if requireJSON {
+		ct := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
+		if ct == "" || (!strings.HasPrefix(ct, "application/json") && !strings.HasPrefix(ct, "application/merge-patch+json")) {
+			return false
+		}
+	}
+	if site := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site"))); site == "cross-site" || site == "same-site" {
+		return false
+	}
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.EqualFold(u.Host, r.Host)
+}
+
+func (s *hubServer) handleHubHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "role": "hub"})
+}
+
+// collectNodes resolves all nodes and probes them concurrently. Resolver
+// errors are soft: surviving sources still render, the error is reported
+// alongside.
+func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
+	nodes, err := s.registry.Nodes()
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	statuses := s.prober.ProbeAll(probeCtx, nodes)
+	views := make([]hubNodeView, 0, len(nodes))
+	for _, n := range nodes {
+		views = append(views, hubNodeView{
+			ID:        n.ID,
+			Name:      n.Name,
+			Source:    n.Source,
+			URL:       n.URL,
+			BasePath:  n.BasePath,
+			ProxyPath: "/node/" + n.ID + "/",
+			HasToken:  n.Token != "",
+			Status:    statuses[n.ID],
+		})
+	}
+	return views, err
+}
+
+func (s *hubServer) handleNodes(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		views, err := s.collectNodes(r.Context())
+		resp := map[string]any{"nodes": views}
+		if err != nil {
+			resp["resolver_error"] = err.Error()
+		}
+		writeJSON(w, http.StatusOK, resp)
+	case http.MethodPost:
+		if !hubBrowserRequestAllowed(r, true) {
+			http.Error(w, "forbidden cross-site hub request", http.StatusForbidden)
+			return
+		}
+		s.handleAddNode(w, r)
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// addNodeRequest is the Add Node form payload. Token is accepted here (over
+// the loopback-only hub) and persisted to the 0600 local store; it is never
+// echoed back.
+type addNodeRequest struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	BasePath string `json:"base_path"`
+	Token    string `json:"token"`
+}
+
+func (s *hubServer) handleAddNode(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "node persistence is disabled", http.StatusForbidden)
+		return
+	}
+	var req addNodeRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	node, err := s.store.Add(hub.Node{
+		ID:       strings.TrimSpace(req.ID),
+		Name:     strings.TrimSpace(req.Name),
+		URL:      req.URL,
+		BasePath: strings.TrimSpace(req.BasePath),
+		Token:    strings.TrimSpace(req.Token),
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// Pre-existing config/contain nodes win registry precedence; warn the
+	// caller when the stored node is shadowed by an identical ID elsewhere.
+	if existing, ok := s.registry.Lookup(node.ID); ok && existing.Source != hub.SourceLocal {
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"id":      node.ID,
+			"warning": fmt.Sprintf("node id %q is shadowed by a %s node with the same id", node.ID, existing.Source),
+		})
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"id": node.ID})
+}
+
+// handleNodeItem handles DELETE /api/nodes/<id> (local-store nodes only).
+func (s *hubServer) handleNodeItem(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/nodes/")
+	if id == "" || strings.Contains(id, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodDelete {
+		w.Header().Set("Allow", "DELETE")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !hubBrowserRequestAllowed(r, false) {
+		http.Error(w, "forbidden cross-site hub request", http.StatusForbidden)
+		return
+	}
+	if s.store == nil {
+		http.Error(w, "node persistence is disabled", http.StatusForbidden)
+		return
+	}
+	if err := s.store.Remove(id); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"removed": id})
+}
+
+// handleTestNode probes an ad-hoc node spec (the Add Node form's Test
+// connection button) without persisting anything. The supplied token is used
+// for the probe only and never stored or echoed.
+func (s *hubServer) handleTestNode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !hubBrowserRequestAllowed(r, true) {
+		http.Error(w, "forbidden cross-site hub request", http.StatusForbidden)
+		return
+	}
+	var req addNodeRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	n := hub.Node{ID: "test", Name: "test", URL: req.URL, BasePath: strings.TrimSpace(req.BasePath), Token: strings.TrimSpace(req.Token)}
+	if err := n.Normalize(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	writeJSON(w, http.StatusOK, map[string]any{"status": s.prober.Probe(ctx, n)})
+}
+
+// The dashboard markup and styles live in editable .html/.css files so they
+// keep editor support while the hub stays a single go:embed binary, matching
+// the serveui convention. The CSS is inlined as template.CSS so the page is
+// self-contained (no extra stylesheet request).
+//
+//go:embed templates/hub_index.html
+var hubIndexHTML string
+
+//go:embed templates/hub.css
+var hubIndexCSS string
+
+var hubIndexTmpl = template.Must(template.New("hub-index").Parse(hubIndexHTML))
+
+type hubIndexView struct {
+	CSS template.CSS
+	// CanAddNodes toggles the Add Node UI.
+	CanAddNodes bool
+}
+
+func (s *hubServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// Headers are committed if Execute fails mid-stream; nothing useful to
+	// surface to the client at that point.
+	_ = hubIndexTmpl.Execute(w, hubIndexView{
+		CSS:         template.CSS(hubIndexCSS),
+		CanAddNodes: s.store != nil,
+	})
+}
+
+func (s *hubServer) handleNodeProxy(w http.ResponseWriter, r *http.Request) {
+	if !hubBrowserRequestAllowed(r, false) {
+		http.Error(w, "forbidden cross-site hub request", http.StatusForbidden)
+		return
+	}
+	// Reject encoded path separators outright: r.URL.Path is already decoded,
+	// so %2f would otherwise smuggle a separator past the segment checks.
+	if hubContainsEncodedSeparator(r.URL.EscapedPath()) {
+		http.Error(w, "bad request: encoded path separators not allowed", http.StatusBadRequest)
+		return
+	}
+	id, rest, ok := parseHubNodePath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if err := hub.ValidateID(id); err != nil {
+		http.Error(w, fmt.Sprintf("invalid node id %q", id), http.StatusBadRequest)
+		return
+	}
+	if hubHasDotDotSegment(rest) {
+		http.Error(w, "bad request: path traversal not allowed", http.StatusBadRequest)
+		return
+	}
+	node, ok := s.registry.Lookup(id)
+	if !ok {
+		http.Error(w, fmt.Sprintf("unknown node %q", id), http.StatusNotFound)
+		return
+	}
+	// Bare /node/<id> -> /node/<id>/ so the node UI's relative URLs resolve
+	// under the mount. Preserve the query string.
+	if rest == "" {
+		target := "/node/" + id + "/"
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+		return
+	}
+	scheme, host, ok := strings.Cut(node.URL, "://")
+	if !ok {
+		http.Error(w, fmt.Sprintf("node %q has an invalid url", id), http.StatusBadGateway)
+		return
+	}
+	t := &hubProxyTarget{
+		nodeID:   node.ID,
+		nodeName: node.Name,
+		scheme:   scheme,
+		host:     host,
+		path:     hubJoinBasePath(node.BasePath, rest),
+		token:    node.Token,
+		basePath: strings.TrimRight(node.BasePath, "/"),
+		mount:    "/node/" + node.ID,
+	}
+	s.proxy.ServeHTTP(w, r.WithContext(withHubProxyTarget(r.Context(), t)))
+}
+
+// parseHubNodePath splits "/node/<id>/<rest>" into id and the remainder
+// (including its leading slash). "/node/<id>" yields an empty rest.
+func parseHubNodePath(p string) (id, rest string, ok bool) {
+	const prefix = "/node/"
+	if !strings.HasPrefix(p, prefix) {
+		return "", "", false
+	}
+	tail := p[len(prefix):]
+	if tail == "" {
+		return "", "", false
+	}
+	if slash := strings.IndexByte(tail, '/'); slash >= 0 {
+		return tail[:slash], tail[slash:], true
+	}
+	return tail, "", true
+}
+
+// hubJoinBasePath joins a node's base path with the proxied remainder,
+// collapsing the slash seam. An empty remainder targets the base path root.
+func hubJoinBasePath(base, rest string) string {
+	base = strings.TrimRight(base, "/")
+	if rest == "" {
+		return base + "/"
+	}
+	if !strings.HasPrefix(rest, "/") {
+		rest = "/" + rest
+	}
+	return base + rest
+}
+
+// hubContainsEncodedSeparator reports whether an escaped path smuggles an
+// encoded path separator (%2f) or backslash (%5c).
+func hubContainsEncodedSeparator(escapedPath string) bool {
+	lower := strings.ToLower(escapedPath)
+	return strings.Contains(lower, "%2f") || strings.Contains(lower, "%5c")
+}
+
+// hubHasDotDotSegment reports whether any segment of the decoded path is "..".
+func hubHasDotDotSegment(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// hubRewriteProxyRequest is the ReverseProxy Rewrite hook. Using Rewrite (vs
+// the legacy Director) means ReverseProxy does NOT auto-append X-Forwarded-*;
+// we also explicitly drop client-supplied forwarding/credential headers so
+// they can neither spoof metadata nor reach the node.
+func hubRewriteProxyRequest(pr *httputil.ProxyRequest) {
+	t := hubProxyTargetFrom(pr.In.Context())
+	if t == nil {
+		return
+	}
+	out := pr.Out
+	out.URL.Scheme = t.scheme
+	out.URL.Host = t.host
+	out.URL.Path = t.path
+	out.URL.RawPath = "" // force Go to re-encode Path from the cleaned value
+	out.Host = t.host
+
+	// Inject the real per-node token server-side; strip every client-supplied
+	// credential the node would otherwise honor (Authorization Bearer,
+	// x-api-key, and the term_llm_token cookie).
+	if t.token != "" {
+		out.Header.Set("Authorization", "Bearer "+t.token)
+	} else {
+		out.Header.Del("Authorization")
+	}
+	out.Header.Del("Cookie")
+	out.Header.Del("X-Api-Key")
+
+	// Take ownership of response encoding so ModifyResponse sees decompressed
+	// HTML: with Accept-Encoding cleared, the Transport transparently
+	// negotiates and decodes gzip itself.
+	out.Header.Del("Accept-Encoding")
+
+	// Drop spoofable forwarding metadata.
+	out.Header.Del("X-Forwarded-For")
+	out.Header.Del("X-Forwarded-Host")
+	out.Header.Del("X-Forwarded-Proto")
+	out.Header.Del("X-Forwarded-Prefix")
+	out.Header.Del("Forwarded")
+}
+
+// hubRebaseProxyResponse rewrites the node's baked-in base path onto the hub
+// mount (/node/<id>) for HTML documents, fixes redirect Location headers, and
+// injects the window.TERM_LLM_HUB context so the node UI can render its
+// "Back to Hub" link. Because the SPA derives every URL it builds from the
+// single window.TERM_LLM_UI_PREFIX value and the <base> tag, rebasing those
+// two strings re-homes all subsequent requests onto /node/<id>/* where the
+// token is injected. Non-HTML bodies (JS, JSON, SSE, images) pass through
+// untouched, which keeps streaming responses streaming.
+func hubRebaseProxyResponse(resp *http.Response) error {
+	t := hubProxyTargetFrom(resp.Request.Context())
+	if t == nil {
+		return nil
+	}
+
+	hubRewriteLocationHeader(resp, t)
+
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/html") {
+		return nil
+	}
+	// A HEAD response carries the real Content-Length but no body; rewriting
+	// would clobber that length to 0.
+	if resp.Request.Method == http.MethodHead {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if len(body) == 0 {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return nil
+	}
+
+	if t.basePath != "" && t.basePath != t.mount {
+		var baseHits, prefixHits int
+		body, baseHits, prefixHits = hubRebaseUIPrefix(body, t.basePath, t.mount)
+		if (baseHits == 0 || prefixHits == 0) && resp.StatusCode == http.StatusOK {
+			// One of the two prefix tokens the SPA bakes into its HTML no
+			// longer matches our needle (serveui's emitted shape drifted).
+			// Open-via-hub silently breaks when this happens, so be loud.
+			log.Printf("WARNING: hub node %q: UI prefix rebase matched base=%d prefix=%d (expected >=1 each); open-via-hub may be broken — check serveui's <base>/TERM_LLM_UI_PREFIX shape",
+				t.nodeID, baseHits, prefixHits)
+		}
+	}
+	body = hubInjectContext(body, t)
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	// The Transport already decoded any gzip (we cleared Accept-Encoding);
+	// make sure no stale encoding header survives the body rewrite.
+	resp.Header.Del("Content-Encoding")
+	return nil
+}
+
+// hubRebaseUIPrefix replaces the two prefix tokens the node bakes into its
+// served HTML. The needles are built with the SAME html.EscapeString /
+// json.Marshal shapes the serve uses (internal/serveui/embed.go and
+// cmd/serve_handlers.go) so they match byte-for-byte regardless of the node's
+// actual base path. It reports how many times each needle matched so the
+// caller can warn loudly on drift.
+func hubRebaseUIPrefix(body []byte, basePath, mount string) (out []byte, baseHits, prefixHits int) {
+	oldBase := []byte(`<base href="` + htmlpkg.EscapeString(basePath) + `/">`)
+	newBase := []byte(`<base href="` + htmlpkg.EscapeString(mount) + `/">`)
+	baseHits = bytes.Count(body, oldBase)
+	body = bytes.ReplaceAll(body, oldBase, newBase)
+
+	oldPrefix, _ := json.Marshal(basePath)
+	newPrefix, _ := json.Marshal(mount)
+	oldPrefixNeedle := []byte("window.TERM_LLM_UI_PREFIX=" + string(oldPrefix))
+	prefixHits = bytes.Count(body, oldPrefixNeedle)
+	body = bytes.ReplaceAll(body, oldPrefixNeedle,
+		[]byte("window.TERM_LLM_UI_PREFIX="+string(newPrefix)))
+	return body, baseHits, prefixHits
+}
+
+// hubInjectContext injects window.TERM_LLM_HUB into the served HTML head so
+// the node's web UI knows it was opened via the hub and can render a "Back
+// to Hub" link. The hub URL is root-relative ("/") because the proxied UI is
+// same-origin with the hub.
+func hubInjectContext(body []byte, t *hubProxyTarget) []byte {
+	ctxJSON, err := json.Marshal(map[string]string{
+		"url":      "/",
+		"nodeId":   t.nodeID,
+		"nodeName": t.nodeName,
+	})
+	if err != nil {
+		return body
+	}
+	snippet := []byte(`<script>window.TERM_LLM_HUB=` + string(ctxJSON) + `;</script></head>`)
+	if bytes.Contains(body, []byte("</head>")) {
+		return bytes.Replace(body, []byte("</head>"), snippet, 1)
+	}
+	return body
+}
+
+// hubRewriteLocationHeader rebases a root-relative redirect Location that
+// points at the node base path onto the hub mount, so node redirects (e.g.
+// the /chat -> /chat/ normalization) land back inside /node/<id>/.
+func hubRewriteLocationHeader(resp *http.Response, t *hubProxyTarget) {
+	loc := resp.Header.Get("Location")
+	if loc == "" || t.basePath == "" {
+		return
+	}
+	if loc == t.basePath {
+		resp.Header.Set("Location", t.mount)
+		return
+	}
+	if strings.HasPrefix(loc, t.basePath+"/") {
+		resp.Header.Set("Location", t.mount+loc[len(t.basePath):])
+	}
+}
+
+func hubProxyErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	id := "node"
+	if t := hubProxyTargetFrom(r.Context()); t != nil {
+		id = t.nodeID
+	}
+	w.WriteHeader(http.StatusBadGateway)
+	fmt.Fprintf(w, "hub: node %q backend unreachable: %v\n", id, err)
+}
+
+var (
+	serveHubHost      string
+	serveHubPort      int
+	serveHubConfig    string
+	serveHubContain   bool
+	serveHubNodesFile string
+)
+
+var serveHubCmd = &cobra.Command{
+	Use:   "hub",
+	Short: "Run the term-llm Hub: one dashboard over many term-llm web nodes (experimental)",
+	Long: `Run the term-llm Hub, a launcher and control plane over many term-llm web
+nodes (serves). Nodes are discovered from a static config file (--config),
+from local contain workspaces, and from nodes added in the dashboard UI
+(persisted to a local JSON store).
+
+The dashboard lists every node with live reachability, latency, and any
+detected agent/version/capabilities, and opens a node's full web UI through
+the hub at /node/<id>/ with the node's bearer token injected server-side —
+node tokens never reach the browser.
+
+Routes:
+  GET  /                  hub dashboard
+  GET  /api/nodes         list nodes with probe status (never includes tokens)
+  POST /api/nodes         add a node to the local store
+  DELETE /api/nodes/<id>  remove a local-store node
+  POST /api/nodes/test    probe a node spec without persisting it
+  ANY  /node/<id>/...     reverse proxy to that node's serve
+
+Config file (--config), YAML or JSON:
+  nodes:
+    - name: jarvis
+      url: http://127.0.0.1:8081/chat
+      token: <web bearer token>
+
+EXPERIMENTAL: the hub has no authentication of its own yet; it refuses to
+bind beyond loopback. To expose it, front it with an authenticating reverse
+proxy and keep the hub itself on loopback.`,
+	Args: cobra.NoArgs,
+	RunE: runServeHub,
+}
+
+// validateHubBind rejects a bind that would expose the hub unsafely. The hub
+// has no authentication of its own yet (node tokens are injected server-side,
+// but nothing gates who may reach the hub), so it must stay on loopback.
+func validateHubBind(host string, port int) error {
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid --port %d (must be 1-65535)", port)
+	}
+	if !isLoopbackHost(host) {
+		return fmt.Errorf("serve hub has no authentication yet, so --host must be a loopback address (127.0.0.1, localhost, or ::1); got %q. To expose it, put an authenticating proxy in front and keep the hub on loopback", host)
+	}
+	return nil
+}
+
+// defaultHubNodesFile is where dashboard-added nodes persist when
+// --nodes-file is not given.
+func defaultHubNodesFile() (string, error) {
+	dir, err := appdata.GetDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "hub", "nodes.json"), nil
+}
+
+func runServeHub(cmd *cobra.Command, args []string) error {
+	if err := validateHubBind(serveHubHost, serveHubPort); err != nil {
+		return err
+	}
+
+	var resolvers []hub.Resolver
+	if strings.TrimSpace(serveHubConfig) != "" {
+		resolvers = append(resolvers, hub.NewStaticResolver(serveHubConfig))
+	}
+	nodesFile := strings.TrimSpace(serveHubNodesFile)
+	if nodesFile == "" {
+		var err error
+		nodesFile, err = defaultHubNodesFile()
+		if err != nil {
+			return fmt.Errorf("resolve hub nodes file: %w", err)
+		}
+	}
+	store := hub.NewStore(nodesFile)
+	resolvers = append(resolvers, store)
+	if serveHubContain {
+		resolvers = append(resolvers, hub.NewContainResolver())
+	}
+
+	s := newHubServer(hub.NewRegistry(resolvers...), store)
+	addr := net.JoinHostPort(serveHubHost, strconv.Itoa(serveHubPort))
+	srv := &http.Server{Addr: addr, Handler: s.handler()}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "term-llm Hub listening on http://%s\n", addr)
+	fmt.Fprintf(out, "  GET http://%s/api/nodes\n", addr)
+	fmt.Fprintf(out, "  ANY http://%s/node/<id>/...\n", addr)
+	fmt.Fprintf(out, "  node store: %s\n", nodesFile)
+	fmt.Fprintln(out, "WARNING: experimental, no hub auth yet; bind to loopback only.")
+	return srv.ListenAndServe()
+}
+
+func init() {
+	serveCmd.AddCommand(serveHubCmd)
+	serveHubCmd.Flags().StringVar(&serveHubHost, "host", "127.0.0.1", "Host to bind (loopback only until hub auth exists)")
+	serveHubCmd.Flags().IntVar(&serveHubPort, "port", 8090, "Port to bind")
+	serveHubCmd.Flags().StringVar(&serveHubConfig, "config", "", "Path to a static nodes config file (YAML or JSON)")
+	serveHubCmd.Flags().BoolVar(&serveHubContain, "contain", true, "Discover nodes from local contain workspaces")
+	serveHubCmd.Flags().StringVar(&serveHubNodesFile, "nodes-file", "", "Path to the JSON store for dashboard-added nodes (default: <data-dir>/hub/nodes.json)")
+}

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -125,6 +125,12 @@ func hubProxyTargetFrom(ctx context.Context) *hubProxyTarget {
 	return t
 }
 
+type hubNodeDiagnostic struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+}
+
 // hubNodeView is the public record for one node. It deliberately omits the
 // bearer token: tokens are injected server-side and must never be sent to a
 // hub client.
@@ -138,8 +144,9 @@ type hubNodeView struct {
 	ProxyPath  string `json:"proxy_path"`
 	// HasToken reports whether the hub holds a bearer token for this node
 	// (without it, a token-guarded node will answer 401 through the proxy).
-	HasToken bool       `json:"has_token"`
-	Status   hub.Status `json:"status"`
+	HasToken    bool                `json:"has_token"`
+	Status      hub.Status          `json:"status"`
+	Diagnostics []hubNodeDiagnostic `json:"diagnostics,omitempty"`
 }
 
 func (s *hubServer) handler() http.Handler {
@@ -221,7 +228,98 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 		}
 		views = append(views, view)
 	}
+	for i := range views {
+		views[i].Diagnostics = hubNodeDiagnostics(nodes[i], views[i], nodes)
+	}
 	return views, err
+}
+
+func hubNodeDiagnostics(n hub.Node, view hubNodeView, all []hub.Node) []hubNodeDiagnostic {
+	diagnostics := []hubNodeDiagnostic{}
+	add := func(severity, code, message string) {
+		diagnostics = append(diagnostics, hubNodeDiagnostic{Severity: severity, Code: code, Message: message})
+	}
+	if n.UsesReverseConnection() && !view.Status.Reachable {
+		add("error", "reverse_disconnected", "Reverse node is waiting for its outbound websocket connection.")
+	}
+	if n.Token == "" {
+		add("warning", "missing_token", "No bearer token is configured; authenticated health, proxy, and delegation calls may fail.")
+	}
+	if n.Delegation != nil && n.Delegation.Enabled {
+		if strings.TrimSpace(n.Delegation.Workdir) == "" {
+			add("warning", "delegation_missing_workdir", "Delegation is enabled, but no workdir is configured; this node cannot accept delegated jobs.")
+		} else if !hubStatusHasCapability(view.Status, "jobs") {
+			if view.Status.Reachable && len(view.Status.Capabilities) > 0 {
+				add("warning", "delegation_jobs_missing", "This node accepts delegation, but its health capabilities do not include jobs; start it with jobs enabled.")
+			} else {
+				add("warning", "delegation_jobs_unknown", "This node accepts delegation, but the Hub cannot verify the jobs capability; check the token and node version.")
+			}
+		}
+	}
+	for _, msg := range hubPolicyMismatchDiagnostics(n, all) {
+		add("warning", "delegation_policy_mismatch", msg)
+		if len(diagnostics) >= 8 {
+			break
+		}
+	}
+	return diagnostics
+}
+
+func hubStatusHasCapability(st hub.Status, capability string) bool {
+	for _, c := range st.Capabilities {
+		if strings.EqualFold(strings.TrimSpace(c), capability) {
+			return true
+		}
+	}
+	return false
+}
+
+func hubPolicyMismatchDiagnostics(n hub.Node, all []hub.Node) []string {
+	if n.Delegation == nil || !n.Delegation.Enabled {
+		return nil
+	}
+	messages := []string{}
+	for _, target := range all {
+		if target.ID == n.ID || !n.CanDelegateTo(target.ID) {
+			continue
+		}
+		if target.Delegation == nil || !target.Delegation.Enabled {
+			messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node has delegation disabled.", target.ID))
+			continue
+		}
+		if strings.TrimSpace(target.Delegation.Workdir) == "" {
+			messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node has no delegation workdir.", target.ID))
+			continue
+		}
+		acceptFrom := target.Delegation.AcceptFrom
+		if len(acceptFrom) == 0 {
+			acceptFrom = []string{"*"}
+		}
+		if !hubNodeListMatches(acceptFrom, n.ID) {
+			messages = append(messages, fmt.Sprintf("Can delegate to %q, but that node does not accept from %q.", target.ID, n.ID))
+		}
+	}
+	if len(n.Delegation.AcceptFrom) > 0 && !hubNodeListMatches(n.Delegation.AcceptFrom, "*") && strings.TrimSpace(n.Delegation.Workdir) != "" {
+		for _, origin := range all {
+			if origin.ID == n.ID || !hubNodeListMatches(n.Delegation.AcceptFrom, origin.ID) {
+				continue
+			}
+			if !origin.CanDelegateTo(n.ID) {
+				messages = append(messages, fmt.Sprintf("Accepts from %q, but that node is not configured to delegate here.", origin.ID))
+			}
+		}
+	}
+	return messages
+}
+
+func hubNodeListMatches(patterns []string, id string) bool {
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p == "*" || p == id {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *hubServer) handleNodes(w http.ResponseWriter, r *http.Request) {

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -184,6 +184,12 @@ func (s *hubServer) auth(next http.Handler) http.Handler {
 			writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "invalid hub authentication credentials")
 			return
 		}
+		if hubDelegationOperatorRoute(r) {
+			clone := r.Clone(r.Context())
+			clone.Header = r.Header.Clone()
+			clone.Header.Del("Authorization")
+			r = clone
+		}
 		next.ServeHTTP(w, r)
 	})
 }
@@ -193,6 +199,10 @@ func hubNodeAuthRoute(r *http.Request) bool {
 		return true
 	}
 	return (r.URL.Path == "/api/delegations" || strings.HasPrefix(r.URL.Path, "/api/delegations/")) && strings.TrimSpace(r.Header.Get(hubNodeIDHeader)) != ""
+}
+
+func hubDelegationOperatorRoute(r *http.Request) bool {
+	return (r.URL.Path == "/api/delegations" || strings.HasPrefix(r.URL.Path, "/api/delegations/")) && strings.TrimSpace(r.Header.Get(hubNodeIDHeader)) == ""
 }
 
 func hubBearerTokenMatches(r *http.Request, want string) bool {

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -44,15 +44,28 @@ type hubServer struct {
 	// store backs the dashboard's Add Node form; nil disables mutation.
 	store  *hub.Store
 	prober *hub.Prober
-	proxy  *httputil.ReverseProxy
+	// reverse tracks private nodes that dial out to the hub and receive node
+	// requests over a websocket instead of direct hub -> node HTTP.
+	reverse *hubReverseManager
+	proxy   *httputil.ReverseProxy
+	// delegations is the cross-node delegation ledger; nil disables the
+	// /api/delegations endpoints.
+	delegations *hub.DelegationStore
+	// nodeAPIClient performs hub -> node jobs API calls for delegations. It
+	// shares the proxy's direct-dial transport (no env proxy: requests carry
+	// node tokens) but, unlike streaming proxy traffic, gets a whole-request
+	// timeout.
+	nodeAPIClient *http.Client
 }
 
 func newHubServer(registry *hub.Registry, store *hub.Store) *hubServer {
 	transport := newHubTransport()
 	s := &hubServer{
-		registry: registry,
-		store:    store,
-		prober:   hub.NewProber(transport),
+		registry:      registry,
+		store:         store,
+		prober:        hub.NewProber(transport),
+		reverse:       newHubReverseManager(),
+		nodeAPIClient: &http.Client{Transport: transport, Timeout: 30 * time.Second},
 	}
 	s.proxy = &httputil.ReverseProxy{
 		Rewrite:        hubRewriteProxyRequest,
@@ -116,12 +129,13 @@ func hubProxyTargetFrom(ctx context.Context) *hubProxyTarget {
 // bearer token: tokens are injected server-side and must never be sent to a
 // hub client.
 type hubNodeView struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Source    string `json:"source"`
-	URL       string `json:"url"`
-	BasePath  string `json:"base_path"`
-	ProxyPath string `json:"proxy_path"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Source     string `json:"source"`
+	Connection string `json:"connection"`
+	URL        string `json:"url"`
+	BasePath   string `json:"base_path"`
+	ProxyPath  string `json:"proxy_path"`
 	// HasToken reports whether the hub holds a bearer token for this node
 	// (without it, a token-guarded node will answer 401 through the proxy).
 	HasToken bool       `json:"has_token"`
@@ -134,6 +148,9 @@ func (s *hubServer) handler() http.Handler {
 	mux.HandleFunc("/api/nodes/test", s.handleTestNode)
 	mux.HandleFunc("/api/nodes/", s.handleNodeItem)
 	mux.HandleFunc("/api/nodes", s.handleNodes)
+	mux.HandleFunc("/api/delegations/", s.handleDelegationItem)
+	mux.HandleFunc("/api/delegations", s.handleDelegations)
+	mux.HandleFunc("/api/connect", s.handleReverseConnect)
 	mux.HandleFunc("/node/", s.handleNodeProxy)
 	mux.HandleFunc("/", s.handleIndex)
 	return mux
@@ -179,16 +196,30 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 	statuses := s.prober.ProbeAll(probeCtx, nodes)
 	views := make([]hubNodeView, 0, len(nodes))
 	for _, n := range nodes {
-		views = append(views, hubNodeView{
-			ID:        n.ID,
-			Name:      n.Name,
-			Source:    n.Source,
-			URL:       n.URL,
-			BasePath:  n.BasePath,
-			ProxyPath: "/node/" + n.ID + "/",
-			HasToken:  n.Token != "",
-			Status:    statuses[n.ID],
-		})
+		view := hubNodeView{
+			ID:         n.ID,
+			Name:       n.Name,
+			Source:     n.Source,
+			Connection: n.Connection,
+			URL:        n.URL,
+			BasePath:   n.BasePath,
+			ProxyPath:  "/node/" + n.ID + "/",
+			HasToken:   n.Token != "",
+			Status:     statuses[n.ID],
+		}
+		if n.UsesReverseConnection() {
+			connected, connectedAt, lastSeen := s.reverse.status(n.ID)
+			if connected {
+				view.Status = hub.Status{Reachable: true, State: "connected", LatencyMS: 0, Details: map[string]string{
+					"connection":   "reverse",
+					"connected_at": connectedAt.Format(time.RFC3339),
+					"last_seen":    lastSeen.Format(time.RFC3339),
+				}}
+			} else {
+				view.Status = hub.Status{State: "disconnected", Error: "waiting for reverse connection", Details: map[string]string{"connection": "reverse"}}
+			}
+		}
+		views = append(views, view)
 	}
 	return views, err
 }
@@ -375,6 +406,10 @@ func (s *hubServer) handleNodeProxy(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("unknown node %q", id), http.StatusNotFound)
 		return
 	}
+	if node.UsesReverseConnection() {
+		s.handleReverseNodeProxy(w, r, node, rest)
+		return
+	}
 	// Bare /node/<id> -> /node/<id>/ so the node UI's relative URLs resolve
 	// under the mount. Preserve the query string.
 	if rest == "" {
@@ -401,6 +436,70 @@ func (s *hubServer) handleNodeProxy(w http.ResponseWriter, r *http.Request) {
 		mount:    "/node/" + node.ID,
 	}
 	s.proxy.ServeHTTP(w, r.WithContext(withHubProxyTarget(r.Context(), t)))
+}
+
+func (s *hubServer) handleReverseNodeProxy(w http.ResponseWriter, r *http.Request, node hub.Node, rest string) {
+	if !s.reverse.isConnected(node.ID) {
+		http.Error(w, fmt.Sprintf("node %q reverse connection is not connected", node.ID), http.StatusBadGateway)
+		return
+	}
+	if rest == "" {
+		target := "/node/" + node.ID + "/"
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+		return
+	}
+	t := &hubProxyTarget{
+		nodeID:   node.ID,
+		nodeName: node.Name,
+		path:     hubJoinBasePath(node.BasePath, rest),
+		token:    node.Token,
+		basePath: strings.TrimRight(node.BasePath, "/"),
+		mount:    "/node/" + node.ID,
+	}
+	body := r.Body
+	if body == nil {
+		body = http.NoBody
+	}
+	req, err := http.NewRequestWithContext(withHubProxyTarget(r.Context(), t), r.Method, "http://reverse.local"+t.path, body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.URL.RawQuery = r.URL.RawQuery
+	req.Header = r.Header.Clone()
+	if node.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+node.Token)
+	} else {
+		req.Header.Del("Authorization")
+	}
+	req.Header.Del("Cookie")
+	req.Header.Del("X-Api-Key")
+	req.Header.Del("Accept-Encoding")
+	req.Header.Del("X-Forwarded-For")
+	req.Header.Del("X-Forwarded-Host")
+	req.Header.Del("X-Forwarded-Proto")
+	req.Header.Del("X-Forwarded-Prefix")
+	req.Header.Del("Forwarded")
+	resp, err := s.reverse.do(r.Context(), node, req)
+	if err != nil {
+		hubProxyErrorHandler(w, r.WithContext(withHubProxyTarget(r.Context(), t)), err)
+		return
+	}
+	defer resp.Body.Close()
+	if err := hubRebaseProxyResponse(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	for k, vals := range resp.Header {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 // parseHubNodePath splits "/node/<id>/<rest>" into id and the remainder
@@ -640,7 +739,12 @@ Routes:
   POST /api/nodes         add a node to the local store
   DELETE /api/nodes/<id>  remove a local-store node
   POST /api/nodes/test    probe a node spec without persisting it
+  GET  /api/connect      reverse-node websocket endpoint (node auth)
   ANY  /node/<id>/...     reverse proxy to that node's serve
+  POST /api/delegations   create a cross-node delegation (node auth)
+  GET  /api/delegations   list delegations
+  GET  /api/delegations/<id>         delegation status
+  POST /api/delegations/<id>/cancel  cancel (originating node only)
 
 Config file (--config), YAML or JSON:
   nodes:
@@ -702,6 +806,8 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	}
 
 	s := newHubServer(hub.NewRegistry(resolvers...), store)
+	// The delegation ledger lives beside the node store (same private dir).
+	s.delegations = hub.NewDelegationStore(filepath.Join(filepath.Dir(nodesFile), "delegations.json"))
 	addr := net.JoinHostPort(serveHubHost, strconv.Itoa(serveHubPort))
 	srv := &http.Server{Addr: addr, Handler: s.handler()}
 

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -14,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -36,9 +39,11 @@ import (
 // per request from the node ID prefix, so a host-based router can later map
 // Host -> node and reuse the same proxy plumbing unchanged.
 //
-// Hub-level authentication is intentionally not implemented yet: the hub
-// refuses to bind beyond loopback. TODO(hub): hub auth (member token ->
-// allowed nodes), node self-registration, and mTLS to nodes.
+// Hub-level authentication is intentionally small: one optional bearer token
+// gates the operator dashboard, registry API, and node proxy. Reverse node
+// websocket connections and delegation calls from nodes continue to use node
+// auth (node id + that node's serve token), so Hub auth does not require user
+// accounts or per-member ACLs.
 type hubServer struct {
 	registry *hub.Registry
 	// store backs the dashboard's Add Node form; nil disables mutation.
@@ -56,6 +61,9 @@ type hubServer struct {
 	// node tokens) but, unlike streaming proxy traffic, gets a whole-request
 	// timeout.
 	nodeAPIClient *http.Client
+
+	requireAuth bool
+	token       string
 }
 
 func newHubServer(registry *hub.Registry, store *hub.Store) *hubServer {
@@ -160,14 +168,53 @@ func (s *hubServer) handler() http.Handler {
 	mux.HandleFunc("/api/connect", s.handleReverseConnect)
 	mux.HandleFunc("/node/", s.handleNodeProxy)
 	mux.HandleFunc("/", s.handleIndex)
-	return mux
+	return s.auth(mux)
+}
+
+func (s *hubServer) auth(next http.Handler) http.Handler {
+	if !s.requireAuth {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions || hubNodeAuthRoute(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !hubBearerTokenMatches(r, s.token) {
+			writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "invalid hub authentication credentials")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func hubNodeAuthRoute(r *http.Request) bool {
+	if r.URL.Path == "/api/connect" {
+		return true
+	}
+	return (r.URL.Path == "/api/delegations" || strings.HasPrefix(r.URL.Path, "/api/delegations/")) && strings.TrimSpace(r.Header.Get(hubNodeIDHeader)) != ""
+}
+
+func hubBearerTokenMatches(r *http.Request, want string) bool {
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	scheme, rest, ok := strings.Cut(auth, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return false
+	}
+	got := strings.TrimSpace(rest)
+	if got == "" || strings.TrimSpace(want) == "" {
+		return false
+	}
+	wantHash := sha256.Sum256([]byte(strings.TrimSpace(want)))
+	gotHash := sha256.Sum256([]byte(got))
+	return subtle.ConstantTimeCompare(wantHash[:], gotHash[:]) == 1
 }
 
 // hubBrowserRequestAllowed rejects cross-site browser requests before the hub
 // exercises any token-injecting authority or mutates its node registry. This is
-// not a replacement for real hub auth, but it closes the obvious loopback CSRF
-// path while v1 is loopback-only. Same-origin proxied node content is still
-// trusted in v1; long-term host-based node isolation should remove that caveat.
+// defense-in-depth for --auth none and for bearer-authenticated browser use.
+// Same-origin proxied node content is still trusted in v1; long-term host-based
+// node isolation should remove that caveat.
 func hubBrowserRequestAllowed(r *http.Request, requireJSON bool) bool {
 	if requireJSON {
 		ct := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
@@ -816,6 +863,8 @@ var (
 	serveHubConfig    string
 	serveHubContain   bool
 	serveHubNodesFile string
+	serveHubAuthMode  string
+	serveHubToken     string
 )
 
 var serveHubCmd = &cobra.Command{
@@ -850,22 +899,23 @@ Config file (--config), YAML or JSON:
       url: http://127.0.0.1:8081/chat
       token: <web bearer token>
 
-EXPERIMENTAL: the hub has no authentication of its own yet; it refuses to
-bind beyond loopback. To expose it, front it with an authenticating reverse
-proxy and keep the hub itself on loopback.`,
+EXPERIMENTAL: Hub auth is intentionally simple: --auth bearer (the default)
+protects the dashboard, registry API, and node proxy with one Hub bearer token.
+/api/connect and node-originated delegation calls use node auth instead. Use
+--auth none only for loopback-only local development.`,
 	Args: cobra.NoArgs,
 	RunE: runServeHub,
 }
 
-// validateHubBind rejects a bind that would expose the hub unsafely. The hub
-// has no authentication of its own yet (node tokens are injected server-side,
-// but nothing gates who may reach the hub), so it must stay on loopback.
-func validateHubBind(host string, port int) error {
+// validateHubBind rejects unauthenticated public binds. A Hub with bearer auth
+// may bind publicly for use behind a reverse proxy, but --auth none stays
+// loopback-only because the Hub injects node tokens server-side.
+func validateHubBind(host string, port int, requireAuth bool) error {
 	if port <= 0 || port > 65535 {
 		return fmt.Errorf("invalid --port %d (must be 1-65535)", port)
 	}
-	if !isLoopbackHost(host) {
-		return fmt.Errorf("serve hub has no authentication yet, so --host must be a loopback address (127.0.0.1, localhost, or ::1); got %q. To expose it, put an authenticating proxy in front and keep the hub on loopback", host)
+	if !requireAuth && !isLoopbackHost(host) {
+		return fmt.Errorf("--auth none is only allowed on loopback hosts (got %q)", host)
 	}
 	return nil
 }
@@ -881,7 +931,16 @@ func defaultHubNodesFile() (string, error) {
 }
 
 func runServeHub(cmd *cobra.Command, args []string) error {
-	if err := validateHubBind(serveHubHost, serveHubPort); err != nil {
+	authMode, err := resolveServeAuthMode(cmd.Flags().Changed("auth"), serveHubAuthMode, false, false)
+	if err != nil {
+		return err
+	}
+	requireAuth := authMode != "none"
+	if err := validateHubBind(serveHubHost, serveHubPort, requireAuth); err != nil {
+		return err
+	}
+	token, tokenSource, err := resolveServeToken(serveHubToken, os.Getenv("TERM_LLM_HUB_TOKEN"), requireAuth, generateServeToken)
+	if err != nil {
 		return err
 	}
 
@@ -904,6 +963,8 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	}
 
 	s := newHubServer(hub.NewRegistry(resolvers...), store)
+	s.requireAuth = requireAuth
+	s.token = token
 	// The delegation ledger lives beside the node store (same private dir).
 	s.delegations = hub.NewDelegationStore(filepath.Join(filepath.Dir(nodesFile), "delegations.json"))
 	addr := net.JoinHostPort(serveHubHost, strconv.Itoa(serveHubPort))
@@ -914,15 +975,29 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(out, "  GET http://%s/api/nodes\n", addr)
 	fmt.Fprintf(out, "  ANY http://%s/node/<id>/...\n", addr)
 	fmt.Fprintf(out, "  node store: %s\n", nodesFile)
-	fmt.Fprintln(out, "WARNING: experimental, no hub auth yet; bind to loopback only.")
+	fmt.Fprintf(out, "  auth: %s\n", authSummary(requireAuth))
+	if requireAuth {
+		switch tokenSource {
+		case tokenSourceGenerated:
+			fmt.Fprintf(out, "  generated Hub bearer token: %s\n", token)
+		case tokenSourceEnv:
+			fmt.Fprintln(out, "  Hub bearer token: from TERM_LLM_HUB_TOKEN")
+		case tokenSourceFlag:
+			fmt.Fprintln(out, "  Hub bearer token: from --token")
+		}
+	} else {
+		fmt.Fprintln(out, "WARNING: hub auth disabled; bind to loopback only.")
+	}
 	return srv.ListenAndServe()
 }
 
 func init() {
 	serveCmd.AddCommand(serveHubCmd)
-	serveHubCmd.Flags().StringVar(&serveHubHost, "host", "127.0.0.1", "Host to bind (loopback only until hub auth exists)")
+	serveHubCmd.Flags().StringVar(&serveHubHost, "host", "127.0.0.1", "Host to bind")
 	serveHubCmd.Flags().IntVar(&serveHubPort, "port", 8090, "Port to bind")
 	serveHubCmd.Flags().StringVar(&serveHubConfig, "config", "", "Path to a static nodes config file (YAML or JSON)")
 	serveHubCmd.Flags().BoolVar(&serveHubContain, "contain", true, "Discover nodes from local contain workspaces")
 	serveHubCmd.Flags().StringVar(&serveHubNodesFile, "nodes-file", "", "Path to the JSON store for dashboard-added nodes (default: <data-dir>/hub/nodes.json)")
+	serveHubCmd.Flags().StringVar(&serveHubAuthMode, "auth", "bearer", "Hub auth mode: bearer or none (none is loopback-only)")
+	serveHubCmd.Flags().StringVar(&serveHubToken, "token", "", "Hub bearer token (defaults to $TERM_LLM_HUB_TOKEN, else auto-generated)")
 }

--- a/cmd/serve_hub_delegations.go
+++ b/cmd/serve_hub_delegations.go
@@ -325,25 +325,48 @@ func (s *hubServer) handleCreateDelegation(w http.ResponseWriter, r *http.Reques
 		UpdatedAt:  now,
 	}
 
+	if err := s.delegations.Add(d); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	jobID, runID, err := s.createDelegationJob(r.Context(), target, d, prompt, timeout)
 	d.JobID = jobID
 	d.RunID = runID
 	if err != nil {
-		if jobID != "" {
-			// The job exists on the target but never triggered; keep an audit
-			// record so the orphan is traceable.
-			d.Status = hub.DelegationStatusError
-			d.Error = err.Error()
-			_ = s.delegations.Add(d)
+		updated, updateErr := s.delegations.Update(d.ID, func(rec *hub.Delegation) {
+			rec.JobID = jobID
+			rec.RunID = runID
+			rec.Error = err.Error()
+			if runID != "" {
+				rec.Status = hub.DelegationStatusRunning
+			} else if jobID != "" {
+				// The target job is known, but the trigger response was lost or failed.
+				// Keep the record non-terminal so later status reads can discover a run
+				// via /v2/runs?job_id=... after a node reconnects.
+				rec.Status = hub.DelegationStatusPending
+			} else {
+				rec.Status = hub.DelegationStatusError
+			}
+		})
+		if updateErr == nil {
+			d = updated
 		}
 		http.Error(w, fmt.Sprintf("delegate to node %q: %v", target.ID, err), http.StatusBadGateway)
 		return
 	}
 	d.Status = hub.DelegationStatusRunning
-	if err := s.delegations.Add(d); err != nil {
+	updated, err := s.delegations.Update(d.ID, func(rec *hub.Delegation) {
+		rec.JobID = jobID
+		rec.RunID = runID
+		rec.Status = hub.DelegationStatusRunning
+		rec.Error = ""
+	})
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	d = updated
 	writeJSON(w, http.StatusCreated, map[string]any{"delegation": d})
 }
 
@@ -377,6 +400,15 @@ func (s *hubServer) handleCancelDelegation(w http.ResponseWriter, r *http.Reques
 	if !found {
 		http.Error(w, fmt.Sprintf("target node %q is no longer known to the hub", d.TargetNode), http.StatusBadGateway)
 		return
+	}
+	if d.RunID == "" && d.JobID != "" {
+		// A previous create/trigger may have lost the trigger response across a
+		// direct/reverse disconnect. Try one refresh so cancel can target the run
+		// if the node did in fact start it.
+		if err := s.refreshDelegation(r.Context(), &d); err != nil {
+			http.Error(w, fmt.Sprintf("refresh delegation before cancel on node %q: %v", target.ID, err), http.StatusBadGateway)
+			return
+		}
 	}
 	if d.RunID != "" {
 		if err := s.doNodeJSON(r.Context(), target, http.MethodPost,
@@ -481,6 +513,7 @@ func (s *hubServer) refreshDelegation(ctx context.Context, d *hub.Delegation) er
 		if run.ID != "" {
 			rec.RunID = run.ID
 		}
+		rec.Error = ""
 		if hub.DelegationStatusTerminal(status) {
 			rec.Response = run.Response
 			rec.Error = run.Error
@@ -640,6 +673,13 @@ func jobsV2SessionName(job jobsV2Job, cfg jobsV2LLMConfig) string {
 	return ""
 }
 
+// hubNodeJobsJob mirrors the jobs-v2 job fields the hub needs.
+type hubNodeJobsJob struct {
+	ID     string          `json:"id"`
+	Name   string          `json:"name"`
+	Labels json.RawMessage `json:"labels"`
+}
+
 // hubNodeJobsRun mirrors the jobs-v2 run fields the hub needs.
 type hubNodeJobsRun struct {
 	ID       string `json:"id"`
@@ -651,8 +691,9 @@ type hubNodeJobsRun struct {
 
 // createDelegationJob creates and triggers a manual jobs-v2 LLM job on the
 // target node. Returns the target job and run ids; a non-empty job id with an
-// error means the job was created but never triggered.
+// error means the job is known, but no run could be confirmed.
 func (s *hubServer) createDelegationJob(ctx context.Context, target hub.Node, d hub.Delegation, prompt string, timeoutSeconds int) (jobID, runID string, err error) {
+	jobName := "hub-delegation-" + d.ID
 	labels, err := json.Marshal(map[string]any{"hub_delegation": map[string]any{
 		"id":     d.ID,
 		"origin": d.OriginNode,
@@ -671,7 +712,7 @@ func (s *hubServer) createDelegationJob(ctx context.Context, target hub.Node, d 
 		runnerConfig["model"] = d.Model
 	}
 	payload := map[string]any{
-		"name":               "hub-delegation-" + d.ID,
+		"name":               jobName,
 		"enabled":            true,
 		"runner_type":        "llm",
 		"runner_config":      runnerConfig,
@@ -681,23 +722,72 @@ func (s *hubServer) createDelegationJob(ctx context.Context, target hub.Node, d 
 		"misfire_policy":     "run",
 		"labels":             json.RawMessage(labels),
 	}
-	var job struct {
-		ID string `json:"id"`
-	}
+	var job hubNodeJobsJob
 	if err := s.doNodeJSON(ctx, target, http.MethodPost, "/v2/jobs", payload, &job); err != nil {
-		return "", "", fmt.Errorf("create job: %w", err)
+		// If the request reached the node but the response was lost (or a retry hit
+		// the jobs-v2 unique name constraint), recover by name/label instead of
+		// blindly creating another job.
+		if existing, ok, lookupErr := s.findDelegationJob(ctx, target, jobName, d.ID); lookupErr == nil && ok {
+			job = existing
+		} else {
+			if lookupErr != nil {
+				return "", "", fmt.Errorf("create job: %w (idempotency lookup failed: %v)", err, lookupErr)
+			}
+			return "", "", fmt.Errorf("create job: %w", err)
+		}
 	}
 	if job.ID == "" {
 		return "", "", errors.New("target jobs API returned a job without an id")
 	}
 	var run hubNodeJobsRun
 	if err := s.doNodeJSON(ctx, target, http.MethodPost, "/v2/jobs/"+url.PathEscape(job.ID)+"/trigger", map[string]any{}, &run); err != nil {
+		// The trigger may have succeeded but the reverse/direct connection dropped
+		// before the response made it back. Check the latest run for this job so the
+		// ledger can resume exact-run polling instead of leaving an orphan.
+		if latest, ok, lookupErr := s.findLatestDelegationRun(ctx, target, job.ID); lookupErr == nil && ok && latest.ID != "" {
+			return job.ID, latest.ID, nil
+		} else if lookupErr != nil {
+			return job.ID, "", fmt.Errorf("trigger job %s: %w (run lookup failed: %v)", job.ID, err, lookupErr)
+		}
 		return job.ID, "", fmt.Errorf("trigger job %s: %w", job.ID, err)
 	}
 	if run.ID == "" {
 		return job.ID, "", errors.New("target jobs API returned a run without an id")
 	}
 	return job.ID, run.ID, nil
+}
+
+func (s *hubServer) findDelegationJob(ctx context.Context, target hub.Node, name, delegationID string) (hubNodeJobsJob, bool, error) {
+	var jobs struct {
+		Data []hubNodeJobsJob `json:"data"`
+	}
+	if err := s.doNodeJSON(ctx, target, http.MethodGet, "/v2/jobs?limit=200&offset=0", nil, &jobs); err != nil {
+		return hubNodeJobsJob{}, false, err
+	}
+	for _, job := range jobs.Data {
+		if job.Name != name {
+			continue
+		}
+		if label := hubDelegationIDFromJobLabels(job.Labels); label != "" && label != delegationID {
+			continue
+		}
+		return job, true, nil
+	}
+	return hubNodeJobsJob{}, false, nil
+}
+
+func (s *hubServer) findLatestDelegationRun(ctx context.Context, target hub.Node, jobID string) (hubNodeJobsRun, bool, error) {
+	var runs struct {
+		Data []hubNodeJobsRun `json:"data"`
+	}
+	if err := s.doNodeJSON(ctx, target, http.MethodGet,
+		"/v2/runs?limit=1&offset=0&job_id="+url.QueryEscape(jobID), nil, &runs); err != nil {
+		return hubNodeJobsRun{}, false, err
+	}
+	if len(runs.Data) == 0 {
+		return hubNodeJobsRun{}, false, nil
+	}
+	return runs.Data[0], true, nil
 }
 
 // doNodeJSON performs one JSON request against a node's API (mounted under

--- a/cmd/serve_hub_delegations.go
+++ b/cmd/serve_hub_delegations.go
@@ -596,33 +596,12 @@ func pathClean(p string) string {
 	return strings.TrimRight(cleaned.String(), "/")
 }
 
-const hubDelegationStatusFooter = `
-
----
-Before your final message, state your completion status on its own line in this exact format:
-STATUS: COMPLETE
-or
-STATUS: BLOCKED — <brief reason you could not complete the task>
-or
-STATUS: PARTIAL — <what was done and what is still missing>
-
-Choose COMPLETE only if you fully accomplished the task. Do not omit this line.`
-
-// hubDelegationInstructions wraps the delegated prompt with provenance so the
-// target agent knows the work arrived via the hub, plus the STATUS footer the
-// jobs-v2 agent flow expects.
-func hubDelegationInstructions(d hub.Delegation, prompt string) string {
-	var b strings.Builder
-	b.WriteString("You are handling a cross-node delegation routed through a term-llm Hub.\n")
-	fmt.Fprintf(&b, "Delegation id: %s\n", d.ID)
-	fmt.Fprintf(&b, "Origin node: %s\n", d.OriginNode)
-	fmt.Fprintf(&b, "Target node (you): %s\n", d.TargetNode)
-	fmt.Fprintf(&b, "Delegation depth: %d of max %d (chain: %s)\n", d.Depth, hub.DefaultDelegationMaxDepth, strings.Join(d.Chain, " -> "))
-	b.WriteString("Further hub_delegate calls from this job chain automatically: parent_delegation_id is attached for you.\n")
-	b.WriteString("\n---\n\n")
-	b.WriteString(prompt)
-	b.WriteString(hubDelegationStatusFooter)
-	return b.String()
+// hubDelegationInstructions returns the delegated prompt as the target node's
+// user-visible task text. Delegation provenance is trusted metadata carried in
+// hub-written job labels and tool context; it should not pollute the target
+// session transcript or change what the origin asked the target to do.
+func hubDelegationInstructions(_ hub.Delegation, prompt string) string {
+	return prompt
 }
 
 // jobsV2HubDelegationLabel is the trusted label shape the hub writes onto

--- a/cmd/serve_hub_delegations.go
+++ b/cmd/serve_hub_delegations.go
@@ -1,0 +1,769 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+)
+
+// Cross-node delegation: a node asks the hub to run a prompt as a jobs-v2 LLM
+// job on another node. The hub is the only party that holds node tokens, so
+// nodes authenticate to the hub with their own serve token and the hub talks
+// to the target node's jobs API with the target's token. Delegation records
+// live in a 0600 JSON ledger and never contain tokens.
+//
+// Routes (see hubServer.handler):
+//
+//	POST /api/delegations             create + trigger (node auth)
+//	GET  /api/delegations             list (node auth or same-origin GET)
+//	GET  /api/delegations/{id}        status, refreshed from the target run
+//	POST /api/delegations/{id}/cancel cancel target run (origin node only)
+
+const (
+	// hubNodeIDHeader carries the caller's claimed node id; the bearer token
+	// must match that node's stored token.
+	hubNodeIDHeader = "X-Term-LLM-Node-ID"
+
+	hubDelegationDefaultTimeout = 3600
+	hubDelegationMinTimeout     = 10
+	hubDelegationDefaultAgent   = hub.DefaultDelegationAgent
+
+	// In-flight caps: per-target comes from the node's delegation policy.
+	hubDelegationHubMaxInFlight    = 32
+	hubDelegationOriginMaxInFlight = 8
+)
+
+// authenticateNode resolves the caller's node identity from the claimed node
+// id header plus bearer token. Failures are deliberately uniform so callers
+// cannot probe which node ids exist; nodes without a stored token can never
+// authenticate (an empty token is absence of a credential, not a credential).
+func (s *hubServer) authenticateNode(r *http.Request) (hub.Node, error) {
+	failed := errors.New("node authentication failed")
+	id := strings.TrimSpace(r.Header.Get(hubNodeIDHeader))
+	if id == "" {
+		return hub.Node{}, fmt.Errorf("missing %s header", hubNodeIDHeader)
+	}
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return hub.Node{}, errors.New("missing bearer token")
+	}
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" {
+		return hub.Node{}, errors.New("missing bearer token")
+	}
+	node, ok := s.registry.Lookup(id)
+	if !ok || node.Token == "" {
+		return hub.Node{}, failed
+	}
+	// Hash both sides so the comparison is constant-time regardless of token
+	// lengths.
+	want := sha256.Sum256([]byte(node.Token))
+	got := sha256.Sum256([]byte(token))
+	if subtle.ConstantTimeCompare(want[:], got[:]) != 1 {
+		return hub.Node{}, failed
+	}
+	return node, nil
+}
+
+// delegationReader gates read-only delegation endpoints and resolves who is
+// reading: an authenticated node may read only delegations it originates or
+// targets, while a same-origin browser GET (the hub operator's dashboard;
+// hub v1 is loopback-only) sees everything. Records carry no tokens either
+// way.
+func (s *hubServer) delegationReader(r *http.Request) (requester hub.Node, viaNode, allowed bool) {
+	if node, err := s.authenticateNode(r); err == nil {
+		return node, true, true
+	}
+	if r.Header.Get(hubNodeIDHeader) != "" || r.Header.Get("Authorization") != "" {
+		// The caller attempted node auth and failed; don't silently fall back.
+		return hub.Node{}, false, false
+	}
+	return hub.Node{}, false, r.Method == http.MethodGet && hubBrowserRequestAllowed(r, false)
+}
+
+// delegationVisibleTo reports whether a node may see a delegation record: it
+// must be a party to it.
+func delegationVisibleTo(d hub.Delegation, nodeID string) bool {
+	return d.OriginNode == nodeID || d.TargetNode == nodeID
+}
+
+type hubDelegationCreateRequest struct {
+	TargetNode     string `json:"target_node"`
+	Prompt         string `json:"prompt"`
+	AgentName      string `json:"agent_name"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+	Model          string `json:"model"`
+	Cwd            string `json:"cwd"`
+	// ParentDelegationID links a chained delegation (the origin is itself
+	// working on a delegated job) for depth/loop enforcement. Verified
+	// against the ledger.
+	ParentDelegationID string `json:"parent_delegation_id"`
+}
+
+func (s *hubServer) handleDelegations(w http.ResponseWriter, r *http.Request) {
+	if s.delegations == nil {
+		http.Error(w, "delegation ledger is disabled", http.StatusServiceUnavailable)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		requester, viaNode, allowed := s.delegationReader(r)
+		if !allowed {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		records, err := s.delegations.List()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if viaNode {
+			scoped := make([]hub.Delegation, 0, len(records))
+			for _, d := range records {
+				if delegationVisibleTo(d, requester.ID) {
+					scoped = append(scoped, d)
+				}
+			}
+			records = scoped
+		}
+		if !viaNode {
+			refreshed := make([]hub.Delegation, 0, len(records))
+			for _, d := range records {
+				if !hub.DelegationStatusTerminal(d.Status) {
+					_ = s.refreshDelegation(r.Context(), &d)
+				}
+				refreshed = append(refreshed, d)
+			}
+			records = refreshed
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"delegations": records})
+	case http.MethodPost:
+		origin, err := s.authenticateNode(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+		s.handleCreateDelegation(w, r, origin)
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *hubServer) handleDelegationItem(w http.ResponseWriter, r *http.Request) {
+	if s.delegations == nil {
+		http.Error(w, "delegation ledger is disabled", http.StatusServiceUnavailable)
+		return
+	}
+	suffix := strings.TrimPrefix(r.URL.Path, "/api/delegations/")
+	if id, ok := strings.CutSuffix(suffix, "/cancel"); ok && !strings.Contains(id, "/") {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleCancelDelegation(w, r, id)
+		return
+	}
+	if suffix == "" || strings.Contains(suffix, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	requester, viaNode, allowed := s.delegationReader(r)
+	if !allowed {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	d, ok, err := s.delegations.Get(suffix)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// A node that is not a party to the delegation gets the same 404 as a
+	// missing id so foreign ids cannot be probed.
+	if !ok || (viaNode && !delegationVisibleTo(d, requester.ID)) {
+		http.Error(w, fmt.Sprintf("unknown delegation %q", suffix), http.StatusNotFound)
+		return
+	}
+	resp := map[string]any{}
+	if refreshErr := s.refreshDelegation(r.Context(), &d); refreshErr != nil {
+		resp["refresh_error"] = refreshErr.Error()
+	}
+	resp["delegation"] = d
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *hubServer) handleCreateDelegation(w http.ResponseWriter, r *http.Request, origin hub.Node) {
+	var req hubDelegationCreateRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4<<20)).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	targetID := strings.TrimSpace(req.TargetNode)
+	prompt := strings.TrimSpace(req.Prompt)
+	if targetID == "" || prompt == "" {
+		http.Error(w, "target_node and prompt are required", http.StatusBadRequest)
+		return
+	}
+	if targetID == origin.ID {
+		http.Error(w, "cannot delegate to the originating node", http.StatusBadRequest)
+		return
+	}
+	if !origin.CanDelegateTo(targetID) {
+		http.Error(w, fmt.Sprintf("node %q may not delegate to %q", origin.ID, targetID), http.StatusForbidden)
+		return
+	}
+	target, ok := s.registry.Lookup(targetID)
+	if !ok {
+		http.Error(w, fmt.Sprintf("unknown target node %q", targetID), http.StatusNotFound)
+		return
+	}
+	if err := target.AcceptsDelegationFrom(origin.ID); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	cwd, err := resolveDelegationCwd(target.DelegationWorkdir(), req.Cwd)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	depth := 1
+	chain := []string{origin.ID, target.ID}
+	if parentID := strings.TrimSpace(req.ParentDelegationID); parentID != "" {
+		parent, found, err := s.delegations.Get(parentID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !found {
+			http.Error(w, fmt.Sprintf("unknown parent_delegation_id %q", parentID), http.StatusBadRequest)
+			return
+		}
+		if parent.TargetNode != origin.ID {
+			http.Error(w, "parent_delegation_id does not belong to the delegating node", http.StatusForbidden)
+			return
+		}
+		for _, hop := range parent.Chain {
+			if hop == target.ID {
+				http.Error(w, fmt.Sprintf("delegation loop: node %q already appears in chain %v", target.ID, parent.Chain), http.StatusConflict)
+				return
+			}
+		}
+		depth = parent.Depth + 1
+		chain = append(append([]string{}, parent.Chain...), target.ID)
+	}
+	if depth > hub.DefaultDelegationMaxDepth {
+		http.Error(w, fmt.Sprintf("delegation depth %d exceeds the maximum of %d", depth, hub.DefaultDelegationMaxDepth), http.StatusForbidden)
+		return
+	}
+
+	if err := s.checkDelegationCaps(r.Context(), origin, target); err != nil {
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+		return
+	}
+
+	timeout := req.TimeoutSeconds
+	if timeout <= 0 {
+		timeout = hubDelegationDefaultTimeout
+	}
+	if timeout < hubDelegationMinTimeout {
+		timeout = hubDelegationMinTimeout
+	}
+	if timeout > hubDelegationDefaultTimeout {
+		timeout = hubDelegationDefaultTimeout
+	}
+	agentName := strings.TrimSpace(req.AgentName)
+	if agentName == "" {
+		agentName = hubDelegationDefaultAgent
+	}
+	if err := target.AcceptsDelegationAgent(agentName); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	model := strings.TrimSpace(req.Model)
+	if err := target.AcceptsDelegationModel(model); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	id, err := hub.NewDelegationID()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	now := time.Now().UTC()
+	d := hub.Delegation{
+		ID:         id,
+		OriginNode: origin.ID,
+		TargetNode: target.ID,
+		AgentName:  agentName,
+		Prompt:     prompt,
+		Model:      model,
+		Cwd:        cwd,
+		Status:     hub.DelegationStatusPending,
+		Depth:      depth,
+		Chain:      chain,
+		ParentID:   strings.TrimSpace(req.ParentDelegationID),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	jobID, runID, err := s.createDelegationJob(r.Context(), target, d, prompt, timeout)
+	d.JobID = jobID
+	d.RunID = runID
+	if err != nil {
+		if jobID != "" {
+			// The job exists on the target but never triggered; keep an audit
+			// record so the orphan is traceable.
+			d.Status = hub.DelegationStatusError
+			d.Error = err.Error()
+			_ = s.delegations.Add(d)
+		}
+		http.Error(w, fmt.Sprintf("delegate to node %q: %v", target.ID, err), http.StatusBadGateway)
+		return
+	}
+	d.Status = hub.DelegationStatusRunning
+	if err := s.delegations.Add(d); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"delegation": d})
+}
+
+func (s *hubServer) handleCancelDelegation(w http.ResponseWriter, r *http.Request, id string) {
+	requester, err := s.authenticateNode(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	d, ok, err := s.delegations.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		http.Error(w, fmt.Sprintf("unknown delegation %q", id), http.StatusNotFound)
+		return
+	}
+	if d.OriginNode != requester.ID {
+		http.Error(w, "only the originating node may cancel a delegation", http.StatusForbidden)
+		return
+	}
+	if hub.DelegationStatusTerminal(d.Status) {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"delegation": d,
+			"error":      fmt.Sprintf("delegation %q is already %s", id, d.Status),
+		})
+		return
+	}
+	target, found := s.registry.Lookup(d.TargetNode)
+	if !found {
+		http.Error(w, fmt.Sprintf("target node %q is no longer known to the hub", d.TargetNode), http.StatusBadGateway)
+		return
+	}
+	if d.RunID != "" {
+		if err := s.doNodeJSON(r.Context(), target, http.MethodPost,
+			"/v2/runs/"+url.PathEscape(d.RunID)+"/cancel", map[string]any{}, nil); err != nil {
+			http.Error(w, fmt.Sprintf("cancel run on node %q: %v", target.ID, err), http.StatusBadGateway)
+			return
+		}
+	}
+	updated, err := s.delegations.Update(d.ID, func(rec *hub.Delegation) {
+		if !hub.DelegationStatusTerminal(rec.Status) {
+			rec.Status = hub.DelegationStatusCancelRequested
+		}
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"delegation": updated})
+}
+
+// checkDelegationCaps enforces hub-wide, per-origin, and per-target in-flight
+// limits. Ledger statuses only advance when polled, so before rejecting it
+// refreshes active records once (bounded by the hub-wide cap) and recounts.
+func (s *hubServer) checkDelegationCaps(ctx context.Context, origin, target hub.Node) error {
+	over := func() (error, bool) {
+		total, byOrigin, byTarget, err := s.delegations.ActiveCounts()
+		if err != nil {
+			return err, false
+		}
+		if byTarget[target.ID] >= target.DelegationMaxInFlight() {
+			return fmt.Errorf("node %q already has %d delegations in flight (max %d)", target.ID, byTarget[target.ID], target.DelegationMaxInFlight()), true
+		}
+		if byOrigin[origin.ID] >= hubDelegationOriginMaxInFlight {
+			return fmt.Errorf("node %q already originates %d delegations in flight (max %d)", origin.ID, byOrigin[origin.ID], hubDelegationOriginMaxInFlight), true
+		}
+		if total >= hubDelegationHubMaxInFlight {
+			return fmt.Errorf("hub already has %d delegations in flight (max %d)", total, hubDelegationHubMaxInFlight), true
+		}
+		return nil, false
+	}
+	err, capped := over()
+	if err == nil || !capped {
+		return err
+	}
+	s.refreshActiveDelegations(ctx)
+	err, _ = over()
+	return err
+}
+
+// refreshActiveDelegations re-polls every active record's target run so stale
+// "running" entries don't pin in-flight caps forever.
+func (s *hubServer) refreshActiveDelegations(ctx context.Context) {
+	records, err := s.delegations.List()
+	if err != nil {
+		return
+	}
+	for i := range records {
+		if hub.DelegationStatusTerminal(records[i].Status) {
+			continue
+		}
+		_ = s.refreshDelegation(ctx, &records[i])
+	}
+}
+
+// refreshDelegation polls the target node for the delegation's latest run and
+// folds any status change back into the ledger and *d.
+func (s *hubServer) refreshDelegation(ctx context.Context, d *hub.Delegation) error {
+	if hub.DelegationStatusTerminal(d.Status) || d.JobID == "" {
+		return nil
+	}
+	target, ok := s.registry.Lookup(d.TargetNode)
+	if !ok {
+		return fmt.Errorf("target node %q is no longer known to the hub", d.TargetNode)
+	}
+	var run hubNodeJobsRun
+	if d.RunID != "" {
+		// Poll the exact run the delegation triggered: the job's newest run
+		// could be a different (e.g. manually re-triggered) one.
+		if err := s.doNodeJSON(ctx, target, http.MethodGet,
+			"/v2/runs/"+url.PathEscape(d.RunID), nil, &run); err != nil {
+			return fmt.Errorf("poll node %q: %w", target.ID, err)
+		}
+	} else {
+		var runs struct {
+			Data []hubNodeJobsRun `json:"data"`
+		}
+		if err := s.doNodeJSON(ctx, target, http.MethodGet,
+			"/v2/runs?limit=1&offset=0&job_id="+url.QueryEscape(d.JobID), nil, &runs); err != nil {
+			return fmt.Errorf("poll node %q: %w", target.ID, err)
+		}
+		if len(runs.Data) == 0 {
+			return nil
+		}
+		run = runs.Data[0]
+	}
+	status := delegationStatusFromRun(run.Status)
+	if status == d.Status && run.ID == d.RunID {
+		return nil
+	}
+	updated, err := s.delegations.Update(d.ID, func(rec *hub.Delegation) {
+		rec.Status = status
+		if run.ID != "" {
+			rec.RunID = run.ID
+		}
+		if hub.DelegationStatusTerminal(status) {
+			rec.Response = run.Response
+			rec.Error = run.Error
+		}
+	})
+	if err != nil {
+		return err
+	}
+	*d = updated
+	return nil
+}
+
+// delegationStatusFromRun maps a jobs-v2 run status onto a delegation status.
+func delegationStatusFromRun(runStatus string) string {
+	switch runStatus {
+	case "succeeded":
+		return hub.DelegationStatusSucceeded
+	case "failed", "skipped":
+		return hub.DelegationStatusFailed
+	case "cancelled":
+		return hub.DelegationStatusCancelled
+	case "cancel_requested":
+		return hub.DelegationStatusCancelRequested
+	case "timed_out":
+		return hub.DelegationStatusTimedOut
+	default:
+		return hub.DelegationStatusRunning
+	}
+}
+
+// resolveDelegationCwd defaults to the target's delegation workdir and
+// confines an explicit cwd inside it: the workdir is the target operator's
+// consent boundary for delegated work. The workdir itself is canonicalized
+// (absolute, "."/".." resolved) so prefix containment cannot be confused by
+// an un-normalized configured path.
+func resolveDelegationCwd(workdir, requested string) (string, error) {
+	workdir = strings.TrimSpace(workdir)
+	if workdir == "" {
+		return "", errors.New("target node has no delegation workdir")
+	}
+	if !strings.HasPrefix(workdir, "/") {
+		return "", fmt.Errorf("target node's delegation workdir %q is not an absolute path", workdir)
+	}
+	workdir = pathClean(workdir)
+	if workdir == "" {
+		return "", errors.New("target node's delegation workdir resolves to the filesystem root; refusing")
+	}
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return workdir, nil
+	}
+	if !strings.HasPrefix(requested, "/") {
+		requested = workdir + "/" + requested
+	}
+	cwd := pathClean(requested)
+	if cwd == workdir || strings.HasPrefix(cwd, workdir+"/") {
+		return cwd, nil
+	}
+	return "", fmt.Errorf("cwd %q is outside the target node's delegation workdir %q", requested, workdir)
+}
+
+// pathClean is filepath.Clean with forward slashes: delegation workdirs are
+// paths on the (POSIX) target node, not on the hub host.
+func pathClean(p string) string {
+	cleaned := strings.Builder{}
+	segments := strings.Split(p, "/")
+	stack := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		switch seg {
+		case "", ".":
+		case "..":
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		default:
+			stack = append(stack, seg)
+		}
+	}
+	cleaned.WriteString("/" + strings.Join(stack, "/"))
+	return strings.TrimRight(cleaned.String(), "/")
+}
+
+const hubDelegationStatusFooter = `
+
+---
+Before your final message, state your completion status on its own line in this exact format:
+STATUS: COMPLETE
+or
+STATUS: BLOCKED — <brief reason you could not complete the task>
+or
+STATUS: PARTIAL — <what was done and what is still missing>
+
+Choose COMPLETE only if you fully accomplished the task. Do not omit this line.`
+
+// hubDelegationInstructions wraps the delegated prompt with provenance so the
+// target agent knows the work arrived via the hub, plus the STATUS footer the
+// jobs-v2 agent flow expects.
+func hubDelegationInstructions(d hub.Delegation, prompt string) string {
+	var b strings.Builder
+	b.WriteString("You are handling a cross-node delegation routed through a term-llm Hub.\n")
+	fmt.Fprintf(&b, "Delegation id: %s\n", d.ID)
+	fmt.Fprintf(&b, "Origin node: %s\n", d.OriginNode)
+	fmt.Fprintf(&b, "Target node (you): %s\n", d.TargetNode)
+	fmt.Fprintf(&b, "Delegation depth: %d of max %d (chain: %s)\n", d.Depth, hub.DefaultDelegationMaxDepth, strings.Join(d.Chain, " -> "))
+	b.WriteString("Further hub_delegate calls from this job chain automatically: parent_delegation_id is attached for you.\n")
+	b.WriteString("\n---\n\n")
+	b.WriteString(prompt)
+	b.WriteString(hubDelegationStatusFooter)
+	return b.String()
+}
+
+// jobsV2HubDelegationLabel is the trusted label shape the hub writes onto
+// delegated jobs. Target jobs-v2 runners use it for chain tracking and for
+// making delegated runs visible as recognizable target-node sessions.
+type jobsV2HubDelegationLabel struct {
+	ID     string   `json:"id"`
+	Origin string   `json:"origin"`
+	Depth  int      `json:"depth"`
+	Chain  []string `json:"chain"`
+}
+
+func hubDelegationLabelFromJobLabels(labels json.RawMessage) jobsV2HubDelegationLabel {
+	if len(labels) == 0 {
+		return jobsV2HubDelegationLabel{}
+	}
+	var parsed struct {
+		HubDelegation jobsV2HubDelegationLabel `json:"hub_delegation"`
+	}
+	if err := json.Unmarshal(labels, &parsed); err != nil {
+		return jobsV2HubDelegationLabel{}
+	}
+	parsed.HubDelegation.ID = strings.TrimSpace(parsed.HubDelegation.ID)
+	parsed.HubDelegation.Origin = strings.TrimSpace(parsed.HubDelegation.Origin)
+	return parsed.HubDelegation
+}
+
+// hubDelegationIDFromJobLabels extracts the hub_delegation.id label the hub
+// writes onto delegated jobs. The jobs-v2 runner feeds it into the tool
+// context so chained hub_delegate calls carry a trusted parent_delegation_id
+// instead of relying on the model to volunteer one.
+func hubDelegationIDFromJobLabels(labels json.RawMessage) string {
+	return hubDelegationLabelFromJobLabels(labels).ID
+}
+
+func jobsV2SessionName(job jobsV2Job, cfg jobsV2LLMConfig) string {
+	_ = cfg
+	if label := hubDelegationLabelFromJobLabels(job.Labels); label.ID != "" {
+		origin := label.Origin
+		if origin == "" && len(label.Chain) > 0 {
+			origin = strings.TrimSpace(label.Chain[0])
+		}
+		if origin == "" {
+			origin = "Hub"
+		}
+		return "Delegation from " + origin
+	}
+	return ""
+}
+
+// hubNodeJobsRun mirrors the jobs-v2 run fields the hub needs.
+type hubNodeJobsRun struct {
+	ID       string `json:"id"`
+	JobID    string `json:"job_id"`
+	Status   string `json:"status"`
+	Response string `json:"response"`
+	Error    string `json:"error"`
+}
+
+// createDelegationJob creates and triggers a manual jobs-v2 LLM job on the
+// target node. Returns the target job and run ids; a non-empty job id with an
+// error means the job was created but never triggered.
+func (s *hubServer) createDelegationJob(ctx context.Context, target hub.Node, d hub.Delegation, prompt string, timeoutSeconds int) (jobID, runID string, err error) {
+	labels, err := json.Marshal(map[string]any{"hub_delegation": map[string]any{
+		"id":     d.ID,
+		"origin": d.OriginNode,
+		"depth":  d.Depth,
+		"chain":  d.Chain,
+	}})
+	if err != nil {
+		return "", "", fmt.Errorf("encode delegation labels: %w", err)
+	}
+	runnerConfig := map[string]any{
+		"agent_name":   d.AgentName,
+		"instructions": hubDelegationInstructions(d, prompt),
+		"cwd":          d.Cwd,
+	}
+	if d.Model != "" {
+		runnerConfig["model"] = d.Model
+	}
+	payload := map[string]any{
+		"name":               "hub-delegation-" + d.ID,
+		"enabled":            true,
+		"runner_type":        "llm",
+		"runner_config":      runnerConfig,
+		"trigger_type":       "manual",
+		"concurrency_policy": "allow",
+		"timeout_seconds":    timeoutSeconds,
+		"misfire_policy":     "run",
+		"labels":             json.RawMessage(labels),
+	}
+	var job struct {
+		ID string `json:"id"`
+	}
+	if err := s.doNodeJSON(ctx, target, http.MethodPost, "/v2/jobs", payload, &job); err != nil {
+		return "", "", fmt.Errorf("create job: %w", err)
+	}
+	if job.ID == "" {
+		return "", "", errors.New("target jobs API returned a job without an id")
+	}
+	var run hubNodeJobsRun
+	if err := s.doNodeJSON(ctx, target, http.MethodPost, "/v2/jobs/"+url.PathEscape(job.ID)+"/trigger", map[string]any{}, &run); err != nil {
+		return job.ID, "", fmt.Errorf("trigger job %s: %w", job.ID, err)
+	}
+	if run.ID == "" {
+		return job.ID, "", errors.New("target jobs API returned a run without an id")
+	}
+	return job.ID, run.ID, nil
+}
+
+// doNodeJSON performs one JSON request against a node's API (mounted under
+// the node's base path) with the node's token injected server-side. It uses
+// the hub's direct-dial client: routing token-carrying requests through an
+// environment HTTP proxy would leak node tokens.
+func (s *hubServer) doNodeJSON(ctx context.Context, node hub.Node, method, path string, payload, out any) error {
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode node request: %w", err)
+		}
+		body = strings.NewReader(string(data))
+	}
+	var targetURL string
+	if node.UsesReverseConnection() {
+		targetURL = "http://reverse.local" + node.BasePath + path
+	} else {
+		targetURL = node.BaseURL() + path
+	}
+	req, err := http.NewRequestWithContext(ctx, method, targetURL, body)
+	if err != nil {
+		return err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if node.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+node.Token)
+	}
+	var resp *http.Response
+	if node.UsesReverseConnection() {
+		resp, err = s.reverse.do(ctx, node, req)
+	} else {
+		resp, err = s.nodeAPIClient.Do(req)
+	}
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(data))
+		// An upstream (or misconfigured proxy) may reflect the Authorization
+		// header into the error body; never let the target's token travel
+		// back to the origin node or into the ledger.
+		if node.Token != "" {
+			msg = strings.ReplaceAll(msg, node.Token, "[redacted]")
+		}
+		if len(msg) > 300 {
+			msg = msg[:300] + "…"
+		}
+		if msg == "" {
+			msg = resp.Status
+		}
+		return fmt.Errorf("node API %s %s: HTTP %d: %s", method, path, resp.StatusCode, msg)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode node API response: %w", err)
+	}
+	return nil
+}

--- a/cmd/serve_hub_delegations_test.go
+++ b/cmd/serve_hub_delegations_test.go
@@ -267,10 +267,8 @@ func TestHubDelegationCreateHappyPath(t *testing.T) {
 		t.Fatalf("runner_config = %v", runner)
 	}
 	instructions, _ := runner["instructions"].(string)
-	for _, needle := range []string{"summarize the build failures", "STATUS: COMPLETE", "cross-node delegation", d.ID, "Origin node: alpha"} {
-		if !strings.Contains(instructions, needle) {
-			t.Fatalf("instructions missing %q:\n%s", needle, instructions)
-		}
+	if instructions != "summarize the build failures" {
+		t.Fatalf("instructions = %q, want delegated prompt verbatim", instructions)
 	}
 	labels, _ := json.Marshal(fake.lastJobBody["labels"])
 	if !strings.Contains(string(labels), d.ID) || !strings.Contains(string(labels), "hub_delegation") {

--- a/cmd/serve_hub_delegations_test.go
+++ b/cmd/serve_hub_delegations_test.go
@@ -23,6 +23,8 @@ type fakeTargetJobs struct {
 	mu          sync.Mutex
 	server      *httptest.Server
 	jobSeq      int
+	jobs        map[string]hubNodeJobsJob
+	jobRuns     map[string]string
 	lastAuth    string
 	lastJobBody map[string]any
 	runStatus   string
@@ -40,12 +42,20 @@ type fakeTargetJobs struct {
 
 func newFakeTargetJobs(t *testing.T) *fakeTargetJobs {
 	t.Helper()
-	f := &fakeTargetJobs{runStatus: "running"}
+	f := &fakeTargetJobs{runStatus: "running", jobs: map[string]hubNodeJobsJob{}, jobRuns: map[string]string{}}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/chat/v2/jobs", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		f.lastAuth = r.Header.Get("Authorization")
+		if r.Method == http.MethodGet {
+			jobs := make([]hubNodeJobsJob, 0, len(f.jobs))
+			for _, job := range f.jobs {
+				jobs = append(jobs, job)
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"data": jobs, "total": len(jobs)})
+			return
+		}
 		if f.reflectAuthFailures {
 			http.Error(w, "upstream rejected credential "+r.Header.Get("Authorization"), http.StatusInternalServerError)
 			return
@@ -53,8 +63,23 @@ func newFakeTargetJobs(t *testing.T) *fakeTargetJobs {
 		var body map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		f.lastJobBody = body
+		name, _ := body["name"].(string)
+		for _, existing := range f.jobs {
+			if existing.Name == name {
+				http.Error(w, "job name already exists", http.StatusBadRequest)
+				return
+			}
+		}
 		f.jobSeq++
-		writeJSON(w, http.StatusCreated, map[string]any{"id": fmt.Sprintf("job_%d", f.jobSeq)})
+		id := fmt.Sprintf("job_%d", f.jobSeq)
+		job := hubNodeJobsJob{ID: id, Name: name}
+		if labels, ok := body["labels"].(map[string]any); ok {
+			if data, err := json.Marshal(labels); err == nil {
+				job.Labels = data
+			}
+		}
+		f.jobs[id] = job
+		writeJSON(w, http.StatusCreated, job)
 	})
 	mux.HandleFunc("/chat/v2/jobs/", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
@@ -65,20 +90,27 @@ func newFakeTargetJobs(t *testing.T) *fakeTargetJobs {
 			return
 		}
 		jobID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/chat/v2/jobs/"), "/trigger")
-		writeJSON(w, http.StatusCreated, map[string]any{"id": "run-for-" + jobID, "job_id": jobID, "status": "queued"})
+		runID := "run-for-" + jobID
+		f.jobRuns[jobID] = runID
+		writeJSON(w, http.StatusCreated, map[string]any{"id": runID, "job_id": jobID, "status": "queued"})
 	})
 	mux.HandleFunc("/chat/v2/runs", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		f.lastAuth = r.Header.Get("Authorization")
 		jobID := r.URL.Query().Get("job_id")
-		writeJSON(w, http.StatusOK, map[string]any{"data": []map[string]any{{
-			"id":       "run-for-" + jobID,
-			"job_id":   jobID,
-			"status":   f.runStatus,
-			"response": f.runResponse,
-			"error":    f.runError,
-		}}})
+		runID := f.jobRuns[jobID]
+		data := []map[string]any{}
+		if runID != "" {
+			data = append(data, map[string]any{
+				"id":       runID,
+				"job_id":   jobID,
+				"status":   f.runStatus,
+				"response": f.runResponse,
+				"error":    f.runError,
+			})
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"data": data})
 	})
 	mux.HandleFunc("/chat/v2/runs/", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
@@ -646,6 +678,77 @@ func TestHubDelegationTargetTokenRedactedFromLedger(t *testing.T) {
 	}
 }
 
+func TestHubDelegationTriggerFailureKeepsJobPollable(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	fake.mu.Lock()
+	fake.reflectTriggerFailure = true
+	fake.mu.Unlock()
+
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d %q", rec.Code, rec.Body.String())
+	}
+	records, err := s.delegations.List()
+	if err != nil || len(records) != 1 {
+		t.Fatalf("ledger records = %v (%v)", records, err)
+	}
+	d := records[0]
+	if d.JobID == "" || d.RunID != "" || d.Status != hub.DelegationStatusPending {
+		t.Fatalf("partial trigger record = %+v, want job_id only and pending", d)
+	}
+
+	fake.mu.Lock()
+	fake.reflectTriggerFailure = false
+	fake.jobRuns[d.JobID] = "run-for-" + d.JobID
+	fake.mu.Unlock()
+	fake.setRun("succeeded", "resumed", "")
+
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh: %d %q", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Delegation hub.Delegation `json:"delegation"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Delegation.RunID != "run-for-"+d.JobID || resp.Delegation.Status != hub.DelegationStatusSucceeded || resp.Delegation.Response != "resumed" || resp.Delegation.Error != "" {
+		t.Fatalf("refreshed partial trigger = %+v", resp.Delegation)
+	}
+}
+
+func TestHubDelegationCancelDiscoversRunAfterLostTriggerResponse(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	fake.mu.Lock()
+	fake.reflectTriggerFailure = true
+	fake.mu.Unlock()
+
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("create with lost trigger response: %d %q", rec.Code, rec.Body.String())
+	}
+	records, err := s.delegations.List()
+	if err != nil || len(records) != 1 {
+		t.Fatalf("ledger records = %v (%v)", records, err)
+	}
+	d := records[0]
+	fake.mu.Lock()
+	fake.reflectTriggerFailure = false
+	fake.jobRuns[d.JobID] = "run-for-" + d.JobID
+	fake.mu.Unlock()
+
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodPost, "/api/delegations/"+d.ID+"/cancel", "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cancel: %d %q", rec.Code, rec.Body.String())
+	}
+	fake.mu.Lock()
+	cancelled := append([]string(nil), fake.cancelled...)
+	fake.mu.Unlock()
+	if len(cancelled) != 1 || cancelled[0] != "run-for-"+d.JobID {
+		t.Fatalf("cancelled runs = %v, want discovered run", cancelled)
+	}
+}
 func TestHubDelegationRefreshUsesExactRunID(t *testing.T) {
 	s, fake := newDelegationHub(t)
 	_, d := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})

--- a/cmd/serve_hub_delegations_test.go
+++ b/cmd/serve_hub_delegations_test.go
@@ -1,0 +1,716 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+// fakeTargetJobs fakes the slice of a node's jobs-v2 API the hub drives:
+// create job, trigger, list runs, cancel run.
+type fakeTargetJobs struct {
+	mu          sync.Mutex
+	server      *httptest.Server
+	jobSeq      int
+	lastAuth    string
+	lastJobBody map[string]any
+	runStatus   string
+	runResponse string
+	runError    string
+	cancelled   []string
+	// runGets records the exact run ids fetched via GET /v2/runs/{id}.
+	runGets []string
+	// reflectAuthFailures / reflectTriggerFailure make job create (resp.
+	// trigger) fail with a body that echoes the Authorization header, like a
+	// misbehaving upstream or proxy would.
+	reflectAuthFailures   bool
+	reflectTriggerFailure bool
+}
+
+func newFakeTargetJobs(t *testing.T) *fakeTargetJobs {
+	t.Helper()
+	f := &fakeTargetJobs{runStatus: "running"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat/v2/jobs", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.lastAuth = r.Header.Get("Authorization")
+		if f.reflectAuthFailures {
+			http.Error(w, "upstream rejected credential "+r.Header.Get("Authorization"), http.StatusInternalServerError)
+			return
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.lastJobBody = body
+		f.jobSeq++
+		writeJSON(w, http.StatusCreated, map[string]any{"id": fmt.Sprintf("job_%d", f.jobSeq)})
+	})
+	mux.HandleFunc("/chat/v2/jobs/", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.lastAuth = r.Header.Get("Authorization")
+		if f.reflectTriggerFailure {
+			http.Error(w, "upstream rejected credential "+r.Header.Get("Authorization"), http.StatusInternalServerError)
+			return
+		}
+		jobID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/chat/v2/jobs/"), "/trigger")
+		writeJSON(w, http.StatusCreated, map[string]any{"id": "run-for-" + jobID, "job_id": jobID, "status": "queued"})
+	})
+	mux.HandleFunc("/chat/v2/runs", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.lastAuth = r.Header.Get("Authorization")
+		jobID := r.URL.Query().Get("job_id")
+		writeJSON(w, http.StatusOK, map[string]any{"data": []map[string]any{{
+			"id":       "run-for-" + jobID,
+			"job_id":   jobID,
+			"status":   f.runStatus,
+			"response": f.runResponse,
+			"error":    f.runError,
+		}}})
+	})
+	mux.HandleFunc("/chat/v2/runs/", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.lastAuth = r.Header.Get("Authorization")
+		path := strings.TrimPrefix(r.URL.Path, "/chat/v2/runs/")
+		if runID, ok := strings.CutSuffix(path, "/cancel"); ok {
+			f.cancelled = append(f.cancelled, runID)
+			writeJSON(w, http.StatusOK, map[string]any{"id": runID, "status": "cancel_requested"})
+			return
+		}
+		f.runGets = append(f.runGets, path)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"id":       path,
+			"job_id":   strings.TrimPrefix(path, "run-for-"),
+			"status":   f.runStatus,
+			"response": f.runResponse,
+			"error":    f.runError,
+		})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeTargetJobs) setRun(status, response, errText string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.runStatus, f.runResponse, f.runError = status, response, errText
+}
+
+// newDelegationHub builds a hub over a fake fleet: alpha and beta accept
+// delegations (workdir /work), closed has no workdir, restricted may only
+// delegate to gamma, tokenless has no stored token.
+func newDelegationHub(t *testing.T) (*hubServer, *fakeTargetJobs) {
+	t.Helper()
+	fake := newFakeTargetJobs(t)
+	nodes := []hub.Node{
+		{ID: "alpha", Name: "Alpha", URL: fake.server.URL, BasePath: "/chat", Token: "alpha-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work"}},
+		{ID: "beta", Name: "Beta", URL: fake.server.URL, BasePath: "/chat", Token: "beta-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work", MaxInFlight: 1, AllowedModels: []string{"haiku"}}},
+		{ID: "gamma", Name: "Gamma", URL: fake.server.URL, BasePath: "/chat", Token: "gamma-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work"}},
+		{ID: "anyagent", Name: "AnyAgent", URL: fake.server.URL, BasePath: "/chat", Token: "anyagent-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work", AllowedAgents: []string{"*"}}},
+		{ID: "pathy", Name: "Pathy", URL: fake.server.URL, BasePath: "/chat", Token: "pathy-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work", AllowedAgents: []string{"skills/custom-agent"}}},
+		{ID: "closed", Name: "Closed", URL: fake.server.URL, BasePath: "/chat", Token: "closed-token"},
+		{ID: "restricted", Name: "Restricted", URL: fake.server.URL, BasePath: "/chat", Token: "restricted-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, To: []string{"gamma"}, Workdir: "/work"}},
+		{ID: "tokenless", Name: "Tokenless", URL: fake.server.URL, BasePath: "/chat", Token: ""},
+		{ID: "picky", Name: "Picky", URL: fake.server.URL, BasePath: "/chat", Token: "picky-token",
+			Delegation: &hub.DelegationPolicy{Enabled: true, AcceptFrom: []string{"beta"}, Workdir: "/work"}},
+	}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: nodes}), nil)
+	s.delegations = hub.NewDelegationStore(filepath.Join(t.TempDir(), "delegations.json"))
+	return s, fake
+}
+
+func delegationRequest(method, path, nodeID, token string, payload any) *http.Request {
+	var req *http.Request
+	if payload != nil {
+		data, _ := json.Marshal(payload)
+		req = httptest.NewRequest(method, path, strings.NewReader(string(data)))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	if nodeID != "" {
+		req.Header.Set(hubNodeIDHeader, nodeID)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req
+}
+
+func createDelegation(t *testing.T, s *hubServer, nodeID, token string, payload map[string]any) (*httptest.ResponseRecorder, hub.Delegation) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodPost, "/api/delegations", nodeID, token, payload))
+	var resp struct {
+		Delegation hub.Delegation `json:"delegation"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	return rec, resp.Delegation
+}
+
+func TestHubDelegationAuthMatrix(t *testing.T) {
+	s, _ := newDelegationHub(t)
+	payload := map[string]any{"target_node": "beta", "prompt": "do the thing"}
+
+	cases := []struct {
+		name   string
+		nodeID string
+		token  string
+		want   int
+	}{
+		{"no credentials", "", "", http.StatusUnauthorized},
+		{"missing token", "alpha", "", http.StatusUnauthorized},
+		{"wrong token", "alpha", "beta-token", http.StatusUnauthorized},
+		{"unknown node", "ghost", "alpha-token", http.StatusUnauthorized},
+		{"empty-token node cannot authenticate", "tokenless", "anything", http.StatusUnauthorized},
+		{"valid", "alpha", "alpha-token", http.StatusCreated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, _ := createDelegation(t, s, tc.nodeID, tc.token, payload)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body %q)", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHubDelegationCreateHappyPath(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	rec, d := createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "beta",
+		"prompt":      "summarize the build failures",
+		"model":       "haiku",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if d.ID == "" || d.Status != hub.DelegationStatusRunning {
+		t.Fatalf("delegation = %+v", d)
+	}
+	if d.JobID != "job_1" || d.RunID != "run-for-job_1" {
+		t.Fatalf("job/run ids = %q %q", d.JobID, d.RunID)
+	}
+	if d.Depth != 1 || strings.Join(d.Chain, ",") != "alpha,beta" {
+		t.Fatalf("depth/chain = %d %v", d.Depth, d.Chain)
+	}
+
+	// The hub must talk to the target with the TARGET's token, and no token
+	// may appear in the client-facing response.
+	if fake.lastAuth != "Bearer beta-token" {
+		t.Fatalf("target saw auth %q", fake.lastAuth)
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{"alpha-token", "beta-token"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("response leaked token %q: %s", secret, body)
+		}
+	}
+
+	runner, _ := fake.lastJobBody["runner_config"].(map[string]any)
+	if runner["cwd"] != "/work" {
+		t.Fatalf("cwd = %v, want target workdir", runner["cwd"])
+	}
+	if runner["model"] != "haiku" || runner["agent_name"] != hubDelegationDefaultAgent {
+		t.Fatalf("runner_config = %v", runner)
+	}
+	instructions, _ := runner["instructions"].(string)
+	for _, needle := range []string{"summarize the build failures", "STATUS: COMPLETE", "cross-node delegation", d.ID, "Origin node: alpha"} {
+		if !strings.Contains(instructions, needle) {
+			t.Fatalf("instructions missing %q:\n%s", needle, instructions)
+		}
+	}
+	labels, _ := json.Marshal(fake.lastJobBody["labels"])
+	if !strings.Contains(string(labels), d.ID) || !strings.Contains(string(labels), "hub_delegation") {
+		t.Fatalf("labels = %s", labels)
+	}
+	label := hubDelegationLabelFromJobLabels(json.RawMessage(labels))
+	if label.ID != d.ID || label.Origin != "alpha" || label.Depth != 1 || strings.Join(label.Chain, ",") != "alpha,beta" {
+		t.Fatalf("parsed delegation label = %+v", label)
+	}
+	if got := jobsV2SessionName(jobsV2Job{Labels: json.RawMessage(labels)}, jobsV2LLMConfig{}); got != "Delegation from alpha" {
+		t.Fatalf("delegation session name = %q", got)
+	}
+}
+
+func TestHubDelegationPolicyDeny(t *testing.T) {
+	s, _ := newDelegationHub(t)
+
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "closed", "prompt": "x"})
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "does not accept delegations") {
+		t.Fatalf("no-workdir target: %d %q", rec.Code, rec.Body.String())
+	}
+
+	rec, _ = createDelegation(t, s, "restricted", "restricted-token", map[string]any{"target_node": "beta", "prompt": "x"})
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "may not delegate") {
+		t.Fatalf("origin to-list: %d %q", rec.Code, rec.Body.String())
+	}
+
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "picky", "prompt": "x"})
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "does not accept delegations from") {
+		t.Fatalf("accept_from list: %d %q", rec.Code, rec.Body.String())
+	}
+
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "alpha", "prompt": "x"})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("self-delegation: %d %q", rec.Code, rec.Body.String())
+	}
+
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "ghost-node", "prompt": "x"})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown target: %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHubDelegationCwdConfinement(t *testing.T) {
+	s, fake := newDelegationHub(t)
+
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x", "cwd": "/etc"})
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "outside the target node's delegation workdir") {
+		t.Fatalf("escape cwd: %d %q", rec.Code, rec.Body.String())
+	}
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x", "cwd": "/work/../etc"})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("dot-dot cwd: %d %q", rec.Code, rec.Body.String())
+	}
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "gamma", "prompt": "x", "cwd": "/work/sub/dir"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("nested cwd: %d %q", rec.Code, rec.Body.String())
+	}
+	runner, _ := fake.lastJobBody["runner_config"].(map[string]any)
+	if runner["cwd"] != "/work/sub/dir" {
+		t.Fatalf("cwd = %v", runner["cwd"])
+	}
+}
+
+func TestHubDelegationParentDepthAndLoops(t *testing.T) {
+	s, _ := newDelegationHub(t)
+
+	_, root := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "root"})
+	if root.ID == "" {
+		t.Fatalf("root create failed")
+	}
+
+	// beta (target of root) chains to gamma: depth 2.
+	rec, child := createDelegation(t, s, "beta", "beta-token", map[string]any{
+		"target_node": "gamma", "prompt": "child", "parent_delegation_id": root.ID,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("chained create: %d %q", rec.Code, rec.Body.String())
+	}
+	if child.Depth != 2 || strings.Join(child.Chain, ",") != "alpha,beta,gamma" {
+		t.Fatalf("child depth/chain = %d %v", child.Depth, child.Chain)
+	}
+
+	// Unknown parent id.
+	rec, _ = createDelegation(t, s, "beta", "beta-token", map[string]any{
+		"target_node": "gamma", "prompt": "x", "parent_delegation_id": "dlg_nope",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown parent: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// Only the node the parent targeted may chain on it.
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "gamma", "prompt": "x", "parent_delegation_id": root.ID,
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("parent ownership: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// Loop refusal: root chain is alpha->beta, so beta may not delegate back
+	// to alpha under that parent.
+	rec, _ = createDelegation(t, s, "beta", "beta-token", map[string]any{
+		"target_node": "alpha", "prompt": "x", "parent_delegation_id": root.ID,
+	})
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "delegation loop") {
+		t.Fatalf("loop: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// Depth cap: a parent already at max depth cannot chain further.
+	deep := hub.Delegation{
+		ID: "dlg_deep", OriginNode: "x1", TargetNode: "alpha",
+		Status: hub.DelegationStatusRunning, Depth: hub.DefaultDelegationMaxDepth,
+		Chain: []string{"x1", "x2", "alpha"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	if err := s.delegations.Add(deep); err != nil {
+		t.Fatalf("seed deep parent: %v", err)
+	}
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "gamma", "prompt": "x", "parent_delegation_id": "dlg_deep",
+	})
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "depth") {
+		t.Fatalf("depth cap: %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHubDelegationStatusRefreshAndList(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	_, d := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+
+	// Still running on the target.
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status GET: %d %q", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Delegation hub.Delegation `json:"delegation"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Delegation.Status != hub.DelegationStatusRunning {
+		t.Fatalf("status = %q", resp.Delegation.Status)
+	}
+
+	// Target finishes; the Hub dashboard list refresh folds the result into the
+	// ledger too, so artifact links/images appear without opening an item route.
+	fake.setRun("succeeded", "![art](/chat/files/art.svg)", "")
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/delegations", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), hub.DelegationStatusSucceeded) || !strings.Contains(rec.Body.String(), "/chat/files/art.svg") {
+		t.Fatalf("dashboard list refresh: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// Item polling also returns the refreshed terminal result.
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, "alpha", "alpha-token", nil))
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Delegation.Status != hub.DelegationStatusSucceeded || resp.Delegation.Response != "![art](/chat/files/art.svg)" {
+		t.Fatalf("refreshed = %+v", resp.Delegation)
+	}
+	stored, ok, _ := s.delegations.Get(d.ID)
+	if !ok || stored.Status != hub.DelegationStatusSucceeded {
+		t.Fatalf("ledger not updated: %+v", stored)
+	}
+
+	// Same-origin browser GET (no node auth) may read; the list carries no tokens.
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/delegations", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), d.ID) {
+		t.Fatalf("list: %d %q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "beta-token") {
+		t.Fatalf("list leaked a token")
+	}
+
+	// Failed node auth must not fall back to the browser path.
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations", "alpha", "wrong", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad node auth fallback: %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/delegations/dlg_missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing id: %d", rec.Code)
+	}
+}
+
+func TestHubDelegationCancel(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	_, d := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+
+	// Only the originating node may cancel.
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodPost, "/api/delegations/"+d.ID+"/cancel", "beta", "beta-token", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-origin cancel: %d %q", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodPost, "/api/delegations/"+d.ID+"/cancel", "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("origin cancel: %d %q", rec.Code, rec.Body.String())
+	}
+	fake.mu.Lock()
+	cancelled := append([]string(nil), fake.cancelled...)
+	fake.mu.Unlock()
+	if len(cancelled) != 1 || cancelled[0] != d.RunID {
+		t.Fatalf("cancelled runs = %v, want [%s]", cancelled, d.RunID)
+	}
+
+	// Once terminal, cancelling again conflicts.
+	fake.setRun("cancelled", "", "cancelled by user")
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh after cancel: %d", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodPost, "/api/delegations/"+d.ID+"/cancel", "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("cancel terminal: %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHubDelegationInFlightCaps(t *testing.T) {
+	s, _ := newDelegationHub(t)
+
+	// beta's policy caps in-flight delegations at 1; the fake target reports
+	// the first run still running, so the second create must be refused.
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "first"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("first create: %d %q", rec.Code, rec.Body.String())
+	}
+	rec, _ = createDelegation(t, s, "gamma", "gamma-token", map[string]any{"target_node": "beta", "prompt": "second"})
+	if rec.Code != http.StatusTooManyRequests || !strings.Contains(rec.Body.String(), "in flight") {
+		t.Fatalf("capped create: %d %q", rec.Code, rec.Body.String())
+	}
+	// Other targets are unaffected by beta's cap.
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "gamma", "prompt": "third"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("other target: %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestResolveDelegationCwd(t *testing.T) {
+	cases := []struct {
+		workdir, requested, want string
+		wantErr                  bool
+	}{
+		{"/work", "", "/work", false},
+		{"/work/", "", "/work", false},
+		{"/work", "/work", "/work", false},
+		{"/work", "/work/sub", "/work/sub", false},
+		{"/work", "sub/dir", "/work/sub/dir", false},
+		{"/work", "/worker", "", true},
+		{"/work", "/etc", "", true},
+		{"/work", "/work/../etc", "", true},
+		{"/work", "../outside", "", true},
+		{"", "", "", true},
+		// Workdir canonicalization: relative or root workdirs are refused,
+		// un-normalized ones are cleaned before containment checks.
+		{"relative", "", "", true},
+		{"/", "", "", true},
+		{"/work/..", "", "", true},
+		{"/work/.", "", "/work", false},
+		{"/work/sub/..", "sub", "/work/sub", false},
+	}
+	for _, tc := range cases {
+		got, err := resolveDelegationCwd(tc.workdir, tc.requested)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("resolveDelegationCwd(%q, %q) = %q, want error", tc.workdir, tc.requested, got)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Errorf("resolveDelegationCwd(%q, %q) = %q, %v; want %q", tc.workdir, tc.requested, got, err, tc.want)
+		}
+	}
+}
+
+func TestHubDelegationAgentModelPolicy(t *testing.T) {
+	s, _ := newDelegationHub(t)
+
+	// Default policy: only the default delegation agent is accepted.
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "beta", "prompt": "x", "agent_name": "shell"})
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "default delegation agent") {
+		t.Fatalf("non-default agent: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// "*" accepts plain agent names but never path-like ones.
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "anyagent", "prompt": "x", "agent_name": "reviewer"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("wildcard agent: %d %q", rec.Code, rec.Body.String())
+	}
+	for _, agent := range []string{"../evil", "skills/custom-agent", ".hidden", `..\evil`, "~root"} {
+		rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+			"target_node": "anyagent", "prompt": "x", "agent_name": agent})
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("path-like agent %q: %d %q", agent, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Path-like names work when listed exactly.
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "pathy", "prompt": "x", "agent_name": "skills/custom-agent"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("exact path agent: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// Model overrides: refused without allowed_models, exact match enforced.
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "gamma", "prompt": "x", "model": "haiku"})
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "model override") {
+		t.Fatalf("model without allowed_models: %d %q", rec.Code, rec.Body.String())
+	}
+	rec, _ = createDelegation(t, s, "alpha", "alpha-token", map[string]any{
+		"target_node": "beta", "prompt": "x", "model": "gpt-x"})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("disallowed model: %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHubDelegationReadScoping(t *testing.T) {
+	s, _ := newDelegationHub(t)
+	_, d := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "private"})
+	if d.ID == "" {
+		t.Fatalf("create failed")
+	}
+
+	// A node that is neither origin nor target must not see the record.
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations", "gamma", "gamma-token", nil))
+	if rec.Code != http.StatusOK || strings.Contains(rec.Body.String(), d.ID) {
+		t.Fatalf("foreign list: %d %q", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, "gamma", "gamma-token", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("foreign item should 404: %d %q", rec.Code, rec.Body.String())
+	}
+
+	// Origin and target both may read item and see it in their list.
+	for _, creds := range [][2]string{{"alpha", "alpha-token"}, {"beta", "beta-token"}} {
+		rec = httptest.NewRecorder()
+		s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, creds[0], creds[1], nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("party read %s: %d %q", creds[0], rec.Code, rec.Body.String())
+		}
+		rec = httptest.NewRecorder()
+		s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations", creds[0], creds[1], nil))
+		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), d.ID) {
+			t.Fatalf("party list %s: %d", creds[0], rec.Code)
+		}
+	}
+}
+
+func TestHubDelegationTargetTokenRedactedFromErrors(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	fake.mu.Lock()
+	fake.reflectAuthFailures = true
+	fake.mu.Unlock()
+
+	// Job creation fails with a body reflecting the Authorization header; the
+	// hub's error response must never carry the target token back.
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d %q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "beta-token") {
+		t.Fatalf("error leaked the target token: %q", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "[redacted]") {
+		t.Fatalf("expected redaction marker in %q", rec.Body.String())
+	}
+}
+
+func TestHubDelegationTargetTokenRedactedFromLedger(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	fake.mu.Lock()
+	fake.reflectTriggerFailure = true
+	fake.mu.Unlock()
+
+	// Create succeeds, trigger fails reflecting the Authorization header: the
+	// orphan audit record must store the redacted error.
+	rec, _ := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d %q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "beta-token") {
+		t.Fatalf("error leaked the target token: %q", rec.Body.String())
+	}
+	records, err := s.delegations.List()
+	if err != nil || len(records) != 1 {
+		t.Fatalf("ledger records = %v (%v)", records, err)
+	}
+	if strings.Contains(records[0].Error, "beta-token") {
+		t.Fatalf("ledger stored the target token: %q", records[0].Error)
+	}
+	if !strings.Contains(records[0].Error, "[redacted]") {
+		t.Fatalf("expected redaction marker in ledger error %q", records[0].Error)
+	}
+}
+
+func TestHubDelegationRefreshUsesExactRunID(t *testing.T) {
+	s, fake := newDelegationHub(t)
+	_, d := createDelegation(t, s, "alpha", "alpha-token", map[string]any{"target_node": "beta", "prompt": "x"})
+	fake.setRun("succeeded", "done", "")
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, delegationRequest(http.MethodGet, "/api/delegations/"+d.ID, "alpha", "alpha-token", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh: %d %q", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Delegation hub.Delegation `json:"delegation"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Delegation.Status != hub.DelegationStatusSucceeded || resp.Delegation.Response != "done" {
+		t.Fatalf("refreshed = %+v", resp.Delegation)
+	}
+	fake.mu.Lock()
+	gets := append([]string(nil), fake.runGets...)
+	fake.mu.Unlock()
+	if len(gets) == 0 || gets[len(gets)-1] != d.RunID {
+		t.Fatalf("run gets = %v, want exact run id %q", gets, d.RunID)
+	}
+}
+
+func TestHubDelegationIDFromJobLabels(t *testing.T) {
+	cases := []struct {
+		labels string
+		want   string
+	}{
+		{`{"hub_delegation":{"id":"dlg_abc"}}`, "dlg_abc"},
+		{`{"hub_delegation":{"id":" dlg_abc "}}`, "dlg_abc"},
+		{`{"other":true}`, ""},
+		{`not json`, ""},
+		{``, ""},
+	}
+	for _, tc := range cases {
+		if got := hubDelegationIDFromJobLabels(json.RawMessage(tc.labels)); got != tc.want {
+			t.Errorf("hubDelegationIDFromJobLabels(%q) = %q, want %q", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestJobsV2LLMRunnerHubDelegationContext(t *testing.T) {
+	got := "unset"
+	runner := &jobsV2LLMRunner{exec: func(ctx context.Context, cfg jobsV2LLMConfig, onEvent func(llm.Event)) (serveJobsExecResult, error) {
+		got = tools.HubDelegationIDFromContext(ctx)
+		return serveJobsExecResult{}, nil
+	}}
+	job := jobsV2Job{
+		RunnerConfig: json.RawMessage(`{"agent_name":"developer","instructions":"x","cwd":"/tmp"}`),
+		Labels:       json.RawMessage(`{"hub_delegation":{"id":"dlg_label"}}`),
+	}
+	if _, err := runner.Run(context.Background(), job, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got != "dlg_label" {
+		t.Fatalf("delegation id in tool context = %q, want dlg_label", got)
+	}
+
+	job.Labels = nil
+	if _, err := runner.Run(context.Background(), job, nil); err != nil {
+		t.Fatalf("Run without labels: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("delegation id without labels = %q, want empty", got)
+	}
+}

--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -245,9 +245,13 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 	if c == nil {
 		return nil, fmt.Errorf("node %q is not connected", node.ID)
 	}
-	body, err := io.ReadAll(io.LimitReader(req.Body, 32<<20))
-	if err != nil {
-		return nil, err
+	var body []byte
+	if req.Body != nil {
+		var readErr error
+		body, readErr = io.ReadAll(io.LimitReader(req.Body, 32<<20))
+		if readErr != nil {
+			return nil, readErr
+		}
 	}
 	id := fmt.Sprintf("req_%d", time.Now().UnixNano())
 	ch := make(chan hubReverseResponse, 1)

--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/samsaffron/term-llm/internal/hub"
+)
+
+// Reverse node connections let a private node dial out to a public Hub. The
+// Hub still exposes the same node abstraction: callers ask the Hub to request a
+// node path, and the transport is either direct HTTP or this websocket tunnel.
+// The tunnel is deliberately small: one request frame, one buffered response
+// frame. That is enough for Hub UI proxying and jobs-v2 delegation without
+// adding offline queues, arbitrary forwarding, or a second delegation API.
+
+const (
+	hubReversePingInterval = 20 * time.Second
+	hubReversePongWait     = 60 * time.Second
+	hubReverseWriteWait    = 10 * time.Second
+)
+
+type hubReverseRequest struct {
+	ID     string      `json:"id"`
+	Method string      `json:"method"`
+	Path   string      `json:"path"`
+	Header http.Header `json:"header,omitempty"`
+	Body   []byte      `json:"body,omitempty"`
+}
+
+type hubReverseResponse struct {
+	ID     string      `json:"id"`
+	Status int         `json:"status"`
+	Header http.Header `json:"header,omitempty"`
+	Body   []byte      `json:"body,omitempty"`
+	Error  string      `json:"error,omitempty"`
+}
+
+type hubReverseConnection struct {
+	nodeID      string
+	connectedAt time.Time
+	lastSeenMu  sync.RWMutex
+	lastSeen    time.Time
+	conn        *websocket.Conn
+	writeMu     sync.Mutex
+	pendingMu   sync.Mutex
+	pending     map[string]chan hubReverseResponse
+}
+
+type hubReverseManager struct {
+	mu    sync.RWMutex
+	conns map[string]*hubReverseConnection
+}
+
+func newHubReverseManager() *hubReverseManager {
+	return &hubReverseManager{conns: map[string]*hubReverseConnection{}}
+}
+
+func (m *hubReverseManager) isConnected(nodeID string) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	c := m.conns[nodeID]
+	m.mu.RUnlock()
+	return c != nil
+}
+
+func (m *hubReverseManager) status(nodeID string) (connected bool, connectedAt, lastSeen time.Time) {
+	if m == nil {
+		return false, time.Time{}, time.Time{}
+	}
+	m.mu.RLock()
+	c := m.conns[nodeID]
+	m.mu.RUnlock()
+	if c == nil {
+		return false, time.Time{}, time.Time{}
+	}
+	return true, c.connectedAt, c.lastSeenValue()
+}
+
+func (m *hubReverseManager) attach(node hub.Node, conn *websocket.Conn) {
+	c := &hubReverseConnection{
+		nodeID:      node.ID,
+		connectedAt: time.Now().UTC(),
+		lastSeen:    time.Now().UTC(),
+		conn:        conn,
+		pending:     map[string]chan hubReverseResponse{},
+	}
+	m.mu.Lock()
+	old := m.conns[node.ID]
+	m.conns[node.ID] = c
+	m.mu.Unlock()
+	if old != nil {
+		_ = old.conn.Close()
+		old.failPending("reverse connection replaced")
+	}
+	go c.readLoop(func() {
+		m.mu.Lock()
+		if m.conns[node.ID] == c {
+			delete(m.conns, node.ID)
+		}
+		m.mu.Unlock()
+	})
+}
+
+func (c *hubReverseConnection) touch() {
+	c.lastSeenMu.Lock()
+	c.lastSeen = time.Now().UTC()
+	c.lastSeenMu.Unlock()
+}
+
+func (c *hubReverseConnection) lastSeenValue() time.Time {
+	c.lastSeenMu.RLock()
+	defer c.lastSeenMu.RUnlock()
+	return c.lastSeen
+}
+
+func hubReverseSetHeartbeat(conn *websocket.Conn, touch func()) error {
+	if touch != nil {
+		touch()
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(hubReversePongWait)); err != nil {
+		return err
+	}
+	conn.SetPongHandler(func(string) error {
+		if touch != nil {
+			touch()
+		}
+		return conn.SetReadDeadline(time.Now().Add(hubReversePongWait))
+	})
+	return nil
+}
+
+func hubReversePingLoop(conn *websocket.Conn, writeMu *sync.Mutex, done <-chan struct{}) {
+	ticker := time.NewTicker(hubReversePingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			writeMu.Lock()
+			_ = conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
+			err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(hubReverseWriteWait))
+			_ = conn.SetWriteDeadline(time.Time{})
+			writeMu.Unlock()
+			if err != nil {
+				_ = conn.Close()
+				return
+			}
+		}
+	}
+}
+
+func (c *hubReverseConnection) readLoop(done func()) {
+	donePing := make(chan struct{})
+	defer close(donePing)
+	defer done()
+	defer c.conn.Close()
+	if err := hubReverseSetHeartbeat(c.conn, c.touch); err != nil {
+		c.failPending(fmt.Sprintf("reverse connection heartbeat setup failed: %v", err))
+		return
+	}
+	go hubReversePingLoop(c.conn, &c.writeMu, donePing)
+	for {
+		var resp hubReverseResponse
+		if err := c.conn.ReadJSON(&resp); err != nil {
+			c.failPending(fmt.Sprintf("reverse connection closed: %v", err))
+			return
+		}
+		c.touch()
+		c.pendingMu.Lock()
+		ch := c.pending[resp.ID]
+		delete(c.pending, resp.ID)
+		c.pendingMu.Unlock()
+		if ch != nil {
+			ch <- resp
+			close(ch)
+		}
+	}
+}
+
+func (c *hubReverseConnection) failPending(msg string) {
+	c.pendingMu.Lock()
+	pending := c.pending
+	c.pending = map[string]chan hubReverseResponse{}
+	c.pendingMu.Unlock()
+	for id, ch := range pending {
+		ch <- hubReverseResponse{ID: id, Status: http.StatusBadGateway, Error: msg}
+		close(ch)
+	}
+}
+
+func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Request) (*http.Response, error) {
+	if m == nil {
+		return nil, fmt.Errorf("node %q is configured for reverse connection but reverse transport is disabled", node.ID)
+	}
+	m.mu.RLock()
+	c := m.conns[node.ID]
+	m.mu.RUnlock()
+	if c == nil {
+		return nil, fmt.Errorf("node %q is not connected", node.ID)
+	}
+	body, err := io.ReadAll(io.LimitReader(req.Body, 32<<20))
+	if err != nil {
+		return nil, err
+	}
+	id := fmt.Sprintf("req_%d", time.Now().UnixNano())
+	ch := make(chan hubReverseResponse, 1)
+	c.pendingMu.Lock()
+	c.pending[id] = ch
+	c.pendingMu.Unlock()
+
+	frame := hubReverseRequest{ID: id, Method: req.Method, Path: req.URL.RequestURI(), Header: req.Header.Clone(), Body: body}
+	c.writeMu.Lock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
+	err = c.conn.WriteJSON(frame)
+	_ = c.conn.SetWriteDeadline(time.Time{})
+	c.writeMu.Unlock()
+	if err != nil {
+		c.pendingMu.Lock()
+		delete(c.pending, id)
+		c.pendingMu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Error != "" {
+			return nil, errors.New(resp.Error)
+		}
+		return &http.Response{
+			StatusCode:    resp.Status,
+			Status:        fmt.Sprintf("%d %s", resp.Status, http.StatusText(resp.Status)),
+			Header:        resp.Header,
+			Body:          io.NopCloser(bytes.NewReader(resp.Body)),
+			ContentLength: int64(len(resp.Body)),
+			Request:       req,
+		}, nil
+	case <-ctx.Done():
+		c.pendingMu.Lock()
+		delete(c.pending, id)
+		c.pendingMu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+func (s *hubServer) handleReverseConnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	node, err := s.authenticateNode(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if !node.UsesReverseConnection() {
+		http.Error(w, fmt.Sprintf("node %q is not configured for reverse connection", node.ID), http.StatusForbidden)
+		return
+	}
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	s.reverse.attach(node, conn)
+	log.Printf("hub: reverse node %q connected", node.ID)
+}
+
+func localHubConnectBase(host string, port int, _ string) string {
+	host = strings.TrimSpace(host)
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s", netJoinHostPortForURL(host, port))
+}
+
+func netJoinHostPortForURL(host string, port int) string {
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		return fmt.Sprintf("[%s]:%d", host, port)
+	}
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
+func runHubReverseConnector(ctx context.Context, hubURL, nodeID, token, localBase, allowedBasePath string, client *http.Client) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	for ctx.Err() == nil {
+		if err := hubReverseConnectOnce(ctx, hubURL, nodeID, token, localBase, allowedBasePath, client); err != nil && ctx.Err() == nil {
+			log.Printf("hub reverse connect: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func hubReverseConnectOnce(ctx context.Context, hubURL, nodeID, token, localBase, allowedBasePath string, client *http.Client) error {
+	u, err := url.Parse(strings.TrimRight(hubURL, "/") + "/api/connect")
+	if err != nil {
+		return err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return fmt.Errorf("unsupported hub url scheme %q", u.Scheme)
+	}
+	q := u.Query()
+	q.Set("node_id", nodeID)
+	u.RawQuery = q.Encode()
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+token)
+	header.Set(hubNodeIDHeader, nodeID)
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), header)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	var writeMu sync.Mutex
+	donePing := make(chan struct{})
+	defer close(donePing)
+	if err := hubReverseSetHeartbeat(conn, nil); err != nil {
+		return err
+	}
+	go hubReversePingLoop(conn, &writeMu, donePing)
+	log.Printf("hub reverse connect: node %q connected to %s", nodeID, hubURL)
+	for {
+		var req hubReverseRequest
+		if err := conn.ReadJSON(&req); err != nil {
+			return err
+		}
+		resp := handleHubReverseRequest(ctx, req, token, localBase, allowedBasePath, client)
+		writeMu.Lock()
+		_ = conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
+		err := conn.WriteJSON(resp)
+		_ = conn.SetWriteDeadline(time.Time{})
+		writeMu.Unlock()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func handleHubReverseRequest(ctx context.Context, frame hubReverseRequest, token, localBase, allowedBasePath string, client *http.Client) hubReverseResponse {
+	if frame.ID == "" {
+		return hubReverseResponse{Status: http.StatusBadRequest, Error: "missing request id"}
+	}
+	if !strings.HasPrefix(frame.Path, "/") || hubContainsEncodedSeparator(frame.Path) || hubHasDotDotSegment(frame.Path) {
+		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadRequest, Error: "invalid reverse request path"}
+	}
+	pathOnly := frame.Path
+	if i := strings.IndexByte(pathOnly, '?'); i >= 0 {
+		pathOnly = pathOnly[:i]
+	}
+	allowedBasePath = strings.TrimRight(allowedBasePath, "/")
+	if allowedBasePath != "" && pathOnly != allowedBasePath && !strings.HasPrefix(pathOnly, allowedBasePath+"/") {
+		return hubReverseResponse{ID: frame.ID, Status: http.StatusForbidden, Error: "reverse request outside node base path"}
+	}
+	localURL := strings.TrimRight(localBase, "/") + frame.Path
+	req, err := http.NewRequestWithContext(ctx, frame.Method, localURL, bytes.NewReader(frame.Body))
+	if err != nil {
+		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadRequest, Error: err.Error()}
+	}
+	req.Header = frame.Header.Clone()
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadGateway, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadGateway, Error: err.Error()}
+	}
+	return hubReverseResponse{ID: frame.ID, Status: resp.StatusCode, Header: resp.Header.Clone(), Body: body}
+}

--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -20,27 +20,37 @@ import (
 // Reverse node connections let a private node dial out to a public Hub. The
 // Hub still exposes the same node abstraction: callers ask the Hub to request a
 // node path, and the transport is either direct HTTP or this websocket tunnel.
-// The tunnel is deliberately small: one request frame, one buffered response
-// frame. That is enough for Hub UI proxying and jobs-v2 delegation without
-// adding offline queues, arbitrary forwarding, or a second delegation API.
+// The tunnel uses a small JSON frame protocol: the Hub sends request frames; the
+// node replies with response_start, response_body, and response_end frames. A
+// legacy single buffered response frame is still accepted so older tests and
+// doNodeJSON-style callers keep working as ordinary http.Response readers.
 
 const (
 	hubReversePingInterval = 20 * time.Second
 	hubReversePongWait     = 60 * time.Second
 	hubReverseWriteWait    = 10 * time.Second
+	hubReverseChunkSize    = 32 * 1024
+
+	hubReverseFrameRequest       = "request"
+	hubReverseFrameCancel        = "cancel"
+	hubReverseFrameResponseStart = "response_start"
+	hubReverseFrameResponseBody  = "response_body"
+	hubReverseFrameResponseEnd   = "response_end"
 )
 
 type hubReverseRequest struct {
+	Type   string      `json:"type,omitempty"`
 	ID     string      `json:"id"`
-	Method string      `json:"method"`
-	Path   string      `json:"path"`
+	Method string      `json:"method,omitempty"`
+	Path   string      `json:"path,omitempty"`
 	Header http.Header `json:"header,omitempty"`
 	Body   []byte      `json:"body,omitempty"`
 }
 
 type hubReverseResponse struct {
+	Type   string      `json:"type,omitempty"`
 	ID     string      `json:"id"`
-	Status int         `json:"status"`
+	Status int         `json:"status,omitempty"`
 	Header http.Header `json:"header,omitempty"`
 	Body   []byte      `json:"body,omitempty"`
 	Error  string      `json:"error,omitempty"`
@@ -182,13 +192,24 @@ func (c *hubReverseConnection) readLoop(done func()) {
 		c.touch()
 		c.pendingMu.Lock()
 		ch := c.pending[resp.ID]
-		delete(c.pending, resp.ID)
+		if hubReverseResponseFrameTerminal(resp) {
+			delete(c.pending, resp.ID)
+		}
 		c.pendingMu.Unlock()
 		if ch != nil {
 			ch <- resp
-			close(ch)
+			if hubReverseResponseFrameTerminal(resp) {
+				close(ch)
+			}
 		}
 	}
+}
+
+func hubReverseResponseFrameTerminal(resp hubReverseResponse) bool {
+	if resp.Type == "" {
+		return true
+	}
+	return resp.Type == hubReverseFrameResponseEnd || resp.Error != ""
 }
 
 func (c *hubReverseConnection) failPending(msg string) {
@@ -197,9 +218,21 @@ func (c *hubReverseConnection) failPending(msg string) {
 	c.pending = map[string]chan hubReverseResponse{}
 	c.pendingMu.Unlock()
 	for id, ch := range pending {
-		ch <- hubReverseResponse{ID: id, Status: http.StatusBadGateway, Error: msg}
+		select {
+		case ch <- hubReverseResponse{ID: id, Status: http.StatusBadGateway, Error: msg}:
+		default:
+		}
 		close(ch)
 	}
+}
+
+func (c *hubReverseConnection) writeRequest(frame hubReverseRequest) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
+	err := c.conn.WriteJSON(frame)
+	_ = c.conn.SetWriteDeadline(time.Time{})
+	return err
 }
 
 func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Request) (*http.Response, error) {
@@ -222,13 +255,8 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 	c.pending[id] = ch
 	c.pendingMu.Unlock()
 
-	frame := hubReverseRequest{ID: id, Method: req.Method, Path: req.URL.RequestURI(), Header: req.Header.Clone(), Body: body}
-	c.writeMu.Lock()
-	_ = c.conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
-	err = c.conn.WriteJSON(frame)
-	_ = c.conn.SetWriteDeadline(time.Time{})
-	c.writeMu.Unlock()
-	if err != nil {
+	frame := hubReverseRequest{Type: hubReverseFrameRequest, ID: id, Method: req.Method, Path: req.URL.RequestURI(), Header: req.Header.Clone(), Body: body}
+	if err := c.writeRequest(frame); err != nil {
 		c.pendingMu.Lock()
 		delete(c.pending, id)
 		c.pendingMu.Unlock()
@@ -237,9 +265,18 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 
 	select {
 	case resp := <-ch:
-		if resp.Error != "" {
-			return nil, errors.New(resp.Error)
-		}
+		return c.buildHTTPResponseFromReverseFrame(ctx, req, id, ch, resp)
+	case <-ctx.Done():
+		c.cancelPending(id)
+		return nil, ctx.Err()
+	}
+}
+
+func (c *hubReverseConnection) buildHTTPResponseFromReverseFrame(ctx context.Context, req *http.Request, id string, ch <-chan hubReverseResponse, resp hubReverseResponse) (*http.Response, error) {
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	if resp.Type == "" {
 		return &http.Response{
 			StatusCode:    resp.Status,
 			Status:        fmt.Sprintf("%d %s", resp.Status, http.StatusText(resp.Status)),
@@ -248,12 +285,60 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 			ContentLength: int64(len(resp.Body)),
 			Request:       req,
 		}, nil
-	case <-ctx.Done():
-		c.pendingMu.Lock()
-		delete(c.pending, id)
-		c.pendingMu.Unlock()
-		return nil, ctx.Err()
 	}
+	if resp.Type != hubReverseFrameResponseStart {
+		return nil, fmt.Errorf("unexpected reverse response frame %q", resp.Type)
+	}
+	pr, pw := io.Pipe()
+	go c.copyReverseResponseBody(ctx, id, ch, pw)
+	return &http.Response{
+		StatusCode: resp.Status,
+		Status:     fmt.Sprintf("%d %s", resp.Status, http.StatusText(resp.Status)),
+		Header:     resp.Header,
+		Body:       pr,
+		Request:    req,
+	}, nil
+}
+
+func (c *hubReverseConnection) copyReverseResponseBody(ctx context.Context, id string, ch <-chan hubReverseResponse, pw *io.PipeWriter) {
+	defer pw.Close()
+	for {
+		select {
+		case resp, ok := <-ch:
+			if !ok {
+				return
+			}
+			if resp.Error != "" {
+				_ = pw.CloseWithError(errors.New(resp.Error))
+				return
+			}
+			switch resp.Type {
+			case hubReverseFrameResponseBody:
+				if len(resp.Body) > 0 {
+					if _, err := pw.Write(resp.Body); err != nil {
+						c.cancelPending(id)
+						return
+					}
+				}
+			case hubReverseFrameResponseEnd:
+				return
+			default:
+				_ = pw.CloseWithError(fmt.Errorf("unexpected reverse response frame %q", resp.Type))
+				return
+			}
+		case <-ctx.Done():
+			_ = pw.CloseWithError(ctx.Err())
+			c.cancelPending(id)
+			return
+		}
+	}
+}
+
+func (c *hubReverseConnection) cancelPending(id string) {
+	c.pendingMu.Lock()
+	delete(c.pending, id)
+	c.pendingMu.Unlock()
+	_ = c.writeRequest(hubReverseRequest{Type: hubReverseFrameCancel, ID: id})
 }
 
 func (s *hubServer) handleReverseConnect(w http.ResponseWriter, r *http.Request) {
@@ -343,29 +428,64 @@ func hubReverseConnectOnce(ctx context.Context, hubURL, nodeID, token, localBase
 	}
 	go hubReversePingLoop(conn, &writeMu, donePing)
 	log.Printf("hub reverse connect: node %q connected to %s", nodeID, hubURL)
+	activeMu := sync.Mutex{}
+	active := map[string]context.CancelFunc{}
+	defer func() {
+		activeMu.Lock()
+		defer activeMu.Unlock()
+		for _, cancel := range active {
+			cancel()
+		}
+	}()
 	for {
 		var req hubReverseRequest
 		if err := conn.ReadJSON(&req); err != nil {
 			return err
 		}
-		resp := handleHubReverseRequest(ctx, req, token, localBase, allowedBasePath, client)
-		writeMu.Lock()
-		_ = conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
-		err := conn.WriteJSON(resp)
-		_ = conn.SetWriteDeadline(time.Time{})
-		writeMu.Unlock()
-		if err != nil {
-			return err
+		if req.Type == hubReverseFrameCancel {
+			activeMu.Lock()
+			cancel := active[req.ID]
+			delete(active, req.ID)
+			activeMu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
+			continue
 		}
+		reqCtx, cancel := context.WithCancel(ctx)
+		activeMu.Lock()
+		active[req.ID] = cancel
+		activeMu.Unlock()
+		go func(req hubReverseRequest, reqCtx context.Context, cancel context.CancelFunc) {
+			defer func() {
+				activeMu.Lock()
+				delete(active, req.ID)
+				activeMu.Unlock()
+				cancel()
+			}()
+			handleHubReverseRequest(reqCtx, req, token, localBase, allowedBasePath, client, func(resp hubReverseResponse) error {
+				writeMu.Lock()
+				defer writeMu.Unlock()
+				_ = conn.SetWriteDeadline(time.Now().Add(hubReverseWriteWait))
+				err := conn.WriteJSON(resp)
+				_ = conn.SetWriteDeadline(time.Time{})
+				return err
+			})
+		}(req, reqCtx, cancel)
 	}
 }
 
-func handleHubReverseRequest(ctx context.Context, frame hubReverseRequest, token, localBase, allowedBasePath string, client *http.Client) hubReverseResponse {
+func handleHubReverseRequest(ctx context.Context, frame hubReverseRequest, token, localBase, allowedBasePath string, client *http.Client, writeFrame func(hubReverseResponse) error) {
+	sendError := func(status int, msg string) {
+		_ = writeFrame(hubReverseResponse{Type: hubReverseFrameResponseStart, ID: frame.ID, Status: status, Error: msg})
+	}
 	if frame.ID == "" {
-		return hubReverseResponse{Status: http.StatusBadRequest, Error: "missing request id"}
+		_ = writeFrame(hubReverseResponse{Type: hubReverseFrameResponseStart, Status: http.StatusBadRequest, Error: "missing request id"})
+		return
 	}
 	if !strings.HasPrefix(frame.Path, "/") || hubContainsEncodedSeparator(frame.Path) || hubHasDotDotSegment(frame.Path) {
-		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadRequest, Error: "invalid reverse request path"}
+		sendError(http.StatusBadRequest, "invalid reverse request path")
+		return
 	}
 	pathOnly := frame.Path
 	if i := strings.IndexByte(pathOnly, '?'); i >= 0 {
@@ -373,25 +493,53 @@ func handleHubReverseRequest(ctx context.Context, frame hubReverseRequest, token
 	}
 	allowedBasePath = strings.TrimRight(allowedBasePath, "/")
 	if allowedBasePath != "" && pathOnly != allowedBasePath && !strings.HasPrefix(pathOnly, allowedBasePath+"/") {
-		return hubReverseResponse{ID: frame.ID, Status: http.StatusForbidden, Error: "reverse request outside node base path"}
+		sendError(http.StatusForbidden, "reverse request outside node base path")
+		return
 	}
 	localURL := strings.TrimRight(localBase, "/") + frame.Path
 	req, err := http.NewRequestWithContext(ctx, frame.Method, localURL, bytes.NewReader(frame.Body))
 	if err != nil {
-		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadRequest, Error: err.Error()}
+		sendError(http.StatusBadRequest, err.Error())
+		return
 	}
 	req.Header = frame.Header.Clone()
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadGateway, Error: err.Error()}
+		if ctx.Err() != nil {
+			return
+		}
+		sendError(http.StatusBadGateway, err.Error())
+		return
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
-	if err != nil {
-		return hubReverseResponse{ID: frame.ID, Status: http.StatusBadGateway, Error: err.Error()}
+	if err := writeFrame(hubReverseResponse{Type: hubReverseFrameResponseStart, ID: frame.ID, Status: resp.StatusCode, Header: resp.Header.Clone()}); err != nil {
+		return
 	}
-	return hubReverseResponse{ID: frame.ID, Status: resp.StatusCode, Header: resp.Header.Clone(), Body: body}
+	buf := make([]byte, hubReverseChunkSize)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			if err := writeFrame(hubReverseResponse{Type: hubReverseFrameResponseBody, ID: frame.ID, Body: chunk}); err != nil {
+				return
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				_ = writeFrame(hubReverseResponse{Type: hubReverseFrameResponseEnd, ID: frame.ID})
+				return
+			}
+			if ctx.Err() == nil {
+				_ = writeFrame(hubReverseResponse{Type: hubReverseFrameResponseEnd, ID: frame.ID, Error: readErr.Error()})
+			}
+			return
+		}
+	}
 }

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+)
+
+func TestHubReverseNodeProxy(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/healthz" {
+			t.Fatalf("backend path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer node-token" {
+			t.Fatalf("backend auth = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","agent":"artist"}`))
+	}))
+	defer backend.Close()
+
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	hubTS := httptest.NewServer(s.handler())
+	defer hubTS.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	waitForReverseNode(t, s, "artist")
+
+	req := httptest.NewRequest(http.MethodGet, "/node/artist/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"agent":"artist"`) {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestHubReverseDelegationNodeJSON(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/v2/jobs" {
+			t.Fatalf("backend path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer node-token" {
+			t.Fatalf("backend auth = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"job_reverse"}`))
+	}))
+	defer backend.Close()
+
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	hubTS := httptest.NewServer(s.handler())
+	defer hubTS.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	waitForReverseNode(t, s, "artist")
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := s.doNodeJSON(ctx, node, http.MethodPost, "/v2/jobs", map[string]string{"name": "demo"}, &out); err != nil {
+		t.Fatalf("doNodeJSON: %v", err)
+	}
+	if out.ID != "job_reverse" {
+		t.Fatalf("id = %q", out.ID)
+	}
+}
+
+func waitForReverseNode(t *testing.T, s *hubServer, nodeID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.reverse.isConnected(nodeID) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("node %q did not connect", nodeID)
+}

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,6 +44,86 @@ func TestHubReverseNodeProxy(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"agent":"artist"`) {
 		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestHubReverseNodeProxyStreamsChunkedResponse(t *testing.T) {
+	large := strings.Repeat("0123456789abcdef", (hubReverseChunkSize*3)/16)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/stream" {
+			t.Fatalf("backend path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(large))
+	}))
+	defer backend.Close()
+
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	hubTS := httptest.NewServer(s.handler())
+	defer hubTS.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	waitForReverseNode(t, s, "artist")
+
+	req := httptest.NewRequest(http.MethodGet, "/node/artist/stream", nil)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body len=%d", rec.Code, rec.Body.Len())
+	}
+	if rec.Body.String() != large {
+		t.Fatalf("streamed body mismatch len=%d want=%d", rec.Body.Len(), len(large))
+	}
+}
+
+func TestHubReverseResponseCancellation(t *testing.T) {
+	backendCanceled := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/slow" {
+			t.Fatalf("backend path = %q", r.URL.Path)
+		}
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte("hello"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+		close(backendCanceled)
+	}))
+	defer backend.Close()
+
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	hubTS := httptest.NewServer(s.handler())
+	defer hubTS.Close()
+
+	connectorCtx, stopConnector := context.WithCancel(context.Background())
+	defer stopConnector()
+	go runHubReverseConnector(connectorCtx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	waitForReverseNode(t, s, "artist")
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "http://reverse.local/chat/slow", nil).WithContext(reqCtx)
+	resp, err := s.reverse.do(reqCtx, node, req)
+	if err != nil {
+		t.Fatalf("reverse do: %v", err)
+	}
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		t.Fatalf("read first chunk: %v", err)
+	}
+	cancelReq()
+	_, err = io.ReadAll(resp.Body)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("read after cancel err = %v", err)
+	}
+	select {
+	case <-backendCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("backend request was not canceled")
 	}
 }
 

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -1,0 +1,404 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+)
+
+// hubWithBackend spins up a fake node serve and returns a hub fronting it as
+// node "alpha" with the given base path and a fixed token.
+func hubWithBackend(t *testing.T, basePath string, h http.HandlerFunc) *hubServer {
+	t.Helper()
+	backend := httptest.NewServer(h)
+	t.Cleanup(backend.Close)
+	return newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{{
+		ID:       "alpha",
+		Name:     "Alpha",
+		Source:   hub.SourceConfig,
+		URL:      backend.URL,
+		BasePath: basePath,
+		Token:    "tkn-123",
+	}}}), nil)
+}
+
+type fakeHubResolver struct{ nodes []hub.Node }
+
+func (f fakeHubResolver) Source() string             { return hub.SourceConfig }
+func (f fakeHubResolver) Nodes() ([]hub.Node, error) { return f.nodes, nil }
+
+func TestHubProxyInjectsTokenAndStripsCredentials(t *testing.T) {
+	var gotAuth, gotCookie, gotAPIKey, gotPath, gotQuery, gotFwd string
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotCookie = r.Header.Get("Cookie")
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		gotFwd = r.Header.Get("X-Forwarded-Host")
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		io.WriteString(w, "hello from node")
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/node/alpha/v1/models?limit=5", nil)
+	// Client-supplied credentials must never reach the node; the hub injects
+	// the real per-node token server-side.
+	req.Header.Set("Authorization", "Bearer client-supplied")
+	req.Header.Set("Cookie", "term_llm_token=client-cookie")
+	req.Header.Set("X-Api-Key", "client-key")
+	req.Header.Set("X-Forwarded-Host", "evil.example.com")
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer tkn-123" {
+		t.Errorf("backend Authorization = %q, want injected token", gotAuth)
+	}
+	if gotCookie != "" || gotAPIKey != "" || gotFwd != "" {
+		t.Errorf("credentials leaked: cookie=%q apikey=%q fwd=%q", gotCookie, gotAPIKey, gotFwd)
+	}
+	if gotPath != "/chat/v1/models" || gotQuery != "limit=5" {
+		t.Errorf("backend path = %q query = %q", gotPath, gotQuery)
+	}
+}
+
+func TestHubProxyRebasesAndInjectsHubContext(t *testing.T) {
+	const body = `<html><head><base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script></head><body></body></html>`
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, body)
+	})
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/node/alpha/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	got := rec.Body.String()
+	if !strings.Contains(got, `<base href="/node/alpha/">`) {
+		t.Errorf("base tag not rebased: %s", got)
+	}
+	if !strings.Contains(got, `window.TERM_LLM_UI_PREFIX="/node/alpha"`) {
+		t.Errorf("UI prefix not rebased: %s", got)
+	}
+	if !strings.Contains(got, `window.TERM_LLM_HUB={"nodeId":"alpha","nodeName":"Alpha","url":"/"}`) {
+		t.Errorf("hub context not injected: %s", got)
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != fmt.Sprintf("%d", len(got)) {
+		t.Errorf("Content-Length = %q, want %d", cl, len(got))
+	}
+}
+
+func TestHubProxyLeavesNonHTMLUntouched(t *testing.T) {
+	const body = `data: {"x":"/chat"}` + "\n\n"
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, body)
+	})
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/node/alpha/v1/responses", nil))
+	if rec.Body.String() != body {
+		t.Errorf("SSE body rewritten: %q", rec.Body.String())
+	}
+}
+
+func TestHubProxyRewritesLocation(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/chat/", http.StatusMovedPermanently)
+	})
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/node/alpha/chat", nil))
+	if loc := rec.Header().Get("Location"); loc != "/node/alpha/" {
+		t.Errorf("Location = %q, want /node/alpha/", loc)
+	}
+}
+
+func TestHubProxyUnknownNodeIs404(t *testing.T) {
+	s := newHubServer(hub.NewRegistry(), nil)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/node/ghost/", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHubProxyRejectsEncodedSeparatorsAndTraversal(t *testing.T) {
+	s := newHubServer(hub.NewRegistry(), nil)
+	for _, path := range []string{"/node/a%2fb/", "/node/alpha/..%2fetc"} {
+		rec := httptest.NewRecorder()
+		s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s status = %d, want 400", path, rec.Code)
+		}
+	}
+	// Go's ServeMux redirects dot-dot paths to their cleaned form before the
+	// handler runs; hit the handler directly to verify its own guard for
+	// requests that bypass mux cleaning.
+	rec := httptest.NewRecorder()
+	s.handleNodeProxy(rec, httptest.NewRequest(http.MethodGet, "/node/alpha/../escape", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("dot-dot status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHubBareNodePathRedirects(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/node/alpha?x=1", nil))
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/node/alpha/?x=1" {
+		t.Errorf("Location = %q", loc)
+	}
+}
+
+func TestHubNodesAPIDoesNotLeakTokens(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"ok","agent":"alpha-agent"}`)
+	})
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/nodes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "tkn-123") {
+		t.Fatal("node token leaked into /api/nodes response")
+	}
+	var resp struct {
+		Nodes []hubNodeView `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Nodes) != 1 {
+		t.Fatalf("nodes = %+v", resp.Nodes)
+	}
+	n := resp.Nodes[0]
+	if !n.HasToken || n.ProxyPath != "/node/alpha/" {
+		t.Errorf("node view = %+v", n)
+	}
+	if !n.Status.Reachable || n.Status.Agent != "alpha-agent" {
+		t.Errorf("status = %+v, want reachable with agent", n.Status)
+	}
+}
+
+func TestHubAddTestRemoveNodeFlow(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"ok"}`)
+	}))
+	defer backend.Close()
+
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s := newHubServer(hub.NewRegistry(store), store)
+	h := s.handler()
+
+	// Test connection (does not persist).
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/nodes/test",
+		strings.NewReader(`{"url":"`+backend.URL+`/chat","token":"t"}`))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"reachable":true`) {
+		t.Fatalf("test status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Add.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/nodes",
+		strings.NewReader(`{"name":"Beta","url":"`+backend.URL+`/chat","token":"beta-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if node, ok := s.registry.Lookup("beta"); !ok || node.Token != "beta-token" {
+		t.Fatalf("added node not resolvable: %+v %v", node, ok)
+	}
+
+	// Remove.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/api/nodes/beta", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, ok := s.registry.Lookup("beta"); ok {
+		t.Fatal("removed node still resolvable")
+	}
+}
+
+func TestHubRejectsCrossSiteBrowserRequests(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("cross-site request reached backend")
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/node/alpha/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("proxy cross-site status = %d, want 403", rec.Code)
+	}
+
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s = newHubServer(hub.NewRegistry(store), store)
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/nodes", strings.NewReader(`{"url":"http://127.0.0.1:1/chat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("api cross-site status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHubIndexBranding(t *testing.T) {
+	s := newHubServer(hub.NewRegistry(), hub.NewStore(filepath.Join(t.TempDir(), "nodes.json")))
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "term-llm Hub") && !strings.Contains(body, `term-llm <span class="hub-brand-accent">Hub</span>`) {
+		t.Error("dashboard missing term-llm Hub branding")
+	}
+	if !strings.Contains(body, "addNodeModal") {
+		t.Error("dashboard missing Add Node UI while store is enabled")
+	}
+}
+
+func TestHubTransportNoEnvProxy(t *testing.T) {
+	// The hub dials known node hosts directly; honoring HTTP_PROXY could
+	// route a token-injected request through an external proxy and leak the
+	// per-node token.
+	if newHubTransport().Proxy != nil {
+		t.Fatal("hub transport must not use an environment proxy")
+	}
+}
+
+func TestValidateHubBind(t *testing.T) {
+	cases := []struct {
+		host    string
+		port    int
+		wantErr bool
+	}{
+		{"127.0.0.1", 8090, false},
+		{"localhost", 8090, false},
+		{"::1", 8090, false},
+		{"0.0.0.0", 8090, true},
+		{"192.168.1.20", 8090, true},
+		{"127.0.0.1", 0, true},
+		{"127.0.0.1", 70000, true},
+	}
+	for _, tc := range cases {
+		if err := validateHubBind(tc.host, tc.port); (err != nil) != tc.wantErr {
+			t.Errorf("validateHubBind(%q,%d) err=%v wantErr=%v", tc.host, tc.port, err, tc.wantErr)
+		}
+	}
+}
+
+func TestHubHeadDoesNotClobberContentLength(t *testing.T) {
+	const body = `<base href="/chat/">`
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		io.WriteString(w, body)
+	})
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/node/alpha/", nil))
+	if cl := rec.Header().Get("Content-Length"); cl != fmt.Sprintf("%d", len(body)) {
+		t.Errorf("HEAD Content-Length = %q, want %d", cl, len(body))
+	}
+}
+
+func TestServeHealthIdentityGating(t *testing.T) {
+	srv := &serveServer{cfg: serveServerConfig{
+		requireAuth: true,
+		token:       "node-token",
+		agentName:   "jarvis",
+		ui:          true,
+	}}
+
+	// Unauthenticated: bare status only.
+	rec := httptest.NewRecorder()
+	srv.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "jarvis") {
+		t.Errorf("unauthenticated healthz leaked identity: %s", rec.Body.String())
+	}
+
+	// With the bearer token: identity fields included.
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("Authorization", "Bearer node-token")
+	srv.handleHealth(rec, req)
+	var resp struct {
+		Status       string   `json:"status"`
+		Agent        string   `json:"agent"`
+		Version      string   `json:"version"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Agent != "jarvis" || resp.Version == "" || len(resp.Capabilities) == 0 {
+		t.Errorf("authed healthz = %+v, want identity fields", resp)
+	}
+
+	// Wrong token: no identity.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	srv.handleHealth(rec, req)
+	if strings.Contains(rec.Body.String(), "jarvis") {
+		t.Errorf("wrong-token healthz leaked identity: %s", rec.Body.String())
+	}
+}
+
+func TestServeWebHubFlagsInjectContext(t *testing.T) {
+	srv := &serveServer{cfg: serveServerConfig{
+		basePath:    "/chat",
+		hubURL:      "http://127.0.0.1:8090/",
+		hubNodeID:   "jarvis",
+		hubNodeName: "Jarvis",
+	}}
+	html := string(srv.buildIndexHTML())
+	if !strings.Contains(html, `window.TERM_LLM_HUB={"nodeId":"jarvis","nodeName":"Jarvis","url":"http://127.0.0.1:8090/"}`) {
+		t.Errorf("index missing hub context: %s", html[:min(600, len(html))])
+	}
+}
+
+// Guard against the serveui shapes drifting away from the hub's rebase
+// needles (see hubRebaseUIPrefix).
+func TestHubRebaseNeedlesMatchServeOutput(t *testing.T) {
+	srv := &serveServer{cfg: serveServerConfig{basePath: "/chat"}}
+	html := srv.buildIndexHTML()
+	rewritten, baseHits, prefixHits := hubRebaseUIPrefix(html, "/chat", "/node/x")
+	if baseHits == 0 || prefixHits == 0 {
+		t.Fatalf("rebase needles drifted: baseHits=%d prefixHits=%d", baseHits, prefixHits)
+	}
+	if !strings.Contains(string(rewritten), `<base href="/node/x/">`) {
+		t.Error("rebased html missing new base tag")
+	}
+}

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -195,6 +195,69 @@ func TestHubNodesAPIDoesNotLeakTokens(t *testing.T) {
 	}
 }
 
+func TestHubNodesAPIDiagnostics(t *testing.T) {
+	webOnly := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"ok","capabilities":["web"]}`)
+	}))
+	defer webOnly.Close()
+	jobs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"ok","capabilities":["web","jobs"]}`)
+	}))
+	defer jobs.Close()
+
+	nodes := []hub.Node{
+		{ID: "origin", Name: "Origin", Source: hub.SourceConfig, URL: jobs.URL, BasePath: "/chat", Token: "origin-token", Delegation: &hub.DelegationPolicy{Enabled: true, To: []string{"target"}, Workdir: "/work"}},
+		{ID: "target", Name: "Target", Source: hub.SourceConfig, URL: webOnly.URL, BasePath: "/chat", Token: "target-token", Delegation: &hub.DelegationPolicy{Enabled: true, AcceptFrom: []string{"other"}, Workdir: "/work"}},
+		{ID: "nowork", Name: "NoWork", Source: hub.SourceConfig, Connection: "reverse", BasePath: "/chat", Token: "nowork-token", Delegation: &hub.DelegationPolicy{Enabled: true}},
+		{ID: "notoken", Name: "NoToken", Source: hub.SourceConfig, URL: jobs.URL, BasePath: "/chat"},
+	}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: nodes}), nil)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/nodes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Nodes []hubNodeView `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]hubNodeView{}
+	for _, n := range resp.Nodes {
+		byID[n.ID] = n
+	}
+	assertDiagnosticCode(t, byID["nowork"], "reverse_disconnected")
+	assertDiagnosticCode(t, byID["nowork"], "delegation_missing_workdir")
+	assertDiagnosticCode(t, byID["notoken"], "missing_token")
+	assertDiagnosticCode(t, byID["target"], "delegation_jobs_missing")
+	assertDiagnosticCode(t, byID["origin"], "delegation_policy_mismatch")
+}
+
+func assertDiagnosticCode(t *testing.T, n hubNodeView, code string) {
+	t.Helper()
+	for _, d := range n.Diagnostics {
+		if d.Code == code {
+			return
+		}
+	}
+	t.Fatalf("node %q diagnostics missing %q: %+v", n.ID, code, n.Diagnostics)
+}
+
+func TestHubIndexIncludesDiagnosticsUI(t *testing.T) {
+	s := newHubServer(hub.NewRegistry(), nil)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+	for _, want := range []string{"node-diagnostics", "diagnostic-label", "n.diagnostics"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("dashboard missing %q", want)
+		}
+	}
+}
+
 func TestHubAddTestRemoveNodeFlow(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -34,6 +34,63 @@ type fakeHubResolver struct{ nodes []hub.Node }
 func (f fakeHubResolver) Source() string             { return hub.SourceConfig }
 func (f fakeHubResolver) Nodes() ([]hub.Node, error) { return f.nodes, nil }
 
+func TestHubAuthProtectsDashboardAPIAndProxy(t *testing.T) {
+	var gotAuth string
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		io.WriteString(w, "ok")
+	})
+	s.requireAuth = true
+	s.token = "hub-secret"
+	h := s.handler()
+
+	for _, path := range []string{"/", "/api/nodes", "/node/alpha/"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("%s without auth status = %d, want 401", path, rec.Code)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/node/alpha/v1/models", nil)
+	req.Header.Set("Authorization", "bearer hub-secret")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authorized proxy status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer tkn-123" {
+		t.Fatalf("backend Authorization = %q, want node token injection", gotAuth)
+	}
+}
+
+func TestHubAuthSkipsReverseConnectNodeAuth(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
+	s.requireAuth = true
+	s.token = "hub-secret"
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/connect", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want node-auth 401", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "hub authentication") {
+		t.Fatalf("/api/connect should be gated by node auth, got body %q", rec.Body.String())
+	}
+}
+
+func TestValidateHubBindAllowsPublicOnlyWithAuth(t *testing.T) {
+	if err := validateHubBind("0.0.0.0", 8090, true); err != nil {
+		t.Fatalf("public bind with auth: %v", err)
+	}
+	if err := validateHubBind("0.0.0.0", 8090, false); err == nil {
+		t.Fatal("expected public bind without auth to fail")
+	}
+	if err := validateHubBind("127.0.0.1", 8090, false); err != nil {
+		t.Fatalf("loopback bind without auth: %v", err)
+	}
+}
+
 func TestHubProxyInjectsTokenAndStripsCredentials(t *testing.T) {
 	var gotAuth, gotCookie, gotAPIKey, gotPath, gotQuery, gotFwd string
 	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
@@ -356,21 +413,23 @@ func TestHubTransportNoEnvProxy(t *testing.T) {
 
 func TestValidateHubBind(t *testing.T) {
 	cases := []struct {
-		host    string
-		port    int
-		wantErr bool
+		host        string
+		port        int
+		requireAuth bool
+		wantErr     bool
 	}{
-		{"127.0.0.1", 8090, false},
-		{"localhost", 8090, false},
-		{"::1", 8090, false},
-		{"0.0.0.0", 8090, true},
-		{"192.168.1.20", 8090, true},
-		{"127.0.0.1", 0, true},
-		{"127.0.0.1", 70000, true},
+		{"127.0.0.1", 8090, false, false},
+		{"localhost", 8090, false, false},
+		{"::1", 8090, false, false},
+		{"0.0.0.0", 8090, false, true},
+		{"192.168.1.20", 8090, false, true},
+		{"0.0.0.0", 8090, true, false},
+		{"127.0.0.1", 0, true, true},
+		{"127.0.0.1", 70000, true, true},
 	}
 	for _, tc := range cases {
-		if err := validateHubBind(tc.host, tc.port); (err != nil) != tc.wantErr {
-			t.Errorf("validateHubBind(%q,%d) err=%v wantErr=%v", tc.host, tc.port, err, tc.wantErr)
+		if err := validateHubBind(tc.host, tc.port, tc.requireAuth); (err != nil) != tc.wantErr {
+			t.Errorf("validateHubBind(%q,%d,%v) err=%v wantErr=%v", tc.host, tc.port, tc.requireAuth, err, tc.wantErr)
 		}
 	}
 }

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -22,6 +22,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/procutil"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
 	_ "modernc.org/sqlite"
 )
 
@@ -328,6 +329,7 @@ type jobsV2LLMConfig struct {
 	ContinueWith   string              `json:"continue_with,omitempty"`
 	PersistSession *bool               `json:"persist_session,omitempty"`
 	SessionID      string              `json:"session_id,omitempty"`
+	SessionName    string              `json:"session_name,omitempty"`
 	NotifyWhenDone bool                `json:"notify_when_done,omitempty"`
 	NotifyOrigin   *jobsV2NotifyOrigin `json:"notify_origin,omitempty"`
 
@@ -414,6 +416,9 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 		return jobsV2RunResult{}, fmt.Errorf("llm runner cwd is required")
 	}
 	cfg.SessionID = cfg.effectiveSessionID()
+	if strings.TrimSpace(cfg.SessionName) == "" {
+		cfg.SessionName = jobsV2SessionName(job, cfg)
+	}
 	progressiveOpts := askProgressiveOptions{
 		Enabled:      cfg.Progressive,
 		Timeout:      time.Duration(job.TimeoutSeconds) * time.Second,
@@ -427,6 +432,12 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 	cfg.StopWhen = string(progressiveOpts.StopWhen)
 	cfg.ContinueWith = progressiveOpts.ContinueWith
 	res := jobsV2RunResult{SessionID: cfg.SessionID}
+	// Delegated hub jobs carry their delegation id as a hub-written label;
+	// surface it on the context so hub_delegate chains depth/loop tracking
+	// without trusting the model to pass parent_delegation_id.
+	if delegationID := hubDelegationIDFromJobLabels(job.Labels); delegationID != "" {
+		ctx = tools.WithHubDelegationID(ctx, delegationID)
+	}
 	var thinkingBuilder strings.Builder
 	var responseBuilder strings.Builder
 	progressTracker := newProgressTracker()
@@ -2960,9 +2971,12 @@ func newServeJobsExecutor(baseCfg *config.Config) serveJobsExecutor {
 		var persistSyntheticUserMessage func(context.Context, llm.Message) error
 		var sess *session.Session
 		turnStartTime := time.Now()
+		sessionName := strings.TrimSpace(cfg.SessionName)
 		if store != nil {
 			sess = &session.Session{
 				ID:        cfg.SessionID,
+				Name:      sessionName,
+				Summary:   sessionName,
 				Provider:  provider.Name(),
 				Model:     modelName,
 				Mode:      session.ModeAsk,

--- a/cmd/templates/hub.css
+++ b/cmd/templates/hub.css
@@ -1,0 +1,204 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0f1115;
+  --surface: #171a21;
+  --surface-2: #1f242e;
+  --border: #2a303d;
+  --text: #e6e9ef;
+  --muted: #98a1b3;
+  --accent: #7aa2f7;
+  --ok: #34d399;
+  --down: #f87171;
+  --warn: #fbbf24;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f5f6f8;
+    --surface: #ffffff;
+    --surface-2: #eef0f4;
+    --border: #d8dce4;
+    --text: #1c2230;
+    --muted: #5b6475;
+    --accent: #3b6fd4;
+    --ok: #059669;
+    --down: #dc2626;
+    --warn: #b45309;
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.hidden { display: none !important; }
+
+.hub-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1.4rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  position: sticky;
+  top: 0;
+}
+
+.hub-brand { display: flex; align-items: center; gap: 0.6rem; }
+.hub-logo { color: var(--accent); }
+.hub-brand h1 { margin: 0; font-size: 1.15rem; font-weight: 700; letter-spacing: 0.01em; }
+.hub-brand-accent { color: var(--accent); }
+
+.hub-header-actions { display: flex; align-items: center; gap: 0.6rem; }
+.hub-summary { color: var(--muted); font-size: 0.88rem; }
+
+.hub-btn {
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0.42rem 0.85rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.hub-btn:hover { border-color: var(--accent); }
+.hub-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.hub-btn.primary:hover { filter: brightness(1.1); }
+.hub-btn.ghost { background: transparent; }
+.hub-btn.danger { color: var(--down); }
+.hub-btn.danger:hover { border-color: var(--down); }
+
+.hub-main { padding: 1.4rem; max-width: 1180px; margin: 0 auto; }
+
+.hub-error {
+  border: 1px solid var(--down);
+  background: color-mix(in srgb, var(--down) 12%, transparent);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.node-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+  gap: 1rem;
+}
+
+.node-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.node-card-head { display: flex; align-items: center; gap: 0.55rem; }
+.node-name { margin: 0; font-size: 1.02rem; font-weight: 700; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.ok { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+.status-dot.down { background: var(--down); }
+
+.source-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+  padding: 0.12rem 0.55rem;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.source-badge.source-contain { color: var(--accent); border-color: var(--accent); }
+.source-badge.source-local { color: var(--ok); border-color: var(--ok); }
+
+.node-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.18rem 0.8rem;
+  margin: 0;
+  font-size: 0.86rem;
+}
+.node-meta dt { color: var(--muted); font-weight: 600; }
+.node-meta dd { margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.82rem; }
+
+.node-caps { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.cap-chip {
+  font-size: 0.74rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.14rem 0.6rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.node-error { color: var(--down); font-size: 0.82rem; word-break: break-word; }
+.node-warn { color: var(--warn); font-size: 0.82rem; }
+
+.node-actions { display: flex; gap: 0.5rem; margin-top: auto; padding-top: 0.3rem; }
+
+.hub-empty { text-align: center; color: var(--muted); padding: 3.5rem 1rem; }
+.hub-empty p { margin: 0.3rem 0; }
+.hub-empty-hint code, .hub-empty-hint em { color: var(--text); }
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  width: min(440px, 100%);
+  padding: 1.1rem 1.25rem 1.25rem;
+}
+
+.modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.8rem; }
+.modal-header h2 { margin: 0; font-size: 1.05rem; }
+
+.modal form { display: flex; flex-direction: column; gap: 0.75rem; }
+.modal label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.88rem; font-weight: 600; }
+.modal label .optional { color: var(--muted); font-weight: 400; }
+.modal input {
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0.5rem 0.65rem;
+  font: inherit;
+  font-size: 0.9rem;
+}
+.modal input:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+
+.modal-status { min-height: 1.2rem; font-size: 0.85rem; color: var(--muted); }
+.modal-actions { display: flex; justify-content: flex-end; gap: 0.5rem; }

--- a/cmd/templates/hub.css
+++ b/cmd/templates/hub.css
@@ -202,3 +202,76 @@ body {
 
 .modal-status { min-height: 1.2rem; font-size: 0.85rem; color: var(--muted); }
 .modal-actions { display: flex; justify-content: flex-end; gap: 0.5rem; }
+
+.delegations-panel {
+  margin-top: 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+}
+
+.delegations-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+}
+.delegations-head h2 { margin: 0; font-size: 1.02rem; }
+.delegations-head p { margin: 0.15rem 0 0; color: var(--muted); font-size: 0.86rem; }
+.delegations-count { color: var(--muted); font-size: 0.84rem; white-space: nowrap; }
+
+.delegations-list { display: grid; gap: 0.65rem; }
+.delegation-row {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  padding: 0.75rem 0.85rem;
+  display: grid;
+  gap: 0.45rem;
+}
+.delegation-route { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; }
+.route-arrow { color: var(--muted); }
+.delegation-status {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.08rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.status-succeeded { color: var(--ok); border-color: var(--ok); }
+.status-failed, .status-error, .status-timed_out, .status-cancelled { color: var(--down); border-color: var(--down); }
+.status-running, .status-queued { color: var(--warn); border-color: var(--warn); }
+.delegation-meta { color: var(--muted); font-size: 0.78rem; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.delegation-prompt {
+  color: var(--muted);
+  font-size: 0.84rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.delegation-response {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.86rem;
+}
+.delegation-response-text {
+  margin: 0;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font: inherit;
+}
+.delegation-artifact-img {
+  max-width: min(100%, 420px);
+  max-height: 240px;
+  object-fit: contain;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #fff;
+}
+.delegation-artifact-link { color: var(--accent); font-weight: 700; }
+.delegations-empty { color: var(--muted); font-size: 0.88rem; }

--- a/cmd/templates/hub.css
+++ b/cmd/templates/hub.css
@@ -158,6 +158,21 @@ body {
 
 .node-error { color: var(--down); font-size: 0.82rem; word-break: break-word; }
 .node-warn { color: var(--warn); font-size: 0.82rem; }
+.node-diagnostics { display: grid; gap: 0.35rem; }
+.node-diagnostic {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.45rem;
+  align-items: start;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 0.42rem 0.55rem;
+  background: var(--surface-2);
+  font-size: 0.82rem;
+}
+.diagnostic-label { font-size: 0.68rem; font-weight: 800; letter-spacing: 0.04em; color: var(--warn); }
+.diagnostic-error .diagnostic-label { color: var(--down); }
+.diagnostic-message { word-break: break-word; }
 
 .node-actions { display: flex; gap: 0.5rem; margin-top: auto; padding-top: 0.3rem; }
 

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <title>term-llm Hub</title>
+  <style>{{.CSS}}</style>
+</head>
+<body>
+  <header class="hub-header">
+    <div class="hub-brand">
+      <svg class="hub-logo" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="3"></circle>
+        <circle cx="4.5" cy="5" r="2"></circle>
+        <circle cx="19.5" cy="5" r="2"></circle>
+        <circle cx="4.5" cy="19" r="2"></circle>
+        <circle cx="19.5" cy="19" r="2"></circle>
+        <line x1="6.2" y1="6.4" x2="9.8" y2="10"></line>
+        <line x1="17.8" y1="6.4" x2="14.2" y2="10"></line>
+        <line x1="6.2" y1="17.6" x2="9.8" y2="14"></line>
+        <line x1="17.8" y1="17.6" x2="14.2" y2="14"></line>
+      </svg>
+      <h1>term-llm <span class="hub-brand-accent">Hub</span></h1>
+    </div>
+    <div class="hub-header-actions">
+      <span class="hub-summary" id="hubSummary" aria-live="polite"></span>
+      <button class="hub-btn ghost" id="refreshBtn" type="button" title="Refresh nodes">↻ Refresh</button>
+      {{if .CanAddNodes}}<button class="hub-btn primary" id="addNodeBtn" type="button">＋ Add node</button>{{end}}
+    </div>
+  </header>
+
+  <main class="hub-main">
+    <div class="hub-error hidden" id="hubError" role="alert"></div>
+    <section class="node-grid" id="nodeGrid" aria-label="Nodes"></section>
+    <div class="hub-empty hidden" id="hubEmpty">
+      <p>No nodes yet.</p>
+      <p class="hub-empty-hint">Point the hub at nodes with <code>--config</code>, create contain workspaces, or add one with <em>Add node</em>.</p>
+    </div>
+  </main>
+
+  {{if .CanAddNodes}}
+  <div class="modal-overlay hidden" id="addNodeModal" role="dialog" aria-modal="true" aria-labelledby="addNodeTitle">
+    <div class="modal">
+      <div class="modal-header">
+        <h2 id="addNodeTitle">Add node</h2>
+        <button class="hub-btn ghost" id="addNodeCloseBtn" type="button" aria-label="Close">✕</button>
+      </div>
+      <form id="addNodeForm">
+        <label>Name
+          <input id="nodeNameInput" type="text" placeholder="jarvis" autocomplete="off" required>
+        </label>
+        <label>URL
+          <input id="nodeUrlInput" type="url" placeholder="http://127.0.0.1:8081/chat" autocomplete="off" required>
+        </label>
+        <label>Bearer token <span class="optional">(optional, kept server-side)</span>
+          <input id="nodeTokenInput" type="password" autocomplete="off">
+        </label>
+        <div class="modal-status" id="addNodeStatus" aria-live="polite"></div>
+        <div class="modal-actions">
+          <button class="hub-btn ghost" id="testNodeBtn" type="button">Test connection</button>
+          <button class="hub-btn primary" type="submit">Add node</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  {{end}}
+
+  <script>
+  (() => {
+    'use strict';
+    const grid = document.getElementById('nodeGrid');
+    const summary = document.getElementById('hubSummary');
+    const errorBox = document.getElementById('hubError');
+    const emptyBox = document.getElementById('hubEmpty');
+
+    const el = (tag, className, text) => {
+      const node = document.createElement(tag);
+      if (className) node.className = className;
+      if (text !== undefined) node.textContent = text;
+      return node;
+    };
+
+    const renderNode = (n) => {
+      const card = el('article', 'node-card');
+      const head = el('div', 'node-card-head');
+      const dotClass = n.status.reachable ? 'ok' : 'down';
+      const dot = el('span', `status-dot ${dotClass}`);
+      dot.title = n.status.reachable ? 'Reachable' : (n.status.error || 'Unreachable');
+      head.appendChild(dot);
+      head.appendChild(el('h2', 'node-name', n.name));
+      head.appendChild(el('span', `source-badge source-${n.source}`, n.source));
+      card.appendChild(head);
+
+      const meta = el('dl', 'node-meta');
+      const row = (label, value) => {
+        if (!value) return;
+        meta.appendChild(el('dt', '', label));
+        meta.appendChild(el('dd', '', value));
+      };
+      row('ID', n.id);
+      row('URL', n.url + (n.base_path || ''));
+      row('Status', n.status.state + (n.status.reachable ? ` · ${n.status.latency_ms} ms` : ''));
+      row('Agent', n.status.agent);
+      row('Version', n.status.version);
+      card.appendChild(meta);
+
+      if (Array.isArray(n.status.capabilities) && n.status.capabilities.length) {
+        const caps = el('div', 'node-caps');
+        n.status.capabilities.forEach((c) => caps.appendChild(el('span', 'cap-chip', c)));
+        card.appendChild(caps);
+      }
+      if (!n.status.reachable && n.status.error) {
+        card.appendChild(el('div', 'node-error', n.status.error));
+      }
+      if (!n.has_token) {
+        card.appendChild(el('div', 'node-warn', 'No bearer token configured — the open action may be rejected by the node.'));
+      }
+
+      const actions = el('div', 'node-actions');
+      const open = el('a', 'hub-btn primary', 'Open');
+      open.href = n.proxy_path;
+      actions.appendChild(open);
+      if (n.source === 'local') {
+        const del = el('button', 'hub-btn danger', 'Remove');
+        del.type = 'button';
+        del.addEventListener('click', async () => {
+          if (!confirm(`Remove node "${n.name}"?`)) return;
+          await fetch(`api/nodes/${encodeURIComponent(n.id)}`, { method: 'DELETE' });
+          refresh();
+        });
+        actions.appendChild(del);
+      }
+      card.appendChild(actions);
+      return card;
+    };
+
+    const refresh = async () => {
+      try {
+        const resp = await fetch('api/nodes');
+        if (!resp.ok) throw new Error(`api/nodes returned ${resp.status}`);
+        const data = await resp.json();
+        const nodes = Array.isArray(data.nodes) ? data.nodes : [];
+        grid.replaceChildren(...nodes.map(renderNode));
+        emptyBox.classList.toggle('hidden', nodes.length > 0);
+        const up = nodes.filter((n) => n.status.reachable).length;
+        summary.textContent = nodes.length ? `${up}/${nodes.length} nodes reachable` : '';
+        if (data.resolver_error) {
+          errorBox.textContent = `Some sources failed to resolve: ${data.resolver_error}`;
+          errorBox.classList.remove('hidden');
+        } else {
+          errorBox.classList.add('hidden');
+        }
+      } catch (err) {
+        errorBox.textContent = `Failed to load nodes: ${err.message}`;
+        errorBox.classList.remove('hidden');
+      }
+    };
+
+    document.getElementById('refreshBtn').addEventListener('click', refresh);
+    refresh();
+    setInterval(refresh, 15000);
+
+    const modal = document.getElementById('addNodeModal');
+    if (!modal) return;
+    const status = document.getElementById('addNodeStatus');
+    const nameInput = document.getElementById('nodeNameInput');
+    const urlInput = document.getElementById('nodeUrlInput');
+    const tokenInput = document.getElementById('nodeTokenInput');
+    const showModal = (show) => {
+      modal.classList.toggle('hidden', !show);
+      status.textContent = '';
+      if (show) nameInput.focus();
+    };
+    document.getElementById('addNodeBtn').addEventListener('click', () => showModal(true));
+    document.getElementById('addNodeCloseBtn').addEventListener('click', () => showModal(false));
+    modal.addEventListener('click', (e) => { if (e.target === modal) showModal(false); });
+
+    const payload = () => ({
+      name: nameInput.value.trim(),
+      url: urlInput.value.trim(),
+      token: tokenInput.value.trim(),
+    });
+
+    document.getElementById('testNodeBtn').addEventListener('click', async () => {
+      status.textContent = 'Testing…';
+      try {
+        const resp = await fetch('api/nodes/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload()),
+        });
+        if (!resp.ok) throw new Error(await resp.text());
+        const data = await resp.json();
+        const st = data.status || {};
+        status.textContent = st.reachable
+          ? `✓ Reachable in ${st.latency_ms} ms${st.agent ? ` · agent: ${st.agent}` : ''}${st.version ? ` · ${st.version}` : ''}`
+          : `✗ Not reachable: ${st.error || st.state}`;
+      } catch (err) {
+        status.textContent = `✗ ${err.message}`;
+      }
+    });
+
+    document.getElementById('addNodeForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      status.textContent = 'Adding…';
+      try {
+        const resp = await fetch('api/nodes', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload()),
+        });
+        if (!resp.ok) throw new Error(await resp.text());
+        const data = await resp.json();
+        status.textContent = data.warning ? `Added with warning: ${data.warning}` : '';
+        if (!data.warning) {
+          showModal(false);
+          nameInput.value = urlInput.value = tokenInput.value = '';
+        }
+        refresh();
+      } catch (err) {
+        status.textContent = `✗ ${err.message}`;
+      }
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -178,8 +178,15 @@
       if (!n.status.reachable && n.status.error) {
         card.appendChild(el('div', 'node-error', n.status.error));
       }
-      if (!n.has_token) {
-        card.appendChild(el('div', 'node-warn', 'No bearer token configured — the open action may be rejected by the node.'));
+      if (Array.isArray(n.diagnostics) && n.diagnostics.length) {
+        const diagList = el('div', 'node-diagnostics');
+        n.diagnostics.forEach((d) => {
+          const item = el('div', `node-diagnostic diagnostic-${d.severity || 'warning'}`);
+          item.appendChild(el('span', 'diagnostic-label', (d.severity || 'warning').toUpperCase()));
+          item.appendChild(el('span', 'diagnostic-message', d.message || d.code || 'Node diagnostic'));
+          diagList.appendChild(item);
+        });
+        card.appendChild(diagList);
       }
 
       const actions = el('div', 'node-actions');

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -33,6 +33,17 @@
   <main class="hub-main">
     <div class="hub-error hidden" id="hubError" role="alert"></div>
     <section class="node-grid" id="nodeGrid" aria-label="Nodes"></section>
+    <section class="delegations-panel" id="delegationsPanel" aria-label="Delegations">
+      <div class="delegations-head">
+        <div>
+          <h2>Delegations</h2>
+          <p>Cross-node work routed through the Hub.</p>
+        </div>
+        <span class="delegations-count" id="delegationsCount"></span>
+      </div>
+      <div class="delegations-list" id="delegationsList"></div>
+      <div class="delegations-empty hidden" id="delegationsEmpty">No delegated work yet.</div>
+    </section>
     <div class="hub-empty hidden" id="hubEmpty">
       <p>No nodes yet.</p>
       <p class="hub-empty-hint">Point the hub at nodes with <code>--config</code>, create contain workspaces, or add one with <em>Add node</em>.</p>
@@ -70,15 +81,69 @@
   (() => {
     'use strict';
     const grid = document.getElementById('nodeGrid');
+    const delegationsList = document.getElementById('delegationsList');
+    const delegationsCount = document.getElementById('delegationsCount');
+    const delegationsEmpty = document.getElementById('delegationsEmpty');
     const summary = document.getElementById('hubSummary');
     const errorBox = document.getElementById('hubError');
     const emptyBox = document.getElementById('hubEmpty');
 
+    const nodeBasePaths = new Map();
     const el = (tag, className, text) => {
       const node = document.createElement(tag);
       if (className) node.className = className;
       if (text !== undefined) node.textContent = text;
       return node;
+    };
+    const safeURL = (raw, delegation) => {
+      if (!raw) return '';
+      try {
+        const u = new URL(raw, window.location.href);
+        if (u.protocol === 'http:' || u.protocol === 'https:') return u.href;
+      } catch (_) {}
+      if (raw.startsWith('/node/')) return raw;
+      if (raw.startsWith('/') && delegation && delegation.target_node) {
+        const base = nodeBasePaths.get(delegation.target_node) || '';
+        let p = raw;
+        if (base && p === base) p = '/';
+        if (base && p.startsWith(base + '/')) p = p.slice(base.length);
+        return `/node/${encodeURIComponent(delegation.target_node)}${p}`;
+      }
+      if (raw.startsWith('/')) return raw;
+      return '';
+    };
+
+    const appendResponse = (parent, text, delegation) => {
+      const box = el('div', 'delegation-response');
+      const imgMatch = text.match(/!\[([^\]]*)\]\(([^)]+)\)/);
+      if (imgMatch) {
+        const src = safeURL(imgMatch[2].trim(), delegation);
+        if (src) {
+          const link = el('a', 'delegation-artifact-link', imgMatch[1] || 'Open artifact');
+          link.href = src;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          const img = document.createElement('img');
+          img.className = 'delegation-artifact-img';
+          img.src = src;
+          img.alt = imgMatch[1] || 'Delegated artifact';
+          box.appendChild(img);
+          box.appendChild(link);
+        }
+      }
+      const linkMatch = text.match(/(?<!!)\[([^\]]+)\]\(([^)]+)\)/);
+      if (!box.childNodes.length && linkMatch) {
+        const href = safeURL(linkMatch[2].trim(), delegation);
+        if (href) {
+          const link = el('a', 'delegation-artifact-link', linkMatch[1]);
+          link.href = href;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          box.appendChild(link);
+        }
+      }
+      box.appendChild(el('pre', 'delegation-response-text', text.replace(/!\[[^\]]*\]\([^)]+\)/g, '').trim()));
+      parent.appendChild(box);
     };
 
     const renderNode = (n) => {
@@ -135,12 +200,54 @@
       return card;
     };
 
+    const renderDelegation = (d) => {
+      const row = el('article', 'delegation-row');
+      const status = el('span', `delegation-status status-${d.status || 'unknown'}`, d.status || 'unknown');
+      const route = el('div', 'delegation-route');
+      route.appendChild(el('strong', '', d.origin_node || 'unknown'));
+      route.appendChild(el('span', 'route-arrow', '→'));
+      route.appendChild(el('strong', '', d.target_node || 'unknown'));
+      route.appendChild(status);
+      row.appendChild(route);
+      const meta = el('div', 'delegation-meta', `${d.agent_name || 'agent'} · depth ${d.depth || 1}${d.job_id ? ` · ${d.job_id}` : ''}`);
+      row.appendChild(meta);
+      if (d.prompt) {
+        row.appendChild(el('div', 'delegation-prompt', d.prompt));
+      }
+      if (d.response) {
+        appendResponse(row, d.response, d);
+      }
+      if (d.error) {
+        row.appendChild(el('div', 'node-error', d.error));
+      }
+      return row;
+    };
+
+    const refreshDelegations = async () => {
+      try {
+        const resp = await fetch('api/delegations');
+        if (!resp.ok) throw new Error(`api/delegations returned ${resp.status}`);
+        const data = await resp.json();
+        const delegations = Array.isArray(data.delegations) ? data.delegations : [];
+        delegationsList.replaceChildren(...delegations.slice(0, 8).map(renderDelegation));
+        delegationsEmpty.classList.toggle('hidden', delegations.length > 0);
+        const active = delegations.filter((d) => !['succeeded', 'failed', 'cancelled', 'timed_out', 'error'].includes(d.status)).length;
+        delegationsCount.textContent = delegations.length ? `${active} active · ${delegations.length} total` : '';
+      } catch (_) {
+        delegationsList.replaceChildren();
+        delegationsEmpty.classList.remove('hidden');
+        delegationsCount.textContent = '';
+      }
+    };
+
     const refresh = async () => {
       try {
         const resp = await fetch('api/nodes');
         if (!resp.ok) throw new Error(`api/nodes returned ${resp.status}`);
         const data = await resp.json();
         const nodes = Array.isArray(data.nodes) ? data.nodes : [];
+        nodeBasePaths.clear();
+        nodes.forEach((n) => nodeBasePaths.set(n.id, n.base_path || ''));
         grid.replaceChildren(...nodes.map(renderNode));
         emptyBox.classList.toggle('hidden', nodes.length > 0);
         const up = nodes.filter((n) => n.status.reachable).length;
@@ -151,15 +258,16 @@
         } else {
           errorBox.classList.add('hidden');
         }
+        refreshDelegations();
       } catch (err) {
         errorBox.textContent = `Failed to load nodes: ${err.message}`;
         errorBox.classList.remove('hidden');
       }
     };
 
-    document.getElementById('refreshBtn').addEventListener('click', refresh);
+    document.getElementById('refreshBtn').addEventListener('click', () => { refresh(); refreshDelegations(); });
     refresh();
-    setInterval(refresh, 15000);
+    setInterval(() => { refresh(); refreshDelegations(); }, 15000);
 
     const modal = document.getElementById('addNodeModal');
     if (!modal) return;

--- a/docs-site/content/guides/hub.md
+++ b/docs-site/content/guides/hub.md
@@ -1,0 +1,74 @@
+---
+title: "Hub"
+weight: 16
+description: "Run term-llm Hub: one dashboard over many term-llm web nodes, with server-side token injection and one-click open."
+kicker: "Deploy agents"
+---
+
+`term-llm serve hub` runs the **term-llm Hub**: a launcher and control plane that puts every term-llm web node you operate behind one pane of glass. The dashboard shows each node with live reachability, latency, and (when detected) its agent name, version, and capabilities, and opens any node's full web UI through the hub with a single click.
+
+```bash
+term-llm serve hub
+# term-llm Hub listening on http://127.0.0.1:8090
+```
+
+## Nodes
+
+The core object is a **node**: a reachable term-llm serve (web/API endpoint) with an identity, a URL + base path, an optional web bearer token, and a source. Nodes are discovered from three resolvers, re-resolved on every request so changes are picked up without a restart:
+
+1. **Static config** (`--config nodes.yaml`) — YAML or JSON:
+
+   ```yaml
+   nodes:
+     - name: jarvis
+       url: http://127.0.0.1:8081/chat
+       token: <web bearer token>
+     - id: edge
+       url: https://edge.example.com
+       base_path: /ui
+       token: <token>
+   ```
+
+   `id` is derived from `name` when omitted; the base path may be embedded in the URL or given explicitly. Hub v1 requires a non-root base path such as `/chat` because path-based proxying needs a stable prefix to rebase.
+
+2. **Contain workspaces** (on by default, disable with `--contain=false`) — every local `term-llm contain` workspace with a provisioned `WEB_TOKEN` in its `.env` shows up automatically, using its `WEB_PORT`/`WEB_BASE_PATH`.
+
+3. **Dashboard-added nodes** — the **Add node** form (with a **Test connection** button) persists nodes to a local JSON store (`--nodes-file`, default `<data-dir>/hub/nodes.json`, mode 0600 since it holds tokens).
+
+When two sources produce the same node id, precedence is config → local store → contain.
+
+## Opening a node
+
+Each node's **Open** action navigates to `/node/<id>/`, a reverse proxy onto that node's serve:
+
+- The node's bearer token is injected **server-side**; tokens never reach the browser, and client-supplied `Authorization`, `Cookie`, and `X-Api-Key` headers are stripped before forwarding.
+- The node UI's baked-in base path (`<base>` tag and `window.TERM_LLM_UI_PREFIX`) is rebased onto `/node/<id>` so the SPA's API calls, service worker, and subresources all route back through the hub.
+- The hub injects `window.TERM_LLM_HUB` into the node's page, so the node's web UI shows a **Back to Hub** link in the sidebar (below Widgets).
+- SSE and other long-lived streams pass through untouched; only connection and response-header times are bounded.
+
+A node can also be made hub-aware when opened directly (not through the proxy):
+
+```bash
+term-llm serve web --hub-url http://127.0.0.1:8090/ --hub-node-id jarvis --hub-node-name Jarvis
+```
+
+## API
+
+```text
+GET    /api/nodes        nodes with probe status (never includes tokens)
+POST   /api/nodes        add a node to the local store
+DELETE /api/nodes/<id>   remove a local-store node
+POST   /api/nodes/test   probe a node spec without persisting it
+ANY    /node/<id>/...    reverse proxy to the node's serve
+GET    /healthz          hub health
+```
+
+Probes hit each node's `{base}/healthz` with the node token. Serves report their agent name, version, and capabilities (`web`, `api`, `jobs`, `widgets`, `voice`) on `healthz` only to callers presenting the valid bearer token (or when the serve runs with auth disabled).
+
+## Security posture
+
+The hub is **experimental and loopback-only**: it has no authentication of its own yet, so it refuses to bind to a non-loopback host. Anyone who can reach the hub can reach every node it fronts. To expose it, put an authenticating reverse proxy in front and keep the hub itself on loopback. The backend transport never uses an environment proxy (`HTTP_PROXY` would see injected tokens). The hub rejects obvious cross-site browser requests and requires JSON content types for mutating node-registry APIs, but that is not a replacement for real hub auth.
+
+Routing is path-based (`/node/<id>/...`) in v1; the proxy target is resolved per request, so host-based routing can be layered on later without changing the proxy plumbing. Because path routing puts hub UI and proxied node UI on the same browser origin, Hub v1 treats registered nodes/widgets as trusted. The node web UI namespaces localStorage by hub node id to avoid ordinary state bleed, but untrusted remote nodes/widgets still need the future host-based/widget-grant isolation work before they should be opened through a shared hub origin.
+
+Future cross-node communication will be mediated by Hub-authenticated delegation APIs (reserved under `/api/delegations`) rather than by nodes calling each other directly. That follow-up should use distinct node→Hub credentials, default-deny delegation policy, and the existing jobs-v2 execution path on target nodes. Node self-registration, scheduling, hub-level user auth, cross-node delegation tools, and mTLS between hub and nodes are deliberately out of scope for v1.

--- a/docs-site/content/guides/hub.md
+++ b/docs-site/content/guides/hub.md
@@ -108,6 +108,16 @@ POST   /api/delegations/<id>/cancel  cancel a delegation (originating node only)
 
 Probes hit each node's `{base}/healthz` with the node token. Serves report their agent name, version, and capabilities (`web`, `api`, `jobs`, `widgets`, `voice`) on `healthz` only to callers presenting the valid bearer token (or when the serve runs with auth disabled).
 
+The dashboard also shows lightweight diagnostics on each node card when the Hub can spot a likely configuration problem:
+
+- reverse nodes that have not connected their outbound websocket
+- nodes without a configured bearer token
+- `delegation.enabled: true` without a delegation `workdir`
+- nodes that accept delegation but do not report the `jobs` capability (or whose jobs capability cannot be verified)
+- obvious origin/target policy mismatches, such as an origin whose `to` allows a target that does not `accept_from` that origin
+
+These diagnostics are advisory and token-safe; `/api/nodes` still never returns node tokens or full secret-bearing config.
+
 ## Security posture
 
 The hub is **experimental and loopback-only by default**: it has no authentication of its own yet, so the built-in server refuses to bind to a non-loopback host. Anyone who can reach the hub can reach every node it fronts. To expose it publicly, put an authenticating reverse proxy in front and keep the hub itself on loopback. Reverse nodes authenticate their websocket with the node id plus the node's bearer token; the hub accepts that connection only for nodes configured with `connection: reverse`, and the node-side connector forwards only requests under its configured base path.

--- a/docs-site/content/guides/hub.md
+++ b/docs-site/content/guides/hub.md
@@ -29,7 +29,42 @@ The core object is a **node**: a reachable term-llm serve (web/API endpoint) wit
        token: <token>
    ```
 
-   `id` is derived from `name` when omitted; the base path may be embedded in the URL or given explicitly. Hub v1 requires a non-root base path such as `/chat` because path-based proxying needs a stable prefix to rebase.
+    `id` is derived from `name` when omitted; the base path may be embedded in the URL or given explicitly. Hub v1 requires a non-root base path such as `/chat` because path-based proxying needs a stable prefix to rebase.
+
+    Nodes support two connection modes:
+
+    - `connection: direct` (the default): the Hub dials the node's `url`.
+    - `connection: reverse`: the node dials the Hub and keeps a websocket open, so the node can live behind NAT, in Docker, on a laptop, or in a private cloud network with no inbound port.
+
+    A reverse node still needs a stable `id`, `base_path`, and `token`, but it does not need a Hub-reachable `url`:
+
+    ```yaml
+    nodes:
+      - id: artist
+        name: Artist
+        connection: reverse
+        base_path: /chat
+        token: <artist web bearer token>
+        delegation:
+          enabled: true
+          accept_from: [jarvis]
+          workdir: /work
+    ```
+
+    Start the private node with reverse connect enabled:
+
+    ```bash
+    term-llm serve web jobs \
+      --base-path /chat \
+      --token "$ARTIST_TOKEN" \
+      --hub-url https://hub.example.com \
+      --hub-node-id artist \
+      --hub-connect reverse
+    ```
+
+    The Hub still exposes the same `/node/artist/...` proxy and delegation APIs. The only difference is transport: direct nodes use Hub → node HTTP, reverse nodes use the node's outbound websocket.
+
+    Nodes do **not** need to be local. A direct node can be another process on the same machine, a Docker/contain workspace, a VM, a cloud runner, or a remote server reachable over a private network/tunnel. If the Hub cannot reach the node, use `connection: reverse` and let the node maintain the outbound connection instead.
 
 2. **Contain workspaces** (on by default, disable with `--contain=false`) — every local `term-llm contain` workspace with a provisioned `WEB_TOKEN` in its `.env` shows up automatically, using its `WEB_PORT`/`WEB_BASE_PATH`.
 
@@ -37,14 +72,16 @@ The core object is a **node**: a reachable term-llm serve (web/API endpoint) wit
 
 When two sources produce the same node id, precedence is config → local store → contain.
 
+The reverse connection is intentionally a transport choice, not a second Hub API. Delegation, node opening, token injection, and policy checks all continue to target the same node record; the Hub chooses direct HTTP or the reverse websocket based on `connection`. The socket is kept alive with websocket pings and read deadlines on both sides, so silent network drops are detected and the node reconnects. Reverse mode does not queue work while the node is offline: the dashboard shows it as disconnected and requests fail fast until it reconnects.
+
 ## Opening a node
 
-Each node's **Open** action navigates to `/node/<id>/`, a reverse proxy onto that node's serve:
+Each node's **Open** action navigates to `/node/<id>/`, a proxy onto that node's serve. For direct nodes the Hub dials the configured URL; for reverse nodes the Hub sends the same request over the node's connected websocket.
 
 - The node's bearer token is injected **server-side**; tokens never reach the browser, and client-supplied `Authorization`, `Cookie`, and `X-Api-Key` headers are stripped before forwarding.
 - The node UI's baked-in base path (`<base>` tag and `window.TERM_LLM_UI_PREFIX`) is rebased onto `/node/<id>` so the SPA's API calls, service worker, and subresources all route back through the hub.
 - The hub injects `window.TERM_LLM_HUB` into the node's page, so the node's web UI shows a **Back to Hub** link in the sidebar (below Widgets).
-- SSE and other long-lived streams pass through untouched; only connection and response-header times are bounded.
+- Direct-node SSE and other long-lived streams pass through untouched; only connection and response-header times are bounded. Reverse-node requests are carried over the node's outbound websocket and are currently buffered per request, which keeps the implementation simple for dashboard/API/delegation traffic.
 
 A node can also be made hub-aware when opened directly (not through the proxy):
 
@@ -60,15 +97,97 @@ POST   /api/nodes        add a node to the local store
 DELETE /api/nodes/<id>   remove a local-store node
 POST   /api/nodes/test   probe a node spec without persisting it
 ANY    /node/<id>/...    reverse proxy to the node's serve
+GET    /api/connect      reverse-node websocket endpoint (node auth)
 GET    /healthz          hub health
+
+POST   /api/delegations              create a cross-node delegation (node auth)
+GET    /api/delegations              list delegations (node auth or same-origin)
+GET    /api/delegations/<id>         delegation status, refreshed from the target
+POST   /api/delegations/<id>/cancel  cancel a delegation (originating node only)
 ```
 
 Probes hit each node's `{base}/healthz` with the node token. Serves report their agent name, version, and capabilities (`web`, `api`, `jobs`, `widgets`, `voice`) on `healthz` only to callers presenting the valid bearer token (or when the serve runs with auth disabled).
 
 ## Security posture
 
-The hub is **experimental and loopback-only**: it has no authentication of its own yet, so it refuses to bind to a non-loopback host. Anyone who can reach the hub can reach every node it fronts. To expose it, put an authenticating reverse proxy in front and keep the hub itself on loopback. The backend transport never uses an environment proxy (`HTTP_PROXY` would see injected tokens). The hub rejects obvious cross-site browser requests and requires JSON content types for mutating node-registry APIs, but that is not a replacement for real hub auth.
+The hub is **experimental and loopback-only by default**: it has no authentication of its own yet, so the built-in server refuses to bind to a non-loopback host. Anyone who can reach the hub can reach every node it fronts. To expose it publicly, put an authenticating reverse proxy in front and keep the hub itself on loopback. Reverse nodes authenticate their websocket with the node id plus the node's bearer token; the hub accepts that connection only for nodes configured with `connection: reverse`, and the node-side connector forwards only requests under its configured base path.
+
+The backend transport never uses an environment proxy (`HTTP_PROXY` would see injected tokens). The hub rejects obvious cross-site browser requests and requires JSON content types for mutating node-registry APIs, but that is not a replacement for real hub auth.
 
 Routing is path-based (`/node/<id>/...`) in v1; the proxy target is resolved per request, so host-based routing can be layered on later without changing the proxy plumbing. Because path routing puts hub UI and proxied node UI on the same browser origin, Hub v1 treats registered nodes/widgets as trusted. The node web UI namespaces localStorage by hub node id to avoid ordinary state bleed, but untrusted remote nodes/widgets still need the future host-based/widget-grant isolation work before they should be opened through a shared hub origin.
 
-Future cross-node communication will be mediated by Hub-authenticated delegation APIs (reserved under `/api/delegations`) rather than by nodes calling each other directly. That follow-up should use distinct node→Hub credentials, default-deny delegation policy, and the existing jobs-v2 execution path on target nodes. Node self-registration, scheduling, hub-level user auth, cross-node delegation tools, and mTLS between hub and nodes are deliberately out of scope for v1.
+Node self-registration, scheduling, hub-level user auth, and mTLS between hub and nodes are deliberately out of scope for v1.
+
+## Cross-node delegation
+
+An agent on one node can delegate work to another node **through the hub** — nodes never talk to each other directly and never see each other's tokens. The flow:
+
+1. The agent on node A calls the `hub_delegate` tool (`target_node`, `prompt`, optional `agent_name`/`model`/`cwd`/`timeout_seconds`).
+2. The tool calls `POST /api/delegations` on the hub, authenticating **as node A** with A's own serve token plus an `X-Term-LLM-Node-ID` header. The hub verifies the token against the node's stored token (constant-time); nodes the hub holds no token for can never authenticate.
+3. The hub checks policy, then uses **node B's token** (which only the hub holds) to create and trigger a manual jobs-v2 LLM job on B. The job's instructions carry a provenance preamble (delegation id, origin, depth, chain) and the job is labelled `hub_delegation` for traceability.
+4. `hub_delegate` returns a `delegation_id` immediately (or blocks with `wait: true`). `hub_check_delegation` polls the hub, which polls the target run and returns the final response.
+5. The Hub dashboard also polls active delegation runs from the list view. If the target returns Markdown links or image links (for example `![result](/chat/files/result.svg)`), the dashboard surfaces the artifact inline while preserving the raw response text.
+
+### Delegation policy
+
+Policy lives on the node entry in the hub config. **Default off**: a node with no `delegation.enabled: true` can neither originate nor accept delegated work. Once enabled, `to` and `accept_from` can narrow which nodes may talk; accepting still requires a `workdir`.
+
+```yaml
+nodes:
+  - name: jarvis
+    url: http://127.0.0.1:8081/chat
+    token: <web bearer token>
+    delegation:
+      enabled: true       # REQUIRED: delegation is otherwise completely off
+      to: ["*"]           # node ids this node may delegate to (default: all once enabled)
+      accept_from: ["*"]  # node ids accepted from (default: all once enabled + workdir set)
+      workdir: /work      # REQUIRED to accept; delegated jobs start here
+      max_in_flight: 4    # concurrent delegations targeting this node (default 4)
+      allowed_agents: []  # agents origins may request (default: developer only)
+      allowed_models: []  # model overrides origins may request (default: none)
+```
+
+`allowed_agents` defaults to the default delegation agent only (`developer`); `"*"` allows any plain agent name, but path-like names (containing `/`, `\`, `..`, or leading `.`/`~`) must be listed exactly — agent names can resolve to files on the target node. `allowed_models` defaults to refusing every model override (the target's own default model is used); list models or `"*"` to open it up.
+
+Contain workspaces opt in automatically when their compose file declares an `x-term-llm.workspace` path — the sandbox accepts delegations with that path as the workdir (default agent only, no model overrides). Static/manual nodes must set `delegation.enabled: true` explicitly. An explicit `cwd` on a delegation must resolve inside the target's workdir.
+
+Loop and load protection: chains are capped at depth 3, a target already in the chain is refused, and in-flight caps apply hub-wide, per origin, and per target. Chaining is anchored in hub-written provenance: a delegated job carries a `hub_delegation` label, the jobs-v2 runner exposes it to the tools, and `hub_delegate` attaches `parent_delegation_id` from it automatically — the model cannot reset the depth count by omitting the parent. A manually supplied `parent_delegation_id` is still verified against the ledger (the parent must target the delegating node). The remaining gap: an agent running *outside* a delegated jobs-v2 run (e.g. an interactive session) starts a fresh chain at depth 1, which is the intended meaning of a new root delegation.
+
+### What the workdir does — and does not — protect
+
+The delegation workdir scopes where the delegated job **starts** (its `cwd`) and where its file tools are rooted. It is **not an OS sandbox**: a delegated agent whose target-node agent definition enables `shell` (the default `developer` agent does) executes commands with the target serve process's normal privileges and can touch anything that user can. Treat `accept_from` + `allowed_agents` as the real policy boundary, and use [contain workspaces]({{< relref "agent-containers" >}}) when you want delegated work inside an actual container sandbox.
+
+### Artifact-returning delegations
+
+A useful pattern is an origin agent delegating a concrete artifact to a specialist node, then showing the returned link to the user:
+
+```text
+User asks Jarvis: "ask Artist to draw a hub-and-spoke robot"
+Jarvis calls hub_delegate(target_node="artist", prompt="create /home/agent/Files/hub-artist-demo.svg and return ![Hub artist demo](/chat/files/hub-artist-demo.svg)")
+Hub runs a jobs-v2 job on Artist
+Artist writes the file and returns the Markdown image link
+Jarvis calls hub_check_delegation and displays the returned image/link
+Hub dashboard shows the delegation status plus the inline artifact preview
+```
+
+The link is the target deployment's normal served file URL. Hub does not copy artifacts between nodes in v1. For user-facing replies, have the origin agent display the returned Markdown link directly when that path is reachable from the user's web surface, or have the target return an absolute `https://...` URL.
+
+### Node-side setup
+
+A node started with `serve web jobs --hub-url ... --hub-node-id ...` configures the delegation tools in-process from its own serve token. Add `--hub-connect reverse` when the node should maintain an outbound websocket to the Hub instead of requiring the Hub to reach its URL directly. The target node must run with `jobs` enabled so the hub can create and trigger the delegated jobs-v2 run. Standalone processes can export `TERM_LLM_HUB_URL`, `TERM_LLM_HUB_NODE_ID`, and `TERM_LLM_HUB_TOKEN` instead; the token is captured at startup and **scrubbed from the process environment**, so subprocesses spawned by tools (shell commands, custom tools, widgets, MCP servers) never inherit it. It is also never injected into browser-facing HTML or config.
+
+`hub_delegate` and `hub_check_delegation` are not enabled in any builtin agent. Enable them explicitly on the agents that should delegate:
+
+```yaml
+tools:
+  enabled: [read_file, shell, hub_delegate, hub_check_delegation]
+```
+
+### Delegation security posture
+
+- **No token movement**: node A authenticates with its own credential; the hub alone holds B's token; delegation records and API responses never contain tokens, and target-node error bodies are redacted before they travel back.
+- **Default off**: nodes cannot originate or accept delegations unless `delegation.enabled: true` is set; accepting also requires a workdir. `to`, `accept_from`, `allowed_agents`, and `allowed_models` narrow the enabled surface.
+- **Bounded execution**: delegated work runs through the standard jobs-v2 path on the target with a clamped timeout, starting inside the target's declared workdir (a cwd/file-tool scope, not an OS sandbox — see above).
+- **Scoped visibility**: a node may read only delegations it originates or targets; the full list is reserved for the hub operator's same-origin dashboard.
+- The delegation ledger (`<data-dir>/hub/delegations.json`, mode 0600) holds prompts/response excerpts for audit; terminal records are pruned after 7 days.
+- All hub→node and node→hub clients dial directly (no `HTTP_PROXY`), since those requests carry bearer tokens.

--- a/docs-site/content/guides/hub.md
+++ b/docs-site/content/guides/hub.md
@@ -10,7 +10,14 @@ kicker: "Deploy agents"
 ```bash
 term-llm serve hub
 # term-llm Hub listening on http://127.0.0.1:8090
+#   auth: bearer required
+#   generated Hub bearer token: ...
 ```
+
+Hub auth is deliberately simple: by default the dashboard, `/api/nodes`,
+`/healthz`, and `/node/<id>/...` require one Hub bearer token. Provide a stable
+one with `--token` or `TERM_LLM_HUB_TOKEN` when running behind a public reverse
+proxy. Use `--auth none` only for loopback-only local development.
 
 ## Nodes
 
@@ -106,7 +113,7 @@ GET    /api/delegations/<id>         delegation status, refreshed from the targe
 POST   /api/delegations/<id>/cancel  cancel a delegation (originating node only)
 ```
 
-Probes hit each node's `{base}/healthz` with the node token. Serves report their agent name, version, and capabilities (`web`, `api`, `jobs`, `widgets`, `voice`) on `healthz` only to callers presenting the valid bearer token (or when the serve runs with auth disabled).
+Probes hit each node's `{base}/healthz` with the node token. Serves report their agent name, version, and capabilities (`web`, `api`, `jobs`, `widgets`, `voice`) on `healthz` only to callers presenting the valid bearer token (or when the serve runs with auth disabled). Hub dashboard/API/proxy routes require the Hub bearer token when `--auth bearer` is active; `/api/connect` and node-originated delegation calls use node auth instead so reverse nodes and `hub_delegate` do not need a separate Hub user account.
 
 The dashboard also shows lightweight diagnostics on each node card when the Hub can spot a likely configuration problem:
 
@@ -120,9 +127,9 @@ These diagnostics are advisory and token-safe; `/api/nodes` still never returns 
 
 ## Security posture
 
-The hub is **experimental and loopback-only by default**: it has no authentication of its own yet, so the built-in server refuses to bind to a non-loopback host. Anyone who can reach the hub can reach every node it fronts. To expose it publicly, put an authenticating reverse proxy in front and keep the hub itself on loopback. Reverse nodes authenticate their websocket with the node id plus the node's bearer token; the hub accepts that connection only for nodes configured with `connection: reverse`, and the node-side connector forwards only requests under its configured base path.
+The hub is **experimental but no longer unauthenticated by default**: `--auth bearer` protects the dashboard, Hub APIs, health endpoint, and node proxy with a single Hub token. Set it explicitly with `--token` or `TERM_LLM_HUB_TOKEN` for stable deployments; otherwise the hub prints a generated token at startup. `--auth none` is still available for local development, but it is loopback-only because anyone who can reach an unauthenticated hub can reach every node it fronts. Reverse nodes authenticate their websocket with the node id plus the node's bearer token; the hub accepts that connection only for nodes configured with `connection: reverse`, and the node-side connector forwards only requests under its configured base path.
 
-The backend transport never uses an environment proxy (`HTTP_PROXY` would see injected tokens). The hub rejects obvious cross-site browser requests and requires JSON content types for mutating node-registry APIs, but that is not a replacement for real hub auth.
+The backend transport never uses an environment proxy (`HTTP_PROXY` would see injected tokens). The hub still rejects obvious cross-site browser requests and requires JSON content types for mutating node-registry APIs as defense-in-depth around the simple bearer gate.
 
 Routing is path-based (`/node/<id>/...`) in v1; the proxy target is resolved per request, so host-based routing can be layered on later without changing the proxy plumbing. Because path routing puts hub UI and proxied node UI on the same browser origin, Hub v1 treats registered nodes/widgets as trusted. The node web UI namespaces localStorage by hub node id to avoid ordinary state bleed, but untrusted remote nodes/widgets still need the future host-based/widget-grant isolation work before they should be opened through a shared hub origin.
 

--- a/internal/contain/env.go
+++ b/internal/contain/env.go
@@ -1,0 +1,142 @@
+package contain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// defaultWebBasePath is the fallback URL prefix when a workspace .env has no
+// WEB_BASE_PATH. The fallback web port reuses webPortBase (see webport.go) so
+// there is a single source for the base port; note that the dynamic free-port
+// picker defaultWebPort() is for *creating* workspaces, not for reading an
+// existing one's config.
+const defaultWebBasePath = "/chat"
+
+// EnvPath returns the .env path for a named contain workspace. The file is
+// written with 0600 permissions and holds the workspace's web UI settings
+// (WEB_PORT, WEB_TOKEN, WEB_BASE_PATH) among other secrets.
+func EnvPath(name string) (string, error) {
+	dir, err := ContainerDir(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".env"), nil
+}
+
+// ReadEnvFile parses a KEY=VALUE .env file into a map. Blank lines and lines
+// beginning with '#' are ignored, surrounding whitespace is trimmed, and one
+// layer of surrounding single or double quotes is stripped from values. Lines
+// without an '=' are skipped.
+func ReadEnvFile(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	values := map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		if key != "" {
+			values[key] = value
+		}
+	}
+	return values, nil
+}
+
+// WebConfig captures the web UI connection settings for a contain workspace,
+// resolved from its .env file. It is the discovery surface tooling (such as
+// the hub) needs to reach a workspace's serve without parsing the 0600 .env
+// ad hoc.
+type WebConfig struct {
+	// Port is the host port the workspace's web UI is published on.
+	Port string
+	// Token is the bearer token guarding the web UI. Empty when not yet
+	// provisioned (e.g. a freshly templated workspace).
+	Token string
+	// BasePath is the URL prefix the web UI is mounted under (always rooted
+	// with a leading slash, no trailing slash).
+	BasePath string
+}
+
+// ReadWebConfig reads the workspace .env and returns the resolved web UI
+// settings. Port and BasePath fall back to their template defaults when unset
+// or still holding an unrendered placeholder; Token has no default and is
+// returned empty when not yet provisioned. The error reports a missing or
+// unreadable workspace .env.
+func ReadWebConfig(name string) (WebConfig, error) {
+	if err := ValidateName(name); err != nil {
+		return WebConfig{}, err
+	}
+	envPath, err := EnvPath(name)
+	if err != nil {
+		return WebConfig{}, err
+	}
+	values, err := ReadEnvFile(envPath)
+	if err != nil {
+		return WebConfig{}, err
+	}
+	cfg := WebConfig{
+		Port:     resolveEnvValue(values["WEB_PORT"], strconv.Itoa(webPortBase)),
+		Token:    cleanEnvValue(values["WEB_TOKEN"]),
+		BasePath: resolveEnvValue(values["WEB_BASE_PATH"], defaultWebBasePath),
+	}
+	if err := validateWebPort(cfg.Port); err != nil {
+		return WebConfig{}, fmt.Errorf("workspace %q: %w", name, err)
+	}
+	if !strings.HasPrefix(cfg.BasePath, "/") {
+		cfg.BasePath = "/" + cfg.BasePath
+	}
+	// Mirror the serve's normalizeBasePath: drop trailing slashes so a workspace
+	// with WEB_BASE_PATH="/chat/" yields the same canonical "/chat" the serve
+	// bakes into its HTML. Guard against collapsing "/" to "".
+	if trimmed := strings.TrimRight(cfg.BasePath, "/"); trimmed != "" {
+		cfg.BasePath = trimmed
+	}
+	return cfg, nil
+}
+
+// validateWebPort rejects a WEB_PORT that is not a plain decimal TCP port in
+// the 1-65535 range. The default port is itself valid, so this also guards the
+// fallback. strconv.Atoi rejects signs-with-junk and trailing characters, so
+// "80x"/"-1" fail here rather than being silently truncated.
+func validateWebPort(port string) error {
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("invalid WEB_PORT %q: must be a number 1-65535", port)
+	}
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("invalid WEB_PORT %q: must be 1-65535", port)
+	}
+	return nil
+}
+
+// cleanEnvValue trims a raw .env value and drops unrendered template
+// placeholders ({{...}}) left by a workspace template that was never rendered.
+func cleanEnvValue(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.Contains(value, "{{") {
+		return ""
+	}
+	return value
+}
+
+// resolveEnvValue returns the cleaned value, or fallback when the value is
+// empty or an unrendered placeholder.
+func resolveEnvValue(value, fallback string) string {
+	if cleaned := cleanEnvValue(value); cleaned != "" {
+		return cleaned
+	}
+	return fallback
+}

--- a/internal/contain/env_test.go
+++ b/internal/contain/env_test.go
@@ -1,0 +1,98 @@
+package contain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeEnvForTest(t *testing.T, name, contents string) {
+	t.Helper()
+	dir, err := ContainerDir(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadWebConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeEnvForTest(t, "alpha", "WEB_PORT=8222\nWEB_TOKEN=secret-token\nWEB_BASE_PATH=/chat/\n")
+
+	web, err := ReadWebConfig("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if web.Port != "8222" || web.Token != "secret-token" {
+		t.Errorf("web = %+v", web)
+	}
+	// Trailing slash is normalized away to match the serve's canonical shape.
+	if web.BasePath != "/chat" {
+		t.Errorf("BasePath = %q, want /chat", web.BasePath)
+	}
+}
+
+func TestReadWebConfigDefaults(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeEnvForTest(t, "bare", "OTHER=1\n")
+
+	web, err := ReadWebConfig("bare")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if web.Port != "8081" || web.BasePath != "/chat" || web.Token != "" {
+		t.Errorf("web = %+v, want defaults with empty token", web)
+	}
+}
+
+func TestReadWebConfigUnrenderedPlaceholders(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeEnvForTest(t, "tmpl", "WEB_PORT={{web_port}}\nWEB_TOKEN={{web_token}}\nWEB_BASE_PATH={{base}}\n")
+
+	web, err := ReadWebConfig("tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if web.Port != "8081" || web.BasePath != "/chat" || web.Token != "" {
+		t.Errorf("web = %+v, want placeholder values replaced by defaults", web)
+	}
+}
+
+func TestReadWebConfigInvalidPort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeEnvForTest(t, "badport", "WEB_PORT=80x\nWEB_TOKEN=t\n")
+
+	if _, err := ReadWebConfig("badport"); err == nil {
+		t.Fatal("invalid WEB_PORT accepted, want error")
+	}
+}
+
+func TestReadWebConfigMissingWorkspace(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if _, err := ReadWebConfig("nope"); err == nil {
+		t.Fatal("missing workspace read, want error")
+	}
+}
+
+func TestReadEnvFileParsing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	contents := "# comment\nA=1\nB = \"quoted\" \n\nNOEQUALS\nC='single'\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	values, err := ReadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["A"] != "1" || values["B"] != "quoted" || values["C"] != "single" {
+		t.Errorf("values = %+v", values)
+	}
+	if _, ok := values["NOEQUALS"]; ok {
+		t.Error("line without '=' should be skipped")
+	}
+}

--- a/internal/hub/contain.go
+++ b/internal/hub/contain.go
@@ -1,0 +1,62 @@
+package hub
+
+import (
+	"net"
+
+	"github.com/samsaffron/term-llm/internal/contain"
+)
+
+// ContainResolver discovers nodes from local contain workspaces: each
+// workspace with a provisioned web token becomes a node whose URL/token come
+// from its .env (via contain.ReadWebConfig). List and Read are fields so
+// tests can substitute fakes for the container config directory.
+type ContainResolver struct {
+	// Host is the host the workspaces' serves are published on (loopback in
+	// the one-container-per-agent shape).
+	Host string
+	// List enumerates contain workspace definitions.
+	List func() ([]contain.ListEntry, error)
+	// Read resolves a workspace's web config from its .env.
+	Read func(name string) (contain.WebConfig, error)
+}
+
+// NewContainResolver returns a resolver over the local contain workspaces.
+func NewContainResolver() *ContainResolver {
+	return &ContainResolver{
+		Host: "127.0.0.1",
+		List: contain.Definitions,
+		Read: contain.ReadWebConfig,
+	}
+}
+
+// Source implements Resolver.
+func (c *ContainResolver) Source() string { return SourceContain }
+
+// Nodes implements Resolver. Workspaces whose .env cannot be read or that
+// have no provisioned web token are skipped (they have no reachable serve to
+// front), so a half-created workspace never breaks hub discovery.
+func (c *ContainResolver) Nodes() ([]Node, error) {
+	entries, err := c.List()
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]Node, 0, len(entries))
+	for _, e := range entries {
+		web, err := c.Read(e.Name)
+		if err != nil || web.Token == "" {
+			continue
+		}
+		if ValidateID(e.Name) != nil {
+			continue
+		}
+		nodes = append(nodes, Node{
+			ID:       e.Name,
+			Name:     e.Name,
+			Source:   SourceContain,
+			URL:      "http://" + net.JoinHostPort(c.Host, web.Port),
+			BasePath: web.BasePath,
+			Token:    web.Token,
+		})
+	}
+	return nodes, nil
+}

--- a/internal/hub/contain.go
+++ b/internal/hub/contain.go
@@ -2,6 +2,8 @@ package hub
 
 import (
 	"net"
+	"path/filepath"
+	"strings"
 
 	"github.com/samsaffron/term-llm/internal/contain"
 )
@@ -18,15 +20,42 @@ type ContainResolver struct {
 	List func() ([]contain.ListEntry, error)
 	// Read resolves a workspace's web config from its .env.
 	Read func(name string) (contain.WebConfig, error)
+	// Workspace resolves a workspace's in-container workspace path (the
+	// compose x-term-llm workspace hint). A non-empty result becomes the
+	// node's delegation workdir, opting the workspace in to accepting
+	// hub-mediated delegations; an empty result leaves the node unable to
+	// accept (default deny).
+	Workspace func(name string) string
 }
 
 // NewContainResolver returns a resolver over the local contain workspaces.
 func NewContainResolver() *ContainResolver {
 	return &ContainResolver{
-		Host: "127.0.0.1",
-		List: contain.Definitions,
-		Read: contain.ReadWebConfig,
+		Host:      "127.0.0.1",
+		List:      contain.Definitions,
+		Read:      contain.ReadWebConfig,
+		Workspace: containWorkspaceHint,
 	}
+}
+
+// containWorkspaceHint reads the workspace's compose x-term-llm workspace
+// hint. Only rooted paths are usable as a delegation workdir; anything else
+// (missing hint, unreadable compose) yields "" and the node stays
+// non-accepting.
+func containWorkspaceHint(name string) string {
+	dir, err := contain.ContainerDir(name)
+	if err != nil {
+		return ""
+	}
+	info, err := contain.ReadComposeInfo(filepath.Join(dir, "compose.yaml"))
+	if err != nil {
+		return ""
+	}
+	ws := strings.TrimSpace(info.Hints.Workspace)
+	if !strings.HasPrefix(ws, "/") {
+		return ""
+	}
+	return ws
 }
 
 // Source implements Resolver.
@@ -49,14 +78,22 @@ func (c *ContainResolver) Nodes() ([]Node, error) {
 		if ValidateID(e.Name) != nil {
 			continue
 		}
-		nodes = append(nodes, Node{
+		node := Node{
 			ID:       e.Name,
 			Name:     e.Name,
 			Source:   SourceContain,
 			URL:      "http://" + net.JoinHostPort(c.Host, web.Port),
 			BasePath: web.BasePath,
 			Token:    web.Token,
-		})
+		}
+		// Contained workspaces are sandboxes with a declared workspace path,
+		// so they safely accept delegations with that path as the workdir.
+		if c.Workspace != nil {
+			if ws := c.Workspace(e.Name); ws != "" {
+				node.Delegation = &DelegationPolicy{Enabled: true, AcceptFrom: []string{"*"}, Workdir: ws}
+			}
+		}
+		nodes = append(nodes, node)
 	}
 	return nodes, nil
 }

--- a/internal/hub/contain_test.go
+++ b/internal/hub/contain_test.go
@@ -1,0 +1,61 @@
+package hub
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/contain"
+)
+
+func TestContainResolverDiscoversWorkspaces(t *testing.T) {
+	r := &ContainResolver{
+		Host: "127.0.0.1",
+		List: func() ([]contain.ListEntry, error) {
+			return []contain.ListEntry{
+				{Name: "jarvis", Status: "running"},
+				{Name: "untokened", Status: "running"},
+				{Name: "broken", Status: "missing"},
+			}, nil
+		},
+		Read: func(name string) (contain.WebConfig, error) {
+			switch name {
+			case "jarvis":
+				return contain.WebConfig{Port: "8222", Token: "tkn-1", BasePath: "/chat"}, nil
+			case "untokened":
+				return contain.WebConfig{Port: "8223", Token: "", BasePath: "/chat"}, nil
+			default:
+				return contain.WebConfig{}, fmt.Errorf("no .env")
+			}
+		},
+	}
+
+	nodes, err := r.Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Workspaces without a provisioned token or readable .env are skipped.
+	if len(nodes) != 1 {
+		t.Fatalf("len(nodes) = %d, want 1: %+v", len(nodes), nodes)
+	}
+	n := nodes[0]
+	if n.ID != "jarvis" || n.Source != SourceContain || n.Token != "tkn-1" {
+		t.Errorf("node = %+v", n)
+	}
+	if n.URL != "http://127.0.0.1:8222" || n.BasePath != "/chat" {
+		t.Errorf("url/base = %q %q", n.URL, n.BasePath)
+	}
+	if n.BaseURL() != "http://127.0.0.1:8222/chat" {
+		t.Errorf("BaseURL = %q", n.BaseURL())
+	}
+}
+
+func TestContainResolverListError(t *testing.T) {
+	r := &ContainResolver{
+		Host: "127.0.0.1",
+		List: func() ([]contain.ListEntry, error) { return nil, fmt.Errorf("no config dir") },
+		Read: func(string) (contain.WebConfig, error) { return contain.WebConfig{}, nil },
+	}
+	if _, err := r.Nodes(); err == nil {
+		t.Fatal("list error swallowed, want error")
+	}
+}

--- a/internal/hub/contain_test.go
+++ b/internal/hub/contain_test.go
@@ -49,6 +49,46 @@ func TestContainResolverDiscoversWorkspaces(t *testing.T) {
 	}
 }
 
+func TestContainResolverDelegationWorkdir(t *testing.T) {
+	r := &ContainResolver{
+		Host: "127.0.0.1",
+		List: func() ([]contain.ListEntry, error) {
+			return []contain.ListEntry{{Name: "jarvis"}, {Name: "nohint"}}, nil
+		},
+		Read: func(name string) (contain.WebConfig, error) {
+			return contain.WebConfig{Port: "8222", Token: "tkn-1", BasePath: "/chat"}, nil
+		},
+		Workspace: func(name string) string {
+			if name == "jarvis" {
+				return "/workspace"
+			}
+			return ""
+		},
+	}
+	nodes, err := r.Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("len(nodes) = %d, want 2", len(nodes))
+	}
+	byID := map[string]Node{}
+	for _, n := range nodes {
+		byID[n.ID] = n
+	}
+	withHint := byID["jarvis"]
+	if withHint.Delegation == nil || withHint.Delegation.Workdir != "/workspace" {
+		t.Errorf("workspace hint should set the delegation workdir: %+v", withHint.Delegation)
+	}
+	if err := withHint.AcceptsDelegationFrom("anyone"); err != nil {
+		t.Errorf("contain node with workdir should accept delegations: %v", err)
+	}
+	noHint := byID["nohint"]
+	if noHint.Delegation != nil {
+		t.Errorf("workspace without a hint must stay non-accepting: %+v", noHint.Delegation)
+	}
+}
+
 func TestContainResolverListError(t *testing.T) {
 	r := &ContainResolver{
 		Host: "127.0.0.1",

--- a/internal/hub/delegation.go
+++ b/internal/hub/delegation.go
@@ -1,0 +1,235 @@
+package hub
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultDelegationMaxInFlight bounds concurrently active delegations per
+// target node when the node's policy does not set max_in_flight.
+const DefaultDelegationMaxInFlight = 4
+
+// DefaultDelegationMaxDepth bounds delegation chains (A -> B -> C is depth 3)
+// so two mutually-delegating nodes cannot recurse forever.
+const DefaultDelegationMaxDepth = 3
+
+// DefaultDelegationAgent is the agent delegated jobs run as when the request
+// names none; with no allowed_agents policy it is also the ONLY agent a
+// target accepts.
+const DefaultDelegationAgent = "developer"
+
+// DelegationPolicy is a node's cross-node delegation policy, configured per
+// node in the hub config:
+//
+//	nodes:
+//	  - name: jarvis
+//	    url: http://127.0.0.1:8081/chat
+//	    token: secret
+//	    delegation:
+//	      to: ["*"]           # node ids this node may delegate to
+//	      accept_from: ["*"]  # node ids this node accepts delegations from
+//	      workdir: /work      # REQUIRED to accept; cwd for delegated jobs
+//	      max_in_flight: 4    # concurrently active delegations targeting this node
+//	      allowed_agents: []  # agents origins may request (default: developer only)
+//	      allowed_models: []  # model overrides origins may request (default: none)
+//
+// Defaults are off: a node must set delegation.enabled to true before it can
+// originate or accept delegated work. Accepting still also requires a workdir.
+type DelegationPolicy struct {
+	Enabled     bool     `json:"enabled,omitempty" yaml:"enabled"`
+	To          []string `json:"to,omitempty" yaml:"to"`
+	AcceptFrom  []string `json:"accept_from,omitempty" yaml:"accept_from"`
+	Workdir     string   `json:"workdir,omitempty" yaml:"workdir"`
+	MaxInFlight int      `json:"max_in_flight,omitempty" yaml:"max_in_flight"`
+	// AllowedAgents lists agent names origins may request on this node.
+	// Empty means only DefaultDelegationAgent; "*" allows any plain agent
+	// name, but path-like names (containing a separator or "..") always
+	// require an exact entry.
+	AllowedAgents []string `json:"allowed_agents,omitempty" yaml:"allowed_agents"`
+	// AllowedModels lists model overrides origins may request. Empty means no
+	// override is accepted (the target's own default is used); "*" allows any.
+	AllowedModels []string `json:"allowed_models,omitempty" yaml:"allowed_models"`
+}
+
+// matchNodeList reports whether id matches the pattern list: "*" matches any
+// node, anything else is an exact node id match.
+func matchNodeList(patterns []string, id string) bool {
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p == "*" || p == id {
+			return true
+		}
+	}
+	return false
+}
+
+// CanDelegateTo reports whether this node's policy allows originating a
+// delegation to the target node. Delegation is default-off; once enabled, an
+// empty "to" list means any target (the target still has to accept).
+func (n Node) CanDelegateTo(targetID string) bool {
+	if n.Delegation == nil || !n.Delegation.Enabled {
+		return false
+	}
+	if len(n.Delegation.To) == 0 {
+		return true
+	}
+	return matchNodeList(n.Delegation.To, targetID)
+}
+
+// AcceptsDelegationFrom returns nil when this node accepts delegated work
+// from the origin node, or an error describing why not. Delegation is
+// default-off; accepting additionally requires an explicit delegation workdir.
+func (n Node) AcceptsDelegationFrom(originID string) error {
+	if n.Delegation == nil || !n.Delegation.Enabled {
+		return fmt.Errorf("node %q does not accept delegations (delegation is not enabled)", n.ID)
+	}
+	if strings.TrimSpace(n.Delegation.Workdir) == "" {
+		return fmt.Errorf("node %q does not accept delegations (no delegation workdir configured)", n.ID)
+	}
+	acceptFrom := n.Delegation.AcceptFrom
+	if len(acceptFrom) == 0 {
+		acceptFrom = []string{"*"}
+	}
+	if !matchNodeList(acceptFrom, originID) {
+		return fmt.Errorf("node %q does not accept delegations from node %q", n.ID, originID)
+	}
+	return nil
+}
+
+// DelegationWorkdir returns the node's configured delegation workdir ("" when
+// delegation is disabled or the node does not accept delegations).
+func (n Node) DelegationWorkdir() string {
+	if n.Delegation == nil || !n.Delegation.Enabled {
+		return ""
+	}
+	return strings.TrimSpace(n.Delegation.Workdir)
+}
+
+// DelegationMaxInFlight returns the per-target concurrency cap for this node.
+func (n Node) DelegationMaxInFlight() int {
+	if n.Delegation == nil || n.Delegation.MaxInFlight <= 0 {
+		return DefaultDelegationMaxInFlight
+	}
+	return n.Delegation.MaxInFlight
+}
+
+// pathLikeAgentName reports whether an agent name looks like a filesystem
+// path. Agent names can resolve to files on the target node, so a remote
+// origin must never smuggle one in under a "*" wildcard.
+func pathLikeAgentName(name string) bool {
+	return strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "~")
+}
+
+// AcceptsDelegationAgent returns nil when this node's policy allows delegated
+// work to run as the given agent. With no allowed_agents configured only
+// DefaultDelegationAgent is accepted; "*" accepts any plain name; path-like
+// names always need an exact entry.
+func (n Node) AcceptsDelegationAgent(agent string) error {
+	var allowed []string
+	if n.Delegation != nil {
+		allowed = n.Delegation.AllowedAgents
+	}
+	if len(allowed) == 0 {
+		if agent == DefaultDelegationAgent {
+			return nil
+		}
+		return fmt.Errorf("node %q only accepts the default delegation agent %q (set delegation.allowed_agents to permit others)", n.ID, DefaultDelegationAgent)
+	}
+	for _, p := range allowed {
+		p = strings.TrimSpace(p)
+		if p == agent {
+			return nil
+		}
+		if p == "*" && !pathLikeAgentName(agent) {
+			return nil
+		}
+	}
+	return fmt.Errorf("node %q does not accept delegations running agent %q", n.ID, agent)
+}
+
+// AcceptsDelegationModel returns nil when this node's policy allows the given
+// model override. An empty model (use the target's default) is always
+// allowed; with no allowed_models configured every override is refused.
+func (n Node) AcceptsDelegationModel(model string) error {
+	if model == "" {
+		return nil
+	}
+	if n.Delegation == nil || len(n.Delegation.AllowedModels) == 0 {
+		return fmt.Errorf("node %q does not accept a model override (set delegation.allowed_models to permit one)", n.ID)
+	}
+	if !matchNodeList(n.Delegation.AllowedModels, model) {
+		return fmt.Errorf("node %q does not accept delegations using model %q", n.ID, model)
+	}
+	return nil
+}
+
+// Delegation statuses. Pending/running/cancel_requested are active; the rest
+// are terminal. They deliberately mirror jobs-v2 run statuses since a
+// delegation is fronted by one jobs-v2 run on the target node, with "error"
+// added for delegations that broke outside the target run itself.
+const (
+	DelegationStatusPending         = "pending"
+	DelegationStatusRunning         = "running"
+	DelegationStatusCancelRequested = "cancel_requested"
+	DelegationStatusSucceeded       = "succeeded"
+	DelegationStatusFailed          = "failed"
+	DelegationStatusCancelled       = "cancelled"
+	DelegationStatusTimedOut        = "timed_out"
+	DelegationStatusError           = "error"
+)
+
+// DelegationStatusTerminal reports whether a delegation status is final.
+func DelegationStatusTerminal(status string) bool {
+	switch status {
+	case DelegationStatusSucceeded, DelegationStatusFailed, DelegationStatusCancelled,
+		DelegationStatusTimedOut, DelegationStatusError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Delegation is one hub-mediated cross-node delegation: origin node asked the
+// hub to run a prompt as a jobs-v2 LLM job on the target node. The record
+// deliberately holds NO tokens — node credentials live only in node sources —
+// so the ledger and every API view built from it are safe to serve.
+type Delegation struct {
+	ID         string `json:"id"`
+	OriginNode string `json:"origin_node"`
+	TargetNode string `json:"target_node"`
+	AgentName  string `json:"agent_name,omitempty"`
+	// Prompt is stored truncated (see delegationPromptLimit) for audit; the
+	// full prompt only travels to the target job's instructions.
+	Prompt string `json:"prompt,omitempty"`
+	Model  string `json:"model,omitempty"`
+	Cwd    string `json:"cwd,omitempty"`
+	// JobID/RunID identify the jobs-v2 job and run on the TARGET node.
+	JobID  string `json:"job_id,omitempty"`
+	RunID  string `json:"run_id,omitempty"`
+	Status string `json:"status"`
+	// Depth is 1 for a direct delegation and parent depth+1 for delegations
+	// created with parent_delegation_id. Chain lists the node ids involved
+	// from the root origin through this delegation's target, used to refuse
+	// delegation loops.
+	Depth    int      `json:"depth"`
+	Chain    []string `json:"chain,omitempty"`
+	ParentID string   `json:"parent_delegation_id,omitempty"`
+	// Response holds the target run's final response (truncated) once the
+	// delegation reaches a terminal status.
+	Response  string    `json:"response,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// NewDelegationID returns a fresh delegation id ("dlg_" + 16 hex chars).
+func NewDelegationID() (string, error) {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate delegation id: %w", err)
+	}
+	return "dlg_" + hex.EncodeToString(buf[:]), nil
+}

--- a/internal/hub/delegation_store.go
+++ b/internal/hub/delegation_store.go
@@ -1,0 +1,219 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	// delegationPromptLimit bounds the prompt excerpt stored in the ledger.
+	delegationPromptLimit = 2000
+	// delegationResponseLimit bounds the terminal response stored in the ledger.
+	delegationResponseLimit = 64 * 1024
+	// delegationRetention is how long terminal records are kept.
+	delegationRetention = 7 * 24 * time.Hour
+	// delegationMaxRecords caps the ledger size; oldest terminal records are
+	// dropped first, active records are never pruned.
+	delegationMaxRecords = 1000
+)
+
+// DelegationStore persists delegation records in a local JSON ledger. The
+// file is written 0600 like the node store: the records hold no tokens, but
+// prompts and responses are still private session content.
+type DelegationStore struct {
+	mu   sync.Mutex
+	path string
+	// now is a hook for prune tests.
+	now func() time.Time
+}
+
+// NewDelegationStore returns a store backed by the given JSON file path. The
+// file is created lazily on first Add.
+func NewDelegationStore(path string) *DelegationStore {
+	return &DelegationStore{path: path, now: time.Now}
+}
+
+// Path returns the backing file path.
+func (s *DelegationStore) Path() string { return s.path }
+
+// delegationFile is the on-disk JSON shape.
+type delegationFile struct {
+	Delegations []Delegation `json:"delegations"`
+}
+
+func (s *DelegationStore) readLocked() ([]Delegation, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read hub delegation ledger: %w", err)
+	}
+	var f delegationFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse hub delegation ledger %s: %w", s.path, err)
+	}
+	return f.Delegations, nil
+}
+
+func (s *DelegationStore) writeLocked(records []Delegation) error {
+	records = s.pruneLocked(records)
+	data, err := json.MarshalIndent(delegationFile{Delegations: records}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode hub delegation ledger: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create hub delegation ledger dir: %w", err)
+	}
+	// 0600: prompts/responses are private content. Chmod first so an existing
+	// overly-permissive file is corrected as well as newly created files.
+	if err := os.Chmod(s.path, 0o600); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("secure hub delegation ledger permissions: %w", err)
+	}
+	if err := os.WriteFile(s.path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write hub delegation ledger: %w", err)
+	}
+	if err := os.Chmod(s.path, 0o600); err != nil {
+		return fmt.Errorf("secure hub delegation ledger permissions: %w", err)
+	}
+	return nil
+}
+
+// pruneLocked drops terminal records older than the retention window, then
+// enforces the record cap by dropping the oldest terminal records. Active
+// records always survive pruning so in-flight caps stay accurate.
+func (s *DelegationStore) pruneLocked(records []Delegation) []Delegation {
+	cutoff := s.now().Add(-delegationRetention)
+	kept := records[:0]
+	for _, d := range records {
+		if DelegationStatusTerminal(d.Status) && d.UpdatedAt.Before(cutoff) {
+			continue
+		}
+		kept = append(kept, d)
+	}
+	if len(kept) <= delegationMaxRecords {
+		return kept
+	}
+	// Over cap: drop oldest terminal records first.
+	sort.SliceStable(kept, func(i, j int) bool { return kept[i].CreatedAt.Before(kept[j].CreatedAt) })
+	overflow := len(kept) - delegationMaxRecords
+	trimmed := make([]Delegation, 0, delegationMaxRecords)
+	for _, d := range kept {
+		if overflow > 0 && DelegationStatusTerminal(d.Status) {
+			overflow--
+			continue
+		}
+		trimmed = append(trimmed, d)
+	}
+	return trimmed
+}
+
+func truncateForLedger(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "… [truncated]"
+}
+
+// Add persists a new delegation record. Prompt and response excerpts are
+// truncated to keep the ledger bounded.
+func (s *DelegationStore) Add(d Delegation) error {
+	if d.ID == "" {
+		return fmt.Errorf("delegation id must not be empty")
+	}
+	d.Prompt = truncateForLedger(d.Prompt, delegationPromptLimit)
+	d.Response = truncateForLedger(d.Response, delegationResponseLimit)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.readLocked()
+	if err != nil {
+		return err
+	}
+	for _, existing := range records {
+		if existing.ID == d.ID {
+			return fmt.Errorf("delegation %q already exists", d.ID)
+		}
+	}
+	records = append(records, d)
+	return s.writeLocked(records)
+}
+
+// Get returns a delegation by id.
+func (s *DelegationStore) Get(id string) (Delegation, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.readLocked()
+	if err != nil {
+		return Delegation{}, false, err
+	}
+	for _, d := range records {
+		if d.ID == id {
+			return d, true, nil
+		}
+	}
+	return Delegation{}, false, nil
+}
+
+// Update applies fn to the stored record and persists the result. The
+// record's UpdatedAt is stamped and the response excerpt re-truncated.
+func (s *DelegationStore) Update(id string, fn func(*Delegation)) (Delegation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.readLocked()
+	if err != nil {
+		return Delegation{}, err
+	}
+	for i := range records {
+		if records[i].ID != id {
+			continue
+		}
+		fn(&records[i])
+		records[i].UpdatedAt = s.now().UTC()
+		records[i].Response = truncateForLedger(records[i].Response, delegationResponseLimit)
+		updated := records[i]
+		if err := s.writeLocked(records); err != nil {
+			return Delegation{}, err
+		}
+		return updated, nil
+	}
+	return Delegation{}, fmt.Errorf("delegation %q not found", id)
+}
+
+// List returns all records, newest first.
+func (s *DelegationStore) List() ([]Delegation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.readLocked()
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(records, func(i, j int) bool { return records[i].CreatedAt.After(records[j].CreatedAt) })
+	return records, nil
+}
+
+// ActiveCounts tallies non-terminal delegations hub-wide, per origin node,
+// and per target node, for in-flight cap enforcement.
+func (s *DelegationStore) ActiveCounts() (total int, byOrigin, byTarget map[string]int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.readLocked()
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	byOrigin = map[string]int{}
+	byTarget = map[string]int{}
+	for _, d := range records {
+		if DelegationStatusTerminal(d.Status) {
+			continue
+		}
+		total++
+		byOrigin[d.OriginNode]++
+		byTarget[d.TargetNode]++
+	}
+	return total, byOrigin, byTarget, nil
+}

--- a/internal/hub/delegation_test.go
+++ b/internal/hub/delegation_test.go
@@ -1,0 +1,264 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestDelegationPolicyDefaults(t *testing.T) {
+	n := Node{ID: "alpha"}
+	if n.CanDelegateTo("beta") {
+		t.Fatalf("node without a policy must not originate delegations")
+	}
+	if err := n.AcceptsDelegationFrom("beta"); err == nil {
+		t.Fatalf("node without a delegation workdir must not accept delegations")
+	}
+	if got := n.DelegationMaxInFlight(); got != DefaultDelegationMaxInFlight {
+		t.Fatalf("DelegationMaxInFlight = %d, want %d", got, DefaultDelegationMaxInFlight)
+	}
+}
+
+func TestDelegationPolicyAcceptRequiresWorkdir(t *testing.T) {
+	n := Node{ID: "alpha", Delegation: &DelegationPolicy{Enabled: true, AcceptFrom: []string{"*"}}}
+	if err := n.AcceptsDelegationFrom("beta"); err == nil {
+		t.Fatalf("accept_from without workdir must still deny")
+	}
+	n.Delegation.Workdir = "/work"
+	if err := n.AcceptsDelegationFrom("beta"); err != nil {
+		t.Fatalf("workdir + accept_from * should accept: %v", err)
+	}
+}
+
+func TestDelegationPolicyMatching(t *testing.T) {
+	n := Node{ID: "alpha", Delegation: &DelegationPolicy{
+		Enabled:    true,
+		To:         []string{"beta"},
+		AcceptFrom: []string{"gamma"},
+		Workdir:    "/work",
+	}}
+	if !n.CanDelegateTo("beta") {
+		t.Fatalf("explicit to entry should allow")
+	}
+	if n.CanDelegateTo("gamma") {
+		t.Fatalf("node not in to list should be denied")
+	}
+	if err := n.AcceptsDelegationFrom("gamma"); err != nil {
+		t.Fatalf("explicit accept_from entry should accept: %v", err)
+	}
+	if err := n.AcceptsDelegationFrom("beta"); err == nil {
+		t.Fatalf("origin not in accept_from should be denied")
+	}
+	// Workdir set with empty accept_from defaults to accepting any node.
+	open := Node{ID: "alpha", Delegation: &DelegationPolicy{Enabled: true, Workdir: "/work"}}
+	if err := open.AcceptsDelegationFrom("anyone"); err != nil {
+		t.Fatalf("workdir without accept_from should default to *: %v", err)
+	}
+}
+
+func TestDelegationStatusTerminal(t *testing.T) {
+	for _, status := range []string{DelegationStatusSucceeded, DelegationStatusFailed, DelegationStatusCancelled, DelegationStatusTimedOut, DelegationStatusError} {
+		if !DelegationStatusTerminal(status) {
+			t.Fatalf("%s should be terminal", status)
+		}
+	}
+	for _, status := range []string{DelegationStatusPending, DelegationStatusRunning, DelegationStatusCancelRequested, ""} {
+		if DelegationStatusTerminal(status) {
+			t.Fatalf("%s should not be terminal", status)
+		}
+	}
+}
+
+func newTestDelegation(id, origin, target, status string, created time.Time) Delegation {
+	return Delegation{
+		ID:         id,
+		OriginNode: origin,
+		TargetNode: target,
+		Status:     status,
+		Depth:      1,
+		Chain:      []string{origin, target},
+		CreatedAt:  created,
+		UpdatedAt:  created,
+	}
+}
+
+func TestDelegationStoreCRUD(t *testing.T) {
+	s := NewDelegationStore(filepath.Join(t.TempDir(), "ledger", "delegations.json"))
+	now := time.Now().UTC()
+
+	if err := s.Add(newTestDelegation("dlg_1", "a", "b", DelegationStatusRunning, now)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := s.Add(newTestDelegation("dlg_1", "a", "b", DelegationStatusRunning, now)); err == nil {
+		t.Fatalf("duplicate Add should fail")
+	}
+	if err := s.Add(newTestDelegation("dlg_2", "a", "c", DelegationStatusRunning, now.Add(time.Second))); err != nil {
+		t.Fatalf("Add second: %v", err)
+	}
+
+	d, ok, err := s.Get("dlg_1")
+	if err != nil || !ok {
+		t.Fatalf("Get dlg_1: ok=%v err=%v", ok, err)
+	}
+	if d.TargetNode != "b" {
+		t.Fatalf("TargetNode = %q", d.TargetNode)
+	}
+
+	updated, err := s.Update("dlg_1", func(rec *Delegation) {
+		rec.Status = DelegationStatusSucceeded
+		rec.Response = "done"
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Status != DelegationStatusSucceeded || updated.Response != "done" {
+		t.Fatalf("updated = %+v", updated)
+	}
+	if _, err := s.Update("dlg_missing", func(*Delegation) {}); err == nil {
+		t.Fatalf("Update on unknown id should fail")
+	}
+
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 || list[0].ID != "dlg_2" {
+		t.Fatalf("List should be newest first, got %+v", list)
+	}
+
+	total, byOrigin, byTarget, err := s.ActiveCounts()
+	if err != nil {
+		t.Fatalf("ActiveCounts: %v", err)
+	}
+	if total != 1 || byOrigin["a"] != 1 || byTarget["c"] != 1 {
+		t.Fatalf("ActiveCounts = %d %v %v", total, byOrigin, byTarget)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(s.Path())
+		if err != nil {
+			t.Fatalf("stat ledger: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("ledger permissions = %o, want 600", perm)
+		}
+	}
+}
+
+func TestDelegationStorePrune(t *testing.T) {
+	s := NewDelegationStore(filepath.Join(t.TempDir(), "delegations.json"))
+	now := time.Now().UTC()
+	s.now = func() time.Time { return now }
+
+	old := now.Add(-delegationRetention - time.Hour)
+	stale := newTestDelegation("dlg_old", "a", "b", DelegationStatusSucceeded, old)
+	stale.UpdatedAt = old
+	if err := s.Add(stale); err != nil {
+		t.Fatalf("Add stale: %v", err)
+	}
+	oldActive := newTestDelegation("dlg_old_active", "a", "b", DelegationStatusRunning, old)
+	oldActive.UpdatedAt = old
+	if err := s.Add(oldActive); err != nil {
+		t.Fatalf("Add old active: %v", err)
+	}
+	// Adding a fresh record triggers a prune pass on write.
+	if err := s.Add(newTestDelegation("dlg_new", "a", "b", DelegationStatusRunning, now)); err != nil {
+		t.Fatalf("Add fresh: %v", err)
+	}
+
+	if _, ok, _ := s.Get("dlg_old"); ok {
+		t.Fatalf("terminal record past retention should be pruned")
+	}
+	if _, ok, _ := s.Get("dlg_old_active"); !ok {
+		t.Fatalf("active record must never be pruned")
+	}
+	if _, ok, _ := s.Get("dlg_new"); !ok {
+		t.Fatalf("fresh record should remain")
+	}
+}
+
+func TestDelegationStorePromptTruncation(t *testing.T) {
+	s := NewDelegationStore(filepath.Join(t.TempDir(), "delegations.json"))
+	d := newTestDelegation("dlg_big", "a", "b", DelegationStatusRunning, time.Now().UTC())
+	for len(d.Prompt) <= delegationPromptLimit {
+		d.Prompt += "0123456789abcdef"
+	}
+	if err := s.Add(d); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got, _, _ := s.Get("dlg_big")
+	if len(got.Prompt) > delegationPromptLimit+len("… [truncated]") {
+		t.Fatalf("prompt not truncated: %d bytes", len(got.Prompt))
+	}
+}
+
+func TestNewDelegationID(t *testing.T) {
+	a, err := NewDelegationID()
+	if err != nil {
+		t.Fatalf("NewDelegationID: %v", err)
+	}
+	b, _ := NewDelegationID()
+	if a == b || len(a) != len("dlg_")+16 {
+		t.Fatalf("ids should be unique 16-hex: %q %q", a, b)
+	}
+}
+
+func TestAcceptsDelegationAgent(t *testing.T) {
+	deny := func(n Node, agent string) {
+		t.Helper()
+		if err := n.AcceptsDelegationAgent(agent); err == nil {
+			t.Errorf("node %q should refuse agent %q", n.ID, agent)
+		}
+	}
+	allow := func(n Node, agent string) {
+		t.Helper()
+		if err := n.AcceptsDelegationAgent(agent); err != nil {
+			t.Errorf("node %q should accept agent %q: %v", n.ID, agent, err)
+		}
+	}
+
+	// No allowed_agents: only the default agent.
+	bare := Node{ID: "bare", Delegation: &DelegationPolicy{Workdir: "/work"}}
+	allow(bare, DefaultDelegationAgent)
+	deny(bare, "reviewer")
+	deny(bare, "skills/custom")
+
+	// "*": plain names only; path-like names always need an exact entry.
+	wild := Node{ID: "wild", Delegation: &DelegationPolicy{Workdir: "/work", AllowedAgents: []string{"*"}}}
+	allow(wild, "reviewer")
+	allow(wild, DefaultDelegationAgent)
+	for _, agent := range []string{"../evil", "skills/custom", `..\evil`, ".hidden", "~root"} {
+		deny(wild, agent)
+	}
+
+	// Exact entries, including path-like ones.
+	exact := Node{ID: "exact", Delegation: &DelegationPolicy{Workdir: "/work", AllowedAgents: []string{"reviewer", "skills/custom"}}}
+	allow(exact, "reviewer")
+	allow(exact, "skills/custom")
+	deny(exact, DefaultDelegationAgent)
+}
+
+func TestAcceptsDelegationModel(t *testing.T) {
+	bare := Node{ID: "bare", Delegation: &DelegationPolicy{Workdir: "/work"}}
+	if err := bare.AcceptsDelegationModel(""); err != nil {
+		t.Errorf("empty model should always be allowed: %v", err)
+	}
+	if err := bare.AcceptsDelegationModel("haiku"); err == nil {
+		t.Errorf("model override without allowed_models should be refused")
+	}
+
+	listed := Node{ID: "listed", Delegation: &DelegationPolicy{Workdir: "/work", AllowedModels: []string{"haiku"}}}
+	if err := listed.AcceptsDelegationModel("haiku"); err != nil {
+		t.Errorf("listed model refused: %v", err)
+	}
+	if err := listed.AcceptsDelegationModel("gpt-x"); err == nil {
+		t.Errorf("unlisted model should be refused")
+	}
+
+	wild := Node{ID: "wild", Delegation: &DelegationPolicy{Workdir: "/work", AllowedModels: []string{"*"}}}
+	if err := wild.AcceptsDelegationModel("anything"); err != nil {
+		t.Errorf("wildcard model refused: %v", err)
+	}
+}

--- a/internal/hub/node.go
+++ b/internal/hub/node.go
@@ -1,0 +1,155 @@
+// Package hub models a fleet of term-llm web nodes for `term-llm serve hub`.
+//
+// The core object is a Node: a reachable term-llm serve (web/API endpoint)
+// with an identity, a backend URL + base path, an optional bearer token, and
+// a source describing which resolver produced it. Resolvers (static config,
+// contain workspaces, the local UI-added store) feed a Registry, which is the
+// single lookup surface the hub server routes and proxies from.
+//
+// TODO(hub): node self-registration, scheduling, and mTLS between hub and
+// nodes are deliberately out of scope for v1; see docs-site guide "Hub".
+package hub
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Source labels for the built-in resolvers.
+const (
+	SourceConfig  = "config"
+	SourceContain = "contain"
+	SourceLocal   = "local"
+)
+
+// Node is one reachable term-llm web/API endpoint known to the hub.
+type Node struct {
+	// ID uniquely identifies the node within the hub and is used as the
+	// proxy path segment (/node/<id>/...). Restricted to a path-safe charset.
+	ID string `json:"id" yaml:"id"`
+	// Name is the human-facing label shown on the dashboard.
+	Name string `json:"name" yaml:"name"`
+	// Source is the resolver that produced this node (config/contain/local).
+	Source string `json:"source" yaml:"-"`
+	// URL is the backend origin, e.g. "http://127.0.0.1:8081". Never sent to
+	// hub clients together with Token.
+	URL string `json:"url" yaml:"url"`
+	// BasePath is the URL prefix the node's serve is mounted under, e.g.
+	// "/chat". Always rooted, no trailing slash; root-mounted serves are not
+	// supported by Hub v1 because path-based proxying needs a stable prefix.
+	BasePath string `json:"base_path,omitempty" yaml:"base_path"`
+	// Token is the node's web bearer token. It is injected server-side by the
+	// hub proxy and MUST never be marshalled into any client-facing response;
+	// API handlers convert Node to a public view first.
+	Token string `json:"token,omitempty" yaml:"token"`
+}
+
+// BaseURL returns the node's backend origin joined with its base path,
+// without a trailing slash (e.g. "http://127.0.0.1:8081/chat").
+func (n Node) BaseURL() string {
+	return strings.TrimRight(n.URL, "/") + n.BasePath
+}
+
+var nodeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// ValidateID rejects node IDs that are empty or unsafe as a single proxy path
+// segment. The charset deliberately excludes '/', '%', and whitespace so an ID
+// can never smuggle extra path segments into /node/<id>/.
+func ValidateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("node id must not be empty")
+	}
+	if len(id) > 64 {
+		return fmt.Errorf("node id %q too long (max 64 chars)", id)
+	}
+	if !nodeIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid node id %q: use letters, digits, '.', '_' or '-' (must start with a letter or digit)", id)
+	}
+	return nil
+}
+
+// SlugID derives a valid node ID from a free-form name, for nodes added
+// without an explicit ID. Returns an error when nothing usable remains.
+func SlugID(name string) (string, error) {
+	slug := strings.ToLower(strings.TrimSpace(name))
+	slug = regexp.MustCompile(`[^a-z0-9._-]+`).ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-._")
+	if len(slug) > 64 {
+		slug = slug[:64]
+	}
+	if err := ValidateID(slug); err != nil {
+		return "", fmt.Errorf("cannot derive node id from %q: %w", name, err)
+	}
+	return slug, nil
+}
+
+// ParseNodeURL splits a node URL like "http://127.0.0.1:8081/chat" into its
+// origin ("http://127.0.0.1:8081") and normalized base path ("/chat"). A URL
+// without a path yields an empty base path; Normalize rejects that unless an
+// explicit BasePath is supplied, because Hub v1's path proxy needs a prefix.
+func ParseNodeURL(raw string) (origin, basePath string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", fmt.Errorf("node url must not be empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid node url %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", "", fmt.Errorf("invalid node url %q: scheme must be http or https", raw)
+	}
+	if u.Host == "" {
+		return "", "", fmt.Errorf("invalid node url %q: missing host", raw)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", "", fmt.Errorf("invalid node url %q: must not carry a query or fragment", raw)
+	}
+	basePath = strings.TrimRight(u.Path, "/")
+	if basePath != "" && !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+	return u.Scheme + "://" + u.Host, basePath, nil
+}
+
+// Normalize validates and canonicalizes a node in place: the URL is split
+// into origin + base path (an explicit BasePath wins over a path embedded in
+// URL), the ID falls back to a slug of the name, and the name falls back to
+// the ID.
+func (n *Node) Normalize() error {
+	origin, urlBase, err := ParseNodeURL(n.URL)
+	if err != nil {
+		return err
+	}
+	n.URL = origin
+	if n.BasePath == "" {
+		n.BasePath = urlBase
+	}
+	n.BasePath = strings.TrimRight(n.BasePath, "/")
+	if n.BasePath != "" && !strings.HasPrefix(n.BasePath, "/") {
+		n.BasePath = "/" + n.BasePath
+	}
+	if n.BasePath == "" {
+		return fmt.Errorf("node base path must not be root; use the serve web base path such as /chat")
+	}
+	if n.ID == "" {
+		name := n.Name
+		if name == "" {
+			name = strings.TrimPrefix(strings.TrimPrefix(n.URL, "https://"), "http://")
+		}
+		id, err := SlugID(name)
+		if err != nil {
+			return err
+		}
+		n.ID = id
+	}
+	if err := ValidateID(n.ID); err != nil {
+		return err
+	}
+	if n.Name == "" {
+		n.Name = n.ID
+	}
+	return nil
+}

--- a/internal/hub/node.go
+++ b/internal/hub/node.go
@@ -33,6 +33,10 @@ type Node struct {
 	Name string `json:"name" yaml:"name"`
 	// Source is the resolver that produced this node (config/contain/local).
 	Source string `json:"source" yaml:"-"`
+	// Connection is how the Hub reaches this node. Empty/"direct" means the Hub
+	// dials URL. "reverse" means the node must dial the Hub and keep a websocket
+	// open; useful for private nodes behind NAT/firewalls.
+	Connection string `json:"connection,omitempty" yaml:"connection"`
 	// URL is the backend origin, e.g. "http://127.0.0.1:8081". Never sent to
 	// hub clients together with Token.
 	URL string `json:"url" yaml:"url"`
@@ -44,12 +48,20 @@ type Node struct {
 	// hub proxy and MUST never be marshalled into any client-facing response;
 	// API handlers convert Node to a public view first.
 	Token string `json:"token,omitempty" yaml:"token"`
+	// Delegation is the node's cross-node delegation policy. Nil or disabled
+	// means the node cannot originate or accept delegations.
+	Delegation *DelegationPolicy `json:"delegation,omitempty" yaml:"delegation"`
 }
 
 // BaseURL returns the node's backend origin joined with its base path,
-// without a trailing slash (e.g. "http://127.0.0.1:8081/chat").
+// without a trailing slash (e.g. "http://127.0.0.1:8081/chat"). Reverse nodes
+// may not have a URL; callers that dial directly must check UsesReverseConnection first.
 func (n Node) BaseURL() string {
 	return strings.TrimRight(n.URL, "/") + n.BasePath
+}
+
+func (n Node) UsesReverseConnection() bool {
+	return strings.EqualFold(strings.TrimSpace(n.Connection), "reverse")
 }
 
 var nodeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
@@ -119,11 +131,24 @@ func ParseNodeURL(raw string) (origin, basePath string, err error) {
 // URL), the ID falls back to a slug of the name, and the name falls back to
 // the ID.
 func (n *Node) Normalize() error {
-	origin, urlBase, err := ParseNodeURL(n.URL)
-	if err != nil {
-		return err
+	n.Connection = strings.ToLower(strings.TrimSpace(n.Connection))
+	if n.Connection == "" {
+		n.Connection = "direct"
 	}
-	n.URL = origin
+	if n.Connection != "direct" && n.Connection != "reverse" {
+		return fmt.Errorf("invalid node connection %q: use direct or reverse", n.Connection)
+	}
+	var urlBase string
+	if n.URL != "" {
+		origin, parsedBase, err := ParseNodeURL(n.URL)
+		if err != nil {
+			return err
+		}
+		n.URL = origin
+		urlBase = parsedBase
+	} else if !n.UsesReverseConnection() {
+		return fmt.Errorf("node url must not be empty")
+	}
 	if n.BasePath == "" {
 		n.BasePath = urlBase
 	}

--- a/internal/hub/node_test.go
+++ b/internal/hub/node_test.go
@@ -1,0 +1,99 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseNodeURL(t *testing.T) {
+	cases := []struct {
+		raw      string
+		origin   string
+		basePath string
+		wantErr  bool
+	}{
+		{"http://127.0.0.1:8081/chat", "http://127.0.0.1:8081", "/chat", false},
+		{"http://127.0.0.1:8081/chat/", "http://127.0.0.1:8081", "/chat", false},
+		{"http://127.0.0.1:8081", "http://127.0.0.1:8081", "", false},
+		{"https://node.example.com/agent/x", "https://node.example.com", "/agent/x", false},
+		{"", "", "", true},
+		{"ftp://127.0.0.1/chat", "", "", true},
+		{"http:///chat", "", "", true},
+		{"http://127.0.0.1:8081/chat?x=1", "", "", true},
+	}
+	for _, tc := range cases {
+		origin, basePath, err := ParseNodeURL(tc.raw)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ParseNodeURL(%q) = (%q,%q), want error", tc.raw, origin, basePath)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseNodeURL(%q) error: %v", tc.raw, err)
+			continue
+		}
+		if origin != tc.origin || basePath != tc.basePath {
+			t.Errorf("ParseNodeURL(%q) = (%q,%q), want (%q,%q)", tc.raw, origin, basePath, tc.origin, tc.basePath)
+		}
+	}
+}
+
+func TestValidateID(t *testing.T) {
+	for _, ok := range []string{"jarvis", "node-1", "a.b_c", "X9"} {
+		if err := ValidateID(ok); err != nil {
+			t.Errorf("ValidateID(%q) = %v, want nil", ok, err)
+		}
+	}
+	bad := []string{"", "-lead", ".lead", "has space", "a/b", "a%2fb", strings.Repeat("x", 65)}
+	for _, id := range bad {
+		if err := ValidateID(id); err == nil {
+			t.Errorf("ValidateID(%q) = nil, want error", id)
+		}
+	}
+}
+
+func TestNormalizeDerivesIDAndName(t *testing.T) {
+	n := Node{Name: "My Node!", URL: "http://127.0.0.1:9000/chat"}
+	if err := n.Normalize(); err != nil {
+		t.Fatal(err)
+	}
+	if n.ID != "my-node" {
+		t.Errorf("ID = %q, want my-node", n.ID)
+	}
+	if n.URL != "http://127.0.0.1:9000" || n.BasePath != "/chat" {
+		t.Errorf("URL/BasePath = %q %q", n.URL, n.BasePath)
+	}
+	if n.BaseURL() != "http://127.0.0.1:9000/chat" {
+		t.Errorf("BaseURL = %q", n.BaseURL())
+	}
+
+	n2 := Node{ID: "n2", URL: "http://127.0.0.1:9000/chat"}
+	if err := n2.Normalize(); err != nil {
+		t.Fatal(err)
+	}
+	if n2.Name != "n2" {
+		t.Errorf("Name = %q, want fallback to ID", n2.Name)
+	}
+}
+
+func TestNormalizeRejectsRootBasePath(t *testing.T) {
+	for _, n := range []Node{
+		{ID: "root-url", URL: "http://127.0.0.1:9000"},
+		{ID: "slash-base", URL: "http://127.0.0.1:9000/chat", BasePath: "/"},
+	} {
+		if err := n.Normalize(); err == nil {
+			t.Fatalf("Normalize(%+v) = nil, want root base path error", n)
+		}
+	}
+}
+
+func TestNormalizeExplicitBasePathWins(t *testing.T) {
+	n := Node{ID: "x", URL: "http://127.0.0.1:9000/chat", BasePath: "/other/"}
+	if err := n.Normalize(); err != nil {
+		t.Fatal(err)
+	}
+	if n.BasePath != "/other" {
+		t.Errorf("BasePath = %q, want /other", n.BasePath)
+	}
+}

--- a/internal/hub/node_test.go
+++ b/internal/hub/node_test.go
@@ -5,7 +5,34 @@ import (
 	"testing"
 )
 
-func TestParseNodeURL(t *testing.T) {
+func TestNodeNormalizeReverseConnection(t *testing.T) {
+	n := Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat"}
+	if err := n.Normalize(); err != nil {
+		t.Fatalf("Normalize reverse: %v", err)
+	}
+	if !n.UsesReverseConnection() {
+		t.Fatalf("UsesReverseConnection = false")
+	}
+	if n.URL != "" || n.BasePath != "/chat" || n.Connection != "reverse" {
+		t.Fatalf("normalized node = %+v", n)
+	}
+}
+
+func TestNodeNormalizeReverseRequiresBasePath(t *testing.T) {
+	n := Node{ID: "artist", Connection: "reverse"}
+	if err := n.Normalize(); err == nil {
+		t.Fatalf("reverse node without base path should fail")
+	}
+}
+
+func TestNodeNormalizeInvalidConnection(t *testing.T) {
+	n := Node{ID: "artist", Connection: "sideways", URL: "http://127.0.0.1:8080/chat"}
+	if err := n.Normalize(); err == nil {
+		t.Fatalf("invalid connection should fail")
+	}
+}
+
+func TestNodeBaseURL(t *testing.T) {
 	cases := []struct {
 		raw      string
 		origin   string

--- a/internal/hub/probe.go
+++ b/internal/hub/probe.go
@@ -1,0 +1,109 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Status is the probed health of one node, safe to send to hub clients (it
+// never carries the node token).
+type Status struct {
+	// Reachable reports whether the node answered its health endpoint.
+	Reachable bool `json:"reachable"`
+	// State is "ok" when reachable, otherwise a short failure label
+	// ("unreachable", "error <code>").
+	State string `json:"state"`
+	// LatencyMS is the health round-trip in milliseconds (reachable only).
+	LatencyMS int64 `json:"latency_ms"`
+	// Version/Agent/Capabilities are best-effort, reported by nodes whose
+	// healthz includes them (newer term-llm serves, when the probe carries a
+	// valid bearer token).
+	Version      string   `json:"version,omitempty"`
+	Agent        string   `json:"agent,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+	// Error holds the failure detail for unreachable nodes.
+	Error string `json:"error,omitempty"`
+}
+
+// Prober checks node health over HTTP. The client must not use an
+// environment proxy: probes carry node bearer tokens, and routing them
+// through an HTTP_PROXY would leak the tokens (callers pass the same
+// direct-dial transport the hub proxy uses).
+type Prober struct {
+	Client *http.Client
+}
+
+// NewProber returns a prober over the given transport with a bounded
+// per-probe timeout so one hung node cannot stall a dashboard refresh.
+func NewProber(transport http.RoundTripper) *Prober {
+	return &Prober{Client: &http.Client{Transport: transport, Timeout: 3 * time.Second}}
+}
+
+// healthzResponse mirrors the term-llm serve healthz payload. The extended
+// fields are only present when the serve trusts the request (see
+// cmd/serve_handlers.go handleHealth).
+type healthzResponse struct {
+	Status       string   `json:"status"`
+	Version      string   `json:"version"`
+	Agent        string   `json:"agent"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// Probe checks one node's {base}/healthz, measuring latency and decoding any
+// extended identity fields the node reports.
+func (p *Prober) Probe(ctx context.Context, n Node) Status {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, n.BaseURL()+"/healthz", nil)
+	if err != nil {
+		return Status{State: "unreachable", Error: err.Error()}
+	}
+	if n.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+n.Token)
+	}
+	start := time.Now()
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		return Status{State: "unreachable", Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	latency := time.Since(start).Milliseconds()
+	if resp.StatusCode != http.StatusOK {
+		return Status{
+			State:     fmt.Sprintf("error %d", resp.StatusCode),
+			LatencyMS: latency,
+			Error:     fmt.Sprintf("healthz returned %s", resp.Status),
+		}
+	}
+	st := Status{Reachable: true, State: "ok", LatencyMS: latency}
+	var body healthzResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err == nil {
+		st.Version = body.Version
+		st.Agent = body.Agent
+		st.Capabilities = body.Capabilities
+	}
+	return st
+}
+
+// ProbeAll probes nodes concurrently and returns statuses keyed by node ID.
+func (p *Prober) ProbeAll(ctx context.Context, nodes []Node) map[string]Status {
+	statuses := make(map[string]Status, len(nodes))
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	for _, n := range nodes {
+		wg.Add(1)
+		go func(n Node) {
+			defer wg.Done()
+			st := p.Probe(ctx, n)
+			mu.Lock()
+			statuses[n.ID] = st
+			mu.Unlock()
+		}(n)
+	}
+	wg.Wait()
+	return statuses
+}

--- a/internal/hub/probe.go
+++ b/internal/hub/probe.go
@@ -25,6 +25,9 @@ type Status struct {
 	Version      string   `json:"version,omitempty"`
 	Agent        string   `json:"agent,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
+	// Details carries small transport-specific facts such as reverse connection
+	// timestamps. It is diagnostic only and never carries credentials.
+	Details map[string]string `json:"details,omitempty"`
 	// Error holds the failure detail for unreachable nodes.
 	Error string `json:"error,omitempty"`
 }

--- a/internal/hub/probe_test.go
+++ b/internal/hub/probe_test.go
@@ -1,0 +1,83 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestProbeReadsIdentityFields(t *testing.T) {
+	var gotAuth string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/chat/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","agent":"jarvis","version":"1.2.3","capabilities":["web","jobs"]}`))
+	}))
+	defer backend.Close()
+
+	p := NewProber(http.DefaultTransport)
+	st := p.Probe(context.Background(), Node{ID: "n", URL: backend.URL, BasePath: "/chat", Token: "tkn"})
+
+	if gotAuth != "Bearer tkn" {
+		t.Errorf("probe Authorization = %q, want Bearer tkn", gotAuth)
+	}
+	if !st.Reachable || st.State != "ok" {
+		t.Fatalf("status = %+v, want reachable ok", st)
+	}
+	if st.Agent != "jarvis" || st.Version != "1.2.3" || len(st.Capabilities) != 2 {
+		t.Errorf("identity = %+v", st)
+	}
+	if st.LatencyMS < 0 {
+		t.Errorf("latency = %d", st.LatencyMS)
+	}
+}
+
+func TestProbeUnreachable(t *testing.T) {
+	p := NewProber(http.DefaultTransport)
+	// Reserved TEST-NET-1 address: connection should fail fast via context.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	st := p.Probe(ctx, Node{ID: "n", URL: "http://192.0.2.1:9", BasePath: ""})
+	if st.Reachable || st.State != "unreachable" || st.Error == "" {
+		t.Fatalf("status = %+v, want unreachable with error", st)
+	}
+}
+
+func TestProbeNon200(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer backend.Close()
+
+	p := NewProber(http.DefaultTransport)
+	st := p.Probe(context.Background(), Node{ID: "n", URL: backend.URL})
+	if st.Reachable || st.State != "error 401" {
+		t.Fatalf("status = %+v, want error 401", st)
+	}
+}
+
+func TestProbeAllKeysByID(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer backend.Close()
+
+	p := NewProber(http.DefaultTransport)
+	statuses := p.ProbeAll(context.Background(), []Node{
+		{ID: "a", URL: backend.URL},
+		{ID: "b", URL: "http://192.0.2.1:9"},
+	})
+	if !statuses["a"].Reachable {
+		t.Errorf("a = %+v, want reachable", statuses["a"])
+	}
+	if statuses["b"].Reachable {
+		t.Errorf("b = %+v, want unreachable", statuses["b"])
+	}
+}

--- a/internal/hub/resolver.go
+++ b/internal/hub/resolver.go
@@ -1,0 +1,81 @@
+package hub
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Resolver enumerates nodes from one backing source (static config file,
+// contain workspaces, the local UI-added store, ...). Implementations should
+// be cheap to call: the hub re-resolves on each dashboard/API request so
+// config edits and new workspaces are picked up without a restart.
+type Resolver interface {
+	// Source returns the stable label stamped onto nodes from this resolver.
+	Source() string
+	// Nodes returns the current nodes for this source.
+	Nodes() ([]Node, error)
+}
+
+// Registry combines several resolvers into one lookup surface. Resolver order
+// is precedence order: when two sources yield the same node ID, the earlier
+// resolver wins and the later duplicate is dropped.
+type Registry struct {
+	resolvers []Resolver
+}
+
+// NewRegistry builds a registry over the given resolvers in precedence order.
+func NewRegistry(resolvers ...Resolver) *Registry {
+	return &Registry{resolvers: resolvers}
+}
+
+// Nodes returns all known nodes sorted by name (then ID), deduplicated by ID
+// with earlier resolvers winning. A failing resolver does not hide the
+// others' nodes: its error is joined into the returned error while the
+// remaining sources still resolve, so one broken source never blanks the
+// dashboard.
+func (r *Registry) Nodes() ([]Node, error) {
+	var (
+		nodes []Node
+		errs  []error
+		seen  = map[string]bool{}
+	)
+	for _, res := range r.resolvers {
+		batch, err := res.Nodes()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolver %q: %w", res.Source(), err))
+			continue
+		}
+		for _, n := range batch {
+			if n.Source == "" {
+				n.Source = res.Source()
+			}
+			if n.ID == "" || seen[n.ID] {
+				continue
+			}
+			seen[n.ID] = true
+			nodes = append(nodes, n)
+		}
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Name != nodes[j].Name {
+			return nodes[i].Name < nodes[j].Name
+		}
+		return nodes[i].ID < nodes[j].ID
+	})
+	return nodes, errors.Join(errs...)
+}
+
+// Lookup resolves a single node by ID, honoring the same precedence as Nodes.
+func (r *Registry) Lookup(id string) (Node, bool) {
+	if id == "" {
+		return Node{}, false
+	}
+	nodes, _ := r.Nodes()
+	for _, n := range nodes {
+		if n.ID == id {
+			return n, true
+		}
+	}
+	return Node{}, false
+}

--- a/internal/hub/resolver_test.go
+++ b/internal/hub/resolver_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import (
+	"fmt"
+	"testing"
+)
+
+type fakeResolver struct {
+	source string
+	nodes  []Node
+	err    error
+}
+
+func (f fakeResolver) Source() string         { return f.source }
+func (f fakeResolver) Nodes() ([]Node, error) { return f.nodes, f.err }
+
+func TestRegistryDedupesByPrecedence(t *testing.T) {
+	r := NewRegistry(
+		fakeResolver{source: "config", nodes: []Node{
+			{ID: "shared", Name: "from-config", URL: "http://127.0.0.1:1"},
+			{ID: "cfg-only", Name: "cfg", URL: "http://127.0.0.1:2"},
+		}},
+		fakeResolver{source: "contain", nodes: []Node{
+			{ID: "shared", Name: "from-contain", URL: "http://127.0.0.1:3"},
+			{ID: "ws", Name: "ws", URL: "http://127.0.0.1:4"},
+		}},
+	)
+	nodes, err := r.Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("len(nodes) = %d, want 3 (duplicate dropped)", len(nodes))
+	}
+	got, ok := r.Lookup("shared")
+	if !ok || got.Name != "from-config" {
+		t.Fatalf("Lookup(shared) = %+v, %v; want the config node (earlier resolver wins)", got, ok)
+	}
+}
+
+func TestRegistrySoftFailsBrokenResolver(t *testing.T) {
+	r := NewRegistry(
+		fakeResolver{source: "config", err: fmt.Errorf("boom")},
+		fakeResolver{source: "contain", nodes: []Node{{ID: "ok", Name: "ok", URL: "http://127.0.0.1:1"}}},
+	)
+	nodes, err := r.Nodes()
+	if err == nil {
+		t.Fatal("expected the broken resolver's error to surface")
+	}
+	if len(nodes) != 1 || nodes[0].ID != "ok" {
+		t.Fatalf("nodes = %+v, want the surviving resolver's node", nodes)
+	}
+}
+
+func TestRegistryStampsSource(t *testing.T) {
+	r := NewRegistry(fakeResolver{source: "config", nodes: []Node{{ID: "a", Name: "a", URL: "http://127.0.0.1:1"}}})
+	nodes, err := r.Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodes[0].Source != "config" {
+		t.Fatalf("Source = %q, want stamped from resolver", nodes[0].Source)
+	}
+}
+
+func TestRegistrySortsByName(t *testing.T) {
+	r := NewRegistry(fakeResolver{source: "config", nodes: []Node{
+		{ID: "b", Name: "zeta", URL: "http://127.0.0.1:1"},
+		{ID: "a", Name: "alpha", URL: "http://127.0.0.1:2"},
+	}})
+	nodes, _ := r.Nodes()
+	if nodes[0].Name != "alpha" || nodes[1].Name != "zeta" {
+		t.Fatalf("nodes unsorted: %+v", nodes)
+	}
+}

--- a/internal/hub/static.go
+++ b/internal/hub/static.go
@@ -1,0 +1,67 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// configFile is the on-disk shape of a hub nodes config (--config). YAML is
+// the primary format; JSON parses too since YAML is a superset.
+//
+//	nodes:
+//	  - id: jarvis            # optional, derived from name when omitted
+//	    name: Jarvis          # optional, falls back to id
+//	    url: http://127.0.0.1:8081/chat
+//	    base_path: /chat      # optional, may also be embedded in url
+//	    token: secret         # optional web bearer token, injected server-side
+type configFile struct {
+	Nodes []Node `yaml:"nodes"`
+}
+
+// ParseConfig parses a static hub config document into normalized nodes.
+func ParseConfig(data []byte) ([]Node, error) {
+	var cfg configFile
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse hub config: %w", err)
+	}
+	seen := map[string]bool{}
+	nodes := make([]Node, 0, len(cfg.Nodes))
+	for i := range cfg.Nodes {
+		n := cfg.Nodes[i]
+		n.Source = SourceConfig
+		if err := n.Normalize(); err != nil {
+			return nil, fmt.Errorf("hub config node %d: %w", i+1, err)
+		}
+		if seen[n.ID] {
+			return nil, fmt.Errorf("hub config node %d: duplicate node id %q", i+1, n.ID)
+		}
+		seen[n.ID] = true
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
+}
+
+// StaticResolver resolves nodes from a config file on every call, so edits
+// are picked up without restarting the hub.
+type StaticResolver struct {
+	Path string
+}
+
+// NewStaticResolver returns a resolver over the given config file path.
+func NewStaticResolver(path string) *StaticResolver {
+	return &StaticResolver{Path: path}
+}
+
+// Source implements Resolver.
+func (s *StaticResolver) Source() string { return SourceConfig }
+
+// Nodes implements Resolver by re-reading and re-parsing the config file.
+func (s *StaticResolver) Nodes() ([]Node, error) {
+	data, err := os.ReadFile(s.Path)
+	if err != nil {
+		return nil, fmt.Errorf("read hub config: %w", err)
+	}
+	return ParseConfig(data)
+}

--- a/internal/hub/static.go
+++ b/internal/hub/static.go
@@ -16,6 +16,10 @@ import (
 //	    url: http://127.0.0.1:8081/chat
 //	    base_path: /chat      # optional, may also be embedded in url
 //	    token: secret         # optional web bearer token, injected server-side
+//	  - id: private
+//	    connection: reverse  # node dials /api/connect; no Hub-reachable url required
+//	    base_path: /chat
+//	    token: secret
 type configFile struct {
 	Nodes []Node `yaml:"nodes"`
 }

--- a/internal/hub/static_test.go
+++ b/internal/hub/static_test.go
@@ -1,0 +1,103 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfigYAML(t *testing.T) {
+	nodes, err := ParseConfig([]byte(`
+nodes:
+  - name: Jarvis
+    url: http://127.0.0.1:8081/chat
+    token: secret-1
+  - id: edge
+    url: https://edge.example.com
+    base_path: /ui
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("len(nodes) = %d, want 2", len(nodes))
+	}
+	if nodes[0].ID != "jarvis" || nodes[0].Name != "Jarvis" || nodes[0].Token != "secret-1" {
+		t.Errorf("node 0 = %+v", nodes[0])
+	}
+	if nodes[0].URL != "http://127.0.0.1:8081" || nodes[0].BasePath != "/chat" {
+		t.Errorf("node 0 url/base = %q %q", nodes[0].URL, nodes[0].BasePath)
+	}
+	if nodes[0].Source != SourceConfig {
+		t.Errorf("node 0 source = %q, want config", nodes[0].Source)
+	}
+	if nodes[1].ID != "edge" || nodes[1].BasePath != "/ui" || nodes[1].Token != "" {
+		t.Errorf("node 1 = %+v", nodes[1])
+	}
+}
+
+func TestParseConfigJSON(t *testing.T) {
+	nodes, err := ParseConfig([]byte(`{"nodes":[{"name":"alpha","url":"http://127.0.0.1:8082/chat","token":"tkn"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != "alpha" || nodes[0].Token != "tkn" {
+		t.Fatalf("nodes = %+v", nodes)
+	}
+}
+
+func TestParseConfigRejectsDuplicateIDs(t *testing.T) {
+	_, err := ParseConfig([]byte(`
+nodes:
+  - id: same
+    url: http://127.0.0.1:8081/chat
+  - id: same
+    url: http://127.0.0.1:8082/chat
+`))
+	if err == nil {
+		t.Fatal("duplicate ids parsed, want error")
+	}
+}
+
+func TestParseConfigRejectsBadURL(t *testing.T) {
+	if _, err := ParseConfig([]byte("nodes:\n  - id: x\n    url: not-a-url\n")); err == nil {
+		t.Fatal("bad url parsed, want error")
+	}
+}
+
+func TestStaticResolverReadsFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nodes.yaml")
+	if err := os.WriteFile(path, []byte("nodes:\n  - name: a\n    url: http://127.0.0.1:8081/chat\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := NewStaticResolver(path)
+	if r.Source() != SourceConfig {
+		t.Errorf("Source = %q", r.Source())
+	}
+	nodes, err := r.Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != "a" {
+		t.Fatalf("nodes = %+v", nodes)
+	}
+
+	// Edits are picked up without restart: the file is re-read per call.
+	if err := os.WriteFile(path, []byte("nodes:\n  - name: a\n    url: http://127.0.0.1:8081/chat\n  - name: b\n    url: http://127.0.0.1:8082/chat\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	nodes, err = r.Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("after edit len(nodes) = %d, want 2", len(nodes))
+	}
+}
+
+func TestStaticResolverMissingFile(t *testing.T) {
+	r := NewStaticResolver(filepath.Join(t.TempDir(), "missing.yaml"))
+	if _, err := r.Nodes(); err == nil {
+		t.Fatal("missing config file resolved, want error")
+	}
+}

--- a/internal/hub/store.go
+++ b/internal/hub/store.go
@@ -1,0 +1,130 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Store persists UI-added nodes in a local JSON file (0600 — it holds node
+// bearer tokens). It doubles as a Resolver so UI-added nodes resolve through
+// the same Registry as config/contain nodes.
+type Store struct {
+	mu   sync.Mutex
+	path string
+}
+
+// storeFile is the on-disk JSON shape.
+type storeFile struct {
+	Nodes []Node `json:"nodes"`
+}
+
+// NewStore returns a store backed by the given JSON file path. The file is
+// created lazily on first Add.
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+// Path returns the backing file path.
+func (s *Store) Path() string { return s.path }
+
+// Source implements Resolver.
+func (s *Store) Source() string { return SourceLocal }
+
+// Nodes implements Resolver. A missing file is an empty store, not an error.
+func (s *Store) Nodes() ([]Node, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.readLocked()
+}
+
+func (s *Store) readLocked() ([]Node, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read hub node store: %w", err)
+	}
+	var f storeFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse hub node store %s: %w", s.path, err)
+	}
+	for i := range f.Nodes {
+		f.Nodes[i].Source = SourceLocal
+	}
+	return f.Nodes, nil
+}
+
+func (s *Store) writeLocked(nodes []Node) error {
+	data, err := json.MarshalIndent(storeFile{Nodes: nodes}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode hub node store: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create hub node store dir: %w", err)
+	}
+	// 0600: the store holds node bearer tokens. Chmod first so an existing
+	// overly-permissive file is corrected as well as newly created files.
+	if err := os.Chmod(s.path, 0o600); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("secure hub node store permissions: %w", err)
+	}
+	if err := os.WriteFile(s.path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write hub node store: %w", err)
+	}
+	if err := os.Chmod(s.path, 0o600); err != nil {
+		return fmt.Errorf("secure hub node store permissions: %w", err)
+	}
+	return nil
+}
+
+// Add normalizes and persists a new node. The node ID must not collide with
+// another stored node.
+func (s *Store) Add(n Node) (Node, error) {
+	n.Source = SourceLocal
+	if err := n.Normalize(); err != nil {
+		return Node{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	nodes, err := s.readLocked()
+	if err != nil {
+		return Node{}, err
+	}
+	for _, existing := range nodes {
+		if existing.ID == n.ID {
+			return Node{}, fmt.Errorf("node id %q already exists", n.ID)
+		}
+	}
+	nodes = append(nodes, n)
+	if err := s.writeLocked(nodes); err != nil {
+		return Node{}, err
+	}
+	return n, nil
+}
+
+// Remove deletes a stored node by ID. Removing an unknown ID is an error so
+// the UI can surface a stale dashboard.
+func (s *Store) Remove(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	nodes, err := s.readLocked()
+	if err != nil {
+		return err
+	}
+	kept := nodes[:0]
+	found := false
+	for _, n := range nodes {
+		if n.ID == id {
+			found = true
+			continue
+		}
+		kept = append(kept, n)
+	}
+	if !found {
+		return fmt.Errorf("node %q not found in local store", id)
+	}
+	return s.writeLocked(kept)
+}

--- a/internal/hub/store_test.go
+++ b/internal/hub/store_test.go
@@ -1,0 +1,86 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestStoreAddListRemove(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub", "nodes.json")
+	s := NewStore(path)
+
+	nodes, err := s.Nodes()
+	if err != nil || len(nodes) != 0 {
+		t.Fatalf("empty store Nodes() = %v, %v", nodes, err)
+	}
+
+	added, err := s.Add(Node{Name: "Jarvis", URL: "http://127.0.0.1:8081/chat", Token: "tkn"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if added.ID != "jarvis" || added.Source != SourceLocal {
+		t.Fatalf("added = %+v", added)
+	}
+
+	// Token must persist (it is injected server-side on proxying) and the
+	// file must be private: it holds bearer tokens.
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != 0o600 {
+			t.Errorf("store file mode = %v, want 0600", fi.Mode().Perm())
+		}
+		// A rewrite tightens an existing permissive store file too.
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.Add(Node{ID: "other", URL: "http://127.0.0.1:9000/chat"}); err != nil {
+			t.Fatal(err)
+		}
+		fi, err = os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != 0o600 {
+			t.Errorf("store file mode after rewrite = %v, want 0600", fi.Mode().Perm())
+		}
+		if err := s.Remove("other"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A second store over the same path sees the persisted node.
+	nodes, err = NewStore(path).Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != "jarvis" || nodes[0].Token != "tkn" {
+		t.Fatalf("persisted nodes = %+v", nodes)
+	}
+
+	if _, err := s.Add(Node{ID: "jarvis", URL: "http://127.0.0.1:9000/chat"}); err == nil {
+		t.Fatal("duplicate id added, want error")
+	}
+
+	if err := s.Remove("jarvis"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Remove("jarvis"); err == nil {
+		t.Fatal("removing missing node succeeded, want error")
+	}
+	nodes, err = s.Nodes()
+	if err != nil || len(nodes) != 0 {
+		t.Fatalf("after remove Nodes() = %v, %v", nodes, err)
+	}
+}
+
+func TestStoreRejectsInvalidNode(t *testing.T) {
+	s := NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	if _, err := s.Add(Node{Name: "x", URL: "not-a-url"}); err == nil {
+		t.Fatal("invalid url added, want error")
+	}
+}

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -561,7 +561,7 @@ func TestStaticAssetsSupportEffortDropdown(t *testing.T) {
 	}
 	coreSrc := string(coreJS)
 	for _, want := range []string{
-		"selectedEffort: 'term_llm_selected_effort'",
+		"selectedEffort: scopedStorageKey('term_llm_selected_effort')",
 		"selectedEffort: localStorage.getItem(STORAGE_KEYS.selectedEffort) || ''",
 		"effortSelect: document.getElementById('effortSelect')",
 	} {
@@ -658,7 +658,7 @@ func TestStaticAssetsSupportIncrementalMarkdownStreaming(t *testing.T) {
 	coreSrc := string(coreJS)
 	for _, want := range []string{
 		"sidebarCollapsed: localStorage.getItem(STORAGE_KEYS.sidebarCollapsed) === '1'",
-		"sidebarCollapsed: 'term_llm_sidebar_collapsed'",
+		"sidebarCollapsed: scopedStorageKey('term_llm_sidebar_collapsed')",
 		"sidebarRailNewChatBtn: document.getElementById('sidebarRailNewChatBtn')",
 	} {
 		if !strings.Contains(coreSrc, want) {

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -9,6 +9,9 @@ app.markdownStreaming = window.TermLLMMarkdownStreaming || null;
 // into index.html as window.TERM_LLM_UI_PREFIX, defaults to '/ui'.
 const UI_PREFIX = (window.TERM_LLM_UI_PREFIX || '/ui');
 const UI_VERSION = String(window.TERM_LLM_UI_VERSION || '');
+const HUB_CONTEXT = window.TERM_LLM_HUB || null;
+const STORAGE_SCOPE = HUB_CONTEXT && HUB_CONTEXT.nodeId ? `:${HUB_CONTEXT.nodeId}` : '';
+const scopedStorageKey = (key) => STORAGE_SCOPE ? `${key}${STORAGE_SCOPE}` : key;
 const LEGACY_DRAFT_SESSION_ID = '__draft__';
 
 const parseSidebarSessionCategories = (raw) => {
@@ -27,19 +30,19 @@ const parseSidebarSessionCategories = (raw) => {
 };
 
 const STORAGE_KEYS = {
-  token: 'term_llm_token',
-  activeSession: 'term_llm_active_session',
-  draftSessionActive: 'term_llm_draft_session_active',
-  selectedModel: 'term_llm_selected_model',
-  selectedProvider: 'term_llm_selected_provider',
-  selectedEffort: 'term_llm_selected_effort',
-  sidebarCollapsed: 'term_llm_sidebar_collapsed',
-  diffSidebarWidth: 'term_llm_diff_sidebar_width',
-  showHiddenSessions: 'term_llm_show_hidden_sessions',
-  showWidgetsSidebar: 'term_llm_show_widgets_sidebar',
-  notificationsEnabled: 'term_llm_notifications_enabled',
-  lastNotifiedResponseId: 'term_llm_last_notified_response_id',
-  draftMessages: 'term_llm_draft_messages'
+  token: scopedStorageKey('term_llm_token'),
+  activeSession: scopedStorageKey('term_llm_active_session'),
+  draftSessionActive: scopedStorageKey('term_llm_draft_session_active'),
+  selectedModel: scopedStorageKey('term_llm_selected_model'),
+  selectedProvider: scopedStorageKey('term_llm_selected_provider'),
+  selectedEffort: scopedStorageKey('term_llm_selected_effort'),
+  sidebarCollapsed: scopedStorageKey('term_llm_sidebar_collapsed'),
+  diffSidebarWidth: scopedStorageKey('term_llm_diff_sidebar_width'),
+  showHiddenSessions: scopedStorageKey('term_llm_show_hidden_sessions'),
+  showWidgetsSidebar: scopedStorageKey('term_llm_show_widgets_sidebar'),
+  notificationsEnabled: scopedStorageKey('term_llm_notifications_enabled'),
+  lastNotifiedResponseId: scopedStorageKey('term_llm_last_notified_response_id'),
+  draftMessages: scopedStorageKey('term_llm_draft_messages')
 };
 
 const initialStoredActiveSessionId = localStorage.getItem(STORAGE_KEYS.activeSession) || '';
@@ -177,6 +180,7 @@ const elements = {
   sidebarBrandText: document.getElementById('sidebarBrandText'),
   newChatBtn: document.getElementById('newChatBtn'),
   widgetsOpenBtn: document.getElementById('widgetsOpenBtn'),
+  backToHubLink: document.getElementById('backToHubLink'),
   widgetsModal: document.getElementById('widgetsModal'),
   widgetsModalList: document.getElementById('widgetsModalList'),
   widgetsModalCloseBtn: document.getElementById('widgetsModalCloseBtn'),
@@ -1511,6 +1515,7 @@ Object.assign(app, {
   syncViewportShell,
   UI_PREFIX,
   UI_VERSION,
+  HUB_CONTEXT,
   maybeReloadForUIVersion,
   parseSidebarSessionCategories,
   isStandalone,

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -165,6 +165,23 @@ const closeWidgetsModal = () => {
   elements.widgetsModal?.classList.add('hidden');
 };
 
+// When this serve was opened through a term-llm Hub (the hub proxy injects
+// window.TERM_LLM_HUB, or the serve was started with --hub-url), reveal the
+// "Back to Hub" link below the Widgets entry so the hub stays one click away.
+const applyBackToHubLink = () => {
+  const link = elements.backToHubLink;
+  if (!link) return;
+  const hub = window.TERM_LLM_HUB;
+  const url = hub && typeof hub.url === 'string' ? hub.url : '';
+  if (!url) {
+    link.classList.add('hidden');
+    return;
+  }
+  link.href = url;
+  link.title = hub.nodeName ? `Back to Hub (this node: ${hub.nodeName})` : 'Back to Hub';
+  link.classList.remove('hidden');
+};
+
 if (elements.widgetsOpenBtn) elements.widgetsOpenBtn.addEventListener('click', openWidgetsModal);
 if (elements.widgetsModalCloseBtn) elements.widgetsModalCloseBtn.addEventListener('click', closeWidgetsModal);
 if (elements.widgetsModal) {
@@ -195,8 +212,11 @@ document.addEventListener('keydown', (event) => {
 });
 if (elements.sidebarSearchInput) elements.sidebarSearchInput.addEventListener('input', scheduleSidebarSearch);
 
+applyBackToHubLink();
+
 Object.assign(app, {
   renderWidgetSidebar,
+  applyBackToHubLink,
   scheduleSidebarSearch
 });
 })();

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -708,7 +708,8 @@
     }
 
     .new-chat-btn,
-    .widgets-sidebar-btn {
+    .widgets-sidebar-btn,
+    .back-to-hub-link {
       width: 100%;
       border-radius: 10px;
       border: 1px solid transparent;
@@ -735,12 +736,21 @@
     }
 
     .new-chat-btn:hover,
-    .widgets-sidebar-btn:hover {
+    .widgets-sidebar-btn:hover,
+    .back-to-hub-link:hover {
       background: var(--surface-2);
       border-color: var(--border);
     }
 
     .widgets-sidebar-btn.hidden {
+      display: none;
+    }
+
+    .back-to-hub-link {
+      text-decoration: none;
+    }
+
+    .back-to-hub-link.hidden {
       display: none;
     }
 

--- a/internal/serveui/static/app_sidebar_test.js
+++ b/internal/serveui/static/app_sidebar_test.js
@@ -110,7 +110,9 @@ function createHarness(options = {}) {
     widgetsModalList: new Element('div'),
     widgetsModalCloseBtn: new Element('button'),
     sidebarSearchInput: new Element('input'),
+    backToHubLink: new Element('a'),
   };
+  elements.backToHubLink.classList.add('back-to-hub-link', 'hidden');
   const state = {
     widgets: [],
     widgetsLoaded: false,
@@ -133,7 +135,7 @@ function createHarness(options = {}) {
   document.createElement = (tag) => new Element(tag);
   const navigator = { platform: options.platform || 'Linux x86_64' };
   const context = {
-    window: { TermLLMApp: app },
+    window: { TermLLMApp: app, TERM_LLM_HUB: options.hub },
     document,
     navigator,
     URLSearchParams,
@@ -205,6 +207,23 @@ async function run(name, fn) {
 
     assert(elements.widgetsOpenBtn.classList.contains('hidden'), 'widgets button is hidden');
     assertEqual(elements.widgetsModalList.children.length, 0, 'modal list is cleared');
+  });
+
+  await run('back to hub link stays hidden without hub context', () => {
+    const { elements } = createHarness();
+    assert(elements.backToHubLink.classList.contains('hidden'), 'link is hidden without TERM_LLM_HUB');
+  });
+
+  await run('back to hub link renders from hub context', () => {
+    const { elements } = createHarness({ hub: { url: '/', nodeId: 'jarvis', nodeName: 'Jarvis' } });
+    assert(!elements.backToHubLink.classList.contains('hidden'), 'link is visible with TERM_LLM_HUB');
+    assertEqual(elements.backToHubLink.href, '/', 'link points at the hub url');
+    assertEqual(elements.backToHubLink.title, 'Back to Hub (this node: Jarvis)', 'title names the node');
+  });
+
+  await run('back to hub link ignores hub context without a url', () => {
+    const { elements } = createHarness({ hub: { nodeId: 'jarvis' } });
+    assert(elements.backToHubLink.classList.contains('hidden'), 'link stays hidden when hub context has no url');
   });
 
   await run('sidebar search fetches server results', async () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -180,6 +180,13 @@
               </svg>
               <span>Widgets</span>
             </button>
+            <a class="back-to-hub-link hidden" id="backToHubLink" aria-label="Back to Hub">
+              <svg class="sidebar-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M19 12H5"></path>
+                <path d="M12 19l-7-7 7-7"></path>
+              </svg>
+              <span>Back to Hub</span>
+            </a>
           </div>
           <div class="sidebar-search-wrap">
             <input class="sidebar-search-input" id="sidebarSearchInput" type="search" placeholder="Search chats" autocomplete="off" aria-label="Search chats">

--- a/internal/tools/hub_delegate.go
+++ b/internal/tools/hub_delegate.go
@@ -1,0 +1,421 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+// hub_delegate / hub_check_delegation let an agent on one term-llm node run
+// work on another node via the Hub. The node authenticates to the Hub with
+// its OWN serve token (the Hub verifies it against the node's stored token);
+// it never sees other nodes' tokens. Configuration is in-process (see
+// hub_env.go): serve hands it over with ConfigureHubDelegation, or a
+// standalone process exports TERM_LLM_HUB_URL / TERM_LLM_HUB_NODE_ID /
+// TERM_LLM_HUB_TOKEN, which are captured at startup — the token is then
+// scrubbed from the environment so tool subprocesses never inherit it.
+
+const defaultHubDelegationPollInterval = 5 * time.Second
+
+type HubDelegateArgs struct {
+	TargetNode         string `json:"target_node"`
+	Prompt             string `json:"prompt"`
+	AgentName          string `json:"agent_name,omitempty"`
+	TimeoutSeconds     int    `json:"timeout_seconds,omitempty"`
+	Model              string `json:"model,omitempty"`
+	Cwd                string `json:"cwd,omitempty"`
+	Wait               bool   `json:"wait,omitempty"`
+	ParentDelegationID string `json:"parent_delegation_id,omitempty"`
+}
+
+type HubCheckDelegationArgs struct {
+	DelegationIDs       []string `json:"delegation_ids"`
+	Wait                *bool    `json:"wait,omitempty"`
+	PollIntervalSeconds int      `json:"poll_interval_seconds,omitempty"`
+}
+
+// HubDelegationResult is the tool-facing view of one delegation.
+type HubDelegationResult struct {
+	DelegationID string `json:"delegation_id"`
+	TargetNode   string `json:"target_node,omitempty"`
+	Status       string `json:"status"`
+	Response     string `json:"response,omitempty"`
+	Error        string `json:"error,omitempty"`
+	// RefreshError surfaces a hub-side polling problem (e.g. target node
+	// unreachable) without failing the whole check.
+	RefreshError string `json:"refresh_error,omitempty"`
+}
+
+func hubDelegationResultFrom(d hub.Delegation, refreshError string) HubDelegationResult {
+	return HubDelegationResult{
+		DelegationID: d.ID,
+		TargetNode:   d.TargetNode,
+		Status:       d.Status,
+		Response:     d.Response,
+		Error:        d.Error,
+		RefreshError: refreshError,
+	}
+}
+
+// hubDelegationClient talks to the Hub's delegation API as this node.
+type hubDelegationClient struct {
+	hubURL     string
+	nodeID     string
+	token      string
+	httpClient *http.Client
+}
+
+// newHubDelegationClient builds the client from the in-process hub config
+// (serve flags or TERM_LLM_HUB_* captured at startup) or returns a clean
+// error naming every missing piece by its environment variable.
+func newHubDelegationClient() (*hubDelegationClient, error) {
+	hubURL, nodeID, token := hubDelegationConfig()
+	var missing []string
+	if hubURL == "" {
+		missing = append(missing, "TERM_LLM_HUB_URL")
+	}
+	if nodeID == "" {
+		missing = append(missing, "TERM_LLM_HUB_NODE_ID")
+	}
+	if token == "" {
+		missing = append(missing, "TERM_LLM_HUB_TOKEN")
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("hub delegation is not configured on this node: missing %s (set automatically by 'serve web --hub-url --hub-node-id', or export them before the process starts)", strings.Join(missing, ", "))
+	}
+	return &hubDelegationClient{
+		hubURL: strings.TrimRight(hubURL, "/"),
+		nodeID: nodeID,
+		token:  token,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+			// No environment proxy: every request carries this node's serve
+			// token, and routing it through an HTTP_PROXY would leak it.
+			Transport: &http.Transport{Proxy: nil},
+		},
+	}, nil
+}
+
+func (c *hubDelegationClient) doJSON(ctx context.Context, method, path string, payload, out any) error {
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode hub request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.hubURL+path, body)
+	if err != nil {
+		return err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("X-Term-LLM-Node-ID", c.nodeID)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(data))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return fmt.Errorf("hub %s %s failed: HTTP %d: %s", method, path, resp.StatusCode, msg)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode hub response: %w", err)
+	}
+	return nil
+}
+
+// hubDelegationEnvelope is the hub's {"delegation": ..., "refresh_error":...}
+// response shape.
+type hubDelegationEnvelope struct {
+	Delegation   hub.Delegation `json:"delegation"`
+	RefreshError string         `json:"refresh_error"`
+}
+
+func (c *hubDelegationClient) createDelegation(ctx context.Context, a HubDelegateArgs) (hub.Delegation, error) {
+	payload := map[string]any{
+		"target_node": a.TargetNode,
+		"prompt":      a.Prompt,
+	}
+	if a.AgentName != "" {
+		payload["agent_name"] = a.AgentName
+	}
+	if a.TimeoutSeconds > 0 {
+		payload["timeout_seconds"] = a.TimeoutSeconds
+	}
+	if a.Model != "" {
+		payload["model"] = a.Model
+	}
+	if a.Cwd != "" {
+		payload["cwd"] = a.Cwd
+	}
+	if a.ParentDelegationID != "" {
+		payload["parent_delegation_id"] = a.ParentDelegationID
+	}
+	var envelope hubDelegationEnvelope
+	if err := c.doJSON(ctx, http.MethodPost, "/api/delegations", payload, &envelope); err != nil {
+		return hub.Delegation{}, err
+	}
+	if envelope.Delegation.ID == "" {
+		return hub.Delegation{}, fmt.Errorf("hub returned a delegation without an id")
+	}
+	return envelope.Delegation, nil
+}
+
+func (c *hubDelegationClient) getDelegation(ctx context.Context, id string) (hub.Delegation, string, error) {
+	var envelope hubDelegationEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, "/api/delegations/"+url.PathEscape(id), nil, &envelope); err != nil {
+		return hub.Delegation{}, "", err
+	}
+	return envelope.Delegation, envelope.RefreshError, nil
+}
+
+func (c *hubDelegationClient) waitForDelegation(ctx context.Context, id string, pollInterval time.Duration) (hub.Delegation, string, error) {
+	if pollInterval <= 0 {
+		pollInterval = defaultHubDelegationPollInterval
+	}
+	for {
+		d, refreshErr, err := c.getDelegation(ctx, id)
+		if err != nil {
+			return hub.Delegation{}, "", err
+		}
+		if hub.DelegationStatusTerminal(d.Status) {
+			return d, refreshErr, nil
+		}
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return d, refreshErr, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// resolveClient returns the injected test client or builds one from the
+// in-process config.
+func resolveHubDelegationClient(injected *hubDelegationClient) (*hubDelegationClient, error) {
+	if injected != nil {
+		return injected, nil
+	}
+	return newHubDelegationClient()
+}
+
+type HubDelegateTool struct {
+	client *hubDelegationClient
+	// pollIntervalOverride lets tests poll sub-second.
+	pollIntervalOverride time.Duration
+}
+
+func NewHubDelegateTool() *HubDelegateTool { return &HubDelegateTool{} }
+
+func NewHubDelegateToolWithClient(client *hubDelegationClient) *HubDelegateTool {
+	return &HubDelegateTool{client: client}
+}
+
+func (t *HubDelegateTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        HubDelegateToolName,
+		Description: `Delegate a task to another term-llm node via the Hub. The Hub runs the prompt as a background agent job on the target node and returns a delegation_id; use hub_check_delegation to retrieve the result (or set wait=true to block).`,
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"target_node": map[string]any{
+					"type":        "string",
+					"description": "Hub node id to delegate to",
+				},
+				"prompt": map[string]any{
+					"type":        "string",
+					"description": "The task for the remote agent to execute",
+				},
+				"agent_name": map[string]any{
+					"type":        "string",
+					"description": "Agent to run on the target node (default 'developer')",
+				},
+				"timeout_seconds": map[string]any{
+					"type":        "integer",
+					"description": "Job timeout on the target node in seconds (default 3600, max 3600)",
+					"minimum":     10,
+					"maximum":     3600,
+				},
+				"model": map[string]any{
+					"type":        "string",
+					"description": "Optional model override for the remote agent",
+				},
+				"cwd": map[string]any{
+					"type":        "string",
+					"description": "Optional working directory on the target node; must be inside the target's delegation workdir (default: the workdir itself)",
+				},
+				"wait": map[string]any{
+					"type":        "boolean",
+					"description": "When true, block until the delegation finishes and return the result. Defaults to false.",
+				},
+				"parent_delegation_id": map[string]any{
+					"type":        "string",
+					"description": "Set automatically when this task runs inside a delegated hub job; only provide it when chaining manually outside one (the hub verifies it either way)",
+				},
+			},
+			"required":             []string{"target_node", "prompt"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *HubDelegateTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var a HubDelegateArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+	}
+	if strings.TrimSpace(a.TargetNode) == "" {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "target_node is required")), nil
+	}
+	if strings.TrimSpace(a.Prompt) == "" {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "prompt is required")), nil
+	}
+	// A trusted delegation id on the context (set by the jobs-v2 runner from
+	// the hub-written job label) always wins over the model-provided argument:
+	// chained delegations must count against depth/loop limits.
+	if id := HubDelegationIDFromContext(ctx); id != "" {
+		a.ParentDelegationID = id
+	}
+	client, err := resolveHubDelegationClient(t.client)
+	if err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+	}
+	d, err := client.createDelegation(ctx, a)
+	if err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+	}
+	refreshErr := ""
+	if a.Wait {
+		d, refreshErr, err = client.waitForDelegation(ctx, d.ID, t.pollIntervalOverride)
+		if err != nil {
+			return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, fmt.Sprintf("delegation %s created but waiting failed: %v", d.ID, err))), nil
+		}
+	}
+	data, _ := json.Marshal(hubDelegationResultFrom(d, refreshErr))
+	return llm.TextOutput(string(data)), nil
+}
+
+func (t *HubDelegateTool) Preview(args json.RawMessage) string {
+	var a HubDelegateArgs
+	_ = json.Unmarshal(args, &a)
+	if a.TargetNode == "" {
+		return "hub delegate"
+	}
+	return fmt.Sprintf("delegate to %s", a.TargetNode)
+}
+
+type HubCheckDelegationTool struct {
+	client *hubDelegationClient
+	// pollIntervalOverride lets tests poll sub-second; poll_interval_seconds
+	// has a 1s floor.
+	pollIntervalOverride time.Duration
+}
+
+func NewHubCheckDelegationTool() *HubCheckDelegationTool { return &HubCheckDelegationTool{} }
+
+func NewHubCheckDelegationToolWithClient(client *hubDelegationClient) *HubCheckDelegationTool {
+	return &HubCheckDelegationTool{client: client}
+}
+
+func (t *HubCheckDelegationTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        HubCheckDelegationToolName,
+		Description: `Check (and by default wait for) hub delegations started with hub_delegate, returning their status and final responses.`,
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"delegation_ids": map[string]any{
+					"type":        "array",
+					"description": "Delegation IDs returned by hub_delegate",
+					"items":       map[string]any{"type": "string"},
+					"minItems":    1,
+				},
+				"wait": map[string]any{
+					"type":        "boolean",
+					"description": "Wait for the delegations to finish (default true). When false, return the current status immediately.",
+				},
+				"poll_interval_seconds": map[string]any{
+					"type":        "integer",
+					"description": "How often to poll the hub while waiting (default 5)",
+					"minimum":     1,
+				},
+			},
+			"required":             []string{"delegation_ids"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *HubCheckDelegationTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	var a HubCheckDelegationArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+	}
+	if len(a.DelegationIDs) == 0 {
+		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "delegation_ids is required")), nil
+	}
+	client, err := resolveHubDelegationClient(t.client)
+	if err != nil {
+		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+	}
+	wait := a.Wait == nil || *a.Wait
+	pollInterval := time.Duration(a.PollIntervalSeconds) * time.Second
+	if t.pollIntervalOverride > 0 {
+		pollInterval = t.pollIntervalOverride
+	}
+	results := make([]HubDelegationResult, 0, len(a.DelegationIDs))
+	for _, id := range a.DelegationIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		var (
+			d          hub.Delegation
+			refreshErr string
+			err        error
+		)
+		if wait {
+			d, refreshErr, err = client.waitForDelegation(ctx, id, pollInterval)
+		} else {
+			d, refreshErr, err = client.getDelegation(ctx, id)
+		}
+		if err != nil {
+			results = append(results, HubDelegationResult{DelegationID: id, Status: "unknown", Error: err.Error()})
+			continue
+		}
+		results = append(results, hubDelegationResultFrom(d, refreshErr))
+	}
+	data, _ := json.Marshal(map[string]any{"delegations": results})
+	return llm.TextOutput(string(data)), nil
+}
+
+func (t *HubCheckDelegationTool) Preview(args json.RawMessage) string {
+	var a HubCheckDelegationArgs
+	_ = json.Unmarshal(args, &a)
+	return fmt.Sprintf("check %d delegation(s)", len(a.DelegationIDs))
+}

--- a/internal/tools/hub_delegate_test.go
+++ b/internal/tools/hub_delegate_test.go
@@ -1,0 +1,301 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+)
+
+// fakeHub fakes the Hub delegation API the node tools talk to.
+type fakeHub struct {
+	mu         sync.Mutex
+	server     *httptest.Server
+	lastAuth   string
+	lastNodeID string
+	lastCreate map[string]any
+	// statusSequence is returned by successive GETs (last entry repeats).
+	statusSequence []string
+	getCalls       int
+	response       string
+}
+
+func newFakeHub(t *testing.T) *fakeHub {
+	t.Helper()
+	f := &fakeHub{statusSequence: []string{"running"}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/delegations", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.lastAuth = r.Header.Get("Authorization")
+		f.lastNodeID = r.Header.Get("X-Term-LLM-Node-ID")
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.lastCreate = body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"delegation": hub.Delegation{
+			ID: "dlg_test", OriginNode: "alpha", TargetNode: "beta", Status: hub.DelegationStatusRunning,
+		}})
+	})
+	mux.HandleFunc("/api/delegations/", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.lastAuth = r.Header.Get("Authorization")
+		f.lastNodeID = r.Header.Get("X-Term-LLM-Node-ID")
+		idx := f.getCalls
+		if idx >= len(f.statusSequence) {
+			idx = len(f.statusSequence) - 1
+		}
+		f.getCalls++
+		status := f.statusSequence[idx]
+		d := hub.Delegation{ID: "dlg_test", OriginNode: "alpha", TargetNode: "beta", Status: status}
+		if hub.DelegationStatusTerminal(status) {
+			d.Response = f.response
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"delegation": d})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeHub) client() *hubDelegationClient {
+	return &hubDelegationClient{
+		hubURL:     f.server.URL,
+		nodeID:     "alpha",
+		token:      "alpha-token",
+		httpClient: f.server.Client(),
+	}
+}
+
+func TestHubDelegateMissingConfig(t *testing.T) {
+	t.Cleanup(resetHubDelegationForTest())
+
+	out, err := NewHubDelegateTool().Execute(context.Background(),
+		json.RawMessage(`{"target_node":"beta","prompt":"x"}`))
+	if err != nil {
+		t.Fatalf("Execute returned hard error: %v", err)
+	}
+	text := out.Content
+	for _, needle := range []string{"TERM_LLM_HUB_URL", "TERM_LLM_HUB_NODE_ID", "TERM_LLM_HUB_TOKEN", "not configured"} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("error should name %q: %s", needle, text)
+		}
+	}
+}
+
+func TestHubDelegateClientFromEnvCaptureScrubsToken(t *testing.T) {
+	t.Cleanup(resetHubDelegationForTest())
+	t.Setenv("TERM_LLM_HUB_URL", "http://127.0.0.1:8090/")
+	t.Setenv("TERM_LLM_HUB_NODE_ID", "alpha")
+	t.Setenv("TERM_LLM_HUB_TOKEN", "tkn-secret")
+
+	captureHubDelegationEnv()
+
+	c, err := newHubDelegationClient()
+	if err != nil {
+		t.Fatalf("newHubDelegationClient: %v", err)
+	}
+	if c.hubURL != "http://127.0.0.1:8090" || c.nodeID != "alpha" || c.token != "tkn-secret" {
+		t.Fatalf("client = %+v", c)
+	}
+	// The credential must be gone from the process environment: every
+	// shell/custom/widget/MCP subprocess inherits os.Environ().
+	if got := os.Getenv("TERM_LLM_HUB_TOKEN"); got != "" {
+		t.Fatalf("TERM_LLM_HUB_TOKEN still set after capture: %q", got)
+	}
+	for _, e := range os.Environ() {
+		if strings.Contains(e, "tkn-secret") {
+			t.Fatalf("token leaked into process environment: %s", e)
+		}
+	}
+}
+
+func TestConfigureHubDelegationStaysOutOfEnv(t *testing.T) {
+	t.Cleanup(resetHubDelegationForTest())
+
+	ConfigureHubDelegation("http://127.0.0.1:9999", "alpha", "flag-secret")
+	c, err := newHubDelegationClient()
+	if err != nil {
+		t.Fatalf("newHubDelegationClient: %v", err)
+	}
+	if c.token != "flag-secret" {
+		t.Fatalf("token = %q", c.token)
+	}
+	for _, e := range os.Environ() {
+		if strings.Contains(e, "flag-secret") {
+			t.Fatalf("flag-provided token leaked into process environment: %s", e)
+		}
+	}
+	// Flag-provided config is re-derived on reload; no env handover needed.
+	if env := HubDelegationEnviron(); env != nil {
+		t.Fatalf("HubDelegationEnviron = %v, want nil for flag-provided token", env)
+	}
+}
+
+func TestHubDelegationEnvironForReload(t *testing.T) {
+	t.Cleanup(resetHubDelegationForTest())
+	t.Setenv("TERM_LLM_HUB_URL", "http://127.0.0.1:8090")
+	t.Setenv("TERM_LLM_HUB_NODE_ID", "alpha")
+	t.Setenv("TERM_LLM_HUB_TOKEN", "env-secret")
+	captureHubDelegationEnv()
+
+	env := strings.Join(HubDelegationEnviron(), "\n")
+	for _, needle := range []string{"TERM_LLM_HUB_TOKEN=env-secret", "TERM_LLM_HUB_URL=", "TERM_LLM_HUB_NODE_ID=alpha"} {
+		if !strings.Contains(env, needle) {
+			t.Fatalf("HubDelegationEnviron missing %q: %q", needle, env)
+		}
+	}
+}
+
+func TestHubDelegateCreate(t *testing.T) {
+	f := newFakeHub(t)
+	tool := NewHubDelegateToolWithClient(f.client())
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(
+		`{"target_node":"beta","prompt":"do it","agent_name":"developer","timeout_seconds":120,"cwd":"/work/sub","parent_delegation_id":"dlg_parent"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result HubDelegationResult
+	if err := json.Unmarshal([]byte(out.Content), &result); err != nil {
+		t.Fatalf("decode output %q: %v", out.Content, err)
+	}
+	if result.DelegationID != "dlg_test" || result.Status != hub.DelegationStatusRunning {
+		t.Fatalf("result = %+v", result)
+	}
+	if f.lastAuth != "Bearer alpha-token" || f.lastNodeID != "alpha" {
+		t.Fatalf("hub saw auth %q node %q", f.lastAuth, f.lastNodeID)
+	}
+	for key, want := range map[string]any{
+		"target_node":          "beta",
+		"prompt":               "do it",
+		"agent_name":           "developer",
+		"timeout_seconds":      float64(120),
+		"cwd":                  "/work/sub",
+		"parent_delegation_id": "dlg_parent",
+	} {
+		if got := f.lastCreate[key]; got != want {
+			t.Fatalf("create payload %s = %v, want %v", key, got, want)
+		}
+	}
+}
+
+func TestHubDelegateParentFromContext(t *testing.T) {
+	f := newFakeHub(t)
+	tool := NewHubDelegateToolWithClient(f.client())
+
+	// Inside a delegated job the runner stamps the context; the tool must
+	// chain from it even when the model omits parent_delegation_id.
+	ctx := WithHubDelegationID(context.Background(), "dlg_trusted")
+	if _, err := tool.Execute(ctx, json.RawMessage(`{"target_node":"beta","prompt":"x"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := f.lastCreate["parent_delegation_id"]; got != "dlg_trusted" {
+		t.Fatalf("parent_delegation_id = %v, want dlg_trusted", got)
+	}
+
+	// A model-provided parent id must not override the trusted context.
+	if _, err := tool.Execute(ctx, json.RawMessage(`{"target_node":"beta","prompt":"x","parent_delegation_id":"dlg_spoofed"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := f.lastCreate["parent_delegation_id"]; got != "dlg_trusted" {
+		t.Fatalf("parent_delegation_id = %v, want dlg_trusted (context wins)", got)
+	}
+}
+
+func TestHubDelegateWait(t *testing.T) {
+	f := newFakeHub(t)
+	f.statusSequence = []string{"running", "running", "succeeded"}
+	f.response = "remote result"
+	tool := NewHubDelegateToolWithClient(f.client())
+	tool.pollIntervalOverride = time.Millisecond
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(
+		`{"target_node":"beta","prompt":"do it","wait":true}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result HubDelegationResult
+	_ = json.Unmarshal([]byte(out.Content), &result)
+	if result.Status != hub.DelegationStatusSucceeded || result.Response != "remote result" {
+		t.Fatalf("result = %+v", result)
+	}
+	if f.getCalls < 3 {
+		t.Fatalf("getCalls = %d, want >= 3", f.getCalls)
+	}
+}
+
+func TestHubDelegateInvalidParams(t *testing.T) {
+	tool := NewHubDelegateToolWithClient(newFakeHub(t).client())
+	out, _ := tool.Execute(context.Background(), json.RawMessage(`{"prompt":"x"}`))
+	if !strings.Contains(out.Content, "target_node is required") {
+		t.Fatalf("output = %s", out.Content)
+	}
+	out, _ = tool.Execute(context.Background(), json.RawMessage(`{"target_node":"beta"}`))
+	if !strings.Contains(out.Content, "prompt is required") {
+		t.Fatalf("output = %s", out.Content)
+	}
+}
+
+func TestHubCheckDelegationWaits(t *testing.T) {
+	f := newFakeHub(t)
+	f.statusSequence = []string{"running", "succeeded"}
+	f.response = "done"
+	tool := NewHubCheckDelegationToolWithClient(f.client())
+	tool.pollIntervalOverride = time.Millisecond
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"delegation_ids":["dlg_test"]}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var resp struct {
+		Delegations []HubDelegationResult `json:"delegations"`
+	}
+	if err := json.Unmarshal([]byte(out.Content), &resp); err != nil {
+		t.Fatalf("decode %q: %v", out.Content, err)
+	}
+	if len(resp.Delegations) != 1 || resp.Delegations[0].Status != hub.DelegationStatusSucceeded || resp.Delegations[0].Response != "done" {
+		t.Fatalf("resp = %+v", resp)
+	}
+}
+
+func TestHubCheckDelegationNoWait(t *testing.T) {
+	f := newFakeHub(t)
+	tool := NewHubCheckDelegationToolWithClient(f.client())
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"delegation_ids":["dlg_test"],"wait":false}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var resp struct {
+		Delegations []HubDelegationResult `json:"delegations"`
+	}
+	_ = json.Unmarshal([]byte(out.Content), &resp)
+	if len(resp.Delegations) != 1 || resp.Delegations[0].Status != hub.DelegationStatusRunning {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if f.getCalls != 1 {
+		t.Fatalf("getCalls = %d, want 1", f.getCalls)
+	}
+}
+
+func TestHubDelegationToolsRegistered(t *testing.T) {
+	if !ValidToolName(HubDelegateToolName) || !ValidToolName(HubCheckDelegationToolName) {
+		t.Fatalf("hub delegation tools should be valid tool names")
+	}
+	if GetToolKind(HubDelegateToolName) != KindAgent || GetToolKind(HubCheckDelegationToolName) != KindAgent {
+		t.Fatalf("hub delegation tools should be KindAgent")
+	}
+}

--- a/internal/tools/hub_env.go
+++ b/internal/tools/hub_env.go
@@ -1,0 +1,135 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Hub delegation credentials live in process memory, NOT in the process
+// environment: every external subprocess this process spawns (shell tool,
+// custom tools, widgets, MCP servers, program jobs) inherits os.Environ(), so
+// a hub token in env would leak to model-controlled commands. serve hands the
+// config over in-process with ConfigureHubDelegation; standalone processes
+// may export TERM_LLM_HUB_* instead, which init() captures and then scrubs
+// the token from the environment before any tool can spawn a subprocess.
+
+const (
+	hubEnvURL    = "TERM_LLM_HUB_URL"
+	hubEnvNodeID = "TERM_LLM_HUB_NODE_ID"
+	hubEnvToken  = "TERM_LLM_HUB_TOKEN"
+)
+
+var hubDelegationCfg struct {
+	sync.Mutex
+	url, nodeID, token string
+	// tokenFromEnv records that the token arrived via the environment, so a
+	// reload re-exec of this same binary can hand it to the next generation
+	// (HubDelegationEnviron); a flag-provided token is re-derived from flags.
+	tokenFromEnv bool
+}
+
+func init() { captureHubDelegationEnv() }
+
+// captureHubDelegationEnv fills hub delegation config gaps from TERM_LLM_HUB_*
+// and removes the token from the process environment so subprocesses never
+// inherit it. Runs at process start; safe to call again (tests).
+func captureHubDelegationEnv() {
+	hubDelegationCfg.Lock()
+	defer hubDelegationCfg.Unlock()
+	if v := strings.TrimSpace(os.Getenv(hubEnvURL)); v != "" && hubDelegationCfg.url == "" {
+		hubDelegationCfg.url = v
+	}
+	if v := strings.TrimSpace(os.Getenv(hubEnvNodeID)); v != "" && hubDelegationCfg.nodeID == "" {
+		hubDelegationCfg.nodeID = v
+	}
+	if v := strings.TrimSpace(os.Getenv(hubEnvToken)); v != "" {
+		if hubDelegationCfg.token == "" {
+			hubDelegationCfg.token = v
+			hubDelegationCfg.tokenFromEnv = true
+		}
+		_ = os.Unsetenv(hubEnvToken)
+	}
+}
+
+// ConfigureHubDelegation fills hub delegation config gaps in-process (explicit
+// TERM_LLM_HUB_* values captured at startup win, matching the old env
+// precedence) without ever writing the token into the process environment.
+func ConfigureHubDelegation(url, nodeID, token string) {
+	hubDelegationCfg.Lock()
+	defer hubDelegationCfg.Unlock()
+	if v := strings.TrimSpace(url); v != "" && hubDelegationCfg.url == "" {
+		hubDelegationCfg.url = v
+	}
+	if v := strings.TrimSpace(nodeID); v != "" && hubDelegationCfg.nodeID == "" {
+		hubDelegationCfg.nodeID = v
+	}
+	if v := strings.TrimSpace(token); v != "" && hubDelegationCfg.token == "" {
+		hubDelegationCfg.token = v
+	}
+}
+
+// hubDelegationConfig returns the current in-process hub delegation config.
+func hubDelegationConfig() (url, nodeID, token string) {
+	hubDelegationCfg.Lock()
+	defer hubDelegationCfg.Unlock()
+	return hubDelegationCfg.url, hubDelegationCfg.nodeID, hubDelegationCfg.token
+}
+
+// HubDelegationEnviron returns the TERM_LLM_HUB_* entries a reload re-exec of
+// this SAME binary needs to keep hub delegation working when the token
+// originally arrived via the environment (init scrubbed it, so os.Environ()
+// no longer carries it). It returns nil when the token came from flags or
+// in-process config. Never pass the result to any other subprocess.
+func HubDelegationEnviron() []string {
+	hubDelegationCfg.Lock()
+	defer hubDelegationCfg.Unlock()
+	if !hubDelegationCfg.tokenFromEnv || hubDelegationCfg.token == "" {
+		return nil
+	}
+	env := []string{hubEnvToken + "=" + hubDelegationCfg.token}
+	if hubDelegationCfg.url != "" {
+		env = append(env, hubEnvURL+"="+hubDelegationCfg.url)
+	}
+	if hubDelegationCfg.nodeID != "" {
+		env = append(env, hubEnvNodeID+"="+hubDelegationCfg.nodeID)
+	}
+	return env
+}
+
+// resetHubDelegationForTest clears the in-process config and returns a
+// restore function.
+func resetHubDelegationForTest() func() {
+	hubDelegationCfg.Lock()
+	prevURL, prevNode, prevToken, prevFromEnv := hubDelegationCfg.url, hubDelegationCfg.nodeID, hubDelegationCfg.token, hubDelegationCfg.tokenFromEnv
+	hubDelegationCfg.url, hubDelegationCfg.nodeID, hubDelegationCfg.token, hubDelegationCfg.tokenFromEnv = "", "", "", false
+	hubDelegationCfg.Unlock()
+	return func() {
+		hubDelegationCfg.Lock()
+		hubDelegationCfg.url, hubDelegationCfg.nodeID, hubDelegationCfg.token, hubDelegationCfg.tokenFromEnv = prevURL, prevNode, prevToken, prevFromEnv
+		hubDelegationCfg.Unlock()
+	}
+}
+
+// hubDelegationCtxKey carries the id of the hub delegation a tool execution
+// belongs to. The jobs-v2 runner sets it from the job's hub_delegation label,
+// so chaining is anchored in hub-written provenance rather than in a
+// model-controlled argument.
+type hubDelegationCtxKey struct{}
+
+// WithHubDelegationID marks ctx as executing inside the given hub delegation.
+func WithHubDelegationID(ctx context.Context, id string) context.Context {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, hubDelegationCtxKey{}, id)
+}
+
+// HubDelegationIDFromContext returns the delegation id ctx executes under, or
+// "" when this execution is not part of a hub delegation.
+func HubDelegationIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(hubDelegationCtxKey{}).(string)
+	return id
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -157,6 +157,10 @@ func (r *LocalToolRegistry) registerTool(specName string) error {
 		tool = NewQueueAgentTool()
 	case WaitForJobsToolName:
 		tool = NewWaitForJobsTool()
+	case HubDelegateToolName:
+		tool = NewHubDelegateTool()
+	case HubCheckDelegationToolName:
+		tool = NewHubCheckDelegationTool()
 	case RunAgentScriptToolName:
 		tool = NewRunAgentScriptTool(r.config, r.limits)
 	case InitiateHandoverToolName:

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -129,6 +129,9 @@ const (
 	WaitForJobsToolName      = "wait_for_jobs"
 	RunAgentScriptToolName   = "run_agent_script"
 	InitiateHandoverToolName = "initiate_handover"
+
+	HubDelegateToolName        = "hub_delegate"
+	HubCheckDelegationToolName = "hub_check_delegation"
 )
 
 // AllToolNames returns all standard tool spec names that can be registered directly.
@@ -151,28 +154,32 @@ func AllToolNames() []string {
 		WaitForJobsToolName,
 		RunAgentScriptToolName,
 		InitiateHandoverToolName,
+		HubDelegateToolName,
+		HubCheckDelegationToolName,
 	}
 }
 
 // validToolNames is a set of valid tool spec names for fast lookup.
 // Note: activate_skill is excluded as it requires a skills registry and is registered separately.
 var validToolNames = map[string]bool{
-	ReadFileToolName:         true,
-	WriteFileToolName:        true,
-	EditFileToolName:         true,
-	UnifiedDiffToolName:      true,
-	ShellToolName:            true,
-	GrepToolName:             true,
-	GlobToolName:             true,
-	ViewImageToolName:        true,
-	ShowImageToolName:        true,
-	ImageGenerateToolName:    true,
-	AskUserToolName:          true,
-	SpawnAgentToolName:       true,
-	QueueAgentToolName:       true,
-	WaitForJobsToolName:      true,
-	RunAgentScriptToolName:   true,
-	InitiateHandoverToolName: true,
+	ReadFileToolName:           true,
+	WriteFileToolName:          true,
+	EditFileToolName:           true,
+	UnifiedDiffToolName:        true,
+	ShellToolName:              true,
+	GrepToolName:               true,
+	GlobToolName:               true,
+	ViewImageToolName:          true,
+	ShowImageToolName:          true,
+	ImageGenerateToolName:      true,
+	AskUserToolName:            true,
+	SpawnAgentToolName:         true,
+	QueueAgentToolName:         true,
+	WaitForJobsToolName:        true,
+	RunAgentScriptToolName:     true,
+	InitiateHandoverToolName:   true,
+	HubDelegateToolName:        true,
+	HubCheckDelegationToolName: true,
 }
 
 // ValidToolName checks if a name is a valid tool spec name.
@@ -195,7 +202,8 @@ func GetToolKind(specName string) ToolKind {
 		return KindImage
 	case AskUserToolName:
 		return KindInteractive
-	case SpawnAgentToolName, QueueAgentToolName, WaitForJobsToolName, InitiateHandoverToolName:
+	case SpawnAgentToolName, QueueAgentToolName, WaitForJobsToolName, InitiateHandoverToolName,
+		HubDelegateToolName, HubCheckDelegationToolName:
 		return KindAgent
 	case RunAgentScriptToolName:
 		return KindExecute


### PR DESCRIPTION
## What

Adds term-llm Hub as a single dashboard/proxy over multiple term-llm web nodes, plus opt-in cross-node delegation.

Hub v1 includes:

- `term-llm serve hub`
- Hub bearer auth (`--auth bearer`, `--token`, `TERM_LLM_HUB_TOKEN`) with `--auth none` restricted to loopback
- static/config, local-store, and contain node discovery
- `/node/<id>/...` node UI proxy with server-side bearer-token injection
- Back to Hub UI context injection
- node health/status API with dashboard diagnostics
- direct and reverse/private node connection modes
- cross-node delegation APIs
- `hub_delegate` and `hub_check_delegation` tools
- jobs-v2 delegated run creation/trigger/status/cancel
- delegation reconnect/recovery hardening for partial job/trigger failures
- delegation ledger/audit trail
- target-node sidebar sessions titled like `Delegation from jarvis-home`
- Hub Delegations dashboard panel with returned artifact previews

## Safety model

Delegation is default-off and opt-in per node:

```yaml
delegation:
  enabled: true
```

Without `delegation.enabled: true`, a node can neither originate nor accept delegated work.

Accepting delegated work still requires a target workdir:

```yaml
delegation:
  enabled: true
  accept_from: [jarvis-home]
  workdir: /work
```

Existing narrowing knobs remain available:

- `to`
- `accept_from`
- `allowed_agents`
- `allowed_models`
- `max_in_flight`

But the user-facing safety story is the simple switch: delegation participation is off until the operator enables it.

## Hub auth

Hub now has first-party bearer auth:

```bash
TERM_LLM_HUB_TOKEN=... term-llm serve hub --auth bearer
```

- `--auth bearer` is the default.
- `--auth none` is allowed only on loopback.
- Public/non-loopback binds require Hub auth.
- `/api/connect` remains node-authenticated so reverse nodes can connect with their node token.
- Node-originated delegation calls keep using node auth (`X-Term-LLM-Node-ID` + node bearer token), not the operator Hub token.

This keeps Hub auth simple: one operator token now; no users/RBAC/OAuth in this PR.

## Reverse/private nodes

Adds reverse connection mode for private nodes where the Hub has a public address but cannot reach the node directly.

Hub config:

```yaml
nodes:
  - id: artist
    name: Artist
    connection: reverse
    base_path: /chat
    token: <artist-token>
    delegation:
      enabled: true
      accept_from: [jarvis-home]
      workdir: /work
```

Private node:

```bash
term-llm serve web jobs \
  --base-path /chat \
  --token "$ARTIST_TOKEN" \
  --hub-url https://hub.example.com \
  --hub-node-id artist \
  --hub-connect reverse
```

The node dials `GET /api/connect` as a websocket using its node id + bearer token. Hub requests then use the same node record and policy path as direct nodes; only the transport changes. Both ends send websocket pings every 20s, require pong/read activity within 60s, and use write deadlines so silent half-open sockets are detected and the node reconnects instead of sitting stale.

Reverse transport now streams responses in bounded chunks over the websocket, with cancellation propagation. Direct-node streams still use the normal reverse proxy path.

This keeps the architecture simple:

- direct nodes: Hub → node HTTP
- reverse nodes: node → Hub websocket, Hub sends request frames over it
- same `/node/<id>/...` proxy
- same delegation APIs
- same token injection/redaction model
- no offline queue or second delegation API

## Dashboard diagnostics

Node cards now surface token-safe diagnostics for common bad setups:

- reverse node disconnected
- missing node bearer token
- delegation enabled without a workdir
- delegation accept policy present but no jobs capability detected
- obvious origin/target policy mismatches

The point is to show the rake before someone steps on it.

## Delegation recovery hardening

Partial target failures are now more recoverable:

- delegation records are persisted before target job creation/trigger where possible
- known jobs without known runs stay refreshable instead of becoming dead terminal errors
- trigger-response-loss can recover by polling target runs
- cancel refreshes/reuses recovered run IDs
- stale transport errors clear when a later refresh finds the real run state

Still no offline queue. Offline nodes fail fast; reconnect lets subsequent refresh/cancel paths recover known work.

## Node-anywhere docs

Docs cover both modes:

- direct nodes can run on the same machine, Docker/contain, VM, cloud runner, remote server, private network/tunnel
- reverse nodes can run behind NAT/firewalls with no inbound port, as long as they can dial the Hub

## Demo

Standalone isolated demo video, using two clean node homes/session stores rather than Sam's real Jarvis setup:

- Jarvis Home asks Artist to draw a picture
- Hub dashboard shows delegated work
- Artist sidebar shows `Delegation from jarvis-home`
- back to Hub after success
- original Jarvis Home session shows the returned image

Video artifact:

`/chat/files/term-llm-hub-standalone-demo.mp4`

## Tests

```text
go test ./cmd ./internal/hub
go test ./...
go build ./...
```

Live smoke:

```text
Hub bearer auth rejects unauthenticated /api/nodes
Hub configured with connection: reverse
Private node started with --hub-connect reverse
GET /api/nodes shows connection=reverse and connected status
GET /node/private/healthz succeeds through the reverse websocket
```
