### PR TITLE
fix: File-backed session SQLite store still uses the default unbounded connection pool

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -195,11 +195,13 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
-	if dbPath == ":memory:" {
-		// Required for raw :memory: databases: keep a single connection so
-		// schema and session data stay visible to every operation.
-		db.SetMaxOpenConns(1)
-	}
+	// Keep SQLite access on a single pooled connection. For :memory: databases
+	// this is required so schema/data stay visible everywhere; for file-backed
+	// databases it avoids the default unbounded pool opening multiple concurrent
+	// writers against one WAL file, which otherwise increases SQLITE_BUSY retries
+	// on hot persistence paths.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	// Initialize schema and run migrations.
 	// Read-only mode skips initialization because it cannot write schema changes.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -256,6 +256,20 @@ func TestNewSQLiteStoreMemoryDBUsesSingleConnection(t *testing.T) {
 	}
 }
 
+func TestNewSQLiteStoreFileDBUsesSingleConnection(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	if got := store.db.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("MaxOpenConnections = %d, want 1 for file-backed databases", got)
+	}
+}
+
 func TestSQLiteStoreListByNumberCursorReturnsCompleteSessions(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 


### PR DESCRIPTION
## What changed

- bound the session SQLite store to a single pooled connection for all databases, not just `:memory:`
- kept the existing `:memory:` behavior while also preventing file-backed stores from using `database/sql`'s default unbounded open-connection pool
- added a regression test covering file-backed stores so the pool bound stays in place

## Why this is high-value

The session store is on hot persistence paths for streamed responses, session resume, and serve/Telegram state updates. With SQLite in WAL mode, letting `database/sql` open many concurrent connections to the same file increases writer contention and pushes callers into `retryOnBusy()` loops. Serializing access through one shared pooled connection prevents that failure mode and reduces `SQLITE_BUSY` spikes without changing higher-level store behavior.

## Validation

- `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- `go test ./...`
- `go test -count=1 ./internal/session -run 'TestNewSQLiteStore(MemoryDBUsesSingleConnection|FileDBUsesSingleConnection)$' -v`
- `git diff --check`
