### PR TITLE
feat: add direct shell mode to chat

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -101,9 +101,10 @@ Agent examples (use @agent shortcut or --agent flag):
 
 Keyboard shortcuts:
   Enter        - Send message
+  ! command    - Run directly in the session directory, then ask the model to respond
   Shift+Enter  - Insert newline
   Ctrl+/ Ctrl+H - Show help
-  Ctrl+C       - Copy selection; cancel active response/tool; press twice when idle to quit
+  Ctrl+C       - Copy selection; cancel active response/tool/shell; press twice when idle to quit
   Ctrl+K       - Clear conversation
   Ctrl+N       - New session
   Ctrl+L       - Switch model

--- a/docs-site/content/guides/usage.md
+++ b/docs-site/content/guides/usage.md
@@ -63,8 +63,9 @@ See [Skills](/guides/skills/) for the full guide on creating, sharing, and exten
 | Key | Action |
 |-----|--------|
 | `Enter` | Send message |
+| `! command` | Run a shell command directly in the session directory; stream output, then ask the model to respond |
 | `Ctrl+J` or `Alt+Enter` | Insert newline |
-| `Ctrl+C` | Quit |
+| `Ctrl+C` | Copy selection; cancel active response/tool/shell; press twice when idle to quit |
 | `Ctrl+K` | Clear conversation |
 | `Ctrl+S` | Toggle web search |
 | `Ctrl+P` | Command palette |
@@ -73,9 +74,13 @@ See [Skills](/guides/skills/) for the full guide on creating, sharing, and exten
 | `Ctrl+N` | New session |
 | `Ctrl+F` | Attach file |
 | `Ctrl+O` | Conversation inspector |
-| `Esc` | Cancel streaming |
+| `Esc` | Cancel streaming or a running `!` shell command |
 | `Left click` | Move cursor in chat input |
 | `Shift+drag` | Select/copy chat output text in terminal |
+
+Type `!` as the first composer character to enter shell mode, for example `! git status`. The remainder runs through your configured `$SHELL` in the session's effective directory (including a bound worktree) without tool approval, because it is an explicit direct user action. Combined stdout/stderr streams live; `Esc` or `Ctrl+C` cancels the process. term-llm keeps up to 64 KiB of output, records the command, directory, output, and exit status in the session, and automatically starts a model response even when the command fails. Pasting text that starts with `!` into an empty composer also enters shell mode. Type a partial earlier `!` command and press `Tab` to complete it from the current session; `Up`/`Down` history recalls shell commands without their captured output.
+
+`/shell` remains available when you want an interactive terminal handoff rather than a captured command turn.
 
 ### TUI attachments
 

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -203,8 +203,16 @@ type Model struct {
 	newlineCompactor        *ui.StreamingNewlineCompactor
 
 	// External UI state
-	pausedForExternalUI      bool // True when paused for ask_user or approval prompts
-	externalProcessActive    bool // True while Bubble Tea is handing the terminal to /shell
+	pausedForExternalUI   bool // True when paused for ask_user or approval prompts
+	externalProcessActive bool // True while Bubble Tea is handing the terminal to /shell
+
+	// Direct shell mode (`! command`) streams a user-invoked process inside the
+	// managed TUI. It is separate from LLM streaming because it bypasses the
+	// engine/tool approval path and only starts a model turn after the process exits.
+	directShellEligible bool
+	directShellRun      *directShellRun
+	directShellGen      uint64
+
 	approvalMgr              *tools.ApprovalManager
 	requestedApprovalMode    tools.ApprovalMode
 	requestedApprovalChanged bool
@@ -2176,14 +2184,14 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
-		if (m.streaming || m.sideQuestion.Running || m.branchContextInFlight()) && !m.pausedForExternalUI {
+		if (m.streaming || m.directShellRun != nil || m.sideQuestion.Running || m.branchContextInFlight()) && !m.pausedForExternalUI {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			cmds = append(cmds, cmd)
 		}
 
 	case tickMsg:
-		if m.streaming {
+		if m.streaming || m.directShellRun != nil {
 			cmds = append(cmds, m.tickEvery())
 		}
 
@@ -2215,6 +2223,12 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		if msg.seq == m.copyStatusSeq {
 			m.copyStatus = ""
 		}
+
+	case directShellOutputMsg:
+		return m.handleDirectShellOutput(msg)
+
+	case directShellDoneMsg:
+		return m.handleDirectShellDone(msg)
 
 	case shellExitedMsg:
 		m.setShellTerminalHandoff(false)

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -931,8 +931,8 @@ func (m *Model) showHelpModal() (tea.Model, tea.Cmd) {
 			title: "Global",
 			rows: [][2]string{
 				{"Ctrl+/ or Ctrl+H", "Show help"},
-				{"Ctrl+C", "Copy selection; cancel active response/tool; press twice when idle to quit"},
-				{"Esc", "Cancel streaming / close modal / clear selection or input"},
+				{"Ctrl+C", "Copy selection; cancel active response/tool/shell; press twice when idle to quit"},
+				{"Esc", "Cancel streaming or a running ! command / close modal / clear selection or input"},
 				{"Ctrl+P", "Command palette"},
 				{"Ctrl+K", "Clear conversation"},
 				{"Ctrl+N", "New session"},
@@ -949,6 +949,7 @@ func (m *Model) showHelpModal() (tea.Model, tea.Cmd) {
 			title: "Composer",
 			rows: [][2]string{
 				{"Enter", "Send message; while streaming, queue interjection"},
+				{"! command", "Run directly in the session directory, then ask the model to respond"},
 				{"Ctrl+J / Alt+Enter / Shift+Enter", "Insert newline"},
 				{"\\ + Enter", "Turn trailing backslash into a newline"},
 				{"/", "Open slash-command completions from an empty composer"},

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -332,6 +332,13 @@ func (m *Model) cancelActiveForInterrupt() (bool, tea.Cmd) {
 		cancelled = true
 	}
 
+	if m.directShellRun != nil && !m.directShellRun.cancelRequested {
+		m.directShellRun.cancelRequested = true
+		m.directShellRun.cancel()
+		m.bumpContentVersion()
+		cancelled = true
+	}
+
 	if (m.streaming || m.streamCancelFunc != nil) && !m.isStreamCancelRequested() {
 		m.phase = "Stopping..."
 		if m.streamCancelFunc != nil {
@@ -362,7 +369,7 @@ func (m *Model) quitFromInterrupt() (tea.Model, tea.Cmd) {
 		m.dialog.Close()
 	}
 
-	hadActiveStream := m.streaming || m.streamCancelFunc != nil
+	hadActiveStream := m.streaming || m.streamCancelFunc != nil || m.directShellRun != nil
 	_, _ = m.cancelActiveForInterrupt()
 	m.setShellTerminalHandoff(false)
 	if m.program != nil {
@@ -384,7 +391,7 @@ func (m *Model) quitFromInterrupt() (tea.Model, tea.Cmd) {
 func (m *Model) handleCtrlC() (tea.Model, tea.Cmd) {
 	if cancelled, cancelCmd := m.cancelActiveForInterrupt(); cancelled {
 		m.ctrlCExitArmedUntil = time.Time{}
-		_, footerCmd := m.showFooterWarning("Interrupted current response/tool/skill.")
+		_, footerCmd := m.showFooterWarning("Interrupted current response/tool/shell/skill.")
 		return m, tea.Batch(cancelCmd, footerCmd, m.terminalTitleCmd())
 	}
 
@@ -864,11 +871,13 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Shell-style prompt history: Up/Down first move within the composer, then
-	// recall cross-session persisted user prompts at the visual boundaries. This
-	// runs before viewport scrolling so the streaming interjection composer gets
-	// the same history behavior as the normal composer.
-	if handled, cmd := m.handlePromptHistoryKey(msg); handled {
-		return m, cmd
+	// recall cross-session persisted user prompts at the visual boundaries. A
+	// running direct command owns the composer, so history stays inert until it
+	// finishes.
+	if m.directShellRun == nil {
+		if handled, cmd := m.handlePromptHistoryKey(msg); handled {
+			return m, cmd
+		}
 	}
 
 	// Ctrl+Y copies the active rendered selection, or the latest assistant
@@ -882,8 +891,11 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.cmdCopy(nil)
 	}
 
-	// Handle cancel during streaming (takes priority over clearing selection)
+	// Handle cancel during streaming or a direct shell command (takes priority over clearing selection)
 	if key.Matches(msg, m.keyMap.Cancel) {
+		if m.directShellRun != nil {
+			return m.cancelDirectShell()
+		}
 		if m.branchOperationCancel != nil {
 			m.branchOperationCancel()
 			m.branchOperationCancel = nil
@@ -1020,6 +1032,12 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if m.directShellRun != nil {
+		// The managed command owns the composer until completion. Scrolling and
+		// cancellation were handled above; all other keys wait for the result.
+		return m, nil
+	}
+
 	// Newline insertion (ctrl+j, alt+enter, shift+enter) — works in both the
 	// streaming interjection composer and the normal composer. Must precede
 	// any Send handler so shift+enter is caught before a plain "enter" match.
@@ -1050,6 +1068,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.streaming {
 		if key.Matches(msg, m.keyMap.Send) {
 			raw := strings.TrimSpace(m.textarea.Value())
+			if m.directShellComposerActive() {
+				return m.showFooterWarning("Wait for the current response to finish before running a shell command.")
+			}
 			if strings.HasSuffix(raw, "\\") {
 				m.setTextareaValue(strings.TrimSuffix(raw, "\\") + "\n")
 				return m, nil
@@ -1110,6 +1131,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.textarea, cmd = m.textarea.Update(msg)
 		m.updateTextareaHeight()
 		newVal := m.textarea.Value()
+		m.updateDirectShellEligibilityAfterKey(old, newVal)
 		newCursor := textareaCursorByteOffset(newVal, m.textarea.Line(), m.textarea.Column())
 		if newVal != old {
 			m.resetPromptHistoryIfEdited()
@@ -1169,6 +1191,16 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Handle clear
 	if key.Matches(msg, m.keyMap.Clear) {
 		return m.cmdClear()
+	}
+
+	// Shell history completion mirrors Claude Code: type a partial command after
+	// ! and press Tab to complete it from earlier shell-mode turns.
+	if key.Matches(msg, key.NewBinding(key.WithKeys("tab"))) && m.directShellComposerActive() {
+		if completion, ok := m.directShellHistoryCompletion(m.textarea.Value()); ok {
+			m.setTextareaValue(completion)
+			m.textarea.MoveToEnd()
+		}
+		return m, nil
 	}
 
 	// Handle tab completion for /mcp commands
@@ -1243,12 +1275,20 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Handle send
 	if key.Matches(msg, m.keyMap.Send) {
-		content := strings.TrimSpace(m.textarea.Value())
+		rawInput := m.textarea.Value()
+		content := strings.TrimSpace(rawInput)
 		if m.branchFocusCapture {
 			if content == "" {
 				return m.showFooterWarning("Describe what the new path should retain, or press Esc to cancel.")
 			}
 			return m.startConversationBranchWithNotes(content)
+		}
+
+		if m.directShellRun != nil {
+			return m.showFooterWarning("Wait for the shell command to finish or press Esc to cancel it.")
+		}
+		if m.directShellComposerActive() {
+			return m.startDirectShell(rawInput)
 		}
 
 		// Check for backslash continuation
@@ -1312,13 +1352,14 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Update textarea for other keys (skip during streaming - no text input needed)
-	if !m.streaming {
+	// Update textarea for other keys when no response or direct command owns it.
+	if !m.streaming && m.directShellRun == nil {
 		old := m.textarea.Value()
 		oldCursor := textareaCursorByteOffset(old, m.textarea.Line(), m.textarea.Column())
 		var cmd tea.Cmd
 		m.textarea, cmd = m.textarea.Update(msg)
 		newVal := m.textarea.Value()
+		m.updateDirectShellEligibilityAfterKey(old, newVal)
 		newCursor := textareaCursorByteOffset(newVal, m.textarea.Line(), m.textarea.Column())
 		// Clear selection when user starts typing
 		if m.selection.Active && newVal != old {
@@ -1415,7 +1456,22 @@ func (m *Model) handlePasteMsg(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 
 	old := m.textarea.Value()
 	m.textarea.InsertString(text)
-	if m.selection.Active && m.textarea.Value() != old {
+	newValue := m.textarea.Value()
+	// Match Claude Code: pasting a leading ! into an empty composer enters shell
+	// mode just like typing it. Pasting after a deliberately entered ! preserves
+	// shell mode, while inserting text into an unrelated draft cannot turn that
+	// draft into an executable command accidentally.
+	switch {
+	case !strings.HasPrefix(newValue, "!"):
+		m.directShellEligible = false
+	case old == "":
+		m.directShellEligible = true
+	case m.directShellEligible:
+		// Preserve an already-active shell composer.
+	default:
+		m.directShellEligible = false
+	}
+	if m.selection.Active && newValue != old {
 		m.selection = Selection{}
 	}
 	if newVal := m.textarea.Value(); newVal != old {

--- a/internal/tui/chat/prompt_history.go
+++ b/internal/tui/chat/prompt_history.go
@@ -281,6 +281,9 @@ func memoryPromptText(msg session.Message) (string, bool) {
 	if text == "" || llm.IsInternalCompactionSummaryText(text) {
 		return "", false
 	}
+	if command, ok := directShellCommandFromResult(msg.TextContent); ok {
+		return command, true
+	}
 	return msg.TextContent, true
 }
 
@@ -312,8 +315,12 @@ func (m *Model) applyMemoryPromptHistoryEntry(index int, text string, cursorAtEn
 }
 
 func (m *Model) applyPromptHistoryText(text string, cursorAtEnd bool) {
+	if command, ok := directShellCommandFromResult(text); ok {
+		text = command
+	}
 	m.promptHistory.recalledText = text
 	m.textarea.SetValue(text)
+	m.directShellEligible = strings.HasPrefix(text, "!")
 	if cursorAtEnd {
 		m.textarea.MoveToEnd()
 	} else {

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -117,8 +117,12 @@ func (m *Model) View() (view tea.View) {
 		renderedLines++
 	}
 
-	// Live response/child-agent stream and branch-context preparation.
-	if m.streaming || m.activeSkillRunCount() > 0 {
+	// Live direct-shell output, model/child-agent stream, or branch-context preparation.
+	if m.directShellRun != nil {
+		shellOutput := m.renderDirectShellInline()
+		b.WriteString(shellOutput)
+		renderedLines += lipgloss.Height(shellOutput)
+	} else if m.streaming || m.activeSkillRunCount() > 0 {
 		streaming := m.renderStreamingInline()
 		b.WriteString(streaming)
 		renderedLines += lipgloss.Height(streaming)
@@ -373,6 +377,9 @@ func (m *Model) viewAltScreen() string {
 			}
 		} else {
 			contentStr = m.viewCache.historyContent + m.viewCache.completedStream
+			if m.directShellRun != nil {
+				contentStr += m.renderDirectShellInline()
+			}
 			if m.branchContextInFlight() {
 				contentStr += m.renderBranchPathNotesActivity()
 			}
@@ -419,7 +426,7 @@ func (m *Model) viewAltScreen() string {
 		if m.handoverPreview != nil && m.handoverPreview.editing {
 			m.scrollToBottom = true
 		}
-		if firstRender || ((m.streaming || m.activeSkillRunCount() > 0) && wasAtBottom) || m.scrollToBottom {
+		if firstRender || ((m.streaming || m.directShellRun != nil || m.activeSkillRunCount() > 0) && wasAtBottom) || m.scrollToBottom {
 			m.viewport.GotoBottom()
 			m.scrollToBottom = false
 			m.resizeReflowRestoreAnchor = false
@@ -759,6 +766,25 @@ func (m *Model) buildFooterLayout() footerLayout {
 		appendMetaRow(strings.Join(chips, " "))
 	}
 
+	shellAccent := m.directShellComposerActive() || m.directShellRun != nil
+	if m.directShellRun != nil {
+		appendMetaRow(lipgloss.NewStyle().Foreground(theme.Warning).Bold(true).Render("  ! shell command running · Esc cancels"))
+		m.textarea.Placeholder = "Shell command running…"
+	} else if m.directShellComposerActive() {
+		appendMetaRow(lipgloss.NewStyle().Foreground(theme.Warning).Bold(true).Render("  ! shell mode · runs directly without tool approval"))
+		m.textarea.Placeholder = "Type a shell command…"
+	} else {
+		m.textarea.Placeholder = "Type a message..."
+	}
+	textareaStyles := m.textarea.Styles()
+	promptColor := theme.Primary
+	if shellAccent {
+		promptColor = theme.Warning
+	}
+	textareaStyles.Focused.Prompt = lipgloss.NewStyle().Foreground(promptColor).Bold(true)
+	textareaStyles.Blurred = textareaStyles.Focused
+	m.textarea.SetStyles(textareaStyles)
+
 	textareaView := m.textarea.View()
 	rows = append(rows, textareaView)
 	rows = append(rows, separator)
@@ -853,6 +879,41 @@ func (m *Model) renderMd(text string, width int) string {
 		return ""
 	}
 	return m.renderMarkdown(text)
+}
+
+func (m *Model) renderDirectShellInline() string {
+	run := m.directShellRun
+	if run == nil {
+		return ""
+	}
+	theme := m.styles.Theme()
+	commandStyle := lipgloss.NewStyle().Foreground(theme.Warning).Bold(true)
+	metaStyle := lipgloss.NewStyle().Foreground(theme.Muted)
+	outputStyle := lipgloss.NewStyle().Foreground(theme.Text)
+
+	width := max(20, m.width-2)
+	var b strings.Builder
+	b.WriteString(commandStyle.Render("! " + terminaltext.EscapeControlsPreserveLayout(run.command)))
+	b.WriteString("\n")
+	b.WriteString(metaStyle.Render("  in " + terminaltext.EscapeControlsPreserveLayout(run.dir)))
+	b.WriteString("\n")
+	output, _ := run.capture.text()
+	if output == "" {
+		b.WriteString(metaStyle.Render("  (waiting for output)"))
+	} else {
+		for _, line := range strings.Split(wordwrap.String(output, width), "\n") {
+			b.WriteString(outputStyle.Render("  " + line))
+			b.WriteString("\n")
+		}
+	}
+	if run.cancelRequested {
+		if output == "" {
+			b.WriteString("\n")
+		}
+		b.WriteString(metaStyle.Render("  cancelling…"))
+	}
+	b.WriteString("\n")
+	return b.String()
 }
 
 func (m *Model) renderBranchPathNotesActivity() string {
@@ -1043,6 +1104,7 @@ func (m *Model) updateTextareaHeight() {
 // setTextareaValue sets the textarea value and updates its height for proper wrapping
 func (m *Model) setTextareaValue(s string) {
 	m.textarea.SetValue(s)
+	m.directShellEligible = strings.HasPrefix(s, "!")
 	m.updateTextareaHeight()
 }
 
@@ -1172,6 +1234,9 @@ func (m *Model) renderStatusLine() string {
 	}
 	if m.fastMode {
 		baseSegments = append(baseSegments, seg(successStyle.Render("fast"), 30, false))
+	}
+	if m.directShellComposerActive() {
+		baseSegments = append(baseSegments, seg(warningStyle.Render("shell mode"), 0, true))
 	}
 	if goalText, goalStatus := m.statusLineGoalPart(); goalText != "" {
 		style := mutedStyle
@@ -1457,6 +1522,12 @@ func (m *Model) statusLineStreamingVariants(mutedStyle lipgloss.Style) []string 
 	started := time.Time{}
 	tokens := 0
 	switch {
+	case m.directShellRun != nil:
+		phase = "Running shell · Esc cancels"
+		if m.directShellRun.cancelRequested {
+			phase = "Cancelling shell"
+		}
+		started = m.directShellRun.startedAt
 	case m.streaming:
 		phase = m.phase
 		started = m.streamStartTime

--- a/internal/tui/chat/shell.go
+++ b/internal/tui/chat/shell.go
@@ -1,20 +1,30 @@
 package chat
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/procutil"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/terminaltext"
 )
 
 func (m *Model) cmdShell(rawArgs string) (tea.Model, tea.Cmd) {
 	m.setTextareaValue("")
 	if m.streaming {
 		return m.showFooterWarning("Cannot open a shell while a response is streaming.")
+	}
+	if m.directShellRun != nil {
+		return m.showFooterWarning("Cannot open a shell while a shell-mode command is running.")
 	}
 	opts, err := parseShellArgs(rawArgs)
 	if err != nil {
@@ -272,4 +282,334 @@ func shellExitMessage(dir string, err error) shellExitedMsg {
 	}
 	msg.err = err
 	return msg
+}
+
+const (
+	directShellCaptureLimit = 64 << 10
+	directShellWaitDelay    = time.Second
+)
+
+type directShellRun struct {
+	generation      uint64
+	command         string
+	dir             string
+	startedAt       time.Time
+	cancel          context.CancelFunc
+	cancelRequested bool
+	capture         directShellCapture
+}
+
+type directShellCapture struct {
+	data    []byte
+	omitted int64
+}
+
+func (c *directShellCapture) append(p []byte) {
+	if len(p) == 0 {
+		return
+	}
+	remaining := directShellCaptureLimit - len(c.data)
+	if remaining > 0 {
+		keep := min(remaining, len(p))
+		c.data = append(c.data, p[:keep]...)
+		p = p[keep:]
+	}
+	c.omitted += int64(len(p))
+}
+
+func (c *directShellCapture) text() (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	text := terminaltext.EscapeControlsPreserveLayout(string(bytes.ToValidUTF8(c.data, []byte("�"))))
+	if c.omitted == 0 {
+		return text, false
+	}
+	if text != "" && !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	text += fmt.Sprintf("[output truncated after %d bytes; %d additional bytes omitted]", directShellCaptureLimit, c.omitted)
+	return text, true
+}
+
+type directShellOutputMsg struct {
+	generation uint64
+	data       []byte
+	events     <-chan tea.Msg
+}
+
+type directShellDoneMsg struct {
+	generation uint64
+	exitCode   int
+	cancelled  bool
+	err        error
+}
+
+type directShellEventWriter struct {
+	ctx        context.Context
+	generation uint64
+	events     chan tea.Msg
+}
+
+func (w *directShellEventWriter) Write(p []byte) (int, error) {
+	chunk := append([]byte(nil), p...)
+	select {
+	case w.events <- directShellOutputMsg{generation: w.generation, data: chunk, events: w.events}:
+	case <-w.ctx.Done():
+		// Cancellation owns process termination. Dropping late pipe bytes prevents a
+		// cancelled command from blocking while the final completion event is queued.
+	}
+	return len(p), nil
+}
+
+func (m *Model) directShellComposerActive() bool {
+	return m != nil && m.directShellEligible && strings.HasPrefix(m.textarea.Value(), "!")
+}
+
+const directShellResultMarker = "[term-llm shell result v1]"
+
+// directShellCommandFromResult recognizes the durable shell-turn format and
+// returns only the executable history entry, never the captured output. The
+// explicit trailing marker avoids treating an ordinary prompt as shell history,
+// while the working-directory boundary supports multiline commands.
+func directShellCommandFromResult(text string) (string, bool) {
+	text = strings.TrimSpace(text)
+	if !strings.HasSuffix(text, "\n"+directShellResultMarker) || !strings.HasPrefix(text, "! ") {
+		return "", false
+	}
+	boundary := strings.Index(text, "\n[working directory: ")
+	if boundary < 0 {
+		return "", false
+	}
+	command := text[:boundary]
+	if strings.TrimSpace(strings.TrimPrefix(command, "! ")) == "" {
+		return "", false
+	}
+	return command, true
+}
+
+func (m *Model) directShellHistoryCompletion(prefix string) (string, bool) {
+	prefix = strings.TrimSpace(prefix)
+	if !strings.HasPrefix(prefix, "!") || m == nil {
+		return "", false
+	}
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		command, ok := directShellCommandFromResult(m.messages[i].TextContent)
+		if ok && command != prefix && strings.HasPrefix(command, prefix) {
+			return command, true
+		}
+	}
+	return "", false
+}
+
+func (m *Model) updateDirectShellEligibilityAfterKey(oldValue, newValue string) {
+	m.directShellEligible = strings.HasPrefix(newValue, "!") &&
+		(m.directShellEligible || !strings.HasPrefix(oldValue, "!"))
+}
+
+func (m *Model) startDirectShell(raw string) (tea.Model, tea.Cmd) {
+	if m.streaming {
+		return m.showFooterWarning("Wait for the current response to finish before running a shell command.")
+	}
+	if m.directShellRun != nil {
+		return m.showFooterWarning("A shell command is already running. Press Esc to cancel it.")
+	}
+	if m.worktreeOperationBusy() {
+		return m.showFooterWarning("Wait for the current worktree operation to finish before running a shell command.")
+	}
+	if len(m.files) > 0 || len(m.images) > 0 {
+		return m.showFooterWarning("Shell mode cannot use attachments. Remove them or send a normal prompt.")
+	}
+
+	raw = m.expandedPastePlaceholders(raw)
+	if !strings.HasPrefix(raw, "!") {
+		return m, nil
+	}
+	command := strings.TrimSpace(strings.TrimPrefix(raw, "!"))
+	if command == "" {
+		return m.showFooterWarning("Type a command after !, or press Esc to leave shell mode.")
+	}
+	dir, err := m.interactiveShellDir()
+	if err != nil {
+		return m.showFooterError(err.Error())
+	}
+
+	m.directShellGen++
+	generation := m.directShellGen
+	lifecycleCtx := m.rootContext()
+	ctx, cancel := context.WithCancel(lifecycleCtx)
+	events := make(chan tea.Msg, 256)
+	m.directShellRun = &directShellRun{
+		generation: generation,
+		command:    command,
+		dir:        dir,
+		startedAt:  time.Now(),
+		cancel:     cancel,
+	}
+	m.clearFooterMessage()
+	m.resetPromptHistory()
+	m.setTextareaValue("")
+	m.pasteChunks = nil
+	m.hideMentionPopup()
+	m.selection = Selection{}
+	m.resetRetainedStreamTracker()
+	m.viewCache.completedStream = ""
+	m.invalidateHistoryCache()
+	m.scrollToBottom = true
+	m.bumpContentVersion()
+
+	return m, tea.Batch(
+		m.runDirectShellCmd(ctx, lifecycleCtx, generation, command, dir, events),
+		waitDirectShellEvent(events),
+		m.spinner.Tick,
+		m.tickEvery(),
+	)
+}
+
+func (m *Model) runDirectShellCmd(ctx, lifecycleCtx context.Context, generation uint64, command, dir string, events chan tea.Msg) tea.Cmd {
+	worktreeDir := m.boundWorktreeForShellEnv()
+	return func() tea.Msg {
+		cmd := exec.CommandContext(ctx, interactiveShellPath(), "-c", command)
+		cmd.Dir = dir
+		cmd.Env = interactiveShellEnv(os.Environ(), dir, worktreeDir, false)
+		cmd.WaitDelay = directShellWaitDelay
+		procutil.ConfigureCommandProcessGroup(cmd)
+
+		writer := &directShellEventWriter{ctx: ctx, generation: generation, events: events}
+		// Using the exact same comparable writer for both pipes makes os/exec
+		// serialize writes, preserving the order in which stdout/stderr is observed.
+		cmd.Stdout = writer
+		cmd.Stderr = writer
+		err := cmd.Run()
+
+		done := directShellDoneMsg{generation: generation, err: err}
+		switch {
+		case ctx.Err() != nil:
+			done.cancelled = true
+			done.exitCode = 130
+		case err == nil:
+			done.exitCode = 0
+		default:
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				done.exitCode = exitErr.ExitCode()
+				done.err = nil
+			} else {
+				done.exitCode = -1
+			}
+		}
+		select {
+		case events <- done:
+		case <-lifecycleCtx.Done():
+			// The TUI has exited and no listener can drain the bounded event queue.
+			// Do not retain the completed process goroutine trying to report into it.
+		}
+		return nil
+	}
+}
+
+func waitDirectShellEvent(events <-chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		return <-events
+	}
+}
+
+func (m *Model) handleDirectShellOutput(msg directShellOutputMsg) (tea.Model, tea.Cmd) {
+	if m.directShellRun == nil || msg.generation != m.directShellRun.generation {
+		return m, waitDirectShellEvent(msg.events)
+	}
+	m.directShellRun.capture.append(msg.data)
+	m.bumpContentVersion()
+	m.scrollToBottom = true
+	return m, waitDirectShellEvent(msg.events)
+}
+
+func (m *Model) cancelDirectShell() (tea.Model, tea.Cmd) {
+	if m.directShellRun == nil {
+		return m, nil
+	}
+	if !m.directShellRun.cancelRequested {
+		m.directShellRun.cancelRequested = true
+		m.directShellRun.cancel()
+		m.bumpContentVersion()
+	}
+	return m.showFooterMuted("Cancelling shell command…")
+}
+
+func (m *Model) handleDirectShellDone(msg directShellDoneMsg) (tea.Model, tea.Cmd) {
+	run := m.directShellRun
+	if run == nil || msg.generation != run.generation {
+		return m, nil
+	}
+	if run.cancel != nil {
+		run.cancel()
+	}
+	output, truncated := run.capture.text()
+	resultText := formatDirectShellResult(run.command, run.dir, output, msg.exitCode, msg.cancelled, truncated, msg.err)
+	m.directShellRun = nil
+	m.directShellEligible = false
+	m.bumpContentVersion()
+	return m.sendDirectShellResult(run.command, resultText)
+}
+
+func formatDirectShellResult(command, dir, output string, exitCode int, cancelled, truncated bool, runErr error) string {
+	command = terminaltext.EscapeControlsPreserveLayout(command)
+	dir = terminaltext.EscapeControlsPreserveLayout(dir)
+	if strings.TrimSpace(output) == "" {
+		output = "(no output)"
+	} else {
+		output = strings.TrimRight(output, "\n")
+	}
+
+	status := fmt.Sprintf("exit status: %d", exitCode)
+	if cancelled {
+		status = "cancelled by user"
+	} else if runErr != nil {
+		status = "failed to start: " + terminaltext.EscapeControlsPreserveLayout(runErr.Error())
+	}
+	if truncated {
+		status += "; captured output truncated"
+	}
+	return fmt.Sprintf("! %s\n[working directory: %s]\n[combined stdout/stderr, in observed order]\n%s\n[%s]\n%s", command, dir, output, status, directShellResultMarker)
+}
+
+func (m *Model) sendDirectShellResult(command, content string) (tea.Model, tea.Cmd) {
+	m.clearFooterMessage()
+	var preSendCmds []tea.Cmd
+	if cmd := m.applyPendingStreamModelSwitch(); cmd != nil {
+		preSendCmds = append(preSendCmds, cmd)
+	}
+	m.recordCurrentModelUse()
+	m.ensureContextMessages()
+	m.appendPendingModelSwitchMarker()
+
+	userMsg := &session.Message{
+		SessionID:   m.sess.ID,
+		Role:        llm.RoleUser,
+		Parts:       []llm.Part{{Type: llm.PartText, Text: content}},
+		TextContent: content,
+		CreatedAt:   time.Now(),
+		Sequence:    -1,
+	}
+	m.messages = append(m.messages, *userMsg)
+	m.invalidateHistoryCache()
+	if m.store != nil {
+		_ = m.store.AddMessage(context.Background(), m.sess.ID, userMsg)
+		m.messages[len(m.messages)-1].ID = userMsg.ID
+		_ = m.store.IncrementUserTurns(context.Background(), m.sess.ID)
+		m.sess.UserTurns++
+		if m.sess.Summary == "" {
+			m.sess.Summary = session.TruncateSummary("! " + command)
+			_ = m.store.Update(context.Background(), m.sess)
+		}
+	}
+	if cmd := m.scheduleTitleFallbackCmd(); cmd != nil {
+		preSendCmds = append(preSendCmds, cmd)
+	}
+	if m.userMessageCount() == 1 {
+		if cmd := m.maybeNameHandoverCmd("! " + command); cmd != nil {
+			preSendCmds = append(preSendCmds, cmd)
+		}
+	}
+	return m.beginUserResponse(content, content, preSendCmds)
 }

--- a/internal/tui/chat/shell_mode_test.go
+++ b/internal/tui/chat/shell_mode_test.go
@@ -1,0 +1,389 @@
+package chat
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/ui"
+)
+
+func directShellTestModel(t *testing.T) *Model {
+	t.Helper()
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh unavailable: %v", err)
+	}
+	t.Setenv("SHELL", shell)
+	m := newTestChatModel(true)
+	m.width = 100
+	m.height = 30
+	return m
+}
+
+func startDirectShellTest(t *testing.T, m *Model, input string) (tea.BatchMsg, <-chan tea.Msg) {
+	t.Helper()
+	m.setTextareaValue(input)
+	updated, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(*Model)
+	if cmd == nil || m.directShellRun == nil {
+		t.Fatalf("direct shell did not start: cmd=%v run=%#v footer=%q", cmd != nil, m.directShellRun, m.footerMessage)
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) < 2 {
+		t.Fatalf("start command = %T, want batch with process and listener", cmd())
+	}
+	processDone := make(chan tea.Msg, 1)
+	go func() { processDone <- batch[0]() }()
+	return batch, processDone
+}
+
+func directShellCmdMsg(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("nil direct-shell listener command")
+	}
+	ch := make(chan tea.Msg, 1)
+	go func() { ch <- cmd() }()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for direct-shell event")
+		return nil
+	}
+}
+
+func pumpDirectShellTest(t *testing.T, m *Model, listener tea.Cmd, onOutput func(string)) tea.Cmd {
+	t.Helper()
+	for {
+		msg := directShellCmdMsg(t, listener)
+		switch typed := msg.(type) {
+		case directShellOutputMsg:
+			updated, next := m.Update(typed)
+			m = updated.(*Model)
+			if onOutput != nil {
+				output, _ := m.directShellRun.capture.text()
+				onOutput(output)
+			}
+			listener = next
+		case directShellDoneMsg:
+			updated, followup := m.Update(typed)
+			m = updated.(*Model)
+			return followup
+		default:
+			t.Fatalf("unexpected direct-shell event %T", msg)
+		}
+	}
+}
+
+func TestDirectShellSuccessPersistsResultAndStartsModelResponse(t *testing.T) {
+	m := directShellTestModel(t)
+	store := &mockStore{}
+	m.store = store
+
+	batch, processDone := startDirectShellTest(t, m, "! printf success")
+	followup := pumpDirectShellTest(t, m, batch[1], nil)
+	if msg := directShellCmdMsg(t, func() tea.Msg { return <-processDone }); msg != nil {
+		t.Fatalf("process command returned %T, want nil", msg)
+	}
+
+	if m.directShellRun != nil || !m.streaming || followup == nil {
+		t.Fatalf("completion state: run=%#v streaming=%v followup=%v", m.directShellRun, m.streaming, followup != nil)
+	}
+	if len(store.added) != 1 {
+		t.Fatalf("persisted messages = %d, want 1", len(store.added))
+	}
+	got := store.added[0]
+	if got.Role != llm.RoleUser || !strings.Contains(got.TextContent, "! printf success") ||
+		!strings.Contains(got.TextContent, "success") || !strings.Contains(got.TextContent, "exit status: 0") {
+		t.Fatalf("persisted shell result = %#v", got)
+	}
+	if len(m.messages) != 1 || m.messages[0].TextContent != got.TextContent {
+		t.Fatalf("in-memory shell result = %#v, persisted=%#v", m.messages, got)
+	}
+
+	followBatch, ok := followup().(tea.BatchMsg)
+	if !ok || len(followBatch) == 0 {
+		t.Fatalf("model follow-up command = %T, want batch", followup())
+	}
+	_ = followBatch[0]()
+	provider := m.provider.(*llm.MockProvider)
+	requests := provider.RecordedRequests()
+	if len(requests) != 1 || len(requests[0].Messages) == 0 {
+		t.Fatalf("model follow-up requests = %#v", requests)
+	}
+	if contextText := llm.MessageText(requests[0].Messages[len(requests[0].Messages)-1]); contextText != got.TextContent {
+		t.Fatalf("model context shell result = %q, want %q", contextText, got.TextContent)
+	}
+}
+
+func TestDirectShellNonzeroExitStillStartsModelResponse(t *testing.T) {
+	m := directShellTestModel(t)
+	batch, _ := startDirectShellTest(t, m, "! printf failure >&2; exit 7")
+	followup := pumpDirectShellTest(t, m, batch[1], nil)
+
+	if !m.streaming || followup == nil || len(m.messages) != 1 {
+		t.Fatalf("nonzero completion did not start model: streaming=%v followup=%v messages=%d", m.streaming, followup != nil, len(m.messages))
+	}
+	text := m.messages[0].TextContent
+	if !strings.Contains(text, "failure") || !strings.Contains(text, "exit status: 7") {
+		t.Fatalf("nonzero result = %q", text)
+	}
+}
+
+func TestDirectShellLaunchFailureStillStartsModelResponse(t *testing.T) {
+	m := directShellTestModel(t)
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "missing-shell"))
+	batch, _ := startDirectShellTest(t, m, "! echo unreachable")
+	followup := pumpDirectShellTest(t, m, batch[1], nil)
+
+	if !m.streaming || followup == nil || len(m.messages) != 1 {
+		t.Fatalf("launch failure did not start model: streaming=%v followup=%v messages=%d", m.streaming, followup != nil, len(m.messages))
+	}
+	if text := m.messages[0].TextContent; !strings.Contains(text, "failed to start:") || !strings.Contains(text, "missing-shell") {
+		t.Fatalf("launch failure result = %q", text)
+	}
+}
+
+func TestDirectShellStreamsCombinedOutputInObservedOrder(t *testing.T) {
+	m := directShellTestModel(t)
+	batch, _ := startDirectShellTest(t, m, "! printf first; sleep 0.05; printf second >&2; sleep 0.05; printf third")
+	var snapshots []string
+	pumpDirectShellTest(t, m, batch[1], func(output string) {
+		if m.streaming {
+			t.Fatal("model started before shell completion")
+		}
+		if m.directShellRun == nil {
+			t.Fatal("shell run cleared while output was still arriving")
+		}
+		snapshots = append(snapshots, output)
+	})
+
+	if len(snapshots) < 2 {
+		t.Fatalf("live output snapshots = %#v, want multiple events", snapshots)
+	}
+	text := m.messages[0].TextContent
+	first, second, third := strings.Index(text, "first"), strings.Index(text, "second"), strings.Index(text, "third")
+	if first < 0 || second <= first || third <= second {
+		t.Fatalf("combined output order lost: %q", text)
+	}
+}
+
+func TestDirectShellCancellationPersistsAndStartsModelResponse(t *testing.T) {
+	m := directShellTestModel(t)
+	batch, processDone := startDirectShellTest(t, m, "! printf started; sleep 30")
+
+	msg := directShellCmdMsg(t, batch[1])
+	output, ok := msg.(directShellOutputMsg)
+	if !ok {
+		t.Fatalf("first event = %T, want output", msg)
+	}
+	updated, listener := m.Update(output)
+	m = updated.(*Model)
+	updated, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = updated.(*Model)
+	if m.directShellRun == nil || !m.directShellRun.cancelRequested {
+		t.Fatalf("cancel state = %#v", m.directShellRun)
+	}
+	pumpDirectShellTest(t, m, listener, nil)
+	_ = directShellCmdMsg(t, func() tea.Msg { return <-processDone })
+
+	if !m.streaming || m.directShellRun != nil || len(m.messages) != 1 {
+		t.Fatalf("cancel completion state: streaming=%v run=%#v messages=%d", m.streaming, m.directShellRun, len(m.messages))
+	}
+	text := m.messages[0].TextContent
+	if !strings.Contains(text, "started") || !strings.Contains(text, "cancelled by user") {
+		t.Fatalf("cancelled result = %q", text)
+	}
+}
+
+func TestDirectShellEmptyBangStaysInComposer(t *testing.T) {
+	m := directShellTestModel(t)
+	m.setTextareaValue("!")
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(*Model)
+
+	if m.directShellRun != nil || m.streaming || len(m.messages) != 0 {
+		t.Fatalf("empty bang executed: run=%#v streaming=%v messages=%d", m.directShellRun, m.streaming, len(m.messages))
+	}
+	if m.textarea.Value() != "!" || !strings.Contains(m.footerMessage, "Type a command after !") {
+		t.Fatalf("empty bang draft=%q footer=%q", m.textarea.Value(), m.footerMessage)
+	}
+}
+
+func TestDirectShellPasteEntersShellMode(t *testing.T) {
+	m := directShellTestModel(t)
+	updated, _ := m.Update(tea.PasteMsg{Content: "! printf pasted"})
+	m = updated.(*Model)
+	if !m.directShellComposerActive() {
+		t.Fatal("pasted leading bang did not activate shell mode")
+	}
+	updated, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(*Model)
+	if m.directShellRun == nil || cmd == nil || m.streaming {
+		t.Fatalf("pasted bang did not start shell command: run=%#v cmd=%v streaming=%v", m.directShellRun, cmd != nil, m.streaming)
+	}
+	m.directShellRun.cancel()
+}
+
+func TestDirectShellPasteCannotConvertExistingDraft(t *testing.T) {
+	m := directShellTestModel(t)
+	m.setTextareaValue("draft")
+	m.directShellEligible = false
+	m.textarea.MoveToBegin()
+	updated, _ := m.Update(tea.PasteMsg{Content: "! "})
+	m = updated.(*Model)
+	if got := m.textarea.Value(); got != "! draft" || m.directShellComposerActive() {
+		t.Fatalf("paste into existing draft = %q active=%v", got, m.directShellComposerActive())
+	}
+}
+
+func TestDirectShellHistoryCompletionAndRecallStripOutput(t *testing.T) {
+	m := directShellTestModel(t)
+	result := formatDirectShellResult("git status --short", "/tmp/project", "M shell.go", 0, false, false, nil)
+	m.messages = append(m.messages, *session.NewMessage(m.sess.ID, llm.UserText(result), -1))
+
+	m.setTextareaValue("! git st")
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyTab})
+	m = updated.(*Model)
+	if got := m.textarea.Value(); got != "! git status --short" || !m.directShellComposerActive() {
+		t.Fatalf("shell history completion = %q active=%v", got, m.directShellComposerActive())
+	}
+
+	m.setTextareaValue("")
+	handled, _ := m.recallPreviousPrompt()
+	if !handled || m.textarea.Value() != "! git status --short" || !m.directShellComposerActive() {
+		t.Fatalf("shell recall = %q active=%v handled=%v", m.textarea.Value(), m.directShellComposerActive(), handled)
+	}
+	if strings.Contains(m.textarea.Value(), "M shell.go") {
+		t.Fatalf("shell recall leaked captured output: %q", m.textarea.Value())
+	}
+}
+
+func TestDirectShellMultilineHistoryIsUnambiguous(t *testing.T) {
+	command := "printf one\\n\nprintf two"
+	result := formatDirectShellResult(command, "/tmp/project", "one\ntwo", 0, false, false, nil)
+	got, ok := directShellCommandFromResult(result)
+	if !ok || got != "! "+command {
+		t.Fatalf("multiline shell history = %q, %v; want %q", got, ok, "! "+command)
+	}
+	if _, ok := directShellCommandFromResult("! harmless\n[working directory: prose]"); ok {
+		t.Fatal("ordinary prompt was misclassified as shell history")
+	}
+}
+
+func TestDirectShellNormalPromptsContainingBangDoNotExecute(t *testing.T) {
+	for _, input := range []string{"explain ! printf normal", " ! printf leading-space"} {
+		m := directShellTestModel(t)
+		m.setTextareaValue(input)
+		updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+		m = updated.(*Model)
+		if m.directShellRun != nil || !m.streaming || len(m.messages) != 1 {
+			t.Fatalf("normal prompt %q entered shell mode: run=%#v streaming=%v messages=%d", input, m.directShellRun, m.streaming, len(m.messages))
+		}
+		if got := m.messages[0].TextContent; got != strings.TrimSpace(input) {
+			t.Fatalf("normal prompt text = %q, want %q", got, strings.TrimSpace(input))
+		}
+	}
+}
+
+func TestDirectShellUsesEffectiveWorkingDirectory(t *testing.T) {
+	m := directShellTestModel(t)
+	worktree := t.TempDir()
+	m.sess = &session.Session{ID: "shell-cwd", CWD: t.TempDir(), WorktreeDir: worktree}
+	batch, _ := startDirectShellTest(t, m, "! pwd; printf marker > cwd-marker")
+	pumpDirectShellTest(t, m, batch[1], nil)
+
+	if !strings.Contains(m.messages[0].TextContent, worktree) {
+		t.Fatalf("shell result did not report effective cwd: %q", m.messages[0].TextContent)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, "cwd-marker")); err != nil {
+		t.Fatalf("command did not execute in worktree: %v", err)
+	}
+}
+
+func TestDirectShellDoesNotExecuteDuringStreaming(t *testing.T) {
+	m := directShellTestModel(t)
+	m.streaming = true
+	m.setTextareaValue("! printf blocked")
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(*Model)
+
+	if m.directShellRun != nil || m.textarea.Value() != "! printf blocked" {
+		t.Fatalf("streaming shell submission mutated state: run=%#v draft=%q", m.directShellRun, m.textarea.Value())
+	}
+	if !strings.Contains(m.footerMessage, "current response") {
+		t.Fatalf("streaming shell warning = %q", m.footerMessage)
+	}
+}
+
+func TestDirectShellComposerAndRunningVisualTreatment(t *testing.T) {
+	m := directShellTestModel(t)
+	m.setTextareaValue("! echo visual")
+	composer := ui.StripANSI(m.View().Content)
+	if !strings.Contains(composer, "shell mode") || !strings.Contains(composer, "runs directly without tool approval") {
+		t.Fatalf("shell composer treatment missing: %q", composer)
+	}
+
+	m.directShellRun = &directShellRun{command: "echo visual", dir: "/tmp", startedAt: time.Now()}
+	m.setTextareaValue("")
+	m.bumpContentVersion()
+	running := ui.StripANSI(m.View().Content)
+	if !strings.Contains(running, "! echo visual") || !strings.Contains(running, "Esc cancels") || !strings.Contains(running, "waiting for output") {
+		t.Fatalf("running shell treatment missing: %q", running)
+	}
+}
+
+func TestDirectShellCaptureIsBoundedAndReadable(t *testing.T) {
+	var capture directShellCapture
+	capture.append([]byte(strings.Repeat("x", directShellCaptureLimit+123)))
+	text, truncated := capture.text()
+	if !truncated || len(capture.data) != directShellCaptureLimit || capture.omitted != 123 {
+		t.Fatalf("capture bounds: truncated=%v kept=%d omitted=%d", truncated, len(capture.data), capture.omitted)
+	}
+	if !strings.Contains(text, "123 additional bytes omitted") {
+		t.Fatalf("capture marker = %q", text[len(text)-100:])
+	}
+}
+
+func TestDirectShellCompletionDoesNotBlockAfterTUIExit(t *testing.T) {
+	m := directShellTestModel(t)
+	commandCtx, cancelCommand := context.WithCancel(context.Background())
+	defer cancelCommand()
+	lifecycleCtx, cancelLifecycle := context.WithCancel(context.Background())
+	events := make(chan tea.Msg, 1)
+	events <- directShellOutputMsg{}
+	cancelLifecycle()
+
+	done := make(chan struct{})
+	dir := t.TempDir()
+	go func() {
+		_ = m.runDirectShellCmd(commandCtx, lifecycleCtx, 1, "true", dir, events)()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shell completion blocked on a full event queue after TUI exit")
+	}
+}
+
+func TestDirectShellRunningOwnsPromptHistory(t *testing.T) {
+	m := directShellTestModel(t)
+	m.messages = append(m.messages, *session.NewMessage(m.sess.ID, llm.UserText("older prompt"), -1))
+	m.directShellRun = &directShellRun{cancel: func() {}}
+
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(*Model)
+	if got := m.textarea.Value(); got != "" || m.promptHistory.active {
+		t.Fatalf("running shell allowed prompt history: draft=%q active=%v", got, m.promptHistory.active)
+	}
+}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -477,6 +477,9 @@ func (m *Model) ensureContextMessages() {
 }
 
 func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
+	if m.directShellRun != nil {
+		return m.showFooterWarning("Wait for the shell command to finish or press Esc to cancel it.")
+	}
 	// Delegation intent comes only from text deliberately visible in the composer.
 	// Collapsed paste payloads are expanded for the provider after this check, so
 	// hidden pasted prose cannot synthesize an @agent request.
@@ -621,7 +624,14 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 			fmt.Sprintf("[with: %s]", strings.Join(attachmentNames, ", "))))
 	}
 	// tea.Println adds newline, no need for extra
+	return m.beginUserResponse(content, userDisplay.String(), preSendCmds)
+}
 
+// beginUserResponse transitions from a committed user message to the normal
+// assistant stream. Keeping this separate lets direct shell mode persist its
+// own structured, literal command result without re-running composer semantics
+// such as @ mentions, pasted placeholders, or attachment expansion.
+func (m *Model) beginUserResponse(content, userDisplay string, preSendCmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	// Clear input and attachments
 	m.resetPromptHistory()
 	m.setTextareaValue("")
@@ -672,9 +682,8 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 	m.smoothTickPending = false
 	m.streamRenderTickPending = false
 
-	// Start the stream
-	// In alt screen mode, View() renders history including user message
-	// In inline mode, print user message to scrollback first
+	// Start the stream. In alt screen mode, View() renders history including the
+	// user message. Inline mode prints the prepared user turn to scrollback first.
 	if m.altScreen {
 		cmds := []tea.Cmd{
 			m.startStream(content),
@@ -686,7 +695,7 @@ func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 	}
 	cmds := []tea.Cmd{
-		tea.Println(userDisplay.String()),
+		tea.Println(userDisplay),
 		m.startStream(content),
 		m.spinner.Tick,
 		m.tickEvery(),


### PR DESCRIPTION
## Summary

Add Claude Code-style direct shell mode to the interactive chat composer:

- type or paste `! command` at the start of an empty composer to execute it directly
- run through the configured `$SHELL` in the session's effective directory, including bound worktrees
- stream combined stdout/stderr live in observed order
- bypass tool approval because the command is an explicit direct user action
- cancel the process group with `Esc` or `Ctrl+C`
- persist the command, directory, output, and exit state as a readable conversation turn
- automatically start the normal model response after success, nonzero exit, cancellation, or launch failure
- cap captured output at **64 KiB**, with the exact omitted byte count in the truncation marker
- recall shell history without captured output; complete partial commands from the current session with `Tab`
- keep `/shell` for interactive/full-screen PTY handoff

## Review fixes

A separate code review found and this branch fixes:

- a possible blocked completion goroutine when the TUI exits with a full event queue
- prompt-history input leaking through while a direct command owns the composer
- ambiguous/multiline shell history parsing
- paste activation of an unrelated existing draft

## Verification

- `go test ./internal/tui/chat -run 'DirectShell' -count=1`
- `go test -race ./internal/tui/chat -run 'DirectShell' -count=1`
- isolated `HOME`/XDG: `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- demo video rendered at 1920×1080, 30 fps and reviewed via sampled contact sheet

## Deliberate scope

This is foreground, captured shell execution. It does not add Claude's `Ctrl+B` background-task manager, and it does not pretend captured pipes are a PTY; interactive programs remain the job of `/shell`.
