### PR TITLE
fix: Concurrent ChatGPT token refresh can delete freshly renewed credentials

### DIFF
--- a/internal/credentials/chatgpt.go
+++ b/internal/credentials/chatgpt.go
@@ -5,9 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/oauth"
+)
+
+var (
+	chatGPTRefreshMu    sync.Mutex
+	refreshChatGPTToken = oauth.RefreshToken
 )
 
 // ChatGPTCredentials holds the OAuth tokens for ChatGPT
@@ -108,30 +114,46 @@ func ClearChatGPTCredentials() error {
 }
 
 // RefreshChatGPTCredentials refreshes the access token using the refresh token.
-// The updated credentials are automatically saved to storage.
+// Concurrent refreshes are serialized so rotating a shared persisted token only
+// performs one exchange. The updated credentials are automatically saved to storage.
 func RefreshChatGPTCredentials(creds *ChatGPTCredentials) error {
+	chatGPTRefreshMu.Lock()
+	defer chatGPTRefreshMu.Unlock()
+
 	if creds.RefreshToken == "" {
 		return fmt.Errorf("no refresh token available")
 	}
 
-	tokenResp, err := oauth.RefreshToken(creds.RefreshToken)
+	// Providers keep independent in-memory copies of the same credentials. A
+	// caller waiting for the refresh lock may therefore still hold the token
+	// that another caller just rotated. Prefer the newly persisted credentials
+	// instead of exchanging that stale refresh token again.
+	if stored, err := GetChatGPTCredentials(); err == nil && *stored != *creds {
+		*creds = *stored
+		return nil
+	}
+
+	tokenResp, err := refreshChatGPTToken(creds.RefreshToken)
 	if err != nil {
 		return err
 	}
 
-	// Update credentials
-	creds.AccessToken = tokenResp.AccessToken
-	creds.ExpiresAt = time.Now().Unix() + int64(tokenResp.ExpiresIn)
+	// Do not mutate the caller until persistence succeeds. This keeps its copy
+	// consistent with storage if the atomic save fails.
+	refreshed := *creds
+	refreshed.AccessToken = tokenResp.AccessToken
+	refreshed.ExpiresAt = time.Now().Unix() + int64(tokenResp.ExpiresIn)
 
 	// Update refresh token if a new one was provided
 	if tokenResp.RefreshToken != "" {
-		creds.RefreshToken = tokenResp.RefreshToken
+		refreshed.RefreshToken = tokenResp.RefreshToken
 	}
 
 	// Save updated credentials
-	if err := SaveChatGPTCredentials(creds); err != nil {
+	if err := SaveChatGPTCredentials(&refreshed); err != nil {
 		return fmt.Errorf("failed to save refreshed credentials: %w", err)
 	}
+	*creds = refreshed
 
 	return nil
 }

--- a/internal/credentials/chatgpt_test.go
+++ b/internal/credentials/chatgpt_test.go
@@ -1,0 +1,87 @@
+package credentials
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/oauth"
+)
+
+func TestRefreshChatGPTCredentialsConcurrentCallersReuseRotatedCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	stale := &ChatGPTCredentials{
+		AccessToken:  "stale-access",
+		RefreshToken: "stale-refresh",
+		ExpiresAt:    time.Now().Add(-time.Minute).Unix(),
+		AccountID:    "account-1",
+	}
+	if err := SaveChatGPTCredentials(stale); err != nil {
+		t.Fatalf("save stale credentials: %v", err)
+	}
+	first, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("load first credential copy: %v", err)
+	}
+	second, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("load second credential copy: %v", err)
+	}
+
+	originalRefresh := refreshChatGPTToken
+	defer func() { refreshChatGPTToken = originalRefresh }()
+
+	var calls atomic.Int32
+	exchangeStarted := make(chan struct{})
+	releaseExchange := make(chan struct{})
+	refreshChatGPTToken = func(refreshToken string) (*oauth.ChatGPTTokenResponse, error) {
+		if refreshToken != "stale-refresh" {
+			return nil, errors.New("unexpected refresh token")
+		}
+		if calls.Add(1) != 1 {
+			return nil, errors.New("stale refresh token was exchanged twice")
+		}
+		close(exchangeStarted)
+		<-releaseExchange
+		return &oauth.ChatGPTTokenResponse{
+			AccessToken:  "renewed-access",
+			RefreshToken: "rotated-refresh",
+			ExpiresIn:    3600,
+		}, nil
+	}
+
+	results := make(chan error, 2)
+	go func() { results <- RefreshChatGPTCredentials(first) }()
+	<-exchangeStarted
+	secondStarted := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		results <- RefreshChatGPTCredentials(second)
+	}()
+	<-secondStarted
+	close(releaseExchange)
+
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("concurrent refresh failed: %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("refresh exchanges = %d, want 1", got)
+	}
+	for name, creds := range map[string]*ChatGPTCredentials{"first": first, "second": second} {
+		if creds.AccessToken != "renewed-access" || creds.RefreshToken != "rotated-refresh" {
+			t.Fatalf("%s credentials were not renewed: %#v", name, creds)
+		}
+	}
+
+	stored, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("load renewed credentials: %v", err)
+	}
+	if stored.AccessToken != "renewed-access" || stored.RefreshToken != "rotated-refresh" {
+		t.Fatalf("stored credentials were not renewed: %#v", stored)
+	}
+}

--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -331,13 +331,10 @@ func NewChatGPTResponsesClient(creds *credentials.ChatGPTCredentials) *Responses
 			return nil
 		},
 		OnAuthRetry: func(_ context.Context) error {
-			if err := credentials.RefreshChatGPTCredentials(creds); err == nil {
-				return nil
+			if err := credentials.RefreshChatGPTCredentials(creds); err != nil {
+				return fmt.Errorf("ChatGPT session refresh failed: %w", err)
 			}
-			if clearErr := credentials.ClearChatGPTCredentials(); clearErr != nil {
-				return fmt.Errorf("ChatGPT session expired and failed to clear credentials: %w", clearErr)
-			}
-			return fmt.Errorf("ChatGPT session expired — please re-run your command to re-authenticate")
+			return nil
 		},
 	}
 }

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -82,6 +82,32 @@ func TestNewChatGPTResponsesClientUsesCurrentCodexHeaders(t *testing.T) {
 	}
 }
 
+func TestChatGPTAuthRetryFailurePreservesStoredCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	creds := &credentials.ChatGPTCredentials{
+		AccessToken: "current-access",
+		ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		AccountID:   "test-account",
+	}
+	if err := credentials.SaveChatGPTCredentials(creds); err != nil {
+		t.Fatalf("save credentials: %v", err)
+	}
+
+	client := NewChatGPTResponsesClient(creds)
+	if err := client.OnAuthRetry(context.Background()); err == nil {
+		t.Fatal("auth retry succeeded without a refresh token")
+	}
+
+	stored, err := credentials.GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("auth retry failure removed stored credentials: %v", err)
+	}
+	if stored.AccessToken != "current-access" {
+		t.Fatalf("stored access token = %q, want preserved token", stored.AccessToken)
+	}
+}
+
 func TestChatGPTStream_OmitsPromptCacheKeyButKeepsSessionHeader(t *testing.T) {
 	origClient := chatGPTHTTPClient
 	defer func() { chatGPTHTTPClient = origClient }()


### PR DESCRIPTION
## What changed

- Serialize ChatGPT OAuth refreshes process-wide.
- Reload persisted credentials after acquiring the refresh lock and reuse a token another caller already renewed instead of exchanging the same rotating refresh token twice.
- Save a refreshed copy before mutating the caller's in-memory credentials.
- Preserve persisted credentials when an HTTP/WebSocket auth retry refresh fails instead of deleting them for every refresh error.
- Add regression coverage for two concurrent stale credential copies and for preserving credentials after a refresh failure.

## Why this is high-value

Serve sessions, Telegram, image generation, and jobs can each hold independent copies of the same daily-use ChatGPT credentials. At token rollover, concurrent refreshes could race on the rotating refresh token; the losing request could then delete the winner's freshly saved credentials and force process-wide interactive reauthentication. The refresh path now performs one effective exchange and distributes the renewed credentials to waiting callers, while transient failures can no longer erase valid on-disk auth state.

## Validation

- `gofmt -w internal/credentials/chatgpt.go internal/credentials/chatgpt_test.go internal/llm/chatgpt.go internal/llm/chatgpt_test.go`
- `go build ./...`
- `go test ./internal/credentials ./internal/llm`
- `go test -race ./internal/credentials ./internal/llm`
- Full `go test ./...` attempted. With an isolated `XDG_CONFIG_HOME`, all packages passed except the unrelated pre-existing `internal/jobs.TestProgramRunnerDoesNotLeakBackgroundChildren`, which consistently sees a killed background child remain visible in this container environment.
