### PR TITLE
fix: A transient Telegram startup failure permanently disables the bot

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -78,6 +78,12 @@ var (
 	serveHubRegistrationToken   string
 )
 
+const (
+	servePlatformInitialRetryDelay = time.Second
+	servePlatformMaxRetryDelay     = 30 * time.Second
+	servePlatformRetryResetAfter   = time.Minute
+)
+
 var serveCmd = &cobra.Command{
 	Use:   "serve <platform> [platform...]",
 	Short: "Run the agent as a server (web, api, jobs, Telegram, or any combination)",
@@ -754,9 +760,7 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 		wg.Add(1)
 		go func(p serve.Platform) {
 			defer wg.Done()
-			if err := p.Run(ctx, cfg, serveSettings); err != nil && !errors.Is(err, context.Canceled) {
-				log.Printf("[%s] error: %v", p.Name(), err)
-			}
+			runPlatformSupervisor(ctx, cfg, serveSettings, p, servePlatformInitialRetryDelay)
 		}(p)
 	}
 
@@ -780,6 +784,46 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 
 	wg.Wait()
 	return nil
+}
+
+func runPlatformSupervisor(ctx context.Context, cfg *config.Config, settings serve.Settings, platform serve.Platform, initialRetryDelay time.Duration) {
+	retryDelay := initialRetryDelay
+	for {
+		startedAt := time.Now()
+		err := platform.Run(ctx, cfg, settings)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if time.Since(startedAt) >= servePlatformRetryResetAfter {
+			retryDelay = initialRetryDelay
+		}
+		if err != nil {
+			log.Printf("[%s] error: %v; retrying in %s", platform.Name(), err, retryDelay)
+		} else {
+			log.Printf("[%s] stopped unexpectedly; retrying in %s", platform.Name(), retryDelay)
+		}
+
+		timer := time.NewTimer(retryDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		case <-timer.C:
+		}
+
+		if retryDelay < servePlatformMaxRetryDelay {
+			retryDelay *= 2
+			if retryDelay > servePlatformMaxRetryDelay {
+				retryDelay = servePlatformMaxRetryDelay
+			}
+		}
+	}
 }
 
 // newServeEngineWithTools creates a new engine with tools wired up for serving.

--- a/cmd/serve_platform_test.go
+++ b/cmd/serve_platform_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/serve"
+)
+
+type transientFailurePlatform struct {
+	runCalls  atomic.Int32
+	connected chan struct{}
+}
+
+func (p *transientFailurePlatform) Name() string     { return "test" }
+func (p *transientFailurePlatform) NeedsSetup() bool { return false }
+func (p *transientFailurePlatform) RunSetup() error  { return nil }
+
+func (p *transientFailurePlatform) Run(ctx context.Context, _ *config.Config, _ serve.Settings) error {
+	switch p.runCalls.Add(1) {
+	case 1:
+		return errors.New("transient startup failure")
+	case 2:
+		close(p.connected)
+		<-ctx.Done()
+		return ctx.Err()
+	default:
+		return errors.New("unexpected extra run")
+	}
+}
+
+func TestRunPlatformSupervisorRetriesAndStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	platform := &transientFailurePlatform{connected: make(chan struct{})}
+	done := make(chan struct{})
+	go func() {
+		runPlatformSupervisor(ctx, &config.Config{}, serve.Settings{}, platform, time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-platform.connected:
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("platform was not restarted after transient failure")
+	}
+	if calls := platform.runCalls.Load(); calls != 2 {
+		cancel()
+		t.Fatalf("Run calls = %d, want 2", calls)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not stop promptly after cancellation")
+	}
+	if calls := platform.runCalls.Load(); calls != 2 {
+		t.Fatalf("Run calls after cancellation = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
## What changed

- Supervise each non-web platform loop instead of invoking `Platform.Run` only once.
- Retry unexpected returns with context-aware exponential backoff from 1 second to 30 seconds.
- Reset the backoff after a platform has remained running for one minute.
- Stop retrying immediately when the serve context is cancelled.
- Add a focused fake-platform regression test covering a transient first-run failure, successful restart, and prompt cancellation without an extra retry.

## Why this is high-value

Telegram is a daily Jarvis interface, while the web server and jobs can remain healthy if Telegram's startup `getMe` request hits a transient DNS, network, timeout, or API failure. Previously that one failure terminated the only Telegram goroutine, silently leaving the bot unavailable until the whole serve process was manually restarted. The supervisor lets Telegram recover automatically while preserving normal shutdown behavior and bounding retry frequency.

## Validation

- `gofmt -w cmd/serve.go cmd/serve_platform_test.go`
- `go build ./...`
- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$HOME/.config CODEX_HOME=$HOME/.codex go test ./...`
- `go test ./cmd -run TestRunPlatformSupervisorRetriesAndStopsOnCancellation -count=100`
- `git diff --check`

The unisolated full test command also ran; two existing skill-catalog tests failed because the agent host's 30 user-global skills exhausted their configured visible-skill budgets. The same complete suite passes with an isolated HOME as shown above.
