### PR TITLE
feat: report session worktree directory with OSC 7

### DIFF
--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -81,10 +81,14 @@ type Model struct {
 	keyMap   KeyMap
 
 	// Session state
-	store         session.Store     // Session storage backend
-	sess          *session.Session  // Current session
-	messages      []session.Message // In-memory messages for current session
-	compactionIdx int               // Prefix length to skip for LLM context; 0 means no prefix is skipped.
+	store    session.Store     // Session storage backend
+	sess     *session.Session  // Current session
+	messages []session.Message // In-memory messages for current session
+	// pendingTerminalDirectory is emitted as OSC 7 after a successful runtime
+	// directory change, keeping terminal workspace metadata in sync without a
+	// process-wide chdir.
+	pendingTerminalDirectory string
+	compactionIdx            int // Prefix length to skip for LLM context; 0 means no prefix is skipped.
 	// olderScrollbackLoaded is false when a compacted resume initially loaded only
 	// the active tail; scrolling upward can hydrate the older display prefix once.
 	olderScrollbackLoaded bool
@@ -1480,6 +1484,9 @@ func (m *Model) Init() tea.Cmd {
 	if cmd := m.terminalTitleCmd(); cmd != nil {
 		baseCmds = append(baseCmds, cmd)
 	}
+	if cmd := terminalWorkingDirectoryCmd(m.effectiveWorkingDir()); cmd != nil {
+		baseCmds = append(baseCmds, cmd)
+	}
 
 	// Set markdown renderer for chat renderer
 	if m.chatRenderer != nil {
@@ -1622,7 +1629,13 @@ func (m *Model) shouldIgnoreStreamEvent(msg streamEventMsg) bool {
 }
 
 // Update handles messages
-func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
+	defer func() {
+		if reportCmd := m.takeTerminalWorkingDirectoryCmd(); reportCmd != nil {
+			cmd = tea.Batch(cmd, reportCmd)
+		}
+	}()
+
 	var cmds []tea.Cmd
 	var flushCmds []tea.Cmd
 

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -937,6 +937,7 @@ func (m *Model) cmdClear() (tea.Model, tea.Cmd) {
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		m.sess.CWD = cwd
+		m.pendingTerminalDirectory = cwd
 	}
 
 	// Persist new session
@@ -1835,6 +1836,7 @@ func (m *Model) cmdNew() (tea.Model, tea.Cmd) {
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		m.sess.CWD = cwd
+		m.pendingTerminalDirectory = cwd
 	}
 
 	// Persist to store

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -4359,6 +4359,9 @@ func TestApplyRuntimeDirectoryRefreshesExistingSystemMessage(t *testing.T) {
 	if m.sess.CWD != "/new" || m.sess.WorktreeDir != "/new" {
 		t.Fatalf("session binding = %q/%q", m.sess.CWD, m.sess.WorktreeDir)
 	}
+	if m.pendingTerminalDirectory != "/new" {
+		t.Fatalf("pending terminal directory = %q, want /new", m.pendingTerminalDirectory)
+	}
 	if m.viewCache.historyValid || m.contextEstimateCachedValid {
 		t.Fatal("runtime refresh left history/context estimate caches valid")
 	}

--- a/internal/tui/chat/working_directory.go
+++ b/internal/tui/chat/working_directory.go
@@ -1,0 +1,45 @@
+package chat
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// terminalWorkingDirectoryCmd reports the session's effective directory using
+// OSC 7. Terminal emulators use this shell-integration sequence to update their
+// working-directory metadata even though term-llm deliberately keeps its
+// process working directory unchanged.
+func terminalWorkingDirectoryCmd(dir string) tea.Cmd {
+	sequence := terminalWorkingDirectorySequence(dir)
+	if sequence == "" {
+		return nil
+	}
+	return tea.Raw(sequence)
+}
+
+func terminalWorkingDirectorySequence(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" || !filepath.IsAbs(dir) {
+		return ""
+	}
+
+	path := filepath.ToSlash(filepath.Clean(dir))
+	// Windows drive paths need a leading slash in a file URI.
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	uri := (&url.URL{Scheme: "file", Path: path}).String()
+	return "\x1b]7;" + uri + "\x1b\\"
+}
+
+func (m *Model) takeTerminalWorkingDirectoryCmd() tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	dir := m.pendingTerminalDirectory
+	m.pendingTerminalDirectory = ""
+	return terminalWorkingDirectoryCmd(dir)
+}

--- a/internal/tui/chat/working_directory_test.go
+++ b/internal/tui/chat/working_directory_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -36,6 +37,30 @@ func TestPendingWorkingDirectoryReportIsEmittedAfterUpdate(t *testing.T) {
 	}
 	if m.pendingTerminalDirectory != "" {
 		t.Fatalf("pending terminal directory was not cleared: %q", m.pendingTerminalDirectory)
+	}
+}
+
+func TestNewSessionReportsProcessWorkingDirectory(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name string
+		run  func(*Model)
+	}{
+		{name: "clear", run: func(m *Model) { _, _ = m.cmdClear() }},
+		{name: "new", run: func(m *Model) { _, _ = m.cmdNew() }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestChatModel(false)
+			m.sess = &session.Session{CWD: "/stale/worktree", WorktreeDir: "/stale/worktree"}
+			tt.run(m)
+			if m.pendingTerminalDirectory != cwd {
+				t.Fatalf("pending terminal directory = %q, want process cwd %q", m.pendingTerminalDirectory, cwd)
+			}
+		})
 	}
 }
 

--- a/internal/tui/chat/working_directory_test.go
+++ b/internal/tui/chat/working_directory_test.go
@@ -1,0 +1,52 @@
+package chat
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestTerminalWorkingDirectorySequence(t *testing.T) {
+	dir := filepath.Join(string(filepath.Separator), "tmp", "term llm", "worktree#1")
+	got := terminalWorkingDirectorySequence(dir)
+	want := "\x1b]7;file:///tmp/term%20llm/worktree%231\x1b\\"
+	if got != want {
+		t.Fatalf("terminalWorkingDirectorySequence() = %q, want %q", got, want)
+	}
+
+	for _, invalid := range []string{"", "relative/path"} {
+		if got := terminalWorkingDirectorySequence(invalid); got != "" {
+			t.Errorf("terminalWorkingDirectorySequence(%q) = %q, want empty", invalid, got)
+		}
+	}
+}
+
+func TestPendingWorkingDirectoryReportIsEmittedAfterUpdate(t *testing.T) {
+	m := newTestChatModel(false)
+	dir := filepath.Join(string(filepath.Separator), "tmp", "switched-worktree")
+	m.pendingTerminalDirectory = dir
+
+	_, cmd := m.Update(struct{}{})
+	raw := strings.Join(rawStringsFromCmd(cmd), "")
+	want := terminalWorkingDirectorySequence(dir)
+	if !strings.Contains(raw, want) {
+		t.Fatalf("Update raw output = %q, want OSC 7 report %q", raw, want)
+	}
+	if m.pendingTerminalDirectory != "" {
+		t.Fatalf("pending terminal directory was not cleared: %q", m.pendingTerminalDirectory)
+	}
+}
+
+func TestInitReportsResumedSessionWorkingDirectory(t *testing.T) {
+	m := newTestChatModel(false)
+	dir := filepath.Join(string(filepath.Separator), "tmp", "resumed worktree")
+	m.sess = &session.Session{CWD: dir, WorktreeDir: dir}
+
+	raw := strings.Join(rawStringsFromCmd(m.Init()), "")
+	want := terminalWorkingDirectorySequence(dir)
+	if !strings.Contains(raw, want) {
+		t.Fatalf("Init raw output = %q, want OSC 7 report %q", raw, want)
+	}
+}

--- a/internal/tui/chat/worktree.go
+++ b/internal/tui/chat/worktree.go
@@ -394,6 +394,7 @@ func (m *Model) applyRuntimeDirectory(dir, worktreeDir string) error {
 	}
 	m.invalidateHistoryCache()
 	m.resetContextEstimateBaseline(context.Background())
+	m.pendingTerminalDirectory = dir
 	return nil
 }
 


### PR DESCRIPTION
## What

- emit a standard OSC 7 working-directory report when chat starts or resumes
- emit a fresh report after a successful runtime directory/worktree change
- keep the process working directory unchanged
- encode filesystem paths as `file://` URIs

## Why

term-llm binds tools and sessions to worktrees without using a process-wide `chdir`. That is the safe runtime model, but it leaves terminal working-directory metadata stale after `/worktree` switches. OSC 7 is the standard shell-integration mechanism for reporting the logical working directory to terminal emulators.

## Verification

- `go test ./internal/tui/chat`
- `go build ./...`
