### PR TITLE
fix: make server truth end stale web streams

### DIFF
--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -29,7 +29,12 @@ const rebaseSessionAssetURL = (url) => (
 );
 
 const resumeAndDrain = (session, options) => {
-  void resumeActiveResponse(session, options).finally(() => {
+  void resumeActiveResponse(session, options).catch(() => {
+    // A failed replay/reconciliation attempt must not strand local active state.
+    // The state endpoint is authoritative and the poll remains independent of
+    // the response transport, so retry truth reconciliation even if streaming dies.
+    if (session?.id) scheduleSessionStatePoll(session.id, 0);
+  }).finally(() => {
     drainInterruptQueueIfIdle(session);
   });
 };
@@ -374,7 +379,7 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
   stopSessionStatePoll();
   sessionStatePollTimer = setTimeout(async () => {
     const active = getActiveSession();
-    if (!active || active.id !== sessionId || state.abortController) {
+    if (!active || active.id !== sessionId) {
       stopSessionStatePoll();
       return;
     }
@@ -386,7 +391,7 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
     }
     if (syncResult?.kind === 'retry') {
       const stillActive = getActiveSession();
-      if (stillActive && stillActive.id === sessionId && !state.abortController) {
+      if (stillActive && stillActive.id === sessionId) {
         scheduleSessionStatePoll(sessionId, SESSION_STATE_POLL_RETRY);
       }
     }
@@ -589,17 +594,28 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     return loadResult;
   }
 
-  if (!activeRun && !state.abortController) {
+  if (!activeRun) {
     if (sampledRunEpoch < Math.max(0, Number(transcript?.latestRunEpoch) || 0)) {
       window.TermLLMConversation?.transcriptDiagnostic?.('stale_status_rejection', {
         responseId: session.activeResponseId || transcript?.activeRun?.id || '',
         transcriptRev: transcript?.rev,
       });
+      // The local transcript advanced while this state request was in flight.
+      // Do not apply the stale result, but never leave it as the final word:
+      // immediately sample authoritative state again, independently of whether
+      // a response transport still owns an AbortController.
+      if (isStillActive()) scheduleSessionStatePoll(session.id, 0);
       return loadResult;
     }
     if (isStillActive()) stopSessionStatePoll();
-    if (session.activeResponseId || (isStillActive() && state.currentStreamResponseId)) {
-      clearActiveResponseTracking(session, session.activeResponseId || state.currentStreamResponseId);
+    const inactiveResponseId = session.activeResponseId || (
+      state.currentStreamSessionId === session.id ? state.currentStreamResponseId : ''
+    );
+    if (state.currentStreamSessionId === session.id) {
+      detachResponseStream();
+    }
+    if (inactiveResponseId) {
+      clearActiveResponseTracking(session, inactiveResponseId);
       saveSessions();
     }
     setSessionOptimisticBusy(session, false);

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -29,11 +29,18 @@ const rebaseSessionAssetURL = (url) => (
 );
 
 const resumeAndDrain = (session, options) => {
-  void resumeActiveResponse(session, options).catch(() => {
-    // A failed replay/reconciliation attempt must not strand local active state.
-    // The state endpoint is authoritative and the poll remains independent of
-    // the response transport, so retry truth reconciliation even if streaming dies.
-    if (session?.id) scheduleSessionStatePoll(session.id, 0);
+  void resumeActiveResponse(session, options).catch(async () => {
+    const expectedResponseId = String(options?.responseId || session?.activeResponseId || '').trim();
+    const stillOwnsFailedTransport = Boolean(expectedResponseId
+      && state.currentStreamSessionId === session?.id
+      && state.currentStreamResponseId === expectedResponseId);
+    if (stillOwnsFailedTransport) detachResponseStream();
+    try {
+      const result = await syncActiveSessionFromServer(session, true, { skipMessagesFetch: true });
+      if (result?.kind === 'retry' && session?.id) scheduleSessionStatePoll(session.id, 0);
+    } catch (_err) {
+      if (session?.id) scheduleSessionStatePoll(session.id, 0);
+    }
   }).finally(() => {
     drainInterruptQueueIfIdle(session);
   });
@@ -379,7 +386,7 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
   stopSessionStatePoll();
   sessionStatePollTimer = setTimeout(async () => {
     const active = getActiveSession();
-    if (!active || active.id !== sessionId) {
+    if (!active || active.id !== sessionId || state.abortController) {
       stopSessionStatePoll();
       return;
     }
@@ -391,7 +398,7 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
     }
     if (syncResult?.kind === 'retry') {
       const stillActive = getActiveSession();
-      if (stillActive && stillActive.id === sessionId) {
+      if (stillActive && stillActive.id === sessionId && !state.abortController) {
         scheduleSessionStatePoll(sessionId, SESSION_STATE_POLL_RETRY);
       }
     }
@@ -417,6 +424,12 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
 
   const busyBefore = sessionHasInProgressState(session);
   const sampledRunEpoch = Math.max(0, Number(session.transcript?.latestRunEpoch) || 0);
+  const sampledTransport = {
+    controller: state.abortController,
+    generation: Number(state.streamGeneration || 0),
+    sessionId: String(state.currentStreamSessionId || '').trim(),
+    responseId: String(state.currentStreamResponseId || '').trim(),
+  };
 
   const loadResult = await loadServerSessionState(requestSessionId);
   if (loadResult.kind === 'auth') {
@@ -600,18 +613,25 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
         responseId: session.activeResponseId || transcript?.activeRun?.id || '',
         transcriptRev: transcript?.rev,
       });
-      // The local transcript advanced while this state request was in flight.
-      // Do not apply the stale result, but never leave it as the final word:
-      // immediately sample authoritative state again, independently of whether
-      // a response transport still owns an AbortController.
-      if (isStillActive()) scheduleSessionStatePoll(session.id, 0);
+      return loadResult;
+    }
+    const transportUnchanged = state.abortController === sampledTransport.controller
+      && Number(state.streamGeneration || 0) === sampledTransport.generation
+      && String(state.currentStreamSessionId || '').trim() === sampledTransport.sessionId
+      && String(state.currentStreamResponseId || '').trim() === sampledTransport.responseId;
+    const sampledOwnedResponse = sampledTransport.sessionId === session.id && Boolean(sampledTransport.responseId);
+    const currentOwnsTransport = state.currentStreamSessionId === session.id && Boolean(state.currentStreamResponseId);
+    // An idle response sampled before a new send must not cancel that send. A
+    // transport may only be retired when this request observed its stable,
+    // server-issued response ID both before and after the state round trip.
+    if ((state.abortController || currentOwnsTransport) && !(sampledOwnedResponse && transportUnchanged)) {
       return loadResult;
     }
     if (isStillActive()) stopSessionStatePoll();
     const inactiveResponseId = session.activeResponseId || (
       state.currentStreamSessionId === session.id ? state.currentStreamResponseId : ''
     );
-    if (state.currentStreamSessionId === session.id) {
+    if (state.currentStreamSessionId === session.id && state.currentStreamResponseId) {
       detachResponseStream();
     }
     if (inactiveResponseId) {

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -343,15 +343,12 @@ const pollSidebarStatus = (isRecovery = false) => {
         if (!isCurrent()) return false;
         const active = app.getActiveSession?.();
         const activeStatus = active ? data.sessions.find((entry) => entry?.id === active.id) : null;
-        const localOwnsResponse = Boolean(active && (
-          active.activeResponseId
-          || (state.currentStreamSessionId === active.id && state.currentStreamResponseId)
-          || (state.streaming && state.activeSessionId === active.id)
-        ));
-        if (activeStatus && !activeStatus.active_run && !activeStatus.active_response_id && localOwnsResponse) {
-          // Status polling is independent of SSE. If it says idle while the
-          // transport claims ownership, force selected-session reconciliation;
-          // a dead event stream never gets to veto authoritative server truth.
+        const ownedResponseId = String(active?.activeResponseId || (
+          state.currentStreamSessionId === active?.id ? state.currentStreamResponseId : ''
+        ) || '').trim();
+        if (activeStatus && !activeStatus.active_run && !activeStatus.active_response_id && ownedResponseId) {
+          // Status is independent of SSE. Confirm selected-session truth when a
+          // server-issued response ID remains locally owned after status says idle.
           try {
             const result = await app.syncActiveSessionFromServer(active, true, { skipMessagesFetch: true });
             if (result?.kind === 'retry') app.scheduleSessionStatePoll?.(active.id, 0);

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -341,6 +341,25 @@ const pollSidebarStatus = (isRecovery = false) => {
         app.updateSidebarStatus(data.sessions);
         await app.reconcileTranscriptFromStatus(data.sessions, { sampledRunEpochs });
         if (!isCurrent()) return false;
+        const active = app.getActiveSession?.();
+        const activeStatus = active ? data.sessions.find((entry) => entry?.id === active.id) : null;
+        const localOwnsResponse = Boolean(active && (
+          active.activeResponseId
+          || (state.currentStreamSessionId === active.id && state.currentStreamResponseId)
+          || (state.streaming && state.activeSessionId === active.id)
+        ));
+        if (activeStatus && !activeStatus.active_run && !activeStatus.active_response_id && localOwnsResponse) {
+          // Status polling is independent of SSE. If it says idle while the
+          // transport claims ownership, force selected-session reconciliation;
+          // a dead event stream never gets to veto authoritative server truth.
+          try {
+            const result = await app.syncActiveSessionFromServer(active, true, { skipMessagesFetch: true });
+            if (result?.kind === 'retry') app.scheduleSessionStatePoll?.(active.id, 0);
+          } catch (_err) {
+            app.scheduleSessionStatePoll?.(active.id, 0);
+          }
+          if (!isCurrent()) return false;
+        }
         // Discover sessions created in other tabs/devices
         const localIds = new Set(state.sessions.map((s) => s.id));
         const hasUnknown = data.sessions.some((entry) => !localIds.has(entry.id));

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1045,7 +1045,14 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
       if (state.abortController) {
         state.abortController = null;
       }
-      await app.syncActiveSessionFromServer(session, false);
+      try {
+        await app.syncActiveSessionFromServer(session, false);
+      } catch (err) {
+        // State reconciliation is a fallback inside an infinite recovery loop.
+        // A transient transcript/state error must not terminate that loop and
+        // leave activeResponseId behind with no transport owner.
+        console.warn('[stream] session-state reconciliation failed; continuing reconnect', err);
+      }
       if (!ownsResumeKey()) {
         setStreaming(Boolean(state.currentStreamResponseId));
         return false;

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1037,20 +1037,11 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
       consecutiveHeartbeatAborts = 0;
       setConnectionState('Checking session state\u2026', 'bad');
       setReconnectDiagnostic('checking-state', reconnectReason, 0);
-      // Temporarily clear the abort controller so syncActiveSessionFromServer
-      // can act on the server state.  The !activeRun && !state.abortController
-      // branch inside sync refuses to clear tracking while a controller is set,
-      // but our own retry loop is the one that set it — creating a deadlock
-      // where the loop never exits even after the server confirms the run is done.
-      if (state.abortController) {
-        state.abortController = null;
-      }
       try {
         await app.syncActiveSessionFromServer(session, false);
       } catch (err) {
-        // State reconciliation is a fallback inside an infinite recovery loop.
-        // A transient transcript/state error must not terminate that loop and
-        // leave activeResponseId behind with no transport owner.
+        // This is a fallback inside an infinite recovery loop. A transient
+        // state/transcript error is unknown, not terminal: keep reconnecting.
         console.warn('[stream] session-state reconciliation failed; continuing reconnect', err);
       }
       if (!ownsResumeKey()) {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3381,6 +3381,96 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
   pass(name);
 }
 
+async function testIdleSidebarTruthClearsStuckTransportOwnership() {
+  const name = 'idle sidebar truth clears stale streaming ownership even with an attached controller';
+  let appRef = null;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (url === '/ui/v1/sessions/sess_stuck/state') {
+        return new Response(JSON.stringify({
+          active_run: false,
+          transcript_rev: 0,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (isTailMessagesURL(url, 'sess_stuck')) {
+        return new Response(JSON.stringify({ messages: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions/status') {
+        return new Response(JSON.stringify({ sessions: [{
+          id: 'sess_stuck',
+          active_run: false,
+          transcript_rev: 0,
+        }] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: {
+      detachResponseStream() {
+        const controller = appRef.state.abortController;
+        appRef.state.abortController = null;
+        appRef.state.currentStreamSessionId = '';
+        appRef.state.currentStreamResponseId = '';
+        appRef.state.streaming = false;
+        controller?.abort();
+      },
+    },
+  });
+  appRef = app;
+  app.stopSidebarStatusPoll();
+
+  const session = {
+    id: 'sess_stuck',
+    title: 'Stuck stream',
+    origin: 'web',
+    created: 1710000000000,
+    messages: [],
+    activeResponseId: 'resp_already_done',
+    lastSequenceNumber: 48,
+  };
+  session.transcript = new windowObj.ConversationController(session.id);
+  const controller = new AbortController();
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  app.state.streaming = true;
+  app.state.currentStreamSessionId = session.id;
+  app.state.currentStreamResponseId = session.activeResponseId;
+  app.state.abortController = controller;
+  app.setSessionOptimisticBusy(session, true);
+  app.setSessionServerActiveRun(session, true);
+
+  await app.startSidebarStatusPoll();
+
+  const remaining = {
+    activeResponseId: session.activeResponseId,
+    currentStreamSessionId: app.state.currentStreamSessionId,
+    currentStreamResponseId: app.state.currentStreamResponseId,
+    hasController: Boolean(app.state.abortController),
+    streaming: app.state.streaming,
+    optimisticBusy: Boolean(session.__optimisticBusy),
+    serverActive: Boolean(session.__serverActiveRun),
+  };
+  if (controller.signal.aborted !== true
+    || remaining.activeResponseId
+    || remaining.currentStreamSessionId
+    || remaining.currentStreamResponseId
+    || remaining.hasController
+    || remaining.streaming
+    || remaining.optimisticBusy
+    || remaining.serverActive) {
+    fail(name, 'idle server truth did not fully clear local response ownership', JSON.stringify(remaining));
+    return;
+  }
+
+  pass(name);
+}
+
 async function testSessionProgressStatePrefersLocalAndServerSignals() {
   const name = 'session progress state combines optimistic local state with server truth';
   const { app } = await createSessionsHarness();
@@ -6583,6 +6673,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testActiveStatusSyncsInRunTranscriptRevisionsWithoutDuplicatingActiveOutput();
   await testHugeTranscriptGapTraversalStaysBoundedAndAnchored();
   await testIdleSessionSyncRescuesPendingInterruptCommit();
+  await testIdleSidebarTruthClearsStuckTransportOwnership();
   await testSessionProgressStatePrefersLocalAndServerSignals();
   await testResumeAndDrainFiringViaSync();
   await testSyncIgnoresPendingInterjectionWithoutExactID();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3381,29 +3381,117 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
   pass(name);
 }
 
-async function testIdleSidebarTruthClearsStuckTransportOwnership() {
-  const name = 'idle sidebar truth clears stale streaming ownership even with an attached controller';
-  let appRef = null;
-  const { app, windowObj } = await createSessionsHarness({
-    fetchImpl: async (url) => {
-      if (url === '/ui/v1/sessions/sess_stuck/state') {
-        return new Response(JSON.stringify({
-          active_run: false,
-          transcript_rev: 0,
-        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
-      }
-      if (isTailMessagesURL(url, 'sess_stuck')) {
-        return new Response(JSON.stringify({ messages: [] }), {
+async function testIdleStateRetiresOnlySampledTransportOwnership() {
+  const name = 'idle state retires a stable response transport without killing a newer local run';
+
+  const runScenario = async ({ startNewRunDuringState }) => {
+    const sessionId = startNewRunDuringState ? 'sess_idle_race' : 'sess_idle_stable';
+    const responseId = 'resp_finished';
+    let appRef = null;
+    let controller = null;
+    const { app, windowObj } = await createSessionsHarness({
+      fetchImpl: async (url) => {
+        if (url === `/ui/v1/sessions/${sessionId}/state`) {
+          if (startNewRunDuringState) {
+            controller = new AbortController();
+            appRef.setSessionOptimisticBusy(appRef.state.sessions[0], true);
+            appRef.state.currentStreamSessionId = sessionId;
+            appRef.state.currentStreamResponseId = '';
+            appRef.state.abortController = controller;
+            appRef.state.streaming = true;
+          }
+          return new Response(JSON.stringify({ active_run: false, transcript_rev: 0 }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ sessions: [] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }
-      if (parsedTestURL(url)?.pathname === '/ui/v1/sessions/status') {
+      },
+      appOverrides: {
+        detachResponseStream() {
+          const owned = appRef.state.abortController;
+          appRef.state.streamGeneration += 1;
+          appRef.state.abortController = null;
+          appRef.state.currentStreamSessionId = '';
+          appRef.state.currentStreamResponseId = '';
+          appRef.state.streaming = false;
+          owned?.abort();
+        },
+      },
+    });
+    appRef = app;
+    app.stopSidebarStatusPoll();
+    const session = {
+      id: sessionId,
+      title: 'Idle ownership race',
+      origin: 'web',
+      created: 1710000000000,
+      messages: [],
+      activeResponseId: startNewRunDuringState ? null : responseId,
+      lastSequenceNumber: 0,
+    };
+    session.transcript = new windowObj.ConversationController(session.id);
+    app.state.sessions = [session];
+    app.state.activeSessionId = session.id;
+    app.state.draftSessionActive = false;
+    if (!startNewRunDuringState) {
+      controller = new AbortController();
+      app.state.currentStreamSessionId = session.id;
+      app.state.currentStreamResponseId = responseId;
+      app.state.abortController = controller;
+      app.state.streaming = true;
+    }
+
+    await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
+    return { app, session, controller };
+  };
+
+  const stable = await runScenario({ startNewRunDuringState: false });
+  if (!stable.controller.signal.aborted
+    || stable.session.activeResponseId
+    || stable.app.state.abortController
+    || stable.app.state.currentStreamResponseId
+    || stable.app.state.streaming) {
+    fail(name, 'stable finished transport was not retired');
+    return;
+  }
+
+  const raced = await runScenario({ startNewRunDuringState: true });
+  if (raced.controller.signal.aborted
+    || raced.app.state.abortController !== raced.controller
+    || raced.app.state.currentStreamSessionId !== raced.session.id
+    || raced.app.state.currentStreamResponseId !== ''
+    || !raced.app.state.streaming) {
+    fail(name, 'idle sample killed transport ownership created after the request began');
+    return;
+  }
+
+  pass(name);
+}
+
+async function testIdleSidebarStatusPreservesUnacknowledgedPost() {
+  const name = 'idle sidebar status cannot abort a response POST before it has a response id';
+  const sessionId = 'sess_uploading';
+  let appRef = null;
+  const controller = new AbortController();
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const path = parsedTestURL(url)?.pathname;
+      if (path === '/ui/v1/sessions/status') {
         return new Response(JSON.stringify({ sessions: [{
-          id: 'sess_stuck',
+          id: sessionId,
           active_run: false,
           transcript_rev: 0,
         }] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (path === `/ui/v1/sessions/${sessionId}/state`) {
+        return new Response(JSON.stringify({ active_run: false, transcript_rev: 0 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       return new Response(JSON.stringify({ sessions: [] }), {
         status: 200,
@@ -3412,62 +3500,45 @@ async function testIdleSidebarTruthClearsStuckTransportOwnership() {
     },
     appOverrides: {
       detachResponseStream() {
-        const controller = appRef.state.abortController;
+        const owned = appRef.state.abortController;
         appRef.state.abortController = null;
         appRef.state.currentStreamSessionId = '';
         appRef.state.currentStreamResponseId = '';
         appRef.state.streaming = false;
-        controller?.abort();
+        owned?.abort();
       },
     },
   });
   appRef = app;
   app.stopSidebarStatusPoll();
-
   const session = {
-    id: 'sess_stuck',
-    title: 'Stuck stream',
+    id: sessionId,
+    title: 'Uploading',
     origin: 'web',
     created: 1710000000000,
     messages: [],
-    activeResponseId: 'resp_already_done',
-    lastSequenceNumber: 48,
+    activeResponseId: null,
+    lastSequenceNumber: 0,
   };
   session.transcript = new windowObj.ConversationController(session.id);
-  const controller = new AbortController();
   app.state.sessions = [session];
   app.state.activeSessionId = session.id;
   app.state.draftSessionActive = false;
-  app.state.streaming = true;
-  app.state.currentStreamSessionId = session.id;
-  app.state.currentStreamResponseId = session.activeResponseId;
-  app.state.abortController = controller;
   app.setSessionOptimisticBusy(session, true);
-  app.setSessionServerActiveRun(session, true);
+  app.state.currentStreamSessionId = session.id;
+  app.state.currentStreamResponseId = '';
+  app.state.abortController = controller;
+  app.state.streaming = true;
 
   await app.startSidebarStatusPoll();
 
-  const remaining = {
-    activeResponseId: session.activeResponseId,
-    currentStreamSessionId: app.state.currentStreamSessionId,
-    currentStreamResponseId: app.state.currentStreamResponseId,
-    hasController: Boolean(app.state.abortController),
-    streaming: app.state.streaming,
-    optimisticBusy: Boolean(session.__optimisticBusy),
-    serverActive: Boolean(session.__serverActiveRun),
-  };
-  if (controller.signal.aborted !== true
-    || remaining.activeResponseId
-    || remaining.currentStreamSessionId
-    || remaining.currentStreamResponseId
-    || remaining.hasController
-    || remaining.streaming
-    || remaining.optimisticBusy
-    || remaining.serverActive) {
-    fail(name, 'idle server truth did not fully clear local response ownership', JSON.stringify(remaining));
+  if (controller.signal.aborted
+    || app.state.abortController !== controller
+    || !app.state.streaming
+    || !app.sessionHasInProgressState(session)) {
+    fail(name, 'sidebar idle status aborted an unacknowledged response POST');
     return;
   }
-
   pass(name);
 }
 
@@ -6673,7 +6744,8 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testActiveStatusSyncsInRunTranscriptRevisionsWithoutDuplicatingActiveOutput();
   await testHugeTranscriptGapTraversalStaysBoundedAndAnchored();
   await testIdleSessionSyncRescuesPendingInterruptCommit();
-  await testIdleSidebarTruthClearsStuckTransportOwnership();
+  await testIdleStateRetiresOnlySampledTransportOwnership();
+  await testIdleSidebarStatusPreservesUnacknowledgedPost();
   await testSessionProgressStatePrefersLocalAndServerSignals();
   await testResumeAndDrainFiringViaSync();
   await testSyncIgnoresPendingInterjectionWithoutExactID();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -3238,7 +3238,7 @@ async function testRecoverySnapshotDoesNotDuplicateOptimisticInterjection() {
 }
 
 async function testResumeActiveResponseHeartbeatCancelSlowsAndRecovers() {
-  const name = 'resumeActiveResponse heartbeat cancellations keep recovering with slow backoff';
+  const name = 'resumeActiveResponse heartbeat cancellations survive state reconciliation failure and keep recovering';
   const responseId = 'resp_events_heartbeat_retry';
   const intervalCallbacks = [];
   const retryDelays = [];
@@ -3302,6 +3302,7 @@ async function testResumeActiveResponseHeartbeatCancelSlowsAndRecovers() {
   const { app, elements, state, cleanup } = harness;
   app.syncActiveSessionFromServer = async (session) => {
     syncCalls += 1;
+    if (syncCalls === 1) throw new Error('transient state reconciliation failure');
     session.activeResponseId = responseId;
     return { active_run: true, active_response_id: responseId };
   };


### PR DESCRIPTION
## What

Make stalled response recovery converge on server truth without allowing an old idle sample to cancel a newer send:

- reconnect-loop state reconciliation failures are caught and treated as unknown, so replay keeps retrying
- a rejected resume detaches only the matching failed transport, then performs selected-session reconciliation
- sidebar status detecting “server idle, client still owns a server-issued response ID” confirms through `/state`
- idle `/state` may retire a transport only when its controller, generation, session ID, and non-empty response ID are unchanged across the state round trip
- unacknowledged `POST /v1/responses` ownership (`currentStreamResponseId === ''`) is never retired by idle polling
- normal state polling remains suppressed while a healthy transport is attached; no extra active-run poll loop

## Why

Session 3137 exposed the failure sharply:

- the final response was persisted at **18:40:12 AEST**
- the client’s last `/events` connection had ended at **18:28:24**
- the browser still claimed the run was active
- Stop at **18:58:29** received 404 because the response had already been done for **18m 16s**
- reload showed the correct durable transcript immediately

The likely root failure was a rejected reconciliation killing the nominally infinite reconnect loop. The fix makes that loop exception-safe and adds an independent, ownership-safe server-truth path.

## Race invariants

1. A stable stale transport with a server-issued response ID can be retired when `/state` confirms idle.
2. An idle response sampled before a newer local send cannot abort that send.
3. Sidebar idle status cannot abort a response POST before the server has issued its response ID.
4. A transient reconciliation exception cannot terminate heartbeat recovery.

## Verification

- `node internal/serveui/static/app_sessions_test.js`
- `node internal/serveui/static/app_stream_test.js`
- `go test ./internal/serveui/...`
- `go build .`
- all three differential race probes from the first Opus review now pass:
  - newer run survives stale idle state
  - in-flight response POST survives sidebar idle status
  - no perpetual 1.2-second `/state` polling loop
