### PR TITLE
perf: streamline fresh web session startup

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1135,6 +1135,9 @@ type serveServer struct {
 	widgetsMgr              *widgets.Manager
 	indexHTMLOnce           sync.Once
 	cachedIndexHTML         []byte
+	worktreeRootOnce        sync.Once
+	worktreeRoot            string
+	worktreeRootErr         error
 	fileTrackStoreFn        func() *filetrack.Store // test seam; nil → process-wide store from config
 	worktreeRootFn          func() (string, error)  // test seam; nil → os.Getwd
 }

--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -15,6 +15,49 @@ type webCurrentPlan struct {
 	Explanation string         `json:"explanation,omitempty"`
 }
 
+type webPlanSummary struct {
+	Version        int64  `json:"version"`
+	StepCount      int    `json:"step_count"`
+	CompletedSteps int    `json:"completed_steps"`
+	Position       int    `json:"position"`
+	State          string `json:"state"`
+}
+
+func summarizeWebPlan(snapshot planpkg.Snapshot, version int64) *webPlanSummary {
+	if version <= 0 || snapshot.NormalizeAndValidate() != nil || len(snapshot.Plan) == 0 {
+		return nil
+	}
+	summary := &webPlanSummary{
+		Version:   version,
+		StepCount: len(snapshot.Plan),
+		Position:  1,
+		State:     string(planpkg.StatusPending),
+	}
+	firstPending := 0
+	for index, step := range snapshot.Plan {
+		switch step.Status {
+		case planpkg.StatusCompleted:
+			summary.CompletedSteps++
+		case planpkg.StatusInProgress:
+			summary.Position = index + 1
+			summary.State = string(planpkg.StatusInProgress)
+		case planpkg.StatusPending:
+			if firstPending == 0 {
+				firstPending = index + 1
+			}
+		}
+	}
+	if summary.State != string(planpkg.StatusInProgress) {
+		if firstPending > 0 {
+			summary.Position = firstPending
+		} else {
+			summary.Position = summary.StepCount
+			summary.State = string(planpkg.StatusCompleted)
+		}
+	}
+	return summary
+}
+
 func planSnapshotStoreForWeb(store session.Store) (session.PlanSnapshotStore, bool) {
 	if store == nil {
 		return nil, false

--- a/cmd/serve_file_changes_test.go
+++ b/cmd/serve_file_changes_test.go
@@ -6,9 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/filetrack"
+	planpkg "github.com/samsaffron/term-llm/internal/plan"
 	"github.com/samsaffron/term-llm/internal/session"
 )
 
@@ -34,6 +38,143 @@ func getSessionPath(t *testing.T, srv *serveServer, path string) (int, map[strin
 		_ = json.Unmarshal(rr.Body.Bytes(), &body)
 	}
 	return rr.Code, body
+}
+
+func TestHandleSessionsSelectedSessionSideloadsStartupMetadata(t *testing.T) {
+	ctx := context.Background()
+	sessionStore, err := session.NewStore(session.Config{
+		Enabled: true,
+		Path:    filepath.Join(t.TempDir(), "sessions.db"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { sessionStore.Close() })
+
+	fileStore, err := filetrack.Open(filepath.Join(t.TempDir(), "file_history.db"), filetrack.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { fileStore.Close() })
+
+	now := time.Now()
+	clean := &session.Session{ID: "clean-session", Summary: "Clean", CreatedAt: now, UpdatedAt: now}
+	changed := &session.Session{ID: "changed-session", Summary: "Changed", CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second)}
+	for _, sess := range []*session.Session{clean, changed} {
+		if err := sessionStore.Create(ctx, sess); err != nil {
+			t.Fatalf("Create(%s): %v", sess.ID, err)
+		}
+	}
+	if _, err := fileStore.RecordChange(ctx, filetrack.ChangeRecord{
+		SessionID: changed.ID,
+		Path:      "/work/changed.go",
+		Before:    []byte("old\nkeep\n"),
+		After:     []byte("new\nkeep\nextra\n"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	planStore := sessionStore.(session.PlanSnapshotStore)
+	if _, err := planStore.SavePlanSnapshot(ctx, changed.ID, planpkg.Snapshot{Plan: []planpkg.Step{
+		{Step: "Finished", Status: planpkg.StatusCompleted},
+		{Step: "Working", Status: planpkg.StatusInProgress},
+		{Step: "Later", Status: planpkg.StatusPending},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &serveServer{
+		store:            sessionStore,
+		fileTrackStoreFn: func() *filetrack.Store { return fileStore },
+	}
+
+	type fileChangeSummary struct {
+		FileCount int `json:"file_count"`
+		Adds      int `json:"adds"`
+		Dels      int `json:"dels"`
+	}
+	type planSummary struct {
+		Version        int64  `json:"version"`
+		StepCount      int    `json:"step_count"`
+		CompletedSteps int    `json:"completed_steps"`
+		Position       int    `json:"position"`
+		State          string `json:"state"`
+	}
+	type selectedSession struct {
+		ID                string            `json:"id"`
+		Number            int64             `json:"number"`
+		FileChangeSummary fileChangeSummary `json:"file_change_summary"`
+		PlanSummary       *planSummary      `json:"plan_summary"`
+	}
+	request := func(selector string) selectedSession {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v1/sessions?selected_session="+selector, nil)
+		rr := httptest.NewRecorder()
+		srv.handleSessions(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET selected_session=%s: status=%d body=%s", selector, rr.Code, rr.Body.String())
+		}
+		var body struct {
+			Sessions []json.RawMessage `json:"sessions"`
+			Selected selectedSession   `json:"selected_session"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(selector, "selected_only=1") && len(body.Sessions) != 0 {
+			t.Fatalf("selected_only returned %d sidebar sessions, want none", len(body.Sessions))
+		}
+		return body.Selected
+	}
+
+	cleanSelected := request(clean.ID)
+	if cleanSelected.ID != clean.ID || cleanSelected.FileChangeSummary != (fileChangeSummary{}) {
+		t.Fatalf("clean selected session = %#v", cleanSelected)
+	}
+	if cleanSelected.PlanSummary != nil {
+		t.Fatalf("clean plan summary = %#v, want nil", cleanSelected.PlanSummary)
+	}
+
+	// Numeric route selectors are resolved in this bulk request, before the
+	// browser is allowed to issue any session-scoped requests.
+	changedSelected := request(strconv.FormatInt(changed.Number, 10) + "&selected_only=1")
+	if changedSelected.ID != changed.ID || changedSelected.Number != changed.Number {
+		t.Fatalf("numeric selected session = %#v", changedSelected)
+	}
+	if got := changedSelected.FileChangeSummary; got.FileCount != 1 || got.Adds != 2 || got.Dels != 1 {
+		t.Fatalf("file change summary = %#v, want count=1 adds=2 dels=1", got)
+	}
+	if got := changedSelected.PlanSummary; got == nil || got.Version <= 0 || got.StepCount != 3 || got.CompletedSteps != 1 || got.Position != 2 || got.State != "in_progress" {
+		t.Fatalf("plan summary = %#v", got)
+	}
+}
+
+func TestHandleSessionsWithoutSelectionDoesNotLoadFileChanges(t *testing.T) {
+	// A plain sidebar listing has no selected_session sideload. This guards the
+	// many-row endpoint against per-session file-history or plan lookups.
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{
+		Enabled: true,
+		Path:    filepath.Join(t.TempDir(), "sessions.db"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	for _, id := range []string{"one", "two"} {
+		if err := store.Create(ctx, &session.Session{ID: id, CreatedAt: time.Now(), UpdatedAt: time.Now()}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	srv := &serveServer{store: store, fileTrackStoreFn: func() *filetrack.Store {
+		t.Fatal("plain session listing must not open file tracking")
+		return nil
+	}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessions(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
 }
 
 func TestSessionFileChangesEndpoints(t *testing.T) {

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -316,6 +316,8 @@ func (s *serveServer) buildIndexHTML() []byte {
 	titleEscaped, _ := json.Marshal(s.cfg.uiTitle)
 	headSnippet += `<script>window.TERM_LLM_UI_TITLE=` + string(titleEscaped) + `;</script>`
 	headSnippet += `<script>window.TERM_LLM_LOCATION_SHARING_ENABLED=` + strconv.FormatBool(!s.cfg.locationSharingDisabled) + `;</script>`
+	_, worktreeRootErr := s.currentGitRoot()
+	headSnippet += `<script>window.TERM_LLM_WORKTREES_ENABLED=` + strconv.FormatBool(worktreeRootErr == nil) + `;</script>`
 	if s.cfg.hubURL != "" {
 		hubEscaped, _ := json.Marshal(map[string]string{
 			"url":      s.cfg.hubURL,
@@ -1016,6 +1018,137 @@ func sessionSummaryLastMessageAt(sess session.SessionSummary) time.Time {
 	return lastMessageAt
 }
 
+type webFileChangeSummary struct {
+	FileCount int `json:"file_count"`
+	Adds      int `json:"adds"`
+	Dels      int `json:"dels"`
+}
+
+type webSessionEntry struct {
+	ID            string                `json:"id"`
+	Number        int64                 `json:"number,omitempty"`
+	Name          string                `json:"name,omitempty"`
+	ShortTitle    string                `json:"short_title"`
+	LongTitle     string                `json:"long_title"`
+	Mode          session.SessionMode   `json:"mode,omitempty"`
+	Origin        session.SessionOrigin `json:"origin,omitempty"`
+	Provider      string                `json:"provider,omitempty"`
+	Archived      bool                  `json:"archived"`
+	Pinned        bool                  `json:"pinned"`
+	CreatedAt     int64                 `json:"created_at"`
+	LastMessageAt int64                 `json:"last_message_at"`
+	MsgCount      int                   `json:"message_count"`
+}
+
+type webSelectedSessionEntry struct {
+	webSessionEntry
+	FileChangeSummary webFileChangeSummary `json:"file_change_summary"`
+	PlanSummary       *webPlanSummary      `json:"plan_summary"`
+}
+
+func (s *serveServer) webSessionEntryFromSummary(sess session.SessionSummary) webSessionEntry {
+	return webSessionEntry{
+		Name:          sess.Name,
+		ID:            sess.ID,
+		Number:        sess.Number,
+		ShortTitle:    sess.PreferredShortTitle(),
+		LongTitle:     sess.PreferredLongTitle(),
+		Mode:          sess.Mode,
+		Origin:        sess.Origin,
+		Provider:      sessionSummaryProviderKey(s.cfgRef, sess),
+		Archived:      sess.Archived,
+		Pinned:        sess.Pinned,
+		CreatedAt:     sess.CreatedAt.UnixMilli(),
+		LastMessageAt: sessionSummaryLastMessageAt(sess).UnixMilli(),
+		MsgCount:      sess.MessageCount,
+	}
+}
+
+func (s *serveServer) webSessionEntryFromSession(sess *session.Session) webSessionEntry {
+	lastMessageAt := sess.UpdatedAt
+	if lastMessageAt.IsZero() {
+		lastMessageAt = sess.CreatedAt
+	}
+	provider := strings.TrimSpace(sess.ProviderKey)
+	if provider == "" {
+		provider = resolveSessionProviderKey(s.cfgRef, sess)
+	}
+	return webSessionEntry{
+		Name:          sess.Name,
+		ID:            sess.ID,
+		Number:        sess.Number,
+		ShortTitle:    sess.PreferredShortTitle(),
+		LongTitle:     sess.PreferredLongTitle(),
+		Mode:          sess.Mode,
+		Origin:        sess.Origin,
+		Provider:      provider,
+		Archived:      sess.Archived,
+		Pinned:        sess.Pinned,
+		CreatedAt:     sess.CreatedAt.UnixMilli(),
+		LastMessageAt: lastMessageAt.UnixMilli(),
+		MsgCount:      sess.LastMessageCount,
+	}
+}
+
+func (s *serveServer) selectedWebSession(ctx context.Context, selector string, summaries []session.SessionSummary) (*webSelectedSessionEntry, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return nil, nil
+	}
+
+	var selected webSessionEntry
+	if number, err := strconv.ParseInt(selector, 10, 64); err == nil && number > 0 {
+		for _, summary := range summaries {
+			if summary.Number == number {
+				selected = s.webSessionEntryFromSummary(summary)
+				break
+			}
+		}
+		if selected.ID == "" {
+			sess, err := s.store.GetByNumber(ctx, number)
+			if err != nil || sess == nil {
+				return nil, nil
+			}
+			selected = s.webSessionEntryFromSession(sess)
+		}
+	} else {
+		for _, summary := range summaries {
+			if summary.ID == selector {
+				selected = s.webSessionEntryFromSummary(summary)
+				break
+			}
+		}
+		if selected.ID == "" {
+			sess, err := s.store.Get(ctx, selector)
+			if err != nil || sess == nil {
+				return nil, nil
+			}
+			selected = s.webSessionEntryFromSession(sess)
+		}
+	}
+
+	result := &webSelectedSessionEntry{webSessionEntry: selected}
+	if fileStore := s.fileTrackStore(); fileStore != nil {
+		changes, err := fileStore.ListSessionChanges(ctx, selected.ID)
+		if err != nil {
+			return nil, fmt.Errorf("summarize selected session file changes: %w", err)
+		}
+		result.FileChangeSummary.FileCount = len(changes)
+		for _, change := range changes {
+			result.FileChangeSummary.Adds += change.Adds
+			result.FileChangeSummary.Dels += change.Dels
+		}
+	}
+	if planStore, ok := planSnapshotStoreForWeb(s.store); ok {
+		snapshot, version, err := planStore.LoadPlanSnapshot(ctx, selected.ID)
+		if err != nil {
+			return nil, fmt.Errorf("load selected session plan: %w", err)
+		}
+		result.PlanSummary = summarizeWebPlan(snapshot, version)
+	}
+	return result, nil
+}
+
 func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
@@ -1023,63 +1156,51 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	categories, err := parseSidebarSessionCategories(r.URL.Query().Get("categories"), false)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
-		return
-	}
-	includeArchived := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_archived")), "1") ||
-		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_archived")), "true")
-
-	sessions, err := s.store.List(r.Context(), session.ListOptions{
-		Limit:          100,
-		Archived:       includeArchived,
-		Categories:     categories,
-		SortByActivity: true,
-	})
-	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to list sessions")
+	selectedOnly := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("selected_only")), "1") ||
+		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("selected_only")), "true")
+	selectedSelector := strings.TrimSpace(r.URL.Query().Get("selected_session"))
+	if selectedOnly && selectedSelector == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "selected_session is required with selected_only")
 		return
 	}
 
-	type sessionEntry struct {
-		ID            string                `json:"id"`
-		Number        int64                 `json:"number,omitempty"`
-		Name          string                `json:"name,omitempty"`
-		ShortTitle    string                `json:"short_title"`
-		LongTitle     string                `json:"long_title"`
-		Mode          session.SessionMode   `json:"mode,omitempty"`
-		Origin        session.SessionOrigin `json:"origin,omitempty"`
-		Provider      string                `json:"provider,omitempty"`
-		Archived      bool                  `json:"archived"`
-		Pinned        bool                  `json:"pinned"`
-		CreatedAt     int64                 `json:"created_at"`
-		LastMessageAt int64                 `json:"last_message_at"`
-		MsgCount      int                   `json:"message_count"`
-	}
+	var sessions []session.SessionSummary
+	if !selectedOnly {
+		categories, err := parseSidebarSessionCategories(r.URL.Query().Get("categories"), false)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+			return
+		}
+		includeArchived := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_archived")), "1") ||
+			strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_archived")), "true")
 
-	result := make([]sessionEntry, 0, len(sessions))
-	for _, sess := range sessions {
-		provider := sessionSummaryProviderKey(s.cfgRef, sess)
-		lastMessageAt := sessionSummaryLastMessageAt(sess)
-		result = append(result, sessionEntry{
-			Name:          sess.Name,
-			ID:            sess.ID,
-			Number:        sess.Number,
-			ShortTitle:    sess.PreferredShortTitle(),
-			LongTitle:     sess.PreferredLongTitle(),
-			Mode:          sess.Mode,
-			Origin:        sess.Origin,
-			Provider:      provider,
-			Archived:      sess.Archived,
-			Pinned:        sess.Pinned,
-			CreatedAt:     sess.CreatedAt.UnixMilli(),
-			LastMessageAt: lastMessageAt.UnixMilli(),
-			MsgCount:      sess.MessageCount,
+		sessions, err = s.store.List(r.Context(), session.ListOptions{
+			Limit:          100,
+			Archived:       includeArchived,
+			Categories:     categories,
+			SortByActivity: true,
 		})
+		if err != nil {
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to list sessions")
+			return
+		}
 	}
 
-	writeJSONConditional(w, r, http.StatusOK, map[string]any{"sessions": result})
+	result := make([]webSessionEntry, 0, len(sessions))
+	for _, sess := range sessions {
+		result = append(result, s.webSessionEntryFromSummary(sess))
+	}
+
+	selected, err := s.selectedWebSession(r.Context(), selectedSelector, sessions)
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to load selected session metadata")
+		return
+	}
+
+	writeJSONConditional(w, r, http.StatusOK, map[string]any{
+		"sessions":         result,
+		"selected_session": selected,
+	})
 }
 
 func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Request) {

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1158,6 +1158,8 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 
 	selectedOnly := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("selected_only")), "1") ||
 		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("selected_only")), "true")
+	includeWidgetStatus := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_widget_status")), "1") ||
+		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_widget_status")), "true")
 	selectedSelector := strings.TrimSpace(r.URL.Query().Get("selected_session"))
 	if selectedOnly && selectedSelector == "" {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "selected_session is required with selected_only")
@@ -1197,10 +1199,16 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSONConditional(w, r, http.StatusOK, map[string]any{
+	payload := map[string]any{
 		"sessions":         result,
 		"selected_session": selected,
-	})
+	}
+	if includeWidgetStatus {
+		// The shell HTML is public and process-wide cached so mutable widget
+		// status belongs in this primary authenticated startup response instead.
+		payload["widget_status"] = s.currentWidgetStatus()
+	}
+	writeJSONConditional(w, r, http.StatusOK, payload)
 }
 
 func (s *serveServer) handleSessionsSearch(w http.ResponseWriter, r *http.Request) {

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1160,9 +1160,15 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("selected_only")), "true")
 	includeWidgetStatus := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_widget_status")), "1") ||
 		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_widget_status")), "true")
+	includeTranscript := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_transcript")), "1") ||
+		strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_transcript")), "true")
 	selectedSelector := strings.TrimSpace(r.URL.Query().Get("selected_session"))
 	if selectedOnly && selectedSelector == "" {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "selected_session is required with selected_only")
+		return
+	}
+	if includeTranscript && selectedSelector == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "selected_session is required with include_transcript")
 		return
 	}
 
@@ -1207,6 +1213,14 @@ func (s *serveServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 		// The shell HTML is public and process-wide cached so mutable widget
 		// status belongs in this primary authenticated startup response instead.
 		payload["widget_status"] = s.currentWidgetStatus()
+	}
+	if includeTranscript && selected != nil {
+		// Only the explicitly selected startup session gets transcript I/O. Keep
+		// ordinary 100-row sidebar listings summary-only and N+1 free.
+		sideload, sideloadErr := s.selectedTranscriptStartupSideload(r.Context(), selected.ID)
+		if sideloadErr == nil && sideload != nil {
+			payload["selected_transcript"] = sideload
+		}
 	}
 	writeJSONConditional(w, r, http.StatusOK, payload)
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/serveui"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
+	"github.com/samsaffron/term-llm/internal/widgets"
 )
 
 type stagedStream struct {
@@ -5046,6 +5047,138 @@ func TestHandleSessions_ListsFromStore(t *testing.T) {
 	}
 	if body.Sessions[0].LastMessageAt != body.Sessions[0].CreatedAt {
 		t.Fatalf("last_message_at = %d, want %d (fallback to created_at when no messages)", body.Sessions[0].LastMessageAt, body.Sessions[0].CreatedAt)
+	}
+}
+
+func TestHandleSessions_SideloadsExactWidgetStatus(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	widgetsDir := t.TempDir()
+	widgetDir := filepath.Join(widgetsDir, "private-widget-id")
+	if err := os.MkdirAll(widgetDir, 0o755); err != nil {
+		t.Fatalf("mkdir widget: %v", err)
+	}
+	manifest := `title: "Startup Metrics"
+mount: metrics
+command: ["widget-server", "--socket", "$SOCKET"]
+description: "Safe sidebar description"
+`
+	if err := os.WriteFile(filepath.Join(widgetDir, "widget.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write widget manifest: %v", err)
+	}
+	manager := widgets.NewManager(widgetsDir, "/ui")
+	defer manager.Close()
+
+	srv := &serveServer{
+		cfg:        serveServerConfig{basePath: "/ui", ui: true},
+		store:      store,
+		widgetsMgr: manager,
+	}
+
+	sideloadReq := httptest.NewRequest(http.MethodGet, "/v1/sessions?include_widget_status=1", nil)
+	sideloadRec := httptest.NewRecorder()
+	srv.handleSessions(sideloadRec, sideloadReq)
+	if sideloadRec.Code != http.StatusOK {
+		t.Fatalf("sideload status = %d, want 200; body=%s", sideloadRec.Code, sideloadRec.Body.String())
+	}
+	var sideload map[string]any
+	if err := json.Unmarshal(sideloadRec.Body.Bytes(), &sideload); err != nil {
+		t.Fatalf("decode sideload: %v", err)
+	}
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/admin/widgets/status", nil)
+	statusRec := httptest.NewRecorder()
+	srv.handleAdminWidgetsStatus(statusRec, statusReq)
+	if statusRec.Code != http.StatusOK {
+		t.Fatalf("widget status = %d, want 200; body=%s", statusRec.Code, statusRec.Body.String())
+	}
+	var statusPayload map[string]any
+	if err := json.Unmarshal(statusRec.Body.Bytes(), &statusPayload); err != nil {
+		t.Fatalf("decode widget status: %v", err)
+	}
+
+	if !reflect.DeepEqual(sideload["widget_status"], statusPayload) {
+		t.Fatalf("sideloaded widget_status = %#v, want exact endpoint shape %#v", sideload["widget_status"], statusPayload)
+	}
+	widgetStatus, ok := sideload["widget_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("widget_status type = %T, want object", sideload["widget_status"])
+	}
+	entries, ok := widgetStatus["widgets"].([]any)
+	if !ok || len(entries) != 1 {
+		t.Fatalf("widget_status.widgets = %#v, want one entry", widgetStatus["widgets"])
+	}
+	entry, ok := entries[0].(map[string]any)
+	if !ok || entry["id"] != "private-widget-id" || entry["mount"] != "metrics" || entry["title"] != "Startup Metrics" || entry["description"] != "Safe sidebar description" || entry["state"] != "stopped" {
+		t.Fatalf("serialized widget entry = %#v", entries[0])
+	}
+	if strings.Contains(sideloadRec.Body.String(), widgetsDir) || strings.Contains(sideloadRec.Body.String(), "widget-server") || strings.Contains(sideloadRec.Body.String(), "$SOCKET") {
+		t.Fatalf("sideload exposed filesystem or command configuration: %s", sideloadRec.Body.String())
+	}
+
+	index := string(srv.buildIndexHTML())
+	for _, sensitive := range []string{"private-widget-id", "Startup Metrics", "Safe sidebar description", widgetsDir} {
+		if strings.Contains(index, sensitive) {
+			t.Fatalf("public bootstrap HTML exposed widget status/config value %q", sensitive)
+		}
+	}
+
+	// The sideload remains behind the same auth wrapper as the sessions API;
+	// the public shell must not become an alternate widget-discovery surface.
+	srv.cfg.requireAuth = true
+	srv.cfg.token = "startup-secret"
+	handler := srv.httpHandler()
+	unauthorized := httptest.NewRecorder()
+	handler.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodGet, "/ui/v1/sessions?include_widget_status=1", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated sideload status = %d, want 401", unauthorized.Code)
+	}
+	if strings.Contains(unauthorized.Body.String(), "Startup Metrics") {
+		t.Fatalf("unauthenticated sideload leaked widget status: %s", unauthorized.Body.String())
+	}
+	authorizedReq := httptest.NewRequest(http.MethodGet, "/ui/v1/sessions?include_widget_status=1", nil)
+	authorizedReq.Header.Set("Authorization", "Bearer startup-secret")
+	authorized := httptest.NewRecorder()
+	handler.ServeHTTP(authorized, authorizedReq)
+	if authorized.Code != http.StatusOK || !strings.Contains(authorized.Body.String(), "Startup Metrics") {
+		t.Fatalf("authenticated sideload status = %d, body=%s", authorized.Code, authorized.Body.String())
+	}
+}
+
+func TestHandleSessions_SideloadsAuthoritativeEmptyWidgetStatus(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	srv := &serveServer{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions?include_widget_status=1", nil)
+	rec := httptest.NewRecorder()
+	srv.handleSessions(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		WidgetStatus struct {
+			Widgets []json.RawMessage `json:"widgets"`
+		} `json:"widget_status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.WidgetStatus.Widgets == nil {
+		t.Fatalf("widget_status.widgets = nil, want authoritative [] in %s", rec.Body.String())
+	}
+	if len(payload.WidgetStatus.Widgets) != 0 {
+		t.Fatalf("widget_status.widgets = %d entries, want 0", len(payload.WidgetStatus.Widgets))
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -516,6 +516,44 @@ func TestCustomBasePath_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestBuildIndexHTMLBootstrapsWorktreeCapabilityAndReusesGitRoot(t *testing.T) {
+	tests := []struct {
+		name       string
+		cwd        string
+		wantGlobal string
+		wantStatus int
+	}{
+		{name: "git cwd", cwd: newGitRepoForBindingTest(t), wantGlobal: `window.TERM_LLM_WORKTREES_ENABLED=true`, wantStatus: http.StatusOK},
+		{name: "non-git cwd", cwd: t.TempDir(), wantGlobal: `window.TERM_LLM_WORKTREES_ENABLED=false`, wantStatus: http.StatusConflict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCalls := 0
+			srv := &serveServer{
+				cfg: serveServerConfig{basePath: "/ui"},
+				worktreeRootFn: func() (string, error) {
+					rootCalls++
+					return tt.cwd, nil
+				},
+			}
+
+			body := string(srv.renderIndexHTML())
+			if !strings.Contains(body, tt.wantGlobal) {
+				t.Fatalf("index missing %q", tt.wantGlobal)
+			}
+
+			rec := httptest.NewRecorder()
+			srv.handleWorktrees(rec, httptest.NewRequest(http.MethodGet, "/v1/worktrees", nil))
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("worktree list status = %d body=%s, want %d", rec.Code, rec.Body.String(), tt.wantStatus)
+			}
+			if rootCalls != 1 {
+				t.Fatalf("worktree root detection called %d times, want once across bootstrap and request", rootCalls)
+			}
+		})
+	}
+}
+
 func TestBuildIndexHTMLDisablesLocationSharing(t *testing.T) {
 	srv := &serveServer{cfg: serveServerConfig{basePath: "/ui", locationSharingDisabled: true}}
 	body := string(srv.buildIndexHTML())

--- a/cmd/serve_transcript.go
+++ b/cmd/serve_transcript.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,8 +13,9 @@ import (
 )
 
 const (
-	transcriptBodiesMaxAnchors    = session.TranscriptMaterializationMaxRanges
-	transcriptBodiesMaxQueryBytes = 4096
+	transcriptBodiesMaxAnchors     = session.TranscriptMaterializationMaxRanges
+	transcriptBodiesMaxQueryBytes  = 4096
+	transcriptStartupViewportTurns = 9
 )
 
 type transcriptRowsResponse struct {
@@ -35,6 +37,12 @@ type transcriptResponse struct {
 type transcriptBodiesResponse struct {
 	Rev      int64                 `json:"rev"`
 	Messages []sessionMessageEntry `json:"messages"`
+}
+
+type transcriptStartupSideload struct {
+	Index     transcriptResponse       `json:"index"`
+	IndexETag string                   `json:"index_etag"`
+	Bodies    transcriptBodiesResponse `json:"bodies"`
 }
 
 func transcriptRoleCode(role string) byte {
@@ -85,13 +93,20 @@ func (s *serveServer) activeTranscriptRun(sessionID string) (string, int64) {
 	return id, run.startedRev
 }
 
-func writeTranscriptJSON(w http.ResponseWriter, r *http.Request, rev int64, payload any) {
+func transcriptJSON(payload any) ([]byte, string, error) {
 	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, jsonPayloadETag(body), nil
+}
+
+func writeTranscriptJSON(w http.ResponseWriter, r *http.Request, rev int64, payload any) {
+	body, etag, err := transcriptJSON(payload)
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	etag := jsonPayloadETag(body)
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("ETag", etag)
 	w.Header().Set("X-Transcript-Rev", strconv.FormatInt(rev, 10))
@@ -102,6 +117,36 @@ func writeTranscriptJSON(w http.ResponseWriter, r *http.Request, rev int64, payl
 		return
 	}
 	writeJSONGzipBody(w, r, http.StatusOK, body)
+}
+
+func transcriptRowsFromSnapshot(snapshot session.TranscriptSnapshot) transcriptRowsResponse {
+	rows := transcriptRowsResponse{
+		Seqs:  make([]int, 0, len(snapshot.Items)),
+		IDs:   make([]int64, 0, len(snapshot.Items)),
+		Flags: make([]int, 0, len(snapshot.Items)),
+	}
+	var roles strings.Builder
+	roles.Grow(len(snapshot.Items))
+	for _, item := range snapshot.Items {
+		rows.Seqs = append(rows.Seqs, item.Seq)
+		rows.IDs = append(rows.IDs, item.ID)
+		rows.Flags = append(rows.Flags, int(item.Flags))
+		roles.WriteByte(transcriptRoleCode(item.Role))
+	}
+	rows.Roles = roles.String()
+	return rows
+}
+
+func (s *serveServer) transcriptResponseFromSnapshot(sessionID string, snapshot session.TranscriptSnapshot) transcriptResponse {
+	activeResponseID, startedRev := s.activeTranscriptRun(sessionID)
+	return transcriptResponse{
+		Rev:              snapshot.Rev,
+		CompactionSeq:    snapshot.CompactionSeq,
+		CompactionCount:  snapshot.CompactionCount,
+		ActiveResponseID: activeResponseID,
+		StartedRev:       startedRev,
+		Rows:             transcriptRowsFromSnapshot(snapshot),
+	}
 }
 
 func (s *serveServer) handleSessionTranscript(w http.ResponseWriter, r *http.Request, sessionID string) {
@@ -119,29 +164,8 @@ func (s *serveServer) handleSessionTranscript(w http.ResponseWriter, r *http.Req
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get transcript")
 		return
 	}
-	rows := transcriptRowsResponse{
-		Seqs:  make([]int, 0, len(snapshot.Items)),
-		IDs:   make([]int64, 0, len(snapshot.Items)),
-		Flags: make([]int, 0, len(snapshot.Items)),
-	}
-	var roles strings.Builder
-	roles.Grow(len(snapshot.Items))
-	for _, item := range snapshot.Items {
-		rows.Seqs = append(rows.Seqs, item.Seq)
-		rows.IDs = append(rows.IDs, item.ID)
-		rows.Flags = append(rows.Flags, int(item.Flags))
-		roles.WriteByte(transcriptRoleCode(item.Role))
-	}
-	rows.Roles = roles.String()
-	activeResponseID, startedRev := s.activeTranscriptRun(sessionID)
-	writeTranscriptJSON(w, r, snapshot.Rev, transcriptResponse{
-		Rev:              snapshot.Rev,
-		CompactionSeq:    snapshot.CompactionSeq,
-		CompactionCount:  snapshot.CompactionCount,
-		ActiveResponseID: activeResponseID,
-		StartedRev:       startedRev,
-		Rows:             rows,
-	})
+	payload := s.transcriptResponseFromSnapshot(sessionID, snapshot)
+	writeTranscriptJSON(w, r, snapshot.Rev, payload)
 }
 
 func parseTranscriptBodyAnchors(raw string) ([]int64, error) {
@@ -207,6 +231,75 @@ func expandTranscriptTurnRanges(items []session.TranscriptIndexItem, requested [
 	return ranges
 }
 
+func transcriptStartupBodyAnchors(items []session.TranscriptIndexItem) []int64 {
+	if len(items) == 0 {
+		return nil
+	}
+	anchors := make([]int64, 0, transcriptStartupViewportTurns)
+	for ordinal := len(items) - 1; ordinal >= 0 && len(anchors) < transcriptStartupViewportTurns; ordinal-- {
+		if ordinal == 0 || items[ordinal].Role == "user" {
+			anchors = append(anchors, items[ordinal].ID)
+		}
+	}
+	for left, right := 0, len(anchors)-1; left < right; left, right = left+1, right-1 {
+		anchors[left], anchors[right] = anchors[right], anchors[left]
+	}
+	return anchors
+}
+
+var errTranscriptProjectionChanged = errors.New("transcript changed while loading bodies")
+
+func readCoherentTranscriptProjection(
+	ctx context.Context,
+	indexer session.TranscriptIndexer,
+	sessionID string,
+	selectRanges func(session.TranscriptSnapshot) []session.TranscriptRange,
+) (session.TranscriptSnapshot, []session.Message, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		snapshot, err := indexer.GetTranscriptSnapshot(ctx, sessionID)
+		if err != nil {
+			return session.TranscriptSnapshot{}, nil, fmt.Errorf("get transcript snapshot: %w", err)
+		}
+		rev, messages, err := indexer.GetMessagesByTranscriptRanges(ctx, sessionID, selectRanges(snapshot))
+		if err != nil {
+			return session.TranscriptSnapshot{}, nil, fmt.Errorf("get transcript bodies: %w", err)
+		}
+		if rev == snapshot.Rev {
+			return snapshot, messages, nil
+		}
+	}
+	return session.TranscriptSnapshot{}, nil, errTranscriptProjectionChanged
+}
+
+func (s *serveServer) selectedTranscriptStartupSideload(ctx context.Context, sessionID string) (*transcriptStartupSideload, error) {
+	indexer, ok := transcriptIndexerForWeb(s.store)
+	if !ok {
+		return nil, nil
+	}
+	snapshot, messages, err := readCoherentTranscriptProjection(ctx, indexer, sessionID, func(snapshot session.TranscriptSnapshot) []session.TranscriptRange {
+		return expandTranscriptTurnRanges(snapshot.Items, transcriptStartupBodyAnchors(snapshot.Items))
+	})
+	if errors.Is(err, session.ErrNotFound) || errors.Is(err, errTranscriptProjectionChanged) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load startup transcript projection: %w", err)
+	}
+	index := s.transcriptResponseFromSnapshot(sessionID, snapshot)
+	_, etag, err := transcriptJSON(index)
+	if err != nil {
+		return nil, fmt.Errorf("serialize startup transcript index: %w", err)
+	}
+	return &transcriptStartupSideload{
+		Index:     index,
+		IndexETag: etag,
+		Bodies: transcriptBodiesResponse{
+			Rev:      snapshot.Rev,
+			Messages: s.sessionMessageEntries(messages),
+		},
+	}, nil
+}
+
 func (s *serveServer) handleSessionTranscriptBodies(w http.ResponseWriter, r *http.Request, sessionID string) {
 	indexer, ok := transcriptIndexerForWeb(s.store)
 	if !ok {
@@ -219,30 +312,23 @@ func (s *serveServer) handleSessionTranscriptBodies(w http.ResponseWriter, r *ht
 		return
 	}
 
-	for attempt := 0; attempt < 3; attempt++ {
-		snapshot, err := indexer.GetTranscriptSnapshot(r.Context(), sessionID)
-		if errors.Is(err, session.ErrNotFound) {
-			writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
-			return
-		}
-		if err != nil {
-			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get transcript")
-			return
-		}
-		ranges := expandTranscriptTurnRanges(snapshot.Items, requested)
-		rev, messages, err := indexer.GetMessagesByTranscriptRanges(r.Context(), sessionID, ranges)
-		if err != nil {
-			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get transcript bodies")
-			return
-		}
-		if rev != snapshot.Rev {
-			continue
-		}
-		writeTranscriptJSON(w, r, rev, transcriptBodiesResponse{
-			Rev:      rev,
-			Messages: s.sessionMessageEntries(messages),
-		})
+	snapshot, messages, err := readCoherentTranscriptProjection(r.Context(), indexer, sessionID, func(snapshot session.TranscriptSnapshot) []session.TranscriptRange {
+		return expandTranscriptTurnRanges(snapshot.Items, requested)
+	})
+	if errors.Is(err, session.ErrNotFound) {
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
 		return
 	}
-	writeOpenAIError(w, http.StatusConflict, "conflict_error", "transcript changed while loading bodies; refresh the index")
+	if errors.Is(err, errTranscriptProjectionChanged) {
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", "transcript changed while loading bodies; refresh the index")
+		return
+	}
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get transcript bodies")
+		return
+	}
+	writeTranscriptJSON(w, r, snapshot.Rev, transcriptBodiesResponse{
+		Rev:      snapshot.Rev,
+		Messages: s.sessionMessageEntries(messages),
+	})
 }

--- a/cmd/serve_transcript_test.go
+++ b/cmd/serve_transcript_test.go
@@ -235,6 +235,147 @@ func TestHandleSessionTranscriptBodiesLoadsLargeTurnAtomicallyWithFarEndToolCont
 	}
 }
 
+func TestHandleSessionsSelectedTranscriptSideloadMatchesTranscriptEndpointsAndIsBounded(t *testing.T) {
+	srv, store, sess := newTranscriptHandlerServer(t)
+	ctx := context.Background()
+	const totalTurns = 20
+	for i := 0; i < totalTurns; i++ {
+		if err := store.AddMessage(ctx, sess.ID, session.NewMessage(sess.ID, llm.UserText(fmt.Sprintf("turn-%02d", i)), -1)); err != nil {
+			t.Fatalf("AddMessage %d: %v", i, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions?selected_session="+sess.ID+"&selected_only=1&include_transcript=1", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessions(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("sessions status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var startup struct {
+		SelectedSession    *webSelectedSessionEntry   `json:"selected_session"`
+		SelectedTranscript *transcriptStartupSideload `json:"selected_transcript"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &startup); err != nil {
+		t.Fatalf("decode sessions: %v", err)
+	}
+	if startup.SelectedSession == nil || startup.SelectedSession.ID != sess.ID {
+		t.Fatalf("selected session=%+v", startup.SelectedSession)
+	}
+	if startup.SelectedTranscript == nil {
+		t.Fatalf("missing selected transcript sideload: %s", rr.Body.String())
+	}
+	if got, want := len(startup.SelectedTranscript.Index.Rows.IDs), totalTurns; got != want {
+		t.Fatalf("sideload index rows=%d want=%d", got, want)
+	}
+	if got, want := len(startup.SelectedTranscript.Bodies.Messages), transcriptStartupViewportTurns; got != want {
+		t.Fatalf("sideload bodies=%d want bounded %d", got, want)
+	}
+	if startup.SelectedTranscript.Index.Rev != startup.SelectedTranscript.Bodies.Rev {
+		t.Fatalf("sideload revisions differ: index=%d bodies=%d", startup.SelectedTranscript.Index.Rev, startup.SelectedTranscript.Bodies.Rev)
+	}
+
+	indexReq := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sess.ID+"/transcript", nil)
+	indexRec := httptest.NewRecorder()
+	srv.handleSessionByID(indexRec, indexReq)
+	if indexRec.Code != http.StatusOK {
+		t.Fatalf("index status=%d body=%s", indexRec.Code, indexRec.Body.String())
+	}
+	var endpointIndex transcriptResponse
+	if err := json.Unmarshal(indexRec.Body.Bytes(), &endpointIndex); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := startup.SelectedTranscript.IndexETag, indexRec.Header().Get("ETag"); got != want || got == "" {
+		t.Fatalf("sideload index etag=%q endpoint=%q", got, want)
+	}
+	gotIndex, _ := json.Marshal(startup.SelectedTranscript.Index)
+	wantIndex, _ := json.Marshal(endpointIndex)
+	if string(gotIndex) != string(wantIndex) {
+		t.Fatalf("sideload index diverges from endpoint:\n got %s\nwant %s", gotIndex, wantIndex)
+	}
+
+	anchors := make([]string, 0, transcriptStartupViewportTurns)
+	for _, message := range startup.SelectedTranscript.Bodies.Messages {
+		anchors = append(anchors, strconv.FormatInt(message.ID, 10))
+	}
+	bodiesReq := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sess.ID+"/transcript/bodies?ids="+strings.Join(anchors, ","), nil)
+	bodiesRec := httptest.NewRecorder()
+	srv.handleSessionByID(bodiesRec, bodiesReq)
+	if bodiesRec.Code != http.StatusOK {
+		t.Fatalf("bodies status=%d body=%s", bodiesRec.Code, bodiesRec.Body.String())
+	}
+	var endpointBodies transcriptBodiesResponse
+	if err := json.Unmarshal(bodiesRec.Body.Bytes(), &endpointBodies); err != nil {
+		t.Fatal(err)
+	}
+	gotBodies, _ := json.Marshal(startup.SelectedTranscript.Bodies)
+	wantBodies, _ := json.Marshal(endpointBodies)
+	if string(gotBodies) != string(wantBodies) {
+		t.Fatalf("sideload bodies diverge from endpoint:\n got %s\nwant %s", gotBodies, wantBodies)
+	}
+}
+
+type countingTranscriptSideloadStore struct {
+	session.Store
+	indexer       session.TranscriptIndexer
+	snapshotCalls int
+	bodyCalls     int
+}
+
+func (s *countingTranscriptSideloadStore) GetTranscriptIndex(ctx context.Context, sessionID string) (int64, []session.TranscriptIndexItem, error) {
+	return s.indexer.GetTranscriptIndex(ctx, sessionID)
+}
+
+func (s *countingTranscriptSideloadStore) GetTranscriptSnapshot(ctx context.Context, sessionID string) (session.TranscriptSnapshot, error) {
+	s.snapshotCalls++
+	return s.indexer.GetTranscriptSnapshot(ctx, sessionID)
+}
+
+func (s *countingTranscriptSideloadStore) GetMessagesByTranscriptRanges(ctx context.Context, sessionID string, ranges []session.TranscriptRange) (int64, []session.Message, error) {
+	s.bodyCalls++
+	return s.indexer.GetMessagesByTranscriptRanges(ctx, sessionID, ranges)
+}
+
+func (s *countingTranscriptSideloadStore) TranscriptRev(ctx context.Context, sessionID string) (int64, error) {
+	return s.indexer.TranscriptRev(ctx, sessionID)
+}
+
+func TestHandleSessionsTranscriptSideloadIsExplicitAndSelectedOnly(t *testing.T) {
+	srv, store, sess := newTranscriptHandlerServer(t)
+	indexer, ok := store.(session.TranscriptIndexer)
+	if !ok {
+		t.Fatal("test store does not implement TranscriptIndexer")
+	}
+	counting := &countingTranscriptSideloadStore{Store: store, indexer: indexer}
+	srv.store = counting
+
+	plainReq := httptest.NewRequest(http.MethodGet, "/v1/sessions", nil)
+	plainRec := httptest.NewRecorder()
+	srv.handleSessions(plainRec, plainReq)
+	if plainRec.Code != http.StatusOK {
+		t.Fatalf("plain status=%d body=%s", plainRec.Code, plainRec.Body.String())
+	}
+	if strings.Contains(plainRec.Body.String(), "selected_transcript") || counting.snapshotCalls != 0 || counting.bodyCalls != 0 {
+		t.Fatalf("ordinary sidebar listing enriched transcripts: snapshots=%d bodies=%d body=%s", counting.snapshotCalls, counting.bodyCalls, plainRec.Body.String())
+	}
+
+	selectedReq := httptest.NewRequest(http.MethodGet, "/v1/sessions?selected_session="+sess.ID, nil)
+	selectedRec := httptest.NewRecorder()
+	srv.handleSessions(selectedRec, selectedReq)
+	if selectedRec.Code != http.StatusOK {
+		t.Fatalf("selected status=%d body=%s", selectedRec.Code, selectedRec.Body.String())
+	}
+	if strings.Contains(selectedRec.Body.String(), "selected_transcript") || counting.snapshotCalls != 0 || counting.bodyCalls != 0 {
+		t.Fatalf("selection without include flag loaded transcript: snapshots=%d bodies=%d body=%s", counting.snapshotCalls, counting.bodyCalls, selectedRec.Body.String())
+	}
+
+	invalidReq := httptest.NewRequest(http.MethodGet, "/v1/sessions?include_transcript=1", nil)
+	invalidRec := httptest.NewRecorder()
+	srv.handleSessions(invalidRec, invalidReq)
+	if invalidRec.Code != http.StatusBadRequest {
+		t.Fatalf("include without selected status=%d body=%s", invalidRec.Code, invalidRec.Body.String())
+	}
+}
+
 func TestHandleSessionTranscriptBodiesCapsTurnAnchorsAndMalformedQuerySize(t *testing.T) {
 	srv, store, sess := newTranscriptHandlerServer(t)
 	ctx := context.Background()

--- a/cmd/serve_widgets.go
+++ b/cmd/serve_widgets.go
@@ -127,24 +127,31 @@ func (s *serveServer) handleAdminWidgetsReload(w http.ResponseWriter, r *http.Re
 	_ = json.NewEncoder(w).Encode(res)
 }
 
+type widgetStatusResponse struct {
+	Widgets    []widgets.WidgetStatus `json:"widgets"`
+	LoadErrors []string               `json:"load_errors,omitempty"`
+}
+
+func (s *serveServer) currentWidgetStatus() widgetStatusResponse {
+	resp := widgetStatusResponse{Widgets: make([]widgets.WidgetStatus, 0)}
+	if s.widgetsMgr == nil {
+		return resp
+	}
+	resp.Widgets = s.widgetsMgr.Status()
+	for _, err := range s.widgetsMgr.LoadErrors() {
+		resp.LoadErrors = append(resp.LoadErrors, err.Error())
+	}
+	return resp
+}
+
 // handleAdminWidgetsStatus handles GET /admin/widgets/status.
 func (s *serveServer) handleAdminWidgetsStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	type statusResponse struct {
-		Widgets    []widgets.WidgetStatus `json:"widgets"`
-		LoadErrors []string               `json:"load_errors,omitempty"`
-	}
-	resp := statusResponse{
-		Widgets: s.widgetsMgr.Status(),
-	}
-	for _, e := range s.widgetsMgr.LoadErrors() {
-		resp.LoadErrors = append(resp.LoadErrors, e.Error())
-	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(s.currentWidgetStatus())
 }
 
 // handleAdminWidgetStop handles POST /admin/widgets/<mount>/stop.

--- a/cmd/serve_worktrees.go
+++ b/cmd/serve_worktrees.go
@@ -45,16 +45,29 @@ type worktreeRow struct {
 	InUse      []worktree.InUseSession `json:"in_use,omitempty"`
 }
 
+// currentGitRoot resolves the serve process's startup repository once and shares
+// it between the HTML capability bootstrap and every worktree API handler.
+func (s *serveServer) currentGitRoot() (string, error) {
+	s.worktreeRootOnce.Do(func() {
+		cwd, err := os.Getwd()
+		if s.worktreeRootFn != nil {
+			cwd, err = s.worktreeRootFn()
+		}
+		if err != nil {
+			s.worktreeRootErr = err
+			return
+		}
+		if !worktree.IsGitRepo(cwd) {
+			s.worktreeRootErr = fmt.Errorf("not a git repository")
+			return
+		}
+		s.worktreeRoot, s.worktreeRootErr = worktree.MainRepoRoot(cwd)
+	})
+	return s.worktreeRoot, s.worktreeRootErr
+}
+
 func (s *serveServer) currentGitRootOr409(w http.ResponseWriter) (string, bool) {
-	cwd, err := os.Getwd()
-	if s.worktreeRootFn != nil {
-		cwd, err = s.worktreeRootFn()
-	}
-	if err != nil || !worktree.IsGitRepo(cwd) {
-		writeOpenAIError(w, http.StatusConflict, "invalid_request_error", "not a git repository")
-		return "", false
-	}
-	root, err := worktree.MainRepoRoot(cwd)
+	root, err := s.currentGitRoot()
 	if err != nil {
 		writeOpenAIError(w, http.StatusConflict, "invalid_request_error", "not a git repository")
 		return "", false

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -167,6 +167,25 @@ func cssRuleBlocks(cssSrc, selector string) []string {
 	}
 }
 
+func TestRenderIndexHTMLPlacesServerBootstrapBeforeApplicationScripts(t *testing.T) {
+	const capability = `<script>window.TERM_LLM_WORKTREES_ENABLED=false;</script>`
+	rendered := string(RenderIndexHTML("/chat", capability, RenderOptions{}))
+	capabilityAt := strings.Index(rendered, capability)
+	appAt := strings.Index(rendered, `src="app-core.js?v=`)
+	if capabilityAt < 0 {
+		t.Fatal("rendered index missing server capability bootstrap")
+	}
+	if appAt < 0 {
+		t.Fatal("rendered index missing app-core script")
+	}
+	if capabilityAt > appAt {
+		t.Fatal("server capability bootstrap must precede application scripts")
+	}
+	if !strings.Contains(rendered, `id="chipWorktree" hidden`) {
+		t.Fatal("embedded worktree control must start hidden until the explicit capability is applied")
+	}
+}
+
 func TestStaticAssetsEmbedProductionFilesOnly(t *testing.T) {
 	embedded := make(map[string]bool)
 	var testFixtures []string

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -147,6 +147,7 @@ const state = {
   sessionStateRequestGeneration: 0,
   lastAppliedSessionStateRequestGeneration: 0,
   currentPlan: null,
+  currentPlanSummary: null,
   currentPlanSessionId: '',
   currentPlanInitialized: false,
   currentPlanUnseen: false,
@@ -1534,9 +1535,11 @@ const updateSessionUsageDisplay = (session) => {
 const SCROLL_STICKY_THRESHOLD = 96;
 const SCROLL_UP_KEYS = new Set(['ArrowUp', 'PageUp', 'Home']);
 const SCROLL_TO_BOTTOM_MIN_INTERVAL_MS = 500;
+const FORCED_BOTTOM_SETTLE_MAX_MS = 1500;
 let lastScrollToBottomAt = -SCROLL_TO_BOTTOM_MIN_INTERVAL_MS;
 let pendingScrollToBottomTimer = 0;
 let pendingScrollToBottomForce = false;
+let forcedBottomSettle = null;
 
 const isNearBottom = () => {
   const el = elements.chatScroll;
@@ -1547,6 +1550,7 @@ const isNearBottom = () => {
 const noteUserScrollIntent = () => {
   state.autoScroll = false;
   clearPendingScrollToBottom();
+  cancelForcedBottomSettle();
 };
 
 const noteScrollPositionChanged = () => {
@@ -1577,6 +1581,59 @@ const clearPendingScrollToBottom = () => {
   pendingScrollToBottomForce = false;
 };
 
+const cancelForcedBottomSettle = () => {
+  const settle = forcedBottomSettle;
+  if (!settle) return;
+  forcedBottomSettle = null;
+  if (settle.rafId) window.cancelAnimationFrame(settle.rafId);
+  if (settle.timerId) window.clearTimeout(settle.timerId);
+  settle.observer?.disconnect();
+};
+
+const requestForcedBottomSettle = () => {
+  const settle = forcedBottomSettle;
+  if (!settle || settle.rafId) return;
+  if (Date.now() >= settle.expiresAt) {
+    cancelForcedBottomSettle();
+    return;
+  }
+
+  settle.rafId = window.requestAnimationFrame(() => {
+    if (forcedBottomSettle !== settle) return;
+    settle.rafId = 0;
+    if (Date.now() >= settle.expiresAt || !elements.chatScroll) {
+      cancelForcedBottomSettle();
+      return;
+    }
+    state.autoScroll = true;
+    elements.chatScroll.scrollTop = elements.chatScroll.scrollHeight;
+  });
+};
+
+// Forced startup/session renders can gain height after their DOM commit as
+// markdown, media, fonts, and the mobile visual viewport settle. Keep the
+// bottom anchored briefly, but never leave an observer running indefinitely.
+const startForcedBottomSettle = () => {
+  cancelForcedBottomSettle();
+  const settle = {
+    expiresAt: Date.now() + FORCED_BOTTOM_SETTLE_MAX_MS,
+    observer: null,
+    rafId: 0,
+    timerId: 0,
+  };
+  forcedBottomSettle = settle;
+
+  if (typeof ResizeObserver === 'function') {
+    settle.observer = new ResizeObserver(requestForcedBottomSettle);
+    if (elements.messages) settle.observer.observe(elements.messages);
+    settle.observer.observe(elements.chatScroll);
+  }
+  settle.timerId = window.setTimeout(() => {
+    if (forcedBottomSettle === settle) cancelForcedBottomSettle();
+  }, FORCED_BOTTOM_SETTLE_MAX_MS);
+  requestForcedBottomSettle();
+};
+
 const performScrollToBottom = (force = false) => {
   if (force) {
     state.autoScroll = true;
@@ -1592,6 +1649,7 @@ const scrollToBottom = (force = false) => {
   if (force) {
     clearPendingScrollToBottom();
     performScrollToBottom(true);
+    startForcedBottomSettle();
     return;
   }
   if (!state.autoScroll) {
@@ -1773,10 +1831,14 @@ const syncViewportShell = (() => {
 syncViewportShell();
 if (window.visualViewport) {
   window.visualViewport.addEventListener('resize', syncViewportShell);
+  window.visualViewport.addEventListener('resize', requestForcedBottomSettle);
   window.visualViewport.addEventListener('scroll', syncViewportShell);
+  window.visualViewport.addEventListener('scroll', requestForcedBottomSettle);
 }
 window.addEventListener('resize', syncViewportShell);
+window.addEventListener('resize', requestForcedBottomSettle);
 window.addEventListener('orientationchange', syncViewportShell);
+window.addEventListener('orientationchange', requestForcedBottomSettle);
 window.addEventListener('pageshow', syncViewportShell);
 document.addEventListener('focusin', syncViewportShell);
 document.addEventListener('focusout', () => {
@@ -1961,6 +2023,15 @@ const sessionIdFromURL = () => {
   const escaped = UI_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = path.match(new RegExp('^' + escaped + '/(.+)$'));
   return match ? decodeURIComponent(match[1]) : '';
+};
+
+// Numeric deep links are human-facing session numbers. They are route lookup
+// keys, not durable session IDs, so no session-scoped endpoint may see one.
+const isSessionIdentityResolved = (sessionOrId) => {
+  const id = String(
+    sessionOrId && typeof sessionOrId === 'object' ? sessionOrId.id : sessionOrId
+  ).trim();
+  return Boolean(id) && !/^\d+$/.test(id);
 };
 
 const updateURL = (sessionId) => {
@@ -2529,6 +2600,7 @@ Object.assign(app, {
   requestNotificationPermission,
   maybeNotifyResponseComplete,
   sessionIdFromURL,
+  isSessionIdentityResolved,
   sessionSlug,
   findSessionBySlug,
   updateURL,

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -60,6 +60,8 @@ const sessionDiffState = (sessionId) => {
       lastActivityAt: 0,
       pendingScrollPath: '',
       listLoaded: false,
+      summaryKnown: false,
+      summary: { fileCount: 0, adds: 0, dels: 0 },
       hidden: true               // panel starts closed; only an explicit user toggle reveals it
     };
     diffStateBySession.set(sessionId, ds);
@@ -67,7 +69,39 @@ const sessionDiffState = (sessionId) => {
   return ds;
 };
 
+const normalizeSessionDiffSummary = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const fileCount = Number(value.file_count);
+  const adds = Number(value.adds);
+  const dels = Number(value.dels);
+  if (!Number.isSafeInteger(fileCount) || fileCount < 0
+      || !Number.isSafeInteger(adds) || adds < 0
+      || !Number.isSafeInteger(dels) || dels < 0) return null;
+  return { fileCount, adds, dels };
+};
+
+const applySessionDiffSummary = (sessionId, value) => {
+  const owner = String(sessionId || '').trim();
+  const summary = normalizeSessionDiffSummary(value);
+  if (!owner || !summary) return false;
+  const ds = sessionDiffState(owner);
+  ds.summaryKnown = true;
+  ds.summary = summary;
+  if (summary.fileCount === 0) {
+    ds.files.clear();
+    ds.listLoaded = true;
+    reconcileDiffPathState(ds);
+  } else if (ds.files.size === 0) {
+    ds.listLoaded = false;
+  }
+  if (owner === state.activeSessionId) renderDiffSidebar(owner);
+  return true;
+};
+
 const authHeaders = () => (state.token ? { Authorization: `Bearer ${state.token}` } : {});
+const isResolvedSessionIdentity = typeof app.isSessionIdentityResolved === 'function'
+  ? app.isSessionIdentityResolved
+  : (sessionId) => Boolean(String(sessionId || '').trim()) && !/^\d+$/.test(String(sessionId).trim());
 
 const isDiffDrawerViewport = () => {
   try {
@@ -316,6 +350,7 @@ const reconcileDiffPathState = (ds) => {
 };
 
 const fetchSessionFileChanges = async (sessionId) => {
+  if (!isResolvedSessionIdentity(sessionId)) return false;
   const ds = sessionDiffState(sessionId);
   // Snapshot per-path seqs so live rows whose change events land while this
   // fetch is in flight survive the authoritative replace below.
@@ -353,6 +388,12 @@ const fetchSessionFileChanges = async (sessionId) => {
     });
     ds.files = next;
     ds.listLoaded = true;
+    ds.summaryKnown = true;
+    ds.summary = { fileCount: next.size, adds: 0, dels: 0 };
+    next.forEach((entry) => {
+      ds.summary.adds += entry.adds;
+      ds.summary.dels += entry.dels;
+    });
     reconcileDiffPathState(ds);
     // Cached diffs predating the authoritative seq are stale even though no
     // live event bumped them (the tab may have missed events while detached).
@@ -361,8 +402,10 @@ const fetchSessionFileChanges = async (sessionId) => {
       if (cached && (entry.lastSeq || 0) > (cached.seq || 0)) ds.dirtyPaths.add(path);
     });
     if (sessionId === state.activeSessionId) renderDiffSidebar(sessionId);
+    return true;
   } catch {
     // Network failures leave existing state untouched.
+    return false;
   }
 };
 
@@ -446,8 +489,19 @@ const fileDirName = (path) => {
 
 const kindBadgeLabel = { create: 'A', modify: 'M', delete: 'D' };
 
+const diffTotals = (ds) => {
+  if (!ds) return { fileCount: 0, adds: 0, dels: 0 };
+  if (!ds.listLoaded && ds.summaryKnown) return ds.summary;
+  const totals = { fileCount: ds.files.size, adds: 0, dels: 0 };
+  ds.files.forEach((entry) => {
+    totals.adds += entry.adds;
+    totals.dels += entry.dels;
+  });
+  return totals;
+};
+
 const applyDiffSidebarVisibility = (ds) => {
-  const hasChanges = ds && ds.files.size > 0;
+  const hasChanges = diffTotals(ds).fileCount > 0;
   const drawer = isDiffDrawerViewport();
   const visible = hasChanges && !ds.hidden && !drawer;
   const drawerOpen = Boolean(hasChanges && drawer && elements.diffSidebar?.classList.contains('open'));
@@ -557,13 +611,22 @@ const requestDiffHighlight = () => {
   });
 };
 
+const DIFF_FILE_ICON_SVG = '<svg class="diff-toggle-file-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 1.75h4.25L12.5 5.5v8.75h-8z"/><path d="M8.75 1.75V5.5h3.75"/><path d="M6.25 8.5h4"/><path d="M6.25 11h3"/></svg>';
+
 const renderDiffTotals = (ds) => {
-  let adds = 0;
-  let dels = 0;
-  ds.files.forEach((entry) => {
-    adds += entry.adds;
-    dels += entry.dels;
-  });
+  const { fileCount, adds, dels } = diffTotals(ds);
+  if (fileCount === 0) {
+    if (elements.diffSidebarTotals) elements.diffSidebarTotals.textContent = '';
+    if (elements.diffToggleBadge) {
+      elements.diffToggleBadge.replaceChildren();
+    }
+    if (elements.diffToggleBtn) {
+      elements.diffToggleBtn.title = '';
+      elements.diffToggleBtn.setAttribute?.('aria-label', 'Toggle file changes');
+    }
+    return;
+  }
+
   const summary = [];
   if (adds > 0) summary.push(`+${adds}`);
   if (dels > 0) summary.push(`−${dels}`);
@@ -572,24 +635,15 @@ const renderDiffTotals = (ds) => {
   if (elements.diffToggleBadge) {
     const badge = elements.diffToggleBadge;
     const parts = [];
-    const fileCount = ds.files.size || 0;
     const fileCountEl = createEl('span', 'diff-toggle-file-count');
-    fileCountEl.innerHTML = '<svg class="diff-toggle-file-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 1.75h4.25L12.5 5.5v8.75h-8z"/><path d="M8.75 1.75V5.5h3.75"/><path d="M6.25 8.5h4"/><path d="M6.25 11h3"/></svg>';
+    fileCountEl.innerHTML = DIFF_FILE_ICON_SVG;
     fileCountEl.dataset.fileCount = String(fileCount);
     parts.push(fileCountEl);
     if (adds > 0) parts.push(createEl('span', 'diff-toggle-stat-add', `+${adds}`));
     if (dels > 0) parts.push(createEl('span', 'diff-toggle-stat-del', `−${dels}`));
-    if (parts.length === 1 && fileCount === 0) parts.push(createEl('span', 'diff-toggle-stat-neutral', '0'));
     badge.replaceChildren(...parts);
-    // Pulse on change so new activity is discoverable while the panel is
-    // closed, without stealing attention when nothing moved.
-    if (badge._lastSummary !== undefined && badge._lastSummary !== summaryText && summaryText) {
-      applyTransientClass(badge, 'pulse');
-    }
-    badge._lastSummary = summaryText;
   }
   if (elements.diffToggleBtn) {
-    const fileCount = ds.files.size || 0;
     const fileLabel = `${fileCount} changed ${fileCount === 1 ? 'file' : 'files'}`;
     elements.diffToggleBtn.title = summary.length > 0 ? `${fileLabel} (${summary.join(' ')})` : fileLabel;
     elements.diffToggleBtn.setAttribute?.('aria-label', `Toggle file changes: ${elements.diffToggleBtn.title}`);
@@ -950,8 +1004,8 @@ const renderDiffSidebar = (sessionId) => {
   const ds = sessionDiffState(sessionId);
   applyDiffSidebarVisibility(ds);
   updateDiffBulkToggle(ds);
-  if (ds.files.size === 0) return;
   renderDiffTotals(ds);
+  if (ds.files.size === 0) return;
   // Skip the accordion (and its lazy diff fetches) while hidden; it renders
   // on reveal.
   if (elements.diffSidebar?.hidden) return;
@@ -1031,6 +1085,7 @@ const setDiffSidebarHidden = (hidden) => {
   if (!sessionId) return;
   const ds = sessionDiffState(sessionId);
   ds.hidden = Boolean(hidden);
+  if (!ds.hidden && !ds.listLoaded && (ds.summaryKnown || ds.files.size === 0)) void fetchSessionFileChanges(sessionId);
   renderDiffSidebar(sessionId);
   if (!ds.hidden) scheduleDiffRefresh(sessionId);
 };
@@ -1045,6 +1100,7 @@ const toggleDiffSidebar = () => {
     if (open) {
       app.closeCurrentPlanSurface?.({ restoreFocus: false });
       ds.hidden = false;
+      if (!ds.listLoaded && (ds.summaryKnown || ds.files.size === 0)) void fetchSessionFileChanges(sessionId);
       setPanelOpen({
         panel: elements.diffSidebar,
         open: true,
@@ -1113,10 +1169,13 @@ const activateDiffSidebar = (sessionId) => {
     return;
   }
   const ds = sessionDiffState(sessionId);
+  if (!ds.summaryKnown) {
+    const session = state.sessions?.find?.((item) => String(item?.id || '').trim() === String(sessionId));
+    if (session?.fileChangeSummary) applySessionDiffSummary(sessionId, session.fileChangeSummary);
+  }
   if (elements.diffFilterInput) elements.diffFilterInput.value = ds.filter || '';
   renderDiffSidebar(sessionId);
   applyDiffSidebarVisibility(ds);
-  if (!ds.listLoaded) void fetchSessionFileChanges(sessionId);
 };
 
 // After a run completes/fails, true-up against the server (events may have
@@ -1340,6 +1399,8 @@ Object.assign(app, {
   computeInlineEmphasis,
   sortDiffPaths,
   buildUnifiedDiff,
+  normalizeSessionDiffSummary,
+  applySessionDiffSummary,
   handleFileChangeEvent,
   activateDiffSidebar,
   refreshFileChangesAfterRun,

--- a/internal/serveui/static/app-plan.js
+++ b/internal/serveui/static/app-plan.js
@@ -80,6 +80,35 @@ const normalizeCurrentPlan = (value) => {
   return { version, steps, ...(explanation ? { explanation } : {}) };
 };
 
+const normalizeCurrentPlanSummary = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const version = Number(value.version);
+  const total = Number(value.step_count);
+  const completed = Number(value.completed_steps);
+  const position = Number(value.position);
+  const status = String(value.state || '');
+  if (!Number.isSafeInteger(version) || version <= 0
+      || !Number.isSafeInteger(total) || total <= 0
+      || !Number.isSafeInteger(completed) || completed < 0 || completed > total
+      || !Number.isSafeInteger(position) || position <= 0 || position > total
+      || !PLAN_STATUSES.has(status)) return null;
+  const complete = status === 'completed';
+  if (complete && (completed !== total || position !== total)) return null;
+  return { version, total, completed, position, complete, state: status };
+};
+
+const planSummaryFromPlan = (plan) => {
+  const summary = planSummary(plan);
+  return {
+    version: Number(plan?.version) || 0,
+    total: summary.total,
+    completed: summary.completed,
+    position: summary.position,
+    complete: summary.complete,
+    state: summary.complete ? 'completed' : ((plan?.steps || []).some((step) => step.status === 'in_progress') ? 'in_progress' : 'pending'),
+  };
+};
+
 const markerForStatus = (status) => {
   if (status === 'completed') return '✓';
   if (status === 'in_progress') return '●';
@@ -137,7 +166,7 @@ const renderPlanSurface = (progressElement, explanationElement, checklistElement
 };
 
 const currentPlanIsVisible = () => Boolean(
-  state.currentPlan
+  (state.currentPlan || state.currentPlanSummary)
   && state.currentPlanSessionId
   && state.currentPlanSessionId === state.activeSessionId
   && !state.draftSessionActive
@@ -195,11 +224,13 @@ const showPlanSurfaceForViewport = ({ transferFocus = false } = {}) => {
 const renderCurrentPlan = () => {
   const visible = currentPlanIsVisible();
   const plan = visible ? state.currentPlan : null;
+  const summary = visible
+    ? (plan ? planSummaryFromPlan(plan) : state.currentPlanSummary)
+    : null;
   if (elements.planToggleBtn) {
-    setHidden(elements.planToggleBtn, !plan);
-    elements.planToggleBtn.setAttribute('aria-expanded', state.currentPlanOpen && visible ? 'true' : 'false');
-    if (plan) {
-      const summary = planSummary(plan);
+    setHidden(elements.planToggleBtn, !summary);
+    elements.planToggleBtn.setAttribute('aria-expanded', state.currentPlanOpen && Boolean(plan) && visible ? 'true' : 'false');
+    if (summary) {
       if (elements.planToggleWord) {
         elements.planToggleWord.textContent = summary.complete ? 'Done' : 'Plan';
       }
@@ -214,7 +245,7 @@ const renderCurrentPlan = () => {
       elements.planToggleBtn.title = status;
     }
   }
-  if (elements.planUnseenDot) setHidden(elements.planUnseenDot, !plan || !state.currentPlanUnseen);
+  if (elements.planUnseenDot) setHidden(elements.planUnseenDot, !summary || !state.currentPlanUnseen);
 
   renderPlanSurface(elements.planPanelProgress, elements.planPanelExplanation, elements.planPanelChecklist, plan);
   renderPlanSurface(elements.planSheetProgress, elements.planSheetExplanation, elements.planSheetChecklist, plan);
@@ -250,12 +281,43 @@ const restoreFocusAfterForcedPlanClose = ({ preferReturnTarget = false } = {}) =
 const resetCurrentPlanForSession = (sessionId = '') => {
   restoreFocusAfterForcedPlanClose();
   state.currentPlan = null;
+  state.currentPlanSummary = null;
   state.currentPlanSessionId = String(sessionId || '').trim();
   state.currentPlanInitialized = false;
   state.currentPlanUnseen = false;
   state.currentPlanOpen = false;
   planReturnFocus = null;
   renderCurrentPlan();
+};
+
+const applyCurrentPlanSummary = (sessionId, value) => {
+  const owner = String(sessionId || '').trim();
+  if (!owner || owner !== String(state.activeSessionId || '').trim() || state.draftSessionActive) return false;
+  if (value === null) {
+    restoreFocusAfterForcedPlanClose({ preferReturnTarget: true });
+    state.currentPlan = null;
+    state.currentPlanSummary = null;
+    state.currentPlanSessionId = owner;
+    state.currentPlanInitialized = true;
+    state.currentPlanUnseen = false;
+    state.currentPlanOpen = false;
+    planReturnFocus = null;
+    renderCurrentPlan();
+    return true;
+  }
+  const incoming = normalizeCurrentPlanSummary(value);
+  if (!incoming) return false;
+  const currentVersion = Math.max(
+    Number(state.currentPlan?.version || 0),
+    Number(state.currentPlanSummary?.version || 0),
+  );
+  if (state.currentPlanSessionId === owner && currentVersion > incoming.version) return false;
+  state.currentPlanSummary = incoming;
+  state.currentPlanSessionId = owner;
+  state.currentPlanInitialized = true;
+  state.currentPlanUnseen = false;
+  renderCurrentPlan();
+  return true;
 };
 
 const applyCurrentPlanState = (sessionId, response) => {
@@ -265,9 +327,13 @@ const applyCurrentPlanState = (sessionId, response) => {
 
   const wasInitialized = state.currentPlanInitialized && state.currentPlanSessionId === owner;
   const previousPlan = state.currentPlanSessionId === owner ? state.currentPlan : null;
+  const previousVersion = state.currentPlanSessionId === owner
+    ? Math.max(Number(previousPlan?.version || 0), Number(state.currentPlanSummary?.version || 0))
+    : 0;
   if (response.current_plan === null) {
     restoreFocusAfterForcedPlanClose({ preferReturnTarget: true });
     state.currentPlan = null;
+    state.currentPlanSummary = null;
     state.currentPlanSessionId = owner;
     state.currentPlanInitialized = true;
     state.currentPlanUnseen = false;
@@ -283,11 +349,12 @@ const applyCurrentPlanState = (sessionId, response) => {
   if (previousPlan && incoming.version <= Number(previousPlan.version || 0)) return false;
 
   state.currentPlan = incoming;
+  state.currentPlanSummary = planSummaryFromPlan(incoming);
   state.currentPlanSessionId = owner;
   state.currentPlanInitialized = true;
-  state.currentPlanUnseen = Boolean(wasInitialized && !state.currentPlanOpen);
+  state.currentPlanUnseen = Boolean(wasInitialized && incoming.version > previousVersion && !state.currentPlanOpen);
   renderCurrentPlan();
-  if (wasInitialized) {
+  if (wasInitialized && incoming.version > previousVersion) {
     const summary = planSummary(incoming);
     announcePlanChange(`Plan updated, ${summary.completed} of ${summary.total} steps complete`);
   }
@@ -308,6 +375,15 @@ const focusPlanSheetAfterComposerBlur = () => {
 
 const openCurrentPlanSurface = (source = null) => {
   if (!currentPlanIsVisible()) return false;
+  if (!state.currentPlan) {
+    const owner = String(state.activeSessionId || '').trim();
+    Promise.resolve(app.refreshCurrentPlanFromServer?.()).then(() => {
+      if (owner === String(state.activeSessionId || '').trim() && state.currentPlan) {
+        openCurrentPlanSurface(source);
+      }
+    }).catch(() => {});
+    return true;
+  }
   app.closeDiffSidebar?.();
   planReturnFocus = source?.focus ? source : elements.planToggleBtn;
   state.currentPlanOpen = true;
@@ -412,9 +488,11 @@ Object.assign(app, {
   PLAN_MOBILE_QUERY,
   planSummary,
   normalizeCurrentPlan,
+  normalizeCurrentPlanSummary,
   renderPlanChecklist,
   renderCurrentPlan,
   resetCurrentPlanForSession,
+  applyCurrentPlanSummary,
   applyCurrentPlanState,
   openCurrentPlanSurface,
   closeCurrentPlanSurface,

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -2465,23 +2465,64 @@ const mountedConversationDOMFor = (sessionOrId) => {
   return sessionId && !state.draftSessionActive && state.activeSessionId === sessionId ? elements.messages : null;
 };
 
-const updateMountedToolGroupNode = (sessionOrId, message) => {
+const mountedConversationSessionFor = (sessionOrId) => {
+  if (sessionOrId && typeof sessionOrId === 'object') return sessionOrId;
+  const sessionId = String(sessionOrId || '').trim();
+  return state.sessions.find((session) => String(session?.id || '').trim() === sessionId) || null;
+};
+
+const insertMountedMessageNode = (sessionOrId, message, node) => {
+  const root = mountedConversationDOMFor(sessionOrId);
+  const session = mountedConversationSessionFor(sessionOrId);
+  if (!root || !session || !message || !node) return null;
+  stampMessageNodeSession(node, session.id);
+
+  // Durable transcript rows can live inside a grouped turn section. Its order
+  // is owned by renderTranscriptMessages; incremental stream reconciliation
+  // must never pull an individual durable row out of that container.
+  if (node.parentNode && node.parentNode !== root) return node;
+
+  const messageIndex = session.messages.findIndex((candidate) => (
+    candidate === message || (candidate?.id && candidate.id === message.id)
+  ));
+  if (messageIndex >= 0) {
+    for (let index = messageIndex + 1; index < session.messages.length; index += 1) {
+      const later = session.messages[index];
+      if (!later?.id || later.id === message.id) continue;
+      let reference = findMessageElement(later.id, session);
+      while (reference?.parentNode && reference.parentNode !== root) reference = reference.parentNode;
+      if (reference?.parentNode === root && reference !== node) {
+        root.insertBefore(node, reference);
+        return node;
+      }
+    }
+  }
+  root.appendChild(node);
+  return node;
+};
+
+const reconcileMountedMessageNode = (sessionOrId, message, update, alwaysReorder = false) => {
   if (!mountedConversationDOMFor(sessionOrId)) return false;
-  updateToolGroupNode(message);
+  const existing = alwaysReorder ? null : findMessageElement(message?.id, sessionOrId);
+  update(message);
+  if (!existing) {
+    const node = findMessageElement(message?.id, sessionOrId);
+    if (node) insertMountedMessageNode(sessionOrId, message, node);
+  }
   return true;
 };
 
-const updateMountedModelSwapNode = (sessionOrId, message) => {
-  if (!mountedConversationDOMFor(sessionOrId)) return false;
-  updateModelSwapNode(message);
-  return true;
-};
+const updateMountedToolGroupNode = (sessionOrId, message) => (
+  reconcileMountedMessageNode(sessionOrId, message, updateToolGroupNode)
+);
 
-const updateMountedUserNode = (sessionOrId, message) => {
-  if (!mountedConversationDOMFor(sessionOrId)) return false;
-  updateUserNode(message);
-  return true;
-};
+const updateMountedModelSwapNode = (sessionOrId, message) => (
+  reconcileMountedMessageNode(sessionOrId, message, updateModelSwapNode)
+);
+
+const updateMountedUserNode = (sessionOrId, message) => (
+  reconcileMountedMessageNode(sessionOrId, message, updateUserNode, true)
+);
 
 const enqueueMountedAssistantStreamUpdate = (sessionOrId, message) => {
   if (!mountedConversationDOMFor(sessionOrId)) return false;
@@ -3016,6 +3057,7 @@ Object.assign(app, {
   buildArgsNode,
   createToolEntryNode,
   updateToolGroupNode,
+  insertMountedMessageNode,
   updateMountedToolGroupNode,
   updateMountedModelSwapNode,
   updateMountedUserNode,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,7 +4,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
+  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
   splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
   openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
   clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
@@ -460,6 +460,12 @@ const switchToSession = async (sessionId, options = {}) => {
   updateURL(sessionSlug(session));
   refreshPendingInterjectionBanner();
 
+  const needsSelectedMetadata = !Object.prototype.hasOwnProperty.call(session, 'fileChangeSummary')
+    || !Object.prototype.hasOwnProperty.call(session, 'planSummary');
+  const selectedMetadataPromise = needsSelectedMetadata && isSessionIdentityResolved(session)
+    ? mergeServerSessions({ selectedSession: session.id, selectedOnly: true })
+    : null;
+
   let preloadServerMessagesPromise = null;
   if (session._serverOnly) {
     preloadServerMessagesPromise = loadServerSessionMessages(session.id);
@@ -483,6 +489,11 @@ const switchToSession = async (sessionId, options = {}) => {
     }
   }
 
+  if (selectedMetadataPromise) {
+    await selectedMetadataPromise;
+    if (!isCurrentSwitch()) return null;
+  }
+
   if (options.sync !== false) {
     await syncActiveSessionFromServer(session, true, {
       skipMessagesFetch: didPreloadServerMessages,
@@ -491,7 +502,9 @@ const switchToSession = async (sessionId, options = {}) => {
     if (!isCurrentSwitch()) return null;
   }
   if (!isCurrentSwitch()) return null;
-  await app.refreshSkillCommands?.(session.id);
+  if (isSessionIdentityResolved(session)) {
+    await app.refreshSkillCommands?.(session.id);
+  }
   if (!isCurrentSwitch()) return null;
   if (syncSelectedRuntimeFromSession(session)) {
     app.updateHeader();
@@ -1387,17 +1400,26 @@ const syncTranscriptOnce = async (session, options = {}) => {
 };
 
 const mergeTranscriptSyncRequest = (session, options = {}) => {
-  const pending = session._transcriptSyncPending || { force: false, forceScroll: false, targetRev: 0, reason: '' };
-  pending.force = pending.force || options.force === true;
+  const pending = session._transcriptSyncPending || {
+    force: false,
+    forceWithoutTarget: false,
+    forceScroll: false,
+    targetRev: 0,
+    reason: ''
+  };
+  const targetRev = Math.max(0, Number(options.targetRev) || 0);
+  const force = options.force === true;
+  pending.force = pending.force || force;
+  pending.forceWithoutTarget = pending.forceWithoutTarget || (force && targetRev === 0);
   pending.forceScroll = pending.forceScroll || options.forceScroll === true;
-  pending.targetRev = Math.max(Number(pending.targetRev) || 0, Number(options.targetRev) || 0);
+  pending.targetRev = Math.max(Number(pending.targetRev) || 0, targetRev);
   if (options.reason) pending.reason = String(options.reason);
   session._transcriptSyncPending = pending;
   return pending;
 };
 
 const syncTranscript = async (session, options = {}) => {
-  if (!session || !ensureSessionTranscript(session)) return false;
+  if (!session || !isSessionIdentityResolved(session) || !ensureSessionTranscript(session)) return false;
   mergeTranscriptSyncRequest(session, options);
   if (session._transcriptSyncPromise) return session._transcriptSyncPromise;
 
@@ -1415,16 +1437,18 @@ const syncTranscript = async (session, options = {}) => {
         mergeTranscriptSyncRequest(session, { reason: 'target-revision', force: true, targetRev });
       }
       const pending = session._transcriptSyncPending;
+      const pendingTargetRev = Math.max(0, Number(pending?.targetRev) || 0);
+      const pendingForceNeedsFetch = Boolean(pending?.force)
+        && (Boolean(pending?.forceWithoutTarget) || pendingTargetRev === 0);
       if (pending
-          && !pending.force
+          && !pendingForceNeedsFetch
           && !pending.forceScroll
-          && Number(pending.targetRev) > 0
           && transcript
-          && transcript.rev >= Number(pending.targetRev)) {
-        // A status poll can discover a revision while an activation request is
-        // already in flight. If that response reached the queued target, the
-        // queued request carries no new work and must not manufacture a 304
-        // index round-trip plus another client reconciliation.
+          && transcript.rev >= pendingTargetRev) {
+        // A completed response absorbs queued ordinary requests and forced
+        // requests whose positive target revision is now satisfied. Preserve
+        // untargeted force (for example stale body recovery) and forceScroll:
+        // neither semantic can be proven complete from transcript.rev alone.
         delete session._transcriptSyncPending;
       }
       if (!session._transcriptSyncPending) return true;
@@ -1640,7 +1664,7 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
 };
 
 const syncActiveSessionFromServer = async (session, pollOnActive = false, { skipMessagesFetch = false, expectedSwitchGeneration = null } = {}) => {
-  if (!session) return SESSION_STATE_RETRY_RESULT;
+  if (!session || !isSessionIdentityResolved(session)) return SESSION_STATE_RETRY_RESULT;
 
   const requestSessionId = String(session.id || '').trim();
   if (!requestSessionId) return SESSION_STATE_RETRY_RESULT;
@@ -1904,6 +1928,16 @@ const applyServerSessionSummary = (target, serverSession) => {
   if (Object.prototype.hasOwnProperty.call(serverSession, 'goal')) {
     target.goal = serverSession.goal && typeof serverSession.goal === 'object' ? { ...serverSession.goal } : null;
   }
+  if (Object.prototype.hasOwnProperty.call(serverSession, 'file_change_summary')) {
+    target.fileChangeSummary = serverSession.file_change_summary && typeof serverSession.file_change_summary === 'object'
+      ? { ...serverSession.file_change_summary }
+      : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(serverSession, 'plan_summary')) {
+    target.planSummary = serverSession.plan_summary && typeof serverSession.plan_summary === 'object'
+      ? { ...serverSession.plan_summary }
+      : null;
+  }
   return target;
 };
 
@@ -1949,6 +1983,13 @@ const mergeServerSessions = async (options = {}) => {
     if (includeArchived) {
       params.set('include_archived', '1');
     }
+    const selectedSession = String(options.selectedSession || '').trim();
+    if (selectedSession) {
+      params.set('selected_session', selectedSession);
+    }
+    if (options.selectedOnly === true) {
+      params.set('selected_only', '1');
+    }
     const query = params.toString();
     const resp = await fetch(`${UI_PREFIX}/v1/sessions${query ? `?${query}` : ''}`, {
       headers: requestHeaders('')
@@ -1964,7 +2005,8 @@ const mergeServerSessions = async (options = {}) => {
         .map(s => [Number(s.number), s])
     );
 
-    for (const serverSession of data.sessions) {
+    const mergeServerSession = (serverSession) => {
+      if (!serverSession || typeof serverSession !== 'object') return null;
       const sNum = Number(serverSession.number || 0);
       let local = localById.get(serverSession.id) ||
         (sNum > 0 ? localByNumber.get(sNum) : null) ||
@@ -1972,7 +2014,9 @@ const mergeServerSessions = async (options = {}) => {
       if (local) {
         reconcileServerSessionIdentity(local, serverSession);
         applyServerSessionSummary(local, serverSession);
-        continue;
+        localById.set(local.id, local);
+        if (Number(local.number) > 0) localByNumber.set(Number(local.number), local);
+        return local;
       }
 
       local = applyServerSessionSummary({
@@ -1995,6 +2039,21 @@ const mergeServerSessions = async (options = {}) => {
         _serverOnly: true
       }, serverSession);
       state.sessions.push(local);
+      localById.set(local.id, local);
+      if (Number(local.number) > 0) localByNumber.set(Number(local.number), local);
+      return local;
+    };
+
+    for (const serverSession of data.sessions) mergeServerSession(serverSession);
+
+    const selected = mergeServerSession(data.selected_session);
+    if (selected && selected.id === state.activeSessionId && !state.draftSessionActive) {
+      if (selected.fileChangeSummary) {
+        app.applySessionDiffSummary?.(selected.id, selected.fileChangeSummary);
+      }
+      if (Object.prototype.hasOwnProperty.call(selected, 'planSummary')) {
+        app.applyCurrentPlanSummary?.(selected.id, selected.planSummary);
+      }
     }
 
     persistAndRefreshShell();
@@ -2277,9 +2336,21 @@ const setSessionPinned = async (session, pinned) => {
 };
 
 // ===== Initialization =====
+const configuredStartupHydrationTimeout = Number(window.TERM_LLM_STARTUP_HYDRATION_TIMEOUT_MS);
+const STARTUP_HYDRATION_TIMEOUT_MS = Number.isFinite(configuredStartupHydrationTimeout)
+  && configuredStartupHydrationTimeout >= 0
+  ? configuredStartupHydrationTimeout
+  : 10000;
+
+const refreshSkillCommandsAfterStartup = (sessionId) => {
+  Promise.resolve()
+    .then(() => app.refreshSkillCommands?.(sessionId))
+    .catch(() => {});
+};
+
 const hydrateActiveSessionAfterStartup = async () => {
   const active = getActiveSession();
-  if (!active) return;
+  if (!active || !isSessionIdentityResolved(active)) return;
 
   // Start state sync immediately so the server round-trip overlaps with the
   // messages fetch instead of serialising after it. For server-only sessions,
@@ -2301,10 +2372,24 @@ const hydrateActiveSessionAfterStartup = async () => {
   }
 
   await statePromise;
-  await app.refreshSkillCommands?.(active.id);
   if (syncSelectedRuntimeFromSession(active)) {
     app.updateHeader();
   }
+  refreshSkillCommandsAfterStartup(active.id);
+};
+
+const waitForStartupHydration = async () => {
+  const active = getActiveSession();
+  if (!active || !isSessionIdentityResolved(active)) return;
+
+  setStartupStatus('Loading conversation…');
+  const hydration = hydrateActiveSessionAfterStartup().catch(() => {});
+  let timeoutID = null;
+  const timeout = new Promise((resolve) => {
+    timeoutID = window.setTimeout(resolve, STARTUP_HYDRATION_TIMEOUT_MS);
+  });
+  await Promise.race([hydration, timeout]);
+  if (timeoutID !== null) window.clearTimeout(timeoutID);
 };
 
 const initialize = async () => {
@@ -2367,7 +2452,7 @@ const initialize = async () => {
     setStartupStatus(state.token ? 'Checking your token…' : 'Connecting…');
     setConnectionState(state.token ? 'Validating token…' : 'Connecting…');
 
-    const sessionsPromise = mergeServerSessions();
+    const sessionsPromise = mergeServerSessions({ selectedSession: urlSlug });
 
     // Start a speculative models fetch immediately using the provider stored in
     // localStorage. For returning users this runs in parallel with fetchProviders,
@@ -2415,8 +2500,7 @@ const initialize = async () => {
       subscribeToPush();
     }
 
-    hideStartupSplash();
-    await hydrateActiveSessionAfterStartup().catch(() => {});
+    await waitForStartupHydration();
   } catch (err) {
     const message = err?.message || 'Unable to validate token.';
     setStartupStatus(message);
@@ -3187,6 +3271,7 @@ document.addEventListener('visibilitychange', async () => {
     stopSidebarStatusPoll();
     return;
   }
+  if (!state.connected) return;
   // Reconcile the authoritative transcript before looking for an active
   // response. Another tab may have completed several turns and started a new
   // one while this page was hidden; attaching first would only replay the new

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -407,6 +407,45 @@ const syncSelectedRuntimeFromSession = (session) => {
   return true;
 };
 
+const selectedTranscriptReady = (session) => {
+  if (!session || session._serverOnly) return false;
+  const transcript = session.transcript;
+  if (transcript) {
+    return transcriptSyncSegmentIndexes(transcript).every((index) => (
+      ['materialized', 'empty'].includes(transcript.segments[index]?.state)
+    ));
+  }
+  if (Array.isArray(session.messages) && session.messages.length > 0) return true;
+  return Math.max(0, Number(session.messageCount) || 0) === 0;
+};
+
+const continueSessionSwitchHydration = (session, switchGeneration, options = {}) => {
+  if (!session) return;
+  const sessionId = String(session.id || '').trim();
+  const isCurrent = () => state.sessionSwitchGeneration === switchGeneration
+    && String(state.activeSessionId || '').trim() === sessionId
+    && !state.draftSessionActive;
+
+  if (options.sync !== false) {
+    const statePromise = syncActiveSessionFromServer(session, true, {
+      // Conversation readiness is owned by the selected sideload or its single
+      // fallback. State still fetches a transcript when it reports a newer rev.
+      skipMessagesFetch: true,
+      expectedSwitchGeneration: switchGeneration
+    });
+    void Promise.resolve(statePromise).then(() => {
+      if (isCurrent() && syncSelectedRuntimeFromSession(session)) app.updateHeader();
+    }).catch(() => {});
+  }
+
+  if (isSessionIdentityResolved(session)) {
+    void Promise.resolve().then(() => {
+      if (!isCurrent()) return null;
+      return app.refreshSkillCommands?.(sessionId);
+    }).catch(() => {});
+  }
+};
+
 const switchToSession = async (sessionId, options = {}) => {
   const nextId = String(sessionId || '').trim();
   if (!nextId) return null;
@@ -466,55 +505,38 @@ const switchToSession = async (sessionId, options = {}) => {
   updateURL(sessionSlug(session));
   refreshPendingInterjectionBanner();
 
-  const needsSelectedMetadata = !Object.prototype.hasOwnProperty.call(session, 'fileChangeSummary')
-    || !Object.prototype.hasOwnProperty.call(session, 'planSummary');
-  const selectedMetadataPromise = needsSelectedMetadata && isSessionIdentityResolved(session)
-    ? mergeServerSessions({ selectedSession: session.id, selectedOnly: true })
+  const needsSelectedPayload = isSessionIdentityResolved(session) && !selectedTranscriptReady(session);
+  const selectedPayloadPromise = needsSelectedPayload
+    ? mergeServerSessions({
+      selectedSession: session.id,
+      selectedOnly: true,
+      includeTranscript: true,
+      expectedSwitchGeneration: switchGeneration
+    })
     : null;
-
-  let preloadServerMessagesPromise = null;
-  if (session._serverOnly) {
-    preloadServerMessagesPromise = loadServerSessionMessages(session.id);
-  }
 
   persistAndRefreshShell();
   renderMessages(true);
   restoreDraftMessageForSession(session.id, { replace: true });
   app.activateDiffSidebar?.(session.id);
 
-  let didPreloadServerMessages = false;
-  if (preloadServerMessagesPromise) {
-    const msgs = await preloadServerMessagesPromise;
+  let conversationReady = selectedTranscriptReady(session);
+  if (selectedPayloadPromise) {
+    const selectedResult = await selectedPayloadPromise;
     if (!isCurrentSwitch()) return null;
-    if (Array.isArray(msgs)) {
-      persistAndRefreshShell();
-      if (isCurrentSwitch()) {
-        renderMessages(true);
-      }
-      didPreloadServerMessages = true;
-    }
+    conversationReady = selectedResult?.selectedTranscriptApplied === true || selectedTranscriptReady(session);
   }
 
-  if (selectedMetadataPromise) {
-    await selectedMetadataPromise;
+  // Missing, malformed, or legacy selected payloads use the established
+  // transcript path once. syncTranscript owns its single final render.
+  if (!conversationReady && isSessionIdentityResolved(session)) {
+    await loadServerSessionMessages(session.id);
     if (!isCurrentSwitch()) return null;
   }
 
-  if (options.sync !== false) {
-    await syncActiveSessionFromServer(session, true, {
-      skipMessagesFetch: didPreloadServerMessages,
-      expectedSwitchGeneration: switchGeneration
-    });
-    if (!isCurrentSwitch()) return null;
-  }
   if (!isCurrentSwitch()) return null;
-  if (isSessionIdentityResolved(session)) {
-    await app.refreshSkillCommands?.(session.id);
-  }
-  if (!isCurrentSwitch()) return null;
-  if (syncSelectedRuntimeFromSession(session)) {
-    app.updateHeader();
-  }
+  if (syncSelectedRuntimeFromSession(session)) app.updateHeader();
+  continueSessionSwitchHydration(session, switchGeneration, options);
   if (options.focusPrompt) {
     elements.promptInput.focus();
   }
@@ -1696,7 +1718,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
   if (loadResult.kind !== 'ok') return SESSION_STATE_RETRY_RESULT;
   const runtimeState = loadResult.state;
   const belongsToSelectedSession = requestSessionId === String(state.activeSessionId || '').trim() && !state.draftSessionActive;
-  if (belongsToSelectedSession && !selectedResponseApplies()) return loadResult;
+  if ((hasExpectedGeneration || belongsToSelectedSession) && !selectedResponseApplies()) return loadResult;
   if (selectedResponseApplies()) {
     state.lastAppliedSessionStateRequestGeneration = requestGeneration;
     app.applyCurrentPlanState?.(requestSessionId, runtimeState);
@@ -1947,7 +1969,7 @@ const applyServerSessionSummary = (target, serverSession) => {
   return target;
 };
 
-const applySelectedTranscriptSideload = (session, sideload) => {
+const applySelectedTranscriptSideload = (session, sideload, options = {}) => {
   if (!session || !sideload || typeof sideload !== 'object' || typeof window.TranscriptStore !== 'function') return false;
   const index = sideload.index;
   const bodies = sideload.bodies;
@@ -2017,10 +2039,10 @@ const applySelectedTranscriptSideload = (session, sideload) => {
     current._checkInvariants?.();
     refreshSessionMessagesFromTranscript(session);
     touchTranscriptSkeleton(session);
-    session._startupTranscriptSideloaded = true;
+    if (options.startup === true) session._startupTranscriptSideloaded = true;
     if (session.id === state.activeSessionId && !state.draftSessionActive) {
       renderMessages(true);
-      session._startupTranscriptRendered = true;
+      if (options.startup === true) session._startupTranscriptRendered = true;
     }
     return true;
   } catch (_) {
@@ -2060,6 +2082,11 @@ const reconcileServerSessionIdentity = (session, serverSession) => {
 };
 
 const mergeServerSessions = async (options = {}) => {
+  const result = {
+    selectedSession: null,
+    selectedTranscriptApplied: false,
+    selectedResponseCurrent: false
+  };
   try {
     const categories = Array.isArray(options.categories) ? options.categories : state.sidebarSessionCategories;
     const includeArchived = typeof options.includeArchived === 'boolean'
@@ -2089,9 +2116,9 @@ const mergeServerSessions = async (options = {}) => {
     const resp = await fetch(`${UI_PREFIX}/v1/sessions${query ? `?${query}` : ''}`, {
       headers: requestHeaders('')
     });
-    if (!resp.ok) return;
+    if (!resp.ok) return result;
     const data = await resp.json();
-    if (!Array.isArray(data.sessions)) return;
+    if (!Array.isArray(data.sessions)) return result;
     if (options.includeWidgetStatus === true) {
       applyWidgetStatus(data.widget_status);
     }
@@ -2145,10 +2172,19 @@ const mergeServerSessions = async (options = {}) => {
     for (const serverSession of data.sessions) mergeServerSession(serverSession);
 
     const selected = mergeServerSession(data.selected_session);
-    if (selected && options.includeTranscript === true) {
-      applySelectedTranscriptSideload(selected, data.selected_transcript);
+    result.selectedSession = selected;
+    const expectedSwitchGeneration = Number(options.expectedSwitchGeneration);
+    const hasExpectedSwitchGeneration = Number.isFinite(expectedSwitchGeneration) && expectedSwitchGeneration > 0;
+    result.selectedResponseCurrent = Boolean(selected)
+      && selected.id === state.activeSessionId
+      && !state.draftSessionActive
+      && (!hasExpectedSwitchGeneration || state.sessionSwitchGeneration === expectedSwitchGeneration);
+    if (result.selectedResponseCurrent && options.includeTranscript === true) {
+      result.selectedTranscriptApplied = applySelectedTranscriptSideload(selected, data.selected_transcript, {
+        startup: options.startupTranscript === true
+      });
     }
-    if (selected && selected.id === state.activeSessionId && !state.draftSessionActive) {
+    if (result.selectedResponseCurrent && selected.id === state.activeSessionId && !state.draftSessionActive) {
       if (selected.fileChangeSummary) {
         app.applySessionDiffSummary?.(selected.id, selected.fileChangeSummary);
       }
@@ -2158,8 +2194,10 @@ const mergeServerSessions = async (options = {}) => {
     }
 
     persistAndRefreshShell();
+    return result;
   } catch {
     // Gracefully fall back to in-memory-only
+    return result;
   }
 };
 
@@ -2578,6 +2616,7 @@ const initialize = async () => {
     const sessionsPromise = mergeServerSessions({
       selectedSession: urlSlug,
       includeTranscript: Boolean(urlSlug),
+      startupTranscript: true,
       includeWidgetStatus: true
     });
     // Session selection owns conversation readiness. Begin transcript fallback

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -2018,7 +2018,10 @@ const applySelectedTranscriptSideload = (session, sideload) => {
     refreshSessionMessagesFromTranscript(session);
     touchTranscriptSkeleton(session);
     session._startupTranscriptSideloaded = true;
-    if (session.id === state.activeSessionId && !state.draftSessionActive) renderMessages(true);
+    if (session.id === state.activeSessionId && !state.draftSessionActive) {
+      renderMessages(true);
+      session._startupTranscriptRendered = true;
+    }
     return true;
   } catch (_) {
     // The detached validation above makes this path defensive only. Leave the
@@ -2439,6 +2442,13 @@ const STARTUP_HYDRATION_TIMEOUT_MS = Number.isFinite(configuredStartupHydrationT
   && configuredStartupHydrationTimeout >= 0
   ? configuredStartupHydrationTimeout
   : 10000;
+let startupSplashReleased = false;
+
+const releaseStartupSplash = () => {
+  if (startupSplashReleased) return;
+  startupSplashReleased = true;
+  hideStartupSplash();
+};
 
 const refreshSkillCommandsAfterStartup = (sessionId) => {
   Promise.resolve()
@@ -2448,49 +2458,62 @@ const refreshSkillCommandsAfterStartup = (sessionId) => {
 
 const hydrateActiveSessionAfterStartup = async () => {
   const active = getActiveSession();
-  if (!active || !isSessionIdentityResolved(active)) return;
+  if (!active || !isSessionIdentityResolved(active)) return false;
 
   const hasTranscriptSideload = active._startupTranscriptSideloaded === true;
+  const hasRenderedTranscriptSideload = active._startupTranscriptRendered === true;
   // Start state sync immediately so the server round-trip overlaps with a
-  // fallback transcript fetch. A valid startup sideload already owns the first
-  // projection, so state only refreshes it when the server reports a newer rev.
+  // fallback transcript fetch. Runtime metadata and active-response recovery
+  // continue independently after the selected transcript is ready to reveal.
   const statePromise = syncActiveSessionFromServer(active, true, {
     skipMessagesFetch: Boolean(active._serverOnly) || hasTranscriptSideload
   });
+  void (async () => {
+    try {
+      await statePromise;
+      if (syncSelectedRuntimeFromSession(active)) {
+        app.updateHeader();
+      }
+    } catch (_) {
+      // Runtime state is best-effort during startup and must not create an
+      // unhandled rejection after transcript readiness releases the splash.
+    } finally {
+      delete active._startupTranscriptSideloaded;
+      delete active._startupTranscriptRendered;
+      refreshSkillCommandsAfterStartup(active.id);
+    }
+  })();
+
+  if (hasRenderedTranscriptSideload) return true;
 
   const preloadMessagesPromise = active._serverOnly && !hasTranscriptSideload
     ? loadServerSessionMessages(active.id)
     : null;
+  if (!preloadMessagesPromise) return false;
 
-  if (preloadMessagesPromise) {
-    const msgs = await preloadMessagesPromise;
-    if (Array.isArray(msgs)) {
-      saveSessions();
-      renderSidebar();
-      renderMessages(true);
-    }
-  }
-
-  await statePromise;
-  delete active._startupTranscriptSideloaded;
-  if (syncSelectedRuntimeFromSession(active)) {
-    app.updateHeader();
-  }
-  refreshSkillCommandsAfterStartup(active.id);
+  const msgs = await preloadMessagesPromise;
+  if (!Array.isArray(msgs)) return false;
+  saveSessions();
+  renderSidebar();
+  // This force-scroll render is the fallback transcript's final startup
+  // projection and bottom-position boundary.
+  renderMessages(true);
+  return true;
 };
 
 const waitForStartupHydration = async () => {
   const active = getActiveSession();
-  if (!active || !isSessionIdentityResolved(active)) return;
+  if (!active || !isSessionIdentityResolved(active)) return false;
 
   setStartupStatus('Loading conversation…');
-  const hydration = hydrateActiveSessionAfterStartup().catch(() => {});
+  const hydration = hydrateActiveSessionAfterStartup().catch(() => false);
   let timeoutID = null;
   const timeout = new Promise((resolve) => {
-    timeoutID = window.setTimeout(resolve, STARTUP_HYDRATION_TIMEOUT_MS);
+    timeoutID = window.setTimeout(() => resolve(false), STARTUP_HYDRATION_TIMEOUT_MS);
   });
-  await Promise.race([hydration, timeout]);
+  const rendered = await Promise.race([hydration, timeout]);
   if (timeoutID !== null) window.clearTimeout(timeoutID);
+  return rendered === true;
 };
 
 const initialize = async () => {
@@ -2557,6 +2580,15 @@ const initialize = async () => {
       includeTranscript: Boolean(urlSlug),
       includeWidgetStatus: true
     });
+    // Session selection owns conversation readiness. Begin transcript fallback
+    // and runtime state as soon as the authoritative merge lands, without
+    // waiting for providers or models. Only an actual selected transcript
+    // render releases the splash here; draft/unresolved/error paths retain the
+    // existing final or bounded fallback.
+    const startupHydrationPromise = sessionsPromise.then(() => waitForStartupHydration());
+    void startupHydrationPromise.then((rendered) => {
+      if (rendered) releaseStartupSplash();
+    }).catch(() => {});
 
     // Start a speculative models fetch immediately using the provider stored in
     // localStorage. For returning users this runs in parallel with fetchProviders,
@@ -2606,7 +2638,7 @@ const initialize = async () => {
       subscribeToPush();
     }
 
-    await waitForStartupHydration();
+    await startupHydrationPromise;
   } catch (err) {
     const message = err?.message || 'Unable to validate token.';
     setStartupStatus(message);
@@ -2615,7 +2647,7 @@ const initialize = async () => {
       handleAuthFailure();
     }
   } finally {
-    hideStartupSplash();
+    releaseStartupSplash();
   }
 };
 

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -50,6 +50,12 @@ let sidebarStatusPollInFlightGeneration = -1;
 let sidebarStatusPollIsRecovery = false;
 let sidebarStatusImmediatePending = false;
 
+const applyWidgetStatus = (data) => {
+  state.widgets = Array.isArray(data?.widgets) ? data.widgets : [];
+  state.widgetsLoaded = true;
+  app.renderWidgetSidebar?.();
+};
+
 const refreshWidgetsSidebar = async () => {
   if (!app.renderWidgetSidebar) return;
   try {
@@ -63,10 +69,7 @@ const refreshWidgetsSidebar = async () => {
       return;
     }
     if (!resp.ok) return;
-    const data = await resp.json();
-    state.widgets = Array.isArray(data.widgets) ? data.widgets : [];
-    state.widgetsLoaded = true;
-    app.renderWidgetSidebar?.();
+    applyWidgetStatus(await resp.json());
   } catch (_) {
     // Widgets are optional; leave the section hidden if the admin route is unavailable.
   }
@@ -91,7 +94,7 @@ const stopSidebarStatusPoll = () => {
 
 const scheduleSidebarStatusPoll = (delay) => {
   clearSidebarStatusTimer();
-  if (!sidebarStatusPollEnabled || document.visibilityState === 'hidden') return;
+  if (!state.connected || !sidebarStatusPollEnabled || document.visibilityState === 'hidden') return;
   sidebarStatusTimer = setTimeout(() => {
     sidebarStatusTimer = null;
     return pollSidebarStatus(false);
@@ -108,7 +111,7 @@ const sidebarStatusPollDelay = () => {
 };
 
 const pollSidebarStatus = (isRecovery = false) => {
-  if (!sidebarStatusPollEnabled || document.visibilityState === 'hidden') return Promise.resolve(false);
+  if (!state.connected || !sidebarStatusPollEnabled || document.visibilityState === 'hidden') return Promise.resolve(false);
   if (sidebarStatusPollPromise) return sidebarStatusPollPromise;
 
   clearSidebarStatusTimer();
@@ -119,7 +122,8 @@ const pollSidebarStatus = (isRecovery = false) => {
   sidebarStatusPollIsRecovery = isRecovery;
 
   const isCurrent = () => (
-    sidebarStatusPollEnabled
+    state.connected
+    && sidebarStatusPollEnabled
     && document.visibilityState !== 'hidden'
     && sidebarStatusPollGeneration === generation
     && sidebarStatusPollController === controller
@@ -193,6 +197,7 @@ const ensureSidebarStatusPoll = () => {
     stopSidebarStatusPoll();
     return Promise.resolve(false);
   }
+  if (!state.connected) return Promise.resolve(false);
 
   sidebarStatusPollEnabled = true;
   clearSidebarStatusTimer();
@@ -212,7 +217,7 @@ const ensureSidebarStatusPoll = () => {
 const startSidebarStatusPoll = () => ensureSidebarStatusPoll();
 
 const refreshSidebarStatusPoll = (forceNow = false) => {
-  if (document.visibilityState === 'hidden') return Promise.resolve(false);
+  if (!state.connected || document.visibilityState === 'hidden') return Promise.resolve(false);
   if (forceNow) return ensureSidebarStatusPoll();
 
   sidebarStatusPollEnabled = true;
@@ -221,6 +226,7 @@ const refreshSidebarStatusPoll = (forceNow = false) => {
 };
 
 const handleFetchTransportFallback = () => {
+  if (!state.connected) return Promise.resolve(false);
   if (document.visibilityState !== 'hidden' && sidebarStatusPollPromise && !sidebarStatusPollIsRecovery) {
     sidebarStatusPollEnabled = true;
     clearSidebarStatusTimer();
@@ -1990,6 +1996,9 @@ const mergeServerSessions = async (options = {}) => {
     if (options.selectedOnly === true) {
       params.set('selected_only', '1');
     }
+    if (options.includeWidgetStatus === true) {
+      params.set('include_widget_status', '1');
+    }
     const query = params.toString();
     const resp = await fetch(`${UI_PREFIX}/v1/sessions${query ? `?${query}` : ''}`, {
       headers: requestHeaders('')
@@ -1997,6 +2006,9 @@ const mergeServerSessions = async (options = {}) => {
     if (!resp.ok) return;
     const data = await resp.json();
     if (!Array.isArray(data.sessions)) return;
+    if (options.includeWidgetStatus === true) {
+      applyWidgetStatus(data.widget_status);
+    }
 
     const localById = new Map(state.sessions.map(s => [s.id, s]));
     const localByNumber = new Map(
@@ -2439,7 +2451,6 @@ const initialize = async () => {
   ensureActiveSession();
 
   renderSidebar();
-  app.renderWidgetSidebar?.();
   renderMessages(true);
   renderProviderOptions();
   renderModelOptions();
@@ -2452,7 +2463,7 @@ const initialize = async () => {
     setStartupStatus(state.token ? 'Checking your token…' : 'Connecting…');
     setConnectionState(state.token ? 'Validating token…' : 'Connecting…');
 
-    const sessionsPromise = mergeServerSessions({ selectedSession: urlSlug });
+    const sessionsPromise = mergeServerSessions({ selectedSession: urlSlug, includeWidgetStatus: true });
 
     // Start a speculative models fetch immediately using the provider stored in
     // localStorage. For returning users this runs in parallel with fetchProviders,
@@ -2484,7 +2495,6 @@ const initialize = async () => {
     app.updateHeader?.();
     setConnectionState('', '');
     startSidebarStatusPoll();
-    void refreshWidgetsSidebar();
     if (!state.draftSessionActive && !getActiveSession()) {
       ensureActiveSession();
       renderMessages(true);
@@ -3348,7 +3358,7 @@ window.addEventListener('offline', () => {
 });
 
 window.addEventListener('pageshow', (event) => {
-  void ensureSidebarStatusPoll();
+  if (state.connected) void ensureSidebarStatusPoll();
   const session = getActiveSession();
   if (!session) return;
   if (session.activeResponseId && app.wakeResponseReconnect?.({
@@ -3425,6 +3435,7 @@ Object.assign(app, {
   syncSelectedRuntimeFromSession,
   applyServerSessionSummary,
   mergeServerSessions,
+  refreshWidgetsSidebar,
   startSidebarStatusPoll,
   stopSidebarStatusPoll,
   refreshSidebarStatusPoll,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1947,6 +1947,86 @@ const applyServerSessionSummary = (target, serverSession) => {
   return target;
 };
 
+const applySelectedTranscriptSideload = (session, sideload) => {
+  if (!session || !sideload || typeof sideload !== 'object' || typeof window.TranscriptStore !== 'function') return false;
+  const index = sideload.index;
+  const bodies = sideload.bodies;
+  const etag = String(sideload.index_etag || '').trim();
+  const rev = Number(index?.rev);
+  if (!index?.rows || !Number.isFinite(rev) || rev < 0 || !etag
+      || !bodies || Number(bodies.rev) !== rev || !Array.isArray(bodies.messages)) return false;
+
+  const current = ensureSessionTranscript(session);
+  if (!current || current.rev > rev) return false;
+
+  // Validate the complete transaction in a detached store before mutating the
+  // selected canonical session. This catches malformed parallel arrays,
+  // out-of-window bodies, and incomplete turns without exposing a partial
+  // projection or disturbing optimistic entries.
+  const staging = new window.TranscriptStore(`startup-sideload:${session.id}`, current.budgets);
+  try {
+    staging.applyIndex(index, etag);
+    if (staging.ids.length > 0) {
+      const last = staging.ids.length - 1;
+      staging.setViewport(last, last, { deferBudget: true });
+    }
+    for (const optimistic of current.optimistic || []) {
+      staging.addOptimistic({ ...optimistic }, optimistic.revAtSend, {
+        persisted: current.persistedOptimistic?.has?.(optimistic) === true
+      });
+    }
+    if (current.activeRun) staging.setActiveRun(current.activeRun.id, current.activeRun.startedRev);
+
+    const wantedIndexes = transcriptSyncSegmentIndexes(staging);
+    const allowedBodyIDs = new Set();
+    for (const segmentIndex of wantedIndexes) {
+      const segment = staging.segments[segmentIndex];
+      if (!segment) continue;
+      for (let ordinal = segment.startOrdinal; ordinal <= segment.endOrdinal; ordinal += 1) {
+        allowedBodyIDs.add(staging.ids[ordinal]);
+      }
+    }
+    const normalizedBodyID = (entry) => {
+      const value = entry?.id ?? entry?.ID;
+      return Number.isFinite(Number(value)) ? Number(value) : value;
+    };
+    if (bodies.messages.some((entry) => !allowedBodyIDs.has(normalizedBodyID(entry)))) return false;
+    staging.materialize(bodies.messages, { countFetch: false, deferBudget: true });
+    if (!wantedIndexes.every((segmentIndex) => ['materialized', 'empty'].includes(staging.segments[segmentIndex]?.state))) {
+      return false;
+    }
+    staging.enforceBudget();
+    staging._checkInvariants?.();
+  } catch (_) {
+    return false;
+  } finally {
+    staging.destroy();
+  }
+
+  try {
+    current.applyIndex(index, etag);
+    if (current.ids.length > 0) {
+      const last = current.ids.length - 1;
+      current.setViewport(last, last, { deferBudget: true });
+    }
+    current.materialize(bodies.messages, { countFetch: false, deferBudget: true });
+    if (index.active_response_id) current.setActiveRun(index.active_response_id, index.started_rev);
+    current.reconcileOptimistic();
+    persistTranscriptOptimistic(session);
+    current.enforceBudget();
+    current._checkInvariants?.();
+    refreshSessionMessagesFromTranscript(session);
+    touchTranscriptSkeleton(session);
+    session._startupTranscriptSideloaded = true;
+    if (session.id === state.activeSessionId && !state.draftSessionActive) renderMessages(true);
+    return true;
+  } catch (_) {
+    // The detached validation above makes this path defensive only. Leave the
+    // marker unset so activation falls back to the normal transcript endpoints.
+    return false;
+  }
+};
+
 const reconcileServerSessionIdentity = (session, serverSession) => {
   if (!session || !serverSession) return session;
 
@@ -1995,6 +2075,9 @@ const mergeServerSessions = async (options = {}) => {
     }
     if (options.selectedOnly === true) {
       params.set('selected_only', '1');
+    }
+    if (options.includeTranscript === true) {
+      params.set('include_transcript', '1');
     }
     if (options.includeWidgetStatus === true) {
       params.set('include_widget_status', '1');
@@ -2059,6 +2142,9 @@ const mergeServerSessions = async (options = {}) => {
     for (const serverSession of data.sessions) mergeServerSession(serverSession);
 
     const selected = mergeServerSession(data.selected_session);
+    if (selected && options.includeTranscript === true) {
+      applySelectedTranscriptSideload(selected, data.selected_transcript);
+    }
     if (selected && selected.id === state.activeSessionId && !state.draftSessionActive) {
       if (selected.fileChangeSummary) {
         app.applySessionDiffSummary?.(selected.id, selected.fileChangeSummary);
@@ -2364,13 +2450,15 @@ const hydrateActiveSessionAfterStartup = async () => {
   const active = getActiveSession();
   if (!active || !isSessionIdentityResolved(active)) return;
 
-  // Start state sync immediately so the server round-trip overlaps with the
-  // messages fetch instead of serialising after it. For server-only sessions,
-  // the explicit message preload below owns the message fetch to avoid a double
-  // request.
-  const statePromise = syncActiveSessionFromServer(active, true, { skipMessagesFetch: Boolean(active._serverOnly) });
+  const hasTranscriptSideload = active._startupTranscriptSideloaded === true;
+  // Start state sync immediately so the server round-trip overlaps with a
+  // fallback transcript fetch. A valid startup sideload already owns the first
+  // projection, so state only refreshes it when the server reports a newer rev.
+  const statePromise = syncActiveSessionFromServer(active, true, {
+    skipMessagesFetch: Boolean(active._serverOnly) || hasTranscriptSideload
+  });
 
-  const preloadMessagesPromise = active._serverOnly
+  const preloadMessagesPromise = active._serverOnly && !hasTranscriptSideload
     ? loadServerSessionMessages(active.id)
     : null;
 
@@ -2384,6 +2472,7 @@ const hydrateActiveSessionAfterStartup = async () => {
   }
 
   await statePromise;
+  delete active._startupTranscriptSideloaded;
   if (syncSelectedRuntimeFromSession(active)) {
     app.updateHeader();
   }
@@ -2463,7 +2552,11 @@ const initialize = async () => {
     setStartupStatus(state.token ? 'Checking your token…' : 'Connecting…');
     setConnectionState(state.token ? 'Validating token…' : 'Connecting…');
 
-    const sessionsPromise = mergeServerSessions({ selectedSession: urlSlug, includeWidgetStatus: true });
+    const sessionsPromise = mergeServerSessions({
+      selectedSession: urlSlug,
+      includeTranscript: Boolean(urlSlug),
+      includeWidgetStatus: true
+    });
 
     // Start a speculative models fetch immediately using the provider stored in
     // localStorage. For returning users this runs in parallel with fetchProviders,
@@ -2494,7 +2587,10 @@ const initialize = async () => {
     renderModelOptions();
     app.updateHeader?.();
     setConnectionState('', '');
-    startSidebarStatusPoll();
+    // The primary sessions response is authoritative for startup. Arm the
+    // ordinary cadence instead of immediately reconciling the same status and
+    // triggering duplicate selected-session state work during first paint.
+    refreshSidebarStatusPoll();
     if (!state.draftSessionActive && !getActiveSession()) {
       ensureActiveSession();
       renderMessages(true);
@@ -3434,6 +3530,7 @@ Object.assign(app, {
   invalidateSessionStateForSelection,
   syncSelectedRuntimeFromSession,
   applyServerSessionSummary,
+  applySelectedTranscriptSideload,
   mergeServerSessions,
   refreshWidgetsSidebar,
   startSidebarStatusPoll,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -7,7 +7,7 @@ const {
   getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
   persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
   updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
+  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
   updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
   conversationDOMFor, isConversationMounted,
   subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
@@ -683,6 +683,9 @@ const appendStreamMessageNode = (session, message, createNode = createMessageNod
   if (!root) return null;
   const node = createNode(message);
   if (node?.dataset) node.dataset.sessionId = String(session?.id || '');
+  if (typeof insertMountedMessageNode === 'function') {
+    return insertMountedMessageNode(session, message, node);
+  }
   root.appendChild(node);
   return node;
 };

--- a/internal/serveui/static/app-worktrees.js
+++ b/internal/serveui/static/app-worktrees.js
@@ -6,7 +6,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
   const { UI_PREFIX, state, elements } = worktreeApp;
   if (!UI_PREFIX || !state || !elements) return;
 
-  let available = false;
+  const worktreesEnabled = window.TERM_LLM_WORKTREES_ENABLED === true;
   let loading = false;
   let menu = null;
 
@@ -33,7 +33,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
   };
 
   const renderWorktreeChip = () => {
-    if (!available) {
+    if (!worktreesEnabled) {
       setChipVisible(false);
       return;
     }
@@ -52,23 +52,15 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
   };
 
   const loadWorktrees = async () => {
+    if (!worktreesEnabled) return [];
     try {
       const res = await fetch(`${UI_PREFIX}/v1/worktrees`, { headers: authHeaders() });
-      if (res.status === 409) {
-        available = false;
-        state.worktrees = [];
-        renderWorktreeChip();
-        return [];
-      }
       if (!res.ok) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(res) : res.text());
       const data = await res.json();
-      available = true;
       state.worktrees = Array.isArray(data.worktrees) ? data.worktrees : [];
       renderWorktreeChip();
       return state.worktrees;
     } catch (_err) {
-      available = false;
-      renderWorktreeChip();
       return [];
     }
   };
@@ -184,6 +176,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
   };
 
   const openMenu = async () => {
+    if (!worktreesEnabled) return;
     const session = activeSession();
     const isDraft = state.draftSessionActive;
     const activeDir = !isDraft ? (session?.worktreeDir || '') : '';
@@ -242,7 +235,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
     elements.chipWorktreeTrigger.setAttribute('aria-expanded', 'true');
   };
 
-  if (elements.chipWorktreeTrigger) {
+  if (worktreesEnabled && elements.chipWorktreeTrigger) {
     elements.chipWorktreeTrigger.addEventListener('click', (event) => {
       event.preventDefault();
       if (menu) closeMenu(); else void openMenu();
@@ -276,6 +269,6 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
     renderWorktreeChip
   });
 
-  void loadWorktrees();
-  setInterval(renderWorktreeChip, 1000);
+  renderWorktreeChip();
+  if (worktreesEnabled) setInterval(renderWorktreeChip, 1000);
 })();

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -658,16 +658,6 @@
       white-space: nowrap;
     }
 
-    .diff-toggle-badge.pulse {
-      animation: diff-badge-pulse 0.6s ease;
-    }
-
-    @keyframes diff-badge-pulse {
-      0% { transform: scale(1); }
-      35% { transform: scale(1.18); }
-      100% { transform: scale(1); }
-    }
-
     .diff-filter-row {
       padding: 0.45rem 0.75rem;
       border-bottom: 1px solid var(--border);
@@ -763,8 +753,7 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .diff-file-row.updated,
-      .diff-toggle-badge.pulse {
+      .diff-file-row.updated {
         animation: none;
       }
     }

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -67,7 +67,7 @@ function makeNode() {
   };
 }
 
-function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], documentOverrides = {}, navigatorOverrides = {}, initialStorage = {}, agentName = '', uiTitle = '', hub = null, now = () => Date.now(), timerOverrides = {} } = {}) {
+function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], documentOverrides = {}, navigatorOverrides = {}, windowOverrides = {}, contextOverrides = {}, initialStorage = {}, agentName = '', uiTitle = '', hub = null, now = () => Date.now(), timerOverrides = {} } = {}) {
   const nodes = new Map(Object.entries(nodeOverrides));
   const cookieWrites = [];
   const document = {
@@ -136,6 +136,7 @@ function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], document
     history: { pushState() {} },
     MediaRecorder: undefined,
     focus() {},
+    ...windowOverrides,
   };
 
   const DateShim = class extends Date {
@@ -160,6 +161,7 @@ function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], document
     Date: DateShim,
     TextEncoder,
     TextDecoder,
+    ...contextOverrides,
   };
   context.globalThis = context;
 
@@ -1145,6 +1147,166 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
   }
   if (testApp.state.autoScroll !== true) {
     fail(name, 'forced scroll should restore autoScroll');
+    return;
+  }
+  pass(name);
+})();
+
+(function testForcedScrollSettlesAfterPostRenderLayoutGrowth() {
+  const name = 'forced scroll stays bottom-anchored while post-render layout settles';
+  const frames = [];
+  const timers = [];
+  let resizeCallback = null;
+  let observerDisconnected = false;
+  const observed = [];
+  const viewportListeners = { resize: [], scroll: [] };
+  const visualViewport = {
+    height: 844,
+    offsetTop: 0,
+    addEventListener(type, listener) { viewportListeners[type].push(listener); },
+  };
+  const chatScroll = Object.assign(makeNode(), {
+    scrollTop: 0,
+    scrollHeight: 1000,
+    clientHeight: 100,
+  });
+  const messages = makeNode();
+
+  class FakeResizeObserver {
+    constructor(callback) { resizeCallback = callback; }
+    observe(node) { observed.push(node); }
+    disconnect() { observerDisconnected = true; }
+  }
+
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { chatScroll, messages },
+    windowOverrides: {
+      visualViewport,
+      requestAnimationFrame(callback) {
+        frames.push(callback);
+        return frames.length;
+      },
+    },
+    contextOverrides: { ResizeObserver: FakeResizeObserver },
+    timerOverrides: {
+      setTimeout(fn, delay) {
+        timers.push({ fn, delay, cleared: false });
+        return timers.length;
+      },
+      clearTimeout(id) {
+        if (timers[id - 1]) timers[id - 1].cleared = true;
+      },
+    },
+  });
+
+  // Ignore app-core's initial viewport synchronization frame.
+  frames.length = 0;
+  testApp.scrollToBottom(true);
+  if (chatScroll.scrollTop !== 1000) {
+    fail(name, `expected immediate forced scroll, got ${chatScroll.scrollTop}`);
+    return;
+  }
+  if (typeof resizeCallback !== 'function' || !observed.includes(chatScroll) || !observed.includes(messages)) {
+    fail(name, 'forced scroll did not observe the transcript and scroll viewport while layout settles');
+    return;
+  }
+
+  // Finish the initial follow-up frame, then model a later markdown/image/font
+  // layout change that grows the transcript after renderMessages returned.
+  while (frames.length) frames.shift()();
+  chatScroll.scrollHeight = 1079;
+  resizeCallback();
+  while (frames.length) frames.shift()();
+
+  if (chatScroll.scrollTop !== 1079) {
+    fail(name, `post-render growth left viewport at ${chatScroll.scrollTop}`);
+    return;
+  }
+
+  // Mobile browser chrome changes the visual viewport and then the chat box.
+  // The settling anchor must run after that viewport synchronization as well.
+  chatScroll.scrollHeight = 1158;
+  viewportListeners.resize.forEach((listener) => listener());
+  while (frames.length) frames.shift()();
+  if (chatScroll.scrollTop !== 1158) {
+    fail(name, `visual viewport resize left viewport at ${chatScroll.scrollTop}`);
+    return;
+  }
+
+  const settleTimer = timers.find((timer) => timer.delay > 0);
+  if (!settleTimer || settleTimer.delay > 2000) {
+    fail(name, `settling anchor was not bounded, timers=${JSON.stringify(timers.map((timer) => timer.delay))}`);
+    return;
+  }
+  settleTimer.fn();
+  chatScroll.scrollHeight = 1200;
+  resizeCallback();
+  viewportListeners.resize.forEach((listener) => listener());
+  while (frames.length) frames.shift()();
+  if (!observerDisconnected || chatScroll.scrollTop !== 1158) {
+    fail(name, 'settling work continued after its bounded window');
+    return;
+  }
+  pass(name);
+})();
+
+(function testUserIntentCancelsForcedScrollSettling() {
+  const name = 'explicit user intent cancels forced-scroll settling corrections';
+  const frames = [];
+  const timers = [];
+  let resizeCallback = null;
+  let observerDisconnected = false;
+  const chatScroll = Object.assign(makeNode(), {
+    scrollTop: 0,
+    scrollHeight: 1000,
+    clientHeight: 100,
+  });
+
+  class FakeResizeObserver {
+    constructor(callback) { resizeCallback = callback; }
+    observe() {}
+    disconnect() { observerDisconnected = true; }
+  }
+
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { chatScroll, messages: makeNode() },
+    windowOverrides: {
+      requestAnimationFrame(callback) {
+        frames.push(callback);
+        return frames.length;
+      },
+      cancelAnimationFrame() {},
+    },
+    contextOverrides: { ResizeObserver: FakeResizeObserver },
+    timerOverrides: {
+      setTimeout(fn, delay) {
+        timers.push({ fn, delay, cleared: false });
+        return timers.length;
+      },
+      clearTimeout(id) {
+        if (timers[id - 1]) timers[id - 1].cleared = true;
+      },
+    },
+  });
+
+  frames.length = 0;
+  testApp.scrollToBottom(true);
+  while (frames.length) frames.shift()();
+  testApp.noteUserScrollIntent();
+  chatScroll.scrollHeight = 1120;
+  resizeCallback?.();
+  while (frames.length) frames.shift()();
+
+  if (chatScroll.scrollTop !== 1000) {
+    fail(name, `settling correction fought user intent and moved to ${chatScroll.scrollTop}`);
+    return;
+  }
+  if (!observerDisconnected || !timers.some((timer) => timer.cleared)) {
+    fail(name, 'user intent did not tear down the bounded settling work');
+    return;
+  }
+  if (testApp.state.autoScroll !== false) {
+    fail(name, 'autoScroll should remain disabled after user intent');
     return;
   }
   pass(name);

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -571,23 +571,58 @@ async function run(name, fn) {
     assert(!elements.appShell.classList.contains('diff-open'), 'grid back to two columns');
   });
 
-  await run('toggle stays hidden for sessions without file changes', async () => {
-    const { app, elements, state, flushTimers } = createHarness();
-    assert(elements.diffToggleBtn.hidden, 'toggle hidden on load');
-
-    // Activating a session whose server list is empty must not reveal anything.
+  await run('known clean session has no Changes toggle and makes no request', async () => {
+    const { app, elements, fetchCalls, flushTimers } = createHarness();
+    app.applySessionDiffSummary('s1', { file_count: 0, adds: 0, dels: 0 });
     app.activateDiffSidebar('s1');
     await flushTimers();
-    assert(elements.diffToggleBtn.hidden, 'toggle hidden after empty list fetch');
-    assert(elements.diffSidebar.hidden, 'sidebar hidden after empty list fetch');
 
-    // Switching away from a session with changes to one without hides both.
-    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
-    assert(!elements.diffToggleBtn.hidden, 'toggle visible once a file changed');
-    state.activeSessionId = 'clean';
-    app.activateDiffSidebar('clean');
-    assert(elements.diffToggleBtn.hidden, 'toggle hidden again on changeless session');
-    assert(elements.diffSidebar.hidden, 'sidebar hidden again on changeless session');
+    assert(elements.diffToggleBtn.hidden, 'clean session has no changes affordance');
+    assert(elements.diffSidebar.hidden, 'clean session keeps sidebar hidden');
+    assertEqual(elements.diffToggleBadge.children.length, 0, 'clean session has no provisional badge');
+    assertEqual(fetchCalls.filter((url) => url.endsWith('/file-changes')).length, 0, 'clean startup does not fetch the full list');
+  });
+
+  await run('aggregate metadata renders the final Changes header before the list loads', async () => {
+    const { app, elements, fetchCalls, flushTimers } = createHarness();
+    app.applySessionDiffSummary('s1', { file_count: 2, adds: 4, dels: 2 });
+    app.activateDiffSidebar('s1');
+    await flushTimers();
+
+    assert(!elements.diffToggleBtn.hidden, 'changed session exposes Changes immediately');
+    const fileCount = elements.diffToggleBadge.querySelector('.diff-toggle-file-count');
+    assert(fileCount, 'changed toggle renders the file icon/count');
+    assertEqual(fileCount.dataset.fileCount, '2', 'aggregate metadata supplies the actual file count');
+    assertEqual(elementText(elements.diffToggleBadge), '+4−2', 'aggregate metadata supplies additions and deletions');
+    assertEqual(elements.diffToggleBtn.title, '2 changed files (+4 −2)', 'initial title is final and accurate');
+    assertEqual(elements.diffFileList.children.length, 0, 'full file rows remain lazy');
+    assertEqual(fetchCalls.filter((url) => url.endsWith('/file-changes')).length, 0, 'rendering the header does not fetch the list');
+  });
+
+  await run('opening a known changed session fetches the full list exactly once', async () => {
+    const { app, elements, fetchCalls, flushTimers } = createHarness({
+      fetch: async (url) => ({
+        ok: true,
+        json: async () => (String(url).includes('/diff?')
+          ? { path: '/work/a.go', kind: 'modify', lang: 'go', truncated: false, hunks: [] }
+          : { file_changes: [
+              { path: '/work/a.go', kind: 'modify', adds: 3, dels: 2, truncated: false },
+              { path: '/work/b.go', kind: 'create', adds: 1, dels: 0, truncated: false }
+            ] })
+      })
+    });
+    app.applySessionDiffSummary('s1', { file_count: 2, adds: 4, dels: 2 });
+    app.activateDiffSidebar('s1');
+
+    app.toggleDiffSidebar();
+    await flushTimers();
+    assertEqual(fetchCalls.filter((url) => url.endsWith('/file-changes')).length, 1, 'first reveal fetches the exact list once');
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 2, 'drawer is populated from the lazy list');
+
+    app.toggleDiffSidebar();
+    app.toggleDiffSidebar();
+    await flushTimers();
+    assertEqual(fetchCalls.filter((url) => url.endsWith('/file-changes')).length, 1, 'reopening reuses the loaded list');
   });
 
   await run('drawer mode: no auto-open, toggle opens populated panel', async () => {
@@ -671,14 +706,30 @@ async function run(name, fn) {
     assertEqual(app.clampDiffWidth(500, 0), 500, 'missing viewport falls back sanely');
   });
 
-  await run('activateDiffSidebar fetches the server list once', async () => {
+  await run('activateDiffSidebar defers the server list until interaction', async () => {
     const { app, state, fetchCalls, flushTimers } = createHarness();
     state.activeSessionId = 's2';
     app.activateDiffSidebar('s2');
     await flushTimers();
     app.activateDiffSidebar('s2');
     await flushTimers();
-    assertEqual(fetchCalls.filter((u) => u.includes('s2') && u.endsWith('/file-changes')).length, 1, 'list fetched once per session');
+    assertEqual(fetchCalls.filter((u) => u.includes('s2') && u.endsWith('/file-changes')).length, 0, 'activation does not fetch a hidden ancillary list');
+
+    app.toggleDiffSidebar();
+    await flushTimers();
+    assertEqual(fetchCalls.filter((u) => u.includes('s2') && u.endsWith('/file-changes')).length, 1, 'first reveal lazily fetches the list once');
+    app.activateDiffSidebar('s2');
+    await flushTimers();
+    assertEqual(fetchCalls.filter((u) => u.includes('s2') && u.endsWith('/file-changes')).length, 1, 'loaded list stays cached for the session');
+  });
+
+  await run('numeric route stub never reaches file-changes endpoint', async () => {
+    const { app, state, fetchCalls, flushTimers } = createHarness();
+    state.activeSessionId = '3347';
+    app.activateDiffSidebar('3347');
+    app.toggleDiffSidebar();
+    await flushTimers();
+    assertEqual(fetchCalls.filter((u) => u.includes('/sessions/3347/')).length, 0, 'unresolved identity emitted a session-scoped diff request');
   });
 
   await run('server list is authoritative and removes stale duplicate live rows', async () => {
@@ -698,27 +749,6 @@ async function run(name, fn) {
     await app.fetchSessionFileChanges('s1');
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'server refresh replaced stale live row instead of adding a duplicate');
     assertEqual(elementText(elements.diffToggleBadge), '−3', 'badge shows cumulative diff stat');
-  });
-
-  await run('fresh page load keeps restored session diff sidebar closed', async () => {
-    const { app, elements, flushTimers } = createHarness({
-      fetch: async (url) => ({
-        ok: true,
-        json: async () => (String(url).includes('/diff?')
-          ? { path: '/work/a.go', kind: 'create', lang: 'go', truncated: false, hunks: [] }
-          : { file_changes: [{ path: '/work/a.go', kind: 'create', adds: 3, dels: 0, truncated: false }] })
-      })
-    });
-    // No switchToSession call — the script itself activates for the restored
-    // session, but page load must not open the diff panel without a click.
-    await flushTimers();
-    assert(elements.diffSidebar.hidden, 'sidebar remains closed on fresh load when session has changes');
-    assert(!elements.diffToggleBtn.hidden, 'toggle visible on fresh load');
-    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 0, 'file list not populated while hidden');
-
-    app.toggleDiffSidebar();
-    assert(!elements.diffSidebar.hidden, 'explicit toggle opens restored session sidebar');
-    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'file list populated after user opens');
   });
 
   await run('sortDiffPaths orders by recency then path', () => {

--- a/internal/serveui/static/app_plan_test.js
+++ b/internal/serveui/static/app_plan_test.js
@@ -196,6 +196,30 @@ function snapshot(version, statuses = ['completed', 'in_progress', 'pending']) {
   };
 }
 
+function testPlanSummaryRendersInitialAffordance() {
+  const name = 'selected session plan summary renders the final affordance before plan body state';
+  const h = createHarness();
+
+  if (!h.app.applyCurrentPlanSummary('session-a', {
+    version: 7,
+    step_count: 4,
+    completed_steps: 2,
+    position: 3,
+    state: 'in_progress',
+  })) return fail(name, 'valid plan summary was not accepted');
+  if (h.elements.planToggleBtn.hidden
+    || h.elements.planToggleWord.textContent !== 'Plan'
+    || h.elements.planToggleProgress.textContent !== '3/4'
+    || !h.elements.planToggleBtn.getAttribute('aria-label').includes('Step 3 of 4')) {
+    return fail(name, 'initial plan affordance was not complete and accurate');
+  }
+  if (h.elements.planPanelChecklist.children.length !== 0) return fail(name, 'summary metadata invented full plan steps');
+
+  h.app.applyCurrentPlanSummary('session-a', null);
+  if (!h.elements.planToggleBtn.hidden) return fail(name, 'authoritative no-plan summary left the affordance visible');
+  pass(name);
+}
+
 function testPlanStateAndRendering() {
   const name = 'authoritative plan versions render shared progress and explicit clears';
   const h = createHarness();
@@ -334,6 +358,7 @@ function testInvalidSnapshotsAreRejected() {
 }
 
 [
+  testPlanSummaryRendersInitialAffordance,
   testPlanStateAndRendering,
   testSessionIsolationAndReset,
   testMobileInteractionsAndBreakpointTransfer,

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -1889,6 +1889,62 @@ async function run(name, fn) {
     assertEqual(messages.children[2].dataset.messageId, 'm3', 'new node has correct id');
   });
 
+  await run('mounted reconnect reconciliation restores an earlier user before later tool rows', () => {
+    const { app, session, messages } = createHarness();
+    const user = {
+      id: 'msg_keep_going',
+      role: 'user',
+      content: 'keep going',
+      interruptState: 'interject',
+      created: 1000,
+    };
+    const queueAgent = {
+      id: 'tools_queue_agent',
+      role: 'tool-group',
+      status: 'done',
+      tools: [{ id: 'call_queue_agent', name: 'queue_agent', status: 'done', arguments: '{}' }],
+      created: 2000,
+    };
+    const waitForJobs = {
+      id: 'tools_wait_for_jobs',
+      role: 'tool-group',
+      status: 'running',
+      tools: [{ id: 'call_wait_for_jobs', name: 'wait_for_jobs', status: 'running', arguments: '{}' }],
+      created: 3000,
+    };
+    session.messages = [user, queueAgent, waitForJobs];
+
+    // Reproduce the live reconnect window: recovery has mounted later stream
+    // cards, while the earlier optimistic/interjected user row is temporarily
+    // absent. Replaying response.interjection updates that existing message.
+    messages.appendChild(app.createToolGroupNode(queueAgent));
+    messages.appendChild(app.createToolGroupNode(waitForJobs));
+    app.updateMountedUserNode(session, user);
+
+    assertEqual(
+      messages.children.map((node) => node.dataset.messageId).join(','),
+      'msg_keep_going,tools_queue_agent,tools_wait_for_jobs',
+      'live DOM follows session message order without requiring a reload'
+    );
+  });
+
+  await run('forced transcript render starts bottom anchoring after DOM commit', () => {
+    const scrollCalls = [];
+    let harness = null;
+    harness = createHarness({
+      scrollToBottom(force) {
+        scrollCalls.push({ force, renderedCount: harness.messages.children.length });
+      },
+    });
+    harness.session.messages = [{ id: 'startup-user', role: 'user', content: 'hello', created: 1000 }];
+
+    harness.app.renderMessages(true);
+
+    assertEqual(scrollCalls.length, 1, 'render issues one bottom-anchor request');
+    assertEqual(scrollCalls[0].force, true, 'startup render requests forced anchoring');
+    assertEqual(scrollCalls[0].renderedCount, 1, 'forced anchoring starts after transcript DOM commit');
+  });
+
   await run('renderMessages exposes gated mounted-count and duration diagnostics', () => {
     const { app, session, messages, windowObj } = createHarness();
     windowObj.__TERM_LLM_DIAGNOSTICS__ = true;

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -973,7 +973,19 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
   const events = [];
   const scheduled = [];
   let appRef = null;
-  const { app } = await createSessionsHarness({
+  let releaseState;
+  let releaseModels;
+  let markStateStarted;
+  let markModelsStarted;
+  let markSideloadRendered;
+  let stateResolved = false;
+  let modelsResolved = false;
+  const stateGate = new Promise((resolve) => { releaseState = resolve; });
+  const modelsGate = new Promise((resolve) => { releaseModels = resolve; });
+  const stateStarted = new Promise((resolve) => { markStateStarted = resolve; });
+  const modelsStarted = new Promise((resolve) => { markModelsStarted = resolve; });
+  const sideloadRendered = new Promise((resolve) => { markSideloadRendered = resolve; });
+  const harnessPromise = createSessionsHarness({
     pathname: '/ui/3347',
     setTimeout(fn, delay) {
       const handle = { fn, delay, cleared: false };
@@ -996,6 +1008,9 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (parsed?.pathname === '/ui/v1/sessions/sess_3347/state') {
+        markStateStarted();
+        await stateGate;
+        stateResolved = true;
         return new Response(JSON.stringify({ active_run: false, transcript_rev: 20 }), {
           status: 200, headers: { 'Content-Type': 'application/json' },
         });
@@ -1003,14 +1018,29 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
       return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     },
     appOverrides: {
+      async fetchModels() {
+        markModelsStarted();
+        await modelsGate;
+        modelsResolved = true;
+        return [];
+      },
       renderMessages() {
         const session = appRef?.state.sessions.find((item) => item.id === 'sess_3347');
-        events.push({ type: 'render', contents: session?.messages.map((message) => message.content) || [] });
+        const contents = session?.messages.map((message) => message.content) || [];
+        events.push({ type: 'render', contents });
+        if (contents.filter((content) => typeof content === 'string').length === 9) markSideloadRendered();
       },
-      hideStartupSplash() { events.push({ type: 'splash' }); },
+      hideStartupSplash() { events.push({ type: 'splash', stateResolved, modelsResolved }); },
     },
     onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
   });
+
+  await Promise.all([sideloadRendered, stateStarted, modelsStarted]);
+  await new Promise((resolve) => setImmediate(resolve));
+  const splashBeforeState = events.some((event) => event.type === 'splash' && !event.stateResolved && !event.modelsResolved);
+  releaseState();
+  releaseModels();
+  const { app } = await harnessPromise;
 
   const startupURL = fetchCalls.find((url) => parsedTestURL(url)?.pathname === '/ui/v1/sessions');
   if (parsedTestURL(startupURL)?.searchParams.get('include_transcript') !== '1') {
@@ -1026,6 +1056,10 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
   const hydratedRender = events.findIndex((event) => event.type === 'render'
     && event.contents.filter((content) => typeof content === 'string').length === 9);
   const splash = events.findIndex((event) => event.type === 'splash');
+  if (!splashBeforeState) {
+    fail(name, 'splash remained coupled to delayed runtime state or models after the sideload render', JSON.stringify(events));
+    return;
+  }
   if (!session || hydratedRender < 0 || splash <= hydratedRender) {
     fail(name, 'bounded sideload was not rendered atomically before splash hide', JSON.stringify(events));
     return;
@@ -1136,6 +1170,7 @@ async function testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision
       return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     },
   });
+  await new Promise((resolve) => setImmediate(resolve));
   app.stopSidebarStatusPoll();
   const session = app.state.sessions.find((item) => item.id === 'sess_52');
   if (indexRequests !== 1 || bodyRequests !== 1 || session?.transcript.rev !== 3 || session?.messages.at(-1)?.content !== '3') {
@@ -1146,11 +1181,20 @@ async function testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision
 }
 
 async function testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus() {
-  const name = 'scheduled status reconciliation does not duplicate startup state for sideloaded active run';
+  const name = 'active startup reveals rendered sideload before state and resumes without duplicate state';
   const scheduled = [];
+  const events = [];
   let stateRequests = 0;
   let statusRequests = 0;
-  const { app } = await createSessionsHarness({
+  let stateResolved = false;
+  let appRef = null;
+  let releaseState;
+  let markStateStarted;
+  let markSideloadRendered;
+  const stateGate = new Promise((resolve) => { releaseState = resolve; });
+  const stateStarted = new Promise((resolve) => { markStateStarted = resolve; });
+  const sideloadRendered = new Promise((resolve) => { markSideloadRendered = resolve; });
+  const harnessPromise = createSessionsHarness({
     pathname: '/ui/63',
     setTimeout(fn, delay) {
       const handle = { fn, delay, cleared: false };
@@ -1176,6 +1220,9 @@ async function testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus
       }
       if (parsed?.pathname === '/ui/v1/sessions/sess_63/state') {
         stateRequests += 1;
+        markStateStarted();
+        await stateGate;
+        stateResolved = true;
         return new Response(JSON.stringify({ active_run: true, active_response_id: 'resp_63', started_rev: 5, transcript_rev: 6 }), {
           status: 200, headers: { 'Content-Type': 'application/json' },
         });
@@ -1188,8 +1235,37 @@ async function testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus
       }
       return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     },
+    appOverrides: {
+      renderMessages() {
+        const contents = appRef?.state.sessions.find((item) => item.id === 'sess_63')?.messages
+          .map((message) => message.content) || [];
+        events.push({ type: 'render', contents, stateResolved });
+        if (contents.includes('active')) markSideloadRendered();
+      },
+      hideStartupSplash() { events.push({ type: 'splash', stateResolved }); },
+      async resumeActiveResponse(session, options) {
+        events.push({ type: 'resume', sessionId: session.id, responseId: options?.responseId, stateResolved });
+      },
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
   });
 
+  await Promise.all([sideloadRendered, stateStarted]);
+  await new Promise((resolve) => setImmediate(resolve));
+  const splashBeforeState = events.some((event) => event.type === 'splash' && !event.stateResolved);
+  releaseState();
+  const { app } = await harnessPromise;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  if (!splashBeforeState) {
+    fail(name, 'active transcript render remained blocked on runtime state', JSON.stringify(events));
+    return;
+  }
+  const resumeEvent = events.find((event) => event.type === 'resume');
+  if (!resumeEvent || resumeEvent.sessionId !== 'sess_63' || resumeEvent.responseId !== 'resp_63' || !resumeEvent.stateResolved) {
+    fail(name, 'delayed runtime state did not resume the active response after reveal', JSON.stringify(events));
+    return;
+  }
   if (stateRequests !== 1 || statusRequests !== 0) {
     fail(name, 'startup issued immediate status or duplicate state request', JSON.stringify({ stateRequests, statusRequests }));
     return;
@@ -1211,17 +1287,22 @@ async function testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus
 }
 
 async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
-  const name = 'deep-linked startup hides splash after transcript render without waiting for skills';
+  const name = 'fallback transcript render reveals startup before delayed state and skills';
   const events = [];
   let releaseBodies;
+  let releaseState;
   let releaseSkills;
   let markBodiesStarted;
+  let markStateStarted;
+  let markHydratedRendered;
   let markSkillsStarted;
-  let markSplashHidden;
+  let stateResolved = false;
   const bodiesStarted = new Promise((resolve) => { markBodiesStarted = resolve; });
+  const stateStarted = new Promise((resolve) => { markStateStarted = resolve; });
+  const hydratedRendered = new Promise((resolve) => { markHydratedRendered = resolve; });
   const skillsStarted = new Promise((resolve) => { markSkillsStarted = resolve; });
-  const splashHidden = new Promise((resolve) => { markSplashHidden = resolve; });
   const bodiesGate = new Promise((resolve) => { releaseBodies = resolve; });
+  const stateGate = new Promise((resolve) => { releaseState = resolve; });
   const skillsGate = new Promise((resolve) => { releaseSkills = resolve; });
 
   const harnessPromise = createSessionsHarness({
@@ -1267,6 +1348,9 @@ async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (String(url) === '/ui/v1/sessions/sess_3347/state') {
+        markStateStarted();
+        await stateGate;
+        stateResolved = true;
         return new Response(JSON.stringify({ active_run: false, transcript_rev: 2 }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -1277,9 +1361,11 @@ async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
     appOverrides: {
       hideStartupSplash() {
         events.push('splash-hidden');
-        markSplashHidden();
       },
-      renderMessages() { events.push('messages-rendered'); },
+      renderMessages() {
+        events.push('messages-rendered');
+        if (events.includes('bodies-resolved')) markHydratedRendered();
+      },
       async refreshSkillCommands() {
         events.push('skills-started');
         markSkillsStarted();
@@ -1289,14 +1375,14 @@ async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
     },
   });
 
-  await bodiesStarted;
+  await Promise.all([bodiesStarted, stateStarted]);
   const hiddenBeforeBodies = events.includes('splash-hidden');
   releaseBodies();
+  await hydratedRendered;
+  await new Promise((resolve) => setImmediate(resolve));
+  const splashBeforeState = events.includes('splash-hidden') && !stateResolved;
+  releaseState();
   await skillsStarted;
-  const splashWonRace = await Promise.race([
-    splashHidden.then(() => true),
-    new Promise((resolve) => setTimeout(() => resolve(false), 50)),
-  ]);
   const skillsPendingWhenSplashHid = !events.includes('skills-resolved');
   releaseSkills();
   const { app } = await harnessPromise;
@@ -1312,8 +1398,8 @@ async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
     fail(name, 'startup splash did not hide after the hydrated transcript render boundary', JSON.stringify(events));
     return;
   }
-  if (!splashWonRace || !skillsPendingWhenSplashHid) {
-    fail(name, 'startup splash waited for the delayed skill-command refresh', JSON.stringify(events));
+  if (!splashBeforeState || !skillsPendingWhenSplashHid) {
+    fail(name, 'startup splash waited for delayed runtime state or skill-command refresh', JSON.stringify(events));
     return;
   }
   const session = app.state.sessions.find((item) => item.id === 'sess_3347');

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -940,7 +940,8 @@ async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
             created_at: 1710000000000,
             message_count: 2,
             transcript_rev: 2,
-          }]
+          }],
+          widget_status: { widgets: [] },
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (isTranscriptIndexURL(url, 'sess_3347')) {
@@ -1017,6 +1018,164 @@ async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
   const session = app.state.sessions.find((item) => item.id === 'sess_3347');
   if (!session || session.messages.map((message) => message.content).join(',') !== 'question,answer') {
     fail(name, 'startup completed without the canonical transcript projection', JSON.stringify(session?.messages || []));
+    return;
+  }
+  pass(name);
+}
+
+async function testStartupSideloadsWidgetsBeforeFirstPaint() {
+  const name = 'startup sideloads authoritative widget status before first paint without widget requests';
+  const events = [];
+  const fetchCalls = [];
+  const sideloadedWidgets = [
+    { id: 'metrics', mount: 'metrics', title: 'Metrics', description: 'Local metrics', state: 'stopped' },
+  ];
+
+  let appRef = null;
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: null,
+          widget_status: { widgets: sideloadedWidgets },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: {
+      renderWidgetSidebar() {
+        events.push({
+          type: 'widgets-rendered',
+          loaded: Boolean(appRef?.state.widgetsLoaded),
+          widgets: JSON.parse(JSON.stringify(appRef?.state.widgets || [])),
+        });
+      },
+      hideStartupSplash() { events.push({ type: 'splash-hidden' }); },
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
+  });
+  app.stopSidebarStatusPoll();
+
+  const widgetRender = events.find((event) => event.type === 'widgets-rendered');
+  const widgetRenderIndex = events.indexOf(widgetRender);
+  const splashIndex = events.findIndex((event) => event.type === 'splash-hidden');
+  const startupSessionsURL = fetchCalls.find((url) => parsedTestURL(url)?.pathname === '/ui/v1/sessions');
+  if (!startupSessionsURL || parsedTestURL(startupSessionsURL)?.searchParams.get('include_widget_status') !== '1') {
+    fail(name, 'primary startup request did not opt into widget status sideload', JSON.stringify(fetchCalls));
+    return;
+  }
+  if (!widgetRender || !widgetRender.loaded || JSON.stringify(widgetRender.widgets) !== JSON.stringify(sideloadedWidgets)) {
+    fail(name, 'first widget render did not use the authoritative sideload', JSON.stringify(events));
+    return;
+  }
+  if (widgetRenderIndex < 0 || splashIndex <= widgetRenderIndex) {
+    fail(name, 'widget sidebar did not render before the startup splash was hidden', JSON.stringify(events));
+    return;
+  }
+  if (fetchCalls.some((url) => parsedTestURL(url)?.pathname === '/ui/admin/widgets/status')) {
+    fail(name, 'startup requested the deferred widget status endpoint', JSON.stringify(fetchCalls));
+    return;
+  }
+  if (fetchCalls.some((url) => parsedTestURL(url)?.pathname.startsWith('/ui/widgets/'))) {
+    fail(name, 'startup eagerly requested full widget app content', JSON.stringify(fetchCalls));
+    return;
+  }
+  pass(name);
+}
+
+async function testStartupSideloadsEmptyWidgetList() {
+  const name = 'startup treats an empty sideloaded widget list as authoritative';
+  let statusRequests = 0;
+  const renders = [];
+  let appRef = null;
+
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/admin/widgets/status') statusRequests += 1;
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: null,
+          widget_status: { widgets: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: {
+      renderWidgetSidebar() {
+        renders.push({
+          loaded: Boolean(appRef?.state.widgetsLoaded),
+          count: appRef?.state.widgets.length || 0,
+        });
+      },
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
+  });
+  app.stopSidebarStatusPoll();
+
+  if (statusRequests !== 0 || !app.state.widgetsLoaded || app.state.widgets.length !== 0) {
+    fail(name, 'empty widget sideload was not final at startup', JSON.stringify({ statusRequests, state: app.state }));
+    return;
+  }
+  if (renders.length !== 1 || !renders[0].loaded || renders[0].count !== 0) {
+    fail(name, 'empty widget sideload caused a provisional or duplicate render', JSON.stringify(renders));
+    return;
+  }
+  pass(name);
+}
+
+async function testExplicitWidgetRefreshStillUsesStatusEndpoint() {
+  const name = 'explicit widget refresh uses the status endpoint after startup';
+  let statusRequests = 0;
+  const initialWidget = { id: 'one', mount: 'one', title: 'One', state: 'stopped' };
+  const refreshedWidget = { id: 'two', mount: 'two', title: 'Two', state: 'running' };
+
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: null,
+          widget_status: { widgets: [initialWidget] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/admin/widgets/status') {
+        statusRequests += 1;
+        return new Response(JSON.stringify({ widgets: [refreshedWidget] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: { renderWidgetSidebar() {} },
+  });
+  app.stopSidebarStatusPoll();
+
+  if (statusRequests !== 0 || app.state.widgets[0]?.id !== 'one') {
+    fail(name, 'startup did not remain request-free with sideloaded status', JSON.stringify({ statusRequests, widgets: app.state.widgets }));
+    return;
+  }
+  if (typeof app.refreshWidgetsSidebar !== 'function') {
+    fail(name, 'explicit widget refresh is not available');
+    return;
+  }
+  await app.refreshWidgetsSidebar();
+  if (statusRequests !== 1 || app.state.widgets[0]?.id !== 'two' || !app.state.widgetsLoaded) {
+    fail(name, 'explicit refresh did not update from the status endpoint', JSON.stringify({ statusRequests, widgets: app.state.widgets }));
     return;
   }
   pass(name);
@@ -2675,6 +2834,68 @@ async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
   if (statusCalls !== 2) {
     app.stopSidebarStatusPoll();
     fail(name, `later visibility change did not restart normal polling; got ${statusCalls} status requests`);
+    return;
+  }
+
+  app.stopSidebarStatusPoll();
+  pass(name);
+}
+
+async function testPageshowWaitsForInitialConnectionBeforeStatusPoll() {
+  const name = 'pageshow waits for initial session merge before starting status polling';
+  let releaseSessions;
+  let pageshowHandler = null;
+  let statusCalls = 0;
+  const sessionsGate = new Promise((resolve) => {
+    releaseSessions = () => resolve(new Response(JSON.stringify({ sessions: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  });
+
+  const harnessPromise = createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (String(url) === '/ui/v1/sessions') return sessionsGate;
+      if (String(url) === '/ui/v1/sessions/status') statusCalls += 1;
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    onInitializeStarted({ windowObj }) {
+      const pageshowHandlers = windowObj.listeners.pageshow || [];
+      pageshowHandler = pageshowHandlers[pageshowHandlers.length - 1] || null;
+      pageshowHandler?.({ type: 'pageshow', persisted: false });
+    },
+  });
+
+  if (!pageshowHandler) {
+    releaseSessions();
+    await harnessPromise;
+    fail(name, 'expected pageshow listener during initialization');
+    return;
+  }
+  if (statusCalls !== 0) {
+    releaseSessions();
+    const { app } = await harnessPromise;
+    app.stopSidebarStatusPoll();
+    fail(name, `pre-connected pageshow started ${statusCalls} status requests`);
+    return;
+  }
+
+  releaseSessions();
+  const { app } = await harnessPromise;
+  if (!app.state.connected || statusCalls !== 1) {
+    app.stopSidebarStatusPoll();
+    fail(name, 'initial merge did not start exactly one connected status poll', JSON.stringify({ connected: app.state.connected, statusCalls }));
+    return;
+  }
+
+  await app.stopSidebarStatusPoll();
+  pageshowHandler({ type: 'pageshow', persisted: true });
+  if (statusCalls !== 2) {
+    app.stopSidebarStatusPoll();
+    fail(name, `connected BFCache pageshow did not restart normal polling; got ${statusCalls} status requests`);
     return;
   }
 
@@ -4899,6 +5120,9 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testSwitchToSessionSyncsSelectedRuntime();
   await testNumericDeepLinkResolvesRealSessionId();
   await testStartupSplashWaitsForDeepLinkedTranscriptRender();
+  await testStartupSideloadsWidgetsBeforeFirstPaint();
+  await testStartupSideloadsEmptyWidgetList();
+  await testExplicitWidgetRefreshStillUsesStatusEndpoint();
   await testStartupHydrationTimeoutDoesNotBlockIndefinitely();
   await testUnresolvedNumericDeepLinkSkipsSessionScopedStartupRequests();
   await testNewQueryStartsDraftInsteadOfLastSession();
@@ -4941,6 +5165,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testApplyServerSessionSummaryMapsLastMessageAt();
   await testSanitizeSessionPreservesLastMessageAt();
   await testPreConnectedVisibilityDoesNotStartSidebarStatusPoll();
+  await testPageshowWaitsForInitialConnectionBeforeStatusPoll();
   await testSidebarStatusPollRecoversIdempotentlyAfterPageShow();
   await testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus();
   await testReconnectBackoffWakeSignalsReuseExistingLoop();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -318,6 +318,7 @@ async function createSessionsHarness(options = {}) {
 
   const windowObj = {
     TERM_LLM_UI_PREFIX: options.uiPrefix || '/ui',
+    TERM_LLM_STARTUP_HYDRATION_TIMEOUT_MS: options.startupHydrationTimeoutMS,
     TERM_LLM_SIDEBAR_SESSIONS: 'all',
     TERM_LLM_HUB: options.hub || null,
     TERM_LLM_LOCATION_SHARING_ENABLED: options.locationSharingEnabled !== false,
@@ -407,6 +408,9 @@ async function createSessionsHarness(options = {}) {
   Object.assign(app, defaultAppStubs(app, options.appOverrides || {}));
 
   vm.runInContext(sessionsSource, context, { filename: 'app-sessions.js' });
+  if (typeof options.onInitializeStarted === 'function') {
+    options.onInitializeStarted({ app, windowObj, storage, elementMap });
+  }
   await windowObj.__termllmInitializePromise;
 
   return { app, storage, windowObj, elementMap };
@@ -602,7 +606,7 @@ async function testArchivingActiveSessionClearsItsComposerDraft() {
   const drafts = new Map([['', 'blank draft']]);
   const { app, windowObj } = await createSessionsHarness({
     fetchImpl: async (url, options = {}) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({ sessions: [] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -783,13 +787,22 @@ async function testSwitchToSessionSyncsSelectedRuntime() {
 async function testNumericDeepLinkResolvesRealSessionId() {
   const name = 'numeric deep link resolves server session id';
   const fetchCalls = [];
-  const { app, storage } = await createSessionsHarness({
+  let appliedDiffSummary = null;
+  const { app, storage, elementMap } = await createSessionsHarness({
     pathname: '/ui/1291',
+    appOverrides: {
+      applySessionDiffSummary(sessionId, summary) {
+        appliedDiffSummary = { sessionId, summary };
+        return true;
+      },
+    },
     fetchImpl: async (url) => {
       fetchCalls.push(url);
-      if (url === '/ui/v1/sessions') {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === '1291') {
         return new Response(JSON.stringify({
-          sessions: [{
+          sessions: [],
+          selected_session: {
             id: 'sess_real',
             number: 1291,
             short_title: 'Real session',
@@ -800,7 +813,9 @@ async function testNumericDeepLinkResolvesRealSessionId() {
             pinned: false,
             created_at: 1710000000000,
             message_count: 1,
-          }]
+            file_change_summary: { file_count: 2, adds: 7, dels: 3 },
+            plan_summary: { version: 4, step_count: 3, completed_steps: 1, position: 2, state: 'in_progress' },
+          }
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (isTranscriptIndexURL(url, 'sess_real')) {
@@ -844,12 +859,270 @@ async function testNumericDeepLinkResolvesRealSessionId() {
     fail(name, 'should load transcript index via resolved server session id', JSON.stringify(fetchCalls));
     return;
   }
+  const unresolvedScopedCalls = fetchCalls.filter((url) => {
+    const parsed = parsedTestURL(url);
+    return Boolean(parsed && (
+      parsed.pathname.includes('/v1/sessions/1291/')
+      || parsed.pathname.includes('/api/sessions/1291/')
+    ));
+  });
+  if (unresolvedScopedCalls.length > 0) {
+    fail(name, 'numeric route stub reached a session-scoped endpoint before identity reconciliation', JSON.stringify(fetchCalls));
+    return;
+  }
+  if (!appliedDiffSummary
+    || appliedDiffSummary.sessionId !== 'sess_real'
+    || appliedDiffSummary.summary.file_count !== 2
+    || appliedDiffSummary.summary.adds !== 7
+    || appliedDiffSummary.summary.dels !== 3) {
+    fail(name, 'selected diff aggregate was not applied during session merge', JSON.stringify(appliedDiffSummary));
+    return;
+  }
+  const planToggle = elementMap.get('planToggleBtn');
+  if (planToggle.hidden
+    || elementMap.get('planToggleWord').textContent !== 'Plan'
+    || elementMap.get('planToggleProgress').textContent !== '2/3') {
+    fail(name, 'selected plan summary did not render the initial affordance');
+    return;
+  }
+  if (fetchCalls.some((url) => String(url).includes('/file-changes'))) {
+    fail(name, 'startup must not fetch the full file-change list', JSON.stringify(fetchCalls));
+    return;
+  }
+  const sessionsIndex = fetchCalls.findIndex((url) => {
+    const parsed = parsedTestURL(url);
+    return parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === '1291';
+  });
+  const transcriptIndex = fetchCalls.findIndex((url) => isTranscriptIndexURL(url, 'sess_real'));
+  if (sessionsIndex < 0 || transcriptIndex <= sessionsIndex) {
+    fail(name, 'canonical transcript request did not wait for session identity lookup', JSON.stringify(fetchCalls));
+    return;
+  }
   if (fetchCalls.some((url) => isSessionMessagesURL(url, 'pending_1291'))) {
     fail(name, 'should not use pending_ prefix in session id', JSON.stringify(fetchCalls));
     return;
   }
   if ([...storage.values()].some((value) => String(value).includes('hello from server'))) {
     fail(name, 'durable transcript bodies must not be written to localStorage', JSON.stringify([...storage.entries()]));
+    return;
+  }
+  pass(name);
+}
+
+async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
+  const name = 'deep-linked startup hides splash after transcript render without waiting for skills';
+  const events = [];
+  let releaseBodies;
+  let releaseSkills;
+  let markBodiesStarted;
+  let markSkillsStarted;
+  let markSplashHidden;
+  const bodiesStarted = new Promise((resolve) => { markBodiesStarted = resolve; });
+  const skillsStarted = new Promise((resolve) => { markSkillsStarted = resolve; });
+  const splashHidden = new Promise((resolve) => { markSplashHidden = resolve; });
+  const bodiesGate = new Promise((resolve) => { releaseBodies = resolve; });
+  const skillsGate = new Promise((resolve) => { releaseSkills = resolve; });
+
+  const harnessPromise = createSessionsHarness({
+    pathname: '/ui/3347',
+    fetchImpl: async (url) => {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: 'sess_3347',
+            number: 3347,
+            short_title: 'Hydrated session',
+            long_title: 'Hydrated session',
+            mode: 'chat',
+            origin: 'web',
+            archived: false,
+            pinned: false,
+            created_at: 1710000000000,
+            message_count: 2,
+            transcript_rev: 2,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTranscriptIndexURL(url, 'sess_3347')) {
+        return new Response(JSON.stringify({
+          rev: 2,
+          compaction_seq: -1,
+          compaction_count: 0,
+          rows: { ids: [31, 32], seqs: [0, 1], roles: 'ua', flags: [0, 0] }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"startup-2"' } });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_3347')) {
+        events.push('bodies-started');
+        markBodiesStarted();
+        await bodiesGate;
+        events.push('bodies-resolved');
+        return new Response(JSON.stringify({
+          rev: 2,
+          messages: [
+            { id: 31, sequence: 0, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'question' }] },
+            { id: 32, sequence: 1, role: 'assistant', created_at: 2000, parts: [{ type: 'text', text: 'answer' }] }
+          ]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (String(url) === '/ui/v1/sessions/sess_3347/state') {
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 2 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: {
+      hideStartupSplash() {
+        events.push('splash-hidden');
+        markSplashHidden();
+      },
+      renderMessages() { events.push('messages-rendered'); },
+      async refreshSkillCommands() {
+        events.push('skills-started');
+        markSkillsStarted();
+        await skillsGate;
+        events.push('skills-resolved');
+      },
+    },
+  });
+
+  await bodiesStarted;
+  const hiddenBeforeBodies = events.includes('splash-hidden');
+  releaseBodies();
+  await skillsStarted;
+  const splashWonRace = await Promise.race([
+    splashHidden.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+  const skillsPendingWhenSplashHid = !events.includes('skills-resolved');
+  releaseSkills();
+  const { app } = await harnessPromise;
+
+  if (hiddenBeforeBodies) {
+    fail(name, 'startup splash hid while canonical transcript bodies were still pending', JSON.stringify(events));
+    return;
+  }
+  const bodiesResolvedIndex = events.indexOf('bodies-resolved');
+  const hydratedRenderIndex = events.indexOf('messages-rendered', bodiesResolvedIndex + 1);
+  const splashHiddenIndex = events.indexOf('splash-hidden');
+  if (bodiesResolvedIndex < 0 || hydratedRenderIndex < 0 || splashHiddenIndex <= hydratedRenderIndex) {
+    fail(name, 'startup splash did not hide after the hydrated transcript render boundary', JSON.stringify(events));
+    return;
+  }
+  if (!splashWonRace || !skillsPendingWhenSplashHid) {
+    fail(name, 'startup splash waited for the delayed skill-command refresh', JSON.stringify(events));
+    return;
+  }
+  const session = app.state.sessions.find((item) => item.id === 'sess_3347');
+  if (!session || session.messages.map((message) => message.content).join(',') !== 'question,answer') {
+    fail(name, 'startup completed without the canonical transcript projection', JSON.stringify(session?.messages || []));
+    return;
+  }
+  pass(name);
+}
+
+async function testStartupHydrationTimeoutDoesNotBlockIndefinitely() {
+  const name = 'deep-linked startup hydration has a bounded splash fallback';
+  let releaseBodies;
+  let bodiesPending = false;
+  let splashHidden = false;
+  const bodiesGate = new Promise((resolve) => { releaseBodies = resolve; });
+
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/3348',
+    startupHydrationTimeoutMS: 0,
+    fetchImpl: async (url) => {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: 'sess_3348',
+            number: 3348,
+            short_title: 'Slow session',
+            mode: 'chat',
+            origin: 'web',
+            created_at: 1710000000000,
+            message_count: 1,
+            transcript_rev: 1,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTranscriptIndexURL(url, 'sess_3348')) {
+        return new Response(JSON.stringify({
+          rev: 1,
+          compaction_seq: -1,
+          compaction_count: 0,
+          rows: { ids: [41], seqs: [0], roles: 'u', flags: [0] }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"startup-slow-1"' } });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_3348')) {
+        bodiesPending = true;
+        await bodiesGate;
+        bodiesPending = false;
+        return new Response(JSON.stringify({
+          rev: 1,
+          messages: [{ id: 41, sequence: 0, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'eventually' }] }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (String(url) === '/ui/v1/sessions/sess_3348/state') {
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 1 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: {
+      hideStartupSplash() { splashHidden = true; },
+    },
+  });
+
+  if (!splashHidden || !bodiesPending) {
+    releaseBodies();
+    fail(name, 'startup did not leave the splash through the bound while hydration remained pending', JSON.stringify({ splashHidden, bodiesPending }));
+    return;
+  }
+
+  releaseBodies();
+  for (let attempts = 0; attempts < 10 && app.state.sessions[0]?._serverOnly; attempts += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  pass(name);
+}
+
+async function testUnresolvedNumericDeepLinkSkipsSessionScopedStartupRequests() {
+  const name = 'unresolved numeric deep link waits before session-scoped startup requests';
+  const fetchCalls = [];
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/3347',
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+
+  if (app.state.activeSessionId !== '3347') {
+    fail(name, `numeric route stub unexpectedly changed identity to ${JSON.stringify(app.state.activeSessionId)}`);
+    return;
+  }
+  const scopedCalls = fetchCalls.filter((url) => {
+    const parsed = parsedTestURL(url);
+    return Boolean(parsed && (
+      parsed.pathname.includes('/v1/sessions/3347/')
+      || parsed.pathname.includes('/api/sessions/3347/')
+    ));
+  });
+  if (scopedCalls.length > 0) {
+    fail(name, 'startup issued requests against an unresolved numeric identity', JSON.stringify(fetchCalls));
     return;
   }
   pass(name);
@@ -865,7 +1138,7 @@ async function testNewQueryStartsDraftInsteadOfLastSession() {
       term_llm_draft_session_active: '0',
     },
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({
           sessions: [{
             id: 'sess_old',
@@ -942,7 +1215,7 @@ async function testMergeServerSessionsMigratesInterruptBuffersToRealSessionId() 
   const name = 'session id reconciliation migrates interrupt buffers to real session id';
   const { app } = await createSessionsHarness({
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({
           sessions: [{
             id: 'sess_real',
@@ -997,7 +1270,7 @@ async function testDeveloperMessagesAreHidden() {
   const { app } = await createSessionsHarness({
     pathname: '/ui/42',
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({
           sessions: [{
             id: 'sess_dev',
@@ -1569,7 +1842,7 @@ async function testSwitchToSessionSyncsWithoutTokenAndResumes() {
     },
     fetchImpl: async (url) => {
       fetchCalls.push(url);
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({
           sessions: [
             {
@@ -1701,7 +1974,7 @@ async function testSwitchToSessionAttachesChangedActiveResponseFromStartedRevisi
       term_llm_active_session: 'sess_other',
     },
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({
           sessions: [
             {
@@ -1806,7 +2079,7 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
 
   const { app } = await createSessionsHarness({
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({ sessions: [] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -1974,7 +2247,7 @@ async function testResumeAndDrainFiringViaSync() {
 
   const { app } = await createSessionsHarness({
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({ sessions: [] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -2075,7 +2348,7 @@ async function testTerminalSyncRequeuesPendingInterjectionAsFollowUp() {
 
   const { app } = await createSessionsHarness({
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({ sessions: [] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -2340,6 +2613,72 @@ async function testSanitizeSessionPreservesLastMessageAt() {
     return;
   }
 
+  pass(name);
+}
+
+async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
+  const name = 'pre-connected visibility changes wait for initial session merge before status polling';
+  let releaseSessions;
+  let visibilityHandler = null;
+  let statusCalls = 0;
+  const sessionsGate = new Promise((resolve) => {
+    releaseSessions = () => resolve(new Response(JSON.stringify({ sessions: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  });
+
+  const harnessPromise = createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (String(url) === '/ui/v1/sessions') return sessionsGate;
+      if (String(url) === '/ui/v1/sessions/status') statusCalls += 1;
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    onInitializeStarted({ windowObj }) {
+      visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0] || null;
+      if (!visibilityHandler) return;
+      windowObj.document.visibilityState = 'hidden';
+      void visibilityHandler({ type: 'visibilitychange' });
+      windowObj.document.visibilityState = 'visible';
+      void visibilityHandler({ type: 'visibilitychange' });
+    },
+  });
+
+  if (!visibilityHandler) {
+    releaseSessions();
+    await harnessPromise;
+    fail(name, 'expected visibilitychange listener during initialization');
+    return;
+  }
+  if (statusCalls !== 0) {
+    releaseSessions();
+    await harnessPromise;
+    fail(name, `pre-connected visibility started ${statusCalls} status requests`);
+    return;
+  }
+
+  releaseSessions();
+  const { app, windowObj } = await harnessPromise;
+  if (!app.state.connected || statusCalls !== 1) {
+    app.stopSidebarStatusPoll();
+    fail(name, 'initial merge did not start exactly one connected status poll', JSON.stringify({ connected: app.state.connected, statusCalls }));
+    return;
+  }
+
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+  if (statusCalls !== 2) {
+    app.stopSidebarStatusPoll();
+    fail(name, `later visibility change did not restart normal polling; got ${statusCalls} status requests`);
+    return;
+  }
+
+  app.stopSidebarStatusPoll();
   pass(name);
 }
 
@@ -2813,7 +3152,7 @@ async function testLateActiveRunSyncDoesNotMarkDraftStreaming() {
   const name = 'late active-run sync does not mark New Chat draft as streaming';
   const { app } = await createSessionsHarness({
     fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (url === '/ui/v1/sessions/sess_late_busy/state') {
@@ -4002,6 +4341,127 @@ async function testTerminalTranscriptSyncQueuesBehindInflightRequest() {
   pass(name);
 }
 
+async function testSatisfiedTerminalSyncDoesNotRefetchTranscript() {
+  const name = 'terminal force with a satisfied positive target is absorbed in flight';
+  let resolveFirst;
+  let indexRequests = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, 'satisfied-terminal-sync')) {
+        indexRequests += 1;
+        if (indexRequests === 1) {
+          return new Promise((resolve) => { resolveFirst = resolve; });
+        }
+        return new Response(null, { status: 304, headers: { ETag: '"terminal-2"' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+  const session = { id: 'satisfied-terminal-sync', messages: [] };
+  session.transcript = new windowObj.TranscriptStore(session.id);
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const activation = app.syncTranscript(session, { reason: 'activation' });
+  while (typeof resolveFirst !== 'function') await new Promise((resolve) => setTimeout(resolve, 0));
+  const terminal = app.noteTranscriptTerminal(session, 2);
+  resolveFirst(new Response(JSON.stringify({
+    rev: 2, compaction_seq: -1, compaction_count: 0,
+    rows: { ids: [], seqs: [], roles: '', flags: [] }
+  }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"terminal-2"' } }));
+
+  const [activationLoaded, terminalLoaded] = await Promise.all([activation, terminal]);
+  if (!activationLoaded || !terminalLoaded || session.transcript.rev !== 2) {
+    fail(name, 'the completed request did not satisfy the terminal target', JSON.stringify({ activationLoaded, terminalLoaded, rev: session.transcript.rev }));
+    return;
+  }
+  if (indexRequests !== 1) {
+    fail(name, `satisfied terminal target caused ${indexRequests} transcript index requests`);
+    return;
+  }
+  pass(name);
+}
+
+async function testUntargetedForceQueuesBehindInflightRequest() {
+  const name = 'force without a positive target still follows an in-flight request';
+  let resolveFirst;
+  let indexRequests = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, 'untargeted-force-sync')) {
+        indexRequests += 1;
+        if (indexRequests === 1) {
+          return new Promise((resolve) => { resolveFirst = resolve; });
+        }
+        return new Response(JSON.stringify({
+          rev: 1, compaction_seq: -1, compaction_count: 0,
+          rows: { ids: [], seqs: [], roles: '', flags: [] }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"untargeted-1"' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+  const session = { id: 'untargeted-force-sync', messages: [] };
+  session.transcript = new windowObj.TranscriptStore(session.id);
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const activation = app.syncTranscript(session, { reason: 'activation' });
+  while (typeof resolveFirst !== 'function') await new Promise((resolve) => setTimeout(resolve, 0));
+  const staleBodies = app.syncTranscript(session, { reason: 'stale-bodies', force: true, targetRev: 0 });
+  resolveFirst(new Response(JSON.stringify({
+    rev: 1, compaction_seq: -1, compaction_count: 0,
+    rows: { ids: [], seqs: [], roles: '', flags: [] }
+  }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"untargeted-1"' } }));
+
+  const [activationLoaded, staleBodiesLoaded] = await Promise.all([activation, staleBodies]);
+  if (!activationLoaded || !staleBodiesLoaded || indexRequests !== 2) {
+    fail(name, 'untargeted force was incorrectly absorbed', JSON.stringify({ activationLoaded, staleBodiesLoaded, indexRequests }));
+    return;
+  }
+  pass(name);
+}
+
+async function testForceScrollQueuesBehindSatisfiedInflightRequest() {
+  const name = 'forceScroll still follows an in-flight request with a satisfied target';
+  let resolveFirst;
+  let indexRequests = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, 'force-scroll-sync')) {
+        indexRequests += 1;
+        if (indexRequests === 1) {
+          return new Promise((resolve) => { resolveFirst = resolve; });
+        }
+        return new Response(null, { status: 304, headers: { ETag: '"force-scroll-1"' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  });
+  const session = { id: 'force-scroll-sync', messages: [] };
+  session.transcript = new windowObj.TranscriptStore(session.id);
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const activation = app.syncTranscript(session, { reason: 'activation' });
+  while (typeof resolveFirst !== 'function') await new Promise((resolve) => setTimeout(resolve, 0));
+  const forceScroll = app.syncTranscript(session, { reason: 'terminal-view', forceScroll: true, targetRev: 1 });
+  resolveFirst(new Response(JSON.stringify({
+    rev: 1, compaction_seq: -1, compaction_count: 0,
+    rows: { ids: [], seqs: [], roles: '', flags: [] }
+  }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"force-scroll-1"' } }));
+
+  const [activationLoaded, forceScrollLoaded] = await Promise.all([activation, forceScroll]);
+  if (!activationLoaded || !forceScrollLoaded || indexRequests !== 2) {
+    fail(name, 'forceScroll request was incorrectly absorbed', JSON.stringify({ activationLoaded, forceScrollLoaded, indexRequests }));
+    return;
+  }
+  pass(name);
+}
+
 async function testActiveStatusDefersInRunTranscriptRevisionsUntilTerminal() {
   const name = 'active status attaches at started_rev without reconciling in-run revisions';
   const fetchCalls = [];
@@ -4016,7 +4476,7 @@ async function testActiveStatusDefersInRunTranscriptRevisionsUntilTerminal() {
           rows: { ids: [], seqs: [], roles: '', flags: [] }
         }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"active-9"' } });
       }
-      if (String(url) === '/ui/v1/sessions') {
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions') {
         return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
@@ -4299,7 +4759,7 @@ async function testTranscriptSyncCommitsOneRenderedProjection() {
 }
 
 async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
-  const name = 'in-flight sync absorbs status target satisfied by its response';
+  const name = 'in-flight sync absorbs forced active-status target satisfied by its response';
   const sessionId = 'coalesced-revision-sync';
   let indexRequests = 0;
   let releaseFirstIndex;
@@ -4342,14 +4802,16 @@ async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   app.state.sessions = [session];
   app.state.activeSessionId = sessionId;
   app.state.draftSessionActive = false;
+  app.state.streaming = true;
 
   const activation = app.syncTranscript(session, { reason: 'activation' });
   await firstIndexStarted;
   const statusSync = app.reconcileTranscriptFromStatus([{
     id: sessionId,
-    transcript_rev: 2,
-    active_response_id: '',
-    started_rev: 0
+    transcript_rev: 9,
+    active_response_id: 'resp_inflight',
+    started_rev: 2,
+    active_run: true
   }]);
   releaseFirstIndex();
   const [loaded] = await Promise.all([activation, statusSync]);
@@ -4359,6 +4821,59 @@ async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   }
   if (indexRequests !== 1) {
     fail(name, `satisfied revision caused ${indexRequests} transcript index requests`);
+    return;
+  }
+  pass(name);
+}
+
+async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
+  const name = 'in-flight sync absorbs queued non-forced targetRev zero activation';
+  const sessionId = 'coalesced-zero-revision-sync';
+  let indexRequests = 0;
+  let releaseFirstIndex;
+  let markFirstIndexStarted;
+  const firstIndexStarted = new Promise((resolve) => { markFirstIndexStarted = resolve; });
+  const firstIndexGate = new Promise((resolve) => { releaseFirstIndex = resolve; });
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        indexRequests += 1;
+        if (indexRequests === 1) {
+          markFirstIndexStarted();
+          await firstIndexGate;
+          return new Response(JSON.stringify({
+            rev: 1,
+            compaction_seq: -1,
+            compaction_count: 0,
+            rows: { ids: [], seqs: [], roles: '', flags: [] }
+          }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"coalesced-zero-1"' } });
+        }
+        return new Response(null, { status: 304, headers: { ETag: '"coalesced-zero-1"' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+
+  const stateSync = app.syncTranscript(session, { reason: 'state', targetRev: 0 });
+  await firstIndexStarted;
+  const activationSync = app.syncTranscript(session, { reason: 'activation', targetRev: 0 });
+  releaseFirstIndex();
+  const [stateLoaded, activationLoaded] = await Promise.all([stateSync, activationSync]);
+
+  if (!stateLoaded || !activationLoaded || session.transcript.rev !== 1) {
+    fail(name, 'the completed request did not satisfy both zero-revision callers', JSON.stringify({ stateLoaded, activationLoaded, rev: session.transcript.rev }));
+    return;
+  }
+  if (indexRequests !== 1) {
+    fail(name, `queued targetRev=0 activation caused ${indexRequests} transcript index requests`);
     return;
   }
   pass(name);
@@ -4383,6 +4898,9 @@ async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   await testSwitchingSessionsDiscardsPendingAttachments();
   await testSwitchToSessionSyncsSelectedRuntime();
   await testNumericDeepLinkResolvesRealSessionId();
+  await testStartupSplashWaitsForDeepLinkedTranscriptRender();
+  await testStartupHydrationTimeoutDoesNotBlockIndefinitely();
+  await testUnresolvedNumericDeepLinkSkipsSessionScopedStartupRequests();
   await testNewQueryStartsDraftInsteadOfLastSession();
   await testNewQueryRefreshesHeaderAfterRuntimeMetadataLoads();
   await testMergeServerSessionsMigratesInterruptBuffersToRealSessionId();
@@ -4404,9 +4922,13 @@ async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   await testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalReconciliation();
   await testTranscriptSyncCommitsOneRenderedProjection();
   await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
+  await testInflightSyncAbsorbsQueuedZeroRevisionActivation();
   await testGroupedToolRowsPreserveDurableRangesAndLaterAnchors();
   await testLargeToolTurnLoadsAsOneSegmentWithFarEndGrouping();
   await testTerminalTranscriptSyncQueuesBehindInflightRequest();
+  await testSatisfiedTerminalSyncDoesNotRefetchTranscript();
+  await testUntargetedForceQueuesBehindInflightRequest();
+  await testForceScrollQueuesBehindSatisfiedInflightRequest();
   await testSwitchToSessionSyncsWithoutTokenAndResumes();
   await testSwitchToSessionAttachesChangedActiveResponseFromStartedRevision();
   await testActiveStatusDefersInRunTranscriptRevisionsUntilTerminal();
@@ -4418,6 +4940,7 @@ async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   await testSyncUsesServerProvidedPendingInterjectionId();
   await testApplyServerSessionSummaryMapsLastMessageAt();
   await testSanitizeSessionPreservesLastMessageAt();
+  await testPreConnectedVisibilityDoesNotStartSidebarStatusPoll();
   await testSidebarStatusPollRecoversIdempotentlyAfterPageShow();
   await testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus();
   await testReconnectBackoffWakeSignalsReuseExistingLoop();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -25,6 +25,14 @@ function pass(name) {
   console.log('PASS:', name);
 }
 
+async function waitFor(predicate, message, attempts = 50) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error(message || 'condition was not met');
+}
+
 function makeClassList() {
   const classes = new Set();
   return {
@@ -1286,6 +1294,487 @@ async function testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus
   pass(name);
 }
 
+async function testSidebarSwitchAppliesSelectedTranscriptBeforeAsyncStateAndSkills() {
+  const name = 'sidebar switch applies one selected transcript payload before asynchronous state and skills';
+  const fetchCalls = [];
+  const events = [];
+  let appRef = null;
+  let releaseState;
+  let releaseSkills;
+  let markStateStarted;
+  let markSkillsStarted;
+  const stateGate = new Promise((resolve) => { releaseState = resolve; });
+  const skillsGate = new Promise((resolve) => { releaseSkills = resolve; });
+  const stateStarted = new Promise((resolve) => { markStateStarted = resolve; });
+  const skillsStarted = new Promise((resolve) => { markSkillsStarted = resolve; });
+  let appliedDiff = null;
+  let appliedPlan = null;
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === 'sess_switch') {
+        events.push('selected');
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: {
+            id: 'sess_switch', short_title: 'Switch target', origin: 'web', created_at: 2,
+            message_count: 1, transcript_rev: 4,
+            file_change_summary: { file_count: 2, adds: 7, dels: 3 },
+            plan_summary: { completed: 2, total: 3 },
+          },
+          selected_transcript: startupTranscriptSideload({
+            rev: 4,
+            ids: [41],
+            messages: [{ id: 41, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'sideloaded switch' }] }],
+          }),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_switch/state') {
+        events.push('state');
+        markStateStarted();
+        await stateGate;
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 4 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (isTranscriptIndexURL(url, 'sess_switch')) {
+        events.push('transcript');
+        return new Response(JSON.stringify({
+          rev: 4, compaction_seq: -1, compaction_count: 0,
+          rows: { ids: [41], seqs: [0], roles: 'u', flags: [0] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"legacy-switch-4"' } });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_switch')) {
+        events.push('bodies');
+        return new Response(JSON.stringify({
+          rev: 4,
+          messages: [{ id: 41, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'legacy switch' }] }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: {
+      renderMessages() {
+        const visible = appRef?.state.sessions.find((item) => item.id === appRef.state.activeSessionId);
+        if (visible?.messages.some((message) => message.content === 'sideloaded switch')) events.push('render');
+      },
+      applySessionDiffSummary(sessionId, summary) { appliedDiff = { sessionId, summary }; },
+      applyCurrentPlanSummary(sessionId, summary) { appliedPlan = { sessionId, summary }; },
+      async refreshSkillCommands(sessionId) {
+        if (sessionId !== 'sess_switch') return [];
+        events.push('skills');
+        markSkillsStarted();
+        await skillsGate;
+        return [];
+      },
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
+  });
+  app.stopSidebarStatusPoll();
+  const previous = { id: 'sess_previous', title: 'Previous', messages: [], created: 1 };
+  const target = { id: 'sess_switch', title: 'Switch target', messages: [], created: 2, _serverOnly: true };
+  app.state.sessions = [previous, target];
+  app.state.activeSessionId = previous.id;
+  app.state.draftSessionActive = false;
+  fetchCalls.length = 0;
+  events.length = 0;
+
+  const switching = app.switchToSession(target.id, { closeSidebar: false });
+  await stateStarted;
+  const completedBeforeState = await Promise.race([
+    switching.then(() => true),
+    new Promise((resolve) => setImmediate(() => resolve(false))),
+  ]);
+  releaseState();
+  await skillsStarted;
+  const completedBeforeSkills = await Promise.race([
+    switching.then(() => true),
+    new Promise((resolve) => setImmediate(() => resolve(false))),
+  ]);
+  releaseSkills();
+  await switching;
+  const completedBeforeStateAndSkills = completedBeforeState && completedBeforeSkills;
+
+  const selectedRequests = fetchCalls.filter((url) => {
+    const parsed = parsedTestURL(url);
+    return parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === target.id;
+  });
+  const selectedURL = parsedTestURL(selectedRequests[0]);
+  const transcriptRequests = fetchCalls.filter((url) => isTranscriptIndexURL(url, target.id) || isTranscriptBodiesURL(url, target.id));
+  if (selectedRequests.length !== 1
+      || selectedURL?.searchParams.get('selected_only') !== '1'
+      || selectedURL?.searchParams.get('include_transcript') !== '1'
+      || transcriptRequests.length !== 0) {
+    fail(name, 'switch did not use exactly one selected-only transcript payload', JSON.stringify(fetchCalls));
+    return;
+  }
+  if (!completedBeforeStateAndSkills || events.indexOf('render') < 0
+      || events.indexOf('render') > events.indexOf('state') || events.indexOf('render') > events.indexOf('skills')) {
+    fail(name, 'visible transcript remained coupled to runtime state or skills', JSON.stringify({ completedBeforeStateAndSkills, events }));
+    return;
+  }
+  if (target.messages[0]?.content !== 'sideloaded switch' || target.transcript?.rev !== 4) {
+    fail(name, 'selected transcript was not applied to the canonical target', JSON.stringify(target.messages));
+    return;
+  }
+  if (appliedDiff?.sessionId !== target.id || appliedDiff.summary?.file_count !== 2
+      || appliedPlan?.sessionId !== target.id || appliedPlan.summary?.completed !== 2) {
+    fail(name, 'selected diff or plan summary was lost', JSON.stringify({ appliedDiff, appliedPlan }));
+    return;
+  }
+  pass(name);
+}
+
+async function testRapidSidebarSwitchRejectsStaleSelectedTranscriptAndState() {
+  const name = 'rapid sidebar switch rejects stale selected transcript and runtime state';
+  const fetchCalls = [];
+  const stateSessions = [];
+  const skillSessions = [];
+  let releaseA;
+  let markAStarted;
+  const aGate = new Promise((resolve) => { releaseA = resolve; });
+  const aStarted = new Promise((resolve) => { markAStarted = resolve; });
+  const selectedPayload = (id, rev, text) => ({
+    sessions: [],
+    selected_session: { id, short_title: id, origin: 'web', created_at: rev, message_count: 1, transcript_rev: rev },
+    selected_transcript: startupTranscriptSideload({
+      rev,
+      ids: [rev],
+      messages: [{ id: rev, sequence: 0, role: 'user', parts: [{ type: 'text', text }] }],
+    }),
+  });
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === 'sess_a') {
+        markAStarted();
+        await aGate;
+        return new Response(JSON.stringify(selectedPayload('sess_a', 1, 'stale A')), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === 'sess_b') {
+        return new Response(JSON.stringify(selectedPayload('sess_b', 2, 'current B')), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_a/state' || parsed?.pathname === '/ui/v1/sessions/sess_b/state') {
+        const id = parsed.pathname.includes('sess_a') ? 'sess_a' : 'sess_b';
+        stateSessions.push(id);
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: id === 'sess_a' ? 1 : 2 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: {
+      async refreshSkillCommands(sessionId) {
+        skillSessions.push(String(sessionId || ''));
+        return [];
+      },
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const previous = { id: 'sess_previous', title: 'Previous', messages: [], created: 0 };
+  const sessionA = { id: 'sess_a', title: 'A', messages: [], created: 1, _serverOnly: true };
+  const sessionB = { id: 'sess_b', title: 'B', messages: [], created: 2, _serverOnly: true };
+  app.state.sessions = [previous, sessionA, sessionB];
+  app.state.activeSessionId = previous.id;
+  app.state.draftSessionActive = false;
+  fetchCalls.length = 0;
+  skillSessions.length = 0;
+
+  const switchA = app.switchToSession(sessionA.id, { closeSidebar: false });
+  await aStarted;
+  const switchB = app.switchToSession(sessionB.id, { closeSidebar: false });
+  await switchB;
+  await waitFor(() => stateSessions.includes('sess_b') && skillSessions.includes('sess_b'), 'current switch hydration did not start');
+  releaseA();
+  await switchA;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  if (app.state.activeSessionId !== sessionB.id || sessionB.messages[0]?.content !== 'current B') {
+    fail(name, 'current B sideload did not remain selected', JSON.stringify({ active: app.state.activeSessionId, messages: sessionB.messages }));
+    return;
+  }
+  if (sessionA.messages.some((message) => message.content === 'stale A') || Number(sessionA.transcript?.rev || 0) !== 0) {
+    fail(name, 'stale A sideload mutated its transcript after B won', JSON.stringify({ messages: sessionA.messages, rev: sessionA.transcript?.rev }));
+    return;
+  }
+  if (stateSessions.includes('sess_a') || skillSessions.includes('sess_a')) {
+    fail(name, 'stale A runtime hydration started after B won', JSON.stringify({ stateSessions, skillSessions }));
+    return;
+  }
+  const transcriptRequests = fetchCalls.filter((url) => /\/transcript(?:\/bodies)?(?:\?|$)/.test(String(url)));
+  if (transcriptRequests.length !== 0) {
+    fail(name, 'valid rapid-switch sideloads used transcript endpoints', JSON.stringify(transcriptRequests));
+    return;
+  }
+  pass(name);
+}
+
+async function testRapidSidebarSwitchRejectsLateRuntimeResponse() {
+  const name = 'rapid sidebar switch rejects late runtime response from the previous selection';
+  let releaseAState;
+  let markAStateStarted;
+  const aStateGate = new Promise((resolve) => { releaseAState = resolve; });
+  const aStateStarted = new Promise((resolve) => { markAStateStarted = resolve; });
+  const openedPrompts = [];
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions/sess_runtime_a/state') {
+        markAStateStarted();
+        await aStateGate;
+        return new Response(JSON.stringify({
+          active_run: false,
+          provider: 'stale-provider',
+          model: 'stale-model',
+          transcript_rev: 0,
+          pending_ask_user: { call_id: 'stale-call', questions: [{ question: 'stale?' }] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ active_run: false, transcript_rev: 0 }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: {
+      openAskUserModal(sessionId) { openedPrompts.push(sessionId); },
+      async refreshSkillCommands() { return []; },
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const previous = { id: 'previous', messages: [], created: 0 };
+  const sessionA = { id: 'sess_runtime_a', messages: [{ id: 'a', role: 'user', content: 'A' }], provider: 'provider-a', created: 1 };
+  const sessionB = { id: 'sess_runtime_b', messages: [{ id: 'b', role: 'user', content: 'B' }], provider: 'provider-b', created: 2 };
+  app.state.sessions = [previous, sessionA, sessionB];
+  app.state.activeSessionId = previous.id;
+  app.state.draftSessionActive = false;
+
+  await app.switchToSession(sessionA.id, { closeSidebar: false });
+  await aStateStarted;
+  await app.switchToSession(sessionB.id, { sync: false, closeSidebar: false });
+  releaseAState();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  if (app.state.activeSessionId !== sessionB.id || sessionB.provider !== 'provider-b'
+      || sessionA.provider !== 'provider-a' || openedPrompts.length !== 0) {
+    fail(name, 'late A runtime state leaked after B became current', JSON.stringify({ active: app.state.activeSessionId, sessionA, sessionB, openedPrompts }));
+    return;
+  }
+  pass(name);
+}
+
+async function testSidebarSwitchMalformedSideloadFallsBackExactlyOnce() {
+  const name = 'sidebar switch malformed sideload falls back to transcript index and bodies exactly once';
+  const order = [];
+  let indexRequests = 0;
+  let bodyRequests = 0;
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === 'sess_fallback') {
+        order.push('selected');
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: { id: 'sess_fallback', short_title: 'Fallback', origin: 'web', created_at: 1, message_count: 1, transcript_rev: 3 },
+          selected_transcript: { index_etag: '"bad"', index: { rev: 3, rows: { ids: [31], seqs: [], roles: 'u', flags: [0] } }, bodies: { rev: 3, messages: [] } },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTranscriptIndexURL(url, 'sess_fallback')) {
+        indexRequests += 1;
+        order.push('index');
+        return new Response(JSON.stringify({
+          rev: 3, compaction_seq: -1, compaction_count: 0,
+          rows: { ids: [31], seqs: [0], roles: 'u', flags: [0] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"fallback-3"' } });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_fallback')) {
+        bodyRequests += 1;
+        order.push('bodies');
+        return new Response(JSON.stringify({
+          rev: 3,
+          messages: [{ id: 31, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'fallback once' }] }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_fallback/state') {
+        order.push('state');
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 3 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: { async refreshSkillCommands() { return []; } },
+  });
+  app.stopSidebarStatusPoll();
+  const target = { id: 'sess_fallback', title: 'Fallback', messages: [], created: 1, _serverOnly: true };
+  app.state.sessions = [{ id: 'previous', messages: [], created: 0 }, target];
+  app.state.activeSessionId = 'previous';
+  app.state.draftSessionActive = false;
+
+  await app.switchToSession(target.id, { closeSidebar: false });
+  await waitFor(() => order.includes('state'), 'fallback state hydration did not start');
+  if (indexRequests !== 1 || bodyRequests !== 1 || target.messages[0]?.content !== 'fallback once') {
+    fail(name, 'fallback request count or projection was incorrect', JSON.stringify({ indexRequests, bodyRequests, messages: target.messages }));
+    return;
+  }
+  if (JSON.stringify(order.slice(0, 4)) !== JSON.stringify(['selected', 'index', 'bodies', 'state'])) {
+    fail(name, 'fallback did not finish rendering before asynchronous state', JSON.stringify(order));
+    return;
+  }
+  pass(name);
+}
+
+async function testSidebarSwitchActiveSideloadReconcilesNewerStartedRevision() {
+  const name = 'sidebar active sideload reconciles a newer started revision before resuming';
+  const order = [];
+  const resumeCalls = [];
+  let indexRequests = 0;
+  let bodyRequests = 0;
+  let appRef = null;
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions' && parsed.searchParams.get('selected_session') === 'sess_active_switch') {
+        order.push('selected');
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: { id: 'sess_active_switch', short_title: 'Active', origin: 'web', created_at: 1, message_count: 2, transcript_rev: 6 },
+          selected_transcript: startupTranscriptSideload({
+            rev: 4,
+            ids: [41],
+            messages: [{ id: 41, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'ready at four' }] }],
+            activeResponseId: 'resp_old',
+            startedRev: 4,
+          }),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_active_switch/state') {
+        order.push('state');
+        return new Response(JSON.stringify({
+          active_run: true, active_response_id: 'resp_new', started_rev: 5, transcript_rev: 6,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTranscriptIndexURL(url, 'sess_active_switch')) {
+        indexRequests += 1;
+        order.push('index');
+        return new Response(JSON.stringify({
+          rev: 5, compaction_seq: -1, compaction_count: 0,
+          active_response_id: 'resp_new', started_rev: 5,
+          rows: { ids: [41, 42], seqs: [0, 1], roles: 'uu', flags: [0, 0] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"active-switch-5"' } });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_active_switch')) {
+        bodyRequests += 1;
+        order.push('bodies');
+        return new Response(JSON.stringify({
+          rev: 5,
+          messages: [
+            { id: 41, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'ready at four' }] },
+            { id: 42, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'started at five' }] },
+          ],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: {
+      renderMessages() {
+        const target = appRef?.state.sessions.find((item) => item.id === 'sess_active_switch');
+        if (target?.messages.some((message) => message.content === 'ready at four')) order.push('render');
+      },
+      async resumeActiveResponse(session, options = {}) {
+        order.push('resume');
+        resumeCalls.push({ sessionId: session.id, responseId: options.responseId });
+      },
+      async refreshSkillCommands() { return []; },
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
+  });
+  app.stopSidebarStatusPoll();
+  const target = { id: 'sess_active_switch', title: 'Active', messages: [], created: 1, _serverOnly: true };
+  app.state.sessions = [{ id: 'previous', messages: [], created: 0 }, target];
+  app.state.activeSessionId = 'previous';
+  app.state.draftSessionActive = false;
+  order.length = 0;
+
+  await app.switchToSession(target.id, { closeSidebar: false });
+  await waitFor(() => resumeCalls.length > 0, 'newer active response was not resumed');
+  if (indexRequests !== 1 || bodyRequests !== 1 || target.transcript?.rev !== 5) {
+    fail(name, 'newer started revision did not reconcile exactly once', JSON.stringify({ indexRequests, bodyRequests, rev: target.transcript?.rev }));
+    return;
+  }
+  if (resumeCalls.length !== 1 || resumeCalls[0].responseId !== 'resp_new'
+      || order.indexOf('render') < 0 || order.indexOf('render') > order.indexOf('state')
+      || order.indexOf('bodies') > order.indexOf('resume')) {
+    fail(name, 'active response ordering was incorrect', JSON.stringify({ order, resumeCalls }));
+    return;
+  }
+  pass(name);
+}
+
+async function testSidebarSwitchSkipsLoadedAndUnresolvedSessionRequests() {
+  const name = 'sidebar switch skips selected and scoped requests for loaded live and unresolved sessions';
+  const fetchCalls = [];
+  const { app } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: { async refreshSkillCommands() { return []; } },
+  });
+  app.stopSidebarStatusPoll();
+  const previous = { id: 'previous', messages: [], created: 0 };
+  const loaded = {
+    id: 'sess_loaded', messages: [{ id: 'live', role: 'assistant', content: 'already live' }], created: 1,
+    activeResponseId: 'resp_live',
+  };
+  const unresolved = { id: '1291', number: 1291, messages: [], created: 2, _serverOnly: true };
+  app.state.sessions = [previous, loaded, unresolved];
+  app.state.activeSessionId = previous.id;
+  app.state.draftSessionActive = false;
+  fetchCalls.length = 0;
+
+  await app.switchToSession(loaded.id, { sync: false, closeSidebar: false });
+  await new Promise((resolve) => setImmediate(resolve));
+  const loadedCalls = fetchCalls.slice();
+  await app.switchToSession(unresolved.id, { closeSidebar: false });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  if (loadedCalls.length !== 0) {
+    fail(name, 'already-loaded live session refetched during selection', JSON.stringify(loadedCalls));
+    return;
+  }
+  const unresolvedScoped = fetchCalls.filter((url) => String(url).includes('/v1/sessions/1291/'));
+  if (unresolvedScoped.length !== 0) {
+    fail(name, 'unresolved numeric identity reached a session-scoped endpoint', JSON.stringify(unresolvedScoped));
+    return;
+  }
+  pass(name);
+}
+
 async function testStartupSplashWaitsForDeepLinkedTranscriptRender() {
   const name = 'fallback transcript render reveals startup before delayed state and skills';
   const events = [];
@@ -2461,6 +2950,7 @@ async function testSwitchToSessionSyncsWithoutTokenAndResumes() {
   });
 
   await app.switchToSession('sess_resume');
+  await waitFor(() => resumeCalls.length > 0, 'sidebar state hydration did not resume active response');
 
   if (!fetchCalls.includes('/ui/v1/sessions/sess_resume/state')) {
     fail(name, 'expected session switch to fetch runtime state without a token', JSON.stringify(fetchCalls));
@@ -2599,6 +3089,7 @@ async function testSwitchToSessionAttachesChangedActiveResponseFromStartedRevisi
   resumeCalls.length = 0;
 
   await app.switchToSession('sess_resume');
+  await waitFor(() => resumeCalls.length > 0, 'changed active response did not resume after asynchronous state hydration');
 
   if (resumeCalls.length !== 1) {
     fail(name, 'expected session switch to trigger exactly one resume', JSON.stringify(resumeCalls));
@@ -5511,6 +6002,12 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testMalformedStartupTranscriptSideloadFallsBack();
   await testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision();
   await testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus();
+  await testSidebarSwitchAppliesSelectedTranscriptBeforeAsyncStateAndSkills();
+  await testRapidSidebarSwitchRejectsStaleSelectedTranscriptAndState();
+  await testRapidSidebarSwitchRejectsLateRuntimeResponse();
+  await testSidebarSwitchMalformedSideloadFallsBackExactlyOnce();
+  await testSidebarSwitchActiveSideloadReconcilesNewerStartedRevision();
+  await testSidebarSwitchSkipsLoadedAndUnresolvedSessionRequests();
   await testStartupSplashWaitsForDeepLinkedTranscriptRender();
   await testStartupSideloadsWidgetsBeforeFirstPaint();
   await testStartupSideloadsEmptyWidgetList();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -145,6 +145,25 @@ function isTranscriptBodiesURL(url, sessionId) {
   return Boolean(parsed && parsed.pathname === `/ui/v1/sessions/${sessionId}/transcript/bodies`);
 }
 
+function startupTranscriptSideload({ rev, ids, messages, etag = `\"startup-${rev}\"`, activeResponseId = '', startedRev = 0 }) {
+  return {
+    index_etag: etag,
+    index: {
+      rev,
+      compaction_seq: -1,
+      compaction_count: 0,
+      ...(activeResponseId ? { active_response_id: activeResponseId, started_rev: startedRev } : {}),
+      rows: {
+        ids,
+        seqs: ids.map((_, index) => index),
+        roles: 'u'.repeat(ids.length),
+        flags: ids.map(() => 0),
+      },
+    },
+    bodies: { rev, messages },
+  };
+}
+
 function isSessionMessagesURL(url, sessionId) {
   const parsed = parsedTestURL(url);
   return Boolean(parsed && parsed.pathname === `/ui/v1/sessions/${sessionId}/messages`);
@@ -906,6 +925,288 @@ async function testNumericDeepLinkResolvesRealSessionId() {
     fail(name, 'durable transcript bodies must not be written to localStorage', JSON.stringify([...storage.entries()]));
     return;
   }
+  pass(name);
+}
+
+async function testIdleStartupSchedulesNormalPollWithoutImmediateRequest() {
+  const name = 'idle startup schedules normal poll delay without immediate status request';
+  const scheduled = [];
+  let statusRequests = 0;
+  const { app } = await createSessionsHarness({
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) { if (handle) handle.cleared = true; },
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions/status') statusRequests += 1;
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({ sessions: [], selected_session: null, widget_status: { widgets: [] } }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+  });
+  const pollTimers = scheduled.filter((handle) => !handle.cleared && handle.delay >= 2000);
+  if (statusRequests !== 0 || pollTimers.length !== 1 || pollTimers[0].delay !== 30000) {
+    fail(name, 'idle startup did not arm exactly one normal idle timer', JSON.stringify({ statusRequests, timers: pollTimers.map(({ delay }) => delay) }));
+    return;
+  }
+  app.stopSidebarStatusPoll();
+  pass(name);
+}
+
+async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTranscriptRequests() {
+  const name = 'startup transcript sideload renders bounded first paint with zero transcript requests';
+  const ids = Array.from({ length: 20 }, (_, index) => index + 1);
+  const messages = ids.slice(-9).map((id) => ({
+    id,
+    sequence: id - 1,
+    role: 'user',
+    created_at: id * 1000,
+    parts: [{ type: 'text', text: `turn-${id}` }],
+  }));
+  const fetchCalls = [];
+  const events = [];
+  const scheduled = [];
+  let appRef = null;
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/3347',
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) { if (handle) handle.cleared = true; },
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: {
+            id: 'sess_3347', number: 3347, short_title: 'Sideloaded', long_title: 'Sideloaded',
+            mode: 'chat', origin: 'web', created_at: 1000, message_count: ids.length, transcript_rev: 20,
+          },
+          selected_transcript: startupTranscriptSideload({ rev: 20, ids, messages }),
+          widget_status: { widgets: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_3347/state') {
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 20 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+    appOverrides: {
+      renderMessages() {
+        const session = appRef?.state.sessions.find((item) => item.id === 'sess_3347');
+        events.push({ type: 'render', contents: session?.messages.map((message) => message.content) || [] });
+      },
+      hideStartupSplash() { events.push({ type: 'splash' }); },
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; },
+  });
+
+  const startupURL = fetchCalls.find((url) => parsedTestURL(url)?.pathname === '/ui/v1/sessions');
+  if (parsedTestURL(startupURL)?.searchParams.get('include_transcript') !== '1') {
+    fail(name, 'selected startup request did not opt into transcript sideload', startupURL);
+    return;
+  }
+  const transcriptRequests = fetchCalls.filter((url) => isTranscriptIndexURL(url, 'sess_3347') || isTranscriptBodiesURL(url, 'sess_3347'));
+  if (transcriptRequests.length !== 0) {
+    fail(name, 'valid sideload issued transcript endpoint requests', JSON.stringify(transcriptRequests));
+    return;
+  }
+  const session = app.state.sessions.find((item) => item.id === 'sess_3347');
+  const hydratedRender = events.findIndex((event) => event.type === 'render'
+    && event.contents.filter((content) => typeof content === 'string').length === 9);
+  const splash = events.findIndex((event) => event.type === 'splash');
+  if (!session || hydratedRender < 0 || splash <= hydratedRender) {
+    fail(name, 'bounded sideload was not rendered atomically before splash hide', JSON.stringify(events));
+    return;
+  }
+  if (session.transcript.rev !== 20 || session.transcript.bodies.size !== 9
+      || session.transcript.segments.filter((segment) => segment.state === 'materialized').length !== 9) {
+    fail(name, 'sideload did not preserve the initial viewport budget', JSON.stringify({ rev: session.transcript.rev, bodies: session.transcript.bodies.size, segments: session.transcript.segments }));
+    return;
+  }
+  const statusRequests = fetchCalls.filter((url) => parsedTestURL(url)?.pathname === '/ui/v1/sessions/status');
+  const liveTimers = scheduled.filter((handle) => !handle.cleared && handle.delay >= 2000);
+  if (statusRequests.length !== 0 || liveTimers.length !== 1 || liveTimers[0].delay !== 5000) {
+    fail(name, 'startup did not arm the normal visible-active-session poll delay', JSON.stringify({ statusRequests, liveTimers: liveTimers.map(({ delay }) => delay) }));
+    return;
+  }
+  app.stopSidebarStatusPoll();
+  pass(name);
+}
+
+async function testMalformedStartupTranscriptSideloadFallsBack() {
+  const name = 'malformed startup transcript sideload falls back to index and bodies';
+  let indexRequests = 0;
+  let bodyRequests = 0;
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/41',
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        const malformed = startupTranscriptSideload({
+          rev: 2,
+          ids: [1, 2],
+          messages: [{ id: 1, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'fallback' }] }],
+        });
+        malformed.bodies.rev = 1;
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: { id: 'sess_41', number: 41, short_title: 'Fallback', origin: 'web', created_at: 1, transcript_rev: 2 },
+          selected_transcript: malformed,
+          widget_status: { widgets: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTranscriptIndexURL(url, 'sess_41')) {
+        indexRequests += 1;
+        return new Response(JSON.stringify({ rev: 2, compaction_seq: -1, compaction_count: 0, rows: { ids: [1], seqs: [0], roles: 'u', flags: [0] } }), {
+          status: 200, headers: { 'Content-Type': 'application/json', ETag: '"fallback-2"' },
+        });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_41')) {
+        bodyRequests += 1;
+        return new Response(JSON.stringify({ rev: 2, messages: [{ id: 1, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'fallback' }] }] }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_41/state') {
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 2 }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const session = app.state.sessions.find((item) => item.id === 'sess_41');
+  if (indexRequests !== 1 || bodyRequests !== 1 || session?.messages[0]?.content !== 'fallback') {
+    fail(name, 'fallback did not use the existing activation path', JSON.stringify({ indexRequests, bodyRequests, messages: session?.messages }));
+    return;
+  }
+  pass(name);
+}
+
+async function testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision() {
+  const name = 'startup transcript sideload refreshes only when concurrent state revision is newer';
+  let indexRequests = 0;
+  let bodyRequests = 0;
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/52',
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: { id: 'sess_52', number: 52, short_title: 'Race', origin: 'web', created_at: 1, transcript_rev: 2 },
+          selected_transcript: startupTranscriptSideload({
+            rev: 2,
+            ids: [1, 2],
+            messages: [
+              { id: 1, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'one' }] },
+              { id: 2, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'two' }] },
+            ],
+          }),
+          widget_status: { widgets: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_52/state') {
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 3 }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTranscriptIndexURL(url, 'sess_52')) {
+        indexRequests += 1;
+        return new Response(JSON.stringify({ rev: 3, compaction_seq: -1, compaction_count: 0, rows: { ids: [1, 2, 3], seqs: [0, 1, 2], roles: 'uuu', flags: [0, 0, 0] } }), {
+          status: 200, headers: { 'Content-Type': 'application/json', ETag: '"race-3"' },
+        });
+      }
+      if (isTranscriptBodiesURL(url, 'sess_52')) {
+        bodyRequests += 1;
+        return new Response(JSON.stringify({
+          rev: 3,
+          messages: [1, 2, 3].map((id) => ({ id, sequence: id - 1, role: 'user', parts: [{ type: 'text', text: String(id) }] })),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const session = app.state.sessions.find((item) => item.id === 'sess_52');
+  if (indexRequests !== 1 || bodyRequests !== 1 || session?.transcript.rev !== 3 || session?.messages.at(-1)?.content !== '3') {
+    fail(name, 'newer state revision was lost or fetched redundantly', JSON.stringify({ indexRequests, bodyRequests, rev: session?.transcript.rev, messages: session?.messages }));
+    return;
+  }
+  pass(name);
+}
+
+async function testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus() {
+  const name = 'scheduled status reconciliation does not duplicate startup state for sideloaded active run';
+  const scheduled = [];
+  let stateRequests = 0;
+  let statusRequests = 0;
+  const { app } = await createSessionsHarness({
+    pathname: '/ui/63',
+    setTimeout(fn, delay) {
+      const handle = { fn, delay, cleared: false };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeout(handle) { if (handle) handle.cleared = true; },
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === '/ui/v1/sessions') {
+        return new Response(JSON.stringify({
+          sessions: [],
+          selected_session: { id: 'sess_63', number: 63, short_title: 'Active', origin: 'web', created_at: 1, transcript_rev: 5 },
+          selected_transcript: startupTranscriptSideload({
+            rev: 5,
+            ids: [1],
+            messages: [{ id: 1, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'active' }] }],
+            activeResponseId: 'resp_63',
+            startedRev: 5,
+          }),
+          widget_status: { widgets: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/sess_63/state') {
+        stateRequests += 1;
+        return new Response(JSON.stringify({ active_run: true, active_response_id: 'resp_63', started_rev: 5, transcript_rev: 6 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsed?.pathname === '/ui/v1/sessions/status') {
+        statusRequests += 1;
+        return new Response(JSON.stringify({ sessions: [{ id: 'sess_63', active_response_id: 'resp_63', started_rev: 5, transcript_rev: 6 }] }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    },
+  });
+
+  if (stateRequests !== 1 || statusRequests !== 0) {
+    fail(name, 'startup issued immediate status or duplicate state request', JSON.stringify({ stateRequests, statusRequests }));
+    return;
+  }
+  const firstPoll = scheduled.find((handle) => !handle.cleared && handle.delay === 2000);
+  if (!firstPoll) {
+    fail(name, 'active startup did not arm normal active poll delay', JSON.stringify(scheduled.map(({ delay, cleared }) => ({ delay, cleared }))));
+    return;
+  }
+  firstPoll.cleared = true;
+  await firstPoll.fn();
+  await Promise.resolve();
+  if (statusRequests !== 1 || stateRequests !== 1) {
+    fail(name, 'status reconciliation duplicated selected-session state', JSON.stringify({ stateRequests, statusRequests }));
+    return;
+  }
+  app.stopSidebarStatusPoll();
   pass(name);
 }
 
@@ -2821,9 +3122,9 @@ async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
 
   releaseSessions();
   const { app, windowObj } = await harnessPromise;
-  if (!app.state.connected || statusCalls !== 1) {
+  if (!app.state.connected || statusCalls !== 0) {
     app.stopSidebarStatusPoll();
-    fail(name, 'initial merge did not start exactly one connected status poll', JSON.stringify({ connected: app.state.connected, statusCalls }));
+    fail(name, 'initial authoritative merge should only schedule status polling', JSON.stringify({ connected: app.state.connected, statusCalls }));
     return;
   }
 
@@ -2831,9 +3132,9 @@ async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
   await visibilityHandler({ type: 'visibilitychange' });
   windowObj.document.visibilityState = 'visible';
   await visibilityHandler({ type: 'visibilitychange' });
-  if (statusCalls !== 2) {
+  if (statusCalls !== 1) {
     app.stopSidebarStatusPoll();
-    fail(name, `later visibility change did not restart normal polling; got ${statusCalls} status requests`);
+    fail(name, `later visibility recovery did not poll immediately; got ${statusCalls} status requests`);
     return;
   }
 
@@ -2885,17 +3186,17 @@ async function testPageshowWaitsForInitialConnectionBeforeStatusPoll() {
 
   releaseSessions();
   const { app } = await harnessPromise;
-  if (!app.state.connected || statusCalls !== 1) {
+  if (!app.state.connected || statusCalls !== 0) {
     app.stopSidebarStatusPoll();
-    fail(name, 'initial merge did not start exactly one connected status poll', JSON.stringify({ connected: app.state.connected, statusCalls }));
+    fail(name, 'initial authoritative merge should only schedule status polling', JSON.stringify({ connected: app.state.connected, statusCalls }));
     return;
   }
 
   await app.stopSidebarStatusPoll();
   pageshowHandler({ type: 'pageshow', persisted: true });
-  if (statusCalls !== 2) {
+  if (statusCalls !== 1) {
     app.stopSidebarStatusPoll();
-    fail(name, `connected BFCache pageshow did not restart normal polling; got ${statusCalls} status requests`);
+    fail(name, `connected BFCache pageshow did not recover immediately; got ${statusCalls} status requests`);
     return;
   }
 
@@ -3041,7 +3342,7 @@ async function testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus()
     fetchImpl: async (url) => {
       if (url === '/ui/v1/sessions/status') {
         statusCalls += 1;
-        if (statusCalls > 1) {
+        if (statusCalls >= 1) {
           return new Promise((resolve) => {
             resolveStatus = () => resolve(new Response(JSON.stringify({
               sessions: [{ id: 'stale_session', short_title: 'Stale' }],
@@ -5119,6 +5420,11 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testSwitchingSessionsDiscardsPendingAttachments();
   await testSwitchToSessionSyncsSelectedRuntime();
   await testNumericDeepLinkResolvesRealSessionId();
+  await testIdleStartupSchedulesNormalPollWithoutImmediateRequest();
+  await testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTranscriptRequests();
+  await testMalformedStartupTranscriptSideloadFallsBack();
+  await testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision();
+  await testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus();
   await testStartupSplashWaitsForDeepLinkedTranscriptRender();
   await testStartupSideloadsWidgetsBeforeFirstPaint();
   await testStartupSideloadsEmptyWidgetList();

--- a/internal/serveui/static/app_worktrees_test.js
+++ b/internal/serveui/static/app_worktrees_test.js
@@ -83,8 +83,7 @@ function flushAsync() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-async function testActiveRootOpensStableResponsiveMenu() {
-  const name = 'active root chip opens a stable responsive worktree menu';
+function makeHarness(options = {}) {
   const documentListeners = {};
   const body = makeNode('body');
   const trigger = makeNode('button');
@@ -94,12 +93,13 @@ async function testActiveRootOpensStableResponsiveMenu() {
   backdrop.hidden = true;
   const positionCalls = [];
   const windowListeners = {};
+  const session = options.session || { id: 'session-root', worktreeDir: '' };
   const state = {
-    activeSessionId: 'session-root',
-    draftSessionActive: false,
-    selectedWorktreeDir: '',
-    selectedWorktreeName: '',
-    sessions: [{ id: 'session-root', worktreeDir: '' }],
+    activeSessionId: session.id,
+    draftSessionActive: Boolean(options.draftSessionActive),
+    selectedWorktreeDir: options.selectedWorktreeDir || '',
+    selectedWorktreeName: options.selectedWorktreeName || '',
+    sessions: [session],
     worktrees: [],
   };
   const elements = {
@@ -117,6 +117,7 @@ async function testActiveRootOpensStableResponsiveMenu() {
     },
   };
   const windowObj = {
+    TERM_LLM_WORKTREES_ENABLED: options.enabled === true,
     TermLLMApp: {
       UI_PREFIX: '/chat',
       state,
@@ -129,21 +130,25 @@ async function testActiveRootOpensStableResponsiveMenu() {
       (windowListeners[type] = windowListeners[type] || []).push(listener);
     },
     visualViewport: null,
-    prompt: () => null,
+    prompt: options.prompt || (() => null),
     alert() {},
     confirm: () => false,
   };
-  const fetch = async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({
-      worktrees: [
-        { root: true, name: 'root', dir: '/repo' },
-        { name: 'feature', dir: '/repo-worktrees/feature', branch: 'feature', dirty_files: 2 },
-      ],
-    }),
-    text: async () => '',
-  });
+  let worktreeRequests = 0;
+  const fetch = async () => {
+    worktreeRequests += 1;
+    return ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        worktrees: [
+          { root: true, name: 'root', dir: '/repo' },
+          { name: 'feature', dir: '/repo-worktrees/feature', branch: 'feature', dirty_files: 2 },
+        ],
+      }),
+      text: async () => '',
+    });
+  };
   const context = {
     window: windowObj,
     document,
@@ -154,18 +159,52 @@ async function testActiveRootOpensStableResponsiveMenu() {
   };
   context.globalThis = context;
   vm.runInNewContext(source, context, { filename: 'app-worktrees.js' });
+  return {
+    app: windowObj.TermLLMApp,
+    backdrop,
+    body,
+    documentListeners,
+    elements,
+    label,
+    positionCalls,
+    trigger,
+    windowListeners,
+    get worktreeRequests() { return worktreeRequests; },
+  };
+}
+
+async function testGitCapabilityRendersAndLoadsLazily() {
+  const name = 'git bootstrap renders immediately and keeps worktree list lazy';
+  const harness = makeHarness({ enabled: true });
   await flushAsync();
 
-  const clickListener = trigger.listeners.click && trigger.listeners.click[0];
+  if (harness.worktreeRequests !== 0) {
+    fail(name, `startup issued ${harness.worktreeRequests} unconditional worktree request(s)`);
+    return;
+  }
+  if (harness.elements.chipWorktree.hidden || harness.elements.chipSepEffortWorktree.hidden) {
+    fail(name, 'explicit git capability did not render the worktree control immediately');
+    return;
+  }
+  if (harness.label.textContent !== 'root' || harness.trigger.title !== 'Manage worktrees') {
+    fail(name, `root chip rendered label/title ${JSON.stringify(harness.label.textContent)}/${JSON.stringify(harness.trigger.title)}`);
+    return;
+  }
+
+  const clickListener = harness.trigger.listeners.click && harness.trigger.listeners.click[0];
   if (!clickListener) {
     fail(name, 'worktree trigger has no click listener');
     return;
   }
-  clickListener({ target: label, preventDefault() {} });
+  clickListener({ target: harness.label, preventDefault() {} });
   await flushAsync();
   await flushAsync();
+  if (harness.worktreeRequests !== 1) {
+    fail(name, `first interaction issued ${harness.worktreeRequests} worktree requests instead of one lazy list load`);
+    return;
+  }
 
-  const menu = body.children.find((child) => child.classList.contains('worktree-popover'));
+  const menu = harness.body.children.find((child) => child.classList.contains('worktree-popover'));
   if (!menu) {
     fail(name, 'clicking root did not render a menu');
     return;
@@ -178,45 +217,105 @@ async function testActiveRootOpensStableResponsiveMenu() {
     fail(name, 'the current root checkout is exposed as an actionable menu item');
     return;
   }
-  const lastPositionCall = positionCalls[positionCalls.length - 1];
+  const lastPositionCall = harness.positionCalls[harness.positionCalls.length - 1];
   if (!lastPositionCall || lastPositionCall[2]?.mobileSheet !== true) {
     fail(name, 'worktree menu did not request mobile bottom-sheet positioning');
     return;
   }
-  if (backdrop.hidden) {
+  if (harness.backdrop.hidden) {
     fail(name, 'worktree menu backdrop stayed hidden');
     return;
   }
 
-  for (const listener of documentListeners.click || []) {
-    listener({ target: label });
+  for (const listener of harness.documentListeners.click || []) {
+    listener({ target: harness.label });
   }
-  if (!body.children.includes(menu)) {
+  if (!harness.body.children.includes(menu)) {
     fail(name, 'the opening click bubbling from the trigger label immediately closed the menu');
     return;
   }
 
-  for (const listener of windowListeners.resize || []) {
+  for (const listener of harness.windowListeners.resize || []) {
     listener();
   }
-  const resizePositionCall = positionCalls[positionCalls.length - 1];
+  const resizePositionCall = harness.positionCalls[harness.positionCalls.length - 1];
   if (!resizePositionCall || resizePositionCall[2]?.mobileSheet !== true) {
     fail(name, 'worktree menu lost bottom-sheet positioning after a viewport resize');
     return;
   }
 
-  for (const listener of backdrop.listeners.click || []) {
-    listener({ target: backdrop });
+  for (const listener of harness.backdrop.listeners.click || []) {
+    listener({ target: harness.backdrop });
   }
-  if (body.children.includes(menu) || !backdrop.hidden) {
+  if (harness.body.children.includes(menu) || !harness.backdrop.hidden) {
     fail(name, 'backdrop click did not close the worktree menu');
     return;
   }
   pass(name);
 }
 
+async function testNonGitCapabilityNeverRendersOrRequests() {
+  const name = 'non-git bootstrap never renders or requests worktrees';
+  const harness = makeHarness({ enabled: false });
+  await flushAsync();
+
+  if (!harness.elements.chipWorktree.hidden || !harness.elements.chipSepEffortWorktree.hidden) {
+    fail(name, 'non-git bootstrap left the worktree control or separator visible');
+    return;
+  }
+  const clickListeners = harness.trigger.listeners.click || [];
+  for (const listener of clickListeners) {
+    listener({ target: harness.label, preventDefault() {} });
+  }
+  await harness.app.loadWorktrees();
+  await flushAsync();
+  await flushAsync();
+  if (harness.worktreeRequests !== 0) {
+    fail(name, `startup/click issued ${harness.worktreeRequests} worktree request(s)`);
+    return;
+  }
+  if (harness.body.children.some((child) => child.classList.contains('worktree-popover'))) {
+    fail(name, 'non-git capability opened an unusable worktree menu');
+    return;
+  }
+  pass(name);
+}
+
+async function testSelectedSessionWorktreeLabelSurvivesLazyBootstrap() {
+  const name = 'git bootstrap preserves selected session worktree labels without eager list';
+  const harness = makeHarness({
+    enabled: true,
+    session: {
+      id: 'session-worktree',
+      worktreeDir: '/repo-worktrees/feature',
+      worktreeName: 'feature',
+    },
+  });
+  await flushAsync();
+
+  if (harness.elements.chipWorktree.hidden) {
+    fail(name, 'selected session worktree chip is hidden');
+    return;
+  }
+  if (harness.label.textContent !== '⌥ feature') {
+    fail(name, `selected worktree label = ${JSON.stringify(harness.label.textContent)}`);
+    return;
+  }
+  if (harness.trigger.title !== 'Open worktree diff/actions') {
+    fail(name, `selected worktree title = ${JSON.stringify(harness.trigger.title)}`);
+    return;
+  }
+  if (harness.worktreeRequests !== 0) {
+    fail(name, `selected session label required ${harness.worktreeRequests} eager list request(s)`);
+    return;
+  }
+  pass(name);
+}
+
 (async () => {
-  await testActiveRootOpensStableResponsiveMenu();
+  await testGitCapabilityRendersAndLoadsLazily();
+  await testNonGitCapabilityNeverRendersOrRequests();
+  await testSelectedSessionWorktreeLabelSurvivesLazyBootstrap();
   if (failures > 0) process.exit(1);
   console.log('\nAll tests passed');
 })().catch((error) => {

--- a/internal/serveui/static/side-question.js
+++ b/internal/serveui/static/side-question.js
@@ -6,6 +6,9 @@ const { UI_PREFIX, state, elements, getActiveSession, requestHeaders } = app;
 const side = state.sideQuestion;
 side.pending = false;
 let openOperation = 0;
+const isResolvedSessionIdentity = typeof app.isSessionIdentityResolved === 'function'
+  ? app.isSessionIdentityResolved
+  : (sessionId) => Boolean(String(sessionId || '').trim()) && !/^\d+$/.test(String(sessionId).trim());
 
 const endpoint = (sessionId, suffix = '') => `${UI_PREFIX}/api/sessions/${encodeURIComponent(sessionId)}/side-question${suffix}`;
 
@@ -77,9 +80,11 @@ const applyView = (view) => {
 };
 
 const recover = async (sessionId) => {
+  if (!isResolvedSessionIdentity(sessionId)) return false;
   const response = await fetch(endpoint(sessionId), { headers: requestHeaders(sessionId) });
   if (!response.ok) throw new Error(`Unable to load side questions (${response.status})`);
   applyView(await response.json());
+  return true;
 };
 
 const parseSSE = async (response) => {
@@ -130,6 +135,10 @@ const openSideQuestion = async (question = '') => {
   const session = getActiveSession();
   if (!session || state.draftSessionActive) {
     window.alert('Start the main conversation before asking a side question.');
+    return;
+  }
+  if (!isResolvedSessionIdentity(session)) {
+    window.alert('This session is still loading. Try again in a moment.');
     return;
   }
   const trimmed = String(question || '').trim();
@@ -204,7 +213,9 @@ const cancel = async (focus = true) => {
   side.error = '';
   render();
   if (focus) focusComposer();
-  await fetch(endpoint(session.id, '/active'), { method: 'DELETE', headers: requestHeaders(session.id) }).catch(() => {});
+  if (isResolvedSessionIdentity(session)) {
+    await fetch(endpoint(session.id, '/active'), { method: 'DELETE', headers: requestHeaders(session.id) }).catch(() => {});
+  }
 };
 
 const close = () => {
@@ -245,7 +256,7 @@ setInterval(() => {
   if (currentId === observedSessionId) return;
   const previousId = observedSessionId;
   observedSessionId = currentId;
-  if (previousId && side.running) {
+  if (previousId && side.running && isResolvedSessionIdentity(previousId)) {
     fetch(endpoint(previousId, '/active'), { method: 'DELETE', headers: requestHeaders(previousId) }).catch(() => {});
   }
   side.generation += 1;
@@ -257,11 +268,7 @@ setInterval(() => {
   side.error = '';
   side.history = [];
   render();
-  if (currentId) recover(currentId).catch(() => {});
 }, 500);
-
-const initialSession = getActiveSession();
-if (initialSession) recover(initialSession.id).catch(() => {});
 
 Object.assign(app, { openSideQuestion, recoverSideQuestion: recover, renderSideQuestion: render });
 })();

--- a/internal/serveui/static/side_question_test.js
+++ b/internal/serveui/static/side_question_test.js
@@ -46,7 +46,7 @@ const names = [
 const elements = Object.fromEntries(names.map((name) => [name, new Element(name.includes('Input') ? 'input' : 'div')]));
 const document = new Element('document');
 document.createElement = (tag) => new Element(tag);
-let session = null;
+let session = { id: 'main' };
 let fetches = [];
 let failNextPost = false;
 let deferNextGet = false;
@@ -103,6 +103,14 @@ vm.runInNewContext(source, context, { filename: 'side-question.js' });
 const assert = (condition, message) => { if (!condition) throw new Error(message); };
 
 (async () => {
+  assert(fetches.length === 0, 'unopened side-question issued an eager startup recovery request');
+  session = { id: '3347' };
+  const unresolvedStart = fetches.length;
+  const unresolved = await app.recoverSideQuestion(session.id);
+  assert(unresolved === false, 'numeric route stub recovery should report that identity is unresolved');
+  assert(fetches.length === unresolvedStart, 'numeric route stub reached the side-question endpoint');
+  session = { id: 'main' };
+
   assert(!indexHTML.includes('sideQuestionCopyBtn'), 'side overlay retained redundant copy control');
   assert(!indexHTML.includes('sideQuestionClearBtn'), 'side overlay retained clear control');
   assert(!indexHTML.includes('sideQuestionCancelBtn'), 'side overlay retained cancel control');


### PR DESCRIPTION
## What

Make fresh deep links and first uncached sidebar navigation render from one authoritative selected-session payload.

- resolve numeric route selectors before issuing session-scoped requests
- sideload the selected session's bounded initial transcript projection
- sideload selected-session diff and plan summaries
- sideload widget status in the authenticated startup response
- bootstrap worktree capability so non-Git deployments never render a bogus control
- render final diff counts and plan progress on first paint while keeping full bodies lazy
- coalesce redundant transcript synchronizations without swallowing real revision updates
- reveal the conversation as soon as its transcript projection is mounted; runtime state continues in parallel
- schedule normal status polling instead of polling immediately after an authoritative startup response
- preserve bottom anchoring through bounded mobile layout settling
- restore canonical live DOM order after reconnect/interjection reconciliation
- lazy-load side-question history and full diff bodies
- remove decorative diff-count pulse animation

## Why

The old startup path issued partially resolved requests, routine 404/409 responses, and serial transcript index/body round trips. Header controls discovered their own availability after interaction and changed meaning after load. Reload/reconnect could also expose a blank transcript, land above the mobile bottom, or misorder a replayed user row until reload.

The selected-session response now contains compact, bounded first-paint data:

```json
{
  "selected_session": {
    "file_change_summary": { "file_count": 6, "adds": 51, "dels": 19 },
    "plan_summary": {
      "version": 7,
      "step_count": 4,
      "completed_steps": 2,
      "position": 3,
      "state": "in_progress"
    }
  },
  "selected_transcript": {
    "index_etag": "…",
    "index": { "rev": 528, "rows": {} },
    "bodies": { "rev": 528, "messages": [] }
  },
  "widget_status": { "widgets": [] }
}
```

Only the selected session is enriched. Ordinary sidebar listings remain summary-only, avoiding N+1 transcript, file-history, or plan lookups. Transcript bodies are bounded to the initial viewport/overscan. Full history, exact file lists, diff bodies, and widget application content remain lazy.

## Live browser verification

Deployed the branch to `wasnotwas.com/chat` and traced it with the shared Chromium profile.

### Direct `/chat/3347`

- one authenticated startup payload
- conversation rendered and splash removed at ~2.23 s in the sampled run
- zero startup `/transcript` requests
- zero startup `/transcript/bodies` requests
- zero startup `/admin/widgets/status` requests
- no immediate duplicate `/sessions/status` poll
- state and skills continue asynchronously after first paint

### `/chat/` then immediate sidebar click

Before:

- transcript index + bodies rendered at ~1.94 s after click

After:

- one selected-session sideload request
- conversation rendered at ~0.86 s desktop and ~0.76 s mobile
- zero transcript index/body requests
- state and skills continue asynchronously

Also confirmed:

- accurate diff header before interaction (`6 files`, `+51`, `−19` in the final run)
- no provisional icon, count mutation, or pulse animation
- no worktree control or 409 in Jarvis's non-Git deployment
- 16 widgets rendered from the startup payload
- mobile 390×844 viewport settled at the true bottom (0.9 px measured delta)
- reconnect/interjection DOM ordering follows canonical session order without reload

## Tests

- Node suites for sessions, transcript store, rendering, streaming, diffs, plans, worktrees, widgets/sidebar, and core scrolling
- Go handler/serialization/embed/transcript/worktree tests
- isolated `go test ./... -count=1`
- `go build ./...`
- `git diff --check`
