### PR TITLE
fix: Concurrent MCP disable can nil-panic an in-flight tool call

### DIFF
--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -359,13 +359,14 @@ func (m *Manager) CallTool(ctx context.Context, fullName string, args json.RawMe
 
 	m.mu.RLock()
 	state, ok := m.statuses[serverName]
-	m.mu.RUnlock()
-
 	if !ok || state.Status != StatusReady || state.Client == nil {
+		m.mu.RUnlock()
 		return llm.ToolOutput{}, fmt.Errorf("MCP server %s is not running", serverName)
 	}
+	client := state.Client
+	m.mu.RUnlock()
 
-	return state.Client.CallTool(ctx, toolName, args)
+	return client.CallTool(ctx, toolName, args)
 }
 
 // parseToolName extracts server name and tool name from prefixed name.

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -238,6 +238,53 @@ func TestManagerDisable_CancelsInFlightStartup(t *testing.T) {
 	}
 }
 
+func TestManagerCallToolConcurrentDisable(t *testing.T) {
+	const iterations = 100
+
+	for i := 0; i < iterations; i++ {
+		manager := NewManager()
+		client := NewClient("test", ServerConfig{})
+		manager.clients["test"] = client
+		manager.statuses["test"] = &ServerState{
+			Name:   "test",
+			Status: StatusReady,
+			Client: client,
+		}
+
+		start := make(chan struct{})
+		callDone := make(chan error, 1)
+		disableDone := make(chan error, 1)
+		go func() {
+			<-start
+			_, err := manager.CallTool(context.Background(), "test__tool", nil)
+			callDone <- err
+		}()
+		go func() {
+			<-start
+			disableDone <- manager.Disable("test")
+		}()
+		close(start)
+
+		select {
+		case err := <-callDone:
+			if err == nil || !strings.Contains(err.Error(), "not running") {
+				t.Fatalf("iteration %d: CallTool error = %v, want not running", i, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iteration %d: CallTool did not return", i)
+		}
+
+		select {
+		case err := <-disableDone:
+			if err != nil {
+				t.Fatalf("iteration %d: Disable returned error: %v", i, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iteration %d: Disable did not return", i)
+		}
+	}
+}
+
 func waitForServerStatus(t *testing.T, manager *Manager, name string, want ServerStatus, timeout time.Duration) (ServerStatus, error) {
 	t.Helper()
 


### PR DESCRIPTION
## What changed

- Keep `Manager.mu` read-locked while validating an MCP server's status and client pointer.
- Capture the client locally before releasing the manager lock, then invoke the tool through that stable pointer.
- Add a concurrent `CallTool`/`Disable` regression test that repeatedly exercises the lifecycle race.

## Why this is high-value

The TUI can disable or restart MCP servers, and runtime cleanup can stop them, while a tool call is in flight. Previously, `CallTool` released the manager lock before reading the shared `ServerState`. `Disable` could then set `state.Client` to nil between the readiness check and method call, producing a nil-receiver panic that terminated the entire long-running process. Capturing the client under the lock turns that process crash into the client's existing synchronized success/error behavior.

## Validation

- `gofmt -w internal/mcp/manager.go internal/mcp/manager_test.go`
- `go build ./...`
- `go test -race ./internal/mcp -run '^TestManagerCallToolConcurrentDisable$' -count=100`
- Verified the regression test reports the `ServerState` data race when the production fix is temporarily reverted.
- `go test ./... -skip '^(TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir|TestProgramRunnerDoesNotLeakBackgroundChildren)$'`

A full `go test ./...` was also run. It reached and passed `internal/mcp`, but this environment has two unrelated failures: the cmd skill-context test sees Jarvis's 30 installed user skills and omits its project fixture at the configured 8-skill limit (it passes with isolated `HOME`/`XDG_CONFIG_HOME`), and the jobs background-child cleanup test still observes its spawned child after one second.
