### PR TITLE
fix: settle orphaned evaluating interjections

### DIFF
--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -46,6 +46,26 @@ const discardPendingInterruptCommit = (messageId) => {
   state.pendingInterruptCommits = state.pendingInterruptCommits.filter(entry => entry.messageId !== messageId);
 };
 
+const settleOrphanedEvaluatingInterjections = (session) => {
+  if (!session?.id) return 0;
+  const tracked = new Set();
+  for (const entry of state.pendingInterruptCommits) {
+    if (entry.sessionId === session.id && entry.messageId) tracked.add(entry.messageId);
+  }
+  for (const entry of state.pendingInterjections) {
+    if (entry.sessionId === session.id && entry.messageId) tracked.add(entry.messageId);
+  }
+
+  let settled = 0;
+  for (const message of window.TermLLMConversation.sessionMessages(session)) {
+    if (message?.role !== 'user' || message.interruptState !== 'evaluating' || tracked.has(message.id)) continue;
+    setInterruptMessageState(session, message.id, 'failed');
+    settled += 1;
+  }
+  if (settled > 0) app.persistPendingIntents?.(session);
+  return settled;
+};
+
 const requeueUncommittedInterrupts = (session) => {
   if (!session?.id) return;
   const remaining = [];
@@ -320,6 +340,7 @@ Object.assign(app, {
   trackPendingInterruptCommit,
   resolvePendingInterruptCommitById,
   discardPendingInterruptCommit,
+  settleOrphanedEvaluatingInterjections,
   requeueUncommittedInterrupts,
   drainInterruptQueueIfIdle,
   setInterruptMessageState,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -616,6 +616,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
       setConnectionState('', '');
       setStreaming(false);
     }
+    app.settleOrphanedEvaluatingInterjections?.(session);
     requeuePendingInterjections(session);
     drainInterruptQueueIfIdle(session);
   }

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3271,6 +3271,7 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
   const name = 'idle session sync rescues pending interrupt commits';
   const sendCalls = [];
   const requeueCalls = [];
+  const settleCalls = [];
   let appRef = null;
 
   const { app } = await createSessionsHarness({
@@ -3305,6 +3306,9 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
       });
     },
     appOverrides: {
+      settleOrphanedEvaluatingInterjections(session) {
+        settleCalls.push(session.id);
+      },
       requeueUncommittedInterrupts(session) {
         requeueCalls.push(session.id);
         const [entry] = appRef.state.pendingInterruptCommits;
@@ -3355,6 +3359,10 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
 
   await app.syncActiveSessionFromServer(session, false);
 
+  if (settleCalls.length !== 1 || settleCalls[0] !== session.id) {
+    fail(name, 'expected idle sync to settle orphaned evaluating interjections', JSON.stringify(settleCalls));
+    return;
+  }
   if (requeueCalls.length !== 1 || requeueCalls[0] !== session.id) {
     fail(name, 'expected idle sync to requeue pending interrupt commits', JSON.stringify(requeueCalls));
     return;

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -1444,6 +1444,45 @@ async function testInactiveInterruptHelpersDoNotTouchVisibleDOM() {
   pass(name);
 }
 
+async function testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections() {
+  const name = 'idle recovery marks orphaned evaluating interjections failed but preserves tracked transactions';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const session = {
+    id: 'session_orphaned_interjection',
+    title: 'Orphaned interjection',
+    messages: [
+      { id: 'msg_orphan', role: 'user', content: 'taking forever', created: 1000, interruptState: 'evaluating' },
+      { id: 'msg_tracked', role: 'user', content: 'still classifying', created: 1001, interruptState: 'evaluating' },
+      { id: 'msg_queued', role: 'user', content: 'already queued', created: 1002, interruptState: 'queue' },
+    ],
+    activeResponseId: null,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.pendingInterruptCommits = [{
+    sessionId: session.id,
+    prompt: 'still classifying',
+    messageId: 'msg_tracked',
+  }];
+
+  const settled = app.settleOrphanedEvaluatingInterjections(session);
+  const messages = projectedMessages(session);
+  if (settled !== 1
+    || messages.find((message) => message.id === 'msg_orphan')?.interruptState !== 'failed'
+    || messages.find((message) => message.id === 'msg_tracked')?.interruptState !== 'evaluating'
+    || messages.find((message) => message.id === 'msg_queued')?.interruptState !== 'queue') {
+    fail(name, 'orphan settlement changed the wrong interjection state', JSON.stringify(messages));
+    await cleanup();
+    return;
+  }
+
+  await cleanup();
+  pass(name);
+}
+
 async function testInactiveSessionPromptEventsRemainActionable() {
   const name = 'inactive ask-user and approval prompt events still create actionable modal state';
   const harness = createHarness();
@@ -6837,6 +6876,7 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testInactiveSessionStreamEventsDoNotAppendToVisibleDOM();
   await testInactiveExistingMessageUpdatesDoNotTouchVisibleDOM();
   await testInactiveInterruptHelpersDoNotTouchVisibleDOM();
+  await testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections();
   await testInactiveSessionPromptEventsRemainActionable();
   await testInactiveSessionFailureDoesNotMutateProjectionOrVisibleDOM();
   await testConsumeResponseStreamReportsStaleWithoutApplyingEvents();


### PR DESCRIPTION
## What

Settle locally persisted interjection messages that remain `evaluating` after authoritative session state is idle and no live client transaction still owns them.

- tracked pending commits/interjections remain untouched
- orphaned `evaluating` messages transition to `failed`
- the settled state is persisted, so reload does not resurrect the spinner

## Why

An interjection is first rendered optimistically and persisted as a client-owned transcript intent. Its in-memory `pendingInterruptCommits` bookkeeping is not persisted. After a reload or interrupted recovery, the message can therefore survive forever as `evaluating` even though:

- the server reports `active_run: false`
- there is no server `pending_interjection`
- there is no local pending commit or interjection transaction

Observed on session 3137: “this is taking forever” remained `evaluating…` for three hours while the server was idle and later turns had completed.

## Invariant

An inline interjection may show `evaluating` only while a matching local pending commit or pending interjection transaction exists. Idle reconciliation marks unowned evaluating intents failed rather than leaving an immortal spinner.

## Verification

- `node internal/serveui/static/app_stream_test.js`
- `node internal/serveui/static/app_sessions_test.js`
- `go test ./internal/serveui/...`
- `go build .`
