### PR TITLE
fix: preserve empty Responses tool outputs

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -157,6 +157,18 @@ func (i ResponsesInputItem) MarshalJSON() ([]byte, error) {
 		return append([]byte(nil), i.Raw...), nil
 	}
 	type wire ResponsesInputItem
+	if i.Type == "function_call_output" {
+		// The Responses API requires output even when the tool returned an empty
+		// string. The field is otherwise omitted to avoid sending it on unrelated
+		// input item types.
+		return json.Marshal(struct {
+			wire
+			Output string `json:"output"`
+		}{
+			wire:   wire(i),
+			Output: i.Output,
+		})
+	}
 	return json.Marshal(wire(i))
 }
 

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -235,6 +235,32 @@ func TestBuildResponsesInput_ToolCalls(t *testing.T) {
 	}
 }
 
+func TestBuildResponsesInput_EmptyToolResultIncludesOutput(t *testing.T) {
+	messages := []Message{
+		{Role: RoleAssistant, Parts: []Part{{Type: PartToolCall, ToolCall: &ToolCall{
+			ID:        "call_empty",
+			Name:      "web_search",
+			Arguments: json.RawMessage(`{"query":"test"}`),
+		}}}},
+		{Role: RoleTool, Parts: []Part{{Type: PartToolResult, ToolResult: &ToolResult{
+			ID:   "call_empty",
+			Name: "web_search",
+		}}}},
+	}
+
+	input := BuildResponsesInput(messages)
+	if len(input) != 2 {
+		t.Fatalf("expected 2 input items, got %d", len(input))
+	}
+	got, err := json.Marshal(input[1])
+	if err != nil {
+		t.Fatalf("marshal empty tool result: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"output":""`)) {
+		t.Fatalf("empty function_call_output omitted required output field: %s", got)
+	}
+}
+
 func TestBuildResponsesInput_ToolResultStructuredImageParts(t *testing.T) {
 	messages := []Message{
 		{Role: RoleAssistant, Parts: []Part{{Type: PartToolCall, ToolCall: &ToolCall{


### PR DESCRIPTION
## Summary

- always serialize the required `output` field for Responses API `function_call_output` items, including empty strings
- continue omitting `output` from unrelated input item types
- add a regression test covering an empty tool result

## Problem

A tool can legitimately return an empty string. `ResponsesInputItem.Output` uses `omitempty`, so stateless replay serialized that result without an `output` field:

```json
{"type":"function_call_output","call_id":"call_empty"}
```

The Responses API rejects the request with `Missing required parameter: input[N].output`. Because subsequent turns replay the same malformed history, the session cannot recover.

## Test

- `go test ./internal/llm -count=1`
