### PR TITLE
fix: Provider streams retain a full unused Event copy for every delta

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1623,7 +1623,7 @@ func (e *Engine) runSimpleScratchpad(ctx context.Context, req Request, send even
 			return err
 		}
 
-		var scratchpad []Event
+		var scratchpadHasVisibleOutput bool
 		var textBuilder strings.Builder
 		var reasoningBuilder strings.Builder
 		var reasoningTextItemID string
@@ -1659,7 +1659,7 @@ func (e *Engine) runSimpleScratchpad(ctx context.Context, req Request, send even
 				if event.Text != "" {
 					textBuilder.WriteString(event.Text)
 				}
-				scratchpad = append(scratchpad, event)
+				scratchpadHasVisibleOutput = true
 				if err := send.Send(event); err != nil {
 					_ = stream.Close()
 					return err
@@ -1680,7 +1680,7 @@ func (e *Engine) runSimpleScratchpad(ctx context.Context, req Request, send even
 					reasoningEncryptedContent = event.ReasoningEncryptedContent
 					reasoningKind = MergeReasoningKind(reasoningKind, event.ReasoningKind)
 				}
-				scratchpad = append(scratchpad, event)
+				scratchpadHasVisibleOutput = true
 				if err := send.Send(event); err != nil {
 					_ = stream.Close()
 					return err
@@ -1692,13 +1692,13 @@ func (e *Engine) runSimpleScratchpad(ctx context.Context, req Request, send even
 					metrics.CachedInputTokens += event.Use.CachedInputTokens
 					metrics.CacheWriteTokens += event.Use.CacheWriteTokens
 				}
-				scratchpad = append(scratchpad, event)
+				scratchpadHasVisibleOutput = true
 				if err := send.Send(event); err != nil {
 					_ = stream.Close()
 					return err
 				}
 			case EventImageGenerated:
-				scratchpad = append(scratchpad, event)
+				scratchpadHasVisibleOutput = true
 				if err := send.Send(event); err != nil {
 					_ = stream.Close()
 					return err
@@ -1723,7 +1723,7 @@ func (e *Engine) runSimpleScratchpad(ctx context.Context, req Request, send even
 				return failed
 			}
 			attempt := retry + 1
-			if len(scratchpad) > 0 {
+			if scratchpadHasVisibleOutput {
 				if err := send.Send(Event{Type: EventAttemptDiscard}); err != nil {
 					return err
 				}
@@ -2177,16 +2177,16 @@ turnLoop:
 				reasoningKind,
 			)
 		}
-		var scratchpadEvents []Event // Attempt-local visible model output that can be discarded/replayed until a tool boundary.
-		scratchpadCommitted := false // True after provider completion or after a tool-call boundary makes assistant work durable.
+		var scratchpadHasVisibleOutput bool // Whether attempt-local model output needs discarding on an uncommitted retry.
+		scratchpadCommitted := false        // True after provider completion or after a tool-call boundary makes assistant work durable.
 		stageOrSendModelEvent := func(event Event) error {
 			if !scratchpadCommitted {
-				scratchpadEvents = append(scratchpadEvents, event)
+				scratchpadHasVisibleOutput = true
 			}
 			return send.Send(event)
 		}
 		flushScratchpad := func() error {
-			scratchpadEvents = nil
+			scratchpadHasVisibleOutput = false
 			scratchpadCommitted = true
 			return nil
 		}
@@ -2454,7 +2454,7 @@ turnLoop:
 			}
 			uncommittedStreamRetries++
 			uncommittedPriorErr = cause
-			if len(scratchpadEvents) > 0 {
+			if scratchpadHasVisibleOutput {
 				if err := send.Send(Event{Type: EventAttemptDiscard}); err != nil {
 					return false, err
 				}
@@ -2470,7 +2470,7 @@ turnLoop:
 			slog.Debug("retrying failed uncommitted model stream", "attempt", uncommittedStreamRetries, "error", cause)
 			// Drop all attempt-local assistant output. Nothing from this provider
 			// attempt crossed a durable boundary, so replaying the same request is safe.
-			scratchpadEvents = nil
+			scratchpadHasVisibleOutput = false
 			if softCheckpointInProgress {
 				softCompactionUsage = Usage{}
 			}

--- a/internal/llm/engine_benchmark_test.go
+++ b/internal/llm/engine_benchmark_test.go
@@ -105,3 +105,60 @@ func BenchmarkLoggingStreamTextDeltas(b *testing.B) {
 		}
 	}
 }
+
+type scratchpadBenchmarkProvider struct {
+	events    []Event
+	toolCalls bool
+}
+
+func (p *scratchpadBenchmarkProvider) Name() string       { return "scratchpad-benchmark" }
+func (p *scratchpadBenchmarkProvider) Credential() string { return "test" }
+func (p *scratchpadBenchmarkProvider) Capabilities() Capabilities {
+	return Capabilities{ToolCalls: p.toolCalls}
+}
+func (p *scratchpadBenchmarkProvider) Stream(context.Context, Request) (Stream, error) {
+	return &benchmarkEventStream{events: p.events}, nil
+}
+
+func BenchmarkProviderStreamScratchpad(b *testing.B) {
+	const deltaCount = 4096
+	events := make([]Event, 0, deltaCount+1)
+	for i := 0; i < deltaCount; i++ {
+		if i%2 == 0 {
+			events = append(events, Event{Type: EventTextDelta, Text: "x"})
+		} else {
+			events = append(events, Event{Type: EventReasoningDelta, Text: "r", ReasoningKind: ReasoningKindRaw})
+		}
+	}
+	events = append(events, Event{Type: EventDone})
+
+	b.Run("Simple", func(b *testing.B) {
+		provider := &scratchpadBenchmarkProvider{events: events}
+		engine := NewEngine(provider, nil)
+		req := Request{Messages: []Message{UserText("benchmark")}}
+		b.SetBytes(deltaCount)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := engine.runSimpleScratchpad(context.Background(), req, eventSender{}); err != nil {
+				b.Fatalf("runSimpleScratchpad returned error: %v", err)
+			}
+		}
+	})
+
+	b.Run("Agentic", func(b *testing.B) {
+		provider := &scratchpadBenchmarkProvider{events: events, toolCalls: true}
+		engine := NewEngine(provider, NewToolRegistry())
+		req := Request{
+			Messages: []Message{UserText("benchmark")},
+			Tools:    []ToolSpec{{Name: "benchmark_tool", Schema: map[string]any{"type": "object"}}},
+			MaxTurns: 1,
+		}
+		b.SetBytes(deltaCount)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := engine.runLoop(context.Background(), req, eventSender{}); err != nil {
+				b.Fatalf("runLoop returned error: %v", err)
+			}
+		}
+	})
+}

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -4990,6 +4990,7 @@ func TestEngineRetriesUncommittedTextScratchpadAfterStreamError(t *testing.T) {
 
 	var text strings.Builder
 	var retryEvents int
+	var discardEvents int
 	for {
 		event, err := stream.Recv()
 		if err == io.EOF {
@@ -5002,6 +5003,7 @@ func TestEngineRetriesUncommittedTextScratchpadAfterStreamError(t *testing.T) {
 		case EventError:
 			t.Fatalf("unexpected stream error event: %v", event.Err)
 		case EventAttemptDiscard:
+			discardEvents++
 			text.Reset()
 		case EventRetry:
 			retryEvents++
@@ -5010,8 +5012,11 @@ func TestEngineRetriesUncommittedTextScratchpadAfterStreamError(t *testing.T) {
 		}
 	}
 
-	if retryEvents == 0 {
-		t.Fatalf("expected retry event")
+	if retryEvents != 1 {
+		t.Fatalf("retry events = %d, want 1", retryEvents)
+	}
+	if discardEvents != 1 {
+		t.Fatalf("discard events = %d, want 1 for visible provisional text", discardEvents)
 	}
 	if got := text.String(); got != "good" {
 		t.Fatalf("text = %q, want only committed retry output %q", got, "good")
@@ -5066,11 +5071,11 @@ func TestEngineRetriesAgenticUncommittedTextAfterStreamError(t *testing.T) {
 		}
 	}
 
-	if retryEvents == 0 {
-		t.Fatalf("expected retry event")
+	if retryEvents != 1 {
+		t.Fatalf("retry events = %d, want 1", retryEvents)
 	}
-	if discardEvents == 0 {
-		t.Fatalf("expected discard event for visible provisional text")
+	if discardEvents != 1 {
+		t.Fatalf("discard events = %d, want 1 for visible provisional text", discardEvents)
 	}
 	if got := text.String(); got != "good" {
 		t.Fatalf("text = %q, want only committed retry output %q", got, "good")
@@ -5083,8 +5088,69 @@ func TestEngineRetriesAgenticUncommittedTextAfterStreamError(t *testing.T) {
 	}
 }
 
+func TestEngineRetriesWithoutDiscardBeforeVisibleOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		agentic bool
+	}{
+		{name: "simple"},
+		{name: "agentic", agentic: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &recoverTextProvider{failBeforeOutput: true}
+			registry := NewToolRegistry()
+			req := Request{Messages: []Message{UserText("hello")}, MaxTurns: 3}
+			if tc.agentic {
+				tool := &countingTool{}
+				registry.Register(tool)
+				req.Tools = []ToolSpec{tool.Spec()}
+			}
+			engine := NewEngine(provider, registry)
+			stream, err := engine.Stream(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Stream() error = %v", err)
+			}
+			defer stream.Close()
+
+			var text strings.Builder
+			var retryEvents int
+			var discardEvents int
+			for {
+				event, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("Recv() error = %v", err)
+				}
+				switch event.Type {
+				case EventError:
+					t.Fatalf("unexpected stream error event: %v", event.Err)
+				case EventAttemptDiscard:
+					discardEvents++
+				case EventRetry:
+					retryEvents++
+				case EventTextDelta:
+					text.WriteString(event.Text)
+				}
+			}
+
+			if retryEvents != 1 {
+				t.Fatalf("retry events = %d, want 1", retryEvents)
+			}
+			if discardEvents != 0 {
+				t.Fatalf("discard events = %d, want 0 before visible output", discardEvents)
+			}
+			if got := text.String(); got != "good" {
+				t.Fatalf("text = %q, want %q", got, "good")
+			}
+		})
+	}
+}
+
 type recoverTextProvider struct {
-	calls []Request
+	calls            []Request
+	failBeforeOutput bool
 }
 
 func (p *recoverTextProvider) Name() string       { return "recover-text" }
@@ -5095,8 +5161,12 @@ func (p *recoverTextProvider) Capabilities() Capabilities {
 func (p *recoverTextProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	p.calls = append(p.calls, req)
 	if len(p.calls) == 1 {
+		var events []Event
+		if !p.failBeforeOutput {
+			events = []Event{{Type: EventTextDelta, Text: "bad"}}
+		}
 		return &errAfterEventsStream{
-			events: []Event{{Type: EventTextDelta, Text: "bad"}},
+			events: events,
 			err:    &StreamIncompleteError{Transport: "test stream", Terminal: "done", Err: errors.New("stream disconnected during text")},
 		}, nil
 	}


### PR DESCRIPTION
## What changed

- Replaced the simple and agentic stream scratchpad `[]Event` buffers with a boolean that records whether an uncommitted attempt emitted output.
- Preserved the existing retry behavior: output-bearing failed attempts emit exactly one `EventAttemptDiscard`, while failures before output emit none.
- Added focused coverage for both simple and tool-enabled retry paths, plus a 4,096-delta benchmark for each path.

## Why this is high-value

Every streamed text, reasoning, usage, or image event was copied into an attempt-local slice even though no event contents were ever read or replayed. Since `Event` is a large struct, long provider responses retained and repeatedly copied megabytes of redundant data until completion or a durable tool boundary. These paths cover ordinary web, Telegram, and scheduled-job turns, including final tool-enabled responses.

The new boolean preserves the only information the retry logic needs while making scratchpad bookkeeping constant-space. On the 4,096-delta benchmark, retained allocation dropped from about 9.15 MB/op to about 11 KB/op in both paths. Simple-stream time fell from about 1.19 ms/op to 0.19 ms/op, and agentic-stream time from about 1.19 ms/op to 0.25 ms/op on the test host.

## Validation

- `gofmt -w internal/llm/engine.go internal/llm/engine_test.go internal/llm/engine_benchmark_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `go test ./internal/llm -run 'TestEngineRetries(UncommittedTextScratchpadAfterStreamError|AgenticUncommittedTextAfterStreamError|WithoutDiscardBeforeVisibleOutput)$' -count=1`
- `go test -run '^$' -bench ProviderStreamScratchpad -benchmem -count=3 ./internal/llm`
- `git diff --check`

Representative benchmark results:

```text
Before
BenchmarkProviderStreamScratchpad/Simple-32     1209055 ns/op  9152119 B/op  39 allocs/op
BenchmarkProviderStreamScratchpad/Agentic-32    1192644 ns/op  9152423 B/op  41 allocs/op

After
BenchmarkProviderStreamScratchpad/Simple-32      194645 ns/op    11121 B/op  23 allocs/op
BenchmarkProviderStreamScratchpad/Agentic-32     247474 ns/op    11424 B/op  25 allocs/op
```
