### PR TITLE
fix(claude-bin): frame replayed history so resumed sessions don't restart

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -1506,7 +1506,86 @@ func (p *ClaudeBinProvider) systemPromptForTurn(messages []Message) string {
 
 // buildConversationPrompt constructs the conversation prompt from messages.
 // This can be called with a subset of messages when resuming a session.
+//
+// When the slice carries a multi-turn history (earlier assistant/tool turns
+// precede the latest user message), the earlier turns are wrapped in a
+// <conversation_history> block with an explicit instruction so Claude Code
+// treats them as already-handled context and replies only to the latest user
+// message. Without this, a fresh CLI session — e.g. after a runtime eviction or
+// server restart, when --resume state is gone — receives the whole transcript
+// as a single pasted user turn and re-answers it from the very beginning.
 func (p *ClaudeBinProvider) buildConversationPrompt(messages []Message) string {
+	finalTurnStart := conversationFinalTurnStart(messages)
+	if finalTurnStart <= 0 || !messagesContainPriorAssistantTurn(messages[:finalTurnStart]) {
+		return strings.TrimSpace(strings.Join(p.renderConversationParts(messages), "\n\n"))
+	}
+
+	historyText := strings.TrimSpace(strings.Join(p.renderConversationParts(messages[:finalTurnStart]), "\n\n"))
+	finalText := strings.TrimSpace(strings.Join(p.renderConversationParts(messages[finalTurnStart:]), "\n\n"))
+	switch {
+	case historyText == "":
+		return finalText
+	case finalText == "":
+		return historyText
+	}
+
+	var b strings.Builder
+	b.WriteString("<conversation_history>\n")
+	b.WriteString(historyText)
+	b.WriteString("\n</conversation_history>\n\n")
+	b.WriteString(claudeBinResumeReplayInstruction)
+	b.WriteString("\n\n")
+	b.WriteString(finalText)
+	return b.String()
+}
+
+// claudeBinResumeReplayInstruction is injected between the replayed history and
+// the latest user turn so Claude Code does not re-answer already-handled turns.
+const claudeBinResumeReplayInstruction = "The block above is the earlier part of this same conversation, included only so you have the full context. You have already written those assistant replies and already performed any actions shown there — do not repeat them and do not re-answer earlier user messages. Continue the conversation naturally, responding only to the user's most recent message below."
+
+// conversationFinalTurnStart returns the index in messages where the latest user
+// turn begins (including an immediately preceding developer message, which is
+// buffered into that user turn). It returns 0 when there is no user message or
+// the latest user turn is already at the start, signalling that no history/final
+// split is needed.
+func conversationFinalTurnStart(messages []Message) int {
+	lastUser := -1
+	for i, msg := range messages {
+		if msg.Role == RoleUser {
+			lastUser = i
+		}
+	}
+	if lastUser <= 0 {
+		return 0
+	}
+	if messages[lastUser-1].Role == RoleDeveloper {
+		return lastUser - 1
+	}
+	return lastUser
+}
+
+// messagesContainPriorAssistantTurn reports whether the slice holds a completed
+// prior assistant reply, i.e. genuine already-answered conversation history that
+// should be framed as replayed context. A lone tool result (with no preceding
+// assistant turn) is deliberately excluded: that is fresh tool output feeding the
+// current question — notably the synthetic tool-result image replay — and must
+// still be emitted as a live stream-json vision turn, not flattened to text.
+// Tools are always invoked by the assistant, so any real multi-turn history
+// carries an assistant turn; this predicate never misses a genuine transcript.
+func messagesContainPriorAssistantTurn(messages []Message) bool {
+	for _, msg := range messages {
+		if msg.Role == RoleAssistant {
+			return true
+		}
+	}
+	return false
+}
+
+// renderConversationParts converts messages into Claude CLI stdin transcript
+// lines ("User: ...", "Assistant: ...", "Tool result (...): ..."). System
+// messages are dropped (passed via --system-prompt); developer messages are
+// buffered into the following user turn wrapped in <developer> tags.
+func (p *ClaudeBinProvider) renderConversationParts(messages []Message) []string {
 	var conversationParts []string
 	var pendingDev string
 
@@ -1572,7 +1651,7 @@ func (p *ClaudeBinProvider) buildConversationPrompt(messages []Message) string {
 		}
 	}
 
-	return strings.TrimSpace(strings.Join(conversationParts, "\n\n"))
+	return conversationParts
 }
 
 // mapModelToClaudeArg converts a model name to claude CLI argument.
@@ -1798,7 +1877,26 @@ type sdkImageSource struct {
 // message order. User messages are emitted as normal. Tool result images are
 // replayed as synthetic follow-up user messages tied to the originating tool
 // call via parent_tool_use_id so Claude can vision-analyze them on resume.
+//
+// stream-json only carries user-role turns, so a fresh CLI session (no --resume
+// state, e.g. after a runtime eviction or server restart) that replays a full
+// transcript would otherwise present a pile of unanswered user questions — with
+// every assistant reply dropped — and Claude re-answers from the very start.
+// When a multi-turn history precedes the latest user message we therefore flatten
+// the earlier turns (assistant replies included) into a leading <conversation_history>
+// text block carrying claudeBinResumeReplayInstruction, and emit only the latest
+// turn as live stream-json so its own images still reach the model as real blocks.
 func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID string) string {
+	historyPrefix := ""
+	emitMessages := messages
+	if finalTurnStart := conversationFinalTurnStart(messages); finalTurnStart > 0 && messagesContainPriorAssistantTurn(messages[:finalTurnStart]) {
+		historyText := strings.TrimSpace(strings.Join(p.renderConversationParts(messages[:finalTurnStart]), "\n\n"))
+		if historyText != "" {
+			historyPrefix = "<conversation_history>\n" + historyText + "\n</conversation_history>\n\n" + claudeBinResumeReplayInstruction + "\n\n"
+			emitMessages = messages[finalTurnStart:]
+		}
+	}
+
 	var lines []string
 	appendUserMessage := func(content []sdkContentBlock, parentToolUseID *string) {
 		if len(content) == 0 {
@@ -1821,7 +1919,8 @@ func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID s
 	}
 
 	var pendingDev string
-	for _, msg := range messages {
+	prefixInjected := false
+	for _, msg := range emitMessages {
 		switch msg.Role {
 		case RoleDeveloper:
 			pendingDev = collectTextParts(msg.Parts)
@@ -1834,6 +1933,10 @@ func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID s
 				}
 				blocks = append([]sdkContentBlock{devBlock}, blocks...)
 				pendingDev = ""
+			}
+			if historyPrefix != "" && !prefixInjected {
+				blocks = append([]sdkContentBlock{{Type: "text", Text: historyPrefix}}, blocks...)
+				prefixInjected = true
 			}
 			appendUserMessage(blocks, nil)
 		case RoleTool:
@@ -1852,6 +1955,15 @@ func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID s
 				appendUserMessage(blocks, parentToolUseID)
 			}
 		}
+	}
+
+	// Defensive: the framing is normally injected onto the latest user turn in
+	// the loop above, and emitMessages always contains that turn (conversationFinalTurnStart
+	// returns the latest user index, or the developer line right before it) — so this
+	// fallback is unreachable today. It only fires if a future change to the slice
+	// derivation drops the user turn, ensuring the replayed history is never lost.
+	if historyPrefix != "" && !prefixInjected {
+		appendUserMessage([]sdkContentBlock{{Type: "text", Text: strings.TrimRight(historyPrefix, "\n")}}, nil)
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -1413,6 +1413,103 @@ func TestBuildStreamJsonInput_SessionID(t *testing.T) {
 	}
 }
 
+func TestBuildStreamJsonInput_FramesPriorHistoryAndKeepsFinalImage(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "FIRST_QUESTION"}}},
+		{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "FIRST_ANSWER"}}},
+		{Role: RoleUser, Parts: []Part{
+			{Type: PartText, Text: "LATEST_QUESTION"},
+			{Type: PartImage, ImageData: &ToolImageData{MediaType: "image/jpeg", Base64: "dGVzdA=="}},
+		}},
+	}
+
+	msgsOut := parseSDKUserMessages(t, p.buildStreamJsonInput(msgs, "sess-frame"))
+	if len(msgsOut) != 1 {
+		t.Fatalf("expected the prior history to collapse into a single live user turn, got %d messages", len(msgsOut))
+	}
+
+	blocks := msgsOut[0].Message.Content
+	if len(blocks) < 2 {
+		t.Fatalf("expected a leading framing text block plus the final turn content, got %d blocks", len(blocks))
+	}
+
+	framing := blocks[0]
+	if framing.Type != "text" {
+		t.Fatalf("expected first block to be the framing text, got type %q", framing.Type)
+	}
+	for _, want := range []string{"<conversation_history>", "FIRST_QUESTION", "FIRST_ANSWER", "</conversation_history>", claudeBinResumeReplayInstruction} {
+		if !strings.Contains(framing.Text, want) {
+			t.Errorf("framing block missing %q\ngot: %q", want, framing.Text)
+		}
+	}
+	// The assistant reply must survive: stream-json normally drops it, which is
+	// what made Claude re-answer the whole thread from the start on resume.
+	if !strings.Contains(framing.Text, "Assistant: FIRST_ANSWER") {
+		t.Errorf("expected the prior assistant turn to be preserved in the framing block, got: %q", framing.Text)
+	}
+
+	var sawLatestText, sawImage bool
+	for _, b := range blocks {
+		if b.Type == "text" && strings.Contains(b.Text, "LATEST_QUESTION") && !strings.Contains(b.Text, "<conversation_history>") {
+			sawLatestText = true
+		}
+		if b.Type == "image" && b.Source != nil && b.Source.Data == "dGVzdA==" {
+			sawImage = true
+		}
+	}
+	if !sawLatestText {
+		t.Error("expected the latest user question to be sent as live content")
+	}
+	if !sawImage {
+		t.Error("expected the final turn image to survive as a real vision block")
+	}
+}
+
+func TestBuildStreamJsonInput_NoFramingWithoutPriorTurn(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	// A single user turn with an image (fresh first message): no prior assistant
+	// turn, so no framing should be added and behavior is unchanged.
+	msgs := []Message{
+		{Role: RoleUser, Parts: []Part{
+			{Type: PartText, Text: "hello"},
+			{Type: PartImage, ImageData: &ToolImageData{MediaType: "image/jpeg", Base64: "dGVzdA=="}},
+		}},
+	}
+	out := p.buildStreamJsonInput(msgs, "sess-fresh")
+	if strings.Contains(out, "conversation_history") || strings.Contains(out, claudeBinResumeReplayInstruction) {
+		t.Fatalf("did not expect resume framing for a fresh single-turn input, got: %q", out)
+	}
+}
+
+// TestBuildStreamJsonInput_FramesHistoryEvenWhenFinalUserEmpty locks the concern
+// behind the trailing defensive guard via the path that is actually reachable: a
+// prior answered history followed by a latest user turn whose own content is empty.
+// The loop injects the framing onto that content-less turn, so the replayed history
+// must still reach the model rather than being silently dropped.
+func TestBuildStreamJsonInput_FramesHistoryEvenWhenFinalUserEmpty(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "FIRST_QUESTION"}}},
+		{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "FIRST_ANSWER"}}},
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: ""}}},
+	}
+
+	msgsOut := parseSDKUserMessages(t, p.buildStreamJsonInput(msgs, "sess-empty-final"))
+	if len(msgsOut) != 1 {
+		t.Fatalf("expected exactly one emitted user message carrying the framing, got %d", len(msgsOut))
+	}
+	blocks := msgsOut[0].Message.Content
+	if len(blocks) != 1 || blocks[0].Type != "text" {
+		t.Fatalf("expected a single framing text block, got %+v", blocks)
+	}
+	for _, want := range []string{"<conversation_history>", "FIRST_QUESTION", "Assistant: FIRST_ANSWER", "</conversation_history>", claudeBinResumeReplayInstruction} {
+		if !strings.Contains(blocks[0].Text, want) {
+			t.Errorf("framing block missing %q\ngot: %q", want, blocks[0].Text)
+		}
+	}
+}
+
 func TestFormatToolOutputForClaude_UsesStructuredImageParts(t *testing.T) {
 	p := NewClaudeBinProvider("sonnet", nil)
 
@@ -1516,6 +1613,59 @@ func TestBuildConversationPrompt_DeveloperRoleWithoutFollowingUser(t *testing.T)
 	// (same as anthropic.go behavior — pendingDev is lost at end of loop).
 	if strings.Contains(out, "trailing dev message") {
 		t.Errorf("trailing developer message without following user turn should be dropped, got: %q", out)
+	}
+}
+
+// TestBuildConversationPrompt_WrapsReplayedHistory covers the resume-after-eviction
+// case: a fresh provider instance is handed the full transcript. Earlier turns
+// must be wrapped as <conversation_history> context so Claude Code answers only
+// the latest user message instead of re-running the whole thread from the top.
+func TestBuildConversationPrompt_WrapsReplayedHistory(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "first question"}}},
+		{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "first answer"}}},
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "latest question"}}},
+	}
+	out := p.buildConversationPrompt(msgs)
+
+	closeIdx := strings.Index(out, "</conversation_history>")
+	if !strings.Contains(out, "<conversation_history>") || closeIdx < 0 {
+		t.Fatalf("expected replayed history to be wrapped, got: %q", out)
+	}
+	history := out[:closeIdx]
+	if !strings.Contains(history, "first question") || !strings.Contains(history, "first answer") {
+		t.Fatalf("prior turn must live inside the history block, got: %q", out)
+	}
+	// The latest user message is the only turn to answer: it must sit AFTER the
+	// history block, not inside it.
+	if strings.Contains(history, "latest question") {
+		t.Fatalf("latest question leaked into history block: %q", out)
+	}
+	tail := out[closeIdx:]
+	if !strings.Contains(tail, "User: latest question") {
+		t.Fatalf("latest question missing from final turn: %q", out)
+	}
+	if !strings.Contains(tail, "responding only to the user's most recent message") {
+		t.Fatalf("replay instruction missing: %q", out)
+	}
+}
+
+// TestBuildConversationPrompt_SingleTurnNoFraming guards the common paths (a
+// brand-new conversation and the mid-session --resume case that sends only new
+// messages): with no prior assistant/tool turn there must be no history framing.
+func TestBuildConversationPrompt_SingleTurnNoFraming(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	msgs := []Message{
+		{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: "platform note"}}},
+		{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "just one question"}}},
+	}
+	out := p.buildConversationPrompt(msgs)
+	if strings.Contains(out, "<conversation_history>") {
+		t.Fatalf("a single new turn must not be wrapped as history: %q", out)
+	}
+	if !strings.Contains(out, "just one question") {
+		t.Fatalf("user message missing: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a `claude-bin` runtime is recreated — runtime eviction after idle, or a
server restart — the Claude CLI `--resume` state is gone. On the next turn the
provider therefore re-submits the **whole transcript** from scratch. Both stdin
paths mishandled this replay, causing a resumed conversation to be re-answered
**from the very beginning**: the model re-did its opening actions, replied again
to user messages it had already answered, and repeated things like earlier
apologies.

## Root cause

`claude-bin` is the Claude Code CLI, not a stateless API. Continuity is kept in
memory via `sessionID` (the CLI session) + `messagesSent`. A fresh provider
instance (`sessionID == ""`) replays everything, and the two builders both lose
turn structure:

- **Text mode** (`buildConversationPrompt`): flattened the entire transcript into
  a single `User: … / Assistant: …` blob delivered as **one pasted user turn**.
  Claude read it as a freshly-pasted thread starting at the first `User:` line and
  answered it top-to-bottom.
- **stream-json mode** (`buildStreamJsonInput`, selected when the history carries
  an image): only ever emitted **user-role** turns and **dropped every assistant
  reply entirely**. Claude received a pile of unanswered questions and re-answered
  all of them — strictly worse than text mode.

This only manifests on **resume** (a new runtime); within a live runtime,
follow-up turns use `--resume` and keep proper turn structure, so it looked fine
until you reopened an old conversation.

## Fix

Split the message slice at the latest user turn. When genuine prior history
precedes it, wrap the earlier turns (assistant replies **included**) in a
`<conversation_history>` block followed by an explicit instruction
(`claudeBinResumeReplayInstruction`) telling Claude Code those turns are already
handled and to reply only to the latest user message. The latest turn is still
emitted live — in stream-json mode it stays a real stream-json turn, so any image
in the current message still reaches the model as a true vision block.

Shared helpers used by both paths:
- `conversationFinalTurnStart` — index where the latest user turn begins (folds an
  immediately preceding developer message into that turn).
- `messagesContainPriorAssistantTurn` — gates the framing on a prior **assistant**
  turn. A lone tool-result image with no preceding assistant turn is deliberately
  *not* framed, so the synthetic tool-result image replay path keeps emitting a
  live vision turn. (Tools are always invoked by the assistant, so any real
  multi-turn history carries an assistant turn — this never misses a genuine
  transcript.)
- `renderConversationParts` — extracted transcript renderer, now returning
  `[]string` so callers can slice history vs. final turn.

## Behavior matrix

| Situation | Before | After |
|---|---|---|
| First turn / single user message | as-is | unchanged (no framing) |
| Live runtime follow-up (`--resume`) | only new msg sent | unchanged |
| Resume, text history | whole thread re-answered | framed history + reply to last only |
| Resume, history with image (stream-json) | assistant turns dropped, all re-answered | framed history (assistant replies kept) + last turn live |
| Trailing tool-result image, no prior assistant | live vision turn | unchanged (not framed) |

## Tests

Added regression tests for both stdin paths:
- `TestBuildConversationPrompt_WrapsReplayedHistory`
- `TestBuildConversationPrompt_SingleTurnNoFraming`
- `TestBuildStreamJsonInput_FramesPriorHistoryAndKeepsFinalImage`
- `TestBuildStreamJsonInput_NoFramingWithoutPriorTurn`

Existing `claude_bin` tests (incl. the tool-result-image ordering test) still
pass; `gofmt`, `go vet ./internal/llm/` and `go test ./internal/llm/` are green.

## Verification

Reproduced on a real resumed web conversation (history containing an image →
stream-json path) and confirmed live that the agent now continues from the latest
message instead of replaying the thread.
