### PR TITLE
fix: ask response persistence lies to the engine after AddMessage fails, dropping assistant turns

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -608,10 +608,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 			// Calculate duration from stream start
 			durationMs := time.Since(turnStartTime).Milliseconds()
 
-			sessionMsg := session.NewMessageWithReasoningPolicy(sess.ID, assistantMsg, -1, reasoningPersistenceCfg)
-			sessionMsg.DurationMs = durationMs
-			_ = store.AddMessage(ctx, sess.ID, sessionMsg)
-			return nil
+			return persistAskAssistantResponse(ctx, store, sess, assistantMsg, durationMs, reasoningPersistenceCfg)
 		}
 
 		// Set up turn callback for tool result messages and metrics
@@ -644,12 +641,14 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	turnCompletedCallback := persistTurnCompleted
 	if outputTool != nil {
 		responseCompletedCallback = func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
+			if persistResponseCompleted != nil {
+				if err := persistResponseCompleted(ctx, turnIndex, assistantMsg, metrics); err != nil {
+					return err
+				}
+			}
 			outputToolMessagesMu.Lock()
 			outputToolMessages = append(outputToolMessages, assistantMsg)
 			outputToolMessagesMu.Unlock()
-			if persistResponseCompleted != nil {
-				return persistResponseCompleted(ctx, turnIndex, assistantMsg, metrics)
-			}
 			return nil
 		}
 		turnCompletedCallback = func(ctx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
@@ -1047,6 +1046,12 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func persistAskAssistantResponse(ctx context.Context, store session.Store, sess *session.Session, assistantMsg llm.Message, durationMs int64, reasoningPersistenceCfg config.ReasoningConfig) error {
+	sessionMsg := session.NewMessageWithReasoningPolicy(sess.ID, assistantMsg, -1, reasoningPersistenceCfg)
+	sessionMsg.DurationMs = durationMs
+	return store.AddMessage(ctx, sess.ID, sessionMsg)
 }
 
 func ensureOutputToolCaptured(ctx context.Context, provider llm.Provider, registry *llm.ToolRegistry, baseReq llm.Request, outputTool *tools.SetOutputTool, assistantText string) error {

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +13,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
@@ -212,6 +215,114 @@ func TestAskReasoningDoesNotPanicAfterModelCopy(t *testing.T) {
 
 	if got := model.phase; got != "Reading context" {
 		t.Fatalf("expected reasoning to keep/update status phase, got %q", got)
+	}
+}
+
+type askFailOnceMessageStore struct {
+	session.NoopStore
+
+	failErr                    error
+	assistantFailuresRemaining int
+	assistantAttempts          int
+	messages                   []session.Message
+}
+
+func (s *askFailOnceMessageStore) AddMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	if msg.Role == llm.RoleAssistant {
+		s.assistantAttempts++
+		if s.assistantFailuresRemaining > 0 {
+			s.assistantFailuresRemaining--
+			return s.failErr
+		}
+	}
+
+	copied := *msg
+	copied.Parts = append([]llm.Part(nil), msg.Parts...)
+	s.messages = append(s.messages, copied)
+	return nil
+}
+
+func TestAskResponsePersistenceErrorRedeliversAssistantToTurnCallback(t *testing.T) {
+	storeErr := errors.New("sqlite busy")
+	store := &askFailOnceMessageStore{
+		failErr:                    storeErr,
+		assistantFailuresRemaining: 1,
+	}
+	sess := &session.Session{ID: "ask-persistence-test"}
+	reasoningPersistenceCfg := config.DefaultReasoningConfig()
+	turnStartTime := time.Now()
+
+	tool := &progressiveTestTool{}
+	toolSpec := tool.Spec()
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+
+	provider := llm.NewMockProvider("mock")
+	provider.AddTurn(llm.MockTurn{
+		Text: "I'll count.",
+		ToolCalls: []llm.ToolCall{{
+			ID:        "call-1",
+			Name:      toolSpec.Name,
+			Arguments: json.RawMessage(`{}`),
+		}},
+	})
+
+	engine := llm.NewEngine(provider, registry)
+	engine.SetResponseCompletedCallback(func(ctx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
+		durationMs := time.Since(turnStartTime).Milliseconds()
+		return persistAskAssistantResponse(ctx, store, sess, assistantMsg, durationMs, reasoningPersistenceCfg)
+	})
+	engine.SetTurnCompletedCallback(func(ctx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
+		for _, msg := range turnMessages {
+			sessionMsg := session.NewMessageWithReasoningPolicy(sess.ID, msg, -1, reasoningPersistenceCfg)
+			if msg.Role == llm.RoleAssistant {
+				sessionMsg.DurationMs = time.Since(turnStartTime).Milliseconds()
+			}
+			_ = store.AddMessage(ctx, sess.ID, sessionMsg)
+		}
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), llm.Request{
+		Messages: []llm.Message{llm.UserText("test")},
+		Tools:    []llm.ToolSpec{toolSpec},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		_, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv() error = %v", recvErr)
+		}
+	}
+
+	if store.assistantAttempts != 2 {
+		t.Fatalf("assistant AddMessage attempts = %d, want response failure plus turn retry", store.assistantAttempts)
+	}
+
+	var gotAssistant bool
+	var gotToolResult bool
+	for _, msg := range store.messages {
+		switch msg.Role {
+		case llm.RoleAssistant:
+			if msg.TextContent == "I'll count." {
+				gotAssistant = true
+			}
+		case llm.RoleTool:
+			gotToolResult = true
+		}
+	}
+	if !gotAssistant {
+		t.Fatalf("assistant response was not retried through TurnCompletedCallback; persisted messages: %+v", store.messages)
+	}
+	if !gotToolResult {
+		t.Fatalf("tool result was not persisted; persisted messages: %+v", store.messages)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Return the `store.AddMessage` error from ask response persistence instead of reporting success after a failed assistant write.
- Keep output-tool response tracking aligned with the engine callback contract by only marking the response handled after persistence succeeds.
- Added a focused regression test where the first assistant `AddMessage` fails and the engine redelivers the assistant through `TurnCompletedCallback`, preserving the durable turn.

## Why this is high-value

`term-llm ask` uses `ResponseCompletedCallback` to persist assistant/tool-call turns before tool execution. When that write failed transiently, ask returned `nil`, so the engine believed the assistant turn was already durable and omitted it from the later turn callback. That silently corrupted saved sessions by keeping tool results/metrics while dropping the assistant message that caused them. Returning the write error activates the engine's existing fallback path.

## Validation

- `go test ./cmd -run 'TestAskResponsePersistenceErrorRedeliversAssistantToTurnCallback|TestEnsureOutputTool|TestRunOutputTool' -count=1`
- `go build ./...`
- `go test ./...`
- `git diff --check`
