### PR TITLE
fix: Shell file tracking runs full-repo `git status` twice on every shell tool call

### DIFF
--- a/internal/tools/file_track_test.go
+++ b/internal/tools/file_track_test.go
@@ -351,6 +351,57 @@ func TestShellToolGitFallback(t *testing.T) {
 	}
 }
 
+func TestShellToolGitAffectedPathsBoundTracking(t *testing.T) {
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git unavailable, skipping: %v (%s)", err, out)
+		}
+	}
+	runGit("init")
+	hinted := filepath.Join(dir, "hinted.txt")
+	outside := filepath.Join(dir, "outside.txt")
+	if err := os.WriteFile(hinted, []byte("before\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("outside-before\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "init")
+
+	recorder := &fakeFileRecorder{}
+	tool := NewShellTool(nil, nil, DefaultOutputLimits())
+	tool.recorder = recorder
+
+	args, _ := json.Marshal(ShellArgs{
+		Command:       "echo after > hinted.txt && echo outside-after > outside.txt && echo fresh > untracked.txt",
+		WorkingDir:    dir,
+		AffectedPaths: []string{"hinted.txt"},
+	})
+	output, err := tool.Execute(trackingContext(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(output.FileChanges) != 1 {
+		t.Fatalf("file changes = %+v, want only hinted.txt", output.FileChanges)
+	}
+
+	rec := recorder.findRecord(t, hinted)
+	if string(rec.Before) != "before\n" || string(rec.After) != "after\n" {
+		t.Fatalf("hinted record = %q → %q", rec.Before, rec.After)
+	}
+	for _, rec := range recorder.recorded() {
+		if canonicalTestPath(rec.Path) != canonicalTestPath(hinted) {
+			t.Fatalf("unexpected record outside affected_paths: %+v", rec)
+		}
+	}
+}
+
 func TestShellToolSkipsGitIgnoredAffectedPathMatches(t *testing.T) {
 	dir := t.TempDir()
 	runGit := func(args ...string) {

--- a/internal/tools/shell_track.go
+++ b/internal/tools/shell_track.go
@@ -35,18 +35,20 @@ type shellSnapshotEntry struct {
 }
 
 // shellSnapshot holds the pre-exec state used to detect file changes made by
-// a shell command. Three layers feed it: declared affected_paths globs, the
-// session's already-tracked paths, and git status when inside a repository.
+// a shell command. Three layers can feed it: declared affected_paths globs,
+// the session's already-tracked paths, and a repo-wide git-status fallback
+// when no narrower hints exist.
 type shellSnapshot struct {
-	sessionID    string
-	workDir      string
-	patterns     []string
-	files        map[string]*shellSnapshotEntry
-	gitRoot      string
-	gitStatus    map[string]string // absolute path -> porcelain XY status
-	contentReads int
-	contentBytes int64
-	maxFileBytes int
+	sessionID            string
+	workDir              string
+	patterns             []string
+	files                map[string]*shellSnapshotEntry
+	gitRoot              string
+	gitStatus            map[string]string // absolute path -> porcelain XY status
+	useGitStatusFallback bool
+	contentReads         int
+	contentBytes         int64
+	maxFileBytes         int
 }
 
 // canReadContent reports whether a file of the given size may have its
@@ -85,9 +87,16 @@ func preShellSnapshot(ctx context.Context, recorder FileChangeRecorder, workDir 
 		maxFileBytes: recorder.MaxFileBytes(),
 	}
 
+	var sessionPaths []string
 	if repo := DetectGitRepo(workDir); repo.IsRepo {
 		snap.gitRoot = repo.Root
-		snap.gitStatus = gitStatusPorcelain(ctx, repo.Root)
+		sessionPaths = recorder.SessionPaths(ctx, sessionID)
+		if !hasShellTrackingHints(patterns, sessionPaths) {
+			snap.useGitStatusFallback = true
+			snap.gitStatus = gitStatusPorcelain(ctx, repo.Root)
+		}
+	} else {
+		sessionPaths = recorder.SessionPaths(ctx, sessionID)
 	}
 
 	candidates := expandShellPatterns(workDir, patterns)
@@ -110,7 +119,7 @@ func preShellSnapshot(ctx context.Context, recorder FileChangeRecorder, workDir 
 			candidates = append(candidates, path)
 		}
 	}
-	candidates = append(candidates, recorder.SessionPaths(ctx, sessionID)...)
+	candidates = append(candidates, sessionPaths...)
 	for _, path := range candidates {
 		if _, seen := snap.files[path]; seen {
 			continue
@@ -155,7 +164,7 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 	}
 
 	var postStatus map[string]string
-	if snap.gitRoot != "" {
+	if snap.gitRoot != "" && snap.useGitStatusFallback {
 		postStatus = gitStatusPorcelain(ctx, snap.gitRoot)
 		for path := range gitChangedPaths(snap.gitStatus, postStatus) {
 			if _, seen := candidates[path]; !seen {
@@ -322,6 +331,18 @@ func expandShellPatterns(workDir string, patterns []string) []string {
 		}, doublestar.WithNoFollow())
 	}
 	return paths
+}
+
+func hasShellTrackingHints(patterns, sessionPaths []string) bool {
+	if len(sessionPaths) > 0 {
+		return true
+	}
+	for _, pattern := range patterns {
+		if strings.TrimSpace(pattern) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // gitIgnoredCandidates returns the subset of paths ignored by Git. It uses


### PR DESCRIPTION
## What changed

- Skip the repo-wide `git status --porcelain -z --untracked-files=all` fallback when shell tracking already has narrower hints from `affected_paths` or session-tracked paths.
- Keep the existing full-repo git-status fallback for the no-hints case, so shell calls without any narrower candidate set still detect clean tracked, dirty tracked, and untracked repo changes.
- Added a regression test covering the bounded-tracking behavior when `affected_paths` is present in a git repo, while keeping the existing no-hints git fallback test.

## Why this is high-value

`shell` is a very hot tool path, and before this change every invocation inside a git repo paid for two whole-repo status scans: once before `cmd.Run` and once after. In large repos that work can dominate end-to-end tool latency.

This change removes both full-repo scans for the common case where the tool already has a bounded candidate set from `affected_paths` or prior session tracking. That cuts unnecessary subprocess work, repo traversal, and output parsing on every shell call, while preserving the broader best-effort fallback for shell commands that provide no narrower hints at all.

## Validation

- `gofmt -w internal/tools/shell_track.go internal/tools/file_track_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
