### PR TITLE
fix: call hub auth credential a token

### DIFF
--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -183,12 +183,12 @@ var hubLoginTemplate = template.Must(template.New("hub-login").Parse(`<!doctype 
 <body>
   <main>
     <h1>term-llm Hub</h1>
-    <p>Enter your hub magic key to continue. I’ll store it in an HTTP-only cookie on this host.</p>
-    {{if .Invalid}}<div class="error">That magic key was not accepted.</div>{{end}}
+    <p>Enter your hub access token to continue. I’ll store it in an HTTP-only cookie on this host.</p>
+    {{if .Invalid}}<div class="error">That hub token was not accepted.</div>{{end}}
     <form method="get" action="{{.Action}}">
-      <label for="token">Magic key</label>
+      <label for="token">Hub token</label>
       <input id="token" name="token" type="password" autocomplete="current-password" autofocus required>
-      <button type="submit">Unlock Hub</button>
+      <button type="submit">Connect to Hub</button>
     </form>
   </main>
 </body>

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -118,7 +118,7 @@ func TestHubAuthBrowserNavigationShowsLoginPage(t *testing.T) {
 		t.Fatalf("browser login status = %d, want 401", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"term-llm Hub", "Magic key", `name="token"`} {
+	for _, want := range []string{"term-llm Hub", "Hub token", `name="token"`} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("login page missing %q: %s", want, body)
 		}
@@ -142,7 +142,7 @@ func TestHubAuthInvalidBrowserTokenShowsLoginError(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("invalid browser token status = %d, want 401", rec.Code)
 	}
-	if body := rec.Body.String(); !strings.Contains(body, "not accepted") || !strings.Contains(body, "Magic key") {
+	if body := rec.Body.String(); !strings.Contains(body, "not accepted") || !strings.Contains(body, "Hub token") {
 		t.Fatalf("invalid token login body = %q", body)
 	}
 }
@@ -165,7 +165,7 @@ func TestHubAuthAPIStillReturnsJSONError(t *testing.T) {
 	if !strings.Contains(ct, "application/json") {
 		t.Fatalf("API content-type = %q, want JSON", ct)
 	}
-	if body := rec.Body.String(); !strings.Contains(body, "invalid_api_key") || strings.Contains(body, "Magic key") {
+	if body := rec.Body.String(); !strings.Contains(body, "invalid_api_key") || strings.Contains(body, "Hub token") {
 		t.Fatalf("API body = %q", body)
 	}
 }


### PR DESCRIPTION
## What

Follow-up to #843: rename the Hub login credential from "magic key" to "Hub token" / "hub access token".

Changes:

- Login copy: "Enter your hub access token..."
- Field label: "Hub token"
- Invalid message: "That hub token was not accepted."
- Button: "Connect to Hub"
- Tests updated to assert the precise wording

## Why

The credential is the Hub token (`TERM_LLM_HUB_TOKEN` / hub `--token`). Calling it a "magic key" is cute but confusing.

## Tests

- `go test ./cmd -run 'TestHubAuth'`
