### PR TITLE
fix: recover malformed response completions

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -807,6 +807,13 @@ func responseRunTimeoutMessage(timeout time.Duration) string {
 	return fmt.Sprintf("Response run timed out after %s. Continue to resume from saved progress, or move long-running investigations to a background job.", humanDuration(timeout))
 }
 
+func responseRunDeadlineMessage(runCtx context.Context, timeout time.Duration) string {
+	if runCtx != nil && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return responseRunTimeoutMessage(timeout)
+	}
+	return "The model provider request timed out before the response run deadline. Continue to retry from saved progress."
+}
+
 func humanDuration(d time.Duration) string {
 	if d%time.Hour == 0 {
 		hours := int(d / time.Hour)
@@ -1927,7 +1934,7 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 			errMessage := err.Error()
 			if errors.Is(err, context.DeadlineExceeded) {
 				errType = "timeout_error"
-				errMessage = responseRunTimeoutMessage(s.responseTimeout())
+				errMessage = responseRunDeadlineMessage(runCtx, s.responseTimeout())
 			} else if errors.Is(err, errServeSessionBusy) {
 				errType = "conflict_error"
 			}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -9094,7 +9094,20 @@ func TestResolveServeResponseTimeout(t *testing.T) {
 	}
 }
 
-func TestStartResponseRunDeadlineExceededFailsWithHelpfulTimeoutMessage(t *testing.T) {
+func TestResponseRunDeadlineMessageUsesConfiguredLimitOnlyWhenRunContextExpired(t *testing.T) {
+	timeout := 45 * time.Minute
+	if got := responseRunDeadlineMessage(context.Background(), timeout); strings.Contains(got, "45 minutes") {
+		t.Fatalf("live run context falsely claimed configured timeout: %q", got)
+	}
+
+	expiredCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	if got := responseRunDeadlineMessage(expiredCtx, timeout); !strings.Contains(got, "timed out after 45 minutes") {
+		t.Fatalf("expired run context message = %q, want configured timeout", got)
+	}
+}
+
+func TestStartResponseRunProviderDeadlineDoesNotClaimRunTimeout(t *testing.T) {
 	provider := llm.NewMockProvider("mock").AddError(context.DeadlineExceeded)
 	engine := llm.NewEngine(provider, nil)
 	rt := &serveRuntime{
@@ -9135,8 +9148,11 @@ func TestStartResponseRunDeadlineExceededFailsWithHelpfulTimeoutMessage(t *testi
 		t.Fatalf("error type = %v, want timeout_error: %#v", got, snapshot)
 	}
 	message, _ := errPayload["message"].(string)
-	if !strings.Contains(message, "timed out after 45 minutes") {
-		t.Fatalf("timeout message = %q, want configured 45 minute explanation", message)
+	if !strings.Contains(message, "provider request timed out before the response run deadline") {
+		t.Fatalf("timeout message = %q, want provider timeout explanation", message)
+	}
+	if strings.Contains(message, "45 minutes") {
+		t.Fatalf("provider timeout falsely claimed the configured response deadline: %q", message)
 	}
 	if strings.Contains(message, "context deadline exceeded") {
 		t.Fatalf("timeout message leaked raw context error: %q", message)

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -1090,6 +1090,20 @@ func (c *ResponsesClient) streamHTTPPrepared(ctx context.Context, httpPayload Re
 			lastEventType = ""
 
 			stop, err := handler.HandleJSONEvent(data, eventType, send)
+			if err != nil && (eventType == "response.completed" || eventType == "response.incomplete") && !json.Valid(data) {
+				// A truncated terminal event is a transport failure, not a provider
+				// rejection. Classifying it as incomplete lets the engine preserve
+				// committed tool progress and resume instead of surfacing a misleading
+				// invalid_request_error to the user.
+				if finishErr := handler.FinishIncomplete(send); finishErr != nil {
+					err = errors.Join(err, finishErr)
+				}
+				return false, &StreamIncompleteError{
+					Transport: "Responses API SSE",
+					Terminal:  eventType,
+					Err:       err,
+				}
+			}
 			if stop {
 				sawTerminal = true
 			}

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -1734,6 +1734,10 @@ func TestResponsesClientStream_ErrorsOnMalformedCompletedEvent(t *testing.T) {
 			if event.Err == nil {
 				t.Fatal("expected EventError.Err to be set")
 			}
+			var incomplete *StreamIncompleteError
+			if !errors.As(event.Err, &incomplete) {
+				t.Fatalf("malformed terminal event error = %T %v, want StreamIncompleteError", event.Err, event.Err)
+			}
 			if !strings.Contains(event.Err.Error(), "decode Responses API response.completed event") {
 				t.Fatalf("expected completed decode error, got: %v", event.Err)
 			}

--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -185,6 +186,17 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 			}
 			completed, err := handler.HandleJSONEvent(data, eventType, send)
 			if err != nil {
+				if (eventType == "response.completed" || eventType == "response.incomplete") && !json.Valid(data) {
+					c.discardWebSocketLocked()
+					if finishErr := handler.FinishIncomplete(send); finishErr != nil {
+						err = errors.Join(err, finishErr)
+					}
+					return &StreamIncompleteError{
+						Transport: "Responses WebSocket",
+						Terminal:  eventType,
+						Err:       err,
+					}
+				}
 				if wsErr, ok := err.(*responsesAPIEventError); ok && wsErr.APIError != nil {
 					switch wsErr.APIError.Code {
 					case "previous_response_not_found":

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -910,6 +910,52 @@ func TestResponsesClientWebSocketReadFailureAfterEventsReturnsIncomplete(t *test
 	}
 }
 
+func TestResponsesClientWebSocketMalformedCompletedReturnsIncomplete(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			t.Fatal("HTTP fallback should not be used after visible WebSocket output")
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		_, _, _ = conn.ReadMessage()
+		_ = conn.WriteJSON(map[string]any{"type": "response.output_text.delta", "delta": "partial"})
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed","response":`))
+	}))
+	defer server.Close()
+
+	client := &ResponsesClient{BaseURL: server.URL, UseWebSocket: true}
+	stream, err := client.Stream(context.Background(), ResponsesRequest{Model: "gpt-test", Input: []ResponsesInputItem{{Type: "message", Role: "user", Content: "hi"}}, Stream: true}, false)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+
+	event, err := stream.Recv()
+	if err != nil || event.Type != EventTextDelta || event.Text != "partial" {
+		t.Fatalf("first event = %#v, err=%v, want partial text", event, err)
+	}
+	event, err = stream.Recv()
+	if err != nil {
+		t.Fatalf("second Recv returned transport error instead of EventError: %v", err)
+	}
+	if event.Type != EventError || event.Err == nil {
+		t.Fatalf("second event = %#v, want error event", event)
+	}
+	var incomplete *StreamIncompleteError
+	if !errors.As(event.Err, &incomplete) {
+		t.Fatalf("error type = %T, want StreamIncompleteError: %v", event.Err, event.Err)
+	}
+	if !strings.Contains(event.Err.Error(), "decode Responses API response.completed event") {
+		t.Fatalf("incomplete stream missing decode cause: %v", event.Err)
+	}
+}
+
 func TestResponsesClientWebSocketBackoffHonorsContextCancellation(t *testing.T) {
 	withResponsesWebSocketBaseBackoff(t, time.Hour)
 


### PR DESCRIPTION
## What

- classify malformed/truncated `response.completed` and `response.incomplete` events as incomplete transport streams on both SSE and WebSocket paths
- preserve finalized tool progress so the engine can use its existing interrupted-stream recovery instead of surfacing `invalid_request_error`
- distinguish provider-level deadline failures from expiration of the configured response-run context
- only report `Response run timed out after <configured limit>` when that run context actually expired

## Why

A live web session received a truncated `response.completed` payload after substantial tool progress. term-llm treated the JSON decode failure as an invalid request, forcing a manual continuation instead of routing it through stream recovery.

The resumed request then returned `context.DeadlineExceeded` after roughly **4 minutes 9 seconds**, but term-llm reported that the run had timed out after the configured **2 hours**. Any nested provider/network deadline was being attributed to the outer response-run limit without checking which context had actually expired.

## Verification

- `go build ./...`
- targeted SSE, WebSocket, and response-run timeout regression tests
- `go test ./internal/llm`
- full `go test ./...` passed everywhere relevant; the existing unrelated `internal/jobs` `TestProgramRunnerDoesNotLeakBackgroundChildren` process-cleanup test fails in this container
