### PR TITLE
fix: make terminal response ownership absolute

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -1177,6 +1177,15 @@ const noteTranscriptTerminal = (session, responseId, finalRev, runEpoch = 0) => 
     observedCreatedEpoch: session?.latestRunEpoch || 0,
   });
   if (activeBefore && transcript.activeRun) return Promise.resolve(false);
+  if (!(session._terminalResponseRetirements instanceof Map)) {
+    session._terminalResponseRetirements = new Map();
+  }
+  const terminalResponseId = String(responseId || '').trim();
+  if (terminalResponseId) {
+    const targetRev = Math.max(0, Number(finalRev) || 0);
+    const previousTarget = Number(session._terminalResponseRetirements.get(terminalResponseId)) || 0;
+    session._terminalResponseRetirements.set(terminalResponseId, Math.max(previousTarget, targetRev));
+  }
   persistTranscriptOptimistic(session);
   return syncTranscript(session, {
     reason: 'terminal',
@@ -1461,6 +1470,24 @@ const materializeTranscriptSegments = (session, request) => {
   });
 };
 
+const commitTerminalResponseAuthority = (session, transcript) => {
+  const pending = session?._terminalResponseRetirements;
+  if (!(pending instanceof Map) || pending.size === 0 || !transcript) return [];
+  const removed = [];
+  for (const [responseId, targetRev] of [...pending]) {
+    // Never retire before the transcript revision named by the terminal event
+    // is present. An older in-flight/304 sync may complete first.
+    if ((Number(targetRev) || 0) > 0 && transcript.rev < Number(targetRev)) continue;
+    // A newer status sample may prove the response is still active. Keep its
+    // overlays until a later successful terminal sync establishes authority.
+    if (transcript.activeRun?.id === responseId) continue;
+    removed.push(...(transcript.retireResponseOutput?.(responseId) || []));
+    pending.delete(responseId);
+  }
+  if (pending.size === 0) delete session._terminalResponseRetirements;
+  return removed;
+};
+
 const syncTranscriptOnce = async (session, options = {}) => {
   const transcript = ensureSessionTranscript(session);
   if (!transcript) return false;
@@ -1479,6 +1506,7 @@ const syncTranscriptOnce = async (session, options = {}) => {
       replacement.addOptimistic(local, local.revAtSend);
     }
     if (activeRun) replacement.setActiveRun(activeRun.id, activeRun.startedRev, activeRun.epoch || 0);
+    commitTerminalResponseAuthority(session, replacement);
     replacement.reconcileOptimistic();
     transcript.destroy();
     session.transcript = replacement;
@@ -1524,7 +1552,10 @@ const syncTranscriptOnce = async (session, options = {}) => {
     // Reconcile while all requested bodies are present, then persist the
     // optimistic source before the transaction's final budget can evict a
     // distant turn. withViewportAnchor publishes one bounded projection after
-    // this callback resolves.
+    // this callback resolves. A successful terminal sync is also the ownership
+    // commit boundary: server-produced overlays from the completed response
+    // cannot survive merely because their segment ordinal drifted.
+    commitTerminalResponseAuthority(session, transcript);
     transcript.reconcileOptimistic();
     persistTranscriptOptimistic(session);
     return true;

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -6537,13 +6537,19 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
       compaction_count: 0,
       active_response_id: 'resp_assistant_tail',
       started_rev: 7,
-      rows: { ids: [401, 402], seqs: [401, 402], roles: 'ua', flags: [0, 0] }
+      rows: {
+        ids: [401, 402], seqs: [401, 402], roles: 'ua', flags: [0, 0],
+        response_ids: ['', 'resp_assistant_tail'], assistant_segment_ordinals: [-1, 0]
+      }
     }
     : {
       rev: 8,
       compaction_seq: -1,
       compaction_count: 0,
-      rows: { ids: [401, 403], seqs: [401, 403], roles: 'ua', flags: [0, 0] }
+      rows: {
+        ids: [401, 403], seqs: [401, 403], roles: 'ua', flags: [0, 0],
+        response_ids: ['', 'resp_assistant_tail'], assistant_segment_ordinals: [-1, 0]
+      }
     };
   const transcriptBodies = () => ({
     rev: phase === 'status' ? 7 : 8,
@@ -6553,6 +6559,8 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
         id: phase === 'status' ? 402 : 403,
         sequence: phase === 'status' ? 402 : 403,
         role: 'assistant',
+        response_id: 'resp_assistant_tail',
+        assistant_segment_ordinal: 0,
         created_at: 2000,
         parts: [{
           type: 'text',
@@ -6600,8 +6608,10 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
   session.transcript.setActiveRun('resp_assistant_tail', 7);
   const optimistic = {
     id: 'msg_assistant_tail',
-    clientKey: 'msg_assistant_tail',
+    clientKey: 'resp_assistant_tail:assistant:0',
     role: 'assistant',
+    responseId: 'resp_assistant_tail',
+    assistantSegmentOrdinal: 0,
     content: 'durable prefix plus optimistic suffix',
     revAtSend: 7,
     durableSeqAtSend: 401,
@@ -6632,6 +6642,15 @@ async function testAssistantTailOwnershipAcrossStatusTerminalAndInactiveRefresh(
     fail(name, 'partial durable coverage retired the live suffix source', JSON.stringify(session.transcript.optimistic));
     return;
   }
+
+  // Reproduce the live-only failure: a cursor/recovery race leaves the completed
+  // response overlay with a stale stable-looking ordinal. Ordinary identity
+  // reconciliation cannot pair ordinal 99 with durable ordinal 0, but terminal
+  // authority must still retire all server output owned by this response.
+  const driftedOverlay = session.transcript.optimistic[0];
+  driftedOverlay.assistantSegmentOrdinal = 99;
+  driftedOverlay.clientKey = 'resp_assistant_tail:assistant:99';
+  session.transcript.rebuildOptimisticIdentityIndex();
 
   phase = 'terminal';
   const terminalLoaded = await app.noteTranscriptTerminal(session, 8);

--- a/internal/serveui/static/transcript-store.js
+++ b/internal/serveui/static/transcript-store.js
@@ -1026,6 +1026,21 @@
       return removed;
     }
 
+    retireResponseOutput(responseId) {
+      const owner = String(responseId || '').trim();
+      if (!owner) return [];
+      const removed = this.optimistic.filter((entry) => (
+        messageResponseID(entry) === owner
+        && ['assistant', 'tool', 'tool-group'].includes(entry?.role)
+      ));
+      if (removed.length > 0) {
+        const removedSet = new Set(removed);
+        this.optimistic = this.optimistic.filter((entry) => !removedSet.has(entry));
+        this.rebuildOptimisticIdentityIndex();
+      }
+      return removed;
+    }
+
     clearTransientOptimistic() {
       const removed = this.optimistic.filter((entry) => entry?.transient);
       this.optimistic = this.optimistic.filter((entry) => !entry?.transient);

--- a/internal/serveui/static/transcript_store_test.js
+++ b/internal/serveui/static/transcript_store_test.js
@@ -721,6 +721,30 @@ const materializeOrdinals = (store, ordinals, estHeight = 20) => {
   assert.equal(transcriptIsClientOwnedIntent({ id: 'durable-user', role: 'user', durable: true }), false);
 })();
 
+// Terminal authority is response-scoped rather than segment-scoped. Once the
+// server confirms completion, every assistant/tool overlay owned by that
+// response is obsolete even when its segment identity drifted.
+(() => {
+  const store = new TranscriptStore('terminal-response-authority');
+  const staleAssistant = store.addOptimistic({
+    id: 'stale-assistant', role: 'assistant', responseId: 'resp_done',
+    assistantSegmentOrdinal: 99, content: 'duplicate output'
+  });
+  const staleTools = store.addOptimistic({
+    id: 'stale-tools', role: 'tool-group', responseId: 'resp_done',
+    tools: [{ id: 'call_done', status: 'done' }]
+  });
+  const newerAssistant = store.addOptimistic({
+    id: 'newer-assistant', role: 'assistant', responseId: 'resp_new',
+    assistantSegmentOrdinal: 0, content: 'still active'
+  });
+  const queuedUser = store.addOptimistic({ id: 'queued-user', role: 'user', content: 'next turn' });
+  assert.deepEqual(store.retireResponseOutput('resp_done'), [staleAssistant, staleTools]);
+  assert.deepEqual(store.optimistic, [newerAssistant, queuedUser]);
+  store._checkInvariants();
+  store.destroy();
+})();
+
 // Exact production regression: a durable row and a same-revision overlay for the
 // same response. Retirement must come from durable coverage, never from a
 // transcript revision that has not advanced past the overlay's capture point.


### PR DESCRIPTION
## What

Make successful terminal transcript synchronization an absolute response-ownership boundary.

Once the transcript reaches the revision named by a terminal response event, every in-memory assistant/tool overlay owned by that completed response is retired before the transaction publishes its single projection—regardless of segment ordinal or content.

## Remaining failure after #963

PR #963 correctly removed assistant/tool output from localStorage, but a completed response could still remain duplicated for the lifetime of an already-open page:

```text
srv_seq_*   durable response R, assistant ordinal 0
msg_*       in-memory response R, assistant ordinal 99
```

Ordinary reconciliation intentionally refused to pair two different stable-looking segment identities. That conservative rule is appropriate while response R is active, but wrong after R is terminal and its final durable revision has synchronized. The unmatched overlay then survived until reload, which discarded ephemeral state.

Production session #3396 demonstrated exactly that class: the server transcript contained one final assistant row while the open browser rendered it twice; reload removed the second card.

## Invariant

> After a successful transcript sync reaches response R's terminal revision, the server transcript is the sole authority for every assistant/tool output owned by R.

At that boundary, segment ordinal drift is irrelevant. The entire completed response—not an individual segment—is committed.

## Safety

Terminal retirements are tracked as `response_id -> final_rev` and committed inside the transcript transaction after authoritative bodies are loaded but before its single render boundary.

The implementation deliberately does **not** retire when:

- transcript synchronization fails;
- an older in-flight or `304` sync has not reached `final_rev`;
- server state still reports the same response as active.

It preserves:

- queued user intent;
- overlays owned by a newer/different response;
- all output while the server remains unavailable.

No content equality is used.

## Live verification

On the deployed branch, session #3396 was loaded cleanly and then deliberately given the exact failure:

```json
{
  "durable": {
    "id": "srv_seq_9_text_0",
    "responseId": "resp_N61Hj5xm5NdY",
    "ordinal": 0
  },
  "optimistic": {
    "id": "live_stale_terminal_overlay",
    "responseId": "resp_N61Hj5xm5NdY",
    "ordinal": 99
  }
}
```

Both carried identical assistant output and were simultaneously present in `session.messages`.

Calling the real terminal sync at the current revision produced:

```json
{
  "loaded": true,
  "after": [
    {
      "id": "srv_seq_9_text_0",
      "durable": true,
      "ordinal": 0
    }
  ],
  "optimistic": [],
  "publishedDuplicate": false,
  "stored": []
}
```

A MutationObserver sampled every DOM publication during the transaction. No duplicate projection was published. The duplicate was removed without reloading.

## Tests

- Store-level response retirement removes assistant/tool overlays across ordinal drift.
- Different-response output and queued user intent survive.
- Existing active-prefix test now mutates the overlay from ordinal 0 to ordinal 99 immediately before terminal synchronization.
- Terminal sync must still publish exactly one complete durable assistant.

Verification passed:

- all JavaScript suites;
- isolated `go test ./... -count=1`;
- `go test -race ./internal/serveui ./internal/session -count=1`;
- `go build ./...`;
- `git diff --check`.
