### PR TITLE
fix: Reverse-hub request IDs can collide and corrupt concurrent in-flight requests

### DIFF
--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -65,14 +66,15 @@ type hubReversePending struct {
 }
 
 type hubReverseConnection struct {
-	nodeID      string
-	connectedAt time.Time
-	lastSeenMu  sync.RWMutex
-	lastSeen    time.Time
-	conn        *websocket.Conn
-	writeMu     sync.Mutex
-	pendingMu   sync.Mutex
-	pending     map[string]*hubReversePending
+	nodeID       string
+	connectedAt  time.Time
+	lastSeenMu   sync.RWMutex
+	lastSeen     time.Time
+	conn         *websocket.Conn
+	writeMu      sync.Mutex
+	pendingMu    sync.Mutex
+	pending      map[string]*hubReversePending
+	requestIDSeq atomic.Uint64
 }
 
 func newHubReversePending() *hubReversePending {
@@ -223,6 +225,10 @@ func (c *hubReverseConnection) lastSeenValue() time.Time {
 	return c.lastSeen
 }
 
+func (c *hubReverseConnection) nextRequestID() string {
+	return fmt.Sprintf("req_%d", c.requestIDSeq.Add(1))
+}
+
 func hubReverseSetHeartbeat(conn *websocket.Conn, touch func()) error {
 	if touch != nil {
 		touch()
@@ -356,7 +362,7 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 			return nil, readErr
 		}
 	}
-	id := fmt.Sprintf("req_%d", time.Now().UnixNano())
+	id := c.nextRequestID()
 	pending := newHubReversePending()
 	c.pendingMu.Lock()
 	c.pending[id] = pending

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -295,6 +295,38 @@ func TestHubReverseReadLoopSurvivesCanceledUndrainedStream(t *testing.T) {
 	}
 }
 
+func TestHubReverseConnectionNextRequestIDIsUnique(t *testing.T) {
+	var c hubReverseConnection
+
+	const goroutines = 8
+	const perGoroutine = 256
+
+	ids := make(chan string, goroutines*perGoroutine)
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				ids <- c.nextRequestID()
+			}
+		}()
+	}
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[string]struct{}, goroutines*perGoroutine)
+	for id := range ids {
+		if _, exists := seen[id]; exists {
+			t.Fatalf("duplicate reverse request ID %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+	if len(seen) != goroutines*perGoroutine {
+		t.Fatalf("unique reverse request IDs = %d, want %d", len(seen), goroutines*perGoroutine)
+	}
+}
+
 type reverseDoResult struct {
 	resp *http.Response
 	err  error


### PR DESCRIPTION
## What changed

- Replaced reverse-hub request ID generation in `cmd/serve_hub_reverse.go` from `time.Now().UnixNano()` to a per-connection atomic counter via `hubReverseConnection.nextRequestID()`.
- Added `TestHubReverseConnectionNextRequestIDIsUnique` to validate that concurrent callers on the same reverse connection do not get duplicate request IDs.

## Why this is high-value

The reverse-hub protocol routes every response frame only by request ID. Before this change, two concurrent requests on the same reverse connection could generate the same timestamp-based ID and collide in the `pending` map. That could overwrite an in-flight waiter, misroute frames, or leave a caller hanging until cancellation. Using an atomic sequence makes request IDs collision-free within a connection, which is exactly the scope the protocol needs for safe routing.

## Validation

- `gofmt -w cmd/serve_hub_reverse.go cmd/serve_hub_reverse_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
