### PR TITLE
fix: animate file changes panel

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -329,6 +329,117 @@ const generateUUID = () => {
 };
 const generateId = (prefix) => `${prefix}_${generateUUID()}`;
 
+const PANEL_ANIMATION_FALLBACK_MS = 280;
+
+const setElementHidden = (element, hidden) => {
+  if (!element) return;
+  element.hidden = Boolean(hidden);
+  if (hidden) element.setAttribute?.('hidden', '');
+  else element.removeAttribute?.('hidden');
+};
+
+const nextFrame = (callback) => {
+  const raf = window.requestAnimationFrame || globalThis.requestAnimationFrame;
+  if (typeof raf === 'function') return raf.call(window, callback);
+  callback();
+  return 0;
+};
+
+const clearNextFrame = (id) => {
+  const cancel = window.cancelAnimationFrame || globalThis.cancelAnimationFrame;
+  if (id && typeof cancel === 'function') cancel.call(window, id);
+};
+
+const normalizePanelClassTargets = (panel, targets, fallbackClass) => {
+  const input = Array.isArray(targets) && targets.length > 0
+    ? targets
+    : [{ element: panel, className: fallbackClass }];
+  return input
+    .map((target) => ({
+      element: target?.element || target?.target || target,
+      className: target?.className || fallbackClass
+    }))
+    .filter((target) => target.element && target.className);
+};
+
+// Shared drawer/panel transition helper. Elements that start as `hidden` need a
+// paint at their closed transform/column before the open class is applied;
+// otherwise the browser sees only the final state and the slide-in animation is
+// skipped. Closing waits for the transition before restoring `hidden`.
+const setAnimatedPanelOpen = ({
+  panel,
+  open,
+  openClass = 'open',
+  hiddenWhenClosed = false,
+  classTargets = null,
+  transitionElement = null,
+  onOpened = null,
+  onClosed = null
+} = {}) => {
+  if (!panel) return;
+  const targets = normalizePanelClassTargets(panel, classTargets, openClass);
+  const token = Symbol('panel-animation');
+  panel._termLLMPanelAnimationToken = token;
+  if (panel._termLLMPanelAnimationFrame) {
+    clearNextFrame(panel._termLLMPanelAnimationFrame);
+    panel._termLLMPanelAnimationFrame = 0;
+  }
+  if (panel._termLLMPanelAnimationTimer) {
+    clearTimeout(panel._termLLMPanelAnimationTimer);
+    panel._termLLMPanelAnimationTimer = 0;
+  }
+
+  const toggleClasses = (enabled) => {
+    targets.forEach((target) => target.element.classList?.toggle?.(target.className, enabled));
+  };
+
+  if (open) {
+    if (hiddenWhenClosed) setElementHidden(panel, false);
+    // Force a style read after un-hiding so the closed state becomes the
+    // animation starting point before the next frame applies the open class.
+    try { void panel.offsetWidth; } catch (_) { /* non-browser test doubles */ }
+    const applyOpen = () => {
+      panel._termLLMPanelAnimationFrame = 0;
+      if (panel._termLLMPanelAnimationToken !== token) return;
+      toggleClasses(true);
+      if (typeof onOpened === 'function') onOpened();
+    };
+    panel._termLLMPanelAnimationFrame = nextFrame(applyOpen);
+    return;
+  }
+
+  toggleClasses(false);
+  if (!hiddenWhenClosed) {
+    if (typeof onClosed === 'function') onClosed();
+    return;
+  }
+
+  const finish = () => {
+    if (panel._termLLMPanelAnimationToken !== token) return;
+    panel._termLLMPanelAnimationTimer = 0;
+    setElementHidden(panel, true);
+    if (typeof onClosed === 'function') onClosed();
+  };
+  const node = transitionElement || targets[0]?.element || panel;
+  let done = false;
+  const finishOnce = () => {
+    if (done) return;
+    done = true;
+    node?.removeEventListener?.('transitionend', onTransitionEnd);
+    if (panel._termLLMPanelAnimationTimer) {
+      clearTimeout(panel._termLLMPanelAnimationTimer);
+      panel._termLLMPanelAnimationTimer = 0;
+    }
+    finish();
+  };
+  function onTransitionEnd(event) {
+    if (event?.target && event.target !== node) return;
+    finishOnce();
+  }
+  node?.addEventListener?.('transitionend', onTransitionEnd);
+  panel._termLLMPanelAnimationTimer = setTimeout(finishOnce, PANEL_ANIMATION_FALLBACK_MS);
+};
+
 const INTERRUPT_BADGE_META = {
   evaluating: { className: 'pending', label: 'evaluating…' },
   pending_interject: { className: 'pending', icon: '⏳', label: 'will incorporate' },
@@ -1525,6 +1636,8 @@ Object.assign(app, {
   INTERJECTION_PHASE,
   sanitizeInterruptState,
   syncTokenCookie,
+  setAnimatedPanelOpen,
+  setElementHidden,
   truncate,
   asTimestamp,
   fullDate,

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -7,7 +7,14 @@
 // Files render as an accordion: each one expands inline where it sits in the
 // list and can be collapsed individually.
 const app = window.TermLLMApp || (window.TermLLMApp = {});
-const { state, elements, STORAGE_KEYS, UI_PREFIX } = app;
+const {
+  state,
+  elements,
+  STORAGE_KEYS,
+  UI_PREFIX,
+  setAnimatedPanelOpen: setPanelOpen,
+  setElementHidden: setPanelHidden
+} = app;
 
 const DIFF_REFRESH_DEBOUNCE_MS = 350;
 const DIFF_RENDER_DEBOUNCE_MS = 80;
@@ -275,24 +282,36 @@ const applyDiffSidebarVisibility = (ds) => {
   const hasChanges = ds && ds.files.size > 0;
   const drawer = isDiffDrawerViewport();
   const visible = hasChanges && !ds.hidden && !drawer;
+  const drawerOpen = Boolean(hasChanges && drawer && elements.diffSidebar?.classList.contains('open'));
 
   if (elements.diffSidebar) {
-    if (visible || (drawer && elements.diffSidebar.classList.contains('open') && hasChanges)) {
-      elements.diffSidebar.removeAttribute?.('hidden');
-      elements.diffSidebar.hidden = false;
+    if (!hasChanges) {
+      elements.diffSidebar.classList.remove('open');
+      elements.appShell?.classList.remove('diff-open');
+      setPanelHidden(elements.diffSidebar, true);
+    } else if (drawer) {
+      elements.appShell?.classList.remove('diff-open');
+      if (drawerOpen) setPanelHidden(elements.diffSidebar, false);
+      else setPanelHidden(elements.diffSidebar, true);
     } else {
-      elements.diffSidebar.setAttribute?.('hidden', '');
-      elements.diffSidebar.hidden = true;
+      elements.diffSidebar.classList.remove('open');
+      setPanelOpen({
+        panel: elements.diffSidebar,
+        open: visible,
+        hiddenWhenClosed: true,
+        classTargets: [{ element: elements.appShell, className: 'diff-open' }],
+        transitionElement: elements.appShell
+      });
     }
-    if (!drawer || !hasChanges) elements.diffSidebar.classList.remove('open');
+  } else {
+    elements.appShell?.classList.toggle('diff-open', visible);
   }
-  elements.appShell?.classList.toggle('diff-open', visible);
 
   if (elements.diffToggleBtn) {
     elements.diffToggleBtn.hidden = !hasChanges;
     if (hasChanges) elements.diffToggleBtn.removeAttribute?.('hidden');
     else elements.diffToggleBtn.setAttribute?.('hidden', '');
-    elements.diffToggleBtn.classList.toggle('active', visible || (drawer && elements.diffSidebar?.classList.contains('open')));
+    elements.diffToggleBtn.classList.toggle('active', visible || drawerOpen);
   }
 };
 
@@ -496,6 +515,15 @@ const scrollFileIntoView = (path) => {
   }
 };
 
+const renderDiffSidebarContent = (sessionId, ds) => {
+  renderDiffTotals(ds);
+  renderDiffAccordion(sessionId, ds);
+  if (ds.pendingScrollPath) {
+    scrollFileIntoView(ds.pendingScrollPath);
+    ds.pendingScrollPath = '';
+  }
+};
+
 const renderDiffSidebar = (sessionId) => {
   if (sessionId !== state.activeSessionId) return;
   const ds = sessionDiffState(sessionId);
@@ -542,33 +570,45 @@ const setDiffSidebarHidden = (hidden) => {
 };
 
 const toggleDiffSidebar = () => {
+  const sessionId = state.activeSessionId;
+  const ds = sessionId ? sessionDiffState(sessionId) : null;
+  if (!sessionId || !ds) return;
+
   if (isDiffDrawerViewport()) {
     const open = !elements.diffSidebar?.classList.contains('open');
-    const ds = state.activeSessionId ? sessionDiffState(state.activeSessionId) : null;
     if (open) {
-      if (ds) ds.hidden = false;
-      elements.diffSidebar?.removeAttribute?.('hidden');
-      if (elements.diffSidebar) elements.diffSidebar.hidden = false;
-      elements.diffSidebar?.classList.add('open');
-      // The closed drawer skips panel rendering; populate it now.
-      renderDiffSidebar(state.activeSessionId);
-      scheduleDiffRefresh(state.activeSessionId);
+      ds.hidden = false;
+      setPanelOpen({
+        panel: elements.diffSidebar,
+        open: true,
+        hiddenWhenClosed: true,
+        classTargets: [{ element: elements.diffSidebar, className: 'open' }],
+        transitionElement: elements.diffSidebar
+      });
+      elements.appShell?.classList.remove('diff-open');
+      elements.diffToggleBtn?.classList.toggle('active', true);
+      renderDiffSidebarContent(sessionId, ds);
+      scheduleDiffRefresh(sessionId);
     } else {
       closeDiffDrawer();
     }
     return;
   }
-  const ds = state.activeSessionId ? sessionDiffState(state.activeSessionId) : null;
-  setDiffSidebarHidden(!ds?.hidden);
+  setDiffSidebarHidden(!ds.hidden);
 };
 
 const closeDiffDrawer = () => {
-  elements.diffSidebar?.classList.remove('open');
+  setPanelOpen({
+    panel: elements.diffSidebar,
+    open: false,
+    hiddenWhenClosed: true,
+    classTargets: [{ element: elements.diffSidebar, className: 'open' }],
+    transitionElement: elements.diffSidebar
+  });
+  elements.diffToggleBtn?.classList.toggle('active', false);
+  elements.appShell?.classList.remove('diff-open');
   const ds = diffStateBySession.get(state.activeSessionId);
-  if (ds) {
-    ds.hidden = true;
-    applyDiffSidebarVisibility(ds);
-  }
+  if (ds) ds.hidden = true;
 };
 
 // ===== Session lifecycle =====

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -5,7 +5,8 @@ const app = window.TermLLMApp;
 const {
   STORAGE_KEYS, state, elements, INTERRUPT_BADGE_META, sanitizeInterruptState, relativeTime, fullDate, sessionBucket, toolIcon, formatUsage,
   saveSessions, findMessageElement, scrollToBottom, refreshRelativeTimes, ensureActiveSession, updateDocumentTitle,
-  updateSessionUsageDisplay, renderMath, visibleSessions, sessionHasInProgressState, setSessionServerActiveRun
+  updateSessionUsageDisplay, renderMath, visibleSessions, sessionHasInProgressState, setSessionServerActiveRun,
+  setAnimatedPanelOpen
 } = app;
 
 const isMobileViewport = () => window.matchMedia('(max-width: 767px)').matches;
@@ -37,13 +38,25 @@ const applyTextDirection = (element, value) => {
 };
 
 const openSidebar = () => {
-  elements.sidebar.classList.add('open');
-  elements.sidebarBackdrop.classList.add('open');
+  setAnimatedPanelOpen?.({
+    panel: elements.sidebar,
+    open: true,
+    classTargets: [
+      { element: elements.sidebar, className: 'open' },
+      { element: elements.sidebarBackdrop, className: 'open' }
+    ]
+  });
 };
 
 const closeSidebar = () => {
-  elements.sidebar.classList.remove('open');
-  elements.sidebarBackdrop.classList.remove('open');
+  setAnimatedPanelOpen?.({
+    panel: elements.sidebar,
+    open: false,
+    classTargets: [
+      { element: elements.sidebar, className: 'open' },
+      { element: elements.sidebarBackdrop, className: 'open' }
+    ]
+  });
 };
 
 const closeSidebarIfMobile = () => {

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -35,6 +35,10 @@
       --sidebar-width: 280px;
       --sidebar-rail-width: 56px;
       --diff-sidebar-width: clamp(300px, 28vw, 460px);
+      --layout-transition-duration: 0.2s;
+      --panel-transition-duration: 0.22s;
+      --panel-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
+      --panel-fade-duration: 0.18s;
       --diff-add-bg: rgba(46, 160, 67, 0.18);
       --diff-add-ln-bg: rgba(46, 160, 67, 0.30);
       --diff-del-bg: rgba(248, 81, 73, 0.16);
@@ -203,7 +207,7 @@
 
     .app {
       display: grid;
-      grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+      grid-template-columns: var(--sidebar-width) minmax(0, 1fr) 0px;
       min-height: var(--app-height);
       height: var(--app-height);
       width: 100%;
@@ -214,11 +218,11 @@
       right: 0;
       z-index: 1;
       overflow: hidden;
-      transition: grid-template-columns 0.2s ease;
+      transition: grid-template-columns var(--layout-transition-duration) ease;
     }
 
     .app.sidebar-collapsed {
-      grid-template-columns: var(--sidebar-rail-width) minmax(0, 1fr);
+      grid-template-columns: var(--sidebar-rail-width) minmax(0, 1fr) 0px;
     }
 
     .app.diff-open {
@@ -247,6 +251,15 @@
       min-width: 0;
       overflow: hidden;
       padding-right: var(--safe-right);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity var(--panel-fade-duration) ease;
+    }
+
+    .app.diff-open .diff-sidebar,
+    .diff-sidebar.open {
+      opacity: 1;
+      pointer-events: auto;
     }
 
     .diff-resize-handle {
@@ -564,11 +577,11 @@
     @media (max-width: 1099px) {
       .app.diff-open,
       .app.sidebar-collapsed.diff-open {
-        grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+        grid-template-columns: var(--sidebar-width) minmax(0, 1fr) 0px;
       }
 
       .app.sidebar-collapsed.diff-open {
-        grid-template-columns: var(--sidebar-rail-width) minmax(0, 1fr);
+        grid-template-columns: var(--sidebar-rail-width) minmax(0, 1fr) 0px;
       }
 
       .diff-sidebar {
@@ -580,7 +593,8 @@
         width: min(440px, calc(100vw - var(--safe-left)), 90vw);
         z-index: 60;
         transform: translateX(100%);
-        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: transform var(--panel-transition-duration) var(--panel-transition-easing),
+                    opacity var(--panel-fade-duration) ease;
         box-shadow: none;
         padding: var(--safe-top) var(--safe-right) var(--safe-bottom) 0;
         touch-action: pan-y;
@@ -646,7 +660,7 @@
       z-index: 1;
       opacity: 0;
       pointer-events: none;
-      transition: opacity 0.15s ease;
+      transition: opacity var(--panel-fade-duration) ease;
     }
 
     .sidebar-rail-btn {
@@ -660,7 +674,7 @@
       display: flex;
       flex-direction: column;
       flex: 1;
-      transition: opacity 0.15s ease;
+      transition: opacity var(--panel-fade-duration) ease;
     }
 
     .app.sidebar-collapsed .sidebar-rail {
@@ -2684,7 +2698,7 @@
       background: var(--backdrop);
       opacity: 0;
       pointer-events: none;
-      transition: opacity 0.18s ease;
+      transition: opacity var(--panel-fade-duration) ease;
       z-index: 15;
     }
 
@@ -3334,7 +3348,7 @@
         display: flex;
         flex-direction: column;
         transform: translateX(-100%);
-        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.22s;
+        transition: transform var(--panel-transition-duration) var(--panel-transition-easing), visibility 0s linear var(--panel-transition-duration);
         box-shadow: none;
         padding-bottom: var(--safe-bottom);
         visibility: hidden;
@@ -3362,7 +3376,7 @@
         box-shadow: 4px 0 20px rgba(0, 0, 0, 0.28);
         visibility: visible;
         pointer-events: auto;
-        transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0s;
+        transition: transform var(--panel-transition-duration) var(--panel-transition-easing), visibility 0s linear 0s;
       }
 
       .sidebar-close {

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -165,7 +165,22 @@ function createHarness(options = {}) {
     UI_PREFIX: '/chat',
     STORAGE_KEYS: { diffSidebarWidth: 'term_llm_diff_sidebar_width' },
     state,
-    elements
+    elements,
+    setElementHidden(element, hidden) {
+      if (!element) return;
+      element.hidden = Boolean(hidden);
+      if (hidden) element.setAttribute?.('hidden', '');
+      else element.removeAttribute?.('hidden');
+    },
+    setAnimatedPanelOpen({ panel, open, openClass = 'open', hiddenWhenClosed = false, classTargets = null } = {}) {
+      if (!panel) return;
+      const targets = Array.isArray(classTargets) && classTargets.length > 0
+        ? classTargets
+        : [{ element: panel, className: openClass }];
+      if (open && hiddenWhenClosed) app.setElementHidden(panel, false);
+      targets.forEach((target) => target.element?.classList?.toggle?.(target.className || openClass, Boolean(open)));
+      if (!open && hiddenWhenClosed) app.setElementHidden(panel, true);
+    }
   };
 
   const document = new Element('document');


### PR DESCRIPTION
## What

- Centralizes panel open/close animation handling in `app-core.js` so hidden panels get a paint at their closed state before the open class is applied.
- Adds a shared swipe-to-close gesture helper for side panels:
  - panel follows the finger during horizontal touch/pointer moves
  - vertical scroll intent is ignored
  - close commits by distance threshold or fling velocity
  - slight resistance is applied when dragging the wrong way
- Uses the shared helpers for both the mobile session sidebar and the file changes panel.
- Changes the desktop app grid to always have a zero-width diff track, so opening the file changes list animates the track width instead of jumping from 2 columns to 3.
- Reuses the sidebar drawer timing/easing variables for the file changes drawer and related panel fades.

## Why

Opening the edit/file changes list removed `hidden` and applied the open state in the same frame. The browser skipped the transition and rendered the final state immediately. The sidebar did not have that problem because it was already in layout at its closed transform.

For touch gestures, the nice-feeling pattern is: lock only after horizontal intent wins, keep the surface anchored to the finger, avoid hijacking vertical scroll, then commit on a threshold or fling. That is now shared instead of being bespoke diff-sidebar logic.

## Tests

- `for f in internal/serveui/static/*_test.js; do mise x node@24 -- node "$f" || exit 1; done`
- `go build ./...`
- `go test ./...`
