### PR TITLE
fix: misfire_policy=skip jobs run after service downtime

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -702,6 +702,10 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 		_ = db.Close()
 		return nil, err
 	}
+	if err := mgr.reconcileMisfiredSchedules(time.Now().UTC()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 
 	mgr.wg.Add(1)
 	go mgr.schedulerLoop()
@@ -785,6 +789,64 @@ func (m *jobsV2Manager) recoverRuns() error {
 		}
 	}
 
+	return nil
+}
+
+func (m *jobsV2Manager) reconcileMisfiredSchedules(now time.Time) error {
+	rows, err := m.db.Query(`SELECT id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, schedule_timezone, concurrency_policy, max_concurrent_runs, retry_policy, timeout_seconds, misfire_policy, labels, next_run_at, created_at, updated_at FROM jobs_v2 WHERE enabled = 1 AND misfire_policy = 'skip' AND trigger_type IN (?, ?) AND next_run_at IS NOT NULL AND next_run_at <= ? ORDER BY next_run_at ASC`, jobsV2TriggerCron, jobsV2TriggerOnce, now.UTC())
+	if err != nil {
+		return fmt.Errorf("load misfired schedules: %w", err)
+	}
+
+	var jobs []jobsV2Job
+	for rows.Next() {
+		job, err := scanJobV2(rows)
+		if err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan misfired schedule: %w", err)
+		}
+		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("scan misfired schedules: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close misfired schedules query: %w", err)
+	}
+
+	for _, job := range jobs {
+		var next *time.Time
+		if job.TriggerType == jobsV2TriggerCron {
+			cfg, err := parseTriggerConfig(job.TriggerType, job.TriggerConfig, job.ScheduleTimezone)
+			if err != nil {
+				return fmt.Errorf("parse misfired schedule %s: %w", job.ID, err)
+			}
+			nextRun, err := nextCronTime(cfg.Expression, effectiveCronTimezone(cfg.Timezone, job.ScheduleTimezone), now.UTC())
+			if err != nil {
+				return fmt.Errorf("advance misfired schedule %s: %w", job.ID, err)
+			}
+			nextRun = nextRun.UTC()
+			next = &nextRun
+		}
+
+		tx, err := m.db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin misfired schedule update %s: %w", job.ID, err)
+		}
+		if job.TriggerType == jobsV2TriggerOnce {
+			_, err = tx.Exec(`UPDATE jobs_v2 SET enabled = 0, next_run_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND enabled = 1 AND misfire_policy = 'skip' AND next_run_at <= ?`, job.ID, now.UTC())
+		} else {
+			_, err = tx.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND enabled = 1 AND misfire_policy = 'skip' AND next_run_at <= ?`, next, job.ID, now.UTC())
+		}
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("update misfired schedule %s: %w", job.ID, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit misfired schedule update %s: %w", job.ID, err)
+		}
+	}
 	return nil
 }
 

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -29,6 +29,101 @@ func TestNewJobsV2ManagerLimitsFileBackedDBConnections(t *testing.T) {
 	}
 }
 
+func TestNewJobsV2ManagerReconcilesMisfirePolicies(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jobs_v2.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	if err := execJobsV2Schema(db); err != nil {
+		_ = db.Close()
+		t.Fatalf("execJobsV2Schema failed: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-10 * time.Minute)
+	cronConfig := `{"expression":"*/5 * * * *","timezone":"UTC"}`
+	onceConfig := `{"run_at":"` + past.Format(time.RFC3339) + `"}`
+	jobs := []struct {
+		id            string
+		triggerType   jobsV2TriggerType
+		triggerConfig string
+		misfirePolicy string
+	}{
+		{id: "job_skip_cron", triggerType: jobsV2TriggerCron, triggerConfig: cronConfig, misfirePolicy: "skip"},
+		{id: "job_skip_once", triggerType: jobsV2TriggerOnce, triggerConfig: onceConfig, misfirePolicy: "skip"},
+		{id: "job_run_cron", triggerType: jobsV2TriggerCron, triggerConfig: cronConfig, misfirePolicy: "run"},
+		{id: "job_run_once", triggerType: jobsV2TriggerOnce, triggerConfig: onceConfig, misfirePolicy: "run"},
+	}
+	for _, job := range jobs {
+		_, err := db.Exec(`INSERT INTO jobs_v2 (id, name, enabled, runner_type, runner_config, trigger_type, trigger_config, schedule_timezone, concurrency_policy, max_concurrent_runs, timeout_seconds, misfire_policy, next_run_at, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, ?, 'UTC', 'forbid', 1, 30, ?, ?, ?, ?)`,
+			job.id, job.id, jobsV2RunnerProgram, `{"command":"true"}`, job.triggerType, job.triggerConfig, job.misfirePolicy, past, now, now)
+		if err != nil {
+			_ = db.Close()
+			t.Fatalf("insert %s: %v", job.id, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded database: %v", err)
+	}
+
+	startedAt := time.Now().UTC()
+	mgr, err := newJobsV2Manager(dbPath, 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var count int
+		if err := mgr.db.QueryRow(`SELECT COUNT(1) FROM job_runs_v2`).Scan(&count); err != nil {
+			t.Fatalf("count startup runs: %v", err)
+		}
+		if count == 2 {
+			break
+		}
+		if count > 2 || time.Now().After(deadline) {
+			t.Fatalf("startup run count = %d, want 2", count)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for _, tc := range []struct {
+		id      string
+		enabled bool
+		hasNext bool
+		runs    int
+	}{
+		{id: "job_skip_cron", enabled: true, hasNext: true, runs: 0},
+		{id: "job_skip_once", enabled: false, hasNext: false, runs: 0},
+		{id: "job_run_cron", enabled: true, hasNext: true, runs: 1},
+		{id: "job_run_once", enabled: false, hasNext: false, runs: 1},
+	} {
+		job, err := mgr.GetJob(tc.id)
+		if err != nil {
+			t.Fatalf("GetJob(%s): %v", tc.id, err)
+		}
+		if job.Enabled != tc.enabled {
+			t.Errorf("%s enabled = %v, want %v", tc.id, job.Enabled, tc.enabled)
+		}
+		if (job.NextRunAt != nil) != tc.hasNext {
+			t.Errorf("%s next_run_at = %v, want present %v", tc.id, job.NextRunAt, tc.hasNext)
+		}
+		if job.NextRunAt != nil && !job.NextRunAt.After(startedAt) {
+			t.Errorf("%s next_run_at = %v, want after startup %v", tc.id, job.NextRunAt, startedAt)
+		}
+
+		var runCount int
+		if err := mgr.db.QueryRow(`SELECT COUNT(1) FROM job_runs_v2 WHERE job_id = ?`, tc.id).Scan(&runCount); err != nil {
+			t.Fatalf("count runs for %s: %v", tc.id, err)
+		}
+		if runCount != tc.runs {
+			t.Errorf("%s run count = %d, want %d", tc.id, runCount, tc.runs)
+		}
+	}
+}
+
 func TestJobsV2RunSummaryUsesCoveringIndex(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 0, nil)
 	if err != nil {


### PR DESCRIPTION
## What changed

- Reconcile overdue `misfire_policy=skip` schedules synchronously when the jobs manager starts, before scheduler and worker goroutines begin.
- Advance skipped cron jobs to their next future occurrence without creating a run.
- Disable expired skipped once jobs without creating a run.
- Keep `misfire_policy=run` jobs overdue so the scheduler queues one normal catch-up run.
- Guard each persisted schedule transition and commit it transactionally.
- Add a file-backed restart test covering overdue cron and once jobs under both policies.

## Why this is high-value

Jarvis's bundled memory-maintenance and system-upgrade jobs explicitly use `misfire_policy=skip`. Previously the field was persisted but never read, so restarting after downtime immediately launched stale work despite that policy. This could duplicate memory maintenance, trigger delayed package upgrades, waste provider calls, or produce stale side effects during recovery.

## Validation

- `gofmt -w cmd/serve_jobs_v2.go cmd/serve_jobs_v2_test.go`
- `go build ./...`
- `go test ./cmd -run TestNewJobsV2ManagerReconcilesMisfirePolicies -count=1`
- Related jobs scheduler tests pass.
- `go test ./...` was run; the changed and related packages pass. The repository's unrelated `internal/jobs.TestProgramRunnerDoesNotLeakBackgroundChildren` timing test failed under the full-suite load but passed when rerun alone.
- `git diff --check`
