### PR TITLE
fix(web): route large request bodies over HTTPS

### DIFF
--- a/internal/serveui/static/app-webrtc.js
+++ b/internal/serveui/static/app-webrtc.js
@@ -425,8 +425,8 @@
   function patchedFetch(url, options) {
     const urlStr = typeof url === 'string' ? url : url.toString();
     if (dataChannel && dataChannel.readyState === 'open' && isAPIPath(urlStr)) {
-      // Only route string bodies (all term-llm API calls use JSON strings).
-      if (!options || options.body === undefined || typeof options.body === 'string') {
+      // Bodies over 100 KiB expand again inside one data-channel frame, so use HTTPS.
+      if ((!options || options.body === undefined || typeof options.body === 'string') && (!options?.body || new Blob([options.body]).size <= 100 * 1024)) {
         return webrtcFetch(urlStr, options || {});
       }
     }

--- a/internal/serveui/static/app_webrtc_test.js
+++ b/internal/serveui/static/app_webrtc_test.js
@@ -294,6 +294,39 @@ async function testSynchronousSendThrowFallsBackForMutation() {
   console.log('PASS: synchronous WebRTC send throw proves non-delivery and falls back once over HTTPS');
 }
 
+async function testLargeBodiesBypassWebRTCWithoutDegradingChannel() {
+  const harness = await createEnabledHarness();
+  const channel = harness.channels[0];
+  const limit = 100 * 1024;
+
+  const atLimit = harness.window.fetch('/ui/v1/at-limit', {
+    method: 'POST',
+    body: 'a'.repeat(limit),
+    __termLLMRetrySafe: true,
+  });
+  const routedRequest = channel.sent.find((frame) => frame.path === '/ui/v1/at-limit');
+  if (!routedRequest?.id) fail('body at the cutoff did not use WebRTC');
+  channel.onmessage({ data: JSON.stringify({ id: routedRequest.id, type: 'done', status: 200 }) });
+  await atLimit;
+
+  const oversized = await harness.window.fetch('/ui/v1/oversized', {
+    method: 'POST',
+    body: 'a'.repeat(limit + 1),
+    __termLLMRetrySafe: true,
+  });
+  if (!oversized.ok || harness.getHTTPSAPICalls() !== 1) {
+    fail(`oversized body did not use HTTPS exactly once (calls=${harness.getHTTPSAPICalls()})`);
+  }
+  if (channel.sent.some((frame) => frame.path === '/ui/v1/oversized')) {
+    fail('oversized body was also sent over WebRTC');
+  }
+  if (harness.getTransportRecoveries() !== 0 || channel.readyState !== 'open') {
+    fail('oversized HTTPS request falsely degraded the healthy WebRTC channel');
+  }
+
+  console.log('PASS: request bodies over 100 KiB bypass WebRTC without degrading the channel');
+}
+
 async function testAmbiguousMutationDrainIsNotReplayed() {
   const harness = await createEnabledHarness();
   const channel = harness.channels[0];
@@ -408,6 +441,7 @@ async function testUnansweredMutationTimeoutDoesNotCancelServerWork() {
   await testChannelCloseSignalsTransportRecoveryOnce();
   await testSendFallbackSignalsTransportRecoveryOnce();
   await testSynchronousSendThrowFallsBackForMutation();
+  await testLargeBodiesBypassWebRTCWithoutDegradingChannel();
   await testAmbiguousMutationDrainIsNotReplayed();
   await testTwentySecondFallbackAndPersistentRecovery();
   await testVisibilityChurnDoesNotHammerSignaling();

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -33,8 +33,9 @@ import (
 )
 
 const (
-	maxFrameBytes       = 10 * 1024 * 1024 // 10 MB
-	defaultSetupTimeout = 30 * time.Second
+	maxFrameBytes         = 10 * 1024 * 1024 // 10 MB
+	maxOutboundFrameBytes = 128 * 1024       // safely below the advertised 256 KiB SCTP message size
+	defaultSetupTimeout   = 30 * time.Second
 )
 
 // Cap per-channel HTTP dispatches so one client cannot create an unbounded
@@ -110,6 +111,13 @@ type dataChannelConn interface {
 	ReadDataChannel([]byte) (int, bool, error)
 	WriteDataChannel([]byte, bool) (int, error)
 	Close() error
+}
+
+func writeDataChannelText(dc dataChannelConn, text string) (int, error) {
+	if len(text) > maxOutboundFrameBytes {
+		return 0, fmt.Errorf("webrtc: outbound data channel frame is %d bytes, limit is %d", len(text), maxOutboundFrameBytes)
+	}
+	return dc.WriteDataChannel([]byte(text), true)
 }
 
 const maxChunkDataBytes = 16 * 1024
@@ -622,7 +630,7 @@ func (p *peer) runDataChannel(ctx context.Context, dc dataChannelConn, closeTran
 	send := func(text string) error {
 		sendMu.Lock()
 		defer sendMu.Unlock()
-		_, err := dc.WriteDataChannel([]byte(text), true)
+		_, err := writeDataChannelText(dc, text)
 		if err != nil {
 			stopDataChannel()
 		} else {

--- a/internal/webrtc/peer_test.go
+++ b/internal/webrtc/peer_test.go
@@ -818,6 +818,50 @@ func TestChunkStreaming(t *testing.T) {
 	}
 }
 
+type outboundLimitDataChannel struct {
+	writes int
+}
+
+func (d *outboundLimitDataChannel) ReadDataChannel([]byte) (int, bool, error) {
+	return 0, false, io.EOF
+}
+
+func (d *outboundLimitDataChannel) WriteDataChannel(data []byte, _ bool) (int, error) {
+	d.writes++
+	return len(data), nil
+}
+
+func (d *outboundLimitDataChannel) Close() error { return nil }
+
+func TestWriteDataChannelTextEnforcesOutboundFrameLimit(t *testing.T) {
+	dc := &outboundLimitDataChannel{}
+	if _, err := writeDataChannelText(dc, strings.Repeat("a", maxOutboundFrameBytes)); err != nil {
+		t.Fatalf("frame at limit: %v", err)
+	}
+	if _, err := writeDataChannelText(dc, strings.Repeat("a", maxOutboundFrameBytes+1)); err == nil {
+		t.Fatal("oversized outbound frame was accepted")
+	}
+	if dc.writes != 1 {
+		t.Fatalf("data channel writes = %d, want only the at-limit frame", dc.writes)
+	}
+}
+
+func TestChunkFramesRemainBelowOutboundLimitAfterJSONEscaping(t *testing.T) {
+	largest := 0
+	err := sendChunkFrames(func(frame string) error {
+		if len(frame) > largest {
+			largest = len(frame)
+		}
+		return nil
+	}, "response-id", strings.Repeat("\x00", maxChunkDataBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if largest > maxOutboundFrameBytes {
+		t.Fatalf("escaped chunk frame = %d bytes, limit = %d", largest, maxOutboundFrameBytes)
+	}
+}
+
 func TestChunkWriter_SplitsLargePayloadInto16KFrames(t *testing.T) {
 	large := strings.Repeat("🙂", maxChunkDataBytes) + "tail"
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- route `/v1/` request bodies larger than **100 KiB (102,400 bytes)** over HTTPS instead of WebRTC
- keep smaller API requests on the existing direct WebRTC path
- preserve the existing 16 KiB response-body chunking and add a transport-wide **128 KiB outbound frame cap**
- fail closed if any future response path attempts to send a larger data-channel frame
- avoid falsely degrading and renegotiating a healthy data channel during image submissions
- cover the exact request cutoff: **100 KiB stays on WebRTC; 100 KiB + 1 byte uses HTTPS**

## Why 100 KiB

WebRTC request bodies are base64-encoded into a single RTCDataChannel frame. A 100 KiB JSON body expands to roughly 133 KiB before the frame envelope, leaving conservative headroom below the advertised 256 KiB SCTP message size. Image-bearing requests are generally larger and do not benefit from forcing that payload through the direct channel.

Server responses already split body data into UTF-8-safe 16 KiB chunks. The added 128 KiB serialized-frame ceiling is a second line of defence around every outbound frame, including headers and future frame types. Tests cover the exact hard boundary and a worst-case JSON-escaping payload; oversized frames are rejected before `WriteDataChannel`.

## Reproduction and live verification

Before the fix, submitting a 368,988-byte PNG plus text caused the WebRTC request to miss its first-frame deadline, mark the connection unstable, tear down the channel, and replay the idempotent request over HTTPS.

After deploying this branch locally, the same image submission:

- completed `POST /responses` with HTTP 200
- produced no WebRTC degraded/retrying diagnostic
- left the data channel connected
- returned the expected text read from the screenshot

## Tests

- `go test ./internal/webrtc ./internal/serveui/...`
- `mise x node@24.15.0 -- node internal/serveui/static/app_webrtc_test.js`
- `go build ./...`

`go test ./...` otherwise passed but reported two unrelated environment-sensitive skill-discovery failures because the local Jarvis config limits visible skill metadata; the changed WebRTC and serve UI packages pass.
