### PR TITLE
fix: show hub login page for browser auth

### DIFF
--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/sha256"
 	"crypto/subtle"
+	"html/template"
 	"net/http"
 	"net/url"
 	"strings"
@@ -49,6 +50,10 @@ func (s *hubServer) auth(next http.Handler) http.Handler {
 			}
 		}
 		if !hubBearerTokenMatches(r, s.token) {
+			if hubShouldRenderLogin(r) {
+				writeHubLoginPage(w, r, hubQueryTokenSupplied(r))
+				return
+			}
 			writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "invalid hub authentication credentials")
 			return
 		}
@@ -85,6 +90,124 @@ func hubBearerTokenMatches(r *http.Request, want string) bool {
 
 func hubQueryTokenMatches(r *http.Request, want string) bool {
 	return hubTokenMatches(strings.TrimSpace(want), r.URL.Query().Get("token"))
+}
+
+func hubQueryTokenSupplied(r *http.Request) bool {
+	_, ok := r.URL.Query()["token"]
+	return ok
+}
+
+func hubShouldRenderLogin(r *http.Request) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("Sec-Fetch-Mode")), "navigate") {
+		return true
+	}
+	accept := strings.ToLower(r.Header.Get("Accept"))
+	return strings.Contains(accept, "text/html")
+}
+
+var hubLoginTemplate = template.Must(template.New("hub-login").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>term-llm Hub</title>
+  <style>
+    :root { color-scheme: dark light; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+    }
+    main {
+      width: min(24rem, calc(100vw - 2rem));
+      padding: 1.5rem;
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 16px;
+      background: #161b22;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.35);
+    }
+    h1 { margin: 0 0 0.35rem; font-size: 1.35rem; }
+    p { margin: 0 0 1rem; color: #8b949e; line-height: 1.45; }
+    .error {
+      margin-bottom: 1rem;
+      padding: 0.65rem 0.75rem;
+      border: 1px solid rgba(248,81,73,0.35);
+      border-radius: 10px;
+      background: rgba(248,81,73,0.10);
+      color: #ffa198;
+      font-size: 0.92rem;
+    }
+    label { display: block; margin-bottom: 0.45rem; font-weight: 650; }
+    input {
+      box-sizing: border-box;
+      width: 100%;
+      padding: 0.72rem 0.8rem;
+      border-radius: 10px;
+      border: 1px solid rgba(255,255,255,0.16);
+      background: #0d1117;
+      color: inherit;
+      font: inherit;
+    }
+    button {
+      width: 100%;
+      margin-top: 0.9rem;
+      padding: 0.72rem 0.8rem;
+      border: 0;
+      border-radius: 10px;
+      background: #238636;
+      color: white;
+      font: inherit;
+      font-weight: 750;
+      cursor: pointer;
+    }
+    button:hover { background: #2ea043; }
+    code { color: #a5d6ff; }
+    @media (prefers-color-scheme: light) {
+      body { background: #f6f8fa; color: #24292f; }
+      main { background: #fff; border-color: rgba(27,31,36,0.15); box-shadow: 0 20px 60px rgba(27,31,36,0.12); }
+      p { color: #57606a; }
+      input { background: #fff; border-color: rgba(27,31,36,0.18); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>term-llm Hub</h1>
+    <p>Enter your hub magic key to continue. I’ll store it in an HTTP-only cookie on this host.</p>
+    {{if .Invalid}}<div class="error">That magic key was not accepted.</div>{{end}}
+    <form method="get" action="{{.Action}}">
+      <label for="token">Magic key</label>
+      <input id="token" name="token" type="password" autocomplete="current-password" autofocus required>
+      <button type="submit">Unlock Hub</button>
+    </form>
+  </main>
+</body>
+</html>`))
+
+func writeHubLoginPage(w http.ResponseWriter, r *http.Request, invalid bool) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusUnauthorized)
+	action := r.URL.EscapedPath()
+	if action == "" {
+		action = "/"
+	}
+	if err := hubLoginTemplate.Execute(w, struct {
+		Action  string
+		Invalid bool
+	}{Action: action, Invalid: invalid}); err != nil {
+		return
+	}
 }
 
 func bearerTokenFromHeader(r *http.Request) string {

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -102,6 +102,74 @@ func TestHubAuthQueryTokenSetsCookie(t *testing.T) {
 	}
 }
 
+func TestHubAuthBrowserNavigationShowsLoginPage(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	s.requireAuth = true
+	s.token = "hub-secret"
+	h := s.handler()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "text/html")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("browser login status = %d, want 401", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"term-llm Hub", "Magic key", `name="token"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("login page missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "invalid hub authentication credentials") || strings.Contains(body, "invalid_api_key") {
+		t.Fatalf("login page should not show API JSON error: %s", body)
+	}
+}
+
+func TestHubAuthInvalidBrowserTokenShowsLoginError(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	s.requireAuth = true
+	s.token = "hub-secret"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/?token=wrong", nil)
+	req.Header.Set("Sec-Fetch-Mode", "navigate")
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid browser token status = %d, want 401", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "not accepted") || !strings.Contains(body, "Magic key") {
+		t.Fatalf("invalid token login body = %q", body)
+	}
+}
+
+func TestHubAuthAPIStillReturnsJSONError(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	s.requireAuth = true
+	s.token = "hub-secret"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/nodes", nil)
+	req.Header.Set("Accept", "text/html")
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("API status = %d, want 401", rec.Code)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Fatalf("API content-type = %q, want JSON", ct)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "invalid_api_key") || strings.Contains(body, "Magic key") {
+		t.Fatalf("API body = %q", body)
+	}
+}
+
 func TestHubAuthSkipsReverseConnectNodeAuth(t *testing.T) {
 	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {})
 	s.requireAuth = true


### PR DESCRIPTION
## What

Adds a browser-friendly Hub auth page for unauthenticated dashboard/proxy navigation.

- Browser-ish GET/HEAD requests outside `/api/` now receive a small HTML "magic key" form instead of raw OpenAI-style JSON.
- Submitting the form uses the existing `?token=...` flow from #842, which sets the HTTP-only hub auth cookie and redirects back to the requested path.
- Invalid browser-submitted keys render the same form with a clear error.
- API paths continue returning the existing JSON `invalid_api_key` response.

## Why

Opening `http://10.0.0.52:12654/` in a browser currently shows:

```json
{"error":{"message":"invalid hub authentication credentials","type":"invalid_api_key"}}
```

That is fine for API clients and miserable for humans. The Hub dashboard should ask for the magic key.

## Tests

- `go test ./cmd -run 'TestHubAuth'`
- `go test ./...`
