### PR TITLE
fix: A stopping widget can erase and orphan its concurrent replacement

### DIFF
--- a/internal/widgets/manager.go
+++ b/internal/widgets/manager.go
@@ -304,7 +304,7 @@ func (m *Manager) ensureRunning(e *widgetEntry) error {
 		return err
 	}
 	if m.isShuttingDown() {
-		e.stopProcess()
+		e.stopProcessLocked()
 		return errWidgetManagerShuttingDown
 	}
 	return nil
@@ -418,7 +418,7 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 		defer close(procDone)
 		_ = cmd.Wait()
 		e.mu.Lock()
-		if e.state == stateRunning || e.state == stateStarting {
+		if e.proc == cmd.Process && (e.state == stateRunning || e.state == stateStarting) {
 			e.state = stateStopped
 			e.proc = nil
 			e.procDone = nil
@@ -429,7 +429,7 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 	}()
 
 	if ctx.Err() != nil {
-		e.stopProcess()
+		e.stopProcessLocked()
 		return errWidgetManagerShuttingDown
 	}
 
@@ -439,7 +439,7 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 	var lastErr error
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
-			e.stopProcess()
+			e.stopProcessLocked()
 			return errWidgetManagerShuttingDown
 		}
 
@@ -464,7 +464,7 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 			break
 		}
 		if ctx.Err() != nil {
-			e.stopProcess()
+			e.stopProcessLocked()
 			return errWidgetManagerShuttingDown
 		}
 		lastErr = err
@@ -478,13 +478,13 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 				default:
 				}
 			}
-			e.stopProcess()
+			e.stopProcessLocked()
 			return errWidgetManagerShuttingDown
 		case <-t.C:
 		}
 	}
 	if ctx.Err() != nil {
-		e.stopProcess()
+		e.stopProcessLocked()
 		return errWidgetManagerShuttingDown
 	}
 	if lastErr != nil {
@@ -502,7 +502,7 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 	proxy.Transport = transport
 
 	if ctx.Err() != nil {
-		e.stopProcess()
+		e.stopProcessLocked()
 		return errWidgetManagerShuttingDown
 	}
 
@@ -513,7 +513,7 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 	e.mu.Unlock()
 
 	if ctx.Err() != nil {
-		e.stopProcess()
+		e.stopProcessLocked()
 		return errWidgetManagerShuttingDown
 	}
 
@@ -522,6 +522,13 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 }
 
 func (e *widgetEntry) stopProcess() {
+	e.startMu.Lock()
+	defer e.startMu.Unlock()
+	e.stopProcessLocked()
+}
+
+// stopProcessLocked requires startMu to be held.
+func (e *widgetEntry) stopProcessLocked() {
 	e.mu.Lock()
 	proc := e.proc
 	done := e.procDone

--- a/internal/widgets/manager_test.go
+++ b/internal/widgets/manager_test.go
@@ -5,14 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -70,6 +73,120 @@ func TestWidgetStopProcessReapsChildProcessGroup(t *testing.T) {
 	t.Fatalf("widget child process still serving after stop on %s", url)
 }
 
+func TestWidgetStopSerializesConcurrentRestart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups and Unix sockets are Unix-specific")
+	}
+
+	t.Setenv("TERM_LLM_WIDGET_TEST_CHILD", "1")
+	termMarker := filepath.Join(t.TempDir(), "term-received")
+	t.Setenv("TERM_LLM_WIDGET_TEST_TERM_DELAY", "750ms")
+	t.Setenv("TERM_LLM_WIDGET_TEST_TERM_MARKER", termMarker)
+
+	m := &Manager{
+		basePath: "/chat",
+		entries:  make(map[string]*widgetEntry),
+	}
+	e := &widgetEntry{
+		manifest: &Manifest{
+			ID:      "restart-widget",
+			Title:   "Restart Widget",
+			Mount:   "restart-widget",
+			Dir:     t.TempDir(),
+			Command: []string{os.Args[0], "-test.run=TestWidgetChildHTTPServer", "--", "$SOCKET"},
+		},
+		state:   stateStopped,
+		lastReq: time.Now(),
+	}
+	m.entries[e.manifest.Mount] = e
+
+	if err := m.ensureRunning(e); err != nil {
+		t.Fatalf("start initial widget: %v", err)
+	}
+	defer e.stopProcess()
+
+	e.mu.Lock()
+	oldProc := e.proc
+	e.mu.Unlock()
+	if oldProc == nil {
+		t.Fatal("initial widget did not record its process")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		e.stopProcess()
+		close(stopDone)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(termMarker); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat termination marker: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("stopping widget did not receive SIGTERM")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- m.ensureRunning(e)
+	}()
+
+	select {
+	case err := <-startDone:
+		t.Fatalf("replacement start completed before old process exited: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopProcess did not finish")
+	}
+	select {
+	case err := <-startDone:
+		if err != nil {
+			t.Fatalf("start replacement widget: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement did not start after old process exited")
+	}
+
+	e.mu.Lock()
+	newProc := e.proc
+	state := e.state
+	proxy := e.proxy
+	e.mu.Unlock()
+	if state != stateRunning {
+		t.Fatalf("replacement state = %v, want running", state)
+	}
+	if newProc == nil || newProc.Pid == oldProc.Pid {
+		t.Fatalf("replacement process = %v, old PID = %d", newProc, oldProc.Pid)
+	}
+	if proxy == nil {
+		t.Fatal("replacement proxy was cleared by stale process cleanup")
+	}
+	if err := oldProc.Signal(syscall.Signal(0)); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("old process is not reaped: signal error = %v", err)
+	}
+
+	socketPath := filepath.Join(socketRuntimeDir, e.manifest.ID+".sock")
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Fatalf("replacement socket is unavailable: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/widgets/restart-widget/", nil)
+	m.Proxy(e.manifest.Mount, rr, req)
+	if rr.Code != http.StatusOK || rr.Body.String() != "ok" {
+		t.Fatalf("replacement response = (%d, %q), want (200, %q)", rr.Code, rr.Body.String(), "ok")
+	}
+}
+
 func TestManagerCloseContextPreventsStartAfterShutdownBegins(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process groups are Unix-specific")
@@ -108,7 +225,19 @@ func TestManagerCloseContextPreventsStartAfterShutdownBegins(t *testing.T) {
 	}()
 	time.Sleep(50 * time.Millisecond)
 
-	m.CloseContext(context.Background())
+	closeDone := make(chan struct{})
+	go func() {
+		m.CloseContext(context.Background())
+		close(closeDone)
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for !m.isShuttingDown() {
+		if time.Now().After(deadline) {
+			e.startMu.Unlock()
+			t.Fatal("shutdown did not begin")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	e.startMu.Unlock()
 
 	select {
@@ -120,6 +249,11 @@ func TestManagerCloseContextPreventsStartAfterShutdownBegins(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		e.stopProcess()
 		t.Fatal("ensureRunning did not return after shutdown began")
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CloseContext did not finish")
 	}
 
 	e.mu.Lock()
@@ -262,19 +396,49 @@ func TestWidgetChildHTTPServer(t *testing.T) {
 		t.Skip("helper process")
 	}
 
-	var port string
+	var address string
 	for i, arg := range os.Args {
 		if arg == "--" && i+1 < len(os.Args) {
-			port = os.Args[i+1]
+			address = os.Args[i+1]
 			break
 		}
 	}
-	if port == "" {
-		log.Fatal("missing port")
+	if address == "" {
+		log.Fatal("missing address")
+	}
+
+	if delayValue := os.Getenv("TERM_LLM_WIDGET_TEST_TERM_DELAY"); delayValue != "" {
+		delay, err := time.ParseDuration(delayValue)
+		if err != nil {
+			log.Fatalf("parse termination delay: %v", err)
+		}
+		termCh := make(chan os.Signal, 1)
+		signal.Notify(termCh, syscall.SIGTERM)
+		go func() {
+			<-termCh
+			if marker := os.Getenv("TERM_LLM_WIDGET_TEST_TERM_MARKER"); marker != "" {
+				if err := os.WriteFile(marker, nil, 0600); err != nil {
+					log.Printf("write termination marker: %v", err)
+				}
+			}
+			time.Sleep(delay)
+			os.Exit(0)
+		}()
+	}
+
+	network := "tcp"
+	if os.Getenv("TERM_LLM_WIDGET_SOCKET") != "" {
+		network = "unix"
+	} else {
+		address = "127.0.0.1:" + address
+	}
+	listener, err := net.Listen(network, address)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	})
-	log.Fatal(http.ListenAndServe("127.0.0.1:"+port, handler))
+	log.Fatal(http.Serve(listener, handler))
 }


### PR DESCRIPTION
## What changed

- Serialize each widget's complete stop lifecycle with the same mutex used for starts, including process termination, waiting, and Unix-socket cleanup.
- Use a lock-aware stop helper from startup cancellation paths that already hold the lifecycle mutex.
- Make process-exit cleanup conditional on the exiting command still owning the entry's recorded process.
- Add a regression test with a socket widget that delays SIGTERM handling, overlaps a stop with a restart request, and verifies the replacement remains tracked, retains its socket/proxy, serves successfully, and is the only surviving process.

## Why this is high-value

Idle reaping and manual stops can overlap a new widget request during the old process's termination window. Previously the request could start a replacement, then the old process's waiter could clear the replacement's process and proxy while deferred socket cleanup unlinked its live socket. That left a user-visible widget broken and its replacement process orphaned until operator cleanup or a server restart. Serializing stop and start closes this realistic lifecycle race, while the ownership check prevents any stale waiter from mutating newer process state.

## Validation

- `go build ./...`
- `go test -race ./internal/widgets -count=1 -timeout=45s`
- `HOME=<temporary> XDG_CONFIG_HOME=<temporary> go test ./...` (isolated from the host's installed skill catalog so environment-sensitive skill visibility tests use only their fixtures)
- `git diff --check`
