### PR TITLE
FIX: reviewer PR diff base

### DIFF
--- a/internal/agents/builtin/reviewer/agent.yaml
+++ b/internal/agents/builtin/reviewer/agent.yaml
@@ -9,12 +9,22 @@ tools:
   enabled: [read_file, glob, grep, shell]
 
 shell:
-  allow: ["git diff *", "git log *", "git status", "git show *", "git blame *"]
+  allow:
+    - "git diff *"
+    - "git log *"
+    - "git status"
+    - "git show *"
+    - "git blame *"
+    - "git fetch *"
+    - "git merge-base *"
+    - "gh pr view *"
+    - "gh pr diff *"
   auto_run: true
   scripts:
     git-changes: "git status --porcelain=v1 && echo '---' && git diff --stat && echo '---' && git diff"
     git-staged: "git diff --cached --stat && echo '---' && git diff --cached"
     git-recent: "git log --oneline -20"
+    review-branch-main: "git fetch origin main --prune && base=$(git merge-base HEAD origin/main) && git diff --stat --no-color ${base}...HEAD && echo '---' && git diff --no-color ${base}...HEAD"
 
 max_turns: 200
 handover_mode: "light"

--- a/internal/agents/builtin/reviewer/system.md
+++ b/internal/agents/builtin/reviewer/system.md
@@ -46,12 +46,25 @@ Turn 1: [parallel] git diff, git log, read file1.go, read file2.go, grep for fun
 
 #### Turn 1: Get the Diff and Read Changed Files
 
-You already know WHICH files changed (see above). Now get the actual changes:
+First decide what kind of review the user requested:
+
+- **GitHub pull request review** (the prompt contains a PR number like `PR #353`, `#353`, a `github.com/.../pull/353` URL, or explicitly says GitHub PR): use GitHub's PR metadata and diff as the source of truth. When the user writes `#353`, pass `353` to `gh` because an unquoted `#353` may be parsed as a shell comment. In the first parallel batch, run:
+  - `gh pr view <number-or-url> --json number,title,url,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository`
+  - `gh pr diff <number-or-url> --patch --color=never`
+  - read the changed files indicated by that PR diff as needed
+
+  Do **not** use plain `git diff`, the current local branch's upstream, or a stale local checkout for a GitHub PR review. GitHub's PR diff is deterministic for the PR base/head and avoids unrelated branch changes leaking into the review.
+
+- **Committed local branch review** (the user asks to review a branch against a base branch): fetch the requested base branch and diff against the merge-base, for example `git fetch origin <base> --prune`, `git merge-base HEAD origin/<base>`, then `git diff <merge-base>...HEAD`. Do not diff against the current branch's upstream unless the user explicitly asks for that upstream.
+
+- **Uncommitted local changes review** (the default prompt or explicit uncommitted/staged changes request): use the working tree/index diff commands below.
+
+For uncommitted local changes, you already know WHICH files changed (see above). Now get the actual changes:
 
 Make ALL these calls in parallel:
 ```
 [parallel]
-- shell: git diff && git diff --cached    # Full diff content
+- shell: git diff && git diff --cached    # Full uncommitted/staged diff content only
 - shell: git log --oneline -5             # Recent commit context
 - read: [all changed files in parallel]   # Full file context
 ```

--- a/internal/agents/embedded_test.go
+++ b/internal/agents/embedded_test.go
@@ -160,6 +160,49 @@ func TestBuiltinAgentConfigs(t *testing.T) {
 	}
 }
 
+func TestReviewerBuiltinUsesGitHubPRDiffForPRReviews(t *testing.T) {
+	agent, err := getBuiltinAgent("reviewer")
+	if err != nil {
+		t.Fatalf("getBuiltinAgent(reviewer): %v", err)
+	}
+
+	promptChecks := []string{
+		"GitHub pull request review",
+		"When the user writes `#353`, pass `353` to `gh`",
+		"gh pr view <number-or-url>",
+		"gh pr diff <number-or-url> --patch --color=never",
+		"Do **not** use plain `git diff`",
+		"stale local checkout",
+		"unrelated branch changes",
+		"git merge-base HEAD origin/<base>",
+		"git diff <merge-base>...HEAD",
+	}
+	for _, want := range promptChecks {
+		if !strings.Contains(agent.SystemPrompt, want) {
+			t.Errorf("reviewer prompt missing %q", want)
+		}
+	}
+
+	allowChecks := []string{
+		"gh pr view *",
+		"gh pr diff *",
+		"git fetch *",
+		"git merge-base *",
+	}
+	for _, want := range allowChecks {
+		if !stringSliceContains(agent.Shell.Allow, want) {
+			t.Errorf("reviewer shell.allow = %#v, missing %q", agent.Shell.Allow, want)
+		}
+	}
+
+	branchScript := agent.Shell.Scripts["review-branch-main"]
+	for _, want := range []string{"git fetch origin main --prune", "git merge-base HEAD origin/main", "git diff --no-color ${base}...HEAD"} {
+		if !strings.Contains(branchScript, want) {
+			t.Errorf("review-branch-main script = %q, missing %q", branchScript, want)
+		}
+	}
+}
+
 func TestDeveloperBuiltinCanSpawnDocumentedSubagents(t *testing.T) {
 	agent, err := getBuiltinAgent("developer")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Update the built-in reviewer workflow so GitHub PR reviews use deterministic GitHub PR metadata and `gh pr diff --patch --color=never` instead of the current local branch diff.
- Allow the reviewer to run the required `gh pr view` / `gh pr diff` commands and merge-base/fetch commands for local branch reviews.
- Add regression coverage that locks the reviewer to GitHub PR diffs for PR review prompts and merge-base diffs for committed local branch reviews.

## Bug scenario
In /host/patch-triage, PR #353 is based on origin/main and only changes stale-patch files. The previous reviewer instructions told the agent to gather context with plain `git diff`, which can reflect the local checkout/upstream state rather than the PR base/head pair. That allowed unrelated branch/request-revision work, such as removal of `claim_next_revision_patch`, to appear in the diff even though GitHub's PR diff did not include it.

## Fix
For prompts that mention a GitHub PR number or PR URL, reviewer now treats GitHub as the source of truth:

```bash
gh pr view <number-or-url> --json number,title,url,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository
gh pr diff <number-or-url> --patch --color=never
```

For committed local branch reviews, reviewer is instructed to fetch the requested base and diff `<merge-base>...HEAD` rather than using the branch upstream.

## Validation
- `gofmt -w internal/agents/embedded_test.go`
- `go test ./internal/agents`
- `go test ./...`
- `go build ./...`
