### PR TITLE
fix: every queue_agent call creates a permanent jobs_v2 row with no cleanup path

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -22,6 +22,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/procutil"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
 	_ "modernc.org/sqlite"
 )
 
@@ -1010,6 +1011,28 @@ func (m *jobsV2Manager) pruneOldData(now time.Time) error {
 	if m.retentionRunDays > 0 {
 		cutoff := now.Add(-time.Duration(m.retentionRunDays) * 24 * time.Hour)
 		_, err := m.db.Exec(`
+			DELETE FROM jobs_v2
+			WHERE labels = ?
+			  AND NOT EXISTS (
+				  SELECT 1
+				  FROM job_runs_v2 active_runs
+				  WHERE active_runs.job_id = jobs_v2.id
+				    AND active_runs.status NOT IN (?, ?, ?, ?, ?)
+			  )
+			  AND COALESCE(
+				  (
+					  SELECT MAX(COALESCE(all_runs.finished_at, all_runs.created_at))
+					  FROM job_runs_v2 all_runs
+					  WHERE all_runs.job_id = jobs_v2.id
+				  ),
+				  jobs_v2.created_at
+			  ) < ?`,
+			tools.QueueAgentEphemeralJobLabelsJSON,
+			terminalStatuses[0], terminalStatuses[1], terminalStatuses[2], terminalStatuses[3], terminalStatuses[4], cutoff)
+		if err != nil {
+			return err
+		}
+		_, err = m.db.Exec(`
 			DELETE FROM job_runs_v2
 			WHERE status IN (?, ?, ?, ?, ?)
 			  AND COALESCE(finished_at, created_at) < ?`,

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
 )
 
 func TestNewJobsV2ManagerDoesNotForceSingleConnectionForFileBackedDB(t *testing.T) {
@@ -978,6 +979,91 @@ func TestJobsV2RetentionPrunesOldData(t *testing.T) {
 	if eventsCount != 0 {
 		t.Fatalf("eventsCount = %d, want 0 after event retention pruning", eventsCount)
 	}
+}
+
+func TestJobsV2RetentionPrunesOldQueueAgentJobs(t *testing.T) {
+	mgr := newJobsV2ManagerWithoutLoops(t)
+
+	mgr.retentionRunDays = 1
+	mgr.retentionEventDays = 1
+	mgr.retentionMaxRunsJob = 10
+
+	now := time.Now().UTC()
+	old := now.Add(-48 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+	labels := tools.QueueAgentEphemeralJobLabelsJSON
+	var err error
+
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, labels, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'allow', 1, 60, 'run', ?, ?, ?)`,
+		"job_queue_agent_old", "queue-agent-old", jobsV2RunnerLLM, `{"agent_name":"developer","instructions":"old","cwd":"/tmp"}`, jobsV2TriggerManual, `{}`, labels, old, old)
+	if err != nil {
+		t.Fatalf("insert old queue_agent job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, finished_at, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?, ?)`,
+		"run_queue_agent_old", "job_queue_agent_old", old, jobsV2RunSucceeded, old, old, old)
+	if err != nil {
+		t.Fatalf("insert old queue_agent run: %v", err)
+	}
+
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, labels, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'allow', 1, 60, 'run', ?, ?, ?)`,
+		"job_queue_agent_recent", "queue-agent-recent", jobsV2RunnerLLM, `{"agent_name":"developer","instructions":"recent","cwd":"/tmp"}`, jobsV2TriggerManual, `{}`, labels, recent, recent)
+	if err != nil {
+		t.Fatalf("insert recent queue_agent job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, finished_at, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?, ?)`,
+		"run_queue_agent_recent", "job_queue_agent_recent", recent, jobsV2RunSucceeded, recent, recent, recent)
+	if err != nil {
+		t.Fatalf("insert recent queue_agent run: %v", err)
+	}
+
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, labels, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'allow', 1, 60, 'run', ?, ?, ?)`,
+		"job_queue_agent_running", "queue-agent-running", jobsV2RunnerLLM, `{"agent_name":"developer","instructions":"running","cwd":"/tmp"}`, jobsV2TriggerManual, `{}`, labels, old, old)
+	if err != nil {
+		t.Fatalf("insert running queue_agent job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?)`,
+		"run_queue_agent_running", "job_queue_agent_running", old, jobsV2RunRunning, old, old)
+	if err != nil {
+		t.Fatalf("insert running queue_agent run: %v", err)
+	}
+
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, labels, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'allow', 1, 60, 'run', ?, ?, ?)`,
+		"job_queue_agent_untriggered", "queue-agent-untriggered", jobsV2RunnerLLM, `{"agent_name":"developer","instructions":"untriggered","cwd":"/tmp"}`, jobsV2TriggerManual, `{}`, labels, old, old)
+	if err != nil {
+		t.Fatalf("insert untriggered queue_agent job: %v", err)
+	}
+
+	_, err = mgr.db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'forbid', 1, 60, 'skip', ?, ?)`,
+		"job_manual_old", "manual-old", jobsV2RunnerProgram, `{"command":"echo","args":["x"]}`, jobsV2TriggerManual, `{}`, old, old)
+	if err != nil {
+		t.Fatalf("insert manual control job: %v", err)
+	}
+	_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, finished_at, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?, ?)`,
+		"run_manual_old", "job_manual_old", old, jobsV2RunSucceeded, old, old, old)
+	if err != nil {
+		t.Fatalf("insert manual control run: %v", err)
+	}
+
+	if err := mgr.pruneOldData(now); err != nil {
+		t.Fatalf("pruneOldData failed: %v", err)
+	}
+
+	assertJobExists := func(jobID string, want bool) {
+		t.Helper()
+		var count int
+		if err := mgr.db.QueryRow(`SELECT COUNT(1) FROM jobs_v2 WHERE id = ?`, jobID).Scan(&count); err != nil {
+			t.Fatalf("count job %s: %v", jobID, err)
+		}
+		if got := count == 1; got != want {
+			t.Fatalf("job %s exists = %v, want %v", jobID, got, want)
+		}
+	}
+
+	assertJobExists("job_queue_agent_old", false)
+	assertJobExists("job_queue_agent_recent", true)
+	assertJobExists("job_queue_agent_running", true)
+	assertJobExists("job_queue_agent_untriggered", false)
+	assertJobExists("job_manual_old", true)
 }
 
 func TestJobsV2LLMProgressiveRunStoresEnvelopeAndProgressEvents(t *testing.T) {

--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	defaultQueuedAgentTimeout      = 3600
-	defaultQueuedAgentPollInterval = 5
-	defaultJobsServerBaseURL       = "http://127.0.0.1:8080"
+	defaultQueuedAgentTimeout        = 3600
+	defaultQueuedAgentPollInterval   = 5
+	defaultJobsServerBaseURL         = "http://127.0.0.1:8080"
+	QueueAgentEphemeralJobLabelsJSON = `{"term_llm_queue_agent":"ephemeral"}`
 )
 
 type QueueAgentArgs struct {
@@ -65,15 +66,16 @@ type jobsBackedAgentClient struct {
 }
 
 type jobsV2AgentJobPayload struct {
-	Name              string         `json:"name"`
-	Enabled           bool           `json:"enabled"`
-	RunnerType        string         `json:"runner_type"`
-	RunnerConfig      map[string]any `json:"runner_config"`
-	TriggerType       string         `json:"trigger_type"`
-	TriggerConfig     map[string]any `json:"trigger_config,omitempty"`
-	ConcurrencyPolicy string         `json:"concurrency_policy"`
-	TimeoutSeconds    int            `json:"timeout_seconds"`
-	MisfirePolicy     string         `json:"misfire_policy"`
+	Name              string          `json:"name"`
+	Enabled           bool            `json:"enabled"`
+	RunnerType        string          `json:"runner_type"`
+	RunnerConfig      map[string]any  `json:"runner_config"`
+	TriggerType       string          `json:"trigger_type"`
+	TriggerConfig     map[string]any  `json:"trigger_config,omitempty"`
+	ConcurrencyPolicy string          `json:"concurrency_policy"`
+	TimeoutSeconds    int             `json:"timeout_seconds"`
+	MisfirePolicy     string          `json:"misfire_policy"`
+	Labels            json.RawMessage `json:"labels,omitempty"`
 }
 
 type jobsV2AgentJobResponse struct {
@@ -339,6 +341,7 @@ Choose COMPLETE only if you fully accomplished the task. Do not omit this line.`
 		ConcurrencyPolicy: "allow",
 		TimeoutSeconds:    timeout,
 		MisfirePolicy:     "run",
+		Labels:            json.RawMessage(QueueAgentEphemeralJobLabelsJSON),
 	}
 
 	var job jobsV2AgentJobResponse

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -23,6 +23,9 @@ func TestQueueAgentCreatesAndTriggersJobsBackedLLMJob(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode create payload: %v", err)
 			}
+			if string(payload.Labels) != QueueAgentEphemeralJobLabelsJSON {
+				t.Fatalf("labels = %s, want %s", string(payload.Labels), QueueAgentEphemeralJobLabelsJSON)
+			}
 			if payload.RunnerType != "llm" {
 				t.Fatalf("runner_type = %q, want llm", payload.RunnerType)
 			}


### PR DESCRIPTION
## What changed

- Tagged `queue_agent`-created jobs with a dedicated labels marker so the jobs server can distinguish ephemeral sub-agent jobs from normal user-managed jobs.
- Extended `jobsV2Manager.pruneOldData` to delete old terminal `queue_agent` jobs from `jobs_v2` itself before the existing run/event retention pass.
  - This only applies to jobs carrying the queue-agent ephemeral label.
  - Jobs are deleted only when they have no active/non-terminal runs and their latest run activity is older than the existing run-retention cutoff.
  - Old untriggered queue-agent jobs are also cleaned up once they age past that cutoff.
- Added tests covering:
  - `queue_agent` sending the ephemeral labels marker on job creation.
  - retention pruning deleting old queue-agent jobs while preserving recent queue-agent jobs, active queue-agent jobs, and normal manual jobs.

## Why this is high-value

Every `queue_agent` call previously inserted a brand-new permanent row into `jobs_v2` and nothing ever removed it. Over time that makes the jobs catalog grow without bound, which directly increases the amount of persistent state behind:

- `SELECT COUNT(1) FROM jobs_v2`
- paged `/v2/jobs` reads
- admin/job-list clutter

This fix turns that permanent leak into bounded retained state. After the normal run-retention window passes, old ephemeral queue-agent jobs are deleted entirely, so the job catalog no longer grows forever from one-shot background sub-agent work.

## Validation

- `gofmt -w internal/tools/queue_agent.go internal/tools/queue_agent_test.go cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
