### PR TITLE
fix: Telegram Bot API client has no deadline, so startup and sends can hang forever

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -37,9 +37,86 @@ const telegramMaxConcurrentHandlers = 8
 const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
 const telegramDownloadTimeout = 5 * time.Minute
+const telegramBotAPIRequestTimeout = 30 * time.Second
+const telegramUpdateLongPollSeconds = 60
+const telegramBotAPILongPollTimeout = (telegramUpdateLongPollSeconds * time.Second) + 10*time.Second
 const telegramSessionShutdownFallbackTimeout = 5 * time.Second
 
 var telegramDownloadHTTPClient = &http.Client{Timeout: telegramDownloadTimeout}
+
+// telegramBotHTTPClient applies per-request deadlines to the Telegram Bot API
+// client. The upstream library builds requests without contexts, so wrapping Do
+// here is the only way to keep startup, sends, edits, and long polling bounded.
+type telegramBotHTTPClient struct {
+	client          *http.Client
+	requestTimeout  time.Duration
+	longPollTimeout time.Duration
+}
+
+func newTelegramBotHTTPClient(requestTimeout, longPollTimeout time.Duration) *telegramBotHTTPClient {
+	transport := http.DefaultTransport
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = defaultTransport.Clone()
+	}
+	return &telegramBotHTTPClient{
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   longPollTimeout,
+		},
+		requestTimeout:  requestTimeout,
+		longPollTimeout: longPollTimeout,
+	}
+}
+
+func newTelegramBotAPI(token string) (*tgbotapi.BotAPI, error) {
+	return tgbotapi.NewBotAPIWithClient(token, tgbotapi.APIEndpoint, newTelegramBotHTTPClient(telegramBotAPIRequestTimeout, telegramBotAPILongPollTimeout))
+}
+
+func (c *telegramBotHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	timeout := c.requestTimeout
+	if telegramBotAPIIsLongPoll(req) {
+		timeout = c.longPollTimeout
+	}
+	if timeout <= 0 {
+		return c.client.Do(req)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), timeout)
+	resp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		cancel()
+		return resp, err
+	}
+	if resp == nil || resp.Body == nil {
+		cancel()
+		return resp, nil
+	}
+	resp.Body = &telegramCancelOnCloseReadCloser{ReadCloser: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+func telegramBotAPIIsLongPoll(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	path := strings.TrimRight(req.URL.Path, "/")
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		path = path[i+1:]
+	}
+	return path == "getUpdates"
+}
+
+type telegramCancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *telegramCancelOnCloseReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.once.Do(r.cancel)
+	return err
+}
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
 // handleMessage, allowing tests to supply a fake without a live connection.
@@ -338,7 +415,7 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 		log.Println("[telegram] warning: no allowed_user_ids or allowed_usernames configured; all messages will be rejected")
 	}
 
-	bot, err := tgbotapi.NewBotAPI(token)
+	bot, err := newTelegramBotAPI(token)
 	if err != nil {
 		return fmt.Errorf("telegram connect: %w", err)
 	}
@@ -371,7 +448,7 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 	}
 
 	u := tgbotapi.NewUpdate(0)
-	u.Timeout = 60
+	u.Timeout = telegramUpdateLongPollSeconds
 	updates := bot.GetUpdatesChan(u)
 
 	for {

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -2467,6 +2467,122 @@ func TestDownloadTelegramPhoto_TooLarge(t *testing.T) {
 	}
 }
 
+func writeTelegramGetMeOK(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"ok":true,"result":{"id":123,"is_bot":true,"first_name":"Test","username":"test_bot"}}`)
+}
+
+func telegramTestAPIEndpoint(serverURL string) string {
+	return serverURL + "/bot%s/%s"
+}
+
+func TestTelegramBotAPIClientTimesOutStartup(t *testing.T) {
+	const requestTimeout = 50 * time.Millisecond
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(started) })
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	start := time.Now()
+	_, err := tgbotapi.NewBotAPIWithClient("test-token", telegramTestAPIEndpoint(ts.URL), newTelegramBotHTTPClient(requestTimeout, time.Second))
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected startup timeout error")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("startup timeout took too long: %s", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("expected getMe request to reach test server")
+	}
+}
+
+func TestTelegramBotAPIClientTimesOutSend(t *testing.T) {
+	const requestTimeout = 50 * time.Millisecond
+	sendStarted := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getMe"):
+			writeTelegramGetMeOK(w)
+		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
+			once.Do(func() { close(sendStarted) })
+			select {
+			case <-r.Context().Done():
+			case <-release:
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	bot, err := tgbotapi.NewBotAPIWithClient("test-token", telegramTestAPIEndpoint(ts.URL), newTelegramBotHTTPClient(requestTimeout, time.Second))
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+
+	start := time.Now()
+	_, err = bot.Send(tgbotapi.NewMessage(123, "hello"))
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected send timeout error")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("send timeout took too long: %s", elapsed)
+	}
+	select {
+	case <-sendStarted:
+	default:
+		t.Fatal("expected sendMessage request to reach test server")
+	}
+}
+
+func TestTelegramBotAPIClientAllowsLongPollPastRegularTimeout(t *testing.T) {
+	const requestTimeout = 30 * time.Millisecond
+	const longPollTimeout = 500 * time.Millisecond
+	const longPollDelay = 100 * time.Millisecond
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getMe"):
+			writeTelegramGetMeOK(w)
+		case strings.HasSuffix(r.URL.Path, "/getUpdates"):
+			time.Sleep(longPollDelay)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ok":true,"result":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	bot, err := tgbotapi.NewBotAPIWithClient("test-token", telegramTestAPIEndpoint(ts.URL), newTelegramBotHTTPClient(requestTimeout, longPollTimeout))
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+	u := tgbotapi.NewUpdate(0)
+	u.Timeout = telegramUpdateLongPollSeconds
+	updates, err := bot.GetUpdates(u)
+	if err != nil {
+		t.Fatalf("expected long poll to outlive regular timeout: %v", err)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("expected no updates, got %d", len(updates))
+	}
+}
+
 func TestDownloadTelegramPhoto_Timeout(t *testing.T) {
 	oldClient := telegramDownloadHTTPClient
 	telegramDownloadHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}


### PR DESCRIPTION
## What changed

- Construct the Telegram Bot API client with `NewBotAPIWithClient` instead of the library default unbounded `http.Client`.
- Added a small HTTP client wrapper that applies a 30s deadline to normal Bot API calls (`getMe`, sends, edits, `getFile`) and a 70s deadline to `getUpdates`, preserving the existing 60s long-poll window with slack.
- Added regression tests covering startup timeout, send timeout, and long-poll requests outliving the regular request timeout.

## Why this is high-value

Sam/Jarvis uses the Telegram surface routinely, and this client is on every `serve --telegram` startup, every long-poll request, and every reply/edit while streaming. Before this change, a stalled Telegram API/network call could block startup forever or wedge a per-chat stream while holding the session mutex, preventing later messages, `/reset`, and cleanup for that chat from making progress.

## Validation

- `go test ./internal/serve -run 'TestTelegramBotAPIClient' -count=1 -v`
- `go build ./...`
- `go test ./...`
- `git diff --check`
