### PR TITLE
feat: add conversation branching

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -140,6 +140,7 @@ Slash commands:
   /inspect     - View conversation/tool details
   /compact     - Compact conversation context
   /resume      - Browse and resume previous sessions
+  /tree        - Browse paths or branch from an earlier message
   /reload      - Re-exec current binary and resume session
   /handover    - Hand conversation to another agent`,
 	RunE:              runChat,
@@ -201,9 +202,10 @@ func runChat(cmd *cobra.Command, args []string) error {
 	resumeID := strings.TrimSpace(chatResume)
 
 	handoverAutoSend := ""
+	relaunchHandoff := chatRelaunchHandoff{}
 	chatHandoverApprovalMode = nil
 	for {
-		nextResumeID, nextAutoSend, err := runChatOnce(ctx, cmd, initialText, cliAgent, resumeRequested, resumeID, handoverAutoSend)
+		nextResumeID, nextAutoSend, err := runChatOnce(ctx, cmd, initialText, cliAgent, resumeRequested, resumeID, handoverAutoSend, &relaunchHandoff)
 		if err != nil {
 			return err
 		}
@@ -233,6 +235,10 @@ type chatProgramInput struct {
 	reader       io.Reader
 	disableInput bool
 	cleanup      func()
+}
+
+type chatRelaunchHandoff struct {
+	branchPrefill string
 }
 
 func buildChatProgramInput(autoSendMode bool) (chatProgramInput, error) {
@@ -275,7 +281,7 @@ func buildChatHandoverApprovalManager(cfg *config.Config, settings SessionSettin
 	return tools.NewApprovalManager(perms), nil
 }
 
-func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string) (string, string, error) {
+func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string, relaunchHandoff *chatRelaunchHandoff) (string, string, error) {
 	cfg, err := loadConfigWithSetup()
 	if err != nil {
 		return "", "", err
@@ -650,6 +656,10 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	if handoverAutoSend != "" {
 		model.SetHandoverAutoSend(handoverAutoSend)
 	}
+	if relaunchHandoff != nil && relaunchHandoff.branchPrefill != "" {
+		model.SetBranchPrefill(relaunchHandoff.branchPrefill)
+		relaunchHandoff.branchPrefill = ""
+	}
 	model.SetSideQuestionProviderFactory(func(providerKey, modelName string) (llm.Provider, error) {
 		if strings.TrimSpace(providerKey) == "" {
 			providerKey = provider.Name()
@@ -858,6 +868,9 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	if m, ok := finalModel.(*chat.Model); ok {
 		nextResumeID = m.RequestedResumeSessionID()
 		nextHandoverAutoSend = m.RequestedHandoverAutoSend()
+		if relaunchHandoff != nil {
+			relaunchHandoff.branchPrefill = m.RequestedBranchPrefill()
+		}
 		// Carry a user-selected mode only into an actual handover. Ordinary /resume
 		// and /new relaunches must resolve the target session/config independently.
 		mode := m.ApprovalModeRequested()

--- a/cmd/serve_branch.go
+++ b/cmd/serve_branch.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func (s *serveServer) handleSessionTree(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if s == nil || s.store == nil {
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session history is unavailable")
+		return
+	}
+	store, ok := s.store.(session.ConversationBranchStore)
+	if !ok {
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", "conversation branching is unavailable")
+		return
+	}
+	tree, err := store.GetBranchTree(r.Context(), sessionID)
+	switch {
+	case errors.Is(err, session.ErrNotFound):
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
+	case errors.Is(err, session.ErrBranchingUnsupported):
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", "conversation branching is unavailable")
+	case err != nil:
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to load conversation tree")
+	default:
+		writeJSON(w, http.StatusOK, tree)
+	}
+}

--- a/cmd/serve_branch_test.go
+++ b/cmd/serve_branch_test.go
@@ -1,0 +1,303 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestResponsesBranchCreatesChildAndContinuesWithoutChangingSource(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sourceID = "serve-branch-source"
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", ProviderKey: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReplaceMessages(ctx, sourceID, []session.Message{
+		*session.NewMessage(sourceID, llm.UserText("first"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("first answer"), -1),
+		*session.NewMessage(sourceID, llm.UserText("second"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("second answer"), -1),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seed, _ := store.GetMessages(ctx, sourceID, 0, 0)
+	anchorID := durableResponseIDForMessageID(seed[1].ID)
+	mutationStore := store.(session.TranscriptUndoRedoStore)
+	state, err := mutationStore.TranscriptMutationState(ctx, sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("alternate answer")
+	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
+		engine := llm.NewEngine(provider, nil)
+		rt := &serveRuntime{provider: provider, engine: engine, store: store, defaultModel: "mock-model"}
+		rt.Touch()
+		return rt, nil
+	})
+	defer manager.Close()
+	srv := &serveServer{sessionMgr: manager, store: store}
+	body := fmt.Sprintf(`{"input":"alternate question","stream":true,"previous_response_id":%q,"branch":true,"expected_rev":%d,"idempotency_key":"branch-request"}`, anchorID, state.Rev)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", sourceID)
+	rr := httptest.NewRecorder()
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	childID := strings.TrimSpace(rr.Header().Get("x-session-id"))
+	if childID == "" || childID == sourceID {
+		t.Fatalf("x-session-id = %q", childID)
+	}
+	sourceMessages, _ := store.GetMessages(ctx, sourceID, 0, 0)
+	if len(sourceMessages) != 4 || sourceMessages[3].TextContent != "second answer" {
+		t.Fatalf("source changed: %#v", sourceMessages)
+	}
+	childMessages, _ := store.GetMessages(ctx, childID, 0, 0)
+	if len(childMessages) != 4 {
+		t.Fatalf("child messages = %#v", childMessages)
+	}
+	if got, want := strings.TrimSpace(rr.Header().Get("x-branch-anchor-id")), durableResponseIDForMessageID(childMessages[1].ID); got != want {
+		t.Fatalf("x-branch-anchor-id = %q, want copied child anchor %q", got, want)
+	}
+	want := []string{"first", "first answer", "alternate question", "alternate answer"}
+	for i := range want {
+		if childMessages[i].TextContent != want[i] {
+			t.Fatalf("child message %d = %q, want %q", i, childMessages[i].TextContent, want[i])
+		}
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider requests = %d, want 1", len(provider.Requests))
+	}
+	providerTexts := make([]string, 0, len(provider.Requests[0].Messages))
+	for _, message := range provider.Requests[0].Messages {
+		if text := strings.TrimSpace(llm.MessageText(message)); text != "" {
+			providerTexts = append(providerTexts, text)
+		}
+	}
+	if got := strings.Join(providerTexts, "|"); got != "first|first answer|alternate question" {
+		t.Fatalf("provider copied prefix/input = %q", got)
+	}
+
+	// Retrying the same streamed branch request must resolve to the same child
+	// and replay the existing response run instead of calling the provider again.
+	retryReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	retryReq.Header.Set("Content-Type", "application/json")
+	retryReq.Header.Set("session_id", sourceID)
+	retryRR := httptest.NewRecorder()
+	srv.handleResponses(retryRR, retryReq)
+	if retryRR.Code != http.StatusOK {
+		t.Fatalf("retry status/body = %d %s", retryRR.Code, retryRR.Body.String())
+	}
+	if retryChildID := strings.TrimSpace(retryRR.Header().Get("x-session-id")); retryChildID != childID {
+		t.Fatalf("retry x-session-id = %q, want %q", retryChildID, childID)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider requests after retry = %d, want 1", len(provider.Requests))
+	}
+	retryMessages, _ := store.GetMessages(ctx, childID, 0, 0)
+	if len(retryMessages) != len(childMessages) {
+		t.Fatalf("child messages after retry = %d, want %d", len(retryMessages), len(childMessages))
+	}
+
+	treeReq := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+childID+"/tree", nil)
+	treeRR := httptest.NewRecorder()
+	srv.handleSessionByID(treeRR, treeReq)
+	if treeRR.Code != http.StatusOK {
+		t.Fatalf("tree status/body = %d %s", treeRR.Code, treeRR.Body.String())
+	}
+	var tree session.BranchTree
+	if err := json.Unmarshal(treeRR.Body.Bytes(), &tree); err != nil {
+		t.Fatal(err)
+	}
+	if tree.RootSessionID != sourceID || tree.ActiveSessionID != childID || len(tree.Nodes) != 2 || tree.PathCount != 2 {
+		t.Fatalf("tree = %#v", tree)
+	}
+}
+
+func TestResponsesBranchKeepsStaleAndHeaderConflictSemantics(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sourceID = "serve-branch-conflict"
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReplaceMessages(ctx, sourceID, []session.Message{
+		*session.NewMessage(sourceID, llm.UserText("one"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("one answer"), -1),
+		*session.NewMessage(sourceID, llm.UserText("two"), -1),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	messages, _ := store.GetMessages(ctx, sourceID, 0, 0)
+	staleID := durableResponseIDForMessageID(messages[0].ID)
+	srv := &serveServer{store: store}
+
+	request := func(body, header string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if header != "" {
+			req.Header.Set("session_id", header)
+		}
+		rr := httptest.NewRecorder()
+		srv.handleResponses(rr, req)
+		return rr
+	}
+	withoutBranch := request(fmt.Sprintf(`{"input":"next","previous_response_id":%q}`, staleID), sourceID)
+	if withoutBranch.Code != http.StatusConflict || !strings.Contains(withoutBranch.Body.String(), "stale") {
+		t.Fatalf("ordinary stale response = %d %s", withoutBranch.Code, withoutBranch.Body.String())
+	}
+	withWrongHeader := request(fmt.Sprintf(`{"input":"next","previous_response_id":%q,"branch":true}`, staleID), "other")
+	if withWrongHeader.Code != http.StatusConflict || !strings.Contains(withWrongHeader.Body.String(), "conflicts") {
+		t.Fatalf("branch header conflict = %d %s", withWrongHeader.Code, withWrongHeader.Body.String())
+	}
+}
+
+func TestResponsesBranchSupportsEmptyAnchorAndRequiresAnchorField(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sourceID = "serve-empty-branch-source"
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", ProviderKey: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddMessage(ctx, sourceID, session.NewMessage(sourceID, llm.UserText("source stays here"), -1)); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := llm.NewMockProvider("mock").AddTextResponse("fresh answer")
+	manager := newServeSessionManager(time.Minute, 10, func(context.Context) (*serveRuntime, error) {
+		runtime := &serveRuntime{provider: provider, engine: llm.NewEngine(provider, nil), store: store, defaultModel: "mock-model"}
+		runtime.Touch()
+		return runtime, nil
+	})
+	defer manager.Close()
+	srv := &serveServer{sessionMgr: manager, store: store}
+
+	missing := httptest.NewRecorder()
+	missingReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"fresh question","stream":true,"branch":true}`))
+	missingReq.Header.Set("Content-Type", "application/json")
+	missingReq.Header.Set("session_id", sourceID)
+	srv.handleResponses(missing, missingReq)
+	if missing.Code != http.StatusBadRequest || !strings.Contains(missing.Body.String(), "requires previous_response_id") {
+		t.Fatalf("missing anchor status/body = %d %s", missing.Code, missing.Body.String())
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"fresh question","stream":true,"previous_response_id":"resp_msg_0","branch":true,"idempotency_key":"empty-branch"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", sourceID)
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("empty branch status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	childID := strings.TrimSpace(rr.Header().Get("x-session-id"))
+	if childID == "" || childID == sourceID {
+		t.Fatalf("empty branch child ID = %q", childID)
+	}
+	if got := rr.Header().Get("x-branch-anchor-id"); got != "" {
+		t.Fatalf("empty branch copied anchor header = %q, want empty", got)
+	}
+	childMessages, err := store.GetMessages(ctx, childID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(childMessages) != 2 || childMessages[0].TextContent != "fresh question" || childMessages[1].TextContent != "fresh answer" {
+		t.Fatalf("empty branch messages = %#v", childMessages)
+	}
+	sourceMessages, _ := store.GetMessages(ctx, sourceID, 0, 0)
+	if len(sourceMessages) != 1 || sourceMessages[0].TextContent != "source stays here" {
+		t.Fatalf("empty branch changed source = %#v", sourceMessages)
+	}
+}
+
+func TestResponsesBranchRejectsActiveSourceBeforeCopy(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sourceID = "serve-active-branch-source"
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddMessage(ctx, sourceID, session.NewMessage(sourceID, llm.AssistantText("durable answer"), -1)); err != nil {
+		t.Fatal(err)
+	}
+	messages, _ := store.GetMessages(ctx, sourceID, 0, 0)
+
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	defer manager.Close()
+	runtime := &serveRuntime{}
+	active := &runtimeInterruptState{cancel: func() {}, done: make(chan struct{})}
+	close(active.done)
+	runtime.setActiveInterrupt(active)
+	defer runtime.clearActiveInterrupt(active)
+	putTestSession(manager, sourceID, runtime)
+	srv := &serveServer{sessionMgr: manager, store: store}
+
+	rr := httptest.NewRecorder()
+	body := fmt.Sprintf(`{"input":"alternate","stream":true,"previous_response_id":%q,"branch":true}`, durableResponseIDForMessageID(messages[0].ID))
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("session_id", sourceID)
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "source work is active") {
+		t.Fatalf("active source status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	tree, err := store.(session.ConversationBranchStore).GetBranchTree(ctx, sourceID)
+	if err != nil || len(tree.Nodes) != 1 {
+		t.Fatalf("active source created a branch: %#v, %v", tree, err)
+	}
+}
+
+func TestBranchStreamingModeIsFirstPartyOnly(t *testing.T) {
+	if _, ok := parseDurableResponseMessageID("resp_msg_0"); ok {
+		t.Fatal("ordinary continuation parser accepted branch-only empty anchor")
+	}
+	if id, ok := parseBranchDurableResponseMessageID("resp_msg_0"); !ok || id != 0 {
+		t.Fatalf("branch empty anchor parse = %d/%v", id, ok)
+	}
+	external := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	external.Header.Set("Idempotency-Key", "header-key")
+	if branchUsesFirstPartyUIStream(external, true) {
+		t.Fatal("external branch request selected first-party UI streaming")
+	}
+	if got := responseRunIdempotencyKey(external, responsesCreateRequest{IdempotencyKey: "unrelated-body-key"}); got != "header-key" {
+		t.Fatalf("non-branch run idempotency key = %q, want header-key", got)
+	}
+	if got := responseRunIdempotencyKey(external, responsesCreateRequest{Branch: true, IdempotencyKey: "branch-body-key"}); got != "branch-body-key" {
+		t.Fatalf("branch run idempotency key = %q, want branch-body-key", got)
+	}
+	firstParty := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	firstParty.Header.Set("X-Term-LLM-UI-Version", "test")
+	if !branchUsesFirstPartyUIStream(firstParty, true) {
+		t.Fatal("first-party branch request did not select UI streaming")
+	}
+	if branchUsesFirstPartyUIStream(firstParty, false) {
+		t.Fatal("ordinary first-party request was mislabeled as a branch stream")
+	}
+}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1752,6 +1752,16 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if suffix == "tree" {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		s.handleSessionTree(w, r, sessionID)
+		return
+	}
+
 	if suffix == "transcript" || suffix == "transcript/bodies" {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
@@ -2405,7 +2415,7 @@ func (s *serveServer) cors(next http.HandlerFunc) http.HandlerFunc {
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, session_id, Idempotency-Key, X-Idempotency-Key, X-Term-LLM-Request-ID, X-Term-LLM-UI-Version, X-API-Key, anthropic-version")
-			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number, x-response-id, x-term-llm-ui-version")
+			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number, x-response-id, x-branch-anchor-id, x-term-llm-ui-version")
 		}
 
 		w.Header().Set("X-Term-LLM-UI-Version", serveui.AssetVersion())

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -39,6 +39,7 @@ type resolvedResponsesRequest struct {
 	previousResponseID string
 	previousDurable    bool
 	freshConversation  bool
+	durableRuntime     bool
 	uiStream           bool
 	idempotencyKey     string
 }
@@ -188,6 +189,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	if identifiedUserBatch && req.PreviousResponseID != "" {
 		replaceHistory = false
 	}
+	if req.Branch && strings.TrimSpace(req.PreviousResponseID) == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "branch requires previous_response_id")
+		return
+	}
 
 	// External /v1/responses callers follow OpenAI-style chaining:
 	// previous_response_id continues a conversation; no previous response means a
@@ -195,8 +200,34 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	headerSessionID := strings.TrimSpace(r.Header.Get("session_id"))
 	sessionID := ""
 	previousDurable := false
+	resolvedPreviousResponseID := req.PreviousResponseID
+	branched := false
 	if req.PreviousResponseID != "" {
-		if durable, status, msg := s.resolveDurablePreviousResponseID(ctx, req.PreviousResponseID, headerSessionID, inputMessages, identifiedUserBatch); status != 0 {
+		if req.Branch {
+			idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
+			if idempotencyKey == "" {
+				idempotencyKey = responseIdempotencyKeyFromRequest(r)
+			}
+			durable, status, msg := s.resolveDurableBranch(ctx, req.PreviousResponseID, headerSessionID, inputMessages, identifiedUserBatch, req.ExpectedRev, idempotencyKey)
+			if status != 0 {
+				errType := "invalid_request_error"
+				if status == http.StatusConflict {
+					errType = "conflict_error"
+				} else if status >= http.StatusInternalServerError {
+					errType = "server_error"
+				}
+				writeOpenAIError(w, status, errType, msg)
+				return
+			}
+			sessionID = durable.sessionID
+			resolvedPreviousResponseID = durable.latestID
+			previousDurable = true
+			branched = true
+			w.Header().Set("x-session-id", sessionID)
+			if durable.latestID != durableResponseMessagePrefix+"0" {
+				w.Header().Set("x-branch-anchor-id", durable.latestID)
+			}
+		} else if durable, status, msg := s.resolveDurablePreviousResponseID(ctx, req.PreviousResponseID, headerSessionID, inputMessages, identifiedUserBatch); status != 0 {
 			errType := "invalid_request_error"
 			if status == http.StatusConflict {
 				errType = "conflict_error"
@@ -237,15 +268,18 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		replaceHistory = true
 	}
 
+	runIdempotencyKey := responseRunIdempotencyKey(r, req)
 	s.handleResolvedResponses(w, r, ctx, resolvedResponsesRequest{
 		req:                req,
 		inputMessages:      inputMessages,
 		replaceHistory:     replaceHistory,
 		sessionID:          sessionID,
-		previousResponseID: req.PreviousResponseID,
+		previousResponseID: resolvedPreviousResponseID,
 		previousDurable:    previousDurable,
 		freshConversation:  req.PreviousResponseID == "",
-		idempotencyKey:     responseIdempotencyKeyFromRequest(r),
+		durableRuntime:     branched,
+		uiStream:           branchUsesFirstPartyUIStream(r, branched),
+		idempotencyKey:     runIdempotencyKey,
 	})
 }
 
@@ -489,7 +523,7 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 		}
 	} else {
 		var err error
-		if previousResponseID != "" || rr.uiStream {
+		if previousResponseID != "" || rr.durableRuntime {
 			runtime, stateful, err = s.runtimeForProviderRequest(ctx, sessionID, reqProvider)
 		} else {
 			runtime, stateful, err = s.runtimeForFreshProviderRequest(ctx, sessionID, freshProvider)
@@ -897,6 +931,20 @@ func responseIdempotencyKeyFromRequest(r *http.Request) string {
 		}
 	}
 	return ""
+}
+
+func responseRunIdempotencyKey(r *http.Request, req responsesCreateRequest) string {
+	key := responseIdempotencyKeyFromRequest(r)
+	if req.Branch && strings.TrimSpace(req.IdempotencyKey) != "" {
+		// The branch body key scopes both child materialization and replay of
+		// that child's first run. Non-branch requests retain header semantics.
+		key = strings.TrimSpace(req.IdempotencyKey)
+	}
+	return key
+}
+
+func branchUsesFirstPartyUIStream(r *http.Request, branched bool) bool {
+	return branched && isFirstPartyUIResponseRequest(r)
 }
 
 func isFirstPartyUIResponseRequest(r *http.Request) bool {

--- a/cmd/serve_protocol_responses.go
+++ b/cmd/serve_protocol_responses.go
@@ -42,6 +42,9 @@ type responsesCreateRequest struct {
 	TopP               *float32                     `json:"top_p,omitempty"`
 	Stream             bool                         `json:"stream,omitempty"`
 	PreviousResponseID string                       `json:"previous_response_id,omitempty"`
+	Branch             bool                         `json:"branch,omitempty"`
+	ExpectedRev        *int64                       `json:"expected_rev,omitempty"`
+	IdempotencyKey     string                       `json:"idempotency_key,omitempty"`
 	ClientMessageID    string                       `json:"client_message_id,omitempty"`
 	ReasoningEffort    string                       `json:"reasoning_effort,omitempty"`
 	Reasoning          *responsesReasoningRequest   `json:"reasoning,omitempty"`

--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -34,6 +35,16 @@ func parseDurableResponseMessageID(responseID string) (int64, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+// parseBranchDurableResponseMessageID additionally accepts resp_msg_0 as the
+// branch-only representation of an empty copied transcript. Ordinary response
+// continuation must keep rejecting zero because it has no durable message row.
+func parseBranchDurableResponseMessageID(responseID string) (int64, bool) {
+	if strings.TrimSpace(responseID) == durableResponseMessagePrefix+"0" {
+		return 0, true
+	}
+	return parseDurableResponseMessageID(responseID)
 }
 
 func isVisibleContinuationRole(role llm.Role) bool {
@@ -78,6 +89,96 @@ func latestDurableResponseID(messages []session.Message) string {
 type durablePreviousResponseResolution struct {
 	sessionID string
 	latestID  string
+}
+
+func (s *serveServer) lockBranchSourceRuntime(sessionID string) (func(), bool) {
+	if s == nil {
+		return func() {}, false
+	}
+	if s.responseRuns != nil && s.responseRuns.activeRunID(sessionID) != "" {
+		return nil, true
+	}
+	if s.sessionMgr == nil {
+		return func() {}, false
+	}
+	runtime, ok := s.sessionMgr.Get(sessionID)
+	if !ok || runtime == nil {
+		return func() {}, false
+	}
+	if runtime.hasActiveActivity() || !runtime.mu.TryLock() {
+		return nil, true
+	}
+	if runtime.hasActiveActivity() {
+		runtime.mu.Unlock()
+		return nil, true
+	}
+	return runtime.mu.Unlock, false
+}
+
+func (s *serveServer) resolveDurableBranch(ctx context.Context, previousResponseID, headerSessionID string, inputMessages []llm.Message, allowIdentifiedUserBatch bool, expectedRev *int64, idempotencyKey string) (durablePreviousResponseResolution, int, string) {
+	msgID, ok := parseBranchDurableResponseMessageID(previousResponseID)
+	if !ok {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, "branch requires a durable previous_response_id"
+	}
+	if s.store == nil {
+		return durablePreviousResponseResolution{}, http.StatusConflict, "conversation branching is unavailable"
+	}
+	if err := validateDurableContinuationInput(inputMessages, allowIdentifiedUserBatch); err != nil {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, err.Error()
+	}
+
+	sourceSessionID := strings.TrimSpace(headerSessionID)
+	if msgID > 0 {
+		msg, err := getMessageByID(ctx, s.store, msgID)
+		if err != nil || msg.ID == 0 {
+			return durablePreviousResponseResolution{}, http.StatusBadRequest, fmt.Sprintf("previous_response_id %q not found", previousResponseID)
+		}
+		if !isVisibleContinuationRole(msg.Role) {
+			return durablePreviousResponseResolution{}, http.StatusBadRequest, "previous_response_id must refer to a user or assistant message"
+		}
+		if sourceSessionID != "" && sourceSessionID != msg.SessionID {
+			return durablePreviousResponseResolution{}, http.StatusConflict, fmt.Sprintf("session_id %q conflicts with previous_response_id session %q", sourceSessionID, msg.SessionID)
+		}
+		sourceSessionID = msg.SessionID
+	} else if sourceSessionID == "" {
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, "empty-transcript branch requires session_id"
+	}
+
+	unlockSource, busy := s.lockBranchSourceRuntime(sourceSessionID)
+	if busy {
+		return durablePreviousResponseResolution{}, http.StatusConflict, "cannot branch while source work is active"
+	}
+	defer unlockSource()
+
+	branchStore, ok := s.store.(session.ConversationBranchStore)
+	if !ok {
+		return durablePreviousResponseResolution{}, http.StatusConflict, "conversation branching is unavailable"
+	}
+	result, err := branchStore.CreateBranch(ctx, sourceSessionID, session.CreateBranchOptions{
+		AnchorMessageID: msgID,
+		ExpectedRev:     expectedRev,
+		IdempotencyKey:  strings.TrimSpace(idempotencyKey),
+	})
+	switch {
+	case errors.Is(err, session.ErrBranchConflict):
+		return durablePreviousResponseResolution{}, http.StatusConflict, "conversation changed in another client; refresh and try again"
+	case errors.Is(err, session.ErrBranchingUnsupported):
+		return durablePreviousResponseResolution{}, http.StatusConflict, "conversation branching is unavailable"
+	case errors.Is(err, session.ErrNotFound):
+		return durablePreviousResponseResolution{}, http.StatusBadRequest, "branch source or anchor was not found"
+	case err != nil:
+		return durablePreviousResponseResolution{}, http.StatusInternalServerError, "failed to create conversation branch"
+	case result.Session == nil || strings.TrimSpace(result.Session.ID) == "":
+		return durablePreviousResponseResolution{}, http.StatusInternalServerError, "failed to create conversation branch"
+	}
+	latestID := durableResponseIDForMessageID(result.AnchorMessageID)
+	if result.AnchorMessageID == 0 {
+		latestID = durableResponseMessagePrefix + "0"
+	}
+	return durablePreviousResponseResolution{
+		sessionID: result.Session.ID,
+		latestID:  latestID,
+	}, 0, ""
 }
 
 func (s *serveServer) resolveDurablePreviousResponseID(ctx context.Context, previousResponseID, headerSessionID string, inputMessages []llm.Message, allowIdentifiedUserBatch bool) (durablePreviousResponseResolution, int, string) {

--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -15,7 +15,7 @@ import (
 
 //go:embed static/index.html static/manifest.webmanifest static/icon-512.png static/sw.js
 //go:embed static/app.css
-//go:embed static/app-core.js static/toast.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
+//go:embed static/app-core.js static/toast.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-branching.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
 //go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diffs.js static/app-worktrees.js
 //go:embed static/decoration.js static/markdown-setup.js static/markdown-streaming.js static/transcript-window.js static/active-response.js static/conversation.js
 //go:embed static/vendor
@@ -111,6 +111,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`href="side-question.js"`, `href="` + versioned("side-question.js") + `"`},
 		{`href="app-sidebar.js"`, `href="` + versioned("app-sidebar.js") + `"`},
 		{`href="app-sessions.js"`, `href="` + versioned("app-sessions.js") + `"`},
+		{`href="app-branching.js"`, `href="` + versioned("app-branching.js") + `"`},
 		{`href="app-session-events.js"`, `href="` + versioned("app-session-events.js") + `"`},
 		{`href="app-mcp.js"`, `href="` + versioned("app-mcp.js") + `"`},
 		{`href="app-goals-location.js"`, `href="` + versioned("app-goals-location.js") + `"`},
@@ -143,6 +144,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`src="side-question.js"`, `src="` + versioned("side-question.js") + `"`},
 		{`src="app-sidebar.js"`, `src="` + versioned("app-sidebar.js") + `"`},
 		{`src="app-sessions.js"`, `src="` + versioned("app-sessions.js") + `"`},
+		{`src="app-branching.js"`, `src="` + versioned("app-branching.js") + `"`},
 		{`src="app-session-events.js"`, `src="` + versioned("app-session-events.js") + `"`},
 		{`src="app-mcp.js"`, `src="` + versioned("app-mcp.js") + `"`},
 		{`src="app-goals-location.js"`, `src="` + versioned("app-goals-location.js") + `"`},

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -51,6 +51,7 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	legacyProductionLines := 0
 	transportLines := map[string]int{}
 	completionLines := 0
+	branchingLines := 0
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".js") || strings.HasSuffix(name, "_test.js") {
@@ -65,13 +66,15 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 			transportLines[name] = lineCount
 		} else if name == "slash-commands.js" {
 			completionLines = lineCount
+		} else if name == "app-branching.js" {
+			branchingLines = lineCount
 		} else {
 			legacyProductionLines += lineCount
 		}
 	}
-	// Keep focused transport/completion boundaries from weakening the pre-existing
-	// ratchet: legacy production code must still decrease, while each extracted
-	// module gets a narrow independent ceiling tied to its audited responsibility.
+	// Keep focused transport/completion/branching boundaries from weakening the
+	// pre-existing ratchet: legacy production code must still decrease, while each
+	// extracted module gets a narrow independent ceiling.
 	if legacyProductionLines >= 20570 {
 		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20570", legacyProductionLines)
 	}
@@ -80,6 +83,9 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	}
 	if completionLines > 450 {
 		t.Fatalf("composer completion controller=%d lines, budget=450", completionLines)
+	}
+	if branchingLines == 0 || branchingLines > 300 {
+		t.Fatalf("conversation branching controller=%d lines, budget=300", branchingLines)
 	}
 
 	for _, name := range []string{"active-response.js", "conversation.js", "transcript-window.js"} {
@@ -100,6 +106,23 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 				t.Fatalf("pure lifecycle module %s accesses forbidden effect %q", name, forbidden)
 			}
 		}
+	}
+}
+
+func TestBranchingAssetIsVersionedAndCached(t *testing.T) {
+	if _, err := StaticAsset("app-branching.js"); err != nil {
+		t.Fatalf("StaticAsset(app-branching.js): %v", err)
+	}
+	rendered := string(RenderIndexHTML("/chat", "", RenderOptions{}))
+	if !strings.Contains(rendered, `src="app-branching.js?v=`) || !strings.Contains(rendered, `href="app-branching.js?v=`) {
+		t.Fatal("app-branching.js must be versioned in both script and preload tags")
+	}
+	serviceWorker, err := StaticAsset("sw.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(serviceWorker), "'./app-branching.js'") {
+		t.Fatal("service worker shell cache is missing app-branching.js")
 	}
 }
 

--- a/internal/serveui/static/app-branching.js
+++ b/internal/serveui/static/app-branching.js
@@ -119,6 +119,12 @@ const applyPendingBranchProjection = () => {
   root.appendChild(divider);
 };
 
+const branchActionIcon = (button, label) => {
+  button.title = label;
+  button.setAttribute('aria-label', label);
+  button.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="5" r="2"></circle><circle cx="18" cy="15" r="2"></circle><circle cx="6" cy="19" r="2"></circle><path d="M6 7v10"></path><path d="M8 7h3a7 7 0 0 1 7 7v-1"></path></svg>';
+};
+
 const syncBranchActions = () => {
   const root = elements.messages;
   const session = app.getActiveSession?.();
@@ -130,8 +136,8 @@ const syncBranchActions = () => {
     if (!node || node.querySelector?.('.message-branch-action')) continue;
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'message-branch-action';
-    button.textContent = 'Edit from here';
+    button.className = 'turn-action-btn message-branch-action';
+    branchActionIcon(button, 'Edit from here');
     button.addEventListener('click', () => beginPendingBranch(message, 'user'));
     node.appendChild(button);
   }
@@ -144,7 +150,7 @@ const syncBranchActions = () => {
       button = document.createElement('button');
       button.type = 'button';
       button.className = 'turn-action-btn turn-branch-btn';
-      button.textContent = 'Branch from here';
+      branchActionIcon(button, 'Branch from here');
       button.addEventListener('click', (event) => {
         event.preventDefault();
         const current = window.TermLLMConversation.sessionMessages(app.getActiveSession?.())

--- a/internal/serveui/static/app-branching.js
+++ b/internal/serveui/static/app-branching.js
@@ -122,7 +122,7 @@ const applyPendingBranchProjection = () => {
 const branchActionIcon = (button, label) => {
   button.title = label;
   button.setAttribute('aria-label', label);
-  button.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="5" r="2"></circle><circle cx="18" cy="15" r="2"></circle><circle cx="6" cy="19" r="2"></circle><path d="M6 7v10"></path><path d="M8 7h3a7 7 0 0 1 7 7v-1"></path></svg>';
+  button.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12h5"></path><path d="M8 12V9a3 3 0 0 1 3-3h10"></path><path d="M8 12v3a3 3 0 0 0 3 3h10"></path></svg>';
 };
 
 const syncBranchActions = () => {

--- a/internal/serveui/static/app-branching.js
+++ b/internal/serveui/static/app-branching.js
@@ -1,0 +1,289 @@
+(() => {
+'use strict';
+
+const app = window.TermLLMApp;
+if (!app) return;
+const { state } = app;
+state.pendingBranch ??= null;
+state.branchTree ??= null;
+
+const elements = app.elements || {};
+Object.assign(elements, {
+  branchTreeBtn: document.getElementById('branchTreeBtn'),
+  branchTreeModal: document.getElementById('branchTreeModal'),
+  branchTreeList: document.getElementById('branchTreeList'),
+  branchTreeCloseBtn: document.getElementById('branchTreeCloseBtn'),
+  pendingBranchBanner: document.getElementById('pendingBranchBanner'),
+  pendingBranchBannerText: document.getElementById('pendingBranchBannerText'),
+  pendingBranchCancelBtn: document.getElementById('pendingBranchCancelBtn'),
+});
+
+const BRANCHING_NOTICE_KEY = 'term_llm_branching_notice';
+const durableSourceTailID = (message) => {
+  const ids = Array.isArray(message?.durableSourceRowIds) ? message.durableSourceRowIds : [];
+  const value = ids.at(-1) ?? message?.durableRowId;
+  const id = Number(value);
+  return Number.isFinite(id) && id > 0 ? id : 0;
+};
+
+const syncPendingBranchBanner = () => {
+  const pending = state.pendingBranch;
+  const active = app.getActiveSession?.();
+  const visible = Boolean(pending && active && !state.draftSessionActive && pending.sourceSessionId === active.id);
+  if (elements.pendingBranchBanner) elements.pendingBranchBanner.hidden = !visible;
+  if (visible && elements.pendingBranchBannerText) {
+    elements.pendingBranchBannerText.textContent = pending.selectedRole === 'user'
+      ? 'Editing into a new conversation path'
+      : 'Continuing in a new conversation path';
+  }
+};
+
+const cancelPendingBranch = (options = {}) => {
+  const pending = state.pendingBranch;
+  state.pendingBranch = null;
+  if (options.restoreComposer && pending?.originalComposer != null) {
+    elements.promptInput.value = String(pending.originalComposer || '');
+    app.autoGrowPrompt?.();
+  }
+  syncPendingBranchBanner();
+  app.renderMessages?.(false);
+};
+
+const beginPendingBranch = (message, role = '') => {
+  const session = app.getActiveSession?.();
+  if (!session || state.draftSessionActive || message?.durable !== true) return false;
+  if (state.streaming || state.compressing || state.sideQuestion?.running || app.sessionHasInProgressState?.(session)) {
+    app.showToast?.('Cannot branch while work is active.', { id: 'conversation-branch', tone: 'warning' });
+    return false;
+  }
+  const messages = window.TermLLMConversation.sessionMessages(session);
+  const index = messages.findIndex((candidate) => candidate?.id === message.id);
+  if (index < 0) return false;
+  const selectedRole = role || message.role;
+  let anchorMessageId = durableSourceTailID(message);
+  if (selectedRole === 'user') {
+    anchorMessageId = 0;
+    for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+      const candidate = messages[cursor];
+      if (candidate?.role !== 'user' && candidate?.role !== 'assistant') continue;
+      anchorMessageId = durableSourceTailID(candidate);
+      if (anchorMessageId > 0) break;
+    }
+  }
+  if (selectedRole !== 'user' && anchorMessageId <= 0) return false;
+  const originalComposer = String(elements.promptInput.value || '');
+  state.pendingBranch = {
+    sourceSessionId: session.id,
+    anchorMessageId,
+    previousResponseId: `resp_msg_${anchorMessageId}`,
+    expectedRev: Math.max(0, Number(session.transcript?.rev) || 0),
+    idempotencyKey: app.generateId?.('branch') || `branch_${Date.now()}`,
+    selectedMessageId: message.id,
+    selectedRole,
+    originalComposer,
+  };
+  elements.promptInput.value = selectedRole === 'user' ? String(message.content || '') : '';
+  app.autoGrowPrompt?.();
+  elements.promptInput.focus?.();
+  syncPendingBranchBanner();
+  app.renderMessages?.(false);
+  if (localStorage.getItem(BRANCHING_NOTICE_KEY) !== '1') {
+    localStorage.setItem(BRANCHING_NOTICE_KEY, '1');
+    app.showToast?.('Conversation context branches; filesystem and tool side effects do not rewind.', { id: 'conversation-branch', tone: 'warning', duration: 7000 });
+  }
+  return true;
+};
+
+const applyPendingBranchProjection = () => {
+  const root = elements.messages;
+  if (!root) return;
+  root.querySelectorAll?.('.branch-hidden').forEach((node) => node.classList.remove('branch-hidden'));
+  root.querySelector?.('.branch-pending-divider')?.remove();
+  const pending = state.pendingBranch;
+  const session = app.getActiveSession?.();
+  if (!pending || !session || pending.sourceSessionId !== session.id) return;
+  const selected = app.findMessageElement?.(pending.selectedMessageId);
+  if (!selected) return;
+  let hide = false;
+  for (const node of Array.from(root.children || [])) {
+    if (node === selected) {
+      if (pending.selectedRole === 'user') node.classList.add('branch-hidden');
+      hide = true;
+      continue;
+    }
+    if (hide) node.classList.add('branch-hidden');
+  }
+  const divider = document.createElement('div');
+  divider.className = 'branch-pending-divider';
+  divider.textContent = pending.selectedRole === 'user' ? 'Editing into a new path' : 'Continuing in a new path';
+  root.appendChild(divider);
+};
+
+const syncBranchActions = () => {
+  const root = elements.messages;
+  const session = app.getActiveSession?.();
+  if (!root || !session || state.draftSessionActive) return;
+  const messages = window.TermLLMConversation.sessionMessages(session);
+  for (const message of messages) {
+    if (message?.role !== 'user' || message.durable !== true || durableSourceTailID(message) <= 0) continue;
+    const node = app.findMessageElement?.(message.id);
+    if (!node || node.querySelector?.('.message-branch-action')) continue;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'message-branch-action';
+    button.textContent = 'Edit from here';
+    button.addEventListener('click', () => beginPendingBranch(message, 'user'));
+    node.appendChild(button);
+  }
+  root.querySelectorAll?.('.turn-action-panel').forEach((panel) => {
+    const assistantID = panel.dataset?.turnAssistantId || '';
+    const message = messages.find((candidate) => candidate?.id === assistantID);
+    if (!message || message.durable !== true || durableSourceTailID(message) <= 0) return;
+    let button = panel.querySelector?.('.turn-branch-btn');
+    if (!button) {
+      button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'turn-action-btn turn-branch-btn';
+      button.textContent = 'Branch from here';
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const current = window.TermLLMConversation.sessionMessages(app.getActiveSession?.())
+          .find((candidate) => candidate?.id === button.dataset.turnAssistantId);
+        if (current) beginPendingBranch(current, 'assistant');
+      });
+      panel.appendChild(button);
+    }
+    button.dataset.turnAssistantId = assistantID;
+  });
+  applyPendingBranchProjection();
+  syncPendingBranchBanner();
+};
+
+const branchTreeDepth = (nodes, node) => {
+  const byId = new Map(nodes.map((entry) => [entry.session_id, entry]));
+  let depth = 0;
+  let parent = node?.parent_session_id;
+  while (parent && byId.has(parent) && depth < nodes.length) {
+    depth += 1;
+    parent = byId.get(parent)?.parent_session_id;
+  }
+  return depth;
+};
+
+const renderBranchTree = (tree) => {
+  if (!elements.branchTreeList) return;
+  elements.branchTreeList.innerHTML = '';
+  const nodes = Array.isArray(tree?.nodes) ? tree.nodes : [];
+  for (const node of nodes) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `branch-tree-item${node.session_id === state.activeSessionId ? ' active' : ''}`;
+    button.style.paddingLeft = `${.65 + branchTreeDepth(nodes, node) * 1.1}rem`;
+    const marker = document.createElement('span');
+    marker.textContent = node.session_id === state.activeSessionId ? '●' : '○';
+    const copy = document.createElement('span');
+    const title = document.createElement('span');
+    title.textContent = node.title || `Session #${node.session_number || ''}`;
+    const detail = document.createElement('small');
+    detail.textContent = node.anchor_preview ? `Forked after: ${node.anchor_preview}` : 'Original path';
+    copy.appendChild(title);
+    copy.appendChild(detail);
+    button.appendChild(marker);
+    button.appendChild(copy);
+    button.addEventListener('click', async () => {
+      elements.branchTreeModal.hidden = true;
+      cancelPendingBranch();
+      if (!state.sessions.some((session) => session.id === node.session_id)) {
+        state.sessions.push({ id: node.session_id, number: Number(node.session_number) || 0, title: node.title || 'Conversation path', messages: [], lastResponseId: null, activeResponseId: null, created: Date.now(), _serverOnly: true });
+      }
+      await app.switchToSession?.(node.session_id, { focusPrompt: true });
+    });
+    elements.branchTreeList.appendChild(button);
+  }
+};
+
+const refreshBranchTree = async (options = {}) => {
+  const session = app.getActiveSession?.();
+  if (!session || state.draftSessionActive || !app.isSessionIdentityResolved?.(session)) {
+    if (elements.branchTreeBtn) elements.branchTreeBtn.hidden = true;
+    return null;
+  }
+  const ownerID = session.id;
+  try {
+    const response = await app.apiFetch(`${app.UI_PREFIX}/v1/sessions/${encodeURIComponent(ownerID)}/tree`, { headers: app.requestHeaders(session.id) });
+    if (!response.ok) throw new Error('Conversation tree unavailable');
+    const tree = await response.json();
+    if (state.activeSessionId !== ownerID || state.draftSessionActive) return null;
+    state.branchTree = { ...tree, session_id: ownerID };
+    const count = Math.max(1, Number(tree.path_count) || 1);
+    if (elements.branchTreeBtn) {
+      elements.branchTreeBtn.textContent = `${count} path${count === 1 ? '' : 's'}`;
+      elements.branchTreeBtn.hidden = count <= 1;
+    }
+    if (options.render !== false) renderBranchTree(tree);
+    return tree;
+  } catch (_err) {
+    if (state.activeSessionId === ownerID && elements.branchTreeBtn) elements.branchTreeBtn.hidden = true;
+    return null;
+  }
+};
+
+const openBranchTree = async () => {
+  const tree = await refreshBranchTree();
+  if (!tree || Number(tree.path_count) <= 1 || !elements.branchTreeModal) return;
+  elements.branchTreeModal.hidden = false;
+  elements.branchTreeCloseBtn?.focus?.();
+};
+
+const adoptBranchedSessionOwnership = (source, childSessionId, userMessages = [], copiedAnchorResponseId = '') => {
+  const childID = String(childSessionId || '').trim();
+  if (!source || !childID || childID === source.id) return source;
+  for (const message of userMessages) source.transcript?.removePendingIntent?.(message.clientMessageId || message.id);
+  app.persistPendingIntents?.(source);
+  app.refreshSessionMessagesFromTranscript?.(source);
+  app.setSessionOptimisticBusy?.(source, false);
+
+  let child = state.sessions.find((candidate) => candidate.id === childID);
+  if (!child) {
+    child = { ...source, id: childID, number: 0, title: source.title || 'Branched conversation', created: Date.now(), lastMessageAt: Date.now(), activeResponseId: null, messages: [], transcript: typeof window.ConversationController === 'function' ? new window.ConversationController(childID) : null, _serverOnly: false };
+    state.sessions.unshift(child);
+  }
+  const copiedAnchor = String(copiedAnchorResponseId || '').trim();
+  child.lastResponseId = copiedAnchor || child.lastResponseId || null;
+  for (const message of userMessages) app.trackPendingIntent?.(child, message);
+  state.pendingBranch = null;
+  state.activeSessionId = childID;
+  state.draftSessionActive = false;
+  if (elements.messages?.dataset) elements.messages.dataset.sessionId = childID;
+  app.updateURL?.(app.sessionSlug?.(child) || childID);
+  app.persistAndRefreshShell?.();
+  syncPendingBranchBanner();
+  app.renderMessages?.(true);
+  void refreshBranchTree({ render: false });
+  return child;
+};
+
+if (elements.branchTreeBtn) elements.branchTreeBtn.addEventListener('click', openBranchTree);
+if (elements.branchTreeCloseBtn) elements.branchTreeCloseBtn.addEventListener('click', () => { elements.branchTreeModal.hidden = true; });
+if (elements.pendingBranchCancelBtn) elements.pendingBranchCancelBtn.addEventListener('click', () => cancelPendingBranch({ restoreComposer: true }));
+if (elements.branchTreeModal) elements.branchTreeModal.addEventListener('click', (event) => {
+  if (event.target === elements.branchTreeModal) elements.branchTreeModal.hidden = true;
+});
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && elements.branchTreeModal && !elements.branchTreeModal.hidden) {
+    elements.branchTreeModal.hidden = true;
+    elements.branchTreeBtn?.focus?.();
+  }
+});
+
+Object.assign(app, {
+  beginPendingBranch,
+  cancelPendingBranch,
+  applyPendingBranchProjection,
+  syncBranchActions,
+  refreshBranchTree,
+  openBranchTree,
+  adoptBranchedSessionOwnership,
+});
+syncPendingBranchBanner();
+})();

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -2456,7 +2456,6 @@ const syncTurnActionPanelForAssistant = (assistantId) => {
 const syncTurnActionPanels = () => {
   const root = elements.messages;
   if (!root) return;
-
   root.querySelectorAll('.turn-action-panel').forEach((panel) => panel.remove());
 
   getAssistantTurns(ensureActiveSession()).forEach((turn) => {
@@ -2465,6 +2464,7 @@ const syncTurnActionPanels = () => {
     if (!node || !node.classList?.contains('assistant')) return;
     ensureTurnActionPanel(node, turn);
   });
+  app.syncBranchActions?.();
 };
 
 const updateToolGroupNode = (message) => {

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -274,6 +274,11 @@ const sendMessage = async (options = {}) => {
   }
 
   let session = getActiveSession();
+  const branchIntent = !batchingFollowUps && session && !state.draftSessionActive
+    && state.pendingBranch?.sourceSessionId === session.id
+    ? { ...state.pendingBranch }
+    : null;
+  const branchSourceSession = branchIntent ? session : null;
   const skillInvocation = !batchingFollowUps && pendingAttachments.length === 0
     ? app.matchSkillInvocation?.(prompt)
     : null;
@@ -290,6 +295,10 @@ const sendMessage = async (options = {}) => {
     && !state.draftSessionActive
     && (session.activeResponseId || progressEntry?.serverActiveRun || ownsLiveStream)
   );
+  if (branchIntent && activeSessionBusy) {
+    app.showToast?.('Cannot branch while work is active.', { id: 'conversation-branch', tone: 'warning' });
+    return;
+  }
   if (skillInvocation && session && !state.draftSessionActive) {
     if (activeSessionBusy && skillInvocation.execution !== 'isolated') {
       app.queueMainSkillInvocation(session, skillInvocation);
@@ -480,7 +489,7 @@ const sendMessage = async (options = {}) => {
   setStreaming(true);
   options._onTransportStarted?.();
   app.refreshSidebarStatusPoll?.();
-  const streamState = createResponseStreamState(session);
+  let streamState = createResponseStreamState(session);
   let previousResponseId = '';
   try {
     const input = messageSpecs.map((spec, index) => {
@@ -504,12 +513,19 @@ const sendMessage = async (options = {}) => {
       client_message_id: userMessage.clientMessageId,
       input
     };
-    previousResponseId = String(session.lastResponseId || '').trim();
+    previousResponseId = branchIntent
+      ? String(branchIntent.previousResponseId || `resp_msg_${Number(branchIntent.anchorMessageId) || 0}`).trim()
+      : String(session.lastResponseId || '').trim();
     if (!previousResponseId && session.worktreeDir) {
       body.worktree_dir = session.worktreeDir;
     }
     if (previousResponseId) {
       body.previous_response_id = previousResponseId;
+    }
+    if (branchIntent) {
+      body.branch = true;
+      body.expected_rev = Math.max(0, Number(branchIntent.expectedRev) || 0);
+      body.idempotency_key = String(branchIntent.idempotencyKey || userMessage.responseRequestId).trim();
     }
     app.canonicalizeSelectedModelEffort();
     const currentProvider = session.provider || '';
@@ -576,13 +592,31 @@ const sendMessage = async (options = {}) => {
     }, { policy: app.API_FETCH_POLICY.idempotentMutation, retries: 0, timeoutMs: 0 });
     controller._heartbeatStaleThreshold = HEARTBEAT_STALE_THRESHOLD;
     const headerResponseId = String(response.headers.get('x-response-id') || '').trim();
+    const authoritativeSessionId = String(response.headers.get('x-session-id') || '').trim();
+    const copiedBranchAnchorId = String(response.headers.get('x-branch-anchor-id') || '').trim();
     const headerSessionNumber = Number(response.headers.get('x-session-number') || 0);
+    if (!response.ok) {
+      throw await normalizeError(response);
+    }
+    if (branchIntent) {
+      if (!authoritativeSessionId || authoritativeSessionId === branchSourceSession?.id) {
+        throw new Error('Branch response did not identify a child session.');
+      }
+      clearDraftMessageForSession(branchSourceSession.id);
+      session = app.adoptBranchedSessionOwnership?.(branchSourceSession, authoritativeSessionId, userMessages, copiedBranchAnchorId) || session;
+      streamState = createResponseStreamState(session);
+      attachResponseStream(session, headerResponseId, controller);
+      if (headerResponseId) setActiveResponseTracking(session, headerResponseId, 0);
+      try {
+        await app.refreshActiveSessionMessagesFromServer?.(session, {
+          force: true, useEtag: false, forceScroll: true, reason: 'branch-ownership'
+        });
+      } catch (_err) {
+      }
+    }
     if (headerSessionNumber > 0 && session.number !== headerSessionNumber) {
       session.number = headerSessionNumber;
       updateURL(sessionSlug(session));
-    }
-    if (!response.ok) {
-      throw await normalizeError(response);
     }
     setConnectionState('', '');
     clearDraftMessageForSession(session.id);

--- a/internal/serveui/static/app-sessions.js
+++ b/internal/serveui/static/app-sessions.js
@@ -122,6 +122,8 @@ const switchToDraftSession = async (options = {}) => {
   }
   state.activeSessionId = '';
   state.draftSessionActive = true;
+  state.pendingBranch = null;
+  if (elements.branchTreeBtn) elements.branchTreeBtn.hidden = true;
   updateURL('');
 
   if (options.clearComposer) {
@@ -266,6 +268,11 @@ const switchToSession = async (sessionId, options = {}) => {
     }
   }
   if (!session) return null;
+  if (state.pendingBranch && state.pendingBranch.sourceSessionId !== nextId) {
+    app.cancelPendingBranch?.();
+  }
+  state.branchTree = null;
+  if (elements.branchTreeBtn) elements.branchTreeBtn.hidden = true;
 
   const switchGeneration = (Number(state.sessionSwitchGeneration || 0) + 1);
   state.sessionSwitchGeneration = switchGeneration;
@@ -344,6 +351,7 @@ const switchToSession = async (sessionId, options = {}) => {
   if (options.closeSidebar !== false) {
     closeSidebarIfMobile();
   }
+  void app.refreshBranchTree?.({ render: false });
   return session;
 };
 
@@ -1130,6 +1138,7 @@ const initialize = async () => {
     // ordinary cadence instead of immediately reconciling the same status and
     // triggering duplicate selected-session state work during first paint.
     app.refreshSidebarStatusPoll();
+    void app.refreshBranchTree?.({ render: false });
     if (!state.draftSessionActive && !getActiveSession()) {
       ensureActiveSession();
       renderMessages(true);

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -4950,22 +4950,19 @@
   cursor: pointer;
   text-decoration: underline;
 }
-.message-branch-action,
-.turn-branch-btn {
-  border: 0;
-  background: transparent;
-  color: var(--text-muted);
-  font: inherit;
-  font-size: .75rem;
-  padding: .2rem .35rem;
-  cursor: pointer;
-  border-radius: .35rem;
+.message-branch-action svg,
+.turn-branch-btn svg { width: 16px; height: 16px; }
+.message.user .message-branch-action {
+  align-self: flex-end;
+  margin-top: .15rem;
+  opacity: 0;
 }
-.message-branch-action:hover,
-.message-branch-action:focus-visible,
-.turn-branch-btn:hover,
-.turn-branch-btn:focus-visible { color: var(--text); background: var(--surface-2); }
-.message.user .message-branch-action { align-self: flex-end; margin-top: .15rem; }
+.message.user:hover .message-branch-action,
+.message.user:focus-within .message-branch-action,
+.message.user .message-branch-action:focus-visible { opacity: 1; }
+@media (hover: none) {
+  .message.user .message-branch-action { opacity: .7; }
+}
 .branch-pending-divider {
   margin: .9rem auto;
   padding: .55rem .8rem;

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -4926,3 +4926,103 @@
   .toast { animation: none; }
   .toast-leaving { transition: none; }
 }
+
+/* Conversation branching */
+.branch-hidden { display: none !important; }
+.pending-branch-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  margin-bottom: .5rem;
+  padding: .45rem .65rem;
+  border: 1px dashed var(--border);
+  border-radius: .55rem;
+  color: var(--text-muted);
+  font-size: .8rem;
+}
+.pending-branch-banner[hidden] { display: none; }
+.pending-branch-banner button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.message-branch-action,
+.turn-branch-btn {
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: .75rem;
+  padding: .2rem .35rem;
+  cursor: pointer;
+  border-radius: .35rem;
+}
+.message-branch-action:hover,
+.message-branch-action:focus-visible,
+.turn-branch-btn:hover,
+.turn-branch-btn:focus-visible { color: var(--text); background: var(--surface-2); }
+.message.user .message-branch-action { align-self: flex-end; margin-top: .15rem; }
+.branch-pending-divider {
+  margin: .9rem auto;
+  padding: .55rem .8rem;
+  max-width: 42rem;
+  border: 1px dashed var(--border);
+  border-radius: .65rem;
+  color: var(--text-muted);
+  font-size: .8rem;
+  text-align: center;
+}
+.branch-pending-divider button { margin-left: .5rem; }
+.branch-tree-trigger { white-space: nowrap; }
+.branch-tree-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 95;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0,0,0,.48);
+}
+.branch-tree-modal[hidden] { display: none; }
+.branch-tree-card {
+  width: min(36rem, 100%);
+  max-height: min(42rem, calc(100dvh - 2rem));
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: .9rem;
+  background: var(--surface);
+  box-shadow: var(--shadow-strong);
+  padding: 1rem;
+}
+.branch-tree-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.branch-tree-header p,
+.branch-tree-note { color: var(--text-muted); font-size: .8rem; margin: .25rem 0 0; }
+.branch-tree-list { display: grid; gap: .35rem; margin: 1rem 0; }
+.branch-tree-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: .6rem;
+  align-items: start;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: .55rem;
+  padding: .55rem .65rem;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+.branch-tree-item:hover,
+.branch-tree-item:focus-visible { background: var(--surface-2); border-color: var(--border); }
+.branch-tree-item.active { border-color: var(--border); background: var(--surface-2); }
+.branch-tree-item small { display: block; color: var(--text-muted); margin-top: .15rem; }
+@media (max-width: 640px) {
+  .branch-tree-modal { align-items: end; padding: 0; }
+  .branch-tree-card { width: 100%; max-height: 80dvh; border-radius: 1rem 1rem 0 0; padding-bottom: calc(1rem + env(safe-area-inset-bottom)); }
+  .message-branch-action,
+  .turn-branch-btn { min-height: 2rem; }
+}

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -21,6 +21,7 @@ const sidebarSource = fs.readFileSync(path.join(dir, 'app-sidebar.js'), 'utf8');
 const sessionEventsSource = fs.readFileSync(path.join(dir, 'app-session-events.js'), 'utf8');
 const sessionsSource = fs.readFileSync(path.join(dir, 'app-sessions.js'), 'utf8')
   .replace('initialize();', 'window.__termllmInitializePromise = initialize();');
+const branchingSource = fs.readFileSync(path.join(dir, 'app-branching.js'), 'utf8');
 const mcpSource = fs.readFileSync(path.join(dir, 'app-mcp.js'), 'utf8');
 const goalsLocationSource = fs.readFileSync(path.join(dir, 'app-goals-location.js'), 'utf8');
 const messageConvertSource = fs.readFileSync(path.join(dir, 'app-message-convert.js'), 'utf8');
@@ -485,6 +486,7 @@ async function createSessionsHarness(options = {}) {
   vm.runInContext(intentStorageSource, context, { filename: 'intent-storage.js' });
   vm.runInContext(sessionAdminSource, context, { filename: 'app-session-admin.js' });
   vm.runInContext(sessionsSource, context, { filename: 'app-sessions.js' });
+  vm.runInContext(branchingSource, context, { filename: 'app-branching.js' });
   vm.runInContext(sessionEventsSource, context, { filename: 'app-session-events.js' });
   if (typeof options.onInitializeStarted === 'function') {
     options.onInitializeStarted({ app, windowObj, storage, elementMap });
@@ -497,7 +499,7 @@ async function createSessionsHarness(options = {}) {
 async function testSwitchingSessionsStagesCurrentComposerBeforeRestore() {
   const name = 'switching sessions stages current composer before restoring target draft';
   const drafts = new Map([['', 'existing blank draft']]);
-  const { app } = await createSessionsHarness({
+  const { app, windowObj } = await createSessionsHarness({
     fetchImpl: async () => new Response(JSON.stringify({ sessions: [] }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' }
@@ -1937,8 +1939,8 @@ async function testSidebarSwitchSkipsLoadedAndUnresolvedSessionRequests() {
   await app.switchToSession(unresolved.id, { closeSidebar: false });
   await new Promise((resolve) => setImmediate(resolve));
 
-  if (loadedCalls.length !== 0) {
-    fail(name, 'already-loaded live session refetched during selection', JSON.stringify(loadedCalls));
+  if (loadedCalls.length !== 1 || !loadedCalls[0].endsWith(`/sessions/${loaded.id}/tree`)) {
+    fail(name, 'loaded selection made requests other than its required branch-tree refresh', JSON.stringify(loadedCalls));
     return;
   }
   const unresolvedScoped = fetchCalls.filter((url) => String(url).includes('/v1/sessions/1291/'));
@@ -7116,7 +7118,167 @@ async function testInflightSyncAbsorbsQueuedZeroRevisionActivation() {
   pass(name);
 }
 
+async function testConversationBranchTreeOpensAndSwitchesPaths() {
+  const name = 'conversation tree renders path count and switches to an existing branch';
+  const { app, windowObj } = await createSessionsHarness({
+    appOverrides: { renderMessages() {} },
+  });
+  const makeSession = (id, number, title) => {
+    const session = { id, number, title, messages: [], activeResponseId: null, lastResponseId: null };
+    session.transcript = new windowObj.TermLLMConversation.ConversationController(id);
+    session.transcript.publishedMessages = [];
+    return session;
+  };
+  const root = makeSession('branch_tree_root', 10, 'Root path');
+  const child = makeSession('branch_tree_child', 11, 'Alternate path');
+  app.state.sessions = [root, child];
+  app.state.activeSessionId = root.id;
+  app.state.draftSessionActive = false;
+  const treeRequests = [];
+  app.apiFetch = async (url) => {
+    if (String(url).includes('/tree')) treeRequests.push(String(url));
+    if (String(url).endsWith(`/sessions/${root.id}/tree`)) {
+      return new Response(JSON.stringify({
+        root_session_id: root.id,
+        active_session_id: root.id,
+        path_count: 2,
+        nodes: [
+          { session_id: root.id, session_number: 10, title: 'Root path' },
+          { session_id: child.id, session_number: 11, parent_session_id: root.id, title: 'Alternate path', anchor_preview: 'first answer' },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (String(url).endsWith(`/sessions/${child.id}/tree`)) {
+      return new Response(JSON.stringify({
+        root_session_id: child.id,
+        active_session_id: child.id,
+        path_count: 1,
+        nodes: [{ session_id: child.id, session_number: 11, title: 'Alternate path' }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  await app.openBranchTree();
+  if (app.elements.branchTreeBtn.textContent !== '2 paths'
+      || app.elements.branchTreeModal.hidden
+      || app.elements.branchTreeList.children.length !== 2) {
+    fail(name, 'tree did not render its count and paths');
+    return;
+  }
+  app.elements.branchTreeList.children[1].click();
+  await waitFor(() => app.state.activeSessionId === child.id, 'branch path did not become active');
+  await waitFor(() => app.elements.branchTreeBtn.hidden, 'single-path child did not hide the path button');
+  if (!app.elements.branchTreeModal.hidden || !windowObj.location.pathname.includes('/11')) {
+    fail(name, 'path switch did not close the tree and update the URL', windowObj.location.pathname);
+    return;
+  }
+  if (!treeRequests.some((url) => url.endsWith(`/sessions/${child.id}/tree`))) {
+    fail(name, 'session switch reused another component cached tree instead of refreshing the child');
+    return;
+  }
+  pass(name);
+}
+
+async function testConversationBranchPendingSelectionUsesDurableBoundaries() {
+  const name = 'conversation branch actions stage durable anchors and user prefill without persistence';
+  const { app, windowObj } = await createSessionsHarness({
+    appOverrides: { renderMessages() {} },
+  });
+  const session = {
+    id: 'branch_pending_source',
+    title: 'Branch pending',
+    messages: [
+      { id: 'u1', role: 'user', content: 'first', durable: true, durableSourceRowIds: [71] },
+      { id: 'a1', role: 'assistant', content: 'answer', durable: true, durableSourceRowIds: [72] },
+      { id: 'tools1', role: 'tool-group', content: '', durable: true, durableSourceRowIds: [73] },
+      { id: 'u2', role: 'user', content: 'edit me', durable: true, durableSourceRowIds: [74] },
+    ],
+    lastResponseId: 'resp_msg_74',
+    activeResponseId: null,
+  };
+  session.transcript = new windowObj.TermLLMConversation.ConversationController(session.id);
+  session.transcript.publishedMessages = session.messages.slice();
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+  app.elements.promptInput.value = 'unrelated draft';
+
+  if (!app.beginPendingBranch(session.messages[3], 'user')) {
+    fail(name, 'user branch action was rejected');
+    return;
+  }
+  if (app.state.pendingBranch?.anchorMessageId !== 72
+      || app.state.pendingBranch?.previousResponseId !== 'resp_msg_72'
+      || app.elements.promptInput.value !== 'edit me'
+      || app.elements.pendingBranchBanner.hidden) {
+    fail(name, 'user edit did not target preceding durable boundary or show the mounted-independent banner', JSON.stringify(app.state.pendingBranch));
+    return;
+  }
+  app.cancelPendingBranch({ restoreComposer: true });
+  if (app.state.pendingBranch || app.elements.promptInput.value !== 'unrelated draft') {
+    fail(name, 'cancel did not restore the original composer');
+    return;
+  }
+  if (!app.beginPendingBranch(session.messages[1], 'assistant')
+      || app.state.pendingBranch?.anchorMessageId !== 72
+      || app.elements.promptInput.value !== '') {
+    fail(name, 'assistant branch did not target its durable row', JSON.stringify(app.state.pendingBranch));
+    return;
+  }
+  pass(name);
+}
+
+async function testPendingBranchProjectionHidesVirtualTranscriptGaps() {
+  const name = 'pending branch projection hides suffix gaps and keeps cancel banner visible when selection is unmounted';
+  const { app } = await createSessionsHarness({ appOverrides: { renderMessages() {} } });
+  const session = { id: 'branch_gap_source', messages: [], activeResponseId: null, lastResponseId: 'resp_msg_5' };
+  app.state.sessions = [session];
+  app.state.activeSessionId = session.id;
+  app.state.draftSessionActive = false;
+
+  const before = makeNode();
+  const selected = makeNode();
+  const gap = makeNode();
+  gap.className = 'transcript-gap';
+  const suffix = makeNode();
+  const root = makeNode();
+  root.children.push(before, selected, gap, suffix);
+  root.querySelectorAll = (selector) => selector === '.branch-hidden'
+    ? root.children.filter((node) => node.classList.contains('branch-hidden'))
+    : [];
+  app.elements.messages = root;
+  app.findMessageElement = (id) => id === 'selected' ? selected : null;
+  app.state.pendingBranch = { sourceSessionId: session.id, selectedMessageId: 'selected', selectedRole: 'assistant' };
+  app.applyPendingBranchProjection();
+  if (before.classList.contains('branch-hidden') || selected.classList.contains('branch-hidden')
+      || !gap.classList.contains('branch-hidden') || !suffix.classList.contains('branch-hidden')) {
+    fail(name, 'assistant projection did not hide the complete suffix including its virtual gap');
+    return;
+  }
+
+  for (const node of root.children) node.classList.remove('branch-hidden');
+  app.state.pendingBranch.selectedRole = 'user';
+  app.applyPendingBranchProjection();
+  if (before.classList.contains('branch-hidden') || !selected.classList.contains('branch-hidden')
+      || !gap.classList.contains('branch-hidden') || !suffix.classList.contains('branch-hidden')) {
+    fail(name, 'user edit projection hid the retained prefix or exposed the selected turn');
+    return;
+  }
+
+  app.findMessageElement = () => null;
+  app.syncBranchActions();
+  if (app.elements.pendingBranchBanner.hidden) {
+    fail(name, 'unmounted branch selection lost its pending banner/cancel affordance');
+    return;
+  }
+  pass(name);
+}
+
 (async () => {
+  await testConversationBranchTreeOpensAndSwitchesPaths();
+  await testConversationBranchPendingSelectionUsesDurableBoundaries();
+  await testPendingBranchProjectionHidesVirtualTranscriptGaps();
   await testSanitizeMessagePreservesSkillRunState();
   await testSanitizeMessagePreservesAskUserCallIdentity();
   await testSanitizeMessagePreservesPlanExecutionEvidence();

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -19,6 +19,7 @@ const interjectSource = fs.readFileSync(path.join(dir, 'app-interject.js'), 'utf
 const modalsSource = fs.readFileSync(path.join(dir, 'app-modals.js'), 'utf8');
 const composerSource = fs.readFileSync(path.join(dir, 'app-composer.js'), 'utf8');
 const skillsSource = fs.readFileSync(path.join(dir, 'app-skills.js'), 'utf8');
+const branchingSource = fs.readFileSync(path.join(dir, 'app-branching.js'), 'utf8');
 const conversation = require('./conversation.js');
 const projectedMessages = (session) => session?.transcript?.conversation
   ? conversation.sessionMessages(session)
@@ -767,7 +768,11 @@ function createHarness(options = {}) {
         },
       }), {
         status: 200,
-        headers: { 'x-response-id': responseId },
+        headers: {
+          'x-response-id': responseId,
+          ...(options.postSessionId ? { 'x-session-id': String(options.postSessionId) } : {}),
+          ...(options.postBranchAnchorId ? { 'x-branch-anchor-id': String(options.postBranchAnchorId) } : {}),
+        },
       });
     }
     if (url === `/ui/v1/responses/${responseId}`) {
@@ -841,6 +846,7 @@ function createHarness(options = {}) {
   vm.runInNewContext(interjectSource, context, { filename: 'app-interject.js' });
   vm.runInNewContext(modalsSource, context, { filename: 'app-modals.js' });
   vm.runInNewContext(skillsSource, context, { filename: 'app-skills.js' });
+  vm.runInNewContext(branchingSource, context, { filename: 'app-branching.js' });
 
   const applyResponseRecoverySnapshot = app.applyResponseRecoverySnapshot;
   app.applyResponseRecoverySnapshot = (session, payload = {}) => {
@@ -4318,6 +4324,85 @@ async function testResumeActiveResponseClearsTerminalTrackingWhen409SnapshotHasN
   }
 
   await cleanup();
+  pass(name);
+}
+
+async function testSendMessageBranchesAndTransfersStreamOwnership() {
+  const name = 'real branch adoption seeds copied anchor and preserves follow-up continuation ownership';
+  const childID = 'session_branch_child';
+  const copiedAnchorID = 'resp_msg_142';
+  const failedBranchBody = [
+    'event: response.created\n',
+    'data: {"response":{"id":"resp_test","model":"test-model","status":"in_progress"},"sequence_number":1}\n\n',
+    'event: response.failed\n',
+    'data: {"error":{"message":"branch stream interrupted"},"sequence_number":2}\n\n',
+    'data: [DONE]\n\n',
+  ].join('');
+  const harness = createHarness({ postSessionId: childID, postBranchAnchorId: copiedAnchorID, postBody: failedBranchBody });
+  const { app, elements, state, fetchCalls, cleanup } = harness;
+  const source = {
+    id: 'session_branch_source',
+    title: 'Branch source',
+    provider: 'mock',
+    activeModel: 'test-model',
+    activeEffort: '',
+    messages: [
+      { id: 'u1', role: 'user', content: 'original', created: 1, durable: true, durableSourceRowIds: [41] },
+      { id: 'a1', role: 'assistant', content: 'answer', created: 2, durable: true, durableSourceRowIds: [42] },
+    ],
+    lastResponseId: 'resp_msg_99',
+    activeResponseId: null,
+    number: 1,
+  };
+  state.sessions.push(source);
+  state.activeSessionId = source.id;
+  state.selectedProvider = 'mock';
+  state.selectedModel = 'test-model';
+  state.pendingBranch = {
+    sourceSessionId: source.id,
+    anchorMessageId: 42,
+    previousResponseId: 'resp_msg_42',
+    expectedRev: 8,
+    idempotencyKey: 'branch_idempotency',
+    selectedMessageId: 'a1',
+    selectedRole: 'assistant',
+  };
+  app.refreshActiveSessionMessagesFromServer = async () => true;
+  elements.promptInput.value = 'alternate follow-up';
+
+  await app.sendMessage();
+
+  const child = state.sessions.find((session) => session.id === childID);
+  const firstPost = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const firstBody = firstPost?.body ? JSON.parse(firstPost.body) : null;
+  if (!firstBody || firstBody.branch !== true || firstBody.previous_response_id !== 'resp_msg_42'
+      || firstBody.expected_rev !== 8 || firstBody.idempotency_key !== 'branch_idempotency') {
+    await cleanup();
+    fail(name, 'branch protocol fields missing from response request', firstPost?.body || JSON.stringify(fetchCalls));
+    return;
+  }
+  if (!child || child.lastResponseId !== copiedAnchorID || state.activeSessionId !== childID
+      || state.currentStreamSessionId && state.currentStreamSessionId !== childID) {
+    await cleanup();
+    fail(name, 'real adoption did not transfer ownership and seed the copied durable anchor', JSON.stringify({ active: state.activeSessionId, stream: state.currentStreamSessionId, lastResponseId: child?.lastResponseId }));
+    return;
+  }
+  const sourceUsers = projectedMessages(source).filter((message) => message.role === 'user');
+  if (sourceUsers.some((message) => message.content === 'alternate follow-up')) {
+    await cleanup();
+    fail(name, 'optimistic branch prompt remained in source projection', JSON.stringify(sourceUsers));
+    return;
+  }
+
+  elements.promptInput.value = 'safe follow-up after interruption';
+  await app.sendMessage();
+  const posts = fetchCalls.filter((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const followUpBody = posts[1]?.body ? JSON.parse(posts[1].body) : null;
+  await cleanup();
+  if (!followUpBody || followUpBody.branch === true || followUpBody.previous_response_id !== copiedAnchorID) {
+    fail(name, 'follow-up did not preserve copied history through the adopted durable anchor', posts[1]?.body || JSON.stringify(posts));
+    return;
+  }
   pass(name);
 }
 
@@ -8104,6 +8189,7 @@ async function testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch()
   await testSendMessageDoesNotResumeAfterStalePostStream();
   await testSendMessageUsesLocalContinuationIdWithoutPreflightSync();
   await testSendMessageIncludesServerToolsForFirstPartyUI();
+  await testSendMessageBranchesAndTransfersStreamOwnership();
   await testSendMessageRecoversStaleContinuationAfterConflict();
   await testSendMessageConsumesPostStreamWhenAvailable();
   await testSendMessageRefreshesHeaderAfterCompletionUnlocksModelPicker();

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -143,6 +143,7 @@
   <link rel="preload" as="script" href="app-skills.js">
   <link rel="preload" as="script" href="app-sidebar.js">
   <link rel="preload" as="script" href="app-sessions.js">
+  <link rel="preload" as="script" href="app-branching.js">
   <link rel="preload" as="script" href="app-session-events.js">
   <link rel="preload" as="script" href="app-mcp.js">
   <link rel="preload" as="script" href="app-goals-location.js">
@@ -282,6 +283,7 @@
                 <span class="chip-label" id="chipWorktreeLabel">root</span>
               </button>
             </div>
+            <button class="header-action branch-tree-trigger" id="branchTreeBtn" type="button" hidden aria-haspopup="dialog" aria-label="Open conversation paths">1 path</button>
             <button class="header-action plan-toggle" id="planToggleBtn" type="button" hidden aria-expanded="false" aria-label="Open current plan">
               <span class="plan-toggle-word" id="planToggleWord">Plan</span>
               <span class="plan-toggle-progress" id="planToggleProgress"></span>
@@ -306,6 +308,10 @@
           <div id="voiceStatus" class="voice-status hidden" aria-live="polite"></div>
           <div id="locationStatus" class="voice-status hidden" role="status" aria-live="polite"></div>
           <div id="pendingInterjectionBanner" class="pending-interjection hidden" aria-live="polite"></div>
+          <div id="pendingBranchBanner" class="pending-branch-banner" role="status" hidden>
+            <span id="pendingBranchBannerText">New conversation path pending</span>
+            <button id="pendingBranchCancelBtn" type="button">Cancel</button>
+          </div>
           <div id="attachmentsStrip" class="attachments" style="display:none;"></div>
           <button type="button" id="goalChip" class="goal-chip hidden" aria-label="Manage goal"></button>
           <div class="composer-box">
@@ -407,6 +413,20 @@
     </div>
   </section>
   <div class="visually-hidden" id="planAnnouncement" role="status" aria-live="polite" aria-atomic="true"></div>
+
+  <div class="branch-tree-modal" id="branchTreeModal" role="dialog" aria-modal="true" aria-labelledby="branchTreeTitle" hidden>
+    <div class="branch-tree-card">
+      <div class="branch-tree-header">
+        <div>
+          <strong id="branchTreeTitle">Conversation paths</strong>
+          <p>Switch paths without deleting alternatives.</p>
+        </div>
+        <button class="icon-btn" id="branchTreeCloseBtn" type="button" aria-label="Close conversation paths">✕</button>
+      </div>
+      <div class="branch-tree-list" id="branchTreeList"></div>
+      <p class="branch-tree-note">Branches rewind conversation context only. Filesystem and tool side effects are not undone.</p>
+    </div>
+  </div>
 
   <div class="side-question-overlay hidden" id="sideQuestionOverlay" role="dialog" aria-modal="true" aria-labelledby="sideQuestionTitle">
     <div class="side-question-panel">
@@ -650,6 +670,7 @@
   <script src="intent-storage.js"></script>
   <script src="app-session-admin.js"></script>
   <script src="app-sessions.js"></script>
+  <script src="app-branching.js"></script>
   <script src="app-session-events.js"></script>
   <script src="app-diffs.js"></script>
   <script src="app-worktrees.js"></script>

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -32,6 +32,7 @@ const SHELL_ASSETS = [
   './side-question.js',
   './app-sidebar.js',
   './app-sessions.js',
+  './app-branching.js',
   './app-session-events.js',
   './app-mcp.js',
   './app-goals-location.js',

--- a/internal/session/branch.go
+++ b/internal/session/branch.go
@@ -1,0 +1,299 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+// CreateBranch materializes a normal linear child session containing the source
+// transcript prefix through opts.AnchorMessageID. The dedicated edge table is
+// metadata only; provider state, redo state, plans, goals, and usage are not copied.
+func (s *SQLiteStore) CreateBranch(ctx context.Context, sourceSessionID string, opts CreateBranchOptions) (BranchResult, error) {
+	if s == nil || !s.hasSessionBranches || !s.hasTranscriptRev || !s.hasMessageStreamIdentity || !s.hasMessageClientID {
+		return BranchResult{}, ErrBranchingUnsupported
+	}
+	sourceSessionID = strings.TrimSpace(sourceSessionID)
+	if sourceSessionID == "" || opts.AnchorMessageID < 0 {
+		return BranchResult{}, ErrNotFound
+	}
+	opts.IdempotencyKey = strings.TrimSpace(opts.IdempotencyKey)
+
+	var result BranchResult
+	err := retryOnBusy(ctx, 5, func() error {
+		conn, err := s.beginImmediate(ctx)
+		if err != nil {
+			return err
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				rollbackImmediate(conn)
+			}
+		}()
+
+		actual, err := transcriptMutationState(ctx, conn, sourceSessionID)
+		if err != nil {
+			return err
+		}
+		if opts.ExpectedState != nil && actual != *opts.ExpectedState {
+			return ErrBranchConflict
+		}
+		if opts.ExpectedRev != nil && actual.Rev != *opts.ExpectedRev {
+			return ErrBranchConflict
+		}
+
+		anchorSequence := -1
+		var nullableAnchor any
+		if opts.AnchorMessageID > 0 {
+			var anchorCompactionTail bool
+			var anchorRole, anchorText string
+			if err := conn.QueryRowContext(ctx, `
+				SELECT sequence, role, text_content, COALESCE(compaction_tail, FALSE)
+				FROM messages WHERE id = ? AND session_id = ?`, opts.AnchorMessageID, sourceSessionID).
+				Scan(&anchorSequence, &anchorRole, &anchorText, &anchorCompactionTail); errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			} else if err != nil {
+				return fmt.Errorf("resolve branch anchor: %w", err)
+			}
+			if anchorCompactionTail || (anchorRole == string(llm.RoleUser) && llm.IsInternalCompactionSummaryText(anchorText)) {
+				return ErrNotFound
+			}
+			nullableAnchor = opts.AnchorMessageID
+		}
+
+		if opts.IdempotencyKey != "" {
+			var childID string
+			var replayAnchorSequence int
+			err := conn.QueryRowContext(ctx, `
+				SELECT child_session_id, fork_after_sequence FROM session_branches
+				WHERE parent_session_id = ? AND idempotency_key = ?`, sourceSessionID, opts.IdempotencyKey).Scan(&childID, &replayAnchorSequence)
+			if err == nil {
+				if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+					return fmt.Errorf("commit branch replay: %w", err)
+				}
+				committed = true
+				_ = conn.Close()
+				child, err := s.Get(ctx, childID)
+				if err != nil {
+					return err
+				}
+				result = BranchResult{Session: child, Reused: true}
+				if replayAnchorSequence >= 0 {
+					_ = s.db.QueryRowContext(ctx, `SELECT id FROM messages WHERE session_id = ? AND sequence = ? ORDER BY id DESC LIMIT 1`, childID, replayAnchorSequence).Scan(&result.AnchorMessageID)
+				}
+				return nil
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("lookup idempotent branch: %w", err)
+			}
+		}
+
+		var parentCompactionSeq, parentCompactionCount int
+		if err := conn.QueryRowContext(ctx, `SELECT compaction_seq, compaction_count FROM sessions WHERE id = ?`, sourceSessionID).Scan(&parentCompactionSeq, &parentCompactionCount); err != nil {
+			return fmt.Errorf("load branch source compaction: %w", err)
+		}
+		childCompactionSeq, childCompactionCount := -1, 0
+		preserveCompactionTail := false
+		if parentCompactionSeq >= 0 && anchorSequence >= parentCompactionSeq {
+			childCompactionSeq = parentCompactionSeq
+			childCompactionCount = parentCompactionCount
+			preserveCompactionTail = true
+		}
+
+		childID := NewID()
+		now := time.Now()
+		insertSession := `
+			INSERT INTO sessions (
+				id, number, name, summary, generated_short_title, generated_long_title,
+				title_source, title_generated_at, title_basis_msg_seq, title_skipped_at,
+				provider, provider_key, model, reasoning_effort, reasoning_mode, mode,
+				approval_mode, origin, agent, cwd, worktree_dir, created_at, updated_at,
+				archived, pinned, parent_id, search, tools, mcp, user_turns, llm_turns,
+				tool_calls, input_tokens, cached_input_tokens, cache_write_tokens,
+				output_tokens, last_total_tokens, last_message_count, status, tags,
+				goal, share, compaction_seq, compaction_count, transcript_rev
+			)
+			SELECT ?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), '', '', '', '',
+			       '', NULL, 0, NULL,
+			       provider, provider_key, model, reasoning_effort, reasoning_mode, mode,
+			       approval_mode, origin, agent, cwd, worktree_dir, ?, ?,
+			       FALSE, FALSE, NULL, search, tools, mcp, 0, 0,
+			       0, 0, 0, 0, 0,
+			       0, 0, 'active', NULL,
+			       NULL, NULL, ?, ?, 0
+			FROM sessions WHERE id = ?`
+		inserted, err := conn.ExecContext(ctx, insertSession, childID, now, now, childCompactionSeq, childCompactionCount, sourceSessionID)
+		if err != nil {
+			return fmt.Errorf("insert branch session: %w", err)
+		}
+		if rows, _ := inserted.RowsAffected(); rows != 1 {
+			return ErrNotFound
+		}
+
+		if anchorSequence >= 0 {
+			compactionTailExpr := "FALSE"
+			prefixFilter := ""
+			if preserveCompactionTail {
+				compactionTailExpr = "compaction_tail"
+			} else {
+				// A pre-boundary branch becomes uncompacted. Copy only the visible
+				// transcript prefix: historical compaction summaries and retained
+				// duplicate tails are persistence artifacts, not additional turns.
+				prefixFilter = fmt.Sprintf(`
+					AND COALESCE(compaction_tail, FALSE) = FALSE
+					AND NOT (role = 'user' AND substr(%s, 1, %d) = '%s')`,
+					trimmedMessageTextSQL(""), len(internalCompactionSummarySQLPrefix), internalCompactionSummarySQLPrefix)
+			}
+			copyMessages := `
+				INSERT INTO messages (
+					session_id, role, parts, text_content, duration_ms, turn_index,
+					created_at, sequence, compaction_tail, client_message_id, response_id,
+					assistant_segment_ordinal, segment_start_sequence, segment_end_sequence
+				)
+				SELECT ?, role, parts, text_content, duration_ms, turn_index,
+				       created_at, sequence, ` + compactionTailExpr + `, '', '', -1, 0, 0
+				FROM messages
+				WHERE session_id = ? AND sequence <= ?` + prefixFilter + `
+				ORDER BY sequence, id`
+			if _, err := conn.ExecContext(ctx, copyMessages, childID, sourceSessionID, anchorSequence); err != nil {
+				return fmt.Errorf("copy branch messages: %w", err)
+			}
+			if _, err := conn.ExecContext(ctx, `UPDATE sessions SET transcript_rev = 1 WHERE id = ?`, childID); err != nil {
+				return fmt.Errorf("initialize branch transcript revision: %w", err)
+			}
+		}
+		if err := s.recomputeTranscriptMetadata(ctx, conn, childID, true); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+			INSERT INTO session_branches (
+				child_session_id, parent_session_id, fork_after_message_id,
+				fork_after_sequence, idempotency_key, created_at
+			) VALUES (?, ?, ?, ?, ?, ?)`, childID, sourceSessionID, nullableAnchor, anchorSequence, opts.IdempotencyKey, now); err != nil {
+			return fmt.Errorf("insert branch edge: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return fmt.Errorf("commit branch: %w", err)
+		}
+		committed = true
+		_ = conn.Close()
+
+		child, err := s.Get(ctx, childID)
+		if err != nil {
+			return err
+		}
+		result = BranchResult{Session: child}
+		if anchorSequence >= 0 {
+			if err := s.db.QueryRowContext(ctx, `SELECT id FROM messages WHERE session_id = ? AND sequence = ? ORDER BY id DESC LIMIT 1`, childID, anchorSequence).Scan(&result.AnchorMessageID); err != nil {
+				return fmt.Errorf("load copied branch anchor: %w", err)
+			}
+		}
+		return nil
+	})
+	return result, err
+}
+
+// GetBranchTree returns all surviving sessions connected to sessionID. Parent
+// IDs intentionally are not foreign keys, so a deleted parent simply makes its
+// surviving child the root of a smaller tree.
+func (s *SQLiteStore) GetBranchTree(ctx context.Context, sessionID string) (BranchTree, error) {
+	if s == nil || !s.hasSessionBranches {
+		return BranchTree{}, ErrBranchingUnsupported
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return BranchTree{}, ErrNotFound
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		WITH RECURSIVE component(id) AS (
+			VALUES (?)
+			UNION
+			SELECT b.parent_session_id
+			FROM session_branches b JOIN component c ON b.child_session_id = c.id
+			JOIN sessions parent ON parent.id = b.parent_session_id
+			UNION
+			SELECT b.child_session_id
+			FROM session_branches b JOIN component c ON b.parent_session_id = c.id
+			JOIN sessions child ON child.id = b.child_session_id
+		)
+		SELECT sess.id, COALESCE(sess.number, 0), COALESCE(edge.parent_session_id, ''),
+		       COALESCE(edge.fork_after_message_id, 0), COALESCE(edge.fork_after_sequence, -1),
+		       COALESCE(NULLIF(sess.name, ''), NULLIF(sess.generated_short_title, ''), NULLIF(sess.summary, ''), 'Untitled'),
+		       COALESCE(anchor.role, ''), COALESCE(anchor.text_content, ''), sess.created_at
+		FROM component c
+		JOIN sessions sess ON sess.id = c.id
+		LEFT JOIN session_branches edge ON edge.child_session_id = sess.id
+		LEFT JOIN messages anchor ON anchor.id = edge.fork_after_message_id
+		ORDER BY sess.created_at, sess.number`, sessionID)
+	if err != nil {
+		return BranchTree{}, fmt.Errorf("query branch tree: %w", err)
+	}
+	defer rows.Close()
+
+	byID := make(map[string]BranchTreeNode)
+	for rows.Next() {
+		var node BranchTreeNode
+		if err := rows.Scan(&node.SessionID, &node.SessionNumber, &node.ParentSessionID,
+			&node.ForkAfterMessageID, &node.ForkAfterSequence, &node.Title,
+			&node.AnchorRole, &node.AnchorPreview, &node.CreatedAt); err != nil {
+			return BranchTree{}, fmt.Errorf("scan branch tree: %w", err)
+		}
+		node.AnchorPreview = TruncateSummary(node.AnchorPreview)
+		byID[node.SessionID] = node
+	}
+	if err := rows.Err(); err != nil {
+		return BranchTree{}, err
+	}
+	if _, ok := byID[sessionID]; !ok {
+		return BranchTree{}, ErrNotFound
+	}
+
+	children := make(map[string][]BranchTreeNode)
+	roots := make([]BranchTreeNode, 0, 1)
+	for _, node := range byID {
+		if _, parentSurvives := byID[node.ParentSessionID]; node.ParentSessionID == "" || !parentSurvives {
+			roots = append(roots, node)
+		} else {
+			children[node.ParentSessionID] = append(children[node.ParentSessionID], node)
+		}
+	}
+	less := func(a, b BranchTreeNode) bool {
+		if a.CreatedAt.Equal(b.CreatedAt) {
+			return a.SessionNumber < b.SessionNumber
+		}
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	sort.Slice(roots, func(i, j int) bool { return less(roots[i], roots[j]) })
+	for parent := range children {
+		sort.Slice(children[parent], func(i, j int) bool { return less(children[parent][i], children[parent][j]) })
+	}
+
+	tree := BranchTree{ActiveSessionID: sessionID}
+	visited := make(map[string]bool, len(byID))
+	var appendTree func(BranchTreeNode)
+	appendTree = func(node BranchTreeNode) {
+		if visited[node.SessionID] {
+			return
+		}
+		visited[node.SessionID] = true
+		tree.Nodes = append(tree.Nodes, node)
+		for _, child := range children[node.SessionID] {
+			appendTree(child)
+		}
+	}
+	for _, root := range roots {
+		if tree.RootSessionID == "" {
+			tree.RootSessionID = root.SessionID
+		}
+		appendTree(root)
+	}
+	tree.PathCount = len(tree.Nodes)
+	return tree, nil
+}

--- a/internal/session/branch_test.go
+++ b/internal/session/branch_test.go
@@ -1,0 +1,284 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func newBranchTestStore(t *testing.T) (*SQLiteStore, *Session) {
+	t.Helper()
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	sess := &Session{
+		ID: "branch-source", Provider: "Mock", ProviderKey: "mock", Model: "model-a",
+		ReasoningEffort: "high", ReasoningMode: "pro", Mode: ModeChat,
+		ApprovalMode: ApprovalModeAuto, Origin: OriginWeb, Agent: "developer",
+		CWD: "/tmp/project", WorktreeDir: "/tmp/project-wt", Search: true,
+		Tools: "read_file,shell", MCP: "playwright",
+	}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatal(err)
+	}
+	return store, sess
+}
+
+func addBranchTestMessage(t *testing.T, store *SQLiteStore, sessionID string, msg llm.Message) Message {
+	t.Helper()
+	stored := NewMessage(sessionID, msg, -1)
+	if err := store.AddMessage(context.Background(), sessionID, stored); err != nil {
+		t.Fatal(err)
+	}
+	return *stored
+}
+
+func TestCreateBranchRequiresCurrentSchemaCapability(t *testing.T) {
+	store, source := newBranchTestStore(t)
+	store.hasSessionBranches = false
+	_, err := store.CreateBranch(context.Background(), source.ID, CreateBranchOptions{})
+	if !errors.Is(err, ErrBranchingUnsupported) {
+		t.Fatalf("old schema error = %v, want ErrBranchingUnsupported", err)
+	}
+}
+
+func TestCreateBranchCopiesPrefixAndClearsStreamIdentity(t *testing.T) {
+	ctx := context.Background()
+	store, source := newBranchTestStore(t)
+	user := llm.UserText("original prompt")
+	user.ClientMessageID = "client-source"
+	first := addBranchTestMessage(t, store, source.ID, user)
+	assistant := llm.AssistantText("answer")
+	assistant.ResponseID = "resp-source"
+	assistant.AssistantSegmentOrdinal = 3
+	assistant.SegmentStartSequence = 11
+	assistant.SegmentEndSequence = 19
+	second := addBranchTestMessage(t, store, source.ID, assistant)
+	_ = addBranchTestMessage(t, store, source.ID, llm.UserText("uncopied suffix"))
+
+	state, err := store.TranscriptMutationState(ctx, source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.CreateBranch(ctx, source.ID, CreateBranchOptions{
+		AnchorMessageID: second.ID,
+		ExpectedState:   &state,
+		IdempotencyKey:  "copy-prefix",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Session == nil || result.Session.ID == source.ID {
+		t.Fatalf("unexpected branch result: %#v", result)
+	}
+	child := result.Session
+	if child.ProviderKey != source.ProviderKey || child.Model != source.Model || child.ReasoningEffort != source.ReasoningEffort ||
+		child.ReasoningMode != source.ReasoningMode || child.ApprovalMode != source.ApprovalMode || child.Origin != source.Origin ||
+		child.Agent != source.Agent || child.CWD != source.CWD || child.WorktreeDir != source.WorktreeDir || !child.Search ||
+		child.Tools != source.Tools || child.MCP != source.MCP {
+		t.Fatalf("branch did not inherit runtime settings: %#v", child)
+	}
+	if child.ParentID != "" || child.InputTokens != 0 || child.LLMTurns != 0 || child.Status != StatusActive {
+		t.Fatalf("branch inherited lineage/activity state: %#v", child)
+	}
+
+	messages, err := store.GetMessages(ctx, child.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 || messages[0].TextContent != "original prompt" || messages[1].TextContent != "answer" {
+		t.Fatalf("copied messages = %#v", messages)
+	}
+	if messages[0].ID == first.ID || messages[1].ID == second.ID || result.AnchorMessageID != messages[1].ID {
+		t.Fatalf("branch did not allocate fresh message identities: %#v", messages)
+	}
+	if messages[0].ClientMessageID != "" || messages[1].ResponseID != "" || messages[1].AssistantSegmentOrdinal != -1 ||
+		messages[1].SegmentStartSequence != 0 || messages[1].SegmentEndSequence != 0 {
+		t.Fatalf("copied stream identity was not cleared: %#v", messages)
+	}
+	if len(messages[1].Parts) != len(second.Parts) || messages[1].Parts[0].Text != second.Parts[0].Text {
+		t.Fatalf("parts fidelity lost: got %#v want %#v", messages[1].Parts, second.Parts)
+	}
+}
+
+func TestCreateBranchEmptyIdempotentAndRevisionConflict(t *testing.T) {
+	ctx := context.Background()
+	store, source := newBranchTestStore(t)
+	if ErrBranchConflict == ErrTranscriptConflict {
+		t.Fatal("ErrBranchConflict must remain a distinct branch-specific sentinel")
+	}
+	if !errors.Is(ErrBranchConflict, ErrTranscriptConflict) || errors.Is(ErrTranscriptConflict, ErrBranchConflict) {
+		t.Fatalf("branch/transcript conflict matching is not directional as documented")
+	}
+	sourceMessage := addBranchTestMessage(t, store, source.ID, llm.UserText("source"))
+	state, err := store.TranscriptMutationState(ctx, source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.CreateBranch(ctx, source.ID, CreateBranchOptions{ExpectedState: &state, IdempotencyKey: "empty"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages, _ := store.GetMessages(ctx, result.Session.ID, 0, 0)
+	if len(messages) != 0 || result.AnchorMessageID != 0 {
+		t.Fatalf("empty branch copied messages: %#v", messages)
+	}
+	replay, err := store.CreateBranch(ctx, source.ID, CreateBranchOptions{
+		AnchorMessageID: sourceMessage.ID,
+		ExpectedState:   &state,
+		IdempotencyKey:  "empty",
+	})
+	if err != nil || !replay.Reused || replay.Session.ID != result.Session.ID || replay.AnchorMessageID != 0 {
+		t.Fatalf("idempotent replay = %#v, %v", replay, err)
+	}
+
+	staleRev := state.Rev - 1
+	_, err = store.CreateBranch(ctx, source.ID, CreateBranchOptions{ExpectedRev: &staleRev})
+	if !errors.Is(err, ErrBranchConflict) {
+		t.Fatalf("stale revision error = %v", err)
+	}
+}
+
+func TestCreateBranchCompactionProviderRedoAndOrphanTree(t *testing.T) {
+	ctx := context.Background()
+	store, source := newBranchTestStore(t)
+	pre := addBranchTestMessage(t, store, source.ID, llm.UserText("before compaction"))
+	post := addBranchTestMessage(t, store, source.ID, llm.AssistantText("after compaction"))
+	if _, err := store.db.Exec(`UPDATE sessions SET compaction_seq = ?, compaction_count = 2 WHERE id = ?`, post.Sequence, source.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE messages SET compaction_tail = TRUE WHERE id = ?`, pre.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveProviderState(ctx, source.ID, "mock", []byte(`{"opaque":true}`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO session_redo(session_id, stack_pos, suffix, metadata) VALUES (?, 0, '[]', '{}')`, source.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := store.CreateBranch(ctx, source.ID, CreateBranchOptions{AnchorMessageID: pre.ID, IdempotencyKey: "pre"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("hidden compaction-tail anchor error = %v, want ErrNotFound", err)
+	}
+
+	after, err := store.CreateBranch(ctx, source.ID, CreateBranchOptions{AnchorMessageID: post.ID, IdempotencyKey: "post"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Session.CompactionSeq != post.Sequence || after.Session.CompactionCount != 2 {
+		t.Fatalf("post-boundary branch compaction = %d/%d", after.Session.CompactionSeq, after.Session.CompactionCount)
+	}
+	childProviderState, err := store.LoadProviderState(ctx, after.Session.ID, "mock")
+	if err != nil || len(childProviderState) != 0 {
+		t.Fatalf("child provider state = %q, %v; want empty", childProviderState, err)
+	}
+	var redoCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM session_redo WHERE session_id = ?`, after.Session.ID).Scan(&redoCount); err != nil || redoCount != 0 {
+		t.Fatalf("child redo count/error = %d/%v", redoCount, err)
+	}
+
+	tree, err := store.GetBranchTree(ctx, after.Session.ID)
+	if err != nil || len(tree.Nodes) != 2 || tree.PathCount != 2 || tree.RootSessionID != source.ID {
+		t.Fatalf("tree before parent delete = %#v, %v", tree, err)
+	}
+	if err := store.Delete(ctx, source.ID); err != nil {
+		t.Fatal(err)
+	}
+	orphan, err := store.GetBranchTree(ctx, after.Session.ID)
+	if err != nil || len(orphan.Nodes) != 1 || orphan.RootSessionID != after.Session.ID {
+		t.Fatalf("orphan tree = %#v, %v", orphan, err)
+	}
+}
+
+func TestCreateBranchAfterTwoCompactionsCopiesVisiblePreBoundaryPrefixOnce(t *testing.T) {
+	ctx := context.Background()
+	store, source := newBranchTestStore(t)
+	originalUser := addBranchTestMessage(t, store, source.ID, llm.UserText("original question"))
+	originalAssistant := addBranchTestMessage(t, store, source.ID, llm.AssistantText("original answer"))
+
+	firstSummary := *NewMessage(source.ID, llm.UserText("[Context Compaction]\nfirst summary"), -1)
+	firstAck := *NewMessage(source.ID, llm.AssistantText("I've reviewed the context summary. I'll continue from where we left off."), -1)
+	firstAck.CompactionTail = true
+	firstRetainedUser := *NewMessage(source.ID, llm.UserText("original question"), -1)
+	firstRetainedUser.CompactionTail = true
+	firstRetainedAssistant := *NewMessage(source.ID, llm.AssistantText("original answer"), -1)
+	firstRetainedAssistant.CompactionTail = true
+	if err := store.CompactMessages(ctx, source.ID, []Message{firstSummary, firstAck, firstRetainedUser, firstRetainedAssistant}); err != nil {
+		t.Fatal(err)
+	}
+
+	laterUser := addBranchTestMessage(t, store, source.ID, llm.UserText("later question"))
+	laterAssistant := addBranchTestMessage(t, store, source.ID, llm.AssistantText("later answer"))
+	secondSummary := *NewMessage(source.ID, llm.UserText("[Context Compaction]\nsecond summary"), -1)
+	secondAck := *NewMessage(source.ID, llm.AssistantText("I've reviewed the context summary. I'll continue from where we left off."), -1)
+	secondAck.CompactionTail = true
+	secondRetainedUser := *NewMessage(source.ID, llm.UserText("later question"), -1)
+	secondRetainedUser.CompactionTail = true
+	secondRetainedAssistant := *NewMessage(source.ID, llm.AssistantText("later answer"), -1)
+	secondRetainedAssistant.CompactionTail = true
+	if err := store.CompactMessages(ctx, source.ID, []Message{secondSummary, secondAck, secondRetainedUser, secondRetainedAssistant}); err != nil {
+		t.Fatal(err)
+	}
+
+	refreshed, err := store.Get(ctx, source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.CompactionCount != 2 || laterAssistant.Sequence >= refreshed.CompactionSeq {
+		t.Fatalf("fixture compaction boundary/count = %d/%d, anchor sequence=%d", refreshed.CompactionSeq, refreshed.CompactionCount, laterAssistant.Sequence)
+	}
+
+	result, err := store.CreateBranch(ctx, source.ID, CreateBranchOptions{AnchorMessageID: laterAssistant.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Session.CompactionSeq != -1 || result.Session.CompactionCount != 0 {
+		t.Fatalf("pre-boundary child compaction = %d/%d", result.Session.CompactionSeq, result.Session.CompactionCount)
+	}
+	messages, err := store.GetMessages(ctx, result.Session.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"original question", "original answer", "later question", "later answer"}
+	if len(messages) != len(want) {
+		t.Fatalf("copied messages = %#v, want one visible prefix", messages)
+	}
+	for i, message := range messages {
+		if message.TextContent != want[i] || message.CompactionTail || llm.IsInternalCompactionSummaryText(message.TextContent) {
+			t.Fatalf("copied message %d = %#v, want %q", i, message, want[i])
+		}
+	}
+	if messages[0].ID == originalUser.ID || messages[1].ID == originalAssistant.ID || messages[2].ID == laterUser.ID || messages[3].ID == laterAssistant.ID {
+		t.Fatalf("branch reused source row identities: %#v", messages)
+	}
+	if result.AnchorMessageID != messages[3].ID {
+		t.Fatalf("copied anchor = %d, want %d", result.AnchorMessageID, messages[3].ID)
+	}
+}
+
+func TestLoggingStoreConversationBranchCapabilityDelegatesAndFallsBack(t *testing.T) {
+	ctx := context.Background()
+	store, source := newBranchTestStore(t)
+	logging := NewLoggingStore(store, nil)
+	result, err := logging.CreateBranch(ctx, source.ID, CreateBranchOptions{IdempotencyKey: "logging"})
+	if err != nil || result.Session == nil {
+		t.Fatalf("delegated CreateBranch = %#v, %v", result, err)
+	}
+	tree, err := logging.GetBranchTree(ctx, result.Session.ID)
+	if err != nil || len(tree.Nodes) != 2 {
+		t.Fatalf("delegated GetBranchTree = %#v, %v", tree, err)
+	}
+
+	fallback := NewLoggingStore(&NoopStore{}, nil)
+	if _, err := fallback.CreateBranch(ctx, source.ID, CreateBranchOptions{}); !errors.Is(err, ErrBranchingUnsupported) {
+		t.Fatalf("fallback CreateBranch error = %v", err)
+	}
+	if _, err := fallback.GetBranchTree(ctx, source.ID); !errors.Is(err, ErrBranchingUnsupported) {
+		t.Fatalf("fallback GetBranchTree error = %v", err)
+	}
+}

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -386,6 +386,32 @@ func (s *LoggingStore) TranscriptRev(ctx context.Context, sessionID string) (int
 	return rev, err
 }
 
+// CreateBranch preserves the optional branching capability through the logging decorator.
+func (s *LoggingStore) CreateBranch(ctx context.Context, sourceSessionID string, opts CreateBranchOptions) (BranchResult, error) {
+	store, ok := s.Store.(ConversationBranchStore)
+	if !ok {
+		return BranchResult{}, ErrBranchingUnsupported
+	}
+	result, err := store.CreateBranch(ctx, sourceSessionID, opts)
+	if err != nil && !errors.Is(err, ErrBranchConflict) {
+		s.logOnce("CreateBranch", err)
+	}
+	return result, err
+}
+
+// GetBranchTree preserves the optional branching capability through the logging decorator.
+func (s *LoggingStore) GetBranchTree(ctx context.Context, sessionID string) (BranchTree, error) {
+	store, ok := s.Store.(ConversationBranchStore)
+	if !ok {
+		return BranchTree{}, ErrBranchingUnsupported
+	}
+	tree, err := store.GetBranchTree(ctx, sessionID)
+	if err != nil {
+		s.logOnce("GetBranchTree", err)
+	}
+	return tree, err
+}
+
 // PreviousUserPrompt delegates the optional PromptHistoryStore capability when
 // the wrapped store supports it.
 func (s *LoggingStore) PreviousUserPrompt(ctx context.Context, agent string, beforeID int64) (*PromptHistoryEntry, error) {

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -48,9 +48,11 @@ type SQLiteStore struct {
 	hasMessageCompactionTail bool // true if messages table has compaction_tail column
 	hasMessageStreamIdentity bool // true if messages table has response-scoped segment identity columns
 	hasMessageClientID       bool // true if messages table has client_message_id
+	hasSessionBranches       bool // true if session_branches table exists
 }
 
 var _ MessageSequenceStore = (*SQLiteStore)(nil)
+var _ ConversationBranchStore = (*SQLiteStore)(nil)
 
 // Schema for the sessions database.
 const schema = `
@@ -153,6 +155,18 @@ CREATE TABLE IF NOT EXISTS session_redo (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (session_id, stack_pos)
 );
+
+CREATE TABLE IF NOT EXISTS session_branches (
+    child_session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    parent_session_id TEXT NOT NULL,
+    fork_after_message_id INTEGER,
+    fork_after_sequence INTEGER NOT NULL,
+    idempotency_key TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_branches_idempotency
+    ON session_branches(parent_session_id, idempotency_key)
+    WHERE idempotency_key <> '';
 
 -- Metadata table for current session tracking
 CREATE TABLE IF NOT EXISTS metadata (
@@ -295,6 +309,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 	if cfg.ReadOnly {
 		store.probeSessionColumns()
 		store.probeMessageColumns()
+		store.probeBranchTable()
 	} else {
 		store.setCurrentColumns()
 	}
@@ -343,7 +358,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 44
+const schemaVersion = 45
 
 // migration represents a schema migration.
 type migration struct {
@@ -1239,6 +1254,30 @@ var migrations = []migration{
 				PRIMARY KEY (session_id, stack_pos)
 			)`)
 			return err
+		},
+	},
+	{
+		version:     45,
+		description: "create conversation branch edges",
+		up: func(db schemaExecutor) error {
+			for _, statement := range []string{
+				`CREATE TABLE IF NOT EXISTS session_branches (
+					child_session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+					parent_session_id TEXT NOT NULL,
+					fork_after_message_id INTEGER,
+					fork_after_sequence INTEGER NOT NULL,
+					idempotency_key TEXT NOT NULL DEFAULT '',
+					created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)`,
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_branches_idempotency
+					ON session_branches(parent_session_id, idempotency_key)
+					WHERE idempotency_key <> ''`,
+			} {
+				if _, err := db.Exec(statement); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	},
 }
@@ -4556,6 +4595,14 @@ func (s *SQLiteStore) setCurrentColumns() {
 	s.hasMessageCompactionTail = true
 	s.hasMessageStreamIdentity = true
 	s.hasMessageClientID = true
+	s.hasSessionBranches = true
+}
+
+func (s *SQLiteStore) probeBranchTable() {
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'session_branches'`).Scan(&count); err == nil {
+		s.hasSessionBranches = count > 0
+	}
 }
 
 // probeSessionColumns checks optional session columns in a single PRAGMA scan.

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -515,6 +515,8 @@ func TestInitSchemaFreshDBDoesNotRunHistoricalMigrations(t *testing.T) {
 	}{
 		{objectType: "table", name: "push_subscriptions"},
 		{objectType: "table", name: "session_provider_state"},
+		{objectType: "table", name: "session_branches"},
+		{objectType: "index", name: "idx_session_branches_idempotency"},
 		{objectType: "index", name: "idx_messages_session_sequence"},
 		{objectType: "index", name: "idx_sessions_status"},
 		{objectType: "index", name: "idx_sessions_title_skipped"},

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -28,6 +28,11 @@ var (
 	// ErrTranscriptConflict means a transcript mutation was based on a stale
 	// revision or head row and must be retried after refreshing the transcript.
 	ErrTranscriptConflict = errors.New("session: transcript changed")
+	// Branch errors describe unavailable schema support and stale optimistic state.
+	ErrBranchingUnsupported = errors.New("session: conversation branching unsupported")
+	// ErrBranchConflict is branch-specific while matching the shared transcript
+	// conflict sentinel for callers that handle all optimistic transcript races.
+	ErrBranchConflict = fmt.Errorf("session: branch conflict: %w", ErrTranscriptConflict)
 	// ErrNothingToUndo means there is no real post-compaction user turn to undo.
 	ErrNothingToUndo = errors.New("session: nothing to undo")
 	// ErrNothingToRedo means no durable undo suffix remains for this session.
@@ -384,6 +389,52 @@ type TranscriptUndoRedoStore interface {
 	TranscriptMutationState(ctx context.Context, sessionID string) (TranscriptMutationState, error)
 	UndoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error)
 	RedoLastUserTurn(ctx context.Context, sessionID string, expected TranscriptMutationState) (TranscriptMutationResult, error)
+}
+
+// CreateBranchOptions identifies a durable source prefix and optional optimistic
+// concurrency/idempotency guards. AnchorMessageID zero means an empty prefix.
+type CreateBranchOptions struct {
+	AnchorMessageID int64
+	ExpectedState   *TranscriptMutationState
+	ExpectedRev     *int64
+	IdempotencyKey  string
+}
+
+// BranchResult is the newly materialized (or idempotently reused) linear child.
+type BranchResult struct {
+	Session         *Session `json:"session"`
+	AnchorMessageID int64    `json:"anchor_message_id,omitempty"`
+	Reused          bool     `json:"reused,omitempty"`
+}
+
+// BranchTreeNode is one normal session in a connected conversation tree.
+type BranchTreeNode struct {
+	SessionID          string    `json:"session_id"`
+	SessionNumber      int64     `json:"session_number,omitempty"`
+	ParentSessionID    string    `json:"parent_session_id,omitempty"`
+	ForkAfterMessageID int64     `json:"fork_after_message_id,omitempty"`
+	ForkAfterSequence  int       `json:"fork_after_sequence"`
+	Title              string    `json:"title,omitempty"`
+	AnchorRole         string    `json:"anchor_role,omitempty"`
+	AnchorPreview      string    `json:"anchor_preview,omitempty"`
+	CreatedAt          time.Time `json:"created_at"`
+}
+
+// BranchTree is a connected component rooted at its oldest surviving ancestor.
+// PathCount counts independently resumable linear sessions in the component;
+// it intentionally equals len(Nodes), including non-leaf ancestor sessions.
+type BranchTree struct {
+	RootSessionID   string           `json:"root_session_id"`
+	ActiveSessionID string           `json:"active_session_id"`
+	PathCount       int              `json:"path_count"`
+	Nodes           []BranchTreeNode `json:"nodes"`
+}
+
+// ConversationBranchStore is an optional capability so old/read-only schemas
+// and custom stores can fail explicitly without expanding the core Store API.
+type ConversationBranchStore interface {
+	CreateBranch(ctx context.Context, sourceSessionID string, opts CreateBranchOptions) (BranchResult, error)
+	GetBranchTree(ctx context.Context, sessionID string) (BranchTree, error)
 }
 
 // SessionSummaryTranscriptRevisionReporter reports whether Store.List populates

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -52,6 +52,14 @@ type pendingStreamModelSwitch struct {
 	applied  bool
 }
 
+type pendingConversationBranch struct {
+	sourceSessionID string
+	anchorMessageID int64
+	expected        session.TranscriptMutationState
+	idempotencyKey  string
+	prefill         string
+}
+
 type promptHistoryState struct {
 	active          bool
 	cursorID        int64
@@ -309,12 +317,18 @@ type Model struct {
 
 	// If set, the caller should relaunch chat with this session ID.
 	pendingResumeSessionID string
+	pendingBranch          *pendingConversationBranch
+	pendingBranchPrefill   string
+	branchTreeChoices      map[string]pendingConversationBranch
 
 	// If set, the caller should auto-send this message after handover restart.
 	pendingHandoverAutoSend string
 
 	// If set, auto-send this message on Init (used after handover restart).
 	handoverAutoSend string
+	// branchPrefill restores an edited/follow-up draft after a branch relaunch
+	// without submitting it to the model.
+	branchPrefill string
 
 	// Deferred model switch marker for non-submitting shortcuts such as Ctrl+R.
 	// Coalesces repeated effort changes and is appended when the next user turn is sent.
@@ -1641,6 +1655,14 @@ func (m *Model) Init() tea.Cmd {
 		m.chatRenderer.SetToolsExpanded(m.toolsExpanded)
 	}
 
+	// Branch relaunches restore the user's edited/follow-up draft but deliberately
+	// require a fresh Enter confirmation instead of auto-sending it.
+	if m.branchPrefill != "" {
+		m.textarea.SetValue(m.branchPrefill)
+		m.branchPrefill = ""
+		m.updateTextareaHeight()
+	}
+
 	// Handover auto-send: send the target agent's default prompt after restart
 	if m.handoverAutoSend != "" {
 		m.textarea.SetValue(m.handoverAutoSend)
@@ -1686,6 +1708,11 @@ func (m *Model) RequestedResumeSessionID() string {
 // RequestedHandoverAutoSend returns a message to auto-send after handover restart.
 func (m *Model) RequestedHandoverAutoSend() string {
 	return strings.TrimSpace(m.pendingHandoverAutoSend)
+}
+
+// RequestedBranchPrefill returns a draft to restore without auto-submitting it.
+func (m *Model) RequestedBranchPrefill() string {
+	return m.pendingBranchPrefill
 }
 
 // YoloModeActive returns the current effective yolo state, including approval
@@ -1740,6 +1767,11 @@ func (m *Model) WaitStreamDone() {
 // SetHandoverAutoSend sets a message to auto-send on Init (for handover restart).
 func (m *Model) SetHandoverAutoSend(text string) {
 	m.handoverAutoSend = strings.TrimSpace(text)
+}
+
+// SetBranchPrefill restores a branch draft on Init without scheduling send.
+func (m *Model) SetBranchPrefill(text string) {
+	m.branchPrefill = text
 }
 
 func chatMouseModeFromEnv() bool {

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -104,6 +104,11 @@ func AllCommands() []Command {
 			Usage:       "/clear",
 		},
 		{
+			Name:        "tree",
+			Description: "Browse conversation paths or branch from an earlier message",
+			Usage:       "/tree",
+		},
+		{
 			Name:        "undo",
 			Description: "Remove the latest user turn and everything after it",
 			Usage:       "/undo",
@@ -528,6 +533,8 @@ func (m *Model) ExecuteCommand(input string) (tea.Model, tea.Cmd) {
 		return m.cmdGoal(args, rawArgs)
 	case "clear":
 		return m.cmdClear()
+	case "tree":
+		return m.cmdTree(args)
 	case "undo":
 		return m.cmdUndoRedo(false, args)
 	case "redo":

--- a/internal/tui/chat/dialog.go
+++ b/internal/tui/chat/dialog.go
@@ -22,6 +22,7 @@ const (
 	DialogNone DialogType = iota
 	DialogModelPicker
 	DialogSessionList
+	DialogBranchTree
 	DialogDirApproval
 	DialogMCPPicker
 	DialogWorktreeRecovery
@@ -161,15 +162,24 @@ func (d *DialogModel) ShowModelPicker(currentProviderModel string, providers []P
 // ShowSessionList opens the session list dialog.
 // items should have ID=full session ID, Label=display name.
 func (d *DialogModel) ShowSessionList(items []DialogItem, currentSessionID string) {
-	d.dialogType = DialogSessionList
-	d.title = "Resume Session"
+	d.showSessionItems(DialogSessionList, "Resume Session", items, currentSessionID)
+}
+
+// ShowBranchTree opens the connected paths and durable branch-point picker.
+func (d *DialogModel) ShowBranchTree(items []DialogItem, currentItemID string) {
+	d.showSessionItems(DialogBranchTree, "Conversation Tree", items, currentItemID)
+}
+
+func (d *DialogModel) showSessionItems(dialogType DialogType, title string, items []DialogItem, currentItemID string) {
+	d.dialogType = dialogType
+	d.title = title
 	d.cursor = 0
 	d.query = ""
 	d.items = nil
 	d.filtered = nil
 
 	for _, item := range items {
-		item.Selected = item.ID == currentSessionID
+		item.Selected = item.ID == currentItemID
 		d.items = append(d.items, item)
 		if item.Selected {
 			d.cursor = len(d.items) - 1

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -639,6 +639,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				case DialogSessionList:
 					m.dialog.Close()
 					return m.cmdResume([]string{selected.ID})
+				case DialogBranchTree:
+					m.dialog.Close()
+					return m.handleBranchTreeSelection(selected.ID)
 				case DialogShareChoice:
 					req := m.pendingShare
 					m.pendingShare = nil
@@ -816,6 +819,11 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.textarea.Value() != "" {
 			m.setTextareaValue("")
 			m.pasteChunks = nil
+			return m, nil
+		}
+		if m.pendingBranch != nil {
+			m.pendingBranch = nil
+			return m.showFooterMuted("Pending branch cancelled.")
 		}
 		return m, nil
 	}
@@ -1154,6 +1162,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// paths like /tmp/foo do not trap the composer behind command handling.
 		if strings.HasPrefix(content, "/") && m.isSlashCommandLike(content) {
 			return m.handleSlashCommand(content)
+		}
+		if m.pendingBranch != nil && content != "" {
+			return m.submitPendingBranch(content)
 		}
 
 		// sendMessage expands collapsed paste placeholders only after deriving

--- a/internal/tui/chat/tree.go
+++ b/internal/tui/chat/tree.go
@@ -1,0 +1,218 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func branchTreeDepths(tree session.BranchTree) map[string]int {
+	depths := make(map[string]int, len(tree.Nodes))
+	for _, node := range tree.Nodes {
+		depth := 0
+		parent := node.ParentSessionID
+		for parent != "" && depth < len(tree.Nodes) {
+			depth++
+			found := false
+			for _, candidate := range tree.Nodes {
+				if candidate.SessionID == parent {
+					parent = candidate.ParentSessionID
+					found = true
+					break
+				}
+			}
+			if !found {
+				break
+			}
+		}
+		depths[node.SessionID] = depth
+	}
+	return depths
+}
+
+func branchMessagePreview(message session.Message) string {
+	text := strings.TrimSpace(message.TextContent)
+	if text == "" {
+		text = "(attachment or tool content)"
+	}
+	return session.TruncateSummary(text)
+}
+
+func hiddenBranchTreeMessage(message session.Message) bool {
+	if message.CompactionTail || llm.IsInternalCompactionSummaryText(message.TextContent) {
+		return true
+	}
+	for _, part := range message.Parts {
+		if part.Type == llm.PartText && llm.IsInternalCompactionSummaryText(part.Text) {
+			return true
+		}
+	}
+	return false
+}
+
+func visibleAssistantBranchRow(message session.Message) bool {
+	if strings.TrimSpace(message.TextContent) != "" {
+		return true
+	}
+	for _, part := range message.Parts {
+		if part.Type == llm.PartText && strings.TrimSpace(part.Text) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Model) cmdTree(args []string) (tea.Model, tea.Cmd) {
+	if len(args) != 0 {
+		m.setTextareaValue("")
+		return m.showFooterError("Usage: /tree")
+	}
+	if m.transcriptMutationBusy() {
+		return m.showFooterWarning("Cannot open the conversation tree while work is active.")
+	}
+	if m.store == nil || m.sess == nil || strings.TrimSpace(m.sess.ID) == "" {
+		return m.showFooterError("No stored conversation to branch.")
+	}
+	branchStore, ok := m.store.(session.ConversationBranchStore)
+	if !ok {
+		return m.showFooterError("Session storage does not support conversation branching.")
+	}
+	ctx := context.Background()
+	tree, err := branchStore.GetBranchTree(ctx, m.sess.ID)
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Load conversation tree: %v", err))
+	}
+	messages, err := m.store.GetMessages(ctx, m.sess.ID, 0, 0)
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Load branch points: %v", err))
+	}
+	mutationStore, ok := m.store.(session.TranscriptUndoRedoStore)
+	if !ok {
+		return m.showFooterError("Session storage does not support revision-safe branching.")
+	}
+	state, err := mutationStore.TranscriptMutationState(ctx, m.sess.ID)
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Load conversation revision: %v", err))
+	}
+
+	items := make([]DialogItem, 0, len(tree.Nodes)+len(messages))
+	depths := branchTreeDepths(tree)
+	for _, node := range tree.Nodes {
+		marker := "○"
+		if node.SessionID == m.sess.ID {
+			marker = "●"
+		}
+		label := strings.Repeat("  ", depths[node.SessionID]) + marker + " " + node.Title
+		description := fmt.Sprintf("#%d", node.SessionNumber)
+		if node.AnchorPreview != "" {
+			description += " · forked after " + node.AnchorPreview
+		}
+		items = append(items, DialogItem{
+			ID: "path:" + node.SessionID, Label: label, Description: description, Category: "Existing paths",
+		})
+	}
+
+	m.branchTreeChoices = make(map[string]pendingConversationBranch)
+	previousContinuationID := int64(0)
+	for _, message := range messages {
+		if hiddenBranchTreeMessage(message) || message.Role == llm.RoleSystem || message.Role == llm.RoleDeveloper || message.Role == llm.RoleEvent {
+			continue
+		}
+		anchorID := message.ID
+		prefill := ""
+		roleLabel := string(message.Role)
+		switch message.Role {
+		case llm.RoleUser:
+			anchorID = previousContinuationID
+			prefill = message.TextContent
+			roleLabel = "edit user"
+		case llm.RoleAssistant:
+			if !visibleAssistantBranchRow(message) {
+				continue
+			}
+			roleLabel = "branch after assistant"
+		case llm.RoleTool:
+			roleLabel = "branch after tool"
+		default:
+			continue
+		}
+		choiceID := fmt.Sprintf("fork:%d:%d", anchorID, message.ID)
+		choice := pendingConversationBranch{
+			sourceSessionID: m.sess.ID,
+			anchorMessageID: anchorID,
+			expected:        state,
+			idempotencyKey:  session.NewID(),
+			prefill:         prefill,
+		}
+		m.branchTreeChoices[choiceID] = choice
+		items = append(items, DialogItem{
+			ID: choiceID, Label: roleLabel + ": " + branchMessagePreview(message),
+			Description: fmt.Sprintf("message %d", message.Sequence+1), Category: "Branch points",
+		})
+		if message.Role == llm.RoleUser || message.Role == llm.RoleAssistant {
+			previousContinuationID = message.ID
+		}
+	}
+	m.dialog.ShowBranchTree(items, "path:"+m.sess.ID)
+	m.setTextareaValue("")
+	return m, nil
+}
+
+func (m *Model) handleBranchTreeSelection(choiceID string) (tea.Model, tea.Cmd) {
+	if strings.HasPrefix(choiceID, "path:") {
+		return m.requestResumeSession(strings.TrimPrefix(choiceID, "path:"))
+	}
+	choice, ok := m.branchTreeChoices[choiceID]
+	if !ok {
+		return m.showFooterError("That branch point is no longer available.")
+	}
+	m.pendingBranch = &choice
+	m.setTextareaValue(choice.prefill)
+	m.textarea.Focus()
+	return m.showFooterWarning("Branch pending. Edit or type a prompt, then press Enter. Conversation context rewinds; filesystem and tool side effects do not.")
+}
+
+func (m *Model) submitPendingBranch(prefill string) (tea.Model, tea.Cmd) {
+	if m.pendingBranch == nil {
+		return m, nil
+	}
+	if m.transcriptMutationBusy() {
+		return m.showFooterWarning("Cannot create a branch while work is active.")
+	}
+	if len(m.files) > 0 || len(m.images) > 0 {
+		return m.showFooterWarning("Create the branch before attaching files or images.")
+	}
+	branchStore, ok := m.store.(session.ConversationBranchStore)
+	if !ok {
+		return m.showFooterError("Session storage does not support conversation branching.")
+	}
+	pending := *m.pendingBranch
+	result, err := branchStore.CreateBranch(context.Background(), pending.sourceSessionID, session.CreateBranchOptions{
+		AnchorMessageID: pending.anchorMessageID,
+		ExpectedState:   &pending.expected,
+		IdempotencyKey:  pending.idempotencyKey,
+	})
+	switch {
+	case errors.Is(err, session.ErrBranchConflict):
+		m.pendingBranch = nil
+		return m.showFooterWarning("Conversation changed in another client; reopen /tree and try again.")
+	case err != nil:
+		return m.showFooterError(fmt.Sprintf("Create branch: %v", err))
+	case result.Session == nil:
+		return m.showFooterError("Create branch: storage returned no child session.")
+	}
+	if err := m.store.SetCurrent(context.Background(), result.Session.ID); err != nil {
+		return m.showFooterError(fmt.Sprintf("Select branch: %v", err))
+	}
+	m.pendingBranch = nil
+	m.pendingResumeSessionID = result.Session.ID
+	m.pendingBranchPrefill = prefill
+	m.clearSideQuestionHistory()
+	m.quitting = true
+	return m, m.quitCmd()
+}

--- a/internal/tui/chat/tree_test.go
+++ b/internal/tui/chat/tree_test.go
@@ -1,0 +1,189 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type branchChatStore struct {
+	*mockStore
+	tree       session.BranchTree
+	state      session.TranscriptMutationState
+	result     session.BranchResult
+	createOpts []session.CreateBranchOptions
+	currentID  string
+}
+
+func (s *branchChatStore) GetBranchTree(context.Context, string) (session.BranchTree, error) {
+	return s.tree, nil
+}
+
+func (s *branchChatStore) TranscriptMutationState(context.Context, string) (session.TranscriptMutationState, error) {
+	return s.state, nil
+}
+
+func (s *branchChatStore) UndoLastUserTurn(context.Context, string, session.TranscriptMutationState) (session.TranscriptMutationResult, error) {
+	return session.TranscriptMutationResult{}, nil
+}
+
+func (s *branchChatStore) RedoLastUserTurn(context.Context, string, session.TranscriptMutationState) (session.TranscriptMutationResult, error) {
+	return session.TranscriptMutationResult{}, nil
+}
+
+func (s *branchChatStore) CreateBranch(_ context.Context, _ string, opts session.CreateBranchOptions) (session.BranchResult, error) {
+	s.createOpts = append(s.createOpts, opts)
+	return s.result, nil
+}
+
+func (s *branchChatStore) SetCurrent(_ context.Context, id string) error {
+	s.currentID = id
+	return nil
+}
+
+func newBranchChatModel() (*Model, *branchChatStore, []session.Message) {
+	const sourceID = "tui-tree-source"
+	messages := []session.Message{
+		{ID: 11, SessionID: sourceID, Role: llm.RoleUser, TextContent: "first question", Sequence: 0},
+		{ID: 12, SessionID: sourceID, Role: llm.RoleAssistant, TextContent: "first answer", Sequence: 1},
+		{ID: 13, SessionID: sourceID, Role: llm.RoleUser, TextContent: "edit this question", Sequence: 2},
+	}
+	base := &mockStore{
+		sessions: map[string]*session.Session{
+			sourceID: {ID: sourceID, Number: 1, Provider: "mock", Model: "mock"},
+		},
+		messages: map[string][]session.Message{sourceID: messages},
+	}
+	store := &branchChatStore{
+		mockStore: base,
+		state:     session.TranscriptMutationState{Rev: 7, HeadID: 13},
+		tree: session.BranchTree{
+			RootSessionID: sourceID, ActiveSessionID: sourceID, PathCount: 2,
+			Nodes: []session.BranchTreeNode{
+				{SessionID: sourceID, SessionNumber: 1, Title: "Original"},
+				{SessionID: "existing-child", SessionNumber: 2, ParentSessionID: sourceID, Title: "Existing path", ForkAfterMessageID: 12},
+			},
+		},
+		result: session.BranchResult{Session: &session.Session{ID: "new-child", Provider: "mock", Model: "mock"}},
+	}
+	m := newCmdTestModel(store)
+	m.sess = base.sessions[sourceID]
+	m.messages = messages
+	return m, store, messages
+}
+
+func TestTreeUserSelectionTargetsPreviousBoundaryAndRelaunchesWithPrefill(t *testing.T) {
+	m, store, messages := newBranchChatModel()
+	updated, cmd := m.cmdTree(nil)
+	m = updated.(*Model)
+	if cmd != nil || !m.dialog.IsOpen() || m.dialog.Type() != DialogBranchTree {
+		t.Fatalf("tree dialog = open:%v type:%v cmd:%v", m.dialog.IsOpen(), m.dialog.Type(), cmd != nil)
+	}
+	var choiceID string
+	for id, choice := range m.branchTreeChoices {
+		if choice.prefill == "edit this question" {
+			choiceID = id
+			if choice.anchorMessageID != messages[1].ID || choice.expected.Rev != 7 {
+				t.Fatalf("user choice = %#v", choice)
+			}
+		}
+	}
+	if choiceID == "" {
+		t.Fatal("edit branch choice missing")
+	}
+	m.dialog.Close()
+	updated, _ = m.handleBranchTreeSelection(choiceID)
+	m = updated.(*Model)
+	if m.pendingBranch == nil || m.textarea.Value() != "edit this question" {
+		t.Fatalf("pending branch/composer = %#v / %q", m.pendingBranch, m.textarea.Value())
+	}
+	m.setTextareaValue("edited question")
+	updated, cmd = m.submitPendingBranch("edited question")
+	m = updated.(*Model)
+	if cmd == nil || !m.quitting || m.RequestedResumeSessionID() != "new-child" || m.RequestedBranchPrefill() != "edited question" {
+		t.Fatalf("relaunch state: cmd=%v quitting=%v resume=%q prefill=%q", cmd != nil, m.quitting, m.RequestedResumeSessionID(), m.RequestedBranchPrefill())
+	}
+	if store.currentID != "new-child" || len(store.createOpts) != 1 || store.createOpts[0].AnchorMessageID != messages[1].ID {
+		t.Fatalf("store branch call/current = %#v / %q", store.createOpts, store.currentID)
+	}
+}
+
+func TestTreeHidesCompactionArtifactsAndUserAnchorSkipsToolRows(t *testing.T) {
+	m, store, messages := newBranchChatModel()
+	sourceID := m.sess.ID
+	tool := session.Message{ID: 14, SessionID: sourceID, Role: llm.RoleTool, TextContent: "orphan tool result", Sequence: 3}
+	summary := session.Message{ID: 15, SessionID: sourceID, Role: llm.RoleUser, TextContent: "[Context Compaction]\ninternal summary", Sequence: 4}
+	tail := session.Message{ID: 16, SessionID: sourceID, Role: llm.RoleAssistant, TextContent: "duplicate retained answer", Sequence: 5, CompactionTail: true}
+	user := session.Message{ID: 17, SessionID: sourceID, Role: llm.RoleUser, TextContent: "after tool", Sequence: 6}
+	store.messages[sourceID] = append(store.messages[sourceID], tool, summary, tail, user)
+	store.state = session.TranscriptMutationState{Rev: 8, HeadID: user.ID}
+
+	updated, _ := m.cmdTree(nil)
+	m = updated.(*Model)
+	var afterTool *pendingConversationBranch
+	for _, choice := range m.branchTreeChoices {
+		if choice.prefill == "after tool" {
+			copy := choice
+			afterTool = &copy
+		}
+		if choice.anchorMessageID == summary.ID || choice.anchorMessageID == tail.ID || choice.prefill == summary.TextContent {
+			t.Fatalf("hidden compaction artifact became a branch choice: %#v", choice)
+		}
+	}
+	if afterTool == nil {
+		t.Fatal("post-tool user branch choice missing")
+	}
+	if afterTool.anchorMessageID != messages[2].ID {
+		t.Fatalf("post-tool user anchor = %d, want previous visible user %d", afterTool.anchorMessageID, messages[2].ID)
+	}
+}
+
+func TestTreeAssistantSelectionUsesAssistantAnchorAndExistingPathSwitches(t *testing.T) {
+	m, _, messages := newBranchChatModel()
+	updated, _ := m.cmdTree(nil)
+	m = updated.(*Model)
+	var assistantChoice string
+	for id, choice := range m.branchTreeChoices {
+		if choice.anchorMessageID == messages[1].ID && choice.prefill == "" {
+			assistantChoice = id
+			break
+		}
+	}
+	if assistantChoice == "" {
+		t.Fatal("assistant branch choice missing")
+	}
+	updated, _ = m.handleBranchTreeSelection(assistantChoice)
+	m = updated.(*Model)
+	if m.pendingBranch == nil || m.textarea.Value() != "" {
+		t.Fatalf("assistant selection = %#v / %q", m.pendingBranch, m.textarea.Value())
+	}
+
+	m2, _, _ := newBranchChatModel()
+	updated, _ = m2.handleBranchTreeSelection("path:existing-child")
+	m2 = updated.(*Model)
+	if !m2.quitting || m2.RequestedResumeSessionID() != "existing-child" {
+		t.Fatalf("existing path did not request resume: %#v", m2)
+	}
+}
+
+func TestTreeBusyGateAndBranchPrefillDoesNotAutoSend(t *testing.T) {
+	m, _, _ := newBranchChatModel()
+	m.streaming = true
+	updated, cmd := m.cmdTree(nil)
+	m = updated.(*Model)
+	if cmd == nil || m.dialog.IsOpen() {
+		t.Fatalf("busy tree opened dialog or omitted warning command: open=%v cmd=%v", m.dialog.IsOpen(), cmd != nil)
+	}
+
+	m2 := newTestChatModel(false)
+	m2.SetBranchPrefill("confirm this branch prompt")
+	_ = m2.Init()
+	if got := m2.textarea.Value(); got != "confirm this branch prompt" {
+		t.Fatalf("branch prefill = %q", got)
+	}
+	if m2.handoverAutoSend != "" {
+		t.Fatalf("branch prefill scheduled auto send: %q", m2.handoverAutoSend)
+	}
+}


### PR DESCRIPTION
## Summary

Add first-class conversation branching to both the web UI and TUI while keeping each branch as an ordinary linear session.

- add atomic, revision-safe branch persistence with source-scoped idempotency
- continue stale durable response anchors into child sessions only when `branch: true`
- add web `Edit from here`, `Branch from here`, pending-branch projection, and conversation-path switching
- add TUI `/tree` for choosing branch points and switching existing paths
- preserve original paths without turning the transcript/runtime model into a message DAG

## Storage and protocol

Branches are connected through a dedicated `session_branches` edge table. Child sessions copy the selected structured transcript prefix with fresh row IDs while clearing run/client/segment identity. Provider continuation state and redo state are deliberately not copied.

`POST /v1/responses` accepts:

```json
{
  "previous_response_id": "resp_msg_<message-id>",
  "branch": true,
  "expected_rev": 37,
  "idempotency_key": "..."
}
```

Ordinary stale-anchor requests still return `409`. Branch responses transfer ownership through the existing session header plus a durable copied-prefix anchor, preventing interrupted first streams from causing a later bare send to replace branch history.

## UX

### Web

- `Edit from here` on user messages
- `Branch from here` on assistant turns
- retained-prefix preview and cancelable pending branch
- child-session ownership transfer on send
- `N paths` modal for switching alternatives

### TUI

- `/tree` displays existing paths and replayable user/assistant/tool branch points
- selecting a user turn preloads it for editing
- selecting assistant/tool output continues after it
- branch creation reuses the established session relaunch/resume lifecycle

Conversation branching rewinds model context only. It does not undo filesystem, tool, or external side effects.

## Review and video findings

The implementation went through an Opus plan review, implementation review, and correction pass. Manual web/TUI recordings then exposed one additional web projection bug: editing a user turn hid the retained prefix as well as the suffix. The projection logic and regression coverage were corrected before publication.

## Verification

Passed:

- focused session branch, response protocol, TUI tree, web ownership, and compaction regressions
- all 21 browser-side JavaScript test files under Node 24.15.0
- isolated touched-package suite
- full isolated root-module `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

The branch test matrix includes source revision conflicts, source-scoped idempotency, empty anchors, multiple compactions, identity clearing, provider/redo exclusion, busy-source refusal, interrupted web stream follow-up safety, external-vs-first-party streaming semantics, and TUI continuation-boundary filtering.
