### PR TITLE
fix: Response-run SSE subscribers are hard-dropped on brief backpressure, truncating live web streams

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -569,14 +569,24 @@ func (r *responseRun) subscribe(after int64) responseRunSubscribeResult {
 	return responseRunSubscribeResult{id: id, replay: replay, ch: ch}
 }
 
-func (r *responseRun) subscriberWasDropped(id int) bool {
+func (r *responseRun) droppedSubscriberTerminalPayload(id int) (map[string]any, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.subscriberDropped[id] {
-		return false
+		return nil, false
 	}
 	delete(r.subscriberDropped, id)
-	return true
+	return map[string]any{
+		"response_id":      r.id,
+		"status":           r.status,
+		"sequence_number":  r.lastSequenceNumber,
+		"min_replay_after": r.minReplayAfter,
+		"error": map[string]any{
+			"type":    "stream_buffer_overflow",
+			"message": "live response stream fell behind; reconnect with the last received sequence number or fetch the response snapshot if replay is no longer available",
+		},
+		"recovery": r.recoveryPayloadLocked(),
+	}, true
 }
 
 func (r *responseRun) unsubscribe(ch <-chan responseRunEvent) {
@@ -1582,6 +1592,14 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 		flusher.Flush()
 	}
+	writeDropped := func(payload map[string]any) {
+		stopKeepalive()
+		if err := writeSSEEvent(w, "response.stream_error", payload); err != nil {
+			return
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}
 
 	if len(replay) > 0 {
 		pingMu.Lock()
@@ -1611,7 +1629,8 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 			return
 		case ev, ok := <-ch:
 			if !ok {
-				if run.subscriberWasDropped(subscriberID) {
+				if payload, dropped := run.droppedSubscriberTerminalPayload(subscriberID); dropped {
+					writeDropped(payload)
 					return
 				}
 				writeDone()
@@ -1642,7 +1661,8 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 				return
 			}
 			if closed {
-				if run.subscriberWasDropped(subscriberID) {
+				if payload, dropped := run.droppedSubscriberTerminalPayload(subscriberID); dropped {
+					writeDropped(payload)
 					return
 				}
 				writeDone()

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -652,7 +653,7 @@ func waitForResponseRunCondition(t *testing.T, timeout time.Duration, fn func() 
 	t.Fatal(message)
 }
 
-func TestStreamResponseRunEventsDoesNotWriteDoneWhenSubscriberOverflows(t *testing.T) {
+func TestStreamResponseRunEventsEmitsStructuredErrorWhenSubscriberOverflows(t *testing.T) {
 	srv := &serveServer{shutdownCh: make(chan struct{})}
 	run := newResponseRun("resp_overflow", "sess_test", "", "mock", time.Now().Unix(), func() {})
 	gate := make(chan struct{})
@@ -702,7 +703,50 @@ func TestStreamResponseRunEventsDoesNotWriteDoneWhenSubscriberOverflows(t *testi
 	if !strings.Contains(body, "event: response.output_text.delta\n") {
 		t.Fatalf("stream body missing replayed delta events: %q", body)
 	}
-	if strings.Contains(body, "data: [DONE]\n\n") {
-		t.Fatalf("overflowed stream should not emit [DONE], got: %q", body)
+
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	sawStreamError := false
+	sawDone := false
+	for {
+		eventName, data, ok := readSSEEvent(t, scanner)
+		if !ok {
+			break
+		}
+		if data == "[DONE]" {
+			sawDone = true
+			break
+		}
+		if eventName != "response.stream_error" {
+			continue
+		}
+		sawStreamError = true
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			t.Fatalf("unmarshal stream error payload: %v", err)
+		}
+		if got := payload["response_id"]; got != run.id {
+			t.Fatalf("response_id = %v, want %q", got, run.id)
+		}
+		if got := payload["status"]; got != "completed" {
+			t.Fatalf("status = %v, want completed", got)
+		}
+		errPayload, _ := payload["error"].(map[string]any)
+		if got := errPayload["type"]; got != "stream_buffer_overflow" {
+			t.Fatalf("error.type = %v, want stream_buffer_overflow", got)
+		}
+		wantSequence := float64(defaultResponseRunSubscriberBuffer + 17)
+		if got := payload["sequence_number"]; got != wantSequence {
+			t.Fatalf("sequence_number = %v, want %v", got, wantSequence)
+		}
+		recovery, _ := payload["recovery"].(map[string]any)
+		if got := recovery["sequence_number"]; got != wantSequence {
+			t.Fatalf("recovery.sequence_number = %v, want %v", got, wantSequence)
+		}
+	}
+	if !sawStreamError {
+		t.Fatalf("overflowed stream missing response.stream_error: %q", body)
+	}
+	if !sawDone {
+		t.Fatalf("overflowed stream missing [DONE]: %q", body)
 	}
 }


### PR DESCRIPTION
## What changed

- Kept the existing overflow/drop behavior in `storeEventLocked`, but stopped treating it as a silent EOF on the SSE endpoint.
- Added `droppedSubscriberTerminalPayload` so an overflowed subscriber now gets a final `response.stream_error` SSE event with:
  - `error.type = stream_buffer_overflow`
  - current `sequence_number`
  - `min_replay_after`
  - `recovery` payload for resuming cleanly
- Updated `streamResponseRunEvents` to emit that terminal event and then write `[DONE]` instead of returning abruptly when a subscriber channel was closed due to overflow.
- Replaced the old overflow test expectation with a test that verifies the stream now emits both the structured terminal error and `[DONE]`.

## Why this is high-value

Today, a brief slow-client or proxy hiccup can fill the fixed per-subscriber buffer, close the live SSE stream, and make the browser/API client see an abrupt truncation even though the response run continues. That is directly user-visible and looks like flaky streaming.

This change is intentionally small and low-risk: it does not alter run execution or replay storage, and it does not change the existing overflow decision in the broadcaster. It fixes the reliability problem at the user boundary by turning a silent mid-stream death into an explicit recoverable terminal event that tells the client how to resume.

## Validation

- `gofmt -w cmd/serve_response_runs.go cmd/serve_response_runs_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
