### PR TITLE
fix: Memory mining rescans every completed session every 30 minutes

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -61,7 +61,12 @@ When finished, reply briefly with plain text like "done".`
 type memoryMineCandidate struct {
 	Summary session.SessionSummary
 	Session *session.Session
+	State   *memorydb.MiningState
 	Agent   string
+}
+
+type memoryMiningStateStore interface {
+	ListStates(ctx context.Context) ([]memorydb.MiningState, error)
 }
 
 type memoryAgentFragmentStore interface {
@@ -260,7 +265,7 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("list complete sessions: %w", err)
 	}
 
-	candidates, err := collectMineCandidates(ctx, sessStore, complete, currentID)
+	candidates, err := collectMineCandidates(ctx, sessStore, memStore, complete, currentID)
 	if err != nil {
 		return err
 	}
@@ -287,14 +292,9 @@ func runMemoryMine(cmd *cobra.Command, args []string) error {
 	fragmentCache := newMemoryAgentFragmentCache(memoryMineTaxonomyMaxTokens)
 
 	for i, candidate := range candidates {
-		state, err := memStore.GetState(ctx, candidate.Session.ID)
-		if err != nil {
-			return fmt.Errorf("get mining state for session %s: %w", candidate.Session.ID, err)
-		}
-
 		startOffset := 0
-		if state != nil {
-			startOffset = state.LastMinedOffset
+		if candidate.State != nil {
+			startOffset = candidate.State.LastMinedOffset
 		}
 
 		existing, taxonomyMap, err := fragmentCache.get(ctx, memStore, candidate.Agent)
@@ -500,16 +500,45 @@ func minePromoteAgents(globalAgent string, candidates []memoryMineCandidate) []s
 	return agents
 }
 
-func collectMineCandidates(ctx context.Context, store session.Store, complete []session.SessionSummary, currentID string) ([]memoryMineCandidate, error) {
-	out := make([]memoryMineCandidate, 0, len(complete))
+func collectMineCandidates(ctx context.Context, store session.Store, stateStore memoryMiningStateStore, complete []session.SessionSummary, currentID string) ([]memoryMineCandidate, error) {
+	states, err := stateStore.ListStates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list mining states: %w", err)
+	}
+	statesBySession := make(map[string]memorydb.MiningState, len(states))
+	for _, state := range states {
+		statesBySession[state.SessionID] = state
+	}
 
+	var maxSequences map[string]int
+	if sequenceStore, ok := store.(session.MessageSequenceStore); ok {
+		sessionIDs := make([]string, 0, len(complete))
+		for _, summary := range complete {
+			sessionIDs = append(sessionIDs, summary.ID)
+		}
+		maxSequences, err = sequenceStore.MaxMessageSequences(ctx, sessionIDs)
+		if err != nil {
+			return nil, fmt.Errorf("get maximum message sequences: %w", err)
+		}
+	}
+
+	out := make([]memoryMineCandidate, 0, len(complete))
 	for _, summary := range complete {
+		state, hasState := statesBySession[summary.ID]
+		maxSequence, hasMaxSequence := maxSequences[summary.ID]
+		if hasState && hasMaxSequence && state.LastMinedOffset > maxSequence {
+			continue
+		}
+
 		candidate, ok, err := buildMemoryMineCandidate(ctx, store, summary, currentID)
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
 			continue
+		}
+		if hasState {
+			candidate.State = &state
 		}
 
 		out = append(out, candidate)

--- a/cmd/memory_mine_test.go
+++ b/cmd/memory_mine_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,6 +30,54 @@ type trackingMemoryMineStore struct {
 		fromSeq int
 		limit   int
 	}
+}
+
+type candidateDiscoveryStore struct {
+	session.NoopStore
+	maxSequenceCalls     int
+	getCalls             int
+	getMessagesCalls     int
+	getMessagesFromCalls int
+}
+
+func (s *candidateDiscoveryStore) MaxMessageSequences(_ context.Context, sessionIDs []string) (map[string]int, error) {
+	s.maxSequenceCalls++
+	sequences := make(map[string]int, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		sequences[sessionID] = 9
+	}
+	return sequences, nil
+}
+
+func (s *candidateDiscoveryStore) Get(_ context.Context, id string) (*session.Session, error) {
+	s.getCalls++
+	return nil, nil
+}
+
+func (s *candidateDiscoveryStore) GetMessages(_ context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
+	s.getMessagesCalls++
+	return nil, nil
+}
+
+func (s *candidateDiscoveryStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq, limit int) ([]session.Message, error) {
+	s.getMessagesFromCalls++
+	return nil, nil
+}
+
+type candidateDiscoveryStateStore struct {
+	states         []memorydb.MiningState
+	listStateCalls int
+	getStateCalls  int
+}
+
+func (s *candidateDiscoveryStateStore) ListStates(_ context.Context) ([]memorydb.MiningState, error) {
+	s.listStateCalls++
+	return s.states, nil
+}
+
+func (s *candidateDiscoveryStateStore) GetState(_ context.Context, sessionID string) (*memorydb.MiningState, error) {
+	s.getStateCalls++
+	return nil, nil
 }
 
 func (s *trackingMemoryMineStore) GetMessages(_ context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
@@ -185,6 +234,44 @@ func TestValidateFragmentPath(t *testing.T) {
 		if got != tc.want {
 			t.Fatalf("validateFragmentPath(%q) = %q, want %q", tc.path, got, tc.want)
 		}
+	}
+}
+
+func TestCollectMineCandidatesSkipsFullyMinedSessionsWithoutPointReads(t *testing.T) {
+	const sessionCount = 5000
+
+	oldLimit := memoryMineLimit
+	oldSince := memoryMineSince
+	memoryMineLimit = 0
+	memoryMineSince = 0
+	t.Cleanup(func() {
+		memoryMineLimit = oldLimit
+		memoryMineSince = oldSince
+	})
+
+	complete := make([]session.SessionSummary, sessionCount)
+	states := make([]memorydb.MiningState, sessionCount)
+	for i := 0; i < sessionCount; i++ {
+		sessionID := fmt.Sprintf("session-%d", i)
+		complete[i] = session.SessionSummary{ID: sessionID}
+		states[i] = memorydb.MiningState{SessionID: sessionID, LastMinedOffset: 10}
+	}
+
+	sessStore := &candidateDiscoveryStore{}
+	stateStore := &candidateDiscoveryStateStore{states: states}
+	got, err := collectMineCandidates(context.Background(), sessStore, stateStore, complete, "")
+	if err != nil {
+		t.Fatalf("collectMineCandidates: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("candidate count = %d, want 0", len(got))
+	}
+	if sessStore.maxSequenceCalls != 1 || stateStore.listStateCalls != 1 {
+		t.Fatalf("batch calls = max sequences %d, states %d; want 1 each", sessStore.maxSequenceCalls, stateStore.listStateCalls)
+	}
+	if sessStore.getCalls != 0 || stateStore.getStateCalls != 0 || sessStore.getMessagesCalls != 0 || sessStore.getMessagesFromCalls != 0 {
+		t.Fatalf("point reads = Get %d, GetState %d, GetMessages %d, GetMessagesFrom %d; want all zero",
+			sessStore.getCalls, stateStore.getStateCalls, sessStore.getMessagesCalls, sessStore.getMessagesFromCalls)
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2215,6 +2215,30 @@ func (s *Store) SetMeta(ctx context.Context, key, value string) error {
 	return nil
 }
 
+// ListStates returns all session mining states in one query.
+func (s *Store) ListStates(ctx context.Context) ([]MiningState, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT session_id, agent, last_mined_offset, mined_at
+		FROM memory_mining_state`)
+	if err != nil {
+		return nil, fmt.Errorf("list mining states: %w", err)
+	}
+	defer rows.Close()
+
+	states := make([]MiningState, 0)
+	for rows.Next() {
+		var state MiningState
+		if err := rows.Scan(&state.SessionID, &state.Agent, &state.LastMinedOffset, &state.MinedAt); err != nil {
+			return nil, fmt.Errorf("scan mining state: %w", err)
+		}
+		states = append(states, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mining states: %w", err)
+	}
+	return states, nil
+}
+
 // GetState returns mining state for a session.
 func (s *Store) GetState(ctx context.Context, sessionID string) (*MiningState, error) {
 	row := s.db.QueryRowContext(ctx, `

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -985,6 +985,14 @@ func TestStoreMiningState(t *testing.T) {
 	if got.LastMinedOffset != 100 {
 		t.Fatalf("offset after update = %d, want 100", got.LastMinedOffset)
 	}
+
+	states, err := store.ListStates(ctx)
+	if err != nil {
+		t.Fatalf("ListStates() error = %v", err)
+	}
+	if len(states) != 1 || states[0].SessionID != "sess-1" || states[0].LastMinedOffset != 100 {
+		t.Fatalf("ListStates() = %+v, want updated sess-1 state", states)
+	}
 }
 
 func TestStoreMetaGetSet(t *testing.T) {

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -3126,6 +3126,52 @@ func (s *SQLiteStore) GetMessagesFrom(ctx context.Context, sessionID string, fro
 	return scanMessageRows(rows)
 }
 
+// MaxMessageSequences returns the greatest persisted message sequence for each
+// requested session. Sessions without messages are returned with sequence -1.
+func (s *SQLiteStore) MaxMessageSequences(ctx context.Context, sessionIDs []string) (map[string]int, error) {
+	const batchSize = 500
+
+	result := make(map[string]int, len(sessionIDs))
+	for start := 0; start < len(sessionIDs); start += batchSize {
+		end := min(start+batchSize, len(sessionIDs))
+		values := make([]string, 0, end-start)
+		args := make([]any, 0, end-start)
+		for _, sessionID := range sessionIDs[start:end] {
+			result[sessionID] = -1
+			values = append(values, "(?)")
+			args = append(args, sessionID)
+		}
+
+		query := `
+			WITH requested(session_id) AS (VALUES ` + strings.Join(values, ",") + `)
+			SELECT requested.session_id, COALESCE((
+				SELECT MAX(messages.sequence)
+				FROM messages
+				WHERE messages.session_id = requested.session_id
+			), -1)
+			FROM requested`
+		rows, err := s.db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("query maximum message sequences: %w", err)
+		}
+		for rows.Next() {
+			var sessionID string
+			var maxSequence int
+			if err := rows.Scan(&sessionID, &maxSequence); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scan maximum message sequence: %w", err)
+			}
+			result[sessionID] = maxSequence
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("iterate maximum message sequences: %w", err)
+		}
+		rows.Close()
+	}
+	return result, nil
+}
+
 func scanMessageRows(rows *sql.Rows) ([]Message, error) {
 	var messages []Message
 	for rows.Next() {

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -592,6 +592,42 @@ func TestSQLiteStoreGetMessagesFromHonorsLimit(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreMaxMessageSequencesBatchesSessions(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	store, err := NewSQLiteStore(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.AddMessage(ctx, sess.ID, NewMessage(sess.ID, llm.UserText("latest"), 7)); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	sessionIDs := make([]string, 501)
+	for i := range sessionIDs {
+		sessionIDs[i] = fmt.Sprintf("missing-%d", i)
+	}
+	sessionIDs[len(sessionIDs)-1] = sess.ID
+
+	got, err := store.MaxMessageSequences(ctx, sessionIDs)
+	if err != nil {
+		t.Fatalf("MaxMessageSequences: %v", err)
+	}
+	if got[sessionIDs[0]] != -1 {
+		t.Fatalf("missing session max = %d, want -1", got[sessionIDs[0]])
+	}
+	if got[sess.ID] != 7 {
+		t.Fatalf("persisted session max = %d, want 7", got[sess.ID])
+	}
+}
+
 func TestSQLiteStoreGetMessagesPageDescendingHonorsBeforeSeqAndLimit(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -188,6 +188,12 @@ type ProviderStateStore interface {
 	DeleteProviderState(ctx context.Context, sessionID, providerKey string) error
 }
 
+// MessageSequenceStore is an optional Store capability for fetching the latest
+// message sequence for many sessions without issuing one query per session.
+type MessageSequenceStore interface {
+	MaxMessageSequences(ctx context.Context, sessionIDs []string) (map[string]int, error)
+}
+
 // MessagesDescendingPager is an optional Store capability for efficient reverse
 // pagination over session messages. Implementations return messages ordered by
 // descending sequence and, when beforeSeq > 0, only rows with sequence < beforeSeq.


### PR DESCRIPTION
## What changed

- Added a batched SQLite session-store capability that returns the maximum persisted message sequence for up to 500 requested sessions per query.
- Added a single-query memory mining-state listing and use it to filter fully mined sessions before loading full session rows.
- Carried the already-loaded mining state into the mining loop, eliminating the second per-candidate state lookup.
- Added focused coverage for 5,000 fully mined sessions, asserting candidate discovery performs one batch-capability call per store and zero `Get`, `GetState`, `GetMessages`, or `GetMessagesFrom` point reads. Added SQLite coverage across the 500-session batch boundary.

## Why this is high-value

Jarvis runs memory mining every 30 minutes and retains an ever-growing completed-session history. Previously, even when every old session was current, each run loaded every full session, queried its mining state, and issued an empty message query. That produced roughly three SQLite point reads per historical session on every run, plus avoidable session/message allocations.

The common fully-mined path now consists of paged summary listing, one mining-state scan, and batched indexed maximum-sequence lookups. Fully mined sessions are rejected before full session or message loading, so SQLite round trips, decoding, allocations, filesystem I/O, and read-transaction contention no longer grow at several point queries per historical session. Pending sessions preserve the existing loading and mining behavior.

## Validation

- `gofmt -w cmd/memory_mine.go cmd/memory_mine_test.go internal/memory/store.go internal/memory/store_test.go internal/session/store.go internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `git diff --check`
