### PR TITLE
fix: keep long transcript viewport at tail

### DIFF
--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -6163,6 +6163,121 @@ async function testTranscriptSyncCommitsOneRenderedProjection() {
   pass(name);
 }
 
+async function testBottomPinnedTranscriptSyncKeepsFollowingTail() {
+  const name = 'bottom-pinned transcript sync keeps distant tails through repeated anchored commits';
+  const sessionId = 'follow-live-tail';
+  let servedTurns = 3;
+  const pendingTurns = [8, 13, 18];
+  let anchorID = 5;
+  const makeIndex = (turns) => {
+    const ids = Array.from({ length: turns * 2 }, (_, ordinal) => ordinal + 1);
+    return {
+      rev: turns * 2,
+      compaction_seq: -1,
+      compaction_count: 0,
+      rows: {
+        ids,
+        seqs: ids.map((id) => id - 1),
+        roles: 'ua'.repeat(turns),
+        flags: ids.map(() => 0),
+        response_ids: ids.map((id) => id % 2 === 0 ? `resp-${id / 2 - 1}` : ''),
+        assistant_segment_ordinals: ids.map((id) => id % 2 === 0 ? 0 : -1),
+      }
+    };
+  };
+  const turnBodies = (startIDs) => startIDs.flatMap((id) => [
+    { id, sequence: id - 1, role: 'user', parts: [{ type: 'text', text: `question-${id}` }] },
+    { id: id + 1, sequence: id, role: 'assistant', parts: [{ type: 'text', text: `answer-${id + 1}` }] },
+  ]);
+
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (isTranscriptIndexURL(url, sessionId)) {
+        servedTurns = pendingTurns.shift() || servedTurns;
+        return new Response(JSON.stringify(makeIndex(servedTurns)), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', ETag: `"tail-${servedTurns}"` }
+        });
+      }
+      if (isTranscriptBodiesURL(url, sessionId)) {
+        const ids = String(parsedTestURL(url)?.searchParams.get('ids') || '').split(',').filter(Boolean).map(Number);
+        return new Response(JSON.stringify({ rev: servedTurns * 2, messages: turnBodies(ids) }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
+    appOverrides: { renderMessages() {} }
+  });
+  app.stopSidebarStatusPoll();
+
+  const messages = app.elements.messages;
+  const chatScroll = app.elements.chatScroll;
+  chatScroll.clientHeight = 400;
+  chatScroll.getBoundingClientRect = () => ({ top: 0, bottom: 400 });
+  const anchorNode = {
+    dataset: {},
+    getBoundingClientRect: () => ({ top: 0, bottom: 40 })
+  };
+  Object.defineProperty(anchorNode.dataset, 'durableId', { get: () => String(anchorID) });
+  messages.querySelectorAll = (selector) => selector === '[data-durable-id]' ? [anchorNode] : [];
+  messages.querySelector = (selector) => String(selector) === `[data-durable-id="${anchorID}"]` ? anchorNode : null;
+
+  const session = { id: sessionId, messages: [] };
+  const transcript = new windowObj.ConversationController(sessionId, { maxMaterializedTurns: 3, overscanTurns: 0 });
+  transcript.applyIndex(makeIndex(3));
+  transcript.setViewport(5, 5);
+  transcript.materialize(turnBodies([1, 3, 5]), { countFetch: false });
+  session.transcript = transcript;
+  app.state.sessions = [session];
+  app.state.activeSessionId = sessionId;
+  app.state.draftSessionActive = false;
+  app.state.autoScroll = true;
+
+  for (const expectedTurns of [8, 13]) {
+    const loaded = await app.syncTranscript(session, { reason: 'tail-follow-regression', force: true });
+    const tail = transcript.segments[expectedTurns - 1];
+    const materialized = transcript.segments.filter((segment) => segment.state === 'materialized').length;
+    if (!loaded || transcript.ids.length !== expectedTurns * 2 || tail?.state !== 'materialized'
+      || transcript.viewport.lastOrdinal !== transcript.ids.length - 1 || materialized > 3) {
+      fail(name, 'bottom-owned sync lost or over-materialized a distant tail', JSON.stringify({
+        loaded,
+        expectedTurns,
+        viewport: transcript.viewport,
+        tailState: tail?.state,
+        materialized,
+      }));
+      return;
+    }
+    anchorID = expectedTurns * 2 - 1;
+  }
+
+  app.state.autoScroll = false;
+  const historicalAnchor = anchorID;
+  const loadedAway = await app.syncTranscript(session, { reason: 'preserve-history', force: true });
+  const materializedAway = transcript.segments.filter((segment) => segment.state === 'materialized').length;
+  if (!loadedAway || transcript.viewport.firstOrdinal !== historicalAnchor - 1
+    || transcript.viewport.lastOrdinal === transcript.ids.length - 1
+    || transcript.pinnedSegments.has(transcript.segments.length - 1)
+    || materializedAway > 3) {
+    fail(name, 'scrolled-away sync was dragged to or over-pinned the new tail', JSON.stringify({
+      loadedAway,
+      historicalAnchor,
+      viewport: transcript.viewport,
+      tailState: transcript.segments.at(-1)?.state,
+      materialized: transcript.segments.map((segment, index) => segment.state === 'materialized' ? index : null).filter((index) => index != null),
+      pinned: [...transcript.pinnedSegments],
+    }));
+    return;
+  }
+  transcript._checkInvariants();
+  pass(name);
+}
+
 async function testSatisfiedInflightRevisionDoesNotRefetchTranscript() {
   const name = 'in-flight sync absorbs forced active-status target satisfied by its response';
   const sessionId = 'coalesced-revision-sync';
@@ -6346,6 +6461,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testReloadRetiresStalePersistedAssistantIdentityAfterTerminalAdvance();
   await testReloadScopesStalePersistedRetirementToCurrentActiveResponse();
   await testTranscriptSyncCommitsOneRenderedProjection();
+  await testBottomPinnedTranscriptSyncKeepsFollowingTail();
   await testSatisfiedInflightRevisionDoesNotRefetchTranscript();
   await testInflightSyncAbsorbsQueuedZeroRevisionActivation();
   await testTranscriptProjectionAnnotatesCompactionBoundaryOnceAcrossSegments();

--- a/internal/serveui/static/conversation.js
+++ b/internal/serveui/static/conversation.js
@@ -552,6 +552,10 @@
       };
       return {
         capture: () => {
+          // Bottom stickiness is the anchor. Capturing a durable row here would
+          // restore an old ordinal after append-only growth and let final budget
+          // enforcement evict the newly fetched tail before it can render.
+          if (forceScroll || state.autoScroll) return null;
           const viewport = scrollRect();
           const nodes = Array.from(elements.messages.querySelectorAll?.('[data-durable-id]') || []);
           const node = nodes.find((candidate) => {
@@ -775,9 +779,10 @@
       }
     
       const adapter = transcriptViewportAdapter(session, options.forceScroll === true);
+      const followTail = Boolean(adapter && (options.forceScroll === true || state.autoScroll));
       const loaded = await transcript.withViewportAnchor(adapter, async () => {
         if (data) applyTranscriptIndex(transcript, data, resp.headers?.get?.('ETag') || '');
-        if (transcript.ids.length > 0 && transcript.viewport.firstOrdinal < 0) {
+        if (transcript.ids.length > 0 && (followTail || transcript.viewport.firstOrdinal < 0)) {
           const last = transcript.ids.length - 1;
           transcript.setViewport(last, last, { deferBudget: true });
         }

--- a/internal/serveui/static/transcript-window.js
+++ b/internal/serveui/static/transcript-window.js
@@ -63,9 +63,6 @@
         ? rows.assistant_segment_ordinals.map((value) => finiteInt(value, -1))
         : ids.map(() => -1);
       const incomingRev = finiteInt(envelope?.rev, this.rev);
-      const previousLength = this.ids.length;
-      const previousViewport = { ...this.viewport };
-      const followedPreviousTail = previousLength > 0 && previousViewport.lastOrdinal >= previousLength - 1;
       const rollback = incomingRev < this.rev;
       if (ids.length !== seqs.length || ids.length !== flags.length || ids.length !== roles.length
         || ids.length !== responseIDs.length || ids.length !== assistantSegmentOrdinals.length) {
@@ -120,17 +117,15 @@
       this.compactionSeq = finiteInt(envelope?.compaction_seq, -1);
       this.compactionCount = finiteInt(envelope?.compaction_count, 0);
       this.rebuildSegments(oldSegmentState);
-      // Ordinals are positions, not stable viewport anchors. If the viewport owned
-      // the old tail, append-only growth must move it to the new tail before body
-      // budgeting; otherwise a distant freshly fetched tail can be evicted at once.
-      if (appendOnly && followedPreviousTail && ids.length > previousLength) {
-        const span = previousViewport.firstOrdinal >= 0
-          ? Math.max(0, previousViewport.lastOrdinal - previousViewport.firstOrdinal)
-          : 0;
-        this.viewport = {
-          firstOrdinal: Math.max(0, ids.length - 1 - span),
-          lastOrdinal: ids.length - 1,
-        };
+      // Rewrites and compaction can retire the ordinals a viewport referred to.
+      // An invalid positive viewport pins nothing and corrupts eviction distance;
+      // reset it to the existing implicit-tail sentinel instead.
+      if (ids.length === 0) {
+        this.viewport = { firstOrdinal: -1, lastOrdinal: -1 };
+      } else if (this.viewport.firstOrdinal < 0 || this.viewport.lastOrdinal < 0
+        || this.viewport.firstOrdinal >= ids.length || this.viewport.lastOrdinal >= ids.length
+        || this.viewport.lastOrdinal < this.viewport.firstOrdinal) {
+        this.viewport = { firstOrdinal: -1, lastOrdinal: -1 };
       }
       this.rev = incomingRev;
       if (etag) this.etag = String(etag);

--- a/internal/serveui/static/transcript-window.js
+++ b/internal/serveui/static/transcript-window.js
@@ -63,6 +63,9 @@
         ? rows.assistant_segment_ordinals.map((value) => finiteInt(value, -1))
         : ids.map(() => -1);
       const incomingRev = finiteInt(envelope?.rev, this.rev);
+      const previousLength = this.ids.length;
+      const previousViewport = { ...this.viewport };
+      const followedPreviousTail = previousLength > 0 && previousViewport.lastOrdinal >= previousLength - 1;
       const rollback = incomingRev < this.rev;
       if (ids.length !== seqs.length || ids.length !== flags.length || ids.length !== roles.length
         || ids.length !== responseIDs.length || ids.length !== assistantSegmentOrdinals.length) {
@@ -117,6 +120,18 @@
       this.compactionSeq = finiteInt(envelope?.compaction_seq, -1);
       this.compactionCount = finiteInt(envelope?.compaction_count, 0);
       this.rebuildSegments(oldSegmentState);
+      // Ordinals are positions, not stable viewport anchors. If the viewport owned
+      // the old tail, append-only growth must move it to the new tail before body
+      // budgeting; otherwise a distant freshly fetched tail can be evicted at once.
+      if (appendOnly && followedPreviousTail && ids.length > previousLength) {
+        const span = previousViewport.firstOrdinal >= 0
+          ? Math.max(0, previousViewport.lastOrdinal - previousViewport.firstOrdinal)
+          : 0;
+        this.viewport = {
+          firstOrdinal: Math.max(0, ids.length - 1 - span),
+          lastOrdinal: ids.length - 1,
+        };
+      }
       this.rev = incomingRev;
       if (etag) this.etag = String(etag);
       this.refreshPinnedSegments();

--- a/internal/serveui/static/transcript_window_test.js
+++ b/internal/serveui/static/transcript_window_test.js
@@ -42,6 +42,67 @@ const index = {
   }), /sparse client_message_id/);
 })();
 
+const turnIndex = (turns, rev = turns * 2) => {
+  const ids = [];
+  const seqs = [];
+  const responseIDs = [];
+  const assistantOrdinals = [];
+  for (let turn = 0; turn < turns; turn++) {
+    ids.push(turn * 2 + 1, turn * 2 + 2);
+    seqs.push(turn * 2, turn * 2 + 1);
+    responseIDs.push('', `resp-${turn}`);
+    assistantOrdinals.push(-1, 0);
+  }
+  return {
+    rev,
+    compaction_seq: -1,
+    compaction_count: 0,
+    rows: {
+      ids,
+      seqs,
+      roles: 'ua'.repeat(turns),
+      flags: ids.map(() => 0),
+      client_message_ids: Object.fromEntries(Array.from({ length: turns }, (_, turn) => [turn * 2, `client-${turn}`])),
+      response_ids: responseIDs,
+      assistant_segment_ordinals: assistantOrdinals,
+    },
+  };
+};
+
+(() => {
+  const atTail = new TranscriptWindow('follow-tail', { maxMaterializedTurns: 2, overscanTurns: 0 });
+  atTail.applyIndex(turnIndex(3));
+  atTail.setViewport(5, 5);
+  atTail.materializeSegment(1, [
+    { id: 3, sequence: 2, role: 'user' },
+    { id: 4, sequence: 3, role: 'assistant' },
+  ]);
+  atTail.materializeSegment(2, [
+    { id: 5, sequence: 4, role: 'user' },
+    { id: 6, sequence: 5, role: 'assistant' },
+  ]);
+
+  const appended = atTail.applyIndex(turnIndex(10));
+  assert.equal(appended.appendOnly, true);
+  assert.deepEqual(atTail.viewport, { firstOrdinal: 19, lastOrdinal: 19 }, 'tail-following viewport advances across an append-only gap');
+  assert(atTail.pinnedSegments.has(9), 'new tail segment is pinned before body-budget enforcement');
+  atTail.materializeSegment(9, [
+    { id: 19, sequence: 18, role: 'user' },
+    { id: 20, sequence: 19, role: 'assistant' },
+  ]);
+  assert.equal(atTail.segments[9].state, 'materialized', 'distant new tail survives a full materialized-turn budget');
+  assert.equal(atTail.segments[1].state, 'evicted', 'an older unpinned turn pays the body budget instead');
+  atTail._checkInvariants();
+
+  const scrolledAway = new TranscriptWindow('preserve-scroll', { maxMaterializedTurns: 2, overscanTurns: 0 });
+  scrolledAway.applyIndex(turnIndex(3));
+  scrolledAway.setViewport(0, 1);
+  scrolledAway.applyIndex(turnIndex(10));
+  assert.deepEqual(scrolledAway.viewport, { firstOrdinal: 0, lastOrdinal: 1 }, 'an append-only gap does not drag a historical viewport to the tail');
+  assert(!scrolledAway.pinnedSegments.has(9), 'new tail remains unpinned while the user reads history');
+  scrolledAway._checkInvariants();
+})();
+
 (async () => {
   const window = new TranscriptWindow('anchor');
   window.applyIndex(index);

--- a/internal/serveui/static/transcript_window_test.js
+++ b/internal/serveui/static/transcript_window_test.js
@@ -42,65 +42,34 @@ const index = {
   }), /sparse client_message_id/);
 })();
 
-const turnIndex = (turns, rev = turns * 2) => {
-  const ids = [];
-  const seqs = [];
-  const responseIDs = [];
-  const assistantOrdinals = [];
-  for (let turn = 0; turn < turns; turn++) {
-    ids.push(turn * 2 + 1, turn * 2 + 2);
-    seqs.push(turn * 2, turn * 2 + 1);
-    responseIDs.push('', `resp-${turn}`);
-    assistantOrdinals.push(-1, 0);
-  }
-  return {
-    rev,
+(() => {
+  const window = new TranscriptWindow('compaction-viewport', { overscanTurns: 0 });
+  window.applyIndex({
+    rev: 6,
     compaction_seq: -1,
     compaction_count: 0,
     rows: {
-      ids,
-      seqs,
-      roles: 'ua'.repeat(turns),
-      flags: ids.map(() => 0),
-      client_message_ids: Object.fromEntries(Array.from({ length: turns }, (_, turn) => [turn * 2, `client-${turn}`])),
-      response_ids: responseIDs,
-      assistant_segment_ordinals: assistantOrdinals,
+      ids: [1, 2, 3, 4, 5, 6],
+      seqs: [0, 1, 2, 3, 4, 5],
+      roles: 'uauaua',
+      flags: [0, 0, 0, 0, 0, 0],
     },
-  };
-};
-
-(() => {
-  const atTail = new TranscriptWindow('follow-tail', { maxMaterializedTurns: 2, overscanTurns: 0 });
-  atTail.applyIndex(turnIndex(3));
-  atTail.setViewport(5, 5);
-  atTail.materializeSegment(1, [
-    { id: 3, sequence: 2, role: 'user' },
-    { id: 4, sequence: 3, role: 'assistant' },
-  ]);
-  atTail.materializeSegment(2, [
-    { id: 5, sequence: 4, role: 'user' },
-    { id: 6, sequence: 5, role: 'assistant' },
-  ]);
-
-  const appended = atTail.applyIndex(turnIndex(10));
-  assert.equal(appended.appendOnly, true);
-  assert.deepEqual(atTail.viewport, { firstOrdinal: 19, lastOrdinal: 19 }, 'tail-following viewport advances across an append-only gap');
-  assert(atTail.pinnedSegments.has(9), 'new tail segment is pinned before body-budget enforcement');
-  atTail.materializeSegment(9, [
-    { id: 19, sequence: 18, role: 'user' },
-    { id: 20, sequence: 19, role: 'assistant' },
-  ]);
-  assert.equal(atTail.segments[9].state, 'materialized', 'distant new tail survives a full materialized-turn budget');
-  assert.equal(atTail.segments[1].state, 'evicted', 'an older unpinned turn pays the body budget instead');
-  atTail._checkInvariants();
-
-  const scrolledAway = new TranscriptWindow('preserve-scroll', { maxMaterializedTurns: 2, overscanTurns: 0 });
-  scrolledAway.applyIndex(turnIndex(3));
-  scrolledAway.setViewport(0, 1);
-  scrolledAway.applyIndex(turnIndex(10));
-  assert.deepEqual(scrolledAway.viewport, { firstOrdinal: 0, lastOrdinal: 1 }, 'an append-only gap does not drag a historical viewport to the tail');
-  assert(!scrolledAway.pinnedSegments.has(9), 'new tail remains unpinned while the user reads history');
-  scrolledAway._checkInvariants();
+  });
+  window.setViewport(4, 5);
+  window.applyIndex({
+    rev: 7,
+    compaction_seq: 5,
+    compaction_count: 2,
+    rows: {
+      ids: [101, 102],
+      seqs: [0, 1],
+      roles: 'ua',
+      flags: [0, 0],
+    },
+  });
+  assert.deepEqual(window.viewport, { firstOrdinal: -1, lastOrdinal: -1 }, 'compaction resets a retired viewport to implicit tail ownership');
+  assert.deepEqual([...window.pinnedSegments], [0], 'compaction leaves the replacement tail pinned');
+  window._checkInvariants();
 })();
 
 (async () => {


### PR DESCRIPTION
## Problem

A bottom-sticky transcript sync still captured the first visible durable DOM row as a historical scroll anchor. When a long or stale session appended a distant tail, the transaction then:

1. fetched the new tail with body-budget enforcement deferred;
2. restored the old durable anchor before the transaction's final budget pass;
3. ranked the new tail as the farthest unpinned materialized turn;
4. evicted it before the transaction's single render boundary.

Reload appeared to fix it because activation explicitly starts with tail ownership.

## Fix

Make viewport ownership explicit at the transaction boundary:

- when `autoScroll` or `forceScroll` owns the bottom, do not capture a historical durable-row anchor;
- re-seat the transcript viewport at the current final ordinal on every sync, including `304` body refreshes;
- when the user has scrolled away, retain durable-row anchoring and do not pin or move to the new tail;
- if compaction, rollback, or rewrite leaves viewport ordinals outside the new index, reset to the existing implicit-tail sentinel instead of retaining a positive viewport that pins nothing and corrupts eviction distance.

Virtualization and the **60 materialized turn / 8 overscan turn** defaults remain intact.

## Regression coverage

The integration regression runs the real `syncTranscript` transaction with deferred body budgeting and a real durable DOM anchor:

- starts with a full **3-turn** materialization budget at **3 turns**;
- append-only sync to **8 turns** keeps turn 8 materialized;
- a second append-only sync to **13 turns** also keeps turn 13 materialized, proving ownership survives consecutive transactions;
- switching `autoScroll` off before growth to **18 turns** preserves the historical anchor, does not pin the new tail, and remains within the 3-turn budget.

A separate compaction test shrinks a viewport at ordinals `4..5` to a 2-row replacement transcript and verifies it becomes `-1..-1` with the replacement tail pinned.

Both tests fail against the original PR head (`01bf8191`): the first distant tail is evicted, and the compacted viewport remains out of range.

## Review

Reviewed with `claude-bin:opus-medium`. Its high-severity finding exposed that the original ordinal-span implementation could resurrect a stale post-compaction viewport into a 32-turn pin and effectively disable body budgeting. That implementation has been removed rather than patched around.

## Verification

- transcript window, conversation, app session, and app stream JavaScript suites
- clean isolated `go test ./... -count=1`
- `go test -race ./internal/serveui ./internal/session -count=1`
- `go build ./...`
- `git diff --check`

No binary was installed and no service was restarted after the review amendments.
### Phone/background resume

The deployed failure is specifically reproducible when a bottom-sticky mobile page is suspended, viewport/layout events flip `autoScroll` while hidden, and status reconciliation catches up several turns while a newer response is still active. Sequencing remains correct, but the old durable anchor wins the final budget pass and the fetched tail is evicted before render.

The page now snapshots the user's tail/history ownership on the first `visibilitychange(hidden)` or `pagehide`, restores that exact ownership before the visibility/pageshow status poll, and ignores synthetic hidden-layout changes in either direction. The status transaction can therefore commit the missing durable turns before reconnecting the active response.

The integration test drives the actual hidden → synthetic mobile scroll → visible → status reconciliation path twice, across **3 → 8 → 13 turns** with a full **3-turn** materialization budget and an active response. Both tails render and remain bounded. A separate test verifies an intentionally historical viewport remains historical despite an inverse synthetic layout event.

The deployed `01bf8191` build fails this test at the first catch-up: transcript sequencing reaches 8 turns, but the viewport stays at ordinal 4 and turn 8 is evicted. The amended branch passes.
