### PR TITLE
feat: enrich session stats summary

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -534,8 +534,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	// Create stream adapter for unified event handling with proper buffering
 	adapter := ui.NewStreamAdapter(ui.DefaultStreamBufferSize)
 	if sess != nil {
-		adapter.Stats().SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns)
+		adapter.Stats().SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns+sess.CompactionCount)
 	}
+	adapter.Stats().SetModel(activeModel(cfg))
 
 	var outputToolMessagesMu sync.Mutex
 	outputToolMessages := append([]llm.Message{}, messages...)
@@ -712,21 +713,23 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	var compactionCallback llm.CompactionCallback
-	if store != nil && sess != nil {
-		compactionCallback = func(cbCtx context.Context, result *llm.CompactionResult) error {
-			_, _, refreshed, err := session.ApplyCompaction(cbCtx, store, sess, nil, result)
-			if err != nil {
-				return err
-			}
-			if refreshed != nil {
-				sess = refreshed
-			}
-			if result != nil && !result.Usage.BillableCountersZero() {
-				_ = store.UpdateMetrics(cbCtx, sess.ID, 0, 0, result.Usage.InputTokens, result.Usage.OutputTokens, result.Usage.CachedInputTokens, result.Usage.CacheWriteTokens)
-			}
+	var compactionUsages compactionUsageCollector
+	compactionCallback := func(cbCtx context.Context, result *llm.CompactionResult) error {
+		compactionUsages.add(result)
+		if store == nil || sess == nil {
 			return nil
 		}
+		_, _, refreshed, err := session.ApplyCompaction(cbCtx, store, sess, nil, result)
+		if err != nil {
+			return err
+		}
+		if refreshed != nil {
+			sess = refreshed
+		}
+		if result != nil && !result.Usage.BillableCountersZero() {
+			_ = store.UpdateMetrics(cbCtx, sess.ID, 0, 0, result.Usage.InputTokens, result.Usage.OutputTokens, result.Usage.CachedInputTokens, result.Usage.CacheWriteTokens)
+		}
+		return nil
 	}
 
 	var jsonInfo sessionInfo
@@ -853,8 +856,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		if !askPorcelain || askJSON || showStats || needsCollector {
 			bridge = newAskProgressiveBridge(ui.DefaultStreamBufferSize)
 			if sess != nil {
-				bridge.Stats().SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns)
+				bridge.Stats().SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns+sess.CompactionCount)
 			}
+			bridge.Stats().SetModel(activeModel(cfg))
 			stats = bridge.Stats()
 			events = wrapStreamEvents(bridge.Events())
 			if askPorcelain && !askJSON {
@@ -872,6 +876,9 @@ func runAsk(cmd *cobra.Command, args []string) error {
 			ContinueWith: progressiveOpts.ContinueWith,
 		}
 		runProgressive := func() askProgressiveRunResult {
+			if bridge != nil {
+				bridge.Stats().RequestStart()
+			}
 			sink := runpkg.EventSink(eventSinkFunc(func(llm.Event) {}))
 			if bridge != nil {
 				sink = askProgressiveRunnerSink{bridge: bridge}
@@ -1236,8 +1243,10 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		jsonFinalPending = false
 	}
 
+	compactionUsages.merge(stats)
 	if showStats && stats != nil && !askJSON {
 		stats.Finalize()
+		setEstimatedStatsCost(stats, activeModel(cfg))
 		fmt.Fprintln(cmd.ErrOrStderr(), stats.Render())
 	}
 

--- a/cmd/ask_progressive.go
+++ b/cmd/ask_progressive.go
@@ -98,6 +98,9 @@ func (b *askProgressiveBridge) send(event ui.StreamEvent) error {
 }
 
 func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
+	if b == nil {
+		return nil
+	}
 	switch event.Type {
 	case llm.EventError:
 		if event.Err != nil {
@@ -106,16 +109,21 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 	case llm.EventTextDelta:
 		b.attemptUsageCommitted = false
 		if event.Text != "" {
+			b.stats.ObserveOutput()
 			return b.send(ui.TextEvent(event.Text))
 		}
 	case llm.EventReasoningDelta:
 		b.attemptUsageCommitted = false
 		kind := llm.NormalizeReasoningKind(event.ReasoningKind)
 		if llm.IsEncryptedReasoningDelta(event) {
+			b.stats.ObserveOutput()
 			break
 		}
 		if event.Text == "" && event.ReasoningItemID == "" && !event.ReasoningFinal {
 			break
+		}
+		if event.Text != "" {
+			b.stats.ObserveOutput()
 		}
 		title := ""
 		displayable := kind == llm.ReasoningKindSummary
@@ -190,6 +198,7 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 			}
 		}
 	case llm.EventUsage:
+		b.stats.GenerationEnd()
 		if event.Use != nil {
 			b.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
 			if !b.attemptUsageCommitted {
@@ -206,13 +215,18 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 			return b.send(ui.PhaseEvent(event.Text))
 		}
 	case llm.EventRetry:
+		b.stats.ScheduleRetryStart(event.RetryWaitSecs)
 		return b.send(ui.RetryEvent(event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs))
 	case llm.EventAttemptDiscard:
-		if b.attemptUsageCalls > 0 {
-			b.stats.DiscardUsage(b.attemptInput, b.attemptOutput, b.attemptCached, b.attemptCacheWrite, b.attemptUsageCalls)
-		}
+		b.stats.DiscardUsage(b.attemptInput, b.attemptOutput, b.attemptCached, b.attemptCacheWrite, b.attemptUsageCalls)
 		b.resetAttemptUsage()
 		return b.send(ui.AttemptDiscardEvent())
+	case llm.EventModelSwitch:
+		model := event.Model
+		if model == "" {
+			model = event.Text
+		}
+		b.stats.SetModel(model)
 	case llm.EventInterjection:
 		if event.Text != "" {
 			return b.send(ui.InterjectionEvent(event.Text, event.InterjectionID))

--- a/cmd/ask_progressive.go
+++ b/cmd/ask_progressive.go
@@ -201,7 +201,7 @@ func (b *askProgressiveBridge) HandleEvent(event llm.Event) error {
 		b.stats.GenerationEnd()
 		if event.Use != nil {
 			b.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
-			if !b.attemptUsageCommitted {
+			if !event.Use.BillableCountersZero() && !b.attemptUsageCommitted {
 				b.attemptInput += event.Use.InputTokens
 				b.attemptOutput += event.Use.OutputTokens
 				b.attemptCached += event.Use.CachedInputTokens

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -437,11 +437,13 @@ func (s *execRunSink) Event(event llm.Event) {
 			s.stats.GenerationEnd()
 			s.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
 		}
-		s.attemptInput += event.Use.InputTokens
-		s.attemptOutput += event.Use.OutputTokens
-		s.attemptCached += event.Use.CachedInputTokens
-		s.attemptCacheWrite += event.Use.CacheWriteTokens
-		s.attemptUsageCalls++
+		if !event.Use.BillableCountersZero() {
+			s.attemptInput += event.Use.InputTokens
+			s.attemptOutput += event.Use.OutputTokens
+			s.attemptCached += event.Use.CachedInputTokens
+			s.attemptCacheWrite += event.Use.CacheWriteTokens
+			s.attemptUsageCalls++
+		}
 		return
 	}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -151,9 +151,11 @@ func runExec(cmd *cobra.Command, args []string) error {
 
 	// Track session stats
 	stats := ui.NewSessionStats()
+	statsModel := ""
 	defer func() {
 		if showStats {
 			stats.Finalize()
+			setEstimatedStatsCost(stats, statsModel)
 			fmt.Fprintln(cmd.ErrOrStderr(), stats.Render())
 		}
 	}()
@@ -218,6 +220,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer execEnv.Close()
+	statsModel = execEnv.llmReq.Model
 
 	for {
 		systemPrompt := prompt.SuggestSystemPrompt(shell, instructions, numSuggestions, execSearch)
@@ -240,6 +243,8 @@ func runExec(cmd *cobra.Command, args []string) error {
 			defer close(progressCh)
 			configureInteractiveSink(execEnv.runtime.toolMgr, sink)
 			llmReq := execEnv.llmReq
+			stats.SetModel(statsModel)
+			stats.RequestStart()
 			_, runErr := execEnv.runtime.RunWithEvents(ctx, false, false, []llm.Message{llm.SystemText(systemPrompt), llm.UserText(userPrompt)}, llmReq, func(ev llm.Event) error {
 				sink.Event(ev)
 				return nil
@@ -341,6 +346,9 @@ type execRunSink struct {
 	suggestions []llm.CommandSuggestion
 	err         error
 	sentFirst   bool
+
+	attemptInput, attemptOutput, attemptCached, attemptCacheWrite int
+	attemptUsageCalls                                             int
 }
 
 func execBoolPtr(v bool) *bool { return &v }
@@ -380,8 +388,12 @@ func (s *execRunSink) Event(event llm.Event) {
 		return
 	}
 
-	if event.Type == llm.EventToolExecEnd && s.debug {
-		if event.ToolName != "" {
+	if event.Type == llm.EventToolExecEnd {
+		if s.stats != nil {
+			s.stats.ToolEnd()
+		}
+		s.resetAttemptUsage()
+		if s.debug && event.ToolName != "" {
 			phase := ui.FormatToolPhase(event.ToolName, event.ToolInfo)
 			if event.ToolSuccess {
 				fmt.Fprintf(os.Stderr, "  %s %s\n", ui.SuccessCircle(), phase.Completed)
@@ -392,16 +404,49 @@ func (s *execRunSink) Event(event llm.Event) {
 	}
 
 	if event.Type == llm.EventRetry {
+		if s.stats != nil {
+			s.stats.ScheduleRetryStart(event.RetryWaitSecs)
+		}
 		status := ui.FormatRetryStatus("Rate limited", event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs, 0, "...")
 		s.sendProgress(ui.ProgressUpdate{Status: status})
 		return
 	}
 
-	if event.Type == llm.EventUsage && event.Use != nil {
+	if event.Type == llm.EventAttemptDiscard {
 		if s.stats != nil {
-			s.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
+			s.stats.DiscardUsage(s.attemptInput, s.attemptOutput, s.attemptCached, s.attemptCacheWrite, s.attemptUsageCalls)
+		}
+		s.resetAttemptUsage()
+		s.suggestions = nil
+		return
+	}
+
+	if event.Type == llm.EventModelSwitch {
+		model := event.Model
+		if model == "" {
+			model = event.Text
+		}
+		if s.stats != nil {
+			s.stats.SetModel(model)
 		}
 		return
+	}
+
+	if event.Type == llm.EventUsage && event.Use != nil {
+		if s.stats != nil {
+			s.stats.GenerationEnd()
+			s.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
+		}
+		s.attemptInput += event.Use.InputTokens
+		s.attemptOutput += event.Use.OutputTokens
+		s.attemptCached += event.Use.CachedInputTokens
+		s.attemptCacheWrite += event.Use.CacheWriteTokens
+		s.attemptUsageCalls++
+		return
+	}
+
+	if s.stats != nil && (event.Type == llm.EventTextDelta && event.Text != "" || event.Type == llm.EventReasoningDelta && (event.Text != "" || llm.IsEncryptedReasoningDelta(event))) {
+		s.stats.ObserveOutput()
 	}
 
 	if !s.sentFirst {
@@ -413,6 +458,11 @@ func (s *execRunSink) Event(event llm.Event) {
 		s.err = event.Err
 		return
 	}
+	if event.Type == llm.EventToolCall {
+		// Tool calls are durable boundaries; a later retry must not discard the
+		// provider request that produced the tool.
+		s.resetAttemptUsage()
+	}
 	if event.Type == llm.EventToolCall && event.Tool != nil && event.Tool.Name == llm.SuggestCommandsToolName {
 		llm.DebugToolCall(s.debug, *event.Tool)
 		parsed, err := llm.ParseCommandSuggestions(*event.Tool)
@@ -422,6 +472,12 @@ func (s *execRunSink) Event(event llm.Event) {
 		}
 		s.suggestions = append(s.suggestions, parsed...)
 	}
+}
+
+func (s *execRunSink) resetAttemptUsage() {
+	s.attemptInput, s.attemptOutput = 0, 0
+	s.attemptCached, s.attemptCacheWrite = 0, 0
+	s.attemptUsageCalls = 0
 }
 
 func (s *execRunSink) sendProgress(update ui.ProgressUpdate) {

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
 
 func TestEnvEnabled(t *testing.T) {
 	tests := []struct {
@@ -25,8 +31,41 @@ func TestEnvEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(allowAutoRunEnv, tt.value)
 			if got := envEnabled(allowAutoRunEnv); got != tt.want {
-				t.Fatalf("envEnabled(%q)=%v, want %v", tt.value, got, tt.want)
+				t.Fatalf("envEnabled(%q)=%v, want %v", allowAutoRunEnv, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExecRunSinkDiscardsRetryAttemptUsageAndPerformance(t *testing.T) {
+	stats := ui.NewSessionStats()
+	stats.SetModel("gpt-5.6-sol")
+	sink := &execRunSink{stats: stats}
+	sink.Event(llm.Event{Type: llm.EventTextDelta, Text: "discard me"})
+	sink.Event(llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 10, OutputTokens: 50}})
+	sink.Event(llm.Event{Type: llm.EventAttemptDiscard})
+	sink.Event(llm.Event{Type: llm.EventTextDelta, Text: "keep me"})
+	sink.Event(llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 2, OutputTokens: 3}})
+	calls, _ := stats.UsageCalls()
+	if stats.InputTokens != 2 || stats.OutputTokens != 3 || len(calls) != 1 || calls[0].OutputTokens != 3 {
+		t.Fatalf("exec stats retained discarded attempt: stats=%+v calls=%+v", stats, calls)
+	}
+}
+
+func TestExecRunSinkEndsToolTiming(t *testing.T) {
+	stats := ui.NewSessionStats()
+	sink := &execRunSink{stats: stats}
+	sink.Event(llm.Event{Type: llm.EventToolExecStart, ToolName: "shell"})
+	time.Sleep(time.Millisecond)
+	sink.Event(llm.Event{Type: llm.EventToolExecEnd, ToolName: "shell", ToolSuccess: true})
+	toolTime := stats.ToolTime
+	time.Sleep(time.Millisecond)
+	stats.Finalize()
+
+	if toolTime <= 0 {
+		t.Fatal("expected completed exec tool to record tool time")
+	}
+	if stats.ToolTime != toolTime {
+		t.Fatalf("tool time continued after end: before=%s after=%s", toolTime, stats.ToolTime)
 	}
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -17,9 +18,14 @@ func setEstimatedStatsCost(stats *ui.SessionStats, model string) {
 	}
 }
 
+type compactionUsageEntry struct {
+	model string
+	usage llm.Usage
+}
+
 type compactionUsageCollector struct {
 	mu     sync.Mutex
-	usages []llm.Usage
+	usages []compactionUsageEntry
 }
 
 func (c *compactionUsageCollector) add(result *llm.CompactionResult) {
@@ -27,7 +33,7 @@ func (c *compactionUsageCollector) add(result *llm.CompactionResult) {
 		return
 	}
 	c.mu.Lock()
-	c.usages = append(c.usages, result.Usage)
+	c.usages = append(c.usages, compactionUsageEntry{model: strings.TrimSpace(result.Model), usage: result.Usage})
 	c.mu.Unlock()
 }
 
@@ -36,10 +42,11 @@ func (c *compactionUsageCollector) merge(stats *ui.SessionStats) {
 		return
 	}
 	c.mu.Lock()
-	usages := append([]llm.Usage(nil), c.usages...)
+	usages := append([]compactionUsageEntry(nil), c.usages...)
 	c.usages = nil
 	c.mu.Unlock()
-	for _, u := range usages {
-		stats.AddCompactionUsage(u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
+	for _, entry := range usages {
+		u := entry.usage
+		stats.AddCompactionUsageForModel(entry.model, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
 	}
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"sync"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+func setEstimatedStatsCost(stats *ui.SessionStats, model string) {
+	if stats == nil {
+		return
+	}
+	stats.ClearEstimatedCost()
+	if cost, err := ui.EstimateSessionStatsCost(stats, model); err == nil {
+		stats.SetEstimatedCost(cost)
+	}
+}
+
+type compactionUsageCollector struct {
+	mu     sync.Mutex
+	usages []llm.Usage
+}
+
+func (c *compactionUsageCollector) add(result *llm.CompactionResult) {
+	if result == nil {
+		return
+	}
+	c.mu.Lock()
+	c.usages = append(c.usages, result.Usage)
+	c.mu.Unlock()
+}
+
+func (c *compactionUsageCollector) merge(stats *ui.SessionStats) {
+	if stats == nil {
+		return
+	}
+	c.mu.Lock()
+	usages := append([]llm.Usage(nil), c.usages...)
+	c.usages = nil
+	c.mu.Unlock()
+	for _, u := range usages {
+		stats.AddCompactionUsage(u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
+	}
+}

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+func TestCompactionUsageCollectorMergesWithoutSession(t *testing.T) {
+	var collector compactionUsageCollector
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			collector.add(&llm.CompactionResult{Usage: llm.Usage{
+				InputTokens: 7, OutputTokens: 3, CachedInputTokens: 11, CacheWriteTokens: 2,
+			}})
+		}()
+	}
+	wg.Wait()
+	stats := ui.NewSessionStats()
+	collector.merge(stats)
+	if stats.InputTokens != 56 || stats.OutputTokens != 24 || stats.CachedInputTokens != 88 || stats.CacheWriteTokens != 16 || stats.LLMCallCount != 8 || stats.CompactionLLMCallCount != 8 {
+		t.Fatalf("compaction usage not merged into --stats: %+v", stats)
+	}
+}
+
+func TestSetEstimatedStatsCostSumsRequestScopedTierPricing(t *testing.T) {
+	stats := ui.NewSessionStats()
+	stats.SetModel("gpt-5.6-sol")
+	// Each request is below the 272K whole-request tier even though their
+	// aggregate is above it. Each must therefore retain base pricing.
+	stats.AddUsage(200_000, 10_000, 0, 0)
+	stats.AddUsage(200_000, 10_000, 0, 0)
+
+	setEstimatedStatsCost(stats, "")
+	out := stats.Render()
+	// 400K input at $5/M + 20K output at $30/M = $2.60.
+	if !strings.Contains(out, "$2.6000") {
+		t.Fatalf("stats cost was not summed per request: %s", out)
+	}
+}
+
+func TestSetEstimatedStatsCostTracksModelSwitchPerCall(t *testing.T) {
+	stats := ui.NewSessionStats()
+	stats.SetModel("gpt-5.6-sol")
+	stats.AddUsage(100_000, 0, 0, 0) // $0.50
+	stats.SetModel("gpt-5.6-luna")
+	stats.AddUsage(100_000, 0, 0, 0) // $0.10
+	setEstimatedStatsCost(stats, "gpt-5.6-luna")
+	if out := stats.Render(); !strings.Contains(out, "$0.6000") {
+		t.Fatalf("model-switched calls were not priced independently: %s", out)
+	}
+}
+
+func TestSetEstimatedStatsCostOmitsResumedHistoricalUsage(t *testing.T) {
+	stats := ui.NewSessionStats()
+	stats.SeedTotals(100, 10, 0, 0, 0, 1)
+	stats.SetModel("gpt-5.6-sol")
+	stats.AddUsage(100, 10, 0, 0)
+	setEstimatedStatsCost(stats, "gpt-5.6-sol")
+	if out := stats.Render(); strings.Contains(out, "$") {
+		t.Fatalf("resumed whole-session cost should be omitted: %s", out)
+	}
+}

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -16,7 +16,7 @@ func TestCompactionUsageCollectorMergesWithoutSession(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			collector.add(&llm.CompactionResult{Usage: llm.Usage{
+			collector.add(&llm.CompactionResult{Model: "  gpt-5.6-sol  ", Usage: llm.Usage{
 				InputTokens: 7, OutputTokens: 3, CachedInputTokens: 11, CacheWriteTokens: 2,
 			}})
 		}()
@@ -26,6 +26,12 @@ func TestCompactionUsageCollectorMergesWithoutSession(t *testing.T) {
 	collector.merge(stats)
 	if stats.InputTokens != 56 || stats.OutputTokens != 24 || stats.CachedInputTokens != 88 || stats.CacheWriteTokens != 16 || stats.LLMCallCount != 8 || stats.CompactionLLMCallCount != 8 {
 		t.Fatalf("compaction usage not merged into --stats: %+v", stats)
+	}
+	calls, _ := stats.UsageCalls()
+	for _, call := range calls {
+		if call.Model != "gpt-5.6-sol" {
+			t.Fatalf("compaction model = %q, want normalized actual model", call.Model)
+		}
 	}
 }
 

--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -73,7 +73,8 @@ type CompactionResult struct {
 	NewMessages    []Message
 	OriginalCount  int
 	CompactedCount int
-	Usage          Usage // Token usage/cost of the helper LLM call that produced the summary.
+	Model          string // Model used by the helper LLM call.
+	Usage          Usage  // Token usage/cost of the helper LLM call that produced the summary.
 }
 
 // EstimateTokens returns an approximate token count for a string using a
@@ -596,6 +597,7 @@ func SoftCompact(ctx context.Context, provider Provider, model, systemPrompt str
 	}
 
 	result := compactionResultFromBriefPrepared(systemPrompt, briefText, prepared, originalCount, config)
+	result.Model = strings.TrimSpace(model)
 	result.Usage = usage
 	return result, nil
 }
@@ -1567,6 +1569,7 @@ func Compact(ctx context.Context, provider Provider, model, systemPrompt string,
 	// compaction: deterministic previous-turn excerpts, the model-written
 	// continuation brief, then a bounded raw suffix.
 	result := compactionResultFromBriefPrepared(systemPrompt, briefText, prepared, originalCount, config)
+	result.Model = strings.TrimSpace(model)
 	result.Usage = usage
 	return result, nil
 }

--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -49,6 +49,24 @@ func DefaultCompactionConfig() CompactionConfig {
 	}
 }
 
+func effectiveCompactionThresholdRatios(config *CompactionConfig) (soft, hard float64) {
+	soft, hard = defaultSoftThresholdRatio, defaultHardThresholdRatio
+	if config == nil {
+		return soft, hard
+	}
+	if config.SoftThresholdRatio > 0 {
+		soft = config.SoftThresholdRatio
+	} else if config.ThresholdRatio > 0 {
+		soft = config.ThresholdRatio
+	}
+	if config.HardThresholdRatio > 0 {
+		hard = config.HardThresholdRatio
+	} else if config.ThresholdRatio > 0 {
+		hard = config.ThresholdRatio
+	}
+	return soft, hard
+}
+
 // CompactionResult describes what happened during compaction.
 type CompactionResult struct {
 	Summary        string

--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -433,6 +433,9 @@ func TestSoftCompactUsesBriefPromptAndReportsUsage(t *testing.T) {
 	if !strings.Contains(prompt, "compact continuation brief") || !strings.Contains(prompt, "## Objective") || !strings.Contains(prompt, "## Relevant Files & Symbols") || strings.Contains(prompt, "Create a detailed summary") {
 		t.Fatalf("soft compaction prompt mismatch:\n%s", prompt)
 	}
+	if result.Model != "test-model" {
+		t.Fatalf("result model = %q, want test-model", result.Model)
+	}
 	if result.Usage.InputTokens != 12 || result.Usage.OutputTokens != 7 {
 		t.Fatalf("result usage = %+v, want 12/7", result.Usage)
 	}

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -527,6 +527,26 @@ func (e *Engine) InputLimit() int {
 	return v
 }
 
+// CompactionThresholds returns the configured soft and hard compaction token
+// thresholds. The final value is false when compaction is disabled or the
+// input limit is unknown.
+func (e *Engine) CompactionThresholds() (soft, hard int, enabled bool) {
+	e.callbackMu.RLock()
+	inputLimit := e.inputLimit
+	var config *CompactionConfig
+	if e.compactionConfig != nil {
+		copy := *e.compactionConfig
+		config = &copy
+	}
+	e.callbackMu.RUnlock()
+
+	if config == nil || inputLimit <= 0 {
+		return 0, 0, false
+	}
+	softRatio, hardRatio := effectiveCompactionThresholdRatios(config)
+	return int(float64(inputLimit) * softRatio), int(float64(inputLimit) * hardRatio), true
+}
+
 // LastTotalTokens returns the total tokens (cached+input+output) from the most
 // recent API response, approximating current context fullness.
 func (e *Engine) LastTotalTokens() int {
@@ -1625,20 +1645,7 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	var softCheckpointPrepared preparedCompactionContext
 	var softCheckpointOriginalCount int
 	var resumeAfterCompaction bool
-	softThresholdRatio := defaultSoftThresholdRatio
-	hardThresholdRatio := defaultHardThresholdRatio
-	if compactionConfig != nil {
-		if compactionConfig.SoftThresholdRatio > 0 {
-			softThresholdRatio = compactionConfig.SoftThresholdRatio
-		} else if compactionConfig.ThresholdRatio > 0 {
-			softThresholdRatio = compactionConfig.ThresholdRatio
-		}
-		if compactionConfig.HardThresholdRatio > 0 {
-			hardThresholdRatio = compactionConfig.HardThresholdRatio
-		} else if compactionConfig.ThresholdRatio > 0 {
-			hardThresholdRatio = compactionConfig.ThresholdRatio
-		}
-	}
+	softThresholdRatio, hardThresholdRatio := effectiveCompactionThresholdRatios(compactionConfig)
 	contextThresholdState := func(messages []Message) (estimate, soft, hard int) {
 		if compactionConfig == nil || inputLimit <= 0 {
 			return 0, 0, 0

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -2581,6 +2581,7 @@ turnLoop:
 					brief := continuationBriefFromAssistantMessage(finalMsg)
 					if brief != "" && compactionConfig != nil && softCheckpointOriginalCount > 0 {
 						result := compactionResultFromBriefPrepared(systemPrompt, brief, softCheckpointPrepared, softCheckpointOriginalCount, *compactionConfig)
+						result.Model = strings.TrimSpace(req.Model)
 						result.Usage = softCompactionUsage
 						if applyCompaction(result) {
 							resetSoftCheckpointState()

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -3075,6 +3075,23 @@ func TestRunLoopReactiveCompactsOnContextOverflowEvent(t *testing.T) {
 	}
 }
 
+func TestCompactionThresholdsUseEffectiveEngineConfig(t *testing.T) {
+	e := NewEngine(nil, nil)
+	if soft, hard, enabled := e.CompactionThresholds(); soft != 0 || hard != 0 || enabled {
+		t.Fatalf("disabled thresholds = (%d, %d, %v), want (0, 0, false)", soft, hard, enabled)
+	}
+
+	e.SetCompaction(10_000, CompactionConfig{SoftThresholdRatio: 0.72, HardThresholdRatio: 0.88})
+	if soft, hard, enabled := e.CompactionThresholds(); soft != 7200 || hard != 8800 || !enabled {
+		t.Fatalf("custom thresholds = (%d, %d, %v), want (7200, 8800, true)", soft, hard, enabled)
+	}
+
+	e.SetCompaction(10_000, CompactionConfig{ThresholdRatio: 0.80})
+	if soft, hard, enabled := e.CompactionThresholds(); soft != 8000 || hard != 8000 || !enabled {
+		t.Fatalf("legacy thresholds = (%d, %d, %v), want (8000, 8000, true)", soft, hard, enabled)
+	}
+}
+
 func TestConfigureContextManagementClearsUnknownLimit(t *testing.T) {
 	RegisterConfigLimits([]ConfigModelLimit{{Provider: "mock", Model: "known-model", InputLimit: 1234}})
 	defer RegisterConfigLimits(nil)

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -2762,6 +2762,9 @@ func TestRunLoopSoftThresholdCheckpointsCompactsAndContinues(t *testing.T) {
 	if compactionResult == nil {
 		t.Fatal("compaction callback was not called")
 	}
+	if compactionResult.Model != "compact-rush" {
+		t.Fatalf("compaction model = %q, want compact-rush", compactionResult.Model)
+	}
 	if compactionResult.Usage.InputTokens != 84 || compactionResult.Usage.OutputTokens != 2 {
 		t.Fatalf("compaction usage = %+v, want brief usage 84/2", compactionResult.Usage)
 	}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -798,7 +798,7 @@ func NewWithFastProvider(cfg *config.Config, provider llm.Provider, fastProvider
 
 	stats := ui.NewSessionStats()
 	if sess != nil {
-		stats.SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns)
+		stats.SeedTotals(sess.InputTokens, sess.OutputTokens, sess.CachedInputTokens, sess.CacheWriteTokens, sess.ToolCalls, sess.LLMTurns+sess.CompactionCount)
 	}
 
 	var mcpStatusChan chan mcp.StatusUpdate
@@ -942,7 +942,7 @@ func (m *Model) seedStatsFromSession() {
 	if m.stats == nil {
 		m.stats = ui.NewSessionStats()
 	}
-	m.stats.SeedTotals(m.sess.InputTokens, m.sess.OutputTokens, m.sess.CachedInputTokens, m.sess.CacheWriteTokens, m.sess.ToolCalls, m.sess.LLMTurns)
+	m.stats.SeedTotals(m.sess.InputTokens, m.sess.OutputTokens, m.sess.CachedInputTokens, m.sess.CacheWriteTokens, m.sess.ToolCalls, m.sess.LLMTurns+m.sess.CompactionCount)
 }
 
 func (m *Model) configureContextManagementForSession() {
@@ -2231,6 +2231,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case ui.StreamEventUsage:
+			if m.stats != nil {
+				m.stats.GenerationEnd()
+			}
 			inputTokens := ev.InputTokens
 			outputTokens := ev.OutputTokens
 			cachedTokens := ev.CachedTokens
@@ -2260,6 +2263,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case ui.StreamEventText:
 			m.commitCurrentReasoningToStream()
 			m.attemptUsageCommitted = false
+			if m.stats != nil && ev.Text != "" {
+				m.stats.ObserveOutput()
+			}
 			text := ev.Text
 			if m.newlineCompactor == nil {
 				m.newlineCompactor = ui.NewStreamingNewlineCompactor(ui.MaxStreamingConsecutiveNewlines)
@@ -2297,11 +2303,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.phase = "Responding"
 			m.setRetryStatus("")
 
+		case ui.StreamEventGenerationActivity:
+			if m.stats != nil {
+				m.stats.ObserveOutput()
+			}
+
 		case ui.StreamEventReasoning:
+			if m.stats != nil && ev.ReasoningText != "" {
+				m.stats.ObserveOutput()
+			}
 			m.handleReasoningStreamEvent(ev)
 
 		case ui.StreamEventAttemptDiscard:
-			if m.stats != nil && m.attemptUsageCalls > 0 {
+			if m.stats != nil {
 				m.stats.DiscardUsage(m.attemptInput, m.attemptOutput, m.attemptCached, m.attemptCacheWrite, m.attemptUsageCalls)
 			}
 			m.resetAttemptUsage()
@@ -2346,11 +2360,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case ui.StreamEventModelSwitch:
+			if m.stats != nil {
+				m.stats.SetModel(ev.Text)
+			}
 			if m.markPendingStreamModelSwitchApplied(ev.Text) {
 				m.bumpContentVersion()
 			}
 
 		case ui.StreamEventRetry:
+			if m.stats != nil {
+				m.stats.ScheduleRetryStart(ev.RetryWait)
+			}
 			m.setRetryStatus(ev.RetryStatus("Retrying stream", 1, "..."))
 
 		case ui.StreamEventImage:
@@ -2626,9 +2646,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.autoSendExitOnDone {
 					// Queue exhausted and exit requested, quit
 					m.quitting = true
-					if m.showStats && m.stats.LLMCallCount > 0 {
-						m.stats.Finalize()
-						return m, m.quitCmd(messageStatsCmd, tea.Println(m.stats.Render()))
+					if summary := m.exitStatsSummary(); summary != "" {
+						return m, m.quitCmd(messageStatsCmd, tea.Println(summary))
 					}
 					return m, m.quitCmd(messageStatsCmd)
 				}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -1631,6 +1631,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if timeoutMsg, ok := msg.(streamCancelTimeoutMsg); ok {
 		return m.handleStreamCancelTimeout(timeoutMsg)
 	}
+	if usageMsg, ok := msg.(compactionUsageMsg); ok {
+		// Compaction callbacks run on the stream goroutine. Apply stats and
+		// session-counter mutations only on Bubble Tea's Update goroutine.
+		m.recordCompactionUsage(context.Background(), usageMsg.sessionID, usageMsg.model, usageMsg.usage)
+		return m, nil
+	}
 	if handled, cmd := m.handleTerminalTitleProviderMsg(msg); handled {
 		return m, cmd
 	}
@@ -1839,7 +1845,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if refreshed != nil {
 			m.sess = refreshed
 		}
-		m.recordCompactionUsage(context.Background(), sessionIDOf(m.sess), msg.result.Usage)
+		m.recordCompactionUsage(context.Background(), sessionIDOf(m.sess), msg.result.Model, msg.result.Usage)
 		m.messagesMu.Lock()
 		m.messages = updated
 		m.compactionIdx = activeStart
@@ -2250,8 +2256,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if writeTokens < 0 {
 				writeTokens = 0
 			}
-			if m.stats != nil && (inputTokens > 0 || outputTokens > 0 || cachedTokens > 0 || writeTokens > 0) {
+			if m.stats != nil {
+				// Even an all-zero terminal usage event consumes pending request
+				// timing; SessionStats intentionally does not count it as a call.
 				m.stats.AddUsage(inputTokens, outputTokens, cachedTokens, writeTokens)
+			}
+			if inputTokens > 0 || outputTokens > 0 || cachedTokens > 0 || writeTokens > 0 {
 				if !m.attemptUsageCommitted {
 					m.attemptInput += inputTokens
 					m.attemptOutput += outputTokens

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -996,6 +996,7 @@ func (m *Model) cmdClear() (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) cmdQuit() (tea.Model, tea.Cmd) {
+	hadActiveStream := m.streaming || m.streamCancelFunc != nil
 	// Signal tool-initiated handover (if any) right before quitting.
 	// The session is about to restart so the tool result is moot,
 	// but we unblock the goroutine to avoid a leak.
@@ -1009,6 +1010,11 @@ func (m *Model) cmdQuit() (tea.Model, tea.Cmd) {
 		m.streamCancelFunc = nil
 	}
 	m.quitting = true
+	if !hadActiveStream {
+		if summary := m.exitStatsSummary(); summary != "" {
+			return m, m.quitCmd(tea.Println(summary))
+		}
+	}
 	return m, m.quitCmd()
 }
 

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -594,6 +594,17 @@ func TestStatsModalUsesEngineThresholdsAndClearCacheDenominator(t *testing.T) {
 	}
 }
 
+func TestStatsModalCollapsesEqualCompactionThresholds(t *testing.T) {
+	m := newCmdTestModel(&mockStore{})
+	m.engine = llm.NewEngine(nil, nil)
+	m.engine.SetCompaction(1000, llm.CompactionConfig{ThresholdRatio: 0.8})
+	m.engine.SetContextEstimateBaseline(1, 0)
+	content := m.renderStatsModal()
+	if strings.Count(content, "compact at:") != 1 || !strings.Contains(content, "Soft compact at:") {
+		t.Fatalf("equal thresholds should display once:\n%s", content)
+	}
+}
+
 func TestStatsModalDoesNotFinalizeLiveTiming(t *testing.T) {
 	oldEstimator := statsCostEstimator
 	statsCostEstimator = func(string, *ui.SessionStats) (float64, error) {

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -492,7 +492,7 @@ func TestCmdStatsOpensModalWithTotalsAndCompactions(t *testing.T) {
 		t.Fatalf("stats should open content dialog, got open=%v type=%v", rm.dialog.IsOpen(), rm.dialog.Type())
 	}
 	content := rm.dialog.Content()
-	for _, want := range []string{"Context Usage", "Current state vs entire history", "Current context", "Entire history", "Input tokens", "Cache write tokens", "Total tokens", "Tool calls", "Compactions:        3", "LLM cost:           200k cache, 484 in, 1.2k out", "Last boundary:"} {
+	for _, want := range []string{"Stats:", "Current Context / Window Pressure", "Current context vs cumulative history", "Current context", "Cumulative history", "Cumulative Session Token Usage", "Fresh input tokens", "Cache write tokens", "Cache hit rate:", "Total tokens", "Cumulative Session Activity", "Tool calls", "Compactions:        3", "LLM cost:           200k cache, 484 in, 1.2k out", "Last boundary:"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("stats content missing %q:\n%s", want, content)
 		}
@@ -523,7 +523,7 @@ func TestCmdStatsUsesActiveContextAfterCompaction(t *testing.T) {
 		"Compactions:        2",
 		"Last boundary:      seq 10 (2 messages hidden from active context)",
 		"Active messages:    2 (user 1, assistant 1, tool 0)",
-		"Not in context:",
+		"Outside context:",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("stats content missing %q:\n%s", want, content)
@@ -546,6 +546,67 @@ func TestStatsSeedsCacheWriteTokensFromSession(t *testing.T) {
 	}
 	if !strings.Contains(content, "Total tokens:       190") {
 		t.Fatalf("stats total did not include cache-write tokens:\n%s", content)
+	}
+}
+
+func TestStatsModalUsesEngineThresholdsAndClearCacheDenominator(t *testing.T) {
+	oldEstimator := statsCostEstimator
+	estimatorCalls := 0
+	statsCostEstimator = func(string, *ui.SessionStats) (float64, error) {
+		estimatorCalls++
+		if estimatorCalls == 1 {
+			return 0.1234, nil
+		}
+		return 0, errors.New("raw pricing lookup detail")
+	}
+	t.Cleanup(func() { statsCostEstimator = oldEstimator })
+
+	m := newCmdTestModel(&mockStore{})
+	m.engine = llm.NewEngine(nil, nil)
+	m.engine.SetCompaction(1000, llm.CompactionConfig{
+		SoftThresholdRatio: 0.70,
+		HardThresholdRatio: 0.85,
+	})
+	m.engine.SetContextEstimateBaseline(10, 0)
+	m.stats = ui.NewSessionStats()
+	m.stats.AddUsage(400, 100, 200, 200)
+
+	content := m.renderStatsModal()
+	for _, want := range []string{
+		"Stats:",
+		"$0.1234",
+		"× Soft compact at:  700       70.0% (300 window buffer)",
+		"! Hard compact at:  850       85.0% (150 window buffer)",
+		"Cache hit rate:     25.0% (cache read / (fresh + read + write input))",
+		"Estimated cost:     unavailable",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("stats content missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "raw pricing lookup detail") {
+		t.Fatalf("stats exposed raw pricing error:\n%s", content)
+	}
+	// The modal may price its summary copy, but must not attach that cost to the
+	// live stats object.
+	if live := m.stats.Render(); strings.Contains(live, "$") {
+		t.Fatalf("rendering /stats mutated live estimated cost: %s", live)
+	}
+}
+
+func TestStatsModalDoesNotFinalizeLiveTiming(t *testing.T) {
+	oldEstimator := statsCostEstimator
+	statsCostEstimator = func(string, *ui.SessionStats) (float64, error) {
+		return 0, errors.New("unavailable")
+	}
+	t.Cleanup(func() { statsCostEstimator = oldEstimator })
+
+	m := newCmdTestModel(&mockStore{})
+	m.stats = ui.NewSessionStats()
+	before := m.stats.LLMTime
+	_ = m.renderStatsModal()
+	if m.stats.LLMTime != before {
+		t.Fatalf("rendering /stats finalized live timing: before=%v after=%v", before, m.stats.LLMTime)
 	}
 }
 

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -544,6 +544,9 @@ func TestStatsSeedsCacheWriteTokensFromSession(t *testing.T) {
 	if !strings.Contains(content, "Cache write tokens:") || !strings.Contains(content, "30") {
 		t.Fatalf("stats did not include cache write tokens restored from session DB metrics:\n%s", content)
 	}
+	if !strings.Contains(content, "Total tokens:       190") {
+		t.Fatalf("stats total did not include cache-write tokens:\n%s", content)
+	}
 }
 
 func TestStatsPricingModelStripsProviderAndEffort(t *testing.T) {

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -329,6 +329,7 @@ func (m *Model) quitFromInterrupt() (tea.Model, tea.Cmd) {
 		m.dialog.Close()
 	}
 
+	hadActiveStream := m.streaming || m.streamCancelFunc != nil
 	_, _ = m.cancelActiveForInterrupt()
 	m.pausedForExternalUI = false
 	if m.program != nil {
@@ -339,9 +340,10 @@ func (m *Model) quitFromInterrupt() (tea.Model, tea.Cmd) {
 		}()
 	}
 
-	if m.showStats && m.stats.LLMCallCount > 0 {
-		m.stats.Finalize()
-		return m, m.quitCmd(tea.Println(m.stats.Render()))
+	if !hadActiveStream {
+		if summary := m.exitStatsSummary(); summary != "" {
+			return m, m.quitCmd(tea.Println(summary))
+		}
 	}
 	return m, m.quitCmd()
 }

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -1428,6 +1428,26 @@ func TestUpdate_StreamEventUsage_CacheOnlyUpdatesStats(t *testing.T) {
 	}
 }
 
+func TestUpdateAllZeroStreamUsageConsumesPendingTimingWithoutCall(t *testing.T) {
+	m := newTestChatModel(false)
+	m.stats = ui.NewSessionStats()
+	m.stats.RequestStart()
+	m.stats.ObserveOutput()
+
+	_, _ = m.Update(streamEventMsg{event: ui.UsageEvent(0, 0, 0, 0)})
+	if m.stats.LLMCallCount != 0 {
+		t.Fatalf("all-zero usage incremented call count: %+v", m.stats)
+	}
+
+	// A later usage record without new observed activity must not inherit the
+	// consumed request's TTFT/generation state.
+	m.stats.AddUsage(1, 1, 0, 0)
+	calls, _ := m.stats.UsageCalls()
+	if len(calls) != 1 || calls[0].ObservedOutput {
+		t.Fatalf("all-zero usage leaked pending timing into the next call: %+v", calls)
+	}
+}
+
 func TestRenderInputInline_ShowsPendingInterjection(t *testing.T) {
 	m := newTestChatModel(false)
 	m.pendingInterjection = "stop doing that"

--- a/internal/tui/chat/stats.go
+++ b/internal/tui/chat/stats.go
@@ -9,12 +9,23 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/ui"
-	"github.com/samsaffron/term-llm/internal/usage"
 )
 
 const defaultAutoCompactThreshold = 0.90
 
 var statsCostEstimator = estimateStatsCost
+
+func (m *Model) exitStatsSummary() string {
+	if m == nil || !m.showStats || m.stats == nil || m.stats.LLMCallCount <= 0 {
+		return ""
+	}
+	m.stats.Finalize()
+	m.stats.ClearEstimatedCost()
+	if cost, err := statsCostEstimator(m.statsPricingModel(), m.stats); err == nil {
+		m.stats.SetEstimatedCost(cost)
+	}
+	return m.stats.Render()
+}
 
 func (m *Model) cmdStats() (tea.Model, tea.Cmd) {
 	m.setTextareaValue("")
@@ -92,7 +103,7 @@ func (m *Model) renderStatsModal() string {
 
 	b.WriteString("\nToken Usage\n")
 	if m.stats != nil {
-		totalTokens := m.stats.InputTokens + m.stats.CachedInputTokens + m.stats.OutputTokens
+		totalTokens := m.stats.InputTokens + m.stats.CachedInputTokens + m.stats.CacheWriteTokens + m.stats.OutputTokens
 		b.WriteString(fmt.Sprintf("Input tokens:       %s\n", ui.FormatTokenCount(m.stats.InputTokens)))
 		if m.stats.CachedInputTokens > 0 {
 			b.WriteString(fmt.Sprintf("Cache read tokens:  %s\n", ui.FormatTokenCount(m.stats.CachedInputTokens)))
@@ -153,6 +164,7 @@ func (m *Model) recordCompactionUsage(ctx context.Context, sessionID string, u l
 	if m.stats == nil {
 		m.stats = ui.NewSessionStats()
 	}
+	m.stats.SetModel(m.statsPricingModel())
 	m.stats.AddCompactionUsage(u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
 	if !u.BillableCountersZero() && m.store != nil && sessionID != "" {
 		_ = m.store.UpdateMetrics(ctx, sessionID, 0, 0, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
@@ -192,22 +204,7 @@ func formatCompactionUsage(stats *ui.SessionStats) string {
 }
 
 func estimateStatsCost(model string, stats *ui.SessionStats) (float64, error) {
-	model = strings.TrimSpace(model)
-	if model == "" {
-		return 0, fmt.Errorf("model unknown")
-	}
-	if stats == nil {
-		return 0, fmt.Errorf("no usage recorded")
-	}
-	fetcher := usage.NewPricingFetcher()
-	return fetcher.CalculateCost(usage.UsageEntry{
-		Model:            model,
-		InputTokens:      stats.InputTokens,
-		OutputTokens:     stats.OutputTokens,
-		CacheReadTokens:  stats.CachedInputTokens,
-		CacheWriteTokens: stats.CacheWriteTokens,
-		Provider:         usage.ProviderTermLLM,
-	})
+	return ui.EstimateSessionStatsCost(stats, model)
 }
 
 func (m *Model) statsPricingModel() string {

--- a/internal/tui/chat/stats.go
+++ b/internal/tui/chat/stats.go
@@ -115,7 +115,9 @@ func (m *Model) renderStatsModal() string {
 	}
 	if compactionEnabled {
 		b.WriteString(fmt.Sprintf("× Soft compact at:  %-8s %5.1f%% (%s window buffer)\n", ui.FormatTokenCount(softThreshold), percent(softThreshold, limit), ui.FormatTokenCount(max(0, limit-softThreshold))))
-		b.WriteString(fmt.Sprintf("! Hard compact at:  %-8s %5.1f%% (%s window buffer)\n", ui.FormatTokenCount(hardThreshold), percent(hardThreshold, limit), ui.FormatTokenCount(max(0, limit-hardThreshold))))
+		if hardThreshold != softThreshold {
+			b.WriteString(fmt.Sprintf("! Hard compact at:  %-8s %5.1f%% (%s window buffer)\n", ui.FormatTokenCount(hardThreshold), percent(hardThreshold, limit), ui.FormatTokenCount(max(0, limit-hardThreshold))))
+		}
 	}
 
 	b.WriteString("\nCumulative Session Token Usage\n")
@@ -181,12 +183,17 @@ func sessionIDOf(sess *session.Session) string {
 	return sess.ID
 }
 
-func (m *Model) recordCompactionUsage(ctx context.Context, sessionID string, u llm.Usage) {
+type compactionUsageMsg struct {
+	sessionID string
+	model     string
+	usage     llm.Usage
+}
+
+func (m *Model) recordCompactionUsage(ctx context.Context, sessionID, model string, u llm.Usage) {
 	if m.stats == nil {
 		m.stats = ui.NewSessionStats()
 	}
-	m.stats.SetModel(m.statsPricingModel())
-	m.stats.AddCompactionUsage(u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
+	m.stats.AddCompactionUsageForModel(model, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
 	if !u.BillableCountersZero() && m.store != nil && sessionID != "" {
 		_ = m.store.UpdateMetrics(ctx, sessionID, 0, 0, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
 	}

--- a/internal/tui/chat/stats.go
+++ b/internal/tui/chat/stats.go
@@ -11,8 +11,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
-const defaultAutoCompactThreshold = 0.90
-
 var statsCostEstimator = estimateStatsCost
 
 func (m *Model) exitStatsSummary() string {
@@ -25,6 +23,20 @@ func (m *Model) exitStatsSummary() string {
 		m.stats.SetEstimatedCost(cost)
 	}
 	return m.stats.Render()
+}
+
+func (m *Model) liveStatsSummary() string {
+	if m == nil || m.stats == nil {
+		return ""
+	}
+	// Price and render a value copy: opening /stats must not finalize the live
+	// timer or attach transient pricing state to the session accumulator.
+	snapshot := *m.stats
+	snapshot.ClearEstimatedCost()
+	if cost, err := statsCostEstimator(m.statsPricingModel(), &snapshot); err == nil {
+		snapshot.SetEstimatedCost(cost)
+	}
+	return snapshot.Render()
 }
 
 func (m *Model) cmdStats() (tea.Model, tea.Cmd) {
@@ -73,16 +85,18 @@ func (m *Model) renderStatsModal() string {
 	if limit > 0 {
 		free = max(0, limit-currentTokens)
 	}
-	buffer := 0
-	threshold := 0
-	if limit > 0 {
-		threshold = int(float64(limit) * defaultAutoCompactThreshold)
-		buffer = max(0, limit-threshold)
+	softThreshold, hardThreshold, compactionEnabled := 0, 0, false
+	if m.engine != nil {
+		softThreshold, hardThreshold, compactionEnabled = m.engine.CompactionThresholds()
 	}
 
 	var b strings.Builder
-	b.WriteString("Context Usage\n")
-	b.WriteString(renderContextGrid(currentTokens, limit, threshold))
+	if summary := m.liveStatsSummary(); summary != "" {
+		b.WriteString(summary)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Current Context / Window Pressure\n")
+	b.WriteString(renderContextGrid(currentTokens, limit, softThreshold, hardThreshold))
 	b.WriteString("\n\n")
 	b.WriteString(fmt.Sprintf("%s:%s\n", nonEmpty(m.providerKey, m.providerName), nonEmpty(m.modelName, "unknown-model")))
 	if limit > 0 {
@@ -90,21 +104,24 @@ func (m *Model) renderStatsModal() string {
 	} else {
 		b.WriteString(fmt.Sprintf("%s tokens used (context window unknown)\n", ui.FormatTokenCount(currentTokens)))
 	}
-	b.WriteString("\nCurrent state vs entire history\n")
+	b.WriteString("\nCurrent context vs cumulative history\n")
 	b.WriteString(fmt.Sprintf("■ Current context:   %-8s %5.1f%% of window\n", ui.FormatTokenCount(currentTokens), percent(currentTokens, limit)))
-	b.WriteString(fmt.Sprintf("◆ Entire history:    %-8s %5.1f%% of window\n", ui.FormatTokenCount(historyTokens), percent(historyTokens, limit)))
+	b.WriteString(fmt.Sprintf("◆ Cumulative history: %-8s %5.1f%% of window\n", ui.FormatTokenCount(historyTokens), percent(historyTokens, limit)))
 	if hidden := max(0, historyTokens-currentTokens); hidden > 0 {
-		b.WriteString(fmt.Sprintf("· Not in context:    %-8s %5.1f%% of history\n", ui.FormatTokenCount(hidden), percent(hidden, historyTokens)))
+		b.WriteString(fmt.Sprintf("· Outside context:   %-8s %5.1f%% of history\n", ui.FormatTokenCount(hidden), percent(hidden, historyTokens)))
 	}
 	if limit > 0 {
 		b.WriteString(fmt.Sprintf("□ Free space:        %-8s %5.1f%% of window\n", ui.FormatTokenCount(free), percent(free, limit)))
-		b.WriteString(fmt.Sprintf("☒ Autocompact buf:  %-8s %5.1f%% of window\n", ui.FormatTokenCount(buffer), percent(buffer, limit)))
+	}
+	if compactionEnabled {
+		b.WriteString(fmt.Sprintf("× Soft compact at:  %-8s %5.1f%% (%s window buffer)\n", ui.FormatTokenCount(softThreshold), percent(softThreshold, limit), ui.FormatTokenCount(max(0, limit-softThreshold))))
+		b.WriteString(fmt.Sprintf("! Hard compact at:  %-8s %5.1f%% (%s window buffer)\n", ui.FormatTokenCount(hardThreshold), percent(hardThreshold, limit), ui.FormatTokenCount(max(0, limit-hardThreshold))))
 	}
 
-	b.WriteString("\nToken Usage\n")
+	b.WriteString("\nCumulative Session Token Usage\n")
 	if m.stats != nil {
 		totalTokens := m.stats.InputTokens + m.stats.CachedInputTokens + m.stats.CacheWriteTokens + m.stats.OutputTokens
-		b.WriteString(fmt.Sprintf("Input tokens:       %s\n", ui.FormatTokenCount(m.stats.InputTokens)))
+		b.WriteString(fmt.Sprintf("Fresh input tokens: %s\n", ui.FormatTokenCount(m.stats.InputTokens)))
 		if m.stats.CachedInputTokens > 0 {
 			b.WriteString(fmt.Sprintf("Cache read tokens:  %s\n", ui.FormatTokenCount(m.stats.CachedInputTokens)))
 		}
@@ -113,16 +130,20 @@ func (m *Model) renderStatsModal() string {
 		}
 		b.WriteString(fmt.Sprintf("Output tokens:      %s\n", ui.FormatTokenCount(m.stats.OutputTokens)))
 		b.WriteString(fmt.Sprintf("Total tokens:       %s\n", ui.FormatTokenCount(totalTokens)))
+		inputCategories := m.stats.InputTokens + m.stats.CachedInputTokens + m.stats.CacheWriteTokens
+		if inputCategories > 0 {
+			b.WriteString(fmt.Sprintf("Cache hit rate:     %.1f%% (cache read / (fresh + read + write input))\n", percent(m.stats.CachedInputTokens, inputCategories)))
+		}
 		if cost, err := statsCostEstimator(m.statsPricingModel(), m.stats); err == nil {
 			b.WriteString(fmt.Sprintf("Estimated cost:     $%.4f\n", cost))
 		} else {
-			b.WriteString(fmt.Sprintf("Estimated cost:     unavailable (%s)\n", err.Error()))
+			b.WriteString("Estimated cost:     unavailable\n")
 		}
 	} else {
 		b.WriteString("No token usage recorded yet.\n")
 	}
 
-	b.WriteString("\nActivity\n")
+	b.WriteString("\nCumulative Session Activity\n")
 	if m.stats != nil {
 		b.WriteString(fmt.Sprintf("LLM calls:          %d\n", m.stats.LLMCallCount))
 		b.WriteString(fmt.Sprintf("Tool calls:         %d\n", m.stats.ToolCallCount))
@@ -266,19 +287,24 @@ func (m *Model) estimateMessagesTokens(messages []session.Message) int {
 	return total
 }
 
-func renderContextGrid(used, limit, threshold int) string {
+func renderContextGrid(used, limit, softThreshold, hardThreshold int) string {
 	const cols = 48
 	const rows = 6
 	total := cols * rows
 	usedCells := 0
-	bufferCells := 0
+	softBufferCells := 0
+	hardBufferCells := 0
 	if limit > 0 {
 		usedCells = int(float64(used) / float64(limit) * float64(total))
 		if used > 0 && usedCells == 0 {
 			usedCells = 1
 		}
-		buffer := max(0, limit-threshold)
-		bufferCells = int(float64(buffer) / float64(limit) * float64(total))
+		if softThreshold > 0 {
+			softBufferCells = int(float64(max(0, limit-softThreshold)) / float64(limit) * float64(total))
+		}
+		if hardThreshold > 0 {
+			hardBufferCells = int(float64(max(0, limit-hardThreshold)) / float64(limit) * float64(total))
+		}
 	}
 	var b strings.Builder
 	for r := 0; r < rows; r++ {
@@ -287,7 +313,9 @@ func renderContextGrid(used, limit, threshold int) string {
 			switch {
 			case i < usedCells:
 				b.WriteRune('■')
-			case limit > 0 && i >= total-bufferCells:
+			case hardBufferCells > 0 && i >= total-hardBufferCells:
+				b.WriteRune('!')
+			case softBufferCells > 0 && i >= total-softBufferCells:
 				b.WriteRune('×')
 			default:
 				b.WriteRune('□')

--- a/internal/tui/chat/stats_exit_test.go
+++ b/internal/tui/chat/stats_exit_test.go
@@ -1,0 +1,80 @@
+package chat
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+func TestCmdQuitPrintsSummaryWhenIdle(t *testing.T) {
+	oldEstimator := statsCostEstimator
+	called := false
+	statsCostEstimator = func(string, *ui.SessionStats) (float64, error) {
+		called = true
+		return 0.25, nil
+	}
+	t.Cleanup(func() { statsCostEstimator = oldEstimator })
+
+	m := newTestChatModel(false)
+	m.showStats = true
+	m.stats = ui.NewSessionStats()
+	m.stats.AddUsage(2, 1, 0, 0)
+	_, cmd := m.cmdQuit()
+	if !called {
+		t.Fatal("idle /quit did not produce the stats summary")
+	}
+	if cmd == nil {
+		t.Fatal("idle /quit returned no quit command")
+	}
+}
+
+func TestCmdQuitDoesNotSummarizeCancellingStream(t *testing.T) {
+	oldEstimator := statsCostEstimator
+	statsCostEstimator = func(string, *ui.SessionStats) (float64, error) {
+		t.Fatal("/quit must not estimate incomplete active-stream stats")
+		return 0, nil
+	}
+	t.Cleanup(func() { statsCostEstimator = oldEstimator })
+
+	m := newTestChatModel(false)
+	m.showStats = true
+	m.streaming = true
+	m.stats = ui.NewSessionStats()
+	m.stats.AddUsage(1, 1, 0, 0)
+	_, _ = m.cmdQuit()
+}
+
+func TestSeedStatsFromSessionIncludesPersistedCompactions(t *testing.T) {
+	m := newTestChatModel(false)
+	m.sess = &session.Session{LLMTurns: 3, CompactionCount: 2}
+	m.seedStatsFromSession()
+	if m.stats.LLMCallCount != 5 {
+		t.Fatalf("resumed LLM calls = %d, want 5", m.stats.LLMCallCount)
+	}
+}
+
+func TestExitStatsSummaryUsesBalancedOutputAndOmitsUnavailableCost(t *testing.T) {
+	oldEstimator := statsCostEstimator
+	statsCostEstimator = func(string, *ui.SessionStats) (float64, error) {
+		return 0, errors.New("pricing unavailable")
+	}
+	t.Cleanup(func() { statsCostEstimator = oldEstimator })
+
+	m := newTestChatModel(false)
+	m.showStats = true
+	m.stats = ui.NewSessionStats()
+	m.stats.AddUsage(1200, 300, 400, 50)
+
+	out := m.exitStatsSummary()
+	for _, want := range []string{"Stats:", "1.2K in + 400 cached + 50 cache write → 300 out", "1 call"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("exit stats missing %q: %s", want, out)
+		}
+	}
+	if strings.Contains(out, "$") {
+		t.Fatalf("unavailable cost should be omitted: %s", out)
+	}
+}

--- a/internal/tui/chat/stats_race_test.go
+++ b/internal/tui/chat/stats_race_test.go
@@ -1,0 +1,51 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+// This intentionally produces compaction notifications on a separate goroutine
+// while applying every stats mutation serially through Update, matching Bubble
+// Tea's runtime ownership model. Run under -race to guard against reintroducing
+// direct callback-goroutine SessionStats mutation.
+func TestCompactionUsageMessagesMutateStatsOnlyThroughUpdate(t *testing.T) {
+	m := newTestChatModel(false)
+	m.stats = ui.NewSessionStats()
+	m.stats.SetModel("main-model")
+	m.stats.RequestStart()
+	m.stats.ObserveOutput()
+
+	messages := make(chan compactionUsageMsg)
+	go func() {
+		defer close(messages)
+		for range 100 {
+			messages <- compactionUsageMsg{
+				model: " compact-model ",
+				usage: llm.Usage{InputTokens: 2, OutputTokens: 1},
+			}
+		}
+	}()
+	for msg := range messages {
+		if _, cmd := m.Update(msg); cmd != nil {
+			t.Fatal("compaction usage message unexpectedly returned a command")
+		}
+	}
+
+	if m.stats.CompactionLLMCallCount != 100 || m.stats.LLMCallCount != 100 {
+		t.Fatalf("compaction counts = %d/%d, want 100/100", m.stats.CompactionLLMCallCount, m.stats.LLMCallCount)
+	}
+	calls, _ := m.stats.UsageCalls()
+	if len(calls) != 100 || calls[0].Model != "compact-model" {
+		t.Fatalf("compaction calls = %#v", calls)
+	}
+
+	// The pending main request remains intact after all compaction messages.
+	m.stats.AddUsage(5, 2, 0, 0)
+	calls, _ = m.stats.UsageCalls()
+	if calls[len(calls)-1].Model != "main-model" || !calls[len(calls)-1].ObservedOutput {
+		t.Fatalf("pending main call was clobbered: %+v", calls[len(calls)-1])
+	}
+}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -495,6 +495,10 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	m.resetRetainedStreamTracker()
 	m.phase = "Thinking"
 	m.streamStartTime = time.Now()
+	if m.stats != nil {
+		m.stats.SetModel(m.statsPricingModel())
+		m.stats.RequestStart()
+	}
 	if m.altScreen {
 		m.scrollToBottom = true
 	}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -247,8 +247,12 @@ func (m *Model) streamCompactionCallback(streamSess *session.Session) llm.Compac
 		if refreshed != nil {
 			m.sess = refreshed
 		}
-		if result != nil {
-			m.recordCompactionUsage(ctx, streamSessionID, result.Usage)
+		if result != nil && m.program != nil {
+			m.program.Send(compactionUsageMsg{
+				sessionID: streamSessionID,
+				model:     result.Model,
+				usage:     result.Usage,
+			})
 		}
 		if m.engine != nil {
 			m.engine.SetContextEstimateBaseline(0, 0)

--- a/internal/ui/stats.go
+++ b/internal/ui/stats.go
@@ -2,93 +2,119 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
+
+// UsageCall is usage and performance data for one provider request made by this
+// process. Keeping request boundaries is important because some pricing tiers
+// apply to each request independently.
+type UsageCall struct {
+	Model             string
+	InputTokens       int
+	OutputTokens      int
+	CachedInputTokens int
+	CacheWriteTokens  int
+	TTFT              time.Duration
+	GenerationTime    time.Duration
+	ObservedOutput    bool
+}
 
 // SessionStats tracks statistics for a session.
 type SessionStats struct {
 	StartTime         time.Time
 	InputTokens       int
 	OutputTokens      int
-	CachedInputTokens int // Tokens read from cache
-	CacheWriteTokens  int // Tokens written to cache
+	CachedInputTokens int
+	CacheWriteTokens  int
 	ToolCallCount     int
-	LLMCallCount      int // Number of LLM API calls made
+	LLMCallCount      int
 
-	// Compaction usage is included in the cumulative token counters above and
-	// tracked separately so UIs can show how much the summary helper calls cost.
 	CompactionInputTokens       int
 	CompactionOutputTokens      int
 	CompactionCachedInputTokens int
 	CompactionCacheWriteTokens  int
 	CompactionLLMCallCount      int
 
-	// Per-call tracking (current process only, not seeded from persisted data)
-	lastInputTokens  int  // Input tokens from most recent LLM call
-	lastOutputTokens int  // Output tokens from most recent LLM call
-	peakInputTokens  int  // Highest input tokens seen in any single LLM call
-	hasPerCallUsage  bool // True after first AddUsage in this process
+	lastInputTokens  int
+	lastOutputTokens int
+	peakInputTokens  int
+	hasPerCallUsage  bool
 
-	// Time tracking
 	LLMTime       time.Duration
 	ToolTime      time.Duration
 	lastEventTime time.Time
 	inTool        bool
+
+	currentModel       string
+	requestStartTime   time.Time
+	firstActivityTime  time.Time
+	activityStartTime  time.Time
+	activityDuration   time.Duration
+	usageCalls         []UsageCall
+	hasHistoricalUsage bool
+	estimatedCostUSD   *float64
 }
 
-// NewSessionStats creates a new SessionStats with StartTime set to now.
 func NewSessionStats() *SessionStats {
 	now := time.Now()
-	return &SessionStats{
-		StartTime:     now,
-		lastEventTime: now,
-	}
+	return &SessionStats{StartTime: now, lastEventTime: now}
 }
 
 // SeedTotals initializes cumulative counters from persisted session metrics.
-// Timing remains scoped to the current process run.
+// Process-local call, timing, model, and cost state is reset: persisted totals
+// do not contain enough request detail to price or calculate throughput safely.
 func (s *SessionStats) SeedTotals(input, output, cached, cacheWrite, toolCalls, llmCalls int) {
-	s.InputTokens = input
-	s.OutputTokens = output
-	s.CachedInputTokens = cached
-	s.CacheWriteTokens = cacheWrite
-	s.ToolCallCount = toolCalls
-	s.LLMCallCount = llmCalls
-	// Reset compaction-only fields; persisted sessions store only cumulative
-	// token metrics today, not a separate compaction-cost breakdown.
-	s.CompactionInputTokens = 0
-	s.CompactionOutputTokens = 0
-	s.CompactionCachedInputTokens = 0
-	s.CompactionCacheWriteTokens = 0
+	s.InputTokens, s.OutputTokens = input, output
+	s.CachedInputTokens, s.CacheWriteTokens = cached, cacheWrite
+	s.ToolCallCount, s.LLMCallCount = toolCalls, llmCalls
+	s.CompactionInputTokens, s.CompactionOutputTokens = 0, 0
+	s.CompactionCachedInputTokens, s.CompactionCacheWriteTokens = 0, 0
 	s.CompactionLLMCallCount = 0
-	// Reset per-call fields so stale data from prior usage doesn't leak through
-	s.lastInputTokens = 0
-	s.lastOutputTokens = 0
-	s.peakInputTokens = 0
+	s.lastInputTokens, s.lastOutputTokens, s.peakInputTokens = 0, 0, 0
 	s.hasPerCallUsage = false
+	s.currentModel = ""
+	s.requestStartTime, s.activityStartTime = time.Time{}, time.Time{}
+	s.activityDuration = 0
+	s.usageCalls = nil
+	s.hasHistoricalUsage = input != 0 || output != 0 || cached != 0 || cacheWrite != 0 || llmCalls != 0
+	s.estimatedCostUSD = nil
 }
 
-// AddUsage adds token usage to the stats and increments the LLM call count.
+// SetModel sets the model attached to subsequently completed usage calls.
+func (s *SessionStats) SetModel(model string) { s.currentModel = strings.TrimSpace(model) }
+
 func (s *SessionStats) AddUsage(input, output, cached, cacheWrite int) {
+	s.addUsageAt(input, output, cached, cacheWrite, time.Now(), true)
+}
+
+func (s *SessionStats) addUsageAt(input, output, cached, cacheWrite int, now time.Time, recordPerformance bool) {
+	s.stopActivityAt(now)
 	s.InputTokens += input
 	s.OutputTokens += output
 	s.CachedInputTokens += cached
 	s.CacheWriteTokens += cacheWrite
 	s.LLMCallCount++
 	totalContext := input + cached + output
-	s.lastInputTokens = totalContext
-	s.lastOutputTokens = output
-	s.hasPerCallUsage = true
+	s.lastInputTokens, s.lastOutputTokens, s.hasPerCallUsage = totalContext, output, true
 	if totalContext > s.peakInputTokens {
 		s.peakInputTokens = totalContext
 	}
+
+	call := UsageCall{Model: s.currentModel, InputTokens: input, OutputTokens: output, CachedInputTokens: cached, CacheWriteTokens: cacheWrite}
+	if recordPerformance && s.activityDuration > 0 {
+		call.ObservedOutput = true
+		call.GenerationTime = s.activityDuration
+		if !s.requestStartTime.IsZero() && !s.firstActivityTime.IsZero() && !s.firstActivityTime.Before(s.requestStartTime) {
+			call.TTFT = s.firstActivityTime.Sub(s.requestStartTime)
+		}
+	}
+	s.usageCalls = append(s.usageCalls, call)
+	s.resetPendingCall()
 }
 
-// AddCompactionUsage records usage for a compaction helper LLM call. The tokens
-// are included in the overall usage counters and also kept as a compaction-only
-// subtotal for display.
 func (s *SessionStats) AddCompactionUsage(input, output, cached, cacheWrite int) {
-	s.AddUsage(input, output, cached, cacheWrite)
+	s.addUsageAt(input, output, cached, cacheWrite, time.Now(), false)
 	s.CompactionInputTokens += input
 	s.CompactionOutputTokens += output
 	s.CompactionCachedInputTokens += cached
@@ -96,62 +122,122 @@ func (s *SessionStats) AddCompactionUsage(input, output, cached, cacheWrite int)
 	s.CompactionLLMCallCount++
 }
 
-// DiscardUsage removes usage that belonged to an interrupted provisional
-// attempt. Peak/last per-call details are process-local display hints, so reset
-// them conservatively rather than pretending the discarded call committed.
+// DiscardUsage removes provisional usage calls from the tail and resets any
+// uncompleted attempt activity. Performance is always derived from retained
+// call records, so TTFT and throughput are restored exactly after a retry.
 func (s *SessionStats) DiscardUsage(input, output, cached, cacheWrite, calls int) {
-	s.InputTokens -= input
-	if s.InputTokens < 0 {
-		s.InputTokens = 0
+	s.InputTokens = max(0, s.InputTokens-input)
+	s.OutputTokens = max(0, s.OutputTokens-output)
+	s.CachedInputTokens = max(0, s.CachedInputTokens-cached)
+	s.CacheWriteTokens = max(0, s.CacheWriteTokens-cacheWrite)
+	s.LLMCallCount = max(0, s.LLMCallCount-calls)
+	if calls > len(s.usageCalls) {
+		calls = len(s.usageCalls)
 	}
-	s.OutputTokens -= output
-	if s.OutputTokens < 0 {
-		s.OutputTokens = 0
+	if calls > 0 {
+		s.usageCalls = s.usageCalls[:len(s.usageCalls)-calls]
 	}
-	s.CachedInputTokens -= cached
-	if s.CachedInputTokens < 0 {
-		s.CachedInputTokens = 0
-	}
-	s.CacheWriteTokens -= cacheWrite
-	if s.CacheWriteTokens < 0 {
-		s.CacheWriteTokens = 0
-	}
-	s.LLMCallCount -= calls
-	if s.LLMCallCount < 0 {
-		s.LLMCallCount = 0
-	}
-	s.lastInputTokens = 0
-	s.lastOutputTokens = 0
-	s.peakInputTokens = 0
-	s.hasPerCallUsage = false
+	s.rebuildPerCallHints()
+	s.resetPendingCall()
+	s.estimatedCostUSD = nil
 }
 
-// ToolStart marks the start of a tool execution.
+func (s *SessionStats) rebuildPerCallHints() {
+	s.lastInputTokens, s.lastOutputTokens, s.peakInputTokens = 0, 0, 0
+	s.hasPerCallUsage = false
+	for _, call := range s.usageCalls {
+		total := call.InputTokens + call.CachedInputTokens + call.OutputTokens
+		s.lastInputTokens, s.lastOutputTokens, s.hasPerCallUsage = total, call.OutputTokens, true
+		if total > s.peakInputTokens {
+			s.peakInputTokens = total
+		}
+	}
+}
+
+func (s *SessionStats) RequestStart() { s.requestStartAt(time.Now()) }
+func (s *SessionStats) requestStartAt(now time.Time) {
+	s.stopActivityAt(now)
+	s.resetPendingCall()
+	s.requestStartTime = now
+}
+
+// ScheduleRetryStart records when a retried provider request will start. Retry
+// events are emitted before the provider wait, so TTFT must exclude that delay.
+func (s *SessionStats) ScheduleRetryStart(waitSecs float64) {
+	if waitSecs < 0 {
+		waitSecs = 0
+	}
+	s.scheduleRetryStartAt(time.Now(), time.Duration(waitSecs*float64(time.Second)))
+}
+
+func (s *SessionStats) scheduleRetryStartAt(now time.Time, wait time.Duration) {
+	s.stopActivityAt(now)
+	s.resetPendingCall()
+	s.requestStartTime = now.Add(wait)
+}
+
+// ObserveOutput records generation activity. This includes visible text and
+// reasoning as well as hidden/encrypted reasoning events, but not tool calls.
+func (s *SessionStats) ObserveOutput() { s.outputAt(time.Now()) }
+func (s *SessionStats) outputAt(now time.Time) {
+	if s.firstActivityTime.IsZero() {
+		s.firstActivityTime = now
+	}
+	if s.activityStartTime.IsZero() {
+		s.activityStartTime = now
+	}
+}
+
+// GenerationEnd closes the current activity interval. AddUsage associates the
+// accumulated interval with that completed provider request.
+func (s *SessionStats) GenerationEnd() { s.stopActivityAt(time.Now()) }
+func (s *SessionStats) stopActivityAt(now time.Time) {
+	if !s.activityStartTime.IsZero() && !now.Before(s.activityStartTime) {
+		s.activityDuration += now.Sub(s.activityStartTime)
+	}
+	s.activityStartTime = time.Time{}
+}
+func (s *SessionStats) resetPendingCall() {
+	s.requestStartTime, s.firstActivityTime, s.activityStartTime = time.Time{}, time.Time{}, time.Time{}
+	s.activityDuration = 0
+}
+
+// UsageCalls returns current-process calls and whether they represent the whole
+// displayed session. A false completeness value means historical seeded usage
+// prevents a truthful whole-session cost.
+func (s *SessionStats) UsageCalls() ([]UsageCall, bool) {
+	return append([]UsageCall(nil), s.usageCalls...), !s.hasHistoricalUsage
+}
+
+func (s *SessionStats) SetEstimatedCost(cost float64) {
+	if cost >= 0 {
+		s.estimatedCostUSD = &cost
+	}
+}
+func (s *SessionStats) ClearEstimatedCost() { s.estimatedCostUSD = nil }
+
 func (s *SessionStats) ToolStart() {
 	now := time.Now()
+	s.stopActivityAt(now)
 	if !s.inTool {
-		// Was in LLM phase, record LLM time
 		s.LLMTime += now.Sub(s.lastEventTime)
 	}
-	s.lastEventTime = now
-	s.inTool = true
+	s.lastEventTime, s.inTool = now, true
 	s.ToolCallCount++
 }
-
-// ToolEnd marks the end of tool execution (back to LLM).
 func (s *SessionStats) ToolEnd() {
 	now := time.Now()
 	if s.inTool {
-		// Was in tool phase, record tool time
 		s.ToolTime += now.Sub(s.lastEventTime)
 	}
-	s.lastEventTime = now
-	s.inTool = false
+	s.lastEventTime, s.inTool = now, false
+	s.requestStartTime = now
+	s.firstActivityTime = time.Time{}
+	s.activityDuration = 0
 }
-
-// Finalize records any remaining time.
 func (s *SessionStats) Finalize() {
 	now := time.Now()
+	s.stopActivityAt(now)
 	if s.inTool {
 		s.ToolTime += now.Sub(s.lastEventTime)
 	} else {
@@ -160,56 +246,60 @@ func (s *SessionStats) Finalize() {
 	s.lastEventTime = now
 }
 
-// Render returns the stats as a compact single-line string.
 func (s SessionStats) Render() string {
-	total := time.Since(s.StartTime)
-
-	// Format tokens with optional cache info
-	var tokensStr string
-	switch {
-	case s.CachedInputTokens > 0 && s.CacheWriteTokens > 0:
-		tokensStr = fmt.Sprintf("%s in (cache: %s read, %s write) → %s out",
-			FormatTokenCount(s.InputTokens),
-			FormatTokenCount(s.CachedInputTokens),
-			FormatTokenCount(s.CacheWriteTokens),
-			FormatTokenCount(s.OutputTokens))
-	case s.CachedInputTokens > 0:
-		tokensStr = fmt.Sprintf("%s in (cache: %s read) → %s out",
-			FormatTokenCount(s.InputTokens),
-			FormatTokenCount(s.CachedInputTokens),
-			FormatTokenCount(s.OutputTokens))
-	case s.CacheWriteTokens > 0:
-		tokensStr = fmt.Sprintf("%s in (cache: %s write) → %s out",
-			FormatTokenCount(s.InputTokens),
-			FormatTokenCount(s.CacheWriteTokens),
-			FormatTokenCount(s.OutputTokens))
-	default:
-		tokensStr = fmt.Sprintf("%s in → %s out",
-			FormatTokenCount(s.InputTokens),
-			FormatTokenCount(s.OutputTokens))
+	parts := []string{fmt.Sprintf("%.1fs", time.Since(s.StartTime).Seconds())}
+	tokenParts := []string{fmt.Sprintf("%s in", formatStatsTokenCount(s.InputTokens))}
+	if s.CachedInputTokens > 0 {
+		tokenParts = append(tokenParts, fmt.Sprintf("%s cached", formatStatsTokenCount(s.CachedInputTokens)))
 	}
+	if s.CacheWriteTokens > 0 {
+		tokenParts = append(tokenParts, fmt.Sprintf("%s cache write", formatStatsTokenCount(s.CacheWriteTokens)))
+	}
+	parts = append(parts, fmt.Sprintf("%s → %s out", strings.Join(tokenParts, " + "), formatStatsTokenCount(s.OutputTokens)))
 
-	// Append last/peak context info when there's been at least one AddUsage this process
-	if s.hasPerCallUsage {
-		lastStr := fmt.Sprintf("last: %s→%s",
-			FormatTokenCount(s.lastInputTokens),
-			FormatTokenCount(s.lastOutputTokens))
-		if s.peakInputTokens > s.lastInputTokens {
-			tokensStr += fmt.Sprintf(" (%s, peak: %s)", lastStr, FormatTokenCount(s.peakInputTokens))
-		} else {
-			tokensStr += fmt.Sprintf(" (%s)", lastStr)
+	var firstTTFT time.Duration
+	var generated int
+	var generationTime time.Duration
+	for _, call := range s.usageCalls {
+		if !call.ObservedOutput {
+			continue
 		}
+		if firstTTFT == 0 && call.TTFT > 0 {
+			firstTTFT = call.TTFT
+		}
+		generated += call.OutputTokens
+		generationTime += call.GenerationTime
 	}
-
-	// Format time breakdown
-	var timeStr string
+	performance := []string{}
+	if firstTTFT > 0 {
+		performance = append(performance, fmt.Sprintf("TTFT %.1fs", firstTTFT.Seconds()))
+	}
+	if generated > 0 && generationTime > 0 {
+		performance = append(performance, fmt.Sprintf("%.0f tok/s", float64(generated)/generationTime.Seconds()))
+	}
+	if len(performance) > 0 {
+		parts = append(parts, strings.Join(performance, ", "))
+	}
+	if s.estimatedCostUSD != nil {
+		parts = append(parts, fmt.Sprintf("$%.4f", *s.estimatedCostUSD))
+	}
+	activity := []string{}
 	if s.ToolCallCount > 0 {
-		timeStr = fmt.Sprintf("%.1fs (llm %.1fs + tool %.1fs)",
-			total.Seconds(), s.LLMTime.Seconds(), s.ToolTime.Seconds())
-	} else {
-		timeStr = fmt.Sprintf("%.1fs", total.Seconds())
+		activity = append(activity, fmt.Sprintf("%d %s", s.ToolCallCount, plural(s.ToolCallCount, "tool", "tools")))
 	}
+	if s.LLMCallCount > 0 {
+		activity = append(activity, fmt.Sprintf("%d %s", s.LLMCallCount, plural(s.LLMCallCount, "call", "calls")))
+	}
+	if len(activity) > 0 {
+		parts = append(parts, strings.Join(activity, ", "))
+	}
+	return "Stats: " + strings.Join(parts, " | ")
+}
 
-	return fmt.Sprintf("Stats: %s | %s | %d tools | %d llm calls",
-		timeStr, tokensStr, s.ToolCallCount, s.LLMCallCount)
+func formatStatsTokenCount(n int) string { return strings.Replace(FormatTokenCount(n), "k", "K", 1) }
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
 }

--- a/internal/ui/stats.go
+++ b/internal/ui/stats.go
@@ -18,6 +18,7 @@ type UsageCall struct {
 	TTFT              time.Duration
 	GenerationTime    time.Duration
 	ObservedOutput    bool
+	Compaction        bool
 }
 
 // SessionStats tracks statistics for a session.
@@ -74,7 +75,7 @@ func (s *SessionStats) SeedTotals(input, output, cached, cacheWrite, toolCalls, 
 	s.lastInputTokens, s.lastOutputTokens, s.peakInputTokens = 0, 0, 0
 	s.hasPerCallUsage = false
 	s.currentModel = ""
-	s.requestStartTime, s.activityStartTime = time.Time{}, time.Time{}
+	s.requestStartTime, s.firstActivityTime, s.activityStartTime = time.Time{}, time.Time{}, time.Time{}
 	s.activityDuration = 0
 	s.usageCalls = nil
 	s.hasHistoricalUsage = input != 0 || output != 0 || cached != 0 || cacheWrite != 0 || llmCalls != 0
@@ -90,6 +91,12 @@ func (s *SessionStats) AddUsage(input, output, cached, cacheWrite int) {
 
 func (s *SessionStats) addUsageAt(input, output, cached, cacheWrite int, now time.Time, recordPerformance bool) {
 	s.stopActivityAt(now)
+	if input == 0 && output == 0 && cached == 0 && cacheWrite == 0 {
+		// Some providers emit a terminal usage event with no counters. It still
+		// completes the pending request timing, but is not a meaningful usage call.
+		s.resetPendingCall()
+		return
+	}
 	s.InputTokens += input
 	s.OutputTokens += output
 	s.CachedInputTokens += cached
@@ -113,8 +120,36 @@ func (s *SessionStats) addUsageAt(input, output, cached, cacheWrite int, now tim
 	s.resetPendingCall()
 }
 
+// AddCompactionUsage records a helper compaction call against the current model.
+// Unlike AddUsage, it deliberately leaves pending main-call timing untouched.
 func (s *SessionStats) AddCompactionUsage(input, output, cached, cacheWrite int) {
-	s.addUsageAt(input, output, cached, cacheWrite, time.Now(), false)
+	s.AddCompactionUsageForModel(s.currentModel, input, output, cached, cacheWrite)
+}
+
+// AddCompactionUsageForModel records compaction usage against the model that
+// performed it without changing the model or timing of a pending main call.
+func (s *SessionStats) AddCompactionUsageForModel(model string, input, output, cached, cacheWrite int) {
+	if input == 0 && output == 0 && cached == 0 && cacheWrite == 0 {
+		return
+	}
+	s.InputTokens += input
+	s.OutputTokens += output
+	s.CachedInputTokens += cached
+	s.CacheWriteTokens += cacheWrite
+	s.LLMCallCount++
+	totalContext := input + cached + output
+	s.lastInputTokens, s.lastOutputTokens, s.hasPerCallUsage = totalContext, output, true
+	if totalContext > s.peakInputTokens {
+		s.peakInputTokens = totalContext
+	}
+	s.usageCalls = append(s.usageCalls, UsageCall{
+		Model:             strings.TrimSpace(model),
+		InputTokens:       input,
+		OutputTokens:      output,
+		CachedInputTokens: cached,
+		CacheWriteTokens:  cacheWrite,
+		Compaction:        true,
+	})
 	s.CompactionInputTokens += input
 	s.CompactionOutputTokens += output
 	s.CompactionCachedInputTokens += cached
@@ -131,11 +166,13 @@ func (s *SessionStats) DiscardUsage(input, output, cached, cacheWrite, calls int
 	s.CachedInputTokens = max(0, s.CachedInputTokens-cached)
 	s.CacheWriteTokens = max(0, s.CacheWriteTokens-cacheWrite)
 	s.LLMCallCount = max(0, s.LLMCallCount-calls)
-	if calls > len(s.usageCalls) {
-		calls = len(s.usageCalls)
-	}
-	if calls > 0 {
-		s.usageCalls = s.usageCalls[:len(s.usageCalls)-calls]
+	remaining := calls
+	for i := len(s.usageCalls) - 1; i >= 0 && remaining > 0; i-- {
+		if s.usageCalls[i].Compaction {
+			continue
+		}
+		s.usageCalls = append(s.usageCalls[:i], s.usageCalls[i+1:]...)
+		remaining--
 	}
 	s.rebuildPerCallHints()
 	s.resetPendingCall()

--- a/internal/ui/stats_cost.go
+++ b/internal/ui/stats_cost.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/usage"
+)
+
+// EstimateSessionStatsCost prices each current-process provider request
+// separately using bundled or already-cached pricing only.
+func EstimateSessionStatsCost(stats *SessionStats, fallbackModel string) (float64, error) {
+	if stats == nil {
+		return 0, fmt.Errorf("no usage recorded")
+	}
+	calls, complete := stats.UsageCalls()
+	if !complete {
+		return 0, fmt.Errorf("resumed session has unpriced historical usage")
+	}
+	if len(calls) == 0 {
+		return 0, fmt.Errorf("no current-process usage recorded")
+	}
+
+	fetcher := usage.NewPricingFetcher()
+	var total float64
+	for _, call := range calls {
+		model := strings.TrimSpace(call.Model)
+		if model == "" {
+			model = strings.TrimSpace(fallbackModel)
+		}
+		if model == "" {
+			return 0, fmt.Errorf("model unknown")
+		}
+		cost, err := fetcher.CalculateCostLocal(usage.UsageEntry{
+			Model:            model,
+			InputTokens:      call.InputTokens,
+			OutputTokens:     call.OutputTokens,
+			CacheReadTokens:  call.CachedInputTokens,
+			CacheWriteTokens: call.CacheWriteTokens,
+			Provider:         usage.ProviderTermLLM,
+		})
+		if err != nil {
+			return 0, err
+		}
+		total += cost
+	}
+	return total, nil
+}

--- a/internal/ui/stats_test.go
+++ b/internal/ui/stats_test.go
@@ -291,6 +291,63 @@ func TestDiscardRestoresPerformanceFromRetainedCalls(t *testing.T) {
 	}
 }
 
+func TestDiscardKeepsInterleavedCompactionCall(t *testing.T) {
+	stats := NewSessionStats()
+	stats.AddUsage(10, 2, 0, 0)
+	stats.AddCompactionUsageForModel("compact-model", 20, 3, 0, 0)
+
+	stats.DiscardUsage(10, 2, 0, 0, 1)
+
+	calls, _ := stats.UsageCalls()
+	if len(calls) != 1 || !calls[0].Compaction || calls[0].Model != "compact-model" {
+		t.Fatalf("discard removed the durable compaction call: %+v", calls)
+	}
+	if stats.LLMCallCount != 1 || stats.InputTokens != 20 || stats.OutputTokens != 3 {
+		t.Fatalf("totals after discard = %+v, want only compaction usage", stats)
+	}
+}
+
+func TestAddCompactionUsagePreservesPendingMainCallTimingAndModel(t *testing.T) {
+	stats := NewSessionStats()
+	base := time.Now().Add(-5 * time.Second)
+	stats.SetModel("main-model")
+	stats.requestStartAt(base)
+	stats.outputAt(base.Add(time.Second))
+	stats.stopActivityAt(base.Add(2 * time.Second))
+
+	stats.AddCompactionUsageForModel("  compact-model  ", 20, 5, 3, 2)
+	if stats.requestStartTime != base || stats.firstActivityTime != base.Add(time.Second) || stats.activityDuration != time.Second {
+		t.Fatalf("compaction disturbed pending timing: %+v", stats)
+	}
+
+	stats.outputAt(base.Add(3 * time.Second))
+	stats.addUsageAt(10, 4, 0, 0, base.Add(4*time.Second), true)
+	calls, _ := stats.UsageCalls()
+	if len(calls) != 2 {
+		t.Fatalf("usage calls = %d, want 2", len(calls))
+	}
+	if calls[0].Model != "compact-model" || calls[1].Model != "main-model" {
+		t.Fatalf("call models = %q, %q", calls[0].Model, calls[1].Model)
+	}
+	if calls[1].TTFT != time.Second || calls[1].GenerationTime != 2*time.Second {
+		t.Fatalf("main-call timing = TTFT %v generation %v", calls[1].TTFT, calls[1].GenerationTime)
+	}
+}
+
+func TestAllZeroUsageConsumesPendingTimingWithoutRecordingCall(t *testing.T) {
+	stats := NewSessionStats()
+	stats.RequestStart()
+	stats.ObserveOutput()
+	stats.AddUsage(0, 0, 0, 0)
+
+	if stats.LLMCallCount != 0 || len(stats.usageCalls) != 0 {
+		t.Fatalf("zero usage recorded a meaningful call: %+v", stats)
+	}
+	if !stats.requestStartTime.IsZero() || !stats.firstActivityTime.IsZero() || !stats.activityStartTime.IsZero() || stats.activityDuration != 0 {
+		t.Fatalf("zero usage retained pending timing: %+v", stats)
+	}
+}
+
 func TestSeedTotalsResetsProcessLocalState(t *testing.T) {
 	stats := NewSessionStats()
 	stats.SetModel("old")

--- a/internal/ui/stats_test.go
+++ b/internal/ui/stats_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSessionStatsSeedTotals(t *testing.T) {
@@ -112,11 +113,12 @@ func TestSeedTotalsClearsPerCallState(t *testing.T) {
 		t.Errorf("expected no last/peak after reseed without AddUsage, got: %s", out)
 	}
 
-	// New AddUsage should work normally after reseed
+	// New AddUsage should preserve per-call tracking without adding the old,
+	// overly detailed last/peak diagnostics to balanced --stats.
 	stats.AddUsage(3000, 300, 0, 0)
 	out = stats.Render()
-	if !strings.Contains(out, "last:") {
-		t.Errorf("expected last info after AddUsage post-reseed, got: %s", out)
+	if strings.Contains(out, "last:") || strings.Contains(out, "peak:") {
+		t.Errorf("balanced stats should omit last/peak details, got: %s", out)
 	}
 }
 
@@ -157,20 +159,20 @@ func TestRenderCacheLabels(t *testing.T) {
 			name:        "both read and write",
 			cached:      500,
 			write:       7500,
-			wantContain: "cache: 500 read, 7.5k write",
+			wantContain: "500 cached + 7.5K cache write",
 		},
 		{
 			name:        "read only",
 			cached:      500,
 			write:       0,
-			wantContain: "cache: 500 read",
-			wantAbsent:  "write",
+			wantContain: "500 cached",
+			wantAbsent:  "cache write",
 		},
 		{
 			name:        "write only",
 			cached:      0,
 			write:       7500,
-			wantContain: "cache: 7.5k write",
+			wantContain: "7.5K cache write",
 			wantAbsent:  "read",
 		},
 		{
@@ -203,32 +205,108 @@ func TestRenderCacheLabels(t *testing.T) {
 	}
 }
 
-func TestRenderIncludesLastAndPeak(t *testing.T) {
+func TestRenderBalancedStatsWithTimingCostAndCacheWrite(t *testing.T) {
 	stats := NewSessionStats()
+	base := time.Now().Add(-12300 * time.Millisecond)
+	stats.StartTime = base
+	stats.requestStartAt(base)
+	stats.outputAt(base.Add(800 * time.Millisecond))
+	stats.addUsageAt(24_000, 1_200, 18_000, 2_000, base.Add(1300*time.Millisecond), true)
+	stats.ToolCallCount = 3
+	stats.LLMCallCount = 4
+	stats.SetEstimatedCost(0.084)
 
-	// No calls yet — should not include last/peak
 	out := stats.Render()
-	if strings.Contains(out, "last:") {
-		t.Errorf("expected no last/peak before any calls, got: %s", out)
+	for _, want := range []string{
+		"Stats: 12.3s | 24K in + 18K cached + 2.0K cache write → 1.2K out",
+		"TTFT 0.8s, 2400 tok/s",
+		"$0.0840",
+		"3 tools, 4 calls",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in render output, got: %s", want, out)
+		}
 	}
+}
 
-	// Single call — last == peak, so no "peak:" shown
-	stats.AddUsage(1000, 200, 0, 0)
-	out = stats.Render()
-	if !strings.Contains(out, "(last:") {
-		t.Errorf("expected last info in render, got: %s", out)
+func TestRenderGracefullyOmitsUnavailablePerformanceCostAndActivity(t *testing.T) {
+	stats := NewSessionStats()
+	out := stats.Render()
+	for _, absent := range []string{"TTFT", "tok/s", "$", "tools", "calls", "last:", "peak:"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("did not expect %q in render output, got: %s", absent, out)
+		}
 	}
-	if strings.Contains(out, "peak:") {
-		t.Errorf("expected no peak when last == peak, got: %s", out)
+	if !strings.Contains(out, "0 in → 0 out") {
+		t.Errorf("expected token accounting to remain present, got: %s", out)
 	}
+}
 
-	// Second call with lower input — peak > last, so "peak:" should appear
-	stats.AddUsage(500, 100, 0, 0)
-	out = stats.Render()
-	if !strings.Contains(out, "last:") {
-		t.Errorf("expected last info in render, got: %s", out)
+func TestGenerationRateUsesOnlyObservedCompletedCalls(t *testing.T) {
+	stats := NewSessionStats()
+	base := time.Now().Add(-10 * time.Second)
+
+	// A tool-only generation reports output usage but has no observed generation
+	// activity, so it must not inflate throughput.
+	stats.requestStartAt(base)
+	stats.addUsageAt(10, 900, 0, 0, base.Add(time.Second), true)
+
+	stats.requestStartAt(base.Add(2 * time.Second))
+	stats.outputAt(base.Add(3 * time.Second))
+	stats.addUsageAt(10, 100, 0, 0, base.Add(5*time.Second), true)
+
+	out := stats.Render()
+	if !strings.Contains(out, "50 tok/s") {
+		t.Fatalf("rate should use only 100 observed tokens over 2s, got: %s", out)
 	}
-	if !strings.Contains(out, "peak:") {
-		t.Errorf("expected peak info when peak > last, got: %s", out)
+	if !strings.Contains(out, "TTFT 1.0s") {
+		t.Fatalf("TTFT should come from the observed call, got: %s", out)
+	}
+}
+
+func TestAttemptDiscardWithoutUsageClearsPendingTiming(t *testing.T) {
+	stats := NewSessionStats()
+	stats.RequestStart()
+	stats.ObserveOutput()
+	stats.DiscardUsage(0, 0, 0, 0, 0)
+	if !stats.requestStartTime.IsZero() || !stats.firstActivityTime.IsZero() || !stats.activityStartTime.IsZero() || stats.activityDuration != 0 {
+		t.Fatalf("attempt discard retained pending timing: %+v", stats)
+	}
+}
+
+func TestDiscardRestoresPerformanceFromRetainedCalls(t *testing.T) {
+	stats := NewSessionStats()
+	base := time.Now().Add(-10 * time.Second)
+	stats.requestStartAt(base)
+	stats.outputAt(base.Add(time.Second))
+	stats.addUsageAt(10, 100, 0, 0, base.Add(3*time.Second), true) // 50 tok/s
+	stats.requestStartAt(base.Add(4 * time.Second))
+	stats.outputAt(base.Add(8 * time.Second))
+	stats.addUsageAt(10, 1000, 0, 0, base.Add(9*time.Second), true)
+	stats.DiscardUsage(10, 1000, 0, 0, 1)
+
+	out := stats.Render()
+	if !strings.Contains(out, "TTFT 1.0s, 50 tok/s") {
+		t.Fatalf("discard should restore retained-call timing, got: %s", out)
+	}
+}
+
+func TestSeedTotalsResetsProcessLocalState(t *testing.T) {
+	stats := NewSessionStats()
+	stats.SetModel("old")
+	stats.RequestStart()
+	stats.ObserveOutput()
+	stats.AddUsage(1, 1, 0, 0)
+	stats.SetEstimatedCost(1)
+	stats.SeedTotals(10, 20, 0, 0, 0, 1)
+	calls, complete := stats.UsageCalls()
+	if complete || len(calls) != 0 {
+		t.Fatalf("seeded calls = %v, complete=%v", calls, complete)
+	}
+	out := stats.Render()
+	for _, absent := range []string{"TTFT", "tok/s", "$"} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("SeedTotals retained %q: %s", absent, out)
+		}
 	}
 }

--- a/internal/ui/stream_adapter.go
+++ b/internal/ui/stream_adapter.go
@@ -87,6 +87,7 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 		ctx = context.Background()
 	}
 	defer close(a.events)
+	a.stats.RequestStart()
 
 	emit := func(event StreamEvent) bool {
 		if ctx.Err() != nil {
@@ -132,6 +133,7 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 		case llm.EventTextDelta:
 			a.attemptUsageCommitted = false
 			if event.Text != "" {
+				a.stats.ObserveOutput()
 				if !emit(TextEvent(event.Text)) {
 					return
 				}
@@ -141,11 +143,18 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 			a.attemptUsageCommitted = false
 			kind := llm.NormalizeReasoningKind(event.ReasoningKind)
 			if llm.IsEncryptedReasoningDelta(event) {
-				// Encrypted replay metadata never enters UI stream events.
+				a.stats.ObserveOutput()
+				// Preserve generation timing without exposing encrypted replay data.
+				if !emit(GenerationActivityEvent()) {
+					return
+				}
 				continue
 			}
 			if event.Text == "" && event.ReasoningItemID == "" && !event.ReasoningFinal {
 				continue
+			}
+			if event.Text != "" {
+				a.stats.ObserveOutput()
 			}
 			title := ""
 			displayable := kind == llm.ReasoningKindSummary
@@ -240,20 +249,20 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 			}
 
 		case llm.EventRetry:
+			a.stats.ScheduleRetryStart(event.RetryWaitSecs)
 			if !emit(RetryEvent(event.RetryAttempt, event.RetryMaxAttempts, event.RetryWaitSecs)) {
 				return
 			}
 
 		case llm.EventAttemptDiscard:
-			if a.attemptUsageCalls > 0 {
-				a.stats.DiscardUsage(a.attemptInput, a.attemptOutput, a.attemptCached, a.attemptCacheWrite, a.attemptUsageCalls)
-			}
+			a.stats.DiscardUsage(a.attemptInput, a.attemptOutput, a.attemptCached, a.attemptCacheWrite, a.attemptUsageCalls)
 			a.resetAttemptUsage()
 			if !emit(AttemptDiscardEvent()) {
 				return
 			}
 
 		case llm.EventUsage:
+			a.stats.GenerationEnd()
 			if event.Use != nil {
 				totalTokens = event.Use.OutputTokens
 				usageEvent := UsageEvent(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
@@ -283,6 +292,7 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 				model = event.Text
 			}
 			if model != "" {
+				a.stats.SetModel(model)
 				if !emit(ModelSwitchEvent(model, event.ReasoningEffort)) {
 					return
 				}

--- a/internal/ui/stream_adapter.go
+++ b/internal/ui/stream_adapter.go
@@ -270,7 +270,7 @@ func (a *StreamAdapter) ProcessStream(ctx context.Context, stream llm.Stream) {
 					return
 				}
 				a.stats.AddUsage(event.Use.InputTokens, event.Use.OutputTokens, event.Use.CachedInputTokens, event.Use.CacheWriteTokens)
-				if !a.attemptUsageCommitted {
+				if !event.Use.BillableCountersZero() && !a.attemptUsageCommitted {
 					a.attemptInput += event.Use.InputTokens
 					a.attemptOutput += event.Use.OutputTokens
 					a.attemptCached += event.Use.CachedInputTokens

--- a/internal/ui/stream_adapter_test.go
+++ b/internal/ui/stream_adapter_test.go
@@ -124,8 +124,8 @@ func TestStreamAdapterEmitsDiffOperation(t *testing.T) {
 	var diffEvent *StreamEvent
 	for ev := range adapter.Events() {
 		if ev.Type == StreamEventDiff {
-			copy := ev
-			diffEvent = &copy
+			eventCopy := ev
+			diffEvent = &eventCopy
 		}
 	}
 
@@ -134,6 +134,35 @@ func TestStreamAdapterEmitsDiffOperation(t *testing.T) {
 	}
 	if diffEvent.DiffOperation != llm.DiffOperationCreate {
 		t.Fatalf("diff operation = %q, want %q", diffEvent.DiffOperation, llm.DiffOperationCreate)
+	}
+}
+
+func TestStreamAdapterAllZeroUsageConsumesTimingWithoutCall(t *testing.T) {
+	stream := &testStream{events: []llm.Event{
+		{Type: llm.EventTextDelta, Text: "activity"},
+		{Type: llm.EventUsage, Use: &llm.Usage{}},
+	}}
+	adapter := NewStreamAdapter(10)
+	go adapter.ProcessStream(context.Background(), stream)
+
+	var usageEvents int
+	for event := range adapter.Events() {
+		if event.Type == StreamEventUsage {
+			usageEvents++
+		}
+	}
+	if usageEvents != 1 {
+		t.Fatalf("usage events = %d, want 1", usageEvents)
+	}
+	stats := adapter.Stats()
+	if stats.LLMCallCount != 0 {
+		t.Fatalf("zero usage incremented call count: %+v", stats)
+	}
+	if adapter.attemptUsageCalls != 0 {
+		t.Fatalf("zero usage incremented provisional attempt calls: %d", adapter.attemptUsageCalls)
+	}
+	if !stats.requestStartTime.IsZero() || !stats.firstActivityTime.IsZero() || !stats.activityStartTime.IsZero() || stats.activityDuration != 0 {
+		t.Fatalf("zero usage retained pending timing: %+v", stats)
 	}
 }
 

--- a/internal/ui/stream_adapter_test.go
+++ b/internal/ui/stream_adapter_test.go
@@ -302,6 +302,58 @@ func TestParseDiffMarkers(t *testing.T) {
 	}
 }
 
+type retryDelayStream struct {
+	testStream
+	delayed bool
+}
+
+func (s *retryDelayStream) Recv() (llm.Event, error) {
+	event, err := s.testStream.Recv()
+	if err == nil && !s.delayed && event.Type == llm.EventTextDelta {
+		s.delayed = true
+		time.Sleep(60 * time.Millisecond)
+	}
+	return event, err
+}
+
+func TestStreamAdapterRetryWaitExcludedFromReplacementTTFT(t *testing.T) {
+	stream := &retryDelayStream{testStream: testStream{events: []llm.Event{
+		{Type: llm.EventAttemptDiscard},
+		{Type: llm.EventRetry, RetryWaitSecs: 0.04},
+		{Type: llm.EventTextDelta, Text: "replacement"},
+		{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 2, OutputTokens: 3}},
+	}}}
+	adapter := NewStreamAdapter(10)
+	adapter.Stats().RequestStart()
+	go adapter.ProcessStream(context.Background(), stream)
+	for range adapter.Events() {
+	}
+	calls, _ := adapter.Stats().UsageCalls()
+	if len(calls) != 1 || !calls[0].ObservedOutput {
+		t.Fatalf("replacement call = %+v", calls)
+	}
+	if calls[0].TTFT < 10*time.Millisecond || calls[0].TTFT > 45*time.Millisecond {
+		t.Fatalf("replacement TTFT = %s, want retry wait excluded", calls[0].TTFT)
+	}
+}
+
+func TestStreamAdapterAssociatesUsageWithModelSwitches(t *testing.T) {
+	stream := &testStream{events: []llm.Event{
+		{Type: llm.EventModelSwitch, Model: "gpt-5.6-sol"},
+		{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 1}},
+		{Type: llm.EventModelSwitch, Model: "gpt-5.6-luna"},
+		{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 2}},
+	}}
+	adapter := NewStreamAdapter(10)
+	go adapter.ProcessStream(context.Background(), stream)
+	for range adapter.Events() {
+	}
+	calls, _ := adapter.Stats().UsageCalls()
+	if len(calls) != 2 || calls[0].Model != "gpt-5.6-sol" || calls[1].Model != "gpt-5.6-luna" {
+		t.Fatalf("usage models = %+v", calls)
+	}
+}
+
 func TestStreamAdapterDiscardRemovesAttemptUsage(t *testing.T) {
 	stream := &testStream{events: []llm.Event{
 		{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 10, OutputTokens: 5, CachedInputTokens: 2, CacheWriteTokens: 1}},
@@ -372,6 +424,25 @@ func TestStreamAdapterForwardsClassifiedReasoningSummary(t *testing.T) {
 	}
 	if !got.ReasoningDisplayable {
 		t.Fatal("summary should be marked displayable")
+	}
+}
+
+func TestStreamAdapterHiddenReasoningCountsAsGenerationActivity(t *testing.T) {
+	stream := &testStream{events: []llm.Event{
+		{Type: llm.EventReasoningDelta, ReasoningKind: llm.ReasoningKindEncrypted, ReasoningEncryptedContent: "secret"},
+		{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 3, OutputTokens: 4}},
+	}}
+	adapter := NewStreamAdapter(10)
+	go adapter.ProcessStream(context.Background(), stream)
+	var sawActivity bool
+	for ev := range adapter.Events() {
+		if ev.Type == StreamEventGenerationActivity {
+			sawActivity = true
+		}
+	}
+	calls, _ := adapter.Stats().UsageCalls()
+	if !sawActivity || len(calls) != 1 || !calls[0].ObservedOutput {
+		t.Fatalf("hidden reasoning activity not associated with usage: event=%v calls=%+v", sawActivity, calls)
 	}
 }
 

--- a/internal/ui/stream_event.go
+++ b/internal/ui/stream_event.go
@@ -24,8 +24,9 @@ const (
 	StreamEventInterjection // User interjected a message mid-stream
 	StreamEventModelSwitch  // Request model changed at a provider-turn boundary
 	StreamEventAttemptDiscard
-	StreamEventReasoning  // Classified, non-encrypted reasoning text/metadata
-	StreamEventFileChange // Recorded file change metadata (file tracking)
+	StreamEventReasoning          // Classified, non-encrypted reasoning text/metadata
+	StreamEventGenerationActivity // Hidden generation activity (for timing only)
+	StreamEventFileChange         // Recorded file change metadata (file tracking)
 )
 
 // StreamEvent represents a unified event from the LLM stream.
@@ -103,6 +104,10 @@ func TextEvent(text string) StreamEvent {
 
 func AttemptDiscardEvent() StreamEvent {
 	return StreamEvent{Type: StreamEventAttemptDiscard}
+}
+
+func GenerationActivityEvent() StreamEvent {
+	return StreamEvent{Type: StreamEventGenerationActivity}
 }
 
 // ReasoningEvent creates a classified, non-encrypted reasoning stream event.

--- a/internal/usage/pricing.go
+++ b/internal/usage/pricing.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -136,37 +137,7 @@ func (p *PricingFetcher) GetPricing(modelName string) (ModelPricing, error) {
 	if err := p.ensureLoaded(); err != nil {
 		return ModelPricing{}, err
 	}
-
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	// Try exact match first
-	if pricing, ok := p.cache[modelName]; ok {
-		return pricing, nil
-	}
-
-	// Try with different provider prefixes
-	for _, prefix := range providerPrefixes {
-		key := prefix + modelName
-		if pricing, ok := p.cache[key]; ok {
-			return pricing, nil
-		}
-	}
-
-	if pricing, ok := lookupBundledPricing(modelName); ok {
-		return pricing, nil
-	}
-
-	// Try case-insensitive partial matching
-	lower := strings.ToLower(modelName)
-	for key, pricing := range p.cache {
-		keyLower := strings.ToLower(key)
-		if strings.Contains(keyLower, lower) || strings.Contains(lower, keyLower) {
-			return pricing, nil
-		}
-	}
-
-	return ModelPricing{}, fmt.Errorf("pricing not found for model: %s", modelName)
+	return p.lookupLoadedPricing(modelName)
 }
 
 func lookupBundledPricing(modelName string) (ModelPricing, bool) {
@@ -324,10 +295,15 @@ func (p *PricingFetcher) lookupLoadedPricing(modelName string) (ModelPricing, er
 		}
 	}
 	lower := strings.ToLower(modelName)
-	for key, pricing := range p.cache {
+	keys := make([]string, 0, len(p.cache))
+	for key := range p.cache {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
 		keyLower := strings.ToLower(key)
 		if strings.Contains(keyLower, lower) || strings.Contains(lower, keyLower) {
-			return pricing, nil
+			return p.cache[key], nil
 		}
 	}
 	return ModelPricing{}, fmt.Errorf("pricing not found for model: %s", modelName)

--- a/internal/usage/pricing.go
+++ b/internal/usage/pricing.go
@@ -38,11 +38,13 @@ type ModelPricing struct {
 
 // PricingFetcher fetches and caches model pricing from LiteLLM
 type PricingFetcher struct {
-	mu         sync.RWMutex
-	cache      map[string]ModelPricing
-	lastFetch  time.Time
-	cacheDir   string
-	httpClient *http.Client
+	mu           sync.RWMutex
+	cache        map[string]ModelPricing
+	lastFetch    time.Time
+	cacheDir     string
+	httpClient   *http.Client
+	localOnce    sync.Once
+	localLoadErr error
 }
 
 // NewPricingFetcher creates a new pricing fetcher
@@ -286,6 +288,63 @@ func (p *PricingFetcher) parseData(data []byte) error {
 	return nil
 }
 
+// GetPricingLocal returns bundled pricing or pricing from the existing on-disk
+// cache. It never performs a network request and accepts stale cache data: exit
+// summaries must remain immediate even when the network is unavailable.
+func (p *PricingFetcher) GetPricingLocal(modelName string) (ModelPricing, error) {
+	if pricing, ok := lookupBundledPricing(modelName); ok {
+		return pricing, nil
+	}
+	p.localOnce.Do(func() {
+		cacheFile := filepath.Join(p.cacheDir, "pricing.json")
+		data, err := os.ReadFile(cacheFile)
+		if err != nil {
+			p.localLoadErr = fmt.Errorf("local pricing unavailable: %w", err)
+			return
+		}
+		p.mu.Lock()
+		p.localLoadErr = p.parseData(data)
+		p.mu.Unlock()
+	})
+	if p.localLoadErr != nil {
+		return ModelPricing{}, p.localLoadErr
+	}
+	return p.lookupLoadedPricing(modelName)
+}
+
+func (p *PricingFetcher) lookupLoadedPricing(modelName string) (ModelPricing, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if pricing, ok := p.cache[modelName]; ok {
+		return pricing, nil
+	}
+	for _, prefix := range providerPrefixes {
+		if pricing, ok := p.cache[prefix+modelName]; ok {
+			return pricing, nil
+		}
+	}
+	lower := strings.ToLower(modelName)
+	for key, pricing := range p.cache {
+		keyLower := strings.ToLower(key)
+		if strings.Contains(keyLower, lower) || strings.Contains(lower, keyLower) {
+			return pricing, nil
+		}
+	}
+	return ModelPricing{}, fmt.Errorf("pricing not found for model: %s", modelName)
+}
+
+// CalculateCostLocal calculates cost without fetching pricing from the network.
+func (p *PricingFetcher) CalculateCostLocal(entry UsageEntry) (float64, error) {
+	if entry.Model == "" {
+		return 0, nil
+	}
+	pricing, err := p.GetPricingLocal(entry.Model)
+	if err != nil {
+		return 0, err
+	}
+	return calculateCostWithPricing(entry, pricing), nil
+}
+
 // CalculateCost calculates the cost for a usage entry
 func (p *PricingFetcher) CalculateCost(entry UsageEntry) (float64, error) {
 	if entry.Model == "" {
@@ -296,7 +355,10 @@ func (p *PricingFetcher) CalculateCost(entry UsageEntry) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	return calculateCostWithPricing(entry, pricing), nil
+}
 
+func calculateCostWithPricing(entry UsageEntry, pricing ModelPricing) float64 {
 	if pricing.WholeRequestTier {
 		threshold := pricing.TieredThreshold
 		if threshold <= 0 {
@@ -313,7 +375,7 @@ func (p *PricingFetcher) CalculateCost(entry UsageEntry) (float64, error) {
 		return float64(entry.InputTokens)*price(pricing.InputCostPerToken, pricing.InputCostPerTokenAbove200k) +
 			float64(entry.OutputTokens)*price(pricing.OutputCostPerToken, pricing.OutputCostPerTokenAbove200k) +
 			float64(entry.CacheWriteTokens)*price(pricing.CacheCreationInputTokenCost, pricing.CacheCreationCostAbove200k) +
-			float64(entry.CacheReadTokens)*price(pricing.CacheReadInputTokenCost, pricing.CacheReadCostAbove200k), nil
+			float64(entry.CacheReadTokens)*price(pricing.CacheReadInputTokenCost, pricing.CacheReadCostAbove200k)
 	}
 
 	var cost float64
@@ -346,7 +408,7 @@ func (p *PricingFetcher) CalculateCost(entry UsageEntry) (float64, error) {
 		pricing.CacheReadCostAbove200k,
 	)
 
-	return cost, nil
+	return cost
 }
 
 // calculateTieredCost calculates cost with tiered pricing (200k threshold)

--- a/internal/usage/pricing_test.go
+++ b/internal/usage/pricing_test.go
@@ -2,8 +2,66 @@ package usage
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
+
+func TestCalculateCostLocalUsesStaleCacheWithoutNetwork(t *testing.T) {
+	cacheDir := t.TempDir()
+	cacheFile := filepath.Join(cacheDir, "pricing.json")
+	if err := os.WriteFile(cacheFile, []byte(`{"local-model":{"input_cost_per_token":0.000001}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(cacheFile, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	fetcher := NewPricingFetcher()
+	fetcher.cacheDir = cacheDir
+	// No network client is needed: a network attempt would panic on nil.
+	fetcher.httpClient = nil
+	cost, err := fetcher.CalculateCostLocal(UsageEntry{Model: "local-model", InputTokens: 1000})
+	if err != nil {
+		t.Fatalf("CalculateCostLocal() error = %v", err)
+	}
+	if math.Abs(cost-0.001) > 1e-9 {
+		t.Fatalf("cost = %g, want .001", cost)
+	}
+}
+
+func TestGetPricingLocalLoadsDiskCacheAtMostOnce(t *testing.T) {
+	cacheDir := t.TempDir()
+	cacheFile := filepath.Join(cacheDir, "pricing.json")
+	if err := os.WriteFile(cacheFile, []byte(`{"model-a":{"input_cost_per_token":0.000001},"model-b":{"input_cost_per_token":0.000002}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fetcher := NewPricingFetcher()
+	fetcher.cacheDir = cacheDir
+	if _, err := fetcher.GetPricingLocal("model-a"); err != nil {
+		t.Fatalf("first GetPricingLocal() error = %v", err)
+	}
+	if err := os.Remove(cacheFile); err != nil {
+		t.Fatal(err)
+	}
+	pricing, err := fetcher.GetPricingLocal("model-b")
+	if err != nil {
+		t.Fatalf("second GetPricingLocal() reread disk cache: %v", err)
+	}
+	if pricing.InputCostPerToken != 0.000002 {
+		t.Fatalf("model-b input price = %g", pricing.InputCostPerToken)
+	}
+}
+
+func TestCalculateCostLocalGracefullyFailsWithoutCache(t *testing.T) {
+	fetcher := NewPricingFetcher()
+	fetcher.cacheDir = t.TempDir()
+	fetcher.httpClient = nil
+	if _, err := fetcher.CalculateCostLocal(UsageEntry{Model: "unknown", InputTokens: 1}); err == nil {
+		t.Fatal("expected unavailable local pricing error")
+	}
+}
 
 func TestPricingFetcherUsesBundledSambaNovaPricing(t *testing.T) {
 	fetcher := NewPricingFetcher()

--- a/internal/usage/pricing_test.go
+++ b/internal/usage/pricing_test.go
@@ -54,6 +54,47 @@ func TestGetPricingLocalLoadsDiskCacheAtMostOnce(t *testing.T) {
 	}
 }
 
+func TestGetPricingLocalMatchesGetPricingDeterministicPrecedence(t *testing.T) {
+	cacheDir := t.TempDir()
+	data := []byte(`{
+		"anthropic/model-x":{"input_cost_per_token":0.000002},
+		"aaa-model-x-extended":{"input_cost_per_token":0.000003},
+		"zzz-model-x-extended":{"input_cost_per_token":0.000004},
+		"aaa-fuzzy-name":{"input_cost_per_token":0.000005},
+		"zzz-fuzzy-name":{"input_cost_per_token":0.000006}
+	}`)
+	if err := os.WriteFile(filepath.Join(cacheDir, "pricing.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	local := NewPricingFetcher()
+	local.cacheDir = cacheDir
+	network := NewPricingFetcher()
+	if err := network.parseData(data); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		model string
+		want  float64
+	}{
+		{model: "model-x", want: 0.000002}, // provider-prefix match beats partial matches
+		{model: "fuzzy", want: 0.000005},   // ambiguous partial match is lexical, not map-order dependent
+	} {
+		localPricing, err := local.GetPricingLocal(tc.model)
+		if err != nil {
+			t.Fatalf("GetPricingLocal(%q): %v", tc.model, err)
+		}
+		regularPricing, err := network.GetPricing(tc.model)
+		if err != nil {
+			t.Fatalf("GetPricing(%q): %v", tc.model, err)
+		}
+		if localPricing.InputCostPerToken != tc.want || regularPricing.InputCostPerToken != tc.want {
+			t.Fatalf("pricing(%q) local=%g regular=%g, want %g", tc.model, localPricing.InputCostPerToken, regularPricing.InputCostPerToken, tc.want)
+		}
+	}
+}
+
 func TestCalculateCostLocalGracefullyFailsWithoutCache(t *testing.T) {
 	fetcher := NewPricingFetcher()
 	fetcher.cacheDir = t.TempDir()


### PR DESCRIPTION
## What

Replace the terse `--stats` footer with a balanced one-line summary:

```text
Stats: 12.3s | 24K in + 18K cached → 1.2K out | TTFT 0.8s, 42 tok/s | $0.0840 | 3 tools, 4 calls
```

The footer now reports:

- fresh, cached, cache-write, and output tokens
- time to first token
- output throughput over observed generation time
- locally available estimated cost
- tool and LLM call counts

## Accounting details

- Prices each provider request separately so request-scoped long-context tiers remain correct.
- Tracks the model used by each request across model switches.
- Never fetches pricing from the network during command/chat exit; bundled or existing local cache only.
- Omits cost for resumed sessions whose historical per-call/model breakdown is unavailable rather than inventing a total.
- Excludes tool-only turns from throughput when no generation activity was observed.
- Removes discarded retry attempts from tokens, TTFT, throughput, and cost, and excludes retry backoff from replacement TTFT.
- Includes compaction usage in ask stats, including `--no-session` runs.

## Chat and exec fixes

- Use the same summary for completed chat exits while avoiding incomplete output when quitting during an active stream.
- Fix `exec` tool timing so `EventToolExecEnd` actually closes the tool interval.
- Include cache-write tokens in the interactive `/stats` total.
- Include persisted compactions when seeding resumed LLM call counts.

## Verification

- `go build ./...`
- `go test ./internal/ui ./internal/usage ./internal/tui/chat`
- focused `cmd` tests covering stats, exec, ask/progressive, compaction, retries, and chat exits
- `git diff --check`


## Interactive `/stats`

The chat modal now also:

- leads with the same balanced summary without mutating live timing
- distinguishes current window pressure from cumulative session usage
- shows cache hit percentage with its denominator
- reads the engine's effective soft/hard compaction thresholds instead of assuming 90%
- suppresses raw pricing lookup errors

## Review hardening

A full Claude/Fable review found one blocking concurrency issue and several accounting edge cases. Follow-up fixes route compaction stats through Bubble Tea's update loop, preserve in-flight timing across compaction, attach compaction cost to its actual model, consume zero-usage terminal events safely, and keep durable compaction calls when provisional retry usage is discarded.
