### PR TITLE
fix: Worktree listing performs 7N Git launches and N full session scans

### DIFF
--- a/cmd/serve_worktrees.go
+++ b/cmd/serve_worktrees.go
@@ -146,9 +146,13 @@ func (s *serveServer) handleWorktreeList(w http.ResponseWriter, r *http.Request)
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
+	dirs := make([]string, 0, len(items))
 	for _, wt := range items {
-		inUse, _ := worktree.InUse(r.Context(), s.store, wt.Dir)
-		rows = append(rows, worktreeRow{Name: wt.Name, Dir: wt.Dir, RepoRoot: wt.RepoRoot, Branch: wt.Branch, Detached: wt.Detached, Base: wt.Base, HeadSHA: wt.HeadSHA, DirtyFiles: wt.DirtyFiles, InUse: inUse})
+		dirs = append(dirs, wt.Dir)
+	}
+	inUseByDir, _ := worktree.InUseByDir(r.Context(), s.store, dirs)
+	for _, wt := range items {
+		rows = append(rows, worktreeRow{Name: wt.Name, Dir: wt.Dir, RepoRoot: wt.RepoRoot, Branch: wt.Branch, Detached: wt.Detached, Base: wt.Base, HeadSHA: wt.HeadSHA, DirtyFiles: wt.DirtyFiles, InUse: inUseByDir[wt.Dir]})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"worktrees": rows})
 }

--- a/cmd/serve_worktrees_test.go
+++ b/cmd/serve_worktrees_test.go
@@ -80,6 +80,76 @@ type worktreeAPIResponse struct {
 	Dir  string `json:"dir"`
 }
 
+type countingWorktreeListStore struct {
+	session.NoopStore
+	summaries []session.SessionSummary
+	listCalls int
+	lastOpts  session.ListOptions
+}
+
+func (s *countingWorktreeListStore) List(ctx context.Context, opts session.ListOptions) ([]session.SessionSummary, error) {
+	s.listCalls++
+	s.lastOpts = opts
+	return append([]session.SessionSummary(nil), s.summaries...), nil
+}
+
+func TestServeWorktreeListBatchesSessionUsage(t *testing.T) {
+	repo := newGitRepoForBindingTest(t)
+	wt1, err := worktree.Create(context.Background(), repo, worktree.CreateOptions{Name: "batched-one"})
+	if err != nil {
+		t.Fatalf("Create wt1: %v", err)
+	}
+	t.Cleanup(func() { _ = worktree.Remove(context.Background(), wt1.Dir, worktree.RemoveOptions{Force: true}) })
+	wt2, err := worktree.Create(context.Background(), repo, worktree.CreateOptions{Name: "batched-two"})
+	if err != nil {
+		t.Fatalf("Create wt2: %v", err)
+	}
+	t.Cleanup(func() { _ = worktree.Remove(context.Background(), wt2.Dir, worktree.RemoveOptions{Force: true}) })
+
+	store := &countingWorktreeListStore{summaries: []session.SessionSummary{
+		{ID: "sess-one", Number: 11, Name: "one", WorktreeDir: wt1.Dir, Status: session.StatusActive},
+		{ID: "sess-two", Number: 12, Name: "two", WorktreeDir: wt2.Dir, Status: session.StatusComplete},
+	}}
+	srv := &serveServer{store: store, worktreeRootFn: worktreeRootForTest(repo)}
+	req := httptest.NewRequest(http.MethodGet, "/v1/worktrees", nil)
+	rec := httptest.NewRecorder()
+	srv.handleWorktrees(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("session List calls = %d, want 1", store.listCalls)
+	}
+	if store.lastOpts.Archived || store.lastOpts.Limit != 10000 {
+		t.Fatalf("List options = %+v, want non-archived limit 10000", store.lastOpts)
+	}
+
+	var resp struct {
+		Worktrees []struct {
+			Dir   string                  `json:"dir"`
+			InUse []worktree.InUseSession `json:"in_use,omitempty"`
+		} `json:"worktrees"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	assertInUse := func(dir, id string) {
+		t.Helper()
+		for _, row := range resp.Worktrees {
+			if !sameServePath(row.Dir, dir) {
+				continue
+			}
+			if len(row.InUse) != 1 || row.InUse[0].ID != id {
+				t.Fatalf("worktree %s in_use = %+v, want %s", dir, row.InUse, id)
+			}
+			return
+		}
+		t.Fatalf("worktree %s missing from response: %+v", dir, resp.Worktrees)
+	}
+	assertInUse(wt1.Dir, "sess-one")
+	assertInUse(wt2.Dir, "sess-two")
+}
+
 func TestServeWorktreeMergeCleanupSemantics(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -403,34 +404,62 @@ func listForRoot(mainRoot, bucket string) ([]Worktree, error) {
 		if dir == "" {
 			continue
 		}
+		if _, ok := rec["prunable"]; ok {
+			continue
+		}
 		if samePath(dir, mainRoot) {
 			continue
 		}
-		if !strings.HasPrefix(filepath.Clean(dir), filepath.Clean(bucket)+string(filepath.Separator)) {
+		cleanDir := filepath.Clean(dir)
+		if !strings.HasPrefix(cleanDir, filepath.Clean(bucket)+string(filepath.Separator)) {
 			continue
 		}
-		wt, err := describeWorktree(dir, true)
+		abs, err := filepath.Abs(dir)
 		if err != nil {
 			continue
 		}
-		if m, ok := metasByDir[filepath.Clean(dir)]; ok {
+		branch := branchNameFromPorcelain(rec["branch"])
+		wt := Worktree{
+			Name:     slug(filepath.Base(abs)),
+			Dir:      abs,
+			RepoRoot: mainRoot,
+			Branch:   branch,
+			Detached: branch == "",
+			Status:   StatusReady,
+			HeadSHA:  strings.TrimSpace(rec["HEAD"]),
+		}
+		if wt.Name == "" {
+			wt.Name = filepath.Base(abs)
+		}
+		baseResolved := false
+		if m, ok := metasByDir[cleanDir]; ok {
 			wt.Name = m.Name
 			wt.Base = m.Base
 			wt.Branch = firstNonEmpty(wt.Branch, m.Branch)
 			wt.RepoRoot = m.RepoRoot
 			wt.CreatedAt = m.CreatedAt
 			wt.LastBoundAt = m.LastBoundAt
-		} else {
-			wt.Name = slug(filepath.Base(dir))
-			if wt.Name == "" {
-				wt.Name = filepath.Base(dir)
+			if strings.TrimSpace(wt.Base) == "" {
+				wt.Base, _ = mergeBase(abs, "HEAD")
+				baseResolved = true
+				if strings.TrimSpace(wt.Base) != "" {
+					m.Base = wt.Base
+					_ = writeMetadata(bucket, m)
+				}
 			}
+		} else {
+			wt.Base, _ = mergeBase(abs, "HEAD")
+			baseResolved = true
 			m := metadata{Name: wt.Name, Dir: dir, Base: wt.Base, Branch: wt.Branch, RepoRoot: mainRoot, CreatedAt: time.Now()}
 			_ = writeMetadata(bucket, m)
 		}
-		seen[filepath.Clean(dir)] = true
-		result = append(result, *wt)
+		if strings.TrimSpace(wt.Base) == "" && !baseResolved {
+			wt.Base, _ = mergeBase(abs, "HEAD")
+		}
+		seen[cleanDir] = true
+		result = append(result, wt)
 	}
+	populateDirtyCounts(result)
 	// Drop stale metadata whose directory is no longer in git's worktree list.
 	for dir, m := range metasByDir {
 		if !seen[dir] {
@@ -932,24 +961,48 @@ func MergeBackAndCleanup(ctx context.Context, dir string, opts MergeOptions, sto
 
 // InUse returns non-archived sessions currently bound to dir when the store exposes worktree summaries.
 func InUse(ctx context.Context, store session.Store, dir string) ([]InUseSession, error) {
-	if store == nil {
-		return nil, nil
-	}
-	abs, err := filepath.Abs(dir)
+	byDir, err := InUseByDir(ctx, store, []string{dir})
 	if err != nil {
 		return nil, err
+	}
+	return byDir[dir], nil
+}
+
+// InUseByDir returns non-archived sessions grouped by requested worktree directory.
+func InUseByDir(ctx context.Context, store session.Store, dirs []string) (map[string][]InUseSession, error) {
+	if store == nil || len(dirs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]InUseSession, len(dirs))
+	dirsByKey := make(map[string][]string, len(dirs))
+	for _, dir := range dirs {
+		if _, ok := out[dir]; ok {
+			continue
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return nil, err
+		}
+		key, _ := samePathKey(abs)
+		out[dir] = nil
+		dirsByKey[key] = append(dirsByKey[key], dir)
 	}
 	list, err := store.List(ctx, session.ListOptions{Archived: false, Limit: 10000})
 	if err != nil {
 		return nil, err
 	}
-	var out []InUseSession
 	for _, s := range list {
 		if s.WorktreeDir == "" {
 			continue
 		}
-		if samePath(s.WorktreeDir, abs) {
-			out = append(out, InUseSession{ID: s.ID, Number: s.Number, Name: s.Name, Status: string(s.Status)})
+		key, _ := samePathKey(s.WorktreeDir)
+		matches := dirsByKey[key]
+		if len(matches) == 0 {
+			continue
+		}
+		inUse := InUseSession{ID: s.ID, Number: s.Number, Name: s.Name, Status: string(s.Status)}
+		for _, dir := range matches {
+			out[dir] = append(out[dir], inUse)
 		}
 	}
 	return out, nil
@@ -1026,6 +1079,32 @@ func conflictFiles(root string) []string {
 
 func dirtyCount(dir string) int {
 	return len(statusLines(statusPorcelain(dir)))
+}
+
+func populateDirtyCounts(items []Worktree) {
+	if len(items) == 0 {
+		return
+	}
+	workers := 4
+	if len(items) < workers {
+		workers = len(items)
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				items[idx].DirtyFiles = dirtyCount(items[idx].Dir)
+			}
+		}()
+	}
+	for i := range items {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
 }
 
 func statusPorcelain(dir string) string {
@@ -1330,6 +1409,14 @@ func metadataByDir(root string) map[string]metadata {
 	return out
 }
 
+func branchNameFromPorcelain(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "refs/heads/") {
+		return strings.TrimPrefix(ref, "refs/heads/")
+	}
+	return ref
+}
+
 func parsePorcelainWorktrees(out string) []map[string]string {
 	var records []map[string]string
 	cur := map[string]string{}
@@ -1463,15 +1550,20 @@ func runGitAllowExit(dir string, args []string, allowed map[int]bool) (string, e
 }
 
 func samePath(a, b string) bool {
-	aa, _ := filepath.Abs(a)
-	bb, _ := filepath.Abs(b)
-	if ra, err := filepath.EvalSymlinks(aa); err == nil {
-		aa = ra
+	aa, _ := samePathKey(a)
+	bb, _ := samePathKey(b)
+	return aa == bb
+}
+
+func samePathKey(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path), err
 	}
-	if rb, err := filepath.EvalSymlinks(bb); err == nil {
-		bb = rb
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
 	}
-	return filepath.Clean(aa) == filepath.Clean(bb)
+	return filepath.Clean(abs), nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -62,6 +62,71 @@ func runGitForWorktreeTest(t *testing.T, dir string, args ...string) string {
 	return string(out)
 }
 
+func TestListUsesPorcelainMetadataWithoutPerWorktreeGitProbes(t *testing.T) {
+	repo := newGitRepoForWorktreeTest(t)
+	wt1, err := Create(context.Background(), repo, CreateOptions{Name: "list-fast-one"})
+	if err != nil {
+		t.Fatalf("Create wt1: %v", err)
+	}
+	t.Cleanup(func() { _ = Remove(context.Background(), wt1.Dir, RemoveOptions{Force: true}) })
+	wt2, err := Create(context.Background(), repo, CreateOptions{Name: "list-fast-two"})
+	if err != nil {
+		t.Fatalf("Create wt2: %v", err)
+	}
+	t.Cleanup(func() { _ = Remove(context.Background(), wt2.Dir, RemoveOptions{Force: true}) })
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath git: %v", err)
+	}
+	wrapperDir := t.TempDir()
+	wrapper := filepath.Join(wrapperDir, "git")
+	logPath := filepath.Join(wrapperDir, "git.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s|%s\\n' \"$PWD\" \"$*\" >> \"$TERM_LLM_GIT_LOG\"\n" +
+		"exec \"$TERM_LLM_REAL_GIT\" \"$@\"\n"
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git wrapper: %v", err)
+	}
+	t.Setenv("TERM_LLM_REAL_GIT", realGit)
+	t.Setenv("TERM_LLM_GIT_LOG", logPath)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	items, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("List returned %d worktrees, want 2: %+v", len(items), items)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read git log: %v", err)
+	}
+	worktreeDirs := map[string]bool{filepath.Clean(wt1.Dir): true, filepath.Clean(wt2.Dir): true}
+	statusCalls := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		cwd, args, ok := strings.Cut(line, "|")
+		if !ok || !worktreeDirs[filepath.Clean(cwd)] {
+			continue
+		}
+		if args == "status --porcelain" {
+			statusCalls++
+			continue
+		}
+		if strings.HasPrefix(args, "rev-parse ") || strings.HasPrefix(args, "symbolic-ref ") || strings.HasPrefix(args, "merge-base ") {
+			t.Fatalf("List ran per-worktree metadata probe in %s: git %s\nfull log:\n%s", cwd, args, data)
+		}
+	}
+	if statusCalls != 2 {
+		t.Fatalf("per-worktree status calls = %d, want 2\nfull log:\n%s", statusCalls, data)
+	}
+}
+
 func TestDiffIncludesUntrackedFiles(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- Batched worktree in-use session lookup for the web worktree list endpoint by listing session summaries once and grouping them by canonical worktree path.
- Reworked managed worktree listing to build metadata from `git worktree list --porcelain` instead of re-running per-worktree root/head/branch/base Git probes.
- Kept dirty-file checks as the only per-worktree Git operation and run those checks with bounded concurrency.
- Added regression coverage that verifies one session-list call for multiple worktrees and uses a counting Git wrapper to reject per-worktree metadata probes during `worktree.List`.

## Why this is high-value

The worktree selector is on the interactive web path and is refreshed on initial load, menu open, and after worktree actions. Previously it did one full session summary scan per worktree and around seven serial Git launches per row. This change reduces the session-store work from O(worktrees × sessions) to O(worktrees + sessions), and reduces per-row Git work to only dirty status checks.

## Validation

- `go test ./internal/worktree ./cmd -run 'TestListUsesPorcelainMetadataWithoutPerWorktreeGitProbes|TestServeWorktreeListBatchesSessionUsage' -count=1`
- `go build ./...`
- `git diff --check`
- `go test ./...` was run, but this checkout still fails on unrelated existing tests in this environment:
  - `cmd`: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` does not see the project-local test skill because Sam's user skill registry hits `max_visible_skills=8` first.
  - `internal/jobs`: `TestProgramRunnerDoesNotLeakBackgroundChildren` intermittently reports a still-live background child; rerunning that test alone passed during validation.
