### PR TITLE
fix: catch up transcript after mobile page suspension

### DIFF
--- a/internal/serveui/static/app-session-events.js
+++ b/internal/serveui/static/app-session-events.js
@@ -21,6 +21,25 @@ const {
 } = app;
 
 // ===== Event listeners =====
+let pageResumeFollowTail = false;
+let pageWasBackgrounded = false;
+const rememberPageTailOwnership = () => {
+  if (pageWasBackgrounded) return;
+  pageResumeFollowTail = Boolean(state.autoScroll);
+  pageWasBackgrounded = true;
+};
+const restorePageTailOwnership = () => {
+  if (!pageWasBackgrounded) return false;
+  const followTail = pageResumeFollowTail;
+  pageWasBackgrounded = false;
+  pageResumeFollowTail = false;
+  // Mobile viewport resize/scroll events can flip autoScroll while the page is
+  // suspended. Restore the user's pre-background ownership instead of treating
+  // those synthetic layout events as intentional scrolling in either direction.
+  state.autoScroll = followTail;
+  return followTail;
+};
+
 elements.newChatBtn.addEventListener('click', app.createAndSwitchToFreshSession);
 elements.sidebarRailNewChatBtn.addEventListener('click', async () => {
   await app.createAndSwitchToFreshSession();
@@ -283,10 +302,12 @@ window.addEventListener('popstate', async () => {
 
 document.addEventListener('visibilitychange', async () => {
   if (document.visibilityState !== 'visible') {
+    rememberPageTailOwnership();
     flushStreamPersistence();
     app.stopSidebarStatusPoll();
     return;
   }
+  restorePageTailOwnership();
   if (!state.connected) return;
   // Reconcile the authoritative transcript before looking for an active
   // response. Another tab may have completed several turns and started a new
@@ -325,6 +346,7 @@ document.addEventListener('visibilitychange', async () => {
 });
 
 window.addEventListener('pagehide', () => {
+  rememberPageTailOwnership();
   flushStreamPersistence();
   app.stopSidebarStatusPoll();
 });
@@ -364,6 +386,7 @@ window.addEventListener('offline', () => {
 });
 
 window.addEventListener('pageshow', (event) => {
+  restorePageTailOwnership();
   if (state.connected) void app.ensureSidebarStatusPoll();
   const session = getActiveSession();
   if (!session) return;

--- a/internal/serveui/static/app-session-events.js
+++ b/internal/serveui/static/app-session-events.js
@@ -353,6 +353,10 @@ window.addEventListener('pagehide', () => {
 
 window.addEventListener('online', async () => {
   setConnectionState('', '');
+  // As with visibility recovery, reconcile durable history before waking the
+  // response stream. Replaying only the current response cannot recover turns
+  // that completed while this client was offline.
+  await app.startSidebarStatusPoll();
   const session = getActiveSession();
   if (!session) return;
   if (session.activeResponseId && app.wakeResponseReconnect?.({

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3798,6 +3798,71 @@ async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
   pass(name);
 }
 
+async function testVisibilityResumeRestoresPreBackgroundTailOwnership() {
+  const name = 'visibility resume restores pre-background tail ownership before catch-up';
+  let appRef = null;
+  const autoScrollAtStatus = [];
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (String(url).startsWith('/ui/v1/sessions/status')) {
+        autoScrollAtStatus.push(appRef?.state.autoScroll);
+        return new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  });
+  appRef = app;
+  await app.stopSidebarStatusPoll();
+  autoScrollAtStatus.length = 0;
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  if (!visibilityHandler) {
+    fail(name, 'expected visibilitychange listener');
+    return;
+  }
+
+  app.state.autoScroll = true;
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  // Mobile viewport events can report a synthetic scroll while suspended.
+  app.state.autoScroll = false;
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+
+  if (app.state.autoScroll !== true || autoScrollAtStatus[0] !== true) {
+    app.stopSidebarStatusPoll();
+    fail(name, 'resume catch-up lost bottom ownership before status reconciliation', JSON.stringify({
+      autoScroll: app.state.autoScroll,
+      autoScrollAtStatus,
+    }));
+    return;
+  }
+
+  await app.stopSidebarStatusPoll();
+  app.state.autoScroll = false;
+  windowObj.document.visibilityState = 'hidden';
+  await visibilityHandler({ type: 'visibilitychange' });
+  // The inverse synthetic layout result must not drag a historical reader down.
+  app.state.autoScroll = true;
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+  if (app.state.autoScroll !== false || autoScrollAtStatus[1] !== false) {
+    app.stopSidebarStatusPoll();
+    fail(name, 'resume catch-up replaced historical ownership with synthetic bottom stickiness', JSON.stringify({
+      autoScroll: app.state.autoScroll,
+      autoScrollAtStatus,
+    }));
+    return;
+  }
+  app.stopSidebarStatusPoll();
+  pass(name);
+}
+
 async function testPageshowWaitsForInitialConnectionBeforeStatusPoll() {
   const name = 'pageshow waits for initial session merge before starting status polling';
   let releaseSessions;
@@ -6192,6 +6257,18 @@ async function testBottomPinnedTranscriptSyncKeepsFollowingTail() {
 
   const { app, windowObj } = await createSessionsHarness({
     fetchImpl: async (url) => {
+      if (String(url).startsWith('/ui/v1/sessions/status')) {
+        const targetTurns = pendingTurns[0] || servedTurns;
+        return new Response(JSON.stringify({
+          sessions: [{
+            id: sessionId,
+            transcript_rev: targetTurns * 2,
+            active_response_id: 'resp-live',
+            run_epoch: 1,
+            started_rev: 6,
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json', ETag: `"status-${targetTurns}"` } });
+      }
       if (isTranscriptIndexURL(url, sessionId)) {
         servedTurns = pendingTurns.shift() || servedTurns;
         return new Response(JSON.stringify(makeIndex(servedTurns)), {
@@ -6211,7 +6288,10 @@ async function testBottomPinnedTranscriptSyncKeepsFollowingTail() {
         headers: { 'Content-Type': 'application/json' }
       });
     },
-    appOverrides: { renderMessages() {} }
+    appOverrides: {
+      renderMessages() {},
+      wakeResponseReconnect() { return true; },
+    }
   });
   app.stopSidebarStatusPoll();
 
@@ -6227,7 +6307,7 @@ async function testBottomPinnedTranscriptSyncKeepsFollowingTail() {
   messages.querySelectorAll = (selector) => selector === '[data-durable-id]' ? [anchorNode] : [];
   messages.querySelector = (selector) => String(selector) === `[data-durable-id="${anchorID}"]` ? anchorNode : null;
 
-  const session = { id: sessionId, messages: [] };
+  const session = { id: sessionId, messages: [], activeResponseId: 'resp-live' };
   const transcript = new windowObj.ConversationController(sessionId, { maxMaterializedTurns: 3, overscanTurns: 0 });
   transcript.applyIndex(makeIndex(3));
   transcript.setViewport(5, 5);
@@ -6237,9 +6317,21 @@ async function testBottomPinnedTranscriptSyncKeepsFollowingTail() {
   app.state.activeSessionId = sessionId;
   app.state.draftSessionActive = false;
   app.state.autoScroll = true;
+  await app.stopSidebarStatusPoll();
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  if (!visibilityHandler) {
+    fail(name, 'expected visibilitychange listener');
+    return;
+  }
 
   for (const expectedTurns of [8, 13]) {
-    const loaded = await app.syncTranscript(session, { reason: 'tail-follow-regression', force: true });
+    windowObj.document.visibilityState = 'hidden';
+    await visibilityHandler({ type: 'visibilitychange' });
+    // Reproduce the synthetic mobile scroll/layout event seen while suspended.
+    app.state.autoScroll = false;
+    windowObj.document.visibilityState = 'visible';
+    await visibilityHandler({ type: 'visibilitychange' });
+    const loaded = transcript.ids.length === expectedTurns * 2;
     const tail = transcript.segments[expectedTurns - 1];
     const materialized = transcript.segments.filter((segment) => segment.state === 'materialized').length;
     if (!loaded || transcript.ids.length !== expectedTurns * 2 || tail?.state !== 'materialized'
@@ -6483,6 +6575,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testApplyServerSessionSummaryMapsLastMessageAt();
   await testSanitizeSessionPreservesLastMessageAt();
   await testPreConnectedVisibilityDoesNotStartSidebarStatusPoll();
+  await testVisibilityResumeRestoresPreBackgroundTailOwnership();
   await testPageshowWaitsForInitialConnectionBeforeStatusPoll();
   await testSidebarStatusPollRecoversIdempotentlyAfterPageShow();
   await testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -4113,9 +4113,19 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   const name = 'online visibility and pageshow wake the existing response reconnect loop';
   const wakeReasons = [];
   let resumeCalls = 0;
+  let onlineStatusCompleted = false;
+  let onlineWakeAfterStatus = false;
   const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (String(url).startsWith('/ui/v1/sessions/status')) onlineStatusCompleted = true;
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    },
     appOverrides: {
       wakeResponseReconnect({ reason, sessionId, responseId }) {
+        if (reason === 'online') onlineWakeAfterStatus = onlineStatusCompleted;
         wakeReasons.push(`${reason}:${sessionId}:${responseId}`);
         return true;
       },
@@ -4147,6 +4157,8 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   }
 
   await visibilityHandler({ type: 'visibilitychange' });
+  await app.stopSidebarStatusPoll();
+  onlineStatusCompleted = false;
   await onlineHandler({ type: 'online' });
   pageshowHandler({ type: 'pageshow', persisted: false });
 
@@ -4157,6 +4169,10 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   ];
   if (JSON.stringify(wakeReasons) !== JSON.stringify(want)) {
     fail(name, 'unexpected reconnect wake calls', JSON.stringify(wakeReasons));
+    return;
+  }
+  if (!onlineWakeAfterStatus) {
+    fail(name, 'online recovery woke the active response before authoritative status catch-up');
     return;
   }
   if (resumeCalls !== 0) {


### PR DESCRIPTION
## Problem

On mobile, a bottom-sticky page can be suspended while a response continues elsewhere. Viewport resize/scroll events during suspension may flip `state.autoScroll` before the page becomes visible again.

Visibility recovery correctly polls status before reconnecting the active response, so transcript sequencing reaches the new revision. But because bottom ownership has been lost, that catch-up transaction captures the old durable row as a historical anchor. With body-budget enforcement deferred until the transaction boundary, the distant new tail is then evicted before render. The result is clean sequencing and no duplicates, but no visible catch-up until full reload.

This remained after #966 because the sync transaction respected the *current* `autoScroll` state; mobile suspension had already corrupted that state.

## Fix

Snapshot the user's exact tail/history ownership on the first `visibilitychange(hidden)` or `pagehide`, then restore it before the visibility/pageshow status poll.

- A page that owned the tail before suspension catches up at the tail before reconnecting an active response.
- A page intentionally reading history stays in history.
- Later synthetic hidden-layout events cannot flip ownership in either direction.

## Regression coverage

The integration test exercises the actual mobile recovery path with an active response:

1. Start bottom-pinned with a full **3-turn** materialization budget.
2. Hide the page.
3. Simulate mobile layout changing `autoScroll` to false while suspended.
4. Show the page and reconcile status from **3 → 8 turns**.
5. Repeat for **8 → 13 turns**.

Both distant tails remain materialized and the budget remains bounded. A separate ownership test covers both synthetic directions: tail→history and history→tail.

The currently deployed pre-fix build fails at the first recovery: the transcript reaches 8 turns, but the viewport remains at ordinal 4 and turn 8 is evicted before render.

## Verification

- app session and stream JavaScript suites
- relevant Go tests
- race tests for `internal/serveui` and `internal/session`
- full build
- diff check

No binary installation, service restart, or deployment was performed.
## Network reconnect

The `online` path had the same ordering hole independently of page suspension: it woke the current response replay loop immediately, before authoritative status/transcript reconciliation. A clean replay of the current response cannot recover completed turns missed while offline.

`online` recovery now awaits the immediate status poll—including transcript reconciliation—before waking or starting the active response stream. Existing reconnect-loop ownership is retained; this does not spawn a second resume loop. The regression asserts the online wake occurs only after status catch-up completes.
