### PR TITLE
fix(chatgpt): stop requesting sequential summary cutoff

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -268,10 +268,7 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 		PromptCacheKey:                  req.SessionID,
 		Store:                           boolPtr(false),
 		Stream:                          true,
-		StreamOptions: &ResponsesStreamOptions{
-			ReasoningSummaryDelivery: "sequential_cutoff",
-		},
-		SessionID: req.SessionID,
+		SessionID:                       req.SessionID,
 	}
 
 	if serviceTier := p.serviceTier; req.ServiceTierSet || strings.TrimSpace(req.ServiceTier) != "" {

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -259,7 +259,7 @@ func TestChatGPTStream_ServiceTierOverrideCanClearProviderDefault(t *testing.T) 
 	}
 }
 
-func TestChatGPTStream_IncludesSequentialCutoffReasoningSummaryDelivery(t *testing.T) {
+func TestChatGPTStream_OmitsReasoningSummaryDeliveryOverride(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() { chatGPTHTTPClient = origClient }()
 
@@ -292,12 +292,8 @@ func TestChatGPTStream_IncludesSequentialCutoffReasoningSummaryDelivery(t *testi
 	defer stream.Close()
 	drainStreamToDone(t, stream)
 
-	streamOptions, ok := captured["stream_options"].(map[string]any)
-	if !ok {
-		t.Fatalf("stream_options missing or wrong type in request: %#v", captured)
-	}
-	if got, want := streamOptions["reasoning_summary_delivery"], "sequential_cutoff"; got != want {
-		t.Fatalf("reasoning_summary_delivery = %#v, want %q", got, want)
+	if streamOptions, ok := captured["stream_options"]; ok {
+		t.Fatalf("stream_options = %#v, want omitted", streamOptions)
 	}
 }
 


### PR DESCRIPTION
## What

Stop sending `stream_options.reasoning_summary_delivery: "sequential_cutoff"` on ChatGPT/Codex Responses requests.

Update the request-capture regression test to require `stream_options` to be omitted.

## Why

The backend regression this option worked around is fixed. Live tests against `gpt-5.6-luna` now show that sequential cutoff adds cumulative/repeated summary events without restoring detailed summary prose:

- With sequential cutoff: 19 summary deltas, 13 summary completions, 5 unique headings.
- Without sequential cutoff: 9 summary deltas, 9 summary completions, 9 unique headings.
- Both runs completed the answer body and returned 0 `<!-- -->` placeholders.

Removing the override lets the repaired backend use its normal one-pass summary delivery. The existing HTML-comment sanitation and cumulative-summary deduplication remain in place defensively.

## Tests

- `go test ./internal/llm`
- `go build ./...`
- `go test ./...` reaches an unrelated existing `cmd` failure: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` is affected by the host's skill visibility cap (8 of 30 skills shown), so its temporary `worktree-skill` is omitted. The isolated test fails identically.
