### PR TITLE
fix: update canonical interjection intent state

### DIFF
--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -59,7 +59,7 @@ const settleOrphanedEvaluatingInterjections = (session) => {
   let settled = 0;
   for (const message of window.TermLLMConversation.sessionMessages(session)) {
     if (message?.role !== 'user' || message.interruptState !== 'evaluating' || tracked.has(message.id)) continue;
-    setInterruptMessageState(session, message.id, 'failed');
+    setInterjectionPhase(session, message.id, 'failed');
     settled += 1;
   }
   if (settled > 0) app.persistPendingIntents?.(session);
@@ -105,10 +105,24 @@ const setInterruptMessageState = (session, messageId, interruptState) => {
   if (!messageId) return;
   const normalized = sanitizeInterruptState(interruptState);
   if (!normalized) return;
-  const message = window.TermLLMConversation.sessionMessages(session).find(m => m.id === messageId && m.role === 'user');
+  const intents = session?.transcript?.conversation?.intents;
+  let canonical = intents?.get?.(messageId) || null;
+  if (!canonical && intents?.values) {
+    canonical = [...intents.values()].find(message => (
+      message?.id === messageId
+      || message?.clientMessageId === messageId
+      || message?.client_message_id === messageId
+    )) || null;
+  }
+  const projected = window.TermLLMConversation.sessionMessages(session)
+    .find(message => message.id === messageId && message.role === 'user');
+  const message = canonical || projected;
   if (!message) return;
   message.interruptState = normalized;
-  updateVisibleUserNode(session, message);
+  if (canonical) app.refreshSessionMessagesFromTranscript?.(session);
+  const visibleMessage = window.TermLLMConversation.sessionMessages(session)
+    .find(entry => entry.id === messageId && entry.role === 'user') || message;
+  updateVisibleUserNode(session, visibleMessage);
 };
 
 // Transition an interjection to a lifecycle phase, updating both the inline

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -1448,18 +1448,21 @@ async function testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections() {
   const name = 'idle recovery marks orphaned evaluating interjections failed but preserves tracked transactions';
   const harness = createHarness();
   const { app, state, cleanup } = harness;
+  const intents = [
+    { id: 'msg_orphan', clientMessageId: 'msg_orphan', role: 'user', content: 'taking forever', created: 1000, interruptState: 'evaluating' },
+    { id: 'msg_tracked', clientMessageId: 'msg_tracked', role: 'user', content: 'still classifying', created: 1001, interruptState: 'evaluating' },
+    { id: 'msg_queued', clientMessageId: 'msg_queued', role: 'user', content: 'already queued', created: 1002, interruptState: 'queue' },
+  ];
   const session = {
     id: 'session_orphaned_interjection',
     title: 'Orphaned interjection',
-    messages: [
-      { id: 'msg_orphan', role: 'user', content: 'taking forever', created: 1000, interruptState: 'evaluating' },
-      { id: 'msg_tracked', role: 'user', content: 'still classifying', created: 1001, interruptState: 'evaluating' },
-      { id: 'msg_queued', role: 'user', content: 'already queued', created: 1002, interruptState: 'queue' },
-    ],
+    messages: [],
     activeResponseId: null,
     lastSequenceNumber: 0,
     number: 1,
   };
+  session.transcript = new ConversationController(session.id);
+  for (const intent of intents) session.transcript.addPendingIntent(intent, 0);
   state.sessions.push(session);
   state.activeSessionId = session.id;
   state.pendingInterruptCommits = [{
@@ -1471,7 +1474,7 @@ async function testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections() {
   const settled = app.settleOrphanedEvaluatingInterjections(session);
   const messages = projectedMessages(session);
   if (settled !== 1
-    || messages.find((message) => message.id === 'msg_orphan')?.interruptState !== 'failed'
+    || messages.find((message) => message.id === 'msg_orphan')?.interruptState !== 'error'
     || messages.find((message) => message.id === 'msg_tracked')?.interruptState !== 'evaluating'
     || messages.find((message) => message.id === 'msg_queued')?.interruptState !== 'queue') {
     fail(name, 'orphan settlement changed the wrong interjection state', JSON.stringify(messages));


### PR DESCRIPTION
## What

Update interjection badges through the transcript controller’s canonical pending-intent map, then refresh the projection and persist that canonical state.

Also settle orphaned evaluating interjections through the lifecycle phase `failed`, whose actual badge state is `error`.

## Why

PR #974 mutated `TermLLMConversation.sessionMessages(session)`, which is a rendered projection for transcript-backed sessions—not the canonical intent. Refreshing or persisting immediately reconstructed `evaluating` from the untouched canonical map.

It also passed `failed` directly to `setInterruptMessageState`, but `failed` is a lifecycle phase; the valid badge state is `error`. Production’s `sanitizeInterruptState('failed')` returns an empty string. The test harness’s permissive sanitizer hid both mistakes.

## Browser reproduction

Using the shared authenticated browser against session 3137:

1. Injected `msg_pathology_evaluating` into the real pending-intent localStorage registry with `interruptState: evaluating` and no pending transaction bookkeeping.
2. Reloaded `/chat/3137`.
3. Confirmed it remained `evaluating` indefinitely while server state was idle.
4. Called the merged #974 helper: it returned `1`, but canonical intent, projection and localStorage all remained `evaluating`.
5. Applied this patch in-page and transitioned the canonical intent to `error`.
6. Confirmed canonical map, rendered projection and localStorage all became `error`.
7. Reloaded again and confirmed `error` survived hydration.

## Verification

- regression fixture now uses a real `ConversationController` and canonical pending intents, not `session.messages`
- asserts lifecycle settlement produces badge state `error`
- `node internal/serveui/static/app_stream_test.js`
- `node internal/serveui/static/app_sessions_test.js`
- `go test ./internal/serveui/...`
- shared-browser localStorage/reload reproduction above
