### PR TITLE
fix: A stalled queued run prevents completed sibling results from being collected

### DIFF
--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -48,6 +49,7 @@ type WaitForJobsArgs struct {
 
 type QueuedJobResult struct {
 	JobID           string   `json:"job_id"`
+	RunID           string   `json:"run_id,omitempty"`
 	Status          string   `json:"status"`
 	ExitReason      string   `json:"exit_reason,omitempty"`
 	Truncated       bool     `json:"truncated,omitempty"`
@@ -279,33 +281,45 @@ func (t *WaitForJobsTool) Execute(ctx context.Context, args json.RawMessage) (ll
 		pollInterval = t.pollIntervalOverride
 	}
 
-	results := make([]QueuedJobResult, 0, len(a.JobIDs)+len(a.RunIDs))
-	for _, runID := range a.RunIDs {
+	results := make([]QueuedJobResult, len(a.RunIDs)+len(a.JobIDs))
+	var wg sync.WaitGroup
+	for i, runID := range a.RunIDs {
 		runID = strings.TrimSpace(runID)
 		if runID == "" {
-			results = append(results, QueuedJobResult{Status: "not_found", Error: "blank run_id"})
+			results[i] = QueuedJobResult{Status: "not_found", Error: "blank run_id"}
 			continue
 		}
-		run, err := t.client.waitForRun(ctx, runID, pollInterval)
-		if err != nil {
-			results = append(results, QueuedJobResult{Status: "failed", Error: err.Error()})
-			continue
-		}
-		results = append(results, queuedJobResultFromJobsRun("", run))
+		wg.Add(1)
+		go func(i int, runID string) {
+			defer wg.Done()
+			run, err := t.client.waitForRun(ctx, runID, pollInterval)
+			if err != nil {
+				results[i] = QueuedJobResult{RunID: runID, Status: "failed", Error: err.Error()}
+				return
+			}
+			results[i] = queuedJobResultFromJobsRun("", run)
+			results[i].RunID = runID
+		}(i, runID)
 	}
-	for _, jobID := range a.JobIDs {
+	for i, jobID := range a.JobIDs {
+		i += len(a.RunIDs)
 		jobID = strings.TrimSpace(jobID)
 		if jobID == "" {
-			results = append(results, QueuedJobResult{Status: "not_found", Error: "blank job_id"})
+			results[i] = QueuedJobResult{Status: "not_found", Error: "blank job_id"}
 			continue
 		}
-		run, err := t.client.waitForJob(ctx, jobID, pollInterval)
-		if err != nil {
-			results = append(results, QueuedJobResult{JobID: jobID, Status: "failed", Error: err.Error()})
-			continue
-		}
-		results = append(results, queuedJobResultFromJobsRun(jobID, run))
+		wg.Add(1)
+		go func(i int, jobID string) {
+			defer wg.Done()
+			run, err := t.client.waitForJob(ctx, jobID, pollInterval)
+			if err != nil {
+				results[i] = QueuedJobResult{JobID: jobID, Status: "failed", Error: err.Error()}
+				return
+			}
+			results[i] = queuedJobResultFromJobsRun(jobID, run)
+		}(i, jobID)
 	}
+	wg.Wait()
 	data, _ := json.Marshal(results)
 	return llm.TextOutput(string(data)), nil
 }

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -237,6 +237,49 @@ func TestWaitForJobsPollsSpecificRunUntilTerminal(t *testing.T) {
 	}
 }
 
+func TestWaitForJobsMultipleRunsCollectsCompletedSibling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/runs/run_stalled":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_stalled", JobID: "job_stalled", Status: "running"})
+		case "/v2/runs/run_done":
+			writeJSON(t, w, jobsV2AgentRunResponse{
+				ID:       "run_done",
+				JobID:    "job_done",
+				Status:   "succeeded",
+				Response: "completed sibling response",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewWaitForJobsToolWithClient(client)
+	tool.pollIntervalOverride = time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	out, err := tool.Execute(ctx, json.RawMessage(`{"run_ids":["run_stalled","run_done"]}`))
+	if err != nil {
+		t.Fatalf("wait Execute() error = %v", err)
+	}
+	var results []QueuedJobResult
+	if err := json.Unmarshal([]byte(out.Content), &results); err != nil {
+		t.Fatalf("wait output is not JSON: %v; %s", err, out.Content)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].RunID != "run_stalled" || results[0].Status != "failed" || !strings.Contains(results[0].Error, "context deadline exceeded") {
+		t.Fatalf("stalled result = %+v, want correlated deadline failure", results[0])
+	}
+	if results[1].RunID != "run_done" || results[1].JobID != "job_done" || results[1].Status != "succeeded" || results[1].Response != "completed sibling response" {
+		t.Fatalf("completed result = %+v, want persisted sibling response", results[1])
+	}
+}
+
 func TestQueueAgentSurfacesJobsErrorBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
## What changed

- Wait for every requested `run_id` and `job_id` concurrently instead of blocking on them sequentially.
- Store each result in its original position so the response order remains unchanged.
- Include `run_id` on run-based results, including context/error results, so stalled runs remain recoverable and correlated.
- Add a regression test where the first run remains active through the context deadline while a later sibling has already succeeded.

## Why this is high-value

`wait_for_jobs` is used to collect parallel queued-agent work. Previously, one slow or wedged run at the front of a batch could consume the entire tool context before later IDs were queried. Already-completed sibling responses were then reported as generic failures and effectively hidden, wasting successful background research or coding work. Concurrent polling isolates each requested ID while retaining the existing result order and terminal-status behavior.

## Validation

- `go test ./internal/tools`
- `go test -race ./internal/tools -run 'TestWaitForJobs' -count=1`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`

The unisolated full test command initially encountered two unrelated `cmd` tests that discovered the host's global term-llm skills and exceeded their visible-skill limits. The full suite passes with an isolated XDG config directory.
