### PR TITLE
fix: Telegram callback persistence queue discards per-session ordering and spawns untracked goroutines when full

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -949,12 +949,7 @@ func (q *telegramStoreOpQueue) enqueue(ctx context.Context, op string, fn func(c
 		return
 	}
 	storeOp := telegramStoreOp{ctx: ctx, op: op, fn: fn}
-	select {
-	case q.ops <- storeOp:
-	default:
-		log.Printf("[telegram] callback persistence queue full for %s; running %s asynchronously", q.sessionID, op)
-		go q.mgr.runStoreOpWithoutCancel(ctx, q.sessionID, op, fn)
-	}
+	q.ops <- storeOp
 }
 
 func (q *telegramStoreOpQueue) closeAndWait(ctx context.Context) {

--- a/internal/serve/telegram_queue_test.go
+++ b/internal/serve/telegram_queue_test.go
@@ -1,0 +1,75 @@
+package serve
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestTelegramStoreOpQueueFullStillSerializesOps(t *testing.T) {
+	mgr := &telegramSessionMgr{store: &session.NoopStore{}}
+	q := newTelegramStoreOpQueue(mgr, "session-1")
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	finalRan := make(chan struct{})
+	finalEnqueued := make(chan struct{})
+
+	q.enqueue(context.Background(), "first", func(context.Context) error {
+		close(firstStarted)
+		<-releaseFirst
+		return nil
+	})
+
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first op did not start")
+	}
+
+	for i := 0; i < 128; i++ {
+		q.enqueue(context.Background(), "buffered", func(context.Context) error {
+			return nil
+		})
+	}
+
+	go func() {
+		q.enqueue(context.Background(), "final", func(context.Context) error {
+			close(finalRan)
+			return nil
+		})
+		close(finalEnqueued)
+	}()
+
+	select {
+	case <-finalEnqueued:
+		t.Fatal("final enqueue returned while queue was full")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case <-finalRan:
+		t.Fatal("final op ran before queued ops drained")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-finalEnqueued:
+	case <-time.After(5 * time.Second):
+		t.Fatal("final enqueue did not complete after queue space freed")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	q.closeAndWait(drainCtx)
+
+	select {
+	case <-finalRan:
+	default:
+		t.Fatal("final op did not finish before closeAndWait returned")
+	}
+}


### PR DESCRIPTION
## What changed

- Removed the Telegram callback persistence queue overflow bypass that spawned `runStoreOpWithoutCancel` in an untracked goroutine when the 128-slot queue filled.
- Made `telegramStoreOpQueue.enqueue()` always hand work to the single serialized worker so per-session persistence stays ordered even under backpressure.
- Added `TestTelegramStoreOpQueueFullStillSerializesOps` to cover the full-queue case and assert that a trailing callback op does not escape the queue and that `closeAndWait()` does not return before it finishes.

## Why this is high-value

The existing overflow path broke the core guarantee that this queue is a single serialized persistence lane for a Telegram session. Once the buffer filled, later writes could run concurrently with earlier queued writes, so transcript rows, metrics updates, and context-estimate updates could be persisted out of order. It also spawned unbounded 5-second store goroutines that `closeAndWait()` never tracked, which directly risks durability and responsiveness during slow-store or tool-heavy runs.

This fix applies backpressure instead of bypassing serialization, which preserves message ordering and ensures shutdown waits on the same persistence path that handled the callbacks.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_queue_test.go`
- `go build ./...`
- `go test ./...`
- Added `go test ./internal/serve -run TestTelegramStoreOpQueueFullStillSerializesOps -count=1`
