### PR TITLE
fix: stabilize revisioned web transcript rendering

### DIFF
--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1658,9 +1658,12 @@ const observeTranscriptGap = (node, _message, sessionId) => {
   if (!transcriptGapObserver) {
     transcriptGapObserver = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        if (!entry.isIntersecting) return;
+        if (!entry.isIntersecting || state.autoScroll) return;
         transcriptGapObserver.unobserve(entry.target);
-        loadTranscriptGap(entry.target, entry.target.dataset?.sessionId, null, entry.boundingClientRect);
+        window.requestAnimationFrame(() => {
+          if (entry.target.isConnected === false) return;
+          loadTranscriptGap(entry.target, entry.target.dataset?.sessionId);
+        });
       });
     }, { root: elements.chatScroll || null, rootMargin: '800px 0px' });
   }

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1073,7 +1073,7 @@ const noteTranscriptTerminal = (session, finalRev) => {
   });
 };
 
-const transcriptViewportAdapter = (session) => {
+const transcriptViewportAdapter = (session, forceScroll = false) => {
   if (!session || session.id !== state.activeSessionId || !elements.messages || !elements.chatScroll) return null;
   const scrollRect = () => elements.chatScroll.getBoundingClientRect?.() || { top: 0, bottom: Number(elements.chatScroll.clientHeight) || 0 };
   const durableNodeForID = (id) => {
@@ -1100,8 +1100,12 @@ const transcriptViewportAdapter = (session) => {
       return { id: Number(node.dataset.durableId), top: rect.top - viewport.top };
     },
     render: () => {
+      // TranscriptStore is the durable/body/optimistic source of truth. Publish
+      // its bounded display projection only at the transaction's single render
+      // boundary so session.messages and the DOM cannot observe half-applied
+      // index/body/reconciliation state.
       refreshSessionMessagesFromTranscript(session);
-      renderMessages(false);
+      renderMessages(forceScroll);
     },
     topForID: (id) => {
       const node = durableNodeForID(id);
@@ -1293,18 +1297,20 @@ const materializeTranscriptSegmentsOnce = async (session, request) => {
 
   transcript.enforceBudget();
   transcript.reconcileOptimistic();
-  refreshSessionMessagesFromTranscript(session);
+  persistTranscriptOptimistic(session);
   if (adapter) {
+    // adapter.render publishes the bounded store projection and reconciles the
+    // DOM once; do not build session.messages separately before that commit.
     adapter.render?.(transcript);
     const top = anchor == null ? null : adapter.topForID?.(anchor.id);
     if (Number.isFinite(top) && Number.isFinite(anchor.top)) adapter.adjustScroll?.(top - anchor.top);
   } else {
+    refreshSessionMessagesFromTranscript(session);
     renderMessages(false);
   }
   // Drop the temporary anchor pin after the anchored render. The viewport stays
   // on the newly loaded batch so the next fill can evict the old region.
   transcript.refreshPinnedSegments();
-  persistTranscriptOptimistic(session);
   return true;
 };
 
@@ -1328,21 +1334,6 @@ const syncTranscriptOnce = async (session, options = {}) => {
   if (transcript.etag && !options.force) headers['If-None-Match'] = transcript.etag;
   const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/transcript`, { headers });
   transcript.noteIndexFetch(resp.status === 304, resp.headers?.get?.('ETag') || '');
-  if (resp.status === 304) {
-    if (transcript.ids.length > 0 && transcript.viewport.firstOrdinal < 0) {
-      const last = transcript.ids.length - 1;
-      transcript.setViewport(last, last);
-    }
-    const loaded = await fetchTranscriptSegments(session, transcriptSyncSegmentIndexes(transcript), { deferBudget: true });
-    if (loaded) {
-      transcript.reconcileOptimistic();
-      persistTranscriptOptimistic(session);
-      transcript.enforceBudget();
-      refreshSessionMessagesFromTranscript(session);
-      if (session.id === state.activeSessionId) renderMessages(options.forceScroll === true);
-    }
-    return loaded;
-  }
   if (resp.status === 404) {
     const pages = await fetchLegacyTranscriptPages(session.id);
     if (!pages) return false;
@@ -1351,34 +1342,47 @@ const syncTranscriptOnce = async (session, options = {}) => {
     session.transcript.setViewport(Math.max(0, session.transcript.ids.length - 1), Math.max(0, session.transcript.ids.length - 1));
     session.transcript.enforceBudget();
     refreshSessionMessagesFromTranscript(session);
-    renderMessages(options.forceScroll === true);
+    if (session.id === state.activeSessionId) renderMessages(options.forceScroll === true);
     touchTranscriptSkeleton(session);
     return true;
   }
-  if (!resp.ok) return false;
-  const data = await resp.json().catch(() => null);
-  if (!data?.rows) return false;
-  const adapter = transcriptViewportAdapter(session);
-  transcript.withViewportAnchor(adapter, () => transcript.applyIndex(data, resp.headers?.get?.('ETag') || ''));
-  if (data.active_response_id) transcript.setActiveRun(data.active_response_id, data.started_rev);
+  if (resp.status !== 304 && !resp.ok) return false;
 
-  if (transcript.ids.length > 0 && transcript.viewport.firstOrdinal < 0) {
-    const last = transcript.ids.length - 1;
-    transcript.setViewport(last, last);
+  let data = null;
+  if (resp.status !== 304) {
+    data = await resp.json().catch(() => null);
+    if (!data?.rows) return false;
   }
-  const loaded = await fetchTranscriptSegments(session, transcriptSyncSegmentIndexes(transcript), { deferBudget: true });
-  if (!loaded) {
-    transcript.etag = '';
-    return false;
-  }
-  transcript.withViewportAnchor(adapter, () => {
+
+  const adapter = transcriptViewportAdapter(session, options.forceScroll === true);
+  const loaded = await transcript.withViewportAnchor(adapter, async () => {
+    if (data) {
+      transcript.applyIndex(data, resp.headers?.get?.('ETag') || '');
+      if (data.active_response_id) transcript.setActiveRun(data.active_response_id, data.started_rev);
+    }
+    if (transcript.ids.length > 0 && transcript.viewport.firstOrdinal < 0) {
+      const last = transcript.ids.length - 1;
+      transcript.setViewport(last, last, { deferBudget: true });
+    }
+    const bodiesLoaded = await fetchTranscriptSegments(
+      session,
+      transcriptSyncSegmentIndexes(transcript),
+      { deferBudget: true }
+    );
+    if (!bodiesLoaded) {
+      transcript.etag = '';
+      return false;
+    }
+    // Reconcile while all requested bodies are present, then persist the
+    // optimistic source before the transaction's final budget can evict a
+    // distant turn. withViewportAnchor publishes one bounded projection after
+    // this callback resolves.
     transcript.reconcileOptimistic();
     persistTranscriptOptimistic(session);
-    transcript.enforceBudget();
-    refreshSessionMessagesFromTranscript(session);
+    return true;
   });
+  if (!loaded) return false;
   touchTranscriptSkeleton(session);
-  if (session.id === state.activeSessionId) renderMessages(options.forceScroll === true);
   return true;
 };
 
@@ -1409,6 +1413,19 @@ const syncTranscript = async (session, options = {}) => {
       const targetRev = Math.max(Number(request.targetRev) || 0, queuedTarget);
       if (transcript && transcript.rev < targetRev) {
         mergeTranscriptSyncRequest(session, { reason: 'target-revision', force: true, targetRev });
+      }
+      const pending = session._transcriptSyncPending;
+      if (pending
+          && !pending.force
+          && !pending.forceScroll
+          && Number(pending.targetRev) > 0
+          && transcript
+          && transcript.rev >= Number(pending.targetRev)) {
+        // A status poll can discover a revision while an activation request is
+        // already in flight. If that response reached the queued target, the
+        // queued request carries no new work and must not manufacture a 304
+        // index round-trip plus another client reconciliation.
+        delete session._transcriptSyncPending;
       }
       if (!session._transcriptSyncPending) return true;
     }

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -426,6 +426,7 @@ function createHarness(appOverrides = {}) {
     CSS: { escape(value) { return String(value); } },
     setTimeout: windowObj.setTimeout.bind(windowObj),
     clearTimeout: windowObj.clearTimeout.bind(windowObj),
+    ...(appOverrides.IntersectionObserver ? { IntersectionObserver: appOverrides.IntersectionObserver } : {}),
   };
   context.globalThis = context;
   windowObj.document = document;
@@ -2021,6 +2022,54 @@ async function run(name, fn) {
     assert(turn.children[0] === userNode, 'unchanged durable user node should survive the stream append');
     assert(turn.children[1] === assistantNode, 'unchanged durable assistant node should survive the stream append');
     assertEqual(messages.children[1].dataset.messageId, 'stream-tail', 'stream tail should append after materialized turn');
+  });
+
+  await run('transcript gap observer uses current geometry after initial auto-scroll', async () => {
+    const loads = [];
+    let observerCallback = null;
+    class FakeIntersectionObserver {
+      constructor(callback) { observerCallback = callback; }
+      observe() {}
+      unobserve() {}
+    }
+    const { app, session, messages, timers } = createHarness({
+      IntersectionObserver: FakeIntersectionObserver,
+      materializeTranscriptSegments(targetSession, range) { loads.push({ targetSession, range }); }
+    });
+    app.elements.chatScroll = { getBoundingClientRect: () => ({ top: 0, bottom: 600 }) };
+    session.transcript = {};
+    session.messages = [
+      { id: 'gap', role: 'transcript-gap', transcriptGap: true, startOrdinal: 0, endOrdinal: 1000, estimatedHeight: 5000, startSegmentIndex: 0, endSegmentIndex: 1000 },
+      { id: 'u2', role: 'user', content: 'latest', durable: true, durableRowId: 1002, transcriptSegmentIndex: 1001, created: Date.now() },
+    ];
+    app.renderMessages(true);
+    const gap = messages.children[0];
+    // The observer captured this gap before renderMessages' forced scroll to the
+    // latest turn. By callback time the gap is above the viewport.
+    gap.getBoundingClientRect = () => ({ top: -5000, bottom: -100 });
+    app.state.autoScroll = true;
+    observerCallback([{
+      isIntersecting: true,
+      target: gap,
+      boundingClientRect: { top: 0, bottom: 5000 }
+    }]);
+    assertEqual(loads.length, 0, 'initial bottom-pinned render does not materialize an earlier gap');
+    assertEqual(timers.filter((timer) => !timer.cleared).length, 0, 'bottom-pinned gap does not queue deferred work');
+
+    app.state.autoScroll = false;
+    observerCallback([{
+      isIntersecting: true,
+      target: gap,
+      boundingClientRect: { top: 0, bottom: 5000 }
+    }]);
+    assertEqual(loads.length, 0, 'user-initiated intersection waits for post-scroll layout before materializing');
+    runNextTimer(timers);
+    await flushMicrotasks();
+
+    assertEqual(loads.length, 1, 'intersection requests one bounded materialization');
+    assertEqual(loads[0].targetSession, session, 'intersection targets the active session');
+    assertEqual(loads[0].range.targetOrdinal, 1000, 'callback remeasures the gap after forced scrolling');
+    assertEqual(loads[0].range.direction, 'backward', 'gap above the current viewport loads from its trailing edge');
   });
 
   await run('renderMessages bounds transcript DOM with compact clickable gap ranges', async () => {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -4238,6 +4238,123 @@ async function testHugeTranscriptGapTraversalStaysBoundedAndAnchored() {
   pass(name);
 }
 
+async function testTranscriptSyncCommitsOneRenderedProjection() {
+  const name = 'transcript sync commits one rendered projection after index and bodies';
+  const sessionId = 'single-render-sync';
+  let renders = 0;
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        return new Response(JSON.stringify({
+          rev: 2,
+          compaction_seq: -1,
+          compaction_count: 0,
+          rows: { ids: [101, 102], seqs: [0, 1], roles: 'ua', flags: [0, 0] }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"single-render-2"' } });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        return new Response(JSON.stringify({
+          rev: 2,
+          messages: [
+            { id: 101, sequence: 0, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'question' }] },
+            { id: 102, sequence: 1, role: 'assistant', created_at: 2000, parts: [{ type: 'text', text: 'answer' }] }
+          ]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: {
+      renderMessages() { renders += 1; }
+    }
+  });
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+  renders = 0;
+
+  const loaded = await app.syncTranscript(session, { reason: 'activation' });
+  if (!loaded || session.messages.map((message) => message.content).join(',') !== 'question,answer') {
+    fail(name, 'sync did not commit the complete projected transcript', JSON.stringify({ loaded, messages: session.messages }));
+    return;
+  }
+  if (renders !== 1) {
+    fail(name, `sync rendered ${renders} intermediate projections instead of one`);
+    return;
+  }
+  pass(name);
+}
+
+async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
+  const name = 'in-flight sync absorbs status target satisfied by its response';
+  const sessionId = 'coalesced-revision-sync';
+  let indexRequests = 0;
+  let releaseFirstIndex;
+  let markFirstIndexStarted;
+  const firstIndexStarted = new Promise((resolve) => { markFirstIndexStarted = resolve; });
+  const firstIndexGate = new Promise((resolve) => { releaseFirstIndex = resolve; });
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        indexRequests += 1;
+        if (indexRequests === 1) {
+          markFirstIndexStarted();
+          await firstIndexGate;
+          return new Response(JSON.stringify({
+            rev: 2,
+            compaction_seq: -1,
+            compaction_count: 0,
+            rows: { ids: [201, 202], seqs: [0, 1], roles: 'ua', flags: [0, 0] }
+          }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"coalesced-2"' } });
+        }
+        return new Response(null, { status: 304, headers: { ETag: '"coalesced-2"' } });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        return new Response(JSON.stringify({
+          rev: 2,
+          messages: [
+            { id: 201, sequence: 0, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'question' }] },
+            { id: 202, sequence: 1, role: 'assistant', created_at: 2000, parts: [{ type: 'text', text: 'answer' }] }
+          ]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+
+  const activation = app.syncTranscript(session, { reason: 'activation' });
+  await firstIndexStarted;
+  const statusSync = app.reconcileTranscriptFromStatus([{
+    id: sessionId,
+    transcript_rev: 2,
+    active_response_id: '',
+    started_rev: 0
+  }]);
+  releaseFirstIndex();
+  const [loaded] = await Promise.all([activation, statusSync]);
+  if (!loaded || session.transcript.rev !== 2) {
+    fail(name, 'the first response did not satisfy the queued target revision', JSON.stringify({ loaded, rev: session.transcript.rev }));
+    return;
+  }
+  if (indexRequests !== 1) {
+    fail(name, `satisfied revision caused ${indexRequests} transcript index requests`);
+    return;
+  }
+  pass(name);
+}
+
 (async () => {
   await testSanitizeMessagePreservesSkillRunState();
   await testSanitizeMessagePreservesPlanExecutionEvidence();
@@ -4276,6 +4393,8 @@ async function testHugeTranscriptGapTraversalStaysBoundedAndAnchored() {
   await testSessionPruningDestroysTranscriptStores();
   await testOptimisticTranscriptStorageIsPerSession();
   await testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconciliation();
+  await testTranscriptSyncCommitsOneRenderedProjection();
+  await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
   await testGroupedToolRowsPreserveDurableRangesAndLaterAnchors();
   await testLargeToolTurnLoadsAsOneSegmentWithFarEndGrouping();
   await testTerminalTranscriptSyncQueuesBehindInflightRequest();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3612,8 +3612,8 @@ async function testOptimisticTranscriptStorageIsPerSession() {
   pass(name);
 }
 
-async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconciliation() {
-  const name = 'reload reconciles persisted tool turns within their target segment beyond the materialization budget';
+async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalReconciliation() {
+  const name = 'reload reconciles matched persisted tools and retires unmatched completed tool UI at the terminal revision';
   const sessionId = 'stale-tool-reload';
   const storageKey = 'term_llm_optimistic_transcript';
   let nextID = 201;
@@ -3665,6 +3665,15 @@ async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconcili
       tools: [{ id: 'never-durable-call', name: 'write_file', status: 'done' }],
       revAtSend: 5,
       durableSeqAtSend: staleTurn[staleTurn.length - 1].sequence,
+      optimistic: true
+    },
+    {
+      id: 'local-queued-user',
+      clientKey: 'local-queued-user',
+      role: 'user',
+      content: 'queued after the active run',
+      revAtSend: 5,
+      durableSeqAtSend: raw[raw.length - 1].sequence,
       optimistic: true
     }
   ];
@@ -3747,14 +3756,14 @@ async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconcili
     return;
   }
   let optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
-  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
-    fail(name, '200 reconciliation did not retire only the target-segment match before budget enforcement', JSON.stringify(optimisticKeys));
+  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-queued-user'])) {
+    fail(name, '200 terminal reconciliation retained stale completed tool UI or dropped the queued user', JSON.stringify(optimisticKeys));
     return;
   }
   let saved = JSON.parse(storage.get(storageKey) || 'null');
   let savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
-  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
-    fail(name, '200 reconciliation was not persisted before budget enforcement', JSON.stringify(saved));
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-queued-user'])) {
+    fail(name, '200 terminal reconciliation was not persisted without the stale tool tail', JSON.stringify(saved));
     return;
   }
   if (session.transcript.segments[0]?.state !== 'evicted'
@@ -3784,14 +3793,14 @@ async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconcili
     fail(name, '304 sync did not rematerialize the evicted reconciliation target', JSON.stringify({ loadedNotModified, targetStatesAtFetch, bodyRequests }));
     return;
   }
-  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
-    fail(name, '304 reconciliation did not retire its target-segment match before budget enforcement', JSON.stringify(optimisticKeys));
+  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-queued-user'])) {
+    fail(name, '304 reconciliation retained completed tool UI or dropped the queued user', JSON.stringify(optimisticKeys));
     return;
   }
   saved = JSON.parse(storage.get(storageKey) || 'null');
   savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
-  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-unmatched-tool-group'])) {
-    fail(name, '304 reconciliation was not persisted before budget enforcement', JSON.stringify(saved));
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-queued-user'])) {
+    fail(name, '304 reconciliation persistence did not retain only the queued user', JSON.stringify(saved));
     return;
   }
   const finalMaterialized = session.transcript.segments.filter((segment) => segment.state === 'materialized').length;
@@ -4392,7 +4401,7 @@ async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   await testConvertServerMessagesSuppressesNonBubbleAssistantRows();
   await testSessionPruningDestroysTranscriptStores();
   await testOptimisticTranscriptStorageIsPerSession();
-  await testReloadMaterializesPersistedOptimisticToolTurnsBeforeReconciliation();
+  await testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalReconciliation();
   await testTranscriptSyncCommitsOneRenderedProjection();
   await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
   await testGroupedToolRowsPreserveDurableRangesAndLaterAnchors();

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -556,45 +556,55 @@
       const anchor = adapter?.capture?.() || null;
       const oldIDs = this.ids.slice();
       const oldOrdinal = anchor ? oldIDs.indexOf(normalizedID(anchor.id)) : -1;
-      const result = mutation();
-      if (!anchor) {
-        adapter?.render?.(this);
-        return result;
-      }
-      let targetID = normalizedID(anchor.id);
-      if (!this.ids.includes(targetID)) {
-        targetID = null;
-        for (let ordinal = oldOrdinal - 1; ordinal >= 0; ordinal -= 1) {
-          if (this.ids.includes(oldIDs[ordinal])) {
-            targetID = oldIDs[ordinal];
-            break;
-          }
-        }
-        if (targetID == null) {
-          for (let ordinal = oldOrdinal + 1; ordinal < oldIDs.length; ordinal += 1) {
+      const finish = (result) => {
+        let targetID = anchor ? normalizedID(anchor.id) : null;
+        if (anchor && !this.ids.includes(targetID)) {
+          targetID = null;
+          for (let ordinal = oldOrdinal - 1; ordinal >= 0; ordinal -= 1) {
             if (this.ids.includes(oldIDs[ordinal])) {
               targetID = oldIDs[ordinal];
               break;
             }
           }
+          if (targetID == null) {
+            for (let ordinal = oldOrdinal + 1; ordinal < oldIDs.length; ordinal += 1) {
+              if (this.ids.includes(oldIDs[ordinal])) {
+                targetID = oldIDs[ordinal];
+                break;
+              }
+            }
+          }
         }
+        const targetSegment = this.segmentForID(targetID);
+        if (targetSegment >= 0) {
+          const targetOrdinal = this.ordinalForID(targetID);
+          const span = Math.max(0, this.viewport.lastOrdinal - this.viewport.firstOrdinal);
+          this.viewport = {
+            firstOrdinal: targetOrdinal,
+            lastOrdinal: Math.min(this.ids.length - 1, targetOrdinal + span)
+          };
+        }
+        // Finalize the body budget before projecting the store into the DOM. The
+        // previous implementation rendered inside each intermediate mutation,
+        // then evicted after rendering and needed another reconciliation pass to
+        // make the DOM agree with the store. A transcript transaction now has one
+        // observable commit: resolve the viewport, enforce the final budget, and
+        // render exactly once.
+        this.refreshPinnedSegments();
+        this.enforceBudget();
+        adapter?.render?.(this);
+        if (anchor) {
+          const top = targetID == null ? null : adapter?.topForID?.(targetID);
+          if (Number.isFinite(top) && Number.isFinite(anchor.top)) adapter?.adjustScroll?.(top - anchor.top);
+        }
+        return result;
+      };
+
+      const result = mutation();
+      if (result && typeof result.then === 'function') {
+        return Promise.resolve(result).then(finish);
       }
-      const targetSegment = this.segmentForID(targetID);
-      if (targetSegment >= 0) {
-        const targetOrdinal = this.ordinalForID(targetID);
-        const span = Math.max(0, this.viewport.lastOrdinal - this.viewport.firstOrdinal);
-        this.viewport = {
-          firstOrdinal: targetOrdinal,
-          lastOrdinal: Math.min(this.ids.length - 1, targetOrdinal + span)
-        };
-        this.pinnedSegments.add(targetSegment);
-      }
-      adapter?.render?.(this);
-      const top = targetID == null ? null : adapter?.topForID?.(targetID);
-      if (Number.isFinite(top) && Number.isFinite(anchor.top)) adapter?.adjustScroll?.(top - anchor.top);
-      this.refreshPinnedSegments();
-      this.enforceBudget();
-      return result;
+      return finish(result);
     }
 
     releaseBodies() {

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -539,7 +539,12 @@
             }
           }
         }
-        if (matched) removed.push(local);
+        // Reaching a newer durable revision with no active run is the terminal
+        // authority for completed tool UI. An unmatched completed tool cannot
+        // represent queued input and must not remain persisted at the tail.
+        const completedTool = (local.role === 'tool-group' || local.role === 'tool')
+          && ['done', 'error', 'failed', 'cancelled'].includes(String(local.status || '').toLowerCase());
+        if (matched || (!this.activeRun && completedTool)) removed.push(local);
         else kept.push(local);
       }
       this.optimistic = kept;

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -307,6 +307,38 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   );
   assert.deepEqual(scopedTools.optimistic.map((entry) => entry.clientKey), ['persisted-tools']);
 
+  const terminalTools = new TranscriptStore('terminal-tools');
+  terminalTools.applyIndex(envelope([40], { rev: 5 }));
+  terminalTools.addOptimistic({
+    clientKey: 'completed-tool-tail',
+    role: 'tool-group',
+    status: 'done',
+    tools: [{ id: 'local-only-call', status: 'done' }]
+  }, 5, { persisted: true });
+  terminalTools.addOptimistic({ clientKey: 'completed-standalone-tool', role: 'tool', status: 'error' }, 5, { persisted: true });
+  terminalTools.addOptimistic({ clientKey: 'queued-user', role: 'user', durableSeqAtSend: 99 }, 5, { persisted: true });
+  terminalTools.addOptimistic({
+    clientKey: 'running-tool',
+    role: 'tool-group',
+    status: 'running',
+    tools: [{ id: 'active-call', status: 'running' }]
+  }, 5, { persisted: true });
+  terminalTools.setActiveRun('resp-active', 5);
+  terminalTools.applyIndex(envelope([40, 41], { rev: 6, roles: 'ua' }));
+  materializeOrdinals(terminalTools, [1]);
+  assert.equal(terminalTools.reconcileOptimistic().length, 0, 'active runs must retain unmatched completed tool UI');
+  terminalTools.setActiveRun('', 0);
+  assert.deepEqual(
+    terminalTools.reconcileOptimistic().map((entry) => entry.clientKey),
+    ['completed-tool-tail', 'completed-standalone-tool'],
+    'an authoritative terminal revision must retire unmatched completed tool UI'
+  );
+  assert.deepEqual(
+    terminalTools.optimistic.map((entry) => entry.clientKey),
+    ['queued-user', 'running-tool'],
+    'queued user messages and running tools must survive terminal tool cleanup'
+  );
+
   const displayOnly = new TranscriptStore('display-only');
   displayOnly.addOptimistic({ clientKey: 'guardian', role: 'event', transient: true });
   displayOnly.addOptimistic({ clientKey: 'pending-user', role: 'user' });


### PR DESCRIPTION
## What

Stabilize revisioned web transcripts in two layers:

1. Prevent initial virtual transcript gaps from materializing while the conversation is auto-scrolled to the latest response. User-driven gap loading is deferred until layout settles and uses current geometry.
2. Make transcript index application, bounded body hydration, optimistic reconciliation, budget enforcement, message projection, and DOM reconciliation publish as one client transaction rather than several intermediate renders.
3. Drop queued revision targets already satisfied by an in-flight transcript response.
4. Retire unmatched completed optimistic tool/tool-group entries once a newer durable revision is authoritative and no run is active, while preserving running tools and queued user messages.

## Why

Today's transcript refactor introduced two distinct browser regressions:

- A pre-scroll `IntersectionObserver` callback could hydrate old transcript regions, repeatedly evict the correct tail, and leave reload/session switching at the wrong part of a long conversation.
- Transcript synchronization exposed index-only, hydrated, and reconciled projections separately, causing avoidable DOM churn and redundant revision requests during activation, reload, switching, and tool completion.
- Browsers that participated in streaming could persist completed optimistic tool groups whose client-side IDs did not match their durable rows. Those unmatched groups were deliberately retained forever and appended after the correct durable transcript on every reload.

The server-side revision index and body requests were already fast. The visible slowness and disorder came from browser-side materialization and reconciliation churn.

## Browser evidence

All scenarios used isolated state and system Chromium via Playwright.

### Long-session correctness

24,000 durable rows / 6,000 turns:

- transcript body requests: **16 → 4** (**75% fewer**)
- mounted DOM descendants: **1,986 → 299** (**84.9% fewer**)
- reload evictions: **151 → 0**
- reload remains on turns 5991–6000 instead of drifting to turns 1–60

### Reconciliation and navigation churn

- 400-turn reload mutations: **168 → 88** (**47.6% fewer**)
- repeated session-switch mutations: **31.5–31.8% fewer**
- dynamic streamed-tool mutations: **348 → 158** (**54.6% fewer**)
- reload transcript index requests: **2 → 1**

Streaming, persisted tool groups, gap materialization, direct reload, and repeated session switching remained correctly ordered with no duplicate messages or page errors.

## Verification

- Added regression coverage for stale pre-scroll observer geometry and user-initiated gap loading
- Added regression coverage for one rendered projection per transcript sync
- Added regression coverage for queued revisions satisfied by an in-flight response
- Added persisted-localStorage coverage proving terminal unmatched tool tails are removed while active tools and queued users survive
- `go test ./internal/serveui`
- `go test ./...` in clean isolated environments on both implementation strategies
- `go build ./...`
- Browser before/after runs with `/usr/bin/chromium` via Playwright

The combined branch was also built and deployed to the live `/chat` web UI for interactive verification.
