### PR TITLE
fix responsive worktree picker rendering

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -373,6 +373,23 @@ func TestChipPickerJS(t *testing.T) {
 	}
 }
 
+func TestWorktreePopoverUsesResponsiveChipUI(t *testing.T) {
+	worktreesJS, err := StaticAsset("app-worktrees.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(worktreesJS)
+	for _, want := range []string{
+		"chip-popover chip-popover-runtime worktree-popover",
+		"chip-popover-item worktree-option",
+		"worktreeApp.positionChipPopover(elements.chipWorktreeTrigger, menu)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("app-worktrees.js missing responsive popover integration %q", want)
+		}
+	}
+}
+
 func TestAppWebRTCDoesNotReferenceLexicalApp(t *testing.T) {
 	webrtcJS, err := StaticAsset("app-webrtc.js")
 	if err != nil {

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -2727,8 +2727,7 @@ const buildChipOptionLabel = (opt) => {
   return { primary: text, meta: '' };
 };
 
-const positionChipPopover = (triggerEl) => {
-  const pop = elements.chipPopover;
+const positionChipPopover = (triggerEl, pop = elements.chipPopover) => {
   if (!pop || !triggerEl?.getBoundingClientRect) return;
   pop.hidden = false;
 
@@ -4443,6 +4442,7 @@ restoreLatestDraftMessage();
 Object.assign(app, {
   requestHeaders,
   normalizeError,
+  positionChipPopover,
   fetchProviders,
   fetchModels,
   parseSSEStream,

--- a/internal/serveui/static/app-worktrees.js
+++ b/internal/serveui/static/app-worktrees.js
@@ -190,28 +190,38 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
     const rows = await loadWorktrees();
     closeMenu();
     menu = document.createElement('div');
-    menu.className = 'chip-popover-runtime worktree-popover';
+    menu.className = 'chip-popover chip-popover-runtime worktree-popover';
     menu.setAttribute('role', 'listbox');
-    const addRow = (text, onClick) => {
+    const addRow = (labelText, metaText, onClick, selected = false) => {
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'chip-option';
-      btn.textContent = text;
+      btn.className = 'chip-popover-item worktree-option';
+      btn.setAttribute('role', 'option');
+      if (selected) btn.setAttribute('aria-selected', 'true');
+      const label = document.createElement('span');
+      label.className = 'chip-popover-item-label';
+      label.textContent = labelText;
+      btn.appendChild(label);
+      if (metaText) {
+        const meta = document.createElement('span');
+        meta.className = 'chip-popover-item-meta';
+        meta.textContent = metaText;
+        btn.appendChild(meta);
+      }
       btn.addEventListener('click', onClick);
       menu.appendChild(btn);
     };
-    addRow('root checkout', () => chooseWorktree(null));
+    const selectedDir = state.selectedWorktreeDir || '';
+    addRow('root checkout', '', () => chooseWorktree(null), !selectedDir);
     rows.filter((r) => !r.root).forEach((row) => {
       const ref = row.branch || (row.head_sha ? `detached@${row.head_sha.slice(0, 8)}` : 'detached');
-      addRow(`${row.name} · ±${row.dirty_files || 0} · ${ref}`, () => chooseWorktree(row));
+      addRow(row.name, `±${row.dirty_files || 0} · ${ref}`, () => chooseWorktree(row), row.dir === selectedDir);
     });
-    addRow(loading ? 'creating…' : '+ new worktree…', () => { void createWorktree(); });
-    const rect = elements.chipWorktreeTrigger.getBoundingClientRect();
-    menu.style.position = 'fixed';
-    menu.style.top = `${Math.round(rect.bottom + 6)}px`;
-    menu.style.left = `${Math.round(rect.left)}px`;
-    menu.style.zIndex = '1000';
+    addRow(loading ? 'creating…' : '+ new worktree…', '', () => { void createWorktree(); });
     document.body.appendChild(menu);
+    if (typeof worktreeApp.positionChipPopover === 'function') {
+      worktreeApp.positionChipPopover(elements.chipWorktreeTrigger, menu);
+    }
     elements.chipWorktreeTrigger.setAttribute('aria-expanded', 'true');
   };
 
@@ -226,6 +236,22 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
     if (event.target === elements.chipWorktreeTrigger || menu.contains(event.target)) return;
     closeMenu();
   });
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape' || !menu) return;
+    closeMenu();
+    elements.chipWorktreeTrigger?.focus?.();
+  });
+
+  const repositionMenu = () => {
+    if (!menu || typeof worktreeApp.positionChipPopover !== 'function') return;
+    worktreeApp.positionChipPopover(elements.chipWorktreeTrigger, menu);
+  };
+  window.addEventListener('resize', repositionMenu);
+  window.addEventListener('orientationchange', repositionMenu);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', repositionMenu);
+    window.visualViewport.addEventListener('scroll', repositionMenu);
+  }
 
   Object.assign(worktreeApp, {
     loadWorktrees,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1694,6 +1694,26 @@
       padding: 0.75rem;
     }
 
+    .worktree-popover {
+      width: min(360px, calc(100vw - 0.75rem));
+    }
+
+    .worktree-option {
+      appearance: none;
+      width: 100%;
+      border: 0;
+      background: transparent;
+      font: inherit;
+      text-align: left;
+    }
+
+    .worktree-option .chip-popover-item-meta {
+      overflow: hidden;
+      max-width: 10rem;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .runtime-popover-header {
       margin-bottom: 0.7rem;
     }


### PR DESCRIPTION
## What

- apply the shared chip-popover styling to the web worktree picker
- reuse viewport-aware positioning for desktop and mobile
- split worktree names from status metadata so long names truncate cleanly
- preserve selection state and reposition on resize/orientation changes
- add Escape handling and a regression test

## Why

The picker used an undefined option class and omitted the base popover class. It was also anchored directly to the trigger's left edge without collision detection, leaving most of the menu off-screen.

In the reproduction:

- desktop: the picker right edge was 1664px in a 1440px viewport; it is now 1434px
- mobile: the picker right edge was 637px in a 390px viewport; it is now 382px

## Verification

- reproduced in a throwaway git repository with real managed worktrees
- captured desktop and iPhone 13 screenshots before and after
- `XDG_CONFIG_HOME=<isolated> go test ./...`
- `go build ./...`
- `git diff --check`
