### PR TITLE
feat: preserve MCP image tool results

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
 	mcpTui "github.com/samsaffron/term-llm/internal/tui/mcp"
 	"github.com/spf13/cobra"
@@ -794,8 +795,41 @@ func mcpRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("call %s: %w", call.name, err)
 		}
 
-		fmt.Println(result)
+		if err := renderMCPToolResult(cmd.OutOrStdout(), result); err != nil {
+			return fmt.Errorf("format result for %s: %w", call.name, err)
+		}
+		if err := mcpToolResultError(call.name, result); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func mcpToolResultError(name string, result llm.ToolOutput) error {
+	if result.IsError {
+		return fmt.Errorf("tool %s returned an error", name)
+	}
+	return nil
+}
+
+func renderMCPToolResult(w io.Writer, result llm.ToolOutput) error {
+	hasImage := false
+	for _, part := range result.ContentParts {
+		if part.Type == llm.ToolContentPartImageData {
+			hasImage = true
+			break
+		}
+	}
+	if !hasImage {
+		_, err := fmt.Fprintln(w, result.Content)
+		return err
+	}
+
+	data, err := json.MarshalIndent(result.ContentParts, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
 }

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
 	"github.com/spf13/cobra"
 )
@@ -79,6 +82,37 @@ func TestMCPRunArgCompletionUsesCachedTools(t *testing.T) {
 		t.Fatalf("directive = %v, want %v", directive, wantDirective)
 	}
 }
+func TestMCPRunIsErrorRendersThenFails(t *testing.T) {
+	result := llm.ToolOutput{
+		Content: "tool failed usefully",
+		IsError: true,
+	}
+	var output bytes.Buffer
+	if err := renderMCPToolResult(&output, result); err != nil {
+		t.Fatalf("renderMCPToolResult() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "tool failed usefully") {
+		t.Fatalf("rendered output = %q, want useful error content", output.String())
+	}
+	if err := mcpToolResultError("failure", result); err == nil {
+		t.Fatal("IsError result must retain non-zero command behavior")
+	}
+}
+
+func TestRenderMCPToolResultImageOnly(t *testing.T) {
+	result := llm.ToolOutput{ContentParts: []llm.ToolContentPart{{
+		Type:      llm.ToolContentPartImageData,
+		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="},
+	}}}
+	var output bytes.Buffer
+	if err := renderMCPToolResult(&output, result); err != nil {
+		t.Fatalf("renderMCPToolResult() error = %v", err)
+	}
+	if !strings.Contains(output.String(), `"type": "image_data"`) || !strings.Contains(output.String(), `"base64": "aGVsbG8="`) {
+		t.Fatalf("rendered image output = %q", output.String())
+	}
+}
+
 func TestParseValue(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -1783,9 +1783,8 @@ func truncateMessageParts(msg Message, maxChars int) Message {
 		if part.Text != "" {
 			result.Parts[i].Text = TruncateToolResult(part.Text, maxChars)
 		}
-		if part.ToolResult != nil && len(part.ToolResult.Content) > maxChars {
-			tr := *part.ToolResult
-			tr.Content = TruncateToolResult(tr.Content, maxChars)
+		if part.ToolResult != nil {
+			tr := truncateToolResult(*part.ToolResult, maxChars)
 			result.Parts[i].ToolResult = &tr
 		}
 	}

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -850,21 +850,21 @@ func (e *Engine) continueWithAutoInterjections(ctx context.Context, send eventSe
 }
 
 // applyToolOutputTruncation applies global and compaction truncation limits
-// to tool output content. Global limit fires first (typically stricter),
-// then compaction limit as a secondary safety net.
-func (e *Engine) applyToolOutputTruncation(content string) string {
+// to all textual tool output, including structured content parts. Global limit
+// fires first (typically stricter), then compaction limit as a safety net.
+func (e *Engine) applyToolOutputTruncation(output ToolOutput) ToolOutput {
 	e.callbackMu.RLock()
 	maxChars := e.maxToolOutputChars
 	cc := e.compactionConfig
 	e.callbackMu.RUnlock()
 
 	if maxChars > 0 {
-		content = TruncateToolResult(content, maxChars)
+		output = truncateToolOutput(output, maxChars)
 	}
 	if cc != nil && cc.MaxToolResultChars > 0 {
-		content = TruncateToolResult(content, cc.MaxToolResultChars)
+		output = truncateToolOutput(output, cc.MaxToolResultChars)
 	}
-	return content
+	return output
 }
 
 // getCompactionCallback returns the current compaction callback under read lock.
@@ -3193,7 +3193,7 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send 
 
 	// Truncate large tool outputs (global limit, then compaction limit).
 	if err == nil {
-		output.Content = e.applyToolOutputTruncation(output.Content)
+		output = e.applyToolOutputTruncation(output)
 	}
 
 	if err != nil {
@@ -3275,7 +3275,7 @@ func (e *Engine) handleSyncToolExecution(ctx context.Context, event Event, send 
 
 	// Truncate large tool outputs (global limit, then compaction limit).
 	if err == nil {
-		result.Content = e.applyToolOutputTruncation(result.Content)
+		result = e.applyToolOutputTruncation(result)
 	}
 
 	// Debug logging

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -149,14 +149,17 @@ type ollamaMsgChunk struct {
 
 // buildOllamaMessages converts internal messages to Ollama's native format.
 // Ollama tool results use role "tool" with plain text content; tool calls have
-// no ID field. Developer-role messages are folded into the next user turn.
+// no ID field. Tool-result images are delivered in a following synthetic user
+// message because Ollama does not currently accept images on tool messages.
+// Developer-role messages are folded into the next user turn.
 func buildOllamaMessages(messages []Message) []ollamaChatMsg {
 	messages = sanitizeToolHistory(messages)
 
 	var result []ollamaChatMsg
 	var pendingDev string
 
-	for _, msg := range messages {
+	for i := 0; i < len(messages); i++ {
+		msg := messages[i]
 		switch msg.Role {
 		case RoleDeveloper:
 			text, _, _ := splitParts(msg.Parts)
@@ -205,13 +208,56 @@ func buildOllamaMessages(messages []Message) []ollamaChatMsg {
 				result = append(result, ollamaChatMsg{Role: "assistant", Content: text})
 			}
 		case RoleTool:
-			for _, part := range msg.Parts {
-				if part.Type != PartToolResult || part.ToolResult == nil {
-					continue
+			var toolImages []string
+			var imageToolNames []string
+			for ; i < len(messages) && messages[i].Role == RoleTool; i++ {
+				for _, part := range messages[i].Parts {
+					if part.Type != PartToolResult || part.ToolResult == nil {
+						continue
+					}
+
+					content := toolResultTextContent(part.ToolResult)
+					var images []string
+					invalidImages := 0
+					for _, contentPart := range toolResultContentParts(part.ToolResult) {
+						if contentPart.Type != ToolContentPartImageData {
+							continue
+						}
+						_, base64Data, ok := toolResultImageData(contentPart)
+						if !ok {
+							invalidImages++
+							continue
+						}
+						images = append(images, base64Data)
+					}
+
+					if invalidImages > 0 {
+						warning := fmt.Sprintf("[Ollama omitted %d invalid or unsupported tool-result image(s).]", invalidImages)
+						if content == "" {
+							content = warning
+						} else {
+							content += "\n\n" + warning
+						}
+					}
+					if content == "" && len(images) > 0 {
+						content = fmt.Sprintf("[Tool %q returned %d image(s), attached in the following user message.]", part.ToolResult.Name, len(images))
+					}
+					result = append(result, ollamaChatMsg{Role: "tool", Content: content})
+					if len(images) > 0 {
+						toolImages = append(toolImages, images...)
+						imageToolNames = append(imageToolNames, part.ToolResult.Name)
+					}
 				}
+			}
+			i-- // The outer loop advances to the first message after this tool-result run.
+			if len(toolImages) > 0 {
+				// Ollama currently ignores/rejects images on role=tool. A
+				// synthetic user turn is the documented-compatible way to
+				// actually place tool-produced images in model context.
 				result = append(result, ollamaChatMsg{
-					Role:    "tool",
-					Content: toolResultTextContent(part.ToolResult),
+					Role:    "user",
+					Content: fmt.Sprintf("Image(s) returned by tool(s) %q.", strings.Join(imageToolNames, ", ")),
+					Images:  toolImages,
 				})
 			}
 		}

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -448,6 +448,127 @@ func TestBuildOllamaMessagesDeveloperRole(t *testing.T) {
 	}
 }
 
+func TestBuildOllamaMessagesToolResultImageFallback(t *testing.T) {
+	msgs := []Message{
+		UserText("inspect it"),
+		{Role: RoleAssistant, Parts: []Part{{
+			Type:     PartToolCall,
+			ToolCall: &ToolCall{ID: "call-1", Name: "inspect", Arguments: json.RawMessage(`{}`)},
+		}}},
+		ToolResultMessageFromOutput("call-1", "inspect", ToolOutput{
+			ContentParts: []ToolContentPart{{
+				Type:      ToolContentPartImageData,
+				ImageData: &ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="},
+			}},
+		}, nil),
+	}
+
+	result := buildOllamaMessages(msgs)
+	if len(result) != 4 {
+		t.Fatalf("expected user, assistant, tool, image fallback; got %#v", result)
+	}
+	if result[2].Role != "tool" || !strings.Contains(result[2].Content, "following user message") {
+		t.Fatalf("image-only tool result was silent: %#v", result[2])
+	}
+	if result[3].Role != "user" || len(result[3].Images) != 1 || result[3].Images[0] != "aGVsbG8=" {
+		t.Fatalf("tool image was not delivered through explicit user fallback: %#v", result[3])
+	}
+	if !strings.Contains(result[3].Content, "inspect") {
+		t.Fatalf("fallback does not identify tool provenance: %#v", result[3])
+	}
+}
+
+func TestBuildOllamaMessagesAggregatesConsecutiveToolResultImages(t *testing.T) {
+	toolCalls := func(calls ...ToolCall) Message {
+		parts := make([]Part, 0, len(calls))
+		for i := range calls {
+			call := calls[i]
+			parts = append(parts, Part{Type: PartToolCall, ToolCall: &call})
+		}
+		return Message{Role: RoleAssistant, Parts: parts}
+	}
+	imageOutput := func(mediaType, data string, text ...string) ToolOutput {
+		parts := make([]ToolContentPart, 0, len(text)+1)
+		for _, content := range text {
+			parts = append(parts, ToolContentPart{Type: ToolContentPartText, Text: content})
+		}
+		parts = append(parts, ToolContentPart{
+			Type:      ToolContentPartImageData,
+			ImageData: &ToolImageData{MediaType: mediaType, Base64: data},
+		})
+		return ToolOutput{ContentParts: parts}
+	}
+
+	msgs := []Message{
+		UserText("first turn"),
+		toolCalls(
+			ToolCall{ID: "call-early", Name: "early", Arguments: json.RawMessage(`{}`)},
+			ToolCall{ID: "call-mixed", Name: "mixed", Arguments: json.RawMessage(`{}`)},
+			ToolCall{ID: "call-text", Name: "text", Arguments: json.RawMessage(`{}`)},
+		),
+		ToolResultMessageFromOutput("call-early", "early", imageOutput("image/png", "ZWFybHk="), nil),
+		ToolResultMessageFromOutput("call-mixed", "mixed", imageOutput("image/webp", "bWl4ZWQ=", "mixed text"), nil),
+		ToolResultMessage("call-text", "text", "text only", nil),
+		UserText("second turn"),
+		toolCalls(ToolCall{ID: "call-later", Name: "later", Arguments: json.RawMessage(`{}`)}),
+		ToolResultMessageFromOutput("call-later", "later", imageOutput("image/gif", "bGF0ZXI="), nil),
+	}
+
+	result := buildOllamaMessages(msgs)
+	if len(result) != 10 {
+		t.Fatalf("expected two complete tool runs with separate image fallbacks; got %#v", result)
+	}
+	wantRoles := []string{"user", "assistant", "tool", "tool", "tool", "user", "user", "assistant", "tool", "user"}
+	for i, role := range wantRoles {
+		if result[i].Role != role {
+			t.Fatalf("message %d role = %q, want %q; messages: %#v", i, result[i].Role, role, result)
+		}
+	}
+	if result[3].Content != "mixed text" {
+		t.Fatalf("mixed image/text tool content = %q, want text preserved", result[3].Content)
+	}
+	if got := result[5].Images; len(got) != 2 || got[0] != "ZWFybHk=" || got[1] != "bWl4ZWQ=" {
+		t.Fatalf("first tool-run images = %#v, want early and mixed images in order", got)
+	}
+	if !strings.Contains(result[5].Content, "early") || !strings.Contains(result[5].Content, "mixed") {
+		t.Fatalf("first fallback provenance = %q, want both image tools", result[5].Content)
+	}
+	if got := result[9].Images; len(got) != 1 || got[0] != "bGF0ZXI=" {
+		t.Fatalf("second tool-run images = %#v, want no cross-turn aggregation", got)
+	}
+	if strings.Contains(result[9].Content, "early") || strings.Contains(result[9].Content, "mixed") {
+		t.Fatalf("second fallback leaked first-turn provenance: %q", result[9].Content)
+	}
+}
+
+func TestBuildOllamaMessagesMalformedToolResultImagesAreVisible(t *testing.T) {
+	msgs := []Message{
+		UserText("inspect it"),
+		{Role: RoleAssistant, Parts: []Part{{
+			Type:     PartToolCall,
+			ToolCall: &ToolCall{ID: "call-1", Name: "inspect", Arguments: json.RawMessage(`{}`)},
+		}}},
+		ToolResultMessageFromOutput("call-1", "inspect", ToolOutput{
+			ContentParts: []ToolContentPart{
+				{Type: ToolContentPartImageData, ImageData: &ToolImageData{MediaType: "image/png"}},
+				{Type: ToolContentPartImageData, ImageData: &ToolImageData{MediaType: "image/png", Base64: "not-base64"}},
+				{Type: ToolContentPartImageData, ImageData: &ToolImageData{MediaType: "image/svg+xml", Base64: "PHN2Zz4="}},
+			},
+		}, nil),
+	}
+
+	result := buildOllamaMessages(msgs)
+	if len(result) != 3 {
+		t.Fatalf("invalid images must not create a fake delivered-image message: %#v", result)
+	}
+	if result[2].Role != "tool" || !strings.Contains(result[2].Content, "omitted 3 invalid or unsupported") {
+		t.Fatalf("malformed images were silently dropped: %#v", result[2])
+	}
+	if len(result[2].Images) != 0 {
+		t.Fatalf("invalid images were sent: %#v", result[2].Images)
+	}
+}
+
 func TestOllamaProviderListModels(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/tags" {

--- a/internal/llm/tool_result_content.go
+++ b/internal/llm/tool_result_content.go
@@ -42,6 +42,88 @@ func toolResultTextContent(result *ToolResult) string {
 	return b.String()
 }
 
+// truncateToolOutput applies a single aggregate text limit across structured
+// content parts. Images and part ordering are preserved, while the retained
+// head and tail text use the same marker as plain tool output truncation.
+func truncateToolOutput(output ToolOutput, maxChars int) ToolOutput {
+	content, parts := truncateToolResultContent(output.Content, output.ContentParts, maxChars)
+	output.Content = content
+	output.ContentParts = parts
+	return output
+}
+
+func truncateToolResultContent(content string, parts []ToolContentPart, maxChars int) (string, []ToolContentPart) {
+	if len(parts) == 0 {
+		return TruncateToolResult(content, maxChars), nil
+	}
+
+	parts = cloneToolContentParts(parts)
+	var text strings.Builder
+	for _, part := range parts {
+		if part.Type == ToolContentPartText {
+			text.WriteString(part.Text)
+		}
+	}
+
+	textRunes := []rune(text.String())
+	if len(textRunes) == 0 {
+		// Image-only structured results may still carry a textual fallback.
+		return TruncateToolResult(content, maxChars), parts
+	}
+	if len(textRunes) <= maxChars {
+		// Structured text is canonical. Do not retain a divergent, potentially
+		// unbounded second copy in Content.
+		return string(textRunes), parts
+	}
+
+	head := maxChars / 2
+	tail := maxChars - head
+	middle := string(textRunes[head : len(textRunes)-tail])
+	marker := fmt.Sprintf("\n[...%d chars truncated - %d lines...]\n", len(textRunes)-maxChars, 1+strings.Count(middle, "\n"))
+	tailStart := len(textRunes) - tail
+	textOffset := 0
+	markerAdded := false
+
+	for i := range parts {
+		if parts[i].Type != ToolContentPartText {
+			continue
+		}
+		runes := []rune(parts[i].Text)
+		start := textOffset
+		end := start + len(runes)
+		var retained strings.Builder
+
+		if start < head {
+			prefixEnd := min(end, head) - start
+			retained.WriteString(string(runes[:prefixEnd]))
+		}
+		if !markerAdded && end >= head {
+			retained.WriteString(marker)
+			markerAdded = true
+		}
+		if end > tailStart {
+			suffixStart := max(start, tailStart) - start
+			retained.WriteString(string(runes[suffixStart:]))
+		}
+
+		parts[i].Text = retained.String()
+		textOffset = end
+	}
+
+	var flattened strings.Builder
+	for _, part := range parts {
+		if part.Type == ToolContentPartText {
+			flattened.WriteString(part.Text)
+		}
+	}
+	return flattened.String(), parts
+}
+
+func truncateToolResult(result ToolResult, maxChars int) ToolResult {
+	result.Content, result.ContentParts = truncateToolResultContent(result.Content, result.ContentParts, maxChars)
+	return result
+}
+
 func toolResultImageData(part ToolContentPart) (mediaType, base64Data string, ok bool) {
 	if part.Type != ToolContentPartImageData || part.ImageData == nil {
 		return "", "", false

--- a/internal/llm/tool_result_content_test.go
+++ b/internal/llm/tool_result_content_test.go
@@ -1,0 +1,113 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateToolOutputStructuredContent(t *testing.T) {
+	image := &ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="}
+	original := ToolOutput{
+		Content: strings.Repeat("unbounded fallback", 20),
+		ContentParts: []ToolContentPart{
+			{Type: ToolContentPartText, Text: "abcdefghij"},
+			{Type: ToolContentPartImageData, ImageData: image},
+			{Type: ToolContentPartText, Text: "klmnopqrst"},
+		},
+	}
+
+	got := truncateToolOutput(original, 10)
+	if len(got.ContentParts) != 3 {
+		t.Fatalf("ContentParts length = %d, want 3", len(got.ContentParts))
+	}
+	if got.ContentParts[0].Type != ToolContentPartText ||
+		got.ContentParts[1].Type != ToolContentPartImageData ||
+		got.ContentParts[2].Type != ToolContentPartText {
+		t.Fatalf("ContentParts order changed: %#v", got.ContentParts)
+	}
+	if got.ContentParts[1].ImageData == nil || got.ContentParts[1].ImageData.Base64 != image.Base64 {
+		t.Fatalf("image was not preserved: %#v", got.ContentParts[1])
+	}
+	if got.ContentParts[1].ImageData == image {
+		t.Fatal("image metadata was not cloned")
+	}
+	if !strings.HasPrefix(got.ContentParts[0].Text, "abcde") || !strings.Contains(got.ContentParts[0].Text, "10 chars truncated") {
+		t.Fatalf("first text part = %q, want retained head and marker", got.ContentParts[0].Text)
+	}
+	if got.ContentParts[2].Text != "pqrst" {
+		t.Fatalf("last text part = %q, want retained tail", got.ContentParts[2].Text)
+	}
+	if got.Content != got.ContentParts[0].Text+got.ContentParts[2].Text {
+		t.Fatalf("Content = %q, want flattened bounded structured text", got.Content)
+	}
+	if strings.Contains(got.Content, "unbounded fallback") {
+		t.Fatalf("Content retained stale unbounded fallback: %q", got.Content)
+	}
+
+	if original.ContentParts[0].Text != "abcdefghij" || original.ContentParts[2].Text != "klmnopqrst" {
+		t.Fatalf("original output was mutated: %#v", original.ContentParts)
+	}
+}
+
+func TestTruncateToolOutputImageOnlyFallback(t *testing.T) {
+	got := truncateToolOutput(ToolOutput{
+		Content: strings.Repeat("x", 100),
+		ContentParts: []ToolContentPart{{
+			Type:      ToolContentPartImageData,
+			ImageData: &ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="},
+		}},
+	}, 20)
+
+	if len(got.ContentParts) != 1 || got.ContentParts[0].Type != ToolContentPartImageData {
+		t.Fatalf("image-only parts changed: %#v", got.ContentParts)
+	}
+	if !strings.Contains(got.Content, "80 chars truncated") {
+		t.Fatalf("image-only text fallback was not truncated: %q", got.Content)
+	}
+}
+
+func TestEngineApplyCompactionToolResultLimitCoversContentParts(t *testing.T) {
+	engine := NewEngine(nil, nil)
+	config := DefaultCompactionConfig()
+	config.MaxToolResultChars = 6
+	engine.SetCompaction(1000, config)
+
+	got := engine.applyToolOutputTruncation(ToolOutput{
+		ContentParts: []ToolContentPart{
+			{Type: ToolContentPartText, Text: "abcdef"},
+			{Type: ToolContentPartImageData, ImageData: &ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="}},
+			{Type: ToolContentPartText, Text: "ghijkl"},
+		},
+	})
+
+	if !strings.Contains(got.Content, "6 chars truncated") {
+		t.Fatalf("structured output bypassed compaction tool-result limit: %q", got.Content)
+	}
+	if got.ContentParts[1].Type != ToolContentPartImageData {
+		t.Fatalf("mixed content order changed: %#v", got.ContentParts)
+	}
+}
+
+func TestEngineApplyToolOutputTruncationCoversContentParts(t *testing.T) {
+	engine := NewEngine(nil, nil)
+	engine.SetMaxToolOutputChars(8)
+
+	got := engine.applyToolOutputTruncation(ToolOutput{
+		Content: "stale and unbounded",
+		ContentParts: []ToolContentPart{
+			{Type: ToolContentPartText, Text: "123456"},
+			{Type: ToolContentPartImageData, ImageData: &ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="}},
+			{Type: ToolContentPartText, Text: "789012"},
+		},
+	})
+
+	if !strings.Contains(got.Content, "4 chars truncated") {
+		t.Fatalf("structured output bypassed engine truncation: %q", got.Content)
+	}
+	if got.ContentParts[1].Type != ToolContentPartImageData {
+		t.Fatalf("mixed content order changed: %#v", got.ContentParts)
+	}
+	if got.Content != got.ContentParts[0].Text+got.ContentParts[2].Text {
+		t.Fatalf("Content and ContentParts diverged: content=%q parts=%#v", got.Content, got.ContentParts)
+	}
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -2,9 +2,11 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/procutil"
 )
 
@@ -269,21 +272,21 @@ func (c *Client) refreshTools(ctx context.Context) error {
 }
 
 // CallTool invokes a tool on the MCP server.
-func (c *Client) CallTool(ctx context.Context, name string, args json.RawMessage) (string, error) {
+func (c *Client) CallTool(ctx context.Context, name string, args json.RawMessage) (llm.ToolOutput, error) {
 	c.mu.RLock()
 	session := c.session
 	running := c.running
 	c.mu.RUnlock()
 
 	if !running || session == nil {
-		return "", fmt.Errorf("MCP server %s is not running", c.name)
+		return llm.ToolOutput{}, fmt.Errorf("MCP server %s is not running", c.name)
 	}
 
 	// Parse arguments
 	var arguments map[string]any
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &arguments); err != nil {
-			return "", fmt.Errorf("invalid tool arguments: %w", err)
+			return llm.ToolOutput{}, fmt.Errorf("invalid tool arguments: %w", err)
 		}
 	}
 
@@ -292,29 +295,86 @@ func (c *Client) CallTool(ctx context.Context, name string, args json.RawMessage
 		Arguments: arguments,
 	})
 	if err != nil {
-		return "", fmt.Errorf("call tool %s: %w", name, err)
+		return llm.ToolOutput{}, fmt.Errorf("call tool %s: %w", name, err)
 	}
 
-	if result.IsError {
-		return "", fmt.Errorf("tool %s returned error: %s", name, formatContent(result.Content))
-	}
-
-	return formatContent(result.Content), nil
+	output := formatContent(result.Content)
+	output.IsError = result.IsError
+	return output, nil
 }
 
-// formatContent converts MCP content to a string.
-func formatContent(content []mcp.Content) string {
-	var sb strings.Builder
-	for _, c := range content {
-		switch v := c.(type) {
+// formatContent converts MCP content to ordered LLM tool-result content. Content
+// remains the concatenation of all textual parts for callers and providers that
+// only understand text.
+func formatContent(content []mcp.Content) llm.ToolOutput {
+	output := llm.ToolOutput{
+		ContentParts: make([]llm.ToolContentPart, 0, len(content)),
+	}
+	var text strings.Builder
+
+	for _, contentPart := range content {
+		switch part := contentPart.(type) {
 		case *mcp.TextContent:
-			sb.WriteString(v.Text)
-		default:
-			// For other content types, try JSON encoding
-			if data, err := json.Marshal(c); err == nil {
-				sb.WriteString(string(data))
+			if part == nil {
+				appendTextContentPart(&output, &text, fallbackContent(part))
+				continue
 			}
+			appendTextContentPart(&output, &text, part.Text)
+		case *mcp.ImageContent:
+			if mediaType, ok := supportedImageMediaType(part); ok {
+				output.ContentParts = append(output.ContentParts, llm.ToolContentPart{
+					Type: llm.ToolContentPartImageData,
+					ImageData: &llm.ToolImageData{
+						MediaType: mediaType,
+						Base64:    base64.StdEncoding.EncodeToString(part.Data),
+					},
+				})
+				continue
+			}
+			appendTextContentPart(&output, &text, fallbackContent(part))
+		default:
+			// The current LLM result model cannot represent audio or resources.
+			// Keep their MCP JSON as text rather than silently dropping them.
+			appendTextContentPart(&output, &text, fallbackContent(contentPart))
 		}
 	}
-	return sb.String()
+
+	output.Content = text.String()
+	if len(output.ContentParts) == 0 {
+		output.ContentParts = nil
+	}
+	return output
+}
+
+func appendTextContentPart(output *llm.ToolOutput, text *strings.Builder, content string) {
+	output.ContentParts = append(output.ContentParts, llm.ToolContentPart{
+		Type: llm.ToolContentPartText,
+		Text: content,
+	})
+	text.WriteString(content)
+}
+
+func supportedImageMediaType(content *mcp.ImageContent) (string, bool) {
+	if content == nil || len(content.Data) == 0 {
+		return "", false
+	}
+	mediaType, _, err := mime.ParseMediaType(content.MIMEType)
+	if err != nil {
+		return "", false
+	}
+	mediaType = strings.ToLower(mediaType)
+	switch mediaType {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return mediaType, true
+	default:
+		return "", false
+	}
+}
+
+func fallbackContent(content mcp.Content) string {
+	data, err := json.Marshal(content)
+	if err == nil {
+		return string(data)
+	}
+	return fmt.Sprintf("[unsupported MCP content %T; JSON encoding failed: %v]", content, err)
 }

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -2,10 +2,12 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -14,6 +16,7 @@ import (
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -384,4 +387,126 @@ func mcpProcStatState(data []byte) (byte, bool) {
 		return 0, false
 	}
 	return stat[end+2], true
+}
+
+func TestFormatContent(t *testing.T) {
+	imagePart := func(mimeType string, data []byte) llm.ToolContentPart {
+		return llm.ToolContentPart{
+			Type: llm.ToolContentPartImageData,
+			ImageData: &llm.ToolImageData{
+				MediaType: mimeType,
+				Base64:    base64.StdEncoding.EncodeToString(data),
+			},
+		}
+	}
+	textPart := func(text string) llm.ToolContentPart {
+		return llm.ToolContentPart{Type: llm.ToolContentPartText, Text: text}
+	}
+
+	tests := []struct {
+		name    string
+		content []sdkmcp.Content
+		want    llm.ToolOutput
+	}{
+		{
+			name:    "text only compatibility",
+			content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "hello"}, &sdkmcp.TextContent{Text: " world"}},
+			want: llm.ToolOutput{
+				Content:      "hello world",
+				ContentParts: []llm.ToolContentPart{textPart("hello"), textPart(" world")},
+			},
+		},
+		{
+			name:    "image only",
+			content: []sdkmcp.Content{&sdkmcp.ImageContent{MIMEType: "image/png", Data: []byte("png bytes")}},
+			want: llm.ToolOutput{
+				ContentParts: []llm.ToolContentPart{imagePart("image/png", []byte("png bytes"))},
+			},
+		},
+		{
+			name:    "image MIME type is case normalized",
+			content: []sdkmcp.Content{&sdkmcp.ImageContent{MIMEType: "Image/PNG", Data: []byte("png bytes")}},
+			want: llm.ToolOutput{
+				ContentParts: []llm.ToolContentPart{imagePart("image/png", []byte("png bytes"))},
+			},
+		},
+		{
+			name:    "image MIME parameters are removed",
+			content: []sdkmcp.Content{&sdkmcp.ImageContent{MIMEType: `image/png; profile="example"`, Data: []byte("png bytes")}},
+			want: llm.ToolOutput{
+				ContentParts: []llm.ToolContentPart{imagePart("image/png", []byte("png bytes"))},
+			},
+		},
+		{
+			name: "mixed content preserves ordering",
+			content: []sdkmcp.Content{
+				&sdkmcp.TextContent{Text: "before"},
+				&sdkmcp.ImageContent{MIMEType: "image/webp", Data: []byte("webp bytes")},
+				&sdkmcp.TextContent{Text: "after"},
+			},
+			want: llm.ToolOutput{
+				Content: "beforeafter",
+				ContentParts: []llm.ToolContentPart{
+					textPart("before"),
+					imagePart("image/webp", []byte("webp bytes")),
+					textPart("after"),
+				},
+			},
+		},
+		{
+			name: "unsupported content is retained as text",
+			content: []sdkmcp.Content{
+				&sdkmcp.AudioContent{MIMEType: "audio/wav", Data: []byte("audio")},
+				&sdkmcp.ResourceLink{URI: "https://example.com/file", Name: "file"},
+			},
+			want: llm.ToolOutput{
+				Content: `{"type":"audio","mimeType":"audio/wav","data":"YXVkaW8="}{"type":"resource_link","uri":"https://example.com/file","name":"file"}`,
+				ContentParts: []llm.ToolContentPart{
+					textPart(`{"type":"audio","mimeType":"audio/wav","data":"YXVkaW8="}`),
+					textPart(`{"type":"resource_link","uri":"https://example.com/file","name":"file"}`),
+				},
+			},
+		},
+		{
+			name:    "empty image falls back to MCP JSON",
+			content: []sdkmcp.Content{&sdkmcp.ImageContent{MIMEType: "image/png"}},
+			want: llm.ToolOutput{
+				Content:      `{"type":"image","mimeType":"image/png","data":""}`,
+				ContentParts: []llm.ToolContentPart{textPart(`{"type":"image","mimeType":"image/png","data":""}`)},
+			},
+		},
+		{
+			name:    "unsupported image MIME type falls back to MCP JSON",
+			content: []sdkmcp.Content{&sdkmcp.ImageContent{MIMEType: "image/svg+xml", Data: []byte("svg")}},
+			want: llm.ToolOutput{
+				Content:      `{"type":"image","mimeType":"image/svg+xml","data":"c3Zn"}`,
+				ContentParts: []llm.ToolContentPart{textPart(`{"type":"image","mimeType":"image/svg+xml","data":"c3Zn"}`)},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := formatContent(test.content)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("formatContent() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFormatContent_JSONFailureHasVisibleFallback(t *testing.T) {
+	output := formatContent([]sdkmcp.Content{&sdkmcp.AudioContent{
+		MIMEType: "audio/wav",
+		Data:     []byte("audio"),
+		Meta:     sdkmcp.Meta{"unencodable": make(chan int)},
+	}})
+
+	if len(output.ContentParts) != 1 || output.ContentParts[0].Type != llm.ToolContentPartText {
+		t.Fatalf("ContentParts = %#v, want one text fallback", output.ContentParts)
+	}
+	if !strings.Contains(output.Content, "unsupported MCP content *mcp.AudioContent") ||
+		!strings.Contains(output.Content, "JSON encoding failed") {
+		t.Fatalf("Content = %q, want visible JSON failure fallback", output.Content)
+	}
 }

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -350,11 +350,11 @@ func (m *Manager) AllTools() []ToolSpec {
 
 // CallTool routes a tool call to the appropriate MCP server.
 // Tool names should be prefixed with "servername__".
-func (m *Manager) CallTool(ctx context.Context, fullName string, args json.RawMessage) (string, error) {
+func (m *Manager) CallTool(ctx context.Context, fullName string, args json.RawMessage) (llm.ToolOutput, error) {
 	// Parse server name from tool name
 	serverName, toolName := parseToolName(fullName)
 	if serverName == "" {
-		return "", fmt.Errorf("invalid MCP tool name: %s (expected servername__toolname)", fullName)
+		return llm.ToolOutput{}, fmt.Errorf("invalid MCP tool name: %s (expected servername__toolname)", fullName)
 	}
 
 	m.mu.RLock()
@@ -362,7 +362,7 @@ func (m *Manager) CallTool(ctx context.Context, fullName string, args json.RawMe
 	m.mu.RUnlock()
 
 	if !ok || state.Status != StatusReady || state.Client == nil {
-		return "", fmt.Errorf("MCP server %s is not running", serverName)
+		return llm.ToolOutput{}, fmt.Errorf("MCP server %s is not running", serverName)
 	}
 
 	return state.Client.CallTool(ctx, toolName, args)

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 const runMCPManagerTestServerEnv = "TERM_LLM_MCP_MANAGER_TEST_SERVER"
@@ -33,6 +35,24 @@ func runMCPManagerTestServer() {
 	mcpSDK.AddTool(server, &mcpSDK.Tool{Name: "greet", Description: "say hi"}, func(ctx context.Context, req *mcpSDK.CallToolRequest, args managerTestGreetingParams) (*mcpSDK.CallToolResult, any, error) {
 		return &mcpSDK.CallToolResult{
 			Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: "hi " + args.Name}},
+		}, nil, nil
+	})
+	mcpSDK.AddTool(server, &mcpSDK.Tool{Name: "mixed", Description: "return text and an image"}, func(ctx context.Context, req *mcpSDK.CallToolRequest, args struct{}) (*mcpSDK.CallToolResult, any, error) {
+		return &mcpSDK.CallToolResult{Content: []mcpSDK.Content{
+			&mcpSDK.TextContent{Text: "before"},
+			&mcpSDK.ImageContent{MIMEType: "image/png", Data: []byte("image bytes")},
+			&mcpSDK.TextContent{Text: "after"},
+		}}, nil, nil
+	})
+	mcpSDK.AddTool(server, &mcpSDK.Tool{Name: "image", Description: "return an image"}, func(ctx context.Context, req *mcpSDK.CallToolRequest, args struct{}) (*mcpSDK.CallToolResult, any, error) {
+		return &mcpSDK.CallToolResult{Content: []mcpSDK.Content{
+			&mcpSDK.ImageContent{MIMEType: "image/png", Data: []byte("image only")},
+		}}, nil, nil
+	})
+	mcpSDK.AddTool(server, &mcpSDK.Tool{Name: "failure", Description: "return a tool error"}, func(ctx context.Context, req *mcpSDK.CallToolRequest, args struct{}) (*mcpSDK.CallToolResult, any, error) {
+		return &mcpSDK.CallToolResult{
+			Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: "tool failed"}},
+			IsError: true,
 		}, nil, nil
 	})
 	if err := server.Run(context.Background(), &mcpSDK.StdioTransport{}); err != nil {
@@ -111,8 +131,50 @@ func TestManagerEnable_ReadyStdioServerSurvivesStartupTimeoutContext(t *testing.
 	if err != nil {
 		t.Fatalf("CallTool after startup timeout elapsed: %v", err)
 	}
-	if !strings.Contains(got, "hi Ada") {
-		t.Fatalf("CallTool result = %q, want greeting", got)
+	if !strings.Contains(got.Content, "hi Ada") {
+		t.Fatalf("CallTool result = %q, want greeting", got.Content)
+	}
+	if len(got.ContentParts) != 1 || got.ContentParts[0].Type != llm.ToolContentPartText || got.ContentParts[0].Text != "hi Ada" {
+		t.Fatalf("text-only ContentParts = %#v, want one text part", got.ContentParts)
+	}
+
+	mixedTool := NewMCPTool(manager, ToolSpec{Name: "greeter__mixed"})
+	mixed, err := mixedTool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("execute mixed MCP tool: %v", err)
+	}
+	if mixed.Content != "beforeafter" {
+		t.Fatalf("mixed Content = %q, want %q", mixed.Content, "beforeafter")
+	}
+	if len(mixed.ContentParts) != 3 ||
+		mixed.ContentParts[0].Type != llm.ToolContentPartText || mixed.ContentParts[0].Text != "before" ||
+		mixed.ContentParts[1].Type != llm.ToolContentPartImageData || mixed.ContentParts[1].ImageData == nil ||
+		mixed.ContentParts[1].ImageData.MediaType != "image/png" ||
+		mixed.ContentParts[1].ImageData.Base64 != base64.StdEncoding.EncodeToString([]byte("image bytes")) ||
+		mixed.ContentParts[2].Type != llm.ToolContentPartText || mixed.ContentParts[2].Text != "after" {
+		t.Fatalf("mixed ContentParts = %#v, want ordered text/image/text", mixed.ContentParts)
+	}
+
+	imageOnly, err := manager.CallTool(context.Background(), "greeter__image", nil)
+	if err != nil {
+		t.Fatalf("call image-only MCP tool: %v", err)
+	}
+	if imageOnly.Content != "" || len(imageOnly.ContentParts) != 1 ||
+		imageOnly.ContentParts[0].Type != llm.ToolContentPartImageData || imageOnly.ContentParts[0].ImageData == nil {
+		t.Fatalf("image-only result = %#v, want one structured image", imageOnly)
+	}
+
+	failure, err := manager.CallTool(context.Background(), "greeter__failure", nil)
+	if err != nil {
+		t.Fatalf("MCP IsError result should remain a tool output, got error: %v", err)
+	}
+	if !failure.IsError || failure.Content != "tool failed" || len(failure.ContentParts) != 1 {
+		t.Fatalf("failure result = %#v, want preserved content with IsError", failure)
+	}
+
+	_, err = manager.CallTool(context.Background(), "greeter__greet", json.RawMessage("{"))
+	if err == nil || !strings.Contains(err.Error(), "invalid tool arguments") {
+		t.Fatalf("malformed arguments error = %v, want invalid tool arguments", err)
 	}
 }
 

--- a/internal/mcp/tool.go
+++ b/internal/mcp/tool.go
@@ -37,11 +37,7 @@ func (t *MCPTool) Preview(args json.RawMessage) string {
 
 // Execute invokes the tool on the MCP server.
 func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
-	result, err := t.manager.CallTool(ctx, t.toolSpec.Name, args)
-	if err != nil {
-		return llm.ToolOutput{}, err
-	}
-	return llm.TextOutput(result), nil
+	return t.manager.CallTool(ctx, t.toolSpec.Name, args)
 }
 
 // RegisterMCPTools registers all MCP tools from the manager into the tool registry.


### PR DESCRIPTION
## What

Preserve structured MCP tool results instead of flattening every response to text.

- map MCP text and image content into ordered `llm.ToolOutput` parts
- pass inline PNG/JPEG/GIF/WebP images through to provider-native tool results
- normalize MIME types and retain unsupported MCP content as visible JSON fallback text
- preserve MCP `isError` semantics in the agent loop and direct `mcp run` exit behavior
- apply tool-output truncation consistently to structured text parts
- add an explicit Ollama fallback that delivers tool-result images after each complete run of tool responses
- render multimodal results from `term-llm mcp run`

## Why

MCP explicitly supports image content in tool results, but term-llm's MCP adapter converted all non-text content to JSON text. Screenshot-producing tools therefore could not provide actual visual input to models.

This is needed for MCP computer-use and browser tools, and makes the adapter conform more closely to the protocol's typed content model.

## Verification

Passed:

```text
go test ./internal/mcp ./internal/llm -count=1
go test ./cmd -run 'MCP' -count=1
go build ./...
git diff --check
```

End-to-end smoke tested with a real stdio MCP server returning ordered text/image/text content and `gemini-2.5-flash`. The model called the MCP tool, read `MCP IMAGE` from the returned PNG, and correctly identified the blue background and yellow circle.

A full `go test ./... -count=1` was also run. It reached all packages; the changed MCP/LLM tests passed. Two pre-existing environment-sensitive tests failed:

- `cmd/TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` because the configured visible-skill limit omitted its test skill
- `internal/jobs/TestProgramRunnerDoesNotLeakBackgroundChildren` because its background child remained visible

## Notes

Resource links, embedded resources, and audio remain textual JSON fallbacks because `llm.ToolOutput` currently has first-class structured parts only for text and image data. They are not silently discarded.
