### PR TITLE
fix: Tool-enabled runtimes leak a memory SQLite store and connection

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -71,17 +71,35 @@ func openMemoryStore() (*memorydb.Store, error) {
 	return store, nil
 }
 
-// wireImageRecorder opens the memory store and attaches it to the registry as an image recorder.
+type imageRecordStore interface {
+	tools.ImageRecorder
+	Close() error
+}
+
+type lazyImageRecorder struct {
+	open func() (imageRecordStore, error)
+}
+
+func (r *lazyImageRecorder) RecordImage(ctx context.Context, record *memorydb.ImageRecord) error {
+	store, err := r.open()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return store.RecordImage(ctx, record)
+}
+
+func openImageRecordStore() (imageRecordStore, error) {
+	return openMemoryStore()
+}
+
+// wireImageRecorder attaches a recorder that opens the memory store only when an image is recorded.
 // Non-fatal: if the store cannot be opened, image generation still works normally.
 func wireImageRecorder(registry *tools.LocalToolRegistry, agent, sessionID string) {
 	if registry == nil {
 		return
 	}
-	store, err := openMemoryStore()
-	if err != nil {
-		return
-	}
-	registry.SetImageRecorder(store, agent, sessionID)
+	registry.SetImageRecorder(&lazyImageRecorder{open: openImageRecordStore}, agent, sessionID)
 }
 
 func recordImageDirect(cfg *config.Config, prompt, outputPath string, result *image.ImageResult, providerName string) {

--- a/cmd/memory_recorder_test.go
+++ b/cmd/memory_recorder_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	memorydb "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+type countingImageRecordStore struct {
+	recordCalls int
+	closeCalls  int
+}
+
+func (s *countingImageRecordStore) RecordImage(_ context.Context, _ *memorydb.ImageRecord) error {
+	s.recordCalls++
+	return nil
+}
+
+func (s *countingImageRecordStore) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+func TestWireImageRecorderLazilyOpensAndClosesStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "memory.db")
+	oldMemoryDBPath := memoryDBPath
+	memoryDBPath = dbPath
+	t.Cleanup(func() { memoryDBPath = oldMemoryDBPath })
+
+	for range 100 {
+		toolConfig := tools.DefaultToolConfig()
+		toolConfig.Enabled = nil
+		toolMgr, err := tools.NewToolManager(&toolConfig, &config.Config{})
+		if err != nil {
+			t.Fatalf("NewToolManager: %v", err)
+		}
+		wireImageRecorder(toolMgr.Registry, "jarvis", "session-id")
+	}
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("memory store opened during recorder wiring: stat error = %v", err)
+	}
+
+	store := &countingImageRecordStore{}
+	openCalls := 0
+	recorder := &lazyImageRecorder{open: func() (imageRecordStore, error) {
+		openCalls++
+		return store, nil
+	}}
+	if err := recorder.RecordImage(context.Background(), &memorydb.ImageRecord{}); err != nil {
+		t.Fatalf("RecordImage: %v", err)
+	}
+	if openCalls != 1 {
+		t.Fatalf("store open calls = %d, want 1", openCalls)
+	}
+	if store.recordCalls != 1 {
+		t.Fatalf("store RecordImage calls = %d, want 1", store.recordCalls)
+	}
+	if store.closeCalls != 1 {
+		t.Fatalf("store Close calls = %d, want 1", store.closeCalls)
+	}
+}


### PR DESCRIPTION
## What changed

- Replaced eager memory-store wiring with a lightweight `ImageRecorder` that opens the memory SQLite store only when `RecordImage` is called.
- Closed the store after every image record attempt, so no SQL connection remains owned by a tool manager.
- Added a focused regression test that wires 100 tool managers without creating the memory database, then verifies one image record causes exactly one open, one record, and one close.

## Why this is high-value

`SessionSettings.SetupToolManager` runs for ordinary tool-enabled web, Telegram, job, and subagent runtimes. Previously every setup initialized the memory schema and retained an unclosed `sql.DB`, even when image generation was never used. Repeated runtime creation could therefore accumulate SQLite connections, file descriptors, connection-opener goroutines, and memory in the long-running daemon.

The lazy recorder removes that per-runtime resource ownership without broad lifecycle changes and preserves best-effort image recording behavior.

## Validation

- `gofmt -w cmd/memory.go cmd/memory_recorder_test.go`
- `go build ./...`
- `go test ./cmd -run TestWireImageRecorderLazilyOpensAndClosesStore -count=1`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./cmd`
- `git diff --check`

`go test ./...` was also run. All relevant packages passed, but the repository-wide command encountered two unrelated existing/environmental failures: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` reads the host's eight-skill display cap (and passes with an isolated `XDG_CONFIG_HOME`), while `TestProgramRunnerDoesNotLeakBackgroundChildren` in unchanged `internal/jobs` also fails when run alone.
