### PR TITLE
fix: Every shell call renders the full approval transcript before fast-path approval

### DIFF
--- a/internal/tools/approval.go
+++ b/internal/tools/approval.go
@@ -972,11 +972,20 @@ func getDirectoryForApproval(path string) string {
 // CheckShellApproval checks if a shell command is approved.
 // workDir is the directory where the command will execute (may be empty for cwd).
 func (m *ApprovalManager) CheckShellApproval(command, workDir string) (ConfirmOutcome, error) {
-	return m.CheckShellApprovalWithContext(context.Background(), command, workDir, nil)
+	return m.checkShellApprovalWithContext(context.Background(), command, workDir, nil)
 }
 
 // CheckShellApprovalWithContext checks shell approval with optional transcript evidence.
+// It keeps the existing eager transcript API for callers that have already
+// materialized approval evidence.
 func (m *ApprovalManager) CheckShellApprovalWithContext(ctx context.Context, command, workDir string, transcript []TranscriptEntry) (ConfirmOutcome, error) {
+	return m.checkShellApprovalWithContext(ctx, command, workDir, func() []TranscriptEntry { return transcript })
+}
+
+// checkShellApprovalWithContext checks shell approval with lazily-supplied
+// transcript evidence. The supplier is only evaluated when an auto guardian
+// reviewer actually needs the transcript.
+func (m *ApprovalManager) checkShellApprovalWithContext(ctx context.Context, command, workDir string, transcript func() []TranscriptEntry) (ConfirmOutcome, error) {
 	// Yolo mode - auto-approve everything
 	if m.YoloEnabled() {
 		if m.DebugApproval {
@@ -1132,7 +1141,7 @@ func addApprovalContextLine(b *strings.Builder, seen map[string]struct{}, label,
 	fmt.Fprintf(b, "%s=%q\n", label, value)
 }
 
-func (m *ApprovalManager) checkShellGuardianApproval(ctx context.Context, command, workDir string, transcript []TranscriptEntry) (ConfirmOutcome, bool, error) {
+func (m *ApprovalManager) checkShellGuardianApproval(ctx context.Context, command, workDir string, transcript func() []TranscriptEntry) (ConfirmOutcome, bool, error) {
 	reviewFunc := m.lookupPolicyReviewFunc()
 	if reviewFunc == nil {
 		m.emitGuardianEvent("guardian: auto mode unavailable (no reviewer configured); prompting for approval")
@@ -1142,7 +1151,11 @@ func (m *ApprovalManager) checkShellGuardianApproval(ctx context.Context, comman
 		return Cancel, false, nil
 	}
 	approvalContext := m.guardianApprovalContext(command, workDir)
-	decision, err := reviewFunc(ctx, PolicyReviewRequest{Command: command, WorkDir: normalizeGuardianWorkDir(workDir), Transcript: transcript, ApprovalContext: approvalContext, ScopeID: llm.SessionIDFromContext(ctx)})
+	var entries []TranscriptEntry
+	if transcript != nil {
+		entries = transcript()
+	}
+	decision, err := reviewFunc(ctx, PolicyReviewRequest{Command: command, WorkDir: normalizeGuardianWorkDir(workDir), Transcript: entries, ApprovalContext: approvalContext, ScopeID: llm.SessionIDFromContext(ctx)})
 	if err != nil {
 		m.emitGuardianEvent(fmt.Sprintf("guardian: review failed (%v)", err))
 		if m.AutoHeadless() {

--- a/internal/tools/approval_auto_test.go
+++ b/internal/tools/approval_auto_test.go
@@ -78,6 +78,72 @@ func TestApprovalManagerAutoReviewerOnlyAfterDeterministicMiss(t *testing.T) {
 	}
 }
 
+func TestApprovalManagerLazyTranscriptSupplierSkipsFastPaths(t *testing.T) {
+	t.Run("yolo", func(t *testing.T) {
+		mgr := newApprovalAutoTestManager(NewToolPermissions())
+		mgr.SetApprovalMode(ModeYolo)
+		calls := 0
+		outcome, err := mgr.checkShellApprovalWithContext(context.Background(), "echo hi", "", func() []TranscriptEntry {
+			calls++
+			return []TranscriptEntry{{Role: "user", Text: "expensive transcript"}}
+		})
+		if err != nil || outcome != ProceedOnce {
+			t.Fatalf("outcome = %v, err = %v, want yolo allow", outcome, err)
+		}
+		if calls != 0 {
+			t.Fatalf("transcript supplier called %d times on yolo fast path, want 0", calls)
+		}
+	})
+
+	t.Run("deterministic allow", func(t *testing.T) {
+		perms := NewToolPermissions()
+		perms.ShellAllow = []string{"git *"}
+		if err := perms.CompileShellPatterns(); err != nil {
+			t.Fatal(err)
+		}
+		mgr := newApprovalAutoTestManager(perms)
+		mgr.SetApprovalMode(ModeAuto)
+		mgr.PolicyReviewFunc = func(ctx context.Context, req PolicyReviewRequest) (PolicyDecision, error) {
+			t.Fatal("guardian reviewer should not be called for deterministic allow")
+			return PolicyDecision{}, nil
+		}
+		calls := 0
+		outcome, err := mgr.checkShellApprovalWithContext(context.Background(), "git status", "", func() []TranscriptEntry {
+			calls++
+			return []TranscriptEntry{{Role: "user", Text: "expensive transcript"}}
+		})
+		if err != nil || outcome != ProceedOnce {
+			t.Fatalf("outcome = %v, err = %v, want deterministic allow", outcome, err)
+		}
+		if calls != 0 {
+			t.Fatalf("transcript supplier called %d times on deterministic fast path, want 0", calls)
+		}
+	})
+}
+
+func TestApprovalManagerLazyTranscriptSupplierInvokedForGuardian(t *testing.T) {
+	mgr := newApprovalAutoTestManager(NewToolPermissions())
+	mgr.SetApprovalMode(ModeAuto)
+	wantTranscript := TranscriptEntry{Role: "user", Text: "please inspect before running"}
+	mgr.PolicyReviewFunc = func(ctx context.Context, req PolicyReviewRequest) (PolicyDecision, error) {
+		if len(req.Transcript) != 1 || req.Transcript[0] != wantTranscript {
+			t.Fatalf("review transcript = %#v, want %#v", req.Transcript, []TranscriptEntry{wantTranscript})
+		}
+		return PolicyDecision{Allowed: true, RiskLevel: "low", UserAuthorization: "high", Rationale: "ok"}, nil
+	}
+	calls := 0
+	outcome, err := mgr.checkShellApprovalWithContext(context.Background(), "echo hi", t.TempDir(), func() []TranscriptEntry {
+		calls++
+		return []TranscriptEntry{wantTranscript}
+	})
+	if err != nil || outcome != ProceedAlways {
+		t.Fatalf("outcome = %v, err = %v, want guardian allow", outcome, err)
+	}
+	if calls != 1 {
+		t.Fatalf("transcript supplier called %d times for guardian review, want 1", calls)
+	}
+}
+
 func TestApprovalManagerGuardianExactCacheDoesNotTreatStarAsPattern(t *testing.T) {
 	mgr := newApprovalAutoTestManager(NewToolPermissions())
 	mgr.SetApprovalMode(ModeAuto)

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -293,7 +293,9 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 	// Check permissions — pass both command and working directory so the
 	// approval UI can show the user where the command will run.
 	if t.approval != nil {
-		outcome, err := t.approval.CheckShellApprovalWithContext(ctx, a.Command, workDir, shellApprovalTranscriptFromContext(ctx))
+		outcome, err := t.approval.checkShellApprovalWithContext(ctx, a.Command, workDir, func() []TranscriptEntry {
+			return shellApprovalTranscriptFromContext(ctx)
+		})
 		if err != nil {
 			if toolErr, ok := err.(*ToolError); ok {
 				return errorOutput(formatToolError(toolErr)), nil


### PR DESCRIPTION
## What changed

- Added a lazy shell approval path that accepts a transcript supplier instead of an already-materialized transcript.
- Switched `ShellTool.Execute` to pass `shellApprovalTranscriptFromContext(ctx)` as that supplier, so transcript rendering is deferred until an auto guardian reviewer actually needs it.
- Kept the existing eager `CheckShellApprovalWithContext` API for callers that already build transcript evidence, such as handover approval.
- Added tests proving the supplier is not invoked for yolo or deterministic shell approvals, and is invoked exactly once for guardian review.

## Why this is high-value

Shell is one of Jarvis's hottest tool paths. Before this change, every shell invocation rendered the full approval transcript before `CheckShellApprovalWithContext` could take the yolo, configured allowlist, session cache, guardian exact cache, or project approval fast paths. Rendering copies the active message slice and materializes text/tool-call/tool-result evidence, so the wasted work grows with session length and repeats for every shell call.

With the transcript behind a supplier, fast-path-approved commands skip that copy/render work entirely. Only unresolved auto-mode commands with an available guardian reviewer pay the transcript cost, preserving guardian evidence while making common approved shell calls independent of transcript size.

## Validation

- `gofmt -w internal/tools/approval.go internal/tools/shell.go internal/tools/approval_auto_test.go`
- `go build ./...`
- `go test ./internal/tools -run 'TestApprovalManager(LazyTranscriptSupplier|AutoReviewerOnlyAfterDeterministicMiss|GuardianExactCacheDoesNotTreatStarAsPattern)'`
- `tmp=$(mktemp -d); mkdir -p "$tmp/home" "$tmp/xdg" "$tmp/codex"; HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" CODEX_HOME="$tmp/codex" go test ./...` (isolated user skill dirs so the existing cmd skill-visibility test is not affected by Jarvis's ambient user skills)
- `git diff --check`
