### PR TITLE
fix: TUI drops visible partial assistant replies on stream error/cancel

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1047,6 +1047,67 @@ func (m *Model) flushStreamingContentOnErrorToScrollback() []tea.Cmd {
 	return ui.ScrollbackPrintlnCommands(output, true)
 }
 
+func (m *Model) interruptedAssistantFallbackMessage() (llm.Message, bool) {
+	responseContent := m.currentResponse.String()
+	reasoningContent, reasoningKind, reasoningTitle := m.currentReasoningPartMetadata()
+	if responseContent == "" && reasoningContent == "" {
+		return llm.Message{}, false
+	}
+
+	part := llm.Part{Type: llm.PartText, Text: responseContent}
+	if reasoningContent != "" {
+		part.ReasoningContent = reasoningContent
+		part.ReasoningKind = reasoningKind
+		part.ReasoningSummaryTitle = reasoningTitle
+	}
+
+	return llm.Message{Role: llm.RoleAssistant, Parts: []llm.Part{part}}, true
+}
+
+func (m *Model) salvageInterruptedAssistantMessage() {
+	if m.sess == nil {
+		return
+	}
+	assistantMsg, ok := m.interruptedAssistantFallbackMessage()
+	if !ok {
+		return
+	}
+
+	sessionMsg := session.NewMessageWithReasoningPolicy(m.sess.ID, assistantMsg, -1, m.effectiveReasoningConfig())
+	sessionMsg.DurationMs = time.Since(m.streamStartTime).Milliseconds()
+
+	m.messagesMu.Lock()
+	localMsg := *sessionMsg
+	localMsg.Sequence = len(m.messages)
+	m.messages = append(m.messages, localMsg)
+	m.messagesMu.Unlock()
+	m.invalidateHistoryCache()
+
+	if m.store == nil {
+		return
+	}
+
+	dbCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), 5*time.Second)
+	defer cancel()
+
+	m.pendingMu.Lock()
+	pendingAssistantMsgID := m.pendingAssistantMsgID
+	m.pendingMu.Unlock()
+	if pendingAssistantMsgID != 0 {
+		sessionMsg.ID = pendingAssistantMsgID
+		err := m.store.UpdateMessage(dbCtx, m.sess.ID, sessionMsg)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, session.ErrNotFound) {
+			return
+		}
+		sessionMsg.ID = 0
+	}
+
+	_ = m.store.AddMessage(dbCtx, m.sess.ID, sessionMsg)
+}
+
 // SetAgentResolver configures the function used to resolve agent names
 // during /handover. The function should match cmd.LoadAgent's signature.
 func (m *Model) SetAgentResolver(resolver func(name string, cfg *config.Config) (*agents.Agent, error)) {
@@ -1578,6 +1639,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.streamRenderTickPending = false
 				m.preserveStreamingContentOnError()
 				errorOutputCmds := m.flushStreamingContentOnErrorToScrollback()
+				m.salvageInterruptedAssistantMessage()
 				m.resetCurrentReasoning()
 				m.streaming = false
 				m.err = nil

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"path/filepath"
 	"strings"
@@ -283,6 +284,114 @@ func TestInterjectionDuringToolTurnDoesNotDoublePersist(t *testing.T) {
 	}
 	if userTexts[0] != "reconsider this" {
 		t.Fatalf("persisted user text = %q, want %q", userTexts[0], "reconsider this")
+	}
+}
+
+func TestUpdate_StreamErrorSalvagesPartialAssistantReply(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{ID: "stream-error-salvage", CreatedAt: time.Now()}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	userMsg := session.NewMessage(sess.ID, llm.UserText("hello"), -1)
+	if err := store.AddMessage(context.Background(), sess.ID, userMsg); err != nil {
+		t.Fatalf("AddMessage(user): %v", err)
+	}
+
+	m := newTestChatModel(false)
+	m.store = store
+	m.sess = sess
+	m.messages = []session.Message{*userMsg}
+	m.streaming = true
+	m.streamStartTime = time.Now().Add(-2 * time.Second)
+	m.width = 80
+	m.currentResponse.WriteString("partial answer")
+	m.tracker.AddTextSegment("partial answer", m.width)
+
+	_, _ = m.Update(streamEventMsg{event: ui.ErrorEvent(context.Canceled)})
+
+	if len(m.messages) != 2 {
+		t.Fatalf("in-memory message count = %d, want 2", len(m.messages))
+	}
+	if got := m.messages[1].TextContent; got != "partial answer" {
+		t.Fatalf("in-memory assistant text = %q, want %q", got, "partial answer")
+	}
+
+	persisted, err := store.GetMessages(context.Background(), sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(persisted) != 2 {
+		t.Fatalf("persisted message count = %d, want 2", len(persisted))
+	}
+	if persisted[1].Role != llm.RoleAssistant || persisted[1].TextContent != "partial answer" {
+		t.Fatalf("persisted assistant = (%s, %q), want (%s, %q)", persisted[1].Role, persisted[1].TextContent, llm.RoleAssistant, "partial answer")
+	}
+}
+
+func TestUpdate_StreamErrorUpdatesPendingAssistantFallbackRow(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{ID: "stream-error-pending", CreatedAt: time.Now()}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	userMsg := session.NewMessage(sess.ID, llm.UserText("hello"), -1)
+	if err := store.AddMessage(context.Background(), sess.ID, userMsg); err != nil {
+		t.Fatalf("AddMessage(user): %v", err)
+	}
+	pendingMsg := session.NewMessage(sess.ID, llm.AssistantText("draft"), -1)
+	if err := store.AddMessage(context.Background(), sess.ID, pendingMsg); err != nil {
+		t.Fatalf("AddMessage(pending): %v", err)
+	}
+	persisted, err := store.GetMessages(context.Background(), sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages(before): %v", err)
+	}
+	if len(persisted) != 2 {
+		t.Fatalf("precondition persisted message count = %d, want 2", len(persisted))
+	}
+
+	m := newTestChatModel(false)
+	m.store = store
+	m.sess = sess
+	m.messages = []session.Message{persisted[0]}
+	m.pendingAssistantMsgID = persisted[1].ID
+	m.streaming = true
+	m.streamStartTime = time.Now().Add(-2 * time.Second)
+	m.width = 80
+	m.currentResponse.WriteString("updated partial")
+	m.tracker.AddTextSegment("updated partial", m.width)
+
+	_, _ = m.Update(streamEventMsg{event: ui.ErrorEvent(errors.New("boom"))})
+
+	if len(m.messages) != 2 {
+		t.Fatalf("in-memory message count = %d, want 2", len(m.messages))
+	}
+	if got := m.messages[1].TextContent; got != "updated partial" {
+		t.Fatalf("in-memory assistant text = %q, want %q", got, "updated partial")
+	}
+
+	persisted, err = store.GetMessages(context.Background(), sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages(after): %v", err)
+	}
+	if len(persisted) != 2 {
+		t.Fatalf("persisted message count = %d, want 2 (update existing pending row, not duplicate)", len(persisted))
+	}
+	if persisted[1].TextContent != "updated partial" {
+		t.Fatalf("persisted assistant text = %q, want %q", persisted[1].TextContent, "updated partial")
 	}
 }
 


### PR DESCRIPTION
## What changed

- salvage visible partial assistant output when a TUI stream ends with `StreamEventError` or cancellation
- synthesize a fallback assistant message from the accumulated streamed text/reasoning, append it to in-memory `m.messages`, and invalidate history/context caches
- best-effort persist that fallback with a short timeout, updating the existing pending assistant row when one already exists so interrupted streams do not create duplicate assistant rows
- add regression tests covering both the fresh-fallback path and the pending-row update path

## Why this is high-value

This fixes a real data-loss path in the main interactive TUI surface. Before this change, users could see partial assistant text on screen after an interrupted or failed stream, but that visible content was not added to conversation state and could be missing from persisted session history. That meant the next turn could lose context, and resuming the session later could lose the partial reply entirely.

## Validation

- `gofmt -w internal/tui/chat/chat.go internal/tui/chat/streaming_test.go`
- `go build ./...`
- `go test ./...`
- added tests:
  - `TestUpdate_StreamErrorSalvagesPartialAssistantReply`
  - `TestUpdate_StreamErrorUpdatesPendingAssistantFallbackRow`
- `git diff --check`
