### PR TITLE
fix: TUI cancel/quit clears stream persistence state before the stream actually exits

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -94,15 +94,16 @@ type Model struct {
 	reasoningRawWarned       bool
 
 	// Streaming state
-	currentResponse  strings.Builder
-	currentTokens    int
-	streamStartTime  time.Time
-	webSearchUsed    bool
-	retryStatus      string
-	streamCancelFunc context.CancelFunc
-	streamDone       chan struct{}       // closed when the engine goroutine exits
-	tracker          *ui.ToolTracker     // Tool and segment tracking (shared component)
-	subagentTracker  *ui.SubagentTracker // Subagent progress tracking
+	currentResponse       strings.Builder
+	currentTokens         int
+	streamStartTime       time.Time
+	webSearchUsed         bool
+	retryStatus           string
+	streamCancelFunc      context.CancelFunc
+	streamDone            chan struct{}       // closed when the engine goroutine exits
+	streamCancelRequested bool                // user requested stream cancellation; wait for stream exit before final cleanup
+	tracker               *ui.ToolTracker     // Tool and segment tracking (shared component)
+	subagentTracker       *ui.SubagentTracker // Subagent progress tracking
 
 	// Persist-as-we-go: row ID and latest per-turn snapshot of the in-progress
 	// assistant message. Written from engine callbacks on a non-UI goroutine;
@@ -1677,6 +1678,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.salvageInterruptedAssistantMessage()
 				m.resetCurrentReasoning()
 				m.streaming = false
+				m.streamCancelRequested = false
 				m.err = nil
 				var footerCmd tea.Cmd
 				if !errors.Is(ev.Err, context.Canceled) {
@@ -2040,6 +2042,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			m.persistContextEstimate(context.Background())
 			m.streaming = false
+			m.streamCancelRequested = false
 
 			// Flag to scroll to bottom after response completes (alt screen mode)
 			if m.altScreen {

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
-	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 	"github.com/samsaffron/term-llm/internal/tui/inspector"
 	sessionsui "github.com/samsaffron/term-llm/internal/tui/sessions"
@@ -538,20 +537,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		if m.streaming && m.streamCancelFunc != nil {
-			// Flush buffered text on cancel
-			if m.smoothBuffer != nil {
-				m.smoothBuffer.FlushAll()
-				m.smoothBuffer.Reset()
-			}
+			m.streamCancelRequested = true
+			m.phase = "Stopping..."
 			m.streamCancelFunc()
-			m.streaming = false
-			m.resetCurrentReasoning()
-
-			// Clear callbacks and update status
-			m.clearStreamCallbacks()
-			if m.store != nil {
-				_ = m.store.UpdateStatus(context.Background(), m.sess.ID, session.StatusInterrupted)
-			}
 
 			// Drain any pending interjection (discard since we're quitting)
 			_ = m.engine.DrainInterjection()
@@ -581,20 +569,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Handle cancel during streaming (takes priority over clearing selection)
 	if key.Matches(msg, m.keyMap.Cancel) {
 		if m.streaming && m.streamCancelFunc != nil {
-			// Flush buffered text on cancel
-			if m.smoothBuffer != nil {
-				m.smoothBuffer.FlushAll()
-				m.smoothBuffer.Reset()
-			}
+			m.streamCancelRequested = true
+			m.phase = "Stopping..."
 			m.streamCancelFunc()
-			m.streaming = false
-			m.resetCurrentReasoning()
-
-			// Clear callbacks and update status
-			m.clearStreamCallbacks()
-			if m.store != nil {
-				_ = m.store.UpdateStatus(context.Background(), m.sess.ID, session.StatusInterrupted)
-			}
 
 			// Recover pending interjection text into textarea
 			if residual := m.engine.DrainInterjection(); residual != "" {
@@ -1354,6 +1331,7 @@ func (m *Model) applyInterruptActionWithParts(interjectionID, content string, pa
 			// Parts already came from current composer images, so leave m.images as-is if still present.
 		}
 		if m.streamCancelFunc != nil {
+			m.streamCancelRequested = true
 			m.streamCancelFunc()
 		}
 	case llm.InterruptInterject:

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -831,6 +831,10 @@ func TestStreamError_PendingInterjectRestoresDraftWithoutEngineResidual(t *testi
 func TestHandleKeyMsg_StreamingEscCancelsActiveStream(t *testing.T) {
 	m := newTestChatModel(false)
 	m.streaming = true
+	m.pendingAssistantMsgID = 42
+	m.pendingAssistantSnapshot = llm.AssistantText("partial answer")
+	m.pendingAssistantSnapshotSet = true
+	m.completedAssistantTurns = 1
 
 	cancelCalls := 0
 	m.streamCancelFunc = func() {
@@ -842,8 +846,26 @@ func TestHandleKeyMsg_StreamingEscCancelsActiveStream(t *testing.T) {
 	if cancelCalls != 1 {
 		t.Fatalf("expected esc to call stream cancel once, got %d", cancelCalls)
 	}
-	if m.streaming {
-		t.Fatal("expected esc to end streaming mode immediately")
+	if !m.streaming {
+		t.Fatal("expected stream to remain active until the stream goroutine exits")
+	}
+	if !m.streamCancelRequested {
+		t.Fatal("expected esc to mark stream cancellation as pending")
+	}
+	if got := m.phase; got != "Stopping..." {
+		t.Fatalf("phase after esc = %q, want %q", got, "Stopping...")
+	}
+	if got := m.pendingAssistantMsgID; got != 42 {
+		t.Fatalf("pendingAssistantMsgID after esc = %d, want 42", got)
+	}
+	if !m.pendingAssistantSnapshotSet {
+		t.Fatal("expected pending assistant snapshot to remain available until stream shutdown")
+	}
+	if got := m.pendingAssistantSnapshot.Parts[0].Text; got != "partial answer" {
+		t.Fatalf("pending assistant snapshot text after esc = %q, want %q", got, "partial answer")
+	}
+	if got := m.completedAssistantTurns; got != 1 {
+		t.Fatalf("completedAssistantTurns after esc = %d, want 1", got)
 	}
 }
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -479,6 +479,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 func (m *Model) startStream(content string) tea.Cmd {
 	ctx, cancel := context.WithCancel(m.rootContext())
 	m.streamCancelFunc = cancel
+	m.streamCancelRequested = false
 
 	return func() tea.Msg {
 		// Mark session as active when starting a new stream
@@ -692,18 +693,33 @@ func (m *Model) listenForStreamEventsSync() tea.Msg {
 	if co := m.streamCoalescer; co != nil {
 		event, ok := co.next()
 		if !ok {
+			if m.streamCancelRequested {
+				return streamEventMsg{event: ui.ErrorEvent(context.Canceled)}
+			}
 			return streamEventMsg{event: ui.DoneEvent(0)}
+		}
+		if m.streamCancelRequested && event.Type == ui.StreamEventDone {
+			return streamEventMsg{event: ui.ErrorEvent(context.Canceled)}
 		}
 		return streamEventMsg{event: event}
 	}
 
 	if m.streamChan == nil {
+		if m.streamCancelRequested {
+			return streamEventMsg{event: ui.ErrorEvent(context.Canceled)}
+		}
 		return streamEventMsg{event: ui.DoneEvent(0)}
 	}
 
 	event, ok := <-m.streamChan
 	if !ok {
+		if m.streamCancelRequested {
+			return streamEventMsg{event: ui.ErrorEvent(context.Canceled)}
+		}
 		return streamEventMsg{event: ui.DoneEvent(0)}
+	}
+	if m.streamCancelRequested && event.Type == ui.StreamEventDone {
+		return streamEventMsg{event: ui.ErrorEvent(context.Canceled)}
 	}
 	return streamEventMsg{event: event}
 }

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -287,6 +287,58 @@ func TestInterjectionDuringToolTurnDoesNotDoublePersist(t *testing.T) {
 	}
 }
 
+func TestListenForStreamEventsSync_CancelledClosedStreamUsesInterruptedCleanup(t *testing.T) {
+	store := &mockStore{}
+	sess := &session.Session{ID: "stream-cancel-closed", CreatedAt: time.Now()}
+	userMsg := session.NewMessage(sess.ID, llm.UserText("hello"), -1)
+	if err := store.AddMessage(context.Background(), sess.ID, userMsg); err != nil {
+		t.Fatalf("AddMessage(user): %v", err)
+	}
+
+	m := newTestChatModel(false)
+	m.store = store
+	m.sess = sess
+	m.messages = []session.Message{*userMsg}
+	m.streaming = true
+	m.streamCancelRequested = true
+	m.streamStartTime = time.Now().Add(-2 * time.Second)
+	m.pendingAssistantSnapshot = llm.AssistantText("partial answer")
+	m.pendingAssistantSnapshotSet = true
+	m.width = 80
+
+	closed := make(chan ui.StreamEvent)
+	close(closed)
+	m.streamCoalescer = &streamEventCoalescer{ch: closed}
+
+	msg := m.listenForStreamEventsSync()
+	ev, ok := msg.(streamEventMsg)
+	if !ok {
+		t.Fatalf("listenForStreamEventsSync returned %T, want streamEventMsg", msg)
+	}
+	if ev.event.Type != ui.StreamEventError || !errors.Is(ev.event.Err, context.Canceled) {
+		t.Fatalf("listenForStreamEventsSync event = %#v, want canceled error", ev.event)
+	}
+
+	_, _ = m.Update(msg)
+
+	if len(m.messages) != 2 {
+		t.Fatalf("in-memory message count = %d, want 2", len(m.messages))
+	}
+	if got := m.messages[1].TextContent; got != "partial answer" {
+		t.Fatalf("in-memory assistant text = %q, want %q", got, "partial answer")
+	}
+	if len(store.statusUpdates) == 0 {
+		t.Fatal("expected interrupted status update")
+	}
+	last := store.statusUpdates[len(store.statusUpdates)-1]
+	if last.status != session.StatusInterrupted {
+		t.Fatalf("final status = %q, want %q", last.status, session.StatusInterrupted)
+	}
+	if m.streamCancelRequested {
+		t.Fatal("expected cancellation flag to clear after interrupted cleanup")
+	}
+}
+
 func TestUpdate_StreamErrorSalvagesPartialAssistantReply(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What changed

- Stopped the Ctrl+C / Esc cancellation paths from clearing stream callbacks and pending assistant persistence state before the engine stream goroutine exits.
- Added a `streamCancelRequested` state so user-initiated cancellation stays in a stopping state until shutdown finishes.
- Taught `listenForStreamEventsSync()` to synthesize `context.Canceled` when a canceled stream closes silently, so the existing interrupted-error cleanup path runs instead of the normal success path.
- Covered the regression with tests for both Esc cancellation state preservation and canceled-stream shutdown cleanup.

## Why this is high-value

This fixes a real transcript-corruption race on the main TUI path.

Before this change, cancel/quit cleared `pendingAssistantMsgID`, `pendingAssistantSnapshot`, and related persistence state immediately after calling `streamCancelFunc()`, even though the engine stream goroutine could still run already-captured callbacks while finishing. That could:

- lose the partial assistant snapshot needed by interrupted-message salvage
- fall back from updating the pending assistant row to inserting a new one
- misclassify a canceled stream as a successful completion when the adapter channel closed without an explicit error

The result was user-visible dropped partial replies or duplicate/misordered assistant rows after cancellation.

## Validation

- `gofmt -w internal/tui/chat/chat.go internal/tui/chat/handlers.go internal/tui/chat/streaming.go internal/tui/chat/handlers_test.go internal/tui/chat/streaming_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
