### PR TITLE
feat: add swipe-to-close panel gestures

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -440,6 +440,170 @@ const setAnimatedPanelOpen = ({
   panel._termLLMPanelAnimationTimer = setTimeout(finishOnce, PANEL_ANIMATION_FALLBACK_MS);
 };
 
+const PANEL_SWIPE_INTENT_PX = 8;
+const PANEL_SWIPE_VERTICAL_CANCEL_RATIO = 1.15;
+const PANEL_SWIPE_CLOSE_RATIO = 0.28;
+const PANEL_SWIPE_CLOSE_MIN_PX = 70;
+const PANEL_SWIPE_CLOSE_MAX_PX = 140;
+const PANEL_SWIPE_FLING_PX_PER_MS = 0.65;
+const PANEL_SWIPE_RESISTANCE = 0.25;
+const PANEL_SWIPE_MAX_OVERSHOOT_PX = 32;
+const PANEL_SWIPE_OFFSET_VAR = '--panel-swipe-offset-x';
+const PANEL_SWIPE_DRAG_CLASS = 'panel-swipe-dragging';
+
+const panelSwipePoint = (event) => ({
+  x: Number(event?.clientX) || 0,
+  y: Number(event?.clientY) || 0
+});
+
+const panelSwipeWidth = (panel) => {
+  const rectWidth = Number(panel?.getBoundingClientRect?.().width) || 0;
+  const offsetWidth = Number(panel?.offsetWidth) || 0;
+  return Math.max(1, rectWidth || offsetWidth || 280);
+};
+
+const panelSwipeThreshold = (panel, minPx, maxPx, ratio) => {
+  const width = panelSwipeWidth(panel);
+  return Math.min(maxPx, Math.max(minPx, width * ratio));
+};
+
+// Installs a drag-to-dismiss gesture for side panels. The panel tracks the
+// finger while the gesture is active, locks only after horizontal intent wins,
+// and commits on either distance or fling velocity. Vertical scrolling inside
+// the panel is left alone so the surface feels attached to the finger without
+// stealing ordinary scrolling.
+const initPanelSwipeToClose = ({
+  panel,
+  side = 'left',
+  isEnabled = () => true,
+  isOpen = () => panel?.classList?.contains?.('open'),
+  shouldIgnoreTarget = null,
+  onClose = null,
+  offsetVar = PANEL_SWIPE_OFFSET_VAR,
+  dragClass = PANEL_SWIPE_DRAG_CLASS,
+  intentPx = PANEL_SWIPE_INTENT_PX,
+  verticalCancelRatio = PANEL_SWIPE_VERTICAL_CANCEL_RATIO,
+  closeRatio = PANEL_SWIPE_CLOSE_RATIO,
+  closeMinPx = PANEL_SWIPE_CLOSE_MIN_PX,
+  closeMaxPx = PANEL_SWIPE_CLOSE_MAX_PX,
+  flingPxPerMs = PANEL_SWIPE_FLING_PX_PER_MS,
+  resistance = PANEL_SWIPE_RESISTANCE,
+  maxOvershootPx = PANEL_SWIPE_MAX_OVERSHOOT_PX
+} = {}) => {
+  if (!panel?.addEventListener) return () => {};
+  const direction = side === 'right' ? 1 : -1;
+  let gesture = null;
+
+  const matchesPointer = (event) => !gesture || event?.pointerId === undefined || gesture.pointerId === undefined || event.pointerId === gesture.pointerId;
+  const closeDeltaFor = (event) => (panelSwipePoint(event).x - gesture.startX) * direction;
+
+  const resetGesture = (event) => {
+    if (gesture?.dragging) panel.classList?.remove?.(dragClass);
+    try {
+      if (gesture?.pointerId !== undefined) panel.releasePointerCapture?.(gesture.pointerId);
+      if (event?.pointerId !== undefined && event.pointerId !== gesture?.pointerId) panel.releasePointerCapture?.(event.pointerId);
+    } catch (_) {
+      // Pointer capture may already be gone after browser cancellation.
+    }
+    gesture = null;
+  };
+
+  const setDragOffset = (closeDelta) => {
+    let distance = closeDelta;
+    if (distance < 0) distance = Math.max(distance * resistance, -maxOvershootPx);
+    else distance = Math.min(distance, panelSwipeWidth(panel));
+    panel.style?.setProperty?.(offsetVar, `${direction * distance}px`);
+  };
+
+  const updateVelocity = (event) => {
+    const now = Date.now();
+    const closeDelta = closeDeltaFor(event);
+    const elapsed = Math.max(1, now - gesture.lastAt);
+    gesture.velocity = (closeDelta - gesture.lastCloseDelta) / elapsed;
+    gesture.lastCloseDelta = closeDelta;
+    gesture.lastAt = now;
+    return closeDelta;
+  };
+
+  const onPointerDown = (event) => {
+    if (event?.button !== undefined && event.button !== 0) return;
+    if (event?.isPrimary === false) return;
+    if (typeof isEnabled === 'function' && !isEnabled()) return;
+    if (typeof isOpen === 'function' && !isOpen()) return;
+    if (typeof shouldIgnoreTarget === 'function' && shouldIgnoreTarget(event.target)) return;
+    const point = panelSwipePoint(event);
+    gesture = {
+      pointerId: event.pointerId,
+      startX: point.x,
+      startY: point.y,
+      lastCloseDelta: 0,
+      lastAt: Date.now(),
+      velocity: 0,
+      dragging: false
+    };
+  };
+
+  const onPointerMove = (event) => {
+    if (!gesture || !matchesPointer(event)) return;
+    const point = panelSwipePoint(event);
+    const dx = point.x - gesture.startX;
+    const dy = point.y - gesture.startY;
+    const closeDelta = dx * direction;
+
+    if (!gesture.dragging) {
+      const absX = Math.abs(dx);
+      const absY = Math.abs(dy);
+      if (absX < intentPx && absY < intentPx) return;
+      if (absY > absX * verticalCancelRatio || closeDelta <= 0) {
+        resetGesture(event);
+        return;
+      }
+      gesture.dragging = true;
+      panel.classList?.add?.(dragClass);
+      try { panel.setPointerCapture?.(event.pointerId); } catch (_) { /* pointer may be synthetic in tests */ }
+    }
+
+    event.preventDefault?.();
+    setDragOffset(updateVelocity(event));
+  };
+
+  const onPointerEnd = (event) => {
+    if (!gesture || !matchesPointer(event)) return;
+    if (!gesture.dragging) {
+      resetGesture(event);
+      return;
+    }
+    event.preventDefault?.();
+    const closeDelta = updateVelocity(event);
+    const shouldClose = Math.max(closeDelta, 0) >= panelSwipeThreshold(panel, closeMinPx, closeMaxPx, closeRatio)
+      || gesture.velocity >= flingPxPerMs;
+
+    panel.classList?.remove?.(dragClass);
+    try { void panel.offsetWidth; } catch (_) { /* non-browser test doubles */ }
+    if (shouldClose && typeof onClose === 'function') onClose(event);
+    panel.style?.removeProperty?.(offsetVar);
+    resetGesture(event);
+  };
+
+  const onPointerCancel = (event) => {
+    if (!gesture || !matchesPointer(event)) return;
+    panel.style?.removeProperty?.(offsetVar);
+    resetGesture(event);
+  };
+
+  panel.addEventListener('pointerdown', onPointerDown);
+  panel.addEventListener('pointermove', onPointerMove);
+  panel.addEventListener('pointerup', onPointerEnd);
+  panel.addEventListener('pointercancel', onPointerCancel);
+
+  return () => {
+    panel.removeEventListener?.('pointerdown', onPointerDown);
+    panel.removeEventListener?.('pointermove', onPointerMove);
+    panel.removeEventListener?.('pointerup', onPointerEnd);
+    panel.removeEventListener?.('pointercancel', onPointerCancel);
+  };
+};
+
 const INTERRUPT_BADGE_META = {
   evaluating: { className: 'pending', label: 'evaluating…' },
   pending_interject: { className: 'pending', icon: '⏳', label: 'will incorporate' },
@@ -1638,6 +1802,7 @@ Object.assign(app, {
   syncTokenCookie,
   setAnimatedPanelOpen,
   setElementHidden,
+  initPanelSwipeToClose,
   truncate,
   asTimestamp,
   fullDate,

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -13,7 +13,8 @@ const {
   STORAGE_KEYS,
   UI_PREFIX,
   setAnimatedPanelOpen: setPanelOpen,
-  setElementHidden: setPanelHidden
+  setElementHidden: setPanelHidden,
+  initPanelSwipeToClose
 } = app;
 
 const DIFF_REFRESH_DEBOUNCE_MS = 350;
@@ -724,31 +725,13 @@ const isInsideDiffResizeHandle = (target) => {
 const initDiffCloseGesture = () => {
   const panel = elements.diffSidebar;
   if (!panel?.addEventListener) return;
-  let startX = 0;
-  let startY = 0;
-  let tracking = false;
-
-  panel.addEventListener('pointerdown', (event) => {
-    if (!isDiffDrawerViewport()) return;
-    if (!panel.classList.contains('open')) return;
-    if (isInsideDiffResizeHandle(event.target)) return;
-    startX = Number(event.clientX) || 0;
-    startY = Number(event.clientY) || 0;
-    tracking = true;
-  });
-
-  panel.addEventListener('pointerup', (event) => {
-    if (!tracking) return;
-    tracking = false;
-    const dx = (Number(event.clientX) || 0) - startX;
-    const dy = Math.abs((Number(event.clientY) || 0) - startY);
-    // Right-side drawer: a decisive rightward swipe closes it. Keep the
-    // threshold high enough that ordinary vertical diff scrolling is ignored.
-    if (dx > 70 && dx > dy * 1.4) closeDiffDrawer();
-  });
-
-  panel.addEventListener('pointercancel', () => {
-    tracking = false;
+  initPanelSwipeToClose?.({
+    panel,
+    side: 'right',
+    isEnabled: isDiffDrawerViewport,
+    isOpen: () => panel.classList.contains('open'),
+    shouldIgnoreTarget: isInsideDiffResizeHandle,
+    onClose: closeDiffDrawer
   });
 };
 

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -6,7 +6,7 @@ const {
   STORAGE_KEYS, state, elements, INTERRUPT_BADGE_META, sanitizeInterruptState, relativeTime, fullDate, sessionBucket, toolIcon, formatUsage,
   saveSessions, findMessageElement, scrollToBottom, refreshRelativeTimes, ensureActiveSession, updateDocumentTitle,
   updateSessionUsageDisplay, renderMath, visibleSessions, sessionHasInProgressState, setSessionServerActiveRun,
-  setAnimatedPanelOpen
+  setAnimatedPanelOpen, initPanelSwipeToClose
 } = app;
 
 const isMobileViewport = () => window.matchMedia('(max-width: 767px)').matches;
@@ -64,6 +64,14 @@ const closeSidebarIfMobile = () => {
     closeSidebar();
   }
 };
+
+initPanelSwipeToClose?.({
+  panel: elements.sidebar,
+  side: 'left',
+  isEnabled: isMobileViewport,
+  isOpen: () => elements.sidebar?.classList.contains('open'),
+  onClose: closeSidebar
+});
 
 const applySidebarToggleButtonState = () => {
   const expanded = !state.sidebarCollapsed;

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -262,6 +262,12 @@
       pointer-events: auto;
     }
 
+    .panel-swipe-dragging {
+      transition: none !important;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
     .diff-resize-handle {
       position: absolute;
       left: 0;
@@ -628,7 +634,7 @@
       }
 
       .diff-sidebar.open {
-        transform: translateX(0);
+        transform: translateX(var(--panel-swipe-offset-x, 0px));
         box-shadow: -4px 0 20px rgba(0, 0, 0, 0.28);
       }
     }
@@ -3353,6 +3359,7 @@
         padding-bottom: var(--safe-bottom);
         visibility: hidden;
         pointer-events: none;
+        touch-action: pan-y;
       }
 
       .sidebar-rail {
@@ -3372,7 +3379,7 @@
       }
 
       .sidebar.open {
-        transform: translateX(0);
+        transform: translateX(var(--panel-swipe-offset-x, 0px));
         box-shadow: 4px 0 20px rgba(0, 0, 0, 0.28);
         visibility: visible;
         pointer-events: auto;

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -743,6 +743,123 @@ const app = loadAppCore();
   pass(name);
 })();
 
+function makeSwipePanel(width = 320) {
+  const listeners = new Map();
+  const styleValues = new Map();
+  const classes = new Set();
+  const syncClassName = (panel) => { panel.className = Array.from(classes).join(' '); };
+  const panel = {
+    className: '',
+    offsetWidth: width,
+    style: {
+      setProperty(name, value) { styleValues.set(String(name), String(value)); },
+      removeProperty(name) { const value = styleValues.get(String(name)) || ''; styleValues.delete(String(name)); return value; },
+      getPropertyValue(name) { return styleValues.get(String(name)) || ''; },
+    },
+    classList: {
+      add(...tokens) { tokens.forEach((token) => classes.add(token)); syncClassName(panel); },
+      remove(...tokens) { tokens.forEach((token) => classes.delete(token)); syncClassName(panel); },
+      contains(token) { return classes.has(token); },
+      toggle(token, force) {
+        const enabled = force === undefined ? !classes.has(token) : Boolean(force);
+        if (enabled) classes.add(token); else classes.delete(token);
+        syncClassName(panel);
+        return enabled;
+      },
+    },
+    addEventListener(type, listener) {
+      const list = listeners.get(type) || [];
+      list.push(listener);
+      listeners.set(type, list);
+    },
+    removeEventListener(type, listener) {
+      const list = listeners.get(type) || [];
+      const idx = list.indexOf(listener);
+      if (idx !== -1) list.splice(idx, 1);
+      listeners.set(type, list);
+    },
+    dispatchEvent(event) {
+      const evt = { target: panel, button: 0, isPrimary: true, preventDefault() { this.defaultPrevented = true; }, ...event };
+      (listeners.get(evt.type) || []).slice().forEach((listener) => listener(evt));
+      return evt;
+    },
+    getBoundingClientRect() { return { width, height: 600, top: 0, left: 0, right: width, bottom: 600 }; },
+    setPointerCapture() {},
+    releasePointerCapture() {},
+  };
+  return panel;
+}
+
+(function testPanelSwipeToCloseTracksLeftPanelAndCommits() {
+  const name = 'initPanelSwipeToClose tracks a left panel and commits on touch move';
+  const testApp = loadAppCore();
+  const panel = makeSwipePanel(320);
+  let closed = 0;
+  testApp.initPanelSwipeToClose({
+    panel,
+    side: 'left',
+    isEnabled: () => true,
+    isOpen: () => true,
+    onClose: () => { closed += 1; },
+  });
+
+  panel.dispatchEvent({ type: 'pointerdown', pointerId: 1, clientX: 220, clientY: 20 });
+  const move = panel.dispatchEvent({ type: 'pointermove', pointerId: 1, clientX: 130, clientY: 24 });
+  if (!move.defaultPrevented) {
+    fail(name, 'dragging move should prevent the browser horizontal pan');
+    return;
+  }
+  if (panel.style.getPropertyValue('--panel-swipe-offset-x') !== '-90px') {
+    fail(name, `expected panel to follow finger at -90px, got ${panel.style.getPropertyValue('--panel-swipe-offset-x')}`);
+    return;
+  }
+  if (!panel.classList.contains('panel-swipe-dragging')) {
+    fail(name, 'drag class should be present while moving');
+    return;
+  }
+  panel.dispatchEvent({ type: 'pointerup', pointerId: 1, clientX: 120, clientY: 24 });
+  if (closed !== 1) {
+    fail(name, `expected close callback once, got ${closed}`);
+    return;
+  }
+  if (panel.style.getPropertyValue('--panel-swipe-offset-x')) {
+    fail(name, 'drag offset should be cleared after release');
+    return;
+  }
+  pass(name);
+})();
+
+(function testPanelSwipeToCloseIgnoresVerticalScrollIntent() {
+  const name = 'initPanelSwipeToClose leaves vertical scrolling alone';
+  const testApp = loadAppCore();
+  const panel = makeSwipePanel(320);
+  let closed = 0;
+  testApp.initPanelSwipeToClose({
+    panel,
+    side: 'right',
+    isEnabled: () => true,
+    isOpen: () => true,
+    onClose: () => { closed += 1; },
+  });
+
+  panel.dispatchEvent({ type: 'pointerdown', pointerId: 1, clientX: 120, clientY: 20 });
+  const move = panel.dispatchEvent({ type: 'pointermove', pointerId: 1, clientX: 145, clientY: 120 });
+  panel.dispatchEvent({ type: 'pointerup', pointerId: 1, clientX: 180, clientY: 160 });
+  if (move.defaultPrevented) {
+    fail(name, 'vertical intent should not be prevented');
+    return;
+  }
+  if (closed !== 0) {
+    fail(name, `vertical scroll should not close, got ${closed}`);
+    return;
+  }
+  if (panel.classList.contains('panel-swipe-dragging')) {
+    fail(name, 'vertical scroll should not enter drag mode');
+    return;
+  }
+  pass(name);
+})();
+
 if (failures > 0) {
   process.exit(1);
 }

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -42,6 +42,13 @@ class ClassList {
   }
 }
 
+class StyleDecl {
+  constructor() { this.values = new Map(); }
+  setProperty(name, value) { this.values.set(String(name), String(value)); }
+  removeProperty(name) { const value = this.values.get(String(name)) || ''; this.values.delete(String(name)); return value; }
+  getPropertyValue(name) { return this.values.get(String(name)) || ''; }
+}
+
 class Element {
   constructor(tagName) {
     this.tagName = String(tagName || '').toUpperCase();
@@ -51,7 +58,7 @@ class Element {
     this.attributes = new Map();
     this.className = '';
     this.classList = new ClassList(this);
-    this.style = {};
+    this.style = new StyleDecl();
     this.listeners = new Map();
     this.textContent = '';
     this.value = '';
@@ -102,6 +109,9 @@ class Element {
     return results;
   }
   querySelector(selector) { return this.querySelectorAll(selector)[0] || null; }
+  getBoundingClientRect() { return { width: 320, height: 600, top: 0, left: 0, right: 320, bottom: 600 }; }
+  setPointerCapture() {}
+  releasePointerCapture() {}
 }
 
 function createHarness(options = {}) {
@@ -180,6 +190,45 @@ function createHarness(options = {}) {
       if (open && hiddenWhenClosed) app.setElementHidden(panel, false);
       targets.forEach((target) => target.element?.classList?.toggle?.(target.className || openClass, Boolean(open)));
       if (!open && hiddenWhenClosed) app.setElementHidden(panel, true);
+    },
+    initPanelSwipeToClose({ panel, side = 'left', isEnabled = () => true, isOpen = () => true, shouldIgnoreTarget = null, onClose = null } = {}) {
+      const direction = side === 'right' ? 1 : -1;
+      let start = null;
+      panel.addEventListener('pointerdown', (event) => {
+        if (!isEnabled() || !isOpen() || shouldIgnoreTarget?.(event.target)) return;
+        start = { x: Number(event.clientX) || 0, y: Number(event.clientY) || 0, dragging: false };
+      });
+      panel.addEventListener('pointermove', (event) => {
+        if (!start) return;
+        const dx = (Number(event.clientX) || 0) - start.x;
+        const dy = Math.abs((Number(event.clientY) || 0) - start.y);
+        const closeDelta = dx * direction;
+        if (!start.dragging) {
+          if (Math.abs(dx) < 8 && dy < 8) return;
+          if (dy > Math.abs(dx) * 1.15 || closeDelta <= 0) {
+            start = null;
+            return;
+          }
+          start.dragging = true;
+          panel.classList.add('panel-swipe-dragging');
+        }
+        panel.style.setProperty('--panel-swipe-offset-x', `${direction * closeDelta}px`);
+      });
+      panel.addEventListener('pointerup', (event) => {
+        if (!start) return;
+        const dx = (Number(event.clientX) || 0) - start.x;
+        const closeDelta = dx * direction;
+        const shouldClose = start.dragging && closeDelta >= 70;
+        panel.classList.remove('panel-swipe-dragging');
+        panel.style.removeProperty('--panel-swipe-offset-x');
+        start = null;
+        if (shouldClose) onClose?.(event);
+      });
+      panel.addEventListener('pointercancel', () => {
+        panel.classList.remove('panel-swipe-dragging');
+        panel.style.removeProperty('--panel-swipe-offset-x');
+        start = null;
+      });
     }
   };
 
@@ -547,6 +596,8 @@ async function run(name, fn) {
     assert(elements.diffSidebar.classList.contains('open'), 'drawer starts open');
 
     await elements.diffSidebar.dispatchEvent({ type: 'pointerdown', target: elements.diffSidebar, clientX: 120, clientY: 40 });
+    await elements.diffSidebar.dispatchEvent({ type: 'pointermove', target: elements.diffSidebar, clientX: 205, clientY: 48 });
+    assertEqual(elements.diffSidebar.style.getPropertyValue('--panel-swipe-offset-x'), '85px', 'drawer follows the touch move');
     await elements.diffSidebar.dispatchEvent({ type: 'pointerup', target: elements.diffSidebar, clientX: 215, clientY: 48 });
     assert(!elements.diffSidebar.classList.contains('open'), 'rightward swipe closes drawer');
   });
@@ -558,6 +609,7 @@ async function run(name, fn) {
     app.toggleDiffSidebar();
 
     await elements.diffSidebar.dispatchEvent({ type: 'pointerdown', target: elements.diffSidebar, clientX: 120, clientY: 40 });
+    await elements.diffSidebar.dispatchEvent({ type: 'pointermove', target: elements.diffSidebar, clientX: 150, clientY: 150 });
     await elements.diffSidebar.dispatchEvent({ type: 'pointerup', target: elements.diffSidebar, clientX: 150, clientY: 150 });
     assert(elements.diffSidebar.classList.contains('open'), 'mostly vertical gesture keeps drawer open');
   });

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -433,6 +433,26 @@ async function run(name, fn) {
 }
 
 (async () => {
+  await run('sidebar registers shared swipe-to-close gesture', () => {
+    const swipeRegistrations = [];
+    const { app } = createHarness({
+      initPanelSwipeToClose(options) { swipeRegistrations.push(options); },
+      setAnimatedPanelOpen({ open, classTargets }) {
+        classTargets.forEach((target) => target.element.classList.toggle(target.className, Boolean(open)));
+      },
+    });
+
+    assertEqual(swipeRegistrations.length, 1, 'one sidebar swipe registration');
+    const registration = swipeRegistrations[0];
+    assertEqual(registration.panel, app.elements.sidebar, 'gesture is registered on the sidebar');
+    assertEqual(registration.side, 'left', 'sidebar closes toward the left edge');
+    app.elements.sidebar.classList.add('open');
+    app.elements.sidebarBackdrop.classList.add('open');
+    registration.onClose();
+    assert(!app.elements.sidebar.classList.contains('open'), 'gesture close calls sidebar close helper');
+    assert(!app.elements.sidebarBackdrop.classList.contains('open'), 'gesture close also clears backdrop');
+  });
+
   await run('discovers every assistant turn and skips empty assistant segments', () => {
     const { app, session } = createHarness();
     session.messages = [


### PR DESCRIPTION
## What

- Adds a shared swipe-to-close helper for side panels.
- Wires it into both mobile drawers:
  - left session sidebar swipes left to close
  - right file changes panel swipes right to close
- Makes panels follow horizontal touch/pointer movement while dragging via a shared CSS offset variable.
- Keeps vertical scroll gestures inside the panels untouched by locking only after horizontal intent wins.
- Commits close by distance threshold or fling velocity, with a small resistance when dragging the wrong way.

## Why

The earlier panel animation fix made open/close transitions consistent, but touch dismissal still felt binary: the diff panel only decided on release, and the session sidebar had no matching swipe close.

The nicer drawer pattern is the boring-but-important one: follow the finger, don't steal vertical scroll, commit on threshold/velocity, snap back if the gesture doesn't mean it. Physics without cosplay.

## Tests

- `for f in internal/serveui/static/*_test.js; do mise x node@24 -- node "$f" || exit 1; done`
- `go build ./...`
- `go test ./...`
