### PR TITLE
fix: Telegram store-op queue deliberately runs fallback writes concurrently with queued writes during close, risking out-of-order or duplicate persisted messages

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -924,7 +924,6 @@ type telegramStoreOpQueue struct {
 	sessionID string
 	ops       chan telegramStoreOp
 	done      chan struct{}
-	closedCh  chan struct{}
 	once      sync.Once
 
 	mu        sync.Mutex
@@ -938,7 +937,6 @@ func newTelegramStoreOpQueue(mgr *telegramSessionMgr, sessionID string) *telegra
 		sessionID: sessionID,
 		ops:       make(chan telegramStoreOp, 128),
 		done:      make(chan struct{}),
-		closedCh:  make(chan struct{}),
 	}
 	go q.run()
 	return q
@@ -960,28 +958,22 @@ func (q *telegramStoreOpQueue) enqueue(ctx context.Context, op string, fn func(c
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
-		q.mgr.runStoreOpWithoutCancel(ctx, q.sessionID, op, fn)
 		return
 	}
 	q.enqueueWG.Add(1)
 	q.mu.Unlock()
 	defer q.enqueueWG.Done()
 
-	select {
-	case q.ops <- storeOp:
-	case <-q.closedCh:
-		q.mgr.runStoreOpWithoutCancel(ctx, q.sessionID, op, fn)
-	}
+	q.ops <- storeOp
 }
 
-func (q *telegramStoreOpQueue) closeAndWait(ctx context.Context) {
+func (q *telegramStoreOpQueue) closeAndWait(ctx context.Context) bool {
 	if q == nil {
-		return
+		return true
 	}
 	q.once.Do(func() {
 		q.mu.Lock()
 		q.closed = true
-		close(q.closedCh)
 		q.mu.Unlock()
 		go func() {
 			q.enqueueWG.Wait()
@@ -990,7 +982,9 @@ func (q *telegramStoreOpQueue) closeAndWait(ctx context.Context) {
 	})
 	select {
 	case <-q.done:
+		return true
 	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -1683,17 +1677,31 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		newHistory = append(newHistory, normalizeUserMessageForHistory(userMsg))
 		newHistory = append(newHistory, producedSnapshot...)
 		if partial != "" {
+			drained := true
 			if callbackStoreQueue != nil {
 				drainCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-				callbackStoreQueue.closeAndWait(drainCtx)
+				drained = callbackStoreQueue.closeAndWait(drainCtx)
 				cancel()
 			}
 			assistantMsg := llm.AssistantText(partial)
-			if m.store != nil && sess.meta != nil && !m.persistedAssistantTextMatches(persistCtx, sess.meta.ID, partial) {
-				storeMsg := session.NewMessage(sess.meta.ID, assistantMsg, -1)
-				m.runStoreOpWithoutCancel(persistCtx, sess.meta.ID, fallbackOp, func(storeCtx context.Context) error {
-					return m.store.AddMessage(storeCtx, sess.meta.ID, storeMsg)
-				})
+			if m.store != nil && sess.meta != nil {
+				persistAssistantFallback := func(storeCtx context.Context) {
+					if m.persistedAssistantTextMatches(storeCtx, sess.meta.ID, partial) {
+						return
+					}
+					storeMsg := session.NewMessage(sess.meta.ID, assistantMsg, -1)
+					m.runStoreOpWithoutCancel(storeCtx, sess.meta.ID, fallbackOp, func(opCtx context.Context) error {
+						return m.store.AddMessage(opCtx, sess.meta.ID, storeMsg)
+					})
+				}
+				if drained || callbackStoreQueue == nil {
+					persistAssistantFallback(persistCtx)
+				} else {
+					go func() {
+						<-callbackStoreQueue.done
+						persistAssistantFallback(context.Background())
+					}()
+				}
 			}
 			if !assistantTextCaptured {
 				newHistory = append(newHistory, assistantMsg)

--- a/internal/serve/telegram_queue_test.go
+++ b/internal/serve/telegram_queue_test.go
@@ -2,7 +2,6 @@ package serve
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -75,12 +74,14 @@ func TestTelegramStoreOpQueueFullStillSerializesOps(t *testing.T) {
 	}
 }
 
-func TestTelegramStoreOpQueueCloseUnblocksFullQueueEnqueue(t *testing.T) {
+func TestTelegramStoreOpQueueCloseKeepsBlockedEnqueueSerialized(t *testing.T) {
 	mgr := &telegramSessionMgr{store: &session.NoopStore{}}
 	q := newTelegramStoreOpQueue(mgr, "session-1")
 
 	firstStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})
+	finalRan := make(chan struct{})
+	finalReturned := make(chan struct{})
 	q.enqueue(context.Background(), "first", func(context.Context) error {
 		close(firstStarted)
 		<-releaseFirst
@@ -97,11 +98,9 @@ func TestTelegramStoreOpQueueCloseUnblocksFullQueueEnqueue(t *testing.T) {
 		q.enqueue(context.Background(), "buffered", func(context.Context) error { return nil })
 	}
 
-	var finalRan atomic.Bool
-	finalReturned := make(chan struct{})
 	go func() {
 		q.enqueue(context.Background(), "final", func(context.Context) error {
-			finalRan.Store(true)
+			close(finalRan)
 			return nil
 		})
 		close(finalReturned)
@@ -113,21 +112,41 @@ func TestTelegramStoreOpQueueCloseUnblocksFullQueueEnqueue(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	closeCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	closeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	q.closeAndWait(closeCtx)
+	if q.closeAndWait(closeCtx) {
+		t.Fatal("closeAndWait unexpectedly drained a blocked queue")
+	}
+
+	select {
+	case <-finalReturned:
+		t.Fatal("blocked enqueue returned during close before queue space freed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case <-finalRan:
+		t.Fatal("blocked enqueue ran inline during close")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirst)
 
 	select {
 	case <-finalReturned:
 	case <-time.After(5 * time.Second):
-		t.Fatal("blocked enqueue did not return after closeAndWait")
-	}
-	if !finalRan.Load() {
-		t.Fatal("blocked enqueue fallback op did not run")
+		t.Fatal("blocked enqueue did not complete after queued work drained")
 	}
 
-	close(releaseFirst)
 	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer drainCancel()
-	q.closeAndWait(drainCtx)
+	if !q.closeAndWait(drainCtx) {
+		t.Fatal("closeAndWait did not drain after queue space freed")
+	}
+
+	select {
+	case <-finalRan:
+	default:
+		t.Fatal("blocked enqueue did not run after queued work drained")
+	}
 }


### PR DESCRIPTION
## What changed

- Removed the Telegram store-op queue shutdown fallback that executed blocked or post-close store writes inline instead of through the per-session queue.
- Kept in-flight enqueues blocked on the queue until space is available so they still run in FIFO order before shutdown completes.
- Made `closeAndWait` report whether the queue fully drained before the caller's deadline.
- Changed the partial-history salvage path so fallback assistant-message persistence only runs after the callback store queue has drained; if the short 500ms wait expires, the fallback write is deferred until `q.done` instead of racing queued `AddMessage` / metrics / context-estimate writes.
- Replaced the old regression test that asserted the broken inline-fallback behavior with a test that proves close no longer unblocks a full queue by running the op concurrently.

## Why this is high-value

This queue is on the Telegram stream error/interrupt recovery path that persists partial assistant output for future context. Before this fix, starting queue shutdown could deliberately bypass the serializer and run fallback writes inline while earlier queued callbacks were still pending. That could persist assistant text out of order, duplicate the final assistant message, or apply metrics/context-estimate updates against the wrong message sequence.

The fix keeps one serialization path per Telegram session during shutdown, so recovery persistence can no longer race earlier queued session writes.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_queue_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --stat`
- `git diff --check`
