### PR TITLE
fix(webui): stop rewrapping null body status responses (Firefox 'Connection unstable')

### DIFF
--- a/internal/serveui/static/app-network.js
+++ b/internal/serveui/static/app-network.js
@@ -187,8 +187,16 @@ const composeAbortSignal = (parentSignal, timeoutMs) => {
   return { signal: controller.signal, timedOut: () => timeout, cleanup };
 };
 
+// Per the Fetch spec, a response carrying a null body status must never be
+// rebuilt with a body: `new Response(body, { status: 304 })` throws a
+// TypeError. Chromium reports `response.body === null` for these, so the body
+// check alone happens to work there, but Firefox exposes a non-null empty
+// stream. The UI polls an ETagged endpoint that legitimately answers 304, so on
+// Firefox every poll threw and drove connectivity to 'unstable' forever.
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 const responseWithAbortLifetime = (response, cleanup) => {
-  if (!response.body) {
+  if (!response.body || NULL_BODY_STATUSES.has(response.status)) {
     cleanup();
     return response;
   }

--- a/internal/serveui/static/app_network_test.js
+++ b/internal/serveui/static/app_network_test.js
@@ -386,7 +386,45 @@ async function testStreamRecoveryHasNoPostWakeHotSpin() {
   console.log('PASS: stream wake race is direct and later retries retain their real backoff');
 }
 
+async function testNullBodyStatusIsNotRewrapped() {
+  // Firefox exposes a non-null empty body stream for null body statuses, unlike
+  // Chromium which reports null. Rewrapping such a response throws
+  // "Response body is given with a null body status", which used to surface as
+  // a permanent 'unstable' badge because the UI polls an ETagged endpoint that
+  // legitimately answers 304 every few seconds.
+  for (const status of [204, 205, 304]) {
+    const harness = createHarness(async () => ({
+      status,
+      statusText: '',
+      headers: new Headers(),
+      body: new ReadableStream({ start(controller) { controller.close(); } }),
+      url: '/ui/v1/sessions/status',
+      redirected: false,
+      type: 'basic',
+    }));
+
+    // retries: 0 keeps this deterministic. With retries the rewrap failure parks
+    // on the harness' fake timer, the promise never settles and node exits 0
+    // silently — a green test on broken code.
+    let thrown = null;
+    let response = null;
+    try {
+      response = await harness.app.apiFetch('/ui/v1/sessions/status', {}, { retries: 0 });
+    } catch (error) {
+      thrown = error;
+    }
+    assert(!thrown, `status ${status} threw instead of passing through: ${thrown && thrown.message}`);
+    assert(response.status === status, `status ${status} was not passed through untouched`);
+    assert(harness.state.connectivity.phase !== 'unstable', `status ${status} drove connectivity to unstable`);
+    assert(Number(harness.state.connectivity.consecutiveFailures || 0) === 0, `status ${status} recorded a spurious failure`);
+    const errors = harness.app.networkDiagnostics.filter((entry) => entry.kind === 'network-error');
+    assert(errors.length === 0, `status ${status} logged a network error: ${JSON.stringify(errors[0] || {})}`);
+  }
+  console.log('PASS: null body statuses (204/205/304) pass through without rewrapping or false connectivity failures');
+}
+
 (async () => {
+  await testNullBodyStatusIsNotRewrapped();
   await testClassificationAndRetryAfter();
   await testRetryPolicies();
   await testTimeoutAuthAbortAndDiagnostics();


### PR DESCRIPTION
## Problem

On Firefox the web UI shows a permanent **"Connection unstable"** badge. It clears
whenever any request succeeds and returns a few seconds later, so it reads as a
flapping network. The network is fine — it is a client-side bug.

The connectivity diagnostics ring shows the same failure repeating every ~7s:

```
network-error | GET | safe-read | TypeError |
Response constructor: Response body is given with a null body status. |
/chat/v1/sessions/status
```

with `consecutiveFailures` climbing (25 observed).

## Root cause

1. The UI polls `GET {base}/v1/sessions/status` every few seconds.
2. That endpoint sends `ETag` + `Cache-Control: no-cache`, so the browser
   revalidates with `If-None-Match`.
3. The server correctly answers **`304 Not Modified`** with no body.
4. The poll is a timed request, so it goes through `responseWithAbortLifetime`,
   which rebuilds the response in order to disarm the timeout when the body ends.
5. The guard is `if (!response.body)`. Chromium reports `response.body === null`
   for null body statuses, so the guard holds there. **Firefox exposes a non-null
   empty `ReadableStream`**, so the guard is bypassed.
6. `new Response(body, { status: 304 })` is forbidden by the Fetch spec
   ([null body status](https://fetch.spec.whatwg.org/#null-body-status)) and throws.
7. The throw lands in the network error path, which sets
   `phase: 'unstable'` — permanently, since the next poll fails identically.

Verified against the server:

```
$ curl -sI -H "If-None-Match: \"d3badc29f74a9fd4\"" .../v1/sessions/status
HTTP/1.1 304 Not Modified
```

## Fix

Skip the rewrap for null body statuses. There is no body to track, so the
timeout can be cleaned up immediately — which is exactly what the existing
`!response.body` branch already does.

```js
const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);

const responseWithAbortLifetime = (response, cleanup) => {
  if (!response.body || NULL_BODY_STATUSES.has(response.status)) {
    cleanup();
    return response;
  }
```

## Test

Adds `testNullBodyStatusIsNotRewrapped` covering 204/205/304 with a Firefox-like
response (non-null empty body stream). Verified red before the fix
(exit 1) and green after.

The test deliberately passes `retries: 0`. With retries enabled, the rewrap
failure parks on the harness' fake timer, the promise never settles, and node
exits 0 with no output — i.e. a green test on broken code. Worth knowing for
future tests in this harness.

`internal/serveui/static/app-network.js` is now 572 lines, within its 600-line
budget.

## Note

`TestConversationLifecycleSizeAndPurityBudgets` fails on current `main`
(`legacy first-party production JS=20504 lines, must decrease from 20467`),
identically with and without this change. `app-network.js` is excluded from that
counter, so this PR does not affect it. `TestAppNetworkJS` and
`TestApplicationFetchesUseSharedNetworkLayer` pass.
