### PR TITLE
fix: reconcile session transcript across tabs

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1734,6 +1734,16 @@ const refreshActiveSessionMessagesFromServer = async (session, options = {}) => 
   return refreshPromise;
 };
 
+const attachExternallyActiveResponseAfterCatchUp = async (session, refreshed) => {
+  if (!refreshed || !session || session.id !== state.activeSessionId) return false;
+  if (document.visibilityState === 'hidden' || state.draftSessionActive) return false;
+  if (state.abortController || state.streaming || session.activeResponseId) return false;
+  const progress = state.sessionProgressById?.[session.id] || null;
+  if (!progress?.serverActiveRun || progress?.optimisticBusy) return false;
+  await syncActiveSessionFromServer(session, true, { skipMessagesFetch: true });
+  return true;
+};
+
 const reconcilePendingActiveTranscriptRefresh = async () => {
   const active = getActiveSession();
   if (!active) return false;
@@ -1745,13 +1755,16 @@ const reconcilePendingActiveTranscriptRefresh = async () => {
     return false;
   }
 
+  const progress = state.sessionProgressById?.[active.id] || null;
   const refreshed = await refreshActiveSessionMessagesFromServer(active, {
     transcriptUpdatedAt: pendingTranscriptUpdatedAt,
-    forceScroll: false
+    forceScroll: false,
+    allowServerActiveRun: Boolean(progress?.serverActiveRun)
   });
   if (numericTranscriptUpdatedAt(active.transcriptUpdatedAt) === pendingTranscriptUpdatedAt) {
     delete active._pendingTranscriptUpdatedAt;
   }
+  await attachExternallyActiveResponseAfterCatchUp(active, refreshed);
   return refreshed;
 };
 
@@ -1784,6 +1797,7 @@ const reconcileActiveTranscriptFromStatus = async (statusSessions) => {
   if (numericTranscriptUpdatedAt(active.transcriptUpdatedAt) === incomingTranscriptUpdatedAt) {
     delete active._pendingTranscriptUpdatedAt;
   }
+  await attachExternallyActiveResponseAfterCatchUp(active, refreshed);
   return refreshed;
 };
 
@@ -3356,8 +3370,18 @@ document.addEventListener('visibilitychange', async () => {
   // one while this page was hidden; attaching first would only replay the new
   // response and leave the earlier turns missing.
   await startSidebarStatusPoll();
+  if (document.visibilityState !== 'visible') return;
   const session = getActiveSession();
   if (!session) return;
+
+  const pendingTranscriptUpdatedAt = numericTranscriptUpdatedAt(session._pendingTranscriptUpdatedAt);
+  if (pendingTranscriptUpdatedAt > numericTranscriptUpdatedAt(session.transcriptUpdatedAt)) {
+    // Do not attach a newer response onto a stale transcript. The visible
+    // status poll retains the pending version and retries the tail fetch; once
+    // it succeeds, reconciliation attaches the external response itself.
+    setConnectionState('Catching up with this session\u2026', 'bad');
+    return;
+  }
 
   if (session.activeResponseId && app.wakeResponseReconnect?.({
     reason: 'visibility',

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1635,14 +1635,20 @@ const recordTranscriptVersionsFromStatus = (statusSessions) => {
   }
 };
 
-const canRefreshActiveSessionMessages = (session) => {
+const canRefreshActiveSessionMessages = (session, options = {}) => {
   if (!session || session.id !== state.activeSessionId) return false;
   if (document.visibilityState === 'hidden') return false;
   if (state.draftSessionActive) return false;
   if (state.abortController || state.streaming) return false;
   if (session.activeResponseId) return false;
   if (state.currentStreamSessionId === session.id && state.currentStreamResponseId) return false;
-  if (sessionHasInProgressState(session)) return false;
+  const progress = state.sessionProgressById?.[session.id] || null;
+  const onlyServerRunIsActive = Boolean(
+    options.allowServerActiveRun
+    && progress?.serverActiveRun
+    && !progress?.optimisticBusy
+  );
+  if (sessionHasInProgressState(session) && !onlyServerRunIsActive) return false;
   const history = ensureSessionHistory(session);
   if (!history || history.loadingOlder) return false;
   return true;
@@ -1669,7 +1675,7 @@ const refreshActiveSessionMessagesFromServer = async (session, options = {}) => 
     return false;
   }
 
-  if (!canRefreshActiveSessionMessages(session)) return false;
+  if (!canRefreshActiveSessionMessages(session, options)) return false;
 
   const refreshSessionId = session.id;
   const refreshPromise = (async () => {
@@ -1692,7 +1698,7 @@ const refreshActiveSessionMessagesFromServer = async (session, options = {}) => 
       }
       if (!page) return false;
 
-      if (!canRefreshActiveSessionMessages(session) || session.id !== state.activeSessionId) {
+      if (!canRefreshActiveSessionMessages(session, options) || session.id !== state.activeSessionId) {
         return false;
       }
 
@@ -1766,13 +1772,14 @@ const reconcileActiveTranscriptFromStatus = async (statusSessions) => {
   }
 
   active._pendingTranscriptUpdatedAt = incomingTranscriptUpdatedAt;
-  if (entry.active_run) {
-    return false;
-  }
-
   const refreshed = await refreshActiveSessionMessagesFromServer(active, {
     transcriptUpdatedAt: incomingTranscriptUpdatedAt,
-    forceScroll: false
+    forceScroll: false,
+    // A foreground tab can discover that another tab has already advanced the
+    // transcript and started the next response. Catch up the committed tail
+    // before attaching that response's event stream; the stream snapshot only
+    // reconstructs its own turn and cannot fill gaps from earlier turns.
+    allowServerActiveRun: Boolean(entry.active_run)
   });
   if (numericTranscriptUpdatedAt(active.transcriptUpdatedAt) === incomingTranscriptUpdatedAt) {
     delete active._pendingTranscriptUpdatedAt;
@@ -3344,7 +3351,11 @@ document.addEventListener('visibilitychange', async () => {
     stopSidebarStatusPoll();
     return;
   }
-  startSidebarStatusPoll();
+  // Reconcile the authoritative transcript before looking for an active
+  // response. Another tab may have completed several turns and started a new
+  // one while this page was hidden; attaching first would only replay the new
+  // response and leave the earlier turns missing.
+  await startSidebarStatusPoll();
   const session = getActiveSession();
   if (!session) return;
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -4040,6 +4040,175 @@ async function testForegroundCatchUpRefreshesTranscriptBeforeResumingExternalRun
   pass(name);
 }
 
+async function testForegroundCatchUpRetriesBeforeAttachingExternalRun() {
+  const name = 'failed foreground catch-up retries before attaching another tab run';
+  let appRef = null;
+  let testReady = false;
+  let messageCalls = 0;
+  let stateCalls = 0;
+  let resumeCalls = 0;
+  const harness = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        return new Response(JSON.stringify({
+          sessions: testReady ? [{
+            id: 'sess_retry_cross_tab',
+            short_title: 'Retry cross tab',
+            active_run: true,
+            transcript_updated_at: 2000,
+          }] : []
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_retry_cross_tab')) {
+        messageCalls += 1;
+        if (messageCalls === 1) {
+          return new Response('temporary failure', { status: 503 });
+        }
+        return new Response(JSON.stringify({
+          messages: [{
+            id: 'msg_retry_caught_up',
+            sequence: 2,
+            role: 'assistant',
+            created_at: 1710000000002,
+            parts: [{ type: 'text', text: 'caught up after retry' }],
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === '/ui/v1/sessions/sess_retry_cross_tab/state') {
+        stateCalls += 1;
+        return new Response(JSON.stringify({
+          active_run: true,
+          active_response_id: 'resp_retry_cross_tab',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: {
+      updateSidebarStatus(entries) {
+        if (!appRef) return;
+        for (const entry of entries) {
+          appRef.setSessionServerActiveRun(entry.id, Boolean(entry.active_run));
+        }
+      },
+      async resumeActiveResponse() { resumeCalls += 1; },
+    },
+  });
+  const { app, windowObj } = harness;
+  appRef = app;
+  await app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_retry_cross_tab',
+    title: 'Retry cross tab',
+    origin: 'web',
+    created: 1710000000000,
+    transcriptUpdatedAt: 1000,
+    messages: [],
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  testReady = true;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+
+  if (messageCalls !== 1 || stateCalls !== 0 || resumeCalls !== 0 || session.activeResponseId) {
+    fail(name, 'failed catch-up attached the external response instead of leaving it pending', JSON.stringify({ messageCalls, stateCalls, resumeCalls, activeResponseId: session.activeResponseId }));
+    return;
+  }
+
+  await app.startSidebarStatusPoll();
+  await Promise.resolve();
+  await Promise.resolve();
+  app.stopSidebarStatusPoll();
+
+  if (messageCalls !== 2 || stateCalls !== 1 || resumeCalls !== 1) {
+    fail(name, 'successful retry did not catch up and attach exactly once', JSON.stringify({ messageCalls, stateCalls, resumeCalls }));
+    return;
+  }
+  if (session.messages.length !== 1 || session.messages[0].content !== 'caught up after retry') {
+    fail(name, 'successful retry attached without applying the authoritative transcript', JSON.stringify(session.messages));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testForegroundCatchUpStopsWhenPageIsRehidden() {
+  const name = 'foreground catch-up does not attach after page is hidden again';
+  let testReady = false;
+  let resolveStatus = null;
+  let stateCalls = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status' && testReady) {
+        return new Promise((resolve) => {
+          resolveStatus = () => resolve(new Response(JSON.stringify({ sessions: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          }));
+        });
+      }
+      if (url === '/ui/v1/sessions/sess_rehidden/state') {
+        stateCalls += 1;
+        return new Response(JSON.stringify({ active_run: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+  });
+  await app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_rehidden',
+    title: 'Rehidden',
+    origin: 'web',
+    created: 1,
+    messages: [],
+    activeResponseId: null,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  testReady = true;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'visible';
+  const foregroundPromise = visibilityHandler({ type: 'visibilitychange' });
+  await Promise.resolve();
+  if (typeof resolveStatus !== 'function') {
+    fail(name, 'expected foreground reconciliation to wait on status');
+    return;
+  }
+
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  resolveStatus();
+  await foregroundPromise;
+  await Promise.resolve();
+
+  if (stateCalls !== 0) {
+    fail(name, `stale foreground handler issued ${stateCalls} hidden state requests`);
+    return;
+  }
+
+  pass(name);
+}
+
 async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   const name = 'online visibility and pageshow wake the existing response reconnect loop';
   const wakeReasons = [];
@@ -5396,6 +5565,8 @@ async function testSessionSwitchClearsPlanBeforeRejectingOldResponse() {
   await testActiveTranscriptRefreshSkipsBusyStates();
   await testLateActiveMessagesResponseIgnoredAfterSessionSwitch();
   await testForegroundCatchUpRefreshesTranscriptBeforeResumingExternalRun();
+  await testForegroundCatchUpRetriesBeforeAttachingExternalRun();
+  await testForegroundCatchUpStopsWhenPageIsRehidden();
   await testReconnectBackoffWakeSignalsReuseExistingLoop();
   await testLoadServerSessionStateUsesExplicitResultContract();
   await testSessionStatePollRetriesAfterTransientFailure();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3925,6 +3925,121 @@ async function testLateActiveMessagesResponseIgnoredAfterSessionSwitch() {
   pass(name);
 }
 
+async function testForegroundCatchUpRefreshesTranscriptBeforeResumingExternalRun() {
+  const name = 'foreground catch-up refreshes missed turns before resuming another tab run';
+  let appRef = null;
+  let testReady = false;
+  const order = [];
+  let resumeMessages = [];
+  const harness = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        order.push('status');
+        return new Response(JSON.stringify({
+          sessions: testReady ? [{
+            id: 'sess_cross_tab',
+            short_title: 'Cross tab',
+            active_run: true,
+            message_count: 3,
+            last_message_at: 1710000000003,
+            transcript_updated_at: 2000,
+          }] : []
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_cross_tab')) {
+        order.push('messages');
+        return new Response(JSON.stringify({
+          messages: [
+            {
+              id: 'msg_user_other_tab',
+              sequence: 2,
+              role: 'user',
+              created_at: 1710000000002,
+              parts: [{ type: 'text', text: 'continued in the other tab' }],
+            },
+            {
+              id: 'msg_assistant_other_tab',
+              sequence: 3,
+              role: 'assistant',
+              created_at: 1710000000003,
+              parts: [{ type: 'text', text: 'completed there' }],
+            },
+          ]
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"cross-tab-tail"' } });
+      }
+      if (url === '/ui/v1/sessions/sess_cross_tab/state') {
+        order.push('state');
+        return new Response(JSON.stringify({
+          active_run: true,
+          active_response_id: 'resp_other_tab',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: {
+      updateSidebarStatus(entries) {
+        if (!appRef) return;
+        for (const entry of entries) {
+          appRef.setSessionServerActiveRun(entry.id, Boolean(entry.active_run));
+        }
+      },
+      async resumeActiveResponse(session) {
+        order.push('resume');
+        resumeMessages = session.messages.map((message) => message.content);
+      },
+    },
+  });
+  const { app, windowObj } = harness;
+  appRef = app;
+  await app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_cross_tab',
+    title: 'Cross tab',
+    origin: 'web',
+    created: 1710000000000,
+    transcriptUpdatedAt: 1000,
+    messages: [{ id: 'old_local', role: 'user', content: 'original tab', created: 1710000000000 }],
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  testReady = true;
+  order.length = 0;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+  await Promise.resolve();
+  await Promise.resolve();
+  app.stopSidebarStatusPoll();
+
+  const messagesIndex = order.indexOf('messages');
+  const stateIndex = order.indexOf('state');
+  const resumeIndex = order.indexOf('resume');
+  if (messagesIndex < 0 || stateIndex < 0 || resumeIndex < 0 || !(messagesIndex < stateIndex && stateIndex < resumeIndex)) {
+    fail(name, 'expected status transcript catch-up before state attach and resume', JSON.stringify(order));
+    return;
+  }
+  if (!resumeMessages.includes('continued in the other tab') || !resumeMessages.includes('completed there')) {
+    fail(name, 'resumed stream did not retain turns committed by the other tab', JSON.stringify(resumeMessages));
+    return;
+  }
+  if (session.activeResponseId !== 'resp_other_tab') {
+    fail(name, `expected external response to be attached, got ${session.activeResponseId}`);
+    return;
+  }
+
+  pass(name);
+}
+
 async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   const name = 'online visibility and pageshow wake the existing response reconnect loop';
   const wakeReasons = [];
@@ -5280,6 +5395,7 @@ async function testSessionSwitchClearsPlanBeforeRejectingOldResponse() {
   await testStatusPollUnchangedTranscriptDoesNotFetchMessages();
   await testActiveTranscriptRefreshSkipsBusyStates();
   await testLateActiveMessagesResponseIgnoredAfterSessionSwitch();
+  await testForegroundCatchUpRefreshesTranscriptBeforeResumingExternalRun();
   await testReconnectBackoffWakeSignalsReuseExistingLoop();
   await testLoadServerSessionStateUsesExplicitResultContract();
   await testSessionStatePollRetriesAfterTransientFailure();


### PR DESCRIPTION
## What

- reconcile the active session transcript before attaching a response when a hidden tab becomes visible
- allow an idle tab to fetch committed transcript updates while the server reports a run started elsewhere
- preserve the existing guards for locally owned streams, optimistic sends, and session switches
- add a regression test covering: tab A goes hidden, tab B commits turns and starts another response, then tab A returns and catches up before resuming

## Why

A response event snapshot only reconstructs that response's turn. If another tab completed one or more turns and started a new response while the original tab was hidden, the original tab could attach the newest response without first loading the intervening committed transcript. That left a permanent gap in the visible conversation.

## Verification

- `node internal/serveui/static/app_sessions_test.js`
- all `internal/serveui/static/*_test.js`
- `go test ./internal/serveui/...`
- `go build ./...`
- `go test ./...` (the two `cmd` tests that pick up Jarvis's global skills fail in the normal environment; `XDG_CONFIG_HOME=$(mktemp -d) go test ./cmd` passes)
