### PR TITLE
fix: Local hub node store rewrites are non-atomic, so a partial write can make UI-added nodes disappear and fail auth

### DIFF
--- a/internal/hub/store.go
+++ b/internal/hub/store.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/samsaffron/term-llm/internal/config"
 )
 
 // Store persists UI-added nodes in a local JSON file (0600 — it holds node
@@ -67,15 +69,13 @@ func (s *Store) writeLocked(nodes []Node) error {
 		return fmt.Errorf("create hub node store dir: %w", err)
 	}
 	// 0600: the store holds node bearer tokens. Chmod first so an existing
-	// overly-permissive file is corrected as well as newly created files.
+	// overly-permissive file is corrected before the atomic rewrite preserves its
+	// mode, and new files still land at 0600.
 	if err := os.Chmod(s.path, 0o600); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("secure hub node store permissions: %w", err)
 	}
-	if err := os.WriteFile(s.path, append(data, '\n'), 0o600); err != nil {
+	if err := config.WriteFileAtomically(s.path, append(data, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write hub node store: %w", err)
-	}
-	if err := os.Chmod(s.path, 0o600); err != nil {
-		return fmt.Errorf("secure hub node store permissions: %w", err)
 	}
 	return nil
 }

--- a/internal/hub/store_test.go
+++ b/internal/hub/store_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -104,6 +105,57 @@ func TestStoreUpsertCreatesAndReplaces(t *testing.T) {
 	}
 	if len(nodes) != 1 || nodes[0].ID != "docker-a" || nodes[0].Token != "two" {
 		t.Fatalf("persisted nodes = %+v", nodes)
+	}
+}
+
+func TestStoreWriteLockedFailureLeavesExistingFileUntouched(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions behave differently on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "hub")
+	path := filepath.Join(dir, "nodes.json")
+	s := NewStore(path)
+
+	if err := s.writeLocked([]Node{{ID: "jarvis", URL: "http://127.0.0.1:8081/chat", Token: "one"}}); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read seeded store: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod dir read-only: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0o755); err != nil {
+			t.Fatalf("restore dir permissions: %v", err)
+		}
+	}()
+
+	err = s.writeLocked([]Node{{ID: "jarvis", URL: "http://127.0.0.1:8081/chat", Token: "two"}})
+	if err == nil {
+		t.Fatal("expected writeLocked to fail")
+	}
+	if !strings.Contains(err.Error(), "create temp file") {
+		t.Fatalf("error = %v, want create temp file", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read store after failed rewrite: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("store changed on failed rewrite: got %q want %q", after, before)
+	}
+
+	nodes, err := NewStore(path).Nodes()
+	if err != nil {
+		t.Fatalf("Nodes after failed rewrite: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Token != "one" {
+		t.Fatalf("nodes after failed rewrite = %+v", nodes)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Switched `internal/hub/store.go` from direct `os.WriteFile(...)` rewrites to the existing atomic temp-file + fsync + rename helper used for other critical persisted files.
- Kept the existing `0600` bearer-token protection behavior by tightening any existing store file before the atomic rewrite.
- Added a regression test that forces the atomic temp-file creation path to fail and verifies the previously persisted node store remains intact and readable.

## Why this is high-value

The local hub node store is the persistence layer for UI-added nodes and their bearer tokens. Before this change, add/upsert/remove rewrote the full JSON file in place. If the process crashed or the write was interrupted after truncation but before the full JSON landed, the store could become partial/invalid JSON.

Because `readLocked()` hard-fails on JSON parse errors and `Registry.Lookup()` ignores resolver errors, that corruption could make locally stored nodes silently disappear from hub lookups and break token-based auth for those nodes until manual repair. This change makes each rewrite atomic so the store is either fully updated or the previous valid file remains in place.

## Validation

- `gofmt -w internal/hub/store.go internal/hub/store_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
