### PR TITLE
fix: jobs can remain permanently active if final status persistence fails after three short retries

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -229,14 +229,15 @@ var (
 )
 
 const (
-	jobsV2SchedulerMinDelay   = 100 * time.Millisecond
-	jobsV2SchedulerIdleDelay  = time.Minute
-	jobsV2SchedulerErrorDelay = 200 * time.Millisecond
-	jobsV2WorkerMinDelay      = 100 * time.Millisecond
-	jobsV2WorkerIdleDelay     = time.Minute
-	jobsV2WorkerErrorDelay    = 200 * time.Millisecond
-	jobsV2FinishRunAttempts   = 3
-	jobsV2FinishRunRetryDelay = 50 * time.Millisecond
+	jobsV2SchedulerMinDelay      = 100 * time.Millisecond
+	jobsV2SchedulerIdleDelay     = time.Minute
+	jobsV2SchedulerErrorDelay    = 200 * time.Millisecond
+	jobsV2WorkerMinDelay         = 100 * time.Millisecond
+	jobsV2WorkerIdleDelay        = time.Minute
+	jobsV2WorkerErrorDelay       = 200 * time.Millisecond
+	jobsV2FinishRunRetryDelay    = 50 * time.Millisecond
+	jobsV2FinishRunRetryMaxDelay = time.Second
+	jobsV2FinishRunRetryTimeout  = 30 * time.Second
 )
 
 type jobsV2ProgramConfig struct {
@@ -1417,19 +1418,31 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 }
 
 func (m *jobsV2Manager) finishRunWithRetry(runID string, status jobsV2RunStatus, result jobsV2RunResult, runErr error, policyAttempt int) {
+	deadline := time.Now().Add(jobsV2FinishRunRetryTimeout)
+	delay := jobsV2FinishRunRetryDelay
+	attempts := 0
 	var lastErr error
-	for attempt := 1; attempt <= jobsV2FinishRunAttempts; attempt++ {
+	for {
+		attempts++
 		if err := m.finishRun(runID, status, result, runErr, policyAttempt); err != nil {
 			lastErr = err
-			if attempt < jobsV2FinishRunAttempts {
-				time.Sleep(jobsV2FinishRunRetryDelay)
-				continue
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				break
 			}
-		} else {
-			return
+			wait := min(delay, remaining)
+			select {
+			case <-time.After(wait):
+			case <-m.doneChan():
+				log.Printf("jobs v2: failed to finish run %q as %s after %d attempts; manager is closing and run may remain active until restart recovery: %v", runID, status, attempts, lastErr)
+				return
+			}
+			delay = min(delay*2, jobsV2FinishRunRetryMaxDelay)
+			continue
 		}
+		return
 	}
-	log.Printf("jobs v2: failed to finish run %q as %s after %d attempts; run may remain active: %v", runID, status, jobsV2FinishRunAttempts, lastErr)
+	log.Printf("jobs v2: failed to finish run %q as %s after %d attempts over %s; run may remain active until restart recovery: %v", runID, status, attempts, jobsV2FinishRunRetryTimeout, lastErr)
 }
 
 func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result jobsV2RunResult, runErr error, attempt int) error {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -1748,7 +1748,7 @@ func TestJobsV2ExecuteRunRetriesFinishRunAfterTransientDBLock(t *testing.T) {
 					return jobsV2RunResult{}, err
 				}
 				go func() {
-					time.Sleep(70 * time.Millisecond)
+					time.Sleep(250 * time.Millisecond)
 					_ = tx.Rollback()
 					_ = lockDB.Close()
 					close(lockReleased)


### PR DESCRIPTION
## What changed

- Reworked `finishRunWithRetry` in `cmd/serve_jobs_v2.go` to retry final run persistence for up to 30 seconds instead of only 3 short attempts.
- Added bounded exponential backoff between retries, starting at 50ms and capping at 1s.
- Stop retrying early if the manager is shutting down, and log that restart recovery may still be needed.
- Strengthened the existing transient SQLite lock test so it now holds the lock long enough to exceed the old 3-attempt / 150ms retry window.

## Why this is high-value

A run only leaves `queued` / `claimed` / `running` through final status persistence. Before this change, a brief burst of SQLite write failures at completion time could leave a run non-terminal forever until process restart. That could permanently consume concurrency slots and block future job executions, especially for single-run or `forbid` jobs.

This change keeps terminalization durable across transient DB write failures, preventing a single short-lived persistence error from wedging the job pipeline.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./...`
- Updated `TestJobsV2ExecuteRunRetriesFinishRunAfterTransientDBLock` passes with a lock duration that exceeds the old retry budget.
