### PR TITLE
fix: Concurrent Telegram handlers can execute and persist same-chat messages out of order

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -507,10 +507,11 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 				bot.StopReceivingUpdates()
 				return nil
 			}
-			go func(msg *tgbotapi.Message) {
+			admission := mgr.admitMessage(update.Message)
+			go func(msg *tgbotapi.Message, admission *telegramMessageAdmission) {
 				defer mgr.releaseMessageSlot()
-				mgr.handleMessage(ctx, bot, msg)
-			}(update.Message)
+				mgr.handleMessageWithAdmission(ctx, bot, msg, admission)
+			}(update.Message, admission)
 		}
 	}
 }
@@ -547,6 +548,61 @@ func (m *telegramSessionMgr) acquireMessageSlot(ctx context.Context) bool {
 
 func (m *telegramSessionMgr) releaseMessageSlot() {
 	<-m.messageSlots
+}
+
+type telegramMessageAdmission struct {
+	mgr    *telegramSessionMgr
+	chatID int64
+	ready  <-chan struct{}
+	done   chan struct{}
+	once   sync.Once
+}
+
+func (m *telegramSessionMgr) admitMessage(msg *tgbotapi.Message) *telegramMessageAdmission {
+	if msg == nil || msg.Chat == nil {
+		return nil
+	}
+
+	m.admissionMu.Lock()
+	defer m.admissionMu.Unlock()
+	if m.messageAdmissions == nil {
+		m.messageAdmissions = make(map[int64]chan struct{})
+	}
+	chatID := msg.Chat.ID
+	admission := &telegramMessageAdmission{
+		mgr:    m,
+		chatID: chatID,
+		ready:  m.messageAdmissions[chatID],
+		done:   make(chan struct{}),
+	}
+	m.messageAdmissions[chatID] = admission.done
+	return admission
+}
+
+func (a *telegramMessageAdmission) wait(ctx context.Context) bool {
+	if a == nil || a.ready == nil {
+		return true
+	}
+	select {
+	case <-a.ready:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (a *telegramMessageAdmission) release() {
+	if a == nil {
+		return
+	}
+	a.once.Do(func() {
+		close(a.done)
+		a.mgr.admissionMu.Lock()
+		if a.mgr.messageAdmissions[a.chatID] == a.done {
+			delete(a.mgr.messageAdmissions, a.chatID)
+		}
+		a.mgr.admissionMu.Unlock()
+	})
 }
 
 // telegramSession holds per-chat conversation state.
@@ -590,8 +646,12 @@ type telegramSessionMgr struct {
 	allowedUserIDs   map[int64]struct{}
 	allowedUsernames map[string]struct{}
 	messageSlots     chan struct{}
-	tickerInterval   time.Duration // 0 means use default (500ms); overridden in tests
-	editInterval     time.Duration // 0 means use minEditInterval; overridden in tests
+
+	admissionMu       sync.Mutex
+	messageAdmissions map[int64]chan struct{}
+
+	tickerInterval time.Duration // 0 means use default (500ms); overridden in tests
+	editInterval   time.Duration // 0 means use minEditInterval; overridden in tests
 
 	// streamEventTimeout bounds how long the stream watchdog waits between events
 	// before declaring the stream dead. 0 means use defaultStreamEventTimeout.
@@ -1237,6 +1297,11 @@ func (m *telegramSessionMgr) persistedAssistantTextMatches(ctx context.Context, 
 }
 
 func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot telegramBot, msg *tgbotapi.Message) {
+	m.handleMessageWithAdmission(ctx, bot, msg, m.admitMessage(msg))
+}
+
+func (m *telegramSessionMgr) handleMessageWithAdmission(ctx context.Context, bot telegramBot, msg *tgbotapi.Message, admission *telegramMessageAdmission) {
+	defer admission.release()
 	if msg.From == nil {
 		log.Printf("[telegram] ignoring message with no sender")
 		return
@@ -1247,6 +1312,9 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot telegramBot,
 	}
 
 	chatID := msg.Chat.ID
+	if !admission.wait(ctx) {
+		return
+	}
 
 	if msg.IsCommand() {
 		switch msg.Command() {
@@ -1474,7 +1542,7 @@ func (m *telegramSessionMgr) handleMessage(ctx context.Context, bot telegramBot,
 	sess.streamToolName.Store("")
 	sess.cancelMu.Unlock()
 
-	if err := m.streamReply(ctx, bot, sess, chatID, userMsg); err != nil {
+	if err := m.streamReplyWithAdmission(ctx, bot, sess, chatID, userMsg, admission.release); err != nil {
 		log.Printf("[telegram] error streaming reply for chat %d: %v", chatID, err)
 		_, _ = bot.Send(tgbotapi.NewMessage(chatID, "Sorry, an error occurred: "+err.Error()))
 	}
@@ -1496,6 +1564,10 @@ func sendStreamDone(done chan<- error, once *sync.Once, err error) {
 
 // streamReply streams an LLM response back to the chat via live message editing.
 func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, sess *telegramSession, chatID int64, userMsg llm.Message) error {
+	return m.streamReplyWithAdmission(ctx, bot, sess, chatID, userMsg, nil)
+}
+
+func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot botSender, sess *telegramSession, chatID int64, userMsg llm.Message, releaseAdmission func()) error {
 	// We acquire the session lock for the entire streaming call so that
 	// concurrent messages from the same chat are serialised.
 	sess.mu.Lock()
@@ -1611,6 +1683,12 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 		m.runStoreOp(ctx, sess.meta.ID, "UpdateStatus(active)", func(storeCtx context.Context) error {
 			return m.store.UpdateStatus(storeCtx, sess.meta.ID, session.StatusActive)
 		})
+	}
+
+	// The turn is now durably ordered and its cancellation state is visible.
+	// Let the next same-chat message inspect or interrupt it before provider output completes.
+	if releaseAdmission != nil {
+		releaseAdmission()
 	}
 
 	// Collect assistant and tool-result messages via callbacks.

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -3082,6 +3082,201 @@ func (s *oneShotTextStream) Recv() (llm.Event, error) {
 }
 func (s *oneShotTextStream) Close() error { return nil }
 
+type admissionOrderProvider struct {
+	requests              chan llm.Request
+	firstChunkSent        chan struct{}
+	firstContextCancelled chan struct{}
+	streamCount           atomic.Int32
+}
+
+func newAdmissionOrderProvider() *admissionOrderProvider {
+	return &admissionOrderProvider{
+		requests:              make(chan llm.Request, 2),
+		firstChunkSent:        make(chan struct{}),
+		firstContextCancelled: make(chan struct{}),
+	}
+}
+
+func (p *admissionOrderProvider) Name() string                   { return "admission-order" }
+func (p *admissionOrderProvider) Credential() string             { return "mock" }
+func (p *admissionOrderProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+func (p *admissionOrderProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	p.requests <- req
+	if p.streamCount.Add(1) == 1 {
+		return &cancelAwareBlockingStream{
+			ctx:                   ctx,
+			text:                  "photo answer",
+			firstChunkSent:        p.firstChunkSent,
+			firstContextCancelled: p.firstContextCancelled,
+			closed:                make(chan struct{}),
+		}, nil
+	}
+	return &oneShotTextStream{text: "clarified answer"}, nil
+}
+
+func testMessageHasImage(msg llm.Message) bool {
+	for _, part := range msg.Parts {
+		if part.Type == llm.PartImage {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHandleMessage_PreservesArrivalOrderAcrossPhotoDownload(t *testing.T) {
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "telegram-admission-order.db")})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer store.Close()
+
+	provider := newAdmissionOrderProvider()
+	mgr := &telegramSessionMgr{
+		sessions:         make(map[int64]*telegramSession),
+		store:            store,
+		allowedUserIDs:   map[int64]struct{}{7: {}},
+		idleTimeout:      time.Hour,
+		interruptTimeout: time.Second,
+		tickerInterval:   5 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       llm.NewEngine(provider, llm.NewToolRegistry()),
+					ProviderName: "mock",
+					ModelName:    "test",
+				}, nil
+			},
+		},
+	}
+
+	downloadStarted := make(chan struct{})
+	releaseDownload := make(chan struct{})
+	var releaseOnce sync.Once
+	releasePhoto := func() { releaseOnce.Do(func() { close(releaseDownload) }) }
+	defer releasePhoto()
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-downloadStarted:
+		default:
+			close(downloadStarted)
+		}
+		select {
+		case <-releaseDownload:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte{0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08})
+	}))
+	defer imageServer.Close()
+	bot := &fakeBotSender{fileURL: imageServer.URL}
+
+	photoMessage := &tgbotapi.Message{
+		MessageID: 1,
+		From:      &tgbotapi.User{ID: 7, UserName: "sam"},
+		Chat:      &tgbotapi.Chat{ID: 42},
+		Caption:   "first photo",
+		Photo:     []tgbotapi.PhotoSize{{FileID: "photo-1", Width: 800, Height: 600}},
+	}
+	textMessage := &tgbotapi.Message{
+		MessageID: 2,
+		From:      &tgbotapi.User{ID: 7, UserName: "sam"},
+		Chat:      &tgbotapi.Chat{ID: 42},
+		Text:      "stop and use this clarification",
+	}
+	photoAdmission := mgr.admitMessage(photoMessage)
+	textAdmission := mgr.admitMessage(textMessage)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	photoDone := make(chan struct{})
+	go func() {
+		mgr.handleMessageWithAdmission(ctx, bot, photoMessage, photoAdmission)
+		close(photoDone)
+	}()
+	select {
+	case <-downloadStarted:
+	case <-ctx.Done():
+		t.Fatal("photo download did not start")
+	}
+
+	textDone := make(chan struct{})
+	go func() {
+		mgr.handleMessageWithAdmission(ctx, bot, textMessage, textAdmission)
+		close(textDone)
+	}()
+	select {
+	case req := <-provider.requests:
+		t.Fatalf("later text reached provider while earlier photo was downloading: %+v", req.Messages)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releasePhoto()
+	var firstRequest llm.Request
+	select {
+	case firstRequest = <-provider.requests:
+	case <-ctx.Done():
+		t.Fatal("photo did not reach provider after download completed")
+	}
+	if got := collectUserText(firstRequest.Messages[len(firstRequest.Messages)-1]); got != "first photo" {
+		t.Fatalf("first provider request user message = %q, want photo caption", got)
+	}
+	if !testMessageHasImage(firstRequest.Messages[len(firstRequest.Messages)-1]) {
+		t.Fatal("first provider request did not contain the photo")
+	}
+	select {
+	case <-provider.firstChunkSent:
+	case <-ctx.Done():
+		t.Fatal("photo stream did not start")
+	}
+
+	var secondRequest llm.Request
+	select {
+	case secondRequest = <-provider.requests:
+	case <-ctx.Done():
+		t.Fatal("clarification did not reach provider")
+	}
+	if got := collectUserText(secondRequest.Messages[len(secondRequest.Messages)-1]); got != textMessage.Text {
+		t.Fatalf("second provider request user message = %q, want %q", got, textMessage.Text)
+	}
+	select {
+	case <-photoDone:
+	case <-ctx.Done():
+		t.Fatal("photo handler did not finish after interruption")
+	}
+	select {
+	case <-textDone:
+	case <-ctx.Done():
+		t.Fatal("text handler did not finish")
+	}
+
+	mgr.mu.Lock()
+	sess := mgr.sessions[42]
+	mgr.mu.Unlock()
+	if sess == nil || sess.meta == nil {
+		t.Fatal("telegram session was not created")
+	}
+	persisted, err := store.GetMessages(ctx, sess.meta.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("get persisted messages: %v", err)
+	}
+	var userMessages []session.Message
+	for _, msg := range persisted {
+		if msg.Role == llm.RoleUser {
+			userMessages = append(userMessages, msg)
+		}
+	}
+	if len(userMessages) != 2 {
+		t.Fatalf("persisted user messages = %+v, want two", userMessages)
+	}
+	if userMessages[0].TextContent != "first photo" || userMessages[1].TextContent != textMessage.Text {
+		t.Fatalf("persisted user message order = [%q, %q]", userMessages[0].TextContent, userMessages[1].TextContent)
+	}
+	if userMessages[0].Sequence >= userMessages[1].Sequence {
+		t.Fatalf("persisted user sequences = [%d, %d], want arrival order", userMessages[0].Sequence, userMessages[1].Sequence)
+	}
+}
+
 func TestHandleMessage_CancelInterruptIsNotBlockedBySessionMutex(t *testing.T) {
 	provider := newInterruptSequenceProvider()
 	mgr := &telegramSessionMgr{


### PR DESCRIPTION
## What changed

- Assign each Telegram update a per-chat FIFO admission token before its handler goroutine starts.
- Hold admission through preprocessing, session lookup, interrupt-state observation, and user-turn persistence.
- Release admission once the active stream state is installed and the user turn is durably ordered, before waiting for provider output, so the next message can still interrupt the established run.
- Add a regression test with a blocked photo download followed by text; it verifies provider request order, photo preservation, and persisted user-message sequence.

## Why this is high-value

A rapid photo-plus-clarification flow is normal Jarvis usage. Previously, the later text could overtake a downloading photo, start provider work, and then be cancelled by the earlier photo handler. That wasted work and permanently reversed the conversation chronology. Per-chat admission prevents that race without reducing concurrency between different chats or preventing follow-up interruption of an active response.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_test.go`
- `go build ./...`
- `HOME="$TEST_ROOT/home" XDG_CONFIG_HOME="$TEST_ROOT/config" CODEX_HOME="$TEST_ROOT/codex" go test ./...`
- `go test -race ./internal/serve -run TestHandleMessage_PreservesArrivalOrderAcrossPhotoDownload -count=1`
- `go test ./internal/serve -run TestHandleMessage_PreservesArrivalOrderAcrossPhotoDownload -count=20`
- `git diff --check`
