### PR TITLE
fix: A lost trigger response hides an already-running queued agent

### DIFF
--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	defaultQueuedAgentTimeout        = 3600
-	defaultQueuedAgentPollInterval   = 5
-	defaultJobsServerBaseURL         = "http://127.0.0.1:8080"
-	QueueAgentEphemeralJobLabelKey   = "term_llm_queue_agent"
-	QueueAgentEphemeralJobLabelValue = "ephemeral"
-	QueueAgentEphemeralJobLabelsJSON = `{"term_llm_queue_agent":"ephemeral"}`
+	defaultQueuedAgentTimeout          = 3600
+	defaultQueuedAgentPollInterval     = 5
+	queuedAgentTriggerReconcileTimeout = 2 * time.Second
+	defaultJobsServerBaseURL           = "http://127.0.0.1:8080"
+	QueueAgentEphemeralJobLabelKey     = "term_llm_queue_agent"
+	QueueAgentEphemeralJobLabelValue   = "ephemeral"
+	QueueAgentEphemeralJobLabelsJSON   = `{"term_llm_queue_agent":"ephemeral"}`
 )
 
 type QueueAgentArgs struct {
@@ -203,7 +204,17 @@ func (t *QueueAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 	}
 	run, err := t.client.triggerJob(ctx, job.ID)
 	if err != nil {
-		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+		// TriggerJob commits the run before writing its response. If that response
+		// is lost, reconcile with server state instead of hiding an active run and
+		// encouraging the caller to queue a duplicate.
+		reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), queuedAgentTriggerReconcileTimeout)
+		reconciledRun, found, reconcileErr := t.client.latestRunForJob(reconcileCtx, job.ID)
+		cancel()
+		if reconcileErr == nil && found && reconciledRun.ID != "" {
+			run = reconciledRun
+		} else {
+			return llm.TextOutput(formatQueuedAgentTriggerPartialResult(job.ID, agentName, err, reconcileErr)), nil
+		}
 	}
 
 	data, _ := json.Marshal(QueueAgentResult{JobID: job.ID, RunID: run.ID, AgentName: agentName})
@@ -646,6 +657,26 @@ func sanitizeJobNamePart(name string) string {
 		return "agent"
 	}
 	return result
+}
+
+func formatQueuedAgentTriggerPartialResult(jobID, agentName string, triggerErr, reconcileErr error) string {
+	message := fmt.Sprintf("trigger request failed: %v", triggerErr)
+	if reconcileErr != nil {
+		message += fmt.Sprintf("; checking for an admitted run also failed: %v", reconcileErr)
+	} else {
+		message += "; no admitted run was visible during reconciliation"
+	}
+	message += "; use wait_for_jobs with this job_id before retrying queue_agent"
+
+	data, _ := json.Marshal(map[string]any{
+		"job_id":     jobID,
+		"agent_name": agentName,
+		"error": map[string]any{
+			"type":    ErrExecutionFailed,
+			"message": message,
+		},
+	})
+	return string(data)
 }
 
 func formatQueuedAgentError(errType ToolErrorType, message string) string {

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -75,6 +75,128 @@ func TestQueueAgentCreatesAndTriggersJobsBackedLLMJob(t *testing.T) {
 	}
 }
 
+func TestQueueAgentRecoversRunAfterLostTriggerResponse(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		cancelOnAdmission bool
+	}{
+		{name: "connection closes"},
+		{name: "caller cancelled after admission", cancelOnAdmission: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var triggerRequests int32
+			var runLookups int32
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs":
+					writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_123"})
+				case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs/job_123/trigger":
+					atomic.AddInt32(&triggerRequests, 1)
+					if test.cancelOnAdmission {
+						cancel()
+					}
+					hijacker, ok := w.(http.Hijacker)
+					if !ok {
+						t.Error("response writer does not support hijacking")
+						return
+					}
+					conn, _, err := hijacker.Hijack()
+					if err != nil {
+						t.Errorf("hijack trigger response: %v", err)
+						return
+					}
+					_ = conn.Close()
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/runs":
+					atomic.AddInt32(&runLookups, 1)
+					if got := r.URL.Query().Get("job_id"); got != "job_123" {
+						t.Errorf("job_id query = %q, want job_123", got)
+					}
+					writeJSON(t, w, jobsV2AgentRunsListResponse{Data: []jobsV2AgentRunResponse{{
+						ID: "run_123", JobID: "job_123", Status: "queued",
+					}}})
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+			tool := NewQueueAgentToolWithClient(client)
+			out, err := tool.Execute(ctx, json.RawMessage(`{"agent_name":"developer","prompt":"do it","cwd":"/tmp/work"}`))
+			if err != nil {
+				t.Fatalf("queue Execute() error = %v", err)
+			}
+			var result QueueAgentResult
+			if err := json.Unmarshal([]byte(out.Content), &result); err != nil {
+				t.Fatalf("queue output is not JSON: %v; %s", err, out.Content)
+			}
+			if result.JobID != "job_123" || result.RunID != "run_123" || result.AgentName != "developer" {
+				t.Fatalf("unexpected result: %+v; output: %s", result, out.Content)
+			}
+			if got := atomic.LoadInt32(&triggerRequests); got != 1 {
+				t.Fatalf("trigger requests = %d, want 1", got)
+			}
+			if got := atomic.LoadInt32(&runLookups); got != 1 {
+				t.Fatalf("run lookups = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestQueueAgentPreservesJobIDWhenTriggerCannotBeReconciled(t *testing.T) {
+	var triggerRequests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs":
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_123"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/jobs/job_123/trigger":
+			atomic.AddInt32(&triggerRequests, 1)
+			hijacker := w.(http.Hijacker)
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Errorf("hijack trigger response: %v", err)
+				return
+			}
+			_ = conn.Close()
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/runs":
+			writeJSON(t, w, jobsV2AgentRunsListResponse{})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewQueueAgentToolWithClient(client)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"agent_name":"developer","prompt":"do it","cwd":"/tmp/work"}`))
+	if err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+	var result struct {
+		JobID     string `json:"job_id"`
+		AgentName string `json:"agent_name"`
+		Error     struct {
+			Type    ToolErrorType `json:"type"`
+			Message string        `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(out.Content), &result); err != nil {
+		t.Fatalf("queue output is not JSON: %v; %s", err, out.Content)
+	}
+	if result.JobID != "job_123" || result.AgentName != "developer" || result.Error.Type != ErrExecutionFailed {
+		t.Fatalf("unexpected partial result: %+v; output: %s", result, out.Content)
+	}
+	if !strings.Contains(result.Error.Message, "wait_for_jobs") {
+		t.Fatalf("partial result does not explain reconciliation: %s", out.Content)
+	}
+	if got := atomic.LoadInt32(&triggerRequests); got != 1 {
+		t.Fatalf("trigger requests = %d, want 1", got)
+	}
+}
+
 func TestQueueAgentNotifyWhenDonePersistsTrustedOrigin(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {


### PR DESCRIPTION
## What changed

- Reconcile a failed `queue_agent` trigger response against `/v2/runs?job_id=...` using a detached, two-second context.
- Return the original job/run IDs when the jobs server already admitted the run, rather than reporting a misleading execution failure.
- Preserve the created job ID in a structured partial error when reconciliation cannot find the run, with guidance to use `wait_for_jobs` before retrying.
- Add HTTP tests for a connection closed after trigger admission, cancellation immediately after admission, and an unresolved trigger. The recovery cases assert that only one trigger request is sent.

## Why this is high-value

The jobs server commits and wakes a queued run before writing the trigger response. A cancelled turn or transient loopback connection failure could therefore hide an expensive agent that was already queued or running. Jarvis could then retry, launch duplicate work, and lose the original run's handle and result. Reconciliation keeps the existing run observable without retriggering.

## Validation

- `go build ./...`
- `go test ./internal/tools -count=1`
- `go test -race ./internal/tools -run 'TestQueueAgent(RecoversRunAfterLostTriggerResponse|PreservesJobIDWhenTriggerCannotBeReconciled)$' -count=1`
- `HOME=<clean temp dir> go test ./...`
- `git diff --check`

A first `go test ./...` under the agent's populated home exposed two unrelated `cmd` skill-discovery tests that omit their temporary project skill when the global 31-skill catalog exceeds the configured display limit. Both tests, and the full suite, pass with a clean temporary `HOME` matching CI isolation.
