### PR TITLE
feat: split chat header into title and controls rows

### DIFF
--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -475,7 +475,7 @@
 
     .diff-toggle {
       position: relative;
-      margin-left: 0.45rem;
+      margin-left: 0;
       width: auto;
       min-width: 92px;
       height: 30px;
@@ -1147,20 +1147,33 @@
       border-bottom: 1px solid var(--border);
       background: var(--surface);
       display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.35rem;
+      padding: calc(0.7rem + var(--safe-top)) calc(1.15rem + var(--safe-right)) 0.62rem calc(1.15rem + var(--safe-left));
+      position: relative;
+      z-index: 1;
+    }
+
+    .header-title-row {
+      display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 0.75rem;
-      padding: calc(0.85rem + var(--safe-top)) calc(1.15rem + var(--safe-right)) 0.85rem calc(1.15rem + var(--safe-left));
-      flex-wrap: wrap;
-      position: relative;
-      z-index: 1;
+      min-width: 0;
+    }
+
+    .header-controls-row {
+      display: flex;
+      align-items: center;
+      min-width: 0;
     }
 
     .header-left {
       display: inline-flex;
       align-items: center;
       gap: 0.6rem;
-      flex: 1;
+      flex: 1 1 auto;
       min-width: 0;
     }
 
@@ -1208,6 +1221,9 @@
       font-size: 0.8rem;
       color: var(--text-muted);
       white-space: nowrap;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
     }
 
     .model-picker {
@@ -3270,16 +3286,22 @@
       }
 
       .main-header {
-        padding: calc(0.7rem + var(--safe-top)) calc(0.8rem + var(--safe-right)) 0.7rem calc(0.8rem + var(--safe-left));
-        flex-wrap: nowrap;
-        align-items: flex-start;
+        padding: calc(0.7rem + var(--safe-top)) calc(0.8rem + var(--safe-right)) 0.68rem calc(0.8rem + var(--safe-left));
+        gap: 0.32rem;
+      }
+
+      .header-title-row {
+        align-items: center;
+        gap: 0.55rem;
+      }
+
+      .header-controls-row {
+        padding-left: calc(38px + 0.55rem);
       }
 
       .header-title {
-        white-space: normal;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
+        white-space: nowrap;
+        display: block;
       }
 
       .mobile-menu {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -193,12 +193,17 @@
 
     <main class="main">
       <header class="main-header">
-        <div class="header-left">
-          <button class="icon-btn mobile-menu" id="mobileMenuBtn" aria-label="Open sidebar" title="Open sidebar">☰</button>
-          <h1 class="header-title" id="activeSessionTitle">Chat</h1>
-          <span class="connection-state bad" id="connectionState" hidden aria-live="polite"></span>
+        <div class="header-title-row">
+          <div class="header-left">
+            <button class="icon-btn mobile-menu" id="mobileMenuBtn" aria-label="Open sidebar" title="Open sidebar">☰</button>
+            <h1 class="header-title" id="activeSessionTitle">Chat</h1>
+            <span class="connection-state bad" id="connectionState" hidden aria-live="polite"></span>
+          </div>
+          <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
+            <span class="diff-toggle-badge" id="diffToggleBadge"></span>
+          </button>
         </div>
-        <div class="header-right">
+        <div class="header-controls-row">
           <div class="header-stats" id="headerStats">
             <div class="model-picker" id="modelPicker">
               <div class="model-chip" data-chip="provider" id="chipProvider">
@@ -237,9 +242,6 @@
             <span class="chip-sep header-tokens-sep" id="headerTokensSep" hidden>·</span>
             <span class="header-tokens" id="headerTokens"></span>
           </div>
-          <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
-            <span class="diff-toggle-badge" id="diffToggleBadge"></span>
-          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## What

Implements the header layout we mocked but did not land in the prior title PR:

- title/diff get their own first row
- model/provider/effort/token usage move to a second row
- long titles stay one line with ellipsis instead of wrapping the header taller
- diff no longer needs to share the metadata row; constrained widths keep the compact file-count variant from #803
- mobile controls row is indented under the title text after the hamburger

## Why

The one-row header gets too dense once generated titles, model controls, token usage, and file-change actions are all present. The two-row layout gives the title the primary visual row while keeping runtime controls available below.

## Verification

- `go test ./...`
- `go build -o /tmp/term-llm-two-row-header .`
- Ran the built web UI locally and captured real Playwright screenshots at multiple widths:
  - 1440px: `/chat/images/two-row-header-1440.png`
  - 1100px: `/chat/images/two-row-header-1100.png`
  - 820px: `/chat/images/two-row-header-820.png`
  - 620px: `/chat/images/two-row-header-620.png`
  - 430px: `/chat/images/two-row-header-430.png`
  - 390px: `/chat/images/two-row-header-390.png`
