### PR TITLE
fix: Ripgrep can hang forever after stderr exceeds the 64 KiB capture limit

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -326,6 +326,7 @@ func runRipgrep(ctx context.Context, args []string, limits ripgrepCaptureLimits,
 	stderrCh := make(chan []byte, 1)
 	go func() {
 		data, _ := io.ReadAll(io.LimitReader(stderr, 64*1024))
+		_, _ = io.Copy(io.Discard, stderr)
 		stderrCh <- data
 	}()
 

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -4,13 +4,56 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestRunRipgrepDrainsStderrBeyondCaptureLimit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake rg executable uses a POSIX shell wrapper")
+	}
+
+	fakeDir := t.TempDir()
+	fakeRG := filepath.Join(fakeDir, "rg")
+	script := "#!/bin/sh\nexec \"$FAKE_RG_TEST_BINARY\" -test.run=TestRipgrepStderrHelperProcess\n"
+	if err := os.WriteFile(fakeRG, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake rg: %v", err)
+	}
+	t.Setenv("FAKE_RG_TEST_BINARY", os.Args[0])
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _, err := runRipgrep(ctx, nil, defaultRipgrepCaptureLimits(), 0, false)
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("runRipgrep blocked after its stderr capture limit was reached")
+	}
+	if err == nil {
+		t.Fatal("expected fake rg failure")
+	}
+	const prefix = "ripgrep failed: "
+	if !strings.HasPrefix(err.Error(), prefix) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(err.Error()) > len(prefix)+64*1024 {
+		t.Fatalf("stderr diagnostic exceeded capture limit: %d bytes", len(err.Error())-len(prefix))
+	}
+}
+
+func TestRipgrepStderrHelperProcess(t *testing.T) {
+	if os.Getenv("FAKE_RG_TEST_BINARY") == "" {
+		return
+	}
+	_, _ = os.Stderr.Write(bytes.Repeat([]byte("x"), 4*1024*1024))
+	os.Exit(2)
+}
 
 func TestCaptureRipgrepOutputStopsNearByteCapForOversizedLine(t *testing.T) {
 	limits := ripgrepCaptureLimits{maxOutputLines: 100, maxBufferedBytes: 1024}


### PR DESCRIPTION
## What changed

- Continue draining ripgrep's stderr pipe to EOF after retaining the existing bounded 64 KiB diagnostic prefix.
- Add a regression test that places a fake `rg` first in `PATH`, writes 4 MiB to stderr, and verifies `runRipgrep` returns promptly with bounded diagnostic text.

## Why this is high-value

The grep tool is a daily agent path. Previously, once ripgrep wrote more than the 64 KiB capture limit plus the OS pipe capacity, the stderr reader stopped consuming data and ripgrep blocked on its full pipe. The stdout reader then waited forever for EOF, wedging the active provider/tool loop. Draining excess diagnostics prevents that deadlock without increasing diagnostic memory use or changing successful grep behavior.

## Validation

- `gofmt -w internal/tools/grep.go internal/tools/grep_test.go`
- `go build ./...`
- `go test ./internal/tools -run TestRunRipgrepDrainsStderrBeyondCaptureLimit -count=10`
- `go test ./...` (all changed-package tests pass; the repository-wide run encountered unrelated existing failures in `cmd` skill-visibility isolation and `internal/jobs` background-child cleanup)
- `git diff --check`
