### PR TITLE
fix: Finished jobs can remain stuck in claimed/running forever because finishRun errors are dropped

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -228,12 +229,14 @@ var (
 )
 
 const (
-	jobsV2SchedulerMinDelay   = 100 * time.Millisecond
-	jobsV2SchedulerIdleDelay  = time.Minute
-	jobsV2SchedulerErrorDelay = 200 * time.Millisecond
-	jobsV2WorkerMinDelay      = 100 * time.Millisecond
-	jobsV2WorkerIdleDelay     = time.Minute
-	jobsV2WorkerErrorDelay    = 200 * time.Millisecond
+	jobsV2SchedulerMinDelay    = 100 * time.Millisecond
+	jobsV2SchedulerIdleDelay   = time.Minute
+	jobsV2SchedulerErrorDelay  = 200 * time.Millisecond
+	jobsV2WorkerMinDelay       = 100 * time.Millisecond
+	jobsV2WorkerIdleDelay      = time.Minute
+	jobsV2WorkerErrorDelay     = 200 * time.Millisecond
+	jobsV2FinishRunRetryDelay  = 500 * time.Millisecond
+	jobsV2FinishRunMaxAttempts = 3
 )
 
 type jobsV2ProgramConfig struct {
@@ -1318,15 +1321,21 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 }
 
 func (m *jobsV2Manager) executeRun(run jobsV2Run) {
+	finish := func(status jobsV2RunStatus, result jobsV2RunResult, runErr error) {
+		if err := m.finishRunWithRetry(run.ID, status, result, runErr, run.Attempt); err != nil {
+			log.Printf("[jobs-v2] failed to finalize run %s as %s: %v", run.ID, status, err)
+		}
+	}
+
 	job, err := m.GetJob(run.JobID)
 	if err != nil {
-		_ = m.finishRun(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("load job: %w", err), run.Attempt)
+		finish(jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("load job: %w", err))
 		return
 	}
 
 	runner, ok := m.runners[job.RunnerType]
 	if !ok {
-		_ = m.finishRun(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("unknown runner type: %s", job.RunnerType), run.Attempt)
+		finish(jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("unknown runner type: %s", job.RunnerType))
 		return
 	}
 
@@ -1352,7 +1361,7 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 	started := time.Now().UTC()
 	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunRunning, started, run.ID, jobsV2RunClaimed)
 	if err != nil {
-		_ = m.finishRun(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("mark run running: %w", err), run.Attempt)
+		finish(jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("mark run running: %w", err))
 		return
 	}
 	affected, _ := res.RowsAffected()
@@ -1380,26 +1389,43 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 	}
 	result, runErr := runner.Run(ctx, job, pw)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		_ = m.finishRun(run.ID, jobsV2RunTimedOut, result, context.DeadlineExceeded, run.Attempt)
+		finish(jobsV2RunTimedOut, result, context.DeadlineExceeded)
 		return
 	}
 	if errors.Is(ctx.Err(), context.Canceled) {
-		_ = m.finishRun(run.ID, jobsV2RunCancelled, result, context.Canceled, run.Attempt)
+		finish(jobsV2RunCancelled, result, context.Canceled)
 		return
 	}
 	if result.ExitReason == exitReasonTimeout {
-		_ = m.finishRun(run.ID, jobsV2RunTimedOut, result, context.DeadlineExceeded, run.Attempt)
+		finish(jobsV2RunTimedOut, result, context.DeadlineExceeded)
 		return
 	}
 	if result.ExitReason == exitReasonCancelled {
-		_ = m.finishRun(run.ID, jobsV2RunCancelled, result, context.Canceled, run.Attempt)
+		finish(jobsV2RunCancelled, result, context.Canceled)
 		return
 	}
 	if runErr != nil {
-		_ = m.finishRun(run.ID, jobsV2RunFailed, result, runErr, run.Attempt)
+		finish(jobsV2RunFailed, result, runErr)
 		return
 	}
-	_ = m.finishRun(run.ID, jobsV2RunSucceeded, result, nil, run.Attempt)
+	finish(jobsV2RunSucceeded, result, nil)
+}
+
+func (m *jobsV2Manager) finishRunWithRetry(runID string, status jobsV2RunStatus, result jobsV2RunResult, runErr error, attempt int) error {
+	var lastErr error
+	for finishAttempt := 1; finishAttempt <= jobsV2FinishRunMaxAttempts; finishAttempt++ {
+		if err := m.finishRun(runID, status, result, runErr, attempt); err != nil {
+			lastErr = err
+			if finishAttempt == jobsV2FinishRunMaxAttempts {
+				return fmt.Errorf("persist terminal run state after %d attempts: %w", finishAttempt, err)
+			}
+			log.Printf("[jobs-v2] failed to persist terminal status for run %s as %s (attempt %d/%d): %v", runID, status, finishAttempt, jobsV2FinishRunMaxAttempts, err)
+			time.Sleep(jobsV2FinishRunRetryDelay)
+			continue
+		}
+		return nil
+	}
+	return lastErr
 }
 
 func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result jobsV2RunResult, runErr error, attempt int) error {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -1606,11 +1606,25 @@ func TestJobsV2MaybeRunCleanupRetriesAfterFailure(t *testing.T) {
 
 func newJobsV2ManagerWithoutLoops(t *testing.T) *jobsV2Manager {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	return newJobsV2ManagerWithoutLoopsAtPath(t, ":memory:")
+}
+
+func newJobsV2ManagerWithoutLoopsAtPath(t *testing.T, dbPath string) *jobsV2Manager {
+	t.Helper()
+	dsn := dbPath
+	if strings.Contains(dsn, "?") {
+		dsn += "&"
+	} else {
+		dsn += "?"
+	}
+	dsn += "_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		t.Fatalf("sql.Open failed: %v", err)
 	}
-	db.SetMaxOpenConns(1)
+	if dbPath == ":memory:" {
+		db.SetMaxOpenConns(1)
+	}
 	if err := execJobsV2Schema(db); err != nil {
 		_ = db.Close()
 		t.Fatalf("execJobsV2Schema failed: %v", err)
@@ -1623,6 +1637,7 @@ func newJobsV2ManagerWithoutLoops(t *testing.T) *jobsV2Manager {
 		workerIdleDelay:    jobsV2WorkerIdleDelay,
 		cleanupInterval:    0,
 		cancels:            make(map[string]context.CancelFunc),
+		runners:            make(map[jobsV2RunnerType]jobsV2Runner),
 	}
 }
 
@@ -1633,6 +1648,23 @@ type testJobsV2Runner struct {
 func (r *testJobsV2Runner) Run(ctx context.Context, job jobsV2Job, pw progressWriter) (jobsV2RunResult, error) {
 	r.called = true
 	return jobsV2RunResult{}, nil
+}
+
+type blockingJobsV2Runner struct {
+	started chan struct{}
+	release chan struct{}
+	result  jobsV2RunResult
+	err     error
+}
+
+func (r *blockingJobsV2Runner) Run(ctx context.Context, job jobsV2Job, pw progressWriter) (jobsV2RunResult, error) {
+	close(r.started)
+	select {
+	case <-ctx.Done():
+		return jobsV2RunResult{}, ctx.Err()
+	case <-r.release:
+		return r.result, r.err
+	}
 }
 
 func TestJobsV2ExecuteRunDoesNotStartWhenManagerClosed(t *testing.T) {
@@ -1701,6 +1733,110 @@ func TestJobsV2ExecuteRunDoesNotStartWhenManagerClosed(t *testing.T) {
 	}
 	if updated.StartedAt != nil {
 		t.Fatal("started_at was set even though closed manager should not start the run")
+	}
+}
+
+func TestJobsV2ExecuteRunRetriesFinishRunAfterTransientDBLock(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jobs_v2.db")
+	mgr := newJobsV2ManagerWithoutLoopsAtPath(t, dbPath)
+
+	runner := &blockingJobsV2Runner{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		result:  jobsV2RunResult{Response: "ok"},
+	}
+	mgr.runners[jobsV2RunnerProgram] = runner
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:           "finish-run-retry",
+		Enabled:        true,
+		RunnerType:     jobsV2RunnerProgram,
+		RunnerConfig:   json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:    jobsV2TriggerManual,
+		TriggerConfig:  json.RawMessage(`{}`),
+		TimeoutSeconds: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+	run, ok, err := mgr.claimNextRun()
+	if err != nil {
+		t.Fatalf("claimNextRun failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("claimNextRun did not return a run")
+	}
+
+	execDone := make(chan struct{})
+	go func() {
+		mgr.executeRun(run)
+		close(execDone)
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not start in time")
+	}
+
+	current, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun while running failed: %v", err)
+	}
+	if current.Status != jobsV2RunRunning {
+		t.Fatalf("status while running = %s, want %s", current.Status, jobsV2RunRunning)
+	}
+
+	lockDB, err := sql.Open("sqlite", dbPath+"?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)")
+	if err != nil {
+		t.Fatalf("open lock db failed: %v", err)
+	}
+	defer func() { _ = lockDB.Close() }()
+	lockDB.SetMaxOpenConns(1)
+	if _, err := lockDB.Exec(`BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE failed: %v", err)
+	}
+	defer func() {
+		_, _ = lockDB.Exec(`ROLLBACK`)
+	}()
+	if _, err := lockDB.Exec(`UPDATE job_runs_v2 SET updated_at = CURRENT_TIMESTAMP WHERE id = ?`, run.ID); err != nil {
+		t.Fatalf("lock update failed: %v", err)
+	}
+
+	go func() {
+		time.Sleep(5200 * time.Millisecond)
+		_, _ = lockDB.Exec(`ROLLBACK`)
+	}()
+	close(runner.release)
+
+	select {
+	case <-execDone:
+	case <-time.After(12 * time.Second):
+		t.Fatal("executeRun did not return in time")
+	}
+
+	finished, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun after executeRun failed: %v", err)
+	}
+	if finished.Status != jobsV2RunSucceeded {
+		t.Fatalf("final status = %s, want %s", finished.Status, jobsV2RunSucceeded)
+	}
+	if finished.Response != "ok" {
+		t.Fatalf("response = %q, want %q", finished.Response, "ok")
+	}
+
+	active, err := mgr.countActiveRuns(job.ID)
+	if err != nil {
+		t.Fatalf("countActiveRuns failed: %v", err)
+	}
+	if active != 0 {
+		t.Fatalf("active runs = %d, want 0", active)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a small `finishRunWithRetry` helper in `cmd/serve_jobs_v2.go` and routed every terminal `executeRun` path through it instead of discarding `finishRun` errors.
- The helper retries terminal status persistence up to 3 times with a short delay and logs loudly if finalization still cannot be persisted.
- Added a regression test that holds a transient SQLite write lock while a run is finishing, then verifies the run still reaches `succeeded` and no longer counts as active.

## Why this is high-value

A transient DB error during `finishRun` was previously dropped, leaving a run stuck in `claimed` or `running` until process restart. Because active-run counting includes those states, one bad finalization could block future runs for concurrency-limited jobs indefinitely, while also breaking retries/notifications and showing stale running jobs in the UI. Retrying the terminal update before `executeRun` returns closes that reliability hole for steady-state transient failures.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- Added `TestJobsV2ExecuteRunRetriesFinishRunAfterTransientDBLock` to reproduce the transient-finalization-failure path and verify the run is not left active.
