### PR TITLE
fix: Stateful web runs continue after session persistence fails

### DIFF
--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -1023,6 +1023,7 @@ func serveRuntimeSetupFromContext(ctx context.Context) func(*llm.Request) error 
 var (
 	errServeSessionBusy         = errors.New("session is busy processing another request")
 	errServeSessionLimitReached = errors.New("session limit reached: all sessions are busy")
+	errServeSessionPersistence  = errors.New("failed to persist or hydrate session")
 )
 
 func (rt *serveRuntime) Run(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request) (serveRunResult, error) {
@@ -1066,6 +1067,9 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 	defer restoreAllowedTools()
 	rt.Touch()
 	persisted := rt.ensurePersistedSession(ctx, req.SessionID, inputMessages)
+	if stateful && rt.store != nil && req.SessionID != "" && !persisted {
+		return serveRunResult{}, errServeSessionPersistence
+	}
 	if persisted {
 		rt.persistStatus(ctx, req.SessionID, session.StatusActive)
 	}

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -213,6 +213,113 @@ func newServeRuntimeTestStore() *serveRuntimeTestStore {
 	}
 }
 
+type failingServeRuntimeSessionStore struct {
+	session.Store
+	err error
+}
+
+func (s *failingServeRuntimeSessionStore) Create(context.Context, *session.Session) error {
+	return s.err
+}
+
+func (s *failingServeRuntimeSessionStore) Get(context.Context, string) (*session.Session, error) {
+	return nil, s.err
+}
+
+func TestServeRuntimeStatefulRunRequiresSessionPersistence(t *testing.T) {
+	storeErr := errors.New("database unavailable")
+	store := &failingServeRuntimeSessionStore{
+		Store: newServeRuntimeTestStore(),
+		err:   storeErr,
+	}
+	provider := llm.NewMockProvider("mock").AddTextResponse("must not run")
+	rt := &serveRuntime{
+		store:        store,
+		provider:     provider,
+		engine:       llm.NewEngine(provider, nil),
+		defaultModel: "mock-model",
+	}
+
+	startCalls := 0
+	eventCalls := 0
+	_, err := rt.RunWithEventsAndStart(
+		context.Background(),
+		true,
+		false,
+		[]llm.Message{llm.UserText("hello")},
+		llm.Request{SessionID: "sess-persistence-failure"},
+		func() { startCalls++ },
+		func(llm.Event) error {
+			eventCalls++
+			return nil
+		},
+	)
+	if !errors.Is(err, errServeSessionPersistence) {
+		t.Fatalf("RunWithEventsAndStart() error = %v, want %v", err, errServeSessionPersistence)
+	}
+	if startCalls != 0 {
+		t.Fatalf("start callbacks = %d, want 0", startCalls)
+	}
+	if eventCalls != 0 {
+		t.Fatalf("event callbacks = %d, want 0", eventCalls)
+	}
+	if len(provider.Requests) != 0 {
+		t.Fatalf("provider requests = %d, want 0", len(provider.Requests))
+	}
+}
+
+func TestServeRuntimeNonPersistentRunsStillExecute(t *testing.T) {
+	storeErr := errors.New("database unavailable")
+	tests := []struct {
+		name     string
+		stateful bool
+		store    session.Store
+	}{
+		{
+			name:     "stateless with failing store",
+			stateful: false,
+			store: &failingServeRuntimeSessionStore{
+				Store: newServeRuntimeTestStore(),
+				err:   storeErr,
+			},
+		},
+		{
+			name:     "stateful with store disabled",
+			stateful: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+			rt := &serveRuntime{
+				store:        tc.store,
+				provider:     provider,
+				engine:       llm.NewEngine(provider, nil),
+				defaultModel: "mock-model",
+			}
+
+			result, err := rt.RunWithEvents(
+				context.Background(),
+				tc.stateful,
+				false,
+				[]llm.Message{llm.UserText("hello")},
+				llm.Request{SessionID: "sess-non-persistent"},
+				func(llm.Event) error { return nil },
+			)
+			if err != nil {
+				t.Fatalf("RunWithEvents() error = %v", err)
+			}
+			if got := result.Text.String(); got != "ok" {
+				t.Fatalf("result text = %q, want ok", got)
+			}
+			if len(provider.Requests) != 1 {
+				t.Fatalf("provider requests = %d, want 1", len(provider.Requests))
+			}
+		})
+	}
+}
+
 func (s *serveRuntimeTestStore) Create(ctx context.Context, sess *session.Session) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## What changed

- Fail stateful runs before `onStart` or provider execution when a configured session store cannot create or hydrate the requested session.
- Preserve existing execution behavior for explicitly stateless runs and runtimes with persistence disabled.
- Add regression coverage for failing `Get`/`Create` calls, callback suppression, and provider suppression, plus companion coverage for allowed non-persistent runs.

## Why this is high-value

The web/Jarvis path relies on stateful session persistence for both transcript durability and prior-turn context. Previously, a transient SQLite lock or I/O failure could still start and complete a provider run while every persistence and hydration path remained disabled. The answer could appear successful but disappear after reload, and resumed conversations could reach the provider without their stored history. Failing before the run starts prevents a temporary database fault from becoming permanent loss of the entire turn or a context-free response.

## Validation

- `go test ./cmd -run '^TestServeRuntime(StatefulRunRequiresSessionPersistence|NonPersistentRunsStillExecute)$'`
- `go build ./...`
- `HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/config" XDG_DATA_HOME="$TEST_HOME/data" XDG_CACHE_HOME="$TEST_HOME/cache" GOMODCACHE="$GOMODCACHE" go test ./...`
- `go vet ./...`
- `git diff --check`
