### PR TITLE
fix: Scheduled autotitling can overwrite concurrent session metadata

### DIFF
--- a/cmd/sessions_autotitle.go
+++ b/cmd/sessions_autotitle.go
@@ -197,14 +197,12 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "  short:   %s\n  long:    %s\n", cand.ShortTitle, cand.LongTitle)
 
 		if !sessionsAutotitleDryRun {
-			sess.GeneratedShortTitle = cand.ShortTitle
-			sess.GeneratedLongTitle = cand.LongTitle
-			sess.TitleSource = session.TitleSourceGenerated
-			sess.TitleGeneratedAt = time.Now().UTC()
+			generatedAt := time.Now().UTC()
+			basisMsgSeq := 0
 			if len(messages) > 0 {
-				sess.TitleBasisMsgSeq = messages[len(messages)-1].Sequence
+				basisMsgSeq = messages[len(messages)-1].Sequence
 			}
-			if err := store.Update(ctx, sess); err != nil {
+			if err := updateAutotitle(ctx, store, sess, cand.ShortTitle, cand.LongTitle, generatedAt, basisMsgSeq); err != nil {
 				fmt.Fprintf(cmd.OutOrStdout(), "  save:    failed (%v)\n\n", err)
 				continue
 			}
@@ -220,5 +218,17 @@ func runSessionsAutotitle(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "Generated titles for %d sessions (dry run).\n", generated)
 	}
+	return nil
+}
+
+func updateAutotitle(ctx context.Context, store session.Store, sess *session.Session, shortTitle, longTitle string, generatedAt time.Time, basisMsgSeq int) error {
+	if err := session.UpdateGeneratedTitle(ctx, store, sess, shortTitle, longTitle, generatedAt, basisMsgSeq); err != nil {
+		return err
+	}
+	sess.GeneratedShortTitle = shortTitle
+	sess.GeneratedLongTitle = longTitle
+	sess.TitleSource = session.TitleSourceGenerated
+	sess.TitleGeneratedAt = generatedAt
+	sess.TitleBasisMsgSeq = basisMsgSeq
 	return nil
 }

--- a/cmd/sessions_autotitle_test.go
+++ b/cmd/sessions_autotitle_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type trackingAutotitleStore struct {
+	*session.SQLiteStore
+	updateCalls         int
+	generatedTitleCalls int
+}
+
+func (s *trackingAutotitleStore) Update(ctx context.Context, sess *session.Session) error {
+	s.updateCalls++
+	return s.SQLiteStore.Update(ctx, sess)
+}
+
+func (s *trackingAutotitleStore) UpdateGeneratedTitle(ctx context.Context, id, shortTitle, longTitle string, generatedAt time.Time, basisMsgSeq int) error {
+	s.generatedTitleCalls++
+	return s.SQLiteStore.UpdateGeneratedTitle(ctx, id, shortTitle, longTitle, generatedAt, basisMsgSeq)
+}
+
+func TestUpdateAutotitleDoesNotClobberConcurrentSessionMetadata(t *testing.T) {
+	ctx := context.Background()
+	sqlStore, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlStore.Close() })
+
+	original := &session.Session{
+		ID:        session.NewID(),
+		Provider:  "test",
+		Model:     "original-model",
+		Mode:      session.ModeChat,
+		Status:    session.StatusActive,
+		CreatedAt: time.Now().Add(-time.Hour),
+		UpdatedAt: time.Now().Add(-time.Hour),
+	}
+	if err := sqlStore.Create(ctx, original); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	stale, err := sqlStore.Get(ctx, original.ID)
+	if err != nil {
+		t.Fatalf("Get stale candidate: %v", err)
+	}
+	concurrent, err := sqlStore.Get(ctx, original.ID)
+	if err != nil {
+		t.Fatalf("Get concurrent session: %v", err)
+	}
+	concurrent.Name = "Manual title"
+	concurrent.Pinned = true
+	concurrent.Model = "new-model"
+	concurrent.Status = session.StatusInterrupted
+	concurrent.Goal = session.NewGoal("Preserve this goal", 1200, time.Now())
+	concurrent.UpdatedAt = time.Now()
+	if err := sqlStore.Update(ctx, concurrent); err != nil {
+		t.Fatalf("concurrent Update: %v", err)
+	}
+
+	store := &trackingAutotitleStore{SQLiteStore: sqlStore}
+	generatedAt := time.Now().UTC().Truncate(time.Second)
+	if err := updateAutotitle(ctx, store, stale, "Generated short", "Generated long", generatedAt, 7); err != nil {
+		t.Fatalf("updateAutotitle: %v", err)
+	}
+
+	if store.generatedTitleCalls != 1 {
+		t.Fatalf("UpdateGeneratedTitle calls = %d, want 1", store.generatedTitleCalls)
+	}
+	if store.updateCalls != 0 {
+		t.Fatalf("Update calls = %d, want 0", store.updateCalls)
+	}
+
+	loaded, err := sqlStore.Get(ctx, original.ID)
+	if err != nil {
+		t.Fatalf("Get updated session: %v", err)
+	}
+	if loaded.GeneratedShortTitle != "Generated short" || loaded.GeneratedLongTitle != "Generated long" || loaded.TitleSource != session.TitleSourceGenerated || loaded.TitleBasisMsgSeq != 7 {
+		t.Fatalf("generated title fields not persisted: %#v", loaded)
+	}
+	if loaded.Name != concurrent.Name || loaded.Pinned != concurrent.Pinned || loaded.Model != concurrent.Model || loaded.Status != concurrent.Status {
+		t.Fatalf("concurrent metadata clobbered: %#v", loaded)
+	}
+	if loaded.Goal == nil || loaded.Goal.Objective != concurrent.Goal.Objective || loaded.Goal.TokenBudget != concurrent.Goal.TokenBudget {
+		t.Fatalf("concurrent goal clobbered: %#v", loaded.Goal)
+	}
+	if stale.GeneratedShortTitle != "Generated short" || stale.GeneratedLongTitle != "Generated long" || stale.TitleSource != session.TitleSourceGenerated || stale.TitleBasisMsgSeq != 7 || !stale.TitleGeneratedAt.Equal(generatedAt) {
+		t.Fatalf("local title fields not updated after save: %#v", stale)
+	}
+}


### PR DESCRIPTION
## What changed

- Persist scheduled autotitles through the existing generated-title-only store API instead of a full session-row update.
- Update the in-memory title fields only after persistence succeeds.
- Add a focused SQLite-backed regression test that captures a stale candidate, changes its manual name, pinned state, model, status, and goal, then verifies autotitling changes only generated-title fields.
- Assert that the command save path calls `UpdateGeneratedTitle` and never `Update` when the store supports the title-only capability.

## Why this is high-value

The autotitle command loads all candidate sessions before making serial provider calls, so a later candidate can be stale for minutes. A full-row `Update` from that snapshot could silently revert user-visible changes made while the job was running, including a manual title, pin/status state, model selection, and goal. The title-only update removes that realistic race without changing title generation behavior.

## Validation

- `gofmt -w cmd/sessions_autotitle.go cmd/sessions_autotitle_test.go`
- `go build ./...`
- `go test ./cmd -run '^TestUpdateAutotitleDoesNotClobberConcurrentSessionMetadata$' -count=1`
- `go test ./...` with an isolated `HOME`/`XDG_CONFIG_HOME` (passes; the normal agent home injects its global skill catalog into two unrelated cwd-skill tests)
- `git diff --check`
