### PR TITLE
fix: Telegram session shutdown can block forever waiting for a stuck stream

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -515,7 +515,7 @@ func (m *telegramSessionMgr) getOrCreate(ctx context.Context, chatID int64) (*te
 	m.mu.Lock()
 	if existing, ok := m.sessions[chatID]; ok {
 		m.mu.Unlock()
-		closeTelegramSession(created)
+		m.closeTelegramSession(created)
 		return existing, nil
 	}
 	m.sessions[chatID] = created
@@ -539,7 +539,7 @@ func (m *telegramSessionMgr) resetSessionIfCurrent(ctx context.Context, chatID i
 	current := m.sessions[chatID]
 	if expected != nil && current != nil && current != expected {
 		m.mu.Unlock()
-		closeTelegramSession(created)
+		m.closeTelegramSession(created)
 		return current, false, nil
 	}
 	m.sessions[chatID] = created
@@ -547,7 +547,7 @@ func (m *telegramSessionMgr) resetSessionIfCurrent(ctx context.Context, chatID i
 	m.mu.Unlock()
 
 	if current != nil {
-		closeTelegramSession(current)
+		m.closeTelegramSession(current)
 	}
 	return created, true, nil
 }
@@ -826,11 +826,31 @@ func (m *telegramSessionMgr) closeAllSessions() {
 	m.mu.Unlock()
 
 	for _, sess := range sessions {
-		closeTelegramSession(sess)
+		m.closeTelegramSession(sess)
 	}
 }
 
-func closeTelegramSession(sess *telegramSession) {
+func telegramSessionCloseWait(timeout time.Duration) time.Duration {
+	if timeout > 0 {
+		return timeout
+	}
+	return 5 * time.Second
+}
+
+func telegramSessionLogLabel(sess *telegramSession) string {
+	if sess == nil || sess.meta == nil {
+		return "unknown"
+	}
+	if name := strings.TrimSpace(sess.meta.Name); name != "" {
+		return name
+	}
+	if id := strings.TrimSpace(sess.meta.ID); id != "" {
+		return id
+	}
+	return "unknown"
+}
+
+func (m *telegramSessionMgr) closeTelegramSession(sess *telegramSession) {
 	if sess == nil {
 		return
 	}
@@ -843,7 +863,12 @@ func closeTelegramSession(sess *telegramSession) {
 	if cancelFn != nil {
 		cancelFn()
 		if doneCh != nil {
-			<-doneCh
+			wait := telegramSessionCloseWait(m.interruptTimeout)
+			select {
+			case <-doneCh:
+			case <-time.After(wait):
+				log.Printf("[telegram] stream for session %s did not stop within %s during shutdown; continuing cleanup", telegramSessionLogLabel(sess), wait)
+			}
 		}
 	}
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -1332,6 +1332,76 @@ func TestTelegramSessionMgrResetSessionIfCurrent_CancelsActiveStream(t *testing.
 	}
 }
 
+func TestTelegramSessionMgrResetSessionIfCurrent_TimesOutStuckStreamShutdown(t *testing.T) {
+	var cleanupCalls atomic.Int32
+	cancelled := make(chan struct{})
+	mgr := &telegramSessionMgr{
+		sessions:         make(map[int64]*telegramSession),
+		interruptTimeout: 25 * time.Millisecond,
+		settings: Settings{
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{ProviderName: "mock", ModelName: "replacement"}, nil
+			},
+		},
+	}
+	original := &telegramSession{
+		meta: &session.Session{Name: "telegram:42", ID: "stuck-session"},
+		runtime: &SessionRuntime{
+			Cleanup: func() {
+				cleanupCalls.Add(1)
+			},
+		},
+	}
+	original.streamCancel = func() {
+		select {
+		case <-cancelled:
+		default:
+			close(cancelled)
+		}
+	}
+	original.replyDone = make(chan struct{})
+	mgr.sessions[42] = original
+
+	resetDone := make(chan struct{})
+	var (
+		replacement *telegramSession
+		replaced    bool
+		resetErr    error
+	)
+	go func() {
+		replacement, replaced, resetErr = mgr.resetSessionIfCurrent(context.Background(), 42, original)
+		close(resetDone)
+	}()
+
+	select {
+	case <-cancelled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected reset to cancel the stuck stream")
+	}
+
+	select {
+	case <-resetDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("resetSessionIfCurrent blocked on stuck stream shutdown")
+	}
+
+	if resetErr != nil {
+		t.Fatalf("resetSessionIfCurrent failed: %v", resetErr)
+	}
+	if !replaced {
+		t.Fatal("expected reset to replace the active session")
+	}
+	if replacement == nil || replacement == original {
+		t.Fatal("expected a new replacement session")
+	}
+	if got := cleanupCalls.Load(); got != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", got)
+	}
+	if got := mgr.sessions[42]; got != replacement {
+		t.Fatal("expected replacement session to be current")
+	}
+}
+
 func TestTelegramSessionMgrResetSessionIfCurrent_RestoresHistoryFromDB(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What changed

- changed Telegram session shutdown to use a bounded wait instead of blocking forever on `replyDone`
- reused the manager timeout setting for this shutdown wait, with a 5s fallback when no timeout is configured
- logged when a stuck stream does not stop in time and continued best-effort cleanup
- added a regression test covering `resetSessionIfCurrent` when the active stream ignores cancellation and never closes `replyDone`

## Why this is high-value

A single wedged Telegram stream could previously block `/reset`, session replacement, or full Telegram platform shutdown forever because `closeTelegramSession` waited on `replyDone` with no timeout. That can stall operational recovery and service reload/shutdown. This change converts that failure mode into a bounded wait with logging, so the manager can keep making progress even when a provider or tool path is stuck.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go test ./internal/serve -run 'TestTelegramSessionMgrResetSessionIfCurrent_(CancelsActiveStream|TimesOutStuckStreamShutdown)$'`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
