### PR TITLE
perf(web): trim unused app dependencies

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -956,14 +956,6 @@ func TestStaticAssetsSupportTurnCopyActionPanel(t *testing.T) {
 		}
 	}
 
-	streamJS, err := StaticAsset("app-stream.js")
-	if err != nil {
-		t.Fatalf("StaticAsset(app-stream.js): %v", err)
-	}
-	if !strings.Contains(string(streamJS), "syncTurnActionPanels") {
-		t.Fatal("app-stream.js missing syncTurnActionPanels integration")
-	}
-
 	css, err := StaticAsset("app.css")
 	if err != nil {
 		t.Fatalf("StaticAsset(app.css): %v", err)

--- a/internal/serveui/static/app-composer.js
+++ b/internal/serveui/static/app-composer.js
@@ -4,15 +4,7 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  UI_PREFIX, state, elements, applyTextDirection
 } = app;
 const { normalizeError } = app;
 

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -1237,12 +1237,6 @@ const fmtTokens = (n) => {
   return m < 10 ? `${m.toFixed(1)}M` : `${Math.round(m)}M`;
 };
 
-const escapeHTML = (str) => {
-  const div = document.createElement('div');
-  div.textContent = str;
-  return div.innerHTML;
-};
-
 const KNOWN_EFFORT_SUFFIXES = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
 const HEADER_EFFORT_LEVELS = new Set([...KNOWN_EFFORT_SUFFIXES, 'auto']);
 

--- a/internal/serveui/static/app-goals-location.js
+++ b/internal/serveui/static/app-goals-location.js
@@ -4,20 +4,7 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-  splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-  openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-  clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-  updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-  trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-  restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
+  UI_PREFIX, elements, saveSessions, ensureActiveSession, renderSidebar, autoGrowPrompt
 } = app;
 
 const openGoalModal = () => {

--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -4,17 +4,12 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  UI_PREFIX, state, elements, INTERJECTION_PHASE, saveSessions, persistAndRefreshShell, conversationDOMFor,
+  cloneAttachmentForMessage
 } = app;
-const { requestHeaders, normalizeError, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, scrollVisibleStreamToBottom, sendMessage } = app;
+const {
+  requestHeaders, normalizeError, isSessionVisible, sendMessage
+} = app;
 
 const queueInterruptFollowUp = (sessionId, prompt, messageId, attachments = []) => {
   const normalizedSessionId = String(sessionId || '').trim();

--- a/internal/serveui/static/app-mcp.js
+++ b/internal/serveui/static/app-mcp.js
@@ -4,20 +4,9 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-  splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-  openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-  clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-  updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-  trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-  restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
+  UI_PREFIX, state, elements, saveSessions, getActiveSession, createSession, ensureActiveSession, sessionSlug,
+  updateURL, persistAndRefreshShell, updateMCPStatusDisplay, setElementHidden, handleAuthFailure, renderMessages,
+  requestHeaders, normalizeError, sessionHasInProgressState
 } = app;
 
 const normalizeMCPServerView = (server) => {

--- a/internal/serveui/static/app-message-convert.js
+++ b/internal/serveui/static/app-message-convert.js
@@ -2,20 +2,7 @@
 (function initMessageConvert() {
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-  splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-  openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-  clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-  updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-  trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-  restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
+  generateId
 } = app;
 const rebaseMessageAssetURL = (url) => typeof app.rebaseHubAssetURL === 'function' ? app.rebaseHubAssetURL(url) : String(url || '').trim();
 // ===== Server session helpers =====

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -3,9 +3,9 @@
 
 const app = window.TermLLMApp;
 const {
-  STORAGE_KEYS, state, elements, INTERRUPT_BADGE_META, sanitizeInterruptState, asTimestamp, relativeTime, fullDate, sessionBucket, toolIcon, formatUsage,
-  saveSessions, findMessageElement, mountedConversationSessionId, isConversationMounted, conversationDOMFor,
-  scrollToBottom, refreshRelativeTimes, ensureActiveSession, updateDocumentTitle,
+  STORAGE_KEYS, state, elements, INTERRUPT_BADGE_META, sanitizeInterruptState, asTimestamp, relativeTime, fullDate,
+  sessionBucket, toolIcon, formatUsage, saveSessions, findMessageElement, mountedConversationSessionId,
+  conversationDOMFor, scrollToBottom, refreshRelativeTimes, ensureActiveSession, updateDocumentTitle,
   updateSessionUsageDisplay, renderMath, visibleSessions, sessionHasInProgressState, setSessionServerActiveRun,
   setAnimatedPanelOpen, initPanelSwipeToClose
 } = app;

--- a/internal/serveui/static/app-response-effects.js
+++ b/internal/serveui/static/app-response-effects.js
@@ -5,15 +5,8 @@
 const app = window.TermLLMApp;
 const ConversationController = window.TermLLMConversation?.ConversationController;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  state, saveSessions, setProviderRetryStatus, updateSessionUsageDisplay, renderSidebar, renderMessages,
+  maybeNotifyResponseComplete, setSessionOptimisticBusy, setSessionServerActiveRun
 } = app;
 const { rebaseStreamAssetURL, forceSidebarStatusRefreshSoon, normalizeEffortForCompare, clearSessionPendingEffort, clearTerminalPendingEffort, classifyRecoverableContinuationFailure, setActiveResponseTracking, scheduleStreamPersistence, flushStreamPersistence, clearActiveResponseTracking, isSessionVisible, updateVisibleToolGroupNode, enqueueVisibleAssistantStreamUpdate, finalizeVisibleAssistantStreamRender, scrollVisibleStreamToBottom, scheduleVisibleStreamScroll, responseStreamOwnerId, clearProviderRetryForEvent, applyResponseRecoverySnapshot, addErrorMessage } = app;
 

--- a/internal/serveui/static/app-runtime.js
+++ b/internal/serveui/static/app-runtime.js
@@ -4,15 +4,8 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  UI_PREFIX, STORAGE_KEYS, state, elements, getActiveSession, updateSessionUsageDisplay, splitHeaderModelEffort,
+  compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider
 } = app;
 const { requestHeaders, normalizeError, effectiveEffortForCompare, sessionHasQueueableActiveRun, setSessionPendingEffort, clearSessionPendingEffort, markRuntimeSelectionIntent, addErrorMessage } = app;
 

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -4,15 +4,10 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, saveSessions, getActiveSession, createSession,
+  setConnectionState, sessionSlug, updateURL, persistAndRefreshShell, refreshRelativeTimes, renderMessages,
+  syncTurnActionPanels, setSessionOptimisticBusy, renderAttachments, buildAttachmentInputParts,
+  cloneAttachmentForMessage
 } = app;
 const DRAFT_MESSAGE_LIMIT = 10;
 const draftMessagesStorageKey = () => STORAGE_KEYS.draftMessages || 'term_llm_draft_messages';
@@ -99,7 +94,15 @@ const restoreLatestDraftMessage = () => {
   return restoreDraftMessageForSession(state.activeSessionId);
 };
 
-const { requestHeaders, normalizeError, hasSessionContinuationContext, effectiveEffortForCompare, clearRuntimeSelectionIntent, classifyRecoverableContinuationFailure, sleep, streamReconnectDelay, streamReconnectLabel, isTransientPreResponsePostError, setActiveResponseTracking, HEARTBEAT_STALE_THRESHOLD, heartbeatUploadGraceThreshold, attachResponseStream, detachResponseStream, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, finalizeVisibleAssistantStreamRender, scrollVisibleStreamToBottom, createResponseStreamState, consumeResponseStream, resumeActiveResponse, setStreaming, recoverInterruptFailure, addErrorMessage, waitForNetworkRetry } = app;
+const {
+  requestHeaders, normalizeError, hasSessionContinuationContext, effectiveEffortForCompare,
+  clearRuntimeSelectionIntent, classifyRecoverableContinuationFailure, streamReconnectDelay, streamReconnectLabel,
+  isTransientPreResponsePostError, setActiveResponseTracking, HEARTBEAT_STALE_THRESHOLD,
+  heartbeatUploadGraceThreshold, attachResponseStream, detachResponseStream, isSessionVisible,
+  appendStreamMessageNode, updateVisibleUserNode, finalizeVisibleAssistantStreamRender, scrollVisibleStreamToBottom,
+  createResponseStreamState, consumeResponseStream, resumeActiveResponse, setStreaming, recoverInterruptFailure,
+  addErrorMessage, waitForNetworkRetry
+} = app;
 
 const restoreQueuedFollowUps = (entries, sessionId) => {
   for (const entry of entries) {

--- a/internal/serveui/static/app-session-admin.js
+++ b/internal/serveui/static/app-session-admin.js
@@ -4,20 +4,8 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-  splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-  openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-  clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-  updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-  trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-  restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
+  UI_PREFIX, state, elements, persistAndRefreshShell, handleAuthFailure, renderSidebar, closeSidebar, requestHeaders,
+  normalizeError
 } = app;
 
 const updateSessionMetadata = async (session, patch) => {

--- a/internal/serveui/static/app-session-events.js
+++ b/internal/serveui/static/app-session-events.js
@@ -4,20 +4,11 @@
 
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-  splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-  openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-  clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-  updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-  trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-  restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
+  state, elements, getActiveSession, sessionIdFromURL, findSessionBySlug, openAuthModal, closeAuthModal,
+  handleAuthFailure, setStreaming, autoGrowPrompt, toggleVoiceRecording, sendMessage, openSidebar, closeSidebar,
+  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent,
+  noteScrollPositionChanged, shouldDisableAutoScrollForKey, submitApprovalModal, requestNotificationPermission,
+  HEARTBEAT_STALE_THRESHOLD, applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence
 } = app;
 
 // ===== Event listeners =====

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -4,29 +4,21 @@
 const app = window.TermLLMApp;
 const ConversationController = window.TermLLMConversation?.ConversationController;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-  sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-  splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-  openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-  clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-  autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-  connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-  openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-  requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-  applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-  updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-  moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-  trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-  restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
+  UI_PREFIX, STORAGE_KEYS, state, elements, asTimestamp, loadSessions, saveSessions, getActiveSession,
+  ensureActiveSession, sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL,
+  updateDocumentTitle, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus,
+  persistAndRefreshShell, refreshRelativeTimes, splitHeaderModelEffort, handleAuthFailure, closeAskUserModal,
+  openAskUserModal, setActiveResponseTracking, clearActiveResponseTracking, setStreaming, resumeActiveResponse,
+  renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
+  autoGrowPrompt, updateVoiceUI, fetchProviders, fetchModels, closeSidebar, closeSidebarIfMobile, openApprovalModal,
+  closeApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI, shouldAutoSubscribeToPush,
+  detachResponseStream, requestHeaders, discardPendingAttachments, sessionHasInProgressState,
+  setSessionServerActiveRun, setSessionOptimisticBusy, moveSessionProgressState, drainInterruptQueueIfIdle,
+  requeuePendingInterjections, trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit,
+  refreshPendingInterjectionBanner, restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
 } = app;
 let sessionStatePollTimer = null;
 const SESSION_STATE_POLL_RETRY = 5000;
-
-const rebaseSessionAssetURL = (url) => (
-  typeof app.rebaseHubAssetURL === 'function'
-    ? app.rebaseHubAssetURL(url)
-    : String(url || '').trim()
-);
 
 const resumeAndDrain = (session, options) => {
   void resumeActiveResponse(session, options).catch(async () => {
@@ -355,24 +347,9 @@ const switchToSession = async (sessionId, options = {}) => {
 
 
 const {
-  findSessionById,
-  ensureSessionTranscript,
-  trackPendingIntent,
-  retirePendingIntent,
-  noteTranscriptRunCreated,
-  noteTranscriptTerminal,
-  refreshSessionMessagesFromTranscript,
-  touchTranscriptSkeleton,
-  transcriptSyncSegmentIndexes,
-  materializeTranscriptSegments,
-  syncTranscript,
-  loadServerSessionMessages,
-  refreshActiveSessionMessagesFromServer,
-  loadOlderSessionMessages,
-  maybeLoadOlderSessionMessages,
-  SESSION_STATE_RETRY_RESULT,
-  loadServerSessionState,
-  reconcileTranscriptFromStatus
+  findSessionById, ensureSessionTranscript, refreshSessionMessagesFromTranscript, touchTranscriptSkeleton,
+  transcriptSyncSegmentIndexes, syncTranscript, loadServerSessionMessages, refreshActiveSessionMessagesFromServer,
+  SESSION_STATE_RETRY_RESULT, loadServerSessionState
 } = app;
 
 const stopSessionStatePoll = () => {

--- a/internal/serveui/static/app-skills.js
+++ b/internal/serveui/static/app-skills.js
@@ -2,17 +2,14 @@
 (function initAppSkills() {
 const app = window.TermLLMApp;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  UI_PREFIX, state, elements, generateId, truncate, saveSessions, persistAndRefreshShell, renderMessages,
+  setSessionOptimisticBusy
 } = app;
-const { requestHeaders, normalizeError, parseSSEStream, sleep, streamReconnectDelay, setActiveResponseTracking, isSessionVisible, appendStreamMessageNode, updateVisibleUserNode, scrollVisibleStreamToBottom, resumeActiveResponse, setStreaming, drainInterruptQueueIfIdle, addErrorMessage, createResumableStreamRecovery } = app;
+const {
+  requestHeaders, normalizeError, parseSSEStream, setActiveResponseTracking, isSessionVisible,
+  appendStreamMessageNode, updateVisibleUserNode, scrollVisibleStreamToBottom, resumeActiveResponse, setStreaming,
+  drainInterruptQueueIfIdle, addErrorMessage, createResumableStreamRecovery
+} = app;
 const skillRunStore = () => {
   if (!state.skillRunsById || typeof state.skillRunsById !== 'object') {
     state.skillRunsById = {};

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -4,15 +4,13 @@
 const app = window.TermLLMApp;
 const ConversationController = window.TermLLMConversation?.ConversationController;
 const {
-  UI_PREFIX, STORAGE_KEYS, state, elements, generateId, sanitizeInterruptState, INTERJECTION_PHASE, sanitizeMessage, syncTokenCookie, truncate, saveSessions,
-  getActiveSession, createSession, scrollToBottom, setConnectionState, setProviderRetryStatus, clearProviderRetryStatus, sessionSlug, updateURL,
-  persistAndRefreshShell, updateSessionUsageDisplay, splitHeaderModelEffort, compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider, refreshRelativeTimes, requestHeaders: _unusedRequestHeaders, updateUserNode,
-  updateToolNode, updateToolGroupNode, createMessageNode, createToolGroupNode, updateModelSwapNode, renderSidebar, renderMessages, maybeNotifyResponseComplete,
-  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, syncTurnActionPanels,
-  updateMountedToolGroupNode, updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate, finalizeMountedAssistantStreamRender,
-  conversationDOMFor, isConversationMounted,
-  subscribeToPush, shouldAutoSubscribeToPush, applyTextDirection, shouldSuppressPromptAutoFocus, setSessionOptimisticBusy, setSessionServerActiveRun,
-  renderAttachments, buildAttachmentInputParts, cloneAttachmentForMessage
+  UI_PREFIX, state, elements, generateId, sanitizeMessage, saveSessions, getActiveSession, scrollToBottom,
+  setConnectionState, clearProviderRetryStatus, persistAndRefreshShell, updateSessionUsageDisplay, updateUserNode,
+  updateToolGroupNode, createMessageNode, updateModelSwapNode, renderSidebar, renderMessages,
+  insertMountedMessageNode, enqueueAssistantStreamUpdate, finalizeAssistantStreamRender, updateMountedToolGroupNode,
+  updateMountedModelSwapNode, updateMountedUserNode, enqueueMountedAssistantStreamUpdate,
+  finalizeMountedAssistantStreamRender, conversationDOMFor, isConversationMounted, shouldSuppressPromptAutoFocus,
+  setSessionOptimisticBusy, setSessionServerActiveRun
 } = app;
 
 const rebaseStreamAssetURL = (url) => (
@@ -521,14 +519,6 @@ const updateVisibleToolGroupNode = (session, message) => {
     updateMountedToolGroupNode(session, message);
   } else if (isSessionVisible(session)) {
     updateToolGroupNode(message);
-  }
-};
-
-const updateVisibleModelSwapNode = (session, message) => {
-  if (typeof updateMountedModelSwapNode === 'function') {
-    updateMountedModelSwapNode(session, message);
-  } else if (isSessionVisible(session)) {
-    updateModelSwapNode(message);
   }
 };
 

--- a/internal/serveui/static/conversation.js
+++ b/internal/serveui/static/conversation.js
@@ -482,21 +482,9 @@
     const app = window.TermLLMApp;
     const ConversationController = window.TermLLMConversation?.ConversationController;
     const {
-      UI_PREFIX, STORAGE_KEYS, state, elements, generateId, truncate, asTimestamp, loadSessions, saveSessions, getActiveSession, createSession, ensureActiveSession,
-      sessionIdFromURL, isSessionIdentityResolved, sessionSlug, findSessionBySlug, updateURL, updateDocumentTitle, scrollToBottom, setConnectionState, setStartupStatus, hideStartupSplash, clearProviderRetryStatus, persistAndRefreshShell, refreshRelativeTimes,
-      splitHeaderModelEffort, updateMCPStatusDisplay, setElementHidden,
-      openAuthModal, closeAuthModal, handleAuthFailure, closeAskUserModal, openAskUserModal, setActiveResponseTracking,
-      clearActiveResponseTracking, setStreaming, resumeActiveResponse, renderSidebar, renderMessages, renderProviderOptions, renderModelOptions, normalizeSelectedProvider,
-      autoGrowPrompt, updateVoiceUI, toggleVoiceRecording, fetchProviders, fetchModels, addErrorMessage, sendMessage, openSidebar, closeSidebar, closeSidebarIfMobile,
-      connectToken, submitAskUserModal, cancelActiveResponse, handleFiles, noteUserScrollIntent, noteScrollPositionChanged, shouldDisableAutoScrollForKey,
-      openApprovalModal, closeApprovalModal, submitApprovalModal, registerServiceWorker, subscribeToPush, refreshNotificationUI,
-      requestNotificationPermission, shouldAutoSubscribeToPush, detachResponseStream, HEARTBEAT_STALE_THRESHOLD,
-      applyDesktopSidebarState, toggleSidebarCollapsed, flushStreamPersistence, requestHeaders, normalizeError, discardPendingAttachments,
-      updateSidebarStatus, sessionHasInProgressState, hasAnySessionInProgressState, setSessionServerActiveRun, setSessionOptimisticBusy,
-      moveSessionProgressState, requeueUncommittedInterrupts, drainInterruptQueueIfIdle, requeuePendingInterjections,
-      trackPendingInterjection, removePendingInterjectionById, trackPendingInterruptCommit, refreshPendingInterjectionBanner,
-      restoreDraftMessageForSession, stageDraftMessage, clearDraftMessageForSession
-    } = app;
+  UI_PREFIX, state, elements, getActiveSession, isSessionIdentityResolved, handleAuthFailure, renderMessages,
+  requestHeaders
+} = app;
     const TRANSCRIPT_RECENT_SKELETONS = [];
     const PENDING_INTENT_LIMIT = 256;
     const TRANSCRIPT_EMPTY_BODY_FLAG = Number(window.TRANSCRIPT_FLAG_EMPTY_BODY || 2);


### PR DESCRIPTION
## What

- trim 823 unused `TermLLMApp` destructured bindings across 15 production scripts
- remove three unreferenced helpers: `escapeHTML`, `rebaseSessionAssetURL`, and `updateVisibleModelSwapNode`
- remove a stale test assertion that treated an unused `syncTurnActionPanels` binding as stream integration; the actual render-side behavior remains covered

## Size

Measured over the same set of first-party production JavaScript assets before and after this commit:

| Metric | Before | After | Reduction |
|---|---:|---:|---:|
| Raw JS | 862,798 B | 844,146 B | 18,652 B (2.16%) |
| Per-file gzip -9 | 215,761 B | 208,386 B | 7,375 B (3.42%) |

Vendor assets, CSS, HTML, and images are excluded so the comparison only measures the JavaScript changed here.

## Verification

- `node --check` on every production JS asset
- `go test ./internal/serveui`
- `go build ./...`
- `git diff --check`

`go test ./...` reaches the full suite but this machine's mounted user skills cause two unrelated `cmd` skill-discovery tests to fail: the injected skills consume the tests' configured visibility budget before their temporary fixture skill is selected. All other packages, including `internal/serveui`, pass.
