### PR TITLE
test: configure identity in worktree fixtures

### DIFF
--- a/cmd/worktree_binding_test.go
+++ b/cmd/worktree_binding_test.go
@@ -21,6 +21,8 @@ func newGitRepoForBindingTest(t *testing.T) string {
 		t.Fatalf("MkdirAll repo: %v", err)
 	}
 	runGitForBindingTest(t, repo, "init", "-q")
+	runGitForBindingTest(t, repo, "config", "user.name", "Test User")
+	runGitForBindingTest(t, repo, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("base\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -33,6 +33,8 @@ func newGitRepoForWorktreeTest(t *testing.T) string {
 		t.Fatalf("MkdirAll repo: %v", err)
 	}
 	runGitForWorktreeTest(t, repo, "init", "-q")
+	runGitForWorktreeTest(t, repo, "config", "user.name", "Test User")
+	runGitForWorktreeTest(t, repo, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("base\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}


### PR DESCRIPTION
## What

Configure a repository-local Git identity in the worktree test fixtures used by both `internal/worktree` and the server handler tests.

## Why

Main CI runs with no global Git identity. The fixture's setup commands supplied identity only through command-scoped environment variables, so later production `git commit-tree` subprocesses could not discover an author/committer and seven worktree tests failed.

Keeping the identity in each temporary repository preserves test isolation while matching how the worktree code reads Git configuration.

## Testing

- `go build ./...`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...` with author/committer environment variables unset
- `git diff --check`
