### PR TITLE
fix: detach web stream immediately on stop

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1235,15 +1235,14 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
 const cancelActiveResponse = async (session) => {
   const responseId = String(session?.activeResponseId || state.currentStreamResponseId || '').trim();
 
-  // Instant UI feedback: tear down the local stream before the server POST.
-  // If the run is blocked in a tool (e.g. a shell tool hung on cmd.Wait),
-  // the /cancel POST can take seconds to return. Aborting the reader here
-  // makes Stop feel responsive; the POST below still drives the
-  // authoritative server-side cancel.
+  // Instant UI feedback: fully detach the local stream before the server POST.
+  // Merely aborting its controller leaves the controller registered until the
+  // async reader unwinds. A fast /cancel response can then schedule a state poll
+  // that refuses to run because it still sees that stale controller.
+  // Detaching synchronously makes Stop final locally; the POST below still
+  // drives the authoritative server-side cancel.
   state.expectCanceledRun = true;
-  if (state.abortController) {
-    state.abortController.abort();
-  }
+  detachResponseStream();
   setConnectionState('Cancelling\u2026');
 
   if (!responseId) {

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -4644,7 +4644,9 @@ async function testCancelActiveResponseTearsDownLocallyBeforeServerPost() {
   const { app, state, connectionStates, getCancelRequested, releaseCancel, cleanup } = harness;
 
   const controller = new AbortController();
+  state.streaming = true;
   state.abortController = controller;
+  state.currentStreamSessionId = 'session_1';
   state.currentStreamResponseId = 'resp_test';
   const session = { id: 'session_1', activeResponseId: 'resp_test' };
   state.sessions = [session];
@@ -4657,6 +4659,18 @@ async function testCancelActiveResponseTearsDownLocallyBeforeServerPost() {
 
   if (!controller.signal.aborted) {
     fail(name, 'abortController was not aborted synchronously');
+    releaseCancel();
+    await cancelPromise.catch(() => {});
+    await cleanup();
+    return;
+  }
+  if (state.abortController || state.currentStreamSessionId || state.currentStreamResponseId || state.streaming) {
+    fail(name, 'local stream ownership was not cleared synchronously', JSON.stringify({
+      hasController: Boolean(state.abortController),
+      streamSessionId: state.currentStreamSessionId,
+      streamResponseId: state.currentStreamResponseId,
+      streaming: state.streaming,
+    }));
     releaseCancel();
     await cancelPromise.catch(() => {});
     await cleanup();


### PR DESCRIPTION
## What

Make the web UI's Stop action synchronously detach the local response stream before posting the authoritative server cancellation.

This clears the abort controller, stream ownership, and streaming UI immediately rather than waiting for the aborted fetch reader to unwind.

## Why

The old path only called `AbortController.abort()`. A fast successful `/cancel` response could schedule session-state reconciliation while the aborted controller was still registered. The poll refuses to run while a controller exists, leaving the browser stuck even though the server reports `active_run: false`.

Stop should mean stop locally, without an async cleanup race.

## Verification

- `node internal/serveui/static/app_stream_test.js`
- Targeted Go cancellation tests
- `go build .`

The broad `go test ./cmd` run hit two unrelated environment-dependent skill-discovery failures because this Jarvis installation exposes more skills than those tests' metadata budget; all other cmd tests in that run passed.
