### PR TITLE
fix(web): unify network recovery

### DIFF
--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -15,7 +15,7 @@ import (
 
 //go:embed static/index.html static/manifest.webmanifest static/icon-512.png static/sw.js
 //go:embed static/app.css
-//go:embed static/app-core.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
+//go:embed static/app-core.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
 //go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diffs.js static/app-worktrees.js
 //go:embed static/decoration.js static/markdown-setup.js static/markdown-streaming.js static/transcript-window.js static/active-response.js static/conversation.js
 //go:embed static/vendor
@@ -91,6 +91,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`href="manifest.webmanifest"`, `href="` + versioned("manifest.webmanifest") + `"`},
 		{`href="app.css"`, `href="` + versioned("app.css") + `"`},
 		{`href="app-core.js"`, `href="` + versioned("app-core.js") + `"`},
+		{`href="app-network.js"`, `href="` + versioned("app-network.js") + `"`},
 		{`href="transcript-window.js"`, `href="` + versioned("transcript-window.js") + `"`},
 		{`href="active-response.js"`, `href="` + versioned("active-response.js") + `"`},
 		{`href="conversation.js"`, `href="` + versioned("conversation.js") + `"`},
@@ -124,6 +125,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`src="active-response.js"`, `src="` + versioned("active-response.js") + `"`},
 		{`src="conversation.js"`, `src="` + versioned("conversation.js") + `"`},
 		{`src="app-core.js"`, `src="` + versioned("app-core.js") + `"`},
+		{`src="app-network.js"`, `src="` + versioned("app-network.js") + `"`},
 		{`src="app-plan.js"`, `src="` + versioned("app-plan.js") + `"`},
 		{`src="slash-commands.js"`, `src="` + versioned("slash-commands.js") + `"`},
 		{`src="app-render.js"`, `src="` + versioned("app-render.js") + `"`},
@@ -210,6 +212,7 @@ func renderServiceWorkerBytes(opts RenderOptions) []byte {
 		{"'./active-response.js'", "'./" + versioned("active-response.js") + "'"},
 		{"'./conversation.js'", "'./" + versioned("conversation.js") + "'"},
 		{"'./app-core.js'", "'./" + versioned("app-core.js") + "'"},
+		{"'./app-network.js'", "'./" + versioned("app-network.js") + "'"},
 		{"'./app-plan.js'", "'./" + versioned("app-plan.js") + "'"},
 		{"'./slash-commands.js'", "'./" + versioned("slash-commands.js") + "'"},
 		{"'./app-render.js'", "'./" + versioned("app-render.js") + "'"},

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -48,7 +48,8 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	productionLines := 0
+	legacyProductionLines := 0
+	transportLines := map[string]int{}
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".js") || strings.HasSuffix(name, "_test.js") {
@@ -58,10 +59,21 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		productionLines += len(strings.Split(strings.TrimSuffix(string(body), "\n"), "\n"))
+		lineCount := len(strings.Split(strings.TrimSuffix(string(body), "\n"), "\n"))
+		if name == "app-network.js" || name == "app-webrtc.js" {
+			transportLines[name] = lineCount
+		} else {
+			legacyProductionLines += lineCount
+		}
 	}
-	if productionLines >= 21015 {
-		t.Fatalf("first-party production JS=%d lines, must decrease from 21015", productionLines)
+	// Keep the new transport boundary from weakening the pre-existing ratchet:
+	// legacy production code must still decrease, while each transport module
+	// gets a narrow independent ceiling tied to its audited responsibility.
+	if legacyProductionLines >= 20467 {
+		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20467", legacyProductionLines)
+	}
+	if transportLines["app-network.js"] > 600 || transportLines["app-webrtc.js"] > 725 {
+		t.Fatalf("transport modules grew beyond focused budgets: %v", transportLines)
 	}
 
 	for _, name := range []string{"active-response.js", "conversation.js", "transcript-window.js"} {
@@ -238,6 +250,30 @@ func cssRuleBlocks(cssSrc, selector string) []string {
 		}
 		blocks = append(blocks, cssSrc[bodyStart:bodyStart+end])
 		cssSrc = cssSrc[bodyStart+end+1:]
+	}
+}
+
+func TestApplicationFetchesUseSharedNetworkLayer(t *testing.T) {
+	allowedRawFetch := map[string]bool{
+		"static/app-network.js": true, // owns the application transport boundary
+		"static/app-webrtc.js":  true, // transport shim must retain original fetch
+		"static/sw.js":          true, // service-worker bootstrap/cache transport
+	}
+	err := fs.WalkDir(staticFiles, "static", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".js") || strings.Contains(path, "/vendor/") || allowedRawFetch[path] {
+			return err
+		}
+		body, readErr := fs.ReadFile(staticFiles, path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(body), "fetch(") {
+			t.Errorf("%s bypasses app.apiFetch", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -620,6 +656,23 @@ func TestWorktreePopoverUsesResponsiveChipUI(t *testing.T) {
 	}
 	if want := `.header-controls-row .model-chip[data-chip="worktree"] .chip-trigger:not(.header-action)`; !strings.Contains(string(appCSS), want) {
 		t.Fatalf("app.css missing mobile worktree trigger padding selector %q", want)
+	}
+}
+
+func TestAppNetworkJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping JS app-network tests")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "app_network_test.js")
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("app_network_test.js failed: %v", err)
 	}
 }
 

--- a/internal/serveui/static/app-composer.js
+++ b/internal/serveui/static/app-composer.js
@@ -128,7 +128,7 @@ const transcribeVoiceBlob = async (blob, mimeType) => {
     headers.Authorization = `Bearer ${state.token}`;
   }
 
-  const response = await fetch(`${UI_PREFIX}/v1/transcribe`, {
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/transcribe`, {
     method: 'POST',
     headers,
     body: form

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -164,6 +164,12 @@ const state = {
   autoScroll: true,
   authRequired: false,
   connected: false,
+  connectivity: {
+    authenticated: false, startupConnected: false,
+    network: typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'unknown',
+    phase: '', pendingSafe: 0, consecutiveFailures: 0,
+    lastSuccessAt: 0, lastFailureAt: 0, lastRecoveryAt: 0,
+    diagnostics: [] },
   attachments: [],
   widgets: [],
   widgetsLoaded: false,
@@ -1703,20 +1709,38 @@ const renderHeaderStatus = () => {
   const el = elements.connectionState;
   if (!el) return;
 
-  const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
-  const warningText = offline ? 'Network offline' : legacyConnectionWarning;
+  const connectivityStatus = app.connectivityHeaderStatus?.() || null;
+  const urgentNetwork = Number(connectivityStatus?.priority || 0) > 0 ? connectivityStatus : null;
+  const warningText = urgentNetwork?.text || legacyConnectionWarning;
   const retryText = !warningText && providerRetryOwnerIsVisible()
     ? String(providerRetryStatus.text || '').trim()
     : '';
-  if (!warningText && !retryText) {
+  const fallbackNetwork = !warningText && !retryText ? connectivityStatus : null;
+  const text = warningText || retryText || fallbackNetwork?.text || '';
+  if (!text) {
     hideConnectionState();
     return;
   }
 
-  el.textContent = warningText || retryText;
+  el.textContent = text;
   el.classList.remove('ok', 'bad', 'retry');
-  el.classList.add(warningText ? 'bad' : 'retry');
+  el.classList.add(urgentNetwork?.mode || (warningText ? 'bad' : (fallbackNetwork?.mode || 'retry')));
   el.hidden = false;
+  const connectivity = state.connectivity || {};
+  el.dataset.network = String(connectivity.network || '');
+  el.dataset.phase = String(connectivity.phase || '');
+  el.dataset.pendingSafe = String(Math.max(0, Number(connectivity.pendingSafe || 0)));
+};
+
+const setConnectivityState = (patch = {}) => {
+  state.connectivity = { ...(state.connectivity || {}), ...(patch || {}) };
+  renderHeaderStatus();
+  return state.connectivity;
+};
+
+const setApplicationConnected = (connected, startupConnected = connected) => {
+  state.connected = Boolean(connected);
+  return setConnectivityState({ authenticated: Boolean(connected), startupConnected: Boolean(startupConnected) });
 };
 
 const setConnectionState = (text, mode = '') => {
@@ -1929,14 +1953,14 @@ const subscribeToPush = async () => {
       keys: subJSON.keys
     };
 
-    const resp = await fetch(`${UI_PREFIX}/v1/push/subscribe`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/v1/push/subscribe`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': state.token ? `Bearer ${state.token}` : ''
       },
       body: JSON.stringify(body)
-    });
+    }, { auth: app.API_FETCH_AUTH?.ignore || 'ignore' });
     if (!resp.ok) {
       console.warn('Push subscribe failed:', resp.status, await resp.text().catch(() => ''));
     }
@@ -2576,6 +2600,8 @@ Object.assign(app, {
   scrollToBottom,
   setConnectionState,
   clearConnectionStateOwner,
+  setConnectivityState,
+  setApplicationConnected,
   setProviderRetryStatus,
   clearProviderRetryStatus,
   setStartupStatus,

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -357,7 +357,7 @@ const fetchSessionFileChanges = async (sessionId) => {
   const seqAtStart = new Map();
   ds.files.forEach((entry, path) => seqAtStart.set(path, entry.lastSeq || 0));
   try {
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/file-changes`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/file-changes`, {
       headers: authHeaders()
     });
     if (!resp.ok) return; // 404 = tracking disabled; treat as no changes
@@ -426,7 +426,7 @@ const fetchFileDiff = (sessionId, path) => {
   const request = (async () => {
     try {
       const url = `${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/file-changes/diff?path=${encodeURIComponent(path)}`;
-      const resp = await fetch(url, { headers: authHeaders() });
+      const resp = await app.apiFetch(url, { headers: authHeaders() });
       if (!resp.ok) {
         markDiffFetchError(sessionId, path);
         return null;

--- a/internal/serveui/static/app-goals-location.js
+++ b/internal/serveui/static/app-goals-location.js
@@ -44,7 +44,7 @@ const closeGoalModal = () => {
 const postSessionGoal = async (action, extra = {}) => {
   const session = ensureActiveSession?.();
   if (!session) return null;
-  const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/goal`, {
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/goal`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action, ...extra })

--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -286,10 +286,10 @@ const cancelPendingInterjection = async (entry) => {
   }
   try {
     if (entry.action === 'interject') {
-      const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(entry.sessionId)}/interjections/${encodeURIComponent(entry.messageId)}`, {
+      const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(entry.sessionId)}/interjections/${encodeURIComponent(entry.messageId)}`, {
         method: 'DELETE',
         headers: requestHeaders(entry.sessionId)
-      });
+      }, { policy: app.API_FETCH_POLICY.idempotentMutation });
       if (!response.ok) throw await normalizeError(response);
     }
     removePendingInterjectionById(entry.messageId);
@@ -327,11 +327,11 @@ const interruptActiveRunNow = async (session, prompt, messageId, contentParts = 
     : { message: prompt, interjection_id: messageId, client_message_id: messageId };
   const headers = requestHeaders(session.id);
   headers['Idempotency-Key'] = `interrupt_${messageId}`;
-  const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/interrupt`, {
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/interrupt`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body)
-  });
+  }, { policy: app.API_FETCH_POLICY.idempotentMutation });
   if (!response.ok) {
     throw await normalizeError(response);
   }
@@ -345,10 +345,10 @@ const interruptActiveRunNow = async (session, prompt, messageId, contentParts = 
   const pendingEntry = state.pendingInterjections.find((entry) => entry.messageId === messageId);
   if (pendingEntry?.cancelRequested) {
     if (action === 'interject') {
-      const cancelResponse = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/interjections/${encodeURIComponent(messageId)}`, {
+      const cancelResponse = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/interjections/${encodeURIComponent(messageId)}`, {
         method: 'DELETE',
         headers: requestHeaders(session.id)
-      });
+      }, { policy: app.API_FETCH_POLICY.idempotentMutation });
       if (!cancelResponse.ok) throw await normalizeError(cancelResponse);
     }
     removePendingInterjectionById(messageId);

--- a/internal/serveui/static/app-mcp.js
+++ b/internal/serveui/static/app-mcp.js
@@ -161,7 +161,7 @@ const ensureActiveSessionForMCP = () => {
 const mcpHeaders = () => requestHeaders ? requestHeaders('') : { 'Content-Type': 'application/json' };
 
 const fetchSessionMCP = async (sessionId) => {
-  const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/mcp`, {
+  const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/mcp`, {
     headers: mcpHeaders(),
   });
   if (!resp.ok) throw await normalizeError(resp);
@@ -332,7 +332,7 @@ const applySessionMCP = async (sessionId, enabledNames) => {
   mcpModalErrorMessage = '';
   renderMCPModal(session);
   try {
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/mcp`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/mcp`, {
       method: 'PATCH',
       headers: mcpHeaders(),
       body: JSON.stringify({ enabled: requestedEnabled }),

--- a/internal/serveui/static/app-modals.js
+++ b/internal/serveui/static/app-modals.js
@@ -358,7 +358,7 @@ const submitAskUserModal = async (cancelled = false) => {
   elements.askUserCancelBtn.textContent = cancelled ? 'Dismissing…' : 'Dismiss';
 
   try {
-    const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(prompt.sessionId)}/ask_user`, {
+    const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(prompt.sessionId)}/ask_user`, {
       method: 'POST',
       headers: requestHeaders(prompt.sessionId),
       body: JSON.stringify(cancelled
@@ -505,7 +505,7 @@ const submitApprovalModal = async (denied = false) => {
   const body = { approval_id: prompt.approvalId, choice: choiceIndex };
 
   try {
-    const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(prompt.sessionId)}/approval`, {
+    const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(prompt.sessionId)}/approval`, {
       method: 'POST',
       headers: requestHeaders(prompt.sessionId),
       body: JSON.stringify(body)
@@ -603,6 +603,7 @@ const handleAuthFailure = () => {
   app.stopSessionStatePoll();
   closeAskUserModal();
   state.token = '';
+  app.setApplicationConnected?.(false, false);
   localStorage.removeItem(STORAGE_KEYS.token);
   syncTokenCookie('');
   setConnectionState('Not connected', 'bad');
@@ -683,7 +684,8 @@ const connectToken = async () => {
     }
     state.token = token;
     state.models = models;
-    state.connected = true;
+    app.setApplicationConnected?.(true, true);
+    if (!app.setApplicationConnected) state.connected = true;
     localStorage.setItem(STORAGE_KEYS.token, token);
     syncTokenCookie(token);
 
@@ -713,6 +715,8 @@ const connectToken = async () => {
     elements.authError.textContent = message;
     if (err?.status === 401) {
       state.token = '';
+      app.setApplicationConnected?.(false, false);
+      if (!app.setApplicationConnected) state.connected = false;
       localStorage.removeItem(STORAGE_KEYS.token);
       syncTokenCookie('');
     }

--- a/internal/serveui/static/app-network.js
+++ b/internal/serveui/static/app-network.js
@@ -1,0 +1,552 @@
+(() => {
+'use strict';
+
+const app = window.TermLLMApp || (window.TermLLMApp = {});
+const { state } = app;
+const UI_PREFIX = app.UI_PREFIX || window.TERM_LLM_UI_PREFIX || '/ui';
+const POLICY = Object.freeze({
+  safeRead: 'safe-read',
+  idempotentMutation: 'idempotent-mutation',
+  mutation: 'non-retryable-mutation',
+  stream: 'stream',
+});
+const AUTH = Object.freeze({ session: 'session', caller: 'caller', ignore: 'ignore' });
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const RETRYABLE_STATUSES = new Set([408, 425, 429]);
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_MUTATION_TIMEOUT_MS = 30000;
+const MAX_RETRY_AFTER_MS = 60000;
+const RECOVERY_HOOK_TIMEOUT_MS = 5000;
+const diagnostics = [];
+const waiters = new Map();
+const recoveryHooks = new Set();
+let waiterSequence = 0;
+let coordinatedRecoveryPromise = null;
+let activeRecoveryController = null;
+let recoveryQueued = false;
+let queuedRecoveryReason = '';
+let recoveryRetryTimer = 0;
+let recoveryProbeAttempt = 0;
+let successfulRecoveryEpoch = 0;
+
+const online = () => typeof navigator === 'undefined' || navigator.onLine !== false;
+const visible = () => typeof document === 'undefined' || document.visibilityState !== 'hidden';
+const retryableStatus = (status) => RETRYABLE_STATUSES.has(Number(status)) || Number(status) >= 500;
+const retryDelay = (attempt) => {
+  const normalized = Math.max(0, Number(attempt) || 0);
+  return normalized >= 5 ? 60000 : Math.round(1000 * Math.pow(1.5, normalized));
+};
+const requestURL = (resource) => {
+  if (typeof Request !== 'undefined' && resource instanceof Request) return resource.url;
+  return String(resource);
+};
+const retryAfterDelay = (response, now = Date.now()) => {
+  const value = String(response?.headers?.get?.('Retry-After') || '').trim();
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.min(MAX_RETRY_AFTER_MS, seconds * 1000);
+  const at = Date.parse(value);
+  return Number.isFinite(at) ? Math.min(MAX_RETRY_AFTER_MS, Math.max(0, at - now)) : 0;
+};
+
+const noteDiagnostic = (kind, detail = {}) => {
+  diagnostics.push({ at: Date.now(), kind, ...detail });
+  if (diagnostics.length > 100) diagnostics.splice(0, diagnostics.length - 100);
+  if (state?.connectivity) state.connectivity.diagnostics = diagnostics;
+};
+
+const setConnectivity = (patch) => {
+  if (typeof app.setConnectivityState === 'function') app.setConnectivityState(patch);
+  else if (state) state.connectivity = { ...(state.connectivity || {}), ...patch };
+};
+
+const classifyRequest = (resource, options = {}, controls = {}) => {
+  const isRequest = typeof Request !== 'undefined' && resource instanceof Request;
+  const method = String(options.method || (isRequest ? resource.method : 'GET') || 'GET').toUpperCase();
+  let policy = String(controls.policy || '').trim();
+  if (!Object.values(POLICY).includes(policy)) policy = SAFE_METHODS.has(method) ? POLICY.safeRead : POLICY.mutation;
+
+  const headers = new Headers(options.headers || (isRequest ? resource.headers : undefined));
+  const hasIdempotencyKey = Boolean(headers.get('Idempotency-Key'));
+  if (policy === POLICY.idempotentMutation && method === 'POST' && !hasIdempotencyKey) {
+    noteDiagnostic('unsafe-idempotent-policy', { method, url: requestURL(resource) });
+    policy = POLICY.mutation;
+  }
+  const retryable = policy === POLICY.safeRead || policy === POLICY.idempotentMutation;
+  const pendingMutation = policy === POLICY.idempotentMutation;
+  const authOwner = Object.values(AUTH).includes(controls.auth) ? controls.auth : AUTH.caller;
+  const retries = retryable ? Math.max(0, Number.isFinite(Number(controls.retries)) ? Number(controls.retries) : 2) : 0;
+  const timeoutMs = controls.timeoutMs === 0
+    ? 0
+    : Math.max(1, Number(controls.timeoutMs) || (SAFE_METHODS.has(method) ? DEFAULT_TIMEOUT_MS : DEFAULT_MUTATION_TIMEOUT_MS));
+  return { method, policy, retryable, pendingMutation, authOwner, retries, timeoutMs, hasIdempotencyKey };
+};
+
+const suspendWaiter = (waiter) => {
+  if (waiter.timer) window.clearTimeout(waiter.timer);
+  waiter.timer = 0;
+  waiter.remaining = Math.max(0, waiter.deadline - Date.now());
+};
+
+const armWaiter = (waiter) => {
+  if (waiter.settled || waiter.timer || !online()) return;
+  waiter.deadline = Date.now() + waiter.remaining;
+  waiter.timer = window.setTimeout(() => waiter.finish('timer'), waiter.remaining);
+};
+
+const updatePendingSafe = (delta) => {
+  setConnectivity({ pendingSafe: Math.max(0, Number(state?.connectivity?.pendingSafe || 0) + delta) });
+};
+
+const waitForNetworkRetry = (delay, controls = {}) => new Promise((resolve) => {
+  const id = ++waiterSequence;
+  const waiter = {
+    id,
+    key: String(controls.key || ''),
+    reason: String(controls.reason || ''),
+    pendingSafe: controls.pendingSafe === true,
+    remaining: Math.max(0, Number(delay) || 0),
+    deadline: Date.now() + Math.max(0, Number(delay) || 0),
+    timer: 0,
+    settled: false,
+    signal: controls.signal || null,
+    finish(wakeReason) {
+      if (waiter.settled) return;
+      waiter.settled = true;
+      if (waiter.timer) window.clearTimeout(waiter.timer);
+      waiter.signal?.removeEventListener?.('abort', waiter.onAbort);
+      waiters.delete(id);
+      if (waiter.pendingSafe) updatePendingSafe(-1);
+      resolve(String(wakeReason || 'timer'));
+    },
+  };
+  waiters.set(id, waiter);
+  waiter.onAbort = () => waiter.finish('aborted');
+  if (waiter.signal?.aborted) Promise.resolve().then(waiter.onAbort);
+  else waiter.signal?.addEventListener?.('abort', waiter.onAbort, { once: true });
+  if (waiter.pendingSafe) updatePendingSafe(1);
+  if (online()) armWaiter(waiter);
+  else setConnectivity({ network: 'offline', phase: 'offline' });
+  noteDiagnostic('retry-wait', { key: waiter.key, reason: waiter.reason, delay: waiter.remaining, online: online() });
+  const observedEpoch = Number(controls.afterRecoveryEpoch);
+  if (online() && Number.isFinite(observedEpoch) && successfulRecoveryEpoch > observedEpoch) {
+    Promise.resolve().then(() => waiter.finish('recovered-during-attempt'));
+  }
+});
+
+const wakeNetworkRetry = (key, reason = 'wake') => {
+  const normalized = String(key || '');
+  let woke = false;
+  for (const waiter of waiters.values()) {
+    if (normalized && waiter.key !== normalized) continue;
+    waiter.finish(reason);
+    woke = true;
+  }
+  return woke;
+};
+
+const wakeAllNetworkRetries = (reason = 'wake') => wakeNetworkRetry('', reason);
+
+const cancelNetworkRetries = (keyPrefix, reason = 'detached') => {
+  const prefix = String(keyPrefix || '');
+  let canceled = false;
+  for (const waiter of waiters.values()) {
+    if (prefix && !waiter.key.startsWith(prefix)) continue;
+    waiter.finish(reason);
+    canceled = true;
+  }
+  return canceled;
+};
+
+const composeAbortSignal = (parentSignal, timeoutMs) => {
+  if (!timeoutMs) return { signal: parentSignal, cleanup() {}, timedOut: () => false };
+  const controller = new AbortController();
+  let timeout = false;
+  let cleaned = false;
+  let timer = 0;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    if (timer) window.clearTimeout(timer);
+    parentSignal?.removeEventListener?.('abort', onAbort);
+  };
+  const onAbort = () => {
+    controller.abort(parentSignal?.reason);
+    cleanup();
+  };
+  if (parentSignal?.aborted) {
+    onAbort();
+  } else {
+    parentSignal?.addEventListener?.('abort', onAbort, { once: true });
+    timer = window.setTimeout(() => {
+      timeout = true;
+      controller.abort();
+      cleanup();
+    }, timeoutMs);
+  }
+  return { signal: controller.signal, timedOut: () => timeout, cleanup };
+};
+
+const responseWithAbortLifetime = (response, cleanup) => {
+  if (!response.body) {
+    cleanup();
+    return response;
+  }
+  const reader = response.body.getReader();
+  const body = new ReadableStream({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          cleanup();
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (error) {
+        cleanup();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try { await reader.cancel(reason); } finally { cleanup(); }
+    },
+  });
+  const wrapped = new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers });
+  for (const property of ['url', 'redirected', 'type']) {
+    try { Object.defineProperty(wrapped, property, { value: response[property] }); } catch (_error) { /* optional metadata */ }
+  }
+  return wrapped;
+};
+
+const transportFetch = async (resource, options, timeoutMs, transportRetrySafe = false) => {
+  const isRequest = typeof Request !== 'undefined' && resource instanceof Request;
+  const parentSignal = options.signal || (isRequest ? resource.signal : null);
+  const abort = composeAbortSignal(parentSignal, timeoutMs);
+  const fetchOptions = { ...options, __termLLMRetrySafe: Boolean(transportRetrySafe) };
+  if (abort.signal) fetchOptions.signal = abort.signal;
+  try {
+    const response = await window.fetch(resource, fetchOptions);
+    return timeoutMs ? responseWithAbortLifetime(response, abort.cleanup) : response;
+  } catch (error) {
+    abort.cleanup();
+    if (abort.timedOut()) {
+      const timeoutError = new Error(`Request timed out after ${timeoutMs} ms.`);
+      timeoutError.name = 'TimeoutError';
+      timeoutError.status = 0;
+      timeoutError.cause = error;
+      throw timeoutError;
+    }
+    throw error;
+  }
+};
+
+const apiFetch = async (resource, options = {}, controls = {}) => {
+  const classification = classifyRequest(resource, options, controls);
+  let attempt = 0;
+  for (;;) {
+    if (!online()) {
+      setConnectivity({ network: 'offline', phase: 'offline' });
+      if (!classification.retryable) {
+        const error = new Error('Network offline. This action was not sent; retry it when online.');
+        error.name = 'OfflineError';
+        error.status = 0;
+        error.networkClassification = classification;
+        throw error;
+      }
+      await waitForNetworkRetry(0, {
+        reason: 'offline', pendingSafe: classification.pendingMutation, signal: options.signal
+      });
+      if (options.signal?.aborted) {
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      }
+    }
+
+    const startedAt = Date.now();
+    const attemptRecoveryEpoch = successfulRecoveryEpoch;
+    try {
+      const response = await transportFetch(resource, options, classification.timeoutMs, classification.retryable);
+      noteDiagnostic('request', {
+        method: classification.method,
+        policy: classification.policy,
+        status: response.status,
+        attempt,
+        durationMs: Date.now() - startedAt,
+        url: requestURL(resource),
+      });
+      if (response.status === 401 && classification.authOwner === AUTH.session) {
+        window.setTimeout(() => app.handleAuthFailure?.(), 0);
+      }
+      if (!retryableStatus(response.status) || !classification.retryable || attempt >= classification.retries) {
+        if (response.status < 500) {
+          const currentPhase = String(state?.connectivity?.phase || '');
+          const recovering = currentPhase === 'recovering' || currentPhase === 'catching-up';
+          setConnectivity({
+            network: online() ? (recovering ? 'recovering' : 'healthy') : 'offline',
+            phase: online() ? (recovering ? currentPhase : '') : 'offline',
+            consecutiveFailures: 0,
+            lastSuccessAt: Date.now()
+          });
+        }
+        return response;
+      }
+      const delay = retryAfterDelay(response) || retryDelay(attempt);
+      try { await response.body?.cancel(); } catch (_error) { /* retry supersedes this response */ }
+      attempt += 1;
+      setConnectivity({ network: 'unstable', phase: 'unstable', consecutiveFailures: Number(state?.connectivity?.consecutiveFailures || 0) + 1 });
+       await waitForNetworkRetry(delay, {
+         reason: `http-${response.status}`,
+         pendingSafe: classification.pendingMutation,
+         signal: options.signal,
+         afterRecoveryEpoch: attemptRecoveryEpoch,
+       });
+    } catch (error) {
+      if (options.signal?.aborted) throw error;
+      const failures = Number(state?.connectivity?.consecutiveFailures || 0) + 1;
+      setConnectivity({
+        network: online() ? 'unstable' : 'offline',
+        phase: online() ? 'unstable' : 'offline',
+        consecutiveFailures: failures,
+        lastFailureAt: Date.now(),
+      });
+      noteDiagnostic('network-error', {
+        method: classification.method,
+        policy: classification.policy,
+        attempt,
+        name: String(error?.name || ''),
+        message: String(error?.message || error || ''),
+        url: requestURL(resource),
+      });
+      if (!classification.retryable || attempt >= classification.retries) {
+        error.networkClassification = classification;
+        throw error;
+      }
+      const delay = retryDelay(attempt);
+      attempt += 1;
+      await waitForNetworkRetry(delay, {
+        reason: String(error?.name || 'network-error'),
+        pendingSafe: classification.pendingMutation,
+        signal: options.signal,
+        afterRecoveryEpoch: attemptRecoveryEpoch,
+      });
+    }
+  }
+};
+
+const addNetworkRecoveryHook = (hook) => {
+  if (typeof hook !== 'function') return () => {};
+  recoveryHooks.add(hook);
+  return () => recoveryHooks.delete(hook);
+};
+
+const healthProbe = async (signal) => {
+  const headers = {};
+  if (state?.token) headers.Authorization = `Bearer ${state.token}`;
+  const response = await transportFetch(`${UI_PREFIX}/v1/providers`, { headers, signal }, 5000);
+  const healthy = Boolean(response && response.status < 500);
+  try { await response.body?.cancel(); } catch (_error) { /* status is sufficient */ }
+  return healthy;
+};
+
+const scheduleRecoveryRetry = () => {
+  if (recoveryRetryTimer || !online()) return;
+  const delay = retryDelay(recoveryProbeAttempt);
+  recoveryProbeAttempt += 1;
+  setConnectivity({ network: 'unstable', phase: 'unstable', recoveryRetryScheduled: true });
+  recoveryRetryTimer = window.setTimeout(() => {
+    recoveryRetryTimer = 0;
+    void runCoordinatedNetworkRecovery('health-backoff');
+  }, delay);
+};
+
+const runBoundedRecoveryHook = async (hook, reason, signal) => {
+  let timer = 0;
+  let abortHandler = null;
+  const hookResult = Promise.resolve().then(() => hook(reason, { signal })).then(
+    () => ({ outcome: 'complete' }),
+    (error) => ({ outcome: 'failed', error })
+  );
+  const timeoutResult = new Promise((resolve) => {
+    timer = window.setTimeout(() => resolve({ outcome: 'timeout' }), RECOVERY_HOOK_TIMEOUT_MS);
+  });
+  const abortResult = new Promise((resolve) => {
+    abortHandler = () => resolve({ outcome: 'aborted' });
+    if (signal.aborted) abortHandler();
+    else signal.addEventListener('abort', abortHandler, { once: true });
+  });
+  const result = await Promise.race([hookResult, timeoutResult, abortResult]);
+  if (timer) window.clearTimeout(timer);
+  signal.removeEventListener?.('abort', abortHandler);
+  if (result.outcome !== 'complete') {
+    noteDiagnostic('recovery-hook-' + result.outcome, {
+      reason,
+      message: String(result.error?.message || result.error || ''),
+    });
+  }
+  return result.outcome;
+};
+
+const runRecoveryPass = async (reason, controller) => {
+  if (!online()) return false;
+  setConnectivity({ network: 'recovering', phase: 'recovering', recoveryReason: reason, recoveryRetryScheduled: false });
+  noteDiagnostic('recovery-start', { reason, waiters: waiters.size });
+  let healthy = false;
+  try {
+    healthy = await healthProbe(controller.signal);
+  } catch (error) {
+    noteDiagnostic('recovery-failed', { reason, message: String(error?.message || error || '') });
+  }
+  if (controller.signal.aborted) return false;
+  if (!healthy) {
+    setConnectivity({ network: 'unstable', phase: 'unstable', lastFailureAt: Date.now() });
+    scheduleRecoveryRetry();
+    noteDiagnostic('recovery-complete', { reason, healthy: false, waiters: waiters.size });
+    return false;
+  }
+
+  recoveryProbeAttempt = 0;
+  setConnectivity({ network: 'recovering', phase: 'catching-up', consecutiveFailures: 0, lastSuccessAt: Date.now() });
+  await Promise.all(Array.from(recoveryHooks, (hook) => runBoundedRecoveryHook(hook, reason, controller.signal)));
+  if (!online() || controller.signal.aborted) return false;
+
+  successfulRecoveryEpoch += 1;
+  wakeAllNetworkRetries(reason);
+  setConnectivity({ network: 'healthy', phase: '', consecutiveFailures: 0, lastRecoveryAt: Date.now(), recoveryRetryScheduled: false });
+  noteDiagnostic('recovery-complete', { reason, healthy: true, waiters: waiters.size });
+  return true;
+};
+
+const runCoordinatedNetworkRecovery = (reason = 'recovery') => {
+  if (coordinatedRecoveryPromise) {
+    if (activeRecoveryController?.signal.aborted && online()) {
+      recoveryQueued = true;
+      queuedRecoveryReason = String(reason || 'recovery');
+    }
+    return coordinatedRecoveryPromise;
+  }
+  if (recoveryRetryTimer) {
+    window.clearTimeout(recoveryRetryTimer);
+    recoveryRetryTimer = 0;
+  }
+  coordinatedRecoveryPromise = (async () => {
+    let nextReason = String(reason || 'recovery');
+    let result = false;
+    do {
+      recoveryQueued = false;
+      activeRecoveryController = new AbortController();
+      result = await runRecoveryPass(nextReason, activeRecoveryController);
+      nextReason = queuedRecoveryReason || 'recovery';
+      queuedRecoveryReason = '';
+    } while (recoveryQueued && online());
+    return result;
+  })().finally(() => {
+    activeRecoveryController = null;
+    coordinatedRecoveryPromise = null;
+  });
+  return coordinatedRecoveryPromise;
+};
+
+const createResumableStreamRecovery = (options = {}) => {
+  let attempt = 0;
+  let failures = 0;
+  let stopped = false;
+  let attemptRecoveryEpoch = successfulRecoveryEpoch;
+  const key = String(options.key || `stream-${Date.now()}-${Math.random()}`);
+  const terminal = () => stopped || Boolean(options.isTerminal?.());
+  const describe = (phase, reason = '', delay = 0) => {
+    const detail = {
+      phase,
+      reason,
+      delay,
+      attempt,
+      cursor: Math.max(0, Number(options.getCursor?.() || 0)),
+      heartbeat: Boolean(options.heartbeat),
+    };
+    options.onStatus?.(detail);
+    noteDiagnostic('stream-recovery', { key, ...detail });
+  };
+  return {
+    key,
+    get attempt() { return attempt; },
+    noteAttempt() { attemptRecoveryEpoch = successfulRecoveryEpoch; },
+    noteConnected() { failures = 0; describe('connected'); },
+    noteActivity() { attempt = 0; failures = 0; },
+    async wait(reason = 'stream-ended') {
+      if (terminal()) return 'terminal';
+      failures += 1;
+      const delay = retryDelay(attempt);
+      describe(online() ? 'waiting' : 'offline', reason, delay);
+      if (options.reconcile && failures >= Math.max(1, Number(options.reconcileEvery) || 5)) {
+        failures = 0;
+        describe('reconciling', reason, 0);
+        await options.reconcile(reason).catch((error) => noteDiagnostic('stream-reconcile-failed', { key, message: String(error?.message || error || '') }));
+        if (terminal()) return 'terminal';
+      }
+      attempt += 1;
+      return waitForNetworkRetry(delay, {
+        key, reason, signal: options.signal, afterRecoveryEpoch: attemptRecoveryEpoch
+      });
+    },
+    wake(reason = 'wake') { return wakeNetworkRetry(key, reason); },
+    stop() { stopped = true; wakeNetworkRetry(key, 'detached'); },
+  };
+};
+
+const connectivityHeaderStatus = () => {
+  const connectivity = state?.connectivity || {};
+  const phase = String(connectivity.phase || connectivity.network || '');
+  if (phase === 'offline') return {
+    text: Number(connectivity.pendingSafe || 0) > 0
+      ? 'Offline — message pending safely; reconnect to continue'
+      : 'Offline — reconnect to continue',
+    mode: 'bad', priority: 3,
+  };
+  if (phase === 'recovering') return { text: 'Network restored — recovering…', mode: 'retry', priority: 0 };
+  if (phase === 'catching-up') return { text: 'Catching up with the server…', mode: 'retry', priority: 0 };
+  if (phase === 'unstable') return {
+    text: connectivity.recoveryRetryScheduled ? 'Connection unstable — checking again shortly…' : 'Connection unstable',
+    mode: 'bad', priority: 0,
+  };
+  return null;
+};
+
+if (typeof window.addEventListener === 'function') {
+  window.addEventListener('offline', () => {
+    activeRecoveryController?.abort();
+    if (recoveryRetryTimer) {
+      window.clearTimeout(recoveryRetryTimer);
+      recoveryRetryTimer = 0;
+    }
+    for (const waiter of waiters.values()) suspendWaiter(waiter);
+    setConnectivity({ network: 'offline', phase: 'offline', recoveryRetryScheduled: false });
+    noteDiagnostic('offline', { waiters: waiters.size });
+  });
+  window.addEventListener('online', () => { void runCoordinatedNetworkRecovery('online'); });
+  window.addEventListener('pageshow', () => { if (online()) void runCoordinatedNetworkRecovery('pageshow'); });
+}
+if (typeof document?.addEventListener === 'function') {
+  document.addEventListener('visibilitychange', () => {
+    if (visible() && online()) void runCoordinatedNetworkRecovery('visibility');
+  });
+}
+
+Object.assign(app, {
+  API_FETCH_POLICY: POLICY,
+  API_FETCH_AUTH: AUTH,
+  apiFetch,
+  classifyAPIRequest: classifyRequest,
+  retryAfterDelay,
+  waitForNetworkRetry,
+  wakeNetworkRetry,
+  wakeAllNetworkRetries,
+  cancelNetworkRetries,
+  addNetworkRecoveryHook,
+  runCoordinatedNetworkRecovery,
+  createResumableStreamRecovery,
+  connectivityHeaderStatus,
+  networkDiagnostics: diagnostics,
+  noteNetworkDiagnostic: noteDiagnostic,
+});
+})();

--- a/internal/serveui/static/app-runtime.js
+++ b/internal/serveui/static/app-runtime.js
@@ -21,7 +21,7 @@ const fetchProviders = async (tokenOverride = '') => {
   const token = tokenOverride || state.token;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const response = await fetch(`${UI_PREFIX}/v1/providers`, { headers });
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/providers`, { headers });
   if (!response.ok) {
     throw await normalizeError(response);
   }
@@ -62,7 +62,7 @@ const fetchModels = async (tokenOverride = '', provider = '') => {
   let url = `${UI_PREFIX}/v1/models`;
   if (provider) url += `?provider=${encodeURIComponent(provider)}`;
 
-  const response = await fetch(url, { headers });
+  const response = await app.apiFetch(url, { headers });
   if (!response.ok) {
     throw await normalizeError(response);
   }
@@ -261,7 +261,7 @@ const queueActiveRunEffortChange = async (session, effort) => {
   const model = String(session?.activeModel || state.selectedModel || '').trim();
   if (!session || !session.id || !model) return false;
 
-  const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/effort`, {
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/effort`, {
     method: 'POST',
     headers: requestHeaders(session.id),
     body: JSON.stringify({

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -99,7 +99,7 @@ const restoreLatestDraftMessage = () => {
   return restoreDraftMessageForSession(state.activeSessionId);
 };
 
-const { requestHeaders, normalizeError, hasSessionContinuationContext, effectiveEffortForCompare, clearRuntimeSelectionIntent, classifyRecoverableContinuationFailure, sleep, streamReconnectDelay, streamReconnectLabel, isTransientPreResponsePostError, setActiveResponseTracking, HEARTBEAT_STALE_THRESHOLD, heartbeatUploadGraceThreshold, attachResponseStream, detachResponseStream, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, finalizeVisibleAssistantStreamRender, scrollVisibleStreamToBottom, createResponseStreamState, consumeResponseStream, resumeActiveResponse, setStreaming, recoverInterruptFailure, addErrorMessage } = app;
+const { requestHeaders, normalizeError, hasSessionContinuationContext, effectiveEffortForCompare, clearRuntimeSelectionIntent, classifyRecoverableContinuationFailure, sleep, streamReconnectDelay, streamReconnectLabel, isTransientPreResponsePostError, setActiveResponseTracking, HEARTBEAT_STALE_THRESHOLD, heartbeatUploadGraceThreshold, attachResponseStream, detachResponseStream, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, finalizeVisibleAssistantStreamRender, scrollVisibleStreamToBottom, createResponseStreamState, consumeResponseStream, resumeActiveResponse, setStreaming, recoverInterruptFailure, addErrorMessage, waitForNetworkRetry } = app;
 
 const restoreQueuedFollowUps = (entries, sessionId) => {
   for (const entry of entries) {
@@ -163,7 +163,7 @@ const sendMessage = async (options = {}) => {
     elements.sendBtn.disabled = true;
     elements.sendBtn.title = 'Compressing conversation';
     try {
-      const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/compact`, {
+      const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/compact`, {
         method: 'POST',
         headers: requestHeaders(session.id),
         body: '{}'
@@ -490,12 +490,12 @@ const sendMessage = async (options = {}) => {
     headers['X-Term-LLM-Request-ID'] = userMessage.responseRequestId;
     const requestBody = JSON.stringify(body);
     controller._heartbeatStaleThreshold = heartbeatUploadGraceThreshold(requestBody);
-    let response = await fetch(`${UI_PREFIX}/v1/responses`, {
+    let response = await app.apiFetch(`${UI_PREFIX}/v1/responses`, {
       method: 'POST',
       headers,
       body: requestBody,
       signal: controller.signal
-    });
+    }, { policy: app.API_FETCH_POLICY.idempotentMutation, retries: 0, timeoutMs: 0 });
     controller._heartbeatStaleThreshold = HEARTBEAT_STALE_THRESHOLD;
     const headerResponseId = String(response.headers.get('x-response-id') || '').trim();
     const headerSessionNumber = Number(response.headers.get('x-session-number') || 0);
@@ -602,10 +602,19 @@ const sendMessage = async (options = {}) => {
       attachResponseStream(session, '', null);
       setSessionOptimisticBusy(session, true);
       setStreaming(true);
-      setConnectionState(streamReconnectLabel(retryCount));
+      setConnectionState(
+        typeof navigator !== 'undefined' && navigator.onLine === false
+          ? 'Offline — message pending safely; reconnect to continue'
+          : streamReconnectLabel(retryCount),
+        'bad'
+      );
       const retryGeneration = state.streamGeneration;
-      await sleep(streamReconnectDelay(retryCount));
-      if (state.streamGeneration !== retryGeneration || state.activeSessionId !== session.id) {
+      const wakeReason = await waitForNetworkRetry(streamReconnectDelay(retryCount), {
+        key: `${session.id}:initial:${userMessage.responseRequestId}`,
+        reason: controller._heartbeatAbort ? 'heartbeat-stale' : 'pre-response-post',
+        pendingSafe: true
+      });
+      if (wakeReason === 'detached' || state.streamGeneration !== retryGeneration || state.activeSessionId !== session.id) {
         restoreFollowUpBatch();
         persistAndRefreshShell();
         return { followUpBatchRestored };

--- a/internal/serveui/static/app-session-admin.js
+++ b/internal/serveui/static/app-session-admin.js
@@ -21,7 +21,7 @@ const {
 } = app;
 
 const updateSessionMetadata = async (session, patch) => {
-  const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}`, {
+  const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}`, {
     method: 'PATCH',
     headers: requestHeaders(session.id),
     body: JSON.stringify(patch)
@@ -37,7 +37,7 @@ const refineSessionTitle = async (session, options = {}) => {
   session._refiningTitle = true;
   renderSidebar();
   try {
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/title/refine`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/title/refine`, {
       method: 'POST',
       headers: requestHeaders(session.id),
       body: JSON.stringify({ preview: Boolean(options.preview) })

--- a/internal/serveui/static/app-session-events.js
+++ b/internal/serveui/static/app-session-events.js
@@ -300,6 +300,32 @@ window.addEventListener('popstate', async () => {
   await app.switchToSession(stub.id, { closeSidebar: false });
 });
 
+app.addNetworkRecoveryHook?.(async (_reason) => {
+  if (!state.connected || document.visibilityState === 'hidden') return;
+  await app.startSidebarStatusPoll();
+  const session = getActiveSession();
+  if (!session) return;
+
+  // The sidebar status pass reconciles durable transcript/session truth once
+  // before retry waiters are released. This recovers a POST accepted before
+  // x-response-id arrived and avoids independent stream/poll stampedes.
+  const streamIsStale = Date.now() - Number(state.lastEventTime || 0) > HEARTBEAT_STALE_THRESHOLD;
+  if (state.abortController && streamIsStale) {
+    state.abortController._heartbeatAbort = true;
+    if (typeof state.abortController._heartbeatCancelStream === 'function') {
+      await state.abortController._heartbeatCancelStream().catch(() => {});
+    } else if (!state.abortController._responseBodyAttached) {
+      state.abortController.abort();
+    }
+  } else if (!state.abortController && session.activeResponseId) {
+    setStreaming(true);
+    void app.resumeAndDrain?.(session, {
+      responseId: session.activeResponseId,
+      recoverFromSnapshot: false
+    });
+  }
+});
+
 document.addEventListener('visibilitychange', async () => {
   if (document.visibilityState !== 'visible') {
     rememberPageTailOwnership();
@@ -308,41 +334,7 @@ document.addEventListener('visibilitychange', async () => {
     return;
   }
   restorePageTailOwnership();
-  if (!state.connected) return;
-  // Reconcile the authoritative transcript before looking for an active
-  // response. Another tab may have completed several turns and started a new
-  // one while this page was hidden; attaching first would only replay the new
-  // response and leave the earlier turns missing.
-  await app.startSidebarStatusPoll();
-  if (document.visibilityState !== 'visible') return;
-  const session = getActiveSession();
-  if (!session) return;
-
-  if (session.activeResponseId && app.wakeResponseReconnect?.({
-    reason: 'visibility',
-    sessionId: session.id,
-    responseId: session.activeResponseId
-  })) {
-    setConnectionState('Page visible, reconnecting\u2026', 'bad');
-    setStreaming(true);
-    return;
-  }
-  if (session.activeResponseId && !state.abortController) {
-    setStreaming(true);
-    app.resumeAndDrain(session, {
-      responseId: session.activeResponseId,
-      recoverFromSnapshot: false
-    });
-    return;
-  }
-  if (state.abortController && state.lastEventTime > 0 && Date.now() - state.lastEventTime > HEARTBEAT_STALE_THRESHOLD) {
-    state.abortController._heartbeatAbort = true;
-    state.abortController.abort(); // triggers retry in resumeActiveResponse
-    return;
-  }
-  if (!state.streaming && !state.abortController) {
-    await app.syncActiveSessionFromServer(session, true);
-  }
+  if (state.connected) await app.runCoordinatedNetworkRecovery?.('visibility');
 });
 
 window.addEventListener('pagehide', () => {
@@ -352,66 +344,15 @@ window.addEventListener('pagehide', () => {
 });
 
 window.addEventListener('online', async () => {
-  setConnectionState('', '');
-  // As with visibility recovery, reconcile durable history before waking the
-  // response stream. Replaying only the current response cannot recover turns
-  // that completed while this client was offline.
-  await app.startSidebarStatusPoll();
-  const session = getActiveSession();
-  if (!session) return;
-  if (session.activeResponseId && app.wakeResponseReconnect?.({
-    reason: 'online',
-    sessionId: session.id,
-    responseId: session.activeResponseId
-  })) {
-    setConnectionState('Network restored, reconnecting\u2026', 'bad');
-    setStreaming(true);
-    return;
-  }
-  if (session.activeResponseId && state.abortController) {
-    // Abort the stale fetch so the existing resume loop reconnects immediately
-    // instead of waiting for the heartbeat timeout.
-    state.abortController._heartbeatAbort = true;
-    state.abortController.abort();
-  } else if (session.activeResponseId && !state.abortController) {
-    setConnectionState('Network restored, reconnecting\u2026', 'bad');
-    setStreaming(true);
-    app.resumeAndDrain(session, {
-      responseId: session.activeResponseId,
-      recoverFromSnapshot: false
-    });
-  } else if (!state.streaming) {
-    await app.syncActiveSessionFromServer(session, true);
-  }
+  if (state.connected) await app.runCoordinatedNetworkRecovery?.('online');
 });
 
 window.addEventListener('offline', () => {
-  setConnectionState('Network offline', 'bad');
+  app.setConnectivityState?.({ network: 'offline', phase: 'offline' });
 });
 
-window.addEventListener('pageshow', (event) => {
+window.addEventListener('pageshow', async () => {
   restorePageTailOwnership();
-  if (state.connected) void app.ensureSidebarStatusPoll();
-  const session = getActiveSession();
-  if (!session) return;
-  if (session.activeResponseId && app.wakeResponseReconnect?.({
-    reason: 'pageshow',
-    sessionId: session.id,
-    responseId: session.activeResponseId
-  })) {
-    setConnectionState('Page restored, reconnecting\u2026', 'bad');
-    setStreaming(true);
-    return;
-  }
-  if (!event.persisted) return;
-  if (session.activeResponseId) {
-    setStreaming(true);
-    app.resumeAndDrain(session, {
-      responseId: session.activeResponseId,
-      recoverFromSnapshot: false
-    });
-  } else {
-    void app.syncActiveSessionFromServer(session, true);
-  }
+  if (state.connected) await app.runCoordinatedNetworkRecovery?.('pageshow');
 });
 })();

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -835,7 +835,7 @@ const mergeServerSessions = async (options = {}) => {
       params.set('include_widget_status', '1');
     }
     const query = params.toString();
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions${query ? `?${query}` : ''}`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions${query ? `?${query}` : ''}`, {
       headers: requestHeaders('')
     });
     if (!resp.ok) return result;
@@ -1101,7 +1101,8 @@ const initialize = async () => {
     setStartupStatus('Syncing sessions…');
 
     [state.models] = await Promise.all([modelsPromise, sessionsPromise]);
-    state.connected = true;
+    app.setApplicationConnected?.(true, true);
+    if (!app.setApplicationConnected) state.connected = true;
     renderModelOptions();
     app.updateHeader?.();
     setConnectionState('', '');

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -109,7 +109,7 @@ const runSidebarSearch = async (query, seq) => {
 
   try {
     const headers = app.requestHeaders ? app.requestHeaders('') : {};
-    const resp = await fetch(`${UI_PREFIX}/v1/sessions/search?${params.toString()}`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/search?${params.toString()}`, {
       headers,
       signal: searchAbort.signal
     });
@@ -237,9 +237,9 @@ const applyWidgetStatus = (data) => {
 const refreshWidgetsSidebar = async () => {
   if (!app.renderWidgetSidebar) return;
   try {
-    const resp = await fetch(`${UI_PREFIX}/admin/widgets/status`, {
+    const resp = await app.apiFetch(`${UI_PREFIX}/admin/widgets/status`, {
       headers: app.requestHeaders('')
-    });
+    }, { auth: app.API_FETCH_AUTH?.ignore || 'ignore' });
     if (resp.status === 404) {
       state.widgets = [];
       state.widgetsLoaded = false;
@@ -324,7 +324,7 @@ const pollSidebarStatus = (isRecovery = false) => {
       const headers = app.requestHeaders('');
       if (sidebarStatusEtag) headers['If-None-Match'] = sidebarStatusEtag;
 
-      const resp = await fetch(`${UI_PREFIX}/v1/sessions/status${query ? `?${query}` : ''}`, {
+      const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/status${query ? `?${query}` : ''}`, {
         headers,
         signal: controller.signal,
       });

--- a/internal/serveui/static/app-skills.js
+++ b/internal/serveui/static/app-skills.js
@@ -12,7 +12,7 @@ const {
   subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
   renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
 } = app;
-const { requestHeaders, normalizeError, parseSSEStream, sleep, streamReconnectDelay, setActiveResponseTracking, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, scrollVisibleStreamToBottom, resumeActiveResponse, setStreaming, drainInterruptQueueIfIdle, addErrorMessage } = app;
+const { requestHeaders, normalizeError, parseSSEStream, sleep, streamReconnectDelay, setActiveResponseTracking, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, scrollVisibleStreamToBottom, resumeActiveResponse, setStreaming, drainInterruptQueueIfIdle, addErrorMessage, createResumableStreamRecovery } = app;
 const skillRunStore = () => {
   if (!state.skillRunsById || typeof state.skillRunsById !== 'object') {
     state.skillRunsById = {};
@@ -111,20 +111,44 @@ const applySkillRunEvent = (run, envelope) => {
 const followSkillRun = async (run) => {
   if (!run || !run.id || skillRunIsTerminal(run.status) || run.following) return;
   run.following = true;
-  let retryAttempt = 0;
+  const recovery = createResumableStreamRecovery({
+    key: `skill:${run.sessionId}:${run.id}`,
+    getCursor: () => run.lastSequence || 0,
+    isTerminal: () => skillRunIsTerminal(run.status),
+    heartbeat: false,
+    reconcileEvery: 5,
+    reconcile: async () => {
+      const url = `${UI_PREFIX}/v1/sessions/${encodeURIComponent(run.sessionId)}/skill-runs/${encodeURIComponent(run.id)}`;
+      const response = await app.apiFetch(url, { headers: requestHeaders(run.sessionId) }, {
+        policy: app.API_FETCH_POLICY.safeRead,
+        retries: 0,
+      });
+      if (!response.ok) throw await normalizeError(response);
+      upsertSkillRunSnapshot(run.sessionId, await response.json().catch(() => ({})), run.eventsURL);
+    },
+    onStatus: ({ phase, reason }) => {
+      if (phase === 'connected') run.progress = '';
+      else if (phase === 'offline') run.progress = 'Offline — run is safe; reconnecting when online';
+      else if (phase === 'reconciling') run.progress = 'Catching up…';
+      else if (phase === 'waiting') run.progress = reason ? `Reconnecting: ${reason}` : 'Reconnecting…';
+      renderSkillRun(run);
+    },
+  });
   try {
     while (!skillRunIsTerminal(run.status)) {
       const controller = new AbortController();
       run.controller = controller;
+      let sawEvent = false;
+      let reconnectReason = 'stream-ended';
       try {
         const separator = run.eventsURL.includes('?') ? '&' : '?';
-        const response = await fetch(`${run.eventsURL}${separator}after=${encodeURIComponent(run.lastSequence || 0)}`, {
+        const response = await app.apiFetch(`${run.eventsURL}${separator}after=${encodeURIComponent(run.lastSequence || 0)}`, {
           headers: { ...requestHeaders(run.sessionId), Accept: 'text/event-stream' },
           signal: controller.signal,
-        });
+        }, { policy: app.API_FETCH_POLICY.stream, timeoutMs: 0, retries: 0 });
         if (!response.ok) throw await normalizeError(response);
         if (!response.body) throw { status: 0, message: 'No skill run event stream from server.' };
-        let sawEvent = false;
+        recovery.noteConnected();
         await parseSSEStream(response.body, (_eventName, data) => {
           if (!data) return true;
           let envelope;
@@ -134,22 +158,22 @@ const followSkillRun = async (run) => {
             return true;
           }
           sawEvent = applySkillRunEvent(run, envelope) || sawEvent;
+          if (sawEvent) recovery.noteActivity();
           return !skillRunIsTerminal(run.status);
-        }, { trackHeartbeat: false });
-        if (sawEvent) retryAttempt = 0;
+        }, { trackHeartbeat: false, abortController: controller });
       } catch (error) {
         if (controller.signal.aborted) return;
-        run.progress = error?.message ? `Reconnecting: ${error.message}` : 'Reconnecting…';
-        renderSkillRun(run);
+        reconnectReason = error?.message || (error?.status ? `http-${error.status}` : 'network-error');
       } finally {
         if (run.controller === controller) run.controller = null;
       }
       if (!skillRunIsTerminal(run.status)) {
-        await sleep(streamReconnectDelay(retryAttempt));
-        retryAttempt += 1;
+        const wakeReason = await recovery.wait(reconnectReason);
+        if (wakeReason === 'detached' || wakeReason === 'terminal') return;
       }
     }
   } finally {
+    recovery.stop();
     run.following = false;
     run.controller = null;
   }
@@ -184,10 +208,10 @@ const cancelSkillRun = async (sessionId, runId) => {
     run.status = 'cancelling';
     renderSkillRun(run);
   }
-  const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/skill-runs/${encodeURIComponent(runId)}`, {
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/skill-runs/${encodeURIComponent(runId)}`, {
     method: 'DELETE',
     headers: requestHeaders(sessionId),
-  });
+  }, { policy: app.API_FETCH_POLICY.idempotentMutation });
   if (!response.ok) {
     const error = await normalizeError(response);
     if (run) {
@@ -235,11 +259,11 @@ const invokeSkill = async (session, invocation, options = {}) => {
   }
 
   try {
-    const response = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/skills/invoke`, {
+    const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/skills/invoke`, {
       method: 'POST',
       headers: { ...requestHeaders(session.id), 'Idempotency-Key': `skill_${message.clientMessageId || message.id}` },
       body: JSON.stringify({ name: invocation.name, arguments: invocation.arguments || '', client_message_id: message.clientMessageId || message.id }),
-    });
+    }, { policy: app.API_FETCH_POLICY.idempotentMutation });
     if (!response.ok) throw await normalizeError(response);
     const payload = await response.json();
     execution = payload.execution || execution;

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -366,7 +366,6 @@ const scheduleStreamScroll = () => {
 };
 
 const activeResumeKeys = new Map();
-const responseReconnectWaiters = new Map();
 
 const streamDiagnosticsEnabled = () => Boolean(
   window.__TERM_LLM_DIAGNOSTICS__ || window.__WEBRTC_DIAGNOSTICS__
@@ -381,33 +380,12 @@ const setReconnectDiagnostic = (reconnectState, reason = '', delay = 0) => {
   dataset.reconnectDelayMs = String(Math.max(0, Number(delay) || 0));
 };
 
-const waitForResponseReconnect = (delay, resumeKey, reason) => new Promise((resolve) => {
-  let settled = false;
-  let timerId = 0;
-  const finish = (wakeReason) => {
-    if (settled) return;
-    settled = true;
-    if (timerId) window.clearTimeout(timerId);
-    if (responseReconnectWaiters.get(resumeKey)?.finish === finish) {
-      responseReconnectWaiters.delete(resumeKey);
-    }
-    resolve(String(wakeReason || 'timer'));
-  };
-  timerId = window.setTimeout(() => finish('timer'), delay);
-  responseReconnectWaiters.set(resumeKey, { finish, timerId });
-  setReconnectDiagnostic('waiting', reason, delay);
-});
-
 const wakeResponseReconnect = ({ reason = '', sessionId = '', responseId = '' } = {}) => {
   const normalizedSessionId = String(sessionId || '').trim();
   const normalizedResponseId = String(responseId || '').trim();
   if (!normalizedSessionId || !normalizedResponseId) return false;
-  const key = `${normalizedSessionId}:${normalizedResponseId}`;
-  const waiter = responseReconnectWaiters.get(key);
-  if (!waiter) return false;
   setReconnectDiagnostic('waking', reason, 0);
-  waiter.finish(reason);
-  return true;
+  return app.wakeNetworkRetry(`${normalizedSessionId}:${normalizedResponseId}`, reason);
 };
 
 const attachResponseStream = (session, responseId = '', controller = null) => {
@@ -421,11 +399,9 @@ const attachResponseStream = (session, responseId = '', controller = null) => {
 
 const clearResumeKeysForSession = (sessionId) => {
   const prefix = sessionId + ':';
+  app.cancelNetworkRetries?.(prefix, 'detached');
   for (const key of activeResumeKeys.keys()) {
     if (key.startsWith(prefix)) activeResumeKeys.delete(key);
-  }
-  for (const [key, waiter] of responseReconnectWaiters) {
-    if (key.startsWith(prefix)) waiter.finish('detached');
   }
 };
 
@@ -821,7 +797,7 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
 };
 
 const fetchResponseSnapshot = async (session, responseId) => {
-  const response = await fetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}`, {
+  const response = await app.apiFetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}`, {
     headers: requestHeaders(session?.id || '')
   });
   if (!response.ok) {
@@ -1036,8 +1012,22 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
     : (options.streamState || createResponseStreamState(session));
   let consecutiveHttpFailures = 0;
   let consecutiveHeartbeatAborts = 0;
-  let retryAttempt = 0;
   let reconnectReason = 'stream-ended';
+  const recovery = app.createResumableStreamRecovery({
+    key: resumeKey,
+    getCursor: () => responseEventSequence(session, responseId),
+    isTerminal: () => !ownsResumeKey() || session.activeResponseId !== responseId,
+    heartbeat: true,
+    onStatus: ({ phase, reason, delay, attempt }) => {
+      setReconnectDiagnostic(phase, reason, delay);
+      if (phase === 'waiting' || phase === 'offline') {
+        setConnectionState(
+          phase === 'offline' ? 'Offline — response is safe; reconnecting when online' : streamReconnectLabel(attempt),
+          'bad'
+        );
+      }
+    },
+  });
 
   for (;;) {
     if (!ownsResumeKey()) {
@@ -1087,12 +1077,13 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
     setStreaming(true);
     let streamActivityBaseline = Number(state.lastEventTime || 0);
 
+    recovery.noteAttempt();
     try {
       const replayAfterSequence = responseEventSequence(session, responseId);
-      const response = await fetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/events?after=${encodeURIComponent(replayAfterSequence)}`, {
+      const response = await app.apiFetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/events?after=${encodeURIComponent(replayAfterSequence)}`, {
         headers: requestHeaders(session.id),
         signal: controller.signal
-      });
+      }, { policy: app.API_FETCH_POLICY.stream, timeoutMs: 0, retries: 0 });
       if (!ownsResumeKey()) {
         if (state.abortController === controller) state.abortController = null;
         try { await response.body?.cancel(); } catch (_) { /* response may already be closed */ }
@@ -1107,6 +1098,7 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
       }
 
       consecutiveHttpFailures = 0;
+      recovery.noteConnected();
       setConnectionState('', '');
       setReconnectDiagnostic('connected', '', 0);
       const streamGeneration = state.streamGeneration;
@@ -1123,7 +1115,7 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
         replayThroughSequence
       });
       if (streamHadActivitySince(streamActivityBaseline)) {
-        retryAttempt = 0;
+        recovery.noteActivity();
         consecutiveHeartbeatAborts = 0;
       }
       if (controller._heartbeatAbort) {
@@ -1174,7 +1166,7 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
 
       const sawStreamActivity = streamHadActivitySince(streamActivityBaseline);
       if (sawStreamActivity) {
-        retryAttempt = 0;
+        recovery.noteActivity();
         consecutiveHttpFailures = 0;
         consecutiveHeartbeatAborts = 0;
       }
@@ -1237,14 +1229,11 @@ const resumeActiveResponseInner = async (session, responseId, options, resumeOwn
       }
     }
 
-    setConnectionState(streamReconnectLabel(retryAttempt), 'bad');
     if (session.activeResponseId !== responseId) {
       setStreaming(Boolean(state.currentStreamResponseId));
       return true;
     }
-    const retryDelay = streamReconnectDelay(retryAttempt);
-    retryAttempt += 1;
-    const wakeReason = await waitForResponseReconnect(retryDelay, resumeKey, reconnectReason);
+    const wakeReason = await recovery.wait(reconnectReason);
     if (wakeReason === 'detached' || !ownsResumeKey()) {
       setStreaming(Boolean(state.currentStreamResponseId));
       return false;
@@ -1275,7 +1264,7 @@ const cancelActiveResponse = async (session) => {
 
   let response;
   try {
-    response = await fetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/cancel`, {
+    response = await app.apiFetch(`${UI_PREFIX}/v1/responses/${encodeURIComponent(responseId)}/cancel`, {
       method: 'POST',
       headers: requestHeaders(session?.id || '')
     });

--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -18,9 +18,9 @@
 // way a normal fetch abort would, letting app-layer recovery take over.
 //
 // If ICE negotiation does not complete within 8 seconds the browser silently
-// falls back to the normal HTTPS path; no user-visible error is shown.
-// When the data channel later disconnects or errors the same silent fallback
-// applies — all pending requests are rescued via HTTPS.
+// falls back to HTTPS and keeps renegotiating in the background with bounded
+// backoff. Online, visibility, and pageshow wake that retry immediately. Data
+// channel disconnects follow the same path while HTTPS remains available.
 //
 // Diagnostics mode: set window.__WEBRTC_DIAGNOSTICS__ = true (or pass
 // ?webrtc_diag=1 in the URL) to enable console.log timeline output:
@@ -71,6 +71,9 @@
 
   let dataChannel = null;
   let renegotiating = false;
+  let renegotiationTimer = null;
+  let renegotiationAttempt = 0;
+  const RENEGOTIATION_BACKOFF_MS = [2000, 5000, 10000, 30000, 60000];
 
   // ---------------------------------------------------------------------------
   // Diagnostics
@@ -94,6 +97,17 @@
   function diagQueue(state, fallback) {
     diag('queue state=' + state + ' pending=' + pendingRequests.size +
       ' fallback=' + (fallback || 'none'));
+  }
+
+  function noteTransportState(transportState, detail) {
+    const app = termApp();
+    if (app && typeof app.noteNetworkDiagnostic === 'function') {
+      app.noteNetworkDiagnostic('webrtc', {
+        state: transportState,
+        detail: String(detail || ''),
+        attempt: renegotiationAttempt,
+      });
+    }
   }
 
   function termApp() {
@@ -130,6 +144,7 @@
   async function initWebRTC() {
     diagT0 = performance.now();
     diag('init signaling=' + SIGNALING_URL);
+    let pc = null;
     try {
       // 1. Request a signaling session (no auth — session_id gates routing).
       const sessStart = performance.now();
@@ -139,7 +154,7 @@
       });
       if (!sessResp.ok) {
         diag('session request failed status=' + sessResp.status);
-        return;
+        return false;
       }
       const sess = await sessResp.json();
       diag('session created id=' + sess.session_id +
@@ -163,7 +178,7 @@
         pcConfig.iceTransportPolicy = 'relay';
         diag('FORCED TURN — iceTransportPolicy=relay');
       }
-      const pc = new RTCPeerConnection(pcConfig);
+      pc = new RTCPeerConnection(pcConfig);
 
       pc.oniceconnectionstatechange = () => {
         diag('ICE state=' + pc.iceConnectionState);
@@ -219,7 +234,8 @@
       });
       if (!sendResp.ok) {
         diag('offer post failed status=' + sendResp.status);
-        return;
+        try { pc.close(); } catch (_e) { /* ignore */ }
+        return false;
       }
       diag('offer sent (' + ((performance.now() - offerStart) | 0) + 'ms)');
 
@@ -227,7 +243,8 @@
       const answer = await pollForAnswer(sess.session_id, ICE_TIMEOUT_MS);
       if (!answer) {
         diag('answer timeout — falling back to HTTPS');
-        return; // timed out — fall back to HTTPS silently
+        try { pc.close(); } catch (_e) { /* ignore */ }
+        return false; // timed out — HTTPS remains available while retrying
       }
       diag('answer received');
 
@@ -248,11 +265,18 @@
       dc.onerror = () => onChannelClose(dc);
 
       window.fetch = patchedFetch;
+      renegotiationAttempt = 0;
+      noteTransportState('connected', 'data-channel-open');
 
       diag('data channel open — fetch patched');
+      return true;
     } catch (_e) {
       diag('init error: ' + (_e && _e.message ? _e.message : String(_e)));
-      // Silent fallback — HTTPS continues to work for all requests.
+      if (pc) {
+        try { pc.close(); } catch (_closeError) { /* ignore */ }
+      }
+      noteTransportState('https', _e && _e.message ? _e.message : 'negotiation-failed');
+      return false;
     }
   }
 
@@ -310,10 +334,10 @@
   // Drain all pending requests to HTTPS
   // ---------------------------------------------------------------------------
 
-  // Called when the channel dies (close/error/timeout).  Every in-flight
-  // request that hasn't received its first response frame yet gets retried
-  // via HTTPS.  Requests that already started streaming are closed — the
-  // consumer will see a truncated stream and can retry at the app layer.
+  // Called when the channel dies (close/error/timeout). Retry-safe requests
+  // that have not received a response frame are rescued via HTTPS; unsafe
+  // mutations report an unknown outcome instead of being replayed. Requests
+  // already streaming are closed for app-layer cursor resume.
   function drainPendingToHTTPS(reason) {
     if (pendingRequests.size === 0) return;
     diagQueue('draining', reason + ':https-before-response-or-stream-close');
@@ -334,16 +358,52 @@
     dataChannel = null;
     restoreHTTPSFetch('data channel closed');
     drainPendingToHTTPS('channel closed');
+    scheduleRenegotiation('channel-closed');
   }
 
   // ---------------------------------------------------------------------------
   // Background renegotiation
   // ---------------------------------------------------------------------------
 
-  function triggerRenegotiation() {
+  function scheduleRenegotiation(reason, immediate) {
+    if (dataChannel && dataChannel.readyState === 'open') return;
     if (renegotiating) return;
-    renegotiating = true;
+    if (renegotiationTimer) {
+      if (!immediate) return;
+      clearTimeout(renegotiationTimer);
+      renegotiationTimer = null;
+    }
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      noteTransportState('waiting-online', reason);
+      return;
+    }
+    const index = Math.min(renegotiationAttempt, RENEGOTIATION_BACKOFF_MS.length - 1);
+    const delay = immediate ? 0 : RENEGOTIATION_BACKOFF_MS[index];
+    noteTransportState('retrying', reason + ':' + delay + 'ms');
+    diag('renegotiation scheduled reason=' + reason + ' delay=' + delay + 'ms attempt=' + (renegotiationAttempt + 1));
+    renegotiationTimer = setTimeout(async () => {
+      renegotiationTimer = null;
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        noteTransportState('waiting-online', reason);
+        return;
+      }
+      renegotiating = true;
+      let connected = false;
+      try {
+        connected = await initWebRTC();
+      } finally {
+        renegotiating = false;
+      }
+      if (connected) {
+        renegotiationAttempt = 0;
+        return;
+      }
+      renegotiationAttempt += 1;
+      scheduleRenegotiation('background-retry', false);
+    }, delay);
+  }
 
+  function triggerRenegotiation() {
     // Tear down the current channel so new requests route to HTTPS immediately.
     const previousChannel = dataChannel;
     dataChannel = null;
@@ -354,21 +414,8 @@
 
     // Rescue any other in-flight requests stuck on the dead channel.
     drainPendingToHTTPS('renegotiation');
-
     diag('renegotiating — new requests use HTTPS');
-
-    // Small delay before renegotiating to avoid tight loops if the network
-    // is genuinely down.  2 s is enough to not spam but short enough that
-    // if the issue was transient, WebRTC comes back quickly.
-    setTimeout(async () => {
-      try {
-        await initWebRTC();
-      } catch (_e) {
-        diag('renegotiation failed: ' + (_e && _e.message ? _e.message : String(_e)));
-      } finally {
-        renegotiating = false;
-      }
-    }, 2000);
+    scheduleRenegotiation('transport-degraded', false);
   }
 
   // ---------------------------------------------------------------------------
@@ -396,7 +443,7 @@
   }
 
   function webrtcFetch(urlStr, options) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const reqId = crypto.randomUUID();
       let streamController;
       let resolved = false;
@@ -406,6 +453,7 @@
 
       const urlObj = new URL(urlStr, window.location.origin);
       const method = (options.method || 'GET').toUpperCase();
+      const transportRetrySafe = responseTimeoutForMethod(method) === READ_RESPONSE_TIMEOUT_MS || options.__termLLMRetrySafe === true;
       const responseTimeoutMs = responseTimeoutForMethod(method);
       const path = urlObj.pathname + (urlObj.search || '');
       const bodySize = options.body ? new Blob([options.body]).size : 0;
@@ -422,6 +470,10 @@
 
       function resolveOnce(response) {
         if (!resolved) { resolved = true; resolve(response); }
+      }
+
+      function rejectOnce(error) {
+        if (!resolved) { resolved = true; reject(error); }
       }
 
       // Central cleanup — idempotent, called from every exit path.
@@ -473,9 +525,13 @@
         cleanup('first-frame-timeout');
         closeStream();
 
-        // Fall back to HTTPS for this request. Mutation endpoints that can be
-        // replayed must enforce idempotency server-side.
-        resolveOnce(originalFetch(urlStr, options));
+        if (transportRetrySafe) {
+          resolveOnce(originalFetch(urlStr, options));
+        } else {
+          const error = new Error('WebRTC mutation outcome is unknown; the request was not replayed over HTTPS.');
+          error.name = 'UnknownMutationOutcomeError';
+          rejectOnce(error);
+        }
 
         // Mark the channel as degraded and renegotiate in the background.
         // This also drains any other stuck pending requests.
@@ -529,11 +585,15 @@
         diagQueue('fallback', fallbackState);
         cleanup('drain-fallback');
         if (!gotResponse) {
-          // Haven't received anything yet — retry via HTTPS. Mutation endpoints
-          // are responsible for making transport retries idempotent.
           closeStream();
-          diag('↩ fallback ' + method + ' ' + path);
-          resolveOnce(originalFetch(urlStr, options));
+          if (transportRetrySafe) {
+            diag('↩ fallback ' + method + ' ' + path);
+            resolveOnce(originalFetch(urlStr, options));
+          } else {
+            const error = new Error('WebRTC mutation outcome is unknown; the request was not replayed over HTTPS.');
+            error.name = 'UnknownMutationOutcomeError';
+            rejectOnce(error);
+          }
         } else {
           // Already streaming — close the stream; consumer sees truncation.
           // App-layer resume logic will reconnect via HTTPS.
@@ -599,6 +659,8 @@
         diag('send error: ' + (_e && _e.message ? _e.message : String(_e)));
         cleanup('send-error');
         closeStream();
+        // A synchronous send failure proves that no frame left this browser,
+        // so even a non-idempotent mutation is safe to send once over HTTPS.
         resolveOnce(originalFetch(urlStr, options));
         triggerRenegotiation();
       }
@@ -619,9 +681,32 @@
   // Kick off
   // ---------------------------------------------------------------------------
 
+  const startPersistentWebRTC = async () => {
+    if (renegotiating || (dataChannel && dataChannel.readyState === 'open')) return;
+    renegotiating = true;
+    let connected = false;
+    try {
+      connected = await initWebRTC();
+    } finally {
+      renegotiating = false;
+    }
+    if (!connected) {
+      renegotiationAttempt += 1;
+      scheduleRenegotiation('startup-retry', false);
+    }
+  };
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('online', () => scheduleRenegotiation('online', true));
+    window.addEventListener('pageshow', () => scheduleRenegotiation('pageshow', true));
+  }
+  if (typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') scheduleRenegotiation('visibility', false);
+    });
+  }
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initWebRTC);
+    document.addEventListener('DOMContentLoaded', startPersistentWebRTC);
   } else {
-    initWebRTC();
+    startPersistentWebRTC();
   }
 }());

--- a/internal/serveui/static/app-worktrees.js
+++ b/internal/serveui/static/app-worktrees.js
@@ -54,7 +54,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
   const loadWorktrees = async () => {
     if (!worktreesEnabled) return [];
     try {
-      const res = await fetch(`${UI_PREFIX}/v1/worktrees`, { headers: authHeaders() });
+      const res = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees`, { headers: authHeaders() });
       if (!res.ok) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(res) : res.text());
       const data = await res.json();
       state.worktrees = Array.isArray(data.worktrees) ? data.worktrees : [];
@@ -85,7 +85,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
     loading = true;
     renderWorktreeChip();
     try {
-      const res = await fetch(`${UI_PREFIX}/v1/worktrees`, {
+      const res = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees`, {
         method: 'POST',
         headers: authHeaders(),
         body: JSON.stringify({ name })
@@ -109,12 +109,12 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
     const value = action.trim().toLowerCase();
     try {
       if (value === 'diff') {
-        const res = await fetch(`${UI_PREFIX}/v1/worktrees/diff?dir=${encodeURIComponent(dir)}`, { headers: authHeaders() });
+        const res = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees/diff?dir=${encodeURIComponent(dir)}`, { headers: authHeaders() });
         if (!res.ok) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(res) : res.text());
         const data = await res.json();
         window.alert(data.diff || 'Worktree is clean.');
       } else if (value === 'merge') {
-        const res = await fetch(`${UI_PREFIX}/v1/worktrees/merge`, { method: 'POST', headers: authHeaders(), body: JSON.stringify({ dir }) });
+        const res = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees/merge`, { method: 'POST', headers: authHeaders(), body: JSON.stringify({ dir }) });
         if (!res.ok && res.status !== 409) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(res) : res.text());
         const data = await res.json().catch(() => ({}));
         const result = data.result || {};
@@ -134,7 +134,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
           } else if (Array.isArray(cleanup.in_use) && cleanup.in_use.length > 0) {
             const remove = window.confirm(`Merge succeeded, but the worktree is used by ${cleanup.in_use.length} session(s). Remove it anyway?`);
             if (remove) {
-              const deleteRes = await fetch(`${UI_PREFIX}/v1/worktrees?dir=${encodeURIComponent(dir)}&force=1`, { method: 'DELETE', headers: authHeaders() });
+              const deleteRes = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees?dir=${encodeURIComponent(dir)}&force=1`, { method: 'DELETE', headers: authHeaders() });
               if (!deleteRes.ok) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(deleteRes) : deleteRes.text());
               const session = activeSession();
               if (session && session.worktreeDir === dir) session.worktreeRemoved = true;
@@ -151,7 +151,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
       } else if (value === 'promote') {
         const branch = window.prompt('Branch name:', '');
         if (!branch) return;
-        const res = await fetch(`${UI_PREFIX}/v1/worktrees/promote`, { method: 'POST', headers: authHeaders(), body: JSON.stringify({ dir, branch }) });
+        const res = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees/promote`, { method: 'POST', headers: authHeaders(), body: JSON.stringify({ dir, branch }) });
         if (!res.ok && res.status !== 409) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(res) : res.text());
         const data = await res.json().catch(() => ({}));
         if (res.status === 409) {
@@ -163,7 +163,7 @@ const worktreeApp = window.TermLLMApp || (window.TermLLMApp = {});
         }
       } else if (value === 'remove' || value === 'rm') {
         if (!window.confirm('Remove this worktree?')) return;
-        const res = await fetch(`${UI_PREFIX}/v1/worktrees?dir=${encodeURIComponent(dir)}`, { method: 'DELETE', headers: authHeaders() });
+        const res = await worktreeApp.apiFetch(`${UI_PREFIX}/v1/worktrees?dir=${encodeURIComponent(dir)}`, { method: 'DELETE', headers: authHeaders() });
         if (!res.ok) throw await (worktreeApp.normalizeError ? worktreeApp.normalizeError(res) : res.text());
         const session = activeSession();
         if (session && session.worktreeDir === dir) session.worktreeRemoved = true;

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -7,6 +7,7 @@ const vm = require('vm');
 
 const dir = __dirname;
 const source = fs.readFileSync(path.join(dir, 'app-core.js'), 'utf8');
+const networkSource = fs.readFileSync(path.join(dir, 'app-network.js'), 'utf8');
 
 let failures = 0;
 const pendingAsyncTests = [];
@@ -161,11 +162,17 @@ function loadAppCoreWith({ nodeOverrides = {}, docQSTracker = () => [], document
     Date: DateShim,
     TextEncoder,
     TextDecoder,
+    Headers,
+    Request,
+    Response,
+    AbortController,
+    ReadableStream,
     ...contextOverrides,
   };
   context.globalThis = context;
 
   vm.runInNewContext(source, context, { filename: 'app-core.js' });
+  vm.runInNewContext(networkSource, context, { filename: 'app-network.js' });
   context.window.TermLLMApp.__testCookieWrites = cookieWrites;
   context.window.TermLLMApp.__testDocument = document;
   return context.window.TermLLMApp;
@@ -780,7 +787,7 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
     fail(name, 'offline warning should be visible');
     return;
   }
-  if (connectionNode.textContent !== 'Network offline') {
+  if (connectionNode.textContent !== 'Offline — reconnect to continue') {
     fail(name, `got ${JSON.stringify(connectionNode.textContent)}`);
     return;
   }
@@ -794,8 +801,64 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
   testApp.state.draftSessionActive = false;
   testApp.setProviderRetryStatus(session.id, 'resp_offline', 'Retrying provider…');
   testApp.clearProviderRetryStatus(session.id, 'resp_offline');
-  if (connectionNode.hidden || connectionNode.textContent !== 'Network offline' || !classes.has('bad')) {
+  if (connectionNode.hidden || connectionNode.textContent !== 'Offline — reconnect to continue' || !classes.has('bad')) {
     fail(name, 'provider retry set/clear changed the offline warning', connectionNode.textContent);
+    return;
+  }
+  pass(name);
+})();
+
+(function testConnectivityStateIsSeparateAndActionable() {
+  const name = 'connectivity state separates authentication from actionable network phases';
+  const classes = new Set();
+  const connectionNode = Object.assign(makeNode(), {
+    hidden: true,
+    classList: {
+      add(...names) { names.forEach((n) => classes.add(n)); },
+      remove(...names) { names.forEach((n) => classes.delete(n)); },
+      contains(value) { return classes.has(value); },
+    },
+  });
+  const testApp = loadAppCoreWith({
+    nodeOverrides: { connectionState: connectionNode },
+    navigatorOverrides: { onLine: true },
+  });
+
+  testApp.setApplicationConnected(true, true);
+  testApp.setConnectivityState({ network: 'offline', phase: 'offline', pendingSafe: 1 });
+  if (!testApp.state.connected || !testApp.state.connectivity.authenticated || !testApp.state.connectivity.startupConnected) {
+    fail(name, 'network outage incorrectly cleared startup/authentication state');
+    return;
+  }
+  if (connectionNode.textContent !== 'Offline — message pending safely; reconnect to continue' || !classes.has('bad')) {
+    fail(name, 'pending-safe offline status was not actionable', connectionNode.textContent);
+    return;
+  }
+
+  testApp.setConnectivityState({ network: 'recovering', phase: 'recovering', pendingSafe: 0 });
+  if (connectionNode.textContent !== 'Network restored — recovering…' || !classes.has('retry')) {
+    fail(name, 'recovering status was not visible', connectionNode.textContent);
+    return;
+  }
+  testApp.setConnectivityState({ network: 'recovering', phase: 'catching-up' });
+  if (connectionNode.textContent !== 'Catching up with the server…') {
+    fail(name, 'catching-up status was not visible', connectionNode.textContent);
+    return;
+  }
+  testApp.setConnectivityState({ network: 'unstable', phase: 'unstable' });
+  if (connectionNode.textContent !== 'Connection unstable' || !classes.has('bad')) {
+    fail(name, 'unstable status falsely promised an automatic retry', connectionNode.textContent);
+    return;
+  }
+  testApp.setConnectionState('Response reconnect paused — retry from the composer', 'bad');
+  if (connectionNode.textContent !== 'Response reconnect paused — retry from the composer') {
+    fail(name, 'generic connectivity status obscured an actionable legacy warning', connectionNode.textContent);
+    return;
+  }
+  testApp.setConnectionState('', '');
+  testApp.setConnectivityState({ network: 'healthy', phase: '' });
+  if (!connectionNode.hidden || connectionNode.textContent) {
+    fail(name, 'healthy network should leave the header quiet', connectionNode.textContent);
     return;
   }
   pass(name);

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -294,6 +294,7 @@ function createHarness(options = {}) {
     }
   };
   context.globalThis = context;
+  app.apiFetch = (...args) => context.fetch(...args);
   vm.runInNewContext(source, context, { filename: 'app-diffs.js' });
 
   const flushTimers = async () => {

--- a/internal/serveui/static/app_network_test.js
+++ b/internal/serveui/static/app_network_test.js
@@ -1,0 +1,368 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'app-network.js'), 'utf8');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function createHarness(fetchImpl, online = true) {
+  const listeners = new Map();
+  const documentListeners = new Map();
+  const timers = [];
+  let now = 0;
+  const navigator = { onLine: online };
+  const document = {
+    visibilityState: 'visible',
+    addEventListener(type, handler) { documentListeners.set(type, handler); },
+  };
+  const state = {
+    token: 'token',
+    connectivity: { network: online ? 'unknown' : 'offline', phase: '', pendingSafe: 0, consecutiveFailures: 0 },
+  };
+  const app = {
+    UI_PREFIX: '/ui',
+    state,
+    setConnectivityState(patch) {
+      state.connectivity = { ...state.connectivity, ...patch };
+      return state.connectivity;
+    },
+  };
+  const window = {
+    TermLLMApp: app,
+    TERM_LLM_UI_PREFIX: '/ui',
+    fetch: fetchImpl,
+    setTimeout(callback, delay) {
+      const timer = { callback, at: now + Number(delay || 0), cleared: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout(timer) { if (timer) timer.cleared = true; },
+    addEventListener(type, handler) {
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(handler);
+    },
+  };
+  const context = {
+    window,
+    document,
+    navigator,
+    console,
+    URL,
+    Request,
+    Response,
+    Headers,
+    AbortController,
+    DOMException,
+    ReadableStream,
+    Date,
+    Math,
+    Set,
+    Map,
+    Error,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(source, context, { filename: 'app-network.js' });
+
+  const flush = async () => {
+    for (let i = 0; i < 30; i += 1) await Promise.resolve();
+  };
+  const advance = async (ms) => {
+    now += ms;
+    for (;;) {
+      const due = timers.filter((timer) => !timer.cleared && timer.at <= now).sort((a, b) => a.at - b.at)[0];
+      if (!due) break;
+      due.cleared = true;
+      due.callback();
+      await flush();
+    }
+  };
+  const dispatch = async (type) => {
+    for (const handler of listeners.get(type) || []) handler({ type });
+    await flush();
+  };
+  return {
+    app, state, navigator, document, timers, advance, dispatch, flush,
+    dispatchDocument: async (type) => {
+      const handler = documentListeners.get(type);
+      if (handler) handler({ type });
+      await flush();
+    },
+    activeTimers: () => timers.filter((timer) => !timer.cleared),
+  };
+}
+
+async function testClassificationAndRetryAfter() {
+  const harness = createHarness(async () => new Response('{}', { status: 200 }));
+  const { app } = harness;
+  const P = app.API_FETCH_POLICY;
+  assert(app.classifyAPIRequest('/ui/v1/models').policy === P.safeRead, 'GET should default to safe-read');
+  assert(app.classifyAPIRequest('/ui/admin/widgets/status').authOwner === app.API_FETCH_AUTH.caller, '401 ownership should default explicitly to the caller');
+  assert(app.classifyAPIRequest('/ui/v1/action', { method: 'POST' }).policy === P.mutation, 'POST should default to non-retryable mutation');
+  assert(app.classifyAPIRequest('/ui/v1/action', { method: 'POST' }, { policy: P.idempotentMutation }).policy === P.mutation,
+    'POST without an idempotency key must not be treated as retry-safe');
+  assert(app.classifyAPIRequest('/ui/v1/action', { method: 'POST', headers: { 'Idempotency-Key': 'stable' } }, { policy: P.idempotentMutation }).retryable,
+    'POST with an explicit idempotency key should be retry-safe');
+  assert(app.retryAfterDelay(new Response(null, { status: 429, headers: { 'Retry-After': '20' } })) === 20000,
+    'Retry-After seconds should control retry delay');
+  console.log('PASS: API policies classify reads and mutations safely and honor Retry-After');
+}
+
+async function testRetryPolicies() {
+  let safeCalls = 0;
+  const safeHarness = createHarness(async (url) => {
+    if (String(url).endsWith('/providers')) return new Response('{}', { status: 200 });
+    safeCalls += 1;
+    return new Response('{}', { status: safeCalls === 1 ? 503 : 200 });
+  });
+  const safePromise = safeHarness.app.apiFetch('/ui/v1/models', {}, { policy: safeHarness.app.API_FETCH_POLICY.safeRead, retries: 1 });
+  await safeHarness.flush();
+  assert(safeCalls === 1, 'safe read should wait before retry');
+  await safeHarness.advance(1000);
+  assert((await safePromise).status === 200 && safeCalls === 2, 'safe read should retry once');
+
+  let mutationCalls = 0;
+  const mutationHarness = createHarness(async () => {
+    mutationCalls += 1;
+    return new Response('{}', { status: 503 });
+  });
+  const mutationResponse = await mutationHarness.app.apiFetch('/ui/v1/action', { method: 'POST' });
+  assert(mutationResponse.status === 503 && mutationCalls === 1, 'non-idempotent mutation must never retry automatically');
+
+  let idempotentCalls = 0;
+  const idempotentHarness = createHarness(async () => {
+    idempotentCalls += 1;
+    return new Response('{}', {
+      status: idempotentCalls === 1 ? 429 : 200,
+      headers: idempotentCalls === 1 ? { 'Retry-After': '20' } : {},
+    });
+  });
+  const idempotentPromise = idempotentHarness.app.apiFetch('/ui/v1/action', {
+    method: 'POST',
+    headers: { 'Idempotency-Key': 'turn-1' },
+  }, { policy: idempotentHarness.app.API_FETCH_POLICY.idempotentMutation, retries: 1 });
+  await idempotentHarness.flush();
+  await idempotentHarness.advance(19999);
+  assert(idempotentCalls === 1, 'idempotent mutation retried before Retry-After elapsed');
+  await idempotentHarness.advance(1);
+  assert((await idempotentPromise).status === 200 && idempotentCalls === 2, 'idempotent mutation did not retry after Retry-After');
+  console.log('PASS: API retries safe reads and explicitly idempotent mutations only');
+}
+
+async function testTimeoutAuthAbortAndDiagnostics() {
+  let authFailures = 0;
+  const authHarness = createHarness(async () => new Response('{}', { status: 401 }));
+  authHarness.app.handleAuthFailure = () => { authFailures += 1; };
+
+  const optional = await authHarness.app.apiFetch('/ui/admin/widgets/status', {}, { retries: 0 });
+  await authHarness.advance(0);
+  assert(optional.status === 401 && authFailures === 0, 'optional/admin 401 must not clear a valid session token');
+
+  const owned = await authHarness.app.apiFetch('/ui/v1/private', {}, {
+    retries: 0,
+    auth: authHarness.app.API_FETCH_AUTH.session,
+  });
+  await authHarness.advance(0);
+  assert(owned.status === 401 && authFailures === 1, 'session-owned 401 should trigger auth handling exactly once');
+  assert(authHarness.app.networkDiagnostics.some((entry) => entry.kind === 'request' && entry.status === 401), 'request diagnostics should record HTTP status');
+
+  const request = new Request('https://example.test/ui/v1/request-diagnostic');
+  await authHarness.app.apiFetch(request, {}, { retries: 0, auth: authHarness.app.API_FETCH_AUTH.ignore });
+  assert(authHarness.app.networkDiagnostics.some((entry) => entry.url === request.url), 'Request diagnostics should use the normalized URL');
+
+  const timeoutHarness = createHarness((_url, options) => new Promise((_resolve, reject) => {
+    options.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+  }));
+  const timed = timeoutHarness.app.apiFetch('/ui/v1/slow', {}, { policy: timeoutHarness.app.API_FETCH_POLICY.safeRead, retries: 0, timeoutMs: 2000 })
+    .then(() => null, (error) => error);
+  await timeoutHarness.advance(2000);
+  const timeoutError = await timed;
+  assert(timeoutError?.name === 'TimeoutError' && timeoutError?.networkClassification?.policy === timeoutHarness.app.API_FETCH_POLICY.safeRead,
+    'timeout should retain network classification diagnostics');
+
+  const bodyHarness = createHarness(async (_url, options) => new Response(new ReadableStream({
+    start(controller) {
+      options.signal.addEventListener('abort', () => controller.error(new DOMException('aborted', 'AbortError')), { once: true });
+    },
+  }), { status: 200 }));
+  const controller = new AbortController();
+  const bodyResponse = await bodyHarness.app.apiFetch('/ui/v1/body', { signal: controller.signal }, {
+    policy: bodyHarness.app.API_FETCH_POLICY.safeRead,
+    retries: 0,
+    timeoutMs: 5000,
+  });
+  controller.abort();
+  const bodyError = await bodyResponse.text().then(() => null, (error) => error);
+  assert(bodyError?.name === 'AbortError', 'caller abort after headers should abort response body consumption');
+  assert(bodyHarness.activeTimers().length === 0, 'abort-after-headers leaked the composed timeout');
+  console.log('PASS: API layer makes auth ownership explicit and preserves aborts through the response body');
+}
+
+async function testOfflineAbortClearsPendingRequest() {
+  const harness = createHarness(async () => { throw new Error('transport should not run'); }, false);
+  const controller = new AbortController();
+  const outcome = harness.app.apiFetch('/ui/v1/search', { signal: controller.signal }, {
+    policy: harness.app.API_FETCH_POLICY.safeRead,
+  }).then(() => null, (error) => error);
+  await harness.flush();
+  assert(harness.state.connectivity.pendingSafe === 0, 'parked safe read was mislabeled as a pending message');
+  controller.abort();
+  await harness.flush();
+  const error = await outcome;
+  assert(error?.name === 'AbortError' && harness.state.connectivity.pendingSafe === 0, 'aborted offline request leaked a retry waiter');
+
+  const mutationController = new AbortController();
+  const mutation = harness.app.apiFetch('/ui/v1/responses', {
+    method: 'POST',
+    headers: { 'Idempotency-Key': 'message-1' },
+    signal: mutationController.signal,
+  }, { policy: harness.app.API_FETCH_POLICY.idempotentMutation }).catch((caught) => caught);
+  await harness.flush();
+  assert(harness.state.connectivity.pendingSafe === 1, 'retry-safe pending mutation was not represented in pending copy');
+  mutationController.abort();
+  await mutation;
+  assert(harness.state.connectivity.pendingSafe === 0, 'pending mutation count did not clear after cancellation');
+  console.log('PASS: pending-safe copy tracks mutations, not parked reads, and aborts detach waiters');
+}
+
+async function testTwentySecondOfflineWakeAndRecoveryGate() {
+  const calls = [];
+  const harness = createHarness(async (url) => {
+    calls.push(String(url));
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }, false);
+  let reconciled = 0;
+  harness.app.addNetworkRecoveryHook(async () => { reconciled += 1; });
+  const pending = harness.app.apiFetch('/ui/v1/models', {}, { policy: harness.app.API_FETCH_POLICY.safeRead, retries: 1 });
+  await harness.flush();
+  assert(calls.length === 0, 'offline safe read should not hit the transport');
+  assert(harness.state.connectivity.pendingSafe === 0, 'parked read should not use pending-message copy');
+  await harness.advance(20000);
+  assert(calls.length === 0, '20-second offline interval should suspend retry timers');
+
+  harness.navigator.onLine = true;
+  await harness.dispatch('online');
+  const response = await pending;
+  assert(response.status === 200, 'pending safe read did not recover after online');
+  assert(calls[0] === '/ui/v1/providers' && calls[1] === '/ui/v1/models', 'health/reconciliation gate did not precede retry');
+  assert(reconciled === 1, 'coordinated recovery should run one reconciliation pass');
+  assert(harness.state.connectivity.pendingSafe === 0 && harness.state.connectivity.network === 'healthy', 'connectivity did not return to healthy');
+  console.log('PASS: 20-second offline retry is suspended then wakes behind one recovery gate');
+}
+
+async function testFailedProbeDoesNotReleaseRetries() {
+  const calls = [];
+  let healthy = false;
+  const harness = createHarness(async (url) => {
+    calls.push(String(url));
+    if (String(url).endsWith('/providers')) return new Response('{}', { status: healthy ? 200 : 503 });
+    return new Response('{}', { status: 200 });
+  }, false);
+  const first = harness.app.apiFetch('/ui/v1/models?a=1');
+  const second = harness.app.apiFetch('/ui/v1/models?a=2');
+  await harness.flush();
+
+  harness.navigator.onLine = true;
+  await harness.dispatch('online');
+  assert(calls.length === 1 && calls[0] === '/ui/v1/providers', 'failed health probe released pending retries');
+  assert(harness.state.connectivity.phase === 'unstable', 'failed health probe did not expose unstable state');
+  await harness.advance(999);
+  assert(calls.length === 1, 'coordinated probe backoff fired too early');
+
+  healthy = true;
+  await harness.advance(1);
+  await Promise.all([first, second]);
+  assert(calls.filter((url) => url === '/ui/v1/providers').length === 2, 'health recovery did not retry through one coordinated probe');
+  assert(calls.filter((url) => url.startsWith('/ui/v1/models')).length === 2, 'healthy recovery did not release both reads');
+  console.log('PASS: failed health probe retains all waiters behind one armed recovery backoff');
+}
+
+async function testDoubleFlapDoesNotDeadlockHookWaiter() {
+  const calls = [];
+  const harness = createHarness(async (url) => {
+    calls.push(String(url));
+    return new Response('{}', { status: 200 });
+  }, false);
+  let hookCalls = 0;
+  harness.app.addNetworkRecoveryHook(() => {
+    hookCalls += 1;
+    if (hookCalls === 1) return harness.app.waitForNetworkRetry(60000, { key: 'hook:refresh', reason: 'hook-refresh' });
+    return undefined;
+  });
+  const pending = harness.app.apiFetch('/ui/v1/models');
+  await harness.flush();
+
+  harness.navigator.onLine = true;
+  await harness.dispatch('online');
+  assert(hookCalls === 1, 'first recovery hook did not enter its wait');
+  harness.navigator.onLine = false;
+  await harness.dispatch('offline');
+  harness.navigator.onLine = true;
+  await harness.dispatch('online');
+  const response = await pending;
+  assert(response.status === 200, 'pending request remained deadlocked after second online transition');
+  assert(hookCalls === 2, 'second online transition did not start a fresh bounded recovery pass');
+  assert(calls.filter((url) => url === '/ui/v1/providers').length === 2, 'double flap should perform exactly one probe per online epoch');
+  console.log('PASS: offline-online-offline-online restores waiter liveness while a recovery hook is waiting');
+}
+
+async function testRecoveryHooksAreIsolatedAndBounded() {
+  const harness = createHarness(async () => new Response('{}', { status: 200 }), false);
+  let secondHook = 0;
+  harness.app.addNetworkRecoveryHook(() => new Promise(() => {}));
+  harness.app.addNetworkRecoveryHook(() => { secondHook += 1; throw new Error('hook failed'); });
+  const pending = harness.app.apiFetch('/ui/v1/models');
+  await harness.flush();
+  harness.navigator.onLine = true;
+  await harness.dispatch('online');
+  assert(secondHook === 1, 'blocked hook prevented independent hook execution');
+  await harness.advance(4999);
+  let settled = false;
+  pending.then(() => { settled = true; });
+  await harness.flush();
+  assert(!settled, 'blocked hook was not bounded by the configured timeout');
+  await harness.advance(1);
+  assert((await pending).status === 200, 'hook timeout/failure prevented safe waiter release');
+  assert(harness.app.networkDiagnostics.some((entry) => entry.kind === 'recovery-hook-timeout'), 'hook timeout was not diagnosed');
+  assert(harness.app.networkDiagnostics.some((entry) => entry.kind === 'recovery-hook-failed'), 'hook failure was not diagnosed');
+  console.log('PASS: recovery hooks run independently, time out, and cannot strand waiters');
+}
+
+async function testStreamRecoveryHasNoPostWakeHotSpin() {
+  const harness = createHarness(async () => new Response('{}', { status: 200 }));
+  const raced = harness.app.createResumableStreamRecovery({ key: 'stream:race' });
+  raced.noteAttempt();
+  await harness.app.runCoordinatedNetworkRecovery('online');
+  const racedWake = await raced.wait('ended');
+  assert(racedWake === 'recovered-during-attempt', 'recovery/wait race was not solved by the recovery epoch');
+
+  const recovery = harness.app.createResumableStreamRecovery({ key: 'stream:backoff' });
+  recovery.noteAttempt();
+  let settled = false;
+  const wait = recovery.wait('ended').then((reason) => { settled = true; return reason; });
+  await harness.flush();
+  assert(!settled, 'post-recovery stream retry hot-spun instead of arming delay');
+  await harness.advance(999);
+  assert(!settled, 'stream retry delay completed early');
+  assert(await harness.advance(1).then(() => wait) === 'timer', 'armed stream backoff did not complete normally');
+  console.log('PASS: stream wake race is direct and later retries retain their real backoff');
+}
+
+(async () => {
+  await testClassificationAndRetryAfter();
+  await testRetryPolicies();
+  await testTimeoutAuthAbortAndDiagnostics();
+  await testOfflineAbortClearsPendingRequest();
+  await testTwentySecondOfflineWakeAndRecoveryGate();
+  await testFailedProbeDoesNotReleaseRetries();
+  await testDoubleFlapDoesNotDeadlockHookWaiter();
+  await testRecoveryHooksAreIsolatedAndBounded();
+  await testStreamRecoveryHasNoPostWakeHotSpin();
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exitCode = 1;
+});

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -460,8 +460,24 @@ async function createSessionsHarness(options = {}) {
   vm.runInContext(planSource, context, { filename: 'app-plan.js' });
 
   const app = windowObj.TermLLMApp;
+  app.apiFetch = (...args) => context.fetch(...args);
+  app.API_FETCH_POLICY = { safeRead: 'safe-read', idempotentMutation: 'idempotent-mutation', mutation: 'non-retryable-mutation', stream: 'stream' };
   vm.runInContext(sidebarSource, context, { filename: 'app-sidebar.js' });
   Object.assign(app, defaultAppStubs(app, options.appOverrides || {}));
+  const networkRecoveryHooks = [];
+  app.addNetworkRecoveryHook = (hook) => {
+    networkRecoveryHooks.push(hook);
+    return () => {};
+  };
+  app.runCoordinatedNetworkRecovery = async (reason) => {
+    const active = app.getActiveSession?.();
+    const wakeOwner = active?.activeResponseId ? { sessionId: active.id, responseId: active.activeResponseId } : null;
+    for (const hook of networkRecoveryHooks) await hook(reason);
+    if (wakeOwner) {
+      app.wakeResponseReconnect?.({ reason, ...wakeOwner });
+    }
+    return true;
+  };
 
   vm.runInContext(mcpSource, context, { filename: 'app-mcp.js' });
   vm.runInContext(goalsLocationSource, context, { filename: 'app-goals-location.js' });
@@ -4046,6 +4062,48 @@ async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
   pass(name);
 }
 
+async function testHealthyVisibilityDoesNotAbortActiveStream() {
+  const name = 'healthy active stream survives visibility recovery without an abort';
+  const { app, windowObj } = await createSessionsHarness();
+  app.stopSidebarStatusPoll();
+  app.startSidebarStatusPoll = async () => true;
+  const session = {
+    id: 'session_visible_stream', number: 17, title: 'Visible stream', mode: 'chat', origin: 'web',
+    created: Date.now(), lastMessageAt: Date.now(), activeResponseId: 'resp_visible_stream', messages: [],
+  };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  app.state.connected = true;
+  app.state.currentStreamSessionId = session.id;
+  app.state.currentStreamResponseId = session.activeResponseId;
+  app.state.lastEventTime = Date.now();
+  const controller = new AbortController();
+  controller._heartbeatAbort = false;
+  app.state.abortController = controller;
+
+  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  windowObj.document.visibilityState = 'visible';
+  await visibilityHandler({ type: 'visibilitychange' });
+  if (controller.signal.aborted || controller._heartbeatAbort) {
+    fail(name, 'visibility recovery aborted a stream with recent activity');
+    return;
+  }
+
+  const staleController = new AbortController();
+  staleController._heartbeatAbort = false;
+  app.state.abortController = staleController;
+  app.state.lastEventTime = Date.now() - 60000;
+  await visibilityHandler({ type: 'visibilitychange' });
+  if (!staleController.signal.aborted || !staleController._heartbeatAbort) {
+    fail(name, 'visibility recovery did not retire a genuinely stale stream');
+    return;
+  }
+  app.state.abortController = null;
+  app.stopSidebarStatusPoll();
+  pass(name);
+}
+
 async function testVisibilityResumeRestoresPreBackgroundTailOwnership() {
   const name = 'visibility resume restores pre-background tail ownership before catch-up';
   let appRef = null;
@@ -4365,8 +4423,17 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   let onlineWakeAfterStatus = false;
   const { app, windowObj } = await createSessionsHarness({
     fetchImpl: async (url) => {
-      if (String(url).startsWith('/ui/v1/sessions/status')) onlineStatusCompleted = true;
-      return new Response(JSON.stringify({ sessions: [] }), {
+      const isStatus = String(url).startsWith('/ui/v1/sessions/status');
+      if (isStatus) onlineStatusCompleted = true;
+      return new Response(JSON.stringify({
+        sessions: isStatus ? [{
+          id: 'sess_wake_signals',
+          active_response_id: 'resp_wake_signals',
+          active_run: true,
+          run_epoch: 1,
+          started_rev: 0,
+        }] : []
+      }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' }
       });
@@ -4408,7 +4475,7 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   await app.stopSidebarStatusPoll();
   onlineStatusCompleted = false;
   await onlineHandler({ type: 'online' });
-  pageshowHandler({ type: 'pageshow', persisted: false });
+  await pageshowHandler({ type: 'pageshow', persisted: false });
 
   const want = [
     'visibility:sess_wake_signals:resp_wake_signals',
@@ -6886,6 +6953,7 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testApplyServerSessionSummaryMapsLastMessageAt();
   await testSanitizeSessionPreservesLastMessageAt();
   await testPreConnectedVisibilityDoesNotStartSidebarStatusPoll();
+  await testHealthyVisibilityDoesNotAbortActiveStream();
   await testVisibilityResumeRestoresPreBackgroundTailOwnership();
   await testPageshowWaitsForInitialConnectionBeforeStatusPoll();
   await testSidebarStatusPollRecoversIdempotentlyAfterPageShow();

--- a/internal/serveui/static/app_sidebar_test.js
+++ b/internal/serveui/static/app_sidebar_test.js
@@ -147,6 +147,7 @@ function createHarness(options = {}) {
     AbortController,
   };
   context.globalThis = context;
+  app.apiFetch = (...args) => context.fetch(...args);
   vm.runInNewContext(source, context, { filename: 'app-sidebar.js' });
   return { app, elements, state, document, get renderSidebarCount() { return renderSidebarCount; } };
 }

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -10,6 +10,7 @@ const { webcrypto } = require('crypto');
 
 const dir = __dirname;
 const attachmentsSource = fs.readFileSync(path.join(dir, 'app-attachments.js'), 'utf8');
+const networkSource = fs.readFileSync(path.join(dir, 'app-network.js'), 'utf8');
 const source = fs.readFileSync(path.join(dir, 'app-stream.js'), 'utf8');
 const responseEffectsSource = fs.readFileSync(path.join(dir, 'app-response-effects.js'), 'utf8');
 const sendSource = fs.readFileSync(path.join(dir, 'app-send.js'), 'utf8');
@@ -627,6 +628,8 @@ function createHarness(options = {}) {
       : () => null,
   };
 
+  const windowEventListeners = new Map();
+  const navigatorObj = options.navigator || { mediaDevices: null, onLine: true };
   const windowObj = {
     TermLLMApp: app,
     ConversationController,
@@ -646,8 +649,15 @@ function createHarness(options = {}) {
     cancelAnimationFrame(handle) {
       clearTimeout(handle);
     },
-    addEventListener() {},
-    removeEventListener() {},
+    addEventListener(type, handler) {
+      if (!windowEventListeners.has(type)) windowEventListeners.set(type, []);
+      windowEventListeners.get(type).push(handler);
+    },
+    removeEventListener(type, handler) {
+      const listeners = windowEventListeners.get(type) || [];
+      const index = listeners.indexOf(handler);
+      if (index >= 0) listeners.splice(index, 1);
+    },
     innerWidth: 1280,
     innerHeight: 800,
     location: { search: '', origin: 'https://example.test' },
@@ -677,7 +687,7 @@ function createHarness(options = {}) {
     Blob,
     CSS: options.CSS,
     performance: { now: () => Date.now() },
-    navigator: { mediaDevices: null },
+    navigator: navigatorObj,
     MediaRecorder: undefined,
     FileReader: fileReaderClass,
     alert(message) { if (typeof options.onAlert === 'function') options.onAlert(message); },
@@ -685,6 +695,7 @@ function createHarness(options = {}) {
   };
   context.globalThis = context;
   windowObj.document = document;
+  windowObj.navigator = navigatorObj;
   windowObj.localStorage = localStorage;
   windowObj.URL = urlAPI;
   windowObj.CSS = options.CSS;
@@ -816,6 +827,9 @@ function createHarness(options = {}) {
   };
   context.fetch = windowObj.fetch;
 
+  // The shared API/recovery layer is loaded immediately after app-core in the
+  // browser and before every feature module.
+  vm.runInNewContext(networkSource, context, { filename: 'app-network.js' });
   // app-attachments.js is a dependency leaf that app-stream.js destructures from
   // the shared app bag at load time, so it must run first (mirrors index.html).
   vm.runInNewContext(attachmentsSource, context, { filename: 'app-attachments.js' });
@@ -865,6 +879,11 @@ function createHarness(options = {}) {
     getEventsStarted: () => getEventsStarted,
     postStreamCanceled: () => postStreamCanceled,
     connectionStates,
+    navigator: navigatorObj,
+    dispatchWindowEvent: async (type) => {
+      for (const handler of windowEventListeners.get(type) || []) handler({ type });
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    },
     getProviderRetryStatus: () => providerRetryStatus ? { ...providerRetryStatus } : null,
     getModelSwapUpdateCount: () => modelSwapUpdateCount,
     getCancelRequested: () => cancelRequested,
@@ -2093,6 +2112,97 @@ async function testSendMessageTransientPreResponseFailureRetries() {
     return;
   }
 
+  pass(name);
+}
+
+async function testInitialPostOfflineWake() {
+  const name = 'offline initial response POST wakes without duplicating the turn';
+  const navigator = { mediaDevices: null, onLine: true };
+  let postCount = 0;
+  const idempotencyKeys = [];
+  const postBodies = [];
+  const harness = createHarness({
+    navigator,
+    fetchImpl: async (url, requestOptions, { Response, ReadableStream, TextEncoder }) => {
+      if (url !== '/ui/v1/responses' || (requestOptions.method || 'GET') !== 'POST') {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      postCount += 1;
+      idempotencyKeys.push(requestOptions.headers?.['Idempotency-Key'] || '');
+      postBodies.push(String(requestOptions.body || ''));
+      if (postCount === 1) {
+        navigator.onLine = false;
+        throw new TypeError('Failed to fetch');
+      }
+      const body = [
+        'event: response.created\n',
+        'data: {"response":{"id":"resp_test","status":"in_progress"},"sequence_number":1}\n\n',
+        'event: response.completed\n',
+        'data: {"response":{"id":"resp_test","status":"completed"},"sequence_number":2}\n\n',
+        'data: [DONE]\n\n',
+      ].join('');
+      return new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(body));
+          controller.close();
+        },
+      }), { status: 200, headers: { 'x-response-id': 'resp_test' } });
+    },
+  });
+  const { app, elements, state, cleanup } = harness;
+  elements.promptInput.value = 'survive outage';
+  const sendPromise = app.sendMessage();
+  const pending = await waitFor(() => postCount === 1 && state.connectivity?.pendingSafe === 1, 1000);
+  if (!pending) {
+    fail(name, 'initial POST did not enter pending-safe offline state');
+    await cleanup();
+    return;
+  }
+
+  navigator.onLine = true;
+  app.wakeAllNetworkRetries('online');
+  await sendPromise;
+  await cleanup();
+
+  const users = projectedMessages(state.sessions[0]).filter((message) => message.role === 'user');
+  if (postCount !== 2 || users.length !== 1 || idempotencyKeys[0] !== idempotencyKeys[1] || postBodies[0] !== postBodies[1]) {
+    fail(name, 'recovery was not idempotent', JSON.stringify({ postCount, users: users.length, idempotencyKeys }));
+    return;
+  }
+  pass(name);
+}
+
+async function testInitialPostWaiterDetachesOnSessionSwitch() {
+  const name = 'initial response POST retry waiter detaches on session switch';
+  const navigator = { mediaDevices: null, onLine: true };
+  let postCount = 0;
+  const harness = createHarness({
+    navigator,
+    fetchImpl: async (url, requestOptions) => {
+      if (url !== '/ui/v1/responses' || (requestOptions.method || 'GET') !== 'POST') {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      postCount += 1;
+      navigator.onLine = false;
+      throw new TypeError('Failed to fetch');
+    },
+  });
+  const { app, elements, state, cleanup } = harness;
+  elements.promptInput.value = 'detach me';
+  const sendPromise = app.sendMessage();
+  const pending = await waitFor(() => postCount === 1 && state.connectivity?.pendingSafe === 1, 1000);
+  if (!pending) {
+    fail(name, 'initial POST did not enter its retry wait');
+    await cleanup();
+    return;
+  }
+  app.detachResponseStream();
+  await sendPromise;
+  await cleanup();
+  if (postCount !== 1 || state.connectivity?.pendingSafe !== 0) {
+    fail(name, 'detached initial POST waiter retried or leaked pending state', JSON.stringify({ postCount, pendingSafe: state.connectivity?.pendingSafe }));
+    return;
+  }
   pass(name);
 }
 
@@ -3550,16 +3660,18 @@ async function testResumeActiveResponseHeartbeatCancelSlowsAndRecovers() {
 }
 
 async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
-  const name = 'slow response reconnect backoff is wakeable without a duplicate resume loop';
+  const name = 'established response survives a 20-second outage and wakes with exact replay';
   const responseId = 'resp_wakeable_retry';
   const timers = [];
+  let now = 0;
   let nextTimerID = 0;
   let eventsCount = 0;
   const harness = createHarness({
     responseId,
     diagnostics: true,
     setTimeout(callback, ms) {
-      const timer = { id: ++nextTimerID, callback, ms: Number(ms || 0), cleared: false };
+      const delay = Number(ms || 0);
+      const timer = { id: ++nextTimerID, callback, ms: delay, at: now + delay, cleared: false };
       timers.push(timer);
       return timer.id;
     },
@@ -3578,8 +3690,10 @@ async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
       const body = [
         'event: response.created\n',
         `data: {"response":{"id":"${responseId}","status":"in_progress"},"sequence_number":1}\n\n`,
+        'event: response.output_text.delta\n',
+        `data: {"response_id":"${responseId}","delta":"exact replay","sequence_number":2}\n\n`,
         'event: response.completed\n',
-        `data: {"response":{"id":"${responseId}","status":"completed"},"sequence_number":2}\n\n`,
+        `data: {"response":{"id":"${responseId}","status":"completed"},"sequence_number":3}\n\n`,
         'data: [DONE]\n\n',
       ].join('');
       const encoder = new TextEncoder();
@@ -3612,6 +3726,7 @@ async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
       return;
     }
     const timer = timers.find((item) => !item.cleared);
+    now = timer.at;
     timer.cleared = true;
     timer.callback();
   }
@@ -3619,6 +3734,19 @@ async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
   const slowReady = await waitFor(() => eventsCount === 6 && timers.some((timer) => !timer.cleared && timer.ms === 60000), 1000);
   if (!slowReady) {
     fail(name, 'slow one-minute retry was not scheduled', JSON.stringify(timers));
+    await cleanup();
+    return;
+  }
+  const outageTarget = now + 20000;
+  for (const timer of timers.filter((item) => !item.cleared && item.at <= outageTarget).sort((a, b) => a.at - b.at)) {
+    now = timer.at;
+    timer.cleared = true;
+    timer.callback();
+    await Promise.resolve();
+  }
+  now = outageTarget;
+  if (eventsCount !== 6 || !timers.some((timer) => !timer.cleared && timer.ms === 60000 && timer.at > now)) {
+    fail(name, `armed slow retry fired during real 20-second advance: events=${eventsCount}`);
     await cleanup();
     return;
   }
@@ -3657,6 +3785,11 @@ async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
   await cleanup();
   if (eventsCount !== 7) {
     fail(name, `expected one resumed fetch after wake, got ${eventsCount} total fetches`);
+    return;
+  }
+  const replayedAssistants = projectedMessages(session).filter((message) => message.role === 'assistant');
+  if (replayedAssistants.length !== 1 || replayedAssistants[0].content !== 'exact replay') {
+    fail(name, 'terminal replay was missing or duplicated', JSON.stringify(projectedMessages(session)));
     return;
   }
   if (!connectionStates.some((status) => status.source === 'legacy' && status.text.includes('within one minute'))) {
@@ -7468,6 +7601,8 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testSendMessageHeartbeatAbortRetriesBeforeResponseId();
   await testSendMessageLargeUploadUsesLongerPreResponseHeartbeatGrace();
   await testSendMessageTransientPreResponseFailureRetries();
+  await testInitialPostOfflineWake();
+  await testInitialPostWaiterDetachesOnSessionSwitch();
   await testSendMessageHeartbeatAbortKeepsRetryingWithSlowBackoff();
   await testSendMessageDoesNotResumeAfterStalePostStream();
   await testSendMessageUsesLocalContinuationIdWithoutPreflightSync();

--- a/internal/serveui/static/app_webrtc_test.js
+++ b/internal/serveui/static/app_webrtc_test.js
@@ -55,6 +55,10 @@ function testResponseTimeouts() {
 async function createEnabledHarness() {
   const channels = [];
   const scheduled = [];
+  const windowListeners = new Map();
+  const documentListeners = new Map();
+  let now = 0;
+  let signalingOnline = true;
   let transportRecoveries = 0;
   let httpsAPICalls = 0;
 
@@ -105,6 +109,7 @@ async function createEnabledHarness() {
   const originalFetch = async (url) => {
     const value = String(url);
     if (value.endsWith('/session')) {
+      if (!signalingOnline) throw new TypeError('simulated signaling outage');
       return new Response(JSON.stringify({ session_id: 'signal-session' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -129,7 +134,10 @@ async function createEnabledHarness() {
   const document = {
     readyState: 'complete',
     visibilityState: 'visible',
-    addEventListener() {},
+    addEventListener(type, handler) {
+      if (!documentListeners.has(type)) documentListeners.set(type, []);
+      documentListeners.get(type).push(handler);
+    },
   };
   const window = {
     __WEBRTC_ENABLED__: true,
@@ -138,6 +146,10 @@ async function createEnabledHarness() {
     TERM_LLM_UI_PREFIX: '/ui',
     location: { search: '', origin: 'https://example.test' },
     fetch: originalFetch,
+    addEventListener(type, handler) {
+      if (!windowListeners.has(type)) windowListeners.set(type, []);
+      windowListeners.get(type).push(handler);
+    },
     TermLLMApp: {
       handleFetchTransportFallback() {
         transportRecoveries += 1;
@@ -162,7 +174,7 @@ async function createEnabledHarness() {
     crypto: webcrypto,
     RTCPeerConnection: FakePeerConnection,
     setTimeout(fn, delay) {
-      const handle = { fn, delay, cleared: false };
+      const handle = { fn, delay, at: now + Number(delay || 0), cleared: false };
       scheduled.push(handle);
       return handle;
     },
@@ -183,7 +195,39 @@ async function createEnabledHarness() {
   return {
     channels,
     originalFetch,
+    scheduled,
     window,
+    setSignalingOnline(value) { signalingOnline = Boolean(value); },
+    async dispatchWindow(type) {
+      for (const handler of windowListeners.get(type) || []) handler({ type });
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    },
+    async dispatchDocument(type) {
+      for (const handler of documentListeners.get(type) || []) handler({ type });
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    },
+    async runNextTimer(expectedDelay) {
+      const timer = scheduled.find((item) => !item.cleared && (expectedDelay === undefined || item.delay === expectedDelay));
+      if (!timer) return false;
+      now = Math.max(now, timer.at);
+      timer.cleared = true;
+      timer.fn();
+      for (let i = 0; i < 20; i += 1) await new Promise((resolve) => setImmediate(resolve));
+      return true;
+    },
+    async advanceTime(ms) {
+      const target = now + Number(ms || 0);
+      for (;;) {
+        const timer = scheduled.filter((item) => !item.cleared && item.at <= target).sort((a, b) => a.at - b.at)[0];
+        if (!timer) break;
+        now = timer.at;
+        timer.cleared = true;
+        timer.fn();
+        for (let i = 0; i < 20; i += 1) await new Promise((resolve) => setImmediate(resolve));
+      }
+      now = target;
+    },
+    getNow: () => now,
     getHTTPSAPICalls: () => httpsAPICalls,
     getTransportRecoveries: () => transportRecoveries,
   };
@@ -236,10 +280,89 @@ async function testSendFallbackSignalsTransportRecoveryOnce() {
   console.log('PASS: WebRTC request fallback restores fetch and signals app recovery once');
 }
 
+async function testSynchronousSendThrowFallsBackForMutation() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const patchedFetch = harness.window.fetch;
+  channel.throwOnSend = true;
+  const response = await patchedFetch('/ui/v1/non-idempotent-action', { method: 'POST', body: '{}' });
+  if (!response.ok || harness.getHTTPSAPICalls() !== 1) {
+    fail('synchronous send throw did not safely fall back to HTTPS for a mutation');
+  }
+  console.log('PASS: synchronous WebRTC send throw proves non-delivery and falls back once over HTTPS');
+}
+
+async function testAmbiguousMutationDrainIsNotReplayed() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const pending = harness.window.fetch('/ui/v1/non-idempotent-action', { method: 'POST', body: '{}' })
+    .then(() => null, (error) => error);
+  channel.close();
+  const error = await pending;
+  if (!error || error.name !== 'UnknownMutationOutcomeError') {
+    fail('mutation accepted by dataChannel.send did not protect its ambiguous outcome');
+  }
+  if (harness.getHTTPSAPICalls() !== 0) {
+    fail('ambiguous mutation was replayed during channel drain');
+  }
+  console.log('PASS: first-frame/channel-drain ambiguity never replays an unsafe mutation');
+}
+
+async function testTwentySecondFallbackAndPersistentRecovery() {
+  const harness = await createEnabledHarness();
+  const firstChannel = harness.channels[0];
+  const patchedFetch = harness.window.fetch;
+  harness.setSignalingOnline(false);
+  firstChannel.close();
+
+  const httpsResponse = await harness.window.fetch('/ui/v1/sessions/status', { headers: {} });
+  if (!httpsResponse.ok || harness.getHTTPSAPICalls() !== 1) {
+    fail('HTTPS did not remain functional during WebRTC outage');
+  }
+  await harness.runNextTimer(2000);
+  await harness.runNextTimer(5000);
+  await harness.runNextTimer(10000);
+  await harness.advanceTime(3000);
+  if (harness.getNow() !== 20000 || harness.channels.length !== 1) {
+    fail(`WebRTC unexpectedly recovered during real 20-second backoff (channels=${harness.channels.length})`);
+  }
+  if (!harness.scheduled.some((timer) => !timer.cleared && timer.delay === 30000)) {
+    fail('persistent WebRTC recovery did not continue with bounded backoff');
+  }
+
+  harness.setSignalingOnline(true);
+  await harness.dispatchWindow('online');
+  await harness.runNextTimer(0);
+  await waitFor(() => harness.channels.length === 2 && harness.window.fetch !== harness.originalFetch, 'WebRTC did not recover quickly after restoration');
+  if (harness.window.fetch === patchedFetch) {
+    // A new patched function identity is not required; this assertion exists to
+    // document that routing is active again, not to demand wrapper churn.
+  }
+  console.log('PASS: WebRTC survives a 20-second outage on HTTPS and recovers immediately when signaling returns');
+}
+
+async function testVisibilityChurnDoesNotHammerSignaling() {
+  const harness = await createEnabledHarness();
+  harness.setSignalingOnline(false);
+  harness.channels[0].close();
+  for (let i = 0; i < 8; i += 1) await harness.dispatchDocument('visibilitychange');
+  const activeRetries = harness.scheduled.filter((timer) => !timer.cleared && timer.delay === 2000);
+  const immediateRetries = harness.scheduled.filter((timer) => !timer.cleared && timer.delay === 0);
+  if (activeRetries.length !== 1 || immediateRetries.length !== 0) {
+    fail(`visibility churn rescheduled signaling (${activeRetries.length} backoffs, ${immediateRetries.length} immediate)`);
+  }
+  if (harness.channels.length !== 1) fail('visibility churn started signaling before the armed backoff');
+  console.log('PASS: visibility churn preserves one armed WebRTC signaling backoff');
+}
+
 (async () => {
   testResponseTimeouts();
   await testChannelCloseSignalsTransportRecoveryOnce();
   await testSendFallbackSignalsTransportRecoveryOnce();
+  await testSynchronousSendThrowFallsBackForMutation();
+  await testAmbiguousMutationDrainIsNotReplayed();
+  await testTwentySecondFallbackAndPersistentRecovery();
+  await testVisibilityChurnDoesNotHammerSignaling();
 })().catch((error) => {
   console.error(error);
   process.exit(1);

--- a/internal/serveui/static/app_worktrees_test.js
+++ b/internal/serveui/static/app_worktrees_test.js
@@ -158,6 +158,7 @@ function makeHarness(options = {}) {
     console,
   };
   context.globalThis = context;
+  windowObj.TermLLMApp.apiFetch = (...args) => fetch(...args);
   vm.runInNewContext(source, context, { filename: 'app-worktrees.js' });
   return {
     app: windowObj.TermLLMApp,

--- a/internal/serveui/static/chip_picker_test.js
+++ b/internal/serveui/static/chip_picker_test.js
@@ -226,17 +226,21 @@ function loadCore(options = {}) {
   const { ctx, elementMap, windowObj } = makeContext(options);
   vm.runInNewContext(coreSource, ctx, { filename: 'app-core.js' });
   const app = ctx.window.TermLLMApp;
+  app.apiFetch = (...args) => ctx.window.fetch(...args);
+  app.API_FETCH_POLICY = { safeRead: 'safe-read', idempotentMutation: 'idempotent-mutation', mutation: 'non-retryable-mutation', stream: 'stream' };
   return { ctx, app, elementMap, windowObj };
 }
 
 function loadCoreAndStream(options = {}) {
   const { ctx, elementMap, windowObj } = makeContext(options);
   vm.runInNewContext(coreSource, ctx, { filename: 'app-core.js' });
+  const app = ctx.window.TermLLMApp;
+  app.apiFetch = (...args) => ctx.window.fetch(...args);
+  app.API_FETCH_POLICY = { safeRead: 'safe-read', idempotentMutation: 'idempotent-mutation', mutation: 'non-retryable-mutation', stream: 'stream' };
   vm.runInNewContext(attachmentsSource, ctx, { filename: 'app-attachments.js' });
   vm.runInNewContext(streamSource, ctx, { filename: 'app-stream.js' });
   vm.runInNewContext(runtimeSource, ctx, { filename: 'app-runtime.js' });
   vm.runInNewContext(modalsSource, ctx, { filename: 'app-modals.js' });
-  const app = ctx.window.TermLLMApp;
   return { ctx, app, elementMap, windowObj };
 }
 

--- a/internal/serveui/static/conversation.js
+++ b/internal/serveui/static/conversation.js
@@ -712,7 +712,7 @@
         if (id != null) requested.push(id);
       }
       if (requested.length === 0) return true;
-      const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/transcript/bodies?ids=${requested.join(',')}`, {
+      const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/transcript/bodies?ids=${requested.join(',')}`, {
         headers: requestHeaders(session.id)
       });
       if (!resp.ok) return false;
@@ -768,7 +768,7 @@
       if (!transcript) return false;
       const headers = requestHeaders(session.id);
       if (transcript.etag && !options.force) headers['If-None-Match'] = transcript.etag;
-      const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/transcript`, { headers });
+      const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/transcript`, { headers });
       transcript.noteIndexFetch(resp.status === 304, resp.headers?.get?.('ETag') || '');
       if (resp.status !== 304 && !resp.ok) return false;
       let data = null;
@@ -887,7 +887,7 @@
       try {
         const headers = {};
         if (state.token) headers.Authorization = `Bearer ${state.token}`;
-        const resp = await fetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/state`, { headers });
+        const resp = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(sessionId)}/state`, { headers });
         if (!resp.ok) {
           if (resp.status === 404) {
             return sessionStateOKResult({ active_run: false, active_response_id: '' });

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -125,6 +125,7 @@
   </style>
   <link rel="stylesheet" href="app.css">
   <link rel="preload" as="script" href="app-core.js">
+  <link rel="preload" as="script" href="app-network.js">
   <link rel="preload" as="script" href="transcript-window.js">
   <link rel="preload" as="script" href="active-response.js">
   <link rel="preload" as="script" href="conversation.js">
@@ -625,6 +626,7 @@
   <script src="active-response.js"></script>
   <script src="conversation.js"></script>
   <script src="app-core.js"></script>
+  <script src="app-network.js"></script>
   <script src="app-plan.js"></script>
   <script src="slash-commands.js"></script>
   <script src="app-render.js"></script>

--- a/internal/serveui/static/side-question.js
+++ b/internal/serveui/static/side-question.js
@@ -81,7 +81,7 @@ const applyView = (view) => {
 
 const recover = async (sessionId) => {
   if (!isResolvedSessionIdentity(sessionId)) return false;
-  const response = await fetch(endpoint(sessionId), { headers: requestHeaders(sessionId) });
+  const response = await app.apiFetch(endpoint(sessionId), { headers: requestHeaders(sessionId) });
   if (!response.ok) throw new Error(`Unable to load side questions (${response.status})`);
   applyView(await response.json());
   return true;
@@ -173,7 +173,7 @@ const openSideQuestion = async (question = '') => {
   elements.sideQuestionInput.value = '';
   render();
   try {
-    const response = await fetch(endpoint(session.id), {
+    const response = await app.apiFetch(endpoint(session.id), {
       method: 'POST',
       headers: requestHeaders(session.id),
       body: JSON.stringify({ question: trimmed })
@@ -192,7 +192,7 @@ const openSideQuestion = async (question = '') => {
     focusComposer();
   } catch (err) {
     if (operation !== openOperation) return;
-    await fetch(endpoint(session.id, '/active'), { method: 'DELETE', headers: requestHeaders(session.id) }).catch(() => {});
+    await app.apiFetch(endpoint(session.id, '/active'), { method: 'DELETE', headers: requestHeaders(session.id) }).catch(() => {});
     side.running = false;
     side.pending = false;
     side.error = err?.message || String(err);
@@ -214,7 +214,7 @@ const cancel = async (focus = true) => {
   render();
   if (focus) focusComposer();
   if (isResolvedSessionIdentity(session)) {
-    await fetch(endpoint(session.id, '/active'), { method: 'DELETE', headers: requestHeaders(session.id) }).catch(() => {});
+    await app.apiFetch(endpoint(session.id, '/active'), { method: 'DELETE', headers: requestHeaders(session.id) }).catch(() => {});
   }
 };
 
@@ -257,7 +257,7 @@ setInterval(() => {
   const previousId = observedSessionId;
   observedSessionId = currentId;
   if (previousId && side.running && isResolvedSessionIdentity(previousId)) {
-    fetch(endpoint(previousId, '/active'), { method: 'DELETE', headers: requestHeaders(previousId) }).catch(() => {});
+    app.apiFetch(endpoint(previousId, '/active'), { method: 'DELETE', headers: requestHeaders(previousId) }).catch(() => {});
   }
   side.generation += 1;
   side.visible = false;

--- a/internal/serveui/static/side_question_test.js
+++ b/internal/serveui/static/side_question_test.js
@@ -98,6 +98,7 @@ const window = {
 };
 const context = { window, document, fetch, Response, TextDecoder, console, setInterval: () => 1 };
 context.globalThis = context;
+app.apiFetch = (...args) => fetch(...args);
 vm.runInNewContext(source, context, { filename: 'side-question.js' });
 
 const assert = (condition, message) => { if (!condition) throw new Error(message); };

--- a/internal/serveui/static/slash-commands.js
+++ b/internal/serveui/static/slash-commands.js
@@ -102,7 +102,7 @@ const refreshSkillCommands = async (sessionId) => {
     ? app.requestHeaders(id)
     : { 'Content-Type': 'application/json', session_id: id };
   try {
-    const response = await fetch(`${prefix}/v1/sessions/${encodeURIComponent(id)}/skills`, { headers });
+    const response = await app.apiFetch(`${prefix}/v1/sessions/${encodeURIComponent(id)}/skills`, { headers });
     if (!response.ok) {
       if (generation === skillRefreshGeneration) setSkillCommands([]);
       return [];

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -12,6 +12,7 @@ const SHELL_ASSETS = [
   './active-response.js',
   './conversation.js',
   './app-core.js',
+  './app-network.js',
   './app-plan.js',
   './slash-commands.js',
   './app-render.js',


### PR DESCRIPTION
## What

Centralize browser network handling and make chat recovery predictable across HTTPS and WebRTC failures.

- add a shared `apiFetch` layer with explicit safe-read, idempotent-mutation, non-retryable-mutation, and stream policies
- separate authentication state from browser/backend connectivity state
- coordinate offline/online recovery through one health and reconciliation gate
- make both established-response and pre-response POST backoff wakeable
- share resumable stream recovery between response streams and isolated skill runs
- route first-party application requests through the common network layer
- persistently renegotiate degraded WebRTC in the background while HTTPS remains usable
- preserve ambiguous mutation outcomes rather than blindly replaying them
- add deterministic outage, flap, retry, auth, abort, and WebRTC regression coverage

## Why

The durable response stream already replayed missed events safely once a response ID existed, but failure handling around it was fragmented across feature modules.

The worst path was an initial message POST during a 20-second outage: five fast failures put it into a 60-second sleep at about 13.2 seconds, so connectivity returning at 20 seconds could still leave the message waiting roughly another 53 seconds. The initial POST now uses the same wakeable recovery mechanism as established streams and resumes immediately after coordinated health and transcript reconciliation.

The shared layer also makes the retry contract explicit: reads may retry, mutations retry only with an idempotency guarantee, and ambiguous unsafe WebRTC mutations surface an unknown outcome instead of being duplicated.

## Recovery behavior

For an active response:

1. show an explicit offline/recovering state
2. leave the server-side response run alive
3. suspend retries while the browser is explicitly offline
4. on restoration, perform one shared health/reconciliation pass
5. wake parked streams and replay from the last applied sequence
6. recover gaps from the response snapshot

For a pre-response POST, the message body, attachments, client message ID, request ID, and idempotency key remain stable across retries. Session switches cancel the parked retry.

## Review fixes

A Claude Opus review found and the final commit fixes:

- a double-flap recovery deadlock
- a post-recovery hot spin that could jump directly to the 60-second retry tier
- unsafe WebRTC handling when `dataChannel.send()` synchronously proved no frame was sent
- over-broad centralized 401 handling
- healthy streams being restarted on every visibility change
- caller aborts no longer propagating after response headers
- misleading pending-safe and automatic-retry status text
- unbounded/unisolated recovery hooks

Regression tests cover each path.

## Tests

- all 18 `internal/serveui/static/*_test.js` suites
- `go test ./internal/serveui`
- `go build ./...`
- isolated `go test ./...`
- `go vet ./...`
- `git diff --check`

The 20-second outage tests cover an established response, the initial POST before `x-response-id`, and WebRTC HTTPS fallback/recovery. They assert immediate wake after restoration, stable idempotency, no duplicated turn, and terminal replay where applicable.
