### PR TITLE
FIX: per-session handover plan file, named upfront from the first user message

### DIFF
--- a/internal/agents/builtin/planner/system.md
+++ b/internal/agents/builtin/planner/system.md
@@ -11,7 +11,16 @@ Today is {{date}}. Working in {{cwd}}.
 
 ## Handover Document
 
-Maintain your plan in `{{handover_path}}`. Write to it incrementally as you work — update sections as your understanding evolves rather than writing everything at once. When the user runs `/handover @developer`, this file becomes the context for the next agent.
+Your plan lives at exactly this path, decided upfront and fixed for this session:
+
+`{{handover_path}}`
+
+Write to it incrementally as you work — update sections as your understanding evolves rather than writing everything at once. When the user runs `/handover @developer`, this exact file becomes the context for the next agent.
+
+Rules for this file — no exceptions:
+- Never choose a different filename or directory for the plan; the handover mechanism reads this exact path and nothing else
+- Never write the plan into the repository, the working directory, or any other location
+- Do not create additional .md files in the handover directory
 
 Structure your handover document with these sections:
 - **Objective** — what the user is trying to accomplish

--- a/internal/session/handover_path_test.go
+++ b/internal/session/handover_path_test.go
@@ -1,0 +1,49 @@
+package session
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetHandoverPathPinnedPerDirAndDate(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	ResetHandoverPathCache()
+	t.Cleanup(ResetHandoverPathCache)
+
+	first, err := GetHandoverPath(".", "2026-07-02")
+	if err != nil {
+		t.Fatalf("GetHandoverPath: %v", err)
+	}
+	base := filepath.Base(first)
+	if !strings.HasPrefix(base, "2026-07-02-") {
+		t.Fatalf("expected date prefix on %q", base)
+	}
+	if !IsRandomHandoverName(base) {
+		t.Fatalf("expected random handover name, got %q", base)
+	}
+
+	second, err := GetHandoverPath(".", "2026-07-02")
+	if err != nil {
+		t.Fatalf("GetHandoverPath: %v", err)
+	}
+	if second != first {
+		t.Fatalf("path not pinned across calls: %q != %q", second, first)
+	}
+
+	otherDate, err := GetHandoverPath(".", "2026-07-03")
+	if err != nil {
+		t.Fatalf("GetHandoverPath: %v", err)
+	}
+	if otherDate == first {
+		t.Fatal("different date should produce a different path")
+	}
+
+	otherDir, err := GetHandoverPath(t.TempDir(), "2026-07-02")
+	if err != nil {
+		t.Fatalf("GetHandoverPath: %v", err)
+	}
+	if otherDir == first {
+		t.Fatal("different project dir should produce a different path")
+	}
+}

--- a/internal/session/handover_path_test.go
+++ b/internal/session/handover_path_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 )
 
-func TestGetHandoverPathPinnedPerDirAndDate(t *testing.T) {
+func TestGetHandoverPathUniquePerCall(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	ResetHandoverPathCache()
-	t.Cleanup(ResetHandoverPathCache)
 
 	first, err := GetHandoverPath(".", "2026-07-02")
 	if err != nil {
@@ -27,23 +25,35 @@ func TestGetHandoverPathPinnedPerDirAndDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetHandoverPath: %v", err)
 	}
-	if second != first {
-		t.Fatalf("path not pinned across calls: %q != %q", second, first)
+	if second == first {
+		t.Fatal("expected distinct paths per call so concurrent sessions get their own files")
+	}
+}
+
+func TestExtractHandoverPath(t *testing.T) {
+	dir := filepath.Join("/data", "handover", "proj-abc123")
+	path := filepath.Join(dir, "2026-07-02-amber-creek-bloom.md")
+	prompt := "Your plan lives at exactly this path:\n\n`" + path + "`\n\nWrite to it incrementally."
+
+	if got := ExtractHandoverPath(prompt, dir); got != path {
+		t.Fatalf("got %q, want %q", got, path)
 	}
 
-	otherDate, err := GetHandoverPath(".", "2026-07-03")
-	if err != nil {
-		t.Fatalf("GetHandoverPath: %v", err)
-	}
-	if otherDate == first {
-		t.Fatal("different date should produce a different path")
+	// Descriptive (renamed) slugs match too.
+	renamed := filepath.Join(dir, "2026-07-02-fix-auth-migration.md")
+	if got := ExtractHandoverPath("plan at "+renamed+" please", dir); got != renamed {
+		t.Fatalf("got %q, want %q", got, renamed)
 	}
 
-	otherDir, err := GetHandoverPath(t.TempDir(), "2026-07-02")
-	if err != nil {
-		t.Fatalf("GetHandoverPath: %v", err)
+	// A different project dir must not match.
+	if got := ExtractHandoverPath(prompt, filepath.Join("/data", "handover", "other-def456")); got != "" {
+		t.Fatalf("expected no match for other dir, got %q", got)
 	}
-	if otherDir == first {
-		t.Fatal("different project dir should produce a different path")
+
+	if got := ExtractHandoverPath("", dir); got != "" {
+		t.Fatalf("expected no match for empty prompt, got %q", got)
+	}
+	if got := ExtractHandoverPath(prompt, ""); got != "" {
+		t.Fatalf("expected no match for empty dir, got %q", got)
 	}
 }

--- a/internal/session/handover_prettify_test.go
+++ b/internal/session/handover_prettify_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func staticSlugGen(slug string) HandoverSlugGenerator {
+	return func(context.Context, string) (string, error) { return slug, nil }
+}
+
+func TestPrettifyHandoverNameBeforeFileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
+
+	if err := PrettifyHandoverName(context.Background(), path, "fix the auth system", staticSlugGen("auth refactor")); err != nil {
+		t.Fatalf("PrettifyHandoverName: %v", err)
+	}
+
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink at %s (err %v)", path, err)
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if target != "2026-07-02-auth-refactor.md" {
+		t.Fatalf("symlink target = %q", target)
+	}
+
+	// Writing through the original path lands in the descriptive file.
+	if err := os.WriteFile(path, []byte("the plan"), 0o644); err != nil {
+		t.Fatalf("write through symlink: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "2026-07-02-auth-refactor.md"))
+	if err != nil || string(data) != "the plan" {
+		t.Fatalf("pretty file content = %q, err %v", data, err)
+	}
+
+	// Second call is a no-op (already a symlink).
+	if err := PrettifyHandoverName(context.Background(), path, "fix the auth system", staticSlugGen("other words")); err != nil {
+		t.Fatalf("second PrettifyHandoverName: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "2026-07-02-other-words.md")); err == nil {
+		t.Fatal("second call should not create another file")
+	}
+}
+
+func TestPrettifyHandoverNameExistingFileCarriesContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
+	if err := os.WriteFile(path, []byte("already written"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := PrettifyHandoverName(context.Background(), path, "db migration work", staticSlugGen("db migration")); err != nil {
+		t.Fatalf("PrettifyHandoverName: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "2026-07-02-db-migration.md"))
+	if err != nil || string(data) != "already written" {
+		t.Fatalf("renamed file content = %q, err %v", data, err)
+	}
+	// Original path still readable through the symlink.
+	data, err = os.ReadFile(path)
+	if err != nil || string(data) != "already written" {
+		t.Fatalf("content via original path = %q, err %v", data, err)
+	}
+}
+
+func TestPrettifyHandoverNameCollisionKeepsRandomWord(t *testing.T) {
+	dir := t.TempDir()
+	occupied := filepath.Join(dir, "2026-07-02-auth-refactor.md")
+	if err := os.WriteFile(occupied, []byte("another session"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
+	if err := PrettifyHandoverName(context.Background(), path, "fix auth", staticSlugGen("auth refactor")); err != nil {
+		t.Fatalf("PrettifyHandoverName: %v", err)
+	}
+
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if target != "2026-07-02-auth-refactor-amber.md" {
+		t.Fatalf("symlink target = %q", target)
+	}
+	// The occupied file is untouched.
+	data, _ := os.ReadFile(occupied)
+	if string(data) != "another session" {
+		t.Fatalf("occupied file was modified: %q", data)
+	}
+}
+
+func TestPrettifyHandoverNameCapsSlugAtTwoWords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
+
+	if err := PrettifyHandoverName(context.Background(), path, "task", staticSlugGen("one two three four")); err != nil {
+		t.Fatalf("PrettifyHandoverName: %v", err)
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if target != "2026-07-02-one-two.md" {
+		t.Fatalf("symlink target = %q", target)
+	}
+}
+
+func TestPrettifyHandoverNameSkipsNonRandomNames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2026-07-02-my-custom-plan.md")
+	if err := os.WriteFile(path, []byte("content"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := PrettifyHandoverName(context.Background(), path, "task", staticSlugGen("nice name")); err != nil {
+		t.Fatalf("PrettifyHandoverName: %v", err)
+	}
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("descriptively named file must stay a regular file (err %v)", err)
+	}
+}

--- a/internal/session/handover_prettify_test.go
+++ b/internal/session/handover_prettify_test.go
@@ -11,7 +11,18 @@ func staticSlugGen(slug string) HandoverSlugGenerator {
 	return func(context.Context, string) (string, error) { return slug, nil }
 }
 
+// requireSymlinks skips the test when the platform (or privilege level, e.g.
+// Windows without Developer Mode) does not support creating symlinks.
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	probe := filepath.Join(t.TempDir(), "probe")
+	if err := os.Symlink("target", probe); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+}
+
 func TestPrettifyHandoverNameBeforeFileExists(t *testing.T) {
+	requireSymlinks(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
 
@@ -50,6 +61,7 @@ func TestPrettifyHandoverNameBeforeFileExists(t *testing.T) {
 }
 
 func TestPrettifyHandoverNameExistingFileCarriesContent(t *testing.T) {
+	requireSymlinks(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
 	if err := os.WriteFile(path, []byte("already written"), 0o644); err != nil {
@@ -72,6 +84,7 @@ func TestPrettifyHandoverNameExistingFileCarriesContent(t *testing.T) {
 }
 
 func TestPrettifyHandoverNameCollisionKeepsRandomWord(t *testing.T) {
+	requireSymlinks(t)
 	dir := t.TempDir()
 	occupied := filepath.Join(dir, "2026-07-02-auth-refactor.md")
 	if err := os.WriteFile(occupied, []byte("another session"), 0o644); err != nil {
@@ -98,6 +111,7 @@ func TestPrettifyHandoverNameCollisionKeepsRandomWord(t *testing.T) {
 }
 
 func TestPrettifyHandoverNameCapsSlugAtTwoWords(t *testing.T) {
+	requireSymlinks(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
 

--- a/internal/session/handover_rename.go
+++ b/internal/session/handover_rename.go
@@ -114,6 +114,85 @@ func MaybeRenameHandover(ctx context.Context, path string, slugGen HandoverSlugG
 	return nil
 }
 
+// PrettifyHandoverName renames a random-named handover file to a short
+// descriptive name derived from the session's first user message, so the file
+// has a nice name from the start. The original random path — baked into the
+// session's system prompt — keeps working via a symlink; when the agent has
+// not written the file yet, the symlink dangles until the first write lands
+// in the descriptive file (write tools follow symlinks).
+//
+// slugGen receives the description and should return roughly two words; the
+// result is sanitized and capped at two dash-separated words. Errors from
+// slugGen are silently skipped — the file simply keeps its random name.
+func PrettifyHandoverName(ctx context.Context, path, description string, slugGen HandoverSlugGenerator) error {
+	base := filepath.Base(path)
+	if !IsRandomHandoverName(base) {
+		return nil // already renamed or not a random name
+	}
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil // already prettified
+	}
+	if slugGen == nil || strings.TrimSpace(description) == "" {
+		return nil
+	}
+
+	slug, err := slugGen(ctx, description)
+	if err != nil || strings.TrimSpace(slug) == "" {
+		return nil // silently skip on error
+	}
+	slug = limitSlugWords(sanitizeSlug(slug), 2)
+	if slug == "" {
+		return nil
+	}
+
+	datePrefix := base[:10] // "2026-04-03"
+	dir := filepath.Dir(path)
+	newName := datePrefix + "-" + slug + ".md"
+	newPath := filepath.Join(dir, newName)
+	if _, err := os.Lstat(newPath); err == nil {
+		// A concurrent session got the same description: keep one random word
+		// from the original name for uniqueness.
+		words := handoverRandomPattern.FindStringSubmatch(base)
+		if words == nil {
+			return nil
+		}
+		newName = datePrefix + "-" + slug + "-" + words[1] + ".md"
+		newPath = filepath.Join(dir, newName)
+		if _, err := os.Lstat(newPath); err == nil {
+			return nil
+		}
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("handover prettify mkdir: %w", err)
+	}
+	// If the agent already wrote the file, carry the content over; otherwise
+	// the symlink dangles until the first write creates the target.
+	renamed := false
+	if _, err := os.Stat(path); err == nil {
+		if err := os.Rename(path, newPath); err != nil {
+			return fmt.Errorf("handover prettify rename: %w", err)
+		}
+		renamed = true
+	}
+	if err := os.Symlink(newName, path); err != nil {
+		if renamed {
+			_ = os.Rename(newPath, path)
+		}
+		return fmt.Errorf("handover prettify symlink: %w", err)
+	}
+	return nil
+}
+
+// limitSlugWords truncates a dash-separated slug to at most n words.
+func limitSlugWords(slug string, n int) string {
+	parts := strings.Split(slug, "-")
+	if len(parts) > n {
+		parts = parts[:n]
+	}
+	return strings.Join(parts, "-")
+}
+
 func sanitizeSlug(s string) string {
 	s = strings.ToLower(strings.TrimSpace(s))
 	// Replace any non-alphanumeric chars with dashes

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/appdata"
@@ -187,16 +188,41 @@ func GetHandoverDir(cwd string) (string, error) {
 	return filepath.Join(dataDir, "handover", projectID), nil
 }
 
-// GetHandoverPath returns a full handover file path with a deterministic
-// random name like "2026-04-03-amber-creek-bloom.md". The random slug is
-// generated once per call; callers should cache the result for the session.
+// handoverPathCache pins the generated handover path per (handover dir, date)
+// for the lifetime of the process. System prompts embed this path via
+// {{handover_path}}; without pinning, every re-expansion (chat relaunch,
+// serve runtime recreation, spawned sub-agents) would mint a fresh random
+// slug and point the agent at a different file mid-session.
+var (
+	handoverPathMu    sync.Mutex
+	handoverPathCache = map[string]string{}
+)
+
+// GetHandoverPath returns the handover file path for the given working
+// directory and date, e.g. "2026-04-03-amber-creek-bloom.md". The random
+// slug is generated once per (project, date) and pinned for the lifetime of
+// the process, so repeated prompt expansions always name the same file.
 func GetHandoverPath(cwd, date string) (string, error) {
 	dir, err := GetHandoverDir(cwd)
 	if err != nil {
 		return "", err
 	}
-	slug := RandomHandoverSlug()
-	return filepath.Join(dir, date+"-"+slug+".md"), nil
+	key := dir + "\x00" + date
+	handoverPathMu.Lock()
+	defer handoverPathMu.Unlock()
+	if p, ok := handoverPathCache[key]; ok {
+		return p, nil
+	}
+	p := filepath.Join(dir, date+"-"+RandomHandoverSlug()+".md")
+	handoverPathCache[key] = p
+	return p, nil
+}
+
+// ResetHandoverPathCache clears pinned handover paths. Test helper.
+func ResetHandoverPathCache() {
+	handoverPathMu.Lock()
+	defer handoverPathMu.Unlock()
+	handoverPathCache = map[string]string{}
 }
 
 // ResolveDBPath resolves an optional DB path override.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/appdata"
@@ -188,41 +188,29 @@ func GetHandoverDir(cwd string) (string, error) {
 	return filepath.Join(dataDir, "handover", projectID), nil
 }
 
-// handoverPathCache pins the generated handover path per (handover dir, date)
-// for the lifetime of the process. System prompts embed this path via
-// {{handover_path}}; without pinning, every re-expansion (chat relaunch,
-// serve runtime recreation, spawned sub-agents) would mint a fresh random
-// slug and point the agent at a different file mid-session.
-var (
-	handoverPathMu    sync.Mutex
-	handoverPathCache = map[string]string{}
-)
-
-// GetHandoverPath returns the handover file path for the given working
-// directory and date, e.g. "2026-04-03-amber-creek-bloom.md". The random
-// slug is generated once per (project, date) and pinned for the lifetime of
-// the process, so repeated prompt expansions always name the same file.
+// GetHandoverPath returns a full handover file path with a random name like
+// "2026-04-03-amber-creek-bloom.md". A fresh slug is generated per call so
+// concurrent sessions in the same project get distinct plan files. The
+// expanded system prompt is the durable per-session record of the path; use
+// ExtractHandoverPath to recover it.
 func GetHandoverPath(cwd, date string) (string, error) {
 	dir, err := GetHandoverDir(cwd)
 	if err != nil {
 		return "", err
 	}
-	key := dir + "\x00" + date
-	handoverPathMu.Lock()
-	defer handoverPathMu.Unlock()
-	if p, ok := handoverPathCache[key]; ok {
-		return p, nil
-	}
-	p := filepath.Join(dir, date+"-"+RandomHandoverSlug()+".md")
-	handoverPathCache[key] = p
-	return p, nil
+	slug := RandomHandoverSlug()
+	return filepath.Join(dir, date+"-"+slug+".md"), nil
 }
 
-// ResetHandoverPathCache clears pinned handover paths. Test helper.
-func ResetHandoverPathCache() {
-	handoverPathMu.Lock()
-	defer handoverPathMu.Unlock()
-	handoverPathCache = map[string]string{}
+// ExtractHandoverPath recovers the handover file path embedded in a system
+// prompt via {{handover_path}}. It matches the first path under dir with the
+// "<date>-<slug>.md" shape. Returns "" when the prompt names no such file.
+func ExtractHandoverPath(prompt, dir string) string {
+	if prompt == "" || dir == "" {
+		return ""
+	}
+	re := regexp.MustCompile(regexp.QuoteMeta(dir) + `[\\/]\d{4}-\d{2}-\d{2}-[a-zA-Z0-9-]+\.md`)
+	return re.FindString(prompt)
 }
 
 // ResolveDBPath resolves an optional DB path override.

--- a/internal/tools/edit.go
+++ b/internal/tools/edit.go
@@ -198,9 +198,11 @@ func (t *EditFileTool) executeDirectEdit(ctx context.Context, a EditFileArgs) (l
 	// Apply the replacement
 	newContent := edit.ApplyMatch(content, result, a.NewText)
 
-	// Write back atomically using a unique temp file
-	dir := filepath.Dir(absPath)
-	base := filepath.Base(absPath)
+	// Write back atomically using a unique temp file. Follow symlinks so the
+	// rename writes through the link instead of replacing it.
+	writePath := resolveWriteTarget(absPath)
+	dir := filepath.Dir(writePath)
+	base := filepath.Base(writePath)
 	tempFile, err := os.CreateTemp(dir, "."+base+".*.tmp")
 	if err != nil {
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to create temp file: %v", err))), nil
@@ -228,7 +230,7 @@ func (t *EditFileTool) executeDirectEdit(ctx context.Context, a EditFileArgs) (l
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to set file permissions: %v", err))), nil
 	}
 
-	if err := os.Rename(tempPath, absPath); err != nil {
+	if err := os.Rename(tempPath, writePath); err != nil {
 		os.Remove(tempPath)
 		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to rename temp file: %v", err))), nil
 	}
@@ -396,8 +398,11 @@ func (t *UnifiedDiffTool) applyFileDiff(ctx context.Context, absPath string, fd 
 		return fmt.Sprintf("No changes for %s.\n", fd.Path), warnings, nil, nil
 	}
 
-	dir := filepath.Dir(absPath)
-	base := filepath.Base(absPath)
+	// Follow symlinks so the atomic rename writes through the link instead
+	// of replacing it.
+	writePath := resolveWriteTarget(absPath)
+	dir := filepath.Dir(writePath)
+	base := filepath.Base(writePath)
 	tempFile, err := os.CreateTemp(dir, "."+base+".*.tmp")
 	if err != nil {
 		return "", append(warnings, fmt.Sprintf("%s: failed to create temp file: %v", fd.Path, err)), nil, nil
@@ -421,7 +426,7 @@ func (t *UnifiedDiffTool) applyFileDiff(ctx context.Context, absPath string, fd 
 		return "", append(warnings, fmt.Sprintf("%s: failed to set permissions: %v", fd.Path, err)), nil, nil
 	}
 
-	if err := os.Rename(tempPath, absPath); err != nil {
+	if err := os.Rename(tempPath, writePath); err != nil {
 		os.Remove(tempPath)
 		return "", append(warnings, fmt.Sprintf("%s: failed to rename: %v", fd.Path, err)), nil, nil
 	}

--- a/internal/tools/permissions.go
+++ b/internal/tools/permissions.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/gobwas/glob"
+
+	"github.com/samsaffron/term-llm/internal/appdata"
 )
 
 // ToolPermissions manages allowlists for tool access.
@@ -112,6 +114,9 @@ func (p *ToolPermissions) IsPathAllowedForRead(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if isHandoverPath(resolved) {
+		return true, nil
+	}
 	return p.isPathInDirs(resolved, p.ReadDirs), nil
 }
 
@@ -121,7 +126,27 @@ func (p *ToolPermissions) IsPathAllowedForWrite(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if isHandoverPath(resolved) {
+		return true, nil
+	}
 	return p.isPathInDirs(resolved, p.WriteDirs), nil
+}
+
+// isHandoverPath reports whether resolvedPath is inside term-llm's own
+// handover data directory. Handover plan documents are app-managed state
+// (see session.GetHandoverDir); agents read and update their session's plan
+// there constantly, so these paths are always allowed without explicit
+// read/write dir grants or approval prompts.
+func isHandoverPath(resolvedPath string) bool {
+	dataDir, err := appdata.GetDataDir()
+	if err != nil {
+		return false
+	}
+	root := filepath.Join(dataDir, "handover")
+	if resolved, err := filepath.EvalSymlinks(root); err == nil && resolved != "" {
+		root = resolved
+	}
+	return strings.HasPrefix(resolvedPath, root+string(filepath.Separator))
 }
 
 // IsShellCommandAllowed checks if a shell command matches any allowlist pattern or script.

--- a/internal/tools/permissions_handover_test.go
+++ b/internal/tools/permissions_handover_test.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHandoverPathsAlwaysAllowed ensures agents can maintain their handover
+// plan file — which lives in term-llm's own data directory — without explicit
+// read/write dir grants or approval prompts.
+func TestHandoverPathsAlwaysAllowed(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	handoverDir := filepath.Join(xdg, "term-llm", "handover", "proj-abc123")
+	if err := os.MkdirAll(handoverDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	plan := filepath.Join(handoverDir, "2026-07-02-auth-refactor.md")
+
+	perms := NewToolPermissions() // no read/write dirs granted
+
+	allowed, err := perms.IsPathAllowedForWrite(plan)
+	if err != nil {
+		t.Fatalf("IsPathAllowedForWrite: %v", err)
+	}
+	if !allowed {
+		t.Fatal("handover plan file should be writable without grants")
+	}
+
+	if err := os.WriteFile(plan, []byte("plan"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	allowed, err = perms.IsPathAllowedForRead(plan)
+	if err != nil {
+		t.Fatalf("IsPathAllowedForRead: %v", err)
+	}
+	if !allowed {
+		t.Fatal("handover plan file should be readable without grants")
+	}
+
+	// Other files in the data dir stay protected.
+	other := filepath.Join(xdg, "term-llm", "sessions.db")
+	allowed, err = perms.IsPathAllowedForWrite(other)
+	if err != nil {
+		t.Fatalf("IsPathAllowedForWrite other: %v", err)
+	}
+	if allowed {
+		t.Fatal("non-handover data files must not be writable without grants")
+	}
+}

--- a/internal/tools/write.go
+++ b/internal/tools/write.go
@@ -114,15 +114,20 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 		}
 	}
 
+	// Follow symlinks (including dangling ones) so the atomic rename below
+	// writes through the link — e.g. renamed handover plan files — instead
+	// of replacing the link with a regular file.
+	writePath := resolveWriteTarget(absPath)
+
 	// Create parent directories
-	dir := filepath.Dir(absPath)
+	dir := filepath.Dir(writePath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to create directory: %v", err))), nil
 	}
 
 	// Atomic write: write to a uniquely-named temp file, then rename.
 	// Using os.CreateTemp avoids a name collision when concurrent calls target the same destination.
-	base := filepath.Base(absPath)
+	base := filepath.Base(writePath)
 	tf, err := os.CreateTemp(dir, "."+base+".*.tmp")
 	if err != nil {
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to create temp file: %v", err))), nil
@@ -155,7 +160,7 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to set file permissions: %v", err))), nil
 	}
 
-	if err := os.Rename(tempPath, absPath); err != nil {
+	if err := os.Rename(tempPath, writePath); err != nil {
 		os.Remove(tempPath)
 		return textOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "failed to rename temp file: %v", err))), nil
 	}
@@ -190,6 +195,28 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 	output.Content = warning + output.Content
 
 	return output, nil
+}
+
+// resolveWriteTarget follows symlinks at absPath so atomic temp+rename
+// writes land in the link's target instead of replacing the link with a
+// regular file. Dangling links resolve too — the rename then creates the
+// target. Non-symlinks are returned unchanged.
+func resolveWriteTarget(absPath string) string {
+	for i := 0; i < 8; i++ {
+		fi, err := os.Lstat(absPath)
+		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			return absPath
+		}
+		target, err := os.Readlink(absPath)
+		if err != nil {
+			return absPath
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(absPath), target)
+		}
+		absPath = target
+	}
+	return absPath
 }
 
 // countLines counts the number of lines in a string.

--- a/internal/tools/write.go
+++ b/internal/tools/write.go
@@ -199,8 +199,13 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (llm.
 
 // resolveWriteTarget follows symlinks at absPath so atomic temp+rename
 // writes land in the link's target instead of replacing the link with a
-// regular file. Dangling links resolve too — the rename then creates the
-// target. Non-symlinks are returned unchanged.
+// regular file. Only links whose target is a plain sibling name in the same
+// directory are followed — the handover rename case. Absolute targets or
+// targets in other directories are left alone: permission approval happens
+// before this resolution, so following them could redirect an approved write
+// outside the approved directory (e.g. a dangling link planted in the
+// auto-approved handover dir). Dangling same-directory links resolve too —
+// the rename then creates the target.
 func resolveWriteTarget(absPath string) string {
 	for i := 0; i < 8; i++ {
 		fi, err := os.Lstat(absPath)
@@ -211,10 +216,10 @@ func resolveWriteTarget(absPath string) string {
 		if err != nil {
 			return absPath
 		}
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(filepath.Dir(absPath), target)
+		if filepath.IsAbs(target) || filepath.Dir(target) != "." {
+			return absPath
 		}
-		absPath = target
+		absPath = filepath.Join(filepath.Dir(absPath), target)
 	}
 	return absPath
 }

--- a/internal/tools/write_symlink_test.go
+++ b/internal/tools/write_symlink_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveWriteTarget(t *testing.T) {
+	dir := t.TempDir()
+
+	regular := filepath.Join(dir, "plain.md")
+	if err := os.WriteFile(regular, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := resolveWriteTarget(regular); got != regular {
+		t.Fatalf("regular file resolved to %q", got)
+	}
+
+	missing := filepath.Join(dir, "missing.md")
+	if got := resolveWriteTarget(missing); got != missing {
+		t.Fatalf("missing path resolved to %q", got)
+	}
+
+	// Dangling symlinks resolve to their (not yet existing) target.
+	link := filepath.Join(dir, "link.md")
+	if err := os.Symlink("target.md", link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	want := filepath.Join(dir, "target.md")
+	if got := resolveWriteTarget(link); got != want {
+		t.Fatalf("dangling link resolved to %q, want %q", got, want)
+	}
+
+	// Chains resolve through intermediate links.
+	link2 := filepath.Join(dir, "link2.md")
+	if err := os.Symlink("link.md", link2); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if got := resolveWriteTarget(link2); got != want {
+		t.Fatalf("chained link resolved to %q, want %q", got, want)
+	}
+}
+
+// TestWriteFileToolWritesThroughSymlink ensures the atomic temp+rename write
+// follows symlinks (including dangling ones) instead of replacing the link
+// with a regular file. Renamed handover plan files rely on this.
+func TestWriteFileToolWritesThroughSymlink(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
+	if err := os.Symlink("2026-07-02-auth-refactor.md", link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	tool := NewWriteFileTool(nil)
+	args, err := json.Marshal(WriteFileArgs{Path: link, Content: "the plan"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// The link must survive and the content must land in its target.
+	fi, err := os.Lstat(link)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink was replaced (err %v)", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "2026-07-02-auth-refactor.md"))
+	if err != nil || string(data) != "the plan" {
+		t.Fatalf("target content = %q, err %v", data, err)
+	}
+}

--- a/internal/tools/write_symlink_test.go
+++ b/internal/tools/write_symlink_test.go
@@ -8,7 +8,18 @@ import (
 	"testing"
 )
 
+// requireSymlinks skips the test when the platform (or privilege level, e.g.
+// Windows without Developer Mode) does not support creating symlinks.
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	probe := filepath.Join(t.TempDir(), "probe")
+	if err := os.Symlink("target", probe); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+}
+
 func TestResolveWriteTarget(t *testing.T) {
+	requireSymlinks(t)
 	dir := t.TempDir()
 
 	regular := filepath.Join(dir, "plain.md")
@@ -24,7 +35,7 @@ func TestResolveWriteTarget(t *testing.T) {
 		t.Fatalf("missing path resolved to %q", got)
 	}
 
-	// Dangling symlinks resolve to their (not yet existing) target.
+	// Dangling same-directory symlinks resolve to their target.
 	link := filepath.Join(dir, "link.md")
 	if err := os.Symlink("target.md", link); err != nil {
 		t.Fatalf("Symlink: %v", err)
@@ -34,7 +45,7 @@ func TestResolveWriteTarget(t *testing.T) {
 		t.Fatalf("dangling link resolved to %q, want %q", got, want)
 	}
 
-	// Chains resolve through intermediate links.
+	// Chains of same-directory links resolve through intermediates.
 	link2 := filepath.Join(dir, "link2.md")
 	if err := os.Symlink("link.md", link2); err != nil {
 		t.Fatalf("Symlink: %v", err)
@@ -42,12 +53,43 @@ func TestResolveWriteTarget(t *testing.T) {
 	if got := resolveWriteTarget(link2); got != want {
 		t.Fatalf("chained link resolved to %q, want %q", got, want)
 	}
+
+	// Links leaving their own directory are never followed: permission
+	// approval ran against the link path, so following these could redirect
+	// an approved write elsewhere.
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	absEscape := filepath.Join(dir, "abs-escape.md")
+	if err := os.Symlink(filepath.Join(sub, "x.md"), absEscape); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if got := resolveWriteTarget(absEscape); got != absEscape {
+		t.Fatalf("absolute-target link followed to %q", got)
+	}
+	relEscape := filepath.Join(dir, "rel-escape.md")
+	if err := os.Symlink(filepath.Join("sub", "x.md"), relEscape); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if got := resolveWriteTarget(relEscape); got != relEscape {
+		t.Fatalf("subdir-target link followed to %q", got)
+	}
+	upEscape := filepath.Join(sub, "up-escape.md")
+	if err := os.Symlink(filepath.Join("..", "plain.md"), upEscape); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if got := resolveWriteTarget(upEscape); got != upEscape {
+		t.Fatalf("parent-target link followed to %q", got)
+	}
 }
 
 // TestWriteFileToolWritesThroughSymlink ensures the atomic temp+rename write
-// follows symlinks (including dangling ones) instead of replacing the link
-// with a regular file. Renamed handover plan files rely on this.
+// follows same-directory symlinks (including dangling ones) instead of
+// replacing the link with a regular file. Renamed handover plan files rely
+// on this.
 func TestWriteFileToolWritesThroughSymlink(t *testing.T) {
+	requireSymlinks(t)
 	dir := t.TempDir()
 	link := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
 	if err := os.Symlink("2026-07-02-auth-refactor.md", link); err != nil {
@@ -71,5 +113,40 @@ func TestWriteFileToolWritesThroughSymlink(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(dir, "2026-07-02-auth-refactor.md"))
 	if err != nil || string(data) != "the plan" {
 		t.Fatalf("target content = %q, err %v", data, err)
+	}
+}
+
+// TestWriteFileToolDoesNotFollowEscapingSymlink ensures a dangling symlink
+// pointing outside its own directory cannot redirect an approved write:
+// the link is replaced with a regular file and the outside target is never
+// created.
+func TestWriteFileToolDoesNotFollowEscapingSymlink(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "escaped.md")
+	link := filepath.Join(dir, "2026-07-02-amber-anchor-apple.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	tool := NewWriteFileTool(nil)
+	args, err := json.Marshal(WriteFileArgs{Path: link, Content: "content"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if _, err := os.Stat(outside); err == nil {
+		t.Fatal("write escaped through symlink to outside directory")
+	}
+	fi, err := os.Lstat(link)
+	if err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("expected link replaced by regular file (err %v)", err)
+	}
+	data, err := os.ReadFile(link)
+	if err != nil || string(data) != "content" {
+		t.Fatalf("link path content = %q, err %v", data, err)
 	}
 }

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -2726,11 +2726,11 @@ func (m *Model) cmdHandover(args []string) (tea.Model, tea.Cmd) {
 			}
 		}
 		if handoverDir != "" {
-			// Prefer the pinned handover path — the exact file agents are told
-			// about via {{handover_path}} — so documents written by other
-			// sessions or stray .md files can't shadow the plan. Fall back to
-			// scanning for the latest .md for legacy/cross-day sessions.
-			latestFile, latestInfo := pinnedHandoverFile()
+			// Prefer the exact file this session's agent was told about via
+			// {{handover_path}}, so documents written by concurrent sessions
+			// or stray .md files can't shadow the plan. Fall back to scanning
+			// for the latest .md when the prompt names no handover file.
+			latestFile, latestInfo := m.sessionHandoverFile(handoverDir)
 			if latestFile == "" || latestInfo.Size() == 0 {
 				latestFile, latestInfo = findLatestHandoverFile(handoverDir)
 			}
@@ -2893,12 +2893,32 @@ func pendingTargetScriptPreview(agent *agents.Agent) string {
 	return b.String()
 }
 
-// pinnedHandoverFile returns the process-pinned handover path for the current
-// project — the exact path agents see via {{handover_path}} — if a non-empty
-// file exists there (following the rename symlink). Returns ("", nil) otherwise.
-func pinnedHandoverFile() (string, os.FileInfo) {
-	path, err := session.GetHandoverPath(".", time.Now().Format("2006-01-02"))
-	if err != nil {
+// currentSystemPromptText returns the text of this session's persisted system
+// message, or "" if none exists.
+func (m *Model) currentSystemPromptText() string {
+	m.messagesMu.Lock()
+	defer m.messagesMu.Unlock()
+	for _, msg := range m.messages {
+		if msg.Role != llm.RoleSystem {
+			continue
+		}
+		for _, p := range msg.Parts {
+			if p.Text != "" {
+				return p.Text
+			}
+		}
+	}
+	return ""
+}
+
+// sessionHandoverFile returns the handover file this session's agent was told
+// about via {{handover_path}} — recovered from the persisted system prompt —
+// if a file exists there (following the rename symlink). Returns ("", nil)
+// otherwise. Each session names its own file, so concurrent sessions in the
+// same project cannot shadow each other's plans.
+func (m *Model) sessionHandoverFile(dir string) (string, os.FileInfo) {
+	path := session.ExtractHandoverPath(m.currentSystemPromptText(), dir)
+	if path == "" {
 		return "", nil
 	}
 	info, err := os.Stat(path)

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -2726,7 +2726,14 @@ func (m *Model) cmdHandover(args []string) (tea.Model, tea.Cmd) {
 			}
 		}
 		if handoverDir != "" {
-			latestFile, latestInfo := findLatestHandoverFile(handoverDir)
+			// Prefer the pinned handover path — the exact file agents are told
+			// about via {{handover_path}} — so documents written by other
+			// sessions or stray .md files can't shadow the plan. Fall back to
+			// scanning for the latest .md for legacy/cross-day sessions.
+			latestFile, latestInfo := pinnedHandoverFile()
+			if latestFile == "" || latestInfo.Size() == 0 {
+				latestFile, latestInfo = findLatestHandoverFile(handoverDir)
+			}
 			if latestFile != "" && latestInfo.Size() > 0 {
 				// Check freshness: file must have been modified after the session started
 				sessionStart := time.Time{}
@@ -2884,6 +2891,21 @@ func pendingTargetScriptPreview(agent *agents.Agent) string {
 		b.WriteString("\n```\n")
 	}
 	return b.String()
+}
+
+// pinnedHandoverFile returns the process-pinned handover path for the current
+// project — the exact path agents see via {{handover_path}} — if a non-empty
+// file exists there (following the rename symlink). Returns ("", nil) otherwise.
+func pinnedHandoverFile() (string, os.FileInfo) {
+	path, err := session.GetHandoverPath(".", time.Now().Format("2006-01-02"))
+	if err != nil {
+		return "", nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", nil
+	}
+	return path, info
 }
 
 // findLatestHandoverFile scans dir for .md files and returns the path and

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -2727,11 +2727,18 @@ func (m *Model) cmdHandover(args []string) (tea.Model, tea.Cmd) {
 		}
 		if handoverDir != "" {
 			// Prefer the exact file this session's agent was told about via
-			// {{handover_path}}, so documents written by concurrent sessions
-			// or stray .md files can't shadow the plan. Fall back to scanning
-			// for the latest .md when the prompt names no handover file.
-			latestFile, latestInfo := m.sessionHandoverFile(handoverDir)
-			if latestFile == "" || latestInfo.Size() == 0 {
+			// {{handover_path}}. When the prompt names a path, never fall back
+			// to scanning — a newer .md from a concurrent session must not
+			// shadow this session's plan, even while ours is empty or unwritten.
+			// Scanning for the latest .md remains only for legacy prompts that
+			// name no handover file.
+			var latestFile string
+			var latestInfo os.FileInfo
+			if pinned := session.ExtractHandoverPath(m.currentSystemPromptText(), handoverDir); pinned != "" {
+				if info, err := os.Stat(pinned); err == nil {
+					latestFile, latestInfo = pinned, info
+				}
+			} else {
 				latestFile, latestInfo = findLatestHandoverFile(handoverDir)
 			}
 			if latestFile != "" && latestInfo.Size() > 0 {
@@ -2909,23 +2916,6 @@ func (m *Model) currentSystemPromptText() string {
 		}
 	}
 	return ""
-}
-
-// sessionHandoverFile returns the handover file this session's agent was told
-// about via {{handover_path}} — recovered from the persisted system prompt —
-// if a file exists there (following the rename symlink). Returns ("", nil)
-// otherwise. Each session names its own file, so concurrent sessions in the
-// same project cannot shadow each other's plans.
-func (m *Model) sessionHandoverFile(dir string) (string, os.FileInfo) {
-	path := session.ExtractHandoverPath(m.currentSystemPromptText(), dir)
-	if path == "" {
-		return "", nil
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return "", nil
-	}
-	return path, info
 }
 
 // findLatestHandoverFile scans dir for .md files and returns the path and

--- a/internal/tui/chat/handover_pinned_test.go
+++ b/internal/tui/chat/handover_pinned_test.go
@@ -1,0 +1,77 @@
+package chat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/agents"
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// TestCmdHandoverFileModePrefersPinnedPath ensures /handover reads the exact
+// file agents are told about via {{handover_path}}, even when another .md in
+// the handover directory has a newer modification time.
+func TestCmdHandoverFileModePrefersPinnedPath(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "xdg-data"))
+	session.ResetHandoverPathCache()
+	t.Cleanup(session.ResetHandoverPathCache)
+
+	pinned, err := session.GetHandoverPath(".", time.Now().Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("GetHandoverPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(pinned), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pinned, []byte("the pinned plan"), 0o644); err != nil {
+		t.Fatalf("WriteFile pinned: %v", err)
+	}
+
+	// A stray document with a newer mtime must not shadow the pinned plan.
+	decoy := filepath.Join(filepath.Dir(pinned), "2026-01-01-stray-notes.md")
+	if err := os.WriteFile(decoy, []byte("stray notes"), 0o644); err != nil {
+		t.Fatalf("WriteFile decoy: %v", err)
+	}
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(decoy, future, future); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	m := newTestChatModel(false)
+	m.store = &mockStore{}
+	m.config = &config.Config{}
+	m.sess = &session.Session{ID: "pinned-handover", CreatedAt: time.Now().Add(-time.Minute)}
+	m.agentName = "planner"
+	m.currentAgent = &agents.Agent{Name: "planner", EnableHandover: true, HandoverMode: "file"}
+	m.agentResolver = func(name string, cfg *config.Config) (*agents.Agent, error) {
+		return &agents.Agent{Name: name, SystemPrompt: "You are target."}, nil
+	}
+
+	_, cmd := m.cmdHandover([]string{"@developer"})
+	if cmd == nil {
+		t.Fatal("expected handover command")
+	}
+	msg := cmd()
+	done, ok := msg.(handoverDoneMsg)
+	if !ok {
+		t.Fatalf("handover command returned %T, want handoverDoneMsg", msg)
+	}
+	if done.result == nil {
+		t.Fatal("expected handover result")
+	}
+	if done.result.Document != "the pinned plan" {
+		t.Fatalf("handover used wrong document: %q", done.result.Document)
+	}
+}

--- a/internal/tui/chat/handover_pinned_test.go
+++ b/internal/tui/chat/handover_pinned_test.go
@@ -8,13 +8,16 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
-// TestCmdHandoverFileModePrefersPinnedPath ensures /handover reads the exact
-// file agents are told about via {{handover_path}}, even when another .md in
-// the handover directory has a newer modification time.
-func TestCmdHandoverFileModePrefersPinnedPath(t *testing.T) {
+// TestCmdHandoverFileModeUsesSessionPromptPath ensures /handover reads the
+// exact file this session's agent was told about via {{handover_path}} (as
+// recorded in its persisted system prompt), even when another .md in the
+// handover directory — e.g. from a concurrent session — has a newer
+// modification time.
+func TestCmdHandoverFileModeUsesSessionPromptPath(t *testing.T) {
 	tmp := t.TempDir()
 	oldWD, err := os.Getwd()
 	if err != nil {
@@ -25,23 +28,21 @@ func TestCmdHandoverFileModePrefersPinnedPath(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "xdg-data"))
-	session.ResetHandoverPathCache()
-	t.Cleanup(session.ResetHandoverPathCache)
 
-	pinned, err := session.GetHandoverPath(".", time.Now().Format("2006-01-02"))
+	planPath, err := session.GetHandoverPath(".", time.Now().Format("2006-01-02"))
 	if err != nil {
 		t.Fatalf("GetHandoverPath: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(pinned), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(pinned, []byte("the pinned plan"), 0o644); err != nil {
-		t.Fatalf("WriteFile pinned: %v", err)
+	if err := os.WriteFile(planPath, []byte("the session plan"), 0o644); err != nil {
+		t.Fatalf("WriteFile plan: %v", err)
 	}
 
-	// A stray document with a newer mtime must not shadow the pinned plan.
-	decoy := filepath.Join(filepath.Dir(pinned), "2026-01-01-stray-notes.md")
-	if err := os.WriteFile(decoy, []byte("stray notes"), 0o644); err != nil {
+	// A concurrent session's document with a newer mtime must not shadow it.
+	decoy := filepath.Join(filepath.Dir(planPath), "2026-01-01-other-session-plan.md")
+	if err := os.WriteFile(decoy, []byte("someone else's plan"), 0o644); err != nil {
 		t.Fatalf("WriteFile decoy: %v", err)
 	}
 	future := time.Now().Add(time.Hour)
@@ -52,11 +53,15 @@ func TestCmdHandoverFileModePrefersPinnedPath(t *testing.T) {
 	m := newTestChatModel(false)
 	m.store = &mockStore{}
 	m.config = &config.Config{}
-	m.sess = &session.Session{ID: "pinned-handover", CreatedAt: time.Now().Add(-time.Minute)}
+	m.sess = &session.Session{ID: "prompt-path-handover", CreatedAt: time.Now().Add(-time.Minute)}
 	m.agentName = "planner"
 	m.currentAgent = &agents.Agent{Name: "planner", EnableHandover: true, HandoverMode: "file"}
 	m.agentResolver = func(name string, cfg *config.Config) (*agents.Agent, error) {
 		return &agents.Agent{Name: name, SystemPrompt: "You are target."}, nil
+	}
+	sysPrompt := "You are a planner. Maintain your plan in `" + planPath + "`."
+	m.messages = []session.Message{
+		*session.NewMessage(m.sess.ID, llm.SystemText(sysPrompt), -1),
 	}
 
 	_, cmd := m.cmdHandover([]string{"@developer"})
@@ -71,7 +76,7 @@ func TestCmdHandoverFileModePrefersPinnedPath(t *testing.T) {
 	if done.result == nil {
 		t.Fatal("expected handover result")
 	}
-	if done.result.Document != "the pinned plan" {
+	if done.result.Document != "the session plan" {
 		t.Fatalf("handover used wrong document: %q", done.result.Document)
 	}
 }

--- a/internal/tui/chat/handover_pinned_test.go
+++ b/internal/tui/chat/handover_pinned_test.go
@@ -80,3 +80,53 @@ func TestCmdHandoverFileModeUsesSessionPromptPath(t *testing.T) {
 		t.Fatalf("handover used wrong document: %q", done.result.Document)
 	}
 }
+
+// TestCmdHandoverFileModeIgnoresDecoyWhenPinnedUnwritten ensures that when
+// the prompt names a pinned plan file that has not been written yet, file
+// mode does NOT fall back to a newer .md from a concurrent session.
+func TestCmdHandoverFileModeIgnoresDecoyWhenPinnedUnwritten(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "xdg-data"))
+
+	planPath, err := session.GetHandoverPath(".", time.Now().Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("GetHandoverPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// The pinned plan is never written; only a concurrent session's doc exists.
+	decoy := filepath.Join(filepath.Dir(planPath), "2026-01-01-other-session-plan.md")
+	if err := os.WriteFile(decoy, []byte("someone else's plan"), 0o644); err != nil {
+		t.Fatalf("WriteFile decoy: %v", err)
+	}
+
+	m := newTestChatModel(false)
+	m.store = &mockStore{}
+	m.config = &config.Config{}
+	m.sess = &session.Session{ID: "unwritten-pinned", CreatedAt: time.Now().Add(-time.Minute)}
+	m.agentName = "planner"
+	m.currentAgent = &agents.Agent{Name: "planner", EnableHandover: true, HandoverMode: "file"}
+	m.agentResolver = func(name string, cfg *config.Config) (*agents.Agent, error) {
+		return &agents.Agent{Name: name, SystemPrompt: "You are target."}, nil
+	}
+	sysPrompt := "You are a planner. Maintain your plan in `" + planPath + "`."
+	m.messages = []session.Message{
+		*session.NewMessage(m.sess.ID, llm.SystemText(sysPrompt), -1),
+	}
+
+	_, cmd := m.cmdHandover([]string{"@developer"})
+	if cmd != nil {
+		if done, ok := cmd().(handoverDoneMsg); ok {
+			t.Fatalf("handover must not proceed with another session's document: %q", done.result.Document)
+		}
+	}
+}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -841,7 +841,12 @@ func (m *Model) maybeRenameHandoverCmd() tea.Cmd {
 		if err != nil {
 			return handoverRenameDoneMsg{err: err}
 		}
-		path, _ := findLatestHandoverFile(dir)
+		// Rename the pinned handover file the agent writes to; only fall back
+		// to the latest-.md scan when the pinned path has no file yet.
+		path, _ := pinnedHandoverFile()
+		if path == "" {
+			path, _ = findLatestHandoverFile(dir)
+		}
 		if path == "" {
 			return handoverRenameDoneMsg{}
 		}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -375,6 +375,14 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Name the handover file from the first user message so it carries a
+	// descriptive filename from the start.
+	if m.userMessageCount() == 1 {
+		if cmd := m.maybeNameHandoverCmd(content); cmd != nil {
+			preSendCmds = append(preSendCmds, cmd)
+		}
+	}
+
 	// Print user message permanently to scrollback (inline mode)
 	theme := m.styles.Theme()
 	promptStyle := lipgloss.NewStyle().Foreground(theme.Primary).Bold(true)
@@ -824,10 +832,93 @@ func (m *Model) saveSessionCmd() tea.Cmd {
 	}
 }
 
+// userMessageCount returns the number of user messages in this session.
+func (m *Model) userMessageCount() int {
+	m.messagesMu.Lock()
+	defer m.messagesMu.Unlock()
+	n := 0
+	for _, msg := range m.messages {
+		if msg.Role == llm.RoleUser {
+			n++
+		}
+	}
+	return n
+}
+
+// fastSlugGen returns a HandoverSlugGenerator that formats content into
+// promptFmt (which must contain a single %s), runs it through the fast
+// provider, and returns the trimmed response. Content is truncated to keep
+// the request small.
+func fastSlugGen(provider llm.Provider, promptFmt string) session.HandoverSlugGenerator {
+	return func(ctx context.Context, content string) (string, error) {
+		if len(content) > 2000 {
+			content = content[:2000]
+		}
+		prompt := fmt.Sprintf(promptFmt, content)
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		stream, err := provider.Stream(ctx, llm.Request{
+			Messages: []llm.Message{
+				llm.UserText(prompt),
+			},
+			MaxTurns: 1,
+		})
+		if err != nil {
+			return "", err
+		}
+		defer stream.Close()
+		var b strings.Builder
+		for {
+			ev, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return "", err
+			}
+			if ev.Type == llm.EventTextDelta {
+				b.WriteString(ev.Text)
+			}
+		}
+		return strings.TrimSpace(b.String()), nil
+	}
+}
+
+// maybeNameHandoverCmd names this session's handover file from the first user
+// message: the fast provider produces two descriptive words which replace the
+// random slug upfront, and a symlink from the original path (baked into the
+// system prompt) keeps the agent's writes landing in the renamed file.
+func (m *Model) maybeNameHandoverCmd(firstMessage string) tea.Cmd {
+	if m.currentAgent == nil || !m.currentAgent.EnableHandover {
+		return nil
+	}
+	provider := m.fastProvider
+	if provider == nil {
+		return nil
+	}
+	promptText := m.currentSystemPromptText()
+	rootCtx := m.rootContext()
+	return func() tea.Msg {
+		dir, err := session.GetHandoverDir(".")
+		if err != nil {
+			return handoverRenameDoneMsg{err: err}
+		}
+		path := session.ExtractHandoverPath(promptText, dir)
+		if path == "" {
+			return handoverRenameDoneMsg{}
+		}
+		slugGen := fastSlugGen(provider, "Generate exactly two lowercase dash-separated words that describe this task, e.g. auth-refactor. Reply with ONLY the two words, nothing else.\n\n%s")
+		err = session.PrettifyHandoverName(rootCtx, path, firstMessage, slugGen)
+		return handoverRenameDoneMsg{err: err}
+	}
+}
+
 // maybeRenameHandoverCmd returns a tea.Cmd that checks the handover directory
 // for a random-named file large enough to rename. If found, it uses the fast
 // provider to generate a descriptive slug, renames the file, and creates a
-// symlink from the old name so the system prompt path remains valid.
+// symlink from the old name so the system prompt path remains valid. This is
+// the fallback for sessions where first-message naming did not run (e.g. no
+// fast provider at the time); it skips files that are already symlinks.
 func (m *Model) maybeRenameHandoverCmd() tea.Cmd {
 	if m.currentAgent == nil || !m.currentAgent.EnableHandover {
 		return nil
@@ -838,6 +929,7 @@ func (m *Model) maybeRenameHandoverCmd() tea.Cmd {
 	}
 	// Snapshot the prompt before the async command to avoid racing on m.messages.
 	promptText := m.currentSystemPromptText()
+	rootCtx := m.rootContext()
 	return func() tea.Msg {
 		dir, err := session.GetHandoverDir(".")
 		if err != nil {
@@ -852,40 +944,8 @@ func (m *Model) maybeRenameHandoverCmd() tea.Cmd {
 		if path == "" {
 			return handoverRenameDoneMsg{}
 		}
-		slugGen := func(ctx context.Context, content string) (string, error) {
-			// Truncate content to first 2000 chars to keep the request small
-			if len(content) > 2000 {
-				content = content[:2000]
-			}
-			prompt := fmt.Sprintf("Generate a short filesystem-safe slug (2-5 words, lowercase, dash-separated) that describes this document. Reply with ONLY the slug, nothing else.\n\n%s", content)
-			ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-			defer cancel()
-			stream, err := provider.Stream(ctx, llm.Request{
-				Messages: []llm.Message{
-					llm.UserText(prompt),
-				},
-				MaxTurns: 1,
-			})
-			if err != nil {
-				return "", err
-			}
-			defer stream.Close()
-			var b strings.Builder
-			for {
-				ev, err := stream.Recv()
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
-					return "", err
-				}
-				if ev.Type == llm.EventTextDelta {
-					b.WriteString(ev.Text)
-				}
-			}
-			return strings.TrimSpace(b.String()), nil
-		}
-		err = session.MaybeRenameHandover(m.rootContext(), path, slugGen)
+		slugGen := fastSlugGen(provider, "Generate a short filesystem-safe slug (2-5 words, lowercase, dash-separated) that describes this document. Reply with ONLY the slug, nothing else.\n\n%s")
+		err = session.MaybeRenameHandover(rootCtx, path, slugGen)
 		return handoverRenameDoneMsg{err: err}
 	}
 }

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -836,14 +836,16 @@ func (m *Model) maybeRenameHandoverCmd() tea.Cmd {
 	if provider == nil {
 		return nil
 	}
+	// Snapshot the prompt before the async command to avoid racing on m.messages.
+	promptText := m.currentSystemPromptText()
 	return func() tea.Msg {
 		dir, err := session.GetHandoverDir(".")
 		if err != nil {
 			return handoverRenameDoneMsg{err: err}
 		}
-		// Rename the pinned handover file the agent writes to; only fall back
-		// to the latest-.md scan when the pinned path has no file yet.
-		path, _ := pinnedHandoverFile()
+		// Rename the file this session's agent writes to; only fall back to
+		// the latest-.md scan when the prompt names no handover file.
+		path := session.ExtractHandoverPath(promptText, dir)
 		if path == "" {
 			path, _ = findLatestHandoverFile(dir)
 		}


### PR DESCRIPTION
## What

Planner → developer handovers were unreliable: the planner (especially on fable) would end up with its plan somewhere other than the file the handover mechanism reads. This PR makes the plan file per-session and authoritative, gives it a descriptive name upfront, and keeps concurrent planning per project intact.

### Per-session plan file, resolved from the system prompt

- `{{handover_path}}` still generates a unique random name per session, so concurrent sessions in one project never share a file. New `session.ExtractHandoverPath` recovers that exact path from the persisted system prompt — which survives resume, since the stored system message is reused rather than re-expanded.
- `/handover` file mode reads that exact file instead of scanning for the newest `.md`, so a concurrent session's plan, a spawned sub-agent's doc, or any stray file can't shadow it. The latest-scan survives only as a fallback when the prompt names no handover file.

### Descriptive filename from the first user message

- On the first user message of a handover-enabled session, the fast model produces two words describing the task (e.g. `auth-refactor`) and the plan file is named `2026-07-02-auth-refactor.md` immediately — set in stone upfront, instead of the old "wait for 1000 bytes then rename from content" flow (which is kept only as a fallback when no fast provider was available).
- The random path baked into the system prompt keeps working via a symlink; when the agent hasn't written yet, the symlink dangles until the first write creates the descriptive file. Name collisions between concurrent sessions keep one random word for uniqueness (`2026-07-02-auth-refactor-amber.md`).

### write_file/edit_file now write through symlinks

The atomic temp+rename in `write_file` and `edit_file` used to **replace** a symlink with a regular file. That silently broke the existing rename-with-symlink flow too (the agent's next write to the old path clobbered the link and content diverged). Both tools now resolve the link (including dangling ones) and rename onto its target.

### No permission prompts for the plan file

The plan lives under term-llm's own data dir (`~/.local/share/term-llm/handover/…`), outside the project's granted write roots, so every plan update triggered an approval prompt. `IsPathAllowedForRead/Write` now always allow paths inside the handover data root — it is app-managed state, not user files. Everything else in the data dir (e.g. `sessions.db`) stays protected.

### Planner prompt hardening

`system.md` states the path is decided upfront and fixed for the session, and forbids choosing a different filename, writing the plan into the repository/working directory, or creating extra `.md` files in the handover directory.

## Notes

- Tests: `ExtractHandoverPath` matching, `PrettifyHandoverName` (dangling-symlink naming, existing-content carry-over, collision suffix, two-word cap, non-random skip), write-through-symlink for the write tool, and a regression asserting `/handover` prefers the session's own plan over a newer stray `.md`. Full `go test ./...` passes (53 packages).

