### PR TITLE
fix: Gemini accepts truncated SSE responses as successful completions

### DIFF
--- a/internal/llm/gemini_api.go
+++ b/internal/llm/gemini_api.go
@@ -196,9 +196,13 @@ func streamGeminiResponses(ctx context.Context, client *http.Client, baseURL, ap
 
 func readGeminiSSE(r io.Reader, handle func(*geminiGenerateContentResponse) error) error {
 	decoder := newSSEDecoder(r, sseDecoderOptions{Transport: "Gemini SSE"})
+	sawTerminal := false
 	for {
 		_, data, err := decoder.Next()
 		if err == io.EOF {
+			if !sawTerminal {
+				return &StreamIncompleteError{Transport: "Gemini SSE", Terminal: "candidate finishReason"}
+			}
 			return nil
 		}
 		if err != nil {
@@ -217,6 +221,12 @@ func readGeminiSSE(r io.Reader, handle func(*geminiGenerateContentResponse) erro
 		}
 		if err := geminiResponseError(&response, true); err != nil {
 			return err
+		}
+		if len(response.Candidates) > 0 && response.Candidates[0] != nil {
+			switch response.Candidates[0].FinishReason {
+			case "STOP", "MAX_TOKENS":
+				sawTerminal = true
+			}
 		}
 	}
 }

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -172,6 +172,7 @@ func TestGeminiStreamUsesMinimalRESTClient(t *testing.T) {
 	}
 	var text string
 	var usage *Usage
+	sawDone := false
 	for {
 		event, recvErr := stream.Recv()
 		if recvErr == io.EOF {
@@ -189,6 +190,12 @@ func TestGeminiStreamUsesMinimalRESTClient(t *testing.T) {
 		if event.Type == EventUsage {
 			usage = event.Use
 		}
+		if event.Type == EventDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatal("stream did not emit EventDone")
 	}
 	if text != "hello world" {
 		t.Fatalf("text = %q", text)
@@ -205,6 +212,54 @@ func TestGeminiStreamUsesMinimalRESTClient(t *testing.T) {
 	}
 	if config.MaxOutputTokens != 99 || config.Temperature == nil || *config.Temperature != 0 || config.TopP == nil || *config.TopP != 0.75 {
 		t.Fatalf("generation controls = %+v", config)
+	}
+}
+
+func TestGeminiStreamRejectsTruncatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"partial\"}]}}]}\n\n")
+	}))
+	defer server.Close()
+
+	provider := NewGeminiProvider("test-key", "gemini-test")
+	provider.baseURL = server.URL
+	provider.client = server.Client()
+	stream, err := provider.Stream(context.Background(), Request{Messages: []Message{UserText("hi")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawText, sawError bool
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatal(recvErr)
+		}
+		switch event.Type {
+		case EventTextDelta:
+			sawText = event.Text == "partial"
+		case EventDone:
+			t.Fatal("truncated stream emitted EventDone")
+		case EventError:
+			var incomplete *StreamIncompleteError
+			if !errors.As(event.Err, &incomplete) {
+				t.Fatalf("error = %T %v, want StreamIncompleteError", event.Err, event.Err)
+			}
+			if incomplete.Transport != "Gemini SSE" || incomplete.Terminal != "candidate finishReason" {
+				t.Fatalf("incomplete error = %+v", incomplete)
+			}
+			sawError = true
+		}
+	}
+	if !sawText {
+		t.Fatal("stream did not emit partial candidate text")
+	}
+	if !sawError {
+		t.Fatal("truncated stream did not emit EventError")
 	}
 }
 
@@ -249,7 +304,7 @@ func TestReadGeminiSSEAllowsTruncationAndIgnoresSecondaryCandidates(t *testing.T
 func TestReadGeminiSSEHandlesMultilineAndLargeEvents(t *testing.T) {
 	largeText := strings.Repeat("x", 5*1024*1024)
 	payload := "data: {\"candidates\":[{\"content\":{\"parts\":[\n" +
-		"data: {\"text\":" + string(mustJSONMarshal(t, largeText)) + "}]}}]}\n\n"
+		"data: {\"text\":" + string(mustJSONMarshal(t, largeText)) + "}]},\"finishReason\":\"STOP\"}]}\n\n"
 	var got string
 	err := readGeminiSSE(strings.NewReader(payload), func(resp *geminiGenerateContentResponse) error {
 		got = resp.Candidates[0].Content.Parts[0].Text
@@ -314,7 +369,7 @@ func TestGeminiStreamReturnsTypedSSEError(t *testing.T) {
 func TestGeminiStreamRejectsEmptyCandidateResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w, "data: {\"usageMetadata\":{\"promptTokenCount\":1,\"totalTokenCount\":1}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"totalTokenCount\":1}}\n\n")
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## What changed

- Track whether Gemini's primary candidate emitted an accepted terminal `finishReason` (`STOP` or `MAX_TOKENS`).
- Return a `StreamIncompleteError` when the SSE connection reaches EOF before that terminal reason, preventing the provider from emitting `EventDone` for partial output.
- Add a provider-level regression test for a response that emits text and then disconnects, and tighten complete-stream coverage to require `EventDone`.

## Why this is high-value

A proxy reset, provider disconnect, or dropped HTTP/2 stream could previously turn partial Gemini output into a successful completion. That silently corrupts the persisted/displayed answer and can omit trailing text or tool calls. Returning the existing typed incomplete-stream error routes the failure through term-llm's established transient retry and recovery behavior instead.

## Validation

- `gofmt -w internal/llm/gemini_api.go internal/llm/gemini_test.go`
- `go build ./...`
- `go test ./internal/llm -run 'Test(GeminiStreamUsesMinimalRESTClient|GeminiStreamRejectsTruncatedResponse|ReadGeminiSSE|GeminiStreamRejectsEmptyCandidateResponse)'`
- `HOME=$(mktemp -d) GOPATH=/home/agent/go GOCACHE=/home/agent/.cache/go-build go test ./...`
- `git diff --check`
