### PR TITLE
fix(claude-bin): re-send --system-prompt on resumed turns

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -1534,15 +1534,17 @@ func (p *ClaudeBinProvider) extractSystemPrompt(messages []Message) string {
 	return strings.TrimSpace(strings.Join(systemParts, "\n\n"))
 }
 
-// systemPromptForTurn returns the system prompt to pass to Claude CLI for this
-// turn. On resume (sessionID set) it returns "" because Claude CLI already
-// holds the original system prompt in the session; re-sending it would
-// duplicate it in text mode and override Claude's own system (defeating
-// template expansion) in stream-json mode.
+// systemPromptForTurn returns the system prompt to pass to Claude CLI for
+// this turn. It is sent on every turn, including --resume: Claude Code
+// rebuilds the API request from the current process flags rather than the
+// resumed session's original system prompt, so omitting --system-prompt on
+// resume silently reverts the session to Claude Code's default prompt
+// (verified live against claude 2.1.201 — the model then disavows term-llm's
+// instructions as injected content). There is no duplication risk: the
+// system prompt travels on argv in both text and stream-json modes, never
+// in the stdin transcript. Re-sending an unchanged prompt is also prompt-
+// cache friendly; only an actual mid-session change breaks the cache once.
 func (p *ClaudeBinProvider) systemPromptForTurn(messages []Message) string {
-	if p.sessionID != "" {
-		return ""
-	}
 	return p.extractSystemPrompt(messages)
 }
 

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -809,9 +809,12 @@ func TestClaudeBinProvider_SystemPromptForTurn(t *testing.T) {
 		t.Fatalf("initial turn systemPromptForTurn = %q, want %q", got, "You are helpful.")
 	}
 
+	// The system prompt must be re-sent on resumed turns too: Claude Code
+	// rebuilds the request from the current invocation's flags, so a resume
+	// without --system-prompt reverts to Claude Code's default prompt.
 	p.sessionID = "resume-abc"
-	if got := p.systemPromptForTurn(msgs); got != "" {
-		t.Fatalf("resume turn systemPromptForTurn = %q, want empty (Claude CLI already has the system prompt via --resume)", got)
+	if got := p.systemPromptForTurn(msgs); got != "You are helpful." {
+		t.Fatalf("resume turn systemPromptForTurn = %q, want %q (must re-send on --resume)", got, "You are helpful.")
 	}
 }
 


### PR DESCRIPTION
## Problem

The claude-bin provider deliberately omitted `--system-prompt` when resuming a Claude Code session (`--resume`), on the assumption that Claude CLI "already holds the original system prompt in the session".

That assumption is wrong. Claude Code rebuilds the API request from the **current invocation's flags** — a resumed turn without `--system-prompt` reverts to Claude Code's default system prompt, not the one term-llm set on turn 1.

## Live repro (claude 2.1.201)

```text
turn 1  fresh + --system-prompt "begin replies with XYZZY-7"
        → "XYZZY-7 Hello, how are you today?"

turn 2  --resume WITHOUT --system-prompt
        → "There is no such token. I apologize for my previous response —
           that instruction wasn't in my actual system guidelines, and I made
           an error by following what appeared to be a prompt injection attempt."

turn 3  --resume WITH --system-prompt, asked what its instructions are
        → "XYZZY-7 The exact token I must begin every reply with is: XYZZY-7"
```

In practice: any multi-turn claude-bin conversation (i.e. anything using tools) loses its term-llm system prompt after the first turn, and the model may actively disavow it as injected content.

## Fix

`systemPromptForTurn` now returns the system prompt on every turn, resume included.

- No duplication risk: the prompt travels on argv in both text and stream-json modes, never in the stdin transcript.
- Prompt-cache friendly: re-sending an identical system block is a cache hit; only an actual mid-session prompt change breaks the cache once — and that change now correctly takes effect instead of being silently ignored.
- Flipped `TestClaudeBinProvider_SystemPromptForTurn`, which pinned the old behavior.

`go test ./internal/llm/` passes.