### PR TITLE
polish Hub quiet card UI

### DIFF
--- a/cmd/templates/hub.css
+++ b/cmd/templates/hub.css
@@ -1,39 +1,70 @@
 :root {
   color-scheme: dark light;
-  --bg: #0f1115;
-  --surface: #171a21;
-  --surface-2: #1f242e;
-  --border: #2a303d;
-  --text: #e6e9ef;
-  --muted: #98a1b3;
-  --accent: #7aa2f7;
+  --bg: #212121;
+  --bg-accent: rgba(255, 255, 255, 0.03);
+  --surface: #2f2f2f;
+  --surface-2: #373737;
+  --surface-3: #424242;
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.15);
+  --text: #ececec;
+  --muted: #9a9a9a;
+  --muted-2: #777777;
+  --accent: #ececec;
+  --accent-contrast: #212121;
   --ok: #34d399;
   --down: #f87171;
-  --warn: #fbbf24;
+  --warn: #e5a210;
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.1);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.12);
+  --overlay: rgba(0, 0, 0, 0.6);
 }
 
 @media (prefers-color-scheme: light) {
   :root {
-    --bg: #f5f6f8;
+    --bg: #ffffff;
+    --bg-accent: rgba(0, 0, 0, 0.02);
     --surface: #ffffff;
-    --surface-2: #eef0f4;
-    --border: #d8dce4;
-    --text: #1c2230;
-    --muted: #5b6475;
-    --accent: #3b6fd4;
+    --surface-2: #f7f7f8;
+    --surface-3: #ececec;
+    --border: rgba(0, 0, 0, 0.08);
+    --border-strong: rgba(0, 0, 0, 0.15);
+    --text: #0d0d0d;
+    --muted: #6e6e6e;
+    --muted-2: #9a9a9a;
+    --accent: #0d0d0d;
+    --accent-contrast: #ffffff;
     --ok: #059669;
     --down: #dc2626;
     --warn: #b45309;
+    --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --overlay: rgba(0, 0, 0, 0.32);
   }
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: var(--surface-3) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
 
 body {
   margin: 0;
+  min-height: 100vh;
   background: var(--bg);
   color: var(--text);
-  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font: 15px/1.5 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  letter-spacing: 0.01em;
 }
 
 .hidden { display: none !important; }
@@ -43,27 +74,60 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.9rem 1.4rem;
+  padding: 1rem 1.5rem;
   border-bottom: 1px solid var(--border);
-  background: var(--surface);
+  background: color-mix(in srgb, var(--bg) 92%, var(--surface));
   position: sticky;
   top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.hub-brand { display: flex; align-items: center; gap: 0.6rem; }
-.hub-logo { color: var(--accent); }
-.hub-brand h1 { margin: 0; font-size: 1.15rem; font-weight: 700; letter-spacing: 0.01em; }
-.hub-brand-accent { color: var(--accent); }
+.hub-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+}
 
-.hub-header-actions { display: flex; align-items: center; gap: 0.6rem; }
-.hub-summary { color: var(--muted); font-size: 0.88rem; }
+.hub-logo {
+  color: var(--text);
+  opacity: 0.88;
+  flex: 0 0 auto;
+}
+
+.hub-brand h1 {
+  margin: 0;
+  font-size: 1.12rem;
+  font-weight: 700;
+  letter-spacing: 0.005em;
+  white-space: nowrap;
+}
+
+.hub-brand-accent { color: var(--muted); }
+
+.hub-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.hub-summary {
+  color: var(--muted);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
 
 .hub-btn {
   border: 1px solid var(--border);
   background: var(--surface-2);
   color: var(--text);
-  border-radius: 8px;
-  padding: 0.42rem 0.85rem;
+  border-radius: 10px;
+  padding: 0.48rem 0.88rem;
+  min-height: 36px;
   font: inherit;
   font-size: 0.9rem;
   font-weight: 600;
@@ -71,83 +135,142 @@ body {
   text-decoration: none;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.35rem;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
-.hub-btn:hover { border-color: var(--accent); }
-.hub-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
-.hub-btn.primary:hover { filter: brightness(1.1); }
-.hub-btn.ghost { background: transparent; }
-.hub-btn.copied { color: var(--ok); border-color: var(--ok); background: color-mix(in srgb, var(--ok) 10%, transparent); }
-.hub-btn.danger { color: var(--down); }
-.hub-btn.danger:hover { border-color: var(--down); }
-.hub-btn.small { padding: 0.24rem 0.55rem; font-size: 0.78rem; border-radius: 7px; }
-.hub-btn.disabled, .hub-btn[aria-disabled="true"] { opacity: 0.55; pointer-events: none; cursor: not-allowed; }
 
-.hub-main { padding: 1.4rem; max-width: 1180px; margin: 0 auto; }
+.hub-btn:hover {
+  background: var(--surface-3);
+  border-color: var(--border-strong);
+}
+
+.hub-btn:active { transform: translateY(1px); }
+
+.hub-btn:focus-visible,
+.node-menu-toggle:focus-visible,
+.node-menu-item:focus-visible,
+.node-session-row:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  outline-offset: 2px;
+}
+
+.hub-btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.hub-btn.primary:hover {
+  background: color-mix(in srgb, var(--accent) 88%, var(--surface-3));
+  border-color: color-mix(in srgb, var(--accent) 88%, var(--border-strong));
+}
+
+.hub-btn.ghost { background: transparent; }
+
+.hub-btn.copied {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 45%, var(--border));
+  background: color-mix(in srgb, var(--ok) 10%, transparent);
+}
+
+.hub-btn.danger { color: var(--down); }
+.hub-btn.danger:hover { border-color: color-mix(in srgb, var(--down) 50%, var(--border)); }
+
+.hub-btn.small {
+  min-height: 28px;
+  padding: 0.22rem 0.55rem;
+  font-size: 0.78rem;
+  border-radius: 8px;
+}
+
+.hub-btn.disabled,
+.hub-btn[aria-disabled="true"] {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+.hub-main {
+  padding: 1.5rem;
+  max-width: 1320px;
+  margin: 0 auto;
+}
 
 .hub-error {
-  border: 1px solid var(--down);
-  background: color-mix(in srgb, var(--down) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--down) 38%, var(--border));
+  background: color-mix(in srgb, var(--down) 8%, var(--surface));
   color: var(--text);
-  border-radius: 10px;
-  padding: 0.7rem 1rem;
+  border-radius: 12px;
+  padding: 0.7rem 0.9rem;
   margin-bottom: 1rem;
   font-size: 0.9rem;
 }
 
 .node-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
+  gap: 1.1rem;
 }
 
 .node-card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  padding: 1.15rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.76rem;
+  min-height: 322px;
+  box-shadow: var(--shadow-card);
 }
 
-.node-card-head { display: flex; align-items: center; gap: 0.55rem; }
-.node-name { margin: 0; font-size: 1.02rem; font-weight: 700; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.node-summary-line { color: var(--muted); font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.node-card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+  min-width: 0;
+}
+
+.node-name {
+  margin: 0;
+  font-size: 1.08rem;
+  font-weight: 720;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-summary-line {
+  color: var(--muted);
+  font-size: 0.86rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-count-badge {
-  font-size: 0.72rem;
-  font-weight: 700;
-  border-radius: 999px;
-  padding: 0.12rem 0.55rem;
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border));
-  color: var(--accent);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
   flex-shrink: 0;
 }
 
 .status-dot {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
   flex-shrink: 0;
+  background: var(--muted-2);
 }
-.status-dot.ok { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+
+.status-dot.ok { background: var(--ok); }
 .status-dot.down { background: var(--down); }
 
-.source-badge {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-radius: 999px;
-  padding: 0.12rem 0.55rem;
-  border: 1px solid var(--border);
-  color: var(--muted);
-  flex-shrink: 0;
-}
-.source-badge.source-contain { color: var(--accent); border-color: var(--accent); }
-.source-badge.source-local { color: var(--ok); border-color: var(--ok); }
+.source-badge { display: none; }
 
 .node-meta {
   display: grid;
@@ -156,15 +279,32 @@ body {
   margin: 0;
   font-size: 0.86rem;
 }
-.node-meta dt { color: var(--muted); font-weight: 600; }
-.node-meta dd { margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.82rem; }
 
-.node-caps { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.node-meta dt {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.node-meta dd {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.node-caps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
 .cap-chip {
-  font-size: 0.74rem;
+  font-size: 0.78rem;
   font-weight: 600;
   border-radius: 999px;
-  padding: 0.14rem 0.6rem;
+  padding: 0.14rem 0.58rem;
   background: var(--surface-2);
   border: 1px solid var(--border);
   color: var(--muted);
@@ -172,20 +312,25 @@ body {
 
 .node-sessions {
   display: grid;
-  gap: 0.6rem;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--surface-2) 68%, transparent);
-  padding: 0.7rem;
+  gap: 0.72rem;
+  border-top: 1px solid var(--border);
+  padding-top: 0.86rem;
+  margin-top: 0.24rem;
 }
-.node-session-group { display: grid; gap: 0.3rem; }
+
+.node-session-group {
+  display: grid;
+  gap: 0.3rem;
+}
+
 .node-session-label {
   color: var(--muted);
   font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.06em;
+  font-weight: 780;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
+
 .node-session-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -193,19 +338,22 @@ body {
   align-items: baseline;
   color: var(--text);
   text-decoration: none;
-  border: 1px solid transparent;
   border-radius: 9px;
-  padding: 0.36rem 0.45rem;
-  margin: 0 -0.1rem;
+  padding: 0.3rem 0.38rem;
+  margin: 0 -0.38rem;
+  border: 1px solid transparent;
 }
+
 .node-session-row:hover {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: var(--surface-2);
+  border-color: var(--border);
 }
+
 .node-session-row.is-active {
-  border-color: color-mix(in srgb, var(--ok) 55%, var(--border));
-  background: color-mix(in srgb, var(--ok) 9%, transparent);
+  background: color-mix(in srgb, var(--ok) 8%, transparent);
+  border-color: color-mix(in srgb, var(--ok) 28%, var(--border));
 }
+
 .node-session-title {
   min-width: 0;
   overflow: hidden;
@@ -213,81 +361,248 @@ body {
   white-space: nowrap;
   font-weight: 650;
 }
+
 .node-session-meta {
   color: var(--muted);
-  font-size: 0.76rem;
+  font-size: 0.78rem;
   white-space: nowrap;
 }
-.node-session-empty { color: var(--muted); font-size: 0.84rem; }
 
-.node-error { color: var(--down); font-size: 0.82rem; word-break: break-word; }
-.node-warn { color: var(--warn); font-size: 0.82rem; }
-.node-diagnostics { display: grid; gap: 0.35rem; }
+.node-session-empty {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.node-error {
+  color: var(--down);
+  font-size: 0.82rem;
+  word-break: break-word;
+}
+
+.node-warn {
+  color: var(--warn);
+  font-size: 0.82rem;
+}
+
+.node-diagnostics {
+  display: grid;
+  gap: 0.35rem;
+}
+
 .node-diagnostic {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.45rem;
   align-items: start;
   border: 1px solid var(--border);
-  border-radius: 9px;
+  border-radius: 10px;
   padding: 0.42rem 0.55rem;
   background: var(--surface-2);
   font-size: 0.82rem;
 }
-.diagnostic-label { font-size: 0.68rem; font-weight: 800; letter-spacing: 0.04em; color: var(--warn); }
+
+.diagnostic-label {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--warn);
+}
+
 .diagnostic-error .diagnostic-label { color: var(--down); }
 .diagnostic-message { word-break: break-word; }
 
-.node-actions { display: flex; gap: 0.5rem; margin-top: auto; padding-top: 0.3rem; }
+.node-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
 
-.hub-empty { text-align: center; color: var(--muted); padding: 3.5rem 1rem; }
+.node-actions .hub-btn.primary { min-width: 88px; }
+
+.node-menu {
+  position: relative;
+  margin-left: auto;
+}
+
+.node-menu-toggle {
+  width: 38px;
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  list-style: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.node-menu-toggle::-webkit-details-marker { display: none; }
+
+.node-menu-toggle:hover,
+.node-menu[open] .node-menu-toggle {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.node-menu-list {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.4rem);
+  min-width: 150px;
+  z-index: 10;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  padding: 0.35rem;
+}
+
+.node-menu-item {
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+}
+
+.node-menu-item:hover { background: var(--surface-2); }
+.node-menu-item.danger { color: var(--down); }
+
+.hub-empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 3.5rem 1rem;
+}
+
 .hub-empty p { margin: 0.3rem 0; }
-.hub-empty-hint code, .hub-empty-hint em { color: var(--text); }
+.hub-empty-hint code,
+.hub-empty-hint em { color: var(--text); }
 
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 1rem;
+  z-index: 60;
 }
 
 .modal {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: 16px;
   width: min(720px, 100%);
   max-height: calc(100vh - 2rem);
   overflow: auto;
   padding: 1.1rem 1.25rem 1.25rem;
+  box-shadow: 0 18px 70px rgba(0, 0, 0, 0.28);
 }
 
-.modal-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 0.8rem; }
-.modal-title { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; }
-.modal-header h2 { margin: 0; font-size: 1.05rem; }
-.help-toggle { color: var(--accent); }
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.8rem;
+}
+
+.modal-title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.help-toggle { color: var(--muted); }
 
 .registration-help {
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 14px;
   background: var(--surface-2);
   padding: 0.85rem;
   margin-bottom: 0.95rem;
   display: grid;
   gap: 0.75rem;
 }
-.registration-help h3 { margin: 0; font-size: 0.98rem; }
-.registration-help h4 { margin: 0; font-size: 0.9rem; }
-.registration-help p { margin: 0; color: var(--muted); font-size: 0.86rem; }
-.registration-help code, .command-box { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-.registration-help-head { display: flex; justify-content: space-between; gap: 1rem; }
-.registration-loading { color: var(--muted); font-size: 0.85rem; }
-.registration-enabled, .registration-disabled { display: grid; gap: 0.8rem; }
-.help-field { display: grid; gap: 0.35rem; }
-.help-label { color: var(--text); font-size: 0.82rem; font-weight: 700; }
-.copy-row { display: flex; align-items: center; gap: 0.45rem; min-width: 0; }
+
+.registration-help h3 {
+  margin: 0;
+  font-size: 0.98rem;
+}
+
+.registration-help h4 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.registration-help p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.registration-help code,
+.command-box {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.registration-help-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.registration-loading {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.registration-enabled,
+.registration-disabled {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.help-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.help-label {
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.copy-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
 .copy-row code {
   flex: 1;
   min-width: 0;
@@ -295,25 +610,29 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--bg);
   color: var(--text);
   padding: 0.42rem 0.55rem;
   font-size: 0.82rem;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
-.copy-row code.copy-flash, .command-box.copy-flash {
-  border-color: var(--ok);
+
+.copy-row code.copy-flash,
+.command-box.copy-flash {
+  border-color: color-mix(in srgb, var(--ok) 60%, var(--border));
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--ok) 18%, transparent);
 }
+
 .help-warning { color: var(--warn) !important; }
-.help-note { border-left: 3px solid var(--accent); padding-left: 0.7rem; }
+.help-note { border-left: 3px solid var(--border-strong); padding-left: 0.7rem; }
 .help-actions { display: flex; justify-content: flex-end; }
+
 .command-box {
   margin: 0;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--bg);
   color: var(--text);
   padding: 0.75rem;
@@ -321,6 +640,7 @@ body {
   line-height: 1.45;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
+
 .token-glossary {
   display: grid;
   grid-template-columns: max-content 1fr;
@@ -328,32 +648,70 @@ body {
   margin: 0;
   font-size: 0.82rem;
 }
-.token-glossary dt { color: var(--text); font-weight: 700; }
-.token-glossary dd { margin: 0; color: var(--muted); }
 
-.modal form { display: flex; flex-direction: column; gap: 0.75rem; }
-.modal label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.88rem; font-weight: 600; }
-.modal label .optional { color: var(--muted); font-weight: 400; }
+.token-glossary dt {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.token-glossary dd {
+  margin: 0;
+  color: var(--muted);
+}
+
+.modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.modal label .optional {
+  color: var(--muted);
+  font-weight: 400;
+}
+
 .modal input {
   border: 1px solid var(--border);
   background: var(--surface-2);
   color: var(--text);
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 0.5rem 0.65rem;
   font: inherit;
   font-size: 0.9rem;
 }
-.modal input:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
 
-.modal-status { min-height: 1.2rem; font-size: 0.85rem; color: var(--muted); }
-.modal-actions { display: flex; justify-content: flex-end; gap: 0.5rem; }
+.modal input:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  outline-offset: -1px;
+}
+
+.modal-status {
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
 
 .delegations-panel {
-  margin-top: 1.25rem;
+  margin-top: 1.35rem;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  padding: 1.15rem 1.25rem;
+  box-shadow: var(--shadow-card);
 }
 
 .delegations-head {
@@ -363,21 +721,47 @@ body {
   gap: 1rem;
   margin-bottom: 0.85rem;
 }
-.delegations-head h2 { margin: 0; font-size: 1.02rem; }
-.delegations-head p { margin: 0.15rem 0 0; color: var(--muted); font-size: 0.86rem; }
-.delegations-count { color: var(--muted); font-size: 0.84rem; white-space: nowrap; }
 
-.delegations-list { display: grid; gap: 0.65rem; }
+.delegations-head h2 {
+  margin: 0;
+  font-size: 1.02rem;
+}
+
+.delegations-head p {
+  margin: 0.15rem 0 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.delegations-count {
+  color: var(--muted);
+  font-size: 0.84rem;
+  white-space: nowrap;
+}
+
+.delegations-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
 .delegation-row {
   background: var(--surface-2);
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: 12px;
   padding: 0.75rem 0.85rem;
   display: grid;
   gap: 0.45rem;
 }
-.delegation-route { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; }
+
+.delegation-route {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
 .route-arrow { color: var(--muted); }
+
 .delegation-status {
   border: 1px solid var(--border);
   border-radius: 999px;
@@ -386,11 +770,23 @@ body {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  color: var(--muted);
 }
-.status-succeeded { color: var(--ok); border-color: var(--ok); }
-.status-failed, .status-error, .status-timed_out, .status-cancelled { color: var(--down); border-color: var(--down); }
-.status-running, .status-queued { color: var(--warn); border-color: var(--warn); }
-.delegation-meta { color: var(--muted); font-size: 0.78rem; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+
+.status-succeeded { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 45%, var(--border)); }
+.status-failed,
+.status-error,
+.status-timed_out,
+.status-cancelled { color: var(--down); border-color: color-mix(in srgb, var(--down) 45%, var(--border)); }
+.status-running,
+.status-queued { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 45%, var(--border)); }
+
+.delegation-meta {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
 .delegation-prompt {
   color: var(--muted);
   font-size: 0.84rem;
@@ -398,11 +794,13 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
 .delegation-response {
   display: grid;
   gap: 0.45rem;
   font-size: 0.86rem;
 }
+
 .delegation-response-text {
   margin: 0;
   color: var(--text);
@@ -410,6 +808,7 @@ body {
   word-break: break-word;
   font: inherit;
 }
+
 .delegation-artifact-img {
   max-width: min(100%, 420px);
   max-height: 240px;
@@ -418,5 +817,38 @@ body {
   border: 1px solid var(--border);
   background: #fff;
 }
-.delegation-artifact-link { color: var(--accent); font-weight: 700; }
-.delegations-empty { color: var(--muted); font-size: 0.88rem; }
+
+.delegation-artifact-link {
+  color: var(--text);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.delegation-artifact-link:hover { text-decoration: underline; }
+.delegations-empty { color: var(--muted); font-size: 0.9rem; }
+
+@media (max-width: 720px) {
+  .hub-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .hub-header-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .hub-summary {
+    flex-basis: 100%;
+    order: -1;
+  }
+
+  .hub-main { padding: 0.85rem; }
+  .node-card { min-height: 0; }
+  .node-session-row { grid-template-columns: minmax(0, 1fr); gap: 0.08rem; }
+  .node-session-meta { white-space: normal; }
+  .modal-actions { flex-direction: column-reverse; }
+  .modal-actions .hub-btn { width: 100%; }
+}

--- a/cmd/templates/hub_index.html
+++ b/cmd/templates/hub_index.html
@@ -26,8 +26,8 @@
     </div>
     <div class="hub-header-actions">
       <span class="hub-summary" id="hubSummary" aria-live="polite"></span>
-      <button class="hub-btn ghost" id="refreshBtn" type="button" title="Refresh nodes">↻ Refresh</button>
-      {{if .CanAddNodes}}<button class="hub-btn primary" id="addNodeBtn" type="button">＋ Add node</button>{{end}}
+      <button class="hub-btn ghost" id="refreshBtn" type="button" title="Refresh nodes">Refresh</button>
+      {{if .CanAddNodes}}<button class="hub-btn primary" id="addNodeBtn" type="button">Add node</button>{{end}}
     </div>
   </header>
 
@@ -299,7 +299,6 @@ term-llm serve hub</code></pre>
       if (n.sessions && n.sessions.count_label) {
         head.appendChild(el('span', 'session-count-badge', n.sessions.count_label));
       }
-      head.appendChild(el('span', `source-badge source-${n.source}`, n.source));
       card.appendChild(head);
 
       const capabilities = Array.isArray(status.capabilities) ? status.capabilities : [];
@@ -345,14 +344,22 @@ term-llm serve hub</code></pre>
       fresh.href = n.new_session_path || `${n.proxy_path}?new=1`;
       actions.appendChild(fresh);
       if (n.source === 'local') {
-        const del = el('button', 'hub-btn danger', 'Remove');
+        const menu = el('details', 'node-menu');
+        const toggle = el('summary', 'node-menu-toggle', '⋯');
+        toggle.setAttribute('aria-label', `More actions for ${n.name}`);
+        menu.appendChild(toggle);
+        const list = el('div', 'node-menu-list');
+        const del = el('button', 'node-menu-item danger', 'Remove node');
         del.type = 'button';
         del.addEventListener('click', async () => {
+          menu.open = false;
           if (!confirm(`Remove node "${n.name}"?`)) return;
           await fetch(`api/nodes/${encodeURIComponent(n.id)}`, { method: 'DELETE' });
           refresh();
         });
-        actions.appendChild(del);
+        list.appendChild(del);
+        menu.appendChild(list);
+        actions.appendChild(menu);
       }
       card.appendChild(actions);
       return card;


### PR DESCRIPTION
## What

- Restyles the Hub dashboard around quieter card surfaces and neutral light/dark theme tokens aligned with the chat UI.
- Removes loud source/session badges from node cards; session counts are quiet text, and config/local source labels are no longer shown as prominent badges.
- Moves the rare destructive `Remove node` action behind a `⋯` overflow menu for local nodes.
- Simplifies header actions by dropping icon glyphs from `Refresh` and `Add node`.
- Adds responsive card/header handling for narrower screens.

## Why

The current Hub UI is visually heavy: too many badge colors, confusing source labels, and a prominent destructive action. This keeps the existing card layout as the conservative direction, but reduces loudness and prioritizes clarity.

## Screenshots checked locally

Rendered static previews with mocked Hub node data in both themes:

- Light: `/chat/images/hub-quiet-final-light.png`
- Dark: `/chat/images/hub-quiet-final-dark.png`

## Test plan

- `go build ./...`
- `go test ./...`
