### PR TITLE
fix: Anthropic treats truncated streams as successful completions

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -281,6 +281,7 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 		}
 
 		var lastUsage *Usage
+		sawMessageStop := false
 		var streamOpts []option.RequestOption
 		if p.use1m {
 			streamOpts = append(streamOpts, option.WithHeaderAdd("anthropic-beta", the1mBetaHeader))
@@ -342,10 +343,15 @@ func (p *AnthropicProvider) streamStandard(ctx context.Context, req Request) (St
 						lastUsage.CacheWriteTokens = int(variant.Usage.CacheCreationInputTokens)
 					}
 				}
+			case anthropic.MessageStopEvent:
+				sawMessageStop = true
 			}
 		}
 		if err := stream.Err(); err != nil {
 			return fmt.Errorf("anthropic streaming error: %w", err)
+		}
+		if !sawMessageStop {
+			return &StreamIncompleteError{Transport: "Anthropic SSE", Terminal: "message_stop"}
 		}
 		if lastUsage != nil {
 			if err := send.Send(Event{Type: EventUsage, Use: lastUsage}); err != nil {
@@ -441,6 +447,7 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 		currentServerTool := ""
 		currentServerToolIndex := int64(-1)
 		var lastUsage *Usage
+		sawMessageStop := false
 
 		stream := p.client.Beta.Messages.NewStreaming(ctx, params)
 		for stream.Next() {
@@ -526,10 +533,15 @@ func (p *AnthropicProvider) streamWithSearch(ctx context.Context, req Request) (
 						lastUsage.CacheWriteTokens = int(variant.Usage.CacheCreationInputTokens)
 					}
 				}
+			case anthropic.BetaRawMessageStopEvent:
+				sawMessageStop = true
 			}
 		}
 		if err := stream.Err(); err != nil {
 			return fmt.Errorf("anthropic streaming error: %w", err)
+		}
+		if !sawMessageStop {
+			return &StreamIncompleteError{Transport: "Anthropic SSE", Terminal: "message_stop"}
 		}
 		if currentServerTool != "" {
 			if err := send.Send(Event{Type: EventToolExecEnd, ToolName: currentServerTool, ToolSuccess: true}); err != nil {

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -3,7 +3,9 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1158,6 +1160,100 @@ data: {"type":"message_stop"}
 			}
 			if tt.wantText != "" && textContent != tt.wantText {
 				t.Errorf("text content = %q, want %q", textContent, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestAnthropicStreamsRejectMissingMessageStop(t *testing.T) {
+	tests := []struct {
+		name      string
+		search    bool
+		sse       string
+		wantEvent EventType
+	}{
+		{
+			name:      "standard partial text",
+			wantEvent: EventTextDelta,
+			sse: "event: message_start\n" +
+				`data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n" +
+				"event: content_block_start\n" +
+				`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+				"event: content_block_delta\n" +
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}` + "\n\n",
+		},
+		{
+			name:      "beta active server tool",
+			search:    true,
+			wantEvent: EventToolExecStart,
+			sse: "event: message_start\n" +
+				`data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n" +
+				"event: content_block_start\n" +
+				`data: {"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{}}}` + "\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				fmt.Fprint(w, tt.sse)
+			}))
+			defer ts.Close()
+
+			client := anthropic.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(ts.URL))
+			provider := &AnthropicProvider{client: &client, model: "claude-sonnet-4-6"}
+			stream, err := provider.Stream(context.Background(), Request{
+				Messages: []Message{UserText("test")},
+				Search:   tt.search,
+			})
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			defer stream.Close()
+
+			var sawPartial, sawError, sawDone, sawSuccessfulToolEnd bool
+			for {
+				event, recvErr := stream.Recv()
+				if errors.Is(recvErr, io.EOF) {
+					break
+				}
+				if recvErr != nil {
+					t.Fatalf("Recv() error: %v", recvErr)
+				}
+				if event.Type == tt.wantEvent {
+					sawPartial = true
+				}
+				switch event.Type {
+				case EventError:
+					sawError = true
+					var incomplete *StreamIncompleteError
+					if !errors.As(event.Err, &incomplete) {
+						t.Fatalf("error = %T %v, want StreamIncompleteError", event.Err, event.Err)
+					}
+					if incomplete.Transport != "Anthropic SSE" || incomplete.Terminal != "message_stop" {
+						t.Errorf("incomplete error = %+v, want Anthropic SSE message_stop", incomplete)
+					}
+				case EventDone:
+					sawDone = true
+				case EventToolExecEnd:
+					if event.ToolSuccess {
+						sawSuccessfulToolEnd = true
+					}
+				}
+			}
+
+			if !sawPartial {
+				t.Fatalf("missing partial stream event %v", tt.wantEvent)
+			}
+			if !sawError {
+				t.Fatal("missing EventError")
+			}
+			if sawDone {
+				t.Fatal("truncated stream emitted EventDone")
+			}
+			if sawSuccessfulToolEnd {
+				t.Fatal("truncated stream reported server tool success")
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

- Track Anthropic's required `message_stop` terminal event in both standard and beta web-search streams.
- Return `StreamIncompleteError` when a syntactically valid SSE stream reaches EOF without that marker, instead of emitting `EventDone`.
- Delay beta server-tool fallback success until after terminal validation so an interrupted active tool is not reported as successful.
- Add standard and beta HTTP stream regressions covering partial output followed by clean EOF.

## Why this is high-value

Anthropic is a regular provider path, and its SDK treats clean EOF as a successful scanner termination even when the response was cut off. A proxy reset or provider disconnect could therefore persist partial text or tool activity as a completed answer. Classifying the missing terminal event as `StreamIncompleteError` activates the engine's existing retry/recovery path rather than silently corrupting the transcript.

## Validation

- `go test ./internal/llm -run 'TestAnthropicStreamsRejectMissingMessageStop|TestStreamWithSearchServerToolExecEnd|TestAnthropicStreamSerializesReasoningEffort' -count=1`
- `go build ./...`
- `XDG_CONFIG_HOME=<temporary-empty-directory> go test ./...`
- `git diff --check`
