### PR TITLE
fix: Reverse hub proxy silently truncates request bodies over 32 MiB

### DIFF
--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -25,11 +25,12 @@ import (
 // accepted and exposed as an ordinary http.Response reader.
 
 const (
-	hubReversePingInterval  = 20 * time.Second
-	hubReversePongWait      = 60 * time.Second
-	hubReverseWriteWait     = 10 * time.Second
-	hubReverseChunkSize     = 32 * 1024
-	hubReversePendingBuffer = 16
+	hubReversePingInterval        = 20 * time.Second
+	hubReversePongWait            = 60 * time.Second
+	hubReverseWriteWait           = 10 * time.Second
+	hubReverseChunkSize           = 32 * 1024
+	hubReversePendingBuffer       = 16
+	hubReverseRequestMaxBodyBytes = 32 << 20
 
 	hubReverseFrameRequest       = "request"
 	hubReverseFrameCancel        = "cancel"
@@ -339,6 +340,33 @@ func (c *hubReverseConnection) writeRequest(frame hubReverseRequest) error {
 	return err
 }
 
+func hubReadReverseRequestBody(body io.ReadCloser) (data []byte, overLimit bool, err error) {
+	defer body.Close()
+	data, err = io.ReadAll(io.LimitReader(body, hubReverseRequestMaxBodyBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(data) > hubReverseRequestMaxBodyBytes {
+		return data, true, nil
+	}
+	return data, false, nil
+}
+
+func hubReverseErrorResponse(req *http.Request, status int, msg string) *http.Response {
+	if msg != "" && msg[len(msg)-1] != '\n' {
+		msg += "\n"
+	}
+	body := []byte(msg)
+	return &http.Response{
+		StatusCode:    status,
+		Status:        fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:        http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}
+
 func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Request) (*http.Response, error) {
 	if m == nil {
 		return nil, fmt.Errorf("node %q is configured for reverse connection but reverse transport is disabled", node.ID)
@@ -351,10 +379,14 @@ func (m *hubReverseManager) do(ctx context.Context, node hub.Node, req *http.Req
 	}
 	var body []byte
 	if req.Body != nil {
+		var overLimit bool
 		var readErr error
-		body, readErr = io.ReadAll(io.LimitReader(req.Body, 32<<20))
+		body, overLimit, readErr = hubReadReverseRequestBody(req.Body)
 		if readErr != nil {
 			return nil, readErr
+		}
+		if overLimit {
+			return hubReverseErrorResponse(req, http.StatusRequestEntityTooLarge, fmt.Sprintf("hub reverse proxy request body exceeds %d bytes", hubReverseRequestMaxBodyBytes)), nil
 		}
 	}
 	id := c.nextRequestID()

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -77,6 +79,30 @@ func TestHubReverseNodeProxy(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"agent":"artist"`) {
 		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestHubReverseNodeProxyRejectsOversizedRequestBody(t *testing.T) {
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	s.reverse.mu.Lock()
+	s.reverse.conns[node.ID] = &hubReverseConnection{pending: map[string]*hubReversePending{}}
+	conn := s.reverse.conns[node.ID]
+	s.reverse.mu.Unlock()
+
+	body := bytes.Repeat([]byte("x"), hubReverseRequestMaxBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/node/artist/upload", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), fmt.Sprintf("exceeds %d bytes", hubReverseRequestMaxBodyBytes)) {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+	if got := conn.requestSeq.Load(); got != 0 {
+		t.Fatalf("reverse request sequence advanced to %d for rejected oversized request", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Replaced the reverse hub proxy request-body read with the existing `limit+1` overflow detection pattern instead of a plain `io.LimitReader(..., 32<<20)` read.
- When a reverse-proxied request body exceeds 32 MiB, `hubReverseManager.do` now returns a synthetic HTTP 413 response instead of forwarding a truncated body to the node.
- Added a regression test covering oversized POSTs through the reverse node proxy and asserting that no reverse request is dispatched.

## Why this is high-value

The old code silently accepted only the first 32 MiB of a larger request body, then rebuilt and forwarded that shortened body to the reverse-connected node as if it were complete. That can corrupt uploads, large form posts, and API requests in a way that looks successful to users.

Rejecting overflow with a clear 413 avoids silent data loss and makes the failure explicit and debuggable.

## Validation

- `gofmt -w cmd/serve_hub_reverse.go cmd/serve_hub_reverse_test.go`
- `go build ./...`
- `go test ./...`
- Added `TestHubReverseNodeProxyRejectsOversizedRequestBody`
