### PR TITLE
fix: Transcript scans monopolize the sole session database connection

### DIFF
--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -22,6 +22,7 @@ import (
 // SQLiteStore implements Store using SQLite.
 type SQLiteStore struct {
 	db                       *sql.DB
+	readDB                   *sql.DB
 	cfg                      Config
 	hasGeneratedTitles       bool // true if sessions table has generated title columns
 	hasCompactionSeq         bool // true if sessions table has compaction_seq column
@@ -268,6 +269,26 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 			// Log but don't fail
 			fmt.Fprintf(os.Stderr, "warning: session cleanup failed: %v\n", err)
 		}
+	}
+
+	// File-backed WAL databases can serve reads while the single writer is
+	// active. Keep transcript scans on one dedicated read-only connection so
+	// decoding long tool-heavy histories cannot occupy the writer connection.
+	if dbPath != ":memory:" && !cfg.ReadOnly {
+		readDSN := "file:" + filepath.ToSlash(dbPath) + "?mode=ro&_pragma=query_only(1)&_pragma=busy_timeout(5000)&_pragma=mmap_size(134217728)"
+		readDB, err := sql.Open("sqlite", readDSN)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("open transcript read database: %w", err)
+		}
+		readDB.SetMaxOpenConns(1)
+		readDB.SetMaxIdleConns(1)
+		if err := readDB.Ping(); err != nil {
+			readDB.Close()
+			db.Close()
+			return nil, fmt.Errorf("connect transcript read database: %w", err)
+		}
+		store.readDB = readDB
 	}
 
 	return store, nil
@@ -3320,10 +3341,17 @@ func transcriptRowHasDisplayBody(role llm.Role, parts []llm.Part, planToolCalls 
 	return false
 }
 
+func (s *SQLiteStore) transcriptReadDB() *sql.DB {
+	if s.readDB != nil {
+		return s.readDB
+	}
+	return s.db
+}
+
 // GetTranscriptSnapshot returns the complete transcript envelope from one
 // SQLite read transaction.
 func (s *SQLiteStore) GetTranscriptSnapshot(ctx context.Context, sessionID string) (TranscriptSnapshot, error) {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	tx, err := s.transcriptReadDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return TranscriptSnapshot{}, fmt.Errorf("begin transcript index read: %w", err)
 	}
@@ -3422,7 +3450,7 @@ func (s *SQLiteStore) GetTranscriptIndex(ctx context.Context, sessionID string) 
 // durable rows it expands to, so a giant tool turn never approaches SQLite's
 // variable limit.
 func (s *SQLiteStore) GetMessagesByTranscriptRanges(ctx context.Context, sessionID string, ranges []TranscriptRange) (int64, []Message, error) {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	tx, err := s.transcriptReadDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return 0, nil, fmt.Errorf("begin transcript bodies read: %w", err)
 	}
@@ -3867,9 +3895,13 @@ func (s *SQLiteStore) ListPushSubscriptions(ctx context.Context) ([]PushSubscrip
 	return subs, rows.Err()
 }
 
-// Close closes the database connection.
+// Close closes the database connections.
 func (s *SQLiteStore) Close() error {
-	return s.db.Close()
+	var readErr error
+	if s.readDB != nil {
+		readErr = s.readDB.Close()
+	}
+	return errors.Join(readErr, s.db.Close())
 }
 
 // setCurrentColumns records optional columns that are guaranteed to exist after

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -255,6 +255,9 @@ func TestNewSQLiteStoreMemoryDBUsesSingleConnection(t *testing.T) {
 	if got := store.db.Stats().MaxOpenConnections; got != 1 {
 		t.Fatalf("MaxOpenConnections = %d, want 1 for :memory: databases", got)
 	}
+	if store.readDB != nil {
+		t.Fatal(":memory: database unexpectedly has a separate read connection")
+	}
 }
 
 func TestNewSQLiteStoreFileDBUsesSingleConnection(t *testing.T) {
@@ -266,6 +269,42 @@ func TestNewSQLiteStoreFileDBUsesSingleConnection(t *testing.T) {
 
 	if got := store.db.Stats().MaxOpenConnections; got != 1 {
 		t.Fatalf("MaxOpenConnections = %d, want 1 for file-backed databases", got)
+	}
+	if store.readDB == nil {
+		t.Fatal("file-backed database has no transcript read connection")
+	}
+	if got := store.readDB.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("read MaxOpenConnections = %d, want 1 for file-backed databases", got)
+	}
+}
+
+func TestSQLiteStoreTranscriptReadDoesNotOccupyWriterConnection(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	readTx, err := store.transcriptReadDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("begin transcript read: %v", err)
+	}
+	defer readTx.Rollback()
+	var id string
+	if err := readTx.QueryRowContext(ctx, "SELECT id FROM sessions WHERE id = ?", sess.ID).Scan(&id); err != nil {
+		t.Fatalf("establish transcript snapshot: %v", err)
+	}
+
+	writeCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	if err := store.AddMessage(writeCtx, sess.ID, NewMessage(sess.ID, llm.UserText("concurrent write"), -1)); err != nil {
+		t.Fatalf("AddMessage while transcript read is open: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Keep the existing single pooled writer connection for SQLite session mutations.
- Open one separately pooled, read-only connection for normal file-backed WAL stores.
- Route `GetTranscriptSnapshot` and `GetMessagesByTranscriptRanges` through that reader while preserving the single-connection fallback for `:memory:` and read-only stores.
- Close both handles with the store.
- Add an integration test that holds a transcript read transaction open and verifies `AddMessage` still completes through the writer within a one-second deadline.

## Why this is high-value

Transcript snapshot and range reads scan and decode complete message-part JSON while their read transaction remains open. Large, tool-heavy sessions therefore occupied the store's only pooled connection and forced unrelated persistence callbacks to wait before they could even begin a write transaction. In ordinary web, Telegram, and scheduled-job use, that head-of-line blocking can consume bounded persistence deadlines and delay or lose best-effort streaming checkpoints.

File-backed databases already use WAL, so one read-only connection can scan a coherent snapshot concurrently with the serialized writer. This removes connection-pool wait time for writes without adding concurrent writers, and caps the reader at one connection to bound SQLite cache and connection overhead. Raw `:memory:` stores retain their required single connection.

## Validation

- `gofmt -w internal/session/sqlite.go internal/session/sqlite_test.go`
- `go build ./...`
- Targeted SQLite connection and overlap tests pass.
- `go test ./...` passes with an isolated HOME/XDG config (preventing locally installed Jarvis skills from contaminating cmd skill-discovery fixtures).
- `git diff --check`
