### PR TITLE
feat: smoother, friendlier web UI diff panel

### DIFF
--- a/internal/llm/debug_provider.go
+++ b/internal/llm/debug_provider.go
@@ -214,8 +214,11 @@ func (d *DebugProvider) Capabilities() Capabilities {
 // Otherwise, streams the debug markdown content.
 func (d *DebugProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
-		// If tool results are present, stream completion text
-		if hasToolResults(req.Messages) {
+		// If the request is completing a tool round (the conversation ends
+		// with tool results), stream completion text. Earlier turns' tool
+		// results must not short-circuit new user commands in multi-turn
+		// sessions.
+		if lastMessageHasToolResults(req.Messages) {
 			return d.streamCompletionText(ctx, send)
 		}
 
@@ -470,16 +473,19 @@ func nextDebugCallID() string {
 	return fmt.Sprintf("debug-call-%d", debugCallID.Add(1))
 }
 
-// hasToolResults checks if any message contains tool results.
-func hasToolResults(msgs []Message) bool {
-	for _, msg := range msgs {
-		if msg.Role == RoleTool {
+// lastMessageHasToolResults reports whether the conversation ends with tool
+// results, i.e. this request is the follow-up round of the current turn.
+func lastMessageHasToolResults(msgs []Message) bool {
+	if len(msgs) == 0 {
+		return false
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role == RoleTool {
+		return true
+	}
+	for _, part := range last.Parts {
+		if part.Type == PartToolResult {
 			return true
-		}
-		for _, part := range msg.Parts {
-			if part.Type == PartToolResult {
-				return true
-			}
 		}
 	}
 	return false
@@ -639,13 +645,13 @@ func parseCommand(prompt string, tools []ToolSpec) []*ToolCall {
 					continue
 				}
 				for j := 0; j < multiplier; j++ {
-					calls = append(calls, makeCall("read_file", map[string]string{"file_path": file}))
+					calls = append(calls, makeCall("read_file", map[string]string{"path": file}))
 				}
 			}
 			return calls
 		}
 		toolName = "read_file"
-		argsMap = map[string]string{"file_path": args[0]}
+		argsMap = map[string]string{"path": args[0]}
 
 	case "write":
 		if !toolSet["write_file"] {
@@ -658,8 +664,8 @@ func parseCommand(prompt string, tools []ToolSpec) []*ToolCall {
 			}
 			toolName = "write_file"
 			argsMap = map[string]string{
-				"file_path": filePath,
-				"content":   generateWriteContent(writeLines),
+				"path":    filePath,
+				"content": generateWriteContent(writeLines),
 			}
 		} else {
 			if len(args) < 2 {
@@ -667,8 +673,8 @@ func parseCommand(prompt string, tools []ToolSpec) []*ToolCall {
 			}
 			toolName = "write_file"
 			argsMap = map[string]string{
-				"file_path": args[0],
-				"content":   strings.Join(args[1:], " "),
+				"path":    args[0],
+				"content": strings.Join(args[1:], " "),
 			}
 		}
 
@@ -715,9 +721,9 @@ func parseCommand(prompt string, tools []ToolSpec) []*ToolCall {
 		calls := make([]*ToolCall, len(edits))
 		for i, e := range edits {
 			argsJSON, _ := json.Marshal(map[string]string{
-				"file_path": filePath,
-				"old_text":  e[0],
-				"new_text":  e[1],
+				"path":     filePath,
+				"old_text": e[0],
+				"new_text": e[1],
 			})
 			calls[i] = &ToolCall{
 				ID:        nextDebugCallID(),

--- a/internal/llm/debug_provider_test.go
+++ b/internal/llm/debug_provider_test.go
@@ -836,3 +836,103 @@ func TestParseSequenceDSLWithWrite(t *testing.T) {
 		t.Errorf("action 2: got text length %d, want 100", len(actions[2].Text))
 	}
 }
+
+// drainDebugStream collects tool calls and concatenated text from one stream.
+func drainDebugStream(t *testing.T, p *DebugProvider, req Request) ([]*ToolCall, string) {
+	t.Helper()
+	stream, err := p.Stream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	var calls []*ToolCall
+	var text strings.Builder
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("stream error: %v", err)
+		}
+		switch event.Type {
+		case EventToolCall:
+			calls = append(calls, event.Tool)
+		case EventTextDelta:
+			text.WriteString(event.Text)
+		}
+	}
+	return calls, text.String()
+}
+
+// Earlier turns' tool results must not short-circuit new user commands:
+// only a conversation ENDING in tool results is the follow-up round of the
+// current turn.
+func TestDebugProviderCommandsWorkAfterEarlierToolResults(t *testing.T) {
+	p := NewDebugProvider("fast")
+	tools := []ToolSpec{{Name: "read_file"}}
+
+	calls, _ := drainDebugStream(t, p, Request{
+		Tools: tools,
+		Messages: []Message{
+			{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "read a.txt"}}},
+			{Role: RoleTool, Parts: []Part{{Type: PartToolResult, Text: "contents of a"}}},
+			{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "Debug: Tool execution completed successfully."}}},
+			{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "read b.txt"}}},
+		},
+	})
+
+	if len(calls) != 1 {
+		t.Fatalf("got %d tool calls, want 1 (later-turn command must still parse)", len(calls))
+	}
+	var args map[string]string
+	if err := json.Unmarshal(calls[0].Arguments, &args); err != nil {
+		t.Fatalf("failed to unmarshal args: %v", err)
+	}
+	if args["path"] != "b.txt" {
+		t.Errorf("read_file path = %q, want b.txt", args["path"])
+	}
+}
+
+func TestDebugProviderCompletionWhenConversationEndsWithToolResults(t *testing.T) {
+	p := NewDebugProvider("fast")
+	tools := []ToolSpec{{Name: "read_file"}}
+
+	calls, text := drainDebugStream(t, p, Request{
+		Tools: tools,
+		Messages: []Message{
+			{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "read a.txt"}}},
+			{Role: RoleTool, Parts: []Part{{Type: PartToolResult, Text: "contents of a"}}},
+		},
+	})
+
+	if len(calls) != 0 {
+		t.Fatalf("got %d tool calls, want 0 (trailing tool results complete the turn)", len(calls))
+	}
+	if !strings.Contains(text, "Tool execution completed") {
+		t.Errorf("completion text = %q, want it to contain 'Tool execution completed'", text)
+	}
+}
+
+func TestDebugProviderDSLSequenceAfterEarlierToolResults(t *testing.T) {
+	p := NewDebugProvider("fast")
+	tools := []ToolSpec{{Name: "read_file"}, {Name: "write_file"}}
+
+	calls, _ := drainDebugStream(t, p, Request{
+		Tools: tools,
+		Messages: []Message{
+			{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "read a.txt"}}},
+			{Role: RoleTool, Parts: []Part{{Type: PartToolResult, Text: "contents of a"}}},
+			{Role: RoleAssistant, Parts: []Part{{Type: PartText, Text: "done"}}},
+			{Role: RoleUser, Parts: []Part{{Type: PartText, Text: "read c.txt, write*3 d.txt"}}},
+		},
+	})
+
+	if len(calls) != 2 {
+		t.Fatalf("got %d tool calls, want 2 (DSL sequence on a later turn)", len(calls))
+	}
+	if calls[0].Name != "read_file" || calls[1].Name != "write_file" {
+		t.Errorf("tool names = %q,%q, want read_file,write_file", calls[0].Name, calls[1].Name)
+	}
+}

--- a/internal/llm/debug_provider_test.go
+++ b/internal/llm/debug_provider_test.go
@@ -465,8 +465,8 @@ func TestDebugProviderMixedStreamToolArguments(t *testing.T) {
 	if err := json.Unmarshal(toolCalls[0].Arguments, &readArgs); err != nil {
 		t.Fatalf("failed to unmarshal read_file args: %v", err)
 	}
-	if readArgs["file_path"] != "README.md" {
-		t.Errorf("read_file file_path = %q, want README.md", readArgs["file_path"])
+	if readArgs["path"] != "README.md" {
+		t.Errorf("read_file path = %q, want README.md", readArgs["path"])
 	}
 
 	// Check shell args
@@ -609,8 +609,8 @@ func TestDebugProviderEditCommand(t *testing.T) {
 			continue
 		}
 
-		if args["file_path"] != testFile {
-			t.Errorf("tool call %d: got file_path %q, want %q", i, args["file_path"], testFile)
+		if args["path"] != testFile {
+			t.Errorf("tool call %d: got path %q, want %q", i, args["path"], testFile)
 		}
 		if args["old_text"] == "" {
 			t.Errorf("tool call %d: old_text is empty", i)
@@ -780,8 +780,8 @@ func TestParseCommandWriteLines(t *testing.T) {
 					t.Fatalf("failed to unmarshal args: %v", err)
 				}
 
-				if args["file_path"] != tt.wantPath {
-					t.Errorf("got file_path %q, want %q", args["file_path"], tt.wantPath)
+				if args["path"] != tt.wantPath {
+					t.Errorf("got path %q, want %q", args["path"], tt.wantPath)
 				}
 
 				if tt.wantLines > 0 {

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -411,7 +411,11 @@ const elements = {
   diffResizeHandle: document.getElementById('diffResizeHandle'),
   diffFileList: document.getElementById('diffFileList'),
   diffToggleBtn: document.getElementById('diffToggleBtn'),
-  diffToggleBadge: document.getElementById('diffToggleBadge')
+  diffToggleBadge: document.getElementById('diffToggleBadge'),
+  diffExpandAllBtn: document.getElementById('diffExpandAllBtn'),
+  diffCollapseAllBtn: document.getElementById('diffCollapseAllBtn'),
+  diffFilterRow: document.getElementById('diffFilterRow'),
+  diffFilterInput: document.getElementById('diffFilterInput')
 };
 
 const displayAgentName = (name) => {

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -4,8 +4,10 @@
 // Live diff sidebar: shows the active session's cumulative file changes while
 // the agent works. Fed by metadata-only `response.file_change` stream events;
 // diff content is fetched on demand from the session file-changes endpoints.
-// Files render as an accordion: each one expands inline where it sits in the
-// list and can be collapsed individually.
+// Files render as an accordion ordered by recency: each one expands inline
+// where it sits in the list and can be collapsed individually. Rendering is
+// keyed by path — blocks are reused across renders so live updates patch the
+// existing DOM instead of rebuilding it (no flicker, selection/focus survive).
 const app = window.TermLLMApp || (window.TermLLMApp = {});
 const {
   state,
@@ -21,10 +23,16 @@ const DIFF_REFRESH_DEBOUNCE_MS = 350;
 const DIFF_RENDER_DEBOUNCE_MS = 80;
 const DIFF_MIN_WIDTH = 280;
 // Per-line tokenizing is cheap but not free; skip highlighting huge diffs.
+// The cap applies to the rows actually rendered, so a capped view of a huge
+// diff still gets color.
 const DIFF_HIGHLIGHT_MAX_ROWS = 1500;
 // Cap initially rendered rows per file so a huge retained diff cannot flood
-// the DOM; a "show more" control reveals the rest on demand.
+// the DOM; a "show more" control reveals further chunks on demand.
 const DIFF_RENDER_MAX_ROWS = 400;
+// Show the filter input once the list is long enough for scanning to hurt.
+const DIFF_FILTER_MIN_FILES = 8;
+// How long transient feedback (update pulse, copied checkmark) stays applied.
+const DIFF_FEEDBACK_MS = 700;
 
 // Per-session diff state lives here, NOT on session objects: sessions persist
 // to localStorage and this data is server-backed and rebuildable.
@@ -37,10 +45,15 @@ const sessionDiffState = (sessionId) => {
       files: new Map(),          // path -> { path, kind, adds, dels, truncated, lastSeq }
       expanded: new Set(),       // paths whose diff body is open
       userCollapsed: new Set(),  // paths the user explicitly collapsed (blocks auto-expand)
-      fullDiffPaths: new Set(),  // paths the user asked to render beyond the row cap
+      userExpanded: new Set(),   // paths the user explicitly expanded (blocks auto-collapse)
+      autoExpandedPath: '',      // the file currently held open by live-follow
+      rowLimits: new Map(),      // path -> rendered row cap raised by "show more"
       diffCache: new Map(),      // path -> { seq, data }
       dirtyPaths: new Set(),     // cached diff is stale (newer change seen)
+      fetchErrors: new Set(),    // paths whose last diff fetch failed (shows retry)
       inflight: new Map(),       // path -> Promise (request dedup)
+      blocks: new Map(),         // path -> reusable DOM block (see syncDiffFileBlock)
+      filter: '',                // substring filter over paths (display only)
       refreshTimer: null,
       renderTimer: null,
       lastActivityAt: 0,
@@ -103,6 +116,80 @@ const countRowChanges = (rows) => {
   return { adds, dels };
 };
 
+// sortDiffPaths orders file entries most-recently-changed first (server seq
+// is monotonic), falling back to path order for ties. A live panel should
+// keep the file being edited at the top, not buried alphabetically.
+const sortDiffPaths = (entries) => entries
+  .slice()
+  .sort((a, b) => ((b.lastSeq || 0) - (a.lastSeq || 0)) || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+  .map((entry) => entry.path);
+
+// emphasizeRowPair computes the changed span between a paired del/add line
+// (common prefix/suffix trimmed) and stores it as row.emph = [start, end).
+// Pairs with nothing in common are left alone — whole-line emphasis is noise.
+const emphasizeRowPair = (del, add) => {
+  const a = del.text;
+  const b = add.text;
+  if (a === b) return;
+  const maxP = Math.min(a.length, b.length);
+  let p = 0;
+  while (p < maxP && a[p] === b[p]) p += 1;
+  let s = 0;
+  while (s < maxP - p && a[a.length - 1 - s] === b[b.length - 1 - s]) s += 1;
+  if (p + s === 0) return;
+  // Skip when the lines barely relate: emphasis should mark a small edit,
+  // not repaint an entire replaced line.
+  if (p + s < Math.max(a.length, b.length) * 0.2) return;
+  del.emph = [p, a.length - s];
+  add.emph = [p, b.length - s];
+};
+
+// computeInlineEmphasis pairs consecutive del/add runs index-wise (GitHub
+// style) and marks the changed span within each pair.
+const computeInlineEmphasis = (rows) => {
+  let i = 0;
+  while (i < rows.length) {
+    if (rows[i].type !== 'del') {
+      i += 1;
+      continue;
+    }
+    const delStart = i;
+    while (i < rows.length && rows[i].type === 'del') i += 1;
+    const addStart = i;
+    while (i < rows.length && rows[i].type === 'add') i += 1;
+    const pairs = Math.min(addStart - delStart, i - addStart);
+    for (let j = 0; j < pairs; j += 1) {
+      emphasizeRowPair(rows[delStart + j], rows[addStart + j]);
+    }
+  }
+  return rows;
+};
+
+// buildUnifiedDiff reconstructs a unified diff patch from the cached hunk
+// payload, for the per-file "copy diff" action.
+const buildUnifiedDiff = (path, data) => {
+  const out = [`--- a/${path}`, `+++ b/${path}`];
+  (Array.isArray(data?.hunks) ? data.hunks : []).forEach((hunk) => {
+    const lines = Array.isArray(hunk.lines) ? hunk.lines : [];
+    let oldLen = 0;
+    let newLen = 0;
+    lines.forEach((line) => {
+      if (line.t === 'add') newLen += 1;
+      else if (line.t === 'del') oldLen += 1;
+      else {
+        oldLen += 1;
+        newLen += 1;
+      }
+    });
+    out.push(`@@ -${Number(hunk.old_start) || 1},${oldLen} +${Number(hunk.new_start) || 1},${newLen} @@`);
+    lines.forEach((line) => {
+      const prefix = line.t === 'add' ? '+' : line.t === 'del' ? '-' : ' ';
+      out.push(prefix + String(line.s ?? ''));
+    });
+  });
+  return `${out.join('\n')}\n`;
+};
+
 // ===== State updates =====
 
 const handleFileChangeEvent = (session, payload) => {
@@ -125,9 +212,17 @@ const handleFileChangeEvent = (session, payload) => {
   });
   ds.dirtyPaths.add(path);
 
-  // Live follow: open the file being edited unless the user collapsed it.
+  // Live follow: keep only the file being edited open. The previously
+  // followed file collapses again unless the user opened it themselves —
+  // a busy run should read as "one file at a time", not an ever-growing
+  // wall of expanded diffs.
   const newlyExpanded = !ds.expanded.has(path) && !ds.userCollapsed.has(path);
-  if (!ds.userCollapsed.has(path)) ds.expanded.add(path);
+  if (!ds.userCollapsed.has(path)) {
+    const prev = ds.autoExpandedPath;
+    if (prev && prev !== path && !ds.userExpanded.has(prev)) ds.expanded.delete(prev);
+    ds.expanded.add(path);
+    ds.autoExpandedPath = path;
+  }
 
   if (session.id !== state.activeSessionId) return;
   if (newlyExpanded) ds.pendingScrollPath = path;
@@ -215,6 +310,14 @@ const fetchSessionFileChanges = async (sessionId) => {
   }
 };
 
+// markDiffFetchError records a failed diff fetch so the body can offer a
+// retry instead of sitting on "Loading diff…" forever.
+const markDiffFetchError = (sessionId, path) => {
+  const ds = sessionDiffState(sessionId);
+  ds.fetchErrors.add(path);
+  if (sessionId === state.activeSessionId) scheduleDiffRender(sessionId);
+};
+
 const fetchFileDiff = (sessionId, path) => {
   const ds = sessionDiffState(sessionId);
   const existingRequest = ds.inflight.get(path);
@@ -225,9 +328,13 @@ const fetchFileDiff = (sessionId, path) => {
     try {
       const url = `${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/file-changes/diff?path=${encodeURIComponent(path)}`;
       const resp = await fetch(url, { headers: authHeaders() });
-      if (!resp.ok) return null;
+      if (!resp.ok) {
+        markDiffFetchError(sessionId, path);
+        return null;
+      }
       const data = await resp.json();
       ds.diffCache.set(path, { seq: seqAtRequest, data });
+      ds.fetchErrors.delete(path);
 
       // A newer change may have landed mid-fetch; leave it dirty and schedule
       // another refresh (the debounce timer that requested this fetch already
@@ -249,6 +356,7 @@ const fetchFileDiff = (sessionId, path) => {
       if (sessionId === state.activeSessionId) scheduleDiffRender(sessionId);
       return data;
     } catch {
+      markDiffFetchError(sessionId, path);
       return null;
     } finally {
       ds.inflight.delete(path);
@@ -349,12 +457,22 @@ const resolveHljsLanguage = (lang) => {
   return highlighter.getLanguage?.(name) ? name : '';
 };
 
-// renderDiffCode renders one code cell, syntax-highlighted per line when hljs
-// and the language are available. Per-line tokenizing is stateless, so
-// multi-line constructs (block comments, template literals) may mis-color
-// continuation lines — an accepted trade-off for live re-rendering.
-const renderDiffCode = (type, text, lang) => {
+// renderDiffCode renders one code cell. Rows with a word-level emphasis span
+// render as plain text with the changed range marked — the mark carries more
+// signal than syntax colors for an edited line, and mixing both cheaply is
+// not possible with per-line re-highlighting. Other rows are syntax-
+// highlighted per line when hljs and the language are available. Per-line
+// tokenizing is stateless, so multi-line constructs (block comments, template
+// literals) may mis-color continuation lines — an accepted trade-off for
+// live re-rendering.
+const renderDiffCode = (type, text, lang, emph) => {
   const el = createEl('span', 'diff-code');
+  if (Array.isArray(emph) && emph[1] > emph[0]) {
+    if (emph[0] > 0) el.appendChild(createEl('span', '', text.slice(0, emph[0])));
+    el.appendChild(createEl('span', 'diff-word', text.slice(emph[0], emph[1])));
+    if (emph[1] < text.length) el.appendChild(createEl('span', '', text.slice(emph[1])));
+    return el;
+  }
   const language = resolveHljsLanguage(lang);
   if (language && text) {
     try {
@@ -390,8 +508,10 @@ const renderDiffTotals = (ds) => {
   const summary = [];
   if (adds > 0) summary.push(`+${adds}`);
   if (dels > 0) summary.push(`−${dels}`);
-  if (elements.diffSidebarTotals) elements.diffSidebarTotals.textContent = summary.join(' ');
+  const summaryText = summary.join(' ');
+  if (elements.diffSidebarTotals) elements.diffSidebarTotals.textContent = summaryText;
   if (elements.diffToggleBadge) {
+    const badge = elements.diffToggleBadge;
     const parts = [];
     const fileCount = ds.files.size || 0;
     const fileCountEl = createEl('span', 'diff-toggle-file-count');
@@ -401,7 +521,14 @@ const renderDiffTotals = (ds) => {
     if (adds > 0) parts.push(createEl('span', 'diff-toggle-stat-add', `+${adds}`));
     if (dels > 0) parts.push(createEl('span', 'diff-toggle-stat-del', `−${dels}`));
     if (parts.length === 1 && fileCount === 0) parts.push(createEl('span', 'diff-toggle-stat-neutral', '0'));
-    elements.diffToggleBadge.replaceChildren(...parts);
+    badge.replaceChildren(...parts);
+    // Pulse on change so new activity is discoverable while the panel is
+    // closed, without stealing attention when nothing moved.
+    if (badge._lastSummary !== undefined && badge._lastSummary !== summaryText && summaryText) {
+      badge.classList?.add?.('pulse');
+      setTimeout(() => badge.classList?.remove?.('pulse'), DIFF_FEEDBACK_MS);
+    }
+    badge._lastSummary = summaryText;
   }
   if (elements.diffToggleBtn) {
     const fileCount = ds.files.size || 0;
@@ -411,10 +538,36 @@ const renderDiffTotals = (ds) => {
   }
 };
 
+// copyDiffText writes text to the clipboard and flashes the button as
+// feedback. Clipboard access is unavailable in some contexts (plain http);
+// the button then simply does nothing rather than throwing.
+const copyDiffText = (button, text) => {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) return;
+  navigator.clipboard.writeText(text).then(() => {
+    button.classList?.add?.('copied');
+    setTimeout(() => button.classList?.remove?.('copied'), DIFF_FEEDBACK_MS);
+  }).catch(() => {});
+};
+
 const renderDiffFileBody = (sessionId, ds, path) => {
   const body = createEl('div', 'diff-file-body');
   const cached = ds.diffCache.get(path);
   if (!cached) {
+    if (ds.fetchErrors.has(path)) {
+      const note = createEl('div', 'diff-note diff-error');
+      note.appendChild(createEl('span', '', 'Couldn’t load this diff.'));
+      const retry = createEl('button', 'diff-retry', 'Retry');
+      retry.setAttribute('type', 'button');
+      retry.addEventListener('click', (event) => {
+        event.stopPropagation?.();
+        ds.fetchErrors.delete(path);
+        void fetchFileDiff(sessionId, path);
+        renderDiffSidebar(sessionId);
+      });
+      note.appendChild(retry);
+      body.appendChild(note);
+      return body;
+    }
     body.appendChild(createEl('div', 'diff-note', 'Loading diff…'));
     void fetchFileDiff(sessionId, path);
     return body;
@@ -424,16 +577,18 @@ const renderDiffFileBody = (sessionId, ds, path) => {
     return body;
   }
 
-  const rows = buildDiffRowModel(cached.data.hunks);
-  const lang = rows.length <= DIFF_HIGHLIGHT_MAX_ROWS ? (cached.data.lang || '') : '';
-  if (lang) requestDiffHighlight();
+  const rows = computeInlineEmphasis(buildDiffRowModel(cached.data.hunks));
 
+  const limit = ds.rowLimits.get(path) || DIFF_RENDER_MAX_ROWS;
   let visibleRows = rows;
   let hiddenCount = 0;
-  if (rows.length > DIFF_RENDER_MAX_ROWS && !ds.fullDiffPaths.has(path)) {
-    visibleRows = rows.slice(0, DIFF_RENDER_MAX_ROWS);
+  if (rows.length > limit) {
+    visibleRows = rows.slice(0, limit);
     hiddenCount = rows.length - visibleRows.length;
   }
+
+  const lang = visibleRows.length <= DIFF_HIGHLIGHT_MAX_ROWS ? (cached.data.lang || '') : '';
+  if (lang) requestDiffHighlight();
 
   const table = createEl('div', 'diff-rows');
   visibleRows.forEach((row) => {
@@ -443,22 +598,175 @@ const renderDiffFileBody = (sessionId, ds, path) => {
     } else {
       rowEl.appendChild(createEl('span', 'diff-ln old', row.oldNo ? String(row.oldNo) : ''));
       rowEl.appendChild(createEl('span', 'diff-ln new', row.newNo ? String(row.newNo) : ''));
-      rowEl.appendChild(renderDiffCode(row.type, row.text, lang));
+      rowEl.appendChild(renderDiffCode(row.type, row.text, lang, row.emph));
     }
     table.appendChild(rowEl);
   });
   body.appendChild(table);
 
   if (hiddenCount > 0) {
-    const more = createEl('button', 'diff-show-more', `Show ${hiddenCount} more lines`);
+    // Reveal in chunks: rendering thousands of rows in one synchronous pass
+    // janks the panel. A second control jumps straight to everything.
+    const chunk = Math.min(DIFF_RENDER_MAX_ROWS, hiddenCount);
+    const more = createEl('button', 'diff-show-more', `Show ${chunk} more lines`);
     more.setAttribute('type', 'button');
     more.addEventListener('click', () => {
-      ds.fullDiffPaths.add(path);
+      ds.rowLimits.set(path, limit + DIFF_RENDER_MAX_ROWS);
       renderDiffSidebar(sessionId);
     });
     body.appendChild(more);
+    if (hiddenCount > DIFF_RENDER_MAX_ROWS) {
+      const all = createEl('button', 'diff-show-more diff-show-all', `Show all ${hiddenCount} hidden lines`);
+      all.setAttribute('type', 'button');
+      all.addEventListener('click', () => {
+        ds.rowLimits.set(path, Infinity);
+        renderDiffSidebar(sessionId);
+      });
+      body.appendChild(all);
+    }
   }
   return body;
+};
+
+// syncDiffFileBlock creates or patches the reusable DOM block for one file.
+// The header is built once and updated in place; the body is rebuilt only
+// when the underlying diff data, row limit, error state, or highlighter
+// availability changed (tracked via bodyKey).
+const syncDiffFileBlock = (sessionId, ds, path) => {
+  const entry = ds.files.get(path);
+  const expanded = ds.expanded.has(path);
+  let block = ds.blocks.get(path);
+
+  if (!block) {
+    const el = createEl('div', 'diff-file');
+    const header = createEl('div', 'diff-file-row');
+    header.setAttribute('role', 'button');
+    header.setAttribute('tabindex', '0');
+    header.title = path;
+    if (header.dataset) header.dataset.path = path;
+    header.addEventListener('click', () => toggleDiffFile(sessionId, path));
+    header.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault?.();
+        toggleDiffFile(sessionId, path);
+      }
+    });
+
+    const chevron = createEl('span', 'diff-chevron', '▸');
+    const kindBadge = createEl('span', 'diff-kind-badge');
+    const nameWrap = createEl('span', 'diff-file-name');
+    const base = createEl('span', 'diff-file-base', fileBaseName(path));
+    nameWrap.appendChild(base);
+    const dirName = fileDirName(path);
+    if (dirName) nameWrap.appendChild(createEl('span', 'diff-file-dir', dirName));
+    const counts = createEl('span', 'diff-file-counts');
+
+    const actions = createEl('span', 'diff-file-actions');
+    const copyPath = createEl('button', 'diff-action-btn', '⧉');
+    copyPath.setAttribute('type', 'button');
+    copyPath.title = 'Copy path';
+    copyPath.setAttribute('aria-label', `Copy path ${path}`);
+    copyPath.addEventListener('click', (event) => {
+      event.stopPropagation?.();
+      copyDiffText(copyPath, path);
+    });
+    const copyPatch = createEl('button', 'diff-action-btn', '±');
+    copyPatch.setAttribute('type', 'button');
+    copyPatch.title = 'Copy diff';
+    copyPatch.setAttribute('aria-label', `Copy diff for ${path}`);
+    copyPatch.addEventListener('click', (event) => {
+      event.stopPropagation?.();
+      const cached = ds.diffCache.get(path);
+      if (cached && !cached.data.truncated) {
+        copyDiffText(copyPatch, buildUnifiedDiff(path, cached.data));
+        return;
+      }
+      fetchFileDiff(sessionId, path).then((data) => {
+        if (data && !data.truncated) copyDiffText(copyPatch, buildUnifiedDiff(path, data));
+      });
+    });
+    actions.appendChild(copyPath);
+    actions.appendChild(copyPatch);
+
+    header.appendChild(chevron);
+    header.appendChild(kindBadge);
+    header.appendChild(nameWrap);
+    header.appendChild(counts);
+    header.appendChild(actions);
+    el.appendChild(header);
+
+    block = { el, header, kindBadge, counts, body: null, bodyKey: '', renderedKind: '', renderedAdds: null, renderedDels: null, renderedTruncated: null };
+    ds.blocks.set(path, block);
+  }
+
+  block.header.className = `diff-file-row${expanded ? ' expanded' : ''}`;
+  block.header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+
+  if (block.renderedKind !== entry.kind) {
+    block.kindBadge.className = `diff-kind-badge diff-kind-${entry.kind}`;
+    block.kindBadge.textContent = kindBadgeLabel[entry.kind] || 'M';
+    block.renderedKind = entry.kind;
+  }
+
+  const countsChanged = block.renderedAdds !== entry.adds
+    || block.renderedDels !== entry.dels
+    || block.renderedTruncated !== entry.truncated;
+  if (countsChanged) {
+    const parts = [];
+    if (entry.truncated) {
+      parts.push(createEl('span', 'diff-count-muted', '–'));
+    } else {
+      if (entry.adds > 0) parts.push(createEl('span', 'diff-count-add', `+${entry.adds}`));
+      if (entry.dels > 0) parts.push(createEl('span', 'diff-count-del', `−${entry.dels}`));
+    }
+    block.counts.replaceChildren(...parts);
+    // Pulse rows that changed after their first paint so live updates are
+    // visible without re-reading the numbers.
+    if (block.renderedAdds !== null) {
+      block.header.classList.add('updated');
+      setTimeout(() => block.header.classList?.remove?.('updated'), DIFF_FEEDBACK_MS);
+    }
+    block.renderedAdds = entry.adds;
+    block.renderedDels = entry.dels;
+    block.renderedTruncated = entry.truncated;
+  }
+
+  if (!expanded) {
+    if (block.body) {
+      block.body = null;
+      block.bodyKey = '';
+      block.el.replaceChildren(block.header);
+    }
+    return block;
+  }
+
+  const cached = ds.diffCache.get(path);
+  const bodyKey = [
+    cached ? cached.seq : 'none',
+    ds.rowLimits.get(path) || 0,
+    ds.fetchErrors.has(path) ? 1 : 0,
+    typeof window.hljs !== 'undefined' ? 1 : 0
+  ].join('|');
+  if (!block.body || block.bodyKey !== bodyKey) {
+    block.body = renderDiffFileBody(sessionId, ds, path);
+    block.bodyKey = bodyKey;
+    block.el.replaceChildren(block.header, block.body);
+  }
+  return block;
+};
+
+const diffFilterMatches = (ds, path) => {
+  const filter = String(ds.filter || '').toLowerCase();
+  return !filter || path.toLowerCase().includes(filter);
+};
+
+const updateDiffFilterVisibility = (ds) => {
+  const row = elements.diffFilterRow;
+  if (!row) return;
+  const show = ds.files.size >= DIFF_FILTER_MIN_FILES || Boolean(ds.filter);
+  row.hidden = !show;
+  if (show) row.removeAttribute?.('hidden');
+  else row.setAttribute?.('hidden', '');
 };
 
 const renderDiffAccordion = (sessionId, ds) => {
@@ -466,42 +774,25 @@ const renderDiffAccordion = (sessionId, ds) => {
   if (!list) return;
   const keepScroll = list.scrollTop;
 
-  const blocks = [];
-  const paths = Array.from(ds.files.keys()).sort();
-  paths.forEach((path) => {
-    const entry = ds.files.get(path);
-    const expanded = ds.expanded.has(path);
-    const block = createEl('div', 'diff-file');
-
-    const header = createEl('button', `diff-file-row${expanded ? ' expanded' : ''}`);
-    header.setAttribute('type', 'button');
-    header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    header.title = path;
-    if (header.dataset) header.dataset.path = path;
-    header.appendChild(createEl('span', 'diff-chevron', '▸'));
-    header.appendChild(createEl('span', `diff-kind-badge diff-kind-${entry.kind}`, kindBadgeLabel[entry.kind] || 'M'));
-    const nameWrap = createEl('span', 'diff-file-name');
-    nameWrap.appendChild(createEl('span', 'diff-file-base', fileBaseName(path)));
-    const dir = fileDirName(path);
-    if (dir) nameWrap.appendChild(createEl('span', 'diff-file-dir', dir));
-    header.appendChild(nameWrap);
-    const counts = createEl('span', 'diff-file-counts');
-    if (entry.truncated) {
-      counts.appendChild(createEl('span', 'diff-count-muted', '–'));
-    } else {
-      if (entry.adds > 0) counts.appendChild(createEl('span', 'diff-count-add', `+${entry.adds}`));
-      if (entry.dels > 0) counts.appendChild(createEl('span', 'diff-count-del', `−${entry.dels}`));
-    }
-    header.appendChild(counts);
-    header.addEventListener('click', () => toggleDiffFile(sessionId, path));
-    block.appendChild(header);
-
-    if (expanded) block.appendChild(renderDiffFileBody(sessionId, ds, path));
-    blocks.push(block);
+  ds.blocks.forEach((_, path) => {
+    if (!ds.files.has(path)) ds.blocks.delete(path);
   });
 
-  list.replaceChildren(...blocks);
+  const paths = sortDiffPaths(Array.from(ds.files.values())).filter((path) => diffFilterMatches(ds, path));
+  const desired = paths.map((path) => syncDiffFileBlock(sessionId, ds, path).el);
+
+  if (desired.length === 0 && ds.filter) {
+    list.replaceChildren(createEl('div', 'diff-note', 'No files match the filter.'));
+  } else {
+    // Only touch the list when membership or order actually changed; count
+    // updates and body swaps patch reused nodes above without any list-level
+    // DOM churn (preserving scroll position, text selection, and focus).
+    const current = list.children || [];
+    const unchanged = current.length === desired.length && desired.every((el, i) => current[i] === el);
+    if (!unchanged) list.replaceChildren(...desired);
+  }
   list.scrollTop = keepScroll;
+  updateDiffFilterVisibility(ds);
 };
 
 const scrollFileIntoView = (path) => {
@@ -549,13 +840,49 @@ const toggleDiffFile = (sessionId, path) => {
     ds.expanded.delete(path);
     // Remember the explicit collapse so live changes stop re-opening it.
     ds.userCollapsed.add(path);
+    ds.userExpanded.delete(path);
+    if (ds.autoExpandedPath === path) ds.autoExpandedPath = '';
   } else {
     ds.expanded.add(path);
     ds.userCollapsed.delete(path);
+    // Explicit expands survive live-follow auto-collapse.
+    ds.userExpanded.add(path);
     if (ds.dirtyPaths.has(path) || !ds.diffCache.has(path)) {
       void fetchFileDiff(sessionId, path);
     }
   }
+  renderDiffSidebar(sessionId);
+};
+
+const expandAllDiffFiles = () => {
+  const sessionId = state.activeSessionId;
+  if (!sessionId) return;
+  const ds = sessionDiffState(sessionId);
+  ds.userCollapsed.clear();
+  ds.files.forEach((_, path) => {
+    ds.expanded.add(path);
+    ds.userExpanded.add(path);
+  });
+  renderDiffSidebar(sessionId);
+};
+
+const collapseAllDiffFiles = () => {
+  const sessionId = state.activeSessionId;
+  if (!sessionId) return;
+  const ds = sessionDiffState(sessionId);
+  ds.expanded.clear();
+  ds.userExpanded.clear();
+  ds.autoExpandedPath = '';
+  // Live changes must not immediately re-open what the user just closed.
+  ds.files.forEach((_, path) => ds.userCollapsed.add(path));
+  renderDiffSidebar(sessionId);
+};
+
+const setDiffFilter = (value) => {
+  const sessionId = state.activeSessionId;
+  if (!sessionId) return;
+  const ds = sessionDiffState(sessionId);
+  ds.filter = String(value || '');
   renderDiffSidebar(sessionId);
 };
 
@@ -629,6 +956,7 @@ const activateDiffSidebar = (sessionId) => {
     return;
   }
   const ds = sessionDiffState(sessionId);
+  if (elements.diffFilterInput) elements.diffFilterInput.value = ds.filter || '';
   renderDiffSidebar(sessionId);
   applyDiffSidebarVisibility(ds);
   if (!ds.listLoaded) void fetchSessionFileChanges(sessionId);
@@ -679,6 +1007,15 @@ const restoreDiffSidebarWidth = () => {
   }
 };
 
+const resetDiffSidebarWidth = () => {
+  elements.appShell?.style?.removeProperty?.('--diff-sidebar-user-width');
+  try {
+    if (STORAGE_KEYS?.diffSidebarWidth) localStorage.removeItem(STORAGE_KEYS.diffSidebarWidth);
+  } catch {
+    // Storage unavailable; nothing stored to clear.
+  }
+};
+
 const initDiffResize = () => {
   const handle = elements.diffResizeHandle;
   if (!handle?.addEventListener) return;
@@ -711,6 +1048,7 @@ const initDiffResize = () => {
   };
   handle.addEventListener('pointerup', finishDrag);
   handle.addEventListener('pointercancel', finishDrag);
+  handle.addEventListener('dblclick', resetDiffSidebarWidth);
 };
 
 const isInsideDiffResizeHandle = (target) => {
@@ -733,6 +1071,49 @@ const initDiffCloseGesture = () => {
     shouldIgnoreTarget: isInsideDiffResizeHandle,
     onClose: closeDiffDrawer
   });
+};
+
+// ===== Keyboard =====
+
+const isEditableTarget = (target) => {
+  const tag = String(target?.tagName || '').toLowerCase();
+  return tag === 'input' || tag === 'textarea' || Boolean(target?.isContentEditable);
+};
+
+const handleDiffGlobalKeydown = (event) => {
+  if (event.key !== 'Escape') return;
+  const input = elements.diffFilterInput;
+  if (input && event.target === input) {
+    // First escape clears the filter, keeping the panel open.
+    const ds = currentDiffState();
+    if (ds?.filter) {
+      input.value = '';
+      setDiffFilter('');
+    }
+    input.blur?.();
+    return;
+  }
+  if (isEditableTarget(event.target)) return;
+  if (isDiffDrawerViewport() && elements.diffSidebar?.classList.contains('open')) {
+    closeDiffDrawer();
+  }
+};
+
+// Arrow keys walk the file headers so the accordion is usable without a
+// pointer; Enter/Space on a header toggles it (wired per header).
+const handleDiffListKeydown = (event) => {
+  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+  const list = elements.diffFileList;
+  if (!list?.querySelectorAll) return;
+  const rows = Array.from(list.querySelectorAll('.diff-file-row'));
+  if (rows.length === 0) return;
+  const active = typeof document !== 'undefined' ? document.activeElement : null;
+  const index = rows.indexOf(active);
+  const next = event.key === 'ArrowDown'
+    ? (index < 0 ? 0 : Math.min(rows.length - 1, index + 1))
+    : (index < 0 ? rows.length - 1 : Math.max(0, index - 1));
+  rows[next].focus?.();
+  event.preventDefault?.();
 };
 
 restoreDiffSidebarWidth();
@@ -783,16 +1164,26 @@ if (diffViewportMedia) {
   }
 }
 window.addEventListener?.('resize', handleDiffViewportChange);
+window.addEventListener?.('keydown', handleDiffGlobalKeydown);
 
+elements.diffFileList?.addEventListener?.('keydown', handleDiffListKeydown);
 elements.diffToggleBtn?.addEventListener?.('click', toggleDiffSidebar);
 elements.diffSidebarCloseBtn?.addEventListener?.('click', () => {
   if (isDiffDrawerViewport()) closeDiffDrawer();
   else setDiffSidebarHidden(true);
 });
+elements.diffExpandAllBtn?.addEventListener?.('click', expandAllDiffFiles);
+elements.diffCollapseAllBtn?.addEventListener?.('click', collapseAllDiffFiles);
+elements.diffFilterInput?.addEventListener?.('input', (event) => {
+  setDiffFilter(event.target?.value ?? elements.diffFilterInput.value ?? '');
+});
 
 Object.assign(app, {
   buildDiffRowModel,
   clampDiffWidth,
+  computeInlineEmphasis,
+  sortDiffPaths,
+  buildUnifiedDiff,
   handleFileChangeEvent,
   activateDiffSidebar,
   refreshFileChangesAfterRun,

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -48,7 +48,8 @@ const sessionDiffState = (sessionId) => {
       userExpanded: new Set(),   // paths the user explicitly expanded (blocks auto-collapse)
       autoExpandedPath: '',      // the file currently held open by live-follow
       rowLimits: new Map(),      // path -> rendered row cap raised by "show more"
-      diffCache: new Map(),      // path -> { seq, data }
+      diffCache: new Map(),      // path -> { seq, rev, data }
+      cacheRev: 0,               // bumped on every cache write; keys body rebuilds
       dirtyPaths: new Set(),     // cached diff is stale (newer change seen)
       fetchErrors: new Set(),    // paths whose last diff fetch failed (shows retry)
       inflight: new Map(),       // path -> Promise (request dedup)
@@ -131,17 +132,26 @@ const emphasizeRowPair = (del, add) => {
   const a = del.text;
   const b = add.text;
   if (a === b) return;
-  const maxP = Math.min(a.length, b.length);
+  // Compare code points, not UTF-16 units, so the mark never splits a
+  // surrogate pair (two different emoji share a high surrogate).
+  const aCP = Array.from(a);
+  const bCP = Array.from(b);
+  const maxP = Math.min(aCP.length, bCP.length);
   let p = 0;
-  while (p < maxP && a[p] === b[p]) p += 1;
+  while (p < maxP && aCP[p] === bCP[p]) p += 1;
   let s = 0;
-  while (s < maxP - p && a[a.length - 1 - s] === b[b.length - 1 - s]) s += 1;
+  while (s < maxP - p && aCP[aCP.length - 1 - s] === bCP[bCP.length - 1 - s]) s += 1;
   if (p + s === 0) return;
   // Skip when the lines barely relate: emphasis should mark a small edit,
   // not repaint an entire replaced line.
-  if (p + s < Math.max(a.length, b.length) * 0.2) return;
-  del.emph = [p, a.length - s];
-  add.emph = [p, b.length - s];
+  if (p + s < Math.max(aCP.length, bCP.length) * 0.2) return;
+  const unitLen = (cps, count) => (count > 0 ? cps.slice(0, count).join('').length : 0);
+  const prefixA = unitLen(aCP, p);
+  const prefixB = unitLen(bCP, p);
+  const suffixA = unitLen(aCP.slice(aCP.length - s), s);
+  const suffixB = unitLen(bCP.slice(bCP.length - s), s);
+  del.emph = [prefixA, a.length - suffixA];
+  add.emph = [prefixB, b.length - suffixB];
 };
 
 // computeInlineEmphasis pairs consecutive del/add runs index-wise (GitHub
@@ -266,6 +276,45 @@ const scheduleDiffRefresh = (sessionId) => {
 
 // ===== Fetching =====
 
+// reconcileDiffPathState prunes path-keyed state after the authoritative
+// server list replaced ds.files: live rows can carry non-canonical paths
+// (e.g. relative) that the replace renames, and without pruning their
+// expansion/cache/limit state both leaks and detaches live-follow.
+const reconcileDiffPathState = (ds) => {
+  const prune = (collection) => {
+    collection.forEach((_, key) => {
+      // Sets iterate as (value, value); Maps as (value, key) — key works for both.
+      if (!ds.files.has(key)) collection.delete(key);
+    });
+  };
+  const wasFollowing = Boolean(ds.autoExpandedPath);
+  prune(ds.expanded);
+  prune(ds.userCollapsed);
+  prune(ds.userExpanded);
+  prune(ds.rowLimits);
+  prune(ds.diffCache);
+  prune(ds.dirtyPaths);
+  prune(ds.fetchErrors);
+  prune(ds.blocks);
+  if (ds.pendingScrollPath && !ds.files.has(ds.pendingScrollPath)) ds.pendingScrollPath = '';
+  if (ds.autoExpandedPath && !ds.files.has(ds.autoExpandedPath)) {
+    // The followed path was canonicalized away; keep following the change
+    // stream by moving to the most recent entry the user hasn't collapsed.
+    ds.autoExpandedPath = '';
+    if (wasFollowing) {
+      let candidate = null;
+      ds.files.forEach((entry) => {
+        if (ds.userCollapsed.has(entry.path)) return;
+        if (!candidate || (entry.lastSeq || 0) > (candidate.lastSeq || 0)) candidate = entry;
+      });
+      if (candidate) {
+        ds.autoExpandedPath = candidate.path;
+        ds.expanded.add(candidate.path);
+      }
+    }
+  }
+};
+
 const fetchSessionFileChanges = async (sessionId) => {
   const ds = sessionDiffState(sessionId);
   // Snapshot per-path seqs so live rows whose change events land while this
@@ -304,6 +353,13 @@ const fetchSessionFileChanges = async (sessionId) => {
     });
     ds.files = next;
     ds.listLoaded = true;
+    reconcileDiffPathState(ds);
+    // Cached diffs predating the authoritative seq are stale even though no
+    // live event bumped them (the tab may have missed events while detached).
+    ds.files.forEach((entry, path) => {
+      const cached = ds.diffCache.get(path);
+      if (cached && (entry.lastSeq || 0) > (cached.seq || 0)) ds.dirtyPaths.add(path);
+    });
     if (sessionId === state.activeSessionId) renderDiffSidebar(sessionId);
   } catch {
     // Network failures leave existing state untouched.
@@ -333,7 +389,10 @@ const fetchFileDiff = (sessionId, path) => {
         return null;
       }
       const data = await resp.json();
-      ds.diffCache.set(path, { seq: seqAtRequest, data });
+      // rev, not seq, keys body rebuilds: a refetch can return newer server
+      // content under an unchanged local seq (events missed while detached).
+      ds.cacheRev += 1;
+      ds.diffCache.set(path, { seq: seqAtRequest, rev: ds.cacheRev, data });
       ds.fetchErrors.delete(path);
 
       // A newer change may have landed mid-fetch; leave it dirty and schedule
@@ -525,8 +584,7 @@ const renderDiffTotals = (ds) => {
     // Pulse on change so new activity is discoverable while the panel is
     // closed, without stealing attention when nothing moved.
     if (badge._lastSummary !== undefined && badge._lastSummary !== summaryText && summaryText) {
-      badge.classList?.add?.('pulse');
-      setTimeout(() => badge.classList?.remove?.('pulse'), DIFF_FEEDBACK_MS);
+      applyTransientClass(badge, 'pulse');
     }
     badge._lastSummary = summaryText;
   }
@@ -538,14 +596,27 @@ const renderDiffTotals = (ds) => {
   }
 };
 
+// applyTransientClass flashes a feedback class, clearing any pending removal
+// first so rapid re-triggers extend the feedback instead of cutting it short.
+const applyTransientClass = (el, className) => {
+  if (!el?.classList) return;
+  const timers = el._diffFeedbackTimers || (el._diffFeedbackTimers = {});
+  if (timers[className]) clearTimeout(timers[className]);
+  el.classList.add(className);
+  timers[className] = setTimeout(() => {
+    el.classList.remove(className);
+    delete timers[className];
+  }, DIFF_FEEDBACK_MS);
+};
+
 // copyDiffText writes text to the clipboard and flashes the button as
-// feedback. Clipboard access is unavailable in some contexts (plain http);
-// the button then simply does nothing rather than throwing.
+// feedback. Uses the app-wide writer, which falls back to execCommand in
+// contexts without the async clipboard API (e.g. plain http).
 const copyDiffText = (button, text) => {
-  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) return;
-  navigator.clipboard.writeText(text).then(() => {
-    button.classList?.add?.('copied');
-    setTimeout(() => button.classList?.remove?.('copied'), DIFF_FEEDBACK_MS);
+  const writer = app.getClipboardWriter?.();
+  if (!writer) return;
+  Promise.resolve(writer.writeText(text)).then(() => {
+    applyTransientClass(button, 'copied');
   }).catch(() => {});
 };
 
@@ -646,6 +717,9 @@ const syncDiffFileBlock = (sessionId, ds, path) => {
     if (header.dataset) header.dataset.path = path;
     header.addEventListener('click', () => toggleDiffFile(sessionId, path));
     header.addEventListener('keydown', (event) => {
+      // Keys pressed on the nested action buttons must activate those
+      // buttons, not toggle the accordion.
+      if (event.target && event.target !== header) return;
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault?.();
         toggleDiffFile(sessionId, path);
@@ -723,8 +797,7 @@ const syncDiffFileBlock = (sessionId, ds, path) => {
     // Pulse rows that changed after their first paint so live updates are
     // visible without re-reading the numbers.
     if (block.renderedAdds !== null) {
-      block.header.classList.add('updated');
-      setTimeout(() => block.header.classList?.remove?.('updated'), DIFF_FEEDBACK_MS);
+      applyTransientClass(block.header, 'updated');
     }
     block.renderedAdds = entry.adds;
     block.renderedDels = entry.dels;
@@ -742,7 +815,7 @@ const syncDiffFileBlock = (sessionId, ds, path) => {
 
   const cached = ds.diffCache.get(path);
   const bodyKey = [
-    cached ? cached.seq : 'none',
+    cached ? cached.rev : 'none',
     ds.rowLimits.get(path) || 0,
     ds.fetchErrors.has(path) ? 1 : 0,
     typeof window.hljs !== 'undefined' ? 1 : 0

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -340,6 +340,16 @@
       text-align: left;
       font-size: 0.82rem;
       color: var(--text);
+      user-select: none;
+    }
+
+    .diff-file-row.updated {
+      animation: diff-row-updated 0.6s ease;
+    }
+
+    @keyframes diff-row-updated {
+      0% { background: var(--surface-3); }
+      100% { background: var(--surface); }
     }
 
     .diff-file-row:hover {
@@ -536,6 +546,117 @@
       margin-left: 0;
       font-variant-numeric: tabular-nums;
       white-space: nowrap;
+    }
+
+    .diff-toggle-badge.pulse {
+      animation: diff-badge-pulse 0.6s ease;
+    }
+
+    @keyframes diff-badge-pulse {
+      0% { transform: scale(1); }
+      35% { transform: scale(1.18); }
+      100% { transform: scale(1); }
+    }
+
+    .diff-filter-row {
+      padding: 0.45rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+      flex: none;
+    }
+
+    .diff-filter-row[hidden] {
+      display: none;
+    }
+
+    .diff-filter-input {
+      width: 100%;
+      padding: 0.3rem 0.5rem;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--surface-2);
+      color: var(--text);
+      font-size: 0.8rem;
+    }
+
+    .diff-filter-input:focus {
+      outline: none;
+      border-color: var(--border-strong);
+    }
+
+    .diff-file-actions {
+      flex: none;
+      display: none;
+      gap: 0.2rem;
+    }
+
+    /* Actions swap in for the counts on hover/focus so the header row keeps
+       a stable width. focus-within keeps them reachable by keyboard/tap. */
+    .diff-file-row:hover .diff-file-actions,
+    .diff-file-row:focus-within .diff-file-actions {
+      display: inline-flex;
+    }
+
+    .diff-file-row:hover .diff-file-counts,
+    .diff-file-row:focus-within .diff-file-counts {
+      display: none;
+    }
+
+    .diff-action-btn {
+      border: 0;
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      padding: 0.1rem 0.3rem;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      line-height: 1;
+    }
+
+    .diff-action-btn:hover {
+      background: var(--surface-3);
+      color: var(--text);
+    }
+
+    .diff-action-btn.copied {
+      color: var(--accent-green);
+    }
+
+    .diff-row.add .diff-word {
+      background: var(--diff-add-ln-bg);
+      border-radius: 3px;
+    }
+
+    .diff-row.del .diff-word {
+      background: var(--diff-del-ln-bg);
+      border-radius: 3px;
+    }
+
+    .diff-error {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--danger);
+    }
+
+    .diff-retry {
+      border: 1px solid var(--border);
+      background: var(--surface-2);
+      color: var(--text);
+      border-radius: 6px;
+      padding: 0.15rem 0.6rem;
+      cursor: pointer;
+      font-size: 0.75rem;
+    }
+
+    .diff-retry:hover {
+      background: var(--surface-3);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .diff-file-row.updated,
+      .diff-toggle-badge.pulse {
+        animation: none;
+      }
     }
 
     .diff-toggle-file-count {

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -181,6 +181,11 @@ function createHarness(options = {}) {
     STORAGE_KEYS: { diffSidebarWidth: 'term_llm_diff_sidebar_width' },
     state,
     elements,
+    clipboardWrites: [],
+    getClipboardWriter() {
+      const writes = this.clipboardWrites;
+      return { writeText: (text) => { writes.push(String(text)); return Promise.resolve(); } };
+    },
     setElementHidden(element, hidden) {
       if (!element) return;
       element.hidden = Boolean(hidden);
@@ -927,6 +932,91 @@ async function run(name, fn) {
     const actions = elements.diffFileList.querySelector('.diff-file-actions');
     assert(actions, 'actions container rendered in the header');
     assertEqual(actions.querySelectorAll('.diff-action-btn').length, 2, 'copy path and copy diff buttons present');
+  });
+
+  await run('canonical server paths inherit live-follow expansion state', async () => {
+    const { app, elements } = createHarness({
+      fetch: async (url) => ({
+        ok: true,
+        json: async () => (String(url).includes('/diff?')
+          ? { path: '/w/hello.txt', kind: 'modify', lang: '', truncated: false, hunks: [] }
+          : { file_changes: [{ path: '/w/hello.txt', kind: 'modify', adds: 1, dels: 0, truncated: false, seq: 5 }] })
+      })
+    });
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: 'hello.txt', kind: 'modify', adds: 1, dels: 0, seq: 5 });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 1, 'live row auto-expanded');
+
+    await app.fetchSessionFileChanges('s1');
+    const rows = elements.diffFileList.querySelectorAll('.diff-file-row');
+    assertEqual(rows.length, 1, 'canonical row replaced the live duplicate');
+    assertEqual(rows[0].dataset.path, '/w/hello.txt', 'row carries the canonical path');
+    assert(rows[0].classList.contains('expanded'), 'canonical row inherits live-follow expansion');
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 1, 'body stays open across canonicalization');
+  });
+
+  await run('a refetch with unchanged seq still refreshes the rendered body', async () => {
+    let version = 1;
+    const { app, elements, flushTimers } = createHarness({
+      fetch: async (url) => ({
+        ok: true,
+        json: async () => (String(url).includes('/diff?')
+          ? { path: '/a', kind: 'modify', lang: '', truncated: false, hunks: [{ old_start: 1, new_start: 1, lines: [{ t: 'add', s: `content v${version}` }] }] }
+          : { file_changes: [{ path: '/a', kind: 'modify', adds: 1, dels: 0, truncated: false }] })
+      })
+    });
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+    await flushTimers();
+    assert(elementText(elements.diffFileList.querySelector('.diff-code')).includes('content v1'), 'initial body rendered');
+
+    // Newer server content under the same local seq (events missed while
+    // detached) must still replace the rendered rows.
+    version = 2;
+    app.refreshFileChangesAfterRun({ id: 's1' });
+    await flushTimers();
+    await flushTimers();
+    assert(elementText(elements.diffFileList.querySelector('.diff-code')).includes('content v2'), 'refetched body replaces stale rows');
+  });
+
+  await run('enter on nested action buttons does not toggle the header', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+
+    const header = elements.diffFileList.querySelector('.diff-file-row');
+    const action = header.querySelector('.diff-action-btn');
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 1, 'starts expanded');
+
+    await header.dispatchEvent({ type: 'keydown', key: 'Enter', target: action });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 1, 'enter on action button leaves the accordion alone');
+
+    await header.dispatchEvent({ type: 'keydown', key: 'Enter', target: header });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'enter on the header itself toggles');
+  });
+
+  await run('emphasis never splits surrogate pairs', () => {
+    const { app } = createHarness();
+    const rows = app.computeInlineEmphasis([
+      { type: 'del', text: '😀x' },
+      { type: 'add', text: '😃x' }
+    ]);
+    assertEqual(rows[0].emph.join(','), '0,2', 'del mark spans the whole emoji (both UTF-16 units)');
+    assertEqual(rows[1].emph.join(','), '0,2', 'add mark spans the whole emoji (both UTF-16 units)');
+  });
+
+  await run('copy path action writes through the app clipboard writer', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/w/a.go', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+
+    const action = elements.diffFileList.querySelector('.diff-action-btn');
+    await action.dispatchEvent({ type: 'click' });
+    await flushTimers();
+    assertEqual(app.clipboardWrites[0], '/w/a.go', 'copy path uses getClipboardWriter');
   });
 
   if (failures > 0) {

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -123,10 +123,15 @@ function createHarness(options = {}) {
     diffResizeHandle: new Element('div'),
     diffFileList: new Element('div'),
     diffToggleBtn: new Element('button'),
-    diffToggleBadge: new Element('span')
+    diffToggleBadge: new Element('span'),
+    diffExpandAllBtn: new Element('button'),
+    diffCollapseAllBtn: new Element('button'),
+    diffFilterRow: new Element('div'),
+    diffFilterInput: new Element('input')
   };
   elements.diffSidebar.hidden = true;
   elements.diffToggleBtn.hidden = true;
+  elements.diffFilterRow.hidden = true;
 
   const state = {
     token: '',
@@ -386,7 +391,7 @@ async function run(name, fn) {
     assertEqual(fetchCalls.filter((u) => u.includes('/diff?')).length, 2, 'refresh converges once up to date');
   });
 
-  await run('live changes auto-expand files inline (accordion) after explicit open', async () => {
+  await run('live changes follow the most recently edited file only', async () => {
     const { app, elements, flushTimers } = createHarness();
     app.toggleDiffSidebar();
     app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
@@ -395,8 +400,25 @@ async function run(name, fn) {
 
     const rows = elements.diffFileList.querySelectorAll('.diff-file-row');
     assertEqual(rows.length, 2, 'both files listed');
-    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 2, 'both changed files auto-expand');
-    assert(rows[0].classList.contains('expanded'), 'header carries expanded state');
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 1, 'only the file being edited stays expanded');
+    assertEqual(rows[0].dataset.path, '/b', 'most recent file sorts to the top');
+    assert(rows[0].classList.contains('expanded'), 'followed file header carries expanded state');
+    assert(!rows[1].classList.contains('expanded'), 'previously followed file auto-collapsed');
+  });
+
+  await run('user-expanded files survive live-follow auto-collapse', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+
+    // /a is auto-expanded; the user pins it open by toggling it closed and open.
+    app.toggleDiffFile('s1', '/a');
+    app.toggleDiffFile('s1', '/a');
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/b', kind: 'create', adds: 1, dels: 0, seq: 2 });
+    await flushTimers();
+
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 2, 'pinned file stays open while live-follow moves on');
   });
 
   await run('explicit collapse sticks while the agent keeps editing', async () => {
@@ -671,6 +693,240 @@ async function run(name, fn) {
     app.toggleDiffSidebar();
     assert(!elements.diffSidebar.hidden, 'explicit toggle opens restored session sidebar');
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'file list populated after user opens');
+  });
+
+  await run('sortDiffPaths orders by recency then path', () => {
+    const { app } = createHarness();
+    const order = app.sortDiffPaths([
+      { path: '/b', lastSeq: 1 },
+      { path: '/c', lastSeq: 3 },
+      { path: '/a', lastSeq: 1 },
+      { path: '/d', lastSeq: 2 }
+    ]);
+    assertEqual(order.join(','), '/c,/d,/a,/b', 'recent first, ties by path');
+  });
+
+  await run('computeInlineEmphasis marks the changed span of paired lines', () => {
+    const { app } = createHarness();
+    const rows = app.computeInlineEmphasis([
+      { type: 'ctx', text: 'unchanged' },
+      { type: 'del', text: 'const a = 1;' },
+      { type: 'del', text: 'foo' },
+      { type: 'add', text: 'const a = 2;' },
+      { type: 'add', text: 'totally different xyz' }
+    ]);
+    assertEqual(rows[1].emph.join(','), '10,11', 'del emphasis covers the changed literal');
+    assertEqual(rows[3].emph.join(','), '10,11', 'add emphasis covers the changed literal');
+    assert(!rows[2].emph, 'unrelated del line gets no emphasis');
+    assert(!rows[4].emph, 'unrelated add line gets no emphasis');
+    assert(!rows[0].emph, 'context lines get no emphasis');
+  });
+
+  await run('emphasized rows render a diff-word mark span', async () => {
+    const { app, elements, flushTimers } = createHarness({
+      fetch: async (url) => ({
+        ok: true,
+        json: async () => (String(url).includes('/diff?')
+          ? { path: '/a.go', kind: 'modify', lang: '', truncated: false, hunks: [{ old_start: 1, new_start: 1, lines: [
+              { t: 'del', s: 'count = 1' },
+              { t: 'add', s: 'count = 2' }
+            ] }] }
+          : { file_changes: [] })
+      })
+    });
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a.go', kind: 'modify', adds: 1, dels: 1, seq: 1 });
+    await flushTimers();
+    await flushTimers();
+
+    const marks = elements.diffFileList.querySelectorAll('.diff-word');
+    assertEqual(marks.length, 2, 'both paired rows carry a word mark');
+    assertEqual(marks[0].textContent, '1', 'del mark wraps the removed literal');
+    assertEqual(marks[1].textContent, '2', 'add mark wraps the inserted literal');
+  });
+
+  await run('failed diff fetches surface an error with retry', async () => {
+    let failFetches = true;
+    const { app, elements, flushTimers } = createHarness({
+      fetch: async (url) => {
+        if (String(url).includes('/diff?') && failFetches) return { ok: false, json: async () => ({}) };
+        return {
+          ok: true,
+          json: async () => (String(url).includes('/diff?')
+            ? { path: '/a', kind: 'modify', lang: '', truncated: false, hunks: [{ old_start: 1, new_start: 1, lines: [{ t: 'add', s: 'hello' }] }] }
+            : { file_changes: [] })
+        };
+      }
+    });
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+    await flushTimers();
+
+    const error = elements.diffFileList.querySelector('.diff-error');
+    assert(error, 'error note rendered after failed fetch');
+    const retry = elements.diffFileList.querySelector('.diff-retry');
+    assert(retry, 'retry control rendered');
+
+    failFetches = false;
+    await retry.dispatchEvent({ type: 'click' });
+    await flushTimers();
+    await flushTimers();
+
+    assert(!elements.diffFileList.querySelector('.diff-error'), 'error cleared after successful retry');
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-row').length, 1, 'diff rows render after retry');
+  });
+
+  await run('very large diffs reveal in chunks with a show-all escape hatch', async () => {
+    const manyLines = Array.from({ length: 900 }, (_, i) => ({ t: 'add', s: `line ${i}` }));
+    const { app, elements, flushTimers } = createHarness({
+      fetch: async (url) => ({
+        ok: true,
+        json: async () => (String(url).includes('/diff?')
+          ? { path: '/big.txt', kind: 'create', lang: '', truncated: false, hunks: [{ old_start: 1, new_start: 1, lines: manyLines }] }
+          : { file_changes: [] })
+      })
+    });
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/big.txt', kind: 'create', adds: 900, dels: 0, seq: 1 });
+    await flushTimers();
+    await flushTimers();
+
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-row').length, 400, 'first chunk capped at the render limit');
+    const more = elements.diffFileList.querySelector('.diff-show-more');
+    assertEqual(more.textContent, 'Show 400 more lines', 'chunk control offers the next chunk');
+    const all = elements.diffFileList.querySelector('.diff-show-all');
+    assertEqual(all.textContent, 'Show all 500 hidden lines', 'show-all control reports the full remainder');
+
+    await more.dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-row').length, 800, 'second chunk revealed');
+    assert(!elements.diffFileList.querySelector('.diff-show-all'), 'show-all gone once remainder fits one chunk');
+
+    await elements.diffFileList.querySelector('.diff-show-more').dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-row').length, 900, 'all rows rendered');
+    assert(!elements.diffFileList.querySelector('.diff-show-more'), 'controls gone once fully revealed');
+  });
+
+  await run('filter input appears for long lists and narrows rows', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    for (let i = 1; i <= 7; i += 1) {
+      app.handleFileChangeEvent({ id: 's1' }, { path: `/src/f${i}.txt`, kind: 'create', adds: 1, dels: 0, seq: i });
+    }
+    await flushTimers();
+    assert(elements.diffFilterRow.hidden, 'filter hidden below the file threshold');
+
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/src/g8.txt', kind: 'create', adds: 1, dels: 0, seq: 8 });
+    await flushTimers();
+    assert(!elements.diffFilterRow.hidden, 'filter appears once the list is long');
+
+    elements.diffFilterInput.value = 'g8';
+    await elements.diffFilterInput.dispatchEvent({ type: 'input', target: elements.diffFilterInput });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'filter narrows to matching paths');
+
+    elements.diffFilterInput.value = 'no-such-file';
+    await elements.diffFilterInput.dispatchEvent({ type: 'input', target: elements.diffFilterInput });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 0, 'no rows for a non-matching filter');
+    assert(elements.diffFileList.querySelector('.diff-note'), 'empty state note shown');
+
+    elements.diffFilterInput.value = '';
+    await elements.diffFilterInput.dispatchEvent({ type: 'input', target: elements.diffFilterInput });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 8, 'clearing the filter restores all rows');
+  });
+
+  await run('expand-all and collapse-all act on every file and stick', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    for (let i = 1; i <= 3; i += 1) {
+      app.handleFileChangeEvent({ id: 's1' }, { path: `/f${i}`, kind: 'modify', adds: 1, dels: 0, seq: i });
+    }
+    await flushTimers();
+
+    await elements.diffCollapseAllBtn.dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'collapse-all closes every body');
+
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/f1', kind: 'modify', adds: 2, dels: 0, seq: 4 });
+    await flushTimers();
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'live changes do not undo collapse-all');
+
+    await elements.diffExpandAllBtn.dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 3, 'expand-all opens every body');
+  });
+
+  await run('escape closes the diff drawer but leaves inputs alone', async () => {
+    const { app, elements, windowObj, flushTimers } = createHarness({ drawer: true });
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+    app.toggleDiffSidebar();
+    assert(elements.diffSidebar.classList.contains('open'), 'drawer starts open');
+
+    windowObj.dispatchEvent({ type: 'keydown', key: 'Escape', target: new Element('textarea') });
+    assert(elements.diffSidebar.classList.contains('open'), 'escape while typing does not close the drawer');
+
+    windowObj.dispatchEvent({ type: 'keydown', key: 'Escape', target: elements.diffSidebar });
+    assert(!elements.diffSidebar.classList.contains('open'), 'escape closes the drawer');
+  });
+
+  await run('double-clicking the resize handle resets the stored width', async () => {
+    const { app, elements, localStorage } = createHarness();
+    localStorage.setItem('term_llm_diff_sidebar_width', '555');
+    elements.appShell.style.setProperty('--diff-sidebar-user-width', '555px');
+
+    await elements.diffResizeHandle.dispatchEvent({ type: 'dblclick' });
+    assertEqual(localStorage.getItem('term_llm_diff_sidebar_width'), null, 'stored width cleared');
+    assertEqual(elements.appShell.style.getPropertyValue('--diff-sidebar-user-width'), '', 'width override removed');
+  });
+
+  await run('live count updates patch the existing header instead of rebuilding', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+
+    const before = elements.diffFileList.querySelectorAll('.diff-file-row')[0];
+    let listRebuilds = 0;
+    const original = elements.diffFileList.replaceChildren.bind(elements.diffFileList);
+    elements.diffFileList.replaceChildren = (...nodes) => {
+      listRebuilds += 1;
+      return original(...nodes);
+    };
+
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 7, dels: 2, seq: 2 });
+    await flushTimers();
+
+    const after = elements.diffFileList.querySelectorAll('.diff-file-row')[0];
+    assert(before === after, 'header node identity preserved across live updates');
+    assertEqual(listRebuilds, 0, 'list container not rebuilt for an in-place update');
+    assertEqual(elements.diffFileList.querySelector('.diff-count-add').textContent, '+7', 'counts updated in place');
+  });
+
+  await run('buildUnifiedDiff reconstructs a patch from cached hunks', () => {
+    const { app } = createHarness();
+    const patch = app.buildUnifiedDiff('src/main.go', {
+      hunks: [{ old_start: 3, new_start: 3, lines: [
+        { t: 'ctx', s: 'a' },
+        { t: 'del', s: 'old' },
+        { t: 'add', s: 'new' }
+      ] }]
+    });
+    const lines = patch.split('\n');
+    assertEqual(lines[0], '--- a/src/main.go', 'old file header');
+    assertEqual(lines[1], '+++ b/src/main.go', 'new file header');
+    assertEqual(lines[2], '@@ -3,2 +3,2 @@', 'hunk header with computed lengths');
+    assertEqual(lines[3], ' a', 'context line prefixed with space');
+    assertEqual(lines[4], '-old', 'deletion prefixed with minus');
+    assertEqual(lines[5], '+new', 'addition prefixed with plus');
+  });
+
+  await run('file headers expose copy actions', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/work/a.go', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+
+    const actions = elements.diffFileList.querySelector('.diff-file-actions');
+    assert(actions, 'actions container rendered in the header');
+    assertEqual(actions.querySelectorAll('.diff-action-btn').length, 2, 'copy path and copy diff buttons present');
   });
 
   if (failures > 0) {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -310,7 +310,12 @@
       <div class="diff-sidebar-header">
         <span class="diff-sidebar-title">Changes</span>
         <span class="diff-sidebar-totals" id="diffSidebarTotals"></span>
+        <button class="icon-btn" id="diffExpandAllBtn" type="button" aria-label="Expand all files" title="Expand all">⌄</button>
+        <button class="icon-btn" id="diffCollapseAllBtn" type="button" aria-label="Collapse all files" title="Collapse all">⌃</button>
         <button class="icon-btn" id="diffSidebarCloseBtn" type="button" aria-label="Hide changes" title="Hide changes">✕</button>
+      </div>
+      <div class="diff-filter-row" id="diffFilterRow" hidden>
+        <input class="diff-filter-input" id="diffFilterInput" type="search" placeholder="Filter files…" aria-label="Filter changed files" autocomplete="off" spellcheck="false">
       </div>
       <div class="diff-file-list" id="diffFileList" aria-label="Changed files"></div>
     </aside>


### PR DESCRIPTION
## What

Ten UX improvements to the web UI diff sidebar, plus two debug-provider fixes discovered while verifying them end to end.

**Diff panel (`app-diffs.js`, `app.css`, `index.html`, `app-core.js`):**

1. **Keyed incremental rendering** — file blocks are cached per path and patched in place; the list container is only touched when membership/order changes. No more full rebuild per event: text selection, focus, and scroll position survive live updates.
2. **Error state with retry** — a failed diff fetch used to leave "Loading diff…" forever; it now shows "Couldn't load this diff — Retry".
3. **Calmer live-follow** — only the file currently being edited stays auto-expanded (the previous one collapses unless the user pinned it open), with new expand-all/collapse-all header buttons and a subtle pulse on rows that update.
4. **Word-level diff emphasis** — adjacent del/add lines are paired and the changed span is marked, GitHub-style.
5. **Recency ordering** — most recently changed file sorts to the top instead of alphabetical.
6. **Chunked show-more** — huge diffs reveal 400 rows at a time (plus a "show all" escape hatch) instead of one synchronous render of thousands of rows; highlighting now gates on rendered rows, not total rows.
7. **Per-file copy actions** — hover a header for copy-path and copy-diff (reconstructs a unified patch from the cached hunks).
8. **Path filter** — appears automatically once the list reaches 8 files.
9. **Keyboard support** — Escape closes the drawer, arrow keys walk file headers, Enter/Space toggles, double-click on the resize handle resets the stored width.
10. **Badge pulse** — the toggle badge pulses when totals change so activity is discoverable while the panel is closed.

**Debug provider fixes (found via the e2e below):**
- Tool commands sent the stale `file_path` argument; the tools expect `path`, so every `write`/`edit`/`read` DSL command failed with INVALID_PARAMS.
- Any tool result in history short-circuited to canned completion text, so DSL commands only worked on a session's first turn. Now only a trailing tool round short-circuits.

## Testing

- `app_diffs_test.js`: 35 cases pass (12 new covering emphasis, retry, chunking, filter, expand/collapse-all, Escape, resize reset, node-identity reuse, unified-diff builder, ordering).
- Full `go test ./...` passes.
- **Clean-room Playwright e2e**: built the binary, ran `serve web --no-auth --provider debug --yolo` under a throwaway `$HOME`/workspace, drove real runs through the composer (debug DSL emits real tool calls -> real file-tracking events), and verified all ten behaviors in headless Chromium — 16 checks passed, including fault-injected fetch failures (route abort) and drawer mode across the viewport breakpoint. Environment fully torn down afterwards.
