### PR TITLE
fix: unblock WebRTC peer cleanup on idle timeout

### DIFF
--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -63,6 +63,12 @@ type responseFrame struct {
 	Status  int               `json:"status,omitempty"`  // HTTP status; for "headers" and "done"
 }
 
+type dataChannelConn interface {
+	ReadDataChannel([]byte) (int, bool, error)
+	WriteDataChannel([]byte, bool) (int, error)
+	Close() error
+}
+
 const maxChunkDataBytes = 16 * 1024
 
 // peer is the home-side WebRTC peer.
@@ -506,10 +512,12 @@ func (p *peer) handleOffer(ctx context.Context, offer signalingMsg) {
 	}
 	defer dc.Close()
 
-	p.runDataChannel(ctx, dc)
+	p.runDataChannel(ctx, dc, func() {
+		_ = sctpAssoc.Close()
+	})
 }
 
-func (p *peer) runDataChannel(ctx context.Context, dc *datachannel.DataChannel) {
+func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTransport func()) {
 	dataChannelCtx, cancelDataChannelRequests := context.WithCancel(ctx)
 	defer cancelDataChannelRequests()
 
@@ -529,6 +537,12 @@ func (p *peer) runDataChannel(ctx context.Context, dc *datachannel.DataChannel) 
 			cancelDataChannelRequests()
 			close(stop)
 			_ = dc.Close()
+			// DataChannel.Close only resets the SCTP stream's write direction and
+			// does not wake a goroutine blocked in ReadDataChannel. Close the
+			// underlying association before waiting for the reader to finish.
+			if closeTransport != nil {
+				closeTransport()
+			}
 		})
 	}
 	send := func(text string) error {

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -51,6 +52,63 @@ func encodeRequest(id, method, path string, headers map[string]string, body stri
 	}
 	data, _ := json.Marshal(f)
 	return data
+}
+
+type blockingReadDataChannel struct {
+	readUnblock <-chan struct{}
+	closed      chan struct{}
+}
+
+func (d *blockingReadDataChannel) ReadDataChannel([]byte) (int, bool, error) {
+	<-d.readUnblock
+	return 0, false, io.EOF
+}
+
+func (d *blockingReadDataChannel) WriteDataChannel(data []byte, _ bool) (int, error) {
+	return len(data), nil
+}
+
+func (d *blockingReadDataChannel) Close() error {
+	close(d.closed)
+	return nil
+}
+
+func TestRunDataChannel_IdleTimeoutClosesTransportToWakeReader(t *testing.T) {
+	p := newTestPeer("/ui", http.NotFoundHandler())
+	p.cfg.IdleTimeout = 10 * time.Millisecond
+
+	readUnblock := make(chan struct{})
+	transportClosed := make(chan struct{})
+	dc := &blockingReadDataChannel{
+		readUnblock: readUnblock,
+		closed:      make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.runDataChannel(context.Background(), dc, func() {
+			close(transportClosed)
+			close(readUnblock)
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runDataChannel remained blocked waiting for ReadDataChannel after idle timeout")
+	}
+
+	select {
+	case <-dc.closed:
+	default:
+		t.Fatal("idle timeout did not close the data channel")
+	}
+	select {
+	case <-transportClosed:
+	default:
+		t.Fatal("idle timeout did not close the underlying transport")
+	}
 }
 
 func TestTryAcquireDataChannelRequestSlot_ReturnsFalseWhenFull(t *testing.T) {


### PR DESCRIPTION
## What

- close the underlying SCTP association whenever a WebRTC data channel is stopped
- use a narrow data-channel interface so shutdown behavior is regression-testable
- add a test modelling Pion's asymmetric close semantics: closing the data channel does not wake a blocked reader, while closing the transport does

## Why

The web peer's idle-timeout path called `DataChannel.Close()` and then waited on `readDone`. Pion's data-channel close resets only the SCTP stream's write direction, so a goroutine blocked in `ReadDataChannel` could remain blocked forever.

That also kept `handleOffer` alive and prevented the active connection counter from decrementing. On the affected deployment, pprof showed **8 leaked handlers plus 2 live handlers = the configured 10-connection maximum**. New WebRTC offers were then rejected and browsers had to fall back to HTTPS, creating intermittent connection delays.

Closing the SCTP association wakes the blocked stream reader before `runDataChannel` waits for it.

## Validation

- `go test ./internal/webrtc`
- `go test -race ./internal/webrtc`
- `go build ./...`
- `go test ./...` *(two unrelated failures on current main: a user-config-dependent `cmd` skill-visibility test and a flaky jobs child-process cleanup test; the jobs test passed when rerun alone)*
- `git diff --check`
