### PR TITLE
fix: order TUI compaction boundaries with stream events

### DIFF
--- a/docs-site/content/guides/debugging.md
+++ b/docs-site/content/guides/debugging.md
@@ -10,6 +10,32 @@ next:
 ---
 Use `--debug` to print provider-level diagnostics (requests, model info, etc.). Use `--debug-raw` for a timestamped, raw view of tool calls, tool results, and reconstructed requests. Raw debug is most useful for troubleshooting tool calling and search.
 
+### Exercise automatic compaction locally
+
+The `debug:compaction` provider is a hermetic, zero-cost TUI scenario with a 20k context window. Its deterministic first-turn usage crosses the default compaction threshold; the next turn emits a short internal brief and continues from the compacted context. Start it, send any seed message, then send a second message:
+
+```bash
+term-llm chat --provider debug:compaction
+```
+
+The second turn's status line should progress through the compaction phases. Normal chat should retain a `Context compacted` boundary immediately before the continuation; `Ctrl+O` shows the summary and retained-tail details. No provider credentials, local model, or special configuration are required.
+
+To exercise tool ordering across the boundary in one agent turn, enable the harmless `glob` tool and send exactly `run the tool compaction probe`:
+
+```bash
+term-llm chat --provider debug:compaction --tools glob
+```
+
+The deterministic sequence is three `glob` calls, automatic compaction, three more `glob` calls, then a completion message. This is intended for live TUI recordings and regression tests of tool/compaction placement.
+
+For a non-interactive smoke test, use:
+
+```bash
+term-llm chat --provider debug:compaction \
+  --auto-send "seed the compaction probe" \
+  --auto-send "continue after compaction"
+```
+
 ### Trace agy-bin generation requests
 
 To inspect the exact generation payload that `agy` sends through term-llm's compatibility proxy, set `TERM_LLM_AGY_PROXY_TRACE_FILE` to a JSONL file in a private directory:

--- a/internal/llm/debug_provider.go
+++ b/internal/llm/debug_provider.go
@@ -20,11 +20,12 @@ type debugPreset struct {
 
 // presets maps variant names to their streaming configurations.
 var presets = map[string]debugPreset{
-	"fast":     {ChunkSize: 50, Delay: 5 * time.Millisecond},
-	"normal":   {ChunkSize: 20, Delay: 20 * time.Millisecond},
-	"slow":     {ChunkSize: 10, Delay: 50 * time.Millisecond},
-	"realtime": {ChunkSize: 5, Delay: 30 * time.Millisecond},
-	"burst":    {ChunkSize: 200, Delay: 100 * time.Millisecond},
+	"fast":       {ChunkSize: 50, Delay: 5 * time.Millisecond},
+	"normal":     {ChunkSize: 20, Delay: 20 * time.Millisecond},
+	"slow":       {ChunkSize: 10, Delay: 50 * time.Millisecond},
+	"realtime":   {ChunkSize: 5, Delay: 30 * time.Millisecond},
+	"burst":      {ChunkSize: 200, Delay: 100 * time.Millisecond},
+	"compaction": {ChunkSize: 12, Delay: 80 * time.Millisecond},
 }
 
 // debugMarkdown contains rich markdown content for performance testing.
@@ -174,7 +175,7 @@ type DebugProvider struct {
 }
 
 // NewDebugProvider creates a debug provider with the specified variant.
-// Valid variants: fast, normal, slow, realtime, burst
+// Valid variants: fast, normal, slow, realtime, burst, compaction.
 // Empty string defaults to "normal".
 func NewDebugProvider(variant string) *DebugProvider {
 	if variant == "" {
@@ -213,6 +214,9 @@ func (d *DebugProvider) Capabilities() Capabilities {
 // If tool results are present, emits completion text.
 // Otherwise, streams the debug markdown content.
 func (d *DebugProvider) Stream(ctx context.Context, req Request) (Stream, error) {
+	if d.variant == "compaction" {
+		return d.streamCompactionScenario(ctx, req), nil
+	}
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
 		// If the request is completing a tool round (the conversation ends
 		// with tool results), stream completion text. Earlier turns' tool
@@ -253,6 +257,132 @@ func (d *DebugProvider) Stream(ctx context.Context, req Request) (Stream, error)
 		// Fall back to debug markdown
 		return d.streamDebugMarkdown(ctx, send)
 	}), nil
+}
+
+func (d *DebugProvider) streamCompactionScenario(ctx context.Context, req Request) Stream {
+	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+		last := ""
+		if len(req.Messages) > 0 {
+			last = MessageText(req.Messages[len(req.Messages)-1])
+		}
+
+		text := "Compaction probe seed response. term-llm should now compact this 20k-context conversation and continue."
+		usage := Usage{InputTokens: 18_100, OutputTokens: 24}
+		toolScenario := requestContainsText(req.Messages, "tool compaction probe")
+		switch {
+		case strings.TrimSpace(last) == strings.TrimSpace(contextContinuationBriefPrompt):
+			if toolScenario {
+				text = "Tool compaction probe: three pre-compaction glob calls are complete. Next perform three post-compaction glob calls, then confirm completion."
+			} else {
+				text = "Objective: verify the TUI compaction boundary. Next: continue the probe after compaction."
+			}
+			usage = Usage{InputTokens: 800, OutputTokens: 22}
+		case strings.Contains(last, "Create a detailed summary of our conversation"):
+			if toolScenario {
+				text = "Tool compaction probe: three pre-compaction glob calls are complete. Preserve their results. Next perform three post-compaction glob calls, then confirm completion."
+			} else {
+				text = "The user is running the hermetic TUI compaction probe. Preserve the boundary and continue with a short confirmation."
+			}
+			usage = Usage{InputTokens: 1_200, OutputTokens: 28}
+		case toolScenario:
+			return d.streamToolCompactionStep(ctx, send, req)
+		case requestContainsCompactionSummary(req.Messages):
+			text = "Compaction probe continuation complete. The durable boundary marker should appear immediately above this response."
+			usage = Usage{InputTokens: 1_400, OutputTokens: 26}
+		}
+		return d.streamTextWithUsage(ctx, send, text, usage)
+	})
+}
+
+func (d *DebugProvider) streamToolCompactionStep(ctx context.Context, send eventSender, req Request) error {
+	if !hasToolSpec(req.Tools, "glob") {
+		return d.streamTextWithUsage(ctx, send, "Tool compaction probe requires --tools glob.", Usage{InputTokens: 100, OutputTokens: 10})
+	}
+
+	prefix := "debug_compact_pre_"
+	if requestContainsCompactionSummary(req.Messages) {
+		prefix = "debug_compact_post_"
+	}
+	completed := countToolResultsWithPrefix(req.Messages, prefix)
+	if completed >= 3 {
+		return d.streamTextWithUsage(ctx, send, "Tool compaction probe complete: 3 tool calls before compaction and 3 after.", Usage{InputTokens: 1_500, OutputTokens: 20})
+	}
+
+	callNumber := completed + 1
+	arguments, _ := json.Marshal(map[string]string{"pattern": "go.mod"})
+	if err := send.Send(Event{Type: EventToolCall, Tool: &ToolCall{
+		ID:        fmt.Sprintf("%s%d", prefix, callNumber),
+		Name:      "glob",
+		Arguments: arguments,
+	}}); err != nil {
+		return err
+	}
+	inputTokens := 500
+	if prefix == "debug_compact_pre_" && callNumber == 3 {
+		inputTokens = 18_100
+	}
+	return send.Send(Event{Type: EventUsage, Use: &Usage{InputTokens: inputTokens, OutputTokens: 8}})
+}
+
+func hasToolSpec(tools []ToolSpec, name string) bool {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func requestContainsText(messages []Message, needle string) bool {
+	needle = strings.ToLower(needle)
+	for _, msg := range messages {
+		if strings.Contains(strings.ToLower(MessageText(msg)), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func countToolResultsWithPrefix(messages []Message, prefix string) int {
+	count := 0
+	for _, msg := range messages {
+		for _, part := range msg.Parts {
+			if part.Type == PartToolResult && part.ToolResult != nil && strings.HasPrefix(part.ToolResult.ID, prefix) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func requestContainsCompactionSummary(messages []Message) bool {
+	for _, msg := range messages {
+		if IsInternalCompactionSummaryText(MessageText(msg)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *DebugProvider) streamTextWithUsage(ctx context.Context, send eventSender, text string, usage Usage) error {
+	for len(text) > 0 {
+		end := d.preset.ChunkSize
+		if end > len(text) {
+			end = len(text)
+		}
+		if err := send.Send(Event{Type: EventTextDelta, Text: text[:end]}); err != nil {
+			return err
+		}
+		text = text[end:]
+		if len(text) > 0 && d.preset.Delay > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(d.preset.Delay):
+			}
+		}
+	}
+	return send.Send(Event{Type: EventUsage, Use: &usage})
 }
 
 // streamDebugMarkdown streams the standard debug markdown content.
@@ -557,15 +687,22 @@ func generateSyntheticEdits(filePath string, count int) [][2]string {
 	}
 
 	edits := make([][2]string, 0, count)
-	// Pick evenly spaced lines to avoid overlapping edits
+	// Pick evenly spaced non-empty lines to avoid overlapping edits. Scan forward
+	// from each target so harmless formatting changes do not reduce the requested
+	// number of synthetic calls.
 	step := max(1, len(lines)/count)
+	used := make(map[int]bool, count)
 
-	for i := 0; i < count && i*step < len(lines); i++ {
+	for i := 0; i < count; i++ {
 		lineIdx := i * step
-		line := lines[lineIdx]
-		if strings.TrimSpace(line) == "" {
-			continue // skip blank lines
+		for lineIdx < len(lines) && (used[lineIdx] || strings.TrimSpace(lines[lineIdx]) == "") {
+			lineIdx++
 		}
+		if lineIdx >= len(lines) {
+			break
+		}
+		used[lineIdx] = true
+		line := lines[lineIdx]
 		// Simple edit: append " // edited by debug" to the line
 		edits = append(edits, [2]string{
 			line,

--- a/internal/llm/debug_provider_test.go
+++ b/internal/llm/debug_provider_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
 )
 
 func TestDebugProviderName(t *testing.T) {
@@ -23,6 +25,7 @@ func TestDebugProviderName(t *testing.T) {
 		{"slow", "debug:slow"},
 		{"realtime", "debug:realtime"},
 		{"burst", "debug:burst"},
+		{"compaction", "debug:compaction"},
 		{"unknown", "debug:unknown"}, // Unknown variants still get named
 	}
 
@@ -33,6 +36,22 @@ func TestDebugProviderName(t *testing.T) {
 				t.Errorf("Name() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewProviderPreservesDebugVariantOverride(t *testing.T) {
+	cfg := &config.Config{
+		DefaultProvider: "debug",
+		Providers: map[string]config.ProviderConfig{
+			"debug": {Model: "compaction"},
+		},
+	}
+	provider, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	if got := provider.Name(); got != "debug:compaction" {
+		t.Fatalf("provider name = %q, want debug:compaction", got)
 	}
 }
 
@@ -120,6 +139,138 @@ func TestDebugProviderStream(t *testing.T) {
 
 	if !gotUsage {
 		t.Error("stream did not emit usage event")
+	}
+}
+
+func TestDebugCompactionModelLimits(t *testing.T) {
+	if got := InputLimitForProviderModel("debug", "compaction"); got != 19_000 {
+		t.Fatalf("input limit = %d, want 19000", got)
+	}
+	if got := OutputLimitForModel("compaction"); got != 1_000 {
+		t.Fatalf("output limit = %d, want 1000", got)
+	}
+}
+
+func TestDebugCompactionScenario(t *testing.T) {
+	p := NewDebugProvider("compaction")
+	p.preset.Delay = 0
+
+	tests := []struct {
+		name      string
+		messages  []Message
+		wantText  string
+		wantInput int
+	}{
+		{name: "seed", messages: []Message{UserText("run probe")}, wantText: "seed response", wantInput: 18_100},
+		{name: "soft brief", messages: []Message{UserText(contextContinuationBriefPrompt)}, wantText: "verify the TUI compaction boundary", wantInput: 800},
+		{name: "hard summary", messages: []Message{UserText("Create a detailed summary of our conversation")}, wantText: "hermetic TUI compaction probe", wantInput: 1_200},
+		{name: "continuation", messages: []Message{UserText("[Context Compaction]\nsummary"), UserText(contextContinuationPrompt)}, wantText: "continuation complete", wantInput: 1_400},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream, err := p.Stream(context.Background(), Request{Messages: tt.messages})
+			if err != nil {
+				t.Fatalf("Stream() error = %v", err)
+			}
+			defer stream.Close()
+			var text strings.Builder
+			var usage *Usage
+			for {
+				event, recvErr := stream.Recv()
+				if recvErr == io.EOF {
+					break
+				}
+				if recvErr != nil {
+					t.Fatalf("Recv() error = %v", recvErr)
+				}
+				if event.Type == EventTextDelta {
+					text.WriteString(event.Text)
+				}
+				if event.Type == EventUsage {
+					usage = event.Use
+				}
+			}
+			if !strings.Contains(text.String(), tt.wantText) {
+				t.Fatalf("text = %q, want substring %q", text.String(), tt.wantText)
+			}
+			if usage == nil || usage.InputTokens != tt.wantInput {
+				t.Fatalf("usage = %+v, want input %d", usage, tt.wantInput)
+			}
+		})
+	}
+}
+
+func TestDebugToolCompactionScenario(t *testing.T) {
+	p := NewDebugProvider("compaction")
+	p.preset.Delay = 0
+	glob := ToolSpec{Name: "glob"}
+	preResults := []Message{
+		UserText("run the tool compaction probe"),
+		ToolResultMessage("debug_compact_pre_1", "glob", "go.mod", nil),
+		ToolResultMessage("debug_compact_pre_2", "glob", "go.mod", nil),
+	}
+
+	stream, err := p.Stream(context.Background(), Request{Messages: preResults, Tools: []ToolSpec{glob}})
+	if err != nil {
+		t.Fatalf("pre Stream() error = %v", err)
+	}
+	preCall, preUsage, _ := collectDebugScenarioStream(t, stream)
+	if preCall == nil || preCall.ID != "debug_compact_pre_3" {
+		t.Fatalf("pre call = %+v, want debug_compact_pre_3", preCall)
+	}
+	if preUsage == nil || preUsage.InputTokens != 18_100 {
+		t.Fatalf("pre usage = %+v, want hard-threshold input", preUsage)
+	}
+
+	postMessages := append([]Message{
+		UserText("[Context Compaction]\nTool compaction probe: continue with post-compaction calls."),
+	}, preResults[1:]...)
+	stream, err = p.Stream(context.Background(), Request{Messages: postMessages, Tools: []ToolSpec{glob}})
+	if err != nil {
+		t.Fatalf("post Stream() error = %v", err)
+	}
+	postCall, _, _ := collectDebugScenarioStream(t, stream)
+	if postCall == nil || postCall.ID != "debug_compact_post_1" {
+		t.Fatalf("post call = %+v, want debug_compact_post_1", postCall)
+	}
+
+	postMessages = append(postMessages,
+		ToolResultMessage("debug_compact_post_1", "glob", "go.mod", nil),
+		ToolResultMessage("debug_compact_post_2", "glob", "go.mod", nil),
+		ToolResultMessage("debug_compact_post_3", "glob", "go.mod", nil),
+	)
+	stream, err = p.Stream(context.Background(), Request{Messages: postMessages, Tools: []ToolSpec{glob}})
+	if err != nil {
+		t.Fatalf("final Stream() error = %v", err)
+	}
+	finalCall, _, finalText := collectDebugScenarioStream(t, stream)
+	if finalCall != nil || !strings.Contains(finalText, "3 tool calls before compaction and 3 after") {
+		t.Fatalf("final call=%+v text=%q", finalCall, finalText)
+	}
+}
+
+func collectDebugScenarioStream(t *testing.T, stream Stream) (*ToolCall, *Usage, string) {
+	t.Helper()
+	defer stream.Close()
+	var call *ToolCall
+	var usage *Usage
+	var text strings.Builder
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			return call, usage, text.String()
+		}
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		switch event.Type {
+		case EventToolCall:
+			call = event.Tool
+		case EventUsage:
+			usage = event.Use
+		case EventTextDelta:
+			text.WriteString(event.Text)
+		}
 	}
 }
 

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -324,7 +324,11 @@ func NewFastProvider(cfg *config.Config, name string) (Provider, error) {
 func newProviderInternal(cfg *config.Config) (Provider, error) {
 	// Handle hidden debug provider first
 	if cfg.DefaultProvider == "debug" {
-		return NewDebugProvider(""), nil
+		variant := ""
+		if providerCfg, ok := cfg.Providers["debug"]; ok {
+			variant = providerCfg.Model
+		}
+		return NewDebugProvider(variant), nil
 	}
 
 	providerCfg, ok := cfg.Providers[cfg.DefaultProvider]

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -23,6 +23,11 @@ type ModelEntry struct {
 // may intentionally omit entries and populate model IDs from their live cache.
 // When adding a curated model, include InputLimit/OutputLimit if known.
 var ProviderModels = map[string][]ModelEntry{
+	"debug": {
+		// Hermetic automatic-compaction scenario: a 20k context with a 1k
+		// output reserve and deterministic usage above the 90% soft threshold.
+		{ID: "compaction", InputLimit: 19_000, OutputLimit: 1_000},
+	},
 	"anthropic": {
 		// Claude 4.x/5. Reasoning-effort metadata is provider-level below:
 		// Fable and Opus support low/medium/high/xhigh/max; Sonnet supports low/medium/high.

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -96,7 +96,9 @@ type Model struct {
 	// olderScrollbackLoaded is false when a compacted resume initially loaded only
 	// the active tail; scrolling upward can hydrate the older display prefix once.
 	olderScrollbackLoaded      bool
-	messagesMu                 sync.Mutex // Protects messages from concurrent compaction callback
+	messagesMu                 sync.Mutex // Protects messages read by the compaction callback.
+	compactionApplyMu          sync.Mutex
+	pendingCompactionApplies   []compactionAppliedMsg
 	streaming                  bool
 	transcriptMutationInFlight bool
 	shareInFlight              bool
@@ -1917,12 +1919,6 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 	if timeoutMsg, ok := msg.(streamCancelTimeoutMsg); ok {
 		return m.handleStreamCancelTimeout(timeoutMsg)
 	}
-	if usageMsg, ok := msg.(compactionUsageMsg); ok {
-		// Compaction callbacks run on the stream goroutine. Apply stats and
-		// session-counter mutations only on Bubble Tea's Update goroutine.
-		m.recordCompactionUsage(context.Background(), usageMsg.sessionID, usageMsg.model, usageMsg.usage)
-		return m, nil
-	}
 	if handled, mentionCmd := m.handleMentionMessage(msg); handled {
 		return m, mentionCmd
 	}
@@ -2175,16 +2171,16 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		} else {
 			updated, activeStart, refreshed, _ = session.ApplyCompaction(context.Background(), nil, m.sess, full, msg.result)
 		}
-		if refreshed != nil {
-			m.sess = refreshed
-		}
-		m.recordCompactionUsage(context.Background(), sessionIDOf(m.sess), msg.result.Model, msg.result.Usage)
-		m.messagesMu.Lock()
-		m.messages = updated
-		m.compactionIdx = activeStart
-		m.messagesMu.Unlock()
 		m.setStreamingContextMessages(msg.result.ActiveMessages())
-		m.invalidateHistoryCache()
+		m.applyCompactionToUI(compactionAppliedMsg{
+			sessionID:   sessionIDOf(m.sess),
+			messages:    updated,
+			activeStart: activeStart,
+			refreshed:   refreshed,
+			model:       msg.result.Model,
+			usage:       msg.result.Usage,
+		})
+		m.resetPendingAssistantAfterCompaction()
 
 		if m.engine != nil {
 			m.engine.ResetConversation()
@@ -2416,6 +2412,7 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 
 		switch ev.Type {
 		case ui.StreamEventError:
+			m.applyAllPendingCompactionsToUI(msg.generation)
 			if ev.Err != nil {
 				m.setRetryStatus("")
 				// Flush any buffered text on error
@@ -2709,6 +2706,13 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			}
 
 		case ui.StreamEventPhase:
+			if ev.Phase == llm.PhaseCompactingResumeTask {
+				// The resume phase is the ordered handoff before continuation provider
+				// text. Earlier stream events stay ahead of the durable boundary.
+				if m.applyNextPendingCompactionToUI(msg.generation) {
+					m.resetLivePresentationAfterCompaction()
+				}
+			}
 			m.phase = ev.Phase
 			m.setRetryStatus("")
 			// Display WARNING phases as visible text in the conversation
@@ -2823,6 +2827,7 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			}
 
 		case ui.StreamEventDone:
+			m.applyAllPendingCompactionsToUI(msg.generation)
 			m.setRetryStatus("")
 			m.currentTokens = ev.Tokens
 			m.resetAttemptUsage()

--- a/internal/tui/chat/stats.go
+++ b/internal/tui/chat/stats.go
@@ -216,10 +216,14 @@ func sessionIDOf(sess *session.Session) string {
 	return sess.ID
 }
 
-type compactionUsageMsg struct {
-	sessionID string
-	model     string
-	usage     llm.Usage
+type compactionAppliedMsg struct {
+	generation  uint64
+	sessionID   string
+	messages    []session.Message
+	activeStart int
+	refreshed   *session.Session
+	model       string
+	usage       llm.Usage
 }
 
 func (m *Model) recordGuardianUsage(ctx context.Context, model string, u llm.Usage) {

--- a/internal/tui/chat/stats_race_test.go
+++ b/internal/tui/chat/stats_race_test.go
@@ -11,26 +11,28 @@ import (
 // while applying every stats mutation serially through Update, matching Bubble
 // Tea's runtime ownership model. Run under -race to guard against reintroducing
 // direct callback-goroutine SessionStats mutation.
-func TestCompactionUsageMessagesMutateStatsOnlyThroughUpdate(t *testing.T) {
+func TestCompactionAppliedMessagesMutateStatsOnlyThroughUpdate(t *testing.T) {
 	m := newTestChatModel(false)
 	m.stats = ui.NewSessionStats()
 	m.stats.SetModel("main-model")
 	m.stats.RequestStart()
 	m.stats.ObserveOutput()
 
-	messages := make(chan compactionUsageMsg)
+	messages := make(chan compactionAppliedMsg)
 	go func() {
 		defer close(messages)
 		for range 100 {
-			messages <- compactionUsageMsg{
-				model: " compact-model ",
-				usage: llm.Usage{InputTokens: 2, OutputTokens: 1},
+			messages <- compactionAppliedMsg{
+				generation: m.streamGeneration,
+				model:      " compact-model ",
+				usage:      llm.Usage{InputTokens: 2, OutputTokens: 1},
 			}
 		}
 	}()
 	for msg := range messages {
-		if _, cmd := m.Update(msg); cmd != nil {
-			t.Fatal("compaction usage message unexpectedly returned a command")
+		m.queueCompactionForUI(msg)
+		if _, cmd := m.Update(streamEventMsg{event: ui.PhaseEvent(llm.PhaseCompactingResumeTask), generation: m.streamGeneration}); cmd == nil {
+			t.Fatal("compaction resume phase did not schedule the stream listener")
 		}
 	}
 

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -224,15 +225,12 @@ func (m *Model) setupStreamPersistenceCallbacks(streamStart time.Time) {
 	m.engine.SetTurnCompletedCallback(turnCompleted)
 }
 
-func (m *Model) streamCompactionCallback(streamSess *session.Session) llm.CompactionCallback {
+func (m *Model) streamCompactionCallback(streamSess *session.Session, generation uint64) llm.CompactionCallback {
 	streamSessionID := ""
 	if streamSess != nil {
 		streamSessionID = streamSess.ID
 	}
 	return func(ctx context.Context, result *llm.CompactionResult) error {
-		if streamSessionID != "" && (m.sess == nil || m.sess.ID != streamSessionID) {
-			return nil
-		}
 		m.messagesMu.Lock()
 		full := append([]session.Message(nil), m.messages...)
 		m.messagesMu.Unlock()
@@ -240,40 +238,154 @@ func (m *Model) streamCompactionCallback(streamSess *session.Session) llm.Compac
 		if err != nil {
 			return err
 		}
-		m.messagesMu.Lock()
-		m.messages = updated
-		m.compactionIdx = activeStart
-		m.messagesMu.Unlock()
-		if refreshed != nil {
-			m.sess = refreshed
-		}
-		if result != nil && m.program != nil {
-			m.program.Send(compactionUsageMsg{
-				sessionID: streamSessionID,
-				model:     result.Model,
-				usage:     result.Usage,
-			})
-		}
-		if m.engine != nil {
-			m.engine.SetContextEstimateBaseline(0, 0)
+
+		msg := compactionAppliedMsg{
+			generation:  generation,
+			sessionID:   streamSessionID,
+			messages:    updated,
+			activeStart: activeStart,
+			refreshed:   refreshed,
 		}
 		if result != nil {
+			// Streaming context has its own mutex and must move immediately. Later
+			// persistence callbacks extend this compacted base with assistant/tool
+			// work produced after the boundary; replaying a frozen snapshot on the
+			// UI goroutine would erase those additions.
 			m.setStreamingContextMessages(result.ActiveMessages())
+			msg.model = result.Model
+			msg.usage = result.Usage
 		}
-		m.invalidateHistoryCache()
-		// Any pending assistant row that snapshot had upserted is now stale:
-		// compaction rewrote the message table. Clear the tracking so the
-		// next snapshot/response inserts fresh instead of trying to update
-		// a row that no longer exists.
-		m.pendingMu.Lock()
-		m.pendingAssistantMsgID = 0
-		m.pendingAssistantTextSet = false
-		m.pendingAssistantSnapshot = llm.Message{}
-		m.pendingAssistantSnapshotSet = false
-		m.completedAssistantTurns = 0
-		m.pendingMu.Unlock()
+		// Snapshot persistence may already own an assistant row from before the
+		// boundary. Clear that mutex-protected identity immediately so the response
+		// callback inserts the loose tool call on the compacted side before its
+		// result is persisted.
+		m.resetPendingAssistantAfterCompaction()
+		m.queueCompactionForUI(msg)
 		return nil
 	}
+}
+
+func (m *Model) queueCompactionForUI(msg compactionAppliedMsg) {
+	m.compactionApplyMu.Lock()
+	m.pendingCompactionApplies = append(m.pendingCompactionApplies, msg)
+	m.compactionApplyMu.Unlock()
+}
+
+func (m *Model) discardPendingCompactionsBeforeGeneration(generation uint64) {
+	m.compactionApplyMu.Lock()
+	kept := m.pendingCompactionApplies[:0]
+	for _, msg := range m.pendingCompactionApplies {
+		if msg.generation >= generation {
+			kept = append(kept, msg)
+		}
+	}
+	m.pendingCompactionApplies = kept
+	m.compactionApplyMu.Unlock()
+}
+
+func (m *Model) takePendingCompactions(generation uint64, all bool) []compactionAppliedMsg {
+	m.compactionApplyMu.Lock()
+	defer m.compactionApplyMu.Unlock()
+
+	pending := m.pendingCompactionApplies
+	kept := pending[:0]
+	var taken []compactionAppliedMsg
+	for _, msg := range pending {
+		switch {
+		case msg.generation < generation:
+			// A terminal event from the old stream was ignored after a new stream
+			// started. Its durable state belongs to that old generation and must not
+			// leak into this one.
+			continue
+		case msg.generation == generation && (all || len(taken) == 0):
+			taken = append(taken, msg)
+		default:
+			kept = append(kept, msg)
+		}
+	}
+	m.pendingCompactionApplies = kept
+	return taken
+}
+
+func (m *Model) applyNextPendingCompactionToUI(generation uint64) bool {
+	applied := false
+	for _, pending := range m.takePendingCompactions(generation, false) {
+		m.applyCompactionToUI(pending)
+		applied = true
+	}
+	return applied
+}
+
+func (m *Model) applyAllPendingCompactionsToUI(generation uint64) {
+	for _, pending := range m.takePendingCompactions(generation, true) {
+		m.applyCompactionToUI(pending)
+	}
+}
+
+func (m *Model) applyCompactionToUI(msg compactionAppliedMsg) {
+	if msg.sessionID != "" && (m.sess == nil || m.sess.ID != msg.sessionID) {
+		return
+	}
+	m.messagesMu.Lock()
+	m.messages = msg.messages
+	m.compactionIdx = msg.activeStart
+	m.messagesMu.Unlock()
+	if msg.refreshed != nil {
+		m.sess = msg.refreshed
+	}
+	if m.engine != nil {
+		m.engine.SetContextEstimateBaseline(0, 0)
+	}
+	m.invalidateHistoryCache()
+
+	if !msg.usage.BillableCountersZero() {
+		m.recordCompactionUsage(context.Background(), msg.sessionID, msg.model, msg.usage)
+	}
+}
+
+func (m *Model) resetLivePresentationAfterCompaction() {
+	// The callback's in-memory snapshot can lag response/tool persistence from the
+	// turn that crossed the boundary. Reload before clearing the tracker so history
+	// already owns those pre-boundary rows; otherwise the marker appears above the
+	// current turn and jumps downward when StreamEventDone performs the same reload.
+	if m.store != nil && m.sess != nil {
+		if loaded, compactionIdx, err := loadSessionMessagesForScrollback(context.Background(), m.store, m.sess); err != nil {
+			slog.Warn("reload TUI scrollback at compaction boundary failed", "error", err)
+		} else {
+			m.messagesMu.Lock()
+			m.messages = loaded
+			m.compactionIdx = compactionIdx
+			m.messagesMu.Unlock()
+			m.invalidateHistoryCache()
+		}
+	}
+
+	// History now owns everything before the boundary. The live tracker must only
+	// contain continuation events; retaining its earlier segments duplicates the
+	// pre-compaction tool/text rows below the durable marker and makes the marker
+	// jump when StreamEventDone reloads persisted history.
+	m.resetTracker()
+	m.currentResponse.Reset()
+	m.resetCurrentReasoning()
+	if m.smoothBuffer != nil {
+		m.smoothBuffer.Reset()
+	}
+	m.newlineCompactor = ui.NewStreamingNewlineCompactor(ui.MaxStreamingConsecutiveNewlines)
+	m.smoothTickPending = false
+	m.viewCache.completedStream = ""
+	m.resetAltScreenStreamingAppendCache()
+	m.bumpContentVersion()
+}
+
+func (m *Model) resetPendingAssistantAfterCompaction() {
+	// Compaction rewrites the message table, so any snapshot-upsert row is stale.
+	m.pendingMu.Lock()
+	m.pendingAssistantMsgID = 0
+	m.pendingAssistantTextSet = false
+	m.pendingAssistantSnapshot = llm.Message{}
+	m.pendingAssistantSnapshotSet = false
+	m.completedAssistantTurns = 0
+	m.pendingMu.Unlock()
 }
 
 func (m *Model) shouldInjectPlatformDeveloperMessage() bool {
@@ -587,6 +699,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 func (m *Model) startStream(content string) tea.Cmd {
 	ctx, cancel := context.WithCancel(m.rootContext())
 	m.streamGeneration++
+	m.discardPendingCompactionsBeforeGeneration(m.streamGeneration)
 	streamGeneration := m.streamGeneration
 	m.streamCancelFunc = cancel
 	m.setStreamCancelRequested(false)
@@ -692,7 +805,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 		// Set up compaction callback to update in-memory state and persist.
 		// This runs on the engine goroutine, so we protect m.messages with a mutex.
 		streamSess := m.sess
-		compactionCB := m.streamCompactionCallback(streamSess)
+		compactionCB := m.streamCompactionCallback(streamSess, streamGeneration)
 		if m.runner == nil {
 			m.engine.SetCompactionCallback(compactionCB)
 		}

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -59,6 +59,157 @@ func (s *updateMessageFailStore) GetMessages(ctx context.Context, sessionID stri
 	return append([]session.Message(nil), msgs...), nil
 }
 
+func TestCompactionBoundaryAppliesAtResumePhaseBarrier(t *testing.T) {
+	m := newTestChatModel(false)
+	m.store = nil
+	m.sess.ID = "compaction-update"
+	m.engine.SetContextEstimateBaseline(17_500, 3)
+	messages := []session.Message{
+		{Role: llm.RoleUser, TextContent: "before", Sequence: 0},
+		{Role: llm.RoleUser, TextContent: "[Context Compaction]\nsummary", Sequence: 1},
+	}
+	refreshed := *m.sess
+	refreshed.CompactionSeq = 1
+	refreshed.CompactionCount = 1
+	m.currentResponse.WriteString("pre-boundary text")
+	m.tracker.AddTextSegment("pre-boundary text", m.width)
+
+	m.queueCompactionForUI(compactionAppliedMsg{
+		generation:  m.streamGeneration,
+		sessionID:   m.sess.ID,
+		messages:    messages,
+		activeStart: 1,
+		refreshed:   &refreshed,
+		model:       "compact-model",
+		usage:       llm.Usage{InputTokens: 20, OutputTokens: 5},
+	})
+	if m.compactionIdx != 0 {
+		t.Fatalf("boundary applied before ordered resume phase: %d", m.compactionIdx)
+	}
+
+	updated, cmd := m.Update(streamEventMsg{
+		event:      ui.PhaseEvent(llm.PhaseCompactingResumeTask),
+		generation: m.streamGeneration,
+	})
+	if cmd == nil {
+		t.Fatal("resume phase did not schedule the next stream listener")
+	}
+	rm := updated.(*Model)
+	if rm.compactionIdx != 1 || len(rm.messages) != 2 || rm.messages[1].Sequence != 1 {
+		t.Fatalf("compaction boundary state not applied: idx=%d messages=%#v", rm.compactionIdx, rm.messages)
+	}
+	if rm.sess.CompactionSeq != 1 || rm.sess.CompactionCount != 1 {
+		t.Fatalf("refreshed session not applied: %+v", rm.sess)
+	}
+	if total, count := rm.engine.ContextEstimateBaseline(); total != 0 || count != 0 {
+		t.Fatalf("context baseline = (%d, %d), want cleared", total, count)
+	}
+	if rm.stats.CompactionLLMCallCount != 1 {
+		t.Fatalf("compaction usage count = %d, want 1", rm.stats.CompactionLLMCallCount)
+	}
+	if rm.currentResponse.Len() != 0 || len(rm.tracker.CompletedSegments()) != 0 {
+		t.Fatalf("pre-boundary live presentation survived compaction: response=%q segments=%#v", rm.currentResponse.String(), rm.tracker.CompletedSegments())
+	}
+}
+
+func TestPendingCompactionForStaleSessionIsDiscarded(t *testing.T) {
+	m := newTestChatModel(false)
+	m.sess.ID = "current"
+	original := append([]session.Message(nil), m.messages...)
+	m.queueCompactionForUI(compactionAppliedMsg{
+		generation:  m.streamGeneration,
+		sessionID:   "stale",
+		messages:    []session.Message{{Role: llm.RoleUser, TextContent: "wrong session"}},
+		activeStart: 1,
+	})
+
+	m.applyAllPendingCompactionsToUI(m.streamGeneration)
+	if m.compactionIdx != 0 || len(m.messages) != len(original) {
+		t.Fatalf("stale compaction mutated current session: idx=%d messages=%#v", m.compactionIdx, m.messages)
+	}
+	m.compactionApplyMu.Lock()
+	pending := len(m.pendingCompactionApplies)
+	m.compactionApplyMu.Unlock()
+	if pending != 0 {
+		t.Fatalf("stale compactions remained pending: %d", pending)
+	}
+}
+
+func TestQueuedCompactionsApplyInFIFOOrder(t *testing.T) {
+	m := newTestChatModel(false)
+	generation := m.streamGeneration
+	m.queueCompactionForUI(compactionAppliedMsg{generation: generation, messages: []session.Message{{TextContent: "first"}}, activeStart: 1})
+	m.queueCompactionForUI(compactionAppliedMsg{generation: generation, messages: []session.Message{{TextContent: "first"}, {TextContent: "second"}}, activeStart: 2})
+
+	m.applyNextPendingCompactionToUI(generation)
+	if m.compactionIdx != 1 || len(m.messages) != 1 {
+		t.Fatalf("first boundary = idx %d, messages %#v", m.compactionIdx, m.messages)
+	}
+	m.applyNextPendingCompactionToUI(generation)
+	if m.compactionIdx != 2 || len(m.messages) != 2 {
+		t.Fatalf("second boundary = idx %d, messages %#v", m.compactionIdx, m.messages)
+	}
+}
+
+func TestTerminalEventsApplyAllCompactionsForCurrentGeneration(t *testing.T) {
+	tests := []struct {
+		name  string
+		event ui.StreamEvent
+	}{
+		{name: "done", event: ui.DoneEvent(0)},
+		{name: "error", event: ui.ErrorEvent(errors.New("provider failed after compaction"))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestChatModel(false)
+			m.store = nil
+			m.streaming = true
+			m.streamGeneration = 2
+			m.queueCompactionForUI(compactionAppliedMsg{generation: 1, messages: []session.Message{{TextContent: "stale"}}, activeStart: 9})
+			m.queueCompactionForUI(compactionAppliedMsg{generation: 2, messages: []session.Message{{TextContent: "current"}}, activeStart: 1})
+
+			_, _ = m.Update(streamEventMsg{event: tt.event, generation: 2})
+			if m.compactionIdx != 1 || len(m.messages) != 1 || m.messages[0].TextContent != "current" {
+				t.Fatalf("terminal apply used wrong generation: idx=%d messages=%#v", m.compactionIdx, m.messages)
+			}
+			m.compactionApplyMu.Lock()
+			pending := len(m.pendingCompactionApplies)
+			m.compactionApplyMu.Unlock()
+			if pending != 0 {
+				t.Fatalf("terminal event left %d compactions pending", pending)
+			}
+		})
+	}
+}
+
+func TestDeferredBoundaryDoesNotClobberPostCompactionStreamingContext(t *testing.T) {
+	m := newTestChatModel(false)
+	m.store = nil
+	m.streaming = true
+	m.sess.ID = "stream-context"
+	m.streamGeneration = 3
+	m.messages = []session.Message{{Role: llm.RoleUser, TextContent: "old", Sequence: 0}}
+	m.pendingAssistantMsgID = 42
+	m.pendingAssistantTextSet = true
+	result := &llm.CompactionResult{NewMessages: []llm.Message{llm.UserText("[Context Compaction]\nsummary")}}
+
+	if err := m.streamCompactionCallback(m.sess, 3)(context.Background(), result); err != nil {
+		t.Fatalf("compaction callback: %v", err)
+	}
+	if m.pendingAssistantMsgID != 0 || m.pendingAssistantTextSet {
+		t.Fatalf("pre-boundary assistant identity survived callback: id=%d text_set=%v", m.pendingAssistantMsgID, m.pendingAssistantTextSet)
+	}
+	m.contextEstimateMu.Lock()
+	m.streamingContextMessages = append(m.streamingContextMessages, llm.AssistantText("post-compaction assistant"))
+	m.contextEstimateMu.Unlock()
+
+	m.applyNextPendingCompactionToUI(3)
+	contextMessages := m.buildMessagesForContextEstimate()
+	if got := llm.MessageText(contextMessages[len(contextMessages)-1]); got != "post-compaction assistant" {
+		t.Fatalf("deferred boundary clobbered post-compaction context: %#v", contextMessages)
+	}
+}
+
 func TestEnsureContextMessagesResetsBaselineWhenMutatingPrefix(t *testing.T) {
 	baseMessages := []session.Message{
 		{Role: llm.RoleUser, Parts: []llm.Part{{Type: llm.PartText, Text: "hello"}}, TextContent: "hello", Sequence: 0},


### PR DESCRIPTION
## Summary

- keep automatic-compaction persistence on the engine callback goroutine, but defer Bubble Tea model/cache mutation to ordered stream barriers
- apply queued durable boundaries at `Compacting: resume task`, with generation-aware Done/Error fallbacks
- preserve post-compaction assistant/tool context by moving the mutex-protected context base immediately and deferring only Bubble Tea-owned state
- queue multiple compactions FIFO and prevent stale generations or sessions leaking into later streams
- share the same UI-state application path with manual `/compact`, including stale pending-assistant cleanup
- add `debug:compaction`, a built-in zero-cost 20k-context scenario for repeatable live TUI compaction tests
- preserve debug model variants through the normal `--provider debug:<variant>` factory path and make synthetic edit generation deterministic across harmless file formatting changes

## One-command live reproduction

```bash
term-llm chat --provider debug:compaction
```

Send any seed message, then a second message. The deterministic seed reports `18,100` input + `24` output tokens against a `19,000` effective input budget (`20,000` context minus `1,000` output reserve). The resulting `18,124` baseline exceeds the default hard threshold (`19,000 × 0.95 = 18,050`), so the second turn compacts without provider credentials, a local model, custom config, or API cost.

Non-interactive smoke:

```bash
term-llm chat --provider debug:compaction \
  --auto-send "seed the compaction probe" \
  --auto-send "continue after compaction"
```

Tool-boundary smoke in one agent turn:

```bash
term-llm chat --provider debug:compaction --tools glob
# Send: run the tool compaction probe
```

That scenario deterministically executes:

```text
glob pre_1 → glob pre_2 → glob pre_3 → compaction → glob post_1 → glob post_2 → glob post_3 → completion
```

The third pre-compaction call reports the hard-threshold usage. Its call/result pair is replayed together on the compacted side of the boundary before the three post-compaction calls. The final message confirms the exact 3+3 count.

This live scenario exposed a second ordering bug while developing the PR: deferred pending-assistant cleanup let the third tool call remain attached to its pre-boundary persisted row while its result was inserted post-boundary, producing an unmatched active tool result after resume. The callback now clears that mutex-protected persistence identity immediately, so the loose call is reinserted after the summary before its result. The verified active order is `pre_3 call → pre_3 result → post_1 call`.

A subsequent 200ms frame-by-frame audit exposed the remaining visual defect: at the resume phase the durable marker initially rendered above the entire live tracker, so all six tool rows appeared after it; at StreamEventDone, persisted history reloaded and the first three rows jumped above the marker while the tracker still duplicated all six below it. The resume barrier now reloads the just-persisted compaction scrollback, transfers pre-boundary ownership to history, and resets the live tracker/response buffers before continuation events. Every audited frame now holds the stable `3 rows → marker → 3 rows` layout with no duplicate or jump.

The final persisted ordering is:

```text
user turn
↳ Context compacted · internal summary hidden · Ctrl+O to inspect
assistant continuation
```

`Ctrl+O` exposes the summary and retained-tail boundary details.

## Root cause

`streamCompactionCallback` directly mutated `messages`, `compactionIdx`, session metadata, pending-assistant state, stats, and render caches from the engine goroutine. That raced Bubble Tea's `Update`/`View` ownership and could make the durable marker appear late or at a transiently incorrect position.

The callback now persists the result and queues generation-tagged UI state under a mutex. The ordered resume phase consumes one boundary before continuation provider text; Done/Error consume all remaining boundaries for post-response and cancellation paths. Multiple pending compactions remain FIFO.

The mutex-protected streaming-context base still moves immediately in the callback. That is intentional: later response/tool persistence callbacks extend the compacted base, and a deferred frozen snapshot would erase that post-compaction work.

## External review follow-up

Opus review concerns addressed:

- removed the initial unbounded Bubble Tea acknowledgement wait
- stopped bypassing buffered pre-compaction stream events
- added stale-session coverage
- consolidated manual `/compact` state application
- removed the superseded usage-message path

Grok (`grok-bin:grok-4.5-high`) review concerns addressed:

- preserved post-compaction assistant/tool streaming context instead of clobbering it at deferred apply
- replaced the single pending slot with a FIFO queue
- tagged pending boundaries by stream generation and discard stale generations
- added Resume, Done, Error, consecutive-compaction, stale-session, and context-preservation coverage
- narrowed the resume-phase ordering claim to the continuation-provider handoff

Grok's zero-usage metrics concern was checked and is not a regression: `AddCompactionUsageForModel` already ignores all-zero billable counters.

## Verification

- `go test -race ./internal/tui/chat ./internal/llm`
- `go test ./internal/render/chat ./internal/session`
- `go vet ./internal/tui/chat ./internal/llm`
- `go build ./...`
- built-in two-turn `debug:compaction` TUI recording: one boundary persisted at sequence 4; normal marker and Ctrl+O inspector both visible
- live tool-boundary TUI smoke: one boundary persisted at sequence 7; verified IDs `debug_compact_pre_1..3`, paired active `pre_3` call/result, `debug_compact_post_1..3`, then exact 3+3 completion
- 200ms frame audit of the rendered MP4: stable 3-before/3-after marker placement; no tracker duplication or StreamEventDone jump
- built-in non-interactive two-turn smoke: `compaction_seq=4`, `compaction_count=1`

A broad `go test ./...` was attempted earlier. It passed all relevant packages but failed two unrelated `cmd` skill-discovery tests because the live user skill inventory exhausted their configured visible-skill budget.
