### PR TITLE
feat: register reverse hub nodes with token

### DIFF
--- a/cmd/reload_exec.go
+++ b/cmd/reload_exec.go
@@ -48,8 +48,10 @@ func execReload(sessionID string) error {
 	}
 
 	// Re-exec'ing the SAME binary: hand back any env-provided hub delegation
-	// token that startup scrubbed from the environment, or the next
-	// generation would silently lose hub access. This env goes only to
+	// and registration tokens that startup scrubbed from the environment, or the
+	// next generation would silently lose hub access. This env goes only to
 	// ourselves, never to tool subprocesses.
-	return syscall.Exec(exe, newArgs, append(os.Environ(), tools.HubDelegationEnviron()...))
+	reloadEnv := append(os.Environ(), tools.HubDelegationEnviron()...)
+	reloadEnv = append(reloadEnv, hubRegistrationEnviron()...)
+	return syscall.Exec(exe, newArgs, reloadEnv)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -69,6 +69,8 @@ var (
 	serveHubNodeID              string
 	serveHubNodeName            string
 	serveHubConnect             string
+	serveHubRegister            bool
+	serveHubRegistrationToken   string
 )
 
 var serveCmd = &cobra.Command{
@@ -151,6 +153,8 @@ func init() {
 	serveCmd.Flags().StringVar(&serveHubNodeID, "hub-node-id", "", "This node's id on the hub (used with --hub-url)")
 	serveCmd.Flags().StringVar(&serveHubNodeName, "hub-node-name", "", "This node's display name on the hub (used with --hub-url)")
 	serveCmd.Flags().StringVar(&serveHubConnect, "hub-connect", "direct", "Hub connection mode for this node: direct or reverse")
+	serveCmd.Flags().BoolVar(&serveHubRegister, "hub-register", false, "Register this reverse node with the Hub before connecting")
+	serveCmd.Flags().StringVar(&serveHubRegistrationToken, "hub-registration-token", "", "Hub registration token for --hub-register (defaults to $TERM_LLM_HUB_REGISTRATION_TOKEN)")
 
 	AddCommonFlags(serveCmd,
 		CommonCoreFlags|CommonSearch|CommonNativeSearch|CommonMaxTurns|CommonAgent,
@@ -241,6 +245,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	if serveHubConnect != "direct" && serveHubConnect != "reverse" {
 		return fmt.Errorf("invalid --hub-connect %q (use direct or reverse)", serveHubConnect)
+	}
+	hubRegistrationToken := ""
+	if serveHubRegister {
+		hubRegistrationToken = resolveServeHubRegistrationToken(serveHubRegistrationToken)
 	}
 
 	// Hub-joined nodes: hand the hub context to in-process tools and jobs-v2
@@ -609,19 +617,44 @@ func runServe(cmd *cobra.Command, args []string) error {
 			runWebRTCPeer(ctx, s)
 		}
 
+		reverseHubURL := strings.TrimSpace(serveHubURL)
+		reverseHubNodeID := strings.TrimSpace(serveHubNodeID)
+		if serveHubRegister {
+			if serveHubConnect != "reverse" {
+				return fmt.Errorf("--hub-register requires --hub-connect reverse")
+			}
+			if reverseHubURL == "" || reverseHubNodeID == "" || token == "" || hubRegistrationToken == "" {
+				return fmt.Errorf("--hub-register requires --hub-url, --hub-node-id, --hub-registration-token, and a bearer --token")
+			}
+		}
+		if serveHubConnect == "reverse" && (reverseHubURL == "" || reverseHubNodeID == "" || token == "") {
+			return fmt.Errorf("--hub-connect reverse requires --hub-url, --hub-node-id, and a bearer --token")
+		}
+
 		if err := s.Start(); err != nil {
 			return err
 		}
 
-		if serveHubConnect == "reverse" {
-			hubURL := strings.TrimSpace(serveHubURL)
-			hubNodeID := strings.TrimSpace(serveHubNodeID)
-			if hubURL == "" || hubNodeID == "" || token == "" {
-				return fmt.Errorf("--hub-connect reverse requires --hub-url, --hub-node-id, and a bearer --token")
+		if serveHubRegister {
+			if err := registerServeHubNode(ctx, nil, reverseHubURL, hubRegistrationToken, hubRegisterNodeRequest{
+				ID:         reverseHubNodeID,
+				Name:       strings.TrimSpace(serveHubNodeName),
+				Connection: "reverse",
+				BasePath:   serveBasePath,
+				Token:      token,
+			}); err != nil {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				_ = s.Stop(shutdownCtx)
+				cancel()
+				return err
 			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "hub registration: registered %s with %s\n", reverseHubNodeID, reverseHubURL)
+		}
+
+		if serveHubConnect == "reverse" {
 			localBase := localHubConnectBase(serveHost, servePort)
-			go runHubReverseConnector(ctx, hubURL, hubNodeID, token, localBase, serveBasePath, newHubReverseLocalClient())
-			fmt.Fprintf(cmd.ErrOrStderr(), "hub reverse: connecting %s to %s\n", hubNodeID, hubURL)
+			go runHubReverseConnector(ctx, reverseHubURL, reverseHubNodeID, token, localBase, serveBasePath, newHubReverseLocalClient())
+			fmt.Fprintf(cmd.ErrOrStderr(), "hub reverse: connecting %s to %s\n", reverseHubNodeID, reverseHubURL)
 		}
 
 		fmt.Fprintf(cmd.ErrOrStderr(), "term-llm serve listening on http://%s:%d\n", serveHost, servePort)

--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -44,8 +44,9 @@ type hubServer struct {
 	// timeout.
 	nodeAPIClient *http.Client
 
-	requireAuth bool
-	token       string
+	requireAuth       bool
+	token             string
+	registrationToken string
 }
 
 func newHubServer(registry *hub.Registry, store *hub.Store) *hubServer {

--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -16,6 +16,7 @@ func (s *hubServer) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHubHealth)
 	mux.HandleFunc("/api/nodes/test", s.handleTestNode)
+	mux.HandleFunc("/api/register-node", s.handleRegisterNode)
 	mux.HandleFunc("/api/nodes/", s.handleNodeItem)
 	mux.HandleFunc("/api/nodes", s.handleNodes)
 	mux.HandleFunc("/api/delegations/", s.handleDelegationItem)
@@ -31,7 +32,7 @@ func (s *hubServer) auth(next http.Handler) http.Handler {
 		return next
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodOptions || r.URL.Path == "/healthz" || hubNodeAuthRoute(r) {
+		if r.Method == http.MethodOptions || r.URL.Path == "/healthz" || hubNodeAuthRoute(r) || hubRegistrationRoute(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/serve_hub_cmd.go
+++ b/cmd/serve_hub_cmd.go
@@ -15,13 +15,14 @@ import (
 )
 
 var (
-	serveHubHost      string
-	serveHubPort      int
-	serveHubConfig    string
-	serveHubContain   bool
-	serveHubNodesFile string
-	serveHubAuthMode  string
-	serveHubToken     string
+	serveHubHost                  string
+	serveHubPort                  int
+	serveHubConfig                string
+	serveHubContain               bool
+	serveHubNodesFile             string
+	serveHubAuthMode              string
+	serveHubToken                 string
+	serveHubRegistrationTokenFlag string
 )
 
 var serveHubCmd = &cobra.Command{
@@ -43,6 +44,7 @@ Routes:
   POST /api/nodes         add a node to the local store
   DELETE /api/nodes/<id>  remove a local-store node
   POST /api/nodes/test    probe a node spec without persisting it
+  POST /api/register-node register/update a reverse node (registration token)
   GET  /api/connect      reverse-node websocket endpoint (node auth)
   ANY  /node/<id>/...     reverse proxy to that node's serve
   POST /api/delegations   create a cross-node delegation (node auth)
@@ -122,6 +124,10 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	s := newHubServer(hub.NewRegistry(resolvers...), store)
 	s.requireAuth = requireAuth
 	s.token = token
+	s.registrationToken = strings.TrimSpace(serveHubRegistrationTokenFlag)
+	if s.registrationToken == "" {
+		s.registrationToken = strings.TrimSpace(os.Getenv(hubRegistrationTokenEnv))
+	}
 	// The delegation ledger lives beside the node store (same private dir).
 	s.delegations = hub.NewDelegationStore(filepath.Join(filepath.Dir(nodesFile), "delegations.json"))
 	addr := net.JoinHostPort(serveHubHost, strconv.Itoa(serveHubPort))
@@ -145,6 +151,9 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Fprintln(out, "WARNING: hub auth disabled; bind to loopback only.")
 	}
+	if s.registrationToken != "" {
+		fmt.Fprintln(out, "  registration: enabled")
+	}
 	return srv.ListenAndServe()
 }
 
@@ -157,4 +166,5 @@ func init() {
 	serveHubCmd.Flags().StringVar(&serveHubNodesFile, "nodes-file", "", "Path to the JSON store for dashboard-added nodes (default: <data-dir>/hub/nodes.json)")
 	serveHubCmd.Flags().StringVar(&serveHubAuthMode, "auth", "bearer", "Hub auth mode: bearer or none (none is loopback-only)")
 	serveHubCmd.Flags().StringVar(&serveHubToken, "token", "", "Hub bearer token (defaults to $TERM_LLM_HUB_TOKEN, else auto-generated)")
+	serveHubCmd.Flags().StringVar(&serveHubRegistrationTokenFlag, "registration-token", "", "Token that allows reverse nodes to self-register (defaults to $TERM_LLM_HUB_REGISTRATION_TOKEN; empty disables registration)")
 }

--- a/cmd/serve_hub_cmd.go
+++ b/cmd/serve_hub_cmd.go
@@ -124,10 +124,7 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	s := newHubServer(hub.NewRegistry(resolvers...), store)
 	s.requireAuth = requireAuth
 	s.token = token
-	s.registrationToken = strings.TrimSpace(serveHubRegistrationTokenFlag)
-	if s.registrationToken == "" {
-		s.registrationToken = strings.TrimSpace(os.Getenv(hubRegistrationTokenEnv))
-	}
+	s.registrationToken = resolveServeHubRegistrationToken(serveHubRegistrationTokenFlag)
 	// The delegation ledger lives beside the node store (same private dir).
 	s.delegations = hub.NewDelegationStore(filepath.Join(filepath.Dir(nodesFile), "delegations.json"))
 	addr := net.JoinHostPort(serveHubHost, strconv.Itoa(serveHubPort))

--- a/cmd/serve_hub_registration.go
+++ b/cmd/serve_hub_registration.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/hub"
+)
+
+const hubRegistrationTokenEnv = "TERM_LLM_HUB_REGISTRATION_TOKEN"
+
+type hubRegisterNodeRequest struct {
+	ID         string `json:"id"`
+	Name       string `json:"name,omitempty"`
+	Connection string `json:"connection,omitempty"`
+	BasePath   string `json:"base_path"`
+	Token      string `json:"token"`
+}
+
+func hubRegistrationRoute(r *http.Request) bool {
+	return r.URL.Path == "/api/register-node"
+}
+
+func hubRegistrationBearerTokenMatches(r *http.Request, want string) bool {
+	return hubTokenMatches(strings.TrimSpace(want), bearerTokenFromHeader(r))
+}
+
+func (s *hubServer) handleRegisterNode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if strings.TrimSpace(s.registrationToken) == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if !hubRegistrationBearerTokenMatches(r, s.registrationToken) {
+		writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "invalid hub registration token")
+		return
+	}
+	if s.store == nil {
+		http.Error(w, "node persistence is disabled", http.StatusForbidden)
+		return
+	}
+
+	var req hubRegisterNodeRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Token) == "" {
+		http.Error(w, "node token is required", http.StatusBadRequest)
+		return
+	}
+	connection := strings.ToLower(strings.TrimSpace(req.Connection))
+	if connection == "" {
+		connection = "reverse"
+	}
+	if connection != "reverse" {
+		http.Error(w, "registration currently supports reverse nodes only", http.StatusBadRequest)
+		return
+	}
+
+	node := hub.Node{
+		ID:         strings.TrimSpace(req.ID),
+		Name:       strings.TrimSpace(req.Name),
+		Connection: "reverse",
+		BasePath:   strings.TrimSpace(req.BasePath),
+		Token:      strings.TrimSpace(req.Token),
+	}
+	if err := node.Normalize(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if existing, ok := s.registry.Lookup(node.ID); ok && existing.Source != hub.SourceLocal {
+		http.Error(w, fmt.Sprintf("node id %q is owned by %s and cannot be replaced by registration", node.ID, existing.Source), http.StatusConflict)
+		return
+	}
+
+	stored, created, err := s.store.Upsert(node)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	log.Printf("hub registration: %s reverse node %q", map[bool]string{true: "created", false: "updated"}[created], stored.ID)
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, map[string]any{
+		"node": hubNodeView{
+			ID:         stored.ID,
+			Name:       stored.Name,
+			Source:     stored.Source,
+			Connection: stored.Connection,
+			BasePath:   stored.BasePath,
+			ProxyPath:  "/node/" + stored.ID + "/",
+			HasToken:   stored.Token != "",
+		},
+		"created": created,
+	})
+}
+
+func resolveServeHubRegistrationToken(flagValue string) string {
+	envValue := strings.TrimSpace(os.Getenv(hubRegistrationTokenEnv))
+	if envValue != "" {
+		_ = os.Unsetenv(hubRegistrationTokenEnv)
+	}
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v
+	}
+	return envValue
+}
+
+func registerServeHubNode(ctx context.Context, client *http.Client, hubURL, registrationToken string, req hubRegisterNodeRequest) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	u, err := url.Parse(strings.TrimRight(strings.TrimSpace(hubURL), "/") + "/api/register-node")
+	if err != nil {
+		return fmt.Errorf("parse hub url: %w", err)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("encode registration request: %w", err)
+	}
+	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(callCtx, http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+strings.TrimSpace(registrationToken))
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg := strings.TrimSpace(string(data))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return fmt.Errorf("hub registration failed: HTTP %d: %s", resp.StatusCode, msg)
+	}
+	return nil
+}

--- a/cmd/serve_hub_registration.go
+++ b/cmd/serve_hub_registration.go
@@ -11,12 +11,35 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/hub"
 )
 
 const hubRegistrationTokenEnv = "TERM_LLM_HUB_REGISTRATION_TOKEN"
+
+var hubRegistrationCfg struct {
+	sync.Mutex
+	token        string
+	tokenFromEnv bool
+}
+
+func init() { captureHubRegistrationEnv() }
+
+func captureHubRegistrationEnv() {
+	v := strings.TrimSpace(os.Getenv(hubRegistrationTokenEnv))
+	if v == "" {
+		return
+	}
+	hubRegistrationCfg.Lock()
+	if hubRegistrationCfg.token == "" {
+		hubRegistrationCfg.token = v
+		hubRegistrationCfg.tokenFromEnv = true
+	}
+	hubRegistrationCfg.Unlock()
+	_ = os.Unsetenv(hubRegistrationTokenEnv)
+}
 
 type hubRegisterNodeRequest struct {
 	ID         string `json:"id"`
@@ -112,14 +135,34 @@ func (s *hubServer) handleRegisterNode(w http.ResponseWriter, r *http.Request) {
 }
 
 func resolveServeHubRegistrationToken(flagValue string) string {
-	envValue := strings.TrimSpace(os.Getenv(hubRegistrationTokenEnv))
-	if envValue != "" {
-		_ = os.Unsetenv(hubRegistrationTokenEnv)
-	}
+	captureHubRegistrationEnv()
 	if v := strings.TrimSpace(flagValue); v != "" {
 		return v
 	}
-	return envValue
+	hubRegistrationCfg.Lock()
+	defer hubRegistrationCfg.Unlock()
+	return hubRegistrationCfg.token
+}
+
+func hubRegistrationEnviron() []string {
+	hubRegistrationCfg.Lock()
+	defer hubRegistrationCfg.Unlock()
+	if !hubRegistrationCfg.tokenFromEnv || hubRegistrationCfg.token == "" {
+		return nil
+	}
+	return []string{hubRegistrationTokenEnv + "=" + hubRegistrationCfg.token}
+}
+
+func resetHubRegistrationForTest() func() {
+	hubRegistrationCfg.Lock()
+	prevToken, prevFromEnv := hubRegistrationCfg.token, hubRegistrationCfg.tokenFromEnv
+	hubRegistrationCfg.token, hubRegistrationCfg.tokenFromEnv = "", false
+	hubRegistrationCfg.Unlock()
+	return func() {
+		hubRegistrationCfg.Lock()
+		hubRegistrationCfg.token, hubRegistrationCfg.tokenFromEnv = prevToken, prevFromEnv
+		hubRegistrationCfg.Unlock()
+	}
 }
 
 func registerServeHubNode(ctx context.Context, client *http.Client, hubURL, registrationToken string, req hubRegisterNodeRequest) error {

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -167,6 +168,140 @@ func TestHubAuthAPIStillReturnsJSONError(t *testing.T) {
 	}
 	if body := rec.Body.String(); !strings.Contains(body, "invalid_api_key") || strings.Contains(body, "Hub token") {
 		t.Fatalf("API body = %q", body)
+	}
+}
+
+func TestHubRegisterNodeCreatesUpdatesAndAuthenticatesReverseNode(t *testing.T) {
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s := newHubServer(hub.NewRegistry(store), store)
+	s.registrationToken = "reg-secret"
+	h := s.handler()
+
+	payload := `{"id":"docker-a","name":"Docker A","connection":"reverse","base_path":"/chat","token":"node-token-1"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/register-node", strings.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer reg-secret")
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "node-token-1") || !strings.Contains(body, `"created":true`) || !strings.Contains(body, `"has_token":true`) {
+		t.Fatalf("register response leaked/missed fields: %s", body)
+	}
+
+	authReq := httptest.NewRequest(http.MethodGet, "/api/connect?node_id=docker-a", nil)
+	authReq.Header.Set(hubNodeIDHeader, "docker-a")
+	authReq.Header.Set("Authorization", "Bearer node-token-1")
+	if node, err := s.authenticateNode(authReq); err != nil || node.ID != "docker-a" {
+		t.Fatalf("registered node did not authenticate: node=%+v err=%v", node, err)
+	}
+
+	payload = `{"id":"docker-a","name":"Docker A2","connection":"reverse","base_path":"/chat","token":"node-token-2"}`
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/register-node", strings.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer reg-secret")
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "node-token-2") || !strings.Contains(rec.Body.String(), `"created":false`) {
+		t.Fatalf("update response = %s", rec.Body.String())
+	}
+
+	authReq = httptest.NewRequest(http.MethodGet, "/api/connect?node_id=docker-a", nil)
+	authReq.Header.Set(hubNodeIDHeader, "docker-a")
+	authReq.Header.Set("Authorization", "Bearer node-token-2")
+	if node, err := s.authenticateNode(authReq); err != nil || node.Name != "Docker A2" {
+		t.Fatalf("updated node did not authenticate: node=%+v err=%v", node, err)
+	}
+}
+
+func TestHubRegisterNodeAuthDisabledAndConflict(t *testing.T) {
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{{
+		ID:         "static-a",
+		Name:       "Static A",
+		Connection: "reverse",
+		BasePath:   "/chat",
+		Token:      "static-token",
+		Source:     hub.SourceConfig,
+	}}}, store), store)
+	h := s.handler()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/register-node", strings.NewReader(`{"id":"docker-a","base_path":"/chat","token":"node-token"}`))
+	req.Header.Set("Authorization", "Bearer reg-secret")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("disabled registration status = %d, want 404", rec.Code)
+	}
+
+	s.registrationToken = "reg-secret"
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/register-node", strings.NewReader(`{"id":"docker-a","base_path":"/chat","token":"node-token"}`))
+	req.Header.Set("Authorization", "Bearer wrong")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token status = %d, want 401", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/register-node", strings.NewReader(`{"id":"static-a","base_path":"/chat","token":"node-token"}`))
+	req.Header.Set("Authorization", "Bearer reg-secret")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("static conflict status = %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHubRegisterServeNodeClient(t *testing.T) {
+	var gotAuth string
+	var got hubRegisterNodeRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/register-node" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected registration request %s %s", r.Method, r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"node": map[string]any{"id": got.ID, "has_token": true}, "created": true})
+	}))
+	defer ts.Close()
+
+	err := registerServeHubNode(t.Context(), ts.Client(), ts.URL, "reg-secret", hubRegisterNodeRequest{
+		ID:         "docker-a",
+		Name:       "Docker A",
+		Connection: "reverse",
+		BasePath:   "/chat",
+		Token:      "node-token",
+	})
+	if err != nil {
+		t.Fatalf("registerServeHubNode: %v", err)
+	}
+	if gotAuth != "Bearer reg-secret" || got.ID != "docker-a" || got.Token != "node-token" || got.Connection != "reverse" {
+		t.Fatalf("request auth=%q body=%+v", gotAuth, got)
+	}
+}
+
+func TestResolveServeHubRegistrationTokenScrubsEnv(t *testing.T) {
+	t.Setenv(hubRegistrationTokenEnv, "env-reg")
+	if got := resolveServeHubRegistrationToken(""); got != "env-reg" {
+		t.Fatalf("env token = %q, want env-reg", got)
+	}
+	if got := os.Getenv(hubRegistrationTokenEnv); got != "" {
+		t.Fatalf("registration token env leaked: %q", got)
+	}
+
+	t.Setenv(hubRegistrationTokenEnv, "env-reg")
+	if got := resolveServeHubRegistrationToken("flag-reg"); got != "flag-reg" {
+		t.Fatalf("flag token = %q, want flag-reg", got)
+	}
+	if got := os.Getenv(hubRegistrationTokenEnv); got != "" {
+		t.Fatalf("registration token env leaked after flag override: %q", got)
 	}
 }
 

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -288,12 +288,18 @@ func TestHubRegisterServeNodeClient(t *testing.T) {
 }
 
 func TestResolveServeHubRegistrationTokenScrubsEnv(t *testing.T) {
+	defer resetHubRegistrationForTest()()
+	captureHubRegistrationEnv()
+
 	t.Setenv(hubRegistrationTokenEnv, "env-reg")
 	if got := resolveServeHubRegistrationToken(""); got != "env-reg" {
 		t.Fatalf("env token = %q, want env-reg", got)
 	}
 	if got := os.Getenv(hubRegistrationTokenEnv); got != "" {
 		t.Fatalf("registration token env leaked: %q", got)
+	}
+	if env := hubRegistrationEnviron(); len(env) != 1 || env[0] != hubRegistrationTokenEnv+"=env-reg" {
+		t.Fatalf("reload env = %#v, want captured registration token", env)
 	}
 
 	t.Setenv(hubRegistrationTokenEnv, "env-reg")

--- a/internal/hub/node.go
+++ b/internal/hub/node.go
@@ -6,8 +6,9 @@
 // contain workspaces, the local UI-added store) feed a Registry, which is the
 // single lookup surface the hub server routes and proxies from.
 //
-// TODO(hub): node self-registration, scheduling, and mTLS between hub and
-// nodes are deliberately out of scope for v1; see docs-site guide "Hub".
+// Reverse nodes may self-register with the hub when the hub operator enables a
+// registration token; scheduling and mTLS between hub and nodes remain out of
+// scope for v1. See docs-site guide "Hub".
 package hub
 
 import (

--- a/internal/hub/store.go
+++ b/internal/hub/store.go
@@ -105,6 +105,36 @@ func (s *Store) Add(n Node) (Node, error) {
 	return n, nil
 }
 
+// Upsert normalizes and creates or replaces a stored node by ID. It only
+// affects the local store; callers that combine the store with higher-priority
+// resolvers should reject shadowed IDs before calling Upsert when that matters.
+func (s *Store) Upsert(n Node) (Node, bool, error) {
+	n.Source = SourceLocal
+	if err := n.Normalize(); err != nil {
+		return Node{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	nodes, err := s.readLocked()
+	if err != nil {
+		return Node{}, false, err
+	}
+	for i, existing := range nodes {
+		if existing.ID == n.ID {
+			nodes[i] = n
+			if err := s.writeLocked(nodes); err != nil {
+				return Node{}, false, err
+			}
+			return n, false, nil
+		}
+	}
+	nodes = append(nodes, n)
+	if err := s.writeLocked(nodes); err != nil {
+		return Node{}, false, err
+	}
+	return n, true, nil
+}
+
 // Remove deletes a stored node by ID. Removing an unknown ID is an error so
 // the UI can surface a stale dashboard.
 func (s *Store) Remove(id string) error {

--- a/internal/hub/store_test.go
+++ b/internal/hub/store_test.go
@@ -78,6 +78,35 @@ func TestStoreAddListRemove(t *testing.T) {
 	}
 }
 
+func TestStoreUpsertCreatesAndReplaces(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub", "nodes.json")
+	s := NewStore(path)
+
+	created, isNew, err := s.Upsert(Node{ID: "docker-a", Name: "Docker A", Connection: "reverse", BasePath: "/chat", Token: "one"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isNew || created.ID != "docker-a" || created.Source != SourceLocal {
+		t.Fatalf("created = %+v isNew=%v", created, isNew)
+	}
+
+	updated, isNew, err := s.Upsert(Node{ID: "docker-a", Name: "Docker A2", Connection: "reverse", BasePath: "/chat", Token: "two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isNew || updated.Name != "Docker A2" || updated.Token != "two" {
+		t.Fatalf("updated = %+v isNew=%v", updated, isNew)
+	}
+
+	nodes, err := NewStore(path).Nodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != "docker-a" || nodes[0].Token != "two" {
+		t.Fatalf("persisted nodes = %+v", nodes)
+	}
+}
+
 func TestStoreRejectsInvalidNode(t *testing.T) {
 	s := NewStore(filepath.Join(t.TempDir(), "nodes.json"))
 	if _, err := s.Add(Node{Name: "x", URL: "not-a-url"}); err == nil {


### PR DESCRIPTION
## What

Adds a minimal registration-token flow for reverse Hub nodes.

Hub side:

- `term-llm serve hub --registration-token <token>`
- or `TERM_LLM_HUB_REGISTRATION_TOKEN=<token>`
- New API: `POST /api/register-node`
- Registration creates/updates reverse nodes in the Hub's writable `nodes-file` store
- Registration is disabled when no registration token is configured
- Static/config/contain nodes cannot be overwritten by registration
- Registration responses omit node tokens

Node side:

- `term-llm serve web --hub-register --hub-registration-token <token> --hub-connect reverse ...`
- Node registers itself before opening the reverse websocket
- The env registration token is scrubbed from `os.Environ()` after capture so tool subprocesses do not inherit it

## Why

Pre-registering `node_id + node_token` in Hub config is secure but clumsy for Docker/private nodes. This adds a bootstrap credential with a narrower job:

```text
Hub token          = administer/read/proxy Hub
Registration token = enroll/update reverse nodes
Node token         = operate/authenticate one node
```

This enables a container script to start a private reverse node without hand-editing Hub config first.

## Example

Hub:

```bash
term-llm serve hub \
  --host 10.0.0.52 \
  --port 12654 \
  --auth bearer \
  --token "$HUB_TOKEN" \
  --registration-token "$HUB_REGISTRATION_TOKEN"
```

Private Docker node:

```bash
term-llm serve web \
  --agent jarvis \
  --host 127.0.0.1 \
  --port 8081 \
  --base-path /chat \
  --auth bearer \
  --token "$NODE_TOKEN" \
  --hub-url http://10.0.0.52:12654/ \
  --hub-node-id "docker-$(hostname)" \
  --hub-node-name "Docker $(hostname)" \
  --hub-connect reverse \
  --hub-register \
  --hub-registration-token "$HUB_REGISTRATION_TOKEN" \
  --yolo
```

## Safety choices

- Simple by design: no id-prefix or allow-update knobs.
- Possession of the registration token allows create/update of dynamic registered nodes.
- Existing non-local nodes are protected: registration cannot replace config/contain nodes.
- Only reverse nodes are supported for registration in this first pass.
- Node tokens are never returned in registration responses.

## Tests

- `go test ./internal/hub ./cmd -run 'Test(StoreUpsert|HubRegister|ResolveServeHubRegistrationToken|HubAuthSkipsReverseConnectNodeAuth)'`
- `go test ./...`
