### PR TITLE
fix: preserve session counts and resumed tool identity

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1086,7 +1086,7 @@ func (s *serveServer) webSessionEntryFromSession(sess *session.Session) webSessi
 		Pinned:        sess.Pinned,
 		CreatedAt:     sess.CreatedAt.UnixMilli(),
 		LastMessageAt: lastMessageAt.UnixMilli(),
-		MsgCount:      sess.LastMessageCount,
+		MsgCount:      sess.MessageCount,
 	}
 }
 

--- a/cmd/serve_transcript_test.go
+++ b/cmd/serve_transcript_test.go
@@ -314,6 +314,128 @@ func TestHandleSessionsSelectedTranscriptSideloadMatchesTranscriptEndpointsAndIs
 	}
 }
 
+func TestHandleSessionsMessageCountMatchesConversationAcrossSelectedTranscriptResponses(t *testing.T) {
+	srv, store, sess := newTranscriptHandlerServer(t)
+	ctx := context.Background()
+	messages := []*session.Message{
+		session.NewMessage(sess.ID, llm.SystemText("internal system prompt"), -1),
+		session.NewMessage(sess.ID, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "internal developer prompt"}}}, -1),
+		session.NewMessage(sess.ID, llm.UserText("run the tools"), -1),
+	}
+	for i := 0; i < 12; i++ {
+		callID := fmt.Sprintf("call-count-%02d", i)
+		messages = append(messages,
+			session.NewMessage(sess.ID, llm.Message{Role: llm.RoleAssistant, Parts: []llm.Part{{
+				Type: llm.PartToolCall,
+				ToolCall: &llm.ToolCall{
+					ID: callID, Name: "read_file",
+				},
+			}}}, -1),
+			session.NewMessage(sess.ID, llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{
+				Type: llm.PartToolResult,
+				ToolResult: &llm.ToolResult{
+					ID: callID, Name: "read_file", Content: "internal result",
+				},
+			}}}, -1),
+			session.NewMessage(sess.ID, llm.Message{Role: llm.RoleEvent}, -1),
+		)
+	}
+	messages = append(messages,
+		session.NewMessage(sess.ID, llm.AssistantText("tools complete"), -1),
+		session.NewMessage(sess.ID, llm.UserText("[Context Compaction] internal summary"), -1),
+	)
+	compactionTail := session.NewMessage(sess.ID, llm.AssistantText("retained internal tail"), -1)
+	compactionTail.CompactionTail = true
+	messages = append(messages, compactionTail,
+		session.NewMessage(sess.ID, llm.UserText("what happened?"), -1),
+		session.NewMessage(sess.ID, llm.AssistantText("all done"), -1),
+	)
+	for i, message := range messages {
+		if err := store.AddMessage(ctx, sess.ID, message); err != nil {
+			t.Fatalf("AddMessage %d: %v", i, err)
+		}
+	}
+
+	indexer, ok := store.(session.TranscriptIndexer)
+	if !ok {
+		t.Fatal("test store does not implement TranscriptIndexer")
+	}
+	snapshot, err := indexer.GetTranscriptSnapshot(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetTranscriptSnapshot: %v", err)
+	}
+	const conversationCount = 4
+	transcriptRowCount := len(snapshot.Items)
+	if transcriptRowCount <= conversationCount {
+		t.Fatalf("transcript rows=%d, want more than conversation count %d", transcriptRowCount, conversationCount)
+	}
+	// Reproduce the live corruption: the legacy context checkpoint tracks raw
+	// model/transcript rows and must never be exposed as the conversation count.
+	if err := store.UpdateContextEstimate(ctx, sess.ID, 1234, transcriptRowCount); err != nil {
+		t.Fatalf("UpdateContextEstimate: %v", err)
+	}
+
+	type sessionsResponse struct {
+		Sessions           []webSessionEntry          `json:"sessions"`
+		SelectedSession    *webSelectedSessionEntry   `json:"selected_session"`
+		SelectedTranscript *transcriptStartupSideload `json:"selected_transcript"`
+	}
+	requestSessions := func(path string) sessionsResponse {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		srv.handleSessions(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET %s: status=%d body=%s", path, rr.Code, rr.Body.String())
+		}
+		var response sessionsResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		return response
+	}
+
+	normal := requestSessions("/v1/sessions?selected_session=" + sess.ID)
+	if len(normal.Sessions) != 1 || normal.Sessions[0].MsgCount != conversationCount {
+		t.Fatalf("normal sessions count=%+v, want %d", normal.Sessions, conversationCount)
+	}
+	if normal.SelectedSession == nil || normal.SelectedSession.MsgCount != conversationCount {
+		t.Fatalf("normal selected_session=%+v, want count %d", normal.SelectedSession, conversationCount)
+	}
+
+	selectedByID := requestSessions("/v1/sessions?selected_session=" + sess.ID + "&selected_only=1&include_transcript=1")
+	if len(selectedByID.Sessions) != 0 || selectedByID.SelectedSession == nil || selectedByID.SelectedSession.MsgCount != conversationCount {
+		t.Fatalf("selected_only by ID=%+v, want count %d and no sessions", selectedByID, conversationCount)
+	}
+	if selectedByID.SelectedTranscript == nil {
+		t.Fatal("selected_only by ID omitted transcript sideload")
+	}
+	if got := len(selectedByID.SelectedTranscript.Index.Rows.IDs); got != transcriptRowCount {
+		t.Fatalf("selected transcript rows=%d, want independent raw row count %d", got, transcriptRowCount)
+	}
+
+	selectedByNumber := requestSessions("/v1/sessions?selected_session=" + strconv.FormatInt(sess.Number, 10) + "&selected_only=1")
+	if len(selectedByNumber.Sessions) != 0 || selectedByNumber.SelectedSession == nil || selectedByNumber.SelectedSession.MsgCount != conversationCount {
+		t.Fatalf("selected_only by number=%+v, want count %d and no sessions", selectedByNumber, conversationCount)
+	}
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/v1/sessions/status", nil)
+	statusRec := httptest.NewRecorder()
+	srv.handleSessionsStatus(statusRec, statusReq)
+	if statusRec.Code != http.StatusOK {
+		t.Fatalf("status endpoint: status=%d body=%s", statusRec.Code, statusRec.Body.String())
+	}
+	var status struct {
+		Sessions []sessionsStatusTestEntry `json:"sessions"`
+	}
+	if err := json.Unmarshal(statusRec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if len(status.Sessions) != 1 || status.Sessions[0].ID != sess.ID || status.Sessions[0].MsgCount != conversationCount {
+		t.Fatalf("status sessions=%+v, want count %d", status.Sessions, conversationCount)
+	}
+}
+
 type countingTranscriptSideloadStore struct {
 	session.Store
 	indexer       session.TranscriptIndexer

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1159,6 +1159,27 @@ const transcriptViewportAdapter = (session, forceScroll = false) => {
   };
 };
 
+const reconcileSessionToolCallProjection = (session, options = {}) => {
+  if (!session || !Array.isArray(session.messages)) return false;
+  const reconcile = window.reconcileToolCallProjection;
+  if (typeof reconcile === 'function') {
+    session.messages = reconcile(session.messages);
+  }
+
+  if (options.trackOptimisticTools === true) {
+    const transcript = ensureSessionTranscript(session);
+    if (transcript) {
+      for (const message of session.messages) {
+        if (message?.durable || (message?.role !== 'tool-group' && message?.role !== 'tool')) continue;
+        transcript.addOptimistic(message, transcript.rev);
+      }
+      transcript.reconcileOptimistic();
+      persistTranscriptOptimistic(session);
+    }
+  }
+  return true;
+};
+
 const refreshSessionMessagesFromTranscript = (session) => {
   const transcript = session?.transcript;
   if (!transcript) return false;
@@ -1209,7 +1230,9 @@ const refreshSessionMessagesFromTranscript = (session) => {
     });
   }
   display.push(...transcript.optimistic);
-  session.messages = display;
+  session.messages = typeof window.reconcileToolCallProjection === 'function'
+    ? window.reconcileToolCallProjection(display)
+    : display;
   delete session._serverOnly;
   return true;
 };
@@ -3577,6 +3600,7 @@ Object.assign(app, {
   noteTranscriptRunCreated,
   noteTranscriptTerminal,
   refreshSessionMessagesFromTranscript,
+  reconcileSessionToolCallProjection,
   refreshActiveSessionMessagesFromServer,
   loadOlderSessionMessages,
   maybeLoadOlderSessionMessages,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1575,6 +1575,7 @@ const applyResponseRecoverySnapshot = (session, payload) => {
       ? session.messages.slice(0, anchorIndex + 1).filter((message) => !shouldDropPreservedOptimisticInterjection(message, recoveredInterjections))
       : [];
     session.messages = preserved.concat(recoveredMessages);
+    app.reconcileSessionToolCallProjection?.(session, { trackOptimisticTools: true });
   }
 
   const nextSeq = Number(payload.last_sequence_number ?? recovery?.sequence_number ?? session.lastSequenceNumber ?? 0);
@@ -5133,6 +5134,7 @@ Object.assign(app, {
   updateResponseSequence,
   createResponseStreamState,
   applyResponseStreamEvent,
+  applyResponseRecoverySnapshot,
   consumeResponseStream,
   scheduleStreamPersistence,
   flushStreamPersistence,

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -7,6 +7,7 @@ const vm = require('vm');
 
 const source = fs.readFileSync(path.join(__dirname, 'app-render.js'), 'utf8');
 const markdownStreaming = require(path.join(__dirname, 'markdown-streaming.js'));
+const { reconcileToolCallProjection } = require('./transcript-store.js');
 let failures = 0;
 
 function fail(name, message, details) {
@@ -1925,6 +1926,59 @@ async function run(name, fn) {
       messages.children.map((node) => node.dataset.messageId).join(','),
       'msg_keep_going,tools_queue_agent,tools_wait_for_jobs',
       'live DOM follows session message order without requiring a reload'
+    );
+  });
+
+  await run('transcript reconciliation removes duplicate optimistic tool DOM without reload', () => {
+    const { app, session, messages } = createHarness();
+    session.transcript = {};
+    const durable = {
+      id: 'srv_seq_387_tools_1',
+      role: 'tool-group',
+      durable: true,
+      transcriptSegmentIndex: 0,
+      status: 'done',
+      tools: [
+        { id: 'call_shell_exact_a', name: 'shell', status: 'done', arguments: '{}' },
+        { id: 'call_shell_exact_b', name: 'shell', status: 'done', arguments: '{}' }
+      ],
+      created: 1000
+    };
+    const exactLive = {
+      id: 'msg_ba0-live-tools',
+      role: 'tool-group',
+      status: 'done',
+      tools: [
+        { id: 'call_shell_exact_a', name: 'shell', status: 'done', arguments: '{}' },
+        { id: 'call_shell_exact_b', name: 'shell', status: 'done', arguments: '{}' }
+      ],
+      created: 1100
+    };
+    const partialLive = {
+      id: 'msg_652-live-tools',
+      role: 'tool-group',
+      status: 'running',
+      tools: [
+        { id: 'call_shell_exact_b', name: 'shell', status: 'done', arguments: '{}' },
+        { id: 'call_shell_newer', name: 'shell', status: 'running', arguments: '{}' }
+      ],
+      created: 1200
+    };
+    session.messages = [durable, exactLive, partialLive];
+    app.renderMessages();
+    assertEqual(messages.querySelectorAll('.tool-group').length, 3, 'reproduction mounts durable and duplicate optimistic cards');
+
+    session.messages = reconcileToolCallProjection(session.messages);
+    app.renderMessages();
+
+    assertEqual(messages.querySelectorAll('.tool-group').length, 2, 'covered optimistic group is removed in the mounted reconciliation');
+    assertEqual(messages.querySelectorAll('[data-tool-id="call_shell_exact_a"]').length, 1, 'first durable call ID appears once in DOM');
+    assertEqual(messages.querySelectorAll('[data-tool-id="call_shell_exact_b"]').length, 1, 'second durable call ID appears once in DOM');
+    assertEqual(messages.querySelectorAll('[data-tool-id="call_shell_newer"]').length, 1, 'newer optimistic-only call remains once in DOM');
+    assertEqual(
+      session.messages.map((message) => message.id).join(','),
+      'srv_seq_387_tools_1,msg_652-live-tools',
+      'session projection preserves durable then newer live ordering'
     );
   });
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -427,6 +427,7 @@ async function createSessionsHarness(options = {}) {
   vm.runInContext(transcriptStoreSource, context, { filename: 'transcript-store.js' });
   windowObj.TranscriptStore = context.TranscriptStore;
   windowObj.transcriptStoreFromMessages = context.transcriptStoreFromMessages;
+  windowObj.reconcileToolCallProjection = context.reconcileToolCallProjection;
   windowObj.TRANSCRIPT_BUDGETS = context.TRANSCRIPT_BUDGETS;
   vm.runInContext(coreSource, context, { filename: 'app-core.js' });
   vm.runInContext(planSource, context, { filename: 'app-plan.js' });
@@ -1089,6 +1090,100 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
     return;
   }
   app.stopSidebarStatusPoll();
+  pass(name);
+}
+
+async function testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwitchBack() {
+  const name = 'selected transcript sideload reconciles stable tool calls across switch away and back';
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async () => new Response(JSON.stringify({ sessions: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  });
+  const session = {
+    id: 'sess_tool_overlap',
+    number: 956,
+    title: 'Tool overlap',
+    messages: [],
+    messageCount: 2,
+    activeResponseId: 'resp_tool_overlap',
+    lastSequenceNumber: 9
+  };
+  app.state.sessions.push(session);
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const transcript = new windowObj.TranscriptStore(session.id);
+  session.transcript = transcript;
+  transcript.addOptimistic({
+    id: 'msg_441406d5-live-tools',
+    role: 'tool-group',
+    status: 'running',
+    created: 1200,
+    tools: [
+      { id: 'call_GwHMMHXf28QA81Zfm9vgRMap', name: 'queue_agent', status: 'done' },
+      { id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', name: 'wait_for_jobs', status: 'done' },
+      { id: 'call_newer_shell', name: 'shell', status: 'running' }
+    ]
+  }, 7);
+  const sideload = {
+    index_etag: '"tool-overlap-7"',
+    index: {
+      rev: 7,
+      compaction_seq: -1,
+      compaction_count: 0,
+      active_response_id: 'resp_tool_overlap',
+      started_rev: 6,
+      rows: {
+        ids: [381, 382],
+        seqs: [381, 382],
+        roles: 'ua',
+        flags: [0, 0]
+      }
+    },
+    bodies: {
+      rev: 7,
+      messages: [
+        { id: 381, sequence: 381, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'continue' }] },
+        {
+          id: 382,
+          sequence: 382,
+          role: 'assistant',
+          created_at: 1100,
+          parts: [
+            { type: 'tool_call', tool_call_id: 'call_GwHMMHXf28QA81Zfm9vgRMap', tool_name: 'queue_agent', tool_arguments: '{}' },
+            { type: 'tool_call', tool_call_id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', tool_name: 'wait_for_jobs', tool_arguments: '{}' }
+          ]
+        }
+      ]
+    }
+  };
+
+  const assertUniqueProjection = (phase) => {
+    const groups = session.messages.filter((message) => message.role === 'tool-group');
+    const callIDs = groups.flatMap((group) => group.tools.map((tool) => tool.id));
+    const unique = new Set(callIDs);
+    if (unique.size !== callIDs.length) {
+      fail(name, `${phase} retained duplicate call IDs`, JSON.stringify(session.messages));
+      return false;
+    }
+    if (groups.map((group) => group.id).join(',') !== 'srv_seq_382_tools_0,msg_441406d5-live-tools'
+        || groups[1].tools.map((tool) => tool.id).join(',') !== 'call_newer_shell') {
+      fail(name, `${phase} lost durable authority or newer optimistic order`, JSON.stringify(groups));
+      return false;
+    }
+    return true;
+  };
+
+  if (!app.applySelectedTranscriptSideload(session, sideload) || !assertUniqueProjection('initial sideload')) return;
+
+  // Reproduce switching away: mounted bodies and the projected message array are
+  // released, while the optimistic transcript tail remains available for resume.
+  session.transcript.releaseBodies();
+  session.messages = [];
+  if (!app.applySelectedTranscriptSideload(session, sideload) || !assertUniqueProjection('switch-back sideload')) return;
+
   pass(name);
 }
 
@@ -6004,6 +6099,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testNumericDeepLinkResolvesRealSessionId();
   await testIdleStartupSchedulesNormalPollWithoutImmediateRequest();
   await testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTranscriptRequests();
+  await testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwitchBack();
   await testMalformedStartupTranscriptSideloadFallsBack();
   await testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision();
   await testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -970,6 +970,7 @@ async function testIdleStartupSchedulesNormalPollWithoutImmediateRequest() {
 async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTranscriptRequests() {
   const name = 'startup transcript sideload renders bounded first paint with zero transcript requests';
   const ids = Array.from({ length: 20 }, (_, index) => index + 1);
+  const authoritativeMessageCount = 4;
   const messages = ids.slice(-9).map((id) => ({
     id,
     sequence: id - 1,
@@ -1009,7 +1010,7 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
           sessions: [],
           selected_session: {
             id: 'sess_3347', number: 3347, short_title: 'Sideloaded', long_title: 'Sideloaded',
-            mode: 'chat', origin: 'web', created_at: 1000, message_count: ids.length, transcript_rev: 20,
+            mode: 'chat', origin: 'web', created_at: 1000, message_count: authoritativeMessageCount, transcript_rev: 20,
           },
           selected_transcript: startupTranscriptSideload({ rev: 20, ids, messages }),
           widget_status: { widgets: [] },
@@ -1075,6 +1076,10 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
   if (session.transcript.rev !== 20 || session.transcript.bodies.size !== 9
       || session.transcript.segments.filter((segment) => segment.state === 'materialized').length !== 9) {
     fail(name, 'sideload did not preserve the initial viewport budget', JSON.stringify({ rev: session.transcript.rev, bodies: session.transcript.bodies.size, segments: session.transcript.segments }));
+    return;
+  }
+  if (session.messageCount !== authoritativeMessageCount || session.transcript.ids.length !== ids.length) {
+    fail(name, 'sideload row application changed the authoritative server message count', JSON.stringify({ messageCount: session.messageCount, transcriptRows: session.transcript.ids.length }));
     return;
   }
   const statusRequests = fetchCalls.filter((url) => parsedTestURL(url)?.pathname === '/ui/v1/sessions/status');

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -11,6 +11,7 @@ const { webcrypto } = require('crypto');
 const dir = __dirname;
 const attachmentsSource = fs.readFileSync(path.join(dir, 'app-attachments.js'), 'utf8');
 const source = fs.readFileSync(path.join(dir, 'app-stream.js'), 'utf8');
+const { reconcileToolCallProjection } = require('./transcript-store.js');
 
 let failures = 0;
 
@@ -480,6 +481,13 @@ function createHarness(options = {}) {
     renderSidebar() {},
     renderWidgetSidebar() {},
     renderMessages() {},
+    reconcileSessionToolCallProjection(session) {
+      session.messages = reconcileToolCallProjection(session.messages);
+      if (typeof options.onReconcileSessionToolCallProjection === 'function') {
+        options.onReconcileSessionToolCallProjection(session);
+      }
+      return true;
+    },
     maybeNotifyResponseComplete: async () => {},
     enqueueAssistantStreamUpdate() {},
     finalizeAssistantStreamRender() {},
@@ -2859,6 +2867,83 @@ async function testResumeActiveResponseRecoversFromSnapshotBeforeReplaying() {
   }
   if (planRefreshes !== 2) {
     fail(name, `expected snapshot recovery and terminal fallback to refetch plan state, got ${planRefreshes}`);
+    await cleanup();
+    return;
+  }
+
+  await cleanup();
+  pass(name);
+}
+
+async function testRecoverySnapshotReconcilesDurableToolCallsIdempotently() {
+  const name = 'recovery snapshot reconciles durable tool calls by stable call ID idempotently';
+  let reconciliations = 0;
+  const harness = createHarness({
+    onReconcileSessionToolCallProjection() { reconciliations += 1; }
+  });
+  const { app, state, cleanup } = harness;
+  const durable = {
+    id: 'srv_seq_382_tools_0',
+    role: 'tool-group',
+    durable: true,
+    status: 'done',
+    tools: [
+      { id: 'call_GwHMMHXf28QA81Zfm9vgRMap', name: 'queue_agent', status: 'done' },
+      { id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', name: 'wait_for_jobs', status: 'done' }
+    ],
+    created: 1000
+  };
+  const interjection = {
+    id: 'msg_interjection', role: 'user', content: 'keep going', interruptState: 'interject', created: 1100
+  };
+  const session = {
+    id: 'session_durable_recovery_overlap',
+    messages: [durable, interjection],
+    activeResponseId: 'resp_overlap',
+    lastSequenceNumber: 0,
+    number: 1
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  const snapshot = {
+    id: 'resp_overlap',
+    status: 'in_progress',
+    last_sequence_number: 9,
+    recovery: {
+      sequence_number: 9,
+      messages: [{
+        id: 'msg_441406d5-live-tools',
+        role: 'tool-group',
+        status: 'running',
+        created: 1200,
+        tools: [
+          { id: 'call_GwHMMHXf28QA81Zfm9vgRMap', name: 'queue_agent', status: 'done' },
+          { id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', name: 'wait_for_jobs', status: 'done' },
+          { id: 'call_newer_shell', name: 'shell', status: 'running' }
+        ]
+      }]
+    }
+  };
+
+  app.applyResponseRecoverySnapshot(session, snapshot);
+  app.applyResponseRecoverySnapshot(session, snapshot);
+
+  const toolGroups = session.messages.filter((message) => message.role === 'tool-group');
+  const callIDs = toolGroups.flatMap((group) => group.tools.map((tool) => tool.id));
+  const counts = new Map(callIDs.map((id) => [id, callIDs.filter((candidate) => candidate === id).length]));
+  if ([...counts.values()].some((count) => count !== 1)) {
+    fail(name, 'repeat recovery projected duplicate stable call IDs', JSON.stringify(session.messages));
+    await cleanup();
+    return;
+  }
+  if (toolGroups.map((group) => group.id).join(',') !== 'srv_seq_382_tools_0,msg_441406d5-live-tools'
+      || toolGroups[1].tools.map((tool) => tool.id).join(',') !== 'call_newer_shell') {
+    fail(name, 'partial overlap did not preserve only the newer optimistic call in order', JSON.stringify(toolGroups));
+    await cleanup();
+    return;
+  }
+  if (reconciliations !== 2) {
+    fail(name, `expected one reconciliation per recovery, got ${reconciliations}`);
     await cleanup();
     return;
   }
@@ -6764,6 +6849,7 @@ async function testIsolatedSkillStreamsIndependentlyAndCancelsIndependently() {
   await testDrainInterruptQueueAfterResumeCompletes();
   await testDrainInterruptQueueIgnoresOtherSessionEntries();
   await testResumeActiveResponseRecoversFromSnapshotBeforeReplaying();
+  await testRecoverySnapshotReconcilesDurableToolCallsIdempotently();
   await testResumeActiveResponseRepairsSequenceGapWithSnapshot();
   await testRecoverySnapshotClearsSyntheticPendingInterjectionByText();
   await testRecoverySnapshotDoesNotDuplicateOptimisticInterjection();

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -35,6 +35,89 @@
   const bodyID = (entry) => normalizedID(entry?.id ?? entry?.ID);
   const bodySeq = (entry) => finiteInt(entry?.sequence ?? entry?.seq, -1);
   const partToolID = (part) => String(part?.tool_call_id || part?.call_id || part?.toolCallId || part?.id || '').trim();
+  const toolEntryID = (tool) => String(tool?.tool_call_id || tool?.call_id || tool?.toolCallId || tool?.id || '').trim();
+
+  const messageToolIDs = (message) => {
+    const ids = new Set();
+    if (message?.role === 'tool-group') {
+      for (const tool of message.tools || []) {
+        const id = toolEntryID(tool);
+        if (id) ids.add(id);
+      }
+    } else if (message?.role === 'tool') {
+      const id = String(message?.tool_call_id || message?.call_id || message?.toolCallId || '').trim();
+      if (id) ids.add(id);
+    }
+    for (const part of message?.parts || []) {
+      const id = partToolID(part);
+      if (id) ids.add(id);
+    }
+    return ids;
+  };
+
+  // Stable tool call IDs are authoritative across the durable/optimistic
+  // boundary. Synthetic message IDs differ between transcript conversion and
+  // response recovery, so reconciling only message rows can project the same
+  // call twice. Reserve every durable call first, then retain optimistic calls
+  // in their existing order only when no earlier projection owns that ID.
+  const reconcileToolCallProjection = (messages) => {
+    if (!Array.isArray(messages) || messages.length === 0) return Array.isArray(messages) ? messages : [];
+    const durableIDs = new Set();
+    for (const message of messages) {
+      if (!message?.durable) continue;
+      for (const id of messageToolIDs(message)) durableIDs.add(id);
+    }
+
+    const claimed = new Set();
+    const result = [];
+    for (const message of messages) {
+      if (!message || (message.role !== 'tool-group' && message.role !== 'tool')) {
+        result.push(message);
+        continue;
+      }
+
+      if (message.role === 'tool-group') {
+        const tools = Array.isArray(message.tools) ? message.tools : [];
+        let stableCount = 0;
+        const retained = tools.filter((tool) => {
+          const id = toolEntryID(tool);
+          if (!id) return true;
+          stableCount += 1;
+          if (message.durable) {
+            if (claimed.has(id)) return false;
+            claimed.add(id);
+            return true;
+          }
+          if (durableIDs.has(id) || claimed.has(id)) return false;
+          claimed.add(id);
+          return true;
+        });
+        if (retained.length !== tools.length) message.tools = retained;
+        if (stableCount > 0 && retained.length === 0) continue;
+        result.push(message);
+        continue;
+      }
+
+      const ids = messageToolIDs(message);
+      if (ids.size === 0) {
+        result.push(message);
+        continue;
+      }
+      const retainedIDs = new Set([...ids].filter((id) => (
+        message.durable ? !claimed.has(id) : (!durableIDs.has(id) && !claimed.has(id))
+      )));
+      if (retainedIDs.size === 0) continue;
+      if (Array.isArray(message.parts)) {
+        message.parts = message.parts.filter((part) => {
+          const id = partToolID(part);
+          return !id || retainedIDs.has(id);
+        });
+      }
+      retainedIDs.forEach((id) => claimed.add(id));
+      result.push(message);
+    }
+    return result;
+  };
 
   class TranscriptStore {
     constructor(sessionId, budgets = {}) {
@@ -466,30 +549,10 @@
       return [...selected];
     }
 
-    durableToolIDsInSegment(segmentIndex, afterSequence = -1) {
+    durableToolIDs() {
       const ids = new Set();
-      const segment = this.segments[segmentIndex];
-      if (!segment) return ids;
-      for (let ordinal = segment.startOrdinal; ordinal <= segment.endOrdinal; ordinal += 1) {
-        if (this.seqs[ordinal] <= afterSequence) continue;
-        const entry = this.bodies.get(this.ids[ordinal]);
-        for (const part of entry?.parts || []) {
-          const id = partToolID(part);
-          if (id) ids.add(id);
-        }
-      }
-      return ids;
-    }
-
-    durableToolIDsAfter(sequence) {
-      const ids = new Set();
-      for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
-        if (this.seqs[ordinal] <= sequence) continue;
-        const entry = this.bodies.get(this.ids[ordinal]);
-        for (const part of entry?.parts || []) {
-          const id = partToolID(part);
-          if (id) ids.add(id);
-        }
+      for (const entry of this.bodies.values()) {
+        for (const id of messageToolIDs(entry)) ids.add(id);
       }
       return ids;
     }
@@ -499,7 +562,35 @@
       const kept = [];
       const removed = [];
       const consumed = new Set();
+      const durableToolIDs = this.durableToolIDs();
+      const claimedOptimisticToolIDs = new Set();
       for (const local of this.optimistic) {
+        const localIsTool = local.role === 'tool-group' || local.role === 'tool';
+        if (localIsTool) {
+          const localIDs = messageToolIDs(local);
+          if (localIDs.size > 0) {
+            const uncovered = new Set([...localIDs].filter((id) => (
+              !durableToolIDs.has(id) && !claimedOptimisticToolIDs.has(id)
+            )));
+            if (local.role === 'tool-group' && Array.isArray(local.tools)) {
+              local.tools = local.tools.filter((tool) => {
+                const id = toolEntryID(tool);
+                return !id || uncovered.has(id);
+              });
+            } else if (local.role === 'tool' && Array.isArray(local.parts)) {
+              local.parts = local.parts.filter((part) => {
+                const id = partToolID(part);
+                return !id || uncovered.has(id);
+              });
+            }
+            if (uncovered.size === 0) {
+              removed.push(local);
+              continue;
+            }
+            uncovered.forEach((id) => claimedOptimisticToolIDs.add(id));
+          }
+        }
+
         if (this.rev <= finiteInt(local.revAtSend, this.rev)) {
           kept.push(local);
           continue;
@@ -515,20 +606,6 @@
               break;
             }
           }
-        } else if (local.role === 'tool-group' || local.role === 'tool') {
-          const localIDs = new Set();
-          for (const tool of local.tools || []) {
-            const id = String(tool?.id || tool?.call_id || '').trim();
-            if (id) localIDs.add(id);
-          }
-          for (const part of local.parts || []) {
-            const id = partToolID(part);
-            if (id) localIDs.add(id);
-          }
-          const durableIDs = this.persistedOptimistic.has(local)
-            ? this.durableToolIDsInSegment(this.segmentAfterSequence(afterSeq), afterSeq)
-            : this.durableToolIDsAfter(afterSeq);
-          matched = localIDs.size > 0 && [...localIDs].every((id) => durableIDs.has(id));
         } else if (local.role === 'assistant') {
           for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
             if (this.seqs[ordinal] <= afterSeq || consumed.has(ordinal)) continue;
@@ -542,7 +619,7 @@
         // Reaching a newer durable revision with no active run is the terminal
         // authority for completed tool UI. An unmatched completed tool cannot
         // represent queued input and must not remain persisted at the tail.
-        const completedTool = (local.role === 'tool-group' || local.role === 'tool')
+        const completedTool = localIsTool
           && ['done', 'error', 'failed', 'cancelled'].includes(String(local.status || '').toLowerCase());
         if (matched || (!this.activeRun && completedTool)) removed.push(local);
         else kept.push(local);
@@ -729,6 +806,7 @@
     TRANSCRIPT_FLAG_COMPACTION_TAIL,
     TRANSCRIPT_FLAG_EMPTY_BODY,
     transcriptStoreFromMessages,
+    reconcileToolCallProjection,
     transcriptRoleCode: roleCode,
     transcriptRoleName: roleName,
     __transcriptStats

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -5,6 +5,7 @@ const {
   TranscriptStore,
   TRANSCRIPT_FLAG_EMPTY_BODY,
   transcriptStoreFromMessages,
+  reconcileToolCallProjection,
   __transcriptStats
 } = require('./transcript-store.js');
 
@@ -286,6 +287,63 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   ]);
   assert.equal(tools.reconcileOptimistic().length, 1, 'interleaved durable tool evidence must replace optimistic group');
 
+  const partialTools = new TranscriptStore('partial-tools');
+  partialTools.applyIndex(envelope([23, 24], { rev: 7, roles: 'ua' }));
+  partialTools.materialize([
+    body(23, 0, 'user'),
+    body(24, 1, 'assistant', [
+      { type: 'tool_call', tool_call_id: 'call_GwHMMHXf28QA81Zfm9vgRMap' },
+      { type: 'tool_call', tool_call_id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu' }
+    ])
+  ]);
+  partialTools.addOptimistic({
+    id: 'msg_441406d5-live-tools',
+    role: 'tool-group',
+    status: 'running',
+    tools: [
+      { id: 'call_GwHMMHXf28QA81Zfm9vgRMap', name: 'queue_agent', status: 'done' },
+      { id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', name: 'wait_for_jobs', status: 'done' },
+      { id: 'call_newer_optimistic_only', name: 'shell', status: 'running' }
+    ]
+  }, 7);
+  assert.deepEqual(
+    partialTools.reconcileOptimistic(),
+    [],
+    'partially covered optimistic groups remain projected for newer calls'
+  );
+  assert.deepEqual(
+    partialTools.optimistic[0].tools.map((tool) => tool.id),
+    ['call_newer_optimistic_only'],
+    'stable durable call IDs are removed even when the transcript revision has not advanced'
+  );
+
+  const durableGroup = {
+    id: 'srv_seq_382_tools_0',
+    role: 'tool-group',
+    durable: true,
+    tools: [
+      { id: 'call_GwHMMHXf28QA81Zfm9vgRMap', name: 'queue_agent' },
+      { id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', name: 'wait_for_jobs' }
+    ]
+  };
+  const liveGroup = {
+    id: 'msg_441406d5-live-tools',
+    role: 'tool-group',
+    tools: [
+      { id: 'call_GwHMMHXf28QA81Zfm9vgRMap', name: 'queue_agent' },
+      { id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', name: 'wait_for_jobs' },
+      { id: 'call_newer_optimistic_only', name: 'shell' }
+    ]
+  };
+  const projected = reconcileToolCallProjection([durableGroup, liveGroup]);
+  assert.deepEqual(projected.map((message) => message.id), ['srv_seq_382_tools_0', 'msg_441406d5-live-tools']);
+  assert.deepEqual(projected[1].tools.map((tool) => tool.id), ['call_newer_optimistic_only']);
+  assert.deepEqual(
+    reconcileToolCallProjection(projected).map((message) => message.id),
+    ['srv_seq_382_tools_0', 'msg_441406d5-live-tools'],
+    'repeat resume reconciliation is idempotent'
+  );
+
   const scopedTools = new TranscriptStore('scoped-persisted-tools');
   scopedTools.applyIndex(envelope([30, 31], { rev: 1, roles: 'ua' }));
   scopedTools.addOptimistic({ clientKey: 'persisted-tools', role: 'tool-group', tools: [{ id: 'shared-call' }] }, 1, { persisted: true });
@@ -302,10 +360,10 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   ]);
   assert.deepEqual(
     scopedTools.reconcileOptimistic().map((entry) => entry.clientKey),
-    ['live-tools'],
-    'persisted tool IDs must match only their target segment while live entries retain later-turn matching'
+    ['persisted-tools', 'live-tools'],
+    'stable durable tool IDs retire every optimistic projection regardless of synthetic group or turn scope'
   );
-  assert.deepEqual(scopedTools.optimistic.map((entry) => entry.clientKey), ['persisted-tools']);
+  assert.deepEqual(scopedTools.optimistic.map((entry) => entry.clientKey), []);
 
   const terminalTools = new TranscriptStore('terminal-tools');
   terminalTools.applyIndex(envelope([40], { rev: 5 }));

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -42,6 +42,7 @@ type SQLiteStore struct {
 	hasGoal                  bool // true if sessions table has goal column
 	hasShare                 bool // true if sessions table has share column
 	hasTranscriptRev         bool // true if sessions table has transcript_rev column
+	hasMessagesTable         bool // true if the messages table exists
 	hasMessageCompactionTail bool // true if messages table has compaction_tail column
 }
 
@@ -1153,6 +1154,17 @@ func qualifiedMessageColumn(alias, column string) string {
 	return alias + "." + column
 }
 
+func (s *SQLiteStore) conversationMessageCountSelectSQL(sessionAlias string) string {
+	if s.hasMessageCount {
+		return "COALESCE(" + qualifiedMessageColumn(sessionAlias, "message_count") + ", 0)"
+	}
+	if !s.hasMessagesTable {
+		return "0"
+	}
+	return "(SELECT COUNT(*) FROM messages WHERE session_id = " + qualifiedMessageColumn(sessionAlias, "id") +
+		" AND " + countableConversationMessageSQL("", s.hasMessageCompactionTail) + ")"
+}
+
 func createMessageCountTriggers(db schemaExecutor) error {
 	oldCountable := countableConversationMessageSQL("old", true)
 	newCountable := countableConversationMessageSQL("new", true)
@@ -2079,10 +2091,7 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 	if s.hasShare {
 		shareCol = "s.share"
 	}
-	messageCountCol := "COALESCE(s.message_count, 0)"
-	if !s.hasMessageCount {
-		messageCountCol = "(SELECT COUNT(*) FROM messages WHERE session_id = s.id AND " + countableConversationMessageSQL("", s.hasMessageCompactionTail) + ")"
-	}
+	messageCountCol := s.conversationMessageCountSelectSQL("s")
 	worktreeDirCol := "''"
 	if s.hasWorktreeDir {
 		worktreeDirCol = "COALESCE(s.worktree_dir, '')"
@@ -2281,13 +2290,10 @@ func (s *SQLiteStore) Search(ctx context.Context, opts SearchOptions) ([]SearchR
 		return []SearchResult{}, nil
 	}
 
-	messageCountCol := "COALESCE(s.message_count, 0)"
+	messageCountCol := s.conversationMessageCountSelectSQL("s")
 	compactionTailClause := ""
 	if s.hasMessageCompactionTail {
 		compactionTailClause = " AND COALESCE(m.compaction_tail, FALSE) = FALSE"
-	}
-	if !s.hasMessageCount {
-		messageCountCol = "(SELECT COUNT(*) FROM messages WHERE session_id = s.id AND " + countableConversationMessageSQL("", s.hasMessageCompactionTail) + ")"
 	}
 
 	originCol := "'tui'"
@@ -3846,6 +3852,7 @@ func (s *SQLiteStore) setCurrentColumns() {
 	s.hasGoal = true
 	s.hasShare = true
 	s.hasTranscriptRev = true
+	s.hasMessagesTable = true
 	s.hasMessageCompactionTail = true
 }
 
@@ -3928,6 +3935,7 @@ func (s *SQLiteStore) probeMessageColumns() {
 		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
 			return
 		}
+		s.hasMessagesTable = true
 		if name == "compaction_tail" {
 			s.hasMessageCompactionTail = true
 		}
@@ -3992,6 +4000,7 @@ func (s *SQLiteStore) sessionSelectCols() string {
 	if s.hasLastMessageCount {
 		base += ", last_message_count"
 	}
+	base += ", " + s.conversationMessageCountSelectSQL("sessions") + " AS message_count"
 	base += ", status, tags"
 	if s.hasGoal {
 		base += ", goal"
@@ -4046,6 +4055,7 @@ func scanSessionRow(row *sql.Row, hasGeneratedTitles, hasCacheWriteTokens, hasCo
 	if hasLastMessageCount {
 		scanArgs = append(scanArgs, &sess.LastMessageCount)
 	}
+	scanArgs = append(scanArgs, &sess.MessageCount)
 	scanArgs = append(scanArgs, &status, &tags, &goalRaw, &shareRaw)
 	if hasCompactionSeq {
 		scanArgs = append(scanArgs, &sess.CompactionSeq)

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -100,6 +100,7 @@ type Session struct {
 	OutputTokens      int           `json:"output_tokens,omitempty"`       // Total output tokens used
 	LastTotalTokens   int           `json:"last_total_tokens,omitempty"`   // Last observed request context size (input+cached+output)
 	LastMessageCount  int           `json:"last_message_count,omitempty"`  // Legacy checkpoint count; estimator uses structural delta
+	MessageCount      int           `json:"message_count,omitempty"`       // User/assistant conversation messages visible as chat bubbles
 	Status            SessionStatus `json:"status,omitempty"`              // Session status
 	Tags              string        `json:"tags,omitempty"`                // Comma-separated tags
 	Goal              *Goal         `json:"goal,omitempty"`                // Persistent objective state for /goal


### PR DESCRIPTION
## What

Deliver two fixes that were live-tested after #956's final pushed head but were not included before #956 merged:

1. Keep selected-session `message_count` semantically consistent with normal listings and status responses.
2. Reconcile resumed optimistic tool calls with durable transcript groups by stable tool-call ID.

## Message counts

`selected_only` resolved sessions through full `Store.Get`/`GetByNumber` records and serialized the legacy model-context checkpoint (`LastMessageCount`). In long tool-heavy sessions that value matched raw transcript/event rows—for example `377`—while normal session lists and `/sessions/status` correctly reported `46` user/assistant conversation messages.

Full session lookups now carry the authoritative conversation `MessageCount`, using persisted `sessions.message_count` on current databases and the existing user/assistant count predicate for older read-only databases. Transcript row counts remain independent for virtualization.

## Resumed tool calls

An active response can appear simultaneously as:

- a durable selected-transcript group such as `srv_seq_382_tools_0`; and
- an optimistic resumed group such as `msg_441406d5-*`.

Both contained the same stable call IDs, but reconciliation keyed on synthetic message IDs, so both cards survived until reload. Durable calls are now authoritative by stable call ID. Fully covered optimistic groups are removed; partially covered groups retain only newer optimistic-only calls in order. Repeated resume is idempotent.

## Reproductions covered

- normal list, selected session, selected-only by ID, selected-only by number, transcript row count, and status all agree on conversation count
- tool/system/internal transcript rows do not inflate sidebar counts
- exact durable/optimistic overlap from the live report
- partial overlap with newer live tools
- repeat recovery/resume
- switch away/back
- session projection and mounted DOM each contain a call ID once

## Verification

- transcript-store, stream, sessions, and render Node suites
- focused session-store and handler tests
- isolated `go test ./... -count=1`
- `go build ./...`
- `git diff --check`
