### PR TITLE
fix: Telegram turn-write failures bypass final transcript reconciliation

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -1080,16 +1080,18 @@ func closeTelegramSessionWithTimeout(sess *telegramSession, wait time.Duration) 
 	cleanup()
 }
 
-func (m *telegramSessionMgr) runStoreOp(ctx context.Context, sessionID, op string, fn func(context.Context) error) {
+func (m *telegramSessionMgr) runStoreOp(ctx context.Context, sessionID, op string, fn func(context.Context) error) bool {
 	if m.store == nil || fn == nil {
-		return
+		return false
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := fn(ctx); err != nil {
 		log.Printf("[telegram] %s failed for %s: %v", op, sessionID, err)
+		return false
 	}
+	return true
 }
 
 func (m *telegramSessionMgr) runStoreOpWithTimeout(sessionID, op string, fn func(context.Context) error) {
@@ -1103,9 +1105,9 @@ func (m *telegramSessionMgr) runStoreOpWithTimeout(sessionID, op string, fn func
 	}
 }
 
-func (m *telegramSessionMgr) runStoreOpWithoutCancel(ctx context.Context, sessionID, op string, fn func(context.Context) error) {
+func (m *telegramSessionMgr) runStoreOpWithoutCancel(ctx context.Context, sessionID, op string, fn func(context.Context) error) bool {
 	if m.store == nil || fn == nil {
-		return
+		return false
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -1114,7 +1116,9 @@ func (m *telegramSessionMgr) runStoreOpWithoutCancel(ctx context.Context, sessio
 	defer cancel()
 	if err := fn(storeCtx); err != nil {
 		log.Printf("[telegram] %s failed for %s: %v", op, sessionID, err)
+		return false
 	}
+	return true
 }
 
 type telegramStoreOp struct {
@@ -1155,7 +1159,9 @@ func (q *telegramStoreOpQueue) run() {
 		if q.isDegraded() {
 			continue
 		}
-		q.mgr.runStoreOpWithoutCancel(op.ctx, q.sessionID, op.op, op.fn)
+		if !q.mgr.runStoreOpWithoutCancel(op.ctx, q.sessionID, op.op, op.fn) {
+			q.markDegraded(op.op + " failed")
+		}
 	}
 }
 
@@ -1642,8 +1648,11 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 	}
 
 	// Persist incoming messages before streaming.
+	turnPersistenceDegraded := false
+	includeSystemPromptOnReconcile := sess.systemPromptPersisted
 	if m.store != nil && sess.meta != nil {
 		if m.settings.SystemPrompt != "" && !sess.systemPromptPersisted {
+			includeSystemPromptOnReconcile = true
 			sysMsg := &session.Message{
 				SessionID:   sess.meta.ID,
 				Role:        llm.RoleSystem,
@@ -1652,10 +1661,13 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 				CreatedAt:   time.Now(),
 				Sequence:    -1,
 			}
-			m.runStoreOp(ctx, sess.meta.ID, "AddMessage(system)", func(storeCtx context.Context) error {
+			if m.runStoreOp(ctx, sess.meta.ID, "AddMessage(system)", func(storeCtx context.Context) error {
 				return m.store.AddMessage(storeCtx, sess.meta.ID, sysMsg)
-			})
-			sess.systemPromptPersisted = true
+			}) {
+				sess.systemPromptPersisted = true
+			} else {
+				turnPersistenceDegraded = true
+			}
 		}
 		storeUserMsg := &session.Message{
 			SessionID:   sess.meta.ID,
@@ -1665,9 +1677,11 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 			CreatedAt:   time.Now(),
 			Sequence:    -1,
 		}
-		m.runStoreOp(ctx, sess.meta.ID, "AddMessage(user)", func(storeCtx context.Context) error {
+		if !m.runStoreOp(ctx, sess.meta.ID, "AddMessage(user)", func(storeCtx context.Context) error {
 			return m.store.AddMessage(storeCtx, sess.meta.ID, storeUserMsg)
-		})
+		}) {
+			turnPersistenceDegraded = true
+		}
 		m.runStoreOp(ctx, sess.meta.ID, "IncrementUserTurns", func(storeCtx context.Context) error {
 			return m.store.IncrementUserTurns(storeCtx, sess.meta.ID)
 		})
@@ -2494,9 +2508,11 @@ loop:
 	if len(produced) == 0 && full != "" {
 		if m.store != nil && sess.meta != nil {
 			assistantMsg := session.NewMessage(sess.meta.ID, llm.AssistantText(full), -1)
-			m.runStoreOp(ctx, sess.meta.ID, "AddMessage(assistant_fallback)", func(storeCtx context.Context) error {
+			if !m.runStoreOp(ctx, sess.meta.ID, "AddMessage(assistant_fallback)", func(storeCtx context.Context) error {
 				return m.store.AddMessage(storeCtx, sess.meta.ID, assistantMsg)
-			})
+			}) {
+				turnPersistenceDegraded = true
+			}
 		}
 		newHistory = append(newHistory, llm.AssistantText(full))
 	}
@@ -2508,9 +2524,9 @@ loop:
 		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		callbackStoreQueue.closeAndWait(drainCtx)
 		cancel()
-		if callbackStoreQueue.isDegraded() && m.store != nil && sess.meta != nil {
+		if (turnPersistenceDegraded || callbackStoreQueue.isDegraded()) && m.store != nil && sess.meta != nil {
 			replacementHistory := make([]llm.Message, 0, len(newHistory)+1)
-			if m.settings.SystemPrompt != "" && sess.systemPromptPersisted && !containsSystemMsg(newHistory) {
+			if m.settings.SystemPrompt != "" && includeSystemPromptOnReconcile && !containsSystemMsg(newHistory) {
 				replacementHistory = append(replacementHistory, llm.SystemText(m.settings.SystemPrompt))
 			}
 			start := sess.carryoverMessageCount
@@ -2522,9 +2538,11 @@ loop:
 			for i, msg := range replacementHistory {
 				snapshot = append(snapshot, *session.NewMessage(sess.meta.ID, msg, i))
 			}
-			m.runStoreOpWithoutCancel(ctx, sess.meta.ID, "ReplaceMessages(callback_reconcile)", func(storeCtx context.Context) error {
+			if m.runStoreOpWithoutCancel(ctx, sess.meta.ID, "ReplaceMessages(callback_reconcile)", func(storeCtx context.Context) error {
 				return m.store.ReplaceMessages(storeCtx, sess.meta.ID, snapshot)
-			})
+			}) && includeSystemPromptOnReconcile {
+				sess.systemPromptPersisted = true
+			}
 		}
 	}
 	if m.store != nil && sess.meta != nil {

--- a/internal/serve/telegram_queue_test.go
+++ b/internal/serve/telegram_queue_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -97,6 +98,27 @@ func TestTelegramStoreOpQueueCanceledContextDegradesWithoutBlocking(t *testing.T
 	defer drainCancel()
 	if !q.closeAndWait(drainCtx) {
 		t.Fatal("queue did not drain")
+	}
+}
+
+func TestTelegramStoreOpQueueOperationFailureDegrades(t *testing.T) {
+	mgr := &telegramSessionMgr{store: &session.NoopStore{}}
+	q := newTelegramStoreOpQueue(mgr, "session-1")
+	sentinel := errors.New("write failed")
+
+	if !q.enqueue(context.Background(), "failing", func(context.Context) error {
+		return sentinel
+	}) {
+		t.Fatal("enqueue failed")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if !q.closeAndWait(drainCtx) {
+		t.Fatal("queue did not drain")
+	}
+	if !q.isDegraded() {
+		t.Fatal("queue was not marked degraded after operation failure")
 	}
 }
 

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -59,6 +59,39 @@ func (s *carryoverPagingStore) GetMessagesPageDescending(ctx context.Context, se
 	return page, nil
 }
 
+type failingTelegramTurnStore struct {
+	session.Store
+
+	mu           sync.Mutex
+	failRole     llm.Role
+	failed       bool
+	replaceCalls int
+}
+
+func (s *failingTelegramTurnStore) AddMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	s.mu.Lock()
+	if !s.failed && msg.Role == s.failRole {
+		s.failed = true
+		s.mu.Unlock()
+		return errors.New("injected AddMessage failure")
+	}
+	s.mu.Unlock()
+	return s.Store.AddMessage(ctx, sessionID, msg)
+}
+
+func (s *failingTelegramTurnStore) ReplaceMessages(ctx context.Context, sessionID string, messages []session.Message) error {
+	s.mu.Lock()
+	s.replaceCalls++
+	s.mu.Unlock()
+	return s.Store.ReplaceMessages(ctx, sessionID, messages)
+}
+
+func (s *failingTelegramTurnStore) stats() (failed bool, replaceCalls int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.failed, s.replaceCalls
+}
+
 // fakeBotSender is a botSender that records all Send calls for test assertions.
 type fakeBotSender struct {
 	mu             sync.Mutex
@@ -567,6 +600,82 @@ func TestStreamReply_TextOnly(t *testing.T) {
 	last := bot.lastText()
 	if last != "Hello" {
 		t.Errorf("lastText = %q; want %q", last, "Hello")
+	}
+}
+
+func TestStreamReply_ReconcilesTranscriptAfterTurnWriteFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		failRole llm.Role
+	}{
+		{name: "direct user write", failRole: llm.RoleUser},
+		{name: "queued callback write", failRole: llm.RoleAssistant},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := testutil.NewEngineHarness()
+			h.AddMockTool("my_tool", "tool output")
+			h.Provider.AddToolCall("id-1", "my_tool", map[string]any{})
+			h.Provider.AddTextResponse("Result")
+
+			baseStore, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "telegram.db")})
+			if err != nil {
+				t.Fatalf("create store: %v", err)
+			}
+			store := &failingTelegramTurnStore{Store: baseStore, failRole: tc.failRole}
+			defer store.Close()
+
+			mgr := &telegramSessionMgr{
+				sessions:       make(map[int64]*telegramSession),
+				store:          store,
+				tickerInterval: 10 * time.Millisecond,
+				settings: Settings{
+					MaxTurns:     5,
+					Store:        store,
+					SystemPrompt: "be helpful",
+					NewSession: func(context.Context) (*SessionRuntime, error) {
+						return &SessionRuntime{
+							Engine:       h.Engine,
+							ProviderName: "mock",
+							ModelName:    "test",
+						}, nil
+					},
+				},
+			}
+			ctx := context.Background()
+			sess, err := mgr.getOrCreate(ctx, 42)
+			if err != nil {
+				t.Fatalf("getOrCreate failed: %v", err)
+			}
+
+			if err := mgr.streamReply(ctx, &fakeBotSender{}, sess, 42, llm.UserText("run tool")); err != nil {
+				t.Fatalf("streamReply returned error: %v", err)
+			}
+
+			failed, replaceCalls := store.stats()
+			if !failed {
+				t.Fatalf("expected injected %s AddMessage failure", tc.failRole)
+			}
+			if replaceCalls != 1 {
+				t.Fatalf("ReplaceMessages calls = %d, want 1", replaceCalls)
+			}
+
+			msgs, err := store.GetMessages(ctx, sess.meta.ID, 0, 0)
+			if err != nil {
+				t.Fatalf("GetMessages failed: %v", err)
+			}
+			wantRoles := []llm.Role{llm.RoleSystem, llm.RoleUser, llm.RoleAssistant, llm.RoleTool, llm.RoleAssistant}
+			if len(msgs) != len(wantRoles) {
+				t.Fatalf("persisted message count = %d, want %d: %#v", len(msgs), len(wantRoles), msgs)
+			}
+			for i, wantRole := range wantRoles {
+				if msgs[i].Role != wantRole {
+					t.Fatalf("message %d role = %s, want %s: %#v", i, msgs[i].Role, wantRole, msgs)
+				}
+			}
+			if msgs[0].TextContent != "be helpful" || msgs[1].TextContent != "run tool" || msgs[4].TextContent != "Result" {
+				t.Fatalf("reconciled transcript text mismatch: %#v", msgs)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

- Made Telegram store helpers report whether writes succeeded.
- Marked a turn persistence-degraded when direct system/user/fallback transcript writes fail.
- Marked the callback persistence queue degraded when an enqueued operation executes but returns an error.
- Reused the existing final `ReplaceMessages` path whenever either direct or queued persistence degraded, including recovery of a failed first system-prompt write.
- Added focused coverage for direct user-write failure, queued assistant-write failure, complete exactly-once system/user/assistant/tool reconciliation, and queue degradation after an operation error.

## Why this is high-value

Telegram intentionally disables the shared runner's runtime persistence and relies on these per-turn writes. Previously, a transient direct or callback write failure was only logged, so a successful response could be delivered while durable history silently omitted the request, answer, system prompt, or tool context. That stale transcript would then be reused after restart or session carryover. The in-memory turn already contains the complete transcript, so final replacement is a narrow, safe repair.

## Validation

- `go build ./...`
- `go test ./internal/serve -run 'TestTelegramStoreOpQueue|TestStreamReply_ReconcilesTranscriptAfterTurnWriteFailure' -count=1`
- `go test -race ./internal/serve -run 'TestTelegramStoreOpQueue|TestStreamReply_ReconcilesTranscriptAfterTurnWriteFailure' -count=1`
- `go test ./...` (all Go packages pass except the unrelated existing `internal/serveui` source-size ratchet: 20,504 legacy JS lines versus its 20,467 threshold; this PR does not touch JS)
- `git diff --check`
