### PR TITLE
fix: Isolated skill streaming shifts 1,024 retained events on every token

### DIFF
--- a/cmd/serve_skills.go
+++ b/cmd/serve_skills.go
@@ -54,6 +54,8 @@ type serveSkillRun struct {
 	Activation        *skills.Activation
 	cancel            context.CancelFunc
 	events            []serveSkillRunEvent
+	eventHead         int
+	eventCount        int
 	nextSequence      int
 	subscribers       map[int]chan serveSkillRunEvent
 	subscriberDropped map[int]bool
@@ -86,10 +88,12 @@ func (run *serveSkillRun) appendEvent(eventType string, data any) {
 func (run *serveSkillRun) appendEventLocked(eventType string, data any) {
 	run.nextSequence++
 	event := serveSkillRunEvent{Sequence: run.nextSequence, Type: eventType, Data: data, At: time.Now().UTC()}
-	run.events = append(run.events, event)
-	if len(run.events) > serveSkillRunEventHistoryLimit {
-		copy(run.events, run.events[len(run.events)-serveSkillRunEventHistoryLimit:])
-		run.events = run.events[:serveSkillRunEventHistoryLimit]
+	if run.eventCount < serveSkillRunEventHistoryLimit {
+		run.events = append(run.events, event)
+		run.eventCount++
+	} else {
+		run.events[run.eventHead] = event
+		run.eventHead = (run.eventHead + 1) % serveSkillRunEventHistoryLimit
 	}
 	for id, subscriber := range run.subscribers {
 		select {
@@ -139,10 +143,20 @@ func errorString(err error) string {
 	return err.Error()
 }
 
+func (run *serveSkillRun) eventHistoryLocked() []serveSkillRunEvent {
+	if run.eventCount == 0 {
+		return nil
+	}
+	events := make([]serveSkillRunEvent, run.eventCount)
+	copied := copy(events, run.events[run.eventHead:])
+	copy(events[copied:], run.events[:run.eventHead])
+	return events
+}
+
 func (run *serveSkillRun) snapshot() map[string]any {
 	run.mu.Lock()
 	defer run.mu.Unlock()
-	events := append([]serveSkillRunEvent(nil), run.events...)
+	events := run.eventHistoryLocked()
 	return map[string]any{
 		"id":               run.ID,
 		"session_id":       run.SessionID,
@@ -160,8 +174,9 @@ func (run *serveSkillRun) snapshot() map[string]any {
 func (run *serveSkillRun) subscribe(after int) ([]serveSkillRunEvent, int, <-chan serveSkillRunEvent, bool) {
 	run.mu.Lock()
 	defer run.mu.Unlock()
-	var replay []serveSkillRunEvent
-	for _, event := range run.events {
+	events := run.eventHistoryLocked()
+	replay := events[:0]
+	for _, event := range events {
 		if event.Sequence > after {
 			replay = append(replay, event)
 		}

--- a/cmd/serve_skills_test.go
+++ b/cmd/serve_skills_test.go
@@ -544,16 +544,48 @@ func TestServeSkillRunSubscriberOverflowReconnectsThroughReplay(t *testing.T) {
 
 func TestServeSkillRunEventHistoryIsBounded(t *testing.T) {
 	run := newServeSkillRun("skill-history", "sess-history", "child-history", &skills.Activation{Skill: &skills.Skill{Name: "review"}}, func() {})
-	for i := 0; i < serveSkillRunEventHistoryLimit+50; i++ {
+	total := serveSkillRunEventHistoryLimit*4 + 137
+	for i := 0; i < total; i++ {
 		run.appendEvent("skill_run.progress", map[string]any{"index": i})
 	}
-	run.mu.Lock()
-	defer run.mu.Unlock()
-	if len(run.events) != serveSkillRunEventHistoryLimit {
-		t.Fatalf("retained events = %d, want %d", len(run.events), serveSkillRunEventHistoryLimit)
+
+	snapshotEvents, ok := run.snapshot()["events"].([]serveSkillRunEvent)
+	if !ok {
+		t.Fatal("snapshot events have unexpected type")
 	}
-	if run.events[0].Sequence != 51 || run.events[len(run.events)-1].Sequence != serveSkillRunEventHistoryLimit+50 {
-		t.Fatalf("retained sequence range = %d..%d", run.events[0].Sequence, run.events[len(run.events)-1].Sequence)
+	if len(snapshotEvents) != serveSkillRunEventHistoryLimit {
+		t.Fatalf("snapshot retained events = %d, want %d", len(snapshotEvents), serveSkillRunEventHistoryLimit)
+	}
+	firstSequence := total - serveSkillRunEventHistoryLimit + 1
+	for i, event := range snapshotEvents {
+		if want := firstSequence + i; event.Sequence != want {
+			t.Fatalf("snapshot event %d sequence = %d, want %d", i, event.Sequence, want)
+		}
+	}
+
+	replay, subscriberID, _, terminal := run.subscribe(0)
+	defer run.unsubscribe(subscriberID)
+	if terminal {
+		t.Fatal("running skill unexpectedly returned a terminal subscription")
+	}
+	if len(replay) != serveSkillRunEventHistoryLimit {
+		t.Fatalf("replayed events = %d, want %d", len(replay), serveSkillRunEventHistoryLimit)
+	}
+	for i, event := range replay {
+		if want := firstSequence + i; event.Sequence != want {
+			t.Fatalf("replay event %d sequence = %d, want %d", i, event.Sequence, want)
+		}
+	}
+}
+
+func BenchmarkServeSkillRunAppendEvents(b *testing.B) {
+	activation := &skills.Activation{Skill: &skills.Skill{Name: "review"}}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		run := newServeSkillRun("skill-benchmark", "sess-benchmark", "child-benchmark", activation, func() {})
+		for j := 0; j < 10_000; j++ {
+			run.appendEvent("skill_run.progress", nil)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- Replaced isolated skill run history's per-event slice shift with bounded circular storage.
- Materialized retained events in chronological order only for snapshots and SSE replay.
- Extended the bounded-history test through more than four complete wraps, checking snapshot and replay ordering.
- Added a 10,000-event append benchmark.

## Why this is high-value

Isolated web skills forward token-sized child text deltas into this history. After 1,024 events, the old implementation copied all 1,024 retained interface-bearing events while holding the run mutex for every subsequent delta. That made a long response perform quadratic copying on the same lock used by SSE subscriptions, snapshots, cancellation, and completion.

The circular buffer replaces each post-limit 1,024-event copy with one indexed overwrite, preserving sequence numbers, the retention limit, chronological replay, and subscriber overflow behavior. On this host, the 10,000-event benchmark improved from roughly 6.83 ms and 244,642 B/op to 0.42 ms and 146,370 B/op (about 16x faster).

## Validation

- `gofmt -w cmd/serve_skills.go cmd/serve_skills_test.go`
- `go build ./...`
- Targeted skill history, overflow, and completion tests pass.
- Targeted race tests pass.
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./... -skip '^TestProgramRunnerDoesNotLeakBackgroundChildren$'` passes.
- Full `go test ./...` was also run. Its skill-discovery tests require an isolated `XDG_CONFIG_HOME`; after isolating that config, the only failure was the unrelated pre-existing `TestProgramRunnerDoesNotLeakBackgroundChildren`, which reproducibly fails alone on this host because the background PID remains observable beyond its one-second deadline.
- `go test ./cmd -run '^$' -bench '^BenchmarkServeSkillRunAppendEvents$' -benchmem -count=3`
- `git diff --check`
