### PR TITLE
feat: expose ElevenLabs transcription timestamps

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -117,7 +117,7 @@ func transcribeWhisperCLI(ctx context.Context, cfg *config.Config, filePath, lan
 func init() {
 	transcribeCmd.Flags().StringVar(&transcribeLanguage, "language", "", "Language hint for transcription (e.g. \"en\", \"ja\")")
 	transcribeCmd.Flags().StringVar(&transcribeModel, "model", "", "Transcription model override")
-	transcribeCmd.Flags().BoolVar(&transcribeTimestamps, "timestamps", false, "Venice: request timestamp metadata before extracting transcript text")
+	transcribeCmd.Flags().BoolVar(&transcribeTimestamps, "timestamps", false, "Request timestamp metadata where supported (ElevenLabs emits JSON with word timestamps)")
 	transcribeCmd.Flags().BoolVar(&transcribePorcelain, "porcelain", false, "Output only the transcript text")
 	transcribeCmd.Flags().StringVar(&transcribeProvider, "provider", "", `Transcription provider override: "openai", "mistral" (Voxtral), "venice", "elevenlabs", "local" (whisper.cpp server), "whisper-cli". Defaults to transcription.provider in config, or "openai".`)
 	_ = transcribeCmd.RegisterFlagCompletionFunc("provider", staticCompletion("openai", "mistral", "venice", "elevenlabs", "local", "whisper-cli"))

--- a/docs-site/content/guides/transcription.md
+++ b/docs-site/content/guides/transcription.md
@@ -40,7 +40,7 @@ Key options:
 - `--language` for a language hint such as `en` or `ja`
 - `--provider` to select the transcription backend
 - `--model` to override the configured transcription model
-- `--timestamps` to ask Venice for timestamp metadata before extracting the transcript text
+- `--timestamps` to ask supported providers for timestamp metadata. ElevenLabs Scribe emits the full JSON response, including `words` entries with `text`, `start`, `end`, `type`, and `logprob`.
 - `--porcelain` to output only transcript text
 
 ## Provider options

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -728,7 +728,7 @@ type TranscriptionConfig struct {
 	Provider   string                        `mapstructure:"provider"`   // named provider from providers map; default "openai"
 	Model      string                        `mapstructure:"model"`      // optional model override
 	SaveDir    string                        `mapstructure:"save_dir"`   // if set, persist each uploaded audio file here
-	Timestamps bool                          `mapstructure:"timestamps"` // Venice: request timestamp metadata
+	Timestamps bool                          `mapstructure:"timestamps"` // Request timestamp metadata where supported
 	Venice     TranscriptionVeniceConfig     `mapstructure:"venice"`
 	ElevenLabs TranscriptionElevenLabsConfig `mapstructure:"elevenlabs"`
 }

--- a/internal/llm/transcribe.go
+++ b/internal/llm/transcribe.go
@@ -23,6 +23,9 @@ func transcribeAndTruncate(ctx context.Context, filePath string, opts Transcribe
 	if err != nil {
 		return "", err
 	}
+	if opts.Provider == "elevenlabs" && opts.Timestamps {
+		return transcript, nil
+	}
 	return TruncateTranscriptIfImplausible(ctx, filePath, transcript), nil
 }
 
@@ -182,11 +185,12 @@ func TranscribeWithConfig(ctx context.Context, cfg *config.Config, filePath, lan
 		}
 		model := firstNonEmptyString(modelOverride, cfg.Transcription.ElevenLabs.Model, "scribe_v2")
 		return transcribeAndTruncate(ctx, filePath, TranscribeOptions{
-			APIKey:   apiKey,
-			Endpoint: endpoint,
-			Model:    model,
-			Language: language,
-			Provider: "elevenlabs",
+			APIKey:     apiKey,
+			Endpoint:   endpoint,
+			Model:      model,
+			Language:   language,
+			Provider:   "elevenlabs",
+			Timestamps: cfg.Transcription.Timestamps,
 		})
 
 	case "openai":

--- a/internal/llm/transcribe_test.go
+++ b/internal/llm/transcribe_test.go
@@ -111,6 +111,62 @@ func TestTranscribeWithConfig_UsesResolvedURLForBuiltins(t *testing.T) {
 	}
 }
 
+func TestTranscribeWithConfig_ElevenLabsPassesTimestampOptions(t *testing.T) {
+	origClient := defaultHTTPClient
+	origProbe := probeAudioDuration
+	defer func() {
+		defaultHTTPClient = origClient
+		probeAudioDuration = origProbe
+	}()
+	probeAudioDuration = func(context.Context, string) (time.Duration, error) {
+		return time.Minute, nil
+	}
+
+	audioFile, err := os.CreateTemp(t.TempDir(), "audio-*.mp3")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	if _, err := audioFile.WriteString("not really audio"); err != nil {
+		t.Fatalf("write temp audio: %v", err)
+	}
+	if err := audioFile.Close(); err != nil {
+		t.Fatalf("close temp audio: %v", err)
+	}
+
+	var requestBody string
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			requestBody = string(body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"text":"hello","words":[{"text":"hello","start":0,"end":0.5,"type":"word","logprob":-0.1}]}`)),
+			}, nil
+		}),
+	}
+
+	result, err := TranscribeWithConfig(context.Background(), &config.Config{
+		Transcription: config.TranscriptionConfig{
+			Timestamps: true,
+		},
+		Providers: map[string]config.ProviderConfig{
+			"elevenlabs": {ResolvedAPIKey: "test-key"},
+		},
+	}, audioFile.Name(), "", "elevenlabs")
+	if err != nil {
+		t.Fatalf("TranscribeWithConfig failed: %v", err)
+	}
+	for _, want := range []string{"timestamps_granularity", "word", "no_verbatim", "true", "tag_audio_events", "false"} {
+		if !strings.Contains(requestBody, want) {
+			t.Fatalf("request body missing %q: %s", want, requestBody)
+		}
+	}
+	if !strings.Contains(result, `"words": [`) {
+		t.Fatalf("result = %q, want timestamp JSON", result)
+	}
+}
+
 func TestTranscribeWithConfig_TruncatesImplausiblyLongTranscript(t *testing.T) {
 	origClient := defaultHTTPClient
 	origProbe := probeAudioDuration

--- a/internal/llm/whisper.go
+++ b/internal/llm/whisper.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,7 +18,7 @@ type TranscribeOptions struct {
 	Model      string // optional, overrides default model name sent to API
 	Language   string // optional, e.g. "en"
 	Provider   string // optional request dialect: "openai" (default), "venice", or "elevenlabs"
-	Timestamps bool   // Venice: request timestamp metadata in JSON responses
+	Timestamps bool   // Request timestamp metadata in JSON responses where supported
 }
 
 type whisperResponse struct {
@@ -77,6 +78,18 @@ func TranscribeFile(ctx context.Context, filePath string, opts TranscribeOptions
 		return "", fmt.Errorf("whisper API error %d: %s", resp.StatusCode, readLimitedBody(resp.Body, whisperErrorBodyLimit))
 	}
 
+	if opts.Provider == "elevenlabs" && opts.Timestamps {
+		var raw json.RawMessage
+		if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+			return "", fmt.Errorf("decode whisper response: %w", err)
+		}
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+			return "", fmt.Errorf("format whisper response: %w", err)
+		}
+		return pretty.String(), nil
+	}
+
 	var result whisperResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", fmt.Errorf("decode whisper response: %w", err)
@@ -129,6 +142,17 @@ func writeTranscriptionBody(mw *multipart.Writer, filePath string, file io.Reade
 	if provider == "venice" && timestamps {
 		if err := mw.WriteField("timestamps", "true"); err != nil {
 			return fmt.Errorf("write timestamps field: %w", err)
+		}
+	}
+	if provider == "elevenlabs" && timestamps {
+		if err := mw.WriteField("timestamps_granularity", "word"); err != nil {
+			return fmt.Errorf("write timestamps granularity field: %w", err)
+		}
+		if err := mw.WriteField("no_verbatim", "true"); err != nil {
+			return fmt.Errorf("write no verbatim field: %w", err)
+		}
+		if err := mw.WriteField("tag_audio_events", "false"); err != nil {
+			return fmt.Errorf("write tag audio events field: %w", err)
 		}
 	}
 	if language != "" {

--- a/internal/llm/whisper_test.go
+++ b/internal/llm/whisper_test.go
@@ -174,6 +174,66 @@ func TestTranscribeFile_ElevenLabsDialect(t *testing.T) {
 	}
 }
 
+func TestTranscribeFile_ElevenLabsWordTimestamps(t *testing.T) {
+	origClient := defaultHTTPClient
+	defer func() {
+		defaultHTTPClient = origClient
+	}()
+
+	audioFile, err := os.CreateTemp(t.TempDir(), "audio-*.mp3")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	if _, err := audioFile.WriteString("audio-bytes"); err != nil {
+		t.Fatalf("write temp audio: %v", err)
+	}
+	if err := audioFile.Close(); err != nil {
+		t.Fatalf("close temp audio: %v", err)
+	}
+
+	var contentType string
+	var bodyBytes []byte
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			contentType = req.Header.Get("Content-Type")
+			bodyBytes, _ = io.ReadAll(req.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"text":"hello world","words":[{"text":"hello","start":0,"end":0.4,"type":"word","logprob":-0.1}]}`)),
+			}, nil
+		}),
+	}
+
+	result, err := TranscribeFile(context.Background(), audioFile.Name(), TranscribeOptions{
+		APIKey:     "test-key",
+		Endpoint:   "https://api.elevenlabs.io/v1/speech-to-text",
+		Model:      "scribe_v2",
+		Provider:   "elevenlabs",
+		Timestamps: true,
+	})
+	if err != nil {
+		t.Fatalf("TranscribeFile failed: %v", err)
+	}
+	if !strings.Contains(result, `"words": [`) || !strings.Contains(result, `"start": 0`) {
+		t.Fatalf("timestamp JSON = %q, want pretty JSON with words", result)
+	}
+
+	fields := readMultipartFields(t, contentType, bodyBytes)
+	if fields["model_id"] != "scribe_v2" {
+		t.Fatalf("model_id = %q, want scribe_v2", fields["model_id"])
+	}
+	if fields["timestamps_granularity"] != "word" {
+		t.Fatalf("timestamps_granularity = %q, want word", fields["timestamps_granularity"])
+	}
+	if fields["no_verbatim"] != "true" {
+		t.Fatalf("no_verbatim = %q, want true", fields["no_verbatim"])
+	}
+	if fields["tag_audio_events"] != "false" {
+		t.Fatalf("tag_audio_events = %q, want false", fields["tag_audio_events"])
+	}
+}
+
 func TestTranscribeFile_VeniceDialect(t *testing.T) {
 	origClient := defaultHTTPClient
 	defer func() {


### PR DESCRIPTION
## What

- Send ElevenLabs Scribe word timestamp options when transcription timestamps are requested.
- Preserve and pretty-print the full ElevenLabs JSON response for timestamped transcription output so `words` metadata is exposed.
- Pass configured/CLI `transcription.timestamps` through to the direct ElevenLabs speech-to-text path.
- Update transcribe help/docs and add regression tests for the ElevenLabs multipart fields and JSON output.

## Why

`term-llm transcribe --provider elevenlabs --model scribe_v2 --timestamps` previously still returned only transcript text and did not request/expose ElevenLabs Scribe word timestamps. The direct ElevenLabs `/v1/speech-to-text` API supports word timing with `timestamps_granularity=word` plus related request fields, returning `words: [{text,start,end,type,logprob}]`.

## Verification

- `go test ./internal/llm ./cmd`
- `go build ./...`
- `go test ./...`
