### PR TITLE
fix: prevent duplicate web interjection handoff

### DIFF
--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -356,6 +356,15 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 		s.syncPersistedSessionRuntime(ctx, sessionID, runtime, req.Model, req.ReasoningEffort, reasoningMode, true, req.WorktreeDir)
 	}
 
+	// A first-party web interjection that reaches a text-only response boundary is
+	// re-sent as a normal follow-up with the same logical message ID. Transfer
+	// ownership before starting that follow-up: otherwise the engine retains the
+	// queued interjection and can inject it again at the new run's first tool
+	// boundary, persisting the user's message twice.
+	if stateful && idempotencyKey != "" && isFirstPartyUIResponseRequest(r) && runtime.engine != nil {
+		runtime.engine.CancelInterjection(idempotencyKey)
+	}
+
 	cleanupRuntime := !stateful
 	if cleanupRuntime {
 		defer func() {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3531,6 +3531,60 @@ func TestHandleResponses_GeneratesSessionIDHeaderWhenMissing(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_UIFollowUpClaimsQueuedInterjection(t *testing.T) {
+	const (
+		sessionID = "sess_interjection_handoff"
+		messageID = "msg_interjection_handoff"
+	)
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("follow-up response")
+	engine := llm.NewEngine(provider, nil)
+	runtime := &serveRuntime{
+		provider:     provider,
+		providerKey:  provider.Name(),
+		engine:       engine,
+		defaultModel: "mock-model",
+	}
+	runtime.Touch()
+	engine.QueueInterjection(llm.QueuedInterjection{
+		ID:          messageID,
+		Message:     llm.UserText("same logical message"),
+		DisplayText: "same logical message",
+	})
+
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	defer manager.Close()
+	putTestSession(manager, sessionID, runtime)
+
+	srv := &serveServer{
+		sessionMgr:   manager,
+		responseRuns: newServeResponseRunManager(),
+	}
+	defer srv.responseRuns.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	req.Header.Set("X-Term-LLM-UI-Version", "test")
+	rr := httptest.NewRecorder()
+	srv.handleResolvedResponses(rr, req, req.Context(), resolvedResponsesRequest{
+		req:                responsesCreateRequest{Stream: true},
+		inputMessages:      []llm.Message{llm.UserText("same logical message")},
+		sessionID:          sessionID,
+		previousResponseID: "resp_previous",
+		previousDurable:    true,
+		idempotencyKey:     messageID,
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("pending interjections after follow-up handoff = %#v, want none", pending)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider request count = %d, want 1", len(provider.Requests))
+	}
+}
+
 func TestHandleResponses_StreamIdempotencyKeyReplaysExistingRun(t *testing.T) {
 	const (
 		sessionID      = "sess_stream_idempotent"


### PR DESCRIPTION
## What

Transfer ownership of a queued web interjection when the web client re-sends it as a normal follow-up.

The first-party UI already reuses the interjection's logical message ID as the follow-up request idempotency key. Before starting that follow-up, the server now removes any still-queued engine interjection with the same ID.

## Why

A text-only response can finish before the engine reaches a tool boundary. In that case:

1. the server retains the interjection in `pendingInterjections`;
2. the web client requeues it as a normal follow-up so the user's message is not lost;
3. the next run can reach a tool boundary and drain the original server-owned copy too.

That turns **1 user interjection into 2 persisted user messages**: one normal follow-up plus one injected copy.

The logical message ID is the ownership token. Claiming it at normal follow-up creation makes the handoff atomic with respect to the next run: the stale queued copy is gone before that run can drain interjections.

The behavior is scoped to stateful first-party UI requests; external Responses API idempotency semantics are unchanged.

## Test

Added a regression test that queues an interjection, starts the corresponding first-party follow-up with the same message ID, and verifies the engine no longer retains a second copy.

Verification:

- `go test ./... -count=1`
- `go build ./...`
