### PR TITLE
fix: Abandoned WebRTC handshakes permanently consume connection slots

### DIFF
--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -32,7 +32,10 @@ import (
 	"github.com/pion/stun/v3"
 )
 
-const maxFrameBytes = 10 * 1024 * 1024 // 10 MB
+const (
+	maxFrameBytes       = 10 * 1024 * 1024 // 10 MB
+	defaultSetupTimeout = 30 * time.Second
+)
 
 // Cap per-channel HTTP dispatches so one client cannot create an unbounded
 // number of expensive handler goroutines.
@@ -73,11 +76,12 @@ const maxChunkDataBytes = 16 * 1024
 
 // peer is the home-side WebRTC peer.
 type peer struct {
-	cfg     Config
-	handler http.Handler
-	cancel  context.CancelFunc
-	active  atomic.Int32
-	client  *http.Client
+	cfg          Config
+	handler      http.Handler
+	cancel       context.CancelFunc
+	active       atomic.Int32
+	client       *http.Client
+	setupTimeout time.Duration
 }
 
 // New creates and starts a WebRTC home peer.
@@ -100,10 +104,11 @@ func New(ctx context.Context, cfg Config, handler http.Handler) (Peer, error) {
 
 	peerCtx, cancel := context.WithCancel(ctx)
 	p := &peer{
-		cfg:     cfg,
-		handler: handler,
-		cancel:  cancel,
-		client:  &http.Client{Timeout: 15 * time.Second},
+		cfg:          cfg,
+		handler:      handler,
+		cancel:       cancel,
+		client:       &http.Client{Timeout: 15 * time.Second},
+		setupTimeout: defaultSetupTimeout,
 	}
 	go p.run(peerCtx)
 	return p, nil
@@ -456,6 +461,19 @@ func (p *peer) handleOffer(ctx context.Context, offer signalingMsg) {
 	defer iceConn.Close()
 	log.Printf("webrtc: ICE accepted for session %s remote=%s", offer.SessionID, iceConn.RemoteAddr())
 
+	// Bound every setup layer after ICE. SCTP and data-channel accept do not
+	// accept contexts, so close ICE when the deadline expires to wake their
+	// pending reads and release this connection's active slot.
+	setupCtx, setupCancel := context.WithTimeout(ctx, p.setupTimeout)
+	stopSetupClose := context.AfterFunc(setupCtx, func() {
+		_ = iceConn.Close()
+		_ = agent.Close()
+	})
+	defer func() {
+		stopSetupClose()
+		setupCancel()
+	}()
+
 	// Run DTLS server handshake over the ICE connection.
 	log.Printf("webrtc: starting DTLS handshake for session %s", offer.SessionID)
 	pconn := dtlsnet.PacketConnFromConn(iceConn)
@@ -475,10 +493,14 @@ func (p *peer) handleOffer(ctx context.Context, offer signalingMsg) {
 		},
 	})
 	if err != nil {
-		log.Printf("webrtc: DTLS handshake for session %s: %v", offer.SessionID, err)
+		log.Printf("webrtc: create DTLS server for session %s: %v", offer.SessionID, err)
 		return
 	}
 	defer dtlsConn.Close()
+	if err := dtlsConn.HandshakeContext(setupCtx); err != nil {
+		log.Printf("webrtc: DTLS handshake for session %s: %v", offer.SessionID, err)
+		return
+	}
 	log.Printf("webrtc: DTLS handshake complete for session %s", offer.SessionID)
 
 	// Establish SCTP association over DTLS.
@@ -511,6 +533,11 @@ func (p *peer) handleOffer(ctx context.Context, offer signalingMsg) {
 		return
 	}
 	defer dc.Close()
+	if !stopSetupClose() {
+		log.Printf("webrtc: setup deadline reached as data channel opened for session %s: %v", offer.SessionID, setupCtx.Err())
+		return
+	}
+	setupCancel()
 
 	p.runDataChannel(ctx, dc, func() {
 		_ = sctpAssoc.Close()

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -7,10 +7,14 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
+	"github.com/pion/ice/v4"
 )
 
 // newTestPeer creates a peer wired to handler with the given basePath,
@@ -53,6 +57,180 @@ func encodeRequest(id, method, path string, headers map[string]string, body stri
 	}
 	data, _ := json.Marshal(f)
 	return data
+}
+
+func gatherTestICEAgent(t *testing.T) (*ice.Agent, string, string, []ice.Candidate) {
+	t.Helper()
+
+	agent, err := ice.NewAgentWithOptions(
+		ice.WithNetworkTypes([]ice.NetworkType{ice.NetworkTypeUDP4}),
+	)
+	if err != nil {
+		t.Fatalf("create browser ICE agent: %v", err)
+	}
+	t.Cleanup(func() { _ = agent.Close() })
+
+	gathered := make(chan struct{})
+	var gatherOnce sync.Once
+	if err := agent.OnCandidate(func(candidate ice.Candidate) {
+		if candidate == nil {
+			gatherOnce.Do(func() { close(gathered) })
+		}
+	}); err != nil {
+		t.Fatalf("register browser candidate callback: %v", err)
+	}
+	if err := agent.GatherCandidates(); err != nil {
+		t.Fatalf("gather browser ICE candidates: %v", err)
+	}
+	select {
+	case <-gathered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out gathering browser ICE candidates")
+	}
+
+	ufrag, pwd, err := agent.GetLocalUserCredentials()
+	if err != nil {
+		t.Fatalf("get browser ICE credentials: %v", err)
+	}
+	candidates, err := agent.GetLocalCandidates()
+	if err != nil {
+		t.Fatalf("get browser ICE candidates: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Fatal("browser ICE agent gathered no candidates")
+	}
+	return agent, ufrag, pwd, candidates
+}
+
+func TestHandleOffer_SetupTimeoutReleasesConnectionSlot(t *testing.T) {
+	browserAgent, browserUfrag, browserPwd, browserCandidates := gatherTestICEAgent(t)
+	browserCert, err := selfsign.GenerateSelfSigned()
+	if err != nil {
+		t.Fatalf("generate browser certificate: %v", err)
+	}
+	browserFingerprint, err := certFingerprint(browserCert)
+	if err != nil {
+		t.Fatalf("fingerprint browser certificate: %v", err)
+	}
+	offerSDP, err := buildAnswer(browserUfrag, browserPwd, browserFingerprint, "0", browserCandidates)
+	if err != nil {
+		t.Fatalf("build browser offer: %v", err)
+	}
+	firstOffer := signalingMsg{SessionID: "abandoned", Type: "offer", SDP: offerSDP}
+	secondOffer := signalingMsg{SessionID: "next", Type: "offer", SDP: offerSDP}
+
+	answers := make(chan signalingMsg, 2)
+	var pollMu sync.Mutex
+	var polledOffer *signalingMsg
+	signaling := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var answer signalingMsg
+			if err := json.NewDecoder(r.Body).Decode(&answer); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			answers <- answer
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			pollMu.Lock()
+			offer := polledOffer
+			polledOffer = nil
+			pollMu.Unlock()
+			if offer == nil {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(offer)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer signaling.Close()
+
+	p := &peer{
+		cfg: Config{
+			SignalingURL: signaling.URL,
+			MaxConns:     1,
+		},
+		handler:      http.NotFoundHandler(),
+		client:       signaling.Client(),
+		setupTimeout: 200 * time.Millisecond,
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		p.handleOffer(context.Background(), firstOffer)
+	}()
+
+	var firstAnswer signalingMsg
+	select {
+	case firstAnswer = <-answers:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first WebRTC answer")
+	}
+	if got := p.active.Load(); got != 1 {
+		t.Fatalf("active connections after first answer = %d, want 1", got)
+	}
+
+	answerInfo, err := parseOffer(firstAnswer.SDP)
+	if err != nil {
+		t.Fatalf("parse first WebRTC answer: %v", err)
+	}
+	for _, rawCandidate := range answerInfo.candidates {
+		candidate, err := ice.UnmarshalCandidate(rawCandidate)
+		if err != nil {
+			t.Fatalf("parse answer ICE candidate: %v", err)
+		}
+		if err := browserAgent.AddRemoteCandidate(candidate); err != nil {
+			t.Fatalf("add answer ICE candidate: %v", err)
+		}
+	}
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	browserConn, err := browserAgent.Dial(dialCtx, answerInfo.iceUfrag, answerInfo.icePwd)
+	cancelDial()
+	if err != nil {
+		t.Fatalf("complete browser ICE connection: %v", err)
+	}
+	defer browserConn.Close()
+	// Deliberately send no DTLS ClientHello after ICE connectivity succeeds.
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("abandoned WebRTC setup did not return after setup timeout")
+	}
+	if got := p.active.Load(); got != 0 {
+		t.Fatalf("active connections after setup timeout = %d, want 0", got)
+	}
+
+	pollMu.Lock()
+	polledOffer = &secondOffer
+	pollMu.Unlock()
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	if err := p.pollOnce(secondCtx); err != nil {
+		cancelSecond()
+		t.Fatalf("poll subsequent offer: %v", err)
+	}
+	select {
+	case answer := <-answers:
+		if answer.SessionID != secondOffer.SessionID {
+			t.Fatalf("subsequent answer session = %q, want %q", answer.SessionID, secondOffer.SessionID)
+		}
+	case <-time.After(5 * time.Second):
+		cancelSecond()
+		t.Fatal("subsequent offer was rejected after abandoned setup")
+	}
+	cancelSecond()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for p.active.Load() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := p.active.Load(); got != 0 {
+		t.Fatalf("active connections after canceling subsequent offer = %d, want 0", got)
+	}
 }
 
 type blockingReadDataChannel struct {


### PR DESCRIPTION
## What changed

- Added a 30-second deadline covering DTLS, SCTP, and data-channel establishment after ICE connectivity succeeds.
- Explicitly run the DTLS handshake with that bounded context.
- Close the ICE connection/agent when setup is canceled or times out so blocking SCTP or data-channel reads wake up.
- Stop the setup-close callback only after the data channel is fully established, preserving the existing long-lived data-channel behavior.
- Added an integration test that completes a real local ICE pair without sending a DTLS ClientHello, verifies the abandoned handler releases its sole active slot, and verifies a subsequent offer is accepted.

## Why this is high-value

An abandoned browser setup could previously block forever between ICE acceptance and data-channel establishment. Every occurrence retained a goroutine and its ICE/DTLS/SCTP resources while permanently consuming one of the default 10 WebRTC connection slots. Normal browser disconnects or network transitions could therefore accumulate into a complete WebRTC outage requiring a serve-process restart. The bounded setup phase makes those slots self-healing while leaving established data channels under the existing idle-timeout lifecycle.

## Validation

- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `go test -race ./internal/webrtc`
- `go test ./internal/webrtc -run TestHandleOffer_SetupTimeoutReleasesConnectionSlot -count=10`
- `git diff --check`

The unisolated full test command encountered the repository's existing user-config-dependent skill visibility failures; the full suite passes with an isolated `XDG_CONFIG_HOME`.
