### PR TITLE
fix: ChatGPT token rotation strands other long-lived runtimes on stale credentials

### DIFF
--- a/internal/credentials/chatgpt.go
+++ b/internal/credentials/chatgpt.go
@@ -5,9 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/oauth"
+)
+
+var (
+	chatGPTCredentialsMu sync.Mutex
+	refreshChatGPTToken  = oauth.RefreshToken
 )
 
 // ChatGPTCredentials holds the OAuth tokens for ChatGPT
@@ -45,11 +51,19 @@ func GetChatGPTCredentials() (*ChatGPTCredentials, error) {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(credPath)
+	creds, err := readChatGPTCredentials(credPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("ChatGPT credentials not found (authenticate first)")
 		}
+		return nil, err
+	}
+	return creds, nil
+}
+
+func readChatGPTCredentials(credPath string) (*ChatGPTCredentials, error) {
+	data, err := os.ReadFile(credPath)
+	if err != nil {
 		return nil, fmt.Errorf("failed to read credentials: %w", err)
 	}
 
@@ -67,17 +81,12 @@ func GetChatGPTCredentials() (*ChatGPTCredentials, error) {
 
 // SaveChatGPTCredentials saves ChatGPT OAuth credentials to storage.
 func SaveChatGPTCredentials(creds *ChatGPTCredentials) error {
-	credPath, err := getChatGPTCredentialsPath()
-	if err != nil {
-		return err
-	}
+	return withChatGPTCredentialsLock(func(credPath string) error {
+		return saveChatGPTCredentials(credPath, creds)
+	})
+}
 
-	// Ensure directory exists
-	dir := filepath.Dir(credPath)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("failed to create credentials directory: %w", err)
-	}
-
+func saveChatGPTCredentials(credPath string, creds *ChatGPTCredentials) error {
 	data, err := json.MarshalIndent(creds, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal credentials: %w", err)
@@ -95,45 +104,97 @@ func SaveChatGPTCredentials(creds *ChatGPTCredentials) error {
 
 // ClearChatGPTCredentials removes the stored ChatGPT credentials.
 func ClearChatGPTCredentials() error {
-	credPath, err := getChatGPTCredentialsPath()
-	if err != nil {
-		return err
-	}
+	return withChatGPTCredentialsLock(func(credPath string) error {
+		return removeChatGPTCredentials(credPath)
+	})
+}
 
+// ClearChatGPTCredentialsIfRefreshToken removes credentials only if they still
+// contain the refresh token that was rejected. A concurrent refresh or login
+// therefore cannot be deleted by a stale provider's authentication retry.
+func ClearChatGPTCredentialsIfRefreshToken(refreshToken string) error {
+	return withChatGPTCredentialsLock(func(credPath string) error {
+		stored, err := readChatGPTCredentials(credPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if stored.RefreshToken != refreshToken {
+			return nil
+		}
+		return removeChatGPTCredentials(credPath)
+	})
+}
+
+func removeChatGPTCredentials(credPath string) error {
 	if err := os.Remove(credPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove credentials: %w", err)
 	}
-
 	return nil
 }
 
 // RefreshChatGPTCredentials refreshes the access token using the refresh token.
 // The updated credentials are automatically saved to storage.
 func RefreshChatGPTCredentials(creds *ChatGPTCredentials) error {
-	if creds.RefreshToken == "" {
-		return fmt.Errorf("no refresh token available")
-	}
+	return withChatGPTCredentialsLock(func(credPath string) error {
+		stored, err := readChatGPTCredentials(credPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to reload ChatGPT credentials: %w", err)
+		}
+		if err == nil && (stored.RefreshToken != creds.RefreshToken || stored.ExpiresAt > creds.ExpiresAt) {
+			*creds = *stored
+			if !creds.IsExpired() {
+				return nil
+			}
+		}
 
-	tokenResp, err := oauth.RefreshToken(creds.RefreshToken)
+		if creds.RefreshToken == "" {
+			return fmt.Errorf("no refresh token available")
+		}
+
+		tokenResp, err := refreshChatGPTToken(creds.RefreshToken)
+		if err != nil {
+			return err
+		}
+
+		creds.AccessToken = tokenResp.AccessToken
+		creds.ExpiresAt = time.Now().Unix() + int64(tokenResp.ExpiresIn)
+		if tokenResp.RefreshToken != "" {
+			creds.RefreshToken = tokenResp.RefreshToken
+		}
+
+		if err := saveChatGPTCredentials(credPath, creds); err != nil {
+			return fmt.Errorf("failed to save refreshed credentials: %w", err)
+		}
+		return nil
+	})
+}
+
+func withChatGPTCredentialsLock(fn func(credPath string) error) (err error) {
+	chatGPTCredentialsMu.Lock()
+	defer chatGPTCredentialsMu.Unlock()
+
+	credPath, err := getChatGPTCredentialsPath()
 	if err != nil {
 		return err
 	}
-
-	// Update credentials
-	creds.AccessToken = tokenResp.AccessToken
-	creds.ExpiresAt = time.Now().Unix() + int64(tokenResp.ExpiresIn)
-
-	// Update refresh token if a new one was provided
-	if tokenResp.RefreshToken != "" {
-		creds.RefreshToken = tokenResp.RefreshToken
+	if err := os.MkdirAll(filepath.Dir(credPath), 0700); err != nil {
+		return fmt.Errorf("failed to create credentials directory: %w", err)
 	}
 
-	// Save updated credentials
-	if err := SaveChatGPTCredentials(creds); err != nil {
-		return fmt.Errorf("failed to save refreshed credentials: %w", err)
+	unlock, err := lockChatGPTCredentials(credPath + ".lock")
+	if err != nil {
+		return fmt.Errorf("failed to lock ChatGPT credentials: %w", err)
 	}
+	defer func() {
+		if unlockErr := unlock(); err == nil && unlockErr != nil {
+			err = fmt.Errorf("failed to unlock ChatGPT credentials: %w", unlockErr)
+		}
+	}()
 
-	return nil
+	return fn(credPath)
 }
 
 // ChatGPTCredentialsExist returns true if ChatGPT credentials are stored.

--- a/internal/credentials/chatgpt_lock_unix.go
+++ b/internal/credentials/chatgpt_lock_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func lockChatGPTCredentials(lockPath string) (func() error, error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("acquire file lock: %w", err)
+	}
+
+	return func() error {
+		unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		closeErr := file.Close()
+		if unlockErr != nil {
+			if closeErr != nil {
+				return fmt.Errorf("unlock file lock: %v; close lock file: %w", unlockErr, closeErr)
+			}
+			return fmt.Errorf("unlock file lock: %w", unlockErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close lock file: %w", closeErr)
+		}
+		return nil
+	}, nil
+}

--- a/internal/credentials/chatgpt_lock_windows.go
+++ b/internal/credentials/chatgpt_lock_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package credentials
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockChatGPTCredentials(lockPath string) (func() error, error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("acquire file lock: %w", err)
+	}
+
+	return func() error {
+		unlockErr := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+		closeErr := file.Close()
+		if unlockErr != nil {
+			if closeErr != nil {
+				return fmt.Errorf("unlock file lock: %v; close lock file: %w", unlockErr, closeErr)
+			}
+			return fmt.Errorf("unlock file lock: %w", unlockErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close lock file: %w", closeErr)
+		}
+		return nil
+	}, nil
+}

--- a/internal/credentials/chatgpt_test.go
+++ b/internal/credentials/chatgpt_test.go
@@ -1,0 +1,212 @@
+package credentials
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/oauth"
+)
+
+func TestRefreshChatGPTCredentialsAdoptsRotatedCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	initial := &ChatGPTCredentials{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
+		AccountID:    "account",
+	}
+	if err := SaveChatGPTCredentials(initial); err != nil {
+		t.Fatalf("save initial credentials: %v", err)
+	}
+
+	first, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("load first credentials: %v", err)
+	}
+	second, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("load second credentials: %v", err)
+	}
+
+	oldRefresh := refreshChatGPTToken
+	t.Cleanup(func() { refreshChatGPTToken = oldRefresh })
+	var refreshTokens []string
+	refreshChatGPTToken = func(refreshToken string) (*oauth.ChatGPTTokenResponse, error) {
+		refreshTokens = append(refreshTokens, refreshToken)
+		return &oauth.ChatGPTTokenResponse{
+			AccessToken:  "new-access",
+			RefreshToken: "new-refresh",
+			ExpiresIn:    3600,
+		}, nil
+	}
+
+	if err := RefreshChatGPTCredentials(first); err != nil {
+		t.Fatalf("refresh first credentials: %v", err)
+	}
+	if err := RefreshChatGPTCredentials(second); err != nil {
+		t.Fatalf("refresh stale second credentials: %v", err)
+	}
+
+	if len(refreshTokens) != 1 || refreshTokens[0] != "old-refresh" {
+		t.Fatalf("refresh calls = %v, want one exchange of old-refresh", refreshTokens)
+	}
+	if second.AccessToken != "new-access" || second.RefreshToken != "new-refresh" {
+		t.Fatalf("stale credentials were not updated from disk: %+v", second)
+	}
+	stored, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("load stored credentials: %v", err)
+	}
+	if stored.AccessToken != "new-access" || stored.RefreshToken != "new-refresh" {
+		t.Fatalf("stored credentials = %+v, want rotated credentials", stored)
+	}
+}
+
+func TestClearChatGPTCredentialsIfRefreshTokenPreservesNewerCredentials(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	newer := &ChatGPTCredentials{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+	}
+	if err := SaveChatGPTCredentials(newer); err != nil {
+		t.Fatalf("save credentials: %v", err)
+	}
+
+	if err := ClearChatGPTCredentialsIfRefreshToken("stale-refresh"); err != nil {
+		t.Fatalf("conditionally clear stale token: %v", err)
+	}
+	stored, err := GetChatGPTCredentials()
+	if err != nil {
+		t.Fatalf("newer credentials were removed: %v", err)
+	}
+	if stored.RefreshToken != "new-refresh" {
+		t.Fatalf("stored refresh token = %q, want new-refresh", stored.RefreshToken)
+	}
+
+	if err := ClearChatGPTCredentialsIfRefreshToken("new-refresh"); err != nil {
+		t.Fatalf("conditionally clear current token: %v", err)
+	}
+	if ChatGPTCredentialsExist() {
+		t.Fatal("matching credentials were not removed")
+	}
+}
+
+func TestChatGPTCredentialsLockSerializesProcesses(t *testing.T) {
+	if os.Getenv("TERM_LLM_CHATGPT_LOCK_HELPER") != "" {
+		runChatGPTCredentialsLockHelper(t)
+		return
+	}
+
+	configDir := t.TempDir()
+	stateDir := t.TempDir()
+	ready := filepath.Join(stateDir, "ready")
+	release := filepath.Join(stateDir, "release")
+	attempting := filepath.Join(stateDir, "attempting")
+	acquired := filepath.Join(stateDir, "acquired")
+
+	holder := chatGPTLockHelperCommand(configDir, "hold", ready, release, "")
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start lock holder: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.WriteFile(release, nil, 0o600)
+		if holder.Process != nil {
+			_ = holder.Process.Kill()
+		}
+	})
+	waitForTestFile(t, ready)
+
+	contender := chatGPTLockHelperCommand(configDir, "acquire", attempting, "", acquired)
+	if err := contender.Start(); err != nil {
+		t.Fatalf("start lock contender: %v", err)
+	}
+	t.Cleanup(func() {
+		if contender.Process != nil {
+			_ = contender.Process.Kill()
+		}
+	})
+	waitForTestFile(t, attempting)
+
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(acquired); err == nil {
+		t.Fatal("second process acquired ChatGPT credential lock before release")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat contender state: %v", err)
+	}
+
+	if err := os.WriteFile(release, nil, 0o600); err != nil {
+		t.Fatalf("release lock holder: %v", err)
+	}
+	if err := holder.Wait(); err != nil {
+		t.Fatalf("lock holder failed: %v", err)
+	}
+	if err := contender.Wait(); err != nil {
+		t.Fatalf("lock contender failed: %v", err)
+	}
+	waitForTestFile(t, acquired)
+}
+
+func chatGPTLockHelperCommand(configDir, action, ready, release, acquired string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestChatGPTCredentialsLockSerializesProcesses$")
+	cmd.Env = append(os.Environ(),
+		"XDG_CONFIG_HOME="+configDir,
+		"TERM_LLM_CHATGPT_LOCK_HELPER="+action,
+		"TERM_LLM_CHATGPT_LOCK_READY="+ready,
+		"TERM_LLM_CHATGPT_LOCK_RELEASE="+release,
+		"TERM_LLM_CHATGPT_LOCK_ACQUIRED="+acquired,
+	)
+	return cmd
+}
+
+func runChatGPTCredentialsLockHelper(t *testing.T) {
+	action := os.Getenv("TERM_LLM_CHATGPT_LOCK_HELPER")
+	ready := os.Getenv("TERM_LLM_CHATGPT_LOCK_READY")
+	release := os.Getenv("TERM_LLM_CHATGPT_LOCK_RELEASE")
+	acquired := os.Getenv("TERM_LLM_CHATGPT_LOCK_ACQUIRED")
+
+	if action == "acquire" {
+		if err := os.WriteFile(ready, nil, 0o600); err != nil {
+			t.Fatalf("signal lock attempt: %v", err)
+		}
+	}
+	err := withChatGPTCredentialsLock(func(string) error {
+		if action == "acquire" {
+			return os.WriteFile(acquired, nil, 0o600)
+		}
+		if err := os.WriteFile(ready, nil, 0o600); err != nil {
+			return err
+		}
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(release); err == nil {
+				return nil
+			} else if !os.IsNotExist(err) {
+				return err
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return os.ErrDeadlineExceeded
+	})
+	if err != nil {
+		t.Fatalf("credential lock helper: %v", err)
+	}
+}
+
+func waitForTestFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}

--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -74,8 +74,10 @@ func NewChatGPTProviderWithOptions(model string, opts ChatGPTProviderOptions) (*
 
 	// Refresh if expired
 	if creds.IsExpired() {
-		if err := credentials.RefreshChatGPTCredentials(creds); err != nil {
-			// Refresh failed - need to re-authenticate
+		if refreshErr := credentials.RefreshChatGPTCredentials(creds); refreshErr != nil {
+			if !errors.Is(refreshErr, oauth.ErrChatGPTRefreshTokenInvalid) {
+				return nil, fmt.Errorf("token refresh failed: %w", refreshErr)
+			}
 			fmt.Println("Token refresh failed. Re-authentication required.")
 			creds, err = PromptForChatGPTAuth()
 			if err != nil {
@@ -331,13 +333,17 @@ func NewChatGPTResponsesClient(creds *credentials.ChatGPTCredentials) *Responses
 			return nil
 		},
 		OnAuthRetry: func(_ context.Context) error {
-			if err := credentials.RefreshChatGPTCredentials(creds); err == nil {
-				return nil
+			if err := credentials.RefreshChatGPTCredentials(creds); err != nil {
+				if !errors.Is(err, oauth.ErrChatGPTRefreshTokenInvalid) {
+					return fmt.Errorf("failed to refresh ChatGPT session: %w", err)
+				}
+				failedRefreshToken := creds.RefreshToken
+				if clearErr := credentials.ClearChatGPTCredentialsIfRefreshToken(failedRefreshToken); clearErr != nil {
+					return fmt.Errorf("ChatGPT session expired and failed to clear credentials: %w", clearErr)
+				}
+				return fmt.Errorf("ChatGPT session expired — please re-run your command to re-authenticate")
 			}
-			if clearErr := credentials.ClearChatGPTCredentials(); clearErr != nil {
-				return fmt.Errorf("ChatGPT session expired and failed to clear credentials: %w", clearErr)
-			}
-			return fmt.Errorf("ChatGPT session expired — please re-run your command to re-authenticate")
+			return nil
 		},
 	}
 }

--- a/internal/oauth/chatgpt.go
+++ b/internal/oauth/chatgpt.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,6 +26,10 @@ const (
 	ChatGPTScopes       = "openid profile email offline_access"
 	ChatGPTCallbackPort = 1455
 )
+
+// ErrChatGPTRefreshTokenInvalid indicates that the authorization server has
+// definitively rejected a refresh token, rather than a transient refresh error.
+var ErrChatGPTRefreshTokenInvalid = errors.New("ChatGPT refresh token expired or revoked")
 
 type ChatGPTTokenResponse struct {
 	AccessToken  string `json:"access_token"`
@@ -179,7 +184,7 @@ func RefreshToken(refreshToken string) (*ChatGPTTokenResponse, error) {
 		}
 		json.NewDecoder(resp.Body).Decode(&errResp)
 		if errResp.Error == "invalid_grant" || strings.Contains(errResp.ErrorDescription, "revoked") {
-			return nil, fmt.Errorf("refresh token expired or revoked: please re-authenticate")
+			return nil, fmt.Errorf("%w: please re-authenticate", ErrChatGPTRefreshTokenInvalid)
 		}
 		if errResp.ErrorDescription != "" {
 			return nil, fmt.Errorf("token refresh failed: %s - %s", errResp.Error, errResp.ErrorDescription)

--- a/internal/oauth/chatgpt_test.go
+++ b/internal/oauth/chatgpt_test.go
@@ -1,0 +1,60 @@
+package oauth
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRefreshTokenClassifiesOnlyInvalidGrantAsInvalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantInvalid bool
+	}{
+		{
+			name:        "invalid grant",
+			status:      http.StatusBadRequest,
+			body:        `{"error":"invalid_grant","error_description":"refresh token already used"}`,
+			wantInvalid: true,
+		},
+		{
+			name:        "transient server error",
+			status:      http.StatusInternalServerError,
+			body:        `{"error":"server_error","error_description":"try again later"}`,
+			wantInvalid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldClient := oauthHTTPClient
+			oauthHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tt.status,
+					Status:     http.StatusText(tt.status),
+					Body:       io.NopCloser(strings.NewReader(tt.body)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+			t.Cleanup(func() { oauthHTTPClient = oldClient })
+
+			_, err := RefreshToken("refresh-token")
+			if err == nil {
+				t.Fatal("RefreshToken succeeded unexpectedly")
+			}
+			if got := errors.Is(err, ErrChatGPTRefreshTokenInvalid); got != tt.wantInvalid {
+				t.Fatalf("errors.Is(invalid) = %v, want %v; error: %v", got, tt.wantInvalid, err)
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## What changed

- Serialized ChatGPT credential refresh, save, and clear operations with an in-process mutex and a cross-process advisory lockfile.
- Reloaded credentials after acquiring the lock so a stale provider adopts a token another runtime already rotated instead of exchanging the obsolete refresh token.
- Classified OAuth `invalid_grant` failures explicitly. Reactive 401 handling now clears credentials only for a definitive invalid-token response and only when the persisted refresh token still matches the rejected token; transient failures and stale runtimes cannot delete newer credentials.
- Avoided launching interactive reauthentication from provider construction for transient refresh failures.
- Added regression coverage for two independently loaded credential objects, conditional deletion, cross-process lock serialization, and invalid-grant versus transient OAuth errors.

## Why this is high-value

ChatGPT backs daily web, Telegram, and scheduled-job paths, each of which can retain its own long-lived provider and credential object. Refresh-token rotation by one runtime previously stranded the others on stale tokens, and a later 401 retry could delete the valid replacement file for every runtime. Locking and reloading at the shared credential boundary prevents routine token rollover from becoming a global reauthentication outage.

## Validation

- `go build ./...`
- `XDG_CONFIG_HOME=<empty temporary directory> go test ./...`
- `go test -race ./internal/credentials ./internal/oauth`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/credentials`
- `git diff --check`
