### PR TITLE
test: configure git identity for worktree fixtures

### DIFF
--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -3389,6 +3389,8 @@ func newGitRepoForChatWorktreeTest(t *testing.T) string {
 		t.Fatalf("MkdirAll repo: %v", err)
 	}
 	runGitForChatWorktreeTest(t, repo, "init", "-q")
+	runGitForChatWorktreeTest(t, repo, "config", "user.name", "Test User")
+	runGitForChatWorktreeTest(t, repo, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile README: %v", err)
 	}


### PR DESCRIPTION
## What

Configure a repository-local Git author identity in the chat worktree test fixture.

## Why

CI has failed on every recent `main` push because the new merge tests call `git commit-tree` outside the helper's per-command environment. GitHub's runner has no global author identity, so the snapshot commit aborts with `Author identity unknown`; the two subsequent merge tests then fail as fallout.

## Verification

- Reproduced the CI environment with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1`
- All three failing worktree merge tests pass
- `go build ./...` passes
- Full `go test ./...` passes the affected package; unrelated environment-sensitive failures remain in `cmd` skill discovery and `internal/jobs` process cleanup locally
