### PR TITLE
fix: Reverse hub proxy silently truncates request bodies at 32 MiB

### DIFF
--- a/cmd/serve_hub_proxy.go
+++ b/cmd/serve_hub_proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	htmlpkg "html"
 	"io"
@@ -470,6 +471,11 @@ func hubRebaseLocationPath(path string, t *hubProxyTarget) string {
 }
 
 func hubProxyErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		return
+	}
 	id := "node"
 	if t := hubProxyTargetFrom(r.Context()); t != nil {
 		id = t.nodeID

--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -25,11 +25,12 @@ import (
 // accepted and exposed as an ordinary http.Response reader.
 
 const (
-	hubReversePingInterval  = 20 * time.Second
-	hubReversePongWait      = 60 * time.Second
-	hubReverseWriteWait     = 10 * time.Second
-	hubReverseChunkSize     = 32 * 1024
-	hubReversePendingBuffer = 16
+	hubReversePingInterval        = 20 * time.Second
+	hubReversePongWait            = 60 * time.Second
+	hubReverseWriteWait           = 10 * time.Second
+	hubReverseChunkSize           = 32 * 1024
+	hubReversePendingBuffer       = 16
+	hubReverseMaxRequestBodyBytes = 32 << 20
 
 	hubReverseFrameRequest       = "request"
 	hubReverseFrameCancel        = "cancel"
@@ -352,9 +353,12 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 	var body []byte
 	if req.Body != nil {
 		var readErr error
-		body, readErr = io.ReadAll(io.LimitReader(req.Body, 32<<20))
+		body, readErr = io.ReadAll(io.LimitReader(req.Body, hubReverseMaxRequestBodyBytes+1))
 		if readErr != nil {
 			return nil, readErr
+		}
+		if len(body) > hubReverseMaxRequestBodyBytes {
+			return nil, fmt.Errorf("reverse request body exceeds %d bytes: %w", hubReverseMaxRequestBodyBytes, &http.MaxBytesError{Limit: hubReverseMaxRequestBodyBytes})
 		}
 	}
 	id := c.nextRequestID()

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -112,6 +112,44 @@ func TestHubReverseNodeProxyStreamsChunkedResponse(t *testing.T) {
 	}
 }
 
+func TestHubReverseNodeProxyRejectsOversizedRequestBody(t *testing.T) {
+	backendCalled := make(chan struct{}, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case backendCalled <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	hubTS := httptest.NewServer(s.handler())
+	defer hubTS.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	waitForReverseNode(t, s, "artist")
+
+	payload := strings.Repeat("a", hubReverseMaxRequestBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/node/artist/upload", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "reverse request body exceeds") {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+	select {
+	case <-backendCalled:
+		t.Fatal("backend received oversized reverse request body")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestHubReverseResponseCancellation(t *testing.T) {
 	backendCanceled := make(chan struct{})
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What changed

- Added an explicit `hubReverseMaxRequestBodyBytes` limit for hub reverse requests.
- Changed `hubReverseManager.do` to read up to `32 MiB + 1 byte`, detect overflow, and reject oversized request bodies instead of forwarding a silently truncated body.
- Taught the hub reverse proxy error handler to return `413 Request Entity Too Large` for this case.
- Added an end-to-end test covering an oversized POST body, asserting the hub returns 413 and the backend never receives the truncated request.

## Why this is high-value

The previous code used `io.LimitReader(req.Body, 32<<20)` with `io.ReadAll`, which stops cleanly at the limit and returns EOF. That meant bodies larger than 32 MiB were treated as successful reads of only the first 32 MiB, then forwarded through the reverse tunnel as if complete. Any upload or large POST/PUT to a reverse-connected node could therefore be silently corrupted.

Rejecting oversized bodies is a small, targeted reliability fix that prevents real user-visible data loss without changing the existing framing model.

## Validation

- `gofmt -w cmd/serve_hub_reverse.go cmd/serve_hub_proxy.go cmd/serve_hub_reverse_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
