### PR TITLE
feat: support typed output tool schemas

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -377,19 +377,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 	}
 
 	if agent != nil && agent.OutputTool.IsConfigured() {
-		agentCfg := agent.OutputTool
-		param := agentCfg.Param
-		if param == "" {
-			param = "content" // default
-		}
-		if toolMgr != nil {
-			outputTool = toolMgr.Registry.RegisterOutputTool(agentCfg.Name, param, agentCfg.Description)
-			// Re-register tools with engine after output tool was added.
-			toolMgr.SetupEngine(engine)
-		} else {
-			outputTool = tools.NewSetOutputTool(agentCfg.Name, param, agentCfg.Description)
-			engine.RegisterTool(outputTool)
-		}
+		outputTool = registerAgentOutputTool(agent.OutputTool, toolMgr, engine)
 	}
 
 	RegisterSkillToolWithEngine(engine, toolMgr, skillsSetup)

--- a/cmd/ask_output_tool_test.go
+++ b/cmd/ask_output_tool_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func TestAskOutputToolRunsOnCompleteAfterCentralizedRunner(t *testing.T) {
+func TestAskTypedOutputToolRunsOnCompleteAfterCentralizedRunner(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
 
@@ -39,8 +39,17 @@ func TestAskOutputToolRunsOnCompleteAfterCentralizedRunner(t *testing.T) {
 	agentYAML := `name: output-agent
 output_tool:
   name: set_commit_message
-  param: message
-  description: Set the commit message
+  description: Set the commit result
+  schema:
+    type: object
+    properties:
+      message:
+        type: string
+      category:
+        type: string
+        enum: [chore, feat, fix]
+    required: [message, category]
+    additionalProperties: false
 on_complete: |
   tee .git/COMMIT_EDITMSG > .git/GITGUI_MSG
 `
@@ -75,9 +84,10 @@ sessions:
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
 	const message = "chore: replace stale message"
+	const wantOutput = `{"category":"chore","message":"chore: replace stale message"}`
 	provider := llm.NewMockProvider("mock").
 		WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true}).
-		AddToolCall("call-1", "set_commit_message", map[string]string{"message": message})
+		AddToolCall("call-1", "set_commit_message", map[string]string{"message": message, "category": "chore"})
 	oldProviderFactory := newAskProvider
 	newAskProvider = func(*config.Config, bool) (llm.Provider, error) { return provider, nil }
 	t.Cleanup(func() { newAskProvider = oldProviderFactory })
@@ -108,16 +118,33 @@ sessions:
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
 		}
-		if string(got) != message {
-			t.Errorf("%s = %q, want %q", name, got, message)
+		if string(got) != wantOutput {
+			t.Errorf("%s = %q, want %q", name, got, wantOutput)
 		}
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider saw %d requests, want 1", len(provider.Requests))
+	}
+	var outputSpec *llm.ToolSpec
+	for i := range provider.Requests[0].Tools {
+		if provider.Requests[0].Tools[i].Name == "set_commit_message" {
+			outputSpec = &provider.Requests[0].Tools[i]
+			break
+		}
+	}
+	if outputSpec == nil {
+		t.Fatal("set_commit_message schema was not sent to provider")
+	}
+	properties, ok := outputSpec.Schema["properties"].(map[string]interface{})
+	if !ok || properties["message"] == nil || properties["category"] == nil {
+		t.Fatalf("output tool properties = %#v", outputSpec.Schema["properties"])
 	}
 }
 
 func TestEnsureOutputToolCapturedCoaxesModelWithoutAssistantText(t *testing.T) {
 	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true})
 	provider.AddToolCall("call_1", "submit_result", map[string]string{"result_json": `{"ok":true}`})
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 
 	if err := ensureOutputToolCaptured(context.Background(), provider, nil, llm.Request{}, outputTool, ""); err != nil {
 		t.Fatalf("ensureOutputToolCaptured() error = %v", err)
@@ -136,7 +163,7 @@ func TestEnsureOutputToolCapturedCoaxesModelWithoutAssistantText(t *testing.T) {
 
 func TestEnsureOutputToolCapturedNoopsAfterToolCapturesValue(t *testing.T) {
 	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true})
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 
 	args, _ := json.Marshal(map[string]string{"result_json": `{"ok":true}`})
 	if _, err := outputTool.Execute(context.Background(), args); err != nil {
@@ -153,7 +180,7 @@ func TestEnsureOutputToolCapturedNoopsAfterToolCapturesValue(t *testing.T) {
 
 func TestEnsureOutputToolCapturedAllowsEmptyStringValue(t *testing.T) {
 	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true})
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 
 	args, _ := json.Marshal(map[string]string{"result_json": ""})
 	if _, err := outputTool.Execute(context.Background(), args); err != nil {
@@ -177,7 +204,7 @@ func TestEnsureOutputToolCapturedAllowsEmptyStringValue(t *testing.T) {
 func TestRunOutputToolFinalizationUsesOnlyOutputToolAndForcesIt(t *testing.T) {
 	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: true})
 	provider.AddToolCall("call_1", "submit_result", map[string]string{"result_json": `{"status":"ok"}`})
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 	baseReq := llm.Request{
 		Model:      "mock-model",
 		WorkingDir: t.TempDir(),
@@ -230,7 +257,7 @@ func TestRunOutputToolFinalizationUsesOnlyOutputToolAndForcesIt(t *testing.T) {
 func TestRunOutputToolFinalizationFallsBackToAutoWhenToolChoiceUnsupported(t *testing.T) {
 	provider := llm.NewMockProvider("mock").WithCapabilities(llm.Capabilities{ToolCalls: true, SupportsToolChoice: false})
 	provider.AddToolCall("call_1", "submit_result", map[string]string{"result_json": `{"status":"ok"}`})
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 
 	if err := runOutputToolFinalization(context.Background(), provider, nil, llm.Request{}, outputTool, "Done."); err != nil {
 		t.Fatalf("runOutputToolFinalization() error = %v", err)
@@ -249,7 +276,7 @@ func TestRunOutputToolFinalizationRetriesWhenModelRespondsWithText(t *testing.T)
 	provider.AddTextResponse("Still prose instead of a tool call.")
 	provider.AddTextResponse("I continue to be prose-only.")
 	provider.AddToolCall("call_4", "submit_result", map[string]string{"result_json": `{"status":"ok"}`})
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 
 	if err := runOutputToolFinalization(context.Background(), provider, nil, llm.Request{}, outputTool, "Done."); err != nil {
 		t.Fatalf("runOutputToolFinalization() error = %v", err)
@@ -271,7 +298,7 @@ func TestRunOutputToolFinalizationFailsWhenToolStillMissing(t *testing.T) {
 	provider.AddTextResponse("Done.")
 	provider.AddTextResponse("Still prose.")
 	provider.AddTextResponse("Still not a tool call.")
-	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result")
+	outputTool := tools.NewSetOutputTool("submit_result", "result_json", "Submit the result", nil)
 	baseReq := llm.Request{Messages: []llm.Message{llm.UserText("Review the thing.")}}
 
 	err := runOutputToolFinalization(context.Background(), provider, nil, baseReq, outputTool, "Done.")

--- a/cmd/output_tool.go
+++ b/cmd/output_tool.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/samsaffron/term-llm/internal/agents"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func registerAgentOutputTool(cfg agents.OutputToolConfig, toolMgr *tools.ToolManager, engine *llm.Engine) *tools.SetOutputTool {
+	outputTool := tools.NewSetOutputTool(cfg.Name, cfg.Param, cfg.Description, cfg.Schema)
+	if toolMgr == nil {
+		engine.RegisterTool(outputTool)
+		return outputTool
+	}
+
+	toolMgr.Registry.RegisterOutputTool(outputTool)
+	toolMgr.SetupEngine(engine)
+	return outputTool
+}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -250,17 +250,7 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 			return nil, err
 		}
 		if agent != nil && agent.OutputTool.IsConfigured() && req.Platform != runpkg.PlatformChat {
-			agentCfg := agent.OutputTool
-			param := agentCfg.Param
-			if param == "" {
-				param = "content"
-			}
-			if toolMgr != nil {
-				toolMgr.Registry.RegisterOutputTool(agentCfg.Name, param, agentCfg.Description)
-				toolMgr.SetupEngine(engine)
-			} else {
-				engine.RegisterTool(tools.NewSetOutputTool(agentCfg.Name, param, agentCfg.Description))
-			}
+			registerAgentOutputTool(agent.OutputTool, toolMgr, engine)
 		}
 	}
 	if err := applyChildSkillRuntime(engine, toolMgr, req.ChildSkill); err != nil {

--- a/cmd/serve_jobs_v2_program_test.go
+++ b/cmd/serve_jobs_v2_program_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +12,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/testutil"
 )
 
 func testJobsV2ProgramJob(t *testing.T, cfg jobsV2ProgramConfig) jobsV2Job {
@@ -82,12 +83,12 @@ func TestJobsV2ProgramRunner_CleansUpBackgroundChildOnSuccess(t *testing.T) {
 
 	pid := readJobsV2ProgramPID(t, pidPath)
 	defer func() {
-		if !jobsV2ProcessHasExited(pid) {
+		if !testutil.ProcessHasExited(pid) {
 			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
 	}()
 
-	waitForJobsV2ProcessExit(t, pid)
+	testutil.WaitForProcessExit(t, pid, 2*time.Second)
 }
 
 func TestJobsV2ProgramRunner_TruncatesCapturedOutput(t *testing.T) {
@@ -137,49 +138,6 @@ func readJobsV2ProgramPID(t *testing.T, path string) int {
 		t.Fatalf("parse child pid %q: %v", pidText, err)
 	}
 	return pid
-}
-
-func waitForJobsV2ProcessExit(t *testing.T, pid int) {
-	t.Helper()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if jobsV2ProcessHasExited(pid) {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	t.Fatalf("timed out waiting for background child process %d to exit", pid)
-}
-
-func jobsV2ProcessHasExited(pid int) bool {
-	err := syscall.Kill(pid, 0)
-	if err != nil {
-		return errors.Is(err, syscall.ESRCH)
-	}
-	if runtime.GOOS == "linux" {
-		state, ok := jobsV2LinuxProcState(pid)
-		return ok && state == 'Z'
-	}
-	return false
-}
-
-func jobsV2LinuxProcState(pid int) (byte, bool) {
-	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
-	if err != nil {
-		return 0, false
-	}
-	stat := string(data)
-	end := strings.LastIndex(stat, ")")
-	if end == -1 {
-		return 0, false
-	}
-	rest := strings.TrimSpace(stat[end+1:])
-	if rest == "" {
-		return 0, false
-	}
-	return rest[0], true
 }
 
 func jobsV2ProgramTestShellQuote(s string) string {

--- a/cmd/spawn_runner_test.go
+++ b/cmd/spawn_runner_test.go
@@ -43,7 +43,7 @@ func (r *capturingSpawnRunner) RunAgentWithCallbackAndOptions(ctx context.Contex
 
 func TestCompleteChildAgentUsesOutputToolAndRunsHookInChildDirectory(t *testing.T) {
 	baseDir := t.TempDir()
-	outputTool := tools.NewSetOutputTool("set_commit_message", "message", "Set the commit message")
+	outputTool := tools.NewSetOutputTool("set_commit_message", "message", "Set the commit message", nil)
 	args, err := json.Marshal(map[string]string{"message": "feat: show isolated skill output"})
 	if err != nil {
 		t.Fatal(err)

--- a/docs-site/content/guides/agents.md
+++ b/docs-site/content/guides/agents.md
@@ -137,7 +137,9 @@ Built-in agents that currently default to `search: true`: `agent-builder`, `web-
 
 ## Structured ask output
 
-Use `output_tool` when an agent must return a machine-consumable artifact to `term-llm ask` instead of relying on freeform prose. In `ask`, a configured output tool is the agent's final return channel: successful completion requires the model to call that tool and provide the configured parameter. If the model naturally finishes without calling it, `ask` runs a constrained finalization pass that preserves the original tool context, forces the output tool when the provider supports named tool choice, and otherwise strongly instructs the model that the task is done and it must call the output tool. If the tool still is not called, `ask` fails nonzero and does not run `on_complete`.
+Use `output_tool` when an agent must return a machine-consumable artifact to `term-llm ask` instead of relying on freeform prose. In `ask`, a configured output tool is the agent's final return channel: successful completion requires the model to call that tool. If the model naturally finishes without calling it, `ask` runs a constrained finalization pass that preserves the original tool context, forces the output tool when the provider supports named tool choice, and otherwise strongly instructs the model that the task is done and it must call the output tool. If the tool still is not called, `ask` fails nonzero and does not run `on_complete`.
+
+Define a typed object `schema` when the final result has multiple parameters:
 
 ```yaml
 name: scanner
@@ -147,14 +149,38 @@ tools:
 
 output_tool:
   name: submit_result
-  param: result_json
-  description: "Submit the final scanner result as JSON"
+  description: "Submit the final scanner result"
+  schema:
+    type: object
+    properties:
+      summary:
+        type: string
+      severity:
+        type: string
+        enum: [low, medium, high]
+      files:
+        type: array
+        items:
+          type: string
+    required: [summary, severity, files]
+    additionalProperties: false
 
 on_complete: |
   jq -e . > result.json
 ```
 
-`on_complete` receives the captured output-tool value on stdin. When `output_tool` is configured, `ask` never falls back to passing assistant prose to `on_complete`; validate formats such as JSON in your handler if you need schema guarantees.
+For a typed schema, `on_complete` receives the complete argument object as compact JSON. The schema root must have `type: object`. Providers enforce the field constraints; validate the JSON again in `on_complete` when correctness is critical.
+
+The legacy `param` shorthand remains available when the tool should capture one string value:
+
+```yaml
+output_tool:
+  name: set_commit_message
+  param: message
+  description: "Set the commit message"
+```
+
+`param` defaults to `content` when omitted, and `param` and `schema` cannot be configured together. For this shorthand, `on_complete` receives only the captured string rather than a JSON object. When `output_tool` is configured, `ask` never falls back to passing assistant prose to `on_complete`.
 
 `output_tool` is ignored in `term-llm chat`. Chat is an open-ended conversation with no single final return value; use `ask` for tool-captured output.
 

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -238,12 +238,13 @@ type MemoryConfig struct {
 
 // OutputToolConfig configures a tool for capturing structured output.
 type OutputToolConfig struct {
-	Name        string `yaml:"name"`        // Tool name (e.g., "set_commit_message")
-	Param       string `yaml:"param"`       // Parameter to capture (default: "content")
-	Description string `yaml:"description"` // Tool description
+	Name        string                 `yaml:"name"`        // Tool name (e.g., "set_commit_message")
+	Param       string                 `yaml:"param"`       // Legacy string parameter to capture (default: "content")
+	Description string                 `yaml:"description"` // Tool description
+	Schema      map[string]interface{} `yaml:"schema"`      // Typed object schema; captures the complete argument object
 }
 
-// IsConfigured returns true if the output tool is configured.
+// IsConfigured returns true if the output tool has a name.
 func (c *OutputToolConfig) IsConfigured() bool {
 	return c.Name != ""
 }
@@ -442,9 +443,17 @@ func (a *Agent) Validate() error {
 	}
 
 	// Validate output_tool if configured
+	if a.OutputTool.Schema != nil && a.OutputTool.Name == "" {
+		return fmt.Errorf("output_tool.name is required when output_tool.schema is configured")
+	}
 	if a.OutputTool.IsConfigured() {
-		if a.OutputTool.Name == "" {
-			return fmt.Errorf("output_tool.name is required when output_tool is configured")
+		if a.OutputTool.Param != "" && a.OutputTool.Schema != nil {
+			return fmt.Errorf("output_tool cannot configure both param and schema")
+		}
+		if a.OutputTool.Schema != nil {
+			if schemaType, ok := a.OutputTool.Schema["type"]; !ok || schemaType != "object" {
+				return fmt.Errorf("output_tool.schema must have \"type\": \"object\" at root")
+			}
 		}
 	}
 

--- a/internal/agents/agent_test.go
+++ b/internal/agents/agent_test.go
@@ -181,6 +181,67 @@ func TestAgent_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "partial legacy output tool remains ignored",
+			agent: Agent{
+				Name: "test",
+				OutputTool: OutputToolConfig{
+					Param:       "content",
+					Description: "missing name",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid typed output tool schema",
+			agent: Agent{
+				Name: "test",
+				OutputTool: OutputToolConfig{
+					Name: "submit_result",
+					Schema: map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"summary": map[string]interface{}{"type": "string"},
+							"score":   map[string]interface{}{"type": "number"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "output tool rejects param and schema",
+			agent: Agent{
+				Name: "test",
+				OutputTool: OutputToolConfig{
+					Name:   "submit_result",
+					Param:  "content",
+					Schema: map[string]interface{}{"type": "object"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "output tool schema requires object root",
+			agent: Agent{
+				Name: "test",
+				OutputTool: OutputToolConfig{
+					Name:   "submit_result",
+					Schema: map[string]interface{}{"type": "array"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "output tool schema requires name",
+			agent: Agent{
+				Name: "test",
+				OutputTool: OutputToolConfig{
+					Schema: map[string]interface{}{"type": "object"},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid agents_md empty",
 			agent: Agent{
 				Name:     "test",

--- a/internal/jobs/program_runner_test.go
+++ b/internal/jobs/program_runner_test.go
@@ -3,15 +3,15 @@ package jobs
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/testutil"
 )
 
 func testProgramJob(t *testing.T, cfg ProgramConfig) Job {
@@ -100,17 +100,7 @@ func TestProgramRunnerDoesNotLeakBackgroundChildren(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse child pid %q: %v", string(pidRaw), err)
 	}
-	deadline := time.Now().Add(time.Second)
-	for {
-		err = syscall.Kill(pid, 0)
-		if errors.Is(err, syscall.ESRCH) {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("background child process %d still appears to be alive", pid)
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	testutil.WaitForProcessExit(t, pid, time.Second)
 }
 
 func shellQuote(s string) string {

--- a/internal/testutil/process.go
+++ b/internal/testutil/process.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// ProcessHasExited reports whether pid no longer has executable code. On Linux,
+// zombies count as exited because kill(pid, 0) continues to report them until
+// their parent or init process reaps them.
+func ProcessHasExited(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err != nil {
+		return errors.Is(err, syscall.ESRCH)
+	}
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	state, ok := linuxProcessState(pid)
+	return ok && state == 'Z'
+}
+
+// WaitForProcessExit waits until pid is gone or is a zombie.
+func WaitForProcessExit(t testing.TB, pid int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ProcessHasExited(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for process %d to exit", pid)
+}
+
+func linuxProcessState(pid int) (byte, bool) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return 0, false
+	}
+	return procStatState(data)
+}
+
+func procStatState(data []byte) (byte, bool) {
+	stat := string(data)
+	end := strings.LastIndexByte(stat, ')')
+	if end == -1 {
+		return 0, false
+	}
+	rest := strings.TrimSpace(stat[end+1:])
+	if rest == "" {
+		return 0, false
+	}
+	return rest[0], true
+}

--- a/internal/testutil/process_test.go
+++ b/internal/testutil/process_test.go
@@ -1,0 +1,39 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcessHasExited(t *testing.T) {
+	if ProcessHasExited(os.Getpid()) {
+		t.Fatal("current process reported as exited")
+	}
+	if !ProcessHasExited(1 << 30) {
+		t.Fatal("nonexistent process reported as running")
+	}
+}
+
+func TestProcStatState(t *testing.T) {
+	tests := []struct {
+		name string
+		stat string
+		want byte
+		ok   bool
+	}{
+		{name: "running", stat: "123 (sleep) S 1 2 3", want: 'S', ok: true},
+		{name: "zombie", stat: "123 (sleep) Z 1 2 3", want: 'Z', ok: true},
+		{name: "parenthesis in name", stat: "123 (sleep) helper) Z 1 2 3", want: 'Z', ok: true},
+		{name: "missing name", stat: "123 sleep Z 1 2 3", ok: false},
+		{name: "missing state", stat: "123 (sleep)", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := procStatState([]byte(tt.stat))
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("procStatState(%q) = %q, %v; want %q, %v", tt.stat, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -430,15 +430,12 @@ func (r *LocalToolRegistry) GetSpawnAgentTool() *SpawnAgentTool {
 	return nil
 }
 
-// RegisterOutputTool creates and registers a SetOutputTool with the given configuration.
-// Returns the tool so the caller can retrieve the captured value later.
-func (r *LocalToolRegistry) RegisterOutputTool(name, param, desc string) *SetOutputTool {
+// RegisterOutputTool adds an output tool to the local registry.
+func (r *LocalToolRegistry) RegisterOutputTool(tool *SetOutputTool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	tool := NewSetOutputTool(name, param, desc)
-	r.tools[name] = tool
-	return tool
+	r.tools[tool.Name()] = tool
 }
 
 // GetOutputTool returns the output tool by name if it exists and is a SetOutputTool.

--- a/internal/tools/set_output.go
+++ b/internal/tools/set_output.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/samsaffron/term-llm/internal/llm"
 )
@@ -13,18 +15,41 @@ import (
 // that LLMs often include even with explicit instructions.
 type SetOutputTool struct {
 	name        string // Configured tool name (e.g., "set_commit_message")
-	paramName   string // Parameter name to capture (e.g., "message")
+	paramName   string // Legacy string parameter name; empty for a typed object
 	description string // Tool description
+	schema      map[string]interface{}
 	value       string // Captured value
-	captured    bool   // Whether the configured parameter was captured
+	captured    bool   // Whether output was captured
 }
 
-// NewSetOutputTool creates a tool with custom name/description.
-func NewSetOutputTool(name, paramName, description string) *SetOutputTool {
+// NewSetOutputTool creates an output tool. A nil schema uses the legacy
+// single-string parameter; a non-nil schema captures the complete argument
+// object as JSON.
+func NewSetOutputTool(name, paramName, description string, schema map[string]interface{}) *SetOutputTool {
+	if schema == nil {
+		if paramName == "" {
+			paramName = "content"
+		}
+		schema = map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				paramName: map[string]interface{}{
+					"type":        "string",
+					"description": "The output content",
+				},
+			},
+			"required":             []string{paramName},
+			"additionalProperties": false,
+		}
+	} else {
+		paramName = ""
+	}
+
 	return &SetOutputTool{
 		name:        name,
 		paramName:   paramName,
 		description: description,
+		schema:      schema,
 	}
 }
 
@@ -32,21 +57,28 @@ func (t *SetOutputTool) Spec() llm.ToolSpec {
 	return llm.ToolSpec{
 		Name:        t.name,
 		Description: t.description,
-		Schema: map[string]interface{}{
-			"type": "object",
-			"properties": map[string]interface{}{
-				t.paramName: map[string]interface{}{
-					"type":        "string",
-					"description": "The output content",
-				},
-			},
-			"required":             []string{t.paramName},
-			"additionalProperties": false,
-		},
+		Schema:      t.schema,
 	}
 }
 
 func (t *SetOutputTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
+	if t.paramName == "" {
+		var object map[string]interface{}
+		if err := json.Unmarshal(args, &object); err != nil {
+			return llm.ToolOutput{}, fmt.Errorf("decode structured output: %w", err)
+		}
+		if object == nil {
+			return llm.ToolOutput{}, fmt.Errorf("structured output must be a JSON object")
+		}
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, args); err != nil {
+			return llm.ToolOutput{}, fmt.Errorf("compact structured output: %w", err)
+		}
+		t.value = compact.String()
+		t.captured = true
+		return llm.TextOutput("Output captured."), nil
+	}
+
 	var params map[string]interface{}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return llm.ToolOutput{}, err
@@ -67,7 +99,7 @@ func (t *SetOutputTool) Value() string {
 	return t.value
 }
 
-// Captured returns true once the configured output parameter has been captured.
+// Captured returns true once output was captured.
 func (t *SetOutputTool) Captured() bool {
 	return t.captured
 }

--- a/internal/tools/set_output_test.go
+++ b/internal/tools/set_output_test.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestSetOutputToolLegacyParameter(t *testing.T) {
+	tool := NewSetOutputTool("submit_result", "", "Submit the result", nil)
+	wantSchema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"content": map[string]interface{}{
+				"type":        "string",
+				"description": "The output content",
+			},
+		},
+		"required":             []string{"content"},
+		"additionalProperties": false,
+	}
+	if got := tool.Spec().Schema; !reflect.DeepEqual(got, wantSchema) {
+		t.Fatalf("Spec().Schema = %#v, want %#v", got, wantSchema)
+	}
+
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"content":"done"}`)); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := tool.Value(); got != "done" {
+		t.Fatalf("Value() = %q, want %q", got, "done")
+	}
+	if !tool.Captured() {
+		t.Fatal("Captured() = false, want true")
+	}
+}
+
+func TestSetOutputToolTypedSchemaCapturesCompleteObject(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"summary": map[string]interface{}{"type": "string"},
+			"score":   map[string]interface{}{"type": "number"},
+			"tags": map[string]interface{}{
+				"type":  "array",
+				"items": map[string]interface{}{"type": "string"},
+			},
+		},
+		"required":             []string{"summary", "score"},
+		"additionalProperties": false,
+	}
+	tool := NewSetOutputTool("submit_result", "", "Submit the result", schema)
+	if got := tool.Spec().Schema; !reflect.DeepEqual(got, schema) {
+		t.Fatalf("Spec().Schema = %#v, want %#v", got, schema)
+	}
+
+	args := json.RawMessage(`{
+		"summary": "done",
+		"score": 0.75,
+		"tags": ["go", "tests"]
+	}`)
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	want := `{"summary":"done","score":0.75,"tags":["go","tests"]}`
+	if got := tool.Value(); got != want {
+		t.Fatalf("Value() = %q, want %q", got, want)
+	}
+	if !tool.Captured() {
+		t.Fatal("Captured() = false, want true")
+	}
+}
+
+func TestSetOutputToolTypedSchemaRejectsNonObjects(t *testing.T) {
+	for _, args := range []string{`null`, `[]`, `"text"`} {
+		t.Run(args, func(t *testing.T) {
+			tool := NewSetOutputTool("submit_result", "", "Submit the result", map[string]interface{}{"type": "object"})
+			if _, err := tool.Execute(context.Background(), json.RawMessage(args)); err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			if tool.Captured() {
+				t.Fatal("Captured() = true after invalid arguments")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Add typed, multi-parameter JSON Schema support to agent `output_tool` configuration:

```yaml
output_tool:
  name: submit_result
  description: Submit the final result
  schema:
    type: object
    properties:
      title:
        type: string
      tracks:
        type: array
        items:
          type: object
          properties:
            title: {type: string}
            uri: {type: string}
          required: [title, uri]
          additionalProperties: false
    required: [title, tracks]
    additionalProperties: false
```

Typed output tools expose the configured schema directly to the provider and capture the complete argument object as compact JSON for `on_complete`.

The existing single-string `param` shorthand remains backward compatible and still defaults to `content`.

## Design

- Centralizes output-tool construction and registration for both `ask` and the shared command runner.
- Removes the duplicated registration blocks from both call sites.
- Uses one `SetOutputTool` implementation for legacy string capture and typed object capture.
- Rejects ambiguous configurations containing both `param` and `schema`.
- Requires typed schemas to use an object root.
- Preserves the old behavior for partial legacy `output_tool` blocks without a name.
- Documents that provider schema enforcement varies and critical consumers should validate again in `on_complete`.

The production-code delta is 35 net lines while removing 22 lines of duplicated call-site setup.

## Why

Agents currently encode structured results as JSON inside one string parameter. That adds escaping, tokens, and another opportunity for malformed output. A real tool schema lets providers constrain arrays, nested objects, enums, required fields, and multiple top-level parameters directly.

## Tests

- `go build ./...`
- Focused typed/legacy output-tool tests across `cmd`, `internal/agents`, and `internal/tools`
- `TestProgramRunnerDoesNotLeakBackgroundChildren` stress-tested for 100 consecutive runs
- Full isolated `go test ./...` passes

## Environment-sensitive test fix

The jobs cleanup test used `kill(pid, 0)` and treated a terminated-but-unreaped zombie as a live leaked process. That made the result depend on how quickly PID 1 reaped children in the test environment.

This PR now centralizes zombie-aware process-exit assertions in `internal/testutil`, uses them in both jobs runner suites, and counts Linux process state `Z` as exited. No production process-cleanup behavior changed.

## Review

A `claude-bin:fable` reviewer found no blockers. Addressed its important findings by preserving legacy `IsConfigured` behavior and restoring the documentation warning about provider-side schema enforcement.
