### PR TITLE
fix: Resuming a large session eagerly loads the entire transcript before first paint

### DIFF
--- a/internal/session/context_state.go
+++ b/internal/session/context_state.go
@@ -93,6 +93,36 @@ func LoadScrollbackWithBoundary(ctx context.Context, store Store, sess *Session)
 	return messages, 0, nil
 }
 
+// LoadInitialScrollbackWithBoundary loads the minimum scrollback needed for the
+// first resumed paint, plus the index where active LLM context begins. For
+// compacted sessions it starts at the persisted compaction boundary and reports
+// the older prefix as deferred so callers can lazy-load that historical
+// scrollback on demand instead of blocking startup on a full transcript read.
+func LoadInitialScrollbackWithBoundary(ctx context.Context, store Store, sess *Session) ([]Message, int, int, error) {
+	if store == nil || sess == nil {
+		return nil, 0, 0, nil
+	}
+	if !HasCompactionBoundary(sess) {
+		messages, idx, err := LoadScrollbackWithBoundary(ctx, store, sess)
+		return messages, idx, 0, err
+	}
+
+	messages, err := store.GetMessagesFrom(ctx, sess.ID, sess.CompactionSeq, 0)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if len(messages) == 0 {
+		clearCompactionBoundary(ctx, store, sess)
+		messages, idx, err := LoadScrollbackWithBoundary(ctx, store, sess)
+		return messages, idx, 0, err
+	}
+
+	var persistedTailIDs []int64
+	messages, persistedTailIDs = markCompactionDisplayTailsForPersistence(messages)
+	persistCompactionTailHints(ctx, store, sess, persistedTailIDs)
+	return messages, 0, sess.CompactionSeq, nil
+}
+
 // ApplyCompaction persists a compaction result, appends the compacted rows to
 // the caller's scrollback snapshot, returns the new active start index, refreshes
 // session metadata when possible, and best-effort clears any persisted context

--- a/internal/session/context_state_test.go
+++ b/internal/session/context_state_test.go
@@ -143,6 +143,43 @@ func TestLoadScrollbackWithBoundary(t *testing.T) {
 	}
 }
 
+func TestLoadInitialScrollbackWithBoundaryStartsAtCompactionSeq(t *testing.T) {
+	ctx := context.Background()
+	base := newContextStateTestStore(t)
+	sess := seedContextStateSession(t, ctx, base)
+	if err := base.CompactMessages(ctx, sess.ID, []Message{
+		*NewMessage(sess.ID, llm.UserText("summary"), -1),
+		*NewMessage(sess.ID, llm.AssistantText("ack"), -1),
+	}); err != nil {
+		t.Fatalf("CompactMessages: %v", err)
+	}
+	refreshed, err := base.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	store := &trackingInitialScrollbackStore{Store: base}
+
+	initial, idx, beforeSeq, err := LoadInitialScrollbackWithBoundary(ctx, store, refreshed)
+	if err != nil {
+		t.Fatalf("LoadInitialScrollbackWithBoundary: %v", err)
+	}
+	if len(initial) != 2 || initial[0].TextContent != "summary" || initial[1].TextContent != "ack" {
+		t.Fatalf("initial scrollback = %#v, want summary/ack tail only", initial)
+	}
+	if idx != 0 {
+		t.Fatalf("idx = %d, want 0 for active-only initial tail", idx)
+	}
+	if beforeSeq != refreshed.CompactionSeq {
+		t.Fatalf("beforeSeq = %d, want compaction seq %d", beforeSeq, refreshed.CompactionSeq)
+	}
+	if store.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages calls = %d, want 0", store.getMessagesCalls)
+	}
+	if len(store.getMessagesFromCalls) != 1 || store.getMessagesFromCalls[0] != refreshed.CompactionSeq {
+		t.Fatalf("GetMessagesFrom calls = %#v, want [%d]", store.getMessagesFromCalls, refreshed.CompactionSeq)
+	}
+}
+
 func TestApplyCompactionPersistsAppendsRefreshesAndClearsEstimate(t *testing.T) {
 	ctx := context.Background()
 	store := newContextStateTestStore(t)
@@ -341,6 +378,22 @@ func messageTexts(messages []Message) []string {
 		out[i] = msg.TextContent
 	}
 	return out
+}
+
+type trackingInitialScrollbackStore struct {
+	Store
+	getMessagesCalls     int
+	getMessagesFromCalls []int
+}
+
+func (s *trackingInitialScrollbackStore) GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]Message, error) {
+	s.getMessagesCalls++
+	return s.Store.GetMessages(ctx, sessionID, limit, offset)
+}
+
+func (s *trackingInitialScrollbackStore) GetMessagesFrom(ctx context.Context, sessionID string, fromSeq, limit int) ([]Message, error) {
+	s.getMessagesFromCalls = append(s.getMessagesFromCalls, fromSeq)
+	return s.Store.GetMessagesFrom(ctx, sessionID, fromSeq, limit)
 }
 
 type failingAfterCompactStore struct {

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -73,13 +73,15 @@ type Model struct {
 	keyMap   KeyMap
 
 	// Session state
-	store         session.Store     // Session storage backend
-	sess          *session.Session  // Current session
-	messages      []session.Message // In-memory messages for current session
-	compactionIdx int               // Prefix length to skip for LLM context; 0 means no prefix is skipped.
-	messagesMu    sync.Mutex        // Protects messages from concurrent compaction callback
-	streaming     bool
-	phase         string // "Thinking", "Searching", "Reading", "Responding"
+	store                     session.Store     // Session storage backend
+	sess                      *session.Session  // Current session
+	messages                  []session.Message // In-memory messages for current session
+	compactionIdx             int               // Prefix length to skip for LLM context; 0 means no prefix is skipped.
+	deferredScrollbackBefore  int               // Oldest not-yet-loaded pre-compaction sequence boundary for lazy resume scrollback.
+	deferredScrollbackLoading bool              // A lazy older-scrollback load is in flight.
+	messagesMu                sync.Mutex        // Protects messages from concurrent compaction callback
+	streaming                 bool
+	phase                     string // "Thinking", "Searching", "Reading", "Responding"
 
 	// Reasoning display/status state. Provider replay metadata is persisted in
 	// assistant parts by the LLM engine; these fields only affect live UI policy.
@@ -482,6 +484,13 @@ type chatGPTModelsLoadedMsg struct {
 	err    error
 }
 
+type olderScrollbackLoadedMsg struct {
+	sessionID     string
+	messages      []session.Message
+	nextBeforeSeq int
+	err           error
+}
+
 // ApprovalRequestMsg triggers an inline approval prompt.
 type ApprovalRequestMsg struct {
 	Path    string
@@ -503,12 +512,95 @@ type HandoverRequestMsg struct {
 	DoneCh chan<- bool
 }
 
+const deferredScrollbackPageSize = 128
+
 func loadSessionMessagesForContext(ctx context.Context, store session.Store, sess *session.Session) ([]session.Message, error) {
 	return session.LoadActiveMessages(ctx, store, sess)
 }
 
 func loadSessionMessagesForScrollback(ctx context.Context, store session.Store, sess *session.Session) ([]session.Message, int, error) {
 	return session.LoadScrollbackWithBoundary(ctx, store, sess)
+}
+
+func reverseSessionMessages(messages []session.Message) []session.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	reversed := make([]session.Message, len(messages))
+	for i := range messages {
+		reversed[len(messages)-1-i] = messages[i]
+	}
+	return reversed
+}
+
+func loadOlderScrollbackPage(ctx context.Context, store session.Store, sessionID string, beforeSeq, limit int) ([]session.Message, int, error) {
+	if store == nil || sessionID == "" || beforeSeq <= 0 {
+		return nil, 0, nil
+	}
+	if pager, ok := store.(session.MessagesDescendingPager); ok {
+		page, err := pager.GetMessagesPageDescending(ctx, sessionID, beforeSeq, limit)
+		if err != nil {
+			return nil, 0, err
+		}
+		ascending := reverseSessionMessages(page)
+		nextBeforeSeq := 0
+		if len(ascending) > 0 {
+			nextBeforeSeq = ascending[0].Sequence
+		}
+		return ascending, nextBeforeSeq, nil
+	}
+	messages, err := store.GetMessages(ctx, sessionID, beforeSeq, 0)
+	if err != nil {
+		return nil, 0, err
+	}
+	return messages, 0, nil
+}
+
+func (m *Model) requestOlderScrollback() tea.Cmd {
+	if m == nil || m.store == nil || m.sess == nil || m.deferredScrollbackLoading || m.deferredScrollbackBefore <= 0 {
+		return nil
+	}
+	sessionID := m.sess.ID
+	beforeSeq := m.deferredScrollbackBefore
+	m.deferredScrollbackLoading = true
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		messages, nextBeforeSeq, err := loadOlderScrollbackPage(ctx, m.store, sessionID, beforeSeq, deferredScrollbackPageSize)
+		return olderScrollbackLoadedMsg{sessionID: sessionID, messages: messages, nextBeforeSeq: nextBeforeSeq, err: err}
+	}
+}
+
+func (m *Model) applyOlderScrollbackLoaded(msg olderScrollbackLoadedMsg) (tea.Model, tea.Cmd) {
+	m.deferredScrollbackLoading = false
+	if m.sess == nil || msg.sessionID != m.sess.ID {
+		return m, nil
+	}
+	if msg.err != nil {
+		return m.showFooterError(fmt.Sprintf("Failed to load older scrollback: %v", msg.err))
+	}
+	m.deferredScrollbackBefore = msg.nextBeforeSeq
+	if len(msg.messages) == 0 {
+		return m, nil
+	}
+	m.messagesMu.Lock()
+	m.messages = append(append([]session.Message(nil), msg.messages...), m.messages...)
+	m.compactionIdx += len(msg.messages)
+	m.messagesMu.Unlock()
+	m.invalidateHistoryCache()
+	return m, nil
+}
+
+func (m *Model) canLoadOlderScrollback() bool {
+	return m != nil && m.deferredScrollbackBefore > 0 && !m.deferredScrollbackLoading
+}
+
+func (m *Model) discardDeferredScrollback() {
+	if m == nil {
+		return
+	}
+	m.deferredScrollbackBefore = 0
+	m.deferredScrollbackLoading = false
 }
 
 func (m *Model) refreshSessionFromStore(ctx context.Context) error {
@@ -618,13 +710,16 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 	// Load existing messages if resuming.
 	// Keep full persisted scrollback available for the human UI, but remember the
 	// compaction boundary so buildMessages only sends the active post-compaction
-	// window to the LLM.
+	// window to the LLM. For compacted sessions, load the active tail first so a
+	// large pre-compaction transcript does not block the first paint.
 	var messages []session.Message
 	var compactionIdx int
+	var deferredScrollbackBefore int
 	if store != nil && sess.ID != "" {
-		if loadedMsgs, idx, err := loadSessionMessagesForScrollback(context.Background(), store, sess); err == nil {
+		if loadedMsgs, idx, beforeSeq, err := session.LoadInitialScrollbackWithBoundary(context.Background(), store, sess); err == nil {
 			messages = loadedMsgs
 			compactionIdx = idx
+			deferredScrollbackBefore = beforeSeq
 		}
 	}
 
@@ -713,6 +808,7 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 		sess:                       sess,
 		messages:                   messages,
 		compactionIdx:              compactionIdx,
+		deferredScrollbackBefore:   deferredScrollbackBefore,
 		rootCtx:                    context.Background(),
 		provider:                   provider,
 		fastProvider:               fastProvider,
@@ -1424,6 +1520,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.resetViewportHorizontalOffset()
 				return m, nil
 			}
+			if wheel, ok := msg.(tea.MouseWheelMsg); ok && wheel.Button == tea.MouseWheelUp && m.viewport.YOffset() == 0 {
+				if cmd := m.requestOlderScrollback(); cmd != nil {
+					return m, cmd
+				}
+			}
 			var cmd tea.Cmd
 			m.viewport, cmd = m.viewport.Update(msg)
 			m.resetViewportHorizontalOffset()
@@ -1467,6 +1568,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case chatGPTModelsLoadedMsg:
 		return m.applyChatGPTModelsLoaded(msg)
+
+	case olderScrollbackLoadedMsg:
+		return m.applyOlderScrollbackLoaded(msg)
 
 	case promptHistoryLookupMsg:
 		return m.handlePromptHistoryLookupMsg(msg)
@@ -1513,6 +1617,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sess = refreshed
 		}
 		m.recordCompactionUsage(context.Background(), sessionIDOf(m.sess), msg.result.Usage)
+		m.discardDeferredScrollback()
 		m.messagesMu.Lock()
 		m.messages = updated
 		m.compactionIdx = activeStart
@@ -2124,6 +2229,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					_, cmd := m.showFooterError(fmt.Sprintf("Session message reload failed after compaction: %v", err))
 					cmds = append(cmds, cmd)
 				} else {
+					m.discardDeferredScrollback()
 					m.messagesMu.Lock()
 					m.messages = loadedMsgs
 					m.compactionIdx = compactionIdx

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -654,6 +654,7 @@ func (m *Model) cmdClear() (tea.Model, tea.Cmd) {
 	// Clear conversation messages and input
 	m.messages = nil
 	m.compactionIdx = 0
+	m.discardDeferredScrollback()
 	m.scrollOffset = 0
 	m.setTextareaValue("")
 	m.clearFiles()
@@ -1474,6 +1475,7 @@ func (m *Model) cmdNew() (tea.Model, tea.Cmd) {
 	// Clear conversation messages and input
 	m.messages = nil
 	m.compactionIdx = 0
+	m.discardDeferredScrollback()
 	m.scrollOffset = 0
 	m.setTextareaValue("")
 	m.clearFiles()

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -154,26 +154,33 @@ func TestStreamingLocalSlashCommandIncludesEffort(t *testing.T) {
 // mockStore implements session.Store for testing resume behavior.
 type mockStore struct {
 	session.NoopStore
-	sessions        map[string]*session.Session
-	getErr          error
-	messages        map[string][]session.Message
-	summaries       []session.SessionSummary
-	msgErr          error
-	updated         *session.Session
-	updateErr       error
-	created         []*session.Session
-	createErr       error
-	added           []session.Message
-	addErr          error
-	currentID       string
-	setCurrentErr   error
-	deleted         []string
-	deleteErr       error
-	statusUpdates   []statusUpdate
-	updateStatusErr error
-	compacted       []session.Message
-	compactSession  string
-	compactErr      error
+	sessions             map[string]*session.Session
+	getErr               error
+	messages             map[string][]session.Message
+	summaries            []session.SessionSummary
+	msgErr               error
+	getMessagesCalls     int
+	getMessagesFromCalls []getMessagesFromCall
+	updated              *session.Session
+	updateErr            error
+	created              []*session.Session
+	createErr            error
+	added                []session.Message
+	addErr               error
+	currentID            string
+	setCurrentErr        error
+	deleted              []string
+	deleteErr            error
+	statusUpdates        []statusUpdate
+	updateStatusErr      error
+	compacted            []session.Message
+	compactSession       string
+	compactErr           error
+}
+
+type getMessagesFromCall struct {
+	fromSeq int
+	limit   int
 }
 
 type statusUpdate struct {
@@ -202,6 +209,7 @@ func (s *mockStore) GetMessages(_ context.Context, sessionID string, _, _ int) (
 	if s.msgErr != nil {
 		return nil, s.msgErr
 	}
+	s.getMessagesCalls++
 	return s.messages[sessionID], nil
 }
 
@@ -209,6 +217,7 @@ func (s *mockStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq
 	if s.msgErr != nil {
 		return nil, s.msgErr
 	}
+	s.getMessagesFromCalls = append(s.getMessagesFromCalls, getMessagesFromCall{fromSeq: fromSeq, limit: limit})
 	var filtered []session.Message
 	for _, msg := range s.messages[sessionID] {
 		if msg.Sequence >= fromSeq {
@@ -316,6 +325,30 @@ func (s *mockStore) CompactMessages(_ context.Context, sessionID string, message
 	s.compacted = append([]session.Message(nil), messages...)
 	s.messages[sessionID] = append(s.messages[sessionID], messages...)
 	return nil
+}
+
+type pagedResumeScrollbackStore struct {
+	*mockStore
+	pageCalls int
+}
+
+func (s *pagedResumeScrollbackStore) GetMessagesPageDescending(_ context.Context, sessionID string, beforeSeq, limit int) ([]session.Message, error) {
+	if s.msgErr != nil {
+		return nil, s.msgErr
+	}
+	s.pageCalls++
+	msgs := s.messages[sessionID]
+	page := make([]session.Message, 0, limit)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if beforeSeq > 0 && msgs[i].Sequence >= beforeSeq {
+			continue
+		}
+		page = append(page, msgs[i])
+		if limit > 0 && len(page) >= limit {
+			break
+		}
+	}
+	return page, nil
 }
 
 func TestCmdHelpOpensModal(t *testing.T) {
@@ -2660,6 +2693,98 @@ func TestProcStatState(t *testing.T) {
 				t.Fatalf("procStatState(%q) = %q, %v; want %q, %v", tt.stat, got, ok, tt.want, tt.ok)
 			}
 		})
+	}
+}
+
+func TestNewLoadsCompactedScrollbackTailAndLazyLoadsOlderPrefix(t *testing.T) {
+	sessionID := "sess-lazy-resume"
+	base := &mockStore{
+		sessions: map[string]*session.Session{
+			sessionID: {ID: sessionID, CompactionSeq: 2, CompactionCount: 1},
+		},
+		messages: map[string][]session.Message{
+			sessionID: {
+				*session.NewMessage(sessionID, llm.UserText("old user"), 0),
+				*session.NewMessage(sessionID, llm.AssistantText("old assistant"), 1),
+				*session.NewMessage(sessionID, llm.UserText("summary"), 2),
+				*session.NewMessage(sessionID, llm.AssistantText("ack"), 3),
+			},
+		},
+	}
+	store := &pagedResumeScrollbackStore{mockStore: base}
+
+	provider := llm.NewMockProvider("mock")
+	engine := llm.NewEngine(provider, nil)
+	m := New(
+		&config.Config{DefaultProvider: "mock"},
+		provider,
+		engine,
+		"mock",
+		"mock-model",
+		nil,
+		20,
+		false,
+		false,
+		false,
+		nil,
+		"",
+		"",
+		false,
+		"",
+		store,
+		base.sessions[sessionID],
+		true,
+		nil,
+		false,
+		false,
+		"",
+		"",
+		false,
+	)
+
+	if len(m.messages) != 2 {
+		t.Fatalf("initial len(messages) = %d, want 2 active tail rows", len(m.messages))
+	}
+	if m.messages[0].Sequence != 2 || m.messages[1].Sequence != 3 {
+		t.Fatalf("initial sequences = [%d %d], want [2 3]", m.messages[0].Sequence, m.messages[1].Sequence)
+	}
+	if m.compactionIdx != 0 {
+		t.Fatalf("initial compactionIdx = %d, want 0 for active-only tail", m.compactionIdx)
+	}
+	if m.deferredScrollbackBefore != 2 {
+		t.Fatalf("deferredScrollbackBefore = %d, want 2", m.deferredScrollbackBefore)
+	}
+	if base.getMessagesCalls != 0 {
+		t.Fatalf("GetMessages calls = %d, want 0 on initial compacted resume", base.getMessagesCalls)
+	}
+	if len(base.getMessagesFromCalls) != 1 || base.getMessagesFromCalls[0].fromSeq != 2 {
+		t.Fatalf("GetMessagesFrom calls = %#v, want first call fromSeq=2", base.getMessagesFromCalls)
+	}
+	if store.pageCalls != 0 {
+		t.Fatalf("GetMessagesPageDescending calls = %d, want 0 before user requests older scrollback", store.pageCalls)
+	}
+
+	cmd := m.requestOlderScrollback()
+	if cmd == nil {
+		t.Fatal("expected lazy older scrollback load command")
+	}
+	result, _ := m.Update(cmd().(olderScrollbackLoadedMsg))
+	rm := result.(*Model)
+
+	if len(rm.messages) != 4 {
+		t.Fatalf("len(messages) after lazy load = %d, want 4", len(rm.messages))
+	}
+	if rm.messages[0].Sequence != 0 || rm.messages[3].Sequence != 3 {
+		t.Fatalf("lazy-loaded sequences = first %d last %d, want 0 and 3", rm.messages[0].Sequence, rm.messages[3].Sequence)
+	}
+	if rm.compactionIdx != 2 {
+		t.Fatalf("compactionIdx after lazy load = %d, want 2", rm.compactionIdx)
+	}
+	if rm.deferredScrollbackBefore != 0 {
+		t.Fatalf("deferredScrollbackBefore after lazy load = %d, want 0", rm.deferredScrollbackBefore)
+	}
+	if store.pageCalls != 1 {
+		t.Fatalf("GetMessagesPageDescending calls = %d, want 1", store.pageCalls)
 	}
 }
 

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -647,6 +647,11 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Allow viewport scrolling even while streaming (in alt screen mode)
 	if m.altScreen {
 		if key.Matches(msg, m.keyMap.PageUp) {
+			if m.viewport.YOffset() == 0 {
+				if cmd := m.requestOlderScrollback(); cmd != nil {
+					return m, cmd
+				}
+			}
 			var cmd tea.Cmd
 			m.viewport, cmd = m.viewport.Update(msg)
 			return m, cmd
@@ -666,6 +671,11 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				scrollAmount = 5
 			}
 			if key.Matches(msg, m.keyMap.HistoryUp) {
+				if m.viewport.YOffset() == 0 {
+					if cmd := m.requestOlderScrollback(); cmd != nil {
+						return m, cmd
+					}
+				}
 				m.viewport.ScrollUp(scrollAmount)
 				return m, nil
 			}
@@ -910,6 +920,11 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			maxScroll := totalMessages - 1
 			if maxScroll < 0 {
 				maxScroll = 0
+			}
+			if m.scrollOffset >= maxScroll {
+				if cmd := m.requestOlderScrollback(); cmd != nil {
+					return m, cmd
+				}
 			}
 			m.scrollOffset += 5
 			if m.scrollOffset > maxScroll {

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -317,6 +317,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 
 	// Build the full message content including file attachments
 	fullContent := content
+	m.discardDeferredScrollback()
 	var fileNames []string
 
 	if len(m.files) > 0 {


### PR DESCRIPTION
## What changed

- Added `session.LoadInitialScrollbackWithBoundary`, which resumes compacted sessions by loading only the persisted post-compaction tail via `GetMessagesFrom(...)` instead of calling `GetMessages(..., 0, 0)` up front.
- Kept the existing full `LoadScrollbackWithBoundary` path for non-compacted sessions and for stale-boundary fallback.
- Updated TUI chat startup to use the new initial loader so resume can paint from the active tail immediately.
- Added lazy older-scrollback loading for compacted resumes:
  - older pre-compaction history is fetched only when the user scrolls upward into it
  - paging uses `GetMessagesPageDescending(...)` when available, with a fallback to `GetMessages(...)` only on demand
- Added tests covering:
  - initial compacted resume using `GetMessagesFrom` instead of `GetMessages`
  - TUI lazy-loading older pre-compaction history and restoring the correct compaction index

## Why this is high-value

Resuming a long compacted session was on the interactive startup path and always performed a full transcript read before first paint, including every persisted message and full `parts` payload. That makes real Jarvis sessions with lots of tool output feel slow and memory-heavy to reopen.

This change reduces startup work materially for compacted sessions by:

- avoiding the eager full-history DB read on resume
- loading only the active post-compaction tail needed for immediate rendering
- deferring older historical scrollback until the user actually scrolls into it
- using reverse keyset paging for older history when the store supports it

The result is less DB work, fewer allocations, and lower resume latency on the hot path, while preserving access to older scrollback on demand.

## Validation

- Added `TestLoadInitialScrollbackWithBoundaryStartsAtCompactionSeq`
- Added `TestNewLoadsCompactedScrollbackTailAndLazyLoadsOlderPrefix`
- Ran `gofmt -w` on changed files
- Ran `go build ./...`
- Ran `go test ./...`
- Ran `git diff --check`
