### PR TITLE
fix: make response tail ownership authoritative

### DIFF
--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -244,6 +244,7 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 			if run, ok := s.responseRuns.get(activeResponseID); ok && run != nil {
 				run.mu.Lock()
 				resp["started_rev"] = run.startedRev
+				resp["run_epoch"] = run.runEpoch
 				run.mu.Unlock()
 			}
 		}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -873,12 +873,16 @@ type sessionMessagePartEntry struct {
 }
 
 type sessionMessageEntry struct {
-	ID             int64                     `json:"id"`
-	Sequence       int                       `json:"sequence"`
-	Role           string                    `json:"role"`
-	Parts          []sessionMessagePartEntry `json:"parts"`
-	CreatedAt      int64                     `json:"created_at"`
-	CompactionTail bool                      `json:"compaction_tail,omitempty"`
+	ID                      int64                     `json:"id"`
+	Sequence                int                       `json:"sequence"`
+	Role                    string                    `json:"role"`
+	Parts                   []sessionMessagePartEntry `json:"parts"`
+	CreatedAt               int64                     `json:"created_at"`
+	CompactionTail          bool                      `json:"compaction_tail,omitempty"`
+	ResponseID              string                    `json:"response_id,omitempty"`
+	AssistantSegmentOrdinal *int                      `json:"assistant_segment_ordinal,omitempty"`
+	SegmentStartSequence    int64                     `json:"segment_start_sequence,omitempty"`
+	SegmentEndSequence      int64                     `json:"segment_end_sequence,omitempty"`
 }
 
 type sessionMessagesResponse struct {
@@ -1382,11 +1386,18 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 			continue
 		}
 		entry := sessionMessageEntry{
-			ID:             msg.ID,
-			Sequence:       msg.Sequence,
-			Role:           string(msg.Role),
-			CreatedAt:      msg.CreatedAt.UnixMilli(),
-			CompactionTail: msg.CompactionTail,
+			ID:                   msg.ID,
+			Sequence:             msg.Sequence,
+			Role:                 string(msg.Role),
+			CreatedAt:            msg.CreatedAt.UnixMilli(),
+			CompactionTail:       msg.CompactionTail,
+			ResponseID:           msg.ResponseID,
+			SegmentStartSequence: msg.SegmentStartSequence,
+			SegmentEndSequence:   msg.SegmentEndSequence,
+		}
+		if msg.Role == llm.RoleAssistant && msg.ResponseID != "" {
+			ordinal := msg.AssistantSegmentOrdinal
+			entry.AssistantSegmentOrdinal = &ordinal
 		}
 		if msg.Role == llm.RoleEvent {
 			if marker, ok := llm.ParseModelSwapMarker(msg.ToLLMMessage()); ok {

--- a/cmd/serve_handlers_status.go
+++ b/cmd/serve_handlers_status.go
@@ -51,6 +51,7 @@ func (s *serveServer) handleSessionsStatus(w http.ResponseWriter, r *http.Reques
 		LongTitle           string `json:"long_title"`
 		ActiveRun           bool   `json:"active_run,omitempty"`
 		ActiveResponseID    string `json:"active_response_id,omitempty"`
+		RunEpoch            int64  `json:"run_epoch,omitempty"`
 		StartedRev          int64  `json:"started_rev,omitempty"`
 		TranscriptRev       int64  `json:"transcript_rev"`
 		MsgCount            int    `json:"message_count"`
@@ -79,13 +80,14 @@ func (s *serveServer) handleSessionsStatus(w http.ResponseWriter, r *http.Reques
 				transcriptRev = rev
 			}
 		}
-		activeResponseID, startedRev := s.activeTranscriptRun(sess.ID)
+		activeResponseID, startedRev, runEpoch := s.activeTranscriptRun(sess.ID)
 		result = append(result, statusEntry{
 			ID:                  sess.ID,
 			ShortTitle:          sess.PreferredShortTitle(),
 			LongTitle:           sess.PreferredLongTitle(),
 			ActiveRun:           activeIDs[sess.ID],
 			ActiveResponseID:    activeResponseID,
+			RunEpoch:            runEpoch,
 			StartedRev:          startedRev,
 			TranscriptRev:       transcriptRev,
 			MsgCount:            sess.MessageCount,

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -36,16 +36,20 @@ type responseRunRecoveryTool struct {
 }
 
 type responseRunRecoveryMessage struct {
-	ID             string
-	Role           string
-	Content        []byte
-	Created        int64
-	Tools          []responseRunRecoveryTool
-	Attachments    []map[string]any
-	Expanded       bool
-	Status         string
-	Usage          map[string]any
-	InterruptState string
+	ID                      string
+	Role                    string
+	Content                 []byte
+	Created                 int64
+	Tools                   []responseRunRecoveryTool
+	Attachments             []map[string]any
+	Expanded                bool
+	Status                  string
+	Usage                   map[string]any
+	InterruptState          string
+	ResponseID              string
+	AssistantSegmentOrdinal int
+	SegmentStartSequence    int64
+	SegmentEndSequence      int64
 }
 
 type responseRunRecoveryEvent struct {
@@ -61,6 +65,11 @@ type responseRunSubscribeResult struct {
 	minReplayAfter   int64
 }
 
+type responseRunSegmentRange struct {
+	Start int64
+	End   int64
+}
+
 type responseRun struct {
 	mu                 sync.Mutex
 	terminalMu         sync.Mutex
@@ -71,6 +80,7 @@ type responseRun struct {
 	reasoningEffort    string
 	reasoningEffortSet bool
 	created            int64
+	runEpoch           int64
 	startedRev         int64
 	finalRev           int64
 	finalRevReader     func() int64
@@ -91,6 +101,7 @@ type responseRun struct {
 	nextMessageOrdinal int64
 	currentAssistant   int
 	currentToolGroup   int
+	segmentRanges      map[int]responseRunSegmentRange
 	compactionEnabled  bool
 	subscribers        map[int]chan responseRunEvent
 	subscriberWarned   map[int]bool // tracks whether 75% buffer warning was logged
@@ -110,6 +121,37 @@ type startResponseRunOptions struct {
 	runtimeSetup              func(*llm.Request) error
 }
 
+type responseRunContextKey struct{}
+
+func withResponseRunContext(ctx context.Context, run *responseRun) context.Context {
+	if ctx == nil || run == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, responseRunContextKey{}, run)
+}
+
+func tagResponseRunMessage(ctx context.Context, msg llm.Message, segmentOrdinal int) llm.Message {
+	if ctx == nil {
+		return msg
+	}
+	run, _ := ctx.Value(responseRunContextKey{}).(*responseRun)
+	if run == nil {
+		return msg
+	}
+	msg.ResponseID = run.id
+	if msg.Role != llm.RoleAssistant {
+		msg.AssistantSegmentOrdinal = -1
+		return msg
+	}
+	msg.AssistantSegmentOrdinal = segmentOrdinal
+	run.mu.Lock()
+	rangeValue := run.segmentRanges[segmentOrdinal]
+	run.mu.Unlock()
+	msg.SegmentStartSequence = rangeValue.Start
+	msg.SegmentEndSequence = rangeValue.End
+	return msg
+}
+
 func newResponseRun(respID, sessionID, previousResponseID, model string, created int64, cancel context.CancelFunc) *responseRun {
 	return &responseRun{
 		id:                 respID,
@@ -121,6 +163,7 @@ func newResponseRun(respID, sessionID, previousResponseID, model string, created
 		maxRetainedEvents:  defaultResponseRunReplayLimit,
 		currentAssistant:   -1,
 		currentToolGroup:   -1,
+		segmentRanges:      make(map[int]responseRunSegmentRange),
 		compactionEnabled:  true,
 		subscribers:        make(map[int]chan responseRunEvent),
 		subscriberWarned:   make(map[int]bool),
@@ -238,10 +281,13 @@ func (r *responseRun) appendEventLocked(event string, payload map[string]any, te
 	if payload == nil {
 		payload = map[string]any{}
 	}
+	payload["response_id"] = r.id
+	payload["run_epoch"] = r.runEpoch
 	if event == "response.created" {
 		payload["started_rev"] = r.startedRev
 		if response := mapValue(payload["response"]); len(response) > 0 {
 			response["started_rev"] = r.startedRev
+			response["run_epoch"] = r.runEpoch
 		}
 	}
 	if terminal {
@@ -308,9 +354,37 @@ func (r *responseRun) storeEventLocked(stored responseRunEvent, terminal bool) {
 	}
 }
 
-func encodeTextDeltaPayload(outputIndex int, delta string, sequenceNumber int64) ([]byte, error) {
-	data := make([]byte, 0, 80+len(delta))
-	data = append(data, `{"output_index":`...)
+func responseRunInt64Value(value any, fallback int64) int64 {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	case json.Number:
+		if parsed, err := typed.Int64(); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func responseRunIntValue(value any, fallback int) int {
+	return int(responseRunInt64Value(value, int64(fallback)))
+}
+
+func encodeTextDeltaPayloadWithIdentity(responseID string, runEpoch int64, outputIndex, segmentOrdinal int, segmentStartSequence int64, delta string, sequenceNumber int64) ([]byte, error) {
+	data := make([]byte, 0, 160+len(responseID)+len(delta))
+	data = append(data, `{"response_id":`...)
+	data = appendJSONString(data, responseID)
+	data = append(data, `,"run_epoch":`...)
+	data = strconv.AppendInt(data, runEpoch, 10)
+	data = append(data, `,"assistant_segment_ordinal":`...)
+	data = strconv.AppendInt(data, int64(segmentOrdinal), 10)
+	data = append(data, `,"segment_start_sequence":`...)
+	data = strconv.AppendInt(data, segmentStartSequence, 10)
+	data = append(data, `,"output_index":`...)
 	data = strconv.AppendInt(data, int64(outputIndex), 10)
 	data = append(data, `,"delta":`...)
 	if utf8.ValidString(delta) {
@@ -328,23 +402,38 @@ func encodeTextDeltaPayload(outputIndex int, delta string, sequenceNumber int64)
 	return data, nil
 }
 
-// appendTextDeltaEvent is a fast path for response.output_text.delta that avoids
+// appendTextDeltaSegmentEvent is a fast path for response.output_text.delta that avoids
 // allocating a map[string]any or a typed payload on every streamed token.
-func (r *responseRun) appendTextDeltaEvent(outputIndex int, delta string) error {
+func (r *responseRun) appendTextDeltaSegmentEvent(outputIndex, segmentOrdinal int, delta string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.lastSequenceNumber++
+	sequenceNumber := r.lastSequenceNumber
+	rangeValue, hadRange := r.segmentRanges[segmentOrdinal]
+	previousRange := rangeValue
+	if rangeValue.Start == 0 {
+		rangeValue.Start = sequenceNumber
+	}
+	rangeValue.End = sequenceNumber
+	r.segmentRanges[segmentOrdinal] = rangeValue
 
-	data, err := encodeTextDeltaPayload(outputIndex, delta, r.lastSequenceNumber)
+	data, err := encodeTextDeltaPayloadWithIdentity(r.id, r.runEpoch, outputIndex, segmentOrdinal, rangeValue.Start, delta, sequenceNumber)
 	if err != nil {
 		r.lastSequenceNumber--
+		if hadRange {
+			r.segmentRanges[segmentOrdinal] = previousRange
+		} else {
+			delete(r.segmentRanges, segmentOrdinal)
+		}
 		return err
 	}
 
 	if delta != "" {
 		r.closeToolGroupLocked()
-		idx := r.ensureAssistantMessageLocked()
+		idx := r.ensureAssistantMessageLocked(segmentOrdinal)
 		r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, delta...)
+		r.recoveryMessages[idx].SegmentStartSequence = rangeValue.Start
+		r.recoveryMessages[idx].SegmentEndSequence = rangeValue.End
 	}
 
 	r.storeEventLocked(responseRunEvent{
@@ -441,12 +530,14 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 			return
 		}
 		r.closeToolGroupLocked()
-		idx := r.ensureAssistantMessageLocked()
+		ordinal := responseRunIntValue(payload["assistant_segment_ordinal"], 0)
+		idx := r.ensureAssistantMessageLocked(ordinal)
 		r.recoveryMessages[idx].Content = append(r.recoveryMessages[idx].Content, delta...)
+		r.recoveryMessages[idx].SegmentStartSequence = responseRunInt64Value(payload["segment_start_sequence"], 0)
+		r.recoveryMessages[idx].SegmentEndSequence = responseRunInt64Value(payload["sequence_number"], 0)
 	case "response.output_text.new_segment":
 		r.closeToolGroupLocked()
 		r.currentAssistant = -1
-		r.ensureAssistantMessageLocked()
 	case "response.output_item.added":
 		item := mapValue(payload["item"])
 		if stringValue(item["type"]) != "function_call" {
@@ -569,14 +660,23 @@ func (r *responseRun) nextRecoveryMessageIDLocked(kind string) string {
 	return fmt.Sprintf("%s_%s_%d", r.id, kind, r.nextMessageOrdinal)
 }
 
-func (r *responseRun) ensureAssistantMessageLocked() int {
+func (r *responseRun) ensureAssistantMessageLocked(segmentOrdinal int) int {
 	if r.currentAssistant >= 0 && r.currentAssistant < len(r.recoveryMessages) {
-		return r.currentAssistant
+		current := &r.recoveryMessages[r.currentAssistant]
+		if current.AssistantSegmentOrdinal == segmentOrdinal {
+			return r.currentAssistant
+		}
+		r.currentAssistant = -1
 	}
+	rangeValue := r.segmentRanges[segmentOrdinal]
 	r.recoveryMessages = append(r.recoveryMessages, responseRunRecoveryMessage{
-		ID:      r.nextRecoveryMessageIDLocked("assistant"),
-		Role:    "assistant",
-		Created: time.Now().UnixMilli(),
+		ID:                      r.nextRecoveryMessageIDLocked("assistant"),
+		Role:                    "assistant",
+		Created:                 time.Now().UnixMilli(),
+		ResponseID:              r.id,
+		AssistantSegmentOrdinal: segmentOrdinal,
+		SegmentStartSequence:    rangeValue.Start,
+		SegmentEndSequence:      rangeValue.End,
 	})
 	r.currentAssistant = len(r.recoveryMessages) - 1
 	return r.currentAssistant
@@ -690,6 +790,7 @@ func (r *responseRun) snapshot() map[string]any {
 		"session_id":           r.sessionID,
 		"previous_response_id": r.previousResponseID,
 		"last_sequence_number": r.lastSequenceNumber,
+		"run_epoch":            r.runEpoch,
 		"started_rev":          r.startedRev,
 	}
 	if r.status != "in_progress" {
@@ -723,10 +824,26 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 
 	messages := make([]map[string]any, 0, len(r.recoveryMessages))
 	for _, msg := range r.recoveryMessages {
+		responseID := msg.ResponseID
+		if responseID == "" {
+			responseID = r.id
+		}
 		entry := map[string]any{
-			"id":      msg.ID,
-			"role":    msg.Role,
-			"created": msg.Created,
+			"id":          msg.ID,
+			"role":        msg.Role,
+			"created":     msg.Created,
+			"responseId":  responseID,
+			"response_id": responseID,
+		}
+		if msg.Role == "assistant" {
+			entry["assistantSegmentOrdinal"] = msg.AssistantSegmentOrdinal
+			entry["assistant_segment_ordinal"] = msg.AssistantSegmentOrdinal
+			if msg.SegmentStartSequence > 0 {
+				entry["segment_start_sequence"] = msg.SegmentStartSequence
+			}
+			if msg.SegmentEndSequence > 0 {
+				entry["segment_end_sequence"] = msg.SegmentEndSequence
+			}
 		}
 		if len(msg.Content) > 0 {
 			entry["content"] = string(msg.Content)
@@ -847,14 +964,15 @@ func (r *responseRun) resolveApprovalRecovery(approvalID string) {
 }
 
 type responseRunManager struct {
-	mu                sync.Mutex
-	runs              map[string]*responseRun
-	activeBySession   map[string]string
-	idempotencyByKey  map[string]string
-	cleanupTimers     map[string]*time.Timer
-	terminalRetention time.Duration
-	runWG             sync.WaitGroup
-	closed            bool
+	mu                 sync.Mutex
+	runs               map[string]*responseRun
+	activeBySession    map[string]string
+	idempotencyByKey   map[string]string
+	cleanupTimers      map[string]*time.Timer
+	nextEpochBySession map[string]int64
+	terminalRetention  time.Duration
+	runWG              sync.WaitGroup
+	closed             bool
 }
 
 const (
@@ -899,11 +1017,12 @@ func newServeResponseRunManager() *responseRunManager {
 
 func newServeResponseRunManagerWithRetention(retention time.Duration) *responseRunManager {
 	return &responseRunManager{
-		runs:              make(map[string]*responseRun),
-		activeBySession:   make(map[string]string),
-		idempotencyByKey:  make(map[string]string),
-		cleanupTimers:     make(map[string]*time.Timer),
-		terminalRetention: retention,
+		runs:               make(map[string]*responseRun),
+		activeBySession:    make(map[string]string),
+		idempotencyByKey:   make(map[string]string),
+		cleanupTimers:      make(map[string]*time.Timer),
+		nextEpochBySession: make(map[string]int64),
+		terminalRetention:  retention,
 	}
 }
 
@@ -957,6 +1076,13 @@ func (m *responseRunManager) createOrGetByIdempotency(run *responseRun, idempote
 	if _, exists := m.runs[run.id]; exists {
 		return nil, false, fmt.Errorf("response run %q already exists", run.id)
 	}
+	previousEpoch := m.nextEpochBySession[run.sessionID]
+	nextEpoch := previousEpoch + 1
+	if now := time.Now().UnixMicro(); nextEpoch < now {
+		nextEpoch = now
+	}
+	m.nextEpochBySession[run.sessionID] = nextEpoch
+	run.runEpoch = nextEpoch
 	m.runs[run.id] = run
 	if key != "" {
 		m.idempotencyByKey[key] = run.id
@@ -1288,11 +1414,13 @@ func writeStoredResponseEvent(w io.Writer, ev responseRunEvent) error {
 }
 
 type responseRunStreamState struct {
-	outputIndex        int
-	toolsSeen          bool
-	model              string
-	reasoningEffort    string
-	reasoningEffortSet bool
+	outputIndex              int
+	toolsSeen                bool
+	assistantBoundaryPending bool
+	assistantSegmentOrdinal  int
+	model                    string
+	reasoningEffort          string
+	reasoningEffortSet       bool
 }
 
 func newResponseRunStreamState(model, reasoningEffort string) *responseRunStreamState {
@@ -1361,15 +1489,18 @@ func (s *serveServer) persistResponseRunErrorEvent(runtime *serveRuntime, sessio
 func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *responseRun, state *responseRunStreamState, ev llm.Event) error {
 	switch ev.Type {
 	case llm.EventTextDelta:
-		if state.toolsSeen {
+		if state.toolsSeen || state.assistantBoundaryPending {
+			state.assistantSegmentOrdinal++
 			if err := run.appendEvent("response.output_text.new_segment", map[string]any{
-				"output_index": state.outputIndex,
+				"output_index":              state.outputIndex,
+				"assistant_segment_ordinal": state.assistantSegmentOrdinal,
 			}); err != nil {
 				return err
 			}
 			state.toolsSeen = false
+			state.assistantBoundaryPending = false
 		}
-		return run.appendTextDeltaEvent(state.outputIndex, ev.Text)
+		return run.appendTextDeltaSegmentEvent(state.outputIndex, state.assistantSegmentOrdinal, ev.Text)
 	case llm.EventAttemptDiscard:
 		state.toolsSeen = false
 		return run.appendEvent("response.attempt.discard", map[string]any{
@@ -1379,8 +1510,11 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 		if ev.Tool == nil {
 			return nil
 		}
-		// Suppress tool calls for server-executed tools in API mode
+		// Suppress tool call metadata for server-executed tools in API mode, but
+		// retain the assistant boundary so persisted callback turn ordinals and
+		// streamed segment identities remain aligned end to end.
 		if s.suppressResponseRunServerToolEvent(runtime, ev.Tool.Name) {
+			state.toolsSeen = true
 			return nil
 		}
 		state.toolsSeen = true
@@ -1392,8 +1526,9 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 			"arguments": string(ev.Tool.Arguments),
 		}
 		if err := run.appendEvent("response.output_item.added", map[string]any{
-			"output_index": state.outputIndex,
-			"item":         item,
+			"output_index":              state.outputIndex,
+			"assistant_segment_ordinal": state.assistantSegmentOrdinal,
+			"item":                      item,
 		}); err != nil {
 			return err
 		}
@@ -1496,6 +1631,10 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 		}
 		return run.appendEvent("response.retry", payload)
 	case llm.EventInterjection:
+		// One or more committed interjections form a single user boundary before
+		// the next assistant text. Defer the ordinal bump until text arrives so a
+		// batch of interjections cannot create skipped segment identities.
+		state.assistantBoundaryPending = true
 		payload := map[string]any{
 			"text": ev.Text,
 		}
@@ -1602,10 +1741,7 @@ func (s *serveServer) storeCompletedResponseRun(runtime *serveRuntime, sessionID
 		return "", err
 	}
 	if result.Text.Len() > 0 {
-		if err := run.appendEvent("response.output_text.delta", map[string]any{
-			"output_index": 0,
-			"delta":        result.Text.String(),
-		}); err != nil {
+		if err := run.appendTextDeltaSegmentEvent(0, 0, result.Text.String()); err != nil {
 			cleanup()
 			return "", err
 		}
@@ -1945,6 +2081,7 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 	//  - serve.response_timeout bounds orphan-run lifetime.
 	runCtx, cancel := context.WithTimeout(context.Background(), s.responseTimeout())
 	run := newResponseRun(respID, sessionID, options.previousResponseID, model, created, cancel)
+	runCtx = withResponseRunContext(runCtx, run)
 	s.configureResponseRunRevision(run, sessionID)
 	createdRun, duplicate, err := mgr.createOrGetByIdempotency(run, options.idempotencyKey)
 	if err != nil {

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1784,9 +1784,14 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 		return
 	}
 
+	replay := subscription.replay
+	replayThrough := after
+	if len(replay) > 0 {
+		replayThrough = replay[len(replay)-1].Sequence
+	}
+	w.Header().Set("X-Term-LLM-Replay-Through", strconv.FormatInt(replayThrough, 10))
 	setSSEHeaders(w)
 	flusher.Flush()
-	replay := subscription.replay
 	ch := subscription.ch
 	subscriberID := subscription.id
 

--- a/cmd/serve_response_runs_bench_test.go
+++ b/cmd/serve_response_runs_bench_test.go
@@ -10,8 +10,8 @@ func BenchmarkResponseRunAppendTextDeltaRetainedReplay(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := run.appendTextDeltaEvent(0, ""); err != nil {
-			b.Fatalf("appendTextDeltaEvent failed: %v", err)
+		if err := run.appendTextDeltaSegmentEvent(0, 0, ""); err != nil {
+			b.Fatalf("appendTextDeltaSegmentEvent failed: %v", err)
 		}
 	}
 }

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"math"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -421,6 +422,39 @@ func TestAppendResponseRunEventKeepsClientToolFileChanges(t *testing.T) {
 	}
 	if !sawFileChange {
 		t.Fatalf("events = %+v, want response.file_change for non-server tool", run.events)
+	}
+}
+
+func TestStreamResponseRunEventsReportsAuthoritativeReplayBoundary(t *testing.T) {
+	run := newResponseRun("resp_replay_boundary", "sess_replay_boundary", "", "mock", time.Now().Unix(), func() {})
+	if err := run.appendEvent("response.created", map[string]any{"response": map[string]any{"id": run.id}}); err != nil {
+		t.Fatalf("append created event: %v", err)
+	}
+	if err := run.appendEvent("response.output_text.delta", map[string]any{"delta": "historical"}); err != nil {
+		t.Fatalf("append text event: %v", err)
+	}
+	run.mu.Lock()
+	run.status = "completed"
+	run.mu.Unlock()
+
+	for _, tc := range []struct {
+		name  string
+		after int64
+		want  string
+	}{
+		{name: "replayed events", after: 0, want: "2"},
+		{name: "empty replay", after: 2, want: "2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			server := &serveServer{}
+			server.streamResponseRunEvents(context.Background(), recorder, run, tc.after)
+			response := recorder.Result()
+			defer response.Body.Close()
+			if got := response.Header.Get("X-Term-LLM-Replay-Through"); got != tc.want {
+				t.Fatalf("X-Term-LLM-Replay-Through = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -164,11 +164,11 @@ func TestResponseRunFinalRevisionReadDoesNotBlockEventMutex(t *testing.T) {
 	}
 }
 
-func TestEncodeTextDeltaPayloadMatchesJSONMarshalForInvalidUTF8(t *testing.T) {
+func TestEncodeTextDeltaPayloadWithIdentityMatchesJSONMarshalForInvalidUTF8(t *testing.T) {
 	delta := string([]byte{'o', 'k', 0xff, '!'})
-	data, err := encodeTextDeltaPayload(2, delta, 7)
+	data, err := encodeTextDeltaPayloadWithIdentity("resp_identity", 3, 2, 1, 5, delta, 7)
 	if err != nil {
-		t.Fatalf("encodeTextDeltaPayload() error = %v", err)
+		t.Fatalf("encodeTextDeltaPayloadWithIdentity() error = %v", err)
 	}
 
 	var got map[string]any
@@ -178,8 +178,8 @@ func TestEncodeTextDeltaPayloadMatchesJSONMarshalForInvalidUTF8(t *testing.T) {
 	if got["delta"] != "ok�!" {
 		t.Fatalf("delta = %q, want replacement-char-normalized string", got["delta"])
 	}
-	if got["output_index"] != float64(2) || got["sequence_number"] != float64(7) {
-		t.Fatalf("payload = %#v, want output_index=2 sequence_number=7", got)
+	if got["response_id"] != "resp_identity" || got["run_epoch"] != float64(3) || got["assistant_segment_ordinal"] != float64(1) || got["segment_start_sequence"] != float64(5) || got["output_index"] != float64(2) || got["sequence_number"] != float64(7) {
+		t.Fatalf("payload = %#v, want stable response/segment identity and sequence", got)
 	}
 }
 
@@ -391,6 +391,37 @@ func TestAppendResponseRunEventSuppressesServerToolMetadata(t *testing.T) {
 	}
 }
 
+func TestSuppressedServerToolStillAdvancesAssistantSegmentIdentity(t *testing.T) {
+	registry := llm.NewToolRegistry()
+	registry.Register(&echoTool{})
+	runtime := &serveRuntime{engine: llm.NewEngine(llm.NewMockProvider("mock"), registry)}
+	server := &serveServer{cfg: serveServerConfig{suppressServerTools: true}}
+	run := newResponseRun("resp_suppressed_boundary", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	state := newResponseRunStreamState("mock", "")
+	for _, event := range []llm.Event{
+		{Type: llm.EventTextDelta, Text: "before"},
+		{Type: llm.EventToolCall, Tool: &llm.ToolCall{ID: "call-hidden", Name: "echo"}},
+		{Type: llm.EventTextDelta, Text: "after"},
+	} {
+		if err := server.appendResponseRunEvent(runtime, run, state, event); err != nil {
+			t.Fatalf("append %v: %v", event.Type, err)
+		}
+	}
+	if len(run.events) != 3 || run.events[1].Event != "response.output_text.new_segment" {
+		t.Fatalf("events = %+v, want text/boundary/text without hidden tool metadata", run.events)
+	}
+	var first, second map[string]any
+	if err := json.Unmarshal(run.events[0].Data, &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(run.events[2].Data, &second); err != nil {
+		t.Fatal(err)
+	}
+	if first["assistant_segment_ordinal"] != float64(0) || second["assistant_segment_ordinal"] != float64(1) {
+		t.Fatalf("segment identities first=%v second=%v", first, second)
+	}
+}
+
 func TestAppendResponseRunEventKeepsClientToolFileChanges(t *testing.T) {
 	registry := llm.NewToolRegistry()
 	runtime := &serveRuntime{engine: llm.NewEngine(llm.NewMockProvider("mock"), registry)}
@@ -589,8 +620,8 @@ func TestResponseRunCompactionKeepsReplayWindowInOrder(t *testing.T) {
 	run.maxRetainedEvents = 3
 
 	for i := 0; i < 8; i++ {
-		if err := run.appendTextDeltaEvent(0, ""); err != nil {
-			t.Fatalf("appendTextDeltaEvent failed at %d: %v", i, err)
+		if err := run.appendTextDeltaSegmentEvent(0, 0, ""); err != nil {
+			t.Fatalf("appendTextDeltaSegmentEvent failed at %d: %v", i, err)
 		}
 	}
 
@@ -766,8 +797,8 @@ func TestResponseRunInteractiveRecoveryDoesNotDisableCompaction(t *testing.T) {
 	}
 
 	for i := 0; i < 6; i++ {
-		if err := run.appendTextDeltaEvent(0, "x"); err != nil {
-			t.Fatalf("appendTextDeltaEvent failed at %d: %v", i, err)
+		if err := run.appendTextDeltaSegmentEvent(0, 0, "x"); err != nil {
+			t.Fatalf("appendTextDeltaSegmentEvent failed at %d: %v", i, err)
 		}
 	}
 
@@ -809,15 +840,17 @@ func TestResponseRunInteractiveRecoveryDoesNotDisableCompaction(t *testing.T) {
 
 func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	run := newResponseRun("resp_interjection", "sess_test", "", "mock", time.Now().Unix(), func() {})
+	streamState := newResponseRunStreamState("mock", "")
+	server := &serveServer{}
 
-	if err := run.appendTextDeltaEvent(0, "before"); err != nil {
-		t.Fatalf("appendTextDeltaEvent before: %v", err)
+	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventTextDelta, Text: "before"}); err != nil {
+		t.Fatalf("appendTextDeltaSegmentEvent before: %v", err)
 	}
-	if err := run.appendEvent("response.interjection", map[string]any{"text": "check X"}); err != nil {
+	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventInterjection, Text: "check X"}); err != nil {
 		t.Fatalf("append interjection: %v", err)
 	}
-	if err := run.appendTextDeltaEvent(0, "after"); err != nil {
-		t.Fatalf("appendTextDeltaEvent after: %v", err)
+	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventTextDelta, Text: "after"}); err != nil {
+		t.Fatalf("appendTextDeltaSegmentEvent after: %v", err)
 	}
 
 	recovery := run.recoveryPayloadLocked()
@@ -842,6 +875,12 @@ func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	}
 	if got := messages[1]["interruptState"]; got != "interject" {
 		t.Fatalf("messages[1].interruptState = %v, want interject", got)
+	}
+	if got := messages[2]["content"]; got != "after" {
+		t.Fatalf("messages[2].content = %v, want after", got)
+	}
+	if first, second := messages[0]["assistant_segment_ordinal"], messages[2]["assistant_segment_ordinal"]; first != 0 || second != 1 {
+		t.Fatalf("assistant segment ordinals = %v, %v; want 0, 1 across interjection", first, second)
 	}
 	atts := []map[string]any{{"name": "image 1", "type": "image/png"}}
 	if err := run.appendEvent("response.interjection", map[string]any{"text": "see image", "interjection_id": "img-1", "attachments": atts}); err != nil {
@@ -1051,5 +1090,77 @@ func TestStreamResponseRunEventsWritesTerminalErrorWhenSubscriberOverflows(t *te
 	}
 	if streamErrorIndex > doneIndex {
 		t.Fatalf("stream_error should be emitted before [DONE], got: %q", body)
+	}
+}
+
+func TestResponseRunTextDeltaCarriesStableSegmentIdentityAcrossReplayAndRecovery(t *testing.T) {
+	run := newResponseRun("resp_segment_identity", "session_identity", "", "test", time.Now().Unix(), nil)
+	manager := newServeResponseRunManagerWithRetention(time.Minute)
+	defer manager.Close()
+	if err := manager.create(run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := run.appendTextDeltaSegmentEvent(0, 0, "prefix"); err != nil {
+		t.Fatalf("append first segment: %v", err)
+	}
+	if err := run.appendEvent("response.output_text.new_segment", map[string]any{
+		"assistant_segment_ordinal": 1,
+	}); err != nil {
+		t.Fatalf("append boundary: %v", err)
+	}
+	if err := run.appendTextDeltaSegmentEvent(1, 1, "suffix"); err != nil {
+		t.Fatalf("append second segment: %v", err)
+	}
+
+	subscription := run.subscribe(0)
+	if len(subscription.replay) != 3 {
+		t.Fatalf("replay events=%d want 3", len(subscription.replay))
+	}
+	for _, event := range []responseRunEvent{subscription.replay[0], subscription.replay[2]} {
+		var payload map[string]any
+		if err := json.Unmarshal(event.Data, &payload); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		if payload["response_id"] != run.id || int64(payload["run_epoch"].(float64)) != run.runEpoch {
+			t.Fatalf("event owner=%v epoch=%v", payload["response_id"], payload["run_epoch"])
+		}
+	}
+	var first, second map[string]any
+	_ = json.Unmarshal(subscription.replay[0].Data, &first)
+	_ = json.Unmarshal(subscription.replay[2].Data, &second)
+	if first["assistant_segment_ordinal"] != float64(0) || second["assistant_segment_ordinal"] != float64(1) {
+		t.Fatalf("segment ordinals first=%v second=%v", first, second)
+	}
+	if first["segment_start_sequence"] != float64(1) || second["segment_start_sequence"] != float64(3) {
+		t.Fatalf("segment start sequences first=%v second=%v", first, second)
+	}
+
+	snapshot := run.snapshot()
+	recovery := snapshot["recovery"].(map[string]any)
+	messages := recovery["messages"].([]map[string]any)
+	if len(messages) != 2 {
+		t.Fatalf("recovery assistant messages=%d want 2", len(messages))
+	}
+	for ordinal, message := range messages {
+		if message["response_id"] != run.id || message["assistant_segment_ordinal"] != ordinal {
+			t.Fatalf("recovery[%d]=%v", ordinal, message)
+		}
+	}
+}
+
+func TestResponseRunManagerAssignsMonotonicSessionEpochs(t *testing.T) {
+	manager := newServeResponseRunManagerWithRetention(time.Minute)
+	defer manager.Close()
+	beforeCreate := time.Now().UnixMilli()
+	first := newResponseRun("resp_epoch_A", "session_epoch", "", "test", 1, nil)
+	second := newResponseRun("resp_epoch_B", "session_epoch", "", "test", 2, nil)
+	if err := manager.create(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.create(second); err != nil {
+		t.Fatal(err)
+	}
+	if first.runEpoch < beforeCreate || second.runEpoch <= first.runEpoch {
+		t.Fatalf("restart-safe epochs before=%d first=%d second=%d", beforeCreate, first.runEpoch, second.runEpoch)
 	}
 }

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -1501,6 +1501,7 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 	// Snapshot fires before each EventToolCall so partial content survives a
 	// consumer cancellation mid-turn.
 	rt.engine.SetAssistantSnapshotCallback(func(cbCtx context.Context, callbackTurnIndex int, assistantMsg llm.Message) error {
+		assistantMsg = tagResponseRunMessage(cbCtx, assistantMsg, callbackTurnIndex)
 		producedMu.Lock()
 		defer producedMu.Unlock()
 		upsertPendingAssistantLocked(cbCtx, assistantMsg, false)
@@ -1512,6 +1513,7 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 	defer rt.engine.SetAssistantSnapshotCallback(nil)
 
 	rt.engine.SetResponseCompletedCallback(func(cbCtx context.Context, callbackTurnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
+		assistantMsg = tagResponseRunMessage(cbCtx, assistantMsg, callbackTurnIndex)
 		producedMu.Lock()
 		defer producedMu.Unlock()
 		upsertPendingAssistantLocked(cbCtx, assistantMsg, true)
@@ -1526,6 +1528,9 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 	// plain-append the rest (tool results or interjections). Reset pending at
 	// end of turn.
 	rt.engine.SetTurnCompletedCallback(func(cbCtx context.Context, callbackTurnIndex int, msgs []llm.Message, metrics llm.TurnMetrics) error {
+		for i := range msgs {
+			msgs[i] = tagResponseRunMessage(cbCtx, msgs[i], callbackTurnIndex)
+		}
 		func() {
 			producedMu.Lock()
 			defer producedMu.Unlock()

--- a/cmd/serve_transcript.go
+++ b/cmd/serve_transcript.go
@@ -19,10 +19,12 @@ const (
 )
 
 type transcriptRowsResponse struct {
-	Seqs  []int   `json:"seqs"`
-	IDs   []int64 `json:"ids"`
-	Roles string  `json:"roles"`
-	Flags []int   `json:"flags"`
+	Seqs                     []int    `json:"seqs"`
+	IDs                      []int64  `json:"ids"`
+	Roles                    string   `json:"roles"`
+	Flags                    []int    `json:"flags"`
+	ResponseIDs              []string `json:"response_ids"`
+	AssistantSegmentOrdinals []int    `json:"assistant_segment_ordinals"`
 }
 
 type transcriptResponse struct {
@@ -30,6 +32,7 @@ type transcriptResponse struct {
 	CompactionSeq    int                    `json:"compaction_seq"`
 	CompactionCount  int                    `json:"compaction_count"`
 	ActiveResponseID string                 `json:"active_response_id,omitempty"`
+	RunEpoch         int64                  `json:"run_epoch,omitempty"`
 	StartedRev       int64                  `json:"started_rev,omitempty"`
 	Rows             transcriptRowsResponse `json:"rows"`
 }
@@ -76,21 +79,21 @@ func transcriptIndexerForWeb(store session.Store) (session.TranscriptIndexer, bo
 	return indexer, ok
 }
 
-func (s *serveServer) activeTranscriptRun(sessionID string) (string, int64) {
+func (s *serveServer) activeTranscriptRun(sessionID string) (string, int64, int64) {
 	if s.responseRuns == nil {
-		return "", 0
+		return "", 0, 0
 	}
 	id := s.responseRuns.activeRunID(sessionID)
 	if id == "" {
-		return "", 0
+		return "", 0, 0
 	}
 	run, ok := s.responseRuns.get(id)
 	if !ok || run == nil {
-		return id, 0
+		return id, 0, 0
 	}
 	run.mu.Lock()
 	defer run.mu.Unlock()
-	return id, run.startedRev
+	return id, run.startedRev, run.runEpoch
 }
 
 func transcriptJSON(payload any) ([]byte, string, error) {
@@ -121,9 +124,11 @@ func writeTranscriptJSON(w http.ResponseWriter, r *http.Request, rev int64, payl
 
 func transcriptRowsFromSnapshot(snapshot session.TranscriptSnapshot) transcriptRowsResponse {
 	rows := transcriptRowsResponse{
-		Seqs:  make([]int, 0, len(snapshot.Items)),
-		IDs:   make([]int64, 0, len(snapshot.Items)),
-		Flags: make([]int, 0, len(snapshot.Items)),
+		Seqs:                     make([]int, 0, len(snapshot.Items)),
+		IDs:                      make([]int64, 0, len(snapshot.Items)),
+		Flags:                    make([]int, 0, len(snapshot.Items)),
+		ResponseIDs:              make([]string, 0, len(snapshot.Items)),
+		AssistantSegmentOrdinals: make([]int, 0, len(snapshot.Items)),
 	}
 	var roles strings.Builder
 	roles.Grow(len(snapshot.Items))
@@ -131,6 +136,8 @@ func transcriptRowsFromSnapshot(snapshot session.TranscriptSnapshot) transcriptR
 		rows.Seqs = append(rows.Seqs, item.Seq)
 		rows.IDs = append(rows.IDs, item.ID)
 		rows.Flags = append(rows.Flags, int(item.Flags))
+		rows.ResponseIDs = append(rows.ResponseIDs, item.ResponseID)
+		rows.AssistantSegmentOrdinals = append(rows.AssistantSegmentOrdinals, item.AssistantSegmentOrdinal)
 		roles.WriteByte(transcriptRoleCode(item.Role))
 	}
 	rows.Roles = roles.String()
@@ -138,12 +145,13 @@ func transcriptRowsFromSnapshot(snapshot session.TranscriptSnapshot) transcriptR
 }
 
 func (s *serveServer) transcriptResponseFromSnapshot(sessionID string, snapshot session.TranscriptSnapshot) transcriptResponse {
-	activeResponseID, startedRev := s.activeTranscriptRun(sessionID)
+	activeResponseID, startedRev, runEpoch := s.activeTranscriptRun(sessionID)
 	return transcriptResponse{
 		Rev:              snapshot.Rev,
 		CompactionSeq:    snapshot.CompactionSeq,
 		CompactionCount:  snapshot.CompactionCount,
 		ActiveResponseID: activeResponseID,
+		RunEpoch:         runEpoch,
 		StartedRev:       startedRev,
 		Rows:             transcriptRowsFromSnapshot(snapshot),
 	}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -217,10 +217,14 @@ const (
 
 // Message holds a role with structured parts.
 type Message struct {
-	Role         Role
-	Parts        []Part
-	CacheAnchor  bool   // provider should apply cache_control to this message (Anthropic-specific)
-	ApprovalRole string `json:",omitempty"` // Optional role override for guardian/policy-review transcripts only.
+	Role                    Role
+	Parts                   []Part
+	CacheAnchor             bool   // provider should apply cache_control to this message (Anthropic-specific)
+	ApprovalRole            string `json:",omitempty"` // Optional role override for guardian/policy-review transcripts only.
+	ResponseID              string `json:",omitempty"` // Stable response owner for persisted/UI projection identity; providers ignore it.
+	AssistantSegmentOrdinal int    `json:",omitempty"` // Response-scoped assistant segment identity; -1 when not applicable.
+	SegmentStartSequence    int64  `json:",omitempty"` // First response event sequence for this assistant segment, when known.
+	SegmentEndSequence      int64  `json:",omitempty"` // Last response event sequence covered by this persisted segment, when known.
 }
 
 // ReasoningKind classifies provider reasoning/thinking payloads for safe display.

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -2052,6 +2052,21 @@ const sanitizeMessage = (msg) => {
     created: asTimestamp(msg.created)
   };
 
+  const responseId = String(msg.responseId || msg.response_id || '').trim();
+  if (responseId) base.responseId = responseId;
+  const segmentOrdinal = Number(msg.assistantSegmentOrdinal ?? msg.assistant_segment_ordinal);
+  if (role === 'assistant' && Number.isFinite(segmentOrdinal) && segmentOrdinal >= 0) {
+    base.assistantSegmentOrdinal = Math.trunc(segmentOrdinal);
+  }
+  const segmentStartSequence = Number(msg.segmentStartSequence ?? msg.segment_start_sequence);
+  const segmentEndSequence = Number(msg.segmentEndSequence ?? msg.segment_end_sequence);
+  if (Number.isFinite(segmentStartSequence) && segmentStartSequence > 0) base.segmentStartSequence = Math.trunc(segmentStartSequence);
+  if (Number.isFinite(segmentEndSequence) && segmentEndSequence > 0) base.segmentEndSequence = Math.trunc(segmentEndSequence);
+  const runEpoch = Number(msg.runEpoch ?? msg.run_epoch);
+  if (Number.isFinite(runEpoch) && runEpoch > 0) base.runEpoch = Math.trunc(runEpoch);
+  if (msg.optimistic === true) base.optimistic = true;
+  if (typeof msg.clientKey === 'string' && msg.clientKey) base.clientKey = msg.clientKey;
+
   if (role === 'user' || role === 'assistant' || role === 'error') {
     base.content = String(msg.content || '');
     if (role === 'assistant' && msg.usage && typeof msg.usage === 'object') {
@@ -2166,6 +2181,14 @@ const sanitizeSession = (session) => {
     lastResponseId: typeof session.lastResponseId === 'string' ? session.lastResponseId : null,
     activeResponseId: typeof session.activeResponseId === 'string' ? session.activeResponseId : null,
     lastSequenceNumber: Number.isFinite(Number(session.lastSequenceNumber)) ? Number(session.lastSequenceNumber) : 0,
+    responseEventCursors: session.responseEventCursors && typeof session.responseEventCursors === 'object'
+      ? Object.fromEntries(Object.entries(session.responseEventCursors).slice(-16).map(([id, cursor]) => [String(id), {
+          appliedSequence: Math.max(0, Number(cursor?.appliedSequence) || 0),
+          terminalSequence: Math.max(0, Number(cursor?.terminalSequence) || 0),
+          finalized: Boolean(cursor?.finalized),
+        }]))
+      : {},
+    latestRunEpoch: Math.max(0, Number(session.latestRunEpoch) || 0),
     sessionUsage: session.sessionUsage && typeof session.sessionUsage === 'object' ? session.sessionUsage : null,
     lastUsage: session.lastUsage && typeof session.lastUsage === 'object' ? session.lastUsage : null,
     activeModel: typeof session.activeModel === 'string' ? session.activeModel : '',

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1230,9 +1230,12 @@ const refreshSessionMessagesFromTranscript = (session) => {
     });
   }
   display.push(...transcript.optimistic);
-  session.messages = typeof window.reconcileToolCallProjection === 'function'
-    ? window.reconcileToolCallProjection(display)
-    : display;
+  session.messages = display;
+  // Recovery and transcript advancement are independent lifecycle boundaries:
+  // newly materialized durable calls must retire overlapping recovered calls in
+  // both the published projection and the optimistic source before any caller
+  // renders. This stays centralized here rather than running per stream token.
+  reconcileSessionToolCallProjection(session, { trackOptimisticTools: true });
   delete session._serverOnly;
   return true;
 };
@@ -1446,6 +1449,10 @@ const syncTranscriptOnce = async (session, options = {}) => {
     return true;
   });
   if (!loaded) return false;
+  // Active transactions publish through the viewport adapter's single render
+  // boundary. Inactive transactions still need their in-memory projection and
+  // optimistic registry reconciled, but must not touch the mounted transcript.
+  if (!adapter) refreshSessionMessagesFromTranscript(session);
   touchTranscriptSkeleton(session);
   return true;
 };

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -120,6 +120,10 @@ const pollSidebarStatus = (isRecovery = false) => {
   sidebarStatusPollController = controller;
   sidebarStatusPollInFlightGeneration = generation;
   sidebarStatusPollIsRecovery = isRecovery;
+  const sampledRunEpochs = new Map(state.sessions.map((session) => [
+    String(session.id || ''),
+    Math.max(Number(session.latestRunEpoch) || 0, Number(session.transcript?.latestRunEpoch) || 0),
+  ]));
 
   const isCurrent = () => (
     state.connected
@@ -157,7 +161,7 @@ const pollSidebarStatus = (isRecovery = false) => {
       if (etag) sidebarStatusEtag = etag;
       if (Array.isArray(data.sessions)) {
         updateSidebarStatus(data.sessions);
-        await reconcileTranscriptFromStatus(data.sessions);
+        await reconcileTranscriptFromStatus(data.sessions, { sampledRunEpochs });
         if (!isCurrent()) return false;
         // Discover sessions created in other tabs/devices
         const localIds = new Set(state.sessions.map((s) => s.id));
@@ -769,6 +773,16 @@ const convertServerMessages = (serverMessages, options = {}) => {
 
   const addDurableSource = (entry, msg) => {
     if (!entry) return entry;
+    const responseId = String(msg?.response_id || msg?.responseId || '').trim();
+    if (responseId) entry.responseId = responseId;
+    const segmentOrdinal = Number(msg?.assistant_segment_ordinal ?? msg?.assistantSegmentOrdinal);
+    if (entry.role === 'assistant' && Number.isFinite(segmentOrdinal) && segmentOrdinal >= 0) {
+      entry.assistantSegmentOrdinal = Math.trunc(segmentOrdinal);
+      const startSequence = Number(msg?.segment_start_sequence ?? msg?.segmentStartSequence);
+      const endSequence = Number(msg?.segment_end_sequence ?? msg?.segmentEndSequence);
+      if (Number.isFinite(startSequence) && startSequence > 0) entry.segmentStartSequence = Math.trunc(startSequence);
+      if (Number.isFinite(endSequence) && endSequence > 0) entry.segmentEndSequence = Math.trunc(endSequence);
+    }
     const id = durableSourceID(msg);
     if (id == null) return entry;
     if (!Array.isArray(entry.durableSourceRowIds)) entry.durableSourceRowIds = [];
@@ -1100,20 +1114,32 @@ const retireTranscriptOptimistic = (session, messageOrKey) => {
   return removed;
 };
 
-const noteTranscriptRunCreated = (session, responseId, startedRev) => {
+const noteTranscriptRunCreated = (session, responseId, startedRev, runEpoch = 0) => {
   const transcript = ensureSessionTranscript(session);
   if (!transcript) return Promise.resolve(false);
-  transcript.setActiveRun(responseId, startedRev);
+  const epoch = Math.max(0, Number(runEpoch) || 0);
+  if (epoch > 0) session.latestRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, epoch);
+  transcript.setActiveRun(responseId, startedRev, epoch);
   const target = Math.max(0, Number(startedRev) || 0);
   if (target > transcript.rev) return syncTranscript(session, { reason: 'run-created', targetRev: target });
   return Promise.resolve(true);
 };
 
-const noteTranscriptTerminal = (session, finalRev) => {
+const noteTranscriptTerminal = (session, responseId, finalRev, runEpoch = 0) => {
+  if (finalRev === undefined && Number.isFinite(Number(responseId))) {
+    finalRev = Number(responseId);
+    responseId = session?.transcript?.activeRun?.id || session?.activeResponseId || '';
+  }
   const transcript = ensureSessionTranscript(session);
   if (!transcript) return Promise.resolve(false);
+  const activeBefore = transcript.activeRun;
   transcript.clearTransientOptimistic();
-  transcript.setActiveRun('', 0);
+  transcript.setActiveRun('', 0, runEpoch, {
+    responseId,
+    sampledEpoch: runEpoch,
+    observedCreatedEpoch: session?.latestRunEpoch || 0,
+  });
+  if (activeBefore && transcript.activeRun) return Promise.resolve(false);
   persistTranscriptOptimistic(session);
   return syncTranscript(session, {
     reason: 'terminal',
@@ -1403,6 +1429,7 @@ const materializeTranscriptSegments = (session, request) => {
 const syncTranscriptOnce = async (session, options = {}) => {
   const transcript = ensureSessionTranscript(session);
   if (!transcript) return false;
+  const observedCreatedEpoch = Math.max(Number(session.latestRunEpoch) || 0, Number(transcript.latestRunEpoch) || 0);
   const headers = requestHeaders(session.id);
   if (transcript.etag && !options.force) headers['If-None-Match'] = transcript.etag;
   const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/transcript`, { headers });
@@ -1419,7 +1446,7 @@ const syncTranscriptOnce = async (session, options = {}) => {
     for (const local of optimistic) {
       replacement.addOptimistic(local.entry, local.entry.revAtSend, { persisted: local.persisted });
     }
-    if (activeRun) replacement.setActiveRun(activeRun.id, activeRun.startedRev);
+    if (activeRun) replacement.setActiveRun(activeRun.id, activeRun.startedRev, activeRun.epoch || 0);
     replacement.reconcileOptimistic();
     transcript.destroy();
     session.transcript = replacement;
@@ -1443,7 +1470,11 @@ const syncTranscriptOnce = async (session, options = {}) => {
   const loaded = await transcript.withViewportAnchor(adapter, async () => {
     if (data) {
       transcript.applyIndex(data, resp.headers?.get?.('ETag') || '');
-      transcript.setActiveRun(data.active_response_id || '', data.started_rev);
+      if (data.active_response_id) {
+        transcript.setActiveRun(data.active_response_id, data.started_rev, data.run_epoch || 0, { observedCreatedEpoch });
+      } else {
+        transcript.setActiveRun('', 0, data.run_epoch || 0, { observedCreatedEpoch });
+      }
     }
     if (transcript.ids.length > 0 && transcript.viewport.firstOrdinal < 0) {
       const last = transcript.ids.length - 1;
@@ -1676,7 +1707,7 @@ const loadServerSessionState = async (sessionId) => {
   }
 };
 
-const reconcileTranscriptFromStatus = async (statusSessions) => {
+const reconcileTranscriptFromStatus = async (statusSessions, options = {}) => {
   if (!Array.isArray(statusSessions)) return false;
   const active = getActiveSession();
   if (!active) return false;
@@ -1686,6 +1717,10 @@ const reconcileTranscriptFromStatus = async (statusSessions) => {
   if (!transcript) return false;
   const incomingRev = Math.max(0, Number(entry.transcript_rev) || 0);
   const activeResponseId = String(entry.active_response_id || '').trim();
+  const runEpoch = Math.max(0, Number(entry.run_epoch) || 0);
+  const sampledRunEpoch = options.sampledRunEpochs instanceof Map
+    ? Math.max(0, Number(options.sampledRunEpochs.get(active.id)) || 0)
+    : Math.max(Number(active.latestRunEpoch) || 0, Number(transcript.latestRunEpoch) || 0);
   const startedRev = Math.max(0, Number(entry.started_rev) || 0);
   const targetRev = activeResponseId ? startedRev : incomingRev;
   let refreshed = false;
@@ -1697,7 +1732,8 @@ const reconcileTranscriptFromStatus = async (statusSessions) => {
     });
   }
   if (activeResponseId) {
-    transcript.setActiveRun(activeResponseId, startedRev);
+    if (runEpoch > 0) active.latestRunEpoch = Math.max(Number(active.latestRunEpoch) || 0, runEpoch);
+    transcript.setActiveRun(activeResponseId, startedRev, runEpoch, { observedCreatedEpoch: sampledRunEpoch });
     if (transcript.rev >= startedRev
       && !state.abortController
       && !state.streaming
@@ -1706,10 +1742,14 @@ const reconcileTranscriptFromStatus = async (statusSessions) => {
       await syncActiveSessionFromServer(active, true, { skipMessagesFetch: true });
     }
   } else if (!refreshed && transcript.activeRun) {
-    // Status is authoritative for run ownership even when another path already
-    // fetched its final transcript revision. Clear and republish once so stale
-    // completed optimistic rows cannot survive an equal-revision terminal poll.
-    transcript.setActiveRun('', 0);
+    const activeBefore = transcript.activeRun;
+    transcript.setActiveRun('', 0, runEpoch, {
+      sampledEpoch: runEpoch,
+      observedCreatedEpoch: sampledRunEpoch,
+    });
+    if (transcript.activeRun === activeBefore) return refreshed;
+    // Status is only authoritative after freshness validation. Reconciliation
+    // below is a defensive terminal normalization, not replay deduplication.
     transcript.reconcileOptimistic();
     persistTranscriptOptimistic(active);
     refreshSessionMessagesFromTranscript(active);
@@ -1766,6 +1806,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     && requestGeneration >= Number(state.lastAppliedSessionStateRequestGeneration || 0);
 
   const busyBefore = sessionHasInProgressState(session);
+  const sampledRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, Number(session.transcript?.latestRunEpoch) || 0);
 
   const loadResult = await loadServerSessionState(requestSessionId);
   if (loadResult.kind === 'auth') {
@@ -1880,6 +1921,16 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
   const transcript = ensureSessionTranscript(session);
   const runtimeTranscriptRev = Math.max(0, Number(runtimeState.transcript_rev) || 0);
   const activeResponseId = String(runtimeState.active_response_id || '').trim();
+  const runEpoch = Math.max(0, Number(runtimeState.run_epoch) || 0);
+  const latestObservedRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, Number(transcript?.latestRunEpoch) || 0);
+  if (activeResponseId && runEpoch > 0 && runEpoch < latestObservedRunEpoch) {
+    window.transcriptDiagnostic?.('stale_status_rejection', {
+      responseId: activeResponseId,
+      transcriptRev: transcript?.rev,
+      startRev: runtimeState.started_rev,
+    });
+    return loadResult;
+  }
   const startedRev = Math.max(0, Number(runtimeState.started_rev) || 0);
   const targetTranscriptRev = activeResponseId ? startedRev : runtimeTranscriptRev;
   if (transcript && targetTranscriptRev > transcript.rev && isStillActive()) {
@@ -1900,8 +1951,9 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
   };
 
   if (activeResponseId) {
+    if (runEpoch > 0) session.latestRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, runEpoch);
     if (transcript) {
-      transcript.setActiveRun(activeResponseId, startedRev);
+      transcript.setActiveRun(activeResponseId, startedRev, runEpoch, { observedCreatedEpoch: sampledRunEpoch });
     }
     const responseChanged = session.activeResponseId !== activeResponseId;
     const recoverFromSnapshot = false;
@@ -1932,9 +1984,17 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
   }
 
   if (!activeRun && !state.abortController) {
+    if (sampledRunEpoch < Math.max(Number(session.latestRunEpoch) || 0, Number(transcript?.latestRunEpoch) || 0)) {
+      window.transcriptDiagnostic?.('stale_status_rejection', {
+        responseId: session.activeResponseId || transcript?.activeRun?.id || '',
+        transcriptRev: transcript?.rev,
+      });
+      return loadResult;
+    }
     if (isStillActive()) stopSessionStatePoll();
-    const clearedTranscriptRun = Boolean(transcript?.activeRun);
-    if (clearedTranscriptRun) transcript.setActiveRun('', 0);
+    const activeBeforeClear = transcript?.activeRun || null;
+    if (activeBeforeClear) transcript.setActiveRun('', 0, runEpoch, { observedCreatedEpoch: sampledRunEpoch });
+    const clearedTranscriptRun = Boolean(activeBeforeClear && !transcript?.activeRun);
     if (session.activeResponseId || (isStillActive() && state.currentStreamResponseId)) {
       clearActiveResponseTracking(session, session.activeResponseId || state.currentStreamResponseId);
       saveSessions();
@@ -2061,7 +2121,9 @@ const applySelectedTranscriptSideload = (session, sideload, options = {}) => {
         persisted: current.persistedOptimistic?.has?.(optimistic) === true
       });
     }
-    staging.setActiveRun(index.active_response_id || '', index.started_rev);
+    staging.setActiveRun(index.active_response_id || '', index.started_rev, index.run_epoch || 0, {
+      observedCreatedEpoch: session.latestRunEpoch || 0,
+    });
 
     const wantedIndexes = transcriptSyncSegmentIndexes(staging);
     const allowedBodyIDs = new Set();
@@ -2096,7 +2158,9 @@ const applySelectedTranscriptSideload = (session, sideload, options = {}) => {
       current.setViewport(last, last, { deferBudget: true });
     }
     current.materialize(bodies.messages, { countFetch: false, deferBudget: true });
-    current.setActiveRun(index.active_response_id || '', index.started_rev);
+    current.setActiveRun(index.active_response_id || '', index.started_rev, index.run_epoch || 0, {
+      observedCreatedEpoch: session.latestRunEpoch || 0,
+    });
     current.reconcileOptimistic();
     persistTranscriptOptimistic(session);
     current.enforceBudget();

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1092,6 +1092,14 @@ const trackTranscriptOptimistic = (session, message) => {
   return tracked;
 };
 
+const retireTranscriptOptimistic = (session, messageOrKey) => {
+  const transcript = session?.transcript;
+  if (!transcript?.removeOptimistic) return [];
+  const removed = transcript.removeOptimistic(messageOrKey);
+  if (removed.length > 0) persistTranscriptOptimistic(session);
+  return removed;
+};
+
 const noteTranscriptRunCreated = (session, responseId, startedRev) => {
   const transcript = ensureSessionTranscript(session);
   if (!transcript) return Promise.resolve(false);
@@ -1159,23 +1167,23 @@ const transcriptViewportAdapter = (session, forceScroll = false) => {
   };
 };
 
-const reconcileSessionToolCallProjection = (session, options = {}) => {
+const reconcileSessionTranscriptProjection = (session, options = {}) => {
   if (!session || !Array.isArray(session.messages)) return false;
-  const reconcile = window.reconcileToolCallProjection;
-  if (typeof reconcile === 'function') {
-    session.messages = reconcile(session.messages);
+  const transcript = ensureSessionTranscript(session);
+
+  if (options.trackOptimisticTail === true && transcript) {
+    for (const [index, message] of session.messages.entries()) {
+      if (message?.durable || !['assistant', 'tool-group', 'tool'].includes(message?.role)) continue;
+      const tracked = transcript.addOptimistic(message, transcript.rev);
+      if (tracked && tracked !== message) session.messages[index] = tracked;
+    }
+    transcript.reconcileOptimistic();
+    persistTranscriptOptimistic(session);
   }
 
-  if (options.trackOptimisticTools === true) {
-    const transcript = ensureSessionTranscript(session);
-    if (transcript) {
-      for (const message of session.messages) {
-        if (message?.durable || (message?.role !== 'tool-group' && message?.role !== 'tool')) continue;
-        transcript.addOptimistic(message, transcript.rev);
-      }
-      transcript.reconcileOptimistic();
-      persistTranscriptOptimistic(session);
-    }
+  const reconcile = window.reconcileTranscriptProjection;
+  if (typeof reconcile === 'function') {
+    session.messages = reconcile(session.messages, transcript);
   }
   return true;
 };
@@ -1231,11 +1239,9 @@ const refreshSessionMessagesFromTranscript = (session) => {
   }
   display.push(...transcript.optimistic);
   session.messages = display;
-  // Recovery and transcript advancement are independent lifecycle boundaries:
-  // newly materialized durable calls must retire overlapping recovered calls in
-  // both the published projection and the optimistic source before any caller
-  // renders. This stays centralized here rather than running per stream token.
-  reconcileSessionToolCallProjection(session, { trackOptimisticTools: true });
+  // Every durable/optimistic handoff is committed through the same projected
+  // tail before callers can render or publish session.messages.
+  reconcileSessionTranscriptProjection(session, { trackOptimisticTail: true });
   delete session._serverOnly;
   return true;
 };
@@ -1309,7 +1315,7 @@ const transcriptSyncSegmentIndexes = (transcript) => {
   if (!transcript) return [];
   const wanted = new Set(transcript.pinnedSegments);
   if (transcript.segments.length > 0) wanted.add(transcript.segments.length - 1);
-  for (const index of transcript.persistedOptimisticToolSegmentIndexes?.(TRANSCRIPT_MATERIALIZE_BATCH_TURNS) || []) {
+  for (const index of transcript.persistedOptimisticSegmentIndexes?.(TRANSCRIPT_MATERIALIZE_BATCH_TURNS) || []) {
     wanted.add(index);
   }
   return [...wanted];
@@ -1404,10 +1410,22 @@ const syncTranscriptOnce = async (session, options = {}) => {
   if (resp.status === 404) {
     const pages = await fetchLegacyTranscriptPages(session.id);
     if (!pages) return false;
+    const optimistic = transcript.optimistic.map((entry) => ({
+      entry: { ...entry },
+      persisted: transcript.persistedOptimistic?.has?.(entry) === true
+    }));
+    const activeRun = transcript.activeRun ? { ...transcript.activeRun } : null;
+    const replacement = window.transcriptStoreFromMessages(session.id, pages);
+    for (const local of optimistic) {
+      replacement.addOptimistic(local.entry, local.entry.revAtSend, { persisted: local.persisted });
+    }
+    if (activeRun) replacement.setActiveRun(activeRun.id, activeRun.startedRev);
+    replacement.reconcileOptimistic();
     transcript.destroy();
-    session.transcript = window.transcriptStoreFromMessages(session.id, pages);
+    session.transcript = replacement;
     session.transcript.setViewport(Math.max(0, session.transcript.ids.length - 1), Math.max(0, session.transcript.ids.length - 1));
     session.transcript.enforceBudget();
+    persistTranscriptOptimistic(session);
     refreshSessionMessagesFromTranscript(session);
     if (session.id === state.activeSessionId) renderMessages(options.forceScroll === true);
     touchTranscriptSkeleton(session);
@@ -1425,7 +1443,7 @@ const syncTranscriptOnce = async (session, options = {}) => {
   const loaded = await transcript.withViewportAnchor(adapter, async () => {
     if (data) {
       transcript.applyIndex(data, resp.headers?.get?.('ETag') || '');
-      if (data.active_response_id) transcript.setActiveRun(data.active_response_id, data.started_rev);
+      transcript.setActiveRun(data.active_response_id || '', data.started_rev);
     }
     if (transcript.ids.length > 0 && transcript.viewport.firstOrdinal < 0) {
       const last = transcript.ids.length - 1;
@@ -1687,6 +1705,15 @@ const reconcileTranscriptFromStatus = async (statusSessions) => {
       && document.visibilityState !== 'hidden') {
       await syncActiveSessionFromServer(active, true, { skipMessagesFetch: true });
     }
+  } else if (!refreshed && transcript.activeRun) {
+    // Status is authoritative for run ownership even when another path already
+    // fetched its final transcript revision. Clear and republish once so stale
+    // completed optimistic rows cannot survive an equal-revision terminal poll.
+    transcript.setActiveRun('', 0);
+    transcript.reconcileOptimistic();
+    persistTranscriptOptimistic(active);
+    refreshSessionMessagesFromTranscript(active);
+    if (active.id === state.activeSessionId && !state.draftSessionActive) renderMessages(false);
   }
   return refreshed;
 };
@@ -1906,6 +1933,8 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
 
   if (!activeRun && !state.abortController) {
     if (isStillActive()) stopSessionStatePoll();
+    const clearedTranscriptRun = Boolean(transcript?.activeRun);
+    if (clearedTranscriptRun) transcript.setActiveRun('', 0);
     if (session.activeResponseId || (isStillActive() && state.currentStreamResponseId)) {
       clearActiveResponseTracking(session, session.activeResponseId || state.currentStreamResponseId);
       saveSessions();
@@ -1919,6 +1948,11 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
         targetRev: runtimeTranscriptRev,
         forceScroll: true
       });
+    } else if (clearedTranscriptRun && transcript) {
+      transcript.reconcileOptimistic();
+      persistTranscriptOptimistic(session);
+      refreshSessionMessagesFromTranscript(session);
+      if (isStillActive()) renderMessages(false);
     }
     const lastError = String(runtimeState.last_error || '').trim();
     let currentTurnStart = 0;
@@ -2027,7 +2061,7 @@ const applySelectedTranscriptSideload = (session, sideload, options = {}) => {
         persisted: current.persistedOptimistic?.has?.(optimistic) === true
       });
     }
-    if (current.activeRun) staging.setActiveRun(current.activeRun.id, current.activeRun.startedRev);
+    staging.setActiveRun(index.active_response_id || '', index.started_rev);
 
     const wantedIndexes = transcriptSyncSegmentIndexes(staging);
     const allowedBodyIDs = new Set();
@@ -2062,7 +2096,7 @@ const applySelectedTranscriptSideload = (session, sideload, options = {}) => {
       current.setViewport(last, last, { deferBudget: true });
     }
     current.materialize(bodies.messages, { countFetch: false, deferBudget: true });
-    if (index.active_response_id) current.setActiveRun(index.active_response_id, index.started_rev);
+    current.setActiveRun(index.active_response_id || '', index.started_rev);
     current.reconcileOptimistic();
     persistTranscriptOptimistic(session);
     current.enforceBudget();
@@ -3603,11 +3637,12 @@ Object.assign(app, {
   reconcileTranscriptFromStatus,
   materializeTranscriptSegments,
   trackTranscriptOptimistic,
+  retireTranscriptOptimistic,
   persistTranscriptOptimistic,
   noteTranscriptRunCreated,
   noteTranscriptTerminal,
   refreshSessionMessagesFromTranscript,
-  reconcileSessionToolCallProjection,
+  reconcileSessionTranscriptProjection,
   refreshActiveSessionMessagesFromServer,
   loadOlderSessionMessages,
   maybeLoadOlderSessionMessages,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -656,6 +656,59 @@ const clearActiveResponseTracking = (session, responseId = '') => {
   }
 };
 
+const responseEventCursor = (session, responseId, create = true) => {
+  if (!session) return null;
+  const id = String(responseId || '').trim();
+  if (!id) return null;
+  if (!session.responseEventCursors || typeof session.responseEventCursors !== 'object') {
+    if (!create) return null;
+    session.responseEventCursors = {};
+  }
+  if (!session.responseEventCursors[id] && create) {
+    session.responseEventCursors[id] = { appliedSequence: 0, terminalSequence: 0, finalized: false };
+    const ids = Object.keys(session.responseEventCursors);
+    if (ids.length > 16) {
+      for (const staleID of ids.slice(0, ids.length - 16)) delete session.responseEventCursors[staleID];
+    }
+  }
+  return session.responseEventCursors[id] || null;
+};
+
+const responseEventSequence = (session, responseId) => Math.max(
+  0,
+  Number(responseEventCursor(session, responseId, false)?.appliedSequence) || 0,
+  String(session?.activeResponseId || '') === String(responseId || '') ? Number(session?.lastSequenceNumber) || 0 : 0
+);
+
+const markResponseEventApplied = (session, responseId, sequence) => {
+  const cursor = responseEventCursor(session, responseId);
+  const seq = Math.max(0, Number(sequence) || 0);
+  if (cursor) cursor.appliedSequence = Math.max(Number(cursor.appliedSequence) || 0, seq);
+  if (String(session?.activeResponseId || '') === String(responseId || '') || !session?.activeResponseId) {
+    session.lastSequenceNumber = Math.max(Number(session.lastSequenceNumber) || 0, seq);
+  }
+  return cursor;
+};
+
+const notifyTranscriptTerminal = (session, responseId, finalRev, runEpoch = 0) => {
+  const handler = app.noteTranscriptTerminal;
+  if (typeof handler !== 'function') return Promise.resolve(false);
+  if (handler.length <= 2) return handler(session, finalRev);
+  return handler(session, responseId, finalRev, runEpoch);
+};
+
+const beginResponseFinalization = (session, responseId, sequence, source = '') => {
+  const cursor = responseEventCursor(session, responseId);
+  if (!cursor) return true;
+  const seq = Math.max(0, Number(sequence) || 0);
+  cursor.appliedSequence = Math.max(Number(cursor.appliedSequence) || 0, seq);
+  cursor.terminalSequence = Math.max(Number(cursor.terminalSequence) || 0, seq);
+  if (cursor.finalized) return false;
+  cursor.finalized = true;
+  cursor.finalizedSource = String(source || 'stream');
+  return true;
+};
+
 const updateResponseSequence = (session, payload) => {
   if (!session || !payload || typeof payload !== 'object') return;
   const seq = Number(payload.sequence_number);
@@ -744,7 +797,7 @@ const scheduleVisibleStreamScroll = (session) => {
 };
 
 const responseStreamOwnerId = (session, payload = null) => {
-  const payloadResponseId = String(payload?.response?.id || payload?.response_id || '').trim();
+  const payloadResponseId = String(payload?.response_id || payload?.response?.id || '').trim();
   if (payloadResponseId) return payloadResponseId;
   const activeResponseId = String(session?.activeResponseId || '').trim();
   if (activeResponseId) return activeResponseId;
@@ -762,51 +815,77 @@ const clearProviderRetryForEvent = (session, payload = null) => {
 
 const rehydrateResponseStreamState = (session, streamState) => {
   if (!session || !streamState) return;
-  const currentToolGroup = session.messages.findLast((message) => (
+  const transcript = session.transcript;
+  const responseId = streamState.responseId || responseStreamOwnerId(session);
+  const currentToolGroup = transcript?.optimistic?.findLast((message) => (
     message.role === 'tool-group'
     && message.status === 'running'
-    && (!message.durable || !streamState.historicalReplayEvent)
+    && message.optimistic === true
+    && message.durable !== true
+    && (!responseId || String(message.responseId || '') === responseId)
   )) || null;
   streamState.currentToolGroup = currentToolGroup;
-  const lastMessage = session.messages[session.messages.length - 1];
-  streamState.currentAssistantMessage = !currentToolGroup
-    && lastMessage?.role === 'assistant'
-    && (!lastMessage.durable || !streamState.historicalReplayEvent)
-    ? lastMessage
-    : null;
+  const currentAssistant = transcript?.optimisticAssistant?.(responseId, streamState.assistantSegmentOrdinal)
+    || transcript?.optimistic?.findLast((message) => (
+      message.role === 'assistant'
+      && message.optimistic === true
+      && message.durable !== true
+      && (!responseId || String(message.responseId || '') === responseId)
+    ))
+    || null;
+  streamState.currentAssistantMessage = currentToolGroup ? null : currentAssistant;
 };
 
-const createResponseStreamState = (session) => {
-  let currentToolGroup = session.messages.findLast((message) => (
-    message.role === 'tool-group' && message.status === 'running'
-  )) || null;
+const createResponseStreamState = (session, options = {}) => {
+  if (session && !session.transcript && typeof window.TranscriptStore === 'function') {
+    session.transcript = new window.TranscriptStore(session.id || 'stream');
+  }
+  if (session?.transcript) {
+    for (const [index, message] of (session.messages || []).entries()) {
+      if (message?.durable === true || message?.optimistic === true || !['assistant', 'tool-group', 'tool'].includes(message?.role)) continue;
+      const tracked = session.transcript.addOptimistic(message, session.transcript.rev);
+      if (tracked) session.messages[index] = tracked;
+    }
+  }
+  let currentToolGroup = null;
   let currentAssistantMessage = null;
   let currentPhaseMessage = null;
   let historicalReplayEvent = false;
-  let assistantSegmentOrdinal = 0;
+  let assistantSegmentOrdinal = Math.max(0, Number(options.assistantSegmentOrdinal) || 0);
+  let responseId = String(options.responseId || responseStreamOwnerId(session) || '').trim();
 
-  if (!currentToolGroup) {
-    const lastMessage = session.messages[session.messages.length - 1];
-    if (lastMessage?.role === 'assistant') {
-      currentAssistantMessage = lastMessage;
+  const ensureAssistantMessage = (payload = null) => {
+    const payloadResponseId = String(payload?.response_id || payload?.response?.id || '').trim();
+    if (payloadResponseId) responseId = payloadResponseId;
+    if (!responseId) responseId = responseStreamOwnerId(session, payload);
+    const payloadOrdinal = Number(payload?.assistant_segment_ordinal);
+    if (Number.isFinite(payloadOrdinal) && payloadOrdinal >= 0) assistantSegmentOrdinal = Math.trunc(payloadOrdinal);
+    if (currentAssistantMessage) {
+      session.transcript?.assertMutableOverlay?.(currentAssistantMessage, 'ensure-assistant');
+      const currentKey = window.assistantSegmentKey?.(currentAssistantMessage) || '';
+      const wantedKey = window.assistantSegmentKey?.(responseId, assistantSegmentOrdinal) || '';
+      if (!wantedKey || currentKey === wantedKey) return currentAssistantMessage;
+      currentAssistantMessage = null;
     }
-  }
-
-  const ensureAssistantMessage = () => {
-    if (currentAssistantMessage) return currentAssistantMessage;
-    const responseId = responseStreamOwnerId(session);
-    const replayClientKey = historicalReplayEvent && responseId
-      ? `${responseId}:replay-assistant:${assistantSegmentOrdinal}`
-      : '';
+    const existing = session.transcript?.optimisticAssistant?.(responseId, assistantSegmentOrdinal) || null;
+    if (existing) {
+      session.transcript.assertMutableOverlay(existing, 'identity-lookup');
+      currentAssistantMessage = existing;
+      return existing;
+    }
     let msg = {
       id: generateId('msg'),
-      ...(replayClientKey ? { clientKey: replayClientKey, historicalReplay: true } : {}),
+      clientKey: responseId ? `${responseId}:assistant:${assistantSegmentOrdinal}` : generateId('assistant'),
       role: 'assistant',
+      responseId,
+      assistantSegmentOrdinal,
       content: '',
       created: Date.now()
     };
     const tracked = app.trackTranscriptOptimistic?.(session, msg);
-    if (tracked) msg = tracked;
+    if (!tracked) throw new Error('assistant stream overlay is not transcript-owned');
+    msg = tracked;
+    session.transcript?.assertMutableOverlay?.(msg, 'new-assistant');
     if (!session.messages.includes(msg)) {
       session.messages.push(msg);
       appendStreamMessageNode(session, msg);
@@ -817,6 +896,7 @@ const createResponseStreamState = (session) => {
 
   const closeToolGroup = () => {
     if (!currentToolGroup) return;
+    session.transcript?.assertMutableOverlay?.(currentToolGroup, 'close-tool-group');
     currentToolGroup.tools.forEach((tool) => {
       if (tool.status === 'running') tool.status = 'done';
     });
@@ -825,7 +905,7 @@ const createResponseStreamState = (session) => {
     currentToolGroup = null;
   };
 
-  return {
+  const result = {
     ensureAssistantMessage,
     closeToolGroup,
     get historicalReplayEvent() {
@@ -834,8 +914,16 @@ const createResponseStreamState = (session) => {
     set historicalReplayEvent(value) {
       historicalReplayEvent = Boolean(value);
     },
-    advanceAssistantSegment() {
-      assistantSegmentOrdinal += 1;
+    advanceAssistantSegment(nextOrdinal = null) {
+      assistantSegmentOrdinal = Number.isFinite(Number(nextOrdinal))
+        ? Math.max(0, Math.trunc(Number(nextOrdinal)))
+        : assistantSegmentOrdinal + 1;
+    },
+    get responseId() {
+      return responseId;
+    },
+    get assistantSegmentOrdinal() {
+      return assistantSegmentOrdinal;
     },
     get currentToolGroup() {
       return currentToolGroup;
@@ -847,6 +935,7 @@ const createResponseStreamState = (session) => {
       return currentAssistantMessage;
     },
     set currentAssistantMessage(value) {
+      if (value) session.transcript?.assertMutableOverlay?.(value, 'cursor-set');
       currentAssistantMessage = value;
     },
     get currentPhaseMessage() {
@@ -856,6 +945,8 @@ const createResponseStreamState = (session) => {
       currentPhaseMessage = value;
     }
   };
+  rehydrateResponseStreamState(session, result);
+  return result;
 };
 
 const applyResponseStreamEvent = (session, streamState, event, payload) => {
@@ -866,11 +957,15 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     if (delta) {
       clearProviderRetryForEvent(session, payload);
       streamState.closeToolGroup();
-      const msg = streamState.ensureAssistantMessage();
+      const msg = streamState.ensureAssistantMessage(payload);
+      session.transcript?.assertMutableOverlay?.(msg, 'text-delta');
+      const segmentStartSequence = Number(payload.segment_start_sequence);
+      if (Number.isFinite(segmentStartSequence) && segmentStartSequence > 0) msg.segmentStartSequence = Math.trunc(segmentStartSequence);
+      if (Number.isFinite(Number(seq)) && Number(seq) > 0) msg.segmentEndSequence = Math.trunc(Number(seq));
       const lastResponseSequence = Number(msg.lastResponseSequence || 0);
       if (!streamState.historicalReplayEvent || !Number.isFinite(Number(seq)) || Number(seq) > lastResponseSequence) {
         msg.content += delta;
-        if (streamState.historicalReplayEvent && Number.isFinite(Number(seq))) {
+        if (Number.isFinite(Number(seq))) {
           msg.lastResponseSequence = Number(seq);
         }
       }
@@ -896,14 +991,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
         last_sequence_number: payload.sequence_number,
         recovery: payload.recovery || null
       });
-      streamState.currentToolGroup = session.messages.findLast((message) => (
-        message.role === 'tool-group' && message.status === 'running'
-      )) || null;
-      streamState.currentAssistantMessage = streamState.currentToolGroup
-        ? null
-        : (session.messages[session.messages.length - 1]?.role === 'assistant'
-          ? session.messages[session.messages.length - 1]
-          : null);
+      rehydrateResponseStreamState(session, streamState);
       streamState.currentPhaseMessage = null;
       return { terminal: false, recoverableStreamError: true };
     }
@@ -911,11 +999,15 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   }
 
   if (event === 'response.created') {
-    const responseId = String(payload?.response?.id || '').trim();
+    const responseId = String(payload?.response_id || payload?.response?.id || '').trim();
+    const runEpoch = Math.max(0, Number(payload?.run_epoch ?? payload?.response?.run_epoch) || 0);
     setSessionOptimisticBusy(session, true);
     if (responseId) {
+      const cursor = responseEventCursor(session, responseId);
+      if (cursor) cursor.finalized = false;
+      if (runEpoch > 0) session.latestRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, runEpoch);
       setActiveResponseTracking(session, responseId, payload?.sequence_number ?? null);
-      void app.noteTranscriptRunCreated?.(session, responseId, payload?.started_rev ?? payload?.response?.started_rev ?? 0);
+      void app.noteTranscriptRunCreated?.(session, responseId, payload?.started_rev ?? payload?.response?.started_rev ?? 0, runEpoch);
       saveSessions();
     }
     const model = payload?.response?.model;
@@ -1052,7 +1144,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       finalizeVisibleAssistantStreamRender(session, streamState.currentAssistantMessage);
     }
     streamState.currentAssistantMessage = null;
-    streamState.advanceAssistantSegment?.();
+    streamState.advanceAssistantSegment?.(payload?.assistant_segment_ordinal);
     return { terminal: false };
   }
 
@@ -1077,19 +1169,27 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       };
 
       if (!streamState.currentToolGroup) {
-        streamState.currentToolGroup = {
+        let group = {
           id: generateId('msg'),
-          ...(streamState.historicalReplayEvent ? { historicalReplay: true } : {}),
+          clientKey: `${String(payload?.response_id || streamState.responseId || responseStreamOwnerId(session))}:tool:${String(item.call_id || item.id || payload.output_index || '')}`,
           role: 'tool-group',
+          responseId: String(payload?.response_id || streamState.responseId || responseStreamOwnerId(session)),
           tools: [toolEntry],
           expanded: false,
           status: 'running',
           created: Date.now()
         };
-        session.messages.push(streamState.currentToolGroup);
-        app.trackTranscriptOptimistic?.(session, streamState.currentToolGroup);
-        appendStreamMessageNode(session, streamState.currentToolGroup, createToolGroupNode);
+        const tracked = app.trackTranscriptOptimistic?.(session, group);
+        if (!tracked) throw new Error('tool stream overlay is not transcript-owned');
+        group = tracked;
+        session.transcript?.assertMutableOverlay?.(group, 'new-tool-group');
+        streamState.currentToolGroup = group;
+        if (!session.messages.includes(group)) {
+          session.messages.push(group);
+          appendStreamMessageNode(session, group, createToolGroupNode);
+        }
       } else {
+        session.transcript?.assertMutableOverlay?.(streamState.currentToolGroup, 'tool-added');
         streamState.currentToolGroup.tools.push(toolEntry);
         updateVisibleToolGroupNode(session, streamState.currentToolGroup);
       }
@@ -1104,6 +1204,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   if (event === 'response.function_call_arguments.delta') {
     clearProviderRetryForEvent(session, payload);
     if (streamState.currentToolGroup) {
+      session.transcript?.assertMutableOverlay?.(streamState.currentToolGroup, 'tool-arguments-delta');
       const outputIndex = payload.output_index;
       const delta = String(payload.delta || '');
       if (delta) {
@@ -1296,14 +1397,18 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   }
 
   if (event === 'response.completed') {
+    const responseId = String(payload?.response_id || payload?.response?.id || session.activeResponseId || state.currentStreamResponseId || '').trim();
+    if (!beginResponseFinalization(session, responseId, payload?.sequence_number, streamState.historicalReplayEvent ? 'replay' : 'live')) {
+      return { terminal: true, repeatedTerminal: true };
+    }
     const usage = payload?.response?.usage;
     streamState.closeToolGroup();
     markToolGroupsDone(session);
     requeuePendingInterjections(session);
 
-    const responseId = String(payload?.response?.id || session.activeResponseId || state.currentStreamResponseId || '').trim();
-    if (responseId) {
-      session.lastResponseId = responseId;
+    const durableResponseId = String(payload?.response?.id || responseId).trim();
+    if (durableResponseId) {
+      session.lastResponseId = durableResponseId;
     }
     clearActiveResponseTracking(session, responseId);
     setSessionOptimisticBusy(session, false);
@@ -1338,11 +1443,15 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       void app.refreshCurrentPlanFromServer?.(session);
     }
     scrollVisibleStreamToBottom(session);
-    void app.noteTranscriptTerminal?.(session, payload?.final_rev ?? payload?.response?.final_rev ?? 0);
+    void notifyTranscriptTerminal(session, responseId, payload?.final_rev ?? payload?.response?.final_rev ?? 0, payload?.run_epoch ?? payload?.response?.run_epoch ?? 0);
     return { terminal: true };
   }
 
   if (event === 'response.cancelled') {
+    const responseId = String(payload?.response_id || payload?.response?.id || session.activeResponseId || state.currentStreamResponseId || '').trim();
+    if (!beginResponseFinalization(session, responseId, payload?.sequence_number, streamState.historicalReplayEvent ? 'replay' : 'live')) {
+      return { terminal: true, repeatedTerminal: true };
+    }
     streamState.closeToolGroup();
     markToolGroupsDone(session);
     if (state.expectCanceledRun) {
@@ -1352,7 +1461,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       requeuePendingInterjections(session);
     }
     clearTerminalPendingEffort(session);
-    clearActiveResponseTracking(session, session.activeResponseId || state.currentStreamResponseId);
+    clearActiveResponseTracking(session, responseId);
     setSessionOptimisticBusy(session, false);
     setSessionServerActiveRun(session, false);
     const lastAssistant = session.messages.findLast((message) => message.role === 'assistant');
@@ -1363,11 +1472,15 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     forceSidebarStatusRefreshSoon();
     app.refreshFileChangesAfterRun?.(session);
     scrollVisibleStreamToBottom(session, true);
-    void app.noteTranscriptTerminal?.(session, payload?.final_rev ?? payload?.response?.final_rev ?? 0);
+    void notifyTranscriptTerminal(session, responseId, payload?.final_rev ?? payload?.response?.final_rev ?? 0, payload?.run_epoch ?? payload?.response?.run_epoch ?? 0);
     return { terminal: true };
   }
 
   if (event === 'response.failed') {
+    const responseId = String(payload?.response_id || payload?.response?.id || session.activeResponseId || state.currentStreamResponseId || '').trim();
+    if (!beginResponseFinalization(session, responseId, payload?.sequence_number, streamState.historicalReplayEvent ? 'replay' : 'live')) {
+      return { terminal: true, repeatedTerminal: true };
+    }
     const errorMessage = payload?.error?.message || 'The response failed.';
     const lowered = errorMessage.toLowerCase();
     const recoverableContinuationFailure = classifyRecoverableContinuationFailure(
@@ -1394,7 +1507,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       requeuePendingInterjections(session);
     }
     clearTerminalPendingEffort(session);
-    clearActiveResponseTracking(session, session.activeResponseId || state.currentStreamResponseId);
+    clearActiveResponseTracking(session, responseId);
     setSessionOptimisticBusy(session, false);
     setSessionServerActiveRun(session, false);
 
@@ -1406,7 +1519,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
     forceSidebarStatusRefreshSoon();
     app.refreshFileChangesAfterRun?.(session);
     scrollVisibleStreamToBottom(session, true);
-    void app.noteTranscriptTerminal?.(session, payload?.final_rev ?? payload?.response?.final_rev ?? 0);
+    void notifyTranscriptTerminal(session, responseId, payload?.final_rev ?? payload?.response?.final_rev ?? 0, payload?.run_epoch ?? payload?.response?.run_epoch ?? 0);
     return {
       terminal: true,
       error: recoverableContinuationFailure
@@ -1418,14 +1531,235 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   return { terminal: false };
 };
 
-const reconcileHistoricalReplayBatch = (session, streamState) => {
-  app.reconcileSessionTranscriptProjection?.(session, { trackOptimisticTail: true });
-  rehydrateResponseStreamState(session, streamState);
-  if (isSessionVisible(session)) {
-    renderMessages(false);
-  } else {
-    persistAndRefreshShell();
+const replayPayloadResponseID = (payload, fallback = '') => String(
+  payload?.response_id || payload?.response?.id || fallback || ''
+).trim();
+
+const createHistoricalReplayStage = (responseId, after, replayThrough, runEpoch = 0) => ({
+  responseId: String(responseId || '').trim(),
+  after: Math.max(0, Number(after) || 0),
+  replayThrough: Math.max(0, Number(replayThrough) || 0),
+  runEpoch: Math.max(0, Number(runEpoch) || 0),
+  appliedSequence: Math.max(0, Number(after) || 0),
+  seen: new Set(),
+  ordered: [],
+  segments: new Map(),
+  toolGroups: new Map(),
+  terminal: null,
+  eventCount: 0,
+});
+
+const reduceHistoricalReplayEvent = (stage, event, payload) => {
+  const sequence = Math.max(0, Number(payload?.sequence_number) || 0);
+  if (!sequence || sequence <= stage.after || stage.seen.has(sequence)) return true;
+  if (sequence !== stage.appliedSequence + 1) {
+    throw new Error(`historical replay gap at ${sequence}`);
   }
+  const responseId = replayPayloadResponseID(payload, stage.responseId);
+  const runEpoch = Math.max(0, Number(payload?.run_epoch ?? payload?.response?.run_epoch) || 0);
+  if (runEpoch > 0) stage.runEpoch = Math.max(stage.runEpoch, runEpoch);
+  if (stage.responseId && responseId && responseId !== stage.responseId) {
+    throw new Error('historical replay response identity changed');
+  }
+  stage.seen.add(sequence);
+  stage.appliedSequence = sequence;
+  stage.eventCount += 1;
+
+  if (event === 'response.output_text.delta') {
+    const ordinal = Math.max(0, Number(payload.assistant_segment_ordinal) || 0);
+    const key = window.assistantSegmentKey?.(responseId, ordinal) || `${responseId}:assistant:${ordinal}`;
+    let segment = stage.segments.get(key);
+    if (!segment) {
+      segment = {
+        type: 'assistant', key, responseId, assistantSegmentOrdinal: ordinal,
+        segmentStartSequence: Math.max(0, Number(payload.segment_start_sequence) || sequence),
+        firstSequence: sequence, lastSequence: sequence, chunks: [], content: '',
+      };
+      stage.segments.set(key, segment);
+      stage.ordered.push(segment);
+    }
+    const delta = String(payload.delta || '');
+    segment.chunks.push({ sequence, delta });
+    segment.content += delta;
+    segment.lastSequence = sequence;
+  } else if (event === 'response.output_item.added' && payload?.item?.type === 'function_call') {
+    const callId = String(payload.item.call_id || payload.item.id || '').trim();
+    const key = window.transcriptToolIdentityKey?.(responseId, callId) || `${responseId}:tool:${callId}`;
+    let group = stage.toolGroups.get(key);
+    if (!group) {
+      group = {
+        type: 'tool-group', key, responseId, callId,
+        id: `${responseId}_replay_tool_${callId}`,
+        role: 'tool-group', status: 'running', expanded: false, created: Date.now(),
+        tools: [{
+          id: callId, name: String(payload.item.name || 'tool'),
+          arguments: String(payload.item.arguments || ''), status: 'running',
+          created: Date.now(), outputIndex: payload.output_index,
+          argumentsFinalized: Boolean(String(payload.item.arguments || '').trim()),
+        }],
+      };
+      stage.toolGroups.set(key, group);
+      stage.ordered.push(group);
+    }
+  } else if (event === 'response.function_call_arguments.delta') {
+    const group = [...stage.toolGroups.values()].findLast((candidate) => (
+      candidate.tools[0]?.outputIndex === payload.output_index || candidate.tools[0]?.status === 'running'
+    ));
+    const tool = group?.tools?.[0];
+    if (tool && !tool.argumentsFinalized) tool.arguments += String(payload.delta || '');
+  } else if (event === 'response.output_item.done' && payload?.item?.type === 'function_call') {
+    const callId = String(payload.item.call_id || payload.item.id || '').trim();
+    const key = window.transcriptToolIdentityKey?.(responseId, callId) || `${responseId}:tool:${callId}`;
+    const tool = stage.toolGroups.get(key)?.tools?.[0];
+    if (tool) {
+      tool.arguments = String(payload.item.arguments || tool.arguments || '');
+      tool.argumentsFinalized = true;
+    }
+  } else if (event === 'response.tool_exec.end') {
+    const callId = String(payload.call_id || '').trim();
+    const key = window.transcriptToolIdentityKey?.(responseId, callId) || `${responseId}:tool:${callId}`;
+    const group = stage.toolGroups.get(key);
+    const tool = group?.tools?.[0];
+    if (tool) {
+      tool.status = payload.success === false ? 'error' : 'done';
+      tool.resultStatus = payload.success === false ? 'error' : 'success';
+      if (Array.isArray(payload.images)) tool.images = payload.images.map(rebaseStreamAssetURL).filter(Boolean);
+      group.status = 'done';
+    }
+  } else if (event === 'response.interjection') {
+    const id = String(payload.interjection_id || `${responseId}_interjection_${sequence}`);
+    stage.ordered.push({
+      type: 'user', id, clientKey: id, role: 'user', responseId,
+      content: String(payload.text || ''), interruptState: 'interject', created: Date.now(),
+    });
+  } else if (event === 'response.completed' || event === 'response.cancelled' || event === 'response.failed') {
+    stage.terminal = { event, payload };
+  }
+  return true;
+};
+
+const mergeHistoricalReplayStage = (session, streamState, stage) => {
+  const transcript = session?.transcript;
+  if (!transcript) throw new Error('historical replay requires a transcript store');
+  let coveredCount = 0;
+  let retainedCount = 0;
+  for (const staged of stage.ordered) {
+    if (staged.type === 'assistant') {
+      let overlay = transcript.optimisticAssistant?.(staged.responseId, staged.assistantSegmentOrdinal) || null;
+      const durable = transcript.durableAssistant?.(staged.responseId, staged.assistantSegmentOrdinal) || null;
+      if (durable && !window.assistantSegmentKey?.(durable.body)) {
+        transcript.bindLegacyAssistantIdentity?.(staged.responseId, staged.assistantSegmentOrdinal, durable);
+        durable.body.responseId = staged.responseId;
+        durable.body.assistantSegmentOrdinal = staged.assistantSegmentOrdinal;
+        const durableRowID = transcript.ids?.[durable.ordinal];
+        const durableSequence = transcript.seqs?.[durable.ordinal];
+        const projected = (session.messages || []).find((message) => (
+          message?.durable === true
+          && message.role === 'assistant'
+          && !window.assistantSegmentKey?.(message)
+          && ((Array.isArray(message.durableSourceRowIds) && message.durableSourceRowIds.includes(durableRowID))
+            || Number(message.serverSeq) === Number(durableSequence))
+        ));
+        if (projected) {
+          projected.responseId = staged.responseId;
+          projected.assistantSegmentOrdinal = staged.assistantSegmentOrdinal;
+        }
+      }
+      if (!overlay) {
+        let content = staged.content;
+        if (durable) {
+          const durableContent = String(durable.content || '');
+          if (content.startsWith(durableContent)) {
+            // Complete replay includes the durable prefix.
+          } else if (durableContent.startsWith(content)) {
+            content = durableContent;
+            coveredCount += 1;
+          } else if (staged.firstSequence > staged.segmentStartSequence) {
+            content = durableContent + content;
+          } else {
+            window.transcriptDiagnostic?.('divergent_content', {
+              responseId: staged.responseId, segmentKey: staged.key, transcriptRev: transcript.rev,
+            });
+            content = durableContent;
+          }
+        }
+        overlay = transcript.addOptimistic({
+          id: `${staged.responseId}_assistant_${staged.assistantSegmentOrdinal}`,
+          clientKey: staged.key,
+          role: 'assistant', responseId: staged.responseId,
+          assistantSegmentOrdinal: staged.assistantSegmentOrdinal,
+          segmentStartSequence: staged.segmentStartSequence,
+          segmentEndSequence: staged.lastSequence,
+          lastResponseSequence: staged.lastSequence,
+          ...(durable == null && staged.firstSequence > staged.segmentStartSequence ? { replaySuffixOnly: true } : {}),
+          content, created: Date.now(), historicalReplay: true,
+        }, transcript.rev);
+      } else {
+        transcript.assertMutableOverlay(overlay, 'replay-merge');
+        for (const chunk of staged.chunks) {
+          if (chunk.sequence <= Number(overlay.lastResponseSequence || 0)) {
+            coveredCount += 1;
+            continue;
+          }
+          overlay.content += chunk.delta;
+          overlay.lastResponseSequence = chunk.sequence;
+          overlay.segmentEndSequence = chunk.sequence;
+        }
+      }
+      transcript.assertMutableOverlay(overlay, 'replay-cursor');
+      retainedCount += 1;
+      continue;
+    }
+    if (staged.type === 'tool-group') {
+      const existing = transcript.optimistic.find((entry) => (
+        entry.role === 'tool-group'
+        && String(entry.responseId || '') === staged.responseId
+        && entry.tools?.some((tool) => String(tool.id || '') === staged.callId)
+      ));
+      if (existing) {
+        transcript.assertMutableOverlay(existing, 'replay-tool-merge');
+        Object.assign(existing.tools.find((tool) => String(tool.id || '') === staged.callId), staged.tools[0]);
+        existing.status = staged.status;
+        coveredCount += 1;
+      } else {
+        transcript.addOptimistic(staged, transcript.rev);
+        retainedCount += 1;
+      }
+      continue;
+    }
+    if (staged.type === 'user') {
+      transcript.addOptimistic(staged, transcript.rev);
+      retainedCount += 1;
+    }
+  }
+  markResponseEventApplied(session, stage.responseId, stage.appliedSequence);
+  transcript.reconcileOptimistic();
+  app.persistTranscriptOptimistic?.(session);
+  if (typeof app.refreshSessionMessagesFromTranscript === 'function') {
+    app.refreshSessionMessagesFromTranscript(session);
+  } else {
+    session.messages = window.reconcileTranscriptProjection([
+      ...(session.messages || []).filter((message) => message?.durable === true),
+      ...transcript.optimistic,
+    ], transcript);
+  }
+  app.reconcileSessionTranscriptProjection?.(session, { trackOptimisticTail: false });
+  rehydrateResponseStreamState(session, streamState);
+  window.transcriptDiagnostic?.('replay_commit', {
+    responseId: stage.responseId,
+    streamGeneration: state.streamGeneration,
+    transcriptRev: transcript.rev,
+    startRev: transcript.activeRun?.startedRev,
+    after: stage.after,
+    replayThrough: stage.replayThrough,
+    appliedSequence: stage.appliedSequence,
+    stagedCount: stage.eventCount,
+    coveredCount,
+    retainedCount,
+  });
+  if (isSessionVisible(session)) renderMessages(false);
+  else persistAndRefreshShell();
+  return stage.terminal;
 };
 
 const consumeResponseStream = async (stream, session, streamState, options = {}) => {
@@ -1440,21 +1774,29 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
   const replayAfterSequence = Math.max(0, Number(options.replayAfterSequence) || 0);
   const replayThroughSequence = Math.max(0, Number(options.replayThroughSequence) || 0);
   let replayBoundaryPending = replayThroughSequence > replayAfterSequence;
+  const replayStage = replayBoundaryPending
+    ? createHistoricalReplayStage(expectedResponseId, replayAfterSequence, replayThroughSequence, options.runEpoch)
+    : null;
 
   const completeReplayBoundary = () => {
-    if (!replayBoundaryPending || stale) return false;
+    if (!replayBoundaryPending || stale || !replayStage || replayStage.appliedSequence < replayThroughSequence) return false;
     replayBoundaryPending = false;
     streamState.historicalReplayEvent = false;
-    reconcileHistoricalReplayBatch(session, streamState);
+    const stagedTerminal = mergeHistoricalReplayStage(session, streamState, replayStage);
+    if (stagedTerminal) {
+      streamState.historicalReplayEvent = true;
+      const result = applyResponseStreamEvent(session, streamState, stagedTerminal.event, stagedTerminal.payload);
+      streamState.historicalReplayEvent = false;
+      if (result?.terminal) sawTerminal = true;
+      if (result?.error) terminalError = result.error;
+    }
     return true;
   };
 
   if (replayBoundaryPending) {
-    // Stream state may have been hydrated from the already-durable selected
-    // projection before the response headers identified this transport batch as
-    // historical. Detach durable cursors once so replay cannot mutate them.
+    // Replay remains detached until the ordered response header boundary is
+    // observed. No stream cursor points at durable/session/DOM state here.
     streamState.historicalReplayEvent = true;
-    rehydrateResponseStreamState(session, streamState);
   }
 
   const eventSequenceNumber = (payload) => {
@@ -1478,13 +1820,17 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
     }
 
     if (data === '[DONE]') {
-      completeReplayBoundary();
-      if (!sawRecoverableStreamError) {
+      if (replayBoundaryPending) {
+        terminalError = {
+          message: 'historical replay ended before its ordered boundary',
+          recoverableReplayInterrupted: true,
+        };
+      } else if (!sawRecoverableStreamError) {
         sawDone = true;
         streamState.closeToolGroup();
         markToolGroupsDone(session);
+        persistAndRefreshShell();
       }
-      persistAndRefreshShell();
       return false;
     }
 
@@ -1502,22 +1848,35 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
       return false;
     }
     const seq = eventSequenceNumber(payload);
-    const currentSeq = Number(session.lastSequenceNumber || 0);
-    const historicalReplayEvent = replayBoundaryPending
-      && seq > 0
-      && seq <= replayThroughSequence;
-    streamState.historicalReplayEvent = historicalReplayEvent;
-    // Reconnects and overlapping POST/event streams can replay an event that is
-    // already reflected in the local projection. Applying it again duplicates
-    // text and can append phase/tool nodes after newer output. Stream overflow
-    // is the one transport control event that intentionally reuses the latest
-    // sequence number and still needs to trigger snapshot recovery.
+    const eventResponseId = replayPayloadResponseID(payload, expectedResponseId);
+    if (replayBoundaryPending && seq > 0 && seq <= replayThroughSequence) {
+      try {
+        reduceHistoricalReplayEvent(replayStage, event, payload);
+      } catch (err) {
+        terminalError = {
+          message: err?.message || 'historical replay reduction failed',
+          recoverableReplayInterrupted: true,
+        };
+        return false;
+      }
+      if (seq >= replayThroughSequence) completeReplayBoundary();
+      return true;
+    }
+    if (replayBoundaryPending && seq > replayThroughSequence) {
+      terminalError = {
+        message: 'fresh response event arrived before replay boundary completion',
+        recoverableReplayInterrupted: true,
+      };
+      return false;
+    }
+
+    streamState.historicalReplayEvent = false;
+    const currentSeq = responseEventSequence(session, eventResponseId);
+    // Overlapping POST and GET transports share a response-scoped cursor. An
+    // already-applied event is ignored without moving mutable cursors to a
+    // projected/durable node.
     if (seq > 0 && (seq < currentSeq || (seq === currentSeq && event !== 'response.stream_error'))) {
-      // This transport may have attached before another transport projected the
-      // replayed event. Align its mutable cursor with the shared transcript so
-      // the next fresh delta continues the existing assistant/tool node.
       rehydrateResponseStreamState(session, streamState);
-      if (historicalReplayEvent && seq >= replayThroughSequence) completeReplayBoundary();
       return true;
     }
     if (seq > currentSeq + 1) {
@@ -1531,15 +1890,14 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
     let result;
     try {
       result = applyResponseStreamEvent(session, streamState, event, payload);
+      if (seq > 0) markResponseEventApplied(session, eventResponseId, seq);
     } catch (err) {
-      session.lastSequenceNumber = currentSeq;
       terminalError = {
         message: err?.message || 'response event projection failed',
         recoverableStreamApplyFailure: true,
       };
       return false;
     }
-    if (historicalReplayEvent && seq >= replayThroughSequence) completeReplayBoundary();
     if (result?.terminal) {
       sawTerminal = true;
     }
@@ -1618,10 +1976,27 @@ const applyResponseRecoverySnapshot = (session, payload) => {
   const hasRecovery = recovery && typeof recovery === 'object';
 
   if (hasRecovery) {
+    const responseId = String(payload.id || session.activeResponseId || state.currentStreamResponseId || '').trim();
     const rawMessages = Array.isArray(recovery.messages) ? recovery.messages : [];
+    let recoveryAssistantOrdinal = 0;
     const recoveredMessages = rawMessages
-      .map((message) => sanitizeMessage(message))
-      .filter(Boolean);
+      .map((message) => {
+        const sanitized = sanitizeMessage(message);
+        if (sanitized?.role === 'assistant') {
+          if (!Number.isFinite(Number(sanitized.assistantSegmentOrdinal))) {
+            sanitized.assistantSegmentOrdinal = recoveryAssistantOrdinal;
+            recoveryAssistantOrdinal += 1;
+          } else {
+            recoveryAssistantOrdinal = Math.max(
+              recoveryAssistantOrdinal,
+              Math.trunc(Number(sanitized.assistantSegmentOrdinal)) + 1
+            );
+          }
+        }
+        return sanitized;
+      })
+      .filter(Boolean)
+      .map((message) => ({ ...message, responseId: String(message.responseId || responseId) }));
 
     const recoveredInterjections = recoveredMessages.filter((message) => (
       message?.role === 'user' && message?.interruptState === 'interject'
@@ -1630,20 +2005,64 @@ const applyResponseRecoverySnapshot = (session, payload) => {
       clearCommittedInterjectionPendingState(session.id, message.id, message.content);
     }
 
-    let anchorIndex = -1;
-    for (let i = session.messages.length - 1; i >= 0; i -= 1) {
-      if (session.messages[i]?.role === 'user') {
-        anchorIndex = i;
-        break;
+    const transcript = session.transcript;
+    if (transcript) {
+      for (const recovered of recoveredMessages) {
+        let existing = null;
+        if (recovered.role === 'assistant') {
+          const durable = transcript.durableAssistant?.(recovered.responseId, recovered.assistantSegmentOrdinal) || null;
+          if (durable && !window.assistantSegmentKey?.(durable.body)) {
+            transcript.bindLegacyAssistantIdentity?.(recovered.responseId, recovered.assistantSegmentOrdinal, durable);
+          }
+          existing = transcript.optimisticAssistant?.(recovered.responseId, recovered.assistantSegmentOrdinal) || null;
+        } else if (recovered.role === 'tool-group') {
+          existing = transcript.optimistic.find((entry) => (
+            entry.role === 'tool-group'
+            && String(entry.responseId || '') === recovered.responseId
+            && entry.tools?.some((tool) => recovered.tools?.some((candidate) => candidate.id && candidate.id === tool.id))
+          )) || null;
+        } else if (recovered.role === 'user') {
+          existing = transcript.optimistic.find((entry) => entry.role === 'user' && String(entry.id || '') === String(recovered.id || '')) || null;
+        }
+        if (existing) {
+          transcript.assertMutableOverlay(existing, 'snapshot-merge');
+          if (existing.role === 'assistant' && String(existing.content || '') !== String(recovered.content || '')) {
+            window.transcriptDiagnostic?.('snapshot_content_authority', {
+              responseId: recovered.responseId,
+              segmentKey: window.assistantSegmentKey?.(recovered),
+              transcriptRev: transcript.rev,
+            });
+          }
+          Object.assign(existing, recovered, { optimistic: true });
+          if (existing.role === 'assistant') delete existing.replaySuffixOnly;
+        } else {
+          transcript.addOptimistic(recovered, transcript.rev);
+        }
       }
+      transcript.rebuildOptimisticIdentityIndex?.();
+      app.persistTranscriptOptimistic?.(session);
+      if (typeof app.refreshSessionMessagesFromTranscript === 'function') {
+        app.refreshSessionMessagesFromTranscript(session);
+      } else {
+        session.messages = window.reconcileTranscriptProjection([
+          ...(session.messages || []).filter((message) => message?.durable === true),
+          ...transcript.optimistic,
+        ], transcript);
+      }
+    } else {
+      // Legacy clients without TranscriptStore still publish the complete
+      // recovery snapshot in one assignment.
+      let anchorIndex = -1;
+      for (let i = session.messages.length - 1; i >= 0; i -= 1) {
+        if (session.messages[i]?.role === 'user') { anchorIndex = i; break; }
+      }
+      const preserved = anchorIndex >= 0
+        ? session.messages.slice(0, anchorIndex + 1).filter((message) => !shouldDropPreservedOptimisticInterjection(message, recoveredInterjections))
+        : [];
+      session.messages = preserved.concat(recoveredMessages);
     }
-
-    const preserved = anchorIndex >= 0
-      ? session.messages.slice(0, anchorIndex + 1).filter((message) => !shouldDropPreservedOptimisticInterjection(message, recoveredInterjections))
-      : [];
-    session.messages = preserved.concat(recoveredMessages);
-    app.reconcileSessionTranscriptProjection?.(session, { trackOptimisticTail: true });
   }
+  app.reconcileSessionTranscriptProjection?.(session, { trackOptimisticTail: true });
 
   const nextSeq = Number(payload.last_sequence_number ?? recovery?.sequence_number ?? session.lastSequenceNumber ?? 0);
   if (Number.isFinite(nextSeq) && nextSeq >= 0) {
@@ -1662,24 +2081,47 @@ const applyResponseRecoverySnapshot = (session, payload) => {
   }
   updateSessionUsageDisplay(session);
 
-  if (payload.status === 'completed') {
+  const terminalStatus = ['completed', 'failed', 'cancelled'].includes(String(payload.status || ''));
+  const firstFinalization = terminalStatus
+    ? beginResponseFinalization(session, responseId, nextSeq, 'snapshot')
+    : true;
+  markResponseEventApplied(session, responseId, nextSeq);
+  if (payload.status === 'completed' && firstFinalization) {
     clearTerminalPendingEffort(session);
-    if (responseId) {
-      session.lastResponseId = responseId;
+    if (responseId) session.lastResponseId = responseId;
+    clearActiveResponseTracking(session, responseId);
+    setSessionOptimisticBusy(session, false);
+    setSessionServerActiveRun(session, false);
+    requeuePendingInterjections(session);
+    void notifyTranscriptTerminal(session, responseId, payload.final_rev || 0, payload.run_epoch || 0);
+  } else if ((payload.status === 'failed' || payload.status === 'cancelled') && firstFinalization) {
+    clearTerminalPendingEffort(session);
+    clearActiveResponseTracking(session, responseId);
+    setSessionOptimisticBusy(session, false);
+    setSessionServerActiveRun(session, false);
+    requeuePendingInterjections(session);
+    void notifyTranscriptTerminal(session, responseId, payload.final_rev || 0, payload.run_epoch || 0);
+  } else if (!terminalStatus && responseId) {
+    const runEpoch = Math.max(0, Number(payload.run_epoch) || 0);
+    const latestRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, Number(session.transcript?.latestRunEpoch) || 0);
+    const currentResponseId = String(session.activeResponseId || '').trim();
+    const staleOwnership = Boolean(
+      currentResponseId
+      && currentResponseId !== responseId
+      && (runEpoch === 0 || runEpoch <= latestRunEpoch)
+    );
+    if (staleOwnership) {
+      window.transcriptDiagnostic?.('stale_status_rejection', {
+        responseId,
+        transcriptRev: session.transcript?.rev,
+        startRev: payload.started_rev,
+      });
+    } else {
+      if (runEpoch > 0) session.latestRunEpoch = Math.max(Number(session.latestRunEpoch) || 0, runEpoch);
+      setActiveResponseTracking(session, responseId, session.lastSequenceNumber);
+      setSessionOptimisticBusy(session, true);
+      session.transcript?.setActiveRun?.(responseId, payload.started_rev || 0, runEpoch);
     }
-    clearActiveResponseTracking(session, responseId);
-    setSessionOptimisticBusy(session, false);
-    setSessionServerActiveRun(session, false);
-    requeuePendingInterjections(session);
-  } else if (payload.status === 'failed' || payload.status === 'cancelled') {
-    clearTerminalPendingEffort(session);
-    clearActiveResponseTracking(session, responseId);
-    setSessionOptimisticBusy(session, false);
-    setSessionServerActiveRun(session, false);
-    requeuePendingInterjections(session);
-  } else if (responseId) {
-    setActiveResponseTracking(session, responseId, session.lastSequenceNumber);
-    setSessionOptimisticBusy(session, true);
   }
 
   saveSessions();
@@ -1868,7 +2310,7 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
         setStreaming(Boolean(state.currentStreamResponseId));
         return false;
       }
-      if (result.error?.recoverableStreamGap || result.error?.recoverableStreamApplyFailure) {
+      if (result.error?.recoverableStreamGap || result.error?.recoverableStreamApplyFailure || result.error?.recoverableReplayInterrupted) {
         const sequenceBeforeRecovery = Number(session.lastSequenceNumber || 0);
         try {
           const snapshot = await recoverResponseStateFromSnapshot(session, responseId);
@@ -5210,6 +5652,12 @@ Object.assign(app, {
   createResponseStreamState,
   applyResponseStreamEvent,
   applyResponseRecoverySnapshot,
+  createHistoricalReplayStage,
+  reduceHistoricalReplayEvent,
+  mergeHistoricalReplayStage,
+  responseEventCursor,
+  responseEventSequence,
+  beginResponseFinalization,
   consumeResponseStream,
   scheduleStreamPersistence,
   flushStreamPersistence,

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1575,7 +1575,7 @@ const applyResponseRecoverySnapshot = (session, payload) => {
       ? session.messages.slice(0, anchorIndex + 1).filter((message) => !shouldDropPreservedOptimisticInterjection(message, recoveredInterjections))
       : [];
     session.messages = preserved.concat(recoveredMessages);
-    app.reconcileSessionToolCallProjection?.(session, { trackOptimisticTools: true });
+    app.reconcileSessionTranscriptProjection?.(session, { trackOptimisticTail: true });
   }
 
   const nextSeq = Number(payload.last_sequence_number ?? recovery?.sequence_number ?? session.lastSequenceNumber ?? 0);
@@ -4012,6 +4012,7 @@ const cancelPendingInterjection = async (entry) => {
     if (session) {
       const idx = session.messages.findIndex(m => m.id === entry.messageId && m.role === 'user');
       if (idx >= 0) session.messages.splice(idx, 1);
+      app.retireTranscriptOptimistic?.(session, entry.messageId);
       if (isSessionVisible(session)) {
         const node = Array.from(elements.messages.querySelectorAll('[data-message-id]'))
           .find(el => el.getAttribute('data-message-id') === entry.messageId);

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -763,11 +763,15 @@ const clearProviderRetryForEvent = (session, payload = null) => {
 const rehydrateResponseStreamState = (session, streamState) => {
   if (!session || !streamState) return;
   const currentToolGroup = session.messages.findLast((message) => (
-    message.role === 'tool-group' && message.status === 'running'
+    message.role === 'tool-group'
+    && message.status === 'running'
+    && (!message.durable || !streamState.historicalReplayEvent)
   )) || null;
   streamState.currentToolGroup = currentToolGroup;
   const lastMessage = session.messages[session.messages.length - 1];
-  streamState.currentAssistantMessage = !currentToolGroup && lastMessage?.role === 'assistant'
+  streamState.currentAssistantMessage = !currentToolGroup
+    && lastMessage?.role === 'assistant'
+    && (!lastMessage.durable || !streamState.historicalReplayEvent)
     ? lastMessage
     : null;
 };
@@ -778,6 +782,8 @@ const createResponseStreamState = (session) => {
   )) || null;
   let currentAssistantMessage = null;
   let currentPhaseMessage = null;
+  let historicalReplayEvent = false;
+  let assistantSegmentOrdinal = 0;
 
   if (!currentToolGroup) {
     const lastMessage = session.messages[session.messages.length - 1];
@@ -788,15 +794,23 @@ const createResponseStreamState = (session) => {
 
   const ensureAssistantMessage = () => {
     if (currentAssistantMessage) return currentAssistantMessage;
-    const msg = {
+    const responseId = responseStreamOwnerId(session);
+    const replayClientKey = historicalReplayEvent && responseId
+      ? `${responseId}:replay-assistant:${assistantSegmentOrdinal}`
+      : '';
+    let msg = {
       id: generateId('msg'),
+      ...(replayClientKey ? { clientKey: replayClientKey, historicalReplay: true } : {}),
       role: 'assistant',
       content: '',
       created: Date.now()
     };
-    session.messages.push(msg);
-    app.trackTranscriptOptimistic?.(session, msg);
-    appendStreamMessageNode(session, msg);
+    const tracked = app.trackTranscriptOptimistic?.(session, msg);
+    if (tracked) msg = tracked;
+    if (!session.messages.includes(msg)) {
+      session.messages.push(msg);
+      appendStreamMessageNode(session, msg);
+    }
     currentAssistantMessage = msg;
     return msg;
   };
@@ -814,6 +828,15 @@ const createResponseStreamState = (session) => {
   return {
     ensureAssistantMessage,
     closeToolGroup,
+    get historicalReplayEvent() {
+      return historicalReplayEvent;
+    },
+    set historicalReplayEvent(value) {
+      historicalReplayEvent = Boolean(value);
+    },
+    advanceAssistantSegment() {
+      assistantSegmentOrdinal += 1;
+    },
     get currentToolGroup() {
       return currentToolGroup;
     },
@@ -844,7 +867,13 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       clearProviderRetryForEvent(session, payload);
       streamState.closeToolGroup();
       const msg = streamState.ensureAssistantMessage();
-      msg.content += delta;
+      const lastResponseSequence = Number(msg.lastResponseSequence || 0);
+      if (!streamState.historicalReplayEvent || !Number.isFinite(Number(seq)) || Number(seq) > lastResponseSequence) {
+        msg.content += delta;
+        if (streamState.historicalReplayEvent && Number.isFinite(Number(seq))) {
+          msg.lastResponseSequence = Number(seq);
+        }
+      }
       scheduleStreamPersistence();
       enqueueVisibleAssistantStreamUpdate(session, msg);
     }
@@ -1023,6 +1052,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       finalizeVisibleAssistantStreamRender(session, streamState.currentAssistantMessage);
     }
     streamState.currentAssistantMessage = null;
+    streamState.advanceAssistantSegment?.();
     return { terminal: false };
   }
 
@@ -1049,6 +1079,7 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
       if (!streamState.currentToolGroup) {
         streamState.currentToolGroup = {
           id: generateId('msg'),
+          ...(streamState.historicalReplayEvent ? { historicalReplay: true } : {}),
           role: 'tool-group',
           tools: [toolEntry],
           expanded: false,
@@ -1387,6 +1418,16 @@ const applyResponseStreamEvent = (session, streamState, event, payload) => {
   return { terminal: false };
 };
 
+const reconcileHistoricalReplayBatch = (session, streamState) => {
+  app.reconcileSessionTranscriptProjection?.(session, { trackOptimisticTail: true });
+  rehydrateResponseStreamState(session, streamState);
+  if (isSessionVisible(session)) {
+    renderMessages(false);
+  } else {
+    persistAndRefreshShell();
+  }
+};
+
 const consumeResponseStream = async (stream, session, streamState, options = {}) => {
   let sawTerminal = false;
   let sawDone = false;
@@ -1396,6 +1437,25 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
   const generation = Number.isFinite(Number(options.generation)) ? Number(options.generation) : state.streamGeneration;
   const sessionId = String(session?.id || '').trim();
   const expectedResponseId = String(options.responseId || '').trim();
+  const replayAfterSequence = Math.max(0, Number(options.replayAfterSequence) || 0);
+  const replayThroughSequence = Math.max(0, Number(options.replayThroughSequence) || 0);
+  let replayBoundaryPending = replayThroughSequence > replayAfterSequence;
+
+  const completeReplayBoundary = () => {
+    if (!replayBoundaryPending || stale) return false;
+    replayBoundaryPending = false;
+    streamState.historicalReplayEvent = false;
+    reconcileHistoricalReplayBatch(session, streamState);
+    return true;
+  };
+
+  if (replayBoundaryPending) {
+    // Stream state may have been hydrated from the already-durable selected
+    // projection before the response headers identified this transport batch as
+    // historical. Detach durable cursors once so replay cannot mutate them.
+    streamState.historicalReplayEvent = true;
+    rehydrateResponseStreamState(session, streamState);
+  }
 
   const eventSequenceNumber = (payload) => {
     const seq = Number(payload?.sequence_number);
@@ -1418,6 +1478,7 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
     }
 
     if (data === '[DONE]') {
+      completeReplayBoundary();
       if (!sawRecoverableStreamError) {
         sawDone = true;
         streamState.closeToolGroup();
@@ -1442,6 +1503,10 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
     }
     const seq = eventSequenceNumber(payload);
     const currentSeq = Number(session.lastSequenceNumber || 0);
+    const historicalReplayEvent = replayBoundaryPending
+      && seq > 0
+      && seq <= replayThroughSequence;
+    streamState.historicalReplayEvent = historicalReplayEvent;
     // Reconnects and overlapping POST/event streams can replay an event that is
     // already reflected in the local projection. Applying it again duplicates
     // text and can append phase/tool nodes after newer output. Stream overflow
@@ -1452,6 +1517,7 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
       // replayed event. Align its mutable cursor with the shared transcript so
       // the next fresh delta continues the existing assistant/tool node.
       rehydrateResponseStreamState(session, streamState);
+      if (historicalReplayEvent && seq >= replayThroughSequence) completeReplayBoundary();
       return true;
     }
     if (seq > currentSeq + 1) {
@@ -1473,6 +1539,7 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
       };
       return false;
     }
+    if (historicalReplayEvent && seq >= replayThroughSequence) completeReplayBoundary();
     if (result?.terminal) {
       sawTerminal = true;
     }
@@ -1749,7 +1816,8 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
     let streamActivityBaseline = Number(state.lastEventTime || 0);
 
     try {
-      const response = await fetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/events?after=${encodeURIComponent(session.lastSequenceNumber || 0)}`, {
+      const replayAfterSequence = Math.max(0, Number(session.lastSequenceNumber) || 0);
+      const response = await fetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/events?after=${encodeURIComponent(replayAfterSequence)}`, {
         headers: requestHeaders(session.id),
         signal: controller.signal
       });
@@ -1771,10 +1839,16 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
       setReconnectDiagnostic('connected', '', 0);
       const streamGeneration = state.streamGeneration;
       streamActivityBaseline = Number(state.lastEventTime || 0);
+      const replayThroughSequence = Math.max(
+        replayAfterSequence,
+        Number(response.headers?.get?.('X-Term-LLM-Replay-Through')) || 0
+      );
       const result = await consumeResponseStream(response.body, session, streamState, {
         generation: streamGeneration,
         responseId,
-        abortController: controller
+        abortController: controller,
+        replayAfterSequence,
+        replayThroughSequence
       });
       if (streamHadActivitySince(streamActivityBaseline)) {
         retryAttempt = 0;

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -7,7 +7,7 @@ const vm = require('vm');
 
 const source = fs.readFileSync(path.join(__dirname, 'app-render.js'), 'utf8');
 const markdownStreaming = require(path.join(__dirname, 'markdown-streaming.js'));
-const { reconcileToolCallProjection } = require('./transcript-store.js');
+const { reconcileTranscriptProjection } = require('./transcript-store.js');
 let failures = 0;
 
 function fail(name, message, details) {
@@ -1968,7 +1968,7 @@ async function run(name, fn) {
     app.renderMessages();
     assertEqual(messages.querySelectorAll('.tool-group').length, 3, 'reproduction mounts durable and duplicate optimistic cards');
 
-    session.messages = reconcileToolCallProjection(session.messages);
+    session.messages = reconcileTranscriptProjection(session.messages);
     app.renderMessages();
 
     assertEqual(messages.querySelectorAll('.tool-group').length, 2, 'covered optimistic group is removed in the mounted reconciliation');
@@ -1979,6 +1979,51 @@ async function run(name, fn) {
       session.messages.map((message) => message.id).join(','),
       'srv_seq_387_tools_1,msg_652-live-tools',
       'session projection preserves durable then newer live ordering'
+    );
+  });
+
+  await run('transcript reconciliation hands one assistant DOM node from durable prefix to live suffix', () => {
+    const { app, session, messages } = createHarness();
+    session.transcript = { rev: 7, activeRun: { id: 'resp_assistant_dom', startedRev: 7 } };
+    const durable = {
+      id: 'srv_seq_402_text_0',
+      role: 'assistant',
+      content: 'durable prefix',
+      durable: true,
+      serverSeq: 402,
+      transcriptSegmentIndex: 0,
+      created: 1000
+    };
+    const optimistic = {
+      id: 'msg_assistant_dom',
+      clientKey: 'msg_assistant_dom',
+      role: 'assistant',
+      content: 'durable prefix plus live suffix',
+      optimistic: true,
+      revAtSend: 7,
+      durableSeqAtSend: 401,
+      created: 1100
+    };
+    session.messages = [durable, optimistic];
+    app.renderMessages();
+    assertEqual(messages.querySelectorAll('.assistant').length, 2, 'race reproduction mounts durable and optimistic assistant nodes');
+
+    session.messages = reconcileTranscriptProjection(session.messages, session.transcript);
+    app.renderMessages();
+
+    assertEqual(messages.querySelectorAll('.assistant').length, 1, 'projection boundary removes the superseded optimistic assistant node');
+    assertEqual(session.messages.length, 1, 'one authoritative assistant remains in session.messages');
+    assertEqual(session.messages[0].id, 'srv_seq_402_text_0', 'durable identity owns the coalesced assistant node');
+    assertEqual(session.messages[0].content, 'durable prefix plus live suffix', 'the optimistic-only suffix remains visible exactly once');
+    assertEqual(
+      messages.querySelectorAll('[data-message-id="srv_seq_402_text_0"]').length,
+      1,
+      'durable assistant identity is unique in the mounted DOM'
+    );
+    assertEqual(
+      messages.querySelectorAll('[data-message-id="msg_assistant_dom"]').length,
+      0,
+      'superseded optimistic assistant identity is removed from the mounted DOM'
     );
   });
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -93,11 +93,13 @@ function makeNode(tagName = 'div') {
     querySelector() { return null; },
     querySelectorAll(selector) {
       const results = [];
+      const toolIDMatch = String(selector || '').match(/^\[data-tool-id="([^"]+)"\]$/);
       const visit = (child) => {
         if (!child) return;
         if (selector === 'input[data-mcp-server]' && child.tagName === 'INPUT' && child.dataset && child.dataset.mcpServer) {
           results.push(child);
         }
+        if (toolIDMatch && child.dataset?.toolId === toolIDMatch[1]) results.push(child);
         (child.children || []).forEach(visit);
       };
       children.forEach(visit);
@@ -1183,6 +1185,172 @@ async function testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwit
   session.transcript.releaseBodies();
   session.messages = [];
   if (!app.applySelectedTranscriptSideload(session, sideload) || !assertUniqueProjection('switch-back sideload')) return;
+
+  pass(name);
+}
+
+async function testTranscriptRefreshPublishesReconciledRecoveryToolsBeforeRender() {
+  const name = 'transcript refresh publishes durable recovery tools once before render';
+  let appRef = null;
+  let renderCount = 0;
+  let projectionAtRender = [];
+  let optimisticAtRender = [];
+  const { app, storage, windowObj, elementMap } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, 'sess_late_durable_tools')) {
+        return new Response(null, { status: 304, headers: { ETag: '"late-tools-9"' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: {
+      renderMessages() {
+        renderCount += 1;
+        const session = appRef?.state.sessions.find((item) => item.id === 'sess_late_durable_tools');
+        if (!session) return;
+        projectionAtRender = session.messages
+          .filter((message) => message.role === 'tool-group')
+          .map((message) => ({ id: message.id, tools: message.tools.map((tool) => tool.id) }));
+        optimisticAtRender = (session.transcript?.optimistic || [])
+          .filter((message) => message.role === 'tool-group')
+          .map((message) => ({ id: message.id, tools: message.tools.map((tool) => tool.id) }));
+        const mounted = elementMap.get('messages');
+        mounted.replaceChildren(...projectionAtRender.flatMap((group) => group.tools.map((toolID) => {
+          const node = makeNode();
+          node.dataset.toolId = toolID;
+          return node;
+        })));
+      }
+    },
+    onInitializeStarted({ app: startedApp }) { appRef = startedApp; }
+  });
+  const session = {
+    id: 'sess_late_durable_tools',
+    number: 957,
+    title: 'Late durable tools',
+    messages: [],
+    activeResponseId: 'resp_late_durable_tools',
+    lastSequenceNumber: 8
+  };
+  app.state.sessions.push(session);
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  // Recovery arrives first and owns the only projection while the durable
+  // transcript still trails the active response.
+  session.messages = [{
+    id: 'msg_c011_recovery_tools',
+    role: 'tool-group',
+    status: 'running',
+    created: 1200,
+    tools: [
+      { id: 'call_A', name: 'shell', status: 'done' },
+      { id: 'call_B', name: 'shell', status: 'done' },
+      { id: 'call_C', name: 'shell', status: 'done' },
+      { id: 'call_D', name: 'shell', status: 'running' }
+    ]
+  }];
+  app.reconcileSessionToolCallProjection(session, { trackOptimisticTools: true });
+  app.renderMessages(false);
+
+  // A later transcript refresh materializes A/B/C durably. Publishing the
+  // combined durable + optimistic projection must reconcile both sources before
+  // the caller's single render boundary, retaining only newer optimistic D.
+  const transcript = session.transcript;
+  transcript.applyIndex({
+    rev: 9,
+    compaction_seq: -1,
+    compaction_count: 0,
+    active_response_id: session.activeResponseId,
+    started_rev: 7,
+    rows: {
+      ids: [436, 437],
+      seqs: [436, 437],
+      roles: 'ua',
+      flags: [0, 0]
+    }
+  }, '"late-tools-9"');
+  transcript.setViewport(1, 1, { deferBudget: true });
+  transcript.materialize([
+    { id: 436, sequence: 436, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'continue' }] },
+    {
+      id: 437,
+      sequence: 437,
+      role: 'assistant',
+      created_at: 1100,
+      parts: [
+        { type: 'tool_call', tool_call_id: 'call_A', tool_name: 'shell', tool_arguments: '{}' },
+        { type: 'tool_call', tool_call_id: 'call_B', tool_name: 'shell', tool_arguments: '{}' },
+        { type: 'tool_call', tool_call_id: 'call_C', tool_name: 'shell', tool_arguments: '{}' }
+      ]
+    }
+  ], { countFetch: false, deferBudget: true });
+  transcript.enforceBudget();
+
+  if (!app.refreshSessionMessagesFromTranscript(session)) {
+    fail(name, 'late durable transcript projection was not published');
+    return;
+  }
+  app.renderMessages(false);
+
+  const expectedProjection = JSON.stringify([
+    { id: 'srv_seq_437_tools_0', tools: ['call_A', 'call_B', 'call_C'] },
+    { id: 'msg_c011_recovery_tools', tools: ['call_D'] }
+  ]);
+  if (JSON.stringify(projectionAtRender) !== expectedProjection
+      || JSON.stringify(optimisticAtRender) !== JSON.stringify([{ id: 'msg_c011_recovery_tools', tools: ['call_D'] }])) {
+    fail(name, 'projection or transcript optimistic state was not reconciled before render', JSON.stringify({ projectionAtRender, optimisticAtRender }));
+    return;
+  }
+
+  const mounted = elementMap.get('messages');
+  for (const callID of ['call_A', 'call_B', 'call_C', 'call_D']) {
+    if (mounted.querySelectorAll(`[data-tool-id="${callID}"]`).length !== 1) {
+      fail(name, `${callID} was not mounted exactly once after transcript refresh`);
+      return;
+    }
+  }
+  const persisted = JSON.parse(storage.get('term_llm_optimistic_transcript') || 'null');
+  const persistedTools = persisted?.sessions?.[session.id]?.[0]?.tools?.map((tool) => tool.id) || [];
+  if (persistedTools.join(',') !== 'call_D') {
+    fail(name, 'covered recovery calls remained in persisted transcript optimistic state', JSON.stringify(persisted));
+    return;
+  }
+
+  // Repeated status-driven publication is idempotent, and an inactive session
+  // updates only data. Switching back renders the same unique projection.
+  const rendersBeforeInactiveRefresh = renderCount;
+  const durableGroup = session.messages.find((message) => message.id === 'srv_seq_437_tools_0');
+  session.messages = [durableGroup, {
+    id: 'msg_c011_recovery_tools',
+    role: 'tool-group',
+    status: 'running',
+    tools: [
+      { id: 'call_A', name: 'shell', status: 'done' },
+      { id: 'call_B', name: 'shell', status: 'done' },
+      { id: 'call_C', name: 'shell', status: 'done' },
+      { id: 'call_D', name: 'shell', status: 'running' }
+    ]
+  }];
+  app.state.activeSessionId = 'sess_other';
+  await app.refreshActiveSessionMessagesFromServer(session, { force: true });
+  await app.refreshActiveSessionMessagesFromServer(session, { force: true });
+  if (renderCount !== rendersBeforeInactiveRefresh || JSON.stringify(session.messages
+    .filter((message) => message.role === 'tool-group')
+    .map((message) => ({ id: message.id, tools: message.tools.map((tool) => tool.id) }))) !== expectedProjection) {
+    fail(name, 'inactive repeat refresh rendered or changed the reconciled projection');
+    return;
+  }
+  app.state.activeSessionId = session.id;
+  app.renderMessages(false);
+  for (const callID of ['call_A', 'call_B', 'call_C', 'call_D']) {
+    if (mounted.querySelectorAll(`[data-tool-id="${callID}"]`).length !== 1) {
+      fail(name, `${callID} was duplicated after switch back`);
+      return;
+    }
+  }
 
   pass(name);
 }
@@ -6100,6 +6268,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testIdleStartupSchedulesNormalPollWithoutImmediateRequest();
   await testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTranscriptRequests();
   await testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwitchBack();
+  await testTranscriptRefreshPublishesReconciledRecoveryToolsBeforeRender();
   await testMalformedStartupTranscriptSideloadFallsBack();
   await testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision();
   await testStartupActiveSideloadAvoidsDuplicateStateAfterScheduledStatus();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -429,7 +429,7 @@ async function createSessionsHarness(options = {}) {
   vm.runInContext(transcriptStoreSource, context, { filename: 'transcript-store.js' });
   windowObj.TranscriptStore = context.TranscriptStore;
   windowObj.transcriptStoreFromMessages = context.transcriptStoreFromMessages;
-  windowObj.reconcileToolCallProjection = context.reconcileToolCallProjection;
+  windowObj.reconcileTranscriptProjection = context.reconcileTranscriptProjection;
   windowObj.TRANSCRIPT_BUDGETS = context.TRANSCRIPT_BUDGETS;
   vm.runInContext(coreSource, context, { filename: 'app-core.js' });
   vm.runInContext(planSource, context, { filename: 'app-plan.js' });
@@ -1095,8 +1095,8 @@ async function testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTrans
   pass(name);
 }
 
-async function testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwitchBack() {
-  const name = 'selected transcript sideload reconciles stable tool calls across switch away and back';
+async function testSelectedTranscriptSideloadReconcilesProjectedTailAcrossSwitchBack() {
+  const name = 'selected transcript sideload reconciles assistant and tool tails across switch away and back';
   const { app, windowObj } = await createSessionsHarness({
     fetchImpl: async () => new Response(JSON.stringify({ sessions: [] }), {
       status: 200,
@@ -1129,6 +1129,17 @@ async function testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwit
       { id: 'call_newer_shell', name: 'shell', status: 'running' }
     ]
   }, 7);
+  transcript.addOptimistic({
+    id: 'msg_441406d5-live-assistant',
+    clientKey: 'msg_441406d5-live-assistant',
+    role: 'assistant',
+    content: 'durable answer plus live suffix',
+    revAtSend: 7,
+    durableSeqAtSend: 381,
+    responseId: 'resp_tool_overlap',
+    responseStartedRev: 6,
+    created: 1190
+  }, 7);
   const sideload = {
     index_etag: '"tool-overlap-7"',
     index: {
@@ -1154,6 +1165,7 @@ async function testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwit
           role: 'assistant',
           created_at: 1100,
           parts: [
+            { type: 'text', text: 'durable answer' },
             { type: 'tool_call', tool_call_id: 'call_GwHMMHXf28QA81Zfm9vgRMap', tool_name: 'queue_agent', tool_arguments: '{}' },
             { type: 'tool_call', tool_call_id: 'call_XX3ODxDyeoIxc7ZUZwJm19qu', tool_name: 'wait_for_jobs', tool_arguments: '{}' }
           ]
@@ -1164,15 +1176,21 @@ async function testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwit
 
   const assertUniqueProjection = (phase) => {
     const groups = session.messages.filter((message) => message.role === 'tool-group');
+    const assistants = session.messages.filter((message) => message.role === 'assistant');
     const callIDs = groups.flatMap((group) => group.tools.map((tool) => tool.id));
     const unique = new Set(callIDs);
     if (unique.size !== callIDs.length) {
       fail(name, `${phase} retained duplicate call IDs`, JSON.stringify(session.messages));
       return false;
     }
-    if (groups.map((group) => group.id).join(',') !== 'srv_seq_382_tools_0,msg_441406d5-live-tools'
+    if (groups.map((group) => group.id).join(',') !== 'srv_seq_382_tools_1,msg_441406d5-live-tools'
         || groups[1].tools.map((tool) => tool.id).join(',') !== 'call_newer_shell') {
       fail(name, `${phase} lost durable authority or newer optimistic order`, JSON.stringify(groups));
+      return false;
+    }
+    if (assistants.length !== 1 || assistants[0].id !== 'srv_seq_382_text_0'
+        || assistants[0].content !== 'durable answer plus live suffix') {
+      fail(name, `${phase} duplicated or lost the assistant tail`, JSON.stringify(assistants));
       return false;
     }
     return true;
@@ -1252,7 +1270,7 @@ async function testTranscriptRefreshPublishesReconciledRecoveryToolsBeforeRender
       { id: 'call_D', name: 'shell', status: 'running' }
     ]
   }];
-  app.reconcileSessionToolCallProjection(session, { trackOptimisticTools: true });
+  app.reconcileSessionTranscriptProjection(session, { trackOptimisticTail: true });
   app.renderMessages(false);
 
   // A later transcript refresh materializes A/B/C durably. Publishing the
@@ -5315,6 +5333,12 @@ async function testOptimisticTranscriptStorageIsPerSession() {
     fail(name, 'one session clobbered another or persisted a display-only row', JSON.stringify(saved));
     return;
   }
+  app.retireTranscriptOptimistic(first, 'send-a');
+  const retired = JSON.parse(storage.get('term_llm_optimistic_transcript') || 'null');
+  if (retired?.sessions?.[first.id] || retired?.sessions?.[second.id]?.[0]?.clientKey !== 'send-b') {
+    fail(name, 'retiring one optimistic writer removed the wrong session or left stale storage', JSON.stringify(retired));
+    return;
+  }
   pass(name);
 }
 
@@ -6246,6 +6270,148 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   pass(name);
 }
 
+async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh() {
+  const name = 'assistant tail ownership coalesces status prefix, terminal completion, and inactive refresh';
+  const sessionId = 'assistant-tail-race';
+  let phase = 'status';
+  let renderCount = 0;
+  const transcriptEnvelope = () => phase === 'status'
+    ? {
+      rev: 7,
+      compaction_seq: -1,
+      compaction_count: 0,
+      active_response_id: 'resp_assistant_tail',
+      started_rev: 7,
+      rows: { ids: [401, 402], seqs: [401, 402], roles: 'ua', flags: [0, 0] }
+    }
+    : {
+      rev: 8,
+      compaction_seq: -1,
+      compaction_count: 0,
+      rows: { ids: [401, 403], seqs: [401, 403], roles: 'ua', flags: [0, 0] }
+    };
+  const transcriptBodies = () => ({
+    rev: phase === 'status' ? 7 : 8,
+    messages: [
+      { id: 401, sequence: 401, role: 'user', created_at: 1000, parts: [{ type: 'text', text: 'question' }] },
+      {
+        id: phase === 'status' ? 402 : 403,
+        sequence: phase === 'status' ? 402 : 403,
+        role: 'assistant',
+        created_at: 2000,
+        parts: [{
+          type: 'text',
+          text: phase === 'status' ? 'durable prefix' : 'durable prefix plus optimistic suffix'
+        }]
+      }
+    ]
+  });
+
+  const { app, windowObj, storage } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        return new Response(JSON.stringify(transcriptEnvelope()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', ETag: `"assistant-${phase}"` }
+        });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        return new Response(JSON.stringify(transcriptBodies()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: {
+      renderMessages() { renderCount += 1; }
+    }
+  });
+  app.stopSidebarStatusPoll();
+
+  const session = { id: sessionId, messages: [] };
+  session.transcript = new windowObj.TranscriptStore(sessionId);
+  session.transcript.applyIndex({
+    rev: 6,
+    compaction_seq: -1,
+    compaction_count: 0,
+    rows: { ids: [401], seqs: [401], roles: 'u', flags: [0] }
+  });
+  session.transcript.materialize(transcriptBodies().messages.slice(0, 1), { countFetch: false });
+  session.transcript.setViewport(0, 0);
+  session.transcript.setActiveRun('resp_assistant_tail', 7);
+  const optimistic = {
+    id: 'msg_assistant_tail',
+    clientKey: 'msg_assistant_tail',
+    role: 'assistant',
+    content: 'durable prefix plus optimistic suffix',
+    revAtSend: 7,
+    durableSeqAtSend: 401,
+    created: 2100
+  };
+  session.messages.push(optimistic);
+  app.trackTranscriptOptimistic(session, optimistic);
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+  app.state.streaming = true;
+
+  const statusLoaded = await app.reconcileTranscriptFromStatus([{
+    id: sessionId,
+    transcript_rev: 7,
+    active_response_id: 'resp_assistant_tail',
+    started_rev: 7,
+    active_run: true
+  }]);
+  const statusAssistants = session.messages.filter((message) => message.role === 'assistant');
+  if (!statusLoaded || statusAssistants.length !== 1
+      || statusAssistants[0].id !== 'srv_seq_402_text_0'
+      || statusAssistants[0].content !== 'durable prefix plus optimistic suffix') {
+    fail(name, 'status projection duplicated or lost the active assistant tail', JSON.stringify(session.messages));
+    return;
+  }
+  if (session.transcript.optimistic.length !== 1) {
+    fail(name, 'partial durable coverage retired the live suffix source', JSON.stringify(session.transcript.optimistic));
+    return;
+  }
+
+  phase = 'terminal';
+  const terminalLoaded = await app.noteTranscriptTerminal(session, 8);
+  const terminalAssistants = session.messages.filter((message) => message.role === 'assistant');
+  if (!terminalLoaded || terminalAssistants.length !== 1
+      || terminalAssistants[0].id !== 'srv_seq_403_text_0'
+      || terminalAssistants[0].content !== 'durable prefix plus optimistic suffix') {
+    fail(name, 'terminal projection did not leave one complete durable assistant', JSON.stringify(session.messages));
+    return;
+  }
+  if (session.transcript.optimistic.length !== 0) {
+    fail(name, 'terminal completion did not clear the superseded optimistic assistant exactly once', JSON.stringify(session.transcript.optimistic));
+    return;
+  }
+  const persisted = JSON.parse(storage.get('term_llm_optimistic_transcript') || '{"sessions":{}}');
+  if (persisted.sessions?.[sessionId]) {
+    fail(name, 'terminal completion left superseded optimistic storage behind', JSON.stringify(persisted));
+    return;
+  }
+
+  const activeRenderCount = renderCount;
+  app.state.activeSessionId = 'different-session';
+  const inactiveLoaded = await app.syncTranscript(session, { reason: 'reconnect', force: true, targetRev: 8 });
+  if (!inactiveLoaded || renderCount !== activeRenderCount) {
+    fail(name, 'inactive transcript refresh touched the mounted DOM', JSON.stringify({ inactiveLoaded, renderCount, activeRenderCount }));
+    return;
+  }
+  if (session.messages.filter((message) => message.role === 'assistant').length !== 1) {
+    fail(name, 'inactive transcript refresh did not remain data-correct', JSON.stringify(session.messages));
+    return;
+  }
+
+  pass(name);
+}
+
 (async () => {
   await testSanitizeMessagePreservesSkillRunState();
   await testSanitizeMessagePreservesPlanExecutionEvidence();
@@ -6267,7 +6433,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testNumericDeepLinkResolvesRealSessionId();
   await testIdleStartupSchedulesNormalPollWithoutImmediateRequest();
   await testStartupTranscriptSideloadRendersBoundedFirstPaintWithoutTranscriptRequests();
-  await testSelectedTranscriptSideloadReconcilesStableToolCallsAcrossSwitchBack();
+  await testSelectedTranscriptSideloadReconcilesProjectedTailAcrossSwitchBack();
   await testTranscriptRefreshPublishesReconciledRecoveryToolsBeforeRender();
   await testMalformedStartupTranscriptSideloadFallsBack();
   await testStartupTranscriptSideloadRevisionRaceFetchesOnlyNewerRevision();
@@ -6306,6 +6472,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testTranscriptSyncCommitsOneRenderedProjection();
   await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
   await testInflightSyncAbsorbsQueuedZeroRevisionActivation();
+  await testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh();
   await testGroupedToolRowsPreserveDurableRangesAndLaterAnchors();
   await testLargeToolTurnLoadsAsOneSegmentWithFarEndGrouping();
   await testTerminalTranscriptSyncQueuesBehindInflightRequest();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -11,7 +11,7 @@ const { webcrypto } = require('crypto');
 const dir = __dirname;
 const attachmentsSource = fs.readFileSync(path.join(dir, 'app-attachments.js'), 'utf8');
 const source = fs.readFileSync(path.join(dir, 'app-stream.js'), 'utf8');
-const { reconcileToolCallProjection } = require('./transcript-store.js');
+const { reconcileTranscriptProjection } = require('./transcript-store.js');
 
 let failures = 0;
 
@@ -481,10 +481,10 @@ function createHarness(options = {}) {
     renderSidebar() {},
     renderWidgetSidebar() {},
     renderMessages() {},
-    reconcileSessionToolCallProjection(session) {
-      session.messages = reconcileToolCallProjection(session.messages);
-      if (typeof options.onReconcileSessionToolCallProjection === 'function') {
-        options.onReconcileSessionToolCallProjection(session);
+    reconcileSessionTranscriptProjection(session) {
+      session.messages = reconcileTranscriptProjection(session.messages);
+      if (typeof options.onReconcileSessionTranscriptProjection === 'function') {
+        options.onReconcileSessionTranscriptProjection(session);
       }
       return true;
     },
@@ -2879,7 +2879,7 @@ async function testRecoverySnapshotReconcilesDurableToolCallsIdempotently() {
   const name = 'recovery snapshot reconciles durable tool calls by stable call ID idempotently';
   let reconciliations = 0;
   const harness = createHarness({
-    onReconcileSessionToolCallProjection() { reconciliations += 1; }
+    onReconcileSessionTranscriptProjection() { reconciliations += 1; }
   });
   const { app, state, cleanup } = harness;
   const durable = {

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -560,6 +560,11 @@ function createHarness(options = {}) {
 
   const windowObj = {
     TermLLMApp: app,
+    TranscriptStore,
+    reconcileTranscriptProjection,
+    assistantSegmentKey: require('./transcript-store.js').assistantSegmentKey,
+    transcriptToolIdentityKey: require('./transcript-store.js').transcriptToolIdentityKey,
+    transcriptDiagnostic: require('./transcript-store.js').transcriptDiagnostic,
     __TERM_LLM_DIAGNOSTICS__: Boolean(options.diagnostics),
     setTimeout: typeof options.setTimeout === 'function' ? options.setTimeout : setTimeout,
     clearTimeout: typeof options.clearTimeout === 'function' ? options.clearTimeout : clearTimeout,
@@ -2478,7 +2483,7 @@ async function testSendMessageRecoversAfterStreamBufferOverflowDone() {
   const session = harness.state.sessions[0];
   const assistant = session && session.messages.find((message) => message.role === 'assistant');
   if (!assistant || assistant.content !== 'hello world') {
-    fail(name, 'assistant content did not recover after overflow', assistant ? assistant.content : 'missing');
+    fail(name, 'assistant content did not recover after overflow', JSON.stringify({ assistant: assistant?.content, messages: session?.messages?.map((message) => [message.role, message.id, message.content]), optimistic: session?.transcript?.optimistic?.map((message) => [message.role, message.id, message.content]) }));
     return;
   }
 
@@ -3098,7 +3103,7 @@ async function testReplayCompletionReconcilesDurableSelectedProjection() {
       ? (message.tools || []).map((tool) => tool.id)
       : []);
     if (projectedCalls.join(',') !== calls.join(',')) {
-      fail(name, `${phase}: session projection did not contain A/B/C durable and D optimistic once`, JSON.stringify(session.messages));
+      fail(name, `${phase}: session projection did not contain A/B/C durable and D optimistic once`, JSON.stringify({ messages: session.messages, optimistic: transcript.optimistic }));
       return false;
     }
     if (optimisticCalls.join(',') !== 'call_D') {
@@ -3144,8 +3149,8 @@ async function testReplayCompletionReconcilesDurableSelectedProjection() {
     transcript.destroy();
     return;
   }
-  if (reconciliations !== 2 || renders !== 4) {
-    fail(name, `expected one replay reconciliation plus snapshot/boundary renders per resume, got ${reconciliations} reconciliations and ${renders} renders`);
+  if (reconciliations !== 4 || renders !== 4) {
+    fail(name, `expected one snapshot normalization and one replay-boundary normalization per resume, got ${reconciliations} reconciliations and ${renders} renders`);
     await cleanup();
     transcript.destroy();
     return;
@@ -4808,7 +4813,10 @@ async function testInterjectionClosesToolGroupAndInsertsUserMessageAtTail() {
   ];
 
   const streamState = app.createResponseStreamState(session);
-  const fakeToolGroup = { id: 'grp_1', role: 'tool-group', tools: [], status: 'running' };
+  const fakeToolGroup = app.trackTranscriptOptimistic(session, {
+    id: 'grp_1', role: 'tool-group', responseId: 'resp_int', tools: [], status: 'running'
+  });
+  session.messages.push(fakeToolGroup);
   streamState.currentToolGroup = fakeToolGroup;
   streamState.currentAssistantMessage = null;
 
@@ -6997,7 +7005,308 @@ async function testIsolatedSkillStreamsIndependentlyAndCancelsIndependently() {
   pass(name);
 }
 
+async function testDetachedReplayPublishesOnlyAtOrderedBoundary() {
+  const name = 'historical replay remains detached until every ordered boundary event is present';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const responseId = 'resp_detached_boundary';
+  const transcript = new TranscriptStore('session_detached_boundary');
+  transcript.setActiveRun(responseId, 0, 1);
+  const session = { id: 'session_detached_boundary', messages: [], transcript, activeResponseId: responseId, lastSequenceNumber: 0 };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.currentStreamResponseId = responseId;
+  const events = [
+    ['response.output_text.delta', { response_id: responseId, assistant_segment_ordinal: 0, segment_start_sequence: 1, delta: 'alpha', sequence_number: 1 }],
+    ['response.output_item.added', { response_id: responseId, item: { type: 'function_call', call_id: 'call_boundary', name: 'shell', arguments: '{}' }, output_index: 1, sequence_number: 2 }],
+    ['response.completed', { response_id: responseId, response: { id: responseId, status: 'completed' }, sequence_number: 3 }],
+  ];
+  for (let cutoff = 0; cutoff < events.length; cutoff += 1) {
+    const stage = app.createHistoricalReplayStage(responseId, 0, 3, 1);
+    for (let i = 0; i < cutoff; i += 1) app.reduceHistoricalReplayEvent(stage, events[i][0], events[i][1]);
+    if (session.messages.length !== 0 || transcript.optimistic.length !== 0) {
+      fail(name, `cutoff ${cutoff} published partial replay`, JSON.stringify(session.messages));
+      await cleanup();
+      return;
+    }
+  }
+  const stage = app.createHistoricalReplayStage(responseId, 0, 3, 1);
+  for (const [event, payload] of events) app.reduceHistoricalReplayEvent(stage, event, payload);
+  const streamState = app.createResponseStreamState(session, { responseId });
+  const terminal = app.mergeHistoricalReplayStage(session, streamState, stage);
+  if (!terminal || transcript.optimistic.length !== 2 || session.messages.length !== 2) {
+    fail(name, 'complete text/tool/terminal boundary was not published atomically', JSON.stringify({ terminal, messages: session.messages }));
+    await cleanup();
+    return;
+  }
+  await cleanup();
+  transcript.destroy();
+  pass(name);
+}
+
+async function testDurableReplayContinuationKeepsCanonicalOverlayCursor() {
+  const name = 'durable prefix replay overlap and refreshes preserve one mutable overlay through fresh suffixes';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const responseId = 'resp_overlay_cursor';
+  const transcript = new TranscriptStore('session_overlay_cursor');
+  transcript.setActiveRun(responseId, 1, 1);
+  transcript.applyIndex({
+    rev: 1,
+    rows: {
+      ids: [10], seqs: [10], roles: 'a', flags: [0],
+      response_ids: [''], assistant_segment_ordinals: [-1],
+    },
+  });
+  transcript.materialize([{ id: 10, sequence: 10, role: 'assistant', parts: [{ type: 'text', text: 'durable' }] }]);
+  let durable = { id: 'srv_10', durableSourceRowIds: [10], role: 'assistant', content: 'durable', durable: true, serverSeq: 10 };
+  const session = { id: 'session_overlay_cursor', messages: [durable], transcript, activeResponseId: responseId, lastSequenceNumber: 0 };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.currentStreamResponseId = responseId;
+  const stage = app.createHistoricalReplayStage(responseId, 0, 1, 1);
+  app.reduceHistoricalReplayEvent(stage, 'response.output_text.delta', {
+    response_id: responseId, assistant_segment_ordinal: 0, segment_start_sequence: 1,
+    delta: 'durable', sequence_number: 1,
+  });
+  const streamState = app.createResponseStreamState(session, { responseId });
+  app.mergeHistoricalReplayStage(session, streamState, stage);
+  for (const [sequence, delta] of [[2, ' suffix'], [3, '!']]) {
+    app.applyResponseStreamEvent(session, streamState, 'response.output_text.delta', {
+      response_id: responseId, assistant_segment_ordinal: 0, segment_start_sequence: 1,
+      delta, sequence_number: sequence,
+    });
+    app.responseEventCursor(session, responseId).appliedSequence = sequence;
+    transcript.applyIndex({
+      rev: sequence,
+      rows: { ids: [10], seqs: [10], roles: 'a', flags: [0], response_ids: [''], assistant_segment_ordinals: [-1] },
+    });
+    const refreshedBody = { id: 10, sequence: 10, role: 'assistant', parts: [{ type: 'text', text: 'durable' }] };
+    transcript.materialize([refreshedBody]);
+    durable = {
+      id: 'srv_10', durableSourceRowIds: [10], role: 'assistant', content: 'durable', durable: true, serverSeq: 10,
+      responseId: refreshedBody.responseId, assistantSegmentOrdinal: refreshedBody.assistantSegmentOrdinal,
+    };
+    session.messages = [durable, ...transcript.optimistic];
+    transcript.reconcileOptimistic();
+    const projection = reconcileTranscriptProjection(session.messages, transcript);
+    if (projection.filter((message) => message.role === 'assistant').length !== 1
+      || projection.find((message) => message.role === 'assistant')?.content !== (sequence === 2 ? 'durable suffix' : 'durable suffix!')) {
+      fail(name, `refresh after sequence ${sequence} lost or duplicated suffix`, JSON.stringify(projection));
+      await cleanup();
+      return;
+    }
+    transcript.assertMutableOverlay(streamState.currentAssistantMessage, 'adversarial-refresh');
+  }
+  await cleanup();
+  transcript.destroy();
+  pass(name);
+}
+
+async function testSuffixOnlyReplayAndRepeatedTerminalAreIdempotent() {
+  const name = 'suffix-only replay composes by identity and repeated terminal finalizes exactly once';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const responseId = 'resp_suffix_terminal';
+  const transcript = new TranscriptStore('session_suffix_terminal');
+  transcript.applyIndex({ rev: 1, rows: { ids: [20], seqs: [20], roles: 'a', flags: [0], response_ids: [responseId], assistant_segment_ordinals: [0] } });
+  transcript.setActiveRun(responseId, 1, 2);
+  const durable = { id: 'srv_20', role: 'assistant', content: 'prefix', durable: true, responseId, assistantSegmentOrdinal: 0, serverSeq: 20 };
+  const session = { id: 'session_suffix_terminal', messages: [durable], transcript, activeResponseId: responseId, lastSequenceNumber: 5 };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.currentStreamResponseId = responseId;
+  const stage = app.createHistoricalReplayStage(responseId, 5, 6, 2);
+  app.reduceHistoricalReplayEvent(stage, 'response.output_text.delta', {
+    response_id: responseId, assistant_segment_ordinal: 0, segment_start_sequence: 1,
+    delta: ' suffix', sequence_number: 6,
+  });
+  const streamState = app.createResponseStreamState(session, { responseId });
+  app.mergeHistoricalReplayStage(session, streamState, stage);
+  transcript.materialize([{ id: 20, sequence: 20, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0, parts: [{ type: 'text', text: 'prefix' }] }]);
+  const projected = reconcileTranscriptProjection([durable, ...transcript.optimistic], transcript);
+  if (projected.filter((message) => message.role === 'assistant').length !== 1 || projected[0]?.content !== 'prefix suffix') {
+    fail(name, 'suffix-only replay did not compose with its identified durable prefix', JSON.stringify(projected));
+    await cleanup();
+    return;
+  }
+  let terminalEffects = 0;
+  app.noteTranscriptTerminal = (_session, _responseId, _finalRev) => { terminalEffects += 1; };
+  for (let i = 0; i < 3; i += 1) {
+    app.applyResponseStreamEvent(session, streamState, 'response.completed', {
+      response_id: responseId, response: { id: responseId, status: 'completed' },
+      sequence_number: 7, final_rev: 2, run_epoch: 2,
+    });
+  }
+  const cursor = app.responseEventCursor(session, responseId);
+  if (terminalEffects !== 1 || !cursor.finalized || cursor.terminalSequence !== 7 || Object.keys(session.responseEventCursors).length > 16) {
+    fail(name, 'terminal effects or cursor retention were not idempotent/bounded', JSON.stringify({ terminalEffects, cursor, cursors: session.responseEventCursors }));
+    await cleanup();
+    return;
+  }
+  await cleanup();
+  transcript.destroy();
+  pass(name);
+}
+
+async function testInterruptedReplayPublishesNothingAndRetriesFromOriginalCursor() {
+  const name = 'interrupted detached replay publishes nothing and retries from the original response cursor';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const responseId = 'resp_interrupted_replay';
+  const transcript = new TranscriptStore('session_interrupted_replay');
+  transcript.setActiveRun(responseId, 0, 4);
+  const session = {
+    id: 'session_interrupted_replay', messages: [], transcript,
+    activeResponseId: responseId, lastSequenceNumber: 0,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.currentStreamResponseId = responseId;
+  const streamState = app.createResponseStreamState(session, { responseId });
+  const makeStream = (body) => new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  const partial = await app.consumeResponseStream(makeStream([
+    'event: response.output_text.delta\n',
+    `data: {"response_id":"${responseId}","assistant_segment_ordinal":0,"segment_start_sequence":1,"delta":"alpha","sequence_number":1}\n\n`,
+    'data: [DONE]\n\n',
+  ].join('')), session, streamState, {
+    generation: state.streamGeneration, responseId, replayAfterSequence: 0, replayThroughSequence: 2,
+  });
+  if (!partial.error?.recoverableReplayInterrupted || session.messages.length !== 0
+    || transcript.optimistic.length !== 0 || app.responseEventSequence(session, responseId) !== 0) {
+    fail(name, 'partial replay leaked staged state or advanced its response cursor', JSON.stringify({ partial, messages: session.messages, optimistic: transcript.optimistic }));
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+  const retried = await app.consumeResponseStream(makeStream([
+    'event: response.output_text.delta\n',
+    `data: {"response_id":"${responseId}","assistant_segment_ordinal":0,"segment_start_sequence":1,"delta":"alpha","sequence_number":1}\n\n`,
+    'event: response.output_text.delta\n',
+    `data: {"response_id":"${responseId}","assistant_segment_ordinal":0,"segment_start_sequence":1,"delta":" beta","sequence_number":2}\n\n`,
+    'data: [DONE]\n\n',
+  ].join('')), session, streamState, {
+    generation: state.streamGeneration, responseId, replayAfterSequence: 0, replayThroughSequence: 2,
+  });
+  const assistant = transcript.optimisticAssistant(responseId, 0);
+  if (retried.error || !assistant || assistant.content !== 'alpha beta' || app.responseEventSequence(session, responseId) !== 2) {
+    fail(name, 'complete retry did not publish exactly once at its replay boundary', JSON.stringify({ retried, assistant, cursor: app.responseEventSequence(session, responseId) }));
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+  await cleanup();
+  transcript.destroy();
+  pass(name);
+}
+
+async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch() {
+  const name = 'stale recovery snapshot cannot reclaim session ownership after a rapid response switch';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const transcript = new TranscriptStore('session_rapid_response_switch');
+  transcript.setActiveRun('resp_new', 2, 2);
+  const session = {
+    id: 'session_rapid_response_switch', messages: [], transcript,
+    activeResponseId: 'resp_new', latestRunEpoch: 2, lastSequenceNumber: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.currentStreamResponseId = 'resp_new';
+  app.applyResponseRecoverySnapshot(session, {
+    id: 'resp_old', status: 'in_progress', run_epoch: 1, started_rev: 1, last_sequence_number: 4,
+    recovery: {
+      sequence_number: 4,
+      messages: [{ id: 'old-assistant', role: 'assistant', response_id: 'resp_old', assistant_segment_ordinal: 0, content: 'old tail' }],
+    },
+  });
+  if (session.activeResponseId !== 'resp_new' || transcript.activeRun?.id !== 'resp_new'
+    || state.currentStreamResponseId !== 'resp_new') {
+    fail(name, 'stale snapshot replaced newer response ownership', JSON.stringify({ session: session.activeResponseId, transcript: transcript.activeRun, stream: state.currentStreamResponseId }));
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+  await cleanup();
+  transcript.destroy();
+  pass(name);
+}
+
+async function testRecoverySnapshotNeverPointsStreamCursorAtDurableProjection() {
+  const name = 'durable-before-snapshot recovery keeps every mutable cursor on the optimistic overlay';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const responseId = 'resp_durable_before_snapshot';
+  const transcript = new TranscriptStore('session_durable_before_snapshot');
+  transcript.applyIndex({
+    rev: 1,
+    rows: { ids: [30], seqs: [30], roles: 'a', flags: [0], response_ids: [responseId], assistant_segment_ordinals: [0] },
+  });
+  transcript.materialize([{
+    id: 30, sequence: 30, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+    parts: [{ type: 'text', text: 'durable prefix' }],
+  }]);
+  transcript.setActiveRun(responseId, 1, 3);
+  const durable = {
+    id: 'srv_30', role: 'assistant', content: 'durable prefix', durable: true, serverSeq: 30,
+    responseId, assistantSegmentOrdinal: 0,
+  };
+  const session = {
+    id: 'session_durable_before_snapshot', messages: [durable], transcript,
+    activeResponseId: responseId, lastSequenceNumber: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.currentStreamSessionId = session.id;
+  state.currentStreamResponseId = responseId;
+  const streamState = app.createResponseStreamState(session, { responseId });
+  let thrown = null;
+  try {
+    app.applyResponseStreamEvent(session, streamState, 'response.stream_error', {
+      response_id: responseId,
+      sequence_number: 2,
+      error: { type: 'stream_buffer_overflow' },
+      recovery: {
+        sequence_number: 2,
+        messages: [{
+          id: `${responseId}_assistant_1`, role: 'assistant', response_id: responseId,
+          assistant_segment_ordinal: 0, content: 'durable prefix suffix',
+        }],
+      },
+    });
+  } catch (err) {
+    thrown = err;
+  }
+  const overlay = transcript.optimisticAssistant(responseId, 0);
+  if (thrown || !overlay || streamState.currentAssistantMessage !== overlay || overlay.durable === true || overlay.optimistic !== true) {
+    fail(name, 'snapshot recovery selected a durable/projection node as the mutable cursor', JSON.stringify({ error: thrown?.message, cursor: streamState.currentAssistantMessage, overlay }));
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+  transcript.assertMutableOverlay(streamState.currentAssistantMessage, 'cursor-never-durable-test');
+  await cleanup();
+  transcript.destroy();
+  pass(name);
+}
+
 (async () => {
+  await testDetachedReplayPublishesOnlyAtOrderedBoundary();
+  await testDurableReplayContinuationKeepsCanonicalOverlayCursor();
+  await testSuffixOnlyReplayAndRepeatedTerminalAreIdempotent();
+  await testInterruptedReplayPublishesNothingAndRetriesFromOriginalCursor();
+  await testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch();
+  await testRecoverySnapshotNeverPointsStreamCursorAtDurableProjection();
   await testUnknownSlashTextRemainsNormalMessage();
   await testMainSkillUsesStructuredInvocationAndResponseStream();
   await testIsolatedSkillStreamsIndependentlyAndCancelsIndependently();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -11,7 +11,7 @@ const { webcrypto } = require('crypto');
 const dir = __dirname;
 const attachmentsSource = fs.readFileSync(path.join(dir, 'app-attachments.js'), 'utf8');
 const source = fs.readFileSync(path.join(dir, 'app-stream.js'), 'utf8');
-const { reconcileTranscriptProjection } = require('./transcript-store.js');
+const { TranscriptStore, reconcileTranscriptProjection } = require('./transcript-store.js');
 
 let failures = 0;
 
@@ -480,9 +480,27 @@ function createHarness(options = {}) {
     },
     renderSidebar() {},
     renderWidgetSidebar() {},
-    renderMessages() {},
-    reconcileSessionTranscriptProjection(session) {
-      session.messages = reconcileTranscriptProjection(session.messages);
+    renderMessages() {
+      if (typeof options.onRenderMessages === 'function') {
+        const session = state.sessions.find((item) => item.id === state.activeSessionId) || null;
+        options.onRenderMessages(session, elements.messages);
+      }
+    },
+    trackTranscriptOptimistic(session, message) {
+      return session?.transcript?.addOptimistic?.(message, session.transcript.rev) || null;
+    },
+    persistTranscriptOptimistic() {},
+    reconcileSessionTranscriptProjection(session, reconcileOptions = {}) {
+      const transcript = session?.transcript || null;
+      if (reconcileOptions.trackOptimisticTail === true && transcript) {
+        for (const [index, message] of session.messages.entries()) {
+          if (message?.durable || !['assistant', 'tool-group', 'tool'].includes(message?.role)) continue;
+          const tracked = transcript.addOptimistic(message, transcript.rev);
+          if (tracked && tracked !== message) session.messages[index] = tracked;
+        }
+        transcript.reconcileOptimistic();
+      }
+      session.messages = reconcileTranscriptProjection(session.messages, transcript);
       if (typeof options.onReconcileSessionTranscriptProjection === 'function') {
         options.onReconcileSessionTranscriptProjection(session);
       }
@@ -712,7 +730,12 @@ function createHarness(options = {}) {
         },
       }), {
         status: 200,
-        headers: { 'Content-Type': 'text/event-stream' },
+        headers: {
+          'Content-Type': 'text/event-stream',
+          ...(options.eventsReplayThrough != null
+            ? { 'X-Term-LLM-Replay-Through': String(options.eventsReplayThrough) }
+            : {})
+        },
       });
     }
     throw new Error(`unexpected fetch: ${url}`);
@@ -1030,7 +1053,10 @@ async function testStaleTerminalStreamDoesNotRefreshStatus() {
 
 async function testConsumeResponseStreamIgnoresAlreadyProjectedEvents() {
   const name = 'response stream ignores replayed events that would duplicate or reorder messages';
-  const harness = createHarness();
+  let reconciliations = 0;
+  const harness = createHarness({
+    onReconcileSessionTranscriptProjection() { reconciliations += 1; }
+  });
   const { app, state, cleanup } = harness;
   const session = {
     id: 'session_replayed_events',
@@ -1076,6 +1102,11 @@ async function testConsumeResponseStreamIgnoresAlreadyProjectedEvents() {
   }
   if (session.lastSequenceNumber !== 2) {
     fail(name, `last sequence = ${session.lastSequenceNumber}, want 2`);
+    await cleanup();
+    return;
+  }
+  if (reconciliations !== 0) {
+    fail(name, `fresh/live event handling performed ${reconciliations} full transcript reconciliations`);
     await cleanup();
     return;
   }
@@ -2949,6 +2980,179 @@ async function testRecoverySnapshotReconcilesDurableToolCallsIdempotently() {
   }
 
   await cleanup();
+  pass(name);
+}
+
+async function testReplayCompletionReconcilesDurableSelectedProjection() {
+  const name = 'replay completion reconciles durable selected tools and assistant before publishing';
+  const responseId = 'resp_inverse_replay';
+  const calls = ['call_A', 'call_B', 'call_C', 'call_D'];
+  let renders = 0;
+  let reconciliations = 0;
+  const harness = createHarness({
+    responseId,
+    eventsReplayThrough: 7,
+    onReconcileSessionTranscriptProjection() { reconciliations += 1; },
+    snapshotPayload: {
+      id: responseId,
+      status: 'in_progress',
+      last_sequence_number: 0,
+    },
+    eventsBody: [
+      'id: 1\n',
+      'event: response.output_text.delta\n',
+      'data: {"delta":"durable assistant prefix plus replay suffix","sequence_number":1}\n\n',
+      'id: 2\n',
+      'event: response.output_text.new_segment\n',
+      'data: {"sequence_number":2}\n\n',
+      ...calls.map((callID, index) => [
+        `id: ${index + 3}\n`,
+        'event: response.output_item.added\n',
+        `data: {"item":{"type":"function_call","call_id":"${callID}","name":"tool_${callID.at(-1)}","arguments":"{}"},"output_index":${index},"sequence_number":${index + 3}}\n\n`,
+      ].join('')),
+      'id: 7\n',
+      'event: response.output_item.done\n',
+      'data: {"item":{"type":"function_call","call_id":"call_D","name":"tool_D","arguments":"{}"},"output_index":3,"sequence_number":7}\n\n',
+      'id: 8\n',
+      'event: response.completed\n',
+      `data: {"response":{"id":"${responseId}","model":"test-model","status":"completed"},"sequence_number":8}\n\n`,
+      'data: [DONE]\n\n',
+    ].join(''),
+    onRenderMessages(session, container) {
+      renders += 1;
+      container.children = [];
+      for (const message of session?.messages || []) {
+        if (message.role === 'assistant') {
+          container.children.push({ dataset: { messageId: message.id }, role: 'assistant', content: message.content });
+        }
+        if (message.role === 'tool-group') {
+          for (const tool of message.tools || []) {
+            container.children.push({ dataset: { toolId: tool.id }, role: 'tool' });
+          }
+        }
+      }
+    },
+  });
+  const { app, state, elements, cleanup } = harness;
+  elements.messages.querySelectorAll = (selector) => {
+    const toolMatch = String(selector || '').match(/^\[data-tool-id="([^"]+)"\]$/);
+    if (toolMatch) return elements.messages.children.filter((node) => node.dataset?.toolId === toolMatch[1]);
+    if (selector === '[data-message-id]') return elements.messages.children.filter((node) => node.dataset?.messageId);
+    return [];
+  };
+
+  const transcript = new TranscriptStore('session_inverse_replay');
+  transcript.applyIndex({
+    rev: 7,
+    compaction_seq: -1,
+    compaction_count: 0,
+    rows: {
+      ids: [491, 492],
+      seqs: [491, 492],
+      roles: 'ua',
+      flags: [0, 0],
+    },
+  }, '"inverse-7"');
+  transcript.setViewport(0, 1, { deferBudget: true });
+  transcript.materialize([
+    { id: 491, sequence: 491, role: 'user', parts: [{ type: 'text', text: 'run tools' }] },
+    {
+      id: 492,
+      sequence: 492,
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'durable assistant prefix' },
+        ...calls.slice(0, 3).map((callID) => ({ type: 'tool_call', tool_call_id: callID })),
+      ],
+    },
+  ], { countFetch: false });
+  transcript.setActiveRun(responseId, 6);
+
+  const session = {
+    id: 'session_inverse_replay',
+    title: 'Inverse replay',
+    transcript,
+    messages: [
+      { id: 'srv_seq_491_user_0', role: 'user', content: 'run tools', durable: true, serverSeq: 491 },
+      { id: 'srv_seq_492_text_0', role: 'assistant', content: 'durable assistant prefix', durable: true, serverSeq: 492 },
+      {
+        id: 'srv_seq_492_tools_0',
+        role: 'tool-group',
+        durable: true,
+        status: 'done',
+        tools: calls.slice(0, 3).map((callID) => ({ id: callID, name: `tool_${callID.at(-1)}`, status: 'done' })),
+      },
+    ],
+    activeResponseId: responseId,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+
+  const assertProjection = (phase) => {
+    const projectedCalls = session.messages.flatMap((message) => message.role === 'tool-group'
+      ? (message.tools || []).map((tool) => tool.id)
+      : []);
+    const optimisticCalls = transcript.optimistic.flatMap((message) => message.role === 'tool-group'
+      ? (message.tools || []).map((tool) => tool.id)
+      : []);
+    if (projectedCalls.join(',') !== calls.join(',')) {
+      fail(name, `${phase}: session projection did not contain A/B/C durable and D optimistic once`, JSON.stringify(session.messages));
+      return false;
+    }
+    if (optimisticCalls.join(',') !== 'call_D') {
+      fail(name, `${phase}: transcript optimistic tail did not retain only D`, JSON.stringify(transcript.optimistic));
+      return false;
+    }
+    if (session.messages.some((message) => message.role === 'tool-group' && (message.tools || []).length === 0)) {
+      fail(name, `${phase}: empty tool group remained`, JSON.stringify(session.messages));
+      return false;
+    }
+    const assistants = session.messages.filter((message) => message.role === 'assistant');
+    if (assistants.length !== 1
+        || assistants[0].id !== 'srv_seq_492_text_0'
+        || assistants[0].content !== 'durable assistant prefix plus replay suffix') {
+      fail(name, `${phase}: durable assistant did not own the replay suffix exactly once`, JSON.stringify(assistants));
+      return false;
+    }
+    for (const callID of calls) {
+      if (elements.messages.querySelectorAll(`[data-tool-id="${callID}"]`).length !== 1) {
+        fail(name, `${phase}: mounted DOM did not contain ${callID} exactly once`, JSON.stringify(elements.messages.children));
+        return false;
+      }
+    }
+    const assistantNodes = elements.messages.querySelectorAll('[data-message-id]')
+      .filter((node) => node.role === 'assistant');
+    if (assistantNodes.length !== 1 || assistantNodes[0].content !== 'durable assistant prefix plus replay suffix') {
+      fail(name, `${phase}: mounted assistant was duplicated or lost its suffix`, JSON.stringify(assistantNodes));
+      return false;
+    }
+    return true;
+  };
+
+  await app.resumeActiveResponse(session, { responseId, recoverFromSnapshot: true });
+  if (!assertProjection('first resume')) {
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+
+  await app.resumeActiveResponse(session, { responseId, recoverFromSnapshot: true });
+  if (!assertProjection('repeated resume')) {
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+  if (reconciliations !== 2 || renders !== 4) {
+    fail(name, `expected one replay reconciliation plus snapshot/boundary renders per resume, got ${reconciliations} reconciliations and ${renders} renders`);
+    await cleanup();
+    transcript.destroy();
+    return;
+  }
+
+  await cleanup();
+  transcript.destroy();
   pass(name);
 }
 
@@ -6850,6 +7054,7 @@ async function testIsolatedSkillStreamsIndependentlyAndCancelsIndependently() {
   await testDrainInterruptQueueIgnoresOtherSessionEntries();
   await testResumeActiveResponseRecoversFromSnapshotBeforeReplaying();
   await testRecoverySnapshotReconcilesDurableToolCallsIdempotently();
+  await testReplayCompletionReconcilesDurableSelectedProjection();
   await testResumeActiveResponseRepairsSequenceGapWithSnapshot();
   await testRecoverySnapshotClearsSyntheticPendingInterjectionByText();
   await testRecoverySnapshotDoesNotDuplicateOptimisticInterjection();

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -55,169 +55,183 @@
     return ids;
   };
 
-  // Durable identity owns every projected transcript event it covers. Tools use
-  // their server-issued call IDs. Assistant rows have no response ID in the
-  // durable body, so they are paired in order only after the stronger
-  // revision/sequence boundary identifies the same response tail. Content is
-  // consulted after that match solely to retain a not-yet-durable suffix.
-  const assistantProjectionCanCover = (local, context = null) => {
-    if (!local || local.role !== 'assistant' || local.durable) return false;
-    if (local.historicalReplay === true) {
-      const localResponseID = String(local.responseId || '').trim();
-      const activeResponseID = String(context?.activeRun?.id || '').trim();
-      return !localResponseID || !activeResponseID || localResponseID === activeResponseID;
+  const messageResponseID = (message) => String(message?.responseId || message?.response_id || '').trim();
+  const assistantSegmentOrdinal = (message) => {
+    const value = message?.assistantSegmentOrdinal ?? message?.assistant_segment_ordinal;
+    return Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : -1;
+  };
+  const assistantSegmentKey = (messageOrResponseID, ordinal = null) => {
+    const responseID = typeof messageOrResponseID === 'object'
+      ? messageResponseID(messageOrResponseID)
+      : String(messageOrResponseID || '').trim();
+    const segmentOrdinal = ordinal == null
+      ? assistantSegmentOrdinal(messageOrResponseID)
+      : finiteInt(ordinal, -1);
+    return responseID && segmentOrdinal >= 0 ? `${responseID}:assistant:${segmentOrdinal}` : '';
+  };
+  const toolIdentityKey = (responseID, callID) => {
+    const id = String(callID || '').trim();
+    if (!id) return '';
+    const owner = String(responseID || '').trim();
+    return owner ? `${owner}:tool:${id}` : `legacy-tool:${id}`;
+  };
+  const transcriptDiagnosticsEnabled = () => Boolean(
+    root.__TERM_LLM_DIAGNOSTICS__ || root.__WEBRTC_DIAGNOSTICS__
+  );
+  const transcriptDiagnostic = (kind, fields = {}) => {
+    if (!transcriptDiagnosticsEnabled() || typeof console === 'undefined') return;
+    const safe = {
+      kind: String(kind || ''),
+      responseId: String(fields.responseId || ''),
+      segmentKey: String(fields.segmentKey || ''),
+      streamGeneration: finiteInt(fields.streamGeneration, 0),
+      transcriptRev: finiteInt(fields.transcriptRev, 0),
+      startRev: finiteInt(fields.startRev, 0),
+      finalRev: finiteInt(fields.finalRev, 0),
+      after: finiteInt(fields.after, 0),
+      replayThrough: finiteInt(fields.replayThrough, 0),
+      appliedSequence: finiteInt(fields.appliedSequence, 0),
+      stagedCount: finiteInt(fields.stagedCount, 0),
+      coveredCount: finiteInt(fields.coveredCount, 0),
+      retainedCount: finiteInt(fields.retainedCount, 0),
+    };
+    console.warn('[transcript]', safe);
+  };
+
+  const messageToolKeys = (message) => {
+    const keys = new Set();
+    const responseID = messageResponseID(message);
+    for (const id of messageToolIDs(message)) {
+      const key = toolIdentityKey(responseID, id);
+      if (key) keys.add(key);
     }
-    const revAtSend = finiteInt(local.revAtSend, -1);
-    const durableSeqAtSend = finiteInt(local.durableSeqAtSend, -1);
-    if (revAtSend < 0 || durableSeqAtSend < 0) return false;
-    const projectionRev = finiteInt(context?.rev, -1);
-    if (projectionRev > revAtSend) return true;
-    const activeRun = context?.activeRun;
-    if (!activeRun || projectionRev < revAtSend) return false;
-    const localResponseID = String(local.responseId || '').trim();
-    if (localResponseID && localResponseID !== String(activeRun.id || '').trim()) return false;
-    const localStartedRev = finiteInt(local.responseStartedRev, revAtSend);
-    return localStartedRev === finiteInt(activeRun.startedRev, localStartedRev);
+    return keys;
   };
 
   const assistantSourceContent = (message) => String(message?.optimisticFullContent ?? message?.content ?? '');
 
-  const assistantSuffixAfterDurable = (durableContent, optimisticContent) => {
+  // Content is consulted only after a stable response-scoped segment identity
+  // match. Durable transcript text is authoritative on divergence. Prefix
+  // relations compute the uncovered optimistic suffix without searching for
+  // repeated text or inferring identity from content.
+  const assistantSuffixAfterDurable = (durableContent, optimisticContent, options = {}) => {
     const durable = String(durableContent || '');
     const optimistic = String(optimisticContent || '');
-    if (optimistic.startsWith(durable)) return optimistic.slice(durable.length);
-    if (durable.startsWith(optimistic)) return '';
-    const maxOverlap = Math.min(durable.length, optimistic.length);
-    for (let length = maxOverlap; length > 0; length -= 1) {
-      if (durable.endsWith(optimistic.slice(0, length))) return optimistic.slice(length);
+    if (options.suffixOnly === true) {
+      const durableEnd = finiteInt(options.durableEndSequence, 0);
+      const optimisticEnd = finiteInt(options.optimisticEndSequence, 0);
+      if ((durableEnd > 0 && optimisticEnd > 0 && durableEnd >= optimisticEnd)
+        || (optimistic && durable.endsWith(optimistic))) {
+        return { suffix: '', divergent: false };
+      }
+      return { suffix: optimistic, divergent: false };
     }
-    return '';
-  };
-
-  const assistantContentsOverlap = (durableContent, optimisticContent) => {
-    const durable = String(durableContent || '');
-    const optimistic = String(optimisticContent || '');
-    if (!durable || !optimistic) return false;
-    if (optimistic.startsWith(durable) || durable.startsWith(optimistic)) return true;
-    const maxOverlap = Math.min(durable.length, optimistic.length);
-    for (let length = maxOverlap; length > 0; length -= 1) {
-      if (durable.endsWith(optimistic.slice(0, length))) return true;
-    }
-    return false;
+    if (optimistic.startsWith(durable)) return { suffix: optimistic.slice(durable.length), divergent: false };
+    if (durable.startsWith(optimistic)) return { suffix: '', divergent: false };
+    return { suffix: '', divergent: true };
   };
 
   const reconcileTranscriptProjection = (messages, context = null) => {
     if (!Array.isArray(messages) || messages.length === 0) return Array.isArray(messages) ? messages : [];
-    const durableIDs = new Set();
-    const durableAssistants = [];
-    for (const [index, message] of messages.entries()) {
+    const durableTools = new Set();
+    const durableAssistants = new Map();
+    const legacyDurableAssistants = [];
+    for (const message of messages) {
       if (!message?.durable) continue;
-      for (const id of messageToolIDs(message)) durableIDs.add(id);
-      if (message.role === 'assistant' && Number.isFinite(Number(message.serverSeq))) {
-        durableAssistants.push({ index, message, serverSeq: finiteInt(message.serverSeq, -1) });
+      for (const key of messageToolKeys(message)) durableTools.add(key);
+      const key = message.role === 'assistant' ? assistantSegmentKey(message) : '';
+      if (message.role === 'assistant' && !key && Number.isFinite(Number(message.serverSeq))) {
+        legacyDurableAssistants.push(message);
+      }
+      if (key) {
+        if (durableAssistants.has(key)) {
+          transcriptDiagnostic('ambiguous_identity', {
+            responseId: messageResponseID(message),
+            segmentKey: key,
+            transcriptRev: context?.rev,
+          });
+        } else durableAssistants.set(key, message);
       }
     }
 
-    const assistantMatches = new Map();
-    const claimedAssistants = new Set();
-    const historicalAssistants = [...messages.entries()].filter(([, message]) => (
-      message?.historicalReplay === true && assistantProjectionCanCover(message, context)
-    ));
-    let historicalCeiling = Number.POSITIVE_INFINITY;
-    for (let offset = historicalAssistants.length - 1; offset >= 0; offset -= 1) {
-      const [index, message] = historicalAssistants[offset];
-      const optimisticContent = assistantSourceContent(message);
-      const match = durableAssistants.findLast((candidate) => (
-        candidate.index < historicalCeiling
-        && !claimedAssistants.has(candidate.index)
-        && assistantContentsOverlap(candidate.message.content, optimisticContent)
-      ));
-      if (!match) continue;
-      historicalCeiling = match.index;
-      claimedAssistants.add(match.index);
-      const crossesUserBoundary = messages.slice(match.index + 1, index).some((candidate) => candidate?.role === 'user');
-      assistantMatches.set(index, { ...match, crossesUserBoundary });
-    }
-    for (const [index, message] of messages.entries()) {
-      if (message?.historicalReplay === true || !assistantProjectionCanCover(message, context)) continue;
-      const afterSeq = finiteInt(message.durableSeqAtSend, -1);
-      const match = durableAssistants.find((candidate) => (
-        candidate.serverSeq > afterSeq && !claimedAssistants.has(candidate.index)
-      ));
-      if (!match) continue;
-      claimedAssistants.add(match.index);
-      const crossesUserBoundary = messages.slice(match.index + 1, index).some((candidate) => candidate?.role === 'user');
-      assistantMatches.set(index, { ...match, crossesUserBoundary });
-    }
-
-    const claimed = new Set();
+    const projectedDurable = new Map();
+    const claimedLegacyAssistants = new Set();
+    const claimedTools = new Set();
     const result = [];
-    for (const [messageIndex, message] of messages.entries()) {
-      const assistantMatch = assistantMatches.get(messageIndex);
-      if (assistantMatch) {
-        const optimisticContent = assistantSourceContent(message);
-        const suffix = assistantSuffixAfterDurable(assistantMatch.message.content, optimisticContent);
-        if (suffix && assistantMatch.crossesUserBoundary) {
-          result.push({
-            ...message,
-            content: suffix,
-            optimisticFullContent: optimisticContent
+    for (const message of messages) {
+      if (!message) continue;
+      if (!message.durable && message.role === 'assistant') {
+        const key = assistantSegmentKey(message);
+        let durable = key ? durableAssistants.get(key) : null;
+        if (!key && finiteInt(message.durableSeqAtSend, -1) >= -1) {
+          const afterSeq = finiteInt(message.durableSeqAtSend, -1);
+          durable = legacyDurableAssistants.find((candidate) => (
+            finiteInt(candidate.serverSeq, -1) > afterSeq && !claimedLegacyAssistants.has(candidate)
+          )) || null;
+          if (durable) claimedLegacyAssistants.add(durable);
+        }
+        if (durable) {
+          const comparison = assistantSuffixAfterDurable(durable.content, assistantSourceContent(message), {
+            suffixOnly: message.replaySuffixOnly === true,
+            durableEndSequence: durable.segmentEndSequence ?? durable.segment_end_sequence,
+            optimisticEndSequence: message.segmentEndSequence ?? message.segment_end_sequence,
           });
+          if (comparison.divergent) {
+            transcriptDiagnostic('divergent_content', {
+              responseId: messageResponseID(message),
+              segmentKey: key,
+              transcriptRev: context?.rev,
+            });
+          } else if (comparison.suffix) {
+            const crossesUserBoundary = !key && messages.slice(messages.indexOf(durable) + 1, messages.indexOf(message)).some((candidate) => candidate?.role === 'user');
+            if (crossesUserBoundary) {
+              result.push({ ...message, content: comparison.suffix, optimisticFullContent: assistantSourceContent(message) });
+              continue;
+            }
+            const existing = projectedDurable.get(durable) || durable;
+            const projected = {
+              ...existing,
+              content: `${String(durable.content || '')}${comparison.suffix}`,
+              optimisticSuffixClientKey: String(message.clientKey || message.id || ''),
+            };
+            projectedDurable.set(durable, projected);
+            const index = result.indexOf(existing);
+            if (index >= 0) result[index] = projected;
+          }
           continue;
         }
-        const durableIndex = result.findIndex((entry) => entry === assistantMatch.message);
-        if (durableIndex >= 0 && suffix) {
-          result[durableIndex] = {
-            ...assistantMatch.message,
-            content: `${String(assistantMatch.message.content || '')}${suffix}`,
-            optimisticSuffixClientKey: String(message.clientKey || message.id || '')
-          };
-        }
-        continue;
-      }
-
-      if (!message || (message.role !== 'tool-group' && message.role !== 'tool')) {
         result.push(message);
         continue;
       }
 
       if (message.role === 'tool-group') {
         const tools = Array.isArray(message.tools) ? message.tools : [];
+        const owner = messageResponseID(message);
         const retained = tools.filter((tool) => {
           const id = toolEntryID(tool);
-          if (!id) return true;
-          if (message.durable) {
-            if (claimed.has(id)) return false;
-            claimed.add(id);
-            return true;
-          }
-          if (durableIDs.has(id) || claimed.has(id)) return false;
-          claimed.add(id);
+          const key = toolIdentityKey(owner, id);
+          const legacyKey = toolIdentityKey('', id);
+          if (!key) return true;
+          if ((!message.durable && (durableTools.has(key) || durableTools.has(legacyKey))) || claimedTools.has(key)) return false;
+          claimedTools.add(key);
           return true;
         });
-        if (retained.length !== tools.length) message.tools = retained;
         if (retained.length === 0) continue;
-        result.push(message);
+        result.push(retained.length === tools.length ? message : { ...message, tools: retained });
         continue;
       }
 
-      const ids = messageToolIDs(message);
-      if (ids.size === 0) {
-        result.push(message);
-        continue;
+      if (message.role === 'tool') {
+        const keys = messageToolKeys(message);
+        const retained = [...keys].filter((key) => (
+          !claimedTools.has(key) && (message.durable || !durableTools.has(key))
+        ));
+        if (keys.size > 0 && retained.length === 0) continue;
+        retained.forEach((key) => claimedTools.add(key));
       }
-      const retainedIDs = new Set([...ids].filter((id) => (
-        message.durable ? !claimed.has(id) : (!durableIDs.has(id) && !claimed.has(id))
-      )));
-      if (retainedIDs.size === 0) continue;
-      if (Array.isArray(message.parts)) {
-        message.parts = message.parts.filter((part) => {
-          const id = partToolID(part);
-          return !id || retainedIDs.has(id);
-        });
-      }
-      retainedIDs.forEach((id) => claimed.add(id));
-      result.push(message);
+
+      const projected = projectedDurable.get(message) || message;
+      result.push(projected);
     }
     return result;
   };
@@ -233,13 +247,23 @@
       this.seqs = [];
       this.roles = '';
       this.flags = [];
+      this.responseIDs = [];
+      this.assistantSegmentOrdinals = [];
+      // Existing rows predate durable stream identity. Replay/snapshot identity
+      // can bind those stable row IDs locally until a later server rewrite
+      // persists the same identity. This survives transcript body refreshes.
+      this.legacyAssistantIdentityByID = new Map();
       this.compactionSeq = -1;
       this.compactionCount = 0;
       this.bodies = new Map();
       this.segments = [];
       this.optimistic = [];
+      this.optimisticOwned = new WeakSet();
+      this.optimisticByAssistantSegment = new Map();
       this.persistedOptimistic = new WeakSet();
       this.activeRun = null;
+      this.activeRunDurableIDsAtStart = new Set();
+      this.latestRunEpoch = 0;
       this.etag = '';
       this.viewport = { firstOrdinal: -1, lastOrdinal: -1 };
       this.pinnedSegments = new Set();
@@ -258,10 +282,17 @@
       const ids = Array.isArray(rows.ids) ? rows.ids.map(normalizedID) : [];
       const seqs = Array.isArray(rows.seqs) ? rows.seqs.map((seq) => finiteInt(seq, -1)) : [];
       const flags = Array.isArray(rows.flags) ? rows.flags.map((flag) => finiteInt(flag, 0)) : [];
+      const responseIDs = Array.isArray(rows.response_ids)
+        ? rows.response_ids.map((value) => String(value || '').trim())
+        : ids.map(() => '');
+      const assistantSegmentOrdinals = Array.isArray(rows.assistant_segment_ordinals)
+        ? rows.assistant_segment_ordinals.map((value) => finiteInt(value, -1))
+        : ids.map(() => -1);
       const roles = String(rows.roles || '');
       const incomingRev = finiteInt(envelope?.rev, this.rev);
       const rollback = incomingRev < this.rev;
-      if (ids.length !== seqs.length || ids.length !== flags.length || ids.length !== roles.length) {
+      if (ids.length !== seqs.length || ids.length !== flags.length || ids.length !== roles.length
+        || ids.length !== responseIDs.length || ids.length !== assistantSegmentOrdinals.length) {
         throw new Error('invalid transcript index parallel arrays');
       }
       const duplicateCheck = new Set(ids);
@@ -273,7 +304,9 @@
         && this.ids[divergence] === ids[divergence]
         && this.seqs[divergence] === seqs[divergence]
         && this.roles[divergence] === roles[divergence]
-        && this.flags[divergence] === flags[divergence]) {
+        && this.flags[divergence] === flags[divergence]
+        && this.responseIDs[divergence] === responseIDs[divergence]
+        && this.assistantSegmentOrdinals[divergence] === assistantSegmentOrdinals[divergence]) {
         divergence += 1;
       }
       const compactionChanged = this.compactionSeq !== finiteInt(envelope?.compaction_seq, -1)
@@ -287,6 +320,19 @@
         for (const local of this.optimistic) local.revAtSend = incomingRev;
       }
       const surviving = new Set(ids);
+      for (const id of this.legacyAssistantIdentityByID.keys()) {
+        if (!surviving.has(id)) this.legacyAssistantIdentityByID.delete(id);
+      }
+      for (let ordinal = 0; ordinal < ids.length; ordinal += 1) {
+        if (responseIDs[ordinal] && assistantSegmentOrdinals[ordinal] >= 0) {
+          this.legacyAssistantIdentityByID.delete(ids[ordinal]);
+        }
+      }
+      for (const entry of this.optimistic) {
+        if (entry?.optimistic !== true || entry?.durable === true) {
+          throw new Error('transcript optimistic registry contains a non-overlay entry');
+        }
+      }
       for (const id of this.bodies.keys()) {
         if (!surviving.has(id)) this.bodies.delete(id);
       }
@@ -295,6 +341,8 @@
       this.seqs = seqs;
       this.roles = roles;
       this.flags = flags;
+      this.responseIDs = responseIDs;
+      this.assistantSegmentOrdinals = assistantSegmentOrdinals;
       this.compactionSeq = finiteInt(envelope?.compaction_seq, -1);
       this.compactionCount = finiteInt(envelope?.compaction_count, 0);
       this.rebuildSegments(oldSegmentState);
@@ -402,6 +450,18 @@
       for (const entry of messages) {
         const id = bodyID(entry);
         if (!known.has(id)) continue;
+        const ordinal = this.ordinalForID(id);
+        if (ordinal >= 0) {
+          const inferredIdentity = this.legacyAssistantIdentityByID.get(id) || null;
+          const responseID = this.responseIDs[ordinal] || inferredIdentity?.responseId || '';
+          const segmentOrdinal = this.assistantSegmentOrdinals[ordinal] >= 0
+            ? this.assistantSegmentOrdinals[ordinal]
+            : finiteInt(inferredIdentity?.assistantSegmentOrdinal, -1);
+          if (!messageResponseID(entry) && responseID) entry.responseId = responseID;
+          if (entry.role === 'assistant' && assistantSegmentOrdinal(entry) < 0 && segmentOrdinal >= 0) {
+            entry.assistantSegmentOrdinal = segmentOrdinal;
+          }
+        }
         this.bodies.set(id, entry);
         const segmentIndex = this.segmentForID(id);
         if (segmentIndex >= 0) touched.add(segmentIndex);
@@ -601,10 +661,56 @@
       return result;
     }
 
+    rebuildOptimisticIdentityIndex() {
+      this.optimisticByAssistantSegment.clear();
+      this.optimisticOwned = new WeakSet();
+      for (const entry of this.optimistic) {
+        this.optimisticOwned.add(entry);
+        const key = entry?.role === 'assistant' ? assistantSegmentKey(entry) : '';
+        if (!key) continue;
+        if (this.optimisticByAssistantSegment.has(key) && this.optimisticByAssistantSegment.get(key) !== entry) {
+          transcriptDiagnostic('ambiguous_identity', {
+            responseId: messageResponseID(entry),
+            segmentKey: key,
+            transcriptRev: this.rev,
+          });
+          continue;
+        }
+        this.optimisticByAssistantSegment.set(key, entry);
+      }
+    }
+
+    optimisticAssistant(responseID, ordinal) {
+      return this.optimisticByAssistantSegment.get(assistantSegmentKey(responseID, ordinal)) || null;
+    }
+
+    assertMutableOverlay(entry, source = '') {
+      const valid = Boolean(
+        entry
+        && entry.optimistic === true
+        && entry.durable !== true
+        && this.optimisticOwned.has(entry)
+      );
+      if (valid) return true;
+      transcriptDiagnostic('attempted_durable_cursor_mutation', {
+        responseId: messageResponseID(entry),
+        segmentKey: assistantSegmentKey(entry),
+        transcriptRev: this.rev,
+      });
+      throw new Error(`mutable stream cursor is not a transcript-owned optimistic overlay${source ? ` (${source})` : ''}`);
+    }
+
     addOptimistic(entry, revAtSend = this.rev, options = {}) {
-      if (!entry || typeof entry !== 'object') return null;
-      const clientKey = String(entry.clientKey || entry.id || `optimistic-${Date.now()}-${this.optimistic.length}`);
-      const existing = this.optimistic.find((item) => String(item.clientKey || item.id || '') === clientKey);
+      if (!entry || typeof entry !== 'object' || entry.durable === true) return null;
+      if (this.activeRun && ['assistant', 'tool', 'tool-group'].includes(entry.role)) {
+        if (!messageResponseID(entry)) entry.responseId = this.activeRun.id;
+        entry.responseStartedRev = finiteInt(entry.responseStartedRev, this.activeRun.startedRev);
+        entry.runEpoch = finiteInt(entry.runEpoch, this.activeRun.epoch);
+      }
+      const segmentKey = entry.role === 'assistant' ? assistantSegmentKey(entry) : '';
+      const clientKey = String(entry.clientKey || segmentKey || entry.id || `optimistic-${Date.now()}-${this.optimistic.length}`);
+      const existing = (segmentKey ? this.optimisticByAssistantSegment.get(segmentKey) : null)
+        || this.optimistic.find((item) => String(item.clientKey || item.id || '') === clientKey);
       if (existing) {
         const previousAssistantContent = existing.role === 'assistant' ? String(existing.content || '') : '';
         const previousRevAtSend = finiteInt(existing.revAtSend, finiteInt(revAtSend, this.rev));
@@ -612,37 +718,88 @@
         Object.assign(existing, entry);
         existing.clientKey = clientKey;
         existing.optimistic = true;
+        this.optimisticOwned.add(existing);
+        delete existing.durable;
         existing.revAtSend = finiteInt(existing.revAtSend, previousRevAtSend);
         existing.durableSeqAtSend = finiteInt(existing.durableSeqAtSend, previousDurableSeqAtSend);
         if (existing.role === 'assistant') {
           const incomingContent = String(entry.content || '');
           if (previousAssistantContent.startsWith(incomingContent)) existing.content = previousAssistantContent;
         }
-        if (this.activeRun && (existing.role === 'assistant' || existing.role === 'tool' || existing.role === 'tool-group')) {
-          if (!String(existing.responseId || '').trim()) existing.responseId = this.activeRun.id;
-          existing.responseStartedRev = finiteInt(existing.responseStartedRev, this.activeRun.startedRev);
-        }
+        if (segmentKey) this.optimisticByAssistantSegment.set(segmentKey, existing);
         if (options.persisted === true) this.persistedOptimistic.add(existing);
         return existing;
       }
       const optimistic = entry;
       optimistic.clientKey = clientKey;
       optimistic.optimistic = true;
+      delete optimistic.durable;
       optimistic.revAtSend = finiteInt(entry.revAtSend, finiteInt(revAtSend, this.rev));
       optimistic.durableSeqAtSend = finiteInt(entry.durableSeqAtSend, this.seqs.length ? this.seqs[this.seqs.length - 1] : -1);
-      if (this.activeRun && (optimistic.role === 'assistant' || optimistic.role === 'tool' || optimistic.role === 'tool-group')) {
-        if (!String(optimistic.responseId || '').trim()) optimistic.responseId = this.activeRun.id;
-        optimistic.responseStartedRev = finiteInt(optimistic.responseStartedRev, this.activeRun.startedRev);
-      }
       this.optimistic.push(optimistic);
+      this.optimisticOwned.add(optimistic);
+      if (segmentKey) this.optimisticByAssistantSegment.set(segmentKey, optimistic);
       if (options.persisted === true) this.persistedOptimistic.add(optimistic);
       return optimistic;
     }
 
-    setActiveRun(id, startedRev = 0) {
+    setActiveRun(id, startedRev = 0, epoch = 0, options = {}) {
       const normalized = String(id || '').trim();
-      this.activeRun = normalized ? { id: normalized, startedRev: finiteInt(startedRev, 0) } : null;
-      return this.activeRun;
+      const nextEpoch = Math.max(0, finiteInt(epoch, 0));
+      if (normalized) {
+        const observedCreatedEpoch = finiteInt(options.observedCreatedEpoch, this.latestRunEpoch);
+        if ((nextEpoch > 0 && nextEpoch < this.latestRunEpoch)
+          || observedCreatedEpoch < this.latestRunEpoch) {
+          transcriptDiagnostic('stale_status_rejection', {
+            responseId: normalized,
+            transcriptRev: this.rev,
+            startRev: startedRev,
+          });
+          return this.activeRun;
+        }
+        if (nextEpoch > 0) this.latestRunEpoch = Math.max(this.latestRunEpoch, nextEpoch);
+        if (this.activeRun?.id !== normalized) {
+          this.activeRunDurableIDsAtStart = new Set(this.ids);
+          // A status/snapshot attach can arrive after the first durable prefix.
+          // Only the assistant tail after the latest durable user boundary is a
+          // structurally safe legacy candidate; earlier history remains excluded.
+          if (finiteInt(startedRev, 0) < this.rev) {
+            let lastUserOrdinal = -1;
+            for (let ordinal = this.roles.length - 1; ordinal >= 0; ordinal -= 1) {
+              if (this.roles[ordinal] === 'u') {
+                lastUserOrdinal = ordinal;
+                break;
+              }
+            }
+            for (let ordinal = lastUserOrdinal + 1; ordinal < this.ids.length; ordinal += 1) {
+              if (this.roles[ordinal] === 'a') this.activeRunDurableIDsAtStart.delete(this.ids[ordinal]);
+            }
+          }
+        }
+        this.activeRun = {
+          id: normalized,
+          startedRev: finiteInt(startedRev, 0),
+          ...((nextEpoch || this.latestRunEpoch) > 0 ? { epoch: nextEpoch || this.latestRunEpoch } : {}),
+        };
+        return this.activeRun;
+      }
+      const expectedResponseID = String(options.responseId || '').trim();
+      const sampledEpoch = Math.max(0, finiteInt(options.sampledEpoch ?? nextEpoch, 0));
+      if (this.activeRun && (
+        (expectedResponseID && this.activeRun.id !== expectedResponseID)
+        || (sampledEpoch > 0 && sampledEpoch < this.latestRunEpoch)
+        || (finiteInt(options.observedCreatedEpoch, this.latestRunEpoch) < this.latestRunEpoch)
+      )) {
+        transcriptDiagnostic('stale_status_rejection', {
+          responseId: expectedResponseID || this.activeRun.id,
+          transcriptRev: this.rev,
+          startRev: this.activeRun.startedRev,
+        });
+        return this.activeRun;
+      }
+      this.activeRun = null;
+      this.activeRunDurableIDsAtStart = new Set();
+      return null;
     }
 
     segmentAfterSequence(sequence) {
@@ -680,6 +837,58 @@
       return ids;
     }
 
+    bindLegacyAssistantIdentity(responseID, segmentOrdinal, durable) {
+      const owner = String(responseID || '').trim();
+      const ordinal = finiteInt(segmentOrdinal, -1);
+      const rowOrdinal = finiteInt(durable?.ordinal, -1);
+      if (!owner || ordinal < 0 || rowOrdinal < 0 || rowOrdinal >= this.ids.length || this.roles[rowOrdinal] !== 'a') {
+        return false;
+      }
+      const id = this.ids[rowOrdinal];
+      const existingResponseID = this.responseIDs[rowOrdinal] || '';
+      const existingSegmentOrdinal = this.assistantSegmentOrdinals[rowOrdinal];
+      if (existingResponseID && (existingResponseID !== owner || existingSegmentOrdinal !== ordinal)) {
+        transcriptDiagnostic('ambiguous_identity', {
+          responseId: owner,
+          segmentKey: assistantSegmentKey(owner, ordinal),
+          transcriptRev: this.rev,
+        });
+        return false;
+      }
+      this.legacyAssistantIdentityByID.set(id, { responseId: owner, assistantSegmentOrdinal: ordinal });
+      if (!existingResponseID) {
+        this.responseIDs[rowOrdinal] = owner;
+        this.assistantSegmentOrdinals[rowOrdinal] = ordinal;
+      }
+      if (durable?.body) {
+        durable.body.responseId = owner;
+        durable.body.assistantSegmentOrdinal = ordinal;
+      }
+      return true;
+    }
+
+    durableAssistant(responseID, ordinal) {
+      const key = assistantSegmentKey(responseID, ordinal);
+      if (!key) return null;
+      const legacy = [];
+      for (let rowOrdinal = 0; rowOrdinal < this.ids.length; rowOrdinal += 1) {
+        if (this.roles[rowOrdinal] !== 'a') continue;
+        const body = this.bodies.get(this.ids[rowOrdinal]);
+        if (!body) continue;
+        const part = (body.parts || []).find((candidate) => candidate?.type === 'text' && String(candidate.text || ''));
+        if (!part) continue;
+        const bodyKey = assistantSegmentKey(body);
+        if (bodyKey === key) return { body, content: String(part.text || ''), ordinal: rowOrdinal };
+        if (!bodyKey && !this.activeRunDurableIDsAtStart.has(this.ids[rowOrdinal])) {
+          legacy.push({ body, content: String(part.text || ''), ordinal: rowOrdinal });
+        }
+      }
+      if (this.activeRun?.id === String(responseID || '').trim()) {
+        return legacy[Math.max(0, finiteInt(ordinal, 0))] || null;
+      }
+      return null;
+    }
+
     durableAssistantParts() {
       const result = [];
       for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
@@ -693,6 +902,12 @@
             ordinal,
             partIndex,
             sequence: this.seqs[ordinal],
+            segmentEndSequence: finiteInt(body.segmentEndSequence ?? body.segment_end_sequence, 0),
+            responseId: messageResponseID(body) || this.responseIDs[ordinal] || '',
+            segmentKey: assistantSegmentKey(
+              messageResponseID(body) || this.responseIDs[ordinal] || '',
+              assistantSegmentOrdinal(body) >= 0 ? assistantSegmentOrdinal(body) : this.assistantSegmentOrdinals[ordinal]
+            ),
             content: String(part.text || '')
           });
         }
@@ -705,106 +920,120 @@
       const kept = [];
       const removed = [];
       const consumedRows = new Set();
-      const consumedAssistantParts = new Set();
       const durableAssistantParts = this.durableAssistantParts();
-      const durableToolIDs = this.durableToolIDs();
-      const claimedOptimisticToolIDs = new Set();
-      const historicalAssistantMatches = new WeakMap();
-      const historicalAssistants = this.optimistic.filter((local) => (
-        local?.historicalReplay === true && assistantProjectionCanCover(local, this)
-      ));
-      let historicalCeiling = durableAssistantParts.length;
-      for (let offset = historicalAssistants.length - 1; offset >= 0; offset -= 1) {
-        const local = historicalAssistants[offset];
-        const optimisticContent = assistantSourceContent(local);
-        let matchIndex = -1;
-        for (let index = historicalCeiling - 1; index >= 0; index -= 1) {
-          if (assistantContentsOverlap(durableAssistantParts[index].content, optimisticContent)) {
-            matchIndex = index;
-            break;
-          }
+      const durableAssistantByKey = new Map();
+      for (const candidate of durableAssistantParts) {
+        if (!candidate.segmentKey) continue;
+        if (durableAssistantByKey.has(candidate.segmentKey)) {
+          transcriptDiagnostic('ambiguous_identity', {
+            responseId: candidate.responseId,
+            segmentKey: candidate.segmentKey,
+            transcriptRev: this.rev,
+          });
+          continue;
         }
-        if (matchIndex < 0) continue;
-        historicalCeiling = matchIndex;
-        historicalAssistantMatches.set(local, durableAssistantParts[matchIndex]);
+        durableAssistantByKey.set(candidate.segmentKey, candidate);
       }
+      const durableToolKeys = new Set();
+      for (const entry of this.bodies.values()) {
+        for (const key of messageToolKeys(entry)) durableToolKeys.add(key);
+      }
+      const claimedOptimisticToolKeys = new Set();
+
       for (const local of this.optimistic) {
         const localIsTool = local.role === 'tool-group' || local.role === 'tool';
         if (localIsTool) {
-          const localIDs = messageToolIDs(local);
-          if (localIDs.size > 0) {
-            const uncovered = new Set([...localIDs].filter((id) => (
-              !durableToolIDs.has(id) && !claimedOptimisticToolIDs.has(id)
-            )));
+          const owner = messageResponseID(local);
+          const localKeys = new Map([...messageToolIDs(local)].map((id) => [toolIdentityKey(owner, id), id]));
+          const uncovered = new Set([...localKeys.entries()].filter(([key, id]) => (
+            key
+            && !durableToolKeys.has(key)
+            && !durableToolKeys.has(toolIdentityKey('', id))
+            && !claimedOptimisticToolKeys.has(key)
+          )).map(([key]) => key));
+          if (localKeys.size > 0) {
             if (local.role === 'tool-group' && Array.isArray(local.tools)) {
-              local.tools = local.tools.filter((tool) => {
-                const id = toolEntryID(tool);
-                return !id || uncovered.has(id);
-              });
+              local.tools = local.tools.filter((tool) => uncovered.has(toolIdentityKey(owner, toolEntryID(tool))));
             } else if (local.role === 'tool' && Array.isArray(local.parts)) {
               local.parts = local.parts.filter((part) => {
                 const id = partToolID(part);
-                return !id || uncovered.has(id);
+                return !id || uncovered.has(toolIdentityKey(owner, id));
               });
             }
             if (uncovered.size === 0) {
               removed.push(local);
               continue;
             }
-            uncovered.forEach((id) => claimedOptimisticToolIDs.add(id));
+            uncovered.forEach((key) => claimedOptimisticToolKeys.add(key));
+          }
+        }
+
+        if (local.role === 'assistant') {
+          const key = assistantSegmentKey(local);
+          const durablePart = key ? durableAssistantByKey.get(key) : null;
+          if (durablePart) {
+            const comparison = assistantSuffixAfterDurable(durablePart.content, assistantSourceContent(local), {
+              suffixOnly: local.replaySuffixOnly === true,
+              durableEndSequence: durablePart.segmentEndSequence,
+              optimisticEndSequence: local.segmentEndSequence ?? local.segment_end_sequence,
+            });
+            if (comparison.divergent) {
+              transcriptDiagnostic('divergent_content', {
+                responseId: messageResponseID(local),
+                segmentKey: key,
+                transcriptRev: this.rev,
+              });
+              removed.push(local);
+            } else if (this.activeRun?.id === messageResponseID(local)) {
+              // A covered live overlay remains the sole mutable cursor until the
+              // response finalizes; fresh deltas must never target its durable projection.
+              kept.push(local);
+            } else if (comparison.suffix) kept.push(local);
+            else removed.push(local);
+            continue;
+          }
+          if (!key) {
+            const legacyPart = durableAssistantParts.find((candidate) => candidate.sequence > finiteInt(local.durableSeqAtSend, -1));
+            if (legacyPart) {
+              const comparison = assistantSuffixAfterDurable(legacyPart.content, assistantSourceContent(local));
+              if (comparison.suffix) kept.push(local);
+              else removed.push(local);
+              continue;
+            }
           }
         }
 
         const afterSeq = finiteInt(local.durableSeqAtSend, -1);
-        if (local.role === 'assistant' && assistantProjectionCanCover(local, this)) {
-          const historicalMatch = historicalAssistantMatches.get(local);
-          const durablePart = historicalMatch || durableAssistantParts.find((candidate) => (
-            local.historicalReplay !== true
-            && candidate.sequence > afterSeq
-            && !consumedAssistantParts.has(candidate.key)
-          ));
-          if (durablePart && !consumedAssistantParts.has(durablePart.key)) {
-            consumedAssistantParts.add(durablePart.key);
-            const suffix = assistantSuffixAfterDurable(durablePart.content, assistantSourceContent(local));
-            if (suffix) {
-              kept.push(local);
-            } else {
-              removed.push(local);
-            }
-            continue;
-          }
-        }
-
         if (this.rev <= finiteInt(local.revAtSend, this.rev)) {
           kept.push(local);
           continue;
         }
         let matched = false;
-        if (local.role === 'user') {
+        if (local.role === 'user' || (local.role === 'assistant' && !assistantSegmentKey(local))) {
+          const wantedRole = local.role === 'user' ? 'u' : 'a';
           for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
             if (this.seqs[ordinal] <= afterSeq || consumedRows.has(ordinal)) continue;
-            if (this.roles[ordinal] === 'u' && this.bodies.has(this.ids[ordinal])) {
+            if (this.roles[ordinal] === wantedRole && this.bodies.has(this.ids[ordinal])) {
               consumedRows.add(ordinal);
               matched = true;
               break;
             }
           }
         }
-        // Reaching a newer durable revision with no active run is the terminal
-        // authority for completed tool UI. An unmatched completed tool cannot
-        // represent queued input and must not remain persisted at the tail.
         const completedTool = localIsTool
           && ['done', 'error', 'failed', 'cancelled'].includes(String(local.status || '').toLowerCase());
         if (matched || (!this.activeRun && completedTool)) removed.push(local);
         else kept.push(local);
       }
       this.optimistic = kept;
+      this.rebuildOptimisticIdentityIndex();
       return removed;
     }
 
     clearTransientOptimistic() {
       const removed = this.optimistic.filter((entry) => entry?.transient);
       this.optimistic = this.optimistic.filter((entry) => !entry?.transient);
+      this.rebuildOptimisticIdentityIndex();
       return removed;
     }
 
@@ -818,6 +1047,7 @@
       const removed = this.optimistic.filter((entry) => String(entry?.clientKey || entry?.id || '') === key);
       if (removed.length > 0) {
         this.optimistic = this.optimistic.filter((entry) => String(entry?.clientKey || entry?.id || '') !== key);
+        this.rebuildOptimisticIdentityIndex();
       }
       return removed;
     }
@@ -898,7 +1128,8 @@
 
     _checkInvariants() {
       const length = this.ids.length;
-      if (this.seqs.length !== length || this.flags.length !== length || this.roles.length !== length) {
+      if (this.seqs.length !== length || this.flags.length !== length || this.roles.length !== length
+        || this.responseIDs.length !== length || this.assistantSegmentOrdinals.length !== length) {
         throw new Error('transcript skeleton arrays differ in length');
       }
       if (new Set(this.ids).size !== length) throw new Error('transcript skeleton IDs are not unique');
@@ -970,6 +1201,8 @@
         ids: unique.map(bodyID),
         seqs: unique.map(bodySeq),
         roles: unique.map((message) => roleCode(message.role)).join(''),
+        response_ids: unique.map((message) => messageResponseID(message)),
+        assistant_segment_ordinals: unique.map((message) => assistantSegmentOrdinal(message)),
         flags: unique.map((message) => {
           let flags = message.compaction_tail ? TRANSCRIPT_FLAG_COMPACTION_TAIL : 0;
           if (!Array.isArray(message.parts) || message.parts.length === 0) flags |= TRANSCRIPT_FLAG_EMPTY_BODY;
@@ -995,6 +1228,9 @@
     TRANSCRIPT_FLAG_EMPTY_BODY,
     transcriptStoreFromMessages,
     reconcileTranscriptProjection,
+    assistantSegmentKey,
+    transcriptToolIdentityKey: toolIdentityKey,
+    transcriptDiagnostic,
     transcriptRoleCode: roleCode,
     transcriptRoleName: roleName,
     __transcriptStats

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -62,6 +62,11 @@
   // consulted after that match solely to retain a not-yet-durable suffix.
   const assistantProjectionCanCover = (local, context = null) => {
     if (!local || local.role !== 'assistant' || local.durable) return false;
+    if (local.historicalReplay === true) {
+      const localResponseID = String(local.responseId || '').trim();
+      const activeResponseID = String(context?.activeRun?.id || '').trim();
+      return !localResponseID || !activeResponseID || localResponseID === activeResponseID;
+    }
     const revAtSend = finiteInt(local.revAtSend, -1);
     const durableSeqAtSend = finiteInt(local.durableSeqAtSend, -1);
     if (revAtSend < 0 || durableSeqAtSend < 0) return false;
@@ -89,6 +94,18 @@
     return '';
   };
 
+  const assistantContentsOverlap = (durableContent, optimisticContent) => {
+    const durable = String(durableContent || '');
+    const optimistic = String(optimisticContent || '');
+    if (!durable || !optimistic) return false;
+    if (optimistic.startsWith(durable) || durable.startsWith(optimistic)) return true;
+    const maxOverlap = Math.min(durable.length, optimistic.length);
+    for (let length = maxOverlap; length > 0; length -= 1) {
+      if (durable.endsWith(optimistic.slice(0, length))) return true;
+    }
+    return false;
+  };
+
   const reconcileTranscriptProjection = (messages, context = null) => {
     if (!Array.isArray(messages) || messages.length === 0) return Array.isArray(messages) ? messages : [];
     const durableIDs = new Set();
@@ -103,8 +120,26 @@
 
     const assistantMatches = new Map();
     const claimedAssistants = new Set();
+    const historicalAssistants = [...messages.entries()].filter(([, message]) => (
+      message?.historicalReplay === true && assistantProjectionCanCover(message, context)
+    ));
+    let historicalCeiling = Number.POSITIVE_INFINITY;
+    for (let offset = historicalAssistants.length - 1; offset >= 0; offset -= 1) {
+      const [index, message] = historicalAssistants[offset];
+      const optimisticContent = assistantSourceContent(message);
+      const match = durableAssistants.findLast((candidate) => (
+        candidate.index < historicalCeiling
+        && !claimedAssistants.has(candidate.index)
+        && assistantContentsOverlap(candidate.message.content, optimisticContent)
+      ));
+      if (!match) continue;
+      historicalCeiling = match.index;
+      claimedAssistants.add(match.index);
+      const crossesUserBoundary = messages.slice(match.index + 1, index).some((candidate) => candidate?.role === 'user');
+      assistantMatches.set(index, { ...match, crossesUserBoundary });
+    }
     for (const [index, message] of messages.entries()) {
-      if (!assistantProjectionCanCover(message, context)) continue;
+      if (message?.historicalReplay === true || !assistantProjectionCanCover(message, context)) continue;
       const afterSeq = finiteInt(message.durableSeqAtSend, -1);
       const match = durableAssistants.find((candidate) => (
         candidate.serverSeq > afterSeq && !claimedAssistants.has(candidate.index)
@@ -148,11 +183,9 @@
 
       if (message.role === 'tool-group') {
         const tools = Array.isArray(message.tools) ? message.tools : [];
-        let stableCount = 0;
         const retained = tools.filter((tool) => {
           const id = toolEntryID(tool);
           if (!id) return true;
-          stableCount += 1;
           if (message.durable) {
             if (claimed.has(id)) return false;
             claimed.add(id);
@@ -163,7 +196,7 @@
           return true;
         });
         if (retained.length !== tools.length) message.tools = retained;
-        if (stableCount > 0 && retained.length === 0) continue;
+        if (retained.length === 0) continue;
         result.push(message);
         continue;
       }
@@ -676,6 +709,25 @@
       const durableAssistantParts = this.durableAssistantParts();
       const durableToolIDs = this.durableToolIDs();
       const claimedOptimisticToolIDs = new Set();
+      const historicalAssistantMatches = new WeakMap();
+      const historicalAssistants = this.optimistic.filter((local) => (
+        local?.historicalReplay === true && assistantProjectionCanCover(local, this)
+      ));
+      let historicalCeiling = durableAssistantParts.length;
+      for (let offset = historicalAssistants.length - 1; offset >= 0; offset -= 1) {
+        const local = historicalAssistants[offset];
+        const optimisticContent = assistantSourceContent(local);
+        let matchIndex = -1;
+        for (let index = historicalCeiling - 1; index >= 0; index -= 1) {
+          if (assistantContentsOverlap(durableAssistantParts[index].content, optimisticContent)) {
+            matchIndex = index;
+            break;
+          }
+        }
+        if (matchIndex < 0) continue;
+        historicalCeiling = matchIndex;
+        historicalAssistantMatches.set(local, durableAssistantParts[matchIndex]);
+      }
       for (const local of this.optimistic) {
         const localIsTool = local.role === 'tool-group' || local.role === 'tool';
         if (localIsTool) {
@@ -705,10 +757,13 @@
 
         const afterSeq = finiteInt(local.durableSeqAtSend, -1);
         if (local.role === 'assistant' && assistantProjectionCanCover(local, this)) {
-          const durablePart = durableAssistantParts.find((candidate) => (
-            candidate.sequence > afterSeq && !consumedAssistantParts.has(candidate.key)
+          const historicalMatch = historicalAssistantMatches.get(local);
+          const durablePart = historicalMatch || durableAssistantParts.find((candidate) => (
+            local.historicalReplay !== true
+            && candidate.sequence > afterSeq
+            && !consumedAssistantParts.has(candidate.key)
           ));
-          if (durablePart) {
+          if (durablePart && !consumedAssistantParts.has(durablePart.key)) {
             consumedAssistantParts.add(durablePart.key);
             const suffix = assistantSuffixAfterDurable(durablePart.content, assistantSourceContent(local));
             if (suffix) {

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -55,22 +55,92 @@
     return ids;
   };
 
-  // Stable tool call IDs are authoritative across the durable/optimistic
-  // boundary. Synthetic message IDs differ between transcript conversion and
-  // response recovery, so reconciling only message rows can project the same
-  // call twice. Reserve every durable call first, then retain optimistic calls
-  // in their existing order only when no earlier projection owns that ID.
-  const reconcileToolCallProjection = (messages) => {
+  // Durable identity owns every projected transcript event it covers. Tools use
+  // their server-issued call IDs. Assistant rows have no response ID in the
+  // durable body, so they are paired in order only after the stronger
+  // revision/sequence boundary identifies the same response tail. Content is
+  // consulted after that match solely to retain a not-yet-durable suffix.
+  const assistantProjectionCanCover = (local, context = null) => {
+    if (!local || local.role !== 'assistant' || local.durable) return false;
+    const revAtSend = finiteInt(local.revAtSend, -1);
+    const durableSeqAtSend = finiteInt(local.durableSeqAtSend, -1);
+    if (revAtSend < 0 || durableSeqAtSend < 0) return false;
+    const projectionRev = finiteInt(context?.rev, -1);
+    if (projectionRev > revAtSend) return true;
+    const activeRun = context?.activeRun;
+    if (!activeRun || projectionRev < revAtSend) return false;
+    const localResponseID = String(local.responseId || '').trim();
+    if (localResponseID && localResponseID !== String(activeRun.id || '').trim()) return false;
+    const localStartedRev = finiteInt(local.responseStartedRev, revAtSend);
+    return localStartedRev === finiteInt(activeRun.startedRev, localStartedRev);
+  };
+
+  const assistantSourceContent = (message) => String(message?.optimisticFullContent ?? message?.content ?? '');
+
+  const assistantSuffixAfterDurable = (durableContent, optimisticContent) => {
+    const durable = String(durableContent || '');
+    const optimistic = String(optimisticContent || '');
+    if (optimistic.startsWith(durable)) return optimistic.slice(durable.length);
+    if (durable.startsWith(optimistic)) return '';
+    const maxOverlap = Math.min(durable.length, optimistic.length);
+    for (let length = maxOverlap; length > 0; length -= 1) {
+      if (durable.endsWith(optimistic.slice(0, length))) return optimistic.slice(length);
+    }
+    return '';
+  };
+
+  const reconcileTranscriptProjection = (messages, context = null) => {
     if (!Array.isArray(messages) || messages.length === 0) return Array.isArray(messages) ? messages : [];
     const durableIDs = new Set();
-    for (const message of messages) {
+    const durableAssistants = [];
+    for (const [index, message] of messages.entries()) {
       if (!message?.durable) continue;
       for (const id of messageToolIDs(message)) durableIDs.add(id);
+      if (message.role === 'assistant' && Number.isFinite(Number(message.serverSeq))) {
+        durableAssistants.push({ index, message, serverSeq: finiteInt(message.serverSeq, -1) });
+      }
+    }
+
+    const assistantMatches = new Map();
+    const claimedAssistants = new Set();
+    for (const [index, message] of messages.entries()) {
+      if (!assistantProjectionCanCover(message, context)) continue;
+      const afterSeq = finiteInt(message.durableSeqAtSend, -1);
+      const match = durableAssistants.find((candidate) => (
+        candidate.serverSeq > afterSeq && !claimedAssistants.has(candidate.index)
+      ));
+      if (!match) continue;
+      claimedAssistants.add(match.index);
+      const crossesUserBoundary = messages.slice(match.index + 1, index).some((candidate) => candidate?.role === 'user');
+      assistantMatches.set(index, { ...match, crossesUserBoundary });
     }
 
     const claimed = new Set();
     const result = [];
-    for (const message of messages) {
+    for (const [messageIndex, message] of messages.entries()) {
+      const assistantMatch = assistantMatches.get(messageIndex);
+      if (assistantMatch) {
+        const optimisticContent = assistantSourceContent(message);
+        const suffix = assistantSuffixAfterDurable(assistantMatch.message.content, optimisticContent);
+        if (suffix && assistantMatch.crossesUserBoundary) {
+          result.push({
+            ...message,
+            content: suffix,
+            optimisticFullContent: optimisticContent
+          });
+          continue;
+        }
+        const durableIndex = result.findIndex((entry) => entry === assistantMatch.message);
+        if (durableIndex >= 0 && suffix) {
+          result[durableIndex] = {
+            ...assistantMatch.message,
+            content: `${String(assistantMatch.message.content || '')}${suffix}`,
+            optimisticSuffixClientKey: String(message.clientKey || message.id || '')
+          };
+        }
+        continue;
+      }
+
       if (!message || (message.role !== 'tool-group' && message.role !== 'tool')) {
         result.push(message);
         continue;
@@ -503,6 +573,22 @@
       const clientKey = String(entry.clientKey || entry.id || `optimistic-${Date.now()}-${this.optimistic.length}`);
       const existing = this.optimistic.find((item) => String(item.clientKey || item.id || '') === clientKey);
       if (existing) {
+        const previousAssistantContent = existing.role === 'assistant' ? String(existing.content || '') : '';
+        const previousRevAtSend = finiteInt(existing.revAtSend, finiteInt(revAtSend, this.rev));
+        const previousDurableSeqAtSend = finiteInt(existing.durableSeqAtSend, this.seqs.length ? this.seqs[this.seqs.length - 1] : -1);
+        Object.assign(existing, entry);
+        existing.clientKey = clientKey;
+        existing.optimistic = true;
+        existing.revAtSend = finiteInt(existing.revAtSend, previousRevAtSend);
+        existing.durableSeqAtSend = finiteInt(existing.durableSeqAtSend, previousDurableSeqAtSend);
+        if (existing.role === 'assistant') {
+          const incomingContent = String(entry.content || '');
+          if (previousAssistantContent.startsWith(incomingContent)) existing.content = previousAssistantContent;
+        }
+        if (this.activeRun && (existing.role === 'assistant' || existing.role === 'tool' || existing.role === 'tool-group')) {
+          if (!String(existing.responseId || '').trim()) existing.responseId = this.activeRun.id;
+          existing.responseStartedRev = finiteInt(existing.responseStartedRev, this.activeRun.startedRev);
+        }
         if (options.persisted === true) this.persistedOptimistic.add(existing);
         return existing;
       }
@@ -511,6 +597,10 @@
       optimistic.optimistic = true;
       optimistic.revAtSend = finiteInt(entry.revAtSend, finiteInt(revAtSend, this.rev));
       optimistic.durableSeqAtSend = finiteInt(entry.durableSeqAtSend, this.seqs.length ? this.seqs[this.seqs.length - 1] : -1);
+      if (this.activeRun && (optimistic.role === 'assistant' || optimistic.role === 'tool' || optimistic.role === 'tool-group')) {
+        if (!String(optimistic.responseId || '').trim()) optimistic.responseId = this.activeRun.id;
+        optimistic.responseStartedRev = finiteInt(optimistic.responseStartedRev, this.activeRun.startedRev);
+      }
       this.optimistic.push(optimistic);
       if (options.persisted === true) this.persistedOptimistic.add(optimistic);
       return optimistic;
@@ -534,14 +624,14 @@
       return low < this.seqs.length ? this.segmentForOrdinal(low) : -1;
     }
 
-    persistedOptimisticToolSegmentIndexes(limit = TRANSCRIPT_MATERIALIZE_BATCH_TURNS) {
+    persistedOptimisticSegmentIndexes(limit = TRANSCRIPT_MATERIALIZE_BATCH_TURNS) {
       if (this.activeRun || this.optimistic.length === 0) return [];
       const max = Math.max(1, finiteInt(limit, TRANSCRIPT_MATERIALIZE_BATCH_TURNS));
       const selected = new Set();
       for (const local of this.optimistic) {
         if (selected.size >= max) break;
         if (!this.persistedOptimistic.has(local)) continue;
-        if (local.role !== 'tool-group' && local.role !== 'tool') continue;
+        if (!['assistant', 'tool-group', 'tool'].includes(local.role)) continue;
         if (this.rev <= finiteInt(local.revAtSend, this.rev)) continue;
         const segmentIndex = this.segmentAfterSequence(local.durableSeqAtSend);
         if (segmentIndex >= 0 && this.segments[segmentIndex]?.state === 'evicted') selected.add(segmentIndex);
@@ -557,11 +647,33 @@
       return ids;
     }
 
+    durableAssistantParts() {
+      const result = [];
+      for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
+        if (this.roles[ordinal] !== 'a') continue;
+        const body = this.bodies.get(this.ids[ordinal]);
+        if (!body) continue;
+        for (const [partIndex, part] of (body.parts || []).entries()) {
+          if (part?.type !== 'text' || !String(part.text || '')) continue;
+          result.push({
+            key: `${ordinal}:${partIndex}`,
+            ordinal,
+            partIndex,
+            sequence: this.seqs[ordinal],
+            content: String(part.text || '')
+          });
+        }
+      }
+      return result;
+    }
+
     reconcileOptimistic() {
       if (this.optimistic.length === 0) return [];
       const kept = [];
       const removed = [];
-      const consumed = new Set();
+      const consumedRows = new Set();
+      const consumedAssistantParts = new Set();
+      const durableAssistantParts = this.durableAssistantParts();
       const durableToolIDs = this.durableToolIDs();
       const claimedOptimisticToolIDs = new Set();
       for (const local of this.optimistic) {
@@ -591,26 +703,33 @@
           }
         }
 
+        const afterSeq = finiteInt(local.durableSeqAtSend, -1);
+        if (local.role === 'assistant' && assistantProjectionCanCover(local, this)) {
+          const durablePart = durableAssistantParts.find((candidate) => (
+            candidate.sequence > afterSeq && !consumedAssistantParts.has(candidate.key)
+          ));
+          if (durablePart) {
+            consumedAssistantParts.add(durablePart.key);
+            const suffix = assistantSuffixAfterDurable(durablePart.content, assistantSourceContent(local));
+            if (suffix) {
+              kept.push(local);
+            } else {
+              removed.push(local);
+            }
+            continue;
+          }
+        }
+
         if (this.rev <= finiteInt(local.revAtSend, this.rev)) {
           kept.push(local);
           continue;
         }
-        const afterSeq = finiteInt(local.durableSeqAtSend, -1);
         let matched = false;
         if (local.role === 'user') {
           for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
-            if (this.seqs[ordinal] <= afterSeq || consumed.has(ordinal)) continue;
+            if (this.seqs[ordinal] <= afterSeq || consumedRows.has(ordinal)) continue;
             if (this.roles[ordinal] === 'u' && this.bodies.has(this.ids[ordinal])) {
-              consumed.add(ordinal);
-              matched = true;
-              break;
-            }
-          }
-        } else if (local.role === 'assistant') {
-          for (let ordinal = 0; ordinal < this.ids.length; ordinal += 1) {
-            if (this.seqs[ordinal] <= afterSeq || consumed.has(ordinal)) continue;
-            if (this.roles[ordinal] === 'a' && this.bodies.has(this.ids[ordinal])) {
-              consumed.add(ordinal);
+              consumedRows.add(ordinal);
               matched = true;
               break;
             }
@@ -631,6 +750,20 @@
     clearTransientOptimistic() {
       const removed = this.optimistic.filter((entry) => entry?.transient);
       this.optimistic = this.optimistic.filter((entry) => !entry?.transient);
+      return removed;
+    }
+
+    removeOptimistic(entryOrKey) {
+      const key = String(
+        entryOrKey && typeof entryOrKey === 'object'
+          ? (entryOrKey.clientKey || entryOrKey.id || '')
+          : (entryOrKey || '')
+      );
+      if (!key) return [];
+      const removed = this.optimistic.filter((entry) => String(entry?.clientKey || entry?.id || '') === key);
+      if (removed.length > 0) {
+        this.optimistic = this.optimistic.filter((entry) => String(entry?.clientKey || entry?.id || '') !== key);
+      }
       return removed;
     }
 
@@ -806,7 +939,7 @@
     TRANSCRIPT_FLAG_COMPACTION_TAIL,
     TRANSCRIPT_FLAG_EMPTY_BODY,
     transcriptStoreFromMessages,
-    reconcileToolCallProjection,
+    reconcileTranscriptProjection,
     transcriptRoleCode: roleCode,
     transcriptRoleName: roleName,
     __transcriptStats

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -448,6 +448,18 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   assert.equal(assistantTail.optimistic.length, 0);
   assert.deepEqual(assistantTail.reconcileOptimistic(), [], 'repeat terminal reconciliation is a no-op');
 
+  const freshness = new TranscriptStore('run-freshness');
+  freshness.setActiveRun('resp-A', 1, 1);
+  freshness.setActiveRun('resp-B', 2, 2);
+  freshness.setActiveRun('', 0, 0, { observedCreatedEpoch: 1 });
+  assert.equal(freshness.activeRun.id, 'resp-B', 'idle status sampled before response B must not clear newer ownership');
+  freshness.setActiveRun('resp-A', 1, 1);
+  assert.equal(freshness.activeRun.id, 'resp-B', 'late response A attach must not replace newer response B');
+  freshness.setActiveRun('resp-A-legacy', 1, 0, { observedCreatedEpoch: 1 });
+  assert.equal(freshness.activeRun.id, 'resp-B', 'late epochless status sampled before response B must not replace newer ownership');
+  freshness.setActiveRun('', 0, 2, { responseId: 'resp-B', sampledEpoch: 2, observedCreatedEpoch: 2 });
+  assert.equal(freshness.activeRun, null, 'fresh response B terminal may clear ownership');
+
   const reloadedAssistant = new TranscriptStore('assistant-tail-reloaded');
   reloadedAssistant.applyIndex(envelope([25, 26], { rev: 7, roles: 'ua', seqs: [25, 26] }));
   reloadedAssistant.materialize([
@@ -580,6 +592,110 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   assert.deepEqual(fallback.renderedMessages().map((entry) => entry.id || entry.role), direct.renderedMessages().map((entry) => entry.id || entry.role));
   assert(__transcriptStats('converted-fallback'));
   fallback._checkInvariants();
+})();
+
+(() => {
+  const responseA = 'resp_identity_A';
+  const responseB = 'resp_identity_B';
+  const durableA = {
+    id: 'durable-A', role: 'assistant', content: 'same text', durable: true,
+    serverSeq: 1, responseId: responseA, assistantSegmentOrdinal: 0,
+  };
+  const durableB = {
+    id: 'durable-B', role: 'assistant', content: 'same text', durable: true,
+    serverSeq: 3, responseId: responseB, assistantSegmentOrdinal: 0,
+  };
+  const optimisticA = {
+    id: 'optimistic-A', clientKey: `${responseA}:assistant:0`, role: 'assistant',
+    responseId: responseA, assistantSegmentOrdinal: 0, content: 'same text A suffix', optimistic: true,
+  };
+  const optimisticB = {
+    id: 'optimistic-B', clientKey: `${responseB}:assistant:0`, role: 'assistant',
+    responseId: responseB, assistantSegmentOrdinal: 0, content: 'same text B suffix', optimistic: true,
+  };
+  const user = { id: 'interjection', role: 'user', content: 'between' };
+  for (const input of [
+    [durableA, user, durableB, optimisticA, optimisticB],
+    [durableA, optimisticA, user, durableB, optimisticB],
+  ]) {
+    const projection = reconcileTranscriptProjection(input);
+    assert.deepEqual(
+      projection.filter((message) => message.role === 'assistant').map((message) => [message.id, message.content]),
+      [['durable-A', 'same text A suffix'], ['durable-B', 'same text B suffix']],
+      'response-scoped identities must preserve interjection boundaries in either arrival order'
+    );
+  }
+
+  const legacyScope = new TranscriptStore('legacy-active-scope');
+  legacyScope.applyIndex(envelope([101], { rev: 1, roles: 'a', seqs: [101] }));
+  legacyScope.materialize([{ id: 101, sequence: 101, role: 'assistant', parts: [{ type: 'text', text: 'old history' }] }]);
+  legacyScope.setActiveRun('resp-live', 1, 1);
+  legacyScope.applyIndex(envelope([101, 102], { rev: 2, roles: 'aa', seqs: [101, 102] }));
+  legacyScope.materialize([
+    { id: 101, sequence: 101, role: 'assistant', parts: [{ type: 'text', text: 'old history' }] },
+    { id: 102, sequence: 102, role: 'assistant', parts: [{ type: 'text', text: 'live prefix' }] },
+  ]);
+  assert.equal(legacyScope.durableAssistant('resp-live', 0)?.body?.id, 102, 'legacy inference must never claim pre-run assistant history');
+
+  const repeatedContent = reconcileTranscriptProjection([
+    durableA,
+    { ...durableA, id: 'durable-A-segment-1', assistantSegmentOrdinal: 1 },
+    durableB,
+  ]);
+  assert.equal(repeatedContent.length, 3, 'identical assistant content in distinct segment/response identities must never cross-match');
+
+  const scopedTools = reconcileTranscriptProjection([
+    { id: 'tools-A', role: 'tool-group', responseId: responseA, durable: true, tools: [{ id: 'call_same' }] },
+    { id: 'tools-B', role: 'tool-group', responseId: responseB, durable: true, tools: [{ id: 'call_same' }] },
+    { id: 'tools-A-replay', role: 'tool-group', responseId: responseA, optimistic: true, tools: [{ id: 'call_same' }] },
+  ]);
+  assert.deepEqual(scopedTools.map((message) => message.id), ['tools-A', 'tools-B'], 'tool IDs are deduplicated only within their response scope');
+  legacyScope.destroy();
+})();
+
+(() => {
+  const responseId = 'resp_optimistic_first';
+  const store = new TranscriptStore('optimistic-first');
+  store.setActiveRun(responseId, 0, 1);
+  const overlay = store.addOptimistic({
+    id: 'overlay-first', role: 'assistant', responseId, assistantSegmentOrdinal: 0,
+    content: 'prefix suffix', segmentStartSequence: 1, segmentEndSequence: 2,
+  });
+  store.assertMutableOverlay(overlay, 'test');
+  assert.throws(
+    () => store.assertMutableOverlay({ id: 'durable-cursor', role: 'assistant', durable: true }, 'test'),
+    /not a transcript-owned optimistic overlay/,
+    'mutable stream cursor assertion must reject durable nodes'
+  );
+  store.applyIndex({
+    rev: 1,
+    rows: { ids: [1], seqs: [1], roles: 'a', flags: [0], response_ids: [responseId], assistant_segment_ordinals: [0] },
+  });
+  store.materialize([{
+    id: 1, sequence: 1, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+    segment_start_sequence: 1, segment_end_sequence: 1, parts: [{ type: 'text', text: 'prefix' }],
+  }]);
+  assert.deepEqual(store.reconcileOptimistic(), [], 'active durable prefix must retain the canonical overlay suffix');
+  assert.equal(store.optimistic[0], overlay);
+  store.setActiveRun('', 0, 1, { responseId, sampledEpoch: 1, observedCreatedEpoch: 1 });
+  store.materialize([{
+    id: 1, sequence: 1, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+    segment_start_sequence: 1, segment_end_sequence: 2, parts: [{ type: 'text', text: 'prefix suffix' }],
+  }]);
+  assert.deepEqual(store.reconcileOptimistic(), [overlay], 'terminal durable body retires the optimistic source exactly once');
+  assert.deepEqual(store.reconcileOptimistic(), [], 'repeated terminal reconciliation remains a no-op');
+
+  const reloaded = transcriptStoreFromMessages('identity-reload', [{
+    messages: [{
+      id: 1, sequence: 1, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+      segment_start_sequence: 1, segment_end_sequence: 2, parts: [{ type: 'text', text: 'prefix suffix' }],
+    }],
+  }]);
+  assert.equal(reloaded.responseIDs[0], responseId);
+  assert.equal(reloaded.assistantSegmentOrdinals[0], 0);
+  assert.equal(reloaded.renderedMessages()[0].response_id, responseId, 'reload preserves durable response-scoped identity');
+  store._checkInvariants();
+  reloaded._checkInvariants();
 })();
 
 console.log('transcript-store tests passed');

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -5,7 +5,7 @@ const {
   TranscriptStore,
   TRANSCRIPT_FLAG_EMPTY_BODY,
   transcriptStoreFromMessages,
-  reconcileToolCallProjection,
+  reconcileTranscriptProjection,
   __transcriptStats
 } = require('./transcript-store.js');
 
@@ -335,13 +335,150 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
       { id: 'call_newer_optimistic_only', name: 'shell' }
     ]
   };
-  const projected = reconcileToolCallProjection([durableGroup, liveGroup]);
+  const projected = reconcileTranscriptProjection([durableGroup, liveGroup]);
   assert.deepEqual(projected.map((message) => message.id), ['srv_seq_382_tools_0', 'msg_441406d5-live-tools']);
   assert.deepEqual(projected[1].tools.map((tool) => tool.id), ['call_newer_optimistic_only']);
   assert.deepEqual(
-    reconcileToolCallProjection(projected).map((message) => message.id),
+    reconcileTranscriptProjection(projected).map((message) => message.id),
     ['srv_seq_382_tools_0', 'msg_441406d5-live-tools'],
     'repeat resume reconciliation is idempotent'
+  );
+
+  const assistantTail = new TranscriptStore('assistant-tail');
+  assistantTail.applyIndex(envelope([25], { rev: 7, roles: 'u' }));
+  assistantTail.materialize([body(25, 25, 'user')]);
+  assistantTail.setActiveRun('resp-assistant-tail', 7);
+  assistantTail.addOptimistic({
+    id: 'msg_assistant_tail',
+    clientKey: 'msg_assistant_tail',
+    role: 'assistant',
+    content: 'durable prefix',
+    durableSeqAtSend: 25,
+    revAtSend: 7
+  }, 7);
+  const recoveredAssistant = assistantTail.addOptimistic({
+    id: 'msg_assistant_tail',
+    clientKey: 'msg_assistant_tail',
+    role: 'assistant',
+    content: 'durable prefix plus optimistic suffix'
+  }, 7);
+  assert.equal(recoveredAssistant, assistantTail.optimistic[0], 'reconnect recovery must update the canonical optimistic object');
+  assert.equal(recoveredAssistant.content, 'durable prefix plus optimistic suffix', 'reconnect recovery must retain newer assistant text');
+  assert.equal(recoveredAssistant.revAtSend, 7, 'reconnect recovery must preserve the original revision boundary');
+  assert.equal(recoveredAssistant.durableSeqAtSend, 25, 'reconnect recovery must preserve the original sequence boundary');
+  assistantTail.applyIndex(envelope([25, 26], { rev: 7, roles: 'ua', seqs: [25, 26] }));
+  assistantTail.materialize([
+    body(25, 25, 'user'),
+    body(26, 26, 'assistant', [{ type: 'text', text: 'durable prefix' }])
+  ]);
+  assert.deepEqual(
+    assistantTail.reconcileOptimistic(),
+    [],
+    'same-revision active durable prefix must retain the optimistic-only suffix'
+  );
+  assert.equal(
+    assistantTail.optimistic[0].content,
+    'durable prefix plus optimistic suffix',
+    'source reconciliation must keep the complete optimistic text for idempotent reload projection'
+  );
+
+  const assistantProjection = reconcileTranscriptProjection([
+    {
+      id: 'srv_seq_26_text_0',
+      role: 'assistant',
+      content: 'durable prefix',
+      durable: true,
+      serverSeq: 26,
+      transcriptSegmentIndex: 0
+    },
+    assistantTail.optimistic[0]
+  ], assistantTail);
+  assert.deepEqual(
+    assistantProjection.map((message) => message.id),
+    ['srv_seq_26_text_0'],
+    'one authoritative assistant node owns durable and optimistic text'
+  );
+  assert.equal(
+    assistantProjection[0].content,
+    'durable prefix plus optimistic suffix',
+    'durable prefix and optimistic suffix must be coalesced without duplication or loss'
+  );
+  assert.deepEqual(
+    reconcileTranscriptProjection(assistantProjection, assistantTail),
+    assistantProjection,
+    'repeat status/reconnect projection is idempotent'
+  );
+
+  const interjectedProjection = reconcileTranscriptProjection([
+    {
+      id: 'srv_seq_26_text_0',
+      role: 'assistant',
+      content: 'durable prefix',
+      durable: true,
+      serverSeq: 26,
+      transcriptSegmentIndex: 0
+    },
+    { id: 'msg_interjection', role: 'user', content: 'stop there', interruptState: 'interject' },
+    assistantTail.optimistic[0]
+  ], assistantTail);
+  assert.deepEqual(
+    interjectedProjection.map((message) => ({ id: message.id, content: message.content })),
+    [
+      { id: 'srv_seq_26_text_0', content: 'durable prefix' },
+      { id: 'msg_interjection', content: 'stop there' },
+      { id: 'msg_assistant_tail', content: ' plus optimistic suffix' }
+    ],
+    'assistant suffix must not move ahead of an intervening user interjection'
+  );
+  assert.deepEqual(
+    reconcileTranscriptProjection(interjectedProjection, assistantTail)
+      .map((message) => ({ id: message.id, content: message.content })),
+    interjectedProjection.map((message) => ({ id: message.id, content: message.content })),
+    'interjected assistant projection must remain idempotent'
+  );
+
+  assistantTail.materialize([
+    body(26, 26, 'assistant', [{ type: 'text', text: 'durable prefix plus optimistic suffix' }])
+  ]);
+  assert.deepEqual(
+    assistantTail.reconcileOptimistic().map((entry) => entry.clientKey),
+    ['msg_assistant_tail'],
+    'the complete durable assistant projection retires its optimistic source exactly once'
+  );
+  assert.equal(assistantTail.optimistic.length, 0);
+  assert.deepEqual(assistantTail.reconcileOptimistic(), [], 'repeat terminal reconciliation is a no-op');
+
+  const reloadedAssistant = new TranscriptStore('assistant-tail-reloaded');
+  reloadedAssistant.applyIndex(envelope([25, 26], { rev: 7, roles: 'ua', seqs: [25, 26] }));
+  reloadedAssistant.materialize([
+    body(25, 25, 'user'),
+    body(26, 26, 'assistant', [{ type: 'text', text: 'durable prefix' }])
+  ]);
+  reloadedAssistant.setActiveRun('resp-assistant-tail', 7);
+  reloadedAssistant.addOptimistic({
+    id: 'msg_assistant_tail',
+    clientKey: 'msg_assistant_tail',
+    role: 'assistant',
+    content: 'durable prefix plus optimistic suffix',
+    durableSeqAtSend: 25,
+    revAtSend: 7
+  }, 7, { persisted: true });
+  reloadedAssistant.reconcileOptimistic();
+  const reloadedProjection = reconcileTranscriptProjection([
+    {
+      id: 'srv_seq_26_text_0',
+      role: 'assistant',
+      content: 'durable prefix',
+      durable: true,
+      serverSeq: 26,
+      transcriptSegmentIndex: 0
+    },
+    ...reloadedAssistant.optimistic
+  ], reloadedAssistant);
+  assert.deepEqual(
+    reloadedProjection.map((message) => ({ id: message.id, content: message.content })),
+    assistantProjection.map((message) => ({ id: message.id, content: message.content })),
+    'persisted reload and live status synchronization must publish the same tail'
   );
 
   const scopedTools = new TranscriptStore('scoped-persisted-tools');

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -44,6 +44,7 @@ type SQLiteStore struct {
 	hasTranscriptRev         bool // true if sessions table has transcript_rev column
 	hasMessagesTable         bool // true if the messages table exists
 	hasMessageCompactionTail bool // true if messages table has compaction_tail column
+	hasMessageStreamIdentity bool // true if messages table has response-scoped segment identity columns
 }
 
 var _ MessageSequenceStore = (*SQLiteStore)(nil)
@@ -111,7 +112,11 @@ CREATE TABLE IF NOT EXISTS messages (
     turn_index INTEGER DEFAULT 0,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     sequence INTEGER NOT NULL,
-    compaction_tail BOOLEAN DEFAULT FALSE
+    compaction_tail BOOLEAN DEFAULT FALSE,
+    response_id TEXT NOT NULL DEFAULT '',
+    assistant_segment_ordinal INTEGER NOT NULL DEFAULT -1,
+    segment_start_sequence INTEGER NOT NULL DEFAULT 0,
+    segment_end_sequence INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated_at ON sessions(updated_at DESC);
@@ -184,7 +189,11 @@ CREATE TABLE messages (
     turn_index INTEGER DEFAULT 0,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     sequence INTEGER NOT NULL,
-    compaction_tail BOOLEAN DEFAULT FALSE
+    compaction_tail BOOLEAN DEFAULT FALSE,
+    response_id TEXT NOT NULL DEFAULT '',
+    assistant_segment_ordinal INTEGER NOT NULL DEFAULT -1,
+    segment_start_sequence INTEGER NOT NULL DEFAULT 0,
+    segment_end_sequence INTEGER NOT NULL DEFAULT 0
 )`
 
 // NewSQLiteStore creates a new SQLite-based session store.
@@ -268,7 +277,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 41
+const schemaVersion = 42
 
 // migration represents a schema migration.
 type migration struct {
@@ -1120,6 +1129,24 @@ var migrations = []migration{
 			}
 			_, err := db.Exec("UPDATE sessions SET transcript_rev = COALESCE(message_count, 0)")
 			return err
+		},
+	},
+	{
+		version:     42,
+		description: "add response scoped transcript segment identity",
+		up: func(db schemaExecutor) error {
+			statements := []string{
+				"ALTER TABLE messages ADD COLUMN response_id TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE messages ADD COLUMN assistant_segment_ordinal INTEGER NOT NULL DEFAULT -1",
+				"ALTER TABLE messages ADD COLUMN segment_start_sequence INTEGER NOT NULL DEFAULT 0",
+				"ALTER TABLE messages ADD COLUMN segment_end_sequence INTEGER NOT NULL DEFAULT 0",
+			}
+			for _, statement := range statements {
+				if _, err := db.Exec(statement); err != nil && !isDuplicateColumnError(err) {
+					return err
+				}
+			}
+			return nil
 		},
 	},
 }
@@ -2561,9 +2588,10 @@ func (s *SQLiteStore) bumpTranscriptRev(ctx context.Context, execer sqliteQueryE
 
 func (s *SQLiteStore) insertMessageAndBumpSession(ctx context.Context, execer sqliteQueryExecer, sessionID string, msg *Message, partsJSON string, sequence int) (int64, error) {
 	result, err := execer.ExecContext(ctx, `
-		INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, sequence, msg.CompactionTail)
+		INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail, response_id, assistant_segment_ordinal, segment_start_sequence, segment_end_sequence)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, sequence, msg.CompactionTail,
+		msg.ResponseID, msg.AssistantSegmentOrdinal, msg.SegmentStartSequence, msg.SegmentEndSequence)
 	if err != nil {
 		return 0, fmt.Errorf("insert message: %w", err)
 	}
@@ -2627,9 +2655,9 @@ func (s *SQLiteStore) updateMessage(ctx context.Context, sessionID string, msg *
 		query += `, text_content = ?`
 		args = append(args, msg.TextContent)
 	}
-	query += `, duration_ms = ?, turn_index = ?, compaction_tail = ?
+	query += `, duration_ms = ?, turn_index = ?, compaction_tail = ?, response_id = ?, assistant_segment_ordinal = ?, segment_start_sequence = ?, segment_end_sequence = ?
 			WHERE id = ? AND session_id = ?`
-	args = append(args, msg.DurationMs, msg.TurnIndex, msg.CompactionTail, msg.ID, sessionID)
+	args = append(args, msg.DurationMs, msg.TurnIndex, msg.CompactionTail, msg.ResponseID, msg.AssistantSegmentOrdinal, msg.SegmentStartSequence, msg.SegmentEndSequence, msg.ID, sessionID)
 
 	return retryOnBusy(ctx, 5, func() error {
 		tx, err := s.db.BeginTx(ctx, nil)
@@ -2793,8 +2821,8 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 
 		if commonPrefix < len(messages) {
 			insertStmt, err := tx.PrepareContext(ctx, `
-				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail, response_id, assistant_segment_ordinal, segment_start_sequence, segment_end_sequence)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 			if err != nil {
 				return fmt.Errorf("prepare message insert: %w", err)
 			}
@@ -2807,7 +2835,8 @@ func (s *SQLiteStore) ReplaceMessages(ctx context.Context, sessionID string, mes
 					createdAt = time.Now()
 				}
 				_, err = insertStmt.ExecContext(ctx,
-					sessionID, string(msg.Role), partsJSON[i], msg.TextContent, msg.DurationMs, msg.TurnIndex, createdAt, i, false)
+					sessionID, string(msg.Role), partsJSON[i], msg.TextContent, msg.DurationMs, msg.TurnIndex, createdAt, i, false,
+					msg.ResponseID, msg.AssistantSegmentOrdinal, msg.SegmentStartSequence, msg.SegmentEndSequence)
 				if err != nil {
 					return fmt.Errorf("insert message %d: %w", i, err)
 				}
@@ -2868,8 +2897,8 @@ func (s *SQLiteStore) ReplaceCompactedMessages(ctx context.Context, sessionID st
 
 		if commonPrefix < len(messages) {
 			insertStmt, err := tx.PrepareContext(ctx, `
-				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+				INSERT INTO messages (session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail, response_id, assistant_segment_ordinal, segment_start_sequence, segment_end_sequence)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 			if err != nil {
 				return fmt.Errorf("prepare compacted message insert: %w", err)
 			}
@@ -2882,7 +2911,8 @@ func (s *SQLiteStore) ReplaceCompactedMessages(ctx context.Context, sessionID st
 					createdAt = time.Now()
 				}
 				_, err = insertStmt.ExecContext(ctx,
-					sessionID, string(msg.Role), partsJSON[i], msg.TextContent, msg.DurationMs, msg.TurnIndex, createdAt, startSeq+i, msg.CompactionTail)
+					sessionID, string(msg.Role), partsJSON[i], msg.TextContent, msg.DurationMs, msg.TurnIndex, createdAt, startSeq+i, msg.CompactionTail,
+					msg.ResponseID, msg.AssistantSegmentOrdinal, msg.SegmentStartSequence, msg.SegmentEndSequence)
 				if err != nil {
 					return fmt.Errorf("insert compacted message %d: %w", i, err)
 				}
@@ -2937,7 +2967,9 @@ func (s *SQLiteStore) compactionStartSeq(ctx context.Context, tx *sql.Tx, sessio
 
 func compactedReplacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID string, startSeq int, desired []Message, desiredPartsJSON []string) (prefix int, fullActiveDelete bool, err error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT sequence, role, parts, text_content, duration_ms, turn_index
+		SELECT sequence, role, parts, text_content, duration_ms, turn_index,
+		       COALESCE(response_id, ''), COALESCE(assistant_segment_ordinal, -1),
+		       COALESCE(segment_start_sequence, 0), COALESCE(segment_end_sequence, 0)
 		FROM messages
 		WHERE session_id = ? AND sequence >= ?
 		ORDER BY sequence ASC, id ASC`, sessionID, startSeq)
@@ -2952,7 +2984,11 @@ func compactedReplacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID
 		var textContent sql.NullString
 		var durationMs sql.NullInt64
 		var turnIndex sql.NullInt64
-		if err := rows.Scan(&sequence, &role, &partsJSON, &textContent, &durationMs, &turnIndex); err != nil {
+		var responseID string
+		var assistantSegmentOrdinal int
+		var segmentStartSequence, segmentEndSequence int64
+		if err := rows.Scan(&sequence, &role, &partsJSON, &textContent, &durationMs, &turnIndex,
+			&responseID, &assistantSegmentOrdinal, &segmentStartSequence, &segmentEndSequence); err != nil {
 			return 0, false, fmt.Errorf("scan compacted message: %w", err)
 		}
 		if sequence < startSeq {
@@ -2978,7 +3014,11 @@ func compactedReplacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID
 			partsJSON != desiredPartsJSON[prefix] ||
 			nullStringValue(textContent) != want.TextContent ||
 			nullInt64Value(durationMs) != want.DurationMs ||
-			int(nullInt64Value(turnIndex)) != want.TurnIndex {
+			int(nullInt64Value(turnIndex)) != want.TurnIndex ||
+			responseID != want.ResponseID ||
+			assistantSegmentOrdinal != want.AssistantSegmentOrdinal ||
+			segmentStartSequence != want.SegmentStartSequence ||
+			segmentEndSequence != want.SegmentEndSequence {
 			break
 		}
 		prefix++
@@ -3048,7 +3088,9 @@ func prepareReplacementMessageParts(messages []Message, stripImageBase64 bool) (
 
 func replacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID string, desired []Message, desiredPartsJSON []string) (prefix int, fullDelete bool, err error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT sequence, role, parts, text_content, duration_ms, turn_index, COALESCE(compaction_tail, FALSE)
+		SELECT sequence, role, parts, text_content, duration_ms, turn_index, COALESCE(compaction_tail, FALSE),
+		       COALESCE(response_id, ''), COALESCE(assistant_segment_ordinal, -1),
+		       COALESCE(segment_start_sequence, 0), COALESCE(segment_end_sequence, 0)
 		FROM messages
 		WHERE session_id = ?
 		ORDER BY sequence ASC, id ASC`, sessionID)
@@ -3064,7 +3106,11 @@ func replacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID string, 
 		var durationMs sql.NullInt64
 		var turnIndex sql.NullInt64
 		var compactionTail bool
-		if err := rows.Scan(&sequence, &role, &partsJSON, &textContent, &durationMs, &turnIndex, &compactionTail); err != nil {
+		var responseID string
+		var assistantSegmentOrdinal int
+		var segmentStartSequence, segmentEndSequence int64
+		if err := rows.Scan(&sequence, &role, &partsJSON, &textContent, &durationMs, &turnIndex, &compactionTail,
+			&responseID, &assistantSegmentOrdinal, &segmentStartSequence, &segmentEndSequence); err != nil {
 			return 0, false, fmt.Errorf("scan existing message: %w", err)
 		}
 		if sequence < 0 {
@@ -3093,7 +3139,11 @@ func replacementCommonPrefix(ctx context.Context, tx *sql.Tx, sessionID string, 
 			nullStringValue(textContent) != want.TextContent ||
 			nullInt64Value(durationMs) != want.DurationMs ||
 			int(nullInt64Value(turnIndex)) != want.TurnIndex ||
-			compactionTail {
+			compactionTail ||
+			responseID != want.ResponseID ||
+			assistantSegmentOrdinal != want.AssistantSegmentOrdinal ||
+			segmentStartSequence != want.SegmentStartSequence ||
+			segmentEndSequence != want.SegmentEndSequence {
 			break
 		}
 		prefix++
@@ -3194,7 +3244,11 @@ func (s *SQLiteStore) messageSelectCols() string {
 	if s.hasMessageCompactionTail {
 		compactionTailCol = "COALESCE(compaction_tail, FALSE) AS compaction_tail"
 	}
-	return `id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, ` + compactionTailCol
+	streamIdentityCols := "'' AS response_id, -1 AS assistant_segment_ordinal, 0 AS segment_start_sequence, 0 AS segment_end_sequence"
+	if s.hasMessageStreamIdentity {
+		streamIdentityCols = "COALESCE(response_id, '') AS response_id, COALESCE(assistant_segment_ordinal, -1) AS assistant_segment_ordinal, COALESCE(segment_start_sequence, 0) AS segment_start_sequence, COALESCE(segment_end_sequence, 0) AS segment_end_sequence"
+	}
+	return `id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, ` + compactionTailCol + `, ` + streamIdentityCols
 }
 
 // TranscriptVersioned reports whether this database has durable transcript
@@ -3297,8 +3351,12 @@ func (s *SQLiteStore) GetTranscriptSnapshot(ctx context.Context, sessionID strin
 	if s.hasMessageCompactionTail {
 		compactionTailCol = "COALESCE(compaction_tail, FALSE)"
 	}
+	streamIdentityCols := "'', -1"
+	if s.hasMessageStreamIdentity {
+		streamIdentityCols = "COALESCE(response_id, ''), COALESCE(assistant_segment_ordinal, -1)"
+	}
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, sequence, role, parts, `+compactionTailCol+`
+		SELECT id, sequence, role, parts, `+compactionTailCol+`, `+streamIdentityCols+`
 		FROM messages
 		WHERE session_id = ? AND role NOT IN ('system', 'developer')
 		ORDER BY sequence ASC, id ASC`, sessionID)
@@ -3313,7 +3371,7 @@ func (s *SQLiteStore) GetTranscriptSnapshot(ctx context.Context, sessionID strin
 		var item TranscriptIndexItem
 		var partsJSON string
 		var compactionTail bool
-		if err := rows.Scan(&item.ID, &item.Seq, &item.Role, &partsJSON, &compactionTail); err != nil {
+		if err := rows.Scan(&item.ID, &item.Seq, &item.Role, &partsJSON, &compactionTail, &item.ResponseID, &item.AssistantSegmentOrdinal); err != nil {
 			return TranscriptSnapshot{}, fmt.Errorf("scan transcript index: %w", err)
 		}
 		if compactionTail {
@@ -3510,7 +3568,8 @@ func scanMessageRows(rows *sql.Rows) ([]Message, error) {
 		var partsJSON string
 		var durationMs sql.NullInt64
 		err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
-			&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence, &msg.CompactionTail)
+			&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence, &msg.CompactionTail,
+			&msg.ResponseID, &msg.AssistantSegmentOrdinal, &msg.SegmentStartSequence, &msg.SegmentEndSequence)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
@@ -3563,7 +3622,8 @@ func (s *SQLiteStore) GetMessageByID(ctx context.Context, msgID int64) (*Message
 	var partsJSON string
 	var durationMs sql.NullInt64
 	err := row.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
-		&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence, &msg.CompactionTail)
+		&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence, &msg.CompactionTail,
+		&msg.ResponseID, &msg.AssistantSegmentOrdinal, &msg.SegmentStartSequence, &msg.SegmentEndSequence)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -3726,25 +3786,7 @@ func (s *SQLiteStore) GetMessages(ctx context.Context, sessionID string, limit, 
 	}
 	defer rows.Close()
 
-	var messages []Message
-	for rows.Next() {
-		var msg Message
-		var partsJSON string
-		var durationMs sql.NullInt64
-		err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &partsJSON,
-			&msg.TextContent, &durationMs, &msg.TurnIndex, &msg.CreatedAt, &msg.Sequence, &msg.CompactionTail)
-		if err != nil {
-			return nil, fmt.Errorf("scan message: %w", err)
-		}
-		if durationMs.Valid {
-			msg.DurationMs = durationMs.Int64
-		}
-		if err := msg.SetPartsFromJSON(partsJSON); err != nil {
-			return nil, fmt.Errorf("deserialize parts: %w", err)
-		}
-		messages = append(messages, msg)
-	}
-	return messages, rows.Err()
+	return scanMessageRows(rows)
 }
 
 // SetCurrent marks a session as the current one.
@@ -3854,6 +3896,7 @@ func (s *SQLiteStore) setCurrentColumns() {
 	s.hasTranscriptRev = true
 	s.hasMessagesTable = true
 	s.hasMessageCompactionTail = true
+	s.hasMessageStreamIdentity = true
 }
 
 // probeSessionColumns checks optional session columns in a single PRAGMA scan.
@@ -3936,8 +3979,11 @@ func (s *SQLiteStore) probeMessageColumns() {
 			return
 		}
 		s.hasMessagesTable = true
-		if name == "compaction_tail" {
+		switch name {
+		case "compaction_tail":
 			s.hasMessageCompactionTail = true
+		case "response_id":
+			s.hasMessageStreamIdentity = true
 		}
 	}
 }

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -2850,3 +2850,69 @@ func explainQueryPlan(t *testing.T, db *sql.DB, query string) string {
 	}
 	return strings.Join(parts, "\n")
 }
+
+func TestSQLiteStoreMigratesLegacyMessagesToResponseSegmentIdentity(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy-stream-identity.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("create current store: %v", err)
+	}
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.AddMessage(ctx, sess.ID, NewMessage(sess.ID, llm.AssistantText("legacy row"), -1)); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close current store: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	for _, column := range []string{"segment_end_sequence", "segment_start_sequence", "assistant_segment_ordinal", "response_id"} {
+		if _, err := db.Exec("ALTER TABLE messages DROP COLUMN " + column); err != nil {
+			db.Close()
+			t.Fatalf("drop %s: %v", column, err)
+		}
+	}
+	if _, err := db.Exec("UPDATE schema_version SET version = 41"); err != nil {
+		db.Close()
+		t.Fatalf("rewind schema version: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+
+	migrated, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("migrate store: %v", err)
+	}
+	defer migrated.Close()
+	messages, err := migrated.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("read migrated legacy row: %v", err)
+	}
+	if len(messages) != 1 || messages[0].ResponseID != "" || messages[0].AssistantSegmentOrdinal != -1 {
+		t.Fatalf("migrated legacy row = %+v", messages)
+	}
+	identified := llm.AssistantText("identified row")
+	identified.ResponseID = "resp_migrated"
+	identified.AssistantSegmentOrdinal = 1
+	identified.SegmentStartSequence = 7
+	identified.SegmentEndSequence = 9
+	if err := migrated.AddMessage(ctx, sess.ID, NewMessage(sess.ID, identified, -1)); err != nil {
+		t.Fatalf("write identified row after migration: %v", err)
+	}
+	messages, err = migrated.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("read identified row: %v", err)
+	}
+	got := messages[len(messages)-1]
+	if got.ResponseID != identified.ResponseID || got.AssistantSegmentOrdinal != 1 || got.SegmentStartSequence != 7 || got.SegmentEndSequence != 9 {
+		t.Fatalf("identified row after migration = %+v", got)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -205,10 +205,12 @@ const (
 // one UI-visible transcript row. IDs are stable identities; Seq is only the
 // current ordering key.
 type TranscriptIndexItem struct {
-	Seq   int
-	ID    int64
-	Role  string
-	Flags uint8
+	Seq                     int
+	ID                      int64
+	Role                    string
+	Flags                   uint8
+	ResponseID              string
+	AssistantSegmentOrdinal int
 }
 
 // TranscriptSnapshot is the complete compact identity stream and its session

--- a/internal/session/transcript_test.go
+++ b/internal/session/transcript_test.go
@@ -252,3 +252,46 @@ func TestSQLiteStoreTranscriptRewriteRetiresIDs(t *testing.T) {
 		t.Fatalf("rewritten row retained retired ID %d", oldSecondID)
 	}
 }
+
+func TestSQLiteStoreTranscriptPersistsResponseScopedAssistantIdentity(t *testing.T) {
+	store, sess := newTranscriptTestStore(t)
+	ctx := context.Background()
+	assistant := llm.AssistantText("stable segment")
+	assistant.ResponseID = "resp_identity"
+	assistant.AssistantSegmentOrdinal = 2
+	assistant.SegmentStartSequence = 11
+	assistant.SegmentEndSequence = 17
+	message := NewMessage(sess.ID, assistant, -1)
+	if err := store.AddMessage(ctx, sess.ID, message); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	snapshot, err := store.GetTranscriptSnapshot(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetTranscriptSnapshot: %v", err)
+	}
+	if len(snapshot.Items) != 1 {
+		t.Fatalf("items=%d want 1", len(snapshot.Items))
+	}
+	item := snapshot.Items[0]
+	if item.ResponseID != assistant.ResponseID || item.AssistantSegmentOrdinal != 2 {
+		t.Fatalf("index identity=%+v", item)
+	}
+	_, bodies, err := store.GetMessagesByTranscriptRanges(ctx, sess.ID, []TranscriptRange{{
+		StartSeq: item.Seq, StartID: item.ID, EndSeq: item.Seq, EndID: item.ID,
+	}})
+	if err != nil {
+		t.Fatalf("GetMessagesByTranscriptRanges: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("bodies=%d want 1", len(bodies))
+	}
+	got := bodies[0]
+	if got.ResponseID != assistant.ResponseID || got.AssistantSegmentOrdinal != 2 || got.SegmentStartSequence != 11 || got.SegmentEndSequence != 17 {
+		t.Fatalf("body identity=%+v", got)
+	}
+	roundTrip := got.ToLLMMessage()
+	if roundTrip.ResponseID != assistant.ResponseID || roundTrip.AssistantSegmentOrdinal != 2 {
+		t.Fatalf("LLM round trip identity=%+v", roundTrip)
+	}
+}

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -113,16 +113,20 @@ type Session struct {
 // The Parts field stores the full llm.Message.Parts as JSON to preserve tool
 // calls, uploaded images/files, and provider replay state exactly.
 type Message struct {
-	ID             int64      `json:"id"`
-	SessionID      string     `json:"session_id"`
-	Role           llm.Role   `json:"role"`
-	Parts          []llm.Part `json:"parts"`        // Full parts array
-	TextContent    string     `json:"text_content"` // Extracted text for display/FTS
-	DurationMs     int64      `json:"duration_ms,omitempty"`
-	TurnIndex      int        `json:"turn_index,omitempty"`
-	CreatedAt      time.Time  `json:"created_at"`
-	Sequence       int        `json:"sequence"`
-	CompactionTail bool       `json:"compaction_tail,omitempty"` // Persisted display hint: retained post-compaction context already visible before the marker
+	ID                      int64      `json:"id"`
+	SessionID               string     `json:"session_id"`
+	Role                    llm.Role   `json:"role"`
+	Parts                   []llm.Part `json:"parts"`        // Full parts array
+	TextContent             string     `json:"text_content"` // Extracted text for display/FTS
+	DurationMs              int64      `json:"duration_ms,omitempty"`
+	TurnIndex               int        `json:"turn_index,omitempty"`
+	CreatedAt               time.Time  `json:"created_at"`
+	Sequence                int        `json:"sequence"`
+	CompactionTail          bool       `json:"compaction_tail,omitempty"` // Persisted display hint: retained post-compaction context already visible before the marker
+	ResponseID              string     `json:"response_id,omitempty"`
+	AssistantSegmentOrdinal int        `json:"assistant_segment_ordinal"` // Response-scoped; -1 when the row is not an assistant segment.
+	SegmentStartSequence    int64      `json:"segment_start_sequence,omitempty"`
+	SegmentEndSequence      int64      `json:"segment_end_sequence,omitempty"`
 }
 
 // SessionSummary is a lightweight view of a session for listing.
@@ -214,11 +218,18 @@ type SearchResult struct {
 // NewMessage creates a new Message from an llm.Message with the given session ID and sequence.
 func NewMessage(sessionID string, msg llm.Message, sequence int) *Message {
 	m := &Message{
-		SessionID: sessionID,
-		Role:      msg.Role,
-		Parts:     msg.Parts,
-		CreatedAt: time.Now(),
-		Sequence:  sequence,
+		SessionID:               sessionID,
+		Role:                    msg.Role,
+		Parts:                   msg.Parts,
+		CreatedAt:               time.Now(),
+		Sequence:                sequence,
+		ResponseID:              msg.ResponseID,
+		AssistantSegmentOrdinal: msg.AssistantSegmentOrdinal,
+		SegmentStartSequence:    msg.SegmentStartSequence,
+		SegmentEndSequence:      msg.SegmentEndSequence,
+	}
+	if msg.Role != llm.RoleAssistant && msg.AssistantSegmentOrdinal == 0 {
+		m.AssistantSegmentOrdinal = -1
 	}
 	m.TextContent = m.ExtractTextContent()
 	return m
@@ -244,8 +255,12 @@ func (m *Message) ToLLMMessage() llm.Message {
 		return llm.Message{}
 	}
 	msg := llm.Message{
-		Role:  m.Role,
-		Parts: providerMessageParts(m.Parts),
+		Role:                    m.Role,
+		Parts:                   providerMessageParts(m.Parts),
+		ResponseID:              m.ResponseID,
+		AssistantSegmentOrdinal: m.AssistantSegmentOrdinal,
+		SegmentStartSequence:    m.SegmentStartSequence,
+		SegmentEndSequence:      m.SegmentEndSequence,
 	}
 	if m.isInternalCompactionSummary() {
 		msg.CacheAnchor = true


### PR DESCRIPTION
## What

Replace repair-oriented web tail deduplication with stable response ownership across durable transcript rows, recovery snapshots, historical replay, and fresh streaming.

This fixes intermittent duplicate assistant messages and tool groups that appeared when the same active response was represented simultaneously as durable `srv_seq_*` rows and optimistic `msg_*` rows.

## Ownership model

- `TranscriptStore` owns the durable base and response-scoped optimistic overlays.
- `session.messages` and the mounted DOM are derived projections.
- Mutable stream cursors may point only at transcript-owned optimistic overlays—never durable/projected rows.
- Durable events are authoritative for covered output; optimistic overlays retain only not-yet-durable suffixes.

## Stable identity

Assistant output now carries immutable response-scoped identity:

```text
(response_id, assistant_segment_ordinal)
```

along with segment sequence boundaries and a restart-safe monotonic `run_epoch`. Identity propagates through:

- live SSE and historical replay
- recovery snapshots
- SQLite message persistence
- transcript indexes and bodies
- browser sanitization, optimistic overlays, and projection

Tool calls retain stable call identity scoped to the response. Content is used only after identity matching to validate coverage and compute an uncovered suffix; it is not the primary identity mechanism.

## Replay and idempotency

- Historical replay is staged detached from session, transcript, DOM, and persistence state.
- A complete ordered replay boundary atomically merges uncovered output.
- Interrupted or gapped replay publishes nothing partial.
- Fresh post-replay deltas remain on the O(1) optimistic path.
- Applied and terminal event cursors are tracked per response with bounded history.
- Repeated replay, terminal events, and overlapping transports are idempotent.
- Stale status/snapshot ownership cannot clear or reclaim a newer run epoch.

## Protocol/schema

Adds response/run/segment metadata to response events, recovery snapshots, session state/status, transcript indexes, and transcript bodies.

SQLite migration 42 adds backward-compatible message columns:

```sql
response_id TEXT NOT NULL DEFAULT ''
assistant_segment_ordinal INTEGER NOT NULL DEFAULT -1
segment_start_sequence INTEGER NOT NULL DEFAULT 0
segment_end_sequence INTEGER NOT NULL DEFAULT 0
```

Older rows continue loading with legacy defaults. The compatibility path uses conservative row/run-boundary inference and prefers temporarily preserving ambiguity over cross-matching unrelated repeated content.

## Live verification

Deployed the exact tree from this branch to `wasnotwas.com/chat` and tested an active response through:

- restart during response
- fresh selected-session sideload
- recovery plus historical replay
- fresh post-replay tool events
- transcript advancement
- switch away/back

The final browser projection contained:

- zero duplicate assistant identities
- zero duplicate tool-call identities
- durable covered tools plus one distinct newer optimistic tool group
- correct active response ownership after switch-back

## Tests

Adversarial coverage includes:

- durable-first and optimistic-first arrival
- replay overlap followed by fresh suffix and repeated transcript refresh
- equivalent recovery snapshot after durable sideload
- suffix-only replay
- interrupted/gapped replay
- repeated replay and terminal events
- stale status after newer response creation
- rapid session/response switching
- interjection segment boundaries
- repeated identical assistant content across responses
- overlapping POST and GET streams
- mutable-cursor assertions
- DOM/session/transcript uniqueness and reload equivalence
- SQLite migration and identified-row round trips

Verification passed:

- all 16 Node suites
- isolated `go test ./... -count=1`
- `go test -race ./cmd ./internal/session ./internal/serveui -count=1`
- `go build ./...`
- `git diff --check`

Text-delta benchmark remains ~95 ns/op, 176 B/op, 1 allocation/op.
