### PR TITLE
fix: simplify diff bulk controls

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -472,8 +472,7 @@ const elements = {
   diffFileList: document.getElementById('diffFileList'),
   diffToggleBtn: document.getElementById('diffToggleBtn'),
   diffToggleBadge: document.getElementById('diffToggleBadge'),
-  diffExpandAllBtn: document.getElementById('diffExpandAllBtn'),
-  diffCollapseAllBtn: document.getElementById('diffCollapseAllBtn'),
+  diffBulkToggleBtn: document.getElementById('diffBulkToggleBtn'),
   diffFilterRow: document.getElementById('diffFilterRow'),
   diffFilterInput: document.getElementById('diffFilterInput')
 };

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -914,8 +914,30 @@ const scrollFileIntoView = (path) => {
   }
 };
 
+const allDiffFilesExpanded = (ds) => {
+  if (ds.files.size === 0) return false;
+  for (const path of ds.files.keys()) {
+    if (!ds.expanded.has(path)) return false;
+  }
+  return true;
+};
+
+const updateDiffBulkToggle = (ds) => {
+  const button = elements.diffBulkToggleBtn;
+  if (!button) return;
+  const collapse = allDiffFilesExpanded(ds);
+  const action = collapse ? 'collapse' : 'expand';
+  const label = collapse ? 'Collapse all' : 'Expand all';
+  button.dataset.action = action;
+  button.setAttribute('aria-label', `${label} files`);
+  button.setAttribute('title', label);
+  const actionElement = button.querySelector?.('.diff-bulk-toggle-action');
+  if (actionElement) actionElement.textContent = collapse ? 'Collapse' : 'Expand';
+};
+
 const renderDiffSidebarContent = (sessionId, ds) => {
   renderDiffTotals(ds);
+  updateDiffBulkToggle(ds);
   renderDiffAccordion(sessionId, ds);
   if (ds.pendingScrollPath) {
     scrollFileIntoView(ds.pendingScrollPath);
@@ -927,6 +949,7 @@ const renderDiffSidebar = (sessionId) => {
   if (sessionId !== state.activeSessionId) return;
   const ds = sessionDiffState(sessionId);
   applyDiffSidebarVisibility(ds);
+  updateDiffBulkToggle(ds);
   if (ds.files.size === 0) return;
   renderDiffTotals(ds);
   // Skip the accordion (and its lazy diff fetches) while hidden; it renders
@@ -983,6 +1006,14 @@ const collapseAllDiffFiles = () => {
   // Live changes must not immediately re-open what the user just closed.
   ds.files.forEach((_, path) => ds.userCollapsed.add(path));
   renderDiffSidebar(sessionId);
+};
+
+const toggleAllDiffFiles = () => {
+  const sessionId = state.activeSessionId;
+  if (!sessionId) return;
+  const ds = sessionDiffState(sessionId);
+  if (allDiffFilesExpanded(ds)) collapseAllDiffFiles();
+  else expandAllDiffFiles();
 };
 
 const setDiffFilter = (value) => {
@@ -1298,8 +1329,7 @@ elements.diffSidebarCloseBtn?.addEventListener?.('click', () => {
   if (isDiffDrawerViewport()) closeDiffDrawer();
   else setDiffSidebarHidden(true);
 });
-elements.diffExpandAllBtn?.addEventListener?.('click', expandAllDiffFiles);
-elements.diffCollapseAllBtn?.addEventListener?.('click', collapseAllDiffFiles);
+elements.diffBulkToggleBtn?.addEventListener?.('click', toggleAllDiffFiles);
 elements.diffFilterInput?.addEventListener?.('input', (event) => {
   setDiffFilter(event.target?.value ?? elements.diffFilterInput.value ?? '');
 });

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -326,6 +326,69 @@
       font-size: 0.8rem;
       color: var(--text-muted);
       font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+
+    .diff-bulk-toggle {
+      min-height: 34px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35rem;
+      padding: 0 0.65rem;
+      border: 1px solid color-mix(in srgb, var(--link) 32%, var(--border));
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--link) 8%, var(--surface-2));
+      color: var(--text);
+      font: inherit;
+      font-size: 0.78rem;
+      font-weight: 650;
+      line-height: 1;
+      white-space: nowrap;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: background 0.15s ease, border-color 0.15s ease;
+    }
+
+    .diff-bulk-toggle:hover {
+      border-color: color-mix(in srgb, var(--link) 48%, var(--border-strong));
+      background: color-mix(in srgb, var(--link) 13%, var(--surface-2));
+    }
+
+    .diff-bulk-toggle:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .diff-bulk-toggle svg {
+      flex: none;
+    }
+
+    .diff-bulk-collapse-icon,
+    .diff-bulk-toggle[data-action="collapse"] .diff-bulk-expand-icon {
+      display: none;
+    }
+
+    .diff-bulk-toggle[data-action="collapse"] .diff-bulk-collapse-icon {
+      display: inline;
+    }
+
+    .diff-sidebar-close {
+      border-radius: 50%;
+    }
+
+    @media (max-width: 360px) {
+      .diff-sidebar-header {
+        gap: 0.35rem;
+      }
+
+      .diff-bulk-toggle {
+        padding-inline: 0.5rem;
+      }
+
+      .diff-bulk-toggle-all {
+        display: none;
+      }
     }
 
     .diff-file-list {

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -124,14 +124,19 @@ function createHarness(options = {}) {
     diffFileList: new Element('div'),
     diffToggleBtn: new Element('button'),
     diffToggleBadge: new Element('span'),
-    diffExpandAllBtn: new Element('button'),
-    diffCollapseAllBtn: new Element('button'),
+    diffBulkToggleBtn: new Element('button'),
     diffFilterRow: new Element('div'),
     diffFilterInput: new Element('input')
   };
   elements.diffSidebar.hidden = true;
   elements.diffToggleBtn.hidden = true;
   elements.diffFilterRow.hidden = true;
+  const diffBulkToggleLabel = new Element('span');
+  diffBulkToggleLabel.className = 'diff-bulk-toggle-label';
+  const diffBulkToggleAction = new Element('span');
+  diffBulkToggleAction.className = 'diff-bulk-toggle-action';
+  diffBulkToggleLabel.appendChild(diffBulkToggleAction);
+  elements.diffBulkToggleBtn.appendChild(diffBulkToggleLabel);
 
   const state = {
     token: '',
@@ -925,23 +930,35 @@ async function run(name, fn) {
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 8, 'clearing the filter restores all rows');
   });
 
-  await run('expand-all and collapse-all act on every file and stick', async () => {
+  await run('adaptive bulk toggle expands, collapses, and sticks', async () => {
     const { app, elements, flushTimers } = createHarness();
+    const bulkLabel = () => `${elements.diffBulkToggleBtn.querySelector('.diff-bulk-toggle-action')?.textContent} all`;
     app.toggleDiffSidebar();
     for (let i = 1; i <= 3; i += 1) {
       app.handleFileChangeEvent({ id: 's1' }, { path: `/f${i}`, kind: 'modify', adds: 1, dels: 0, seq: i });
     }
     await flushTimers();
 
-    await elements.diffCollapseAllBtn.dispatchEvent({ type: 'click' });
-    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'collapse-all closes every body');
+    assertEqual(bulkLabel(), 'Expand all', 'mixed accordion offers to expand all');
+    assertEqual(elements.diffBulkToggleBtn.dataset.action, 'expand', 'expand icon state selected');
+    assertEqual(elements.diffBulkToggleBtn.getAttribute('aria-label'), 'Expand all files', 'expand action announced');
+
+    await elements.diffBulkToggleBtn.dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 3, 'first click opens every body');
+    assertEqual(bulkLabel(), 'Collapse all', 'fully expanded accordion offers to collapse all');
+    assertEqual(elements.diffBulkToggleBtn.dataset.action, 'collapse', 'collapse icon state selected');
+    assertEqual(elements.diffBulkToggleBtn.getAttribute('aria-label'), 'Collapse all files', 'collapse action announced');
+
+    await elements.diffBulkToggleBtn.dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'second click closes every body');
+    assertEqual(bulkLabel(), 'Expand all', 'collapsed accordion returns to expand action');
 
     app.handleFileChangeEvent({ id: 's1' }, { path: '/f1', kind: 'modify', adds: 2, dels: 0, seq: 4 });
     await flushTimers();
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'live changes do not undo collapse-all');
 
-    await elements.diffExpandAllBtn.dispatchEvent({ type: 'click' });
-    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 3, 'expand-all opens every body');
+    await elements.diffBulkToggleBtn.dispatchEvent({ type: 'click' });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 3, 'expand action remains available after live updates');
   });
 
   await run('escape closes the diff drawer but leaves inputs alone', async () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -340,9 +340,20 @@
       <div class="diff-sidebar-header">
         <span class="diff-sidebar-title">Changes</span>
         <span class="diff-sidebar-totals" id="diffSidebarTotals"></span>
-        <button class="icon-btn" id="diffExpandAllBtn" type="button" aria-label="Expand all files" title="Expand all">⌄</button>
-        <button class="icon-btn" id="diffCollapseAllBtn" type="button" aria-label="Collapse all files" title="Collapse all">⌃</button>
-        <button class="icon-btn" id="diffSidebarCloseBtn" type="button" aria-label="Hide changes" title="Hide changes">✕</button>
+        <button class="diff-bulk-toggle" id="diffBulkToggleBtn" type="button" aria-label="Expand all files" title="Expand all" data-action="expand">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <g class="diff-bulk-expand-icon">
+              <path d="m7 9 5-5 5 5"></path>
+              <path d="m7 15 5 5 5-5"></path>
+            </g>
+            <g class="diff-bulk-collapse-icon">
+              <path d="m7 4 5 5 5-5"></path>
+              <path d="m7 20 5-5 5 5"></path>
+            </g>
+          </svg>
+          <span class="diff-bulk-toggle-label"><span class="diff-bulk-toggle-action">Expand</span><span class="diff-bulk-toggle-all"> all</span></span>
+        </button>
+        <button class="icon-btn diff-sidebar-close" id="diffSidebarCloseBtn" type="button" aria-label="Hide changes" title="Hide changes">✕</button>
       </div>
       <div class="diff-filter-row" id="diffFilterRow" hidden>
         <input class="diff-filter-input" id="diffFilterInput" type="search" placeholder="Filter files…" aria-label="Filter changed files" autocomplete="off" spellcheck="false">


### PR DESCRIPTION
## What

- replace the separate Unicode expand/collapse buttons with one adaptive pill
- show **Expand all** while any file is collapsed, then switch to **Collapse all** once every file is open
- use inline SVG unfold icons instead of font-dependent glyphs
- keep the full accessible label and tooltip synchronized with the current action
- shorten the visible label to **Expand** / **Collapse** below 360px so the 90vw drawer still fits on a 320px viewport
- round the adjacent close control to harmonize with the pill

## Why

The old `⌄` and `⌃` controls looked like keyboard characters rather than intentional bulk actions. A single state-aware control is clearer, removes a redundant button, and makes the action explicit without bloating the mobile header.

## Tests

- `node internal/serveui/static/app_diffs_test.js`
- `go test ./internal/serveui`
- `go test ./...`
- `go build ./...`
- rendered both states at a 390px viewport and at the 288px drawer width produced by a 320px viewport; no overlap or wrapping
