### PR TITLE
fix: Telegram interrupts are blocked behind the streaming session mutex

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -53,6 +53,11 @@ type botFileGetter interface {
 	GetFileDirectURL(fileID string) (string, error)
 }
 
+type telegramBot interface {
+	botSender
+	botFileGetter
+}
+
 // downloadTelegramPhoto downloads the largest photo from a Telegram photo array.
 // It returns the media type, base64-encoded data, and a local temp file path.
 // The caller is responsible for removing the temp file when it is no longer needed.
@@ -1094,7 +1099,7 @@ func (m *telegramSessionMgr) persistedAssistantTextMatches(ctx context.Context, 
 	return false
 }
 
-func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.BotAPI, msg *tgbotapi.Message) {
+func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot telegramBot, msg *tgbotapi.Message) {
 	if msg.From == nil {
 		log.Printf("[telegram] ignoring message with no sender")
 		return
@@ -1200,22 +1205,9 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 		return
 	}
 
-	// Check idle timeout and replace the whole session if expired.
-	sess.mu.Lock()
-	expired := time.Since(sess.lastActivity) > m.idleTimeout
-	if !expired {
-		sess.lastActivity = time.Now()
-	}
-	sess.mu.Unlock()
-	if expired {
-		sess, _, err = m.resetSessionIfCurrent(ctx, chatID, sess)
-		if err != nil {
-			_, _ = bot.Send(tgbotapi.NewMessage(chatID, "Error resetting session: "+err.Error()))
-			return
-		}
-	}
-
-	// If a stream is active, decide whether to cancel, interject, or queue.
+	// If a stream is active, decide whether to cancel, interject, or queue before
+	// touching sess.mu. streamReply holds sess.mu for the life of the stream, but
+	// cancelMu remains available specifically so new messages can interrupt it.
 	sess.cancelMu.Lock()
 	doneCh := sess.replyDone
 	cancelFn := sess.streamCancel
@@ -1272,6 +1264,21 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 				return
 			}
 		case <-ctx.Done():
+			return
+		}
+	}
+
+	// Check idle timeout and replace the whole session if expired.
+	sess.mu.Lock()
+	expired := time.Since(sess.lastActivity) > m.idleTimeout
+	if !expired {
+		sess.lastActivity = time.Now()
+	}
+	sess.mu.Unlock()
+	if expired {
+		sess, _, err = m.resetSessionIfCurrent(ctx, chatID, sess)
+		if err != nil {
+			_, _ = bot.Send(tgbotapi.NewMessage(chatID, "Error resetting session: "+err.Error()))
 			return
 		}
 	}

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -108,6 +108,14 @@ func (f *fakeBotSender) allTexts() []string {
 	return out
 }
 
+func (f *fakeBotSender) GetFile(config tgbotapi.FileConfig) (tgbotapi.File, error) {
+	return tgbotapi.File{}, errors.New("fake bot does not support GetFile")
+}
+
+func (f *fakeBotSender) GetFileDirectURL(fileID string) (string, error) {
+	return "", errors.New("fake bot does not support GetFileDirectURL")
+}
+
 type blockingTextProvider struct {
 	text           string
 	firstChunkSent chan struct{}
@@ -169,6 +177,85 @@ func (s *blockingTextStream) Close() error {
 	})
 	return nil
 }
+
+type interruptSequenceProvider struct {
+	firstChunkSent        chan struct{}
+	firstContextCancelled chan struct{}
+	streamCount           atomic.Int32
+}
+
+func newInterruptSequenceProvider() *interruptSequenceProvider {
+	return &interruptSequenceProvider{
+		firstChunkSent:        make(chan struct{}),
+		firstContextCancelled: make(chan struct{}),
+	}
+}
+
+func (p *interruptSequenceProvider) Name() string { return "interrupt-sequence" }
+
+func (p *interruptSequenceProvider) Credential() string { return "mock" }
+
+func (p *interruptSequenceProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+
+func (p *interruptSequenceProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	if p.streamCount.Add(1) == 1 {
+		return &cancelAwareBlockingStream{
+			ctx:                   ctx,
+			text:                  "partial answer",
+			firstChunkSent:        p.firstChunkSent,
+			firstContextCancelled: p.firstContextCancelled,
+			closed:                make(chan struct{}),
+		}, nil
+	}
+	return &oneShotTextStream{text: "new answer"}, nil
+}
+
+type cancelAwareBlockingStream struct {
+	ctx                   context.Context
+	text                  string
+	firstChunkSent        chan struct{}
+	firstContextCancelled chan struct{}
+	closed                chan struct{}
+	closeOnce             sync.Once
+	firstOnce             sync.Once
+	cancelOnce            sync.Once
+	chunkSent             bool
+}
+
+func (s *cancelAwareBlockingStream) Recv() (llm.Event, error) {
+	if !s.chunkSent {
+		s.chunkSent = true
+		s.firstOnce.Do(func() { close(s.firstChunkSent) })
+		return llm.Event{Type: llm.EventTextDelta, Text: s.text}, nil
+	}
+	select {
+	case <-s.ctx.Done():
+		s.cancelOnce.Do(func() { close(s.firstContextCancelled) })
+		return llm.Event{}, s.ctx.Err()
+	case <-s.closed:
+		return llm.Event{}, io.EOF
+	}
+}
+
+func (s *cancelAwareBlockingStream) Close() error {
+	s.closeOnce.Do(func() { close(s.closed) })
+	return nil
+}
+
+type oneShotTextStream struct {
+	text string
+	sent bool
+}
+
+func (s *oneShotTextStream) Recv() (llm.Event, error) {
+	if s.sent {
+		return llm.Event{}, io.EOF
+	}
+	s.sent = true
+	return llm.Event{Type: llm.EventTextDelta, Text: s.text}, nil
+}
+
+func (s *oneShotTextStream) Close() error { return nil }
 
 type errorAfterTextProvider struct {
 	text           string
@@ -312,6 +399,85 @@ func TestHandleMessage_IgnoresMessagesWithNilFrom(t *testing.T) {
 	}()
 
 	mgr.handleMessage(context.Background(), nil, &tgbotapi.Message{Text: "hi"})
+}
+
+func TestHandleMessage_CancelInterruptReachesActiveStreamBeforeSessionMutex(t *testing.T) {
+	provider := newInterruptSequenceProvider()
+	mgr := &telegramSessionMgr{
+		sessions:         make(map[int64]*telegramSession),
+		allowedUserIDs:   map[int64]struct{}{7: {}},
+		idleTimeout:      time.Hour,
+		interruptTimeout: time.Second,
+		tickerInterval:   5 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       llm.NewEngine(provider, llm.NewToolRegistry()),
+					ProviderName: "mock",
+					ModelName:    "test",
+				}, nil
+			},
+		},
+	}
+	bot := &fakeBotSender{}
+
+	firstDone := make(chan struct{})
+	go func() {
+		mgr.handleMessage(context.Background(), bot, telegramTestMessage(42, 7, "write a long reply"))
+		close(firstDone)
+	}()
+
+	select {
+	case <-provider.firstChunkSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first stream never emitted initial chunk")
+	}
+
+	secondDone := make(chan struct{})
+	go func() {
+		mgr.handleMessage(context.Background(), bot, telegramTestMessage(42, 7, "stop and switch to this"))
+		close(secondDone)
+	}()
+
+	select {
+	case <-provider.firstContextCancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second handleMessage did not cancel the active stream while streamReply held sess.mu")
+	}
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first handleMessage did not finish after interrupt")
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second handleMessage did not continue to its replacement request after interrupt")
+	}
+
+	if provider.streamCount.Load() < 2 {
+		t.Fatalf("provider stream count = %d, want replacement request to run", provider.streamCount.Load())
+	}
+	var sawSwitching bool
+	for _, text := range bot.allTexts() {
+		if strings.Contains(text, "switching to your new request") {
+			sawSwitching = true
+			break
+		}
+	}
+	if !sawSwitching {
+		t.Fatalf("telegram sends = %#v, want switching interrupt notice", bot.allTexts())
+	}
+}
+
+func telegramTestMessage(chatID, userID int64, text string) *tgbotapi.Message {
+	return &tgbotapi.Message{
+		From: &tgbotapi.User{ID: userID, UserName: "sam"},
+		Chat: &tgbotapi.Chat{ID: chatID},
+		Text: text,
+	}
 }
 
 func TestTelegramSessionMgrAcquireMessageSlot_BlocksUntilReleased(t *testing.T) {


### PR DESCRIPTION
## What changed

- Check for an active Telegram stream before taking the session mutex used by `streamReply` for long-running stream serialization.
- Keep the interrupt path on `cancelMu`, so a second Telegram message can cancel or interject while the first response/tool run is still streaming.
- Let `handleMessage` accept the existing Telegram bot interface so the end-to-end interrupt path can be tested with a fake bot.
- Added a regression test that starts one blocking Telegram request, sends a second `handleMessage`, and asserts the first stream context is cancelled before the provider is otherwise released.

## Why this is high-value

Sam uses the Telegram/Jarvis path daily, and a follow-up message during a long answer or tool run should be able to stop or steer the work immediately. Previously the second handler blocked on `sess.mu` in the idle-timeout check, but `streamReply` holds that mutex for the entire stream, so the cancel/interject logic could not run until the original work was already done.

## Validation

- `go test ./internal/serve -run TestHandleMessage_CancelInterruptReachesActiveStreamBeforeSessionMutex -count=1 -v`
- `go build ./...`
- `go test ./...`
- `git diff --check`
