### PR TITLE
fix: non-progressive ask leaks the provider stream when the output consumer dies early

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -855,16 +855,20 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		}
 
 		stats = adapter.Stats()
+		streamCtx, cancelStream := context.WithCancel(ctx)
+		defer cancelStream()
 		errChan := make(chan error, 1)
 		go func() {
-			stream, err := engine.Stream(ctx, req)
+			stream, err := engine.Stream(streamCtx, req)
 			if err != nil {
 				errChan <- err
 				return
 			}
 			defer stream.Close()
-			// ProcessStream handles all events and closes the channel when done
-			adapter.ProcessStream(ctx, stream)
+			// ProcessStream handles all events and closes the channel when done.
+			// streamCtx cancellation is how the foreground consumer aborts the
+			// producer if stdout/renderer output fails mid-stream.
+			adapter.ProcessStream(streamCtx, stream)
 			errChan <- nil
 		}()
 
@@ -872,20 +876,24 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		switch {
 		case askJSON:
 			if err := emitSessionStarted(jsonEmit, jsonInfo); err != nil {
+				cancelStream()
+				<-errChan
 				return err
 			}
 			var writeErr error
-			jsonTotalTokens, jsonStreamErr, writeErr = streamJSONEvents(ctx, streamEvents, jsonEmit)
+			jsonTotalTokens, jsonStreamErr, writeErr = streamJSONEvents(streamCtx, streamEvents, jsonEmit)
 			err = writeErr
 			jsonFinalPending = true
 		case useRichRenderer:
-			err = runRenderer(ctx, streamEvents)
+			err = runRenderer(streamCtx, streamEvents)
 		default:
-			err = streamPlainText(ctx, streamEvents, askPorcelain)
+			err = streamPlainText(streamCtx, streamEvents, askPorcelain)
 		}
 		tools.ClearAskUserHooks() // Safe to call even if hooks weren't set
 
 		if err != nil {
+			cancelStream()
+			<-errChan
 			if askJSON && !isTerminalFlushed(err) {
 				_ = emitFatalError(jsonEmit, stats, err)
 				jsonFinalPending = false

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -554,6 +554,67 @@ func TestProgressiveCollectorCapturesBridgeTextWhenDrained(t *testing.T) {
 	}
 }
 
+type nonProgressiveBlockingStream struct {
+	ctx    context.Context
+	sent   int
+	total  int
+	closed chan struct{}
+}
+
+func (s *nonProgressiveBlockingStream) Recv() (llm.Event, error) {
+	if s.sent < s.total {
+		s.sent++
+		return llm.Event{Type: llm.EventTextDelta, Text: "chunk"}, nil
+	}
+	<-s.ctx.Done()
+	return llm.Event{}, s.ctx.Err()
+}
+
+func (s *nonProgressiveBlockingStream) Close() error {
+	close(s.closed)
+	return nil
+}
+
+func TestNonProgressiveConsumerWriteErrorCancellationUnblocksProducer(t *testing.T) {
+	adapter := ui.NewStreamAdapter(1)
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+
+	stream := &nonProgressiveBlockingStream{
+		ctx:    streamCtx,
+		total:  8,
+		closed: make(chan struct{}),
+	}
+	errChan := make(chan error, 1)
+	go func() {
+		defer stream.Close()
+		adapter.ProcessStream(streamCtx, stream)
+		errChan <- nil
+	}()
+
+	_, _, writeErr := streamJSONEvents(streamCtx, adapter.Events(), newJSONEmitter(failingJSONWriter{}))
+	if writeErr == nil {
+		t.Fatal("expected streamJSONEvents to fail")
+	}
+
+	cancelStream()
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatalf("producer error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("producer remained blocked after consumer cancellation")
+	}
+
+	select {
+	case <-stream.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.Close was not reached after consumer cancellation")
+	}
+}
+
 func TestAskViewNoForcedTrailingNewline(t *testing.T) {
 	model := newAskStreamModel()
 	model.pausedForExternalUI = true


### PR DESCRIPTION
## What changed

- ran the non-progressive `ask` streaming path under a child `context.WithCancel`
- passed that child context to `engine.Stream`, `adapter.ProcessStream`, and the foreground stream consumers
- on consumer-side failures (`emitSessionStarted`, JSON write failures, renderer failures, plain-text write failures), cancel the child context before returning and wait for the producer goroutine to finish
- added a regression test that simulates a consumer write failure and verifies cancellation unblocks the producer and reaches `stream.Close()`

## Why this is high-value

This fixes a real hot-path reliability leak in `ask` streaming. Before this change, if the output consumer died early (for example `ask --json | head`, a broken pipe, or a renderer failure), `runAsk` could return immediately while the provider stream goroutine stayed blocked behind the undrained event pipeline. That could leave an in-flight LLM request open until process exit, wasting provider time/tokens and sometimes hanging shell pipelines longer than necessary.

With the new cancellation/join behavior, consumer failures now actively tear down the provider stream and wait for shutdown to complete deterministically.

## Validation

- `gofmt -w cmd/ask.go cmd/ask_test.go`
- `go build ./...`
- `go test ./...`
- added `TestNonProgressiveConsumerWriteErrorCancellationUnblocksProducer`
- `git diff --check`
