### PR TITLE
fix: Sidebar session listing does a full sort on every web refresh because the ORDER BY cannot use any existing index

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -234,7 +234,15 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 29
+const schemaVersion = 30
+
+const (
+	// Keep these expressions aligned with List()'s hot ORDER BY clauses so SQLite
+	// can satisfy the sidebar top-N query directly from the matching indexes.
+	sessionListPinnedOrderExpr       = "COALESCE(pinned, FALSE)"
+	sessionListActivityOrderExpr     = "COALESCE(last_message_at, last_user_message_at, created_at)"
+	sessionListUserActivityOrderExpr = "COALESCE(last_user_message_at, created_at)"
+)
 
 // migration represents a schema migration.
 type migration struct {
@@ -848,6 +856,19 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		// Migration 30: Add expression indexes for the sidebar's two hot activity sorts.
+		// Without these, SQLite scans filtered sessions and builds a temp B-tree for
+		// every top-N refresh because the ORDER BY uses COALESCE() expressions.
+		version:     30,
+		description: "add sidebar session sort indexes",
+		up: func(db *sql.DB) error {
+			if err := createSessionListSortIndexes(db); err != nil {
+				return fmt.Errorf("create sidebar sort indexes: %w", err)
+			}
+			return nil
+		},
+	},
 }
 
 // Keep in sync with llm.IsInternalCompactionSummaryText. SQLite migrations and
@@ -1084,6 +1105,42 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 	_, err = db.Exec("CREATE INDEX IF NOT EXISTS idx_sessions_last_message ON sessions(last_message_at DESC)")
 	if err != nil {
 		return fmt.Errorf("ensure last_message_at index: %w", err)
+	}
+	if err := createSessionListSortIndexes(db); err != nil {
+		return fmt.Errorf("ensure sidebar sort indexes: %w", err)
+	}
+
+	return nil
+}
+
+func createSessionListSortIndexes(db *sql.DB) error {
+	indexDefs := []struct {
+		name   string
+		expr   string
+		errMsg string
+	}{
+		{
+			name:   "idx_sessions_sidebar_activity",
+			expr:   sessionListActivityOrderExpr,
+			errMsg: "create sidebar activity index",
+		},
+		{
+			name:   "idx_sessions_sidebar_last_user_activity",
+			expr:   sessionListUserActivityOrderExpr,
+			errMsg: "create sidebar last-user activity index",
+		},
+	}
+
+	for _, indexDef := range indexDefs {
+		stmt := fmt.Sprintf(
+			"CREATE INDEX IF NOT EXISTS %s ON sessions(archived, %s DESC, %s DESC)",
+			indexDef.name,
+			sessionListPinnedOrderExpr,
+			indexDef.expr,
+		)
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("%s: %w", indexDef.errMsg, err)
+		}
 	}
 
 	return nil
@@ -1545,14 +1602,14 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		// Web sidebar callers set SortByActivity to use last_message_at instead so
 		// assistant-only turns also surface (keeps the top-N window aligned with the
 		// client-side "any-message" ordering).
-		sortCol := "s.updated_at"
+		sortCol := "updated_at"
 		if opts.SortByActivity && s.hasLastMessageAt {
-			sortCol = "COALESCE(s.last_message_at, s.last_user_message_at, s.created_at)"
+			sortCol = sessionListActivityOrderExpr
 		} else if s.hasLastUserMessageAt {
-			sortCol = "COALESCE(s.last_user_message_at, s.created_at)"
+			sortCol = sessionListUserActivityOrderExpr
 		}
 		if s.hasPinned {
-			query += " ORDER BY COALESCE(s.pinned, FALSE) DESC, " + sortCol + " DESC"
+			query += " ORDER BY " + sessionListPinnedOrderExpr + " DESC, " + sortCol + " DESC"
 		} else {
 			query += " ORDER BY " + sortCol + " DESC"
 		}

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -344,6 +344,48 @@ func TestSQLiteStoreListByNumberCursorUsesSessionNumberIndex(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreListByActivityUsesSidebarSortIndex(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	plan := sqliteExplainPlan(t, store.db, `EXPLAIN QUERY PLAN
+		SELECT s.id, s.number
+		FROM sessions s
+		WHERE s.archived = FALSE
+		ORDER BY COALESCE(pinned, FALSE) DESC, COALESCE(last_message_at, last_user_message_at, created_at) DESC
+		LIMIT ?`, 100)
+	if !strings.Contains(plan, "idx_sessions_sidebar_activity") {
+		t.Fatalf("query plan = %q, want sidebar activity index", plan)
+	}
+	if strings.Contains(plan, "USE TEMP B-TREE") {
+		t.Fatalf("query plan = %q, want no temp sort", plan)
+	}
+}
+
+func TestSQLiteStoreListByLastUserActivityUsesSidebarSortIndex(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	plan := sqliteExplainPlan(t, store.db, `EXPLAIN QUERY PLAN
+		SELECT s.id, s.number
+		FROM sessions s
+		WHERE s.archived = FALSE
+		ORDER BY COALESCE(pinned, FALSE) DESC, COALESCE(last_user_message_at, created_at) DESC
+		LIMIT ?`, 100)
+	if !strings.Contains(plan, "idx_sessions_sidebar_last_user_activity") {
+		t.Fatalf("query plan = %q, want sidebar last-user activity index", plan)
+	}
+	if strings.Contains(plan, "USE TEMP B-TREE") {
+		t.Fatalf("query plan = %q, want no temp sort", plan)
+	}
+}
+
 func sqliteExplainPlan(t *testing.T, db *sql.DB, query string, args ...any) string {
 	t.Helper()
 	rows, err := db.Query(query, args...)
@@ -421,6 +463,8 @@ func TestInitSchemaFreshDBDoesNotRunHistoricalMigrations(t *testing.T) {
 		{objectType: "index", name: "idx_sessions_title_skipped"},
 		{objectType: "index", name: "idx_sessions_last_user_msg"},
 		{objectType: "index", name: "idx_sessions_last_message"},
+		{objectType: "index", name: "idx_sessions_sidebar_activity"},
+		{objectType: "index", name: "idx_sessions_sidebar_last_user_activity"},
 	} {
 		var count int
 		if err := db.QueryRow(`


### PR DESCRIPTION
## What changed

- Added two dedicated SQLite expression indexes for the sidebar list orders:
  - `idx_sessions_sidebar_activity` on `(archived, COALESCE(pinned, FALSE) DESC, COALESCE(last_message_at, last_user_message_at, created_at) DESC)`
  - `idx_sessions_sidebar_last_user_activity` on `(archived, COALESCE(pinned, FALSE) DESC, COALESCE(last_user_message_at, created_at) DESC)`
- Added schema migration 30 plus startup index creation so both upgraded and fresh databases get the new indexes.
- Switched `List()` to use the same unqualified ORDER BY expressions as the new indexes so SQLite can match them exactly.
- Added query-plan tests proving the activity-sorted and last-user-activity-sorted queries use the new indexes without a temp sort.

## Why this is high-value

The web sidebar hits `store.List(... SortByActivity: true, Limit: 100)` on refresh/poll. Before this change, SQLite had no index matching `archived + pinned + COALESCE(...) ORDER BY`, so the planner did a scan plus `USE TEMP B-TREE FOR ORDER BY` for each refresh. That work grows with session count and directly affects a user-visible UI path.

With the new indexes, SQLite can read the top sessions in index order and stop at the limit, avoiding the full candidate sort and reducing CPU/latency on a hot path.

## Validation

- Verified the issue was real first with `EXPLAIN QUERY PLAN`, which showed:
  - `SCAN s`
  - `USE TEMP B-TREE FOR ORDER BY`
- Added tests that assert the two sidebar ORDER BY variants use:
  - `idx_sessions_sidebar_activity`
  - `idx_sessions_sidebar_last_user_activity`
  and do **not** use a temp B-tree sort.
- Ran:
  - `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
  - `go build ./...`
  - `go test ./...`
  - `git diff --check`
