### PR TITLE
fix: Serve/web fallback snapshot after compaction can delete pre-compaction scrollback

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -554,6 +554,48 @@ func (rt *serveRuntime) persistSnapshot(ctx context.Context, sessionID string, s
 	return true
 }
 
+type compactedMessageReplacer interface {
+	ReplaceCompactedMessages(ctx context.Context, sessionID string, messages []session.Message) error
+}
+
+func (rt *serveRuntime) persistCompactedSnapshot(ctx context.Context, sessionID string, snapshot []llm.Message) bool {
+	if rt.store == nil || sessionID == "" {
+		return false
+	}
+	replacer, ok := rt.store.(compactedMessageReplacer)
+	if !ok {
+		log.Printf("[serve] session ReplaceCompactedMessages unsupported for %s", sessionID)
+		return false
+	}
+	dbCtx, cancel := inlinePersistContext(ctx, 10*time.Second)
+	defer cancel()
+
+	messages := make([]session.Message, 0, len(snapshot))
+	for _, msg := range snapshot {
+		if msg.Role == "" {
+			continue
+		}
+		sessionMsg := session.NewMessage(sessionID, msg, -1)
+		messages = append(messages, *sessionMsg)
+	}
+	if err := replacer.ReplaceCompactedMessages(dbCtx, sessionID, messages); err != nil {
+		log.Printf("[serve] session ReplaceCompactedMessages failed for %s: %v", sessionID, err)
+		return false
+	}
+	if rt.sessionMeta != nil {
+		if refreshed, err := rt.store.Get(dbCtx, sessionID); err == nil && refreshed != nil {
+			rt.sessionMeta = refreshed
+		}
+	}
+	if setErr := rt.store.SetCurrent(dbCtx, sessionID); setErr != nil {
+		log.Printf("[serve] session SetCurrent failed for %s: %v", sessionID, setErr)
+	}
+	if statusErr := rt.store.UpdateStatus(dbCtx, sessionID, session.StatusActive); statusErr != nil {
+		log.Printf("[serve] session UpdateStatus(active) failed for %s: %v", sessionID, statusErr)
+	}
+	return true
+}
+
 // appendMessages incrementally adds new messages to the DB using AddMessage.
 // Unlike persistSnapshot (which does a full DELETE+INSERT replace), this only
 // appends new messages, making each callback commit a small atomic write that
@@ -880,17 +922,23 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		return snapshot
 	}
 
+	compactedActiveHistory := false
 	persistProducedSnapshot := func(persistCtx context.Context) {
 		producedMu.Lock()
 		defer producedMu.Unlock()
 
 		snapshot := buildSnapshotLocked()
+		useCompactedSnapshot := compactedActiveHistory
 		if stateful {
 			rt.history = snapshot
 			rt.historyPersisted = false
 		}
 		if persisted {
-			rt.historyPersisted = rt.persistSnapshot(persistCtx, req.SessionID, snapshot)
+			if useCompactedSnapshot {
+				rt.historyPersisted = rt.persistCompactedSnapshot(persistCtx, req.SessionID, snapshot)
+			} else {
+				rt.historyPersisted = rt.persistSnapshot(persistCtx, req.SessionID, snapshot)
+			}
 		}
 		persistPlatformInjectionLocked()
 	}
@@ -1033,6 +1081,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 			compacted = append(compacted, result.NewMessages...)
 		}
 		baseHistory = compacted
+		compactedActiveHistory = true
 		inputMessages = nil
 		produced = nil
 		lastAppendedIdx = 0
@@ -1308,6 +1357,7 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 
 	var newHistory []llm.Message
 	var needFinalSnapshot bool
+	var needCompactedSnapshot bool
 	producedMu.Lock()
 	newHistory = buildSnapshotLocked()
 	synthesizedAssistant := len(produced) == 0 && result.Text.Len() > 0
@@ -1333,11 +1383,16 @@ func (rt *serveRuntime) run(ctx context.Context, stateful bool, replaceHistory b
 		} else {
 			needFinalSnapshot = !initialPersisted || lastAppendedIdx < len(produced) || assistantSnapshotDirty || assistantSnapshotNeedsReconcile || synthesizedAssistant
 		}
+		needCompactedSnapshot = compactedActiveHistory
 	}
 	persistPlatformInjectionLocked()
 	producedMu.Unlock()
 	if needFinalSnapshot {
-		rt.historyPersisted = rt.persistSnapshot(ctx, req.SessionID, newHistory)
+		if needCompactedSnapshot {
+			rt.historyPersisted = rt.persistCompactedSnapshot(ctx, req.SessionID, newHistory)
+		} else {
+			rt.historyPersisted = rt.persistSnapshot(ctx, req.SessionID, newHistory)
+		}
 	} else if persisted {
 		rt.historyPersisted = true
 	}

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -812,6 +812,32 @@ func (p *serveRuntimeCompactionProvider) Stream(ctx context.Context, req llm.Req
 	return &serveRuntimeTestStream{events: []llm.Event{{Type: llm.EventTextDelta, Text: "final after compaction"}, {Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 7, OutputTokens: 2}}}}, nil
 }
 
+type serveRuntimeCompactionErrorProvider struct {
+	calls    []llm.Request
+	finalErr error
+}
+
+func (p *serveRuntimeCompactionErrorProvider) Name() string       { return "serve-runtime-compact-error" }
+func (p *serveRuntimeCompactionErrorProvider) Credential() string { return "test" }
+func (p *serveRuntimeCompactionErrorProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{ToolCalls: true}
+}
+func (p *serveRuntimeCompactionErrorProvider) ResetConversation() {}
+
+func (p *serveRuntimeCompactionErrorProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	p.calls = append(p.calls, req)
+	last := ""
+	if len(req.Messages) > 0 {
+		for _, part := range req.Messages[len(req.Messages)-1].Parts {
+			last += part.Text
+		}
+	}
+	if strings.Contains(last, "compact continuation brief") {
+		return &serveRuntimeTestStream{events: []llm.Event{{Type: llm.EventTextDelta, Text: "summary before stream failure"}}}, nil
+	}
+	return &serveRuntimeTestStream{events: []llm.Event{{Type: llm.EventTextDelta, Text: "partial after compaction"}, {Type: llm.EventError, Err: p.finalErr}}}, nil
+}
+
 type serveRuntimeBlockingStream struct {
 	ctx context.Context
 }
@@ -1384,6 +1410,97 @@ func TestServeRuntimeCompactionCallbackUpdatesActiveContext(t *testing.T) {
 		if msg.TextContent == strings.Repeat("stale pre-compaction history ", 60) {
 			t.Fatalf("active context resurrected raw pre-compaction message: %#v", msg)
 		}
+	}
+}
+
+func TestServeRuntimeCompactionErrorFallbackPreservesPreCompactionScrollback(t *testing.T) {
+	llm.RegisterConfigLimits([]llm.ConfigModelLimit{{Provider: "serve-runtime-compact-error", Model: "compact-runtime-error", InputLimit: 1000}})
+	defer llm.RegisterConfigLimits(nil)
+
+	ctx := context.Background()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error = %v", err)
+	}
+	defer store.Close()
+
+	sess := &session.Session{ID: "sess-runtime-compact-error", Status: session.StatusActive, CompactionSeq: -1, Model: "compact-runtime-error"}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	streamErr := errors.New("stream failed after compaction")
+	provider := &serveRuntimeCompactionErrorProvider{finalErr: streamErr}
+	engine := llm.NewEngine(provider, nil)
+	staleText := strings.Repeat("stale pre-compaction history ", 60)
+	rt := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		store:        store,
+		sessionMeta:  sess,
+		autoCompact:  true,
+		defaultModel: "compact-runtime-error",
+		history: []llm.Message{
+			serveRuntimeTextMessage(llm.RoleUser, staleText),
+			serveRuntimeTextMessage(llm.RoleAssistant, "old answer"),
+		},
+	}
+	rt.configureContextManagementForRequest(llm.Request{Model: "compact-runtime-error"})
+	engine.SetContextEstimateBaseline(910, 4)
+
+	_, err = rt.Run(ctx, true, false, []llm.Message{serveRuntimeTextMessage(llm.RoleUser, "continue task")}, llm.Request{
+		SessionID: sess.ID,
+		Model:     "compact-runtime-error",
+		Tools:     []llm.ToolSpec{{Name: "dummy", Schema: map[string]any{"type": "object"}}},
+	})
+	if !errors.Is(err, streamErr) {
+		t.Fatalf("Run() error = %v, want %v", err, streamErr)
+	}
+	if len(provider.calls) < 2 {
+		t.Fatalf("provider calls = %d, want brief + failing continuation", len(provider.calls))
+	}
+
+	msgs, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	var foundStale, foundPartial bool
+	for _, msg := range msgs {
+		if msg.TextContent == staleText {
+			foundStale = true
+		}
+		if msg.TextContent == "partial after compaction" {
+			foundPartial = true
+		}
+	}
+	if !foundStale {
+		t.Fatalf("pre-compaction scrollback was not preserved: %#v", msgs)
+	}
+	if !foundPartial {
+		t.Fatalf("fallback did not persist partial assistant after compaction: %#v", msgs)
+	}
+
+	refreshed, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !session.HasCompactionBoundary(refreshed) {
+		t.Fatalf("compaction boundary was cleared: %+v", refreshed)
+	}
+	active, err := session.LoadActiveMessages(ctx, store, refreshed)
+	if err != nil {
+		t.Fatalf("LoadActiveMessages() error = %v", err)
+	}
+	activeText := ""
+	for _, msg := range active {
+		activeText += msg.TextContent + "\n"
+	}
+	if !strings.Contains(activeText, "summary before stream failure") || !strings.Contains(activeText, "partial after compaction") {
+		t.Fatalf("active context after fallback = %q, want compacted summary and partial assistant", activeText)
+	}
+	if strings.Contains(activeText, staleText) {
+		t.Fatalf("active context resurrected pre-compaction scrollback: %q", activeText)
 	}
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -2230,7 +2230,7 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 		// activity from the persisted rows after the rewrite so unchanged prefixes keep
 		// their original created_at values instead of freshly rebuilt snapshot times.
 		now := time.Now()
-		if err := s.updateReplaceMessagesSessionMetadata(ctx, tx, sessionID, now); err != nil {
+		if err := s.updateReplaceMessagesSessionMetadata(ctx, tx, sessionID, now, true); err != nil {
 			return err
 		}
 
@@ -2238,12 +2238,170 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 	})
 }
 
-func (s *SQLiteStore) updateReplaceMessagesSessionMetadata(ctx context.Context, tx *sql.Tx, sessionID string, now time.Time) error {
+// ReplaceCompactedMessages reconciles the active post-compaction history for a
+// session while preserving pre-compaction scrollback and the compaction boundary.
+// It must only be used with snapshots that start at the current compaction_seq.
+func (s *SQLiteStore) ReplaceCompactedMessages(ctx context.Context, sessionID string, messages []Message) error {
+	partsJSON, err := prepareReplacementMessageParts(messages, s.cfg.StripImageBase64)
+	if err != nil {
+		return err
+	}
+
+	return retryOnBusy(ctx, 5, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin transaction: %w", err)
+		}
+		defer tx.Rollback()
+
+		startSeq, err := s.compactionStartSeq(ctx, tx, sessionID)
+		if err != nil {
+			return err
+		}
+
+		commonPrefix, fullActiveDelete, err := compactedReplacementCommonPrefix(ctx, tx, sessionID, startSeq, messages, partsJSON)
+		if err != nil {
+			return err
+		}
+
+		deleteFrom := startSeq + commonPrefix
+		if fullActiveDelete {
+			commonPrefix = 0
+			deleteFrom = startSeq
+		}
+		if _, err := tx.ExecContext(ctx, "DELETE FROM messages WHERE session_id = ? AND sequence >= ?", sessionID, deleteFrom); err != nil {
+			return fmt.Errorf("delete compacted messages: %w", err)
+		}
+
+		if commonPrefix < len(messages) {
+			insertStmt, err := tx.PrepareContext(ctx, `
+				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+			if err != nil {
+				return fmt.Errorf("prepare compacted message insert: %w", err)
+			}
+			defer insertStmt.Close()
+
+			for i := commonPrefix; i < len(messages); i++ {
+				msg := messages[i]
+				createdAt := msg.CreatedAt
+				if createdAt.IsZero() {
+					createdAt = time.Now()
+				}
+				_, err = insertStmt.ExecContext(ctx,
+					sessionID, string(msg.Role), partsJSON[i], msg.TextContent, msg.DurationMs, msg.TurnIndex, createdAt, startSeq+i, msg.CompactionTail)
+				if err != nil {
+					return fmt.Errorf("insert compacted message %d: %w", i, err)
+				}
+			}
+		}
+
+		now := time.Now()
+		if err := s.updateReplaceMessagesSessionMetadata(ctx, tx, sessionID, now, false); err != nil {
+			return err
+		}
+
+		return tx.Commit()
+	})
+}
+
+func (s *SQLiteStore) compactionStartSeq(ctx context.Context, tx *sql.Tx, sessionID string) (int, error) {
+	if !s.hasCompactionSeq {
+		return 0, fmt.Errorf("replace compacted messages: compaction boundary unsupported")
+	}
+
+	var startSeq int
+	if s.hasCompactionCount {
+		var compactionCount int
+		err := tx.QueryRowContext(ctx, "SELECT compaction_seq, COALESCE(compaction_count, 0) FROM sessions WHERE id = ?", sessionID).Scan(&startSeq, &compactionCount)
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, ErrNotFound
+		}
+		if err != nil {
+			return 0, fmt.Errorf("load compaction boundary: %w", err)
+		}
+		if startSeq < 0 || (startSeq == 0 && compactionCount <= 0) {
+			return 0, fmt.Errorf("replace compacted messages: session %s has no compaction boundary", sessionID)
+		}
+		return startSeq, nil
+	}
+
+	err := tx.QueryRowContext(ctx, "SELECT compaction_seq FROM sessions WHERE id = ?", sessionID).Scan(&startSeq)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("load compaction boundary: %w", err)
+	}
+	if startSeq < 0 {
+		return 0, fmt.Errorf("replace compacted messages: session %s has no compaction boundary", sessionID)
+	}
+	return startSeq, nil
+}
+
+func compactedReplacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID string, startSeq int, desired []Message, desiredPartsJSON []string) (prefix int, fullActiveDelete bool, err error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT sequence, role, parts, text_content, duration_ms, turn_index
+		FROM messages
+		WHERE session_id = ? AND sequence >= ?
+		ORDER BY sequence ASC, id ASC`, sessionID, startSeq)
+	if err != nil {
+		return 0, false, fmt.Errorf("query compacted messages: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sequence int
+		var role, partsJSON string
+		var textContent sql.NullString
+		var durationMs sql.NullInt64
+		var turnIndex sql.NullInt64
+		if err := rows.Scan(&sequence, &role, &partsJSON, &textContent, &durationMs, &turnIndex); err != nil {
+			return 0, false, fmt.Errorf("scan compacted message: %w", err)
+		}
+		if sequence < startSeq {
+			return 0, true, nil
+		}
+
+		expectedSeq := startSeq + prefix
+		if prefix >= len(desired) {
+			if sequence < expectedSeq {
+				return 0, true, nil
+			}
+			break
+		}
+		if sequence != expectedSeq {
+			if sequence < expectedSeq {
+				return 0, true, nil
+			}
+			break
+		}
+
+		want := desired[prefix]
+		if role != string(want.Role) ||
+			partsJSON != desiredPartsJSON[prefix] ||
+			nullStringValue(textContent) != want.TextContent ||
+			nullInt64Value(durationMs) != want.DurationMs ||
+			int(nullInt64Value(turnIndex)) != want.TurnIndex {
+			break
+		}
+		prefix++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, false, err
+	}
+	return prefix, false, nil
+}
+
+func (s *SQLiteStore) updateReplaceMessagesSessionMetadata(ctx context.Context, tx *sql.Tx, sessionID string, now time.Time, clearCompactionBoundary bool) error {
 	setClauses := []string{
 		"updated_at = ?",
-		"user_turns = (SELECT COUNT(*) FROM messages WHERE session_id = ? AND role = 'user')",
 	}
-	args := []any{now, sessionID}
+	args := []any{now}
+	if clearCompactionBoundary {
+		setClauses = append(setClauses, "user_turns = (SELECT COUNT(*) FROM messages WHERE session_id = ? AND role = 'user')")
+		args = append(args, sessionID)
+	}
 
 	if s.hasLastUserMessageAt {
 		// Preserve existing user-activity semantics: every persisted user row counts,
@@ -2263,11 +2421,13 @@ func (s *SQLiteStore) updateReplaceMessagesSessionMetadata(ctx context.Context, 
 		setClauses = append(setClauses, "last_message_at = (SELECT MAX(created_at) FROM messages WHERE session_id = ? AND role IN ('user', 'assistant')"+visibleTailClause+")")
 		args = append(args, sessionID)
 	}
-	if s.hasCompactionSeq {
-		setClauses = append(setClauses, "compaction_seq = -1")
-	}
-	if s.hasCompactionCount {
-		setClauses = append(setClauses, "compaction_count = 0")
+	if clearCompactionBoundary {
+		if s.hasCompactionSeq {
+			setClauses = append(setClauses, "compaction_seq = -1")
+		}
+		if s.hasCompactionCount {
+			setClauses = append(setClauses, "compaction_count = 0")
+		}
 	}
 
 	args = append(args, sessionID)


### PR DESCRIPTION
## What changed

- Track when serve/web runtime history has become active-context-only after engine compaction.
- Route fallback/final snapshot reconciliation in that state through a compaction-aware SQLite replacement path that only rewrites rows at/after the current compaction boundary.
- Preserve pre-compaction scrollback rows and the compaction boundary while still reconciling post-boundary produced output.
- Add an integration-style serve runtime test that compacts, then hits a stream error that forces fallback snapshot persistence.

## Why this is high-value

Long-lived serve/web sessions can compact during ordinary daily use. Before this change, a later fallback full snapshot could pass only the compacted active context to `ReplaceMessages`, which treats its argument as the complete transcript, deletes pre-compaction rows, and clears the boundary. That could permanently remove persisted scrollback/search/audit history after a transient stream/tool/provider error.

## Validation

- `go test ./cmd -run 'TestServeRuntimeCompaction'`
- `go build ./...`
- `go test ./...`
- `git diff --check`
