### PR TITLE
fix: Transient completion-notification failures permanently silence queued jobs

### DIFF
--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -4,15 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/providerhttp"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -99,7 +102,11 @@ type telegramSendRequest struct {
 
 type telegramSendResponse struct {
 	OK          bool   `json:"ok"`
+	ErrorCode   int    `json:"error_code"`
 	Description string `json:"description"`
+	Parameters  struct {
+		RetryAfter int `json:"retry_after"`
+	} `json:"parameters"`
 }
 
 func normalizeTelegramParseMode(parseMode string) (string, error) {
@@ -147,11 +154,13 @@ func sendTelegramMessage(ctx context.Context, token string, chatID int64, messag
 		return fmt.Errorf("read telegram response: %w", err)
 	}
 
+	var apiResp telegramSendResponse
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("telegram send failed: status %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+		_ = json.Unmarshal(respBody, &apiResp)
+		message := fmt.Sprintf("telegram send failed: status %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+		return providerhttp.NewStatusErrorMessageString(message, resp.StatusCode, resp.Status, telegramErrorHeaders(resp.Header, apiResp.Parameters.RetryAfter), string(respBody))
 	}
 
-	var apiResp telegramSendResponse
 	if err := json.Unmarshal(respBody, &apiResp); err != nil {
 		return fmt.Errorf("decode telegram response: %w", err)
 	}
@@ -160,10 +169,25 @@ func sendTelegramMessage(ctx context.Context, token string, chatID int64, messag
 		if detail == "" {
 			detail = "unknown error"
 		}
-		return fmt.Errorf("telegram send failed: %s", detail)
+		message := fmt.Sprintf("telegram send failed: %s", detail)
+		if apiResp.ErrorCode != 0 {
+			return providerhttp.NewStatusErrorMessageString(message, apiResp.ErrorCode, "", telegramErrorHeaders(resp.Header, apiResp.Parameters.RetryAfter), string(respBody))
+		}
+		return errors.New(message)
 	}
 
 	return nil
+}
+
+func telegramErrorHeaders(header http.Header, retryAfterSeconds int) http.Header {
+	header = header.Clone()
+	if retryAfterSeconds > 0 && header.Get("Retry-After") == "" {
+		if header == nil {
+			header = make(http.Header)
+		}
+		header.Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+	}
+	return header
 }
 
 func logTelegramNotifySession(ctx context.Context, cfg *config.Config, chatID int64, message string, errWriter io.Writer) {

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -21,6 +21,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/jobs"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/providerhttp"
 	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -1607,6 +1608,12 @@ func (m *jobsV2Manager) enqueueRunDoneNotification(run jobsV2Run, status jobsV2R
 	}()
 }
 
+const (
+	jobsV2NotifyMaxAttempts       = 3
+	jobsV2NotifyAttemptTimeout    = 10 * time.Second
+	jobsV2NotifyInitialRetryDelay = time.Second
+)
+
 func (m *jobsV2Manager) notifyRunDone(run jobsV2Run, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) {
 	if m == nil || m.notifyDone == nil || !jobsV2NotifyTerminalStatus(status) {
 		return
@@ -1615,11 +1622,55 @@ func (m *jobsV2Manager) notifyRunDone(run jobsV2Run, status jobsV2RunStatus, res
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := m.notifyDone(ctx, run, job, status, result, exitReason, truncated, errText); err != nil {
-		_ = m.addRunEvent(run.ID, "notify_failed", "completion notification failed", map[string]any{"error": err.Error()})
+
+	var notifyErr error
+	for attempt := 1; attempt <= jobsV2NotifyMaxAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), jobsV2NotifyAttemptTimeout)
+		notifyErr = m.notifyDone(ctx, run, job, status, result, exitReason, truncated, errText)
+		cancel()
+		if notifyErr == nil {
+			return
+		}
+		if attempt == jobsV2NotifyMaxAttempts || !jobsV2NotifyErrorRetryable(notifyErr) {
+			break
+		}
+
+		delay := jobsV2NotifyRetryDelay(notifyErr, attempt)
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+		case <-m.doneChan():
+			stopTimer(timer)
+			_ = m.addRunEvent(run.ID, "notify_failed", "completion notification failed", map[string]any{"error": notifyErr.Error()})
+			return
+		}
 	}
+	_ = m.addRunEvent(run.ID, "notify_failed", "completion notification failed", map[string]any{"error": notifyErr.Error()})
+}
+
+func jobsV2NotifyErrorRetryable(err error) bool {
+	var statusErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &statusErr) {
+		return providerhttp.RetryableStatus(statusErr.HTTPStatusCode())
+	}
+	// Persistence and network errors do not generally expose a status code.
+	// Treat them as transient; retries remain bounded by jobsV2NotifyMaxAttempts.
+	return true
+}
+
+func jobsV2NotifyRetryDelay(err error, failedAttempt int) time.Duration {
+	var retryAfterErr interface {
+		RetryAfterDelay() (time.Duration, bool)
+	}
+	if errors.As(err, &retryAfterErr) {
+		if delay, ok := retryAfterErr.RetryAfterDelay(); ok && delay >= 0 {
+			return delay
+		}
+	}
+	if failedAttempt < 1 {
+		failedAttempt = 1
+	}
+	return jobsV2NotifyInitialRetryDelay * time.Duration(1<<(failedAttempt-1))
 }
 
 func (m *jobsV2Manager) addRunEvent(runID, eventType, message string, payload any) error {

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -3,17 +3,28 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/providerhttp"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
+
+type jobsV2NotifyTransientTestError struct{}
+
+func (jobsV2NotifyTransientTestError) Error() string {
+	return "transient notify failure"
+}
+
+func (jobsV2NotifyTransientTestError) RetryAfterDelay() (time.Duration, bool) {
+	return time.Millisecond, true
+}
 
 func TestJobsV2CreateJobSanitizesNotifyOriginFromBody(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 0, nil)
@@ -269,9 +280,102 @@ func TestJobsV2NotifyWhenDoneContinuesLoadedIdleWebSession(t *testing.T) {
 	}
 }
 
-func TestJobsV2NotifyFailureDoesNotChangeRunStatus(t *testing.T) {
+func TestJobsV2NotifyRetriesTransientFailures(t *testing.T) {
+	attempts := 0
 	mgr, err := newJobsV2ManagerWithNotifier(":memory:", 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
-		return errors.New("notify failed")
+		attempts++
+		if attempts < jobsV2NotifyMaxAttempts {
+			return jobsV2NotifyTransientTestError{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "notify-retry-success",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+
+	mgr.notifyRunDone(run, jobsV2RunSucceeded, jobsV2RunResult{Stdout: "ok"}, exitReasonNatural, false, "")
+	if attempts != jobsV2NotifyMaxAttempts {
+		t.Fatalf("notification attempts = %d, want %d", attempts, jobsV2NotifyMaxAttempts)
+	}
+	events, _, err := mgr.ListRunEvents(run.ID, 0, 20, 0)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	for _, ev := range events {
+		if ev.EventType == "notify_failed" {
+			t.Fatalf("unexpected notify_failed event after successful retry: %#v", events)
+		}
+	}
+}
+
+func TestJobsV2NotifyPermanentHTTPFailureDoesNotRetry(t *testing.T) {
+	attempts := 0
+	mgr, err := newJobsV2ManagerWithNotifier(":memory:", 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		attempts++
+		return providerhttp.NewStatusErrorString("Telegram", http.StatusBadRequest, "400 Bad Request", nil, "bad chat")
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "notify-permanent-failure",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+
+	mgr.notifyRunDone(run, jobsV2RunSucceeded, jobsV2RunResult{Stdout: "ok"}, exitReasonNatural, false, "")
+	if attempts != 1 {
+		t.Fatalf("notification attempts = %d, want 1 for permanent HTTP failure", attempts)
+	}
+	events, _, err := mgr.ListRunEvents(run.ID, 0, 20, 0)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	notifyFailures := 0
+	for _, ev := range events {
+		if ev.EventType == "notify_failed" {
+			notifyFailures++
+		}
+	}
+	if notifyFailures != 1 {
+		t.Fatalf("notify_failed events = %d, want 1: %#v", notifyFailures, events)
+	}
+}
+
+func TestJobsV2NotifyFailureDoesNotChangeRunStatus(t *testing.T) {
+	var attempts atomic.Int32
+	mgr, err := newJobsV2ManagerWithNotifier(":memory:", 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		attempts.Add(1)
+		return jobsV2NotifyTransientTestError{}
 	})
 	if err != nil {
 		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
@@ -318,14 +422,17 @@ func TestJobsV2NotifyFailureDoesNotChangeRunStatus(t *testing.T) {
 		}
 		return false
 	}, "async notify_failed event")
-	foundNotifyFailure := false
+	notifyFailures := 0
 	for _, ev := range events {
 		if ev.EventType == "notify_failed" {
-			foundNotifyFailure = true
+			notifyFailures++
 		}
 	}
-	if !foundNotifyFailure {
-		t.Fatalf("expected notify_failed event, got %#v", events)
+	if got := attempts.Load(); got != jobsV2NotifyMaxAttempts {
+		t.Fatalf("notification attempts = %d, want %d", got, jobsV2NotifyMaxAttempts)
+	}
+	if notifyFailures != 1 {
+		t.Fatalf("notify_failed events = %d, want 1: %#v", notifyFailures, events)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Retry asynchronous queued-job completion notifications up to three times for transient failures, with per-attempt timeouts and context-aware exponential backoff.
- Stop immediately for permanent HTTP failures while honoring structured `Retry-After` delays.
- Preserve Telegram HTTP status and API `retry_after` metadata so 429/5xx responses are classified correctly.
- Persist a single `notify_failed` event only after retry exhaustion or a permanent failure; terminal run status remains unchanged.

## Why this is high-value

Queued Jarvis jobs often finish long after they were started, so the Telegram or web completion notice is the user's primary signal that work is ready. Previously, one brief network, Telegram API, or session-store failure permanently discarded that notice because the run was already terminal and notification delivery was attempted only once. A small bounded retry closes that common reliability gap without blocking job completion or retrying permanent 4xx failures.

## Validation

- Added coverage for two transient failures followed by success, asserting three attempts and no `notify_failed` event.
- Added bounded-exhaustion coverage, asserting three attempts, exactly one final `notify_failed` event, and unchanged successful run status.
- Added coverage that permanent HTTP 4xx failures are not retried.
- `gofmt -w cmd/serve_jobs_v2.go cmd/notify.go cmd/serve_jobs_v2_notify_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `git diff --check`
