### PR TITLE
fix: surface websocket retries in web UI

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1232,6 +1232,8 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 		if msg.Role == llm.RoleEvent {
 			if marker, ok := llm.ParseModelSwapMarker(msg.ToLLMMessage()); ok {
 				entry.Parts = append(entry.Parts, sessionMessagePartEntry{Type: "model_swap", Text: marker.DisplayText})
+			} else if marker, ok := llm.ParseRunErrorMarker(msg.ToLLMMessage()); ok {
+				entry.Parts = append(entry.Parts, sessionMessagePartEntry{Type: "error", Text: marker.Message})
 			} else {
 				for _, p := range msg.Parts {
 					if p.Type == llm.PartText && p.Text != "" {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
 
@@ -1260,6 +1261,22 @@ func (s *serveServer) suppressResponseRunServerToolEvent(runtime *serveRuntime, 
 	return s != nil && s.cfg.suppressServerTools && runtime != nil && runtime.isServerExecutedTool(toolName)
 }
 
+func (s *serveServer) persistResponseRunErrorEvent(runtime *serveRuntime, sessionID, respID, errType, errMessage string) {
+	if runtime == nil || runtime.store == nil || strings.TrimSpace(sessionID) == "" || strings.TrimSpace(errMessage) == "" {
+		return
+	}
+	dbCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	msg := llm.RunErrorEventMessage(llm.RunErrorMarker{
+		ResponseID: respID,
+		ErrorType:  errType,
+		Message:    errMessage,
+	})
+	if err := runtime.store.AddMessage(dbCtx, sessionID, session.NewMessage(sessionID, msg, -1)); err != nil {
+		log.Printf("[serve] persist response run error event failed for %s: %v", sessionID, err)
+	}
+}
+
 func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *responseRun, state *responseRunStreamState, ev llm.Event) error {
 	switch ev.Type {
 	case llm.EventTextDelta:
@@ -1382,6 +1399,21 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 		return run.appendEvent("response.phase", map[string]any{
 			"text": ev.Text,
 		})
+	case llm.EventRetry:
+		payload := map[string]any{
+			"attempt":      ev.RetryAttempt,
+			"max_attempts": ev.RetryMaxAttempts,
+			"wait_seconds": ev.RetryWaitSecs,
+		}
+		if ev.Err != nil {
+			payload["error"] = ev.Err.Error()
+		}
+		if ev.RetryMaxAttempts > 0 {
+			payload["message"] = fmt.Sprintf("Model stream interrupted; reconnecting (%d/%d)…", ev.RetryAttempt, ev.RetryMaxAttempts)
+		} else {
+			payload["message"] = "Model stream interrupted; reconnecting…"
+		}
+		return run.appendEvent("response.retry", payload)
 	case llm.EventInterjection:
 		payload := map[string]any{
 			"text": ev.Text,
@@ -1914,6 +1946,9 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 				default:
 					runtime.setLastUIRunError(errMessage)
 				}
+			}
+			if !errors.Is(err, context.Canceled) {
+				s.persistResponseRunErrorEvent(runtime, sessionID, respID, errType, errMessage)
 			}
 			if failErr != nil {
 				log.Printf("response run %s failed to append terminal event: %v", respID, failErr)

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 func TestEncodeTextDeltaPayloadMatchesJSONMarshalForInvalidUTF8(t *testing.T) {
@@ -93,6 +94,71 @@ func TestAppendResponseRunEventEmitsPhase(t *testing.T) {
 	}
 	if payload["text"] != "Compacting context..." {
 		t.Fatalf("payload text = %#v", payload["text"])
+	}
+}
+
+func TestAppendResponseRunEventEmitsRetry(t *testing.T) {
+	run := newResponseRun("resp_retry", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	server := &serveServer{}
+	state := &responseRunStreamState{}
+
+	if err := server.appendResponseRunEvent(nil, run, state, llm.Event{
+		Type:             llm.EventRetry,
+		RetryAttempt:     2,
+		RetryMaxAttempts: 6,
+		RetryWaitSecs:    0.5,
+	}); err != nil {
+		t.Fatalf("appendResponseRunEvent() error = %v", err)
+	}
+
+	run.mu.Lock()
+	defer run.mu.Unlock()
+	if len(run.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(run.events))
+	}
+	ev := run.events[0]
+	if ev.Event != "response.retry" {
+		t.Fatalf("event name = %q, want response.retry", ev.Event)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(ev.Data, &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload["attempt"] != float64(2) || payload["max_attempts"] != float64(6) || payload["wait_seconds"] != 0.5 {
+		t.Fatalf("payload retry fields = %#v", payload)
+	}
+	if !strings.Contains(payload["message"].(string), "reconnecting (2/6)") {
+		t.Fatalf("payload message = %#v", payload["message"])
+	}
+}
+
+func TestPersistResponseRunErrorEventStoresDurableNonLLMMarker(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	runtime := &serveRuntime{store: store}
+	server := &serveServer{}
+
+	server.persistResponseRunErrorEvent(runtime, "sess_error", "resp_error", "timeout_error", "Responses WebSocket retries exhausted")
+
+	store.mu.Lock()
+	messages := append([]session.Message(nil), store.messages["sess_error"]...)
+	store.mu.Unlock()
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(messages))
+	}
+	msg := messages[0]
+	if msg.Role != llm.RoleEvent {
+		t.Fatalf("role = %q, want event", msg.Role)
+	}
+	marker, ok := llm.ParseRunErrorMarker(msg.ToLLMMessage())
+	if !ok {
+		t.Fatalf("missing run error marker in %#v", msg.Parts)
+	}
+	if marker.ResponseID != "resp_error" || marker.ErrorType != "timeout_error" || marker.Message != "Responses WebSocket retries exhausted" {
+		t.Fatalf("marker = %#v", marker)
+	}
+	filtered := llm.FilterConversationMessages([]llm.Message{msg.ToLLMMessage(), llm.UserText("continue")})
+	if len(filtered) != 1 || filtered[0].Role != llm.RoleUser {
+		t.Fatalf("filtered messages = %#v, want only user message", filtered)
 	}
 }
 

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -21,7 +21,11 @@ const maxResponsesAPIErrorBodyBytes = 64 * 1024
 var truncatedResponsesAPIErrorBodySuffix = []byte("\n... response body truncated")
 
 const (
-	responsesWebSocketMaxAttempts = 3
+	// Match Codex's default stream retry budget: five reconnect attempts after
+	// the initial WebSocket stream attempt. Keep the derived attempts constant so
+	// existing EventRetry attempt/max fields continue to describe attempt numbers.
+	responsesWebSocketMaxRetries  = 5
+	responsesWebSocketMaxAttempts = responsesWebSocketMaxRetries + 1
 	responsesWebSocketMaxBackoff  = 2 * time.Second
 )
 

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -508,8 +508,8 @@ func TestResponsesClientWebSocketConnectFailureFallsBackToHTTP(t *testing.T) {
 			if text != "fallback" {
 				t.Fatalf("text = %q, want fallback", text)
 			}
-			if wsAttempts.Load() != 3 {
-				t.Fatalf("websocket attempts = %d, want 3", wsAttempts.Load())
+			if wsAttempts.Load() != int32(responsesWebSocketMaxAttempts) {
+				t.Fatalf("websocket attempts = %d, want %d", wsAttempts.Load(), responsesWebSocketMaxAttempts)
 			}
 			if httpAttempts.Load() != 1 {
 				t.Fatalf("http attempts = %d, want 1", httpAttempts.Load())
@@ -600,11 +600,11 @@ func TestResponsesClientWebSocketReadFailureBeforeEventsRetriesWebSocketThenFall
 			if text != "fallback after read" {
 				t.Fatalf("text = %q, want fallback after read", text)
 			}
-			if wsAttempts.Load() != 3 || httpAttempts.Load() != 1 {
-				t.Fatalf("attempts ws=%d http=%d, want 3/1", wsAttempts.Load(), httpAttempts.Load())
+			if wsAttempts.Load() != int32(responsesWebSocketMaxAttempts) || httpAttempts.Load() != 1 {
+				t.Fatalf("attempts ws=%d http=%d, want %d/1", wsAttempts.Load(), httpAttempts.Load(), responsesWebSocketMaxAttempts)
 			}
-			if retries != responsesWebSocketMaxAttempts-1 {
-				t.Fatalf("retry events = %d, want %d", retries, responsesWebSocketMaxAttempts-1)
+			if retries != responsesWebSocketMaxRetries {
+				t.Fatalf("retry events = %d, want %d", retries, responsesWebSocketMaxRetries)
 			}
 			return
 		case EventError:

--- a/internal/llm/run_error_marker.go
+++ b/internal/llm/run_error_marker.go
@@ -1,0 +1,58 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const RunErrorEventType = "run_error"
+
+// RunErrorMarker is a durable non-LLM transcript event describing a failed
+// response run. It is shown to users in session history but filtered from model
+// context via RoleEvent.
+type RunErrorMarker struct {
+	Type       string `json:"type"`
+	ResponseID string `json:"response_id,omitempty"`
+	ErrorType  string `json:"error_type,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+// RunErrorEventMessage returns a RoleEvent message suitable for durable
+// transcript storage. It intentionally stores structured JSON in a text part so
+// existing session storage schemas can persist it without migration.
+func RunErrorEventMessage(marker RunErrorMarker) Message {
+	marker.Type = RunErrorEventType
+	if strings.TrimSpace(marker.Message) == "" {
+		marker.Message = "The response failed."
+	}
+	data, err := json.Marshal(marker)
+	if err != nil {
+		data = []byte(fmt.Sprintf(`{"type":"%s","message":"%s"}`, RunErrorEventType, strings.ReplaceAll(marker.Message, `"`, `'`)))
+	}
+	return Message{Role: RoleEvent, Parts: []Part{{Type: PartText, Text: string(data)}}}
+}
+
+// ParseRunErrorMarker extracts a run-error marker from a durable event message.
+func ParseRunErrorMarker(msg Message) (RunErrorMarker, bool) {
+	if msg.Role != RoleEvent {
+		return RunErrorMarker{}, false
+	}
+	for _, part := range msg.Parts {
+		if part.Type != PartText || strings.TrimSpace(part.Text) == "" {
+			continue
+		}
+		var marker RunErrorMarker
+		if err := json.Unmarshal([]byte(part.Text), &marker); err != nil {
+			continue
+		}
+		if marker.Type != RunErrorEventType {
+			continue
+		}
+		if strings.TrimSpace(marker.Message) == "" {
+			marker.Message = "The response failed."
+		}
+		return marker, true
+	}
+	return RunErrorMarker{}, false
+}

--- a/internal/render/chat/message_block.go
+++ b/internal/render/chat/message_block.go
@@ -218,6 +218,8 @@ func (r *MessageBlockRenderer) renderEventMessage(msg *session.Message) string {
 	text := strings.TrimSpace(msg.TextContent)
 	if marker, ok := llm.ParseModelSwapMarker(msg.ToLLMMessage()); ok {
 		text = marker.DisplayText
+	} else if marker, ok := llm.ParseRunErrorMarker(msg.ToLLMMessage()); ok {
+		text = marker.Message
 	}
 	if text == "" {
 		text = "↔ Session event"

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -659,6 +659,17 @@ const convertServerMessages = (serverMessages, options = {}) => {
 
     if (msg.role === 'event') {
       flushGroup();
+      const errorMarker = parts.find((part) => part.type === 'error');
+      if (errorMarker) {
+        result.push({
+          id: baseId,
+          role: 'error',
+          content: errorMarker.text || 'The response failed.',
+          created,
+          ...(seq !== null ? { serverSeq: seq } : {})
+        });
+        continue;
+      }
       const marker = parts.find((part) => part.type === 'model_swap') || parts.find((part) => part.type === 'text');
       result.push({
         id: baseId,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -792,6 +792,34 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     return { terminal: false };
   }
 
+  if (event === 'response.retry') {
+    const message = String(payload?.message || '').trim() || 'Model stream interrupted; reconnecting…';
+    if (streamState.currentAssistantMessage?.content) {
+      finalizeVisibleAssistantStreamRender(session, streamState.currentAssistantMessage);
+    }
+    streamState.currentAssistantMessage = null;
+    let marker = streamState.currentPhaseMessage || null;
+    if (!marker) {
+      marker = {
+        id: generateId('phase'),
+        role: 'phase',
+        content: message,
+        created: Date.now(),
+        transient: true
+      };
+      streamState.currentPhaseMessage = marker;
+      session.messages.push(marker);
+      appendStreamMessageNode(session, marker);
+    } else {
+      marker.content = message;
+      if (isSessionVisible(session)) updateUserNode(marker);
+    }
+    setConnectionState(message);
+    scheduleStreamPersistence();
+    scrollVisibleStreamToBottom(session);
+    return { terminal: false };
+  }
+
   if (event === 'response.output_text.new_segment') {
     streamState.closeToolGroup();
     if (streamState.currentAssistantMessage?.content) {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -1001,6 +1001,33 @@ async function testDeveloperMessagesAreHidden() {
   pass(name);
 }
 
+async function testRunErrorEventsConvertToErrorMessages() {
+  const name = 'run error events convert to durable error messages';
+  const { app } = await createSessionsHarness();
+
+  const converted = app.convertServerMessages([
+    {
+      id: 1,
+      sequence: 1,
+      role: 'event',
+      created_at: 1000,
+      parts: [{ type: 'error', text: 'OpenAI Responses WebSocket retries exhausted' }],
+    },
+  ]);
+
+  if (converted.length !== 1) {
+    fail(name, `expected 1 converted message, got ${converted.length}`, JSON.stringify(converted));
+    return;
+  }
+  const msg = converted[0];
+  if (msg.role !== 'error' || msg.content !== 'OpenAI Responses WebSocket retries exhausted' || msg.serverSeq !== 1) {
+    fail(name, 'converted run error missing expected fields', JSON.stringify(msg));
+    return;
+  }
+
+  pass(name);
+}
+
 async function testConvertServerMessagesCompactionSummariesBecomeMarkers() {
   const name = 'server compaction summary converts to compact marker with active boundary';
   const { app } = await createSessionsHarness();
@@ -4011,6 +4038,7 @@ async function testMCPPatchConflictDoesNotOptimisticallyEnable() {
   await testNewQueryRefreshesHeaderAfterRuntimeMetadataLoads();
   await testMergeServerSessionsMigratesInterruptBuffersToRealSessionId();
   await testDeveloperMessagesAreHidden();
+  await testRunErrorEventsConvertToErrorMessages();
   await testConvertServerMessagesCompactionSummariesBecomeMarkers();
   await testConvertServerMessagesSuppressesCompactionRetainedRawTail();
   await testConvertServerMessagesSuppressesAuthoritativeCompactionTailFlag();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -2854,6 +2854,59 @@ function testResponsePhaseEventUpdatesTransientMarker() {
   pass(name);
 }
 
+function testResponseRetryEventUpdatesTransientMarker() {
+  const name = 'response retry event updates transient marker without assistant text';
+  const harness = createHarness();
+  const { app, state } = harness;
+  const session = {
+    id: 'session_retry',
+    title: 'Retry test',
+    messages: [],
+    lastResponseId: null,
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  const streamState = app.createResponseStreamState(session);
+
+  app.applyResponseStreamEvent(session, streamState, 'response.retry', {
+    message: 'Model stream interrupted; reconnecting (2/6)…',
+    attempt: 2,
+    max_attempts: 6,
+    wait_seconds: 0.5,
+    sequence_number: 1,
+  });
+  app.applyResponseStreamEvent(session, streamState, 'response.retry', {
+    message: 'Model stream interrupted; reconnecting (3/6)…',
+    attempt: 3,
+    max_attempts: 6,
+    wait_seconds: 1,
+    sequence_number: 2,
+  });
+
+  const markers = session.messages.filter((message) => message.role === 'phase');
+  const assistants = session.messages.filter((message) => message.role === 'assistant');
+  if (markers.length !== 1) {
+    fail(name, `expected one retry marker, got ${markers.length}`, JSON.stringify(session.messages));
+    return;
+  }
+  if (!markers[0].transient || markers[0].content !== 'Model stream interrupted; reconnecting (3/6)…') {
+    fail(name, 'retry marker was not updated in place', JSON.stringify(markers[0]));
+    return;
+  }
+  if (assistants.length !== 0) {
+    fail(name, 'retry event should not create assistant messages', JSON.stringify(assistants));
+    return;
+  }
+  if (session.lastSequenceNumber !== 2) {
+    fail(name, `lastSequenceNumber = ${session.lastSequenceNumber}, want 2`);
+    return;
+  }
+  pass(name);
+}
+
 function testResponsePhaseSeparatesAssistantSegments() {
   const name = 'response phase separates assistant segments in order';
   const harness = createHarness();
@@ -4888,6 +4941,7 @@ function testCompletedResponseClearsUnappliedQueuedEffort() {
   testCompletedResponseClearsUnappliedQueuedEffort();
   testModelSwapProgressEventUpdatesTransientMarker();
   testResponsePhaseEventUpdatesTransientMarker();
+  testResponseRetryEventUpdatesTransientMarker();
   testResponsePhaseSeparatesAssistantSegments();
   await testConnectTokenPreservesSelectedModelAndProviderFromState();
   await testCancelActiveResponseTearsDownLocallyBeforeServerPost();


### PR DESCRIPTION
## What

- Increase Responses-over-WebSocket recovery from 3 total attempts to 6 total attempts, matching Codex's default of 5 stream reconnect retries after the initial attempt.
- Forward `llm.EventRetry` into response runs as `response.retry` events with attempt/max/wait metadata.
- Render `response.retry` in the web UI as a transient visible status marker and connection-state message, so users see model-stream reconnects instead of a silent stall.
- Persist final response-run failures as durable `RoleEvent` transcript markers, rendered as user-visible error messages but filtered out of future LLM context.

## Why

Session #2832 exposed two bad UX properties:

- when the Responses WebSocket path died/retried, the web UI had no visible "reconnecting / retries exhausted" breadcrumb
- final failures could be visible only through ephemeral response-run memory / one-shot UI state, not durable session history
- term-llm's WebSocket retry budget was lower than Codex's stream retry default

Increasing retries alone would just make users stare at the void for longer. This surfaces retry state and leaves a durable user-facing error when the run ultimately fails, without sending that marker back to models.

## Tests

- `go test ./...`
- `mise x node@24.15.0 -- node internal/serveui/static/app_sessions_test.js`
- `mise x node@24.15.0 -- node internal/serveui/static/app_stream_test.js`
