### PR TITLE
feat: document reverse node registration in hub UI

### DIFF
--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -16,6 +16,7 @@ func (s *hubServer) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHubHealth)
 	mux.HandleFunc("/api/nodes/test", s.handleTestNode)
+	mux.HandleFunc("/api/registration-info", s.handleRegistrationInfo)
 	mux.HandleFunc("/api/register-node", s.handleRegisterNode)
 	mux.HandleFunc("/api/nodes/", s.handleNodeItem)
 	mux.HandleFunc("/api/nodes", s.handleNodes)

--- a/cmd/serve_hub_registration.go
+++ b/cmd/serve_hub_registration.go
@@ -49,8 +49,38 @@ type hubRegisterNodeRequest struct {
 	Token      string `json:"token"`
 }
 
+type hubRegistrationInfo struct {
+	Enabled           bool   `json:"enabled"`
+	TokenConfigured   bool   `json:"token_configured"`
+	CanPersistNodes   bool   `json:"can_persist_nodes"`
+	RegistrationToken string `json:"registration_token,omitempty"`
+}
+
 func hubRegistrationRoute(r *http.Request) bool {
 	return r.URL.Path == "/api/register-node"
+}
+
+func (s *hubServer) handleRegistrationInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !hubBrowserRequestAllowed(r, false) {
+		http.Error(w, "forbidden cross-site hub request", http.StatusForbidden)
+		return
+	}
+	token := strings.TrimSpace(s.registrationToken)
+	info := hubRegistrationInfo{
+		Enabled:         token != "" && s.store != nil,
+		TokenConfigured: token != "",
+		CanPersistNodes: s.store != nil,
+	}
+	if info.Enabled {
+		info.RegistrationToken = token
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, info)
 }
 
 func hubRegistrationBearerTokenMatches(r *http.Request, want string) bool {

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -214,6 +214,14 @@ func TestHubRegistrationInfoRequiresHubAuthAndNoStores(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("cross-site status = %d, want 403", rec.Code)
 	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/registration-info", nil)
+	req.Header.Set("Authorization", "Bearer hub-secret")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed || rec.Header().Get("Allow") != "GET" {
+		t.Fatalf("method status=%d allow=%q, want 405 Allow: GET", rec.Code, rec.Header().Get("Allow"))
+	}
 }
 
 func TestHubIndexShowsRegistrationHelpWithoutEmbeddingToken(t *testing.T) {
@@ -255,6 +263,27 @@ func TestHubRegistrationInfoDisabledOmitsToken(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), "registration_token") {
 		t.Fatalf("disabled response should omit registration_token: %s", rec.Body.String())
+	}
+}
+
+func TestHubRegistrationInfoWithTokenButNoStoreOmitsToken(t *testing.T) {
+	s := newHubServer(hub.NewRegistry(), nil)
+	s.registrationToken = "reg-secret"
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/registration-info", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	var info hubRegistrationInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatalf("decode registration info: %v", err)
+	}
+	if info.Enabled || !info.TokenConfigured || info.CanPersistNodes || info.RegistrationToken != "" {
+		t.Fatalf("persistence-disabled registration info = %+v", info)
+	}
+	if strings.Contains(rec.Body.String(), "reg-secret") || strings.Contains(rec.Body.String(), "registration_token") {
+		t.Fatalf("persistence-disabled response leaked token: %s", rec.Body.String())
 	}
 }
 

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -171,6 +171,93 @@ func TestHubAuthAPIStillReturnsJSONError(t *testing.T) {
 	}
 }
 
+func TestHubRegistrationInfoRequiresHubAuthAndNoStores(t *testing.T) {
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s := newHubServer(hub.NewRegistry(store), store)
+	s.requireAuth = true
+	s.token = "hub-secret"
+	s.registrationToken = "reg-secret"
+	h := s.handler()
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/registration-info", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "reg-secret") {
+		t.Fatalf("unauthenticated response leaked registration token: %s", rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/registration-info", nil)
+	req.Header.Set("Authorization", "Bearer hub-secret")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authenticated status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", cc)
+	}
+	var info hubRegistrationInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatalf("decode registration info: %v", err)
+	}
+	if !info.Enabled || !info.TokenConfigured || !info.CanPersistNodes || info.RegistrationToken != "reg-secret" {
+		t.Fatalf("registration info = %+v", info)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/registration-info", nil)
+	req.Header.Set("Authorization", "Bearer hub-secret")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-site status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHubIndexShowsRegistrationHelpWithoutEmbeddingToken(t *testing.T) {
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s := newHubServer(hub.NewRegistry(store), store)
+	s.registrationToken = "reg-secret"
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("index status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"? Private node", "Register a private / Docker node", "api/registration-info", "Registration token", "Copy token", "Reveal"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("index missing %q", want)
+		}
+	}
+	if strings.Contains(body, "reg-secret") {
+		t.Fatalf("index embedded registration token: %s", body)
+	}
+}
+
+func TestHubRegistrationInfoDisabledOmitsToken(t *testing.T) {
+	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
+	s := newHubServer(hub.NewRegistry(store), store)
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/registration-info", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	var info hubRegistrationInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatalf("decode registration info: %v", err)
+	}
+	if info.Enabled || info.TokenConfigured || !info.CanPersistNodes || info.RegistrationToken != "" {
+		t.Fatalf("disabled registration info = %+v", info)
+	}
+	if strings.Contains(rec.Body.String(), "registration_token") {
+		t.Fatalf("disabled response should omit registration_token: %s", rec.Body.String())
+	}
+}
+
 func TestHubRegisterNodeCreatesUpdatesAndAuthenticatesReverseNode(t *testing.T) {
 	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
 	s := newHubServer(hub.NewRegistry(store), store)

--- a/cmd/templates/hub.css
+++ b/cmd/templates/hub.css
@@ -80,6 +80,7 @@ body {
 .hub-btn.ghost { background: transparent; }
 .hub-btn.danger { color: var(--down); }
 .hub-btn.danger:hover { border-color: var(--down); }
+.hub-btn.small { padding: 0.24rem 0.55rem; font-size: 0.78rem; border-radius: 7px; }
 
 .hub-main { padding: 1.4rem; max-width: 1180px; margin: 0 auto; }
 
@@ -194,12 +195,72 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 14px;
-  width: min(440px, 100%);
+  width: min(720px, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
   padding: 1.1rem 1.25rem 1.25rem;
 }
 
-.modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.8rem; }
+.modal-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 0.8rem; }
+.modal-title { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; }
 .modal-header h2 { margin: 0; font-size: 1.05rem; }
+.help-toggle { color: var(--accent); }
+
+.registration-help {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-2);
+  padding: 0.85rem;
+  margin-bottom: 0.95rem;
+  display: grid;
+  gap: 0.75rem;
+}
+.registration-help h3 { margin: 0; font-size: 0.98rem; }
+.registration-help h4 { margin: 0; font-size: 0.9rem; }
+.registration-help p { margin: 0; color: var(--muted); font-size: 0.86rem; }
+.registration-help code, .command-box { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.registration-help-head { display: flex; justify-content: space-between; gap: 1rem; }
+.registration-loading { color: var(--muted); font-size: 0.85rem; }
+.registration-enabled, .registration-disabled { display: grid; gap: 0.8rem; }
+.help-field { display: grid; gap: 0.35rem; }
+.help-label { color: var(--text); font-size: 0.82rem; font-weight: 700; }
+.copy-row { display: flex; align-items: center; gap: 0.45rem; min-width: 0; }
+.copy-row code {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  padding: 0.42rem 0.55rem;
+  font-size: 0.82rem;
+}
+.help-warning { color: var(--warn) !important; }
+.help-note { border-left: 3px solid var(--accent); padding-left: 0.7rem; }
+.help-actions { display: flex; justify-content: flex-end; }
+.command-box {
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--text);
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+.token-glossary {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.32rem 0.75rem;
+  margin: 0;
+  font-size: 0.82rem;
+}
+.token-glossary dt { color: var(--text); font-weight: 700; }
+.token-glossary dd { margin: 0; color: var(--muted); }
 
 .modal form { display: flex; flex-direction: column; gap: 0.75rem; }
 .modal label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.88rem; font-weight: 600; }

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -354,10 +354,25 @@ term-llm serve hub</code></pre>
       return `'${s}'`;
     };
     const copyText = async (text, label) => {
-      await navigator.clipboard.writeText(text);
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          if (!document.execCommand('copy')) throw new Error('clipboard copy unavailable');
+        } finally {
+          document.body.removeChild(ta);
+        }
+      }
       registrationHelpStatus.textContent = `Copied ${label}.`;
     };
-    const currentHubURL = () => new URL('/', window.location.href).href;
+    const currentHubURL = () => window.location.href.replace(/[?#].*$/, '').replace(/\/?$/, '/');
     const buildRegistrationCommand = (hubURL) => `export HUB_URL=${shellQuote(hubURL)}
 export HUB_REGISTRATION_TOKEN="<copy registration token from above>"
 export NODE_TOKEN="$(openssl rand -hex 32)"
@@ -419,6 +434,10 @@ term-llm serve web \\
     const showModal = (show) => {
       modal.classList.toggle('hidden', !show);
       status.textContent = '';
+      if (!show && registrationTokenRevealed) {
+        registrationTokenRevealed = false;
+        updateRegistrationTokenDisplay();
+      }
       if (show) nameInput.focus();
     };
     document.getElementById('addNodeBtn').addEventListener('click', () => showModal(true));

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -55,9 +55,61 @@
   <div class="modal-overlay hidden" id="addNodeModal" role="dialog" aria-modal="true" aria-labelledby="addNodeTitle">
     <div class="modal">
       <div class="modal-header">
-        <h2 id="addNodeTitle">Add node</h2>
+        <div class="modal-title">
+          <h2 id="addNodeTitle">Add node</h2>
+          <button class="hub-btn ghost help-toggle" id="registrationHelpBtn" type="button" aria-expanded="false" aria-controls="registrationHelp">? Private node</button>
+        </div>
         <button class="hub-btn ghost" id="addNodeCloseBtn" type="button" aria-label="Close">✕</button>
       </div>
+      <section class="registration-help hidden" id="registrationHelp" aria-label="Reverse registration help">
+        <div class="registration-help-head">
+          <div>
+            <h3>Register a private / Docker node</h3>
+            <p>Use this when the Hub cannot directly reach the node — for example, a Docker container, laptop, NAT’d machine, or private network service.</p>
+          </div>
+        </div>
+        <p>The node registers itself with this Hub, opens an outbound reverse connection, and appears in the node list automatically. You do not need to enter a URL here.</p>
+        <div class="registration-loading" id="registrationHelpLoading">Loading registration settings…</div>
+        <div class="registration-enabled hidden" id="registrationEnabledHelp">
+          <div class="help-field">
+            <span class="help-label">Hub URL</span>
+            <div class="copy-row">
+              <code id="registrationHubUrl"></code>
+              <button class="hub-btn ghost small" id="copyHubUrlBtn" type="button">Copy</button>
+            </div>
+          </div>
+          <div class="help-field">
+            <span class="help-label">Registration token</span>
+            <div class="copy-row">
+              <code id="registrationTokenValue">••••••••••••••••••••••••••••••••</code>
+              <button class="hub-btn ghost small" id="copyRegistrationTokenBtn" type="button">Copy token</button>
+              <button class="hub-btn ghost small" id="revealRegistrationTokenBtn" type="button">Reveal</button>
+            </div>
+            <p class="help-warning">Treat this like a deployment secret. It cannot administer the Hub, but it can add or update reverse nodes.</p>
+          </div>
+          <div class="help-field">
+            <span class="help-label">Start a reverse node</span>
+            <pre class="command-box"><code id="registrationCommand"></code></pre>
+            <div class="help-actions"><button class="hub-btn ghost small" id="copyRegistrationCommandBtn" type="button">Copy command</button></div>
+          </div>
+          <p class="help-note">For a stable container, use a stable <code>NODE_ID</code> and <code>NODE_TOKEN</code> from Docker secrets or env instead of generating them on every boot. If the same <code>NODE_ID</code> registers again, Hub updates that registered node.</p>
+          <dl class="token-glossary">
+            <dt>Hub token</dt><dd>Unlocks/administers this Hub UI.</dd>
+            <dt>Registration token</dt><dd>Allows scripts or containers to register reverse nodes.</dd>
+            <dt>Node token</dt><dd>Per-node bearer token used after registration.</dd>
+          </dl>
+        </div>
+        <div class="registration-disabled hidden" id="registrationDisabledHelp">
+          <p><strong>Reverse registration is disabled for this Hub.</strong></p>
+          <p>Start Hub with a registration token:</p>
+          <pre class="command-box"><code>term-llm serve hub \
+  --registration-token "$HUB_REGISTRATION_TOKEN"</code></pre>
+          <p>or set the environment variable:</p>
+          <pre class="command-box"><code>TERM_LLM_HUB_REGISTRATION_TOKEN="$HUB_REGISTRATION_TOKEN" \
+term-llm serve hub</code></pre>
+        </div>
+        <div class="modal-status" id="registrationHelpStatus" aria-live="polite"></div>
+      </section>
       <form id="addNodeForm">
         <label>Name
           <input id="nodeNameInput" type="text" placeholder="jarvis" autocomplete="off" required>
@@ -283,6 +335,87 @@
     const nameInput = document.getElementById('nodeNameInput');
     const urlInput = document.getElementById('nodeUrlInput');
     const tokenInput = document.getElementById('nodeTokenInput');
+    const registrationHelp = document.getElementById('registrationHelp');
+    const registrationHelpBtn = document.getElementById('registrationHelpBtn');
+    const registrationHelpLoading = document.getElementById('registrationHelpLoading');
+    const registrationEnabledHelp = document.getElementById('registrationEnabledHelp');
+    const registrationDisabledHelp = document.getElementById('registrationDisabledHelp');
+    const registrationHelpStatus = document.getElementById('registrationHelpStatus');
+    const registrationHubUrl = document.getElementById('registrationHubUrl');
+    const registrationTokenValue = document.getElementById('registrationTokenValue');
+    const revealRegistrationTokenBtn = document.getElementById('revealRegistrationTokenBtn');
+    const registrationCommand = document.getElementById('registrationCommand');
+    let registrationToken = '';
+    let registrationTokenRevealed = false;
+    let registrationInfoLoaded = false;
+
+    const shellQuote = (value) => {
+      const s = String(value).replace(/'/g, "'\\''");
+      return `'${s}'`;
+    };
+    const copyText = async (text, label) => {
+      await navigator.clipboard.writeText(text);
+      registrationHelpStatus.textContent = `Copied ${label}.`;
+    };
+    const currentHubURL = () => new URL('/', window.location.href).href;
+    const buildRegistrationCommand = (hubURL) => `export HUB_URL=${shellQuote(hubURL)}
+export HUB_REGISTRATION_TOKEN="<copy registration token from above>"
+export NODE_TOKEN="$(openssl rand -hex 32)"
+export NODE_ID="docker-$(hostname)"
+
+# Add --agent, --port, or --base-path if this node needs them.
+term-llm serve web \\
+  --token "$NODE_TOKEN" \\
+  --hub-url "$HUB_URL" \\
+  --hub-node-id "$NODE_ID" \\
+  --hub-node-name "Docker $(hostname)" \\
+  --hub-connect reverse \\
+  --hub-register \\
+  --hub-registration-token "$HUB_REGISTRATION_TOKEN"`;
+    const updateRegistrationTokenDisplay = () => {
+      if (!registrationToken) {
+        registrationTokenValue.textContent = 'Unavailable';
+        revealRegistrationTokenBtn.disabled = true;
+        return;
+      }
+      registrationTokenValue.textContent = registrationTokenRevealed ? registrationToken : '••••••••••••••••••••••••••••••••';
+      revealRegistrationTokenBtn.textContent = registrationTokenRevealed ? 'Hide' : 'Reveal';
+      revealRegistrationTokenBtn.disabled = false;
+    };
+    const loadRegistrationInfo = async () => {
+      if (registrationInfoLoaded) return;
+      registrationHelpLoading.classList.remove('hidden');
+      registrationEnabledHelp.classList.add('hidden');
+      registrationDisabledHelp.classList.add('hidden');
+      registrationHelpStatus.textContent = '';
+      const hubURL = currentHubURL();
+      registrationHubUrl.textContent = hubURL;
+      registrationCommand.textContent = buildRegistrationCommand(hubURL);
+      try {
+        const resp = await fetch('api/registration-info', { headers: { 'Accept': 'application/json' } });
+        if (!resp.ok) throw new Error(await resp.text());
+        const data = await resp.json();
+        registrationInfoLoaded = true;
+        registrationHelpLoading.classList.add('hidden');
+        if (data.enabled && data.registration_token) {
+          registrationToken = data.registration_token;
+          registrationTokenRevealed = false;
+          updateRegistrationTokenDisplay();
+          registrationEnabledHelp.classList.remove('hidden');
+        } else {
+          registrationDisabledHelp.classList.remove('hidden');
+        }
+      } catch (err) {
+        registrationHelpLoading.classList.add('hidden');
+        registrationHelpStatus.textContent = `Could not load registration settings: ${err.message}`;
+      }
+    };
+    const toggleRegistrationHelp = async () => {
+      const show = registrationHelp.classList.contains('hidden');
+      registrationHelp.classList.toggle('hidden', !show);
+      registrationHelpBtn.setAttribute('aria-expanded', show ? 'true' : 'false');
+      if (show) await loadRegistrationInfo();
+    };
     const showModal = (show) => {
       modal.classList.toggle('hidden', !show);
       status.textContent = '';
@@ -291,6 +424,20 @@
     document.getElementById('addNodeBtn').addEventListener('click', () => showModal(true));
     document.getElementById('addNodeCloseBtn').addEventListener('click', () => showModal(false));
     modal.addEventListener('click', (e) => { if (e.target === modal) showModal(false); });
+    registrationHelpBtn.addEventListener('click', () => { toggleRegistrationHelp(); });
+    revealRegistrationTokenBtn.addEventListener('click', () => {
+      registrationTokenRevealed = !registrationTokenRevealed;
+      updateRegistrationTokenDisplay();
+    });
+    document.getElementById('copyHubUrlBtn').addEventListener('click', async () => {
+      try { await copyText(registrationHubUrl.textContent, 'Hub URL'); } catch (err) { registrationHelpStatus.textContent = `Copy failed: ${err.message}`; }
+    });
+    document.getElementById('copyRegistrationTokenBtn').addEventListener('click', async () => {
+      try { await copyText(registrationToken, 'registration token'); } catch (err) { registrationHelpStatus.textContent = `Copy failed: ${err.message}`; }
+    });
+    document.getElementById('copyRegistrationCommandBtn').addEventListener('click', async () => {
+      try { await copyText(registrationCommand.textContent, 'reverse node command'); } catch (err) { registrationHelpStatus.textContent = `Copy failed: ${err.message}`; }
+    });
 
     const payload = () => ({
       name: nameInput.value.trim(),


### PR DESCRIPTION
## What

Adds reverse-registration help directly to the Hub **Add node** modal:

- adds a `? Private node` help toggle
- explains when to use reverse registration for Docker/private/NAT nodes
- shows Hub URL and a reverse-node startup command
- adds Copy/Reveal controls for the configured registration token
- shows setup instructions when reverse registration is disabled
- includes a short Hub token / registration token / node token glossary

The raw registration token is not embedded in the initial dashboard HTML. The browser fetches it from a new authenticated endpoint only when the operator opens the help panel.

## API/security

Adds:

```http
GET /api/registration-info
```

The endpoint:

- is protected by normal Hub authentication
- rejects cross-site browser fetches via the existing Hub browser-request guard
- returns `Cache-Control: no-store`
- omits `registration_token` when registration is disabled

`POST /api/register-node` remains the registration-token endpoint for nodes.

## Tests

```text
go test ./cmd -run 'TestHub(RegistrationInfo|IndexShowsRegistrationHelp|RegisterNode|Auth)'
go test ./...
go build ./...
```
