### PR TITLE
fix: Guardian serializes parallel shell approvals across full provider round-trips

### DIFF
--- a/cmd/guardian_wiring.go
+++ b/cmd/guardian_wiring.go
@@ -16,6 +16,8 @@ import (
 
 var newGuardianProviderByName = llm.NewProviderByName
 
+const guardianReviewerPoolSize = 3
+
 func preflightHeadlessApproval(cfg *config.Config, resolved resolvedApprovalMode, providerName, modelName string) error {
 	if resolved.Mode != tools.ModeAuto {
 		return nil
@@ -122,16 +124,39 @@ func installGuardianReviewerCallbacks(cfg *config.Config, approvalMgr *tools.App
 		}
 		return fmt.Errorf("load guardian policy: %w", err)
 	}
-	reviewer := &guardian.Reviewer{Provider: reviewProvider, Model: model, Policy: policy}
-	if cfg.Guardian.TimeoutSeconds > 0 {
-		reviewer.Timeout = time.Duration(cfg.Guardian.TimeoutSeconds) * time.Second
+	reviewers := make([]*guardian.Reviewer, 0, guardianReviewerPoolSize)
+	for i := 0; i < guardianReviewerPoolSize; i++ {
+		provider := reviewProvider
+		if i > 0 {
+			provider, err = newGuardianProviderByName(cfg, guardianName, model)
+			if err != nil {
+				approvalMgr.PolicyReviewFunc = nil
+				if approvalMgr.ApprovalMode() == tools.ModeAuto {
+					approvalMgr.SetApprovalMode(tools.ModePrompt)
+				}
+				return fmt.Errorf("guardian provider: %w", err)
+			}
+			if provider == nil {
+				approvalMgr.PolicyReviewFunc = nil
+				if approvalMgr.ApprovalMode() == tools.ModeAuto {
+					approvalMgr.SetApprovalMode(tools.ModePrompt)
+				}
+				return fmt.Errorf("auto approval requires an LLM provider")
+			}
+		}
+		reviewer := &guardian.Reviewer{Provider: provider, Model: model, Policy: policy}
+		if cfg.Guardian.TimeoutSeconds > 0 {
+			reviewer.Timeout = time.Duration(cfg.Guardian.TimeoutSeconds) * time.Second
+		}
+		reviewers = append(reviewers, reviewer)
 	}
+	reviewerPool := guardian.NewReviewerPool(reviewers...)
 	approvalMgr.PolicyReviewFunc = func(ctx context.Context, req tools.PolicyReviewRequest) (tools.PolicyDecision, error) {
 		transcript := make([]guardian.TranscriptEntry, 0, len(req.Transcript))
 		for _, e := range req.Transcript {
 			transcript = append(transcript, guardian.TranscriptEntry{Role: e.Role, Text: e.Text})
 		}
-		decision, err := reviewer.Review(ctx, guardian.Request{Command: req.Command, WorkDir: req.WorkDir, Transcript: transcript, ApprovalContext: req.ApprovalContext, ScopeID: req.ScopeID})
+		decision, err := reviewerPool.Review(ctx, guardian.Request{Command: req.Command, WorkDir: req.WorkDir, Transcript: transcript, ApprovalContext: req.ApprovalContext, ScopeID: req.ScopeID})
 		result := tools.PolicyDecision{Allowed: decision.Allowed(), RiskLevel: decision.RiskLevel, UserAuthorization: decision.UserAuthorization, Rationale: decision.Rationale, Model: decision.Model, Usage: decision.Usage}
 		if err != nil {
 			return result, err

--- a/cmd/guardian_wiring_test.go
+++ b/cmd/guardian_wiring_test.go
@@ -20,6 +20,13 @@ type deadlineCapturingProvider struct {
 	ok       bool
 }
 
+type delayedGuardianProvider struct {
+	delegate *llm.MockProvider
+	started  chan<- struct{}
+	release  <-chan struct{}
+	delay    time.Duration
+}
+
 func withGuardianProviderFactory(t *testing.T, fn func(*config.Config, string, string) (llm.Provider, error)) {
 	t.Helper()
 	orig := newGuardianProviderByName
@@ -36,6 +43,34 @@ func (p *deadlineCapturingProvider) Capabilities() llm.Capabilities {
 }
 func (p *deadlineCapturingProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
 	p.deadline, p.ok = ctx.Deadline()
+	return p.delegate.Stream(ctx, req)
+}
+
+func (p *delayedGuardianProvider) Name() string { return "delayed-guardian" }
+func (p *delayedGuardianProvider) Credential() string {
+	return "mock"
+}
+func (p *delayedGuardianProvider) Capabilities() llm.Capabilities {
+	return p.delegate.Capabilities()
+}
+func (p *delayedGuardianProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	select {
+	case p.started <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-p.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	timer := time.NewTimer(p.delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	return p.delegate.Stream(ctx, req)
 }
 
@@ -177,6 +212,69 @@ func TestInstallGuardianReviewerCallbacksUsesDefaultTimeoutWhenUnset(t *testing.
 		t.Fatalf("PolicyReviewFunc: %v", err)
 	}
 	assertDeadlineNear(t, provider.deadline, provider.ok, guardian.DefaultTimeout)
+}
+
+func TestInstallGuardianReviewerCallbacksRunsParallelReviewsConcurrently(t *testing.T) {
+	const providerDelay = 200 * time.Millisecond
+	started := make(chan struct{}, guardianReviewerPoolSize)
+	release := make(chan struct{})
+	factoryCalls := 0
+	withGuardianProviderFactory(t, func(*config.Config, string, string) (llm.Provider, error) {
+		factoryCalls++
+		return &delayedGuardianProvider{
+			delegate: llm.NewMockProvider("mock").AddTextResponse(`{"risk_level":"low","user_authorization":"high","outcome":"allow","rationale":"safe"}`),
+			started:  started,
+			release:  release,
+			delay:    providerDelay,
+		}, nil
+	})
+	mgr := tools.NewApprovalManager(tools.NewToolPermissions())
+	cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+	if err := installGuardianReviewerCallbacks(cfg, mgr, "mock", "mock-model", true); err != nil {
+		t.Fatalf("installGuardianReviewerCallbacks: %v", err)
+	}
+	if factoryCalls != guardianReviewerPoolSize {
+		t.Fatalf("provider factory calls = %d, want %d independent reviewers", factoryCalls, guardianReviewerPoolSize)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	errs := make(chan error, guardianReviewerPoolSize)
+	commands := []string{"echo one", "echo two", "echo three"}
+	start := time.Now()
+	for _, command := range commands {
+		go func() {
+			decision, err := mgr.PolicyReviewFunc(ctx, tools.PolicyReviewRequest{Command: command})
+			if err == nil && !decision.Allowed {
+				err = errors.New("guardian unexpectedly denied command")
+			}
+			errs <- err
+		}()
+	}
+
+	allStarted := true
+	for range commands {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			allStarted = false
+		}
+		if !allStarted {
+			break
+		}
+	}
+	close(release)
+	for range commands {
+		if err := <-errs; err != nil {
+			t.Fatalf("PolicyReviewFunc: %v", err)
+		}
+	}
+	if !allStarted {
+		t.Fatal("parallel reviews did not reach independent providers concurrently")
+	}
+	if elapsed := time.Since(start); elapsed >= 2*providerDelay {
+		t.Fatalf("parallel reviews took %v, want near one %v provider delay", elapsed, providerDelay)
+	}
 }
 
 func TestInstallGuardianReviewerCallbacksUsesPassedProviderNameWhenGuardianUnset(t *testing.T) {

--- a/internal/guardian/guardian.go
+++ b/internal/guardian/guardian.go
@@ -71,6 +71,51 @@ type Reviewer struct {
 	reviewTurnCount       int
 }
 
+// ReviewerPool bounds concurrent reviews while keeping each provider and its
+// conversation state isolated. Idle reviewers are reused in LIFO order so the
+// usual sequential path keeps using its warm delta session.
+type ReviewerPool struct {
+	mu    sync.Mutex
+	idle  []*Reviewer
+	slots chan struct{}
+}
+
+func NewReviewerPool(reviewers ...*Reviewer) *ReviewerPool {
+	pool := &ReviewerPool{}
+	for _, reviewer := range reviewers {
+		if reviewer != nil {
+			pool.idle = append(pool.idle, reviewer)
+		}
+	}
+	pool.slots = make(chan struct{}, len(pool.idle))
+	return pool
+}
+
+func (p *ReviewerPool) Review(ctx context.Context, req Request) (Decision, error) {
+	if p == nil || cap(p.slots) == 0 {
+		return Decision{}, fmt.Errorf("guardian reviewer pool is empty")
+	}
+	select {
+	case p.slots <- struct{}{}:
+	case <-ctx.Done():
+		return Decision{}, ctx.Err()
+	}
+
+	p.mu.Lock()
+	last := len(p.idle) - 1
+	reviewer := p.idle[last]
+	p.idle = p.idle[:last]
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.idle = append(p.idle, reviewer)
+		p.mu.Unlock()
+		<-p.slots
+	}()
+	return reviewer.Review(ctx, req)
+}
+
 func (r *Reviewer) Review(ctx context.Context, req Request) (Decision, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
## What changed

- Added a bounded pool of three Guardian reviewers, each backed by an independently constructed provider.
- Dispatches concurrent policy reviews to separate reviewers instead of holding one reviewer's mutex across every provider round-trip.
- Reuses idle reviewers in LIFO order so ordinary sequential reviews continue using a warm delta-session cache.
- Added an installed-callback concurrency test with three independent delayed providers; all three reviews must enter their provider concurrently and finish in roughly one provider delay.

## Why this is high-value

Auto-approved shell calls are on Jarvis's normal agent path. Distinct first-time commands miss deterministic and exact-command approvals, and parallel tool scheduling can issue several such reviews together. Previously all of those reviews shared one `guardian.Reviewer`, whose mutex is intentionally held for conversation-state safety across the entire streamed provider response. Three parallel approvals therefore incurred roughly three sequential provider round-trips and could make the run appear stuck.

The pool preserves per-reviewer conversation serialization and provider isolation while allowing up to three common parallel misses to overlap. This changes their approval latency from approximately N provider delays to one provider delay for N <= 3, without changing deterministic approval fast paths or Guardian decisions.

## Validation

- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `go test -race ./internal/guardian ./cmd -run 'TestInstallGuardianReviewerCallbacksRunsParallelReviewsConcurrently|TestReviewerManagedProviderUsesFullThenDeltaTurns' -count=1`
- `go test ./cmd -run TestInstallGuardianReviewerCallbacksRunsParallelReviewsConcurrently -count=10`
- `git diff --check`
