### PR TITLE
fix: Jobs SQLite database uses the default unbounded connection pool despite concurrent scheduler and workers

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -669,10 +669,12 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 	if err != nil {
 		return nil, fmt.Errorf("open jobs db: %w", err)
 	}
-	if dbPath == ":memory:" {
-		// Required for :memory: databases: keep a single connection so schema/data persist.
-		db.SetMaxOpenConns(1)
-	}
+	// The jobs manager has concurrent scheduler, worker, and HTTP paths that all
+	// write through this handle. SQLite still allows only one writer at a time,
+	// so keep the pool at a single connection to avoid SQLITE_BUSY contention and
+	// duplicate per-connection page caches.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	if err := execJobsV2Schema(db); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("init jobs schema: %w", err)

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/tools"
 )
 
-func TestNewJobsV2ManagerDoesNotForceSingleConnectionForFileBackedDB(t *testing.T) {
+func TestNewJobsV2ManagerLimitsFileBackedDBConnections(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "jobs_v2.db")
 	mgr, err := newJobsV2Manager(dbPath, 0, nil)
 	if err != nil {
@@ -24,8 +24,8 @@ func TestNewJobsV2ManagerDoesNotForceSingleConnectionForFileBackedDB(t *testing.
 	}
 	defer func() { _ = mgr.Close() }()
 
-	if got := mgr.db.Stats().MaxOpenConnections; got != 0 {
-		t.Fatalf("MaxOpenConnections = %d, want 0 for file-backed DB", got)
+	if got := mgr.db.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("MaxOpenConnections = %d, want 1 for file-backed DB", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- capped the jobs v2 SQLite pool at a single connection immediately after `sql.Open`
- set the idle limit to match so the jobs manager does not keep extra idle SQLite connections around
- updated the jobs v2 manager test to assert that file-backed databases are no longer left on the default unbounded pool

## Why this is high-value

The jobs manager runs a scheduler goroutine, worker goroutines, and HTTP/admin paths against the same SQLite handle. Those paths all perform writes such as claiming runs, updating progress, finishing runs, and inserting events. SQLite still permits only one writer at a time, so leaving `database/sql` on its default unbounded pool allows multiple writer connections to contend and fail with `SQLITE_BUSY` / `database is locked` under load.

Serializing access through a single shared connection removes that failure mode for the jobs service and also avoids duplicate per-connection page caches for the same file-backed database.

## Validation

- `go test ./cmd -run TestNewJobsV2ManagerLimitsFileBackedDBConnections -count=1`
- `go build ./...`
- `go test ./...`
- `git diff --check`
