### PR TITLE
fix: hydrate web history before persistence

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -479,11 +479,37 @@ func (rt *serveRuntime) ensureSessionInStore(ctx context.Context, sessionID stri
 	return sess.Number
 }
 
+func (rt *serveRuntime) restorePersistedHistory(ctx context.Context, sess *session.Session) bool {
+	if sess == nil || len(rt.history) > 0 || rt.historyPersisted {
+		return true
+	}
+	msgs, err := session.LoadActiveMessages(ctx, rt.store, sess)
+	if err != nil {
+		log.Printf("[serve] session history restore failed for %s: %v", sess.ID, err)
+		return false
+	}
+	llmMsgs := make([]llm.Message, 0, len(msgs))
+	for _, m := range msgs {
+		llmMsgs = append(llmMsgs, m.ToLLMMessage())
+	}
+	rt.history = llmMsgs
+	rt.historyPersisted = true
+	return true
+}
+
 func (rt *serveRuntime) ensurePersistedSession(ctx context.Context, sessionID string, inputMessages []llm.Message) bool {
 	if rt.store == nil || sessionID == "" {
 		return false
 	}
 	if rt.sessionMeta != nil && rt.sessionMeta.ID == sessionID {
+		// Metadata-only setup (for example restoring a worktree BaseDir or
+		// updating reasoning settings) can populate sessionMeta before the first
+		// post-restart run. Never treat metadata as proof that the transcript is
+		// hydrated: persisting an empty runtime snapshot would truncate the stored
+		// conversation to the new input.
+		if !rt.restorePersistedHistory(ctx, rt.sessionMeta) {
+			return false
+		}
 		rt.restorePlatformInjectionStateFromHistory()
 		return true
 	}
@@ -491,17 +517,10 @@ func (rt *serveRuntime) ensurePersistedSession(ctx context.Context, sessionID st
 	// Check DB first — ensureSessionInStore may have already created the record.
 	if existing, err := rt.store.Get(ctx, sessionID); err == nil && existing != nil {
 		rt.sessionMeta = existing
-		if len(rt.history) == 0 {
-			if msgs, loadErr := session.LoadActiveMessages(ctx, rt.store, existing); loadErr == nil {
-				llmMsgs := make([]llm.Message, 0, len(msgs))
-				for _, m := range msgs {
-					llmMsgs = append(llmMsgs, m.ToLLMMessage())
-				}
-				rt.history = llmMsgs
-				rt.historyPersisted = true
-				rt.restorePlatformInjectionStateFromHistory()
-			}
+		if !rt.restorePersistedHistory(ctx, existing) {
+			return false
 		}
+		rt.restorePlatformInjectionStateFromHistory()
 		return true
 	}
 
@@ -551,17 +570,10 @@ func (rt *serveRuntime) ensurePersistedSession(ctx context.Context, sessionID st
 			return false
 		}
 		rt.sessionMeta = existing
-		if len(rt.history) == 0 {
-			if msgs, loadErr := session.LoadActiveMessages(ctx, rt.store, existing); loadErr == nil {
-				llmMsgs := make([]llm.Message, 0, len(msgs))
-				for _, m := range msgs {
-					llmMsgs = append(llmMsgs, m.ToLLMMessage())
-				}
-				rt.history = llmMsgs
-				rt.historyPersisted = true
-				rt.restorePlatformInjectionStateFromHistory()
-			}
+		if !rt.restorePersistedHistory(ctx, existing) {
+			return false
 		}
+		rt.restorePlatformInjectionStateFromHistory()
 		if setErr := rt.store.SetCurrent(ctx, sessionID); setErr != nil {
 			log.Printf("[serve] session SetCurrent failed for %s: %v", sessionID, setErr)
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3706,12 +3706,22 @@ func TestResponsesUIBareSessionIDAppendsServerHistory(t *testing.T) {
 	}
 
 	provider := llm.NewMockProvider("mock").AddTextResponse("new answer")
+	// A fresh post-restart web runtime still has a tool manager. Restoring its
+	// persisted BaseDir loads session metadata before Run; that metadata must not
+	// make Run mistake the otherwise empty runtime for a hydrated conversation.
+	toolCfg := tools.DefaultToolConfig()
+	toolCfg.Enabled = []string{tools.ReadFileToolName}
+	toolMgr, err := tools.NewToolManager(&toolCfg, &config.Config{})
+	if err != nil {
+		t.Fatalf("NewToolManager: %v", err)
+	}
 	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
 		engine := llm.NewEngine(provider, nil)
 		rt := &serveRuntime{
 			provider:     provider,
 			engine:       engine,
 			store:        store,
+			toolMgr:      toolMgr,
 			defaultModel: "mock-model",
 		}
 		rt.Touch()
@@ -6093,6 +6103,52 @@ func TestEnsurePersistedSession_RestoresHistory(t *testing.T) {
 	}
 	if rt.history[1].Parts[0].Text != "hi there" {
 		t.Fatalf("history[1].text = %q, want %q", rt.history[1].Parts[0].Text, "hi there")
+	}
+}
+
+func TestEnsurePersistedSession_RestoresHistoryWhenMetadataAlreadyLoaded(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &session.Session{
+		ID:        "metadata-before-history",
+		Provider:  "mock",
+		Model:     "mock-model",
+		Mode:      session.ModeChat,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Status:    session.StatusActive,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ReplaceMessages(ctx, sess.ID, []session.Message{
+		*session.NewMessage(sess.ID, llm.UserText("persisted question"), -1),
+		*session.NewMessage(sess.ID, llm.AssistantText("persisted answer"), -1),
+	}); err != nil {
+		t.Fatalf("ReplaceMessages: %v", err)
+	}
+
+	// Metadata-only request setup can run before the first post-restart turn.
+	rt := &serveRuntime{
+		store:        store,
+		defaultModel: "mock-model",
+		provider:     llm.NewMockProvider("mock"),
+		sessionMeta:  sess,
+	}
+	if ok := rt.ensurePersistedSession(ctx, sess.ID, nil); !ok {
+		t.Fatal("ensurePersistedSession returned false")
+	}
+	if !rt.historyPersisted {
+		t.Fatal("historyPersisted = false, want true after restore")
+	}
+	if len(rt.history) != 2 || rt.history[0].Parts[0].Text != "persisted question" || rt.history[1].Parts[0].Text != "persisted answer" {
+		t.Fatalf("restored history = %#v, want persisted conversation", rt.history)
 	}
 }
 


### PR DESCRIPTION
## What

- Restore persisted active messages when session metadata was loaded before a fresh web runtime's history.
- Fail closed when existing history cannot be loaded, so an incomplete runtime snapshot cannot replace the durable transcript.
- Cover the exact post-restart path where worktree/BaseDir restoration preloads `sessionMeta` on a runtime with tools.
- Add a direct regression test for metadata-loaded/history-empty runtimes.

## Why

After a web-server restart, runtime setup can load an existing session row to restore its tool BaseDir. That populated `sessionMeta` while leaving `history` empty. `ensurePersistedSession` treated non-nil metadata as proof that history was already hydrated, then `ReplaceMessages` reconciled the database against only the injected system/developer messages and the new user input. The unchanged prefix survived; the rest of the transcript was deleted.

Metadata and transcript hydration are separate states. This change makes the persistence boundary enforce that distinction centrally rather than relying on every metadata-only caller to avoid setting `sessionMeta`.

## Verification

- `go test ./cmd -run '^(TestResponsesUIBareSessionIDAppendsServerHistory|TestEnsurePersistedSession_.*)$' -count=1`
- `go test ./internal/session -count=1`
- `go build ./...`

A full local `go test ./cmd -count=1` reached the existing config-dependent `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` failure because this Jarvis installation exposes 30 skills while the test budget renders only eight; the persistence tests and remaining package run showed no related failures.
