### PR TITLE
fix(llm): preserve grok-bin tool/text order in persisted turns

### DIFF
--- a/internal/llm/approval_transcript_test.go
+++ b/internal/llm/approval_transcript_test.go
@@ -227,17 +227,17 @@ func TestSyncBridgeToolExecutionCarriesApprovalTranscript(t *testing.T) {
 }
 
 // TestSyncBridgeSequentialToolCallsSeePriorResults pins the evidence available
-// to the Nth inline tool call. grok-bin and cursor-bin set InlineToolLoop, so a
-// whole multi-tool agent loop runs inside one Stream call; a later shell command
-// is frequently induced by an earlier tool's output, and guardian cannot judge
-// that without seeing the earlier result.
+// to the Nth inline tool call. grok-bin and cursor-bin set InlineToolLoop (and
+// OrderedInlineToolEvents), so a whole multi-tool agent loop runs inside one
+// Stream call; a later shell command is frequently induced by an earlier tool's
+// output, and guardian cannot judge that without seeing the earlier result.
 func TestSyncBridgeSequentialToolCallsSeePriorResults(t *testing.T) {
 	tests := []struct {
 		name         string
 		capabilities Capabilities
 	}{
 		{name: "claude_bin_style", capabilities: Capabilities{ToolCalls: true}},
-		{name: "grok_bin_style", capabilities: Capabilities{ToolCalls: true, InlineToolLoop: true}},
+		{name: "grok_bin_style", capabilities: Capabilities{ToolCalls: true, InlineToolLoop: true, OrderedInlineToolEvents: true}},
 		{name: "cursor_bin_style", capabilities: Capabilities{ToolCalls: true, InlineToolLoop: true, OrderedInlineToolEvents: true}},
 	}
 

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -3211,10 +3211,11 @@ turnLoop:
 
 		// If only sync tools were executed (MCP path), decide whether to continue
 		if len(toolCalls) == 0 && syncToolsExecuted {
-			// Preserve the provider's streamed text/tool/text ordering. Cursor's inline
-			// MCP loop can emit a final assistant segment after one or more tools in the
-			// same stream; rebuilding from separate text/tool accumulators moves that
-			// final text above the tools when the persisted message replaces live output.
+			// Preserve the provider's streamed text/tool/text ordering. Inline MCP loops
+			// (Cursor, Grok, agy) can emit a final assistant segment after one or more
+			// tools in the same stream; rebuilding from separate text/tool accumulators
+			// moves that final text above the tools when the persisted message replaces
+			// live output.
 			var assistantMsg Message
 			if preserveInlineToolOrder && len(inlineSyncParts) > 0 {
 				assistantMsg = buildOrderedInlineAssistant(inlineSyncParts)

--- a/internal/llm/engine_orchestration_test.go
+++ b/internal/llm/engine_orchestration_test.go
@@ -214,6 +214,52 @@ func TestEngineOrchestration_InlineSyncToolLoopPersistsEventOrder(t *testing.T) 
 	}
 }
 
+func TestEngineOrchestration_InlineSyncToolLoopOrderedEventsPreservesToolThenFinalText(t *testing.T) {
+	// Grok-bin shape from session #3751: tools first, then one final assistant segment.
+	// Without OrderedInlineToolEvents the final rebuild puts all text above tool calls.
+	registry := NewToolRegistry()
+	registry.Register(&mockTool{name: "test_tool", result: "tool output"})
+	provider := &inlineSyncToolProvider{inline: true, ordered: true}
+	engine := NewEngine(provider, registry)
+	var persisted []Message
+	engine.SetTurnCompletedCallback(func(ctx context.Context, turn int, messages []Message, metrics TurnMetrics) error {
+		persisted = append(persisted, messages...)
+		return nil
+	})
+
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("use tool")},
+		Tools:    []ToolSpec{{Name: "test_tool"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		if event.Type == EventError {
+			t.Fatalf("unexpected error: %v", event.Err)
+		}
+	}
+
+	if len(persisted) < 1 || persisted[0].Role != RoleAssistant {
+		t.Fatalf("persisted messages = %+v", persisted)
+	}
+	parts := persisted[0].Parts
+	if len(parts) != 2 {
+		t.Fatalf("assistant parts = %+v, want tool/text", parts)
+	}
+	if parts[0].Type != PartToolCall || parts[1].Type != PartText || parts[1].Text != "inline final" {
+		t.Fatalf("assistant parts = %+v, want tool then final text", parts)
+	}
+}
+
 func TestEngineOrchestration_InlineSyncToolLoopWithoutOrderedEventsKeepsLegacyPersistence(t *testing.T) {
 	registry := NewToolRegistry()
 	registry.Register(&mockTool{name: "test_tool", result: "tool output"})

--- a/internal/llm/grok_bin.go
+++ b/internal/llm/grok_bin.go
@@ -180,12 +180,13 @@ func (p *GrokBinProvider) Credential() string { return "grok-bin" }
 
 func (p *GrokBinProvider) Capabilities() Capabilities {
 	return Capabilities{
-		NativeWebSearch:    true,
-		NativeWebFetch:     true,
-		ToolCalls:          true,
-		SupportsToolChoice: false,
-		ManagesOwnContext:  true,
-		InlineToolLoop:     true,
+		NativeWebSearch:         true,
+		NativeWebFetch:          true,
+		ToolCalls:               true,
+		SupportsToolChoice:      false,
+		ManagesOwnContext:       true,
+		InlineToolLoop:          true,
+		OrderedInlineToolEvents: true,
 	}
 }
 

--- a/internal/llm/grok_bin_test.go
+++ b/internal/llm/grok_bin_test.go
@@ -144,11 +144,8 @@ func TestValidateGrokBinModel(t *testing.T) {
 
 func TestGrokBinProviderCapabilities(t *testing.T) {
 	caps := NewGrokBinProvider("grok-4.5", nil).Capabilities()
-	if !caps.NativeWebSearch || !caps.NativeWebFetch || !caps.ToolCalls || !caps.ManagesOwnContext || !caps.InlineToolLoop {
-		t.Fatalf("capabilities = %+v, want native search/fetch, tool calls, managed context, and inline loop", caps)
-	}
-	if caps.OrderedInlineToolEvents {
-		t.Fatalf("capabilities = %+v, ordered inline tool events must remain Cursor-specific", caps)
+	if !caps.NativeWebSearch || !caps.NativeWebFetch || !caps.ToolCalls || !caps.ManagesOwnContext || !caps.InlineToolLoop || !caps.OrderedInlineToolEvents {
+		t.Fatalf("capabilities = %+v, want native search/fetch, tool calls, managed context, inline loop, and ordered inline tool events", caps)
 	}
 }
 


### PR DESCRIPTION
## Summary

Grok CLI (`grok-bin`) sessions could show **tool calls after the final assistant response** in the persisted transcript / web UI, even though tools actually ran first.

Seen on production session **#3751** (`sess_628d66bf-5cbc-41cd-8e6a-06fe1eae360b`): 18 MCP tools ran for ~2 minutes, then a grounded final answer — but the stored assistant message was `text` then all `tool_call` parts.

### Root cause

`grok-bin` already has `InlineToolLoop: true` (tools execute sync via the MCP bridge inside one stream). On turn end, the engine rebuilds the assistant message from separate text/tool accumulators **unless** `OrderedInlineToolEvents` is set:

- without the flag → all text first, then all tool calls (this bug)
- with the flag → stream order preserved via `inlineSyncParts`

Cursor and agy already set `OrderedInlineToolEvents`. Grok did not, and a capability test incorrectly required it stay Cursor-only.

### Fix

- Enable `OrderedInlineToolEvents` on `GrokBinProvider`
- Update capability + approval-transcript tests
- Add regression for the tool-then-final-text shape from session #3751
- Clarify the engine comment that this path is not Cursor-only

## Test plan

- [x] `go test ./internal/llm/ -count=1 -run 'TestGrokBinProviderCapabilities|TestEngineOrchestration_InlineSyncToolLoop|TestSyncBridgeSequentialToolCallsSeePriorResults'`
- [ ] CI on PR
- [ ] After merge/deploy: re-run a Grok tool-using web chat and confirm tools appear before the final answer in `/chat/<n>` reload

