### PR TITLE
fix: compare effective reasoning effort in web UI

### DIFF
--- a/cmd/serve_model_swap.go
+++ b/cmd/serve_model_swap.go
@@ -144,6 +144,29 @@ func (p responseModelSwapPlan) targetLabel(candidate *serveRuntime) string {
 	return providerModelLabel(p.requestedProvider, model)
 }
 
+func modelSwapEffortLabel(effort string) string {
+	effort = normalizeReasoningEffort(effort)
+	if effort == "" {
+		return "auto"
+	}
+	return effort
+}
+
+func (p responseModelSwapPlan) startMessage(candidate *serveRuntime) string {
+	previous := p.previousLabel()
+	target := p.targetLabel(candidate)
+	sameRuntime := previous == target
+	effortChanged := !strings.EqualFold(normalizeReasoningEffort(p.previousEffort), normalizeReasoningEffort(p.requestedEffort))
+	if sameRuntime && effortChanged {
+		return fmt.Sprintf("Switching reasoning effort on %s: %s → %s; trying existing context…", previous, modelSwapEffortLabel(p.previousEffort), modelSwapEffortLabel(p.requestedEffort))
+	}
+	if effortChanged {
+		previous = fmt.Sprintf("%s / %s", previous, modelSwapEffortLabel(p.previousEffort))
+		target = fmt.Sprintf("%s / %s", target, modelSwapEffortLabel(p.requestedEffort))
+	}
+	return fmt.Sprintf("Switching model: %s → %s; trying existing context…", previous, target)
+}
+
 func providerModelLabel(provider, model string) string {
 	provider = strings.TrimSpace(provider)
 	model = strings.TrimSpace(model)
@@ -542,7 +565,7 @@ func (s *serveServer) executeResponseRunModelSwap(runCtx context.Context, runtim
 		}
 	}
 
-	appendProgress("naive_start", fmt.Sprintf("Switching model: %s → %s; trying existing context…", exec.plan.previousLabel(), exec.plan.targetLabel(runtime)))
+	appendProgress("naive_start", exec.plan.startMessage(runtime))
 	visible := false
 	streamState := &responseRunStreamState{}
 	result, err := runtime.RunWithEventsAndStart(runCtx, true, false, inputMessages, llmReq, func() {

--- a/cmd/serve_model_swap_test.go
+++ b/cmd/serve_model_swap_test.go
@@ -36,6 +36,38 @@ func (s *blockingModelSwapReplaceStore) ReplaceMessages(ctx context.Context, ses
 	}
 }
 
+func TestModelSwapStartMessageNamesEffortOnlyChange(t *testing.T) {
+	plan := responseModelSwapPlan{
+		previousProvider:  "chatgpt",
+		previousModel:     "gpt-5.6-sol",
+		previousEffort:    "medium",
+		requestedProvider: "chatgpt",
+		requestedModel:    "gpt-5.6-sol",
+		requestedEffort:   "high",
+	}
+	got := plan.startMessage(nil)
+	want := "Switching reasoning effort on chatgpt:gpt-5.6-sol: medium → high; trying existing context…"
+	if got != want {
+		t.Fatalf("startMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestModelSwapStartMessageIncludesEffortWhenModelAlsoChanges(t *testing.T) {
+	plan := responseModelSwapPlan{
+		previousProvider:  "chatgpt",
+		previousModel:     "gpt-5.6-sol",
+		previousEffort:    "",
+		requestedProvider: "chatgpt",
+		requestedModel:    "gpt-5.6-luna",
+		requestedEffort:   "high",
+	}
+	got := plan.startMessage(nil)
+	want := "Switching model: chatgpt:gpt-5.6-sol / auto → chatgpt:gpt-5.6-luna / high; trying existing context…"
+	if got != want {
+		t.Fatalf("startMessage() = %q, want %q", got, want)
+	}
+}
+
 func TestInsertModelSwapMarkerFallsBackToLatestUser(t *testing.T) {
 	history := []llm.Message{
 		llm.UserText("original trigger"),

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -77,8 +77,18 @@ const hasSessionContinuationContext = (session) => Boolean(
 );
 
 const normalizeEffortForCompare = (value) => {
-  const normalized = String(value || '').trim();
-  return normalized.toLowerCase() === 'default' ? '' : normalized;
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'default' ? '' : normalized;
+};
+
+const effectiveEffortForCompare = (model, effort) => {
+  const explicit = normalizeEffortForCompare(effort);
+  if (explicit) return explicit;
+  const id = String(model || '').trim();
+  const info = id && state.modelInfoByID
+    ? state.modelInfoByID[id]
+    : null;
+  return normalizeEffortForCompare(info?.default_reasoning_effort || '');
 };
 
 const sessionHasQueueableActiveRun = (session) => Boolean(
@@ -152,7 +162,13 @@ const normalizeModelMetadata = (items) => {
     const modes = Array.isArray(m?.reasoning_modes)
       ? m.reasoning_modes.map((v) => String(v || '').trim()).filter(Boolean)
       : [];
-    byID[id] = { id, reasoning_efforts: efforts, reasoning_modes: modes };
+    const defaultEffort = String(m?.default_reasoning_effort || '').trim();
+    byID[id] = {
+      id,
+      reasoning_efforts: efforts,
+      reasoning_modes: modes,
+      ...(defaultEffort ? { default_reasoning_effort: defaultEffort } : {})
+    };
   });
   return { ids, byID };
 };
@@ -2790,7 +2806,7 @@ const queueActiveRunEffortChange = async (session, effort) => {
   persistRuntimeSelection();
   syncSettingsSelectValues();
 
-  if (normalizeEffortForCompare(queuedEffort) === normalizeEffortForCompare(session.activeEffort || '')) {
+  if (effectiveEffortForCompare(model, queuedEffort) === effectiveEffortForCompare(model, session.activeEffort || '')) {
     clearSessionPendingEffort(session);
   } else {
     setSessionPendingEffort(session, queuedEffort);
@@ -2802,6 +2818,18 @@ const queueActiveRunEffortChange = async (session, effort) => {
 
 const applyEffortChange = async (effort) => {
   const session = getActiveSession();
+  const model = String(session?.activeModel || state.selectedModel || '').trim();
+  if (sessionHasQueueableActiveRun(session)
+      && effectiveEffortForCompare(model, effort) === effectiveEffortForCompare(model, session.activeEffort || '')) {
+    state.selectedEffort = effort;
+    clearSessionPendingEffort(session);
+    canonicalizeSelectedModelEffort();
+    persistRuntimeSelection();
+    syncSettingsSelectValues();
+    updateSessionUsageDisplay(session);
+    app.updateHeader();
+    return;
+  }
   if (sessionHasQueueableActiveRun(session)) {
     try {
       const queued = await queueActiveRunEffortChange(session, effort);
@@ -4722,7 +4750,8 @@ const sendMessage = async (options = {}) => {
     const targetDiffers = hasPriorContext && Boolean(
       (targetProvider || '') !== (currentProvider || '')
       || (targetModel || '') !== (currentModel || '')
-      || normalizeEffortForCompare(targetEffort) !== normalizeEffortForCompare(currentEffort)
+      || effectiveEffortForCompare(targetModel || currentModel, targetEffort)
+        !== effectiveEffortForCompare(currentModel || targetModel, currentEffort)
     );
 
     const modeInfo = modelMetadataFor(targetModel || currentModel);

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -766,7 +766,7 @@ async function testModelEffortOptionsFollowMetadata() {
       if (url === '/ui/v1/models?provider=chatgpt') {
         return new Response(JSON.stringify({
           data: [
-            { id: 'gpt-5.5', reasoning_efforts: ['minimal', 'low', 'medium', 'high', 'xhigh'] },
+            { id: 'gpt-5.5', reasoning_efforts: ['minimal', 'low', 'medium', 'high', 'xhigh'], default_reasoning_effort: 'medium' },
             { id: 'listed-no-metadata' },
             { id: 'opus', reasoning_efforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
           ],
@@ -784,6 +784,11 @@ async function testModelEffortOptionsFollowMetadata() {
 
   if (state.selectedEffort !== '') {
     fail(name, `invalid max effort was not cleared: ${JSON.stringify(state.selectedEffort)}`);
+    await cleanup();
+    return;
+  }
+  if (state.modelInfoByID['gpt-5.5']?.default_reasoning_effort !== 'medium') {
+    fail(name, `gpt-5.5 default effort metadata was dropped: ${JSON.stringify(state.modelInfoByID['gpt-5.5'])}`);
     await cleanup();
     return;
   }
@@ -3416,6 +3421,55 @@ async function testSendMessageOmitsModelSwapWhenTargetUnchanged() {
   pass(name);
 }
 
+async function testSendMessageTreatsImplicitDefaultEffortAsEquivalent() {
+  const name = 'sendMessage treats implicit model default effort as unchanged';
+  const harness = createHarness();
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+  const session = {
+    id: 'session_implicit_effort',
+    title: 'Implicit effort test',
+    provider: 'chatgpt',
+    activeModel: 'gpt-5.6-sol',
+    activeEffort: '',
+    messages: [
+      { id: 'u1', role: 'user', content: 'hello', created: 1 },
+      { id: 'a1', role: 'assistant', content: 'hi', created: 2 },
+    ],
+    lastResponseId: 'resp_previous',
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.selectedProvider = 'chatgpt';
+  state.selectedModel = 'gpt-5.6-sol';
+  state.selectedEffort = 'medium';
+  state.modelInfoByID = {
+    'gpt-5.6-sol': {
+      id: 'gpt-5.6-sol',
+      reasoning_efforts: ['low', 'medium', 'high'],
+      default_reasoning_effort: 'medium',
+    },
+  };
+  elements.promptInput.value = 'continue';
+
+  await app.sendMessage();
+  await cleanup();
+
+  const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  if (!postCall || !postCall.body) {
+    fail(name, 'missing POST /ui/v1/responses body', JSON.stringify(fetchCalls));
+    return;
+  }
+  const body = JSON.parse(postCall.body);
+  if (body.model_swap) {
+    fail(name, 'implicit medium → explicit medium must not request a model swap', postCall.body);
+    return;
+  }
+  pass(name);
+}
+
 async function testSendMessageGatesReasoningModeByModelMetadata() {
   const supportedName = 'sendMessage sends Pro mode only for supporting models';
   {
@@ -5812,6 +5866,45 @@ async function testQueueEffortWhileStreamingPostsRuntimeEffortAndShowsPending() 
   pass(name);
 }
 
+async function testEquivalentImplicitEffortWhileStreamingDoesNotQueue() {
+  const name = 'implicit default effort does not queue an equivalent runtime switch';
+  const harness = createHarness();
+  const { app, state, fetchCalls, cleanup } = harness;
+  const session = {
+    id: 'sess_effort_implicit',
+    title: 'Implicit effort',
+    messages: [{ id: 'u1', role: 'user', content: 'run', created: 1 }],
+    activeResponseId: 'resp_effort_implicit',
+    activeModel: 'gpt-5.6-sol',
+    activeEffort: '',
+    provider: 'chatgpt',
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.streaming = true;
+  state.selectedModel = 'gpt-5.6-sol';
+  state.modelInfoByID = {
+    'gpt-5.6-sol': { id: 'gpt-5.6-sol', default_reasoning_effort: 'medium' },
+  };
+
+  await app.applyEffortChange('medium');
+
+  const effortCall = fetchCalls.find(call => call.url === '/ui/v1/sessions/sess_effort_implicit/runtime/effort');
+  if (effortCall) {
+    fail(name, 'equivalent implicit medium → explicit medium queued a runtime switch', effortCall.body);
+    await cleanup();
+    return;
+  }
+  if (session.pendingEffortQueued) {
+    fail(name, 'equivalent effort was marked pending');
+    await cleanup();
+    return;
+  }
+  await cleanup();
+  pass(name);
+}
+
 function testResponseModelSwitchStabilizesEffortAndClearsPending() {
   const name = 'response.model_switch updates effort and clears queued marker';
   const harness = createHarness();
@@ -6213,8 +6306,10 @@ async function testIsolatedSkillStreamsIndependentlyAndCancelsIndependently() {
   await testResumeActiveResponseClearsTerminalTrackingWhen409SnapshotHasNoRecovery();
   await testSendMessageIncludesModelSwapForChangedTarget();
   await testSendMessageOmitsModelSwapWhenTargetUnchanged();
+  await testSendMessageTreatsImplicitDefaultEffortAsEquivalent();
   await testSendMessageGatesReasoningModeByModelMetadata();
   await testQueueEffortWhileStreamingPostsRuntimeEffortAndShowsPending();
+  await testEquivalentImplicitEffortWhileStreamingDoesNotQueue();
   testResponseModelSwitchStabilizesEffortAndClearsPending();
   testCompletedResponseClearsUnappliedQueuedEffort();
   testModelSwapProgressEventUpdatesTransientMarker();


### PR DESCRIPTION
## What

- preserve `default_reasoning_effort` from `/v1/models` in the web UI
- compare effective efforts, so implicit `medium` and explicit `medium` are treated as equal
- avoid both turn-boundary model swaps and active-run effort queueing for equivalent implicit/explicit efforts
- label genuine effort-only changes as effort changes instead of rendering the same model on both sides
- include effort values when both model and effort change

## Why

The UI compared serialized effort values (`""` versus `"medium"`) instead of runtime semantics. For a model whose provider default is medium, choosing medium explicitly could produce:

`Switching model: chatgpt:gpt-5.6-sol → chatgpt:gpt-5.6-sol`

That was both a false swap and a misleading status message.

## Verification

- `go test ./cmd -run 'TestModelSwapStartMessage|TestHandleResponses_ModelSwap|TestInsertModelSwap|TestPersistModelSwap' -count=1`
- `go test ./internal/serveui -count=1`
- `go build ./...`

A broader `go test ./cmd ./internal/serveui` run hit two unrelated environment-sensitive skill-discovery failures in existing `cmd` tests; the complete `internal/serveui` suite and targeted model-swap tests pass.
