### PR TITLE
fix: accept batched durable tool outputs

### DIFF
--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -120,13 +120,22 @@ func (s *serveServer) resolveDurablePreviousResponseID(ctx context.Context, prev
 }
 
 func validateDurableContinuationInput(inputMessages []llm.Message) error {
-	if len(inputMessages) != 1 {
-		return fmt.Errorf("message-backed previous_response_id requires exactly one new user message")
+	if len(inputMessages) == 1 && inputMessages[0].Role == llm.RoleUser {
+		return nil
 	}
-	if inputMessages[0].Role != llm.RoleUser && inputMessages[0].Role != llm.RoleTool {
-		return fmt.Errorf("message-backed previous_response_id only accepts one new user message or tool result")
+	if len(inputMessages) > 0 {
+		allTools := true
+		for _, msg := range inputMessages {
+			if msg.Role != llm.RoleTool {
+				allTools = false
+				break
+			}
+		}
+		if allTools {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("message-backed previous_response_id requires exactly one new user message or one or more tool results")
 }
 
 func getMessageByID(ctx context.Context, store session.Store, msgID int64) (session.Message, error) {

--- a/cmd/serve_responses_durable_test.go
+++ b/cmd/serve_responses_durable_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func TestValidateDurableContinuationInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []llm.Message
+		wantErr  bool
+	}{
+		{name: "one user", messages: []llm.Message{{Role: llm.RoleUser}}},
+		{name: "one tool", messages: []llm.Message{{Role: llm.RoleTool}}},
+		{name: "multiple tools", messages: []llm.Message{{Role: llm.RoleTool}, {Role: llm.RoleTool}}},
+		{name: "empty", wantErr: true},
+		{name: "multiple users", messages: []llm.Message{{Role: llm.RoleUser}, {Role: llm.RoleUser}}, wantErr: true},
+		{name: "mixed user and tool", messages: []llm.Message{{Role: llm.RoleUser}, {Role: llm.RoleTool}}, wantErr: true},
+		{name: "unsupported role", messages: []llm.Message{{Role: llm.RoleAssistant}}, wantErr: true},
+		{name: "tools and unsupported role", messages: []llm.Message{{Role: llm.RoleTool}, {Role: llm.RoleDeveloper}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDurableContinuationInput(tt.messages)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3858,6 +3858,73 @@ func TestResponsesUIBareSessionIDAppendsServerHistory(t *testing.T) {
 	}
 }
 
+func TestResponsesMessageBackedPreviousResponseAcceptsBatchedToolOutputs(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	provider := llm.NewMockProvider("mock").
+		AddTurn(llm.MockTurn{ToolCalls: []llm.ToolCall{
+			{ID: "call_1", Name: "read_file", Arguments: json.RawMessage(`{"path":"a.txt"}`)},
+			{ID: "call_2", Name: "read_file", Arguments: json.RawMessage(`{"path":"b.txt"}`)},
+		}}).
+		AddTextResponse("done")
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{
+			provider:     provider,
+			engine:       engine,
+			store:        store,
+			defaultModel: "mock-model",
+		}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+
+	srv := &serveServer{sessionMgr: manager, store: store}
+	const sessionID = "sess_durable_tool_batch"
+	firstBody := `{"input":"read both files","tools":[{"type":"function","name":"read_file","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}]}`
+	code, firstResponse := doResponsesWithHeader(t, srv, firstBody, sessionID)
+	if code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", code)
+	}
+	previousID, _ := firstResponse["id"].(string)
+	if !strings.HasPrefix(previousID, durableResponseMessagePrefix) {
+		t.Fatalf("first response id = %q, want %s*", previousID, durableResponseMessagePrefix)
+	}
+
+	secondBody := fmt.Sprintf(`{"previous_response_id":%q,"input":[{"type":"function_call_output","call_id":"call_1","output":"alpha"},{"type":"function_call_output","call_id":"call_2","output":"beta"}]}`, previousID)
+	code, _ = doResponses(t, srv, secondBody)
+	if code != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200", code)
+	}
+	if len(provider.Requests) != 2 {
+		t.Fatalf("provider request count = %d, want 2", len(provider.Requests))
+	}
+
+	gotResults := map[string]llm.ToolResult{}
+	for _, msg := range provider.Requests[1].Messages {
+		for _, part := range msg.Parts {
+			if part.Type == llm.PartToolResult && part.ToolResult != nil {
+				gotResults[part.ToolResult.ID] = *part.ToolResult
+			}
+		}
+	}
+	for id, content := range map[string]string{"call_1": "alpha", "call_2": "beta"} {
+		result, ok := gotResults[id]
+		if !ok {
+			t.Fatalf("second provider request missing tool result %q", id)
+		}
+		if result.Name != "read_file" || result.Content != content {
+			t.Fatalf("tool result %q = (%q, %q), want (%q, %q)", id, result.Name, result.Content, "read_file", content)
+		}
+	}
+}
+
 func TestResponsesMessageBackedPreviousResponseIgnoresStaleRuntimeTail(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})


### PR DESCRIPTION
## What

- allow durable `resp_msg_*` continuations with either exactly 1 user message or 1+ all-tool messages
- continue rejecting empty, multiple-user, mixed user/tool, and unsupported-role inputs
- cover the validation matrix with unit tests
- add an HTTP handler regression test for 2 batched `function_call_output` items

## Why

Responses clients can return multiple parallel tool outputs in one continuation request. Each output becomes its own `llm.RoleTool` message, so the previous exactly-1-message check rejected valid batches.

## Verification

- `gofmt` on changed Go files
- focused durable continuation tests
- `go test ./...` in a clean HOME/XDG environment
- clean API smoke test against a built server and fake OpenAI-compatible backend: `resp_msg_3` continued with 2 tool outputs and completed as `resp_msg_6`; backend received both results
- reviewed with `claude-bin:fable`: LGTM, no required changes
