### PR TITLE
fix: keep provider retries out of chat history

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1617,33 +1617,91 @@ const scrollToBottom = (force = false) => {
   }, remaining);
 };
 
+let legacyConnectionWarning = '';
+let providerRetryStatus = null;
+
 function hideConnectionState() {
   const el = elements.connectionState;
   if (!el) return;
   el.textContent = '';
-  el.classList.remove('ok', 'bad');
+  el.classList.remove('ok', 'bad', 'retry');
   el.hidden = true;
 }
 
-const setConnectionState = (text, mode = '') => {
+const visibleResponseIdForSession = (sessionId) => {
+  const ownerSessionId = String(sessionId || '').trim();
+  if (!ownerSessionId || state.draftSessionActive || String(state.activeSessionId || '').trim() !== ownerSessionId) {
+    return '';
+  }
+  const session = state.sessions.find((item) => String(item?.id || '').trim() === ownerSessionId) || null;
+  const trackedResponseId = String(session?.activeResponseId || '').trim();
+  if (trackedResponseId) return trackedResponseId;
+  if (String(state.currentStreamSessionId || '').trim() === ownerSessionId) {
+    return String(state.currentStreamResponseId || '').trim();
+  }
+  return '';
+};
+
+const providerRetryOwnerIsVisible = (status = providerRetryStatus) => Boolean(
+  status
+  && status.sessionId
+  && status.responseId
+  && visibleResponseIdForSession(status.sessionId) === status.responseId
+);
+
+const renderHeaderStatus = () => {
   const el = elements.connectionState;
   if (!el) return;
 
-  // Keep the header quiet during normal operation. The connection state is
-  // intentionally reserved for actionable warnings, so success/progress
-  // updates (including WebRTC "direct" status) do not compete with the
-  // session title and model chips.
   const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
-  const warningText = offline ? 'Network offline' : (mode === 'bad' ? String(text || '').trim() : '');
-  if (!warningText) {
+  const warningText = offline ? 'Network offline' : legacyConnectionWarning;
+  const retryText = !warningText && providerRetryOwnerIsVisible()
+    ? String(providerRetryStatus.text || '').trim()
+    : '';
+  if (!warningText && !retryText) {
     hideConnectionState();
     return;
   }
 
-  el.textContent = warningText;
-  el.classList.remove('ok');
-  el.classList.add('bad');
+  el.textContent = warningText || retryText;
+  el.classList.remove('ok', 'bad', 'retry');
+  el.classList.add(warningText ? 'bad' : 'retry');
   el.hidden = false;
+};
+
+const setConnectionState = (text, mode = '') => {
+  // Keep the header quiet during normal operation. The legacy connection state
+  // remains reserved for actionable warnings, while provider retries use their
+  // own lower-priority source below.
+  legacyConnectionWarning = mode === 'bad' ? String(text || '').trim() : '';
+  renderHeaderStatus();
+};
+
+const setProviderRetryStatus = (sessionId, responseId, text) => {
+  const next = {
+    sessionId: String(sessionId || '').trim(),
+    responseId: String(responseId || '').trim(),
+    text: String(text || '').trim(),
+  };
+  if (!next.sessionId || !next.responseId || !next.text || !providerRetryOwnerIsVisible(next)) {
+    return false;
+  }
+  providerRetryStatus = next;
+  renderHeaderStatus();
+  return true;
+};
+
+const clearProviderRetryStatus = (sessionId, responseId) => {
+  const ownerSessionId = String(sessionId || '').trim();
+  const ownerResponseId = String(responseId || '').trim();
+  if (!providerRetryStatus
+      || providerRetryStatus.sessionId !== ownerSessionId
+      || providerRetryStatus.responseId !== ownerResponseId) {
+    return false;
+  }
+  providerRetryStatus = null;
+  renderHeaderStatus();
+  return true;
 };
 
 const setStartupStatus = (text) => {
@@ -2431,6 +2489,8 @@ Object.assign(app, {
   shouldDisableAutoScrollForKey,
   scrollToBottom,
   setConnectionState,
+  setProviderRetryStatus,
+  clearProviderRetryStatus,
   setStartupStatus,
   hideStartupSplash,
   updateDocumentTitle,

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1618,6 +1618,7 @@ const scrollToBottom = (force = false) => {
 };
 
 let legacyConnectionWarning = '';
+let legacyConnectionWarningOwner = null;
 let providerRetryStatus = null;
 
 function hideConnectionState() {
@@ -1673,8 +1674,19 @@ const setConnectionState = (text, mode = '') => {
   // Keep the header quiet during normal operation. The legacy connection state
   // remains reserved for actionable warnings, while provider retries use their
   // own lower-priority source below.
+  const owner = {};
   legacyConnectionWarning = mode === 'bad' ? String(text || '').trim() : '';
+  legacyConnectionWarningOwner = owner;
   renderHeaderStatus();
+  return owner;
+};
+
+const clearConnectionStateOwner = (owner) => {
+  if (!owner || legacyConnectionWarningOwner !== owner) return false;
+  legacyConnectionWarning = '';
+  legacyConnectionWarningOwner = null;
+  renderHeaderStatus();
+  return true;
 };
 
 const setProviderRetryStatus = (sessionId, responseId, text) => {
@@ -2489,6 +2501,7 @@ Object.assign(app, {
   shouldDisableAutoScrollForKey,
   scrollToBottom,
   setConnectionState,
+  clearConnectionStateOwner,
   setProviderRetryStatus,
   clearProviderRetryStatus,
   setStartupStatus,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, persistAndRefreshShell, refreshRelativeTimes,
+  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
   splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
@@ -300,6 +300,19 @@ const stageCurrentComposerForSession = (sessionId) => {
   clearDraftMessageForSession(sessionId);
 };
 
+const clearSessionProviderRetryOwner = (sessionId) => {
+  const ownerSessionId = String(sessionId || '').trim();
+  if (!ownerSessionId) return false;
+  const session = state.sessions.find((item) => String(item?.id || '').trim() === ownerSessionId) || null;
+  const responseId = String(session?.activeResponseId || (
+    String(state.currentStreamSessionId || '').trim() === ownerSessionId
+      ? state.currentStreamResponseId
+      : ''
+  ) || '').trim();
+  if (!responseId) return false;
+  return clearProviderRetryStatus(ownerSessionId, responseId);
+};
+
 const invalidateSessionStateForSelection = (sessionId = '') => {
   state.sessionStateRequestGeneration = Number(state.sessionStateRequestGeneration || 0) + 1;
   state.lastAppliedSessionStateRequestGeneration = state.sessionStateRequestGeneration;
@@ -325,6 +338,7 @@ const switchToDraftSession = async (options = {}) => {
   closeAskUserModal();
   closeApprovalModal();
   closeMCPModal();
+  clearSessionProviderRetryOwner(previousActiveSessionId);
   if (state.currentStreamSessionId) {
     detachResponseStream();
   } else if (previousActiveSessionId && state.currentStreamSessionId !== previousActiveSessionId) {
@@ -450,6 +464,9 @@ const switchToSession = async (sessionId, options = {}) => {
   }
   if (mcpModalSessionId && mcpModalSessionId !== nextId) {
     closeMCPModal();
+  }
+  if (previousActiveSessionId && previousActiveSessionId !== nextId) {
+    clearSessionProviderRetryOwner(previousActiveSessionId);
   }
   if (state.currentStreamSessionId && state.currentStreamSessionId !== nextId) {
     detachResponseStream();

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
+  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, clearConnectionStateOwner, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
   splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
@@ -69,6 +69,8 @@ const SIDEBAR_POLL_IDLE = 30000;
 // Retry selected-session state after transient upstream/proxy failures so a
 // single hub/reverse blip does not permanently stop active-session updates.
 const SESSION_STATE_POLL_RETRY = 5000;
+const ACTIVE_TRANSCRIPT_CATCH_UP_TEXT = 'Catching up with this session\u2026';
+let activeTranscriptCatchUpWarning = null;
 let sidebarStatusTimer = null;
 let sidebarStatusEtag = null;
 let sidebarHasActive = false;
@@ -300,6 +302,33 @@ const stageCurrentComposerForSession = (sessionId) => {
   clearDraftMessageForSession(sessionId);
 };
 
+const showActiveTranscriptCatchUpWarning = (session, transcriptUpdatedAt) => {
+  const sessionId = String(session?.id || '').trim();
+  const targetTranscriptUpdatedAt = Number(transcriptUpdatedAt || 0);
+  if (!sessionId || !Number.isFinite(targetTranscriptUpdatedAt) || targetTranscriptUpdatedAt <= 0) return false;
+
+  activeTranscriptCatchUpWarning = {
+    sessionId,
+    transcriptUpdatedAt: targetTranscriptUpdatedAt,
+    connectionStateOwner: setConnectionState(ACTIVE_TRANSCRIPT_CATCH_UP_TEXT, 'bad'),
+  };
+  return true;
+};
+
+const clearActiveTranscriptCatchUpWarning = (sessionId, reconciledTranscriptUpdatedAt = null) => {
+  const ownerSessionId = String(sessionId || '').trim();
+  const warning = activeTranscriptCatchUpWarning;
+  if (!warning || warning.sessionId !== ownerSessionId) return false;
+
+  if (reconciledTranscriptUpdatedAt !== null) {
+    const reconciled = Number(reconciledTranscriptUpdatedAt || 0);
+    if (!Number.isFinite(reconciled) || reconciled < warning.transcriptUpdatedAt) return false;
+  }
+
+  activeTranscriptCatchUpWarning = null;
+  return clearConnectionStateOwner(warning.connectionStateOwner);
+};
+
 const clearSessionProviderRetryOwner = (sessionId) => {
   const ownerSessionId = String(sessionId || '').trim();
   if (!ownerSessionId) return false;
@@ -338,6 +367,7 @@ const switchToDraftSession = async (options = {}) => {
   closeAskUserModal();
   closeApprovalModal();
   closeMCPModal();
+  clearActiveTranscriptCatchUpWarning(previousActiveSessionId);
   clearSessionProviderRetryOwner(previousActiveSessionId);
   if (state.currentStreamSessionId) {
     detachResponseStream();
@@ -466,6 +496,7 @@ const switchToSession = async (sessionId, options = {}) => {
     closeMCPModal();
   }
   if (previousActiveSessionId && previousActiveSessionId !== nextId) {
+    clearActiveTranscriptCatchUpWarning(previousActiveSessionId);
     clearSessionProviderRetryOwner(previousActiveSessionId);
   }
   if (state.currentStreamSessionId && state.currentStreamSessionId !== nextId) {
@@ -1753,12 +1784,24 @@ const refreshActiveSessionMessagesFromServer = async (session, options = {}) => 
 
 const attachExternallyActiveResponseAfterCatchUp = async (session, refreshed) => {
   if (!refreshed || !session || session.id !== state.activeSessionId) return false;
+  if (numericTranscriptUpdatedAt(session._pendingTranscriptUpdatedAt) > numericTranscriptUpdatedAt(session.transcriptUpdatedAt)) {
+    return false;
+  }
   if (document.visibilityState === 'hidden' || state.draftSessionActive) return false;
   if (state.abortController || state.streaming || session.activeResponseId) return false;
   const progress = state.sessionProgressById?.[session.id] || null;
   if (!progress?.serverActiveRun || progress?.optimisticBusy) return false;
   await syncActiveSessionFromServer(session, true, { skipMessagesFetch: true });
   return true;
+};
+
+const clearReconciledActiveTranscriptCatchUp = (session) => {
+  if (!session) return false;
+  const currentTranscriptUpdatedAt = numericTranscriptUpdatedAt(session.transcriptUpdatedAt);
+  const pendingTranscriptUpdatedAt = numericTranscriptUpdatedAt(session._pendingTranscriptUpdatedAt);
+  if (pendingTranscriptUpdatedAt > currentTranscriptUpdatedAt) return false;
+  if (pendingTranscriptUpdatedAt > 0) delete session._pendingTranscriptUpdatedAt;
+  return clearActiveTranscriptCatchUpWarning(session.id, currentTranscriptUpdatedAt);
 };
 
 const reconcilePendingActiveTranscriptRefresh = async () => {
@@ -1768,7 +1811,7 @@ const reconcilePendingActiveTranscriptRefresh = async () => {
   if (pendingTranscriptUpdatedAt <= 0) return false;
   const currentTranscriptUpdatedAt = numericTranscriptUpdatedAt(active.transcriptUpdatedAt);
   if (pendingTranscriptUpdatedAt <= currentTranscriptUpdatedAt) {
-    delete active._pendingTranscriptUpdatedAt;
+    clearReconciledActiveTranscriptCatchUp(active);
     return false;
   }
 
@@ -1778,9 +1821,7 @@ const reconcilePendingActiveTranscriptRefresh = async () => {
     forceScroll: false,
     allowServerActiveRun: Boolean(progress?.serverActiveRun)
   });
-  if (numericTranscriptUpdatedAt(active.transcriptUpdatedAt) === pendingTranscriptUpdatedAt) {
-    delete active._pendingTranscriptUpdatedAt;
-  }
+  clearReconciledActiveTranscriptCatchUp(active);
   await attachExternallyActiveResponseAfterCatchUp(active, refreshed);
   return refreshed;
 };
@@ -1797,11 +1838,14 @@ const reconcileActiveTranscriptFromStatus = async (statusSessions) => {
 
   const currentTranscriptUpdatedAt = numericTranscriptUpdatedAt(active.transcriptUpdatedAt);
   if (incomingTranscriptUpdatedAt <= currentTranscriptUpdatedAt) {
-    delete active._pendingTranscriptUpdatedAt;
+    clearReconciledActiveTranscriptCatchUp(active);
     return false;
   }
 
-  active._pendingTranscriptUpdatedAt = incomingTranscriptUpdatedAt;
+  active._pendingTranscriptUpdatedAt = Math.max(
+    numericTranscriptUpdatedAt(active._pendingTranscriptUpdatedAt),
+    incomingTranscriptUpdatedAt
+  );
   const refreshed = await refreshActiveSessionMessagesFromServer(active, {
     transcriptUpdatedAt: incomingTranscriptUpdatedAt,
     forceScroll: false,
@@ -1811,9 +1855,7 @@ const reconcileActiveTranscriptFromStatus = async (statusSessions) => {
     // reconstructs its own turn and cannot fill gaps from earlier turns.
     allowServerActiveRun: Boolean(entry.active_run)
   });
-  if (numericTranscriptUpdatedAt(active.transcriptUpdatedAt) === incomingTranscriptUpdatedAt) {
-    delete active._pendingTranscriptUpdatedAt;
-  }
+  clearReconciledActiveTranscriptCatchUp(active);
   await attachExternallyActiveResponseAfterCatchUp(active, refreshed);
   return refreshed;
 };
@@ -3396,7 +3438,7 @@ document.addEventListener('visibilitychange', async () => {
     // Do not attach a newer response onto a stale transcript. The visible
     // status poll retains the pending version and retries the tail fetch; once
     // it succeeds, reconciliation attaches the external response itself.
-    setConnectionState('Catching up with this session\u2026', 'bad');
+    showActiveTranscriptCatchUpWarning(session, pendingTranscriptUpdatedAt);
     return;
   }
 

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, sessionSlug, updateURL,
+  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
   persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
   enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
@@ -378,7 +378,11 @@ const setActiveResponseTracking = (session, responseId, sequenceNumber = null) =
   const normalized = String(responseId || '').trim();
   if (!normalized) return;
 
-  if (session.activeResponseId !== normalized) {
+  const currentId = String(session.activeResponseId || '').trim();
+  if (currentId && currentId !== normalized) {
+    clearProviderRetryStatus(String(session.id || '').trim(), currentId);
+  }
+  if (currentId !== normalized) {
     session.activeResponseId = normalized;
     if (sequenceNumber === null) {
       session.lastSequenceNumber = 0;
@@ -572,9 +576,13 @@ const detachResponseStream = () => {
   state.streamGeneration += 1;
   const controller = state.abortController;
   const detachedSessionId = state.currentStreamSessionId;
+  const detachedResponseId = state.currentStreamResponseId;
   state.abortController = null;
   state.currentStreamSessionId = '';
   state.currentStreamResponseId = '';
+  if (detachedSessionId && detachedResponseId) {
+    clearProviderRetryStatus(detachedSessionId, detachedResponseId);
+  }
   if (controller) {
     try { controller.abort(); } catch (_) { /* stream may already be closed */ }
   }
@@ -592,6 +600,10 @@ const clearActiveResponseTracking = (session, responseId = '') => {
   if (!session) return;
   const currentId = String(session.activeResponseId || '').trim();
   const targetId = String(responseId || '').trim();
+  const retryOwnerId = targetId || currentId;
+  if (retryOwnerId) {
+    clearProviderRetryStatus(String(session.id || '').trim(), retryOwnerId);
+  }
 
   if (!targetId || currentId === targetId || targetId.startsWith('resp_msg_')) {
     session.activeResponseId = null;
@@ -696,13 +708,29 @@ const scheduleVisibleStreamScroll = (session) => {
   if (isSessionVisible(session)) scheduleStreamScroll();
 };
 
+const responseStreamOwnerId = (session, payload = null) => {
+  const payloadResponseId = String(payload?.response?.id || payload?.response_id || '').trim();
+  if (payloadResponseId) return payloadResponseId;
+  const activeResponseId = String(session?.activeResponseId || '').trim();
+  if (activeResponseId) return activeResponseId;
+  if (String(state.currentStreamSessionId || '').trim() === String(session?.id || '').trim()) {
+    return String(state.currentStreamResponseId || '').trim();
+  }
+  return '';
+};
+
+const clearProviderRetryForEvent = (session, payload = null) => {
+  const responseId = responseStreamOwnerId(session, payload);
+  if (!responseId) return false;
+  return clearProviderRetryStatus(String(session?.id || '').trim(), responseId);
+};
+
 const createResponseStreamState = (session) => {
   let currentToolGroup = session.messages.findLast((message) => (
     message.role === 'tool-group' && message.status === 'running'
   )) || null;
   let currentAssistantMessage = null;
   let currentPhaseMessage = null;
-  let currentPhaseKind = '';
 
   if (!currentToolGroup) {
     const lastMessage = session.messages[session.messages.length - 1];
@@ -755,13 +783,6 @@ const createResponseStreamState = (session) => {
     },
     set currentPhaseMessage(value) {
       currentPhaseMessage = value;
-      if (!value) currentPhaseKind = '';
-    },
-    get currentPhaseKind() {
-      return currentPhaseKind;
-    },
-    set currentPhaseKind(value) {
-      currentPhaseKind = String(value || '');
     }
   };
 };
@@ -772,12 +793,8 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     if (seq > session.lastSequenceNumber) session.lastSequenceNumber = seq;
     const delta = payload.delta || '';
     if (delta) {
+      clearProviderRetryForEvent(session, payload);
       streamState.closeToolGroup();
-      // A later retry belongs after resumed output rather than updating an
-      // older interruption marker. Non-retry phase updates may span output.
-      if (streamState.currentPhaseKind === 'retry') {
-        streamState.currentPhaseMessage = null;
-      }
       const msg = streamState.ensureAssistantMessage();
       msg.content += delta;
       scheduleStreamPersistence();
@@ -917,9 +934,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
         finalizeVisibleAssistantStreamRender(session, streamState.currentAssistantMessage);
       }
       streamState.currentAssistantMessage = null;
-      let marker = streamState.currentPhaseKind === 'phase'
-        ? (streamState.currentPhaseMessage || null)
-        : null;
+      let marker = streamState.currentPhaseMessage || null;
       if (!marker) {
         marker = {
           id: generateId('phase'),
@@ -929,7 +944,6 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
           transient: true
         };
         streamState.currentPhaseMessage = marker;
-        streamState.currentPhaseKind = 'phase';
         session.messages.push(marker);
         appendStreamMessageNode(session, marker);
       } else {
@@ -944,36 +958,15 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
 
   if (event === 'response.retry') {
     const message = String(payload?.message || '').trim() || 'Model stream interrupted; reconnecting…';
-    if (streamState.currentAssistantMessage?.content) {
-      finalizeVisibleAssistantStreamRender(session, streamState.currentAssistantMessage);
+    const responseId = responseStreamOwnerId(session, payload);
+    if (responseId) {
+      setProviderRetryStatus(String(session?.id || '').trim(), responseId, message);
     }
-    streamState.currentAssistantMessage = null;
-    let marker = streamState.currentPhaseKind === 'retry'
-      ? (streamState.currentPhaseMessage || null)
-      : null;
-    if (!marker) {
-      marker = {
-        id: generateId('phase'),
-        role: 'phase',
-        content: message,
-        created: Date.now(),
-        transient: true
-      };
-      streamState.currentPhaseMessage = marker;
-      streamState.currentPhaseKind = 'retry';
-      session.messages.push(marker);
-      appendStreamMessageNode(session, marker);
-    } else {
-      marker.content = message;
-      updateVisibleUserNode(session, marker);
-    }
-    setConnectionState(message);
-    scheduleStreamPersistence();
-    scrollVisibleStreamToBottom(session);
     return { terminal: false };
   }
 
   if (event === 'response.output_text.new_segment') {
+    clearProviderRetryForEvent(session, payload);
     streamState.closeToolGroup();
     if (streamState.currentAssistantMessage?.content) {
       finalizeVisibleAssistantStreamRender(session, streamState.currentAssistantMessage);
@@ -983,6 +976,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   }
 
   if (event === 'response.output_item.added') {
+    clearProviderRetryForEvent(session, payload);
     const item = payload.item;
     if (item?.type === 'function_call') {
       if (streamState.currentAssistantMessage?.content) {
@@ -1025,6 +1019,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   }
 
   if (event === 'response.function_call_arguments.delta') {
+    clearProviderRetryForEvent(session, payload);
     if (streamState.currentToolGroup) {
       const outputIndex = payload.output_index;
       const delta = String(payload.delta || '');
@@ -1047,6 +1042,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   }
 
   if (event === 'response.output_item.done') {
+    clearProviderRetryForEvent(session, payload);
     const item = payload.item;
     if (item?.type === 'function_call' && streamState.currentToolGroup) {
       const callId = item.call_id || item.id;

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1789,6 +1789,10 @@
       color: var(--danger);
     }
 
+    .connection-state.retry {
+      color: var(--muted);
+    }
+
     .header-right {
       margin-left: auto;
       display: flex;

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -806,6 +806,47 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
   pass(name);
 })();
 
+(function testConnectionStateOwnerCannotClearNewerWarning() {
+  const name = 'connection state owners clear only the warning they set';
+  const connectionNode = Object.assign(makeNode(), { hidden: true });
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { connectionState: connectionNode },
+    navigatorOverrides: { onLine: true },
+  });
+
+  const staleCatchUpOwner = testApp.setConnectionState('Catching up with this session…', 'bad');
+  const currentCatchUpOwner = testApp.setConnectionState('Catching up with this session…', 'bad');
+  if (testApp.clearConnectionStateOwner(staleCatchUpOwner)) {
+    fail(name, 'stale owner reported clearing a newer warning');
+    return;
+  }
+  if (connectionNode.hidden || connectionNode.textContent !== 'Catching up with this session…') {
+    fail(name, 'stale owner cleared a newer same-text catch-up warning', connectionNode.textContent);
+    return;
+  }
+
+  testApp.setConnectionState('Transport unavailable', 'bad');
+  if (testApp.clearConnectionStateOwner(currentCatchUpOwner)) {
+    fail(name, 'superseded catch-up owner reported clearing a transport warning');
+    return;
+  }
+  if (connectionNode.hidden || connectionNode.textContent !== 'Transport unavailable') {
+    fail(name, 'catch-up owner cleared a newer transport warning', connectionNode.textContent);
+    return;
+  }
+
+  const ownedWarning = testApp.setConnectionState('Catching up with this session…', 'bad');
+  if (!testApp.clearConnectionStateOwner(ownedWarning)) {
+    fail(name, 'current owner did not clear its warning');
+    return;
+  }
+  if (!connectionNode.hidden || connectionNode.textContent) {
+    fail(name, 'matching owner left its warning visible', connectionNode.textContent);
+    return;
+  }
+  pass(name);
+})();
+
 (function testProviderRetryStatusIsOwnedAndLegacyWarningHasPriority() {
   const name = 'provider retry status is response-owned and lower priority than legacy warnings';
   const classes = new Set();

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -793,6 +793,92 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
     fail(name, 'offline warning should have bad class');
     return;
   }
+  const session = { id: 'session_offline', activeResponseId: 'resp_offline', messages: [] };
+  testApp.state.sessions = [session];
+  testApp.state.activeSessionId = session.id;
+  testApp.state.draftSessionActive = false;
+  testApp.setProviderRetryStatus(session.id, 'resp_offline', 'Retrying provider…');
+  testApp.clearProviderRetryStatus(session.id, 'resp_offline');
+  if (connectionNode.hidden || connectionNode.textContent !== 'Network offline' || !classes.has('bad')) {
+    fail(name, 'provider retry set/clear changed the offline warning', connectionNode.textContent);
+    return;
+  }
+  pass(name);
+})();
+
+(function testProviderRetryStatusIsOwnedAndLegacyWarningHasPriority() {
+  const name = 'provider retry status is response-owned and lower priority than legacy warnings';
+  const classes = new Set();
+  const connectionNode = Object.assign(makeNode(), {
+    hidden: true,
+    classList: {
+      add(...names) { names.forEach((n) => classes.add(n)); },
+      remove(...names) { names.forEach((n) => classes.delete(n)); },
+      contains(name) { return classes.has(name); },
+    },
+  });
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { connectionState: connectionNode },
+    navigatorOverrides: { onLine: true },
+  });
+  const session = { id: 'session_retry', activeResponseId: 'resp_retry', messages: [] };
+  testApp.state.sessions = [session];
+  testApp.state.activeSessionId = session.id;
+  testApp.state.draftSessionActive = false;
+
+  testApp.setProviderRetryStatus(session.id, 'resp_retry', 'Retrying provider (2/6)…');
+  if (connectionNode.hidden || connectionNode.textContent !== 'Retrying provider (2/6)…') {
+    fail(name, 'owned retry status was not shown', JSON.stringify(connectionNode));
+    return;
+  }
+  if (!classes.has('retry') || classes.has('bad')) {
+    fail(name, 'retry status should use neutral retry mode', JSON.stringify(Array.from(classes)));
+    return;
+  }
+
+  testApp.setConnectionState('Catching up session…', 'bad');
+  testApp.setProviderRetryStatus(session.id, 'resp_retry', 'Retrying provider (3/6)…');
+  if (connectionNode.textContent !== 'Catching up session…' || !classes.has('bad')) {
+    fail(name, 'provider retry overwrote the legacy warning', connectionNode.textContent);
+    return;
+  }
+  testApp.clearProviderRetryStatus(session.id, 'resp_retry');
+  if (connectionNode.textContent !== 'Catching up session…' || connectionNode.hidden) {
+    fail(name, 'clearing provider retry erased the legacy warning', connectionNode.textContent);
+    return;
+  }
+  pass(name);
+})();
+
+(function testProviderRetryStatusRejectsStaleOwners() {
+  const name = 'provider retry status ignores background sets and stale clears';
+  const connectionNode = Object.assign(makeNode(), { hidden: true });
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { connectionState: connectionNode },
+    navigatorOverrides: { onLine: true },
+  });
+  const visible = { id: 'session_visible', activeResponseId: 'resp_new', messages: [] };
+  testApp.state.sessions = [visible];
+  testApp.state.activeSessionId = visible.id;
+  testApp.state.draftSessionActive = false;
+
+  testApp.setProviderRetryStatus('session_background', 'resp_old', 'Background retry');
+  if (!connectionNode.hidden || connectionNode.textContent) {
+    fail(name, 'background retry changed the visible header', connectionNode.textContent);
+    return;
+  }
+
+  testApp.setProviderRetryStatus(visible.id, 'resp_new', 'Current retry');
+  testApp.clearProviderRetryStatus(visible.id, 'resp_old');
+  if (connectionNode.hidden || connectionNode.textContent !== 'Current retry') {
+    fail(name, 'stale response cleared the current retry status', connectionNode.textContent);
+    return;
+  }
+  testApp.clearProviderRetryStatus(visible.id, 'resp_new');
+  if (!connectionNode.hidden || connectionNode.textContent) {
+    fail(name, 'matching response did not clear retry status', connectionNode.textContent);
+    return;
+  }
   pass(name);
 })();
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -4139,6 +4139,10 @@ async function testForegroundCatchUpRetriesBeforeAttachingExternalRun() {
     fail(name, 'failed catch-up attached the external response instead of leaving it pending', JSON.stringify({ messageCalls, stateCalls, resumeCalls, activeResponseId: session.activeResponseId }));
     return;
   }
+  if (app.elements.connectionState.hidden || app.elements.connectionState.textContent !== 'Catching up with this session…') {
+    fail(name, 'failed catch-up did not show its pending header warning', app.elements.connectionState.textContent);
+    return;
+  }
 
   await app.startSidebarStatusPoll();
   await Promise.resolve();
@@ -4151,6 +4155,255 @@ async function testForegroundCatchUpRetriesBeforeAttachingExternalRun() {
   }
   if (session.messages.length !== 1 || session.messages[0].content !== 'caught up after retry') {
     fail(name, 'successful retry attached without applying the authoritative transcript', JSON.stringify(session.messages));
+    return;
+  }
+  if (!app.elements.connectionState.hidden || app.elements.connectionState.textContent) {
+    fail(name, 'successful catch-up retry left its header warning visible', app.elements.connectionState.textContent);
+    return;
+  }
+
+  pass(name);
+}
+
+async function testAlreadyReconciledPendingCatchUpClearsWarning() {
+  const name = 'already-reconciled pending catch-up marker clears its owned warning';
+  let testReady = false;
+  let statusCalls = 0;
+  let messageCalls = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        statusCalls += 1;
+        if (statusCalls > 1) {
+          return new Response(null, { status: 304 });
+        }
+        return new Response(JSON.stringify({
+          sessions: testReady ? [{
+            id: 'sess_already_reconciled',
+            short_title: 'Already reconciled',
+            active_run: false,
+            transcript_updated_at: 2000,
+          }] : []
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"status-v1"' } });
+      }
+      if (isTailMessagesURL(url, 'sess_already_reconciled')) {
+        messageCalls += 1;
+        return new Response('temporary failure', { status: 503 });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+  });
+  await app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_already_reconciled',
+    title: 'Already reconciled',
+    origin: 'web',
+    created: 1,
+    transcriptUpdatedAt: 1000,
+    messages: [],
+    activeResponseId: null,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  testReady = true;
+  statusCalls = 0;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+
+  if (messageCalls !== 1 || session._pendingTranscriptUpdatedAt !== 2000
+      || app.elements.connectionState.textContent !== 'Catching up with this session…') {
+    fail(name, 'failed catch-up did not leave the expected marker and warning', JSON.stringify({ messageCalls, pending: session._pendingTranscriptUpdatedAt, warning: app.elements.connectionState.textContent }));
+    return;
+  }
+
+  // Another authoritative path can reconcile the same transcript while the
+  // status marker remains. A subsequent 304 must retire both without refetching.
+  session.transcriptUpdatedAt = 2000;
+  await app.startSidebarStatusPoll();
+  app.stopSidebarStatusPoll();
+
+  if (Object.prototype.hasOwnProperty.call(session, '_pendingTranscriptUpdatedAt')) {
+    fail(name, 'already-reconciled pending marker was not removed', String(session._pendingTranscriptUpdatedAt));
+    return;
+  }
+  if (messageCalls !== 1) {
+    fail(name, `already-reconciled marker unexpectedly fetched messages again (${messageCalls})`);
+    return;
+  }
+  if (!app.elements.connectionState.hidden || app.elements.connectionState.textContent) {
+    fail(name, 'already-reconciled marker left its catch-up warning visible', app.elements.connectionState.textContent);
+    return;
+  }
+
+  pass(name);
+}
+
+async function testStaleCatchUpCompletionPreservesNewerPendingMarker() {
+  const name = 'stale catch-up completion preserves a newer pending transcript before attach';
+  let appRef = null;
+  let testReady = false;
+  let resolveMessages = null;
+  let stateCalls = 0;
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        return new Response(JSON.stringify({
+          sessions: testReady ? [{
+            id: 'sess_newer_pending',
+            short_title: 'Newer pending',
+            active_run: true,
+            transcript_updated_at: 2000,
+          }] : []
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_newer_pending')) {
+        return new Promise((resolve) => {
+          resolveMessages = () => resolve(new Response(JSON.stringify({ messages: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          }));
+        });
+      }
+      if (url === '/ui/v1/sessions/sess_newer_pending/state') {
+        stateCalls += 1;
+        return new Response(JSON.stringify({
+          active_run: true,
+          active_response_id: 'resp_newer_pending',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: {
+      updateSidebarStatus(entries) {
+        if (!appRef) return;
+        for (const entry of entries) {
+          appRef.setSessionServerActiveRun(entry.id, Boolean(entry.active_run));
+        }
+      },
+    },
+  });
+  appRef = app;
+  await app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_newer_pending',
+    title: 'Newer pending',
+    origin: 'web',
+    created: 1,
+    transcriptUpdatedAt: 1000,
+    messages: [],
+    activeResponseId: null,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  testReady = true;
+
+  const pollPromise = app.startSidebarStatusPoll();
+  for (let i = 0; i < 20 && typeof resolveMessages !== 'function'; i += 1) {
+    await Promise.resolve();
+  }
+  if (typeof resolveMessages !== 'function' || session._pendingTranscriptUpdatedAt !== 2000) {
+    fail(name, 'expected the older transcript refresh to be in flight', JSON.stringify({ pending: session._pendingTranscriptUpdatedAt }));
+    return;
+  }
+
+  session._pendingTranscriptUpdatedAt = 3000;
+  resolveMessages();
+  await pollPromise;
+  app.stopSidebarStatusPoll();
+
+  if (session.transcriptUpdatedAt !== 2000 || session._pendingTranscriptUpdatedAt !== 3000) {
+    fail(name, 'older completion erased or regressed the newer pending marker', JSON.stringify({ transcriptUpdatedAt: session.transcriptUpdatedAt, pending: session._pendingTranscriptUpdatedAt }));
+    return;
+  }
+  if (stateCalls !== 0 || session.activeResponseId) {
+    fail(name, 'older completion attached a response before the newer transcript caught up', JSON.stringify({ stateCalls, activeResponseId: session.activeResponseId }));
+    return;
+  }
+
+  pass(name);
+}
+
+async function testCatchUpWarningClearsOnSessionSwitchWithoutClearingNewerWarning() {
+  const name = 'session switch retires only the previous session catch-up warning';
+  let testReady = false;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/status') {
+        return new Response(JSON.stringify({
+          sessions: testReady ? [{
+            id: 'sess_switch_catch_up_a',
+            short_title: 'Catch-up A',
+            active_run: false,
+            transcript_updated_at: 2000,
+          }] : []
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_switch_catch_up_a')) {
+        return new Response('temporary failure', { status: 503 });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+  });
+  await app.stopSidebarStatusPoll();
+
+  const sessionA = {
+    id: 'sess_switch_catch_up_a', title: 'Catch-up A', origin: 'web', created: 1,
+    transcriptUpdatedAt: 1000, messages: [], activeResponseId: null,
+  };
+  const sessionB = {
+    id: 'sess_switch_catch_up_b', title: 'Catch-up B', origin: 'web', created: 2,
+    transcriptUpdatedAt: 1000, messages: [], activeResponseId: null,
+  };
+  app.state.sessions = [sessionA, sessionB];
+  app.state.activeSessionId = sessionA.id;
+  app.state.draftSessionActive = false;
+  testReady = true;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+  app.stopSidebarStatusPoll();
+
+  if (app.elements.connectionState.textContent !== 'Catching up with this session…') {
+    fail(name, 'expected session A catch-up warning before switching', app.elements.connectionState.textContent);
+    return;
+  }
+  await app.switchToSession(sessionB.id, { sync: false });
+  if (!app.elements.connectionState.hidden || app.elements.connectionState.textContent) {
+    fail(name, 'session A catch-up warning leaked into session B', app.elements.connectionState.textContent);
+    return;
+  }
+
+  // A warning established after catch-up ownership changed must survive stale
+  // cleanup from that old owner.
+  app.state.activeSessionId = sessionA.id;
+  app.state.draftSessionActive = false;
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+  app.stopSidebarStatusPoll();
+  app.setConnectionState('Transport unavailable', 'bad');
+  await app.switchToSession(sessionB.id, { sync: false });
+  if (app.elements.connectionState.hidden || app.elements.connectionState.textContent !== 'Transport unavailable') {
+    fail(name, 'session switch catch-up cleanup erased a newer transport warning', app.elements.connectionState.textContent);
     return;
   }
 
@@ -5663,6 +5916,9 @@ async function testStoppedRunReconciliationClearsProviderRetryOwner() {
   await testLateActiveMessagesResponseIgnoredAfterSessionSwitch();
   await testForegroundCatchUpRefreshesTranscriptBeforeResumingExternalRun();
   await testForegroundCatchUpRetriesBeforeAttachingExternalRun();
+  await testAlreadyReconciledPendingCatchUpClearsWarning();
+  await testStaleCatchUpCompletionPreservesNewerPendingMarker();
+  await testCatchUpWarningClearsOnSessionSwitchWithoutClearingNewerWarning();
   await testForegroundCatchUpStopsWhenPageIsRehidden();
   await testReconnectBackoffWakeSignalsReuseExistingLoop();
   await testLoadServerSessionStateUsesExplicitResultContract();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -172,7 +172,11 @@ function defaultAppStubs(app, overrides = {}) {
       if (!session) return;
       const normalized = String(responseId || '').trim();
       if (!normalized) return;
-      if (session.activeResponseId !== normalized) {
+      const currentId = String(session.activeResponseId || '').trim();
+      if (currentId && currentId !== normalized) {
+        app.clearProviderRetryStatus(String(session.id || '').trim(), currentId);
+      }
+      if (currentId !== normalized) {
         session.activeResponseId = normalized;
         if (sequenceNumber === null) {
           session.lastSequenceNumber = 0;
@@ -189,11 +193,21 @@ function defaultAppStubs(app, overrides = {}) {
       if (!session) return;
       const currentId = String(session.activeResponseId || '').trim();
       const targetId = String(responseId || '').trim();
-      if (!targetId || currentId === targetId) {
+      const retryOwnerId = targetId || currentId;
+      if (retryOwnerId) {
+        app.clearProviderRetryStatus(String(session.id || '').trim(), retryOwnerId);
+      }
+      if (!targetId || currentId === targetId || targetId.startsWith('resp_msg_')) {
         session.activeResponseId = null;
         session.lastSequenceNumber = 0;
       }
-      if (!targetId || app.state.currentStreamResponseId === targetId) {
+      if (
+        !targetId
+        || (
+          app.state.currentStreamSessionId === String(session.id || '').trim()
+          && (!app.state.currentStreamResponseId || app.state.currentStreamResponseId === targetId || targetId.startsWith('resp_msg_'))
+        )
+      ) {
         app.state.currentStreamSessionId = '';
         app.state.currentStreamResponseId = '';
       }
@@ -5496,6 +5510,87 @@ async function testSessionSwitchClearsPlanBeforeRejectingOldResponse() {
   pass(name);
 }
 
+async function testSessionSwitchClearsProviderRetryOwner() {
+  const name = 'session switching clears the previous provider retry owner';
+  const clears = [];
+  const { app } = await createSessionsHarness({
+    fetchImpl: async () => new Response(JSON.stringify({ sessions: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+    appOverrides: {
+      clearProviderRetryStatus(sessionId, responseId) {
+        clears.push({ sessionId, responseId });
+        return true;
+      },
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const oldSession = { id: 'session-retry-old', title: 'Old', messages: [], activeResponseId: 'resp-retry-old', lastSequenceNumber: 2 };
+  const nextSession = { id: 'session-retry-next', title: 'Next', messages: [], activeResponseId: null, lastSequenceNumber: 0 };
+  app.state.sessions = [oldSession, nextSession];
+  app.state.activeSessionId = oldSession.id;
+  app.state.draftSessionActive = false;
+  clears.length = 0;
+
+  await app.switchToSession(nextSession.id, { sync: false, closeSidebar: false });
+
+  if (!clears.some((entry) => entry.sessionId === oldSession.id && entry.responseId === oldSession.activeResponseId)) {
+    fail(name, 'previous session retry owner was not cleared', JSON.stringify(clears));
+    return;
+  }
+  pass(name);
+}
+
+async function testStoppedRunReconciliationClearsProviderRetryOwner() {
+  const name = 'stopped-run reconciliation clears matching provider retry owner';
+  const clears = [];
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/session-retry-stopped/state') {
+        return new Response(JSON.stringify({ active_run: false, active_response_id: '' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: {
+      clearProviderRetryStatus(sessionId, responseId) {
+        clears.push({ sessionId, responseId });
+        return true;
+      },
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const session = {
+    id: 'session-retry-stopped',
+    title: 'Stopped',
+    messages: [],
+    activeResponseId: 'resp-retry-stopped',
+    lastSequenceNumber: 4,
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  app.state.abortController = null;
+  clears.length = 0;
+
+  await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
+
+  const matchingClears = clears.filter((entry) => (
+    entry.sessionId === session.id && entry.responseId === 'resp-retry-stopped'
+  ));
+  if (matchingClears.length !== 1) {
+    fail(name, 'stopped run should clear its retry owner once through active-response tracking', JSON.stringify(clears));
+    return;
+  }
+  pass(name);
+}
+
 (async () => {
   await testSanitizeMessagePreservesSkillRunState();
   await testSanitizeMessagePreservesPlanExecutionEvidence();
@@ -5505,6 +5600,8 @@ async function testSessionSwitchClearsPlanBeforeRejectingOldResponse() {
   await testSessionStatePlanRequestsIgnoreOlderOverlaps();
   await testSessionStatePlanRequestsKeepNewerAuthoritativeClear();
   await testSessionSwitchClearsPlanBeforeRejectingOldResponse();
+  await testSessionSwitchClearsProviderRetryOwner();
+  await testStoppedRunReconciliationClearsProviderRetryOwner();
   await testSwitchingSessionsStagesCurrentComposerBeforeRestore();
   await testSwitchingSessionsClearsEmptyComposerDraft();
   await testNewChatClearsExistingDraftComposer();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -310,6 +310,7 @@ function createHarness(options = {}) {
   state.activeSessionId = activeSessionIdValue;
 
   const connectionStates = [];
+  let providerRetryStatus = null;
   let modelSwapUpdateCount = 0;
   const app = {
     UI_PREFIX: '/ui',
@@ -366,7 +367,63 @@ function createHarness(options = {}) {
       return app.isConversationMounted(sessionOrId) ? elements.messages : null;
     },
     scrollToBottom() {},
-    setConnectionState: (text) => { connectionStates.push(String(text || '')); },
+    setConnectionState(text, mode = '') {
+      connectionStates.push({ source: 'legacy', text: String(text || ''), mode: String(mode || '') });
+    },
+    // Mirrors production's strict visible session/response ownership rules.
+    setProviderRetryStatus(sessionId, responseId, text) {
+      const ownerSessionId = String(sessionId || '').trim();
+      const ownerResponseId = String(responseId || '').trim();
+      const activeSession = state.sessions.find((session) => session.id === state.activeSessionId) || null;
+      const visibleResponseId = String(activeSession?.activeResponseId || (
+        state.currentStreamSessionId === ownerSessionId ? state.currentStreamResponseId : ''
+      ) || '').trim();
+      const applied = Boolean(
+        ownerSessionId
+        && ownerResponseId
+        && ownerSessionId === state.activeSessionId
+        && !state.draftSessionActive
+        && ownerResponseId === visibleResponseId
+      );
+      connectionStates.push({
+        source: 'provider-retry',
+        action: 'set',
+        sessionId: ownerSessionId,
+        responseId: ownerResponseId,
+        text: String(text || ''),
+        mode: 'retry',
+        applied,
+      });
+      if (applied) {
+        providerRetryStatus = {
+          sessionId: ownerSessionId,
+          responseId: ownerResponseId,
+          text: String(text || ''),
+          mode: 'retry',
+        };
+      }
+      return applied;
+    },
+    clearProviderRetryStatus(sessionId, responseId) {
+      const ownerSessionId = String(sessionId || '').trim();
+      const ownerResponseId = String(responseId || '').trim();
+      const applied = Boolean(
+        providerRetryStatus
+        && providerRetryStatus.sessionId === ownerSessionId
+        && providerRetryStatus.responseId === ownerResponseId
+      );
+      connectionStates.push({
+        source: 'provider-retry',
+        action: 'clear',
+        sessionId: ownerSessionId,
+        responseId: ownerResponseId,
+        text: '',
+        mode: 'retry',
+        applied,
+      });
+      if (applied) providerRetryStatus = null;
+      return applied;
+    },
     sessionSlug(s) { return s ? s.id : ''; },
     updateURL() {},
     persistAndRefreshShell() {},
@@ -658,6 +715,7 @@ function createHarness(options = {}) {
     getEventsStarted: () => getEventsStarted,
     postStreamCanceled: () => postStreamCanceled,
     connectionStates,
+    getProviderRetryStatus: () => providerRetryStatus ? { ...providerRetryStatus } : null,
     getModelSwapUpdateCount: () => modelSwapUpdateCount,
     getCancelRequested: () => cancelRequested,
     releaseCancel: () => {
@@ -3010,7 +3068,7 @@ async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
     fail(name, `expected one resumed fetch after wake, got ${eventsCount} total fetches`);
     return;
   }
-  if (!connectionStates.some((text) => text.includes('within one minute'))) {
+  if (!connectionStates.some((status) => status.source === 'legacy' && status.text.includes('within one minute'))) {
     fail(name, 'slow reconnect status was not exposed to the UI', JSON.stringify(connectionStates));
     return;
   }
@@ -3514,101 +3572,207 @@ function testResponsePhaseEventUpdatesTransientMarker() {
   pass(name);
 }
 
-function testResponseRetryEventUpdatesTransientMarker() {
-  const name = 'response retry event updates transient marker without assistant text';
+function createRetryProjectionHarness(suffix = 'retry') {
   const harness = createHarness();
-  const { app, state } = harness;
+  const responseId = `resp_${suffix}`;
   const session = {
-    id: 'session_retry',
+    id: `session_${suffix}`,
     title: 'Retry test',
     messages: [],
     lastResponseId: null,
-    activeResponseId: null,
+    activeResponseId: responseId,
     lastSequenceNumber: 0,
     number: 1,
   };
-  state.sessions.push(session);
-  state.activeSessionId = session.id;
-  const streamState = app.createResponseStreamState(session);
+  harness.state.sessions.push(session);
+  harness.state.activeSessionId = session.id;
+  harness.state.currentStreamSessionId = session.id;
+  harness.state.currentStreamResponseId = responseId;
+  return {
+    ...harness,
+    responseId,
+    session,
+    streamState: harness.app.createResponseStreamState(session),
+  };
+}
 
-  app.applyResponseStreamEvent(session, streamState, 'response.retry', {
-    message: 'Model stream interrupted; reconnecting (2/6)…',
-    attempt: 2,
+function projectRetry(harness, sequenceNumber = 1, message = 'Model stream interrupted; reconnecting (2/6)…') {
+  harness.app.applyResponseStreamEvent(harness.session, harness.streamState, 'response.retry', {
+    message,
+    attempt: sequenceNumber + 1,
     max_attempts: 6,
     wait_seconds: 0.5,
-    sequence_number: 1,
+    sequence_number: sequenceNumber,
   });
-  app.applyResponseStreamEvent(session, streamState, 'response.retry', {
-    message: 'Model stream interrupted; reconnecting (3/6)…',
-    attempt: 3,
-    max_attempts: 6,
-    wait_seconds: 1,
-    sequence_number: 2,
-  });
+}
 
-  const markers = session.messages.filter((message) => message.role === 'phase');
-  const assistants = session.messages.filter((message) => message.role === 'assistant');
-  if (markers.length !== 1) {
-    fail(name, `expected one retry marker, got ${markers.length}`, JSON.stringify(session.messages));
+function testResponseRetryEventUpdatesOwnedHeaderStatus() {
+  const name = 'response retry updates one owned header status without transcript messages';
+  const harness = createRetryProjectionHarness('retry_status');
+
+  projectRetry(harness, 1, 'Model stream interrupted; reconnecting (2/6)…');
+  projectRetry(harness, 2, 'Model stream interrupted; reconnecting (3/6)…');
+
+  const status = harness.getProviderRetryStatus();
+  const sets = harness.connectionStates.filter((entry) => entry.source === 'provider-retry' && entry.action === 'set' && entry.applied);
+  if (harness.session.messages.length !== 0) {
+    fail(name, 'retry event created transcript messages', JSON.stringify(harness.session.messages));
     return;
   }
-  if (!markers[0].transient || markers[0].content !== 'Model stream interrupted; reconnecting (3/6)…') {
-    fail(name, 'retry marker was not updated in place', JSON.stringify(markers[0]));
+  if (!status || status.sessionId !== harness.session.id || status.responseId !== harness.responseId
+      || status.text !== 'Model stream interrupted; reconnecting (3/6)…') {
+    fail(name, 'retry attempts did not update the owned header status in place', JSON.stringify(status));
     return;
   }
-  if (assistants.length !== 0) {
-    fail(name, 'retry event should not create assistant messages', JSON.stringify(assistants));
+  if (sets.length !== 2 || sets.some((entry) => entry.mode !== 'retry')) {
+    fail(name, 'header status calls were not source/mode aware', JSON.stringify(sets));
     return;
   }
-  if (session.lastSequenceNumber !== 2) {
-    fail(name, `lastSequenceNumber = ${session.lastSequenceNumber}, want 2`);
+  if (harness.session.lastSequenceNumber !== 2) {
+    fail(name, `lastSequenceNumber = ${harness.session.lastSequenceNumber}, want 2`);
     return;
   }
   pass(name);
 }
 
-function testResponseRetryAfterResumedOutputStaysAtNewInterruption() {
-  const name = 'response retry after resumed output creates a marker at the new interruption';
-  const harness = createHarness();
-  const { app, state } = harness;
-  const session = {
-    id: 'session_retry_order',
-    title: 'Retry ordering test',
-    messages: [],
-    lastResponseId: null,
-    activeResponseId: null,
-    lastSequenceNumber: 0,
-    number: 1,
-  };
-  state.sessions.push(session);
-  state.activeSessionId = session.id;
-  const streamState = app.createResponseStreamState(session);
+function testProviderRetryClearsOnMeaningfulProgress() {
+  const name = 'provider retry clears on every meaningful progress category';
+  const cases = [
+    ['non-empty text delta', 'response.output_text.delta', { delta: 'resumed' }],
+    ['new text segment', 'response.output_text.new_segment', {}],
+    ['output item added', 'response.output_item.added', { item: { type: 'message' } }],
+    ['function arguments delta', 'response.function_call_arguments.delta', { delta: '{' }],
+    ['output item done', 'response.output_item.done', { item: { type: 'message' } }],
+  ];
 
-  app.applyResponseStreamEvent(session, streamState, 'response.output_text.delta', {
-    delta: 'first attempt',
-    sequence_number: 1,
-  });
-  app.applyResponseStreamEvent(session, streamState, 'response.retry', {
-    message: 'Model stream interrupted; reconnecting (2/6)…',
-    sequence_number: 2,
-  });
-  app.applyResponseStreamEvent(session, streamState, 'response.output_text.delta', {
-    delta: 'second attempt',
-    sequence_number: 3,
-  });
-  app.applyResponseStreamEvent(session, streamState, 'response.retry', {
-    message: 'Model stream interrupted; reconnecting (3/6)…',
-    sequence_number: 4,
-  });
+  for (const [label, event, payload] of cases) {
+    const harness = createRetryProjectionHarness(`progress_${event.replace(/[^a-z]+/g, '_')}`);
+    projectRetry(harness, 1);
+    harness.app.applyResponseStreamEvent(harness.session, harness.streamState, event, {
+      ...payload,
+      sequence_number: 2,
+    });
+    if (harness.getProviderRetryStatus() !== null) {
+      fail(name, `${label} did not clear retry`, JSON.stringify(harness.getProviderRetryStatus()));
+      return;
+    }
+  }
+  pass(name);
+}
 
-  const roles = session.messages.map((message) => message.role);
-  if (roles.join(',') !== 'assistant,phase,assistant,phase') {
-    fail(name, `unexpected message roles/order: ${roles.join(',')}`, JSON.stringify(session.messages));
+function testProviderRetryPersistsAcrossNonProgressEvents() {
+  const name = 'provider retry persists across heartbeat phase model-swap and recoverable stream errors';
+  const cases = [
+    ['heartbeat', 'response.heartbeat', {}],
+    ['phase', 'response.phase', { text: 'Compacting context…' }],
+    ['model swap progress', 'response.model_swap.progress', { stage: 'starting' }],
+    ['recoverable stream error', 'response.stream_error', { error: { type: 'temporary_stream_error' } }],
+    ['snapshot recovery', 'response.stream_error', {
+      error: { type: 'stream_buffer_overflow' },
+      recovery: { sequence_number: 2, messages: [] },
+    }],
+  ];
+
+  for (const [label, event, payload] of cases) {
+    const harness = createRetryProjectionHarness(`nonprogress_${event.replace(/[^a-z]+/g, '_')}`);
+    projectRetry(harness, 1);
+    harness.app.applyResponseStreamEvent(harness.session, harness.streamState, event, {
+      ...payload,
+      sequence_number: 2,
+    });
+    const status = harness.getProviderRetryStatus();
+    if (!status || status.responseId !== harness.responseId) {
+      fail(name, `${label} incorrectly cleared retry`, JSON.stringify(status));
+      return;
+    }
+  }
+  pass(name);
+}
+
+function testProviderRetryClearsOnTerminalEvents() {
+  const name = 'provider retry clears on completion failure and cancellation';
+  const cases = [
+    ['response.completed', (responseId) => ({ response: { id: responseId, status: 'completed' } })],
+    ['response.failed', () => ({ error: { message: 'terminal provider failure' } })],
+    ['response.cancelled', () => ({})],
+  ];
+
+  for (const [event, makePayload] of cases) {
+    const harness = createRetryProjectionHarness(`terminal_${event.replace(/[^a-z]+/g, '_')}`);
+    projectRetry(harness, 1);
+    harness.app.applyResponseStreamEvent(harness.session, harness.streamState, event, {
+      ...makePayload(harness.responseId),
+      sequence_number: 2,
+    });
+    if (harness.getProviderRetryStatus() !== null) {
+      fail(name, `${event} did not clear retry`, JSON.stringify(harness.getProviderRetryStatus()));
+      return;
+    }
+  }
+  pass(name);
+}
+
+function testActiveResponseTransitionClearsObsoleteRetryOwner() {
+  const name = 'active response transitions clear only the obsolete retry owner';
+  const harness = createRetryProjectionHarness('response_transition');
+  projectRetry(harness, 1, 'Old response retry');
+
+  const oldResponseId = harness.responseId;
+  const newResponseId = 'resp_response_transition_new';
+  harness.app.setActiveResponseTracking(harness.session, newResponseId, 0);
+  harness.state.currentStreamResponseId = newResponseId;
+  if (harness.getProviderRetryStatus() !== null) {
+    fail(name, 'obsolete retry remained visible after the active response changed', JSON.stringify(harness.getProviderRetryStatus()));
     return;
   }
-  if (session.messages[1].content !== 'Model stream interrupted; reconnecting (2/6)…'
-      || session.messages[3].content !== 'Model stream interrupted; reconnecting (3/6)…') {
-    fail(name, 'retry markers did not remain at their interruption points', JSON.stringify(session.messages));
+
+  projectRetry(harness, 2, 'New response retry');
+  harness.app.clearActiveResponseTracking(harness.session, oldResponseId);
+  const status = harness.getProviderRetryStatus();
+  if (status?.responseId !== newResponseId || harness.session.activeResponseId !== newResponseId) {
+    fail(name, 'stale clear affected the newer response owner', JSON.stringify({ status, activeResponseId: harness.session.activeResponseId }));
+    return;
+  }
+  pass(name);
+}
+
+function testProviderRetryOwnershipGuardsBackgroundDetachAndStaleClear() {
+  const name = 'provider retry ownership guards background events detach and stale clears';
+  const harness = createRetryProjectionHarness('ownership');
+  const background = {
+    id: 'session_background',
+    title: 'Background',
+    messages: [],
+    activeResponseId: 'resp_background',
+    lastSequenceNumber: 0,
+  };
+  harness.state.sessions.push(background);
+  const backgroundState = harness.app.createResponseStreamState(background);
+
+  harness.app.applyResponseStreamEvent(background, backgroundState, 'response.retry', {
+    message: 'Background retry',
+    sequence_number: 1,
+  });
+  if (harness.getProviderRetryStatus() !== null) {
+    fail(name, 'background stream set visible retry status', JSON.stringify(harness.getProviderRetryStatus()));
+    return;
+  }
+
+  projectRetry(harness, 1, 'Old response retry');
+  const oldResponseId = harness.responseId;
+  const newResponseId = 'resp_ownership_new';
+  harness.session.activeResponseId = newResponseId;
+  harness.state.currentStreamResponseId = newResponseId;
+  projectRetry(harness, 2, 'New response retry');
+  harness.app.clearProviderRetryStatus(harness.session.id, oldResponseId);
+  if (harness.getProviderRetryStatus()?.responseId !== newResponseId) {
+    fail(name, 'stale owner cleared newer response retry', JSON.stringify(harness.getProviderRetryStatus()));
+    return;
+  }
+
+  harness.app.detachResponseStream();
+  if (harness.getProviderRetryStatus() !== null) {
+    fail(name, 'detach did not clear matching retry status', JSON.stringify(harness.getProviderRetryStatus()));
     return;
   }
   pass(name);
@@ -3782,7 +3946,7 @@ async function testCancelActiveResponseTearsDownLocallyBeforeServerPost() {
     return;
   }
 
-  if (!connectionStates.includes('Cancelling\u2026')) {
+  if (!connectionStates.some((status) => status.source === 'legacy' && status.text === 'Cancelling\u2026')) {
     fail(name, 'expected "Cancelling\u2026" connection state after click', JSON.stringify(connectionStates));
     releaseCancel();
     await cancelPromise.catch(() => {});
@@ -6055,8 +6219,12 @@ async function testIsolatedSkillStreamsIndependentlyAndCancelsIndependently() {
   testCompletedResponseClearsUnappliedQueuedEffort();
   testModelSwapProgressEventUpdatesTransientMarker();
   testResponsePhaseEventUpdatesTransientMarker();
-  testResponseRetryEventUpdatesTransientMarker();
-  testResponseRetryAfterResumedOutputStaysAtNewInterruption();
+  testResponseRetryEventUpdatesOwnedHeaderStatus();
+  testProviderRetryClearsOnMeaningfulProgress();
+  testProviderRetryPersistsAcrossNonProgressEvents();
+  testProviderRetryClearsOnTerminalEvents();
+  testActiveResponseTransitionClearsObsoleteRetryOwner();
+  testProviderRetryOwnershipGuardsBackgroundDetachAndStaleClear();
   testResponsePhaseUpdateCanStraddleResumedOutput();
   testResponsePhaseSeparatesAssistantSegments();
   await testConnectTokenPreservesSelectedModelAndProviderFromState();


### PR DESCRIPTION
## What

- move provider/model retry notices from transcript messages into the existing header status area
- keep retry status owned by the active session and response so stale/background streams cannot affect the visible header
- clear completed foreground transcript catch-up warnings without erasing newer transport/auth warnings
- make pending transcript catch-up targets monotonic so stale refresh completions cannot attach a response too early
- preserve higher-priority offline, catch-up, and transport warnings
- clear retry status on meaningful resumed output, terminal events, detach, response replacement, and stopped-run reconciliation
- keep ordinary phase markers and server-side retry events unchanged

## Why

A self-correcting provider stream interruption currently leaves `Model stream interrupted; reconnecting (2/6)…` inside the chat transcript. That is operational state, not conversation history. The old retry handler also called the header API without warning mode, which could hide an existing catch-up warning rather than display the retry.

After this change, retries update one neutral header notice and disappear as soon as the response makes real forward progress. If recovery ultimately fails, the existing terminal error remains visible in the transcript.

The related foreground transcript catch-up warning now has explicit ownership and clears after reconciliation succeeds. A stale catch-up completion cannot clear a newer warning, discard a newer pending transcript version, or attach an external response before that newer version is loaded.

## Safety

- provider retry state is keyed by both session ID and response ID
- background events cannot set the active header
- stale clears cannot remove a newer response's status
- legacy connection warnings and offline state retain priority
- heartbeats, phase events, model-swap progress, and recoverable snapshot bookkeeping do not falsely signal recovery

## Verification

- `node internal/serveui/static/app_core_test.js`
- `node internal/serveui/static/app_stream_test.js`
- `node internal/serveui/static/app_sessions_test.js`
- `go test ./... -count=1` with isolated configuration
- `go build ./...`
- `git diff --check`

The plan and implementation were each reviewed with `claude-bin:fable`; the implementation review found no blockers. Follow-up hardening for active-response ID transitions was added and covered by regression tests.
