### PR TITLE
fix: Telegram store-op queue stops serializing writes during close, so interrupted/error recovery can persist messages out of order or twice

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -960,7 +960,6 @@ func (q *telegramStoreOpQueue) enqueue(ctx context.Context, op string, fn func(c
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
-		q.mgr.runStoreOpWithoutCancel(ctx, q.sessionID, op, fn)
 		return
 	}
 	q.enqueueWG.Add(1)
@@ -970,7 +969,6 @@ func (q *telegramStoreOpQueue) enqueue(ctx context.Context, op string, fn func(c
 	select {
 	case q.ops <- storeOp:
 	case <-q.closedCh:
-		q.mgr.runStoreOpWithoutCancel(ctx, q.sessionID, op, fn)
 	}
 }
 
@@ -1684,9 +1682,10 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		newHistory = append(newHistory, producedSnapshot...)
 		if partial != "" {
 			if callbackStoreQueue != nil {
-				drainCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-				callbackStoreQueue.closeAndWait(drainCtx)
-				cancel()
+				// Keep fallback persistence on the same serialized path by waiting for
+				// queued callback writes to drain before checking/persisting the final
+				// assistant text.
+				callbackStoreQueue.closeAndWait(context.Background())
 			}
 			assistantMsg := llm.AssistantText(partial)
 			if m.store != nil && sess.meta != nil && !m.persistedAssistantTextMatches(persistCtx, sess.meta.ID, partial) {

--- a/internal/serve/telegram_queue_test.go
+++ b/internal/serve/telegram_queue_test.go
@@ -122,8 +122,45 @@ func TestTelegramStoreOpQueueCloseUnblocksFullQueueEnqueue(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("blocked enqueue did not return after closeAndWait")
 	}
-	if !finalRan.Load() {
-		t.Fatal("blocked enqueue fallback op did not run")
+	if finalRan.Load() {
+		t.Fatal("blocked enqueue ran inline after closeAndWait started")
+	}
+
+	close(releaseFirst)
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer drainCancel()
+	q.closeAndWait(drainCtx)
+}
+
+func TestTelegramStoreOpQueueDropsLateEnqueueAfterCloseStarts(t *testing.T) {
+	mgr := &telegramSessionMgr{store: &session.NoopStore{}}
+	q := newTelegramStoreOpQueue(mgr, "session-1")
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	q.enqueue(context.Background(), "first", func(context.Context) error {
+		close(firstStarted)
+		<-releaseFirst
+		return nil
+	})
+
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first op did not start")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	q.closeAndWait(closeCtx)
+
+	var lateRan atomic.Bool
+	q.enqueue(context.Background(), "late", func(context.Context) error {
+		lateRan.Store(true)
+		return nil
+	})
+	if lateRan.Load() {
+		t.Fatal("late enqueue ran inline after close started")
 	}
 
 	close(releaseFirst)


### PR DESCRIPTION
## What changed

- Stopped `telegramStoreOpQueue.enqueue` from bypassing the queue once close begins.
  - If the queue is already closing or `closedCh` fires while an enqueue is blocked, the op now returns instead of calling `runStoreOpWithoutCancel(...)` inline.
- Changed Telegram partial-history salvage to fully drain `callbackStoreQueue` before running the fallback `persistedAssistantTextMatches` / `AddMessage` path.
- Updated queue tests to assert that enqueues unblocked by close do **not** run inline, and added coverage for enqueues attempted after close starts.

## Why this is high-value

This fixes the exact reliability failure mode in interrupted/errored Telegram sessions:

- the callback queue exists to serialize assistant/tool/metrics persistence for a single session;
- during close, the old code broke that guarantee by running late writes inline;
- the salvage path then closed the queue with a 500ms wait and immediately did fallback persistence, so queued callback writes could still race the fallback `AddMessage`.

That could reorder auto-sequenced message writes, separate metrics from the messages they belong to, or duplicate the final assistant text. The fix keeps failure recovery on one serialized path so partial transcripts stay consistent for future context.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_queue_test.go`
- `go build ./...`
- `go test ./...`
- `go test ./internal/serve -run 'TestTelegramStoreOpQueue|TestStreamReply_Persists(Interrupted|Errored)PartialAssistantReply'`
- `git diff --check`
