### PR TITLE
fix: preserve display math blocks for KaTeX

### DIFF
--- a/internal/serveui/static/markdown-setup.js
+++ b/internal/serveui/static/markdown-setup.js
@@ -22,14 +22,44 @@
     gfm: true
   });
 
-  // KaTeX auto-render runs after markdown has produced sanitized HTML. Marked
-  // treats backslashes before punctuation as markdown escapes, which would turn
-  // explicit math delimiters like \(...\) and \[...\] into plain parentheses
-  // or brackets before KaTeX ever sees them. Preserve those spans as text here;
-  // KaTeX will render them in the later decoration pass. Single-dollar inline
-  // math intentionally remains disabled to avoid mangling currency in LLM prose.
+  // KaTeX auto-render runs after markdown has produced sanitized HTML.
+  //
+  // Marked's `breaks: true` is useful for chat prose, but it turns display math
+  // written in the common LLM shape
+  //
+  //   $$
+  //   \frac{1}{2}
+  //   $$
+  //
+  // into `$$<br>...<br>$$`. KaTeX auto-render scans text nodes, so those `<br>`
+  // elements split the delimiters and the user sees raw `\frac` soup. Preserve
+  // the whole display-math block as escaped text so KaTeX gets intact delimiters.
+  //
+  // Marked also treats backslashes before punctuation as markdown escapes, which
+  // would turn explicit math delimiters like \(...\) and \[...\] into plain
+  // parentheses or brackets before KaTeX ever sees them. Preserve those spans as
+  // text too. Single-dollar inline math intentionally remains disabled to avoid
+  // mangling currency in LLM prose.
   marked.use({
     extensions: [{
+      name: 'math-display-block',
+      level: 'block',
+      start(src) {
+        return src.indexOf('$$');
+      },
+      tokenizer(src) {
+        const match = /^\$\$[ \t]*\n[\s\S]*?\n[ \t]*\$\$(?=\n|$)/.exec(src);
+        if (!match) return false;
+        return {
+          type: 'math-display-block',
+          raw: match[0],
+          text: match[0]
+        };
+      },
+      renderer(token) {
+        return `<p>${escapeHtml(token.raw)}</p>\n`;
+      }
+    }, {
       name: 'math-delimiter-span',
       level: 'inline',
       start(src) {

--- a/internal/serveui/static/markdown_test.js
+++ b/internal/serveui/static/markdown_test.js
@@ -103,6 +103,12 @@ const cases = [
     contains: ['Cost is $100 and formula is $x + 1$.'],
     absent: ['katex'],
   },
+  {
+    name: 'display dollar math block survives markdown breaks',
+    input: '$$\n\\int e^{2x} \\, dx = \\frac{1}{2}e^{2x} + C\n$$',
+    contains: ['$$\n\\int e^{2x} \\, dx = \\frac{1}{2}e^{2x} + C\n$$'],
+    absent: ['<br>'],
+  },
 ];
 
 for (const tc of cases) {


### PR DESCRIPTION
## What

Fix display math blocks written as:

```text
$$
\frac{1}{2}
$$
```

so they survive markdown parsing intact for KaTeX auto-render.

## Why

Marked runs with `breaks: true`, which was converting multiline `$$ ... $$` blocks into HTML containing `<br>` elements before KaTeX saw them. KaTeX auto-render scans text nodes, so the inserted `<br>` nodes split the delimiters and left users seeing raw `\frac`/`$$` text instead of rendered math.

## Verification

- `go test ./internal/serveui ./cmd`
- Hotfixed Noa/Skrill and verified session 58 now renders KaTeX: `.katex-display` count went from `0` to `14`; raw `\frac` and `$$` disappeared from rendered page text.
