### PR TITLE
fix: serve HTTP server has no read/write/idle deadlines, so slow clients can pin handlers and block shutdown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1105,6 +1105,12 @@ type serveServer struct {
 	fileTrackStoreFn     func() *filetrack.Store // test seam; nil → process-wide store from config
 }
 
+const (
+	serveReadHeaderTimeout     = 5 * time.Second
+	serveIdleTimeout           = 2 * time.Minute
+	serveStreamingWriteTimeout = 30 * time.Second
+)
+
 // fileTrackStore returns the file-change history store, or nil when file
 // tracking is disabled.
 func (s *serveServer) fileTrackStore() *filetrack.Store {
@@ -1114,13 +1120,21 @@ func (s *serveServer) fileTrackStore() *filetrack.Store {
 	return fileTrackingStore(s.cfgRef)
 }
 
+func (s *serveServer) newHTTPServer() *http.Server {
+	return &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", s.cfg.host, s.cfg.port),
+		Handler:           s.httpHandler(),
+		ReadHeaderTimeout: serveReadHeaderTimeout,
+		IdleTimeout:       serveIdleTimeout,
+		// Leave WriteTimeout at zero: several endpoints stream for minutes or
+		// longer, so they use per-write deadlines on the ResponseWriter instead.
+	}
+}
+
 func (s *serveServer) Start() error {
 	s.shutdownCh = make(chan struct{})
 	s.shutdownOnce = sync.Once{}
-	s.server = &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", s.cfg.host, s.cfg.port),
-		Handler: s.httpHandler(),
-	}
+	s.server = s.newHTTPServer()
 
 	if s.cfg.ui {
 		s.prewarmUIAssetCache()

--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -185,6 +185,9 @@ func (s *serveServer) streamAnthropicMessages(ctx context.Context, w http.Respon
 		writeAnthropicError(w, http.StatusInternalServerError, "api_error", "streaming not supported")
 		return
 	}
+	streamWriter := newStreamingResponseWriter(w, serveStreamingWriteTimeout)
+	w = streamWriter
+	flusher = streamWriter
 
 	setSSEHeaders(w)
 	flusher.Flush()

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -164,6 +164,9 @@ func (s *serveServer) streamChatCompletions(ctx context.Context, w http.Response
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "streaming not supported")
 		return
 	}
+	streamWriter := newStreamingResponseWriter(w, serveStreamingWriteTimeout)
+	w = streamWriter
+	flusher = streamWriter
 
 	setSSEHeaders(w)
 	flusher.Flush()

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -48,6 +49,54 @@ func setSSEHeaders(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
+}
+
+// streamingResponseWriter bounds each blocking Write/Flush call without putting
+// a lifetime cap on the entire streaming response.
+type streamingResponseWriter struct {
+	http.ResponseWriter
+	writeTimeout time.Duration
+}
+
+func newStreamingResponseWriter(w http.ResponseWriter, writeTimeout time.Duration) *streamingResponseWriter {
+	return &streamingResponseWriter{ResponseWriter: w, writeTimeout: writeTimeout}
+}
+
+func (w *streamingResponseWriter) Write(b []byte) (int, error) {
+	if err := w.setWriteDeadline(); err != nil {
+		return 0, err
+	}
+	defer w.clearWriteDeadline()
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *streamingResponseWriter) Flush() {
+	if err := w.setWriteDeadline(); err != nil {
+		return
+	}
+	defer w.clearWriteDeadline()
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (w *streamingResponseWriter) setWriteDeadline() error {
+	if w.writeTimeout <= 0 {
+		return nil
+	}
+	err := http.NewResponseController(w.ResponseWriter).SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	if err == nil || errors.Is(err, http.ErrNotSupported) {
+		return nil
+	}
+	return fmt.Errorf("set streaming write deadline: %w", err)
+}
+
+func (w *streamingResponseWriter) clearWriteDeadline() {
+	if w.writeTimeout <= 0 {
+		return
+	}
+	err := http.NewResponseController(w.ResponseWriter).SetWriteDeadline(time.Time{})
+	if err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return
+	}
 }
 
 func writeSSEEvent(w io.Writer, event string, payload any) error {

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -8,11 +8,13 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/session"
 )
@@ -45,6 +47,81 @@ func TestSetSessionNumberHeader(t *testing.T) {
 	setSessionNumberHeader(recorder, &serveRuntime{sessionMeta: &session.Session{Number: 42}})
 	if got := recorder.Header().Get("x-session-number"); got != "42" {
 		t.Fatalf("x-session-number = %q, want 42", got)
+	}
+}
+
+type streamingDeadlineRecorder struct {
+	header    http.Header
+	body      bytes.Buffer
+	deadlines []time.Time
+	flushes   int
+}
+
+func (r *streamingDeadlineRecorder) Header() http.Header {
+	if r.header == nil {
+		r.header = make(http.Header)
+	}
+	return r.header
+}
+
+func (r *streamingDeadlineRecorder) Write(b []byte) (int, error) {
+	return r.body.Write(b)
+}
+
+func (r *streamingDeadlineRecorder) WriteHeader(statusCode int) {}
+
+func (r *streamingDeadlineRecorder) Flush() {
+	r.flushes++
+}
+
+func (r *streamingDeadlineRecorder) SetWriteDeadline(deadline time.Time) error {
+	r.deadlines = append(r.deadlines, deadline)
+	return nil
+}
+
+func TestStreamingResponseWriterSetsAndClearsWriteDeadline(t *testing.T) {
+	recorder := &streamingDeadlineRecorder{}
+	w := newStreamingResponseWriter(recorder, 3*time.Second)
+
+	if _, err := w.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	w.Flush()
+
+	if got := recorder.body.String(); got != "hello" {
+		t.Fatalf("body = %q, want hello", got)
+	}
+	if recorder.flushes != 1 {
+		t.Fatalf("flushes = %d, want 1", recorder.flushes)
+	}
+	if len(recorder.deadlines) != 4 {
+		t.Fatalf("deadline calls = %d, want 4", len(recorder.deadlines))
+	}
+	if recorder.deadlines[0].IsZero() {
+		t.Fatal("first deadline was not set")
+	}
+	if !recorder.deadlines[1].IsZero() {
+		t.Fatal("second deadline was not cleared")
+	}
+	if recorder.deadlines[2].IsZero() {
+		t.Fatal("third deadline was not set")
+	}
+	if !recorder.deadlines[3].IsZero() {
+		t.Fatal("fourth deadline was not cleared")
+	}
+}
+
+func TestStreamingResponseWriterIgnoresUnsupportedDeadline(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	w := newStreamingResponseWriter(recorder, 3*time.Second)
+
+	if _, err := w.Write([]byte("ok")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	w.Flush()
+
+	if got := recorder.Body.String(); got != "ok" {
+		t.Fatalf("body = %q, want ok", got)
 	}
 }
 

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1648,6 +1648,9 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "streaming not supported")
 		return
 	}
+	streamWriter := newStreamingResponseWriter(w, serveStreamingWriteTimeout)
+	w = streamWriter
+	flusher = streamWriter
 
 	setSSEHeaders(w)
 	flusher.Flush()

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -245,6 +245,24 @@ func TestServeServerStopIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestServeServerNewHTTPServerSetsTimeouts(t *testing.T) {
+	s := &serveServer{cfg: serveServerConfig{host: "127.0.0.1", port: 8080}}
+	server := s.newHTTPServer()
+
+	if server == nil {
+		t.Fatal("newHTTPServer() = nil")
+	}
+	if got := server.ReadHeaderTimeout; got != serveReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", got, serveReadHeaderTimeout)
+	}
+	if got := server.IdleTimeout; got != serveIdleTimeout {
+		t.Fatalf("IdleTimeout = %v, want %v", got, serveIdleTimeout)
+	}
+	if got := server.WriteTimeout; got != 0 {
+		t.Fatalf("WriteTimeout = %v, want 0 for streaming endpoints", got)
+	}
+}
+
 func readSSEEvent(t *testing.T, scanner *bufio.Scanner) (string, string, bool) {
 	t.Helper()
 


### PR DESCRIPTION
## What changed

- Set `ReadHeaderTimeout` and `IdleTimeout` on the serve HTTP server in `cmd/serve.go`.
- Kept server-wide `WriteTimeout` at zero so long-lived SSE endpoints do not get an artificial lifetime cap.
- Added a small `streamingResponseWriter` wrapper that applies a per-write `SetWriteDeadline` around every streaming `Write` and `Flush` call.
- Wrapped the serve streaming endpoints (`/v1/chat/completions`, `/v1/messages`, and response-run SSE streams) with that writer so slow or stalled clients cannot block a handler forever.
- Added tests covering the server timeout configuration and the per-write deadline wrapper behavior.

## Why this is high-value

Before this change, `serveServer.Start` created an `http.Server` with no read-header or idle deadlines, and the streaming handlers wrote directly to `http.ResponseWriter`/`Flush` with no per-connection write deadline. That meant:

- slowloris-style header reads could keep connections open indefinitely,
- idle keep-alive clients could sit around forever,
- stalled SSE clients could block inside a socket write/flush indefinitely,
- and blocked streaming handlers could delay or defeat graceful shutdown even though `contextWithShutdown` tries to make them exit promptly.

This fix closes those reliability holes without breaking long-lived streaming behavior.

## Validation

- `gofmt -w cmd/serve.go cmd/serve_protocol.go cmd/serve_handlers_chat.go cmd/serve_handlers_anthropic.go cmd/serve_response_runs.go cmd/serve_test.go cmd/serve_protocol_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
