### PR TITLE
fix: Streaming assistant snapshots rewrite FTS rows on every upsert

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -753,6 +753,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// text-only turns) both fields reset so the next turn starts fresh.
 	pendingAssistantIdx := -1
 	var pendingAssistantMsgID int64
+	pendingAssistantTextPersisted := false
 	persistPlatformInjectionLocked := func() {
 		if injectedPlatform != "" && (stateful || persisted) {
 			rt.lastInjectedPlatform = injectedPlatform
@@ -930,6 +931,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		systemPromptInjected = false
 		pendingAssistantIdx = -1
 		pendingAssistantMsgID = 0
+		pendingAssistantTextPersisted = false
 		assistantSnapshotDirty = false
 		assistantSnapshotNeedsReconcile = false
 		if stateful {
@@ -945,11 +947,12 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// upsertPendingAssistantLocked writes (or rewrites) the in-progress
 	// assistant row for the current turn. First call inserts, subsequent calls
 	// update the same row; on ErrNotFound it re-inserts. Must hold producedMu.
-	upsertPendingAssistantLocked := func(persistCtx context.Context, assistantMsg llm.Message) {
+	upsertPendingAssistantLocked := func(persistCtx context.Context, assistantMsg llm.Message, finalizeText bool) {
 		firstInsert := pendingAssistantIdx < 0
 		if firstInsert {
 			pendingAssistantIdx = len(produced)
 			produced = append(produced, assistantMsg)
+			pendingAssistantTextPersisted = false
 		} else {
 			produced[pendingAssistantIdx] = assistantMsg
 		}
@@ -986,9 +989,12 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		sessionMsg.TurnIndex = turnIndex
 		if pendingAssistantMsgID != 0 {
 			sessionMsg.ID = pendingAssistantMsgID
-			err := rt.store.UpdateMessage(dbCtx, req.SessionID, sessionMsg)
+			err := session.UpdateStreamingMessage(dbCtx, rt.store, req.SessionID, sessionMsg, finalizeText)
 			if err == nil {
 				assistantSnapshotDirty = false
+				if finalizeText {
+					pendingAssistantTextPersisted = true
+				}
 				persistPlatformInjectionLocked()
 				return
 			}
@@ -1002,6 +1008,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			}
 			// Row missing (e.g., compaction). Fall through to re-insert.
 			pendingAssistantMsgID = 0
+			pendingAssistantTextPersisted = false
 			sessionMsg = session.NewMessage(req.SessionID, assistantMsg, -1)
 			sessionMsg.TurnIndex = turnIndex
 		}
@@ -1014,6 +1021,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			return
 		}
 		pendingAssistantMsgID = sessionMsg.ID
+		pendingAssistantTextPersisted = finalizeText
 		assistantSnapshotDirty = false
 		// Reserve produced[pendingAssistantIdx] so plain append-path writes
 		// skip it on subsequent callbacks.
@@ -1028,7 +1036,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	rt.engine.SetAssistantSnapshotCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message) error {
 		producedMu.Lock()
 		defer producedMu.Unlock()
-		upsertPendingAssistantLocked(cbCtx, assistantMsg)
+		upsertPendingAssistantLocked(cbCtx, assistantMsg, false)
 		return nil
 	})
 	defer rt.engine.SetAssistantSnapshotCallback(nil)
@@ -1036,7 +1044,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	rt.engine.SetResponseCompletedCallback(func(cbCtx context.Context, _ int, assistantMsg llm.Message, _ llm.TurnMetrics) error {
 		producedMu.Lock()
 		defer producedMu.Unlock()
-		upsertPendingAssistantLocked(cbCtx, assistantMsg)
+		upsertPendingAssistantLocked(cbCtx, assistantMsg, true)
 		return nil
 	})
 	defer rt.engine.SetResponseCompletedCallback(nil)
@@ -1049,7 +1057,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		defer producedMu.Unlock()
 		appendStart := 0
 		if len(msgs) > 0 && msgs[0].Role == llm.RoleAssistant {
-			upsertPendingAssistantLocked(cbCtx, msgs[0])
+			upsertPendingAssistantLocked(cbCtx, msgs[0], !pendingAssistantTextPersisted)
 			appendStart = 1
 		}
 		if appendStart < len(msgs) {
@@ -1058,6 +1066,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		}
 		pendingAssistantIdx = -1
 		pendingAssistantMsgID = 0
+		pendingAssistantTextPersisted = false
 		return nil
 	})
 	defer rt.engine.SetTurnCompletedCallback(nil)
@@ -1203,7 +1212,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	if persisted {
 		if appendOnlyPersisted {
 			if (assistantSnapshotDirty || assistantSnapshotNeedsReconcile) && pendingAssistantIdx >= 0 && pendingAssistantIdx < len(produced) {
-				upsertPendingAssistantLocked(ctx, produced[pendingAssistantIdx])
+				upsertPendingAssistantLocked(ctx, produced[pendingAssistantIdx], true)
 			}
 			updateStateAndAppendLocked(ctx)
 			needFinalSnapshot = !appendOnlyCaughtUpLocked()

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -78,6 +78,20 @@ func (s *LoggingStore) UpdateMessage(ctx context.Context, sessionID string, msg 
 	return err
 }
 
+// UpdateStreamingMessage wraps the optional streaming-aware update path with the
+// same error logging semantics as UpdateMessage.
+func (s *LoggingStore) UpdateStreamingMessage(ctx context.Context, sessionID string, msg *Message, finalizeText bool) error {
+	updater, ok := s.Store.(StreamingMessageUpdater)
+	if !ok {
+		return s.UpdateMessage(ctx, sessionID, msg)
+	}
+	err := updater.UpdateStreamingMessage(ctx, sessionID, msg, finalizeText)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		s.logOnce("UpdateStreamingMessage", err)
+	}
+	return err
+}
+
 // GetMessageByID wraps Store.GetMessageByID with error logging.
 func (s *LoggingStore) GetMessageByID(ctx context.Context, msgID int64) (*Message, error) {
 	msg, err := s.Store.GetMessageByID(ctx, msgID)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -142,7 +142,7 @@ CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE OF text_content ON messages BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
     INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
 END;
@@ -242,7 +242,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 31
+const schemaVersion = 32
 
 // migration represents a schema migration.
 type migration struct {
@@ -887,6 +887,22 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		// Migration 32: Avoid rewriting the FTS row when streaming updates only
+		// mutate assistant parts/duration. Only text_content changes need FTS sync.
+		version:     32,
+		description: "narrow messages FTS update trigger to text_content",
+		up: func(db *sql.DB) error {
+			if _, err := db.Exec(`DROP TRIGGER IF EXISTS messages_au`); err != nil {
+				return err
+			}
+			_, err := db.Exec(`CREATE TRIGGER messages_au AFTER UPDATE OF text_content ON messages BEGIN
+				INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+				INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+			END`)
+			return err
+		},
+	},
 }
 
 // Keep in sync with llm.IsInternalCompactionSummaryText. SQLite migrations and
@@ -996,7 +1012,7 @@ func rebuildMessagesTableForCurrentRoles(db *sql.DB) error {
 		`CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
 			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
 		END`,
-		`CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+		`CREATE TRIGGER messages_au AFTER UPDATE OF text_content ON messages BEGIN
 			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
 			INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
 		END`,
@@ -2025,6 +2041,16 @@ func (s *SQLiteStore) insertMessageAndBumpSession(ctx context.Context, execer sq
 // "persist as we go" upsert path: the caller first calls AddMessage to stamp
 // an ID, then subsequent snapshots call UpdateMessage with the same ID.
 func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, msg *Message) error {
+	return s.updateMessage(ctx, sessionID, msg, true)
+}
+
+// UpdateStreamingMessage updates an in-progress assistant message while letting
+// the caller defer the FTS-backed text_content rewrite until finalization.
+func (s *SQLiteStore) UpdateStreamingMessage(ctx context.Context, sessionID string, msg *Message, finalizeText bool) error {
+	return s.updateMessage(ctx, sessionID, msg, finalizeText)
+}
+
+func (s *SQLiteStore) updateMessage(ctx context.Context, sessionID string, msg *Message, updateText bool) error {
 	if msg == nil {
 		return fmt.Errorf("update message: nil msg")
 	}
@@ -2037,6 +2063,18 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, msg *
 		return fmt.Errorf("serialize parts: %w", err)
 	}
 
+	query := `
+			UPDATE messages
+			SET role = ?, parts = ?`
+	args := []any{string(msg.Role), partsJSON}
+	if updateText {
+		query += `, text_content = ?`
+		args = append(args, msg.TextContent)
+	}
+	query += `, duration_ms = ?, turn_index = ?, compaction_tail = ?
+			WHERE id = ? AND session_id = ?`
+	args = append(args, msg.DurationMs, msg.TurnIndex, msg.CompactionTail, msg.ID, sessionID)
+
 	return retryOnBusy(ctx, 5, func() error {
 		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
@@ -2044,11 +2082,7 @@ func (s *SQLiteStore) UpdateMessage(ctx context.Context, sessionID string, msg *
 		}
 		defer tx.Rollback()
 
-		result, err := tx.ExecContext(ctx, `
-			UPDATE messages
-			SET role = ?, parts = ?, text_content = ?, duration_ms = ?, turn_index = ?, compaction_tail = ?
-			WHERE id = ? AND session_id = ?`,
-			string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CompactionTail, msg.ID, sessionID)
+		result, err := tx.ExecContext(ctx, query, args...)
 		if err != nil {
 			return fmt.Errorf("update message: %w", err)
 		}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -69,6 +69,23 @@ type Store interface {
 	Close() error
 }
 
+// StreamingMessageUpdater is an optional Store capability for the hot streaming
+// assistant upsert path. Implementations may update role/parts/duration without
+// rewriting the FTS-backed text_content column until finalizeText is true.
+type StreamingMessageUpdater interface {
+	UpdateStreamingMessage(ctx context.Context, sessionID string, msg *Message, finalizeText bool) error
+}
+
+// UpdateStreamingMessage updates an in-progress assistant message using the
+// store's streaming-aware fast path when available, otherwise it falls back to
+// Store.UpdateMessage.
+func UpdateStreamingMessage(ctx context.Context, store Store, sessionID string, msg *Message, finalizeText bool) error {
+	if updater, ok := store.(StreamingMessageUpdater); ok {
+		return updater.UpdateStreamingMessage(ctx, sessionID, msg, finalizeText)
+	}
+	return store.UpdateMessage(ctx, sessionID, msg)
+}
+
 // ProviderStateStore is an optional Store capability for provider-specific
 // resume state. It stores opaque JSON/blob payloads keyed by term-llm session
 // and provider key, allowing providers such as claude-bin to survive runtime

--- a/internal/session/update_message_test.go
+++ b/internal/session/update_message_test.go
@@ -161,6 +161,84 @@ func TestSQLiteStoreUpdateMessageAdjustsVisibleMessageCountOnAssistantTextChange
 	assertListedMessageCount(t, store, 0)
 }
 
+func TestSQLiteStoreUpdateStreamingMessageDefersFTSRewriteUntilFinalized(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	msg := NewMessage(sess.ID, llm.Message{
+		Role:  llm.RoleAssistant,
+		Parts: []llm.Part{{Type: llm.PartText, Text: "partial"}},
+	}, -1)
+	if err := store.AddMessage(ctx, sess.ID, msg); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	updated := NewMessage(sess.ID, llm.Message{
+		Role:  llm.RoleAssistant,
+		Parts: []llm.Part{{Type: llm.PartText, Text: "partial plus final tail"}},
+	}, -1)
+	updated.ID = msg.ID
+	updated.CreatedAt = msg.CreatedAt
+	updated.Sequence = msg.Sequence
+
+	if err := store.UpdateStreamingMessage(ctx, sess.ID, updated, false); err != nil {
+		t.Fatalf("UpdateStreamingMessage snapshot: %v", err)
+	}
+
+	var rawText string
+	if err := store.db.QueryRowContext(ctx, "SELECT COALESCE(text_content, '') FROM messages WHERE id = ?", msg.ID).Scan(&rawText); err != nil {
+		t.Fatalf("query raw text_content after snapshot: %v", err)
+	}
+	if rawText != "partial" {
+		t.Fatalf("raw text_content after snapshot = %q, want %q", rawText, "partial")
+	}
+
+	persisted, err := store.GetMessageByID(ctx, msg.ID)
+	if err != nil {
+		t.Fatalf("GetMessageByID after snapshot: %v", err)
+	}
+	if got := persisted.ExtractTextContent(); got != "partial plus final tail" {
+		t.Fatalf("persisted parts text after snapshot = %q, want %q", got, "partial plus final tail")
+	}
+
+	results, err := store.Search(ctx, SearchOptions{Query: "tail", Limit: 5})
+	if err != nil {
+		t.Fatalf("Search before finalize: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Search before finalize returned %d results, want 0", len(results))
+	}
+
+	if err := store.UpdateStreamingMessage(ctx, sess.ID, updated, true); err != nil {
+		t.Fatalf("UpdateStreamingMessage finalize: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, "SELECT COALESCE(text_content, '') FROM messages WHERE id = ?", msg.ID).Scan(&rawText); err != nil {
+		t.Fatalf("query raw text_content after finalize: %v", err)
+	}
+	if rawText != "partial plus final tail" {
+		t.Fatalf("raw text_content after finalize = %q, want %q", rawText, "partial plus final tail")
+	}
+
+	results, err = store.Search(ctx, SearchOptions{Query: "tail", Limit: 5})
+	if err != nil {
+		t.Fatalf("Search after finalize: %v", err)
+	}
+	if len(results) != 1 || results[0].MessageID != msg.ID {
+		t.Fatalf("Search after finalize = %#v, want single result for message %d", results, msg.ID)
+	}
+}
+
 // TestSQLiteStoreUpdateMessageReturnsErrNotFound verifies that UpdateMessage
 // targeting a missing row returns ErrNotFound (used for the
 // compaction-race fallback path in the upsert callback).

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -106,8 +106,9 @@ type Model struct {
 
 	// Persist-as-we-go: row ID of the in-progress assistant message (0 = none).
 	// Written from engine callbacks on a non-UI goroutine; protected by pendingMu.
-	pendingAssistantMsgID int64
-	pendingMu             sync.Mutex
+	pendingAssistantMsgID   int64
+	pendingAssistantTextSet bool
+	pendingMu               sync.Mutex
 
 	// In-progress LLM context used only for the status-line token estimate while
 	// a stream is active. The persisted session messages are not updated until

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -99,6 +99,7 @@ func (m *Model) clearStreamCallbacks() {
 	m.engine.SetCompactionCallback(nil)
 	m.pendingMu.Lock()
 	m.pendingAssistantMsgID = 0
+	m.pendingAssistantTextSet = false
 	m.pendingMu.Unlock()
 	m.clearStreamingContextMessages()
 }
@@ -119,7 +120,7 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 	staleStreamSession := func() bool {
 		return streamSessionID != "" && (m.sess == nil || m.sess.ID != streamSessionID)
 	}
-	persistPendingAssistant := func(ctx context.Context, assistantMsg llm.Message) {
+	persistPendingAssistant := func(ctx context.Context, assistantMsg llm.Message, finalizeText bool) {
 		if m.store == nil || streamSess == nil || staleStreamSession() {
 			return
 		}
@@ -129,14 +130,18 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 		defer m.pendingMu.Unlock()
 		if m.pendingAssistantMsgID != 0 {
 			sessionMsg.ID = m.pendingAssistantMsgID
-			err := m.store.UpdateMessage(ctx, streamSess.ID, sessionMsg)
+			err := session.UpdateStreamingMessage(ctx, m.store, streamSess.ID, sessionMsg, finalizeText)
 			if err == nil {
+				if finalizeText {
+					m.pendingAssistantTextSet = true
+				}
 				return
 			}
 			if !errors.Is(err, session.ErrNotFound) {
 				return
 			}
 			m.pendingAssistantMsgID = 0
+			m.pendingAssistantTextSet = false
 			sessionMsg = session.NewMessageWithReasoningPolicy(streamSess.ID, assistantMsg, -1, reasoningCfg)
 			sessionMsg.DurationMs = time.Since(streamStart).Milliseconds()
 		}
@@ -144,6 +149,7 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 			return
 		}
 		m.pendingAssistantMsgID = sessionMsg.ID
+		m.pendingAssistantTextSet = finalizeText
 	}
 
 	m.engine.SetAssistantSnapshotCallback(func(ctx context.Context, _ int, assistantMsg llm.Message) error {
@@ -151,7 +157,7 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 			return nil
 		}
 		m.updateStreamingContextAssistant(assistantMsg)
-		persistPendingAssistant(ctx, assistantMsg)
+		persistPendingAssistant(ctx, assistantMsg, false)
 		return nil
 	})
 
@@ -160,7 +166,7 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 			return nil
 		}
 		m.updateStreamingContextAssistant(assistantMsg)
-		persistPendingAssistant(ctx, assistantMsg)
+		persistPendingAssistant(ctx, assistantMsg, true)
 		return nil
 	})
 
@@ -174,7 +180,10 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 		if len(turnMessages) > 0 && turnMessages[0].Role == llm.RoleAssistant {
 			// The estimate snapshot was already updated above. Persist/update the
 			// pending assistant row separately.
-			persistPendingAssistant(ctx, turnMessages[0])
+			m.pendingMu.Lock()
+			finalizeText := !m.pendingAssistantTextSet
+			m.pendingMu.Unlock()
+			persistPendingAssistant(ctx, turnMessages[0], finalizeText)
 			appendStart = 1
 		}
 		if m.store != nil && streamSess != nil {
@@ -188,6 +197,7 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 		}
 		m.pendingMu.Lock()
 		m.pendingAssistantMsgID = 0
+		m.pendingAssistantTextSet = false
 		m.pendingMu.Unlock()
 		if m.store != nil && streamSess != nil {
 			_ = m.store.UpdateMetrics(ctx, streamSess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens)
@@ -569,6 +579,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 			// a row that no longer exists.
 			m.pendingMu.Lock()
 			m.pendingAssistantMsgID = 0
+			m.pendingAssistantTextSet = false
 			m.pendingMu.Unlock()
 			return nil
 		})


### PR DESCRIPTION
## What changed

- Added a streaming-aware message update path in `internal/session` so interim assistant snapshot updates can skip rewriting `messages.text_content` until the assistant message is finalized.
- Narrowed the SQLite FTS update trigger from `AFTER UPDATE ON messages` to `AFTER UPDATE OF text_content ON messages`, plus added a schema migration so existing databases pick up the same behavior.
- Updated the hot streaming persistence call sites in both `cmd/serve_runtime.go` and `internal/tui/chat/streaming.go` to:
  - persist ordinary snapshots without touching FTS-backed text,
  - persist final assistant text once on response completion, and
  - avoid a duplicate final FTS rewrite when turn completion follows response completion.
- Added a regression test proving snapshot updates no longer surface in FTS until finalization, while the final assistant text is still searchable.

## Why this is high-value

This path is hit repeatedly during real streaming turns in both the web runtime and TUI. Before this change, every snapshot update rewrote the entire FTS row because `UpdateMessage` always updated `text_content` and the `messages_au` trigger reindexed on every update.

The fix reduces work in the hot path from "reindex the growing assistant reply on every snapshot" to "update non-FTS message fields during snapshots, then index the final text once". That cuts SQLite write amplification, reduces lock contention, and improves responsiveness on long assistant replies and tool-heavy turns without changing final search behavior.

## Validation

- Verified the issue in current code by tracing `UpdateMessage` updating `text_content` on every snapshot and the unconditional `messages_au` FTS trigger.
- Added `TestSQLiteStoreUpdateStreamingMessageDefersFTSRewriteUntilFinalized` to cover the exact regression.
- Ran:
  - `gofmt -w cmd/serve_runtime.go internal/session/store.go internal/session/logger.go internal/session/sqlite.go internal/session/update_message_test.go internal/tui/chat/chat.go internal/tui/chat/streaming.go`
  - `go build ./...`
  - `go test ./...`
  - `git diff --check`
