### PR TITLE
fix(web): cancel abandoned WebRTC requests

### DIFF
--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -445,9 +445,11 @@
   function webrtcFetch(urlStr, options) {
     return new Promise((resolve, reject) => {
       const reqId = crypto.randomUUID();
+      const requestChannel = dataChannel;
       let streamController;
       let resolved = false;
       let gotResponse = false;
+      let requestSent = false, serverDone = false;
       let cleaned = false;
       const reqStart = performance.now();
 
@@ -476,12 +478,21 @@
         if (!resolved) { resolved = true; reject(error); }
       }
 
-      // Central cleanup — idempotent, called from every exit path.
+      // Central cleanup — idempotent, called from every exit path. If the
+      // browser abandons a request while the data channel remains usable, tell
+      // the peer to cancel the matching HTTP request context and release its
+      // concurrency slot.
       function cleanup(reason) {
         if (cleaned) return;
         cleaned = true;
         clearTimeout(responseTimer);
         clearTimeout(streamWatchdogId);
+        if (requestSent && !serverDone && (gotResponse || transportRetrySafe) && requestChannel?.readyState === 'open') {
+          try {
+            requestChannel.send(JSON.stringify({ id: reqId, type: 'cancel' }));
+            diag('↯ cancel ' + method + ' ' + path + ' reason=' + reason);
+          } catch (_e) { /* channel shutdown will cancel the peer context */ }
+        }
         pendingRequests.delete(reqId);
         if (abortHandler) {
           try { options.signal.removeEventListener('abort', abortHandler); } catch (_e) { /* */ }
@@ -620,6 +631,7 @@
           }
         },
         onDone(status) {
+          serverDone = true;
           markGotResponse();
           const latency = (performance.now() - reqStart) | 0;
           diag('← ' + status + ' ' + method + ' ' + path +
@@ -654,7 +666,8 @@
       };
 
       try {
-        dataChannel.send(JSON.stringify(frame));
+        requestChannel.send(JSON.stringify(frame));
+        requestSent = true;
       } catch (_e) {
         diag('send error: ' + (_e && _e.message ? _e.message : String(_e)));
         cleanup('send-error');

--- a/internal/serveui/static/app_webrtc_test.js
+++ b/internal/serveui/static/app_webrtc_test.js
@@ -66,14 +66,16 @@ async function createEnabledHarness() {
     constructor() {
       this.readyState = 'open';
       this.throwOnSend = false;
+      this.sent = [];
       this.onopen = null;
       this.onclose = null;
       this.onerror = null;
       this.onmessage = null;
     }
 
-    send() {
+    send(data) {
       if (this.throwOnSend) throw new Error('simulated channel send failure');
+      this.sent.push(JSON.parse(String(data)));
     }
 
     close() {
@@ -355,6 +357,52 @@ async function testVisibilityChurnDoesNotHammerSignaling() {
   console.log('PASS: visibility churn preserves one armed WebRTC signaling backoff');
 }
 
+async function testCanceledStreamPropagatesRequestCancellation() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const pending = harness.window.fetch('/ui/v1/responses/resp-1/events', { headers: {} });
+  const request = channel.sent.find((frame) => frame.path === '/ui/v1/responses/resp-1/events');
+  if (!request?.id) fail('WebRTC request frame was not sent');
+
+  channel.onmessage({ data: JSON.stringify({ id: request.id, type: 'headers', status: 200, headers: {} }) });
+  const response = await pending;
+  await response.body.cancel();
+
+  const cancels = channel.sent.filter((frame) => frame.type === 'cancel' && frame.id === request.id);
+  if (cancels.length !== 1) {
+    fail(`stream cancellation emitted ${cancels.length} peer cancel frames, want 1`);
+  }
+
+  const completedPending = harness.window.fetch('/ui/v1/sessions/status', { headers: {} });
+  const completedRequest = channel.sent.find((frame) => frame.path === '/ui/v1/sessions/status');
+  channel.onmessage({ data: JSON.stringify({ id: completedRequest.id, type: 'done', status: 200 }) });
+  await completedPending;
+  const completedCancels = channel.sent.filter((frame) => frame.type === 'cancel' && frame.id === completedRequest.id);
+  if (completedCancels.length !== 0) fail('normally completed request emitted a cancellation frame');
+
+  console.log('PASS: abandoning a WebRTC response cancels the matching peer request exactly once');
+}
+
+async function testUnansweredMutationTimeoutDoesNotCancelServerWork() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const pending = harness.window.fetch('/ui/v1/worktrees', { method: 'POST', body: '{}' })
+    .then(() => null, (error) => error);
+  const request = channel.sent.find((frame) => frame.path === '/ui/v1/worktrees');
+  if (!request?.id) fail('WebRTC mutation request frame was not sent');
+
+  await harness.advanceTime(5000);
+  const error = await pending;
+  if (!error || error.name !== 'UnknownMutationOutcomeError') {
+    fail('unanswered mutation did not preserve unknown-outcome semantics');
+  }
+  const cancels = channel.sent.filter((frame) => frame.type === 'cancel' && frame.id === request.id);
+  if (cancels.length !== 0) fail('automatic mutation timeout canceled non-idempotent server work');
+  if (harness.getHTTPSAPICalls() !== 0) fail('unanswered mutation was replayed over HTTPS');
+
+  console.log('PASS: unanswered mutation timeout neither cancels nor replays server work');
+}
+
 (async () => {
   testResponseTimeouts();
   await testChannelCloseSignalsTransportRecoveryOnce();
@@ -363,6 +411,8 @@ async function testVisibilityChurnDoesNotHammerSignaling() {
   await testAmbiguousMutationDrainIsNotReplayed();
   await testTwentySecondFallbackAndPersistentRecovery();
   await testVisibilityChurnDoesNotHammerSignaling();
+  await testCanceledStreamPropagatesRequestCancellation();
+  await testUnansweredMutationTimeoutDoesNotCancelServerWork();
 })().catch((error) => {
   console.error(error);
   process.exit(1);

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -51,10 +51,50 @@ type signalingMsg struct {
 // requestFrame is a data-channel request from the browser.
 type requestFrame struct {
 	ID      string            `json:"id"`
-	Method  string            `json:"method"`
-	Path    string            `json:"path"`
+	Type    string            `json:"type,omitempty"` // empty for requests, "cancel" for request cancellation
+	Method  string            `json:"method,omitempty"`
+	Path    string            `json:"path,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 	Body    string            `json:"body,omitempty"` // base64-encoded UTF-8 bytes
+}
+
+type dataChannelRequests struct {
+	mu      sync.Mutex
+	cancels map[string]context.CancelFunc
+}
+
+func newDataChannelRequests() *dataChannelRequests {
+	return &dataChannelRequests{cancels: make(map[string]context.CancelFunc)}
+}
+
+func (r *dataChannelRequests) add(id string, cancel context.CancelFunc) bool {
+	if id == "" || cancel == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.cancels[id]; exists {
+		return false
+	}
+	r.cancels[id] = cancel
+	return true
+}
+
+func (r *dataChannelRequests) remove(id string) {
+	r.mu.Lock()
+	delete(r.cancels, id)
+	r.mu.Unlock()
+}
+
+func (r *dataChannelRequests) cancel(id string) bool {
+	r.mu.Lock()
+	cancel := r.cancels[id]
+	r.mu.Unlock()
+	if cancel == nil {
+		return false
+	}
+	cancel()
+	return true
 }
 
 // responseFrame is a data-channel response chunk or completion.
@@ -563,6 +603,7 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 		}
 	}
 	requestSlots := make(chan struct{}, maxDataChannelConcurrentRequests)
+	requests := newDataChannelRequests()
 	stop := make(chan struct{})
 	var stopOnce sync.Once
 	stopDataChannel := func() {
@@ -612,6 +653,20 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 			data := make([]byte, n)
 			copy(data, buf[:n])
 			noteActivity()
+
+			var frame requestFrame
+			if err := json.Unmarshal(data, &frame); err != nil || frame.ID == "" {
+				continue
+			}
+			if frame.Type == "cancel" {
+				requests.cancel(frame.ID)
+				continue
+			}
+			if frame.Type != "" {
+				_ = sendDoneFrame(send, frame.ID, http.StatusBadRequest)
+				continue
+			}
+
 			if !tryAcquireDataChannelRequestSlot(dataChannelCtx, stop, requestSlots) {
 				select {
 				case <-dataChannelCtx.Done():
@@ -620,23 +675,33 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 					return
 				default:
 				}
-				if p.isDataChannelCancelRequest(data) {
-					// Cancellation/control requests must not be starved by long-lived
-					// streaming requests occupying every normal slot. Dispatch them
-					// synchronously to keep goroutine usage bounded while still letting
-					// them free a slot held by the stream they cancel.
-					p.dispatchRequest(dataChannelCtx, send, data)
+				if p.isDataChannelResponseCancelRequest(frame) {
+					// Response cancellation/control requests must not be starved by
+					// long-lived streaming requests occupying every normal slot.
+					reqCtx, cancelRequest := context.WithCancel(dataChannelCtx)
+					p.dispatchDecodedRequest(reqCtx, cancelRequest, send, frame)
+					cancelRequest()
 					continue
 				}
-				sendBusyDataChannelRequest(send, data)
+				sendBusyDataChannelRequest(send, frame.ID)
+				continue
+			}
+
+			reqCtx, cancelRequest := context.WithCancel(dataChannelCtx)
+			if !requests.add(frame.ID, cancelRequest) {
+				cancelRequest()
+				<-requestSlots
+				_ = sendDoneFrame(send, frame.ID, http.StatusBadRequest)
 				continue
 			}
 			wg.Add(1)
-			go func(data []byte) {
+			go func(frame requestFrame) {
 				defer wg.Done()
 				defer func() { <-requestSlots }()
-				p.dispatchRequest(dataChannelCtx, send, data)
-			}(data)
+				defer requests.remove(frame.ID)
+				defer cancelRequest()
+				p.dispatchDecodedRequest(reqCtx, cancelRequest, send, frame)
+			}(frame)
 		}
 	}()
 
@@ -697,19 +762,14 @@ func tryAcquireDataChannelRequestSlot(ctx context.Context, stop <-chan struct{},
 	}
 }
 
-func sendBusyDataChannelRequest(send func(string) error, raw []byte) {
-	var frame requestFrame
-	if err := json.Unmarshal(raw, &frame); err != nil || frame.ID == "" {
+func sendBusyDataChannelRequest(send func(string) error, id string) {
+	if id == "" {
 		return
 	}
-	_ = sendDoneFrame(send, frame.ID, http.StatusServiceUnavailable)
+	_ = sendDoneFrame(send, id, http.StatusServiceUnavailable)
 }
 
-func (p *peer) isDataChannelCancelRequest(raw []byte) bool {
-	var frame requestFrame
-	if err := json.Unmarshal(raw, &frame); err != nil {
-		return false
-	}
+func (p *peer) isDataChannelResponseCancelRequest(frame requestFrame) bool {
 	if !strings.EqualFold(frame.Method, http.MethodPost) || !p.validPath(frame.Path) {
 		return false
 	}
@@ -717,11 +777,21 @@ func (p *peer) isDataChannelCancelRequest(raw []byte) bool {
 	return strings.HasPrefix(frame.Path, prefix) && strings.HasSuffix(frame.Path, "/cancel")
 }
 
-// dispatchRequest decodes a requestFrame, validates it, dispatches it to the
-// HTTP handler, and sends response frames via send.
+// dispatchRequest decodes and dispatches a request frame. runDataChannel uses
+// dispatchDecodedRequest directly so it can register cancellation before the
+// handler goroutine starts.
 func (p *peer) dispatchRequest(ctx context.Context, send func(string) error, raw []byte) {
 	var frame requestFrame
 	if err := json.Unmarshal(raw, &frame); err != nil {
+		return
+	}
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	p.dispatchDecodedRequest(reqCtx, cancel, send, frame)
+}
+
+func (p *peer) dispatchDecodedRequest(ctx context.Context, cancel context.CancelFunc, send func(string) error, frame requestFrame) {
+	if frame.ID == "" || frame.Type != "" {
 		return
 	}
 
@@ -747,10 +817,7 @@ func (p *peer) dispatchRequest(ctx context.Context, send func(string) error, raw
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
-	reqCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(reqCtx, frame.Method, "http://localhost"+frame.Path, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, frame.Method, "http://localhost"+frame.Path, bodyReader)
 	if err != nil {
 		_ = sendDoneFrame(send, frame.ID, http.StatusBadRequest)
 		return

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -290,6 +291,128 @@ func TestRunDataChannel_IdleTimeoutClosesTransportToWakeReader(t *testing.T) {
 	}
 }
 
+type queuedReadDataChannel struct {
+	reads     chan []byte
+	writes    chan responseFrame
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func (d *queuedReadDataChannel) ReadDataChannel(buf []byte) (int, bool, error) {
+	select {
+	case data := <-d.reads:
+		copy(buf, data)
+		return len(data), true, nil
+	case <-d.closed:
+		return 0, false, io.EOF
+	}
+}
+
+func (d *queuedReadDataChannel) WriteDataChannel(data []byte, _ bool) (int, error) {
+	var frame responseFrame
+	if err := json.Unmarshal(data, &frame); err == nil {
+		d.writes <- frame
+	}
+	return len(data), nil
+}
+
+func (d *queuedReadDataChannel) Close() error {
+	d.closeOnce.Do(func() { close(d.closed) })
+	return nil
+}
+
+func TestRunDataChannel_CancelFrameReleasesStreamingRequestSlot(t *testing.T) {
+	streamStarted := make(chan struct{}, maxDataChannelConcurrentRequests)
+	streamCanceled := make(chan struct{}, maxDataChannelConcurrentRequests)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ui/v1/stream":
+			streamStarted <- struct{}{}
+			<-r.Context().Done()
+			streamCanceled <- struct{}{}
+		case "/ui/v1/status":
+			_, _ = io.WriteString(w, "ok")
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	p := newTestPeer("/ui", handler)
+	p.cfg.IdleTimeout = time.Minute
+	dc := &queuedReadDataChannel{
+		reads:  make(chan []byte, maxDataChannelConcurrentRequests+4),
+		writes: make(chan responseFrame, 64),
+		closed: make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.runDataChannel(ctx, dc, nil)
+	}()
+
+	for i := 0; i < maxDataChannelConcurrentRequests; i++ {
+		id := fmt.Sprintf("stream-%d", i)
+		dc.reads <- encodeRequest(id, http.MethodGet, "/ui/v1/stream", nil, "")
+	}
+	for i := 0; i < maxDataChannelConcurrentRequests; i++ {
+		select {
+		case <-streamStarted:
+		case <-time.After(time.Second):
+			t.Fatalf("stream request %d did not start", i)
+		}
+	}
+
+	dc.reads <- encodeRequest("status-busy", http.MethodGet, "/ui/v1/status", nil, "")
+	select {
+	case frame := <-dc.writes:
+		if frame.ID != "status-busy" || frame.Type != "done" || frame.Status != http.StatusServiceUnavailable {
+			t.Fatalf("saturated request frame = %#v, want status-busy done/503", frame)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("saturated request did not receive a busy response")
+	}
+
+	cancelFrame, _ := json.Marshal(requestFrame{ID: "stream-0", Type: "cancel"})
+	dc.reads <- cancelFrame
+	select {
+	case <-streamCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("cancel frame did not cancel the stream request context")
+	}
+
+	attempt := 0
+	dc.reads <- encodeRequest("status-after-0", http.MethodGet, "/ui/v1/status", nil, "")
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case frame := <-dc.writes:
+			if !strings.HasPrefix(frame.ID, "status-after-") || frame.Type != "done" {
+				continue
+			}
+			if frame.Status == http.StatusServiceUnavailable && attempt < 10 {
+				// Context cancellation and the handler's deferred slot release are
+				// separate scheduling points. Retry until that release is observable.
+				attempt++
+				time.Sleep(time.Millisecond)
+				id := fmt.Sprintf("status-after-%d", attempt)
+				dc.reads <- encodeRequest(id, http.MethodGet, "/ui/v1/status", nil, "")
+				continue
+			}
+			if frame.Status != http.StatusOK {
+				t.Fatalf("request after cancellation returned %d, want 200", frame.Status)
+			}
+			cancel()
+			<-done
+			return
+		case <-deadline:
+			cancel()
+			<-done
+			t.Fatal("request slot was not reusable after cancellation")
+		}
+	}
+}
+
 type streamingReadDataChannel struct {
 	request       []byte
 	requestOnce   sync.Once
@@ -425,7 +548,6 @@ func TestTryAcquireDataChannelRequestSlot_StopsWhenConnectionClosing(t *testing.
 }
 
 func TestSendBusyDataChannelRequest(t *testing.T) {
-	raw := encodeRequest("busy-1", "GET", "/ui/v1/models", nil, "")
 	var frames []responseFrame
 	sendBusyDataChannelRequest(func(text string) error {
 		var f responseFrame
@@ -434,25 +556,24 @@ func TestSendBusyDataChannelRequest(t *testing.T) {
 		}
 		frames = append(frames, f)
 		return nil
-	}, raw)
+	}, "busy-1")
 	if len(frames) != 1 || frames[0].ID != "busy-1" || frames[0].Type != "done" || frames[0].Status != http.StatusServiceUnavailable {
 		t.Fatalf("busy frames = %#v, want single done/503", frames)
 	}
 }
 
-func TestIsDataChannelCancelRequest(t *testing.T) {
+func TestIsDataChannelResponseCancelRequest(t *testing.T) {
 	p := newTestPeer("/ui", nil)
-	if !p.isDataChannelCancelRequest(encodeRequest("cancel", "POST", "/ui/v1/responses/resp-123/cancel", nil, "")) {
+	if !p.isDataChannelResponseCancelRequest(requestFrame{ID: "cancel", Method: "POST", Path: "/ui/v1/responses/resp-123/cancel"}) {
 		t.Fatal("expected response cancel request to be recognized")
 	}
-	for _, raw := range [][]byte{
-		encodeRequest("get", "GET", "/ui/v1/responses/resp-123/cancel", nil, ""),
-		encodeRequest("event", "GET", "/ui/v1/responses/resp-123/events", nil, ""),
-		encodeRequest("outside", "POST", "/v1/responses/resp-123/cancel", nil, ""),
-		[]byte("not json"),
+	for _, frame := range []requestFrame{
+		{ID: "get", Method: "GET", Path: "/ui/v1/responses/resp-123/cancel"},
+		{ID: "event", Method: "GET", Path: "/ui/v1/responses/resp-123/events"},
+		{ID: "outside", Method: "POST", Path: "/v1/responses/resp-123/cancel"},
 	} {
-		if p.isDataChannelCancelRequest(raw) {
-			t.Fatalf("unexpected cancel recognition for %s", string(raw))
+		if p.isDataChannelResponseCancelRequest(frame) {
+			t.Fatalf("unexpected cancel recognition for %#v", frame)
 		}
 	}
 }


### PR DESCRIPTION
## What

- add a per-request cancellation control frame to the WebRTC data-channel protocol
- register request cancellation before handler dispatch so browser aborts cancel the matching HTTP context
- release bounded request slots when abandoned response-event streams exit
- preserve the existing response-cancel endpoint bypass when all eight normal slots are occupied
- add browser and saturated-channel regression coverage

## Why

Aborted/reconnected WebRTC response streams remained alive on the server because browser `AbortSignal` cleanup only closed the local `ReadableStream`. Eight stale `/responses/:id/events` handlers could therefore consume all eight per-channel request slots. The peer then returned synthetic empty `503`s for healthy endpoints such as `/v1/sessions/status`, while direct HTTPS remained healthy.

The regression test first occupies all **8** slots and confirms a request receives **503**, sends a cancellation frame for one abandoned stream, then confirms the slot becomes reusable and the same request receives **200**.

## Verification

- `go test -race ./internal/webrtc`
- cancellation saturation test under race detector, `-count=50`
- `go test ./internal/serveui`
- `node internal/serveui/static/app_webrtc_test.js` via Node 24.15.0
- `go build ./...`
- `go test ./...` otherwise passed, with two unrelated environment-sensitive skill-discovery failures in `cmd`
