### PR TITLE
fix: Response completion does an uncancellable session-store lookup and can leave runs stuck in-progress forever

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1493,7 +1493,7 @@ func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID
 			return "", err
 		}
 	}
-	durableID := s.latestDurableResponseIDForSession(context.Background(), sessionID)
+	durableID := s.latestDurableResponseIDForSessionBestEffort(context.Background(), sessionID)
 	completedID := respID
 	if durableID != "" {
 		completedID = durableID
@@ -1910,7 +1910,7 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		if options.resetResponseIDsOnSuccess {
 			s.unregisterSessionResponseIDs(sessionID)
 		}
-		durableID := s.latestDurableResponseIDForSession(context.Background(), sessionID)
+		durableID := s.latestDurableResponseIDForSessionBestEffort(runCtx, sessionID)
 		completedID := respID
 		if durableID != "" {
 			completedID = durableID

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 func TestEncodeTextDeltaPayloadMatchesJSONMarshalForInvalidUTF8(t *testing.T) {
@@ -170,6 +171,96 @@ func TestAppendResponseRunEventKeepsClientToolFileChanges(t *testing.T) {
 	}
 	if !sawFileChange {
 		t.Fatalf("events = %+v, want response.file_change for non-server tool", run.events)
+	}
+}
+
+type fixedLatestVisibleMessageIDStore struct {
+	session.Store
+	id          int64
+	sawDeadline bool
+}
+
+func (s *fixedLatestVisibleMessageIDStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, error) {
+	_, s.sawDeadline = ctx.Deadline()
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return s.id, nil
+}
+
+type blockingLatestVisibleMessageIDStore struct {
+	session.Store
+	sawDeadline bool
+}
+
+func (s *blockingLatestVisibleMessageIDStore) GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, error) {
+	_, s.sawDeadline = ctx.Deadline()
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func TestLatestDurableResponseIDForSessionBestEffortIgnoresParentCancellation(t *testing.T) {
+	store := &fixedLatestVisibleMessageIDStore{id: 42}
+	srv := &serveServer{store: store}
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := srv.latestDurableResponseIDForSessionBestEffort(parentCtx, "sess_test")
+	want := durableResponseIDForMessageID(42)
+	if got != want {
+		t.Fatalf("latestDurableResponseIDForSessionBestEffort() = %q, want %q", got, want)
+	}
+	if !store.sawDeadline {
+		t.Fatal("best-effort durable lookup should apply its own deadline")
+	}
+}
+
+func TestStoreCompletedResponseRunFallsBackWhenDurableLookupTimesOut(t *testing.T) {
+	oldTimeout := durableResponseLookupTimeout
+	durableResponseLookupTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		durableResponseLookupTimeout = oldTimeout
+	})
+
+	store := &blockingLatestVisibleMessageIDStore{}
+	srv := &serveServer{store: store}
+	runtime := &serveRuntime{}
+	var result serveRunResult
+	result.Text.WriteString("done")
+
+	done := make(chan struct{})
+	var (
+		respID string
+		err    error
+	)
+	go func() {
+		respID, err = srv.storeCompletedResponseRun(runtime, "sess_timeout", "", "mock", time.Now().Unix(), result, false)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("storeCompletedResponseRun blocked on durable response lookup")
+	}
+	if err != nil {
+		t.Fatalf("storeCompletedResponseRun() error = %v", err)
+	}
+	if strings.HasPrefix(respID, durableResponseMessagePrefix) {
+		t.Fatalf("respID = %q, want ephemeral fallback id after durable lookup timeout", respID)
+	}
+	if !strings.HasPrefix(respID, "resp_") {
+		t.Fatalf("respID = %q, want ephemeral response id prefix", respID)
+	}
+	if !store.sawDeadline {
+		t.Fatal("durable response lookup should use a bounded deadline")
+	}
+	run, ok := srv.ensureResponseRuns().get(respID)
+	if !ok {
+		t.Fatalf("completed run %q not found", respID)
+	}
+	if status := run.snapshot()["status"]; status != "completed" {
+		t.Fatalf("run status = %v, want completed", status)
 	}
 }
 

--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -6,12 +6,15 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
 const durableResponseMessagePrefix = "resp_msg_"
+
+var durableResponseLookupTimeout = 5 * time.Second
 
 type latestVisibleMessageIDStore interface {
 	GetLatestVisibleMessageID(ctx context.Context, sessionID string) (int64, error)
@@ -146,4 +149,16 @@ func (s *serveServer) latestDurableResponseIDForSession(ctx context.Context, ses
 		return ""
 	}
 	return durableResponseIDForMessageID(msgID)
+}
+
+func (s *serveServer) latestDurableResponseIDForSessionBestEffort(ctx context.Context, sessionID string) string {
+	if s == nil || s.store == nil || sessionID == "" {
+		return ""
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), durableResponseLookupTimeout)
+	defer cancel()
+	return s.latestDurableResponseIDForSession(dbCtx, sessionID)
 }


### PR DESCRIPTION
## What changed

- Replaced both response-completion durable-response lookups with a bounded best-effort helper that uses `context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)`.
- Kept existing behavior of preferring the durable response id when available, but now completion falls back to the ephemeral `resp_*` id if the session-store lookup errors or times out.
- Added regression tests covering:
  - best-effort lookup still working even when the parent context is already canceled
  - synchronous completed-response storage no longer blocking forever on a stuck durable lookup

## Why this is high-value

Before this change, both completion paths used `context.Background()` for the session-store read that discovers the durable response id. If SQLite or the session store blocked there, the model work could already be finished but the run would never reach `response.completed`, never clear the active-run/session-busy state, never emit terminal `[DONE]`, and could delay shutdown waiting on the stuck goroutine.

This fix bounds that final store read to 5 seconds and makes it best-effort, so completion and cleanup still happen even when the durable lookup is unhealthy.

## Validation

- `gofmt -w cmd/serve_responses_durable.go cmd/serve_response_runs.go cmd/serve_response_runs_test.go`
- `go build ./...`
- `go test ./...`
- Added targeted regression tests in `cmd/serve_response_runs_test.go`
