### PR TITLE
fix: Shared provider transport disables HTTP/2 and churns concurrent connections

### DIFF
--- a/internal/llm/copilot.go
+++ b/internal/llm/copilot.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -47,16 +46,7 @@ const (
 // http.Client.Timeout is intentionally NOT set: it applies to the entire
 // request lifetime including reading the streaming response body, and would
 // abort legitimate long-running Copilot streams.
-var copilotHTTPClient = &http.Client{
-	Transport: &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   15 * time.Second,
-		ResponseHeaderTimeout: 2 * time.Minute,
-		IdleConnTimeout:       90 * time.Second,
-	},
-}
+var copilotHTTPClient = newStreamingHTTPClient()
 
 // CopilotProvider implements Provider using GitHub Copilot's OpenAI-compatible API.
 type CopilotProvider struct {

--- a/internal/llm/openai_compat.go
+++ b/internal/llm/openai_compat.go
@@ -18,6 +18,21 @@ import (
 	"github.com/samsaffron/term-llm/internal/providerhttp"
 )
 
+// newStreamingHTTPClient creates an HTTP client with transport-level timeouts.
+// It clones the default transport to retain HTTP/2 and standard connection-pool
+// behavior, while allowing more concurrent provider connections to remain idle.
+func newStreamingHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout: 30 * time.Second,
+	}).DialContext
+	transport.TLSHandshakeTimeout = 15 * time.Second
+	transport.ResponseHeaderTimeout = 2 * time.Minute
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.MaxIdleConnsPerHost = 100
+	return &http.Client{Transport: transport}
+}
+
 // defaultHTTPClient is a shared HTTP client with transport-level timeouts.
 //
 // http.Client.Timeout is intentionally NOT set: it applies to the entire
@@ -27,16 +42,7 @@ import (
 // Instead we use Transport-level timeouts that only cover connection
 // establishment and the initial response headers, so hung connections fail
 // fast while active streams are never killed.
-var defaultHTTPClient = &http.Client{
-	Transport: &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   15 * time.Second,
-		ResponseHeaderTimeout: 2 * time.Minute,
-		IdleConnTimeout:       90 * time.Second,
-	},
-}
+var defaultHTTPClient = newStreamingHTTPClient()
 
 // OpenAICompatProvider implements Provider for OpenAI-compatible APIs
 // Used by Ollama, LM Studio, and other compatible servers.

--- a/internal/llm/openai_compat_test.go
+++ b/internal/llm/openai_compat_test.go
@@ -22,6 +22,48 @@ func TestDefaultHTTPClient_HasNoOverallTimeout(t *testing.T) {
 	}
 }
 
+func TestProviderHTTPClients_UseHTTP2WithLargerIdlePool(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	serverTransport := server.Client().Transport.(*http.Transport)
+	clients := map[string]*http.Client{
+		"default": defaultHTTPClient,
+		"copilot": copilotHTTPClient,
+	}
+	for name, providerClient := range clients {
+		t.Run(name, func(t *testing.T) {
+			providerTransport, ok := providerClient.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("transport type = %T, want *http.Transport", providerClient.Transport)
+			}
+			if !providerTransport.ForceAttemptHTTP2 {
+				t.Fatal("HTTP/2 is not enabled")
+			}
+			if providerTransport.MaxIdleConnsPerHost <= http.DefaultMaxIdleConnsPerHost {
+				t.Fatalf("MaxIdleConnsPerHost = %d, want more than default %d", providerTransport.MaxIdleConnsPerHost, http.DefaultMaxIdleConnsPerHost)
+			}
+
+			transport := providerTransport.Clone()
+			transport.TLSClientConfig = serverTransport.TLSClientConfig.Clone()
+			defer transport.CloseIdleConnections()
+
+			response, err := (&http.Client{Transport: transport}).Get(server.URL)
+			if err != nil {
+				t.Fatalf("HTTP/2 request: %v", err)
+			}
+			defer response.Body.Close()
+			if response.ProtoMajor != 2 {
+				t.Fatalf("response protocol = %s, want HTTP/2", response.Proto)
+			}
+		})
+	}
+}
+
 func TestReadSSEEvent_AllowsEventAndDataLinesWithoutSpace(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("event:error\ndata:{\"error\":{\"message\":\"boom\"}}\n\n"))
 


### PR DESCRIPTION
## What changed

- Build the shared streaming provider transport by cloning `http.DefaultTransport`, preserving HTTP/2 support, proxy handling, and the standard global idle pool.
- Retain the existing dial, TLS handshake, response-header, and idle timeouts while increasing `MaxIdleConnsPerHost` to 100.
- Use the same transport constructor for GitHub Copilot.
- Add a TLS `httptest` regression test that verifies both clients negotiate HTTP/2 and have a larger per-host idle pool.

## Why this is high-value

The shared client handles OpenAI-compatible, OpenAI, ChatGPT, Gemini, xAI, Ollama, and other daily provider traffic. Its custom zero-value transport disabled conservative automatic HTTP/2 and retained only two idle connections per host. Parallel streams therefore opened separate HTTP/1.1 TCP/TLS connections, then discarded excess idle connections after bursts. Restoring HTTP/2 lets concurrent requests multiplex over established connections, while the larger per-host idle pool avoids repeated TCP/TLS setup for bursty jobs, subagents, web, and Telegram requests. Copilot had the same transport construction and receives the same fix.

## Validation

- `gofmt -w internal/llm/openai_compat.go internal/llm/copilot.go internal/llm/openai_compat_test.go`
- `go build ./...`
- `go test ./internal/llm -run 'Test(DefaultHTTPClient_HasNoOverallTimeout|ProviderHTTPClients_UseHTTP2WithLargerIdlePool)$' -count=1`
- `TEST_HOME=$(mktemp -d); HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" CODEX_HOME="$TEST_HOME/.codex" go test ./...`
- `git diff --check`
