### PR TITLE
feat: support custom Anthropic base URLs

### DIFF
--- a/cmd/models.go
+++ b/cmd/models.go
@@ -84,6 +84,9 @@ func runModels(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("provider %q: %w", providerName, err)
 		}
 		providerCfg = cfg.Providers[providerName]
+		if err := providerCfg.ResolveForInference(); err != nil {
+			return fmt.Errorf("provider %q: %w", providerName, err)
+		}
 	}
 
 	// Infer provider type - only use config type if provider is configured
@@ -119,7 +122,7 @@ func runModels(cmd *cobra.Command, args []string) error {
 	var lister ModelLister
 	switch providerType {
 	case config.ProviderTypeAnthropic:
-		provider, err := llm.NewAnthropicProvider(providerCfg.ResolvedAPIKey, providerCfg.Model, providerCfg.Credentials)
+		provider, err := llm.NewAnthropicProviderWithBaseURL(providerCfg.ResolvedAPIKey, providerCfg.Model, providerCfg.Credentials, providerCfg.BaseURL)
 		if err != nil {
 			return fmt.Errorf("anthropic: %w", err)
 		}

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -717,7 +717,7 @@ providers:
     api_key: "op://Infrastructure/vLLM Cluster/credential?account=company.1password.com"
 ```
 
-These values are resolved lazily when term-llm actually needs them.
+These values are resolved lazily when term-llm actually needs them. Endpoint resolution applies to both provider `url` and `base_url`; `embed.ollama.base_url` uses the same resolver when the embedding provider is created.
 
 ## WebRTC direct routing config
 

--- a/docs-site/content/reference/providers-and-models.md
+++ b/docs-site/content/reference/providers-and-models.md
@@ -63,6 +63,21 @@ term-llm ask --provider copilot "question"
 term-llm ask --provider gemini-cli "question"
 ```
 
+### Anthropic-compatible endpoints
+
+Use `type: anthropic` with `base_url` to point the native Anthropic protocol provider at a compatible gateway or self-hosted endpoint:
+
+```yaml
+providers:
+  custom-anthropic:
+    type: anthropic
+    base_url: https://gateway.example.com/anthropic
+    api_key: ${CUSTOM_ANTHROPIC_API_KEY}
+    model: custom-model
+```
+
+The Anthropic SDK appends paths such as `/v1/messages` and `/v1/models` to `base_url`. The field supports the same lazy `srv://` and `$()` endpoint resolution as `url`. Omit `base_url` to use Anthropic's standard API endpoint.
+
 ## WebSocket defaults
 
 The built-in `openai` and `chatgpt` text providers use the Responses WebSocket transport by default. This improves latency in agentic/tool-heavy runs by reusing one connection and continuing compatible turns with `previous_response_id` plus only new input. If setup fails before streaming starts, term-llm falls back to HTTP/SSE; if a WebSocket continuation rejects the previous response ID, it retries once with full input.
@@ -228,7 +243,7 @@ Use `base_url` when the standard `/chat/completions` path should be appended aut
 | Field | Type | Description |
 |---|---|---|
 | `type` | string | Use `openai_compatible` for generic custom providers, or `vllm` for vLLM servers that should receive reasoning controls for Qwen/DeepSeek-style chat templates. Inferred automatically for known names like `ollama`, `cerebras`, `groq`, and `vllm`. |
-| `base_url` | string | Base URL (e.g., `http://localhost:11434/v1`). `/chat/completions` is appended automatically. |
+| `base_url` | string | Base URL (e.g., `http://localhost:11434/v1`). `/chat/completions` is appended automatically. Supports `srv://` and `$()` resolution. |
 | `url` | string | Full chat completions URL, used as-is. Use this when your endpoint path differs from the standard. Supports `srv://` for DNS SRV discovery and `$()` for command-based resolution. |
 | `api_key` | string | API key. Supports `${ENV_VAR}`, `op://`, `file://`, and `$()` resolution. If omitted, term-llm tries `<PROVIDER_NAME>_API_KEY` from the environment. |
 | `model` | string | Default model name. For configured model objects, this may be either the upstream `id` or the friendly `alias`. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,8 +165,10 @@ type ProviderConfig struct {
 	ContextWindow   int `mapstructure:"context_window"`
 	MaxOutputTokens int `mapstructure:"max_output_tokens"`
 
+	// Custom endpoint configuration
+	BaseURL string `mapstructure:"base_url"` // Base URL for Anthropic-compatible or OpenAI-compatible providers
+
 	// OpenAI-compatible specific
-	BaseURL           string `mapstructure:"base_url"`            // Base URL - /chat/completions is appended
 	URL               string `mapstructure:"url"`                 // Full URL - used as-is without appending endpoint
 	NoStreamOptions   bool   `mapstructure:"no_stream_options"`   // Don't send stream_options (for servers that reject it)
 	VLLMThinkingParam string `mapstructure:"vllm_thinking_param"` // vLLM chat_template_kwargs key: "enable_thinking" (Qwen) or "thinking" (DeepSeek)
@@ -198,7 +200,7 @@ type ProviderConfig struct {
 	ResolvedAPIKey string                              `mapstructure:"-"`
 	AccountID      string                              `mapstructure:"-"`
 	OAuthCreds     *credentials.GeminiOAuthCredentials `mapstructure:"-"`
-	ResolvedURL    string                              `mapstructure:"-"` // Resolved URL (after srv:// lookup)
+	ResolvedURL    string                              `mapstructure:"-"` // Resolved full `url` (after srv://, $(), etc.)
 
 	// Resolution tracking - provider credential discovery is deferred until needed,
 	// and expensive values are resolved lazily before inference.
@@ -1907,9 +1909,11 @@ func (cfg *ProviderConfig) ResolveForInference() error {
 
 	var err error
 
-	// Resolve URL fields
+	// Resolve URL fields. Keep a resolved base_url in BaseURL so every provider
+	// that consumes the shared field gets the same lazy endpoint support. ResolvedURL
+	// remains the resolved full `url`, whose routing semantics differ by provider.
 	if needsLazyResolve(cfg.BaseURL) {
-		cfg.ResolvedURL, err = ResolveValue(cfg.BaseURL)
+		cfg.BaseURL, err = ResolveValue(cfg.BaseURL)
 		if err != nil {
 			return fmt.Errorf("base_url: %w", err)
 		}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -20,6 +20,7 @@ var (
 	resolveExecTimeout           = 15 * time.Second
 	resolveExecOutputLimit int64 = 64 << 10
 	resolveExecWaitDelay         = time.Second
+	lookupSRV                    = net.LookupSRV
 )
 
 // ResolveValue handles magic URL schemes in config values:
@@ -94,7 +95,7 @@ func resolveSRV(srvURL string) (string, error) {
 	}
 
 	// Lookup SRV record
-	_, addrs, err := net.LookupSRV("", "", record)
+	_, addrs, err := lookupSRV("", "", record)
 	if err != nil {
 		return "", fmt.Errorf("SRV lookup failed for %s: %w", record, err)
 	}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1,12 +1,38 @@
 package config
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestProviderBaseURLResolvesSRVInPlace(t *testing.T) {
+	// lookupSRV is package-global; keep this test sequential.
+	original := lookupSRV
+	t.Cleanup(func() { lookupSRV = original })
+	lookupSRV = func(service, proto, name string) (string, []*net.SRV, error) {
+		if service != "" || proto != "" || name != "_anthropic._tcp.example.test" {
+			t.Fatalf("LookupSRV(%q, %q, %q)", service, proto, name)
+		}
+		return "", []*net.SRV{{Target: "gateway.example.test.", Port: 8443}}, nil
+	}
+	cfg := &ProviderConfig{BaseURL: "srv://_anthropic._tcp.example.test/anthropic"}
+	if err := resolveProviderCredentials("custom", cfg); err != nil {
+		t.Fatalf("resolveProviderCredentials: %v", err)
+	}
+	if err := cfg.ResolveForInference(); err != nil {
+		t.Fatalf("ResolveForInference: %v", err)
+	}
+	if want := "https://gateway.example.test:8443/anthropic"; cfg.BaseURL != want {
+		t.Fatalf("BaseURL = %q, want %q", cfg.BaseURL, want)
+	}
+	if cfg.ResolvedURL != "" {
+		t.Fatalf("ResolvedURL = %q, want empty for base_url", cfg.ResolvedURL)
+	}
+}
 
 func TestResolveCommand_TimesOutAndKillsProcessGroup(t *testing.T) {
 	origTimeout := resolveExecTimeout

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -115,6 +115,12 @@ func NewEmbeddingProvider(cfg *config.Config, providerOverride string) (Embeddin
 		baseURL := cfg.Embed.Ollama.BaseURL
 		if baseURL == "" {
 			baseURL = config.DefaultEmbedOllamaBaseURL
+		} else {
+			var err error
+			baseURL, err = config.ResolveValue(baseURL)
+			if err != nil {
+				return nil, fmt.Errorf("embed.ollama.base_url: %w", err)
+			}
 		}
 		p := NewOllamaProvider(baseURL)
 		if model != "" {

--- a/internal/embedding/provider_test.go
+++ b/internal/embedding/provider_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestNewEmbeddingProviderResolvesOllamaBaseURL(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Embed.Ollama.BaseURL = "$(printf https://ollama.example.test)"
+
+	provider, err := NewEmbeddingProvider(cfg, "ollama")
+	if err != nil {
+		t.Fatalf("NewEmbeddingProvider: %v", err)
+	}
+	ollama, ok := provider.(*OllamaProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *OllamaProvider", provider)
+	}
+	if want := "https://ollama.example.test"; ollama.baseURL != want {
+		t.Fatalf("baseURL = %q, want %q", ollama.baseURL, want)
+	}
+}
+
 func TestCosineSimilarity(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -100,12 +101,17 @@ func parseModel1m(model string) (string, bool) {
 	return model, false
 }
 
-// NewAnthropicProvider creates a new Anthropic provider.
+// NewAnthropicProvider creates a new Anthropic provider using Anthropic's default API endpoint.
+func NewAnthropicProvider(apiKey, model, credentialMode string) (*AnthropicProvider, error) {
+	return NewAnthropicProviderWithBaseURL(apiKey, model, credentialMode, "")
+}
+
+// NewAnthropicProviderWithBaseURL creates a new Anthropic provider.
 // The credentialMode parameter controls which authentication method is used:
 //   - "" or "auto": try the cascade (api_key → env)
 //   - "api_key":    use only the explicit apiKey parameter
 //   - "env":        use only the ANTHROPIC_API_KEY environment variable
-func NewAnthropicProvider(apiKey, model, credentialMode string) (*AnthropicProvider, error) {
+func NewAnthropicProviderWithBaseURL(apiKey, model, credentialMode, baseURL string) (*AnthropicProvider, error) {
 	// Strip provider-aware reasoning effort first, then -thinking (may leave -1m), then -1m.
 	// This means claude-sonnet-4-6-1m-thinking works correctly:
 	//   step 1: strip effort   -> "claude-sonnet-4-6-1m-thinking"
@@ -121,6 +127,24 @@ func NewAnthropicProvider(apiKey, model, credentialMode string) (*AnthropicProvi
 	// Normalize empty credential mode to "auto"
 	if credentialMode == "" {
 		credentialMode = AnthropicCredAuto
+	}
+
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL != "" {
+		u, err := url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Anthropic base_url %q: %w", baseURL, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("invalid Anthropic base_url %q: must include scheme and host", baseURL)
+		}
+	}
+	mkClient := func(key string) anthropic.Client {
+		opts := []option.RequestOption{option.WithAPIKey(key)}
+		if baseURL != "" {
+			opts = append(opts, option.WithBaseURL(baseURL))
+		}
+		return anthropic.NewClient(opts...)
 	}
 
 	mkProvider := func(client anthropic.Client, cred string) *AnthropicProvider {
@@ -141,14 +165,14 @@ func NewAnthropicProvider(apiKey, model, credentialMode string) (*AnthropicProvi
 		if apiKey == "" {
 			return nil, fmt.Errorf("credentials mode %q requires an explicit api_key in provider config", credentialMode)
 		}
-		return mkProvider(anthropic.NewClient(option.WithAPIKey(apiKey)), "api_key"), nil
+		return mkProvider(mkClient(apiKey), "api_key"), nil
 
 	case AnthropicCredEnv:
 		envKey := os.Getenv("ANTHROPIC_API_KEY")
 		if envKey == "" {
 			return nil, fmt.Errorf("credentials mode %q requires ANTHROPIC_API_KEY environment variable", credentialMode)
 		}
-		return mkProvider(anthropic.NewClient(option.WithAPIKey(envKey)), "env"), nil
+		return mkProvider(mkClient(envKey), "env"), nil
 
 	case AnthropicCredAuto:
 		// Fall through to the cascade below.
@@ -161,12 +185,12 @@ func NewAnthropicProvider(apiKey, model, credentialMode string) (*AnthropicProvi
 
 	// 1. Explicit API key provided (from config)
 	if apiKey != "" {
-		return mkProvider(anthropic.NewClient(option.WithAPIKey(apiKey)), "api_key"), nil
+		return mkProvider(mkClient(apiKey), "api_key"), nil
 	}
 
 	// 2. ANTHROPIC_API_KEY environment variable
 	if envKey := os.Getenv("ANTHROPIC_API_KEY"); envKey != "" {
-		return mkProvider(anthropic.NewClient(option.WithAPIKey(envKey)), "env"), nil
+		return mkProvider(mkClient(envKey), "env"), nil
 	}
 
 	return nil, fmt.Errorf("no Anthropic credentials found. Set ANTHROPIC_API_KEY or configure api_key in provider config")

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -424,7 +424,7 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 
 	switch providerType {
 	case config.ProviderTypeAnthropic:
-		return NewAnthropicProvider(cfg.ResolvedAPIKey, cfg.Model, cfg.Credentials)
+		return NewAnthropicProviderWithBaseURL(cfg.ResolvedAPIKey, cfg.Model, cfg.Credentials, cfg.BaseURL)
 
 	case config.ProviderTypeOpenAI:
 		return NewOpenAIProviderWithOptions(cfg.ResolvedAPIKey, cfg.Model, OpenAIProviderOptions{UseWebSocket: cfg.UseWebSocket, ServiceTier: cfg.ServiceTier, FileUploadPolicy: FileUploadPolicyOverrideForProviderConfig(name, *cfg), Responses: responsesOptionsFromConfig(cfg.Responses)}), nil

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -1,6 +1,10 @@
 package llm
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -61,6 +65,115 @@ func TestNewProviderByNameCursorBinNeedsNoAPIKey(t *testing.T) {
 	if provider.Credential() != "cursor-bin" {
 		t.Fatalf("credential = %q, want cursor-bin", provider.Credential())
 	}
+}
+
+func TestCreateProviderFromConfigAnthropicCustomBaseURL(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-custom-key")
+
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if got := r.Header.Get("X-Api-Key"); got != "sk-custom-key" {
+			t.Errorf("X-Api-Key = %q, want %q", got, "sk-custom-key")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[],"has_more":false}`)
+	}))
+	defer ts.Close()
+
+	provider, err := createProviderFromConfig("custom-anthropic", &config.ProviderConfig{
+		Type:    config.ProviderTypeAnthropic,
+		BaseURL: ts.URL + "/proxy",
+		Model:   "custom-model",
+	})
+	if err != nil {
+		t.Fatalf("createProviderFromConfig: %v", err)
+	}
+	anthropicProvider, ok := provider.(*AnthropicProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *AnthropicProvider", provider)
+	}
+	if _, err := anthropicProvider.ListModels(context.Background()); err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if gotPath != "/proxy/v1/models" {
+		t.Fatalf("request path = %q, want %q", gotPath, "/proxy/v1/models")
+	}
+}
+
+func TestCreateProviderFromConfigRejectsInvalidAnthropicBaseURL(t *testing.T) {
+	_, err := createProviderFromConfig("custom-anthropic", &config.ProviderConfig{
+		Type:           config.ProviderTypeAnthropic,
+		BaseURL:        "gateway.example.test/anthropic",
+		ResolvedAPIKey: "sk-custom-key",
+	})
+	if err == nil || !strings.Contains(err.Error(), "must include scheme and host") {
+		t.Fatalf("error = %v, want invalid base_url guidance", err)
+	}
+}
+
+func TestCreateProviderFromConfigRoutesLazyBaseURLs(t *testing.T) {
+	t.Run("openai compatible appends chat path", func(t *testing.T) {
+		var gotPath string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"choices":[]}`)
+		}))
+		defer ts.Close()
+
+		cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+			"custom": {
+				Type:    config.ProviderTypeOpenAICompat,
+				BaseURL: fmt.Sprintf("$(printf %s)", ts.URL+"/v1"),
+				Model:   "custom-model",
+			},
+		}}
+		if err := cfg.ResolveProviderCredentials("custom"); err != nil {
+			t.Fatalf("ResolveProviderCredentials: %v", err)
+		}
+		providerCfg := cfg.Providers["custom"]
+		provider, err := createProviderFromConfig("custom", &providerCfg)
+		if err != nil {
+			t.Fatalf("createProviderFromConfig: %v", err)
+		}
+		compat, ok := provider.(*OpenAICompatProvider)
+		if !ok {
+			t.Fatalf("provider type = %T, want *OpenAICompatProvider", provider)
+		}
+		resp, err := compat.makeChatRequest(context.Background(), oaiChatRequest{Model: "custom-model"})
+		if err != nil {
+			t.Fatalf("makeChatRequest: %v", err)
+		}
+		resp.Body.Close()
+		if gotPath != "/v1/chat/completions" {
+			t.Fatalf("request path = %q, want %q", gotPath, "/v1/chat/completions")
+		}
+	})
+
+	t.Run("ollama receives resolved base", func(t *testing.T) {
+		cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+			"ollama": {
+				BaseURL: "$(printf https://ollama.example.test)",
+				Model:   "custom-model",
+			},
+		}}
+		if err := cfg.ResolveProviderCredentials("ollama"); err != nil {
+			t.Fatalf("ResolveProviderCredentials: %v", err)
+		}
+		providerCfg := cfg.Providers["ollama"]
+		provider, err := createProviderFromConfig("ollama", &providerCfg)
+		if err != nil {
+			t.Fatalf("createProviderFromConfig: %v", err)
+		}
+		ollama, ok := provider.(*OllamaProvider)
+		if !ok {
+			t.Fatalf("provider type = %T, want *OllamaProvider", provider)
+		}
+		if ollama.baseURL != "https://ollama.example.test" {
+			t.Fatalf("baseURL = %q, want resolved URL", ollama.baseURL)
+		}
+	})
 }
 
 func TestCreateProviderFromConfig_OpenAICompatRequiresProviderName(t *testing.T) {


### PR DESCRIPTION
## Summary

- allow `type: anthropic` providers to set a custom `base_url`
- preserve `base_url` routing semantics after lazy `srv://` / `$()` resolution instead of treating the result as a full `url`
- apply deferred endpoint resolution to model listing and `embed.ollama.base_url`
- document generic Anthropic-compatible endpoints and shared endpoint resolution

This is deliberately protocol-level only: it adds no OpenCode-specific provider behavior, model catalog, or reasoning mapping.

Lazy `base_url` previously landed in the full-URL routing slot. This restores the documented behavior of appending provider paths. Configurations that put `/chat/completions` in a lazy `base_url` remain compatible because the OpenAI-compatible provider normalizes that suffix before appending it.

## Review follow-up

An Opus review found the core change sound. Follow-ups included here:

- regression coverage for the final OpenAI-compatible request path and resolved Ollama routing
- fail-fast validation for malformed Anthropic `base_url` values
- safer cleanup for the SRV resolver test seam
- corrected the OpenAI-compatible field-table wording

## Test plan

- `go test ./internal/config ./internal/embedding ./internal/llm`
- `go test -race ./internal/config ./internal/embedding ./internal/llm`
- `go test ./cmd -run '^TestModels' -count=1`
- `go build ./...`
