### PR TITLE
fix: Exited MCP servers remain permanently marked ready

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -185,6 +185,34 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
 }
 
+func (c *Client) currentSession() *mcp.ClientSession {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.session
+}
+
+// clearTerminatedSession clears a session only if it is still the active one.
+// This prevents a watcher for an old session from disrupting a restarted client.
+func (c *Client) clearTerminatedSession(session *mcp.ClientSession) bool {
+	c.mu.Lock()
+	if c.session != session || !c.running {
+		c.mu.Unlock()
+		return false
+	}
+
+	processCancel := c.processCancel
+	c.session = nil
+	c.processCancel = nil
+	c.running = false
+	c.tools = nil
+	c.mu.Unlock()
+
+	if processCancel != nil {
+		processCancel()
+	}
+	return true
+}
+
 // Stop closes the MCP server connection.
 func (c *Client) Stop() error {
 	c.mu.Lock()

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/samsaffron/term-llm/internal/llm"
 )
 
@@ -126,11 +127,14 @@ func (m *Manager) GetSamplingHandler() *SamplingHandler {
 // sendStatus sends a status update if a channel is configured.
 func (m *Manager) sendStatus(name string, status ServerStatus, err error) {
 	m.mu.RLock()
-	ch := m.statusChan
-	m.mu.RUnlock()
-	if ch != nil {
+	defer m.mu.RUnlock()
+	m.sendStatusLocked(name, status, err)
+}
+
+func (m *Manager) sendStatusLocked(name string, status ServerStatus, err error) {
+	if m.statusChan != nil {
 		select {
-		case ch <- StatusUpdate{Name: name, Status: status, Error: err}:
+		case m.statusChan <- StatusUpdate{Name: name, Status: status, Error: err}:
 		default:
 			// Don't block if channel is full
 		}
@@ -264,9 +268,35 @@ func (m *Manager) Enable(ctx context.Context, name string) error {
 		m.mu.Unlock()
 
 		m.sendStatus(name, status, err)
+		if err == nil {
+			session := client.currentSession()
+			if session != nil {
+				go m.watchSession(name, client, session)
+			}
+		}
 	}()
 
 	return nil
+}
+
+func (m *Manager) watchSession(name string, client *Client, session *sdkmcp.ClientSession) {
+	err := session.Wait()
+	if err == nil {
+		err = fmt.Errorf("MCP server %s session ended", name)
+	} else {
+		err = fmt.Errorf("MCP server %s session ended: %w", name, err)
+	}
+
+	m.mu.Lock()
+	state, ok := m.statuses[name]
+	if !ok || state.Status != StatusReady || state.Client != client || m.clients[name] != client || !client.clearTerminatedSession(session) {
+		m.mu.Unlock()
+		return
+	}
+	state.Status = StatusFailed
+	state.Error = err
+	m.sendStatusLocked(name, StatusFailed, err)
+	m.mu.Unlock()
 }
 
 // Disable stops an MCP server.

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -61,6 +61,10 @@ func runMCPManagerTestServer() {
 			IsError: true,
 		}, nil, nil
 	})
+	mcpSDK.AddTool(server, &mcpSDK.Tool{Name: "crash", Description: "exit without closing the session"}, func(ctx context.Context, req *mcpSDK.CallToolRequest, args struct{}) (*mcpSDK.CallToolResult, any, error) {
+		os.Exit(42)
+		return nil, nil, nil
+	})
 	mcpSDK.AddTool(server, &mcpSDK.Tool{Name: "blocking", Description: "block until the request is cancelled"}, func(ctx context.Context, req *mcpSDK.CallToolRequest, args managerTestBlockingParams) (*mcpSDK.CallToolResult, any, error) {
 		if err := os.WriteFile(args.StartedPath, nil, 0600); err != nil {
 			return nil, nil, err
@@ -188,6 +192,80 @@ func TestManagerEnable_ReadyStdioServerSurvivesStartupTimeoutContext(t *testing.
 	_, err = manager.CallTool(context.Background(), "greeter__greet", json.RawMessage("{"))
 	if err == nil || !strings.Contains(err.Error(), "invalid tool arguments") {
 		t.Fatalf("malformed arguments error = %v, want invalid tool arguments", err)
+	}
+}
+
+func TestManagerExitedServerBecomesFailedAndCanRestart(t *testing.T) {
+	manager := NewManager()
+	manager.config = &Config{Servers: map[string]ServerConfig{
+		"crasher": {
+			Command: os.Args[0],
+			Env: map[string]string{
+				runMCPManagerTestServerEnv: "1",
+			},
+		},
+	}}
+	statusUpdates := make(chan StatusUpdate, 10)
+	manager.SetStatusChannel(statusUpdates)
+	defer manager.StopAll()
+
+	if err := manager.Enable(context.Background(), "crasher"); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	status, err := waitForServerStatus(t, manager, "crasher", StatusReady, 3*time.Second)
+	if status != StatusReady || err != nil {
+		t.Fatalf("server status = %s, error = %v; want ready", status, err)
+	}
+	if len(manager.AllTools()) == 0 {
+		t.Fatal("ready server did not advertise tools")
+	}
+
+	if _, err := manager.CallTool(context.Background(), "crasher__crash", nil); err == nil {
+		t.Fatal("crash tool unexpectedly returned without an error")
+	}
+
+	status, err = waitForServerStatus(t, manager, "crasher", StatusFailed, 3*time.Second)
+	if status != StatusFailed || err == nil {
+		t.Fatalf("server status = %s, error = %v; want failed with terminal error", status, err)
+	}
+	if tools := manager.AllTools(); len(tools) != 0 {
+		t.Fatalf("AllTools after server exit = %#v, want no tools", tools)
+	}
+
+	failedUpdate := false
+	deadline := time.After(3 * time.Second)
+	for !failedUpdate {
+		select {
+		case update := <-statusUpdates:
+			if update.Name == "crasher" && update.Status == StatusFailed {
+				if update.Error == nil {
+					t.Fatal("failed status update had no terminal error")
+				}
+				failedUpdate = true
+			}
+		case <-deadline:
+			t.Fatal("did not receive failed status update")
+		}
+	}
+
+	if err := manager.Restart(context.Background(), "crasher"); err != nil {
+		t.Fatalf("Restart returned error: %v", err)
+	}
+	status, err = waitForServerStatus(t, manager, "crasher", StatusReady, 3*time.Second)
+	if status != StatusReady || err != nil {
+		t.Fatalf("restarted server status = %s, error = %v; want ready", status, err)
+	}
+
+	args, err := json.Marshal(map[string]string{"name": "Grace"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	got, err := manager.CallTool(context.Background(), "crasher__greet", args)
+	if err != nil {
+		t.Fatalf("CallTool after restart: %v", err)
+	}
+	if !strings.Contains(got.Content, "hi Grace") {
+		t.Fatalf("CallTool result after restart = %q, want greeting", got.Content)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Start a watcher on each successfully initialized MCP `ClientSession` using the SDK's `ClientSession.Wait` API.
- When the active session terminates unexpectedly, clear that exact client's running session and cached tools, mark the server failed with the terminal error, and emit a failed status update.
- Guard the transition by both client and session identity so an old watcher cannot overwrite an explicit disable or a restarted server.
- Add an integration test whose stdio MCP helper exits during a tool call, then verify the server becomes failed, its tools disappear, a failed update is emitted, and `Restart` restores a working tool.

## Why this is high-value

Long-running TUI, web, Telegram, and jobs runtimes reuse one MCP manager. Previously, a stdio MCP process that crashed after initialization remained permanently `ready`, so every subsequent call failed while the dead server's tools continued to be advertised. Detecting the SDK session's terminal state makes the failure visible immediately and restores the existing safe restart path without retrying an ambiguous tool call.

## Validation

- `gofmt -w internal/mcp/client.go internal/mcp/manager.go internal/mcp/manager_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `go test -race ./internal/mcp -run 'TestManager(ExitedServerBecomesFailedAndCanRestart|Enable_ReadyStdioServerSurvivesStartupTimeoutContext|CallToolConcurrentDisable)' -count=5`
- `git diff --check`
