### PR TITLE
Add /undo and /redo to web and TUI

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1605,6 +1605,20 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if suffix == "runtime/undo" || suffix == "runtime/redo" {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
+			return
+		}
+		s.handleSessionUndoRedo(w, r, sessionID, suffix == "runtime/redo")
+		return
+	}
+
 	if suffix == "runtime/effort" {
 		if r.Method != http.MethodPost {
 			w.Header().Set("Allow", "POST")

--- a/cmd/serve_undo_redo.go
+++ b/cmd/serve_undo_redo.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type sessionUndoRedoRequest struct {
+	ExpectedRev    int64 `json:"expected_rev"`
+	ExpectedHeadID int64 `json:"expected_head_id"`
+}
+
+func (rt *serveRuntime) resetAfterTranscriptMutation(ctx context.Context, sessionID string) error {
+	if rt == nil {
+		return nil
+	}
+	// Reset continuation and make the in-memory transcript non-authoritative
+	// before any reload that can fail. A later request will hydrate from storage
+	// when sessionMeta remains nil.
+	rt.history = nil
+	rt.historyPersisted = false
+	rt.sessionMeta = nil
+	rt.lastInjectedPlatform = ""
+	rt.clearLastUIRunError()
+	if rt.engine != nil {
+		rt.engine.ResetSessionState(sessionID)
+		rt.engine.SetContextEstimateBaseline(0, 0)
+	}
+	rt.responseMu.Lock()
+	rt.lastResponseID = ""
+	rt.responseIDs = nil
+	rt.responseMu.Unlock()
+	rt.refreshSideQuestionSnapshot(nil)
+
+	sess, err := rt.store.Get(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("reload session metadata: %w", err)
+	}
+	messages, err := session.LoadActiveMessages(ctx, rt.store, sess)
+	if err != nil {
+		return fmt.Errorf("reload active transcript: %w", err)
+	}
+	history := make([]llm.Message, 0, len(messages))
+	for i := range messages {
+		history = append(history, messages[i].ToLLMMessage())
+	}
+	rt.history = history
+	rt.historyPersisted = true
+	rt.sessionMeta = sess
+	rt.restorePlatformInjectionStateFromHistory()
+	rt.refreshSideQuestionSnapshot(history)
+	return nil
+}
+
+func (s *serveServer) handleSessionUndoRedo(w http.ResponseWriter, r *http.Request, sessionID string, redo bool) {
+	operation := "undo"
+	if redo {
+		operation = "redo"
+	}
+	var req sessionUndoRedoRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	mutationStore, ok := s.store.(session.TranscriptUndoRedoStore)
+	if !ok {
+		writeOpenAIError(w, http.StatusNotImplemented, "server_error", "session storage does not support undo/redo")
+		return
+	}
+
+	if s.responseRuns != nil && s.responseRuns.activeRunID(sessionID) != "" {
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", "cannot mutate the transcript while work is active")
+		return
+	}
+
+	var rt *serveRuntime
+	if s.sessionMgr != nil {
+		rt, _ = s.sessionMgr.Get(sessionID)
+		if rt != nil {
+			if !rt.mu.TryLock() {
+				writeOpenAIError(w, http.StatusConflict, "conflict_error", "cannot mutate the transcript while work is active")
+				return
+			}
+			defer rt.mu.Unlock()
+			if rt.hasActiveActivity() || (s.responseRuns != nil && s.responseRuns.activeRunID(sessionID) != "") {
+				writeOpenAIError(w, http.StatusConflict, "conflict_error", "cannot mutate the transcript while work is active")
+				return
+			}
+		}
+	}
+
+	expected := session.TranscriptMutationState{Rev: req.ExpectedRev, HeadID: req.ExpectedHeadID}
+	var result session.TranscriptMutationResult
+	var err error
+	if redo {
+		result, err = mutationStore.RedoLastUserTurn(r.Context(), sessionID, expected)
+	} else {
+		result, err = mutationStore.UndoLastUserTurn(r.Context(), sessionID, expected)
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, session.ErrNotFound):
+			writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
+		case errors.Is(err, session.ErrNothingToUndo):
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", "nothing to undo")
+		case errors.Is(err, session.ErrNothingToRedo):
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", "nothing to redo")
+		case errors.Is(err, session.ErrTranscriptConflict):
+			writeOpenAIError(w, http.StatusConflict, "conflict_error", "transcript changed; refresh and try again")
+		default:
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to "+operation+" transcript")
+		}
+		return
+	}
+
+	if rt != nil {
+		oldResponseIDs := rt.getResponseIDs()
+		if rt.store == nil {
+			rt.store = s.store
+		}
+		if err := rt.resetAfterTranscriptMutation(r.Context(), sessionID); err != nil {
+			log.Printf("[serve] transcript mutation runtime reload failed for %s: %v", sessionID, err)
+		}
+		for _, responseID := range oldResponseIDs {
+			s.responseToSession.Delete(responseID)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":                  true,
+		"operation":           operation,
+		"rev":                 result.Rev,
+		"head_id":             result.HeadID,
+		"user_text":           result.UserText,
+		"attachments_omitted": result.AttachmentsOmitted,
+	})
+}

--- a/cmd/serve_undo_redo_test.go
+++ b/cmd/serve_undo_redo_test.go
@@ -127,6 +127,57 @@ func TestServeUndoRedoShrinksRestoresAndResetsRuntime(t *testing.T) {
 	}
 }
 
+func TestServeUndoRedoSequentialCommandsRestoreTurnsInLIFOOrder(t *testing.T) {
+	srv, store, rt, provider, sessionID := newServeUndoRedoTest(t)
+	turnB := addServeUndoRedoMessage(t, store, sessionID, llm.UserText("turn B"))
+	answerB := addServeUndoRedoMessage(t, store, sessionID, llm.AssistantText("answer B"))
+	turnA := addServeUndoRedoMessage(t, store, sessionID, llm.UserText("turn A"))
+	answerA := addServeUndoRedoMessage(t, store, sessionID, llm.AssistantText("answer A"))
+	rt.history = []llm.Message{turnB.ToLLMMessage(), answerB.ToLLMMessage(), turnA.ToLLMMessage(), answerA.ToLLMMessage()}
+	state, err := store.TranscriptMutationState(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type mutationPayload struct {
+		Rev      int64  `json:"rev"`
+		HeadID   int64  `json:"head_id"`
+		UserText string `json:"user_text"`
+	}
+	mutate := func(operation string) mutationPayload {
+		t.Helper()
+		rr := requestServeUndoRedo(t, srv, sessionID, operation, state)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s status/body = %d %s", operation, rr.Code, rr.Body.String())
+		}
+		var payload mutationPayload
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatal(err)
+		}
+		state = session.TranscriptMutationState{Rev: payload.Rev, HeadID: payload.HeadID}
+		return payload
+	}
+
+	if payload := mutate("undo"); payload.UserText != "turn A" || len(rt.history) != 2 {
+		t.Fatalf("first undo payload=%+v history=%d", payload, len(rt.history))
+	}
+	if payload := mutate("undo"); payload.UserText != "turn B" || len(rt.history) != 0 {
+		t.Fatalf("second undo payload=%+v history=%d", payload, len(rt.history))
+	}
+	mutate("redo")
+	messages, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil || len(messages) != 2 || messages[0].ID != turnB.ID || messages[1].ID != answerB.ID || len(rt.history) != 2 {
+		t.Fatalf("first redo messages=%#v history=%d err=%v", messages, len(rt.history), err)
+	}
+	mutate("redo")
+	messages, err = store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil || len(messages) != 4 || messages[2].ID != turnA.ID || messages[3].ID != answerA.ID || len(rt.history) != 4 {
+		t.Fatalf("second redo messages=%#v history=%d err=%v", messages, len(rt.history), err)
+	}
+	if provider.resets != 4 {
+		t.Fatalf("provider resets=%d, want one per sequential mutation", provider.resets)
+	}
+}
+
 func TestServeUndoRejectsActiveWorkAndStaleClient(t *testing.T) {
 	srv, store, _, _, sessionID := newServeUndoRedoTest(t)
 	addServeUndoRedoMessage(t, store, sessionID, llm.UserText("prompt"))

--- a/cmd/serve_undo_redo_test.go
+++ b/cmd/serve_undo_redo_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type undoRedoResetProvider struct {
+	*llm.MockProvider
+	resets int
+}
+
+func (p *undoRedoResetProvider) ResetConversation() { p.resets++ }
+
+func newServeUndoRedoTest(t *testing.T) (*serveServer, *session.SQLiteStore, *serveRuntime, *undoRedoResetProvider, string) {
+	t.Helper()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	sessionID := session.NewID()
+	if err := store.Create(context.Background(), &session.Session{ID: sessionID, Provider: "mock", ProviderKey: "mock", Model: "mock", Mode: session.ModeChat}); err != nil {
+		t.Fatal(err)
+	}
+	provider := &undoRedoResetProvider{MockProvider: llm.NewMockProvider("mock")}
+	rt := &serveRuntime{
+		provider:         provider,
+		providerKey:      "mock",
+		engine:           llm.NewEngine(provider, nil),
+		store:            store,
+		historyPersisted: true,
+	}
+	rt.Touch()
+	mgr := newServeSessionManager(time.Minute, 10, func(context.Context) (*serveRuntime, error) { return rt, nil })
+	t.Cleanup(mgr.Close)
+	if _, err := mgr.GetOrCreate(context.Background(), sessionID); err != nil {
+		t.Fatal(err)
+	}
+	srv := &serveServer{store: store, sessionMgr: mgr, responseRuns: newServeResponseRunManager()}
+	t.Cleanup(func() { srv.responseRuns.Close() })
+	return srv, store, rt, provider, sessionID
+}
+
+func addServeUndoRedoMessage(t *testing.T, store *session.SQLiteStore, sessionID string, msg llm.Message) session.Message {
+	t.Helper()
+	stored := session.NewMessage(sessionID, msg, -1)
+	if err := store.AddMessage(context.Background(), sessionID, stored); err != nil {
+		t.Fatal(err)
+	}
+	return *stored
+}
+
+func requestServeUndoRedo(t *testing.T, srv *serveServer, sessionID, operation string, state session.TranscriptMutationState) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(sessionUndoRedoRequest{ExpectedRev: state.Rev, ExpectedHeadID: state.HeadID})
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sessionID+"/runtime/"+operation, strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	return rr
+}
+
+func TestServeUndoRedoShrinksRestoresAndResetsRuntime(t *testing.T) {
+	srv, store, rt, provider, sessionID := newServeUndoRedoTest(t)
+	first := addServeUndoRedoMessage(t, store, sessionID, llm.UserText("first"))
+	second := addServeUndoRedoMessage(t, store, sessionID, llm.AssistantText("answer"))
+	third := addServeUndoRedoMessage(t, store, sessionID, llm.UserText("restore me"))
+	fourth := addServeUndoRedoMessage(t, store, sessionID, llm.AssistantText("latest answer"))
+	rt.history = []llm.Message{first.ToLLMMessage(), second.ToLLMMessage(), third.ToLLMMessage(), fourth.ToLLMMessage()}
+	if err := store.SaveProviderState(context.Background(), sessionID, "mock", []byte(`{"continuation":true}`)); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.TranscriptMutationState(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := requestServeUndoRedo(t, srv, sessionID, "undo", state)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("undo status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	var payload struct {
+		Rev      int64  `json:"rev"`
+		HeadID   int64  `json:"head_id"`
+		UserText string `json:"user_text"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.UserText != "restore me" || len(rt.history) != 2 {
+		t.Fatalf("undo payload/history = %#v len=%d", payload, len(rt.history))
+	}
+	if provider.resets != 1 || !rt.historyPersisted {
+		t.Fatalf("runtime reset count=%d persisted=%v", provider.resets, rt.historyPersisted)
+	}
+	providerState, err := store.LoadProviderState(context.Background(), sessionID, "mock")
+	if err != nil || len(providerState) != 0 {
+		t.Fatalf("provider state = %q err=%v", providerState, err)
+	}
+	messages, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil || len(messages) != 2 {
+		t.Fatalf("messages after undo len=%d err=%v", len(messages), err)
+	}
+
+	rr = requestServeUndoRedo(t, srv, sessionID, "redo", session.TranscriptMutationState{Rev: payload.Rev, HeadID: payload.HeadID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("redo status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	messages, err = store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil || len(messages) != 4 {
+		t.Fatalf("messages after redo len=%d err=%v", len(messages), err)
+	}
+	if messages[2].ID != third.ID || messages[3].ID != fourth.ID || len(rt.history) != 4 {
+		t.Fatalf("redo did not restore exact suffix/runtime: %#v history=%d", messages, len(rt.history))
+	}
+	if provider.resets != 2 {
+		t.Fatalf("provider reset count after redo = %d", provider.resets)
+	}
+}
+
+func TestServeUndoRejectsActiveWorkAndStaleClient(t *testing.T) {
+	srv, store, _, _, sessionID := newServeUndoRedoTest(t)
+	addServeUndoRedoMessage(t, store, sessionID, llm.UserText("prompt"))
+	state, err := store.TranscriptMutationState(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.responseRuns.setActiveRun(sessionID, "resp_active")
+	rr := requestServeUndoRedo(t, srv, sessionID, "undo", state)
+	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "work is active") {
+		t.Fatalf("active status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	srv.responseRuns.clearActiveRun(sessionID, "resp_active")
+
+	stale := state
+	stale.HeadID++
+	rr = requestServeUndoRedo(t, srv, sessionID, "undo", stale)
+	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "transcript changed") {
+		t.Fatalf("stale status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	messages, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil || len(messages) != 1 {
+		t.Fatalf("stale request mutated transcript len=%d err=%v", len(messages), err)
+	}
+}
+
+func TestServeUndoWorksWithoutCachedRuntimeOrRuntimeFactory(t *testing.T) {
+	srv, store, _, _, sessionID := newServeUndoRedoTest(t)
+	addServeUndoRedoMessage(t, store, sessionID, llm.UserText("storage only"))
+	state, err := store.TranscriptMutationState(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	factoryCalls := 0
+	srv.sessionMgr.mu.Lock()
+	delete(srv.sessionMgr.sessions, sessionID)
+	srv.sessionMgr.factory = func(context.Context) (*serveRuntime, error) {
+		factoryCalls++
+		return nil, context.Canceled
+	}
+	srv.sessionMgr.mu.Unlock()
+
+	rr := requestServeUndoRedo(t, srv, sessionID, "undo", state)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("storage-only undo status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("runtime factory called %d times, want 0", factoryCalls)
+	}
+	messages, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil || len(messages) != 0 {
+		t.Fatalf("storage-only undo messages=%d err=%v", len(messages), err)
+	}
+}
+
+func TestServeUndoReportsAttachmentsOmitted(t *testing.T) {
+	srv, store, _, _, sessionID := newServeUndoRedoTest(t)
+	message := llm.UserText("describe this")
+	message.Parts = append(message.Parts, llm.Part{Type: llm.PartFile, Text: "file contents"})
+	addServeUndoRedoMessage(t, store, sessionID, message)
+	state, err := store.TranscriptMutationState(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := requestServeUndoRedo(t, srv, sessionID, "undo", state)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("undo status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	var payload struct {
+		AttachmentsOmitted bool   `json:"attachments_omitted"`
+		UserText           string `json:"user_text"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload.AttachmentsOmitted || payload.UserText != "describe this" {
+		t.Fatalf("payload = %s, want text-only composer value with attachment warning flag", rr.Body.String())
+	}
+}

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -357,6 +357,24 @@ func (e *Engine) ResetConversation() {
 	resetProviderConversation(e.provider)
 }
 
+// ResetSessionState resets provider continuation and any tool-owned cached
+// projection for a durable session. The durable store remains authoritative.
+func (e *Engine) ResetSessionState(sessionID string) {
+	if e == nil {
+		return
+	}
+	e.ResetConversation()
+	for _, spec := range e.tools.AllSpecs() {
+		tool, ok := e.tools.Get(spec.Name)
+		if !ok {
+			continue
+		}
+		if resetter, ok := tool.(SessionStateResetter); ok {
+			resetter.ResetSessionState(sessionID)
+		}
+	}
+}
+
 // SetDebugLogger sets the debug logger for this engine.
 func (e *Engine) SetDebugLogger(logger *DebugLogger) {
 	e.debugLogger = logger

--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -41,6 +41,12 @@ type RequestContextTool interface {
 	PrepareCompactionContext(ctx context.Context, sessionID string, result *CompactionResult) error
 }
 
+// SessionStateResetter clears a tool's cached projection for one durable
+// session after an out-of-band transcript mutation such as undo/redo.
+type SessionStateResetter interface {
+	ResetSessionState(sessionID string)
+}
+
 // FinishingTool is an optional interface for tools that signal agent completion.
 // When a finishing tool is executed, the agentic loop should stop after this turn.
 // Example: output capture tools like set_commit_message.

--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -15,7 +15,7 @@ import (
 
 //go:embed static/index.html static/manifest.webmanifest static/icon-512.png static/sw.js
 //go:embed static/app.css
-//go:embed static/app-core.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
+//go:embed static/app-core.js static/toast.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
 //go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diffs.js static/app-worktrees.js
 //go:embed static/decoration.js static/markdown-setup.js static/markdown-streaming.js static/transcript-window.js static/active-response.js static/conversation.js
 //go:embed static/vendor
@@ -91,6 +91,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`href="manifest.webmanifest"`, `href="` + versioned("manifest.webmanifest") + `"`},
 		{`href="app.css"`, `href="` + versioned("app.css") + `"`},
 		{`href="app-core.js"`, `href="` + versioned("app-core.js") + `"`},
+		{`href="toast.js"`, `href="` + versioned("toast.js") + `"`},
 		{`href="app-network.js"`, `href="` + versioned("app-network.js") + `"`},
 		{`href="transcript-window.js"`, `href="` + versioned("transcript-window.js") + `"`},
 		{`href="active-response.js"`, `href="` + versioned("active-response.js") + `"`},
@@ -125,6 +126,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`src="active-response.js"`, `src="` + versioned("active-response.js") + `"`},
 		{`src="conversation.js"`, `src="` + versioned("conversation.js") + `"`},
 		{`src="app-core.js"`, `src="` + versioned("app-core.js") + `"`},
+		{`src="toast.js"`, `src="` + versioned("toast.js") + `"`},
 		{`src="app-network.js"`, `src="` + versioned("app-network.js") + `"`},
 		{`src="app-plan.js"`, `src="` + versioned("app-plan.js") + `"`},
 		{`src="slash-commands.js"`, `src="` + versioned("slash-commands.js") + `"`},
@@ -212,6 +214,7 @@ func renderServiceWorkerBytes(opts RenderOptions) []byte {
 		{"'./active-response.js'", "'./" + versioned("active-response.js") + "'"},
 		{"'./conversation.js'", "'./" + versioned("conversation.js") + "'"},
 		{"'./app-core.js'", "'./" + versioned("app-core.js") + "'"},
+		{"'./toast.js'", "'./" + versioned("toast.js") + "'"},
 		{"'./app-network.js'", "'./" + versioned("app-network.js") + "'"},
 		{"'./app-plan.js'", "'./" + versioned("app-plan.js") + "'"},
 		{"'./slash-commands.js'", "'./" + versioned("slash-commands.js") + "'"},

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -69,8 +69,8 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	// Keep the new transport boundary from weakening the pre-existing ratchet:
 	// legacy production code must still decrease, while each transport module
 	// gets a narrow independent ceiling tied to its audited responsibility.
-	if legacyProductionLines >= 20467 {
-		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20467", legacyProductionLines)
+	if legacyProductionLines >= 20561 {
+		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20561", legacyProductionLines)
 	}
 	if transportLines["app-network.js"] > 600 || transportLines["app-webrtc.js"] > 725 {
 		t.Fatalf("transport modules grew beyond focused budgets: %v", transportLines)
@@ -565,6 +565,43 @@ func TestAppPlanJS(t *testing.T) {
 	t.Log(string(out))
 	if err != nil {
 		t.Fatalf("app_plan_test.js failed: %v", err)
+	}
+}
+
+func TestToastJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping toast tests")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "toast_test.js")
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("toast_test.js failed: %v", err)
+	}
+}
+
+func TestToastAssetIsVersionedAndCached(t *testing.T) {
+	if _, err := StaticAsset("toast.js"); err != nil {
+		t.Fatalf("StaticAsset(toast.js): %v", err)
+	}
+	index, err := StaticAsset("index.html")
+	if err != nil {
+		t.Fatalf("StaticAsset(index.html): %v", err)
+	}
+	toastRegion := `<div class="toast-region" id="toastRegion" aria-label="Notifications"></div>`
+	if !strings.Contains(string(index), toastRegion) {
+		t.Fatal("toast container must not be a live region containing child status/alert live regions")
+	}
+	if rendered := string(RenderIndexHTML("/ui", "", RenderOptions{})); !strings.Contains(rendered, `src="toast.js?v=`) {
+		t.Fatal("RenderIndexHTML does not version toast.js")
+	}
+	if rendered := string(RenderServiceWorker(RenderOptions{})); !strings.Contains(rendered, "'./toast.js?v=") {
+		t.Fatal("RenderServiceWorker does not version toast.js")
 	}
 }
 

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -69,8 +69,8 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	// Keep the new transport boundary from weakening the pre-existing ratchet:
 	// legacy production code must still decrease, while each transport module
 	// gets a narrow independent ceiling tied to its audited responsibility.
-	if legacyProductionLines >= 20561 {
-		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20561", legacyProductionLines)
+	if legacyProductionLines >= 20570 {
+		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20570", legacyProductionLines)
 	}
 	if transportLines["app-network.js"] > 600 || transportLines["app-webrtc.js"] > 725 {
 		t.Fatalf("transport modules grew beyond focused budgets: %v", transportLines)

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -12,6 +12,7 @@ const {
   updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
   conversationDOMFor, isConversationMounted,
   subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
+  sessionHasInProgressState,
   renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
 } = app;
 const DRAFT_MESSAGE_LIMIT = 10;
@@ -144,6 +145,80 @@ const sendMessage = async (options = {}) => {
       case '/new':
         await app.createAndSwitchToFreshSession?.();
         break;
+    }
+    return;
+  }
+
+  if (!batchingFollowUps && /^\/(undo|redo)\b/i.test(prompt)) {
+    const match = prompt.match(/^\/(undo|redo)$/i);
+    elements.promptInput.value = '';
+    app.hideSlashCommands?.();
+    app.autoGrowPrompt();
+    if (!match) {
+      app.showToast?.('Usage: /undo or /redo', { tone: 'warning' });
+      return;
+    }
+    const operation = match[1].toLowerCase();
+    const session = getActiveSession();
+    if (!session || state.draftSessionActive) {
+      app.showToast?.(`Start the conversation before using /${operation}.`, { tone: 'warning' });
+      return;
+    }
+    if (state.transcriptMutating) return;
+    if (state.streaming || state.compressing || state.sideQuestion?.running || sessionHasInProgressState?.(session)) {
+      app.showToast?.(`Cannot ${operation} while work is active.`, { tone: 'warning' });
+      return;
+    }
+    const transcript = session.transcript;
+    const expectedRev = Math.max(0, Number(transcript?.rev) || 0);
+    const ids = Array.isArray(transcript?.ids) ? transcript.ids : [];
+    const expectedHeadId = ids.length > 0 ? Number(ids[ids.length - 1]) || 0 : 0;
+    state.transcriptMutating = true;
+    try {
+      const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/runtime/${operation}`, {
+        method: 'POST',
+        headers: requestHeaders(session.id),
+        body: JSON.stringify({ expected_rev: expectedRev, expected_head_id: expectedHeadId })
+      }, { policy: app.API_FETCH_POLICY.mutation });
+      if (!response.ok) throw await normalizeError(response);
+      const payload = await response.json();
+      await app.refreshActiveSessionMessagesFromServer?.(session, {
+        force: true,
+        useEtag: false,
+        forceScroll: true,
+        reason: operation
+      });
+      await app.syncActiveSessionFromServer?.(session, false, { skipMessagesFetch: true });
+      const sameActiveSession = !state.draftSessionActive
+        && state.activeSessionId === session.id
+        && getActiveSession() === session;
+      if (operation === 'undo') {
+        if (sameActiveSession) {
+          elements.promptInput.value = String(payload?.user_text || '');
+          app.autoGrowPrompt();
+          elements.promptInput.focus?.();
+        }
+        const attachmentsOmitted = Boolean(payload?.attachments_omitted);
+        const message = sameActiveSession
+          ? (attachmentsOmitted
+            ? 'Removed the latest turn. Your prompt is back in the composer. Attachments were not restored.'
+            : 'Removed the latest turn. Your prompt is back in the composer.')
+          : (attachmentsOmitted
+            ? 'Removed the latest turn. Attachments were not restored.'
+            : 'Removed the latest turn.');
+        app.showToast?.(message, { tone: attachmentsOmitted ? 'warning' : 'success' });
+      } else {
+        if (sameActiveSession) {
+          elements.promptInput.value = '';
+          app.autoGrowPrompt();
+        }
+        app.showToast?.('Restored the undone turn.', { tone: 'success' });
+      }
+    } catch (err) {
+      if (err?.status === 409) await app.refreshActiveSessionMessagesFromServer?.(session, { force: true, useEtag: false, reason: `${operation}-conflict` });
+      app.showToast?.(err?.message || `${operation} failed.`, { tone: 'error', duration: 6500 });
+    } finally {
+      state.transcriptMutating = false;
     }
     return;
   }

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -155,18 +155,18 @@ const sendMessage = async (options = {}) => {
     app.hideSlashCommands?.();
     app.autoGrowPrompt();
     if (!match) {
-      app.showToast?.('Usage: /undo or /redo', { tone: 'warning' });
+      app.showToast?.('Usage: /undo or /redo', { id: 'transcript-mutation', tone: 'warning' });
       return;
     }
     const operation = match[1].toLowerCase();
     const session = getActiveSession();
     if (!session || state.draftSessionActive) {
-      app.showToast?.(`Start the conversation before using /${operation}.`, { tone: 'warning' });
+      app.showToast?.(`Start the conversation before using /${operation}.`, { id: 'transcript-mutation', tone: 'warning' });
       return;
     }
     if (state.transcriptMutating) return;
     if (state.streaming || state.compressing || state.sideQuestion?.running || sessionHasInProgressState?.(session)) {
-      app.showToast?.(`Cannot ${operation} while work is active.`, { tone: 'warning' });
+      app.showToast?.(`Cannot ${operation} while work is active.`, { id: 'transcript-mutation', tone: 'warning' });
       return;
     }
     const transcript = session.transcript;
@@ -206,17 +206,17 @@ const sendMessage = async (options = {}) => {
           : (attachmentsOmitted
             ? 'Removed the latest turn. Attachments were not restored.'
             : 'Removed the latest turn.');
-        app.showToast?.(message, { tone: attachmentsOmitted ? 'warning' : 'success' });
+        app.showToast?.(message, { id: 'transcript-mutation', tone: attachmentsOmitted ? 'warning' : 'success' });
       } else {
         if (sameActiveSession) {
           elements.promptInput.value = '';
           app.autoGrowPrompt();
         }
-        app.showToast?.('Restored the undone turn.', { tone: 'success' });
+        app.showToast?.('Restored the undone turn.', { id: 'transcript-mutation', tone: 'success' });
       }
     } catch (err) {
       if (err?.status === 409) await app.refreshActiveSessionMessagesFromServer?.(session, { force: true, useEtag: false, reason: `${operation}-conflict` });
-      app.showToast?.(err?.message || `${operation} failed.`, { tone: 'error', duration: 6500 });
+      app.showToast?.(err?.message || `${operation} failed.`, { id: 'transcript-mutation', tone: 'error', duration: 6500 });
     } finally {
       state.transcriptMutating = false;
     }

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -4865,3 +4865,58 @@
   border-radius: 999px;
   background: var(--surface, var(--bg));
 }
+
+.toast-region {
+  position: fixed;
+  z-index: 3000;
+  top: calc(0.9rem + var(--safe-top));
+  right: calc(0.9rem + var(--safe-right));
+  display: grid;
+  gap: 0.55rem;
+  width: min(24rem, calc(100vw - 1.8rem));
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 0.8rem 0.75rem 0.9rem;
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--text-muted);
+  border-radius: 0.75rem;
+  color: var(--text);
+  background: var(--surface-strong);
+  background: color-mix(in srgb, var(--surface-strong) 94%, transparent);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+  animation: toast-enter 160ms ease-out;
+}
+
+.toast-success { border-left-color: var(--accent-green); }
+.toast-warning { border-left-color: var(--accent-amber); }
+.toast-error { border-left-color: var(--danger); }
+.toast-message { flex: 1; line-height: 1.35; overflow-wrap: anywhere; }
+.toast-close {
+  border: 0;
+  padding: 0 0.15rem;
+  color: var(--text-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.toast-close:hover, .toast-close:focus-visible { color: var(--text); }
+.toast-leaving { opacity: 0; transform: translateY(-0.25rem); transition: opacity 160ms ease, transform 160ms ease; }
+
+@keyframes toast-enter {
+  from { opacity: 0; transform: translateY(-0.35rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast { animation: none; }
+  .toast-leaving { transition: none; }
+}

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -7578,6 +7578,154 @@ async function testWebSlashCommandsInvokeExistingControls() {
   pass(name);
 }
 
+async function testUndoRedoCommandsUseOptimisticTranscriptAndRestoreComposer() {
+  const name = '/undo and /redo mutate the authoritative transcript without sending messages';
+  let operation = '';
+  const harness = createHarness({
+    fetchImpl: async (url, requestOptions, { Response }) => {
+      if (url === '/ui/v1/sessions/session_undo_redo/runtime/undo') {
+        operation = 'undo';
+        return new Response(JSON.stringify({ ok: true, rev: 8, head_id: 12, user_text: 'edit this prompt' }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url === '/ui/v1/sessions/session_undo_redo/runtime/redo') {
+        operation = 'redo';
+        return new Response(JSON.stringify({ ok: true, rev: 9, head_id: 14 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('unexpected request', { status: 500 });
+    },
+  });
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+  const session = { id: 'session_undo_redo', title: 'Undo', messages: [], activeResponseId: null, lastResponseId: null, number: 1 };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  session.transcript = new ConversationController(session.id);
+  session.transcript.rev = 7;
+  session.transcript.ids = [11, 12, 13, 14];
+  session.transcript.publishedMessages = [
+    { id: 11, role: 'user', text: 'first', durable: true },
+    { id: 12, role: 'assistant', text: 'answer', durable: true },
+    { id: 13, role: 'user', text: 'edit this prompt', durable: true },
+    { id: 14, role: 'assistant', text: 'latest answer', durable: true },
+  ];
+  const toasts = [];
+  app.showToast = (message, options) => toasts.push({ message, tone: options?.tone });
+  app.refreshActiveSessionMessagesFromServer = async () => {
+    if (operation === 'undo') {
+      session.transcript.rev = 8;
+      session.transcript.ids = [11, 12];
+      session.transcript.publishedMessages = session.transcript.publishedMessages.slice(0, 2);
+    } else {
+      session.transcript.rev = 9;
+      session.transcript.ids = [11, 12, 13, 14];
+      session.transcript.publishedMessages.push(
+        { id: 13, role: 'user', text: 'edit this prompt', durable: true },
+        { id: 14, role: 'assistant', text: 'latest answer', durable: true },
+      );
+    }
+    return true;
+  };
+
+  elements.promptInput.value = '/undo';
+  await app.sendMessage();
+  const undoCall = fetchCalls.find((call) => call.url.endsWith('/runtime/undo'));
+  const undoBody = JSON.parse(undoCall?.body || '{}');
+  if (!undoCall || undoBody.expected_rev !== 7 || undoBody.expected_head_id !== 14) {
+    fail(name, 'undo did not send the current revision/head', JSON.stringify(fetchCalls));
+    await cleanup();
+    return;
+  }
+  if (session.transcript.ids.length !== 2 || elements.promptInput.value !== 'edit this prompt') {
+    fail(name, 'undo did not shrink transcript and restore composer', JSON.stringify({ ids: session.transcript.ids, prompt: elements.promptInput.value }));
+    await cleanup();
+    return;
+  }
+
+  elements.promptInput.value = '/redo';
+  await app.sendMessage();
+  const redoCall = fetchCalls.find((call) => call.url.endsWith('/runtime/redo'));
+  const redoBody = JSON.parse(redoCall?.body || '{}');
+  await cleanup();
+  if (!redoCall || redoBody.expected_rev !== 8 || redoBody.expected_head_id !== 12) {
+    fail(name, 'redo did not use the post-undo revision/head', JSON.stringify(fetchCalls));
+    return;
+  }
+  if (session.transcript.ids.length !== 4 || elements.promptInput.value !== '') {
+    fail(name, 'redo did not restore transcript and clear composer', JSON.stringify({ ids: session.transcript.ids, prompt: elements.promptInput.value }));
+    return;
+  }
+  if (fetchCalls.some((call) => call.url === '/ui/v1/responses') || toasts.filter((toast) => toast.tone === 'success').length !== 2) {
+    fail(name, 'undo/redo sent a normal message or skipped success toasts', JSON.stringify({ fetchCalls, toasts }));
+    return;
+  }
+  pass(name);
+}
+
+async function testUndoDoesNotRestoreComposerAfterSessionSwitch() {
+  const name = '/undo does not overwrite the composer after an active-session switch';
+  const harness = createHarness({
+    fetchImpl: async (url, requestOptions, { Response }) => new Response(JSON.stringify({
+      ok: true, rev: 2, head_id: 0, user_text: 'old session prompt',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+  });
+  const { app, elements, state, cleanup } = harness;
+  const original = { id: 'session_undo_switch_original', title: 'Original', messages: [], number: 1 };
+  const next = { id: 'session_undo_switch_next', title: 'Next', messages: [], number: 2 };
+  state.sessions.push(original, next);
+  state.activeSessionId = original.id;
+  original.transcript = new ConversationController(original.id);
+  original.transcript.rev = 1;
+  original.transcript.ids = [10];
+  app.refreshActiveSessionMessagesFromServer = async () => {
+    state.activeSessionId = next.id;
+    elements.promptInput.value = 'new session draft';
+    return true;
+  };
+
+  elements.promptInput.value = '/undo';
+  await app.sendMessage();
+  await cleanup();
+  if (state.activeSessionId !== next.id || elements.promptInput.value !== 'new session draft') {
+    fail(name, 'stale undo completion overwrote the new active composer', JSON.stringify({
+      activeSessionId: state.activeSessionId, prompt: elements.promptInput.value,
+    }));
+    return;
+  }
+  pass(name);
+}
+
+async function testUndoWarnsWhenAttachmentsWereNotRestored() {
+  const name = '/undo warns when removed prompt attachments cannot be restored';
+  const harness = createHarness({
+    fetchImpl: async (url, requestOptions, { Response }) => new Response(JSON.stringify({
+      ok: true, rev: 2, head_id: 0, user_text: 'describe this', attachments_omitted: true,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+  });
+  const { app, elements, state, cleanup } = harness;
+  const session = { id: 'session_undo_attachment', title: 'Attachment', messages: [], number: 1 };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  session.transcript = new ConversationController(session.id);
+  session.transcript.rev = 1;
+  session.transcript.ids = [10];
+  const toasts = [];
+  app.showToast = (message, options) => toasts.push({ message, tone: options?.tone });
+  app.refreshActiveSessionMessagesFromServer = async () => true;
+
+  elements.promptInput.value = '/undo';
+  await app.sendMessage();
+  await cleanup();
+  const warning = toasts.find((toast) => toast.tone === 'warning');
+  if (elements.promptInput.value !== 'describe this' || !warning || !warning.message.includes('Attachments were not restored')) {
+    fail(name, 'attachment omission was not explained to the user', JSON.stringify({ prompt: elements.promptInput.value, toasts }));
+    return;
+  }
+  pass(name);
+}
+
 async function testCompressCommandCompactsWithoutSendingMessage() {
   const name = '/compress compacts active context without sending a chat message';
   const harness = createHarness({
@@ -7962,6 +8110,9 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testSendMessageLazilyMaterializesAttachmentDataURLs();
   await testSendMessageKeepsComposerWhenAttachmentMaterializationFails();
   await testWebSlashCommandsInvokeExistingControls();
+  await testUndoRedoCommandsUseOptimisticTranscriptAndRestoreComposer();
+  await testUndoDoesNotRestoreComposerAfterSessionSwitch();
+  await testUndoWarnsWhenAttachmentsWereNotRestored();
   await testCompressCommandCompactsWithoutSendingMessage();
   await testStaleInterrupt404RefreshesAndSendsMessage();
   await testStaleInterruptRecoveryFailedPostKeepsDraft();

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -125,6 +125,7 @@
   </style>
   <link rel="stylesheet" href="app.css">
   <link rel="preload" as="script" href="app-core.js">
+  <link rel="preload" as="script" href="toast.js">
   <link rel="preload" as="script" href="app-network.js">
   <link rel="preload" as="script" href="transcript-window.js">
   <link rel="preload" as="script" href="active-response.js">
@@ -152,6 +153,7 @@
   <link rel="preload" as="script" href="app-worktrees.js">
 </head>
 <body class="app-loading">
+  <div class="toast-region" id="toastRegion" aria-label="Notifications"></div>
   <div class="startup-splash" id="startupSplash" role="status" aria-live="polite">
     <div class="startup-card">
       <div class="startup-mark" aria-hidden="true">⌘</div>
@@ -626,6 +628,7 @@
   <script src="active-response.js"></script>
   <script src="conversation.js"></script>
   <script src="app-core.js"></script>
+  <script src="toast.js"></script>
   <script src="app-network.js"></script>
   <script src="app-plan.js"></script>
   <script src="slash-commands.js"></script>

--- a/internal/serveui/static/slash-commands.js
+++ b/internal/serveui/static/slash-commands.js
@@ -32,8 +32,16 @@ const builtInCommands = [
     description: 'Start a new conversation',
   },
   {
+    name: '/redo',
+    description: 'Restore the turn removed by /undo',
+  },
+  {
     name: '/side',
     description: 'Ask without interrupting the main response',
+  },
+  {
+    name: '/undo',
+    description: 'Remove the latest user turn and everything after it',
   },
 ].sort((a, b) => a.name.localeCompare(b.name));
 

--- a/internal/serveui/static/slash_commands_test.js
+++ b/internal/serveui/static/slash_commands_test.js
@@ -68,10 +68,10 @@ const assert = (condition, message) => { if (!condition) throw new Error(message
 promptInput.value = '/';
 promptInput.dispatch('input');
 assert(!slashCommandMenu.hidden, 'typing / did not show slash commands');
-assert(slashCommandMenu.children.length === 7, 'expected all matching slash commands');
+assert(slashCommandMenu.children.length === 9, 'expected all matching slash commands');
 const commandNames = slashCommandMenu.children.map((option) => option.children[0].textContent);
-assert(JSON.stringify(commandNames) === JSON.stringify(['/compact', '/compress', '/goal', '/mcp', '/model', '/new', '/side']), `commands were not alphabetized: ${JSON.stringify(commandNames)}`);
-assert(slashCommandMenu.children[6].children[1].textContent.includes('without interrupting'), '/side description was not useful');
+assert(JSON.stringify(commandNames) === JSON.stringify(['/compact', '/compress', '/goal', '/mcp', '/model', '/new', '/redo', '/side', '/undo']), `commands were not alphabetized: ${JSON.stringify(commandNames)}`);
+assert(slashCommandMenu.children[7].children[1].textContent.includes('without interrupting'), '/side description was not useful');
 assert(promptInput.attributes['aria-expanded'] === 'true', 'composer did not expose expanded autocomplete state');
 
 promptInput.value = '/si';

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -12,6 +12,7 @@ const SHELL_ASSETS = [
   './active-response.js',
   './conversation.js',
   './app-core.js',
+  './toast.js',
   './app-network.js',
   './app-plan.js',
   './slash-commands.js',

--- a/internal/serveui/static/toast.js
+++ b/internal/serveui/static/toast.js
@@ -18,9 +18,18 @@ const dismissToast = (toast) => {
 const showToast = (message, options = {}) => {
   const text = String(message || '').trim();
   if (!text || !region || typeof document.createElement !== 'function') return null;
+  const toastID = String(options.id || '').trim();
+  if (toastID) {
+    const previous = Array.from(region.children || []).find((item) => item?.attributes?.['data-toast-id'] === toastID || item?.getAttribute?.('data-toast-id') === toastID);
+    if (previous) {
+      if (previous._dismissTimer) window.clearTimeout(previous._dismissTimer);
+      previous.remove?.();
+    }
+  }
   const tone = ['success', 'error', 'warning'].includes(options.tone) ? options.tone : 'info';
   const toast = document.createElement('div');
   toast.className = `toast toast-${tone}`;
+  if (toastID) toast.setAttribute('data-toast-id', toastID);
   toast.setAttribute('role', tone === 'error' ? 'alert' : 'status');
   toast.setAttribute('aria-atomic', 'true');
 

--- a/internal/serveui/static/toast.js
+++ b/internal/serveui/static/toast.js
@@ -1,0 +1,52 @@
+(() => {
+'use strict';
+
+const app = window.TermLLMApp || (window.TermLLMApp = {});
+const region = document.getElementById('toastRegion');
+
+const dismissToast = (toast) => {
+  if (!toast || toast._dismissed) return;
+  toast._dismissed = true;
+  if (toast._dismissTimer) window.clearTimeout(toast._dismissTimer);
+  toast.classList?.add?.('toast-leaving');
+  const remove = () => toast.remove?.();
+  if (typeof window.setTimeout === 'function') window.setTimeout(remove, 180);
+  else remove();
+};
+
+// Shared notifications; specialized dialogs and legacy alerts stay separate.
+const showToast = (message, options = {}) => {
+  const text = String(message || '').trim();
+  if (!text || !region || typeof document.createElement !== 'function') return null;
+  const tone = ['success', 'error', 'warning'].includes(options.tone) ? options.tone : 'info';
+  const toast = document.createElement('div');
+  toast.className = `toast toast-${tone}`;
+  toast.setAttribute('role', tone === 'error' ? 'alert' : 'status');
+  toast.setAttribute('aria-atomic', 'true');
+
+  const copy = document.createElement('span');
+  copy.className = 'toast-message';
+  copy.textContent = text;
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'toast-close';
+  close.setAttribute('aria-label', 'Dismiss notification');
+  close.textContent = '×';
+  close.addEventListener('click', () => dismissToast(toast));
+  toast.append(copy, close);
+  region.appendChild(toast);
+
+  while (region.children.length > 4) {
+    const oldest = region.children[0];
+    if (oldest?._dismissTimer) window.clearTimeout(oldest._dismissTimer);
+    oldest?.remove?.();
+  }
+  const duration = Number.isFinite(Number(options.duration)) ? Math.max(0, Number(options.duration)) : 4200;
+  if (duration > 0 && typeof window.setTimeout === 'function') {
+    toast._dismissTimer = window.setTimeout(() => dismissToast(toast), duration);
+  }
+  return toast;
+};
+
+Object.assign(app, { showToast, dismissToast });
+})();

--- a/internal/serveui/static/toast_test.js
+++ b/internal/serveui/static/toast_test.js
@@ -43,6 +43,13 @@ if (toast.children[1]?.attributes?.['aria-label'] !== 'Dismiss notification') th
 toast.children[1].onclick();
 if (!toast._dismissed) throw new Error('dismiss button did not dismiss toast');
 
+const firstMutation = window.TermLLMApp.showToast('Undo complete', { id: 'transcript-mutation', duration: 0 });
+const secondMutation = window.TermLLMApp.showToast('Redo complete', { id: 'transcript-mutation', duration: 0 });
+const mutationToasts = region.children.filter((item) => item.attributes?.['data-toast-id'] === 'transcript-mutation');
+if (mutationToasts.length !== 1 || mutationToasts[0] !== secondMutation || region.children.includes(firstMutation)) {
+  throw new Error('toast IDs do not replace earlier notifications');
+}
+
 for (let i = 0; i < 6; i += 1) window.TermLLMApp.showToast(`message ${i}`, { duration: 0 });
 if (region.children.length !== 4) throw new Error(`toast stack is not bounded: ${region.children.length}`);
 

--- a/internal/serveui/static/toast_test.js
+++ b/internal/serveui/static/toast_test.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const source = fs.readFileSync(path.join(__dirname, 'toast.js'), 'utf8');
+
+const makeNode = () => {
+  const node = {
+    children: [], attributes: {}, className: '', textContent: '', parentNode: null,
+    classList: { add(value) { node.className += ` ${value}`; } },
+    setAttribute(key, value) { node.attributes[key] = String(value); },
+    addEventListener(type, listener) { node[`on${type}`] = listener; },
+    append(...children) { children.forEach((child) => { child.parentNode = node; node.children.push(child); }); },
+    appendChild(child) { child.parentNode = node; node.children.push(child); return child; },
+    remove() {
+      if (!node.parentNode) return;
+      const index = node.parentNode.children.indexOf(node);
+      if (index >= 0) node.parentNode.children.splice(index, 1);
+    },
+  };
+  return node;
+};
+
+const region = makeNode();
+const document = {
+  getElementById(id) { return id === 'toastRegion' ? region : null; },
+  createElement() { return makeNode(); },
+};
+const window = {
+  TermLLMApp: {},
+  setTimeout() { return 1; },
+  clearTimeout() {},
+};
+vm.runInNewContext(source, { window, document, console }, { filename: 'toast.js' });
+
+const toast = window.TermLLMApp.showToast('Transcript changed', { tone: 'error', duration: 0 });
+if (!toast || region.children.length !== 1) throw new Error('toast was not mounted');
+if (toast.attributes.role !== 'alert' || toast.attributes['aria-atomic'] !== 'true') throw new Error('error toast is not an atomic alert');
+if (toast.children[0]?.textContent !== 'Transcript changed') throw new Error('toast message missing');
+if (toast.children[1]?.attributes?.['aria-label'] !== 'Dismiss notification') throw new Error('dismiss button lacks accessible label');
+toast.children[1].onclick();
+if (!toast._dismissed) throw new Error('dismiss button did not dismiss toast');
+
+for (let i = 0; i < 6; i += 1) window.TermLLMApp.showToast(`message ${i}`, { duration: 0 });
+if (region.children.length !== 4) throw new Error(`toast stack is not bounded: ${region.children.length}`);
+
+console.log('PASS: accessible reusable toast notifications');

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -502,6 +502,39 @@ func (s *LoggingStore) UpdateContextEstimate(ctx context.Context, id string, las
 	return err
 }
 
+// TranscriptMutationState delegates optimistic transcript mutation state.
+func (s *LoggingStore) TranscriptMutationState(ctx context.Context, sessionID string) (TranscriptMutationState, error) {
+	store, ok := s.Store.(TranscriptUndoRedoStore)
+	if !ok {
+		return TranscriptMutationState{}, ErrTranscriptRevisionUnsupported
+	}
+	state, err := store.TranscriptMutationState(ctx, sessionID)
+	s.logOnce("TranscriptMutationState", err)
+	return state, err
+}
+
+// UndoLastUserTurn delegates storage-owned undo.
+func (s *LoggingStore) UndoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error) {
+	store, ok := s.Store.(TranscriptUndoRedoStore)
+	if !ok {
+		return TranscriptMutationResult{}, ErrTranscriptRevisionUnsupported
+	}
+	result, err := store.UndoLastUserTurn(ctx, sessionID, expected)
+	s.logOnce("UndoLastUserTurn", err)
+	return result, err
+}
+
+// RedoLastUserTurn delegates storage-owned redo.
+func (s *LoggingStore) RedoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error) {
+	store, ok := s.Store.(TranscriptUndoRedoStore)
+	if !ok {
+		return TranscriptMutationResult{}, ErrTranscriptRevisionUnsupported
+	}
+	result, err := store.RedoLastUserTurn(ctx, sessionID, expected)
+	s.logOnce("RedoLastUserTurn", err)
+	return result, err
+}
+
 // ClearCompactionBoundary wraps optional Store.ClearCompactionBoundary with error logging.
 func (s *LoggingStore) ClearCompactionBoundary(ctx context.Context, id string) error {
 	clearer, ok := s.Store.(interface {

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -145,6 +145,15 @@ CREATE TABLE IF NOT EXISTS session_plans (
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS session_redo (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    suffix TEXT NOT NULL,
+    metadata TEXT NOT NULL,
+    undo_rev INTEGER NOT NULL,
+    head_id INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Metadata table for current session tracking
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
@@ -334,7 +343,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 43
+const schemaVersion = 44
 
 // migration represents a schema migration.
 type migration struct {
@@ -1217,23 +1226,52 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		version:     44,
+		description: "create durable transcript redo table",
+		up: func(db schemaExecutor) error {
+			_, err := db.Exec(`CREATE TABLE IF NOT EXISTS session_redo (
+				session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+				suffix TEXT NOT NULL,
+				metadata TEXT NOT NULL,
+				undo_rev INTEGER NOT NULL,
+				head_id INTEGER NOT NULL DEFAULT 0,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`)
+			return err
+		},
+	},
 }
 
 // Keep in sync with llm.IsInternalCompactionSummaryText. SQLite migrations and
 // triggers need a SQL form of the same prefix check.
 const internalCompactionSummarySQLPrefix = "[Context Compaction]"
 
-func countableConversationMessageSQL(alias string, includeCompactionTail bool) string {
-	roleCol := qualifiedMessageColumn(alias, "role")
+func trimmedMessageTextSQL(alias string) string {
 	// SQLite's one-argument TRIM only removes spaces. Include common ASCII
 	// whitespace; persisted model/tool text that is only whitespace is expected to
 	// use these characters.
 	textCol := qualifiedMessageColumn(alias, "text_content")
 	trimChars := "char(9) || char(10) || char(11) || char(12) || char(13) || char(32)"
-	textExpr := "TRIM(COALESCE(" + textCol + ", ''), " + trimChars + ")"
+	return "TRIM(COALESCE(" + textCol + ", ''), " + trimChars + ")"
+}
 
-	userPredicate := fmt.Sprintf("(%s = 'user' AND substr(%s, 1, %d) <> '%s')",
+func realUserMessageSQL(alias string, excludeCompactionTail bool) string {
+	roleCol := qualifiedMessageColumn(alias, "role")
+	textExpr := trimmedMessageTextSQL(alias)
+	predicate := fmt.Sprintf("(%s = 'user' AND substr(%s, 1, %d) <> '%s')",
 		roleCol, textExpr, len(internalCompactionSummarySQLPrefix), internalCompactionSummarySQLPrefix)
+	if excludeCompactionTail {
+		predicate = "(COALESCE(" + qualifiedMessageColumn(alias, "compaction_tail") + ", FALSE) = FALSE AND " + predicate + ")"
+	}
+	return predicate
+}
+
+func countableConversationMessageSQL(alias string, includeCompactionTail bool) string {
+	roleCol := qualifiedMessageColumn(alias, "role")
+	textExpr := trimmedMessageTextSQL(alias)
+
+	userPredicate := realUserMessageSQL(alias, false)
 	assistantPredicate := fmt.Sprintf("(%s = 'assistant' AND %s <> '')", roleCol, textExpr)
 	predicate := "(" + userPredicate + " OR " + assistantPredicate + ")"
 	if includeCompactionTail {
@@ -2650,6 +2688,19 @@ func (s *SQLiteStore) bumpTranscriptRev(ctx context.Context, execer sqliteQueryE
 	if !s.hasTranscriptRev {
 		return 0, nil
 	}
+	// session_redo was introduced after transcript revisions. Keep invalidation
+	// below the compatibility guard so old read-only schemas never query a table
+	// they cannot have.
+	if _, err := execer.ExecContext(ctx, `DELETE FROM session_redo WHERE session_id = ?`, sessionID); err != nil {
+		return 0, fmt.Errorf("invalidate transcript redo: %w", err)
+	}
+	return s.bumpTranscriptRevPreservingRedo(ctx, execer, sessionID)
+}
+
+func (s *SQLiteStore) bumpTranscriptRevPreservingRedo(ctx context.Context, execer sqliteQueryExecer, sessionID string) (int64, error) {
+	if !s.hasTranscriptRev {
+		return 0, nil
+	}
 	var rev int64
 	err := execer.QueryRowContext(ctx, `
 		UPDATE sessions
@@ -3402,6 +3453,420 @@ func (s *SQLiteStore) TranscriptRev(ctx context.Context, sessionID string) (int6
 		return 0, fmt.Errorf("get transcript revision: %w", err)
 	}
 	return rev, nil
+}
+
+type undoRedoMetadata struct {
+	GeneratedShortTitle string             `json:"generated_short_title,omitempty"`
+	GeneratedLongTitle  string             `json:"generated_long_title,omitempty"`
+	TitleSource         SessionTitleSource `json:"title_source,omitempty"`
+	TitleGeneratedAt    time.Time          `json:"title_generated_at,omitempty"`
+	TitleBasisMsgSeq    int                `json:"title_basis_msg_seq,omitempty"`
+	TitleSkippedAt      time.Time          `json:"title_skipped_at,omitempty"`
+}
+
+type sqliteQueryRowsExecer interface {
+	sqliteQueryExecer
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func transcriptMutationState(ctx context.Context, q sqliteQueryExecer, sessionID string) (TranscriptMutationState, error) {
+	var state TranscriptMutationState
+	err := q.QueryRowContext(ctx, `
+		SELECT transcript_rev, COALESCE((
+			SELECT id FROM messages
+			WHERE session_id = sessions.id AND role NOT IN ('system', 'developer')
+			ORDER BY sequence DESC, id DESC LIMIT 1
+		), 0)
+		FROM sessions WHERE id = ?`, sessionID).Scan(&state.Rev, &state.HeadID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TranscriptMutationState{}, ErrNotFound
+	}
+	if err != nil {
+		return TranscriptMutationState{}, fmt.Errorf("read transcript mutation state: %w", err)
+	}
+	return state, nil
+}
+
+// TranscriptMutationState returns the durable revision and visible transcript
+// head used for optimistic undo/redo requests.
+func (s *SQLiteStore) TranscriptMutationState(ctx context.Context, sessionID string) (TranscriptMutationState, error) {
+	if !s.hasTranscriptRev {
+		return TranscriptMutationState{}, ErrTranscriptRevisionUnsupported
+	}
+	return transcriptMutationState(ctx, s.db, sessionID)
+}
+
+func requireTranscriptMutationState(actual, expected TranscriptMutationState) error {
+	if actual != expected {
+		return ErrTranscriptConflict
+	}
+	return nil
+}
+
+func (s *SQLiteStore) beginImmediate(ctx context.Context) (*sql.Conn, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get connection: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("begin immediate transaction: %w", err)
+	}
+	return conn, nil
+}
+
+func rollbackImmediate(conn *sql.Conn) {
+	if conn != nil {
+		_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		_ = conn.Close()
+	}
+}
+
+func (s *SQLiteStore) loadUndoRedoMetadata(ctx context.Context, q sqliteQueryExecer, sessionID string) (undoRedoMetadata, error) {
+	var metadata undoRedoMetadata
+	var titleSource sql.NullString
+	var titleGeneratedAt, titleSkippedAt sql.NullTime
+	err := q.QueryRowContext(ctx, `
+		SELECT COALESCE(generated_short_title, ''), COALESCE(generated_long_title, ''), title_source,
+		       title_generated_at, COALESCE(title_basis_msg_seq, 0), title_skipped_at
+		FROM sessions WHERE id = ?`, sessionID).Scan(
+		&metadata.GeneratedShortTitle, &metadata.GeneratedLongTitle, &titleSource,
+		&titleGeneratedAt, &metadata.TitleBasisMsgSeq, &titleSkippedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return undoRedoMetadata{}, ErrNotFound
+	}
+	if err != nil {
+		return undoRedoMetadata{}, fmt.Errorf("load undo metadata: %w", err)
+	}
+	metadata.TitleSource = SessionTitleSource(titleSource.String)
+	if titleGeneratedAt.Valid {
+		metadata.TitleGeneratedAt = titleGeneratedAt.Time
+	}
+	if titleSkippedAt.Valid {
+		metadata.TitleSkippedAt = titleSkippedAt.Time
+	}
+	return metadata, nil
+}
+
+func (s *SQLiteStore) recomputeTranscriptMetadata(ctx context.Context, q sqliteQueryExecer, sessionID string, clearGeneratedTitle bool) error {
+	tailClause := ""
+	if s.hasMessageCompactionTail {
+		tailClause = " AND COALESCE(compaction_tail, FALSE) = FALSE"
+	}
+	realUser := realUserMessageSQL("", s.hasMessageCompactionTail)
+	var firstUserText sql.NullString
+	err := q.QueryRowContext(ctx, "SELECT text_content FROM messages WHERE session_id = ? AND "+realUser+" ORDER BY sequence, id LIMIT 1", sessionID).Scan(&firstUserText)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("load transcript summary source: %w", err)
+	}
+	summary := ""
+	if firstUserText.Valid {
+		summary = TruncateSummary(firstUserText.String)
+	}
+	set := []string{
+		"updated_at = ?",
+		"summary = ?",
+		"last_total_tokens = 0",
+		"last_message_count = 0",
+	}
+	args := []any{time.Now(), summary}
+	// user_turns is an increment-only activity metric. Undo/redo changes the
+	// visible transcript, but must not collapse turns represented by compacted
+	// history or make the metric decrease when a prompt is temporarily undone.
+	if s.hasLastUserMessageAt {
+		// Preserve the documented activity semantics: every persisted user row
+		// counts, including compaction summaries and retained compaction tails.
+		set = append(set, "last_user_message_at = (SELECT MAX(created_at) FROM messages WHERE session_id = ? AND role = 'user')")
+		args = append(args, sessionID)
+	}
+	if s.hasLastMessageAt {
+		set = append(set, "last_message_at = (SELECT MAX(created_at) FROM messages WHERE session_id = ? AND role IN ('user', 'assistant')"+tailClause+")")
+		args = append(args, sessionID)
+	}
+	if clearGeneratedTitle && s.hasGeneratedTitles {
+		set = append(set,
+			"generated_short_title = ''", "generated_long_title = ''",
+			"title_source = CASE WHEN title_source = 'user' THEN title_source ELSE '' END",
+			"title_generated_at = NULL", "title_basis_msg_seq = 0", "title_skipped_at = NULL")
+	}
+	args = append(args, sessionID)
+	result, err := q.ExecContext(ctx, "UPDATE sessions SET "+strings.Join(set, ", ")+" WHERE id = ?", args...)
+	if err != nil {
+		return fmt.Errorf("recompute transcript metadata: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count transcript metadata update: %w", err)
+	}
+	if changed == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) restoreRedoTitleMetadata(ctx context.Context, q sqliteQueryExecer, sessionID string, metadata undoRedoMetadata) error {
+	if !s.hasGeneratedTitles {
+		return nil
+	}
+	var currentSource sql.NullString
+	if err := q.QueryRowContext(ctx, `SELECT title_source FROM sessions WHERE id = ?`, sessionID).Scan(&currentSource); err != nil {
+		return err
+	}
+	if SessionTitleSource(currentSource.String) == TitleSourceUser {
+		return nil
+	}
+	_, err := q.ExecContext(ctx, `
+		UPDATE sessions SET generated_short_title = ?, generated_long_title = ?, title_source = ?,
+		       title_generated_at = ?, title_basis_msg_seq = ?, title_skipped_at = ?
+		WHERE id = ?`, metadata.GeneratedShortTitle, metadata.GeneratedLongTitle, metadata.TitleSource,
+		nullableTime(metadata.TitleGeneratedAt), metadata.TitleBasisMsgSeq, nullableTime(metadata.TitleSkippedAt), sessionID)
+	return err
+}
+
+func nullableTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value
+}
+
+func (s *SQLiteStore) reconcilePlanProjection(ctx context.Context, q sqliteQueryRowsExecer, sessionID string) error {
+	rows, err := q.QueryContext(ctx, `SELECT `+s.messageSelectCols()+` FROM messages WHERE session_id = ? ORDER BY sequence, id`, sessionID)
+	if err != nil {
+		return fmt.Errorf("load transcript for plan reconciliation: %w", err)
+	}
+	messages, err := scanMessageRows(rows)
+	closeErr := rows.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	llmMessages := make([]llm.Message, 0, len(messages))
+	for i := range messages {
+		llmMessages = append(llmMessages, messages[i].ToLLMMessage())
+	}
+	snapshot, represented := planpkg.LatestSuccessfulSnapshot(llmMessages)
+	if !represented || len(snapshot.Plan) == 0 {
+		if _, err := q.ExecContext(ctx, `DELETE FROM session_plans WHERE session_id = ?`, sessionID); err != nil {
+			return fmt.Errorf("clear reconciled plan projection: %w", err)
+		}
+		return nil
+	}
+	raw, err := snapshot.CanonicalJSON()
+	if err != nil {
+		return fmt.Errorf("encode reconciled plan projection: %w", err)
+	}
+	if _, err := q.ExecContext(ctx, `
+		INSERT INTO session_plans (session_id, snapshot, version, updated_at)
+		VALUES (?, ?, 1, CURRENT_TIMESTAMP)
+		ON CONFLICT(session_id) DO UPDATE SET
+			snapshot = excluded.snapshot,
+			version = session_plans.version + 1,
+			updated_at = CURRENT_TIMESTAMP`, sessionID, string(raw)); err != nil {
+		return fmt.Errorf("save reconciled plan projection: %w", err)
+	}
+	return nil
+}
+
+// UndoLastUserTurn removes the latest real user row at or after the compaction
+// boundary and every transcript row after it. The suffix is durably owned by
+// SQLite so another client or a restarted process can redo it.
+func (s *SQLiteStore) UndoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error) {
+	if !s.hasTranscriptRev {
+		return TranscriptMutationResult{}, ErrTranscriptRevisionUnsupported
+	}
+	conn, err := s.beginImmediate(ctx)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	defer rollbackImmediate(conn)
+
+	actual, err := transcriptMutationState(ctx, conn, sessionID)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if err := requireTranscriptMutationState(actual, expected); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	metadata, err := s.loadUndoRedoMetadata(ctx, conn, sessionID)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	compactionSeq := -1
+	if err := conn.QueryRowContext(ctx, `SELECT COALESCE(compaction_seq, -1) FROM sessions WHERE id = ?`, sessionID).Scan(&compactionSeq); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if compactionSeq < 0 {
+		compactionSeq = 0
+	}
+	var targetID int64
+	var targetSeq int
+	var userText string
+	realUserPredicate := realUserMessageSQL("", s.hasMessageCompactionTail)
+	err = conn.QueryRowContext(ctx, `
+		SELECT id, sequence FROM messages
+		WHERE session_id = ? AND sequence >= ? AND `+realUserPredicate+`
+		ORDER BY sequence DESC, id DESC LIMIT 1`, sessionID, compactionSeq).Scan(&targetID, &targetSeq)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TranscriptMutationResult{}, ErrNothingToUndo
+	}
+	if err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("find undo user turn: %w", err)
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT `+s.messageSelectCols()+` FROM messages
+		WHERE session_id = ? AND (sequence > ? OR (sequence = ? AND id >= ?))
+		ORDER BY sequence, id`, sessionID, targetSeq, targetSeq, targetID)
+	if err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("load undo suffix: %w", err)
+	}
+	suffix, err := scanMessageRows(rows)
+	closeErr := rows.Close()
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if closeErr != nil {
+		return TranscriptMutationResult{}, closeErr
+	}
+	if len(suffix) == 0 || suffix[0].ID != targetID {
+		return TranscriptMutationResult{}, fmt.Errorf("undo suffix lost target row")
+	}
+	attachmentsOmitted := false
+	var composerText strings.Builder
+	for _, part := range suffix[0].Parts {
+		switch part.Type {
+		case llm.PartText:
+			composerText.WriteString(part.Text)
+		case llm.PartImage, llm.PartFile:
+			attachmentsOmitted = true
+		}
+	}
+	userText = composerText.String()
+	suffixJSON, err := json.Marshal(suffix)
+	if err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("encode undo suffix: %w", err)
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("encode undo metadata: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, `DELETE FROM messages WHERE session_id = ? AND (sequence > ? OR (sequence = ? AND id >= ?))`, sessionID, targetSeq, targetSeq, targetID); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("delete undo suffix: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, `DELETE FROM session_provider_state WHERE session_id = ?`, sessionID); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("reset provider state for undo: %w", err)
+	}
+	if err := s.recomputeTranscriptMetadata(ctx, conn, sessionID, true); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if err := s.reconcilePlanProjection(ctx, conn, sessionID); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	rev, err := s.bumpTranscriptRevPreservingRedo(ctx, conn, sessionID)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	post, err := transcriptMutationState(ctx, conn, sessionID)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if post.Rev != rev {
+		return TranscriptMutationResult{}, fmt.Errorf("undo revision mismatch")
+	}
+	if _, err := conn.ExecContext(ctx, `
+		INSERT INTO session_redo (session_id, suffix, metadata, undo_rev, head_id, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(session_id) DO UPDATE SET suffix = excluded.suffix, metadata = excluded.metadata,
+			undo_rev = excluded.undo_rev, head_id = excluded.head_id, updated_at = CURRENT_TIMESTAMP`,
+		sessionID, string(suffixJSON), string(metadataJSON), post.Rev, post.HeadID); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("save redo suffix: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("commit undo: %w", err)
+	}
+	return TranscriptMutationResult{TranscriptMutationState: post, UserText: userText, AttachmentsOmitted: attachmentsOmitted}, nil
+}
+
+// RedoLastUserTurn restores the exact durable suffix captured by the latest
+// undo, including stable message IDs, sequences, timestamps, and structured
+// parts. It does not replay tool or external side effects.
+func (s *SQLiteStore) RedoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error) {
+	if !s.hasTranscriptRev {
+		return TranscriptMutationResult{}, ErrTranscriptRevisionUnsupported
+	}
+	conn, err := s.beginImmediate(ctx)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	defer rollbackImmediate(conn)
+	actual, err := transcriptMutationState(ctx, conn, sessionID)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if err := requireTranscriptMutationState(actual, expected); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	var suffixRaw, metadataRaw string
+	var undoRev, headID int64
+	err = conn.QueryRowContext(ctx, `SELECT suffix, metadata, undo_rev, head_id FROM session_redo WHERE session_id = ?`, sessionID).Scan(&suffixRaw, &metadataRaw, &undoRev, &headID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TranscriptMutationResult{}, ErrNothingToRedo
+	}
+	if err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("load redo suffix: %w", err)
+	}
+	if undoRev != actual.Rev || headID != actual.HeadID {
+		return TranscriptMutationResult{}, ErrTranscriptConflict
+	}
+	var suffix []Message
+	if err := json.Unmarshal([]byte(suffixRaw), &suffix); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("decode redo suffix: %w", err)
+	}
+	var metadata undoRedoMetadata
+	if err := json.Unmarshal([]byte(metadataRaw), &metadata); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("decode redo metadata: %w", err)
+	}
+	for i := range suffix {
+		msg := &suffix[i]
+		partsJSON, err := msg.PartsJSONForStorage(s.cfg.StripImageBase64)
+		if err != nil {
+			return TranscriptMutationResult{}, fmt.Errorf("serialize redo message %d: %w", i, err)
+		}
+		if _, err := conn.ExecContext(ctx, `
+			INSERT INTO messages (id, session_id, role, parts, text_content, duration_ms, turn_index, created_at, sequence, compaction_tail, client_message_id, response_id, assistant_segment_ordinal, segment_start_sequence, segment_end_sequence)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			msg.ID, sessionID, string(msg.Role), partsJSON, msg.TextContent, msg.DurationMs, msg.TurnIndex, msg.CreatedAt, msg.Sequence,
+			msg.CompactionTail, msg.ClientMessageID, msg.ResponseID, msg.AssistantSegmentOrdinal, msg.SegmentStartSequence, msg.SegmentEndSequence); err != nil {
+			return TranscriptMutationResult{}, fmt.Errorf("restore redo message %d: %w", i, err)
+		}
+	}
+	if _, err := conn.ExecContext(ctx, `DELETE FROM session_provider_state WHERE session_id = ?`, sessionID); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("reset provider state for redo: %w", err)
+	}
+	if err := s.recomputeTranscriptMetadata(ctx, conn, sessionID, false); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if err := s.restoreRedoTitleMetadata(ctx, conn, sessionID, metadata); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("restore redo title metadata: %w", err)
+	}
+	if err := s.reconcilePlanProjection(ctx, conn, sessionID); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if _, err := conn.ExecContext(ctx, `DELETE FROM session_redo WHERE session_id = ?`, sessionID); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("consume redo suffix: %w", err)
+	}
+	if _, err := s.bumpTranscriptRevPreservingRedo(ctx, conn, sessionID); err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	post, err := transcriptMutationState(ctx, conn, sessionID)
+	if err != nil {
+		return TranscriptMutationResult{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("commit redo: %w", err)
+	}
+	return TranscriptMutationResult{TranscriptMutationState: post}, nil
 }
 
 func transcriptRowHasDisplayBody(role llm.Role, parts []llm.Part, planToolCalls map[string]bool) bool {

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -146,12 +146,12 @@ CREATE TABLE IF NOT EXISTS session_plans (
 );
 
 CREATE TABLE IF NOT EXISTS session_redo (
-    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    stack_pos INTEGER NOT NULL,
     suffix TEXT NOT NULL,
     metadata TEXT NOT NULL,
-    undo_rev INTEGER NOT NULL,
-    head_id INTEGER NOT NULL DEFAULT 0,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (session_id, stack_pos)
 );
 
 -- Metadata table for current session tracking
@@ -1228,15 +1228,15 @@ var migrations = []migration{
 	},
 	{
 		version:     44,
-		description: "create durable transcript redo table",
+		description: "create durable transcript redo stack",
 		up: func(db schemaExecutor) error {
 			_, err := db.Exec(`CREATE TABLE IF NOT EXISTS session_redo (
-				session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+				session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+				stack_pos INTEGER NOT NULL,
 				suffix TEXT NOT NULL,
 				metadata TEXT NOT NULL,
-				undo_rev INTEGER NOT NULL,
-				head_id INTEGER NOT NULL DEFAULT 0,
-				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (session_id, stack_pos)
 			)`)
 			return err
 		},
@@ -3774,13 +3774,16 @@ func (s *SQLiteStore) UndoLastUserTurn(ctx context.Context, sessionID string, ex
 	if post.Rev != rev {
 		return TranscriptMutationResult{}, fmt.Errorf("undo revision mismatch")
 	}
+	// Successive undo entries contain disjoint removed suffixes, so the durable
+	// stack is naturally bounded by the removed transcript rather than an
+	// arbitrary entry limit. Preserve every recovery point until redo consumes it
+	// or an ordinary transcript mutation invalidates the whole stack.
 	if _, err := conn.ExecContext(ctx, `
-		INSERT INTO session_redo (session_id, suffix, metadata, undo_rev, head_id, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-		ON CONFLICT(session_id) DO UPDATE SET suffix = excluded.suffix, metadata = excluded.metadata,
-			undo_rev = excluded.undo_rev, head_id = excluded.head_id, updated_at = CURRENT_TIMESTAMP`,
-		sessionID, string(suffixJSON), string(metadataJSON), post.Rev, post.HeadID); err != nil {
-		return TranscriptMutationResult{}, fmt.Errorf("save redo suffix: %w", err)
+		INSERT INTO session_redo (session_id, stack_pos, suffix, metadata, created_at)
+		SELECT ?, COALESCE(MAX(stack_pos), 0) + 1, ?, ?, CURRENT_TIMESTAMP
+		FROM session_redo WHERE session_id = ?`,
+		sessionID, string(suffixJSON), string(metadataJSON), sessionID); err != nil {
+		return TranscriptMutationResult{}, fmt.Errorf("push redo suffix: %w", err)
 	}
 	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return TranscriptMutationResult{}, fmt.Errorf("commit undo: %w", err)
@@ -3807,17 +3810,16 @@ func (s *SQLiteStore) RedoLastUserTurn(ctx context.Context, sessionID string, ex
 	if err := requireTranscriptMutationState(actual, expected); err != nil {
 		return TranscriptMutationResult{}, err
 	}
+	var stackPos int64
 	var suffixRaw, metadataRaw string
-	var undoRev, headID int64
-	err = conn.QueryRowContext(ctx, `SELECT suffix, metadata, undo_rev, head_id FROM session_redo WHERE session_id = ?`, sessionID).Scan(&suffixRaw, &metadataRaw, &undoRev, &headID)
+	err = conn.QueryRowContext(ctx, `
+		SELECT stack_pos, suffix, metadata FROM session_redo
+		WHERE session_id = ? ORDER BY stack_pos DESC LIMIT 1`, sessionID).Scan(&stackPos, &suffixRaw, &metadataRaw)
 	if errors.Is(err, sql.ErrNoRows) {
 		return TranscriptMutationResult{}, ErrNothingToRedo
 	}
 	if err != nil {
 		return TranscriptMutationResult{}, fmt.Errorf("load redo suffix: %w", err)
-	}
-	if undoRev != actual.Rev || headID != actual.HeadID {
-		return TranscriptMutationResult{}, ErrTranscriptConflict
 	}
 	var suffix []Message
 	if err := json.Unmarshal([]byte(suffixRaw), &suffix); err != nil {
@@ -3853,7 +3855,7 @@ func (s *SQLiteStore) RedoLastUserTurn(ctx context.Context, sessionID string, ex
 	if err := s.reconcilePlanProjection(ctx, conn, sessionID); err != nil {
 		return TranscriptMutationResult{}, err
 	}
-	if _, err := conn.ExecContext(ctx, `DELETE FROM session_redo WHERE session_id = ?`, sessionID); err != nil {
+	if _, err := conn.ExecContext(ctx, `DELETE FROM session_redo WHERE session_id = ? AND stack_pos = ?`, sessionID, stackPos); err != nil {
 		return TranscriptMutationResult{}, fmt.Errorf("consume redo suffix: %w", err)
 	}
 	if _, err := s.bumpTranscriptRevPreservingRedo(ctx, conn, sessionID); err != nil {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -378,8 +378,8 @@ type TranscriptMutationResult struct {
 	AttachmentsOmitted bool   `json:"attachments_omitted,omitempty"`
 }
 
-// TranscriptUndoRedoStore owns the durable, single-level redo suffix. Ordinary
-// transcript writes invalidate redo in the same storage transaction.
+// TranscriptUndoRedoStore owns a durable per-session redo stack. Ordinary
+// transcript writes invalidate the entire stack in the same storage transaction.
 type TranscriptUndoRedoStore interface {
 	TranscriptMutationState(ctx context.Context, sessionID string) (TranscriptMutationState, error)
 	UndoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error)

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -24,6 +24,16 @@ var ErrNotFound = errors.New("session: not found")
 // mutation method that reports the exact transcript revision it commits.
 var ErrTranscriptRevisionUnsupported = errors.New("session: transcript revision unsupported")
 
+var (
+	// ErrTranscriptConflict means a transcript mutation was based on a stale
+	// revision or head row and must be retried after refreshing the transcript.
+	ErrTranscriptConflict = errors.New("session: transcript changed")
+	// ErrNothingToUndo means there is no real post-compaction user turn to undo.
+	ErrNothingToUndo = errors.New("session: nothing to undo")
+	// ErrNothingToRedo means no durable undo suffix remains for this session.
+	ErrNothingToRedo = errors.New("session: nothing to redo")
+)
+
 // Store is the interface for session persistence.
 type Store interface {
 	// Session CRUD
@@ -349,6 +359,31 @@ type TranscriptIndexer interface {
 // older read-only database where TranscriptIndexer exposes revision zero only.
 type TranscriptVersionReporter interface {
 	TranscriptVersioned() bool
+}
+
+// TranscriptMutationState is the optimistic concurrency token for undo/redo.
+// HeadID is the final non-internal transcript row (the same row stream exposed
+// by TranscriptIndexer); zero represents an empty transcript.
+type TranscriptMutationState struct {
+	Rev    int64 `json:"rev"`
+	HeadID int64 `json:"head_id"`
+}
+
+// TranscriptMutationResult describes the transcript after undo or redo.
+// UserText is populated for undo so clients can restore the removed prompt to
+// their composer.
+type TranscriptMutationResult struct {
+	TranscriptMutationState
+	UserText           string `json:"user_text,omitempty"`
+	AttachmentsOmitted bool   `json:"attachments_omitted,omitempty"`
+}
+
+// TranscriptUndoRedoStore owns the durable, single-level redo suffix. Ordinary
+// transcript writes invalidate redo in the same storage transaction.
+type TranscriptUndoRedoStore interface {
+	TranscriptMutationState(ctx context.Context, sessionID string) (TranscriptMutationState, error)
+	UndoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error)
+	RedoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error)
 }
 
 // SessionSummaryTranscriptRevisionReporter reports whether Store.List populates

--- a/internal/session/undo_redo_test.go
+++ b/internal/session/undo_redo_test.go
@@ -1,0 +1,534 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	planpkg "github.com/samsaffron/term-llm/internal/plan"
+)
+
+func newUndoRedoSQLiteStore(t *testing.T) (*SQLiteStore, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	return store, path
+}
+
+func addUndoRedoMessage(t *testing.T, store *SQLiteStore, sessionID string, msg llm.Message, at time.Time) Message {
+	t.Helper()
+	stored := NewMessage(sessionID, msg, -1)
+	stored.CreatedAt = at
+	if err := store.AddMessage(context.Background(), sessionID, stored); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	return *stored
+}
+
+func TestSQLiteUndoRedoShrinksAndExactlyRestoresTranscriptAcrossRestart(t *testing.T) {
+	store, path := newUndoRedoSQLiteStore(t)
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat, TitleSource: TitleSourceGenerated,
+		GeneratedShortTitle: "Generated", GeneratedLongTitle: "Generated conversation", TitleBasisMsgSeq: 3,
+		TitleGeneratedAt: time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := time.Date(2026, 8, 3, 11, 0, 0, 0, time.UTC)
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("first"), base)
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("first answer"), base.Add(time.Second))
+	latest := llm.UserText("second exact prompt")
+	latest.ClientMessageID = "client_second"
+	addUndoRedoMessage(t, store, sess.ID, latest, base.Add(2*time.Second))
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	assistant := llm.AssistantText("second answer")
+	assistant.ResponseID = "resp_second"
+	assistant.AssistantSegmentOrdinal = 0
+	addUndoRedoMessage(t, store, sess.ID, assistant, base.Add(3*time.Second))
+	addUndoRedoMessage(t, store, sess.ID, llm.Message{Role: llm.RoleEvent, Parts: []llm.Part{{Type: llm.PartText, Text: "tail event"}}}, base.Add(4*time.Second))
+
+	before, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages before: %v", err)
+	}
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("TranscriptMutationState: %v", err)
+	}
+	result, err := store.UndoLastUserTurn(ctx, sess.ID, state)
+	if err != nil {
+		t.Fatalf("UndoLastUserTurn: %v", err)
+	}
+	if result.UserText != "second exact prompt" {
+		t.Fatalf("undo user text = %q", result.UserText)
+	}
+	afterUndo, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after undo: %v", err)
+	}
+	if len(afterUndo) != 2 {
+		t.Fatalf("transcript length after undo = %d, want 2", len(afterUndo))
+	}
+	if result.Rev != state.Rev+1 || result.HeadID != afterUndo[len(afterUndo)-1].ID {
+		t.Fatalf("undo state = %+v, before = %+v", result.TranscriptMutationState, state)
+	}
+	refreshed, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get session after undo: %v", err)
+	}
+	if refreshed.UserTurns != 2 || refreshed.Summary != "first" || refreshed.LastTotalTokens != 0 || refreshed.TitleSource == TitleSourceGenerated {
+		t.Fatalf("derived metadata was not reconciled without decreasing user turns: %+v", refreshed)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	store, err = NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	restartState, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("state after restart: %v", err)
+	}
+	redo, err := store.RedoLastUserTurn(ctx, sess.ID, restartState)
+	if err != nil {
+		t.Fatalf("RedoLastUserTurn after restart: %v", err)
+	}
+	afterRedo, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after redo: %v", err)
+	}
+	if !reflect.DeepEqual(afterRedo, before) {
+		t.Fatalf("redo transcript differs\n got: %#v\nwant: %#v", afterRedo, before)
+	}
+	if redo.Rev != restartState.Rev+1 || redo.HeadID != before[len(before)-1].ID {
+		t.Fatalf("redo state = %+v, undo state = %+v", redo.TranscriptMutationState, restartState)
+	}
+	refreshed, err = store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Get session after redo: %v", err)
+	}
+	if refreshed.UserTurns != 2 || refreshed.Summary != "first" || refreshed.GeneratedShortTitle != "Generated" || refreshed.TitleSource != TitleSourceGenerated {
+		t.Fatalf("redo metadata was not restored: %+v", refreshed)
+	}
+}
+
+func TestSQLiteUndoRedoOptimisticChecksAndMutationInvalidation(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("one"), time.Now())
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, TranscriptMutationState{Rev: state.Rev - 1, HeadID: state.HeadID}); !errors.Is(err, ErrTranscriptConflict) {
+		t.Fatalf("stale revision error = %v", err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, TranscriptMutationState{Rev: state.Rev, HeadID: state.HeadID + 1}); !errors.Is(err, ErrTranscriptConflict) {
+		t.Fatalf("stale head error = %v", err)
+	}
+	undo, err := store.UndoLastUserTurn(ctx, sess.ID, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("replacement"), time.Now().Add(time.Second))
+	current, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RedoLastUserTurn(ctx, sess.ID, undo.TranscriptMutationState); !errors.Is(err, ErrTranscriptConflict) {
+		t.Fatalf("stale redo error = %v", err)
+	}
+	if _, err := store.RedoLastUserTurn(ctx, sess.ID, current); !errors.Is(err, ErrNothingToRedo) {
+		t.Fatalf("invalidated redo error = %v", err)
+	}
+}
+
+func TestSQLiteOrdinaryTranscriptMutationsInvalidateRedo(t *testing.T) {
+	mutations := map[string]func(*testing.T, context.Context, *SQLiteStore, string){
+		"add": func(t *testing.T, ctx context.Context, store *SQLiteStore, sessionID string) {
+			addUndoRedoMessage(t, store, sessionID, llm.UserText("new turn"), time.Now())
+		},
+		"update": func(t *testing.T, ctx context.Context, store *SQLiteStore, sessionID string) {
+			messages, err := store.GetMessages(ctx, sessionID, 0, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			messages[len(messages)-1].Parts = []llm.Part{{Type: llm.PartText, Text: "edited answer"}}
+			messages[len(messages)-1].TextContent = "edited answer"
+			if err := store.UpdateMessage(ctx, sessionID, &messages[len(messages)-1]); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"replace": func(t *testing.T, ctx context.Context, store *SQLiteStore, sessionID string) {
+			messages, err := store.GetMessages(ctx, sessionID, 0, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.ReplaceMessages(ctx, sessionID, messages); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"compact": func(t *testing.T, ctx context.Context, store *SQLiteStore, sessionID string) {
+			summary := NewMessage(sessionID, llm.UserText("[Context Compaction]\nsummary"), 0)
+			if err := store.CompactMessages(ctx, sessionID, []Message{*summary}); err != nil {
+				t.Fatal(err)
+			}
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			store, _ := newUndoRedoSQLiteStore(t)
+			defer store.Close()
+			ctx := context.Background()
+			sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+			if err := store.Create(ctx, sess); err != nil {
+				t.Fatal(err)
+			}
+			addUndoRedoMessage(t, store, sess.ID, llm.UserText("first"), time.Now())
+			addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer"), time.Now().Add(time.Millisecond))
+			addUndoRedoMessage(t, store, sess.ID, llm.UserText("undo me"), time.Now().Add(2*time.Millisecond))
+			state, err := store.TranscriptMutationState(ctx, sess.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); err != nil {
+				t.Fatal(err)
+			}
+			mutate(t, ctx, store, sess.ID)
+			current, err := store.TranscriptMutationState(ctx, sess.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.RedoLastUserTurn(ctx, sess.ID, current); !errors.Is(err, ErrNothingToRedo) {
+				t.Fatalf("redo after %s mutation error = %v", name, err)
+			}
+		})
+	}
+}
+
+func TestSQLiteUndoPreservesCompactionBoundaryAndSkipsSyntheticUsers(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := time.Now()
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("old real prompt"), base)
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("old answer"), base.Add(time.Second))
+	summary := NewMessage(sess.ID, llm.UserText("[Context Compaction]\nsummary"), 0)
+	ack := NewMessage(sess.ID, llm.AssistantText("context loaded"), 1)
+	tail := NewMessage(sess.ID, llm.UserText("retained real-looking tail"), 2)
+	tail.CompactionTail = true
+	if err := store.CompactMessages(ctx, sess.ID, []Message{*summary, *ack, *tail}); err != nil {
+		t.Fatalf("CompactMessages: %v", err)
+	}
+	compacted, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); !errors.Is(err, ErrNothingToUndo) {
+		t.Fatalf("synthetic-only undo error = %v", err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("post compact prompt"), base.Add(2*time.Second))
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("post compact answer"), base.Add(3*time.Second))
+	state, _ = store.TranscriptMutationState(ctx, sess.ID)
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); err != nil {
+		t.Fatalf("UndoLastUserTurn post compact: %v", err)
+	}
+	refreshed, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.CompactionSeq != compacted.CompactionSeq || refreshed.CompactionCount != compacted.CompactionCount {
+		t.Fatalf("compaction boundary changed from (%d,%d) to (%d,%d)", compacted.CompactionSeq, compacted.CompactionCount, refreshed.CompactionSeq, refreshed.CompactionCount)
+	}
+}
+
+func TestSQLiteUndoReconcilesPlanAndClearsProviderState(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", ProviderKey: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	firstPlan := `{"plan":[{"step":"first","status":"completed"}]}`
+	secondPlan := `{"plan":[{"step":"second","status":"in_progress"}]}`
+	addPlan := func(prompt, callID, args string, at time.Time) {
+		addUndoRedoMessage(t, store, sess.ID, llm.UserText(prompt), at)
+		addUndoRedoMessage(t, store, sess.ID, llm.Message{Role: llm.RoleAssistant, Parts: []llm.Part{{Type: llm.PartToolCall, ToolCall: &llm.ToolCall{ID: callID, Name: planpkg.ToolName, Arguments: []byte(args)}}}}, at.Add(time.Millisecond))
+		addUndoRedoMessage(t, store, sess.ID, llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartToolResult, ToolResult: &llm.ToolResult{ID: callID, Name: planpkg.ToolName, Content: "ok"}}}}, at.Add(2*time.Millisecond))
+	}
+	addPlan("first prompt", "plan_1", firstPlan, time.Now())
+	addPlan("second prompt", "plan_2", secondPlan, time.Now().Add(time.Second))
+	secondSnapshot, err := planpkg.Parse([]byte(secondPlan))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SavePlanSnapshot(ctx, sess.ID, secondSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveProviderState(ctx, sess.ID, "test", []byte(`{"continuation":"opaque"}`)); err != nil {
+		t.Fatal(err)
+	}
+	state, _ := store.TranscriptMutationState(ctx, sess.ID)
+	undo, err := store.UndoLastUserTurn(ctx, sess.ID, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, version, err := store.LoadPlanSnapshot(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version == 0 || len(plan.Plan) != 1 || plan.Plan[0].Step != "first" {
+		t.Fatalf("plan after undo = %#v version=%d", plan, version)
+	}
+	providerState, err := store.LoadProviderState(ctx, sess.ID, "test")
+	if err != nil || len(providerState) != 0 {
+		t.Fatalf("provider state after undo = %q err=%v", providerState, err)
+	}
+	if _, err := store.RedoLastUserTurn(ctx, sess.ID, undo.TranscriptMutationState); err != nil {
+		t.Fatal(err)
+	}
+	plan, version, err = store.LoadPlanSnapshot(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version == 0 || len(plan.Plan) != 1 || plan.Plan[0].Step != "second" {
+		t.Fatalf("plan after redo = %#v version=%d", plan, version)
+	}
+}
+
+func TestSQLiteUndoCanonicalizesLongMultilineSummary(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	firstPrompt := strings.Repeat("long summary source ", 12) + "\nsecond line must never enter summary"
+	wantSummary := TruncateSummary(firstPrompt)
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat, Summary: wantSummary}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText(firstPrompt), base)
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer"), base.Add(time.Second))
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("undo me"), base.Add(2*time.Second))
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.Summary != wantSummary || strings.Contains(refreshed.Summary, "\n") || len(refreshed.Summary) > 100 {
+		t.Fatalf("summary = %q, want canonical %q", refreshed.Summary, wantSummary)
+	}
+}
+
+func TestSQLiteUndoSkipsWhitespacePrefixedCompactionMarker(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	summary := NewMessage(sess.ID, llm.UserText("\n\t \r[Context Compaction]\nsummary"), 0)
+	if err := store.CompactMessages(ctx, sess.ID, []Message{*summary}); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); !errors.Is(err, ErrNothingToUndo) {
+		t.Fatalf("undo whitespace-prefixed compaction marker error = %v", err)
+	}
+	messages, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil || len(messages) != 1 {
+		t.Fatalf("compaction marker was destructively selected: len=%d err=%v", len(messages), err)
+	}
+}
+
+func TestSQLiteUndoPreservesEveryUserRowActivityAndMonotonicTurns(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("old real prompt"), base)
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	summary := NewMessage(sess.ID, llm.UserText("[Context Compaction]\nsummary"), -1)
+	summary.CreatedAt = base.Add(10 * time.Second)
+	tail := NewMessage(sess.ID, llm.UserText("retained tail"), -1)
+	tail.CreatedAt = base.Add(11 * time.Second)
+	tail.CompactionTail = true
+	if err := store.CompactMessages(ctx, sess.ID, []Message{*summary, *tail}); err != nil {
+		t.Fatal(err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("post-compaction prompt"), base.Add(20*time.Second))
+	if err := store.IncrementUserTurns(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := store.Get(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.UserTurns != 2 {
+		t.Fatalf("UserTurns = %d, want increment-only value 2", refreshed.UserTurns)
+	}
+	var lastUserMessageAt time.Time
+	if err := store.db.QueryRowContext(ctx, `SELECT last_user_message_at FROM sessions WHERE id = ?`, sess.ID).Scan(&lastUserMessageAt); err != nil {
+		t.Fatal(err)
+	}
+	if !lastUserMessageAt.Equal(tail.CreatedAt) {
+		t.Fatalf("last_user_message_at = %v, want retained user row time %v", lastUserMessageAt, tail.CreatedAt)
+	}
+}
+
+func TestSQLiteUndoConcurrentRequestsAllowOneWinner(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("race"), time.Now())
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.UndoLastUserTurn(ctx, sess.ID, state)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	var succeeded, conflicted int
+	for err := range errs {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, ErrTranscriptConflict):
+			conflicted++
+		default:
+			t.Fatalf("concurrent undo error = %v", err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("concurrent undo results: succeeded=%d conflicted=%d", succeeded, conflicted)
+	}
+}
+
+func TestSQLiteRedoRowCascadesWhenSessionDeleted(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("delete me"), time.Now())
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM session_redo WHERE session_id = ?`, sess.ID).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("redo row before delete count=%d err=%v", count, err)
+	}
+	if err := store.Delete(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM session_redo WHERE session_id = ?`, sess.ID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("redo row after cascade count=%d err=%v", count, err)
+	}
+}
+
+func TestSQLiteUndoReportsAttachmentsOmittedFromComposer(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	message := llm.UserText("describe this")
+	message.Parts = append(message.Parts, llm.Part{Type: llm.PartImage, ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="}})
+	addUndoRedoMessage(t, store, sess.ID, message, time.Now())
+	state, err := store.TranscriptMutationState(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.UndoLastUserTurn(ctx, sess.ID, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.AttachmentsOmitted || result.UserText != "describe this" {
+		t.Fatalf("undo result = %+v, want text with attachment warning", result)
+	}
+}

--- a/internal/session/undo_redo_test.go
+++ b/internal/session/undo_redo_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -32,6 +33,47 @@ func addUndoRedoMessage(t *testing.T, store *SQLiteStore, sessionID string, msg 
 		t.Fatalf("AddMessage: %v", err)
 	}
 	return *stored
+}
+
+func applyUndoRedo(t *testing.T, store *SQLiteStore, sessionID string, redo bool) TranscriptMutationResult {
+	t.Helper()
+	ctx := context.Background()
+	state, err := store.TranscriptMutationState(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("TranscriptMutationState: %v", err)
+	}
+	var result TranscriptMutationResult
+	if redo {
+		result, err = store.RedoLastUserTurn(ctx, sessionID, state)
+	} else {
+		result, err = store.UndoLastUserTurn(ctx, sessionID, state)
+	}
+	if err != nil {
+		t.Fatalf("%s: %v", map[bool]string{false: "UndoLastUserTurn", true: "RedoLastUserTurn"}[redo], err)
+	}
+	return result
+}
+
+func redoStackCount(t *testing.T, store *SQLiteStore, sessionID string) int {
+	t.Helper()
+	var count int
+	if err := store.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM session_redo WHERE session_id = ?`, sessionID).Scan(&count); err != nil {
+		t.Fatalf("count redo stack: %v", err)
+	}
+	return count
+}
+
+func transcriptText(t *testing.T, store *SQLiteStore, sessionID string) []string {
+	t.Helper()
+	messages, err := store.GetMessages(context.Background(), sessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	texts := make([]string, len(messages))
+	for i := range messages {
+		texts[i] = messages[i].TextContent
+	}
+	return texts
 }
 
 func TestSQLiteUndoRedoShrinksAndExactlyRestoresTranscriptAcrossRestart(t *testing.T) {
@@ -126,6 +168,125 @@ func TestSQLiteUndoRedoShrinksAndExactlyRestoresTranscriptAcrossRestart(t *testi
 	}
 	if refreshed.UserTurns != 2 || refreshed.Summary != "first" || refreshed.GeneratedShortTitle != "Generated" || refreshed.TitleSource != TitleSourceGenerated {
 		t.Fatalf("redo metadata was not restored: %+v", refreshed)
+	}
+}
+
+func TestSQLiteUndoRedoMultipleTurnsRoundTripInLIFOOrderAcrossRestart(t *testing.T) {
+	store, path := newUndoRedoSQLiteStore(t)
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 8, 3, 14, 0, 0, 0, time.UTC)
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("turn B"), base)
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer B"), base.Add(time.Second))
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("turn A"), base.Add(2*time.Second))
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer A"), base.Add(3*time.Second))
+	before, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstUndo := applyUndoRedo(t, store, sess.ID, false)
+	if firstUndo.UserText != "turn A" || !reflect.DeepEqual(transcriptText(t, store, sess.ID), []string{"turn B", "answer B"}) {
+		t.Fatalf("first undo result=%+v transcript=%q", firstUndo, transcriptText(t, store, sess.ID))
+	}
+	secondUndo := applyUndoRedo(t, store, sess.ID, false)
+	if secondUndo.UserText != "turn B" || len(transcriptText(t, store, sess.ID)) != 0 || redoStackCount(t, store, sess.ID) != 2 {
+		t.Fatalf("second undo result=%+v transcript=%q stack=%d", secondUndo, transcriptText(t, store, sess.ID), redoStackCount(t, store, sess.ID))
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	if redoStackCount(t, store, sess.ID) != 2 {
+		t.Fatalf("redo stack did not survive reopen")
+	}
+	applyUndoRedo(t, store, sess.ID, true)
+	if !reflect.DeepEqual(transcriptText(t, store, sess.ID), []string{"turn B", "answer B"}) || redoStackCount(t, store, sess.ID) != 1 {
+		t.Fatalf("first redo restored wrong turn: transcript=%q stack=%d", transcriptText(t, store, sess.ID), redoStackCount(t, store, sess.ID))
+	}
+	applyUndoRedo(t, store, sess.ID, true)
+	after, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("multi-level round trip differs\n got: %#v\nwant: %#v", after, before)
+	}
+	if redoStackCount(t, store, sess.ID) != 0 {
+		t.Fatalf("redo stack count after full replay = %d, want 0", redoStackCount(t, store, sess.ID))
+	}
+}
+
+func TestSQLiteAddMessageClearsEntireRedoStackAfterOneOrMultipleUndos(t *testing.T) {
+	for _, undoCount := range []int{1, 2} {
+		t.Run(fmt.Sprintf("undos_%d", undoCount), func(t *testing.T) {
+			store, _ := newUndoRedoSQLiteStore(t)
+			defer store.Close()
+			ctx := context.Background()
+			sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+			if err := store.Create(ctx, sess); err != nil {
+				t.Fatal(err)
+			}
+			base := time.Now()
+			addUndoRedoMessage(t, store, sess.ID, llm.UserText("first"), base)
+			addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("first answer"), base.Add(time.Millisecond))
+			addUndoRedoMessage(t, store, sess.ID, llm.UserText("second"), base.Add(2*time.Millisecond))
+			addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("second answer"), base.Add(3*time.Millisecond))
+			for range undoCount {
+				applyUndoRedo(t, store, sess.ID, false)
+			}
+			if got := redoStackCount(t, store, sess.ID); got != undoCount {
+				t.Fatalf("redo stack count before continuation = %d, want %d", got, undoCount)
+			}
+			addUndoRedoMessage(t, store, sess.ID, llm.UserText("ordinary continuation"), base.Add(time.Second))
+			if got := redoStackCount(t, store, sess.ID); got != 0 {
+				t.Fatalf("redo stack count after continuation = %d, want 0", got)
+			}
+			state, err := store.TranscriptMutationState(ctx, sess.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.RedoLastUserTurn(ctx, sess.ID, state); !errors.Is(err, ErrNothingToRedo) {
+				t.Fatalf("redo after ordinary continuation error = %v, want ErrNothingToRedo", err)
+			}
+		})
+	}
+}
+
+func TestSQLiteUndoRedoInterleavingPreservesStackOrder(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("turn B"), base)
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer B"), base.Add(time.Millisecond))
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("turn A"), base.Add(2*time.Millisecond))
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer A"), base.Add(3*time.Millisecond))
+	want := []string{"turn B", "answer B", "turn A", "answer A"}
+
+	applyUndoRedo(t, store, sess.ID, false) // undo A
+	applyUndoRedo(t, store, sess.ID, false) // undo B
+	applyUndoRedo(t, store, sess.ID, true)  // redo B
+	if got := transcriptText(t, store, sess.ID); !reflect.DeepEqual(got, want[:2]) {
+		t.Fatalf("after undo/undo/redo transcript=%q, want %q", got, want[:2])
+	}
+	applyUndoRedo(t, store, sess.ID, false) // undo B again
+	applyUndoRedo(t, store, sess.ID, true)  // redo B
+	applyUndoRedo(t, store, sess.ID, true)  // redo A
+	if got := transcriptText(t, store, sess.ID); !reflect.DeepEqual(got, want) {
+		t.Fatalf("interleaved round trip transcript=%q, want %q", got, want)
 	}
 }
 
@@ -481,7 +642,7 @@ func TestSQLiteUndoConcurrentRequestsAllowOneWinner(t *testing.T) {
 	}
 }
 
-func TestSQLiteRedoRowCascadesWhenSessionDeleted(t *testing.T) {
+func TestSQLiteRedoConcurrentRequestsConsumeOnlyOneStackEntry(t *testing.T) {
 	store, _ := newUndoRedoSQLiteStore(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -489,23 +650,128 @@ func TestSQLiteRedoRowCascadesWhenSessionDeleted(t *testing.T) {
 	if err := store.Create(ctx, sess); err != nil {
 		t.Fatal(err)
 	}
-	addUndoRedoMessage(t, store, sess.ID, llm.UserText("delete me"), time.Now())
+	base := time.Now()
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("turn B"), base)
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer B"), base.Add(time.Millisecond))
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("turn A"), base.Add(2*time.Millisecond))
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("answer A"), base.Add(3*time.Millisecond))
+	applyUndoRedo(t, store, sess.ID, false)
+	applyUndoRedo(t, store, sess.ID, false)
 	state, err := store.TranscriptMutationState(ctx, sess.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.UndoLastUserTurn(ctx, sess.ID, state); err != nil {
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.RedoLastUserTurn(ctx, sess.ID, state)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	var succeeded, conflicted int
+	for err := range errs {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, ErrTranscriptConflict):
+			conflicted++
+		default:
+			t.Fatalf("concurrent redo error = %v", err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("concurrent redo results: succeeded=%d conflicted=%d", succeeded, conflicted)
+	}
+	if got := transcriptText(t, store, sess.ID); !reflect.DeepEqual(got, []string{"turn B", "answer B"}) {
+		t.Fatalf("concurrent redo restored transcript=%q", got)
+	}
+	if got := redoStackCount(t, store, sess.ID); got != 1 {
+		t.Fatalf("concurrent redo stack count=%d, want 1", got)
+	}
+	applyUndoRedo(t, store, sess.ID, true)
+	if got := transcriptText(t, store, sess.ID); !reflect.DeepEqual(got, []string{"turn B", "answer B", "turn A", "answer A"}) {
+		t.Fatalf("remaining redo transcript=%q", got)
+	}
+}
+
+func TestSQLiteMigration44CreatesOrderedRedoStack(t *testing.T) {
+	store, path := newUndoRedoSQLiteStore(t)
+	if _, err := store.db.Exec(`DROP TABLE session_redo; UPDATE schema_version SET version = 43`); err != nil {
+		t.Fatalf("seed version 43 schema: %v", err)
+	}
+	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
-	var count int
-	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM session_redo WHERE session_id = ?`, sess.ID).Scan(&count); err != nil || count != 1 {
-		t.Fatalf("redo row before delete count=%d err=%v", count, err)
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatalf("migrate version 43 store: %v", err)
+	}
+	defer store.Close()
+
+	var version int
+	if err := store.db.QueryRow(`SELECT version FROM schema_version`).Scan(&version); err != nil || version != schemaVersion {
+		t.Fatalf("schema version=%d err=%v, want %d", version, err, schemaVersion)
+	}
+	rows, err := store.db.Query(`PRAGMA table_info(session_redo)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	columns := map[string]int{}
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		columns[name] = primaryKey
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if columns["session_id"] != 1 || columns["stack_pos"] != 2 {
+		t.Fatalf("redo stack primary key columns=%v", columns)
+	}
+	if _, ok := columns["undo_rev"]; ok {
+		t.Fatalf("obsolete per-entry undo revision survived migration: %v", columns)
+	}
+	if _, ok := columns["head_id"]; ok {
+		t.Fatalf("obsolete per-entry head id survived migration: %v", columns)
+	}
+}
+
+func TestSQLiteRedoStackCascadesWhenSessionDeleted(t *testing.T) {
+	store, _ := newUndoRedoSQLiteStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("delete first"), base)
+	addUndoRedoMessage(t, store, sess.ID, llm.AssistantText("first answer"), base.Add(time.Millisecond))
+	addUndoRedoMessage(t, store, sess.ID, llm.UserText("delete second"), base.Add(2*time.Millisecond))
+	applyUndoRedo(t, store, sess.ID, false)
+	applyUndoRedo(t, store, sess.ID, false)
+	if count := redoStackCount(t, store, sess.ID); count != 2 {
+		t.Fatalf("redo entries before delete count=%d, want 2", count)
 	}
 	if err := store.Delete(ctx, sess.ID); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM session_redo WHERE session_id = ?`, sess.ID).Scan(&count); err != nil || count != 0 {
-		t.Fatalf("redo row after cascade count=%d err=%v", count, err)
+	if count := redoStackCount(t, store, sess.ID); count != 0 {
+		t.Fatalf("redo entries after cascade count=%d, want 0", count)
 	}
 }
 

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -388,6 +388,13 @@ func (t *UpdatePlanTool) Spec() llm.ToolSpec {
 	}
 }
 
+func (t *UpdatePlanTool) ResetSessionState(sessionID string) {
+	if t == nil || t.controller == nil {
+		return
+	}
+	t.controller.clearTransientState(sessionID)
+}
+
 func (t *UpdatePlanTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
 	snapshot, err := planpkg.Parse(args)
 	if err != nil {

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -94,12 +94,13 @@ type Model struct {
 	compactionIdx            int // Prefix length to skip for LLM context; 0 means no prefix is skipped.
 	// olderScrollbackLoaded is false when a compacted resume initially loaded only
 	// the active tail; scrolling upward can hydrate the older display prefix once.
-	olderScrollbackLoaded bool
-	messagesMu            sync.Mutex // Protects messages from concurrent compaction callback
-	streaming             bool
-	shareInFlight         bool
-	pendingShare          *shareRequest
-	phase                 string // "Thinking", "Searching", "Reading", "Responding"
+	olderScrollbackLoaded      bool
+	messagesMu                 sync.Mutex // Protects messages from concurrent compaction callback
+	streaming                  bool
+	transcriptMutationInFlight bool
+	shareInFlight              bool
+	pendingShare               *shareRequest
+	phase                      string // "Thinking", "Searching", "Reading", "Responding"
 
 	// Reasoning display/status state. Provider replay metadata is persisted in
 	// assistant parts by the LLM engine; these fields only affect live UI policy.
@@ -1780,6 +1781,7 @@ func isParentChatMessage(msg tea.Msg) bool {
 		mcpStatusUpdateMsg,
 		GuardianReviewMsg,
 		chatGPTModelsLoadedMsg,
+		transcriptMutationDoneMsg,
 		FlushBeforeAskUserMsg,
 		FlushBeforeApprovalMsg,
 		ResumeFromExternalUIMsg,
@@ -2053,6 +2055,9 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 
 	case chatGPTModelsLoadedMsg:
 		return m.applyChatGPTModelsLoaded(msg)
+
+	case transcriptMutationDoneMsg:
+		return m.handleTranscriptMutationDone(msg)
 
 	case promptHistoryLookupMsg:
 		return m.handlePromptHistoryLookupMsg(msg)

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -1049,6 +1049,10 @@ func (m *Model) handleTranscriptMutationDone(msg transcriptMutationDoneMsg) (tea
 	m.olderScrollbackLoaded = true
 	m.scrollOffset = 0
 	m.scrollToBottom = true
+	// A completed response may still be held separately from persisted history for
+	// the streaming fast path. Transcript replacement makes that snapshot stale.
+	m.viewCache.completedStream = ""
+	m.invalidateAltScreenStreamingViewportCache()
 	m.invalidateHistoryCache()
 	m.resetContextEstimateBaseline(m.rootContext())
 	m.resetTitleGenerationStateForSession()

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -104,6 +104,16 @@ func AllCommands() []Command {
 			Usage:       "/clear",
 		},
 		{
+			Name:        "undo",
+			Description: "Remove the latest user turn and everything after it",
+			Usage:       "/undo",
+		},
+		{
+			Name:        "redo",
+			Description: "Restore the turn removed by /undo",
+			Usage:       "/redo",
+		},
+		{
 			Name:        "quit",
 			Aliases:     []string{"q", "exit"},
 			Description: "Exit chat",
@@ -518,6 +528,10 @@ func (m *Model) ExecuteCommand(input string) (tea.Model, tea.Cmd) {
 		return m.cmdGoal(args, rawArgs)
 	case "clear":
 		return m.cmdClear()
+	case "undo":
+		return m.cmdUndoRedo(false, args)
+	case "redo":
+		return m.cmdUndoRedo(true, args)
 	case "quit":
 		return m.cmdQuit()
 	case "model":
@@ -955,6 +969,138 @@ func (m *Model) showHelpModal() (tea.Model, tea.Cmd) {
 
 	m.dialog.ShowContent("Help", b.String())
 	return m, nil
+}
+
+type transcriptMutationDoneMsg struct {
+	sessionID     string
+	redo          bool
+	result        session.TranscriptMutationResult
+	sess          *session.Session
+	messages      []session.Message
+	compactionIdx int
+	mutationErr   error
+	refreshErr    error
+}
+
+func (m *Model) transcriptMutationBusy() bool {
+	return m.transcriptMutationInFlight || m.streaming || m.activeSkillRunCount() > 0 || m.sideQuestion.Running || m.titleGenerationInFlight ||
+		m.worktreeOperationBusy() || m.shareInFlight || m.externalProcessActive || m.pausedForExternalUI
+}
+
+func transcriptMutationCmd(ctx context.Context, store session.Store, mutationStore session.TranscriptUndoRedoStore, sessionID string, redo bool) tea.Cmd {
+	return func() tea.Msg {
+		expected, err := mutationStore.TranscriptMutationState(ctx, sessionID)
+		if err != nil {
+			return transcriptMutationDoneMsg{sessionID: sessionID, redo: redo, mutationErr: err}
+		}
+		var result session.TranscriptMutationResult
+		if redo {
+			result, err = mutationStore.RedoLastUserTurn(ctx, sessionID, expected)
+		} else {
+			result, err = mutationStore.UndoLastUserTurn(ctx, sessionID, expected)
+		}
+		if err != nil {
+			return transcriptMutationDoneMsg{sessionID: sessionID, redo: redo, mutationErr: err}
+		}
+		refreshed, err := store.Get(ctx, sessionID)
+		if err != nil {
+			return transcriptMutationDoneMsg{sessionID: sessionID, redo: redo, result: result, refreshErr: err}
+		}
+		messages, compactionIdx, err := loadSessionMessagesForScrollback(ctx, store, refreshed)
+		return transcriptMutationDoneMsg{
+			sessionID: sessionID, redo: redo, result: result, sess: refreshed,
+			messages: messages, compactionIdx: compactionIdx, refreshErr: err,
+		}
+	}
+}
+
+func (m *Model) handleTranscriptMutationDone(msg transcriptMutationDoneMsg) (tea.Model, tea.Cmd) {
+	m.transcriptMutationInFlight = false
+	command := "undo"
+	if msg.redo {
+		command = "redo"
+	}
+	label := strings.ToUpper(command[:1]) + command[1:]
+	if msg.mutationErr != nil {
+		switch {
+		case errors.Is(msg.mutationErr, context.Canceled), errors.Is(msg.mutationErr, context.DeadlineExceeded):
+			return m.showFooterMuted(label + " cancelled.")
+		case errors.Is(msg.mutationErr, session.ErrNothingToUndo):
+			return m.showFooterMuted("Nothing to undo.")
+		case errors.Is(msg.mutationErr, session.ErrNothingToRedo):
+			return m.showFooterMuted("Nothing to redo.")
+		case errors.Is(msg.mutationErr, session.ErrTranscriptConflict):
+			return m.showFooterWarning("Conversation changed in another client; try again.")
+		default:
+			return m.showFooterError(fmt.Sprintf("%s failed: %v", label, msg.mutationErr))
+		}
+	}
+	if m.sess == nil || m.sess.ID != msg.sessionID {
+		return m.showFooterWarning(label + " completed for a session that is no longer active.")
+	}
+	if msg.refreshErr != nil || msg.sess == nil {
+		return m.showFooterError(fmt.Sprintf("%s succeeded, but refresh failed: %v", label, msg.refreshErr))
+	}
+	m.sess = msg.sess
+	m.messagesMu.Lock()
+	m.messages = msg.messages
+	m.compactionIdx = msg.compactionIdx
+	m.messagesMu.Unlock()
+	m.olderScrollbackLoaded = true
+	m.scrollOffset = 0
+	m.scrollToBottom = true
+	m.invalidateHistoryCache()
+	m.resetContextEstimateBaseline(m.rootContext())
+	m.resetTitleGenerationStateForSession()
+	if m.engine != nil {
+		m.engine.ResetSessionState(m.sess.ID)
+		m.engine.SetContextEstimateBaseline(0, 0)
+	}
+	m.currentResponse.Reset()
+	m.currentTokens = 0
+	m.retryStatus = ""
+	m.clearPendingStreamModelSwitch()
+	if m.tracker != nil {
+		m.resetTracker()
+	}
+	if msg.redo {
+		m.setTextareaValue("")
+		updated, footer := m.showFooterSuccess("Restored the undone turn.")
+		return updated, tea.Batch(footer, m.terminalTitleCmd())
+	}
+	m.setTextareaValue(msg.result.UserText)
+	if msg.result.AttachmentsOmitted {
+		updated, footer := m.showFooterWarning("Removed the latest turn; attachments were not restored.")
+		return updated, tea.Batch(footer, m.terminalTitleCmd())
+	}
+	updated, footer := m.showFooterSuccess("Removed the latest turn.")
+	return updated, tea.Batch(footer, m.terminalTitleCmd())
+}
+
+func (m *Model) cmdUndoRedo(redo bool, args []string) (tea.Model, tea.Cmd) {
+	command := "undo"
+	if redo {
+		command = "redo"
+	}
+	if len(args) != 0 {
+		m.setTextareaValue("")
+		return m.showFooterError("Usage: /" + command)
+	}
+	if m.transcriptMutationBusy() {
+		return m.showFooterWarning("Cannot " + command + " while work is active.")
+	}
+	if m.store == nil || m.sess == nil || strings.TrimSpace(m.sess.ID) == "" {
+		m.setTextareaValue("")
+		return m.showFooterError("No stored session to " + command + ".")
+	}
+	mutationStore, ok := m.store.(session.TranscriptUndoRedoStore)
+	if !ok {
+		m.setTextareaValue("")
+		return m.showFooterError("Session storage does not support /" + command + ".")
+	}
+	m.setTextareaValue("")
+	m.transcriptMutationInFlight = true
+	return m, transcriptMutationCmd(m.rootContext(), m.store, mutationStore, m.sess.ID, redo)
 }
 
 func (m *Model) cmdClear() (tea.Model, tea.Cmd) {

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -115,6 +115,61 @@ func TestCmdUndoRedoShrinksRestoresAndManagesComposer(t *testing.T) {
 	}
 }
 
+func TestCmdUndoRedoSequentialCommandsRestoreTurnsInLIFOOrder(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	sess := &session.Session{ID: session.NewID(), Provider: "mock", Model: "mock", Mode: session.ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	persist := func(msg llm.Message) session.Message {
+		stored := session.NewMessage(sess.ID, msg, -1)
+		if err := store.AddMessage(ctx, sess.ID, stored); err != nil {
+			t.Fatal(err)
+		}
+		return *stored
+	}
+	turnB := persist(llm.UserText("turn B"))
+	answerB := persist(llm.AssistantText("answer B"))
+	turnA := persist(llm.UserText("turn A"))
+	answerA := persist(llm.AssistantText("answer A"))
+	m := newCmdTestModel(store)
+	m.sess = sess
+	m.messages = []session.Message{turnB, answerB, turnA, answerA}
+	run := func(command string) {
+		t.Helper()
+		m.setTextareaValue(command)
+		result, cmd := m.ExecuteCommand(command)
+		m = result.(*Model)
+		if cmd == nil {
+			t.Fatalf("%s returned no async command", command)
+		}
+		result, _ = m.Update(cmd())
+		m = result.(*Model)
+	}
+
+	run("/undo")
+	if len(m.messages) != 2 || m.textarea.Value() != "turn A" {
+		t.Fatalf("first undo messages=%d composer=%q", len(m.messages), m.textarea.Value())
+	}
+	run("/undo")
+	if len(m.messages) != 0 || m.textarea.Value() != "turn B" {
+		t.Fatalf("second undo messages=%d composer=%q", len(m.messages), m.textarea.Value())
+	}
+	run("/redo")
+	if len(m.messages) != 2 || m.messages[0].ID != turnB.ID || m.messages[1].ID != answerB.ID {
+		t.Fatalf("first redo restored wrong turn: %#v", m.messages)
+	}
+	run("/redo")
+	if len(m.messages) != 4 || m.messages[2].ID != turnA.ID || m.messages[3].ID != answerA.ID || m.textarea.Value() != "" {
+		t.Fatalf("second redo failed exact LIFO restore: messages=%#v composer=%q", m.messages, m.textarea.Value())
+	}
+}
+
 func TestCmdUndoRejectsArgumentsAndActiveWork(t *testing.T) {
 	store := &mockStore{}
 	m := newCmdTestModel(store)

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -70,6 +70,9 @@ func TestCmdUndoRedoShrinksRestoresAndManagesComposer(t *testing.T) {
 	m := newCmdTestModel(store)
 	m.sess = sess
 	m.messages = []session.Message{first, second, third, fourth}
+	// Completed responses are cached separately from persisted history for the
+	// streaming fast path. Undo must not leave the removed response on screen.
+	m.viewCache.completedStream = "remove this answer"
 	m.setTextareaValue("/undo")
 
 	result, cmd := m.ExecuteCommand("/undo")
@@ -81,6 +84,9 @@ func TestCmdUndoRedoShrinksRestoresAndManagesComposer(t *testing.T) {
 	m = result.(*Model)
 	if len(m.messages) != 2 {
 		t.Fatalf("messages after undo = %d, want 2", len(m.messages))
+	}
+	if m.viewCache.completedStream != "" {
+		t.Fatalf("completed stream survived undo: %q", m.viewCache.completedStream)
 	}
 	if got := m.textarea.Value(); got != "edit this prompt" {
 		t.Fatalf("composer after undo = %q", got)

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -29,6 +29,162 @@ import (
 	"github.com/samsaffron/term-llm/internal/worktree"
 )
 
+func TestAllCommandsIncludesUndoRedo(t *testing.T) {
+	commands := AllCommands()
+	found := map[string]bool{}
+	for _, cmd := range commands {
+		if cmd.Name == "undo" || cmd.Name == "redo" {
+			found[cmd.Name] = true
+			if cmd.Usage != "/"+cmd.Name {
+				t.Fatalf("%s usage = %q", cmd.Name, cmd.Usage)
+			}
+		}
+	}
+	if !found["undo"] || !found["redo"] {
+		t.Fatalf("undo/redo commands missing: %#v", found)
+	}
+}
+
+func TestCmdUndoRedoShrinksRestoresAndManagesComposer(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	sess := &session.Session{ID: session.NewID(), Provider: "mock", Model: "mock", Mode: session.ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	persist := func(msg llm.Message) session.Message {
+		stored := session.NewMessage(sess.ID, msg, -1)
+		if err := store.AddMessage(ctx, sess.ID, stored); err != nil {
+			t.Fatal(err)
+		}
+		return *stored
+	}
+	first := persist(llm.UserText("first"))
+	second := persist(llm.AssistantText("answer"))
+	third := persist(llm.UserText("edit this prompt"))
+	fourth := persist(llm.AssistantText("remove this answer"))
+	m := newCmdTestModel(store)
+	m.sess = sess
+	m.messages = []session.Message{first, second, third, fourth}
+	m.setTextareaValue("/undo")
+
+	result, cmd := m.ExecuteCommand("/undo")
+	m = result.(*Model)
+	if cmd == nil || !m.transcriptMutationInFlight || len(m.messages) != 4 {
+		t.Fatalf("undo must start asynchronously without mutating UI state: cmd=%v inFlight=%v messages=%d", cmd != nil, m.transcriptMutationInFlight, len(m.messages))
+	}
+	result, _ = m.Update(cmd())
+	m = result.(*Model)
+	if len(m.messages) != 2 {
+		t.Fatalf("messages after undo = %d, want 2", len(m.messages))
+	}
+	if got := m.textarea.Value(); got != "edit this prompt" {
+		t.Fatalf("composer after undo = %q", got)
+	}
+	stored, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil || len(stored) != 2 {
+		t.Fatalf("stored transcript after undo len=%d err=%v", len(stored), err)
+	}
+
+	m.setTextareaValue("/redo")
+	result, cmd = m.ExecuteCommand("/redo")
+	m = result.(*Model)
+	if cmd == nil || !m.transcriptMutationInFlight || len(m.messages) != 2 {
+		t.Fatalf("redo must start asynchronously without mutating UI state: cmd=%v inFlight=%v messages=%d", cmd != nil, m.transcriptMutationInFlight, len(m.messages))
+	}
+	result, _ = m.Update(cmd())
+	m = result.(*Model)
+	if len(m.messages) != 4 {
+		t.Fatalf("messages after redo = %d, want 4", len(m.messages))
+	}
+	if got := m.textarea.Value(); got != "" {
+		t.Fatalf("composer after redo = %q, want empty", got)
+	}
+	if m.messages[2].ID != third.ID || m.messages[3].ID != fourth.ID {
+		t.Fatalf("redo did not restore stable IDs: %#v", m.messages)
+	}
+}
+
+func TestCmdUndoRejectsArgumentsAndActiveWork(t *testing.T) {
+	store := &mockStore{}
+	m := newCmdTestModel(store)
+	m.sess = &session.Session{ID: "undo-busy"}
+	m.setTextareaValue("/undo 2")
+	result, _ := m.ExecuteCommand("/undo 2")
+	m = result.(*Model)
+	if m.footerMessage != "Usage: /undo" {
+		t.Fatalf("argument footer = %q", m.footerMessage)
+	}
+
+	m.streaming = true
+	m.setTextareaValue("/undo")
+	result, _ = m.ExecuteCommand("/undo")
+	m = result.(*Model)
+	if !strings.Contains(m.footerMessage, "work is active") {
+		t.Fatalf("busy footer = %q", m.footerMessage)
+	}
+}
+
+type cancellationUndoRedoStore struct {
+	*mockStore
+	started chan struct{}
+}
+
+func (s *cancellationUndoRedoStore) TranscriptMutationState(ctx context.Context, _ string) (session.TranscriptMutationState, error) {
+	close(s.started)
+	<-ctx.Done()
+	return session.TranscriptMutationState{}, ctx.Err()
+}
+
+func (s *cancellationUndoRedoStore) UndoLastUserTurn(context.Context, string, session.TranscriptMutationState) (session.TranscriptMutationResult, error) {
+	panic("unexpected undo after cancelled state lookup")
+}
+
+func (s *cancellationUndoRedoStore) RedoLastUserTurn(context.Context, string, session.TranscriptMutationState) (session.TranscriptMutationResult, error) {
+	panic("unexpected redo after cancelled state lookup")
+}
+
+func TestCmdUndoRunsOffUpdateLoopAndUsesRootCancellation(t *testing.T) {
+	store := &cancellationUndoRedoStore{mockStore: &mockStore{}, started: make(chan struct{})}
+	m := newCmdTestModel(store)
+	m.sess = &session.Session{ID: "async-undo"}
+	rootCtx, cancel := context.WithCancel(context.Background())
+	m.SetRootContext(rootCtx)
+	result, cmd := m.ExecuteCommand("/undo")
+	m = result.(*Model)
+	if cmd == nil || !m.transcriptMutationInFlight {
+		t.Fatal("undo did not return an asynchronous command")
+	}
+	select {
+	case <-store.started:
+		t.Fatal("storage was touched on the Bubble Tea update loop")
+	default:
+	}
+	resultCh := make(chan tea.Msg, 1)
+	go func() { resultCh <- cmd() }()
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("background undo command did not reach storage")
+	}
+	cancel()
+	var msg tea.Msg
+	select {
+	case msg = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("root cancellation did not stop background undo")
+	}
+	result, _ = m.Update(msg)
+	m = result.(*Model)
+	if m.transcriptMutationInFlight || m.footerMessage != "Undo cancelled." {
+		t.Fatalf("cancelled undo state: inFlight=%v footer=%q", m.transcriptMutationInFlight, m.footerMessage)
+	}
+}
+
 func TestAllCommandsIncludesCompact(t *testing.T) {
 	commands := AllCommands()
 	found := false


### PR DESCRIPTION
## What

Add `/undo` and `/redo` to both the TUI and web chat interfaces.

- `/undo` removes the latest real user message and the complete transcript suffix after it
- `/redo` restores that suffix exactly, including stable message IDs, structured parts, response identity, and timestamps
- no confirmation dialog
- restores the undone user text to the composer
- stores a durable per-session redo stack in SQLite so repeated `/undo` and `/redo` work across process restarts and clients
- rejects stale-client mutations with transcript revision and head-row checks
- refuses mutations while a response, compaction, or side question is active
- preserves compaction boundaries and excludes synthetic compaction rows
- resets provider continuation/runtime state after transcript mutation
- adds a reusable accessible web toast system for success and error feedback

Undo changes conversation history only. It does not reverse tool calls, file edits, shell commands, or other external side effects. Attachments remain available through `/redo` but are not reconstructed in the composer; the UI warns when this applies.

## Why

A mistaken prompt should be immediately editable without branching or manually rebuilding conversation context. Redo is included because an unconfirmed undo without recovery is a foot-gun.

## Storage and consistency

- Adds schema migration 44 with a durable per-session LIFO redo stack
- Supports `/undo /undo /redo /redo` in exact reverse order; ordinary transcript writes clear the whole redo stack
- Performs undo/redo in serialized SQLite transactions
- Bumps `transcript_rev` exactly once per successful mutation
- Invalidates redo on ordinary transcript mutation
- Preserves lifetime usage counters while reconciling transcript-derived metadata and the authoritative plan projection
- Clears durable provider continuation state to prevent an undone turn from leaking back through provider-side response chaining

## Verification

Passed with an isolated temporary home:

```sh
go build ./...
go test ./...
go vet ./...
```

Also passed focused race coverage for concurrent undo and optimistic mutation checks.

The implementation received an Opus merge-gate review. Its five P1 findings and eight P2 findings were fixed with regression coverage before the final full test run.
