### PR TITLE
fix: remove explicit Responses cache breakpoints

### DIFF
--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -346,16 +346,6 @@ func looksLikePlainText(raw []byte) bool {
 // Images exceeding 1 MB are resized/compressed only for the inline LLM payload
 // to avoid provider errors; the saved ImagePath always points at the original
 // uploaded bytes.
-func hasExplicitPromptCacheBreakpoint(raw json.RawMessage) bool {
-	if len(raw) == 0 {
-		return false
-	}
-	var value struct {
-		Mode string `json:"mode"`
-	}
-	return json.Unmarshal(raw, &value) == nil && strings.EqualFold(strings.TrimSpace(value.Mode), "explicit")
-}
-
 func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	var parts []map[string]json.RawMessage
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
@@ -363,12 +353,11 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 		fileCount := 0
 		for _, part := range parts {
 			partType := strings.ToLower(strings.TrimSpace(jsonString(part["type"])))
-			cacheBreakpoint := hasExplicitPromptCacheBreakpoint(part["prompt_cache_breakpoint"])
 			switch partType {
 			case "input_text", "text", "output_text":
 				text := jsonString(part["text"])
 				if text != "" {
-					llmParts = append(llmParts, llm.Part{Type: llm.PartText, Text: text, PromptCacheBreakpoint: cacheBreakpoint})
+					llmParts = append(llmParts, llm.Part{Type: llm.PartText, Text: text})
 				}
 			case "input_image", "image_url":
 				imageURL := jsonImageURL(part["image_url"])

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -139,7 +139,7 @@ Programmatic tool calling is requested with an eligible function tool plus the P
 }
 ```
 
-Every programmatic tool must be present in the request. Optional `output_schema` metadata is preserved for tool definitions. To mark an explicit cache boundary, add `"prompt_cache_breakpoint":{"mode":"explicit"}` to an `input_text`, `input_image`, or `input_file` content block.
+Every programmatic tool must be present in the request. Optional `output_schema` metadata is preserved for tool definitions.
 
 These fields are deliberately gated to the built-in `openai` provider's GPT-5.6 family. Requests using older OpenAI models, custom OpenAI-compatible providers, or ChatGPT OAuth fail validation instead of forwarding unsupported controls. OpenAI Pro and ChatGPT Ultra are distinct: do not send `reasoning.mode: pro` merely because a ChatGPT account has Pro subscription access or a model supports the `ultra` effort.
 

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -534,7 +534,7 @@ Rules and caveats:
 - `reasoning_context` accepts only `auto`, `current_turn`, or `all_turns`.
 - Enabling multi-agent without a concurrency value uses `3`. Multi-agent requests omit the normal reasoning-summary request, send the required beta header, and use HTTP/SSE even when provider WebSocket transport is enabled; WebSocket `response.inject` support is not yet implemented.
 - Programmatic tool calling requires at least one listed tool, and every name must also be present in that request's tool definitions.
-- Prompt-cache `mode` accepts `implicit` or `explicit`; the only supported explicit TTL is `30m`. Explicit content breakpoints are available through the Responses API as `prompt_cache_breakpoint: {"mode":"explicit"}`.
+- Prompt-cache `mode` accepts `implicit` or `explicit`; the only supported explicit TTL is `30m`.
 - Request-level options override populated provider defaults. Ephemeral internal requests, such as title and helper calls, do not inherit provider advanced defaults unless the caller explicitly supplies options.
 
 In terminal chat, `/pro on`, `/pro off`, and `/pro status` set the session's reasoning mode. The setting is persisted with the session and automatically disabled if you switch to a provider/model that does not support it.

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -82,6 +82,54 @@ func TestNewChatGPTResponsesClientUsesCurrentCodexHeaders(t *testing.T) {
 	}
 }
 
+func TestChatGPTStream_CompactionAnchorDoesNotEmitPromptCacheBreakpoint(t *testing.T) {
+	origClient := chatGPTHTTPClient
+	defer func() { chatGPTHTTPClient = origClient }()
+
+	var body []byte
+	chatGPTHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`event: response.completed`,
+				`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+				`data: [DONE]`,
+			}, "\n"))),
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	provider := NewChatGPTProviderWithCreds(&credentials.ChatGPTCredentials{
+		AccessToken: "test-token",
+		AccountID:   "test-account",
+		ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+	}, "gpt-5.6-sol-medium")
+	messages := []Message{{
+		Role:        RoleUser,
+		CacheAnchor: true,
+		Parts:       []Part{{Type: PartText, Text: "[Context Compaction]\nsummary"}},
+	}}
+
+	stream, err := provider.Stream(context.Background(), Request{Messages: messages})
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+	drainStreamToDone(t, stream)
+
+	if strings.Contains(string(body), "prompt_cache_breakpoint") {
+		t.Fatalf("ChatGPT request contains unsupported prompt_cache_breakpoint: %s", body)
+	}
+	if !messages[0].CacheAnchor {
+		t.Fatal("Stream mutated the caller's cache anchor")
+	}
+}
+
 func TestChatGPTStream_IncludesNormalizedServiceTier(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() { chatGPTHTTPClient = origClient }()

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -161,17 +161,12 @@ func (i ResponsesInputItem) MarshalJSON() ([]byte, error) {
 
 // ResponsesContentPart represents a content part (text, image, or file).
 type ResponsesContentPart struct {
-	Type                  string                          `json:"type"`
-	Text                  string                          `json:"text,omitempty"`
-	ImageURL              string                          `json:"image_url,omitempty"` // Plain URL string for Responses API (not object)
-	Detail                string                          `json:"detail,omitempty"`
-	Filename              string                          `json:"filename,omitempty"`
-	FileData              string                          `json:"file_data,omitempty"`
-	PromptCacheBreakpoint *ResponsesPromptCacheBreakpoint `json:"prompt_cache_breakpoint,omitempty"`
-}
-
-type ResponsesPromptCacheBreakpoint struct {
-	Mode string `json:"mode"`
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"` // Plain URL string for Responses API (not object)
+	Detail   string `json:"detail,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data,omitempty"`
 }
 
 // ResponsesTool represents a tool definition in Open Responses format
@@ -326,7 +321,7 @@ func buildResponsesInputItems(messages []Message, policy *FileUploadPolicy) []Re
 	var inputItems []ResponsesInputItem
 	for _, msg := range messages {
 		if msg.Role == RoleSystem || msg.Role == RoleDeveloper {
-			inputItems = append(inputItems, buildResponsesMessageItems("developer", msg.Parts, policy, msg.CacheAnchor)...)
+			inputItems = append(inputItems, buildResponsesMessageItems("developer", msg.Parts, policy)...)
 		} else {
 			inputItems = append(inputItems, buildResponsesInputForRole(msg, policy)...)
 		}
@@ -395,9 +390,9 @@ func BuildResponsesContinuationInputWithFilePolicy(messages []Message, policy *F
 func buildResponsesInputForRole(msg Message, policy *FileUploadPolicy) []ResponsesInputItem {
 	switch msg.Role {
 	case RoleUser:
-		return buildResponsesMessageItems("user", msg.Parts, policy, msg.CacheAnchor)
+		return buildResponsesMessageItems("user", msg.Parts, policy)
 	case RoleDeveloper:
-		return buildResponsesMessageItems("developer", msg.Parts, policy, msg.CacheAnchor)
+		return buildResponsesMessageItems("developer", msg.Parts, policy)
 	case RoleAssistant:
 		return buildResponsesAssistantItems(msg.Parts)
 	case RoleTool:
@@ -430,28 +425,15 @@ func buildResponsesInputForRole(msg Message, policy *FileUploadPolicy) []Respons
 	}
 }
 
-func buildResponsesMessageItems(role string, parts []Part, policy *FileUploadPolicy, cacheAnchor bool) []ResponsesInputItem {
+func buildResponsesMessageItems(role string, parts []Part, policy *FileUploadPolicy) []ResponsesInputItem {
 	var items []ResponsesInputItem
 	var textBuf strings.Builder
-	textBreakpoint := false
-	breakpoint := func(enabled bool) *ResponsesPromptCacheBreakpoint {
-		if !enabled {
-			return nil
-		}
-		return &ResponsesPromptCacheBreakpoint{Mode: "explicit"}
-	}
-
 	flushText := func() {
 		if textBuf.Len() == 0 {
 			return
 		}
-		content := any(textBuf.String())
-		if textBreakpoint {
-			content = []ResponsesContentPart{{Type: "input_text", Text: textBuf.String(), PromptCacheBreakpoint: breakpoint(true)}}
-		}
-		items = append(items, ResponsesInputItem{Type: "message", Role: role, Content: content})
+		items = append(items, ResponsesInputItem{Type: "message", Role: role, Content: textBuf.String()})
 		textBuf.Reset()
-		textBreakpoint = false
 	}
 
 	for _, part := range parts {
@@ -463,20 +445,13 @@ func buildResponsesMessageItems(role string, parts []Part, policy *FileUploadPol
 			}
 		case PartText:
 			if part.Text != "" {
-				if part.PromptCacheBreakpoint {
-					flushText()
-					textBreakpoint = true
-				}
 				textBuf.WriteString(part.Text)
-				if part.PromptCacheBreakpoint {
-					flushText()
-				}
 			}
 		case PartImage:
 			if part.ImageData != nil && strings.TrimSpace(part.ImageData.Base64) != "" {
 				flushText()
 				dataURL := fmt.Sprintf("data:%s;base64,%s", part.ImageData.MediaType, part.ImageData.Base64)
-				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: imageDetail(part.ImageData.Detail), PromptCacheBreakpoint: breakpoint(part.PromptCacheBreakpoint)}}
+				imageParts := []ResponsesContentPart{{Type: "input_image", ImageURL: dataURL, Detail: imageDetail(part.ImageData.Detail)}}
 				if part.ImagePath != "" {
 					imageParts = append(imageParts, ResponsesContentPart{Type: "input_text", Text: "[image saved at: " + part.ImagePath + "]"})
 				}
@@ -493,17 +468,10 @@ func buildResponsesMessageItems(role string, parts []Part, policy *FileUploadPol
 				if mediaType == "" {
 					mediaType = "application/octet-stream"
 				}
-				fileParts := []ResponsesContentPart{{Type: "input_file", Filename: filename, FileData: fmt.Sprintf("data:%s;base64,%s", mediaType, part.FileData.Base64), PromptCacheBreakpoint: breakpoint(part.PromptCacheBreakpoint)}}
+				fileParts := []ResponsesContentPart{{Type: "input_file", Filename: filename, FileData: fmt.Sprintf("data:%s;base64,%s", mediaType, part.FileData.Base64)}}
 				items = append(items, ResponsesInputItem{Type: "message", Role: role, Content: fileParts})
 			} else if text := responseFileTextFallback(part, policy); text != "" {
-				if part.PromptCacheBreakpoint {
-					flushText()
-					textBreakpoint = true
-				}
 				textBuf.WriteString(text)
-				if part.PromptCacheBreakpoint {
-					flushText()
-				}
 			}
 		case PartToolCall:
 			if part.ToolCall == nil {
@@ -522,23 +490,6 @@ func buildResponsesMessageItems(role string, parts []Part, policy *FileUploadPol
 		}
 	}
 	flushText()
-	if cacheAnchor {
-		for i := len(items) - 1; i >= 0; i-- {
-			if items[i].Type != "message" {
-				continue
-			}
-			switch content := items[i].Content.(type) {
-			case string:
-				items[i].Content = []ResponsesContentPart{{Type: "input_text", Text: content, PromptCacheBreakpoint: breakpoint(true)}}
-			case []ResponsesContentPart:
-				if len(content) > 0 {
-					content[len(content)-1].PromptCacheBreakpoint = breakpoint(true)
-					items[i].Content = content
-				}
-			}
-			break
-		}
-	}
 	return items
 }
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -309,7 +309,6 @@ type Part struct {
 	ImagePath                 string         // Local filesystem path to the image (when available, e.g. Telegram uploads)
 	FileData                  *ToolFileData  // User-supplied file (base64-encoded)
 	FilePath                  string         // Local filesystem path to the file (when available)
-	PromptCacheBreakpoint     bool           // Emit an explicit GPT-5.6 prompt-cache breakpoint on this content block.
 	ToolCall                  *ToolCall
 	ToolResult                *ToolResult
 	ProviderReplay            *ProviderReplayItem // Opaque Responses output item used only for stateless continuation.


### PR DESCRIPTION
## What

- remove explicit `prompt_cache_breakpoint` support from the shared Responses serializer used by OpenAI and ChatGPT
- stop translating compaction `CacheAnchor` messages into OpenAI Responses cache markers
- remove inbound API parsing and documentation for per-content cache breakpoints
- retain `CacheAnchor` for Anthropic's explicit `cache_control`, where cache boundaries are required
- add a regression test proving a compacted ChatGPT request does not serialize the unsupported marker

## Why

Compaction summaries are marked with the provider-neutral `CacheAnchor` field, historically consumed by Anthropic. GPT-5.6 support accidentally made the shared Responses serializer turn that field into `prompt_cache_breakpoint` for every OpenAI and ChatGPT request. ChatGPT's `gpt-5.6-sol` rejects the field with HTTP 400, and OpenAI already performs implicit prompt caching without term-llm managing per-content breakpoints.

Explicit caching remains necessary for Anthropic, so its existing cache-control handling is unchanged.

## Verification

- `go build ./...`
- `go test ./internal/llm` passes
- `go test ./cmd` only hits the existing environment-sensitive skill visibility failure in `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir`
