### PR TITLE
fix: Mining limit permanently starves older unmined sessions

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -283,10 +283,15 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	}
 
 	var totalCreated, totalUpdated, totalSkipped int
+	var mineAttempts int
 	var summaryStats memoryMineSummaryStats
 	fragmentCache := newMemoryAgentFragmentCache(memoryMineTaxonomyMaxTokens)
 
 	for i, candidate := range candidates {
+		if memoryMineLimit > 0 && mineAttempts >= memoryMineLimit {
+			break
+		}
+
 		state, err := memStore.GetState(ctx, candidate.Session.ID)
 		if err != nil {
 			return fmt.Errorf("get mining state for session %s: %w", candidate.Session.ID, err)
@@ -310,6 +315,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 			fmt.Printf("[%d/%d] #%d no new messages to mine\n", i+1, len(candidates), candidate.Summary.Number)
 			continue
 		}
+		mineAttempts++
 
 		promptParts := buildExtractionPromptParts(candidate, startOffset, loadResult.NextOffset, loadResult.Messages, taxonomyMap)
 		batchStats := newMemoryExtractionStats(candidate, startOffset, loadResult.NextOffset, len(existing), loadResult, promptParts)
@@ -513,10 +519,6 @@ func collectMineCandidates(ctx context.Context, store session.Store, complete []
 		}
 
 		out = append(out, candidate)
-
-		if memoryMineLimit > 0 && len(out) >= memoryMineLimit {
-			break
-		}
 	}
 
 	return out, nil

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,6 +30,15 @@ type trackingMemoryMineStore struct {
 		fromSeq int
 		limit   int
 	}
+}
+
+type candidateMemoryMineStore struct {
+	session.NoopStore
+	sessions map[string]*session.Session
+}
+
+func (s *candidateMemoryMineStore) Get(_ context.Context, id string) (*session.Session, error) {
+	return s.sessions[id], nil
 }
 
 func (s *trackingMemoryMineStore) GetMessages(_ context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
@@ -185,6 +195,53 @@ func TestValidateFragmentPath(t *testing.T) {
 		if got != tc.want {
 			t.Fatalf("validateFragmentPath(%q) = %q, want %q", tc.path, got, tc.want)
 		}
+	}
+}
+
+func TestCollectMineCandidatesDoesNotApplyLimitBeforeMiningStateCheck(t *testing.T) {
+	oldLimit := memoryMineLimit
+	oldAgent := memoryAgent
+	oldSince := memoryMineSince
+	oldIncludeSubagents := memoryMineIncludeSubagents
+	memoryMineLimit = 50
+	memoryAgent = "jarvis"
+	memoryMineSince = 0
+	memoryMineIncludeSubagents = false
+	t.Cleanup(func() {
+		memoryMineLimit = oldLimit
+		memoryAgent = oldAgent
+		memoryMineSince = oldSince
+		memoryMineIncludeSubagents = oldIncludeSubagents
+	})
+
+	store := &candidateMemoryMineStore{sessions: make(map[string]*session.Session, 51)}
+	complete := make([]session.SessionSummary, 0, 51)
+	for number := int64(51); number >= 1; number-- {
+		id := fmt.Sprintf("session-%d", number)
+		updatedAt := time.Now().Add(-time.Duration(51-number) * time.Minute)
+		store.sessions[id] = &session.Session{
+			ID:        id,
+			Number:    number,
+			Agent:     "jarvis",
+			Status:    session.StatusComplete,
+			UpdatedAt: updatedAt,
+		}
+		complete = append(complete, session.SessionSummary{
+			ID:        id,
+			Number:    number,
+			UpdatedAt: updatedAt,
+		})
+	}
+
+	got, err := collectMineCandidates(context.Background(), store, complete, "")
+	if err != nil {
+		t.Fatalf("collectMineCandidates: %v", err)
+	}
+	if len(got) != 51 {
+		t.Fatalf("len(got) = %d, want all 51 candidates available for mining-state checks", len(got))
+	}
+	if got[50].Session.ID != "session-1" {
+		t.Fatalf("oldest candidate = %q, want session-1", got[50].Session.ID)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Stop truncating completed-session candidates before mining state and pending messages are checked.
- Apply `--limit` to sessions that actually reach an extraction attempt, so fully mined sessions no longer consume the allowance.
- Add a regression test proving an older 51st candidate remains available when `--limit 50` is configured.

## Why this is high-value

The bundled `mine-sessions` job runs every 30 minutes with `--limit 50`. Completed sessions are ordered newest-first, so the previous candidate-level limit repeatedly selected the same newest 50 sessions even after they were fully mined. Any pending session older than that window could therefore remain unmined forever while every scheduled job reported success. Applying the limit after pending messages are confirmed lets the job scan past completed work and recover older memory backlogs or failed extractions.

## Validation

- `gofmt -w cmd/memory_mine.go cmd/memory_mine_test.go`
- `go build ./...`
- `go test ./cmd -run 'TestCollectMineCandidatesDoesNotApplyLimitBeforeMiningStateCheck|TestCollectInsightCandidatesAppliesLimitAfterSkippingMinedSessions'`
- `TEST_HOME=$(mktemp -d) && HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" CODEX_HOME="$TEST_HOME/.codex" go test ./...`
- `git diff --check`
