### PR TITLE
fix: Delegation ledger rewrites are non-atomic and can brick hub delegation state after a crash

### DIFF
--- a/internal/hub/delegation_store.go
+++ b/internal/hub/delegation_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -61,6 +62,62 @@ func (s *DelegationStore) readLocked() ([]Delegation, error) {
 	return f.Delegations, nil
 }
 
+func writeDelegationFileAtomically(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tf, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := tf.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tf.Write(data); err != nil {
+		_ = tf.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tf.Sync(); err != nil {
+		_ = tf.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tf.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tempPath, 0o600); err != nil {
+		return fmt.Errorf("set temp file permissions: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("secure hub delegation ledger permissions: %w", err)
+	}
+	if err := syncDirIfSupported(dir); err != nil {
+		return fmt.Errorf("sync hub delegation ledger dir: %w", err)
+	}
+
+	cleanup = false
+	return nil
+}
+
+func syncDirIfSupported(path string) error {
+	switch runtime.GOOS {
+	case "windows", "darwin":
+		return nil
+	}
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
 func (s *DelegationStore) writeLocked(records []Delegation) error {
 	records = s.pruneLocked(records)
 	data, err := json.MarshalIndent(delegationFile{Delegations: records}, "", "  ")
@@ -71,15 +128,12 @@ func (s *DelegationStore) writeLocked(records []Delegation) error {
 		return fmt.Errorf("create hub delegation ledger dir: %w", err)
 	}
 	// 0600: prompts/responses are private content. Chmod first so an existing
-	// overly-permissive file is corrected as well as newly created files.
+	// overly-permissive file is corrected even if the atomic rewrite fails.
 	if err := os.Chmod(s.path, 0o600); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("secure hub delegation ledger permissions: %w", err)
 	}
-	if err := os.WriteFile(s.path, append(data, '\n'), 0o600); err != nil {
+	if err := writeDelegationFileAtomically(s.path, append(data, '\n')); err != nil {
 		return fmt.Errorf("write hub delegation ledger: %w", err)
-	}
-	if err := os.Chmod(s.path, 0o600); err != nil {
-		return fmt.Errorf("secure hub delegation ledger permissions: %w", err)
 	}
 	return nil
 }

--- a/internal/hub/delegation_test.go
+++ b/internal/hub/delegation_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -144,6 +145,69 @@ func TestDelegationStoreCRUD(t *testing.T) {
 		if perm := info.Mode().Perm(); perm != 0o600 {
 			t.Fatalf("ledger permissions = %o, want 600", perm)
 		}
+	}
+}
+
+func TestDelegationStoreAtomicWriteFailureLeavesExistingLedgerUntouched(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions are not reliable on windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "ledger")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir ledger dir: %v", err)
+	}
+	s := NewDelegationStore(filepath.Join(dir, "delegations.json"))
+	now := time.Now().UTC()
+	if err := s.Add(newTestDelegation("dlg_1", "a", "b", DelegationStatusRunning, now)); err != nil {
+		t.Fatalf("seed ledger: %v", err)
+	}
+	original, err := os.ReadFile(s.Path())
+	if err != nil {
+		t.Fatalf("read seeded ledger: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod ledger dir: %v", err)
+	}
+	defer os.Chmod(dir, 0o700)
+
+	_, err = s.Update("dlg_1", func(rec *Delegation) {
+		rec.Status = DelegationStatusSucceeded
+		rec.Response = "done"
+	})
+	if err == nil {
+		t.Skip("ledger directory remained writable; cannot exercise atomic temp-file creation failure")
+	}
+	if !strings.Contains(err.Error(), "create temp file") && !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("expected atomic temp-file creation failure, got: %v", err)
+	}
+
+	current, readErr := os.ReadFile(s.Path())
+	if readErr != nil {
+		t.Fatalf("read ledger after failed update: %v", readErr)
+	}
+	if string(current) != string(original) {
+		t.Fatalf("ledger was modified after failed atomic write:\n got: %q\nwant: %q", string(current), string(original))
+	}
+
+	got, ok, err := s.Get("dlg_1")
+	if err != nil {
+		t.Fatalf("Get after failed update: %v", err)
+	}
+	if !ok {
+		t.Fatalf("delegation missing after failed update")
+	}
+	if got.Status != DelegationStatusRunning || got.Response != "" {
+		t.Fatalf("delegation changed after failed update: %+v", got)
+	}
+
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".delegations.json.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("unexpected temp files left behind: %v", leftovers)
 	}
 }
 


### PR DESCRIPTION
## What changed

- replaced direct `os.WriteFile` ledger rewrites in `internal/hub/delegation_store.go` with an atomic temp-file write in the same directory
- fsync the temp file before rename, rename it over the live ledger, re-assert `0600` permissions, and fsync the directory on supported platforms
- kept the existing JSON ledger format unchanged
- added a regression test that makes the ledger directory non-writable and verifies a failed update leaves the existing ledger readable, unchanged, and without leaked temp files

## Why this is high-value

The delegation ledger is used by active hub delegation flows. Before this change, every add/update truncated and rewrote the live JSON file in place. A crash, kill, or partial write at the wrong moment could leave invalid JSON on disk, after which later reads would fail hard and the hub delegation endpoints could return 500s until someone manually repaired the file.

This change removes that corruption window for the existing ledger contents: failed replacement attempts now leave the previously committed ledger intact and parseable.

## Validation

- `gofmt -w internal/hub/delegation_store.go internal/hub/delegation_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
