### PR TITLE
fix: Chat starts MCP servers before installing their sampling handler

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -627,6 +627,9 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to load MCP config: %v\n", err)
 	}
 
+	// Set up MCP sampling provider before enabling servers so clients advertise sampling support.
+	mcpManager.SetSamplingProvider(provider, modelName, resolvedYolo)
+
 	// Enable MCP servers
 	if settings.MCP != "" {
 		servers := strings.Split(settings.MCP, ",")
@@ -640,9 +643,6 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 			}
 		}
 	}
-
-	// Set up MCP sampling provider (for sampling/createMessage requests)
-	mcpManager.SetSamplingProvider(provider, modelName, resolvedYolo)
 
 	// Resolve force external search setting
 	forceExternalSearch := resolveForceExternalSearch(cfg, chatNativeSearch, chatNoNativeSearch)


### PR DESCRIPTION
## What changed

Install the interactive chat MCP sampling provider immediately after loading MCP configuration and before enabling any configured MCP servers.

This preserves the existing manager and client behavior while ensuring startup-created clients receive a sampling handler before they build their MCP client options.

## Why this is high-value

`Manager.Enable` creates each MCP client immediately and copies the manager's current sampling handler into it. Previously, chat configured the handler only after enabling its startup servers, and `SetSamplingProvider` does not update those already-created clients. As a result, MCP servers selected at chat startup did not advertise sampling support and could not complete `sampling/createMessage` workflows. Manually enabled servers worked, masking the deterministic startup-path failure.

## Validation

- `gofmt -w cmd/chat.go`
- `go build ./...`
- `XDG_CONFIG_HOME=<isolated temp dir> go test ./...`
- `git diff --check`

The first unisolated test run discovered Jarvis's user-global skills and failed two unrelated skill-selection tests; rerunning with an isolated config home passed the full suite.
