### PR TITLE
fix: Responses tool continuations rescan the entire session history to recover tool names

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -436,7 +436,29 @@ func (s *serveServer) populateResponsesToolResultNames(ctx context.Context, sess
 		collect(runtime.snapshotHistory())
 	}
 	if len(names) < len(missing) && s.store != nil && sessionID != "" {
-		if stored, err := s.store.GetMessages(ctx, sessionID, 0, 0); err == nil {
+		if pager, ok := s.store.(session.MessagesDescendingPager); ok {
+			const pageSize = 128
+			beforeSeq := 0
+			for len(names) < len(missing) {
+				stored, err := pager.GetMessagesPageDescending(ctx, sessionID, beforeSeq, pageSize)
+				if err != nil || len(stored) == 0 {
+					break
+				}
+				for _, msg := range stored {
+					collectParts(msg.Parts)
+					if len(names) == len(missing) {
+						break
+					}
+				}
+				if len(names) == len(missing) || len(stored) < pageSize {
+					break
+				}
+				beforeSeq = stored[len(stored)-1].Sequence
+				if beforeSeq <= 0 {
+					break
+				}
+			}
+		} else if stored, err := s.store.GetMessages(ctx, sessionID, 0, 0); err == nil {
 			for i := len(stored) - 1; i >= 0; i-- {
 				collectParts(stored[i].Parts)
 				if len(names) == len(missing) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -44,6 +44,46 @@ type stagedStream struct {
 	events <-chan llm.Event
 }
 
+type responsesToolNamePagerStore struct {
+	*serveRuntimeTestStore
+	getMessagesPageDescendingCalls int
+	descendingCalls                []struct {
+		beforeSeq int
+		limit     int
+	}
+}
+
+var _ session.MessagesDescendingPager = (*responsesToolNamePagerStore)(nil)
+
+func (s *responsesToolNamePagerStore) GetMessagesPageDescending(ctx context.Context, sessionID string, beforeSeq, limit int) ([]session.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getMessagesPageDescendingCalls++
+	s.descendingCalls = append(s.descendingCalls, struct {
+		beforeSeq int
+		limit     int
+	}{beforeSeq: beforeSeq, limit: limit})
+
+	msgs := s.messages[sessionID]
+	capHint := len(msgs)
+	if limit > 0 && limit < capHint {
+		capHint = limit
+	}
+	page := make([]session.Message, 0, capHint)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if beforeSeq > 0 && msgs[i].Sequence >= beforeSeq {
+			continue
+		}
+		page = append(page, msgs[i])
+		if limit > 0 && len(page) >= limit {
+			break
+		}
+	}
+	out := make([]session.Message, len(page))
+	copy(out, page)
+	return out, nil
+}
+
 func (s *stagedStream) Recv() (llm.Event, error) {
 	select {
 	case event, ok := <-s.events:
@@ -1564,6 +1604,52 @@ func TestPopulateResponsesToolResultNames_FallsBackToStoreForUnresolvedNames(t *
 	}
 	if store.getMessagesCalls != 1 {
 		t.Fatalf("GetMessages calls = %d, want 1 when runtime cannot resolve names", store.getMessagesCalls)
+	}
+}
+
+func TestPopulateResponsesToolResultNames_UsesReversePagedStoreLookup(t *testing.T) {
+	messages := []llm.Message{{
+		Role: llm.RoleTool,
+		Parts: []llm.Part{{
+			Type: llm.PartToolResult,
+			ToolResult: &llm.ToolResult{
+				ID: "call_old",
+			},
+		}},
+	}}
+	baseStore := newServeRuntimeTestStore()
+	store := &responsesToolNamePagerStore{serveRuntimeTestStore: baseStore}
+	for seq := 1; seq <= 130; seq++ {
+		msg := llm.AssistantText(fmt.Sprintf("assistant %d", seq))
+		if seq == 1 {
+			msg = llm.Message{Role: llm.RoleAssistant, Parts: []llm.Part{{
+				Type:     llm.PartToolCall,
+				ToolCall: &llm.ToolCall{ID: "call_old", Name: "bash"},
+			}}}
+		}
+		baseStore.messages["sess-paged"] = append(baseStore.messages["sess-paged"], *session.NewMessage("sess-paged", msg, seq))
+	}
+	srv := &serveServer{store: store}
+
+	srv.populateResponsesToolResultNames(context.Background(), "sess-paged", nil, messages)
+
+	if got := messages[0].Parts[0].ToolResult.Name; got != "bash" {
+		t.Fatalf("tool result name = %q, want %q", got, "bash")
+	}
+	if baseStore.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages calls = %d, want 0 when reverse paging is available", baseStore.getMessagesCalls)
+	}
+	if store.getMessagesPageDescendingCalls != 2 {
+		t.Fatalf("GetMessagesPageDescending calls = %d, want 2 pages", store.getMessagesPageDescendingCalls)
+	}
+	if len(store.descendingCalls) != 2 {
+		t.Fatalf("descending call count = %d, want 2", len(store.descendingCalls))
+	}
+	if store.descendingCalls[0].beforeSeq != 0 || store.descendingCalls[0].limit != 128 {
+		t.Fatalf("first descending call = %+v, want beforeSeq=0 limit=128", store.descendingCalls[0])
+	}
+	if store.descendingCalls[1].beforeSeq != 3 || store.descendingCalls[1].limit != 128 {
+		t.Fatalf("second descending call = %+v, want beforeSeq=3 limit=128", store.descendingCalls[1])
 	}
 }
 


### PR DESCRIPTION
## What changed

- Changed `populateResponsesToolResultNames` to prefer reverse-paged store lookups when the session store supports `session.MessagesDescendingPager`.
- The lookup now scans recent persisted messages in descending sequence order and stops as soon as all missing tool-call IDs are resolved.
- Kept the existing full-history `GetMessages` fallback for stores that do not implement the optional reverse pager.
- Added a regression test covering the reverse-paged path and verifying it resolves an older tool call without falling back to full-history loading.

## Why this is high-value

Responses follow-up requests that contain only `function_call_output` items often arrive without tool names in the current payload, so the server has to recover names from prior tool-call messages.

Before this change, persisted continuations could call `GetMessages(ctx, sessionID, 0, 0)` and deserialize the entire transcript just to recover one or a few tool names. On long-lived, tool-heavy sessions that turns a hot follow-up request into O(full transcript) DB I/O and JSON decoding.

After this change, SQLite/logging-backed stores can read only the newest tail pages and stop early once the needed call IDs are found. That reduces total rows read, JSON deserialization work, peak allocations, and continuation latency, especially when the relevant tool call is near the end of a long session.

## Validation

- `gofmt -w cmd/serve_handlers_responses.go cmd/serve_test.go`
- `go build ./...`
- `go test ./...`
- Added `TestPopulateResponsesToolResultNames_UsesReversePagedStoreLookup` to verify reverse paging is used and full-history `GetMessages` is not called when the pager capability is available.
