### PR TITLE
fix: Agent on_complete hooks can hang ask forever and leak subprocesses

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -2601,6 +2601,11 @@ type onCompleteResult struct {
 	Stderr string
 }
 
+var (
+	onCompleteTimeout   = 10 * time.Second
+	onCompleteWaitDelay = 2 * time.Second
+)
+
 // runOnCompleteCapture executes the on_complete shell command with input piped to stdin
 // and captures stdout/stderr. Runs in the git repo root if available, else cwd.
 func runOnCompleteCapture(command, input string) (onCompleteResult, error) {
@@ -2609,15 +2614,28 @@ func runOnCompleteCapture(command, input string) (onCompleteResult, error) {
 		dir = gitInfo.Root
 	}
 
-	cmd := exec.Command("sh", "-c", command)
+	ctx, cancel := context.WithTimeout(context.Background(), onCompleteTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(input)
+
+	cleanup, prepErr := tools.PrepareCommand(cmd)
+	if prepErr != nil {
+		return onCompleteResult{}, fmt.Errorf("on_complete setup failed: %w", prepErr)
+	}
+	defer cleanup()
+	cmd.WaitDelay = onCompleteWaitDelay
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return onCompleteResult{Stdout: stdout.String(), Stderr: stderr.String()}, fmt.Errorf("timed out after %s", onCompleteTimeout)
+	}
 	return onCompleteResult{Stdout: stdout.String(), Stderr: stderr.String()}, err
 }
 

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
@@ -55,6 +58,49 @@ func TestRunOnCompleteCapture_CapturesStderrAndError(t *testing.T) {
 	}
 	if result.Stderr != "err\n" {
 		t.Errorf("stderr = %q, want %q", result.Stderr, "err\n")
+	}
+}
+
+func TestRunOnCompleteCapture_TimesOutHungHook(t *testing.T) {
+	oldTimeout := onCompleteTimeout
+	onCompleteTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { onCompleteTimeout = oldTimeout })
+
+	started := time.Now()
+	_, err := runOnCompleteCapture("sleep 10", "")
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if err.Error() != "timed out after 100ms" {
+		t.Fatalf("error = %q, want %q", err.Error(), "timed out after 100ms")
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("runOnCompleteCapture took %v, want timeout well under 1s", elapsed)
+	}
+}
+
+func TestRunOnCompleteCapture_ReturnsWhenBackgroundChildKeepsPipeOpen(t *testing.T) {
+	oldTimeout := onCompleteTimeout
+	oldWaitDelay := onCompleteWaitDelay
+	onCompleteTimeout = time.Second
+	onCompleteWaitDelay = 50 * time.Millisecond
+	t.Cleanup(func() {
+		onCompleteTimeout = oldTimeout
+		onCompleteWaitDelay = oldWaitDelay
+	})
+
+	started := time.Now()
+	result, err := runOnCompleteCapture("(sleep 10) & printf done", "")
+	elapsed := time.Since(started)
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("error = %v, want %v", err, exec.ErrWaitDelay)
+	}
+	if result.Stdout != "done" {
+		t.Fatalf("stdout = %q, want %q", result.Stdout, "done")
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("runOnCompleteCapture took %v, want wait-delay recovery well under 1s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## What changed

- wrapped `runOnCompleteCapture` in a bounded `context.WithTimeout` so `ask` no longer waits forever on a stuck `agent.on_complete` hook
- switched `on_complete` execution to `exec.CommandContext` plus `tools.PrepareCommand`, which applies the same process-group cancellation/cleanup used by other command execution paths
- set `WaitDelay` for `on_complete` so `ask` also returns when the parent shell exits but a backgrounded child keeps stdout/stderr open
- added focused tests covering both a hung hook timeout and the background-child/stdout-pipe hang case

## Why this is high-value

`agent.on_complete` runs after the model has already successfully finished. Before this change, a slow or misbehaving hook could still leave `term-llm ask` hung indefinitely at the very end, which is especially painful for scripts and automation. The old path also had no process-group cleanup, so broken hooks could leave stray subprocesses behind.

This fix makes that tail-end hook fail open: the main `ask` result still completes, while timeout/failure continues to surface as the existing non-fatal warning.

## Validation

- `gofmt -w cmd/ask.go cmd/ask_test.go`
- `go build ./...`
- `go test ./cmd -run 'TestRunOnCompleteCapture_'`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
