### PR TITLE
fix: avoid focusing runtime select on open

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2544,7 +2544,8 @@ const openRuntimePopover = (triggerEl) => {
   if (elements.chipPopoverBackdrop) elements.chipPopoverBackdrop.hidden = false;
   pop.hidden = false;
   positionChipPopover(triggerEl);
-  pop.querySelector?.('.runtime-popover-select')?.focus?.({ preventScroll: true });
+  // Leave focus on the trigger. Focusing a native <select> here can open the OS
+  // picker immediately, making the runtime panel feel like dueling modals.
 };
 
 elements.chipPopoverBackdrop?.addEventListener('click', () => {

--- a/internal/serveui/static/chip_picker_test.js
+++ b/internal/serveui/static/chip_picker_test.js
@@ -146,6 +146,7 @@ function makeContext(options = {}) {
     createElement(tag) {
       const node = makeNode();
       node.tagName = tag.toUpperCase();
+      node.focus = () => { document.activeElement = node; };
       return node;
     },
     getElementById(id) {
@@ -690,7 +691,7 @@ function collectNodes(root, predicate, out = []) {
 
 function testCompressedModelChipOpensRuntimeControls() {
   const name = 'compressed model chip opens provider/model/effort controls';
-  const { app, elementMap, windowObj } = loadCoreAndStream();
+  const { app, elementMap, windowObj, ctx } = loadCoreAndStream();
   app.updateHeader = () => app.updateSessionUsageDisplay(null);
   app.state.selectedProvider = 'anthropic';
   app.state.selectedModel = 'claude-sonnet-4.5';
@@ -731,6 +732,10 @@ function testCompressedModelChipOpensRuntimeControls() {
   }
   if (selects[1].children[1]?.textContent !== 'sonnet 4.5') {
     fail(name, `expected compact model option label, got ${JSON.stringify(selects[1].children[1]?.textContent)}`);
+    return;
+  }
+  if (selects.includes(ctx.document.activeElement)) {
+    fail(name, 'runtime popover should not focus a native select on open');
     return;
   }
 


### PR DESCRIPTION
## What

- Stop auto-focusing the first runtime `<select>` when the compact Runtime panel opens.
- Leave focus on the model trigger so opening the panel does not immediately summon the browser/OS native select picker.
- Add a regression assertion around the compressed runtime panel so it still exposes provider/model/effort, but does not focus a native select on open.

## Why

On narrow layouts the compact model button opens the Runtime panel. Auto-focusing the first select made some browsers display the native select control immediately, which looked like a second modal and made the panel feel broken.

## Verification

```text
go test ./cmd ./internal/serveui
go test ./...
go build -o /tmp/term-llm-runtime-no-focus .
python3 /tmp/verify_runtime_popover_no_focus.py
```

Playwright checks at 390px and 320px confirmed:

```text
activeTag: BUTTON
activeId: chipModelTrigger
activeIsRuntimeSelect: false
runtimeSelects: 3
rowHeight: 33
```

Screenshots:

- 390px: `/chat/images/runtime-popover-no-focus-390.png`
- 320px: `/chat/images/runtime-popover-no-focus-320.png`
