### PR TITLE
fix: Telegram fast long replies can exceed the message limit on the final edit and leave the user with a spinner/truncated reply

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1711,6 +1711,39 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		return true
 	}
 
+	ensureCurrentMessage := func() bool {
+		if !needNewMsg {
+			return true
+		}
+		newMsg, sendErr := bot.Send(tgbotapi.NewMessage(chatID, "⏳"))
+		if sendErr != nil {
+			log.Printf("[telegram] failed to send continuation placeholder (chat %d): %v", chatID, sendErr)
+			return false
+		}
+		currentMsgID = newMsg.MessageID
+		lastSentContent = ""
+		lastEditTime = time.Time{}
+		lastVisibleChange = time.Now()
+		needNewMsg = false
+		return true
+	}
+
+	sendProseChunks := func(prose string, force bool) (string, bool) {
+		for utf8.RuneCountInString(prose) > telegramMaxMessageLen {
+			if !ensureCurrentMessage() {
+				return prose, false
+			}
+			chunk, splitAtBytes := prefixRunes(prose, telegramMaxMessageLen)
+			if !sendEdit(currentMsgID, chunk, force) {
+				return prose, false
+			}
+			msgStart += splitAtBytes
+			prose = prose[splitAtBytes:]
+			needNewMsg = true
+		}
+		return prose, true
+	}
+
 	salvagePartialHistory := func(persistCtx context.Context, fallbackOp string) {
 		textMu.Lock()
 		partial := textBuf.String()
@@ -1801,6 +1834,11 @@ loop:
 				continue
 			}
 
+			prose, ok := sendProseChunks(prose, false)
+			if !ok {
+				continue
+			}
+
 			rendered := buildSegment(prose, toolDisplay, phase, true)
 			if forceProgress {
 				elapsed := time.Since(streamStart)
@@ -1809,30 +1847,8 @@ loop:
 				rendered = buildHeartbeatSegment(prose, toolDisplay, phase, spin, elapsed)
 			}
 
-			if utf8.RuneCountInString(prose) > telegramMaxMessageLen {
-				// Keep chunk splitting based on prose, not status line rendering.
-				splitAtRunes := telegramMaxMessageLen
-				proseRunes := utf8.RuneCountInString(prose)
-				if splitAtRunes > proseRunes {
-					splitAtRunes = proseRunes
-				}
-				chunk, splitAtBytes := prefixRunes(prose, splitAtRunes)
-				sendEdit(currentMsgID, chunk, false)
-				msgStart += splitAtBytes
-				needNewMsg = true
+			if !ensureCurrentMessage() {
 				continue
-			}
-
-			if needNewMsg {
-				// Lazily create the next placeholder now that we have content for it.
-				newMsg, sendErr := bot.Send(tgbotapi.NewMessage(chatID, "⏳"))
-				if sendErr == nil {
-					currentMsgID = newMsg.MessageID
-					lastSentContent = ""
-					lastEditTime = time.Time{}
-					lastVisibleChange = time.Now()
-				}
-				needNewMsg = false
 			}
 			sendEdit(currentMsgID, rendered, forceProgress)
 		case <-streamCtx.Done():
@@ -1950,12 +1966,12 @@ loop:
 	switch {
 	case prose != "":
 		// There is new content to show in the current window.
-		// If a lazy placeholder was pending, create it first.
-		if needNewMsg {
-			newMsg, sendErr := bot.Send(tgbotapi.NewMessage(chatID, "⏳"))
-			if sendErr == nil {
-				currentMsgID = newMsg.MessageID
-			}
+		prose, ok := sendProseChunks(prose, true)
+		if !ok {
+			break
+		}
+		if !ensureCurrentMessage() {
+			break
 		}
 		sendEdit(currentMsgID, prose, true)
 	case full == "":

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -61,10 +61,13 @@ func (s *carryoverPagingStore) GetMessagesPageDescending(ctx context.Context, se
 
 // fakeBotSender is a botSender that records all Send calls for test assertions.
 type fakeBotSender struct {
-	mu      sync.Mutex
-	sent    []string // text of each Send call, in order
-	nextID  int      // auto-incrementing MessageID
-	sendErr error    // if non-nil, returned on the very first Send call
+	mu             sync.Mutex
+	sent           []string // text of each successful Send call, in order
+	edits          []string // text of each successful EditMessageText call, in order
+	overLimitEdits []string // rejected edit texts that exceeded maxEditRunes
+	nextID         int      // auto-incrementing MessageID
+	sendErr        error    // if non-nil, returned on the very first Send call
+	maxEditRunes   int      // if positive, reject EditMessageText calls over this many runes
 }
 
 func (f *fakeBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
@@ -83,6 +86,11 @@ func (f *fakeBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
 		text = v.Text
 	case tgbotapi.EditMessageTextConfig:
 		text = v.Text
+		if f.maxEditRunes > 0 && utf8.RuneCountInString(text) > f.maxEditRunes {
+			f.overLimitEdits = append(f.overLimitEdits, text)
+			return tgbotapi.Message{}, fmt.Errorf("telegram: message is too long")
+		}
+		f.edits = append(f.edits, text)
 	}
 	f.sent = append(f.sent, text)
 
@@ -105,6 +113,22 @@ func (f *fakeBotSender) allTexts() []string {
 	defer f.mu.Unlock()
 	out := make([]string, len(f.sent))
 	copy(out, f.sent)
+	return out
+}
+
+func (f *fakeBotSender) allEditTexts() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.edits))
+	copy(out, f.edits)
+	return out
+}
+
+func (f *fakeBotSender) overLimitEditTexts() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.overLimitEdits))
+	copy(out, f.overLimitEdits)
 	return out
 }
 
@@ -727,6 +751,37 @@ func TestStreamReply_UnicodeChunkBoundaryPreservesUTF8(t *testing.T) {
 	}
 	if !foundContent {
 		t.Fatalf("expected full unicode response in sent texts; got %d messages", len(texts))
+	}
+}
+
+func TestStreamReply_FinalEditChunksFastLongResponse(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	response := strings.Repeat("x", telegramMaxMessageLen*2+123)
+	h.Provider.AddTextResponse(response)
+
+	mgr, sess := newTestMgrAndSession(h)
+	mgr.tickerInterval = time.Hour
+	bot := &fakeBotSender{maxEditRunes: telegramMaxMessageLen}
+
+	if err := mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hi")); err != nil {
+		t.Fatalf("streamReply returned error: %v", err)
+	}
+
+	if rejected := bot.overLimitEditTexts(); len(rejected) != 0 {
+		t.Fatalf("attempted %d over-limit edits; first had %d runes", len(rejected), utf8.RuneCountInString(rejected[0]))
+	}
+
+	edits := bot.allEditTexts()
+	if len(edits) != 3 {
+		t.Fatalf("successful edit count = %d; want 3 chunks", len(edits))
+	}
+	for i, text := range edits {
+		if got := utf8.RuneCountInString(text); got > telegramMaxMessageLen {
+			t.Fatalf("edit %d has %d runes; want <= %d", i, got, telegramMaxMessageLen)
+		}
+	}
+	if got := strings.Join(edits, ""); got != response {
+		t.Fatalf("joined edit chunks length = %d; want %d", len(got), len(response))
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a shared Telegram prose chunking path used by both streaming ticker updates and the final stream-completion edit.
- The chunker edits only Telegram-sized prose windows, creates continuation placeholders between chunks, and leaves the remaining tail to be rendered in the current message.
- Extended the Telegram fake bot so tests can reject over-limit edits, then added coverage for a fast long response that completes before any ticker split can run.

## Why this is high-value

Sam's daily Telegram/Jarvis path can produce long answers faster than the 500ms ticker gets a chance to split them. Before this change the completion path sent the entire remaining prose in one final edit, and Telegram edit failures were swallowed, so users could be left with the spinner/placeholder or a truncated visible answer even though the engine finished successfully.

## Validation

- `go test ./internal/serve -run 'TestStreamReply_(FinalEditChunksFastLongResponse|ExactChunkBoundary|UnicodeChunkBoundaryPreservesUTF8)'`
- `go build ./...`
- `go test ./...`
- `git diff --check`
