### PR TITLE
feat: add Claude-style @ file autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ term-llm ask --provider zen "explain git rebase"
 term-llm chat
 ```
 
+### Project `@` mentions
+
+In chat, type `@` to fuzzy-find files and directories under the active project/worktree; the picker keeps Git ignore behavior, and Enter or Tab inserts ordinary text (`@path`, `@"path with spaces"`, or `@directory/`). Manually typed valid mentions work identically. Set `TERM_LLM_AT_MENTIONS=0` to disable the picker.
+
+Mentions are parsed only when the prompt is submitted, at the start of text or after whitespace, `。`, `、`, `？`, or `！`; these punctuation characters start mentions but do not terminate an unquoted path. The visible user text is not rewritten, duplicate references remain visible, and identical raw mention payloads attach once. Textually different references to the same path (for example, `@a` and `@./a`) remain distinct, matching Claude Code, and quoted matches attach before unquoted matches. `#L10` and `#L10-20` select lines. Resolution is confined to the active project/CWD, follows existing non-interactive read policy, never opens approval UI, and never grants read or write access. Missing, denied, escaped, binary, oversized, or otherwise failed resources remain textual references and do not block sending.
+
+Submit-time limits closely follow Claude Code 2.1.220:
+
+- Non-PDF text files are eligible only when their **total** size is at most 256 KiB; a line range does not bypass this gate.
+- Attached content is capped at 25,000 estimated tokens. On overflow, term-llm retries 2,000 lines from line 1 or the requested starting line; if that still exceeds the ceiling, nothing is attached. Unlike Claude Code's API-assisted exact count, term-llm deliberately uses its local four-bytes-per-token estimate, avoiding an API round trip.
+- Directories attach a live, non-recursive, names-only listing with at most 1,000 names and an `… and N more entries` marker.
+- Mentioned PDFs and images remain textual references. Term-llm supports images and some provider-native file uploads through its existing explicit attachment paths, but it has no reliable in-process PDF page-count primitive for Claude's ≤10-page inline / >10-page reference split. `/file` and clipboard/image attachment behavior is unchanged.
+
 If you already have a provider key:
 
 ```bash

--- a/internal/mentions/attachments.go
+++ b/internal/mentions/attachments.go
@@ -1,0 +1,326 @@
+package mentions
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+const (
+	// MaxEagerFileBytes matches Claude Code's total-file-size gate.
+	MaxEagerFileBytes int64 = 256 << 10
+	// MaxEagerContentTokens is applied with term-llm's local four-bytes-per-token estimate.
+	MaxEagerContentTokens = 25_000
+	// MaxEagerFallbackLines is retried from the requested line when content exceeds the token ceiling.
+	MaxEagerFallbackLines = 2_000
+	// MaxEagerDirectoryEntries bounds the names retained from a non-recursive directory listing.
+	MaxEagerDirectoryEntries = 1_000
+)
+
+var imageExtensions = map[string]struct{}{
+	".avif": {}, ".bmp": {}, ".gif": {}, ".heic": {}, ".ico": {}, ".jfif": {},
+	".jpeg": {}, ".jpg": {}, ".png": {}, ".svg": {}, ".tif": {}, ".tiff": {}, ".webp": {},
+}
+
+type eagerLoadOptions struct {
+	openFile   func(secureMentionRoot, string) (*os.File, error)
+	beforeOpen func(string)
+}
+
+// LoadEagerAttachments resolves ordinary textual mentions under root at submit
+// time. Omitted, denied, oversized, binary, and failed resources are silently
+// skipped so the unchanged textual references still reach the model. allowed,
+// when non-nil, must make a non-interactive read-policy decision and must not
+// grant permissions.
+func LoadEagerAttachments(ctx context.Context, root, text string, allowed func(string) bool) []EagerAttachment {
+	return loadEagerAttachments(ctx, root, text, allowed, eagerLoadOptions{})
+}
+
+func loadEagerAttachments(ctx context.Context, root, text string, allowed func(string) bool, opts eagerLoadOptions) []EagerAttachment {
+	root, err := canonicalRoot(root)
+	if err != nil {
+		return nil
+	}
+	secureRoot, err := openSecureMentionRoot(root)
+	if err != nil {
+		return nil
+	}
+	defer secureRoot.Close()
+	if opts.openFile == nil {
+		opts.openFile = func(root secureMentionRoot, name string) (*os.File, error) {
+			return root.Open(name)
+		}
+	}
+
+	var attachments []EagerAttachment
+	for _, mention := range ParseSubmitted(text) {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		resolved, display, err := resolveMentionPath(root, mention.Path)
+		if err != nil {
+			continue
+		}
+		relative := filepath.FromSlash(display)
+
+		// Stat through the retained root descriptor before policy evaluation,
+		// then require the opened descriptor to name that same object. This binds
+		// approval and reading across final- and parent-component replacement.
+		expected, err := secureRoot.Stat(relative)
+		if err != nil {
+			continue
+		}
+		if !expected.IsDir() && (!expected.Mode().IsRegular() || expected.Size() > MaxEagerFileBytes || isInlineMediaPath(resolved)) {
+			continue
+		}
+		if allowed != nil && !allowed(resolved) {
+			continue
+		}
+		if opts.beforeOpen != nil {
+			opts.beforeOpen(resolved)
+		}
+		file, err := opts.openFile(secureRoot, relative)
+		if err != nil {
+			continue
+		}
+		actual, err := file.Stat()
+		if err != nil || !os.SameFile(expected, actual) {
+			file.Close()
+			continue
+		}
+		if actual.IsDir() {
+			attachment, err := loadDirectory(ctx, file, display)
+			if err == nil {
+				attachments = append(attachments, attachment)
+			}
+			continue
+		}
+		if !actual.Mode().IsRegular() || actual.Size() > MaxEagerFileBytes {
+			file.Close()
+			continue
+		}
+		attachment, err := loadTextFile(ctx, file, display, mention)
+		if err == nil {
+			attachments = append(attachments, attachment)
+		}
+	}
+	return attachments
+}
+
+func canonicalRoot(root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", errors.New("empty mention root")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", errors.New("mention root is not a directory")
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func resolveMentionPath(root, mentioned string) (resolved, display string, err error) {
+	mentioned = strings.TrimSuffix(mentioned, "/")
+	if mentioned == "" || !utf8.ValidString(mentioned) || hasUnsafePathRune(mentioned) {
+		return "", "", errors.New("invalid mention path")
+	}
+	candidate := filepath.FromSlash(mentioned)
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(root, candidate)
+	}
+	candidate, err = filepath.Abs(candidate)
+	if err != nil || !pathWithinRoot(root, candidate) {
+		return "", "", errors.New("mention path escapes root")
+	}
+	resolved, err = filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", "", err
+	}
+	resolved = filepath.Clean(resolved)
+	if !pathWithinRoot(root, resolved) {
+		return "", "", errors.New("mention symlink escapes root")
+	}
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", "", errors.New("invalid project-relative mention path")
+	}
+	display = filepath.ToSlash(relative)
+	return resolved, display, nil
+}
+
+func hasUnsafePathRune(value string) bool {
+	for _, r := range value {
+		if r == 0 || unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithinRoot(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func isInlineMediaPath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == ".pdf" {
+		return true
+	}
+	_, image := imageExtensions[ext]
+	return image
+}
+
+func loadTextFile(ctx context.Context, file *os.File, display string, mention SubmittedMention) (EagerAttachment, error) {
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() > MaxEagerFileBytes {
+		return EagerAttachment{}, errors.New("file changed before eager read")
+	}
+	content, err := io.ReadAll(io.LimitReader(file, MaxEagerFileBytes+1))
+	if err != nil {
+		return EagerAttachment{}, err
+	}
+	if int64(len(content)) > MaxEagerFileBytes || !utf8.Valid(content) || binarySample(content) {
+		return EagerAttachment{}, errors.New("file is not eligible text")
+	}
+	if err := ctx.Err(); err != nil {
+		return EagerAttachment{}, err
+	}
+
+	selected := content
+	lineStart, lineEnd := 0, 0
+	if mention.LineStart > 0 {
+		selected, lineStart, lineEnd = selectLines(content, mention.LineStart, mention.LineEnd)
+		if len(selected) == 0 {
+			return EagerAttachment{}, errors.New("requested line range is empty")
+		}
+	}
+	truncated := false
+	// The local reader has no separate selected-range exception or successful
+	// token-truncation result. Every full-file and ranged selection reaches this
+	// common post-selection check, so either local equivalent receives Claude's
+	// first-2,000-lines fallback.
+	if llm.EstimateTokens(string(selected)) > MaxEagerContentTokens {
+		fallbackStart := mention.LineStart
+		if fallbackStart == 0 {
+			fallbackStart = 1
+		}
+		selected, lineStart, lineEnd = selectLines(content, fallbackStart, fallbackStart+MaxEagerFallbackLines-1)
+		if len(selected) == 0 || llm.EstimateTokens(string(selected)) > MaxEagerContentTokens {
+			return EagerAttachment{}, errors.New("file exceeds eager token limit")
+		}
+		truncated = true
+	}
+
+	return EagerAttachment{
+		Path: display, Kind: KindFile, Content: string(selected),
+		LineStart: lineStart, LineEnd: lineEnd, Truncated: truncated,
+	}, nil
+}
+
+func binarySample(content []byte) bool {
+	if len(content) > 8<<10 {
+		content = content[:8<<10]
+	}
+	return bytes.IndexByte(content, 0) >= 0
+}
+
+func selectLines(content []byte, start, end int) ([]byte, int, int) {
+	if start < 1 || end < start {
+		return nil, 0, 0
+	}
+	lines := bytes.SplitAfter(content, []byte{'\n'})
+	if len(lines) > 0 && len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+	if start > len(lines) {
+		return nil, 0, 0
+	}
+	last := min(end, len(lines))
+	return bytes.Join(lines[start-1:last], nil), start, last
+}
+
+func loadDirectory(ctx context.Context, file *os.File, display string) (EagerAttachment, error) {
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.IsDir() {
+		return EagerAttachment{}, errors.New("directory changed before eager read")
+	}
+
+	names := make([]string, 0, MaxEagerDirectoryEntries+1)
+	total := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return EagerAttachment{}, err
+		}
+		batch, readErr := file.Readdirnames(256)
+		for _, name := range batch {
+			total++
+			if len(names) < MaxEagerDirectoryEntries {
+				names = append(names, name)
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return EagerAttachment{}, readErr
+		}
+	}
+	truncated := total > MaxEagerDirectoryEntries
+	if truncated {
+		names = append(names, fmt.Sprintf("… and %d more entries", total-MaxEagerDirectoryEntries))
+	}
+	if !strings.HasSuffix(display, "/") {
+		display += "/"
+	}
+	return EagerAttachment{
+		Path: display, Kind: KindDirectory, Content: strings.Join(names, "\n"),
+		Truncated: truncated, EntryCount: total,
+	}, nil
+}
+
+// FormatEagerAttachments appends submit-time context without changing the
+// visible user text. It uses the existing generic embedded-file format rather
+// than adding mention-specific persistence or provenance types.
+func FormatEagerAttachments(attachments []EagerAttachment) string {
+	if len(attachments) == 0 {
+		return ""
+	}
+	var output strings.Builder
+	output.WriteString("\n\nThe following @-mentioned resources were read before this request:\n\n")
+	for _, attachment := range attachments {
+		switch attachment.Kind {
+		case KindDirectory:
+			fmt.Fprintf(&output, "Non-recursive names in @%s:\n%s\n\n", attachment.Path, attachment.Content)
+		case KindFile:
+			fmt.Fprintf(&output, "Contents of @%s", attachment.Path)
+			if attachment.LineStart > 0 {
+				fmt.Fprintf(&output, " (lines %d-%d)", attachment.LineStart, attachment.LineEnd)
+			}
+			if attachment.Truncated {
+				output.WriteString(" (token-limited fallback; use read_file for more)")
+			}
+			output.WriteString(":\n")
+			output.WriteString(llm.FormatEmbeddedFileText(attachment.Path, "text/plain", attachment.Content))
+		}
+	}
+	return output.String()
+}

--- a/internal/mentions/attachments_test.go
+++ b/internal/mentions/attachments_test.go
@@ -1,0 +1,351 @@
+package mentions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeMentionTestFile(t *testing.T, root, name, content string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestEagerFileSizeBoundary(t *testing.T) {
+	root := t.TempDir()
+	prefix := strings.Repeat("x\n", MaxEagerFallbackLines+1)
+	exact := prefix + strings.Repeat("y", int(MaxEagerFileBytes)-len(prefix))
+	writeMentionTestFile(t, root, "exact.txt", exact)
+	writeMentionTestFile(t, root, "over.txt", exact+"z")
+
+	got := LoadEagerAttachments(context.Background(), root, "@exact.txt @over.txt", nil)
+	if len(got) != 1 || got[0].Path != "exact.txt" {
+		t.Fatalf("boundary attachments = %#v", got)
+	}
+	if !got[0].Truncated || got[0].LineStart != 1 || got[0].LineEnd != MaxEagerFallbackLines {
+		t.Fatalf("exact-boundary token fallback = %#v", got[0])
+	}
+}
+
+func TestGiantOneLine10MBFileIsNeverOpenedOrAttached(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "giant.txt")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := []byte(strings.Repeat("x", 64<<10))
+	for written := 0; written < 10<<20; written += len(block) {
+		if _, err := file.Write(block); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	opens := 0
+	got := loadEagerAttachments(context.Background(), root, "@giant.txt", nil, eagerLoadOptions{
+		openFile: func(secureMentionRoot, string) (*os.File, error) {
+			opens++
+			return nil, errors.New("unexpected open")
+		},
+	})
+	if len(got) != 0 || opens != 0 || FormatEagerAttachments(got) != "" {
+		t.Fatalf("oversized file attachments=%#v opens=%d", got, opens)
+	}
+}
+
+func TestLineRangeDoesNotBypassTotalSizeGate(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "large.txt")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("wanted\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(10 << 20); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	opens := 0
+	got := loadEagerAttachments(context.Background(), root, "@large.txt#L1", nil, eagerLoadOptions{
+		openFile: func(secureMentionRoot, string) (*os.File, error) {
+			opens++
+			return nil, errors.New("unexpected open")
+		},
+	})
+	if len(got) != 0 || opens != 0 {
+		t.Fatalf("oversized ranged file attachments=%#v opens=%d", got, opens)
+	}
+}
+
+func TestTokenOverflowFallsBackToRequestedTwoThousandLines(t *testing.T) {
+	root := t.TempDir()
+	var content strings.Builder
+	for i := 1; i <= 3_200; i++ {
+		fmt.Fprintf(&content, "%04d %s\n", i, strings.Repeat("x", 34))
+	}
+	writeMentionTestFile(t, root, "tokens.txt", content.String())
+
+	got := LoadEagerAttachments(context.Background(), root, "@tokens.txt#L101-3200", nil)
+	if len(got) != 1 {
+		t.Fatalf("attachments = %#v", got)
+	}
+	attachment := got[0]
+	if !attachment.Truncated || attachment.LineStart != 101 || attachment.LineEnd != 2100 {
+		t.Fatalf("fallback range = %#v", attachment)
+	}
+	if !strings.HasPrefix(attachment.Content, "0101 ") || strings.Contains(attachment.Content, "2101 ") {
+		t.Fatalf("fallback content bounds are wrong")
+	}
+}
+
+func TestLocalTokenLimitBoundary(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "exact-tokens.txt", strings.Repeat("x", MaxEagerContentTokens*4))
+	writeMentionTestFile(t, root, "over-tokens.txt", strings.Repeat("x", MaxEagerContentTokens*4+1))
+
+	got := LoadEagerAttachments(context.Background(), root, "@exact-tokens.txt @over-tokens.txt", nil)
+	if len(got) != 1 || got[0].Path != "exact-tokens.txt" || got[0].Truncated {
+		t.Fatalf("token boundary attachments = %#v", got)
+	}
+}
+
+func TestTokenOverflowGiantLineAttachesNothing(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "one-line.txt", strings.Repeat("x", MaxEagerContentTokens*4+1))
+	if got := LoadEagerAttachments(context.Background(), root, "@one-line.txt", nil); len(got) != 0 {
+		t.Fatalf("giant one-line attachment = %#v", got)
+	}
+}
+
+func TestRawDuplicateMentionsAttachOnceWithoutCanonicalDeduplication(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "manual.txt", "first\nsecond\n")
+	input := "manual @manual.txt and @./manual.txt then @manual.txt and @manual.txt#L2"
+	got := LoadEagerAttachments(context.Background(), root, input, nil)
+	if len(got) != 3 {
+		t.Fatalf("raw-deduplicated attachments = %#v", got)
+	}
+	if got[0].Content != "first\nsecond\n" || got[1].Content != "first\nsecond\n" || got[2].Content != "second\n" {
+		t.Fatalf("attachment contents = %#v", got)
+	}
+	formatted := FormatEagerAttachments(got)
+	if strings.Count(formatted, "Contents of @manual.txt") != 3 || strings.Count(input, "@manual.txt") != 3 {
+		t.Fatalf("formatted=%q input=%q", formatted, input)
+	}
+}
+
+func TestQuotedSpaceMentionAndLineRange(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "docs/design notes.md", "one\ntwo\nthree\n")
+	got := LoadEagerAttachments(context.Background(), root, `review @"docs/design notes.md#L2-3"`, nil)
+	if len(got) != 1 || got[0].Path != "docs/design notes.md" || got[0].Content != "two\nthree\n" {
+		t.Fatalf("quoted attachment = %#v", got)
+	}
+}
+
+func TestQuotedAttachmentsPrecedeUnquotedAttachments(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "plain.txt", "plain\n")
+	writeMentionTestFile(t, root, "quoted name.txt", "quoted\n")
+
+	got := LoadEagerAttachments(context.Background(), root, `@plain.txt then @"quoted name.txt"`, nil)
+	if len(got) != 2 || got[0].Path != "quoted name.txt" || got[1].Path != "plain.txt" {
+		t.Fatalf("attachment order = %#v", got)
+	}
+}
+
+func TestDirectoryListingCapsAtOneThousandNames(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "many")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < MaxEagerDirectoryEntries+5; i++ {
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("entry-%04d", i)), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := LoadEagerAttachments(context.Background(), root, "@many/", nil)
+	if len(got) != 1 || got[0].Kind != KindDirectory || got[0].EntryCount != 1005 || !got[0].Truncated {
+		t.Fatalf("directory attachment = %#v", got)
+	}
+	lines := strings.Split(got[0].Content, "\n")
+	if len(lines) != MaxEagerDirectoryEntries+1 || lines[len(lines)-1] != "… and 5 more entries" {
+		t.Fatalf("directory listing line count=%d tail=%q", len(lines), lines[len(lines)-1])
+	}
+}
+
+func TestDeniedAndRootEscapeMentionsAreOmitted(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "project")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMentionTestFile(t, root, "denied.txt", "secret")
+	writeMentionTestFile(t, parent, "outside.txt", "outside")
+
+	checked := 0
+	got := LoadEagerAttachments(context.Background(), root, "@denied.txt", func(string) bool {
+		checked++
+		return false
+	})
+	if len(got) != 0 || checked != 1 {
+		t.Fatalf("denied attachments = %#v checks=%d", got, checked)
+	}
+	if got := LoadEagerAttachments(context.Background(), root, "@../outside.txt", nil); len(got) != 0 {
+		t.Fatalf("root-escaping attachment = %#v", got)
+	}
+
+	if err := os.Symlink(filepath.Join(parent, "outside.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if got := LoadEagerAttachments(context.Background(), root, "@link.txt", nil); len(got) != 0 {
+		t.Fatalf("symlink escape attachment = %#v", got)
+	}
+}
+
+func TestSymlinkSwapAfterApprovalCannotEscapeSecureRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "project")
+	if err := os.MkdirAll(filepath.Join(root, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMentionTestFile(t, root, "note.txt", "approved-final")
+	writeMentionTestFile(t, root, "nested/note.txt", "approved-parent")
+	outside := writeMentionTestFile(t, parent, "outside.txt", "outside-secret")
+	probeLink := filepath.Join(root, "symlink-probe")
+	if err := os.Symlink(outside, probeLink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Remove(probeLink); err != nil {
+		t.Fatal(err)
+	}
+	outsideDir := filepath.Join(parent, "outside-dir")
+	if err := os.Mkdir(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMentionTestFile(t, outsideDir, "note.txt", "outside-parent-secret")
+
+	tests := []struct {
+		name    string
+		mention string
+		swap    func()
+	}{
+		{
+			name:    "final component",
+			mention: "@note.txt",
+			swap: func() {
+				if err := os.Rename(filepath.Join(root, "note.txt"), filepath.Join(root, "approved-note.txt")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outside, filepath.Join(root, "note.txt")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:    "parent component",
+			mention: "@nested/note.txt",
+			swap: func() {
+				if err := os.Rename(filepath.Join(root, "nested"), filepath.Join(root, "approved-nested")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outsideDir, filepath.Join(root, "nested")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			approved := false
+			got := loadEagerAttachments(context.Background(), root, test.mention, func(string) bool {
+				approved = true
+				return true
+			}, eagerLoadOptions{beforeOpen: func(string) { test.swap() }})
+			if !approved {
+				t.Fatal("read policy was not evaluated before the deterministic swap")
+			}
+			if len(got) != 0 {
+				t.Fatalf("replacement escaped through opened descriptor: %#v", got)
+			}
+		})
+		if test.name == "final component" {
+			if err := os.Remove(filepath.Join(root, "note.txt")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Rename(filepath.Join(root, "approved-note.txt"), filepath.Join(root, "note.txt")); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestOpenedDescriptorMustMatchApprovedFile(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "note.txt", "approved-body")
+	writeMentionTestFile(t, root, "replacement.txt", "replacement-body")
+
+	got := loadEagerAttachments(context.Background(), root, "@note.txt", func(string) bool { return true }, eagerLoadOptions{
+		beforeOpen: func(string) {
+			if err := os.Rename(filepath.Join(root, "note.txt"), filepath.Join(root, "original.txt")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Rename(filepath.Join(root, "replacement.txt"), filepath.Join(root, "note.txt")); err != nil {
+				t.Fatal(err)
+			}
+		},
+	})
+	if len(got) != 0 {
+		t.Fatalf("different post-approval descriptor was attached: %#v", got)
+	}
+}
+
+func TestNetworkPathSpellingsCannotEscapeProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	canonical, err := canonicalRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{
+		`//server/share/secret.txt`,
+		`\\server\share\secret.txt`,
+		`\\wsl$\Ubuntu\home\secret.txt`,
+		`\\?\UNC\server\share\secret.txt`,
+	}
+	for _, mentioned := range paths {
+		t.Run(mentioned, func(t *testing.T) {
+			if resolved, _, err := resolveMentionPath(canonical, mentioned); err == nil {
+				t.Fatalf("network path resolved outside project confinement: %q", resolved)
+			}
+		})
+	}
+}
+
+func TestPDFAndImageMentionsRemainTextualReferences(t *testing.T) {
+	root := t.TempDir()
+	writeMentionTestFile(t, root, "small.pdf", "%PDF-1.7 text-like fixture")
+	writeMentionTestFile(t, root, "small.svg", "<svg></svg>")
+	if got := LoadEagerAttachments(context.Background(), root, "@small.pdf @small.svg", nil); len(got) != 0 {
+		t.Fatalf("media mention attachments = %#v", got)
+	}
+}

--- a/internal/mentions/discover.go
+++ b/internal/mentions/discover.go
@@ -1,0 +1,275 @@
+package mentions
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+var (
+	vcsDirs           = map[string]struct{}{`.git`: {}, `.hg`: {}, `.svn`: {}}
+	errNotGitWorktree = errors.New("not in a git worktree")
+)
+
+// Build discovers project files and synthesized parent directories.
+func Build(ctx context.Context, root string, opts BuildOptions) (*Snapshot, error) {
+	if opts.MaxCandidates <= 0 || opts.MaxPathBytes <= 0 {
+		opts = DefaultBuildOptions()
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve mention root: %w", err)
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("stat mention root: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("mention root is not a directory: %s", absRoot)
+	}
+
+	collector := newCandidateCollector(opts)
+	source := "git"
+	gitErr := discoverGit(ctx, absRoot, collector)
+	if errors.Is(gitErr, errNotGitWorktree) {
+		source = "walk"
+		if err := discoverWalk(ctx, absRoot, collector); err != nil {
+			return nil, err
+		}
+	} else if gitErr != nil {
+		return nil, gitErr
+	}
+
+	paths := make([]string, 0, len(collector.entries))
+	for path := range collector.entries {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	snapshot := &Snapshot{Root: absRoot, Source: source, BuiltAt: time.Now(), Truncated: collector.truncated}
+	for _, path := range paths {
+		candidate := makeCandidate(path, collector.entries[path])
+		snapshot.Candidates = append(snapshot.Candidates, candidate)
+		snapshot.PathBytes += candidateAccountedBytes(candidate)
+	}
+	return snapshot, nil
+}
+
+type candidateCollector struct {
+	entries   map[string]Kind
+	opts      BuildOptions
+	pathBytes int64
+	truncated bool
+}
+
+func newCandidateCollector(opts BuildOptions) *candidateCollector {
+	return &candidateCollector{entries: make(map[string]Kind), opts: opts}
+}
+
+func (c *candidateCollector) addWithParents(path string, kind Kind) bool {
+	clean, ok := cleanSafeRelativePath(path)
+	if !ok {
+		return true
+	}
+	var parents []string
+	for parent := filepath.ToSlash(filepath.Dir(filepath.FromSlash(clean))); parent != "." && parent != ""; parent = filepath.ToSlash(filepath.Dir(filepath.FromSlash(parent))) {
+		parents = append(parents, parent)
+	}
+	for i := len(parents) - 1; i >= 0; i-- {
+		if !c.add(parents[i], KindDirectory) {
+			return false
+		}
+	}
+	return c.add(clean, kind)
+}
+
+func (c *candidateCollector) add(path string, kind Kind) bool {
+	if existing, ok := c.entries[path]; ok {
+		if existing == KindDirectory && kind == KindFile {
+			c.entries[path] = kind
+		}
+		return true
+	}
+	candidate := makeCandidate(path, kind)
+	accounted := candidateAccountedBytes(candidate)
+	if len(c.entries) >= c.opts.MaxCandidates || c.pathBytes+accounted > c.opts.MaxPathBytes {
+		c.truncated = true
+		return false
+	}
+	c.entries[path] = kind
+	c.pathBytes += accounted
+	return true
+}
+
+func candidateAccountedBytes(candidate Candidate) int64 {
+	return int64(len(candidate.Path)+len(candidate.LowerPath)) + 64
+}
+
+func discoverGit(ctx context.Context, root string, collector *candidateCollector) error {
+	hasMarker := gitWorktreeMarkerExists(root)
+	probe := exec.CommandContext(ctx, "git", "rev-parse", "--is-inside-work-tree")
+	probe.Dir = root
+	out, err := probe.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if hasMarker {
+			return fmt.Errorf("probe git worktree: %w", err)
+		}
+		return errNotGitWorktree
+	}
+	if strings.TrimSpace(string(out)) != "true" {
+		if hasMarker {
+			return errors.New("git metadata found but root is not an accessible worktree")
+		}
+		return errNotGitWorktree
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--deduplicate", "--", ".")
+	cmd.Dir = root
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("open git ls-files output: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("start git ls-files: %w", err)
+	}
+
+	reader := bufio.NewReader(stdout)
+	for {
+		part, readErr := reader.ReadString(0)
+		if len(part) > 0 {
+			rel := strings.TrimSuffix(part, "\x00")
+			if clean, ok := cleanSafeRelativePath(filepath.ToSlash(rel)); ok {
+				path := filepath.Join(root, filepath.FromSlash(clean))
+				if fi, statErr := os.Lstat(path); statErr == nil {
+					switch {
+					case fi.Mode().IsRegular():
+						collector.addWithParents(clean, KindFile)
+					case fi.IsDir(): // gitlinks/submodules are directory-only in V1
+						collector.addWithParents(strings.TrimSuffix(clean, "/"), KindDirectory)
+					}
+				}
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			_ = cmd.Wait()
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("read git ls-files: %w", readErr)
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("git ls-files: %w", err)
+	}
+	return nil
+}
+
+func gitWorktreeMarkerExists(root string) bool {
+	for dir := filepath.Clean(root); ; dir = filepath.Dir(dir) {
+		_, err := os.Lstat(filepath.Join(dir, ".git"))
+		if err == nil || !errors.Is(err, os.ErrNotExist) {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+	}
+}
+
+func discoverWalk(ctx context.Context, root string, collector *candidateCollector) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			if entry != nil && entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			if _, skip := vcsDirs[entry.Name()]; skip {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		if !collector.addWithParents(filepath.ToSlash(rel), KindFile) {
+			return fs.SkipAll
+		}
+		return nil
+	})
+}
+
+func cleanSafeRelativePath(path string) (string, bool) {
+	if path == "" || filepath.IsAbs(path) || !utf8.ValidString(path) {
+		return "", false
+	}
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", false
+	}
+	for _, r := range clean {
+		if r == 0 || r < 0x20 || r == 0x7f {
+			return "", false
+		}
+	}
+	return clean, true
+}
+
+func makeCandidate(path string, kind Kind) Candidate {
+	lower := lowerASCII(path)
+	base := strings.LastIndexByte(path, '/') + 1
+	candidate := Candidate{Path: path, LowerPath: lower, BaseOffset: uint32(base), Kind: kind}
+	for _, b := range []byte(lower) {
+		candidate.ASCII[b>>6] |= 1 << (b & 63)
+	}
+	return candidate
+}
+
+func lowerASCII(value string) string {
+	buf := []byte(value)
+	for i, b := range buf {
+		if b >= 'A' && b <= 'Z' {
+			buf[i] = b + ('a' - 'A')
+		}
+	}
+	return string(buf)
+}

--- a/internal/mentions/discover_test.go
+++ b/internal/mentions/discover_test.go
@@ -1,0 +1,296 @@
+package mentions
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildWalkIncludesHiddenSynthesizesDirectoriesAndSkipsVCS(t *testing.T) {
+	root := t.TempDir()
+	mustWrite := func(rel string) {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(".hidden/config")
+	mustWrite("internal/llm/types.go")
+	mustWrite(".hg/store/secret")
+
+	s, err := Build(context.Background(), root, DefaultBuildOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]Kind{}
+	for _, c := range s.Candidates {
+		got[c.Path] = c.Kind
+	}
+	for _, want := range []string{".hidden", ".hidden/config", "internal", "internal/llm", "internal/llm/types.go"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("missing %q in %#v", want, got)
+		}
+	}
+	if _, ok := got[".hg/store/secret"]; ok {
+		t.Fatal("indexed VCS metadata")
+	}
+}
+
+func TestBuildGitExcludesIgnoredAndDeletedTracked(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	root := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ignored.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".gitignore", "tracked.txt")
+	run("commit", "-qm", "base")
+	run("update-index", "--add", "--cacheinfo", "160000,"+strings.TrimSpace(gitOutput(t, root, "rev-parse", "HEAD"))+",vendor/sub")
+	if err := os.MkdirAll(filepath.Join(root, "vendor", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vendor", "sub", "inside.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "tracked.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "visible.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Build(context.Background(), root, DefaultBuildOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, c := range s.Candidates {
+		got[c.Path] = true
+	}
+	if got["tracked.txt"] {
+		t.Fatal("deleted tracked path was indexed")
+	}
+	if got["ignored.txt"] {
+		t.Fatal("ignored path was indexed")
+	}
+	if !got["visible.txt"] {
+		t.Fatal("untracked visible path missing")
+	}
+	if !got["vendor/sub"] || got["vendor/sub/inside.go"] {
+		t.Fatalf("submodule should be directory-only, got %#v", got)
+	}
+}
+
+func gitOutput(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+func BenchmarkBuildWalk10K(b *testing.B) {
+	root := b.TempDir()
+	for i := 0; i < 10_000; i++ {
+		path := filepath.Join(root, "src", "pkg", string(rune('a'+i%26)), "file-"+fmtInt(i)+".go")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Build(context.Background(), root, DefaultBuildOptions()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func fmtInt(v int) string {
+	const digits = "0123456789"
+	if v == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = digits[v%10]
+		v /= 10
+	}
+	return string(buf[i:])
+}
+
+func TestBuildGitFailureDoesNotFallBackToIgnoredWalk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake git executable uses a shell script")
+	}
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := t.TempDir()
+	fakeGit := filepath.Join(bin, "git")
+	script := "#!/bin/sh\nif [ \"$1\" = rev-parse ]; then echo true; exit 0; fi\nexit 42\n"
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+
+	if snapshot, err := Build(context.Background(), root, DefaultBuildOptions()); err == nil {
+		for _, candidate := range snapshot.Candidates {
+			if candidate.Path == ".env" {
+				t.Fatal("gitignored secret was exposed by walk fallback")
+			}
+		}
+		t.Fatal("broken git worktree unexpectedly downgraded to walk discovery")
+	}
+}
+
+func TestBuildWithoutGitFailsClosedOnlyWhenGitMetadataExists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH executable semantics differ on Windows")
+	}
+	emptyPath := t.TempDir()
+	t.Setenv("PATH", emptyPath)
+
+	plain := t.TempDir()
+	if err := os.WriteFile(filepath.Join(plain, "visible.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := Build(context.Background(), plain, DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("plain directory without git did not use walk: %v", err)
+	}
+	if snapshot.Source != "walk" {
+		t.Fatalf("plain source = %q, want walk", snapshot.Source)
+	}
+
+	worktree := t.TempDir()
+	if err := os.Mkdir(filepath.Join(worktree, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".env"), []byte("SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Build(context.Background(), worktree, DefaultBuildOptions()); err == nil {
+		t.Fatal("Git worktree without git executable fell back to an unfiltered walk")
+	}
+}
+
+func TestBuildEnforcesLimitsAndWalkSafety(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 20; i++ {
+		if err := os.WriteFile(filepath.Join(root, fmtInt(i)+".txt"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "bad\nname"), nil, 0o644); err != nil && runtime.GOOS != "windows" {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "0.txt"), filepath.Join(root, "linked-file")); err != nil && !errors.Is(err, os.ErrPermission) {
+		// Symlink support is platform/filesystem dependent; direct safety checks
+		// below still cover rejection when links cannot be created.
+		t.Logf("symlink unavailable: %v", err)
+	}
+
+	snapshot, err := Build(context.Background(), root, BuildOptions{MaxCandidates: 3, MaxPathBytes: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshot.Truncated || len(snapshot.Candidates) > 3 {
+		t.Fatalf("candidate limit not enforced: truncated=%v len=%d", snapshot.Truncated, len(snapshot.Candidates))
+	}
+	byteLimited, err := Build(context.Background(), root, BuildOptions{MaxCandidates: 100, MaxPathBytes: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !byteLimited.Truncated || byteLimited.PathBytes > 100 {
+		t.Fatalf("path-byte limit not enforced: truncated=%v bytes=%d", byteLimited.Truncated, byteLimited.PathBytes)
+	}
+	for _, candidate := range snapshot.Candidates {
+		if strings.Contains(candidate.Path, "\n") || candidate.Path == "linked-file" {
+			t.Fatalf("unsafe walk candidate indexed: %q", candidate.Path)
+		}
+	}
+
+	for _, path := range []string{"a/../b.txt", "../secret", "bad\x00name", "bad\nname", string([]byte{'b', 'a', 'd', 0xff})} {
+		clean, ok := cleanSafeRelativePath(path)
+		if path == "a/../b.txt" {
+			if !ok || clean != "b.txt" {
+				t.Fatalf("safe cleaned path = %q, %v", clean, ok)
+			}
+			continue
+		}
+		if ok {
+			t.Fatalf("unsafe path accepted: %q -> %q", path, clean)
+		}
+	}
+}
+
+func TestBuildCancellationDuringGitProbeReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Build(ctx, t.TempDir(), DefaultBuildOptions())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Build error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBuildWalkSkipsSymlinkedFilesAndDirectories(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(root, "linked-file")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linked-dir")); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "visible.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := Build(context.Background(), root, DefaultBuildOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range snapshot.Candidates {
+		if strings.HasPrefix(candidate.Path, "linked-") {
+			t.Fatalf("symlink candidate indexed: %q", candidate.Path)
+		}
+	}
+}

--- a/internal/mentions/match.go
+++ b/internal/mentions/match.go
@@ -1,0 +1,145 @@
+package mentions
+
+import (
+	"container/heap"
+	"context"
+	"sort"
+	"strings"
+)
+
+// Search performs deterministic whole-relative-path fuzzy matching.
+func (s *Snapshot) Search(ctx context.Context, query string, limit int) []Match {
+	if s == nil || limit <= 0 {
+		return nil
+	}
+	query = lowerASCII(query)
+	qbytes := []byte(query)
+	var qmask [4]uint64
+	for _, b := range qbytes {
+		qmask[b>>6] |= 1 << (b & 63)
+	}
+	h := &matchHeap{matches: make([]Match, 0, limit), candidates: s.Candidates}
+	positionScratch := make([]int, 0, len(qbytes))
+	for i := range s.Candidates {
+		if i&255 == 0 {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+		}
+		c := &s.Candidates[i]
+		if !containsMask(c.ASCII, qmask) {
+			continue
+		}
+		score, positions, ok := scoreCandidate(*c, qbytes, positionScratch[:0])
+		if !ok {
+			continue
+		}
+		m := Match{Candidate: i, Score: score}
+		if h.Len() < limit {
+			m.Positions = append([]int(nil), positions...)
+			heap.Push(h, m)
+		} else if betterMatch(m, h.matches[0], s.Candidates) {
+			m.Positions = append([]int(nil), positions...)
+			h.matches[0] = m
+			heap.Fix(h, 0)
+		}
+	}
+	out := append([]Match(nil), h.matches...)
+	sort.Slice(out, func(i, j int) bool { return betterMatch(out[i], out[j], s.Candidates) })
+	return out
+}
+
+func containsMask(have, want [4]uint64) bool {
+	for i := range have {
+		if have[i]&want[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func scoreCandidate(c Candidate, query []byte, positions []int) (int, []int, bool) {
+	if len(query) == 0 {
+		return 1000 - strings.Count(c.Path, "/")*10 - len(c.Path), positions, true
+	}
+	path := []byte(c.LowerPath)
+	positions = positions[:0]
+	pi := 0
+	score := 0
+	for qi, q := range query {
+		found := -1
+		for pi < len(path) {
+			if path[pi] == q {
+				found = pi
+				pi++
+				break
+			}
+			pi++
+		}
+		if found < 0 {
+			return 0, nil, false
+		}
+		positions = append(positions, found)
+		score += 20
+		if found == int(c.BaseOffset) || found > 0 && path[found-1] == '/' {
+			score += 35
+		}
+		if qi > 0 {
+			gap := found - positions[qi-1] - 1
+			if gap == 0 {
+				score += 28
+			} else {
+				score -= gap
+			}
+		}
+	}
+	base := path[c.BaseOffset:]
+	q := string(query)
+	if string(base) == q {
+		score += 500
+	} else if strings.HasPrefix(string(base), q) {
+		score += 250
+	} else if strings.Contains(string(base), q) {
+		score += 100
+	}
+	score -= strings.Count(c.Path, "/") * 4
+	score -= len(c.Path) / 8
+	if c.Kind == KindDirectory {
+		score -= 1
+	}
+	return score, positions, true
+}
+
+func betterMatch(a, b Match, candidates []Candidate) bool {
+	if a.Score != b.Score {
+		return a.Score > b.Score
+	}
+	ap, bp := candidates[a.Candidate].Path, candidates[b.Candidate].Path
+	if len(ap) != len(bp) {
+		return len(ap) < len(bp)
+	}
+	return ap < bp
+}
+
+// matchHeap keeps the worst retained match at index zero.
+type matchHeap struct {
+	matches    []Match
+	candidates []Candidate
+}
+
+func (h matchHeap) Len() int      { return len(h.matches) }
+func (h matchHeap) Swap(i, j int) { h.matches[i], h.matches[j] = h.matches[j], h.matches[i] }
+func (h matchHeap) Less(i, j int) bool {
+	// container/heap puts the Less element at the root, so "less" means
+	// worse according to the exact inverse of the final ordering.
+	return betterMatch(h.matches[j], h.matches[i], h.candidates)
+}
+func (h *matchHeap) Push(x any) { h.matches = append(h.matches, x.(Match)) }
+func (h *matchHeap) Pop() any {
+	old := h.matches
+	x := old[len(old)-1]
+	h.matches = old[:len(old)-1]
+	return x
+}

--- a/internal/mentions/match_test.go
+++ b/internal/mentions/match_test.go
@@ -1,0 +1,125 @@
+package mentions
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func testSnapshot(paths ...string) *Snapshot {
+	s := &Snapshot{}
+	for _, path := range paths {
+		s.Candidates = append(s.Candidates, makeCandidate(path, KindFile))
+	}
+	return s
+}
+
+func TestSearchWholeRelativePathAndRanking(t *testing.T) {
+	s := testSnapshot("docs/types-notes.md", "internal/llm/types.go", "types.go", "internal/tools/read.go")
+	matches := s.Search(context.Background(), "illmtyp", 10)
+	if len(matches) == 0 || s.Candidates[matches[0].Candidate].Path != "internal/llm/types.go" {
+		t.Fatalf("whole-path search = %#v", matches)
+	}
+
+	matches = s.Search(context.Background(), "types.go", 10)
+	if got := s.Candidates[matches[0].Candidate].Path; got != "types.go" {
+		t.Fatalf("exact basename ranked %q first", got)
+	}
+}
+
+func TestSearchReturnsTrueTopKWithTies(t *testing.T) {
+	paths := make([]string, 0, 600)
+	for i := 0; i < 200; i++ {
+		paths = append(paths,
+			fmt.Sprintf("internal/xy/%03d/a.go", i),
+			fmt.Sprintf("ab/internal/%03d/ab.go", i),
+			fmt.Sprintf("src/%03d/abcd.go", i),
+		)
+	}
+	s := testSnapshot(paths...)
+	for _, query := range []string{"a", "ab", "abc", "go"} {
+		full := s.Search(context.Background(), query, len(s.Candidates))
+		for _, limit := range []int{1, 3, 4, 8, 50} {
+			got := s.Search(context.Background(), query, limit)
+			want := full[:min(limit, len(full))]
+			if !reflect.DeepEqual(matchCandidateIDs(got), matchCandidateIDs(want)) {
+				t.Fatalf("query=%q limit=%d candidates=%v, want %v", query, limit, matchCandidateIDs(got), matchCandidateIDs(want))
+			}
+		}
+	}
+}
+
+func matchCandidateIDs(matches []Match) []int {
+	ids := make([]int, len(matches))
+	for i, match := range matches {
+		ids[i] = match.Candidate
+	}
+	return ids
+}
+
+func TestSearchTopKAndPeriodicCancellation(t *testing.T) {
+	paths := make([]string, 2000)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("dir/file-%04d.go", i)
+	}
+	s := testSnapshot(paths...)
+	if got := len(s.Search(context.Background(), "file", 7)); got != 7 {
+		t.Fatalf("top-k len = %d", got)
+	}
+	ctx := newCancelAfterChecksContext(3)
+	if got := s.Search(ctx, "file", 7); got != nil {
+		t.Fatalf("cancelled search = %#v", got)
+	}
+	if ctx.checks < 3 {
+		t.Fatalf("search checked cancellation only %d times", ctx.checks)
+	}
+}
+
+type cancelAfterChecksContext struct {
+	cancelAt int
+	checks   int
+	done     chan struct{}
+}
+
+func newCancelAfterChecksContext(cancelAt int) *cancelAfterChecksContext {
+	return &cancelAfterChecksContext{cancelAt: cancelAt, done: make(chan struct{})}
+}
+
+func (c *cancelAfterChecksContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *cancelAfterChecksContext) Done() <-chan struct{} {
+	c.checks++
+	if c.checks == c.cancelAt {
+		close(c.done)
+	}
+	return c.done
+}
+func (c *cancelAfterChecksContext) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+func (c *cancelAfterChecksContext) Value(any) any { return nil }
+
+func BenchmarkSearch10KSelectiveQuery(b *testing.B)  { benchmarkSearch(b, 10_000, "pkgcomp42") }
+func BenchmarkSearch100KSelectiveQuery(b *testing.B) { benchmarkSearch(b, 100_000, "pkgcomp42") }
+func BenchmarkSearch10KBroadQuery(b *testing.B)      { benchmarkSearch(b, 10_000, "comp") }
+func BenchmarkSearch100KBroadQuery(b *testing.B)     { benchmarkSearch(b, 100_000, "comp") }
+func BenchmarkSearch100KShortQuery(b *testing.B)     { benchmarkSearch(b, 100_000, "c") }
+
+func benchmarkSearch(b *testing.B, count int, query string) {
+	paths := make([]string, count)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("internal/package-%04d/component/file-%06d.go", i%1000, i)
+	}
+	s := testSnapshot(paths...)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.Search(context.Background(), query, 50)
+	}
+}

--- a/internal/mentions/parse.go
+++ b/internal/mentions/parse.go
@@ -1,0 +1,229 @@
+package mentions
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var (
+	submittedLineRange = regexp.MustCompile(`#L([1-9][0-9]*)(?:-L?([1-9][0-9]*))?$`)
+	submittedPathParts = regexp.MustCompile(`^([^#]+)(?:(#L[1-9][0-9]*(?:-L?[1-9][0-9]*)?))?(?:#[^#]*)?$`)
+)
+
+// ActiveTokenAt returns the @ token containing the byte cursor. Tokens start
+// at the buffer beginning or after whitespace or one of Claude Code's four
+// CJK/fullwidth sentence delimiters. Quoted tokens allow spaces and backslash
+// escapes.
+func ActiveTokenAt(text string, cursor int) (ActiveToken, bool) {
+	if cursor < 0 || cursor > len(text) || !utf8.ValidString(text) {
+		return ActiveToken{}, false
+	}
+	lineStart := strings.LastIndexByte(text[:cursor], '\n') + 1
+	for start := cursor - 1; start >= lineStart; start-- {
+		if text[start] != '@' {
+			continue
+		}
+		if start > 0 {
+			r, _ := utf8.DecodeLastRuneInString(text[:start])
+			if !isMentionBoundary(r) {
+				continue
+			}
+		}
+		tail := text[start+1 : cursor]
+		if strings.HasPrefix(tail, "\"") {
+			query, ok := parseQuotedTail(tail[1:])
+			if !ok {
+				continue
+			}
+			return ActiveToken{Start: start, End: cursor, Query: query, Quoted: true}, true
+		}
+		if strings.ContainsAny(tail, " \t\r\n\"") {
+			continue
+		}
+		return ActiveToken{Start: start, End: cursor, Query: tail}, true
+	}
+	return ActiveToken{}, false
+}
+
+func parseQuotedTail(tail string) (string, bool) {
+	var b strings.Builder
+	escaped := false
+	for _, r := range tail {
+		if escaped {
+			b.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == '"' {
+			return "", false // a closed quoted token is no longer active
+		}
+		b.WriteRune(r)
+	}
+	if escaped {
+		b.WriteRune('\\')
+	}
+	return b.String(), true
+}
+
+func isMentionBoundary(r rune) bool {
+	return unicode.IsSpace(r) || r == '。' || r == '、' || r == '？' || r == '！'
+}
+
+// InsertText returns a visible mention token. Paths needing spaces or quoting
+// are escaped using the @"..." form.
+func InsertText(path string, directory bool) string {
+	if directory && !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	if strings.ContainsAny(path, " \t\"\\") {
+		escaped := strings.NewReplacer("\\", "\\\\", "\"", "\\\"").Replace(path)
+		return "@\"" + escaped + "\""
+	}
+	return "@" + path
+}
+
+// ParseSubmitted extracts file and directory mentions at Claude Code's mention
+// start boundaries. The four CJK/fullwidth punctuation runes are start
+// delimiters only: unquoted payloads still continue until whitespace. Quoted
+// matches are returned before unquoted matches, and duplicate raw payloads are
+// removed before path parsing. Quoted paths may contain spaces and escaped
+// quotes/backslashes. A trailing #Lx or #Lx-y suffix inside the quoted or
+// unquoted payload selects one-based lines.
+func ParseSubmitted(text string) []SubmittedMention {
+	matches := append(collectSubmittedMatches(text, true), collectSubmittedMatches(text, false)...)
+	mentions := make([]SubmittedMention, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		if _, duplicate := seen[match.raw]; duplicate {
+			continue
+		}
+		seen[match.raw] = struct{}{}
+		mentions = append(mentions, match.mention)
+	}
+	return mentions
+}
+
+type submittedMatch struct {
+	mention SubmittedMention
+	raw     string
+	end     int
+	quoted  bool
+}
+
+func collectSubmittedMatches(text string, quoted bool) []submittedMatch {
+	var matches []submittedMatch
+	for offset := 0; offset < len(text); {
+		at := strings.IndexByte(text[offset:], '@')
+		if at < 0 {
+			break
+		}
+		at += offset
+		if at > 0 {
+			previous, _ := utf8.DecodeLastRuneInString(text[:at])
+			if !isMentionBoundary(previous) {
+				offset = at + 1
+				continue
+			}
+		}
+
+		match, ok := parseSubmittedAt(text, at)
+		if !ok || match.quoted != quoted {
+			offset = at + 1
+			continue
+		}
+		offset = max(match.end, at+1)
+		matches = append(matches, match)
+	}
+	return matches
+}
+
+func parseSubmittedAt(text string, at int) (submittedMatch, bool) {
+	start := at + 1
+	if start >= len(text) {
+		return submittedMatch{}, false
+	}
+	if text[start] != '"' {
+		end := start
+		for end < len(text) {
+			r, size := utf8.DecodeRuneInString(text[end:])
+			if unicode.IsSpace(r) {
+				break
+			}
+			end += size
+		}
+		if end == start {
+			return submittedMatch{}, false
+		}
+		raw := text[start:end]
+		mention := parseSubmittedPath(raw)
+		return submittedMatch{mention: mention, raw: raw, end: end}, mention.Path != ""
+	}
+
+	var path strings.Builder
+	escaped := false
+	end := start + 1
+	for end < len(text) {
+		r, size := utf8.DecodeRuneInString(text[end:])
+		end += size
+		if escaped {
+			path.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == '"' {
+			raw := path.String()
+			mention := parseSubmittedPath(raw)
+			return submittedMatch{mention: mention, raw: raw, end: end, quoted: true}, mention.Path != ""
+		}
+		path.WriteRune(r)
+	}
+	return submittedMatch{}, false
+}
+
+func parseSubmittedPath(value string) SubmittedMention {
+	parts := submittedPathParts.FindStringSubmatch(value)
+	if parts == nil {
+		return SubmittedMention{Path: value}
+	}
+	mention := SubmittedMention{Path: parts[1]}
+	if parts[2] == "" {
+		return mention
+	}
+	start, end, ok := parseLineRange(parts[2])
+	if !ok {
+		// Do not turn an invalid range into an unintended whole-file read.
+		return SubmittedMention{Path: value}
+	}
+	mention.LineStart, mention.LineEnd = start, end
+	return mention
+}
+
+func parseLineRange(value string) (int, int, bool) {
+	match := submittedLineRange.FindStringSubmatch(value)
+	if match == nil {
+		return 0, 0, false
+	}
+	start, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	end := start
+	if match[2] != "" {
+		end, err = strconv.Atoi(match[2])
+		if err != nil || end < start {
+			return 0, 0, false
+		}
+	}
+	return start, end, true
+}

--- a/internal/mentions/parse_test.go
+++ b/internal/mentions/parse_test.go
@@ -1,0 +1,132 @@
+package mentions
+
+import "testing"
+
+func TestActiveTokenAt(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		cursor int
+		want   string
+		start  int
+		ok     bool
+	}{
+		{"start", "@llmtyp", -1, "llmtyp", 0, true},
+		{"middle", "review @internal/llm/typ please", 24, "internal/llm/typ", 7, true},
+		{"email", "me@example.com", -1, "", 0, false},
+		{"punctuation boundary", "see(@file", -1, "", 0, false},
+		{"ideographic full stop boundary", "see。@file", -1, "file", 6, true},
+		{"ideographic comma boundary", "see、@file", -1, "file", 6, true},
+		{"fullwidth question boundary", "see？@file", -1, "file", 6, true},
+		{"fullwidth exclamation boundary", "see！@file", -1, "file", 6, true},
+		{"quoted CJK boundary", `see。@"docs/design notes`, -1, "docs/design notes", 6, true},
+		{"quoted", `see @"docs/design notes`, -1, "docs/design notes", 4, true},
+		{"closed", `see @"docs/design notes.md"`, -1, "", 0, false},
+		{"unicode before", `é @資料`, -1, "資料", 3, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cursor := tt.cursor
+			if cursor < 0 {
+				cursor = len(tt.text)
+			}
+			got, ok := ActiveTokenAt(tt.text, cursor)
+			if ok != tt.ok || ok && (got.Query != tt.want || got.Start != tt.start) {
+				t.Fatalf("ActiveTokenAt(%q) = %#v, %v", tt.text, got, ok)
+			}
+		})
+	}
+}
+
+func TestInsertText(t *testing.T) {
+	if got := InsertText("internal/llm/types.go", false); got != "@internal/llm/types.go" {
+		t.Fatalf("plain insertion = %q", got)
+	}
+	if got := InsertText(`docs/design "notes".md`, false); got != `@"docs/design \"notes\".md"` {
+		t.Fatalf("quoted insertion = %q", got)
+	}
+	if got := InsertText("internal/llm", true); got != "@internal/llm/" {
+		t.Fatalf("directory insertion = %q", got)
+	}
+}
+
+func TestParseSubmitted(t *testing.T) {
+	input := "@first.go mail@example.com x@nope.go\n" +
+		`review @"docs/design notes.md#L10-20" and @pkg/file.go#L7 and @first.go`
+	got := ParseSubmitted(input)
+	want := []SubmittedMention{
+		{Path: "docs/design notes.md", LineStart: 10, LineEnd: 20},
+		{Path: "first.go"},
+		{Path: "pkg/file.go", LineStart: 7, LineEnd: 7},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ParseSubmitted() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("mention %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseSubmittedCJKStartBoundariesAreNotTerminators(t *testing.T) {
+	for _, delimiter := range []string{"。", "、", "？", "！"} {
+		t.Run(delimiter, func(t *testing.T) {
+			got := ParseSubmitted("prefix" + delimiter + `@plain.go prefix` + delimiter + `@"quoted name.md"`)
+			want := []SubmittedMention{{Path: "quoted name.md"}, {Path: "plain.go"}}
+			if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+				t.Fatalf("ParseSubmitted() = %#v, want %#v", got, want)
+			}
+		})
+	}
+
+	got := ParseSubmitted("。@first.go、@second.go")
+	if len(got) != 1 || got[0].Path != "first.go、@second.go" {
+		t.Fatalf("CJK punctuation became an unquoted terminator: %#v", got)
+	}
+}
+
+func TestParseSubmittedQuotedFirstAndRawDeduplication(t *testing.T) {
+	got := ParseSubmitted(`@same.go @./same.go @"quoted name.md" @same.go#L2 @same.go`)
+	want := []SubmittedMention{
+		{Path: "quoted name.md"},
+		{Path: "same.go"},
+		{Path: "./same.go"},
+		{Path: "same.go", LineStart: 2, LineEnd: 2},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ParseSubmitted() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("mention %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseSubmittedQuotedEscapesAndInvalidRanges(t *testing.T) {
+	got := ParseSubmitted(`see @"docs/a \"quote\".md" and @ok.go#L9-L12 @back.go#L9-2`)
+	if len(got) != 3 {
+		t.Fatalf("mentions = %#v", got)
+	}
+	if got[0].Path != `docs/a "quote".md` {
+		t.Fatalf("quoted path = %q", got[0].Path)
+	}
+	if got[1].LineStart != 9 || got[1].LineEnd != 12 {
+		t.Fatalf("range = %#v", got[1])
+	}
+	if got[2].Path != "back.go#L9-2" || got[2].LineStart != 0 {
+		t.Fatalf("invalid backwards range should remain literal: %#v", got[2])
+	}
+
+	outside := ParseSubmitted(`@"quoted path.md"#L3-4`)
+	if len(outside) != 1 || outside[0] != (SubmittedMention{Path: "quoted path.md"}) {
+		t.Fatalf("range outside closing quote was associated: %#v", outside)
+	}
+
+	fragments := ParseSubmitted(`@guide.md#heading @guide.md#L4-5#heading`)
+	wantFragments := []SubmittedMention{{Path: "guide.md"}, {Path: "guide.md", LineStart: 4, LineEnd: 5}}
+	if len(fragments) != len(wantFragments) || fragments[0] != wantFragments[0] || fragments[1] != wantFragments[1] {
+		t.Fatalf("fragment parsing = %#v, want %#v", fragments, wantFragments)
+	}
+}

--- a/internal/mentions/secure_open.go
+++ b/internal/mentions/secure_open.go
@@ -1,0 +1,14 @@
+package mentions
+
+import (
+	"errors"
+	"os"
+)
+
+var errSecureOpenUnavailable = errors.New("descriptor-relative secure open is unavailable on this platform")
+
+type secureMentionRoot interface {
+	Open(string) (*os.File, error)
+	Stat(string) (os.FileInfo, error)
+	Close() error
+}

--- a/internal/mentions/secure_open_supported.go
+++ b/internal/mentions/secure_open_supported.go
@@ -1,0 +1,68 @@
+//go:build unix || windows || wasip1
+
+package mentions
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// openSecureMentionRoot opens path by walking from its filesystem or volume
+// root one descriptor at a time. The lstat/open/stat identity check rejects a
+// component replaced while it is being opened, including the final component
+// of the configured root. Once returned, os.Root performs subsequent path
+// resolution relative to the retained directory descriptor/handle.
+func openSecureMentionRoot(path string) (secureMentionRoot, error) {
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return nil, errors.New("secure mention root is not absolute")
+	}
+
+	volume := filepath.VolumeName(path)
+	anchorPath := string(filepath.Separator)
+	if volume != "" {
+		anchorPath = volume + string(filepath.Separator)
+	}
+	relative, err := filepath.Rel(anchorPath, path)
+	if err != nil || !filepath.IsLocal(relative) {
+		return nil, errors.New("secure mention root is outside its volume anchor")
+	}
+
+	current, err := os.OpenRoot(anchorPath)
+	if err != nil {
+		return nil, fmt.Errorf("open mention root anchor: %w", err)
+	}
+	if relative == "." {
+		return current, nil
+	}
+
+	components := strings.Split(relative, string(filepath.Separator))
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." {
+			current.Close()
+			return nil, errors.New("invalid secure mention root component")
+		}
+		expected, err := current.Lstat(component)
+		if err != nil || expected.Mode()&os.ModeSymlink != 0 || !expected.IsDir() {
+			current.Close()
+			return nil, errors.New("mention root component is not a stable directory")
+		}
+		next, err := current.OpenRoot(component)
+		if err != nil {
+			current.Close()
+			return nil, fmt.Errorf("open mention root component: %w", err)
+		}
+		actual, statErr := next.Stat(".")
+		if statErr != nil || !os.SameFile(expected, actual) {
+			next.Close()
+			current.Close()
+			return nil, errors.New("mention root component changed while opening")
+		}
+		current.Close()
+		current = next
+	}
+	return current, nil
+}

--- a/internal/mentions/secure_open_unsupported.go
+++ b/internal/mentions/secure_open_unsupported.go
@@ -1,0 +1,9 @@
+//go:build (js && wasm) || plan9
+
+package mentions
+
+func openSecureMentionRoot(string) (secureMentionRoot, error) {
+	// os.Root is pathname-based on these platforms and documents TOCTOU or
+	// rename limitations, so eager mention attachment reads fail closed.
+	return nil, errSecureOpenUnavailable
+}

--- a/internal/mentions/types.go
+++ b/internal/mentions/types.go
@@ -1,0 +1,82 @@
+package mentions
+
+import "time"
+
+// Kind identifies a filesystem mention target.
+type Kind uint8
+
+const (
+	KindFile Kind = iota
+	KindDirectory
+)
+
+// Candidate is an immutable project-relative index entry. LowerPath and
+// ASCII are precomputed so queries do not lowercase or rescan the corpus.
+type Candidate struct {
+	Path       string
+	LowerPath  string
+	BaseOffset uint32
+	ASCII      [4]uint64
+	Kind       Kind
+}
+
+func (c Candidate) BaseName() string {
+	if int(c.BaseOffset) >= len(c.Path) {
+		return c.Path
+	}
+	return c.Path[c.BaseOffset:]
+}
+
+// Match is a ranked candidate and byte positions in its relative path.
+type Match struct {
+	Candidate int
+	Score     int
+	Positions []int
+}
+
+// Snapshot is an immutable index for one root.
+type Snapshot struct {
+	Root       string
+	Candidates []Candidate
+	BuiltAt    time.Time
+	Truncated  bool
+	Source     string
+	PathBytes  int64
+}
+
+// BuildOptions bounds discovery work and memory.
+type BuildOptions struct {
+	MaxCandidates int
+	MaxPathBytes  int64
+}
+
+func DefaultBuildOptions() BuildOptions {
+	return BuildOptions{MaxCandidates: 250_000, MaxPathBytes: 64 << 20}
+}
+
+// ActiveToken describes a cursor-local @ token in valid UTF-8 composer text.
+type ActiveToken struct {
+	Start  int
+	End    int
+	Query  string
+	Quoted bool
+}
+
+// SubmittedMention is an ordinary textual path mention discovered when a
+// prompt is submitted. Line numbers are one-based; zero means no range.
+type SubmittedMention struct {
+	Path      string
+	LineStart int
+	LineEnd   int
+}
+
+// EagerAttachment is bounded context loaded for one submitted textual mention.
+type EagerAttachment struct {
+	Path       string
+	Kind       Kind
+	Content    string
+	LineStart  int
+	LineEnd    int
+	Truncated  bool
+	EntryCount int
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -426,6 +426,23 @@ func (m *ToolManager) BaseDir() string {
 	return m.Registry.BaseDir()
 }
 
+// IsReadPathApproved reports whether path may be read without prompting. It is
+// intentionally read-only: it neither invokes approval UI nor adds permissions.
+func (m *ToolManager) IsReadPathApproved(path string) bool {
+	if m == nil || m.ApprovalMgr == nil {
+		return false
+	}
+	if m.ApprovalMgr.YoloEnabled() {
+		return true
+	}
+	absPath, err := canonicalApprovalPath(path, false)
+	if err != nil {
+		return false
+	}
+	outcome, decided, err := m.ApprovalMgr.checkPathApprovalNoPrompt(ReadFileToolName, absPath, absPath, false)
+	return err == nil && decided && outcome != Cancel
+}
+
 // SetupEngine registers tools with the engine.
 func (m *ToolManager) SetupEngine(engine *llm.Engine) {
 	m.Registry.RegisterWithEngine(engine)

--- a/internal/tools/registry_mention_test.go
+++ b/internal/tools/registry_mention_test.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestToolManagerIsReadPathApprovedDoesNotPromptOrMutatePermissions(t *testing.T) {
+	root := t.TempDir()
+	allowedPath := filepath.Join(root, "allowed.txt")
+	if err := os.WriteFile(allowedPath, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("no"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	permissions := NewToolPermissions()
+	if err := permissions.AddReadDir(root); err != nil {
+		t.Fatal(err)
+	}
+	beforeRead, beforeWrite, beforeShell := permissions.Snapshot()
+	approval := NewApprovalManager(permissions)
+	prompted := false
+	approval.PromptUIFunc = func(string, bool, bool, string) (ApprovalResult, error) {
+		prompted = true
+		return ApprovalResult{}, nil
+	}
+	manager := &ToolManager{ApprovalMgr: approval}
+
+	if !manager.IsReadPathApproved(allowedPath) {
+		t.Fatal("pre-approved path was denied")
+	}
+	if manager.IsReadPathApproved(outside) {
+		t.Fatal("unapproved path was allowed")
+	}
+	afterRead, afterWrite, afterShell := permissions.Snapshot()
+	if prompted || !reflect.DeepEqual(beforeRead, afterRead) || !reflect.DeepEqual(beforeWrite, afterWrite) || !reflect.DeepEqual(beforeShell, afterShell) {
+		t.Fatalf("non-interactive check prompted=%v or mutated permissions: before=%v/%v/%v after=%v/%v/%v", prompted, beforeRead, beforeWrite, beforeShell, afterRead, afterWrite, afterShell)
+	}
+}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -22,6 +22,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
+	"github.com/samsaffron/term-llm/internal/mentions"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/skills"
@@ -228,14 +229,27 @@ type Model struct {
 	handoverToolDoneCh           chan<- bool            // Signal back to initiate_handover tool
 
 	// Pending message context
-	files                   []FileAttachment // Attached files for next message
-	images                  []ImageAttachment
-	selectedImage           int            // -1 means no image chip selected
-	pasteChunks             map[int]string // Collapsed paste placeholders → actual content
-	pasteSeq                int            // Incrementing ID for paste placeholders
-	searchEnabled           bool           // Web search toggle
-	fastMode                bool           // Effective ChatGPT/OpenAI fast service-tier state shown in the footer
-	fastProviderDefault     bool           // Provider config requests fast by default; inherited unless overridden in-session
+	files         []FileAttachment // Attached files for next message
+	images        []ImageAttachment
+	selectedImage int            // -1 means no image chip selected
+	pasteChunks   map[int]string // Collapsed paste placeholders → actual content
+	pasteSeq      int            // Incrementing ID for paste placeholders
+
+	// Project @ autocomplete. The index and queries are background/cancellable;
+	// selections remain ordinary text and are resolved only when submitted.
+	mentionEnabled         bool
+	mentionRoot            string
+	mentionIndex           *mentions.Snapshot
+	mentionIndexGeneration uint64
+	mentionBuildCancel     context.CancelFunc
+	mentionQueryRequest    uint64
+	mentionQueryCtx        context.Context
+	mentionQueryCancel     context.CancelFunc
+	mentionPopup           mentionPopupModel
+
+	searchEnabled           bool // Web search toggle
+	fastMode                bool // Effective ChatGPT/OpenAI fast service-tier state shown in the footer
+	fastProviderDefault     bool // Provider config requests fast by default; inherited unless overridden in-session
 	fastOverride            serviceTierOverride
 	fastMetadataLoaded      bool // ChatGPT model metadata has been loaded
 	fastMetadataStale       bool // Loaded metadata came from stale cache and should refresh in background
@@ -980,6 +994,7 @@ func NewWithFastProviderAndApproval(cfg *config.Config, provider llm.Provider, f
 	}
 	model.configureImageRenderer()
 	model.configureContextManagementForSession()
+	model.initializeMentions()
 	return model
 }
 
@@ -1596,6 +1611,9 @@ func (m *Model) Init() tea.Cmd {
 	if cmd := terminalWorkingDirectoryCmd(m.effectiveWorkingDir()); cmd != nil {
 		baseCmds = append(baseCmds, cmd)
 	}
+	if cmd := m.startMentionIndex(); cmd != nil {
+		baseCmds = append(baseCmds, cmd)
+	}
 
 	// Set markdown renderer for chat renderer
 	if m.chatRenderer != nil {
@@ -1788,6 +1806,9 @@ func isParentChatMessage(msg tea.Msg) bool {
 		ApprovalRequestMsg,
 		AskUserRequestMsg,
 		HandoverRequestMsg,
+		mentionIndexReadyMsg,
+		mentionDebounceMsg,
+		mentionMatchesMsg,
 		SubagentProgressMsg:
 		return true
 	default:
@@ -1881,6 +1902,9 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		// session-counter mutations only on Bubble Tea's Update goroutine.
 		m.recordCompactionUsage(context.Background(), usageMsg.sessionID, usageMsg.model, usageMsg.usage)
 		return m, nil
+	}
+	if handled, mentionCmd := m.handleMentionMessage(msg); handled {
+		return m, mentionCmd
 	}
 	if handled, cmd := m.handleTerminalTitleProviderMsg(msg); handled {
 		return m, cmd

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -952,11 +952,12 @@ func (m *Model) showHelpModal() (tea.Model, tea.Cmd) {
 		{
 			title: "Pickers and completions",
 			rows: [][2]string{
+				{"@query", "Find a project file or directory"},
 				{"Up/Down or Ctrl+P/Ctrl+N", "Move selection"},
-				{"Enter", "Execute command / choose model / toggle MCP server"},
-				{"Tab", "Fill selected completion or choose selected model"},
+				{"Enter", "Select mention / execute command / choose item"},
+				{"Tab", "Select mention or fill selected completion"},
 				{"Backspace", "Edit filter"},
-				{"Esc or Ctrl+C", "Close picker"},
+				{"Esc", "Close picker"},
 			},
 		},
 	}

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -633,10 +633,14 @@ func TestCmdHelpOpensModal(t *testing.T) {
 		"Ctrl+J / Alt+Enter / Shift+Enter",
 		"Pickers and completions",
 		"Ctrl+T",
+		"Close picker",
 	} {
 		if !strings.Contains(rm.dialog.Content(), want) {
 			t.Fatalf("help content missing %q: %q", want, rm.dialog.Content())
 		}
+	}
+	if strings.Contains(rm.dialog.Content(), "Esc or Ctrl+C") {
+		t.Fatalf("help incorrectly advertises Ctrl+C as picker close: %q", rm.dialog.Content())
 	}
 }
 

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -685,6 +685,10 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if handled, cmd := m.handleMentionPopupKey(msg); handled {
+		return m, cmd
+	}
+
 	// Handle completions if visible
 	if m.completions.IsVisible() {
 		switch {
@@ -919,7 +923,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keyMap.Newline) || key.Matches(msg, m.keyMap.NewlineAlt) {
 		m.textarea.InsertString("\n")
 		m.updateTextareaHeight()
-		return m, nil
+		return m, m.updateMentionQuery()
 	}
 
 	// Streaming-local shortcuts that affect the interjection composer or queue
@@ -966,13 +970,17 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			content := m.expandPastePlaceholders(raw)
 			parts := m.imagePartList()
+			hasImages := len(parts) > 0
+			if eagerContext, _ := m.eagerMentionContext(content); eagerContext != "" {
+				parts = append(parts, llm.Part{Type: llm.PartFile, Text: eagerContext})
+			}
 			if content == "" && len(parts) == 0 {
 				m.phase = "Type to interject, attach an image, or press Esc to cancel"
 				return m, nil
 			}
 
 			interjectionID := m.nextPendingInterjectionID()
-			if action, ok := llm.ClassifyInterruptImmediate(content); ok && len(parts) == 0 {
+			if action, ok := llm.ClassifyInterruptImmediate(content); ok && !hasImages {
 				m.applyInterruptActionWithParts(interjectionID, content, parts, action)
 				return m, nil
 			}
@@ -985,10 +993,13 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		// Allow textarea to receive input
 		old := m.textarea.Value()
+		oldCursor := textareaCursorByteOffset(old, m.textarea.Line(), m.textarea.Column())
 		var cmd tea.Cmd
 		m.textarea, cmd = m.textarea.Update(msg)
 		m.updateTextareaHeight()
-		if newVal := m.textarea.Value(); newVal != old {
+		newVal := m.textarea.Value()
+		newCursor := textareaCursorByteOffset(newVal, m.textarea.Line(), m.textarea.Column())
+		if newVal != old {
 			m.resetPromptHistoryIfEdited()
 			if strings.HasPrefix(newVal, "/") {
 				if !m.completions.IsVisible() {
@@ -998,6 +1009,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			} else if m.completions.IsVisible() {
 				m.completions.Hide()
 			}
+		}
+		if newVal != old || newCursor != oldCursor {
+			return m, tea.Batch(cmd, m.updateMentionQuery())
 		}
 		return m, cmd
 	}
@@ -1011,6 +1025,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Handle model picker (Ctrl+L)
 	if key.Matches(msg, m.keyMap.SwitchModel) {
+		m.hideMentionPopup()
 		history, _ := config.LoadModelHistory()
 		m.dialog.ShowModelPicker(m.providerKey+":"+m.modelName, GetAvailableProviders(m.config), config.ModelHistoryOrder(history))
 		return m, nil
@@ -1028,6 +1043,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Handle MCP picker (Ctrl+T)
 	if key.Matches(msg, m.keyMap.MCPPicker) {
+		m.hideMentionPopup()
 		if m.mcpManager == nil {
 			return m.showSystemMessage("MCP not initialized.")
 		}
@@ -1181,20 +1197,26 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Update textarea for other keys (skip during streaming - no text input needed)
 	if !m.streaming {
 		old := m.textarea.Value()
+		oldCursor := textareaCursorByteOffset(old, m.textarea.Line(), m.textarea.Column())
 		var cmd tea.Cmd
 		m.textarea, cmd = m.textarea.Update(msg)
+		newVal := m.textarea.Value()
+		newCursor := textareaCursorByteOffset(newVal, m.textarea.Line(), m.textarea.Column())
 		// Clear selection when user starts typing
-		if m.selection.Active && m.textarea.Value() != old {
+		if m.selection.Active && newVal != old {
 			m.selection = Selection{}
 		}
-		if m.textarea.Value() != old {
+		if newVal != old {
 			m.resetPromptHistoryIfEdited()
 		}
 		m.updateTextareaHeight()
 		// Show argument completions for commands that support them
 		// (e.g., /handover @<partial> triggers agent name completions)
-		if newVal := m.textarea.Value(); newVal != old && strings.HasPrefix(newVal, "/") && !m.completions.IsVisible() {
+		if newVal != old && strings.HasPrefix(newVal, "/") && !m.completions.IsVisible() {
 			m.updateCompletions()
+		}
+		if newVal != old || newCursor != oldCursor {
+			return m, tea.Batch(cmd, m.updateMentionQuery())
 		}
 		return m, cmd
 	}
@@ -1280,6 +1302,7 @@ func (m *Model) handlePasteMsg(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 	}
 	if newVal := m.textarea.Value(); newVal != old {
 		m.reflowTextarea()
+		newVal = m.textarea.Value()
 		if strings.HasPrefix(newVal, "/") {
 			if !m.completions.IsVisible() {
 				m.completions.Show()
@@ -1290,7 +1313,7 @@ func (m *Model) handlePasteMsg(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	m.updateTextareaHeight()
-	return m, nil
+	return m, m.updateMentionQuery()
 }
 
 func shouldCollapsePaste(text string) bool {
@@ -1587,10 +1610,16 @@ func (m *Model) applyInterruptActionWithParts(interjectionID, content string, pa
 		}
 	case llm.InterruptInterject:
 		m.setPendingInterjection(interjectionID, summary, "interject")
-		msg := llm.Message{Role: llm.RoleUser, Parts: append([]llm.Part(nil), parts...)}
+		leadingImages := 0
+		for leadingImages < len(parts) && parts[leadingImages].Type == llm.PartImage {
+			leadingImages++
+		}
+		msg := llm.Message{Role: llm.RoleUser, Parts: make([]llm.Part, 0, len(parts)+1)}
+		msg.Parts = append(msg.Parts, parts[:leadingImages]...)
 		if content != "" {
 			msg.Parts = append(msg.Parts, llm.Part{Type: llm.PartText, Text: content})
 		}
+		msg.Parts = append(msg.Parts, parts[leadingImages:]...)
 		if len(msg.Parts) == 0 {
 			msg = llm.UserText(content)
 		}

--- a/internal/tui/chat/mentions.go
+++ b/internal/tui/chat/mentions.go
@@ -1,0 +1,520 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/samsaffron/term-llm/internal/mentions"
+)
+
+const (
+	mentionQueryDebounce = 30 * time.Millisecond
+	mentionMatchLimit    = 50
+	mentionDisplayLimit  = 8
+)
+
+type mentionPopupModel struct {
+	visible        bool
+	token          mentions.ActiveToken
+	matches        []mentions.Match
+	matchesRoot    string
+	matchesToken   mentions.ActiveToken
+	matchesCursor  int
+	matchesGen     uint64
+	matchesRequest uint64
+	selected       int
+	indexing       bool
+	refreshing     bool
+	searching      bool
+	truncated      bool
+	err            error
+}
+
+func (p *mentionPopupModel) IsVisible() bool { return p != nil && p.visible }
+func (p *mentionPopupModel) clearMatches() {
+	if p == nil {
+		return
+	}
+	p.matches = nil
+	p.matchesRoot = ""
+	p.matchesToken = mentions.ActiveToken{}
+	p.matchesCursor = 0
+	p.matchesGen = 0
+	p.matchesRequest = 0
+	p.selected = 0
+}
+func (p *mentionPopupModel) Hide() {
+	if p == nil {
+		return
+	}
+	p.visible = false
+	p.clearMatches()
+	p.err = nil
+}
+
+type mentionIndexReadyMsg struct {
+	root       string
+	generation uint64
+	snapshot   *mentions.Snapshot
+	err        error
+}
+type mentionDebounceMsg struct {
+	root                string
+	generation, request uint64
+	token               mentions.ActiveToken
+	cursor              int
+}
+type mentionMatchesMsg struct {
+	root                string
+	generation, request uint64
+	token               mentions.ActiveToken
+	cursor              int
+	matches             []mentions.Match
+}
+
+func mentionsEnabledFromEnv() bool {
+	value := strings.TrimSpace(os.Getenv("TERM_LLM_AT_MENTIONS"))
+	return value != "0" && !strings.EqualFold(value, "false")
+}
+
+func (m *Model) initializeMentions() {
+	m.mentionEnabled = mentionsEnabledFromEnv()
+	if !m.mentionEnabled {
+		return
+	}
+	root, err := mentionAbsoluteRoot(m.effectiveWorkingDir())
+	if err != nil {
+		m.mentionEnabled = false
+		m.mentionPopup.err = err
+		return
+	}
+	m.mentionRoot = root
+}
+
+func mentionAbsoluteRoot(root string) (string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", errors.New("project directory is unavailable")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve project directory: %w", err)
+	}
+	return filepath.Clean(abs), nil
+}
+
+func (m *Model) startMentionIndex() tea.Cmd {
+	if m == nil || !m.mentionEnabled {
+		return nil
+	}
+	if m.mentionBuildCancel != nil {
+		m.mentionBuildCancel()
+	}
+	root, err := mentionAbsoluteRoot(m.effectiveWorkingDir())
+	if err != nil {
+		m.mentionIndexGeneration++
+		generation := m.mentionIndexGeneration
+		m.mentionRoot = ""
+		return func() tea.Msg { return mentionIndexReadyMsg{generation: generation, err: err} }
+	}
+	ctx, cancel := context.WithCancel(m.rootContext())
+	m.mentionBuildCancel = cancel
+	m.mentionIndexGeneration++
+	generation := m.mentionIndexGeneration
+	m.mentionRoot = root
+	m.mentionPopup.indexing = m.mentionIndex == nil
+	m.mentionPopup.refreshing = m.mentionIndex != nil
+	return func() tea.Msg {
+		snapshot, err := mentions.Build(ctx, root, mentions.DefaultBuildOptions())
+		return mentionIndexReadyMsg{root: root, generation: generation, snapshot: snapshot, err: err}
+	}
+}
+
+func (m *Model) handleMentionMessage(msg tea.Msg) (bool, tea.Cmd) {
+	switch msg := msg.(type) {
+	case mentionIndexReadyMsg:
+		if msg.root != m.mentionRoot || msg.generation != m.mentionIndexGeneration {
+			return true, nil
+		}
+		if m.mentionBuildCancel != nil {
+			m.mentionBuildCancel()
+			m.mentionBuildCancel = nil
+		}
+		m.mentionPopup.indexing = false
+		m.mentionPopup.refreshing = false
+		if msg.err != nil {
+			if m.mentionIndex == nil {
+				m.mentionPopup.err = msg.err
+			}
+			return true, nil
+		}
+		m.mentionIndex = msg.snapshot
+		m.mentionPopup.clearMatches()
+		m.mentionPopup.searching = m.mentionPopup.visible
+		m.mentionPopup.truncated = msg.snapshot.Truncated
+		m.mentionPopup.err = nil
+		if m.mentionPopup.visible {
+			return true, m.scheduleMentionQuery(m.mentionPopup.token)
+		}
+		return true, nil
+	case mentionDebounceMsg:
+		if !m.mentionQueryCurrent(msg.root, msg.generation, msg.request, msg.token, msg.cursor) || m.mentionIndex == nil {
+			return true, nil
+		}
+		snapshot := m.mentionIndex
+		ctx := m.mentionQueryCtx
+		return true, func() tea.Msg {
+			matches := snapshot.Search(ctx, msg.token.Query, mentionMatchLimit)
+			return mentionMatchesMsg{root: msg.root, generation: msg.generation, request: msg.request, token: msg.token, cursor: msg.cursor, matches: matches}
+		}
+	case mentionMatchesMsg:
+		if !m.mentionQueryCurrent(msg.root, msg.generation, msg.request, msg.token, msg.cursor) {
+			return true, nil
+		}
+		if m.mentionQueryCancel != nil {
+			m.mentionQueryCancel()
+			m.mentionQueryCancel = nil
+		}
+		m.mentionPopup.searching = false
+		m.mentionPopup.matches = msg.matches
+		m.mentionPopup.matchesRoot = msg.root
+		m.mentionPopup.matchesToken = msg.token
+		m.mentionPopup.matchesCursor = msg.cursor
+		m.mentionPopup.matchesGen = msg.generation
+		m.mentionPopup.matchesRequest = msg.request
+		if m.mentionPopup.selected >= len(msg.matches) {
+			m.mentionPopup.selected = max(0, len(msg.matches)-1)
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (m *Model) mentionQueryCurrent(root string, generation, request uint64, token mentions.ActiveToken, cursor int) bool {
+	if !m.mentionPopup.visible || root != m.mentionRoot || generation != m.mentionIndexGeneration || request != m.mentionQueryRequest {
+		return false
+	}
+	currentCursor := textareaCursorByteOffset(m.textarea.Value(), m.textarea.Line(), m.textarea.Column())
+	current, ok := mentions.ActiveTokenAt(m.textarea.Value(), currentCursor)
+	return ok && current == token && currentCursor == cursor
+}
+
+func (m *Model) updateMentionQuery() tea.Cmd {
+	if m == nil || !m.mentionEnabled || strings.HasPrefix(m.textarea.Value(), "/") || m.dialog.IsOpen() {
+		m.hideMentionPopup()
+		return nil
+	}
+	cursor := textareaCursorByteOffset(m.textarea.Value(), m.textarea.Line(), m.textarea.Column())
+	token, ok := mentions.ActiveTokenAt(m.textarea.Value(), cursor)
+	if !ok {
+		m.hideMentionPopup()
+		return nil
+	}
+	m.completions.Hide()
+	m.mentionPopup.visible = true
+	m.mentionPopup.token = token
+	m.mentionPopup.clearMatches()
+	m.mentionPopup.searching = true
+	m.mentionPopup.indexing = m.mentionIndex == nil
+	var refresh tea.Cmd
+	if m.mentionIndex == nil && m.mentionBuildCancel == nil {
+		refresh = m.startMentionIndex()
+	} else if m.mentionIndex != nil && m.mentionBuildCancel == nil && time.Since(m.mentionIndex.BuiltAt) >= 10*time.Second {
+		refresh = m.startMentionIndex()
+	}
+	return tea.Batch(refresh, m.scheduleMentionQuery(token))
+}
+
+func (m *Model) scheduleMentionQuery(token mentions.ActiveToken) tea.Cmd {
+	if m.mentionQueryCancel != nil {
+		m.mentionQueryCancel()
+	}
+	m.mentionQueryRequest++
+	request := m.mentionQueryRequest
+	ctx, cancel := context.WithCancel(m.rootContext())
+	m.mentionQueryCtx, m.mentionQueryCancel = ctx, cancel
+	root, generation := m.mentionRoot, m.mentionIndexGeneration
+	cursor := textareaCursorByteOffset(m.textarea.Value(), m.textarea.Line(), m.textarea.Column())
+	return func() tea.Msg {
+		timer := time.NewTimer(mentionQueryDebounce)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-timer.C:
+			return mentionDebounceMsg{root: root, generation: generation, request: request, token: token, cursor: cursor}
+		}
+	}
+}
+
+func (m *Model) hideMentionPopup() {
+	m.mentionPopup.Hide()
+	if m.mentionQueryCancel != nil {
+		m.mentionQueryCancel()
+		m.mentionQueryCancel = nil
+	}
+}
+
+func (m *Model) handleMentionPopupKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
+	if !m.mentionPopup.IsVisible() {
+		return false, nil
+	}
+	switch msg.String() {
+	case "esc":
+		m.hideMentionPopup()
+		return true, nil
+	case "up", "ctrl+p":
+		if len(m.mentionPopup.matches) > 0 {
+			m.mentionPopup.selected = (m.mentionPopup.selected - 1 + len(m.mentionPopup.matches)) % len(m.mentionPopup.matches)
+		}
+		return true, nil
+	case "down", "ctrl+n":
+		if len(m.mentionPopup.matches) > 0 {
+			m.mentionPopup.selected = (m.mentionPopup.selected + 1) % len(m.mentionPopup.matches)
+		}
+		return true, nil
+	case "enter":
+		if m.mentionPopup.token.Query == "" {
+			return false, nil
+		}
+		if !m.acceptMentionSelection() {
+			m.hideMentionPopup()
+			return false, nil
+		}
+		return true, nil
+	case "tab":
+		if !m.acceptMentionSelection() {
+			m.hideMentionPopup()
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *Model) acceptMentionSelection() bool {
+	if m.mentionIndex == nil || len(m.mentionPopup.matches) == 0 || m.mentionPopup.selected < 0 || m.mentionPopup.selected >= len(m.mentionPopup.matches) {
+		return false
+	}
+	cursor := textareaCursorByteOffset(m.textarea.Value(), m.textarea.Line(), m.textarea.Column())
+	current, ok := mentions.ActiveTokenAt(m.textarea.Value(), cursor)
+	if !ok || current != m.mentionPopup.token || current != m.mentionPopup.matchesToken ||
+		cursor != m.mentionPopup.matchesCursor || m.mentionPopup.matchesRoot != m.mentionRoot ||
+		m.mentionPopup.matchesGen != m.mentionIndexGeneration || m.mentionPopup.matchesRequest != m.mentionQueryRequest {
+		return false
+	}
+	match := m.mentionPopup.matches[m.mentionPopup.selected]
+	if match.Candidate < 0 || match.Candidate >= len(m.mentionIndex.Candidates) {
+		return false
+	}
+	target := m.mentionIndex.Candidates[match.Candidate]
+	token := current
+	old := m.textarea.Value()
+	if token.Start < 0 || token.End < token.Start || token.End > len(old) || old[token.Start:token.End] == "" {
+		return false
+	}
+	inserted := mentions.InsertText(target.Path, target.Kind == mentions.KindDirectory)
+	suffix := old[token.End:]
+	separator := " "
+	if suffix != "" {
+		if r, _ := utf8.DecodeRuneInString(suffix); unicode.IsSpace(r) {
+			separator = ""
+		}
+	}
+	newValue := old[:token.Start] + inserted + separator + suffix
+	m.textarea.SetValue(newValue)
+	m.moveTextareaCursorToByteOffset(token.Start + len(inserted) + len(separator))
+	m.updateTextareaHeight()
+	m.hideMentionPopup()
+	return true
+}
+
+func (m *Model) renderMentionPopup() string {
+	if !m.mentionPopup.IsVisible() {
+		return ""
+	}
+	theme := m.styles.Theme()
+	muted := lipgloss.NewStyle().Foreground(theme.Muted)
+	selected := lipgloss.NewStyle().Foreground(theme.Primary).Bold(true)
+	width := max(24, min(m.width-2, 88))
+	var rows []string
+	switch {
+	case m.mentionPopup.indexing:
+		rows = append(rows, muted.Render("  indexing project files…"))
+	case m.mentionPopup.err != nil:
+		rows = append(rows, muted.Render("  file index unavailable: "+m.mentionPopup.err.Error()))
+	case len(m.mentionPopup.matches) == 0 && m.mentionPopup.searching:
+		rows = append(rows, muted.Render("  searching project files…"))
+	case len(m.mentionPopup.matches) == 0:
+		rows = append(rows, muted.Render("  no matching project files"))
+	default:
+		start := max(0, m.mentionPopup.selected-mentionDisplayLimit+1)
+		end := min(len(m.mentionPopup.matches), start+mentionDisplayLimit)
+		for i := start; i < end; i++ {
+			match := m.mentionPopup.matches[i]
+			if m.mentionIndex == nil || match.Candidate < 0 || match.Candidate >= len(m.mentionIndex.Candidates) {
+				continue
+			}
+			candidate := m.mentionIndex.Candidates[match.Candidate]
+			glyph := "▱"
+			if candidate.Kind == mentions.KindDirectory {
+				glyph = "▸"
+			}
+			prefix := "  "
+			baseStyle := muted
+			if i == m.mentionPopup.selected {
+				prefix = "› "
+				baseStyle = selected
+			}
+			available := max(4, width-lipgloss.Width(prefix+glyph+" "))
+			path, positions := truncateMentionPath(candidate.Path, match.Positions, available)
+			row := baseStyle.Render(prefix+glyph+" ") + highlightMentionPath(path, positions, baseStyle, selected.Underline(true))
+			rows = append(rows, row)
+		}
+	}
+	status := "↑↓ navigate  enter/tab select  esc close"
+	var states []string
+	if m.mentionPopup.refreshing {
+		states = append(states, "refreshing index")
+	}
+	if m.mentionPopup.searching && len(m.mentionPopup.matches) > 0 {
+		states = append(states, "searching")
+	}
+	if m.mentionPopup.truncated {
+		states = append(states, "index truncated")
+	}
+	if len(states) > 0 {
+		status = strings.Join(states, "  ·  ") + "  ·  " + status
+	}
+	rows = append(rows, muted.Render(truncateMentionRow("  "+status, width)))
+	return lipgloss.NewStyle().Width(width).MaxWidth(width).Border(lipgloss.RoundedBorder()).BorderForeground(theme.Muted).Render(strings.Join(rows, "\n"))
+}
+
+func highlightMentionPath(path string, positions []int, normal, highlight lipgloss.Style) string {
+	hits := make(map[int]bool, len(positions))
+	for _, position := range positions {
+		hits[position] = true
+	}
+	var output, run strings.Builder
+	highlighted := false
+	flush := func() {
+		if run.Len() == 0 {
+			return
+		}
+		style := normal
+		if highlighted {
+			style = highlight
+		}
+		output.WriteString(style.Render(run.String()))
+		run.Reset()
+	}
+	first := true
+	for offset, r := range path {
+		hit := false
+		for i := 0; i < utf8.RuneLen(r); i++ {
+			if hits[offset+i] {
+				hit = true
+				break
+			}
+		}
+		if !first && hit != highlighted {
+			flush()
+		}
+		first = false
+		highlighted = hit
+		run.WriteRune(r)
+	}
+	flush()
+	return output.String()
+}
+
+func truncateMentionPath(value string, positions []int, width int) (string, []int) {
+	if lipgloss.Width(value) <= width {
+		return value, positions
+	}
+	runes := []rune(value)
+	startRune := len(runes)
+	for startRune > 0 && lipgloss.Width("…"+string(runes[startRune-1:])) <= width {
+		startRune--
+	}
+	if startRune < len(runes) && lipgloss.Width("…"+string(runes[startRune:])) > width {
+		startRune++
+	}
+	if startRune >= len(runes) {
+		return "…", nil
+	}
+	byteStart := len(string(runes[:startRune]))
+	display := "…" + string(runes[startRune:])
+	adjusted := make([]int, 0, len(positions))
+	for _, position := range positions {
+		if position >= byteStart {
+			adjusted = append(adjusted, len("…")+position-byteStart)
+		}
+	}
+	return display, adjusted
+}
+
+func truncateMentionRow(value string, width int) string {
+	if lipgloss.Width(value) <= width {
+		return value
+	}
+	runes := []rune(value)
+	for len(runes) > 1 && lipgloss.Width(string(runes))+1 > width {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
+}
+
+func (m *Model) resetMentionsForRoot(dir string) {
+	if !m.mentionEnabled {
+		return
+	}
+	if m.mentionBuildCancel != nil {
+		m.mentionBuildCancel()
+		m.mentionBuildCancel = nil
+	}
+	if m.mentionQueryCancel != nil {
+		m.mentionQueryCancel()
+		m.mentionQueryCancel = nil
+	}
+	m.hideMentionPopup()
+	m.mentionIndex = nil
+	m.mentionRoot = ""
+	m.mentionPopup.indexing = false
+	m.mentionPopup.refreshing = false
+	root, err := mentionAbsoluteRoot(dir)
+	if err != nil {
+		m.mentionEnabled = false
+		m.mentionPopup.err = err
+		return
+	}
+	m.mentionRoot = root
+}
+
+func (m *Model) eagerMentionContext(content string) (string, []string) {
+	root := m.mentionRoot
+	if root == "" {
+		root = m.effectiveWorkingDir()
+	}
+	var allowed func(string) bool
+	if m.toolMgr != nil {
+		allowed = m.toolMgr.IsReadPathApproved
+	}
+	ctx, cancel := context.WithTimeout(m.rootContext(), time.Second)
+	defer cancel()
+	attachments := mentions.LoadEagerAttachments(ctx, root, content, allowed)
+	labels := make([]string, 0, len(attachments))
+	for _, attachment := range attachments {
+		labels = append(labels, attachment.Path)
+	}
+	return mentions.FormatEagerAttachments(attachments), labels
+}

--- a/internal/tui/chat/mentions_test.go
+++ b/internal/tui/chat/mentions_test.go
@@ -1,0 +1,392 @@
+package chat
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/mentions"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+func prepareMentionPopup(m *Model, root, value string, candidate mentions.Candidate) {
+	m.mentionEnabled = true
+	m.mentionRoot = root
+	m.mentionIndexGeneration = 1
+	m.mentionIndex = &mentions.Snapshot{Root: root, Candidates: []mentions.Candidate{candidate}}
+	m.setTextareaValue(value)
+	m.textarea.MoveToEnd()
+	token, ok := mentions.ActiveTokenAt(value, len(value))
+	if !ok {
+		panic("test mention token did not parse")
+	}
+	m.mentionPopup = mentionPopupModel{
+		visible: true, token: token, matches: []mentions.Match{{Candidate: 0}},
+		matchesRoot: root, matchesToken: token, matchesCursor: len(value), matchesGen: 1,
+	}
+}
+
+func TestMentionSelectionInsertsOnlyOrdinaryText(t *testing.T) {
+	m := newTestChatModel(false)
+	root := t.TempDir()
+	prepareMentionPopup(m, root, "review @notes", mentions.Candidate{Path: "docs/design notes.md", Kind: mentions.KindFile})
+	m.acceptMentionSelection()
+	if got := m.textarea.Value(); got != `review @"docs/design notes.md" ` {
+		t.Fatalf("selected text = %q", got)
+	}
+	if m.mentionPopup.IsVisible() {
+		t.Fatal("popup remained visible after selection")
+	}
+
+	prepareMentionPopup(m, root, "list @pkg", mentions.Candidate{Path: "internal/pkg", Kind: mentions.KindDirectory})
+	m.acceptMentionSelection()
+	if got := m.textarea.Value(); got != "list @internal/pkg/ " {
+		t.Fatalf("directory selected text = %q", got)
+	}
+}
+
+func TestManualMentionAttachesAtSubmitAndPreservesUserText(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "manual.txt")
+	if err := os.WriteFile(path, []byte("manual body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestChatModel(false)
+	m.mentionRoot = root
+	content := "please review @manual.txt"
+	_, _ = m.sendMessage(content)
+
+	last := m.messages[len(m.messages)-1]
+	if last.TextContent != content {
+		t.Fatalf("visible TextContent = %q, want %q", last.TextContent, content)
+	}
+	providerText := llm.MessageText(last.ToLLMMessage())
+	if !strings.HasPrefix(providerText, content) || !strings.Contains(providerText, "manual body") {
+		t.Fatalf("provider text = %q", providerText)
+	}
+}
+
+func TestSuccessfulMentionPreservesExplicitFileTextContentConsumers(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "mention.txt"), []byte("mention-only-body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestChatModel(false)
+	m.mentionRoot = root
+	m.files = []FileAttachment{{Name: "explicit.txt", Content: "explicitsearchbody\n"}}
+	content := "review @mention.txt"
+	_, _ = m.sendMessage(content)
+
+	last := m.messages[len(m.messages)-1]
+	wantText := content + "\n\n" + llm.EmbeddedFileIntro + "\n\n" +
+		llm.FormatEmbeddedFileText("explicit.txt", "text/plain", "explicitsearchbody\n")
+	if last.TextContent != wantText {
+		t.Fatalf("TextContent lost explicit /file fallback:\n got: %q\nwant: %q", last.TextContent, wantText)
+	}
+	if strings.Contains(last.TextContent, "mention-only-body") {
+		t.Fatalf("provider-only mention context leaked into TextContent: %q", last.TextContent)
+	}
+	if historyText, ok := memoryPromptText(last); !ok || historyText != wantText {
+		t.Fatalf("prompt history text = %q, %v", historyText, ok)
+	}
+	exported := session.ExportToMarkdown(&session.Session{Name: "mentions"}, []session.Message{last}, session.ExportOptions{})
+	if !strings.Contains(exported, "explicitsearchbody") || strings.Contains(exported, "mention-only-body") {
+		t.Fatalf("export did not preserve established /file representation: %q", exported)
+	}
+	providerText := llm.MessageText(last.ToLLMMessage())
+	if !strings.Contains(providerText, "explicitsearchbody") || !strings.Contains(providerText, "mention-only-body") {
+		t.Fatalf("provider text lost attachment content: %q", providerText)
+	}
+
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	persistedSession := &session.Session{ID: session.NewID(), Provider: "test", Model: "test", Mode: session.ModeChat}
+	if err := store.Create(context.Background(), persistedSession); err != nil {
+		t.Fatal(err)
+	}
+	last.SessionID = persistedSession.ID
+	if err := store.AddMessage(context.Background(), persistedSession.ID, &last); err != nil {
+		t.Fatal(err)
+	}
+	results, err := store.Search(context.Background(), session.SearchOptions{Query: "explicitsearchbody", Limit: 5})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("explicit /file text search results = %#v, err=%v", results, err)
+	}
+	historyStore, ok := store.(session.PromptHistoryStore)
+	if !ok {
+		t.Fatal("store does not support prompt history")
+	}
+	history, err := historyStore.PreviousUserPrompt(context.Background(), "", 0)
+	if err != nil || history == nil || history.Text != wantText {
+		t.Fatalf("persisted prompt history = %#v, err=%v", history, err)
+	}
+}
+
+func TestDuplicateMentionsUseRawTextDeduplicationAndRemainVisible(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "same.txt"), []byte("unique attachment body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestChatModel(false)
+	m.mentionRoot = root
+	content := "compare @same.txt with @./same.txt and @same.txt"
+	_, _ = m.sendMessage(content)
+
+	last := m.messages[len(m.messages)-1]
+	if last.TextContent != content || strings.Count(last.TextContent, "@same.txt") != 2 {
+		t.Fatalf("visible duplicate mentions changed: %q", last.TextContent)
+	}
+	if got := strings.Count(llm.MessageText(last.ToLLMMessage()), "unique attachment body"); got != 2 {
+		t.Fatalf("raw-deduplicated attachment body count = %d", got)
+	}
+}
+
+func TestMentionPopupWithNoSelectionDoesNotConsumeSubmission(t *testing.T) {
+	for _, state := range []struct {
+		name      string
+		indexing  bool
+		searching bool
+	}{
+		{name: "indexing", indexing: true},
+		{name: "searching", searching: true},
+		{name: "no matches"},
+	} {
+		t.Run(state.name, func(t *testing.T) {
+			m := newTestChatModel(false)
+			m.mentionEnabled = true
+			m.mentionRoot = t.TempDir()
+			content := "inspect @missing.txt"
+			m.setTextareaValue(content)
+			m.textarea.MoveToEnd()
+			token, ok := mentions.ActiveTokenAt(content, len(content))
+			if !ok {
+				t.Fatal("manual mention token did not parse")
+			}
+			m.mentionPopup = mentionPopupModel{
+				visible: true, token: token, indexing: state.indexing, searching: state.searching,
+			}
+
+			updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+			m = updated.(*Model)
+			if !m.streaming || len(m.messages) == 0 {
+				t.Fatal("first Enter was consumed instead of submitting")
+			}
+			if got := m.messages[len(m.messages)-1].TextContent; got != content {
+				t.Fatalf("submitted text = %q, want %q", got, content)
+			}
+		})
+	}
+}
+
+func TestMentionMatchesAreInvalidatedWhenQueryChanges(t *testing.T) {
+	m := newTestChatModel(false)
+	prepareMentionPopup(m, t.TempDir(), "review @typ", mentions.Candidate{Path: "types.go", Kind: mentions.KindFile})
+
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	m = updated.(*Model)
+	if len(m.mentionPopup.matches) != 0 {
+		t.Fatalf("stale matches survived query mutation: %#v", m.mentionPopup.matches)
+	}
+	updated, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(*Model)
+	if len(m.messages) == 0 || m.messages[len(m.messages)-1].TextContent != "review @typz" {
+		t.Fatalf("stale result rewrote or blocked submission: %#v", m.messages)
+	}
+}
+
+func TestMentionAcceptanceRevalidatesCursorAndTokenRange(t *testing.T) {
+	m := newTestChatModel(false)
+	value := "review @typ"
+	prepareMentionPopup(m, t.TempDir(), value, mentions.Candidate{Path: "types.go", Kind: mentions.KindFile})
+	m.textarea.MoveToBegin()
+
+	consumed, _ := m.handleMentionPopupKey(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !consumed {
+		t.Fatal("Tab with a stale selection should be contained by the picker")
+	}
+	if got := m.textarea.Value(); got != value {
+		t.Fatalf("stale token range rewrote draft to %q", got)
+	}
+	if m.mentionPopup.IsVisible() {
+		t.Fatal("stale popup remained visible after rejected acceptance")
+	}
+}
+
+func TestMentionPopupHidesAfterMouseCursorMove(t *testing.T) {
+	m := newTestChatModel(false)
+	prepareMentionPopup(m, t.TempDir(), "review @typ", mentions.Candidate{Path: "types.go", Kind: mentions.KindFile})
+	_ = m.View()
+
+	_, _ = m.Update(tea.MouseClickMsg{
+		X:      m.textareaLeftX + m.textareaPromptWidth,
+		Y:      m.textareaTopY,
+		Button: tea.MouseLeft,
+	})
+	if m.mentionPopup.IsVisible() {
+		t.Fatal("mouse cursor movement left stale mention popup visible")
+	}
+}
+
+func TestMentionAcceptanceRejectsStaleIndexGeneration(t *testing.T) {
+	m := newTestChatModel(false)
+	value := "review @typ"
+	prepareMentionPopup(m, t.TempDir(), value, mentions.Candidate{Path: "types.go", Kind: mentions.KindFile})
+	m.mentionIndexGeneration++
+
+	consumed, _ := m.handleMentionPopupKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if consumed {
+		t.Fatal("Enter consumed submission for a stale index selection")
+	}
+	if got := m.textarea.Value(); got != value {
+		t.Fatalf("stale index selection rewrote draft to %q", got)
+	}
+}
+
+func TestMentionPopupRefreshesAfterNewline(t *testing.T) {
+	m := newTestChatModel(false)
+	prepareMentionPopup(m, t.TempDir(), "review @typ", mentions.Candidate{Path: "types.go", Kind: mentions.KindFile})
+
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift})
+	m = updated.(*Model)
+	if got := m.textarea.Value(); got != "review @typ\n" {
+		t.Fatalf("newline value = %q", got)
+	}
+	if m.mentionPopup.IsVisible() {
+		t.Fatal("newline left a stale mention popup visible")
+	}
+}
+
+func TestFailedMentionAttachmentStillSends(t *testing.T) {
+	m := newTestChatModel(false)
+	m.mentionRoot = t.TempDir()
+	content := "inspect @missing.txt anyway"
+	_, _ = m.sendMessage(content)
+
+	if !m.streaming || len(m.messages) == 0 {
+		t.Fatal("failed mention blocked submission")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.TextContent != content || llm.MessageText(last.ToLLMMessage()) != content {
+		t.Fatalf("failed mention message = %#v", last)
+	}
+}
+
+func TestDeniedMentionDoesNotPromptOrBlockSending(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "denied.txt"), []byte("do not attach"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	approval := tools.NewApprovalManager(tools.NewToolPermissions())
+	prompted := false
+	approval.PromptUIFunc = func(string, bool, bool, string) (tools.ApprovalResult, error) {
+		prompted = true
+		return tools.ApprovalResult{}, nil
+	}
+	m := newTestChatModel(false)
+	m.mentionRoot = root
+	m.toolMgr = &tools.ToolManager{ApprovalMgr: approval}
+	content := "inspect @denied.txt"
+	_, _ = m.sendMessage(content)
+
+	last := m.messages[len(m.messages)-1]
+	if prompted || last.TextContent != content || strings.Contains(llm.MessageText(last.ToLLMMessage()), "do not attach") {
+		t.Fatalf("denied mention prompted=%v message=%#v", prompted, last)
+	}
+}
+
+func TestStreamingInterjectionGetsSubmitTimeMentionContext(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.txt"), []byte("interjection attachment"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestChatModel(false)
+	m.mentionRoot = root
+	m.streaming = true
+	m.fastProvider = nil
+	m.setTextareaValue("also inspect @note.txt")
+
+	_, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	queued := m.engine.ListPendingInterjections()
+	if len(queued) != 1 {
+		t.Fatalf("queued interjections = %#v", queued)
+	}
+	parts := queued[0].Message.Parts
+	if len(parts) != 2 || parts[0].Type != llm.PartText || parts[1].Type != llm.PartFile {
+		t.Fatalf("queued part order = %#v, want original text before mention context", parts)
+	}
+	if parts[0].Text != "also inspect @note.txt" || !strings.Contains(parts[1].Text, "interjection attachment") {
+		t.Fatalf("queued mention parts = %#v", parts)
+	}
+	text := llm.MessageText(queued[0].Message)
+	if !strings.Contains(text, "also inspect @note.txt") || !strings.Contains(text, "interjection attachment") {
+		t.Fatalf("queued mention context = %q", text)
+	}
+}
+
+func TestMentionPopupRendersInlineAndAltScreen(t *testing.T) {
+	for _, alt := range []bool{false, true} {
+		m := newTestChatModel(alt)
+		m.width, m.height = 80, 24
+		prepareMentionPopup(m, t.TempDir(), "review @typ", mentions.Candidate{Path: "internal/llm/types.go", Kind: mentions.KindFile})
+		content := ui.StripANSI(m.View().Content)
+		if !strings.Contains(content, "internal/llm/types.go") || !strings.Contains(content, "enter/tab select") {
+			t.Fatalf("alt=%v popup missing from frame: %q", alt, content)
+		}
+	}
+}
+
+func TestMentionQueryCancellationAndRootReset(t *testing.T) {
+	m := newTestChatModel(false)
+	root := t.TempDir()
+	prepareMentionPopup(m, root, "review @typ", mentions.Candidate{Path: "types.go", Kind: mentions.KindFile})
+	cmd := m.scheduleMentionQuery(m.mentionPopup.token)
+	msg := cmd()
+	m.mentionQueryRequest++
+	if handled, next := m.handleMentionMessage(msg); !handled || next != nil {
+		t.Fatalf("stale debounce handled=%v next=%v", handled, next)
+	}
+
+	newRoot := t.TempDir()
+	m.resetMentionsForRoot(newRoot)
+	m.setTextareaValue("review @a")
+	m.textarea.MoveToEnd()
+	if cmd := m.updateMentionQuery(); cmd == nil || !m.mentionPopup.indexing || m.mentionIndex != nil {
+		t.Fatalf("root reset did not schedule fresh index: popup=%#v index=%#v", m.mentionPopup, m.mentionIndex)
+	}
+}
+
+func TestBareMentionEnterDoesNotRewriteDraft(t *testing.T) {
+	m := newTestChatModel(false)
+	m.mentionEnabled = true
+	m.mentionIndex = &mentions.Snapshot{Candidates: []mentions.Candidate{{Path: "a.go", Kind: mentions.KindFile}}}
+	m.setTextareaValue("ping me @")
+	m.textarea.MoveToEnd()
+	token, ok := mentions.ActiveTokenAt(m.textarea.Value(), len(m.textarea.Value()))
+	if !ok {
+		t.Fatal("bare token did not parse")
+	}
+	m.mentionPopup = mentionPopupModel{visible: true, token: token, matches: []mentions.Match{{Candidate: 0}}}
+	before := m.textarea.Value()
+	consumed, cmd := m.handleMentionPopupKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if consumed || cmd != nil || m.textarea.Value() != before {
+		t.Fatalf("bare @ Enter consumed=%v value=%q", consumed, m.textarea.Value())
+	}
+}
+
+func TestTruncateMentionPathKeepsMatchedBasename(t *testing.T) {
+	path := "very/deep/project/path/internal/session/types.go"
+	position := strings.LastIndex(path, "types.go")
+	display, positions := truncateMentionPath(path, []int{position}, 20)
+	if !strings.Contains(display, "types.go") || len(positions) != 1 || positions[0] < 0 || positions[0] >= len(display) {
+		t.Fatalf("truncation display=%q positions=%v", display, positions)
+	}
+}

--- a/internal/tui/chat/mouse.go
+++ b/internal/tui/chat/mouse.go
@@ -91,6 +91,9 @@ func (m *Model) handleTextareaMouse(msg tea.MouseMsg) bool {
 	m.textarea.Focus()
 	m.moveCursorToLine(line)
 	m.textarea.SetCursorColumn(col)
+	if m.mentionPopup.IsVisible() {
+		m.hideMentionPopup()
+	}
 
 	return true
 }

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -132,6 +132,15 @@ func (m *Model) View() (view tea.View) {
 		renderedLines += 2
 	}
 
+	// Project mention popup (if visible)
+	if m.mentionPopup.IsVisible() {
+		popup := m.renderMentionPopup()
+		b.WriteString(popup)
+		renderedLines += lipgloss.Height(popup)
+		b.WriteString("\n")
+		renderedLines++
+	}
+
 	// Completions popup (if visible)
 	if m.completions.IsVisible() {
 		completions := m.completions.View()
@@ -514,7 +523,7 @@ func (m *Model) overlayAltScreenPanels(base string, footer footerLayout) string 
 	// In alt-screen mode Bubble Tea v2 clips anything that extends beyond the
 	// fixed terminal height, so popups must be composited into the existing frame
 	// instead of being appended below it.
-	if !m.completions.IsVisible() && !m.dialog.IsOpen() {
+	if !m.completions.IsVisible() && !m.mentionPopup.IsVisible() && !m.dialog.IsOpen() {
 		return base
 	}
 
@@ -622,6 +631,9 @@ func (m *Model) overlayAltScreenPanels(base string, footer footerLayout) string 
 	}
 	if m.completions.IsVisible() {
 		stackPanel(m.completions.View())
+	}
+	if m.mentionPopup.IsVisible() {
+		stackPanel(m.renderMentionPopup())
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -390,6 +390,11 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 		}
 		fullContent += filesContent.String()
 	}
+	displayText := fullContent
+
+	mentionContext, mentionLabels := m.eagerMentionContext(content)
+	fullContent += mentionContext
+	fileNames = append(fileNames, mentionLabels...)
 
 	imageLabels := m.imageAttachmentLabels()
 	parts := m.imagePartList()
@@ -399,7 +404,6 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 		parts = []llm.Part{{Type: llm.PartText, Text: fullContent}}
 	}
 
-	displayText := fullContent
 	if strings.TrimSpace(displayText) == "" && len(imageLabels) > 0 {
 		displayText = "[" + strings.Join(imageLabels, ", ") + "]"
 	}
@@ -486,6 +490,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	// Clear input and attachments
 	m.resetPromptHistory()
 	m.setTextareaValue("")
+	m.hideMentionPopup()
 	m.files = nil
 	m.images = nil
 	m.selectedImage = -1

--- a/internal/tui/chat/worktree.go
+++ b/internal/tui/chat/worktree.go
@@ -413,6 +413,7 @@ func (m *Model) applyRuntimeDirectory(dir, worktreeDir string) error {
 	m.invalidateHistoryCache()
 	m.resetContextEstimateBaseline(context.Background())
 	m.pendingTerminalDirectory = dir
+	m.resetMentionsForRoot(dir)
 	return nil
 }
 


### PR DESCRIPTION
## What

Adds project-scoped `@` file and directory autocomplete to the chat TUI, following Claude Code 2.1.220's submit-time mention semantics.

Typing `@` fuzzy-finds project paths. Selection inserts ordinary text:

```text
@internal/mentions/parse.go
@"docs/file with spaces.md"
@internal/mentions/
```

The original user text remains intact. At submission, both selected and manually typed valid mentions are parsed and may produce bounded attachment context.

## Claude-compatible attachment behavior

The implementation was checked against the embedded JavaScript extracted from the official `@anthropic-ai/claude-code-linux-x64@2.1.220` npm binary.

- Non-PDF text files whose **total file size is at most 262,144 bytes** are eligible for eager attachment.
- Larger files attach nothing; the textual `@path` remains for the model to inspect with tools.
- A requested `#Lx` or `#Lx-Ly` range does not bypass the total-file-size gate.
- Attached text has a **25,000 locally estimated token** ceiling.
- Token/range overflow retries from the requested offset with at most **2,000 lines**.
- If fallback still exceeds the ceiling, attachment is omitted without blocking the prompt.
- Directories attach a non-recursive names-only listing capped at **1,000 entries**, followed by the exact `… and N more entries` marker when truncated.
- Quoted mentions are extracted before unquoted mentions and duplicate handling follows Claude's raw mention strings.
- Mention start boundaries include whitespace plus `。`, `、`, `？`, and `！`, matching 2.1.220.
- Denied, missing, binary, oversized, unsupported image/PDF, and unsafe paths remain textual references and do not block sending.

Intentional divergences:

- term-llm uses local token estimation rather than Claude's conditional token-count API call.
- Local image mentions and PDF inline/reference handling remain on term-llm's existing explicit attachment paths.
- term-llm confines eager reads to the active project and rejects UNC/network/root escapes rather than adding Claude's trusted-network-directory feature.
- Claude's already-read cache optimization, MCP resource templates, and `inputMentionsOnly` orchestration do not have relevant term-llm equivalents in this V1.

## Discovery and search

- Warm asynchronous project index; no filesystem traversal per keystroke.
- Whole-relative-path fuzzy matching with bounded top-K results.
- Git repositories use tracked plus non-ignored untracked files via `git ls-files`.
- Git discovery fails closed when ignore evaluation fails.
- Plain directories include dotfiles, exclude VCS metadata, and do not follow symlinks.
- Queries are cancellable and guarded by root, index generation, request ID, token text/range, and cursor position.
- Popup works in inline and alt-screen modes with fuzzy highlighting, wrapping navigation, Enter/Tab selection, and Escape dismissal.

## Read safety

Mention reads do not grant permissions or invoke interactive approval UI.

The actual opened descriptor is confined with Go's descriptor-relative `os.Root` implementation. The code securely stats, approves, opens, verifies with `os.SameFile`, and reads/lists from the validated descriptor. Regression tests cover final-component and parent-component symlink replacement after approval.

Unsupported platforms without a secure primitive fail closed.

## Compatibility

- Existing `/file` and image attachment behavior is unchanged.
- Original user text precedes generated mention context, including streaming interjections.
- Oversized or failed mentions never prevent submission.
- Enter falls through to ordinary submission when there is no current valid autocomplete selection.
- No new persistence schema or structured mention identity is introduced.

## Performance

Local i9-14900K matcher benchmarks over 100,000 candidates:

- selective query: ~0.8 ms/op
- one-character query: ~3.0 ms/op
- broad query: ~3.8 ms/op

## Verification

```sh
git diff --check
go test -race ./internal/mentions ./internal/tools ./internal/tui/chat
go test ./...
go build ./...
go vet ./...
```

All pass with isolated HOME/XDG directories.

Additional coverage includes:

- 262,144-byte boundary and 10 MB omission
- giant one-line bounded reads
- ranged mentions on oversized files
- 25,000-token fallback to 2,000 lines
- quoted paths, manual mentions, raw duplicate semantics and CJK boundaries
- 1,000-entry directory cap
- denied/root/symlink/UNC escape paths
- stale autocomplete state and cursor/query changes
- `/file`, images, interjections, history, FTS and export compatibility

Set `TERM_LLM_AT_MENTIONS=0` to disable the feature.
