### PR TITLE
fix: Single tool calls can make cancellation and shutdown hang forever

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -3567,9 +3567,10 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 		return cancelledToolCallMessages(calls, err), nil
 	}
 
-	// Fast path: single call, no concurrency overhead
+	// Single calls still run asynchronously so cancellation cannot be held
+	// hostage by a non-cooperative tool implementation.
 	if len(calls) == 1 {
-		return e.executeSingleToolCallSafe(ContextWithApprovalTranscript(ctx, transcript), calls[0], send, debug, debugRaw)
+		return e.executeSingleToolCallCancellable(ContextWithApprovalTranscript(ctx, transcript), calls[0], send, debug, debugRaw)
 	}
 
 	if !parallel {
@@ -3579,7 +3580,7 @@ func (e *Engine) executeToolCalls(ctx context.Context, calls []ToolCall, paralle
 			if err := ctx.Err(); err != nil {
 				return append(results, cancelledToolCallMessages(calls[i:], err)...), nil
 			}
-			msgs, err := e.executeSingleToolCallSafe(toolCtx, call, send, debug, debugRaw)
+			msgs, err := e.executeSingleToolCallCancellable(toolCtx, call, send, debug, debugRaw)
 			if err != nil {
 				return nil, err
 			}
@@ -3677,6 +3678,29 @@ func cancelledToolCallMessages(calls []ToolCall, err error) []Message {
 		msgs = append(msgs, cancelledToolCallMessage(call, err))
 	}
 	return msgs
+}
+
+// executeSingleToolCallCancellable lets the engine abandon a tool that fails to
+// return after its context is cancelled. The buffered channel ensures a late
+// completion cannot strand the tool goroutine while reporting its result.
+func (e *Engine) executeSingleToolCallCancellable(ctx context.Context, call ToolCall, send eventSender, debug bool, debugRaw bool) ([]Message, error) {
+	type executionResult struct {
+		messages []Message
+		err      error
+	}
+
+	resultChan := make(chan executionResult, 1)
+	go func() {
+		messages, err := e.executeSingleToolCallSafe(ctx, call, send, debug, debugRaw)
+		resultChan <- executionResult{messages: messages, err: err}
+	}()
+
+	select {
+	case result := <-resultChan:
+		return result.messages, result.err
+	case <-ctx.Done():
+		return []Message{cancelledToolCallMessage(call, ctx.Err())}, nil
+	}
 }
 
 // executeSingleToolCallSafe wraps executeSingleToolCall with panic recovery.
@@ -3824,14 +3848,28 @@ func (e *Engine) handleSyncToolExecution(ctx context.Context, event Event, send 
 		err = fmt.Errorf("tool '%s' is not in the active skill's allowed-tools list", call.Name)
 	} else {
 		toolCtx := ContextWithCallID(ctx, callID)
-		func() {
+		type executionResult struct {
+			output ToolOutput
+			err    error
+		}
+		resultChan := make(chan executionResult, 1)
+		go func() {
+			var execution executionResult
 			defer func() {
 				if r := recover(); r != nil {
-					err = fmt.Errorf("Error: tool panicked: %v", r)
+					execution.err = fmt.Errorf("Error: tool panicked: %v", r)
 				}
+				resultChan <- execution
 			}()
-			result, err = tool.Execute(toolCtx, call.Arguments)
+			execution.output, execution.err = tool.Execute(toolCtx, call.Arguments)
 		}()
+
+		select {
+		case execution := <-resultChan:
+			result, err = execution.output, execution.err
+		case <-ctx.Done():
+			err = ctx.Err()
+		}
 	}
 
 	// Truncate large tool outputs (global limit, then compaction limit).

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1216,6 +1216,38 @@ func (t *cancellableDelayTool) Preview(args json.RawMessage) string {
 	return ""
 }
 
+type contextIgnoringTool struct {
+	name    string
+	started chan struct{}
+	release chan struct{}
+}
+
+func newContextIgnoringTool(name string) *contextIgnoringTool {
+	return &contextIgnoringTool{
+		name:    name,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (t *contextIgnoringTool) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        t.name,
+		Description: "Blocks without observing context cancellation",
+		Schema:      map[string]any{"type": "object"},
+	}
+}
+
+func (t *contextIgnoringTool) Execute(ctx context.Context, args json.RawMessage) (ToolOutput, error) {
+	close(t.started)
+	<-t.release
+	return TextOutput("late result"), nil
+}
+
+func (t *contextIgnoringTool) Preview(args json.RawMessage) string {
+	return ""
+}
+
 func TestEngineParallelToolExecution(t *testing.T) {
 	t.Parallel()
 
@@ -1439,6 +1471,145 @@ func TestExecuteToolCallsParallelReturnsOnContextCancel(t *testing.T) {
 		if !tr.IsError || !strings.Contains(tr.Content, context.Canceled.Error()) {
 			t.Fatalf("result %d = %+v, want cancellation error result", i, tr)
 		}
+	}
+}
+
+func TestExecuteToolCallsSingleReturnsOnContextCancel(t *testing.T) {
+	tool := newContextIgnoringTool("stuck_single_tool")
+	defer close(tool.release)
+
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	engine := NewEngine(&fakeProvider{}, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	call := ToolCall{ID: "call-1", Name: tool.name, Arguments: json.RawMessage(`{}`)}
+	type callResult struct {
+		messages []Message
+		err      error
+	}
+	done := make(chan callResult, 1)
+	go func() {
+		messages, err := engine.executeToolCalls(ctx, []ToolCall{call}, false, eventSender{}, false, false)
+		done <- callResult{messages: messages, err: err}
+	}()
+
+	select {
+	case <-tool.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for single tool execution to start")
+	}
+	cancel()
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("executeToolCalls error = %v, want synthesized cancellation result", result.err)
+		}
+		if len(result.messages) != 1 || len(result.messages[0].Parts) == 0 || result.messages[0].Parts[0].ToolResult == nil {
+			t.Fatalf("executeToolCalls messages = %#v, want one tool result", result.messages)
+		}
+		toolResult := result.messages[0].Parts[0].ToolResult
+		if toolResult.ID != call.ID || !toolResult.IsError || !strings.Contains(toolResult.Content, context.Canceled.Error()) {
+			t.Fatalf("tool result = %+v, want paired cancellation error for %q", toolResult, call.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("executeToolCalls did not return after cancellation")
+	}
+}
+
+func TestEngineStreamCloseReturnsWhenSingleToolIgnoresCancellation(t *testing.T) {
+	tool := newContextIgnoringTool("stuck_stream_tool")
+	defer close(tool.release)
+
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	provider := &fakeProvider{script: func(call int, req Request) []Event {
+		if call == 0 {
+			return []Event{
+				{Type: EventToolCall, Tool: &ToolCall{ID: "call-1", Name: tool.name, Arguments: json.RawMessage(`{}`)}},
+				{Type: EventDone},
+			}
+		}
+		return []Event{{Type: EventDone}}
+	}}
+	engine := NewEngine(provider, registry)
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("run the tool")},
+		Tools:    []ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	select {
+	case <-tool.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream tool execution to start")
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- stream.Close()
+	}()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not return after cancelling a stuck tool")
+	}
+}
+
+func TestHandleSyncToolExecutionReturnsOnContextCancel(t *testing.T) {
+	tool := newContextIgnoringTool("stuck_sync_tool")
+	defer close(tool.release)
+
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	engine := NewEngine(&fakeProvider{}, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	event := Event{
+		Type:         EventToolCall,
+		ToolCallID:   "sync-1",
+		Tool:         &ToolCall{ID: "sync-1", Name: tool.name, Arguments: json.RawMessage(`{}`)},
+		ToolResponse: make(chan ToolExecutionResponse, 1),
+	}
+
+	type syncResult struct {
+		call   ToolCall
+		output ToolOutput
+		err    error
+	}
+	done := make(chan syncResult, 1)
+	go func() {
+		call, output, err := engine.handleSyncToolExecution(ctx, event, eventSender{}, false, false)
+		done <- syncResult{call: call, output: output, err: err}
+	}()
+
+	select {
+	case <-tool.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for synchronous tool execution to start")
+	}
+	cancel()
+
+	select {
+	case result := <-done:
+		if result.call.ID != event.ToolCallID {
+			t.Fatalf("returned call ID = %q, want %q", result.call.ID, event.ToolCallID)
+		}
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("handleSyncToolExecution error = %v, want context.Canceled", result.err)
+		}
+		if result.output.Content != "" {
+			t.Fatalf("handleSyncToolExecution output = %q, want no late output", result.output.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handleSyncToolExecution did not return after cancellation")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Run single and serial tool executions behind a buffered result channel, allowing the engine to synthesize a paired cancellation result without waiting for a context-ignoring tool.
- Apply the same buffered goroutine/select pattern to synchronous CLI-bridge tool execution while preserving panic recovery and normal tool output handling.
- Add regression coverage for a fake tool that starts and then blocks independently of its context, including direct single-call cancellation, `Engine` stream shutdown, and synchronous bridge execution.

## Why this is high-value

Tool execution is central to Jarvis's web, Telegram, and CLI workflows. A wedged custom tool, MCP transport, subprocess, or network client previously held the engine goroutine forever even after cancellation. Because `channelStream.Close` waits for that goroutine, one non-cooperative tool could permanently strand a response run and block runtime cleanup or service shutdown. The new cancellation boundary lets the engine and stream owner finish promptly while a late tool return is safely absorbed by the buffered channel.

## Validation

- `gofmt -w internal/llm/engine.go internal/llm/engine_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./... -count=1`
- `go test -race ./internal/llm -run 'TestExecuteToolCallsSingleReturnsOnContextCancel|TestEngineStreamCloseReturnsWhenSingleToolIgnoresCancellation|TestHandleSyncToolExecutionReturnsOnContextCancel' -count=10`
- `git diff --check`
