### PR TITLE
feat: use hybrid chat header layout

### DIFF
--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -537,12 +537,15 @@
 
     @media (max-width: 900px) {
       .diff-toggle {
-        min-width: 0;
-        padding: 0 0.58rem;
+        min-width: 52px;
+        height: 32px;
+        padding: 0 0.5rem;
+        border-radius: 9px;
       }
 
       .diff-toggle-file-count {
         display: inline-flex;
+        gap: 0.36rem;
       }
 
       .diff-toggle-file-count::after {
@@ -712,6 +715,10 @@
     .icon-btn:hover {
       background: var(--surface-3);
       color: var(--text);
+    }
+
+    .icon-btn.diff-toggle {
+      width: auto;
     }
 
     .icon-btn:focus-visible {
@@ -1146,11 +1153,7 @@
       min-height: 64px;
       border-bottom: 1px solid var(--border);
       background: var(--surface);
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      gap: 0.35rem;
-      padding: calc(0.7rem + var(--safe-top)) calc(1.15rem + var(--safe-right)) 0.62rem calc(1.15rem + var(--safe-left));
+      padding: calc(0.85rem + var(--safe-top)) calc(1.15rem + var(--safe-right)) 0.85rem calc(1.15rem + var(--safe-left));
       position: relative;
       z-index: 1;
     }
@@ -1158,8 +1161,7 @@
     .header-title-row {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
+      gap: 0.65rem;
       min-width: 0;
     }
 
@@ -1167,6 +1169,8 @@
       display: flex;
       align-items: center;
       min-width: 0;
+      overflow: visible;
+      flex: 0 0 auto;
     }
 
     .header-left {
@@ -1175,6 +1179,29 @@
       gap: 0.6rem;
       flex: 1 1 auto;
       min-width: 0;
+    }
+
+    @media (max-width: 1200px) {
+      .header-title-row {
+        flex-wrap: wrap;
+        row-gap: 0.25rem;
+      }
+
+      .header-left {
+        order: 1;
+        flex-basis: calc(100% - 5rem);
+        min-width: 0;
+      }
+
+      .header-controls-row {
+        order: 3;
+        flex-basis: 100%;
+      }
+
+      .diff-toggle {
+        order: 2;
+        margin-left: auto;
+      }
     }
 
     .mobile-menu {
@@ -3292,7 +3319,8 @@
 
       .header-title-row {
         align-items: center;
-        gap: 9px;
+        column-gap: 9px;
+        row-gap: 0;
       }
 
       .header-controls-row {
@@ -3317,6 +3345,7 @@
 
       .diff-toggle {
         height: 33px;
+        margin-bottom: 2px;
       }
 
 

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -199,12 +199,8 @@
             <h1 class="header-title" id="activeSessionTitle">Chat</h1>
             <span class="connection-state bad" id="connectionState" hidden aria-live="polite"></span>
           </div>
-          <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
-            <span class="diff-toggle-badge" id="diffToggleBadge"></span>
-          </button>
-        </div>
-        <div class="header-controls-row">
-          <div class="header-stats" id="headerStats">
+          <div class="header-controls-row">
+            <div class="header-stats" id="headerStats">
             <div class="model-picker" id="modelPicker">
               <div class="model-chip" data-chip="provider" id="chipProvider">
                 <button type="button" class="chip-trigger" id="chipProviderTrigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Provider">
@@ -242,6 +238,9 @@
             <span class="chip-sep header-tokens-sep" id="headerTokensSep" hidden>·</span>
             <span class="header-tokens" id="headerTokens"></span>
           </div>
+          <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
+            <span class="diff-toggle-badge" id="diffToggleBadge"></span>
+          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## What

Turns the chat header into a hybrid layout:

- wide layouts keep title, model controls, token usage, and diff on one row
- constrained layouts wrap controls to a second row while title + diff stay on row one
- mobile keeps the polished spacing/alignment from #808
- diff stays pinned to the right as the primary header action

## Why

The mandatory two-row layout was cleaner under pressure, but wasteful when there is enough horizontal room. This keeps the compact single-row header where it fits and only uses the second row as a pressure valve.

## Verification

- `go test ./...`
- `go build -o /tmp/term-llm-hybrid-header .`
- Captured real screenshots from the built web UI:
  - 1440px: `/chat/images/hybrid-header-1440.png`
  - 1100px: `/chat/images/hybrid-header-1100.png`
  - 900px: `/chat/images/hybrid-header-900.png`
  - 820px: `/chat/images/hybrid-header-820.png`
  - 620px: `/chat/images/hybrid-header-620.png`
  - 390px: `/chat/images/hybrid-header-390.png`
