### PR TITLE
feat: expand compact runtime control

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -5,7 +5,7 @@ const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
   getActiveSession, createSession, scrollToBottom, setConnectionState, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
+  persistAndRefreshShell, updateSessionUsageDisplay, compactHeaderModelLabel, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
   enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
   subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
@@ -2204,7 +2204,7 @@ elements.chipEffortSelect?.addEventListener('change', () => {
 // Replaces the native <select> dropdown UI: native pickers are inconsistent
 // across OSes, ugly, and can render off-screen. The underlying <select> is kept
 // for state/sync — popover items dispatch a 'change' event on it on selection.
-const chipPopoverState = { selectEl: null, triggerEl: null, filterInput: null };
+const chipPopoverState = { selectEl: null, triggerEl: null, filterInput: null, mode: '' };
 
 const buildChipOptionLabel = (opt) => {
   const text = opt.textContent || opt.value || '';
@@ -2273,6 +2273,7 @@ const closeChipPopover = () => {
   if (!pop || pop.hidden) return;
   pop.hidden = true;
   pop.innerHTML = '';
+  pop.classList?.remove('chip-popover-runtime');
   if (elements.chipPopoverBackdrop) elements.chipPopoverBackdrop.hidden = true;
   if (chipPopoverState.triggerEl) {
     chipPopoverState.triggerEl.setAttribute('aria-expanded', 'false');
@@ -2280,6 +2281,7 @@ const closeChipPopover = () => {
   chipPopoverState.selectEl = null;
   chipPopoverState.triggerEl = null;
   chipPopoverState.filterInput = null;
+  chipPopoverState.mode = '';
 };
 
 const focusChipPopoverItem = (item) => {
@@ -2360,6 +2362,8 @@ const openChipPopover = (selectEl, triggerEl) => {
     return;
   }
   closeChipPopover();
+  pop.classList?.remove('chip-popover-runtime');
+  chipPopoverState.mode = 'select';
   chipPopoverState.selectEl = selectEl;
   chipPopoverState.triggerEl = triggerEl;
   pop.innerHTML = '';
@@ -2439,6 +2443,110 @@ const openChipPopover = (selectEl, triggerEl) => {
   if (filterInput) filterInput.focus?.();
 };
 
+const isRuntimePickerCompressed = () => {
+  const providerChip = elements.chipProviderTrigger?.closest?.('.model-chip');
+  if (!providerChip || !window.getComputedStyle) return false;
+  return window.getComputedStyle(providerChip).display === 'none';
+};
+
+const copySelectOptions = (from, to, formatOption = null) => {
+  to.innerHTML = '';
+  Array.from(from?.options || []).forEach((opt) => {
+    const clone = document.createElement('option');
+    clone.value = opt.value;
+    clone.textContent = formatOption ? formatOption(opt) : opt.textContent;
+    clone.disabled = opt.disabled;
+    to.appendChild(clone);
+  });
+};
+
+const runtimeField = ({ label, value, sourceSelect, onChange, formatOption = null }) => {
+  const field = document.createElement('label');
+  field.className = 'runtime-popover-field';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'runtime-popover-label';
+  labelEl.textContent = label;
+  field.appendChild(labelEl);
+
+  const select = document.createElement('select');
+  select.className = 'runtime-popover-select';
+  copySelectOptions(sourceSelect, select, formatOption);
+  select.value = value || '';
+  select.addEventListener('change', async () => {
+    select.disabled = true;
+    try {
+      await onChange(select.value);
+    } finally {
+      if (chipPopoverState.mode === 'runtime') renderRuntimePopoverContent();
+    }
+  });
+  field.appendChild(select);
+  return field;
+};
+
+const renderRuntimePopoverContent = () => {
+  const pop = elements.chipPopover;
+  if (!pop) return;
+  pop.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.className = 'runtime-popover-header';
+  const title = document.createElement('div');
+  title.className = 'runtime-popover-title';
+  title.textContent = 'Runtime';
+  const hint = document.createElement('div');
+  hint.className = 'runtime-popover-hint';
+  hint.textContent = 'Provider, model, and effort for the next reply';
+  header.appendChild(title);
+  header.appendChild(hint);
+  pop.appendChild(header);
+
+  const fields = document.createElement('div');
+  fields.className = 'runtime-popover-fields';
+  fields.appendChild(runtimeField({
+    label: 'Provider',
+    value: state.selectedProvider || '',
+    sourceSelect: elements.chipProviderSelect,
+    onChange: (value) => applyProviderChange(value),
+  }));
+  fields.appendChild(runtimeField({
+    label: 'Model',
+    value: state.selectedModel || '',
+    sourceSelect: elements.chipModelSelect,
+    onChange: (value) => applyModelChange(value),
+    formatOption: (opt) => opt.value ? compactHeaderModelLabel(opt.value) : opt.textContent,
+  }));
+  fields.appendChild(runtimeField({
+    label: 'Effort',
+    value: state.selectedEffort || '',
+    sourceSelect: elements.chipEffortSelect,
+    onChange: (value) => applyEffortChange(value),
+  }));
+  pop.appendChild(fields);
+};
+
+const openRuntimePopover = (triggerEl) => {
+  const pop = elements.chipPopover;
+  if (!pop || !triggerEl) return;
+  if (chipPopoverState.mode === 'runtime' && chipPopoverState.triggerEl === triggerEl) {
+    closeChipPopover();
+    return;
+  }
+  closeChipPopover();
+  chipPopoverState.mode = 'runtime';
+  chipPopoverState.selectEl = null;
+  chipPopoverState.triggerEl = triggerEl;
+  chipPopoverState.filterInput = null;
+  pop.classList?.add('chip-popover-runtime');
+  renderRuntimePopoverContent();
+  triggerEl.setAttribute('aria-expanded', 'true');
+  if (elements.chipPopoverBackdrop) elements.chipPopoverBackdrop.hidden = false;
+  pop.hidden = false;
+  positionChipPopover(triggerEl);
+  pop.querySelector?.('.runtime-popover-select')?.focus?.({ preventScroll: true });
+};
+
 elements.chipPopoverBackdrop?.addEventListener('click', () => {
   closeChipPopover();
 });
@@ -2447,6 +2555,10 @@ const wireChipTrigger = (triggerEl, selectEl) => {
   if (!triggerEl || !selectEl) return;
   triggerEl.addEventListener('click', (e) => {
     e.stopPropagation();
+    if (triggerEl === elements.chipModelTrigger && isRuntimePickerCompressed()) {
+      openRuntimePopover(triggerEl);
+      return;
+    }
     openChipPopover(selectEl, triggerEl);
   });
 };
@@ -2466,6 +2578,14 @@ document.addEventListener('click', (e) => {
 document.addEventListener('keydown', (e) => {
   const pop = elements.chipPopover;
   if (!pop || pop.hidden) return;
+  if (chipPopoverState.mode === 'runtime') {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeChipPopover();
+      chipPopoverState.triggerEl?.focus?.();
+    }
+    return;
+  }
   // The filter input owns its own keydown handler for navigation/commit. Don't
   // run the document-level handler when it's focused — otherwise Space would be
   // preventDefault'd and the user couldn't type spaces.

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1445,6 +1445,68 @@
       flex: none;
     }
 
+    .chip-popover-runtime {
+      min-width: 280px;
+      padding: 0.75rem;
+    }
+
+    .runtime-popover-header {
+      margin-bottom: 0.7rem;
+    }
+
+    .runtime-popover-title {
+      font-weight: 750;
+      font-size: 0.95rem;
+      color: var(--text);
+      margin-bottom: 0.15rem;
+    }
+
+    .runtime-popover-hint {
+      color: var(--text-muted);
+      font-size: 0.78rem;
+      line-height: 1.35;
+    }
+
+    .runtime-popover-fields {
+      display: grid;
+      gap: 0.6rem;
+    }
+
+    .runtime-popover-field {
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .runtime-popover-label {
+      color: var(--text-muted);
+      font-size: 0.72rem;
+      font-weight: 750;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .runtime-popover-select {
+      width: 100%;
+      min-width: 0;
+      border: 1px solid var(--border);
+      border-radius: 9px;
+      background: var(--surface-1, var(--surface));
+      color: var(--text);
+      padding: 0.55rem 0.65rem;
+      font: inherit;
+      font-size: 0.88rem;
+      outline: none;
+    }
+
+    .runtime-popover-select:focus {
+      border-color: var(--border-strong);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--border-strong) 32%, transparent);
+    }
+
+    .runtime-popover-select:disabled {
+      opacity: 0.65;
+    }
+
     @media (max-width: 540px) {
       .chip-popover-backdrop {
         background: rgba(0, 0, 0, 0.4);
@@ -1458,6 +1520,13 @@
         max-width: none;
         max-height: 60vh;
         font-size: 0.95rem;
+      }
+      .chip-popover-runtime {
+        padding: 0.9rem;
+      }
+      .runtime-popover-select {
+        font-size: 16px;
+        padding: 0.65rem 0.7rem;
       }
       .chip-popover-item {
         padding: 0.7rem 0.75rem;

--- a/internal/serveui/static/chip_picker_test.js
+++ b/internal/serveui/static/chip_picker_test.js
@@ -681,6 +681,70 @@ function testFilterInputHidesNonMatchingItems() {
   pass(name);
 }
 
+function collectNodes(root, predicate, out = []) {
+  if (!root) return out;
+  if (predicate(root)) out.push(root);
+  for (const child of root.children || []) collectNodes(child, predicate, out);
+  return out;
+}
+
+function testCompressedModelChipOpensRuntimeControls() {
+  const name = 'compressed model chip opens provider/model/effort controls';
+  const { app, elementMap, windowObj } = loadCoreAndStream();
+  app.updateHeader = () => app.updateSessionUsageDisplay(null);
+  app.state.selectedProvider = 'anthropic';
+  app.state.selectedModel = 'claude-sonnet-4.5';
+  app.state.selectedEffort = 'medium';
+
+  elementMap.chipProviderTrigger.closest = () => ({ nodeType: 1 });
+  windowObj.getComputedStyle = () => ({ display: 'none' });
+  elementMap.chipProviderSelect.options = [
+    makeOption('', 'Auto (server default)'),
+    makeOption('chatgpt', 'chatgpt (default)'),
+    makeOption('anthropic', 'anthropic'),
+  ];
+  elementMap.chipModelSelect.options = [
+    makeOption('', 'Auto (server default)'),
+    makeOption('claude-sonnet-4.5', 'claude-sonnet-4.5'),
+    makeOption('claude-opus-4.8', 'claude-opus-4.8'),
+  ];
+  elementMap.chipEffortSelect.options = [
+    makeOption('', 'Auto (server default)'),
+    makeOption('medium', 'medium'),
+    makeOption('high', 'high'),
+  ];
+
+  const triggerListeners = elementMap.chipModelTrigger.listeners?.click || [];
+  if (triggerListeners.length === 0) return fail(name, 'no click listener on model trigger');
+  triggerListeners[0]({ stopPropagation() {}, preventDefault() {} });
+
+  const popover = elementMap.chipPopover;
+  if (popover.hidden || !popover.classList.contains('chip-popover-runtime')) {
+    fail(name, 'expected runtime popover to open from compressed model chip');
+    return;
+  }
+
+  const selects = collectNodes(popover, (node) => node.tagName === 'SELECT');
+  if (selects.length !== 3) {
+    fail(name, `expected 3 runtime selects, got ${selects.length}`);
+    return;
+  }
+  if (selects[1].children[1]?.textContent !== 'sonnet 4.5') {
+    fail(name, `expected compact model option label, got ${JSON.stringify(selects[1].children[1]?.textContent)}`);
+    return;
+  }
+
+  selects[2].value = 'high';
+  const listeners = selects[2].listeners?.change || [];
+  if (listeners.length === 0) return fail(name, 'effort select missing change listener');
+  listeners[0]();
+  if (app.state.selectedEffort !== 'high') {
+    fail(name, `expected effort to update to high, got ${JSON.stringify(app.state.selectedEffort)}`);
+    return;
+  }
+  pass(name);
+}
+
 function testMobilePopoverUsesVisualViewportSafeBounds() {
   const name = 'mobile popover tracks the visual viewport so it stays above the iPhone keyboard';
   const vvListeners = { resize: [], scroll: [] };
@@ -743,6 +807,7 @@ async function main() {
   testPopoverHidesFilterInputBelowThreshold();
   testPopoverShowsFilterInputAboveThreshold();
   testFilterInputHidesNonMatchingItems();
+  testCompressedModelChipOpensRuntimeControls();
   testMobilePopoverUsesVisualViewportSafeBounds();
 
   if (failures > 0) {


### PR DESCRIPTION
## What

When the header collapses provider/model/effort down to the single compact model button, that button now expands into a runtime control panel with all three controls:

- Provider
- Model
- Effort

Wide layouts keep the existing individual chip popovers. The combined runtime panel only appears when the header is compressed and the provider/effort chips are hidden.

## Details

- Reuses the existing hidden header `<select>` state as the source of truth.
- Keeps model labels compact in the combined panel (`claude-sonnet-4.5` → `sonnet 4.5`, `claude-opus-4.8` → `opus 4.8`).
- Provider changes still reset/fetch model options through the existing `applyProviderChange` path.
- Model and effort changes commit through the same live header chip paths.
- Escape/backdrop closes the panel.

## Screenshots

| Case | Screenshot |
|---|---|
| 390 / compact runtime panel | ![390 runtime panel](/chat/images/compressed-runtime-control-390.png) |
| 390 / effort changed to high | ![390 effort high](/chat/images/compressed-runtime-control-effort-high-390.png) |
| 320 / compact runtime panel | ![320 runtime panel](/chat/images/compressed-runtime-control-320.png) |

## Verified

```text
go test ./cmd ./internal/serveui
go test ./...
go build -o /tmp/term-llm-runtime-control .
python3 /tmp/verify_compressed_runtime_control.py
```

Playwright verified that the compressed model button opens one panel containing exactly three controls and that changing effort in the expanded panel updates live state.
