### PR TITLE
feat: surface sessions on Hub nodes

### DIFF
--- a/cmd/serve_hub_nodes.go
+++ b/cmd/serve_hub_nodes.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/hub"
@@ -18,22 +20,43 @@ type hubNodeDiagnostic struct {
 	Message  string `json:"message"`
 }
 
+type hubNodeSessionView struct {
+	ID            string `json:"id"`
+	ShortTitle    string `json:"short_title"`
+	LongTitle     string `json:"long_title,omitempty"`
+	ActiveRun     bool   `json:"active_run,omitempty"`
+	LastMessageAt int64  `json:"last_message_at,omitempty"`
+	MessageCount  int    `json:"message_count,omitempty"`
+	ResumePath    string `json:"resume_path"`
+}
+
+type hubNodeSessionsView struct {
+	CountLabel  string               `json:"count_label"`
+	HasMore     bool                 `json:"has_more,omitempty"`
+	ActiveCount int                  `json:"active_count,omitempty"`
+	Active      []hubNodeSessionView `json:"active,omitempty"`
+	Recent      []hubNodeSessionView `json:"recent,omitempty"`
+	ResumePath  string               `json:"resume_path,omitempty"`
+}
+
 // hubNodeView is the public record for one node. It deliberately omits the
 // bearer token: tokens are injected server-side and must never be sent to a
 // hub client.
 type hubNodeView struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Source     string `json:"source"`
-	Connection string `json:"connection"`
-	URL        string `json:"url"`
-	BasePath   string `json:"base_path"`
-	ProxyPath  string `json:"proxy_path"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Source         string `json:"source"`
+	Connection     string `json:"connection"`
+	URL            string `json:"url"`
+	BasePath       string `json:"base_path"`
+	ProxyPath      string `json:"proxy_path"`
+	NewSessionPath string `json:"new_session_path"`
 	// HasToken reports whether the hub holds a bearer token for this node
 	// (without it, a token-guarded node will answer 401 through the proxy).
-	HasToken    bool                `json:"has_token"`
-	Status      hub.Status          `json:"status"`
-	Diagnostics []hubNodeDiagnostic `json:"diagnostics,omitempty"`
+	HasToken    bool                 `json:"has_token"`
+	Status      hub.Status           `json:"status"`
+	Sessions    *hubNodeSessionsView `json:"sessions,omitempty"`
+	Diagnostics []hubNodeDiagnostic  `json:"diagnostics,omitempty"`
 }
 
 func (s *hubServer) handleHubHealth(w http.ResponseWriter, r *http.Request) {
@@ -50,16 +73,18 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 	statuses := s.prober.ProbeAll(probeCtx, nodes)
 	views := make([]hubNodeView, 0, len(nodes))
 	for _, n := range nodes {
+		proxyPath := s.hubPath("/node/" + n.ID + "/")
 		view := hubNodeView{
-			ID:         n.ID,
-			Name:       n.Name,
-			Source:     n.Source,
-			Connection: n.Connection,
-			URL:        n.URL,
-			BasePath:   n.BasePath,
-			ProxyPath:  s.hubPath("/node/" + n.ID + "/"),
-			HasToken:   n.Token != "",
-			Status:     statuses[n.ID],
+			ID:             n.ID,
+			Name:           n.Name,
+			Source:         n.Source,
+			Connection:     n.Connection,
+			URL:            n.URL,
+			BasePath:       n.BasePath,
+			ProxyPath:      proxyPath,
+			NewSessionPath: proxyPath + "?new=1",
+			HasToken:       n.Token != "",
+			Status:         statuses[n.ID],
 		}
 		if n.UsesReverseConnection() {
 			connected, connectedAt, lastSeen := s.reverse.status(n.ID)
@@ -71,10 +96,181 @@ func (s *hubServer) collectNodes(ctx context.Context) ([]hubNodeView, error) {
 		}
 		views = append(views, view)
 	}
+	s.collectNodeSessionViews(probeCtx, nodes, views)
 	for i := range views {
 		views[i].Diagnostics = hubNodeDiagnostics(nodes[i], views[i], nodes)
 	}
 	return views, err
+}
+
+const (
+	hubNodeSessionActiveLimit = 2
+	hubNodeSessionRecentLimit = 3
+	hubNodeSessionCountCap    = 100
+	hubNodeSessionsMaxBytes   = 1 << 20
+)
+
+type hubNodeSessionStatus struct {
+	ID            string `json:"id"`
+	ShortTitle    string `json:"short_title"`
+	LongTitle     string `json:"long_title"`
+	ActiveRun     bool   `json:"active_run"`
+	LastMessageAt int64  `json:"last_message_at"`
+	MessageCount  int    `json:"message_count"`
+}
+
+// collectNodeSessionViews enriches reachable nodes with a bounded session
+// summary. The node endpoint already caps itself at 100 rows, so the Hub can
+// show "100+ sessions" without issuing exact count queries on every refresh.
+func (s *hubServer) collectNodeSessionViews(ctx context.Context, nodes []hub.Node, views []hubNodeView) {
+	if len(nodes) == 0 || len(nodes) != len(views) {
+		return
+	}
+	sessionCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	type result struct {
+		index    int
+		sessions *hubNodeSessionsView
+	}
+	results := make(chan result, len(nodes))
+	var wg sync.WaitGroup
+	for i, n := range nodes {
+		if !views[i].Status.Reachable {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, n hub.Node) {
+			defer wg.Done()
+			sessions, err := s.fetchHubNodeSessions(sessionCtx, n)
+			if err != nil || sessions == nil {
+				return
+			}
+			results <- result{index: i, sessions: sessions}
+		}(i, n)
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+	for res := range results {
+		views[res.index].Sessions = res.sessions
+	}
+}
+
+func (s *hubServer) fetchHubNodeSessions(ctx context.Context, n hub.Node) (*hubNodeSessionsView, error) {
+	req, err := s.newHubNodeSessionsRequest(ctx, n)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.doHubNodeRequest(ctx, n, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("sessions status returned %s", resp.Status)
+	}
+	var body struct {
+		Sessions []hubNodeSessionStatus `json:"sessions"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, hubNodeSessionsMaxBytes)).Decode(&body); err != nil {
+		return nil, err
+	}
+	if body.Sessions == nil {
+		return nil, nil
+	}
+	return s.buildHubNodeSessionsView(n, body.Sessions), nil
+}
+
+func (s *hubServer) newHubNodeSessionsRequest(ctx context.Context, n hub.Node) (*http.Request, error) {
+	if n.UsesReverseConnection() {
+		u := &url.URL{
+			Scheme: "http",
+			Host:   "reverse.local",
+			Path:   hubJoinBasePath(n.BasePath, "/v1/sessions/status"),
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		if n.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+n.Token)
+		}
+		return req, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, n.BaseURL()+"/v1/sessions/status", nil)
+	if err != nil {
+		return nil, err
+	}
+	if n.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+n.Token)
+	}
+	return req, nil
+}
+
+func (s *hubServer) doHubNodeRequest(ctx context.Context, n hub.Node, req *http.Request) (*http.Response, error) {
+	if n.UsesReverseConnection() {
+		return s.reverse.do(ctx, n, req)
+	}
+	return s.prober.Client.Do(req)
+}
+
+func (s *hubServer) buildHubNodeSessionsView(n hub.Node, entries []hubNodeSessionStatus) *hubNodeSessionsView {
+	out := &hubNodeSessionsView{
+		CountLabel: hubNodeSessionCountLabel(len(entries)),
+		HasMore:    len(entries) >= hubNodeSessionCountCap,
+	}
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.ID) == "" {
+			continue
+		}
+		sess := hubNodeSessionView{
+			ID:            entry.ID,
+			ShortTitle:    hubNodeSessionTitle(entry),
+			LongTitle:     strings.TrimSpace(entry.LongTitle),
+			ActiveRun:     entry.ActiveRun,
+			LastMessageAt: entry.LastMessageAt,
+			MessageCount:  entry.MessageCount,
+			ResumePath:    s.hubPath("/node/" + n.ID + "/" + url.PathEscape(entry.ID)),
+		}
+		if sess.ActiveRun {
+			out.ActiveCount++
+			if len(out.Active) < hubNodeSessionActiveLimit {
+				out.Active = append(out.Active, sess)
+			}
+		} else if len(out.Recent) < hubNodeSessionRecentLimit {
+			out.Recent = append(out.Recent, sess)
+		}
+	}
+	if len(out.Active) > 0 {
+		out.ResumePath = out.Active[0].ResumePath
+	} else if len(out.Recent) > 0 {
+		out.ResumePath = out.Recent[0].ResumePath
+	}
+	return out
+}
+
+func hubNodeSessionTitle(entry hubNodeSessionStatus) string {
+	for _, candidate := range []string{entry.ShortTitle, entry.LongTitle, entry.ID} {
+		if title := strings.TrimSpace(candidate); title != "" {
+			return title
+		}
+	}
+	return "Untitled session"
+}
+
+func hubNodeSessionCountLabel(n int) string {
+	if n >= hubNodeSessionCountCap {
+		return "100+ sessions"
+	}
+	if n == 1 {
+		return "1 session"
+	}
+	return fmt.Sprintf("%d sessions", n)
 }
 
 func (s *hubServer) probeReverseNode(ctx context.Context, n hub.Node, connectedAt, lastSeen time.Time) hub.Status {

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -77,6 +78,62 @@ func TestHubReverseNodeProxy(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"agent":"artist"`) {
 		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestHubReverseNodeSessionsSummary(t *testing.T) {
+	var sessionsAuth string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/chat/healthz":
+			_, _ = w.Write([]byte(`{"status":"ok","agent":"artist","capabilities":["web"]}`))
+		case "/chat/v1/sessions/status":
+			sessionsAuth = r.Header.Get("Authorization")
+			_ = json.NewEncoder(w).Encode(map[string]any{"sessions": []map[string]any{{
+				"id":              "sess_reverse",
+				"short_title":     "Reverse session",
+				"active_run":      true,
+				"last_message_at": 1_800_000_000_000,
+				"message_count":   4,
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer backend.Close()
+
+	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
+	hubTS := httptest.NewServer(s.handler())
+	defer hubTS.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	waitForReverseNode(t, s, "artist")
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/nodes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", rec.Code, rec.Body.String())
+	}
+	if sessionsAuth != "Bearer node-token" {
+		t.Fatalf("sessions Authorization = %q, want node token injection", sessionsAuth)
+	}
+
+	var resp struct {
+		Nodes []hubNodeView `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Nodes) != 1 || resp.Nodes[0].Sessions == nil {
+		t.Fatalf("nodes response = %+v", resp.Nodes)
+	}
+	sessions := resp.Nodes[0].Sessions
+	if sessions.CountLabel != "1 session" || sessions.ActiveCount != 1 || sessions.ResumePath != "/node/artist/sess_reverse" {
+		t.Fatalf("sessions summary = %+v", sessions)
 	}
 }
 

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -1016,6 +1016,97 @@ func TestHubBareNodePathRedirects(t *testing.T) {
 	}
 }
 
+func TestHubNodesAPIIncludesBoundedSessionSummary(t *testing.T) {
+	var sessionsAuth string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/chat/healthz":
+			io.WriteString(w, `{"status":"ok","agent":"alpha-agent","version":"v1","capabilities":["web"]}`)
+		case "/chat/v1/sessions/status":
+			sessionsAuth = r.Header.Get("Authorization")
+			type sess struct {
+				ID            string `json:"id"`
+				ShortTitle    string `json:"short_title"`
+				LongTitle     string `json:"long_title"`
+				ActiveRun     bool   `json:"active_run,omitempty"`
+				LastMessageAt int64  `json:"last_message_at"`
+				MessageCount  int    `json:"message_count"`
+			}
+			sessions := make([]sess, 0, 100)
+			for i := 0; i < 100; i++ {
+				sessions = append(sessions, sess{
+					ID:            fmt.Sprintf("sess_%03d", i),
+					ShortTitle:    fmt.Sprintf("Session %03d", i),
+					LastMessageAt: int64(1_800_000_000_000 - i),
+					MessageCount:  i + 1,
+				})
+			}
+			sessions[5].ID = "sess_busy"
+			sessions[5].ShortTitle = "Busy session"
+			sessions[5].ActiveRun = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"sessions": sessions})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer backend.Close()
+
+	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{{
+		ID:       "alpha",
+		Name:     "Alpha",
+		Source:   hub.SourceConfig,
+		URL:      backend.URL,
+		BasePath: "/chat",
+		Token:    "node-token",
+	}}}), nil)
+	s.basePath = "/hub"
+
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hub/api/nodes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "node-token") {
+		t.Fatal("node token leaked into /api/nodes response")
+	}
+	if sessionsAuth != "Bearer node-token" {
+		t.Fatalf("sessions Authorization = %q, want node token injection", sessionsAuth)
+	}
+
+	var resp struct {
+		Nodes []hubNodeView `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Nodes) != 1 {
+		t.Fatalf("nodes = %+v", resp.Nodes)
+	}
+	n := resp.Nodes[0]
+	if n.NewSessionPath != "/hub/node/alpha/?new=1" {
+		t.Fatalf("new session path = %q", n.NewSessionPath)
+	}
+	if n.Sessions == nil {
+		t.Fatalf("sessions summary missing: %+v", n)
+	}
+	if n.Sessions.CountLabel != "100+ sessions" || !n.Sessions.HasMore {
+		t.Fatalf("session count = %q has_more=%v", n.Sessions.CountLabel, n.Sessions.HasMore)
+	}
+	if len(n.Sessions.Active) != 1 || n.Sessions.Active[0].ID != "sess_busy" || n.Sessions.ActiveCount != 1 {
+		t.Fatalf("active sessions = %+v active_count=%d", n.Sessions.Active, n.Sessions.ActiveCount)
+	}
+	if n.Sessions.ResumePath != "/hub/node/alpha/sess_busy" {
+		t.Fatalf("resume path = %q", n.Sessions.ResumePath)
+	}
+	if len(n.Sessions.Recent) != 3 || n.Sessions.Recent[0].ID != "sess_000" {
+		t.Fatalf("recent sessions = %+v", n.Sessions.Recent)
+	}
+	if n.Sessions.Recent[0].ResumePath != "/hub/node/alpha/sess_000" {
+		t.Fatalf("recent resume path = %q", n.Sessions.Recent[0].ResumePath)
+	}
+}
+
 func TestHubNodesAPIDoesNotLeakTokens(t *testing.T) {
 	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/templates/hub.css
+++ b/cmd/templates/hub.css
@@ -82,6 +82,7 @@ body {
 .hub-btn.danger { color: var(--down); }
 .hub-btn.danger:hover { border-color: var(--down); }
 .hub-btn.small { padding: 0.24rem 0.55rem; font-size: 0.78rem; border-radius: 7px; }
+.hub-btn.disabled, .hub-btn[aria-disabled="true"] { opacity: 0.55; pointer-events: none; cursor: not-allowed; }
 
 .hub-main { padding: 1.4rem; max-width: 1180px; margin: 0 auto; }
 
@@ -113,6 +114,17 @@ body {
 
 .node-card-head { display: flex; align-items: center; gap: 0.55rem; }
 .node-name { margin: 0; font-size: 1.02rem; font-weight: 700; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.node-summary-line { color: var(--muted); font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-count-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.12rem 0.55rem;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border));
+  color: var(--accent);
+  flex-shrink: 0;
+}
 
 .status-dot {
   width: 10px;
@@ -157,6 +169,56 @@ body {
   border: 1px solid var(--border);
   color: var(--muted);
 }
+
+.node-sessions {
+  display: grid;
+  gap: 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-2) 68%, transparent);
+  padding: 0.7rem;
+}
+.node-session-group { display: grid; gap: 0.3rem; }
+.node-session-label {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.node-session-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  align-items: baseline;
+  color: var(--text);
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  padding: 0.36rem 0.45rem;
+  margin: 0 -0.1rem;
+}
+.node-session-row:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.node-session-row.is-active {
+  border-color: color-mix(in srgb, var(--ok) 55%, var(--border));
+  background: color-mix(in srgb, var(--ok) 9%, transparent);
+}
+.node-session-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 650;
+}
+.node-session-meta {
+  color: var(--muted);
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+.node-session-empty { color: var(--muted); font-size: 0.84rem; }
 
 .node-error { color: var(--down); font-size: 0.82rem; word-break: break-word; }
 .node-warn { color: var(--warn); font-size: 0.82rem; }

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -207,37 +207,116 @@ term-llm serve hub</code></pre>
       parent.appendChild(box);
     };
 
+    const relativeSessionTime = (ms) => {
+      const t = Number(ms);
+      if (!Number.isFinite(t) || t <= 0) return '';
+      const diff = Math.max(0, Date.now() - t);
+      const minute = 60 * 1000;
+      const hour = 60 * minute;
+      const day = 24 * hour;
+      if (diff < minute) return 'just now';
+      if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
+      if (diff < day) return `${Math.floor(diff / hour)}h ago`;
+      if (diff < 7 * day) return `${Math.floor(diff / day)}d ago`;
+      return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    };
+
+    const sessionMessageCountLabel = (count) => {
+      const n = Number(count);
+      if (!Number.isFinite(n) || n <= 0) return '';
+      return `${n} ${n === 1 ? 'message' : 'messages'}`;
+    };
+
+    const sessionMetaText = (session, { active = false } = {}) => {
+      const parts = [];
+      if (active || session.active_run) parts.push('active now');
+      const rel = relativeSessionTime(session.last_message_at);
+      if (rel) parts.push(rel);
+      const count = sessionMessageCountLabel(session.message_count);
+      if (count) parts.push(count);
+      return parts.join(' · ');
+    };
+
+    const nodeResumePath = (n) => {
+      const sessions = n.sessions || {};
+      return sessions.resume_path
+        || (Array.isArray(sessions.active) && sessions.active[0] && sessions.active[0].resume_path)
+        || (Array.isArray(sessions.recent) && sessions.recent[0] && sessions.recent[0].resume_path)
+        || '';
+    };
+
+    const appendNodeSessionGroup = (parent, label, sessions, opts = {}) => {
+      if (!Array.isArray(sessions) || !sessions.length) return;
+      const group = el('div', 'node-session-group');
+      group.appendChild(el('div', 'node-session-label', label));
+      sessions.forEach((session) => {
+        const row = el('a', `node-session-row${opts.active ? ' is-active' : ''}`);
+        row.href = session.resume_path || '#';
+        row.title = session.long_title || session.short_title || session.id || 'Session';
+        const title = el('span', 'node-session-title', session.short_title || session.long_title || session.id || 'Untitled session');
+        const meta = el('span', 'node-session-meta', sessionMetaText(session, { active: opts.active }));
+        row.appendChild(title);
+        row.appendChild(meta);
+        group.appendChild(row);
+      });
+      parent.appendChild(group);
+    };
+
+    const appendNodeSessions = (card, n) => {
+      const box = el('div', 'node-sessions');
+      const sessions = n.sessions;
+      if (!sessions) {
+        const reachable = Boolean((n.status || {}).reachable);
+        box.appendChild(el('div', 'node-session-empty', reachable ? 'Sessions unavailable' : 'Sessions unavailable while offline'));
+        card.appendChild(box);
+        return;
+      }
+
+      const active = Array.isArray(sessions.active) ? sessions.active : [];
+      const recent = Array.isArray(sessions.recent) ? sessions.recent : [];
+      appendNodeSessionGroup(box, 'Active', active, { active: true });
+      if (active.length) {
+        appendNodeSessionGroup(box, 'Recent', recent);
+      } else if (recent.length) {
+        appendNodeSessionGroup(box, 'Last session', recent.slice(0, 1));
+        appendNodeSessionGroup(box, 'Recent', recent.slice(1));
+      }
+      if (!active.length && !recent.length) {
+        box.appendChild(el('div', 'node-session-empty', 'No sessions yet'));
+      }
+      card.appendChild(box);
+    };
+
     const renderNode = (n) => {
+      const status = n.status || {};
       const card = el('article', 'node-card');
       const head = el('div', 'node-card-head');
-      const dotClass = n.status.reachable ? 'ok' : 'down';
+      const dotClass = status.reachable ? 'ok' : 'down';
       const dot = el('span', `status-dot ${dotClass}`);
-      dot.title = n.status.reachable ? 'Reachable' : (n.status.error || 'Unreachable');
+      dot.title = status.reachable ? 'Reachable' : (status.error || 'Unreachable');
       head.appendChild(dot);
       head.appendChild(el('h2', 'node-name', n.name));
+      if (n.sessions && n.sessions.count_label) {
+        head.appendChild(el('span', 'session-count-badge', n.sessions.count_label));
+      }
       head.appendChild(el('span', `source-badge source-${n.source}`, n.source));
       card.appendChild(head);
 
-      const meta = el('dl', 'node-meta');
-      const row = (label, value) => {
-        if (!value) return;
-        meta.appendChild(el('dt', '', label));
-        meta.appendChild(el('dd', '', value));
-      };
-      row('ID', n.id);
-      row('URL', n.url + (n.base_path || ''));
-      row('Status', n.status.state + (n.status.reachable ? ` · ${n.status.latency_ms} ms` : ''));
-      row('Agent', n.status.agent);
-      row('Version', n.status.version);
-      card.appendChild(meta);
-
-      if (Array.isArray(n.status.capabilities) && n.status.capabilities.length) {
+      const capabilities = Array.isArray(status.capabilities) ? status.capabilities : [];
+      const summaryParts = [status.agent || n.id, status.version, status.state && !status.reachable ? status.state : ''].filter(Boolean);
+      if (summaryParts.length) {
+        card.appendChild(el('div', 'node-summary-line', summaryParts.join(' · ')));
+      }
+      if (capabilities.length) {
         const caps = el('div', 'node-caps');
-        n.status.capabilities.forEach((c) => caps.appendChild(el('span', 'cap-chip', c)));
+        capabilities.forEach((c) => caps.appendChild(el('span', 'cap-chip', c)));
         card.appendChild(caps);
       }
-      if (!n.status.reachable && n.status.error) {
-        card.appendChild(el('div', 'node-error', n.status.error));
+
+      appendNodeSessions(card, n);
+
+      if (!status.reachable && status.error) {
+        card.appendChild(el('div', 'node-error', status.error));
       }
       if (Array.isArray(n.diagnostics) && n.diagnostics.length) {
         const diagList = el('div', 'node-diagnostics');
@@ -251,9 +330,20 @@ term-llm serve hub</code></pre>
       }
 
       const actions = el('div', 'node-actions');
-      const open = el('a', 'hub-btn primary', 'Open');
-      open.href = n.proxy_path;
-      actions.appendChild(open);
+      const resume = el('a', 'hub-btn primary', 'Resume');
+      const resumePath = nodeResumePath(n);
+      if (resumePath) {
+        resume.href = resumePath;
+      } else {
+        resume.href = '#';
+        resume.classList.add('disabled');
+        resume.setAttribute('aria-disabled', 'true');
+        resume.tabIndex = -1;
+      }
+      actions.appendChild(resume);
+      const fresh = el('a', 'hub-btn ghost', 'New');
+      fresh.href = n.new_session_path || `${n.proxy_path}?new=1`;
+      actions.appendChild(fresh);
       if (n.source === 'local') {
         const del = el('button', 'hub-btn danger', 'Remove');
         del.type = 'button';
@@ -319,7 +409,15 @@ term-llm serve hub</code></pre>
         grid.replaceChildren(...nodes.map(renderNode));
         emptyBox.classList.toggle('hidden', nodes.length > 0);
         const up = nodes.filter((n) => n.status.reachable).length;
-        summary.textContent = nodes.length ? `${up}/${nodes.length} nodes reachable` : '';
+        const activeSessions = nodes.reduce((total, n) => {
+          if (!n.sessions) return total;
+          const explicit = Number(n.sessions.active_count);
+          if (Number.isFinite(explicit) && explicit > 0) return total + explicit;
+          return total + (Array.isArray(n.sessions.active) ? n.sessions.active.length : 0);
+        }, 0);
+        summary.textContent = nodes.length
+          ? `${up}/${nodes.length} nodes reachable${activeSessions ? ` · ${activeSessions} active ${activeSessions === 1 ? 'session' : 'sessions'}` : ''}`
+          : '';
         if (data.resolver_error) {
           errorBox.textContent = `Some sources failed to resolve: ${data.resolver_error}`;
           errorBox.classList.remove('hidden');

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
+  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
   splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
@@ -184,6 +184,16 @@ const forceNewSessionFromURL = () => {
   } catch {
     return false;
   }
+};
+
+const clearFreshSessionURL = () => {
+  const target = `${UI_PREFIX}/`;
+  if (typeof history !== 'undefined' && typeof history.replaceState === 'function') {
+    history.replaceState(null, '', target);
+    updateDocumentTitle();
+    return;
+  }
+  updateURL('');
 };
 
 const stageCurrentComposerForSession = (sessionId) => {
@@ -1974,7 +1984,7 @@ const initialize = async () => {
   if (forceNewSession) {
     state.activeSessionId = '';
     state.draftSessionActive = true;
-    updateURL('');
+    clearFreshSessionURL();
   } else if (urlSlug) {
     const found = findSessionBySlug(urlSlug);
     if (found) {

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -177,6 +177,15 @@ const createAndSwitchToFreshSession = async () => {
   await switchToDraftSession({ clearComposer: true, focusPrompt: true });
 };
 
+const forceNewSessionFromURL = () => {
+  try {
+    const params = new URLSearchParams(window.location.search || '');
+    return params.has('new') || params.has('fresh');
+  } catch {
+    return false;
+  }
+};
+
 const stageCurrentComposerForSession = (sessionId) => {
   const prompt = String(elements.promptInput.value || '').trim();
   if (prompt) {
@@ -1960,8 +1969,13 @@ const initialize = async () => {
   state.sessions = loadSessions();
 
   // Check URL for a specific session (number or ID)
-  const urlSlug = sessionIdFromURL();
-  if (urlSlug) {
+  const forceNewSession = forceNewSessionFromURL();
+  const urlSlug = forceNewSession ? '' : sessionIdFromURL();
+  if (forceNewSession) {
+    state.activeSessionId = '';
+    state.draftSessionActive = true;
+    updateURL('');
+  } else if (urlSlug) {
     const found = findSessionBySlug(urlSlug);
     if (found) {
       state.activeSessionId = found.id;

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -290,7 +290,18 @@ async function createSessionsHarness(options = {}) {
     TERM_LLM_SIDEBAR_SESSIONS: 'all',
     TERM_LLM_HUB: options.hub || null,
     location: { pathname: options.pathname || `${options.uiPrefix || '/ui'}/`, search: options.search || '', origin: 'https://example.test', protocol: 'https:', host: 'example.test' },
-    history: { pushState(_state, _title, url) { windowObj.location.pathname = url; } },
+    history: {
+      pushState(_state, _title, url) {
+        const parsed = new URL(url, windowObj.location.origin);
+        windowObj.location.pathname = parsed.pathname;
+        windowObj.location.search = parsed.search;
+      },
+      replaceState(_state, _title, url) {
+        const parsed = new URL(url, windowObj.location.origin);
+        windowObj.location.pathname = parsed.pathname;
+        windowObj.location.search = parsed.search;
+      },
+    },
     matchMedia() {
       return {
         matches: false,
@@ -776,7 +787,7 @@ async function testNumericDeepLinkResolvesRealSessionId() {
 
 async function testNewQueryStartsDraftInsteadOfLastSession() {
   const name = 'new query starts draft instead of resuming last session';
-  const { app } = await createSessionsHarness({
+  const { app, windowObj } = await createSessionsHarness({
     search: '?new=1',
     initialStorage: {
       term_llm_active_session: 'sess_old',
@@ -807,6 +818,10 @@ async function testNewQueryStartsDraftInsteadOfLastSession() {
       draftSessionActive: app.state.draftSessionActive,
       activeSessionId: app.state.activeSessionId,
     }));
+    return;
+  }
+  if (windowObj.location.search !== '') {
+    fail(name, 'expected ?new=1 to be cleared from the address bar', windowObj.location.search);
     return;
   }
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -289,7 +289,7 @@ async function createSessionsHarness(options = {}) {
     TERM_LLM_UI_PREFIX: options.uiPrefix || '/ui',
     TERM_LLM_SIDEBAR_SESSIONS: 'all',
     TERM_LLM_HUB: options.hub || null,
-    location: { pathname: options.pathname || `${options.uiPrefix || '/ui'}/`, search: '', origin: 'https://example.test', protocol: 'https:', host: 'example.test' },
+    location: { pathname: options.pathname || `${options.uiPrefix || '/ui'}/`, search: options.search || '', origin: 'https://example.test', protocol: 'https:', host: 'example.test' },
     history: { pushState(_state, _title, url) { windowObj.location.pathname = url; } },
     matchMedia() {
       return {
@@ -770,6 +770,46 @@ async function testNumericDeepLinkResolvesRealSessionId() {
     fail(name, 'should not use pending_ prefix in session id', JSON.stringify(fetchCalls));
     return;
   }
+  pass(name);
+}
+
+
+async function testNewQueryStartsDraftInsteadOfLastSession() {
+  const name = 'new query starts draft instead of resuming last session';
+  const { app } = await createSessionsHarness({
+    search: '?new=1',
+    initialStorage: {
+      term_llm_active_session: 'sess_old',
+      term_llm_draft_session_active: '0',
+    },
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: 'sess_old',
+            short_title: 'Old session',
+            long_title: 'Old session',
+            mode: 'chat',
+            origin: 'web',
+            archived: false,
+            pinned: false,
+            created_at: 1710000000000,
+            message_count: 1,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+  });
+
+  if (!app.state.draftSessionActive || app.state.activeSessionId !== '') {
+    fail(name, 'expected fresh draft to stay active', JSON.stringify({
+      draftSessionActive: app.state.draftSessionActive,
+      activeSessionId: app.state.activeSessionId,
+    }));
+    return;
+  }
+
   pass(name);
 }
 
@@ -3637,6 +3677,7 @@ async function testMCPPatchConflictDoesNotOptimisticallyEnable() {
   await testSwitchingSessionsDiscardsPendingAttachments();
   await testSwitchToSessionSyncsSelectedRuntime();
   await testNumericDeepLinkResolvesRealSessionId();
+  await testNewQueryStartsDraftInsteadOfLastSession();
   await testMergeServerSessionsMigratesInterruptBuffersToRealSessionId();
   await testDeveloperMessagesAreHidden();
   await testConvertServerMessagesCompactionSummariesBecomeMarkers();


### PR DESCRIPTION
## What

- Reworks Hub node cards around sessions instead of static node metadata.
- Adds bounded per-node session summaries from `/v1/sessions/status`:
  - active sessions, capped to the first 2 shown
  - recent sessions, capped to the first 3 shown
  - count labels capped at `100+ sessions` instead of exact historical counts
- Makes session rows clickable and changes primary node actions to `[Resume] [New]`.
- Adds `?new=1` handling to the web UI so Hub's `New` action opens a fresh draft instead of resuming the browser's last active session.
- Supports direct and reverse-connected nodes without exposing node bearer tokens to the browser.

## Why

The Hub should answer “what is this agent doing and how do I resume the right thing?” instead of only “which nodes exist?”. Exact session totals are not useful enough to justify unbounded counting on a dashboard refresh, so the overview intentionally uses the existing bounded session status list and reports `100+ sessions` when the list is full.

## Tests

- `go build ./...`
- `go test ./...`
- `mise x node@24.15.0 -- node internal/serveui/static/app_sessions_test.js`
