### PR TITLE
fix: Expired Web Push subscriptions are never removed and permanently poison broadcasts

### DIFF
--- a/cmd/notify_web.go
+++ b/cmd/notify_web.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 
@@ -101,16 +100,16 @@ func sendWebPushAll(ctx context.Context, cfg *config.Config, message string, err
 	sent := 0
 	for _, sub := range subs {
 		status, err := sendWebPush(ctx, &sub, payload, opts)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("push to %s: %v", truncateEndpoint(sub.Endpoint), err))
-			continue
-		}
-		// Clean up stale subscriptions on 410 Gone or 404 Not Found
+		// Clean up stale subscriptions on 410 Gone or 404 Not Found. These
+		// statuses are returned with an error, so handle them first.
 		if status == http.StatusGone || status == http.StatusNotFound {
 			if delErr := store.DeletePushSubscription(ctx, sub.Endpoint); delErr != nil {
-				log.Printf("warning: cleanup stale subscription: %v", delErr)
+				errs = append(errs, fmt.Sprintf("remove stale subscription %s: %v", truncateEndpoint(sub.Endpoint), delErr))
 			}
-			errs = append(errs, fmt.Sprintf("removed stale subscription %s", truncateEndpoint(sub.Endpoint)))
+			continue
+		}
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("push to %s: %v", truncateEndpoint(sub.Endpoint), err))
 			continue
 		}
 		sent++

--- a/cmd/notify_web_test.go
+++ b/cmd/notify_web_test.go
@@ -1,6 +1,21 @@
 package cmd
 
-import "testing"
+import (
+	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	webpush "github.com/SherClockHolmes/webpush-go"
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/session"
+)
 
 func TestNormalizeWebPushSubject(t *testing.T) {
 	tests := []struct {
@@ -20,6 +35,106 @@ func TestNormalizeWebPushSubject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := normalizeWebPushSubject(tt.input); got != tt.want {
 				t.Fatalf("normalizeWebPushSubject(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSendWebPushAllRemovesStaleSubscriptions(t *testing.T) {
+	oldNoSession := noSession
+	oldSessionDB := sessionDBPath
+	t.Cleanup(func() {
+		noSession = oldNoSession
+		sessionDBPath = oldSessionDB
+	})
+	noSession = false
+	sessionDBPath = ""
+
+	browserKey, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate browser key: %v", err)
+	}
+	p256dh := base64.RawURLEncoding.EncodeToString(browserKey.PublicKey().Bytes())
+	authSecret := make([]byte, 16)
+	if _, err := rand.Read(authSecret); err != nil {
+		t.Fatalf("generate auth secret: %v", err)
+	}
+	auth := base64.RawURLEncoding.EncodeToString(authSecret)
+
+	vapidPrivate, vapidPublic, err := webpush.GenerateVAPIDKeys()
+	if err != nil {
+		t.Fatalf("generate VAPID keys: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		status        int
+		wantRemaining int
+		wantErrors    bool
+		wantRequests  int32
+	}{
+		{name: "gone", status: http.StatusGone, wantRemaining: 0, wantRequests: 1},
+		{name: "not found", status: http.StatusNotFound, wantRemaining: 0, wantRequests: 1},
+		{name: "server error", status: http.StatusInternalServerError, wantRemaining: 1, wantErrors: true, wantRequests: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int32
+			pushServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.WriteHeader(tt.status)
+			}))
+			defer pushServer.Close()
+
+			dbPath := filepath.Join(t.TempDir(), "sessions.db")
+			store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			if err := store.SavePushSubscription(context.Background(), &session.PushSubscription{
+				Endpoint:  pushServer.URL,
+				KeyP256DH: p256dh,
+				KeyAuth:   auth,
+			}); err != nil {
+				t.Fatalf("SavePushSubscription: %v", err)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatalf("close store: %v", err)
+			}
+
+			cfg := &config.Config{
+				Sessions: config.SessionsConfig{Enabled: true, Path: dbPath},
+				Serve: config.ServeConfig{WebPush: config.WebPushConfig{
+					VAPIDPublicKey:  vapidPublic,
+					VAPIDPrivateKey: vapidPrivate,
+				}},
+			}
+
+			for attempt := 1; attempt <= 2; attempt++ {
+				sent, errs := sendWebPushAll(context.Background(), cfg, "test", io.Discard)
+				if sent != 0 {
+					t.Fatalf("attempt %d sent = %d, want 0", attempt, sent)
+				}
+				if gotErrors := len(errs) > 0; gotErrors != tt.wantErrors {
+					t.Fatalf("attempt %d errors = %v, want errors %t", attempt, errs, tt.wantErrors)
+				}
+			}
+
+			store, err = session.NewStore(session.Config{Enabled: true, Path: dbPath})
+			if err != nil {
+				t.Fatalf("reopen store: %v", err)
+			}
+			defer store.Close()
+			subs, err := store.ListPushSubscriptions(context.Background())
+			if err != nil {
+				t.Fatalf("ListPushSubscriptions: %v", err)
+			}
+			if len(subs) != tt.wantRemaining {
+				t.Fatalf("remaining subscriptions = %d, want %d", len(subs), tt.wantRemaining)
+			}
+			if got := requests.Load(); got != tt.wantRequests {
+				t.Fatalf("push requests = %d, want %d", got, tt.wantRequests)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

- Handle Web Push `404 Not Found` and `410 Gone` responses before the generic delivery-error path.
- Delete subscriptions rejected as stale, suppressing the delivery error when cleanup succeeds while still reporting database deletion failures.
- Add focused coverage proving 404/410 subscriptions are removed and not retried on a second broadcast, while 500 responses remain stored and continue to report errors.

## Why this is high-value

Browser push subscriptions routinely expire when site data is cleared or a browser rotates its endpoint. Previously, `sendWebPush` returned both the stale HTTP status and an error, but `sendWebPushAll` handled the error first, making its cleanup branch unreachable. A single dead endpoint therefore remained in the session database forever, added a failing network request to every scheduled notification, and could make otherwise successful broadcasts report notification errors. This directly affects the web and scheduled-notification paths used in ordinary Jarvis operation.

## Validation

- `go test ./cmd -run '^(TestSendWebPushAllRemovesStaleSubscriptions|TestNormalizeWebPushSubject)$' -count=1`
- `go test -race ./cmd -run '^TestSendWebPushAllRemovesStaleSubscriptions$' -count=1`
- `go build ./...`
- `XDG_CONFIG_HOME=<temporary directory> CODEX_HOME=<temporary directory>/codex go test ./...`

The full suite was run with isolated config paths so host-installed skills could not affect skill-discovery tests.
