### PR TITLE
fix: `gitShowIndex` reads entire tracked blobs into memory before enforcing size caps

### DIFF
--- a/internal/tools/file_track_test.go
+++ b/internal/tools/file_track_test.go
@@ -351,6 +351,50 @@ func TestShellToolGitFallback(t *testing.T) {
 	}
 }
 
+func TestShellToolGitFallbackRespectsMaxFileBytes(t *testing.T) {
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git unavailable, skipping: %v (%s)", err, out)
+		}
+	}
+	runGit("init")
+
+	large := filepath.Join(dir, "large.txt")
+	if err := os.WriteFile(large, []byte(strings.Repeat("a", 200)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "large.txt")
+	runGit("commit", "-m", "init")
+
+	recorder := &fakeFileRecorder{maxFileBytes: 64}
+	tool := NewShellTool(nil, nil, DefaultOutputLimits())
+	tool.recorder = recorder
+
+	args, _ := json.Marshal(ShellArgs{
+		Command:    `awk 'BEGIN { for (i = 0; i < 200; i++) printf "b"; printf "\n" }' > large.txt`,
+		WorkingDir: dir,
+	})
+	if _, err := tool.Execute(trackingContext(), args); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := recorder.findRecord(t, large)
+	if !rec.BeforeUnknown || !rec.AfterUnknown {
+		t.Fatalf("large tracked file should stay metadata-only, got %+v", rec)
+	}
+	if rec.Before != nil || rec.After != nil {
+		t.Fatalf("large tracked file content must not be captured, got %+v", rec)
+	}
+	if rec.AfterSizeHint <= int64(recorder.maxFileBytes) {
+		t.Fatalf("after size hint = %d, want > %d", rec.AfterSizeHint, recorder.maxFileBytes)
+	}
+}
+
 func TestShellToolSkipsGitIgnoredAffectedPathMatches(t *testing.T) {
 	dir := t.TempDir()
 	runGit := func(args ...string) {

--- a/internal/tools/shell_track.go
+++ b/internal/tools/shell_track.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -452,8 +453,26 @@ func gitShowIndex(ctx context.Context, root, absPath string, maxBytes int) ([]by
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", "-C", root, "show", ":"+filepath.ToSlash(rel))
-	out, err := cmd.Output()
-	if err != nil || len(out) > maxBytes {
+	cmd.Stderr = io.Discard
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, false
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, false
+	}
+
+	out, err := io.ReadAll(io.LimitReader(stdout, int64(maxBytes)+1))
+	if err != nil {
+		_ = cmd.Wait()
+		return nil, false
+	}
+	if len(out) > maxBytes {
+		cancel()
+		_ = cmd.Wait()
+		return nil, false
+	}
+	if err := cmd.Wait(); err != nil {
 		return nil, false
 	}
 	return out, true


### PR DESCRIPTION
## What changed

- Reworked `gitShowIndex` in `internal/tools/shell_track.go` to stream `git show :<path>` output through `StdoutPipe` and `io.LimitReader(maxBytes+1)` instead of calling `cmd.Output()`.
- If the tracked blob exceeds the per-file cap, the code now cancels the git command and returns `ok=false` before buffering the entire blob in memory.
- Added a shell tracking test covering the git-fallback path for a clean tracked file whose contents exceed `maxFileBytes`, ensuring the change still degrades to metadata-only recording.

## Why this is high-value

`buildChangeRecord` uses `gitShowIndex` to recover pre-edit contents for clean tracked files. Before this change, that path bypassed the surrounding snapshot protections by materializing the full blob in memory first and only then checking `len(out) > maxBytes`.

That meant a shell command touching a very large tracked file could cause a large one-shot allocation, extra copy work, and latency spikes in a long-lived Jarvis process, despite the file-tracking code otherwise being careful about per-file and per-call budgets. Streaming only up to `maxBytes+1` keeps the existing behavior while capping work and memory to the configured limit.

## Validation

- `gofmt -w internal/tools/shell_track.go internal/tools/file_track_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
