### PR TITLE
fix: serve shutdown timeout is bypassed by unbounded waits in jobs/response-run/widget teardown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1118,6 +1118,38 @@ func (s *serveServer) contextWithShutdown(ctx context.Context) (context.Context,
 	return ctx, cancel
 }
 
+func runServeStopTasks(ctx context.Context, tasks ...func(context.Context) error) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		if len(tasks) == 0 {
+			done <- nil
+			return
+		}
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(tasks))
+		for _, task := range tasks {
+			if task == nil {
+				continue
+			}
+			wg.Add(1)
+			go func(task func(context.Context) error) {
+				defer wg.Done()
+				if err := task(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					errCh <- err
+				}
+			}(task)
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			done <- err
+			return
+		}
+		done <- nil
+	}()
+	return done
+}
+
 func (s *serveServer) Stop(ctx context.Context) error {
 	if s.server == nil {
 		return nil
@@ -1129,15 +1161,19 @@ func (s *serveServer) Stop(ctx context.Context) error {
 			close(s.shutdownCh)
 		}
 	})
+
+	var stopTasks []func(context.Context) error
 	if s.jobsV2 != nil {
-		_ = s.jobsV2.Close()
+		stopTasks = append(stopTasks, s.jobsV2.CloseWithContext)
 	}
 	if s.responseRuns != nil {
-		s.responseRuns.Close()
+		stopTasks = append(stopTasks, s.responseRuns.CloseWithContext)
 	}
 	if s.widgetsMgr != nil {
-		s.widgetsMgr.Close()
+		stopTasks = append(stopTasks, s.widgetsMgr.CloseContext)
 	}
+	stopTasksDone := runServeStopTasks(ctx, stopTasks...)
+
 	closeFileTrackingStore()
 	s.modelsMu.Lock()
 	for _, p := range s.modelsProviders {
@@ -1148,5 +1184,18 @@ func (s *serveServer) Stop(ctx context.Context) error {
 	s.modelsProviders = nil
 	s.modelsCache = nil
 	s.modelsMu.Unlock()
-	return s.server.Shutdown(ctx)
+
+	shutdownErr := s.server.Shutdown(ctx)
+	select {
+	case stopErr := <-stopTasksDone:
+		if shutdownErr != nil {
+			return shutdownErr
+		}
+		return stopErr
+	case <-ctx.Done():
+		if shutdownErr != nil {
+			return shutdownErr
+		}
+		return ctx.Err()
+	}
 }

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -820,7 +820,10 @@ func (m *jobsV2Manager) recoverRuns() error {
 	return nil
 }
 
-func (m *jobsV2Manager) Close() error {
+func (m *jobsV2Manager) CloseWithContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
@@ -839,8 +842,23 @@ func (m *jobsV2Manager) Close() error {
 	for _, cancel := range cancels {
 		cancel()
 	}
-	m.wg.Wait()
-	return m.db.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		m.wg.Wait()
+		done <- m.db.Close()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *jobsV2Manager) Close() error {
+	return m.CloseWithContext(context.Background())
 }
 
 func (m *jobsV2Manager) schedulerLoop() {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -918,11 +918,14 @@ func (m *responseRunManager) ActiveSessionIDs() map[string]bool {
 	return result
 }
 
-func (m *responseRunManager) Close() {
+func (m *responseRunManager) CloseWithContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		return
+		return nil
 	}
 	m.closed = true
 	runs := make([]*responseRun, 0, len(m.runs))
@@ -938,7 +941,23 @@ func (m *responseRunManager) Close() {
 	for _, run := range runs {
 		_ = run.cancelRun()
 	}
-	m.runWG.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		m.runWG.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *responseRunManager) Close() {
+	_ = m.CloseWithContext(context.Background())
 }
 
 func usagePayload(usage llm.Usage) map[string]any {

--- a/cmd/serve_stop_test.go
+++ b/cmd/serve_stop_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestServeStopHonorsContextWhenResponseRunCloseBlocks(t *testing.T) {
+	mgr := newServeResponseRunManager()
+	release := make(chan struct{})
+	mgr.runWG.Add(1)
+	go func() {
+		<-release
+		mgr.runWG.Done()
+	}()
+
+	var releaseOnce sync.Once
+	releaseRun := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	defer releaseRun()
+	time.AfterFunc(500*time.Millisecond, releaseRun)
+
+	srv := &serveServer{
+		server:       &http.Server{},
+		shutdownCh:   make(chan struct{}),
+		responseRuns: mgr,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := srv.Stop(ctx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop error = %v, want context deadline exceeded", err)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("Stop took %s, want it to return before blocked teardown completes", elapsed)
+	}
+}

--- a/internal/widgets/manager.go
+++ b/internal/widgets/manager.go
@@ -460,14 +460,51 @@ func (m *Manager) reapIdle() {
 
 // Close stops all widget processes and the idle reaper.
 func (m *Manager) Close() {
+	_ = m.CloseContext(context.Background())
+}
+
+// CloseContext stops all widget processes and the idle reaper, waiting until
+// they exit or ctx is done.
+func (m *Manager) CloseContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var entries []*widgetEntry
+	shouldWait := false
 	m.stopOnce.Do(func() {
+		shouldWait = true
 		close(m.stopCh)
 		m.mu.RLock()
-		defer m.mu.RUnlock()
+		entries = make([]*widgetEntry, 0, len(m.entries))
 		for _, e := range m.entries {
-			e.stopProcess()
+			entries = append(entries, e)
 		}
+		m.mu.RUnlock()
 	})
+	if !shouldWait {
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		wg.Add(len(entries))
+		for _, e := range entries {
+			go func(e *widgetEntry) {
+				defer wg.Done()
+				e.stopProcess()
+			}(e)
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func freePort() (int, error) {


### PR DESCRIPTION
## What changed

- Made serve shutdown teardown context-aware for jobs, response runs, and widgets by adding bounded close helpers that stop waiting when the serve shutdown context expires.
- Updated `serveServer.Stop` to start those teardown steps in parallel instead of serially, so a slow widget/job/run teardown does not consume the full shutdown window before the HTTP server shutdown begins.
- Added a regression test covering the core failure mode: `serveServer.Stop` now returns on the shutdown deadline even when response-run teardown is blocked.

## Why this is high-value

This fixes a shutdown reliability bug in the long-running `serve` process. Before this change, shutdown advertised a 10 second timeout, but `Stop` could block indefinitely in pre-shutdown teardown because jobs and response runs waited on unbounded `WaitGroup`s and widgets were stopped serially. That could wedge restarts, deploys, watchdog actions, and Ctrl-C handling. With this change, shutdown honors the caller deadline and reaches `server.Shutdown` promptly.

## Validation

- `gofmt -w cmd/serve.go cmd/serve_jobs_v2.go cmd/serve_response_runs.go cmd/serve_stop_test.go internal/widgets/manager.go`
- `go build ./...`
- `go test ./...`
- Added `TestServeStopHonorsContextWhenResponseRunCloseBlocks`
- `git diff --check`
