### PR TITLE
FIX: Map ChatGPT Ultra effort to Codex max

### DIFF
--- a/cmd/models.go
+++ b/cmd/models.go
@@ -27,6 +27,7 @@ are available. Useful for finding model names to configure.
 Examples:
   term-llm models                       # list models from current provider
   term-llm models --provider anthropic  # list models from Anthropic
+  term-llm models --provider chatgpt    # list models from ChatGPT/Codex
   term-llm models --provider openrouter # list models from OpenRouter
   term-llm models --provider nearai     # list models from NEAR AI Cloud
   term-llm models --provider sambanova  # list models from SambaNova
@@ -39,7 +40,7 @@ Examples:
 
 func init() {
 	rootCmd.AddCommand(modelsCmd)
-	modelsCmd.Flags().StringVarP(&modelsProvider, "provider", "p", "", "Provider to list models from (anthropic, copilot, openrouter, nearai, sambanova, venice, xai, zen, ollama, lmstudio, openai-compat)")
+	modelsCmd.Flags().StringVarP(&modelsProvider, "provider", "p", "", "Provider to list models from (anthropic, chatgpt, copilot, openrouter, nearai, sambanova, venice, xai, zen, ollama, lmstudio, openai-compat)")
 	modelsCmd.Flags().BoolVar(&modelsJSON, "json", false, "Output as JSON")
 	modelsCmd.RegisterFlagCompletionFunc("provider", ProviderFlagCompletion)
 }
@@ -52,6 +53,7 @@ type ModelLister interface {
 var modelListSupportedTypes = map[config.ProviderType]bool{
 	config.ProviderTypeAnthropic:    true,
 	config.ProviderTypeOpenAI:       true,
+	config.ProviderTypeChatGPT:      true,
 	config.ProviderTypeCopilot:      true,
 	config.ProviderTypeOpenRouter:   true,
 	config.ProviderTypeOpenAICompat: true,
@@ -131,6 +133,17 @@ func runModels(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("openai API key not configured. Set OPENAI_API_KEY or configure api_key")
 		}
 		lister = llm.NewOpenAIProvider(apiKey, providerCfg.Model)
+	case config.ProviderTypeChatGPT:
+		// ChatGPT uses native OAuth and lists the Codex model catalog.
+		model := ""
+		if ok {
+			model = providerCfg.Model
+		}
+		provider, err := llm.NewChatGPTProvider(model)
+		if err != nil {
+			return fmt.Errorf("chatgpt provider: %w", err)
+		}
+		lister = provider
 	case config.ProviderTypeCopilot:
 		// Copilot uses OAuth - create provider which will prompt for auth if needed
 		model := ""
@@ -255,6 +268,14 @@ func runModels(cmd *cobra.Command, args []string) error {
 				fmt.Printf(" [$%.2f/$%.2f per 1M tokens]", m.InputPrice, m.OutputPrice)
 			}
 		}
+
+		efforts := m.ReasoningEfforts
+		if len(efforts) == 0 {
+			efforts = llm.ReasoningEffortsForProviderModel(providerName, m.ID)
+		}
+		if len(efforts) > 0 {
+			fmt.Printf(" (effort: %s)", strings.Join(efforts, ", "))
+		}
 		fmt.Println()
 	}
 
@@ -269,14 +290,16 @@ func runModels(cmd *cobra.Command, args []string) error {
 func printStaticModels(providerName string, models []string) error {
 	if modelsJSON {
 		type staticModel struct {
-			ID         string `json:"id"`
-			InputLimit int    `json:"input_limit,omitempty"`
+			ID               string   `json:"id"`
+			InputLimit       int      `json:"input_limit,omitempty"`
+			ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
 		}
 		var jsonModels []staticModel
 		for _, m := range models {
 			jsonModels = append(jsonModels, staticModel{
-				ID:         m,
-				InputLimit: llm.InputLimitForProviderModel(providerName, m),
+				ID:               m,
+				InputLimit:       llm.InputLimitForProviderModel(providerName, m),
+				ReasoningEfforts: llm.ReasoningEffortsForProviderModel(providerName, m),
 			})
 		}
 		enc := json.NewEncoder(os.Stdout)
@@ -290,7 +313,7 @@ func printStaticModels(providerName string, models []string) error {
 		if ctxStr := llm.FormatTokenCount(llm.InputLimitForProviderModel(providerName, m)); ctxStr != "" {
 			line += fmt.Sprintf(" [%s input]", ctxStr)
 		}
-		if variants := llm.EffortVariantsFor(m); len(variants) > 0 {
+		if variants := llm.ReasoningEffortsForProviderModel(providerName, m); len(variants) > 0 {
 			line += fmt.Sprintf(" (effort: %s)", strings.Join(variants, ", "))
 		}
 		fmt.Println(line)

--- a/cmd/models_test.go
+++ b/cmd/models_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestModelListSupportedTypesIncludesChatGPT(t *testing.T) {
+	if !modelListSupportedTypes[config.ProviderTypeChatGPT] {
+		t.Fatal("ChatGPT should be wired for dynamic Codex model listing")
+	}
+}
+
 func TestModelListSupportedTypesIncludesSambaNova(t *testing.T) {
 	if !modelListSupportedTypes[config.ProviderTypeSambaNova] {
 		t.Fatal("SambaNova should be wired for dynamic model listing")
@@ -15,6 +21,19 @@ func TestModelListSupportedTypesIncludesSambaNova(t *testing.T) {
 func TestModelListSupportedTypesIncludesNearAI(t *testing.T) {
 	if !modelListSupportedTypes[config.ProviderTypeNearAI] {
 		t.Fatal("NEAR AI should be wired for dynamic model listing")
+	}
+}
+
+func TestBuiltinProviderMetaChatGPTSupportsListModels(t *testing.T) {
+	meta, ok := builtinProviderMeta["chatgpt"]
+	if !ok {
+		t.Fatal("ChatGPT provider metadata missing")
+	}
+	if !meta.supportsListModels {
+		t.Fatal("ChatGPT should advertise Codex model listing support")
+	}
+	if meta.requiresKey || meta.credential != "oauth" {
+		t.Fatalf("ChatGPT metadata = %+v, want OAuth without required API key", meta)
 	}
 }
 

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -94,7 +94,7 @@ var builtinProviderMeta = map[string]struct {
 		credential:         "oauth",
 		envVar:             "",
 		requiresKey:        false,
-		supportsListModels: false,
+		supportsListModels: true,
 		description:        "ChatGPT via native OAuth (ChatGPT Plus/Pro subscription)",
 	},
 	"copilot": {

--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -189,6 +189,18 @@ func runChatGPTBrowserFlow(ctx context.Context) (*oauth.ChatGPTCredentials, erro
 	return oauth.AuthenticateChatGPT(ctx)
 }
 
+// chatGPTReasoningEffortForRequest maps term-llm's user-facing ChatGPT/Codex
+// effort aliases to the values accepted by the backend responses endpoint.
+// Codex exposes "Ultra" in /codex/models and the UI, but sends it as the
+// backend-compatible max effort at inference time.
+func chatGPTReasoningEffortForRequest(effort string) string {
+	effort = strings.TrimSpace(effort)
+	if strings.EqualFold(effort, "ultra") {
+		return "max"
+	}
+	return effort
+}
+
 func (p *ChatGPTProvider) Name() string {
 	if p.effort != "" {
 		return fmt.Sprintf("ChatGPT (%s, effort=%s)", p.model, p.effort)
@@ -245,8 +257,9 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 		return nil, err
 	}
 
-	// Build tools. ChatGPT Ultra remains an effort; no public-API Pro or
-	// multi-agent/PTC/cache controls are synthesized for the Codex backend.
+	// Build tools. ChatGPT's Codex backend exposes Ultra as a user-facing
+	// reasoning level, but the Responses request still uses max effort. term-llm
+	// does not synthesize Codex UI multi-agent/PTC/cache controls for ChatGPT.
 	tools := BuildResponsesTools(req.Tools)
 	if req.Search {
 		tools = append([]any{ResponsesWebSearchTool{Type: "web_search"}}, tools...)
@@ -290,8 +303,8 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 		responsesReq.ParallelToolCalls = boolPtr(true)
 	}
 	responsesReq.Reasoning = &ResponsesReasoning{Summary: "auto"}
-	if effort != "" {
-		responsesReq.Reasoning.Effort = effort
+	if requestEffort := chatGPTReasoningEffortForRequest(effort); requestEffort != "" {
+		responsesReq.Reasoning.Effort = requestEffort
 	}
 
 	return p.responsesClient.Stream(ctx, responsesReq, req.DebugRaw)

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -82,6 +82,57 @@ func TestNewChatGPTResponsesClientUsesCurrentCodexHeaders(t *testing.T) {
 	}
 }
 
+func TestChatGPTStream_MapsUltraReasoningEffortToMaxRequestEffort(t *testing.T) {
+	origClient := chatGPTHTTPClient
+	defer func() { chatGPTHTTPClient = origClient }()
+
+	var captured ResponsesRequest
+	chatGPTHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(req.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`event: response.completed`,
+				`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+				`data: [DONE]`,
+			}, "\n"))),
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	provider := NewChatGPTProviderWithCreds(&credentials.ChatGPTCredentials{
+		AccessToken: "test-token",
+		AccountID:   "test-account",
+		ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+	}, "gpt-5.6-sol-ultra")
+
+	if provider.model != "gpt-5.6-sol" {
+		t.Fatalf("provider model = %q, want gpt-5.6-sol", provider.model)
+	}
+	if provider.effort != "ultra" {
+		t.Fatalf("provider effort = %q, want ultra", provider.effort)
+	}
+
+	stream, err := provider.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+	drainStreamToDone(t, stream)
+
+	if captured.Model != "gpt-5.6-sol" {
+		t.Fatalf("request model = %q, want gpt-5.6-sol", captured.Model)
+	}
+	if captured.Reasoning == nil {
+		t.Fatal("request reasoning missing")
+	}
+	if captured.Reasoning.Effort != "max" {
+		t.Fatalf("request reasoning effort = %q, want max", captured.Reasoning.Effort)
+	}
+}
+
 func TestChatGPTStream_IncludesNormalizedServiceTier(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() { chatGPTHTTPClient = origClient }()

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -3379,6 +3379,8 @@ func newGitRepoForChatWorktreeTest(t *testing.T) string {
 		t.Fatalf("MkdirAll repo: %v", err)
 	}
 	runGitForChatWorktreeTest(t, repo, "init", "-q")
+	runGitForChatWorktreeTest(t, repo, "config", "user.name", "Test User")
+	runGitForChatWorktreeTest(t, repo, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile README: %v", err)
 	}


### PR DESCRIPTION
## What

Support the ChatGPT/Codex `gpt-5.6-sol-ultra` suffix by keeping `ultra` as the user-facing reasoning effort while sending the backend-compatible `max` effort in the `/backend-api/codex/responses` request.

Also:

- wires `term-llm models --provider chatgpt` to the live Codex model catalog so Sol/Terra show `ultra` when advertised by the account
- configures the worktree merge test repo with a local git identity so CI can create snapshot commits when no global git config is present

## Why

The Codex model catalog advertises `ultra` as a supported reasoning level for GPT-5.6 Sol/Terra, and the Codex UI exposes it. The responses endpoint rejects `reasoning.effort=ultra`; Codex maps Ultra to `max` at request time.

## Validation

- `go test ./internal/llm -run 'Test(ChatGPTStream_MapsUltraReasoningEffortToMaxRequestEffort|ReasoningEffortsForProviderModel|NewChatGPTProviderWithCredsDefaultsToGPT56SolMedium)$'`
- `go test ./cmd ./internal/llm`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./internal/tui/chat -run 'TestCmdWorktreeMerge(DefaultRemovesAndRebinds|KeepPreservesBinding)' -count=1 -v`
- live smoke: `go run . ask --no-session --text --max-output-tokens 20 --timeout 120s -p chatgpt:gpt-5.6-sol-ultra "Reply exactly ok"` → `ok`
- live model listing: `go run . models --provider chatgpt` shows `gpt-5.6-sol` / `gpt-5.6-terra` efforts include `ultra`
- `git diff --check`
