### PR TITLE
fix: Parallel image generations overwrite each other

### DIFF
--- a/internal/image/output.go
+++ b/internal/image/output.go
@@ -23,13 +23,36 @@ func SaveImage(data []byte, outputDir, prompt string) (string, error) {
 	}
 
 	filename := generateFilename(prompt)
-	path := filepath.Join(dir, filename)
+	ext := filepath.Ext(filename)
+	stem := strings.TrimSuffix(filename, ext)
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		return "", fmt.Errorf("failed to write image: %w", err)
+	for suffix := 0; ; suffix++ {
+		candidate := filename
+		if suffix > 0 {
+			candidate = fmt.Sprintf("%s-%d%s", stem, suffix+1, ext)
+		}
+		path := filepath.Join(dir, candidate)
+
+		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if os.IsExist(err) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to create image: %w", err)
+		}
+
+		if _, err := file.Write(data); err != nil {
+			_ = file.Close()
+			_ = os.Remove(path)
+			return "", fmt.Errorf("failed to write image: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(path)
+			return "", fmt.Errorf("failed to close image: %w", err)
+		}
+
+		return path, nil
 	}
-
-	return path, nil
 }
 
 // DisplayImage displays the image in terminal using the shared termimage renderer.

--- a/internal/image/output_test.go
+++ b/internal/image/output_test.go
@@ -1,0 +1,52 @@
+package image
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestSaveImageConcurrentCallsDoNotOverwrite(t *testing.T) {
+	const saveCount = 32
+
+	outputDir := t.TempDir()
+	paths := make([]string, saveCount)
+	payloads := make([][]byte, saveCount)
+	errs := make([]error, saveCount)
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(saveCount)
+	for i := 0; i < saveCount; i++ {
+		payloads[i] = []byte(fmt.Sprintf("image-%d", i))
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			paths[i], errs[i] = SaveImage(payloads[i], outputDir, "the same prompt")
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	seen := make(map[string]int, saveCount)
+	for i := 0; i < saveCount; i++ {
+		if errs[i] != nil {
+			t.Fatalf("SaveImage call %d failed: %v", i, errs[i])
+		}
+		if previous, exists := seen[paths[i]]; exists {
+			t.Fatalf("SaveImage calls %d and %d returned the same path %q", previous, i, paths[i])
+		}
+		seen[paths[i]] = i
+
+		got, err := os.ReadFile(paths[i])
+		if err != nil {
+			t.Fatalf("read image from call %d: %v", i, err)
+		}
+		if !bytes.Equal(got, payloads[i]) {
+			t.Fatalf("image from call %d contains %q, want %q", i, got, payloads[i])
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- Save generated images with `O_CREATE|O_EXCL` so an existing filename can never be truncated.
- Retry collisions with a numeric filename suffix while writing through the exclusively created file.
- Add a concurrent regression test that saves 32 distinct payloads for the same prompt and verifies every returned path and file contents are unique.

## Why this is high-value

Parallel tool calls can complete multiple paid image generations in the same second. The old seconds-resolution prompt-based filename made those calls overwrite one another while all callers reported success, permanently losing generated artifacts and leaving tool results or memory records pointing at the same final image. Exclusive creation preserves every output without serializing image generation.

## Validation

- `gofmt -w internal/image/output.go internal/image/output_test.go`
- `go build ./...`
- `go test -race ./internal/image -run '^TestSaveImageConcurrentCallsDoNotOverwrite$' -count=10`
- Full suite passed in an isolated skill environment with the unrelated baseline `TestProgramRunnerDoesNotLeakBackgroundChildren` test skipped: `go test ./... -skip '^TestProgramRunnerDoesNotLeakBackgroundChildren$'`
- A plain `go test ./...` was also run; it hit environment/baseline failures outside this change (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` because host-global skills exceed its eight-skill test limit, and, after isolating HOME, `TestProgramRunnerDoesNotLeakBackgroundChildren`).
- `git diff --stat`
- `git diff --check`
