### PR TITLE
fix: persist only client-owned transcript intent

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1033,13 +1033,36 @@ const TRANSCRIPT_OPTIMISTIC_LIMIT = 256;
 const TRANSCRIPT_EMPTY_BODY_FLAG = Number(window.TRANSCRIPT_FLAG_EMPTY_BODY || 2);
 const findSessionById = (sessionId) => state.sessions.find((item) => item?.id === sessionId) || null;
 
+// Version 2 restricts local persistence to client-owned intent. Version 1 (and
+// the unversioned legacy shape) also stored assistant/tool recovery shadows,
+// which could shadow durable rows after a reload. Migration keeps pending user
+// intent and drops every server-produced projection.
+const TRANSCRIPT_OPTIMISTIC_VERSION = 2;
+
+const isClientOwnedIntentEntry = (entry) => (
+  window.transcriptIsClientOwnedIntent?.(entry) === true
+);
+
+const migrateTranscriptOptimisticSessions = (sessions) => {
+  const migrated = {};
+  for (const [sessionId, entries] of Object.entries(sessions || {})) {
+    if (!Array.isArray(entries)) continue;
+    const intent = entries.filter(isClientOwnedIntentEntry);
+    if (intent.length > 0) migrated[sessionId] = intent;
+  }
+  return migrated;
+};
+
 const readTranscriptOptimisticRegistry = () => {
   try {
     const saved = JSON.parse(localStorage.getItem(STORAGE_KEYS.optimisticTranscript) || 'null');
-    if (saved?.sessions && typeof saved.sessions === 'object') return saved.sessions;
-    if (saved?.sessionId && Array.isArray(saved.entries)) {
-      return { [saved.sessionId]: saved.entries };
-    }
+    const sessions = saved?.sessions && typeof saved.sessions === 'object'
+      ? saved.sessions
+      : (saved?.sessionId && Array.isArray(saved.entries) ? { [saved.sessionId]: saved.entries } : null);
+    if (!sessions) return {};
+    // Every payload is filtered, not just older versions: a downgraded tab or a
+    // hand-edited value must never be able to reintroduce assistant/tool output.
+    return migrateTranscriptOptimisticSessions(sessions);
   } catch {
     // Optimistic recovery is best-effort; durable transcript bodies never live here.
   }
@@ -1055,7 +1078,10 @@ const rekeyTranscriptOptimisticStorage = (previousId, nextId) => {
     const unique = new Map(merged.map((entry) => [String(entry?.clientKey || entry?.id || ''), entry]));
     sessions[nextId] = [...unique.values()].slice(-TRANSCRIPT_OPTIMISTIC_LIMIT);
     delete sessions[previousId];
-    localStorage.setItem(STORAGE_KEYS.optimisticTranscript, JSON.stringify({ version: 1, sessions }));
+    localStorage.setItem(
+      STORAGE_KEYS.optimisticTranscript,
+      JSON.stringify({ version: TRANSCRIPT_OPTIMISTIC_VERSION, sessions })
+    );
   } catch {
     // Identity reconciliation must succeed even when storage is unavailable.
   }
@@ -1067,9 +1093,14 @@ const ensureSessionTranscript = (session) => {
     session.transcript = new window.TranscriptStore(session.id);
     const saved = readTranscriptOptimisticRegistry()[session.id];
     if (Array.isArray(saved)) {
-      saved.slice(-TRANSCRIPT_OPTIMISTIC_LIMIT).forEach((entry) => {
-        session.transcript.addOptimistic(entry, entry.revAtSend, { persisted: true });
-      });
+      // Storage is the one place a projection could re-enter the store after a
+      // reload, so hydration admits client-owned intent only. Assistant and tool
+      // output is never restored here; it comes back from the server.
+      saved
+        .slice(-TRANSCRIPT_OPTIMISTIC_LIMIT)
+        .forEach((entry) => {
+          session.transcript.addOptimistic(entry, entry.revAtSend);
+        });
     }
   }
   return session.transcript;
@@ -1080,8 +1111,11 @@ const persistTranscriptOptimistic = (session) => {
   if (!session?.id) return;
   try {
     const sessions = readTranscriptOptimisticRegistry();
+    // Only client-owned intent is durable across a reload. Assistant and tool
+    // overlays stay in memory for the life of the page and are rebuilt from the
+    // durable transcript plus response replay/snapshot recovery.
     const entries = transcript?.optimistic
-      ?.filter((entry) => !entry?.transient)
+      ?.filter((entry) => !entry?.transient && isClientOwnedIntentEntry(entry))
       .slice(-TRANSCRIPT_OPTIMISTIC_LIMIT)
       .map((entry) => ({ ...entry, optimistic: true })) || [];
     if (entries.length > 0) sessions[session.id] = entries;
@@ -1090,7 +1124,10 @@ const persistTranscriptOptimistic = (session) => {
       localStorage.removeItem(STORAGE_KEYS.optimisticTranscript);
       return;
     }
-    localStorage.setItem(STORAGE_KEYS.optimisticTranscript, JSON.stringify({ version: 1, sessions }));
+    localStorage.setItem(
+      STORAGE_KEYS.optimisticTranscript,
+      JSON.stringify({ version: TRANSCRIPT_OPTIMISTIC_VERSION, sessions })
+    );
   } catch {
     // Storage pressure must not interrupt a response.
   }
@@ -1342,9 +1379,6 @@ const transcriptSyncSegmentIndexes = (transcript) => {
   if (!transcript) return [];
   const wanted = new Set(transcript.pinnedSegments);
   if (transcript.segments.length > 0) wanted.add(transcript.segments.length - 1);
-  for (const index of transcript.persistedOptimisticSegmentIndexes?.(TRANSCRIPT_MATERIALIZE_BATCH_TURNS) || []) {
-    wanted.add(index);
-  }
   return [...wanted];
 };
 
@@ -1438,14 +1472,11 @@ const syncTranscriptOnce = async (session, options = {}) => {
   if (resp.status === 404) {
     const pages = await fetchLegacyTranscriptPages(session.id);
     if (!pages) return false;
-    const optimistic = transcript.optimistic.map((entry) => ({
-      entry: { ...entry },
-      persisted: transcript.persistedOptimistic?.has?.(entry) === true
-    }));
+    const optimistic = transcript.optimistic.map((entry) => ({ ...entry }));
     const activeRun = transcript.activeRun ? { ...transcript.activeRun } : null;
     const replacement = window.transcriptStoreFromMessages(session.id, pages);
     for (const local of optimistic) {
-      replacement.addOptimistic(local.entry, local.entry.revAtSend, { persisted: local.persisted });
+      replacement.addOptimistic(local, local.revAtSend);
     }
     if (activeRun) replacement.setActiveRun(activeRun.id, activeRun.startedRev, activeRun.epoch || 0);
     replacement.reconcileOptimistic();
@@ -2118,9 +2149,7 @@ const applySelectedTranscriptSideload = (session, sideload, options = {}) => {
       staging.setViewport(last, last, { deferBudget: true });
     }
     for (const optimistic of current.optimistic || []) {
-      staging.addOptimistic({ ...optimistic }, optimistic.revAtSend, {
-        persisted: current.persistedOptimistic?.has?.(optimistic) === true
-      });
+      staging.addOptimistic({ ...optimistic }, optimistic.revAtSend);
     }
     staging.setActiveRun(index.active_response_id || '', index.started_rev, index.run_epoch || 0, {
       observedCreatedEpoch: session.latestRunEpoch || 0,

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -430,6 +430,7 @@ async function createSessionsHarness(options = {}) {
   windowObj.TranscriptStore = context.TranscriptStore;
   windowObj.transcriptStoreFromMessages = context.transcriptStoreFromMessages;
   windowObj.reconcileTranscriptProjection = context.reconcileTranscriptProjection;
+  windowObj.transcriptIsClientOwnedIntent = context.transcriptIsClientOwnedIntent;
   windowObj.TRANSCRIPT_BUDGETS = context.TRANSCRIPT_BUDGETS;
   vm.runInContext(coreSource, context, { filename: 'app-core.js' });
   vm.runInContext(planSource, context, { filename: 'app-plan.js' });
@@ -1330,10 +1331,14 @@ async function testTranscriptRefreshPublishesReconciledRecoveryToolsBeforeRender
       return;
     }
   }
+  // Recovery tool output is a server projection: it lives in the in-memory
+  // overlay above, and must never be written to local storage where a reload
+  // could republish it beside the durable row that owns it.
   const persisted = JSON.parse(storage.get('term_llm_optimistic_transcript') || 'null');
-  const persistedTools = persisted?.sessions?.[session.id]?.[0]?.tools?.map((tool) => tool.id) || [];
-  if (persistedTools.join(',') !== 'call_D') {
-    fail(name, 'covered recovery calls remained in persisted transcript optimistic state', JSON.stringify(persisted));
+  const persistedProjection = (persisted?.sessions?.[session.id] || [])
+    .filter((entry) => entry?.role !== 'user');
+  if (persistedProjection.length > 0) {
+    fail(name, 'server-produced recovery output reached persisted transcript optimistic state', JSON.stringify(persisted));
     return;
   }
 
@@ -5342,116 +5347,157 @@ async function testOptimisticTranscriptStorageIsPerSession() {
   pass(name);
 }
 
-async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalReconciliation() {
-  const name = 'reload reconciles matched persisted tools and retires unmatched completed tool UI at the terminal revision';
-  const sessionId = 'stale-tool-reload';
-  const storageKey = 'term_llm_optimistic_transcript';
-  let nextID = 201;
-  let nextSeq = 10;
-  const message = (role, parts) => ({
-    id: nextID++,
-    sequence: nextSeq++,
-    role,
-    created_at: nextSeq * 1000,
-    parts
+async function testStreamProjectionNeverReachesLocalStorage() {
+  const name = 'streaming assistant and tool overlays stay in memory and never reach local storage';
+  const { app, storage } = await createSessionsHarness();
+  const session = { id: 'projection-write-boundary', messages: [] };
+  const responseId = 'resp_write_boundary';
+  app.trackTranscriptOptimistic(session, {
+    id: 'msg_assistant', clientKey: `${responseId}:assistant:0`, role: 'assistant',
+    responseId, assistantSegmentOrdinal: 0, content: 'streamed text'
   });
-  const staleTurn = [
-    message('user', [{ type: 'text', text: 'run the old tool' }]),
-    message('assistant', [{ type: 'tool_call', tool_name: 'read_file', tool_call_id: 'stale-call' }]),
-    message('tool', [{ type: 'tool_result', tool_name: 'read_file', tool_call_id: 'stale-call' }]),
-    message('assistant', [{ type: 'text', text: 'Old turn done.' }])
-  ];
-  const turns = [staleTurn];
-  for (let index = 0; index < 72; index += 1) {
-    turns.push([
-      message('user', [{ type: 'text', text: `filler ${index}` }]),
-      message('assistant', [{ type: 'text', text: `answer ${index}` }])
-    ]);
+  app.trackTranscriptOptimistic(session, {
+    id: 'msg_tools', clientKey: 'msg_tools', role: 'tool-group', responseId,
+    status: 'running', tools: [{ id: 'call_1', status: 'running' }]
+  });
+  app.trackTranscriptOptimistic(session, {
+    id: 'msg_user', clientKey: 'send-1', role: 'user', content: 'queued question'
+  });
+
+  const inMemory = session.transcript.optimistic.map((entry) => entry.clientKey);
+  if (JSON.stringify(inMemory) !== JSON.stringify([`${responseId}:assistant:0`, 'msg_tools', 'send-1'])) {
+    fail(name, 'the in-memory overlay lost live streaming state', JSON.stringify(inMemory));
+    return;
   }
-  const unrelatedTurn = [
-    message('user', [{ type: 'text', text: 'run a later tool' }]),
-    message('assistant', [{ type: 'tool_call', tool_name: 'grep', tool_call_id: 'never-durable-call' }]),
-    message('tool', [{ type: 'tool_result', tool_name: 'grep', tool_call_id: 'never-durable-call' }]),
-    message('assistant', [{ type: 'text', text: 'Later turn done.' }])
-  ];
-  turns.push(unrelatedTurn);
-  const raw = turns.flat();
-  const persistedEntries = [
-    {
-      id: 'local-stale-tool-group',
-      clientKey: 'local-stale-tool-group',
-      role: 'tool-group',
-      status: 'done',
-      tools: [{ id: 'stale-call', name: 'read_file', status: 'done' }],
-      revAtSend: 5,
-      durableSeqAtSend: staleTurn[0].sequence,
-      optimistic: true
-    },
-    {
-      id: 'local-unmatched-tool-group',
-      clientKey: 'local-unmatched-tool-group',
-      role: 'tool-group',
-      status: 'done',
-      tools: [{ id: 'never-durable-call', name: 'write_file', status: 'done' }],
-      revAtSend: 5,
-      durableSeqAtSend: staleTurn[staleTurn.length - 1].sequence,
-      optimistic: true
-    },
-    {
-      id: 'local-queued-user',
-      clientKey: 'local-queued-user',
-      role: 'user',
-      content: 'queued after the active run',
-      revAtSend: 5,
-      durableSeqAtSend: raw[raw.length - 1].sequence,
-      optimistic: true
+  const saved = JSON.parse(storage.get('term_llm_optimistic_transcript') || 'null');
+  if (saved?.version !== 2) {
+    fail(name, 'storage was not stamped with the current version', JSON.stringify(saved));
+    return;
+  }
+  const savedKeys = (saved?.sessions?.[session.id] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['send-1'])) {
+    fail(name, 'server-produced projection was written to local storage', JSON.stringify(saved));
+    return;
+  }
+  pass(name);
+}
+
+async function testLegacyUnversionedStorageMigratesOnlyIntent() {
+  const name = 'legacy unversioned storage keeps queued intent and drops assistant/tool shadows';
+  const sessionId = 'legacy-unversioned-shape';
+  const { app, storage } = await createSessionsHarness({
+    initialStorage: {
+      term_llm_optimistic_transcript: JSON.stringify({
+        sessionId,
+        entries: [
+          {
+            id: 'legacy-assistant', clientKey: 'legacy-assistant', role: 'assistant',
+            content: 'ghost output', optimistic: true
+          },
+          {
+            id: 'legacy-tools', clientKey: 'legacy-tools', role: 'tool-group', status: 'done',
+            tools: [{ id: 'call_old', status: 'done' }], optimistic: true
+          },
+          {
+            id: 'legacy-user', clientKey: 'legacy-user', role: 'user',
+            content: 'still queued', optimistic: true
+          }
+        ]
+      })
     }
-  ];
+  });
+  const session = { id: sessionId, messages: [] };
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  // Tracking a fresh send hydrates the store from legacy storage first.
+  app.trackTranscriptOptimistic(session, {
+    id: 'msg_new_user', clientKey: 'send-new', role: 'user', content: 'newly queued'
+  });
+
+  const hydrated = session.transcript.optimistic.map((entry) => entry.clientKey);
+  if (JSON.stringify(hydrated) !== JSON.stringify(['legacy-user', 'send-new'])) {
+    fail(name, 'legacy hydration restored projection shadows or dropped queued intent', JSON.stringify(hydrated));
+    return;
+  }
+  const saved = JSON.parse(storage.get('term_llm_optimistic_transcript') || 'null');
+  if (saved?.version !== 2) {
+    fail(name, 'legacy payload was not rewritten at the current version', JSON.stringify(saved));
+    return;
+  }
+  const savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['legacy-user', 'send-new'])) {
+    fail(name, 'legacy migration persisted the wrong entries', JSON.stringify(saved));
+    return;
+  }
+  pass(name);
+}
+
+async function testReloadMigratesLegacyProjectionShadowsAtEqualRevision() {
+  const name = 'reload discards legacy assistant/tool shadows at an unchanged revision and keeps queued user intent';
+  const sessionId = 'legacy-projection-shadow';
+  const storageKey = 'term_llm_optimistic_transcript';
+  const responseId = 'resp_TimE4vzRQUUJ';
+  // Version 1 storage written by an older build: server-owned response output
+  // captured at exactly the revision the server still reports. The retired
+  // "rev > revAtSend" rule could never retire these, so an idle session stayed
+  // duplicated forever. Migration must drop them on the way out of storage.
   const persisted = JSON.stringify({
     version: 1,
-    sessions: { [sessionId]: persistedEntries }
+    sessions: {
+      [sessionId]: [
+        {
+          id: 'msg_shadow_assistant', clientKey: `${responseId}:assistant:0`, role: 'assistant',
+          responseId, assistantSegmentOrdinal: 0, content: 'durable answer',
+          revAtSend: 279, durableSeqAtSend: 180, optimistic: true
+        },
+        {
+          id: 'msg_shadow_drifted', clientKey: `${responseId}:assistant:99`, role: 'assistant',
+          responseId, assistantSegmentOrdinal: 99, content: 'durable answer',
+          revAtSend: 279, durableSeqAtSend: 180, optimistic: true
+        },
+        {
+          id: 'msg_shadow_legacy', clientKey: 'msg_shadow_legacy', role: 'assistant',
+          content: 'durable answer', revAtSend: 279, durableSeqAtSend: 180, optimistic: true
+        },
+        {
+          id: 'msg_shadow_tools', clientKey: 'msg_shadow_tools', role: 'tool-group', responseId,
+          status: 'done', tools: [{ id: 'call_stale', name: 'read_file', status: 'done' }],
+          revAtSend: 279, durableSeqAtSend: 180, optimistic: true
+        },
+        {
+          id: 'pending-user', clientKey: 'pending-user', role: 'user', content: 'send me next',
+          revAtSend: 279, durableSeqAtSend: 181, optimistic: true
+        }
+      ]
+    }
   });
-  const bodyRequests = [];
-  const targetStatesAtFetch = [];
-  let indexRequests = 0;
-  let primedMaterializationBudget = false;
-  let session = null;
+  const durable = [
+    { id: 180, sequence: 180, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+    {
+      id: 181, sequence: 181, role: 'assistant', response_id: responseId,
+      assistant_segment_ordinal: 0, parts: [{ type: 'text', text: 'durable answer' }]
+    }
+  ];
   const { app, storage } = await createSessionsHarness({
     initialStorage: { [storageKey]: persisted },
     fetchImpl: async (url) => {
       if (isTranscriptIndexURL(url, sessionId)) {
-        indexRequests += 1;
-        if (indexRequests > 1) {
-          return new Response(null, { status: 304, headers: { ETag: '"stale-tool-rev-8"' } });
-        }
         return new Response(JSON.stringify({
-          rev: 8,
+          rev: 279,
           compaction_seq: -1,
           compaction_count: 0,
           rows: {
-            ids: raw.map((entry) => entry.id),
-            seqs: raw.map((entry) => entry.sequence),
-            roles: raw.map((entry) => ({ user: 'u', assistant: 'a', tool: 't' })[entry.role]).join(''),
-            flags: raw.map(() => 0)
+            ids: [180, 181],
+            seqs: [180, 181],
+            roles: 'ua',
+            flags: [0, 0],
+            response_ids: ['', responseId],
+            assistant_segment_ordinals: [-1, 0]
           }
-        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"stale-tool-rev-8"' } });
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: '"equal-rev-279"' } });
       }
       if (isTranscriptBodiesURL(url, sessionId)) {
-        targetStatesAtFetch.push(session?.transcript?.segments?.[0]?.state || '');
-        if (!primedMaterializationBudget) {
-          primedMaterializationBudget = true;
-          session.transcript.materialize(turns.slice(-60).flat(), { countFetch: false });
-        }
-        const requested = (parsedTestURL(url)?.searchParams.get('ids') || '')
-          .split(',')
-          .filter(Boolean)
-          .map(Number);
-        bodyRequests.push(requested);
-        const requestedAnchors = new Set(requested);
-        const messages = turns
-          .filter((turn) => requestedAnchors.has(turn[0].id))
-          .flat();
-        return new Response(JSON.stringify({ rev: 8, messages }), {
+        return new Response(JSON.stringify({ rev: 279, messages: durable }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
         });
@@ -5462,90 +5508,46 @@ async function testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalR
       });
     }
   });
-  session = { id: sessionId, messages: [] };
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, messages: [] };
   app.state.sessions = [session];
-  app.state.activeSessionId = session.id;
+  app.state.activeSessionId = sessionId;
   app.state.draftSessionActive = false;
 
   const loaded = await app.syncTranscript(session, { reason: 'reload' });
-  const requested = bodyRequests[0] || [];
-  if (!loaded || targetStatesAtFetch[0] !== 'evicted') {
-    fail(name, 'stale turn was not initially evicted before body materialization', JSON.stringify({ loaded, targetStatesAtFetch }));
+  if (!loaded || session.transcript.rev !== 279) {
+    fail(name, 'reload did not settle on the unchanged server revision', JSON.stringify({ loaded, rev: session.transcript?.rev }));
     return;
   }
-  if (turns.length <= 60) {
-    fail(name, 'regression transcript did not exceed the materialized-turn budget', String(turns.length));
+  const assistants = session.messages.filter((message) => message.role === 'assistant');
+  if (assistants.length !== 1 || assistants[0].durable !== true) {
+    fail(name, 'a legacy assistant shadow rendered beside the durable row it duplicates', JSON.stringify(session.messages));
     return;
   }
-  if (!requested.includes(staleTurn[0].id) || !requested.includes(unrelatedTurn[0].id)) {
-    fail(name, 'reload did not fetch both the stale original turn and the pinned later turn', JSON.stringify(bodyRequests));
+  if (session.messages.some((message) => ['tool-group', 'tool'].includes(message.role))) {
+    fail(name, 'a legacy tool shadow survived migration', JSON.stringify(session.messages));
     return;
   }
-  if (requested.length > 32 || requested.length >= turns.length) {
-    fail(name, 'reload body fetch was not bounded to selected turn anchors', JSON.stringify({ requested: requested.length, turns: turns.length }));
+  const optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
+  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['pending-user'])) {
+    fail(name, 'migration dropped queued user intent or retained a projection shadow', JSON.stringify(optimisticKeys));
     return;
   }
-  let optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
-  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-queued-user'])) {
-    fail(name, '200 terminal reconciliation retained stale completed tool UI or dropped the queued user', JSON.stringify(optimisticKeys));
+  const saved = JSON.parse(storage.get(storageKey) || 'null');
+  if (saved?.version !== 2) {
+    fail(name, 'migrated storage was not rewritten at the current version', JSON.stringify(saved));
     return;
   }
-  let saved = JSON.parse(storage.get(storageKey) || 'null');
-  let savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
-  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-queued-user'])) {
-    fail(name, '200 terminal reconciliation was not persisted without the stale tool tail', JSON.stringify(saved));
-    return;
-  }
-  if (session.transcript.segments[0]?.state !== 'evicted'
-      || session.transcript.segments.filter((segment) => segment.state === 'materialized').length > 60) {
-    fail(name, 'post-reconciliation budget did not evict the distant target turn', JSON.stringify({
-      targetState: session.transcript.segments[0]?.state || 'missing',
-      materialized: session.transcript.segments.filter((segment) => segment.state === 'materialized').length
-    }));
-    return;
-  }
-
-  session.transcript.addOptimistic({
-    id: 'local-304-tool-group',
-    clientKey: 'local-304-tool-group',
-    role: 'tool-group',
-    status: 'done',
-    tools: [{ id: 'stale-call', name: 'read_file', status: 'done' }],
-    revAtSend: 5,
-    durableSeqAtSend: staleTurn[0].sequence,
-    optimistic: true
-  }, 5, { persisted: true });
-  app.persistTranscriptOptimistic(session);
-
-  const loadedNotModified = await app.syncTranscript(session, { reason: 'not-modified' });
-  optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
-  if (!loadedNotModified || targetStatesAtFetch[1] !== 'evicted' || !bodyRequests[1]?.includes(staleTurn[0].id)) {
-    fail(name, '304 sync did not rematerialize the evicted reconciliation target', JSON.stringify({ loadedNotModified, targetStatesAtFetch, bodyRequests }));
-    return;
-  }
-  if (JSON.stringify(optimisticKeys) !== JSON.stringify(['local-queued-user'])) {
-    fail(name, '304 reconciliation retained completed tool UI or dropped the queued user', JSON.stringify(optimisticKeys));
-    return;
-  }
-  saved = JSON.parse(storage.get(storageKey) || 'null');
-  savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
-  if (JSON.stringify(savedKeys) !== JSON.stringify(['local-queued-user'])) {
-    fail(name, '304 reconciliation persistence did not retain only the queued user', JSON.stringify(saved));
-    return;
-  }
-  const finalMaterialized = session.transcript.segments.filter((segment) => segment.state === 'materialized').length;
-  if (session.transcript.segments[0]?.state !== 'evicted' || finalMaterialized > 60) {
-    fail(name, '304 sync did not enforce the budget after reconciliation', JSON.stringify({
-      targetState: session.transcript.segments[0]?.state || 'missing',
-      materialized: finalMaterialized
-    }));
+  const savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
+  if (JSON.stringify(savedKeys) !== JSON.stringify(['pending-user'])) {
+    fail(name, 'migrated storage retained server-produced projection', JSON.stringify(saved));
     return;
   }
   pass(name);
 }
 
 async function testReloadRetiresStalePersistedAssistantIdentityAfterTerminalAdvance() {
-  const name = 'reload retires stale version-1 assistant identity after terminal transcript advance';
+  const name = 'reload discards a version-1 assistant identity that no longer matches durable output';
   const sessionId = 'stale-persisted-assistant';
   const storageKey = 'term_llm_optimistic_transcript';
   const responseId = 'resp_stale_persisted';
@@ -5626,24 +5628,24 @@ async function testReloadRetiresStalePersistedAssistantIdentityAfterTerminalAdva
   const loaded = await app.syncTranscript(session, { reason: 'reload' });
   const assistants = session.messages.filter((message) => message.role === 'assistant');
   if (!loaded || assistants.length !== 1 || assistants[0].durable !== true) {
-    fail(name, 'reload retained the stale assistant overlay beside authoritative durable output', JSON.stringify(session.messages));
+    fail(name, 'a stored assistant shadow rendered beside authoritative durable output', JSON.stringify(session.messages));
     return;
   }
   if (JSON.stringify(session.transcript.optimistic.map((entry) => entry.clientKey)) !== JSON.stringify(['pending-user'])) {
-    fail(name, 'terminal retirement did not preserve only the genuinely pending user', JSON.stringify(session.transcript.optimistic));
+    fail(name, 'migration did not preserve only the genuinely pending user', JSON.stringify(session.transcript.optimistic));
     return;
   }
   const saved = JSON.parse(storage.get(storageKey) || 'null');
   const savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
   if (JSON.stringify(savedKeys) !== JSON.stringify(['pending-user'])) {
-    fail(name, 'stale assistant retirement was not persisted', JSON.stringify(saved));
+    fail(name, 'migrated storage retained the stale assistant identity', JSON.stringify(saved));
     return;
   }
   pass(name);
 }
 
 async function testReloadScopesStalePersistedRetirementToCurrentActiveResponse() {
-  const name = 'reload retires stale old response output under a different active response';
+  const name = 'reload during an active response rebuilds output from the server instead of storage';
   const sessionId = 'stale-persisted-active-response';
   const storageKey = 'term_llm_optimistic_transcript';
   const staleResponseId = 'resp_stale_persisted';
@@ -5727,25 +5729,32 @@ async function testReloadScopesStalePersistedRetirementToCurrentActiveResponse()
   app.state.draftSessionActive = false;
 
   const loaded = await app.syncTranscript(session, { reason: 'reload' });
-  const expectedKeys = [
-    'legacy-ownerless',
-    `${activeResponseId}:assistant:0`,
-    `${activeResponseId}:tool:call-current`,
-    'pending-user'
-  ];
+  // Reloading mid-response must not restore any stored projection, not even for
+  // the response that is still running. The live overlay is rebuilt from event
+  // replay and the response snapshot, so storage keeps only queued intent.
+  const expectedKeys = ['pending-user'];
   const optimisticKeys = session.transcript.optimistic.map((entry) => entry.clientKey);
   if (!loaded || session.transcript.activeRun?.id !== activeResponseId
       || JSON.stringify(optimisticKeys) !== JSON.stringify(expectedKeys)) {
-    fail(name, 'active response authority retained stale foreign output or dropped protected entries', JSON.stringify({
+    fail(name, 'reload during an active response restored stored projection or dropped queued intent', JSON.stringify({
       activeRun: session.transcript.activeRun,
       optimisticKeys
     }));
     return;
   }
+  const assistants = session.messages.filter((message) => message.role === 'assistant');
+  if (assistants.length !== 1 || assistants[0].durable !== true) {
+    fail(name, 'a stored assistant shadow rendered beside the durable row during an active response', JSON.stringify(session.messages));
+    return;
+  }
   const saved = JSON.parse(storage.get(storageKey) || 'null');
+  if (saved?.version !== 2) {
+    fail(name, 'storage was not rewritten at the current version during an active response', JSON.stringify(saved));
+    return;
+  }
   const savedKeys = (saved?.sessions?.[sessionId] || []).map((entry) => entry.clientKey);
   if (JSON.stringify(savedKeys) !== JSON.stringify(expectedKeys)) {
-    fail(name, 'response-scoped stale retirement was not persisted', JSON.stringify(saved));
+    fail(name, 'storage retained server-produced projection during an active response', JSON.stringify(saved));
     return;
   }
   pass(name);
@@ -6714,7 +6723,9 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
   await testConvertServerMessagesSuppressesNonBubbleAssistantRows();
   await testSessionPruningDestroysTranscriptStores();
   await testOptimisticTranscriptStorageIsPerSession();
-  await testReloadMaterializesPersistedOptimisticToolTurnsBeforeTerminalReconciliation();
+  await testStreamProjectionNeverReachesLocalStorage();
+  await testLegacyUnversionedStorageMigratesOnlyIntent();
+  await testReloadMigratesLegacyProjectionShadowsAtEqualRevision();
   await testReloadRetiresStalePersistedAssistantIdentityAfterTerminalAdvance();
   await testReloadScopesStalePersistedRetirementToCurrentActiveResponse();
   await testTranscriptSyncCommitsOneRenderedProjection();

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -55,6 +55,19 @@
     return ids;
   };
 
+  // Client-owned intent is the only transcript state a browser may persist.
+  // Assistant and tool rows are server projections whose sole authorities are
+  // the durable transcript and response replay/snapshot recovery. Keeping them
+  // out of local storage is what makes a reload structurally incapable of
+  // resurrecting an overlay that shadows a durable row.
+  const CLIENT_INTENT_ROLES = new Set(['user']);
+  const isClientOwnedIntent = (entry) => (
+    Boolean(entry)
+    && typeof entry === 'object'
+    && entry.durable !== true
+    && CLIENT_INTENT_ROLES.has(entry.role)
+  );
+
   const messageResponseID = (message) => String(message?.responseId || message?.response_id || '').trim();
   const assistantSegmentOrdinal = (message) => {
     const value = message?.assistantSegmentOrdinal ?? message?.assistant_segment_ordinal;
@@ -260,7 +273,6 @@
       this.optimistic = [];
       this.optimisticOwned = new WeakSet();
       this.optimisticByAssistantSegment = new Map();
-      this.persistedOptimistic = new WeakSet();
       this.activeRun = null;
       this.activeRunDurableIDsAtStart = new Set();
       this.latestRunEpoch = 0;
@@ -700,7 +712,7 @@
       throw new Error(`mutable stream cursor is not a transcript-owned optimistic overlay${source ? ` (${source})` : ''}`);
     }
 
-    addOptimistic(entry, revAtSend = this.rev, options = {}) {
+    addOptimistic(entry, revAtSend = this.rev) {
       if (!entry || typeof entry !== 'object' || entry.durable === true) return null;
       if (this.activeRun && ['assistant', 'tool', 'tool-group'].includes(entry.role)) {
         if (!messageResponseID(entry)) entry.responseId = this.activeRun.id;
@@ -727,7 +739,6 @@
           if (previousAssistantContent.startsWith(incomingContent)) existing.content = previousAssistantContent;
         }
         if (segmentKey) this.optimisticByAssistantSegment.set(segmentKey, existing);
-        if (options.persisted === true) this.persistedOptimistic.add(existing);
         return existing;
       }
       const optimistic = entry;
@@ -739,7 +750,6 @@
       this.optimistic.push(optimistic);
       this.optimisticOwned.add(optimistic);
       if (segmentKey) this.optimisticByAssistantSegment.set(segmentKey, optimistic);
-      if (options.persisted === true) this.persistedOptimistic.add(optimistic);
       return optimistic;
     }
 
@@ -812,21 +822,6 @@
         else high = mid;
       }
       return low < this.seqs.length ? this.segmentForOrdinal(low) : -1;
-    }
-
-    persistedOptimisticSegmentIndexes(limit = TRANSCRIPT_MATERIALIZE_BATCH_TURNS) {
-      if (this.activeRun || this.optimistic.length === 0) return [];
-      const max = Math.max(1, finiteInt(limit, TRANSCRIPT_MATERIALIZE_BATCH_TURNS));
-      const selected = new Set();
-      for (const local of this.optimistic) {
-        if (selected.size >= max) break;
-        if (!this.persistedOptimistic.has(local)) continue;
-        if (!['assistant', 'tool-group', 'tool'].includes(local.role)) continue;
-        if (this.rev <= finiteInt(local.revAtSend, this.rev)) continue;
-        const segmentIndex = this.segmentAfterSequence(local.durableSeqAtSend);
-        if (segmentIndex >= 0 && this.segments[segmentIndex]?.state === 'evicted') selected.add(segmentIndex);
-      }
-      return [...selected];
     }
 
     durableToolIDs() {
@@ -943,15 +938,6 @@
       for (const local of this.optimistic) {
         const localIsTool = local.role === 'tool-group' || local.role === 'tool';
         const outputOwner = messageResponseID(local);
-        // An active response is authoritative only for output with the same
-        // stable owner. Legacy ownerless output remains protected because its
-        // response scope cannot be established safely.
-        const activeRunOwnsOutput = Boolean(this.activeRun)
-          && (!outputOwner || this.activeRun.id === outputOwner);
-        const serverOwnsPersistedOutput = !activeRunOwnsOutput
-          && this.persistedOptimistic.has(local)
-          && (local.role === 'assistant' || localIsTool)
-          && this.rev > finiteInt(local.revAtSend, this.rev);
         if (localIsTool) {
           const owner = outputOwner;
           const localKeys = new Map([...messageToolIDs(local)].map((id) => [toolIdentityKey(owner, id), id]));
@@ -998,8 +984,7 @@
               // A covered live overlay remains the sole mutable cursor until the
               // response finalizes; fresh deltas must never target its durable projection.
               kept.push(local);
-            } else if (serverOwnsPersistedOutput) removed.push(local);
-            else if (comparison.suffix) kept.push(local);
+            } else if (comparison.suffix) kept.push(local);
             else removed.push(local);
             continue;
           }
@@ -1007,20 +992,11 @@
             const legacyPart = durableAssistantParts.find((candidate) => candidate.sequence > finiteInt(local.durableSeqAtSend, -1));
             if (legacyPart) {
               const comparison = assistantSuffixAfterDurable(legacyPart.content, assistantSourceContent(local));
-              if (comparison.suffix && !serverOwnsPersistedOutput) kept.push(local);
+              if (comparison.suffix) kept.push(local);
               else removed.push(local);
               continue;
             }
           }
-        }
-
-        if (serverOwnsPersistedOutput) {
-          // Persisted assistant/tool overlays are recovery shadows, not durable
-          // client intent. Once the transcript advances beyond their captured
-          // revision and no active response owns them, the durable transcript
-          // owns the response tail even if an old stable identity never matched.
-          removed.push(local);
-          continue;
         }
 
         const afterSeq = finiteInt(local.durableSeqAtSend, -1);
@@ -1248,6 +1224,7 @@
     TRANSCRIPT_FLAG_EMPTY_BODY,
     transcriptStoreFromMessages,
     reconcileTranscriptProjection,
+    transcriptIsClientOwnedIntent: isClientOwnedIntent,
     assistantSegmentKey,
     transcriptToolIdentityKey: toolIdentityKey,
     transcriptDiagnostic,

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -6,6 +6,7 @@ const {
   TRANSCRIPT_FLAG_EMPTY_BODY,
   transcriptStoreFromMessages,
   reconcileTranscriptProjection,
+  transcriptIsClientOwnedIntent,
   __transcriptStats
 } = require('./transcript-store.js');
 
@@ -474,7 +475,7 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
     content: 'durable prefix plus optimistic suffix',
     durableSeqAtSend: 25,
     revAtSend: 7
-  }, 7, { persisted: true });
+  }, 7);
   reloadedAssistant.reconcileOptimistic();
   const reloadedProjection = reconcileTranscriptProjection([
     {
@@ -490,12 +491,12 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   assert.deepEqual(
     reloadedProjection.map((message) => ({ id: message.id, content: message.content })),
     assistantProjection.map((message) => ({ id: message.id, content: message.content })),
-    'persisted reload and live status synchronization must publish the same tail'
+    'an in-memory reload overlay and live status synchronization must publish the same tail'
   );
 
   const scopedTools = new TranscriptStore('scoped-persisted-tools');
   scopedTools.applyIndex(envelope([30, 31], { rev: 1, roles: 'ua' }));
-  scopedTools.addOptimistic({ clientKey: 'persisted-tools', role: 'tool-group', tools: [{ id: 'shared-call' }] }, 1, { persisted: true });
+  scopedTools.addOptimistic({ clientKey: 'recovered-tools', role: 'tool-group', tools: [{ id: 'shared-call' }] }, 1);
   scopedTools.addOptimistic({ clientKey: 'live-tools', role: 'tool-group', tools: [{ id: 'shared-call' }] });
   scopedTools.applyIndex(envelope([30, 31, 32, 33, 34, 35, 36], { rev: 2, roles: 'uauauat' }));
   scopedTools.materialize([
@@ -509,7 +510,7 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   ]);
   assert.deepEqual(
     scopedTools.reconcileOptimistic().map((entry) => entry.clientKey),
-    ['persisted-tools', 'live-tools'],
+    ['recovered-tools', 'live-tools'],
     'stable durable tool IDs retire every optimistic projection regardless of synthetic group or turn scope'
   );
   assert.deepEqual(scopedTools.optimistic.map((entry) => entry.clientKey), []);
@@ -521,15 +522,15 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
     role: 'tool-group',
     status: 'done',
     tools: [{ id: 'local-only-call', status: 'done' }]
-  }, 5, { persisted: true });
-  terminalTools.addOptimistic({ clientKey: 'completed-standalone-tool', role: 'tool', status: 'error' }, 5, { persisted: true });
-  terminalTools.addOptimistic({ clientKey: 'queued-user', role: 'user', durableSeqAtSend: 99 }, 5, { persisted: true });
+  }, 5);
+  terminalTools.addOptimistic({ clientKey: 'completed-standalone-tool', role: 'tool', status: 'error' }, 5);
+  terminalTools.addOptimistic({ clientKey: 'queued-user', role: 'user', durableSeqAtSend: 99 }, 5);
   terminalTools.addOptimistic({
     clientKey: 'running-tool',
     role: 'tool-group',
     status: 'running',
     tools: [{ id: 'active-call', status: 'running' }]
-  }, 5, { persisted: true });
+  }, 5);
   terminalTools.setActiveRun('resp-active', 5);
   terminalTools.applyIndex(envelope([40, 41], { rev: 6, roles: 'ua' }));
   materializeOrdinals(terminalTools, [1]);
@@ -537,13 +538,13 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   terminalTools.setActiveRun('', 0);
   assert.deepEqual(
     terminalTools.reconcileOptimistic().map((entry) => entry.clientKey),
-    ['completed-tool-tail', 'completed-standalone-tool', 'running-tool'],
-    'an authoritative terminal revision must retire every unmatched persisted tool overlay'
+    ['completed-tool-tail', 'completed-standalone-tool'],
+    'an authoritative terminal revision retires completed tool UI the durable transcript now owns'
   );
   assert.deepEqual(
     terminalTools.optimistic.map((entry) => entry.clientKey),
-    ['queued-user'],
-    'queued user messages must survive terminal server-owned output cleanup'
+    ['queued-user', 'running-tool'],
+    'queued user intent and the still-running in-memory tool overlay survive terminal cleanup'
   );
 
   const displayOnly = new TranscriptStore('display-only');
@@ -698,109 +699,115 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   reloaded._checkInvariants();
 })();
 
+// Persistence classification is shared by storage reads and writes: only
+// non-durable client intent is eligible for browser persistence.
 (() => {
-  const responseId = 'resp_stale_persisted_output';
-  const stalePersisted = new TranscriptStore('stale-persisted-output');
-  const staleMatchedSuffix = stalePersisted.addOptimistic({
-    id: 'stale-matched-suffix', role: 'assistant', responseId, assistantSegmentOrdinal: 0,
-    content: 'prefix suffix ghost', revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const staleAssistant = stalePersisted.addOptimistic({
-    id: 'stale-assistant', role: 'assistant', responseId, assistantSegmentOrdinal: 99,
+  const responseId = 'resp_projection_authority';
+  const projections = [
+    { id: 'matched-identity', role: 'assistant', responseId, assistantSegmentOrdinal: 0, content: 'prefix' },
+    { id: 'drifted-ordinal', role: 'assistant', responseId, assistantSegmentOrdinal: 99, content: 'prefix' },
+    { id: 'ownerless-legacy', role: 'assistant', content: 'legacy recovery output' },
+    { id: 'tool-group', role: 'tool-group', responseId, status: 'running', tools: [{ id: 'call-a', status: 'running' }] },
+    { id: 'standalone-tool', role: 'tool', responseId, status: 'running' },
+  ];
+  for (const projection of projections) {
+    assert.equal(
+      transcriptIsClientOwnedIntent(projection),
+      false,
+      `server-produced ${projection.id} must never be browser-persistable`
+    );
+  }
+  assert.equal(transcriptIsClientOwnedIntent({ id: 'queued-user', role: 'user' }), true);
+  assert.equal(transcriptIsClientOwnedIntent({ id: 'durable-user', role: 'user', durable: true }), false);
+})();
+
+// Exact production regression: a durable row and a same-revision overlay for the
+// same response. Retirement must come from durable coverage, never from a
+// transcript revision that has not advanced past the overlay's capture point.
+(() => {
+  const responseId = 'resp_TimE4vzRQUUJ';
+  const equalRev = new TranscriptStore('equal-revision-coverage');
+  const covered = equalRev.addOptimistic({
+    id: 'msg_overlay', role: 'assistant', responseId, assistantSegmentOrdinal: 0,
+    content: 'durable answer', revAtSend: 279, durableSeqAtSend: 180,
+  }, 279);
+  const queued = equalRev.addOptimistic({
+    id: 'queued-user', role: 'user', content: 'still pending', revAtSend: 279, durableSeqAtSend: 180,
+  }, 279);
+  equalRev.applyIndex({
+    rev: 279,
+    rows: {
+      ids: [180, 181], seqs: [180, 181], roles: 'ua', flags: [0, 0],
+      response_ids: ['', responseId], assistant_segment_ordinals: [-1, 0],
+    },
+  });
+  equalRev.materialize([
+    { id: 180, sequence: 180, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+    {
+      id: 181, sequence: 181, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+      parts: [{ type: 'text', text: 'durable answer' }],
+    },
+  ]);
+  assert.equal(equalRev.rev, 279, 'the transcript revision must stay equal to the overlay capture revision');
+  assert.deepEqual(
+    equalRev.reconcileOptimistic(),
+    [covered],
+    'a fully covered overlay retires at an unchanged revision instead of waiting for an unrelated advance'
+  );
+  assert.deepEqual(equalRev.optimistic, [queued], 'equal-revision retirement preserves queued user intent');
+  equalRev._checkInvariants();
+  equalRev.destroy();
+})();
+
+// Ownership during an active response: the owning response keeps its mutable
+// cursor, a different owner never adopts another response's output.
+(() => {
+  const staleResponseId = 'resp_stale_owner';
+  const activeResponseId = 'resp_current_active';
+  const owners = new TranscriptStore('active-run-ownership');
+  const staleCovered = owners.addOptimistic({
+    id: 'stale-covered', role: 'assistant', responseId: staleResponseId, assistantSegmentOrdinal: 0,
     content: 'prefix suffix', revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const staleLegacyAssistant = stalePersisted.addOptimistic({
-    id: 'stale-legacy-assistant', role: 'assistant', content: 'prefix suffix ghost',
-    revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const staleTool = stalePersisted.addOptimistic({
-    id: 'stale-tool', role: 'tool-group', responseId, status: 'running',
-    tools: [{ id: 'call-stale', status: 'running' }], revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const pendingUser = stalePersisted.addOptimistic({
-    id: 'pending-user', role: 'user', content: 'still pending', revAtSend: 2, durableSeqAtSend: 2,
-  }, 2, { persisted: true });
-  stalePersisted.applyIndex({
-    rev: 2,
-    rows: {
-      ids: [1, 2], seqs: [1, 2], roles: 'ua', flags: [0, 0],
-      response_ids: ['', responseId], assistant_segment_ordinals: [-1, 0],
-    },
-  });
-  stalePersisted.materialize([
-    { id: 1, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'question' }] },
-    {
-      id: 2, sequence: 2, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
-      parts: [{ type: 'text', text: 'prefix suffix' }],
-    },
-  ]);
-  assert.deepEqual(
-    stalePersisted.reconcileOptimistic(),
-    [staleMatchedSuffix, staleAssistant, staleLegacyAssistant, staleTool],
-    'terminal authoritative advancement retires persisted server-owned output whether its stable identity matches or is stale'
-  );
-  assert.deepEqual(stalePersisted.optimistic, [pendingUser], 'terminal retirement preserves genuinely pending user input');
-
-  const currentResponseId = 'resp_current_active';
-  const activePersisted = new TranscriptStore('active-persisted-output');
-  const staleMatchedActive = activePersisted.addOptimistic({
-    id: 'stale-matched-active', role: 'assistant', responseId, assistantSegmentOrdinal: 0,
-    content: 'prefix suffix ghost', revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const staleAssistantActive = activePersisted.addOptimistic({
-    id: 'stale-assistant-active', role: 'assistant', responseId, assistantSegmentOrdinal: 99,
-    content: 'stale persisted output', revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const staleToolActive = activePersisted.addOptimistic({
-    id: 'stale-tool-active', role: 'tool-group', responseId, status: 'running',
-    tools: [{ id: 'call-stale-active', status: 'running' }], revAtSend: 1, durableSeqAtSend: 1,
-  }, 1, { persisted: true });
-  const legacyOwnerless = activePersisted.addOptimistic({
-    id: 'legacy-ownerless-active', role: 'assistant', content: 'legacy recovery output',
-    revAtSend: 1, durableSeqAtSend: 2,
-  }, 1, { persisted: true });
-  activePersisted.setActiveRun(currentResponseId, 1, 2);
-  const activeSuffix = activePersisted.addOptimistic({
-    id: 'active-suffix', role: 'assistant', responseId: currentResponseId, assistantSegmentOrdinal: 0,
-    content: 'active suffix', revAtSend: 1, durableSeqAtSend: 2,
-  }, 1, { persisted: true });
-  const activeTool = activePersisted.addOptimistic({
-    id: 'active-tool', role: 'tool-group', responseId: currentResponseId, status: 'running',
+  }, 1);
+  owners.setActiveRun(activeResponseId, 1, 2);
+  const activeCursor = owners.addOptimistic({
+    id: 'active-cursor', role: 'assistant', responseId: activeResponseId, assistantSegmentOrdinal: 0,
+    content: 'live suffix', revAtSend: 1, durableSeqAtSend: 2,
+  }, 1);
+  const activeTool = owners.addOptimistic({
+    id: 'active-tool', role: 'tool-group', responseId: activeResponseId, status: 'running',
     tools: [{ id: 'call-current', status: 'running' }], revAtSend: 1, durableSeqAtSend: 2,
-  }, 1, { persisted: true });
-  const activePendingUser = activePersisted.addOptimistic({
-    id: 'active-pending-user', role: 'user', content: 'still pending', revAtSend: 2, durableSeqAtSend: 2,
-  }, 2, { persisted: true });
-  activePersisted.applyIndex({
+  }, 1);
+  const queued = owners.addOptimistic({
+    id: 'queued-user', role: 'user', content: 'still pending', revAtSend: 2, durableSeqAtSend: 2,
+  }, 2);
+  owners.applyIndex({
     rev: 2,
-    active_response_id: currentResponseId,
+    active_response_id: activeResponseId,
     rows: {
       ids: [1, 2], seqs: [1, 2], roles: 'ua', flags: [0, 0],
-      response_ids: ['', responseId], assistant_segment_ordinals: [-1, 0],
+      response_ids: ['', staleResponseId], assistant_segment_ordinals: [-1, 0],
     },
   });
-  activePersisted.materialize([
+  owners.materialize([
     { id: 1, sequence: 1, role: 'user', parts: [{ type: 'text', text: 'question' }] },
     {
-      id: 2, sequence: 2, role: 'assistant', response_id: responseId, assistant_segment_ordinal: 0,
+      id: 2, sequence: 2, role: 'assistant', response_id: staleResponseId, assistant_segment_ordinal: 0,
       parts: [{ type: 'text', text: 'prefix suffix' }],
     },
   ]);
   assert.deepEqual(
-    activePersisted.reconcileOptimistic(),
-    [staleMatchedActive, staleAssistantActive, staleToolActive],
-    'a different active response must not protect stale persisted output with a stable old owner'
+    owners.reconcileOptimistic(),
+    [staleCovered],
+    'a different active response must not protect output a durable row already covers'
   );
   assert.deepEqual(
-    activePersisted.optimistic,
-    [legacyOwnerless, activeSuffix, activeTool, activePendingUser],
-    'active reconciliation preserves ownerless recovery output, the current response suffix/tools, and pending user input'
+    owners.optimistic,
+    [activeCursor, activeTool, queued],
+    'the owning response keeps its mutable cursor and tools while queued intent survives'
   );
-
-  stalePersisted._checkInvariants();
-  activePersisted._checkInvariants();
-  stalePersisted.destroy();
-  activePersisted.destroy();
+  owners._checkInvariants();
+  owners.destroy();
 })();
 
 console.log('transcript-store tests passed');


### PR DESCRIPTION
## What

Restrict browser transcript persistence to client-owned intent.

Assistant text and tool state remain in-memory while a page is active, but are never written to `term_llm_optimistic_transcript` and never restored from it. Completed output comes from the durable transcript; active output is reconstructed through response replay/snapshot recovery.

This removes the second authority that caused durable `srv_seq_*` rows and stale local `msg_*` shadows to render together.

## Ownership invariant

| State | Authority | Browser-persisted |
|---|---|---:|
| Queued user intent | Client | Yes |
| Assistant output | Server transcript/recovery | No |
| Tool calls/results | Server transcript/recovery | No |
| Completed transcript | Server | No |

A shared predicate classifies persistable state as a non-durable `user` entry. Both storage reads and writes apply it.

`TranscriptStore` now models only durable rows and in-memory optimistic state. It no longer tracks local-storage provenance.

## Why the revision repairs could not work

Previous fixes tried to retire persisted response output after comparing `revAtSend` with the durable transcript revision. That cannot establish authority when:

```text
transcript.rev == optimistic.revAtSend
```

Production `/chat/3377` demonstrated the failure: stale assistant shadows survived the first reload at revision 279 and disappeared only after an unrelated write advanced the transcript to 280. An idle session could remain duplicated forever.

The fix makes persisted assistant/tool shadows unrepresentable instead of eventually reconciling them.

## Recovery contract

No server change is required:

1. Reload fetches the durable transcript and active response metadata.
2. Active response events replay from sequence zero.
3. If replay history is unavailable, the existing `409 snapshot_required` path fetches the response snapshot.
4. Partial assistant/tool output is already persisted incrementally into the durable transcript.

Neither `session.messages` nor `lastSequenceNumber` was persisted previously, so assistant/tool localStorage was not filling a distinct recovery gap.

## Migration

Storage schema moves to version 2.

Version 1 and unversioned payloads are filtered on every read:

- pending user intent is retained;
- assistant/tool recovery shadows are discarded;
- obsolete response IDs and segment ordinals cannot re-enter the projection.

Writes emit only version-2 intent entries. This remains safe even if an older tab writes a mixed payload later, because every read re-applies the role/ownership predicate.

## Removed complexity

- persisted optimistic provenance in `TranscriptStore`;
- `serverOwnsPersistedOutput` revision/active-owner repair logic;
- `persistedOptimisticSegmentIndexes`;
- distant transcript materialization done solely to compare server rows against browser shadows;
- persistence copying through store replacement and sideload staging.

Token streaming remains on the existing O(1) in-memory overlay path.

## Live verification

Deployed commit `615380d0` and tested both terminal and active sessions with deliberately poisoned version-1 localStorage.

### Equal-revision terminal session

Injected at the exact current revision:

- stale assistant with obsolete ordinal;
- stale tool group;
- valid queued user intent.

After reload:

```json
{
  "assistantDuplicates": [],
  "staleAssistantMounted": false,
  "staleToolMounted": false,
  "queuedIntentMounted": true,
  "storage": {
    "version": 2,
    "entries": [{"role": "user"}]
  }
}
```

### Reload during active response

Injected old assistant/tool shadows while another response was active, plus queued user intent with a valid durable sequence boundary.

After reload:

- active response identity and epoch remained attached;
- current response output was reconstructed from durable/recovery state;
- stale assistant/tool shadows never mounted;
- queued user intent remained in memory and version-2 storage;
- no assistant duplicates remained.

All temporary probes were removed and shared-browser storage was restored cleanly.

## Tests

Adversarial coverage includes:

- exact `rev == revAtSend` production regression;
- drifted assistant ordinal `99`;
- same/different active response owners;
- version-1 and unversioned migration;
- reload during active response;
- streaming assistant/tool write rejection;
- queued user intent preservation;
- storage rewrite to version 2.

Verification passed:

- all JavaScript suites;
- isolated `go test ./... -count=1`;
- `go test -race ./internal/serveui ./internal/session -count=1`;
- `go build ./...`;
- `git diff --check`.
