### PR TITLE
fix: Telegram final flush silently drops rate-limited response chunks

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -30,6 +32,9 @@ import (
 
 const telegramMaxMessageLen = 4000 // Telegram limit is 4096; leave margin
 const minEditInterval = 3 * time.Second
+const telegramFinalDeliveryTimeout = 30 * time.Second
+const telegramFinalDeliveryMaxAttempts = 3
+const telegramTransientRetryDelay = 500 * time.Millisecond
 
 // defaultStreamEventTimeout is used when telegramSessionMgr.streamEventTimeout is zero.
 const defaultStreamEventTimeout = 10 * time.Minute
@@ -125,6 +130,35 @@ func (r *telegramCancelOnCloseReadCloser) Close() error {
 // handleMessage, allowing tests to supply a fake without a live connection.
 type botSender interface {
 	Send(c tgbotapi.Chattable) (tgbotapi.Message, error)
+}
+
+func telegramSendErrorRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *tgbotapi.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == http.StatusTooManyRequests || apiErr.Code == http.StatusRequestTimeout || apiErr.Code >= 500
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "429") || strings.Contains(msg, "too many requests")
+}
+
+func telegramSendRetryDelay(err error, editInterval time.Duration) time.Duration {
+	var apiErr *tgbotapi.Error
+	if errors.As(err, &apiErr) {
+		if apiErr.RetryAfter > 0 {
+			return time.Duration(apiErr.RetryAfter) * time.Second
+		}
+		if apiErr.Code == http.StatusTooManyRequests && editInterval > 0 {
+			return editInterval
+		}
+	}
+	return telegramTransientRetryDelay
 }
 
 // botFileGetter is the subset of tgbotapi.BotAPI used for downloading files.
@@ -561,6 +595,7 @@ type telegramSessionMgr struct {
 	allowedUsernames map[string]struct{}
 	messageSlots     chan struct{}
 	tickerInterval   time.Duration // 0 means use default (500ms); overridden in tests
+	editInterval     time.Duration // 0 means use minEditInterval; overridden in tests
 
 	// streamEventTimeout bounds how long the stream watchdog waits between events
 	// before declaring the stream dead. 0 means use defaultStreamEventTimeout.
@@ -1912,12 +1947,18 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	editInterval := m.editInterval
+	if editInterval <= 0 {
+		editInterval = minEditInterval
+	}
+
 	currentMsgID := placeholder.MessageID
 	msgStart := 0       // byte offset in the full text where the current Telegram message begins
 	needNewMsg := false // true when overflow happened but next placeholder not yet created
 
 	var lastSentContent string
 	var lastEditTime time.Time
+	var lastSuccessfulEditTime time.Time
 	lastVisibleChange := time.Now()
 	streamStart := time.Now()
 	spinChars := []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
@@ -1927,7 +1968,7 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		if !force && content == lastSentContent {
 			return false
 		}
-		if !force && !lastEditTime.IsZero() && time.Since(lastEditTime) < minEditInterval {
+		if !force && !lastEditTime.IsZero() && time.Since(lastEditTime) < editInterval {
 			return false
 		}
 		edit := tgbotapi.NewEditMessageText(chatID, msgID, mdToTelegramHTML(content))
@@ -1941,6 +1982,7 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		contentChanged := content != lastSentContent
 		lastSentContent = content
 		lastEditTime = time.Now()
+		lastSuccessfulEditTime = lastEditTime
 		if contentChanged {
 			lastVisibleChange = lastEditTime
 		}
@@ -1978,6 +2020,104 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 			needNewMsg = true
 		}
 		return prose, true
+	}
+
+	waitForFinalDelay := func(deliveryCtx context.Context, delay time.Duration) error {
+		if err := deliveryCtx.Err(); err != nil {
+			return err
+		}
+		if delay <= 0 {
+			return nil
+		}
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return nil
+		case <-deliveryCtx.Done():
+			return deliveryCtx.Err()
+		}
+	}
+
+	waitForFinalPace := func(deliveryCtx context.Context) error {
+		if lastSuccessfulEditTime.IsZero() {
+			return nil
+		}
+		return waitForFinalDelay(deliveryCtx, time.Until(lastSuccessfulEditTime.Add(editInterval)))
+	}
+
+	sendFinal := func(deliveryCtx context.Context, chattable tgbotapi.Chattable) (tgbotapi.Message, error) {
+		var lastErr error
+		for attempt := 1; attempt <= telegramFinalDeliveryMaxAttempts; attempt++ {
+			if err := waitForFinalPace(deliveryCtx); err != nil {
+				return tgbotapi.Message{}, fmt.Errorf("pace final Telegram delivery: %w", err)
+			}
+			msg, sendErr := bot.Send(chattable)
+			if sendErr == nil {
+				return msg, nil
+			}
+			lastErr = sendErr
+			if !telegramSendErrorRetryable(sendErr) {
+				return tgbotapi.Message{}, fmt.Errorf("final Telegram delivery failed: %w", sendErr)
+			}
+			if attempt == telegramFinalDeliveryMaxAttempts {
+				break
+			}
+			retryDelay := telegramSendRetryDelay(sendErr, editInterval)
+			log.Printf("[telegram] transient final delivery failure (chat %d, attempt %d/%d), retrying in %s: %v", chatID, attempt, telegramFinalDeliveryMaxAttempts, retryDelay, sendErr)
+			if err := waitForFinalDelay(deliveryCtx, retryDelay); err != nil {
+				return tgbotapi.Message{}, fmt.Errorf("final Telegram delivery retry interrupted (%v): %w", lastErr, err)
+			}
+		}
+		return tgbotapi.Message{}, fmt.Errorf("final Telegram delivery failed after %d attempts: %w", telegramFinalDeliveryMaxAttempts, lastErr)
+	}
+
+	sendFinalEdit := func(deliveryCtx context.Context, msgID int, content string) error {
+		edit := tgbotapi.NewEditMessageText(chatID, msgID, mdToTelegramHTML(content))
+		edit.ParseMode = tgbotapi.ModeHTML
+		if _, err := sendFinal(deliveryCtx, edit); err != nil {
+			return err
+		}
+		contentChanged := content != lastSentContent
+		lastSentContent = content
+		lastEditTime = time.Now()
+		lastSuccessfulEditTime = lastEditTime
+		if contentChanged {
+			lastVisibleChange = lastEditTime
+		}
+		return nil
+	}
+
+	ensureFinalCurrentMessage := func(deliveryCtx context.Context) error {
+		if !needNewMsg {
+			return nil
+		}
+		newMsg, err := sendFinal(deliveryCtx, tgbotapi.NewMessage(chatID, "⏳"))
+		if err != nil {
+			return fmt.Errorf("send continuation placeholder: %w", err)
+		}
+		currentMsgID = newMsg.MessageID
+		lastSentContent = ""
+		lastEditTime = time.Time{}
+		lastVisibleChange = time.Now()
+		needNewMsg = false
+		return nil
+	}
+
+	sendFinalProseChunks := func(deliveryCtx context.Context, prose string) (string, error) {
+		for utf8.RuneCountInString(prose) > telegramMaxMessageLen {
+			if err := ensureFinalCurrentMessage(deliveryCtx); err != nil {
+				return prose, err
+			}
+			chunk, splitAtBytes := prefixRunes(prose, telegramMaxMessageLen)
+			if err := sendFinalEdit(deliveryCtx, currentMsgID, chunk); err != nil {
+				return prose, err
+			}
+			msgStart += splitAtBytes
+			prose = prose[splitAtBytes:]
+			needNewMsg = true
+		}
+		return prose, nil
 	}
 
 	salvagePartialHistory := func(persistCtx context.Context, fallbackOp string) {
@@ -2203,6 +2343,10 @@ loop:
 	imagesToSend := append([]string(nil), collectedImages...)
 	textMu.Unlock()
 
+	finalDeliveryCtx, cancelFinalDelivery := context.WithTimeout(ctx, telegramFinalDeliveryTimeout)
+	defer cancelFinalDelivery()
+	var finalDeliveryErr error
+
 	prose := ""
 	if msgStart < len(full) {
 		prose = full[msgStart:]
@@ -2210,21 +2354,21 @@ loop:
 	switch {
 	case prose != "":
 		// There is new content to show in the current window.
-		prose, ok := sendProseChunks(prose, true)
-		if !ok {
+		prose, finalDeliveryErr = sendFinalProseChunks(finalDeliveryCtx, prose)
+		if finalDeliveryErr != nil {
 			break
 		}
-		if !ensureCurrentMessage() {
+		if finalDeliveryErr = ensureFinalCurrentMessage(finalDeliveryCtx); finalDeliveryErr != nil {
 			break
 		}
-		sendEdit(currentMsgID, prose, true)
+		finalDeliveryErr = sendFinalEdit(finalDeliveryCtx, currentMsgID, prose)
 	case full == "":
 		// Nothing was produced at all — show a fallback in the original placeholder.
+		fallback := "(no response)"
 		if ran {
-			sendEdit(currentMsgID, "(done)", true)
-		} else {
-			sendEdit(currentMsgID, "(no response)", true)
+			fallback = "(done)"
 		}
+		finalDeliveryErr = sendFinalEdit(finalDeliveryCtx, currentMsgID, fallback)
 		if m.settings.Debug || m.settings.DebugRaw {
 			log.Printf("[telegram] empty assistant text for chat %d (toolsRan=%v, text_delta=%d, reasoning_delta=%d, tool_start=%d, tool_end=%d, tool_call=%d, phase=%d, usage=%d, done=%d, retry=%d, error=%d, other=%d, other_types=%v)",
 				chatID,
@@ -2333,6 +2477,9 @@ loop:
 		})
 	}
 
+	if finalDeliveryErr != nil {
+		return fmt.Errorf("deliver complete Telegram response: %w", finalDeliveryErr)
+	}
 	return nil
 }
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -144,6 +144,54 @@ func (f *fakeBotSender) overLimitEditTexts() []string {
 	return out
 }
 
+type pacedFinalBotSender struct {
+	*fakeBotSender
+	mu               sync.Mutex
+	minEditInterval  time.Duration
+	lastEdit         time.Time
+	rejectNextEdit   bool
+	rateLimitedEdits int
+}
+
+func (f *pacedFinalBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
+	if _, ok := c.(tgbotapi.EditMessageTextConfig); ok {
+		f.mu.Lock()
+		now := time.Now()
+		if f.rejectNextEdit {
+			f.rejectNextEdit = false
+			f.rateLimitedEdits++
+			f.mu.Unlock()
+			return tgbotapi.Message{}, &tgbotapi.Error{Code: http.StatusTooManyRequests, Message: "Too Many Requests"}
+		}
+		if !f.lastEdit.IsZero() && now.Sub(f.lastEdit) < f.minEditInterval {
+			f.rateLimitedEdits++
+			f.mu.Unlock()
+			return tgbotapi.Message{}, &tgbotapi.Error{Code: http.StatusTooManyRequests, Message: "Too Many Requests"}
+		}
+		f.lastEdit = now
+		f.mu.Unlock()
+	}
+	return f.fakeBotSender.Send(c)
+}
+
+func (f *pacedFinalBotSender) rateLimitCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rateLimitedEdits
+}
+
+type permanentFinalEditErrorBotSender struct {
+	*fakeBotSender
+	err error
+}
+
+func (f *permanentFinalEditErrorBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
+	if _, ok := c.(tgbotapi.EditMessageTextConfig); ok {
+		return tgbotapi.Message{}, f.err
+	}
+	return f.fakeBotSender.Send(c)
+}
+
 type blockingTextProvider struct {
 	text           string
 	firstChunkSent chan struct{}
@@ -773,12 +821,20 @@ func TestStreamReply_FinalEditChunksFastLongResponse(t *testing.T) {
 
 	mgr, sess := newTestMgrAndSession(h)
 	mgr.tickerInterval = time.Hour
-	bot := &fakeBotSender{maxEditRunes: telegramMaxMessageLen}
+	mgr.editInterval = 10 * time.Millisecond
+	bot := &pacedFinalBotSender{
+		fakeBotSender:   &fakeBotSender{maxEditRunes: telegramMaxMessageLen},
+		minEditInterval: mgr.editInterval,
+		rejectNextEdit:  true,
+	}
 
 	if err := mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hi")); err != nil {
 		t.Fatalf("streamReply returned error: %v", err)
 	}
 
+	if got := bot.rateLimitCount(); got != 1 {
+		t.Fatalf("rate-limited edit count = %d; want the injected first failure only", got)
+	}
 	if rejected := bot.overLimitEditTexts(); len(rejected) != 0 {
 		t.Fatalf("attempted %d over-limit edits; first had %d runes", len(rejected), utf8.RuneCountInString(rejected[0]))
 	}
@@ -794,6 +850,26 @@ func TestStreamReply_FinalEditChunksFastLongResponse(t *testing.T) {
 	}
 	if got := strings.Join(edits, ""); got != response {
 		t.Fatalf("joined edit chunks length = %d; want %d", len(got), len(response))
+	}
+}
+
+func TestStreamReply_FinalEditPermanentFailureReturnsError(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	h.Provider.AddTextResponse("complete answer")
+
+	mgr, sess := newTestMgrAndSession(h)
+	mgr.tickerInterval = time.Hour
+	bot := &permanentFinalEditErrorBotSender{
+		fakeBotSender: &fakeBotSender{},
+		err:           &tgbotapi.Error{Code: http.StatusBadRequest, Message: "message cannot be edited"},
+	}
+
+	err := mgr.streamReply(context.Background(), bot, sess, 42, llm.UserText("hi"))
+	if err == nil {
+		t.Fatal("streamReply returned nil after permanent final edit failure")
+	}
+	if !strings.Contains(err.Error(), "deliver complete Telegram response") {
+		t.Fatalf("streamReply error = %q; want final delivery context", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a context-aware final Telegram delivery path that waits for the existing edit interval before flushing completed response chunks.
- Final edits and continuation placeholders now retry bounded transient failures, including Telegram 429 responses, while honoring `retry_after` when supplied.
- Final delivery is capped at three attempts and a 30-second deadline. If all attempts fail, `streamReply` persists the completed turn but returns an error instead of silently reporting success.
- Updated the long-response test with a rate-limiting sender that injects a 429 and rejects edits sent too close together, then verifies every chunk is delivered in order.
- Added a permanent edit-failure test proving incomplete final delivery is surfaced to the caller.

## Why this is high-value

Telegram streaming is a daily Jarvis path. Fast completions and long answers previously forced final edits back-to-back, bypassing the normal three-second edit pacing. A single flood-control or transient failure could leave Telegram showing truncated text or stale progress even though the complete answer was persisted and the turn returned success. The bounded paced retry closes that user-visible reliability gap without changing provider streaming or transcript behavior.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `HOME=<clean temp dir> XDG_CONFIG_HOME=<clean temp config> CODEX_HOME=<clean temp codex> GOPATH=/home/agent/go GOCACHE=/home/agent/.cache/go-build go test ./...`
- `git diff --check`
