### PR TITLE
fix: polish hub tab title and favicon

### DIFF
--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -116,7 +116,8 @@ var hubLoginTemplate = template.Must(template.New("hub-login").Parse(`<!doctype 
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>term-llm Hub</title>
+  <title>Hub - term-llm</title>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230d1117'/%3E%3Cg fill='none' stroke='%23e6edf3' stroke-width='5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='32' cy='32' r='8'/%3E%3Ccircle cx='14' cy='16' r='5'/%3E%3Ccircle cx='50' cy='16' r='5'/%3E%3Ccircle cx='14' cy='48' r='5'/%3E%3Ccircle cx='50' cy='48' r='5'/%3E%3Cpath d='M18 20 27 29M46 20 37 29M18 44 27 35M46 44 37 35'/%3E%3C/g%3E%3C/svg%3E">
   <style>
     :root { color-scheme: dark light; }
     body {

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -118,7 +118,7 @@ func TestHubAuthBrowserNavigationShowsLoginPage(t *testing.T) {
 		t.Fatalf("browser login status = %d, want 401", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"term-llm Hub", "Hub token", `name="token"`} {
+	for _, want := range []string{"Hub - term-llm", `rel="icon"`, "data:image/svg+xml", "term-llm Hub", "Hub token", `name="token"`} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("login page missing %q: %s", want, body)
 		}
@@ -574,6 +574,11 @@ func TestHubIndexBranding(t *testing.T) {
 		t.Fatalf("status = %d", rec.Code)
 	}
 	body := rec.Body.String()
+	for _, want := range []string{"Hub - term-llm", `rel="icon"`, "data:image/svg+xml"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dashboard missing %q", want)
+		}
+	}
 	if !strings.Contains(body, "term-llm Hub") && !strings.Contains(body, `term-llm <span class="hub-brand-accent">Hub</span>`) {
 		t.Error("dashboard missing term-llm Hub branding")
 	}

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="dark light">
-  <title>term-llm Hub</title>
+  <title>Hub - term-llm</title>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230d1117'/%3E%3Cg fill='none' stroke='%23e6edf3' stroke-width='5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='32' cy='32' r='8'/%3E%3Ccircle cx='14' cy='16' r='5'/%3E%3Ccircle cx='50' cy='16' r='5'/%3E%3Ccircle cx='14' cy='48' r='5'/%3E%3Ccircle cx='50' cy='48' r='5'/%3E%3Cpath d='M18 20 27 29M46 20 37 29M18 44 27 35M46 44 37 35'/%3E%3C/g%3E%3C/svg%3E">
   <style>{{.CSS}}</style>
 </head>
 <body>


### PR DESCRIPTION
## What

Polishes the Hub browser tab metadata.

- Changes the Hub dashboard and login page title to `Hub - term-llm`
- Adds an inline SVG favicon using the Hub network glyph
- Covers both authenticated dashboard and unauthenticated login page in tests

## Why

The Hub should have a recognizable browser tab, and `Hub - term-llm` reads better than `term-llm Hub` there.

## Tests

- `go test ./cmd -run 'TestHub(AuthBrowserNavigationShowsLoginPage|IndexBranding)'`
- `go test ./...`
