### PR TITLE
fix: Telegram runner cleanup can hang forever after the stream watchdog fires

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -34,6 +34,10 @@ const minEditInterval = 3 * time.Second
 // defaultStreamEventTimeout is used when telegramSessionMgr.streamEventTimeout is zero.
 const defaultStreamEventTimeout = 10 * time.Minute
 
+// defaultRunnerCleanupTimeout bounds how long streamReply waits for the shared
+// runner to observe cancellation before releasing the Telegram session lock.
+const defaultRunnerCleanupTimeout = 5 * time.Second
+
 const telegramMaxConcurrentHandlers = 8
 const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
@@ -447,9 +451,10 @@ type telegramSession struct {
 	meta                  *session.Session
 	lastActivity          time.Time
 
-	cancelMu      sync.Mutex         // protects streamCancel, replyDone, streamEngine and task/tool tracking
+	cancelMu      sync.Mutex         // protects streamCancel, replyDone, streamEngine, streamToken and task/tool tracking
 	streamCancel  context.CancelFunc // cancels the active stream's context
 	streamEngine  *llm.Engine        // active runner engine for mid-stream interjections
+	streamToken   chan struct{}      // identifies callbacks owned by the active stream
 	replyDone     chan struct{}      // closed when streamReply exits
 	currentTask   string             // text from the user message that started the active stream
 	toolsRanNames []string           // tool names executed during the active stream
@@ -476,6 +481,10 @@ type telegramSessionMgr struct {
 	// streamEventTimeout bounds how long the stream watchdog waits between events
 	// before declaring the stream dead. 0 means use defaultStreamEventTimeout.
 	streamEventTimeout time.Duration
+
+	// runnerCleanupTimeout bounds how long streamReply waits for settings.Runner
+	// to return after cancellation. 0 means use defaultRunnerCleanupTimeout.
+	runnerCleanupTimeout time.Duration
 }
 
 func (m *telegramSessionMgr) newFastProvider() llm.Provider {
@@ -1354,19 +1363,25 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	defer streamCancel()
 
 	replyDone := make(chan struct{})
+	streamToken := make(chan struct{})
 	sess.cancelMu.Lock()
 	sess.streamCancel = streamCancel
 	sess.replyDone = replyDone
+	sess.streamToken = streamToken
 	sess.cancelMu.Unlock()
 	defer func() {
 		sess.cancelMu.Lock()
-		sess.streamCancel = nil
-		sess.replyDone = nil
-		sess.currentTask = ""
-		sess.toolsRanNames = nil
-		sess.streamProseLen.Store(0)
-		sess.streamToolCnt.Store(0)
-		sess.streamToolName.Store("")
+		if sess.streamToken == streamToken {
+			sess.streamCancel = nil
+			sess.replyDone = nil
+			sess.streamEngine = nil
+			sess.streamToken = nil
+			sess.currentTask = ""
+			sess.toolsRanNames = nil
+			sess.streamProseLen.Store(0)
+			sess.streamToolCnt.Store(0)
+			sess.streamToolName.Store("")
+		}
 		sess.cancelMu.Unlock()
 		close(replyDone)
 	}()
@@ -1531,10 +1546,26 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		select {
 		case <-runnerDone:
 			return
-		case <-time.After(5 * time.Second):
-			log.Printf("[telegram] runner for chat %d still shutting down after cleanup timeout; waiting to avoid overlapping the shared engine", chatID)
+		default:
 		}
-		<-runnerDone
+
+		// Ensure early return paths (for example, Telegram send failures after the
+		// runner starts) still ask the runner to stop before we wait for cleanup.
+		streamCancel()
+
+		cleanupTimeout := m.runnerCleanupTimeout
+		if cleanupTimeout <= 0 {
+			cleanupTimeout = defaultRunnerCleanupTimeout
+		}
+		timer := time.NewTimer(cleanupTimeout)
+		defer timer.Stop()
+		select {
+		case <-runnerDone:
+			return
+		case <-timer.C:
+			log.Printf("[telegram] runner for chat %d still shutting down after %s; releasing session lock and allowing cleanup to finish in background", chatID, cleanupTimeout)
+			return
+		}
 	}
 	defer waitForRunnerDone()
 	if m.settings.Runner != nil {
@@ -1567,12 +1598,14 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 				OnTurnCompleted:           turnCompletedCB,
 				OnEngineReady: func(engine *llm.Engine) {
 					sess.cancelMu.Lock()
-					sess.streamEngine = engine
+					if sess.streamToken == streamToken {
+						sess.streamEngine = engine
+					}
 					sess.cancelMu.Unlock()
 				},
 				OnEngineDone: func(engine *llm.Engine) {
 					sess.cancelMu.Lock()
-					if sess.streamEngine == engine {
+					if sess.streamToken == streamToken && sess.streamEngine == engine {
 						sess.streamEngine = nil
 					}
 					sess.cancelMu.Unlock()

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -20,6 +20,7 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/testutil"
 )
@@ -226,6 +227,44 @@ func (s *errorAfterTextStream) Recv() (llm.Event, error) {
 }
 
 func (s *errorAfterTextStream) Close() error { return nil }
+
+type cancelIgnoringRunner struct {
+	started   chan struct{}
+	cancelled chan struct{}
+	release   chan struct{}
+	finished  chan struct{}
+
+	startOnce  sync.Once
+	cancelOnce sync.Once
+	finishOnce sync.Once
+}
+
+func newCancelIgnoringRunner() *cancelIgnoringRunner {
+	return &cancelIgnoringRunner{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+		release:   make(chan struct{}),
+		finished:  make(chan struct{}),
+	}
+}
+
+func (r *cancelIgnoringRunner) Run(ctx context.Context, req runpkg.Request, sink runpkg.EventSink) (runpkg.Result, error) {
+	r.startOnce.Do(func() { close(r.started) })
+	if req.OnEngineReady != nil {
+		req.OnEngineReady(req.Engine)
+	}
+	defer func() {
+		if req.OnEngineDone != nil {
+			req.OnEngineDone(req.Engine)
+		}
+		r.finishOnce.Do(func() { close(r.finished) })
+	}()
+
+	<-ctx.Done()
+	r.cancelOnce.Do(func() { close(r.cancelled) })
+	<-r.release
+	return runpkg.Result{}, ctx.Err()
+}
 
 // newTestMgrAndSession builds a minimal manager and session backed by h's engine.
 func newTestMgrAndSession(h *testutil.EngineHarness) (*telegramSessionMgr, *telegramSession) {
@@ -1997,6 +2036,91 @@ func TestStreamReply_WatchdogTimeoutIsNotTreatedAsUserInterrupt(t *testing.T) {
 	sess.mu.Unlock()
 	if historyLen != 2 {
 		t.Fatalf("watchdog timeout should not persist partial history; got %d messages", historyLen)
+	}
+}
+
+func TestStreamReply_RunnerCleanupTimeoutDoesNotHoldSessionMutex(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	mgr, sess := newTestMgrAndSession(h)
+	mgr.streamEventTimeout = 10 * time.Millisecond
+	mgr.runnerCleanupTimeout = 20 * time.Millisecond
+
+	runner := newCancelIgnoringRunner()
+	mgr.settings.Runner = runner
+	released := false
+	defer func() {
+		if !released {
+			close(runner.release)
+		}
+		select {
+		case <-runner.finished:
+		case <-time.After(time.Second):
+			t.Errorf("runner did not finish after release")
+		}
+	}()
+
+	bot := &fakeBotSender{}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hello"))
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("runner never started")
+	}
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("streamReply remained blocked after runner cleanup timeout")
+	}
+	if err == nil || !strings.Contains(err.Error(), "stream timed out") {
+		t.Fatalf("expected stream timeout error, got: %v", err)
+	}
+
+	select {
+	case <-runner.cancelled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("runner context was not cancelled")
+	}
+
+	sess.cancelMu.Lock()
+	streamCancel := sess.streamCancel
+	replyDone := sess.replyDone
+	streamEngine := sess.streamEngine
+	streamToken := sess.streamToken
+	sess.cancelMu.Unlock()
+	if streamCancel != nil || replyDone != nil || streamEngine != nil || streamToken != nil {
+		t.Fatalf("active stream state was not cleared: cancel=%v replyDone=%v engine=%v token=%v", streamCancel != nil, replyDone != nil, streamEngine != nil, streamToken != nil)
+	}
+
+	locked := make(chan struct{})
+	go func() {
+		sess.mu.Lock()
+		sess.mu.Unlock()
+		close(locked)
+	}()
+	select {
+	case <-locked:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("session mutex remained held after streamReply returned")
+	}
+
+	h.Provider.AddTextResponse("second reply")
+	mgr.settings.Runner = nil
+	if err := mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("second")); err != nil {
+		t.Fatalf("second streamReply failed after stuck runner cleanup: %v", err)
+	}
+
+	close(runner.release)
+	released = true
+	select {
+	case <-runner.finished:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not finish after release")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Bound Telegram `settings.Runner` cleanup in `streamReply` so it no longer waits forever on `runnerDone` after cancellation.
- Cancel the stream before the cleanup wait for early-return paths, then release the Telegram session lock after the bounded timeout if the runner is still stuck.
- Clear active runner engine state on cleanup and guard runner `OnEngineReady`/`OnEngineDone` callbacks with a per-stream token so late callbacks from an abandoned runner cannot corrupt a later stream.
- Added a regression test with a runner that observes cancellation but does not return until explicitly released; the test asserts `streamReply` returns after the bounded cleanup timeout and a second message can run afterward.

## Why this is high-value

Telegram/Jarvis streaming uses a session mutex to serialize each chat. The stream watchdog already cancels stuck streams, but the runner cleanup path did an unconditional receive on `runnerDone` after logging the 5s timeout. If a provider/tool/background operation ignored cancellation, that defer could keep `sess.mu` held forever, wedging all future messages in that chat despite the watchdog firing.

This keeps normal cleanup behavior when the runner exits promptly, while preventing one stuck runner from permanently blocking Sam's daily Telegram session.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./...`
- `git diff --check`
