### PR TITLE
feat: make hub prefix aware

### DIFF
--- a/cmd/serve_hub.go
+++ b/cmd/serve_hub.go
@@ -47,6 +47,10 @@ type hubServer struct {
 	requireAuth       bool
 	token             string
 	registrationToken string
+	// basePath is the external mount prefix for the hub dashboard/API. Empty
+	// means root-mounted; otherwise it is normalized like "/hub" with no
+	// trailing slash.
+	basePath string
 }
 
 func newHubServer(registry *hub.Registry, store *hub.Store) *hubServer {

--- a/cmd/serve_hub_auth.go
+++ b/cmd/serve_hub_auth.go
@@ -25,7 +25,7 @@ func (s *hubServer) handler() http.Handler {
 	mux.HandleFunc("/api/connect", s.handleReverseConnect)
 	mux.HandleFunc("/node/", s.handleNodeProxy)
 	mux.HandleFunc("/", s.handleIndex)
-	return s.auth(mux)
+	return s.mountBasePath(s.auth(mux))
 }
 
 func (s *hubServer) auth(next http.Handler) http.Handler {
@@ -47,13 +47,15 @@ func (s *hubServer) auth(next http.Handler) http.Handler {
 				if clean.RawQuery == "" {
 					clean.ForceQuery = false
 				}
+				clean.Path = s.hubPath(clean.Path)
+				clean.RawPath = ""
 				http.Redirect(w, r, clean.String(), http.StatusFound)
 				return
 			}
 		}
 		if !hubBearerTokenMatches(r, s.token) {
 			if hubShouldRenderLogin(r) {
-				writeHubLoginPage(w, r, hubQueryTokenSupplied(r))
+				s.writeHubLoginPage(w, r, hubQueryTokenSupplied(r))
 				return
 			}
 			writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "invalid hub authentication credentials")
@@ -197,13 +199,13 @@ var hubLoginTemplate = template.Must(template.New("hub-login").Parse(`<!doctype 
 </body>
 </html>`))
 
-func writeHubLoginPage(w http.ResponseWriter, r *http.Request, invalid bool) {
+func (s *hubServer) writeHubLoginPage(w http.ResponseWriter, r *http.Request, invalid bool) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusUnauthorized)
-	action := r.URL.EscapedPath()
+	action := s.hubPath(r.URL.Path)
 	if action == "" {
-		action = "/"
+		action = s.hubPath("/")
 	}
 	if err := hubLoginTemplate.Execute(w, struct {
 		Action  string

--- a/cmd/serve_hub_cmd.go
+++ b/cmd/serve_hub_cmd.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -23,6 +24,7 @@ var (
 	serveHubAuthMode              string
 	serveHubToken                 string
 	serveHubRegistrationTokenFlag string
+	serveHubBasePath              string
 )
 
 var serveHubCmd = &cobra.Command{
@@ -38,14 +40,14 @@ detected agent/version/capabilities, and opens a node's full web UI through
 the hub at /node/<id>/ with the node's bearer token injected server-side —
 node tokens never reach the browser.
 
-Routes:
+Routes (root-mounted by default; when --base-path is set, prefix each route):
   GET  /                  hub dashboard
   GET  /api/nodes         list nodes with probe status (never includes tokens)
   POST /api/nodes         add a node to the local store
   DELETE /api/nodes/<id>  remove a local-store node
   POST /api/nodes/test    probe a node spec without persisting it
   POST /api/register-node register/update a reverse node (registration token)
-  GET  /api/connect      reverse-node websocket endpoint (node auth)
+  GET  /api/connect       reverse-node websocket endpoint (node auth)
   ANY  /node/<id>/...     reverse proxy to that node's serve
   POST /api/delegations   create a cross-node delegation (node auth)
   GET  /api/delegations   list delegations
@@ -79,6 +81,27 @@ func validateHubBind(host string, port int, requireAuth bool) error {
 	return nil
 }
 
+func normalizeHubBasePath(raw string) (string, error) {
+	p := strings.TrimSpace(raw)
+	if p == "" || p == "/" {
+		return "", nil
+	}
+	if strings.Contains(p, "://") || strings.ContainsAny(p, "?#") {
+		return "", fmt.Errorf("--base-path must be a URL path such as /hub, not %q", raw)
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if hubHasDotDotSegment(p) {
+		return "", fmt.Errorf("--base-path must not contain .. segments")
+	}
+	p = path.Clean(p)
+	if p == "/" || p == "." {
+		return "", nil
+	}
+	return p, nil
+}
+
 // defaultHubNodesFile is where dashboard-added nodes persist when
 // --nodes-file is not given.
 func defaultHubNodesFile() (string, error) {
@@ -96,6 +119,10 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	}
 	requireAuth := authMode != "none"
 	if err := validateHubBind(serveHubHost, serveHubPort, requireAuth); err != nil {
+		return err
+	}
+	hubBasePath, err := normalizeHubBasePath(serveHubBasePath)
+	if err != nil {
 		return err
 	}
 	token, tokenSource, err := resolveServeToken(serveHubToken, os.Getenv("TERM_LLM_HUB_TOKEN"), requireAuth, generateServeToken)
@@ -125,15 +152,16 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	s.requireAuth = requireAuth
 	s.token = token
 	s.registrationToken = resolveServeHubRegistrationToken(serveHubRegistrationTokenFlag)
+	s.basePath = hubBasePath
 	// The delegation ledger lives beside the node store (same private dir).
 	s.delegations = hub.NewDelegationStore(filepath.Join(filepath.Dir(nodesFile), "delegations.json"))
 	addr := net.JoinHostPort(serveHubHost, strconv.Itoa(serveHubPort))
 	srv := &http.Server{Addr: addr, Handler: s.handler()}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "term-llm Hub listening on http://%s\n", addr)
-	fmt.Fprintf(out, "  GET http://%s/api/nodes\n", addr)
-	fmt.Fprintf(out, "  ANY http://%s/node/<id>/...\n", addr)
+	fmt.Fprintf(out, "term-llm Hub listening on http://%s%s\n", addr, s.hubPath("/"))
+	fmt.Fprintf(out, "  GET http://%s%s\n", addr, s.hubPath("/api/nodes"))
+	fmt.Fprintf(out, "  ANY http://%s%s\n", addr, s.hubPath("/node/<id>/..."))
 	fmt.Fprintf(out, "  node store: %s\n", nodesFile)
 	fmt.Fprintf(out, "  auth: %s\n", authSummary(requireAuth))
 	if requireAuth {
@@ -163,5 +191,6 @@ func init() {
 	serveHubCmd.Flags().StringVar(&serveHubNodesFile, "nodes-file", "", "Path to the JSON store for dashboard-added nodes (default: <data-dir>/hub/nodes.json)")
 	serveHubCmd.Flags().StringVar(&serveHubAuthMode, "auth", "bearer", "Hub auth mode: bearer or none (none is loopback-only)")
 	serveHubCmd.Flags().StringVar(&serveHubToken, "token", "", "Hub bearer token (defaults to $TERM_LLM_HUB_TOKEN, else auto-generated)")
+	serveHubCmd.Flags().StringVar(&serveHubBasePath, "base-path", "/", "URL prefix for the Hub dashboard/API when mounted behind a reverse proxy (e.g. /hub)")
 	serveHubCmd.Flags().StringVar(&serveHubRegistrationTokenFlag, "registration-token", "", "Token that allows reverse nodes to self-register (defaults to $TERM_LLM_HUB_REGISTRATION_TOKEN; empty disables registration)")
 }

--- a/cmd/serve_hub_index.go
+++ b/cmd/serve_hub_index.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	_ "embed"
+	"encoding/json"
 	"html/template"
 	"net/http"
 )
@@ -20,7 +21,8 @@ var hubIndexCSS string
 var hubIndexTmpl = template.Must(template.New("hub-index").Parse(hubIndexHTML))
 
 type hubIndexView struct {
-	CSS template.CSS
+	CSS          template.CSS
+	BasePathJSON template.JS
 	// CanAddNodes toggles the Add Node UI.
 	CanAddNodes bool
 }
@@ -31,10 +33,12 @@ func (s *hubServer) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	baseJSON, _ := json.Marshal(s.basePath)
 	// Headers are committed if Execute fails mid-stream; nothing useful to
 	// surface to the client at that point.
 	_ = hubIndexTmpl.Execute(w, hubIndexView{
-		CSS:         template.CSS(hubIndexCSS),
-		CanAddNodes: s.store != nil,
+		CSS:          template.CSS(hubIndexCSS),
+		BasePathJSON: template.JS(string(baseJSON)),
+		CanAddNodes:  s.store != nil,
 	})
 }

--- a/cmd/serve_hub_nodes.go
+++ b/cmd/serve_hub_nodes.go
@@ -57,7 +57,7 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 			Connection: n.Connection,
 			URL:        n.URL,
 			BasePath:   n.BasePath,
-			ProxyPath:  "/node/" + n.ID + "/",
+			ProxyPath:  s.hubPath("/node/" + n.ID + "/"),
 			HasToken:   n.Token != "",
 			Status:     statuses[n.ID],
 		}

--- a/cmd/serve_hub_prefix.go
+++ b/cmd/serve_hub_prefix.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+)
+
+// hubPath maps an internal hub route ("/api/nodes", "/node/id/") to the
+// externally mounted route. A root-mounted hub keeps paths unchanged; a hub
+// served with --base-path /hub emits "/hub/api/nodes" and "/hub/node/id/".
+func (s *hubServer) hubPath(p string) string {
+	if p == "" {
+		p = "/"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if s.basePath == "" {
+		return p
+	}
+	if p == "/" {
+		return s.basePath + "/"
+	}
+	return s.basePath + p
+}
+
+func (s *hubServer) hubNodeMount(id string) string {
+	return s.hubPath("/node/" + id)
+}
+
+// mountBasePath lets the hub run behind a reverse-proxy sub-path without nginx
+// rewriting internal routes. Requests outside the mount are 404; the exact
+// mount path redirects to its slash form so browser-relative fetches like
+// "api/nodes" resolve under the mount.
+func (s *hubServer) mountBasePath(next http.Handler) http.Handler {
+	if s.basePath == "" {
+		return next
+	}
+	base := s.basePath
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.URL.Path == base {
+			target := base + "/"
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+			return
+		}
+		if !strings.HasPrefix(r.URL.Path, base+"/") {
+			http.NotFound(w, r)
+			return
+		}
+
+		stripped := strings.TrimPrefix(r.URL.Path, base)
+		if stripped == "" {
+			stripped = "/"
+		}
+		r2 := r.Clone(r.Context())
+		u := *r.URL
+		u.Path = stripped
+		if u.RawPath != "" {
+			if raw, ok := stripHubRawPathPrefix(u.RawPath, base); ok {
+				u.RawPath = raw
+			} else {
+				u.RawPath = ""
+			}
+		}
+		r2.URL = &u
+		next.ServeHTTP(w, r2)
+	})
+}
+
+func stripHubRawPathPrefix(rawPath, base string) (string, bool) {
+	if rawPath == base {
+		return "/", true
+	}
+	prefix := base + "/"
+	if strings.HasPrefix(rawPath, prefix) {
+		return strings.TrimPrefix(rawPath, base), true
+	}
+	return "", false
+}

--- a/cmd/serve_hub_proxy.go
+++ b/cmd/serve_hub_proxy.go
@@ -27,7 +27,8 @@ type hubProxyTarget struct {
 	path     string // backend path: node base path + remainder
 	token    string // per-node bearer token, injected server-side
 	basePath string // node's baked-in prefix, e.g. /chat ("" when root)
-	mount    string // hub-facing prefix, e.g. /node/<id>
+	mount    string // hub-facing prefix, e.g. /hub/node/<id>
+	hubURL   string // hub-facing dashboard URL, e.g. /hub/
 }
 
 type hubProxyTargetKey struct{}
@@ -77,7 +78,7 @@ func (s *hubServer) handleNodeProxy(w http.ResponseWriter, r *http.Request) {
 	// Bare /node/<id> -> /node/<id>/ so the node UI's relative URLs resolve
 	// under the mount. Preserve the query string.
 	if rest == "" {
-		target := "/node/" + id + "/"
+		target := s.hubPath("/node/" + id + "/")
 		if r.URL.RawQuery != "" {
 			target += "?" + r.URL.RawQuery
 		}
@@ -97,7 +98,8 @@ func (s *hubServer) handleNodeProxy(w http.ResponseWriter, r *http.Request) {
 		path:     hubJoinBasePath(node.BasePath, rest),
 		token:    node.Token,
 		basePath: strings.TrimRight(node.BasePath, "/"),
-		mount:    "/node/" + node.ID,
+		mount:    s.hubNodeMount(node.ID),
+		hubURL:   s.hubPath("/"),
 	}
 	s.proxy.ServeHTTP(w, r.WithContext(withHubProxyTarget(r.Context(), t)))
 }
@@ -108,7 +110,7 @@ func (s *hubServer) handleReverseNodeProxy(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if rest == "" {
-		target := "/node/" + node.ID + "/"
+		target := s.hubPath("/node/" + node.ID + "/")
 		if r.URL.RawQuery != "" {
 			target += "?" + r.URL.RawQuery
 		}
@@ -121,7 +123,8 @@ func (s *hubServer) handleReverseNodeProxy(w http.ResponseWriter, r *http.Reques
 		path:     hubJoinBasePath(node.BasePath, rest),
 		token:    node.Token,
 		basePath: strings.TrimRight(node.BasePath, "/"),
-		mount:    "/node/" + node.ID,
+		mount:    s.hubNodeMount(node.ID),
+		hubURL:   s.hubPath("/"),
 	}
 	body := r.Body
 	if body == nil {
@@ -389,11 +392,16 @@ func hubRebaseUIPrefix(body []byte, basePath, mount string) (out []byte, baseHit
 
 // hubInjectContext injects window.TERM_LLM_HUB into the served HTML head so
 // the node's web UI knows it was opened via the hub and can render a "Back
-// to Hub" link. The hub URL is root-relative ("/") because the proxied UI is
-// same-origin with the hub.
+// to Hub" link. The hub URL is root-relative because the proxied UI is
+// same-origin with the hub; it includes the hub mount when served under a
+// prefix such as /hub.
 func hubInjectContext(body []byte, t *hubProxyTarget) []byte {
+	hubURL := t.hubURL
+	if hubURL == "" {
+		hubURL = "/"
+	}
 	ctxJSON, err := json.Marshal(map[string]string{
-		"url":      "/",
+		"url":      hubURL,
 		"nodeId":   t.nodeID,
 		"nodeName": t.nodeName,
 	})

--- a/cmd/serve_hub_registration.go
+++ b/cmd/serve_hub_registration.go
@@ -157,7 +157,7 @@ func (s *hubServer) handleRegisterNode(w http.ResponseWriter, r *http.Request) {
 			Source:     stored.Source,
 			Connection: stored.Connection,
 			BasePath:   stored.BasePath,
-			ProxyPath:  "/node/" + stored.ID + "/",
+			ProxyPath:  s.hubPath("/node/" + stored.ID + "/"),
 			HasToken:   stored.Token != "",
 		},
 		"created": created,

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -248,6 +248,147 @@ func TestHubIndexShowsRegistrationHelpWithoutEmbeddingToken(t *testing.T) {
 	}
 }
 
+func TestHubBasePathMountsDashboardAPIAndProxy(t *testing.T) {
+	const body = `<html><head><base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script></head><body></body></html>`
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, body)
+	})
+	s.basePath = "/hub"
+	h := s.handler()
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("root healthz status = %d, want 200", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/nodes", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unmounted API status = %d, want 404", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub", nil))
+	if rec.Code != http.StatusTemporaryRedirect || rec.Header().Get("Location") != "/hub/" {
+		t.Fatalf("mount redirect status=%d location=%q, want 307 /hub/", rec.Code, rec.Header().Get("Location"))
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("index status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `const hubBasePath = "/hub";`) {
+		t.Fatalf("index did not expose hub base path: %s", rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/api/nodes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nodes status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	var nodesResp struct {
+		Nodes []hubNodeView `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &nodesResp); err != nil {
+		t.Fatalf("decode nodes response: %v", err)
+	}
+	if len(nodesResp.Nodes) != 1 || nodesResp.Nodes[0].ProxyPath != "/hub/node/alpha/" {
+		t.Fatalf("nodes response = %+v, want prefixed proxy path", nodesResp.Nodes)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/node/alpha", nil))
+	if rec.Code != http.StatusTemporaryRedirect || rec.Header().Get("Location") != "/hub/node/alpha/" {
+		t.Fatalf("node redirect status=%d location=%q, want 307 /hub/node/alpha/", rec.Code, rec.Header().Get("Location"))
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/node/alpha/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("node proxy status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	got := rec.Body.String()
+	for _, want := range []string{`<base href="/hub/node/alpha/">`, `window.TERM_LLM_UI_PREFIX="/hub/node/alpha"`, `"url":"/hub/"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("proxied node body missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestHubAuthQueryTokenRedirectsInsideBasePath(t *testing.T) {
+	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	s.requireAuth = true
+	s.token = "hub-secret"
+	s.basePath = "/hub"
+	h := s.handler()
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/?token=hub-secret", nil))
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "/hub/" {
+		t.Fatalf("query token redirect status=%d location=%q, want 302 /hub/", rec.Code, rec.Header().Get("Location"))
+	}
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/hub/", nil)
+	req.Header.Set("Accept", "text/html")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("login status = %d, want 401", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `action="/hub/"`) {
+		t.Fatalf("login form action not mounted: %s", rec.Body.String())
+	}
+}
+
+func TestHubBasePathRejectsEncodedSeparators(t *testing.T) {
+	s := newHubServer(hub.NewRegistry(), nil)
+	s.basePath = "/hub"
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/node/a%2fb/", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestNormalizeHubBasePath(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "", want: ""},
+		{in: "/", want: ""},
+		{in: "hub", want: "/hub"},
+		{in: "/hub/", want: "/hub"},
+		{in: "/hub//private", want: "/hub/private"},
+		{in: "https://wasnotwas.com/hub", wantErr: true},
+		{in: "/hub?x=1", wantErr: true},
+		{in: "/hub/../admin", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := normalizeHubBasePath(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeHubBasePath(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeHubBasePath(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeHubBasePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHubRegistrationInfoDisabledOmitsToken(t *testing.T) {
 	store := hub.NewStore(filepath.Join(t.TempDir(), "nodes.json"))
 	s := newHubServer(hub.NewRegistry(store), store)

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -133,6 +133,11 @@ term-llm serve hub</code></pre>
   <script>
   (() => {
     'use strict';
+    const hubBasePath = {{.BasePathJSON}};
+    const hubPath = (path) => {
+      const p = path.startsWith('/') ? path : `/${path}`;
+      return `${hubBasePath}${p}`;
+    };
     const grid = document.getElementById('nodeGrid');
     const delegationsList = document.getElementById('delegationsList');
     const delegationsCount = document.getElementById('delegationsCount');
@@ -154,13 +159,15 @@ term-llm serve hub</code></pre>
         const u = new URL(raw, window.location.href);
         if (u.protocol === 'http:' || u.protocol === 'https:') return u.href;
       } catch (_) {}
-      if (raw.startsWith('/node/')) return raw;
+      const nodePrefix = hubPath('/node/');
+      if (raw.startsWith(nodePrefix)) return raw;
+      if (raw.startsWith('/node/')) return hubPath(raw);
       if (raw.startsWith('/') && delegation && delegation.target_node) {
         const base = nodeBasePaths.get(delegation.target_node) || '';
         let p = raw;
         if (base && p === base) p = '/';
         if (base && p.startsWith(base + '/')) p = p.slice(base.length);
-        return `/node/${encodeURIComponent(delegation.target_node)}${p}`;
+        return hubPath(`/node/${encodeURIComponent(delegation.target_node)}${p}`);
       }
       if (raw.startsWith('/')) return raw;
       return '';


### PR DESCRIPTION
## What

Makes `term-llm serve hub` prefix-aware so it can be mounted behind a reverse proxy at a sub-path such as `/hub`.

Adds:

```bash
term-llm serve hub --base-path /hub
```

When set, the Hub serves externally at:

```text
/hub/
/hub/api/nodes
/hub/api/register-node
/hub/api/connect
/hub/node/<id>/...
```

while keeping root-mounted behavior unchanged by default.

## Details

- Adds a Hub-specific `--base-path` flag; default `/` normalizes to root-mounted behavior.
- Mount wrapper strips the configured prefix before dispatching to existing Hub handlers.
- Exact `/hub` redirects to `/hub/` so browser-relative dashboard fetches keep working.
- Keeps `/healthz` available at root for process/local health checks, and also via the mount.
- Prefixes dashboard node `proxy_path` values.
- Prefixes node proxy redirects and rebased node UI mounts.
- Injects `window.TERM_LLM_HUB.url` as `/hub/` when mounted.
- Passes Hub base path into dashboard JS so delegation artifact links under `/node/<id>/...` become `/hub/node/<id>/...`.
- Keeps reverse-node registration and connector clients working by appending `/api/...` to whatever Hub URL the operator supplies.

## Self-review / verification

Ran:

```text
go test ./cmd -run 'TestHub|TestNormalizeHubBasePath|TestValidateHubBind'
go test ./...
go build ./...
go vet ./cmd
git diff --check
```

Live smoke with an actual server:

```text
go run . serve hub --host 127.0.0.1 --port 18090 --auth none --contain=false --base-path /hub --nodes-file <tmp>/nodes.json
```

Smoke results:

```text
GET /healthz        -> 200
GET /hub/           -> 200
GET /api/nodes      -> 404
GET /hub/api/nodes  -> 200
```

Manual self-review also searched for remaining root-only Hub assumptions around `/api/` and `/node/`; remaining literals are internal routes/tests or client code that appends to the supplied Hub URL.
