### PR TITLE
fix: canonicalize web model effort state

### DIFF
--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -106,6 +106,7 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 	if persistedModel == "" {
 		persistedModel = runtimeDefaultModel
 	}
+	persistedModel, persistedEffort = normalizeProviderModelEffort(persistedProvider, persistedModel, persistedEffort)
 
 	if persistedProvider != "" {
 		resp["provider"] = persistedProvider

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1958,7 +1958,7 @@ func (s *serveServer) handleModels(w http.ResponseWriter, r *http.Request) {
 	// buries the most-used models behind less-used variants.
 	defaultModel := ""
 	if pc, ok := s.cfgRef.Providers[effectiveName]; ok {
-		defaultModel = pc.Model
+		defaultModel, _ = normalizeProviderModelEffort(effectiveName, pc.Model, "")
 	}
 	ids = llm.SortModelIDsByPopularity(effectiveName, defaultModel, ids)
 
@@ -2314,6 +2314,7 @@ func (s *serveServer) syncPersistedSessionRuntime(ctx context.Context, sessionID
 		modelName = strings.TrimSpace(rt.defaultModel)
 	}
 	effort := strings.TrimSpace(reasoningEffort)
+	modelName, effort = normalizeProviderModelEffort(providerKey, modelName, effort)
 
 	sess, err := s.store.Get(ctx, sessionID)
 	if err != nil {

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -135,6 +135,8 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 		defaultProvider = strings.TrimSpace(s.cfgRef.DefaultProvider)
 	}
 	requestedRuntime := responseRequestedRuntime(req, defaultProvider)
+	req.Model = requestedRuntime.model
+	req.ReasoningEffort = requestedRuntime.effort
 	persistedRuntime := requestedRuntime
 	if !freshConversation {
 		persistedRuntime = s.persistedRuntimeSettings(ctx, sessionID, defaultProvider)
@@ -242,7 +244,12 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 			return
 		}
 		if freshConversation {
-			s.syncPersistedSessionRuntime(ctx, sessionID, runtime, strings.TrimSpace(req.Model), normalizeReasoningEffort(req.ReasoningEffort))
+			providerForNormalization := reqProvider
+			if providerForNormalization == "" {
+				providerForNormalization = runtimeProviderKey(runtime)
+			}
+			req.Model, req.ReasoningEffort = normalizeProviderModelEffort(providerForNormalization, req.Model, req.ReasoningEffort)
+			s.syncPersistedSessionRuntime(ctx, sessionID, runtime, req.Model, req.ReasoningEffort)
 		}
 
 		// Enforce chaining from the latest in-memory response only for ephemeral

--- a/cmd/serve_model_swap.go
+++ b/cmd/serve_model_swap.go
@@ -45,10 +45,11 @@ func responseRequestedRuntime(req responsesCreateRequest, defaultProvider string
 	if provider == "" {
 		provider = strings.TrimSpace(defaultProvider)
 	}
+	model, effort := normalizeProviderModelEffort(provider, req.Model, req.ReasoningEffort)
 	return responseRuntimeSettings{
 		provider: provider,
-		model:    strings.TrimSpace(req.Model),
-		effort:   normalizeReasoningEffort(req.ReasoningEffort),
+		model:    model,
+		effort:   effort,
 	}
 }
 
@@ -69,8 +70,7 @@ func (s *serveServer) persistedRuntimeSettings(ctx context.Context, sessionID st
 		provider = strings.TrimSpace(defaultProvider)
 	}
 	settings.provider = provider
-	settings.model = strings.TrimSpace(sess.Model)
-	settings.effort = normalizeReasoningEffort(sess.ReasoningEffort)
+	settings.model, settings.effort = normalizeProviderModelEffort(provider, sess.Model, sess.ReasoningEffort)
 	return settings
 }
 

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -123,6 +123,37 @@ func normalizeReasoningEffort(value string) string {
 	return v
 }
 
+// normalizeProviderModelEffort canonicalizes the web/API split between model
+// identity and reasoning effort. Older URLs, localStorage values, and CLI-style
+// model names may encode effort as a model suffix (for example
+// "gpt-5.5-medium"). The web UI has a separate effort selector, so the server
+// must not echo a suffixed model and a separate reasoning_effort at the same
+// time. Provider-aware parsing avoids false positives such as
+// "gpt-5.1-codex-max", where "max" is part of the model name for GPT-5
+// providers rather than a supported effort level.
+//
+// Precedence: an explicit reasoning_effort wins over a suffix. If no explicit
+// effort is present, a supported suffix is promoted into reasoning_effort.
+func normalizeProviderModelEffort(provider, model, effort string) (string, string) {
+	model = strings.TrimSpace(model)
+	effort = normalizeReasoningEffort(effort)
+	if model == "" {
+		return "", effort
+	}
+
+	base, suffixEffort := llm.BaseModelAndEffortForProvider(provider, model)
+	if base == "" {
+		return model, effort
+	}
+	if suffixEffort == "" {
+		return base, effort
+	}
+	if effort == "" {
+		effort = suffixEffort
+	}
+	return base, effort
+}
+
 func parseRequestedTools(raw []json.RawMessage) (bool, map[string]bool, []llm.ToolSpec) {
 	search := false
 	toolNames := map[string]bool{}

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -19,6 +19,27 @@ import (
 
 const onePixelPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+KDvV3wAAAABJRU5ErkJggg=="
 
+func TestNormalizeProviderModelEffort_ExplicitEffortWinsOverSuffix(t *testing.T) {
+	model, effort := normalizeProviderModelEffort("chatgpt", "gpt-5.5-medium", "xhigh")
+	if model != "gpt-5.5" || effort != "xhigh" {
+		t.Fatalf("normalizeProviderModelEffort = (%q, %q), want gpt-5.5/xhigh", model, effort)
+	}
+}
+
+func TestNormalizeProviderModelEffort_PromotesSuffixWhenEffortUnset(t *testing.T) {
+	model, effort := normalizeProviderModelEffort("chatgpt", "gpt-5.5-medium", "")
+	if model != "gpt-5.5" || effort != "medium" {
+		t.Fatalf("normalizeProviderModelEffort = (%q, %q), want gpt-5.5/medium", model, effort)
+	}
+}
+
+func TestNormalizeProviderModelEffort_PreservesNaturalMaxModelName(t *testing.T) {
+	model, effort := normalizeProviderModelEffort("chatgpt", "gpt-5.1-codex-max", "xhigh")
+	if model != "gpt-5.1-codex-max" || effort != "xhigh" {
+		t.Fatalf("normalizeProviderModelEffort = (%q, %q), want gpt-5.1-codex-max/xhigh", model, effort)
+	}
+}
+
 func TestSetSessionNumberHeader(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	setSessionNumberHeader(recorder, &serveRuntime{sessionMeta: &session.Session{Number: 42}})

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1615,11 +1615,11 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		"model":   model,
 		"status":  "in_progress",
 	}
+	if effort := strings.TrimSpace(llmReq.ReasoningEffort); effort != "" {
+		createdResponse["reasoning_effort"] = effort
+	}
 	if options.modelSwap != nil && options.modelSwap.plan.enabled {
 		createdResponse["provider"] = options.modelSwap.plan.requestedProvider
-		if effort := strings.TrimSpace(options.modelSwap.plan.requestedEffort); effort != "" {
-			createdResponse["reasoning_effort"] = effort
-		}
 	}
 	if err := run.appendEvent("response.created", map[string]any{
 		"response": createdResponse,
@@ -1736,16 +1736,20 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 			s.registerResponseID(runtime, respID, sessionID)
 		}
 		s.registerResponseID(runtime, completedID, sessionID)
+		completeResponse := map[string]any{
+			"id":            completedID,
+			"object":        "response",
+			"created":       created,
+			"model":         model,
+			"status":        "completed",
+			"usage":         usagePayload(result.Usage),
+			"session_usage": usagePayload(result.SessionUsage),
+		}
+		if effort := strings.TrimSpace(llmReq.ReasoningEffort); effort != "" {
+			completeResponse["reasoning_effort"] = effort
+		}
 		if err := run.complete(map[string]any{
-			"response": map[string]any{
-				"id":            completedID,
-				"object":        "response",
-				"created":       created,
-				"model":         model,
-				"status":        "completed",
-				"usage":         usagePayload(result.Usage),
-				"session_usage": usagePayload(result.SessionUsage),
-			},
+			"response": completeResponse,
 		}, result.Usage, result.SessionUsage); err != nil {
 			log.Printf("response run %s failed to append completion event: %v", respID, err)
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -5879,6 +5879,50 @@ func TestHandleSessionState_FallsBackToDBWhenRuntimeNotLoaded(t *testing.T) {
 	}
 }
 
+func TestHandleSessionState_NormalizesSuffixedModelWithExplicitEffort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{
+		ID:              "sess-normalize-effort",
+		ProviderKey:     "chatgpt",
+		Model:           "gpt-5.5-medium",
+		ReasoningEffort: "xhigh",
+		Mode:            session.ModeChat,
+		Origin:          session.OriginWeb,
+	}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	mgr := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		return &serveRuntime{}, nil
+	})
+	defer mgr.Close()
+
+	srv := &serveServer{sessionMgr: mgr, store: store}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/sess-normalize-effort/state", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `"model":"gpt-5.5"`) {
+		t.Errorf("expected canonical model in state, got %s", body)
+	}
+	if !strings.Contains(body, `"reasoning_effort":"xhigh"`) {
+		t.Errorf("expected explicit reasoning_effort to win, got %s", body)
+	}
+	if strings.Contains(body, "gpt-5.5-medium") {
+		t.Errorf("state leaked suffixed model despite separate effort: %s", body)
+	}
+}
+
 func TestHandleSessionState_DoesNotBlockWhileRunHoldsRuntimeMutex(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
@@ -8709,6 +8753,51 @@ func TestResponsesHandler_ReasoningEffortFlowsToProvider(t *testing.T) {
 	}
 	if got := capturedProvider.Requests[0].ReasoningEffort; got != "high" {
 		t.Fatalf("ReasoningEffort = %q, want %q", got, "high")
+	}
+}
+
+func TestResponsesHandler_NormalizesSuffixedModelAndExplicitEffort(t *testing.T) {
+	var capturedProvider *llm.MockProvider
+	factory := func(ctx context.Context) (*serveRuntime, error) {
+		provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+		capturedProvider = provider
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			providerKey:  "chatgpt",
+			engine:       engine,
+			defaultModel: "gpt-5.5",
+		}
+		rt.Touch()
+		return rt, nil
+	}
+	mgr := newServeSessionManager(time.Minute, 100, factory)
+	defer mgr.Close()
+	srv := &serveServer{
+		sessionMgr: mgr,
+		cfgRef: &config.Config{
+			DefaultProvider: "chatgpt",
+		},
+	}
+
+	body := `{"provider":"chatgpt","model":"gpt-5.5-medium","reasoning_effort":"xhigh","input":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleResponses(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if capturedProvider == nil || len(capturedProvider.Requests) != 1 {
+		t.Fatalf("expected one provider request, got provider=%v", capturedProvider)
+	}
+	captured := capturedProvider.Requests[0]
+	if captured.Model != "gpt-5.5" || captured.ReasoningEffort != "xhigh" {
+		t.Fatalf("captured runtime = model %q effort %q, want gpt-5.5/xhigh", captured.Model, captured.ReasoningEffort)
+	}
+	if strings.Contains(rr.Body.String(), "gpt-5.5-medium") {
+		t.Fatalf("response leaked suffixed model: %s", rr.Body.String())
 	}
 }
 

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -577,8 +577,8 @@ func TestStaticAssetsSupportEffortDropdown(t *testing.T) {
 	streamSrc := string(streamJS)
 	for _, want := range []string{
 		"elements.effortSelect.value = state.selectedEffort",
-		"localStorage.setItem(STORAGE_KEYS.selectedEffort, newEffort)",
-		"localStorage.removeItem(STORAGE_KEYS.selectedEffort)",
+		"const newEffort = elements.effortSelect ? elements.effortSelect.value : ''",
+		"persist(STORAGE_KEYS.selectedEffort, state.selectedEffort || '')",
 		"const currentEffort = session.activeEffort || ''",
 		"body.reasoning_effort = activeEffort",
 		"body.model_swap = { mode: 'auto', fallback: 'handover' }",

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1036,26 +1036,53 @@ const escapeHTML = (str) => {
 
 const KNOWN_EFFORT_SUFFIXES = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
 
-const splitHeaderModelEffort = (model, effort) => {
+const modelEffortSuffix = (model) => {
+  const rawModel = String(model || '').trim();
+  if (!rawModel) return null;
+  const lower = rawModel.toLowerCase();
+  for (const candidate of KNOWN_EFFORT_SUFFIXES) {
+    for (const sep of ['-', '_', ' ']) {
+      const suffix = `${sep}${candidate}`;
+      if (lower.endsWith(suffix)) {
+        return {
+          model: rawModel.slice(0, rawModel.length - suffix.length),
+          effort: candidate,
+        };
+      }
+    }
+  }
+  return null;
+};
+
+const splitHeaderModelEffort = (model, effort, models = []) => {
   const rawModel = String(model || '').trim();
   const rawEffort = String(effort || '').trim();
   if (!rawModel) {
     return { model: rawModel, effort: rawEffort };
   }
 
+  const suffix = modelEffortSuffix(rawModel);
+  if (!suffix) {
+    return { model: rawModel, effort: rawEffort };
+  }
+
+  const knownModels = Array.isArray(models)
+    ? new Set(models.map((m) => String(m || '').trim()).filter(Boolean))
+    : new Set();
+  const hasModelList = knownModels.size > 0;
+  const modelKnown = knownModels.has(rawModel);
+  const baseKnown = knownModels.has(suffix.model);
+  const effortMatches = rawEffort && suffix.effort.toLowerCase() === rawEffort.toLowerCase();
+
   if (rawEffort) {
-    const suffix = new RegExp(`[-_ ]${rawEffort.toLowerCase()}$`, 'i');
-    if (suffix.test(rawModel)) {
-      return { model: rawModel.replace(suffix, ''), effort: rawEffort };
+    if (baseKnown || (effortMatches && (!hasModelList || !modelKnown))) {
+      return { model: suffix.model, effort: rawEffort };
     }
     return { model: rawModel, effort: rawEffort };
   }
 
-  for (const candidate of KNOWN_EFFORT_SUFFIXES) {
-    const suffix = new RegExp(`[-_ ]${candidate}$`, 'i');
-    if (suffix.test(rawModel)) {
-      return { model: rawModel.replace(suffix, ''), effort: candidate };
-    }
+  if (!hasModelList || baseKnown || !modelKnown) {
+    return { model: suffix.model, effort: suffix.effort };
   }
 
   return { model: rawModel, effort: rawEffort };
@@ -1146,14 +1173,15 @@ const updateSessionUsageDisplay = (session) => {
   const model = locked ? (session?.activeModel || state.selectedModel || '') : (state.selectedModel || '');
   const provider = locked ? (session?.provider || state.selectedProvider || '') : (state.selectedProvider || '');
   const effort = locked ? (session?.activeEffort || state.selectedEffort || '') : (state.selectedEffort || '');
-  const headerModelEffort = splitHeaderModelEffort(model, effort);
+  const headerModelEffort = splitHeaderModelEffort(model, effort, state.models);
 
   const defaultProvider = getDefaultProviderName();
   const resolvedProvider = provider || defaultProvider;
   const providerIsDefault = !provider && Boolean(defaultProvider);
   const defaultModel = getDefaultModelForProvider(resolvedProvider);
-  const resolvedModel = headerModelEffort.model || defaultModel;
-  const modelIsDefault = !headerModelEffort.model && Boolean(defaultModel);
+  const defaultModelEffort = splitHeaderModelEffort(defaultModel, headerModelEffort.effort, state.models);
+  const resolvedModel = headerModelEffort.model || defaultModelEffort.model;
+  const modelIsDefault = !headerModelEffort.model && Boolean(defaultModelEffort.model);
 
   setChipLabel(
     elements.chipProviderLabel,
@@ -1170,13 +1198,15 @@ const updateSessionUsageDisplay = (session) => {
     { muted: modelIsDefault || !resolvedModel, hidden: false, title: resolvedModel || '' }
   );
 
-  // Effort has no server-side default, so when unset we show a muted "auto"
-  // placeholder. Keeping the chip visible ensures users can always tap to pick.
-  const effortHasValue = Boolean(headerModelEffort.effort);
+  // Effort is normally independent of the model. If a legacy/configured default
+  // model still carries a suffix, surface that as the effective effort;
+  // otherwise show muted "auto" so users can always tap to pick.
+  const resolvedEffort = headerModelEffort.effort || (!headerModelEffort.model ? defaultModelEffort.effort : '');
+  const effortHasValue = Boolean(resolvedEffort);
   setChipLabel(
     elements.chipEffortLabel,
     elements.chipSepModelEffort,
-    effortHasValue ? headerModelEffort.effort : 'auto',
+    effortHasValue ? resolvedEffort : 'auto',
     { muted: !effortHasValue, hidden: false }
   );
 

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -5,6 +5,7 @@ const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
   sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
+  splitHeaderModelEffort,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
   autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
@@ -224,8 +225,11 @@ const switchToDraftSession = async (options = {}) => {
 const syncSelectedRuntimeFromSession = (session) => {
   if (!session) return false;
   const provider = String(session.provider || '').trim();
-  const model = String(session.activeModel || '').trim();
-  const effort = String(session.activeEffort || '').trim();
+  let model = String(session.activeModel || '').trim();
+  let effort = String(session.activeEffort || '').trim();
+  const split = splitHeaderModelEffort(model, effort, state.models);
+  model = split.model;
+  effort = split.effort;
   if (!provider && !model && !Object.prototype.hasOwnProperty.call(session, 'activeEffort')) {
     return false;
   }
@@ -1310,12 +1314,13 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     session.provider = runtimeState.provider;
     sessionChanged = true;
   }
-  if (runtimeState.model && runtimeState.model !== session.activeModel) {
-    session.activeModel = runtimeState.model;
+  const runtimeSplit = splitHeaderModelEffort(runtimeState.model, runtimeState.reasoning_effort, state.models);
+  if (runtimeSplit.model && runtimeSplit.model !== session.activeModel) {
+    session.activeModel = runtimeSplit.model;
     sessionChanged = true;
   }
-  if (runtimeState.reasoning_effort !== undefined) {
-    const effort = String(runtimeState.reasoning_effort || '');
+  if (runtimeState.reasoning_effort !== undefined || runtimeSplit.effort) {
+    const effort = String(runtimeSplit.effort || '');
     if (effort !== (session.activeEffort || '')) {
       session.activeEffort = effort;
       sessionChanged = true;

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -5,7 +5,7 @@ const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
   getActiveSession, createSession, scrollToBottom, setConnectionState, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, compactHeaderModelLabel, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
+  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateAssistantNode, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
   enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
   subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
@@ -1958,24 +1958,13 @@ const connectToken = async () => {
   // selects are temporarily stale (for example while startup/model refresh work
   // is still settling). Persist the current state instead.
   const persistedProvider = state.selectedProvider;
-  if (persistedProvider) {
-    localStorage.setItem(STORAGE_KEYS.selectedProvider, persistedProvider);
-  } else {
-    localStorage.removeItem(STORAGE_KEYS.selectedProvider);
-  }
   const persistedModel = state.selectedModel;
-  if (persistedModel) {
-    localStorage.setItem(STORAGE_KEYS.selectedModel, persistedModel);
-  } else {
-    localStorage.removeItem(STORAGE_KEYS.selectedModel);
-  }
   const newEffort = elements.effortSelect ? elements.effortSelect.value : '';
+  state.selectedProvider = persistedProvider;
+  state.selectedModel = persistedModel;
   state.selectedEffort = newEffort;
-  if (newEffort) {
-    localStorage.setItem(STORAGE_KEYS.selectedEffort, newEffort);
-  } else {
-    localStorage.removeItem(STORAGE_KEYS.selectedEffort);
-  }
+  canonicalizeSelectedModelEffort();
+  persistRuntimeSelection();
   const showHiddenChanged = nextShowHiddenSessions !== state.showHiddenSessions;
   state.showHiddenSessions = nextShowHiddenSessions;
   localStorage.setItem(STORAGE_KEYS.showHiddenSessions, state.showHiddenSessions ? '1' : '0');
@@ -2143,24 +2132,42 @@ const applyProviderChange = async (provider) => {
   app.updateHeader();
 };
 
+const persistRuntimeSelection = () => {
+  const persist = (key, value) => {
+    if (value) {
+      localStorage.setItem(key, value);
+    } else {
+      localStorage.removeItem(key);
+    }
+  };
+  persist(STORAGE_KEYS.selectedProvider, state.selectedProvider || '');
+  persist(STORAGE_KEYS.selectedModel, state.selectedModel || '');
+  persist(STORAGE_KEYS.selectedEffort, state.selectedEffort || '');
+};
+
+const canonicalizeSelectedModelEffort = () => {
+  const split = splitHeaderModelEffort(state.selectedModel, state.selectedEffort, state.models);
+  if (split.model === (state.selectedModel || '') && split.effort === (state.selectedEffort || '')) {
+    return false;
+  }
+  state.selectedModel = split.model;
+  state.selectedEffort = split.effort;
+  persistRuntimeSelection();
+  return true;
+};
+
 const applyModelChange = (model) => {
   state.selectedModel = model;
-  if (model) {
-    localStorage.setItem(STORAGE_KEYS.selectedModel, model);
-  } else {
-    localStorage.removeItem(STORAGE_KEYS.selectedModel);
-  }
+  canonicalizeSelectedModelEffort();
+  persistRuntimeSelection();
   syncSettingsSelectValues();
   app.updateHeader();
 };
 
 const applyEffortChange = (effort) => {
   state.selectedEffort = effort;
-  if (effort) {
-    localStorage.setItem(STORAGE_KEYS.selectedEffort, effort);
-  } else {
-    localStorage.removeItem(STORAGE_KEYS.selectedEffort);
-  }
+  canonicalizeSelectedModelEffort();
+  persistRuntimeSelection();
   syncSettingsSelectValues();
   app.updateHeader();
 };
@@ -2669,6 +2676,7 @@ const populateModelSelectOptions = (sel, models, previous) => {
 };
 
 const renderModelOptions = () => {
+  canonicalizeSelectedModelEffort();
   const previous = state.selectedModel;
   populateModelSelectOptions(elements.modelSelect, state.models, previous);
   populateModelSelectOptions(elements.chipModelSelect, state.models, previous);
@@ -3635,6 +3643,7 @@ const sendMessage = async (options = {}) => {
       const normalized = String(value || '').trim();
       return normalized.toLowerCase() === 'default' ? '' : normalized;
     };
+    canonicalizeSelectedModelEffort();
     const currentProvider = session.provider || '';
     const currentModel = session.activeModel || '';
     const currentEffort = session.activeEffort || '';
@@ -3895,6 +3904,7 @@ Object.assign(app, {
   handleAuthFailure,
   connectToken,
   normalizeSelectedProvider,
+  canonicalizeSelectedModelEffort,
   renderProviderOptions,
   renderModelOptions,
   autoGrowPrompt,

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -251,6 +251,26 @@ const app = loadAppCore();
   pass(name);
 })();
 
+(function testStripsConflictingEffortSuffixWhenBaseModelExists() {
+  const name = 'splitHeaderModelEffort strips stale suffix when separate effort wins';
+  const result = app.splitHeaderModelEffort('gpt-5.5-medium', 'xhigh', ['gpt-5.5']);
+  if (result.model !== 'gpt-5.5' || result.effort !== 'xhigh') {
+    fail(name, `got ${JSON.stringify(result)}`, 'want {"model":"gpt-5.5","effort":"xhigh"}');
+    return;
+  }
+  pass(name);
+})();
+
+(function testKeepsKnownModelWhoseNameEndsWithEffortWord() {
+  const name = 'splitHeaderModelEffort keeps known natural suffix model';
+  const result = app.splitHeaderModelEffort('gpt-5.1-codex-max', 'xhigh', ['gpt-5.1-codex-max']);
+  if (result.model !== 'gpt-5.1-codex-max' || result.effort !== 'xhigh') {
+    fail(name, `got ${JSON.stringify(result)}`, 'want natural model untouched');
+    return;
+  }
+  pass(name);
+})();
+
 (function testCompactHeaderModelLabelRemovesProviderNoise() {
   const name = 'compactHeaderModelLabel removes provider noise';
   const cases = [

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -368,6 +368,7 @@ function createHarness(options = {}) {
         options.onUpdateSessionUsageDisplay(session, state.streaming);
       }
     },
+    splitHeaderModelEffort(model, effort) { return { model: String(model || '').trim(), effort: String(effort || '').trim() }; },
     refreshRelativeTimes() {},
     updateAssistantNode() {},
     updateUserNode(message) { if (typeof options.onUpdateUserNode === 'function') options.onUpdateUserNode(message); },

--- a/internal/serveui/static/chip_picker_test.js
+++ b/internal/serveui/static/chip_picker_test.js
@@ -258,6 +258,26 @@ function testSplitHeaderModelEffortDetectsKnownEffortSuffix() {
   pass(name);
 }
 
+function testRenderModelOptionsCanonicalizesStaleEffortSuffix() {
+  const name = 'renderModelOptions canonicalizes stale suffixed selected model';
+  const { app, elementMap } = loadCoreAndStream();
+  app.state.models = ['gpt-5.5', 'gpt-5.4'];
+  app.state.selectedModel = 'gpt-5.5-medium';
+  app.state.selectedEffort = 'xhigh';
+  app.renderModelOptions();
+
+  if (app.state.selectedModel !== 'gpt-5.5' || app.state.selectedEffort !== 'xhigh') {
+    fail(name, `state = ${JSON.stringify({ model: app.state.selectedModel, effort: app.state.selectedEffort })}`);
+    return;
+  }
+  const values = elementMap.chipModelSelect.children.map((child) => child.value);
+  if (values.includes('gpt-5.5-medium') || !values.includes('gpt-5.5')) {
+    fail(name, `unexpected model options ${JSON.stringify(values)}`);
+    return;
+  }
+  pass(name);
+}
+
 function testUpdateSessionUsageDisplayUsesProviderDefaultModel() {
   const name = 'updateSessionUsageDisplay shows provider default_model muted when no model selected';
   const { app, elementMap } = loadCore();
@@ -287,6 +307,30 @@ function testUpdateSessionUsageDisplayUsesProviderDefaultModel() {
   }
   if (!modelLabel.classList.contains('stats-muted')) {
     fail(name, 'model label should be muted when showing default');
+    return;
+  }
+  pass(name);
+}
+
+function testUpdateSessionUsageDisplaySplitsSuffixedProviderDefaultModel() {
+  const name = 'updateSessionUsageDisplay splits suffixed provider default_model';
+  const { app, elementMap } = loadCore();
+  app.state.providers = [
+    { name: 'chatgpt', is_default: true, default_model: 'gpt-5.5-medium', models: ['gpt-5.5'] },
+  ];
+  app.state.models = ['gpt-5.5'];
+  app.state.selectedProvider = '';
+  app.state.selectedModel = '';
+  app.state.selectedEffort = 'xhigh';
+
+  app.updateSessionUsageDisplay(null);
+
+  if (elementMap.chipModelLabel.textContent !== 'gpt-5.5') {
+    fail(name, `expected model label gpt-5.5 got ${JSON.stringify(elementMap.chipModelLabel.textContent)}`);
+    return;
+  }
+  if (elementMap.chipEffortLabel.textContent !== 'xhigh') {
+    fail(name, `expected effort xhigh got ${JSON.stringify(elementMap.chipEffortLabel.textContent)}`);
     return;
   }
   pass(name);
@@ -802,7 +846,9 @@ function testMobilePopoverUsesVisualViewportSafeBounds() {
 }
 async function main() {
   testSplitHeaderModelEffortDetectsKnownEffortSuffix();
+  testRenderModelOptionsCanonicalizesStaleEffortSuffix();
   testUpdateSessionUsageDisplayUsesProviderDefaultModel();
+  testUpdateSessionUsageDisplaySplitsSuffixedProviderDefaultModel();
   testUpdateSessionUsageDisplayFallsBackToFirstModelWithoutDefault();
   testChipLockAllowsIdleSessionAndLocksBusyState();
   testUpdateSessionUsageDisplayUsesSelectedRuntimeForIdleSession();


### PR DESCRIPTION
## What

- Canonicalize model/effort pairs server-side before persisting, comparing, streaming, or returning session runtime state.
- Treat `gpt-5.5-medium` + `reasoning_effort=xhigh` as model `gpt-5.5` + effort `xhigh`; explicit effort wins over suffix.
- Keep provider-aware parsing so natural model names like `gpt-5.1-codex-max` are not chopped into fake effort variants.
- Add client-side cleanup for stale localStorage/session state and model picker custom entries, including the provider-default fallback path.

## Why

The web UI has a dedicated effort selector. Showing `gpt-5.5-medium` as the model while also showing `XHIGH` as effort is contradictory: `gpt-5.5` is the model, `xhigh` is the effort. The server should not echo that contradiction and rely on the client to paper over it.

## Tests

- `go build ./...`
- `go test ./...`
- `mise x node@24.15.0 -- node internal/serveui/static/app_core_test.js`
- `mise x node@24.15.0 -- node internal/serveui/static/chip_picker_test.js`
- `mise x node@24.15.0 -- node internal/serveui/static/app_stream_test.js`
- `mise x node@24.15.0 -- node internal/serveui/static/app_sessions_test.js`
