### PR TITLE
fix: harden long-running web sessions

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -442,6 +442,28 @@ func TestWorktreePopoverUsesResponsiveChipUI(t *testing.T) {
 	}
 }
 
+func TestAppWebRTCJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping JS app-webrtc tests")
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "app_webrtc_test.js")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("app_webrtc_test.js not found at %s: %v", script, err)
+	}
+
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("app_webrtc_test.js failed: %v", err)
+	}
+}
+
 func TestAppWebRTCDoesNotReferenceLexicalApp(t *testing.T) {
 	webrtcJS, err := StaticAsset("app-webrtc.js")
 	if err != nil {

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -765,6 +765,7 @@ func TestStaticAssetsSupportIncrementalMarkdownStreaming(t *testing.T) {
 		"function nextStreamingRenderDelay(",
 		"function areMathDelimitersBalanced(",
 		"function findStableMarkdownBoundary(",
+		"function analyzeStableMarkdownBoundary(",
 		"function canStreamPlainTextTail(",
 	} {
 		if !strings.Contains(streamingSrc, want) {
@@ -780,7 +781,7 @@ func TestStaticAssetsSupportIncrementalMarkdownStreaming(t *testing.T) {
 	for _, want := range []string{
 		"const enqueueAssistantStreamUpdate = (message) => {",
 		"const finalizeAssistantStreamRender = (message) => {",
-		"const renderAssistantTailPlainText = (streamState, tail) => {",
+		"const renderAssistantTailPlainText = (streamState, tail, mode = 'plain') => {",
 		"markdown-stream-stable",
 	} {
 		if !strings.Contains(renderSrc, want) {

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -2040,8 +2040,17 @@ const loadSessions = () => {
 // after switchToSession() saves state.
 const MAX_CACHED_MESSAGE_SESSIONS = 10;
 
+const sessionHasCachedTranscript = (session) => Boolean(
+  session
+  && !session._serverOnly
+  && (
+    (Array.isArray(session.messages) && session.messages.length > 0)
+    || (Array.isArray(session._history?.rawMessages) && session._history.rawMessages.length > 0)
+  )
+);
+
 const evictStaleSessionMessages = () => {
-  const withMessages = state.sessions.filter(s => s.messages && s.messages.length > 0 && !s._serverOnly);
+  const withMessages = state.sessions.filter(sessionHasCachedTranscript);
   if (withMessages.length <= MAX_CACHED_MESSAGE_SESSIONS) return;
 
   const keep = new Set();
@@ -2060,10 +2069,14 @@ const evictStaleSessionMessages = () => {
     keep.add(session.id);
   }
 
-  for (const s of state.sessions) {
-    if (!keep.has(s.id) && s.messages && s.messages.length > 0) {
-      s.messages = [];
-      s._serverOnly = true;
+  for (const session of state.sessions) {
+    if (!keep.has(session.id) && sessionHasCachedTranscript(session)) {
+      session.messages = [];
+      // Converted display messages and raw server history hold duplicate copies
+      // of large transcript strings/attachments. Dropping only messages leaves
+      // the raw representation reachable, so evict the complete hydration cache.
+      delete session._history;
+      session._serverOnly = true;
     }
   }
 };

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -885,6 +885,10 @@ const syncAssistantUsageNode = (node, message) => {
 };
 
 const STREAM_STABLE_MIN_TAIL_LENGTH = 256;
+const STREAM_MARKDOWN_MUTABLE_LIMIT = Number(app.markdownStreaming?.MAX_MUTABLE_MARKDOWN_CHARS) || (64 * 1024);
+const STREAM_STABLE_GUARD_LENGTH = 64;
+const STREAM_STABLE_HASH_A_OFFSET = 0x811c9dc5;
+const STREAM_STABLE_HASH_B_OFFSET = 0x9747b28c;
 
 const createAssistantStreamContainers = (body) => {
   body.innerHTML = '';
@@ -910,8 +914,10 @@ const getOrCreateAssistantStreamState = (message, body) => {
       body: null,
       stableContainer: null,
       tailContainer: null,
-      stableSource: '',
       stableLength: 0,
+      stableHashLength: 0,
+      stableHashA: STREAM_STABLE_HASH_A_OFFSET,
+      stableHashB: STREAM_STABLE_HASH_B_OFFSET,
       latestContent: '',
       lastTailContent: '',
       lastTailSource: '',
@@ -932,18 +938,75 @@ const getOrCreateAssistantStreamState = (message, body) => {
   streamState._canPlainCached = null;
   streamState._canPlainCachedAt = 0;
   streamState._stableCheckedAt = 0;
+  streamState.plainFallback = false;
+  streamState.lastBoundaryOperations = 0;
+  streamState.stablePrefixGuard = '';
+  streamState.stableSuffixGuard = '';
+  streamState.stableHashLength = 0;
+  streamState.stableHashA = STREAM_STABLE_HASH_A_OFFSET;
+  streamState.stableHashB = STREAM_STABLE_HASH_B_OFFSET;
   streamState.turnPanelSynced = false;
   assistantStreamStates.set(message.id, streamState);
   return streamState;
+};
+
+const advanceStableAssistantHash = (hashA, hashB, text, limit = String(text || '').length) => {
+  const value = String(text || '');
+  const end = Math.max(0, Math.min(value.length, Number(limit) || 0));
+  let nextA = Number(hashA) >>> 0;
+  let nextB = Number(hashB) >>> 0;
+  for (let index = 0; index < end; index += 1) {
+    const code = value.charCodeAt(index);
+    nextA = Math.imul(nextA ^ code, 0x01000193) >>> 0;
+    nextB = Math.imul(nextB ^ code, 0x5bd1e995) >>> 0;
+  }
+  return { hashA: nextA, hashB: nextB };
+};
+
+const stableAssistantPrefixMatches = (streamState, content) => {
+  const stableLength = Math.max(0, Number(streamState?.stableLength) || 0);
+  if (stableLength <= 0) return true;
+  if (content.length < stableLength) return false;
+  if (Number(streamState?.stableHashLength) !== stableLength) return false;
+  const prefixGuard = String(streamState?.stablePrefixGuard || '');
+  const suffixGuard = String(streamState?.stableSuffixGuard || '');
+  if (prefixGuard && content.slice(0, prefixGuard.length) !== prefixGuard) return false;
+  if (suffixGuard && content.slice(stableLength - suffixGuard.length, stableLength) !== suffixGuard) return false;
+  const fingerprint = advanceStableAssistantHash(
+    STREAM_STABLE_HASH_A_OFFSET,
+    STREAM_STABLE_HASH_B_OFFSET,
+    content,
+    stableLength
+  );
+  return fingerprint.hashA === (Number(streamState.stableHashA) >>> 0)
+    && fingerprint.hashB === (Number(streamState.stableHashB) >>> 0);
+};
+
+const updateStableAssistantFingerprint = (streamState, source, content) => {
+  const stableLength = Math.max(0, Number(streamState?.stableLength) || 0);
+  const sourceLength = String(source || '').length;
+  const previousLength = Math.max(0, stableLength - sourceLength);
+  const previousHashLength = Math.max(0, Number(streamState?.stableHashLength) || 0);
+  const initialHashA = previousHashLength === previousLength
+    ? streamState.stableHashA
+    : STREAM_STABLE_HASH_A_OFFSET;
+  const initialHashB = previousHashLength === previousLength
+    ? streamState.stableHashB
+    : STREAM_STABLE_HASH_B_OFFSET;
+  const fingerprint = advanceStableAssistantHash(initialHashA, initialHashB, source);
+  streamState.stableHashLength = stableLength;
+  streamState.stableHashA = fingerprint.hashA;
+  streamState.stableHashB = fingerprint.hashB;
+  const guardLength = Math.min(STREAM_STABLE_GUARD_LENGTH, stableLength);
+  streamState.stablePrefixGuard = content.slice(0, guardLength);
+  streamState.stableSuffixGuard = content.slice(stableLength - guardLength, stableLength);
 };
 
 const assistantStreamMutableLength = (streamState) => {
   const content = String(streamState?.latestContent || '');
   const stableLength = Math.max(0, Number(streamState?.stableLength) || 0);
   if (stableLength <= 0) return content.length;
-
-  const stableSource = String(streamState?.stableSource || '');
-  if (stableSource && !content.startsWith(stableSource)) return content.length;
+  if (!stableAssistantPrefixMatches(streamState, content)) return content.length;
   return Math.max(0, content.length - Math.min(stableLength, content.length));
 };
 
@@ -970,6 +1033,11 @@ const clearAssistantTailRender = (streamState) => {
   if (!streamState?.tailContainer) return;
   streamState.tailContainer.classList.remove('streaming-plain-text');
   streamState.tailContainer.innerHTML = '';
+  if (webUIDiagnosticsEnabled() && streamState.tailContainer.dataset) {
+    streamState.tailContainer.dataset.mutableMarkdownTailSize = '0';
+    streamState.tailContainer.dataset.streamRenderMode = 'empty';
+    streamState.tailContainer.dataset.boundaryOperations = String(Number(streamState.lastBoundaryOperations) || 0);
+  }
   streamState.tailTextNode = null;
   streamState.lastTailSource = '';
 };
@@ -979,8 +1047,14 @@ const resetAssistantStableRender = (streamState) => {
   if (streamState.stableContainer) {
     streamState.stableContainer.innerHTML = '';
   }
-  streamState.stableSource = '';
   streamState.stableLength = 0;
+  streamState.stablePrefixGuard = '';
+  streamState.stableSuffixGuard = '';
+  streamState.stableHashLength = 0;
+  streamState.stableHashA = STREAM_STABLE_HASH_A_OFFSET;
+  streamState.stableHashB = STREAM_STABLE_HASH_B_OFFSET;
+  streamState.plainFallback = false;
+  streamState.lastBoundaryOperations = 0;
   streamState.lastTailContent = '';
   streamState.lastTailSource = '';
   streamState.tailTextNode = null;
@@ -995,17 +1069,15 @@ const appendAssistantStableMarkdown = (streamState, source) => {
   piece.className = 'markdown-stream-piece';
   renderAssistantMarkdown(piece, source, { streaming: true });
   streamState.stableContainer.appendChild(piece);
-  streamState.stableSource = `${streamState.stableSource || ''}${source}`;
-  streamState.stableLength = streamState.stableSource.length;
+  streamState.stableLength = Math.max(0, Number(streamState.stableLength) || 0) + source.length;
 };
 
 const promoteAssistantStableMarkdown = (streamState, content) => {
-  if (!streamState?.stableContainer || !app.markdownStreaming || typeof app.markdownStreaming.findStableMarkdownBoundary !== 'function') {
-    return false;
+  if (!streamState?.stableContainer || !app.markdownStreaming) {
+    return { promoted: false, fallback: false };
   }
 
-  const stableSource = streamState.stableSource || '';
-  if (stableSource && !content.startsWith(stableSource)) {
+  if (!stableAssistantPrefixMatches(streamState, content)) {
     resetAssistantStableRender(streamState);
     clearAssistantTailRender(streamState);
   }
@@ -1017,17 +1089,44 @@ const promoteAssistantStableMarkdown = (streamState, content) => {
   }
 
   const uncommitted = content.slice(streamState.stableLength || 0);
-  const boundary = app.markdownStreaming.findStableMarkdownBoundary(uncommitted, STREAM_STABLE_MIN_TAIL_LENGTH);
-  if (!boundary || boundary <= 0) return false;
+  if (uncommitted.length > STREAM_MARKDOWN_MUTABLE_LIMIT) {
+    streamState.plainFallback = true;
+    return { promoted: false, fallback: true };
+  }
 
-  appendAssistantStableMarkdown(streamState, uncommitted.slice(0, boundary));
-  return true;
+  const analysis = typeof app.markdownStreaming.analyzeStableMarkdownBoundary === 'function'
+    ? app.markdownStreaming.analyzeStableMarkdownBoundary(uncommitted, STREAM_STABLE_MIN_TAIL_LENGTH)
+    : {
+        boundary: typeof app.markdownStreaming.findStableMarkdownBoundary === 'function'
+          ? app.markdownStreaming.findStableMarkdownBoundary(uncommitted, STREAM_STABLE_MIN_TAIL_LENGTH)
+          : 0,
+        operations: 0,
+        overBudget: false
+      };
+  streamState.lastBoundaryOperations = Number(analysis?.operations) || 0;
+  if (analysis?.overBudget) {
+    streamState.plainFallback = true;
+    return { promoted: false, fallback: true };
+  }
+
+  const boundary = Number(analysis?.boundary) || 0;
+  if (boundary <= 0) return { promoted: false, fallback: false };
+
+  const source = uncommitted.slice(0, boundary);
+  appendAssistantStableMarkdown(streamState, source);
+  updateStableAssistantFingerprint(streamState, source, content);
+  return { promoted: true, fallback: false };
 };
 
-const renderAssistantTailPlainText = (streamState, tail) => {
+const renderAssistantTailPlainText = (streamState, tail, mode = 'plain') => {
   const container = streamState?.tailContainer;
   if (!container) return;
   container.classList.add('streaming-plain-text');
+  if (webUIDiagnosticsEnabled() && container.dataset) {
+    container.dataset.mutableMarkdownTailSize = '0';
+    container.dataset.streamRenderMode = mode;
+    container.dataset.boundaryOperations = String(Number(streamState.lastBoundaryOperations) || 0);
+  }
 
   let textNode = streamState.tailTextNode;
   if (!textNode || textNode.parentNode !== container) {
@@ -1060,6 +1159,11 @@ const renderAssistantTailMarkdown = (streamState, tail) => {
   if (!container) return;
   container.classList.remove('streaming-plain-text');
   streamState.tailTextNode = null;
+  if (webUIDiagnosticsEnabled() && container.dataset) {
+    container.dataset.mutableMarkdownTailSize = String(tail.length);
+    container.dataset.streamRenderMode = 'markdown';
+    container.dataset.boundaryOperations = String(Number(streamState.lastBoundaryOperations) || 0);
+  }
   renderAssistantMarkdown(container, tail, { streaming: true });
   streamState.lastTailSource = tail;
 };
@@ -1102,7 +1206,7 @@ const maybePromoteAssistantStableMarkdown = (streamState, content) => {
   const prevAt = streamState._stableCheckedAt || 0;
   if (prevAt > 0 && content.length > prevAt && !content.slice(prevAt).includes('\n')) {
     streamState._stableCheckedAt = content.length;
-    return false;
+    return { promoted: false, fallback: false };
   }
   const result = promoteAssistantStableMarkdown(streamState, content);
   streamState._stableCheckedAt = content.length;
@@ -1134,11 +1238,25 @@ const performAssistantStreamRender = (streamState) => {
     }
 
     if (content) {
+      // A replacement snapshot can revise already-promoted text. Validate the
+      // complete committed prefix before either an existing or newly-triggered
+      // plain fallback slices at the old stable length, otherwise stale stable
+      // DOM and a truncated tail can survive until finalization.
+      if (!stableAssistantPrefixMatches(streamState, content)) {
+        resetAssistantStableRender(streamState);
+        clearAssistantTailRender(streamState);
+      }
+      const mutableLength = assistantStreamMutableLength(streamState);
+      if (mutableLength > STREAM_MARKDOWN_MUTABLE_LIMIT) {
+        streamState.plainFallback = true;
+      }
+
       // When stable markdown has already been promoted (stableLength > 0) the
-      // plain-text path is unreachable — skip the O(n) eligibility scan.
-      // Otherwise use the incremental cache to avoid re-scanning unchanged prefixes.
+      // ordinary plain-text path is unreachable. Oversized/over-budget tails
+      // use the same incremental text-node renderer, but stay explicitly in a
+      // sticky fallback mode until final full Markdown rendering.
       const ms = app.markdownStreaming;
-      const renderPlainTail = !(streamState.stableLength > 0) && Boolean(
+      const renderPlainTail = !streamState.plainFallback && !(streamState.stableLength > 0) && Boolean(
         ms && (
           (typeof ms.canStreamPlainTextTailIncremental === 'function'
             && ms.canStreamPlainTextTailIncremental(streamState, content))
@@ -1147,15 +1265,24 @@ const performAssistantStreamRender = (streamState) => {
         )
       );
 
-      if (renderPlainTail) {
+      if (streamState.plainFallback) {
+        const tail = content.slice(streamState.stableLength || 0);
+        if (tail !== streamState.lastTailContent) {
+          renderAssistantTailPlainText(streamState, tail, 'plain-fallback');
+          streamState.lastTailContent = tail;
+        }
+      } else if (renderPlainTail) {
         if (content !== streamState.lastTailContent) {
           renderAssistantTailPlainText(streamState, content);
           streamState.lastTailContent = content;
         }
       } else {
-        const promoted = maybePromoteAssistantStableMarkdown(streamState, content);
+        const promotion = maybePromoteAssistantStableMarkdown(streamState, content);
         const tail = content.slice(streamState.stableLength || 0);
-        if (promoted || tail !== streamState.lastTailContent) {
+        if (promotion.fallback) {
+          renderAssistantTailPlainText(streamState, tail, 'plain-fallback');
+          streamState.lastTailContent = tail;
+        } else if (promotion.promoted || tail !== streamState.lastTailContent) {
           if (tail) {
             renderAssistantTailMarkdown(streamState, tail);
           } else {
@@ -2501,7 +2628,39 @@ const updateMessageNode = (message) => {
   }
 };
 
+// Reuse the existing opt-in browser diagnostics switch; counts require a DOM
+// walk, so normal rendering pays only for the duration clock read.
+const webUIDiagnosticsEnabled = () => Boolean(
+  window.__TERM_LLM_DIAGNOSTICS__ || window.__WEBRTC_DIAGNOSTICS__
+);
+
+const renderDiagnosticsNow = () => (
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+
+const mountedElementCount = (root) => {
+  let count = 0;
+  const stack = Array.from(root?.children || []);
+  while (stack.length > 0) {
+    const node = stack.pop();
+    count += 1;
+    if (node?.children?.length) stack.push(...node.children);
+  }
+  return count;
+};
+
+const recordMountedConversationDiagnostics = (startedAt, messageCount, renderMode) => {
+  if (!webUIDiagnosticsEnabled() || !elements.messages?.dataset) return;
+  elements.messages.dataset.mountedMessageCount = String(Math.max(0, Number(messageCount) || 0));
+  elements.messages.dataset.mountedElementCount = String(mountedElementCount(elements.messages));
+  elements.messages.dataset.renderDurationMs = (renderDiagnosticsNow() - startedAt).toFixed(2);
+  elements.messages.dataset.renderMode = renderMode;
+};
+
 const renderMessages = (forceScroll = false) => {
+  const renderStartedAt = renderDiagnosticsNow();
   const session = ensureActiveSession();
   resetAssistantStreamRenders();
 
@@ -2525,6 +2684,7 @@ const renderMessages = (forceScroll = false) => {
     refreshRelativeTimes();
     scrollToBottom(forceScroll);
     updateHeader();
+    recordMountedConversationDiagnostics(renderStartedAt, messages.length, 'empty');
     return;
   }
 
@@ -2549,6 +2709,7 @@ const renderMessages = (forceScroll = false) => {
       refreshRelativeTimes();
       scrollToBottom(forceScroll);
       updateHeader();
+      recordMountedConversationDiagnostics(renderStartedAt, messages.length, 'append');
       return;
     }
   }
@@ -2600,6 +2761,7 @@ const renderMessages = (forceScroll = false) => {
     refreshRelativeTimes();
     scrollToBottom(forceScroll);
     updateHeader();
+    recordMountedConversationDiagnostics(renderStartedAt, messages.length, 'reconcile');
     return;
   }
 
@@ -2616,6 +2778,7 @@ const renderMessages = (forceScroll = false) => {
   refreshRelativeTimes();
   scrollToBottom(forceScroll);
   updateHeader();
+  recordMountedConversationDiagnostics(renderStartedAt, messages.length, 'rebuild');
 };
 
 const updateSidebarStatus = (statusSessions) => {

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -72,6 +72,13 @@ const SESSION_STATE_POLL_RETRY = 5000;
 let sidebarStatusTimer = null;
 let sidebarStatusEtag = null;
 let sidebarHasActive = false;
+let sidebarStatusPollEnabled = false;
+let sidebarStatusPollPromise = null;
+let sidebarStatusPollController = null;
+let sidebarStatusPollGeneration = 0;
+let sidebarStatusPollInFlightGeneration = -1;
+let sidebarStatusPollIsRecovery = false;
+let sidebarStatusImmediatePending = false;
 
 const refreshWidgetsSidebar = async () => {
   if (!app.renderWidgetSidebar) return;
@@ -95,16 +102,28 @@ const refreshWidgetsSidebar = async () => {
   }
 };
 
-const stopSidebarStatusPoll = () => {
+const clearSidebarStatusTimer = () => {
   if (sidebarStatusTimer !== null) {
     clearTimeout(sidebarStatusTimer);
     sidebarStatusTimer = null;
   }
 };
 
+const stopSidebarStatusPoll = () => {
+  sidebarStatusPollEnabled = false;
+  sidebarStatusImmediatePending = false;
+  sidebarStatusPollGeneration += 1;
+  clearSidebarStatusTimer();
+  sidebarStatusPollController?.abort();
+};
+
 const scheduleSidebarStatusPoll = (delay) => {
-  stopSidebarStatusPoll();
-  sidebarStatusTimer = setTimeout(pollSidebarStatus, delay);
+  clearSidebarStatusTimer();
+  if (!sidebarStatusPollEnabled || document.visibilityState === 'hidden') return;
+  sidebarStatusTimer = setTimeout(() => {
+    sidebarStatusTimer = null;
+    return pollSidebarStatus(false);
+  }, delay);
 };
 
 const sidebarStatusPollDelay = () => {
@@ -116,64 +135,135 @@ const sidebarStatusPollDelay = () => {
   return SIDEBAR_POLL_IDLE;
 };
 
-const pollSidebarStatus = async () => {
-  stopSidebarStatusPoll();
-  if (document.visibilityState === 'hidden') return;
+const pollSidebarStatus = (isRecovery = false) => {
+  if (!sidebarStatusPollEnabled || document.visibilityState === 'hidden') return Promise.resolve(false);
+  if (sidebarStatusPollPromise) return sidebarStatusPollPromise;
 
-  try {
-    const params = new URLSearchParams();
-    const categories = state.sidebarSessionCategories;
-    if (Array.isArray(categories) && categories.length > 0 && !categories.includes('all')) {
-      params.set('categories', categories.join(','));
-    }
-    if (state.showHiddenSessions) params.set('include_archived', '1');
-    const query = params.toString();
+  clearSidebarStatusTimer();
+  const generation = sidebarStatusPollGeneration;
+  const controller = new AbortController();
+  sidebarStatusPollController = controller;
+  sidebarStatusPollInFlightGeneration = generation;
+  sidebarStatusPollIsRecovery = isRecovery;
 
-    const headers = requestHeaders('');
-    if (sidebarStatusEtag) headers['If-None-Match'] = sidebarStatusEtag;
+  const isCurrent = () => (
+    sidebarStatusPollEnabled
+    && document.visibilityState !== 'hidden'
+    && sidebarStatusPollGeneration === generation
+    && sidebarStatusPollController === controller
+  );
 
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions/status${query ? `?${query}` : ''}`, { headers });
+  const request = (async () => {
+    try {
+      const params = new URLSearchParams();
+      const categories = state.sidebarSessionCategories;
+      if (Array.isArray(categories) && categories.length > 0 && !categories.includes('all')) {
+        params.set('categories', categories.join(','));
+      }
+      if (state.showHiddenSessions) params.set('include_archived', '1');
+      const query = params.toString();
 
-    if (resp.status === 304) {
-      // No metadata change. If a prior status response revealed an active
-      // transcript update but the detail fetch was deferred or failed, retry the
-      // pending active-session reconciliation without issuing another status
-      // request.
-      await reconcilePendingActiveTranscriptRefresh();
-    } else if (resp.ok) {
+      const headers = requestHeaders('');
+      if (sidebarStatusEtag) headers['If-None-Match'] = sidebarStatusEtag;
+
+      const resp = await fetch(`${UI_PREFIX}/v1/sessions/status${query ? `?${query}` : ''}`, {
+        headers,
+        signal: controller.signal,
+      });
+      if (!isCurrent()) return false;
+
+      if (resp.status === 304) {
+        // No metadata change. If a prior status response revealed an active
+        // transcript update but the detail fetch was deferred or failed, retry the
+        // pending active-session reconciliation without issuing another status
+        // request.
+        await reconcilePendingActiveTranscriptRefresh();
+        return isCurrent();
+      }
+      if (!resp.ok) return false;
+
+      const data = await resp.json();
+      if (!isCurrent()) return false;
       const etag = resp.headers.get('ETag');
       if (etag) sidebarStatusEtag = etag;
-      const data = await resp.json();
       if (Array.isArray(data.sessions)) {
         updateSidebarStatus(data.sessions);
         await reconcileActiveTranscriptFromStatus(data.sessions);
+        if (!isCurrent()) return false;
         recordTranscriptVersionsFromStatus(data.sessions);
         // Discover sessions created in other tabs/devices
         const localIds = new Set(state.sessions.map((s) => s.id));
         const hasUnknown = data.sessions.some((entry) => !localIds.has(entry.id));
         if (hasUnknown) mergeServerSessions();
       }
+      return true;
+    } catch (_e) {
+      // Network error or an intentional visibility abort — recover below when visible.
+      return false;
     }
-  } catch (_e) {
-    // Network error — just retry on next interval
+  })();
+
+  const trackedRequest = request.finally(() => {
+    if (sidebarStatusPollPromise !== trackedRequest) return;
+    sidebarStatusPollPromise = null;
+    sidebarStatusPollIsRecovery = false;
+    if (sidebarStatusPollController === controller) sidebarStatusPollController = null;
+
+    if (!sidebarStatusPollEnabled || document.visibilityState === 'hidden') return;
+    if (sidebarStatusImmediatePending) {
+      sidebarStatusImmediatePending = false;
+      sidebarStatusEtag = null;
+      void pollSidebarStatus(true);
+      return;
+    }
+    if (sidebarStatusPollGeneration === generation) {
+      scheduleSidebarStatusPoll(sidebarStatusPollDelay());
+    }
+  });
+  sidebarStatusPollPromise = trackedRequest;
+  return trackedRequest;
+};
+
+const ensureSidebarStatusPoll = () => {
+  if (document.visibilityState === 'hidden') {
+    stopSidebarStatusPoll();
+    return Promise.resolve(false);
   }
 
-  scheduleSidebarStatusPoll(sidebarStatusPollDelay());
+  sidebarStatusPollEnabled = true;
+  clearSidebarStatusTimer();
+  if (sidebarStatusPollPromise) {
+    if (sidebarStatusPollInFlightGeneration !== sidebarStatusPollGeneration) {
+      sidebarStatusImmediatePending = true;
+      return sidebarStatusPollPromise.then(() => sidebarStatusPollPromise || false);
+    }
+    return sidebarStatusPollPromise;
+  }
+
+  sidebarStatusImmediatePending = false;
+  sidebarStatusEtag = null;
+  return pollSidebarStatus(true);
 };
 
-const startSidebarStatusPoll = () => {
-  stopSidebarStatusPoll();
-  sidebarStatusEtag = null;
-  return pollSidebarStatus();
-};
+const startSidebarStatusPoll = () => ensureSidebarStatusPoll();
 
 const refreshSidebarStatusPoll = (forceNow = false) => {
   if (document.visibilityState === 'hidden') return Promise.resolve(false);
-  if (forceNow) {
-    return startSidebarStatusPoll();
-  }
-  scheduleSidebarStatusPoll(sidebarStatusPollDelay());
+  if (forceNow) return ensureSidebarStatusPoll();
+
+  sidebarStatusPollEnabled = true;
+  if (!sidebarStatusPollPromise) scheduleSidebarStatusPoll(sidebarStatusPollDelay());
   return Promise.resolve(false);
+};
+
+const handleFetchTransportFallback = () => {
+  if (document.visibilityState !== 'hidden' && sidebarStatusPollPromise && !sidebarStatusPollIsRecovery) {
+    sidebarStatusPollEnabled = true;
+    clearSidebarStatusTimer();
+    sidebarStatusImmediatePending = true;
+    return sidebarStatusPollPromise.then(() => sidebarStatusPollPromise || false);
+  }
+  return ensureSidebarStatusPoll();
 };
 
 const createAndSwitchToFreshSession = async () => {
@@ -3253,6 +3343,7 @@ document.addEventListener('visibilitychange', async () => {
 
 window.addEventListener('pagehide', () => {
   flushStreamPersistence();
+  stopSidebarStatusPoll();
 });
 
 window.addEventListener('online', async () => {
@@ -3290,6 +3381,7 @@ window.addEventListener('offline', () => {
 });
 
 window.addEventListener('pageshow', (event) => {
+  void ensureSidebarStatusPoll();
   const session = getActiveSession();
   if (!session) return;
   if (session.activeResponseId && app.wakeResponseReconnect?.({
@@ -3360,6 +3452,7 @@ Object.assign(app, {
   startSidebarStatusPoll,
   stopSidebarStatusPoll,
   refreshSidebarStatusPoll,
+  handleFetchTransportFallback,
   promptRenameSession,
   refineSessionTitle,
   setSessionArchived,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -110,11 +110,13 @@ const clearSidebarStatusTimer = () => {
 };
 
 const stopSidebarStatusPoll = () => {
+  const pending = sidebarStatusPollPromise;
   sidebarStatusPollEnabled = false;
   sidebarStatusImmediatePending = false;
   sidebarStatusPollGeneration += 1;
   clearSidebarStatusTimer();
   sidebarStatusPollController?.abort();
+  return pending || Promise.resolve(false);
 };
 
 const scheduleSidebarStatusPoll = (delay) => {

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -512,33 +512,54 @@ const messageDedupeKey = (message) => {
   });
 };
 
-const messageRangesEquivalent = (messages, leftStart, rightStart, length) => {
-  for (let offset = 0; offset < length; offset += 1) {
-    if (messageDedupeKey(messages[leftStart + offset]) !== messageDedupeKey(messages[rightStart + offset])) {
-      return false;
+const messageFingerprints = (messages, metrics = null) => (Array.isArray(messages) ? messages : []).map((message) => {
+  if (metrics) metrics.fingerprints = Number(metrics.fingerprints || 0) + 1;
+  return messageDedupeKey(message);
+});
+
+const longestCompactionTailOverlap = (fingerprints, markerIndex, start, metrics = null) => {
+  const maxLength = Math.min(markerIndex, fingerprints.length - start);
+  if (maxLength <= 0) return 0;
+
+  const pattern = fingerprints.slice(start, start + maxLength);
+  const sequence = pattern.concat([null], fingerprints.slice(0, markerIndex));
+  const prefix = new Array(sequence.length).fill(0);
+  const equalAt = (left, right) => {
+    if (metrics) metrics.operations = Number(metrics.operations || 0) + 1;
+    return sequence[left] === sequence[right];
+  };
+
+  for (let index = 1; index < sequence.length; index += 1) {
+    let matched = prefix[index - 1];
+    while (matched > 0 && !equalAt(index, matched)) {
+      matched = prefix[matched - 1];
     }
+    if (equalAt(index, matched)) matched += 1;
+    prefix[index] = matched;
   }
-  return true;
+
+  return Math.min(maxLength, prefix[prefix.length - 1]);
 };
 
 const isSyntheticCompactionAckMessage = (message) => (
   message?.role === 'assistant' && String(message.content || '').trim() === "I've reviewed the context summary. I'll continue from where we left off."
 );
 
-const compactionDuplicateTailRange = (messages, markerIndex) => {
+const compactionDuplicateTailRange = (messages, markerIndex, fingerprints = null, metrics = null) => {
   if (markerIndex <= 0 || markerIndex + 1 >= messages.length) return { start: -1, length: 0 };
+  const keys = Array.isArray(fingerprints) && fingerprints.length === messages.length
+    ? fingerprints
+    : messageFingerprints(messages, metrics);
   const candidates = [markerIndex + 1];
   if (isSyntheticCompactionAckMessage(messages[markerIndex + 1])) candidates.push(markerIndex + 2);
   let bestStart = -1;
   let bestLength = 0;
   candidates.forEach((start) => {
     if (start >= messages.length) return;
-    const maxLength = Math.min(markerIndex, messages.length - start);
-    for (let length = 1; length <= maxLength; length += 1) {
-      if (length > bestLength && messageRangesEquivalent(messages, markerIndex - length, start, length)) {
-        bestStart = start;
-        bestLength = length;
-      }
+    const length = longestCompactionTailOverlap(keys, markerIndex, start, metrics);
+    if (length > bestLength) {
+      bestStart = start;
+      bestLength = length;
     }
   });
   return { start: bestStart, length: bestLength };
@@ -547,14 +568,18 @@ const compactionDuplicateTailRange = (messages, markerIndex) => {
 const suppressCompactionTailMessages = (messages) => {
   if (!Array.isArray(messages) || messages.length === 0) return messages;
   const out = messages.slice();
+  const fingerprints = messageFingerprints(out);
   for (let index = 0; index < out.length; index += 1) {
     if (out[index]?.role !== 'compaction') continue;
     if (out[index]?.authoritativeTailSuppressed) continue;
-    const { start, length } = compactionDuplicateTailRange(out, index);
+    const { start, length } = compactionDuplicateTailRange(out, index, fingerprints);
     if (length > 0) {
-      out.splice(index + 1, start + length - (index + 1));
+      const removeCount = start + length - (index + 1);
+      out.splice(index + 1, removeCount);
+      fingerprints.splice(index + 1, removeCount);
     } else if (isSyntheticCompactionAckMessage(out[index + 1])) {
       out.splice(index + 1, 1);
+      fingerprints.splice(index + 1, 1);
     }
   }
   return out;
@@ -1240,6 +1265,13 @@ const applyMCPStateToSession = (session, data) => {
   return changed;
 };
 
+// loadServerSessionState always returns one of these discriminated result
+// shapes. Callers must retry only `retry`; `auth` is a terminal authentication
+// failure and can never be confused with a falsy transient response.
+const SESSION_STATE_AUTH_RESULT = Object.freeze({ kind: 'auth' });
+const SESSION_STATE_RETRY_RESULT = Object.freeze({ kind: 'retry' });
+const sessionStateOKResult = (stateValue) => ({ kind: 'ok', state: stateValue });
+
 const loadServerSessionState = async (sessionId) => {
   try {
     const headers = {};
@@ -1247,15 +1279,19 @@ const loadServerSessionState = async (sessionId) => {
     const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/state`, { headers });
     if (!resp.ok) {
       if (resp.status === 404) {
-        return { active_run: false, active_response_id: '' };
+        return sessionStateOKResult({ active_run: false, active_response_id: '' });
       }
-      return null;
+      if (resp.status === 401) {
+        handleAuthFailure();
+        return SESSION_STATE_AUTH_RESULT;
+      }
+      return SESSION_STATE_RETRY_RESULT;
     }
     const data = await resp.json().catch(() => null);
-    if (!data || typeof data !== 'object') return null;
-    return data;
+    if (!data || typeof data !== 'object') return SESSION_STATE_RETRY_RESULT;
+    return sessionStateOKResult(data);
   } catch {
-    return null;
+    return SESSION_STATE_RETRY_RESULT;
   }
 };
 
@@ -1655,13 +1691,13 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
       stopSessionStatePoll();
       return;
     }
-    let runtimeState = null;
+    let syncResult = SESSION_STATE_RETRY_RESULT;
     try {
-      runtimeState = await syncActiveSessionFromServer(active, true);
+      syncResult = await syncActiveSessionFromServer(active, true);
     } catch (_) {
-      runtimeState = null;
+      syncResult = SESSION_STATE_RETRY_RESULT;
     }
-    if (runtimeState === null) {
+    if (syncResult?.kind === 'retry') {
       const stillActive = getActiveSession();
       if (stillActive && stillActive.id === sessionId && !state.abortController) {
         scheduleSessionStatePoll(sessionId, SESSION_STATE_POLL_RETRY);
@@ -1671,12 +1707,17 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
 };
 
 const syncActiveSessionFromServer = async (session, pollOnActive = false, { skipMessagesFetch = false, expectedSwitchGeneration = null } = {}) => {
-  if (!session) return null;
+  if (!session) return SESSION_STATE_RETRY_RESULT;
 
   const busyBefore = sessionHasInProgressState(session);
 
-  const runtimeState = await loadServerSessionState(session.id);
-  if (!runtimeState) return null;
+  const loadResult = await loadServerSessionState(session.id);
+  if (loadResult.kind === 'auth') {
+    stopSessionStatePoll();
+    return loadResult;
+  }
+  if (loadResult.kind !== 'ok') return SESSION_STATE_RETRY_RESULT;
+  const runtimeState = loadResult.state;
 
   const expectedGeneration = Number(expectedSwitchGeneration);
   const hasExpectedGeneration = Number.isFinite(expectedGeneration) && expectedGeneration > 0;
@@ -1800,12 +1841,12 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     if (isStillActive() && !state.abortController) {
       setStreaming(true);
       resumeAndDrain(session, { responseId: activeResponseId, recoverFromSnapshot });
-      return runtimeState;
+      return loadResult;
     }
     if (pollOnActive && isStillActive()) {
       scheduleSessionStatePoll(session.id);
     }
-    return runtimeState;
+    return loadResult;
   }
 
   if (activeRun && !state.abortController) {
@@ -1816,7 +1857,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     if (pollOnActive && isStillActive()) {
       scheduleSessionStatePoll(session.id);
     }
-    return runtimeState;
+    return loadResult;
   }
 
   if (!activeRun && !state.abortController) {
@@ -1861,7 +1902,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     drainInterruptQueueIfIdle(session);
   }
 
-  return runtimeState;
+  return loadResult;
 };
 
 const applyServerSessionSummary = (target, serverSession) => {
@@ -3183,6 +3224,15 @@ document.addEventListener('visibilitychange', async () => {
   const session = getActiveSession();
   if (!session) return;
 
+  if (session.activeResponseId && app.wakeResponseReconnect?.({
+    reason: 'visibility',
+    sessionId: session.id,
+    responseId: session.activeResponseId
+  })) {
+    setConnectionState('Page visible, reconnecting\u2026', 'bad');
+    setStreaming(true);
+    return;
+  }
   if (session.activeResponseId && !state.abortController) {
     setStreaming(true);
     resumeAndDrain(session, {
@@ -3209,13 +3259,22 @@ window.addEventListener('online', async () => {
   setConnectionState('', '');
   const session = getActiveSession();
   if (!session) return;
+  if (session.activeResponseId && app.wakeResponseReconnect?.({
+    reason: 'online',
+    sessionId: session.id,
+    responseId: session.activeResponseId
+  })) {
+    setConnectionState('Network restored, reconnecting\u2026', 'bad');
+    setStreaming(true);
+    return;
+  }
   if (session.activeResponseId && state.abortController) {
     // Abort the stale fetch so the existing resume loop reconnects immediately
     // instead of waiting for the heartbeat timeout.
     state.abortController._heartbeatAbort = true;
     state.abortController.abort();
   } else if (session.activeResponseId && !state.abortController) {
-    setConnectionState('Network restored, reconnecting\u2026');
+    setConnectionState('Network restored, reconnecting\u2026', 'bad');
     setStreaming(true);
     resumeAndDrain(session, {
       responseId: session.activeResponseId,
@@ -3231,9 +3290,18 @@ window.addEventListener('offline', () => {
 });
 
 window.addEventListener('pageshow', (event) => {
-  if (!event.persisted) return;
   const session = getActiveSession();
   if (!session) return;
+  if (session.activeResponseId && app.wakeResponseReconnect?.({
+    reason: 'pageshow',
+    sessionId: session.id,
+    responseId: session.activeResponseId
+  })) {
+    setConnectionState('Page restored, reconnecting\u2026', 'bad');
+    setStreaming(true);
+    return;
+  }
+  if (!event.persisted) return;
   if (session.activeResponseId) {
     setStreaming(true);
     resumeAndDrain(session, {
@@ -3263,6 +3331,7 @@ initialize();
 Object.assign(app, {
   createAndSwitchToFreshSession,
   convertServerMessages,
+  compactionDuplicateTailRange,
   loadServerSessionMessages,
   refreshActiveSessionMessagesFromServer,
   loadOlderSessionMessages,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -248,7 +248,7 @@ const streamReconnectDelay = (attempt) => {
 
 const streamReconnectLabel = (attempt) => (
   attempt >= STREAM_FAST_RETRY_LIMIT
-    ? 'Connection unstable; retrying once a minute…'
+    ? 'Connection unstable; next retry within one minute (online or returning to this page retries now)…'
     : (attempt < 3 ? 'Reconnecting…' : `Reconnecting (attempt ${attempt + 1})…`)
 );
 
@@ -458,7 +458,54 @@ const scheduleStreamScroll = () => {
 };
 
 // Guards against multiple concurrent resumeActiveResponse loops for the same response.
-const activeResumeKeys = new Set();
+// The per-loop owner prevents a detached loop's eventual cleanup from deleting a
+// replacement loop's registration for the same session and response.
+const activeResumeKeys = new Map();
+const responseReconnectWaiters = new Map();
+
+const streamDiagnosticsEnabled = () => Boolean(
+  window.__TERM_LLM_DIAGNOSTICS__ || window.__WEBRTC_DIAGNOSTICS__
+);
+
+const setReconnectDiagnostic = (reconnectState, reason = '', delay = 0) => {
+  if (!streamDiagnosticsEnabled()) return;
+  const dataset = elements.connectionState?.dataset;
+  if (!dataset) return;
+  dataset.reconnectState = String(reconnectState || '');
+  dataset.reconnectReason = String(reason || '');
+  dataset.reconnectDelayMs = String(Math.max(0, Number(delay) || 0));
+};
+
+const waitForResponseReconnect = (delay, resumeKey, reason) => new Promise((resolve) => {
+  let settled = false;
+  let timerId = 0;
+  const finish = (wakeReason) => {
+    if (settled) return;
+    settled = true;
+    if (timerId) window.clearTimeout(timerId);
+    if (responseReconnectWaiters.get(resumeKey)?.finish === finish) {
+      responseReconnectWaiters.delete(resumeKey);
+    }
+    resolve(String(wakeReason || 'timer'));
+  };
+  timerId = window.setTimeout(() => finish('timer'), delay);
+  responseReconnectWaiters.set(resumeKey, { finish, timerId });
+  setReconnectDiagnostic('waiting', reason, delay);
+});
+
+// Public wake requests use a named object and require both identifiers. A
+// response id alone is ambiguous across sessions and must never wake a waiter.
+const wakeResponseReconnect = ({ reason = '', sessionId = '', responseId = '' } = {}) => {
+  const normalizedSessionId = String(sessionId || '').trim();
+  const normalizedResponseId = String(responseId || '').trim();
+  if (!normalizedSessionId || !normalizedResponseId) return false;
+  const key = `${normalizedSessionId}:${normalizedResponseId}`;
+  const waiter = responseReconnectWaiters.get(key);
+  if (!waiter) return false;
+  setReconnectDiagnostic('waking', reason, 0);
+  waiter.finish(reason);
+  return true;
+};
 
 const attachResponseStream = (session, responseId = '', controller = null) => {
   state.currentStreamSessionId = String(session?.id || '').trim();
@@ -471,8 +518,13 @@ const attachResponseStream = (session, responseId = '', controller = null) => {
 
 const clearResumeKeysForSession = (sessionId) => {
   const prefix = sessionId + ':';
-  for (const key of activeResumeKeys) {
+  for (const key of activeResumeKeys.keys()) {
     if (key.startsWith(prefix)) activeResumeKeys.delete(key);
+  }
+  // A reconnect sleep has no AbortController to settle. Resolve it explicitly
+  // so detaching cannot leave the old loop asleep until its backoff expires.
+  for (const [key, waiter] of responseReconnectWaiters) {
+    if (key.startsWith(prefix)) waiter.finish('detached');
   }
 };
 
@@ -1462,18 +1514,25 @@ const resumeActiveResponse = async (session, options = {}) => {
   if (!responseId) return false;
 
   // Prevent multiple concurrent resume loops for the same session+response.
+  // Cleanup may run after detach has already registered a replacement loop, so
+  // it must remove the key only while it still owns that registration.
   const resumeKey = `${session.id}:${responseId}`;
   if (activeResumeKeys.has(resumeKey)) return false;
-  activeResumeKeys.add(resumeKey);
+  const resumeOwner = {};
+  activeResumeKeys.set(resumeKey, resumeOwner);
 
   try {
-    return await resumeActiveResponseInner(session, responseId, options);
+    return await resumeActiveResponseInner(session, responseId, options, resumeOwner);
   } finally {
-    activeResumeKeys.delete(resumeKey);
+    if (activeResumeKeys.get(resumeKey) === resumeOwner) {
+      activeResumeKeys.delete(resumeKey);
+    }
   }
 };
 
-const resumeActiveResponseInner = async (session, responseId, options) => {
+const resumeActiveResponseInner = async (session, responseId, options, resumeOwner) => {
+  const resumeKey = `${session.id}:${responseId}`;
+  const ownsResumeKey = () => activeResumeKeys.get(resumeKey) === resumeOwner;
   if (state.currentStreamSessionId && state.currentStreamSessionId !== session.id) {
     detachResponseStream();
   }
@@ -1507,6 +1566,10 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
       // event replay path rather than failing the reconnect outright.
     }
   }
+  if (!ownsResumeKey()) {
+    setStreaming(Boolean(state.currentStreamResponseId));
+    return false;
+  }
 
   let streamState = recoveredFromSnapshot
     ? createResponseStreamState(session)
@@ -1514,8 +1577,13 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
   let consecutiveHttpFailures = 0;
   let consecutiveHeartbeatAborts = 0;
   let retryAttempt = 0;
+  let reconnectReason = 'stream-ended';
 
   for (;;) {
+    if (!ownsResumeKey()) {
+      setStreaming(Boolean(state.currentStreamResponseId));
+      return false;
+    }
     if (session.activeResponseId !== responseId) {
       setStreaming(Boolean(state.currentStreamResponseId));
       return true;
@@ -1529,7 +1597,8 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
     if (consecutiveHttpFailures >= 5 || consecutiveHeartbeatAborts >= 5) {
       consecutiveHttpFailures = 0;
       consecutiveHeartbeatAborts = 0;
-      setConnectionState('Checking session state\u2026');
+      setConnectionState('Checking session state\u2026', 'bad');
+      setReconnectDiagnostic('checking-state', reconnectReason, 0);
       // Temporarily clear the abort controller so syncActiveSessionFromServer
       // can act on the server state.  The !activeRun && !state.abortController
       // branch inside sync refuses to clear tracking while a controller is set,
@@ -1539,6 +1608,10 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
         state.abortController = null;
       }
       await app.syncActiveSessionFromServer(session, false);
+      if (!ownsResumeKey()) {
+        setStreaming(Boolean(state.currentStreamResponseId));
+        return false;
+      }
       if (session.activeResponseId !== responseId) {
         // Run completed/changed while we were polling — exit.
         setStreaming(Boolean(state.currentStreamResponseId));
@@ -1561,6 +1634,12 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
         headers: requestHeaders(session.id),
         signal: controller.signal
       });
+      if (!ownsResumeKey()) {
+        if (state.abortController === controller) state.abortController = null;
+        try { await response.body?.cancel(); } catch (_) { /* response may already be closed */ }
+        setStreaming(Boolean(state.currentStreamResponseId));
+        return false;
+      }
       if (!response.ok) {
         throw await normalizeError(response);
       }
@@ -1570,6 +1649,7 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
 
       consecutiveHttpFailures = 0;
       setConnectionState('', '');
+      setReconnectDiagnostic('connected', '', 0);
       const streamGeneration = state.streamGeneration;
       streamActivityBaseline = Number(state.lastEventTime || 0);
       const result = await consumeResponseStream(response.body, session, streamState, { generation: streamGeneration, responseId });
@@ -1636,9 +1716,11 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
         // HTTP failure.  Some browsers reject aborted fetches with the custom
         // abort reason instead of a DOMException, so key off the controller.
         consecutiveHeartbeatAborts += 1;
+        reconnectReason = 'heartbeat-stale';
       } else {
         consecutiveHttpFailures += 1;
         consecutiveHeartbeatAborts = 0;
+        reconnectReason = err?.status ? `http-${err.status}` : 'network-error';
       }
       if (err?.status === 401) {
         handleAuthFailure();
@@ -1680,14 +1762,18 @@ const resumeActiveResponseInner = async (session, responseId, options) => {
       }
     }
 
-    setConnectionState(streamReconnectLabel(retryAttempt));
+    setConnectionState(streamReconnectLabel(retryAttempt), 'bad');
     if (session.activeResponseId !== responseId) {
       setStreaming(Boolean(state.currentStreamResponseId));
       return true;
     }
     const retryDelay = streamReconnectDelay(retryAttempt);
     retryAttempt += 1;
-    await sleep(retryDelay);
+    const wakeReason = await waitForResponseReconnect(retryDelay, resumeKey, reconnectReason);
+    if (wakeReason === 'detached' || !ownsResumeKey()) {
+      setStreaming(Boolean(state.currentStreamResponseId));
+      return false;
+    }
   }
 };
 
@@ -3869,12 +3955,18 @@ const interruptActiveRun = async (session, prompt, messageId, contentParts = nul
   return action;
 };
 
-const runtimeHasActiveRun = (runtimeState) => {
+const runtimeStateFromSyncResult = (result) => (
+  result?.kind === 'ok' ? result.state : (result?.kind ? null : result)
+);
+
+const runtimeHasActiveRun = (syncResult) => {
+  const runtimeState = runtimeStateFromSyncResult(syncResult);
   if (!runtimeState || typeof runtimeState !== 'object') return false;
   return Boolean(runtimeState.active_run || String(runtimeState.active_response_id || '').trim());
 };
 
-const runtimeHasPendingAskUser = (runtimeState, callId) => {
+const runtimeHasPendingAskUser = (syncResult, callId) => {
+  const runtimeState = runtimeStateFromSyncResult(syncResult);
   const normalizedCallId = String(callId || '').trim();
   if (!normalizedCallId || !runtimeState || typeof runtimeState !== 'object') return false;
   const prompts = Array.isArray(runtimeState.pending_ask_users)
@@ -3883,7 +3975,8 @@ const runtimeHasPendingAskUser = (runtimeState, callId) => {
   return prompts.some((item) => String(item?.call_id || '').trim() === normalizedCallId);
 };
 
-const runtimeHasPendingApproval = (runtimeState, approvalId) => {
+const runtimeHasPendingApproval = (syncResult, approvalId) => {
+  const runtimeState = runtimeStateFromSyncResult(syncResult);
   const normalizedApprovalId = String(approvalId || '').trim();
   if (!normalizedApprovalId || !runtimeState || typeof runtimeState !== 'object') return false;
   const approvals = Array.isArray(runtimeState.pending_approvals)
@@ -3898,7 +3991,8 @@ const refreshSessionFromServerTruth = async (session, pollOnActive = false) => {
 };
 
 const recoverInterruptFailure = async (session, prompt, messageId, attachments = []) => {
-  const runtimeState = await refreshSessionFromServerTruth(session, true);
+  const syncResult = await refreshSessionFromServerTruth(session, true);
+  const runtimeState = runtimeStateFromSyncResult(syncResult);
   if (!runtimeState) {
     return false;
   }
@@ -4861,6 +4955,7 @@ Object.assign(app, {
   scheduleStreamScroll,
   HEARTBEAT_STALE_THRESHOLD,
   HEARTBEAT_ABORT_REASON,
+  wakeResponseReconnect,
   resumeActiveResponse,
   cancelActiveResponse,
   closeAskUserModal,

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -107,6 +107,22 @@
     }
   }
 
+  function restoreHTTPSFetch(reason) {
+    const wasWebRTCTransport = window.fetch === patchedFetch;
+    window.fetch = originalFetch;
+    if (!wasWebRTCTransport) return;
+
+    diag(reason + ' — restoring original fetch');
+    const app = termApp();
+    if (app && typeof app.handleFetchTransportFallback === 'function') {
+      try {
+        app.handleFetchTransportFallback();
+      } catch (_e) {
+        diag('app transport fallback hook failed');
+      }
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Initialisation
   // ---------------------------------------------------------------------------
@@ -228,8 +244,8 @@
       // 8. Connected — wire up handlers and patch fetch.
       dataChannel = dc;
       dc.onmessage = handleMessage;
-      dc.onclose = onChannelClose;
-      dc.onerror = onChannelClose;
+      dc.onclose = () => onChannelClose(dc);
+      dc.onerror = () => onChannelClose(dc);
 
       window.fetch = patchedFetch;
 
@@ -313,10 +329,10 @@
   // Channel close / error
   // ---------------------------------------------------------------------------
 
-  function onChannelClose() {
+  function onChannelClose(closedChannel) {
+    if (closedChannel !== dataChannel) return;
     dataChannel = null;
-    diag('data channel closed — restoring original fetch');
-    window.fetch = originalFetch;
+    restoreHTTPSFetch('data channel closed');
     drainPendingToHTTPS('channel closed');
   }
 
@@ -329,11 +345,12 @@
     renegotiating = true;
 
     // Tear down the current channel so new requests route to HTTPS immediately.
-    if (dataChannel) {
-      try { dataChannel.close(); } catch (_e) { /* ignore */ }
-    }
+    const previousChannel = dataChannel;
     dataChannel = null;
-    window.fetch = originalFetch;
+    if (previousChannel) {
+      try { previousChannel.close(); } catch (_e) { /* ignore */ }
+    }
+    restoreHTTPSFetch('data channel degraded');
 
     // Rescue any other in-flight requests stuck on the dead channel.
     drainPendingToHTTPS('renegotiation');

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -26,6 +26,7 @@
 // ?webrtc_diag=1 in the URL) to enable console.log timeline output:
 //   [webrtc] connection lifecycle events with timestamps
 //   [webrtc] per-request: method, path, body size, status, latency
+//   [webrtc] pending queue size and HTTPS/stream-close fallback state
 //
 // Force TURN relay: pass ?webrtc_turn=1 to set iceTransportPolicy=relay,
 // which forces all traffic through the TURN server (ignores host/srflx).
@@ -88,6 +89,11 @@
     if (!diagEnabled) return;
     const elapsed = diagT0 ? ((performance.now() - diagT0) | 0) : 0;
     console.log('[webrtc] +' + elapsed + 'ms ' + msg);
+  }
+
+  function diagQueue(state, fallback) {
+    diag('queue state=' + state + ' pending=' + pendingRequests.size +
+      ' fallback=' + (fallback || 'none'));
   }
 
   function termApp() {
@@ -294,7 +300,7 @@
   // consumer will see a truncated stream and can retry at the app layer.
   function drainPendingToHTTPS(reason) {
     if (pendingRequests.size === 0) return;
-    diag(reason + ' — draining ' + pendingRequests.size + ' pending request(s) to HTTPS');
+    diagQueue('draining', reason + ':https-before-response-or-stream-close');
 
     // Snapshot the entries; fallback() deletes its own key.
     const entries = Array.from(pendingRequests.values());
@@ -412,6 +418,7 @@
           try { options.signal.removeEventListener('abort', abortHandler); } catch (_e) { /* */ }
         }
         diag('cleanup ' + method + ' ' + path + ' reason=' + reason);
+        diagQueue('settled', reason.includes('fallback') || reason.includes('timeout') ? 'https' : 'none');
       }
 
       function closeStream() {
@@ -501,6 +508,8 @@
 
       // fallback: called by drainPendingToHTTPS() when the channel dies.
       function fallback() {
+        const fallbackState = !gotResponse ? 'https' : 'stream-close';
+        diagQueue('fallback', fallbackState);
         cleanup('drain-fallback');
         if (!gotResponse) {
           // Haven't received anything yet — retry via HTTPS. Mutation endpoints
@@ -546,6 +555,7 @@
         },
         fallback,
       });
+      diagQueue('queued', 'none');
 
       // Build and send the request frame.
       const headersObj = {};

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -1072,6 +1072,64 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
   pass(name);
 })();
 
+(function testMessageEvictionReleasesDuplicateHistoryRepresentations() {
+  const name = 'message eviction releases converted and raw history representations';
+  const testApp = loadAppCore();
+  testApp.state.sessions = Array.from({ length: 11 }, (_, index) => ({
+    id: `s${index + 1}`,
+    title: `Session ${index + 1}`,
+    created: 1000 + index,
+    lastMessageAt: 1000 + index,
+    messages: [{ id: `m${index + 1}`, role: 'assistant', content: 'x'.repeat(1024), created: 1000 + index }],
+    _history: {
+      rawMessages: [{ sequence: index + 1, role: 'assistant', parts: [{ type: 'text', text: 'x'.repeat(1024) }] }],
+      loadedTail: true,
+    },
+  }));
+  testApp.state.activeSessionId = 's11';
+
+  testApp.saveSessions();
+
+  const evicted = testApp.state.sessions.find((session) => session.id === 's1');
+  if (!evicted || !evicted._serverOnly || evicted.messages.length !== 0) {
+    fail(name, 'expected oldest inactive session converted messages to be evicted');
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(evicted, '_history')) {
+    fail(name, 'raw server history remained reachable after message eviction');
+    return;
+  }
+  const retained = testApp.state.sessions.find((session) => session.id === 's11');
+  if (!retained?._history?.rawMessages?.length || retained.messages.length !== 1) {
+    fail(name, 'retained active session lost its history representations');
+    return;
+  }
+  pass(name);
+})();
+
+(function testHistoryOnlySessionParticipatesInMessageCacheEviction() {
+  const name = 'history-only inactive sessions participate in cache eviction';
+  const testApp = loadAppCore();
+  testApp.state.sessions = Array.from({ length: 11 }, (_, index) => ({
+    id: `raw${index + 1}`,
+    title: `Raw ${index + 1}`,
+    created: 1000 + index,
+    lastMessageAt: 1000 + index,
+    messages: [],
+    _history: { rawMessages: [{ sequence: index + 1, parts: [{ type: 'text', text: 'large raw history' }] }] },
+  }));
+  testApp.state.activeSessionId = 'raw11';
+
+  testApp.saveSessions();
+
+  const evicted = testApp.state.sessions.find((session) => session.id === 'raw1');
+  if (!evicted?._serverOnly || Object.prototype.hasOwnProperty.call(evicted, '_history')) {
+    fail(name, 'history-only session was not fully evicted');
+    return;
+  }
+  pass(name);
+})();
+
 function dispatchSwipeListeners(listeners, target, event) {
   const evt = {
     target,

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -433,7 +433,7 @@ function createHarness(appOverrides = {}) {
   windowObj.localStorage = context.localStorage;
 
   vm.runInNewContext(source, context, { filename: 'app-render.js' });
-  return { app, session, messages, document, timers, copied, parseCalls };
+  return { app, session, messages, document, windowObj, timers, copied, parseCalls };
 }
 
 function messageNode(id, role) {
@@ -1199,6 +1199,76 @@ async function run(name, fn) {
     assert(tail.innerHTML.includes('more tail content'), 'tail rerendered with appended content');
   });
 
+  await run('stable-prefix hash detects middle replacement and rebuilds promoted markdown', () => {
+    const { app, session, messages, timers } = createHarness();
+    const stablePrefix = Array.from(
+      { length: 20 },
+      (_, index) => `Stable paragraph ${index} with enough prose for promotion.\n\n`
+    ).join('');
+    const message = {
+      id: 'stream-stable-middle-replacement',
+      role: 'assistant',
+      content: `${stablePrefix}${'mutable **tail** '.repeat(30)}`,
+      created: Date.now(),
+    };
+    session.messages = [message];
+
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    const body = messages.children[0].querySelector('.message-body');
+    const stable = body.querySelector('.markdown-stream-stable');
+    assertEqual(stable.children.length, 1, 'stable prefix promoted before replacement');
+    const originalPiece = stable.children[0];
+    const divergence = Math.floor(stablePrefix.length / 2);
+    assert(divergence > 64 && divergence < stablePrefix.length - 64, 'divergence is outside the old edge guards');
+
+    const replacementPrefix = `${stablePrefix.slice(0, divergence)}X${stablePrefix.slice(divergence + 1)}`;
+    message.content = `${replacementPrefix}${'mutable **tail** '.repeat(30)}`;
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    assertEqual(stable.children.length, 1, 'corrected stable prefix is promoted again');
+    assert(stable.children[0] !== originalPiece, 'middle divergence invalidates the old stable DOM piece');
+    assert(stable.children[0].innerHTML.includes(replacementPrefix.slice(divergence - 12, divergence + 12)), 'rebuilt stable DOM contains replacement content');
+  });
+
+  await run('plain fallback resets stale stable DOM before slicing a divergent snapshot', () => {
+    const { app, session, messages, timers, parseCalls } = createHarness();
+    const stablePrefix = Array.from(
+      { length: 20 },
+      (_, index) => `Promoted paragraph ${index} with enough prose for recovery.\n\n`
+    ).join('');
+    const message = {
+      id: 'stream-fallback-stable-recovery',
+      role: 'assistant',
+      content: `${stablePrefix}${'mutable **tail** '.repeat(30)}`,
+      created: Date.now(),
+    };
+    session.messages = [message];
+
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    const body = messages.children[0].querySelector('.message-body');
+    const stable = body.querySelector('.markdown-stream-stable');
+    assertEqual(stable.children.length, 1, 'stable prefix promoted before fallback');
+
+    const oversizedTail = '```txt\n' + 'unfinished **markdown** inside fence\n'.repeat(2500);
+    assert(oversizedTail.length > markdownStreaming.MAX_MUTABLE_MARKDOWN_CHARS, 'fallback fixture exceeds mutable limit');
+    const divergence = Math.floor(stablePrefix.length / 2);
+    const replacementPrefix = `${stablePrefix.slice(0, divergence)}X${stablePrefix.slice(divergence + 1)}`;
+    const parsesBeforeRecovery = parseCalls.length;
+    message.content = `${replacementPrefix}${oversizedTail}`;
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    const recoveredTail = body.querySelector('.markdown-stream-tail');
+    assertEqual(stable.children.length, 0, 'stale stable DOM is cleared on fallback prefix mismatch');
+    assertEqual(recoveredTail.children[0].textContent, message.content, 'fallback restarts from the full corrected snapshot');
+    assertEqual(parseCalls.length, parsesBeforeRecovery, 'fallback recovery does not parse the oversized snapshot as Markdown');
+  });
+
   await run('finalizing streaming markdown replaces streaming containers with full render', () => {
     const { app, session, messages, timers } = createHarness();
     const message = {
@@ -1221,6 +1291,56 @@ async function run(name, fn) {
     assert(body.innerHTML.includes('First paragraph'), 'full markdown render remains');
   });
 
+  await run('oversized incomplete markdown tail uses bounded incremental fallback and finalizes correctly', () => {
+    const observedScheduleLengths = [];
+    const streamingHelpers = {
+      ...markdownStreaming,
+      nextStreamingRenderDelay(length) {
+        observedScheduleLengths.push(length);
+        return markdownStreaming.nextStreamingRenderDelay(length);
+      },
+    };
+    const { app, session, messages, timers, parseCalls, windowObj } = createHarness({ markdownStreaming: streamingHelpers });
+    windowObj.__TERM_LLM_DIAGNOSTICS__ = true;
+    const oversizedFence = '```txt\n' + 'unfinished **markdown** inside fence\n'.repeat(2500);
+    assert(oversizedFence.length > markdownStreaming.MAX_MUTABLE_MARKDOWN_CHARS, 'fixture must exceed mutable markdown limit');
+    const message = {
+      id: 'stream-oversized-fence',
+      role: 'assistant',
+      content: oversizedFence,
+      created: Date.now(),
+    };
+    session.messages = [message];
+
+    app.enqueueAssistantStreamUpdate(message);
+    runAllPendingTimers(timers);
+
+    let body = messages.children[0].querySelector('.message-body');
+    const tail = body.querySelector('.markdown-stream-tail');
+    assert(tail.className.includes('streaming-plain-text'), 'oversized incomplete tail falls back to plain streaming');
+    assertEqual(tail.dataset.streamRenderMode, 'plain-fallback', 'fallback mode is exposed for diagnostics');
+    assertEqual(Number(tail.dataset.mutableMarkdownTailSize), 0, 'no oversized tail remains mutable markdown work');
+    const parsesBeforeAppend = parseCalls.length;
+    const textNode = tail.children[0];
+    observedScheduleLengths.length = 0;
+
+    message.content += 'one more streamed delta';
+    app.enqueueAssistantStreamUpdate(message);
+    const fallbackScheduleLength = observedScheduleLengths[observedScheduleLengths.length - 1];
+    assert(fallbackScheduleLength > markdownStreaming.MAX_MUTABLE_MARKDOWN_CHARS, 'fallback scheduler receives the actual huge mutable tail length');
+    assert(markdownStreaming.nextStreamingRenderDelay(fallbackScheduleLength) > 33, 'huge fallback tail retains slow render cadence');
+    runAllPendingTimers(timers);
+
+    assertEqual(parseCalls.length, parsesBeforeAppend, 'fallback append does not reparse the oversized markdown source');
+    assert(textNode.textContent.endsWith('one more streamed delta'), 'fallback appends only the streamed delta');
+
+    message.content += '\n```';
+    app.finalizeAssistantStreamRender(message);
+    body = messages.children[0].querySelector('.message-body');
+    assert(!body.querySelector('.markdown-stream-tail'), 'streaming fallback removed after final render');
+    assertEqual(parseCalls[parseCalls.length - 1], message.content, 'final render reparses the complete source for correctness');
+  });
+
   await run('plain text streaming renders tail as text node and stays in that mode across extends', () => {
     const { app, session, messages, timers } = createHarness();
     const message = {
@@ -1239,6 +1359,7 @@ async function run(name, fn) {
     const tail = body.querySelector('.markdown-stream-tail');
     assert(tail, 'tail container exists');
     assert(tail.className.includes('streaming-plain-text'), 'tail uses plain-text mode for plain text');
+    assertEqual(tail.dataset.streamRenderMode, undefined, 'stream diagnostics stay unset without opt-in');
 
     // Extend with more plain text (no markdown chars) — cache fast path
     message.content += ' More words with no special characters at all.';
@@ -1707,6 +1828,22 @@ async function run(name, fn) {
     assertEqual(messages.children.length, 3, 'three nodes after incremental render');
     assert(messages.children[0] === firstNode, 'first node is the same object (not recreated)');
     assertEqual(messages.children[2].dataset.messageId, 'm3', 'new node has correct id');
+  });
+
+  await run('renderMessages exposes gated mounted-count and duration diagnostics', () => {
+    const { app, session, messages, windowObj } = createHarness();
+    windowObj.__TERM_LLM_DIAGNOSTICS__ = true;
+    session.messages = [
+      { id: 'diag-u1', role: 'user', content: 'hello', created: Date.now() },
+      { id: 'diag-a1', role: 'assistant', content: 'hi', created: Date.now() },
+    ];
+
+    app.renderMessages();
+
+    assertEqual(messages.dataset.mountedMessageCount, '2', 'mounted message count');
+    assert(Number(messages.dataset.mountedElementCount) >= 2, 'mounted element count should include message DOM');
+    assert(Number(messages.dataset.renderDurationMs) >= 0, 'render duration should be numeric');
+    assertEqual(messages.dataset.renderMode, 'rebuild', 'render mode diagnostic');
   });
 
   await run('renderMessages: full rebuild on session switch', () => {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3417,6 +3417,190 @@ async function testSanitizeSessionPreservesTranscriptUpdatedAt() {
   pass(name);
 }
 
+async function testSidebarStatusPollRecoversIdempotentlyAfterPageShow() {
+  const name = 'pageshow and transport recovery restart one immediate sidebar poll';
+  const scheduled = [];
+  let statusCalls = 0;
+  let holdRecoveryStatus = false;
+  let resolveRecoveryStatus = null;
+  const { app, windowObj } = await createSessionsHarness({
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false, fired: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) {
+      if (handle) handle.cleared = true;
+    },
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        statusCalls += 1;
+        if (holdRecoveryStatus && statusCalls === 1) {
+          return new Promise((resolve) => {
+            resolveRecoveryStatus = () => resolve(new Response(JSON.stringify({ sessions: [] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }));
+          });
+        }
+      }
+      if (url.endsWith('/state')) {
+        return new Response(JSON.stringify({ active_run: false, active_response_id: '' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+  app.stopSidebarStatusPoll();
+  scheduled.length = 0;
+  statusCalls = 0;
+  holdRecoveryStatus = true;
+
+  const session = {
+    id: 'sess_pageshow_poll',
+    title: 'Page show poll',
+    origin: 'web',
+    created: 1,
+    messages: [],
+    activeResponseId: null,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const pageshowHandlers = windowObj.listeners.pageshow || [];
+  const pageshowHandler = pageshowHandlers[pageshowHandlers.length - 1];
+  if (!visibilityHandler || !pageshowHandler) {
+    fail(name, 'expected visibilitychange and pageshow listeners');
+    return;
+  }
+
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  windowObj.document.visibilityState = 'visible';
+  // BFCache restoration does not reliably emit another visibilitychange.
+  pageshowHandler({ type: 'pageshow', persisted: true });
+
+  if (typeof app.handleFetchTransportFallback !== 'function') {
+    fail(name, 'expected an app-level transport fallback hook');
+    return;
+  }
+  const repeatedRecovery = app.handleFetchTransportFallback();
+  app.handleFetchTransportFallback();
+
+  if (statusCalls !== 1 || typeof resolveRecoveryStatus !== 'function') {
+    fail(name, `expected exactly one immediate status request, got ${statusCalls}`);
+    return;
+  }
+  const liveBeforeResolve = scheduled.filter((handle) => !handle.cleared && !handle.fired);
+  if (liveBeforeResolve.length !== 0) {
+    fail(name, 'status timer was scheduled while the immediate request was in flight', JSON.stringify(liveBeforeResolve.map(({ delay }) => delay)));
+    return;
+  }
+
+  resolveRecoveryStatus();
+  await repeatedRecovery;
+  await Promise.resolve();
+
+  let liveTimers = scheduled.filter((handle) => !handle.cleared && !handle.fired);
+  if (liveTimers.length !== 1 || liveTimers[0].delay !== 5000) {
+    fail(name, 'expected exactly one continued visible-session poll timer', JSON.stringify(liveTimers.map(({ delay }) => delay)));
+    return;
+  }
+
+  const nextTimer = liveTimers[0];
+  nextTimer.fired = true;
+  await nextTimer.fn();
+  await Promise.resolve();
+  if (statusCalls !== 2) {
+    fail(name, `continued polling issued ${statusCalls} total requests, want 2`);
+    return;
+  }
+  liveTimers = scheduled.filter((handle) => !handle.cleared && !handle.fired);
+  if (liveTimers.length !== 1 || liveTimers[0].delay !== 5000) {
+    fail(name, 'continued poll did not leave exactly one next timer', JSON.stringify(liveTimers.map(({ delay }) => delay)));
+    return;
+  }
+
+  app.stopSidebarStatusPoll();
+  pass(name);
+}
+
+async function testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus() {
+  const name = 'hidden in-flight sidebar status callback is stale and cannot restart polling';
+  const scheduled = [];
+  let statusCalls = 0;
+  let resolveStatus = null;
+  let staleSidebarUpdates = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) {
+      if (handle) handle.cleared = true;
+    },
+    appOverrides: {
+      updateSidebarStatus(sessions) {
+        if (sessions.some((session) => session.id === 'stale_session')) staleSidebarUpdates += 1;
+      },
+    },
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        statusCalls += 1;
+        if (statusCalls > 1) {
+          return new Promise((resolve) => {
+            resolveStatus = () => resolve(new Response(JSON.stringify({
+              sessions: [{ id: 'stale_session', short_title: 'Stale' }],
+            }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+          });
+        }
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+  app.stopSidebarStatusPoll();
+  scheduled.length = 0;
+  staleSidebarUpdates = 0;
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const pollPromise = app.startSidebarStatusPoll();
+  await Promise.resolve();
+  if (typeof resolveStatus !== 'function') {
+    fail(name, 'expected a status request to remain in flight');
+    return;
+  }
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  resolveStatus();
+  await pollPromise;
+  await Promise.resolve();
+
+  if (staleSidebarUpdates !== 0) {
+    fail(name, `hidden stale response applied ${staleSidebarUpdates} sidebar updates`);
+    return;
+  }
+  const liveTimers = scheduled.filter((handle) => !handle.cleared);
+  if (liveTimers.length !== 0) {
+    fail(name, 'hidden stale response restarted the background poll loop', JSON.stringify(liveTimers.map(({ delay }) => delay)));
+    return;
+  }
+
+  pass(name);
+}
+
 async function testStatusPollAdvancementRefreshesActiveMessagesOnce() {
   const name = 'status poll transcript advancement refreshes active messages exactly once';
   const fetchCalls = [];
@@ -4844,6 +5028,8 @@ async function testSessionSwitchRefreshesSkillsAndDraftClearsThem() {
   await testMergeServerMessagesBumpsLastMessageAt();
   await testSanitizeSessionPreservesLastMessageAt();
   await testSanitizeSessionPreservesTranscriptUpdatedAt();
+  await testSidebarStatusPollRecoversIdempotentlyAfterPageShow();
+  await testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus();
   await testStatusPollAdvancementRefreshesActiveMessagesOnce();
   await testStatusPollUnchangedTranscriptDoesNotFetchMessages();
   await testActiveTranscriptRefreshSkipsBusyStates();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3456,7 +3456,7 @@ async function testSidebarStatusPollRecoversIdempotentlyAfterPageShow() {
       });
     },
   });
-  app.stopSidebarStatusPoll();
+  await app.stopSidebarStatusPoll();
   scheduled.length = 0;
   statusCalls = 0;
   holdRecoveryStatus = true;
@@ -3569,7 +3569,7 @@ async function testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus()
       });
     },
   });
-  app.stopSidebarStatusPoll();
+  await app.stopSidebarStatusPoll();
   scheduled.length = 0;
   staleSidebarUpdates = 0;
   await Promise.resolve();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -320,8 +320,16 @@ async function createSessionsHarness(options = {}) {
     },
     navigator: { standalone: false, mediaDevices: null, serviceWorker: null, geolocation: options.geolocation || null },
     visualViewport: null,
-    addEventListener() {},
-    removeEventListener() {},
+    listeners: {},
+    addEventListener(type, handler) {
+      if (!this.listeners[type]) this.listeners[type] = [];
+      this.listeners[type].push(handler);
+    },
+    removeEventListener(type, handler) {
+      const list = this.listeners[type] || [];
+      const index = list.indexOf(handler);
+      if (index >= 0) list.splice(index, 1);
+    },
     requestAnimationFrame(callback) { return timerSetTimeout(callback, 0); },
     cancelAnimationFrame(handle) { timerClearTimeout(handle); },
     setTimeout: timerSetTimeout,
@@ -1125,6 +1133,44 @@ async function testConvertServerMessagesSuppressesCompactionRetainedRawTail() {
   ], { compactionSeq: 4, compactionCount: 1 });
   if (JSON.stringify(convertedWithAck.map((message) => `${message.role}:${message.content}`)) !== JSON.stringify(want)) {
     fail(name, 'synthetic ack and retained tail should both be suppressed', JSON.stringify(convertedWithAck));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testCompactionDuplicateTailRangeIsLinear() {
+  const name = 'legacy compaction tail overlap is correct with linear bounded work';
+  const { app } = await createSessionsHarness();
+  const prefixLength = 3000;
+  const overlapLength = 1400;
+  const messages = Array.from({ length: prefixLength }, (_, index) => ({
+    role: index % 2 === 0 ? 'user' : 'assistant',
+    content: `message-${index}`,
+  }));
+  const markerIndex = messages.length;
+  messages.push({ role: 'compaction', content: 'Context compacted' });
+  messages.push({
+    role: 'assistant',
+    content: "I've reviewed the context summary. I'll continue from where we left off.",
+  });
+  for (let index = prefixLength - overlapLength; index < prefixLength; index += 1) {
+    messages.push({ ...messages[index] });
+  }
+  messages.push({ role: 'assistant', content: 'new content after duplicated tail' });
+
+  const metrics = { operations: 0, fingerprints: 0 };
+  const match = app.compactionDuplicateTailRange(messages, markerIndex, null, metrics);
+  if (match.start !== markerIndex + 2 || match.length !== overlapLength) {
+    fail(name, 'incorrect longest overlap', JSON.stringify(match));
+    return;
+  }
+  if (metrics.fingerprints !== messages.length) {
+    fail(name, `expected one precomputed fingerprint per message, got ${metrics.fingerprints}`);
+    return;
+  }
+  if (metrics.operations > messages.length * 8) {
+    fail(name, `overlap work scaled beyond a linear bound: ${metrics.operations} operations for ${messages.length} messages`);
     return;
   }
 
@@ -2692,10 +2738,10 @@ async function testSessionState404ClearsStaleActiveResponse() {
   app.state.streaming = true;
   app.state.draftSessionActive = false;
 
-  const runtimeState = await app.syncActiveSessionFromServer(session, false);
+  const syncResult = await app.syncActiveSessionFromServer(session, false);
 
-  if (!runtimeState || runtimeState.active_run !== false) {
-    fail(name, 'expected state 404 to produce inactive runtime state', JSON.stringify(runtimeState));
+  if (syncResult?.kind !== 'ok' || syncResult.state?.active_run !== false) {
+    fail(name, 'expected state 404 to produce an explicit successful inactive result', JSON.stringify(syncResult));
     return;
   }
   if (!fetchCalls.some((url) => isTailMessagesURL(url, 'sess_state_404'))) {
@@ -3623,6 +3669,116 @@ async function testLateActiveMessagesResponseIgnoredAfterSessionSwitch() {
   pass(name);
 }
 
+async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
+  const name = 'online visibility and pageshow wake the existing response reconnect loop';
+  const wakeReasons = [];
+  let resumeCalls = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    appOverrides: {
+      wakeResponseReconnect({ reason, sessionId, responseId }) {
+        wakeReasons.push(`${reason}:${sessionId}:${responseId}`);
+        return true;
+      },
+      resumeActiveResponse: async () => { resumeCalls += 1; },
+    },
+  });
+  app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_wake_signals',
+    title: 'Wake signals',
+    origin: 'web',
+    created: 1,
+    messages: [],
+    activeResponseId: 'resp_wake_signals',
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  app.state.abortController = null;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const onlineHandler = (windowObj.listeners.online || [])[0];
+  const pageshowHandlers = windowObj.listeners.pageshow || [];
+  const pageshowHandler = pageshowHandlers[pageshowHandlers.length - 1];
+  if (!visibilityHandler || !onlineHandler || !pageshowHandler) {
+    fail(name, 'expected all reconnect wake listeners to be registered');
+    return;
+  }
+
+  await visibilityHandler({ type: 'visibilitychange' });
+  await onlineHandler({ type: 'online' });
+  pageshowHandler({ type: 'pageshow', persisted: false });
+
+  const want = [
+    'visibility:sess_wake_signals:resp_wake_signals',
+    'online:sess_wake_signals:resp_wake_signals',
+    'pageshow:sess_wake_signals:resp_wake_signals',
+  ];
+  if (JSON.stringify(wakeReasons) !== JSON.stringify(want)) {
+    fail(name, 'unexpected reconnect wake calls', JSON.stringify(wakeReasons));
+    return;
+  }
+  if (resumeCalls !== 0) {
+    fail(name, `wake listeners started ${resumeCalls} duplicate resume loops`);
+    return;
+  }
+
+  pass(name);
+}
+
+async function testLoadServerSessionStateUsesExplicitResultContract() {
+  const name = 'session state loader returns explicit ok auth and retry results';
+  let authFailures = 0;
+  const { app } = await createSessionsHarness({
+    appOverrides: {
+      handleAuthFailure() { authFailures += 1; },
+    },
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/sess_contract_ok/state') {
+        return new Response(JSON.stringify({ active_run: true, active_response_id: 'resp_contract' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url === '/ui/v1/sessions/sess_contract_auth/state') {
+        return new Response('unauthorized', { status: 401 });
+      }
+      if (url === '/ui/v1/sessions/sess_contract_retry/state') {
+        return new Response('unavailable', { status: 503 });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+  app.stopSidebarStatusPoll();
+
+  const ok = await app.loadServerSessionState('sess_contract_ok');
+  const auth = await app.loadServerSessionState('sess_contract_auth');
+  const retry = await app.loadServerSessionState('sess_contract_retry');
+
+  if (ok?.kind !== 'ok' || ok.state?.active_response_id !== 'resp_contract') {
+    fail(name, 'successful state did not use the ok result contract', JSON.stringify(ok));
+    return;
+  }
+  if (auth?.kind !== 'auth' || Object.prototype.hasOwnProperty.call(auth, 'state')) {
+    fail(name, '401 did not use the distinct auth result contract', JSON.stringify(auth));
+    return;
+  }
+  if (retry?.kind !== 'retry' || Object.prototype.hasOwnProperty.call(retry, 'state')) {
+    fail(name, 'transient failure did not use the distinct retry result contract', JSON.stringify(retry));
+    return;
+  }
+  if (authFailures !== 1) {
+    fail(name, `expected one auth failure callback, got ${authFailures}`);
+    return;
+  }
+
+  pass(name);
+}
+
 async function testSessionStatePollRetriesAfterTransientFailure() {
   const name = 'session state poll retries after transient failure';
   const scheduled = [];
@@ -3689,6 +3845,60 @@ async function testSessionStatePollRetriesAfterTransientFailure() {
   const extraRetry = scheduled.find((item) => item !== retry && item.delay === 5000 && !item.cleared);
   if (extraRetry) {
     fail(name, 'expected successful retry to stop the transient retry loop', JSON.stringify(scheduled.map(({ delay, cleared }) => ({ delay, cleared }))));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testSessionStatePollTreats401AsAuthFailure() {
+  const name = 'session state 401 triggers auth failure without retry';
+  const scheduled = [];
+  let authFailures = 0;
+  let stateCalls = 0;
+  const { app } = await createSessionsHarness({
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) {
+      if (handle) handle.cleared = true;
+    },
+    appOverrides: {
+      handleAuthFailure() { authFailures += 1; },
+    },
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/sess_auth/state') {
+        stateCalls += 1;
+        return new Response('unauthorized', { status: 401 });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+  app.stopSidebarStatusPoll();
+  scheduled.length = 0;
+
+  const session = { id: 'sess_auth', title: 'Auth', origin: 'web', created: 1, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = true;
+
+  app.scheduleSessionStatePoll(session.id, 0);
+  const first = scheduled.find((item) => item.delay === 0 && !item.cleared);
+  if (!first) {
+    fail(name, 'expected initial state poll');
+    return;
+  }
+  await first.fn();
+
+  if (stateCalls !== 1 || authFailures !== 1) {
+    fail(name, `expected one request and one auth failure, got requests=${stateCalls} authFailures=${authFailures}`);
+    return;
+  }
+  const retry = scheduled.find((item) => item !== first && item.delay === 5000 && !item.cleared);
+  if (retry) {
+    fail(name, '401 was treated as a transient failure and retried');
     return;
   }
 
@@ -4598,6 +4808,7 @@ async function testSessionSwitchRefreshesSkillsAndDraftClearsThem() {
   await testRunErrorEventsConvertToErrorMessages();
   await testConvertServerMessagesCompactionSummariesBecomeMarkers();
   await testConvertServerMessagesSuppressesCompactionRetainedRawTail();
+  await testCompactionDuplicateTailRangeIsLinear();
   await testConvertServerMessagesSuppressesAuthoritativeCompactionTailFlag();
   await testConvertServerMessagesHandlesMixedLegacyAndAuthoritativeCompactionTails();
   await testConvertServerMessagesInsertsBoundaryWhenSummaryNotLoaded();
@@ -4637,7 +4848,10 @@ async function testSessionSwitchRefreshesSkillsAndDraftClearsThem() {
   await testStatusPollUnchangedTranscriptDoesNotFetchMessages();
   await testActiveTranscriptRefreshSkipsBusyStates();
   await testLateActiveMessagesResponseIgnoredAfterSessionSwitch();
+  await testReconnectBackoffWakeSignalsReuseExistingLoop();
+  await testLoadServerSessionStateUsesExplicitResultContract();
   await testSessionStatePollRetriesAfterTransientFailure();
+  await testSessionStatePollTreats401AsAuthFailure();
   await testSessionStatePollDoesNotRetryAfterSessionSwitch();
   await testLateActiveRunSyncDoesNotMarkDraftStreaming();
   await testOlderPendingTranscriptVersionIsIgnoredOnStatus304();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -189,6 +189,7 @@ function createHarness(options = {}) {
       querySelector(selector) { return selector === '.arrow' ? this._arrow : null; },
     },
     stopBtn: { classList: makeClassList() },
+    connectionState: makeNode(),
     attachmentsStrip: {
       innerHTML: '',
       style: {},
@@ -460,6 +461,7 @@ function createHarness(options = {}) {
 
   const windowObj = {
     TermLLMApp: app,
+    __TERM_LLM_DIAGNOSTICS__: Boolean(options.diagnostics),
     setTimeout: typeof options.setTimeout === 'function' ? options.setTimeout : setTimeout,
     clearTimeout: typeof options.clearTimeout === 'function' ? options.clearTimeout : clearTimeout,
     setInterval: typeof options.setInterval === 'function' ? options.setInterval : setInterval,
@@ -2703,7 +2705,7 @@ async function testResumeActiveResponseHeartbeatAbortSlowsAndRecovers() {
       throw new Error(`unexpected fetch: ${url}`);
     },
   });
-  const { app, state, cleanup } = harness;
+  const { app, elements, state, cleanup } = harness;
   app.syncActiveSessionFromServer = async (session) => {
     syncCalls += 1;
     session.activeResponseId = responseId;
@@ -2753,7 +2755,265 @@ async function testResumeActiveResponseHeartbeatAbortSlowsAndRecovers() {
     fail(name, 'events retry loop did not poll server state after repeated heartbeat aborts');
     return;
   }
+  if (Object.prototype.hasOwnProperty.call(elements.connectionState.dataset, 'reconnectState')) {
+    fail(name, 'reconnect diagnostics were written without opt-in', JSON.stringify(elements.connectionState.dataset));
+    return;
+  }
 
+  pass(name);
+}
+
+async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
+  const name = 'slow response reconnect backoff is wakeable without a duplicate resume loop';
+  const responseId = 'resp_wakeable_retry';
+  const timers = [];
+  let nextTimerID = 0;
+  let eventsCount = 0;
+  const harness = createHarness({
+    responseId,
+    diagnostics: true,
+    setTimeout(callback, ms) {
+      const timer = { id: ++nextTimerID, callback, ms: Number(ms || 0), cleared: false };
+      timers.push(timer);
+      return timer.id;
+    },
+    clearTimeout(id) {
+      const timer = timers.find((item) => item.id === id);
+      if (timer) timer.cleared = true;
+    },
+    fetchImpl: async (url, _requestOptions, { Response, ReadableStream, TextEncoder }) => {
+      if (!url.startsWith(`/ui/v1/responses/${responseId}/events?after=`)) {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      eventsCount += 1;
+      if (eventsCount <= 6) {
+        return new Response('temporary failure', { status: 503 });
+      }
+      const body = [
+        'event: response.created\n',
+        `data: {"response":{"id":"${responseId}","status":"in_progress"},"sequence_number":1}\n\n`,
+        'event: response.completed\n',
+        `data: {"response":{"id":"${responseId}","status":"completed"},"sequence_number":2}\n\n`,
+        'data: [DONE]\n\n',
+      ].join('');
+      const encoder = new TextEncoder();
+      return new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(body));
+          controller.close();
+        },
+      }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    },
+  });
+  const { app, elements, state, connectionStates, cleanup } = harness;
+  const session = {
+    id: 'session_wakeable_retry',
+    title: 'Wakeable retry',
+    messages: [],
+    activeResponseId: responseId,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+
+  const resumePromise = app.resumeActiveResponse(session, { responseId });
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const ready = await waitFor(() => eventsCount === attempt && timers.some((timer) => !timer.cleared), 1000);
+    if (!ready) {
+      fail(name, `retry ${attempt} did not schedule`);
+      await cleanup();
+      return;
+    }
+    const timer = timers.find((item) => !item.cleared);
+    timer.cleared = true;
+    timer.callback();
+  }
+
+  const slowReady = await waitFor(() => eventsCount === 6 && timers.some((timer) => !timer.cleared && timer.ms === 60000), 1000);
+  if (!slowReady) {
+    fail(name, 'slow one-minute retry was not scheduled', JSON.stringify(timers));
+    await cleanup();
+    return;
+  }
+  const duplicateResult = await app.resumeActiveResponse(session, { responseId });
+  if (duplicateResult !== false) {
+    fail(name, 'duplicate resume call should remain idempotently suppressed');
+    await cleanup();
+    return;
+  }
+
+  const slowTimer = timers.find((timer) => !timer.cleared && timer.ms === 60000);
+  if (elements.connectionState.dataset.reconnectState !== 'waiting') {
+    fail(name, 'opted-in diagnostics did not expose waiting reconnect state', JSON.stringify(elements.connectionState.dataset));
+    await cleanup();
+    return;
+  }
+  const partialWake = app.wakeResponseReconnect({ reason: 'online', responseId });
+  if (partialWake || slowTimer.cleared) {
+    fail(name, 'response-only wake must not match an ambiguous session');
+    await cleanup();
+    return;
+  }
+  const woke = app.wakeResponseReconnect({ reason: 'online', sessionId: session.id, responseId });
+  if (!woke || !slowTimer.cleared) {
+    fail(name, 'online wake did not resolve and cancel the slow backoff');
+    await cleanup();
+    return;
+  }
+  if (elements.connectionState.dataset.reconnectState !== 'waking') {
+    fail(name, 'opted-in diagnostics did not expose wake state', JSON.stringify(elements.connectionState.dataset));
+    await cleanup();
+    return;
+  }
+
+  await resumePromise;
+  await cleanup();
+  if (eventsCount !== 7) {
+    fail(name, `expected one resumed fetch after wake, got ${eventsCount} total fetches`);
+    return;
+  }
+  if (!connectionStates.some((text) => text.includes('within one minute'))) {
+    fail(name, 'slow reconnect status was not exposed to the UI', JSON.stringify(connectionStates));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testDetachDuringSlowReconnectTransfersResumeOwnership() {
+  const name = 'detach during slow reconnect cancels the old loop without releasing the new owner';
+  const responseId = 'resp_detached_retry';
+  const timers = [];
+  let nextTimerID = 0;
+  let eventsCount = 0;
+  const harness = createHarness({
+    responseId,
+    setTimeout(callback, ms) {
+      const timer = { id: ++nextTimerID, callback, ms: Number(ms || 0), cleared: false };
+      timers.push(timer);
+      return timer.id;
+    },
+    clearTimeout(id) {
+      const timer = timers.find((item) => item.id === id);
+      if (timer) timer.cleared = true;
+    },
+    fetchImpl: async (url, requestOptions, { Response, ReadableStream }) => {
+      if (!url.startsWith(`/ui/v1/responses/${responseId}/events?after=`)) {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      eventsCount += 1;
+      if (eventsCount <= 6) {
+        return new Response('temporary failure', { status: 503 });
+      }
+      const signal = requestOptions.signal;
+      return new Response(new ReadableStream({
+        start(controller) {
+          signal.addEventListener('abort', () => {
+            try { controller.error(new DOMException('The operation was aborted.', 'AbortError')); } catch (_err) { /* ignore */ }
+          });
+        },
+      }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    },
+  });
+  const { app, state, cleanup } = harness;
+  const session = {
+    id: 'session_detached_retry',
+    title: 'Detached retry',
+    messages: [],
+    activeResponseId: responseId,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  const otherSession = {
+    id: 'session_other',
+    title: 'Other session',
+    messages: [],
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 2,
+  };
+  state.sessions.push(session, otherSession);
+  state.activeSessionId = session.id;
+
+  let oldResult;
+  void app.resumeActiveResponse(session, { responseId }).then((result) => {
+    oldResult = result;
+  });
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const ready = await waitFor(() => eventsCount === attempt && timers.some((timer) => !timer.cleared), 1000);
+    if (!ready) {
+      fail(name, `retry ${attempt} did not schedule`);
+      app.detachResponseStream();
+      await cleanup();
+      return;
+    }
+    const timer = timers.find((item) => !item.cleared);
+    timer.cleared = true;
+    timer.callback();
+  }
+
+  const slowReady = await waitFor(() => eventsCount === 6 && timers.some((timer) => !timer.cleared && timer.ms === 60000), 1000);
+  if (!slowReady) {
+    fail(name, 'old loop did not enter the one-minute reconnect backoff', JSON.stringify(timers));
+    app.detachResponseStream();
+    await cleanup();
+    return;
+  }
+  const oldSlowTimer = timers.find((timer) => !timer.cleared && timer.ms === 60000);
+
+  // Switch away and immediately back before promise continuations run. The new
+  // loop must acquire the same resume key before the detached old loop cleans up.
+  state.activeSessionId = otherSession.id;
+  app.detachResponseStream();
+  state.activeSessionId = session.id;
+  const newResumePromise = app.resumeActiveResponse(session, { responseId });
+
+  if (!oldSlowTimer.cleared) {
+    fail(name, 'detach did not explicitly cancel the old reconnect waiter');
+    await cleanup();
+    return;
+  }
+  const oldStopped = await waitFor(() => oldResult !== undefined, 1000);
+  if (!oldStopped || oldResult !== false) {
+    fail(name, `detached old resume loop did not terminate; result=${String(oldResult)}`);
+    await cleanup();
+    return;
+  }
+  if (eventsCount !== 7) {
+    fail(name, `only the new loop should issue an event request after switching back; got ${eventsCount} total`);
+    app.detachResponseStream();
+    await newResumePromise;
+    await cleanup();
+    return;
+  }
+
+  // The old loop's finally must not delete the new loop's registration. A
+  // third call is suppressed only while that one new owner remains registered.
+  let duplicateResult;
+  void app.resumeActiveResponse(session, { responseId }).then((result) => {
+    duplicateResult = result;
+  });
+  const duplicateSettled = await waitFor(() => duplicateResult !== undefined || eventsCount !== 7, 1000);
+  if (!duplicateSettled || duplicateResult !== false || eventsCount !== 7) {
+    fail(name, `expected exactly one new resume owner to remain; duplicateResult=${String(duplicateResult)}, events=${eventsCount}`);
+    app.detachResponseStream();
+    await cleanup();
+    return;
+  }
+  oldSlowTimer.callback();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (eventsCount !== 7) {
+    fail(name, `expired old waiter issued another event request; got ${eventsCount} total`);
+    app.detachResponseStream();
+    await newResumePromise;
+    await cleanup();
+    return;
+  }
+
+  app.detachResponseStream();
+  await newResumePromise;
+  await cleanup();
   pass(name);
 }
 
@@ -5552,6 +5812,8 @@ async function testIsolatedSkillStreamsIndependentlyAndCancelsIndependently() {
   await testToolExecImagesAttachToToolArtifactNotAssistantMarkdown();
   await testToolExecImagesUseHubAssetRebase();
   await testResumeActiveResponseHeartbeatAbortSlowsAndRecovers();
+  await testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop();
+  await testDetachDuringSlowReconnectTransfersResumeOwnership();
   await testResumeActiveResponseFallsBackToReplayWhenSnapshotUnavailable();
   await testResumeActiveResponseClearsTerminalTrackingWhen409SnapshotHasNoRecovery();
   await testSendMessageIncludesModelSwapForChangedTarget();

--- a/internal/serveui/static/app_webrtc_test.js
+++ b/internal/serveui/static/app_webrtc_test.js
@@ -3,35 +3,244 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { webcrypto } = require('crypto');
 
 const source = fs.readFileSync(path.join(__dirname, 'app-webrtc.js'), 'utf8');
-const window = {
-  __WEBRTC_ENABLED__: false,
-  __TERM_LLM_WEBRTC_TESTING__: true,
-};
-vm.runInNewContext(source, { window }, { filename: 'app-webrtc.js' });
 
-const hooks = window.__TERM_LLM_WEBRTC_TEST_HOOKS__;
-if (!hooks || typeof hooks.responseTimeoutForMethod !== 'function') {
-  throw new Error('WebRTC timeout test hook was not installed');
+function fail(message) {
+  throw new Error(message);
 }
 
-const cases = [
-  ['GET', 1000],
-  ['get', 1000],
-  ['HEAD', 1000],
-  ['OPTIONS', 1000],
-  ['POST', 5000],
-  ['PATCH', 5000],
-  ['PUT', 5000],
-  ['DELETE', 5000],
-];
-
-for (const [method, expected] of cases) {
-  const actual = hooks.responseTimeoutForMethod(method);
-  if (actual !== expected) {
-    throw new Error(`${method} timeout = ${actual}, want ${expected}`);
+async function waitFor(predicate, message) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
   }
+  fail(message);
 }
 
-console.log('PASS: WebRTC first-frame timeout is 1s for reads and 5s for mutations');
+function testResponseTimeouts() {
+  const window = {
+    __WEBRTC_ENABLED__: false,
+    __TERM_LLM_WEBRTC_TESTING__: true,
+  };
+  vm.runInNewContext(source, { window }, { filename: 'app-webrtc.js' });
+
+  const hooks = window.__TERM_LLM_WEBRTC_TEST_HOOKS__;
+  if (!hooks || typeof hooks.responseTimeoutForMethod !== 'function') {
+    fail('WebRTC timeout test hook was not installed');
+  }
+
+  const cases = [
+    ['GET', 1000],
+    ['get', 1000],
+    ['HEAD', 1000],
+    ['OPTIONS', 1000],
+    ['POST', 5000],
+    ['PATCH', 5000],
+    ['PUT', 5000],
+    ['DELETE', 5000],
+  ];
+
+  for (const [method, expected] of cases) {
+    const actual = hooks.responseTimeoutForMethod(method);
+    if (actual !== expected) {
+      fail(`${method} timeout = ${actual}, want ${expected}`);
+    }
+  }
+
+  console.log('PASS: WebRTC first-frame timeout is 1s for reads and 5s for mutations');
+}
+
+async function createEnabledHarness() {
+  const channels = [];
+  const scheduled = [];
+  let transportRecoveries = 0;
+  let httpsAPICalls = 0;
+
+  class FakeDataChannel {
+    constructor() {
+      this.readyState = 'open';
+      this.throwOnSend = false;
+      this.onopen = null;
+      this.onclose = null;
+      this.onerror = null;
+      this.onmessage = null;
+    }
+
+    send() {
+      if (this.throwOnSend) throw new Error('simulated channel send failure');
+    }
+
+    close() {
+      this.readyState = 'closed';
+      this.onclose?.({ type: 'close' });
+    }
+  }
+
+  class FakePeerConnection {
+    constructor() {
+      this.iceGatheringState = 'complete';
+      this.iceConnectionState = 'connected';
+      this.localDescription = null;
+    }
+
+    createDataChannel() {
+      const channel = new FakeDataChannel();
+      channels.push(channel);
+      return channel;
+    }
+
+    async createOffer() {
+      return { type: 'offer', sdp: 'fake-offer' };
+    }
+
+    async setLocalDescription(offer) {
+      this.localDescription = offer;
+    }
+
+    async setRemoteDescription() {}
+  }
+
+  const originalFetch = async (url) => {
+    const value = String(url);
+    if (value.endsWith('/session')) {
+      return new Response(JSON.stringify({ session_id: 'signal-session' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (value.includes('/signal?')) {
+      return new Response(JSON.stringify({ type: 'answer', sdp: 'fake-answer' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (value.endsWith('/signal')) {
+      return new Response(null, { status: 200 });
+    }
+    if (value.includes('/v1/')) httpsAPICalls += 1;
+    return new Response(JSON.stringify({ sessions: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  const document = {
+    readyState: 'complete',
+    visibilityState: 'visible',
+    addEventListener() {},
+  };
+  const window = {
+    __WEBRTC_ENABLED__: true,
+    __TERM_LLM_WEBRTC_TESTING__: true,
+    __WEBRTC_SIGNALING_URL__: '/webrtc',
+    TERM_LLM_UI_PREFIX: '/ui',
+    location: { search: '', origin: 'https://example.test' },
+    fetch: originalFetch,
+    TermLLMApp: {
+      handleFetchTransportFallback() {
+        transportRecoveries += 1;
+      },
+    },
+  };
+  window.document = document;
+
+  const context = {
+    window,
+    document,
+    URL,
+    URLSearchParams,
+    AbortSignal,
+    Blob,
+    Response,
+    Headers,
+    ReadableStream,
+    DOMException,
+    TextEncoder,
+    performance,
+    crypto: webcrypto,
+    RTCPeerConnection: FakePeerConnection,
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) {
+      if (handle) handle.cleared = true;
+    },
+    btoa(value) { return Buffer.from(value, 'binary').toString('base64'); },
+    console,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(source, context, { filename: 'app-webrtc.js' });
+
+  await waitFor(
+    () => channels.length === 1 && typeof channels[0].onclose === 'function' && window.fetch !== originalFetch,
+    'WebRTC data channel did not initialize and patch fetch'
+  );
+
+  return {
+    channels,
+    originalFetch,
+    window,
+    getHTTPSAPICalls: () => httpsAPICalls,
+    getTransportRecoveries: () => transportRecoveries,
+  };
+}
+
+async function testChannelCloseSignalsTransportRecoveryOnce() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const patchedFetch = harness.window.fetch;
+
+  channel.close();
+  if (harness.window.fetch === patchedFetch) {
+    fail('channel close did not restore the original fetch transport');
+  }
+  if (harness.getTransportRecoveries() !== 1) {
+    fail(`channel close emitted ${harness.getTransportRecoveries()} recovery signals, want 1`);
+  }
+
+  channel.onclose({ type: 'close' });
+  channel.onerror({ type: 'error' });
+  if (harness.getTransportRecoveries() !== 1) {
+    fail('repeated close/error callbacks emitted duplicate recovery signals');
+  }
+
+  console.log('PASS: WebRTC channel close restores fetch and signals app recovery once');
+}
+
+async function testSendFallbackSignalsTransportRecoveryOnce() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const patchedFetch = harness.window.fetch;
+  channel.throwOnSend = true;
+
+  const response = await patchedFetch('/ui/v1/sessions/status', { headers: {} });
+  if (!response.ok || harness.getHTTPSAPICalls() !== 1) {
+    fail(`send failure did not fall back to HTTPS exactly once (calls=${harness.getHTTPSAPICalls()})`);
+  }
+  if (harness.window.fetch === patchedFetch) {
+    fail('send failure did not restore the original fetch transport');
+  }
+  if (harness.getTransportRecoveries() !== 1) {
+    fail(`send fallback emitted ${harness.getTransportRecoveries()} recovery signals, want 1`);
+  }
+
+  channel.onclose({ type: 'close' });
+  if (harness.getTransportRecoveries() !== 1) {
+    fail('late close callback after fallback emitted a duplicate recovery signal');
+  }
+
+  console.log('PASS: WebRTC request fallback restores fetch and signals app recovery once');
+}
+
+(async () => {
+  testResponseTimeouts();
+  await testChannelCloseSignalsTransportRecoveryOnce();
+  await testSendFallbackSignalsTransportRecoveryOnce();
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/internal/serveui/static/markdown-streaming.js
+++ b/internal/serveui/static/markdown-streaming.js
@@ -8,6 +8,9 @@
 })(function markdownStreamingFactory() {
   'use strict';
 
+  const MAX_MUTABLE_MARKDOWN_CHARS = 64 * 1024;
+  const MAX_STABLE_BOUNDARY_OPERATIONS = MAX_MUTABLE_MARKDOWN_CHARS * 8;
+
   function nextStreamingRenderDelay(contentLength) {
     const length = Math.max(0, Number(contentLength) || 0);
     if (length > 96000) return 250;
@@ -22,8 +25,10 @@
       body: null,
       stableContainer: null,
       tailContainer: null,
-      stableSource: '',
       stableLength: 0,
+      stableHashLength: 0,
+      stableHashA: 0,
+      stableHashB: 0,
       latestContent: '',
       lastTailContent: '',
       lastTailSource: '',
@@ -34,30 +39,81 @@
       timerId: 0,
       lastRenderAt: 0,
       plainTextScanSource: '',
-      plainTextEligible: true
+      plainTextEligible: true,
+      plainFallback: false,
+      lastBoundaryOperations: 0
     };
   }
 
-  function countCodeFencesFast(text) {
+  function fenceMarker(line) {
+    const match = String(line || '').match(/^[ \t]{0,3}(`{3,}|~{3,})/);
+    if (!match) return null;
+    return { char: match[1][0], width: match[1].length };
+  }
+
+  function isFenceClose(line, active) {
+    if (!active) return false;
+    const trimmed = String(line || '').replace(/^[ \t]{0,3}/, '');
+    let width = 0;
+    while (width < trimmed.length && trimmed[width] === active.char) width += 1;
+    return width >= active.width && /^[ \t]*$/.test(trimmed.slice(width));
+  }
+
+  function scanFenceState(text, pos = String(text || '').length) {
+    const value = String(text || '');
+    const safePos = Math.max(0, Math.min(value.length, Number(pos) || 0));
+    let active = null;
     let count = 0;
     let lineStart = 0;
 
-    for (let i = 0; i <= text.length; i += 1) {
-      if (i !== text.length && text.charCodeAt(i) !== 10) continue;
-      if (i > lineStart) {
-        const line = text.slice(lineStart, i);
-        const trimmed = line.replace(/^[ \t]+/, '');
-        if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) count += 1;
+    for (let i = 0; i <= safePos; i += 1) {
+      if (i !== safePos && value.charCodeAt(i) !== 10) continue;
+      const marker = fenceMarker(value.slice(lineStart, i));
+      if (marker) {
+        if (!active) {
+          active = marker;
+          count += 1;
+        } else if (marker.char === active.char && isFenceClose(value.slice(lineStart, i), active)) {
+          active = null;
+          count += 1;
+        }
       }
       lineStart = i + 1;
     }
 
-    return count;
+    return { active, count };
+  }
+
+  function countCodeFencesFast(text) {
+    return scanFenceState(text).count;
   }
 
   function isInCodeBlockFast(text, pos) {
-    const safePos = Math.max(0, Math.min(text.length, pos));
-    return countCodeFencesFast(text.slice(0, safePos)) % 2 === 1;
+    return Boolean(scanFenceState(text, pos).active);
+  }
+
+  function withoutFencedCode(text) {
+    const value = String(text || '');
+    const out = [];
+    let active = null;
+    let lineStart = 0;
+
+    for (let i = 0; i <= value.length; i += 1) {
+      if (i !== value.length && value.charCodeAt(i) !== 10) continue;
+      const line = value.slice(lineStart, i);
+      const marker = fenceMarker(line);
+      const wasActive = Boolean(active);
+      if (marker) {
+        if (!active) active = marker;
+        else if (marker.char === active.char && isFenceClose(line, active)) active = null;
+      }
+      const masked = wasActive || marker ? ' '.repeat(line.length) : line;
+      out.push(masked);
+      if (i < value.length) out.push('\n');
+      lineStart = i + 1;
+    }
+
+    return out.join('');
   }
 
   function isWhitespace(ch) {
@@ -285,11 +341,19 @@
     return eligible;
   }
 
-  function containsListOrTableSyntax(text) {
-    const value = String(text || '');
-    return /^\s{0,3}(?:[-+*]\s|\d+[.)]\s)/m.test(value)
-      || /^\s*\|.*\|\s*$/m.test(value)
-      || /^\s*[-:| ]+\|[-:| ]*$/m.test(value);
+  function containsListSyntax(text) {
+    return /^\s{0,3}(?:[-+*]\s|\d+[.)]\s)/m.test(String(text || ''));
+  }
+
+  function boundarySplitsList(text, boundary, stableCandidate) {
+    if (!containsListSyntax(stableCandidate)) return false;
+    const remainder = String(text || '').slice(boundary);
+    // Skip only complete blank lines. Keep the indentation on the first
+    // nonblank line so loose-list continuations and list-item code remain
+    // attached to the stable candidate.
+    const nextLineMatch = remainder.match(/^(?:[ \t]*\r?\n)*([^\r\n]*)/);
+    const nextLine = nextLineMatch ? nextLineMatch[1] : '';
+    return /^\s{0,3}(?:[-+*]\s|\d+[.)]\s)/.test(nextLine) || /^(?: {2,}|\t)\S/.test(nextLine);
   }
 
   function lastBlankLineBoundaryBefore(text, maxIndex) {
@@ -308,32 +372,82 @@
     return best;
   }
 
-  function findStableMarkdownBoundary(text, minTailLength) {
+  function analyzeStableMarkdownBoundary(text, minTailLength, options = {}) {
     const value = String(text || '');
+    const mutableLimit = Math.max(1, Number(options.maxMutableChars) || MAX_MUTABLE_MARKDOWN_CHARS);
+    const operationLimit = Math.max(1, Number(options.maxOperations) || MAX_STABLE_BOUNDARY_OPERATIONS);
+    const result = {
+      boundary: 0,
+      operations: 0,
+      overBudget: false,
+      mutableTailLength: value.length
+    };
+
+    // Do not start an unbounded scan. The caller can preserve the streamed
+    // source with its incremental plain-text fallback until the final full
+    // Markdown render.
+    if (value.length > mutableLimit || value.length > operationLimit) {
+      result.overBudget = true;
+      return result;
+    }
+
     const tailLength = Math.max(0, Number(minTailLength) || 0);
     const latestBoundary = value.length - tailLength;
-    if (latestBoundary <= 0) return 0;
+    if (latestBoundary <= 0) return result;
 
     const boundary = lastBlankLineBoundaryBefore(value, latestBoundary);
-    if (boundary <= 0) return 0;
+    result.operations = value.length;
+    if (boundary <= 0) return result;
+
+    // One bounded fence scan, one fence masking pass, and one pass each for
+    // inline and math state. The estimate is deliberately conservative and is
+    // exposed for deterministic operation-count tests.
+    const estimatedOperations = value.length + (boundary * 4);
+    if (estimatedOperations > operationLimit) {
+      result.overBudget = true;
+      return result;
+    }
 
     const stableCandidate = value.slice(0, boundary);
-    if (!stableCandidate.trim()) return 0;
-    if (isInCodeBlockFast(value, boundary)) return 0;
-    if (!areInlineMarkersBalanced(stableCandidate)) return 0;
-    if (!areMathDelimitersBalanced(stableCandidate)) return 0;
-    if (containsListOrTableSyntax(stableCandidate)) return 0;
+    if (!stableCandidate.trim()) return result;
+    if (isInCodeBlockFast(value, boundary)) {
+      result.operations = estimatedOperations;
+      return result;
+    }
 
-    return boundary;
+    const balanceCandidate = withoutFencedCode(stableCandidate);
+    if (!areInlineMarkersBalanced(balanceCandidate)) {
+      result.operations = estimatedOperations;
+      return result;
+    }
+    if (!areMathDelimitersBalanced(balanceCandidate)) {
+      result.operations = estimatedOperations;
+      return result;
+    }
+    if (boundarySplitsList(value, boundary, stableCandidate)) {
+      result.operations = estimatedOperations;
+      return result;
+    }
+
+    result.boundary = boundary;
+    result.operations = estimatedOperations;
+    return result;
+  }
+
+  function findStableMarkdownBoundary(text, minTailLength) {
+    return analyzeStableMarkdownBoundary(text, minTailLength).boundary;
   }
 
   return {
+    MAX_MUTABLE_MARKDOWN_CHARS,
+    MAX_STABLE_BOUNDARY_OPERATIONS,
     createStreamingState,
     nextStreamingRenderDelay,
     countCodeFencesFast,
     isInCodeBlockFast,
     areInlineMarkersBalanced,
     areMathDelimitersBalanced,
+    analyzeStableMarkdownBoundary,
     findStableMarkdownBoundary,
     canStreamPlainTextTail,
     canStreamPlainTextTailIncremental,

--- a/internal/serveui/static/markdown_streaming_test.js
+++ b/internal/serveui/static/markdown_streaming_test.js
@@ -44,7 +44,7 @@ expectTrue(
   'createStreamingState starts with stable and tail streaming containers unset',
   (() => {
     const state = streaming.createStreamingState();
-    return state && state.stableContainer === null && state.stableLength === 0 && state.stableSource === '' && state.tailContainer === null;
+    return state && state.stableContainer === null && state.stableLength === 0 && state.tailContainer === null;
   })()
 );
 
@@ -181,15 +181,66 @@ expectEqual(
   0
 );
 expectEqual(
-  'findStableMarkdownBoundary is conservative for lists',
+  'findStableMarkdownBoundary stabilizes completed lists',
   streaming.findStableMarkdownBoundary('- one\n- two\n\nrest of response', 5),
+  '- one\n- two\n\n'.length
+);
+expectEqual(
+  'findStableMarkdownBoundary does not split a loose list before another item',
+  streaming.findStableMarkdownBoundary('- one\n\n- two continues the same list with enough text', 5),
   0
 );
 expectEqual(
-  'findStableMarkdownBoundary is conservative for tables',
-  streaming.findStableMarkdownBoundary('| a | b |\n| - | - |\n\nrest of response', 5),
+  'findStableMarkdownBoundary preserves indentation when checking loose-list continuation',
+  streaming.findStableMarkdownBoundary('- one\n\n  continued paragraph in the same loose list item with enough text', 5),
   0
 );
+expectEqual(
+  'findStableMarkdownBoundary preserves indentation when checking list-item code',
+  streaming.findStableMarkdownBoundary('- one\n\n    indented code in the same list item with enough text', 5),
+  0
+);
+expectEqual(
+  'findStableMarkdownBoundary stabilizes completed tables',
+  streaming.findStableMarkdownBoundary('| a | b |\n| - | - |\n\nrest of response', 5),
+  '| a | b |\n| - | - |\n\n'.length
+);
+expectEqual(
+  'findStableMarkdownBoundary stabilizes GFM tables without outer pipes',
+  streaming.findStableMarkdownBoundary('a | b\n--- | ---\n1 | 2\n\nrest of response', 5),
+  'a | b\n--- | ---\n1 | 2\n\n'.length
+);
+expectEqual(
+  'findStableMarkdownBoundary stabilizes closed tilde fences with markdown-like code',
+  streaming.findStableMarkdownBoundary('~~~txt\n* literal marker\n~~~\n\nrest of response', 5),
+  '~~~txt\n* literal marker\n~~~\n\n'.length
+);
+
+expectEqual(
+  'findStableMarkdownBoundary rejects fence-like lines with trailing info as closers',
+  streaming.findStableMarkdownBoundary('```txt\ncode\n```not-a-close\n\nrest of response', 5),
+  0
+);
+
+const bounded = streaming.analyzeStableMarkdownBoundary(
+  '```txt\n' + 'unfinished * fenced text\n'.repeat(5000),
+  256
+);
+expectTrue('stable-boundary analysis reports oversized incomplete tails', bounded.overBudget);
+expectEqual('oversized stable-boundary analysis does not scan past its budget', bounded.operations, 0);
+expectTrue(
+  'stable-boundary analysis exposes a fixed mutable markdown limit',
+  Number(streaming.MAX_MUTABLE_MARKDOWN_CHARS) > 0
+    && bounded.mutableTailLength > streaming.MAX_MUTABLE_MARKDOWN_CHARS
+);
+
+const operationLimited = streaming.analyzeStableMarkdownBoundary(
+  'Paragraph one.\n\n' + 'tail '.repeat(100),
+  10,
+  { maxOperations: 32 }
+);
+expectTrue('stable-boundary analysis falls back on deterministic operation budget', operationLimited.overBudget);
+expectTrue('operation-budget fallback stays within the declared budget', operationLimited.operations <= 32);
 
 if (failures > 0) {
   console.error('\n' + failures + ' test(s) failed');

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -529,6 +529,12 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 
 	// Signal idle resets via channel so we avoid concurrent Timer.Reset / Timer.C access.
 	activity := make(chan struct{}, 1)
+	noteActivity := func() {
+		select {
+		case activity <- struct{}{}:
+		default:
+		}
+	}
 	requestSlots := make(chan struct{}, maxDataChannelConcurrentRequests)
 	stop := make(chan struct{})
 	var stopOnce sync.Once
@@ -551,6 +557,10 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 		_, err := dc.WriteDataChannel([]byte(text), true)
 		if err != nil {
 			stopDataChannel()
+		} else {
+			// Successful response frames, including long-lived SSE chunks, are
+			// connection activity just as much as inbound requests are.
+			noteActivity()
 		}
 		return err
 	}
@@ -574,10 +584,7 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 			}
 			data := make([]byte, n)
 			copy(data, buf[:n])
-			select {
-			case activity <- struct{}{}:
-			default:
-			}
+			noteActivity()
 			if !tryAcquireDataChannelRequestSlot(dataChannelCtx, stop, requestSlots) {
 				select {
 				case <-dataChannelCtx.Done():
@@ -626,6 +633,14 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 			}
 			idle.Reset(p.cfg.IdleTimeout)
 		case <-idle.C:
+			// If a successful outbound write raced with the timer delivery,
+			// honor that queued activity rather than closing an active stream.
+			select {
+			case <-activity:
+				idle.Reset(p.cfg.IdleTimeout)
+				continue
+			default:
+			}
 			log.Printf("webrtc: connection idle timeout, closing data channel")
 			stopDataChannel()
 			<-readDone

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -108,6 +109,109 @@ func TestRunDataChannel_IdleTimeoutClosesTransportToWakeReader(t *testing.T) {
 	case <-transportClosed:
 	default:
 		t.Fatal("idle timeout did not close the underlying transport")
+	}
+}
+
+type streamingReadDataChannel struct {
+	request       []byte
+	requestOnce   sync.Once
+	readUnblock   chan struct{}
+	closed        chan struct{}
+	closeOnce     sync.Once
+	transportOnce sync.Once
+	writes        chan responseFrame
+}
+
+func (d *streamingReadDataChannel) ReadDataChannel(buf []byte) (int, bool, error) {
+	read := false
+	d.requestOnce.Do(func() {
+		copy(buf, d.request)
+		read = true
+	})
+	if read {
+		return len(d.request), true, nil
+	}
+	<-d.readUnblock
+	return 0, false, io.EOF
+}
+
+func (d *streamingReadDataChannel) WriteDataChannel(data []byte, _ bool) (int, error) {
+	var frame responseFrame
+	if err := json.Unmarshal(data, &frame); err == nil {
+		d.writes <- frame
+	}
+	return len(data), nil
+}
+
+func (d *streamingReadDataChannel) Close() error {
+	d.closeOnce.Do(func() { close(d.closed) })
+	return nil
+}
+
+func TestRunDataChannel_SuccessfulOutboundStreamingResetsIdleTimeout(t *testing.T) {
+	const idleTimeout = 100 * time.Millisecond
+	allowNextChunk := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("response writer does not implement http.Flusher")
+			return
+		}
+		for i := 0; i < 6; i++ {
+			_, _ = io.WriteString(w, "stream activity\n")
+			flusher.Flush()
+			if i < 5 {
+				<-allowNextChunk
+			}
+		}
+	})
+	p := newTestPeer("/ui", handler)
+	p.cfg.IdleTimeout = idleTimeout
+
+	dc := &streamingReadDataChannel{
+		request:     encodeRequest("stream-idle", http.MethodGet, "/ui/v1/stream", nil, ""),
+		readUnblock: make(chan struct{}),
+		closed:      make(chan struct{}),
+		writes:      make(chan responseFrame, 64),
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.runDataChannel(context.Background(), dc, func() {
+			dc.transportOnce.Do(func() { close(dc.readUnblock) })
+		})
+	}()
+
+	chunks := 0
+	deadline := time.After(3 * time.Second)
+	for chunks < 6 {
+		select {
+		case frame := <-dc.writes:
+			if frame.Type != "chunk" {
+				continue
+			}
+			chunks++
+			select {
+			case <-dc.closed:
+				t.Fatalf("idle timer closed active stream after %d outbound chunks", chunks)
+			default:
+			}
+			if chunks < 6 {
+				// Keep every gap comfortably below IdleTimeout while making total
+				// stream duration exceed it. Each next chunk is synchronized by
+				// its observed outbound frame rather than an unsignaled sleep loop.
+				time.Sleep(idleTimeout / 4)
+				allowNextChunk <- struct{}{}
+			}
+		case <-deadline:
+			t.Fatalf("timed out after %d outbound chunks", chunks)
+		}
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("connection did not become truly idle after outbound stream completed")
 	}
 }
 


### PR DESCRIPTION
## What

Hardens long-running WebUI sessions without introducing transcript virtualization.

- makes the 60-second response reconnect backoff wake immediately on `online`, visibility restoration, or `pageshow`
- gives each reconnect loop explicit ownership so detach/session switches cancel sleeping waiters without allowing duplicate loops
- bounds mutable streamed-Markdown work at 64 KiB and falls back to incremental plain text until exact final Markdown rendering
- safely promotes completed lists, tables, and closed fences while retaining loose-list continuations
- validates promoted streaming prefixes with bounded-memory fingerprints so snapshot recovery cannot leave stale rendered content
- fully evicts duplicate inactive-session history representations after the existing 10-session cache limit
- replaces quadratic legacy compaction-tail matching with a linear prefix-function overlap
- treats session-state 401 responses as authentication failures rather than transient network failures
- counts successful outbound WebRTC frames as activity so the 30-minute idle timeout cannot kill an active response
- adds opt-in diagnostics for reconnect state, render duration/DOM size, Markdown-tail mode, and WebRTC fallback state

Transcript virtualization/node shedding, WebRTC compression framing, and a new application-level backpressure protocol remain intentionally out of scope.

## Why

Long browser sessions progressively accumulated mounted transcript work, while complex streamed Markdown could repeatedly parse, sanitize, and replace a growing response tail. Connection recovery could also sleep for a full minute after connectivity had already returned, making reload appear necessary.

This PR addresses the bounded correctness and recovery defects first. Transcript node shedding can follow separately.

## Measured streaming result

The same real-Chromium production-cadence harness streamed a 212,520-character bullet-list response before and after this change:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Wall time | 7,219.3 ms | 5,174.9 ms | -2,044.4 ms / **-28.3%** |
| Producer timer p95 | 108.2 ms | 21.9 ms | **-79.8%** |
| Maximum timer stall | 283.9 ms | 55.8 ms | **-80.3%** |
| Sanitizations | 32 | 16 | **-50%** |
| Time in DOMPurify | 402.7 ms | 61.8 ms | **-84.7%** |
| Timer stalls over 100 ms | 16 | 0 | eliminated |

A similarly sized 225,280-character plain-text stream remains near its nominal 20 ms cadence.

## Browser smoke test

A throwaway server was built from this branch and exercised with system Chromium through Playwright:

- real provider stream rendered exactly 250 Markdown list items
- 9,197 streamed characters completed with no recorded long tasks
- synthetic 92,533-character incomplete fenced block entered bounded `plain-fallback` mode
- subsequent deltas appended to the same text node without Markdown reparsing
- finalization replaced fallback output with one correctly rendered code block
- reload restored the persisted two-message transcript and left the composer responsive
- no page exceptions or unexpected HTTP failures

The expected `GET /v1/worktrees` 409 occurred because the throwaway server intentionally had no agent worktree context.

## Polling recovery pathology

A production trace showed the final sidebar status poll at `+606,647 ms` and WebRTC closure at `+2,406,646 ms`: a **1,799,999 ms gap, effectively the exact 30-minute idle timeout**. The transport correctly restored HTTPS, but the already-stopped status loop was never restarted, leaving conversation metadata/transcripts stale until reload.

This PR now also:

- serializes sidebar polling to one timer and one request;
- aborts and generation-invalidates hidden/stale requests;
- immediately resumes polling on BFCache-style `pageshow`, even without a visibility transition;
- has WebRTC signal the app exactly once when falling back to HTTPS;
- guards stale data-channel close callbacks from disrupting newer channels;
- forces one immediate reconciliation and then continues normal visible polling.

A real Chromium smoke test stopped polling, dispatched `pageshow`, and emitted repeated transport-recovery signals. It observed exactly one immediate status request at **+3 ms** and exactly one continued request at **+5,006 ms**, with no page errors.

## Review

Claude Fable 5 reviewed the complete diff and found:

- stale stable-prefix rendering after divergent snapshot recovery
- an indentation bug around loose-list continuation detection
- incomplete middle-prefix divergence detection
- overly fast fallback pacing
- diagnostics writes that were not fully opt-in
- ambiguous reconnect wake arguments
- a fragile session-state return contract

All findings were addressed with regression coverage. A subsequent independent reviewer found one remaining detach/reconnect waiter ownership race; that was also fixed with a deterministic switch-away/switch-back test.

## Verification

- `git diff --check`
- `go build ./...`
- `go test ./...` with isolated `HOME`/XDG directories
- `go test ./internal/serveui ./internal/webrtc -count=1`
- `go test -race ./internal/webrtc -count=1`
- embedded Node/browser-style suites for core, rendering, sessions, streaming, and Markdown boundaries
- real Chromium Playwright smoke test
