### PR TITLE
fix: allow browser auth for hub

### DIFF
--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -6,7 +6,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
+
+const hubAuthCookieName = "term_llm_hub_token"
 
 func (s *hubServer) handler() http.Handler {
 	mux := http.NewServeMux()
@@ -30,6 +33,20 @@ func (s *hubServer) auth(next http.Handler) http.Handler {
 		if r.Method == http.MethodOptions || r.URL.Path == "/healthz" || hubNodeAuthRoute(r) {
 			next.ServeHTTP(w, r)
 			return
+		}
+		if hubQueryTokenMatches(r, s.token) {
+			setHubAuthCookie(w, r.URL.Query().Get("token"))
+			if r.Method == http.MethodGet || r.Method == http.MethodHead {
+				clean := *r.URL
+				q := clean.Query()
+				q.Del("token")
+				clean.RawQuery = q.Encode()
+				if clean.RawQuery == "" {
+					clean.ForceQuery = false
+				}
+				http.Redirect(w, r, clean.String(), http.StatusFound)
+				return
+			}
 		}
 		if !hubBearerTokenMatches(r, s.token) {
 			writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "invalid hub authentication credentials")
@@ -57,18 +74,48 @@ func hubDelegationOperatorRoute(r *http.Request) bool {
 }
 
 func hubBearerTokenMatches(r *http.Request, want string) bool {
+	if hubTokenMatches(strings.TrimSpace(want), bearerTokenFromHeader(r)) {
+		return true
+	}
+	if c, err := r.Cookie(hubAuthCookieName); err == nil && hubTokenMatches(strings.TrimSpace(want), c.Value) {
+		return true
+	}
+	return false
+}
+
+func hubQueryTokenMatches(r *http.Request, want string) bool {
+	return hubTokenMatches(strings.TrimSpace(want), r.URL.Query().Get("token"))
+}
+
+func bearerTokenFromHeader(r *http.Request) string {
 	auth := strings.TrimSpace(r.Header.Get("Authorization"))
 	scheme, rest, ok := strings.Cut(auth, " ")
 	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(rest)
+}
+
+func hubTokenMatches(want, got string) bool {
+	got = strings.TrimSpace(got)
+	if got == "" || want == "" {
 		return false
 	}
-	got := strings.TrimSpace(rest)
-	if got == "" || strings.TrimSpace(want) == "" {
-		return false
-	}
-	wantHash := sha256.Sum256([]byte(strings.TrimSpace(want)))
+	wantHash := sha256.Sum256([]byte(want))
 	gotHash := sha256.Sum256([]byte(got))
 	return subtle.ConstantTimeCompare(wantHash[:], gotHash[:]) == 1
+}
+
+func setHubAuthCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     hubAuthCookieName,
+		Value:    strings.TrimSpace(token),
+		Path:     "/",
+		Expires:  time.Now().Add(365 * 24 * time.Hour),
+		MaxAge:   365 * 24 * 60 * 60,
+		SameSite: http.SameSiteStrictMode,
+		HttpOnly: true,
+	})
 }
 
 // hubBrowserRequestAllowed rejects cross-site browser requests before the hub

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -72,6 +72,36 @@ func TestHubAuthProtectsDashboardAPIAndProxy(t *testing.T) {
 	}
 }
 
+func TestHubAuthQueryTokenSetsCookie(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	s.requireAuth = true
+	s.token = "hub-secret"
+	h := s.handler()
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/?token=hub-secret", nil))
+	if rec.Code != http.StatusFound {
+		t.Fatalf("query token status = %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Fatalf("redirect location = %q, want /", loc)
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != hubAuthCookieName || cookies[0].Value != "hub-secret" || !cookies[0].HttpOnly {
+		t.Fatalf("auth cookie = %#v", cookies)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/node/alpha/v1/models", nil)
+	req.AddCookie(cookies[0])
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cookie-auth proxy status = %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHubAuthSkipsReverseConnectNodeAuth(t *testing.T) {
 	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
 	s.requireAuth = true


### PR DESCRIPTION
## What

Allow `term-llm serve hub --auth bearer` to work from a normal browser session:

- Accept a valid `?token=<hub bearer>` on hub routes.
- Set an HttpOnly `term_llm_hub_token` cookie.
- Redirect back to the same URL with the token stripped.
- Continue accepting normal `Authorization: Bearer ...` clients.
- Keep `/healthz` unauthenticated and `/api/connect` on node auth.

## Why

The Hub dashboard currently protects the HTML, `/api/nodes`, and `/node/<id>/...` with bearer auth, but the dashboard frontend uses ordinary browser `fetch()` and links. A user can send an `Authorization` header with curl, but cannot practically keep the dashboard/API/proxy authenticated in a browser.

This made LAN/private Hub deployments look like auth was broken: the initial page/API/proxy returned 401 unless manually driven with headers.

## Verification

- `go test ./cmd -run 'TestHubAuth|TestValidateHubBind'`
- `go test ./cmd -run 'TestHub|TestServeHub'`
- `go build ./...`

Also live-smoked Jarvis LAN Hub on `10.0.0.52:12654`:

- unauth dashboard: 401
- `/?token=...`: 302 + HttpOnly cookie + token-stripped redirect
- dashboard with cookie: 200
- `/api/nodes` with cookie: 200
- `/node/jarvis/` with cookie: 200 and UI prefix rebased to `/node/jarvis`
