### PR TITLE
fix: Shell tracking rereads every previously touched file despite bounded affected_paths

### DIFF
--- a/internal/tools/file_track_test.go
+++ b/internal/tools/file_track_test.go
@@ -18,11 +18,12 @@ import (
 
 // fakeFileRecorder captures ChangeRecords for assertions.
 type fakeFileRecorder struct {
-	mu           sync.Mutex
-	records      []filetrack.ChangeRecord
-	sessionPaths []string
-	seq          int64
-	maxFileBytes int // 0 = filetrack.DefaultMaxFileBytes
+	mu                sync.Mutex
+	records           []filetrack.ChangeRecord
+	sessionPaths      []string
+	sessionPathsCalls int
+	seq               int64
+	maxFileBytes      int // 0 = filetrack.DefaultMaxFileBytes
 }
 
 func (f *fakeFileRecorder) RecordChange(ctx context.Context, rec filetrack.ChangeRecord) *llm.FileChange {
@@ -43,7 +44,16 @@ func (f *fakeFileRecorder) RecordChange(ctx context.Context, rec filetrack.Chang
 }
 
 func (f *fakeFileRecorder) SessionPaths(ctx context.Context, sessionID string) []string {
-	return f.sessionPaths
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sessionPathsCalls++
+	return append([]string(nil), f.sessionPaths...)
+}
+
+func (f *fakeFileRecorder) sessionPathCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sessionPathsCalls
 }
 
 func (f *fakeFileRecorder) MaxFileBytes() int {
@@ -253,6 +263,52 @@ func TestShellToolRecordsAffectedPaths(t *testing.T) {
 	deleted := recorder.findRecord(t, doomed)
 	if !deleted.AfterMissing || string(deleted.Before) != "delete me\n" {
 		t.Fatalf("delete record = %+v", deleted)
+	}
+}
+
+func TestShellToolAffectedPathsSkipSessionTrackedPaths(t *testing.T) {
+	dir := t.TempDir()
+	hinted := filepath.Join(dir, "hinted.txt")
+	if err := os.WriteFile(hinted, []byte("before\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exceed the content-read cap to model a long-running session whose history
+	// would otherwise consume the remaining snapshot budget on every shell call.
+	historical := make([]string, maxShellContentReads+25)
+	for i := range historical {
+		historical[i] = filepath.Join(dir, fmt.Sprintf("historical-%03d.txt", i))
+		if err := os.WriteFile(historical[i], []byte("old\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	recorder := &fakeFileRecorder{sessionPaths: historical}
+	ctx := trackingContext()
+	snap := preShellSnapshot(ctx, recorder, dir, []string{"hinted.txt"})
+
+	if calls := recorder.sessionPathCallCount(); calls != 0 {
+		t.Fatalf("SessionPaths calls = %d, want 0 for bounded affected_paths", calls)
+	}
+	if len(snap.files) != 1 {
+		t.Fatalf("snapshotted files = %d, want only the hinted file", len(snap.files))
+	}
+	if entry, ok := snap.files[hinted]; !ok || string(entry.content) != "before\n" {
+		t.Fatalf("hinted snapshot = %+v, present=%v", entry, ok)
+	}
+
+	if err := os.WriteFile(hinted, []byte("after\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historical[0], []byte("changed but out of scope\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	changes := postShellChanges(ctx, recorder, snap)
+	if len(changes) != 1 || canonicalTestPath(changes[0].Path) != canonicalTestPath(hinted) {
+		t.Fatalf("file changes = %+v, want only hinted file", changes)
+	}
+	if records := recorder.recorded(); len(records) != 1 || canonicalTestPath(records[0].Path) != canonicalTestPath(hinted) {
+		t.Fatalf("records = %+v, want only hinted file", records)
 	}
 }
 

--- a/internal/tools/shell_track.go
+++ b/internal/tools/shell_track.go
@@ -90,10 +90,13 @@ func preShellSnapshot(ctx context.Context, recorder FileChangeRecorder, workDir 
 		snap.gitRoot = repo.Root
 	}
 
-	sessionPaths := recorder.SessionPaths(ctx, sessionID)
-	// When the caller supplied bounded hints, trust that scope and avoid the
-	// repo-wide git status fallback. Commands that omit hints still get the
-	// broader best-effort dirty/untracked detection below.
+	var sessionPaths []string
+	if len(patterns) == 0 {
+		sessionPaths = recorder.SessionPaths(ctx, sessionID)
+	}
+	// When the caller supplied bounded hints, trust that scope and avoid both
+	// historical session paths and the repo-wide git status fallback. Commands
+	// that omit hints still get the broader best-effort detection below.
 	hasBoundedHints := len(patterns) > 0 || len(sessionPaths) > 0
 	if snap.gitRoot != "" && !hasBoundedHints {
 		snap.gitStatus = gitStatusPorcelain(ctx, snap.gitRoot)


### PR DESCRIPTION
## What changed

- Treat non-empty `affected_paths` as the authoritative shell-tracking scope.
- Skip the `SessionPaths` lookup and historical-path append when bounded hints are present.
- Preserve the existing session-path and Git-status fallbacks for shell calls without hints.
- Add a regression test with 225 historical session files that verifies only the hinted file is snapshotted and recorded, and that `SessionPaths` is never queried.

## Why this is high-value

Shell tracking runs synchronously before and after every shell command. Previously, even a one-file `affected_paths` hint caused every file accumulated over a long-lived session to be statted and potentially read again. The per-call caps limited the damage but still allowed up to 200 content reads and 64 MiB of snapshot traffic, plus a second pass over historical candidates after command execution.

Trusting the already-documented bounded hints changes this work from O(session history) to O(declared scope), eliminating repeated database lookup, file I/O, and content-buffer allocation on Sam/Jarvis's frequent shell-tool path while retaining best-effort broad tracking when hints are absent.

## Validation

- `gofmt -w internal/tools/shell_track.go internal/tools/file_track_test.go`
- `go build ./...`
- `go test ./internal/tools -run 'TestShellTool(AffectedPathsSkipSessionTrackedPaths|RecordsSessionTrackedPaths|RecordsAffectedPaths)$' -count=1`
- `go test ./internal/tools -run TestShellToolAffectedPathsSkipSessionTrackedPaths -count=10`
- Full `go test ./...` passed with an isolated `HOME`, `XDG_CONFIG_HOME`, and `CODEX_HOME` so host-global skills could not displace test fixtures.
- `git diff --check`
