### PR TITLE
fix: project one compaction boundary

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1240,10 +1240,7 @@ const refreshSessionMessagesFromTranscript = (session) => {
         ? { ...entry, transcriptEmptyBody: true }
         : entry);
     }
-    const converted = convertServerMessages(raw, {
-      compactionSeq: transcript.compactionSeq,
-      compactionCount: transcript.compactionCount
-    });
+    const converted = convertServerMessages(raw);
     const claimedAnchors = new Set();
     converted.forEach((message) => {
       const sourceIDs = Array.isArray(message.durableSourceRowIds)
@@ -1263,6 +1260,10 @@ const refreshSessionMessagesFromTranscript = (session) => {
       });
     });
   }
+  annotateCompactionBoundary(display, {
+    compactionSeq: transcript.compactionSeq,
+    compactionCount: transcript.compactionCount
+  });
   display.push(...transcript.optimistic);
   session.messages = display;
   // Every durable/optimistic handoff is committed through the same projected

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -5751,6 +5751,45 @@ async function testReloadScopesStalePersistedRetirementToCurrentActiveResponse()
   pass(name);
 }
 
+async function testTranscriptProjectionAnnotatesCompactionBoundaryOnceAcrossSegments() {
+  const name = 'transcript projection annotates one compaction boundary across materialized segments';
+  const { app, windowObj } = await createSessionsHarness();
+  const raw = [
+    { id: 101, sequence: 11, role: 'user', created_at: 1100, parts: [{ type: 'text', text: 'first prompt' }] },
+    { id: 102, sequence: 12, role: 'assistant', created_at: 1200, parts: [{ type: 'text', text: 'first answer' }] },
+    { id: 103, sequence: 13, role: 'user', created_at: 1300, parts: [{ type: 'text', text: 'second prompt' }] },
+    { id: 104, sequence: 14, role: 'assistant', created_at: 1400, parts: [{ type: 'text', text: 'second answer' }] },
+  ];
+  const session = { id: 'single-compaction-boundary', messages: [] };
+  session.transcript = new windowObj.TranscriptStore(session.id);
+  session.transcript.applyIndex({
+    rev: 4,
+    compaction_seq: 10,
+    compaction_count: 1,
+    rows: { ids: [101, 102, 103, 104], seqs: [11, 12, 13, 14], roles: 'uaua', flags: [0, 0, 0, 0] }
+  });
+  session.transcript.materialize(raw);
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  if (session.transcript.renderRuns().filter((run) => run.type === 'segment').length < 2) {
+    fail(name, 'regression fixture did not produce multiple materialized transcript segments');
+    return;
+  }
+  app.refreshSessionMessagesFromTranscript(session);
+  const boundaries = session.messages.filter((message) => message.role === 'compaction-boundary');
+  if (boundaries.length !== 1 || boundaries[0].id !== 'compaction_boundary_10') {
+    fail(name, 'global compaction metadata produced one marker per materialized segment', JSON.stringify(session.messages));
+    return;
+  }
+  if (session.messages[0] !== boundaries[0] || session.messages[1]?.content !== 'first prompt') {
+    fail(name, 'single marker was not placed at the first visible post-compaction message', JSON.stringify(session.messages));
+    return;
+  }
+  pass(name);
+}
+
 async function testGroupedToolRowsPreserveDurableRangesAndLaterAnchors() {
   const name = 'grouped tool conversion preserves source range and later durable anchors';
   const { app, windowObj } = await createSessionsHarness();
@@ -6682,6 +6721,7 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
   await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
   await testInflightSyncAbsorbsQueuedZeroRevisionActivation();
   await testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh();
+  await testTranscriptProjectionAnnotatesCompactionBoundaryOnceAcrossSegments();
   await testGroupedToolRowsPreserveDurableRangesAndLaterAnchors();
   await testLargeToolTurnLoadsAsOneSegmentWithFarEndGrouping();
   await testTerminalTranscriptSyncQueuesBehindInflightRequest();


### PR DESCRIPTION
## What

Project the active context-compaction boundary once after assembling the complete durable transcript projection, rather than once per materialized transcript segment.

## Why

`refreshSessionMessagesFromTranscript()` converts each materialized turn independently. It previously passed the transcript's global `compaction_seq` into every conversion, causing each post-compaction segment to synthesize the same marker:

```text
srv_seq_544                 compaction
compaction_boundary_544     synthetic
compaction_boundary_544     synthetic
compaction_boundary_544     synthetic
compaction_boundary_544     synthetic
```

This was reproducible after a clean reload in the shared browser, so it was not localStorage corruption.

## Fix

- Keep per-segment server-message conversion and compaction-tail suppression unchanged.
- Stop annotating global compaction metadata inside each segment conversion.
- Annotate the assembled durable display projection once, before optimistic output is appended.

This preserves both cases:

- the real durable compaction marker is tagged as the active boundary when loaded;
- one synthetic boundary is inserted before the first visible post-compaction message when the real marker is outside the loaded window.

## Live verification

Deployed the fix and clean-reloaded session `/chat/3347` with multiple materialized post-compaction segments.

Observed projection:

```json
{
  "boundaries": [
    {
      "id": "srv_seq_544",
      "role": "compaction",
      "activeBoundary": true,
      "seq": 544
    }
  ],
  "assistantDuplicates": [],
  "toolDuplicates": []
}
```

Exactly one boundary remained.

## Tests

Added a regression that builds multiple materialized transcript segments after a global compaction sequence and asserts:

- exactly one `compaction_boundary_10` marker;
- it appears before the first visible post-compaction message.

Verification passed:

- complete app-sessions Node suite
- isolated `go test ./... -count=1`
- `go build ./...`
- `git diff --check`
