### PR TITLE
Persist claude-bin resume state

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -83,6 +83,84 @@ func (rt *serveRuntime) LastUsed() time.Time {
 	return time.Unix(0, unixNano)
 }
 
+func (rt *serveRuntime) providerStateKey() string {
+	if rt == nil {
+		return ""
+	}
+	if key := strings.TrimSpace(rt.providerKey); key != "" {
+		return key
+	}
+	if rt.provider == nil {
+		return ""
+	}
+	if cred := strings.TrimSpace(rt.provider.Credential()); cred != "" {
+		return cred
+	}
+	return strings.TrimSpace(rt.provider.Name())
+}
+
+func (rt *serveRuntime) restoreProviderState(ctx context.Context, sessionID string) {
+	if rt == nil || rt.store == nil || rt.provider == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	importer, ok := rt.provider.(llm.ProviderStateImporter)
+	if !ok {
+		return
+	}
+	stateStore, ok := rt.store.(session.ProviderStateStore)
+	if !ok {
+		return
+	}
+	providerKey := rt.providerStateKey()
+	if providerKey == "" {
+		return
+	}
+	state, err := stateStore.LoadProviderState(ctx, sessionID, providerKey)
+	if err != nil {
+		log.Printf("[serve] load provider state failed for %s/%s: %v", sessionID, providerKey, err)
+		return
+	}
+	if len(state) == 0 {
+		return
+	}
+	if err := importer.ImportProviderState(state); err != nil {
+		log.Printf("[serve] import provider state failed for %s/%s: %v", sessionID, providerKey, err)
+	}
+}
+
+func (rt *serveRuntime) persistProviderState(ctx context.Context, sessionID string) {
+	if rt == nil || rt.store == nil || rt.provider == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	stateStore, ok := rt.store.(session.ProviderStateStore)
+	if !ok {
+		return
+	}
+	providerKey := rt.providerStateKey()
+	if providerKey == "" {
+		return
+	}
+	dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	exporter, ok := rt.provider.(llm.ProviderStateExporter)
+	if !ok {
+		if err := stateStore.DeleteProviderState(dbCtx, sessionID, providerKey); err != nil {
+			log.Printf("[serve] delete provider state failed for %s/%s: %v", sessionID, providerKey, err)
+		}
+		return
+	}
+	state, ok := exporter.ExportProviderState()
+	if !ok || len(state) == 0 {
+		if err := stateStore.DeleteProviderState(dbCtx, sessionID, providerKey); err != nil {
+			log.Printf("[serve] delete provider state failed for %s/%s: %v", sessionID, providerKey, err)
+		}
+		return
+	}
+	if err := stateStore.SaveProviderState(dbCtx, sessionID, providerKey, state); err != nil {
+		log.Printf("[serve] save provider state failed for %s/%s: %v", sessionID, providerKey, err)
+	}
+}
+
 func (rt *serveRuntime) SessionNumber() int64 {
 	if rt == nil {
 		return 0
@@ -614,6 +692,9 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		rt.lastInjectedPlatform = ""
 		rt.historyPersisted = false
 	}
+	if persisted && stateful && !replaceHistory {
+		rt.restoreProviderState(ctx, req.SessionID)
+	}
 	turnIndex := countUserMessages(baseHistory)
 
 	var injectedPlatform string
@@ -1136,6 +1217,10 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		rt.historyPersisted = rt.persistSnapshot(ctx, req.SessionID, newHistory)
 	} else if persisted {
 		rt.historyPersisted = true
+	}
+
+	if persisted && stateful {
+		rt.persistProviderState(ctx, req.SessionID)
 	}
 
 	return result, nil

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -415,6 +416,121 @@ func serveRuntimeTextMessage(role llm.Role, text string) llm.Message {
 			Type: llm.PartText,
 			Text: text,
 		}},
+	}
+}
+
+type serveRuntimePersistentProviderState struct {
+	SessionID    string `json:"session_id"`
+	MessagesSent int    `json:"messages_sent"`
+}
+
+type serveRuntimePersistentProvider struct {
+	sessionID    string
+	messagesSent int
+	importCalls  int
+	received     [][]llm.Message
+}
+
+func (p *serveRuntimePersistentProvider) Name() string { return "persistent-provider" }
+
+func (p *serveRuntimePersistentProvider) Credential() string { return "claude-bin" }
+
+func (p *serveRuntimePersistentProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{ManagesOwnContext: true}
+}
+
+func (p *serveRuntimePersistentProvider) ExportProviderState() ([]byte, bool) {
+	if p.sessionID == "" {
+		return nil, false
+	}
+	data, err := json.Marshal(serveRuntimePersistentProviderState{
+		SessionID:    p.sessionID,
+		MessagesSent: p.messagesSent,
+	})
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+func (p *serveRuntimePersistentProvider) ImportProviderState(data []byte) error {
+	var state serveRuntimePersistentProviderState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return err
+	}
+	p.sessionID = state.SessionID
+	p.messagesSent = state.MessagesSent
+	p.importCalls++
+	return nil
+}
+
+func (p *serveRuntimePersistentProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	delivered := req.Messages
+	if p.sessionID != "" && p.messagesSent > 0 && p.messagesSent < len(req.Messages) {
+		delivered = req.Messages[p.messagesSent:]
+	}
+	p.received = append(p.received, append([]llm.Message(nil), delivered...))
+	if p.sessionID == "" {
+		p.sessionID = "claude-session-from-first-runtime"
+	}
+	p.messagesSent = len(req.Messages)
+	return &serveRuntimeTestStream{events: []llm.Event{
+		{Type: llm.EventTextDelta, Text: "provider answer"},
+		{Type: llm.EventDone},
+	}}, nil
+}
+
+func TestServeRuntimeRestoresProviderStateFromSessionStore(t *testing.T) {
+	ctx := context.Background()
+	sqlStore, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer sqlStore.Close()
+	store := session.NewLoggingStore(sqlStore, t.Logf)
+
+	newRuntime := func(provider *serveRuntimePersistentProvider) *serveRuntime {
+		return &serveRuntime{
+			provider:     provider,
+			providerKey:  "claude-bin",
+			engine:       llm.NewEngine(provider, nil),
+			store:        store,
+			defaultModel: "sonnet",
+		}
+	}
+
+	firstProvider := &serveRuntimePersistentProvider{}
+	if _, err := newRuntime(firstProvider).Run(ctx, true, false,
+		[]llm.Message{serveRuntimeTextMessage(llm.RoleUser, "first question")},
+		llm.Request{SessionID: "sess-persistent-provider", Model: "sonnet"}); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if len(firstProvider.received) != 1 || len(firstProvider.received[0]) != 1 {
+		t.Fatalf("first provider received = %#v, want the initial user message only", firstProvider.received)
+	}
+
+	secondProvider := &serveRuntimePersistentProvider{}
+	if _, err := newRuntime(secondProvider).Run(ctx, true, false,
+		[]llm.Message{serveRuntimeTextMessage(llm.RoleUser, "second question")},
+		llm.Request{SessionID: "sess-persistent-provider", Model: "sonnet"}); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if secondProvider.importCalls != 1 {
+		t.Fatalf("provider state import calls = %d, want 1", secondProvider.importCalls)
+	}
+	if len(secondProvider.received) != 1 {
+		t.Fatalf("second provider calls = %d, want 1", len(secondProvider.received))
+	}
+	var gotText strings.Builder
+	for _, msg := range secondProvider.received[0] {
+		gotText.WriteString(llm.MessageText(msg))
+		gotText.WriteString("\n")
+	}
+	if strings.Contains(gotText.String(), "first question") {
+		t.Fatalf("resumed provider was given already-sent first user turn: %q", gotText.String())
+	}
+	if !strings.Contains(gotText.String(), "second question") {
+		t.Fatalf("resumed provider did not receive the new user turn: %q", gotText.String())
 	}
 }
 

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -365,6 +365,48 @@ func (p *ClaudeBinProvider) ResetConversation() {
 	p.messagesSent = 0
 }
 
+type claudeBinProviderState struct {
+	SessionID    string `json:"session_id"`
+	MessagesSent int    `json:"messages_sent"`
+}
+
+// ExportProviderState persists Claude Code's session id plus the term-llm
+// transcript boundary already submitted to that session. On runtime rehydrate,
+// ImportProviderState lets claude-bin continue with --resume instead of
+// replaying the whole stored transcript as fresh stdin.
+func (p *ClaudeBinProvider) ExportProviderState() ([]byte, bool) {
+	if p.sessionID == "" {
+		return nil, false
+	}
+	data, err := json.Marshal(claudeBinProviderState{
+		SessionID:    p.sessionID,
+		MessagesSent: p.messagesSent,
+	})
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// ImportProviderState restores Claude Code resume state previously returned by
+// ExportProviderState.
+func (p *ClaudeBinProvider) ImportProviderState(data []byte) error {
+	var state claudeBinProviderState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("decode claude-bin provider state: %w", err)
+	}
+	state.SessionID = strings.TrimSpace(state.SessionID)
+	if state.SessionID == "" {
+		return fmt.Errorf("decode claude-bin provider state: missing session_id")
+	}
+	if state.MessagesSent < 0 {
+		return fmt.Errorf("decode claude-bin provider state: negative messages_sent")
+	}
+	p.sessionID = state.SessionID
+	p.messagesSent = state.MessagesSent
+	return nil
+}
+
 func (p *ClaudeBinProvider) Name() string {
 	model := p.model
 	if model == "" {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -876,6 +876,50 @@ func TestClaudeBinProvider_ResetConversationClearsResumeState(t *testing.T) {
 	}
 }
 
+func TestClaudeBinProviderProviderStateRoundTrip(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	p.sessionID = "resume-xyz"
+	p.messagesSent = 7
+
+	data, ok := p.ExportProviderState()
+	if !ok {
+		t.Fatal("ExportProviderState returned ok=false")
+	}
+
+	restored := NewClaudeBinProvider("sonnet", nil)
+	if err := restored.ImportProviderState(data); err != nil {
+		t.Fatalf("ImportProviderState: %v", err)
+	}
+	if restored.sessionID != "resume-xyz" {
+		t.Fatalf("restored sessionID = %q, want resume-xyz", restored.sessionID)
+	}
+	if restored.messagesSent != 7 {
+		t.Fatalf("restored messagesSent = %d, want 7", restored.messagesSent)
+	}
+
+	args, _ := restored.buildArgs(context.Background(), Request{}, eventSender{})
+	if joined := strings.Join(args, " "); !strings.Contains(joined, "--resume resume-xyz") {
+		t.Fatalf("buildArgs() = %q, want --resume resume-xyz", joined)
+	}
+}
+
+func TestClaudeBinProviderProviderStateRejectsInvalidData(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	if err := p.ImportProviderState([]byte(`{"messages_sent":1}`)); err == nil {
+		t.Fatal("expected missing session_id to fail")
+	}
+	if err := p.ImportProviderState([]byte(`{"session_id":"resume","messages_sent":-1}`)); err == nil {
+		t.Fatal("expected negative messages_sent to fail")
+	}
+}
+
+func TestClaudeBinProviderProviderStateEmptyWithoutSession(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	if data, ok := p.ExportProviderState(); ok || len(data) != 0 {
+		t.Fatalf("ExportProviderState() = (%q, %v), want empty false", data, ok)
+	}
+}
+
 func TestClaudeBinProvider_BuildCommandEnv(t *testing.T) {
 	origGetEuid := getEuid
 	defer func() { getEuid = origGetEuid }()

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -58,6 +58,20 @@ type Provider interface {
 	Stream(ctx context.Context, req Request) (Stream, error)
 }
 
+// ProviderStateExporter is implemented by stateful providers that can persist
+// opaque conversation transport state outside the user-visible transcript.
+// The returned bytes must be safe to store in the session database.
+type ProviderStateExporter interface {
+	ExportProviderState() ([]byte, bool)
+}
+
+// ProviderStateImporter restores state previously returned by
+// ProviderStateExporter. Providers should validate and ignore unusable state by
+// returning an error rather than partially applying it.
+type ProviderStateImporter interface {
+	ImportProviderState([]byte) error
+}
+
 // Capabilities describe optional provider features.
 type Capabilities struct {
 	NativeWebSearch    bool // Provider has native web search capability

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -206,6 +206,39 @@ func (s *LoggingStore) NextUserPromptOutsideSession(ctx context.Context, exclude
 	return entry, err
 }
 
+// SaveProviderState delegates optional provider resume state persistence.
+func (s *LoggingStore) SaveProviderState(ctx context.Context, sessionID, providerKey string, state []byte) error {
+	store, ok := s.Store.(ProviderStateStore)
+	if !ok {
+		return nil
+	}
+	err := store.SaveProviderState(ctx, sessionID, providerKey, state)
+	s.logOnce("SaveProviderState", err)
+	return err
+}
+
+// LoadProviderState delegates optional provider resume state loading.
+func (s *LoggingStore) LoadProviderState(ctx context.Context, sessionID, providerKey string) ([]byte, error) {
+	store, ok := s.Store.(ProviderStateStore)
+	if !ok {
+		return nil, nil
+	}
+	state, err := store.LoadProviderState(ctx, sessionID, providerKey)
+	s.logOnce("LoadProviderState", err)
+	return state, err
+}
+
+// DeleteProviderState delegates optional provider resume state deletion.
+func (s *LoggingStore) DeleteProviderState(ctx context.Context, sessionID, providerKey string) error {
+	store, ok := s.Store.(ProviderStateStore)
+	if !ok {
+		return nil
+	}
+	err := store.DeleteProviderState(ctx, sessionID, providerKey)
+	s.logOnce("DeleteProviderState", err)
+	return err
+}
+
 // UpdateMetrics wraps Store.UpdateMetrics with error logging.
 func (s *LoggingStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
 	err := s.Store.UpdateMetrics(ctx, id, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -103,6 +103,14 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_role ON messages(session_id, rol
 CREATE INDEX IF NOT EXISTS idx_messages_role_id ON messages(role, id);
 CREATE INDEX IF NOT EXISTS idx_messages_role_created_id ON messages(role, created_at, id);
 
+CREATE TABLE IF NOT EXISTS session_provider_state (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    provider_key TEXT NOT NULL,
+    state BLOB NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (session_id, provider_key)
+);
+
 -- Metadata table for current session tracking
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
@@ -234,7 +242,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 30
+const schemaVersion = 31
 
 // migration represents a schema migration.
 type migration struct {
@@ -864,6 +872,21 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		// Migration 31: Persist provider-owned resume state outside the transcript.
+		version:     31,
+		description: "create session provider state table",
+		up: func(db *sql.DB) error {
+			_, err := db.Exec(`CREATE TABLE IF NOT EXISTS session_provider_state (
+				session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+				provider_key TEXT NOT NULL,
+				state BLOB NOT NULL,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (session_id, provider_key)
+			)`)
+			return err
+		},
+	},
 }
 
 // Keep in sync with llm.IsInternalCompactionSummaryText. SQLite migrations and
@@ -1357,6 +1380,68 @@ func (s *SQLiteStore) MarkTitleSkipped(ctx context.Context, id string, t time.Ti
 		return fmt.Errorf("mark title skipped: %w", err)
 	}
 	return nil
+}
+
+// SaveProviderState stores opaque provider-owned resume state for a session.
+func (s *SQLiteStore) SaveProviderState(ctx context.Context, sessionID, providerKey string, state []byte) error {
+	sessionID = strings.TrimSpace(sessionID)
+	providerKey = strings.TrimSpace(providerKey)
+	if sessionID == "" || providerKey == "" {
+		return nil
+	}
+	return retryOnBusy(ctx, 5, func() error {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO session_provider_state (session_id, provider_key, state, updated_at)
+			VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(session_id, provider_key) DO UPDATE SET
+			    state = excluded.state,
+			    updated_at = CURRENT_TIMESTAMP
+		`, sessionID, providerKey, state)
+		if err != nil {
+			return fmt.Errorf("save provider state: %w", err)
+		}
+		return nil
+	})
+}
+
+// LoadProviderState returns opaque provider-owned resume state for a session.
+func (s *SQLiteStore) LoadProviderState(ctx context.Context, sessionID, providerKey string) ([]byte, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	providerKey = strings.TrimSpace(providerKey)
+	if sessionID == "" || providerKey == "" {
+		return nil, nil
+	}
+	var state []byte
+	err := s.db.QueryRowContext(ctx, `
+		SELECT state FROM session_provider_state
+		WHERE session_id = ? AND provider_key = ?
+	`, sessionID, providerKey).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load provider state: %w", err)
+	}
+	return append([]byte(nil), state...), nil
+}
+
+// DeleteProviderState removes provider-owned resume state for a session.
+func (s *SQLiteStore) DeleteProviderState(ctx context.Context, sessionID, providerKey string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	providerKey = strings.TrimSpace(providerKey)
+	if sessionID == "" || providerKey == "" {
+		return nil
+	}
+	return retryOnBusy(ctx, 5, func() error {
+		_, err := s.db.ExecContext(ctx, `
+			DELETE FROM session_provider_state
+			WHERE session_id = ? AND provider_key = ?
+		`, sessionID, providerKey)
+		if err != nil {
+			return fmt.Errorf("delete provider state: %w", err)
+		}
+		return nil
+	})
 }
 
 // UpdateMetrics atomically increments the metrics fields for a session.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -416,6 +416,7 @@ func TestInitSchemaFreshDBDoesNotRunHistoricalMigrations(t *testing.T) {
 		name       string
 	}{
 		{objectType: "table", name: "push_subscriptions"},
+		{objectType: "table", name: "session_provider_state"},
 		{objectType: "index", name: "idx_messages_session_sequence"},
 		{objectType: "index", name: "idx_sessions_status"},
 		{objectType: "index", name: "idx_sessions_title_skipped"},
@@ -2079,6 +2080,63 @@ func TestSQLiteStoreCustomPath(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreProviderStateRoundTrip(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "Claude CLI", ProviderKey: "claude-bin", Model: "sonnet", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	initial := []byte(`{"session_id":"claude-1","messages_sent":3}`)
+	if err := store.SaveProviderState(ctx, sess.ID, "claude-bin", initial); err != nil {
+		t.Fatalf("SaveProviderState initial: %v", err)
+	}
+	loaded, err := store.LoadProviderState(ctx, sess.ID, "claude-bin")
+	if err != nil {
+		t.Fatalf("LoadProviderState initial: %v", err)
+	}
+	if string(loaded) != string(initial) {
+		t.Fatalf("provider state = %s, want %s", loaded, initial)
+	}
+
+	updated := []byte(`{"session_id":"claude-2","messages_sent":8}`)
+	if err := store.SaveProviderState(ctx, sess.ID, "claude-bin", updated); err != nil {
+		t.Fatalf("SaveProviderState update: %v", err)
+	}
+	loaded, err = store.LoadProviderState(ctx, sess.ID, "claude-bin")
+	if err != nil {
+		t.Fatalf("LoadProviderState update: %v", err)
+	}
+	if string(loaded) != string(updated) {
+		t.Fatalf("updated provider state = %s, want %s", loaded, updated)
+	}
+
+	if other, err := store.LoadProviderState(ctx, sess.ID, "openai"); err != nil {
+		t.Fatalf("LoadProviderState other provider: %v", err)
+	} else if len(other) != 0 {
+		t.Fatalf("other provider state = %s, want empty", other)
+	}
+
+	if err := store.DeleteProviderState(ctx, sess.ID, "claude-bin"); err != nil {
+		t.Fatalf("DeleteProviderState: %v", err)
+	}
+	loaded, err = store.LoadProviderState(ctx, sess.ID, "claude-bin")
+	if err != nil {
+		t.Fatalf("LoadProviderState after delete: %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("provider state after delete = %s, want empty", loaded)
+	}
+}
+
 func TestSQLiteStoreProviderKeyRoundTrip(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
@@ -2208,6 +2266,17 @@ INSERT INTO schema_version(version) VALUES (7);
 	}
 	if !hasProviderKey {
 		t.Fatal("expected provider_key column after migration")
+	}
+
+	var providerStateTables int
+	if err := store.db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'table' AND name = 'session_provider_state'
+	`).Scan(&providerStateTables); err != nil {
+		t.Fatalf("failed to inspect session_provider_state table: %v", err)
+	}
+	if providerStateTables != 1 {
+		t.Fatalf("session_provider_state table count = %d, want 1", providerStateTables)
 	}
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -69,6 +69,16 @@ type Store interface {
 	Close() error
 }
 
+// ProviderStateStore is an optional Store capability for provider-specific
+// resume state. It stores opaque JSON/blob payloads keyed by term-llm session
+// and provider key, allowing providers such as claude-bin to survive runtime
+// eviction without leaking that state into the user-visible transcript.
+type ProviderStateStore interface {
+	SaveProviderState(ctx context.Context, sessionID, providerKey string, state []byte) error
+	LoadProviderState(ctx context.Context, sessionID, providerKey string) ([]byte, error)
+	DeleteProviderState(ctx context.Context, sessionID, providerKey string) error
+}
+
 // MessagesDescendingPager is an optional Store capability for efficient reverse
 // pagination over session messages. Implementations return messages ordered by
 // descending sequence and, when beforeSeq > 0, only rows with sequence < beforeSeq.


### PR DESCRIPTION
## Summary

- add optional provider-state persistence keyed by `(session_id, provider_key)` in the session DB
- persist `claude-bin`'s Claude Code `session_id` and `messages_sent` boundary so a recreated runtime can use `--resume` and send only new turns
- delegate the optional store capability through `LoggingStore`
- add schema migration 31 plus fresh/migrated schema and round-trip coverage

## Red / green

Red first:

```text
go test ./cmd -run TestServeRuntimeRestoresProviderStateFromSessionStore -count=1
--- FAIL: TestServeRuntimeRestoresProviderStateFromSessionStore
    serve_runtime_test.go:518: provider state import calls = 0, want 1
FAIL
```

Green after implementation:

```text
go test ./cmd -run TestServeRuntimeRestoresProviderStateFromSessionStore -count=1
ok  github.com/samsaffron/term-llm/cmd
```

## Verification

```text
go test ./cmd ./internal/llm ./internal/session
go test ./...
go build ./...
```
