### PR TITLE
fix: escape wedged browser stream readers

### DIFF
--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -197,6 +197,9 @@ const parseSSEStream = async (stream, onEvent, options = {}) => {
     while (true) {
       const { value, done } = await reader.read();
       if (done) break;
+      // Ignore late bytes from a WebKit reader retired by heartbeat takeover
+      // before they refresh global liveness or project stale events.
+      if (abortController?._streamSuperseded) return;
 
       const decoded = decoder.decode(value, { stream: true });
       buffer += decoded.includes('\r') ? decoded.replace(/\r/g, '') : decoded;
@@ -284,9 +287,20 @@ const heartbeatUploadGraceThreshold = (bodyText = '') => {
     Math.max(HEARTBEAT_STALE_THRESHOLD, HEARTBEAT_STALE_THRESHOLD + Math.ceil((bytes / HEARTBEAT_UPLOAD_GRACE_BYTES_PER_SECOND) * 1000))
   );
 };
-// Deliberately not passed to AbortController.abort(): custom abort reasons can
-// make fetch reject with a raw string instead of an AbortError in some browsers.
+// Avoid custom abort reasons: some browsers reject fetch with the raw string.
 const HEARTBEAT_ABORT_REASON = 'heartbeat';
+const HEARTBEAT_TAKEOVER_GRACE = 1000;
+const scheduleHeartbeatTakeover = (controller) => {
+  if (!controller || controller._heartbeatTakeoverScheduled) return;
+  controller._heartbeatTakeoverScheduled = true;
+  const activityBaseline = Number(state.lastEventTime || 0);
+  window.setTimeout(() => {
+    controller._heartbeatTakeoverScheduled = false;
+    if (state.abortController !== controller || !controller._heartbeatAbort
+        || Number(state.lastEventTime || 0) > activityBaseline) return;
+    controller._heartbeatTakeover?.();
+  }, HEARTBEAT_TAKEOVER_GRACE);
+};
 
 const startHeartbeatMonitor = () => {
   stopHeartbeatMonitor();
@@ -310,6 +324,9 @@ const startHeartbeatMonitor = () => {
             Promise.resolve(controller._heartbeatCancelStream()).catch((err) => {
               console.warn('[stream] heartbeat body cancellation failed', err);
             });
+            // WebKit can leave reader.read() and reader.cancel() pending forever.
+            // After a brief grace, release the caller to resume over HTTP.
+            scheduleHeartbeatTakeover(controller);
           } else if (!controller._responseBodyAttached) {
             // Before response headers arrive there is no body reader to cancel.
             controller.abort();
@@ -621,10 +638,11 @@ const reduceHistoricalReplayEvent = (stage, event, payload) => {
   return true;
 };
 
-const mergeHistoricalReplayStage = async (session, _streamState, stage) => {
+const mergeHistoricalReplayStage = async (session, _streamState, stage, isCurrent) => {
   const transcript = session?.transcript;
   if (!transcript) throw new Error('historical replay requires a transcript');
-  await window.TermLLMConversation.enqueueDetachedReplay(transcript, stage.events);
+  const merged = await window.TermLLMConversation.enqueueDetachedReplay(transcript, stage.events, isCurrent);
+  if (!merged || !isCurrent()) return false;
   for (const item of stage.events) {
     if (item?.event !== 'response.interjection') continue;
     const payload = item.payload || {};
@@ -641,10 +659,10 @@ const mergeHistoricalReplayStage = async (session, _streamState, stage) => {
   app.persistPendingIntents?.(session);
   if (isSessionVisible(session)) renderMessages(false);
   else persistAndRefreshShell();
-  return stage.terminal;
+  return true;
 };
 
-const consumeResponseStream = async (stream, session, streamState, options = {}) => {
+const consumeResponseStreamInner = async (stream, session, streamState, options = {}) => {
   let sawTerminal = false;
   let sawDone = false;
   let sawRecoverableStreamError = false;
@@ -659,12 +677,21 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
   const replayStage = replayBoundaryPending
     ? createHistoricalReplayStage(expectedResponseId, replayAfterSequence, replayThroughSequence, options.runEpoch)
     : null;
+  const streamIsCurrent = () => {
+    if (options.abortController?._streamSuperseded || generation !== state.streamGeneration) return false;
+    const currentSessionId = state.currentStreamSessionId;
+    if (currentSessionId && sessionId && currentSessionId !== sessionId) return false;
+    const currentResponseId = state.currentStreamResponseId;
+    return !(expectedResponseId && currentResponseId && currentResponseId !== expectedResponseId);
+  };
 
   const completeReplayBoundary = async () => {
-    if (!replayBoundaryPending || stale || !replayStage || replayStage.appliedSequence < replayThroughSequence) return false;
+    if (!replayBoundaryPending || stale || !replayStage || replayStage.appliedSequence < replayThroughSequence || !streamIsCurrent()) return false;
     replayBoundaryPending = false;
     streamState.historicalReplayEvent = false;
-    const stagedTerminal = await mergeHistoricalReplayStage(session, streamState, replayStage);
+    const merged = await mergeHistoricalReplayStage(session, streamState, replayStage, streamIsCurrent);
+    if (!merged || !streamIsCurrent()) { stale = true; return false; }
+    const stagedTerminal = replayStage.terminal;
     if (stagedTerminal) {
       streamState.historicalReplayEvent = true;
       const result = app.applyResponseStreamEvent(session, streamState, stagedTerminal.event, stagedTerminal.payload);
@@ -684,15 +711,6 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
   const eventSequenceNumber = (payload) => {
     const seq = Number(payload?.sequence_number);
     return Number.isFinite(seq) && seq > 0 ? seq : 0;
-  };
-
-  const streamIsCurrent = () => {
-    if (generation !== state.streamGeneration) return false;
-    const currentSessionId = state.currentStreamSessionId;
-    if (currentSessionId && sessionId && currentSessionId !== sessionId) return false;
-    const currentResponseId = state.currentStreamResponseId;
-    if (expectedResponseId && currentResponseId && currentResponseId !== expectedResponseId) return false;
-    return true;
   };
 
   await parseSSEStream(stream, async (event, data) => {
@@ -794,6 +812,29 @@ const consumeResponseStream = async (stream, session, streamState, options = {})
   }, { abortController: options.abortController });
 
   return { terminal: sawTerminal || sawDone || !session.activeResponseId, stale, error: stale ? null : terminalError };
+};
+
+const consumeResponseStream = async (stream, session, streamState, options = {}) => {
+  const controller = options.abortController || null;
+  if (!controller) return consumeResponseStreamInner(stream, session, streamState, options);
+
+  let takeoverResolve;
+  const takeoverPromise = new Promise((resolve) => { takeoverResolve = resolve; });
+  const heartbeatTakeover = () => {
+    if (controller._streamSuperseded) return;
+    controller._streamSuperseded = true;
+    takeoverResolve({ terminal: false, stale: false, error: null, forcedHeartbeatRecovery: true });
+  };
+  controller._heartbeatTakeover = heartbeatTakeover;
+
+  try {
+    return await Promise.race([
+      consumeResponseStreamInner(stream, session, streamState, options),
+      takeoverPromise,
+    ]);
+  } finally {
+    if (controller._heartbeatTakeover === heartbeatTakeover) delete controller._heartbeatTakeover;
+  }
 };
 
 const fetchResponseSnapshot = async (session, responseId) => {
@@ -1429,6 +1470,7 @@ Object.assign(app, {
   flushStreamPersistence,
   scheduleStreamScroll,
   HEARTBEAT_STALE_THRESHOLD,
+  HEARTBEAT_TAKEOVER_GRACE,
   HEARTBEAT_ABORT_REASON,
   wakeResponseReconnect,
   resumeActiveResponse,

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -1688,6 +1688,59 @@ async function testParseSSEStreamUpdatesHeartbeatOnCommentFrame() {
   pass(name);
 }
 
+async function testSupersededReaderCannotRefreshHeartbeatOrProjectLateData() {
+  const name = 'superseded reader ignores late bytes before heartbeat and projection';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const controller = new AbortController();
+  const encoder = new TextEncoder();
+  let resolveRead;
+  let eventCount = 0;
+  const stream = {
+    getReader() {
+      return {
+        read() {
+          return new Promise((resolve) => {
+            resolveRead = resolve;
+          });
+        },
+        cancel() { return Promise.resolve(); },
+      };
+    },
+  };
+  state.lastEventTime = 1234;
+
+  const parsePromise = app.parseSSEStream(stream, () => {
+    eventCount += 1;
+    return true;
+  }, { abortController: controller });
+  const waiting = await waitFor(() => typeof resolveRead === 'function', 1000);
+  if (!waiting) {
+    fail(name, 'parser did not begin its pending read');
+    await cleanup();
+    return;
+  }
+
+  controller._streamSuperseded = true;
+  resolveRead({
+    done: false,
+    value: encoder.encode('event: response.output_text.delta\ndata: {"delta":"late","sequence_number":9}\n\n'),
+  });
+  await parsePromise;
+  await cleanup();
+
+  if (eventCount !== 0) {
+    fail(name, `late superseded event was projected ${eventCount} times`);
+    return;
+  }
+  if (state.lastEventTime !== 1234) {
+    fail(name, `late superseded bytes refreshed heartbeat to ${state.lastEventTime}`);
+    return;
+  }
+
+  pass(name);
+}
+
 async function testSendMessageHeartbeatCancelsPostStreamWithoutAbortingFetch() {
   const name = 'heartbeat timeout cancels an attached POST body without aborting fetch';
   const intervalCallbacks = [];
@@ -1756,6 +1809,116 @@ async function testSendMessageHeartbeatCancelsPostStreamWithoutAbortingFetch() {
 
   if (!resumed) {
     fail(name, 'heartbeat abort did not resume via /events');
+    return;
+  }
+
+  pass(name);
+}
+
+async function testHeartbeatTakeoverEscapesWedgedReaderCancellation() {
+  const name = 'heartbeat takeover resumes when reader cancellation never settles';
+  const intervalCallbacks = [];
+  let postReaderCanceled = false;
+  let eventsCount = 0;
+  const never = new Promise(() => {});
+  const harness = createHarness({
+    setTimeout(callback, ms) {
+      if (Number(ms) === 1000) return setTimeout(callback, 0);
+      return setTimeout(callback, ms);
+    },
+    clearTimeout(handle) { clearTimeout(handle); },
+    setInterval(callback) {
+      intervalCallbacks.push(callback);
+      return intervalCallbacks.length;
+    },
+    clearInterval() {},
+    fetchImpl: async (url, requestOptions, { Response, Headers, TextEncoder }) => {
+      if (url === '/ui/v1/responses' && (requestOptions.method || 'GET') === 'POST') {
+        const encoder = new TextEncoder();
+        const initialBody = [
+          'event: response.created\n',
+          'data: {"response":{"id":"resp_wedged","model":"test-model","status":"in_progress"},"sequence_number":1}\n\n',
+          'event: response.output_text.delta\n',
+          'data: {"response_id":"resp_wedged","delta":"partial","sequence_number":2}\n\n',
+        ].join('');
+        let readCount = 0;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'x-response-id': 'resp_wedged' }),
+          body: {
+            getReader() {
+              return {
+                read() {
+                  if (readCount++ === 0) {
+                    return Promise.resolve({ value: encoder.encode(initialBody), done: false });
+                  }
+                  return never;
+                },
+                cancel() {
+                  postReaderCanceled = true;
+                  return never;
+                },
+              };
+            },
+          },
+        };
+      }
+      if (url.startsWith('/ui/v1/responses/resp_wedged/events?after=')) {
+        eventsCount += 1;
+        const body = [
+          'event: response.completed\n',
+          'data: {"response":{"id":"resp_wedged","model":"test-model","status":"completed"},"response_id":"resp_wedged","sequence_number":3}\n\n',
+          'data: [DONE]\n\n',
+        ].join('');
+        return new Response(body, {
+          status: 200,
+          headers: { 'X-Term-LLM-Replay-Through': '2' },
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    },
+  });
+  const { app, elements, state, cleanup } = harness;
+  elements.promptInput.value = 'hello';
+
+  const sendPromise = app.sendMessage();
+  const attached = await waitFor(() => (
+    state.currentStreamResponseId === 'resp_wedged'
+    && typeof state.abortController?._heartbeatCancelStream === 'function'
+    && intervalCallbacks.length > 0
+  ), 1000);
+  if (!attached) {
+    fail(name, 'POST stream did not reach the wedged reader');
+    await cleanup();
+    return;
+  }
+
+  const controller = state.abortController;
+  state.lastEventTime = Date.now() - app.HEARTBEAT_STALE_THRESHOLD - 1;
+  intervalCallbacks[intervalCallbacks.length - 1]();
+
+  const resumed = await waitFor(() => eventsCount > 0, 1000);
+  const settled = await Promise.race([
+    sendPromise.then(() => true, () => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 1000)),
+  ]);
+  await cleanup();
+
+  if (!postReaderCanceled) {
+    fail(name, 'heartbeat did not attempt normal reader cancellation first');
+    return;
+  }
+  if (!controller._streamSuperseded || controller.signal.aborted) {
+    fail(name, 'wedged reader was not superseded safely');
+    return;
+  }
+  if (!resumed || eventsCount !== 1) {
+    fail(name, `expected one independent replay request, got ${eventsCount}`);
+    return;
+  }
+  if (!settled) {
+    fail(name, 'send remained blocked behind the wedged reader');
     return;
   }
 
@@ -3659,6 +3822,119 @@ async function testResumeActiveResponseHeartbeatCancelSlowsAndRecovers() {
   pass(name);
 }
 
+async function testResumeHeartbeatTakeoverEscapesWedgedReplayReader() {
+  const name = 'resume heartbeat takeover replaces a wedged replay reader';
+  const responseId = 'resp_wedged_replay';
+  const intervalCallbacks = [];
+  const never = new Promise(() => {});
+  let eventsCount = 0;
+  let firstReaderCanceled = false;
+  const harness = createHarness({
+    responseId,
+    setTimeout(callback, ms) {
+      if (Number(ms) === 1000) return setTimeout(callback, 0);
+      return setTimeout(callback, ms);
+    },
+    clearTimeout(handle) { clearTimeout(handle); },
+    setInterval(callback) {
+      intervalCallbacks.push(callback);
+      return intervalCallbacks.length;
+    },
+    clearInterval() {},
+    fetchImpl: async (url, _requestOptions, { Response, Headers, TextEncoder }) => {
+      if (!url.startsWith(`/ui/v1/responses/${responseId}/events?after=`)) {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      eventsCount += 1;
+      const encoder = new TextEncoder();
+      if (eventsCount === 1) {
+        const initialBody = [
+          'event: response.created\n',
+          `data: {"response":{"id":"${responseId}","model":"test-model","status":"in_progress"},"sequence_number":1}\n\n`,
+        ].join('');
+        let readCount = 0;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'X-Term-LLM-Replay-Through': '0' }),
+          body: {
+            getReader() {
+              return {
+                read() {
+                  if (readCount++ === 0) {
+                    return Promise.resolve({ value: encoder.encode(initialBody), done: false });
+                  }
+                  return never;
+                },
+                cancel() {
+                  firstReaderCanceled = true;
+                  return never;
+                },
+              };
+            },
+          },
+        };
+      }
+      const terminalBody = [
+        'event: response.completed\n',
+        `data: {"response":{"id":"${responseId}","model":"test-model","status":"completed"},"response_id":"${responseId}","sequence_number":2}\n\n`,
+        'data: [DONE]\n\n',
+      ].join('');
+      return new Response(terminalBody, {
+        status: 200,
+        headers: { 'X-Term-LLM-Replay-Through': '1' },
+      });
+    },
+  });
+  const { app, state, cleanup } = harness;
+  const session = {
+    id: 'session_wedged_replay',
+    title: 'Wedged replay',
+    messages: [],
+    lastResponseId: null,
+    activeResponseId: responseId,
+    lastSequenceNumber: 0,
+    number: 1,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+
+  const resumePromise = app.resumeActiveResponse(session, { responseId });
+  const attached = await waitFor(() => (
+    eventsCount === 1
+    && app.responseEventSequence(session, responseId) === 1
+    && typeof state.abortController?._heartbeatCancelStream === 'function'
+    && intervalCallbacks.length > 0
+  ), 1000);
+  if (!attached) {
+    fail(name, 'first replay reader did not wedge after applying its cursor');
+    await cleanup();
+    return;
+  }
+
+  const firstController = state.abortController;
+  state.lastEventTime = Date.now() - app.HEARTBEAT_STALE_THRESHOLD - 1;
+  intervalCallbacks[intervalCallbacks.length - 1]();
+
+  const recovered = await waitFor(() => eventsCount === 2 && !session.activeResponseId, 1000);
+  const settled = await Promise.race([
+    resumePromise.then(() => true, () => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 1000)),
+  ]);
+  await cleanup();
+
+  if (!firstReaderCanceled || !firstController._streamSuperseded || firstController.signal.aborted) {
+    fail(name, 'wedged replay reader was not superseded safely');
+    return;
+  }
+  if (!recovered || !settled) {
+    fail(name, `replay did not recover independently; events=${eventsCount}, settled=${settled}`);
+    return;
+  }
+
+  pass(name);
+}
+
 async function testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop() {
   const name = 'established response survives a 20-second outage and wakes with exact replay';
   const responseId = 'resp_wakeable_retry';
@@ -5356,6 +5632,77 @@ async function testHistoricalReplayCommitsExactInterjectionBeforeFreshEvents() {
   }
 
   await cleanup();
+  pass(name);
+}
+
+async function testHeartbeatTakeoverRetiresQueuedHistoricalReplay() {
+  const name = 'heartbeat takeover retires historical replay queued behind transcript work';
+  const responseId = 'resp_queued_replay_takeover';
+  const harness = createHarness({ responseId });
+  const { app, state, cleanup } = harness;
+  const session = {
+    id: 'session_queued_replay_takeover',
+    title: 'Queued replay takeover',
+    messages: [],
+    activeResponseId: responseId,
+    latestRunEpoch: 1,
+    lastSequenceNumber: 0,
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  session.transcript = new ConversationController(session.id);
+  session.transcript.setActiveRun(responseId, 0, 1);
+
+  let releaseBlocker;
+  let blockerStarted = false;
+  void session.transcript.commands.enqueue(() => new Promise((resolve) => {
+    blockerStarted = true;
+    releaseBlocker = resolve;
+  }));
+  const controller = new AbortController();
+  app.attachResponseStream(session, responseId, controller);
+  const body = strictResponseBytes([
+    'event: response.output_text.delta\n',
+    `data: {"response_id":"${responseId}","run_epoch":1,"sequence_number":1,"assistant_segment_ordinal":0,"delta":"stale"}\n\n`,
+    'data: [DONE]\n\n',
+  ].join(''), responseId, 1);
+  const stream = new ReadableStream({
+    start(streamController) {
+      streamController.enqueue(body);
+      streamController.close();
+    },
+  });
+
+  const consumePromise = app.consumeResponseStream(stream, session, app.createResponseStreamState(session), {
+    responseId,
+    runEpoch: 1,
+    replayAfterSequence: 0,
+    replayThroughSequence: 1,
+    abortController: controller,
+  });
+  const queued = await waitFor(() => blockerStarted && typeof controller._heartbeatTakeover === 'function', 1000);
+  if (!queued) {
+    fail(name, 'historical replay did not queue behind the transcript blocker');
+    releaseBlocker?.();
+    await cleanup();
+    return;
+  }
+
+  controller._heartbeatTakeover();
+  const result = await consumePromise;
+  releaseBlocker();
+  await session.transcript.commands.enqueue(() => true);
+  await cleanup();
+
+  if (!result.forcedHeartbeatRecovery || !controller._streamSuperseded) {
+    fail(name, 'heartbeat did not supersede the queued replay consumer');
+    return;
+  }
+  if (app.responseEventSequence(session, responseId) !== 0 || projectedMessages(session).length !== 0) {
+    fail(name, 'superseded queued replay mutated transcript state', JSON.stringify(projectedMessages(session)));
+    return;
+  }
+
   pass(name);
 }
 
@@ -7596,7 +7943,9 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testInactiveSessionFailureDoesNotMutateProjectionOrVisibleDOM();
   await testConsumeResponseStreamReportsStaleWithoutApplyingEvents();
   await testParseSSEStreamUpdatesHeartbeatOnCommentFrame();
+  await testSupersededReaderCannotRefreshHeartbeatOrProjectLateData();
   await testSendMessageHeartbeatCancelsPostStreamWithoutAbortingFetch();
+  await testHeartbeatTakeoverEscapesWedgedReaderCancellation();
   await testSendMessageHeartbeatCancellationWithoutResponseIDRetriesPost();
   await testSendMessageHeartbeatAbortRetriesBeforeResponseId();
   await testSendMessageLargeUploadUsesLongerPreResponseHeartbeatGrace();
@@ -7649,6 +7998,7 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testToolExecImagesAttachToToolArtifactNotAssistantMarkdown();
   await testToolExecImagesUseHubAssetRebase();
   await testResumeActiveResponseHeartbeatCancelSlowsAndRecovers();
+  await testResumeHeartbeatTakeoverEscapesWedgedReplayReader();
   await testResumeReconnectBackoffCanBeWokenWithoutDuplicateLoop();
   await testDetachDuringSlowReconnectTransfersResumeOwnership();
   await testResumeActiveResponseFallsBackToReplayWhenSnapshotUnavailable();
@@ -7685,6 +8035,7 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testPendingInterjectionsRenderAsCancellableStack();
   await testInterjectionClassificationPreservesStackOrder();
   await testHistoricalReplayCommitsExactInterjectionBeforeFreshEvents();
+  await testHeartbeatTakeoverRetiresQueuedHistoricalReplay();
   await testPendingInterjectionCanCancelWhileClassifying();
   await testClassificationCancelDeletesAcceptedInterjection();
   await testInterruptRecoveryDoesNotResurrectClassificationCancel();

--- a/internal/serveui/static/conversation.js
+++ b/internal/serveui/static/conversation.js
@@ -440,7 +440,9 @@
     return controller?.applyResponseEvent(event, payload) || null;
   };
   const replaceRunSnapshot = (controller, payload) => controller?.replaceActiveSnapshot(payload);
-  const enqueueDetachedReplay = (controller, events) => controller?.commands.enqueue(() => controller.applyDetachedReplay(events));
+  const enqueueDetachedReplay = (controller, events, shouldApply) => controller?.commands.enqueue(() => (
+    !shouldApply || shouldApply() ? controller.applyDetachedReplay(events) : null
+  ));
   const addPendingIntentToConversation = (controller, intent, rev) => controller?.addPendingIntent(intent, rev);
   const applyTranscriptIndex = (controller, index, etag = '', tail = false) => {
     controller.applyIndex(index, etag);


### PR DESCRIPTION
## What

Make WebUI response recovery independent of a browser `ReadableStream` reader successfully unwinding.

After the existing 30-second heartbeat threshold:

- keep the current best-effort `reader.cancel()` path;
- give normal cancellation a 1-second grace period;
- if `reader.read()` / `reader.cancel()` is still wedged, resolve a controller-local takeover promise so the caller can resume via `/events?after=<last sequence>` without waiting for the old reader;
- mark the old reader superseded so late bytes cannot refresh global heartbeat state or project stale events;
- guard queued historical replay commits with transport ownership checks, including inside the transcript command queue.

Unsafe mutations are unchanged: this only takes over response body consumption after a response has been established.

## Why

On iOS Safari we observed a response replay request complete successfully at nginx, but the browser never issued the next `events?after=...` request. The rest of the page remained interactive and a reload reconstructed the completed response from the durable transcript.

The existing heartbeat monitor called `reader.cancel()`, but the recovery loop was still serialized behind `await reader.read()`. WebKit can leave both promises pending indefinitely, putting the liveness supervisor inside the operation it needs to escape.

## Safety

The replacement stream resumes from the response-scoped sequence cursor. Existing duplicate suppression, gap detection, replay boundaries, and snapshot recovery remain authoritative.

A superseded reader is prevented from:

- updating `lastEventTime` with late bytes;
- applying late stream events;
- committing historical replay that was queued behind other transcript work;
- clearing or overwriting replacement transport ownership.

## Tests

Added regressions for:

- a POST response reader whose `read()` and `cancel()` never settle;
- an `/events` replay reader whose `read()` and `cancel()` never settle;
- late bytes released by a superseded reader;
- historical replay blocked in the transcript command queue during takeover.

Verified:

- `go test ./internal/serveui`
- `HOME=<clean temp> go test ./...`
- `go build ./...`
