### PR TITLE
fix: retire orphaned web projections on idle

### DIFF
--- a/cmd/serve_ask_user_state_handler.go
+++ b/cmd/serve_ask_user_state_handler.go
@@ -232,11 +232,6 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 		resp["lastResponseId"] = lastResponseID
 	}
 
-	if indexer, ok := s.transcriptIndexerForWeb(); ok {
-		if rev, err := indexer.TranscriptRev(r.Context(), sessionID); err == nil {
-			resp["transcript_rev"] = rev
-		}
-	}
 	if s.responseRuns != nil {
 		if activeResponseID := s.responseRuns.activeRunID(sessionID); activeResponseID != "" {
 			resp["active_run"] = true
@@ -253,6 +248,15 @@ func (s *serveServer) handleSessionState(w http.ResponseWriter, r *http.Request,
 				}
 				run.mu.Unlock()
 			}
+		}
+	}
+	// Sample the transcript revision after active-run state. Run finalization
+	// commits transcript rows before clearing active ownership, so an idle sample
+	// is paired with a revision that can include that final commit. Sampling in
+	// the opposite order could publish idle plus a stale pre-final revision.
+	if indexer, ok := s.transcriptIndexerForWeb(); ok {
+		if rev, err := indexer.TranscriptRev(r.Context(), sessionID); err == nil {
+			resp["transcript_rev"] = rev
 		}
 	}
 

--- a/cmd/serve_ask_user_state_handler_test.go
+++ b/cmd/serve_ask_user_state_handler_test.go
@@ -74,6 +74,75 @@ type currentPlanResponse struct {
 	Explanation string         `json:"explanation,omitempty"`
 }
 
+type stateRevisionRaceStore struct {
+	session.NoopStore
+	rev     int64
+	onRead  func()
+	readRev bool
+}
+
+func (s *stateRevisionRaceStore) GetTranscriptIndex(context.Context, string) (int64, []session.TranscriptIndexItem, error) {
+	return s.rev, nil, nil
+}
+
+func (s *stateRevisionRaceStore) GetTranscriptSnapshot(context.Context, string) (session.TranscriptSnapshot, error) {
+	return session.TranscriptSnapshot{Rev: s.rev}, nil
+}
+
+func (s *stateRevisionRaceStore) GetMessagesByTranscriptRanges(context.Context, string, []session.TranscriptRange) (int64, []session.Message, error) {
+	return s.rev, nil, nil
+}
+
+func (s *stateRevisionRaceStore) TranscriptRev(context.Context, string) (int64, error) {
+	if !s.readRev {
+		s.readRev = true
+		if s.onRead != nil {
+			s.onRead()
+		}
+	}
+	return s.rev, nil
+}
+
+func (s *stateRevisionRaceStore) TranscriptVersioned() bool { return true }
+
+func TestHandleSessionStateSamplesTranscriptRevisionAfterActiveRun(t *testing.T) {
+	const (
+		sessionID  = "session-state-revision-race"
+		responseID = "resp-state-revision-race"
+		finalRev   = int64(46)
+	)
+	manager := newServeResponseRunManager()
+	defer manager.Close()
+	manager.setActiveRun(sessionID, responseID)
+	store := &stateRevisionRaceStore{rev: finalRev}
+	store.onRead = func() {
+		// Model finalization between the two state samples: durable revision is
+		// already final when active ownership is cleared.
+		manager.clearActiveRun(sessionID, responseID)
+	}
+	srv := &serveServer{store: store, responseRuns: manager}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sessionID+"/state", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var response struct {
+		ActiveRun        bool   `json:"active_run"`
+		ActiveResponseID string `json:"active_response_id"`
+		TranscriptRev    int64  `json:"transcript_rev"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.ActiveRun || response.ActiveResponseID != responseID || response.TranscriptRev != finalRev {
+		t.Fatalf("state sample = %+v, want active ownership paired with final transcript_rev %d", response, finalRev)
+	}
+	if got := manager.activeRunID(sessionID); got != "" {
+		t.Fatalf("race fixture left active run %q after revision read", got)
+	}
+}
+
 func TestHandleSessionStateReturnsLatestAuthoritativePlan(t *testing.T) {
 	store := newSessionStatePlanStore()
 	first := planpkg.Snapshot{Plan: []planpkg.Step{

--- a/internal/serveui/static/active-response.js
+++ b/internal/serveui/static/active-response.js
@@ -265,6 +265,7 @@
 
   const reduceDetachedReplay = (run, events) => {
     const candidate = createActiveRun({ responseId: run.responseID, runEpoch: run.runEpoch, anchor: run.anchor });
+    if (Object.prototype.hasOwnProperty.call(run, 'durableStartCompactionSeq')) Object.assign(candidate, { durableStartCompactionSeq: run.durableStartCompactionSeq, durableStartCompactionCount: run.durableStartCompactionCount });
     candidate.lastSequence = run.lastSequence;
     const currentToolGroupIndex = run.currentToolGroup ? run.projection.indexOf(run.currentToolGroup) : -1;
     candidate.projection = run.projection.map((entry) => clone(entry));

--- a/internal/serveui/static/app-response-effects.js
+++ b/internal/serveui/static/app-response-effects.js
@@ -85,13 +85,13 @@ const applyOwnedResponseProjectionEvent = (session, event, payload) => {
 const applyResponseStreamEvent = (session, streamState, event, payload) => {
   const projectionResult = applyOwnedResponseProjectionEvent(session, event, payload);
   if (projectionResult) return projectionResult;
-
   let lifecycleResult = null;
   if (String(event || '').startsWith('response.') && event !== 'response.file_change') {
     if (!session.transcript && typeof ConversationController === 'function') session.transcript = new ConversationController(session.id || 'stream');
     const responseId = responseStreamOwnerId(session, payload);
     try {
       lifecycleResult = window.TermLLMConversation.dispatchRunEvent(session.transcript, event, payload);
+      if (!lifecycleResult) return { terminal: false, stale: true };
     } catch (error) {
       if (error?.code === 'stale_run_epoch' || error?.code === 'inactive_response_event') return { terminal: false, stale: true };
       throw error;

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -405,6 +405,23 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
   }, delay);
 };
 
+const retireOrphanedActiveProjection = (transcript, sampled, authoritativeRev) => {
+  const responseId = String(sampled?.responseId || '').trim();
+  const runEpoch = Math.max(0, Number(sampled?.runEpoch) || 0);
+  const revision = Math.max(0, Number(authoritativeRev) || 0);
+  const active = transcript?.conversation?.active;
+  if (!responseId || !runEpoch || !revision || !active || active.terminal || active.responseID !== responseId
+      || active.runEpoch !== runEpoch || Number(transcript.latestRunEpoch) !== runEpoch || Number(transcript.rev) < revision) return false;
+  const ordinals = transcript.responseIDs
+    .map((owner, ordinal) => String(owner || '') === responseId ? ordinal : -1).filter((ordinal) => ordinal >= 0);
+  if (!ordinals.length || !ordinals.every((ordinal) => ['materialized', 'empty'].includes(
+    transcript.segments[transcript.segmentForOrdinal(ordinal)]?.state
+  ))) return false;
+  transcript.conversation.active = null;
+  transcript.conversation.protocolError = '';
+  return true;
+};
+
 const syncActiveSessionFromServer = async (session, pollOnActive = false, { skipMessagesFetch = false, expectedSwitchGeneration = null } = {}) => {
   if (!session || !isSessionIdentityResolved(session)) return SESSION_STATE_RETRY_RESULT;
 
@@ -424,6 +441,11 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
 
   const busyBefore = sessionHasInProgressState(session);
   const sampledRunEpoch = Math.max(0, Number(session.transcript?.latestRunEpoch) || 0);
+  const sampledActiveProjection = {
+    responseId: String(session.transcript?.activeRun?.id || '').trim(),
+    runEpoch: Math.max(0, Number(session.transcript?.activeRun?.epoch) || 0),
+    terminal: Boolean(session.transcript?.activeRun?.terminal),
+  };
   const sampledTransport = {
     controller: state.abortController,
     generation: Number(state.streamGeneration || 0),
@@ -626,6 +648,26 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     // server-issued response ID both before and after the state round trip.
     if ((state.abortController || currentOwnsTransport) && !(sampledOwnedResponse && transportUnchanged)) {
       return loadResult;
+    }
+    // Require sampled run/transport stability plus current materialized durable ownership before dropping the overlay.
+    if (transcript && sampledActiveProjection.responseId && !sampledActiveProjection.terminal) {
+      const retiredOrphanedProjection = await transcript.commands.enqueue(() => (
+        retireOrphanedActiveProjection(transcript, sampledActiveProjection, runtimeTranscriptRev)
+      ));
+      const runEpochUnchanged = sampledRunEpoch === Math.max(0, Number(transcript.latestRunEpoch) || 0);
+      const transportStillUnchanged = state.abortController === sampledTransport.controller
+        && Number(state.streamGeneration || 0) === sampledTransport.generation
+        && String(state.currentStreamSessionId || '').trim() === sampledTransport.sessionId
+        && String(state.currentStreamResponseId || '').trim() === sampledTransport.responseId;
+      const nowOwnsTransport = state.currentStreamSessionId === session.id && Boolean(state.currentStreamResponseId);
+      if (!runEpochUnchanged
+          || ((state.abortController || nowOwnsTransport) && !(sampledOwnedResponse && transportStillUnchanged))) {
+        return loadResult;
+      }
+      if (retiredOrphanedProjection) {
+        refreshSessionMessagesFromTranscript(session);
+        if (isStillActive()) renderMessages(true);
+      }
     }
     if (isStillActive()) stopSessionStatePoll();
     const inactiveResponseId = session.activeResponseId || (

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -405,23 +405,6 @@ const scheduleSessionStatePoll = (sessionId, delay = 1200) => {
   }, delay);
 };
 
-const retireOrphanedActiveProjection = (transcript, sampled, authoritativeRev) => {
-  const responseId = String(sampled?.responseId || '').trim();
-  const runEpoch = Math.max(0, Number(sampled?.runEpoch) || 0);
-  const revision = Math.max(0, Number(authoritativeRev) || 0);
-  const active = transcript?.conversation?.active;
-  if (!responseId || !runEpoch || !revision || !active || active.terminal || active.responseID !== responseId
-      || active.runEpoch !== runEpoch || Number(transcript.latestRunEpoch) !== runEpoch || Number(transcript.rev) < revision) return false;
-  const ordinals = transcript.responseIDs
-    .map((owner, ordinal) => String(owner || '') === responseId ? ordinal : -1).filter((ordinal) => ordinal >= 0);
-  if (!ordinals.length || !ordinals.every((ordinal) => ['materialized', 'empty'].includes(
-    transcript.segments[transcript.segmentForOrdinal(ordinal)]?.state
-  ))) return false;
-  transcript.conversation.active = null;
-  transcript.conversation.protocolError = '';
-  return true;
-};
-
 const syncActiveSessionFromServer = async (session, pollOnActive = false, { skipMessagesFetch = false, expectedSwitchGeneration = null } = {}) => {
   if (!session || !isSessionIdentityResolved(session)) return SESSION_STATE_RETRY_RESULT;
 
@@ -440,12 +423,11 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
     && requestGeneration >= Number(state.lastAppliedSessionStateRequestGeneration || 0);
 
   const busyBefore = sessionHasInProgressState(session);
-  const sampledRunEpoch = Math.max(0, Number(session.transcript?.latestRunEpoch) || 0);
   const sampledActiveProjection = {
-    responseId: String(session.transcript?.activeRun?.id || '').trim(),
-    runEpoch: Math.max(0, Number(session.transcript?.activeRun?.epoch) || 0),
-    terminal: Boolean(session.transcript?.activeRun?.terminal),
+    responseId: String(session.transcript?.activeRun?.id || '').trim(), runEpoch: Math.max(0, Number(session.transcript?.activeRun?.epoch) || 0),
+    startedRev: Math.max(0, Number(session.transcript?.activeRun?.startedRev) || 0), terminal: Boolean(session.transcript?.activeRun?.terminal),
   };
+  const sampledSessionResponseId = String(session.activeResponseId || '').trim();
   const sampledTransport = {
     controller: state.abortController,
     generation: Number(state.streamGeneration || 0),
@@ -630,69 +612,86 @@ const syncActiveSessionFromServer = async (session, pollOnActive = false, { skip
   }
 
   if (!activeRun) {
-    if (sampledRunEpoch < Math.max(0, Number(transcript?.latestRunEpoch) || 0)) {
-      window.TermLLMConversation?.transcriptDiagnostic?.('stale_status_rejection', {
-        responseId: session.activeResponseId || transcript?.activeRun?.id || '',
-        transcriptRev: transcript?.rev,
-      });
-      return loadResult;
-    }
-    const transportUnchanged = state.abortController === sampledTransport.controller
+    const transportMatchesSample = () => state.abortController === sampledTransport.controller
       && Number(state.streamGeneration || 0) === sampledTransport.generation
       && String(state.currentStreamSessionId || '').trim() === sampledTransport.sessionId
       && String(state.currentStreamResponseId || '').trim() === sampledTransport.responseId;
-    const sampledOwnedResponse = sampledTransport.sessionId === session.id && Boolean(sampledTransport.responseId);
-    const currentOwnsTransport = state.currentStreamSessionId === session.id && Boolean(state.currentStreamResponseId);
-    // An idle response sampled before a new send must not cancel that send. A
-    // transport may only be retired when this request observed its stable,
-    // server-issued response ID both before and after the state round trip.
-    if ((state.abortController || currentOwnsTransport) && !(sampledOwnedResponse && transportUnchanged)) {
-      return loadResult;
-    }
-    // Require sampled run/transport stability plus current materialized durable ownership before dropping the overlay.
-    if (transcript && sampledActiveProjection.responseId && !sampledActiveProjection.terminal) {
-      const retiredOrphanedProjection = await transcript.commands.enqueue(() => (
-        retireOrphanedActiveProjection(transcript, sampledActiveProjection, runtimeTranscriptRev)
-      ));
-      const runEpochUnchanged = sampledRunEpoch === Math.max(0, Number(transcript.latestRunEpoch) || 0);
-      const transportStillUnchanged = state.abortController === sampledTransport.controller
-        && Number(state.streamGeneration || 0) === sampledTransport.generation
-        && String(state.currentStreamSessionId || '').trim() === sampledTransport.sessionId
-        && String(state.currentStreamResponseId || '').trim() === sampledTransport.responseId;
-      const nowOwnsTransport = state.currentStreamSessionId === session.id && Boolean(state.currentStreamResponseId);
-      if (!runEpochUnchanged
-          || ((state.abortController || nowOwnsTransport) && !(sampledOwnedResponse && transportStillUnchanged))) {
-        return loadResult;
-      }
-      if (retiredOrphanedProjection) {
+    const idleOwnershipStable = () => {
+      const currentOwnsTransport = state.currentStreamSessionId === session.id && Boolean(state.currentStreamResponseId);
+      const sampledOwnedResponse = sampledTransport.sessionId === session.id && Boolean(sampledTransport.responseId);
+      return String(session.activeResponseId || '').trim() === sampledSessionResponseId
+        && !((state.abortController || currentOwnsTransport) && !(sampledOwnedResponse && transportMatchesSample()));
+    };
+    const finishIdleSessionSync = (refreshProjection = false) => {
+      if (refreshProjection) {
         refreshSessionMessagesFromTranscript(session);
         if (isStillActive()) renderMessages(true);
       }
+      if (isStillActive()) stopSessionStatePoll();
+      const inactiveResponseId = session.activeResponseId || (
+        state.currentStreamSessionId === session.id ? state.currentStreamResponseId : ''
+      );
+      if (state.currentStreamSessionId === session.id && state.currentStreamResponseId) {
+        detachResponseStream();
+      }
+      if (inactiveResponseId) {
+        clearActiveResponseTracking(session, inactiveResponseId);
+        saveSessions();
+      }
+      setSessionOptimisticBusy(session, false);
+      setSessionServerActiveRun(session, false);
+      updateBusySidebar();
+      if (isStillActive()) {
+        setStreaming(false); setConnectionState('', '');
+      }
+    };
+
+    let idleDecision = 'stable';
+    if (transcript) {
+      idleDecision = await transcript.commands.enqueue(() => {
+        if (!selectedResponseApplies() || !idleOwnershipStable()) return 'stale';
+        const current = transcript.activeRun;
+        if (!sampledActiveProjection.responseId || sampledActiveProjection.terminal) {
+          if (String(current?.id || '').trim() !== sampledActiveProjection.responseId
+              || Math.max(0, Number(current?.epoch) || 0) !== sampledActiveProjection.runEpoch
+              || Boolean(current?.terminal) !== sampledActiveProjection.terminal) return 'stale';
+          return 'stable';
+        }
+        const retired = transcript.retireOrphanedActiveProjection({
+          responseId: sampledActiveProjection.responseId,
+          runEpoch: sampledActiveProjection.runEpoch,
+          startedRev: sampledActiveProjection.startedRev,
+          transcriptRev: runtimeTranscriptRev,
+        });
+        if (!retired) {
+          if (String(current?.id || '').trim() !== sampledActiveProjection.responseId
+              || Math.max(0, Number(current?.epoch) || 0) !== sampledActiveProjection.runEpoch
+              || Boolean(current?.terminal) !== sampledActiveProjection.terminal) return 'stale';
+          return 'refused';
+        }
+        // The authority decision, projection mutation, render publication,
+        // transport detach, and tracking cleanup are one non-awaiting queued
+        // transaction. Late stream work observes the retired epoch barrier.
+        finishIdleSessionSync(true);
+        return 'retired';
+      });
+    } else if (!idleOwnershipStable()) {
+      idleDecision = 'stale';
     }
-    if (isStillActive()) stopSessionStatePoll();
-    const inactiveResponseId = session.activeResponseId || (
-      state.currentStreamSessionId === session.id ? state.currentStreamResponseId : ''
-    );
-    if (state.currentStreamSessionId === session.id && state.currentStreamResponseId) {
-      detachResponseStream();
+    if (idleDecision === 'stale') return loadResult;
+    if (idleDecision === 'retired') {
+      app.retireUnownedInterjectionIntents?.(session);
+      requeuePendingInterjections(session);
+      drainInterruptQueueIfIdle(session);
+      return loadResult;
     }
-    if (inactiveResponseId) {
-      clearActiveResponseTracking(session, inactiveResponseId);
-      saveSessions();
-    }
-    setSessionOptimisticBusy(session, false);
-    setSessionServerActiveRun(session, false);
-    updateBusySidebar();
-    if (isStillActive()) setStreaming(false);
+
+    finishIdleSessionSync(false);
     if (isStillActive() && !skipMessagesFetch) {
       await refreshActiveSessionMessagesFromServer(session, {
         targetRev: runtimeTranscriptRev,
         forceScroll: true
       });
-    }
-    if (isStillActive()) {
-      setConnectionState('', '');
-      setStreaming(false);
     }
     app.retireUnownedInterjectionIntents?.(session);
     requeuePendingInterjections(session);

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -902,12 +902,12 @@ const applyResponseRecoverySnapshot = (session, payload) => {
 
     const transcript = session.transcript;
     if (transcript) {
-      window.TermLLMConversation.replaceRunSnapshot(transcript, {
+      if (window.TermLLMConversation.replaceRunSnapshot(transcript, {
         ...payload,
         id: responseId,
         last_sequence_number: recovery.sequence_number ?? payload.last_sequence_number,
         recovery: { ...recovery, messages: recoveredMessages },
-      });
+      }) !== true) return false;
       for (const fact of Array.isArray(recovery.events) ? recovery.events : []) {
         app.applyRecoveredInteractiveFact?.(session, String(fact?.event || ''), fact?.payload || {});
       }
@@ -967,9 +967,9 @@ const applyResponseRecoverySnapshot = (session, payload) => {
         startRev: payload.started_rev,
       });
     } else {
+      if (window.TermLLMConversation.attachActiveRun(session.transcript, payload) !== true) return false;
       setActiveResponseTracking(session, responseId);
       setSessionOptimisticBusy(session, true);
-      window.TermLLMConversation.attachActiveRun(session.transcript, payload);
     }
   }
 

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3485,6 +3485,195 @@ async function testIdleSessionSyncRescuesPendingInterruptCommit() {
   pass(name);
 }
 
+async function testIdleStateRetiresLostTerminalProjectionFromCurrentDurableTranscript() {
+  const name = 'idle authoritative state retires a lost-terminal projection only after durable ownership is current';
+  const sessionId = 'sess_lost_terminal';
+  const responseId = 'resp_lost_terminal';
+  const rowCount = 233;
+  const toolCount = 46;
+  const ids = Array.from({ length: rowCount }, (_, index) => index + 1);
+  const responseIDs = ids.map((id) => id === rowCount ? responseId : '');
+  const rawBodies = ids.map((id) => ({
+    id,
+    sequence: id - 1,
+    role: id === 1 ? 'user' : 'assistant',
+    created_at: id * 1000,
+    parts: [{ type: 'text', text: id === 1 ? 'question' : `historical-${id}` }],
+  }));
+  rawBodies[rowCount - 1] = {
+    id: rowCount,
+    sequence: rowCount - 1,
+    role: 'assistant',
+    created_at: rowCount * 1000,
+    parts: [
+      ...Array.from({ length: toolCount }, (_, index) => ({
+        type: 'tool_activity',
+        tool_name: 'shell',
+        tool_call_id: `durable-call-${index + 1}`,
+        tool_status: 'completed',
+      })),
+      { type: 'text', text: 'complete durable final answer' },
+    ],
+  };
+  const transcriptRequests = [];
+  let renderCount = 0;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      const parsed = parsedTestURL(url);
+      if (parsed?.pathname === `/ui/v1/sessions/${sessionId}/state`) {
+        return new Response(JSON.stringify({ active_run: false, active_response_id: '', transcript_rev: 351 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (isTranscriptIndexURL(url, sessionId) || isTranscriptBodiesURL(url, sessionId)) transcriptRequests.push(String(url));
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+    appOverrides: {
+      renderMessages() { renderCount += 1; },
+    },
+  });
+  app.stopSidebarStatusPoll();
+  const session = { id: sessionId, title: 'Lost terminal', messages: [], activeResponseId: null };
+  session.transcript = new windowObj.ConversationController(session.id, { maxMaterializedTurns: 300 });
+  session.transcript.applyIndex({
+    rev: 351,
+    compaction_seq: -1,
+    compaction_count: 0,
+    rows: {
+      ids,
+      seqs: ids.map((id) => id - 1),
+      roles: `u${'a'.repeat(rowCount - 1)}`,
+      flags: ids.map(() => 0),
+      response_ids: responseIDs,
+      assistant_segment_ordinals: ids.map((id) => id === rowCount ? 0 : -1),
+    },
+  });
+  session.transcript.materialize(rawBodies, { countFetch: false });
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  app.refreshSessionMessagesFromTranscript(session);
+  session.transcript.replaceActiveSnapshot({
+    id: responseId,
+    run_epoch: 7,
+    status: 'in_progress',
+    last_sequence_number: 168,
+    recovery: {
+      messages: [{
+        role: 'tool-group',
+        responseId,
+        status: 'running',
+        tools: Array.from({ length: 20 }, (_, index) => ({ id: `stale-call-${index + 1}`, name: 'shell', status: 'done' })),
+      }],
+    },
+  });
+
+  const visibleToolCount = () => projectedMessages(session)
+    .filter((message) => message.role === 'tool-group')
+    .reduce((count, group) => count + group.tools.length, 0);
+  if (visibleToolCount() !== 20 || projectedMessages(session).some((message) => message.content === 'complete durable final answer')) {
+    fail(name, 'fixture did not reproduce the stale 20-tool active projection over durable output');
+    return;
+  }
+
+  const durableResponseIDs = [...session.transcript.responseIDs];
+  session.transcript.responseIDs = session.transcript.responseIDs.map(() => '');
+  await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
+  if (!session.transcript.conversation.active || visibleToolCount() !== 20) {
+    fail(name, 'idle state retired an active projection without durable response ownership');
+    return;
+  }
+  session.transcript.responseIDs = durableResponseIDs;
+  await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
+
+  if (session.transcript.conversation.active !== null
+      || visibleToolCount() !== toolCount
+      || projectedMessages(session).at(-1)?.content !== 'complete durable final answer') {
+    fail(name, 'idle reconciliation did not reveal the complete durable 46-tool transcript', JSON.stringify({
+      active: session.transcript.activeRun,
+      tools: visibleToolCount(),
+      final: projectedMessages(session).at(-1)?.content,
+    }));
+    return;
+  }
+  if (session.transcript.rev !== 351 || session.transcript.ids.length !== rowCount
+      || session.transcript.bodies.size !== rowCount || transcriptRequests.length !== 0 || renderCount === 0) {
+    fail(name, 'recovery refetched or failed to render already-authoritative durable truth', JSON.stringify({
+      rev: session.transcript.rev,
+      rows: session.transcript.ids.length,
+      bodies: session.transcript.bodies.size,
+      transcriptRequests,
+      renderCount,
+    }));
+    return;
+  }
+  pass(name);
+}
+
+async function testStaleIdleStateCannotRetireNewerActiveProjection() {
+  const name = 'stale idle state cannot retire a newer run projection created during the request';
+  const sessionId = 'sess_orphan_epoch_race';
+  const oldResponseId = 'resp_old_projection';
+  const newResponseId = 'resp_new_projection';
+  let session;
+  const { app, windowObj } = await createSessionsHarness({
+    fetchImpl: async (url) => {
+      if (parsedTestURL(url)?.pathname === `/ui/v1/sessions/${sessionId}/state`) {
+        session.transcript.transitionAuthoritativeRun(newResponseId, 351, 8);
+        session.activeResponseId = newResponseId;
+        return new Response(JSON.stringify({ active_run: false, active_response_id: '', transcript_rev: 351 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+  app.stopSidebarStatusPoll();
+  session = { id: sessionId, title: 'Epoch race', messages: [], activeResponseId: oldResponseId };
+  session.transcript = new windowObj.ConversationController(session.id);
+  session.transcript.applyIndex({
+    rev: 351,
+    compaction_seq: -1,
+    compaction_count: 0,
+    rows: {
+      ids: [1, 2], seqs: [0, 1], roles: 'ua', flags: [0, 0],
+      response_ids: ['', oldResponseId], assistant_segment_ordinals: [-1, 0],
+    },
+  });
+  session.transcript.materialize([
+    { id: 1, role: 'user', content: 'old question' },
+    { id: 2, role: 'assistant', responseId: oldResponseId, content: 'old durable answer' },
+  ], { countFetch: false });
+  session.transcript.replaceActiveSnapshot({
+    id: oldResponseId, run_epoch: 7, status: 'in_progress', last_sequence_number: 168,
+    recovery: { messages: [{ role: 'assistant', assistant_segment_ordinal: 0, content: 'old stale prefix' }] },
+  });
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
+
+  if (session.transcript.activeRun?.id !== newResponseId
+      || session.transcript.activeRun?.epoch !== 8
+      || session.activeResponseId !== newResponseId) {
+    fail(name, 'stale idle response cleared or replaced the newer run owner', JSON.stringify({
+      activeRun: session.transcript.activeRun,
+      activeResponseId: session.activeResponseId,
+    }));
+    return;
+  }
+  pass(name);
+}
+
 async function testIdleStateRetiresOnlySampledTransportOwnership() {
   const name = 'idle state retires a stable response transport without killing a newer local run';
 
@@ -6944,6 +7133,8 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   await testActiveStatusSyncsInRunTranscriptRevisionsWithoutDuplicatingActiveOutput();
   await testHugeTranscriptGapTraversalStaysBoundedAndAnchored();
   await testIdleSessionSyncRescuesPendingInterruptCommit();
+  await testIdleStateRetiresLostTerminalProjectionFromCurrentDurableTranscript();
+  await testStaleIdleStateCannotRetireNewerActiveProjection();
   await testIdleStateRetiresOnlySampledTransportOwnership();
   await testIdleSidebarStatusPreservesUnacknowledgedPost();
   await testSessionProgressStatePrefersLocalAndServerSignals();

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3588,6 +3588,18 @@ async function testIdleStateRetiresLostTerminalProjectionFromCurrentDurableTrans
     return;
   }
   session.transcript.responseIDs = durableResponseIDs;
+  try {
+    session.transcript.setActiveRun('resp_blocked_newer', 351, 8);
+    fail(name, 'fixture unexpectedly replaced the orphan with a newer run');
+    return;
+  } catch (_err) {
+    // setActiveRun publishes the newer epoch before refusing to replace the old
+    // owner. Retirement must key off the unchanged owner, not this watermark.
+  }
+  if (session.transcript.latestRunEpoch !== 8 || session.transcript.activeRun?.id !== responseId) {
+    fail(name, 'fixture did not preserve old owner plus newer latestRunEpoch');
+    return;
+  }
   await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
 
   if (session.transcript.conversation.active !== null
@@ -3611,6 +3623,25 @@ async function testIdleStateRetiresLostTerminalProjectionFromCurrentDurableTrans
     }));
     return;
   }
+  const lateEvent = windowObj.TermLLMConversation.dispatchRunEvent(session.transcript, 'response.output_text.delta', {
+    response_id: responseId, run_epoch: 7, sequence_number: 169, delta: 'late stale overlay'
+  });
+  const lateSnapshot = windowObj.TermLLMConversation.replaceRunSnapshot(session.transcript, {
+    id: responseId, run_epoch: 7, status: 'in_progress', last_sequence_number: 169,
+    recovery: { messages: [{ role: 'assistant', content: 'late replay after zero' }] },
+  });
+  if (lateEvent !== null || lateSnapshot !== false || session.transcript.conversation.active !== null
+      || visibleToolCount() !== toolCount || projectedMessages(session).at(-1)?.content !== 'complete durable final answer') {
+    fail(name, 'late event or after=0 recovery replay resurrected the retired overlay', JSON.stringify({
+      lateEvent, lateSnapshot, active: session.transcript.activeRun, tools: visibleToolCount(),
+      final: projectedMessages(session).at(-1)?.content,
+    }));
+    return;
+  }
+  if (!session.transcript.transitionAuthoritativeRun('resp_after_orphan', 351, 8)) {
+    fail(name, 'retired orphan epoch blocked a genuinely newer authoritative run');
+    return;
+  }
   pass(name);
 }
 
@@ -3623,8 +3654,9 @@ async function testStaleIdleStateCannotRetireNewerActiveProjection() {
   const { app, windowObj } = await createSessionsHarness({
     fetchImpl: async (url) => {
       if (parsedTestURL(url)?.pathname === `/ui/v1/sessions/${sessionId}/state`) {
-        session.transcript.transitionAuthoritativeRun(newResponseId, 351, 8);
-        session.activeResponseId = newResponseId;
+        await session.transcript.commands.enqueue(() => {
+          session.transcript.transitionAuthoritativeRun(newResponseId, 351, 8);
+        });
         return new Response(JSON.stringify({ active_run: false, active_response_id: '', transcript_rev: 351 }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -3656,16 +3688,24 @@ async function testStaleIdleStateCannotRetireNewerActiveProjection() {
     id: oldResponseId, run_epoch: 7, status: 'in_progress', last_sequence_number: 168,
     recovery: { messages: [{ role: 'assistant', assistant_segment_ordinal: 0, content: 'old stale prefix' }] },
   });
+  let retirementDecisions = 0;
+  const decideRetirement = session.transcript.retireOrphanedActiveProjection.bind(session.transcript);
+  session.transcript.retireOrphanedActiveProjection = (authority) => {
+    retirementDecisions += 1;
+    return decideRetirement(authority);
+  };
   app.state.sessions = [session];
   app.state.activeSessionId = session.id;
   app.state.draftSessionActive = false;
 
   await app.syncActiveSessionFromServer(session, false, { skipMessagesFetch: true });
 
-  if (session.transcript.activeRun?.id !== newResponseId
+  if (retirementDecisions !== 1
+      || session.transcript.activeRun?.id !== newResponseId
       || session.transcript.activeRun?.epoch !== 8
-      || session.activeResponseId !== newResponseId) {
-    fail(name, 'stale idle response cleared or replaced the newer run owner', JSON.stringify({
+      || session.activeResponseId !== oldResponseId) {
+    fail(name, 'retirement decision did not refuse the changed active owner atomically', JSON.stringify({
+      retirementDecisions,
       activeRun: session.transcript.activeRun,
       activeResponseId: session.activeResponseId,
     }));

--- a/internal/serveui/static/conversation.js
+++ b/internal/serveui/static/conversation.js
@@ -44,6 +44,7 @@
     acknowledgedIntentIDs: new Set(),
     acknowledgedAskUserCallIDs: new Set(),
     active: null,
+    retiredRunEpoch: 0,
     publishedRevision: 0,
     protocolError: '',
   });
@@ -75,17 +76,23 @@
       }
     }
   };
+  const initializeDurableBaseline = (run, durable) => {
+    if (!run || Object.prototype.hasOwnProperty.call(run, 'durableStartCompactionSeq')) return run;
+    run.durableStartCompactionSeq = Number(durable?.compactionSeq ?? -1); run.durableStartCompactionCount = Math.max(0, Number(durable?.compactionCount) || 0);
+    return run;
+  };
   const startActiveRun = (conversation, descriptor) => {
     const responseId = String(descriptor?.responseId || '').trim();
     const incomingEpoch = Math.max(0, Number(descriptor?.runEpoch) || 0);
     if (!responseId || !incomingEpoch) throw new Error('active response requires response_id and run_epoch');
+    if (incomingEpoch <= Math.max(0, Number(conversation.retiredRunEpoch) || 0)) return false;
     if (conversation.active) {
       if (conversation.active.responseID !== responseId) throw new Error('cannot replace an active response before durable handoff');
       if (conversation.active.runEpoch !== incomingEpoch) throw new Error('cannot change the active response run_epoch');
       if (descriptor?.anchor != null) conversation.active.anchor = clone(descriptor.anchor);
       return true;
     }
-    conversation.active = activeResponse.createActiveRun({ ...descriptor, responseId, runEpoch: incomingEpoch });
+    conversation.active = initializeDurableBaseline(activeResponse.createActiveRun({ ...descriptor, responseId, runEpoch: incomingEpoch }), conversation.durable);
     activeResponse.recordCompactionRefs(conversation.active, durableMessages(conversation.durable));
     conversation.protocolError = '';
     return true;
@@ -106,12 +113,14 @@
   };
   const replaceActiveFromSnapshot = (conversation, snapshot, options = {}) => {
     const candidate = activeResponse.activeRunFromSnapshot(snapshot, options);
-    if (conversation.active && conversation.active.responseID !== candidate.responseID) {
-      throw new Error('cannot replace an active response with another snapshot owner');
-    }
+    if (candidate.runEpoch <= Math.max(0, Number(conversation.retiredRunEpoch) || 0)) return false;
+    if (conversation.active && conversation.active.responseID !== candidate.responseID) throw new Error('cannot replace an active response with another snapshot owner');
     if (conversation.active?.runEpoch && candidate.runEpoch !== conversation.active.runEpoch) return false;
     activeResponse.restoreCompactionRefs(conversation.active, candidate);
-    conversation.active = candidate;
+    if (conversation.active && Object.prototype.hasOwnProperty.call(conversation.active, 'durableStartCompactionSeq')) {
+      candidate.durableStartCompactionSeq = conversation.active.durableStartCompactionSeq; candidate.durableStartCompactionCount = conversation.active.durableStartCompactionCount;
+    }
+    conversation.active = initializeDurableBaseline(candidate, conversation.durable);
     activeResponse.recordCompactionRefs(conversation.active, durableMessages(conversation.durable));
     conversation.protocolError = candidate.terminal?.durableHandoff === false ? candidate.terminal.error : '';
     return true;
@@ -119,43 +128,52 @@
   const durableRegionReady = (durable, ordinals) => {
     if (!durable || !Array.isArray(ordinals) || ordinals.length === 0) return false;
     return ordinals.every((ordinal) => {
-      const segmentIndex = typeof durable.segmentForOrdinal === 'function' ? durable.segmentForOrdinal(ordinal) : -1;
-      const state = segmentIndex >= 0 ? durable.segments?.[segmentIndex]?.state : '';
-      return state === 'materialized' || state === 'empty';
+      const index = typeof durable.segmentForOrdinal === 'function' ? durable.segmentForOrdinal(ordinal) : -1;
+      return ['materialized', 'empty'].includes(index >= 0 ? durable.segments?.[index]?.state : '');
     });
   };
   const compactedReplacementReady = (durable, terminal) => {
-    const compactionChanged = Number(durable?.compactionSeq ?? -1) !== Number(terminal?.compactionSeq ?? -1)
+    const changed = Number(durable?.compactionSeq ?? -1) !== Number(terminal?.compactionSeq ?? -1)
       || Number(durable?.compactionCount ?? 0) !== Number(terminal?.compactionCount ?? 0);
-    if (!compactionChanged || !Array.isArray(durable?.ids) || durable.ids.length === 0) return false;
-    const tailOrdinal = durable.ids.length - 1;
-    return durableRegionReady(durable, [tailOrdinal]);
+    return changed && Array.isArray(durable?.ids) && durable.ids.length > 0
+      && durableRegionReady(durable, [durable.ids.length - 1]);
   };
   const responseRowsReady = (conversation) => {
-    const active = conversation.active;
-    if (!active?.terminal?.durableHandoff) return false;
-    const durable = conversation.durable;
-    const rev = Math.max(0, Number(durable?.rev) || 0);
-    if (rev < active.terminal.finalRev) return false;
+    const active = conversation.active, durable = conversation.durable;
+    if (!active?.terminal?.durableHandoff || Math.max(0, Number(durable?.rev) || 0) < active.terminal.finalRev) return false;
     if (active.terminal.durableOutputCount === 0) return true;
-    if (Array.isArray(durable?.responseIDs)) {
-      const ordinals = [];
-      for (let ordinal = 0; ordinal < durable.responseIDs.length; ordinal++) {
-        if (String(durable.responseIDs[ordinal] || '') === active.responseID) ordinals.push(ordinal);
-      }
-      if (ordinals.length > 0) return durableRegionReady(durable, ordinals);
-      return compactedReplacementReady(durable, active.terminal);
-    }
-    return durableMessages(durable).some((message) => responseID(message) === active.responseID);
+    if (!Array.isArray(durable?.responseIDs)) return durableMessages(durable).some((message) => responseID(message) === active.responseID);
+    const ordinals = durable.responseIDs.map((owner, ordinal) => String(owner || '') === active.responseID ? ordinal : -1).filter((ordinal) => ordinal >= 0);
+    return ordinals.length > 0 ? durableRegionReady(durable, ordinals) : compactedReplacementReady(durable, active.terminal);
   };
-  const commitDurableHandoff = (conversation) => {
-    if (!conversation.active?.terminal) return false;
-    if (conversation.active.terminal.durableHandoff !== true) return false;
-    if (!responseRowsReady(conversation)) return false;
-    conversation.active = null;
-    conversation.protocolError = '';
-    acknowledgeDurableIntents(conversation);
-    return true;
+  const finishDurableHandoff = (conversation) => {
+    const retiredEpoch = Math.max(0, Number(conversation.active?.runEpoch) || 0);
+    conversation.active = null; conversation.protocolError = '';
+    conversation.retiredRunEpoch = Math.max(Math.max(0, Number(conversation.retiredRunEpoch) || 0), retiredEpoch);
+    acknowledgeDurableIntents(conversation); return true;
+  };
+  const commitDurableHandoff = (conversation) => conversation.active?.terminal?.durableHandoff === true
+    && responseRowsReady(conversation) && finishDurableHandoff(conversation);
+  const orphanedResponseRowsReady = (conversation, active) => {
+    const durable = conversation.durable, ordinals = [];
+    for (let ordinal = 0; ordinal < (durable?.responseIDs?.length || 0); ordinal++) {
+      if (String(durable.responseIDs[ordinal] || '') === active.responseID) ordinals.push(ordinal);
+    }
+    if (ordinals.length > 0) return durableRegionReady(durable, ordinals);
+    // Zero-output projections are safe to drop. Observed output without exact
+    // ownership requires a materialized compaction that advanced after attach.
+    // Pre-attachment compaction remains frozen: this path has no final_rev.
+    if (!active.projection.some((entry) => entry?.terminalPolicy === 'durable' && entry.role !== 'compaction-ref')) return true;
+    return compactedReplacementReady(durable, { compactionSeq: active.durableStartCompactionSeq, compactionCount: active.durableStartCompactionCount });
+  };
+  const retireOrphanedActiveProjection = (conversation, authority = {}) => {
+    const active = conversation?.active, responseId = String(authority.responseId || authority.response_id || '').trim();
+    const runEpoch = Math.max(0, Number(authority.runEpoch ?? authority.run_epoch) || 0);
+    const revision = Number(authority.transcriptRev ?? authority.transcript_rev);
+    const startedRev = Math.max(0, Number(authority.startedRev ?? authority.started_rev) || 0);
+    if (!active || active.terminal || !responseId || !runEpoch || !Number.isFinite(revision) || revision < startedRev || revision < 0) return false;
+    if (active.responseID !== responseId || active.runEpoch !== runEpoch || Math.max(0, Number(conversation.durable?.rev) || 0) < revision) return false;
+    return orphanedResponseRowsReady(conversation, active) && finishDurableHandoff(conversation);
   };
   const visibleMessages = (conversation) => {
     const active = conversation.active;
@@ -315,11 +333,12 @@
         anchor,
       });
     }
+    retireOrphanedActiveProjection(authority = {}) { return retireOrphanedActiveProjection(this.conversation, authority); }
     transitionAuthoritativeRun(responseId, startedRev = 0, runEpoch = 0, options = {}) {
       const id = String(responseId || '').trim();
       const epoch = Math.max(0, Number(runEpoch) || 0);
       const revision = Math.max(0, Number(startedRev) || 0);
-      if (!id || !epoch) return false;
+      if (!id || !epoch || epoch <= Math.max(0, Number(this.conversation.retiredRunEpoch) || 0)) return false;
       const active = this.conversation.active;
       if (!active || active.responseID === id) {
         return this.setActiveRun(id, revision, epoch, options);
@@ -333,11 +352,7 @@
         : (explicitRowID != null && String(explicitRowID) !== ''
           ? { durableRowId: explicitRowID }
           : (durableTailID != null ? { durableRowId: durableTailID } : null)));
-      this.conversation.active = activeResponse.createActiveRun({
-        responseId: id,
-        runEpoch: epoch,
-        anchor,
-      });
+      this.conversation.active = initializeDurableBaseline(activeResponse.createActiveRun({ responseId: id, runEpoch: epoch, anchor }), this.conversation.durable);
       activeResponse.recordCompactionRefs(this.conversation.active, durableMessages(this.conversation.durable));
       this.conversation.protocolError = '';
       this.startedRev = revision;
@@ -436,7 +451,7 @@
       : controller?.setActiveRun(run.responseId, run.startedRev, run.runEpoch, run.options);
   };
   const dispatchRunEvent = (controller, event, payload = {}) => {
-    attachActiveRun(controller, payload);
+    if (attachActiveRun(controller, payload) !== true) return null;
     return controller?.applyResponseEvent(event, payload) || null;
   };
   const replaceRunSnapshot = (controller, payload) => controller?.replaceActiveSnapshot(payload);
@@ -973,27 +988,12 @@
       reconcileTranscriptFromStatus
     });
   };
-
   return Object.freeze({
-    createConversation,
-    addIntent,
-    acknowledgeDurableIntents,
-    startActiveRun,
-    applyRunEvent,
-    replaceActiveFromSnapshot,
-    responseRowsReady,
-    commitDurableHandoff,
-    visibleMessages,
-    sessionMessages,
-    applyDurable,
-    SessionCommandQueue,
-    ConversationController,
-    assistantSegmentKey,
-    transcriptToolIdentityKey,
-    transcriptIsClientOwnedIntent,
-    transcriptDiagnostic,
+    createConversation, addIntent, acknowledgeDurableIntents, startActiveRun, applyRunEvent, replaceActiveFromSnapshot,
+    responseRowsReady, durableRegionReady, compactedReplacementReady, commitDurableHandoff, retireOrphanedActiveProjection,
+    visibleMessages, sessionMessages, applyDurable, SessionCommandQueue, ConversationController,
+    assistantSegmentKey, transcriptToolIdentityKey, transcriptIsClientOwnedIntent, transcriptDiagnostic,
     attachActiveRun, dispatchRunEvent, replaceRunSnapshot, enqueueDetachedReplay, addPendingIntentToConversation,
-    applyTranscriptIndex, materializeTranscriptBodies, destroyConversationController,
-    initEffects,
+    applyTranscriptIndex, materializeTranscriptBodies, destroyConversationController, initEffects,
   });
 });

--- a/internal/serveui/static/conversation_test.js
+++ b/internal/serveui/static/conversation_test.js
@@ -629,7 +629,132 @@ const envelope = (messages, rev = 1) => ({ rev, messages, renderedMessages() { r
   assert.equal(transcript.activeRun.id, 'web-run');
 })();
 
+(() => {
+  const transcript = new conversationAPI.ConversationController('orphan-newer-epoch');
+  transcript.applyIndex({
+    rev: 2, compaction_seq: -1, compaction_count: 0,
+    rows: {
+      ids: [1, 2], seqs: [0, 1], roles: 'ua', flags: [0, 0],
+      client_message_ids: { 0: 'client-orphan' }, response_ids: ['', 'resp-orphan'], assistant_segment_ordinals: [-1, 0]
+    }
+  });
+  transcript.materialize([
+    { id: 1, sequence: 0, role: 'user', client_message_id: 'client-orphan', parts: [{ type: 'text', text: 'question' }] },
+    { id: 2, sequence: 1, role: 'assistant', response_id: 'resp-orphan', parts: [{ type: 'text', text: 'durable answer' }] },
+  ]);
+  transcript.publishedMessages = [
+    { id: 1, role: 'user', durable: true, clientMessageId: 'client-orphan', content: 'question' },
+    { id: 2, role: 'assistant', durable: true, responseId: 'resp-orphan', content: 'durable answer' },
+  ];
+  transcript.setActiveRun('resp-orphan', 1, 7);
+  transcript.applyResponseEvent('response.output_text.delta', {
+    response_id: 'resp-orphan', run_epoch: 7, sequence_number: 1, delta: 'stale overlay'
+  });
+  transcript.addPendingIntent({ id: 'client-orphan', clientMessageId: 'client-orphan', role: 'user', content: 'question' });
+  transcript.conversation.protocolError = 'stale diagnostic';
+  assert.throws(() => transcript.setActiveRun('resp-newer-blocked', 2, 8), /active response/);
+  assert.equal(transcript.latestRunEpoch, 8, 'fixture must preserve the failed newer epoch bump');
+  assert.equal(transcript.activeRun.id, 'resp-orphan', 'failed newer start replaced the orphan owner');
+
+  assert.equal(transcript.retireOrphanedActiveProjection({
+    responseId: 'resp-orphan', runEpoch: 7, startedRev: 1, transcriptRev: 2
+  }), true, 'newer latestRunEpoch must not block retirement of the still-owned orphan');
+  assert.equal(transcript.conversation.active, null);
+  assert.equal(transcript.conversation.protocolError, '');
+  assert.equal(transcript.conversation.intents.size, 0, 'orphan handoff bypassed durable intent acknowledgement');
+  assert(transcript.conversation.acknowledgedIntentIDs.has('client-orphan'));
+  assert.equal(conversationAPI.dispatchRunEvent(transcript, 'response.output_text.delta', {
+    response_id: 'resp-orphan', run_epoch: 7, sequence_number: 2, delta: 'late'
+  }), null, 'late event resurrected a retired orphan epoch');
+  assert.equal(transcript.replaceActiveSnapshot({
+    id: 'resp-orphan', run_epoch: 7, status: 'in_progress', last_sequence_number: 2,
+    recovery: { messages: [{ role: 'assistant', content: 'late replay' }] }
+  }), false, 'late recovery snapshot resurrected a retired orphan epoch');
+  assert.equal(transcript.conversation.active, null);
+  assert.equal(transcript.transitionAuthoritativeRun('resp-after-orphan', 2, 8), true, 'retired epoch blocked a genuinely newer run');
+})();
+
+(() => {
+  const unmaterialized = new conversationAPI.ConversationController('orphan-unmaterialized');
+  unmaterialized.applyIndex({
+    rev: 2, compaction_seq: -1, compaction_count: 0,
+    rows: { ids: [1], seqs: [0], roles: 'a', flags: [0], response_ids: ['resp-unmaterialized'], assistant_segment_ordinals: [0] }
+  });
+  unmaterialized.setActiveRun('resp-unmaterialized', 1, 1);
+  unmaterialized.applyResponseEvent('response.output_text.delta', {
+    response_id: 'resp-unmaterialized', run_epoch: 1, sequence_number: 1, delta: 'must remain'
+  });
+  assert.equal(unmaterialized.retireOrphanedActiveProjection({
+    responseId: 'resp-unmaterialized', runEpoch: 1, startedRev: 1, transcriptRev: 2
+  }), false, 'unmaterialized owning segment incorrectly proved durable handoff');
+
+  const behind = new conversationAPI.ConversationController('orphan-behind-authority');
+  behind.applyIndex({
+    rev: 1, compaction_seq: -1, compaction_count: 0,
+    rows: { ids: [1], seqs: [0], roles: 'a', flags: [0], response_ids: ['resp-behind'], assistant_segment_ordinals: [0] }
+  });
+  behind.materialize([{ id: 1, sequence: 0, role: 'assistant', parts: [{ type: 'text', text: 'partial durable' }] }]);
+  behind.setActiveRun('resp-behind', 0, 1);
+  assert.equal(behind.retireOrphanedActiveProjection({
+    responseId: 'resp-behind', runEpoch: 1, startedRev: 0, transcriptRev: 2
+  }), false, 'transcript below runtime transcript_rev incorrectly proved authority');
+
+  const terminal = new conversationAPI.ConversationController('orphan-terminal-not-ready');
+  terminal.setActiveRun('resp-terminal-wait', 0, 1);
+  terminal.applyResponseEvent('response.output_text.delta', {
+    response_id: 'resp-terminal-wait', run_epoch: 1, sequence_number: 1, delta: 'frozen terminal'
+  });
+  terminal.applyResponseEvent('response.completed', {
+    response_id: 'resp-terminal-wait', run_epoch: 1, sequence_number: 2,
+    final_rev: 3, durable_handoff: true, durable_output_count: 1
+  });
+  assert.equal(terminal.retireOrphanedActiveProjection({
+    responseId: 'resp-terminal-wait', runEpoch: 1, startedRev: 0, transcriptRev: 0
+  }), false, 'orphan primitive bypassed a terminal handoff that was not durable-ready');
+  assert.equal(conversationAPI.commitDurableHandoff(terminal.conversation), false);
+  assert(terminal.conversation.active, 'terminal-not-ready projection was dropped');
+})();
+
+(() => {
+  const zeroOutput = new conversationAPI.ConversationController('orphan-zero-output');
+  zeroOutput.setActiveRun('resp-zero-output', 0, 1);
+  assert.equal(zeroOutput.retireOrphanedActiveProjection({
+    responseId: 'resp-zero-output', runEpoch: 1, startedRev: 0, transcriptRev: 0
+  }), true, 'authoritative zero-output orphan did not retire');
+
+  const compacted = new conversationAPI.ConversationController('orphan-compacted-output');
+  compacted.applyIndex({
+    rev: 1, compaction_seq: -1, compaction_count: 0,
+    rows: { ids: [1], seqs: [0], roles: 'u', flags: [0], response_ids: [''], assistant_segment_ordinals: [-1] }
+  });
+  compacted.materialize([{ id: 1, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'question' }] }]);
+  compacted.setActiveRun('resp-compacted-orphan', 1, 1);
+  compacted.applyResponseEvent('response.output_text.delta', {
+    response_id: 'resp-compacted-orphan', run_epoch: 1, sequence_number: 1, delta: 'original output'
+  });
+  compacted.applyIndex({
+    rev: 3, compaction_seq: 0, compaction_count: 1,
+    rows: { ids: [9], seqs: [0], roles: 'a', flags: [0], response_ids: [''], assistant_segment_ordinals: [-1] }
+  });
+  compacted.materialize([{ id: 9, sequence: 0, role: 'assistant', parts: [{ type: 'text', text: 'compacted replacement' }] }]);
+  assert.equal(compacted.retireOrphanedActiveProjection({
+    responseId: 'resp-compacted-orphan', runEpoch: 1, startedRev: 1, transcriptRev: 3
+  }), true, 'materialized post-start compaction did not prove orphan replacement');
+})();
+
 (async () => {
+  const replay = new conversationAPI.ConversationController('orphan-late-detached-replay');
+  replay.setActiveRun('resp-late-replay', 0, 3);
+  assert.equal(replay.retireOrphanedActiveProjection({
+    responseId: 'resp-late-replay', runEpoch: 3, startedRev: 0, transcriptRev: 0
+  }), true);
+  assert.equal(conversationAPI.attachActiveRun(replay, { response_id: 'resp-late-replay', run_epoch: 3 }), false);
+  await assert.rejects(conversationAPI.enqueueDetachedReplay(replay, [{
+    event: 'response.output_text.delta',
+    payload: { response_id: 'resp-late-replay', run_epoch: 3, sequence_number: 1, delta: 'late after=0 replay' }
+  }], () => true), /active response is required/);
+  assert.equal(replay.conversation.active, null, 'late detached replay resurrected retired overlay');
+
   const queue = new conversationAPI.SessionCommandQueue();
   const order = [];
   const first = queue.enqueue(async () => { await new Promise((resolve) => setTimeout(resolve, 5)); order.push(1); });


### PR DESCRIPTION
## What

- retire a nonterminal client-side active projection when selected-session state is authoritatively idle **and** the sampled response owner is present in a current, materialized durable transcript
- preserve the existing request-generation, `run_epoch`, stream-generation, controller, session, and response transport ownership guards before and after the queued transcript mutation
- republish and render the durable projection immediately after retirement
- add executable regression coverage for the lost-terminal-event incident, missing durable ownership, a newer run racing a stale idle response, and the existing transport race

## Incident

The production response stream stopped at cursor **168** while WebRTC per-channel request slots were saturated, so response/events/state requests initially returned immediate 503s. Server state and the durable transcript eventually recovered completely: state was idle, and transcript **rev 351** contained **233 rows and 233 bodies**.

The existing tab nevertheless remained frozen at **20 tool calls**, while a fresh reload showed **46 tool calls plus the final answer**. The stale `session.transcript.conversation.active` projection was still nonterminal because the terminal stream event had been lost. `visibleMessages()` therefore continued suppressing durable rows owned by that response and inserted the stale active projection instead.

Force-refetching the transcript index and releasing/refetching every body could not help: those operations refreshed the already-correct durable store, but projection composition still hid its response-owned rows behind the orphaned active overlay.

## Authority and race safety

This does not clear every projection on idle. Retirement requires all of the following:

1. the state response says there is no active run or response;
2. the projection existed when that state request was sampled and is still the same nonterminal response owner and `run_epoch`;
3. no newer run epoch has appeared;
4. the authoritative positive `transcript_rev` has been reached locally;
5. the transcript index contains rows owned by that response and every owning segment is materialized (or explicitly empty), matching durable handoff readiness;
6. the sampled transport/controller/stream generation still owns the reconciliation, with the guard repeated after the queued transcript command.

A stale idle response therefore cannot cancel a run started during its round trip. If durable ownership or materialization cannot be proven, the overlay is conservatively preserved.

## Tests

- `node internal/serveui/static/conversation_test.js`
- `node internal/serveui/static/app_sessions_test.js`
- `go test ./internal/serveui -run 'Test(ConversationLifecycleJS|AppSessionsJS)$' -count=1`
- `go test ./internal/serveui -count=1`
- `go build ./...`
- `HOME=$(mktemp -d) GOCACHE=/home/agent/.cache/go-build GOPATH=/home/agent/go go test ./...`

The unisolated full-suite invocation picked up the host's global skill catalog and failed two unrelated working-directory skill tests; the isolated-HOME full suite passed.
