### PR TITLE
fix: EventPipe runner adapters can hang forever after cancellation

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -70,6 +70,8 @@ var (
 	askSkills string
 	// Session resume flag
 	askResume string
+
+	askRunnerCleanupTimeout = runpkg.DefaultRunnerCleanupTimeout
 )
 
 var askCmd = &cobra.Command{
@@ -990,29 +992,53 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		stats = adapter.Stats()
 		streamCtx, cancelStream := context.WithCancel(ctx)
 		defer cancelStream()
-		var runnerResult runpkg.Result
-		errChan := make(chan error, 1)
+		type runnerStreamResult struct {
+			result   runpkg.Result
+			err      error
+			detached bool
+		}
+		streamResultChan := make(chan runnerStreamResult, 1)
 		go func() {
 			pipe := runpkg.NewEventPipe(streamCtx, ui.DefaultStreamBufferSize)
-			var runErr error
-			done := make(chan struct{})
+			runnerResultChan := make(chan runnerStreamResult, 1)
+			runnerDone := make(chan struct{})
 			go func() {
-				runnerResult, runErr = askRunner.Run(streamCtx, baseRunReq, pipe)
+				result, runErr := askRunner.Run(streamCtx, baseRunReq, pipe)
 				pipe.CloseWithError(runErr)
-				close(done)
+				runnerResultChan <- runnerStreamResult{result: result, err: runErr}
+				close(runnerDone)
 			}()
 			adapter.ProcessStream(streamCtx, pipe)
-			<-done
-			errChan <- runErr
+			cancelStream()
+			cleanupTimeout := askRunnerCleanupTimeout
+			if cleanupTimeout <= 0 {
+				cleanupTimeout = runpkg.DefaultRunnerCleanupTimeout
+			}
+			if !runpkg.WaitForRunnerDone(context.Background(), runnerDone, cleanupTimeout) {
+				detachErr := streamCtx.Err()
+				if detachErr == nil {
+					detachErr = context.Canceled
+				}
+				streamResultChan <- runnerStreamResult{err: detachErr, detached: true}
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: runner did not stop within %s after stream cancellation; detaching\n", cleanupTimeout)
+				return
+			}
+			streamResultChan <- <-runnerResultChan
 		}()
+		waitStreamResult := func() runnerStreamResult {
+			streamResult := <-streamResultChan
+			if !streamResult.detached {
+				applyRunResult(streamResult.result)
+			}
+			return streamResult
+		}
 
 		var jsonStreamErr error
 		switch {
 		case askJSON:
 			if err := emitSessionStarted(jsonEmit, jsonInfo); err != nil {
 				cancelStream()
-				<-errChan
-				applyRunResult(runnerResult)
+				waitStreamResult()
 				return err
 			}
 			var writeErr error
@@ -1053,8 +1079,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		streamDone := false
 		if err != nil {
 			cancelStream()
-			streamErr = <-errChan
-			applyRunResult(runnerResult)
+			streamErr = waitStreamResult().err
 			streamDone = true
 			if isInterruptedErr(err) || isInterruptedErr(streamErr) {
 				return finishInterrupted()
@@ -1068,8 +1093,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		if askJSON && jsonStreamErr != nil {
 			cancelStream()
 			if !streamDone {
-				streamErr = <-errChan
-				applyRunResult(runnerResult)
+				streamErr = waitStreamResult().err
 				streamDone = true
 			}
 			if isInterruptedErr(jsonStreamErr) {
@@ -1083,8 +1107,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		}
 
 		if !streamDone {
-			streamErr = <-errChan
-			applyRunResult(runnerResult)
+			streamErr = waitStreamResult().err
 		}
 		if streamErr != nil {
 			// Update session status based on error type

--- a/internal/run/runner_wait.go
+++ b/internal/run/runner_wait.go
@@ -1,0 +1,37 @@
+package run
+
+import (
+	"context"
+	"time"
+)
+
+// DefaultRunnerCleanupTimeout bounds how long EventPipe adapters wait for a
+// cancelled Runner.Run to finish its own cleanup before detaching. The runner
+// goroutine may still be stuck, but callers must not let that wedge UI/session
+// goroutines that already cancelled their stream context.
+const DefaultRunnerCleanupTimeout = 5 * time.Second
+
+// WaitForRunnerDone waits for Runner.Run to return after its stream context has
+// been cancelled. It deliberately starts a fresh timeout and ignores ctx.Done(),
+// because callers commonly pass a run context they have just cancelled and still
+// need to allow a small cleanup grace period.
+func WaitForRunnerDone(ctx context.Context, done <-chan struct{}, timeout time.Duration) bool {
+	if done == nil {
+		return true
+	}
+	if timeout <= 0 {
+		timeout = DefaultRunnerCleanupTimeout
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	select {
+	case <-done:
+		return true
+	case <-cleanupCtx.Done():
+		return false
+	}
+}

--- a/internal/run/runner_wait_test.go
+++ b/internal/run/runner_wait_test.go
@@ -1,0 +1,42 @@
+package run
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitForRunnerDoneReturnsWhenDoneCloses(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+
+	if !WaitForRunnerDone(context.Background(), done, time.Second) {
+		t.Fatal("WaitForRunnerDone returned false for closed done channel")
+	}
+}
+
+func TestWaitForRunnerDoneTimesOut(t *testing.T) {
+	done := make(chan struct{})
+	start := time.Now()
+
+	if WaitForRunnerDone(context.Background(), done, 10*time.Millisecond) {
+		t.Fatal("WaitForRunnerDone returned true for blocked runner")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("WaitForRunnerDone took %s, want bounded timeout", elapsed)
+	}
+}
+
+func TestWaitForRunnerDoneAllowsCleanupAfterCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(done)
+	}()
+
+	if !WaitForRunnerDone(ctx, done, time.Second) {
+		t.Fatal("WaitForRunnerDone did not allow cleanup after caller context cancellation")
+	}
+}

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -40,6 +40,8 @@ const telegramMaxVoiceDownloadBytes int64 = 25 << 20
 const telegramDownloadTimeout = 5 * time.Minute
 const telegramSessionShutdownFallbackTimeout = 5 * time.Second
 
+var telegramRunnerCleanupTimeout = runpkg.DefaultRunnerCleanupTimeout
+
 var telegramDownloadHTTPClient = &http.Client{Timeout: telegramDownloadTimeout}
 
 // botSender is the subset of tgbotapi.BotAPI used by streamReply and
@@ -441,6 +443,7 @@ type telegramSession struct {
 	runtime               *SessionRuntime
 	history               []llm.Message
 	systemPromptPersisted bool
+	runtimeStale          bool   // true when a detached runner may still be using runtime; reset before reuse
 	carryoverContext      string // one-time context carried from the previous replaced session
 	carryoverContextLabel string
 	carryoverMessageCount int // number of restored prior-session messages at the start of history; not persisted to this session
@@ -1202,14 +1205,16 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot *tgbotapi.Bo
 		return
 	}
 
-	// Check idle timeout and replace the whole session if expired.
+	// Check idle timeout and replace the whole session if expired or if a
+	// previously detached runner may still own the session runtime.
 	sess.mu.Lock()
+	runtimeStale := sess.runtimeStale
 	expired := time.Since(sess.lastActivity) > m.idleTimeout
-	if !expired {
+	if !expired && !runtimeStale {
 		sess.lastActivity = time.Now()
 	}
 	sess.mu.Unlock()
-	if expired {
+	if expired || runtimeStale {
 		sess, _, err = m.resetSessionIfCurrent(ctx, chatID, sess)
 		if err != nil {
 			_, _ = bot.Send(tgbotapi.NewMessage(chatID, "Error resetting session: "+err.Error()))
@@ -1528,13 +1533,14 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		if runnerDone == nil {
 			return
 		}
-		select {
-		case <-runnerDone:
-			return
-		case <-time.After(5 * time.Second):
-			log.Printf("[telegram] runner for chat %d still shutting down after cleanup timeout; waiting to avoid overlapping the shared engine", chatID)
+		cleanupTimeout := telegramRunnerCleanupTimeout
+		if cleanupTimeout <= 0 {
+			cleanupTimeout = runpkg.DefaultRunnerCleanupTimeout
 		}
-		<-runnerDone
+		if !runpkg.WaitForRunnerDone(context.Background(), runnerDone, cleanupTimeout) {
+			sess.runtimeStale = true
+			go log.Printf("[telegram] runner for chat %d did not stop within %s after stream cancellation; detaching and resetting runtime before reuse", chatID, cleanupTimeout)
+		}
 	}
 	defer waitForRunnerDone()
 	if m.settings.Runner != nil {

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -18,6 +18,8 @@ import (
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
+var eventPipeRunnerCleanupTimeout = runpkg.DefaultRunnerCleanupTimeout
+
 func copyLLMMessages(messages []llm.Message) []llm.Message {
 	if len(messages) == 0 {
 		return nil
@@ -710,7 +712,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 				}()
 				adapter.ProcessStream(runCtx, pipe)
 				cancelRun()
-				<-done
+				runpkg.WaitForRunnerDone(context.Background(), done, eventPipeRunnerCleanupTimeout)
 				return
 			}
 

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -92,19 +92,23 @@ func TestEnsureContextMessagesResetsBaselineWhenMutatingPrefix(t *testing.T) {
 	}
 }
 
-func TestRunnerStreamDoneWaitsForRunnerAfterCancellation(t *testing.T) {
+func TestRunnerStreamDoneDetachesAfterCancellationCleanupTimeout(t *testing.T) {
+	oldTimeout := eventPipeRunnerCleanupTimeout
+	eventPipeRunnerCleanupTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { eventPipeRunnerCleanupTimeout = oldTimeout })
+
 	m := newTestChatModel(false)
 	runner := &blockingChatRunner{
 		started: make(chan struct{}),
 		release: make(chan struct{}),
 	}
-	defer func() {
+	t.Cleanup(func() {
 		select {
 		case <-runner.release:
 		default:
 			close(runner.release)
 		}
-	}()
+	})
 	m.SetRunner(runner)
 
 	cmd := m.startStream("hello")
@@ -128,15 +132,8 @@ func TestRunnerStreamDoneWaitsForRunnerAfterCancellation(t *testing.T) {
 
 	select {
 	case <-m.streamDone:
-		t.Fatal("streamDone closed before runner returned")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	close(runner.release)
-	select {
-	case <-m.streamDone:
 	case <-time.After(time.Second):
-		t.Fatal("streamDone did not close after runner returned")
+		t.Fatal("streamDone did not close after runner cleanup timeout")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a shared `run.WaitForRunnerDone` helper with a bounded cleanup deadline for EventPipe runner adapters.
- Updated the TUI chat, `ask`, and Telegram EventPipe runner paths to cancel the run context and detach instead of waiting forever when `Runner.Run` ignores cancellation.
- Avoided the old `ask` shared-result data race risk by passing runner results through a buffered outcome channel and only applying them when the runner actually finishes.
- Marked Telegram sessions with a detached runner as stale so the next message creates a fresh runtime instead of reusing a possibly still-active shared engine.
- Updated/added tests covering the bounded wait helper and the TUI cancellation path where a fake runner never returns.

## Why this is high-value

These EventPipe paths sit on daily chat/ask/Telegram streaming. If a provider, tool, MCP cleanup, or runner path wedges after cancellation, the old code kept waiting on the runner forever after the UI/stream consumer had already stopped. That can freeze TUI stream cleanup, hang `ask` after output cancellation, and keep Telegram chats blocked behind the per-session mutex.

Bounding the post-cancel runner cleanup wait preserves the normal graceful path while preventing one stuck runner from wedging the caller indefinitely.

## Validation

- `gofmt -w internal/run/runner_wait.go internal/run/runner_wait_test.go internal/tui/chat/streaming.go internal/tui/chat/streaming_test.go cmd/ask.go internal/serve/telegram.go`
- `go test ./internal/run ./internal/tui/chat ./internal/serve ./cmd`
- `go build ./...`
- `git diff --check --cached`
- `go test ./...` was run; it fails in unchanged `internal/jobs` at `TestProgramRunnerDoesNotLeakBackgroundChildren` because a background child process still appears alive after the test deadline.
