### PR TITLE
fix: Single tool calls can leave sessions permanently busy after cancellation

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -3567,7 +3567,7 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		return cancelledToolCallMessages(calls, err), nil
 	}
 
-	// Fast path: single call, no concurrency overhead
+	// Fast path: single call
 	if len(calls) == 1 {
 		return e.executeSingleToolCallSafe(ContextWithApprovalTranscript(ctx, transcript), calls[0], send, debug, debugRaw)
 	}
@@ -3692,6 +3692,40 @@ func (e *Engine) executeSingleToolCallSafe(ctx context.Context, call ToolCall, s
 	return e.executeSingleToolCall(ctx, call, send, debug, debugRaw)
 }
 
+type toolExecutionResult struct {
+	output     ToolOutput
+	err        error
+	panicValue any
+}
+
+// executeToolWithCancellation isolates Tool.Execute so a tool that ignores its
+// context cannot keep the engine blocked after the caller cancels. The buffered
+// result channel lets an abandoned invocation finish without blocking later.
+func executeToolWithCancellation(ctx context.Context, tool Tool, args json.RawMessage) (ToolOutput, error, any) {
+	if err := ctx.Err(); err != nil {
+		return ToolOutput{}, err, nil
+	}
+
+	results := make(chan toolExecutionResult, 1)
+	go func() {
+		result := toolExecutionResult{}
+		defer func() {
+			if r := recover(); r != nil {
+				result.panicValue = r
+			}
+			results <- result
+		}()
+		result.output, result.err = tool.Execute(ctx, args)
+	}()
+
+	select {
+	case result := <-results:
+		return result.output, result.err, result.panicValue
+	case <-ctx.Done():
+		return ToolOutput{}, ctx.Err(), nil
+	}
+}
+
 // startToolHeartbeat emits heartbeat events only if a tool is still running
 // after toolHeartbeatInterval. Most tools complete quickly, so using AfterFunc
 // avoids starting a goroutine and ticker on every tool invocation.
@@ -3749,7 +3783,10 @@ func (e *Engine) executeSingleToolCall(ctx context.Context, call ToolCall, send 
 	stopHeartbeat := startToolHeartbeat(ctx, call.ID, call.Name, send)
 	defer stopHeartbeat()
 
-	output, err := tool.Execute(toolCtx, call.Arguments)
+	output, err, panicValue := executeToolWithCancellation(toolCtx, tool, call.Arguments)
+	if panicValue != nil {
+		panic(panicValue)
+	}
 	info := e.getToolPreview(call)
 
 	// Truncate large tool outputs (global limit, then compaction limit).
@@ -3824,14 +3861,11 @@ func (e *Engine) handleSyncToolExecution(ctx context.Context, event Event, send 
 		err = fmt.Errorf("tool '%s' is not in the active skill's allowed-tools list", call.Name)
 	} else {
 		toolCtx := ContextWithCallID(ctx, callID)
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("Error: tool panicked: %v", r)
-				}
-			}()
-			result, err = tool.Execute(toolCtx, call.Arguments)
-		}()
+		var panicValue any
+		result, err, panicValue = executeToolWithCancellation(toolCtx, tool, call.Arguments)
+		if panicValue != nil {
+			err = fmt.Errorf("Error: tool panicked: %v", panicValue)
+		}
 	}
 
 	// Truncate large tool outputs (global limit, then compaction limit).

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1131,6 +1131,33 @@ func (t *delayingTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+// contextIgnoringTool deliberately ignores cancellation until released.
+type contextIgnoringTool struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func newContextIgnoringTool(startBuffer int) *contextIgnoringTool {
+	return &contextIgnoringTool{
+		started: make(chan struct{}, startBuffer),
+		release: make(chan struct{}),
+	}
+}
+
+func (t *contextIgnoringTool) Spec() ToolSpec {
+	return ToolSpec{Name: "context_ignoring_tool", Schema: map[string]any{"type": "object"}}
+}
+
+func (t *contextIgnoringTool) Execute(context.Context, json.RawMessage) (ToolOutput, error) {
+	t.started <- struct{}{}
+	<-t.release
+	return TextOutput("done"), nil
+}
+
+func (t *contextIgnoringTool) Preview(json.RawMessage) string {
+	return ""
+}
+
 // blockingTool simulates a tool that blocks until released so tests can
 // deterministically observe peak concurrency.
 type blockingTool struct {
@@ -1395,50 +1422,132 @@ func TestEngineParallelToolExecutionRespectsDefaultLimit(t *testing.T) {
 	}
 }
 
-func TestExecuteToolCallsParallelReturnsOnContextCancel(t *testing.T) {
+func TestExecuteToolCallsReturnsOnContextCancel(t *testing.T) {
 	t.Parallel()
 
-	tool := &delayingTool{delay: 300 * time.Millisecond}
+	tests := []struct {
+		name     string
+		parallel bool
+		calls    int
+	}{
+		{name: "parallel multiple", parallel: true, calls: 3},
+		{name: "parallel single", parallel: true, calls: 1},
+		{name: "serial", parallel: false, calls: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := newContextIgnoringTool(tt.calls)
+			defer close(tool.release)
+			registry := NewToolRegistry()
+			registry.Register(tool)
+			engine := NewEngine(&fakeProvider{}, registry)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			calls := make([]ToolCall, tt.calls)
+			for i := range calls {
+				calls[i] = ToolCall{
+					ID:        fmt.Sprintf("call-%d", i+1),
+					Name:      "context_ignoring_tool",
+					Arguments: json.RawMessage(`{}`),
+				}
+			}
+
+			type executionResult struct {
+				messages []Message
+				err      error
+			}
+			resultCh := make(chan executionResult, 1)
+			go func() {
+				messages, err := engine.executeToolCalls(ctx, calls, tt.parallel, eventSender{}, false, false)
+				resultCh <- executionResult{messages: messages, err: err}
+			}()
+
+			select {
+			case <-tool.started:
+			case <-time.After(time.Second):
+				t.Fatal("tool did not start")
+			}
+
+			cancelledAt := time.Now()
+			cancel()
+
+			var result executionResult
+			select {
+			case result = <-resultCh:
+			case <-time.After(200 * time.Millisecond):
+				t.Fatal("executeToolCalls did not return promptly after cancellation")
+			}
+			t.Logf("tool execution returned %v after cancellation", time.Since(cancelledAt))
+
+			if result.err != nil {
+				t.Fatalf("executeToolCalls error = %v, want synthesized results on cancellation", result.err)
+			}
+			if len(result.messages) != len(calls) {
+				t.Fatalf("results = %d, want one per announced call (%d)", len(result.messages), len(calls))
+			}
+			for i, msg := range result.messages {
+				if len(msg.Parts) == 0 || msg.Parts[0].ToolResult == nil {
+					t.Fatalf("result %d has no tool result part: %#v", i, msg)
+				}
+				toolResult := msg.Parts[0].ToolResult
+				if toolResult.ID != calls[i].ID {
+					t.Fatalf("result %d ID = %q, want %q", i, toolResult.ID, calls[i].ID)
+				}
+				if !toolResult.IsError || !strings.Contains(toolResult.Content, context.Canceled.Error()) {
+					t.Fatalf("result %d = %+v, want cancellation error result", i, toolResult)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleSyncToolExecutionReturnsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	tool := newContextIgnoringTool(1)
+	defer close(tool.release)
 	registry := NewToolRegistry()
 	registry.Register(tool)
 	engine := NewEngine(&fakeProvider{}, registry)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cancelTimer := time.AfterFunc(25*time.Millisecond, cancel)
-	defer cancelTimer.Stop()
-
-	calls := []ToolCall{
-		{ID: "call-1", Name: "delay_tool", Arguments: json.RawMessage(`{}`)},
-		{ID: "call-2", Name: "delay_tool", Arguments: json.RawMessage(`{}`)},
-		{ID: "call-3", Name: "delay_tool", Arguments: json.RawMessage(`{}`)},
+	event := Event{
+		ToolCallID:   "sync-call-1",
+		Tool:         &ToolCall{ID: "sync-call-1", Name: "context_ignoring_tool", Arguments: json.RawMessage(`{}`)},
+		ToolResponse: make(chan ToolExecutionResponse, 1),
 	}
 
-	start := time.Now()
-	results, err := engine.executeToolCalls(ctx, calls, true, eventSender{}, false, false)
-	elapsed := time.Since(start)
-	t.Logf("parallel tool execution returned after cancellation in %v", elapsed)
+	type syncExecutionResult struct {
+		call ToolCall
+		err  error
+	}
+	resultCh := make(chan syncExecutionResult, 1)
+	go func() {
+		call, _, err := engine.handleSyncToolExecution(ctx, event, eventSender{}, false, false)
+		resultCh <- syncExecutionResult{call: call, err: err}
+	}()
 
-	if err != nil {
-		t.Fatalf("executeToolCalls error = %v, want synthesized results on cancellation", err)
+	select {
+	case <-tool.started:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
 	}
-	if elapsed >= 200*time.Millisecond {
-		t.Fatalf("executeToolCalls returned after %v; want prompt return on cancellation", elapsed)
-	}
-	if len(results) != len(calls) {
-		t.Fatalf("results = %d, want one per announced call (%d)", len(results), len(calls))
-	}
-	for i, msg := range results {
-		if len(msg.Parts) == 0 || msg.Parts[0].ToolResult == nil {
-			t.Fatalf("result %d has no tool result part: %#v", i, msg)
+
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.call.ID != event.ToolCallID {
+			t.Fatalf("call ID = %q, want %q", result.call.ID, event.ToolCallID)
 		}
-		tr := msg.Parts[0].ToolResult
-		if tr.ID != calls[i].ID {
-			t.Fatalf("result %d ID = %q, want %q", i, tr.ID, calls[i].ID)
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("error = %v, want context cancellation", result.err)
 		}
-		if !tr.IsError || !strings.Contains(tr.Content, context.Canceled.Error()) {
-			t.Fatalf("result %d = %+v, want cancellation error result", i, tr)
-		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("handleSyncToolExecution did not return promptly after cancellation")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a cancellation-aware wrapper around `Tool.Execute` that runs the invocation independently and selects its buffered result against `ctx.Done()`.
- Applied the wrapper to normal tool execution and synchronous CLI-bridge tool execution while preserving existing panic handling and output behavior.
- Added deterministic regression coverage for a context-ignoring tool in the single-call, serial multi-call, parallel multi-call, and synchronous bridge paths.

## Why this is high-value

A tool that blocks without observing its context could previously keep the engine producer goroutine alive after cancellation. Because stream shutdown waits for that producer, one stalled `read_file`, MCP, or custom tool invocation could leave a web session permanently active and its runtime locked, blocking all later work in that session. Cancellation now releases the engine immediately; ordinary tool-call paths still produce paired cancellation results, while synchronous bridges return the context error without waiting for the abandoned invocation.

## Validation

- `gofmt -w internal/llm/engine.go internal/llm/engine_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME="$(mktemp -d)" go test ./...`
- `go test -race ./internal/llm -run 'TestExecuteToolCallsReturnsOnContextCancel|TestHandleSyncToolExecutionReturnsOnContextCancel' -count=5`
- `git diff --check`
