### PR TITLE
refactor(llm): unify SSE stream decoding across providers

### DIFF
--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -1,7 +1,6 @@
 package llm
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -341,39 +340,34 @@ func (p *CopilotProvider) streamChatCompletions(ctx context.Context, req Request
 			return newHTTPStatusError("Copilot", resp, respBody)
 		}
 
-		scanner := bufio.NewScanner(resp.Body)
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		// TODO: Confirm GitHub Copilot's chat/completions stream always
+		// terminates with [DONE], then switch RequireDone to true. The previous
+		// parser accepted EOF without [DONE], so keep this lenient for now.
+		decoder := newSSEDecoder(resp.Body, sseDecoderOptions{RequireDone: false, Transport: "Copilot SSE"})
 
 		toolState := newCompatToolState()
 		var lastUsage *Usage
-		var lastEventType string
 		sawVisibleText := false
 		unmarshalErrors := 0
 
-		for scanner.Scan() {
-			line := scanner.Text()
-			if strings.HasPrefix(line, "event: ") {
-				lastEventType = strings.TrimPrefix(line, "event: ")
-				continue
-			}
-			if !strings.HasPrefix(line, "data: ") {
-				continue
-			}
-			data := strings.TrimPrefix(line, "data: ")
-			if data == "[DONE]" {
+		for {
+			eventType, data, err := decoder.Next()
+			if err == io.EOF {
 				break
+			}
+			if err != nil {
+				return fmt.Errorf("Copilot streaming error: %w", err)
 			}
 
 			if debugRaw {
-				DebugRawSection(debugRaw, "Copilot SSE Line", data)
+				DebugRawSection(debugRaw, "Copilot SSE Event", string(data))
 			}
 
 			var chatResp oaiChatResponse
-			if err := json.Unmarshal([]byte(data), &chatResp); err != nil {
+			if err := json.Unmarshal(data, &chatResp); err != nil {
 				unmarshalErrors++
 				if debugRaw {
-					DebugRawSection(debugRaw, "Copilot SSE Parse Error", fmt.Sprintf("error: %v, data: %s", err, data))
+					DebugRawSection(debugRaw, "Copilot SSE Parse Error", fmt.Sprintf("error: %v, data: %s", err, string(data)))
 				}
 				// Allow some parse errors (keepalives, partial data) but fail if too many
 				if unmarshalErrors > 10 {
@@ -382,7 +376,7 @@ func (p *CopilotProvider) streamChatCompletions(ctx context.Context, req Request
 				continue
 			}
 
-			if lastEventType == "error" || chatResp.Error != nil {
+			if eventType == "error" || chatResp.Error != nil {
 				errMsg := "unknown error"
 				if chatResp.Error != nil {
 					errMsg = chatResp.Error.Message
@@ -428,12 +422,6 @@ func (p *CopilotProvider) streamChatCompletions(ctx context.Context, req Request
 					}
 				}
 			}
-
-			lastEventType = ""
-		}
-
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("Copilot streaming error: %w", err)
 		}
 
 		if err := toolState.Validate(); err != nil {

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -1,11 +1,9 @@
 package llm
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -432,136 +430,6 @@ func (p *OpenAICompatProvider) ListModels(ctx context.Context) ([]ModelInfo, err
 	return models, nil
 }
 
-func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
-	lineBytes, eof, err := readSSELineBytes(reader)
-	if err != nil {
-		return "", false, err
-	}
-	return string(lineBytes), eof, nil
-}
-
-func readSSELineBytes(reader *bufio.Reader) (line []byte, eof bool, err error) {
-	var owned []byte
-	for {
-		chunk, readErr := reader.ReadSlice('\n')
-		if len(chunk) > 0 {
-			if owned != nil {
-				owned = append(owned, chunk...)
-			} else if errors.Is(readErr, bufio.ErrBufferFull) {
-				owned = append(owned, chunk...)
-			} else {
-				line = chunk
-			}
-		}
-
-		switch {
-		case readErr == nil:
-			if owned != nil {
-				line = owned
-			}
-			return bytes.TrimRight(line, "\r\n"), false, nil
-		case errors.Is(readErr, bufio.ErrBufferFull):
-			continue
-		case errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF):
-			if owned != nil {
-				line = owned
-			} else if len(chunk) > 0 {
-				line = chunk
-			}
-			return bytes.TrimRight(line, "\r\n"), true, nil
-		default:
-			return nil, false, readErr
-		}
-	}
-}
-
-var (
-	sseEventField = []byte("event")
-	sseDataField  = []byte("data")
-	sseDoneData   = []byte("[DONE]")
-)
-
-func readSSEEvent(reader *bufio.Reader) (eventType, data string, eof bool, err error) {
-	var dataBuilder strings.Builder
-	dataLines := 0
-
-	appendData := func(value []byte) {
-		if dataLines == 0 {
-			data = string(value)
-			dataLines = 1
-			return
-		}
-		if dataLines == 1 {
-			dataBuilder.WriteString(data)
-			data = ""
-		}
-		dataBuilder.WriteByte('\n')
-		dataBuilder.Write(value)
-		dataLines++
-	}
-
-	for {
-		line, lineEOF, err := readSSELineBytes(reader)
-		if err != nil {
-			return "", "", false, err
-		}
-		if len(line) == 0 {
-			if dataLines > 1 {
-				data = dataBuilder.String()
-			}
-			return eventType, data, lineEOF, nil
-		}
-		if i := bytes.IndexByte(line, ':'); i >= 0 {
-			field, value := line[:i], line[i+1:]
-			if len(value) > 0 && value[0] == ' ' {
-				value = value[1:]
-			}
-			switch {
-			case bytes.Equal(field, sseEventField):
-				eventType = string(value)
-			case bytes.Equal(field, sseDataField):
-				appendData(value)
-			}
-		}
-		if lineEOF {
-			if dataLines > 1 {
-				data = dataBuilder.String()
-			}
-			return eventType, data, true, nil
-		}
-	}
-}
-
-func readSSEEventBytes(reader *bufio.Reader) (eventType string, data []byte, eof bool, err error) {
-	for {
-		line, lineEOF, err := readSSELineBytes(reader)
-		if err != nil {
-			return "", nil, false, err
-		}
-		if len(line) == 0 {
-			return eventType, data, lineEOF, nil
-		}
-		if i := bytes.IndexByte(line, ':'); i >= 0 {
-			field, value := line[:i], line[i+1:]
-			if len(value) > 0 && value[0] == ' ' {
-				value = value[1:]
-			}
-			switch {
-			case bytes.Equal(field, sseEventField):
-				eventType = string(value)
-			case bytes.Equal(field, sseDataField):
-				if len(data) > 0 {
-					data = append(data, '\n')
-				}
-				data = append(data, value...)
-			}
-		}
-		if lineEOF {
-			return eventType, data, true, nil
-		}
-	}
-}
-
 type openAICompatResolvedModel struct {
 	Model            string
 	Effort           string
@@ -782,32 +650,21 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
-		reader := bufio.NewReader(resp.Body)
+		decoder := newSSEDecoder(resp.Body, sseDecoderOptions{RequireDone: false, Transport: p.name + " SSE"})
 
 		toolState := newCompatToolState()
 		var lastUsage *Usage
 		var reasoningBuilder strings.Builder
 		sawVisibleText := false
-		sawDone := false
 		sawToolCallsFinish := false
 
 		for {
-			eventType, data, eof, err := readSSEEventBytes(reader)
+			eventType, data, err := decoder.Next()
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
 				return fmt.Errorf("%s streaming error: %w", p.name, err)
-			}
-			if eof && eventType == "" && len(data) == 0 {
-				break
-			}
-			if len(bytes.TrimSpace(data)) == 0 {
-				if eof {
-					break
-				}
-				continue
-			}
-			if bytes.Equal(data, sseDoneData) {
-				sawDone = true
-				break
 			}
 
 			var chatResp oaiChatResponse
@@ -877,12 +734,9 @@ func (p *OpenAICompatProvider) Stream(ctx context.Context, req Request) (Stream,
 					}
 				}
 			}
-
-			if eof {
-				break
-			}
 		}
 
+		sawDone := decoder.DoneSeen()
 		if !sawDone && !sawToolCallsFinish {
 			return &StreamIncompleteError{Transport: p.name + " SSE", Terminal: "[DONE]"}
 		}

--- a/internal/llm/sse.go
+++ b/internal/llm/sse.go
@@ -1,0 +1,233 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+)
+
+type sseDecoderOptions struct {
+	RequireDone bool
+	Transport   string
+	Terminal    string
+}
+
+type sseDecoder struct {
+	reader      *bufio.Reader
+	requireDone bool
+	transport   string
+	terminal    string
+	sawDone     bool
+	closed      bool
+	pendingErr  error
+}
+
+func newSSEDecoder(r io.Reader, opts sseDecoderOptions) *sseDecoder {
+	reader, ok := r.(*bufio.Reader)
+	if !ok {
+		reader = bufio.NewReader(r)
+	}
+	transport := opts.Transport
+	if transport == "" {
+		transport = "SSE"
+	}
+	terminal := opts.Terminal
+	if terminal == "" {
+		terminal = string(sseDoneData)
+	}
+	return &sseDecoder{
+		reader:      reader,
+		requireDone: opts.RequireDone,
+		transport:   transport,
+		terminal:    terminal,
+	}
+}
+
+func (d *sseDecoder) DoneSeen() bool {
+	return d != nil && d.sawDone
+}
+
+func (d *sseDecoder) Next() (eventType string, data []byte, err error) {
+	if d.pendingErr != nil {
+		err := d.pendingErr
+		d.pendingErr = nil
+		return "", nil, err
+	}
+	if d.closed {
+		return "", nil, io.EOF
+	}
+
+	for {
+		eventType, data, eof, err := readSSEEventBytes(d.reader)
+		if err != nil {
+			return "", nil, err
+		}
+		if eof && eventType == "" && len(data) == 0 {
+			d.closed = true
+			if d.requireDone && !d.sawDone {
+				return "", nil, d.missingDoneError()
+			}
+			return "", nil, io.EOF
+		}
+		if bytes.Equal(data, sseDoneData) {
+			d.sawDone = true
+			d.closed = true
+			return "", nil, io.EOF
+		}
+		if len(bytes.TrimSpace(data)) == 0 {
+			if eof {
+				d.closed = true
+				if d.requireDone && !d.sawDone {
+					return "", nil, d.missingDoneError()
+				}
+				return "", nil, io.EOF
+			}
+			continue
+		}
+		if eof {
+			d.closed = true
+			if d.requireDone && !d.sawDone {
+				d.pendingErr = d.missingDoneError()
+			} else {
+				d.pendingErr = io.EOF
+			}
+		}
+		return eventType, data, nil
+	}
+}
+
+func (d *sseDecoder) missingDoneError() error {
+	return &StreamIncompleteError{Transport: d.transport, Terminal: d.terminal}
+}
+
+func readSSELine(reader *bufio.Reader) (line string, eof bool, err error) {
+	lineBytes, eof, err := readSSELineBytes(reader)
+	if err != nil {
+		return "", false, err
+	}
+	return string(lineBytes), eof, nil
+}
+
+func readSSELineBytes(reader *bufio.Reader) (line []byte, eof bool, err error) {
+	var owned []byte
+	for {
+		chunk, readErr := reader.ReadSlice('\n')
+		if len(chunk) > 0 {
+			if owned != nil {
+				owned = append(owned, chunk...)
+			} else if errors.Is(readErr, bufio.ErrBufferFull) {
+				owned = append(owned, chunk...)
+			} else {
+				line = chunk
+			}
+		}
+
+		switch {
+		case readErr == nil:
+			if owned != nil {
+				line = owned
+			}
+			return bytes.TrimRight(line, "\r\n"), false, nil
+		case errors.Is(readErr, bufio.ErrBufferFull):
+			continue
+		case errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF):
+			if owned != nil {
+				line = owned
+			} else if len(chunk) > 0 {
+				line = chunk
+			}
+			return bytes.TrimRight(line, "\r\n"), true, nil
+		default:
+			return nil, false, readErr
+		}
+	}
+}
+
+var (
+	sseEventField = []byte("event")
+	sseDataField  = []byte("data")
+	sseDoneData   = []byte("[DONE]")
+)
+
+func readSSEEvent(reader *bufio.Reader) (eventType, data string, eof bool, err error) {
+	var dataBuilder strings.Builder
+	dataLines := 0
+
+	appendData := func(value []byte) {
+		if dataLines == 0 {
+			data = string(value)
+			dataLines = 1
+			return
+		}
+		if dataLines == 1 {
+			dataBuilder.WriteString(data)
+			data = ""
+		}
+		dataBuilder.WriteByte('\n')
+		dataBuilder.Write(value)
+		dataLines++
+	}
+
+	for {
+		line, lineEOF, err := readSSELineBytes(reader)
+		if err != nil {
+			return "", "", false, err
+		}
+		if len(line) == 0 {
+			if dataLines > 1 {
+				data = dataBuilder.String()
+			}
+			return eventType, data, lineEOF, nil
+		}
+		if i := bytes.IndexByte(line, ':'); i >= 0 {
+			field, value := line[:i], line[i+1:]
+			if len(value) > 0 && value[0] == ' ' {
+				value = value[1:]
+			}
+			switch {
+			case bytes.Equal(field, sseEventField):
+				eventType = string(value)
+			case bytes.Equal(field, sseDataField):
+				appendData(value)
+			}
+		}
+		if lineEOF {
+			if dataLines > 1 {
+				data = dataBuilder.String()
+			}
+			return eventType, data, true, nil
+		}
+	}
+}
+
+func readSSEEventBytes(reader *bufio.Reader) (eventType string, data []byte, eof bool, err error) {
+	for {
+		line, lineEOF, err := readSSELineBytes(reader)
+		if err != nil {
+			return "", nil, false, err
+		}
+		if len(line) == 0 {
+			return eventType, data, lineEOF, nil
+		}
+		if i := bytes.IndexByte(line, ':'); i >= 0 {
+			field, value := line[:i], line[i+1:]
+			if len(value) > 0 && value[0] == ' ' {
+				value = value[1:]
+			}
+			switch {
+			case bytes.Equal(field, sseEventField):
+				eventType = string(value)
+			case bytes.Equal(field, sseDataField):
+				if len(data) > 0 {
+					data = append(data, '\n')
+				}
+				data = append(data, value...)
+			}
+		}
+		if lineEOF {
+			return eventType, data, true, nil
+		}
+	}
+}

--- a/internal/llm/sse_test.go
+++ b/internal/llm/sse_test.go
@@ -1,0 +1,155 @@
+package llm
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type testSSEEvent struct {
+	eventType string
+	data      string
+}
+
+func TestSSEDecoderNext(t *testing.T) {
+	longData := strings.Repeat("x", 1024*1024+128)
+
+	tests := []struct {
+		name           string
+		input          string
+		requireDone    bool
+		wantEvents     []testSSEEvent
+		wantDone       bool
+		wantIncomplete bool
+	}{
+		{
+			name:        "well-formed multi-event stream",
+			requireDone: true,
+			input: "event: message\n" +
+				"data: {\"delta\":\"hello\"}\n\n" +
+				"event: usage\n" +
+				"data: {\"tokens\":3}\n\n" +
+				"data: [DONE]\n\n",
+			wantEvents: []testSSEEvent{
+				{eventType: "message", data: `{"delta":"hello"}`},
+				{eventType: "usage", data: `{"tokens":3}`},
+			},
+			wantDone: true,
+		},
+		{
+			name:           "missing done required",
+			requireDone:    true,
+			input:          "data: {\"delta\":\"hello\"}\n\n",
+			wantEvents:     []testSSEEvent{{data: `{"delta":"hello"}`}},
+			wantIncomplete: true,
+		},
+		{
+			name:        "missing done lenient",
+			requireDone: false,
+			input:       "data: {\"delta\":\"hello\"}\n\n",
+			wantEvents:  []testSSEEvent{{data: `{"delta":"hello"}`}},
+		},
+		{
+			name:        "malformed json passes through raw",
+			requireDone: true,
+			input: "event: chunk\n" +
+				"data: {not-json\n\n" +
+				"data: [DONE]\n\n",
+			wantEvents: []testSSEEvent{{eventType: "chunk", data: `{not-json`}},
+			wantDone:   true,
+		},
+		{
+			name:        "very long line has no scanner limit",
+			requireDone: true,
+			input:       "data: " + longData + "\n\ndata: [DONE]\n\n",
+			wantEvents:  []testSSEEvent{{data: longData}},
+			wantDone:    true,
+		},
+		{
+			name:        "crlf line endings",
+			requireDone: true,
+			input:       "event: message\r\ndata: hello\r\n\r\ndata: [DONE]\r\n\r\n",
+			wantEvents:  []testSSEEvent{{eventType: "message", data: "hello"}},
+			wantDone:    true,
+		},
+		{
+			name:        "comment keepalive lines are ignored",
+			requireDone: true,
+			input:       ": ping\n\n: another ping\n\ndata: ok\n\ndata: [DONE]\n\n",
+			wantEvents:  []testSSEEvent{{data: "ok"}},
+			wantDone:    true,
+		},
+		{
+			name:        "multi-line data fields are joined",
+			requireDone: true,
+			input:       "event: chunk\ndata: hello\ndata: world\n\ndata: [DONE]\n\n",
+			wantEvents:  []testSSEEvent{{eventType: "chunk", data: "hello\nworld"}},
+			wantDone:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoder := newSSEDecoder(strings.NewReader(tt.input), sseDecoderOptions{
+				RequireDone: tt.requireDone,
+				Transport:   "test SSE",
+			})
+
+			var got []testSSEEvent
+			var gotErr error
+			for {
+				eventType, data, err := decoder.Next()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					gotErr = err
+					break
+				}
+				got = append(got, testSSEEvent{eventType: eventType, data: string(data)})
+			}
+
+			assertSSEEvents(t, got, tt.wantEvents)
+			if decoder.DoneSeen() != tt.wantDone {
+				t.Fatalf("DoneSeen() = %v, want %v", decoder.DoneSeen(), tt.wantDone)
+			}
+
+			if tt.wantIncomplete {
+				var incomplete *StreamIncompleteError
+				if !errors.As(gotErr, &incomplete) {
+					t.Fatalf("error = %T %v, want StreamIncompleteError", gotErr, gotErr)
+				}
+				if !strings.Contains(gotErr.Error(), "[DONE]") {
+					t.Fatalf("incomplete error = %v, want mention [DONE]", gotErr)
+				}
+				return
+			}
+			if gotErr != nil {
+				t.Fatalf("unexpected error: %v", gotErr)
+			}
+		})
+	}
+}
+
+func assertSSEEvents(t *testing.T, got, want []testSSEEvent) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("event count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].eventType != want[i].eventType {
+			t.Fatalf("event %d type = %q, want %q", i, got[i].eventType, want[i].eventType)
+		}
+		if got[i].data != want[i].data {
+			t.Fatalf("event %d data len = %d, want %d; prefix = %q", i, len(got[i].data), len(want[i].data), prefixForTest(got[i].data, 80))
+		}
+	}
+}
+
+func prefixForTest(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/llm/xai.go
+++ b/internal/llm/xai.go
@@ -1,7 +1,6 @@
 package llm
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -120,49 +119,33 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
-		reader := bufio.NewReader(resp.Body)
+		decoder := newSSEDecoder(resp.Body, sseDecoderOptions{RequireDone: false, Transport: "xAI SSE"})
 
 		toolState := newCompatToolState()
 		tagStripper := newXAITagStripper()
 		var lastUsage *Usage
-		var lastEventType string
 		sawVisibleText := false
+		skippedJSONChunks := 0
 
 		for {
-			line, eof, err := readSSELine(reader)
+			eventType, data, err := decoder.Next()
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
 				return fmt.Errorf("xAI streaming error: %w", err)
 			}
-			if eof && line == "" {
-				break
-			}
-			if strings.HasPrefix(line, "event: ") {
-				lastEventType = strings.TrimPrefix(line, "event: ")
-				if eof {
-					break
-				}
-				continue
-			}
-			if !strings.HasPrefix(line, "data: ") {
-				if eof {
-					break
-				}
-				continue
-			}
-			data := strings.TrimPrefix(line, "data: ")
-			if data == "[DONE]" {
-				break
-			}
 
 			var chatResp oaiChatResponse
-			if err := json.Unmarshal([]byte(data), &chatResp); err != nil {
-				if eof {
-					break
+			if err := json.Unmarshal(data, &chatResp); err != nil {
+				skippedJSONChunks++
+				if req.DebugRaw {
+					DebugRawSection(req.DebugRaw, "xAI SSE Skipped JSON Chunk", fmt.Sprintf("skipped_chunks: %d\nerror: %v\ndata:\n%s", skippedJSONChunks, err, string(data)))
 				}
 				continue
 			}
 
-			if lastEventType == "error" || chatResp.Error != nil {
+			if eventType == "error" || chatResp.Error != nil {
 				errMsg := "unknown error"
 				if chatResp.Error != nil {
 					errMsg = chatResp.Error.Message
@@ -237,11 +220,10 @@ func (p *XAIProvider) streamStandard(ctx context.Context, req Request) (Stream, 
 					}
 				}
 			}
+		}
 
-			lastEventType = ""
-			if eof {
-				break
-			}
+		if skippedJSONChunks > 0 && req.DebugRaw {
+			DebugRawSection(req.DebugRaw, "xAI SSE Skipped JSON Summary", fmt.Sprintf("skipped_chunks: %d", skippedJSONChunks))
 		}
 
 		// Flush any remaining buffered content
@@ -306,34 +288,26 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 	return newEventStreamWithCancelHook(ctx, func() { _ = resp.Body.Close() }, func(ctx context.Context, send eventSender) error {
 		defer resp.Body.Close()
 
-		reader := bufio.NewReader(resp.Body)
+		decoder := newSSEDecoder(resp.Body, sseDecoderOptions{RequireDone: false, Transport: "xAI Responses SSE"})
 
 		var lastUsage *Usage
 		var searchStarted bool
+		skippedJSONChunks := 0
 
 		for {
-			line, eof, err := readSSELine(reader)
+			_, data, err := decoder.Next()
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
 				return fmt.Errorf("xAI Responses streaming error: %w", err)
 			}
-			if eof && line == "" {
-				break
-			}
-			if !strings.HasPrefix(line, "data: ") {
-				if eof {
-					break
-				}
-				continue
-			}
-			data := strings.TrimPrefix(line, "data: ")
-			if data == "[DONE]" {
-				break
-			}
 
 			var event xaiResponsesEvent
-			if err := json.Unmarshal([]byte(data), &event); err != nil {
-				if eof {
-					break
+			if err := json.Unmarshal(data, &event); err != nil {
+				skippedJSONChunks++
+				if req.DebugRaw {
+					DebugRawSection(req.DebugRaw, "xAI Responses SSE Skipped JSON Chunk", fmt.Sprintf("skipped_chunks: %d\nerror: %v\ndata:\n%s", skippedJSONChunks, err, string(data)))
 				}
 				continue
 			}
@@ -376,9 +350,10 @@ func (p *XAIProvider) streamWithSearch(ctx context.Context, req Request) (Stream
 			case "error":
 				return fmt.Errorf("xAI Responses API error: %s", event.Error)
 			}
-			if eof {
-				break
-			}
+		}
+
+		if skippedJSONChunks > 0 && req.DebugRaw {
+			DebugRawSection(req.DebugRaw, "xAI Responses SSE Skipped JSON Summary", fmt.Sprintf("skipped_chunks: %d", skippedJSONChunks))
 		}
 
 		if lastUsage != nil {


### PR DESCRIPTION
## What

Extracts SSE stream framing into a shared `sseDecoder` (`internal/llm/sse.go`) and converts OpenAI-compat, Copilot, and xAI (standard + Responses search path) to use it. Provider-specific chunk→Event mapping (text/tool/usage deltas) is deliberately untouched — this is transport-layer only, to keep the diff reviewable.

Behavior changes:
- **Copilot**: drops the 1 MiB `bufio.Scanner` line limit (long tool-call chunks no longer at risk of truncation). Stays lenient on missing `[DONE]` — couldn't confirm Copilot always sends it, so `RequireDone` is off with a TODO rather than risking a regression.
- **xAI**: keeps lenient bad-JSON handling but now counts/logs skipped chunks via DebugRaw instead of pure silence.
- **OpenAI-compat**: identical semantics to before (invalid-JSON fatal, `[DONE]` enforced) — it's the reference implementation.

## Why

Three hand-rolled SSE parsers had divergent semantics: one enforced stream completeness, one silently accepted truncated streams, one had a hidden line-size limit. Fixes to framing bugs had to be made three times.

## Tests

Table-driven decoder tests: multi-event streams, missing `[DONE]` strict/lenient, malformed JSON pass-through, >1 MiB lines, CRLF, keep-alive comments, multi-line data fields.

## Validation

Full `go test ./...` passes, including all existing provider tests.

Part of a robustness review series. Generated by developer agents, independently validated by Jarvis.
