### PR TITLE
fix: reconcile persisted optimistic tool groups

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1012,7 +1012,9 @@ const ensureSessionTranscript = (session) => {
     session.transcript = new window.TranscriptStore(session.id);
     const saved = readTranscriptOptimisticRegistry()[session.id];
     if (Array.isArray(saved)) {
-      saved.slice(-TRANSCRIPT_OPTIMISTIC_LIMIT).forEach((entry) => session.transcript.addOptimistic(entry, entry.revAtSend));
+      saved.slice(-TRANSCRIPT_OPTIMISTIC_LIMIT).forEach((entry) => {
+        session.transcript.addOptimistic(entry, entry.revAtSend, { persisted: true });
+      });
     }
   }
   return session.transcript;
@@ -1232,6 +1234,16 @@ const boundedTranscriptSegmentIndexes = (transcript, request) => {
   return selected.sort((a, b) => a - b);
 };
 
+const transcriptSyncSegmentIndexes = (transcript) => {
+  if (!transcript) return [];
+  const wanted = new Set(transcript.pinnedSegments);
+  if (transcript.segments.length > 0) wanted.add(transcript.segments.length - 1);
+  for (const index of transcript.persistedOptimisticToolSegmentIndexes?.(TRANSCRIPT_MATERIALIZE_BATCH_TURNS) || []) {
+    wanted.add(index);
+  }
+  return [...wanted];
+};
+
 const fetchTranscriptSegments = async (session, segmentIndexes, options = {}) => {
   const transcript = ensureSessionTranscript(session);
   if (!transcript) return false;
@@ -1321,10 +1333,11 @@ const syncTranscriptOnce = async (session, options = {}) => {
       const last = transcript.ids.length - 1;
       transcript.setViewport(last, last);
     }
-    const wanted = new Set(transcript.pinnedSegments);
-    if (transcript.segments.length > 0) wanted.add(transcript.segments.length - 1);
-    const loaded = await fetchTranscriptSegments(session, [...wanted]);
+    const loaded = await fetchTranscriptSegments(session, transcriptSyncSegmentIndexes(transcript), { deferBudget: true });
     if (loaded) {
+      transcript.reconcileOptimistic();
+      persistTranscriptOptimistic(session);
+      transcript.enforceBudget();
       refreshSessionMessagesFromTranscript(session);
       if (session.id === state.activeSessionId) renderMessages(options.forceScroll === true);
     }
@@ -1353,18 +1366,17 @@ const syncTranscriptOnce = async (session, options = {}) => {
     const last = transcript.ids.length - 1;
     transcript.setViewport(last, last);
   }
-  const wanted = new Set(transcript.pinnedSegments);
-  if (transcript.segments.length > 0) wanted.add(transcript.segments.length - 1);
-  const loaded = await fetchTranscriptSegments(session, [...wanted]);
+  const loaded = await fetchTranscriptSegments(session, transcriptSyncSegmentIndexes(transcript), { deferBudget: true });
   if (!loaded) {
     transcript.etag = '';
     return false;
   }
   transcript.withViewportAnchor(adapter, () => {
     transcript.reconcileOptimistic();
+    persistTranscriptOptimistic(session);
+    transcript.enforceBudget();
     refreshSessionMessagesFromTranscript(session);
   });
-  persistTranscriptOptimistic(session);
   touchTranscriptSkeleton(session);
   if (session.id === state.activeSessionId) renderMessages(options.forceScroll === true);
   return true;

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3612,6 +3612,199 @@ async function testOptimisticTranscriptStorageIsPerSession() {
   pass(name);
 }
 
+async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconciliation() {
+  const name = 'reload reconciles persisted tool turns within their target segment beyond the materialization budget';
+  const sessionId = 'stale-tool-reload';
+  const storageKey = 'term_llm_optimistic_transcript';
+  let nextID = 201;
+  let nextSeq = 10;
+  const message = (role, parts) => ({
+    id: nextID++,
+    sequence: nextSeq++,
+    role,
+    created_at: nextSeq * 1000,
+    parts
+  });
+  const staleTurn = [
+    message('user', [{ type: 'text', text: 'run the old tool' }]),
+    message('assistant', [{ type: 'tool_call', tool_name: 'read_file', tool_call_id: 'stale-call' }]),
+    message('tool', [{ type: 'tool_result', tool_name: 'read_file', tool_call_id: 'stale-call' }]),
+    message('assistant', [{ type: 'text', text: 'Old turn done.' }])
+  ];
+  const turns = [staleTurn];
+  for (let index = 0; index < 72; index += 1) {
+    turns.push([
+      message('user', [{ type: 'text', text: `filler ${index}` }]),
+      message('assistant', [{ type: 'text', text: `answer ${index}` }])
+    ]);
+  }
+  const unrelatedTurn = [
+    message('user', [{ type: 'text', text: 'run a later tool' }]),
+    message('assistant', [{ type: 'tool_call', tool_name: 'grep', tool_call_id: 'never-durable-call' }]),
+    message('tool', [{ type: 'tool_result', tool_name: 'grep', tool_call_id: 'never-durable-call' }]),
+    message('assistant', [{ type: 'text', text: 'Later turn done.' }])
+  ];
+  turns.push(unrelatedTurn);
+  const raw = turns.flat();
+  const persistedEntries = [
+    {
+      id: 'local-stale-tool-group',
+      clientKey: 'local-stale-tool-group',
+      role: 'tool-group',
+      status: 'done',
+      tools: [{ id: 'stale-call', name: 'read_file', status: 'done' }],
+      revAtSend: 5,
+      durableSeqAtSend: staleTurn[0].sequence,
+      optimistic: true
+    },
+    {
+      id: 'local-unmatched-tool-group',
+      clientKey: 'local-unmatched-tool-group',
+      role: 'tool-group',
+      status: 'done',
+      tools: [{ id: 'never-durable-call', name: 'write_file', status: 'done' }],
+      revAtSend: 5,
+      durableSeqAtSend: staleTurn[staleTurn.length - 1].sequence,
+      optimistic: true
+    }
+  ];
+  const persisted = JSON.stringify({
+    version: 1,
+    sessions: { [sessionId]: persistedEntries }
+  });
+  const bodyRequests = [];
+  const targetStatesAtFetch = [];
+  let indexRequests = 0;
+  let primedMaterializationBudget = false;
+  let session = null;
+  const { app, storage } = await createSessionsHarness({
+    initialStorage: { [storageKey]: persisted },
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        indexRequests += 1;
+        if (indexRequests > 1) {
+          return new Response(null, { status: 304, headers: { ETag: '"stale-tool-rev-8"' } });
+        }
+        return new Response(JSON.stringify({
+          rev: 8,
+          compaction_seq: -1,
+          compaction_count: 0,
+          rows: {
+            ids: raw.map((entry) => entry.id),
+            seqs: raw.map((entry) => entry.sequence),
+            roles: raw.map((entry) => ({ user: 'u', assistant: 'a', tool: 't' })[entry.role]).join(''),
+            flags: raw.map(() => 0)
+          }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"stale-tool-rev-8"' } });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        targetStatesAtFetch.push(session?.transcript?.segments?.[0]?.state || '');
+        if (!primedMaterializationBudget) {
+          primedMaterializationBudget = true;
+          session.transcript.materialize(turns.slice(-60).flat(), { countFetch: false });
+        }
+        const requested = (parsedTestURL(url)?.searchParams.get('ids') || '')
+          .split(',')
+          .filter(Boolean)
+          .map(Number);
+        bodyRequests.push(requested);
+        const requestedAnchors = new Set(requested);
+        const messages = turns
+          .filter((turn) => requestedAnchors.has(turn[0].id))
+          .flat();
+        return new Response(JSON.stringify({ rev: 8, messages }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+  session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const loaded = await app.syncTranscript(session, { reason: 'reload' });
+  const requested = bodyRequests[0] || [];
+  if (!loaded || targetStatesAtFetch[0] !== 'evicted') {
+    fail(name, 'stale turn was not initially evicted before body materialization', JSON.stringify({ loaded, targetStatesAtFetch }));
+    return;
+  }
+  if (turns.length <= 60) {
+    fail(name, 'regression transcript did not exceed the materialized-turn budget', String(turns.length));
+    return;
+  }
+  if (!requested.includes(staleTurn[0].id) || !requested.includes(unrelatedTurn[0].id)) {
+    fail(name, 'reload did not fetch both the stale original turn and the pinned later turn', JSON.stringify(bodyRequests));
+    return;
+  }
+  if (requested.length > 32 || requested.length >= turns.length) {
+    fail(name, 'reload body fetch was not bounded to selected turn anchors', JSON.stringify({ requested: requested.length, turns: turns.length }));
+    return;
+  }
+  let optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
+  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
+    fail(name, '200 reconciliation did not retire only the target-segment match before budget enforcement', JSON.stringify(optimisticKeys));
+    return;
+  }
+  let saved = JSON.parse(storage.get(storageKey) || 'null');
+  let savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
+    fail(name, '200 reconciliation was not persisted before budget enforcement', JSON.stringify(saved));
+    return;
+  }
+  if (session.transcript.segments[0]?.state !== 'evicted'
+      || session.transcript.segments.filter((segment) => segment.state === 'materialized').length > 60) {
+    fail(name, 'post-reconciliation budget did not evict the distant target turn', JSON.stringify({
+      targetState: session.transcript.segments[0]?.state || 'missing',
+      materialized: session.transcript.segments.filter((segment) => segment.state === 'materialized').length
+    }));
+    return;
+  }
+
+  session.transcript.addOptimistic({
+    id: 'local-304-tool-group',
+    clientKey: 'local-304-tool-group',
+    role: 'tool-group',
+    status: 'done',
+    tools: [{ id: 'stale-call', name: 'read_file', status: 'done' }],
+    revAtSend: 5,
+    durableSeqAtSend: staleTurn[0].sequence,
+    optimistic: true
+  }, 5, { persisted: true });
+  app.persistTranscriptOptimistic(session);
+
+  const loadedNotModified = await app.syncTranscript(session, { reason: 'not-modified' });
+  optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
+  if (!loadedNotModified || targetStatesAtFetch[1] !== 'evicted' || !bodyRequests[1]?.includes(staleTurn[0].id)) {
+    fail(name, '304 sync did not rematerialize the evicted reconciliation target', JSON.stringify({ loadedNotModified, targetStatesAtFetch, bodyRequests }));
+    return;
+  }
+  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
+    fail(name, '304 reconciliation did not retire its target-segment match before budget enforcement', JSON.stringify(optimisticKeys));
+    return;
+  }
+  saved = JSON.parse(storage.get(storageKey) || 'null');
+  savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
+    fail(name, '304 reconciliation was not persisted before budget enforcement', JSON.stringify(saved));
+    return;
+  }
+  const finalMaterialized = session.transcript.segments.filter((segment) => segment.state === 'materialized').length;
+  if (session.transcript.segments[0]?.state !== 'evicted' || finalMaterialized > 60) {
+    fail(name, '304 sync did not enforce the budget after reconciliation', JSON.stringify({
+      targetState: session.transcript.segments[0]?.state || 'missing',
+      materialized: finalMaterialized
+    }));
+    return;
+  }
+  pass(name);
+}
+
 async function testGroupedToolRowsPreserveDurableRangesAndLaterAnchors() {
   const name = 'grouped tool conversion preserves source range and later durable anchors';
   const { app, windowObj } = await createSessionsHarness();
@@ -4082,6 +4275,7 @@ async function testHugeTranscriptGapTraversalStaysBoundedAndAnchored() {
   await testConvertServerMessagesSuppressesNonBubbleAssistantRows();
   await testSessionPruningDestroysTranscriptStores();
   await testOptimisticTranscriptStorageIsPerSession();
+  await testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconciliation();
   await testGroupedToolRowsPreserveDurableRangesAndLaterAnchors();
   await testLargeToolTurnLoadsAsOneSegmentWithFarEndGrouping();
   await testTerminalTranscriptSyncQueuesBehindInflightRequest();

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -52,6 +52,7 @@
       this.bodies = new Map();
       this.segments = [];
       this.optimistic = [];
+      this.persistedOptimistic = new WeakSet();
       this.activeRun = null;
       this.etag = '';
       this.viewport = { firstOrdinal: -1, lastOrdinal: -1 };
@@ -414,17 +415,21 @@
       return result;
     }
 
-    addOptimistic(entry, revAtSend = this.rev) {
+    addOptimistic(entry, revAtSend = this.rev, options = {}) {
       if (!entry || typeof entry !== 'object') return null;
       const clientKey = String(entry.clientKey || entry.id || `optimistic-${Date.now()}-${this.optimistic.length}`);
       const existing = this.optimistic.find((item) => String(item.clientKey || item.id || '') === clientKey);
-      if (existing) return existing;
+      if (existing) {
+        if (options.persisted === true) this.persistedOptimistic.add(existing);
+        return existing;
+      }
       const optimistic = entry;
       optimistic.clientKey = clientKey;
       optimistic.optimistic = true;
       optimistic.revAtSend = finiteInt(entry.revAtSend, finiteInt(revAtSend, this.rev));
       optimistic.durableSeqAtSend = finiteInt(entry.durableSeqAtSend, this.seqs.length ? this.seqs[this.seqs.length - 1] : -1);
       this.optimistic.push(optimistic);
+      if (options.persisted === true) this.persistedOptimistic.add(optimistic);
       return optimistic;
     }
 
@@ -432,6 +437,48 @@
       const normalized = String(id || '').trim();
       this.activeRun = normalized ? { id: normalized, startedRev: finiteInt(startedRev, 0) } : null;
       return this.activeRun;
+    }
+
+    segmentAfterSequence(sequence) {
+      const boundary = finiteInt(sequence, -1);
+      let low = 0;
+      let high = this.seqs.length;
+      while (low < high) {
+        const mid = (low + high) >> 1;
+        if (this.seqs[mid] <= boundary) low = mid + 1;
+        else high = mid;
+      }
+      return low < this.seqs.length ? this.segmentForOrdinal(low) : -1;
+    }
+
+    persistedOptimisticToolSegmentIndexes(limit = TRANSCRIPT_MATERIALIZE_BATCH_TURNS) {
+      if (this.activeRun || this.optimistic.length === 0) return [];
+      const max = Math.max(1, finiteInt(limit, TRANSCRIPT_MATERIALIZE_BATCH_TURNS));
+      const selected = new Set();
+      for (const local of this.optimistic) {
+        if (selected.size >= max) break;
+        if (!this.persistedOptimistic.has(local)) continue;
+        if (local.role !== 'tool-group' && local.role !== 'tool') continue;
+        if (this.rev <= finiteInt(local.revAtSend, this.rev)) continue;
+        const segmentIndex = this.segmentAfterSequence(local.durableSeqAtSend);
+        if (segmentIndex >= 0 && this.segments[segmentIndex]?.state === 'evicted') selected.add(segmentIndex);
+      }
+      return [...selected];
+    }
+
+    durableToolIDsInSegment(segmentIndex, afterSequence = -1) {
+      const ids = new Set();
+      const segment = this.segments[segmentIndex];
+      if (!segment) return ids;
+      for (let ordinal = segment.startOrdinal; ordinal <= segment.endOrdinal; ordinal += 1) {
+        if (this.seqs[ordinal] <= afterSequence) continue;
+        const entry = this.bodies.get(this.ids[ordinal]);
+        for (const part of entry?.parts || []) {
+          const id = partToolID(part);
+          if (id) ids.add(id);
+        }
+      }
+      return ids;
     }
 
     durableToolIDsAfter(sequence) {
@@ -478,7 +525,9 @@
             const id = partToolID(part);
             if (id) localIDs.add(id);
           }
-          const durableIDs = this.durableToolIDsAfter(afterSeq);
+          const durableIDs = this.persistedOptimistic.has(local)
+            ? this.durableToolIDsInSegment(this.segmentAfterSequence(afterSeq), afterSeq)
+            : this.durableToolIDsAfter(afterSeq);
           matched = localIDs.size > 0 && [...localIDs].every((id) => durableIDs.has(id));
         } else if (local.role === 'assistant') {
           for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -286,6 +286,27 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   ]);
   assert.equal(tools.reconcileOptimistic().length, 1, 'interleaved durable tool evidence must replace optimistic group');
 
+  const scopedTools = new TranscriptStore('scoped-persisted-tools');
+  scopedTools.applyIndex(envelope([30, 31], { rev: 1, roles: 'ua' }));
+  scopedTools.addOptimistic({ clientKey: 'persisted-tools', role: 'tool-group', tools: [{ id: 'shared-call' }] }, 1, { persisted: true });
+  scopedTools.addOptimistic({ clientKey: 'live-tools', role: 'tool-group', tools: [{ id: 'shared-call' }] });
+  scopedTools.applyIndex(envelope([30, 31, 32, 33, 34, 35, 36], { rev: 2, roles: 'uauauat' }));
+  scopedTools.materialize([
+    body(30, 0, 'user'),
+    body(31, 1, 'assistant'),
+    body(32, 2, 'user'),
+    body(33, 3, 'assistant'),
+    body(34, 4, 'user'),
+    body(35, 5, 'assistant', [{ type: 'tool_call', tool_call_id: 'shared-call' }]),
+    body(36, 6, 'tool', [{ type: 'tool_result', tool_call_id: 'shared-call' }])
+  ]);
+  assert.deepEqual(
+    scopedTools.reconcileOptimistic().map((entry) => entry.clientKey),
+    ['live-tools'],
+    'persisted tool IDs must match only their target segment while live entries retain later-turn matching'
+  );
+  assert.deepEqual(scopedTools.optimistic.map((entry) => entry.clientKey), ['persisted-tools']);
+
   const displayOnly = new TranscriptStore('display-only');
   displayOnly.addOptimistic({ clientKey: 'guardian', role: 'event', transient: true });
   displayOnly.addOptimistic({ clientKey: 'pending-user', role: 'user' });


### PR DESCRIPTION
## What

- mark optimistic transcript entries restored from browser storage
- materialize the exact durable turn associated with persisted optimistic tool groups before reconciliation
- scope persisted tool-call ID matching to that turn so unrelated later tools cannot retire the wrong entry
- defer transcript body-budget enforcement until reconciliation has removed stale entries
- apply the same reconciliation flow to both fresh (`200`) and unchanged (`304`) transcript syncs

## Why

Completed tool groups could remain in `term_llm_optimistic_transcript` when their original durable turn was outside the currently materialized transcript window. Every reload restored those optimistic entries and appended them after the durable transcript, leaving orphaned tool cards at the bottom indefinitely.

## Tests

Regression coverage includes:

- persisted stale tool groups whose original turn starts evicted
- transcripts exceeding the 60-turn materialization budget
- bounded reconciliation fetches
- `200` and `304` transcript sync paths
- an unrelated later turn reusing an unmatched tool-call ID
- persistence cleanup after exact reconciliation
- active-run and stop-before-flush behavior through the existing reconciliation guards

Verified with:

```text
node internal/serveui/static/transcript_store_test.js
node internal/serveui/static/app_sessions_test.js
go test ./internal/serveui -count=1
go build ./...
git diff --check
```
