### PR TITLE
fix: retire unowned interjection intents

### DIFF
--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -46,7 +46,7 @@ const discardPendingInterruptCommit = (messageId) => {
   state.pendingInterruptCommits = state.pendingInterruptCommits.filter(entry => entry.messageId !== messageId);
 };
 
-const settleOrphanedEvaluatingInterjections = (session) => {
+const retireUnownedInterjectionIntents = (session) => {
   if (!session?.id) return 0;
   const tracked = new Set();
   for (const entry of state.pendingInterruptCommits) {
@@ -56,14 +56,24 @@ const settleOrphanedEvaluatingInterjections = (session) => {
     if (entry.sessionId === session.id && entry.messageId) tracked.add(entry.messageId);
   }
 
-  let settled = 0;
+  const retiredIds = [];
   for (const message of window.TermLLMConversation.sessionMessages(session)) {
-    if (message?.role !== 'user' || message.interruptState !== 'evaluating' || tracked.has(message.id)) continue;
-    setInterjectionPhase(session, message.id, 'failed');
-    settled += 1;
+    if (message?.role !== 'user'
+      || (message.interruptState !== 'evaluating' && message.interruptState !== 'error')
+      || tracked.has(message.id)) continue;
+    const removed = app.retirePendingIntent?.(session, message.id) || [];
+    if (removed.length > 0) retiredIds.push(message.id);
   }
-  if (settled > 0) app.persistPendingIntents?.(session);
-  return settled;
+  if (retiredIds.length === 0) return 0;
+
+  app.refreshSessionMessagesFromTranscript?.(session);
+  const conversationDOM = conversationDOMFor?.(session);
+  if (conversationDOM) {
+    for (const node of conversationDOM.querySelectorAll('[data-message-id]')) {
+      if (retiredIds.includes(node.getAttribute('data-message-id'))) node.remove();
+    }
+  }
+  return retiredIds.length;
 };
 
 const requeueUncommittedInterrupts = (session) => {
@@ -354,7 +364,7 @@ Object.assign(app, {
   trackPendingInterruptCommit,
   resolvePendingInterruptCommitById,
   discardPendingInterruptCommit,
-  settleOrphanedEvaluatingInterjections,
+  retireUnownedInterjectionIntents,
   requeueUncommittedInterrupts,
   drainInterruptQueueIfIdle,
   setInterruptMessageState,

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -652,7 +652,7 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
       setConnectionState('', '');
       setStreaming(false);
     }
-    app.settleOrphanedEvaluatingInterjections?.(session);
+    app.retireUnownedInterjectionIntents?.(session);
     requeuePendingInterjections(session);
     drainInterruptQueueIfIdle(session);
   }

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3271,7 +3271,7 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
   const name = 'idle session sync rescues pending interrupt commits';
   const sendCalls = [];
   const requeueCalls = [];
-  const settleCalls = [];
+  const retireCalls = [];
   let appRef = null;
 
   const { app } = await createSessionsHarness({
@@ -3306,8 +3306,8 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
       });
     },
     appOverrides: {
-      settleOrphanedEvaluatingInterjections(session) {
-        settleCalls.push(session.id);
+      retireUnownedInterjectionIntents(session) {
+        retireCalls.push(session.id);
       },
       requeueUncommittedInterrupts(session) {
         requeueCalls.push(session.id);
@@ -3359,8 +3359,8 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
 
   await app.syncActiveSessionFromServer(session, false);
 
-  if (settleCalls.length !== 1 || settleCalls[0] !== session.id) {
-    fail(name, 'expected idle sync to settle orphaned evaluating interjections', JSON.stringify(settleCalls));
+  if (retireCalls.length !== 1 || retireCalls[0] !== session.id) {
+    fail(name, 'expected idle sync to retire unowned interjection intents', JSON.stringify(retireCalls));
     return;
   }
   if (requeueCalls.length !== 1 || requeueCalls[0] !== session.id) {

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -565,6 +565,9 @@ function createHarness(options = {}) {
       }
       return session.transcript.addPendingIntent(message, session.transcript.rev);
     },
+    retirePendingIntent(session, messageOrKey) {
+      return session?.transcript?.removePendingIntent?.(messageOrKey) || [];
+    },
     persistPendingIntents() {},
     refreshSessionMessagesFromTranscript(session) {
       const transcript = session?.transcript;
@@ -1444,14 +1447,15 @@ async function testInactiveInterruptHelpersDoNotTouchVisibleDOM() {
   pass(name);
 }
 
-async function testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections() {
-  const name = 'idle recovery marks orphaned evaluating interjections failed but preserves tracked transactions';
+async function testIdleRecoveryRetiresOnlyUnownedInterjectionIntents() {
+  const name = 'idle recovery removes unowned evaluating and failed interjections but preserves tracked transactions';
   const harness = createHarness();
   const { app, state, cleanup } = harness;
   const intents = [
     { id: 'msg_orphan', clientMessageId: 'msg_orphan', role: 'user', content: 'taking forever', created: 1000, interruptState: 'evaluating' },
-    { id: 'msg_tracked', clientMessageId: 'msg_tracked', role: 'user', content: 'still classifying', created: 1001, interruptState: 'evaluating' },
-    { id: 'msg_queued', clientMessageId: 'msg_queued', role: 'user', content: 'already queued', created: 1002, interruptState: 'queue' },
+    { id: 'msg_failed', clientMessageId: 'msg_failed', role: 'user', content: 'already failed', created: 1001, interruptState: 'error' },
+    { id: 'msg_tracked', clientMessageId: 'msg_tracked', role: 'user', content: 'still classifying', created: 1002, interruptState: 'evaluating' },
+    { id: 'msg_queued', clientMessageId: 'msg_queued', role: 'user', content: 'already queued', created: 1003, interruptState: 'queue' },
   ];
   const session = {
     id: 'session_orphaned_interjection',
@@ -1471,13 +1475,15 @@ async function testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections() {
     messageId: 'msg_tracked',
   }];
 
-  const settled = app.settleOrphanedEvaluatingInterjections(session);
+  const retired = app.retireUnownedInterjectionIntents(session);
   const messages = projectedMessages(session);
-  if (settled !== 1
-    || messages.find((message) => message.id === 'msg_orphan')?.interruptState !== 'error'
+  if (retired !== 2
+    || messages.some((message) => message.id === 'msg_orphan' || message.id === 'msg_failed')
+    || session.transcript.conversation.intents.has('msg_orphan')
+    || session.transcript.conversation.intents.has('msg_failed')
     || messages.find((message) => message.id === 'msg_tracked')?.interruptState !== 'evaluating'
     || messages.find((message) => message.id === 'msg_queued')?.interruptState !== 'queue') {
-    fail(name, 'orphan settlement changed the wrong interjection state', JSON.stringify(messages));
+    fail(name, 'orphan retirement changed the wrong pending intents', JSON.stringify(messages));
     await cleanup();
     return;
   }
@@ -6880,7 +6886,7 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testInactiveSessionStreamEventsDoNotAppendToVisibleDOM();
   await testInactiveExistingMessageUpdatesDoNotTouchVisibleDOM();
   await testInactiveInterruptHelpersDoNotTouchVisibleDOM();
-  await testIdleRecoverySettlesOnlyOrphanedEvaluatingInterjections();
+  await testIdleRecoveryRetiresOnlyUnownedInterjectionIntents();
   await testInactiveSessionPromptEventsRemainActionable();
   await testInactiveSessionFailureDoesNotMutateProjectionOrVisibleDOM();
   await testConsumeResponseStreamReportsStaleWithoutApplyingEvents();


### PR DESCRIPTION
## What

Retire unowned interjection intents instead of keeping them in the transcript as failed messages.

On authoritative idle reconciliation, pending user intents in either `evaluating` or terminal `error` state are removed from:

- the canonical transcript intent map
- pending-intent localStorage
- the rendered conversation DOM

Interjections with live transaction bookkeeping remain untouched, as do queued/committed states.

## Why

#977 made the failed state canonical, which stopped the immortal spinner but exposed the next bad invariant: a failed optimistic interjection remained a pending transcript intent forever. Every later transcript projection merged and sorted that junk again, so posting another message could move the failed item back to the bottom.

That message was never accepted by the server and has no durable or recovery value. Rendering it forever is worse than dropping it.

This also cleans up `error` intents already produced by #977, not only new orphaned `evaluating` intents.

## Shared-browser reproduction

Against session 3137, using a patched isolated web UI with the real sessions DB:

1. Injected one `evaluating` and one `error` interjection into the canonical pending-intent map and real localStorage.
2. Confirmed both rendered and both storage keys existed.
3. Reloaded the session and completed authoritative idle reconciliation.
4. Confirmed both intents were absent from the canonical projection and both localStorage keys were deleted.
5. Confirmed the durable transcript tail remained stable at `srv_seq_147_text_0`, `srv_seq_148`, `srv_seq_149_text_0`.

## Verification

- `node internal/serveui/static/app_stream_test.js`
- `node internal/serveui/static/app_sessions_test.js`
- `go test ./internal/serveui/...`
- shared-browser localStorage/reload reproduction above
