### PR TITLE
perf: make cached web reloads immediate

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -676,6 +676,23 @@ func TestAppNetworkJS(t *testing.T) {
 	}
 }
 
+func TestServiceWorkerJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping service-worker tests")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "sw_test.js")
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("sw_test.js failed: %v", err)
+	}
+}
+
 func TestAppWebRTCJS(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {

--- a/internal/serveui/static/app-network.js
+++ b/internal/serveui/static/app-network.js
@@ -524,7 +524,11 @@ if (typeof window.addEventListener === 'function') {
     noteDiagnostic('offline', { waiters: waiters.size });
   });
   window.addEventListener('online', () => { void runCoordinatedNetworkRecovery('online'); });
-  window.addEventListener('pageshow', () => { if (online()) void runCoordinatedNetworkRecovery('pageshow'); });
+  // A normal pageshow fires during every initial load, when startup requests are
+  // already proving connectivity. Only BFCache restoration needs a recovery pass.
+  window.addEventListener('pageshow', (event) => {
+    if (event?.persisted && online()) void runCoordinatedNetworkRecovery('pageshow');
+  });
 }
 if (typeof document?.addEventListener === 'function') {
   document.addEventListener('visibilitychange', () => {

--- a/internal/serveui/static/app-network.js
+++ b/internal/serveui/static/app-network.js
@@ -524,10 +524,18 @@ if (typeof window.addEventListener === 'function') {
     noteDiagnostic('offline', { waiters: waiters.size });
   });
   window.addEventListener('online', () => { void runCoordinatedNetworkRecovery('online'); });
-  // A normal pageshow fires during every initial load, when startup requests are
-  // already proving connectivity. Only BFCache restoration needs a recovery pass.
   window.addEventListener('pageshow', (event) => {
-    if (event?.persisted && online()) void runCoordinatedNetworkRecovery('pageshow');
+    if (!online()) return;
+    if (event?.persisted) {
+      void runCoordinatedNetworkRecovery('pageshow');
+      return;
+    }
+    // Initial startup requests already prove connectivity. Give them a bounded
+    // head start, then bootstrap recovery only if none has succeeded.
+    window.setTimeout(() => {
+      if (state?.connected || state?.connectivity?.lastSuccessAt || !online()) return;
+      void runCoordinatedNetworkRecovery('startup-pageshow');
+    }, 2000);
   });
 }
 if (typeof document?.addEventListener === 'function') {

--- a/internal/serveui/static/app-session-events.js
+++ b/internal/serveui/static/app-session-events.js
@@ -351,8 +351,8 @@ window.addEventListener('offline', () => {
   app.setConnectivityState?.({ network: 'offline', phase: 'offline' });
 });
 
-window.addEventListener('pageshow', async () => {
+window.addEventListener('pageshow', async (event) => {
   restorePageTailOwnership();
-  if (state.connected) await app.runCoordinatedNetworkRecovery?.('pageshow');
+  if (event?.persisted && state.connected) await app.runCoordinatedNetworkRecovery?.('pageshow');
 });
 })();

--- a/internal/serveui/static/app_network_test.js
+++ b/internal/serveui/static/app_network_test.js
@@ -332,7 +332,7 @@ async function testRecoveryHooksAreIsolatedAndBounded() {
   console.log('PASS: recovery hooks run independently, time out, and cannot strand waiters');
 }
 
-async function testNormalPageShowSkipsRecoveryProbe() {
+async function testNormalPageShowDefersRecoveryProbe() {
   const calls = [];
   const harness = createHarness(async (url) => {
     calls.push(String(url));
@@ -340,11 +340,30 @@ async function testNormalPageShowSkipsRecoveryProbe() {
   });
 
   await harness.dispatch('pageshow', { persisted: false });
-  assert(calls.length === 0, 'normal initial pageshow performed a redundant health probe');
+  assert(calls.length === 0, 'normal initial pageshow performed an immediate redundant health probe');
+  await harness.app.apiFetch('/ui/v1/models');
+  await harness.advance(2000);
+  assert(calls.length === 1 && calls[0] === '/ui/v1/models', 'successful startup did not suppress the deferred health probe');
 
-  await harness.dispatch('pageshow', { persisted: true });
-  assert(calls.length === 1 && calls[0] === '/ui/v1/providers', 'BFCache pageshow did not perform one recovery probe');
-  console.log('PASS: normal pageshow skips recovery while BFCache restoration still probes');
+  const failedStartupCalls = [];
+  const failedStartup = createHarness(async (url) => {
+    failedStartupCalls.push(String(url));
+    return new Response('{}', { status: 200 });
+  });
+  await failedStartup.dispatch('pageshow', { persisted: false });
+  await failedStartup.advance(1999);
+  assert(failedStartupCalls.length === 0, 'startup recovery probe fired before its grace period');
+  await failedStartup.advance(1);
+  assert(failedStartupCalls.length === 1 && failedStartupCalls[0] === '/ui/v1/providers', 'failed startup did not bootstrap recovery after its grace period');
+
+  const restoredCalls = [];
+  const restored = createHarness(async (url) => {
+    restoredCalls.push(String(url));
+    return new Response('{}', { status: 200 });
+  });
+  await restored.dispatch('pageshow', { persisted: true });
+  assert(restoredCalls.length === 1 && restoredCalls[0] === '/ui/v1/providers', 'BFCache pageshow did not perform one immediate recovery probe');
+  console.log('PASS: normal pageshow defers recovery, successful startup suppresses it, and failed startup/BFCache still probe');
 }
 
 async function testStreamRecoveryHasNoPostWakeHotSpin() {
@@ -376,7 +395,7 @@ async function testStreamRecoveryHasNoPostWakeHotSpin() {
   await testFailedProbeDoesNotReleaseRetries();
   await testDoubleFlapDoesNotDeadlockHookWaiter();
   await testRecoveryHooksAreIsolatedAndBounded();
-  await testNormalPageShowSkipsRecoveryProbe();
+  await testNormalPageShowDefersRecoveryProbe();
   await testStreamRecoveryHasNoPostWakeHotSpin();
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : error);

--- a/internal/serveui/static/app_network_test.js
+++ b/internal/serveui/static/app_network_test.js
@@ -81,8 +81,8 @@ function createHarness(fetchImpl, online = true) {
       await flush();
     }
   };
-  const dispatch = async (type) => {
-    for (const handler of listeners.get(type) || []) handler({ type });
+  const dispatch = async (type, detail = {}) => {
+    for (const handler of listeners.get(type) || []) handler({ type, ...detail });
     await flush();
   };
   return {
@@ -332,6 +332,21 @@ async function testRecoveryHooksAreIsolatedAndBounded() {
   console.log('PASS: recovery hooks run independently, time out, and cannot strand waiters');
 }
 
+async function testNormalPageShowSkipsRecoveryProbe() {
+  const calls = [];
+  const harness = createHarness(async (url) => {
+    calls.push(String(url));
+    return new Response('{}', { status: 200 });
+  });
+
+  await harness.dispatch('pageshow', { persisted: false });
+  assert(calls.length === 0, 'normal initial pageshow performed a redundant health probe');
+
+  await harness.dispatch('pageshow', { persisted: true });
+  assert(calls.length === 1 && calls[0] === '/ui/v1/providers', 'BFCache pageshow did not perform one recovery probe');
+  console.log('PASS: normal pageshow skips recovery while BFCache restoration still probes');
+}
+
 async function testStreamRecoveryHasNoPostWakeHotSpin() {
   const harness = createHarness(async () => new Response('{}', { status: 200 }));
   const raced = harness.app.createResumableStreamRecovery({ key: 'stream:race' });
@@ -361,6 +376,7 @@ async function testStreamRecoveryHasNoPostWakeHotSpin() {
   await testFailedProbeDoesNotReleaseRetries();
   await testDoubleFlapDoesNotDeadlockHookWaiter();
   await testRecoveryHooksAreIsolatedAndBounded();
+  await testNormalPageShowSkipsRecoveryProbe();
   await testStreamRecoveryHasNoPostWakeHotSpin();
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : error);

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -4475,7 +4475,7 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   await app.stopSidebarStatusPoll();
   onlineStatusCompleted = false;
   await onlineHandler({ type: 'online' });
-  await pageshowHandler({ type: 'pageshow', persisted: false });
+  await pageshowHandler({ type: 'pageshow', persisted: true });
 
   const want = [
     'visibility:sess_wake_signals:resp_wake_signals',

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -1,4 +1,7 @@
 const SHELL_CACHE = 'term-llm-shell-v3';
+const SHELL_VERSION = SHELL_CACHE.slice('term-llm-shell-'.length);
+const NAVIGATION_NETWORK_BUDGET_MS = 100;
+let shellRefreshPending = false;
 const SHELL_ASSETS = [
   './',
   './index.html',
@@ -51,6 +54,19 @@ const putIfCacheable = async (cache, request, response) => {
   return response;
 };
 
+const refreshShellIfCompatible = async (cachePromise, responsePromise) => {
+  const [cache, response] = await Promise.all([cachePromise, responsePromise]);
+  if (!cache || !response?.ok) return response;
+  try {
+    const html = await response.clone().text();
+    if (!html.includes(`window.TERM_LLM_UI_VERSION="${SHELL_VERSION}"`)) return response;
+    await putIfCacheable(cache, './index.html', response);
+  } catch {
+    // A refresh is opportunistic; the install-time shell remains authoritative.
+  }
+  return response;
+};
+
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
     const cache = await caches.open(SHELL_CACHE);
@@ -79,19 +95,36 @@ self.addEventListener('fetch', (event) => {
   if (!isAppRequest) return;
 
   if (request.mode === 'navigate') {
-    const cachePromise = caches.open(SHELL_CACHE);
-    const networkFetch = cachePromise
-      .then((cache) => fetch(request)
-        .then((response) => putIfCacheable(cache, './index.html', response)))
-      .catch(() => null);
-    // Keep the cached shell's TTFB local while refreshing it for the next
-    // navigation. The versioned service worker precache makes the cached HTML
-    // and its asset URLs an atomic shell release.
-    event.waitUntil(networkFetch);
+    // Only the scope root and explicit index are the chat shell. Widgets, admin,
+    // files, and other in-scope documents must retain their server semantics.
+    const isShellNavigation = url.pathname === scopePath || url.pathname === `${scopePath}index.html`;
+    if (!isShellNavigation) return;
+
+    const cachePromise = caches.open(SHELL_CACHE).catch(() => null);
+    const cachedPromise = cachePromise.then(async (cache) => {
+      if (!cache) return null;
+      return (await cache.match('./index.html')) || (await cache.match('./')) || null;
+    });
+    const networkFetch = fetch(request).catch(() => null);
+    const refresh = refreshShellIfCompatible(cachePromise, networkFetch);
+    event.waitUntil(refresh);
     event.respondWith((async () => {
-      const cache = await cachePromise;
-      const cached = (await cache.match('./index.html')) || (await cache.match('./'));
-      if (cached) return cached;
+      // Preserve fresh-first behavior on fast/local servers, but do not make a
+      // warm reload inherit a slow remote document round trip.
+      // After one cache fallback, keep the outstanding refresh authoritative for
+      // immediate follow-up reloads (including version-mismatch auto-reloads).
+      // This prevents a stale shell from winning a rapid reload loop.
+      const fresh = shellRefreshPending ? await networkFetch : await Promise.race([
+        networkFetch,
+        new Promise((resolve) => setTimeout(() => resolve(null), NAVIGATION_NETWORK_BUDGET_MS)),
+      ]);
+      if (fresh) return fresh;
+      const cached = await cachedPromise;
+      if (cached) {
+        shellRefreshPending = true;
+        void networkFetch.finally(() => { shellRefreshPending = false; });
+        return cached;
+      }
       return (await networkFetch) || Response.error();
     })());
     return;

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -79,15 +79,20 @@ self.addEventListener('fetch', (event) => {
   if (!isAppRequest) return;
 
   if (request.mode === 'navigate') {
+    const cachePromise = caches.open(SHELL_CACHE);
+    const networkFetch = cachePromise
+      .then((cache) => fetch(request)
+        .then((response) => putIfCacheable(cache, './index.html', response)))
+      .catch(() => null);
+    // Keep the cached shell's TTFB local while refreshing it for the next
+    // navigation. The versioned service worker precache makes the cached HTML
+    // and its asset URLs an atomic shell release.
+    event.waitUntil(networkFetch);
     event.respondWith((async () => {
-      const cache = await caches.open(SHELL_CACHE);
-      try {
-        const response = await fetch(request);
-        await putIfCacheable(cache, './index.html', response.clone());
-        return response;
-      } catch {
-        return (await cache.match('./index.html')) || (await cache.match('./'));
-      }
+      const cache = await cachePromise;
+      const cached = (await cache.match('./index.html')) || (await cache.match('./'));
+      if (cached) return cached;
+      return (await networkFetch) || Response.error();
     })());
     return;
   }

--- a/internal/serveui/static/sw_test.js
+++ b/internal/serveui/static/sw_test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'sw.js'), 'utf8');
+const listeners = new Map();
+const entries = new Map();
+const cache = {
+  async addAll() {},
+  async match(key) { return entries.get(String(key)) || undefined; },
+  async put(key, response) { entries.set(String(key), response); },
+};
+let resolveFetch;
+let fetchCalls = 0;
+const context = {
+  self: {
+    location: { origin: 'https://example.test' },
+    registration: { scope: 'https://example.test/chat/' },
+    clients: { claim: async () => {} },
+    skipWaiting: async () => {},
+    addEventListener(type, handler) { listeners.set(type, handler); },
+  },
+  caches: {
+    async open() { return cache; },
+    async keys() { return []; },
+    async delete() { return true; },
+  },
+  fetch() {
+    fetchCalls += 1;
+    return new Promise((resolve) => { resolveFetch = resolve; });
+  },
+  URL,
+  Response,
+  Promise,
+  console,
+};
+vm.runInNewContext(source, context, { filename: 'sw.js' });
+
+function navigationEvent() {
+  let responsePromise;
+  let lifetimePromise;
+  return {
+    request: { method: 'GET', url: 'https://example.test/chat/', mode: 'navigate', destination: 'document' },
+    respondWith(value) { responsePromise = Promise.resolve(value); },
+    waitUntil(value) { lifetimePromise = Promise.resolve(value); },
+    response: () => responsePromise,
+    lifetime: () => lifetimePromise,
+  };
+}
+
+(async () => {
+  entries.set('./index.html', new Response('cached shell', { status: 200 }));
+  const event = navigationEvent();
+  listeners.get('fetch')(event);
+
+  const response = await event.response();
+  if (await response.text() !== 'cached shell') throw new Error('navigation did not return cached shell immediately');
+  if (fetchCalls !== 1 || typeof resolveFetch !== 'function') throw new Error('navigation did not start one background refresh');
+
+  resolveFetch(new Response('fresh shell', { status: 200 }));
+  await event.lifetime();
+  const refreshed = await cache.match('./index.html');
+  if (await refreshed.text() !== 'fresh shell') throw new Error('background refresh did not update cached shell');
+
+  console.log('PASS: navigation returns cached shell before background network refresh');
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exitCode = 1;
+});

--- a/internal/serveui/static/sw_test.js
+++ b/internal/serveui/static/sw_test.js
@@ -9,10 +9,13 @@ const listeners = new Map();
 const entries = new Map();
 const cache = {
   async addAll() {},
-  async match(key) { return entries.get(String(key)) || undefined; },
-  async put(key, response) { entries.set(String(key), response); },
+  async match(key) {
+    const response = entries.get(String(key));
+    return response ? response.clone() : undefined;
+  },
+  async put(key, response) { entries.set(String(key), response.clone()); },
 };
-let resolveFetch;
+const pendingFetches = [];
 let fetchCalls = 0;
 const context = {
   self: {
@@ -29,24 +32,27 @@ const context = {
   },
   fetch() {
     fetchCalls += 1;
-    return new Promise((resolve) => { resolveFetch = resolve; });
+    return new Promise((resolve) => { pendingFetches.push(resolve); });
   },
   URL,
   Response,
   Promise,
+  setTimeout,
   console,
 };
 vm.runInNewContext(source, context, { filename: 'sw.js' });
 
-function navigationEvent() {
+function navigationEvent(url = 'https://example.test/chat/') {
   let responsePromise;
   let lifetimePromise;
+  let intercepted = false;
   return {
-    request: { method: 'GET', url: 'https://example.test/chat/', mode: 'navigate', destination: 'document' },
-    respondWith(value) { responsePromise = Promise.resolve(value); },
+    request: { method: 'GET', url, mode: 'navigate', destination: 'document' },
+    respondWith(value) { intercepted = true; responsePromise = Promise.resolve(value); },
     waitUntil(value) { lifetimePromise = Promise.resolve(value); },
     response: () => responsePromise,
     lifetime: () => lifetimePromise,
+    intercepted: () => intercepted,
   };
 }
 
@@ -56,15 +62,42 @@ function navigationEvent() {
   listeners.get('fetch')(event);
 
   const response = await event.response();
-  if (await response.text() !== 'cached shell') throw new Error('navigation did not return cached shell immediately');
-  if (fetchCalls !== 1 || typeof resolveFetch !== 'function') throw new Error('navigation did not start one background refresh');
+  if (await response.text() !== 'cached shell') throw new Error('slow navigation did not fall back to the cached shell');
+  if (fetchCalls !== 1 || pendingFetches.length !== 1) throw new Error('navigation did not start one network refresh');
 
-  resolveFetch(new Response('fresh shell', { status: 200 }));
+  const immediateReload = navigationEvent();
+  listeners.get('fetch')(immediateReload);
+  let immediateReloadSettled = false;
+  immediateReload.response().then(() => { immediateReloadSettled = true; });
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  if (immediateReloadSettled) throw new Error('immediate follow-up reload reused the stale shell');
+  pendingFetches[1](new Response('<script>window.TERM_LLM_UI_VERSION="v3";</script>follow-up shell', { status: 200 }));
+  if (!(await (await immediateReload.response()).text()).endsWith('follow-up shell')) {
+    throw new Error('immediate follow-up reload did not wait for the authoritative network shell');
+  }
+  await immediateReload.lifetime();
+
+  pendingFetches[0](new Response('<script>window.TERM_LLM_UI_VERSION="v3";</script>fresh shell', { status: 200 }));
   await event.lifetime();
   const refreshed = await cache.match('./index.html');
-  if (await refreshed.text() !== 'fresh shell') throw new Error('background refresh did not update cached shell');
+  if (!(await refreshed.text()).endsWith('fresh shell')) throw new Error('compatible background refresh did not update cached shell');
 
-  console.log('PASS: navigation returns cached shell before background network refresh');
+  const compatibleShell = await (await cache.match('./index.html')).text();
+  const upgradeEvent = navigationEvent();
+  listeners.get('fetch')(upgradeEvent);
+  await upgradeEvent.response();
+  pendingFetches[2](new Response('<script>window.TERM_LLM_UI_VERSION="v4";</script>next release', { status: 200 }));
+  await upgradeEvent.lifetime();
+  if (await (await cache.match('./index.html')).text() !== compatibleShell) {
+    throw new Error('old service worker mixed a new HTML release into its shell cache');
+  }
+
+  const widgetEvent = navigationEvent('https://example.test/chat/widgets/clock/');
+  listeners.get('fetch')(widgetEvent);
+  if (widgetEvent.intercepted()) throw new Error('service worker intercepted a non-shell widget navigation');
+  if ((await (await cache.match('./index.html')).text()).endsWith('WIDGET PAGE')) throw new Error('widget navigation poisoned the shell cache');
+
+  console.log('PASS: shell navigation uses bounded cache fallback without intercepting widget documents');
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : error);
   process.exitCode = 1;


### PR DESCRIPTION
## What

- give the network 100 ms to return the current web shell, then use the version-matched cached shell on slow controlled reloads while the request finishes in the background
- constrain shell fallback to the scope root and explicit `index.html`; widget, admin, file, redirect, and other document routes remain network-owned
- prevent old service workers from mixing a new HTML release with old versioned assets
- make an immediate follow-up/version-mismatch reload wait for the outstanding authoritative network shell rather than repeatedly serving stale HTML
- stop treating normal initial `pageshow` as immediate network recovery, removing the duplicate startup `/v1/providers` probe
- preserve immediate BFCache recovery and add a two-second recovery grace period for failed cold starts
- add executable JS regression coverage for these behaviors

## Why

A production reload waterfall showed two avoidable costs:

- the service worker marked the document as handled but still used unbounded network-first navigation, making reload wait about 1.15 seconds for document TTFB
- initial `pageshow` ran a health probe concurrently with normal startup provider discovery, producing two `/v1/providers` requests

The rest of startup already overlaps sessions, models, and providers intentionally; status polling is deliberately deferred and was left alone.

## Local verification

Built baseline and patched binaries from the same `c76ab4e1` base and loaded each with the same system Chromium harness, local no-auth server, service-worker-controlled second navigation, and a controlled 500 ms document-network delay:

| | Baseline | Patched |
|---|---:|---:|
| reload wall time | 554 ms | 150 ms |
| document TTFB | 507 ms | 101 ms |
| document transfer | 38,491 B | 0 B (shell cache) |
| startup `/v1/providers` requests | 2 | 1 |
| startup `/v1/sessions` requests | 1 | 1 |
| startup `/v1/models` requests | 1 | 1 |

That is 404 ms less reload wall time (72.9%) in the controlled delayed-document case, while fast/local responses retain fresh-first behavior.

## Review hardening

A `claude-bin:opus` review caught that the first cache-first draft applied to every in-scope navigation, which could hijack widget/admin pages and poison the shell cache. The revised implementation:

- only intercepts `/base/` and `/base/index.html`
- caches refreshed HTML only when its embedded UI version matches the active service worker
- makes rapid follow-up reloads network-authoritative until the outstanding refresh settles
- retains failed-startup recovery without restoring the normal duplicate provider probe

## Tests

- `node internal/serveui/static/app_network_test.js`
- `node internal/serveui/static/sw_test.js`
- `node internal/serveui/static/app_sessions_test.js`
- clean-environment `go test ./...`
