### PR TITLE
fix: Serve session manager shutdown can hang forever after the bounded HTTP shutdown returns

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -493,7 +493,11 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 		return runtimeFactory(ctx, "", "")
 	}
 	sessionMgr := newServeSessionManager(serveSessionTTL, serveSessionMax, factory)
-	defer sessionMgr.Close()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		sessionMgr.CloseContext(shutdownCtx)
+	}()
 
 	if hasJobs && strings.TrimSpace(serveAgent) != "" {
 		fmt.Fprintln(cmd.ErrOrStderr(), "warning: --agent is ignored for --platform jobs; set llm runner_config.agent_name per job definition")

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -218,6 +218,10 @@ func (rt *serveRuntime) configureContextManagementForRequest(req llm.Request) {
 }
 
 func (rt *serveRuntime) Close() {
+	rt.CloseContext(context.Background())
+}
+
+func (rt *serveRuntime) CloseContext(ctx context.Context) {
 	rt.interruptMu.Lock()
 	state := rt.activeInterrupt
 	rt.interruptMu.Unlock()
@@ -225,8 +229,43 @@ func (rt *serveRuntime) Close() {
 		state.cancel()
 	}
 
-	rt.mu.Lock()
+	if !rt.lockForClose(ctx) {
+		return
+	}
 	defer rt.mu.Unlock()
+	rt.closeLocked()
+}
+
+// lockForClose waits for the runtime mutex, but lets CloseContext abandon the
+// wait when a provider/tool run keeps holding rt.mu after cancellation.
+func (rt *serveRuntime) lockForClose(ctx context.Context) bool {
+	if ctx == nil {
+		rt.mu.Lock()
+		return true
+	}
+	if rt.mu.TryLock() {
+		return true
+	}
+	done := ctx.Done()
+	if done == nil {
+		rt.mu.Lock()
+		return true
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return false
+		case <-ticker.C:
+			if rt.mu.TryLock() {
+				return true
+			}
+		}
+	}
+}
+
+func (rt *serveRuntime) closeLocked() {
 	rt.clearPendingAskUsers()
 	rt.clearPendingApprovals()
 	if rt.mcpManager != nil {

--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -546,6 +546,10 @@ func (m *serveSessionManager) ActiveSessionIDs() map[string]bool {
 }
 
 func (m *serveSessionManager) Close() {
+	m.CloseContext(context.Background())
+}
+
+func (m *serveSessionManager) CloseContext(ctx context.Context) {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
@@ -560,10 +564,13 @@ func (m *serveSessionManager) Close() {
 	m.sessions = map[string]*serveRuntime{}
 	m.mu.Unlock()
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	for _, rt := range sessions {
 		if m.onEvict != nil {
 			m.onEvict(rt)
 		}
-		rt.Close()
+		rt.CloseContext(ctx)
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1902,6 +1902,59 @@ func TestServeSessionManager_EvictExpiredSkipsActiveRun(t *testing.T) {
 	}
 }
 
+func TestServeSessionManager_CloseContextDoesNotBlockOnStuckRuntime(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	t.Cleanup(manager.Close)
+
+	runCtx, runCancel := context.WithCancel(context.Background())
+	rt := &serveRuntime{}
+	state := &runtimeInterruptState{cancel: runCancel, done: make(chan struct{})}
+	rt.setActiveInterrupt(state)
+	rt.mu.Lock()
+	t.Cleanup(func() {
+		rt.mu.Unlock()
+		rt.clearActiveInterrupt(state)
+		runCancel()
+	})
+	putTestSession(manager, "busy", rt)
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	started := time.Now()
+	go func() {
+		manager.CloseContext(closeCtx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+			t.Fatalf("CloseContext took %s with an expired close context", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseContext blocked on a runtime that never released its mutex")
+	}
+
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("CloseContext did not cancel the active runtime before waiting")
+	}
+
+	manager.mu.Lock()
+	closed := manager.closed
+	sessionCount := len(manager.sessions)
+	manager.mu.Unlock()
+	if !closed {
+		t.Fatal("expected manager to be marked closed")
+	}
+	if sessionCount != 0 {
+		t.Fatalf("sessions after CloseContext = %d, want 0", sessionCount)
+	}
+}
+
 func TestServeSessionManager_GetOrCreateSkipsEvictingActiveRunAtCapacity(t *testing.T) {
 	manager := newServeSessionManager(time.Minute, 2, func(ctx context.Context) (*serveRuntime, error) {
 		rt := &serveRuntime{}


### PR DESCRIPTION
## What changed

- Added context-aware close paths for `serveSessionManager` and `serveRuntime`.
- `serveRuntime.CloseContext` cancels the active run first, then waits for the runtime mutex only until the supplied context is done.
- Changed `runServeLegacy` session-manager cleanup to use a bounded shutdown context instead of the previous unbounded deferred `Close`.
- Added a regression test that holds `rt.mu` to simulate a stuck provider/tool stream and verifies `CloseContext` still returns while cancelling the active interrupt.

## Why this is high-value

`term-llm serve` is a daily web/API/jobs path. Before this change, server shutdown used a 10s bounded `serveServer.Stop`, but the deferred `sessionMgr.Close()` that ran afterwards could block forever on a stateful runtime whose provider/tool ignored cancellation while holding `rt.mu`. That could wedge restarts/reloads until the process was killed. This keeps normal cleanup behavior for cooperative runtimes while bounding the shutdown wait for stuck ones.

## Validation

- `gofmt -w cmd/serve.go cmd/serve_session.go cmd/serve_runtime.go cmd/serve_test.go`
- `go build ./...`
- `go test ./cmd -count=1`
- `go test ./... -skip TestProgramRunnerDoesNotLeakBackgroundChildren`
- `git diff --check`

Note: `go test ./...` was run and consistently fails in `internal/jobs` at the existing `TestProgramRunnerDoesNotLeakBackgroundChildren` (`background child process ... still appears to be alive`). The same isolated test fails independently of this serve-session change; the suite passes when only that unrelated jobs test is skipped.
