### PR TITLE
fix: Shell tool does a full /proc descendant scan after every command

### DIFF
--- a/internal/tools/exec_helpers.go
+++ b/internal/tools/exec_helpers.go
@@ -24,6 +24,11 @@ import (
 // setsid, daemonisation, etc.) can still be reliably reaped on cleanup.
 const shellNonceEnvVar = "TERMLLM_SHELL_NONCE"
 
+type toolCommandCleanupOptions struct {
+	alwaysScanTaggedDescendants  bool
+	suspectBackgroundDescendants bool
+}
+
 type limitedBuffer struct {
 	buf   bytes.Buffer
 	limit int64
@@ -61,6 +66,10 @@ func (b *limitedBuffer) Truncated() bool {
 }
 
 func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
+	return prepareToolCommandWithOptions(cmd, toolCommandCleanupOptions{alwaysScanTaggedDescendants: true})
+}
+
+func prepareToolCommandWithOptions(cmd *exec.Cmd, opts toolCommandCleanupOptions) (func(), error) {
 	var stdinCloser func()
 	if cmd.Stdin == nil {
 		if devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0); err == nil {
@@ -70,6 +79,14 @@ func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
 	}
 
 	configureCommandProcessGroup(cmd)
+	cancelCalled := false
+	if cmd.Cancel != nil {
+		origCancel := cmd.Cancel
+		cmd.Cancel = func() error {
+			cancelCalled = true
+			return origCancel()
+		}
+	}
 	nonce := tagCommandWithNonce(cmd)
 
 	cleanup := func() {
@@ -78,14 +95,15 @@ func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
 		//
 		// First pass: SIGKILL the process group so `nohup foo &` style children
 		// that stayed in our pgid die immediately.
+		var pgroupKillErr error = syscall.ESRCH
 		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			pgroupKillErr = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		}
-		// Second pass: walk /proc for any process still alive that inherited
-		// the nonce env var. This catches descendants that escaped the pgroup
-		// via setsid, double-fork daemonisation, or explicit setpgid. We retry
-		// a few times because a process may be mid-exec when we scan.
-		if nonce != "" {
+		// Second pass: only pay for the host-wide /proc walk when cancellation
+		// happened, the pgroup kill found lingering same-group processes, or the
+		// caller suspects background descendants may have escaped the pgid. This
+		// avoids a full descendant scan on ordinary foreground command exits.
+		if nonce != "" && shouldScanTaggedDescendants(opts, cancelCalled, pgroupKillErr) {
 			killTaggedDescendants(nonce)
 		}
 		if stdinCloser != nil {
@@ -93,6 +111,78 @@ func prepareToolCommand(cmd *exec.Cmd) (func(), error) {
 		}
 	}
 	return cleanup, nil
+}
+
+func shouldScanTaggedDescendants(opts toolCommandCleanupOptions, cancelCalled bool, pgroupKillErr error) bool {
+	if opts.alwaysScanTaggedDescendants {
+		return true
+	}
+	if cancelCalled {
+		return true
+	}
+	if pgroupKillErr == nil {
+		return true
+	}
+	if pgroupKillErr != nil && !errors.Is(pgroupKillErr, syscall.ESRCH) {
+		return true
+	}
+	return opts.suspectBackgroundDescendants
+}
+
+func shellCommandMayLeaveBackgroundDescendants(command string) bool {
+	for _, keyword := range []string{"nohup", "setsid", "disown", "coproc", "daemonize"} {
+		if strings.Contains(command, keyword) {
+			return true
+		}
+	}
+	return hasUnquotedBackgroundAmpersand(command)
+}
+
+func hasUnquotedBackgroundAmpersand(command string) bool {
+	var inSingle, inDouble, escaped bool
+	for i := 0; i < len(command); i++ {
+		switch {
+		case escaped:
+			escaped = false
+			continue
+		case inSingle:
+			if command[i] == '\'' {
+				inSingle = false
+			}
+			continue
+		case inDouble:
+			switch command[i] {
+			case '"':
+				inDouble = false
+			case '\\':
+				escaped = true
+			}
+			continue
+		}
+
+		switch command[i] {
+		case '\\':
+			escaped = true
+		case '\'':
+			inSingle = true
+		case '"':
+			inDouble = true
+		case '&':
+			if i > 0 {
+				if prev := command[i-1]; prev == '&' || prev == '>' {
+					continue
+				}
+			}
+			if i+1 < len(command) {
+				next := command[i+1]
+				if next == '&' || next == '>' {
+					continue
+				}
+			}
+			return true
+		}
+	}
+	return false
 }
 
 const scriptBusyMaxRetries = 4

--- a/internal/tools/exec_helpers_test.go
+++ b/internal/tools/exec_helpers_test.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"errors"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -35,5 +37,85 @@ func TestResolveToolPath_TildeSlashExpanded(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, home) {
 		t.Errorf("resolveToolPath(~/) = %q, expected prefix %q", got, home)
+	}
+}
+
+func TestShouldScanTaggedDescendants(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          toolCommandCleanupOptions
+		cancelCalled  bool
+		pgroupKillErr error
+		want          bool
+	}{
+		{
+			name: "default helper keeps always-scan behavior",
+			opts: toolCommandCleanupOptions{alwaysScanTaggedDescendants: true},
+			want: true,
+		},
+		{
+			name:          "skip scan for clean foreground shell exit",
+			opts:          toolCommandCleanupOptions{},
+			pgroupKillErr: syscall.ESRCH,
+			want:          false,
+		},
+		{
+			name:          "scan when command was cancelled or timed out",
+			opts:          toolCommandCleanupOptions{},
+			cancelCalled:  true,
+			pgroupKillErr: syscall.ESRCH,
+			want:          true,
+		},
+		{
+			name:          "scan when pgroup kill found lingering processes",
+			opts:          toolCommandCleanupOptions{},
+			pgroupKillErr: nil,
+			want:          true,
+		},
+		{
+			name:          "scan when caller suspects escaped background descendants",
+			opts:          toolCommandCleanupOptions{suspectBackgroundDescendants: true},
+			pgroupKillErr: syscall.ESRCH,
+			want:          true,
+		},
+		{
+			name:          "scan on unexpected kill error to stay safe",
+			opts:          toolCommandCleanupOptions{},
+			pgroupKillErr: errors.New("boom"),
+			want:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldScanTaggedDescendants(tt.opts, tt.cancelCalled, tt.pgroupKillErr)
+			if got != tt.want {
+				t.Fatalf("shouldScanTaggedDescendants(...) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellCommandMayLeaveBackgroundDescendants(t *testing.T) {
+	tests := []struct {
+		command string
+		want    bool
+	}{
+		{command: "pwd", want: false},
+		{command: "git status && pwd", want: false},
+		{command: "grep foo file 2>&1", want: false},
+		{command: "echo '&'", want: false},
+		{command: "sleep 1 &", want: true},
+		{command: "nohup sleep 1 >/tmp/x 2>&1 &", want: true},
+		{command: "setsid bash -c 'sleep 1' >/tmp/x 2>&1 < /dev/null &", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			got := shellCommandMayLeaveBackgroundDescendants(tt.command)
+			if got != tt.want {
+				t.Fatalf("shellCommandMayLeaveBackgroundDescendants(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -244,7 +244,9 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	cleanup, prepErr := prepareToolCommand(cmd)
+	cleanup, prepErr := prepareToolCommandWithOptions(cmd, toolCommandCleanupOptions{
+		suspectBackgroundDescendants: shellCommandMayLeaveBackgroundDescendants(a.Command),
+	})
 	if prepErr != nil {
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "command setup error: %v", prepErr))), nil
 	}


### PR DESCRIPTION
## What changed

- Added a shell-specific cleanup path that skips the expensive nonce-based `/proc` descendant scan after ordinary foreground shell commands.
- Kept the cheap process-group `SIGKILL` cleanup in place for every shell invocation.
- Still run the nonce scan when it is actually needed: if cancellation/timeout used `cmd.Cancel`, if the process-group kill found lingering same-group processes, or if the shell command looks like it may background/detach descendants (`&`, `nohup`, `setsid`, `disown`, etc.).
- Left the existing always-scan behavior unchanged for the other `prepareToolCommand` callers.
- Added unit coverage for the scan decision logic and the shell background-command heuristic.

## Why this is high-value

The shell tool is on one of the hottest agent paths. Before this change, every shell command paid for a host-wide `/proc` walk and multiple `/proc/<pid>/environ` reads even for trivial foreground commands like `pwd`, `grep`, and `git status`.

This change removes that per-command process-table I/O from the common case while preserving the descendant-reaping fallback in the cases where it matters. That directly reduces filesystem/syscall work and cuts latency on multi-step shell-heavy agent flows.

## Validation

- `gofmt -w internal/tools/exec_helpers.go internal/tools/exec_helpers_test.go internal/tools/shell.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
