### PR TITLE
fix: ChatGPT OAuth credential refresh overwrites the credential file in place, so a crash or short write can permanently break auth

### DIFF
--- a/internal/credentials/atomic_write.go
+++ b/internal/credentials/atomic_write.go
@@ -1,0 +1,45 @@
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func writeFileAtomically(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	f, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := f.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := f.Chmod(perm); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("set temp file permissions: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	cleanup = false
+	return nil
+}

--- a/internal/credentials/atomic_write_test.go
+++ b/internal/credentials/atomic_write_test.go
@@ -1,0 +1,112 @@
+package credentials
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSaveChatGPTCredentials_CreateTempFailureLeavesExistingFileUntouched(t *testing.T) {
+	testCredentialSaveCreateTempFailureLeavesExistingFileUntouched(
+		t,
+		func() (string, error) {
+			return getChatGPTCredentialsPath()
+		},
+		func() error {
+			return SaveChatGPTCredentials(&ChatGPTCredentials{
+				AccessToken:  "original-access",
+				RefreshToken: "original-refresh",
+				ExpiresAt:    123,
+				AccountID:    "original-account",
+			})
+		},
+		func() error {
+			return SaveChatGPTCredentials(&ChatGPTCredentials{
+				AccessToken:  "updated-access",
+				RefreshToken: "updated-refresh",
+				ExpiresAt:    456,
+				AccountID:    "updated-account",
+			})
+		},
+	)
+}
+
+func TestSaveCopilotCredentials_CreateTempFailureLeavesExistingFileUntouched(t *testing.T) {
+	testCredentialSaveCreateTempFailureLeavesExistingFileUntouched(
+		t,
+		func() (string, error) {
+			return getCopilotCredentialsPath()
+		},
+		func() error {
+			return SaveCopilotCredentials(&CopilotCredentials{
+				AccessToken: "original-access",
+				ExpiresAt:   123,
+			})
+		},
+		func() error {
+			return SaveCopilotCredentials(&CopilotCredentials{
+				AccessToken: "updated-access",
+				ExpiresAt:   456,
+			})
+		},
+	)
+}
+
+func testCredentialSaveCreateTempFailureLeavesExistingFileUntouched(t *testing.T, pathFn func() (string, error), saveOriginal func() error, saveUpdated func() error) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions behave differently on Windows")
+	}
+
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+
+	if err := saveOriginal(); err != nil {
+		t.Fatalf("save original credentials: %v", err)
+	}
+
+	path, err := pathFn()
+	if err != nil {
+		t.Fatalf("get credentials path: %v", err)
+	}
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read original credentials: %v", err)
+	}
+
+	dir := filepath.Dir(path)
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat credentials directory: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod credentials directory read-only: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, info.Mode().Perm()); err != nil {
+			t.Fatalf("restore credentials directory permissions: %v", err)
+		}
+	}()
+
+	err = saveUpdated()
+	if err == nil {
+		t.Fatal("expected save to fail")
+	}
+	if !strings.Contains(err.Error(), "create temp file") {
+		t.Fatalf("error = %v, want create temp file", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read credentials after failed save: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("credentials changed on failed save: got %q want %q", got, original)
+	}
+}

--- a/internal/credentials/chatgpt.go
+++ b/internal/credentials/chatgpt.go
@@ -84,7 +84,7 @@ func SaveChatGPTCredentials(creds *ChatGPTCredentials) error {
 	}
 
 	// Write with restrictive permissions (owner read/write only)
-	if err := os.WriteFile(credPath, data, 0600); err != nil {
+	if err := writeFileAtomically(credPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write credentials: %w", err)
 	}
 

--- a/internal/credentials/copilot.go
+++ b/internal/credentials/copilot.go
@@ -84,7 +84,7 @@ func SaveCopilotCredentials(creds *CopilotCredentials) error {
 	}
 
 	// Write with restrictive permissions (owner read/write only)
-	if err := os.WriteFile(credPath, data, 0600); err != nil {
+	if err := writeFileAtomically(credPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write credentials: %w", err)
 	}
 


### PR DESCRIPTION
## What changed

- replaced in-place credential writes in `internal/credentials/chatgpt.go` with an atomic temp-file-and-rename helper
- reused the same helper for `internal/credentials/copilot.go`, which had the same persisted-state corruption risk
- added tests that verify a failed save cannot modify an already-written credential file

## Why this is high-value

`RefreshChatGPTCredentials` automatically persists refreshed tokens, so normal ChatGPT provider use regularly rewrites the auth file. Before this change, `os.WriteFile` truncated the live file in place. If the process crashed or the write was interrupted after truncation, `chatgpt_oauth.json` could be left empty or partially written, and every later auth read would fail until the user manually re-authenticated.

The new flow writes a fully-formed replacement file first, `Sync`s it, closes it, and only then renames it over the destination. That prevents the live credential file from being corrupted by partial writes during refresh.

## Validation

- `gofmt -w internal/credentials/chatgpt.go internal/credentials/copilot.go internal/credentials/atomic_write.go internal/credentials/atomic_write_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
