### PR TITLE
fix: omit automatic prompt cache keys

### DIFF
--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -265,10 +265,12 @@ func (p *ChatGPTProvider) Stream(ctx context.Context, req Request) (Stream, erro
 		ExtractInstructionsFromMessages: true,
 		Tools:                           tools,
 		Include:                         []string{"reasoning.encrypted_content"},
-		PromptCacheKey:                  req.SessionID,
-		Store:                           boolPtr(false),
-		Stream:                          true,
-		SessionID:                       req.SessionID,
+		// The ChatGPT Codex backend's implicit prefix caching regresses for long
+		// prompts when prompt_cache_key is present. Keep session_id for routing and
+		// WebSocket continuation, but let the backend choose its cache route.
+		Store:     boolPtr(false),
+		Stream:    true,
+		SessionID: req.SessionID,
 	}
 
 	if serviceTier := p.serviceTier; req.ServiceTierSet || strings.TrimSpace(req.ServiceTier) != "" {

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -82,6 +82,58 @@ func TestNewChatGPTResponsesClientUsesCurrentCodexHeaders(t *testing.T) {
 	}
 }
 
+func TestChatGPTStream_OmitsPromptCacheKeyButKeepsSessionHeader(t *testing.T) {
+	origClient := chatGPTHTTPClient
+	defer func() { chatGPTHTTPClient = origClient }()
+
+	var body []byte
+	var sessionID string
+	chatGPTHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		sessionID = req.Header.Get("session_id")
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`event: response.completed`,
+				`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+				`data: [DONE]`,
+			}, "\n"))),
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	provider := NewChatGPTProviderWithCreds(&credentials.ChatGPTCredentials{
+		AccessToken: "test-token",
+		AccountID:   "test-account",
+		ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+	}, "gpt-5.6-sol-medium")
+
+	stream, err := provider.Stream(context.Background(), Request{
+		SessionID: "chatgpt-session-123",
+		Messages:  []Message{UserText("hello")},
+	})
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+	drainStreamToDone(t, stream)
+
+	if sessionID != "chatgpt-session-123" {
+		t.Fatalf("session_id header = %q, want %q", sessionID, "chatgpt-session-123")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if value, ok := payload["prompt_cache_key"]; ok {
+		t.Fatalf("ChatGPT request contains prompt_cache_key = %#v", value)
+	}
+}
+
 func TestChatGPTStream_CompactionAnchorDoesNotEmitPromptCacheBreakpoint(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() { chatGPTHTTPClient = origClient }()

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -145,7 +145,6 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req Request) (Stream, error
 		FileUploadPolicy: p.effectiveFileUploadPolicy(),
 		Tools:            tools,
 		Include:          []string{"reasoning.encrypted_content"},
-		PromptCacheKey:   req.SessionID,
 		Stream:           true,
 		SessionID:        req.SessionID,
 	}

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -1354,10 +1354,10 @@ func TestResponsesClientStream_ParsesMultilineSSEErrorEvent(t *testing.T) {
 	}
 }
 
-func TestOpenAIProviderStream_UsesSessionIDForResponsesCaching(t *testing.T) {
+func TestOpenAIProviderStream_OmitsPromptCacheKeyButKeepsSessionHeader(t *testing.T) {
 	type capturedRequest struct {
-		SessionID      string
-		PromptCacheKey string
+		SessionID         string
+		HasPromptCacheKey bool
 	}
 
 	captured := make(chan capturedRequest, 1)
@@ -1365,15 +1365,14 @@ func TestOpenAIProviderStream_UsesSessionIDForResponsesCaching(t *testing.T) {
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			defer r.Body.Close()
 
-			var payload struct {
-				PromptCacheKey string `json:"prompt_cache_key"`
-			}
+			var payload map[string]any
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &payload)
+			_, hasPromptCacheKey := payload["prompt_cache_key"]
 
 			captured <- capturedRequest{
-				SessionID:      r.Header.Get("session_id"),
-				PromptCacheKey: payload.PromptCacheKey,
+				SessionID:         r.Header.Get("session_id"),
+				HasPromptCacheKey: hasPromptCacheKey,
 			}
 
 			return &http.Response{
@@ -1417,8 +1416,8 @@ func TestOpenAIProviderStream_UsesSessionIDForResponsesCaching(t *testing.T) {
 		if req.SessionID != "openai-session-1" {
 			t.Fatalf("expected session_id header 'openai-session-1', got %q", req.SessionID)
 		}
-		if req.PromptCacheKey != "openai-session-1" {
-			t.Fatalf("expected prompt_cache_key 'openai-session-1', got %q", req.PromptCacheKey)
+		if req.HasPromptCacheKey {
+			t.Fatal("OpenAI request contains prompt_cache_key")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for request capture")


### PR DESCRIPTION
## What

Stop automatically setting `prompt_cache_key` to the session ID for both OpenAI and ChatGPT Responses requests. This applies to HTTP/SSE and WebSocket because both transports consume the same provider request.

Preserve the independent `session_id` header used for request routing and WebSocket continuation. The generic Responses client still supports an explicitly supplied cache key; Copilot behavior is unchanged.

Add regression coverage for both providers verifying that requests omit `prompt_cache_key` while retaining `session_id`.

## Why

Using a per-session `prompt_cache_key` is an anti-pattern for the shared-prefix workload: every new conversation has the same large instructions/tool prefix but a different cache routing key.

Controlled direct calls reproduced the production behavior:

- ~8K-token instructions + changed user tail + per-session cache key: `cached_tokens = 0`
- Same ~8K-token instructions + changed user tail without a cache key: `cached_tokens = 7,936`
- A separate ~2K-token keyless probe cached 1,792 tokens across changed tails and session IDs

This matches production Jarvis sessions where an identical ~10.5K-token shared prefix was repeatedly uncached across new conversations. Omitting the key lets provider-managed implicit prefix routing reuse that shared prefix.

The ChatGPT Codex endpoint does not support `prompt_cache_options` or `prompt_cache_breakpoint`, so explicit caching is not a viable replacement there.

## Tests

- `go test ./internal/llm -count=1`
- `go build ./...`
- Focused ChatGPT, OpenAI, generic Responses-client, and Copilot cache-key tests
- `go test ./...` passes all affected packages; one unrelated `cmd` test fails when user-global skills leak into its fixture (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir`). It passes in isolation with a clean `XDG_CONFIG_HOME`.
