### PR TITLE
fix: File-history total-size cap is never enforced during a long-running process

### DIFF
--- a/internal/filetrack/store.go
+++ b/internal/filetrack/store.go
@@ -116,7 +116,7 @@ type FileDiffSide struct {
 type Options struct {
 	MaxFileBytes    int   // 0 = DefaultMaxFileBytes
 	MaxSessionBytes int   // 0 = DefaultMaxSessionBytes
-	MaxTotalBytes   int64 // 0 = DefaultMaxTotalBytes; whole-database size cap enforced by GC
+	MaxTotalBytes   int64 // 0 = DefaultMaxTotalBytes; whole-database size cap enforced live and by GC
 }
 
 // Store persists file-change history in a dedicated SQLite database.
@@ -128,13 +128,23 @@ type Store struct {
 
 	// recordMu serializes change inserts so per-session sequence allocation and
 	// retained-byte budget checks remain deterministic under parallel tool calls.
-	recordMu sync.Mutex
+	// It also protects the amortized total-budget counters.
+	recordMu                  sync.Mutex
+	uncheckedTotalBytes       int64
+	uncheckedTotalRecordCount int
 
 	mu           sync.Mutex
 	sessionBytes map[string]int64 // retained-bytes budget cache per session
 }
 
 const schemaVersion = 1
+
+const (
+	// Check after at most 8 MiB of retained input, or 64 metadata-only rows.
+	// Smaller configured caps use a proportional interval below.
+	maxUncheckedTotalBytes   = int64(8 * 1024 * 1024)
+	maxUncheckedTotalRecords = 64
+)
 
 const schema = `
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -303,6 +313,18 @@ func normalizePath(path string) string {
 	return filepath.Clean(path)
 }
 
+func (s *Store) totalBudgetCheckDue(retainedBytes int64) bool {
+	byteInterval := s.maxTotalBytes / 16
+	if byteInterval < 1 {
+		byteInterval = 1
+	}
+	if byteInterval > maxUncheckedTotalBytes {
+		byteInterval = maxUncheckedTotalBytes
+	}
+	return s.uncheckedTotalBytes+retainedBytes >= byteInterval ||
+		s.uncheckedTotalRecordCount+1 >= maxUncheckedTotalRecords
+}
+
 // RecordChange records one file transition and returns metadata for event
 // emission. Returns (nil, nil) for no-ops (identical content, missing→missing,
 // or empty session ID).
@@ -399,6 +421,12 @@ func (s *Store) RecordChange(ctx context.Context, rec ChangeRecord) (*Change, er
 		IsBinary:   isBinary,
 	}
 
+	retainedBytes := int64(0)
+	if retain {
+		retainedBytes = beforeSize + afterSize
+	}
+	checkTotalBudget := s.totalBudgetCheckDue(retainedBytes)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin file change transaction: %w", err)
@@ -440,16 +468,34 @@ func (s *Store) RecordChange(ctx context.Context, rec ChangeRecord) (*Change, er
 		return nil, fmt.Errorf("insert file change: %w", err)
 	}
 
+	if checkTotalBudget {
+		if err := s.enforceTotalBudget(ctx, tx); err != nil {
+			return nil, fmt.Errorf("enforce total budget: %w", err)
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit file change: %w", err)
 	}
 
-	if retain {
+	if checkTotalBudget {
+		s.uncheckedTotalBytes = 0
+		s.uncheckedTotalRecordCount = 0
+		// Budget enforcement may have pruned any session, invalidating cached
+		// retained-byte totals. The next write will reload only what it needs.
 		s.mu.Lock()
-		if _, ok := s.sessionBytes[rec.SessionID]; ok {
-			s.sessionBytes[rec.SessionID] += beforeSize + afterSize
-		}
+		s.sessionBytes = make(map[string]int64)
 		s.mu.Unlock()
+	} else {
+		s.uncheckedTotalBytes += retainedBytes
+		s.uncheckedTotalRecordCount++
+		if retain {
+			s.mu.Lock()
+			if _, ok := s.sessionBytes[rec.SessionID]; ok {
+				s.sessionBytes[rec.SessionID] += retainedBytes
+			}
+			s.mu.Unlock()
+		}
 	}
 
 	return change, nil
@@ -858,13 +904,18 @@ const blobSweepSQL = `
 		SELECT after_hash FROM file_changes WHERE after_hash IS NOT NULL
 	)`
 
+type totalBudgetDB interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
 // enforceTotalBudget prunes the least recently changed sessions' history until
 // the database fits maxTotalBytes. This is the cross-session backstop: the
 // per-session budget bounds one session, but many sessions could otherwise
 // grow the database without limit.
-func (s *Store) enforceTotalBudget(ctx context.Context, conn *sql.Conn) error {
+func (s *Store) enforceTotalBudget(ctx context.Context, db totalBudgetDB) error {
 	for {
-		size, err := databaseSize(ctx, conn)
+		size, err := databaseSize(ctx, db)
 		if err != nil {
 			return err
 		}
@@ -873,7 +924,7 @@ func (s *Store) enforceTotalBudget(ctx context.Context, conn *sql.Conn) error {
 		}
 
 		var oldest string
-		err = conn.QueryRowContext(ctx, `
+		err = db.QueryRowContext(ctx, `
 			SELECT session_id FROM file_changes
 			GROUP BY session_id
 			ORDER BY MAX(created_at) ASC, session_id ASC
@@ -885,25 +936,25 @@ func (s *Store) enforceTotalBudget(ctx context.Context, conn *sql.Conn) error {
 			return err
 		}
 
-		if _, err := conn.ExecContext(ctx, "DELETE FROM file_changes WHERE session_id = ?", oldest); err != nil {
+		if _, err := db.ExecContext(ctx, "DELETE FROM file_changes WHERE session_id = ?", oldest); err != nil {
 			return err
 		}
-		if _, err := conn.ExecContext(ctx, blobSweepSQL); err != nil {
+		if _, err := db.ExecContext(ctx, blobSweepSQL); err != nil {
 			return err
 		}
-		if _, err := conn.ExecContext(ctx, "PRAGMA incremental_vacuum"); err != nil {
+		if _, err := db.ExecContext(ctx, "PRAGMA incremental_vacuum"); err != nil {
 			return err
 		}
 	}
 }
 
 // databaseSize returns the database file size in bytes (page count × page size).
-func databaseSize(ctx context.Context, conn *sql.Conn) (int64, error) {
+func databaseSize(ctx context.Context, db totalBudgetDB) (int64, error) {
 	var pageCount, pageSize int64
-	if err := conn.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
 		return 0, fmt.Errorf("page count: %w", err)
 	}
-	if err := conn.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+	if err := db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
 		return 0, fmt.Errorf("page size: %w", err)
 	}
 	return pageCount * pageSize, nil

--- a/internal/filetrack/store_test.go
+++ b/internal/filetrack/store_test.go
@@ -778,6 +778,54 @@ func TestGCEnforcesTotalBudget(t *testing.T) {
 	}
 }
 
+func TestRecordChangeEnforcesTotalBudget(t *testing.T) {
+	dir := t.TempDir()
+	const maxTotalBytes = 256 * 1024
+	store, err := Open(filepath.Join(dir, "file_history.db"), Options{MaxTotalBytes: maxTotalBytes})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	// Poorly compressible text makes each ordinary record materially grow the
+	// database without tripping the binary-content check.
+	noisy := func(seed byte) []byte {
+		content := make([]byte, 128*1024)
+		x := uint32(seed) + 1
+		for i := range content {
+			x = x*1664525 + 1013904223
+			content[i] = byte(32 + (x>>16)%95)
+		}
+		return content
+	}
+	for i, sessionID := range []string{"a-oldest", "b-middle", "c-newest"} {
+		mustRecord(t, store, ChangeRecord{
+			SessionID: sessionID, Path: "/work/f.txt",
+			After: noisy(byte(i)), BeforeMissing: true,
+		})
+	}
+
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	size, err := databaseSize(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size > maxTotalBytes {
+		t.Fatalf("db size after ordinary records = %d, want <= %d", size, maxTotalBytes)
+	}
+	if paths, _ := store.SessionPaths(ctx, "c-newest"); len(paths) != 1 {
+		t.Fatal("newest session history must survive live budget pruning")
+	}
+	if paths, _ := store.SessionPaths(ctx, "a-oldest"); len(paths) != 0 {
+		t.Fatal("oldest session history must be pruned by live budget enforcement")
+	}
+}
+
 func TestRecorderSwallowsAndConverts(t *testing.T) {
 	store := openTestStore(t, Options{})
 	rec := NewRecorder(store)


### PR DESCRIPTION
## What changed

- Enforce `MaxTotalBytes` during ordinary `RecordChange` traffic instead of only during startup GC.
- Amortize the lightweight size check: run it after at most 8 MiB of retained input (using a proportional interval for smaller caps) or 64 metadata-only records.
- Run pruning in the record transaction so an enforcement failure rolls back the new record rather than reporting a committed write as failed, and invalidate per-session byte caches after a live check.
- Add a regression test that grows file history across sessions without calling `GC`, then verifies the database returns under the configured cap while the newest session survives and the oldest is pruned.

## Why this is high-value

Jarvis keeps a process-wide file-history store open across many sessions, while the previous total-budget enforcement ran only when that store was opened. A long-running serve/Jarvis process could therefore grow `file_history.db` past the configured 1 GiB safety limit indefinitely, eventually increasing SQLite work or consuming disk needed by session, memory, and jobs persistence. Live amortized enforcement restores the configured disk backstop without running stale-session GC or database-size queries on every tool write.

## Validation

- `go build ./...`
- `HOME=<temp> XDG_CONFIG_HOME=<temp>/config XDG_DATA_HOME=<temp>/data go test ./...`
- `go test -race ./internal/filetrack -count=1`
- Regression test was confirmed to fail before the fix (`368640` bytes with a `262144`-byte cap) and pass after it.
- `git diff --check`
