### PR TITLE
fix: keep chat header controls on one line

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -571,6 +571,36 @@ const splitHeaderModelEffort = (model, effort) => {
   return { model: rawModel, effort: rawEffort };
 };
 
+const compactHeaderModelLabel = (model) => {
+  const raw = String(model || '').trim();
+  if (!raw) return raw;
+
+  let id = raw.split('/').filter(Boolean).pop() || raw;
+  id = id.replace(/^(?:chatgpt|openai|anthropic|claude):/i, '');
+  const tokens = id.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  const familyIndex = tokens.findIndex((token) => token === 'opus' || token === 'sonnet' || token === 'haiku');
+  if (familyIndex >= 0 && tokens.includes('claude')) {
+    const collectVersion = (start, step) => {
+      const parts = [];
+      for (let i = start; i >= 0 && i < tokens.length && parts.length < 2; i += step) {
+        const token = tokens[i];
+        if (!/^\d+$/.test(token) || token.length > 2) break;
+        if (step < 0) parts.unshift(token);
+        else parts.push(token);
+      }
+      return parts;
+    };
+    const after = collectVersion(familyIndex + 1, 1);
+    const before = collectVersion(familyIndex - 1, -1);
+    const version = (after.length ? after : before).join('.');
+    return [tokens[familyIndex], version].filter(Boolean).join(' ');
+  }
+
+  return id
+    .replace(/_/g, '-')
+    .replace(/^(?:chatgpt|openai|anthropic|claude)[-_: ]+/i, '');
+};
+
 const setChipSelectValue = (sel, value) => {
   if (!sel) return;
   if (sel.value === value) return;
@@ -592,13 +622,15 @@ const getDefaultModelForProvider = (providerName) => {
   return '';
 };
 
-const setChipLabel = (labelEl, sepEl, text, { muted = false, hidden = false } = {}) => {
+const setChipLabel = (labelEl, sepEl, text, { muted = false, hidden = false, title = '' } = {}) => {
   if (sepEl) sepEl.hidden = hidden;
   if (!labelEl) return;
   const chip = labelEl.closest('.model-chip');
   if (chip) chip.hidden = hidden;
   if (hidden) return;
   labelEl.textContent = text;
+  if (title && title !== text) labelEl.setAttribute?.('title', title);
+  else labelEl.removeAttribute?.('title');
   labelEl.classList.toggle('stats-muted', muted);
 };
 
@@ -640,11 +672,12 @@ const updateSessionUsageDisplay = (session) => {
     { muted: providerIsDefault || !resolvedProvider, hidden: false }
   );
 
+  const modelLabel = resolvedModel ? compactHeaderModelLabel(resolvedModel) : '—';
   setChipLabel(
     elements.chipModelLabel,
     elements.chipSepProviderModel,
-    resolvedModel || '—',
-    { muted: modelIsDefault || !resolvedModel, hidden: false }
+    modelLabel,
+    { muted: modelIsDefault || !resolvedModel, hidden: false, title: resolvedModel || '' }
   );
 
   // Effort has no server-side default, so when unset we show a muted "auto"
@@ -1508,6 +1541,7 @@ Object.assign(app, {
   formatUsage,
   renderMath,
   splitHeaderModelEffort,
+  compactHeaderModelLabel,
   updateSessionUsageDisplay,
   isNearBottom,
   noteUserScrollIntent,

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -89,42 +89,11 @@ const toggleSidebarCollapsed = () => {
   setSidebarCollapsed(!state.sidebarCollapsed);
 };
 
-const adaptHeaderLayout = () => {
-  const header = elements.mainHeader;
-  const title = elements.activeSessionTitle;
-  if (!header || !title || !elements.headerControlsRow || !elements.diffToggleBtn) return;
-  if (typeof title.scrollWidth !== 'number' || typeof title.clientWidth !== 'number') return;
-
-  header.classList.remove('header-controls-wrapped');
-
-  // Mobile is governed by CSS. On larger layouts, start as a single row and
-  // only wrap controls if the title is being crushed below a useful width.
-  if (window.innerWidth <= 767) return;
-
-  const titleWidth = title.clientWidth || 0;
-  const titleScrollWidth = title.scrollWidth || 0;
-  const usefulTitleWidth = Math.min(titleScrollWidth, 320);
-  const titleCrushed = titleScrollWidth > titleWidth + 1 && titleWidth < usefulTitleWidth;
-  if (titleCrushed) header.classList.add('header-controls-wrapped');
-};
-
-let headerLayoutFrame = 0;
-const scheduleHeaderLayout = () => {
-  if (headerLayoutFrame) window.cancelAnimationFrame?.(headerLayoutFrame);
-  const run = () => {
-    headerLayoutFrame = 0;
-    adaptHeaderLayout();
-  };
-  if (window.requestAnimationFrame) headerLayoutFrame = window.requestAnimationFrame(run);
-  else run();
-};
-
 const updateHeader = () => {
   const session = ensureActiveSession();
   elements.activeSessionTitle.textContent = session?.title || 'Chat';
   updateDocumentTitle();
   updateSessionUsageDisplay(session);
-  scheduleHeaderLayout();
   applyDesktopSidebarState();
 };
 
@@ -2407,8 +2376,6 @@ const updateSidebarStatus = (statusSessions) => {
   }
   return changed;
 };
-
-window.addEventListener?.('resize', scheduleHeaderLayout);
 
 Object.assign(app, {
   openSidebar,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -475,7 +475,7 @@
 
     .diff-toggle {
       position: relative;
-      margin-left: auto;
+      margin-left: 0;
       width: auto;
       min-width: 92px;
       height: 30px;
@@ -1163,6 +1163,8 @@
       align-items: center;
       gap: 0.65rem;
       min-width: 0;
+      width: 100%;
+      flex-wrap: nowrap;
     }
 
     .header-controls-row {
@@ -1171,42 +1173,16 @@
       min-width: 0;
       overflow: visible;
       flex: 0 0 auto;
-    }
-
-    @media (min-width: 768px) {
-      .header-controls-row > .diff-toggle {
-        margin-left: 0.85rem;
-      }
+      margin-left: auto;
     }
 
     .header-left {
       display: inline-flex;
       align-items: center;
       gap: 0.6rem;
-      flex: 0 1 auto;
+      flex: 1 1 auto;
       min-width: 0;
-    }
-
-    .main-header.header-controls-wrapped .header-title-row {
-      flex-wrap: wrap;
-      row-gap: 0.25rem;
-    }
-
-    .main-header.header-controls-wrapped .header-left {
-      order: 1;
-      flex-basis: calc(100% - 5rem);
-      min-width: 0;
-    }
-
-    .main-header.header-controls-wrapped .header-controls-row {
-      order: 3;
-      flex-basis: 100%;
-      margin-right: 0;
-    }
-
-    .main-header.header-controls-wrapped .diff-toggle {
-      order: 2;
-      margin-left: auto;
+      overflow: hidden;
     }
 
     .mobile-menu {
@@ -1221,6 +1197,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      flex: 1 1 auto;
       min-width: 0;
     }
 
@@ -1229,6 +1206,10 @@
       font-size: 0.78rem;
       font-weight: 650;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 0 1 auto;
+      min-width: 0;
     }
 
     .connection-state[hidden] {
@@ -1498,6 +1479,13 @@
 
     .header-tokens-sep[hidden] {
       display: none;
+    }
+
+    @media (max-width: 1599px) {
+      .header-tokens,
+      .header-tokens-sep {
+        display: none;
+      }
     }
 
     .stats-tokens {
@@ -3324,23 +3312,20 @@
 
       .header-title-row {
         align-items: center;
-        column-gap: 9px;
-        row-gap: 0;
-        flex-wrap: wrap;
+        gap: 8px;
+        flex-wrap: nowrap;
       }
 
       .header-left {
-        order: 1;
-        flex-basis: calc(100% - 5rem);
+        flex: 1 1 auto;
         min-width: 0;
       }
 
       .header-controls-row {
-        order: 3;
-        flex-basis: 100%;
-        padding-left: 43px;
-        margin-top: 0;
-        margin-right: 0;
+        flex: 0 0 auto;
+        justify-content: flex-end;
+        min-width: 0;
+        margin-left: auto;
       }
 
       .header-controls-row .chip-trigger {
@@ -3359,12 +3344,11 @@
       }
 
       .diff-toggle {
-        order: 2;
-        margin-left: auto;
+        flex: 0 0 auto;
         height: 33px;
-        margin-bottom: 2px;
+        min-width: 50px;
+        padding: 0 0.45rem;
       }
-
 
       .header-right {
         margin-left: auto;
@@ -3390,25 +3374,41 @@
       }
 
       .header-tokens,
-      .header-tokens-sep {
+      .header-tokens-sep,
+      .model-picker .chip-sep,
+      .model-chip[data-chip="provider"],
+      .model-chip[data-chip="effort"] {
         display: none;
       }
 
       .model-picker {
+        display: inline-flex;
+        align-items: center;
         flex-wrap: nowrap;
         min-width: 0;
       }
 
-      .chip-trigger {
-        padding: 0.32rem 0.45rem;
+      .model-chip[data-chip="model"] .chip-trigger {
+        height: 32px;
+        max-width: 126px;
+        padding: 0 0.65rem;
+        border: 1px solid var(--border);
+        border-radius: 9px;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .model-chip[data-chip="model"] .chip-trigger::after {
+        content: "▾";
+        margin-left: 0.35rem;
+        color: var(--text-muted);
+        font-size: 0.7rem;
+        line-height: 1;
       }
 
       .model-chip[data-chip="model"] .chip-label {
-        max-width: 38vw;
-      }
-
-      .model-chip[data-chip="provider"] .chip-label {
-        max-width: 22vw;
+        max-width: 90px;
       }
 
       .chat-scroll {

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -251,6 +251,27 @@ const app = loadAppCore();
   pass(name);
 })();
 
+(function testCompactHeaderModelLabelRemovesProviderNoise() {
+  const name = 'compactHeaderModelLabel removes provider noise';
+  const cases = [
+    ['claude-sonnet-4.5-thinking-super-long-preview-build-20260613', 'sonnet 4.5'],
+    ['claude-3-7-sonnet-latest', 'sonnet 3.7'],
+    ['claude-opus-4.8', 'opus 4.8'],
+    ['anthropic/claude-3-5-haiku-20241022', 'haiku 3.5'],
+    ['chatgpt-gpt-5.5', 'gpt-5.5'],
+    ['openai/gpt-5.5', 'gpt-5.5'],
+    ['gpt-5.5', 'gpt-5.5'],
+  ];
+  for (const [input, expected] of cases) {
+    const got = app.compactHeaderModelLabel(input);
+    if (got !== expected) {
+      fail(name, `for ${JSON.stringify(input)} got ${JSON.stringify(got)}, want ${JSON.stringify(expected)}`);
+      return;
+    }
+  }
+  pass(name);
+})();
+
 (function testPendingInterjectBadgeStateIsDistinctFromInjected() {
   const name = 'pending_interject is a valid interrupt state labelled distinctly from injected';
 

--- a/internal/serveui/static/chip_picker_test.js
+++ b/internal/serveui/static/chip_picker_test.js
@@ -379,8 +379,8 @@ function testUpdateSessionUsageDisplayUsesSelectedRuntimeForIdleSession() {
     fail(name, `expected provider label "anthropic" got "${elementMap.chipProviderLabel.textContent}"`);
     return;
   }
-  if (elementMap.chipModelLabel.textContent !== 'claude-sonnet') {
-    fail(name, `expected selected provider default model "claude-sonnet" got "${elementMap.chipModelLabel.textContent}"`);
+  if (elementMap.chipModelLabel.textContent !== 'sonnet') {
+    fail(name, `expected selected provider default model label "sonnet" got "${elementMap.chipModelLabel.textContent}"`);
     return;
   }
 
@@ -440,8 +440,8 @@ function testProviderChipChangeUpdatesHeaderBeforeModelsFetchCompletes() {
     fail(name, `expected header provider to update immediately, got "${elementMap.chipProviderLabel.textContent}"`);
     return;
   }
-  if (elementMap.chipModelLabel.textContent !== 'claude-sonnet') {
-    fail(name, `expected header model fallback for new provider, got "${elementMap.chipModelLabel.textContent}"`);
+  if (elementMap.chipModelLabel.textContent !== 'sonnet') {
+    fail(name, `expected header model fallback label "sonnet", got "${elementMap.chipModelLabel.textContent}"`);
     return;
   }
   const modelValues = elementMap.chipModelSelect.children.map((child) => child.value);

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -238,6 +238,7 @@
             <span class="chip-sep header-tokens-sep" id="headerTokensSep" hidden>·</span>
             <span class="header-tokens" id="headerTokens"></span>
           </div>
+          </div>
           <button class="icon-btn diff-toggle" id="diffToggleBtn" type="button" hidden aria-label="Toggle file changes" title="File changes">
             <span class="diff-toggle-badge" id="diffToggleBadge"></span>
           </button>


### PR DESCRIPTION
## What

Keeps the chat header on a single line at every tested width.

- Removes the adaptive/two-line wrapping path entirely.
- Makes the title the flexible/truncated region.
- Keeps the LLM control visible on the same row.
- Keeps the diff toggle visible on the same row when present.
- Uses compact **model** labels in the header instead of provider/model clutter:
  - `claude-sonnet-4.5-...` → `sonnet 4.5`
  - `claude-opus-4.8` → `opus 4.8`
  - `chatgpt-gpt-5.5` / `openai/gpt-5.5` → `gpt-5.5`
- Keeps the full model id in the label title for hover/inspection.
- Drops lower-priority metadata as space tightens:
  - token usage hides below wide desktop
  - mobile hides provider/effort/tokens and keeps a single compact model button
  - diff compacts to file-count form at narrower widths

## Why

The header should have one stable rule: title on the left, controls on the right, one line only. If space is tight, remove/truncate non-critical detail before wrapping. Two-line headers looked jumpy and made the control cluster feel like it changed docking rules.

## Screenshots

Contact sheet:

![one-line header contact sheet](/chat/images/one-line-header-contact-sheet.png)

Representative individual shots:

| Case | Screenshot |
|---|---|
| 1600 / full fidelity | ![1600](/chat/images/one-line-verified-diff-long-1600.png) |
| 1440 / tokens removed | ![1440](/chat/images/one-line-verified-diff-long-1440.png) |
| 900 / compact diff | ![900](/chat/images/one-line-verified-diff-long-900.png) |
| 390 / compact mobile | ![390](/chat/images/one-line-verified-diff-long-390.png) |
| 320 / `minimax-3.0` still fits | ![320 minimax](/chat/images/one-line-verified-diff-minimax-320.png) |
| 390 / no diff | ![390 no diff](/chat/images/one-line-verified-nodiff-long-390.png) |
| 390 / compact model picker opens | ![390 picker](/chat/images/one-line-verified-mobile-model-popover-390.png) |
| 390 / compact Claude model label | ![390 compact model](/chat/images/one-line-compact-model-label-390.png) |
| 320 / compact Claude model label | ![320 compact model](/chat/images/one-line-compact-model-label-320.png) |

## Verified

```text
go test ./cmd ./internal/serveui
go test ./...
go build -o /tmp/term-llm-right-docked-header .
python3 /tmp/verify_one_line_header.py
python3 /tmp/verify_compact_model_label.py
```

Playwright assertions covered:

- long, short, no-diff, and `minimax-3.0` labels
- compact Claude labels like `sonnet 4.5` derived from full ids
- widths: 1600, 1599, 1440, 1439, 1281, 1280, 1101, 1100, 901, 900, 768, 767, 620, 430, 390, 375, 320
- row height stays <= 36px and visible title/model/diff centers stay aligned
- compact model button opens the picker on mobile
