### PR TITLE
fix: stabilize panel swipe event handling

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -452,11 +452,20 @@ const PANEL_SWIPE_CLOSE_TRANSITION_MAX_MS = 260;
 const PANEL_SWIPE_SNAP_TRANSITION_MIN_MS = 120;
 const PANEL_SWIPE_SNAP_TRANSITION_MAX_MS = 220;
 const PANEL_SWIPE_TRANSITION_RESET_BUFFER_MS = 80;
+const PANEL_SWIPE_CLICK_SUPPRESS_MS = 350;
 const PANEL_TRANSITION_DURATION_VAR = '--panel-transition-duration';
 const PANEL_SWIPE_RESISTANCE = 0.25;
 const PANEL_SWIPE_MAX_OVERSHOOT_PX = 32;
 const PANEL_SWIPE_OFFSET_VAR = '--panel-swipe-offset-x';
 const PANEL_SWIPE_DRAG_CLASS = 'panel-swipe-dragging';
+const PANEL_SWIPE_CAPTURE_OPTIONS = { capture: true, passive: false };
+const PANEL_SWIPE_CLICK_CAPTURE_OPTIONS = { capture: true };
+
+const stopPanelSwipeEvent = (event) => {
+  event?.preventDefault?.();
+  event?.stopImmediatePropagation?.();
+  event?.stopPropagation?.();
+};
 
 const panelSwipePoint = (event) => ({
   x: Number(event?.clientX) || 0,
@@ -613,15 +622,73 @@ const initPanelSwipeToClose = ({
   if (!panel?.addEventListener) return () => {};
   const direction = side === 'right' ? 1 : -1;
   let gesture = null;
+  let suppressClickUntil = 0;
+  let clickSuppressDocument = null;
 
+  const ownerDocumentForPanel = () => panel.ownerDocument || (typeof document !== 'undefined' ? document : null);
   const matchesPointer = (event) => !gesture || event?.pointerId === undefined || gesture.pointerId === undefined || event.pointerId === gesture.pointerId;
   const closeDeltaFor = (event) => (panelSwipePoint(event).x - gesture.startX) * direction;
 
+  // Track active drags from document capture as well as the panel. The diff
+  // drawer is full of buttons/accordion rows; if one of those wins bubbling or
+  // the pointer leaves the translated panel, the drawer should still stay glued
+  // to the pointer.
+  const addDocumentTracking = () => {
+    if (!gesture || gesture.trackingDocument) return;
+    const doc = ownerDocumentForPanel();
+    gesture.trackingDocument = doc || null;
+    if (!doc || doc === panel) return;
+    doc.addEventListener?.('pointermove', onPointerMove, PANEL_SWIPE_CAPTURE_OPTIONS);
+    doc.addEventListener?.('pointerup', onPointerEnd, PANEL_SWIPE_CAPTURE_OPTIONS);
+    doc.addEventListener?.('pointercancel', onPointerCancel, PANEL_SWIPE_CAPTURE_OPTIONS);
+  };
+
+  const removeDocumentTracking = (activeGesture) => {
+    const doc = activeGesture?.trackingDocument;
+    if (!doc || doc === panel) return;
+    doc.removeEventListener?.('pointermove', onPointerMove, PANEL_SWIPE_CAPTURE_OPTIONS);
+    doc.removeEventListener?.('pointerup', onPointerEnd, PANEL_SWIPE_CAPTURE_OPTIONS);
+    doc.removeEventListener?.('pointercancel', onPointerCancel, PANEL_SWIPE_CAPTURE_OPTIONS);
+    activeGesture.trackingDocument = null;
+  };
+
+  const clearDocumentClickSuppressor = () => {
+    if (!clickSuppressDocument) return;
+    clickSuppressDocument.removeEventListener?.('click', onClickSuppress, PANEL_SWIPE_CLICK_CAPTURE_OPTIONS);
+    clickSuppressDocument = null;
+  };
+
+  // A completed drag must not also click the row/button it started on. Native
+  // controls happily synthesize that click after pointerup unless we eat it.
+  const armClickSuppression = () => {
+    suppressClickUntil = Date.now() + PANEL_SWIPE_CLICK_SUPPRESS_MS;
+    const doc = ownerDocumentForPanel();
+    if (doc?.addEventListener && doc !== clickSuppressDocument) {
+      clearDocumentClickSuppressor();
+      doc.addEventListener('click', onClickSuppress, PANEL_SWIPE_CLICK_CAPTURE_OPTIONS);
+      clickSuppressDocument = doc;
+    }
+  };
+
+  const onClickSuppress = (event) => {
+    if (!suppressClickUntil) return;
+    if (Date.now() > suppressClickUntil) {
+      suppressClickUntil = 0;
+      clearDocumentClickSuppressor();
+      return;
+    }
+    stopPanelSwipeEvent(event);
+    suppressClickUntil = 0;
+    clearDocumentClickSuppressor();
+  };
+
   const resetGesture = (event) => {
-    if (gesture?.dragging) panel.classList?.remove?.(dragClass);
+    const activeGesture = gesture;
+    if (activeGesture?.dragging) panel.classList?.remove?.(dragClass);
+    removeDocumentTracking(activeGesture);
     try {
-      if (gesture?.pointerId !== undefined) panel.releasePointerCapture?.(gesture.pointerId);
-      if (event?.pointerId !== undefined && event.pointerId !== gesture?.pointerId) panel.releasePointerCapture?.(event.pointerId);
+      if (activeGesture?.pointerId !== undefined) panel.releasePointerCapture?.(activeGesture.pointerId);
+      if (event?.pointerId !== undefined && event.pointerId !== activeGesture?.pointerId) panel.releasePointerCapture?.(event.pointerId);
     } catch (_) {
       // Pointer capture may already be gone after browser cancellation.
     }
@@ -646,6 +713,7 @@ const initPanelSwipeToClose = ({
     if (typeof isEnabled === 'function' && !isEnabled()) return;
     if (typeof isOpen === 'function' && !isOpen()) return;
     if (typeof shouldIgnoreTarget === 'function' && shouldIgnoreTarget(event.target)) return;
+    if (gesture) resetGesture(event);
     const point = panelSwipePoint(event);
     const now = Date.now();
     gesture = {
@@ -656,8 +724,10 @@ const initPanelSwipeToClose = ({
       lastCloseDelta: 0,
       lastAt: now,
       velocity: 0,
-      dragging: false
+      dragging: false,
+      trackingDocument: null
     };
+    addDocumentTracking();
     if (panel._termLLMPanelSwipeTransitionTimer) clearTimeout(panel._termLLMPanelSwipeTransitionTimer);
     panel.style?.removeProperty?.(transitionDurationVar);
   };
@@ -682,7 +752,7 @@ const initPanelSwipeToClose = ({
       try { panel.setPointerCapture?.(event.pointerId); } catch (_) { /* pointer may be synthetic in tests */ }
     }
 
-    event.preventDefault?.();
+    stopPanelSwipeEvent(event);
     setDragOffset(updateGestureSample(event));
   };
 
@@ -692,7 +762,7 @@ const initPanelSwipeToClose = ({
       resetGesture(event);
       return;
     }
-    event.preventDefault?.();
+    stopPanelSwipeEvent(event);
     const closeDelta = updateGestureSample(event);
     const decision = panelSwipeReleaseDecision({
       panel,
@@ -715,6 +785,7 @@ const initPanelSwipeToClose = ({
 
     panel.classList?.remove?.(dragClass);
     setPanelSwipeReleaseTransition(panel, duration, transitionDurationVar);
+    armClickSuppression();
     try { void panel.offsetWidth; } catch (_) { /* non-browser test doubles */ }
     if (decision.shouldClose && typeof onClose === 'function') onClose(event, decision);
     panel.style?.removeProperty?.(offsetVar);
@@ -723,20 +794,28 @@ const initPanelSwipeToClose = ({
 
   const onPointerCancel = (event) => {
     if (!gesture || !matchesPointer(event)) return;
+    if (gesture.dragging) {
+      stopPanelSwipeEvent(event);
+      armClickSuppression();
+    }
     panel.style?.removeProperty?.(offsetVar);
     resetGesture(event);
   };
 
-  panel.addEventListener('pointerdown', onPointerDown);
-  panel.addEventListener('pointermove', onPointerMove);
-  panel.addEventListener('pointerup', onPointerEnd);
-  panel.addEventListener('pointercancel', onPointerCancel);
+  panel.addEventListener('pointerdown', onPointerDown, PANEL_SWIPE_CAPTURE_OPTIONS);
+  panel.addEventListener('pointermove', onPointerMove, PANEL_SWIPE_CAPTURE_OPTIONS);
+  panel.addEventListener('pointerup', onPointerEnd, PANEL_SWIPE_CAPTURE_OPTIONS);
+  panel.addEventListener('pointercancel', onPointerCancel, PANEL_SWIPE_CAPTURE_OPTIONS);
+  panel.addEventListener('click', onClickSuppress, PANEL_SWIPE_CLICK_CAPTURE_OPTIONS);
 
   return () => {
-    panel.removeEventListener?.('pointerdown', onPointerDown);
-    panel.removeEventListener?.('pointermove', onPointerMove);
-    panel.removeEventListener?.('pointerup', onPointerEnd);
-    panel.removeEventListener?.('pointercancel', onPointerCancel);
+    resetGesture();
+    clearDocumentClickSuppressor();
+    panel.removeEventListener?.('pointerdown', onPointerDown, PANEL_SWIPE_CAPTURE_OPTIONS);
+    panel.removeEventListener?.('pointermove', onPointerMove, PANEL_SWIPE_CAPTURE_OPTIONS);
+    panel.removeEventListener?.('pointerup', onPointerEnd, PANEL_SWIPE_CAPTURE_OPTIONS);
+    panel.removeEventListener?.('pointercancel', onPointerCancel, PANEL_SWIPE_CAPTURE_OPTIONS);
+    panel.removeEventListener?.('click', onClickSuppress, PANEL_SWIPE_CLICK_CAPTURE_OPTIONS);
   };
 };
 

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -743,13 +743,56 @@ const app = loadAppCore();
   pass(name);
 })();
 
-function makeSwipePanel(width = 320) {
+function dispatchSwipeListeners(listeners, target, event) {
+  const evt = {
+    target,
+    button: 0,
+    isPrimary: true,
+    preventDefault() { this.defaultPrevented = true; },
+    stopPropagation() { this.propagationStopped = true; },
+    stopImmediatePropagation() {
+      this.immediatePropagationStopped = true;
+      this.propagationStopped = true;
+    },
+    ...event,
+  };
+  const list = (listeners.get(evt.type) || []).slice().sort((a, b) => Number(b.capture) - Number(a.capture));
+  for (const entry of list) {
+    entry.listener(evt);
+    if (evt.immediatePropagationStopped) break;
+  }
+  return evt;
+}
+
+function makeSwipeEventTarget(defaultTarget = null) {
+  const listeners = new Map();
+  const target = {
+    addEventListener(type, listener, options) {
+      const list = listeners.get(type) || [];
+      list.push({ listener, capture: options === true || Boolean(options?.capture) });
+      listeners.set(type, list);
+    },
+    removeEventListener(type, listener) {
+      const list = listeners.get(type) || [];
+      const idx = list.findIndex((entry) => entry.listener === listener);
+      if (idx !== -1) list.splice(idx, 1);
+      listeners.set(type, list);
+    },
+    dispatchEvent(event) {
+      return dispatchSwipeListeners(listeners, defaultTarget || target, event);
+    },
+  };
+  return target;
+}
+
+function makeSwipePanel(width = 320, { ownerDocument = null } = {}) {
   const listeners = new Map();
   const styleValues = new Map();
   const classes = new Set();
   const syncClassName = (panel) => { panel.className = Array.from(classes).join(' '); };
   const panel = {
     className: '',
+    ownerDocument,
     offsetWidth: width,
     style: {
       setProperty(name, value) { styleValues.set(String(name), String(value)); },
@@ -767,21 +810,19 @@ function makeSwipePanel(width = 320) {
         return enabled;
       },
     },
-    addEventListener(type, listener) {
+    addEventListener(type, listener, options) {
       const list = listeners.get(type) || [];
-      list.push(listener);
+      list.push({ listener, capture: options === true || Boolean(options?.capture) });
       listeners.set(type, list);
     },
     removeEventListener(type, listener) {
       const list = listeners.get(type) || [];
-      const idx = list.indexOf(listener);
+      const idx = list.findIndex((entry) => entry.listener === listener);
       if (idx !== -1) list.splice(idx, 1);
       listeners.set(type, list);
     },
     dispatchEvent(event) {
-      const evt = { target: panel, button: 0, isPrimary: true, preventDefault() { this.defaultPrevented = true; }, ...event };
-      (listeners.get(evt.type) || []).slice().forEach((listener) => listener(evt));
-      return evt;
+      return dispatchSwipeListeners(listeners, panel, event);
     },
     getBoundingClientRect() { return { width, height: 600, top: 0, left: 0, right: width, bottom: 600 }; },
     setPointerCapture() {},
@@ -855,6 +896,67 @@ function makeSwipePanel(width = 320) {
   }
   if (panel.classList.contains('panel-swipe-dragging')) {
     fail(name, 'vertical scroll should not enter drag mode');
+    return;
+  }
+  pass(name);
+})();
+
+(function testPanelSwipeTracksDocumentMovesAfterPointerDown() {
+  const name = 'initPanelSwipeToClose tracks document moves for right drawer drags';
+  const testApp = loadAppCore();
+  const ownerDocument = makeSwipeEventTarget();
+  const panel = makeSwipePanel(320, { ownerDocument });
+  let closed = 0;
+  testApp.initPanelSwipeToClose({
+    panel,
+    side: 'right',
+    isEnabled: () => true,
+    isOpen: () => true,
+    onClose: () => { closed += 1; },
+  });
+
+  panel.dispatchEvent({ type: 'pointerdown', pointerId: 7, clientX: 100, clientY: 20 });
+  const move = ownerDocument.dispatchEvent({ type: 'pointermove', pointerId: 7, clientX: 195, clientY: 24 });
+  if (!move.defaultPrevented || !move.immediatePropagationStopped) {
+    fail(name, 'document-level drag move should win the event before child click handlers');
+    return;
+  }
+  if (panel.style.getPropertyValue('--panel-swipe-offset-x') !== '95px') {
+    fail(name, `expected right drawer to track document move at 95px, got ${panel.style.getPropertyValue('--panel-swipe-offset-x')}`);
+    return;
+  }
+  ownerDocument.dispatchEvent({ type: 'pointerup', pointerId: 7, clientX: 205, clientY: 24 });
+  if (closed !== 1) {
+    fail(name, `expected document-tracked right drawer drag to close once, got ${closed}`);
+    return;
+  }
+  pass(name);
+})();
+
+(function testPanelSwipeSuppressesSyntheticClickAfterDrag() {
+  const name = 'initPanelSwipeToClose suppresses the click generated after a drag';
+  const testApp = loadAppCore();
+  const panel = makeSwipePanel(320);
+  let clicked = false;
+  testApp.initPanelSwipeToClose({
+    panel,
+    side: 'right',
+    isEnabled: () => true,
+    isOpen: () => true,
+  });
+  panel.addEventListener('click', () => { clicked = true; });
+
+  panel.dispatchEvent({ type: 'pointerdown', pointerId: 1, clientX: 100, clientY: 20 });
+  panel.dispatchEvent({ type: 'pointermove', pointerId: 1, clientX: 160, clientY: 22 });
+  panel.dispatchEvent({ type: 'pointerup', pointerId: 1, clientX: 160, clientY: 22 });
+  const click = panel.dispatchEvent({ type: 'click', pointerId: 1 });
+
+  if (!click.defaultPrevented || !click.immediatePropagationStopped) {
+    fail(name, 'post-drag click should be captured and prevented');
+    return;
+  }
+  if (clicked) {
+    fail(name, 'post-drag click should not reach row/button handlers');
     return;
   }
   pass(name);


### PR DESCRIPTION
## What

Stabilizes shared panel swipe-to-close handling so the right file changes drawer keeps tracking even when its accordion buttons/rows try to win the event sequence.

Changes:
- Listen to panel pointer events in capture phase.
- After pointerdown, also track `pointermove`/`pointerup`/`pointercancel` from the owner document in capture phase.
- Once horizontal drag intent wins, stop the active pointer event so child row/button handlers cannot fight the gesture.
- Suppress the synthetic click generated after a drag so releasing over a diff row does not also toggle the accordion.
- Add focused tests for document-level tracking and post-drag click suppression.

## Why

The right edit/file changes sidebar is full of clickable accordion rows. During a swipe, those controls could steal enough of the sequence that the drawer stopped following the pointer abruptly. The drawer gesture needs to own the stream once it has horizontal intent; otherwise it feels broken.

## Verification

- All UI JS tests: `for f in internal/serveui/static/*_test.js; do mise x node@24 -- node "$f"; done`
- `go build ./...`
- `go test ./...`
