### PR TITLE
fix: Stopping the agy proxy can nil its transport under an active request

### DIFF
--- a/internal/agyproxy/proxy.go
+++ b/internal/agyproxy/proxy.go
@@ -277,6 +277,14 @@ func (a loopbackAddr) Network() string { return "tcp" }
 func (a loopbackAddr) String() string  { return string(a) }
 
 func (s *Server) forward(w http.ResponseWriter, req *http.Request) {
+	s.mu.Lock()
+	transport := s.transport
+	s.mu.Unlock()
+	if transport == nil {
+		http.Error(w, "agy tool-filter proxy is stopping", http.StatusServiceUnavailable)
+		return
+	}
+
 	req.RequestURI = ""
 	req.URL.Scheme = "https"
 	req.URL.Host = CloudCodeHost
@@ -317,7 +325,7 @@ func (s *Server) forward(w http.ResponseWriter, req *http.Request) {
 		req.TransferEncoding = nil
 		s.filtered.Add(1)
 	}
-	resp, err := s.transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		http.Error(w, "forward agy request: "+err.Error(), http.StatusBadGateway)
 		return

--- a/internal/agyproxy/proxy_test.go
+++ b/internal/agyproxy/proxy_test.go
@@ -4,11 +4,15 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -314,5 +318,84 @@ func TestServerLifecycleRemovesCA(t *testing.T) {
 	}
 	if err := server.Stop(ctx); err != nil {
 		t.Fatalf("second Stop: %v", err)
+	}
+}
+
+type blockingReadCloser struct {
+	io.Reader
+	started chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingReadCloser) Read(p []byte) (int, error) {
+	r.once.Do(func() {
+		close(r.started)
+		<-r.release
+	})
+	return r.Reader.Read(p)
+}
+
+func (*blockingReadCloser) Close() error { return nil }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestServerStopDoesNotClearTransportUnderActiveForward(t *testing.T) {
+	t.Setenv(GenerationTraceFileEnv, "")
+	var server Server
+	if _, _, err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	server.mu.Lock()
+	transport := server.transport
+	server.mu.Unlock()
+	transport.DialContext = (&net.Dialer{}).DialContext
+	transport.RegisterProtocol("https", roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("forwarded")),
+		}, nil
+	}))
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	body := &blockingReadCloser{
+		Reader:  strings.NewReader(string(generationBody("run_command"))),
+		started: started,
+		release: release,
+	}
+	req := httptest.NewRequest(http.MethodPost, "https://"+CloudCodeHost+generationPath, body)
+	recorder := httptest.NewRecorder()
+	panicResult := make(chan any, 1)
+	go func() {
+		defer func() { panicResult <- recover() }()
+		server.forward(recorder, req)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("forward did not start reading request body")
+	}
+	if err := server.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+
+	select {
+	case panicValue := <-panicResult:
+		if panicValue != nil {
+			t.Fatalf("forward panicked after Stop: %v", panicValue)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("forward did not finish")
+	}
+	if recorder.Code != http.StatusOK || recorder.Body.String() != "forwarded" {
+		t.Fatalf("response = (%d, %q), want (200, %q)", recorder.Code, recorder.Body.String(), "forwarded")
 	}
 }


### PR DESCRIPTION
## What changed

- Snapshot the agy proxy's transport under `Server.mu` when `forward` begins, then use that stable pointer for the upstream round trip.
- Return a service-unavailable response if a handler starts after shutdown has already cleared the transport.
- Add a coordinated regression test that blocks generation request-body processing, calls `Stop`, releases the body, and verifies the active forward completes without a panic.

## Why this is high-value

`Stop` previously cleared `s.transport` while an already-running generation handler could still be reading, expanding, filtering, or tracing its request body. The handler then dereferenced the now-nil transport, producing both a data race and a possible nil-pointer panic. Because agy isolation is stopped during per-turn cleanup, ending or cancelling an agy-backed turn could crash the entire long-running Jarvis process rather than only failing that provider call.

The fix is deliberately lifecycle-local: active handlers retain the transport they started with, while handlers that lose the race with shutdown fail safely.

## Validation

- `go test -race ./internal/agyproxy`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`

The required unisolated `go test ./...` run also completed all packages, but two unrelated `cmd` skill-discovery tests failed because the host's 30 user-global skills exhausted their configured metadata limits before the temporary project skill was listed. Isolating `XDG_CONFIG_HOME` removed that host configuration and the full suite passed.
