### PR TITLE
perf: render streaming markdown blocks incrementally

### DIFF
--- a/internal/ui/streaming/committed_parity_test.go
+++ b/internal/ui/streaming/committed_parity_test.go
@@ -1,0 +1,111 @@
+package streaming
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCommittedRenderedMatchesDirectAtStreamingBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		partial bool
+	}{
+		{
+			name:  "positive incremental paragraphs and heading",
+			input: "Alpha.\n\n## Heading\n\nBeta.\n\n```go\nfmt.Println(\"hi\")\n```\n",
+		},
+		{
+			name:    "positive incremental production partial mode",
+			input:   "Alpha.\n\n## Heading\n\nBeta.\n\n```go\nfmt.Println(\"hi\")\n```\n",
+			partial: true,
+		},
+		{
+			name:  "tight list sibling flush stays tight",
+			input: "- a\n- b\n- c\n",
+		},
+		{
+			name:  "indented heading-looking line remains paragraph continuation",
+			input: "foo\n    # bar\n",
+		},
+		{
+			name:  "indented thematic-looking line remains paragraph continuation",
+			input: "Foo\n    ***\n",
+		},
+		{
+			name:  "blockquote reference definition can rewrite earlier shortcut ref",
+			input: "[foo]\n\n> [foo]: https://example.com\n\nAfter\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sr := newCommittedParityRenderer(t, &bytes.Buffer{}, tt.partial)
+			for i := 0; i < len(tt.input); i++ {
+				if _, err := sr.Write([]byte{tt.input[i]}); err != nil {
+					t.Fatalf("write byte %d failed: %v", i, err)
+				}
+				assertCommittedRenderedMatchesDirect(t, sr, []byte(tt.input[:i+1]))
+			}
+		})
+	}
+}
+
+func TestCorpusCommittedRenderedMatchesDirectAtStreamingBoundaries(t *testing.T) {
+	for _, doc := range loadCorpusDocuments(t) {
+		for _, partial := range []bool{false, true} {
+			name := doc.name
+			if partial {
+				name += "/partial"
+			} else {
+				name += "/plain"
+			}
+			t.Run(name, func(t *testing.T) {
+				sr := newCommittedParityRenderer(t, &bytes.Buffer{}, partial)
+				for i := 0; i < len(doc.content); i++ {
+					if _, err := sr.Write(doc.content[i : i+1]); err != nil {
+						t.Fatalf("write byte %d failed: %v", i, err)
+					}
+					assertCommittedRenderedMatchesDirect(t, sr, doc.content[:i+1])
+				}
+			})
+		}
+	}
+}
+
+func newCommittedParityRenderer(t testing.TB, w *bytes.Buffer, partial bool) *StreamRenderer {
+	t.Helper()
+	if partial {
+		sr, err := NewRendererWithOptions(
+			w,
+			newTestMarkdownRenderer(testRenderWidth),
+			[]StreamRendererOption{WithPartialRendering()},
+		)
+		if err != nil {
+			t.Fatalf("NewRendererWithOptions failed: %v", err)
+		}
+		return sr
+	}
+	sr, err := NewRenderer(w, newTestMarkdownRenderer(testRenderWidth))
+	if err != nil {
+		t.Fatalf("NewRenderer failed: %v", err)
+	}
+	return sr
+}
+
+func assertCommittedRenderedMatchesDirect(t testing.TB, sr *StreamRenderer, inputPrefix []byte) {
+	t.Helper()
+	committedLen := sr.CommittedMarkdownLen()
+	if committedLen == 0 {
+		if got := sr.CommittedRendered(); got != "" {
+			t.Fatalf("CommittedRendered() = %q, want empty", got)
+		}
+		return
+	}
+	if committedLen > len(inputPrefix) {
+		t.Fatalf("committed length %d exceeds input prefix %d", committedLen, len(inputPrefix))
+	}
+	want := renderDirectBytes(t, inputPrefix[:committedLen])
+	got := []byte(sr.CommittedRendered())
+	assertRenderedEqual(t, want, got, [][]byte{inputPrefix})
+}

--- a/internal/ui/streaming/commonmark_corpus_test.go
+++ b/internal/ui/streaming/commonmark_corpus_test.go
@@ -1,0 +1,39 @@
+package streaming
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestCommonMarkFullSpecMarkdownStreamingParity(t *testing.T) {
+	input := []byte(commonMarkSpecMarkdown(t))
+	want := renderDirectBytes(t, input)
+	cases := []corpusChunkCase{
+		{name: "all-at-once", chunks: [][]byte{append([]byte(nil), input...)}},
+		{name: "hundred-pieces", chunks: splitIntoNPieces(input, 100)},
+		{name: "random-seed-1", chunks: randomChunks(input, 1, 32)},
+		{name: "random-seed-89", chunks: randomChunks(input, 89, 32)},
+		{name: "adversarial-markdown-cuts", chunks: adversarialMarkdownChunks(input)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderStreamedBytes(t, tc.chunks)
+			assertRenderedEqual(t, want, got, tc.chunks)
+		})
+	}
+}
+
+func commonMarkSpecMarkdown(tb testing.TB) string {
+	tb.Helper()
+	examples := loadSpec(tb)
+	var combined bytes.Buffer
+	for _, ex := range examples {
+		if combined.Len() > 0 {
+			combined.WriteString("\n\n")
+		}
+		combined.WriteString(fmt.Sprintf("<!-- CommonMark example %d: %s -->\n", ex.Example, ex.Section))
+		combined.WriteString(ex.Markdown)
+	}
+	return combined.String()
+}

--- a/internal/ui/streaming/commonmark_fuzz_test.go
+++ b/internal/ui/streaming/commonmark_fuzz_test.go
@@ -1,0 +1,28 @@
+package streaming
+
+import "testing"
+
+func FuzzCommonMarkFullSpecChunking(f *testing.F) {
+	for _, seed := range []int64{0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89} {
+		f.Add(seed, byte(seed))
+	}
+
+	input := []byte(commonMarkSpecMarkdown(f))
+	want := renderDirectBytes(f, input)
+
+	f.Fuzz(func(t *testing.T, seed int64, mode byte) {
+		var chunks [][]byte
+		switch mode % 4 {
+		case 0:
+			chunks = splitIntoNPieces(input, 100)
+		case 1:
+			chunks = randomChunks(input, seed, 32)
+		case 2:
+			chunks = randomChunks(input, seed, 128)
+		default:
+			chunks = adversarialMarkdownChunks(input)
+		}
+		got := renderStreamedBytes(t, chunks)
+		assertRenderedEqual(t, want, got, chunks)
+	})
+}

--- a/internal/ui/streaming/corpus_test.go
+++ b/internal/ui/streaming/corpus_test.go
@@ -1,0 +1,258 @@
+package streaming
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestCorpusStreamingParity(t *testing.T) {
+	for _, doc := range loadCorpusDocuments(t) {
+		t.Run(doc.name, func(t *testing.T) {
+			want := renderDirectBytes(t, doc.content)
+			cases := corpusChunkCases(doc.content)
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					got := renderStreamedBytes(t, tc.chunks)
+					assertRenderedEqual(t, want, got, tc.chunks)
+				})
+			}
+		})
+	}
+}
+
+type corpusDocument struct {
+	name    string
+	content []byte
+}
+
+type corpusChunkCase struct {
+	name   string
+	chunks [][]byte
+}
+
+func loadCorpusDocuments(t testing.TB) []corpusDocument {
+	t.Helper()
+	root := filepath.Join("testdata", "corpus")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	docs := make([]corpusDocument, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		docs = append(docs, corpusDocument{name: strings.TrimSuffix(entry.Name(), ".md"), content: content})
+	}
+	if len(docs) == 0 {
+		t.Fatalf("no corpus documents found in %s", root)
+	}
+	return docs
+}
+
+func corpusChunkCases(input []byte) []corpusChunkCase {
+	cases := []corpusChunkCase{
+		{name: "all-at-once", chunks: [][]byte{append([]byte(nil), input...)}},
+		{name: "byte-by-byte", chunks: fixedSizeChunks(input, 1)},
+		{name: "line-by-line", chunks: bytes.SplitAfter(input, []byte("\n"))},
+		{name: "hundred-pieces", chunks: splitIntoNPieces(input, 100)},
+		{name: "adversarial-markdown-cuts", chunks: adversarialMarkdownChunks(input)},
+	}
+	for _, size := range []int{2, 3, 5, 8, 13, 21, 64} {
+		cases = append(cases, corpusChunkCase{
+			name:   fmt.Sprintf("fixed-%d", size),
+			chunks: fixedSizeChunks(input, size),
+		})
+	}
+	for _, seed := range []int64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89} {
+		cases = append(cases, corpusChunkCase{
+			name:   fmt.Sprintf("random-seed-%d", seed),
+			chunks: randomChunks(input, seed, 32),
+		})
+	}
+	return cases
+}
+
+func normalizeStreamingSourceForDirect(input []byte) []byte {
+	// StreamRenderer preserves legacy terminal behaviour by normalizing tabs in
+	// markdown to two spaces once any streamed chunk contains a tab.
+	input = bytes.ReplaceAll(input, []byte("\t"), []byte("  "))
+	// Flush treats a trailing partial line as a complete line by appending a
+	// newline before final render. Mirror that source-level behavior for direct
+	// parity tests and fuzzing.
+	if len(input) > 0 && !bytes.HasSuffix(input, []byte("\n")) {
+		input = append(append([]byte(nil), input...), '\n')
+	}
+	return input
+}
+
+func renderDirectBytes(t testing.TB, input []byte) []byte {
+	t.Helper()
+	renderer := newTestMarkdownRenderer(testRenderWidth)
+	out, err := renderer.Render(normalizeStreamingSourceForDirect(input))
+	if err != nil {
+		t.Fatalf("direct render failed: %v", err)
+	}
+	return normalizeNewlines(out)
+}
+
+func renderStreamedBytes(t testing.TB, chunks [][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	sr, err := NewRenderer(&buf, newTestMarkdownRenderer(testRenderWidth))
+	if err != nil {
+		t.Fatalf("NewRenderer failed: %v", err)
+	}
+	for i, chunk := range chunks {
+		if len(chunk) == 0 {
+			continue
+		}
+		if _, err := sr.Write(chunk); err != nil {
+			t.Fatalf("write chunk %d failed: %v", i, err)
+		}
+	}
+	if err := sr.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func fixedSizeChunks(input []byte, size int) [][]byte {
+	if size <= 0 {
+		panic("chunk size must be positive")
+	}
+	chunks := make([][]byte, 0, (len(input)+size-1)/size)
+	for start := 0; start < len(input); start += size {
+		end := min(start+size, len(input))
+		chunks = append(chunks, append([]byte(nil), input[start:end]...))
+	}
+	return chunks
+}
+
+func splitIntoNPieces(input []byte, n int) [][]byte {
+	if n <= 0 {
+		panic("piece count must be positive")
+	}
+	if len(input) == 0 {
+		return nil
+	}
+	if n > len(input) {
+		n = len(input)
+	}
+	chunks := make([][]byte, 0, n)
+	for i := 0; i < n; i++ {
+		start := i * len(input) / n
+		end := (i + 1) * len(input) / n
+		if start == end {
+			continue
+		}
+		chunks = append(chunks, append([]byte(nil), input[start:end]...))
+	}
+	return chunks
+}
+
+func randomChunks(input []byte, seed int64, maxSize int) [][]byte {
+	if maxSize <= 0 {
+		panic("max chunk size must be positive")
+	}
+	r := rand.New(rand.NewSource(seed))
+	chunks := make([][]byte, 0)
+	for start := 0; start < len(input); {
+		size := r.Intn(maxSize) + 1
+		end := min(start+size, len(input))
+		chunks = append(chunks, append([]byte(nil), input[start:end]...))
+		start = end
+	}
+	return chunks
+}
+
+func adversarialMarkdownChunks(input []byte) [][]byte {
+	cutAfter := map[int]struct{}{len(input): {}}
+	markers := []byte("#*_`~|[]()>-+.\n")
+	for i, b := range input {
+		if bytes.IndexByte(markers, b) >= 0 {
+			for _, cut := range []int{i, i + 1, i + 2} {
+				if cut > 0 && cut < len(input) {
+					cutAfter[cut] = struct{}{}
+				}
+			}
+		}
+	}
+	cuts := make([]int, 0, len(cutAfter))
+	for cut := range cutAfter {
+		cuts = append(cuts, cut)
+	}
+	sort.Ints(cuts)
+	chunks := make([][]byte, 0, len(cuts))
+	prev := 0
+	for _, cut := range cuts {
+		if cut <= prev {
+			continue
+		}
+		chunks = append(chunks, append([]byte(nil), input[prev:cut]...))
+		prev = cut
+	}
+	return chunks
+}
+
+func assertRenderedEqual(t testing.TB, want, got []byte, chunks [][]byte) {
+	t.Helper()
+	if bytes.Equal(want, got) {
+		return
+	}
+	idx := firstDiff(want, got)
+	t.Fatalf("streamed render mismatch at byte %d\nwant around diff: %q\ngot  around diff: %q\nchunk sizes: %v", idx, surroundingBytes(want, idx), surroundingBytes(got, idx), chunkSizes(chunks))
+}
+
+func firstDiff(a, b []byte) int {
+	limit := min(len(a), len(b))
+	for i := 0; i < limit; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return limit
+}
+
+func surroundingBytes(b []byte, idx int) []byte {
+	start := max(0, idx-40)
+	end := min(len(b), idx+80)
+	return b[start:end]
+}
+
+func chunkSizes(chunks [][]byte) []int {
+	sizes := make([]int, 0, len(chunks))
+	for _, chunk := range chunks {
+		if len(chunk) > 0 {
+			sizes = append(sizes, len(chunk))
+		}
+	}
+	return sizes
+}
+
+func TestSplitIntoNPiecesProducesDeterministicNonEmptyChunks(t *testing.T) {
+	input := []byte("abcdefghijklmnopqrstuvwxyz")
+	chunks := splitIntoNPieces(input, 100)
+	if len(chunks) != len(input) {
+		t.Fatalf("got %d chunks, want %d", len(chunks), len(input))
+	}
+	if joined := bytes.Join(chunks, nil); !bytes.Equal(joined, input) {
+		t.Fatalf("chunks did not reconstruct input")
+	}
+	if !reflect.DeepEqual(chunkSizes(splitIntoNPieces(input, 5)), []int{5, 5, 5, 5, 6}) {
+		t.Fatalf("unexpected 5-piece split sizes: %v", chunkSizes(splitIntoNPieces(input, 5)))
+	}
+}

--- a/internal/ui/streaming/fuzz_test.go
+++ b/internal/ui/streaming/fuzz_test.go
@@ -1,0 +1,56 @@
+package streaming
+
+import (
+	"bytes"
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzStreamingCorpusParity(f *testing.F) {
+	for _, doc := range loadCorpusDocuments(f) {
+		f.Add(string(doc.content), int64(1), byte(0))
+	}
+	for _, ex := range loadSpec(f) {
+		if len(ex.Markdown) <= 2048 {
+			f.Add(ex.Markdown, int64(ex.Example), byte(ex.Example))
+		}
+	}
+	seeds := []string{
+		"# Heading\n\nParagraph with **bold** and `code`.\n",
+		"```go\nfunc main() {\n\tfmt.Println(\"hi\")\n}\n```\n",
+		"- one\n- two\n\nDone.\n",
+		"A setext heading\n---\n\nDone.\n",
+		"| a | b |\n|---|---|\n| 1 | 2 |\n",
+	}
+	for i, seed := range seeds {
+		f.Add(seed, int64(i+1), byte(i))
+	}
+
+	f.Fuzz(func(t *testing.T, input string, seed int64, mode byte) {
+		if len(input) > 2048 {
+			t.Skip()
+		}
+		if !utf8.ValidString(input) {
+			t.Skip()
+		}
+		content := []byte(input)
+		want := renderDirectBytes(t, content)
+		var chunks [][]byte
+		switch mode % 5 {
+		case 0:
+			chunks = [][]byte{append([]byte(nil), content...)}
+		case 1:
+			chunks = fixedSizeChunks(content, 1)
+		case 2:
+			chunks = splitIntoNPieces(content, 100)
+		case 3:
+			chunks = randomChunks(content, seed, 32)
+		default:
+			chunks = adversarialMarkdownChunks(content)
+		}
+		got := renderStreamedBytes(t, chunks)
+		if !bytes.Equal(want, got) {
+			assertRenderedEqual(t, want, got, chunks)
+		}
+	})
+}

--- a/internal/ui/streaming/streaming.go
+++ b/internal/ui/streaming/streaming.go
@@ -116,6 +116,11 @@ type StreamRenderer struct {
 	// Resume state when a nested block (like fenced code) ends.
 	// Used to keep list context stable across nested blocks.
 	resumeState state
+
+	// Incremental rendering is a conservative fast path for complete blocks whose
+	// rendered form is independent of future markdown. The full-document render
+	// remains the correctness fallback for globally-sensitive constructs.
+	incrementalUnsafe bool
 }
 
 // NewRenderer creates a new streaming markdown renderer.
@@ -293,14 +298,173 @@ func (sr *StreamRenderer) resetListState() {
 // commitPendingLines appends pending block lines into allMarkdown and emits
 // the incremental rendered delta for the updated full document.
 func (sr *StreamRenderer) commitPendingLines() error {
+	markdown := sr.takePendingLines()
+	if len(markdown) == 0 {
+		return nil
+	}
+	return sr.emitCommittedFull(markdown)
+}
+
+func (sr *StreamRenderer) commitPendingLinesIncremental() error {
+	markdown := sr.takePendingLines()
+	if len(markdown) == 0 {
+		return nil
+	}
+	return sr.emitCommittedBlock(markdown)
+}
+
+func (sr *StreamRenderer) takePendingLines() []byte {
 	if len(sr.pendingLines) == 0 {
 		return nil
 	}
+	var markdown bytes.Buffer
 	for _, l := range sr.pendingLines {
+		markdown.WriteString(l)
 		sr.allMarkdown.WriteString(l)
 	}
 	sr.pendingLines = nil
+	return markdown.Bytes()
+}
+
+func (sr *StreamRenderer) emitCommittedFull(markdown []byte) error {
+	if markdownHasGlobalMarkdownSemantics(markdown) {
+		sr.incrementalUnsafe = true
+	}
 	return sr.emitRendered()
+}
+
+// emitCommittedBlock renders a newly committed top-level block. It first tries
+// a conservative append-only render of just that block; globally-sensitive
+// markdown falls back to the legacy full-document render so correctness remains
+// anchored to the complete parser output.
+func (sr *StreamRenderer) emitCommittedBlock(markdown []byte) error {
+	if sr.canAppendRenderedBlock(markdown) {
+		if err := sr.emitRenderedBlock(markdown); err == nil {
+			return nil
+		}
+	}
+	return sr.emitRendered()
+}
+
+func (sr *StreamRenderer) commitRawBlock(markdown string, allowIncremental bool) error {
+	sr.allMarkdown.WriteString(markdown)
+	if !allowIncremental {
+		return sr.emitCommittedFull([]byte(markdown))
+	}
+	return sr.emitCommittedBlock([]byte(markdown))
+}
+
+func (sr *StreamRenderer) commitPendingLinesWith(rawLine string, allowIncremental bool) error {
+	markdown := sr.takePendingLines()
+	if rawLine != "" {
+		markdown = append(markdown, rawLine...)
+		sr.allMarkdown.WriteString(rawLine)
+	}
+	if len(markdown) == 0 {
+		return nil
+	}
+	if !allowIncremental {
+		return sr.emitCommittedFull(markdown)
+	}
+	return sr.emitCommittedBlock(markdown)
+}
+
+func (sr *StreamRenderer) canAppendRenderedBlock(markdown []byte) bool {
+	if sr.incrementalUnsafe {
+		return false
+	}
+	if markdownHasGlobalMarkdownSemantics(markdown) {
+		sr.incrementalUnsafe = true
+		return false
+	}
+	return true
+}
+
+func markdownHasGlobalMarkdownSemantics(markdown []byte) bool {
+	lines := bytes.Split(markdown, []byte("\n"))
+	for _, line := range lines {
+		trimmed := bytes.TrimLeft(line, " \t")
+		if len(trimmed) == 0 {
+			continue
+		}
+		// Link reference definitions can affect links anywhere earlier in the
+		// document, so once one appears the safe append-only model is invalid.
+		if lineHasReferenceDefinition(trimmed) {
+			return true
+		}
+		// Reference-style and shortcut reference links may be resolved by future
+		// definitions. Inline links ([label](url)) are local and safe.
+		if lineHasPotentialReferenceLink(trimmed) {
+			return true
+		}
+		// Raw HTML block boundaries and inline/raw rendering can be affected by
+		// neighbouring lines. Keep the fast path boring rather than clever.
+		if trimmed[0] == '<' {
+			return true
+		}
+	}
+	return false
+}
+
+func lineHasReferenceDefinition(line []byte) bool {
+	return len(line) > 1 && line[0] == '[' && bytes.Contains(line, []byte("]:"))
+}
+
+func lineHasPotentialReferenceLink(line []byte) bool {
+	for i := 0; i < len(line); i++ {
+		if line[i] != '[' {
+			continue
+		}
+		close := bytes.IndexByte(line[i+1:], ']')
+		if close < 0 {
+			continue
+		}
+		after := i + 1 + close + 1
+		if after < len(line) && line[after] == '(' {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func trimRenderedBlock(rendered []byte) []byte {
+	return bytes.Trim(rendered, "\n")
+}
+
+func (sr *StreamRenderer) emitRenderedBlock(markdown []byte) error {
+	if sr.partialEnabled {
+		if err := sr.clearPartialState(); err != nil {
+			return err
+		}
+	}
+
+	blockMarkdown := markdown
+	if sr.hasTabs {
+		blockMarkdown = bytes.ReplaceAll(markdown, []byte("\t"), []byte("  "))
+	}
+
+	rendered, err := sr.renderer.Render(blockMarkdown)
+	if err != nil {
+		return err
+	}
+	rendered = normalizeNewlines(rendered)
+	rendered = trimRenderedBlock(rendered)
+	if len(rendered) == 0 {
+		return nil
+	}
+
+	// Match the ANSI renderer's top-level block separator. If
+	// internal/render/markdown changes renderBlockChildren's document separator,
+	// committed-boundary parity tests should fail before this leaks to scrollback.
+	snapshot := make([]byte, 0, len(sr.lastCommittedRendered)+2+len(rendered))
+	if len(sr.lastCommittedRendered) > 0 {
+		snapshot = append(snapshot, sr.lastCommittedRendered...)
+		snapshot = append(snapshot, '\n', '\n')
+	}
+	snapshot = append(snapshot, rendered...)
+	sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], snapshot...)
+	return sr.applyRenderedSnapshot(snapshot, false)
 }
 
 // applyRenderedSnapshot writes the next rendered snapshot using one of:
@@ -390,14 +554,15 @@ func (sr *StreamRenderer) handleReady(content, rawLine string) error {
 		sr.pendingLines = append(sr.pendingLines, rawLine)
 
 	case blockHeading:
-		// Headings are complete immediately (single line)
-		sr.allMarkdown.WriteString(rawLine)
-		return sr.emitRendered()
+		// Headings are complete immediately (single line). Only use the
+		// block-local fast path when indentation cannot reinterpret the line as
+		// an indented code continuation in CommonMark.
+		return sr.commitRawBlock(rawLine, countLeadingSpaces(content) < 4)
 
 	case blockThematicBreak:
-		// Thematic breaks are complete immediately
-		sr.allMarkdown.WriteString(rawLine)
-		return sr.emitRendered()
+		// Thematic breaks are complete immediately. Keep the fast path limited to
+		// CommonMark top-level indentation.
+		return sr.commitRawBlock(rawLine, countLeadingSpaces(content) < 4)
 
 	case blockTable:
 		sr.state = stateInTable
@@ -427,27 +592,17 @@ func (sr *StreamRenderer) handleReady(content, rawLine string) error {
 func (sr *StreamRenderer) handleParagraph(content, rawLine string) error {
 	// Blank line ends paragraph
 	if isBlankLine(content) {
-		// Commit pending lines to markdown
-		for _, l := range sr.pendingLines {
-			sr.allMarkdown.WriteString(l)
-		}
-		sr.pendingLines = nil
-		sr.allMarkdown.WriteString(rawLine)
+		// Commit pending paragraph plus the terminating blank line.
 		sr.state = stateReady
-		return sr.emitRendered()
+		return sr.commitPendingLinesWith(rawLine, true)
 	}
 
 	// IMPORTANT: Check for setext heading underline FIRST (=== or ---)
 	// This must be checked before thematic break because --- is ambiguous
 	if isSetextUnderline(content) && len(sr.pendingLines) > 0 {
 		// This converts the paragraph to a heading
-		for _, l := range sr.pendingLines {
-			sr.allMarkdown.WriteString(l)
-		}
-		sr.pendingLines = nil
-		sr.allMarkdown.WriteString(rawLine)
 		sr.state = stateReady
-		return sr.emitRendered()
+		return sr.commitPendingLinesWith(rawLine, true)
 	}
 
 	// Check if this line starts a new block type
@@ -456,12 +611,8 @@ func (sr *StreamRenderer) handleParagraph(content, rawLine string) error {
 	switch blockType {
 	case blockFencedCode, blockHeading, blockThematicBreak, blockTable, blockList, blockBlockquote:
 		// Commit current paragraph first
-		for _, l := range sr.pendingLines {
-			sr.allMarkdown.WriteString(l)
-		}
-		sr.pendingLines = nil
 		sr.state = stateReady
-		if err := sr.emitRendered(); err != nil {
+		if err := sr.commitPendingLines(); err != nil {
 			return err
 		}
 		// Then process this line as a new block
@@ -489,15 +640,15 @@ func (sr *StreamRenderer) handleFencedCode(content, rawLine string) error {
 			return nil
 		}
 		// Commit all pending lines
-		for _, l := range sr.pendingLines {
-			sr.allMarkdown.WriteString(l)
-		}
-		sr.pendingLines = nil
+		allowIncremental := sr.fenceIndent < 4
 		sr.state = stateReady
 		sr.fenceChar = 0
 		sr.fenceLen = 0
 		sr.fenceIndent = 0
-		return sr.emitRendered()
+		if allowIncremental {
+			return sr.commitPendingLinesIncremental()
+		}
+		return sr.commitPendingLines()
 	}
 
 	return nil
@@ -517,12 +668,8 @@ func (sr *StreamRenderer) handleTable(content, rawLine string) error {
 		sr.resumeState = stateReady
 		return sr.handleList(content, rawLine)
 	}
-	for _, l := range sr.pendingLines {
-		sr.allMarkdown.WriteString(l)
-	}
-	sr.pendingLines = nil
 	sr.state = stateReady
-	if err := sr.emitRendered(); err != nil {
+	if err := sr.commitPendingLines(); err != nil {
 		return err
 	}
 
@@ -639,12 +786,8 @@ func (sr *StreamRenderer) handleBlockquote(content, rawLine string) error {
 		sr.resumeState = stateReady
 		return sr.handleList(content, rawLine)
 	}
-	for _, l := range sr.pendingLines {
-		sr.allMarkdown.WriteString(l)
-	}
-	sr.pendingLines = nil
 	sr.state = stateReady
-	if err := sr.emitRendered(); err != nil {
+	if err := sr.commitPendingLines(); err != nil {
 		return err
 	}
 	return sr.handleReady(content, rawLine)

--- a/internal/ui/streaming/testdata/corpus/basic-answer.md
+++ b/internal/ui/streaming/testdata/corpus/basic-answer.md
@@ -1,0 +1,17 @@
+# Basic answer
+
+This is a normal LLM answer with **bold**, _emphasis_, `inline code`, and [an inline link](https://example.com).
+
+## Steps
+
+1. Read the code.
+2. Add tests.
+3. Measure performance.
+
+```go
+func main() {
+	fmt.Println("hello")
+}
+```
+
+That should be enough.

--- a/internal/ui/streaming/testdata/corpus/cursed-boundaries.md
+++ b/internal/ui/streaming/testdata/corpus/cursed-boundaries.md
@@ -1,0 +1,13 @@
+# Cursed boundaries
+
+The stream may split inside **strong emphasis**, _emphasis_, ~~strike~~, `inline code`, and links like [docs](https://example.com/docs).
+
+```text
+A code fence can contain # headings, **markdown**, pipes | and fake fences `` that should not close it.
+```
+
+~~~python
+print("tilde fence")
+~~~
+
+Final line without tricks.

--- a/internal/ui/streaming/testdata/corpus/lists.md
+++ b/internal/ui/streaming/testdata/corpus/lists.md
@@ -1,0 +1,21 @@
+# Lists
+
+- tight one
+- tight two
+  - nested one
+  - nested two
+- tight three
+
+- loose one
+
+- loose two with continuation
+  still same item
+
+1. ordered one
+2. ordered two
+   ```ruby
+   puts "nested code"
+   ```
+3. ordered three
+
+Done.

--- a/internal/ui/streaming/testdata/corpus/quotes-and-tables.md
+++ b/internal/ui/streaming/testdata/corpus/quotes-and-tables.md
@@ -1,0 +1,14 @@
+> Block quote starts here.
+> It has **formatting** and `code`.
+>
+> - quoted list item
+> - another item
+
+Normal text after quote.
+
+| Name | Value |
+| --- | ---: |
+| alpha | 1 |
+| beta | 200 |
+
+Trailing paragraph.

--- a/internal/ui/streaming/testdata/corpus/reference-links.md
+++ b/internal/ui/streaming/testdata/corpus/reference-links.md
@@ -1,0 +1,7 @@
+This paragraph has an unresolved reference [example][ref] that is defined later.
+
+The renderer must not assume earlier output is immutable here.
+
+[ref]: https://example.com/reference
+
+A shortcut-ish reference [ref] and another paragraph.

--- a/internal/ui/streaming/testdata/corpus/setext-and-rules.md
+++ b/internal/ui/streaming/testdata/corpus/setext-and-rules.md
@@ -1,0 +1,11 @@
+Paragraph before the setext heading.
+
+A setext heading
+----------------
+
+Another setext heading
+======================
+
+---
+
+Final paragraph after a thematic break.


### PR DESCRIPTION
## What

Adds a conservative fast path for streaming markdown committed blocks:

- renders newly committed blocks incrementally instead of re-rendering the full accumulated markdown when the block is locally safe
- preserves the existing full-document render as the fallback/oracle for globally-sensitive markdown
- disables the fast path after reference-style/global constructs that can change earlier render output
- keeps resettable/non-resettable snapshot handling unchanged via `applyRenderedSnapshot`

Also adds a streaming markdown corpus and chunking parity harness:

- direct render vs streamed render
- all-at-once, byte-by-byte, line-by-line, fixed chunk sizes, random deterministic chunks
- explicit 100-piece splits
- adversarial cuts around markdown syntax bytes
- corpus covers headings, paragraphs, inline formatting, code fences, setext headings, rules, lists, blockquotes, tables, reference links, tabs, and cursed split boundaries

No session transcripts or private examples were committed; the corpus is synthetic.

## Why

The previous streaming renderer preserved correctness by re-rendering all accumulated markdown on each committed block. That is safe but has an accidental quadratic shape for long streamed responses.

The existing benchmark showed:

```text
BenchmarkStreamRendererLargeNoTabs
~63.3 ms/op
~38.5 MB/op
~357k allocs/op
```

This PR keeps the safety fallback while adding a fast path for the common case.

After:

```text
BenchmarkStreamRendererLargeNoTabs
~2.8-2.9 ms/op
~3.4 MB/op
~17k allocs/op
```

That is roughly:

- ~22x faster wall time
- ~11x less allocated memory
- ~21x fewer allocations

## Safety

The optimization is deliberately conservative:

- full render remains the fallback
- global/reference-style markdown disables the incremental path
- final output is protected by corpus parity tests across hostile chunking patterns
- existing CommonMark and streaming tests still pass

Verification run:

```text
go test ./... -count=1
go build ./...
git diff --check
go test ./internal/ui/streaming -run '^$' -bench 'BenchmarkStreamRendererLargeNoTabs|BenchmarkStreamingVsDirect|BenchmarkStreamingFull|BenchmarkStreamingChunked' -benchmem -count=5
```
