### PR TITLE
fix: retire stale persisted response overlays

### DIFF
--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -5544,6 +5544,213 @@ async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalR
   pass(name);
 }
 
+async function testReloadRetiresStalePersistedAssistantIdentityAfterTerminalAdvance() {
+  const name = 'reload retires stale version-1 assistant identity after terminal transcript advance';
+  const sessionId = 'stale-persisted-assistant';
+  const storageKey = 'term_llm_optimistic_transcript';
+  const responseId = 'resp_stale_persisted';
+  const persisted = JSON.stringify({
+    version: 1,
+    sessions: {
+      [sessionId]: [
+        {
+          id: 'stale-assistant',
+          clientKey: `${responseId}:assistant:99`,
+          role: 'assistant',
+          responseId,
+          assistantSegmentOrdinal: 99,
+          content: 'durable answer',
+          revAtSend: 1,
+          durableSeqAtSend: 1,
+          optimistic: true
+        },
+        {
+          id: 'pending-user',
+          clientKey: 'pending-user',
+          role: 'user',
+          content: 'send me next',
+          revAtSend: 2,
+          durableSeqAtSend: 2,
+          optimistic: true
+        }
+      ]
+    }
+  });
+  const durable = [
+    { id: 1, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+    {
+      id: 2,
+      sequence: 2,
+      role: 'assistant',
+      response_id: responseId,
+      assistant_segment_ordinal: 0,
+      parts: [{ type: 'text', text: 'durable answer' }]
+    }
+  ];
+  const { app, storage } = await createSessionsHarness({
+    initialStorage: { [storageKey]: persisted },
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        return new Response(JSON.stringify({
+          rev: 2,
+          compaction_seq: -1,
+          compaction_count: 0,
+          rows: {
+            ids: [1, 2],
+            seqs: [1, 2],
+            roles: 'ua',
+            flags: [0, 0],
+            response_ids: ['', responseId],
+            assistant_segment_ordinals: [-1, 0]
+          }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"stale-assistant-rev-2"' } });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        return new Response(JSON.stringify({ rev: 2, messages: durable }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+
+  const loaded = await app.syncTranscript(session, { reason: 'reload' });
+  const assistants = session.messages.filter((message) => message.role === 'assistant');
+  if (!loaded || assistants.length !== 1 || assistants[0].durable !== true) {
+    fail(name, 'reload retained the stale assistant overlay beside authoritative durable output', JSON.stringify(session.messages));
+    return;
+  }
+  if (JSON.stringify(session.transcript.optimistic.map((entry) => entry.clientKey)) !== JSON.stringify(['pending-user'])) {
+    fail(name, 'terminal retirement did not preserve only the genuinely pending user', JSON.stringify(session.transcript.optimistic));
+    return;
+  }
+  const saved = JSON.parse(storage.get(storageKey) || 'null');
+  const savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['pending-user'])) {
+    fail(name, 'stale assistant retirement was not persisted', JSON.stringify(saved));
+    return;
+  }
+  pass(name);
+}
+
+async function testReloadScopesStalePersistedRetirementToCurrentActiveResponse() {
+  const name = 'reload retires stale old response output under a different active response';
+  const sessionId = 'stale-persisted-active-response';
+  const storageKey = 'term_llm_optimistic_transcript';
+  const staleResponseId = 'resp_stale_persisted';
+  const activeResponseId = 'resp_current_active';
+  const entries = [
+    {
+      id: 'stale-assistant', clientKey: `${staleResponseId}:assistant:99`, role: 'assistant',
+      responseId: staleResponseId, assistantSegmentOrdinal: 99, content: 'stale persisted output',
+      revAtSend: 1, durableSeqAtSend: 1, optimistic: true
+    },
+    {
+      id: 'stale-tool', clientKey: `${staleResponseId}:tool:call-stale`, role: 'tool-group',
+      responseId: staleResponseId, status: 'running', tools: [{ id: 'call-stale', status: 'running' }],
+      revAtSend: 1, durableSeqAtSend: 1, optimistic: true
+    },
+    {
+      id: 'legacy-ownerless', clientKey: 'legacy-ownerless', role: 'assistant', content: 'legacy recovery output',
+      revAtSend: 1, durableSeqAtSend: 2, optimistic: true
+    },
+    {
+      id: 'current-assistant', clientKey: `${activeResponseId}:assistant:0`, role: 'assistant',
+      responseId: activeResponseId, assistantSegmentOrdinal: 0, content: 'current response suffix',
+      revAtSend: 1, durableSeqAtSend: 2, optimistic: true
+    },
+    {
+      id: 'current-tool', clientKey: `${activeResponseId}:tool:call-current`, role: 'tool-group',
+      responseId: activeResponseId, status: 'running', tools: [{ id: 'call-current', status: 'running' }],
+      revAtSend: 1, durableSeqAtSend: 2, optimistic: true
+    },
+    {
+      id: 'pending-user', clientKey: 'pending-user', role: 'user', content: 'send me next',
+      revAtSend: 2, durableSeqAtSend: 2, optimistic: true
+    }
+  ];
+  const durable = [
+    { id: 1, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+    {
+      id: 2, sequence: 2, role: 'assistant', response_id: staleResponseId, assistant_segment_ordinal: 0,
+      parts: [{ type: 'text', text: 'stale persisted output' }]
+    }
+  ];
+  const { app, storage } = await createSessionsHarness({
+    initialStorage: {
+      [storageKey]: JSON.stringify({ version: 1, sessions: { [sessionId]: entries } })
+    },
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        return new Response(JSON.stringify({
+          rev: 2,
+          compaction_seq: -1,
+          compaction_count: 0,
+          active_response_id: activeResponseId,
+          started_rev: 1,
+          run_epoch: 2,
+          rows: {
+            ids: [1, 2],
+            seqs: [1, 2],
+            roles: 'ua',
+            flags: [0, 0],
+            response_ids: ['', staleResponseId],
+            assistant_segment_ordinals: [-1, 0]
+          }
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"stale-active-rev-2"' } });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        return new Response(JSON.stringify({ rev: 2, messages: durable }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+
+  const loaded = await app.syncTranscript(session, { reason: 'reload' });
+  const expectedKeys = [
+    'legacy-ownerless',
+    `${activeResponseId}:assistant:0`,
+    `${activeResponseId}:tool:call-current`,
+    'pending-user'
+  ];
+  const optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
+  if (!loaded || session.transcript.activeRun?.id !== activeResponseId
+      || JSON.stringify(optimisticKeys) !== JSON.stringify(expectedKeys)) {
+    fail(name, 'active response authority retained stale foreign output or dropped protected entries', JSON.stringify({
+      activeRun: session.transcript.activeRun,
+      optimisticKeys
+    }));
+    return;
+  }
+  const saved = JSON.parse(storage.get(storageKey) || 'null');
+  const savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(expectedKeys)) {
+    fail(name, 'response-scoped stale retirement was not persisted', JSON.stringify(saved));
+    return;
+  }
+  pass(name);
+}
+
 async function testGroupedToolRowsPreserveDurableRangesAndLaterAnchors() {
   const name = 'grouped tool conversion preserves source range and later durable anchors';
   const { app, windowObj } = await createSessionsHarness();
@@ -6469,6 +6676,8 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
   await testSessionPruningDestroysTranscriptStores();
   await testOptimisticTranscriptStorageIsPerSession();
   await testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalReconciliation();
+  await testReloadRetiresStalePersistedAssistantIdentityAfterTerminalAdvance();
+  await testReloadScopesStalePersistedRetirementToCurrentActiveResponse();
   await testTranscriptSyncCommitsOneRenderedProjection();
   await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
   await testInflightSyncAbsorbsQueuedZeroRevisionActivation();

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -942,8 +942,18 @@
 
       for (const local of this.optimistic) {
         const localIsTool = local.role === 'tool-group' || local.role === 'tool';
+        const outputOwner = messageResponseID(local);
+        // An active response is authoritative only for output with the same
+        // stable owner. Legacy ownerless output remains protected because its
+        // response scope cannot be established safely.
+        const activeRunOwnsOutput = Boolean(this.activeRun)
+          && (!outputOwner || this.activeRun.id === outputOwner);
+        const serverOwnsPersistedOutput = !activeRunOwnsOutput
+          && this.persistedOptimistic.has(local)
+          && (local.role === 'assistant' || localIsTool)
+          && this.rev > finiteInt(local.revAtSend, this.rev);
         if (localIsTool) {
-          const owner = messageResponseID(local);
+          const owner = outputOwner;
           const localKeys = new Map([...messageToolIDs(local)].map((id) => [toolIdentityKey(owner, id), id]));
           const uncovered = new Set([...localKeys.entries()].filter(([key, id]) => (
             key
@@ -988,7 +998,8 @@
               // A covered live overlay remains the sole mutable cursor until the
               // response finalizes; fresh deltas must never target its durable projection.
               kept.push(local);
-            } else if (comparison.suffix) kept.push(local);
+            } else if (serverOwnsPersistedOutput) removed.push(local);
+            else if (comparison.suffix) kept.push(local);
             else removed.push(local);
             continue;
           }
@@ -996,11 +1007,20 @@
             const legacyPart = durableAssistantParts.find((candidate) => candidate.sequence > finiteInt(local.durableSeqAtSend, -1));
             if (legacyPart) {
               const comparison = assistantSuffixAfterDurable(legacyPart.content, assistantSourceContent(local));
-              if (comparison.suffix) kept.push(local);
+              if (comparison.suffix && !serverOwnsPersistedOutput) kept.push(local);
               else removed.push(local);
               continue;
             }
           }
+        }
+
+        if (serverOwnsPersistedOutput) {
+          // Persisted assistant/tool overlays are recovery shadows, not durable
+          // client intent. Once the transcript advances beyond their captured
+          // revision and no active response owns them, the durable transcript
+          // owns the response tail even if an old stable identity never matched.
+          removed.push(local);
+          continue;
         }
 
         const afterSeq = finiteInt(local.durableSeqAtSend, -1);

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -537,13 +537,13 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   terminalTools.setActiveRun('', 0);
   assert.deepEqual(
     terminalTools.reconcileOptimistic().map((entry) => entry.clientKey),
-    ['completed-tool-tail', 'completed-standalone-tool'],
-    'an authoritative terminal revision must retire unmatched completed tool UI'
+    ['completed-tool-tail', 'completed-standalone-tool', 'running-tool'],
+    'an authoritative terminal revision must retire every unmatched persisted tool overlay'
   );
   assert.deepEqual(
     terminalTools.optimistic.map((entry) => entry.clientKey),
-    ['queued-user', 'running-tool'],
-    'queued user messages and running tools must survive terminal tool cleanup'
+    ['queued-user'],
+    'queued user messages must survive terminal server-owned output cleanup'
   );
 
   const displayOnly = new TranscriptStore('display-only');
@@ -696,6 +696,111 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   assert.equal(reloaded.renderedMessages()[0].response_id, responseId, 'reload preserves durable response-scoped identity');
   store._checkInvariants();
   reloaded._checkInvariants();
+})();
+
+(() => {
+  const responseId = 'resp_stale_persisted_output';
+  const stalePersisted = new TranscriptStore('stale-persisted-output');
+  const staleMatchedSuffix = stalePersisted.addOptimistic({
+    id: 'stale-matched-suffix', role: 'assistant', responseId, assistantSegmentOrdinal: 0,
+    content: 'prefix suffix ghost', revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const staleAssistant = stalePersisted.addOptimistic({
+    id: 'stale-assistant', role: 'assistant', responseId, assistantSegmentOrdinal: 99,
+    content: 'prefix suffix', revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const staleLegacyAssistant = stalePersisted.addOptimistic({
+    id: 'stale-legacy-assistant', role: 'assistant', content: 'prefix suffix ghost',
+    revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const staleTool = stalePersisted.addOptimistic({
+    id: 'stale-tool', role: 'tool-group', responseId, status: 'running',
+    tools: [{ id: 'call-stale', status: 'running' }], revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const pendingUser = stalePersisted.addOptimistic({
+    id: 'pending-user', role: 'user', content: 'still pending', revAtSend: 2, durableSeqAtSend: 2,
+  }, 2, { persisted: true });
+  stalePersisted.applyIndex({
+    rev: 2,
+    rows: {
+      ids: [1, 2], seqs: [1, 2], roles: 'ua', flags: [0, 0],
+      response_ids: ['', responseId], assistant_segment_ordinals: [-1, 0],
+    },
+  });
+  stalePersisted.materialize([
+    { id: 1, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+    {
+      id: 2, sequence: 2, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+      parts: [{ type: 'text', text: 'prefix suffix' }],
+    },
+  ]);
+  assert.deepEqual(
+    stalePersisted.reconcileOptimistic(),
+    [staleMatchedSuffix, staleAssistant, staleLegacyAssistant, staleTool],
+    'terminal authoritative advancement retires persisted server-owned output whether its stable identity matches or is stale'
+  );
+  assert.deepEqual(stalePersisted.optimistic, [pendingUser], 'terminal retirement preserves genuinely pending user input');
+
+  const currentResponseId = 'resp_current_active';
+  const activePersisted = new TranscriptStore('active-persisted-output');
+  const staleMatchedActive = activePersisted.addOptimistic({
+    id: 'stale-matched-active', role: 'assistant', responseId, assistantSegmentOrdinal: 0,
+    content: 'prefix suffix ghost', revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const staleAssistantActive = activePersisted.addOptimistic({
+    id: 'stale-assistant-active', role: 'assistant', responseId, assistantSegmentOrdinal: 99,
+    content: 'stale persisted output', revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const staleToolActive = activePersisted.addOptimistic({
+    id: 'stale-tool-active', role: 'tool-group', responseId, status: 'running',
+    tools: [{ id: 'call-stale-active', status: 'running' }], revAtSend: 1, durableSeqAtSend: 1,
+  }, 1, { persisted: true });
+  const legacyOwnerless = activePersisted.addOptimistic({
+    id: 'legacy-ownerless-active', role: 'assistant', content: 'legacy recovery output',
+    revAtSend: 1, durableSeqAtSend: 2,
+  }, 1, { persisted: true });
+  activePersisted.setActiveRun(currentResponseId, 1, 2);
+  const activeSuffix = activePersisted.addOptimistic({
+    id: 'active-suffix', role: 'assistant', responseId: currentResponseId, assistantSegmentOrdinal: 0,
+    content: 'active suffix', revAtSend: 1, durableSeqAtSend: 2,
+  }, 1, { persisted: true });
+  const activeTool = activePersisted.addOptimistic({
+    id: 'active-tool', role: 'tool-group', responseId: currentResponseId, status: 'running',
+    tools: [{ id: 'call-current', status: 'running' }], revAtSend: 1, durableSeqAtSend: 2,
+  }, 1, { persisted: true });
+  const activePendingUser = activePersisted.addOptimistic({
+    id: 'active-pending-user', role: 'user', content: 'still pending', revAtSend: 2, durableSeqAtSend: 2,
+  }, 2, { persisted: true });
+  activePersisted.applyIndex({
+    rev: 2,
+    active_response_id: currentResponseId,
+    rows: {
+      ids: [1, 2], seqs: [1, 2], roles: 'ua', flags: [0, 0],
+      response_ids: ['', responseId], assistant_segment_ordinals: [-1, 0],
+    },
+  });
+  activePersisted.materialize([
+    { id: 1, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+    {
+      id: 2, sequence: 2, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+      parts: [{ type: 'text', text: 'prefix suffix' }],
+    },
+  ]);
+  assert.deepEqual(
+    activePersisted.reconcileOptimistic(),
+    [staleMatchedActive, staleAssistantActive, staleToolActive],
+    'a different active response must not protect stale persisted output with a stable old owner'
+  );
+  assert.deepEqual(
+    activePersisted.optimistic,
+    [legacyOwnerless, activeSuffix, activeTool, activePendingUser],
+    'active reconciliation preserves ownerless recovery output, the current response suffix/tools, and pending user input'
+  );
+
+  stalePersisted._checkInvariants();
+  activePersisted._checkInvariants();
+  stalePersisted.destroy();
+  activePersisted.destroy();
 })();
 
 console.log('transcript-store tests passed');


### PR DESCRIPTION
## What

Retire stale browser-persisted assistant and tool overlays once the durable transcript has advanced beyond their captured revision and no active response owns them.

This fixes completed response output from `term_llm_optimistic_transcript` reappearing beside durable `srv_seq_*` rows after reload.

## Reproduction

Production `/chat/3377` did not duplicate in the clean shared browser. Injecting a version-1 persisted assistant overlay with an obsolete stable identity reproduced the reported browser-specific failure exactly:

```text
srv_seq_15_text_0   durable
msg_stale_repro     optimistic
same assistant output
```

The stale overlay had a valid-looking response ID but obsolete segment ordinal, so identity reconciliation found no durable match and retained it indefinitely.

A first fix also exposed a second ownership error during live testing: a newer active response protected stale output belonging to an older response. Active ownership is now response-scoped rather than session-scoped.

## Ownership rule

Persisted assistant/tool entries are recovery shadows, not durable client intent. The durable transcript owns them when:

- its revision has advanced beyond `revAtSend`; and
- no active run owns that entry's stable response ID.

The rule deliberately preserves:

- pending optimistic user messages;
- assistant/tool overlays owned by the current active response;
- legacy ownerless output while an active run makes its response scope ambiguous.

It does not use content equality or presentation-layer hiding.

## Live verification

Deployed commit `9678b6cd` and repeated the stale-storage reload test while `/chat/3377` had a different active response.

Result:

```json
{
  "duplicates": [],
  "optimistic": [
    "current-response:assistant:0",
    "current-response:tool:read_file"
  ]
}
```

The injected old-response overlay was removed from both the transcript projection and localStorage; the genuinely current assistant/tool overlays remained.

## Tests

Regression coverage includes:

- version-1 localStorage reload with stale assistant ordinal `99`;
- stale old response while a different response is active;
- matched, mismatched, and legacy persisted assistant identities;
- persisted running/completed tool output;
- persistence cleanup after reconciliation;
- pending user preservation;
- active-response assistant/tool suffix preservation.

Verification passed:

- TranscriptStore Node suite
- app-sessions Node suite
- focused Go JS wrappers
- isolated `go test ./... -count=1`
- `go build ./...`
- `git diff --check`
