### PR TITLE
fix(web): preserve external authentication redirects

### DIFF
--- a/internal/serveui/static/app-network.js
+++ b/internal/serveui/static/app-network.js
@@ -28,6 +28,25 @@ let queuedRecoveryReason = '';
 let recoveryRetryTimer = 0;
 let recoveryProbeAttempt = 0;
 let successfulRecoveryEpoch = 0;
+let externalAuthRedirecting = false;
+
+const maybeRedirectForExternalAuth = (response) => {
+  if (!response || response.status !== 401 || externalAuthRedirecting) return false;
+  const rawURL = String(response.headers?.get?.('x-term-llm-login-url') || '').trim();
+  if (!rawURL) return false;
+
+  let loginURL;
+  try {
+    loginURL = new URL(rawURL, window.location.href);
+  } catch {
+    return false;
+  }
+  if (loginURL.protocol !== 'http:' && loginURL.protocol !== 'https:') return false;
+
+  externalAuthRedirecting = true;
+  window.location.assign(loginURL.href);
+  return true;
+};
 
 const online = () => typeof navigator === 'undefined' || navigator.onLine !== false;
 const visible = () => typeof document === 'undefined' || document.visibilityState !== 'hidden';
@@ -284,6 +303,7 @@ const apiFetch = async (resource, options = {}, controls = {}) => {
         durationMs: Date.now() - startedAt,
         url: requestURL(resource),
       });
+      maybeRedirectForExternalAuth(response);
       if (response.status === 401 && classification.authOwner === AUTH.session) {
         window.setTimeout(() => app.handleAuthFailure?.(), 0);
       }

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -276,6 +276,58 @@ pendingAsyncTests.push((async function testClipboardWriterFallsBackToExecCommand
   pass(name);
 })());
 
+pendingAsyncTests.push((async function testExternalAuth401UsesTopLevelLogin() {
+  const name = 'external auth 401 redirects through a trusted login URL';
+  let redirectedTo = '';
+  const location = {
+    pathname: '/chat', href: 'https://example.test/chat/', origin: 'https://example.test',
+    protocol: 'https:', host: 'example.test',
+    assign(url) { redirectedTo = String(url); },
+  };
+  const testApp = loadAppCoreWith({
+    windowOverrides: {
+      location,
+      fetch: async () => new Response('', {
+        status: 401,
+        headers: { 'X-Term-LLM-Login-URL': '/jarvis-api/auth/google?source=web' },
+      }),
+    },
+  });
+
+  await testApp.apiFetch('/chat/v1/providers', {}, { retries: 0 });
+  if (redirectedTo !== 'https://example.test/jarvis-api/auth/google?source=web') {
+    fail(name, `redirected to ${JSON.stringify(redirectedTo)}`);
+    return;
+  }
+  pass(name);
+})());
+
+pendingAsyncTests.push((async function testExternalAuth401RejectsUnsafeLoginURL() {
+  const name = 'external auth redirect rejects unsafe URL schemes';
+  let redirects = 0;
+  const location = {
+    pathname: '/chat', href: 'https://example.test/chat/', origin: 'https://example.test',
+    protocol: 'https:', host: 'example.test',
+    assign() { redirects += 1; },
+  };
+  const testApp = loadAppCoreWith({
+    windowOverrides: {
+      location,
+      fetch: async () => new Response('', {
+        status: 401,
+        headers: { 'X-Term-LLM-Login-URL': 'javascript:alert(1)' },
+      }),
+    },
+  });
+
+  await testApp.apiFetch('/chat/v1/providers', {}, { retries: 0 });
+  if (redirects !== 0) {
+    fail(name, 'unsafe login URL triggered navigation');
+    return;
+  }
+  pass(name);
+})());
+
 (function testTokenCookieScopedToBasePathForWidgetsAndImages() {
   const name = 'syncTokenCookie scopes auth cookie to UI base path';
   const testApp = loadAppCore();

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -1,10 +1,5 @@
 const SHELL_CACHE = 'term-llm-shell-v3';
-const SHELL_VERSION = SHELL_CACHE.slice('term-llm-shell-'.length);
-const NAVIGATION_NETWORK_BUDGET_MS = 100;
-let shellRefreshPending = false;
 const SHELL_ASSETS = [
-  './',
-  './index.html',
   './manifest.webmanifest',
   './icon-512.png',
   './app.css',
@@ -55,25 +50,11 @@ const putIfCacheable = async (cache, request, response) => {
   return response;
 };
 
-const refreshShellIfCompatible = async (cachePromise, responsePromise) => {
-  const [cache, response] = await Promise.all([cachePromise, responsePromise]);
-  if (!cache || !response?.ok) return response;
-  try {
-    const html = await response.clone().text();
-    if (!html.includes(`window.TERM_LLM_UI_VERSION="${SHELL_VERSION}"`)) return response;
-    await putIfCacheable(cache, './index.html', response);
-  } catch {
-    // A refresh is opportunistic; the install-time shell remains authoritative.
-  }
-  return response;
-};
-
 self.addEventListener('install', (event) => {
-  event.waitUntil((async () => {
-    const cache = await caches.open(SHELL_CACHE);
-    await cache.addAll(SHELL_ASSETS);
-    await self.skipWaiting();
-  })());
+  // Installation must succeed even after an external-auth session expires.
+  // Assets populate opportunistically at fetch time; an atomic addAll() here
+  // would leave an obsolete worker in control if protected asset fetches redirect.
+  event.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener('activate', (event) => {
@@ -95,41 +76,10 @@ self.addEventListener('fetch', (event) => {
   const isAppRequest = url.pathname.startsWith(scopePath);
   if (!isAppRequest) return;
 
-  if (request.mode === 'navigate') {
-    // Only the scope root and explicit index are the chat shell. Widgets, admin,
-    // files, and other in-scope documents must retain their server semantics.
-    const isShellNavigation = url.pathname === scopePath || url.pathname === `${scopePath}index.html`;
-    if (!isShellNavigation) return;
-
-    const cachePromise = caches.open(SHELL_CACHE).catch(() => null);
-    const cachedPromise = cachePromise.then(async (cache) => {
-      if (!cache) return null;
-      return (await cache.match('./index.html')) || (await cache.match('./')) || null;
-    });
-    const networkFetch = fetch(request).catch(() => null);
-    const refresh = refreshShellIfCompatible(cachePromise, networkFetch);
-    event.waitUntil(refresh);
-    event.respondWith((async () => {
-      // Preserve fresh-first behavior on fast/local servers, but do not make a
-      // warm reload inherit a slow remote document round trip.
-      // After one cache fallback, keep the outstanding refresh authoritative for
-      // immediate follow-up reloads (including version-mismatch auto-reloads).
-      // This prevents a stale shell from winning a rapid reload loop.
-      const fresh = shellRefreshPending ? await networkFetch : await Promise.race([
-        networkFetch,
-        new Promise((resolve) => setTimeout(() => resolve(null), NAVIGATION_NETWORK_BUDGET_MS)),
-      ]);
-      if (fresh) return fresh;
-      const cached = await cachedPromise;
-      if (cached) {
-        shellRefreshPending = true;
-        void networkFetch.finally(() => { shellRefreshPending = false; });
-        return cached;
-      }
-      return (await networkFetch) || Response.error();
-    })());
-    return;
-  }
+  // Navigations are authoritative. A cached application shell can mask login,
+  // logout, deployment, and reverse-proxy redirects, so only cache versioned
+  // static assets; the application is not useful offline without its API.
+  if (request.mode === 'navigate') return;
 
   const isShellAsset = SHELL_ASSETS.some((asset) => url.href === new URL(asset, self.registration.scope).href);
   if (!isShellAsset && request.destination !== 'script' && request.destination !== 'style' && request.destination !== 'image' && request.destination !== 'font') {

--- a/internal/serveui/static/sw_test.js
+++ b/internal/serveui/static/sw_test.js
@@ -7,15 +7,15 @@ const vm = require('vm');
 const source = fs.readFileSync(path.join(__dirname, 'sw.js'), 'utf8');
 const listeners = new Map();
 const entries = new Map();
+let addAllCalls = 0;
 const cache = {
-  async addAll() {},
+  async addAll() { addAllCalls += 1; },
   async match(key) {
     const response = entries.get(String(key));
     return response ? response.clone() : undefined;
   },
   async put(key, response) { entries.set(String(key), response.clone()); },
 };
-const pendingFetches = [];
 let fetchCalls = 0;
 const context = {
   self: {
@@ -30,74 +30,59 @@ const context = {
     async keys() { return []; },
     async delete() { return true; },
   },
-  fetch() {
+  async fetch(request) {
     fetchCalls += 1;
-    return new Promise((resolve) => { pendingFetches.push(resolve); });
+    return new Response(`network:${request.url}`, { status: 200 });
   },
   URL,
   Response,
   Promise,
-  setTimeout,
   console,
 };
 vm.runInNewContext(source, context, { filename: 'sw.js' });
 
-function navigationEvent(url = 'https://example.test/chat/') {
+function fetchEvent({ url, mode = 'cors', destination = 'script' }) {
   let responsePromise;
-  let lifetimePromise;
   let intercepted = false;
   return {
-    request: { method: 'GET', url, mode: 'navigate', destination: 'document' },
+    request: { method: 'GET', url, mode, destination },
     respondWith(value) { intercepted = true; responsePromise = Promise.resolve(value); },
-    waitUntil(value) { lifetimePromise = Promise.resolve(value); },
+    waitUntil() {},
     response: () => responsePromise,
-    lifetime: () => lifetimePromise,
     intercepted: () => intercepted,
   };
 }
 
 (async () => {
-  entries.set('./index.html', new Response('cached shell', { status: 200 }));
-  const event = navigationEvent();
-  listeners.get('fetch')(event);
-
-  const response = await event.response();
-  if (await response.text() !== 'cached shell') throw new Error('slow navigation did not fall back to the cached shell');
-  if (fetchCalls !== 1 || pendingFetches.length !== 1) throw new Error('navigation did not start one network refresh');
-
-  const immediateReload = navigationEvent();
-  listeners.get('fetch')(immediateReload);
-  let immediateReloadSettled = false;
-  immediateReload.response().then(() => { immediateReloadSettled = true; });
-  await new Promise((resolve) => setTimeout(resolve, 120));
-  if (immediateReloadSettled) throw new Error('immediate follow-up reload reused the stale shell');
-  pendingFetches[1](new Response('<script>window.TERM_LLM_UI_VERSION="v3";</script>follow-up shell', { status: 200 }));
-  if (!(await (await immediateReload.response()).text()).endsWith('follow-up shell')) {
-    throw new Error('immediate follow-up reload did not wait for the authoritative network shell');
-  }
-  await immediateReload.lifetime();
-
-  pendingFetches[0](new Response('<script>window.TERM_LLM_UI_VERSION="v3";</script>fresh shell', { status: 200 }));
-  await event.lifetime();
-  const refreshed = await cache.match('./index.html');
-  if (!(await refreshed.text()).endsWith('fresh shell')) throw new Error('compatible background refresh did not update cached shell');
-
-  const compatibleShell = await (await cache.match('./index.html')).text();
-  const upgradeEvent = navigationEvent();
-  listeners.get('fetch')(upgradeEvent);
-  await upgradeEvent.response();
-  pendingFetches[2](new Response('<script>window.TERM_LLM_UI_VERSION="v4";</script>next release', { status: 200 }));
-  await upgradeEvent.lifetime();
-  if (await (await cache.match('./index.html')).text() !== compatibleShell) {
-    throw new Error('old service worker mixed a new HTML release into its shell cache');
+  await new Promise((resolve, reject) => {
+    listeners.get('install')({ waitUntil(value) { Promise.resolve(value).then(resolve, reject); } });
+  });
+  if (addAllCalls !== 0) {
+    throw new Error('install pre-cached protected assets and can fail after auth expiry');
   }
 
-  const widgetEvent = navigationEvent('https://example.test/chat/widgets/clock/');
-  listeners.get('fetch')(widgetEvent);
-  if (widgetEvent.intercepted()) throw new Error('service worker intercepted a non-shell widget navigation');
-  if ((await (await cache.match('./index.html')).text()).endsWith('WIDGET PAGE')) throw new Error('widget navigation poisoned the shell cache');
+  for (const url of [
+    'https://example.test/chat/',
+    'https://example.test/chat/index.html',
+    'https://example.test/chat/session-123',
+    'https://example.test/chat/widgets/clock/',
+  ]) {
+    const event = fetchEvent({ url, mode: 'navigate', destination: 'document' });
+    listeners.get('fetch')(event);
+    if (event.intercepted()) throw new Error(`service worker intercepted navigation ${url}`);
+  }
+  if (fetchCalls !== 0) throw new Error('service worker fetched an authoritative navigation');
 
-  console.log('PASS: shell navigation uses bounded cache fallback without intercepting widget documents');
+  const assetURL = 'https://example.test/chat/app-core.js?v=v3';
+  const asset = fetchEvent({ url: assetURL });
+  listeners.get('fetch')(asset);
+  if (!asset.intercepted()) throw new Error('service worker stopped caching versioned static assets');
+  const response = await asset.response();
+  if ((await response.text()) !== `network:${assetURL}` || fetchCalls !== 1) {
+    throw new Error('versioned static asset did not use the cache/network path');
+  }
+
+  console.log('PASS: service worker leaves navigation authoritative and caches only static assets');
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : error);
   process.exitCode = 1;


### PR DESCRIPTION
## Summary

- stop the service worker from caching or intercepting application navigations, so reverse-proxy login/logout and deployment redirects remain authoritative
- keep cache handling for versioned scripts, styles, images, and fonts
- let external auth proxies return `401` with `X-Term-LLM-Login-URL`; the web client performs a top-level HTTP(S) navigation instead of surfacing a misleading fetch failure
- reject non-HTTP(S) login URL schemes

## Why

An authenticated mobile PWA could serve cached `/chat/` HTML after its proxy session cookie expired. The real navigation's OAuth redirect lost a 100 ms service-worker race, then API fetches were redirected toward Google and surfaced as opaque/400-ish failures. HTML navigation is not a safe cache fallback for an app whose authoritative authentication lives at the reverse proxy.

## Tests

- `node internal/serveui/static/sw_test.js`
- `node internal/serveui/static/app_core_test.js`
- `go test ./internal/serveui`
- `go test ./cmd -run TestHandleUI_ServiceWorkerVersionsShellCache -count=1`
- `go test ./...` (all affected packages pass; existing environment-sensitive skill-discovery tests fail because the globally mounted Jarvis skills override their temporary skill fixtures)
