### PR TITLE
fix: Side-question streaming rebuilds the full response string on every delta

### DIFF
--- a/cmd/serve_side_question.go
+++ b/cmd/serve_side_question.go
@@ -31,7 +31,7 @@ type sideQuestionRuntime struct {
 	reasoningEffort string
 	reasoningMode   string
 	question        string
-	response        string
+	response        []byte
 	synthetic       bool
 	usage           llm.Usage
 	totalUsage      llm.Usage
@@ -153,7 +153,7 @@ func (sq *sideQuestionRuntime) backup() sideQuestionStateBackup {
 		history: append([]sidequestion.Entry(nil), sq.history...), mainSnapshot: sidequestion.CloneMessages(sq.mainSnapshot),
 		snapshotReady: sq.snapshotReady, context: sidequestion.CloneMessages(sq.context), providerKey: sq.providerKey,
 		model: sq.model, reasoningEffort: sq.reasoningEffort, reasoningMode: sq.reasoningMode,
-		question: sq.question, response: sq.response, synthetic: sq.synthetic, usage: sq.usage, lastError: sq.lastError,
+		question: sq.question, response: string(sq.response), synthetic: sq.synthetic, usage: sq.usage, lastError: sq.lastError,
 	}
 }
 
@@ -166,7 +166,8 @@ func (sq *sideQuestionRuntime) restore(backup sideQuestionStateBackup) {
 	sq.context = sidequestion.CloneMessages(backup.context)
 	sq.providerKey, sq.model = backup.providerKey, backup.model
 	sq.reasoningEffort, sq.reasoningMode = backup.reasoningEffort, backup.reasoningMode
-	sq.question, sq.response = backup.question, backup.response
+	sq.question = backup.question
+	sq.response = append(sq.response[:0], backup.response...)
 	sq.synthetic, sq.usage, sq.lastError = backup.synthetic, backup.usage, backup.lastError
 }
 
@@ -174,7 +175,7 @@ func (sq *sideQuestionRuntime) view() sideQuestionView {
 	sq.mu.Lock()
 	defer sq.mu.Unlock()
 	return sideQuestionView{
-		Running: sq.running, Question: sq.question, Response: sq.response,
+		Running: sq.running, Question: sq.question, Response: string(sq.response),
 		Synthetic: sq.synthetic, Usage: sq.usage, TotalUsage: sq.totalUsage, Requests: sq.requestCount, Error: sq.lastError,
 		Generation: sq.generation, History: append([]sidequestion.Entry(nil), sq.history...),
 	}
@@ -200,7 +201,7 @@ func (sq *sideQuestionRuntime) cancelActive() {
 	sq.generation++
 	sq.running = false
 	sq.cancel = nil
-	sq.response = ""
+	sq.response = nil
 	sq.lastError = ""
 	sq.mu.Unlock()
 	if cancel != nil {
@@ -213,7 +214,7 @@ func (sq *sideQuestionRuntime) clearHistory() {
 	sq.mu.Lock()
 	sq.history = nil
 	sq.question = ""
-	sq.response = ""
+	sq.response = nil
 	sq.synthetic = false
 	sq.usage = llm.Usage{}
 	sq.lastError = ""
@@ -360,7 +361,7 @@ func (rt *serveRuntime) startSideQuestion(input sideQuestionStart) (<-chan sideQ
 	sq.cancel = cancel
 	sq.done = done
 	sq.question = question
-	sq.response = ""
+	sq.response = nil
 	sq.synthetic = false
 	sq.usage = llm.Usage{}
 	sq.lastError = ""
@@ -384,9 +385,9 @@ func (rt *serveRuntime) startSideQuestion(input sideQuestionStart) (<-chan sideQ
 			if generation == sq.generation {
 				switch event.Type {
 				case llm.EventTextDelta:
-					sq.response += event.Text
+					sq.response = append(sq.response, event.Text...)
 				case llm.EventAttemptDiscard:
-					sq.response = ""
+					sq.response = sq.response[:0]
 				}
 			}
 			sq.mu.Unlock()
@@ -407,18 +408,19 @@ func (rt *serveRuntime) startSideQuestion(input sideQuestionStart) (<-chan sideQ
 			sq.cancel = nil
 			sq.usage = result.Usage
 			if errors.Is(runErr, context.Canceled) {
-				sq.response = ""
+				sq.response = nil
 			} else if runErr != nil {
 				sq.lastError = runErr.Error()
 			} else {
-				sq.response = result.Response
 				sq.synthetic = result.Synthetic
 				if !result.Synthetic && strings.TrimSpace(result.Response) != "" {
 					sq.history = sidequestion.AppendHistory(sq.history, sidequestion.Entry{
 						Question: question, Response: result.Response, CreatedAt: time.Now(), Usage: result.Usage,
 					})
 					sq.question = ""
-					sq.response = ""
+					sq.response = nil
+				} else {
+					sq.response = append(sq.response[:0], result.Response...)
 				}
 			}
 		}

--- a/cmd/serve_side_question_test.go
+++ b/cmd/serve_side_question_test.go
@@ -719,25 +719,49 @@ func (s *stubbornSideStream) Recv() (llm.Event, error) {
 }
 func (*stubbornSideStream) Close() error { return nil }
 
-type burstSideProvider struct{}
-
-func (burstSideProvider) Name() string                   { return "burst" }
-func (burstSideProvider) Credential() string             { return "test" }
-func (burstSideProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
-func (burstSideProvider) Stream(context.Context, llm.Request) (llm.Stream, error) {
-	return &burstSideStream{}, nil
+type burstSideProvider struct {
+	deltas int
 }
 
-type burstSideStream struct{ index int }
+func (p burstSideProvider) Name() string                   { return "burst" }
+func (p burstSideProvider) Credential() string             { return "test" }
+func (p burstSideProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+func (p burstSideProvider) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	deltas := p.deltas
+	if deltas == 0 {
+		deltas = 100
+	}
+	return &burstSideStream{remaining: deltas}, nil
+}
+
+type burstSideStream struct{ remaining int }
 
 func (s *burstSideStream) Recv() (llm.Event, error) {
-	if s.index == 100 {
+	if s.remaining == 0 {
 		return llm.Event{}, io.EOF
 	}
-	s.index++
+	s.remaining--
 	return llm.Event{Type: llm.EventTextDelta, Text: "x"}, nil
 }
 func (*burstSideStream) Close() error { return nil }
+
+func BenchmarkStartSideQuestionTextDeltas(b *testing.B) {
+	const deltas = 10_000
+	provider := burstSideProvider{deltas: deltas}
+	b.ReportAllocs()
+	b.SetBytes(deltas)
+	for b.Loop() {
+		rt := &serveRuntime{providerKey: "burst", defaultModel: "m"}
+		rt.configureSideQuestionContext()
+		rt.sideProviderFactory = func(_, _ string) (llm.Provider, error) { return provider, nil }
+		events, err := rt.startSideQuestion(sideQuestionStart{Question: "question"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		for range events {
+		}
+	}
+}
 
 func TestServeSideQuestionTerminalEventSurvivesBackpressure(t *testing.T) {
 	rt := &serveRuntime{providerKey: "burst", defaultModel: "m"}


### PR DESCRIPTION
## What changed

- Store the live side-question response as an appendable byte slice instead of an immutable string.
- Append text deltas into that buffer and reset its length on an attempt discard.
- Materialize a string only when taking a side-question view or backup, while releasing the buffer when the response is cleared.
- Add a benchmark that streams 10,000 one-byte deltas through `startSideQuestion`.

## Why this is high-value

Side questions are streamed on the user-facing web path. Previously, every delta used string concatenation while holding the side-question mutex, allocating and copying the full response accumulated so far. Token-sized deltas therefore caused quadratic copying, extra GC pressure, and progressively longer lock holds while the user was waiting for the answer.

Appending to a byte slice grows amortized linearly and keeps string materialization off the per-delta path. In the 10,000-delta benchmark, the fix reduced time from about 9.67 ms/op to 0.72 ms/op, allocated bytes from 53.3 MB/op to 137 KB/op, and allocations from 10,044/op to 52/op.

## Validation

- `gofmt -w cmd/serve_side_question.go cmd/serve_side_question_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME="$(mktemp -d)" go test ./...`
- `go test ./cmd -run 'TestServeSideQuestion|TestReplaceHistoryFailureRestoresSideQuestionState' -count=1`
- `go test ./cmd -run '^$' -bench '^BenchmarkStartSideQuestionTextDeltas$' -benchmem -benchtime=5x -count=1`
- `git diff --check`

The isolated XDG config prevents locally installed user skills from affecting two unrelated skill-visibility tests.
