### PR TITLE
fix: Grok ACP cancellation can deadlock behind a blocked stdin write

### DIFF
--- a/internal/llm/grok_acp.go
+++ b/internal/llm/grok_acp.go
@@ -941,7 +941,15 @@ func (p *GrokBinProvider) stopGrokACPProcess(process *grokACPProcess) {
 	process.stopOnce.Do(func() {
 		if process.capabilities.SessionCapabilities.SupportsClose() && process.sessionID != "" {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			_ = process.client.CloseSession(ctx, acp.CloseSessionRequest{SessionID: process.sessionID})
+			closeDone := make(chan struct{})
+			go func() {
+				defer close(closeDone)
+				_ = process.client.CloseSession(ctx, acp.CloseSessionRequest{SessionID: process.sessionID})
+			}()
+			select {
+			case <-closeDone:
+			case <-ctx.Done():
+			}
 			cancel()
 		}
 		_ = process.stdin.Close()

--- a/internal/llm/grok_acp_test.go
+++ b/internal/llm/grok_acp_test.go
@@ -4,15 +4,81 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/acp"
 )
+
+type observedWriteCloser struct {
+	io.WriteCloser
+	started chan struct{}
+	once    sync.Once
+}
+
+func (w *observedWriteCloser) Write(data []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	return w.WriteCloser.Write(data)
+}
+
+func TestStopGrokACPProcessUnblocksBlockedWrite(t *testing.T) {
+	clientSide, agentSide := net.Pipe()
+	defer clientSide.Close()
+	defer agentSide.Close()
+
+	stdin := &observedWriteCloser{WriteCloser: clientSide, started: make(chan struct{})}
+	conn := acp.NewConnection(clientSide, stdin, nil, acp.Options{})
+	waitDone := make(chan struct{})
+	process := &grokACPProcess{
+		cancel:   func() { close(waitDone) },
+		stdin:    stdin,
+		client:   acp.NewClient(conn),
+		conn:     conn,
+		waitDone: waitDone,
+		capabilities: acp.AgentCapabilities{SessionCapabilities: acp.SessionCapabilities{
+			Close: json.RawMessage(`true`),
+		}},
+		sessionID: "blocked-session",
+	}
+
+	callDone := make(chan error, 1)
+	go func() {
+		callDone <- conn.Call(context.Background(), "session/prompt", map[string]string{
+			"prompt": strings.Repeat("x", 1<<20),
+		}, nil)
+	}()
+	select {
+	case <-stdin.started:
+	case <-time.After(time.Second):
+		t.Fatal("ACP call did not start its blocked write")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		var provider GrokBinProvider
+		provider.stopGrokACPProcess(process)
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Grok ACP process stop remained blocked behind the stdin write")
+	}
+	select {
+	case err := <-callDone:
+		if err == nil {
+			t.Fatal("blocked ACP call unexpectedly succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked ACP call did not exit after stdin was closed")
+	}
+}
 
 func TestParseGrokACPUsage(t *testing.T) {
 	usage, err := parseGrokACPUsage(json.RawMessage(`{


### PR DESCRIPTION
## What changed

- Run the optional ACP `session/close` request asynchronously and wait only for its existing one-second graceful-close deadline.
- After that deadline, continue forced shutdown by closing stdin and cancelling the Grok process, even if `CloseSession` is blocked behind another stdin write.
- Add a regression test using `net.Pipe` with an unread peer. It blocks a large ACP prompt write, enables session-close capability, invokes the provider stop path, and verifies both stop and the blocked call exit within bounded time.

## Why this is high-value

A stalled Grok CLI can stop consuming stdin while a prompt request holds the ACP connection's write mutex. Previously, cancellation or runtime cleanup then called `CloseSession` synchronously; that second call waited forever for the same mutex, preventing stdin closure, process cancellation, and the existing kill timeout from ever running. This can wedge an active Jarvis request and orderly shutdown indefinitely. The change preserves graceful session close when responsive while guaranteeing forced process cleanup can proceed.

## Validation

- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `go test -race ./internal/llm -run TestStopGrokACPProcessUnblocksBlockedWrite -count=1`
- `git diff --check`
