### PR TITLE
perf: reduce TUI streaming render snapshot work

### DIFF
--- a/internal/render/markdown/ansi.go
+++ b/internal/render/markdown/ansi.go
@@ -27,6 +27,8 @@ import (
 // Renderer renders complete markdown content for a terminal target.
 // Implementations must treat source as read-only and must not retain it after
 // Render returns; streaming callers may pass slices backed by reusable buffers.
+// Render returns caller-owned bytes that the implementation must not mutate or
+// reuse, including during later Render calls.
 type Renderer interface {
 	Render(source []byte) ([]byte, error)
 	Resize(width int)

--- a/internal/render/markdown/ansi_test.go
+++ b/internal/render/markdown/ansi_test.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,6 +20,31 @@ var testPalette = Palette{
 	Warning:   "#fabd2f",
 	Muted:     "#928374",
 	Text:      "#ebdbb2",
+}
+
+func TestANSIRenderReturnsCallerOwnedStableBytes(t *testing.T) {
+	renderer := NewANSI(Config{Palette: testPalette, Width: 80})
+	first, err := renderer.Render([]byte("First **render**."))
+	if err != nil {
+		t.Fatalf("first Render failed: %v", err)
+	}
+	wantFirst := bytes.Clone(first)
+
+	if _, err := renderer.Render([]byte("A later render with different content.")); err != nil {
+		t.Fatalf("second Render failed: %v", err)
+	}
+	if !bytes.Equal(first, wantFirst) {
+		t.Fatalf("later Render mutated previous result: got %q, want %q", first, wantFirst)
+	}
+
+	first[0] ^= 0xff
+	again, err := renderer.Render([]byte("First **render**."))
+	if err != nil {
+		t.Fatalf("Render after caller mutation failed: %v", err)
+	}
+	if !bytes.Equal(again, wantFirst) {
+		t.Fatalf("caller mutation affected renderer state: got %q, want %q", again, wantFirst)
+	}
 }
 
 func TestRenderString_GoldenVisibleOutput(t *testing.T) {

--- a/internal/ui/streaming/committed_parity_test.go
+++ b/internal/ui/streaming/committed_parity_test.go
@@ -55,15 +55,21 @@ func TestCommittedRenderedMatchesDirectAtStreamingBoundaries(t *testing.T) {
 func TestCorpusCommittedRenderedMatchesDirectAtStreamingBoundaries(t *testing.T) {
 	for _, doc := range loadCorpusDocuments(t) {
 		for _, partial := range []bool{false, true} {
-			name := doc.name
+			mode := "plain"
 			if partial {
-				name += "/partial"
-			} else {
-				name += "/plain"
+				mode = "partial"
 			}
-			t.Run(name, func(t *testing.T) {
-				assertCommittedRenderedMatchesDirectForChunks(t, doc.content, fixedSizeChunks(doc.content, 1), partial)
-			})
+			for _, chunks := range []struct {
+				name   string
+				chunks [][]byte
+			}{
+				{name: "byte-by-byte", chunks: fixedSizeChunks(doc.content, 1)},
+				{name: "adversarial-markdown-cuts", chunks: adversarialMarkdownChunks(doc.content)},
+			} {
+				t.Run(doc.name+"/"+mode+"/"+chunks.name, func(t *testing.T) {
+					assertCommittedRenderedMatchesDirectForChunks(t, doc.content, chunks.chunks, partial)
+				})
+			}
 		}
 	}
 }

--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -102,7 +102,9 @@ func (sr *StreamRenderer) renderFlowingPartialSnapshot(safeContent, rendered str
 	// The committed renderer already proved that block-local appends are safe for
 	// this document. Use the same top-level separator for a local partial block;
 	// globally-sensitive Markdown still goes through the full-document oracle.
-	if len(sr.lastCommittedRendered) > 0 &&
+	if len(rendered) > 0 &&
+		len(sr.lastCommittedRendered) > 0 &&
+		sr.committedMarkdownEndsWithBlankLine() &&
 		!sr.incrementalUnsafe &&
 		!markdownNeedsFullDocumentRender([]byte(safeContent)) &&
 		!markdownHasGlobalMarkdownSemantics([]byte(safeContent)) {
@@ -119,6 +121,21 @@ func (sr *StreamRenderer) renderFlowingPartialSnapshot(safeContent, rendered str
 	}
 
 	return snapshot, nil
+}
+
+// committedMarkdownEndsWithBlankLine reports whether block-local output can be
+// joined to the committed snapshot with the renderer's top-level separator.
+// Without a blank line, the parser may merge the pending line into the preceding
+// paragraph even if the streaming state machine tentatively classified it as a
+// new block (for example pipe-bearing prose that resembles a table row).
+func (sr *StreamRenderer) committedMarkdownEndsWithBlankLine() bool {
+	markdown := sr.allMarkdown.Bytes()
+	if len(markdown) == 0 || markdown[len(markdown)-1] != '\n' {
+		return false
+	}
+	lineEnd := len(markdown) - 1
+	lineStart := bytes.LastIndexByte(markdown[:lineEnd], '\n') + 1
+	return len(bytes.TrimSpace(markdown[lineStart:lineEnd])) == 0
 }
 
 func (sr *StreamRenderer) renderPartialSnapshot(safeContent string) ([]byte, error) {

--- a/internal/ui/streaming/partial.go
+++ b/internal/ui/streaming/partial.go
@@ -37,7 +37,7 @@ func (sr *StreamRenderer) renderPartialBlock() error {
 		return nil
 	}
 
-	firstPending := sr.firstPendingLine()
+	firstPending := firstPendingLine(content)
 	if strings.HasPrefix(firstPending, "|") || isListMarkerOnly(firstPending) {
 		return sr.suppressPartialPreview()
 	}
@@ -95,6 +95,20 @@ func (sr *StreamRenderer) renderFlowingPartialSnapshot(safeContent, rendered str
 		prefixLen := len(sr.lastRendered) - len(sr.partialState.safeRendered)
 		snapshot := make([]byte, 0, prefixLen+len(rendered))
 		snapshot = append(snapshot, sr.lastRendered[:prefixLen]...)
+		snapshot = append(snapshot, rendered...)
+		return snapshot, nil
+	}
+
+	// The committed renderer already proved that block-local appends are safe for
+	// this document. Use the same top-level separator for a local partial block;
+	// globally-sensitive Markdown still goes through the full-document oracle.
+	if len(sr.lastCommittedRendered) > 0 &&
+		!sr.incrementalUnsafe &&
+		!markdownNeedsFullDocumentRender([]byte(safeContent)) &&
+		!markdownHasGlobalMarkdownSemantics([]byte(safeContent)) {
+		snapshot := make([]byte, 0, len(sr.lastCommittedRendered)+2+len(rendered))
+		snapshot = append(snapshot, sr.lastCommittedRendered...)
+		snapshot = append(snapshot, '\n', '\n')
 		snapshot = append(snapshot, rendered...)
 		return snapshot, nil
 	}

--- a/internal/ui/streaming/partial_test.go
+++ b/internal/ui/streaming/partial_test.go
@@ -6,6 +6,21 @@ import (
 	"testing"
 )
 
+func TestFirstPendingLineFromCurrentContent(t *testing.T) {
+	var buf bytes.Buffer
+	sr, err := NewRenderer(&buf, newTestMarkdownRenderer(testRenderWidth))
+	if err != nil {
+		t.Fatalf("NewRenderer failed: %v", err)
+	}
+	sr.pendingLines = []string{"  first line\n", "second line\n"}
+	sr.lineBuf.WriteString("partial")
+
+	content := sr.currentBlockContent()
+	if got, want := firstPendingLine(content), sr.firstPendingLine(); got != want || got != "first line" {
+		t.Fatalf("first pending line = %q, method = %q, want %q", got, want, "first line")
+	}
+}
+
 func TestFindSafePoint(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -509,6 +524,13 @@ func TestFlowingPartialPreviewAvoidsFullSnapshotRerenderAfterFirstTick(t *testin
 	if _, err := sr.Write([]byte("Hello")); err != nil {
 		t.Fatalf("Write first partial failed: %v", err)
 	}
+	if len(renderer.calls) != 1 || string(renderer.calls[0]) != "Hello" {
+		var calls []string
+		for _, call := range renderer.calls {
+			calls = append(calls, string(call))
+		}
+		t.Fatalf("expected first preview to render only the current partial block, got %q", calls)
+	}
 
 	renderer.resetCalls()
 	if _, err := sr.Write([]byte(" world")); err != nil {
@@ -527,6 +549,41 @@ func TestFlowingPartialPreviewAvoidsFullSnapshotRerenderAfterFirstTick(t *testin
 	}
 	if got := buf.String(); got != "# Title\n\nHello world" {
 		t.Fatalf("buffer = %q, want %q", got, "# Title\n\nHello world")
+	}
+}
+
+func TestFlowingPartialPreviewUsesFullRenderForGlobalMarkdown(t *testing.T) {
+	var buf bytes.Buffer
+	renderer := &recordingRenderer{}
+	sr, err := NewRendererWithOptions(
+		&buf,
+		renderer,
+		[]StreamRendererOption{WithPartialRendering()},
+	)
+	if err != nil {
+		t.Fatalf("NewRendererWithOptions failed: %v", err)
+	}
+
+	if _, err := sr.Write([]byte("# Title\n\n")); err != nil {
+		t.Fatalf("Write committed block failed: %v", err)
+	}
+	renderer.resetCalls()
+	if _, err := sr.Write([]byte("> global quote")); err != nil {
+		t.Fatalf("Write partial blockquote failed: %v", err)
+	}
+
+	if len(renderer.calls) != 2 {
+		var calls []string
+		for _, call := range renderer.calls {
+			calls = append(calls, string(call))
+		}
+		t.Fatalf("expected local preview plus full-document fallback, got %q", calls)
+	}
+	if got := string(renderer.calls[1]); got != "# Title\n\n> global quote" {
+		t.Fatalf("full render source = %q", got)
+	}
+	if got := buf.String(); got != "# Title\n\n> global quote" {
+		t.Fatalf("buffer = %q", got)
 	}
 }
 

--- a/internal/ui/streaming/partial_test.go
+++ b/internal/ui/streaming/partial_test.go
@@ -621,6 +621,32 @@ func TestFlowingPartialPreviewMatchesFullRenderAcrossUpdates(t *testing.T) {
 	}
 }
 
+func TestFlowingPartialPreviewDoesNotSeparateAdjacentPipeProse(t *testing.T) {
+	var buf bytes.Buffer
+	sr, err := NewRendererWithOptions(
+		&buf,
+		newTestMarkdownRenderer(testRenderWidth),
+		[]StreamRendererOption{WithPartialRendering()},
+	)
+	if err != nil {
+		t.Fatalf("NewRendererWithOptions failed: %v", err)
+	}
+
+	input := "Alpha beta\nuse `a | b` to pipe\n"
+	if _, err := sr.Write([]byte(input)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	want, err := newTestMarkdownRenderer(testRenderWidth).Render([]byte(input))
+	if err != nil {
+		t.Fatalf("direct render failed: %v", err)
+	}
+	want = bytes.TrimRight(normalizeNewlines(want), "\n")
+	if got := buf.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("partial preview mismatch\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
 // stripAnsiHelper removes ANSI escape sequences for test assertions.
 // Note: can't use ui.StripANSI here because ui imports streaming (circular).
 func stripAnsiHelper(s string) string {

--- a/internal/ui/streaming/streaming.go
+++ b/internal/ui/streaming/streaming.go
@@ -744,7 +744,11 @@ func (sr *StreamRenderer) handleTable(content, rawLine string) error {
 		return sr.handleList(content, rawLine)
 	}
 	sr.state = stateReady
-	if err := sr.commitPendingLinesIncremental(); err != nil {
+	if sr.pendingLinesFormTable() {
+		if err := sr.commitPendingLinesIncremental(); err != nil {
+			return err
+		}
+	} else if err := sr.commitPendingLines(); err != nil {
 		return err
 	}
 
@@ -1177,6 +1181,58 @@ func isThematicBreak(trimmed string) bool {
 	}
 
 	return count >= 3
+}
+
+// pendingLinesFormTable reports whether the current table-shaped block is a
+// well-formed GFM table. A pipe in prose is not enough: the header must be
+// followed immediately by a delimiter row with the same number of cells.
+func (sr *StreamRenderer) pendingLinesFormTable() bool {
+	if len(sr.pendingLines) < 2 {
+		return false
+	}
+	headerCells := tableRowCellCount(sr.pendingLines[0])
+	delimiterCells := tableDelimiterCellCount(sr.pendingLines[1])
+	return headerCells > 0 && headerCells == delimiterCells
+}
+
+func tableRowCellCount(line string) int {
+	trimmed := strings.TrimSpace(line)
+	if !strings.Contains(trimmed, "|") {
+		return 0
+	}
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	if trimmed == "" {
+		return 0
+	}
+
+	cells := 1
+	for i := 0; i < len(trimmed); i++ {
+		if trimmed[i] == '|' && (i == 0 || trimmed[i-1] != '\\') {
+			cells++
+		}
+	}
+	return cells
+}
+
+func tableDelimiterCellCount(line string) int {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	if trimmed == "" {
+		return 0
+	}
+
+	cells := strings.Split(trimmed, "|")
+	for _, cell := range cells {
+		cell = strings.TrimSpace(cell)
+		cell = strings.TrimPrefix(cell, ":")
+		cell = strings.TrimSuffix(cell, ":")
+		if len(cell) < 3 || strings.Trim(cell, "-") != "" {
+			return 0
+		}
+	}
+	return len(cells)
 }
 
 // isTableLine returns true if the line appears to be part of a table.

--- a/internal/ui/streaming/streaming.go
+++ b/internal/ui/streaming/streaming.go
@@ -219,6 +219,12 @@ func (sr *StreamRenderer) CommittedRendered() string {
 	return string(sr.lastCommittedRendered)
 }
 
+// RenderedSnapshot returns the latest rendered bytes. The returned slice is
+// read-only and remains stable across future writes.
+func (sr *StreamRenderer) RenderedSnapshot() []byte {
+	return sr.lastRendered
+}
+
 // PendingMarkdown returns the current incomplete block markdown.
 // This includes pending complete lines plus any partial line in the buffer.
 func (sr *StreamRenderer) PendingMarkdown() string {
@@ -267,7 +273,10 @@ func (sr *StreamRenderer) PendingIsList() bool {
 // firstPendingLine returns the first incomplete line from current block content,
 // left-trimmed of indentation and without trailing carriage return.
 func (sr *StreamRenderer) firstPendingLine() string {
-	content := sr.currentBlockContent()
+	return firstPendingLine(sr.currentBlockContent())
+}
+
+func firstPendingLine(content string) string {
 	if content == "" {
 		return ""
 	}
@@ -521,17 +530,16 @@ func (sr *StreamRenderer) emitRenderedBlock(markdown []byte) error {
 		return nil
 	}
 
-	// Match the ANSI renderer's top-level block separator. If
-	// internal/render/markdown changes renderBlockChildren's document separator,
-	// committed-boundary parity tests should fail before this leaks to scrollback.
-	snapshot := make([]byte, 0, len(sr.lastCommittedRendered)+2+len(rendered))
+	// Match the ANSI renderer's top-level block separator. Grow the committed
+	// snapshot in place so appending a block does not copy the entire rendered
+	// response on every commit. If internal/render/markdown changes
+	// renderBlockChildren's document separator, committed-boundary parity tests
+	// should fail before this leaks to scrollback.
 	if len(sr.lastCommittedRendered) > 0 {
-		snapshot = append(snapshot, sr.lastCommittedRendered...)
-		snapshot = append(snapshot, '\n', '\n')
+		sr.lastCommittedRendered = append(sr.lastCommittedRendered, '\n', '\n')
 	}
-	snapshot = append(snapshot, rendered...)
-	sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], snapshot...)
-	return sr.applyRenderedSnapshot(snapshot, false)
+	sr.lastCommittedRendered = append(sr.lastCommittedRendered, rendered...)
+	return sr.applyRenderedSnapshot(sr.lastCommittedRendered, false)
 }
 
 // applyRenderedSnapshot writes the next rendered snapshot using one of:
@@ -553,7 +561,7 @@ func (sr *StreamRenderer) applyRenderedSnapshot(snapshot []byte, _ bool) error {
 				return err
 			}
 		}
-		sr.lastRendered = append(sr.lastRendered[:0], snapshot...)
+		sr.lastRendered = snapshot
 		sr.renderedLen = len(sr.lastRendered)
 		return nil
 	}
@@ -569,7 +577,7 @@ func (sr *StreamRenderer) applyRenderedSnapshot(snapshot []byte, _ bool) error {
 	// Changed prefix on a resettable writer: rewrite the full snapshot.
 	// Append-only deltas are not safe because bytes before the previous length
 	// may have changed.
-	sr.lastRendered = append(sr.lastRendered[:0], snapshot...)
+	sr.lastRendered = snapshot
 	sr.renderedLen = len(sr.lastRendered)
 	resetter.Reset()
 	if len(snapshot) > 0 {
@@ -736,7 +744,7 @@ func (sr *StreamRenderer) handleTable(content, rawLine string) error {
 		return sr.handleList(content, rawLine)
 	}
 	sr.state = stateReady
-	if err := sr.commitPendingLines(); err != nil {
+	if err := sr.commitPendingLinesIncremental(); err != nil {
 		return err
 	}
 
@@ -892,7 +900,7 @@ func (sr *StreamRenderer) emitRendered() error {
 		stableLen--
 	}
 
-	sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], rendered[:stableLen]...)
+	sr.lastCommittedRendered = bytes.Clone(rendered[:stableLen])
 	return sr.applyRenderedSnapshot(rendered[:stableLen], false)
 }
 
@@ -935,7 +943,7 @@ func (sr *StreamRenderer) Flush() error {
 
 	// Normalize consecutive newlines to fix inconsistent header spacing
 	rendered = normalizeNewlines(rendered)
-	sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], rendered...)
+	sr.lastCommittedRendered = bytes.Clone(rendered)
 
 	// Output final render including trailing newlines.
 	return sr.applyRenderedSnapshot(rendered, true)
@@ -986,7 +994,7 @@ func (sr *StreamRenderer) Resize(newWidth int) error {
 			stableLen--
 		}
 
-		sr.lastCommittedRendered = append(sr.lastCommittedRendered[:0], rendered[:stableLen]...)
+		sr.lastCommittedRendered = bytes.Clone(rendered[:stableLen])
 		if stableLen > 0 {
 			if err := sr.applyRenderedSnapshot(rendered[:stableLen], true); err != nil {
 				return err

--- a/internal/ui/streaming/streaming_test.go
+++ b/internal/ui/streaming/streaming_test.go
@@ -571,6 +571,26 @@ func TestTableCommitUsesBlockLocalRenderWhenSafe(t *testing.T) {
 	}
 }
 
+func TestPseudoTableCommitUsesFullDocumentRender(t *testing.T) {
+	var buf bytes.Buffer
+	renderer := &recordingRenderer{}
+	sr, err := NewRenderer(&buf, renderer)
+	if err != nil {
+		t.Fatalf("NewRenderer failed: %v", err)
+	}
+
+	input := "Alpha beta\nuse `a | b` to pipe\n\n"
+	if _, err := sr.Write([]byte(input)); err != nil {
+		t.Fatalf("write prose containing pipe: %v", err)
+	}
+	if len(renderer.calls) != 2 {
+		t.Fatalf("render calls = %d, want 2", len(renderer.calls))
+	}
+	if got, want := string(renderer.calls[1]), strings.TrimSuffix(input, "\n"); got != want {
+		t.Fatalf("final render source = %q, want full document %q", got, want)
+	}
+}
+
 func TestApplyRenderedSnapshot_NonResettableWriterErrorsOnPrefixChange(t *testing.T) {
 	writer := &nonResettableWriter{}
 	sr, err := NewRenderer(writer, newTestMarkdownRenderer(testRenderWidth))

--- a/internal/ui/streaming/streaming_test.go
+++ b/internal/ui/streaming/streaming_test.go
@@ -546,6 +546,31 @@ func TestNestedList_EmitsNestedItemsIncrementally(t *testing.T) {
 	}
 }
 
+func TestTableCommitUsesBlockLocalRenderWhenSafe(t *testing.T) {
+	var buf bytes.Buffer
+	renderer := &recordingRenderer{}
+	sr, err := NewRenderer(&buf, renderer)
+	if err != nil {
+		t.Fatalf("NewRenderer failed: %v", err)
+	}
+
+	if _, err := sr.Write([]byte("# Results\n\n")); err != nil {
+		t.Fatalf("write heading: %v", err)
+	}
+	renderer.resetCalls()
+
+	table := "| size | time |\n| ---: | ---: |\n| 32 | 1ms |\n\n"
+	if _, err := sr.Write([]byte(table)); err != nil {
+		t.Fatalf("write table: %v", err)
+	}
+	if len(renderer.calls) != 1 {
+		t.Fatalf("table render calls = %d, want 1", len(renderer.calls))
+	}
+	if got := string(renderer.calls[0]); got != table[:len(table)-1] {
+		t.Fatalf("table render source = %q, want block-local %q", got, table[:len(table)-1])
+	}
+}
+
 func TestApplyRenderedSnapshot_NonResettableWriterErrorsOnPrefixChange(t *testing.T) {
 	writer := &nonResettableWriter{}
 	sr, err := NewRenderer(writer, newTestMarkdownRenderer(testRenderWidth))
@@ -569,6 +594,28 @@ func TestApplyRenderedSnapshot_NonResettableWriterErrorsOnPrefixChange(t *testin
 	}
 	if !strings.Contains(err.Error(), "non-resettable writer") {
 		t.Fatalf("expected non-resettable writer error, got: %v", err)
+	}
+}
+
+func TestApplyRenderedSnapshotPreservesPreviousSnapshot(t *testing.T) {
+	var buf bytes.Buffer
+	sr, err := NewRenderer(&buf, newTestMarkdownRenderer(testRenderWidth))
+	if err != nil {
+		t.Fatalf("failed to create renderer: %v", err)
+	}
+
+	initial := make([]byte, len("committed"), 64)
+	copy(initial, "committed")
+	if err := sr.applyRenderedSnapshot(initial, false); err != nil {
+		t.Fatalf("apply initial snapshot: %v", err)
+	}
+	previous := sr.RenderedSnapshot()
+
+	if err := sr.applyRenderedSnapshot([]byte("commitment"), false); err != nil {
+		t.Fatalf("apply changed snapshot: %v", err)
+	}
+	if got := string(previous); got != "committed" {
+		t.Fatalf("previous snapshot mutated to %q", got)
 	}
 }
 

--- a/internal/ui/streaming/testdata/corpus/prose-pipes-and-tables.md
+++ b/internal/ui/streaming/testdata/corpus/prose-pipes-and-tables.md
@@ -1,0 +1,11 @@
+Alpha beta
+use `a | b` to pipe
+
+After text remains a separate paragraph.
+
+| mode | result |
+| :--- | ---: |
+| plain | stable |
+| partial | stable |
+
+A trailing `x | y` expression stays prose too.

--- a/internal/ui/text_segment_renderer.go
+++ b/internal/ui/text_segment_renderer.go
@@ -98,9 +98,6 @@ func (r *TextSegmentRenderer) RenderedAll() string {
 // RenderedCommitted returns the latest rendered snapshot that contains only
 // committed markdown blocks and excludes any active partial preview.
 func (r *TextSegmentRenderer) RenderedCommitted() string {
-	if r.sr == nil {
-		return ""
-	}
 	return r.sr.CommittedRendered()
 }
 
@@ -118,10 +115,6 @@ func (r *TextSegmentRenderer) RenderedUnflushed() string {
 // MarkFlushed marks the current committed rendered output as flushed.
 // Call this after successfully flushing content to scrollback.
 func (r *TextSegmentRenderer) MarkFlushed() {
-	if r.sr == nil {
-		r.flushedRenderedPos = 0
-		return
-	}
 	r.flushedRenderedPos = len(r.sr.CommittedRendered())
 }
 
@@ -133,34 +126,22 @@ func (r *TextSegmentRenderer) FlushedRenderedPos() int {
 // CommittedMarkdownLen returns the number of raw markdown bytes that have been
 // committed as complete blocks by the streaming renderer.
 func (r *TextSegmentRenderer) CommittedMarkdownLen() int {
-	if r.sr == nil {
-		return 0
-	}
 	return r.sr.CommittedMarkdownLen()
 }
 
 // PendingMarkdown returns the markdown that belongs to the current incomplete block.
 func (r *TextSegmentRenderer) PendingMarkdown() string {
-	if r.sr == nil {
-		return ""
-	}
 	return r.sr.PendingMarkdown()
 }
 
 // PendingIsTable reports whether the current incomplete block is a table.
 func (r *TextSegmentRenderer) PendingIsTable() bool {
-	if r.sr == nil {
-		return false
-	}
 	return r.sr.PendingIsTable()
 }
 
 // PendingIsList reports whether the current incomplete block should be treated
 // as a list for preview purposes.
 func (r *TextSegmentRenderer) PendingIsList() bool {
-	if r.sr == nil {
-		return false
-	}
 	return r.sr.PendingIsList()
 }
 

--- a/internal/ui/text_segment_renderer.go
+++ b/internal/ui/text_segment_renderer.go
@@ -1,28 +1,32 @@
 package ui
 
 import (
-	"bytes"
-
 	rendermarkdown "github.com/samsaffron/term-llm/internal/render/markdown"
+	"github.com/samsaffron/term-llm/internal/ui/ansisafe"
 	"github.com/samsaffron/term-llm/internal/ui/streaming"
 )
 
 // TextSegmentRenderer wraps the streaming markdown renderer for use with
-// text segments. It buffers rendered output so View() can read it.
+// text segments. StreamRenderer owns the current snapshot so View() can read it
+// without maintaining a second full-size buffer.
 type TextSegmentRenderer struct {
-	sr     *streaming.StreamRenderer
-	output *bytes.Buffer
-	width  int
+	sr    *streaming.StreamRenderer
+	width int
 
 	// flushedRenderedPos tracks how much of the rendered output has been
 	// flushed to scrollback, allowing RenderedFrom to return only unflushed content.
 	flushedRenderedPos int
 }
 
+type snapshotSink struct{}
+
+func (*snapshotSink) Write(p []byte) (int, error) { return len(p), nil }
+func (*snapshotSink) Reset()                      {}
+
 // NewTextSegmentRenderer creates a new TextSegmentRenderer with the given width.
 // Uses partial flowing snapshots (no cursor control) since Bubble Tea owns the terminal.
 func NewTextSegmentRenderer(width int) (*TextSegmentRenderer, error) {
-	var output bytes.Buffer
+	var output snapshotSink
 	renderer := rendermarkdown.NewANSI(rendermarkdown.Config{
 		Palette: currentMarkdownPalette(),
 		Width:   width,
@@ -40,16 +44,15 @@ func NewTextSegmentRenderer(width int) (*TextSegmentRenderer, error) {
 	}
 
 	return &TextSegmentRenderer{
-		sr:     sr,
-		output: &output,
-		width:  width,
+		sr:    sr,
+		width: width,
 	}, nil
 }
 
 // Write writes text to the streaming renderer.
 // Complete markdown blocks are rendered immediately.
 func (r *TextSegmentRenderer) Write(text string) error {
-	prevOutput := r.output.Bytes()
+	prevOutput := r.sr.RenderedSnapshot()
 	prevFlushedPos := r.flushedRenderedPos
 	if prevFlushedPos > len(prevOutput) {
 		prevFlushedPos = len(prevOutput)
@@ -58,7 +61,7 @@ func (r *TextSegmentRenderer) Write(text string) error {
 
 	var prevFlushedPrefix []byte
 	if prevFlushedPos > 0 {
-		prevFlushedPrefix = append([]byte(nil), prevOutput[:prevFlushedPos]...)
+		prevFlushedPrefix = prevOutput[:prevFlushedPos]
 	}
 
 	_, err := r.sr.Write([]byte(text))
@@ -66,7 +69,7 @@ func (r *TextSegmentRenderer) Write(text string) error {
 		return err
 	}
 
-	currentOutput := r.output.Bytes()
+	currentOutput := r.sr.RenderedSnapshot()
 	currentLen := len(currentOutput)
 	if r.flushedRenderedPos > currentLen {
 		r.flushedRenderedPos = currentLen
@@ -84,12 +87,12 @@ func (r *TextSegmentRenderer) Write(text string) error {
 // Rendered returns the currently rendered output.
 // This is the content to display in View().
 func (r *TextSegmentRenderer) Rendered() string {
-	return r.output.String()
+	return string(r.sr.RenderedSnapshot())
 }
 
 // RenderedAll returns the full rendered output including already-flushed content.
 func (r *TextSegmentRenderer) RenderedAll() string {
-	return r.output.String()
+	return string(r.sr.RenderedSnapshot())
 }
 
 // RenderedCommitted returns the latest rendered snapshot that contains only
@@ -105,18 +108,18 @@ func (r *TextSegmentRenderer) RenderedCommitted() string {
 // been flushed to scrollback yet. Use this in View() to avoid duplicating
 // content that was already printed via FlushStreamingText.
 func (r *TextSegmentRenderer) RenderedUnflushed() string {
-	output := r.output.String()
+	output := r.sr.RenderedSnapshot()
 	if r.flushedRenderedPos >= len(output) {
 		return ""
 	}
-	return safeANSISlice(output, r.flushedRenderedPos)
+	return string(ansisafe.SuffixBytes(output, r.flushedRenderedPos))
 }
 
 // MarkFlushed marks the current committed rendered output as flushed.
 // Call this after successfully flushing content to scrollback.
 func (r *TextSegmentRenderer) MarkFlushed() {
 	if r.sr == nil {
-		r.flushedRenderedPos = r.output.Len()
+		r.flushedRenderedPos = 0
 		return
 	}
 	r.flushedRenderedPos = len(r.sr.CommittedRendered())
@@ -184,7 +187,7 @@ func (r *TextSegmentRenderer) Resize(newWidth int) error {
 	// logic (same approach as Write) so content already printed to
 	// scrollback is not duplicated.
 	prevFlushedPos := r.flushedRenderedPos
-	prevOutput := r.output.Bytes()
+	prevOutput := r.sr.RenderedSnapshot()
 	if prevFlushedPos > len(prevOutput) {
 		prevFlushedPos = len(prevOutput)
 	}
@@ -193,7 +196,6 @@ func (r *TextSegmentRenderer) Resize(newWidth int) error {
 		prevFlushedPrefix = append([]byte(nil), prevOutput[:prevFlushedPos]...)
 	}
 
-	r.output.Reset()
 	r.width = newWidth
 
 	if err := r.sr.Resize(newWidth); err != nil {
@@ -201,7 +203,7 @@ func (r *TextSegmentRenderer) Resize(newWidth int) error {
 		return err
 	}
 
-	currentOutput := r.output.Bytes()
+	currentOutput := r.sr.RenderedSnapshot()
 	if prevFlushedPos > 0 && len(currentOutput) > 0 {
 		r.flushedRenderedPos = longestCommonPrefixLenBytes(prevFlushedPrefix, currentOutput)
 	} else {

--- a/internal/ui/tool_tracker_bench_test.go
+++ b/internal/ui/tool_tracker_bench_test.go
@@ -15,47 +15,61 @@ const (
 
 var streamingRenderBenchmarkSink int
 
-// BenchmarkTUIStreamingRender replays a growing Markdown response through the
+// BenchmarkTUIStreamingRender replays growing Markdown responses through the
 // same ToolTracker -> TextSegmentRenderer -> StreamRenderer path used for live
 // TUI responses. Every token-like append is followed by a View render and the
 // normal incremental scrollback flush check.
 //
-// The corpus contains exactly the requested number of top-level blocks. It
-// cycles through ATX headings, inline-rich paragraphs, fenced code blocks,
-// tables, and thematic breaks. Chunk sizes cycle through 17, 31, 47, and 73
-// bytes, deliberately splitting lines and inline markup as a token stream does.
+// FastPath cycles through ATX headings, inline-rich paragraphs, fenced code
+// blocks, well-formed tables, and thematic breaks. ListHeavy alternates
+// multi-item lists with other common blocks. EarlyUnsafe starts with a reference
+// definition, latching the full-document fallback before otherwise fast-path
+// content. Chunk sizes cycle through 17, 31, 47, and 73 bytes, deliberately
+// splitting lines and inline markup as a token stream does.
 func BenchmarkTUIStreamingRender(b *testing.B) {
-	for _, blocks := range []int{32, 128, 512, 1024} {
-		b.Run(fmt.Sprintf("blocks=%d", blocks), func(b *testing.B) {
-			corpus := streamingRenderBenchmarkCorpus(blocks)
-			chunks := streamingRenderBenchmarkChunks(corpus)
+	workloads := []struct {
+		name   string
+		corpus func(int) string
+	}{
+		{name: "FastPath", corpus: streamingRenderBenchmarkFastPathCorpus},
+		{name: "ListHeavy", corpus: streamingRenderBenchmarkListHeavyCorpus},
+		{name: "EarlyUnsafe", corpus: streamingRenderBenchmarkEarlyUnsafeCorpus},
+	}
+	for _, workload := range workloads {
+		b.Run(workload.name, func(b *testing.B) {
+			for _, blocks := range []int{32, 128, 512, 1024} {
+				b.Run(fmt.Sprintf("blocks=%d", blocks), func(b *testing.B) {
+					corpus := workload.corpus(blocks)
+					chunks := streamingRenderBenchmarkChunks(corpus)
 
-			// Warm the Markdown renderer's internal caches and collect a separate
-			// representative frame-latency sample without contaminating ns/op.
-			streamingRenderBenchmarkReplay(b, chunks, nil)
-			frameDurations := make([]time.Duration, 0, len(chunks))
-			streamingRenderBenchmarkReplay(b, chunks, &frameDurations)
-			sort.Slice(frameDurations, func(i, j int) bool {
-				return frameDurations[i] < frameDurations[j]
-			})
+					// Warm the Markdown renderer's internal caches and collect a
+					// separate warmed frame-latency sample without contaminating ns/op.
+					streamingRenderBenchmarkReplay(b, chunks, nil)
+					frameDurations := make([]time.Duration, 0, len(chunks))
+					streamingRenderBenchmarkReplay(b, chunks, &frameDurations)
+					sort.Slice(frameDurations, func(i, j int) bool {
+						return frameDurations[i] < frameDurations[j]
+					})
 
-			p50FrameNS := float64(framePercentile(frameDurations, 50).Nanoseconds())
-			p95FrameNS := float64(framePercentile(frameDurations, 95).Nanoseconds())
-			p99FrameNS := float64(framePercentile(frameDurations, 99).Nanoseconds())
-			maxFrameNS := float64(frameDurations[len(frameDurations)-1].Nanoseconds())
+					p50FrameNS := float64(framePercentile(frameDurations, 50).Nanoseconds())
+					p95FrameNS := float64(framePercentile(frameDurations, 95).Nanoseconds())
+					p99FrameNS := float64(framePercentile(frameDurations, 99).Nanoseconds())
+					maxFrameNS := float64(frameDurations[len(frameDurations)-1].Nanoseconds())
 
-			b.ReportAllocs()
-			b.SetBytes(int64(len(corpus)))
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				streamingRenderBenchmarkReplay(b, chunks, nil)
+					b.ReportAllocs()
+					b.SetBytes(int64(len(corpus)))
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						streamingRenderBenchmarkReplay(b, chunks, nil)
+					}
+					b.StopTimer()
+					b.ReportMetric(float64(len(chunks)), "frames/op")
+					b.ReportMetric(p50FrameNS, "p50-frame-ns")
+					b.ReportMetric(p95FrameNS, "p95-frame-ns")
+					b.ReportMetric(p99FrameNS, "p99-frame-ns")
+					b.ReportMetric(maxFrameNS, "max-frame-ns")
+				})
 			}
-			b.StopTimer()
-			b.ReportMetric(float64(len(chunks)), "frames/op")
-			b.ReportMetric(p50FrameNS, "p50-frame-ns")
-			b.ReportMetric(p95FrameNS, "p95-frame-ns")
-			b.ReportMetric(p99FrameNS, "p99-frame-ns")
-			b.ReportMetric(maxFrameNS, "max-frame-ns")
 		})
 	}
 }
@@ -94,24 +108,58 @@ func streamingRenderBenchmarkReplay(b *testing.B, chunks []string, frameDuration
 	streamingRenderBenchmarkSink += len(remaining.ToPrint) + maxTailBytes
 }
 
-func streamingRenderBenchmarkCorpus(blocks int) string {
+func streamingRenderBenchmarkFastPathCorpus(blocks int) string {
 	var corpus strings.Builder
 	corpus.Grow(blocks * 120)
 	for i := 0; i < blocks; i++ {
-		switch i % 5 {
-		case 0:
-			fmt.Fprintf(&corpus, "## Streaming renderer phase %d\n\n", i/5+1)
-		case 1:
-			fmt.Fprintf(&corpus, "The agent inspected **%d files**, compared `rendered` snapshots, and linked the [profiling guide](https://go.dev/pprof) before continuing.\n\n", 40+i)
-		case 2:
-			fmt.Fprintf(&corpus, "```go\nfunc renderFrame%d(markdown string) string {\nreturn render(markdown)\n}\n```\n\n", i)
-		case 3:
-			fmt.Fprintf(&corpus, "| sample | blocks | status |\n| ---: | ---: | :--- |\n| %d | %d | stable |\n\n", i/5+1, i+1)
-		case 4:
-			corpus.WriteString("***\n\n")
+		writeStreamingRenderBenchmarkFastPathBlock(&corpus, i)
+	}
+	return corpus.String()
+}
+
+func streamingRenderBenchmarkListHeavyCorpus(blocks int) string {
+	var corpus strings.Builder
+	corpus.Grow(blocks * 180)
+	for i := 0; i < blocks; i++ {
+		if i%2 == 0 {
+			fmt.Fprintf(&corpus, "- inspect **batch %d**\n- compare `rendered` output\n- record the [profile](https://go.dev/pprof)\n- continue streaming\n\n", i/2+1)
+			continue
+		}
+		if i%4 == 1 {
+			fmt.Fprintf(&corpus, "## List checkpoint %d\n\n", i/2+1)
+		} else {
+			fmt.Fprintf(&corpus, "Checkpoint %d keeps the response representative between list blocks.\n\n", i/2+1)
 		}
 	}
 	return corpus.String()
+}
+
+func streamingRenderBenchmarkEarlyUnsafeCorpus(blocks int) string {
+	if blocks <= 0 {
+		return ""
+	}
+	var corpus strings.Builder
+	corpus.Grow(blocks * 120)
+	corpus.WriteString("[streaming-guide]: https://example.com/streaming\n\n")
+	for i := 1; i < blocks; i++ {
+		writeStreamingRenderBenchmarkFastPathBlock(&corpus, i)
+	}
+	return corpus.String()
+}
+
+func writeStreamingRenderBenchmarkFastPathBlock(corpus *strings.Builder, i int) {
+	switch i % 5 {
+	case 0:
+		fmt.Fprintf(corpus, "## Streaming renderer phase %d\n\n", i/5+1)
+	case 1:
+		fmt.Fprintf(corpus, "The agent inspected **%d files**, compared `rendered` snapshots, and linked the [profiling guide](https://go.dev/pprof) before continuing.\n\n", 40+i)
+	case 2:
+		fmt.Fprintf(corpus, "```go\nfunc renderFrame%d(markdown string) string {\nreturn render(markdown)\n}\n```\n\n", i)
+	case 3:
+		fmt.Fprintf(corpus, "| sample | blocks | status |\n| ---: | ---: | :--- |\n| %d | %d | stable |\n\n", i/5+1, i+1)
+	case 4:
+		corpus.WriteString("***\n\n")
+	}
 }
 
 func streamingRenderBenchmarkChunks(corpus string) []string {

--- a/internal/ui/tool_tracker_bench_test.go
+++ b/internal/ui/tool_tracker_bench_test.go
@@ -1,0 +1,137 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	streamingRenderBenchmarkWidth          = 100
+	streamingRenderBenchmarkFlushThreshold = 4096
+)
+
+var streamingRenderBenchmarkSink int
+
+// BenchmarkTUIStreamingRender replays a growing Markdown response through the
+// same ToolTracker -> TextSegmentRenderer -> StreamRenderer path used for live
+// TUI responses. Every token-like append is followed by a View render and the
+// normal incremental scrollback flush check.
+//
+// The corpus contains exactly the requested number of top-level blocks. It
+// cycles through ATX headings, inline-rich paragraphs, fenced code blocks,
+// tables, and thematic breaks. Chunk sizes cycle through 17, 31, 47, and 73
+// bytes, deliberately splitting lines and inline markup as a token stream does.
+func BenchmarkTUIStreamingRender(b *testing.B) {
+	for _, blocks := range []int{32, 128, 512, 1024} {
+		b.Run(fmt.Sprintf("blocks=%d", blocks), func(b *testing.B) {
+			corpus := streamingRenderBenchmarkCorpus(blocks)
+			chunks := streamingRenderBenchmarkChunks(corpus)
+
+			// Warm the Markdown renderer's internal caches and collect a separate
+			// representative frame-latency sample without contaminating ns/op.
+			streamingRenderBenchmarkReplay(b, chunks, nil)
+			frameDurations := make([]time.Duration, 0, len(chunks))
+			streamingRenderBenchmarkReplay(b, chunks, &frameDurations)
+			sort.Slice(frameDurations, func(i, j int) bool {
+				return frameDurations[i] < frameDurations[j]
+			})
+
+			p50FrameNS := float64(framePercentile(frameDurations, 50).Nanoseconds())
+			p95FrameNS := float64(framePercentile(frameDurations, 95).Nanoseconds())
+			p99FrameNS := float64(framePercentile(frameDurations, 99).Nanoseconds())
+			maxFrameNS := float64(frameDurations[len(frameDurations)-1].Nanoseconds())
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(corpus)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				streamingRenderBenchmarkReplay(b, chunks, nil)
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(len(chunks)), "frames/op")
+			b.ReportMetric(p50FrameNS, "p50-frame-ns")
+			b.ReportMetric(p95FrameNS, "p95-frame-ns")
+			b.ReportMetric(p99FrameNS, "p99-frame-ns")
+			b.ReportMetric(maxFrameNS, "max-frame-ns")
+		})
+	}
+}
+
+func streamingRenderBenchmarkReplay(b *testing.B, chunks []string, frameDurations *[]time.Duration) {
+	b.Helper()
+	tracker := NewToolTracker()
+	maxTailBytes := 0
+	for _, chunk := range chunks {
+		var started time.Time
+		if frameDurations != nil {
+			started = time.Now()
+		}
+
+		tracker.AddTextSegment(chunk, streamingRenderBenchmarkWidth)
+		view := tracker.RenderUnflushed(streamingRenderBenchmarkWidth, RenderMarkdown, false)
+		flushed := tracker.FlushStreamingText(
+			streamingRenderBenchmarkFlushThreshold,
+			streamingRenderBenchmarkWidth,
+			RenderMarkdown,
+		)
+		if len(view) > maxTailBytes {
+			maxTailBytes = len(view)
+		}
+		streamingRenderBenchmarkSink += len(view) + len(flushed.ToPrint)
+
+		if frameDurations != nil {
+			*frameDurations = append(*frameDurations, time.Since(started))
+		}
+	}
+
+	tracker.CompleteTextSegments(func(content string) string {
+		return RenderMarkdown(content, streamingRenderBenchmarkWidth)
+	})
+	remaining := tracker.FlushAllRemaining(streamingRenderBenchmarkWidth, 0, RenderMarkdown)
+	streamingRenderBenchmarkSink += len(remaining.ToPrint) + maxTailBytes
+}
+
+func streamingRenderBenchmarkCorpus(blocks int) string {
+	var corpus strings.Builder
+	corpus.Grow(blocks * 120)
+	for i := 0; i < blocks; i++ {
+		switch i % 5 {
+		case 0:
+			fmt.Fprintf(&corpus, "## Streaming renderer phase %d\n\n", i/5+1)
+		case 1:
+			fmt.Fprintf(&corpus, "The agent inspected **%d files**, compared `rendered` snapshots, and linked the [profiling guide](https://go.dev/pprof) before continuing.\n\n", 40+i)
+		case 2:
+			fmt.Fprintf(&corpus, "```go\nfunc renderFrame%d(markdown string) string {\nreturn render(markdown)\n}\n```\n\n", i)
+		case 3:
+			fmt.Fprintf(&corpus, "| sample | blocks | status |\n| ---: | ---: | :--- |\n| %d | %d | stable |\n\n", i/5+1, i+1)
+		case 4:
+			corpus.WriteString("***\n\n")
+		}
+	}
+	return corpus.String()
+}
+
+func streamingRenderBenchmarkChunks(corpus string) []string {
+	sizes := [...]int{17, 31, 47, 73}
+	chunks := make([]string, 0, len(corpus)/32+1)
+	for offset, sizeIndex := 0, 0; offset < len(corpus); sizeIndex++ {
+		end := offset + sizes[sizeIndex%len(sizes)]
+		if end > len(corpus) {
+			end = len(corpus)
+		}
+		chunks = append(chunks, corpus[offset:end])
+		offset = end
+	}
+	return chunks
+}
+
+func framePercentile(durations []time.Duration, percentile int) time.Duration {
+	index := (len(durations)*percentile + 99) / 100
+	if index > 0 {
+		index--
+	}
+	return durations[index]
+}


### PR DESCRIPTION
## Summary

Adds a realistic growing-response benchmark for the live TUI Markdown path and removes repeated whole-response rendering/copying from safe incremental frames while keeping full-document rendering as the correctness oracle.

The Fable review follow-up in `e6fe4ebd` also:

- restricts block-local table commits to conservative, well-formed tables whose header is immediately followed by a matching delimiter row
- keeps pipe-bearing prose/pseudo-tables on the full-document fallback, fixing the `Alpha beta` / ``use `a | b` to pipe`` regression
- adds permanent corpus parity coverage at byte-by-byte and adversarial Markdown boundaries in both plain and partial modes, plus a recording-renderer test proving genuine tables still use the block-local fast path
- documents and tests that `markdown.Renderer.Render` returns caller-owned, stable bytes
- removes the inconsistent dead `sr == nil` guards from `TextSegmentRenderer`

## Benchmark workloads

`BenchmarkTUIStreamingRender` exercises this path after every token-like append:

1. `ToolTracker.AddTextSegment`
2. `ToolTracker.RenderUnflushed` (the live View path)
3. `ToolTracker.FlushStreamingText` with the normal 4096-byte threshold
4. `CompleteTextSegments` and `FlushAllRemaining` at end of stream

It now distinguishes three workloads:

- **FastPath**: headings, inline-rich paragraphs, fenced code, well-formed tables, and thematic breaks
- **ListHeavy**: multi-item lists alternating with headings/paragraphs; representative list processing quickly reaches the full-document fallback
- **EarlyUnsafe**: begins with a reference definition, latching `incrementalUnsafe` before otherwise fast-path Markdown

Common configuration:

- terminal width: 100
- sizes: 32 / 128 / 512 / 1024 block units
- deterministic chunk sizes: 17, 31, 47, and 73 bytes, repeated; chunks split lines and inline syntax
- one unmeasured cache warm-up replay, then one unmeasured warmed replay for frame percentiles, then timed/allocation replay(s)

Exact implementation: `internal/ui/tool_tracker_bench_test.go`.

## Fresh baseline vs updated results

Command:

```sh
go test ./internal/ui -run '^$' \
  -bench '^BenchmarkTUIStreamingRender/(FastPath|ListHeavy|EarlyUnsafe)/blocks=(128|512)$' \
  -benchtime=1x -count=3
```

Baseline production code is `fa017215` with the extended benchmark harness applied; updated code is `e6fe4ebd`. Values are medians of three runs.

| workload | blocks | baseline ns/op | updated ns/op | time change | baseline B/op | updated B/op | bytes change | baseline allocs/op | updated allocs/op | alloc change |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| FastPath | 128 | 95,644,772 | 10,990,666 | 88.51% better | 70,114,512 | 14,817,424 | 78.87% better | 617,093 | 54,187 | 91.22% better |
| FastPath | 512 | 1,577,654,273 | 70,224,882 | 95.55% better | 1,178,661,000 | 113,686,216 | 90.35% better | 10,818,826 | 219,381 | 97.97% better |
| ListHeavy | 128 | 351,131,888 | 343,874,804 | 2.07% better | 229,815,968 | 229,309,288 | 0.22% better | 2,486,697 | 2,486,314 | 0.02% better |
| ListHeavy | 512 | 5,322,818,117 | 5,373,469,853 | 0.95% slower | 3,642,841,040 | 3,607,684,776 | 0.97% better | 39,120,621 | 39,119,101 | ~unchanged |
| EarlyUnsafe | 128 | 211,002,513 | 219,231,132 | 3.90% slower | 131,466,984 | 127,436,312 | 3.07% better | 1,433,704 | 1,433,260 | 0.03% better |
| EarlyUnsafe | 512 | 3,120,068,590 | 3,148,370,197 | 0.91% slower | 1,995,984,192 | 1,868,844,896 | 6.37% better | 21,862,104 | 21,860,550 | 0.01% better |

The expanded results make the scope clear: safe incremental Markdown gets the large win, while list-heavy and early-unsafe documents intentionally retain full-document behavior. Their timing deltas are small/noisy, with no meaningful allocation-count regression and modest byte reductions in the early-unsafe case.

### Machine/runtime caveats

- Intel Core i9-14900K, 32 logical CPUs
- Linux amd64
- Go `go1.26.5-X:nodwarf5`
- dynamic CPU frequency scaling enabled; no CPU pinning or benchmark isolation
- `-benchtime=1x` is intentional because fallback-heavy 512-block replays take several seconds
- allocation data is the more deterministic signal; frame percentiles are useful local tail indicators but are noisier than `ns/op`

## Retained optimizations

- Render the first flowing preview of a safe block locally and join it to the committed snapshot; blockquotes, references, raw HTML, setext/list/indent-sensitive content, and the one-way `incrementalUnsafe` latch retain the full-document fallback.
- Commit conservatively validated top-level tables through the block-local path; pseudo-tables and unsafe documents fall back.
- Grow `lastCommittedRendered` in place for safe committed blocks.
- Give applied snapshots stable ownership and use the `StreamRenderer` snapshot as `TextSegmentRenderer`'s source of truth instead of mirroring the response in a second buffer.
- Convert only the ANSI-safe unflushed suffix to a string for View rendering.
- Reuse already-built current-block content when checking the first pending line.

## Correctness and verification

Coverage includes direct-render parity, committed-boundary parity, CommonMark, partial previews, genuine/pseudo tables, stable renderer/snapshot ownership, flush/scrollback, ANSI-safe slicing, resize, and chat streaming.

Commands run:

```sh
go test ./internal/ui/streaming ./internal/ui ./internal/render/chat ./internal/render/markdown

go test ./internal/ui -run '^$' \
  -bench '^BenchmarkTUIStreamingRender/(FastPath|ListHeavy|EarlyUnsafe)/blocks=(128|512)$' \
  -benchtime=1x -count=3

XDG_CONFIG_HOME=/tmp/term-llm-test-empty go test ./...
XDG_CONFIG_HOME=/tmp/term-llm-test-empty go build ./...
```

The isolated `XDG_CONFIG_HOME` prevents host skill configuration from interfering with request-directory fixtures. No deployment or installed-binary update was performed.


## Disposable exhaustive streaming-parity audit

A follow-up audit compared this branch against merge base `f3b9ef7c02a774546bc8c2cc8af76465d1eae1cc` with the same disposable driver. The driver was removed after use.

Corpus and execution totals per revision:

- 687 documents / 20,501 source bytes: all 652 CommonMark `spec.json` examples, all 7 streaming corpus documents, 12 GFM/table fixtures, and 16 adversarial documents
- both normal and partial-flowing modes
- 67,280 renderer cases: 1,374 byte-by-byte cases, all 35,678 non-empty two-way split cases for documents up to 512 bytes, and 30,228 line/fixed/adversarial/targeted/random chunk cases
- 291,176 writes / 3,155,242 streamed bytes
- 291,176 committed-prefix direct-render checks, 145,588 partial safe-prefix checks, 291,176 snapshot/output accounting checks, 291,176 prior-snapshot ownership checks, 986,032 UTF-8 checks, and 986,032 ANSI-integrity checks
- 67,280 explicit `Flush` calls and 67,280 subsequent `Close` calls

The audit found one PR regression: while the final Fable pipe-prose/table render was correct, the flowing preview could temporarily insert a top-level blank separator between adjacent pipe-bearing prose lines. It also affected whitespace immediately following a committed block. Commit `677a03d1` conservatively limits block-local partial joining to non-empty renders after an actual blank-line boundary and adds a permanent Fable-shaped regression test.

After that fix, PR head and merge base had identical partial safe-prefix discrepancy locations and bytes. Those 7,978 observations reduce to two pre-existing preview-only issues (2,646 stale previews when the safe point shrinks to zero; 5,332 context-sensitive suffix-reuse mismatches, especially reference definitions). Both settle to exact direct output on Flush/Close; they were not folded into this performance PR. The merge base also mutated previously returned internal snapshots in 29,248 write observations and 5,513 flush observations; PR head had zero such ownership failures, consistent with this PR's new stable snapshot contract.

Additional verification included the same audit under `GODEBUG=checkptr=2` and `go test -race`, a byte-stream/MarkFlushed/Resize audit of `TextSegmentRenderer`, both streaming fuzz targets for 20 seconds on both revisions, targeted renderer tests under race/checkptr, `go test ./...`, and `go build ./...`. No race/checkptr, final parity, committed parity, UTF-8, ANSI, output accounting, MarkFlushed, Resize, build, or ordinary test failures remained. No installed binary was updated.
