### PR TITLE
fix: serve shutdown timeout is bypassed by unbounded waits in manager teardown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1129,24 +1129,67 @@ func (s *serveServer) Stop(ctx context.Context) error {
 			close(s.shutdownCh)
 		}
 	})
-	if s.jobsV2 != nil {
-		_ = s.jobsV2.Close()
-	}
-	if s.responseRuns != nil {
-		s.responseRuns.Close()
-	}
-	if s.widgetsMgr != nil {
-		s.widgetsMgr.Close()
-	}
-	closeFileTrackingStore()
-	s.modelsMu.Lock()
-	for _, p := range s.modelsProviders {
-		if cleaner, ok := p.(interface{ CleanupMCP() }); ok {
-			cleaner.CleanupMCP()
+
+	shutdownErrCh := make(chan error, 1)
+	go func() {
+		shutdownErrCh <- s.server.Shutdown(ctx)
+	}()
+
+	teardownErrCh := make(chan error, 1)
+	go func() {
+		var wg sync.WaitGroup
+		var errMu sync.Mutex
+		var teardownErr error
+		recordErr := func(err error) {
+			if err == nil {
+				return
+			}
+			errMu.Lock()
+			if teardownErr == nil {
+				teardownErr = err
+			}
+			errMu.Unlock()
 		}
+
+		if s.jobsV2 != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				recordErr(s.jobsV2.CloseContext(ctx))
+			}()
+		}
+		if s.responseRuns != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				recordErr(s.responseRuns.CloseContext(ctx))
+			}()
+		}
+		if s.widgetsMgr != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				recordErr(s.widgetsMgr.CloseContext(ctx))
+			}()
+		}
+		wg.Wait()
+		closeFileTrackingStore()
+		s.modelsMu.Lock()
+		for _, p := range s.modelsProviders {
+			if cleaner, ok := p.(interface{ CleanupMCP() }); ok {
+				cleaner.CleanupMCP()
+			}
+		}
+		s.modelsProviders = nil
+		s.modelsCache = nil
+		s.modelsMu.Unlock()
+		teardownErrCh <- teardownErr
+	}()
+
+	shutdownErr := <-shutdownErrCh
+	teardownErr := <-teardownErrCh
+	if shutdownErr != nil {
+		return shutdownErr
 	}
-	s.modelsProviders = nil
-	s.modelsCache = nil
-	s.modelsMu.Unlock()
-	return s.server.Shutdown(ctx)
+	return teardownErr
 }

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -820,7 +820,7 @@ func (m *jobsV2Manager) recoverRuns() error {
 	return nil
 }
 
-func (m *jobsV2Manager) Close() error {
+func (m *jobsV2Manager) CloseContext(ctx context.Context) error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
@@ -839,8 +839,14 @@ func (m *jobsV2Manager) Close() error {
 	for _, cancel := range cancels {
 		cancel()
 	}
-	m.wg.Wait()
+	if err := waitForWaitGroupContext(ctx, &m.wg); err != nil {
+		return err
+	}
 	return m.db.Close()
+}
+
+func (m *jobsV2Manager) Close() error {
+	return m.CloseContext(context.Background())
 }
 
 func (m *jobsV2Manager) schedulerLoop() {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -918,11 +918,11 @@ func (m *responseRunManager) ActiveSessionIDs() map[string]bool {
 	return result
 }
 
-func (m *responseRunManager) Close() {
+func (m *responseRunManager) CloseContext(ctx context.Context) error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		return
+		return nil
 	}
 	m.closed = true
 	runs := make([]*responseRun, 0, len(m.runs))
@@ -938,7 +938,11 @@ func (m *responseRunManager) Close() {
 	for _, run := range runs {
 		_ = run.cancelRun()
 	}
-	m.runWG.Wait()
+	return waitForWaitGroupContext(ctx, &m.runWG)
+}
+
+func (m *responseRunManager) Close() {
+	_ = m.CloseContext(context.Background())
 }
 
 func usagePayload(usage llm.Usage) map[string]any {

--- a/cmd/serve_shutdown.go
+++ b/cmd/serve_shutdown.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+)
+
+func waitForWaitGroupContext(ctx context.Context, wg *sync.WaitGroup) error {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -245,6 +245,43 @@ func TestServeServerStopIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestServeServerStopHonorsShutdownContextDuringManagerTeardown(t *testing.T) {
+	jobs := &jobsV2Manager{}
+	jobs.wg.Add(1)
+	defer jobs.wg.Done()
+
+	responseRuns := newServeResponseRunManager()
+	responseRuns.runWG.Add(1)
+	defer responseRuns.runWG.Done()
+
+	s := &serveServer{
+		server:       &http.Server{},
+		shutdownCh:   make(chan struct{}),
+		jobsV2:       jobs,
+		responseRuns: responseRuns,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := s.Stop(ctx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop() error = %v, want context deadline exceeded", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Stop() took %v, want it to honor shutdown context", elapsed)
+	}
+
+	select {
+	case <-s.shutdownCh:
+	default:
+		t.Fatal("shutdown channel was not closed")
+	}
+}
+
 func readSSEEvent(t *testing.T, scanner *bufio.Scanner) (string, string, bool) {
 	t.Helper()
 

--- a/internal/widgets/manager.go
+++ b/internal/widgets/manager.go
@@ -458,16 +458,49 @@ func (m *Manager) reapIdle() {
 	}
 }
 
-// Close stops all widget processes and the idle reaper.
-func (m *Manager) Close() {
+// CloseContext stops all widget processes and the idle reaper, returning early
+// if ctx expires.
+func (m *Manager) CloseContext(ctx context.Context) error {
+	var entries []*widgetEntry
 	m.stopOnce.Do(func() {
 		close(m.stopCh)
 		m.mu.RLock()
-		defer m.mu.RUnlock()
+		entries = make([]*widgetEntry, 0, len(m.entries))
 		for _, e := range m.entries {
-			e.stopProcess()
+			entries = append(entries, e)
 		}
+		m.mu.RUnlock()
 	})
+	if entries == nil {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(entries))
+	for _, e := range entries {
+		go func(e *widgetEntry) {
+			defer wg.Done()
+			e.stopProcess()
+		}(e)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close stops all widget processes and the idle reaper.
+func (m *Manager) Close() {
+	_ = m.CloseContext(context.Background())
 }
 
 func freePort() (int, error) {


### PR DESCRIPTION
## What changed

- started `serveServer.Stop` shutdown and manager teardown concurrently so `server.Shutdown(ctx)` is no longer blocked behind synchronous subsystem cleanup
- added context-aware teardown paths for `jobsV2Manager`, `responseRunManager`, and `widgets.Manager`
- kept the existing blocking `Close()` methods by having them call the new context-aware variants with `context.Background()`
- added a regression test that proves `serveServer.Stop` now returns on the shutdown deadline even when manager waitgroups never finish

## Why this is high-value

This fixes a real shutdown reliability bug: the outer serve loop advertises a 10-second shutdown budget, but before this change `Stop` could block indefinitely in `jobsV2.Close()`, `responseRunManager.Close()`, or serial widget teardown and never even reach `server.Shutdown(ctx)`. That can wedge deploys, restarts, watchdog recovery, and Ctrl-C on long-running services.

After this change, shutdown still requests normal cleanup first, but the waits are bounded by the caller's context so the process can reliably stop within the configured budget.

## Validation

- `gofmt -w cmd/serve.go cmd/serve_jobs_v2.go cmd/serve_response_runs.go cmd/serve_shutdown.go cmd/serve_test.go internal/widgets/manager.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
