### PR TITLE
fix: Delegation cap checks can hang for a long time and still stay wedged on stale active records

### DIFF
--- a/cmd/serve_hub_delegations_state.go
+++ b/cmd/serve_hub_delegations_state.go
@@ -7,14 +7,23 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 	"unicode"
 
 	"github.com/samsaffron/term-llm/internal/hub"
 )
 
+var (
+	hubDelegationCapRefreshBudget          = 3 * time.Second
+	hubDelegationCapRefreshTimeout         = 2 * time.Second
+	hubDelegationCapRefreshParallelism     = 8
+	hubDelegationCapRefreshErrorStaleAfter = 24 * time.Hour
+)
+
 // checkDelegationCaps enforces hub-wide, per-origin, and per-target in-flight
 // limits. Ledger statuses only advance when polled, so before rejecting it
-// refreshes active records once (bounded by the hub-wide cap) and recounts.
+// refreshes active records once on a short best-effort path and recounts.
 func (s *hubServer) checkDelegationCaps(ctx context.Context, origin, target hub.Node) error {
 	over := func() (error, bool) {
 		total, byOrigin, byTarget, err := s.delegations.ActiveCounts()
@@ -36,24 +45,129 @@ func (s *hubServer) checkDelegationCaps(ctx context.Context, origin, target hub.
 	if err == nil || !capped {
 		return err
 	}
-	s.refreshActiveDelegations(ctx)
+	s.refreshActiveDelegations(ctx, origin.ID, target.ID)
 	err, _ = over()
 	return err
 }
 
-// refreshActiveDelegations re-polls every active record's target run so stale
-// "running" entries don't pin in-flight caps forever.
-func (s *hubServer) refreshActiveDelegations(ctx context.Context) {
+// refreshActiveDelegations re-polls active records in priority order so stale
+// entries can stop pinning in-flight caps, but keeps the cap-recovery path
+// bounded with a small worker pool and short child deadlines.
+func (s *hubServer) refreshActiveDelegations(ctx context.Context, originID, targetID string) {
 	records, err := s.delegations.List()
 	if err != nil {
 		return
 	}
-	for i := range records {
-		if hub.DelegationStatusTerminal(records[i].Status) {
+	active := prioritizedActiveDelegations(records, originID, targetID)
+	if len(active) == 0 {
+		return
+	}
+	refreshCtx := ctx
+	cancel := func() {}
+	if hubDelegationCapRefreshBudget > 0 {
+		refreshCtx, cancel = context.WithTimeout(ctx, hubDelegationCapRefreshBudget)
+	}
+	defer cancel()
+
+	workers := hubDelegationCapRefreshParallelism
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > len(active) {
+		workers = len(active)
+	}
+
+	jobs := make(chan hub.Delegation)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for d := range jobs {
+				if refreshCtx.Err() != nil {
+					return
+				}
+				reqCtx := refreshCtx
+				reqCancel := func() {}
+				if hubDelegationCapRefreshTimeout > 0 {
+					reqCtx, reqCancel = context.WithTimeout(refreshCtx, hubDelegationCapRefreshTimeout)
+				}
+				err := s.refreshDelegation(reqCtx, &d)
+				reqCancel()
+				if err != nil {
+					s.maybeTerminalizeDelegationRefreshError(d, err)
+				}
+			}
+		}()
+	}
+
+outer:
+	for _, d := range active {
+		select {
+		case <-refreshCtx.Done():
+			break outer
+		case jobs <- d:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func prioritizedActiveDelegations(records []hub.Delegation, originID, targetID string) []hub.Delegation {
+	target := make([]hub.Delegation, 0, len(records))
+	origin := make([]hub.Delegation, 0, len(records))
+	other := make([]hub.Delegation, 0, len(records))
+	for i := len(records) - 1; i >= 0; i-- {
+		d := records[i]
+		if hub.DelegationStatusTerminal(d.Status) {
 			continue
 		}
-		_ = s.refreshDelegation(ctx, &records[i])
+		switch {
+		case targetID != "" && d.TargetNode == targetID:
+			target = append(target, d)
+		case originID != "" && d.OriginNode == originID:
+			origin = append(origin, d)
+		default:
+			other = append(other, d)
+		}
 	}
+	active := make([]hub.Delegation, 0, len(target)+len(origin)+len(other))
+	active = append(active, target...)
+	active = append(active, origin...)
+	active = append(active, other...)
+	return active
+}
+
+func (s *hubServer) maybeTerminalizeDelegationRefreshError(d hub.Delegation, err error) {
+	if err == nil || d.ID == "" || hub.DelegationStatusTerminal(d.Status) {
+		return
+	}
+	if !delegationRefreshErrorTerminal(d, err) {
+		return
+	}
+	_, _ = s.delegations.Update(d.ID, func(rec *hub.Delegation) {
+		if hub.DelegationStatusTerminal(rec.Status) {
+			return
+		}
+		rec.Status = hub.DelegationStatusError
+		rec.Error = err.Error()
+	})
+}
+
+func delegationRefreshErrorTerminal(d hub.Delegation, err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "is not present in the hub registry") {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if hubDelegationCapRefreshErrorStaleAfter <= 0 || d.UpdatedAt.IsZero() {
+		return false
+	}
+	return time.Since(d.UpdatedAt) >= hubDelegationCapRefreshErrorStaleAfter
 }
 
 // refreshDelegation polls the target node for the delegation's latest run and

--- a/cmd/serve_hub_delegations_test.go
+++ b/cmd/serve_hub_delegations_test.go
@@ -817,3 +817,132 @@ func TestJobsV2LLMRunnerHubDelegationContext(t *testing.T) {
 		t.Fatalf("delegation id without labels = %q, want empty", got)
 	}
 }
+
+func TestCheckDelegationCapsRecoversMissingTargetRecords(t *testing.T) {
+	s, _ := newDelegationHub(t)
+	now := time.Now().Add(-time.Hour).UTC()
+	for i := 0; i < hubDelegationOriginMaxInFlight; i++ {
+		if err := s.delegations.Add(hub.Delegation{
+			ID:         fmt.Sprintf("dlg_missing_%d", i),
+			OriginNode: "alpha",
+			TargetNode: "gone",
+			JobID:      fmt.Sprintf("job_%d", i),
+			RunID:      fmt.Sprintf("run_%d", i),
+			Status:     hub.DelegationStatusRunning,
+			Depth:      1,
+			Chain:      []string{"alpha", "gone"},
+			CreatedAt:  now.Add(time.Duration(i) * time.Second),
+			UpdatedAt:  now.Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("Add stale delegation %d: %v", i, err)
+		}
+	}
+
+	origin, ok := s.registry.Lookup("alpha")
+	if !ok {
+		t.Fatal("origin node alpha missing from registry")
+	}
+	target, ok := s.registry.Lookup("beta")
+	if !ok {
+		t.Fatal("target node beta missing from registry")
+	}
+	if err := s.checkDelegationCaps(t.Context(), origin, target); err != nil {
+		t.Fatalf("checkDelegationCaps: %v", err)
+	}
+
+	records, err := s.delegations.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, d := range records {
+		if d.Status != hub.DelegationStatusError {
+			t.Fatalf("delegation %q status = %q, want %q", d.ID, d.Status, hub.DelegationStatusError)
+		}
+		if !strings.Contains(d.Error, `target node "gone" is not present in the hub registry`) {
+			t.Fatalf("delegation %q error = %q, want missing-target refresh error", d.ID, d.Error)
+		}
+	}
+
+	total, byOrigin, byTarget, err := s.delegations.ActiveCounts()
+	if err != nil {
+		t.Fatalf("ActiveCounts: %v", err)
+	}
+	if total != 0 || byOrigin[origin.ID] != 0 || byTarget["gone"] != 0 {
+		t.Fatalf("active counts after recovery = total=%d byOrigin=%v byTarget=%v, want all cleared", total, byOrigin, byTarget)
+	}
+}
+
+func TestCheckDelegationCapsRefreshIsTimeBound(t *testing.T) {
+	prevBudget := hubDelegationCapRefreshBudget
+	prevTimeout := hubDelegationCapRefreshTimeout
+	prevParallelism := hubDelegationCapRefreshParallelism
+	prevStaleAfter := hubDelegationCapRefreshErrorStaleAfter
+	hubDelegationCapRefreshBudget = 120 * time.Millisecond
+	hubDelegationCapRefreshTimeout = 40 * time.Millisecond
+	hubDelegationCapRefreshParallelism = 4
+	hubDelegationCapRefreshErrorStaleAfter = 0
+	defer func() {
+		hubDelegationCapRefreshBudget = prevBudget
+		hubDelegationCapRefreshTimeout = prevTimeout
+		hubDelegationCapRefreshParallelism = prevParallelism
+		hubDelegationCapRefreshErrorStaleAfter = prevStaleAfter
+	}()
+
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/chat/v2/runs/") {
+			http.NotFound(w, r)
+			return
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(200 * time.Millisecond):
+			writeJSON(w, http.StatusOK, map[string]any{"id": strings.TrimPrefix(r.URL.Path, "/chat/v2/runs/"), "status": "running"})
+		}
+	}))
+	defer slow.Close()
+
+	nodes := []hub.Node{
+		{ID: "alpha", Name: "Alpha", URL: slow.URL, BasePath: "/chat", Token: "alpha-token", Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work"}},
+		{ID: "beta", Name: "Beta", URL: slow.URL, BasePath: "/chat", Token: "beta-token", Delegation: &hub.DelegationPolicy{Enabled: true, Workdir: "/work", MaxInFlight: 1}},
+	}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: nodes}), nil)
+	s.delegations = hub.NewDelegationStore(filepath.Join(t.TempDir(), "delegations.json"))
+
+	now := time.Now().Add(-time.Minute).UTC()
+	for i := 0; i < 8; i++ {
+		if err := s.delegations.Add(hub.Delegation{
+			ID:         fmt.Sprintf("dlg_slow_%d", i),
+			OriginNode: "alpha",
+			TargetNode: "beta",
+			JobID:      fmt.Sprintf("job_%d", i),
+			RunID:      fmt.Sprintf("run_%d", i),
+			Status:     hub.DelegationStatusRunning,
+			Depth:      1,
+			Chain:      []string{"alpha", "beta"},
+			CreatedAt:  now.Add(time.Duration(i) * time.Second),
+			UpdatedAt:  now.Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("Add slow delegation %d: %v", i, err)
+		}
+	}
+
+	origin, ok := s.registry.Lookup("alpha")
+	if !ok {
+		t.Fatal("origin node alpha missing from registry")
+	}
+	target, ok := s.registry.Lookup("beta")
+	if !ok {
+		t.Fatal("target node beta missing from registry")
+	}
+
+	start := time.Now()
+	err := s.checkDelegationCaps(t.Context(), origin, target)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("checkDelegationCaps unexpectedly succeeded with all active records still running")
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("checkDelegationCaps took %v, want bounded parallel refresh under 300ms", elapsed)
+	}
+}


### PR DESCRIPTION
## What changed

- Bounded the delegation cap recovery path in `checkDelegationCaps` by refreshing active delegations with:
  - a short overall budget,
  - per-refresh child deadlines, and
  - parallel workers instead of serial polling.
- Prioritized refreshes for records most likely to unblock the current request first (same target, then same origin, then other active records; oldest first within each bucket).
- When a cap-recovery refresh fails irrecoverably because the target node is gone from the hub registry, the delegation is now marked terminal (`error`) so it no longer consumes in-flight caps forever.
- Added a conservative stale-age escape hatch so very old active records that keep failing refreshes can eventually be terminalized instead of wedging the ledger forever.
- Added tests covering:
  - recovery from stale active records whose target was removed, and
  - the refresh path staying time-bounded instead of serially waiting through many slow polls.

## Why this is high-value

This fixes a real request-path reliability problem in delegation creation.

Previously, once caps appeared full, the hub synchronously walked every non-terminal delegation record and polled each target one-by-one. On slow or unreachable nodes that could block a create request for a long time, and stale records for removed targets were never cleared because refresh errors were discarded. That meant caps could stay permanently exhausted until someone manually edited the ledger.

After this change, cap recovery is aggressively bounded and missing-target records are converted to terminal errors, so the hub can recover automatically from a common stale-ledger failure mode without wedging future delegations.

## Validation

- `gofmt -w cmd/serve_hub_delegations_state.go cmd/serve_hub_delegations_test.go`
- `go build ./...`
- `go test ./...`
- Added/ran targeted tests:
  - `TestCheckDelegationCapsRecoversMissingTargetRecords`
  - `TestCheckDelegationCapsRefreshIsTimeBound`
- `git diff --check`
