### PR TITLE
fix: Completion notifications block the job worker for up to 10s after every run

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1447,7 +1447,7 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		"input_tokens":  result.InputTokens,
 		"output_tokens": result.OutputTokens,
 	})
-	m.notifyRunDone(runID, status, result, exitReason, truncated, errText)
+	m.notifyRunDoneAsync(run, status, result, exitReason, truncated, errText)
 
 	if status == jobsV2RunFailed || status == jobsV2RunTimedOut {
 		job, err := m.GetJob(run.JobID)
@@ -1484,22 +1484,29 @@ func jobsV2NotifyTerminalStatus(status jobsV2RunStatus) bool {
 	}
 }
 
-func (m *jobsV2Manager) notifyRunDone(runID string, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) {
+func (m *jobsV2Manager) notifyRunDoneAsync(run jobsV2Run, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) {
 	if m == nil || m.notifyDone == nil || !jobsV2NotifyTerminalStatus(status) {
 		return
 	}
-	run, err := m.GetRun(runID)
-	if err != nil {
-		return
-	}
-	job, err := m.GetJob(run.JobID)
-	if err != nil {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		job, err := m.GetJob(run.JobID)
+		if err != nil {
+			return
+		}
+		m.notifyRunDone(run, job, status, result, exitReason, truncated, errText)
+	}()
+}
+
+func (m *jobsV2Manager) notifyRunDone(run jobsV2Run, job jobsV2Job, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) {
+	if m == nil || m.notifyDone == nil || !jobsV2NotifyTerminalStatus(status) {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := m.notifyDone(ctx, run, job, status, result, exitReason, truncated, errText); err != nil {
-		_ = m.addRunEvent(runID, "notify_failed", "completion notification failed", map[string]any{"error": err.Error()})
+		_ = m.addRunEvent(run.ID, "notify_failed", "completion notification failed", map[string]any{"error": err.Error()})
 	}
 }
 

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -192,6 +192,12 @@ func TestJobsV2NotifyWhenDoneAppendsWebNotificationToIdleSession(t *testing.T) {
 		t.Fatalf("finishRun: %v", err)
 	}
 
+	waitForServeCondition(t, 2*time.Second, func() bool {
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		return len(store.messages["sess-origin"]) == 1
+	}, "completion notification to append to idle session")
+
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	msgs := store.messages["sess-origin"]
@@ -298,6 +304,18 @@ func TestJobsV2NotifyFailureDoesNotChangeRunStatus(t *testing.T) {
 	if updated.Status != jobsV2RunSucceeded {
 		t.Fatalf("status = %s, want succeeded", updated.Status)
 	}
+	waitForServeCondition(t, 2*time.Second, func() bool {
+		events, _, err := mgr.ListRunEvents(run.ID, 0, 20, 0)
+		if err != nil {
+			return false
+		}
+		for _, ev := range events {
+			if ev.EventType == "notify_failed" {
+				return true
+			}
+		}
+		return false
+	}, "notify_failed event to be recorded asynchronously")
 	events, _, err := mgr.ListRunEvents(run.ID, 0, 20, 0)
 	if err != nil {
 		t.Fatalf("ListRunEvents: %v", err)
@@ -310,5 +328,72 @@ func TestJobsV2NotifyFailureDoesNotChangeRunStatus(t *testing.T) {
 	}
 	if !foundNotifyFailure {
 		t.Fatalf("expected notify_failed event, got %#v", events)
+	}
+}
+
+func TestJobsV2FinishRunDoesNotBlockOnCompletionNotification(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	notifyDone := make(chan struct{})
+	mgr, err := newJobsV2ManagerWithNotifier(":memory:", 0, nil, func(ctx context.Context, run jobsV2Run, job jobsV2Job, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) error {
+		close(started)
+		defer close(notifyDone)
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	defer func() {
+		close(release)
+		_ = mgr.Close()
+	}()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "notify-non-blocking",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+
+	finished := make(chan error, 1)
+	go func() {
+		finished <- mgr.finishRun(run.ID, jobsV2RunSucceeded, jobsV2RunResult{Stdout: "ok"}, nil, run.Attempt)
+	}()
+
+	select {
+	case err := <-finished:
+		if err != nil {
+			t.Fatalf("finishRun: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("finishRun blocked on completion notification")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("completion notification did not start")
+	}
+
+	updated, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if updated.Status != jobsV2RunSucceeded {
+		t.Fatalf("status = %s, want succeeded", updated.Status)
 	}
 }


### PR DESCRIPTION
## What changed

- moved completion notifications off the worker hot path by making `finishRun()` enqueue notification work to an async goroutine after the terminal run state and final event are committed
- reused the already-loaded terminal `run` snapshot for notifications and loaded the job inside the async path
- kept retry scheduling independent of notification delivery
- updated notification tests to wait for the now-async side effects and added a regression test proving `finishRun()` returns quickly even when the notifier is blocked

## Why this is high-value

Before this change, every worker stayed occupied until `notifyRunDone()` finished, and that path can spend up to 10 seconds inside `notifyDone()` waiting on external delivery. That directly reduces queue throughput, delays retries, and makes low-worker setups feel stuck even though the run is already terminal in SQLite.

After this change, the worker returns to claiming the next queued run as soon as terminal DB state is committed. The remaining work is just an async notification goroutine, so notification latency no longer serializes job execution.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_notify_test.go`
- `go build ./...`
- `go test ./...`
- added regression test: `TestJobsV2FinishRunDoesNotBlockOnCompletionNotification`
- updated existing notification tests to verify async delivery and async `notify_failed` event recording
