### PR TITLE
fix: Job cancellation can report success while the newly started job keeps running

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -530,14 +530,15 @@ type jobsV2Manager struct {
 	lastCleanupCompleted time.Time
 	cleanupRunning       bool
 
-	enqueueMu     sync.Mutex
-	mu            sync.Mutex
-	closed        bool
-	done          chan struct{}
-	schedulerWake chan struct{}
-	workerWake    chan struct{}
-	wg            sync.WaitGroup
-	cancels       map[string]context.CancelFunc
+	enqueueMu         sync.Mutex
+	mu                sync.Mutex
+	closed            bool
+	done              chan struct{}
+	schedulerWake     chan struct{}
+	workerWake        chan struct{}
+	wg                sync.WaitGroup
+	cancels           map[string]context.CancelFunc
+	cancelRunAfterGet func(jobsV2Run) // test seam for status-transition races
 }
 
 const jobsV2Schema = `
@@ -2018,31 +2019,59 @@ func (m *jobsV2Manager) listRuns(jobID string, limit, offset int, includeOutput 
 }
 
 func (m *jobsV2Manager) CancelRun(id string) (jobsV2Run, error) {
-	run, err := m.GetRun(id)
-	if err != nil {
-		return jobsV2Run{}, err
-	}
-	now := time.Now().UTC()
-	switch run.Status {
-	case jobsV2RunQueued, jobsV2RunClaimed:
-		_, err = m.db.Exec(`UPDATE job_runs_v2 SET status = ?, finished_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobsV2RunCancelled, now, id)
-		_ = m.addRunEvent(id, "cancelled", "run cancelled before start", nil)
-	case jobsV2RunRunning:
-		_, err = m.db.Exec(`UPDATE job_runs_v2 SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobsV2RunCancelRequested, id)
-		_ = m.addRunEvent(id, "cancel_requested", "cancellation requested", nil)
-		m.mu.Lock()
-		cancel := m.cancels[id]
-		m.mu.Unlock()
-		if cancel != nil {
-			cancel()
+	// A run can advance while cancellation is reading it. Retry conditional
+	// transitions so a newly running process is signalled instead of merely
+	// having its database row overwritten as cancelled.
+	for attempt := 0; attempt < 3; attempt++ {
+		run, err := m.GetRun(id)
+		if err != nil {
+			return jobsV2Run{}, err
 		}
-	default:
-		return run, nil
+		if m.cancelRunAfterGet != nil {
+			m.cancelRunAfterGet(run)
+		}
+
+		switch run.Status {
+		case jobsV2RunQueued, jobsV2RunClaimed:
+			now := time.Now().UTC()
+			res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, finished_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?)`, jobsV2RunCancelled, now, id, jobsV2RunQueued, jobsV2RunClaimed)
+			if err != nil {
+				return jobsV2Run{}, fmt.Errorf("cancel queued run: %w", err)
+			}
+			affected, err := res.RowsAffected()
+			if err != nil {
+				return jobsV2Run{}, fmt.Errorf("inspect queued run cancellation: %w", err)
+			}
+			if affected == 0 {
+				continue
+			}
+			_ = m.addRunEvent(id, "cancelled", "run cancelled before start", nil)
+			return m.GetRun(id)
+		case jobsV2RunRunning:
+			res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunCancelRequested, id, jobsV2RunRunning)
+			if err != nil {
+				return jobsV2Run{}, fmt.Errorf("request run cancellation: %w", err)
+			}
+			affected, err := res.RowsAffected()
+			if err != nil {
+				return jobsV2Run{}, fmt.Errorf("inspect run cancellation request: %w", err)
+			}
+			if affected == 0 {
+				continue
+			}
+			_ = m.addRunEvent(id, "cancel_requested", "cancellation requested", nil)
+			m.mu.Lock()
+			cancel := m.cancels[id]
+			m.mu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
+			return m.GetRun(id)
+		default:
+			return run, nil
+		}
 	}
-	if err != nil {
-		return jobsV2Run{}, err
-	}
-	return m.GetRun(id)
+	return jobsV2Run{}, fmt.Errorf("cancel run %q: status changed during cancellation", id)
 }
 
 func scanJobV2(scanner interface{ Scan(dest ...any) error }) (jobsV2Job, error) {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -305,6 +305,156 @@ func TestJobsV2ManualTriggerAndCancel(t *testing.T) {
 	}
 }
 
+func TestJobsV2CancelRunFollowsClaimedToRunningTransition(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "cancel-claimed-race",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+	if _, err := mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunClaimed, run.ID, jobsV2RunQueued); err != nil {
+		t.Fatalf("mark run claimed: %v", err)
+	}
+
+	runnerStarted := make(chan struct{})
+	cancelObserved := make(chan struct{})
+	releaseRunner := make(chan struct{})
+	runnerDone := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseRunner:
+		default:
+			close(releaseRunner)
+		}
+	}()
+	mgr.runners[jobsV2RunnerProgram] = jobsV2RunnerFunc(func(ctx context.Context, job jobsV2Job, pw progressWriter) (jobsV2RunResult, error) {
+		close(runnerStarted)
+		<-ctx.Done()
+		close(cancelObserved)
+		<-releaseRunner
+		return jobsV2RunResult{}, ctx.Err()
+	})
+
+	advanced := false
+	mgr.cancelRunAfterGet = func(observed jobsV2Run) {
+		if advanced {
+			return
+		}
+		advanced = true
+		if observed.Status != jobsV2RunClaimed {
+			t.Fatalf("initial status = %s, want %s", observed.Status, jobsV2RunClaimed)
+		}
+		go func() {
+			mgr.executeRun(run)
+			close(runnerDone)
+		}()
+		select {
+		case <-runnerStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("runner did not start")
+		}
+	}
+
+	cancelled, err := mgr.CancelRun(run.ID)
+	if err != nil {
+		t.Fatalf("CancelRun failed: %v", err)
+	}
+	if cancelled.Status != jobsV2RunCancelRequested {
+		t.Fatalf("cancelled status = %s, want %s", cancelled.Status, jobsV2RunCancelRequested)
+	}
+	select {
+	case <-cancelObserved:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not observe cancellation")
+	}
+
+	close(releaseRunner)
+	select {
+	case <-runnerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not finish")
+	}
+	finished, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if finished.Status != jobsV2RunCancelled {
+		t.Fatalf("finished status = %s, want %s", finished.Status, jobsV2RunCancelled)
+	}
+}
+
+func TestJobsV2CancelRunDoesNotOverrideConcurrentCompletion(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "cancel-completion-race",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+	if _, err := mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunRunning, time.Now().UTC(), run.ID, jobsV2RunQueued); err != nil {
+		t.Fatalf("mark run running: %v", err)
+	}
+
+	cancelCalled := false
+	mgr.mu.Lock()
+	mgr.cancels[run.ID] = func() { cancelCalled = true }
+	mgr.mu.Unlock()
+
+	finished := false
+	mgr.cancelRunAfterGet = func(observed jobsV2Run) {
+		if finished {
+			return
+		}
+		finished = true
+		if observed.Status != jobsV2RunRunning {
+			t.Fatalf("initial status = %s, want %s", observed.Status, jobsV2RunRunning)
+		}
+		if err := mgr.finishRun(run.ID, jobsV2RunSucceeded, jobsV2RunResult{Stdout: "ok"}, nil, run.Attempt); err != nil {
+			t.Fatalf("finish run: %v", err)
+		}
+	}
+
+	completed, err := mgr.CancelRun(run.ID)
+	if err != nil {
+		t.Fatalf("CancelRun failed: %v", err)
+	}
+	if completed.Status != jobsV2RunSucceeded {
+		t.Fatalf("completed status = %s, want %s", completed.Status, jobsV2RunSucceeded)
+	}
+	if cancelCalled {
+		t.Fatal("cancel function called after run completed")
+	}
+}
+
 func TestJobsV2FinishRunDoesNotOverrideCancelRequested(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 0, nil)
 	if err != nil {


### PR DESCRIPTION
## What changed

- Made queued/claimed and running cancellation updates conditional on the status that was observed.
- Added a bounded retry when another worker advances or completes the run before the cancellation update wins.
- Ensured a claimed-to-running race is re-read as running, transitioned to `cancel_requested`, and signalled through the registered cancel function.
- Added deterministic coverage for both claimed-to-running cancellation and running-to-succeeded completion races.

## Why this is high-value

Previously, cancelling immediately after triggering a job could overwrite a newly running row as `cancelled` without cancelling its runner. The API would report a terminal cancellation while the shell command or LLM agent continued consuming tokens, running tools, and producing filesystem or network side effects. The same stale snapshot could overwrite a just-completed terminal result with `cancel_requested`.

The compare-and-swap status transitions keep the persisted result and the actual runner lifecycle aligned in both races.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./cmd`
- `go test -race ./cmd -run 'TestJobsV2CancelRun(FollowsClaimedToRunningTransition|DoesNotOverrideConcurrentCompletion)$' -count=1`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...` passes all packages except the unchanged `internal/jobs` test `TestProgramRunnerDoesNotLeakBackgroundChildren`, whose killed child remains visible on this host beyond its one-second polling deadline.
- `git diff --check`
