### PR TITLE
fix: keep model picker visible on mobile

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -94,6 +94,11 @@ func TestHeaderControlsUseSharedActionPill(t *testing.T) {
 		t.Fatalf("StaticAsset(app.css): %v", err)
 	}
 	cssSrc := string(css)
+	for _, block := range cssRuleBlocks(cssSrc, ".header-stats") {
+		if strings.Contains(block, "display: none;") {
+			t.Fatalf("mobile header must keep the model picker visible: %s", block)
+		}
+	}
 	for _, want := range []string{
 		"--header-action-height:",
 		"--header-action-radius:",
@@ -137,17 +142,29 @@ func TestHeaderControlsUseSharedActionPill(t *testing.T) {
 }
 
 func cssRuleBlock(cssSrc, selector string) string {
+	blocks := cssRuleBlocks(cssSrc, selector)
+	if len(blocks) == 0 {
+		return ""
+	}
+	return blocks[0]
+}
+
+func cssRuleBlocks(cssSrc, selector string) []string {
 	needle := selector + " {"
-	start := strings.Index(cssSrc, needle)
-	if start < 0 {
-		return ""
+	var blocks []string
+	for {
+		start := strings.Index(cssSrc, needle)
+		if start < 0 {
+			return blocks
+		}
+		bodyStart := start + len(needle)
+		end := strings.Index(cssSrc[bodyStart:], "}")
+		if end < 0 {
+			return blocks
+		}
+		blocks = append(blocks, cssSrc[bodyStart:bodyStart+end])
+		cssSrc = cssSrc[bodyStart+end+1:]
 	}
-	bodyStart := start + len(needle)
-	end := strings.Index(cssSrc[bodyStart:], "}")
-	if end < 0 {
-		return ""
-	}
-	return cssSrc[bodyStart : bodyStart+end]
 }
 
 func TestStaticAssetsEmbedProductionFilesOnly(t *testing.T) {

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -4649,15 +4649,6 @@
       }
     }
 
-    @media (max-width: 480px) {
-      /* Preserve direct navigation, worktree, Plan, and Changes targets when
-         the full provider/model/MCP cluster no longer fits. Runtime settings
-         remain available from Settings. */
-      .header-stats {
-        display: none;
-      }
-    }
-
 /* Side questions stay compact so the main conversation remains visible. */
 .side-question-overlay {
   position: fixed;


### PR DESCRIPTION
## What

- keep the compact model picker visible below 480px instead of hiding the entire header stats cluster
- add a regression assertion preventing responsive CSS from hiding `.header-stats`

## Why

A fresh mobile chat showed only the menu and title, with no indication of which model would answer. The narrow model pill was already designed to fit this breakpoint; a later 480px rule hid its parent wholesale.

## Reproduction

Confirmed before changing code on the current deployed binary at an iPhone 14 viewport: a fresh chat had no model control in the header.

After the fix, the default model pill is visible and usable at 390px and still fits without overlap at 320px.

## Tests

- `go test ./internal/serveui -count=1`
- `go build ./...`
- browser smoke at 390px and 320px viewports

`go test ./...` otherwise passed except for two unrelated `cmd` skill-discovery tests that picked up the host's user skill catalog and omitted their temporary fixture skill due the configured metadata cap.
