### PR TITLE
FIX: headless tool approval prompts

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -94,6 +94,11 @@ Agent examples (use @agent shortcut or --agent flag):
   term-llm ask @editor "Add error handling" -f utils.go
   term-llm ask --agent web-researcher "Find info about Go 1.22"
 
+Non-interactive use (jobs/CI/no TTY):
+  Tool approval prompts require an interactive terminal or web approval UI.
+  For programmatic runs, pre-authorize tools with --yolo or explicit allowlists
+  such as --read-dir, --write-dir, and --shell-allow.
+
 Line range syntax for files:
   main.go       - Include entire file
   main.go:11-22 - Include only lines 11-22
@@ -146,6 +151,22 @@ func init() {
 	askCmd.Flags().Lookup("resume").NoOptDefVal = " " // space means "flag was passed without value"
 
 	rootCmd.AddCommand(askCmd)
+}
+
+func configureAskNonTUIApprovalPrompt(toolMgr *tools.ToolManager, useRichRenderer bool, approvalTTYAvailable bool) {
+	if useRichRenderer || toolMgr == nil || !approvalTTYAvailable {
+		return
+	}
+	// Non-TUI mode with a controlling terminal: set up approval UI directly
+	// (no tea.Program to pause). In headless jobs/CI this must remain unset so
+	// the approval manager returns an actionable non-interactive permission error
+	// instead of trying to open /dev/tty for every prompt.
+	toolMgr.ApprovalMgr.PromptUIFunc = func(path string, isWrite bool, isShell bool, workDir string) (tools.ApprovalResult, error) {
+		if isShell {
+			return tools.RunShellApprovalUI(path, workDir)
+		}
+		return tools.RunFileApprovalUI(path, isWrite)
+	}
 }
 
 func runAsk(cmd *cobra.Command, args []string) error {
@@ -543,15 +564,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	streamEvents := adapter.Events()
 
 	var teaProgram *tea.Program
-	if !useRichRenderer && toolMgr != nil {
-		// Non-TUI mode: set up approval UI directly (no tea.Program to pause)
-		toolMgr.ApprovalMgr.PromptUIFunc = func(path string, isWrite bool, isShell bool, workDir string) (tools.ApprovalResult, error) {
-			if isShell {
-				return tools.RunShellApprovalUI(path, workDir)
-			}
-			return tools.RunFileApprovalUI(path, isWrite)
-		}
-	}
+	configureAskNonTUIApprovalPrompt(toolMgr, useRichRenderer, tools.ApprovalTTYAvailable())
 
 	runRenderer := func(ctx context.Context, events <-chan ui.StreamEvent) error {
 		if teaProgram != nil {

--- a/cmd/ask_noninteractive_test.go
+++ b/cmd/ask_noninteractive_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func TestConfigureAskNonTUIApprovalPromptSkipsHeadless(t *testing.T) {
+	mgr, err := tools.NewToolManager(&tools.ToolConfig{Enabled: []string{"read_file"}}, &config.Config{})
+	if err != nil {
+		t.Fatalf("NewToolManager: %v", err)
+	}
+
+	configureAskNonTUIApprovalPrompt(mgr, false, false)
+	if mgr.ApprovalMgr.PromptUIFunc != nil {
+		t.Fatal("PromptUIFunc was set for a headless non-TUI run")
+	}
+
+	_, err = mgr.ApprovalMgr.CheckPathApproval("read_file", t.TempDir(), "", false)
+	if err == nil {
+		t.Fatal("expected non-interactive permission error")
+	}
+	toolErr, ok := err.(*tools.ToolError)
+	if !ok {
+		t.Fatalf("error type = %T, want *tools.ToolError", err)
+	}
+	if toolErr.Type != tools.ErrPermissionDenied {
+		t.Fatalf("type = %s, want %s", toolErr.Type, tools.ErrPermissionDenied)
+	}
+}
+
+func TestConfigureAskNonTUIApprovalPromptSetsWhenTTYAvailable(t *testing.T) {
+	mgr, err := tools.NewToolManager(&tools.ToolConfig{Enabled: []string{"read_file"}}, &config.Config{})
+	if err != nil {
+		t.Fatalf("NewToolManager: %v", err)
+	}
+
+	configureAskNonTUIApprovalPrompt(mgr, false, true)
+	if mgr.ApprovalMgr.PromptUIFunc == nil {
+		t.Fatal("PromptUIFunc was not set for a non-TUI run with TTY")
+	}
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -164,7 +164,9 @@ func runExec(cmd *cobra.Command, args []string) error {
 		if execYolo {
 			toolMgr.ApprovalMgr.SetYoloMode(true)
 		}
-		toolMgr.ApprovalMgr.PromptFunc = tools.HuhApprovalPrompt
+		if tools.ApprovalTTYAvailable() {
+			toolMgr.ApprovalMgr.PromptFunc = tools.HuhApprovalPrompt
+		}
 		toolMgr.SetupEngine(engine)
 		localToolSpecs = toolMgr.GetSpecs()
 

--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -302,8 +302,10 @@ func runLoop(cmd *cobra.Command, args []string) error {
 		// In loop mode, we use yolo (auto-approve) by default for headless operation
 		if loopYolo {
 			toolMgr.ApprovalMgr.SetYoloMode(true)
-		} else {
-			// Non-yolo mode: use huh approval prompts
+		} else if tools.ApprovalTTYAvailable() {
+			// Non-yolo mode with an interactive terminal: use huh approval prompts.
+			// Headless loop runs leave prompting unset so approval failures are
+			// deterministic and actionable instead of terminal errors.
 			toolMgr.ApprovalMgr.PromptFunc = tools.HuhApprovalPrompt
 		}
 

--- a/internal/tools/approval.go
+++ b/internal/tools/approval.go
@@ -540,7 +540,7 @@ func (m *ApprovalManager) CheckPathApproval(toolName, path, toolInfo string, isW
 		promptFunc = m.parent.PromptFunc
 	}
 	if promptFunc == nil {
-		return Cancel, NewToolError(ErrPermissionDenied, "path not in allowlist and no TTY for approval")
+		return Cancel, NewToolError(ErrPermissionDenied, nonInteractivePathApprovalMessage(isWrite))
 	}
 
 	dir := getDirectoryForApproval(absPath)
@@ -638,6 +638,17 @@ func (m *ApprovalManager) handleFileApprovalResult(result ApprovalResult, path s
 }
 
 // getDirectoryForApproval determines which directory to ask approval for.
+func nonInteractivePathApprovalMessage(isWrite bool) string {
+	if isWrite {
+		return "path requires approval, but no interactive approval UI/TTY is available; run with --yolo to auto-approve tools, or pre-authorize this path with --write-dir (read operations use --read-dir; jobs/agents can use write_dir/read_dir)"
+	}
+	return "path requires approval, but no interactive approval UI/TTY is available; run with --yolo to auto-approve tools, or pre-authorize this path with --read-dir (write operations use --write-dir; jobs/agents can use read_dir/write_dir)"
+}
+
+func nonInteractiveShellApprovalMessage() string {
+	return "shell command requires approval, but no interactive approval UI/TTY is available; run with --yolo to auto-approve tools, or pre-authorize the command with --shell-allow (or a job/agent shell_allow)"
+}
+
 func getDirectoryForApproval(path string) string {
 	// If it's a directory, use it directly
 	info, err := os.Stat(path)
@@ -720,7 +731,7 @@ func (m *ApprovalManager) CheckShellApproval(command, workDir string) (ConfirmOu
 		promptFunc = m.parent.PromptFunc
 	}
 	if promptFunc == nil {
-		return Cancel, NewToolError(ErrPermissionDenied, "command not in allowlist and no TTY for approval")
+		return Cancel, NewToolError(ErrPermissionDenied, nonInteractiveShellApprovalMessage())
 	}
 
 	req := &ApprovalRequest{

--- a/internal/tools/approval_noninteractive_test.go
+++ b/internal/tools/approval_noninteractive_test.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckPathApprovalNoPromptReturnsActionableNonInteractiveError(t *testing.T) {
+	mgr := NewApprovalManager(NewToolPermissions())
+
+	_, err := mgr.CheckPathApproval("read_file", t.TempDir(), "", false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	toolErr, ok := err.(*ToolError)
+	if !ok {
+		t.Fatalf("error type = %T, want *ToolError", err)
+	}
+	if toolErr.Type != ErrPermissionDenied {
+		t.Fatalf("type = %s, want %s", toolErr.Type, ErrPermissionDenied)
+	}
+	for _, want := range []string{"requires approval", "--yolo", "--read-dir", "--write-dir"} {
+		if !strings.Contains(toolErr.Message, want) {
+			t.Fatalf("message %q missing %q", toolErr.Message, want)
+		}
+	}
+	if strings.Contains(toolErr.Message, "/dev/tty") {
+		t.Fatalf("message should not expose /dev/tty failure: %q", toolErr.Message)
+	}
+}
+
+func TestCheckShellApprovalNoPromptReturnsActionableNonInteractiveError(t *testing.T) {
+	mgr := NewApprovalManager(NewToolPermissions())
+
+	_, err := mgr.CheckShellApproval("echo hi", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	toolErr, ok := err.(*ToolError)
+	if !ok {
+		t.Fatalf("error type = %T, want *ToolError", err)
+	}
+	if toolErr.Type != ErrPermissionDenied {
+		t.Fatalf("type = %s, want %s", toolErr.Type, ErrPermissionDenied)
+	}
+	for _, want := range []string{"requires approval", "--yolo", "--shell-allow"} {
+		if !strings.Contains(toolErr.Message, want) {
+			t.Fatalf("message %q missing %q", toolErr.Message, want)
+		}
+	}
+	if strings.Contains(toolErr.Message, "/dev/tty") {
+		t.Fatalf("message should not expose /dev/tty failure: %q", toolErr.Message)
+	}
+}

--- a/internal/tools/ask_user_ui.go
+++ b/internal/tools/ask_user_ui.go
@@ -736,7 +736,7 @@ func getAskUserTTY() (*os.File, error) {
 func RunAskUser(questions []AskUserQuestion) ([]AskUserAnswer, error) {
 	tty, err := getAskUserTTY()
 	if err != nil {
-		return nil, fmt.Errorf("no TTY available: %w", err)
+		return nil, fmt.Errorf("ask_user requires an interactive terminal or web approval UI; no TTY is available for this non-interactive run (avoid ask_user in jobs/CI, or run from an interactive terminal/web session): %w", err)
 	}
 	defer tty.Close()
 

--- a/internal/tools/prompt.go
+++ b/internal/tools/prompt.go
@@ -19,7 +19,25 @@ var (
 	approvalMu      sync.Mutex
 	OnApprovalStart func() // Called before showing prompt (pause TUI)
 	OnApprovalEnd   func() // Called after prompt answered (resume TUI)
+
+	approvalTTYAvailable = defaultApprovalTTYAvailable
 )
+
+// ApprovalTTYAvailable reports whether approval prompts can use a controlling
+// terminal. It intentionally checks /dev/tty rather than stdin/stdout so CLI
+// commands that pipe model output can still prompt when launched from a terminal.
+func ApprovalTTYAvailable() bool {
+	return approvalTTYAvailable()
+}
+
+func defaultApprovalTTYAvailable() bool {
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return false
+	}
+	_ = tty.Close()
+	return true
+}
 
 // AskUserUIHooks allows the TUI to coordinate with ask_user tool prompts.
 var (

--- a/internal/tools/prompt_noninteractive_test.go
+++ b/internal/tools/prompt_noninteractive_test.go
@@ -1,0 +1,18 @@
+package tools
+
+import "testing"
+
+func TestApprovalTTYAvailableUsesInjectedChecker(t *testing.T) {
+	old := approvalTTYAvailable
+	t.Cleanup(func() { approvalTTYAvailable = old })
+
+	approvalTTYAvailable = func() bool { return false }
+	if ApprovalTTYAvailable() {
+		t.Fatal("ApprovalTTYAvailable() = true, want false")
+	}
+
+	approvalTTYAvailable = func() bool { return true }
+	if !ApprovalTTYAvailable() {
+		t.Fatal("ApprovalTTYAvailable() = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes headless/non-interactive tool approval behavior for `term-llm ask` and related non-TUI paths.

## Observed failure

A jobs/program worker ran `term-llm ask --agent developer` without a controlling TTY. When the agent attempted normal tools (`shell`, `read_file`, `glob`, `write_file`, `ask_user`), approvals were wired to terminal UI code and failed before useful execution with errors like:

```
PERMISSION_DENIED: no TTY available: open /dev/tty: no such device or address
```

This made non-interactive runs look like every tool was broken, instead of distinguishing pre-authorized tools from tools that need approval.

## Root cause

`ask` uses the non-rich renderer when stdout is not a terminal. That path unconditionally installed `RunFileApprovalUI` / `RunShellApprovalUI`, which open `/dev/tty`. In a jobs/CI/no-TTY process, any tool call requiring approval therefore tried terminal approval and failed with the raw `/dev/tty` error.

Some other non-TUI paths (`exec`, `loop`) similarly installed interactive approval prompts without checking for a controlling terminal.

## Fix

- Added `tools.ApprovalTTYAvailable()` to explicitly check for a controlling `/dev/tty` before wiring terminal approval prompts.
- Updated `ask` non-TUI setup to only install terminal approval UI when a TTY is available.
- Updated `exec`/`loop` prompt wiring to avoid installing interactive approval prompts in headless runs.
- Improved approval-denied messages when no prompt mechanism exists so they are deterministic/actionable, e.g. use `--yolo`, `--read-dir`, `--write-dir`, or `--shell-allow`.
- Improved the `ask_user` no-TTY error to explain that it requires an interactive terminal/web UI and should be avoided in jobs/CI.
- Documented non-interactive `ask` usage in help text.

Pre-authorized operations still bypass prompting; only operations that actually need approval now fail with the clear non-interactive permission message.

## Validation

- Added regression tests for headless `ask` approval prompt wiring.
- Added regression tests for actionable non-interactive path/shell approval errors.
- Added coverage for the injected TTY-availability checker.
- Ran:

```
gofmt -w .
go test ./internal/tools ./cmd
go test ./...
```
