### PR TITLE
fix: Server shutdown closes file-history DB before active tool recorders finish

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1379,7 +1379,6 @@ func (s *serveServer) Stop(ctx context.Context) error {
 	run(func() error { return s.stopServeSkillRuns(ctx) })
 	run(func() error { return s.server.Shutdown(ctx) })
 
-	closeFileTrackingStore()
 	s.modelsMu.Lock()
 	for _, p := range s.modelsProviders {
 		if cleaner, ok := p.(interface{ CleanupMCP() }); ok {
@@ -1397,6 +1396,13 @@ func (s *serveServer) Stop(ctx context.Context) error {
 	}()
 	select {
 	case <-done:
+		// Shutdown methods may return as soon as ctx expires even though their
+		// owners are still unwinding. Keep the process-wide file history store
+		// open in that case so late tool recorders can finish safely.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		closeFileTrackingStore()
 		close(errCh)
 		for err := range errCh {
 			if err != nil {

--- a/cmd/serve_shutdown_filetrack_test.go
+++ b/cmd/serve_shutdown_filetrack_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/filetrack"
+)
+
+func installShutdownFileTrackStore(t *testing.T) (*filetrack.Store, string) {
+	t.Helper()
+
+	closeFileTrackingStore()
+	path := filepath.Join(t.TempDir(), "file_history.db")
+	store, err := filetrack.Open(path, filetrack.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileTrackMu.Lock()
+	fileTrackStore = store
+	fileTrackKey = "shutdown-test"
+	fileTrackMu.Unlock()
+	t.Cleanup(closeFileTrackingStore)
+	return store, path
+}
+
+func startBlockingFileRecordServer(t *testing.T, store *filetrack.Store) (*serveServer, chan struct{}, <-chan error, <-chan error) {
+	t.Helper()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	recordErr := make(chan error, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		_, err := store.RecordChange(context.WithoutCancel(r.Context()), filetrack.ChangeRecord{
+			SessionID:     "shutdown-session",
+			Path:          "/work/changed.go",
+			BeforeMissing: true,
+			After:         []byte("changed\n"),
+		})
+		recordErr <- err
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ts := httptest.NewUnstartedServer(handler)
+	ts.Start()
+	t.Cleanup(ts.Close)
+
+	requestErr := make(chan error, 1)
+	go func() {
+		resp, err := ts.Client().Get(ts.URL)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			err = resp.Body.Close()
+		}
+		requestErr <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("timed out waiting for file-recording handler")
+	}
+
+	return &serveServer{server: ts.Config, shutdownCh: make(chan struct{})}, release, recordErr, requestErr
+}
+
+func TestServeServerStopKeepsFileTrackingOpenForActiveHandler(t *testing.T) {
+	store, path := installShutdownFileTrackStore(t)
+	srv, release, recordErr, requestErr := startBlockingFileRecordServer(t, store)
+
+	stopErr := make(chan error, 1)
+	go func() { stopErr <- srv.Stop(context.Background()) }()
+
+	select {
+	case <-srv.shutdownCh:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("Stop did not begin shutdown")
+	}
+
+	// Give Stop enough time to reach its wait for the active handler. The file
+	// history store must remain usable until that handler finishes recording.
+	time.Sleep(100 * time.Millisecond)
+	_, usableErr := store.ListSessionChanges(context.Background(), "shutdown-session")
+	close(release)
+
+	if err := <-recordErr; err != nil {
+		t.Fatalf("active handler failed to record during shutdown: %v", err)
+	}
+	if err := <-requestErr; err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if err := <-stopErr; err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if usableErr != nil {
+		t.Fatalf("file tracking closed while handler was active: %v", usableErr)
+	}
+
+	reopened, err := filetrack.Open(path, filetrack.Options{})
+	if err != nil {
+		t.Fatalf("reopen file history: %v", err)
+	}
+	defer reopened.Close()
+	changes, err := reopened.ListSessionChanges(context.Background(), "shutdown-session")
+	if err != nil {
+		t.Fatalf("list persisted changes: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("persisted changes = %d, want 1", len(changes))
+	}
+}
+
+func TestServeServerStopTimeoutLeavesFileTrackingOpen(t *testing.T) {
+	store, _ := installShutdownFileTrackStore(t)
+	srv, release, recordErr, requestErr := startBlockingFileRecordServer(t, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := srv.Stop(ctx); !errors.Is(err, context.Canceled) {
+		close(release)
+		t.Fatalf("Stop error = %v, want context.Canceled", err)
+	}
+
+	// Shutdown returned before the active handler exited, so its retained
+	// recorder must still be able to persist the already-applied mutation.
+	close(release)
+	if err := <-recordErr; err != nil {
+		t.Fatalf("handler failed to record after timed-out Stop: %v", err)
+	}
+	if err := <-requestErr; err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+}


### PR DESCRIPTION
## What changed

- Delay closing the process-wide file-history store until all serve shutdown owners have finished.
- If the shutdown context expires, leave the store open so handlers and response runs that are still unwinding can safely persist late file-change records.
- Add regression coverage for both a successful shutdown with an active recording handler and a timed-out shutdown where the handler records after `Stop` returns.

## Why this is high-value

Write, edit, and shell tools deliberately persist file-history records after filesystem mutation using cancellation-independent contexts. Previously, `serveServer.Stop` closed their shared SQLite store before waiting for active handlers and response runs, so a routine restart could apply a file mutation but silently lose its diff/undo history. The ordering fix preserves recovery data without changing normal request behavior.

## Validation

- `gofmt -w cmd/serve.go cmd/serve_shutdown_filetrack_test.go`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `go test ./cmd -run 'TestServeServerStop(KeepsFileTrackingOpenForActiveHandler|TimeoutLeavesFileTrackingOpen)$' -count=10`
- `git diff --check`
