### PR TITLE
fix: Telegram silently drops photos sent during an active run

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1366,8 +1366,14 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot telegramBot,
 			}
 			sess.cancelMu.Unlock()
 
-			fastProvider := m.newFastProvider()
-			action := llm.ClassifyInterrupt(ctx, fastProvider, newMsgText, activity)
+			// Photo interjections cannot outlive this handler's temporary image path.
+			// Cancel and process them as replacement turns so the full structured
+			// message remains available until the provider consumes it.
+			action := llm.InterruptCancel
+			if tempImagePath == "" {
+				fastProvider := m.newFastProvider()
+				action = llm.ClassifyInterrupt(ctx, fastProvider, newMsgText, activity)
+			}
 			switch action {
 			case llm.InterruptCancel:
 				_, _ = bot.Send(tgbotapi.NewMessage(chatID, "↩️ Stopping current work and switching to your new request."))

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -68,6 +68,7 @@ type fakeBotSender struct {
 	nextID         int      // auto-incrementing MessageID
 	sendErr        error    // if non-nil, returned on the very first Send call
 	maxEditRunes   int      // if positive, reject EditMessageText calls over this many runes
+	fileURL        string   // if non-empty, returned for Telegram file downloads
 }
 
 func (f *fakeBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
@@ -113,6 +114,9 @@ func (f *fakeBotSender) GetFile(config tgbotapi.FileConfig) (tgbotapi.File, erro
 }
 
 func (f *fakeBotSender) GetFileDirectURL(fileID string) (string, error) {
+	if f.fileURL != "" {
+		return f.fileURL, nil
+	}
 	return "", errors.New("fake bot does not support GetFileDirectURL")
 }
 
@@ -2907,6 +2911,8 @@ func TestCloseTelegramSessionDefersCleanupUntilDetachedRunnerReturns(t *testing.
 type interruptSequenceProvider struct {
 	firstChunkSent        chan struct{}
 	firstContextCancelled chan struct{}
+	secondRequest         chan llm.Request
+	secondImagePathValid  chan bool
 	streamCount           atomic.Int32
 }
 
@@ -2914,6 +2920,8 @@ func newInterruptSequenceProvider() *interruptSequenceProvider {
 	return &interruptSequenceProvider{
 		firstChunkSent:        make(chan struct{}),
 		firstContextCancelled: make(chan struct{}),
+		secondRequest:         make(chan llm.Request, 1),
+		secondImagePathValid:  make(chan bool, 1),
 	}
 }
 
@@ -2930,6 +2938,17 @@ func (p *interruptSequenceProvider) Stream(ctx context.Context, req llm.Request)
 			closed:                make(chan struct{}),
 		}, nil
 	}
+	pathValid := false
+	for _, msg := range req.Messages {
+		for _, part := range msg.Parts {
+			if part.Type == llm.PartImage && part.ImagePath != "" {
+				_, err := os.Stat(part.ImagePath)
+				pathValid = err == nil
+			}
+		}
+	}
+	p.secondRequest <- req
+	p.secondImagePathValid <- pathValid
 	return &oneShotTextStream{text: "new answer"}, nil
 }
 
@@ -3040,5 +3059,105 @@ func TestHandleMessage_CancelInterruptIsNotBlockedBySessionMutex(t *testing.T) {
 	}
 	if provider.streamCount.Load() < 2 {
 		t.Fatalf("provider stream count = %d, want at least 2", provider.streamCount.Load())
+	}
+}
+
+func TestHandleMessage_PhotoInterruptCancelsAndPreservesImage(t *testing.T) {
+	provider := newInterruptSequenceProvider()
+	mgr := &telegramSessionMgr{
+		sessions:         make(map[int64]*telegramSession),
+		allowedUserIDs:   map[int64]struct{}{7: {}},
+		idleTimeout:      time.Hour,
+		interruptTimeout: time.Second,
+		tickerInterval:   5 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       llm.NewEngine(provider, llm.NewToolRegistry()),
+					ProviderName: "mock",
+					ModelName:    "test",
+				}, nil
+			},
+		},
+	}
+	imageServer := newTestImageServer(t, []byte{0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08})
+	defer imageServer.Close()
+	bot := &fakeBotSender{fileURL: imageServer.URL}
+	textMessage := &tgbotapi.Message{
+		From: &tgbotapi.User{ID: 7, UserName: "sam"},
+		Chat: &tgbotapi.Chat{ID: 42},
+		Text: "write a long reply",
+	}
+	photoMessage := &tgbotapi.Message{
+		From:  &tgbotapi.User{ID: 7, UserName: "sam"},
+		Chat:  &tgbotapi.Chat{ID: 42},
+		Photo: []tgbotapi.PhotoSize{{FileID: "photo-1", Width: 800, Height: 600}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstDone := make(chan struct{})
+	go func() {
+		mgr.handleMessage(ctx, bot, textMessage)
+		close(firstDone)
+	}()
+	select {
+	case <-provider.firstChunkSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first stream never emitted initial chunk")
+	}
+
+	secondDone := make(chan struct{})
+	go func() {
+		mgr.handleMessage(ctx, bot, photoMessage)
+		close(secondDone)
+	}()
+	select {
+	case <-provider.firstContextCancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("photo did not cancel the active stream")
+	}
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first message did not finish after photo interrupt")
+	}
+
+	var secondReq llm.Request
+	select {
+	case secondReq = <-provider.secondRequest:
+	case <-time.After(2 * time.Second):
+		t.Fatal("photo was not sent in a replacement provider request")
+	}
+	select {
+	case valid := <-provider.secondImagePathValid:
+		if !valid {
+			t.Fatal("photo path was removed before the provider consumed it")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider did not inspect the replacement photo path")
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("photo replacement request did not finish")
+	}
+
+	foundImage := false
+	for _, msg := range secondReq.Messages {
+		for _, part := range msg.Parts {
+			if part.Type == llm.PartImage && part.ImageData != nil && part.ImageData.Base64 != "" {
+				foundImage = true
+			}
+		}
+	}
+	if !foundImage {
+		t.Fatalf("replacement provider request did not contain image data: %+v", secondReq.Messages)
+	}
+	for _, text := range bot.allTexts() {
+		if strings.Contains(text, "Noted") {
+			t.Fatalf("photo was acknowledged as an interjection instead of a replacement: %v", bot.allTexts())
+		}
 	}
 }


### PR DESCRIPTION
## What changed

- Force Telegram photo messages received during an active stream through the existing cancel-and-replace path instead of reducing them to text interjections.
- Preserve the full structured image message and its temporary backing path until the replacement provider turn consumes it.
- Add an integration test with a blocked active stream and a captionless photo, asserting that the photo cancels the old stream, reaches the replacement provider request as an image, and still has a valid local path during provider consumption.

## Why this is high-value

Captionless photos sent while Jarvis was busy were deterministically classified as empty text interjections. Telegram acknowledged them as “Noted,” but the engine received only an empty text message and the handler deleted the downloaded image. Screenshots and photos used to steer a long-running Telegram task were therefore silently lost. Treating attachments as replacement requests uses the already established safe lifecycle and avoids acknowledging work that Jarvis cannot see.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./internal/serve -count=1`
- `go test ./internal/serve -run '^TestHandleMessage_PhotoInterruptCancelsAndPreservesImage$' -count=10`
- `git diff --check`
- `go test ./...` was also run; the changed `internal/serve` package passed, while two unrelated existing/environment-sensitive tests failed: `cmd/TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` (host skill inventory truncation) and `internal/jobs/TestProgramRunnerDoesNotLeakBackgroundChildren` (background child still reported alive).
