### PR TITLE
fix: Telegram callback write failures bypass transcript reconciliation

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1103,9 +1103,9 @@ func (m *telegramSessionMgr) runStoreOpWithTimeout(sessionID, op string, fn func
 	}
 }
 
-func (m *telegramSessionMgr) runStoreOpWithoutCancel(ctx context.Context, sessionID, op string, fn func(context.Context) error) {
+func (m *telegramSessionMgr) runStoreOpWithoutCancel(ctx context.Context, sessionID, op string, fn func(context.Context) error) error {
 	if m.store == nil || fn == nil {
-		return
+		return nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -1114,7 +1114,9 @@ func (m *telegramSessionMgr) runStoreOpWithoutCancel(ctx context.Context, sessio
 	defer cancel()
 	if err := fn(storeCtx); err != nil {
 		log.Printf("[telegram] %s failed for %s: %v", op, sessionID, err)
+		return err
 	}
+	return nil
 }
 
 type telegramStoreOp struct {
@@ -1155,7 +1157,9 @@ func (q *telegramStoreOpQueue) run() {
 		if q.isDegraded() {
 			continue
 		}
-		q.mgr.runStoreOpWithoutCancel(op.ctx, q.sessionID, op.op, op.fn)
+		if err := q.mgr.runStoreOpWithoutCancel(op.ctx, q.sessionID, op.op, op.fn); err != nil {
+			q.markDegraded(fmt.Sprintf("%s failed: %v", op.op, err))
+		}
 	}
 }
 

--- a/internal/serve/telegram_queue_test.go
+++ b/internal/serve/telegram_queue_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -97,6 +98,27 @@ func TestTelegramStoreOpQueueCanceledContextDegradesWithoutBlocking(t *testing.T
 	defer drainCancel()
 	if !q.closeAndWait(drainCtx) {
 		t.Fatal("queue did not drain")
+	}
+}
+
+func TestTelegramStoreOpQueueOperationErrorDegrades(t *testing.T) {
+	mgr := &telegramSessionMgr{store: &session.NoopStore{}}
+	q := newTelegramStoreOpQueue(mgr, "session-1")
+	sentinel := errors.New("write failed")
+
+	if !q.enqueue(context.Background(), "failing", func(context.Context) error {
+		return sentinel
+	}) {
+		t.Fatal("enqueue failed")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if !q.closeAndWait(drainCtx) {
+		t.Fatal("queue did not drain")
+	}
+	if !q.isDegraded() {
+		t.Fatal("queue was not marked degraded after operation error")
 	}
 }
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -38,6 +38,37 @@ type carryoverPagingStore struct {
 	rowsLoaded int
 }
 
+type failFirstAssistantAddStore struct {
+	session.Store
+	mu           sync.Mutex
+	addFailures  int
+	replaceCalls int
+}
+
+func (s *failFirstAssistantAddStore) AddMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	s.mu.Lock()
+	if msg != nil && msg.Role == llm.RoleAssistant && s.addFailures == 0 {
+		s.addFailures++
+		s.mu.Unlock()
+		return errors.New("injected callback AddMessage failure")
+	}
+	s.mu.Unlock()
+	return s.Store.AddMessage(ctx, sessionID, msg)
+}
+
+func (s *failFirstAssistantAddStore) ReplaceMessages(ctx context.Context, sessionID string, messages []session.Message) error {
+	s.mu.Lock()
+	s.replaceCalls++
+	s.mu.Unlock()
+	return s.Store.ReplaceMessages(ctx, sessionID, messages)
+}
+
+func (s *failFirstAssistantAddStore) counts() (addFailures, replaceCalls int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.addFailures, s.replaceCalls
+}
+
 func (s *carryoverPagingStore) List(ctx context.Context, opts session.ListOptions) ([]session.SessionSummary, error) {
 	return append([]session.SessionSummary(nil), s.summaries...), nil
 }
@@ -637,6 +668,74 @@ func TestStreamReply_ToolThenText(t *testing.T) {
 	last := bot.lastText()
 	if last != "Result" {
 		t.Errorf("lastText = %q; want %q", last, "Result")
+	}
+}
+
+func TestStreamReply_ReconcilesFailedCallbackPersistence(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telegram-callback-reconcile.db")
+	baseStore, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer baseStore.Close()
+	store := &failFirstAssistantAddStore{Store: baseStore}
+
+	h := testutil.NewEngineHarness()
+	h.AddMockTool("my_tool", "tool output")
+	h.Provider.AddToolCall("id-1", "my_tool", map[string]any{})
+	h.Provider.AddTextResponse("Result")
+
+	mgr := &telegramSessionMgr{
+		sessions:       make(map[int64]*telegramSession),
+		store:          store,
+		tickerInterval: 10 * time.Millisecond,
+		settings: Settings{
+			MaxTurns: 5,
+			Store:    store,
+			NewSession: func(context.Context) (*SessionRuntime, error) {
+				return &SessionRuntime{
+					Engine:       h.Engine,
+					ProviderName: "mock",
+					ModelName:    "test",
+				}, nil
+			},
+		},
+	}
+	sess, err := mgr.getOrCreate(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("getOrCreate failed: %v", err)
+	}
+
+	if err := mgr.streamReply(context.Background(), &fakeBotSender{}, sess, 42, llm.UserText("run tool")); err != nil {
+		t.Fatalf("streamReply returned error: %v", err)
+	}
+
+	addFailures, replaceCalls := store.counts()
+	if addFailures != 1 {
+		t.Fatalf("callback AddMessage failures = %d, want 1", addFailures)
+	}
+	if replaceCalls != 1 {
+		t.Fatalf("ReplaceMessages calls = %d, want 1", replaceCalls)
+	}
+
+	messages, err := baseStore.GetMessages(context.Background(), sess.meta.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	wantRoles := []llm.Role{llm.RoleUser, llm.RoleAssistant, llm.RoleTool, llm.RoleAssistant}
+	if len(messages) != len(wantRoles) {
+		t.Fatalf("persisted message count = %d, want %d; messages=%#v", len(messages), len(wantRoles), messages)
+	}
+	for i, wantRole := range wantRoles {
+		if messages[i].Role != wantRole {
+			t.Fatalf("message %d role = %s, want %s; messages=%#v", i, messages[i].Role, wantRole, messages)
+		}
+	}
+	if messages[0].TextContent != "run tool" {
+		t.Fatalf("persisted user text = %q, want run tool", messages[0].TextContent)
+	}
+	if messages[3].TextContent != "Result" {
+		t.Fatalf("persisted final assistant text = %q, want Result", messages[3].TextContent)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Return callback persistence errors from `runStoreOpWithoutCancel` while preserving its existing logging and timeout behavior.
- Mark the Telegram callback store queue degraded when a queued operation fails, so the existing final `ReplaceMessages(callback_reconcile)` path repairs the complete in-memory transcript.
- Add a queue unit test for operation errors and an integration test that fails the first assistant callback write, then verifies one reconciliation produces the exact user/assistant/tool/assistant transcript without duplicates.

## Why this is high-value

Telegram disables runtime persistence and relies on callback writes for assistant and tool messages. Previously, a transient callback `AddMessage` failure was only logged: the message was already present in the in-memory `produced` transcript, so the fallback did not run, while the queue remained healthy and skipped final reconciliation. That could permanently leave Telegram's durable session behind the answer Sam already received, causing stale context after restart or carryover. Treating any queued write error as degradation activates the already-established transcript repair path with a small behavioral change.

## Validation

- `gofmt -w internal/serve/telegram.go internal/serve/telegram_queue_test.go internal/serve/telegram_test.go`
- `go build ./...`
- `go test ./internal/serve -count=1`
- `go test -race ./internal/serve -run 'TestTelegramStoreOpQueueOperationErrorDegrades|TestStreamReply_ReconcilesFailedCallbackPersistence' -count=1`
- `git diff --check`
- Ran `go test ./...`; all affected/relevant packages passed, but the repository-wide run still reports unrelated environment/baseline failures in two `cmd` skill-discovery tests (the host skill registry shadows test fixtures) and `internal/serveui`'s existing JS line-budget check (`20504` vs `20467`).
