### PR TITLE
fix: serve/web runs never persist turn metrics or context estimates

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -1105,9 +1105,8 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 	// Turn callback: upsert the assistant row if present as first element, then
 	// plain-append the rest (tool results or interjections). Reset pending at
 	// end of turn.
-	rt.engine.SetTurnCompletedCallback(func(cbCtx context.Context, _ int, msgs []llm.Message, _ llm.TurnMetrics) error {
+	rt.engine.SetTurnCompletedCallback(func(cbCtx context.Context, _ int, msgs []llm.Message, metrics llm.TurnMetrics) error {
 		producedMu.Lock()
-		defer producedMu.Unlock()
 		appendStart := 0
 		if len(msgs) > 0 && msgs[0].Role == llm.RoleAssistant {
 			upsertPendingAssistantLocked(cbCtx, msgs[0], !pendingAssistantTextPersisted)
@@ -1120,6 +1119,28 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		pendingAssistantIdx = -1
 		pendingAssistantMsgID = 0
 		pendingAssistantTextPersisted = false
+		producedMu.Unlock()
+
+		if persisted && rt.store != nil && rt.sessionMeta != nil {
+			if err := rt.store.UpdateMetrics(cbCtx, rt.sessionMeta.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens); err != nil {
+				log.Printf("[serve] session UpdateMetrics failed for %s: %v", req.SessionID, err)
+			} else {
+				rt.sessionMeta.LLMTurns++
+				rt.sessionMeta.ToolCalls += metrics.ToolCalls
+				rt.sessionMeta.InputTokens += metrics.InputTokens
+				rt.sessionMeta.OutputTokens += metrics.OutputTokens
+				rt.sessionMeta.CachedInputTokens += metrics.CachedInputTokens
+				rt.sessionMeta.CacheWriteTokens += metrics.CacheWriteTokens
+			}
+			if total, count := rt.engine.ContextEstimateBaseline(); total > 0 && count > 0 {
+				if err := rt.store.UpdateContextEstimate(cbCtx, rt.sessionMeta.ID, total, count); err != nil {
+					log.Printf("[serve] session UpdateContextEstimate failed for %s: %v", req.SessionID, err)
+				} else {
+					rt.sessionMeta.LastTotalTokens = total
+					rt.sessionMeta.LastMessageCount = count
+				}
+			}
+		}
 		return nil
 	})
 	defer rt.engine.SetTurnCompletedCallback(nil)

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -108,6 +108,42 @@ func (p *serveRuntimeTestProvider) Stream(ctx context.Context, req llm.Request) 
 	return &serveRuntimeTestStream{events: events}, nil
 }
 
+type serveRuntimeMetricsProvider struct {
+	calls int
+}
+
+func (p *serveRuntimeMetricsProvider) Name() string {
+	return "serve-runtime-metrics"
+}
+
+func (p *serveRuntimeMetricsProvider) Credential() string {
+	return "test"
+}
+
+func (p *serveRuntimeMetricsProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{ToolCalls: true}
+}
+
+func (p *serveRuntimeMetricsProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	var events []llm.Event
+	switch p.calls {
+	case 0:
+		events = []llm.Event{
+			{Type: llm.EventToolCall, Tool: &llm.ToolCall{ID: "call-metrics-1", Name: "serve_runtime_test_tool", Arguments: json.RawMessage(`{}`)}},
+			{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 21, OutputTokens: 5, CachedInputTokens: 2, CacheWriteTokens: 1}},
+			{Type: llm.EventDone},
+		}
+	default:
+		events = []llm.Event{
+			{Type: llm.EventTextDelta, Text: "done"},
+			{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 8, OutputTokens: 3}},
+			{Type: llm.EventDone},
+		}
+	}
+	p.calls++
+	return &serveRuntimeTestStream{events: events}, nil
+}
+
 type serveRuntimeTestTool struct{}
 
 func (t *serveRuntimeTestTool) Spec() llm.ToolSpec {
@@ -123,22 +159,24 @@ func (t *serveRuntimeTestTool) Preview(args json.RawMessage) string {
 }
 
 type serveRuntimeTestStore struct {
-	mu                  sync.Mutex
-	sessions            map[string]*session.Session
-	messages            map[string][]session.Message
-	current             string
-	replaceCalls        int
-	replaceFailures     map[int]error
-	replaceMessagesHook func(context.Context, string, []session.Message) error
-	addMessageCalls     int
-	addMessageHook      func(context.Context, string, *session.Message) error
-	updateMessageCalls  int
-	updateMessageHook   func(context.Context, string, *session.Message) error
-	updateFailures      map[int]error
-	getMessagesCalls    int
-	updateStatusCalls   int
-	incrementCalls      int
-	nextID              int64
+	mu                         sync.Mutex
+	sessions                   map[string]*session.Session
+	messages                   map[string][]session.Message
+	current                    string
+	replaceCalls               int
+	replaceFailures            map[int]error
+	replaceMessagesHook        func(context.Context, string, []session.Message) error
+	addMessageCalls            int
+	addMessageHook             func(context.Context, string, *session.Message) error
+	updateMessageCalls         int
+	updateMessageHook          func(context.Context, string, *session.Message) error
+	updateFailures             map[int]error
+	getMessagesCalls           int
+	updateMetricsCalls         int
+	updateContextEstimateCalls int
+	updateStatusCalls          int
+	incrementCalls             int
+	nextID                     int64
 }
 
 var _ session.Store = (*serveRuntimeTestStore)(nil)
@@ -356,10 +394,28 @@ func (s *serveRuntimeTestStore) CompactMessages(ctx context.Context, sessionID s
 }
 
 func (s *serveRuntimeTestStore) UpdateMetrics(ctx context.Context, id string, llmTurns, toolCalls, inputTokens, outputTokens, cachedInputTokens, cacheWriteTokens int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[id]; ok {
+		sess.LLMTurns += llmTurns
+		sess.ToolCalls += toolCalls
+		sess.InputTokens += inputTokens
+		sess.OutputTokens += outputTokens
+		sess.CachedInputTokens += cachedInputTokens
+		sess.CacheWriteTokens += cacheWriteTokens
+	}
+	s.updateMetricsCalls++
 	return nil
 }
 
 func (s *serveRuntimeTestStore) UpdateContextEstimate(ctx context.Context, id string, lastTotalTokens, lastMessageCount int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[id]; ok {
+		sess.LastTotalTokens = lastTotalTokens
+		sess.LastMessageCount = lastMessageCount
+	}
+	s.updateContextEstimateCalls++
 	return nil
 }
 
@@ -612,6 +668,86 @@ func TestServeRuntimeAppendMessagesIncrementsUserTurns(t *testing.T) {
 	}
 	if rt.sessionMeta.UserTurns != 2 {
 		t.Fatalf("runtime UserTurns = %d, want 2", rt.sessionMeta.UserTurns)
+	}
+}
+
+func TestServeRuntimeRunPersistsTurnMetricsAndContextEstimate(t *testing.T) {
+	llm.RegisterConfigLimits([]llm.ConfigModelLimit{{Provider: "serve-runtime-metrics", Model: "metrics-model", InputLimit: 1000}})
+	defer llm.RegisterConfigLimits(nil)
+
+	store := newServeRuntimeTestStore()
+	sess := &session.Session{ID: "sess-turn-metrics", Status: session.StatusActive}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	provider := &serveRuntimeMetricsProvider{}
+	tool := &serveRuntimeTestTool{}
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	engine := llm.NewEngine(provider, registry)
+
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		sessionMeta:  sess,
+		defaultModel: "metrics-model",
+	}
+
+	if _, err := rt.Run(context.Background(), true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "current user")}, llm.Request{
+		SessionID:  sess.ID,
+		Model:      "metrics-model",
+		Tools:      []llm.ToolSpec{tool.Spec()},
+		ToolChoice: llm.ToolChoice{Mode: llm.ToolChoiceAuto},
+		MaxTurns:   4,
+	}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if store.updateMetricsCalls != 2 {
+		t.Fatalf("UpdateMetrics calls = %d, want 2", store.updateMetricsCalls)
+	}
+	if store.updateContextEstimateCalls != 2 {
+		t.Fatalf("UpdateContextEstimate calls = %d, want 2", store.updateContextEstimateCalls)
+	}
+
+	stored, err := store.Get(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if stored.LLMTurns != 2 {
+		t.Fatalf("stored LLMTurns = %d, want 2", stored.LLMTurns)
+	}
+	if stored.ToolCalls != 1 {
+		t.Fatalf("stored ToolCalls = %d, want 1", stored.ToolCalls)
+	}
+	if stored.InputTokens != 29 {
+		t.Fatalf("stored InputTokens = %d, want 29", stored.InputTokens)
+	}
+	if stored.OutputTokens != 8 {
+		t.Fatalf("stored OutputTokens = %d, want 8", stored.OutputTokens)
+	}
+	if stored.CachedInputTokens != 2 {
+		t.Fatalf("stored CachedInputTokens = %d, want 2", stored.CachedInputTokens)
+	}
+	if stored.CacheWriteTokens != 1 {
+		t.Fatalf("stored CacheWriteTokens = %d, want 1", stored.CacheWriteTokens)
+	}
+	if rt.sessionMeta.LLMTurns != stored.LLMTurns || rt.sessionMeta.ToolCalls != stored.ToolCalls {
+		t.Fatalf("runtime metrics = %+v, want store metrics %+v", rt.sessionMeta, stored)
+	}
+
+	total, count := engine.ContextEstimateBaseline()
+	if total <= 0 || count <= 0 {
+		t.Fatalf("ContextEstimateBaseline() = (%d, %d), want positive values", total, count)
+	}
+	if stored.LastTotalTokens != total || stored.LastMessageCount != count {
+		t.Fatalf("stored context estimate = (%d, %d), want (%d, %d)", stored.LastTotalTokens, stored.LastMessageCount, total, count)
+	}
+	if rt.sessionMeta.LastTotalTokens != total || rt.sessionMeta.LastMessageCount != count {
+		t.Fatalf("runtime context estimate = (%d, %d), want (%d, %d)", rt.sessionMeta.LastTotalTokens, rt.sessionMeta.LastMessageCount, total, count)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Updated `cmd/serve_runtime.go` so the existing `SetTurnCompletedCallback` now persists per-turn metrics for serve/web runs via `store.UpdateMetrics(...)`.
- Persisted the engine context-estimate baseline on normal turn completion via `store.UpdateContextEstimate(...)`, matching the existing CLI/TUI/Telegram behavior.
- Updated the in-memory `sessionMeta` counters and persisted context estimate when those writes succeed so active serve sessions stay consistent with stored session state.
- Added a regression test in `cmd/serve_runtime_test.go` that exercises a multi-turn tool run and verifies both metrics and context estimates are persisted.

## Why this is high-value

Serve/web sessions were successfully appending transcript rows but silently leaving session accounting stale on normal completion. That meant:

- `llm_turns`, `tool_calls`, and token totals could stay zero or outdated
- `last_total_tokens` / `last_message_count` were not saved for resumed web sessions
- user-visible stats and any usage/cost reporting based on session rows became incorrect
- resumed sessions could start with a bad context estimate even though other surfaces already persisted it correctly

This fix is small, targeted, and aligns serve/web with already-shipped persistence behavior in ask/TUI/Telegram.

## Validation

- Added regression test: `go test ./cmd -run TestServeRuntimeRunPersistsTurnMetricsAndContextEstimate -count=1`
- Ran `gofmt -w cmd/serve_runtime.go cmd/serve_runtime_test.go`
- Ran `go build ./...`
- Ran `go test ./...`
- Ran `git diff --stat` and `git diff --check`
