### PR TITLE
fix: Late image-recorder wiring drops metadata and leaks a SQLite connection per runtime

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -58,30 +58,71 @@ func init() {
 	memoryCmd.AddCommand(memoryInsightsCmd)
 }
 
-func openMemoryStore() (*memorydb.Store, error) {
-	if dbEnv := os.Getenv("TERM_LLM_MEMORY_DB"); dbEnv != "" {
-		if memoryDBPath == defaultMemoryDBPath {
-			memoryDBPath = dbEnv
-		}
+type imageRecordStore interface {
+	tools.ImageRecorder
+	Close() error
+}
+
+type imageRecordStoreOpener func(path string) (imageRecordStore, error)
+
+type lazyImageRecorder struct {
+	path string
+	open imageRecordStoreOpener
+}
+
+func (r *lazyImageRecorder) RecordImage(ctx context.Context, record *memorydb.ImageRecord) error {
+	store, err := r.open(r.path)
+	if err != nil {
+		return err
 	}
-	store, err := memorydb.NewStore(memorydb.Config{Path: memoryDBPath})
+	defer store.Close()
+	return store.RecordImage(ctx, record)
+}
+
+func resolvedMemoryDBPath() string {
+	if dbEnv := os.Getenv("TERM_LLM_MEMORY_DB"); dbEnv != "" && memoryDBPath == defaultMemoryDBPath {
+		return dbEnv
+	}
+	return memoryDBPath
+}
+
+func openMemoryStoreAtPath(path string) (*memorydb.Store, error) {
+	store, err := memorydb.NewStore(memorydb.Config{Path: path})
 	if err != nil {
 		return nil, fmt.Errorf("open memory store: %w", err)
 	}
 	return store, nil
 }
 
-// wireImageRecorder opens the memory store and attaches it to the registry as an image recorder.
-// Non-fatal: if the store cannot be opened, image generation still works normally.
+func openMemoryStore() (*memorydb.Store, error) {
+	if dbEnv := os.Getenv("TERM_LLM_MEMORY_DB"); dbEnv != "" {
+		if memoryDBPath == defaultMemoryDBPath {
+			memoryDBPath = dbEnv
+		}
+	}
+	return openMemoryStoreAtPath(memoryDBPath)
+}
+
+func openImageRecordStore(path string) (imageRecordStore, error) {
+	return openMemoryStoreAtPath(path)
+}
+
+// wireImageRecorder attaches a recorder that opens the memory store only when
+// an image is generated, then closes it after recording. Recording remains
+// non-fatal if the store cannot be opened.
 func wireImageRecorder(registry *tools.LocalToolRegistry, agent, sessionID string) {
+	wireImageRecorderWithOpener(registry, agent, sessionID, openImageRecordStore)
+}
+
+func wireImageRecorderWithOpener(registry *tools.LocalToolRegistry, agent, sessionID string, open imageRecordStoreOpener) {
 	if registry == nil {
 		return
 	}
-	store, err := openMemoryStore()
-	if err != nil {
-		return
+	recorder := &lazyImageRecorder{
+		path: resolvedMemoryDBPath(),
+		open: open,
 	}
-	registry.SetImageRecorder(store, agent, sessionID)
+	registry.SetImageRecorder(recorder, agent, sessionID)
 }
 
 func recordImageDirect(cfg *config.Config, prompt, outputPath string, result *image.ImageResult, providerName string) {

--- a/cmd/memory_image_recorder_test.go
+++ b/cmd/memory_image_recorder_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+type trackingImageRecordStore struct {
+	records []*memorydb.ImageRecord
+	closes  int
+}
+
+func (s *trackingImageRecordStore) RecordImage(_ context.Context, record *memorydb.ImageRecord) error {
+	copy := *record
+	s.records = append(s.records, &copy)
+	return nil
+}
+
+func (s *trackingImageRecordStore) Close() error {
+	s.closes++
+	return nil
+}
+
+func TestWireImageRecorderIsLazyAndRecordsWithAttribution(t *testing.T) {
+	outputDir := t.TempDir()
+	cfg := &config.Config{
+		Image: config.ImageConfig{
+			Provider:  "debug",
+			OutputDir: outputDir,
+		},
+	}
+	toolConfig := &tools.ToolConfig{
+		Enabled:       []string{tools.ImageGenerateToolName},
+		WriteDirs:     []string{outputDir},
+		ImageProvider: "debug",
+	}
+	registry, err := tools.NewLocalToolRegistry(toolConfig, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewLocalToolRegistry: %v", err)
+	}
+
+	oldMemoryDBPath := memoryDBPath
+	memoryDBPath = filepath.Join(t.TempDir(), "memory.db")
+	t.Cleanup(func() { memoryDBPath = oldMemoryDBPath })
+	t.Setenv("TERM_LLM_MEMORY_DB", "")
+
+	store := &trackingImageRecordStore{}
+	opens := 0
+	wireImageRecorderWithOpener(registry, "jarvis", "session-123", func(path string) (imageRecordStore, error) {
+		opens++
+		if path != memoryDBPath {
+			t.Errorf("opener path = %q, want %q", path, memoryDBPath)
+		}
+		return store, nil
+	})
+	if opens != 0 {
+		t.Fatalf("wiring opened the memory store %d times, want 0", opens)
+	}
+
+	tool, ok := registry.Get(tools.ImageGenerateToolName)
+	if !ok {
+		t.Fatal("image_generate tool not found")
+	}
+	args, err := json.Marshal(tools.ImageGenerateArgs{
+		Prompt:          "a reliable robot",
+		ShowImage:       boolPointer(false),
+		CopyToClipboard: boolPointer(false),
+	})
+	if err != nil {
+		t.Fatalf("marshal arguments: %v", err)
+	}
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if opens != 1 {
+		t.Fatalf("memory store opens = %d, want 1", opens)
+	}
+	if store.closes != 1 {
+		t.Fatalf("memory store closes = %d, want 1", store.closes)
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("recorded images = %d, want 1", len(store.records))
+	}
+	record := store.records[0]
+	if record.Agent != "jarvis" || record.SessionID != "session-123" || record.Prompt != "a reliable robot" {
+		t.Fatalf("record attribution = agent %q, session %q, prompt %q", record.Agent, record.SessionID, record.Prompt)
+	}
+	if record.OutputPath == "" {
+		t.Fatal("record output path is empty")
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -67,7 +67,8 @@ func NewLocalToolRegistry(toolConfig *ToolConfig, appConfig *config.Config, appr
 	return r, nil
 }
 
-// SetImageRecorder wires an image recorder for image generation tracking.
+// SetImageRecorder wires an image recorder for image generation tracking into
+// the already-registered image generation tool.
 func (r *LocalToolRegistry) SetImageRecorder(recorder ImageRecorder, agent, sessionID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -75,12 +76,25 @@ func (r *LocalToolRegistry) SetImageRecorder(recorder ImageRecorder, agent, sess
 	r.memoryStore = recorder
 	r.agent = agent
 	r.sessionID = sessionID
+	r.applyImageRecorderLocked()
+}
+
+// applyImageRecorderLocked pushes the recorder and attribution into the
+// registered image generation tool. Callers must hold r.mu.
+func (r *LocalToolRegistry) applyImageRecorderLocked() {
+	if t, ok := r.tools[ImageGenerateToolName]; ok {
+		if it, ok := t.(*ImageGenerateTool); ok {
+			it.imageRecorder = r.memoryStore
+			it.agent = r.agent
+			it.sessionID = r.sessionID
+		}
+	}
 }
 
 // SetFileChangeRecorder wires a recorder for file-change tracking into the
-// already-registered file-modifying tools. Unlike SetImageRecorder, this
-// mutates registered instances directly (the SetServeMode pattern) so the
-// recorder takes effect regardless of registration order.
+// already-registered file-modifying tools. This mutates registered instances
+// directly (the SetServeMode pattern) so the recorder takes effect regardless
+// of registration order.
 func (r *LocalToolRegistry) SetFileChangeRecorder(recorder FileChangeRecorder) {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
## What changed

- Patch the already-registered `image_generate` tool when `SetImageRecorder` is called, including its agent and session attribution.
- Replace runtime-lifetime ownership of an eagerly opened memory store with a lazy recorder that opens the configured SQLite store only for `RecordImage` and closes it immediately afterward.
- Add an end-to-end regression test covering late recorder wiring, attribution, zero opens during setup, and one open/close pair for one generated image.

## Why this is high-value

Every tool-enabled runtime previously opened and retained a memory SQLite store without any lifecycle owner to close it. At the same time, registration happened before recorder wiring, so the existing `image_generate` instance kept a nil recorder and silently omitted generated-image metadata from memory. This fix restores image search/attribution for ordinary Jarvis image generation while preventing per-runtime database connections, goroutines, and file descriptors from accumulating in the long-running service.

## Validation

- `gofmt -w internal/tools/registry.go cmd/memory.go cmd/memory_image_recorder_test.go`
- `go build ./...`
- `go test ./cmd -run '^TestWireImageRecorderIsLazyAndRecordsWithAttribution$' -count=10`
- `go test ./internal/tools`
- `git diff --check`
- `go test ./...` was also run. All relevant tests passed; the suite still reports two unrelated existing/environment-sensitive failures: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` (the host's 30 configured skills exceed that test's 8-skill visibility cap) and `TestProgramRunnerDoesNotLeakBackgroundChildren` (its background child remains visible in this host environment).
