### PR TITLE
fix: make WebRTC interrupt retries idempotent

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1612,12 +1612,12 @@ func (s *serveServer) handleSessionInterrupt(w http.ResponseWriter, r *http.Requ
 	if fastErr != nil {
 		log.Printf("[serve] fast provider unavailable for interrupt: %v", fastErr)
 	}
-	action, interruptErr := rt.InterruptMessage(r.Context(), msg, displayText, strings.TrimSpace(req.InterjectionID), fastProvider, false)
+	action, replayed, interruptErr := rt.InterruptMessage(r.Context(), msg, displayText, strings.TrimSpace(req.InterjectionID), fastProvider, false)
 	if interruptErr != nil {
 		writeOpenAIError(w, http.StatusConflict, "conflict_error", interruptErr.Error())
 		return
 	}
-	if action == llm.InterruptCancel && s.store != nil {
+	if action == llm.InterruptCancel && !replayed && s.store != nil {
 		goalCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), goalPersistTimeout)
 		defer cancel()
 		if sess, err := s.store.Get(goalCtx, sessionID); err == nil && sess != nil && sess.Goal != nil && sess.Goal.IsActive() {

--- a/cmd/serve_jobs_v2_notify.go
+++ b/cmd/serve_jobs_v2_notify.go
@@ -173,7 +173,7 @@ func (s *serveServer) notifyQueuedAgentWeb(ctx context.Context, runID, sessionID
 				// originating session is already generating. Pass no classifier
 				// provider so this best-effort notice cannot be upgraded into a
 				// cancel/interrupt decision for the user's active run.
-				if _, err := rt.InterruptMessage(ctx, llm.UserText(message), message, "job_notify_"+strings.TrimSpace(runID), nil, true); err == nil {
+				if _, _, err := rt.InterruptMessage(ctx, llm.UserText(message), message, "job_notify_"+strings.TrimSpace(runID), nil, true); err == nil {
 					return nil
 				}
 			}

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -482,6 +482,8 @@ func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, d
 	classifyCtx := ctx
 	classifyCancel := func() {}
 	if interjectionID != "" {
+		// Stay below the web client's 5-second mutation first-frame timeout so a
+		// healthy classifier normally responds before transport fallback begins.
 		classifyCtx, classifyCancel = context.WithTimeout(context.WithoutCancel(ctx), 4*time.Second)
 	}
 	action := llm.ClassifyInterrupt(classifyCtx, fastProvider, classifyText, activity)

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -54,6 +56,7 @@ type serveRuntime struct {
 	yoloMode             bool
 	lastUsedUnixNano     atomic.Int64
 	activeInterrupt      *runtimeInterruptState
+	interjectionCalls    map[string]*runtimeInterjectionCall
 	lastResponseID       string
 	responseIDs          []string
 	cumulativeUsage      llm.Usage
@@ -82,6 +85,15 @@ type runtimeInterruptState struct {
 	model           string
 	reasoningEffort string
 }
+
+type runtimeInterjectionCall struct {
+	done        chan struct{}
+	fingerprint string
+	action      llm.InterruptAction
+	completedAt time.Time
+}
+
+const runtimeInterjectionCallTTL = time.Minute
 
 func (rt *serveRuntime) emitGuardianReview(event tools.GuardianEvent) {
 	message := strings.TrimSpace(event.Message)
@@ -353,7 +365,8 @@ func (rt *serveRuntime) updateInterruptFromEvent(ev llm.Event) {
 }
 
 func (rt *serveRuntime) Interrupt(ctx context.Context, msg string, fastProvider llm.Provider) (llm.InterruptAction, error) {
-	return rt.InterruptMessage(ctx, llm.UserText(msg), msg, "", fastProvider, false)
+	action, _, err := rt.InterruptMessage(ctx, llm.UserText(msg), msg, "", fastProvider, false)
+	return action, err
 }
 
 func (rt *serveRuntime) QueueActiveRunRuntimeSwitch(model, reasoningEffort string) error {
@@ -381,12 +394,72 @@ func (rt *serveRuntime) QueueActiveRunRuntimeSwitch(model, reasoningEffort strin
 	return nil
 }
 
-func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, displayText string, interjectionID string, fastProvider llm.Provider, autoContinue bool) (llm.InterruptAction, error) {
+func interjectionFingerprint(msg llm.Message, displayText string, autoContinue bool) (string, error) {
+	parts := append([]llm.Part(nil), msg.Parts...)
+	for i := range parts {
+		// Parsing inline attachments can materialize them at a fresh temporary path
+		// on each transport retry. The content fields are the stable identity.
+		parts[i].ImagePath = ""
+		parts[i].FilePath = ""
+	}
+	payload, err := json.Marshal(struct {
+		Parts        []llm.Part `json:"parts"`
+		DisplayText  string     `json:"display_text"`
+		AutoContinue bool       `json:"auto_continue"`
+	}{parts, displayText, autoContinue})
+	if err != nil {
+		return "", fmt.Errorf("encode interjection idempotency payload: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return fmt.Sprintf("%x", sum), nil
+}
+
+func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, displayText string, interjectionID string, fastProvider llm.Provider, autoContinue bool) (llm.InterruptAction, bool, error) {
+	interjectionID = strings.TrimSpace(interjectionID)
+	fingerprint := ""
+	if interjectionID != "" {
+		var err error
+		fingerprint, err = interjectionFingerprint(msg, displayText, autoContinue)
+		if err != nil {
+			return llm.InterruptInterject, false, err
+		}
+	}
+
 	rt.interruptMu.Lock()
+	now := time.Now()
+	for id, existing := range rt.interjectionCalls {
+		if !existing.completedAt.IsZero() && now.Sub(existing.completedAt) > runtimeInterjectionCallTTL {
+			delete(rt.interjectionCalls, id)
+		}
+	}
+	var call *runtimeInterjectionCall
+	if interjectionID != "" {
+		if rt.interjectionCalls == nil {
+			rt.interjectionCalls = make(map[string]*runtimeInterjectionCall)
+		}
+		if existing := rt.interjectionCalls[interjectionID]; existing != nil {
+			if existing.fingerprint != fingerprint {
+				rt.interruptMu.Unlock()
+				return llm.InterruptInterject, false, fmt.Errorf("interjection id %q was already used for different content", interjectionID)
+			}
+			rt.interruptMu.Unlock()
+			select {
+			case <-existing.done:
+				return existing.action, true, nil
+			case <-ctx.Done():
+				return llm.InterruptInterject, true, ctx.Err()
+			}
+		}
+		call = &runtimeInterjectionCall{done: make(chan struct{}), fingerprint: fingerprint}
+		rt.interjectionCalls[interjectionID] = call
+	}
 	state := rt.activeInterrupt
 	if state == nil {
+		if call != nil {
+			delete(rt.interjectionCalls, interjectionID)
+		}
 		rt.interruptMu.Unlock()
-		return llm.InterruptInterject, fmt.Errorf("session has no active stream")
+		return llm.InterruptInterject, false, fmt.Errorf("session has no active stream")
 	}
 	cancel := state.cancel
 	activity := llm.InterruptActivity{
@@ -406,7 +479,13 @@ func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, d
 		}
 		classifyText += summary
 	}
-	action := llm.ClassifyInterrupt(ctx, fastProvider, classifyText, activity)
+	classifyCtx := ctx
+	classifyCancel := func() {}
+	if interjectionID != "" {
+		classifyCtx, classifyCancel = context.WithTimeout(context.WithoutCancel(ctx), 4*time.Second)
+	}
+	action := llm.ClassifyInterrupt(classifyCtx, fastProvider, classifyText, activity)
+	classifyCancel()
 	switch action {
 	case llm.InterruptCancel:
 		if cancel != nil {
@@ -415,7 +494,14 @@ func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, d
 	case llm.InterruptInterject:
 		rt.engine.QueueInterjection(llm.QueuedInterjection{ID: interjectionID, Message: msg, DisplayText: displayText, AutoContinue: autoContinue})
 	}
-	return action, nil
+	if call != nil {
+		rt.interruptMu.Lock()
+		call.action = action
+		call.completedAt = time.Now()
+		close(call.done)
+		rt.interruptMu.Unlock()
+	}
+	return action, false, nil
 }
 
 // ensureSessionInStore creates the session record in the database if it doesn't

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2753,6 +2753,62 @@ func TestHandleSessionInterrupt_DeduplicatesRetriedImageInterjection(t *testing.
 	}
 }
 
+func TestInterruptMessage_DeduplicatesConcurrentRetry(t *testing.T) {
+	engine := llm.NewEngine(llm.NewMockProvider("engine"), nil)
+	fastProvider := llm.NewMockProvider("classifier")
+	fastProvider.AddTurn(llm.MockTurn{Text: "interject", Delay: 100 * time.Millisecond})
+	rt := &serveRuntime{engine: engine}
+	state := &runtimeInterruptState{cancel: func() {}, done: make(chan struct{})}
+	rt.setActiveInterrupt(state)
+	defer rt.clearActiveInterrupt(state)
+
+	type result struct {
+		action   llm.InterruptAction
+		replayed bool
+		err      error
+	}
+	results := make(chan result, 2)
+	call := func() {
+		action, replayed, err := rt.InterruptMessage(
+			context.Background(),
+			llm.UserText("please incorporate this"),
+			"please incorporate this",
+			"web-concurrent-1",
+			fastProvider,
+			false,
+		)
+		results <- result{action: action, replayed: replayed, err: err}
+	}
+
+	go call()
+	deadline := time.Now().Add(time.Second)
+	for fastProvider.CurrentTurn() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if fastProvider.CurrentTurn() != 1 {
+		t.Fatal("first interrupt never reached classifier")
+	}
+	go call()
+
+	first := <-results
+	second := <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("interrupt errors = %v, %v", first.err, second.err)
+	}
+	if first.action != llm.InterruptInterject || second.action != llm.InterruptInterject {
+		t.Fatalf("actions = %v, %v, want interject", first.action, second.action)
+	}
+	if first.replayed == second.replayed {
+		t.Fatalf("replayed flags = %v, %v, want exactly one replay", first.replayed, second.replayed)
+	}
+	if got := fastProvider.CurrentTurn(); got != 1 {
+		t.Fatalf("classifier calls = %d, want 1", got)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 1 {
+		t.Fatalf("pending interjections = %d, want 1", len(pending))
+	}
+}
+
 func TestHandleSessionRuntimeGoalMutatesPersistentGoal(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2707,7 +2707,7 @@ func TestServeRuntimeRun_PersistsSessionAndMessages(t *testing.T) {
 	}
 }
 
-func TestHandleSessionInterrupt_MergesMessageWithImageOnlyContent(t *testing.T) {
+func TestHandleSessionInterrupt_DeduplicatesRetriedImageInterjection(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	mgr := newServeSessionManager(time.Minute, 10, nil)
 	defer mgr.Close()
@@ -2720,17 +2720,33 @@ func TestHandleSessionInterrupt_MergesMessageWithImageOnlyContent(t *testing.T) 
 
 	srv := &serveServer{sessionMgr: mgr}
 	body := `{"message":"please inspect this image","interjection_id":"web-1","content":[{"type":"input_image","image_url":"data:image/png;base64,aGVsbG8=","filename":"img.png"}]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-merge/interrupt", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	srv.handleSessionByID(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-merge/interrupt", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		srv.handleSessionByID(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200; body=%s", i+1, rr.Code, rr.Body.String())
+		}
+		if i == 0 {
+			// A transport retry can arrive after the active run has already ended.
+			rt.clearActiveInterrupt(state)
+		}
 	}
 	entries := engine.ListPendingInterjections()
 	if len(entries) != 1 {
-		t.Fatalf("pending entries = %d, want 1", len(entries))
+		t.Fatalf("pending entries after duplicate interjection ID = %d, want 1", len(entries))
 	}
+
+	mismatch := `{"message":"different message","interjection_id":"web-1"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-merge/interrupt", strings.NewReader(mismatch))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("mismatched idempotency payload status = %d, want 409; body=%s", rr.Code, rr.Body.String())
+	}
+
 	parts := entries[0].Message.Parts
 	if len(parts) != 2 || parts[0].Type != llm.PartImage || parts[1].Type != llm.PartText || parts[1].Text != "please inspect this image" {
 		t.Fatalf("queued parts = %#v, want image plus message text", parts)

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -3804,9 +3804,11 @@ const interruptActiveRun = async (session, prompt, messageId, contentParts = nul
   const body = Array.isArray(contentParts) && contentParts.length > 0
     ? { message: prompt, content: prompt ? [...contentParts, { type: 'input_text', text: prompt }] : contentParts, interjection_id: messageId }
     : { message: prompt, interjection_id: messageId };
+  const headers = requestHeaders(session.id);
+  headers['Idempotency-Key'] = messageId;
   const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/interrupt`, {
     method: 'POST',
-    headers: requestHeaders(session.id),
+    headers,
     body: JSON.stringify(body)
   });
   if (!response.ok) {

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -7,8 +7,7 @@
 // Two-tier timeout:
 //   1. First-frame timeout: read-only requests fall back after 1 s; mutations get
 //      5 s because their handlers may legitimately perform classification or
-//      other work before sending headers. Ambiguous mutations are retried only
-//      when they carry an idempotency key.
+//      other work before sending headers.
 //   2. Stream watchdog (30 s):  once streaming begins, if no frame (chunk,
 //      done, or server keepalive) arrives for 30 s the stream is closed and
 //      the channel renegotiated.  The app-layer resume logic reconnects via
@@ -34,6 +33,18 @@
 (function () {
   'use strict';
 
+  const READ_RESPONSE_TIMEOUT_MS = 1000;
+  const MUTATION_RESPONSE_TIMEOUT_MS = 5000;
+  const responseTimeoutForMethod = (method) => {
+    const normalized = String(method || 'GET').toUpperCase();
+    return (normalized === 'GET' || normalized === 'HEAD' || normalized === 'OPTIONS')
+      ? READ_RESPONSE_TIMEOUT_MS
+      : MUTATION_RESPONSE_TIMEOUT_MS;
+  };
+
+  if (window.__TERM_LLM_WEBRTC_TESTING__) {
+    window.__TERM_LLM_WEBRTC_TEST_HOOKS__ = Object.freeze({ responseTimeoutForMethod });
+  }
   if (!window.__WEBRTC_ENABLED__) return;
   if (new URLSearchParams(window.location.search).has('no_webrtc')) return;
 
@@ -43,10 +54,8 @@
 
   // Read-only requests should fail over quickly when UDP is dead. Mutations get
   // longer because endpoints such as /interrupt can classify input before they
-  // emit headers. Mutation retries must still be idempotent server-side because
-  // the original request may have completed despite a lost response frame.
-  const READ_RESPONSE_TIMEOUT_MS = 1000;
-  const MUTATION_RESPONSE_TIMEOUT_MS = 5000;
+  // emit headers. Retried mutations still need endpoint-level idempotency; the
+  // interrupt endpoint uses its stable interjection ID for that purpose.
 
   // Once streaming has started, if no frame arrives within this window,
   // assume the channel silently died.  The backend sends keepalive pings
@@ -364,7 +373,7 @@
   }
 
   function webrtcFetch(urlStr, options) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const reqId = crypto.randomUUID();
       let streamController;
       let resolved = false;
@@ -374,12 +383,7 @@
 
       const urlObj = new URL(urlStr, window.location.origin);
       const method = (options.method || 'GET').toUpperCase();
-      const readOnly = method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
-      const requestHeaderSet = new Headers(options.headers || {});
-      const replaySafe = readOnly || requestHeaderSet.has('Idempotency-Key');
-      const responseTimeoutMs = readOnly
-        ? READ_RESPONSE_TIMEOUT_MS
-        : MUTATION_RESPONSE_TIMEOUT_MS;
+      const responseTimeoutMs = responseTimeoutForMethod(method);
       const path = urlObj.pathname + (urlObj.search || '');
       const bodySize = options.body ? new Blob([options.body]).size : 0;
 
@@ -395,17 +399,6 @@
 
       function resolveOnce(response) {
         if (!resolved) { resolved = true; resolve(response); }
-      }
-
-      function retryOrRejectAmbiguousMutation(reason) {
-        if (replaySafe) {
-          resolveOnce(originalFetch(urlStr, options));
-          return;
-        }
-        if (!resolved) {
-          resolved = true;
-          reject(new TypeError('WebRTC request outcome is unknown; refusing to replay non-idempotent ' + method + ' request (' + reason + ')'));
-        }
       }
 
       // Central cleanup — idempotent, called from every exit path.
@@ -456,10 +449,9 @@
         cleanup('first-frame-timeout');
         closeStream();
 
-        // A read or idempotency-keyed mutation can be replayed over HTTPS. For
-        // any other mutation, surface an ambiguous network failure rather than
-        // risking the side effect twice.
-        retryOrRejectAmbiguousMutation('first-frame timeout');
+        // Fall back to HTTPS for this request. Mutation endpoints that can be
+        // replayed must enforce idempotency server-side.
+        resolveOnce(originalFetch(urlStr, options));
 
         // Mark the channel as degraded and renegotiate in the background.
         // This also drains any other stuck pending requests.
@@ -511,11 +503,11 @@
       function fallback() {
         cleanup('drain-fallback');
         if (!gotResponse) {
-          // No response frame means the server may still have performed the
-          // operation. Replay only requests whose semantics make that safe.
+          // Haven't received anything yet — retry via HTTPS. Mutation endpoints
+          // are responsible for making transport retries idempotent.
           closeStream();
           diag('↩ fallback ' + method + ' ' + path);
-          retryOrRejectAmbiguousMutation('data channel closed');
+          resolveOnce(originalFetch(urlStr, options));
         } else {
           // Already streaming — close the stream; consumer sees truncation.
           // App-layer resume logic will reconnect via HTTPS.

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -5,9 +5,10 @@
 // home peer, bypassing the intermediate relay for all /v1/ API calls.
 //
 // Two-tier timeout:
-//   1. First-frame timeout (1 s):  if no response frame arrives within 1 s,
-//      the request seamlessly falls back to HTTPS and the channel is torn down
-//      and renegotiated in the background.
+//   1. First-frame timeout: read-only requests fall back after 1 s; mutations get
+//      5 s because their handlers may legitimately perform classification or
+//      other work before sending headers. Ambiguous mutations are retried only
+//      when they carry an idempotency key.
 //   2. Stream watchdog (30 s):  once streaming begins, if no frame (chunk,
 //      done, or server keepalive) arrives for 30 s the stream is closed and
 //      the channel renegotiated.  The app-layer resume logic reconnects via
@@ -40,9 +41,12 @@
   const UI_PREFIX = window.TERM_LLM_UI_PREFIX || '/ui';
   const ICE_TIMEOUT_MS = 8000;
 
-  // If no response frame (headers/chunk/done) arrives within this window,
-  // assume UDP is dead: fall back to HTTPS and renegotiate in the background.
-  const RESPONSE_TIMEOUT_MS = 1000;
+  // Read-only requests should fail over quickly when UDP is dead. Mutations get
+  // longer because endpoints such as /interrupt can classify input before they
+  // emit headers. Mutation retries must still be idempotent server-side because
+  // the original request may have completed despite a lost response frame.
+  const READ_RESPONSE_TIMEOUT_MS = 1000;
+  const MUTATION_RESPONSE_TIMEOUT_MS = 5000;
 
   // Once streaming has started, if no frame arrives within this window,
   // assume the channel silently died.  The backend sends keepalive pings
@@ -360,7 +364,7 @@
   }
 
   function webrtcFetch(urlStr, options) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const reqId = crypto.randomUUID();
       let streamController;
       let resolved = false;
@@ -369,7 +373,13 @@
       const reqStart = performance.now();
 
       const urlObj = new URL(urlStr, window.location.origin);
-      const method = options.method || 'GET';
+      const method = (options.method || 'GET').toUpperCase();
+      const readOnly = method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+      const requestHeaderSet = new Headers(options.headers || {});
+      const replaySafe = readOnly || requestHeaderSet.has('Idempotency-Key');
+      const responseTimeoutMs = readOnly
+        ? READ_RESPONSE_TIMEOUT_MS
+        : MUTATION_RESPONSE_TIMEOUT_MS;
       const path = urlObj.pathname + (urlObj.search || '');
       const bodySize = options.body ? new Blob([options.body]).size : 0;
 
@@ -385,6 +395,17 @@
 
       function resolveOnce(response) {
         if (!resolved) { resolved = true; resolve(response); }
+      }
+
+      function retryOrRejectAmbiguousMutation(reason) {
+        if (replaySafe) {
+          resolveOnce(originalFetch(urlStr, options));
+          return;
+        }
+        if (!resolved) {
+          resolved = true;
+          reject(new TypeError('WebRTC request outcome is unknown; refusing to replay non-idempotent ' + method + ' request (' + reason + ')'));
+        }
       }
 
       // Central cleanup — idempotent, called from every exit path.
@@ -430,18 +451,20 @@
       const responseTimer = setTimeout(() => {
         if (gotResponse) return; // already got data, all good
 
-        diag('⚠ timeout (' + RESPONSE_TIMEOUT_MS + 'ms) ' + method + ' ' + path + ' — falling back to HTTPS');
+        diag('⚠ timeout (' + responseTimeoutMs + 'ms) ' + method + ' ' + path + ' — falling back to HTTPS');
 
         cleanup('first-frame-timeout');
         closeStream();
 
-        // Fall back to HTTPS for this request.
-        resolveOnce(originalFetch(urlStr, options));
+        // A read or idempotency-keyed mutation can be replayed over HTTPS. For
+        // any other mutation, surface an ambiguous network failure rather than
+        // risking the side effect twice.
+        retryOrRejectAmbiguousMutation('first-frame timeout');
 
         // Mark the channel as degraded and renegotiate in the background.
         // This also drains any other stuck pending requests.
         triggerRenegotiation();
-      }, RESPONSE_TIMEOUT_MS);
+      }, responseTimeoutMs);
 
       function markGotResponse() {
         if (!gotResponse) {
@@ -488,10 +511,11 @@
       function fallback() {
         cleanup('drain-fallback');
         if (!gotResponse) {
-          // Haven't received anything yet — retry cleanly via HTTPS.
+          // No response frame means the server may still have performed the
+          // operation. Replay only requests whose semantics make that safe.
           closeStream();
           diag('↩ fallback ' + method + ' ' + path);
-          resolveOnce(originalFetch(urlStr, options));
+          retryOrRejectAmbiguousMutation('data channel closed');
         } else {
           // Already streaming — close the stream; consumer sees truncation.
           // App-layer resume logic will reconnect via HTTPS.

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -515,6 +515,7 @@ function createHarness(options = {}) {
       url,
       method: requestOptions.method || 'GET',
       body: typeof requestOptions.body === 'string' ? requestOptions.body : null,
+      headers: requestOptions.headers || null,
     });
     if (typeof options.fetchImpl === 'function') {
       return options.fetchImpl(url, requestOptions, {
@@ -4808,6 +4809,11 @@ async function testStaleInterrupt404RefreshesAndSendsMessage() {
   const interruptCalls = fetchCalls.filter((call) => call.url === `/ui/v1/sessions/${session.id}/interrupt` && call.method === 'POST');
   if (interruptCalls.length !== 1) {
     fail(name, 'expected initial send to attempt interrupt once', JSON.stringify(fetchCalls));
+    return;
+  }
+  const interruptBody = JSON.parse(interruptCalls[0].body || '{}');
+  if (!interruptBody.interjection_id || interruptCalls[0].headers?.['Idempotency-Key'] !== interruptBody.interjection_id) {
+    fail(name, 'interrupt retry key should match its stable interjection id', JSON.stringify(interruptCalls[0]));
     return;
   }
   const postCalls = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');

--- a/internal/serveui/static/app_webrtc_test.js
+++ b/internal/serveui/static/app_webrtc_test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'app-webrtc.js'), 'utf8');
+const window = {
+  __WEBRTC_ENABLED__: false,
+  __TERM_LLM_WEBRTC_TESTING__: true,
+};
+vm.runInNewContext(source, { window }, { filename: 'app-webrtc.js' });
+
+const hooks = window.__TERM_LLM_WEBRTC_TEST_HOOKS__;
+if (!hooks || typeof hooks.responseTimeoutForMethod !== 'function') {
+  throw new Error('WebRTC timeout test hook was not installed');
+}
+
+const cases = [
+  ['GET', 1000],
+  ['get', 1000],
+  ['HEAD', 1000],
+  ['OPTIONS', 1000],
+  ['POST', 5000],
+  ['PATCH', 5000],
+  ['PUT', 5000],
+  ['DELETE', 5000],
+];
+
+for (const [method, expected] of cases) {
+  const actual = hooks.responseTimeoutForMethod(method);
+  if (actual !== expected) {
+    throw new Error(`${method} timeout = ${actual}, want ${expected}`);
+  }
+}
+
+console.log('PASS: WebRTC first-frame timeout is 1s for reads and 5s for mutations');


### PR DESCRIPTION
## What

- make `/interrupt` retries idempotent using the stable interjection ID
- retain completed interrupt results for 1 minute so an HTTPS fallback arriving after the active run ends cannot enqueue the message again
- bind IDs to canonical payload fingerprints and reject mismatched reuse
- serialize concurrent retries so only one classifier call and one queue insertion occur
- keep interrupt classification alive when the original WebRTC transport request disappears
- add an `Idempotency-Key` to web interrupt requests
- keep the 1-second WebRTC first-frame timeout for reads, but allow mutations 5 seconds

## Why

Session 3109 persisted one typed interjection twice. The WebRTC proxy sent `/interrupt`, received no response frame within 1 second while the fast classifier was still running, then retried the same non-idempotent POST over HTTPS. Both requests queued the same message.

The timeout split is now explicit: **1 second for read-only requests, 5 seconds for mutations**. The longer mutation window avoids treating normal classifier latency as a dead channel; endpoint-level idempotency still guarantees that a transport retry cannot duplicate an interjection.

## Verification

- `go build ./...`
- `go test -race ./cmd -run 'TestInterruptMessage_DeduplicatesConcurrentRetry|TestHandleSessionInterrupt_DeduplicatesRetriedImageInterjection' -count=1`
- `go test ./internal/serveui ./internal/llm`
- `node internal/serveui/static/app_webrtc_test.js`
- `node internal/serveui/static/app_stream_test.js`
- `node --check internal/serveui/static/app-webrtc.js`
- `git diff --check`

A full `go test ./...` also ran earlier; unrelated environment-sensitive skill-discovery tests and an existing background-child cleanup test failed. All packages relevant to this change passed.

## Review follow-up

Reviewed with `claude-bin:fable`. Follow-up changes preserve the existing HTTPS fallback behavior for other mutations, add direct coverage for the 1-second/5-second timeout split, test the concurrent duplicate waiter path, and document the 4-second classifier / 5-second transport-timeout relationship.
