### PR TITLE
fix: accept string actions in image output items

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -228,9 +228,10 @@ type responsesOutputItem struct {
 	// For image_generation_call
 	Result        string `json:"result,omitempty"`         // base64-encoded image payload
 	RevisedPrompt string `json:"revised_prompt,omitempty"` // model's revised prompt
-	// For web_search_call
-	Status string                   `json:"status,omitempty"`
-	Action responsesWebSearchAction `json:"action,omitempty"`
+	// For web_search_call. Action is kept raw because other output item types
+	// (notably image_generation_call) may use the same field with a string value.
+	Status string          `json:"status,omitempty"`
+	Action json.RawMessage `json:"action,omitempty"`
 }
 
 type responsesWebSearchAction struct {

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -2577,10 +2577,25 @@ func TestResponsesClientStream_EmitsImageGeneratedEvent(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString(imageBytes)
 	revised := "a red square on a white background"
 
+	addedItem := map[string]any{
+		"type":         "response.output_item.added",
+		"output_index": 0,
+		"item": map[string]any{
+			"type":   "image_generation_call",
+			"action": "generate",
+		},
+	}
+	addedJSON, err := json.Marshal(addedItem)
+	if err != nil {
+		t.Fatalf("marshal added item: %v", err)
+	}
+
 	doneItem := map[string]any{
-		"type": "response.output_item.done",
+		"type":         "response.output_item.done",
+		"output_index": 0,
 		"item": map[string]any{
 			"type":           "image_generation_call",
+			"action":         "generate",
 			"result":         encoded,
 			"revised_prompt": revised,
 		},
@@ -2591,7 +2606,8 @@ func TestResponsesClientStream_EmitsImageGeneratedEvent(t *testing.T) {
 	}
 
 	sse := fmt.Sprintf(
-		"event: response.output_item.done\ndata: %s\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_img_1\"}}\n\n",
+		"event: response.output_item.added\ndata: %s\n\nevent: response.output_item.done\ndata: %s\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_img_1\"}}\n\n",
+		string(addedJSON),
 		string(doneJSON),
 	)
 

--- a/internal/llm/responses_event_handler.go
+++ b/internal/llm/responses_event_handler.go
@@ -264,9 +264,13 @@ func (h *responsesStreamEventHandler) HandleJSONEvent(data []byte, eventType str
 			h.toolState.FinishCall(doneEvent.OutputIndex, doneEvent.Item.CallID, doneEvent.Item.Name, doneEvent.Item.Arguments)
 			h.toolState.SetCaller(doneEvent.OutputIndex, doneEvent.Item.Caller)
 		} else if doneEvent.Item.Type == "web_search_call" {
+			action, err := decodeResponsesWebSearchAction(doneEvent.Item.Action)
+			if err != nil {
+				return false, fmt.Errorf("decode web_search_call action: %w", err)
+			}
 			callID := responsesWebSearchCallID(doneEvent.Item.ID, doneEvent.OutputIndex)
-			toolInfo := responsesWebSearchToolInfo(doneEvent.Item.Action)
-			toolArgs := responsesWebSearchToolArguments(doneEvent.Item.Action)
+			toolInfo := responsesWebSearchToolInfo(action)
+			toolArgs := responsesWebSearchToolArguments(action)
 			toolSucceeded := strings.EqualFold(doneEvent.Item.Status, "completed")
 			status := ToolActivityFailed
 			if toolSucceeded {
@@ -494,6 +498,17 @@ func responsesWebSearchCallID(itemID string, outputIndex int) string {
 		return itemID
 	}
 	return fmt.Sprintf("web_search:%d", outputIndex)
+}
+
+func decodeResponsesWebSearchAction(raw json.RawMessage) (responsesWebSearchAction, error) {
+	var action responsesWebSearchAction
+	if len(raw) == 0 {
+		return action, nil
+	}
+	if err := json.Unmarshal(raw, &action); err != nil {
+		return action, err
+	}
+	return action, nil
 }
 
 func responsesWebSearchToolArguments(action responsesWebSearchAction) json.RawMessage {


### PR DESCRIPTION
## What

Keep Responses API output-item `action` values as raw JSON and decode them as structured web-search actions only for `web_search_call` items.

Add a regression fixture matching ChatGPT image-generation events, where both `response.output_item.added` and `response.output_item.done` contain:

```json
{"type":"image_generation_call","action":"generate"}
```

## Why

`responsesOutputItem.Action` was globally typed as `responsesWebSearchAction`. ChatGPT's image-generation stream uses the same field name with the string value `"generate"`, so decoding aborted before the image result could be emitted:

```
decode Responses API output item: json: cannot unmarshal string into Go struct field responsesOutputItem.action of type llm.responsesWebSearchAction
```

Output items are polymorphic; the shared envelope must not impose web-search's object schema on image-generation calls.

## Verification

- `go test ./internal/llm ./internal/image`
- `go build ./...`
- Full `go test ./...` passes all affected packages; `cmd` has two unrelated ambient-skill-discovery failures (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`) caused by the mounted Jarvis skill set winning the test metadata budget.
