### PR TITLE
fix: snapshot persistence rewrites transcripts without updating user-turn/activity metadata

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -2223,27 +2223,56 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 			}
 		}
 
-		// Update session's updated_at and clear any stale compaction boundary. A
-		// replace is a full-history rewrite; keeping an old compaction_seq could make
-		// future active-context loads start past the end of the rewritten rows.
+		// Recompute activity/turn metadata from the actual persisted rows after the
+		// replace. This preserves unchanged-prefix created_at values while ensuring a
+		// full-history rewrite can't leave user/activity metadata stale.
 		now := time.Now()
-		if s.hasCompactionSeq && s.hasCompactionCount {
-			if _, err := tx.ExecContext(ctx, "UPDATE sessions SET updated_at = ?, compaction_seq = -1, compaction_count = 0 WHERE id = ?",
-				now, sessionID); err != nil {
-				return fmt.Errorf("update session timestamp: %w", err)
-			}
-		} else if s.hasCompactionSeq {
-			if _, err := tx.ExecContext(ctx, "UPDATE sessions SET updated_at = ?, compaction_seq = -1 WHERE id = ?",
-				now, sessionID); err != nil {
-				return fmt.Errorf("update session timestamp: %w", err)
-			}
-		} else if _, err := tx.ExecContext(ctx, "UPDATE sessions SET updated_at = ? WHERE id = ?",
-			now, sessionID); err != nil {
-			return fmt.Errorf("update session timestamp: %w", err)
+		if err := s.updateSessionMetadataAfterReplace(ctx, tx, sessionID, now); err != nil {
+			return err
 		}
 
 		return tx.Commit()
 	})
+}
+
+func (s *SQLiteStore) updateSessionMetadataAfterReplace(ctx context.Context, tx *sql.Tx, sessionID string, now time.Time) error {
+	setClauses := []string{
+		"updated_at = ?",
+		"user_turns = (SELECT COUNT(*) FROM messages WHERE session_id = ? AND role = 'user')",
+	}
+	args := []any{now, sessionID}
+
+	lastUserPredicate := "role = 'user'"
+	lastMessagePredicate := "role IN ('user', 'assistant')"
+	if s.hasMessageCompactionTail {
+		lastUserPredicate = "COALESCE(compaction_tail, FALSE) = FALSE AND " + lastUserPredicate
+		lastMessagePredicate = "COALESCE(compaction_tail, FALSE) = FALSE AND " + lastMessagePredicate
+	}
+	if s.hasLastUserMessageAt {
+		setClauses = append(setClauses,
+			"last_user_message_at = (SELECT MAX(created_at) FROM messages WHERE session_id = ? AND "+lastUserPredicate+")")
+		args = append(args, sessionID)
+	}
+	if s.hasLastMessageAt {
+		setClauses = append(setClauses,
+			"last_message_at = (SELECT MAX(created_at) FROM messages WHERE session_id = ? AND "+lastMessagePredicate+")")
+		args = append(args, sessionID)
+	}
+	if s.hasCompactionSeq {
+		setClauses = append(setClauses, "compaction_seq = -1")
+	}
+	if s.hasCompactionCount {
+		setClauses = append(setClauses, "compaction_count = 0")
+	}
+	args = append(args, sessionID)
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE sessions SET "+strings.Join(setClauses, ", ")+" WHERE id = ?",
+		args...,
+	); err != nil {
+		return fmt.Errorf("update session metadata: %w", err)
+	}
+	return nil
 }
 
 func prepareReplacementMessageParts(messages []Message) ([]string, error) {

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -879,6 +879,67 @@ func assertListedMessageCount(t *testing.T, store *SQLiteStore, want int) {
 	}
 }
 
+func TestSQLiteStoreReplaceMessagesRecomputesActivityMetadata(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	base := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+	messages := []Message{
+		*NewMessage(sess.ID, llm.UserText("hello"), 0),
+		*NewMessage(sess.ID, llm.AssistantText("hi"), 1),
+	}
+	messages[0].CreatedAt = base
+	messages[1].CreatedAt = base.Add(time.Minute)
+	if err := store.ReplaceMessages(ctx, sess.ID, messages); err != nil {
+		t.Fatalf("initial ReplaceMessages: %v", err)
+	}
+
+	assertSessionActivity := func(wantTurns int, wantLastUser, wantLastMessage time.Time) {
+		t.Helper()
+		var gotTurns int
+		var gotLastUser, gotLastMessage sql.NullTime
+		if err := store.db.QueryRowContext(ctx,
+			`SELECT user_turns, last_user_message_at, last_message_at FROM sessions WHERE id = ?`,
+			sess.ID,
+		).Scan(&gotTurns, &gotLastUser, &gotLastMessage); err != nil {
+			t.Fatalf("scan session metadata: %v", err)
+		}
+		if gotTurns != wantTurns {
+			t.Fatalf("user_turns = %d, want %d", gotTurns, wantTurns)
+		}
+		if !gotLastUser.Valid || !gotLastUser.Time.Equal(wantLastUser) {
+			t.Fatalf("last_user_message_at = %v (valid=%v), want %v", gotLastUser.Time, gotLastUser.Valid, wantLastUser)
+		}
+		if !gotLastMessage.Valid || !gotLastMessage.Time.Equal(wantLastMessage) {
+			t.Fatalf("last_message_at = %v (valid=%v), want %v", gotLastMessage.Time, gotLastMessage.Valid, wantLastMessage)
+		}
+	}
+	assertSessionActivity(1, base, base.Add(time.Minute))
+
+	replacement := []Message{
+		*NewMessage(sess.ID, llm.UserText("hello"), 0),
+		*NewMessage(sess.ID, llm.AssistantText("hi"), 1),
+	}
+	replacement[0].CreatedAt = base.Add(24 * time.Hour)
+	replacement[1].CreatedAt = base.Add(25 * time.Hour)
+	if err := store.ReplaceMessages(ctx, sess.ID, replacement); err != nil {
+		t.Fatalf("replacement ReplaceMessages: %v", err)
+	}
+
+	assertSessionActivity(1, base, base.Add(time.Minute))
+}
+
 func TestSQLiteStoreReplaceMessagesPreservesUnchangedPrefix(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- Updated `internal/session.SQLiteStore.ReplaceMessages` to recompute and persist session metadata in the same transaction as the transcript rewrite.
- The replace path now refreshes:
  - `user_turns`
  - `last_user_message_at`
  - `last_message_at`
  - existing compaction-boundary clearing / `updated_at`
- Added a regression test covering both failure modes:
  - initial `ReplaceMessages` must populate the metadata from the persisted transcript
  - rerunning `ReplaceMessages` with an unchanged prefix must preserve the original persisted activity timestamps instead of deriving them from freshly rebuilt in-memory snapshot timestamps

## Why this is high-value

`persistSnapshot` is used for durable pre-stream saves, replace-history runs, and reconciliation after persistence errors. Before this change, it could successfully rewrite the transcript rows while leaving session metadata stale because it relied on `store.Update(...)`, and `Update` intentionally does not write turn counters. That produced real sessions whose transcript existed but whose user-turn count and activity timestamps stayed at `0`/`NULL`/old values.

This directly affects sidebar ordering and exported session stats, especially when a run fails before later append-only callbacks can repair the metadata.

## Validation

- `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- `go test ./...`
- Added regression test: `TestSQLiteStoreReplaceMessagesRecomputesActivityMetadata`
